### PR TITLE
ci: avoid HF 429 on PRs by caching models and downloading minimal mod…

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -3,100 +3,105 @@ name: Test And Build
 on:
   schedule:
     # Run nightly at 2:00 AM UTC
-    - cron: '0 2 * * *'
-  workflow_dispatch:  # Allow manual triggering
-  pull_request:  # Run on all pull requests
+    - cron: "0 2 * * *"
+  workflow_dispatch: # Allow manual triggering
+  pull_request: # Run on all pull requests
 
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Check out the repo
-      uses: actions/checkout@v4
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: 1.85
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.24'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          make \
-          build-essential \
-          pkg-config
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            make \
+            build-essential \
+            pkg-config
 
-    - name: Cache Rust dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          candle-binding/target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            candle-binding/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
-    - name: Cache Go dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+      - name: Cache Go dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-    - name: Cache Models
-      uses: actions/cache@v4
-      with:
-        path: |
-          models/
-        key: ${{ runner.os }}-models-v1-${{ hashFiles('tools/make/models.mk') }}
-        restore-keys: |
-          ${{ runner.os }}-models-v1-
+      - name: Cache Models
+        uses: actions/cache@v4
+        with:
+          path: |
+            models/
+          key: ${{ runner.os }}-models-v1-${{ hashFiles('tools/make/models.mk') }}
+          restore-keys: |
+            ${{ runner.os }}-models-v1-
 
-    - name: Check go mod tidy
-      run: make check-go-mod-tidy
+      - name: Check go mod tidy
+        run: make check-go-mod-tidy
 
-    - name: Build Rust library
-      run: make rust
+      - name: Build Rust library
+        run: make rust
 
-    - name: Install HuggingFace CLI
-      run: |
-        pip install -U "huggingface_hub[cli]"
+      - name: Install HuggingFace CLI
+        run: |
+          pip install -U "huggingface_hub[cli]"
 
-    - name: Download models
-      run: make download-models
 
-    - name: Run semantic router tests
-      run: make test
-      env:
-        CGO_ENABLED: 1
-        LD_LIBRARY_PATH: ${{ github.workspace }}/candle-binding/target/release
+      - name: Download models (minimal on PRs)
+        env:
+          CI_MINIMAL_MODELS: ${{ github.event_name == 'pull_request' }}
+          HF_HUB_ENABLE_HF_TRANSFER: 1
+          HF_HUB_DISABLE_TELEMETRY: 1
+        run: make download-models
 
-    - name: Upload test artifacts on failure
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-logs
-        path: |
-          **/*.log
-          **/test-output.*
-        retention-days: 7
+      - name: Run semantic router tests
+        run: make test
+        env:
+          CGO_ENABLED: 1
+          LD_LIBRARY_PATH: ${{ github.workspace }}/candle-binding/target/release
 
-    - name: Notify on failure
-      if: failure()
-      run: |
-        echo "::error::Test and build failed. Check the workflow run for details."
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: |
+            **/*.log
+            **/test-output.*
+          retention-days: 7
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Test and build failed. Check the workflow run for details."
 
   # Trigger Docker publishing on successful nightly runs
   publish-docker:

--- a/tools/make/models.mk
+++ b/tools/make/models.mk
@@ -2,8 +2,44 @@
 # =  Everything For models  =
 # ======== models.mk ========
 
+# CI_MINIMAL_MODELS=true will download only the minimal set of models required for tests.
+# Default behavior downloads the full set used for local development.
+
 download-models:
 	@$(LOG_TARGET)
+	@mkdir -p models
+	@if [ "$$CI_MINIMAL_MODELS" = "true" ]; then \
+		echo "CI_MINIMAL_MODELS=true -> downloading minimal model set"; \
+		$(MAKE) -s download-models-minimal; \
+	else \
+		echo "CI_MINIMAL_MODELS not set -> downloading full model set"; \
+		$(MAKE) -s download-models-full; \
+	fi
+
+# Minimal models needed to run unit tests on CI (avoid rate limits)
+# - Category classifier (ModernBERT)
+# - PII token classifier (ModernBERT Presidio)
+# - Jailbreak classifier (ModernBERT)
+# - Optional plain PII classifier mapping (small)
+
+download-models-minimal:
+	@mkdir -p models
+	@if [ ! -d "models/category_classifier_modernbert-base_model" ]; then \
+		hf download LLM-Semantic-Router/category_classifier_modernbert-base_model --local-dir models/category_classifier_modernbert-base_model; \
+	fi
+	@if [ ! -d "models/pii_classifier_modernbert-base_presidio_token_model" ]; then \
+		hf download LLM-Semantic-Router/pii_classifier_modernbert-base_presidio_token_model --local-dir models/pii_classifier_modernbert-base_presidio_token_model; \
+	fi
+	@if [ ! -d "models/jailbreak_classifier_modernbert-base_model" ]; then \
+		hf download LLM-Semantic-Router/jailbreak_classifier_modernbert-base_model --local-dir models/jailbreak_classifier_modernbert-base_model; \
+	fi
+	@if [ ! -d "models/pii_classifier_modernbert-base_model" ]; then \
+		hf download LLM-Semantic-Router/pii_classifier_modernbert-base_model --local-dir models/pii_classifier_modernbert-base_model; \
+	fi
+
+# Full model set for local development and docs
+
+download-models-full:
 	@mkdir -p models
 	@if [ ! -d "models/category_classifier_modernbert-base_model" ]; then \
 		hf download LLM-Semantic-Router/category_classifier_modernbert-base_model --local-dir models/category_classifier_modernbert-base_model; \
@@ -14,43 +50,33 @@ download-models:
 	@if [ ! -d "models/jailbreak_classifier_modernbert-base_model" ]; then \
 		hf download LLM-Semantic-Router/jailbreak_classifier_modernbert-base_model --local-dir models/jailbreak_classifier_modernbert-base_model; \
 	fi
-
-	@if [ ! -d "models/pii_classifier_modernbert_base_presidio_token_model" ]; then \
+	@if [ ! -d "models/pii_classifier_modernbert-base_presidio_token_model" ]; then \
 		hf download LLM-Semantic-Router/pii_classifier_modernbert-base_presidio_token_model --local-dir models/pii_classifier_modernbert-base_presidio_token_model; \
 	fi
-
 	@if [ ! -d "models/lora_intent_classifier_bert-base-uncased_model" ]; then \
 		hf download LLM-Semantic-Router/lora_intent_classifier_bert-base-uncased_model --local-dir models/lora_intent_classifier_bert-base-uncased_model; \
 	fi
-
 	@if [ ! -d "models/lora_intent_classifier_roberta-base_model" ]; then \
 		hf download LLM-Semantic-Router/lora_intent_classifier_roberta-base_model --local-dir models/lora_intent_classifier_roberta-base_model; \
 	fi
-
 	@if [ ! -d "models/lora_intent_classifier_modernbert-base_model" ]; then \
 		hf download LLM-Semantic-Router/lora_intent_classifier_modernbert-base_model --local-dir models/lora_intent_classifier_modernbert-base_model; \
 	fi
-
 	@if [ ! -d "models/lora_pii_detector_bert-base-uncased_model" ]; then \
 		hf download LLM-Semantic-Router/lora_pii_detector_bert-base-uncased_model --local-dir models/lora_pii_detector_bert-base-uncased_model; \
 	fi
-
 	@if [ ! -d "models/lora_pii_detector_roberta-base_model" ]; then \
 		hf download LLM-Semantic-Router/lora_pii_detector_roberta-base_model --local-dir models/lora_pii_detector_roberta-base_model; \
 	fi
-
 	@if [ ! -d "models/lora_pii_detector_modernbert-base_model" ]; then \
 		hf download LLM-Semantic-Router/lora_pii_detector_modernbert-base_model --local-dir models/lora_pii_detector_modernbert-base_model; \
 	fi
-
 	@if [ ! -d "models/lora_jailbreak_classifier_bert-base-uncased_model" ]; then \
 		hf download LLM-Semantic-Router/lora_jailbreak_classifier_bert-base-uncased_model --local-dir models/lora_jailbreak_classifier_bert-base-uncased_model; \
 	fi
-
 	@if [ ! -d "models/lora_jailbreak_classifier_roberta-base_model" ]; then \
 		hf download LLM-Semantic-Router/lora_jailbreak_classifier_roberta-base_model --local-dir models/lora_jailbreak_classifier_roberta-base_model; \
 	fi
-
 	@if [ ! -d "models/lora_jailbreak_classifier_modernbert-base_model" ]; then \
 		hf download LLM-Semantic-Router/lora_jailbreak_classifier_modernbert-base_model --local-dir models/lora_jailbreak_classifier_modernbert-base_model; \
 	fi


### PR DESCRIPTION
…el set

**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
ci: avoid HF 429 on PRs by caching models and downloading minimal model set
<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

When frequently pulling models from HF, it's possible to trigger the 429 rate limit; I've added cache.

**Note** I default to downloading only the minimal model set in the PR's CI, which effectively reduces CI time and download volume. However, if others are concerned this might affect CI effectiveness, it can be modified.

```
Download complete. Moving file to models/lora_jailbreak_classifier_roberta-base_model/model.safetensors

Fetching 9 files:  67%|██████▋   | 6/9 [00:02<00:01,  2.50it/s]
Fetching 9 files: 100%|██████████| 9/9 [00:02<00:00,  3.83it/s]
/home/runner/work/semantic-router/semantic-router/models/lora_jailbreak_classifier_roberta-base_model
Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.12/site-packages/huggingface_hub/utils/_http.py", line 407, in hf_raise_for_status
    response.raise_for_status()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/models/LLM-Semantic-Router/lora_jailbreak_classifier_modernbert-base_model/revision/main

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.12/site-packages/huggingface_hub/_snapshot_download.py", line 165, in snapshot_download
    repo_info = api.repo_info(repo_id=repo_id, repo_type=repo_type, revision=revision)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/lib/python3.12/site-packages/huggingface_hub/hf_api.py", line 2864, in repo_info
    return method(
           ^^^^^^^
  File "/home/runner/.local/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/lib/python3.12/site-packages/huggingface_hub/hf_api.py", line 2649, in model_info
    hf_raise_for_status(r)
  File "/home/runner/.local/lib/python3.12/site-packages/huggingface_hub/utils/_http.py", line 480, in hf_raise_for_status
    raise _format(HfHubHTTPError, str(e), response) from e
huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/models/LLM-Semantic-Router/lora_jailbreak_classifier_modernbert-base_model/revision/main

```


https://github.com/vllm-project/semantic-router/actions/runs/17948602908/job/51041394044?pr=203

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
