### PR TITLE
[Feat]: add upstream request span and trace context propagation for distributed tracing

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -76,6 +76,7 @@ type RequestContext struct {
 
 	// Tracing context
 	TraceContext context.Context // OpenTelemetry trace context for span propagation
+	UpstreamSpan trace.Span      // Span for tracking upstream vLLM request duration
 
 	// Response API context
 	ResponseAPICtx *ResponseAPIContext // Non-nil if this is a Response API request


### PR DESCRIPTION

This change implements the `semantic_router.upstream.request` span that was previously defined but never used. The span tracks the full lifecycle of requests forwarded to vLLM backends, starting when the routing decision is made and ending when response headers are received. Key attributes including model name, endpoint address, and HTTP status code are recorded on the span.

Additionally, this change enables distributed trace correlation between the semantic router and vLLM by injecting W3C Trace Context headers https://www.w3.org/TR/trace-context/ (traceparent, tracestate) into upstream requests.


An example trace screenshot is 

<img width="1598" height="625" alt="image" src="https://github.com/user-attachments/assets/175a461c-67aa-48d7-af4b-c3eabd6795d2" />

with corresponding config

```
server:
  port: 50051
  http_port: 8080
  metrics_port: 9190

# Embedding model for semantic cache and classification
bert_model:
  model_id: models/all-MiniLM-L12-v2
  threshold: 0.6
  use_cpu: true

# vLLM Endpoints
vllm_endpoints:
  - name: "local-gpu"
    address: "127.0.0.1"
    port: 8000
    weight: 1

# Model configuration
model_config:
  "auto":
    preferred_endpoints: ["local-gpu"]
  "Qwen/Qwen2.5-7B-Instruct":
    reasoning_family: "qwen3"
    preferred_endpoints: ["local-gpu"]

# Classifier - enables classification span
classifier:
  category_model:
    model_id: "models/category_classifier_modernbert-base_model"
    threshold: 0.6
    use_cpu: true
    category_mapping_path: "models/category_classifier_modernbert-base_model/category_mapping.json"
  pii_model:
    model_id: "models/pii_classifier_modernbert-base_presidio_token_model"
    use_modernbert: false
    threshold: 0.7
    use_cpu: true
    pii_mapping_path: "models/pii_classifier_modernbert-base_presidio_token_model/pii_type_mapping.json"

# Prompt Guard - enables jailbreak_detection span
prompt_guard:
  enabled: true
  use_modernbert: false
  model_id: "models/lora_jailbreak_classifier_bert-base-uncased_model"
  threshold: 0.7
  use_cpu: true
  jailbreak_mapping_path: "models/lora_jailbreak_classifier_bert-base-uncased_model/jailbreak_type_mapping.json"

# Semantic Cache - enables cache.lookup span
semantic_cache:
  enabled: true
  backend_type: "memory"
  similarity_threshold: 0.8
  max_entries: 1000
  ttl_seconds: 3600
  eviction_policy: "fifo"
  use_hnsw: true
  hnsw_m: 16
  hnsw_ef_construction: 200
  embedding_model: "bert"

# Categories for classification
categories:
  - name: math
    description: "Mathematics and quantitative reasoning"
    mmlu_categories: ["math"]
  - name: computer_science
    description: "Computer science and programming"
    mmlu_categories: ["computer_science"]
  - name: other
    description: "General knowledge and miscellaneous topics"
    mmlu_categories: ["other"]

# Decisions - enables routing.decision and system_prompt.injection spans
strategy: "priority"
decisions:
  - name: "math_decision"
    description: "Mathematics and quantitative reasoning"
    priority: 100
    rules:
      operator: "AND"
      conditions:
        - type: "domain"
          name: "math"
    modelRefs:
      - model: "Qwen/Qwen2.5-7B-Instruct"
        use_reasoning: true
    plugins:
      - type: "system_prompt"
        configuration:
          system_prompt: "You are a mathematics expert. Provide step-by-step solutions."
      - type: "pii"
        configuration:
          enabled: true
          pii_types_allowed: []
      - type: "semantic-cache"
        configuration:
          enabled: true
          similarity_threshold: 0.85

  - name: "cs_decision"
    description: "Computer science and programming"
    priority: 100
    rules:
      operator: "AND"
      conditions:
        - type: "domain"
          name: "computer_science"
    modelRefs:
      - model: "Qwen/Qwen2.5-7B-Instruct"
        use_reasoning: false
    plugins:
      - type: "system_prompt"
        configuration:
          system_prompt: "You are a computer science expert. Provide clear code examples."
      - type: "pii"
        configuration:
          enabled: true
          pii_types_allowed: []

  - name: "general_decision"
    description: "General knowledge fallback"
    priority: 50
    rules:
      operator: "AND"
      conditions:
        - type: "domain"
          name: "other"
    modelRefs:
      - model: "Qwen/Qwen2.5-7B-Instruct"
        use_reasoning: false
    plugins:
      - type: "system_prompt"
        configuration:
          system_prompt: "You are a helpful assistant."
      - type: "semantic-cache"
        configuration:
          enabled: true
          similarity_threshold: 0.75

default_model: "Qwen/Qwen2.5-7B-Instruct"

# Reasoning family configuration
reasoning_families:
  qwen3:
    type: "chat_template_kwargs"
    parameter: "enable_thinking"

default_reasoning_effort: high

# Observability - all tracing enabled
observability:
  metrics:
    enabled: true
  tracing:
    enabled: true
    provider: "opentelemetry"
    exporter:
      type: "otlp"
      endpoint: "localhost:4317"
      insecure: true
    sampling:
      type: "always_on"
      rate: 1.0
    resource:
      service_name: "semantic-router"
      service_version: "demo"
      deployment_environment: "local"
```

Note that the vLLM engine side should have OTEL enabled.

```
OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317 \
OTEL_SERVICE_NAME=vllm \
python -m vllm.entrypoints.openai.api_server \
--model Qwen/Qwen2.5-7B-Instruct \
--otlp-traces-endpoint http://localhost:4317
```


FIX #853 https://github.com/vllm-project/semantic-router/issues/853

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/semantic-router/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to semantic-router! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>
