### PR TITLE
[Bugfix] Fix getRecommendedModel to return real model names from config

### DIFF
--- a/src/semantic-router/pkg/services/classification.go
+++ b/src/semantic-router/pkg/services/classification.go
@@ -415,8 +415,40 @@ func (s *ClassificationService) CheckSecurity(req SecurityRequest) (*SecurityRes
 
 // Helper methods
 func (s *ClassificationService) getRecommendedModel(category string, _ float64) string {
-	// TODO: Implement model recommendation logic based on category
-	return fmt.Sprintf("%s-specialized-model", category)
+	// Use classifier's existing logic if available
+	if s.classifier != nil {
+		model := s.classifier.SelectBestModelForCategory(category)
+		if model != "" {
+			return model
+		}
+	}
+
+	// Fallback: Access config directly to find decision and model
+	if s.config != nil {
+		// Find decision by category name (case-insensitive)
+		for _, decision := range s.config.IntelligentRouting.Decisions {
+			if strings.EqualFold(decision.Name, category) {
+				// Get first model from ModelRefs
+				if len(decision.ModelRefs) > 0 {
+					modelRef := decision.ModelRefs[0]
+					// Use LoRA name if specified, otherwise base model
+					if modelRef.LoRAName != "" {
+						return modelRef.LoRAName
+					}
+					return modelRef.Model
+				}
+				break
+			}
+		}
+
+		// Fallback to default model if no decision found
+		if s.config.BackendModels.DefaultModel != "" {
+			return s.config.BackendModels.DefaultModel
+		}
+	}
+
+	// Return empty string if no recommendation available
+	return ""
 }
 
 func (s *ClassificationService) getRoutingDecision(confidence float64, options *IntentOptions) string {

--- a/src/semantic-router/pkg/services/classification_test.go
+++ b/src/semantic-router/pkg/services/classification_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification"
@@ -267,5 +268,193 @@ func BenchmarkClassificationService_GetUnifiedClassifierStats(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = service.GetUnifiedClassifierStats()
+	}
+}
+
+// TestGetRecommendedModel_WithConfig tests that getRecommendedModel returns
+// real model names from configuration instead of hardcoded invalid names.
+func TestGetRecommendedModel_WithConfig(t *testing.T) {
+	// Create a config with real decisions and model refs
+	testConfig := &config.RouterConfig{
+		BackendModels: config.BackendModels{
+			DefaultModel: "default-llm-model",
+		},
+		IntelligentRouting: config.IntelligentRouting{
+			Decisions: []config.Decision{
+				{
+					Name: "math",
+					ModelRefs: []config.ModelRef{
+						{
+							Model: "phi4-math-expert",
+						},
+					},
+				},
+				{
+					Name: "science",
+					ModelRefs: []config.ModelRef{
+						{
+							Model:    "mistral-science-base",
+							LoRAName: "science-lora-adapter",
+						},
+					},
+				},
+				{
+					Name: "code",
+					ModelRefs: []config.ModelRef{
+						{
+							Model: "codellama-13b",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	service := &ClassificationService{
+		classifier: nil, // No classifier - will use config fallback
+		config:     testConfig,
+	}
+
+	tests := []struct {
+		name             string
+		category         string
+		expectedModel    string
+		shouldNotContain string // What should NOT be in the result
+	}{
+		{
+			name:             "Math category should return real model",
+			category:         "math",
+			expectedModel:    "phi4-math-expert",
+			shouldNotContain: "-specialized-model",
+		},
+		{
+			name:             "Science category with LoRA should return LoRA name",
+			category:         "science",
+			expectedModel:    "science-lora-adapter",
+			shouldNotContain: "-specialized-model",
+		},
+		{
+			name:             "Code category should return real model",
+			category:         "code",
+			expectedModel:    "codellama-13b",
+			shouldNotContain: "-specialized-model",
+		},
+		{
+			name:             "Unknown category should return default model",
+			category:         "unknown-category",
+			expectedModel:    "default-llm-model",
+			shouldNotContain: "-specialized-model",
+		},
+		{
+			name:             "Case insensitive category matching",
+			category:         "MATH", // Uppercase
+			expectedModel:    "phi4-math-expert",
+			shouldNotContain: "-specialized-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.getRecommendedModel(tt.category, 0.9)
+
+			// Verify it returns the expected model
+			if result != tt.expectedModel {
+				t.Errorf("getRecommendedModel(%q) = %q, want %q",
+					tt.category, result, tt.expectedModel)
+			}
+
+			// Verify it does NOT contain the old buggy pattern
+			if strings.Contains(result, tt.shouldNotContain) {
+				t.Errorf("getRecommendedModel(%q) = %q, should NOT contain %q (old bug pattern)",
+					tt.category, result, tt.shouldNotContain)
+			}
+		})
+	}
+}
+
+// TestGetRecommendedModel_NoConfig tests fallback behavior when config is nil
+func TestGetRecommendedModel_NoConfig(t *testing.T) {
+	service := &ClassificationService{
+		classifier: nil,
+		config:     nil,
+	}
+
+	result := service.getRecommendedModel("math", 0.9)
+	if result != "" {
+		t.Errorf("getRecommendedModel with nil config should return empty string, got %q", result)
+	}
+}
+
+// TestGetRecommendedModel_EmptyConfig tests fallback behavior with empty config
+func TestGetRecommendedModel_EmptyConfig(t *testing.T) {
+	service := &ClassificationService{
+		classifier: nil,
+		config:     &config.RouterConfig{},
+	}
+
+	result := service.getRecommendedModel("math", 0.9)
+	if result != "" {
+		t.Errorf("getRecommendedModel with empty config should return empty string, got %q", result)
+	}
+}
+
+// TestGetRecommendedModel_NoDecisionFound tests fallback to default model
+func TestGetRecommendedModel_NoDecisionFound(t *testing.T) {
+	testConfig := &config.RouterConfig{
+		BackendModels: config.BackendModels{
+			DefaultModel: "default-llm-model",
+		},
+		IntelligentRouting: config.IntelligentRouting{
+			Decisions: []config.Decision{
+				{
+					Name: "math",
+					ModelRefs: []config.ModelRef{
+						{Model: "phi4-math-expert"},
+					},
+				},
+			},
+		},
+	}
+
+	service := &ClassificationService{
+		classifier: nil,
+		config:     testConfig,
+	}
+
+	// Test with category that doesn't exist in decisions
+	result := service.getRecommendedModel("nonexistent", 0.9)
+	expected := "default-llm-model"
+	if result != expected {
+		t.Errorf("getRecommendedModel(%q) = %q, want %q (should fallback to default)",
+			"nonexistent", result, expected)
+	}
+}
+
+// TestGetRecommendedModel_EmptyModelRefs tests behavior when decision exists but has no ModelRefs
+func TestGetRecommendedModel_EmptyModelRefs(t *testing.T) {
+	testConfig := &config.RouterConfig{
+		BackendModels: config.BackendModels{
+			DefaultModel: "default-llm-model",
+		},
+		IntelligentRouting: config.IntelligentRouting{
+			Decisions: []config.Decision{
+				{
+					Name:      "math",
+					ModelRefs: []config.ModelRef{}, // Empty ModelRefs
+				},
+			},
+		},
+	}
+
+	service := &ClassificationService{
+		classifier: nil,
+		config:     testConfig,
+	}
+
+	result := service.getRecommendedModel("math", 0.9)
+	expected := "default-llm-model"
+	if result != expected {
+		t.Errorf("getRecommendedModel(%q) with empty ModelRefs = %q, want %q (should fallback to default)",
+			"math", result, expected)
 	}
 }


### PR DESCRIPTION
## Problem

Previously, `getRecommendedModel()` returned hardcoded invalid model names like `'math-specialized-model'` instead of actual model names from the configuration. This caused incorrect model recommendations when the router tried to select models based on classified categories.

## Solution

Updated `getRecommendedModel()` to:
- Read actual model names from the configuration's `IntelligentRouting.Decisions`
- Support LoRA adapter names (prefer LoRA over base model when specified)
- Implement case-insensitive category matching
- Add proper fallback to default model when no decision found
- Return empty string when no recommendation is available

## Changes

- **Updated `getRecommendedModel()` method** in `classification.go`:
  - Removed hardcoded `fmt.Sprintf("%s-specialized-model", category)` logic
  - Added config-based model lookup with proper fallback chain
  - Added LoRA adapter support (checks `ModelRef.LoRAName` first)
  - Added case-insensitive matching using `strings.EqualFold()`

- **Added comprehensive tests** in `classification_test.go`:
  - `TestGetRecommendedModel_WithConfig` - Tests real model names from config
  - `TestGetRecommendedModel_NoConfig` - Tests nil config fallback
  - `TestGetRecommendedModel_EmptyConfig` - Tests empty config fallback
  - `TestGetRecommendedModel_NoDecisionFound` - Tests default model fallback
  - `TestGetRecommendedModel_EmptyModelRefs` - Tests empty ModelRefs handling

## Testing

All existing tests pass
New tests cover all scenarios (config fallback, LoRA support, edge cases)
`golangci-lint`: 0 issues
`go vet`: no errors
`go test`: all tests pass (including 5 new test functions)
Pre-commit hooks: passed

Fixes #929