### PR TITLE
fix(tests): enable all 5 Milvus hybrid cache tests (Section 2/5)

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -83,6 +83,31 @@ jobs:
           HF_HUB_DISABLE_TELEMETRY: 1
         run: make download-models
 
+      - name: Start Milvus service
+        run: |
+          echo "Starting Milvus vector database..."
+          docker run -d \
+            --name milvus-semantic-cache \
+            --security-opt seccomp:unconfined \
+            -e ETCD_USE_EMBED=true \
+            -e ETCD_DATA_DIR=/var/lib/milvus/etcd \
+            -e ETCD_CONFIG_PATH=/milvus/configs/advanced/etcd.yaml \
+            -e COMMON_STORAGETYPE=local \
+            -e CLUSTER_ENABLED=false \
+            -p 19530:19530 \
+            -p 9091:9091 \
+            milvusdb/milvus:v2.3.3 \
+            milvus run standalone
+          
+          echo "Waiting for Milvus to be ready..."
+          sleep 20
+          
+          # Verify Milvus is responsive
+          timeout 30 bash -c 'until docker logs milvus-semantic-cache 2>&1 | grep -q "Proxy successfully started"; do sleep 2; done' || true
+          
+          echo "Milvus is ready at localhost:19530"
+          docker ps --filter "name=milvus-semantic-cache"
+
       - name: Run semantic router tests
         run: make test
         env:
@@ -90,6 +115,16 @@ jobs:
           CI_MINIMAL_MODELS: ${{ github.event_name == 'pull_request' }}
           CGO_ENABLED: 1
           LD_LIBRARY_PATH: ${{ github.workspace }}/candle-binding/target/release
+          MILVUS_URI: localhost:19530
+          SKIP_MILVUS_TESTS: false
+
+      - name: Stop Milvus service
+        if: always()
+        run: |
+          echo "Stopping Milvus container..."
+          docker stop milvus-semantic-cache || true
+          docker rm milvus-semantic-cache || true
+          echo "Milvus container cleaned up"
 
       - name: Upload test artifacts on failure
         if: failure()

--- a/tools/make/build-run-test.mk
+++ b/tools/make/build-run-test.mk
@@ -37,6 +37,7 @@ test-semantic-router: build-router
 	@$(LOG_TARGET)
 	@export LD_LIBRARY_PATH=${PWD}/candle-binding/target/release && \
 	export SKIP_MILVUS_TESTS=$${SKIP_MILVUS_TESTS:-true} && \
+	export SR_TEST_MODE=true && \
 		cd src/semantic-router && CGO_ENABLED=1 go test -v ./...
 
 # Test the Rust library and the Go binding

--- a/tools/make/milvus.mk
+++ b/tools/make/milvus.mk
@@ -55,6 +55,7 @@ test-milvus-cache: start-milvus rust
 	@$(LOG_TARGET)
 	@echo "Testing semantic cache with Milvus backend..."
 	@export LD_LIBRARY_PATH=$${PWD}/candle-binding/target/release && \
+	export SR_TEST_MODE=true && \
 		cd src/semantic-router && CGO_ENABLED=1 go test -tags=milvus -v ./pkg/cache/
 	@echo "Consider running 'make stop-milvus' when done testing"
 
@@ -63,6 +64,7 @@ test-semantic-router-milvus: build-router start-milvus
 	@$(LOG_TARGET)
 	@echo "Testing semantic-router with Milvus cache backend..."
 	@export LD_LIBRARY_PATH=$${PWD}/candle-binding/target/release && \
+	export SR_TEST_MODE=true && \
 		cd src/semantic-router && CGO_ENABLED=1 go test -tags=milvus -v ./...
 	@echo "Consider running 'make stop-milvus' when done testing"
 
@@ -154,6 +156,7 @@ benchmark-hybrid-quick: rust ## Run quick Hybrid vs Milvus benchmark (smaller sc
 	@export LD_LIBRARY_PATH=$${PWD}/candle-binding/target/release && \
 		export USE_CPU=$${USE_CPU:-false} && \
 		export SKIP_MILVUS=$${SKIP_MILVUS:-false} && \
+		export SR_BENCHMARK_MODE=true && \
 		echo "Using GPU mode: USE_CPU=$$USE_CPU" && \
 		echo "Skip Milvus: SKIP_MILVUS=$$SKIP_MILVUS" && \
 		cd src/semantic-router/pkg/cache && \
@@ -186,6 +189,7 @@ benchmark-hybrid-only: rust ## Run ONLY Hybrid cache benchmark (skip Milvus for 
 	@export LD_LIBRARY_PATH=$${PWD}/candle-binding/target/release && \
 		export USE_CPU=$${USE_CPU:-false} && \
 		export SKIP_MILVUS=true && \
+		export SR_BENCHMARK_MODE=true && \
 		echo "Using GPU mode: USE_CPU=$$USE_CPU" && \
 		echo "Testing HYBRID CACHE ONLY (Milvus skipped)" && \
 		cd src/semantic-router/pkg/cache && \


### PR DESCRIPTION
  This PR fixes all 5 previously skipped Milvus-dependent cache tests by
  resolving critical implementation and infrastructure issues.

  **Root Cause:**
  Tests failed due to: missing CI infrastructure, incorrect YAML config structure,
  Milvus SDK parameter ordering bug, memory leak in eviction, and a race condition
  where GetByID could return stale pending entries instead of updated responses.

  **Solution:**
  - Add Milvus Docker service to CI with MILVUS_URI and SR_TEST_MODE env vars
  - Fix YAML structure and create createTestMilvusConfig() helper 
  - Fix NewIndexHNSW parameter order: (metric, M, efConstruction)
  - Fix eviction memory leak: remove embeddings from slice and rebuild idMap
  - Fix GetByID race condition: filter query with `response_body != ""`

  Tests Fixed (5/21 total skipped tests):
  ✅ TestHybridCacheBasicOperations
  ✅ TestHybridCachePendingRequest
  ✅ TestHybridCacheEviction
  ✅ TestHybridCacheLocalCacheHit
  ✅ TestHybridVsMilvusSmoke

  Fix partially issue #573 