### PR TITLE
fix: auto-generate lora_config.json in training script

### DIFF
--- a/src/training/training_lora/classifier_model_fine_tuning_lora/ft_linear_lora.py
+++ b/src/training/training_lora/classifier_model_fine_tuning_lora/ft_linear_lora.py
@@ -659,6 +659,27 @@ def merge_lora_adapter_to_full_model(
         )
         logger.info("Created category_mapping.json")
 
+    # Create lora_config.json for Rust router detection
+    # This file signals to the Rust router that this is a LoRA-trained model
+    # and should be routed to the LoRA inference path
+    logger.info("Creating lora_config.json for LoRA model detection...")
+    lora_config = {
+        "rank": 16,  # LoRA rank (r) - matches training configuration
+        "alpha": 32,  # LoRA alpha scaling factor
+        "dropout": 0.1,  # LoRA dropout rate
+        "target_modules": [
+            "attention.self.query",
+            "attention.self.value",
+            "attention.output.dense",
+            "intermediate.dense",
+            "output.dense",
+        ],
+    }
+    lora_config_path = os.path.join(output_path, "lora_config.json")
+    with open(lora_config_path, "w") as f:
+        json.dump(lora_config, f)
+    logger.info(f"Created {lora_config_path}")
+
     logger.info("LoRA adapter merged successfully!")
 
 


### PR DESCRIPTION
## Summary

Fixes missing `lora_config.json` in LoRA intent classifier models.

**Issue:** (discovered by @yehudit1987)

## Problem

The LoRA intent classifier models were missing `lora_config.json` files on HuggingFace, causing:
- Go tests to skip (model initialization failures)
- Mixed routing paths (Intent→Traditional, PII/Security→LoRA)
- New users downloading broken models

The Rust router detects LoRA models by checking for `lora_config.json` (`candle-binding/src/ffi/init.rs:64-68`). Without this file, intent models defaulted to Traditional path while PII/Security used LoRA path, causing initialization conflicts.

## Changes

### 1. Training Script Update
Modified `merge_lora_adapter_to_full_model()` in `ft_linear_lora.py` to automatically create `lora_config.json` when merging LoRA adapters.

**Added code (lines 662-681):**
```python
# Create lora_config.json for Rust router detection
logger.info("Creating lora_config.json for LoRA model detection...")
lora_config = {
    "rank": 16,
    "alpha": 32,
    "dropout": 0.1,
    "target_modules": [
        "attention.self.query",
        "attention.self.value",
        "attention.output.dense",
        "intermediate.dense",
        "output.dense",
    ],
}
lora_config_path = os.path.join(output_path, "lora_config.json")
with open(lora_config_path, "w") as f:
    json.dump(lora_config, f)
logger.info(f"Created {lora_config_path}")
```

This prevents future occurrences when training/merging new LoRA models.
## Testing

### Test without training:
```bash
python src/training/training_lora/test_lora_config_generation.py
```

### Full verification (after HF upload):
```bash
# Delete local models
rm -rf models/lora_intent_classifier*

# Re-download from HuggingFace
make download-models-full

# Verify files exist
ls models/lora_intent_classifier_bert-base-uncased_model/lora_config.json
ls models/lora_intent_classifier_roberta-base_model/lora_config.json
ls models/lora_intent_classifier_modernbert-base_model/lora_config.json

# Run Go tests (should no longer skip)
cd candle-binding && go test -v -run TestLoRAUnifiedClassifier
```

## Credit

Issue discovered by @yehudit1987 while investigating skipped classifier tests in the Go test suite.

## Related

- Issue: #627 (missing lora_config.json in intent classifiers)
- Root cause: Training script merges LoRA but doesn't create metadata file
- Impact: Affects all new users, breaks model routing, skips tests
