### PR TITLE
fix stream mode

### DIFF
--- a/src/semantic-router/pkg/extproc/request_handler.go
+++ b/src/semantic-router/pkg/extproc/request_handler.go
@@ -32,6 +32,43 @@ func serializeOpenAIRequest(req *openai.ChatCompletionNewParams) ([]byte, error)
 	return json.Marshal(req)
 }
 
+// extractStreamParam extracts the stream parameter from the original request body
+func extractStreamParam(originalBody []byte) bool {
+	var requestMap map[string]interface{}
+	if err := json.Unmarshal(originalBody, &requestMap); err != nil {
+		return false
+	}
+
+	if streamValue, exists := requestMap["stream"]; exists {
+		if stream, ok := streamValue.(bool); ok {
+			return stream
+		}
+	}
+	return false
+}
+
+// serializeOpenAIRequestWithStream converts request back to JSON, preserving the stream parameter from original request
+func serializeOpenAIRequestWithStream(req *openai.ChatCompletionNewParams, hasStreamParam bool) ([]byte, error) {
+	// First serialize the SDK object
+	sdkBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// If original request had stream parameter, add it back
+	if hasStreamParam {
+		var sdkMap map[string]interface{}
+		if err := json.Unmarshal(sdkBytes, &sdkMap); err == nil {
+			sdkMap["stream"] = true
+			if modifiedBytes, err := json.Marshal(sdkMap); err == nil {
+				return modifiedBytes, nil
+			}
+		}
+	}
+
+	return sdkBytes, nil
+}
+
 // addSystemPromptToRequestBody adds a system prompt to the beginning of the messages array in the JSON request body
 func addSystemPromptToRequestBody(requestBody []byte, systemPrompt string) ([]byte, error) {
 	if systemPrompt == "" {
@@ -165,7 +202,7 @@ type RequestContext struct {
 	ProcessingStartTime time.Time
 
 	// Streaming detection
-	ExpectStreamingResponse bool // set from request Accept header
+	ExpectStreamingResponse bool // set from request Accept header or stream parameter
 	IsStreamingResponse     bool // set from response Content-Type
 
 	// TTFT tracking
@@ -200,6 +237,7 @@ func (r *OpenAIRouter) handleRequestHeaders(v *ext_proc.ProcessingRequest_Reques
 	if accept, ok := ctx.Headers["accept"]; ok {
 		if strings.Contains(strings.ToLower(accept), "text/event-stream") {
 			ctx.ExpectStreamingResponse = true
+			observability.Infof("Client expects streaming response based on Accept header")
 		}
 	}
 
@@ -229,6 +267,13 @@ func (r *OpenAIRouter) handleRequestBody(v *ext_proc.ProcessingRequest_RequestBo
 	ctx.ProcessingStartTime = time.Now()
 	// Save the original request body
 	ctx.OriginalRequestBody = v.RequestBody.GetBody()
+
+	// Extract stream parameter from original request and update ExpectStreamingResponse if needed
+	hasStreamParam := extractStreamParam(ctx.OriginalRequestBody)
+	if hasStreamParam {
+		observability.Infof("Original request contains stream parameter: true")
+		ctx.ExpectStreamingResponse = true // Set this if stream param is found
+	}
 
 	// Parse the OpenAI request using SDK types
 	openAIRequest, err := parseOpenAIRequest(ctx.OriginalRequestBody)
@@ -472,8 +517,8 @@ func (r *OpenAIRouter) handleModelRouting(openAIRequest *openai.ChatCompletionNe
 				// Modify the model in the request
 				openAIRequest.Model = openai.ChatModel(matchedModel)
 
-				// Serialize the modified request
-				modifiedBody, err := serializeOpenAIRequest(openAIRequest)
+				// Serialize the modified request with stream parameter preserved
+				modifiedBody, err := serializeOpenAIRequestWithStream(openAIRequest, ctx.ExpectStreamingResponse)
 				if err != nil {
 					observability.Errorf("Error serializing modified request: %v", err)
 					metrics.RecordRequestError(actualModel, "serialization_error")
@@ -728,8 +773,8 @@ func (r *OpenAIRouter) handleToolSelection(openAIRequest *openai.ChatCompletionN
 
 // updateRequestWithTools updates the request body with the selected tools
 func (r *OpenAIRouter) updateRequestWithTools(openAIRequest *openai.ChatCompletionNewParams, response **ext_proc.ProcessingResponse, ctx *RequestContext) error {
-	// Re-serialize the request with modified tools
-	modifiedBody, err := serializeOpenAIRequest(openAIRequest)
+	// Re-serialize the request with modified tools and preserved stream parameter
+	modifiedBody, err := serializeOpenAIRequestWithStream(openAIRequest, ctx.ExpectStreamingResponse)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->

fix:
add a workaround to preserve stream filed in user raw request, because openai-go's `openai.ChatCompletionNewParams` doesn't have this field, see issue #209 



<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:

stream mode is not supported well, when user use an auto model, stream filed in of user raw input is dropped, so a non-sse response is returned , this pr reuse the `ExpectStreamingResponse` field introduced by this pr https://github.com/vllm-project/semantic-router/pull/203/files, to identify whether this request expect a stream response
1. detect if the request header `Accept: text/event-stream`
2. extract stream field from raw request body

and finally return a mutated request body to envoy with stream field 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #209 

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: No
