### PR TITLE
fix: avoid double counting cache hits

### DIFF
--- a/src/semantic-router/pkg/extproc/request_handler.go
+++ b/src/semantic-router/pkg/extproc/request_handler.go
@@ -263,8 +263,7 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext) (*ext_proc.ProcessingR
 		if err != nil {
 			observability.Errorf("Error searching cache: %v", err)
 		} else if found {
-			// Record and log cache hit
-			metrics.RecordCacheHit()
+			// Log cache hit
 			observability.LogEvent("cache_hit", map[string]interface{}{
 				"request_id": ctx.RequestID,
 				"model":      requestModel,


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
fix: avoid double counting cache hits

Currently, `handleCaching` calls `metrics.RecordCacheHit()` when a cache hit is found, while both `InMemoryCache.FindSimilar` and `MilvusCache.FindSimilar` already record cache hits internally. This causes a single cache hit to be counted twice.
This PR removes the duplicate call in `handleCaching` so that each hit is counted only once.
[InMemoryCache]
https://github.com/vllm-project/semantic-router/blob/fac50b1eb93361e012dcc30b120b1e1614b5a54a/src/semantic-router/pkg/cache/inmemory_cache.go#L294-L304
[Milvus]
https://github.com/vllm-project/semantic-router/blob/fac50b1eb93361e012dcc30b120b1e1614b5a54a/src/semantic-router/pkg/cache/milvus_cache.go#L598-L609

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
Accurate cache hit metrics are important for monitoring and analysis.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
