### PR TITLE
[CI/Build][Dashboard] Update dashboard build to Go 1.24.1

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,7 +7,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Build backend
-FROM golang:1.21-alpine AS backend-builder
+FROM golang:1.24.1-alpine AS backend-builder
 WORKDIR /app/backend
 COPY backend/go.* ./
 RUN go mod download


### PR DESCRIPTION
- Bump dashboard Dockerfile to golang:1.24.1-alpine
- Fixes OpenShift dashboard build failure due to go.mod requiring 1.24.1
