### PR TITLE
feat: Implement testing profile with mock vllm in docker compose

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,88 @@
+# Copilot Agent Instructions — vLLM Semantic Router
+
+Purpose: help AI coding agents work effectively in this repo by knowing the architecture, conventions, and non-obvious workflows.
+
+## Big picture
+
+- This is a Mixture-of-Models router for LLM requests with: Envoy External Processing (gRPC) for request routing, classification (intent/PII/security), semantic similarity caching, and tool auto-selection.
+- Primary implementation is Go with a Rust ML binding (HuggingFace Candle) via CGO for embeddings/similarity. A small HTTP Classification API is exposed alongside the gRPC extproc server.
+
+## Core components (key files)
+
+- Entry point: `src/semantic-router/cmd/main.go` (starts gRPC extproc, Classification API, and Prometheus metrics)
+- Envoy ExtProc server: `src/semantic-router/pkg/extproc/` (stream handlers, routing logic, request/response transforms)
+- Configuration: `config/config.yaml` (routing categories, model_config, reasoning families, semantic cache backend, vLLM endpoints, tools DB, classifiers)
+- Classification API: `src/semantic-router/pkg/api/server.go` (e.g., POST `/api/v1/classify/intent|pii|security|batch`)
+- Config loader/utilities: `src/semantic-router/pkg/config/` (hot-reload support, endpoint selection, policy helpers)
+- Cache backends: `src/semantic-router/pkg/cache/` (in-memory or Milvus; compile-time tag `milvus`)
+- Tools database: `src/semantic-router/pkg/tools/` (semantic tool selection)
+- Candle Rust binding (CGO): `candle-binding/` (builds native lib used for similarity)
+- Tests: Go unit/integration under `src/semantic-router/pkg/**`, e2e in `e2e-tests/`, research/bench suite in `bench/`
+
+## How things talk to each other
+
+1. Client → Envoy → gRPC ExtProc (`extproc.Server`) → Router selects model/tools/reasoning and edits OpenAI-compatible request → forwards to chosen vLLM endpoint.
+2. Router uses Candle embeddings for similarity cache and tool selection.
+3. Classification uses either legacy ModernBERT models or auto-discovered LoRA unified classifiers (services initialize a global ClassificationService).
+4. Config changes are hot-reloaded (fsnotify) without restarting the gRPC server.
+
+## Build / run workflows (non-obvious bits)
+
+- Makefile orchestrates sub-makefiles under `tools/make/`
+  - Build router (also builds Rust lib): `make build-router`
+  - Run router with config: `CONFIG_FILE=config/config.yaml make run-router`
+  - Run Envoy (installs func-e if missing): `make run-envoy`
+  - Download local models from HF Hub: `make download-models` (uses `hf download` CLI)
+- Dynamic library path on macOS: prefer `DYLD_LIBRARY_PATH` to point to `candle-binding/target/release`; Linux uses `LD_LIBRARY_PATH`. The Makefile sets `LD_LIBRARY_PATH`—on macOS set `DYLD_LIBRARY_PATH` in zsh if needed.
+- Ports: gRPC extproc `:50051` (flag `-port`), Classification API `:8080` (`-api-port`), Prometheus `:9190` (`-metrics-port`).
+- Docker: `docker-compose.yml` spins up router + Envoy (+ optional testing profile).
+
+Example (zsh):
+
+```sh
+# Build native lib + router
+make build-router
+
+# If macOS, ensure Candle dylib is discoverable for CGO
+export DYLD_LIBRARY_PATH="$PWD/candle-binding/target/release:$DYLD_LIBRARY_PATH"
+
+# Run router with the default config and metrics
+CONFIG_FILE=config/config.yaml make run-router
+
+# Run Envoy (separate terminal)
+make run-envoy
+```
+
+## Configuration patterns (edit `config/config.yaml`)
+
+- `categories[]` with per-category `model_scores` and reasoning flags drive model selection; `default_model` is the fallback.
+- `model_config` + `reasoning_families` normalize “reasoning mode” syntax across model families (e.g., deepseek, qwen3, gpt-oss). Use `GetModelReasoningFamily()` helpers, don’t hardcode.
+- `semantic_cache`: `backend_type: memory|milvus`, `similarity_threshold`, `ttl_seconds`. For Milvus, run `make start-milvus` and test with `-tags=milvus`.
+- `tools`: enable semantic tool selection via `tools_db_path` (JSON), `top_k`, and threshold (defaults to BERT threshold if unset).
+- `classifier`: paths to ModernBERT/LoRA models and mapping jsons; batch endpoint requires unified classifier to be available.
+- `vllm_endpoints[]`: list models per endpoint; selection respects per-model `preferred_endpoints` and weights.
+
+## Testing
+
+- Go vet and tidy: `make vet` and `make check-go-mod-tidy`
+- Unit tests (Go): `make test-semantic-router` (set `SKIP_MILVUS_TESTS=false` to include Milvus) or `go test -v ./...` under `src/semantic-router`
+- Milvus-specific: `make test-milvus-cache` or `make test-semantic-router-milvus` (uses `-tags=milvus`)
+- E2E Python tests: see `e2e-tests/README.md` (requires router+envoy running)
+- Quick cURL demos: `make test-auto-prompt-reasoning`, `test-pii`, `test-tools` (hits Envoy at `http://localhost:8801/v1/chat/completions` with `model: "auto"`)
+
+## Conventions & tips for contributors (agents)
+
+- Use config accessors from `pkg/config` (e.g., endpoint selection, PII policies). Avoid duplicating selection logic.
+- Prefer `services.*ClassificationService` APIs for classification; a global service may be set by auto-discovery.
+- Respect streaming in ExtProc handlers and record metrics via `pkg/metrics`.
+- Keep hot-reload safe: re-create `OpenAIRouter` on config changes using `Server.watchConfigAndReload` pattern.
+- When adding cache/tool logic, use existing interfaces: `cache.CacheBackend`, `tools.ToolsDatabase`.
+
+References
+
+- Router main: `src/semantic-router/cmd/main.go`
+- ExtProc: `src/semantic-router/pkg/extproc/`
+- Config: `config/config.yaml`, helpers in `src/semantic-router/pkg/config/`
+- Candle binding: `candle-binding/`
+- Bench: `bench/` (CLI and plots)
+- Docs site: `website/` (Docusaurus)

--- a/Dockerfile.extproc
+++ b/Dockerfile.extproc
@@ -54,5 +54,13 @@ COPY config/config.yaml /app/config/
 ENV LD_LIBRARY_PATH=/app/lib
 
 EXPOSE 50051
+# Install curl for healthchecks and basic diagnostics
+RUN dnf -y update && \
+    dnf -y install curl && \
+    dnf clean all
 
-CMD ["/app/extproc-server", "--config", "/app/config/config.yaml"]
+# Copy entrypoint to allow switching config via env var CONFIG_FILE
+COPY scripts/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/config/config.testing.yaml
+++ b/config/config.testing.yaml
@@ -1,0 +1,84 @@
+bert_model:
+  model_id: sentence-transformers/all-MiniLM-L12-v2
+  threshold: 0.6
+  use_cpu: true
+
+semantic_cache:
+  enabled: true
+  backend_type: "memory"
+  similarity_threshold: 0.8
+  max_entries: 1000
+  ttl_seconds: 3600
+  eviction_policy: "fifo"
+
+tools:
+  enabled: true
+  top_k: 3
+  similarity_threshold: 0.2
+  tools_db_path: "config/tools_db.json"
+  fallback_to_empty: true
+
+prompt_guard:
+  enabled: true
+  use_modernbert: true
+  model_id: "models/jailbreak_classifier_modernbert-base_model"
+  threshold: 0.7
+  use_cpu: true
+  jailbreak_mapping_path: "models/jailbreak_classifier_modernbert-base_model/jailbreak_type_mapping.json"
+
+vllm_endpoints:
+  - name: "mock"
+    address: "mock-vllm"
+    port: 8000
+    models:
+      - "openai/gpt-oss-20b"
+    weight: 1
+    health_check_path: "/health"
+
+model_config:
+  "openai/gpt-oss-20b":
+    reasoning_family: "gpt-oss"
+    preferred_endpoints: ["mock"]
+    pii_policy:
+      allow_by_default: true
+
+categories:
+  - name: other
+    model_scores:
+      - model: openai/gpt-oss-20b
+        score: 0.7
+        use_reasoning: false
+
+default_model: openai/gpt-oss-20b
+
+reasoning_families:
+  deepseek:
+    type: "chat_template_kwargs"
+    parameter: "thinking"
+
+  qwen3:
+    type: "chat_template_kwargs"
+    parameter: "enable_thinking"
+
+  gpt-oss:
+    type: "reasoning_effort"
+    parameter: "reasoning_effort"
+  gpt:
+    type: "reasoning_effort"
+    parameter: "reasoning_effort"
+
+default_reasoning_effort: high
+
+api:
+  batch_classification:
+    max_batch_size: 100
+    concurrency_threshold: 5
+    max_concurrency: 8
+    metrics:
+      enabled: true
+      detailed_goroutine_tracking: true
+      high_resolution_timing: false
+      sample_rate: 1.0
+      duration_buckets:
+        [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30]
+      size_buckets: [1, 2, 5, 10, 20, 50, 100, 200]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./models:/app/models:ro
     environment:
       - LD_LIBRARY_PATH=/app/lib
+      - CONFIG_FILE=${CONFIG_FILE:-/app/config/config.yaml}
     networks:
       - semantic-network
     healthcheck:
@@ -43,6 +44,24 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+
+  # Mock vLLM service for testing profile
+  mock-vllm:
+    build:
+      context: ./tools/mock-vllm
+      dockerfile: Dockerfile
+    container_name: mock-vllm
+    profiles: ["testing"]
+    ports:
+      - "8000:8000"
+    networks:
+      - semantic-network
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
 networks:
   semantic-network:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE_PATH=${CONFIG_FILE:-/app/config/config.yaml}
+
+if [[ ! -f "$CONFIG_FILE_PATH" ]]; then
+  echo "[entrypoint] Config file not found at $CONFIG_FILE_PATH" >&2
+  exit 1
+fi
+
+echo "[entrypoint] Starting semantic-router with config: $CONFIG_FILE_PATH"
+exec /app/extproc-server --config "$CONFIG_FILE_PATH"

--- a/tools/mock-vllm/Dockerfile
+++ b/tools/mock-vllm/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY app.py /app/app.py
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tools/mock-vllm/README.md
+++ b/tools/mock-vllm/README.md
@@ -1,0 +1,9 @@
+# Mock vLLM (OpenAI-compatible) service
+
+A tiny FastAPI server that emulates minimal endpoints used by the router:
+
+- GET /health
+- GET /v1/models
+- POST /v1/chat/completions
+
+Intended for local testing with Docker Compose profile `testing`.

--- a/tools/mock-vllm/app.py
+++ b/tools/mock-vllm/app.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Optional
+
+app = FastAPI()
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    model: str
+    messages: List[ChatMessage]
+    temperature: Optional[float] = 0.2
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/v1/models")
+async def models():
+    return {"data": [{"id": "openai/gpt-oss-20b", "object": "model"}]}
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(req: ChatRequest):
+    # Very simple echo-like behavior
+    last_user = next((m.content for m in reversed(req.messages) if m.role == "user"), "")
+    content = f"[mock-{req.model}] You said: {last_user}"
+    return {
+        "id": "cmpl-mock-123",
+        "object": "chat.completion",
+        "model": req.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+    }

--- a/tools/mock-vllm/requirements.txt
+++ b/tools/mock-vllm/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.9.2


### PR DESCRIPTION
**What type of PR is this?**
feat: Implement testing profile

**What this PR does / why we need it**:
Implement a MVP of testing profile with mock vllm:
- Added a configurable entrypoint for the router to allow overriding config via CONFIG_FILE(In `Docker.extproc` and 'scripts/entrypoint.sh`)
- Implemented a mock vLLM service (FastAPI) with a testing profile in Compose ( In `tools/mock_vllm`)
- Added a testing router config pointing to the mock vLLM(`config/config.testing.yaml`)

Fix: Added curl to the final runtime image (`Docker.extproc`) so docker-compose healthcheck works

**Which issue(s) this PR fixes**:
Fixes #189 

**For reviewer**:
This implementation, which has affected numerous files, may be worth discussing. Looking forward to any suggestions.

