### PR TITLE
[Bugfix] Fix PII mapping path to match deployed model directory

### DIFF
--- a/deploy/openshift/config-openshift.yaml
+++ b/deploy/openshift/config-openshift.yaml
@@ -61,7 +61,7 @@ classifier:
     use_modernbert: true
     threshold: 0.7
     use_cpu: true
-    pii_mapping_path: "models/mom-pii-classifier/pii_type_mapping.json"
+    pii_mapping_path: "models/pii_classifier_modernbert-base_presidio_token_model/pii_type_mapping.json"
 
 # Categories - now only contain metadata for domain classification
 categories:


### PR DESCRIPTION
  The pii_mapping_path pointed to "models/mom-pii-classifier/" but the OpenShift
  deployment downloads a different model to "models/pii_classifier_modernbert-base_presidio_token_model/",
  causing "no such file or directory" startup failures and preventing the SR service from running and falling into a `CrashLoopBackOff` state.

  The mismatch:
  - Config expected: models/mom-pii-classifier/pii_type_mapping.json
  - Deployment provides: models/pii_classifier_modernbert-base_presidio_token_model/pii_type_mapping.json

  Fixed by updating pii_mapping_path to match the actually deployed model directory.
  This aligns the OpenShift config with what the deployment script downloads.

  Resolves: 
  - Err logs: `Failed to create ExtProc server: failed to load PII mapping:
  failed to read PII mapping file: open models/mom-pii-classifier/pii_type_mapping.json:
  no such file or directory`. 
  - With the fix the service starts and the logs present `"Initializing ModernBERT PII token classifier model: models/pii_classifier_modernbert-base_presidio_token_model"}`