### PR TITLE
fix: disable MD032 markdown linting rule

### DIFF
--- a/tools/linter/markdown/markdownlint.yaml
+++ b/tools/linter/markdown/markdownlint.yaml
@@ -51,5 +51,8 @@ MD009: false
 # MD005/list-indent Inconsistent indentation for list items
 MD005: false
 
+# MD032/blanks-around-lists Lists should be surrounded by blank lines
+MD032: false
+
 # MD060/table-column-style Table column style
 MD060: false


### PR DESCRIPTION
- Prevents blocking PRs due to missing blank lines around lists across multiple markdown files