### PR TITLE
fix(tests): resolve 3 skipped model directory tests (Section 3/5)

### DIFF
--- a/candle-binding/src/ffi/init.rs
+++ b/candle-binding/src/ffi/init.rs
@@ -746,6 +746,11 @@ pub extern "C" fn init_lora_unified_classifier(
         }
     };
 
+    // Check if already initialized - return success if so
+    if PARALLEL_LORA_ENGINE.get().is_some() {
+        return true;
+    }
+
     // Load labels dynamically from model configurations
     let _intent_labels_vec = load_labels_from_model_config(intent_path).unwrap_or_else(|e| {
         eprintln!(
@@ -786,7 +791,9 @@ pub extern "C" fn init_lora_unified_classifier(
     ) {
         Ok(engine) => {
             // Store in global static variable (Arc for efficient cloning during concurrent access)
+            // Return true even if already set (race condition)
             PARALLEL_LORA_ENGINE.set(Arc::new(engine)).is_ok()
+                || PARALLEL_LORA_ENGINE.get().is_some()
         }
         Err(e) => {
             eprintln!(

--- a/tools/make/models.mk
+++ b/tools/make/models.mk
@@ -24,6 +24,7 @@ download-models: ## Download models (full or minimal set depending on CI_MINIMAL
 # - PII token classifier (ModernBERT Presidio)
 # - Jailbreak classifier (ModernBERT)
 # - Optional plain PII classifier mapping (small)
+# - LoRA models (BERT architecture) for unified classifier tests
 
 download-models-minimal:
 download-models-minimal: ## Pre-download minimal set of models for CI tests
@@ -46,6 +47,16 @@ download-models-minimal: ## Pre-download minimal set of models for CI tests
 	fi
 	@if [ ! -f "models/pii_classifier_modernbert-base_model/.downloaded" ] || [ ! -d "models/pii_classifier_modernbert-base_model" ]; then \
 		hf download LLM-Semantic-Router/pii_classifier_modernbert-base_model --local-dir models/pii_classifier_modernbert-base_model && printf '%s\n' "$$(date -u +%Y-%m-%dT%H:%M:%SZ)" > models/pii_classifier_modernbert-base_model/.downloaded; \
+	fi
+	# Download LoRA models for unified classifier integration tests
+	@if [ ! -f "models/lora_intent_classifier_bert-base-uncased_model/.downloaded" ] || [ ! -d "models/lora_intent_classifier_bert-base-uncased_model" ]; then \
+		hf download LLM-Semantic-Router/lora_intent_classifier_bert-base-uncased_model --local-dir models/lora_intent_classifier_bert-base-uncased_model && printf '%s\n' "$$(date -u +%Y-%m-%dT%H:%M:%SZ)" > models/lora_intent_classifier_bert-base-uncased_model/.downloaded; \
+	fi
+	@if [ ! -f "models/lora_pii_detector_bert-base-uncased_model/.downloaded" ] || [ ! -d "models/lora_pii_detector_bert-base-uncased_model" ]; then \
+		hf download LLM-Semantic-Router/lora_pii_detector_bert-base-uncased_model --local-dir models/lora_pii_detector_bert-base-uncased_model && printf '%s\n' "$$(date -u +%Y-%m-%dT%H:%M:%SZ)" > models/lora_pii_detector_bert-base-uncased_model/.downloaded; \
+	fi
+	@if [ ! -f "models/lora_jailbreak_classifier_bert-base-uncased_model/.downloaded" ] || [ ! -d "models/lora_jailbreak_classifier_bert-base-uncased_model" ]; then \
+		hf download LLM-Semantic-Router/lora_jailbreak_classifier_bert-base-uncased_model --local-dir models/lora_jailbreak_classifier_bert-base-uncased_model && printf '%s\n' "$$(date -u +%Y-%m-%dT%H:%M:%SZ)" > models/lora_jailbreak_classifier_bert-base-uncased_model/.downloaded; \
 	fi
 
 # Full model set for local development and docs


### PR DESCRIPTION

- Fix incorrect relative path to models directory
- Fix Rust double initialization bug in init_lora_unified_classifier
- Add LoRA models to CI minimal downloads
- Bump model cache version to force fresh download
- Change tests to fail visibly instead of silently skipping

Tests TestAutoDiscoverModels_RealModels, TestAutoInitializeUnifiedClassifier,
and TestUnifiedClassifier_Integration now pass.

Fix Partially issue #573 