### PR TITLE
feat: robust model name filter for DeepSeek

### DIFF
--- a/src/semantic-router/pkg/extproc/reason_mode_selector_test.go
+++ b/src/semantic-router/pkg/extproc/reason_mode_selector_test.go
@@ -23,10 +23,16 @@ func TestGetModelFamilyAndTemplateParam(t *testing.T) {
 			expectedParam:  "thinking",
 		},
 		{
-			name:           "DeepSeek alias ds",
+			name:           "DeepSeek alias ds (prefix)",
 			model:          "DS-1.5B",
 			expectedFamily: "deepseek",
 			expectedParam:  "thinking",
+		},
+		{
+			name:           "Non-leading ds should not match DeepSeek",
+			model:          "mistral-ds-1b",
+			expectedFamily: "unknown",
+			expectedParam:  "",
 		},
 		{
 			name:           "GPT-OSS family",


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
feat: robust model name filter for DeepSeek
<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

Added a `hasDeepSeekAlias` function, which returns true if the model uses a short alias for DeepSeek (e.g., "ds-*")


  - Accept only when the model string starts with: "ds-", "ds_", "ds:", "ds " or exactly equals "ds"
  - Do NOT match occurrences of "ds" in the middle of the model name (e.g., "foo-ds-1b")

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/vllm-project/semantic-router/issues/61

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
