### PR TITLE
feat(scoring): add dynamic model scoring system

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -495,6 +495,33 @@ embedding_models:
 observability:
   metrics:
     enabled: true  # Set to false to disable the Prometheus /metrics endpoint
+    # Windowed metrics for load balancing and scoring
+    windowed_metrics:
+      enabled: true
+      time_windows: ["1m", "5m", "15m"]
+      update_interval: "10s"
+      model_metrics: true
+      queue_depth_estimation: true
+      max_models: 100
+    # Dynamic Model Scoring Configuration
+    # Enables online model score updates based on accuracy, latency, and cost metrics
+    # Scores are auto-updated and used for intelligent model selection
+    dynamic_scoring:
+      enabled: true                    # Enable dynamic scoring
+      time_window: "5m"                # Time window for score computation
+      update_interval: "30s"           # How often to recompute scores
+      min_samples: 10                  # Minimum samples before scoring kicks in
+      default_score: 0.5               # Score for models with insufficient data
+      decay_factor: 0.1                # EMA decay (higher = more weight on recent data)
+      weights:                         # Component weights (must sum to 1.0)
+        accuracy: 0.5                  # Weight for accuracy (1 - error_rate)
+        latency: 0.3                   # Weight for latency score
+        cost: 0.2                      # Weight for cost score
+      normalization:                   # How to normalize raw metrics to 0-1 scale
+        latency_target: 1.0            # Target latency in seconds (scores ~0.5)
+        latency_max: 10.0              # Max acceptable latency (scores 0.0)
+        cost_target: 0.01              # Target cost per 1K tokens (scores ~0.5)
+        cost_max: 0.1                  # Max acceptable cost per 1K tokens (scores 0.0)
   tracing:
     enabled: true  # Enable distributed tracing for docker-compose stack
     provider: "opentelemetry"  # Provider: opentelemetry, openinference, openllmetry

--- a/src/semantic-router/cmd/main.go
+++ b/src/semantic-router/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/tracing"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/scoring"
 )
 
 func main() {
@@ -113,6 +114,17 @@ func main() {
 		} else {
 			logging.Infof("Windowed metrics initialized successfully")
 		}
+	}
+
+	// Initialize dynamic model scoring if enabled
+	if cfg.Observability.Metrics.DynamicScoring.Enabled {
+		logging.Infof("Initializing dynamic model scoring...")
+		if initErr := scoring.InitializeDynamicScoring(cfg.Observability.Metrics.DynamicScoring); initErr != nil {
+			logging.Warnf("Failed to initialize dynamic scoring: %v", initErr)
+		} else {
+			logging.Infof("Dynamic model scoring initialized successfully")
+		}
+		defer scoring.StopDynamicScoring()
 	}
 
 	// Set up signal handling for graceful shutdown

--- a/src/semantic-router/pkg/classification/classifier.go
+++ b/src/semantic-router/pkg/classification/classifier.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/decision"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/scoring"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/entropy"
 )
 
@@ -1302,25 +1303,48 @@ func (c *Classifier) translateMMLUToGeneric(mmluCategory string) string {
 //
 // modelFilter is optional - if provided, only models passing the filter will be considered
 func (c *Classifier) selectBestModelInternalForDecision(decision *config.Decision, modelFilter func(string) bool) (string, float64) {
-	bestModel := ""
+	if len(decision.ModelRefs) == 0 {
+		return "", 0
+	}
 
-	// With new architecture, we only support one model per decision (first ModelRef)
-	if len(decision.ModelRefs) > 0 {
-		modelRef := decision.ModelRefs[0]
+	// Build list of candidate models
+	candidates := make([]string, 0, len(decision.ModelRefs))
+	modelToLoRA := make(map[string]string) // Map model name to LoRA name if specified
+
+	for _, modelRef := range decision.ModelRefs {
 		model := modelRef.Model
+		if modelFilter != nil && !modelFilter(model) {
+			continue
+		}
+		// Use LoRA name if specified, otherwise use the base model name
+		finalModelName := model
+		if modelRef.LoRAName != "" {
+			finalModelName = modelRef.LoRAName
+			modelToLoRA[finalModelName] = modelRef.LoRAName
+		}
+		candidates = append(candidates, finalModelName)
+	}
 
-		if modelFilter == nil || modelFilter(model) {
-			// Use LoRA name if specified, otherwise use the base model name
-			finalModelName := model
-			if modelRef.LoRAName != "" {
-				finalModelName = modelRef.LoRAName
-				logging.Debugf("Using LoRA adapter '%s' for base model '%s'", finalModelName, model)
-			}
-			bestModel = finalModelName
+	if len(candidates) == 0 {
+		return "", 0
+	}
+
+	// If only one candidate, return it directly
+	if len(candidates) == 1 {
+		return candidates[0], 1.0
+	}
+
+	// If dynamic scoring is enabled, use it to select the best model
+	if scoring.IsDynamicScoringEnabled() {
+		bestModel, bestScore := scoring.SelectBestModelByScore(candidates)
+		if bestModel != "" {
+			logging.Debugf("Dynamic scoring selected model '%s' with score %.4f", bestModel, bestScore)
+			return bestModel, bestScore
 		}
 	}
 
-	return bestModel, 1.0 // Return score 1.0 since we don't have scores anymore
+	// Fallback: return the first candidate (original behavior)
+	return candidates[0], 1.0
 }
 
 // SelectBestModelFromList selects the best model from a list of candidate models for a given decision

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -354,6 +354,75 @@ type MetricsConfig struct {
 
 	// Enable windowed metrics collection for load balancing
 	WindowedMetrics WindowedMetricsConfig `yaml:"windowed_metrics"`
+
+	// Dynamic model scoring configuration
+	DynamicScoring DynamicScoringConfig `yaml:"dynamic_scoring"`
+}
+
+// DynamicScoringConfig configures the dynamic model scoring system
+// This enables online model score updates based on accuracy, latency, and cost metrics
+type DynamicScoringConfig struct {
+	// Enabled enables dynamic scoring
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// TimeWindow specifies the time window for score computation (e.g., "5m", "1h")
+	// Default: "5m"
+	TimeWindow string `yaml:"time_window,omitempty" json:"time_window,omitempty"`
+
+	// UpdateInterval specifies how often scores are recomputed
+	// Default: "30s"
+	UpdateInterval string `yaml:"update_interval,omitempty" json:"update_interval,omitempty"`
+
+	// Weights for combining component scores (must sum to 1.0)
+	Weights ScoringWeights `yaml:"weights" json:"weights"`
+
+	// Normalization settings for each component
+	Normalization ScoringNormalization `yaml:"normalization" json:"normalization"`
+
+	// MinSamples is the minimum number of samples required before dynamic scoring is used
+	// Below this threshold, the default score is used
+	// Default: 10
+	MinSamples int `yaml:"min_samples,omitempty" json:"min_samples,omitempty"`
+
+	// DefaultScore is used when there's insufficient data for a model
+	// Default: 0.5
+	DefaultScore float64 `yaml:"default_score,omitempty" json:"default_score,omitempty"`
+
+	// DecayFactor for exponential moving average (0.0-1.0)
+	// Higher values give more weight to recent data
+	// Default: 0.1
+	DecayFactor float64 `yaml:"decay_factor,omitempty" json:"decay_factor,omitempty"`
+}
+
+// ScoringWeights defines the weights for combining score components
+type ScoringWeights struct {
+	// Accuracy weight (based on success rate, 1 - error_rate)
+	Accuracy float64 `yaml:"accuracy" json:"accuracy"`
+
+	// Latency weight (lower is better, normalized)
+	Latency float64 `yaml:"latency" json:"latency"`
+
+	// Cost weight (lower is better, normalized)
+	Cost float64 `yaml:"cost" json:"cost"`
+}
+
+// ScoringNormalization configures how raw metrics are normalized to 0-1 scale
+type ScoringNormalization struct {
+	// LatencyTarget is the target latency in seconds (scores 0.5 at target)
+	// Default: 1.0
+	LatencyTarget float64 `yaml:"latency_target,omitempty" json:"latency_target,omitempty"`
+
+	// LatencyMax is the maximum acceptable latency (scores 0.0 at or above)
+	// Default: 10.0
+	LatencyMax float64 `yaml:"latency_max,omitempty" json:"latency_max,omitempty"`
+
+	// CostTarget is the target cost per 1K tokens in USD (scores 0.5 at target)
+	// Default: 0.01
+	CostTarget float64 `yaml:"cost_target,omitempty" json:"cost_target,omitempty"`
+
+	// CostMax is the maximum acceptable cost per 1K tokens (scores 0.0 at or above)
+	// Default: 0.1
+	CostMax float64 `yaml:"cost_max,omitempty" json:"cost_max,omitempty"`
 }
 
 // WindowedMetricsConfig represents configuration for time-windowed metrics

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/scoring"
 )
 
 // handleResponseBody processes the response body
@@ -82,10 +83,11 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 		)
 
 		// Compute and record cost if pricing is configured
+		var costAmount float64
 		if r.Config != nil {
 			promptRatePer1M, completionRatePer1M, currency, ok := r.Config.GetModelPricing(ctx.RequestModel)
 			if ok {
-				costAmount := (float64(promptTokens)*promptRatePer1M + float64(completionTokens)*completionRatePer1M) / 1_000_000.0
+				costAmount = (float64(promptTokens)*promptRatePer1M + float64(completionTokens)*completionRatePer1M) / 1_000_000.0
 				if currency == "" {
 					currency = "USD"
 				}
@@ -114,6 +116,16 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 				})
 			}
 		}
+
+		// Record metrics for dynamic model scoring
+		scoring.RecordModelRequest(
+			ctx.RequestModel,
+			completionLatency.Seconds(),
+			int64(promptTokens),
+			int64(completionTokens),
+			false, // isError - successful response
+			costAmount,
+		)
 	}
 
 	// Update the cache

--- a/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
@@ -40,6 +40,13 @@ hallucination_mitigation:
     model_id: ""
     threshold: 0
     use_cpu: false
+feedback_detector:
+  enabled: false
+  model_id: ""
+  threshold: 0
+  use_cpu: false
+  use_modernbert: false
+  feedback_mapping_path: ""
 semantic_cache:
   backend_type: memory
   enabled: true
@@ -70,6 +77,13 @@ observability:
       enabled: false
       model_metrics: false
       queue_depth_estimation: false
+    dynamic_scoring:
+      enabled: false
+      weights:
+        accuracy: 0
+        latency: 0
+        cost: 0
+      normalization: {}
 api:
   batch_classification:
     metrics:

--- a/src/semantic-router/pkg/scoring/global.go
+++ b/src/semantic-router/pkg/scoring/global.go
@@ -1,0 +1,119 @@
+package scoring
+
+import (
+	"sync"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// Global scorer instance
+var (
+	globalScorer      *DynamicScorer
+	globalScorerMutex sync.RWMutex
+)
+
+// InitializeDynamicScoring initializes the global dynamic scoring system
+func InitializeDynamicScoring(cfg config.DynamicScoringConfig) error {
+	if !cfg.Enabled {
+		logging.Infof("Dynamic scoring is disabled")
+		return nil
+	}
+
+	// Initialize metrics provider first
+	maxModels := 100
+	InitializeMetricsProvider(maxModels)
+	provider := GetMetricsProvider()
+
+	// Convert config types to scoring types
+	scoringConfig := DynamicScoringConfig{
+		Enabled:        cfg.Enabled,
+		TimeWindow:     cfg.TimeWindow,
+		UpdateInterval: cfg.UpdateInterval,
+		MinSamples:     cfg.MinSamples,
+		DefaultScore:   cfg.DefaultScore,
+		DecayFactor:    cfg.DecayFactor,
+		Weights: ScoreWeights{
+			Accuracy: cfg.Weights.Accuracy,
+			Latency:  cfg.Weights.Latency,
+			Cost:     cfg.Weights.Cost,
+		},
+		Normalization: NormalizationConfig{
+			LatencyTarget: cfg.Normalization.LatencyTarget,
+			LatencyMax:    cfg.Normalization.LatencyMax,
+			CostTarget:    cfg.Normalization.CostTarget,
+			CostMax:       cfg.Normalization.CostMax,
+		},
+	}
+
+	scorer, err := NewDynamicScorer(scoringConfig, provider)
+	if err != nil {
+		return err
+	}
+
+	globalScorerMutex.Lock()
+	globalScorer = scorer
+	globalScorerMutex.Unlock()
+
+	scorer.Start()
+	logging.Infof("Dynamic scoring initialized and started")
+
+	return nil
+}
+
+// GetDynamicScorer returns the global dynamic scorer
+func GetDynamicScorer() *DynamicScorer {
+	globalScorerMutex.RLock()
+	defer globalScorerMutex.RUnlock()
+	return globalScorer
+}
+
+// IsDynamicScoringEnabled returns whether dynamic scoring is enabled and running
+func IsDynamicScoringEnabled() bool {
+	globalScorerMutex.RLock()
+	scorer := globalScorer
+	globalScorerMutex.RUnlock()
+	return scorer != nil && scorer.IsEnabled()
+}
+
+// GetDynamicScore returns the dynamic score for a model
+// Returns the default score if scoring is not enabled or model is unknown
+func GetDynamicScore(model string) float64 {
+	globalScorerMutex.RLock()
+	scorer := globalScorer
+	globalScorerMutex.RUnlock()
+
+	if scorer == nil {
+		return 0.5 // Default score
+	}
+
+	score, _ := scorer.GetScore(model)
+	return score
+}
+
+// SelectBestModelByScore returns the model with the highest dynamic score from candidates
+func SelectBestModelByScore(candidates []string) (string, float64) {
+	globalScorerMutex.RLock()
+	scorer := globalScorer
+	globalScorerMutex.RUnlock()
+
+	if scorer == nil || len(candidates) == 0 {
+		if len(candidates) > 0 {
+			return candidates[0], 0.5
+		}
+		return "", 0
+	}
+
+	return scorer.GetBestModel(candidates)
+}
+
+// StopDynamicScoring stops the global scoring system
+func StopDynamicScoring() {
+	globalScorerMutex.Lock()
+	defer globalScorerMutex.Unlock()
+
+	if globalScorer != nil {
+		globalScorer.Stop()
+		globalScorer = nil
+	}
+}

--- a/src/semantic-router/pkg/scoring/metrics_provider.go
+++ b/src/semantic-router/pkg/scoring/metrics_provider.go
@@ -1,0 +1,319 @@
+package scoring
+
+import (
+	"sync"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// WindowedMetricsProvider implements MetricsProvider using the windowed metrics system
+type WindowedMetricsProvider struct {
+	// costTracker tracks per-model cost data
+	costTracker map[string]*CostData
+	costMutex   sync.RWMutex
+
+	// requestTracker tracks per-model request data for scoring
+	requestTracker map[string]*RequestTracker
+	trackerMutex   sync.RWMutex
+
+	// maxModels limits tracked models to prevent memory issues
+	maxModels int
+}
+
+// CostData tracks cost information for a model
+type CostData struct {
+	TotalCost   float64
+	TotalTokens int64
+	LastUpdated time.Time
+}
+
+// RequestTracker tracks request metrics for scoring within a time window
+type RequestTracker struct {
+	// Ring buffer for request data
+	requests []RequestRecord
+	head     int
+	size     int
+	capacity int
+	mutex    sync.RWMutex
+}
+
+// RequestRecord represents a single request's metrics
+type RequestRecord struct {
+	Timestamp        time.Time
+	LatencySeconds   float64
+	PromptTokens     int64
+	CompletionTokens int64
+	IsError          bool
+	Cost             float64
+}
+
+// NewWindowedMetricsProvider creates a new provider
+func NewWindowedMetricsProvider(maxModels int) *WindowedMetricsProvider {
+	if maxModels <= 0 {
+		maxModels = 100
+	}
+	return &WindowedMetricsProvider{
+		costTracker:    make(map[string]*CostData),
+		requestTracker: make(map[string]*RequestTracker),
+		maxModels:      maxModels,
+	}
+}
+
+// RecordRequest records a request for metrics tracking
+func (p *WindowedMetricsProvider) RecordRequest(model string, latencySeconds float64, promptTokens, completionTokens int64, isError bool, cost float64) {
+	p.trackerMutex.Lock()
+	tracker, exists := p.requestTracker[model]
+	if !exists {
+		if len(p.requestTracker) >= p.maxModels {
+			p.trackerMutex.Unlock()
+			return
+		}
+		tracker = newRequestTracker(10000) // 10k capacity per model
+		p.requestTracker[model] = tracker
+	}
+	p.trackerMutex.Unlock()
+
+	record := RequestRecord{
+		Timestamp:        time.Now(),
+		LatencySeconds:   latencySeconds,
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		IsError:          isError,
+		Cost:             cost,
+	}
+	tracker.add(record)
+
+	// Update cost tracking
+	p.costMutex.Lock()
+	if cd, ok := p.costTracker[model]; ok {
+		cd.TotalCost += cost
+		cd.TotalTokens += promptTokens + completionTokens
+		cd.LastUpdated = time.Now()
+	} else if len(p.costTracker) < p.maxModels {
+		p.costTracker[model] = &CostData{
+			TotalCost:   cost,
+			TotalTokens: promptTokens + completionTokens,
+			LastUpdated: time.Now(),
+		}
+	}
+	p.costMutex.Unlock()
+}
+
+// GetModelMetrics returns metrics for a specific model over the given time window
+func (p *WindowedMetricsProvider) GetModelMetrics(model string, window time.Duration) (ModelMetrics, error) {
+	p.trackerMutex.RLock()
+	tracker, exists := p.requestTracker[model]
+	p.trackerMutex.RUnlock()
+
+	if !exists {
+		return ModelMetrics{}, nil
+	}
+
+	since := time.Now().Add(-window)
+	records := tracker.getRecordsSince(since)
+
+	return p.computeMetrics(model, records), nil
+}
+
+// GetAllModelMetrics returns metrics for all tracked models
+func (p *WindowedMetricsProvider) GetAllModelMetrics(window time.Duration) (map[string]ModelMetrics, error) {
+	p.trackerMutex.RLock()
+	models := make([]string, 0, len(p.requestTracker))
+	for model := range p.requestTracker {
+		models = append(models, model)
+	}
+	p.trackerMutex.RUnlock()
+
+	result := make(map[string]ModelMetrics, len(models))
+	since := time.Now().Add(-window)
+
+	for _, model := range models {
+		p.trackerMutex.RLock()
+		tracker := p.requestTracker[model]
+		p.trackerMutex.RUnlock()
+
+		if tracker != nil {
+			records := tracker.getRecordsSince(since)
+			if len(records) > 0 {
+				result[model] = p.computeMetrics(model, records)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// computeMetrics computes ModelMetrics from request records
+func (p *WindowedMetricsProvider) computeMetrics(model string, records []RequestRecord) ModelMetrics {
+	if len(records) == 0 {
+		return ModelMetrics{}
+	}
+
+	var totalLatency float64
+	var totalTokens int64
+	var totalCost float64
+	var errorCount int
+
+	latencies := make([]float64, 0, len(records))
+
+	for _, r := range records {
+		totalLatency += r.LatencySeconds
+		totalTokens += r.PromptTokens + r.CompletionTokens
+		totalCost += r.Cost
+		latencies = append(latencies, r.LatencySeconds)
+		if r.IsError {
+			errorCount++
+		}
+	}
+
+	requestCount := len(records)
+	avgLatency := totalLatency / float64(requestCount)
+	errorRate := float64(errorCount) / float64(requestCount)
+
+	// Compute P95 latency
+	p95Latency := computePercentile(latencies, 0.95)
+
+	// Compute cost per 1K tokens
+	var costPerKTokens float64
+	if totalTokens > 0 {
+		costPerKTokens = (totalCost / float64(totalTokens)) * 1000
+	}
+
+	return ModelMetrics{
+		RequestCount:      requestCount,
+		ErrorCount:        errorCount,
+		ErrorRate:         errorRate,
+		AvgLatencySeconds: avgLatency,
+		P95LatencySeconds: p95Latency,
+		TotalTokens:       totalTokens,
+		TotalCost:         totalCost,
+		CostPerKTokens:    costPerKTokens,
+	}
+}
+
+// Helper functions for RequestTracker
+
+func newRequestTracker(capacity int) *RequestTracker {
+	return &RequestTracker{
+		requests: make([]RequestRecord, capacity),
+		capacity: capacity,
+	}
+}
+
+func (rt *RequestTracker) add(record RequestRecord) {
+	rt.mutex.Lock()
+	defer rt.mutex.Unlock()
+
+	rt.requests[rt.head] = record
+	rt.head = (rt.head + 1) % rt.capacity
+	if rt.size < rt.capacity {
+		rt.size++
+	}
+}
+
+func (rt *RequestTracker) getRecordsSince(since time.Time) []RequestRecord {
+	rt.mutex.RLock()
+	defer rt.mutex.RUnlock()
+
+	result := make([]RequestRecord, 0, rt.size)
+	for i := 0; i < rt.size; i++ {
+		idx := (rt.head - rt.size + i + rt.capacity) % rt.capacity
+		if !rt.requests[idx].Timestamp.Before(since) {
+			result = append(result, rt.requests[idx])
+		}
+	}
+	return result
+}
+
+// computePercentile computes the given percentile from a slice of values
+func computePercentile(values []float64, percentile float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+
+	// Copy and sort
+	sorted := make([]float64, len(values))
+	copy(sorted, values)
+	sortFloat64s(sorted)
+
+	// Calculate index
+	index := percentile * float64(len(sorted)-1)
+	lower := int(index)
+	upper := lower + 1
+
+	if upper >= len(sorted) {
+		return sorted[len(sorted)-1]
+	}
+
+	// Linear interpolation
+	weight := index - float64(lower)
+	return sorted[lower]*(1-weight) + sorted[upper]*weight
+}
+
+// sortFloat64s sorts a slice of float64 in ascending order
+func sortFloat64s(a []float64) {
+	if len(a) < 12 {
+		// Insertion sort for small slices
+		for i := 1; i < len(a); i++ {
+			for j := i; j > 0 && a[j] < a[j-1]; j-- {
+				a[j], a[j-1] = a[j-1], a[j]
+			}
+		}
+		return
+	}
+	quickSort(a, 0, len(a)-1)
+}
+
+func quickSort(a []float64, low, high int) {
+	if low < high {
+		p := partition(a, low, high)
+		quickSort(a, low, p-1)
+		quickSort(a, p+1, high)
+	}
+}
+
+func partition(a []float64, low, high int) int {
+	pivot := a[high]
+	i := low - 1
+	for j := low; j < high; j++ {
+		if a[j] <= pivot {
+			i++
+			a[i], a[j] = a[j], a[i]
+		}
+	}
+	a[i+1], a[high] = a[high], a[i+1]
+	return i + 1
+}
+
+// Global metrics provider instance
+var (
+	globalMetricsProvider      *WindowedMetricsProvider
+	globalMetricsProviderMutex sync.RWMutex
+)
+
+// InitializeMetricsProvider initializes the global metrics provider
+func InitializeMetricsProvider(maxModels int) {
+	globalMetricsProviderMutex.Lock()
+	defer globalMetricsProviderMutex.Unlock()
+	globalMetricsProvider = NewWindowedMetricsProvider(maxModels)
+	logging.Infof("Initialized scoring metrics provider with maxModels=%d", maxModels)
+}
+
+// GetMetricsProvider returns the global metrics provider
+func GetMetricsProvider() *WindowedMetricsProvider {
+	globalMetricsProviderMutex.RLock()
+	defer globalMetricsProviderMutex.RUnlock()
+	return globalMetricsProvider
+}
+
+// RecordModelRequest is a convenience function to record a request to the global provider
+func RecordModelRequest(model string, latencySeconds float64, promptTokens, completionTokens int64, isError bool, cost float64) {
+	globalMetricsProviderMutex.RLock()
+	provider := globalMetricsProvider
+	globalMetricsProviderMutex.RUnlock()
+
+	if provider != nil {
+		provider.RecordRequest(model, latencySeconds, promptTokens, completionTokens, isError, cost)
+	}
+}

--- a/src/semantic-router/pkg/scoring/scorer.go
+++ b/src/semantic-router/pkg/scoring/scorer.go
@@ -1,0 +1,562 @@
+package scoring
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// DynamicScoringConfig configures the dynamic model scoring system
+type DynamicScoringConfig struct {
+	// Enabled enables dynamic scoring
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// TimeWindow specifies the time window for score computation (e.g., "5m", "1h")
+	// Default: "5m"
+	TimeWindow string `yaml:"time_window,omitempty" json:"time_window,omitempty"`
+
+	// UpdateInterval specifies how often scores are recomputed
+	// Default: "30s"
+	UpdateInterval string `yaml:"update_interval,omitempty" json:"update_interval,omitempty"`
+
+	// Weights for combining component scores (must sum to 1.0)
+	Weights ScoreWeights `yaml:"weights" json:"weights"`
+
+	// Normalization settings for each component
+	Normalization NormalizationConfig `yaml:"normalization" json:"normalization"`
+
+	// MinSamples is the minimum number of samples required before dynamic scoring is used
+	// Below this threshold, the default score is used
+	// Default: 10
+	MinSamples int `yaml:"min_samples,omitempty" json:"min_samples,omitempty"`
+
+	// DefaultScore is used when there's insufficient data for a model
+	// Default: 0.5
+	DefaultScore float64 `yaml:"default_score,omitempty" json:"default_score,omitempty"`
+
+	// DecayFactor for exponential moving average (0.0-1.0)
+	// Higher values give more weight to recent data
+	// Default: 0.1
+	DecayFactor float64 `yaml:"decay_factor,omitempty" json:"decay_factor,omitempty"`
+}
+
+// ScoreWeights defines the weights for combining score components
+type ScoreWeights struct {
+	// Accuracy weight (based on success rate, 1 - error_rate)
+	Accuracy float64 `yaml:"accuracy" json:"accuracy"`
+
+	// Latency weight (lower is better, normalized)
+	Latency float64 `yaml:"latency" json:"latency"`
+
+	// Cost weight (lower is better, normalized)
+	Cost float64 `yaml:"cost" json:"cost"`
+}
+
+// NormalizationConfig configures how raw metrics are normalized to 0-1 scale
+type NormalizationConfig struct {
+	// LatencyTarget is the target latency in seconds (scores 0.5 at target)
+	// Default: 1.0
+	LatencyTarget float64 `yaml:"latency_target,omitempty" json:"latency_target,omitempty"`
+
+	// LatencyMax is the maximum acceptable latency (scores 0.0 at or above)
+	// Default: 10.0
+	LatencyMax float64 `yaml:"latency_max,omitempty" json:"latency_max,omitempty"`
+
+	// CostTarget is the target cost per 1K tokens in USD (scores 0.5 at target)
+	// Default: 0.01
+	CostTarget float64 `yaml:"cost_target,omitempty" json:"cost_target,omitempty"`
+
+	// CostMax is the maximum acceptable cost per 1K tokens (scores 0.0 at or above)
+	// Default: 0.1
+	CostMax float64 `yaml:"cost_max,omitempty" json:"cost_max,omitempty"`
+}
+
+// ModelScore represents the computed dynamic score for a model
+type ModelScore struct {
+	// Model is the model identifier
+	Model string `json:"model"`
+
+	// CompositeScore is the final weighted score (0.0-1.0)
+	CompositeScore float64 `json:"composite_score"`
+
+	// ComponentScores contains individual component scores
+	ComponentScores ComponentScores `json:"component_scores"`
+
+	// Metrics contains the raw metrics used for scoring
+	Metrics ModelMetrics `json:"metrics"`
+
+	// SampleCount is the number of samples used for this score
+	SampleCount int `json:"sample_count"`
+
+	// LastUpdated is when this score was last computed
+	LastUpdated time.Time `json:"last_updated"`
+
+	// IsDefault indicates if default score was used due to insufficient data
+	IsDefault bool `json:"is_default"`
+}
+
+// ComponentScores contains individual normalized scores
+type ComponentScores struct {
+	Accuracy float64 `json:"accuracy"`
+	Latency  float64 `json:"latency"`
+	Cost     float64 `json:"cost"`
+}
+
+// ModelMetrics contains raw metrics for a model
+type ModelMetrics struct {
+	// RequestCount is the total number of requests
+	RequestCount int `json:"request_count"`
+
+	// ErrorCount is the number of failed requests
+	ErrorCount int `json:"error_count"`
+
+	// ErrorRate is the ratio of errors to total requests
+	ErrorRate float64 `json:"error_rate"`
+
+	// AvgLatencySeconds is the average response latency
+	AvgLatencySeconds float64 `json:"avg_latency_seconds"`
+
+	// P95LatencySeconds is the 95th percentile latency
+	P95LatencySeconds float64 `json:"p95_latency_seconds"`
+
+	// TotalTokens is the total tokens processed
+	TotalTokens int64 `json:"total_tokens"`
+
+	// TotalCost is the total cost in USD
+	TotalCost float64 `json:"total_cost"`
+
+	// CostPerKTokens is the cost per 1000 tokens
+	CostPerKTokens float64 `json:"cost_per_k_tokens"`
+}
+
+// MetricsProvider is an interface for getting model metrics
+type MetricsProvider interface {
+	// GetModelMetrics returns metrics for a specific model over the given time window
+	GetModelMetrics(model string, window time.Duration) (ModelMetrics, error)
+
+	// GetAllModelMetrics returns metrics for all tracked models
+	GetAllModelMetrics(window time.Duration) (map[string]ModelMetrics, error)
+}
+
+// Prometheus metrics for dynamic scoring
+var (
+	DynamicScoreGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llm_model_dynamic_score",
+			Help: "Dynamic composite score for model selection (0.0-1.0)",
+		},
+		[]string{"model"},
+	)
+
+	AccuracyScoreGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llm_model_accuracy_score",
+			Help: "Accuracy component score (1 - error_rate)",
+		},
+		[]string{"model"},
+	)
+
+	LatencyScoreGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llm_model_latency_score",
+			Help: "Latency component score (normalized, lower latency is higher score)",
+		},
+		[]string{"model"},
+	)
+
+	CostScoreGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "llm_model_cost_score",
+			Help: "Cost component score (normalized, lower cost is higher score)",
+		},
+		[]string{"model"},
+	)
+
+	ScoringUpdateCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llm_model_scoring_updates_total",
+			Help: "Number of scoring update cycles",
+		},
+		[]string{"status"},
+	)
+)
+
+// DynamicScorer computes and maintains dynamic model scores
+type DynamicScorer struct {
+	config          DynamicScoringConfig
+	metricsProvider MetricsProvider
+	timeWindow      time.Duration
+	updateInterval  time.Duration
+
+	// Current scores for all models
+	scores      map[string]*ModelScore
+	scoresMutex sync.RWMutex
+
+	// Exponential moving averages for score smoothing
+	emaScores map[string]float64
+	emaMutex  sync.RWMutex
+
+	// Background update control
+	stopChan     chan struct{}
+	running      bool
+	runningMutex sync.Mutex
+}
+
+// NewDynamicScorer creates a new DynamicScorer
+func NewDynamicScorer(config DynamicScoringConfig, provider MetricsProvider) (*DynamicScorer, error) {
+	// Parse time window
+	timeWindow := 5 * time.Minute
+	if config.TimeWindow != "" {
+		if d, err := time.ParseDuration(config.TimeWindow); err == nil {
+			timeWindow = d
+		}
+	}
+
+	// Parse update interval
+	updateInterval := 30 * time.Second
+	if config.UpdateInterval != "" {
+		if d, err := time.ParseDuration(config.UpdateInterval); err == nil {
+			updateInterval = d
+		}
+	}
+
+	// Apply defaults
+	if config.MinSamples <= 0 {
+		config.MinSamples = 10
+	}
+	if config.DefaultScore <= 0 {
+		config.DefaultScore = 0.5
+	}
+	if config.DecayFactor <= 0 || config.DecayFactor > 1 {
+		config.DecayFactor = 0.1
+	}
+
+	// Apply normalization defaults
+	if config.Normalization.LatencyTarget <= 0 {
+		config.Normalization.LatencyTarget = 1.0
+	}
+	if config.Normalization.LatencyMax <= 0 {
+		config.Normalization.LatencyMax = 10.0
+	}
+	if config.Normalization.CostTarget <= 0 {
+		config.Normalization.CostTarget = 0.01
+	}
+	if config.Normalization.CostMax <= 0 {
+		config.Normalization.CostMax = 0.1
+	}
+
+	// Validate weights sum to 1.0
+	weightsSum := config.Weights.Accuracy + config.Weights.Latency + config.Weights.Cost
+	if weightsSum == 0 {
+		// Default weights: equal distribution
+		config.Weights.Accuracy = 0.5
+		config.Weights.Latency = 0.3
+		config.Weights.Cost = 0.2
+	} else if math.Abs(weightsSum-1.0) > 0.01 {
+		// Normalize weights to sum to 1.0
+		config.Weights.Accuracy /= weightsSum
+		config.Weights.Latency /= weightsSum
+		config.Weights.Cost /= weightsSum
+	}
+
+	return &DynamicScorer{
+		config:          config,
+		metricsProvider: provider,
+		timeWindow:      timeWindow,
+		updateInterval:  updateInterval,
+		scores:          make(map[string]*ModelScore),
+		emaScores:       make(map[string]float64),
+	}, nil
+}
+
+// Start begins the background score update goroutine
+func (s *DynamicScorer) Start() {
+	s.runningMutex.Lock()
+	defer s.runningMutex.Unlock()
+
+	if s.running || !s.config.Enabled {
+		return
+	}
+	s.running = true
+	s.stopChan = make(chan struct{})
+
+	// Initial computation
+	s.updateScores()
+
+	go func() {
+		ticker := time.NewTicker(s.updateInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				s.updateScores()
+			case <-s.stopChan:
+				return
+			}
+		}
+	}()
+
+	logging.Infof("Dynamic scoring started: window=%v, interval=%v, weights={accuracy:%.2f, latency:%.2f, cost:%.2f}",
+		s.timeWindow, s.updateInterval, s.config.Weights.Accuracy, s.config.Weights.Latency, s.config.Weights.Cost)
+}
+
+// Stop stops the background update goroutine
+func (s *DynamicScorer) Stop() {
+	s.runningMutex.Lock()
+	defer s.runningMutex.Unlock()
+
+	if !s.running {
+		return
+	}
+	close(s.stopChan)
+	s.running = false
+}
+
+// GetScore returns the current score for a model
+func (s *DynamicScorer) GetScore(model string) (float64, bool) {
+	s.scoresMutex.RLock()
+	defer s.scoresMutex.RUnlock()
+
+	if score, exists := s.scores[model]; exists {
+		return score.CompositeScore, true
+	}
+	return s.config.DefaultScore, false
+}
+
+// GetModelScore returns the full score details for a model
+func (s *DynamicScorer) GetModelScore(model string) (*ModelScore, bool) {
+	s.scoresMutex.RLock()
+	defer s.scoresMutex.RUnlock()
+
+	if score, exists := s.scores[model]; exists {
+		// Return a copy to prevent modification
+		scoreCopy := *score
+		return &scoreCopy, true
+	}
+	return nil, false
+}
+
+// GetAllScores returns all current model scores
+func (s *DynamicScorer) GetAllScores() map[string]*ModelScore {
+	s.scoresMutex.RLock()
+	defer s.scoresMutex.RUnlock()
+
+	result := make(map[string]*ModelScore, len(s.scores))
+	for k, v := range s.scores {
+		scoreCopy := *v
+		result[k] = &scoreCopy
+	}
+	return result
+}
+
+// GetBestModel returns the model with the highest score from a list of candidates
+func (s *DynamicScorer) GetBestModel(candidates []string) (string, float64) {
+	if len(candidates) == 0 {
+		return "", 0
+	}
+
+	s.scoresMutex.RLock()
+	defer s.scoresMutex.RUnlock()
+
+	bestModel := candidates[0]
+	bestScore := s.config.DefaultScore
+
+	if score, exists := s.scores[bestModel]; exists {
+		bestScore = score.CompositeScore
+	}
+
+	for _, model := range candidates[1:] {
+		modelScore := s.config.DefaultScore
+		if score, exists := s.scores[model]; exists {
+			modelScore = score.CompositeScore
+		}
+		if modelScore > bestScore {
+			bestScore = modelScore
+			bestModel = model
+		}
+	}
+
+	return bestModel, bestScore
+}
+
+// updateScores recomputes scores for all models
+func (s *DynamicScorer) updateScores() {
+	if s.metricsProvider == nil {
+		ScoringUpdateCounter.WithLabelValues("no_provider").Inc()
+		return
+	}
+
+	allMetrics, err := s.metricsProvider.GetAllModelMetrics(s.timeWindow)
+	if err != nil {
+		logging.Errorf("Failed to get model metrics for scoring: %v", err)
+		ScoringUpdateCounter.WithLabelValues("error").Inc()
+		return
+	}
+
+	s.scoresMutex.Lock()
+	defer s.scoresMutex.Unlock()
+
+	now := time.Now()
+	updatedCount := 0
+
+	for model, metrics := range allMetrics {
+		score := s.computeScore(model, metrics)
+		score.LastUpdated = now
+
+		// Apply exponential moving average for smoothing
+		s.emaMutex.Lock()
+		if prevEMA, exists := s.emaScores[model]; exists {
+			score.CompositeScore = s.config.DecayFactor*score.CompositeScore +
+				(1-s.config.DecayFactor)*prevEMA
+		}
+		s.emaScores[model] = score.CompositeScore
+		s.emaMutex.Unlock()
+
+		s.scores[model] = score
+		updatedCount++
+
+		// Update Prometheus metrics
+		DynamicScoreGauge.WithLabelValues(model).Set(score.CompositeScore)
+		AccuracyScoreGauge.WithLabelValues(model).Set(score.ComponentScores.Accuracy)
+		LatencyScoreGauge.WithLabelValues(model).Set(score.ComponentScores.Latency)
+		CostScoreGauge.WithLabelValues(model).Set(score.ComponentScores.Cost)
+	}
+
+	ScoringUpdateCounter.WithLabelValues("success").Inc()
+	logging.Debugf("Updated dynamic scores for %d models", updatedCount)
+}
+
+// computeScore computes the score for a single model
+func (s *DynamicScorer) computeScore(model string, metrics ModelMetrics) *ModelScore {
+	score := &ModelScore{
+		Model:       model,
+		Metrics:     metrics,
+		SampleCount: metrics.RequestCount,
+	}
+
+	// Check if we have enough samples
+	if metrics.RequestCount < s.config.MinSamples {
+		score.CompositeScore = s.config.DefaultScore
+		score.IsDefault = true
+		score.ComponentScores = ComponentScores{
+			Accuracy: s.config.DefaultScore,
+			Latency:  s.config.DefaultScore,
+			Cost:     s.config.DefaultScore,
+		}
+		return score
+	}
+
+	// Compute accuracy score (1 - error_rate)
+	accuracyScore := 1.0 - metrics.ErrorRate
+	if accuracyScore < 0 {
+		accuracyScore = 0
+	}
+	if accuracyScore > 1 {
+		accuracyScore = 1
+	}
+
+	// Compute latency score (normalized, lower is better)
+	latencyScore := s.normalizeLatency(metrics.AvgLatencySeconds)
+
+	// Compute cost score (normalized, lower is better)
+	costScore := s.normalizeCost(metrics.CostPerKTokens)
+
+	score.ComponentScores = ComponentScores{
+		Accuracy: accuracyScore,
+		Latency:  latencyScore,
+		Cost:     costScore,
+	}
+
+	// Compute weighted composite score
+	score.CompositeScore = s.config.Weights.Accuracy*accuracyScore +
+		s.config.Weights.Latency*latencyScore +
+		s.config.Weights.Cost*costScore
+
+	// Clamp to 0-1 range
+	if score.CompositeScore < 0 {
+		score.CompositeScore = 0
+	}
+	if score.CompositeScore > 1 {
+		score.CompositeScore = 1
+	}
+
+	return score
+}
+
+// normalizeLatency converts latency to a 0-1 score (lower latency = higher score)
+func (s *DynamicScorer) normalizeLatency(latency float64) float64 {
+	if latency <= 0 {
+		return 1.0 // Perfect score for zero/negative latency
+	}
+	if latency >= s.config.Normalization.LatencyMax {
+		return 0.0 // Worst score for max latency
+	}
+
+	// Use exponential decay: score = exp(-latency / target)
+	// This gives 0.5 roughly at target and approaches 0 at max
+	target := s.config.Normalization.LatencyTarget
+	score := math.Exp(-latency / target)
+
+	// Scale to ensure we hit 0 at LatencyMax
+	maxScore := math.Exp(-s.config.Normalization.LatencyMax / target)
+	score = (score - maxScore) / (1 - maxScore)
+
+	if score < 0 {
+		score = 0
+	}
+	if score > 1 {
+		score = 1
+	}
+
+	return score
+}
+
+// normalizeCost converts cost to a 0-1 score (lower cost = higher score)
+func (s *DynamicScorer) normalizeCost(costPerKTokens float64) float64 {
+	if costPerKTokens <= 0 {
+		return 1.0 // Perfect score for free
+	}
+	if costPerKTokens >= s.config.Normalization.CostMax {
+		return 0.0 // Worst score for max cost
+	}
+
+	// Linear interpolation between 0 and max
+	target := s.config.Normalization.CostTarget
+	max := s.config.Normalization.CostMax
+
+	// Score = 1 at 0, 0.5 at target, 0 at max
+	if costPerKTokens <= target {
+		// Linear from 1 to 0.5
+		return 1.0 - 0.5*(costPerKTokens/target)
+	}
+	// Linear from 0.5 to 0
+	return 0.5 * (1 - (costPerKTokens-target)/(max-target))
+}
+
+// ForceUpdate triggers an immediate score update
+func (s *DynamicScorer) ForceUpdate() {
+	s.updateScores()
+}
+
+// IsEnabled returns whether dynamic scoring is enabled
+func (s *DynamicScorer) IsEnabled() bool {
+	return s.config.Enabled
+}
+
+// IsRunning returns whether the scorer is currently running
+func (s *DynamicScorer) IsRunning() bool {
+	s.runningMutex.Lock()
+	defer s.runningMutex.Unlock()
+	return s.running
+}
+
+// GetConfig returns the current configuration
+func (s *DynamicScorer) GetConfig() DynamicScoringConfig {
+	return s.config
+}

--- a/src/semantic-router/pkg/scoring/scorer_test.go
+++ b/src/semantic-router/pkg/scoring/scorer_test.go
@@ -1,0 +1,518 @@
+package scoring
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// MockMetricsProvider implements MetricsProvider for testing
+type MockMetricsProvider struct {
+	metrics map[string]ModelMetrics
+}
+
+func NewMockMetricsProvider() *MockMetricsProvider {
+	return &MockMetricsProvider{
+		metrics: make(map[string]ModelMetrics),
+	}
+}
+
+func (m *MockMetricsProvider) SetModelMetrics(model string, metrics ModelMetrics) {
+	m.metrics[model] = metrics
+}
+
+func (m *MockMetricsProvider) GetModelMetrics(model string, window time.Duration) (ModelMetrics, error) {
+	if metrics, ok := m.metrics[model]; ok {
+		return metrics, nil
+	}
+	return ModelMetrics{}, nil
+}
+
+func (m *MockMetricsProvider) GetAllModelMetrics(window time.Duration) (map[string]ModelMetrics, error) {
+	result := make(map[string]ModelMetrics, len(m.metrics))
+	for k, v := range m.metrics {
+		result[k] = v
+	}
+	return result, nil
+}
+
+func TestNewDynamicScorer(t *testing.T) {
+	provider := NewMockMetricsProvider()
+
+	tests := []struct {
+		name    string
+		config  DynamicScoringConfig
+		wantErr bool
+	}{
+		{
+			name: "default config",
+			config: DynamicScoringConfig{
+				Enabled: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom weights",
+			config: DynamicScoringConfig{
+				Enabled: true,
+				Weights: ScoreWeights{
+					Accuracy: 0.6,
+					Latency:  0.3,
+					Cost:     0.1,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unnormalized weights get normalized",
+			config: DynamicScoringConfig{
+				Enabled: true,
+				Weights: ScoreWeights{
+					Accuracy: 2.0,
+					Latency:  1.0,
+					Cost:     1.0,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scorer, err := NewDynamicScorer(tt.config, provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewDynamicScorer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if scorer == nil {
+				t.Error("NewDynamicScorer() returned nil")
+			}
+		})
+	}
+}
+
+func TestDynamicScorer_ComputeScore(t *testing.T) {
+	provider := NewMockMetricsProvider()
+
+	config := DynamicScoringConfig{
+		Enabled:      true,
+		MinSamples:   5,
+		DefaultScore: 0.5,
+		DecayFactor:  0.1,
+		Weights: ScoreWeights{
+			Accuracy: 0.5,
+			Latency:  0.3,
+			Cost:     0.2,
+		},
+		Normalization: NormalizationConfig{
+			LatencyTarget: 1.0,
+			LatencyMax:    10.0,
+			CostTarget:    0.01,
+			CostMax:       0.1,
+		},
+	}
+
+	scorer, _ := NewDynamicScorer(config, provider)
+
+	tests := []struct {
+		name          string
+		model         string
+		metrics       ModelMetrics
+		minScore      float64
+		maxScore      float64
+		expectDefault bool
+	}{
+		{
+			name:  "perfect model - no errors, low latency, low cost",
+			model: "perfect-model",
+			metrics: ModelMetrics{
+				RequestCount:      100,
+				ErrorCount:        0,
+				ErrorRate:         0.0,
+				AvgLatencySeconds: 0.1,
+				CostPerKTokens:    0.001,
+			},
+			minScore:      0.8,
+			maxScore:      1.0,
+			expectDefault: false,
+		},
+		{
+			name:  "high error rate model",
+			model: "error-prone-model",
+			metrics: ModelMetrics{
+				RequestCount:      100,
+				ErrorCount:        50,
+				ErrorRate:         0.5,
+				AvgLatencySeconds: 0.5,
+				CostPerKTokens:    0.005,
+			},
+			minScore:      0.2,
+			maxScore:      0.6,
+			expectDefault: false,
+		},
+		{
+			name:  "slow model",
+			model: "slow-model",
+			metrics: ModelMetrics{
+				RequestCount:      100,
+				ErrorCount:        0,
+				ErrorRate:         0.0,
+				AvgLatencySeconds: 8.0,
+				CostPerKTokens:    0.001,
+			},
+			minScore:      0.4,
+			maxScore:      0.7,
+			expectDefault: false,
+		},
+		{
+			name:  "expensive model",
+			model: "expensive-model",
+			metrics: ModelMetrics{
+				RequestCount:      100,
+				ErrorCount:        0,
+				ErrorRate:         0.0,
+				AvgLatencySeconds: 0.5,
+				CostPerKTokens:    0.09,
+			},
+			minScore:      0.5,
+			maxScore:      0.85,
+			expectDefault: false,
+		},
+		{
+			name:  "insufficient samples - should use default",
+			model: "new-model",
+			metrics: ModelMetrics{
+				RequestCount:      3, // Below MinSamples
+				ErrorCount:        0,
+				ErrorRate:         0.0,
+				AvgLatencySeconds: 0.1,
+				CostPerKTokens:    0.001,
+			},
+			minScore:      0.5,
+			maxScore:      0.5,
+			expectDefault: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := scorer.computeScore(tt.model, tt.metrics)
+
+			if score.IsDefault != tt.expectDefault {
+				t.Errorf("expected IsDefault=%v, got %v", tt.expectDefault, score.IsDefault)
+			}
+
+			if score.CompositeScore < tt.minScore || score.CompositeScore > tt.maxScore {
+				t.Errorf("expected score in range [%.2f, %.2f], got %.4f",
+					tt.minScore, tt.maxScore, score.CompositeScore)
+			}
+		})
+	}
+}
+
+func TestDynamicScorer_NormalizeLatency(t *testing.T) {
+	config := DynamicScoringConfig{
+		Enabled: true,
+		Normalization: NormalizationConfig{
+			LatencyTarget: 1.0,
+			LatencyMax:    10.0,
+		},
+	}
+
+	scorer, _ := NewDynamicScorer(config, nil)
+
+	tests := []struct {
+		name     string
+		latency  float64
+		minScore float64
+		maxScore float64
+	}{
+		{"zero latency", 0.0, 1.0, 1.0},
+		{"very low latency", 0.1, 0.8, 1.0},
+		{"target latency", 1.0, 0.3, 0.5},
+		{"high latency", 5.0, 0.0, 0.2},
+		{"max latency", 10.0, 0.0, 0.0},
+		{"above max latency", 15.0, 0.0, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := scorer.normalizeLatency(tt.latency)
+			if score < tt.minScore || score > tt.maxScore {
+				t.Errorf("normalizeLatency(%.1f) = %.4f, expected in range [%.2f, %.2f]",
+					tt.latency, score, tt.minScore, tt.maxScore)
+			}
+		})
+	}
+}
+
+func TestDynamicScorer_NormalizeCost(t *testing.T) {
+	config := DynamicScoringConfig{
+		Enabled: true,
+		Normalization: NormalizationConfig{
+			CostTarget: 0.01,
+			CostMax:    0.1,
+		},
+	}
+
+	scorer, _ := NewDynamicScorer(config, nil)
+
+	tests := []struct {
+		name     string
+		cost     float64
+		minScore float64
+		maxScore float64
+	}{
+		{"free", 0.0, 1.0, 1.0},
+		{"very cheap", 0.001, 0.9, 1.0},
+		{"target cost", 0.01, 0.45, 0.55},
+		{"expensive", 0.05, 0.2, 0.35},
+		{"max cost", 0.1, 0.0, 0.05},
+		{"above max cost", 0.2, 0.0, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := scorer.normalizeCost(tt.cost)
+			if score < tt.minScore || score > tt.maxScore {
+				t.Errorf("normalizeCost(%.3f) = %.4f, expected in range [%.2f, %.2f]",
+					tt.cost, score, tt.minScore, tt.maxScore)
+			}
+		})
+	}
+}
+
+func TestDynamicScorer_GetBestModel(t *testing.T) {
+	provider := NewMockMetricsProvider()
+
+	// Set up test models with different scores
+	provider.SetModelMetrics("model-a", ModelMetrics{
+		RequestCount:      100,
+		ErrorRate:         0.1,
+		AvgLatencySeconds: 1.0,
+		CostPerKTokens:    0.01,
+	})
+	provider.SetModelMetrics("model-b", ModelMetrics{
+		RequestCount:      100,
+		ErrorRate:         0.0,
+		AvgLatencySeconds: 0.5,
+		CostPerKTokens:    0.005,
+	})
+	provider.SetModelMetrics("model-c", ModelMetrics{
+		RequestCount:      100,
+		ErrorRate:         0.3,
+		AvgLatencySeconds: 2.0,
+		CostPerKTokens:    0.02,
+	})
+
+	config := DynamicScoringConfig{
+		Enabled:      true,
+		MinSamples:   10,
+		DefaultScore: 0.5,
+		DecayFactor:  1.0, // No smoothing for test
+		Weights: ScoreWeights{
+			Accuracy: 0.5,
+			Latency:  0.3,
+			Cost:     0.2,
+		},
+		Normalization: NormalizationConfig{
+			LatencyTarget: 1.0,
+			LatencyMax:    10.0,
+			CostTarget:    0.01,
+			CostMax:       0.1,
+		},
+	}
+
+	scorer, _ := NewDynamicScorer(config, provider)
+	scorer.updateScores() // Force score computation
+
+	tests := []struct {
+		name       string
+		candidates []string
+		wantModel  string
+	}{
+		{
+			name:       "select best from all",
+			candidates: []string{"model-a", "model-b", "model-c"},
+			wantModel:  "model-b", // Best: no errors, low latency, low cost
+		},
+		{
+			name:       "select from subset",
+			candidates: []string{"model-a", "model-c"},
+			wantModel:  "model-a", // Better than model-c
+		},
+		{
+			name:       "single candidate",
+			candidates: []string{"model-c"},
+			wantModel:  "model-c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bestModel, _ := scorer.GetBestModel(tt.candidates)
+			if bestModel != tt.wantModel {
+				t.Errorf("GetBestModel() = %s, want %s", bestModel, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestDynamicScorer_WeightsNormalization(t *testing.T) {
+	provider := NewMockMetricsProvider()
+
+	// Weights that don't sum to 1.0
+	config := DynamicScoringConfig{
+		Enabled: true,
+		Weights: ScoreWeights{
+			Accuracy: 1.0,
+			Latency:  1.0,
+			Cost:     1.0,
+		},
+	}
+
+	scorer, _ := NewDynamicScorer(config, provider)
+
+	// Check weights were normalized
+	totalWeight := scorer.config.Weights.Accuracy +
+		scorer.config.Weights.Latency +
+		scorer.config.Weights.Cost
+
+	if math.Abs(totalWeight-1.0) > 0.01 {
+		t.Errorf("weights should sum to 1.0, got %f", totalWeight)
+	}
+
+	// Each should be ~0.333
+	expectedWeight := 1.0 / 3.0
+	if math.Abs(scorer.config.Weights.Accuracy-expectedWeight) > 0.01 {
+		t.Errorf("accuracy weight = %f, want ~%f", scorer.config.Weights.Accuracy, expectedWeight)
+	}
+}
+
+func TestDynamicScorer_EMASmooothing(t *testing.T) {
+	provider := NewMockMetricsProvider()
+
+	config := DynamicScoringConfig{
+		Enabled:      true,
+		MinSamples:   5,
+		DefaultScore: 0.5,
+		DecayFactor:  0.3, // EMA decay
+		Weights: ScoreWeights{
+			Accuracy: 0.5,
+			Latency:  0.3,
+			Cost:     0.2,
+		},
+		Normalization: NormalizationConfig{
+			LatencyTarget: 1.0,
+			LatencyMax:    10.0,
+			CostTarget:    0.01,
+			CostMax:       0.1,
+		},
+	}
+
+	scorer, _ := NewDynamicScorer(config, provider)
+
+	// Set initial good metrics
+	provider.SetModelMetrics("test-model", ModelMetrics{
+		RequestCount:      100,
+		ErrorRate:         0.0,
+		AvgLatencySeconds: 0.1,
+		CostPerKTokens:    0.001,
+	})
+
+	scorer.updateScores()
+	initialScore, _ := scorer.GetScore("test-model")
+
+	// Suddenly degrade metrics
+	provider.SetModelMetrics("test-model", ModelMetrics{
+		RequestCount:      100,
+		ErrorRate:         0.5,
+		AvgLatencySeconds: 5.0,
+		CostPerKTokens:    0.05,
+	})
+
+	scorer.updateScores()
+	afterDegradeScore, _ := scorer.GetScore("test-model")
+
+	// With EMA, score should not drop immediately to the new "bad" value
+	// It should be somewhere between initial and new raw score
+	// Since decay is 0.3, the new score = 0.3 * newRaw + 0.7 * initial
+	if afterDegradeScore >= initialScore {
+		t.Errorf("score should decrease after degradation: initial=%.4f, after=%.4f",
+			initialScore, afterDegradeScore)
+	}
+}
+
+func TestWindowedMetricsProvider_RecordAndGet(t *testing.T) {
+	provider := NewWindowedMetricsProvider(10)
+
+	// Record some requests
+	for i := 0; i < 20; i++ {
+		isError := i%5 == 0 // 20% error rate
+		provider.RecordRequest("test-model", 0.5, 100, 50, isError, 0.001)
+	}
+
+	// Get metrics
+	metrics, err := provider.GetModelMetrics("test-model", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("GetModelMetrics() error: %v", err)
+	}
+
+	if metrics.RequestCount != 20 {
+		t.Errorf("RequestCount = %d, want 20", metrics.RequestCount)
+	}
+
+	if metrics.ErrorCount != 4 {
+		t.Errorf("ErrorCount = %d, want 4", metrics.ErrorCount)
+	}
+
+	expectedErrorRate := 0.2
+	if math.Abs(metrics.ErrorRate-expectedErrorRate) > 0.01 {
+		t.Errorf("ErrorRate = %f, want %f", metrics.ErrorRate, expectedErrorRate)
+	}
+}
+
+func TestWindowedMetricsProvider_TimeWindow(t *testing.T) {
+	provider := NewWindowedMetricsProvider(10)
+
+	// Record a request
+	provider.RecordRequest("test-model", 0.5, 100, 50, false, 0.001)
+
+	// Should be visible in 5-minute window
+	metrics, _ := provider.GetModelMetrics("test-model", 5*time.Minute)
+	if metrics.RequestCount != 1 {
+		t.Errorf("RequestCount = %d, want 1", metrics.RequestCount)
+	}
+
+	// Should not be visible in zero-duration window (future only)
+	metrics, _ = provider.GetModelMetrics("test-model", 0)
+	if metrics.RequestCount != 0 {
+		t.Errorf("RequestCount for zero window = %d, want 0", metrics.RequestCount)
+	}
+}
+
+func TestComputePercentile(t *testing.T) {
+	tests := []struct {
+		name       string
+		values     []float64
+		percentile float64
+		want       float64
+		tolerance  float64
+	}{
+		{"empty slice", []float64{}, 0.5, 0.0, 0.0},
+		{"single value", []float64{5.0}, 0.5, 5.0, 0.01},
+		{"p50 of two values", []float64{1.0, 9.0}, 0.5, 5.0, 0.01},
+		{"p95 of sorted list", []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}, 0.95, 9.55, 0.1},
+		{"p0", []float64{1.0, 2.0, 3.0}, 0.0, 1.0, 0.01},
+		{"p100", []float64{1.0, 2.0, 3.0}, 1.0, 3.0, 0.01},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computePercentile(tt.values, tt.percentile)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("computePercentile() = %v, want %v (tolerance %v)", got, tt.want, tt.tolerance)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements a dynamic model scoring system that continuously evaluates model performance based on accuracy, latency, and cost metrics. The system automatically updates scores to enable intelligent model selection when multiple models are configured for a category.

## Related Issue

Fixes #38

## Problem

Static model scoring doesn't adapt to real-world performance variations. Models may degrade over time, experience latency spikes, or have varying costs that aren't reflected in fixed scores.

## Solution

- Real-time score computation using windowed metrics (error rate, latency, cost)
- Configurable weights for accuracy (50%), latency (30%), and cost (20%) components
- Exponential moving average (EMA) smoothing for score stability
- Integration with classifier for dynamic model selection
- Prometheus metrics for observability (`llm_model_dynamic_score`, `llm_model_scoring_updates_total`)
- Thread-safe implementation with proper mutex protection

## Changes Made

| File | Change Type | Description |
|------|-------------|-------------|
| `pkg/scoring/scorer.go` | Added | Core scoring logic with EMA smoothing |
| `pkg/scoring/metrics_provider.go` | Added | Interface to collect metrics from WindowedMetricsManager |
| `pkg/scoring/global.go` | Added | Global scorer instance management |
| `pkg/scoring/scorer_test.go` | Added | Comprehensive unit tests (11 test cases) |
| `pkg/config/config.go` | Modified | Added DynamicScoringConfig to MetricsConfig |
| `pkg/classification/classifier.go` | Modified | Use dynamic scores for model selection |
| `cmd/main.go` | Modified | Initialize scoring system at startup |
| `config/config.yaml` | Modified | Added dynamic_scoring configuration section |
| `pkg/extproc/processor_*.go` | Modified | Record metrics for scoring |

## Configuration

```yaml
observability:
  metrics:
    dynamic_scoring:
      enabled: true
      time_window: "5m"
      update_interval: "30s"
      weights:
        accuracy: 0.5
        latency: 0.3
        cost: 0.2
      normalization:
        latency_target: 1.0
        latency_max: 10.0
        cost_target: 0.01
        cost_max: 0.1
      min_samples: 10
      default_score: 0.5
      decay_factor: 0.1
```

## Testing Done

- [x] Unit tests pass (11 scoring tests)
- [x] Build passes (`make build-router`)
- [x] Router starts with dynamic scoring enabled
- [x] Prometheus metrics exposed and incrementing
- [x] Race condition review completed (added runningMutex protection)


## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (config example)
- [x] Signed-off-by included in commits (DCO)
- [x] No security issues introduced
- [x] Thread-safety verified (mutex protection)