### PR TITLE
chore: replace fmt.Printf with log.Printf for logging

### DIFF
--- a/src/semantic-router/pkg/utils/http/response.go
+++ b/src/semantic-router/pkg/utils/http/response.go
@@ -3,6 +3,7 @@ package http
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -43,7 +44,7 @@ func CreatePIIViolationResponse(model string, deniedPII []string) *ext_proc.Proc
 	responseBody, err := json.Marshal(openAIResponse)
 	if err != nil {
 		// Log the error and return a fallback response
-		fmt.Printf("Error marshaling OpenAI response: %v\n", err)
+		log.Printf("Error marshaling OpenAI response: %v", err)
 		responseBody = []byte(`{"error": "Failed to generate response"}`)
 	}
 
@@ -106,7 +107,7 @@ func CreateJailbreakViolationResponse(jailbreakType string, confidence float32) 
 	responseBody, err := json.Marshal(openAIResponse)
 	if err != nil {
 		// Log the error and return a fallback response
-		fmt.Printf("Error marshaling jailbreak response: %v\n", err)
+		log.Printf("Error marshaling jailbreak response: %v", err)
 		responseBody = []byte(`{"error": "Failed to generate response"}`)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
chore(utils/http): replace `fmt.Printf` with `log.Printf` for logging

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
It seems that codebase leverages `log.Printf` for logging at most cases, this CL replace two `fmt.Printf` calls with `log.Printf` for code style consistency.


