### PR TITLE
make CUDA and Flash Attention 2 optional features

### DIFF
--- a/candle-binding/Cargo.toml
+++ b/candle-binding/Cargo.toml
@@ -11,16 +11,18 @@ crate-type = ["staticlib", "cdylib"]
 
 [features]
 default = []
+# CUDA support (enables GPU acceleration)
+cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 # Flash Attention 2 support (requires CUDA and compatible GPU)
 # Enable with: cargo build --features flash-attn
 # Note: Requires CUDA Compute Capability >= 8.0 (Ampere or newer)
-flash-attn = ["candle-flash-attn"]
+flash-attn = ["cuda", "candle-flash-attn"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-candle-core = { version = "0.8.4", features = ["cuda"] }
-candle-nn = { version = "0.8.4", features = ["cuda"] }
-candle-transformers = { version = "0.8.4", features = ["cuda"] }
+candle-core = "0.8.4"
+candle-nn = "0.8.4"
+candle-transformers = "0.8.4"
 # Flash Attention 2 (optional, requires CUDA)
 # Reference: https://github.com/huggingface/candle/tree/main/candle-flash-attn
 candle-flash-attn = { version = "0.8.4", optional = true }


### PR DESCRIPTION
Part of https://github.com/vllm-project/semantic-router/pull/266

**What type of PR is this?**
## Motivation

Currently, CUDA is always enabled in the build:
```toml
candle-core = { version = "0.8.4", features = ["cuda"] }
```

This PR makes CUDA optional while adding Flash Attention 2 as an advanced optimization feature.

## Changes

### 1. Cargo.toml - Optional Feature Flags
```toml
[features]
default = []
# New: CUDA support (opt-in GPU acceleration)
cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
# New: Flash Attention 2 support (requires CUDA + CC >= 8.0)
flash-attn = ["cuda", "candle-flash-attn"]

[dependencies]
# Before: candle-core = { version = "0.8.4", features = ["cuda"] }
# After: Optional CUDA
candle-core = "0.8.4"
candle-nn = "0.8.4"
candle-transformers = "0.8.4"
candle-flash-attn = { version = "0.8.4", optional = true }
```

**Feature dependency chain**: `flash-attn` → `cuda` → `candle-*/cuda`

### 2. rust.mk - Extended Build & Test Targets

Added new targets for Flash Attention 2:

```makefile
# Build with Flash Attention 2 (requires nvcc)
rust-flash-attn:
	@cd candle-binding && cargo build --release --features flash-attn

# Test with Flash Attention 2
test-rust-flash-attn:
	@cd candle-binding && CUDA_VISIBLE_DEVICES=$(TEST_GPU_DEVICE) \
		cargo test --release --features flash-attn --lib -- --test-threads=1 --nocapture

# Test specific Flash Attention module
test-rust-flash-attn-module:
	@cd candle-binding && CUDA_VISIBLE_DEVICES=$(TEST_GPU_DEVICE) \
		cargo test --release --features flash-attn $(MODULE) --lib -- --nocapture
```

**Existing targets remain unchanged** - default `make build` and `make test` continue to work CPU-only .
