### PR TITLE
fix: the notify is not working for non-write access user.

### DIFF
--- a/.github/workflows/owner-notification.yml
+++ b/.github/workflows/owner-notification.yml
@@ -1,7 +1,7 @@
 name: Owner Notification
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:
@@ -28,6 +28,7 @@ jobs:
       - name: Find owners and notify
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const path = require('path');

--- a/.github/workflows/owner-notification.yml
+++ b/.github/workflows/owner-notification.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,11 +32,11 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            
+
             // Get changed files
             const changedFiles = `${{ steps.changed-files.outputs.all_changed_files }}`.split(' ');
             console.log('Changed files:', changedFiles);
-            
+
             // Function to find OWNER file for a given file path
             function findOwnerFile(filePath) {
                const parts = filePath.split('/');


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The notify is not working for non-write access user.

Changes:
- For `pull_request_target `: essential for external contributors (those submitting PRs from forks).
- For `pull_request_target`: explicitly checks out the PR's head commit.

**Which issue(s) this PR fixes**:

https://github.com/vllm-project/semantic-router/pull/7#issuecomment-3239338303

