### PR TITLE
fix: don't set reasoning effort for non-reasoning models

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -253,4 +253,32 @@ api:
       sample_rate: 1.0                   # Collect metrics for all requests (1.0 = 100%, 0.5 = 50%)
       # Histogram buckets for metrics (directly configure what you need)
       duration_buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30]
-      size_buckets: [1, 2, 5, 10, 20, 50, 100, 200] 
+      size_buckets: [1, 2, 5, 10, 20, 50, 100, 200]
+
+# Model reasoning configurations - define how different models handle reasoning syntax
+model_reasoning_configs:
+  - name: "deepseek"
+    patterns: ["deepseek", "ds-", "ds_", "ds:", "ds "]
+    reasoning_syntax:
+      type: "chat_template_kwargs"
+      parameter: "thinking"
+  
+  - name: "qwen3"
+    patterns: ["qwen3"]
+    reasoning_syntax:
+      type: "chat_template_kwargs"
+      parameter: "enable_thinking"
+  
+  - name: "gpt-oss"
+    patterns: ["gpt-oss", "gpt_oss"]
+    reasoning_syntax:
+      type: "reasoning_effort"
+      parameter: "reasoning_effort"
+  
+  - name: "gpt"
+    patterns: ["gpt"]
+    reasoning_syntax:
+      type: "reasoning_effort"
+      parameter: "reasoning_effort"
+  
+# No default fallback - unknown models should have no reasoning syntax applied 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -57,6 +57,28 @@ model_config:
       pii_types_allowed: ["EMAIL_ADDRESS", "PERSON", "GPE", "PHONE_NUMBER"]  # Only allow these specific PII types
     # Specify which endpoints can serve this model (optional - if not specified, uses all endpoints that list this model)
     preferred_endpoints: ["endpoint1", "endpoint3"]
+    # Reasoning family - phi4 doesn't support reasoning, so omit this field
+  
+  # Example: DeepSeek model with custom name
+  "ds-v31-custom":
+    reasoning_family: "deepseek"  # This model uses DeepSeek reasoning syntax
+    preferred_endpoints: ["endpoint1"]
+    pii_policy:
+      allow_by_default: true
+  
+  # Example: Qwen3 model with custom name  
+  "my-qwen3-model":
+    reasoning_family: "qwen3"     # This model uses Qwen3 reasoning syntax
+    preferred_endpoints: ["endpoint2"]
+    pii_policy:
+      allow_by_default: true
+  
+  # Example: GPT-OSS model with custom name
+  "custom-gpt-oss":
+    reasoning_family: "gpt-oss"   # This model uses GPT-OSS reasoning syntax
+    preferred_endpoints: ["endpoint1"]
+    pii_policy:
+      allow_by_default: true
   gemma3:27b:
     pricing:
       currency: USD
@@ -236,7 +258,6 @@ categories:
   - model: phi4
     score: 0.2
 default_model: mistral-small3.1
-default_reasoning_effort: medium  # Default reasoning effort level (low, medium, high)
 
 # API Configuration
 api:
@@ -255,30 +276,23 @@ api:
       duration_buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30]
       size_buckets: [1, 2, 5, 10, 20, 50, 100, 200]
 
-# Model reasoning configurations - define how different models handle reasoning syntax
-model_reasoning_configs:
-  - name: "deepseek"
-    patterns: ["deepseek", "ds-", "ds_", "ds:", "ds "]
-    reasoning_syntax:
-      type: "chat_template_kwargs"
-      parameter: "thinking"
+# Reasoning family configurations - define how different model families handle reasoning syntax
+reasoning_families:
+  deepseek:
+    type: "chat_template_kwargs"
+    parameter: "thinking"
   
-  - name: "qwen3"
-    patterns: ["qwen3"]
-    reasoning_syntax:
-      type: "chat_template_kwargs"
-      parameter: "enable_thinking"
+  qwen3:
+    type: "chat_template_kwargs"
+    parameter: "enable_thinking"
   
-  - name: "gpt-oss"
-    patterns: ["gpt-oss", "gpt_oss"]
-    reasoning_syntax:
-      type: "reasoning_effort"
-      parameter: "reasoning_effort"
+  gpt-oss:
+    type: "reasoning_effort"
+    parameter: "reasoning_effort"
   
-  - name: "gpt"
-    patterns: ["gpt"]
-    reasoning_syntax:
-      type: "reasoning_effort"
-      parameter: "reasoning_effort"
-  
-# No default fallback - unknown models should have no reasoning syntax applied 
+  gpt:
+    type: "reasoning_effort"
+    parameter: "reasoning_effort"
+
+# Global default reasoning effort level
+default_reasoning_effort: medium  # Default reasoning effort level (low, medium, high) 

--- a/src/semantic-router/pkg/extproc/reason_mode_selector.go
+++ b/src/semantic-router/pkg/extproc/reason_mode_selector.go
@@ -108,7 +108,7 @@ func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled
 		originalReasoningEffort = "low" // Default for compatibility
 	}
 
-	// Clear existing reasoning-related fields
+	// Clear existing reasoning-related fields to start with clean state
 	delete(requestMap, "chat_template_kwargs")
 	delete(requestMap, "reasoning_effort")
 
@@ -117,8 +117,10 @@ func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled
 	if enabled {
 		// When reasoning is enabled, build the appropriate fields
 		reasoningFields, effort := r.buildReasoningRequestFields(model, enabled, categoryName)
-		for key, value := range reasoningFields {
-			requestMap[key] = value
+		if reasoningFields != nil {
+			for key, value := range reasoningFields {
+				requestMap[key] = value
+			}
 		}
 		appliedEffort = effort
 	} else {

--- a/src/semantic-router/pkg/extproc/reason_mode_selector.go
+++ b/src/semantic-router/pkg/extproc/reason_mode_selector.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/vllm-project/semantic-router/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/semantic-router/pkg/metrics"
 )
 
@@ -47,61 +48,42 @@ func (r *OpenAIRouter) getReasoningModeAndCategory(query string) (bool, string) 
 	return false, categoryName
 }
 
-// hasDeepSeekAlias returns true if the model uses a short alias for DeepSeek (e.g., "ds-*")
-// Rules:
-//   - Accept only when the model string starts with: "ds-", "ds_", "ds:", "ds " or exactly equals "ds"
-//   - Do NOT match occurrences of "ds" in the middle of the model name (e.g., "foo-ds-1b")
-func hasDeepSeekAlias(lower string) bool {
-	lower = strings.TrimSpace(lower)
-	if strings.HasPrefix(lower, "ds") {
-		if len(lower) == 2 { // exactly "ds"
-			return true
-		}
-		sep := lower[2]
-		return sep == '-' || sep == '_' || sep == ':' || sep == ' '
+// getModelReasoningConfig finds the reasoning configuration for a model using the config system
+func (r *OpenAIRouter) getModelReasoningConfig(model string) *config.ModelReasoningConfig {
+	if r.Config == nil {
+		return nil
 	}
-	return false
+	return r.Config.FindModelReasoningConfig(model)
 }
 
-// getModelFamilyAndTemplateParam returns a normalized model family name and the template param to be used (if any)
-func getModelFamilyAndTemplateParam(model string) (string, string) {
-	lower := strings.ToLower(strings.TrimSpace(model))
-	if strings.Contains(lower, "qwen3") {
-		return "qwen3", "enable_thinking"
+// buildReasoningRequestFields returns the appropriate fields to add to the request based on model config
+func (r *OpenAIRouter) buildReasoningRequestFields(model string, useReasoning bool, categoryName string) (map[string]interface{}, string) {
+	modelConfig := r.getModelReasoningConfig(model)
+	if modelConfig == nil {
+		// No configuration found for this model - don't apply any reasoning syntax
+		// Unknown models should not have reasoning fields added
+		return nil, "N/A"
 	}
-	if strings.Contains(lower, "deepseek") || hasDeepSeekAlias(lower) {
-		return "deepseek", "thinking"
-	}
-	// GPT-OSS family and generic GPT fall back to using reasoning_effort (OpenAI-compatible field)
-	if strings.Contains(lower, "gpt-oss") || strings.Contains(lower, "gpt_oss") {
-		return "gpt-oss", "reasoning_effort"
-	}
-	if strings.Contains(lower, "gpt") {
-		return "gpt", "reasoning_effort"
-	}
-	return "unknown", ""
-}
 
-// getChatTemplateKwargs returns the appropriate chat template kwargs based on model and reasoning mode
-func getChatTemplateKwargs(model string, useReasoning bool) map[string]interface{} {
-	lower := strings.ToLower(strings.TrimSpace(model))
+	if !useReasoning {
+		// When reasoning is disabled, don't add any reasoning fields
+		return nil, "N/A"
+	}
 
-	// Qwen3: use enable_thinking true/false
-	if strings.Contains(lower, "qwen3") {
-		return map[string]interface{}{
-			"enable_thinking": useReasoning,
+	// When reasoning is enabled, use the configured syntax
+	switch modelConfig.ReasoningSyntax.Type {
+	case "chat_template_kwargs":
+		kwargs := map[string]interface{}{
+			modelConfig.ReasoningSyntax.Parameter: useReasoning,
 		}
+		return map[string]interface{}{"chat_template_kwargs": kwargs}, "N/A"
+	case "reasoning_effort":
+		effort := r.getReasoningEffort(categoryName)
+		return map[string]interface{}{"reasoning_effort": effort}, effort
+	default:
+		// Unknown reasoning syntax type - don't apply anything
+		return nil, "N/A"
 	}
-
-	// DeepSeek v3 family: use thinking true/false
-	if strings.Contains(lower, "deepseek") || strings.Contains(lower, "ds") {
-		return map[string]interface{}{
-			"thinking": useReasoning,
-		}
-	}
-
-	// Default: no chat template kwargs for unknown models
-	return nil
 }
 
 // setReasoningModeToRequestBody adds chat_template_kwargs to the JSON request body
@@ -120,49 +102,60 @@ func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled
 		}
 	}
 
-	family, param := getModelFamilyAndTemplateParam(model)
+	// Get original reasoning effort for potential preservation
+	originalReasoningEffort, hasOriginalEffort := requestMap["reasoning_effort"]
+	if !hasOriginalEffort {
+		originalReasoningEffort = "low" // Default for compatibility
+	}
 
-	// Add chat_template_kwargs for reasoning mode
-	kwargs := getChatTemplateKwargs(model, enabled)
-	if kwargs != nil {
-		requestMap["chat_template_kwargs"] = kwargs
-	} else {
-		delete(requestMap, "chat_template_kwargs")
-	}
-	// Also set Reasoning-Effort in openai request
-	// This is a hack to get the reasoning mode for openai/gpt-oss-20b to work
-	originalReasoningEffort, ok := requestMap["reasoning_effort"]
-	if !ok {
-		// This seems to be the default for openai/gpt-oss models
-		originalReasoningEffort = "low"
-	}
-	var appliedEffort string
+	// Clear existing reasoning-related fields
+	delete(requestMap, "chat_template_kwargs")
+	delete(requestMap, "reasoning_effort")
+
+	var appliedEffort string = "N/A"
+
 	if enabled {
-		// Use configurable reasoning effort based on category
-		effort := r.getReasoningEffort(categoryName)
-		requestMap["reasoning_effort"] = effort
+		// When reasoning is enabled, build the appropriate fields
+		reasoningFields, effort := r.buildReasoningRequestFields(model, enabled, categoryName)
+		for key, value := range reasoningFields {
+			requestMap[key] = value
+		}
 		appliedEffort = effort
 	} else {
-		requestMap["reasoning_effort"] = originalReasoningEffort
-		if s, ok := originalReasoningEffort.(string); ok {
-			appliedEffort = s
+		// When reasoning is disabled, only preserve reasoning_effort for gpt-oss models
+		modelConfig := r.getModelReasoningConfig(model)
+		if modelConfig != nil && modelConfig.Name == "gpt-oss" {
+			requestMap["reasoning_effort"] = originalReasoningEffort
+			if s, ok := originalReasoningEffort.(string); ok {
+				appliedEffort = s
+			}
 		}
+		// For all other models, reasoning fields remain cleared
 	}
 
 	log.Printf("Original reasoning effort: %s", originalReasoningEffort)
-	log.Printf("Added reasoning mode (enabled: %v) and reasoning effort (%s) to request for model: %s", enabled, requestMap["reasoning_effort"], model)
+	log.Printf("Added reasoning mode (enabled: %v) and reasoning effort (%s) to request for model: %s", enabled, appliedEffort, model)
 
 	// Record metrics for template usage and effort when enabled
 	if enabled {
-		// If we applied a known template param, record its usage
-		if kwargs != nil && param != "" {
-			metrics.RecordReasoningTemplateUsage(family, param)
-		} else if kwargs == nil && param == "reasoning_effort" {
-			// For GPT/GPT-OSS, we only set reasoning_effort
-			metrics.RecordReasoningTemplateUsage(family, param)
+		modelConfig := r.getModelReasoningConfig(model)
+		modelFamily := "unknown"
+		templateParam := "reasoning_effort" // default fallback
+
+		if modelConfig != nil {
+			modelFamily = modelConfig.Name
+			if modelConfig.ReasoningSyntax.Type == "chat_template_kwargs" {
+				templateParam = modelConfig.ReasoningSyntax.Parameter
+			} else {
+				templateParam = "reasoning_effort"
+			}
 		}
-		// Record which effort level was used for this family
-		metrics.RecordReasoningEffortUsage(family, appliedEffort)
+
+		// Record template usage and effort
+		metrics.RecordReasoningTemplateUsage(modelFamily, templateParam)
+		if appliedEffort != "N/A" {
+			metrics.RecordReasoningEffortUsage(modelFamily, appliedEffort)
+		}
 	}
 
 	// Serialize back to JSON

--- a/src/semantic-router/pkg/extproc/reason_mode_selector_test.go
+++ b/src/semantic-router/pkg/extproc/reason_mode_selector_test.go
@@ -1,76 +1,365 @@
 package extproc
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/semantic-router/pkg/config"
+)
 
 // TestGetModelFamilyAndTemplateParam verifies model-family detection and template parameter mapping
-func TestGetModelFamilyAndTemplateParam(t *testing.T) {
+// TestModelReasoningConfig tests the new config-driven approach
+func TestModelReasoningConfig(t *testing.T) {
+	// Create a router with sample model configurations
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{
+			DefaultReasoningEffort: "medium",
+			ModelReasoningConfigs: []config.ModelReasoningConfig{
+				{
+					Name:     "qwen3",
+					Patterns: []string{"qwen3"},
+					ReasoningSyntax: config.ModelReasoningSyntax{
+						Type:      "chat_template_kwargs",
+						Parameter: "enable_thinking",
+					},
+				},
+				{
+					Name:     "deepseek",
+					Patterns: []string{"deepseek", "ds-", "ds_", "ds:", "ds "},
+					ReasoningSyntax: config.ModelReasoningSyntax{
+						Type:      "chat_template_kwargs",
+						Parameter: "thinking",
+					},
+				},
+				{
+					Name:     "gpt-oss",
+					Patterns: []string{"gpt-oss", "gpt_oss"},
+					ReasoningSyntax: config.ModelReasoningSyntax{
+						Type:      "reasoning_effort",
+						Parameter: "reasoning_effort",
+					},
+				},
+				{
+					Name:     "gpt",
+					Patterns: []string{"gpt"},
+					ReasoningSyntax: config.ModelReasoningSyntax{
+						Type:      "reasoning_effort",
+						Parameter: "reasoning_effort",
+					},
+				},
+				// No default config - unknown models should not get reasoning syntax
+			},
+		},
+	}
+
 	testCases := []struct {
-		name           string
-		model          string
-		expectedFamily string
-		expectedParam  string
+		name              string
+		model             string
+		expectedConfig    string // expected config name or empty for no config
+		expectedType      string
+		expectedParameter string
+		expectConfig      bool
 	}{
 		{
-			name:           "Qwen3 family",
-			model:          "Qwen3-7B",
-			expectedFamily: "qwen3",
-			expectedParam:  "enable_thinking",
+			name:              "Qwen3 family",
+			model:             "Qwen3-7B",
+			expectedConfig:    "qwen3",
+			expectedType:      "chat_template_kwargs",
+			expectedParameter: "enable_thinking",
+			expectConfig:      true,
 		},
 		{
-			name:           "DeepSeek family",
-			model:          "deepseek-v31",
-			expectedFamily: "deepseek",
-			expectedParam:  "thinking",
+			name:              "DeepSeek family",
+			model:             "deepseek-v31",
+			expectedConfig:    "deepseek",
+			expectedType:      "chat_template_kwargs",
+			expectedParameter: "thinking",
+			expectConfig:      true,
 		},
 		{
-			name:           "DeepSeek alias ds (prefix)",
-			model:          "DS-1.5B",
-			expectedFamily: "deepseek",
-			expectedParam:  "thinking",
+			name:              "DeepSeek alias ds (prefix)",
+			model:             "DS-1.5B",
+			expectedConfig:    "deepseek",
+			expectedType:      "chat_template_kwargs",
+			expectedParameter: "thinking",
+			expectConfig:      true,
 		},
 		{
-			name:           "Non-leading ds should not match DeepSeek",
-			model:          "mistral-ds-1b",
-			expectedFamily: "unknown",
-			expectedParam:  "",
+			name:              "GPT-OSS family",
+			model:             "gpt-oss-20b",
+			expectedConfig:    "gpt-oss",
+			expectedType:      "reasoning_effort",
+			expectedParameter: "reasoning_effort",
+			expectConfig:      true,
 		},
 		{
-			name:           "GPT-OSS family",
-			model:          "gpt-oss-20b",
-			expectedFamily: "gpt-oss",
-			expectedParam:  "reasoning_effort",
+			name:              "GPT generic family",
+			model:             "gpt-4o-mini",
+			expectedConfig:    "gpt",
+			expectedType:      "reasoning_effort",
+			expectedParameter: "reasoning_effort",
+			expectConfig:      true,
 		},
 		{
-			name:           "GPT generic family",
-			model:          "gpt-4o-mini",
-			expectedFamily: "gpt",
-			expectedParam:  "reasoning_effort",
+			name:              "Unknown family (phi4) should have no config",
+			model:             "phi4",
+			expectedConfig:    "",
+			expectedType:      "",
+			expectedParameter: "",
+			expectConfig:      false,
 		},
 		{
-			name:           "GPT underscore variant",
-			model:          "  GPT_OSS-foo  ",
-			expectedFamily: "gpt-oss",
-			expectedParam:  "reasoning_effort",
-		},
-		{
-			name:           "Unknown family",
-			model:          "phi4",
-			expectedFamily: "unknown",
-			expectedParam:  "",
-		},
-		{
-			name:           "Empty model name",
-			model:          "",
-			expectedFamily: "unknown",
-			expectedParam:  "",
+			name:              "Non-matching ds should have no config",
+			model:             "mistral-ds-1b",
+			expectedConfig:    "",
+			expectedType:      "",
+			expectedParameter: "",
+			expectConfig:      false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			family, param := getModelFamilyAndTemplateParam(tc.model)
-			if family != tc.expectedFamily || param != tc.expectedParam {
-				t.Fatalf("for model %q got (family=%q, param=%q), want (family=%q, param=%q)", tc.model, family, param, tc.expectedFamily, tc.expectedParam)
+			modelConfig := router.getModelReasoningConfig(tc.model)
+
+			if !tc.expectConfig {
+				// For unknown models, we expect no configuration
+				if modelConfig != nil {
+					t.Fatalf("Expected no model config for %q, got %+v", tc.model, modelConfig)
+				}
+				return
+			}
+
+			// For known models, we expect a valid configuration
+			if modelConfig == nil {
+				t.Fatalf("Expected model config for %q, got nil", tc.model)
+			}
+			if modelConfig.Name != tc.expectedConfig {
+				t.Fatalf("Expected config name %q for model %q, got %q", tc.expectedConfig, tc.model, modelConfig.Name)
+			}
+			if modelConfig.ReasoningSyntax.Type != tc.expectedType {
+				t.Fatalf("Expected type %q for model %q, got %q", tc.expectedType, tc.model, modelConfig.ReasoningSyntax.Type)
+			}
+			if modelConfig.ReasoningSyntax.Parameter != tc.expectedParameter {
+				t.Fatalf("Expected parameter %q for model %q, got %q", tc.expectedParameter, tc.model, modelConfig.ReasoningSyntax.Parameter)
+			}
+		})
+	}
+}
+
+// TestSetReasoningModeToRequestBody verifies that reasoning_effort is handled correctly for different model families
+func TestSetReasoningModeToRequestBody(t *testing.T) {
+	// Create a router with model reasoning configurations
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{
+			DefaultReasoningEffort: "medium",
+			ModelReasoningConfigs: []config.ModelReasoningConfig{
+				{
+					Name:     "deepseek",
+					Patterns: []string{"deepseek", "ds-", "ds_", "ds:", "ds "},
+					ReasoningSyntax: config.ModelReasoningSyntax{
+						Type:      "chat_template_kwargs",
+						Parameter: "thinking",
+					},
+				},
+				{
+					Name:     "qwen3",
+					Patterns: []string{"qwen3"},
+					ReasoningSyntax: config.ModelReasoningSyntax{
+						Type:      "chat_template_kwargs",
+						Parameter: "enable_thinking",
+					},
+				},
+				{
+					Name:     "gpt-oss",
+					Patterns: []string{"gpt-oss", "gpt_oss"},
+					ReasoningSyntax: config.ModelReasoningSyntax{
+						Type:      "reasoning_effort",
+						Parameter: "reasoning_effort",
+					},
+				},
+				// No default config - unknown models should not get reasoning syntax
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                       string
+		model                      string
+		enabled                    bool
+		initialReasoningEffort     interface{}
+		expectReasoningEffortKey   bool
+		expectedReasoningEffort    interface{}
+		expectedChatTemplateKwargs bool
+	}{
+		{
+			name:                       "GPT-OSS model with reasoning disabled - preserve reasoning_effort",
+			model:                      "gpt-oss-20b",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   true,
+			expectedReasoningEffort:    "low",
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "Phi4 model with reasoning disabled - remove reasoning_effort",
+			model:                      "phi4",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "Phi4 model with reasoning enabled - no fields set (unknown model)",
+			model:                      "phi4",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "DeepSeek model with reasoning disabled - remove reasoning_effort",
+			model:                      "deepseek-v31",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "GPT-OSS model with reasoning enabled - set reasoning_effort",
+			model:                      "gpt-oss-20b",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   true,
+			expectedReasoningEffort:    "medium",
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "DeepSeek model with reasoning enabled - set chat_template_kwargs",
+			model:                      "deepseek-v31",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: true,
+		},
+		{
+			name:                       "DeepSeek alias (ds-) with reasoning enabled - set chat_template_kwargs",
+			model:                      "ds-1.5b",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: true,
+		},
+		{
+			name:                       "DeepSeek alias (ds-) with reasoning disabled - no fields set",
+			model:                      "ds-1.5b",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "Non-matching ds model - no fields set (unknown model)",
+			model:                      "mistral-ds-7b",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+		{
+			name:                       "Qwen3 model with reasoning enabled - set chat_template_kwargs",
+			model:                      "qwen3-7b",
+			enabled:                    true,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: true,
+		},
+		{
+			name:                       "Qwen3 model with reasoning disabled - no fields set",
+			model:                      "qwen3-7b",
+			enabled:                    false,
+			initialReasoningEffort:     "low",
+			expectReasoningEffortKey:   false,
+			expectedReasoningEffort:    nil,
+			expectedChatTemplateKwargs: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Prepare initial request body
+			requestBody := map[string]interface{}{
+				"model": tc.model,
+				"messages": []map[string]string{
+					{"role": "user", "content": "test message"},
+				},
+			}
+			if tc.initialReasoningEffort != nil {
+				requestBody["reasoning_effort"] = tc.initialReasoningEffort
+			}
+
+			requestBytes, err := json.Marshal(requestBody)
+			if err != nil {
+				t.Fatalf("Failed to marshal request body: %v", err)
+			}
+
+			// Call the function under test
+			modifiedBytes, err := router.setReasoningModeToRequestBody(requestBytes, tc.enabled, "test-category")
+			if err != nil {
+				t.Fatalf("setReasoningModeToRequestBody failed: %v", err)
+			}
+
+			// Parse the modified request body
+			var modifiedRequest map[string]interface{}
+			if err := json.Unmarshal(modifiedBytes, &modifiedRequest); err != nil {
+				t.Fatalf("Failed to unmarshal modified request body: %v", err)
+			}
+
+			// Check reasoning_effort handling
+			reasoningEffort, hasReasoningEffort := modifiedRequest["reasoning_effort"]
+			if tc.expectReasoningEffortKey != hasReasoningEffort {
+				t.Fatalf("Expected reasoning_effort key presence: %v, got: %v", tc.expectReasoningEffortKey, hasReasoningEffort)
+			}
+			if tc.expectReasoningEffortKey && reasoningEffort != tc.expectedReasoningEffort {
+				t.Fatalf("Expected reasoning_effort: %v, got: %v", tc.expectedReasoningEffort, reasoningEffort)
+			}
+
+			// Check chat_template_kwargs handling
+			chatTemplateKwargs, hasChatTemplateKwargs := modifiedRequest["chat_template_kwargs"]
+			if tc.expectedChatTemplateKwargs != hasChatTemplateKwargs {
+				t.Fatalf("Expected chat_template_kwargs key presence: %v, got: %v", tc.expectedChatTemplateKwargs, hasChatTemplateKwargs)
+			}
+			if tc.expectedChatTemplateKwargs {
+				kwargs, ok := chatTemplateKwargs.(map[string]interface{})
+				if !ok {
+					t.Fatalf("Expected chat_template_kwargs to be a map")
+				}
+				if len(kwargs) == 0 {
+					t.Fatalf("Expected non-empty chat_template_kwargs")
+				}
+
+				// Validate the specific parameter based on model type
+				if tc.model == "deepseek-v31" || tc.model == "ds-1.5b" {
+					if thinkingValue, exists := kwargs["thinking"]; !exists {
+						t.Fatalf("Expected 'thinking' parameter in chat_template_kwargs for DeepSeek model")
+					} else if thinkingValue != true {
+						t.Fatalf("Expected 'thinking' to be true, got %v", thinkingValue)
+					}
+				} else if tc.model == "qwen3-7b" {
+					if thinkingValue, exists := kwargs["enable_thinking"]; !exists {
+						t.Fatalf("Expected 'enable_thinking' parameter in chat_template_kwargs for Qwen3 model")
+					} else if thinkingValue != true {
+						t.Fatalf("Expected 'enable_thinking' to be true, got %v", thinkingValue)
+					}
+				}
 			}
 		})
 	}

--- a/src/semantic-router/pkg/extproc/reasoning_integration_test.go
+++ b/src/semantic-router/pkg/extproc/reasoning_integration_test.go
@@ -24,32 +24,33 @@ func TestReasoningModeIntegration(t *testing.T) {
 				ReasoningDescription: "Business content is typically conversational",
 			},
 		},
-		ModelReasoningConfigs: []config.ModelReasoningConfig{
-			{
-				Name:     "deepseek",
-				Patterns: []string{"deepseek", "ds-", "ds_", "ds:", "ds "},
-				ReasoningSyntax: config.ModelReasoningSyntax{
-					Type:      "chat_template_kwargs",
-					Parameter: "thinking",
-				},
+		ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+			"deepseek": {
+				Type:      "chat_template_kwargs",
+				Parameter: "thinking",
 			},
-			{
-				Name:     "qwen3",
-				Patterns: []string{"qwen3"},
-				ReasoningSyntax: config.ModelReasoningSyntax{
-					Type:      "chat_template_kwargs",
-					Parameter: "enable_thinking",
-				},
+			"qwen3": {
+				Type:      "chat_template_kwargs",
+				Parameter: "enable_thinking",
 			},
-			{
-				Name:     "gpt-oss",
-				Patterns: []string{"gpt-oss", "gpt_oss"},
-				ReasoningSyntax: config.ModelReasoningSyntax{
-					Type:      "reasoning_effort",
-					Parameter: "reasoning_effort",
-				},
+			"gpt-oss": {
+				Type:      "reasoning_effort",
+				Parameter: "reasoning_effort",
 			},
-			// No default config - unknown models should not get reasoning syntax
+		},
+		ModelConfig: map[string]config.ModelParams{
+			"deepseek-v31": {
+				ReasoningFamily: "deepseek",
+			},
+			"qwen3-model": {
+				ReasoningFamily: "qwen3",
+			},
+			"gpt-oss-model": {
+				ReasoningFamily: "gpt-oss",
+			},
+			"phi4": {
+				// No reasoning family - doesn't support reasoning
+			},
 		},
 	}
 
@@ -185,24 +186,26 @@ func TestReasoningModeIntegration(t *testing.T) {
 		router := &OpenAIRouter{
 			Config: &config.RouterConfig{
 				DefaultReasoningEffort: "medium",
-				ModelReasoningConfigs: []config.ModelReasoningConfig{
-					{
-						Name:     "deepseek",
-						Patterns: []string{"deepseek", "ds-", "ds_", "ds:", "ds "},
-						ReasoningSyntax: config.ModelReasoningSyntax{
-							Type:      "chat_template_kwargs",
-							Parameter: "thinking",
-						},
+				ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+					"deepseek": {
+						Type:      "chat_template_kwargs",
+						Parameter: "thinking",
 					},
-					{
-						Name:     "qwen3",
-						Patterns: []string{"qwen3"},
-						ReasoningSyntax: config.ModelReasoningSyntax{
-							Type:      "chat_template_kwargs",
-							Parameter: "enable_thinking",
-						},
+					"qwen3": {
+						Type:      "chat_template_kwargs",
+						Parameter: "enable_thinking",
 					},
-					// No default config - unknown models should not get reasoning syntax
+				},
+				ModelConfig: map[string]config.ModelParams{
+					"deepseek-v31": {
+						ReasoningFamily: "deepseek",
+					},
+					"qwen3-model": {
+						ReasoningFamily: "qwen3",
+					},
+					"phi4": {
+						// No reasoning family - doesn't support reasoning
+					},
 				},
 			},
 		}
@@ -227,7 +230,7 @@ func TestReasoningModeIntegration(t *testing.T) {
 		}
 
 		// Test with Qwen3 model and reasoning enabled
-		fields, _ = router.buildReasoningRequestFields("qwen3-7b", true, "test-category")
+		fields, _ = router.buildReasoningRequestFields("qwen3-model", true, "test-category")
 		if fields == nil {
 			t.Error("Expected non-nil fields for Qwen3 model with reasoning enabled")
 		}
@@ -244,8 +247,8 @@ func TestReasoningModeIntegration(t *testing.T) {
 		if fields != nil {
 			t.Errorf("Expected nil fields for unknown model with reasoning enabled, got %v", fields)
 		}
-		if effort != "N/A" {
-			t.Errorf("Expected effort string: N/A for unknown model, got %v", effort)
+		if effort != "" {
+			t.Errorf("Expected effort string: empty for unknown model, got %v", effort)
 		}
 	})
 

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -88,34 +88,43 @@ categories:
 
 default_model: your-model
 
-# Model reasoning configurations - define how different models handle reasoning syntax
-model_reasoning_configs:
-  - name: "deepseek"
-    patterns: ["deepseek", "ds-", "ds_", "ds:", "ds "]
-    reasoning_syntax:
-      type: "chat_template_kwargs"
-      parameter: "thinking"
-
-  - name: "qwen3"
-    patterns: ["qwen3"]
-    reasoning_syntax:
-      type: "chat_template_kwargs"
-      parameter: "enable_thinking"
-
-  - name: "gpt-oss"
-    patterns: ["gpt-oss", "gpt_oss"]
-    reasoning_syntax:
-      type: "reasoning_effort"
-      parameter: "reasoning_effort"
-
-  - name: "gpt"
-    patterns: ["gpt"]
-    reasoning_syntax:
-      type: "reasoning_effort"
-      parameter: "reasoning_effort"
+# Reasoning family configurations - define how different model families handle reasoning syntax
+reasoning_families:
+  deepseek:
+    type: "chat_template_kwargs"
+    parameter: "thinking"
+  
+  qwen3:
+    type: "chat_template_kwargs"
+    parameter: "enable_thinking"
+  
+  gpt-oss:
+    type: "reasoning_effort"
+    parameter: "reasoning_effort"
+  
+  gpt:
+    type: "reasoning_effort"
+    parameter: "reasoning_effort"
 
 # Global default reasoning effort level
 default_reasoning_effort: "medium"
+
+# Model configurations - assign reasoning families to specific models
+model_config:
+  # Example: DeepSeek model with custom name
+  "ds-v31-custom":
+    reasoning_family: "deepseek"  # This model uses DeepSeek reasoning syntax
+    preferred_endpoints: ["endpoint1"]
+  
+  # Example: Qwen3 model with custom name
+  "my-qwen3-model":
+    reasoning_family: "qwen3"     # This model uses Qwen3 reasoning syntax  
+    preferred_endpoints: ["endpoint2"]
+  
+  # Example: Model without reasoning support
+  "phi4":
+    # No reasoning_family field - this model doesn't support reasoning mode
+    preferred_endpoints: ["endpoint1"]
 ```
 
 ## Key Configuration Sections
@@ -264,9 +273,22 @@ default_reasoning_effort: "medium"
 - `reasoning_syntax.parameter`: The specific parameter name the model uses
 
 **Pattern Matching:**
-- Exact matches: `"deepseek"` matches models containing "deepseek"
-- Prefix patterns: `"ds-"` matches models starting with "ds-" (like "ds-1.5b")
-- Multiple patterns: `["deepseek", "ds-", "ds_"]` matches any of these patterns
+The system supports both simple string patterns and regular expressions for flexible model matching:
+
+- **Simple string matches**: `"deepseek"` matches any model containing "deepseek"
+- **Prefix patterns**: `"ds-"` matches models starting with "ds-" or exactly "ds"
+- **Regular expressions**: `"^gpt-4.*"` matches models starting with "gpt-4"
+- **Wildcard**: `"*"` matches all models (use for fallback configurations)
+- **Multiple patterns**: `["deepseek", "ds-", "^phi.*"]` matches any of these patterns
+
+**Regex Pattern Examples:**
+```yaml
+patterns:
+  - "^gpt-4.*"        # Models starting with "gpt-4"
+  - ".*-instruct$"    # Models ending with "-instruct"
+  - "phi[0-9]+"       # Models like "phi3", "phi4", etc.
+  - "^(llama|mistral)" # Models starting with "llama" or "mistral"
+```
 
 **Adding New Models:**
 To support a new model family (e.g., Claude), simply add a new configuration:

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -87,6 +87,35 @@ categories:
     score: 0.8
 
 default_model: your-model
+
+# Model reasoning configurations - define how different models handle reasoning syntax
+model_reasoning_configs:
+  - name: "deepseek"
+    patterns: ["deepseek", "ds-", "ds_", "ds:", "ds "]
+    reasoning_syntax:
+      type: "chat_template_kwargs"
+      parameter: "thinking"
+
+  - name: "qwen3"
+    patterns: ["qwen3"]
+    reasoning_syntax:
+      type: "chat_template_kwargs"
+      parameter: "enable_thinking"
+
+  - name: "gpt-oss"
+    patterns: ["gpt-oss", "gpt_oss"]
+    reasoning_syntax:
+      type: "reasoning_effort"
+      parameter: "reasoning_effort"
+
+  - name: "gpt"
+    patterns: ["gpt"]
+    reasoning_syntax:
+      type: "reasoning_effort"
+      parameter: "reasoning_effort"
+
+# Global default reasoning effort level
+default_reasoning_effort: "medium"
 ```
 
 ## Key Configuration Sections
@@ -187,6 +216,98 @@ categories:
     score: 0.8
 
 default_model: your-model          # Fallback model
+```
+
+### Model Reasoning Configuration
+
+Configure how different models handle reasoning mode syntax. This allows you to add new models without code changes:
+
+```yaml
+# Model reasoning configurations - define how different models handle reasoning syntax
+model_reasoning_configs:
+  - name: "deepseek"
+    patterns: ["deepseek", "ds-", "ds_", "ds:", "ds "]
+    reasoning_syntax:
+      type: "chat_template_kwargs"
+      parameter: "thinking"
+
+  - name: "qwen3"
+    patterns: ["qwen3"]
+    reasoning_syntax:
+      type: "chat_template_kwargs"
+      parameter: "enable_thinking"
+
+  - name: "gpt-oss"
+    patterns: ["gpt-oss", "gpt_oss"]
+    reasoning_syntax:
+      type: "reasoning_effort"
+      parameter: "reasoning_effort"
+
+  - name: "gpt"
+    patterns: ["gpt"]
+    reasoning_syntax:
+      type: "reasoning_effort"
+      parameter: "reasoning_effort"
+
+# Global default reasoning effort level (when not specified per category)
+default_reasoning_effort: "medium"
+```
+
+#### Model Reasoning Configuration Options
+
+**Configuration Structure:**
+- `name`: A unique identifier for the model family
+- `patterns`: Array of patterns to match against model names
+- `reasoning_syntax.type`: How the model expects reasoning mode to be specified
+  - `"chat_template_kwargs"`: Use chat template parameters (for models like DeepSeek, Qwen3)
+  - `"reasoning_effort"`: Use OpenAI-compatible reasoning_effort field (for GPT models)
+- `reasoning_syntax.parameter`: The specific parameter name the model uses
+
+**Pattern Matching:**
+- Exact matches: `"deepseek"` matches models containing "deepseek"
+- Prefix patterns: `"ds-"` matches models starting with "ds-" (like "ds-1.5b")
+- Multiple patterns: `["deepseek", "ds-", "ds_"]` matches any of these patterns
+
+**Adding New Models:**
+To support a new model family (e.g., Claude), simply add a new configuration:
+
+```yaml
+model_reasoning_configs:
+  - name: "claude"
+    patterns: ["claude"]
+    reasoning_syntax:
+      type: "chat_template_kwargs"
+      parameter: "enable_reasoning"
+```
+
+**Unknown Models:**
+Models that don't match any configured pattern will have no reasoning fields applied when reasoning mode is enabled. This prevents issues with models that don't support reasoning syntax.
+
+**Default Reasoning Effort:**
+Set the global default reasoning effort level used when categories don't specify their own effort level:
+
+```yaml
+default_reasoning_effort: "high"  # Options: "low", "medium", "high"
+```
+
+**Category-Specific Reasoning Effort:**
+Override the default effort level per category:
+
+```yaml
+categories:
+- name: math
+  use_reasoning: true
+  reasoning_effort: "high"        # Use high effort for complex math
+  model_scores:
+  - model: your-model
+    score: 1.0
+
+- name: general
+  use_reasoning: true
+  reasoning_effort: "low"         # Use low effort for general queries
+  model_scores:
+  - model: your-model
+    score: 1.0
 ```
 
 ### Security Features
@@ -575,6 +696,41 @@ make test-auto-prompt-reasoning      # Math query
 make test-auto-prompt-no-reasoning   # General query
 make test-pii                        # PII detection
 make test-prompt-guard               # Jailbreak protection
+```
+
+### Model Reasoning Configuration Issues
+
+**Model not getting reasoning fields:**
+- Check that the model name matches a pattern in `model_reasoning_configs`
+- Verify the pattern syntax (exact matches vs prefixes)
+- Unknown models will have no reasoning fields applied (this is by design)
+
+**Wrong reasoning syntax applied:**
+- Ensure the `reasoning_syntax.type` matches your model's expected format
+- Check the `reasoning_syntax.parameter` name is correct
+- DeepSeek models typically use `chat_template_kwargs` with `"thinking"`
+- GPT models typically use `reasoning_effort`
+
+**Adding support for new models:**
+```yaml
+# Add a new model configuration
+model_reasoning_configs:
+  - name: "my-new-model"
+    patterns: ["my-model"]
+    reasoning_syntax:
+      type: "chat_template_kwargs"  # or "reasoning_effort"
+      parameter: "custom_parameter"
+```
+
+**Testing model reasoning configuration:**
+```bash
+# Test reasoning with your specific model
+curl -X POST http://localhost:8801/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "your-model-name",
+    "messages": [{"role": "user", "content": "What is 2+2?"}]
+  }'
 ```
 
 ## Configuration Generation


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
If the model doesn't support reasoning, don't set the reasoning effort in API call.
<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
This is a regression when reasoning mode support is added
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
