### PR TITLE
fix(647): enable LoRA PII auto-detection with minimal changes

### DIFF
--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -167,6 +167,9 @@ initContainer:
       repo: LLM-Semantic-Router/jailbreak_classifier_modernbert-base_model
     - name: pii_classifier_modernbert-base_presidio_token_model
       repo: LLM-Semantic-Router/pii_classifier_modernbert-base_presidio_token_model
+    # LoRA PII detector (for auto-detection feature)
+    - name: lora_pii_detector_bert-base-uncased_model
+      repo: LLM-Semantic-Router/lora_pii_detector_bert-base-uncased_model
 
 
 # Autoscaling configuration

--- a/deploy/kubernetes/aibrix/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/aibrix/semantic-router-values/values.yaml
@@ -437,8 +437,10 @@ config:
       use_cpu: true
       category_mapping_path: "models/category_classifier_modernbert-base_model/category_mapping.json"
     pii_model:
-      model_id: "models/pii_classifier_modernbert-base_presidio_token_model"
-      use_modernbert: true
+      # Support both traditional (modernbert) and LoRA-based PII detection
+      # When model_type is "auto", the system will auto-detect LoRA configuration
+      model_id: "models/lora_pii_detector_bert-base-uncased_model"
+      use_modernbert: false  # Use LoRA PII model with auto-detection
       threshold: 0.7
       use_cpu: true
       pii_mapping_path: "models/pii_classifier_modernbert-base_presidio_token_model/pii_type_mapping.json"

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -467,8 +467,10 @@ config:
       use_cpu: true
       category_mapping_path: "models/category_classifier_modernbert-base_model/category_mapping.json"
     pii_model:
-      model_id: "models/pii_classifier_modernbert-base_presidio_token_model"
-      use_modernbert: true
+      # Support both traditional (modernbert) and LoRA-based PII detection
+      # When model_type is "auto", the system will auto-detect LoRA configuration
+      model_id: "models/lora_pii_detector_bert-base-uncased_model"
+      use_modernbert: false  # Use LoRA PII model with auto-detection
       threshold: 0.7
       use_cpu: true
       pii_mapping_path: "models/pii_classifier_modernbert-base_presidio_token_model/pii_type_mapping.json"

--- a/e2e/profiles/dynamic-config/values.yaml
+++ b/e2e/profiles/dynamic-config/values.yaml
@@ -48,8 +48,8 @@ config:
       use_cpu: true
       category_mapping_path: "models/category_classifier_modernbert-base_model/category_mapping.json"
     pii_model:
-      model_id: "models/pii_classifier_modernbert-base_presidio_token_model"
-      use_modernbert: true
+      model_id: "models/lora_pii_detector_bert-base-uncased_model"
+      use_modernbert: false  # Use LoRA PII model with auto-detection
       threshold: 0.7
       use_cpu: true
       pii_mapping_path: "models/pii_classifier_modernbert-base_presidio_token_model/pii_type_mapping.json"

--- a/src/semantic-router/pkg/classification/classifier_test.go
+++ b/src/semantic-router/pkg/classification/classifier_test.go
@@ -287,7 +287,7 @@ var _ = Describe("jailbreak detection", func() {
 
 type MockPIIInitializer struct{ InitError error }
 
-func (m *MockPIIInitializer) Init(_ string, useCPU bool) error { return m.InitError }
+func (m *MockPIIInitializer) Init(_ string, useCPU bool, numClasses int) error { return m.InitError }
 
 type MockPIIInferenceResponse struct {
 	classifyTokensResult candle_binding.TokenClassificationResult

--- a/src/semantic-router/pkg/extproc/extproc_test.go
+++ b/src/semantic-router/pkg/extproc/extproc_test.go
@@ -2030,6 +2030,8 @@ var _ = Describe("Caching Functionality", func() {
 	BeforeEach(func() {
 		cfg = CreateTestConfig()
 		cfg.Enabled = true
+		// Disable PII detection for caching tests (not needed and avoids model loading issues)
+		cfg.InlineModels.Classifier.PIIModel.ModelID = ""
 
 		var err error
 		router, err = CreateTestRouter(cfg)


### PR DESCRIPTION
Switch PII classification from hardcoded ModernBERT to auto-detecting Candle BERT classifier. The Rust layer already has built-in auto-detection that checks for lora_config.json and routes to LoRA or Traditional models.

Changes:
1. Init: Use InitCandleBertTokenClassifier (has auto-detect built-in)
2. Inference: Use ClassifyCandleBertTokens (auto-routes to initialized classifier)

This enables LoRA PII models to work automatically without config changes, providing higher confidence scores for PII entity detection.

Fixes #647
