### PR TITLE
[Doc]: update editUrl in docusaurus config to point to the correct website directory

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -46,7 +46,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/vllm-project/semantic-router/tree/main/docs/',
+            'https://github.com/vllm-project/semantic-router/tree/main/website/',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
Right now when clicking the link to edit the page you get the following error:
<img width="767" height="285" alt="Screenshot 2025-11-10 at 8 51 22 AM" src="https://github.com/user-attachments/assets/487c5bc2-cbbb-4379-8d53-8e6b57422e32" />

<img width="911" height="446" alt="Screenshot 2025-11-10 at 8 51 42 AM" src="https://github.com/user-attachments/assets/26bf0199-b040-4029-83aa-7d72959b2acb" />

This PR changes the editUrl in the Docusaurus configuration from the docs directory to the website directory to ensure proper linking for editing documentation.

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/semantic-router/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.
