### PR TITLE
[CI/Build][Dashboard] Fix OpenShift config map paths and dashboard build

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,17 +1,22 @@
 # Build frontend
 FROM node:18-alpine AS frontend-builder
+ARG BASE_DIR=dashboard
 WORKDIR /app/frontend
-COPY frontend/package*.json ./
+COPY ${BASE_DIR}/frontend/package*.json ./
 RUN npm ci --include=dev   # Ensure devDependencies are installed regardless of NODE_ENV
-COPY frontend/ ./
+COPY ${BASE_DIR}/frontend/ ./
 RUN npm run build
 
-# Build backend
+# Build backend (needs src/semantic-router for replace directive)
 FROM golang:1.24.1-alpine AS backend-builder
+ARG BASE_DIR=dashboard
+ARG ROUTER_DIR=src/semantic-router
+WORKDIR /app
+COPY ${ROUTER_DIR} /src/semantic-router
 WORKDIR /app/backend
-COPY backend/go.* ./
+COPY ${BASE_DIR}/backend/go.* ./
 RUN go mod download
-COPY backend/ ./
+COPY ${BASE_DIR}/backend/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o dashboard-server .
 
 # Final image


### PR DESCRIPTION
  **Summary**

  - Fix OpenShift dashboard build by aligning the Dockerfile to repo‑root build context.
  - Ensure the dashboard build can resolve the local src/semantic-router module.
  - Make the OpenShift BuildConfig dockerfilePath update idempotent.
  - Allow dashboard Dockerfile to build from repo root or dashboard dir
  - Deploy script now runs without error.

  **Changes**

  - dashboard/Dockerfile: add build args, use repo‑root paths, copy router module to /src/semantic-router, keep Go 1.24.1. Can be built from the repo root (needed by the OCP deployment script) or in the same directory the Dockerfile is in.
  - deploy/openshift/deploy-to-openshift.sh: always set dockerfilePath=dashboard/Dockerfile with idempotent patch logic.
  - deploy/openshift/config-openshift.yaml: fix PII mapping path to match downloaded model.

  **Testing**

  - OpenShift build tested manually on OCP 4.19

  **Impact / Risk**

  - Low. Build logic only. No runtime behavior changes other than fixing dashboard build.

  **Why this matters / observed failures**

  - Without these changes, the OpenShift dashboard build fails and the UI never comes up and the deployment script fails.
  - Pods observed:
      - dashboard-custom-* builds in Error / Init:Error
      - dashboard in ImagePullBackOff
  - Build error: go mod download fails because the local module replace can’t find /src/semantic-router/go.mod.
  - This blocks dashboard rollout and leaves observability pods crashing/failed.

All build steps complete successfully in the logs; the deploy was unblocked by fixing the dashboard build context (dashboard/Dockerfile), aligning Go version/paths for the local module replace, and making the BuildConfig patch idempotent, plus correcting the PII mapping path in the OpenShift config. Grafana still needs a secret but I will do that on another PR to avoid conflating this any further. Install stdout logs can be viewed here: https://gist.github.com/nerdalert/1b7c278fce8175f70d91a8fa869c9d5b