### PR TITLE
fix: correct yaml linting hook to call yaml-lint instead of markdown-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
     hooks:
       - id: yaml-and-yml-fmt
         name: yaml/yml fmt
-        entry: bash -c "make markdown-lint"
+        entry: bash -c "make yaml-lint"
         language: system
         files: \.(yaml|yml)$
         exclude: ^(\node_modules/)


### PR DESCRIPTION
## Summary

Fixes the pre-commit configuration bug where the `yaml-and-yml-fmt` hook was incorrectly calling `make markdown-lint` instead of `make yaml-lint`.

## Problem

The bug in `.pre-commit-config.yaml` line 57 caused:
- ❌ YAML files not being properly linted locally
- ✅ GitHub Actions CI catching the issues (because it properly installs `yamllint`)
- 🤔 PRs failing in CI even though `pre-commit run --all-files` passes locally
- 😓 Contributors forced to fix pre-existing YAML issues in files they never touched (see PR #593)

## Changes

Changed line 57 in `.pre-commit-config.yaml`:
```yaml
# Before
entry: bash -c "make markdown-lint"

# After
entry: bash -c "make yaml-lint"
```

## Testing

**Before the fix:**
```bash
$ pre-commit run yaml-and-yml-fmt --all-files
yaml/yml fmt.............................................................Passed
```

**After the fix:**
```bash
$ pre-commit run yaml-and-yml-fmt --all-files
yaml/yml fmt.............................................................Failed
[Shows actual YAML linting errors]
```

This confirms the hook now properly runs `yamllint` and catches the same issues that GitHub Actions CI catches.

## Note on Pre-existing YAML Issues

This PR **only fixes the pre-commit hook configuration**. There are many pre-existing YAML linting issues in the codebase (trailing spaces, comment spacing, etc.) that are now being detected. Fixing all these issues is out of scope for this PR - they can be addressed in a follow-up PR or gradually as files are modified.

The important thing is that now local pre-commit checks will match what GitHub Actions CI checks, preventing the confusion where contributors have to fix issues they didn't create.

Fixes #608

## Checklist
- [x] Fixed the pre-commit hook to call correct command
- [x] Tested locally that the hook now catches YAML linting errors
- [x] Commit includes DCO sign-off
- [x] References the issue number