### PR TITLE
fix(ci): prevent nightly baseline workflow from running on forks

### DIFF
--- a/.github/workflows/performance-nightly.yml
+++ b/.github/workflows/performance-nightly.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   update-baseline:
     runs-on: ubuntu-latest
+    if: github.repository == 'vllm-project/semantic-router'
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
Add repository check to stop automated baseline commits on forks.

Resolve #834 