### PR TITLE
fix(tests): resolve skipped BERT similarity model tests (Section 1/5)

### DIFF
--- a/candle-binding/src/ffi/init.rs
+++ b/candle-binding/src/ffi/init.rs
@@ -146,6 +146,18 @@ pub extern "C" fn init_similarity_model(model_id: *const c_char, use_cpu: bool) 
     }
 }
 
+/// Check if BERT similarity model is initialized
+///
+/// This function checks the Rust-side OnceLock state to determine if the model
+/// has been initialized. This is the source of truth for initialization status.
+///
+/// # Returns
+/// `true` if BERT_SIMILARITY OnceLock contains an initialized model, `false` otherwise
+#[no_mangle]
+pub extern "C" fn is_similarity_model_initialized() -> bool {
+    BERT_SIMILARITY.get().is_some()
+}
+
 /// Initialize traditional BERT classifier
 ///
 /// # Safety


### PR DESCRIPTION
This PR addresses Section 1 of previously skipped tests by fixing all 8 BERT
similarity model tests that were failing due to OnceLock singleton pattern
handling.

**Root Cause:**
Tests assumed the BERT similarity model could be reset and reinitialized
between test runs, but the Rust implementation uses OnceLock which prevents
reinitialization by design.

**Solution:**
- Add is_similarity_model_initialized() FFI to expose Rust OnceLock state
- Update Go layer to treat Rust OnceLock as source of truth
- Remove model reset operations (defer ResetModel() calls)
- Adapt tests to work with single-initialization lifecycle
- Replace invalid model tests with singleton verification

**Tests Fixed (8/21 total skipped tests):**

✅ TestInitModel/InitWithSpecificModel - Model initialization
✅ TestTokenization - Tokenization functionality  
✅ TestEmbeddings - Embedding generation
✅ TestSimilarity - Similarity calculation
✅ TestFindMostSimilar - Finding most similar items
✅ TestUtilityFunctions/IsModelInitialized - Status check
✅ TestErrorHandling/EmptyStringHandling - Empty string handling
✅ TestConcurrency - Concurrent operations

Fix Partially issue #573 
