### PR TITLE
fix: use request id to locate the correct cache entry to update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,7 @@ The test suite includes:
 - **Envoy logs:** Check the terminal running `make run-envoy` for detailed request/response logs
 - **Router logs:** Check the terminal running `make run-router` for classification and routing decisions
 - **Rust library:** Use `RUST_LOG=debug` environment variable for detailed Rust logs
+- **Go library:** Use `SR_LOG_LEVEL=debug` environment variable for detailed Go logs
 
 ## Code Style and Standards
 

--- a/src/semantic-router/pkg/cache/cache_interface.go
+++ b/src/semantic-router/pkg/cache/cache_interface.go
@@ -4,6 +4,7 @@ import "time"
 
 // CacheEntry represents a complete cached request-response pair with associated metadata
 type CacheEntry struct {
+	RequestID    string
 	RequestBody  []byte
 	ResponseBody []byte
 	Model        string
@@ -18,14 +19,13 @@ type CacheBackend interface {
 	IsEnabled() bool
 
 	// AddPendingRequest stores a request awaiting its response
-	// Returns the processed query string and any error
-	AddPendingRequest(model string, query string, requestBody []byte) (string, error)
+	AddPendingRequest(requestID string, model string, query string, requestBody []byte) error
 
 	// UpdateWithResponse completes a pending request with the received response
-	UpdateWithResponse(query string, responseBody []byte) error
+	UpdateWithResponse(requestID string, responseBody []byte) error
 
 	// AddEntry stores a complete request-response pair in the cache
-	AddEntry(model string, query string, requestBody, responseBody []byte) error
+	AddEntry(requestID string, model string, query string, requestBody, responseBody []byte) error
 
 	// FindSimilar searches for semantically similar cached requests
 	// Returns the cached response, match status, and any error

--- a/src/semantic-router/pkg/cache/cache_test.go
+++ b/src/semantic-router/pkg/cache/cache_test.go
@@ -442,7 +442,7 @@ development:
 		})
 
 		It("should handle AddEntry operation with embeddings", func() {
-			err := inMemoryCache.AddEntry("test-model", "test query", []byte("request"), []byte("response"))
+			err := inMemoryCache.AddEntry("test-request-id", "test-model", "test query", []byte("request"), []byte("response"))
 			Expect(err).NotTo(HaveOccurred())
 
 			stats := inMemoryCache.GetStats()
@@ -451,7 +451,7 @@ development:
 
 		It("should handle FindSimilar operation with embeddings", func() {
 			// First add an entry
-			err := inMemoryCache.AddEntry("test-model", "test query", []byte("request"), []byte("response"))
+			err := inMemoryCache.AddEntry("test-request-id", "test-model", "test query", []byte("request"), []byte("response"))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search for similar query
@@ -468,12 +468,11 @@ development:
 		})
 
 		It("should handle AddPendingRequest and UpdateWithResponse", func() {
-			query, err := inMemoryCache.AddPendingRequest("test-model", "test query", []byte("request"))
+			err := inMemoryCache.AddPendingRequest("test-request-id", "test-model", "test query", []byte("request"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(query).To(Equal("test query"))
 
 			// Update with response
-			err = inMemoryCache.UpdateWithResponse("test query", []byte("response"))
+			err = inMemoryCache.UpdateWithResponse("test-request-id", []byte("response"))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should now be able to find it
@@ -494,7 +493,7 @@ development:
 			highThresholdCache := cache.NewInMemoryCache(highThresholdOptions)
 			defer highThresholdCache.Close()
 
-			err := highThresholdCache.AddEntry("test-model", "machine learning", []byte("request"), []byte("ml response"))
+			err := highThresholdCache.AddEntry("test-request-id", "test-model", "machine learning", []byte("request"), []byte("ml response"))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Exact match should work
@@ -512,7 +511,7 @@ development:
 
 		It("should track hit and miss statistics", func() {
 			// Add an entry with a specific query
-			err := inMemoryCache.AddEntry("test-model", "What is machine learning?", []byte("request"), []byte("ML is a subset of AI"))
+			err := inMemoryCache.AddEntry("test-request-id", "test-model", "What is machine learning?", []byte("request"), []byte("ML is a subset of AI"))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search for the exact cached query (should be a hit)
@@ -561,14 +560,13 @@ development:
 
 			// Disabled cache operations should not error but should be no-ops
 			// They should NOT try to generate embeddings
-			query, err := disabledCache.AddPendingRequest("model", "query", []byte("request"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(query).To(Equal("query"))
-
-			err = disabledCache.UpdateWithResponse("query", []byte("response"))
+			err := disabledCache.AddPendingRequest("test-request-id", "test-model", "test query", []byte("request"))
 			Expect(err).NotTo(HaveOccurred())
 
-			err = disabledCache.AddEntry("model", "query", []byte("request"), []byte("response"))
+			err = disabledCache.UpdateWithResponse("test-request-id", []byte("response"))
+			Expect(err).NotTo(HaveOccurred())
+
+			err = disabledCache.AddEntry("test-request-id", "test-model", "test query", []byte("request"), []byte("response"))
 			Expect(err).NotTo(HaveOccurred())
 
 			response, found, err := disabledCache.FindSimilar("model", "query")

--- a/src/semantic-router/pkg/extproc/error_metrics_test.go
+++ b/src/semantic-router/pkg/extproc/error_metrics_test.go
@@ -43,7 +43,6 @@ func getCounterValue(metricName string, want map[string]string) float64 {
 
 func TestRequestParseErrorIncrementsErrorCounter(t *testing.T) {
 	r := &OpenAIRouter{}
-	r.InitializeForTesting()
 
 	ctx := &RequestContext{}
 	// Invalid JSON triggers parse error
@@ -65,7 +64,6 @@ func TestRequestParseErrorIncrementsErrorCounter(t *testing.T) {
 
 func TestResponseParseErrorIncrementsErrorCounter(t *testing.T) {
 	r := &OpenAIRouter{}
-	r.InitializeForTesting()
 
 	ctx := &RequestContext{RequestModel: "model-a"}
 	// Invalid JSON triggers parse error in response body handler
@@ -86,7 +84,6 @@ func TestResponseParseErrorIncrementsErrorCounter(t *testing.T) {
 
 func TestUpstreamStatusIncrements4xx5xxCounters(t *testing.T) {
 	r := &OpenAIRouter{}
-	r.InitializeForTesting()
 
 	ctx := &RequestContext{RequestModel: "m"}
 

--- a/src/semantic-router/pkg/extproc/metrics_integration_test.go
+++ b/src/semantic-router/pkg/extproc/metrics_integration_test.go
@@ -11,6 +11,7 @@ import (
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
 )
 
 func getHistogramSampleCount(metricName, model string) uint64 {
@@ -44,7 +45,9 @@ var _ = Describe("Metrics recording", func() {
 
 	BeforeEach(func() {
 		// Use a minimal router that doesn't require external models
-		router = &OpenAIRouter{}
+		router = &OpenAIRouter{
+			Cache: cache.NewInMemoryCache(cache.InMemoryCacheOptions{Enabled: false}),
+		}
 	})
 
 	It("records TTFT on response headers", func() {

--- a/src/semantic-router/pkg/extproc/metrics_integration_test.go
+++ b/src/semantic-router/pkg/extproc/metrics_integration_test.go
@@ -45,8 +45,6 @@ var _ = Describe("Metrics recording", func() {
 	BeforeEach(func() {
 		// Use a minimal router that doesn't require external models
 		router = &OpenAIRouter{}
-		// Initialize internal maps used by handlers
-		router.InitializeForTesting()
 	})
 
 	It("records TTFT on response headers", func() {

--- a/src/semantic-router/pkg/extproc/request_handler.go
+++ b/src/semantic-router/pkg/extproc/request_handler.go
@@ -276,13 +276,10 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext) (*ext_proc.ProcessingR
 		}
 
 		// Cache miss, store the request for later
-		cacheID, err := r.Cache.AddPendingRequest(requestModel, requestQuery, ctx.OriginalRequestBody)
+		err = r.Cache.AddPendingRequest(ctx.RequestID, requestModel, requestQuery, ctx.OriginalRequestBody)
 		if err != nil {
 			observability.Errorf("Error adding pending request to cache: %v", err)
-		} else {
-			r.pendingRequestsLock.Lock()
-			r.pendingRequests[ctx.RequestID] = []byte(cacheID)
-			r.pendingRequestsLock.Unlock()
+			// Continue without caching
 		}
 	}
 

--- a/src/semantic-router/pkg/extproc/response_handler.go
+++ b/src/semantic-router/pkg/extproc/response_handler.go
@@ -146,7 +146,7 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 	}
 
 	// Update the cache
-	if ctx.RequestQuery != "" && responseBody != nil {
+	if ctx.RequestID != "" && responseBody != nil {
 		err := r.Cache.UpdateWithResponse(ctx.RequestID, responseBody)
 		if err != nil {
 			observability.Errorf("Error updating cache: %v", err)

--- a/src/semantic-router/pkg/extproc/response_handler.go
+++ b/src/semantic-router/pkg/extproc/response_handler.go
@@ -145,17 +145,9 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 		}
 	}
 
-	// Check if this request has a pending cache entry
-	r.pendingRequestsLock.Lock()
-	cacheID, exists := r.pendingRequests[ctx.RequestID]
-	if exists {
-		delete(r.pendingRequests, ctx.RequestID)
-	}
-	r.pendingRequestsLock.Unlock()
-
-	// If we have a pending request, update the cache
-	if exists && ctx.RequestQuery != "" && responseBody != nil {
-		err := r.Cache.UpdateWithResponse(string(cacheID), responseBody)
+	// Update the cache
+	if ctx.RequestQuery != "" && responseBody != nil {
+		err := r.Cache.UpdateWithResponse(ctx.RequestID, responseBody)
 		if err != nil {
 			observability.Errorf("Error updating cache: %v", err)
 			// Continue even if cache update fails

--- a/src/semantic-router/pkg/extproc/router.go
+++ b/src/semantic-router/pkg/extproc/router.go
@@ -2,7 +2,6 @@ package extproc
 
 import (
 	"fmt"
-	"sync"
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
@@ -25,10 +24,6 @@ type OpenAIRouter struct {
 	PIIChecker           *pii.PolicyChecker
 	Cache                cache.CacheBackend
 	ToolsDatabase        *tools.ToolsDatabase
-
-	// Map to track pending requests and their unique IDs
-	pendingRequests     map[string][]byte
-	pendingRequestsLock sync.Mutex
 }
 
 // Ensure OpenAIRouter implements the ext_proc calls
@@ -161,7 +156,6 @@ func NewOpenAIRouter(configPath string) (*OpenAIRouter, error) {
 		PIIChecker:           piiChecker,
 		Cache:                semanticCache,
 		ToolsDatabase:        toolsDatabase,
-		pendingRequests:      make(map[string][]byte),
 	}
 
 	// Log reasoning configuration after router is created

--- a/src/semantic-router/pkg/extproc/test_utils_test.go
+++ b/src/semantic-router/pkg/extproc/test_utils_test.go
@@ -246,8 +246,5 @@ func CreateTestRouter(cfg *config.RouterConfig) (*extproc.OpenAIRouter, error) {
 		ToolsDatabase:        toolsDatabase,
 	}
 
-	// Initialize internal fields for testing
-	router.InitializeForTesting()
-
 	return router, nil
 }

--- a/src/semantic-router/pkg/extproc/testing_helpers_test.go
+++ b/src/semantic-router/pkg/extproc/testing_helpers_test.go
@@ -25,8 +25,3 @@ func (r *OpenAIRouter) HandleResponseHeaders(v *ext_proc.ProcessingRequest_Respo
 func (r *OpenAIRouter) HandleResponseBody(v *ext_proc.ProcessingRequest_ResponseBody, ctx *RequestContext) (*ext_proc.ProcessingResponse, error) {
 	return r.handleResponseBody(v, ctx)
 }
-
-// InitializeForTesting initializes the internal maps and mutexes for testing
-func (r *OpenAIRouter) InitializeForTesting() {
-	r.pendingRequests = make(map[string][]byte)
-}

--- a/tools/make/common.mk
+++ b/tools/make/common.mk
@@ -63,6 +63,8 @@ help:
 	@echo "    clean-milvus            - Stop container and clean data"
 	@echo "    test-milvus-cache       - Test cache with Milvus backend"
 	@echo "    test-semantic-router-milvus - Test router with Milvus cache"
+	@echo "    start-milvus-ui         - Start Milvus UI to browse data"
+	@echo "    stop-milvus-ui          - Stop and remove Milvus UI container"
 	@echo "    Example: CONTAINER_RUNTIME=podman make start-milvus"
 	@echo ""
 	@echo "  Demo targets:"

--- a/tools/make/milvus.mk
+++ b/tools/make/milvus.mk
@@ -66,3 +66,24 @@ test-semantic-router-milvus: build-router start-milvus
 	@export LD_LIBRARY_PATH=$${PWD}/candle-binding/target/release && \
 		cd src/semantic-router && CGO_ENABLED=1 go test -tags=milvus -v ./...
 	@echo "Consider running 'make stop-milvus' when done testing"
+
+# Milvus UI (Attu) management
+start-milvus-ui: ## Start Attu UI to browse Milvus data
+	@$(LOG_TARGET)
+	@echo "Starting Attu (Milvus UI) with $(CONTAINER_RUNTIME)..."
+	@$(CONTAINER_RUNTIME) run -d \
+		--name milvus-ui \
+		--add-host=host.docker.internal:host-gateway \
+		-e MILVUS_URL=host.docker.internal:19530 \
+		-p 18000:3000 \
+		zilliz/attu:v2.3.5
+	@echo "Waiting for Attu to be ready..."
+	@sleep 3
+	@echo "Open UI: http://localhost:18000 (Milvus at host.docker.internal:19530)"
+
+stop-milvus-ui:
+	@$(LOG_TARGET)
+	@echo "Stopping Attu (Milvus UI) container..."
+	@$(CONTAINER_RUNTIME) stop milvus-ui || true
+	@$(CONTAINER_RUNTIME) rm milvus-ui || true
+	@echo "Attu container stopped and removed"


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

fix: use request id to locate the correct cache entry to update

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

The major change:
1. Update the cache interface to use request id to locate the cache entry

Other changes:
-   Added `request_id` to Milvus storage.
-   Replaced the `insert` operation with `upsert` in `MilvusCache.addEntry`. Previously, it always inserted two entries into storage—one for `AddPendingRequest` and another for `UpdateWithResponse`. Now, it updates the entry if a cache entry with the same `request_id` already exists.
-   Removed the logic that added an unknown cache entry when no cache entry was found in `UpdateWithResponse`. I think it's not useful because we this unknown cache entry doesn't have `model` field.
-   Removed `pendingRequests` and `pendingRequestsLock` since they are no longer in use.
-   Added a Docker command to `milvus.mk` to enable starting Attu (the Milvus UI), which is helpful for browsing data.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #144

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
