### PR TITLE
feat: dashboard playground tab connection failure 

### DIFF
--- a/dashboard/backend/handlers/static.go
+++ b/dashboard/backend/handlers/static.go
@@ -19,7 +19,7 @@ func StaticFileServer(staticDir string) http.Handler {
 			strings.HasPrefix(p, "/metrics/") || strings.HasPrefix(p, "/public/") ||
 			strings.HasPrefix(p, "/avatar/") || strings.HasPrefix(p, "/_app/") ||
 			strings.HasPrefix(p, "/_next/") || strings.HasPrefix(p, "/chatui/") ||
-			p == "/conversation" || strings.HasPrefix(p, "/conversations") ||
+			strings.HasPrefix(p, "/static/") || p == "/conversation" || strings.HasPrefix(p, "/conversations") ||
 			strings.HasPrefix(p, "/settings") || p == "/login" || p == "/logout" ||
 			strings.HasPrefix(p, "/r/") {
 			// These paths should have been handled by other handlers

--- a/dashboard/frontend/src/pages/PlaygroundPage.tsx
+++ b/dashboard/frontend/src/pages/PlaygroundPage.tsx
@@ -1,60 +1,15 @@
-import React, { useState, useEffect } from 'react'
 import styles from './PlaygroundPage.module.css'
 
-const PlaygroundPage: React.FC = () => {
-  // Detect OpenWebUI URL based on current hostname
-  const getOpenWebUIUrl = () => {
-    const hostname = window.location.hostname
-    const protocol = window.location.protocol
-
-    // Build-time configurable port (e.g., for All-in-One deployment)
-    const configuredPort = import.meta.env.VITE_OPENWEBUI_PORT
-    if (configuredPort) {
-      return `${protocol}//${hostname}:${configuredPort}`
-    }
-
-    // Assumes openwebui and dashboard have matching hostname patterns
-    const openwebuiHost = hostname.replace('dashboard', 'openwebui')
-    if (openwebuiHost === hostname) {
-      // hostname doesn't contain 'dashboard', cannot determine Open WebUI URL
-      return ''
-    }
-    return `${protocol}//${openwebuiHost}`
-  }
-
-  const [openWebUIUrl] = useState(() => getOpenWebUIUrl())
-  const [currentUrl, setCurrentUrl] = useState('')
-
-  // Auto-load on mount
-  useEffect(() => {
-    // Default to loading the configured URL on mount
-    setCurrentUrl(openWebUIUrl)
-  }, [openWebUIUrl]) // Load when URL changes
-
+const PlaygroundPage = () => {
   return (
     <div className={styles.container}>
       <div className={styles.iframeContainer}>
-        {!currentUrl && (
-          <div className={styles.placeholder}>
-            <span className={styles.placeholderIcon}>🎮</span>
-            <h3>Open WebUI Playground</h3>
-            <p>
-              Test your LLM models and semantic routing with Open WebUI.
-            </p>
-            <p className={styles.note}>
-              If unable to load, please check Open WebUI deployment and port configuration.
-            </p>
-          </div>
-        )}
-
-        {currentUrl && (
           <iframe
-            src={currentUrl}
+          src="/embedded/openwebui/"
             className={styles.iframe}
             title="Open WebUI Playground"
             allowFullScreen
           />
-        )}
       </div>
     </div>
   )

--- a/dashboard/frontend/src/vite-env.d.ts
+++ b/dashboard/frontend/src/vite-env.d.ts
@@ -1,13 +1,5 @@
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly VITE_OPENWEBUI_PORT?: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-
 declare module "*.module.css" {
   const classes: { [key: string]: string };
   export default classes;


### PR DESCRIPTION
## Fix bug: Dashboard Playground Tab Connection Failure 
#849 

Fixes the Playground tab connection issue where OpenWebUI fails to load, showing "localhost refused to connect" error. The fix ensures the Playground tab uses the backend proxy route instead of constructing direct URLs, enabling proper static asset loading and API routing.

## Problem

The Playground tab was attempting to connect directly to OpenWebUI by constructing URLs based on hostname patterns (e.g., replacing 'dashboard' with 'openwebui'). This approach had several issues:

1. **Connection failures**: Direct URLs bypass the backend proxy, causing CORS and connection issues
2. **Static asset loading failures**: OpenWebUI's static assets (`/static/`, `/_app/`) were not being proxied, resulting in 404 errors
3. **API routing issues**: OpenWebUI API endpoints (e.g., `/api/config`) were not routed correctly
4. **Backend detection error**: OpenWebUI detected iframe embedding and showed "Open WebUI Backend Required" error
5. **Deployment incompatibility**: The hostname-based URL construction doesn't work reliably across different deployment scenarios (Docker, Kubernetes, local dev)

## Solution

### Frontend Changes
- **Changed iframe source**: Updated `PlaygroundPage.tsx` to use the backend proxy route `/embedded/openwebui/` instead of constructing direct URLs
- **Simplified component**: Removed unnecessary URL construction logic and state management

### Backend Changes

1. **Added OpenWebUI static asset handlers**:
   - Implemented `/static/` handler with referer-based routing to handle conflicts between Jaeger and OpenWebUI (both use `/static/`)
   - Implemented `/_app/` handler with referer-based routing to handle conflicts between OpenWebUI and ChatUI (both use `/_app/`)

2. **Added OpenWebUI API routing**:
   - Updated `/api/` router to prioritize OpenWebUI API endpoints (`/api/config`) based on path patterns or referer header
   - Ensures OpenWebUI API calls are routed correctly instead of falling through to other services
   - `/api/config` is used for OpenWebUI configuration

3. **Added X-Forwarded-* headers**:
   - Added `X-Forwarded-Host`, `X-Forwarded-Proto`, and `X-Forwarded-For` headers in the proxy
   - Makes OpenWebUI think it's being served directly from the backend, fixing the "Backend Required" error

4. **Updated static file server**:
   - Added `/static/` to the exclusion list to prevent the static file server from attempting to serve proxy routes

## Changes Made

### Files Modified
- `dashboard/frontend/src/pages/PlaygroundPage.tsx` - Changed iframe src to use backend proxy route
- `dashboard/backend/router/router.go` - Added OpenWebUI static asset handlers and API routing
- `dashboard/backend/proxy/proxy.go` - Added X-Forwarded-* headers for backend detection
- `dashboard/backend/handlers/static.go` - Added `/static/` to exclusion list

## Testing

✅ **Verified the fix works:**
- Playground tab loads OpenWebUI successfully
- All static assets (JS, CSS, images) load correctly
- OpenWebUI API endpoints work properly
- No "Backend Required" error
- Works with `quickstart.sh` script

✅ **Tested compatibility:**
- Jaeger `/static/` assets still work correctly (referer-based routing)
- ChatUI `/_app/` assets still work correctly (referer-based routing)
- Other dashboard tabs (Monitoring, Config, Tracing) continue to work
