### PR TITLE
chore: remove docker compose version, because verion is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
-version: '3.8'
-
 services:
+
   # Semantic Router External Processor Service
   semantic-router:
     build:


### PR DESCRIPTION
https://docs.docker.com/reference/compose-file/version-and-name/

`version` field is onsolete