### PR TITLE
docs: add tentative bi-weekly community meetings schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The screenshot below shows the LLM Router dashboard in Grafana.
 
 ![LLM Router Dashboard](./website/static/img/grafana_screenshot.png)
 
-The router is implemented in two ways: 
+The router is implemented in two ways:
 
 - Golang (with Rust FFI based on the [candle](https://github.com/huggingface/candle) rust ML framework)
 - Python
@@ -144,9 +144,11 @@ For questions, feedback, or to contribute, please join `#semantic-router` channe
 We host bi-weekly community meetings to sync up with contributors across different time zones:
 
 - **First Tuesday of the month**: 9:00-10:00 AM EST (accommodates US EST and Asia Pacific contributors)
+  - **Zoom Link**: [https://nyu.zoom.us/j/95065349917](https://nyu.zoom.us/j/95065349917)
+  - **Calendar Invite**: [https://calendar.app.google/EeP6xDgCpxte6d1eA](https://calendar.app.google/EeP6xDgCpxte6d1eA)
 - **Third Tuesday of the month**: 1:00-2:00 PM EST (accommodates US EST and California contributors)
-
-**Zoom Link**: [https://columbiauniversity.zoom.us/j/5260331515](https://columbiauniversity.zoom.us/j/5260331515)
+  - **Zoom Link**: [https://nyu.zoom.us/j/98861585086](https://nyu.zoom.us/j/98861585086)
+  - **Calendar Invite**: [https://calendar.app.google/oYsmt1Pu46o4gFuP8](https://calendar.app.google/oYsmt1Pu46o4gFuP8)
 
 Join us to discuss the latest developments, share ideas, and collaborate on the project!
 


### PR DESCRIPTION
## PR Description

**What type of PR is this?**
docs: add tentative bi-weekly community meetings schedule

**What this PR does / why we need it**:
This PR adds a Community Meetings section to the README.md to establish regular bi-weekly community sync-up sessions. The meetings are scheduled to accommodate contributors across different time zones:

- **First Tuesday of the month**: 9:00-10:00 AM EST (accommodates US EST and Asia Pacific contributors)
- **Third Tuesday of the month**: 1:00-2:00 PM EST (accommodates US EST and California contributors)

This is a **tentative schedule** that we will refine based on community feedback. We will collect feedback on this PR and call for proposals for alternative times to better accommodate contributors' availability and preferences.

This will help foster better community engagement, provide regular touchpoints for contributors to stay in sync, and create opportunities for collaboration and feedback sharing across different geographical regions.

**Which issue(s) this PR fixes**:
<!-- This is a new feature addition, not fixing an existing issue -->

**Release Notes**: No

