### PR TITLE
[Misc] Reduce initial delay for liveness and readiness probes

### DIFF
--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -175,7 +175,7 @@ livenessProbe:
   # -- Enable liveness probe
   enabled: true
   # -- Initial delay seconds
-  initialDelaySeconds: 120
+  initialDelaySeconds: 30
   # -- Period seconds
   periodSeconds: 30
   # -- Timeout seconds
@@ -188,7 +188,7 @@ readinessProbe:
   # -- Enable readiness probe
   enabled: true
   # -- Initial delay seconds
-  initialDelaySeconds: 180
+  initialDelaySeconds: 30
   # -- Period seconds
   periodSeconds: 30
   # -- Timeout seconds


### PR DESCRIPTION
## Description

This PR reduces the initial delay seconds for both liveness and readiness probes in the Helm chart configuration to improve startup time and enable faster detection of service availability.

### Changes
- Reduced liveness probe `initialDelaySeconds` from 120s to 30s
- Reduced readiness probe `initialDelaySeconds` from 180s to 30s

### Motivation
Shorter initial delays allow Kubernetes to detect service availability faster, reducing the time before the service can start receiving traffic. The previous values (120s and 180s) were overly conservative for most deployment scenarios.

---

- [x] Make sure the code changes pass the pre-commit checks.
- [x] Sign-off your commit by using `-s` when doing `git commit`
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.
