### PR TITLE
docs: fix memory values in embedding routing performance table

### DIFF
--- a/website/docs/tutorials/intelligent-route/embedding-routing.md
+++ b/website/docs/tutorials/intelligent-route/embedding-routing.md
@@ -218,10 +218,10 @@ dimension: 768  # or 512, 256, 128 for Matryoshka
 
 | Model | Dimension | Latency | Accuracy | Memory |
 |-------|-----------|---------|----------|--------|
-| Qwen3 | 1024 | 30-50ms | Highest | 600MB |
-| Gemma | 768 | 10-20ms | High | 300MB |
-| Gemma | 512 | 8-15ms | Medium | 300MB |
-| Gemma | 256 | 5-10ms | Lower | 300MB |
+| Qwen3 | 1024 | 30-50ms | Highest | ~2.4GB |
+| Gemma | 768 | 10-20ms | High | ~1.2GB |
+| Gemma | 512 | 8-15ms | Medium | ~1.2GB |
+| Gemma | 256 | 5-10ms | Lower | ~1.2GB |
 
 ## Reference
 


### PR DESCRIPTION
## Description

Fixes incorrect memory values in the embedding routing documentation table. The original values (600MB, 300MB) represented parameter counts, not actual memory usage.

## Changes

- Updated memory values to reflect actual runtime memory usage with F32 dtype:
  - Qwen3: 600MB → ~2.4GB (600M parameters × 4 bytes)
  - Gemma: 300MB → ~1.2GB (300M parameters × 4 bytes)

## Issue

Closes #785

## Explanation

As noted in the issue, models use F32 (float32) dtype, which requires 4 bytes per parameter.

## Note
These values represent the base model memory usage. Actual runtime memory may vary slightly based on system configuration and batch size.