### PR TITLE
fix: don't set reasoning effort for non-reasoning models

### DIFF
--- a/src/semantic-router/pkg/extproc/reason_mode_selector_test.go
+++ b/src/semantic-router/pkg/extproc/reason_mode_selector_test.go
@@ -1,6 +1,11 @@
 package extproc
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/semantic-router/pkg/config"
+)
 
 // TestGetModelFamilyAndTemplateParam verifies model-family detection and template parameter mapping
 func TestGetModelFamilyAndTemplateParam(t *testing.T) {
@@ -71,6 +76,128 @@ func TestGetModelFamilyAndTemplateParam(t *testing.T) {
 			family, param := getModelFamilyAndTemplateParam(tc.model)
 			if family != tc.expectedFamily || param != tc.expectedParam {
 				t.Fatalf("for model %q got (family=%q, param=%q), want (family=%q, param=%q)", tc.model, family, param, tc.expectedFamily, tc.expectedParam)
+			}
+		})
+	}
+}
+
+// TestSetReasoningModeToRequestBody verifies that reasoning_effort is handled correctly for different model families
+func TestSetReasoningModeToRequestBody(t *testing.T) {
+	// Create a minimal router for testing
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{
+			DefaultReasoningEffort: "medium",
+		},
+	}
+
+	testCases := []struct {
+		name                       string
+		model                      string
+		enabled                    bool
+		initialReasoningEffort     interface{}
+		expectReasoningEffortKey   bool
+		expectedReasoningEffort    interface{}
+		expectedChatTemplateKwargs bool
+	}{
+		{
+			name:                       "GPT-OSS model with reasoning disabled - preserve reasoning_effort",
+			model:                      "gpt-oss-20b",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   true,
+			expectedReasoningEffort:    "low",
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "Phi4 model with reasoning disabled - remove reasoning_effort",
+			model:                      "phi4",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "DeepSeek model with reasoning disabled - remove reasoning_effort",
+			model:                      "deepseek-v31",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "GPT-OSS model with reasoning enabled - set reasoning_effort",
+			model:                      "gpt-oss-20b",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   true,
+			expectedReasoningEffort:    "medium",
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "DeepSeek model with reasoning enabled - set chat_template_kwargs",
+			model:                      "deepseek-v31",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Prepare initial request body
+			requestBody := map[string]interface{}{
+				"model": tc.model,
+				"messages": []map[string]string{
+					{"role": "user", "content": "test message"},
+				},
+			}
+			if tc.initialReasoningEffort != nil {
+				requestBody["reasoning_effort"] = tc.initialReasoningEffort
+			}
+
+			requestBytes, err := json.Marshal(requestBody)
+			if err != nil {
+				t.Fatalf("Failed to marshal request body: %v", err)
+			}
+
+			// Call the function under test
+			modifiedBytes, err := router.setReasoningModeToRequestBody(requestBytes, tc.enabled, "test-category")
+			if err != nil {
+				t.Fatalf("setReasoningModeToRequestBody failed: %v", err)
+			}
+
+			// Parse the modified request body
+			var modifiedRequest map[string]interface{}
+			if err := json.Unmarshal(modifiedBytes, &modifiedRequest); err != nil {
+				t.Fatalf("Failed to unmarshal modified request body: %v", err)
+			}
+
+			// Check reasoning_effort handling
+			reasoningEffort, hasReasoningEffort := modifiedRequest["reasoning_effort"]
+			if tc.expectReasoningEffortKey != hasReasoningEffort {
+				t.Fatalf("Expected reasoning_effort key presence: %v, got: %v", tc.expectReasoningEffortKey, hasReasoningEffort)
+			}
+			if tc.expectReasoningEffortKey && reasoningEffort != tc.expectedReasoningEffort {
+				t.Fatalf("Expected reasoning_effort: %v, got: %v", tc.expectedReasoningEffort, reasoningEffort)
+			}
+
+			// Check chat_template_kwargs handling
+			chatTemplateKwargs, hasChatTemplateKwargs := modifiedRequest["chat_template_kwargs"]
+			if tc.expectedChatTemplateKwargs != hasChatTemplateKwargs {
+				t.Fatalf("Expected chat_template_kwargs key presence: %v, got: %v", tc.expectedChatTemplateKwargs, hasChatTemplateKwargs)
+			}
+			if tc.expectedChatTemplateKwargs {
+				kwargs, ok := chatTemplateKwargs.(map[string]interface{})
+				if !ok {
+					t.Fatalf("Expected chat_template_kwargs to be a map")
+				}
+				if len(kwargs) == 0 {
+					t.Fatalf("Expected non-empty chat_template_kwargs")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
If the model doesn't support reasoning, don't set the reasoning effort in API call.
<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
This is a regression when reasoning mode support is added
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
