### PR TITLE
docs: fix the display of the mobile menu.

### DIFF
--- a/website/src/components/ScrollToTop/styles.module.css
+++ b/website/src/components/ScrollToTop/styles.module.css
@@ -45,10 +45,19 @@
   box-shadow: 0 8px 20px rgba(88, 166, 255, 0.5);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 996px) {
   .scrollToTop {
     bottom: 1.5rem;
     right: 1.5rem;
+    width: 45px;
+    height: 45px;
+  }
+}
+
+@media (max-width: 768px) {
+  .scrollToTop {
+    bottom: 5rem;
+    right: 1rem;
     width: 45px;
     height: 45px;
   }


### PR DESCRIPTION
current:

<img width="324" height="281" alt="image" src="https://github.com/user-attachments/assets/72727085-6de7-4efe-84e0-521b4c85f3ca" />

fixed:

<img width="374" height="268" alt="image" src="https://github.com/user-attachments/assets/b2cf1ea3-b54b-4140-9e34-9e004542ef9d" />
