### PR TITLE
fix: /app/extproc-server: /lib64/libc.so.6: version GLIBC_2.39 not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10
 
 RUN dnf -y update && \
     dnf -y install epel-release && \
@@ -32,7 +32,7 @@ RUN ARCH=$(uname -m) && \
     curl -OL https://github.com/envoyproxy/envoy/releases/download/v${ENVOY_VERSION}/envoy-${ENVOY_VERSION}-linux-${ENVOY_ARCH} && \
     chmod +x envoy-${ENVOY_VERSION}-linux-${ENVOY_ARCH} && \
     mv envoy-${ENVOY_VERSION}-linux-${ENVOY_ARCH} /usr/local/bin/envoy
-    
+
 # Install Golang
 ENV GOLANG_VERSION=1.24.1
 RUN ARCH=$(uname -m) && \

--- a/Dockerfile.extproc
+++ b/Dockerfile.extproc
@@ -82,7 +82,7 @@ RUN mkdir -p bin && cd src/semantic-router && \
     go build -ldflags="-w -s" -o ../../bin/router cmd/main.go
 
 # Final stage: copy the binary and the shared library
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10
 
 WORKDIR /app
 

--- a/Dockerfile.extproc.cross
+++ b/Dockerfile.extproc.cross
@@ -212,7 +212,7 @@ RUN mkdir -p bin && cd src/semantic-router && \
     fi
 
 # Final stage: copy the binary and the shared library
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10
 
 # Install OpenSSL runtime libraries
 RUN dnf update -y && \

--- a/website/docs/troubleshooting/network-tips.md
+++ b/website/docs/troubleshooting/network-tips.md
@@ -75,7 +75,7 @@ When building `Dockerfile.extproc`, the Go stage may hang on `proxy.golang.org`.
 ```Dockerfile
 # syntax=docker/dockerfile:1
 
-FROM rust:1.85 AS rust-builder
+FROM rust:1.90 AS rust-builder
 RUN apt-get update && apt-get install -y make build-essential pkg-config && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY tools/make/ tools/make/
@@ -106,7 +106,7 @@ ENV CGO_ENABLED=1
 ENV LD_LIBRARY_PATH=/app/candle-binding/target/release
 RUN mkdir -p bin && cd src/semantic-router && go build -o ../../bin/router cmd/main.go
 
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10
 WORKDIR /app
 COPY --from=go-builder /app/bin/router /app/extproc-server
 COPY --from=go-builder /app/candle-binding/target/release/libcandle_semantic_router.so /app/lib/


### PR DESCRIPTION
**What this PR does / why we need it**:

```
$ kc get pods -n vllm-semantic-router-system
NAME                              READY   STATUS             RESTARTS      AGE
semantic-router-db8694578-clpct   0/1     CrashLoopBackOff   4 (48s ago)   3m4s
ubuntu@sanjeev3-ubuntu:~/repos/github.com/srampal/semantic-router$ kc logs semantic-router-db8694578-clpct -n vllm-semantic-router-system
Defaulted container "semantic-router" out of: semantic-router, model-downloader (init)
[entrypoint] Starting semantic-router with config: /app/config/config.yaml
[entrypoint] Additional args: --secure=false
/app/extproc-server: /lib64/libc.so.6: version `GLIBC_2.39' not found (required by /app/lib/libcandle_semantic_router.so)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
related-to https://github.com/vllm-project/semantic-router/pull/499

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
