### PR TITLE
fix: correct HNSW frontier comparisons in hybrid cache

### DIFF
--- a/src/semantic-router/pkg/cache/hybrid_cache.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache.go
@@ -938,7 +938,7 @@ func (h *HybridCache) searchLayerHybrid(query []float32, ef int, layer int, entr
 		if ep < 0 || ep >= len(h.embeddings) {
 			continue
 		}
-		dist := -dotProduct(query, h.embeddings[ep])
+		dist := -dotProduct(query, h.embeddings[ep]) // Negative product so that higher similarity = lower distance
 		candidates.push(ep, dist)
 		results.push(ep, dist)
 		visited[ep] = true
@@ -946,7 +946,7 @@ func (h *HybridCache) searchLayerHybrid(query []float32, ef int, layer int, entr
 
 	for len(candidates.data) > 0 {
 		currentIdx, currentDist := candidates.pop()
-		if len(results.data) > 0 && currentDist > -results.data[0].dist {
+		if len(results.data) > 0 && currentDist > results.data[0].dist {
 			break
 		}
 
@@ -964,7 +964,7 @@ func (h *HybridCache) searchLayerHybrid(query []float32, ef int, layer int, entr
 
 			dist := -dotProduct(query, h.embeddings[neighborID])
 
-			if len(results.data) < ef || dist < -results.data[0].dist {
+			if len(results.data) < ef || dist < results.data[0].dist {
 				candidates.push(neighborID, dist)
 				results.push(neighborID, dist)
 
@@ -1062,7 +1062,7 @@ func (h *HybridCache) searchLayerHybridWithEarlyStop(query []float32, ef int, la
 		if ep < 0 || ep >= len(h.embeddings) {
 			continue
 		}
-		dist := -dotProductSIMD(query, h.embeddings[ep])
+		dist := -dotProductSIMD(query, h.embeddings[ep]) // Negative product so that higher similarity = lower distance
 		candidates.push(ep, dist)
 		results.push(ep, dist)
 		visited[ep] = true
@@ -1075,7 +1075,7 @@ func (h *HybridCache) searchLayerHybridWithEarlyStop(query []float32, ef int, la
 
 	for len(candidates.data) > 0 {
 		currentIdx, currentDist := candidates.pop()
-		if len(results.data) > 0 && currentDist > -results.data[0].dist {
+		if len(results.data) > 0 && currentDist > results.data[0].dist {
 			break
 		}
 
@@ -1098,7 +1098,7 @@ func (h *HybridCache) searchLayerHybridWithEarlyStop(query []float32, ef int, la
 				return []int{neighborID}
 			}
 
-			if len(results.data) < ef || dist < -results.data[0].dist {
+			if len(results.data) < ef || dist < results.data[0].dist {
 				candidates.push(neighborID, dist)
 				results.push(neighborID, dist)
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Your PR title should be descriptive, and generally start with type that contains a subsystem name with `()` if necessary
and summary followed by a colon. format `chore/docs/api/feat/fix/refactor/style/test: summary`.
Examples:
* "docs: fix grammar error"
* "feat(translator): add new feature"
* "fix: fix xx bug"
* "chore: change ci & build tools etc"
* "api: add xxx fields in ClientTrafficPolicy"
-->
fix: correct HNSW frontier comparisons in hybrid cache

<!--
NOTE: If your PR contains any API changes (changes under `/api`), we recommend you to separate these API changes into
a new PR, and we will review the API part first. It will save you lots of implementation time if the API get accepted.
-->

**What this PR does / why we need it**:
&emsp; This PR fixes the **sign bug** in both `func (h *HybridCache) searchLayerHybrid` and `func (h *HybridCache) searchLayerHybridWithEarlyStop`: the code compared `currentDist` against  `-results.data[0].dist` even though distances were already stored as negatives, so saturated frontiers kept enqueuing worse neighbors instead of pruning them.  
&emsp; ( the stopping condition `(currentDist > -results.data[0].dist)` almost never fires, and the “is this better than the frontier?” check `(dist < -results.data[0].dist)` is nearly always true.)
&emsp; This prevents needless graph traversal, keeps lookup latency under control, and avoids returning responses routed through poor matches.
https://github.com/vllm-project/semantic-router/blob/f8f042d4b5c5c13d8d380dd589fecba5e43d51bf/src/semantic-router/pkg/cache/hybrid_cache.go#L927-L951

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

<!--
For any non-trivial changes, you need to provide a brief description of the changes in the release notes.
-->
Release Notes: Yes/No
