### PR TITLE
fix missing shellcheck in pre-commit image

### DIFF
--- a/Dockerfile.precommit
+++ b/Dockerfile.precommit
@@ -30,5 +30,8 @@ RUN pip install --break-system-packages yamllint
 # CodeSpell
 RUN pip install --break-system-packages codespell
 
+# Shellcheck
+RUN pip install --break-system-packages shellcheck-py
+
 # Golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.5.0


### PR DESCRIPTION
**What this PR does / why we need it**:

```
(base) ➜  semantic-router git:(fix-missing-shellcheck) make precommit-local
make[1]: shellcheck: No such file or directory
make[1]: *** [tools/make/linter.mk:43: shellcheck] Error 127
make[1]: Leaving directory '/app'
make: *** [Makefile:5: _run] Error 2

go lint..................................................................Passed
md fmt...................................................................Passed
yaml/yml fmt.............................................................Passed
js/ts lint...............................................................Passed
cargo fmt................................................................Passed
cargo check..............................................................Passed
black....................................................................Passed
make[1]: *** [precommit-local] Error 1
make: *** [_run] Error 2
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
