### PR TITLE
[CI/Build] Fail e2e tests when accuracy is 0%

### DIFF
--- a/e2e/testcases/domain_classify.go
+++ b/e2e/testcases/domain_classify.go
@@ -92,6 +92,11 @@ func testDomainClassify(ctx context.Context, client *kubernetes.Clientset, opts 
 			correctTests, totalTests, accuracy)
 	}
 
+	// Return error if accuracy is 0%
+	if correctTests == 0 {
+		return fmt.Errorf("domain classification test failed: 0%% accuracy (0/%d correct)", totalTests)
+	}
+
 	return nil
 }
 

--- a/e2e/testcases/jailbreak_detection.go
+++ b/e2e/testcases/jailbreak_detection.go
@@ -103,6 +103,11 @@ func testJailbreakDetection(ctx context.Context, client *kubernetes.Clientset, o
 			correctTests, totalTests, detectionRate)
 	}
 
+	// Return error if detection rate is 0%
+	if correctTests == 0 {
+		return fmt.Errorf("jailbreak detection test failed: 0%% accuracy (0/%d correct)", totalTests)
+	}
+
 	return nil
 }
 

--- a/e2e/testcases/pii_detection.go
+++ b/e2e/testcases/pii_detection.go
@@ -103,6 +103,11 @@ func testPIIDetection(ctx context.Context, client *kubernetes.Clientset, opts pk
 			correctTests, totalTests, detectionRate)
 	}
 
+	// Return error if detection rate is 0%
+	if correctTests == 0 {
+		return fmt.Errorf("PII detection test failed: 0%% accuracy (0/%d correct)", totalTests)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

This PR adds error handling to domain classification, PII detection, and jailbreak detection e2e tests to ensure they fail explicitly when accuracy is 0%.

## Motivation

Previously, these tests would return `nil` (success) even when all test cases failed, which could mask critical issues in the routing and detection logic. This change makes test failures more visible and actionable by returning a descriptive error when `correctTests == 0`.

## Changes

- Added zero-accuracy check in `testDomainClassify()` function
- Added zero-accuracy check in `testPIIDetection()` function  
- Added zero-accuracy check in `testJailbreakDetection()` function
- All three tests now return an error with format: `"<test-name> test failed: 0% accuracy (0/<total> correct)"`

## Testing

The changes ensure that:
- Tests fail explicitly when accuracy is 0%
- Error messages clearly indicate which test failed and the total number of test cases
- Existing behavior is preserved when accuracy > 0%

---

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/semantic-router/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author