### PR TITLE
fix: label count params should be c_int in the pub extern "C" fn init_unified_classifier_c

### DIFF
--- a/candle-binding/src/lib.rs
+++ b/candle-binding/src/lib.rs
@@ -1,7 +1,7 @@
 // This file is a binding for the candle-core and candle-transformers libraries.
 // It is based on https://github.com/huggingface/candle/tree/main/candle-examples/examples/bert
 use std::collections::HashMap;
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{c_char, c_int, CStr, CString};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -1887,11 +1887,11 @@ pub extern "C" fn init_unified_classifier_c(
     pii_head_path: *const c_char,
     security_head_path: *const c_char,
     intent_labels: *const *const c_char,
-    intent_labels_count: usize,
+    intent_labels_count: c_int,
     pii_labels: *const *const c_char,
-    pii_labels_count: usize,
+    pii_labels_count: c_int,
     security_labels: *const *const c_char,
-    security_labels_count: usize,
+    security_labels_count: c_int,
     use_cpu: bool,
 ) -> bool {
     let modernbert_path = unsafe {
@@ -1924,21 +1924,21 @@ pub extern "C" fn init_unified_classifier_c(
 
     // Convert C string arrays to Rust Vec<String>
     let intent_labels_vec = unsafe {
-        std::slice::from_raw_parts(intent_labels, intent_labels_count)
+        std::slice::from_raw_parts(intent_labels, intent_labels_count as usize)
             .iter()
             .map(|&ptr| CStr::from_ptr(ptr).to_str().unwrap_or("").to_string())
             .collect::<Vec<String>>()
     };
 
     let pii_labels_vec = unsafe {
-        std::slice::from_raw_parts(pii_labels, pii_labels_count)
+        std::slice::from_raw_parts(pii_labels, pii_labels_count as usize)
             .iter()
             .map(|&ptr| CStr::from_ptr(ptr).to_str().unwrap_or("").to_string())
             .collect::<Vec<String>>()
     };
 
     let security_labels_vec = unsafe {
-        std::slice::from_raw_parts(security_labels, security_labels_count)
+        std::slice::from_raw_parts(security_labels, security_labels_count as usize)
             .iter()
             .map(|&ptr| CStr::from_ptr(ptr).to_str().unwrap_or("").to_string())
             .collect::<Vec<String>>()


### PR DESCRIPTION
**What type of PR is this?**

fix: label count params should be c_int in the pub extern "C" fn init_unified_classifier_c

**What this PR does / why we need it**:

```
unified_classifier.go:
// C function declarations - Legacy low confidence functions
bool init_unified_classifier_c(const char* modernbert_path, const char* intent_head_path,
                               const char* pii_head_path, const char* security_head_path,
                               const char** intent_labels, int intent_labels_count,
                               const char** pii_labels, int pii_labels_count,
                               const char** security_labels, int security_labels_count,
                               bool use_cpu);

lib.rs:
/// Initialize unified classifier (called from Go)
#[no_mangle]
pub extern "C" fn init_unified_classifier_c(
    modernbert_path: *const c_char,
    intent_head_path: *const c_char,
    pii_head_path: *const c_char,
    security_head_path: *const c_char,
    intent_labels: *const *const c_char,
    intent_labels_count: usize,
    pii_labels: *const *const c_char,
    pii_labels_count: usize,
    security_labels: *const *const c_char,
    security_labels_count: usize,
    use_cpu: bool,
) -> bool {
```

**DEBUG log:**

```
DEBUG: security_labels ptr = 0x140000455d0, count = 4294967298
```

**root cause:**

`4294967298 = 0x100000002 = 2^32 + 2`
The Rust function signature uses usize (64 bits), but Go passes C.int (32 bits).

**test with this patch:**

```
(base) ➜  semantic-router git:(fix-unit-test) make build
==================> Running rust ============> ...
Building Rust library...
   Compiling candle-semantic-router v0.4.0 (/Users/kiki/workspace/semantic-router/candle-binding)
    Finished `release` profile [optimized] target(s) in 3.99s
==================> Running build-router ============> ...
# command-line-arguments
ld: warning: ignoring duplicate libraries: '-lcandle_semantic_router'
(base) ➜  semantic-router git:(fix-unit-test) src/semantic-router/pkg/utils/classification
(base) ➜  classification git:(fix-unit-test) go test -timeout 300s -count=1 --run ^TestUnifiedClassifier_Initialize$/^Initialization_attempt$ github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/classification
# github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/classification.test
ld: warning: ignoring duplicate libraries: '-lcandle_semantic_router'
ok  	github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/classification	0.836s
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #481

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
