### PR TITLE
feat: Update .gitignore for AI docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,17 @@ website/build
 .docusaurus
 spec/
 results/
+
+.github/copilot*.md
+
+# AI tooling regulation docs
+# Ignore Copilot/Claude/Cursor rule docs anywhere in the repo
+**/[Cc]opilot*.md
+**/[Cc]laude*.md
+**/[Cc]ursor*.md
+.github/[Cc]laude*.md
+.github/[Cc]ursor*.md
+
+# Cursor editor rules files
+.cursorrules
+.cursorrules.*


### PR DESCRIPTION
**What type of PR is this?**
feat: Update .gitignore for AI docs

**What this PR does / why we need it**:
Avoid pushing AI docs(cursor, claude, copilot) to the remote repo mistakenly.