### PR TITLE
feat: Fix Playground admin signup: proxy OpenWebUI /workspace+/auth and route /api/v1 via dashboard

### DIFF
--- a/dashboard/frontend/src/pages/PlaygroundPage.tsx
+++ b/dashboard/frontend/src/pages/PlaygroundPage.tsx
@@ -5,7 +5,7 @@ const PlaygroundPage = () => {
     <div className={styles.container}>
       <div className={styles.iframeContainer}>
           <iframe
-          src="/embedded/openwebui/"
+          src="/workspace"
             className={styles.iframe}
             title="Open WebUI Playground"
             allowFullScreen


### PR DESCRIPTION
## Context
This PR is follow-up work for [Issue #849](https://github.com/vllm-project/semantic-router/issues/849) and builds on the previously-merged fix in [PR #850](https://github.com/vllm-project/semantic-router/pull/850).

After pulling #850, testing showed a remaining issue: clicking **Create Admin Account** consistently fails with a **500** on the **`/signup`** API.

## Root cause
OpenWebUI is not fully base-path aware when embedded. In the Playground flow it navigates and/or calls root paths (e.g. `/workspace`, `/auth`) and related OpenWebUI APIs. Without explicit dashboard backend routing for these root routes + OpenWebUI API endpoints, requests can fall through to the dashboard SPA or a different upstream, resulting in broken signup/admin creation.

## Fix
- **Frontend**: Load OpenWebUI in the Playground iframe via a real OpenWebUI root route (`/workspace`) rather than a base-path mount.
- **Dashboard backend**:
  - Proxy OpenWebUI root UI routes needed by the embed (`/workspace`, `/auth`) to OpenWebUI.
  - Route OpenWebUI API requests by path (`/api/v1/*` and `/api/config`) to OpenWebUI even when the Referer is a root route like `/workspace`.
  - Preserve `Authorization` headers when proxying OpenWebUI (forward auth) so authenticated/signup flows work correctly.

## Testing
- ✅ `http://localhost:8700/playground` loads OpenWebUI correctly.
- ✅ **Create Admin Account** no longer returns 500 and proceeds as expected.

## Files changed
- `semantic-router/dashboard/frontend/src/pages/PlaygroundPage.tsx`
- `semantic-router/dashboard/backend/router/router.go`