### PR TITLE
fix:add binary attributes for image files to prevent line ending conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 * text eol=lf
+
+# Binary files - treat as binary, no line ending conversion
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary


### PR DESCRIPTION

**What type of PR is this?**
## 🐛 Problem

When checking out image files from upstream in WSL/Linux environments, these files incorrectly show as "modified":
- `website/static/img/chat.png`
- `website/static/img/dashboard/config.png`
- `website/static/img/dashboard/grafana.png`
- `website/static/img/dashboard/landing.png`
- `website/static/img/dashboard/openwebui.png`
- `website/static/img/dashboard/topology.png`

**Root Cause:**

The `.gitattributes` file has `* text=auto` and `* text eol=lf` configured, but doesn't explicitly specify how to handle binary files like images. This causes Git to incorrectly treat PNG images as text files and attempt CRLF → LF line ending conversion, which corrupts the binary file content.

## ✅ Solution

Add binary attribute declarations for common image formats in `.gitattributes`:

```gitattributes
# Binary files - treat as binary, no line ending conversion
*.png binary
*.jpg binary
*.jpeg binary
*.gif binary
*.ico binary
*.svg binary
```

## 📝 Changes

- Update `.gitattributes` to add `binary` attribute for image file types

## 🎯 Impact

- ✅ Fixes the issue where image files are incorrectly modified during checkout
- ✅ Prevents future binary image files from experiencing the same problem
- ✅ No impact on existing code logic, only changes how Git handles these file types