### PR TITLE
fix(tests): Enable TestCandleBertTokensWithLabels and expose CI failures (Section 4/5)

### DIFF
--- a/candle-binding/semantic-router_test.go
+++ b/candle-binding/semantic-router_test.go
@@ -1362,7 +1362,7 @@ func TestCandleBertTokensWithLabels(t *testing.T) {
 
 	success := InitCandleBertTokenClassifier(BertPIITokenClassifierModelPath, 9, true) // 9 PII classes
 	if !success {
-		t.Skipf("Candle BERT token classifier not available at path: %s", BertPIITokenClassifierModelPath)
+		t.Fatalf("Failed to initialize Candle BERT token classifier at path: %s. Model should be available in CI (included in LoRA model set).", BertPIITokenClassifierModelPath)
 	}
 
 	testText := "Contact Dr. Sarah Johnson at sarah.johnson@hospital.org for medical records"
@@ -1370,7 +1370,7 @@ func TestCandleBertTokensWithLabels(t *testing.T) {
 	result, err := ClassifyCandleBertTokensWithLabels(testText, id2labelJSON)
 	if err != nil {
 		if isModelInitializationError(err) {
-			t.Skipf("Skipping Candle BERT token classifier tests due to model initialization error: %v", err)
+			t.Fatalf("Candle BERT token classifier failed with model initialization error: %v. Model should be initialized earlier in test.", err)
 		}
 		t.Fatalf("Token classification with labels failed: %v", err)
 	}

--- a/candle-binding/src/ffi/init.rs
+++ b/candle-binding/src/ffi/init.rs
@@ -594,6 +594,11 @@ pub extern "C" fn init_candle_bert_token_classifier(
 
     match model_type {
         ModelType::LoRA => {
+            // Check if already initialized
+            if LORA_TOKEN_CLASSIFIER.get().is_some() {
+                return true; // Already initialized, return success
+            }
+
             // Route to LoRA token classifier initialization
             match crate::classifiers::lora::token_lora::LoRATokenClassifier::new(
                 model_path, use_cpu,
@@ -606,6 +611,14 @@ pub extern "C" fn init_candle_bert_token_classifier(
             }
         }
         ModelType::Traditional => {
+            // Check if already initialized
+            if crate::model_architectures::traditional::bert::TRADITIONAL_BERT_TOKEN_CLASSIFIER
+                .get()
+                .is_some()
+            {
+                return true; // Already initialized, return success
+            }
+
             // Route to traditional BERT token classifier
             match crate::model_architectures::traditional::bert::TraditionalBertTokenClassifier::new(
                 model_path,

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -64,8 +64,7 @@ test-binding-lora: $(if $(CI),rust-ci,rust) ## Run Go tests with LoRA and advanc
 	@echo "Running candle-binding tests with LoRA and advanced embedding models..."
 	@export LD_LIBRARY_PATH=${PWD}/candle-binding/target/release && \
 		cd candle-binding && CGO_ENABLED=1 go test -v -race \
-		-run "^Test(BertTokenClassification|BertSequenceClassification|CandleBertClassifier|CandleBertTokenClassifier|CandleBertTokensWithLabels|LoRAUnifiedClassifier|GetEmbeddingSmart|InitEmbeddingModels|GetEmbeddingWithDim|EmbeddingConsistency|EmbeddingPriorityRouting|EmbeddingConcurrency)$$" \
-		|| { echo "⚠️  Warning: Some LoRA/embedding tests failed (may be due to missing restricted models), continuing..."; $(if $(CI),true,exit 1); }
+		-run "^Test(BertTokenClassification|BertSequenceClassification|CandleBertClassifier|CandleBertTokenClassifier|CandleBertTokensWithLabels|LoRAUnifiedClassifier|GetEmbeddingSmart|InitEmbeddingModels|GetEmbeddingWithDim|EmbeddingConsistency|EmbeddingPriorityRouting|EmbeddingConcurrency)$$"
 
 # Test the Rust library - all tests (conditionally use rust-ci in CI environments)
 test-binding: $(if $(CI),rust-ci,rust) ## Run all Go tests with the Rust static library


### PR DESCRIPTION
Fixes TestCandleBertTokensWithLabels which was skipped/failing silently.

Root causes:
1. Classification functions only checked for traditional BERT classifier,
   missing the initialized LoRA classifier (LORA_TOKEN_CLASSIFIER)
2. Tensor shape mismatch: linear layer expected [1, 768] but got [768]
3. CI error handler silently swallowed test failures

Changes:
- src/ffi/classify.rs: Add LoRA classifier routing and filter "O" labels
- src/classifiers/lora/token_lora.rs: Fix tensor shape with unsqueeze(0)
- tools/make/rust.mk: Remove error handler hiding CI failures
- semantic-router_test.go: Change t.Skipf to t.Fatalf
- src/ffi/init.rs: Add OnceLock checks for re-initialization

Result: Test now correctly detects 9 PII entities (was 0 or skipped)

Fix Partially issue #573 