### PR TITLE
fix(api): expose actual PII confidence scores instead of hardcoded 0.9

### DIFF
--- a/config/testing/config.e2e.yaml
+++ b/config/testing/config.e2e.yaml
@@ -69,11 +69,11 @@ classifier:
     use_cpu: true
     category_mapping_path: "models/lora_intent_classifier_bert-base-uncased_model/category_mapping.json"
   pii_model:
-    model_id: "models/pii_classifier_modernbert-base_presidio_token_model"  # TODO: Use local model for now before the code can download the entire model from huggingface
-    use_modernbert: true
+    model_id: "models/lora_pii_detector_bert-base-uncased_model"
+    use_modernbert: false  # BERT-based LoRA model (this field is ignored - always auto-detects)
     threshold: 0.7
     use_cpu: true
-    pii_mapping_path: "models/pii_classifier_modernbert-base_presidio_token_model/pii_type_mapping.json"
+    pii_mapping_path: "models/lora_pii_detector_bert-base-uncased_model/pii_type_mapping.json"
 categories:
   - name: business
     description: "Business and management related queries"
@@ -358,6 +358,24 @@ decisions:
         configuration:
           enabled: true
           pii_types_allowed: ["EMAIL_ADDRESS", "PERSON", "GPE", "PHONE_NUMBER", "US_SSN", "CREDIT_CARD"]
+
+  # Default catch-all decision for unmatched requests (E2E PII test fix)
+  # This ensures PII detection is always enabled, even when no specific decision matches
+  - name: "default_decision"
+    description: "Default catch-all decision - blocks all PII for safety"
+    priority: 1  # Lowest priority - only matches if nothing else does
+    rules:
+      operator: "OR"
+      conditions:
+        - type: "always"  # Always matches as fallback
+    modelRefs:
+      - model: "Model-B"
+        use_reasoning: false
+    plugins:
+      - type: "pii"
+        configuration:
+          enabled: true
+          pii_types_allowed: []  # Block ALL PII - empty list means nothing allowed
 
 default_model: "Model-A"
 

--- a/src/semantic-router/pkg/services/classification.go
+++ b/src/semantic-router/pkg/services/classification.go
@@ -290,8 +290,8 @@ func (s *ClassificationService) DetectPII(req PIIRequest) (*PIIResponse, error) 
 		}, nil
 	}
 
-	// Perform PII detection using the existing classifier
-	piiTypes, err := s.classifier.ClassifyPII(req.Text)
+	// Perform PII detection using the classifier with full details
+	detections, err := s.classifier.ClassifyPIIWithDetails(req.Text)
 	if err != nil {
 		return nil, fmt.Errorf("PII detection failed: %w", err)
 	}
@@ -300,17 +300,19 @@ func (s *ClassificationService) DetectPII(req PIIRequest) (*PIIResponse, error) 
 
 	// Build response
 	response := &PIIResponse{
-		HasPII:           len(piiTypes) > 0,
+		HasPII:           len(detections) > 0,
 		Entities:         []PIIEntity{},
 		ProcessingTimeMs: processingTime,
 	}
 
-	// Convert PII types to entities (simplified for now)
-	for _, piiType := range piiTypes {
+	// Convert PII detections to API entities with actual confidence scores
+	for _, detection := range detections {
 		entity := PIIEntity{
-			Type:       piiType,
-			Value:      "[DETECTED]", // Placeholder - would need actual entity extraction
-			Confidence: 0.9,          // Placeholder - would need actual confidence
+			Type:       detection.EntityType,
+			Value:      "[DETECTED]",                  // Redacted for security
+			Confidence: float64(detection.Confidence), // Actual confidence from model
+			StartPos:   detection.Start,
+			EndPos:     detection.End,
 		}
 		response.Entities = append(response.Entities, entity)
 	}


### PR DESCRIPTION
## Summary

This PR fixes the PII API endpoint to return actual confidence scores from the LoRA model instead of hardcoded `0.9` values.

Fixes #717

## Changes

1. **Added `ClassifyPIIWithDetails()` method** - New classifier method that returns full entity details including actual confidence scores
2. **Updated `DetectPII()` service** - Modified to use `ClassifyPIIWithDetails()` instead of `ClassifyPII()` to access real confidence values
3. **Updated `config.e2e.yaml`** - Configured to use LoRA PII model and added default catch-all decision for E2E testing

## Before vs After

### Before (Hardcoded)
```json
{
  "entities": [
    {"type": "B-EMAIL_ADDRESS", "confidence": 0.9},
    {"type": "B-PERSON", "confidence": 0.9}
  ]
}
```

### After (Actual Scores)
```json
{
  "entities": [
    {"type": "B-EMAIL_ADDRESS", "confidence": 0.9869},
    {"type": "B-PERSON", "confidence": 0.9991}
  ]
}
```

## Test Results

Local testing shows the API now correctly returns actual model confidence scores:

| Test Case | Before | After |
|-----------|--------|-------|
| Email detection | 0.9 (hardcoded) | **0.9869** (actual) |
| SSN detection | 0.9 (hardcoded) | **0.9916, 0.8326** (actual) |
| Multiple PII | 0.9 (hardcoded) | **0.7734-0.9991 range** (actual) |

## Technical Details

The underlying LoRA PII model was already producing accurate confidence scores (fixed in #709), but the API layer was discarding them. This change passes through the actual scores to API consumers.

The new `ClassifyPIIWithDetails()` method returns `[]PIIDetection` with full entity information, while maintaining backward compatibility by keeping the existing `ClassifyPII()` method for callers that only need entity types.

## Testing

- [x] Local testing with `make run-router-e2e`
- [x] Manual API testing with curl
- [x] Pre-commit checks passed
- [x] DCO sign-off added
