### PR TITLE
fix: enhance llm-katan OpenAI API compatibility for issue #241

### DIFF
--- a/e2e-tests/llm-katan/llm_katan/server.py
+++ b/e2e-tests/llm-katan/llm_katan/server.py
@@ -160,9 +160,7 @@ def create_app(config: ServerConfig) -> FastAPI:
 
         try:
             # Convert messages to dict format
-            messages = [
-                {"role": msg.role, "content": msg.content} for msg in request.messages
-            ]
+            messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
 
             # Update metrics
             metrics["total_requests"] += 1
@@ -181,8 +179,13 @@ def create_app(config: ServerConfig) -> FastAPI:
 
                 return StreamingResponse(
                     generate_stream(),
-                    media_type="text/plain",
-                    headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+                    media_type="text/event-stream",
+                    headers={
+                        "Cache-Control": "no-cache",
+                        "Connection": "keep-alive",
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Allow-Headers": "Content-Type",
+                    },
                 )
             else:
                 # Non-streaming response
@@ -198,9 +201,7 @@ def create_app(config: ServerConfig) -> FastAPI:
                 response_time = time.time() - start_time
                 metrics["response_times"].append(response_time)
                 if "choices" in response and response["choices"]:
-                    generated_text = (
-                        response["choices"][0].get("message", {}).get("content", "")
-                    )
+                    generated_text = response["choices"][0].get("message", {}).get("content", "")
                     token_count = len(generated_text.split())  # Rough token estimate
                     metrics["total_tokens_generated"] += token_count
 

--- a/e2e-tests/llm-katan/pyproject.toml
+++ b/e2e-tests/llm-katan/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-katan"
-version = "0.1.8"
+version = "0.1.9"
 description = "LLM Katan - Lightweight LLM Server for Testing - Real tiny models with FastAPI and HuggingFace"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

Fixes llm-katan OpenAI API compatibility issues causing OpenWebUI to hang when connecting to llm-katan endpoints.

### Changes Made

- **Add missing OpenAI API response fields**: `system_fingerprint`, `logprobs`, detailed `usage` object
- **Fix streaming response Content-Type**: Changed from `text/plain` to `text/event-stream` 
- **Add `token_usage` alias**: For better SDK compatibility
- **Apply fixes to both backends**: TransformersBackend and VLLMBackend
- **Bump version to 0.1.9**: Published to PyPI

### Problem Solved

- ✅ **Resolves OpenWebUI hanging issue** when using llm-katan as backend
- ✅ **Improves OpenAI SDK compatibility** with proper response format
- ✅ **Fixes streaming responses** with correct SSE format and final usage chunk

### Testing

- [x] Tested with curl (non-streaming and streaming)
- [x] Verified all OpenAI compatibility fields present
- [x] Confirmed OpenWebUI now works correctly
- [x] Published v0.1.9 to PyPI

Fixes #241