### PR TITLE
chore(e2e): remove legacy mock/real vLLM test modes and Makefile targets

### DIFF
--- a/e2e-tests/run_all_tests.py
+++ b/e2e-tests/run_all_tests.py
@@ -89,12 +89,6 @@ def main():
     )
     parser.add_argument("--pattern", default="*.py", help="Test file pattern to run")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
-    parser.add_argument(
-        "--mock", action="store_true", help="Running with mock vLLM servers"
-    )
-    parser.add_argument(
-        "--real", action="store_true", help="Running with real vLLM servers"
-    )
     args = parser.parse_args()
 
     # Get the directory where this script is located
@@ -126,18 +120,6 @@ def main():
     if not test_files:
         print(f"No test files found matching pattern '{args.pattern}'")
         return 1
-
-    # Print test mode information
-    if args.mock:
-        print("\n🤖 Running in MOCK mode - using mock vLLM servers")
-        print("   ✅ Fast execution, no GPU required")
-        print("   ⚠️  Mock responses, not real model inference")
-    elif args.real:
-        print("\n🧠 Running in REAL mode - using actual vLLM servers")
-        print("   🚀 Real model inference and responses")
-        print("   ⚠️  Requires GPU and longer execution time")
-    else:
-        print("\n🔍 Running in STANDARD mode - checking whatever is available")
 
     print(f"\nRunning {len(test_files)} test files:")
     for file in test_files:

--- a/tools/make/build-run-test.mk
+++ b/tools/make/build-run-test.mk
@@ -113,50 +113,10 @@ start-llm-katan:
 	@echo "Press Ctrl+C to stop servers"
 	@./e2e-tests/start-llm-katan.sh
 
-# Legacy: Start mock vLLM servers for testing (foreground mode for development)
-start-mock-vllm:
-	@echo "Starting mock vLLM servers in foreground mode..."
-	@echo "Press Ctrl+C to stop servers"
-	@./e2e-tests/start-mock-servers.sh
-
-# Start real vLLM servers for testing
-start-vllm:
-	@echo "Starting real vLLM servers..."
-	@./e2e-tests/start-vllm-servers.sh
-
-# Stop real vLLM servers
-stop-vllm:
-	@echo "Stopping real vLLM servers..."
-	@./e2e-tests/stop-vllm-servers.sh
-
 # Run e2e tests with LLM Katan (lightweight real models)
 test-e2e-vllm:
 	@echo "Running e2e tests with LLM Katan servers..."
 	@echo "⚠️  Note: Make sure LLM Katan servers are running with 'make start-llm-katan'"
 	@python3 e2e-tests/run_all_tests.py
 
-# Legacy: Run e2e tests with mock vLLM (assumes mock servers already running)
-test-e2e-mock:
-	@echo "Running e2e tests with mock vLLM servers..."
-	@echo "⚠️  Note: Make sure mock servers are running with 'make start-mock-vllm'"
-	@python3 e2e-tests/run_all_tests.py --mock
-
-# Run e2e tests with real vLLM (assumes real servers already running)
-test-e2e-real:
-	@echo "Running e2e tests with real vLLM servers..."
-	@echo "⚠️  Note: Make sure real vLLM servers are running with 'make start-vllm'"
-	@python3 e2e-tests/run_all_tests.py --real
-
-
-# Note: Automated tests not supported with foreground-only mock servers
-# Use the manual workflow: make start-llm-katan in one terminal, then run tests in another
-
-# Full automated test with cleanup (for CI/CD)
-test-e2e-real-automated: start-vllm
-	@echo "Running automated e2e tests with real vLLM servers..."
-	@sleep 5
-	@python3 e2e-tests/run_all_tests.py --real || ($(MAKE) stop-vllm && exit 1)
-	@$(MAKE) stop-vllm
-
-# Run all e2e tests (LLM Katan, mock and real)
-test-e2e-all: test-e2e-vllm test-e2e-mock test-e2e-real
+# Note: Use the manual workflow: make start-llm-katan in one terminal, then run tests in another


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
chore: remove legacy mock/real vLLM test modes and Makefile 

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
Drop the `--mock / --real` flags from e2e-tests/run_all_tests.py and remove
legacy start/stop and test targets for mock/real vLLM servers from the
tools/make/build-run-test.mk. Simplifies the e2e workflow to rely on the
LLM Katan flow and the manual start/run pattern.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #420

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes
