### PR TITLE
fix(dashboard): return 404 instead of 500 when tools_db.json not found

### DIFF
--- a/dashboard/backend/handlers/tools.go
+++ b/dashboard/backend/handlers/tools.go
@@ -25,7 +25,12 @@ func ToolsDBHandler(configDir string) http.HandlerFunc {
 		data, err := os.ReadFile(toolsDBPath)
 		if err != nil {
 			log.Printf("Error reading tools_db.json: %v", err)
-			http.Error(w, fmt.Sprintf("Failed to read tools database: %v", err), http.StatusInternalServerError)
+			// Return 404 if file doesn't exist, 500 for other errors
+			if os.IsNotExist(err) {
+				http.Error(w, fmt.Sprintf("Tools database not found: %v", err), http.StatusNotFound)
+			} else {
+				http.Error(w, fmt.Sprintf("Failed to read tools database: %v", err), http.StatusInternalServerError)
+			}
 			return
 		}
 


### PR DESCRIPTION
# Fix: ToolsDB handler returns 404 instead of 500 when file not found

## Description

This PR fixes the `ToolsDBHandler` to return the correct HTTP status code when `tools_db.json` is missing. Previously, it returned `500 Internal Server Error` for all file read errors, including when the file doesn't exist. This is semantically incorrect - a missing file should return `404 Not Found`.

## Changes

- Added `os.IsNotExist()` check to distinguish between missing file and actual server errors
- Return `404 Not Found` when `tools_db.json` doesn't exist
- Return `500 Internal Server Error` for other file read errors (permission denied, I/O errors, etc.)

## Code Changes

**File**: `dashboard/backend/handlers/tools.go`

```go
// Before
if err != nil {
    log.Printf("Error reading tools_db.json: %v", err)
    http.Error(w, fmt.Sprintf("Failed to read tools database: %v", err), http.StatusInternalServerError)
    return
}

// After
if err != nil {
    log.Printf("Error reading tools_db.json: %v", err)
    // Return 404 if file doesn't exist, 500 for other errors
    if os.IsNotExist(err) {
        http.Error(w, fmt.Sprintf("Tools database not found: %v", err), http.StatusNotFound)
    } else {
        http.Error(w, fmt.Sprintf("Failed to read tools database: %v", err), http.StatusInternalServerError)
    }
    return
}
```

## Impact

-  Correct HTTP semantics (404 for missing resources, 500 for server errors)
-  Better user experience (frontend can handle 404 gracefully)
-  Improved monitoring/alerting (won't incorrectly alert on missing config files)
-  Easier debugging (clear distinction between missing file and server problems)

## Testing

### Manual Testing

1. Remove `tools_db.json` from config directory
2. Make GET request to `/api/tools-db`
3. **Expected**: HTTP 404 Not Found
4. **Before**: HTTP 500 Internal Server Error

```bash
# Test case
rm config/tools_db.json
curl -v http://localhost:8700/api/tools-db
# Expected: HTTP/1.1 404 Not Found
```

### Test Results

-  Returns 404 when file doesn't exist
-  Returns 500 for other errors (permission denied, etc.)
-  Returns 200 when file exists and is valid JSON

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Manual testing performed
- [x] No breaking changes
- [x] Related issue referenced

## Related Issue

Fixes #971