### PR TITLE
Move model storage to the /mnt directory on both the host and the Kin…

### DIFF
--- a/.github/workflows/integration-test-docker.yml
+++ b/.github/workflows/integration-test-docker.yml
@@ -30,16 +30,43 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Free up disk space
+      - name: Setup model storage on /mnt
         run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          echo "Disk space after cleanup:"
-          df -h
+          # Use /mnt for model storage (has ~75GB vs ~14GB on root)
+          # This helps prevent "no space left on device" errors
+          echo "Disk space before setup:"
+          df -h / && df -h /mnt
+          
+          # Create /mnt/models directory if it doesn't exist
+          sudo mkdir -p /mnt/models
+          sudo chown -R $USER:$USER /mnt/models
+          
+          # If models directory already exists in workspace, move it to /mnt
+          if [ -d "models" ] && [ ! -L "models" ]; then
+            echo "Moving existing models directory to /mnt/models..."
+            # Move contents if /mnt/models is not empty, otherwise just move the directory
+            if [ "$(ls -A /mnt/models 2>/dev/null)" ]; then
+              echo "Warning: /mnt/models already has content, merging..."
+              sudo cp -r models/* /mnt/models/ || true
+              rm -rf models
+            else
+              sudo mv models /mnt/models
+            fi
+          fi
+          
+          # Create symlink from models/ to /mnt/models/ so existing code continues to work
+          if [ ! -e "models" ]; then
+            ln -s /mnt/models models
+            echo "Created symlink: models -> /mnt/models"
+          elif [ -L "models" ]; then
+            echo "Symlink already exists: models -> $(readlink models)"
+          else
+            echo "Warning: models exists but is not a symlink"
+          fi
+          
+          echo "Disk space after setup:"
+          df -h / && df -h /mnt
+          echo "Models directory setup complete. Models will be stored in /mnt/models"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -77,16 +77,6 @@ jobs:
         run: |
           make build-e2e
 
-      - name: Free up disk space
-        run: |
-          # Remove unnecessary toolchains to free ~25GB disk space
-          # This helps prevent "no space left on device" errors
-          echo "Disk before cleanup:"
-          df -h /
-          # Note: Do NOT remove $AGENT_TOOLSDIRECTORY - it contains Go/Rust from setup actions
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/local/lib/android /opt/hostedtoolcache/CodeQL || true
-          echo "Disk after cleanup:"
-          df -h /
 
       - name: Run Integration E2E tests (${{ matrix.profile }})
         id: e2e-test
@@ -96,6 +86,7 @@ jobs:
           TEST_EXIT_CODE=$?
           echo "test_exit_code=${TEST_EXIT_CODE}" >> $GITHUB_OUTPUT
           exit ${TEST_EXIT_CODE}
+
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -80,6 +80,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Setup model storage on /mnt
+        run: |
+          # Use /mnt for model storage (has ~75GB vs ~14GB on root)
+          # This helps prevent "no space left on device" errors
+          echo "Disk space before setup:"
+          df -h / && df -h /mnt
+          
+          # Create /mnt/models directory if it doesn't exist
+          sudo mkdir -p /mnt/models
+          sudo chown -R $USER:$USER /mnt/models
+          
+          # If models directory already exists in workspace, move it to /mnt
+          if [ -d "models" ] && [ ! -L "models" ]; then
+            echo "Moving existing models directory to /mnt/models..."
+            # Move contents if /mnt/models is not empty, otherwise just move the directory
+            if [ "$(ls -A /mnt/models 2>/dev/null)" ]; then
+              echo "Warning: /mnt/models already has content, merging..."
+              sudo cp -r models/* /mnt/models/ || true
+              rm -rf models
+            else
+              sudo mv models /mnt/models
+            fi
+          fi
+          
+          # Create symlink from models/ to /mnt/models/ so existing code continues to work
+          if [ ! -e "models" ]; then
+            ln -s /mnt/models models
+            echo "Created symlink: models -> /mnt/models"
+          elif [ -L "models" ]; then
+            echo "Symlink already exists: models -> $(readlink models)"
+          else
+            echo "Warning: models exists but is not a symlink"
+          fi
+          
+          echo "Disk space after setup:"
+          df -h / && df -h /mnt
+          echo "Models directory setup complete. Models will be stored in /mnt/models"
+
       - name: Cache Models
         uses: actions/cache@v4
         with:

--- a/src/semantic-router/pkg/classification/model_discovery.go
+++ b/src/semantic-router/pkg/classification/model_discovery.go
@@ -62,8 +62,14 @@ func AutoDiscoverModels(modelsDir string) (*ModelPaths, error) {
 		modelsDir = "./models"
 	}
 
+	// Resolve symlinks to handle cases where models directory is a symlink (e.g., CI uses /mnt/models)
+	resolved, err := filepath.EvalSymlinks(modelsDir)
+	if err == nil && resolved != "" {
+		modelsDir = resolved
+	}
+
 	// Check if models directory exists
-	if _, err := os.Stat(modelsDir); os.IsNotExist(err) {
+	if _, statErr := os.Stat(modelsDir); os.IsNotExist(statErr) {
 		return nil, fmt.Errorf("models directory does not exist: %s", modelsDir)
 	}
 
@@ -78,7 +84,7 @@ func AutoDiscoverModels(modelsDir string) (*ModelPaths, error) {
 	legacyPaths := &ModelPaths{}
 
 	// Walk through the models directory to collect all models
-	err := filepath.Walk(modelsDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(modelsDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Move model storage to /mnt directory to prevent disk space issues

## Summary

This PR addresses disk space issues in CI/CD workflows by moving model downloads from the root filesystem (~14GB available) to the `/mnt` directory (~75GB available). This prevents "no space left on device" errors when downloading large models during CI runs.

## Problem

GitHub Actions runners were experiencing disk space exhaustion when downloading large models. The root filesystem (`/`) has only ~14GB available, which is insufficient for model downloads that can reach several GB. The previous workaround of deleting toolchains (~25GB) was:
- Not sufficient for large model sets
- Not stable (depended on toolchain versions)
- Not applicable to Kind clusters (models stored inside the cluster)

## Solution

This PR implements a comprehensive solution that works for both host-level workflows and Kind cluster-based tests:

1. **Host-level workflows** (`test-and-build.yml`, `integration-test-docker.yml`):
   - Creates `/mnt/models` directory
   - Moves existing `models/` directory to `/mnt/models` if present
   - Creates a symlink from `models/` to `/mnt/models/` for backward compatibility
   - All model downloads now use the larger `/mnt` disk (~75GB)

2. **Kind cluster workflows** (`integration-test-k8s.yml`):
   - Mounts host `/mnt` into Kind nodes (control-plane and worker)
   - Patches `local-path-provisioner` ConfigMap to use `/mnt/local-path-provisioner` instead of `/tmp`
   - All PVCs (including model storage) now use the larger disk
   - Removed the temporary "Free up disk space" step (no longer needed)

## Changes

### Files Modified

- **`.github/workflows/test-and-build.yml`** (+38 lines)
  - Added "Setup model storage on /mnt" step with symlink creation
  
- **`.github/workflows/integration-test-docker.yml`** (+45 lines, -11 lines)
  - Replaced "Free up disk space" step with "Setup model storage on /mnt"
  
- **`.github/workflows/integration-test-k8s.yml`** (-11 lines)
  - Removed "Free up disk space" step (no longer needed)
  
- **`e2e/pkg/cluster/kind.go`** (+49 lines, -2 lines)
  - Added Kind config with `/mnt` mount for control-plane and worker nodes
  - Added logic to patch `local-path-config` ConfigMap to use `/mnt/local-path-provisioner`
  - Restarts `local-path-provisioner` deployment after patching

## Technical Details

### Host-Level Implementation
The symlink approach ensures backward compatibility - existing code continues to work without changes:
```bash
models/ -> /mnt/models/
```

### Kind Cluster Implementation
1. **Mount Configuration**: Kind nodes mount host `/mnt` at container path `/mnt`
2. **Storage Provisioner**: `local-path-provisioner` is patched to use `/mnt/local-path-provisioner` as the base path
3. **PVC Storage**: All PersistentVolumeClaims created in the cluster now use the larger disk

## Testing

### Validation Performed
- ✅ Go modules tidy check passed
- ✅ Pre-commit hooks passed (except local OpenSSL issue - CI will handle)
- ✅ Code formatting verified (go fmt, YAML syntax)
- ✅ DCO sign-off verified on all commits
- ✅ Git status clean
- ✅ integration-test-k8s.yml - passed on my fork
- ✅ test-and-build.yml - passed on my fork
- ✅ docker-publish.yml - passed on my fork

## Benefits

1. **5x more disk space**: ~75GB available vs ~14GB on root
2. **Stable solution**: No longer depends on toolchain versions
3. **Works for all scenarios**: Both host-level and Kubernetes-based tests
4. **Backward compatible**: Existing code works without changes (symlink)
5. **Cleaner workflows**: Removed temporary workarounds

## Related Issues

Addresses disk space issues mentioned in PR #623 (follow-up improvement requested by @rootfs)

