### PR TITLE
feat: add docker-compose make help and more

### DIFF
--- a/tools/make/docker.mk
+++ b/tools/make/docker.mk
@@ -49,7 +49,7 @@ docker-test-llm-katan: ## Test llm-katan Docker image locally
 	@echo "\n✅ llm-katan Docker image test passed"
 
 # Run llm-katan Docker image locally
-docker-run-llm-katan: docker-build-llm-katan
+docker-run-llm-katan: docker-build-llm-katan ## Run llm-katan Docker image locally (port 8000)
 	@$(LOG_TARGET)
 	@echo "Running llm-katan Docker image on port 8000..."
 	@echo "Access the server at: http://localhost:8000"
@@ -57,7 +57,7 @@ docker-run-llm-katan: docker-build-llm-katan
 	@$(CONTAINER_RUNTIME) run --rm -p 8000:8000 $(DOCKER_REGISTRY)/llm-katan:$(DOCKER_TAG)
 
 # Run llm-katan with custom served model name
-docker-run-llm-katan-custom:
+docker-run-llm-katan-custom: ## Run llm-katan with a custom served model name (set SERVED_NAME)
 	@$(LOG_TARGET)
 	@echo "Running llm-katan with custom served model name..."
 	@echo "Usage: make docker-run-llm-katan-custom SERVED_NAME=your-served-model-name"
@@ -70,23 +70,23 @@ docker-run-llm-katan-custom:
 		llm-katan --model "Qwen/Qwen3-0.6B" --served-model-name "$(SERVED_NAME)" --host 0.0.0.0 --port 8000
 
 # Clean up Docker images
-docker-clean:
+docker-clean: ## Remove dangling Docker images (prune)
 	@$(LOG_TARGET)
 	@echo "Cleaning up Docker images..."
 	@$(CONTAINER_RUNTIME) image prune -f
 	@echo "Docker cleanup completed"
 
 # Push Docker images (for CI/CD)
-docker-push-all: docker-push-extproc docker-push-llm-katan
+docker-push-all: docker-push-extproc docker-push-llm-katan ## Push all Docker images (for CI/CD)
 	@$(LOG_TARGET)
 	@echo "All Docker images pushed successfully"
 
-docker-push-extproc:
+docker-push-extproc: ## Push extproc Docker image
 	@$(LOG_TARGET)
 	@echo "Pushing extproc Docker image..."
 	@$(CONTAINER_RUNTIME) push $(DOCKER_REGISTRY)/extproc:$(DOCKER_TAG)
 
-docker-push-llm-katan:
+docker-push-llm-katan: ## Push llm-katan Docker image
 	@$(LOG_TARGET)
 	@echo "Pushing llm-katan Docker image..."
 	@$(CONTAINER_RUNTIME) push $(DOCKER_REGISTRY)/llm-katan:$(DOCKER_TAG)
@@ -97,59 +97,59 @@ REBUILD ?=
 BUILD_FLAG=$(if $(REBUILD),--build,)
 
 # Docker compose shortcuts (no rebuild by default)
-docker-compose-up:
+docker-compose-up: ## Start services (default includes llm-katan; REBUILD=1 to rebuild)
 	@$(LOG_TARGET)
 	@echo "Starting services with docker-compose (default includes llm-katan) (REBUILD=$(REBUILD))..."
 	@docker compose --profile llm-katan up -d $(BUILD_FLAG)
 
-docker-compose-up-testing:
+docker-compose-up-testing: ## Start services with testing profile (REBUILD=1 optional)
 	@$(LOG_TARGET)
 	@echo "Starting services with testing profile (REBUILD=$(REBUILD))..."
 	@docker compose --profile testing up -d $(BUILD_FLAG)
 
-docker-compose-up-llm-katan:
+docker-compose-up-llm-katan: ## Start services with llm-katan profile (REBUILD=1 optional)
 	@$(LOG_TARGET)
 	@echo "Starting services with llm-katan profile (REBUILD=$(REBUILD))..."
 	@docker compose --profile llm-katan up -d $(BUILD_FLAG)
 
 # Start core services only (closer to production; excludes llm-katan)
-docker-compose-up-core:
+docker-compose-up-core: ## Start core services only (no llm-katan)
 	@$(LOG_TARGET)
 	@echo "Starting core services (no llm-katan) (REBUILD=$(REBUILD))..."
 	@docker compose up -d $(BUILD_FLAG)
 
 # Explicit rebuild targets for convenience
-docker-compose-rebuild: REBUILD=1
+docker-compose-rebuild: REBUILD=1 ## Force rebuild then start (default includes llm-katan)
 docker-compose-rebuild: docker-compose-up
 
-docker-compose-rebuild-testing: REBUILD=1
+docker-compose-rebuild-testing: REBUILD=1 ## Force rebuild then start (testing profile)
 docker-compose-rebuild-testing: docker-compose-up-testing
 
-docker-compose-rebuild-llm-katan: REBUILD=1
+docker-compose-rebuild-llm-katan: REBUILD=1 ## Force rebuild then start (llm-katan profile)
 docker-compose-rebuild-llm-katan: docker-compose-up-llm-katan
 
-docker-compose-down:
+docker-compose-down: ## Stop services (default includes llm-katan)
 	@$(LOG_TARGET)
 	@echo "Stopping docker-compose services (default includes llm-katan)..."
 	@docker compose --profile llm-katan down
 
-docker-compose-down-core:
+docker-compose-down-core: ## Stop core services only (no llm-katan)
 	@$(LOG_TARGET)
 	@echo "Stopping core services only (no llm-katan)..."
 	@docker compose down
 
-docker-compose-down-testing:
+docker-compose-down-testing: ## Stop services with testing profile
 	@$(LOG_TARGET)
 	@echo "Stopping services with testing profile..."
 	@docker compose --profile testing down
 
-docker-compose-down-llm-katan:
+docker-compose-down-llm-katan: ## Stop services with llm-katan profile
 	@$(LOG_TARGET)
 	@echo "Stopping services with llm-katan profile..."
 	@docker compose --profile llm-katan down
 
 # Help target for Docker commands
-docker-help:
+docker-help: ## Show Docker-specific help for targets and environment variables
 	@echo "Docker Make Targets:"
 	@echo "  docker-build-all          - Build all Docker images"
 	@echo "  docker-build-extproc      - Build extproc Docker image"

--- a/tools/make/milvus.mk
+++ b/tools/make/milvus.mk
@@ -80,7 +80,7 @@ start-milvus-ui: ## Start Attu UI to browse Milvus data
 	@sleep 3
 	@echo "Open UI: http://localhost:18000 (Milvus at host.docker.internal:19530)"
 
-stop-milvus-ui:
+stop-milvus-ui: ## Stop and remove Attu UI container
 	@$(LOG_TARGET)
 	@echo "Stopping Attu (Milvus UI) container..."
 	@$(CONTAINER_RUNTIME) stop milvus-ui || true

--- a/tools/make/observability.mk
+++ b/tools/make/observability.mk
@@ -34,7 +34,7 @@ stop-observability: ## Stop and remove observability containers
 
 ## open-observability: Open Prometheus and Grafana in browser
 open-observability:
-open-observability: Open Prometheus and Grafana in browser
+open-observability: ## Open Prometheus and Grafana in browser
 	@echo "Opening Prometheus and Grafana..."
 	@open http://localhost:9090 2>/dev/null || xdg-open http://localhost:9090 2>/dev/null || echo "Please open http://localhost:9090"
 	@open http://localhost:3000 2>/dev/null || xdg-open http://localhost:3000 2>/dev/null || echo "Please open http://localhost:3000"

--- a/tools/make/pre-commit.mk
+++ b/tools/make/pre-commit.mk
@@ -32,6 +32,7 @@ precommit-check: ## Run pre-commit checks on all relevant files
 #     --name precommit-container ${PRECOMMIT_CONTAINER} \
 #     bash
 # and then, run `pre-commit install && pre-commit run --all-files` command
+
 precommit-local: ## Run pre-commit hooks in a Docker/Podman container
 	@if command -v docker > /dev/null 2>&1; then \
 		CONTAINER_CMD=docker; \


### PR DESCRIPTION
**What this PR does / why we need it**:
```bash
make[1]: Entering directory '/home/jared/vllm-project/semantic-router'
Vllm semantic-router: Intelligent Mixture-of-Models Router for Efficient LLM Inference.

Usage:
  make <Target> <Option>

Targets:

Common
  help             Show help info.

Envoy
  prepare-envoy    Install func-e for managing Envoy versions
  run-envoy        Run Envoy proxy with the configured settings

Golang
  go-lint          Run golangci-lint for src/semantic-router
  go-lint-fix      Auto-fix lint issues in src/semantic-router (may need manual fix)
  vet              Run go vet for all Go modules
  check-go-mod-tidy  Check go mod tidy for all Go modules
  install-controller-gen  Install controller-gen for code generation
  generate-crd     Generate CRD manifests using controller-gen
  generate-deepcopy  Generate deepcopy methods using controller-gen
  generate-api     Generate all API artifacts (deepcopy, CRDs)

Rust
  test-binding     Run Go tests with the Rust static library
  test-category-classifier  Test domain classifier with candle-binding
  test-pii-classifier  Test PII classifier with candle-binding
  test-jailbreak-classifier  Test jailbreak classifier with candle-binding
  rust             Ensure Rust is installed and build the Rust library

Build/Test
  build            Build the Rust library and Golang binding
  build-router     Build the router binary
  run-router       Run the router with the specified config
  run-router-e2e   Run the router with e2e config for testing
  test-semantic-router  Run unit tests for semantic-router (set SKIP_MILVUS_TESTS=false to enable Milvus tests)
  test             Run all tests (Go, Rust, binding)
  clean            Clean built artifacts
  test-auto-prompt-reasoning  Test Envoy extproc with a math prompt (curl)
  test-auto-prompt-no-reasoning  Test tools auto-selection no-reasoning
  test-pii         Test prompts that contain PII
  test-prompt-guard  Test prompt guard classifier
  test-tools       Test tools auto-selection
  test-vllm        Test vLLM endpoint with curl
  start-llm-katan  Start LLM Katan servers in foreground mode for e2e testing
  test-e2e-vllm    Run e2e tests with LLM Katan servers (make sure servers are running)

Docs
  docs-install     Install documentation website dependencies
  docs-dev         Start documentation website in dev mode
  docs-build       Build static documentation website
  docs-serve       Serve built documentation website
  docs-clean       Clean documentation build artifacts

Linter
  docs-lint        Lint documentation in website/
  docs-lint-fix    Auto-fix documentation lint issues in website/
  markdown-lint    Lint all markdown files in the project
  markdown-lint-fix  Auto-fix markdown lint issues
  yaml-lint        Lint all YAML files in the project
  codespell        Check for common misspellings in code and docs

Milvus
  start-milvus     Start Milvus container for testing
  stop-milvus      Stop and remove Milvus container
  restart-milvus   Restart Milvus container
  milvus-status    Show status of Milvus container
  clean-milvus     Clean up Milvus data
  start-milvus-ui  Start Attu UI to browse Milvus data
  stop-milvus-ui   Stop and remove Attu UI container

Models
  download-models  Download models (full or minimal set depending on CI_MINIMAL_MODELS)
  download-models-minimal  Pre-download minimal set of models for CI tests
  download-models-full  Download all models used in local development and docs

Pre-commit
  precommit-install  Install pre-commit Python package
  precommit-check  Run pre-commit checks on all relevant files
  precommit-local  Run pre-commit hooks in a Docker/Podman container

Docker
  docker-build-all  Build all Docker images
  docker-build-extproc  Build extproc Docker image
  docker-build-llm-katan  Build llm-katan Docker image
  docker-build-dashboard  Build dashboard Docker image
  docker-build-precommit  Build precommit Docker image
  docker-test-llm-katan  Test llm-katan Docker image locally
  docker-run-llm-katan  Run llm-katan Docker image locally (port 8000)
  docker-run-llm-katan-custom  Run llm-katan with a custom served model name (set SERVED_NAME)
  docker-clean     Remove dangling Docker images (prune)
  docker-push-all  Push all Docker images (for CI/CD)
  docker-push-extproc  Push extproc Docker image
  docker-push-llm-katan  Push llm-katan Docker image
  docker-compose-up  Start services (default includes llm-katan; REBUILD=1 to rebuild)
  docker-compose-up-testing  Start services with testing profile (REBUILD=1 optional)
  docker-compose-up-llm-katan  Start services with llm-katan profile (REBUILD=1 optional)
  docker-compose-up-core  Start core services only (no llm-katan)
  docker-compose-rebuild  Force rebuild then start (default includes llm-katan)
  docker-compose-rebuild-testing  Force rebuild then start (testing profile)
  docker-compose-rebuild-llm-katan  Force rebuild then start (llm-katan profile)
  docker-compose-down  Stop services (default includes llm-katan)
  docker-compose-down-core  Stop core services only (no llm-katan)
  docker-compose-down-testing  Stop services with testing profile
  docker-compose-down-llm-katan  Stop services with llm-katan profile
  docker-help      Show Docker-specific help for targets and environment variables

Kubernetes
  create-cluster   Create a kind cluster with optimized configuration
  delete-cluster   Delete the kind cluster
  cluster-info     Show cluster information and resource usage
  deploy           Deploy semantic-router to the cluster
  undeploy         Remove semantic-router from the cluster
  load-image       Load Docker image into kind cluster
  test-deployment  Test the deployment
  test-api         Test the Classification API
  port-forward-api  Port forward Classification API (8080)
  port-forward-grpc  Port forward gRPC API (50051)
  port-forward-metrics  Port forward Prometheus metrics (9190)
  logs             Show semantic-router logs
  status           Show deployment status
  setup            Complete setup: create cluster and deploy
  cleanup          Complete cleanup: undeploy and delete cluster

Observability
  o11y-local       Start observability in LOCAL mode (router on host, o11y in Docker)
  o11y-compose     Start observability in COMPOSE mode (all services in Docker)
  stop-observability  Stop and remove observability containers
  open-observability  Open Prometheus and Grafana in browser
  o11y-logs        Show logs from observability containers
  o11y-status      Check status of observability containers
  o11y-clean       Remove observability data volumes

OpenShift
  openshift-login  Login to OpenShift cluster
  openshift-logout  Logout from OpenShift cluster
  openshift-deploy  Deploy semantic-router to OpenShift using Kustomize
  openshift-deploy-auto  Deploy using automated script
  openshift-deploy-template  Deploy using OpenShift template
  openshift-undeploy  Remove deployment (keep namespace)
  openshift-cleanup  Remove deployment and namespace
  openshift-status  Show deployment status
  openshift-logs   Show application logs (follow)
  openshift-logs-previous  Show previous pod logs
  openshift-routes  Show route URLs
  openshift-test   Test deployment connectivity
  openshift-port-forward-api  Port forward Classification API
  openshift-port-forward-grpc  Port forward gRPC API
  openshift-port-forward-metrics  Port forward metrics
  openshift-debug  Show debugging information
make[1]: Leaving directory '/home/jared/vllm-project/semantic-router'
```

Following up PR #455 
