### PR TITLE
feat(website): add News page with articles about vLLM Semantic Router

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -95,6 +95,11 @@ const config: Config = {
           position: 'left',
         },
         {
+          to: '/news',
+          label: 'News',
+          position: 'left',
+        },
+        {
           type: 'dropdown',
           label: 'Community',
           position: 'right',

--- a/website/src/pages/news.js
+++ b/website/src/pages/news.js
@@ -1,0 +1,138 @@
+import React from 'react'
+import Layout from '@theme/Layout'
+import styles from './news.module.css'
+
+const newsArticles = [
+  {
+    title: 'vLLM Semantic Router: Improving Efficiency in AI Reasoning',
+    date: 'September 11, 2025',
+    source: 'Red Hat Developer',
+    description: 'This article explores how the vLLM Semantic Router addresses challenges in AI reasoning by implementing dynamic, semantic-aware routing to optimize performance and cost.',
+    url: 'https://developers.redhat.com/articles/2025/09/11/vllm-semantic-router-improving-efficiency-ai-reasoning',
+    category: 'Technical Article',
+  },
+  {
+    title: 'LLM Semantic Router: Intelligent Request Routing for Large Language Models',
+    date: 'May 20, 2025',
+    source: 'Red Hat Developer',
+    description: 'This piece introduces the LLM Semantic Router, focusing on intelligent, cost-aware request routing to ensure efficient processing of queries by large language models.',
+    url: 'https://developers.redhat.com/articles/2025/05/20/llm-semantic-router-intelligent-request-routing',
+    category: 'Technical Article',
+  },
+  {
+    title: 'Smarter LLMs: How the vLLM Semantic Router Delivers Fast, Efficient Inference',
+    date: 'September 2025',
+    source: 'Joshua Berkowitz Blog',
+    description: 'This blog post highlights the vLLM Semantic Router\'s role in enhancing large language model inference by intelligently routing queries to balance speed, accuracy, and cost.',
+    url: 'https://joshuaberkowitz.us/blog/news-1/smarter-llms-how-the-vllm-semantic-router-delivers-fast-efficient-inference-1133',
+    category: 'Blog Post',
+  },
+  {
+    title: 'vLLM Semantic Router',
+    date: 'September 2025',
+    source: 'Jimmy Song\'s Blog',
+    description: 'This article provides an overview of the vLLM Semantic Router, detailing its features and applications in improving large language model inference efficiency.',
+    url: 'https://jimmysong.io/ai/semantic-router/',
+    category: 'Blog Post',
+  },
+]
+
+function NewsCard({ article }) {
+  return (
+    <div className={`card ${styles.newsCard}`}>
+      <div className="card__header">
+        <div className={styles.cardHeader}>
+          <h3 className={styles.articleTitle}>{article.title}</h3>
+          <div className={styles.articleMeta}>
+            <span className={`badge badge--primary ${styles.categoryBadge}`}>
+              {article.category}
+            </span>
+            <span className={styles.source}>{article.source}</span>
+            <span className={styles.date}>{article.date}</span>
+          </div>
+        </div>
+      </div>
+      <div className="card__body">
+        <p className={styles.articleDescription}>{article.description}</p>
+      </div>
+      <div className="card__footer">
+        <a
+          href={article.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`button button--primary button--outline ${styles.readMoreButton}`}
+        >
+          Read More →
+        </a>
+      </div>
+    </div>
+  )
+}
+
+export default function News() {
+  return (
+    <Layout
+      title="News"
+      description="Latest news, articles, and publications about vLLM Semantic Router"
+    >
+      <div className="container margin-vert--lg">
+        <div className="row">
+          <div className="col col--12">
+            <div className={styles.heroSection}>
+              <h1 className={styles.heroTitle}>News & Articles</h1>
+              <p className={styles.heroDescription}>
+                Stay updated with the latest news, research papers, blog posts, and articles
+                about vLLM Semantic Router and its impact on LLM inference efficiency.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="row">
+          <div className="col col--12">
+            <div className={styles.newsGrid}>
+              {newsArticles.map((article, index) => (
+                <div key={index} className={styles.newsItem}>
+                  <NewsCard article={article} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="row">
+          <div className="col col--12">
+            <div className={styles.contributeSection}>
+              <h2>Contribute to News</h2>
+              <p>
+                Know of an article, blog post, or publication about vLLM Semantic Router
+                that should be featured here?
+              </p>
+              <p className={styles.contributeActions}>
+                <a
+                  href="https://github.com/vllm-project/semantic-router/issues/new?template=feature_request.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Submit a suggestion
+                </a>
+                {' '}
+                or
+                {' '}
+                <a
+                  href="https://github.com/vllm-project/semantic-router/issues/new?template=feature_request.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contribute directly
+                </a>
+                {' '}
+                to our repository.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/website/src/pages/news.module.css
+++ b/website/src/pages/news.module.css
@@ -1,0 +1,211 @@
+.heroSection {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.heroTitle {
+  font-size: 3rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.heroDescription {
+  font-size: 1.2rem;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.newsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+
+.newsItem {
+  height: 100%;
+}
+
+.newsCard {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.newsCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+}
+
+.cardHeader {
+  padding: 0;
+}
+
+.articleTitle {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  line-height: 1.4;
+  color: var(--ifm-heading-color);
+}
+
+.articleMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0;
+}
+
+.categoryBadge {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.source {
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-600);
+  font-weight: 500;
+}
+
+.date {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-500);
+}
+
+.articleDescription {
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.6;
+  margin-bottom: 0;
+}
+
+/* Custom button styling for Read More buttons */
+.newsCard .button--outline {
+  color: white !important;
+  background-color: var(--ifm-color-primary) !important;
+  border-color: var(--ifm-color-primary) !important;
+  transition: all 0.2s ease-in-out;
+  opacity: 1 !important;
+}
+
+.newsCard .button--outline:hover {
+  color: white !important;
+  background-color: var(--ifm-color-primary) !important;
+  border-color: var(--ifm-color-primary) !important;
+  transform: translateY(-1px);
+  opacity: 1 !important;
+  font-weight: bold !important;
+}
+
+/* More specific targeting for outline buttons */
+.newsCard .card__footer .button--outline {
+  color: white !important;
+  background-color: var(--ifm-color-primary) !important;
+  border-color: var(--ifm-color-primary) !important;
+}
+
+.newsCard .card__footer .button--outline:hover {
+  color: white !important;
+  background-color: var(--ifm-color-primary) !important;
+  border-color: var(--ifm-color-primary) !important;
+  font-weight: bold !important;
+}
+
+/* Custom read more button class */
+.readMoreButton {
+  color: white !important;
+  background-color: var(--ifm-color-primary) !important;
+  border-color: var(--ifm-color-primary) !important;
+  transition: all 0.2s ease-in-out;
+}
+
+.readMoreButton:hover {
+  color: white !important;
+  background-color: var(--ifm-color-primary) !important;
+  border-color: var(--ifm-color-primary) !important;
+  transform: translateY(-1px);
+  font-weight: bold !important;
+}
+
+.contributeSection {
+  text-align: center;
+  padding: 2rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+  margin-top: 2rem;
+}
+
+.contributeSection h2 {
+  margin-bottom: 1rem;
+  color: var(--ifm-heading-color);
+}
+
+.contributeSection p {
+  margin-bottom: 0;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.contributeSection a {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.contributeSection a:hover {
+  text-decoration: underline;
+}
+
+.contributeActions {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.contributeActions a {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.contributeActions a:hover {
+  text-decoration: underline;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .heroTitle {
+    font-size: 2.5rem;
+  }
+  
+  .heroDescription {
+    font-size: 1.1rem;
+  }
+  
+  .newsGrid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .articleMeta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .heroTitle {
+    font-size: 2rem;
+  }
+  
+  .newsGrid {
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
**What type of PR is this?**
feat(website): add News page with articles about vLLM Semantic Router

**What this PR does / why we need it**:
This PR adds a new "News" page to the semantic-router website that showcases recent third party articles, blog posts, and news about vLLM Semantic Router. The page provides:

- **News Navigation**: Added "News" tab to the main website navigation in `docusaurus.config.ts`
- **Article Showcase**: Created a dedicated news page (`news.js`) featuring 4 curated articles from:
  - Red Hat Developer articles about vLLM Semantic Router efficiency
  - Community blog posts from Joshua Berkowitz and Jimmy Song
  - Technical articles covering AI reasoning and LLM inference optimization
- **Responsive Design**: Implemented `news.module.css` with:
  - Card-based layout for article previews
  - Responsive grid system for different screen sizes
  - Styled category badges, source attribution, and publication dates
  - Interactive "Read More" buttons with hover effects
- **Community Engagement**: Added a contribution section encouraging users to submit new articles or contribute directly to the repository

This enhancement improves the website's content discoverability and provides visitors with easy access to the latest news and insights about the project.

**Which issue(s) this PR fixes**:
<!-- Add issue number if this addresses a specific issue -->
Fixes #

**Release Notes**: Yes
- Added News page to website showcasing articles and publications about vLLM Semantic Router
- Enhanced website navigation with a dedicated News section
- Improved community engagement through article contribution features

