### PR TITLE
Revert "fix: correct yaml linting hook to call yaml-lint instead of markdown-lint"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
     hooks:
       - id: yaml-and-yml-fmt
         name: yaml/yml fmt
-        entry: bash -c "make yaml-lint"
+        entry: bash -c "make markdown-lint"
         language: system
         files: \.(yaml|yml)$
         exclude: ^(\node_modules/)


### PR DESCRIPTION
Reverts vllm-project/semantic-router#609

@yossiovadia this breaks the CI, can you run it locally and add the changed files too?