### PR TITLE
infra: update Dockerfile.extproc

### DIFF
--- a/Dockerfile.extproc
+++ b/Dockerfile.extproc
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy only essential files for Rust build
+COPY tools/make/ tools/make/
 COPY Makefile ./
 COPY candle-binding/Cargo.toml candle-binding/
 COPY candle-binding/src/ candle-binding/src/
@@ -54,4 +55,4 @@ ENV LD_LIBRARY_PATH=/app/lib
 
 EXPOSE 50051
 
-CMD ["/app/extproc-server", "--config", "/app/config/config.yaml"] 
+CMD ["/app/extproc-server", "--config", "/app/config/config.yaml"]


### PR DESCRIPTION
- Closed #151 

https://github.com/yuluo-yx/semantic-router/actions/runs/17799933338/job/50596729621#step:5:376

`make rust` runs successfully in my repository. The reason for the failure is that I cannot make the main image, but this does not affect the main repository.