### PR TITLE
feat(dashboard): refactor sidebar to align with Python CLI config

### DIFF
--- a/dashboard/backend/router/router.go
+++ b/dashboard/backend/router/router.go
@@ -25,6 +25,11 @@ func Setup(cfg *config.Config) *http.ServeMux {
 	mux.HandleFunc("/api/router/config/update", handlers.UpdateConfigHandler(cfg.AbsConfigPath))
 	log.Printf("Config API endpoints registered: /api/router/config/all, /api/router/config/update")
 
+	// Router defaults endpoints (for .vllm-sr/router-defaults.yaml)
+	mux.HandleFunc("/api/router/config/defaults", handlers.RouterDefaultsHandler(cfg.ConfigDir))
+	mux.HandleFunc("/api/router/config/defaults/update", handlers.UpdateRouterDefaultsHandler(cfg.ConfigDir))
+	log.Printf("Router defaults API endpoints registered: /api/router/config/defaults, /api/router/config/defaults/update")
+
 	// Tools DB endpoint
 	mux.HandleFunc("/api/tools-db", handlers.ToolsDBHandler(cfg.ConfigDir))
 	log.Printf("Tools DB API endpoint registered: /api/tools-db")

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import { ConfigSection } from './components/ConfigNav'
 
 const App: React.FC = () => {
   const [isInIframe, setIsInIframe] = useState(false)
-  const [configSection, setConfigSection] = useState<ConfigSection>('models')
+  const [configSection, setConfigSection] = useState<ConfigSection>('signals')
 
   useEffect(() => {
     // Detect if we're running inside an iframe (potential loop)

--- a/dashboard/frontend/src/components/ConfigNav.tsx
+++ b/dashboard/frontend/src/components/ConfigNav.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
 import styles from './ConfigNav.module.css'
 
+// New navigation structure aligned with Python CLI config format
 export type ConfigSection =
-  | 'models'
-  | 'prompt-guard'
-  | 'similarity-cache'
-  | 'intelligent-routing'
-  | 'topology'
-  | 'tools-selection'
-  | 'observability'
-  | 'classification-api'
+  | 'signals'        // config.yaml: signals (keywords, embeddings, domains, etc.)
+  | 'decisions'      // config.yaml: decisions (routing rules)
+  | 'models'         // config.yaml: providers.models
+  | 'router-config'  // .vllm-sr/router-defaults.yaml (cache, prompt guard, tools, etc.)
+  | 'topology'       // Separate page for visualization
 
 interface ConfigNavProps {
   activeSection: ConfigSection
@@ -19,52 +17,34 @@ interface ConfigNavProps {
 const ConfigNav: React.FC<ConfigNavProps> = ({ activeSection, onSectionChange }) => {
   const sections = [
     {
+      id: 'signals' as ConfigSection,
+      icon: '📡',
+      title: 'Signals',
+      description: 'Keywords, embeddings, domains & preferences'
+    },
+    {
+      id: 'decisions' as ConfigSection,
+      icon: '🔀',
+      title: 'Decisions',
+      description: 'Routing rules with priorities & plugins'
+    },
+    {
       id: 'models' as ConfigSection,
       icon: '🤖',
       title: 'Models',
-      description: 'User defined models and endpoints'
+      description: 'Provider models and endpoints'
     },
     {
-      id: 'prompt-guard' as ConfigSection,
-      icon: '🛡️',
-      title: 'Prompt Guard',
-      description: 'PII and jailbreak ModernBERT detection'
-    },
-    {
-      id: 'similarity-cache' as ConfigSection,
-      icon: '⚡',
-      title: 'Similarity Cache',
-      description: 'Similarity BERT configuration'
-    },
-    {
-      id: 'intelligent-routing' as ConfigSection,
-      icon: '🧠',
-      title: 'Intelligent Routing',
-      description: 'Classify BERT, categories & reasoning'
+      id: 'router-config' as ConfigSection,
+      icon: '⚙️',
+      title: 'Router Configuration',
+      description: 'Cache, prompt guard, tools & observability'
     },
     {
       id: 'topology' as ConfigSection,
       icon: '🗺️',
       title: 'Topology',
-      description: 'Visualize routing chain-of-thought'
-    },
-    {
-      id: 'tools-selection' as ConfigSection,
-      icon: '🔧',
-      title: 'Tools Selection',
-      description: 'Tools configuration and database'
-    },
-    {
-      id: 'observability' as ConfigSection,
-      icon: '📊',
-      title: 'Observability',
-      description: 'Tracing and metrics'
-    },
-    {
-      id: 'classification-api' as ConfigSection,
-      icon: '🔌',
-      title: 'Classification API',
-      description: 'Batch classification settings'
+      description: 'Visualize signal-driven routing flow'
     }
   ]
 

--- a/dashboard/frontend/src/components/EditModal.tsx
+++ b/dashboard/frontend/src/components/EditModal.tsx
@@ -4,8 +4,10 @@ import styles from './EditModal.module.css'
 interface EditModalProps {
   isOpen: boolean
   onClose: () => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSave: (data: any) => Promise<void>
   title: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any
   fields: FieldConfig[]
   mode?: 'edit' | 'add'
@@ -33,6 +35,7 @@ const EditModal: React.FC<EditModalProps> = ({
   fields,
   mode = 'edit'
 }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [formData, setFormData] = useState<any>({})
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -51,7 +54,9 @@ const EditModal: React.FC<EditModalProps> = ({
     }
   }, [isOpen, data, fields])
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleChange = (fieldName: string, value: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setFormData((prev: any) => ({
       ...prev,
       [fieldName]: value

--- a/dashboard/frontend/src/components/Layout.tsx
+++ b/dashboard/frontend/src/components/Layout.tsx
@@ -38,15 +38,13 @@ const Layout: React.FC<LayoutProps> = ({ children, configSection, onConfigSectio
   }, [])
 
   // Config sections for dropdown - no emojis, clean text like NVIDIA Brev
+  // Navigation aligned with Python CLI config structure
   const configSections = [
+    { id: 'signals', title: 'Signals' },
+    { id: 'decisions', title: 'Decisions' },
     { id: 'models', title: 'Models' },
-    { id: 'prompt-guard', title: 'Prompt Guard' },
-    { id: 'similarity-cache', title: 'Similarity Cache' },
-    { id: 'intelligent-routing', title: 'Intelligent Routing' },
-    { id: 'topology', title: 'Topology' },
-    { id: 'tools-selection', title: 'Tools Selection' },
-    { id: 'observability', title: 'Observability' },
-    { id: 'classification-api', title: 'Classification API' }
+    { id: 'router-config', title: 'Router Config' },
+    { id: 'topology', title: 'Topology' }
   ]
 
   return (

--- a/dashboard/frontend/src/pages/TopologyPage.module.css
+++ b/dashboard/frontend/src/pages/TopologyPage.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: calc(100vh - 60px); /* Viewport height minus top navbar */
   width: 100%;
   background: var(--bg-primary);
   overflow: hidden;
@@ -52,7 +52,7 @@
 .flowContainer {
   flex: 1;
   width: 100%;
-  height: 100%;
+  min-height: 500px;
   position: relative;
   background: var(--bg-primary);
 }
@@ -60,6 +60,8 @@
 /* ReactFlow custom styling */
 .flowContainer :global(.react-flow) {
   background: var(--bg-primary);
+  width: 100%;
+  height: 100%; /* Ensure React Flow fills the container */
 }
 
 .flowContainer :global(.react-flow__node) {

--- a/dashboard/frontend/src/pages/TopologyPage.tsx
+++ b/dashboard/frontend/src/pages/TopologyPage.tsx
@@ -7,6 +7,8 @@ import ReactFlow, {
   MiniMap,
   useNodesState,
   useEdgesState,
+  useReactFlow,
+  ReactFlowProvider,
   MarkerType,
   Position,
 } from 'reactflow'
@@ -114,11 +116,13 @@ const normalizeModelScores = (
   }))
 }
 
-const TopologyPage: React.FC = () => {
+// Inner component that uses useReactFlow (must be inside ReactFlowProvider)
+const TopologyFlow: React.FC = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
+  const { fitView } = useReactFlow()
 
   useEffect(() => {
     fetchConfig()
@@ -631,6 +635,17 @@ const TopologyPage: React.FC = () => {
     setEdges(newEdges)
   }
 
+  // Call fitView after nodes are updated
+  useEffect(() => {
+    if (nodes.length > 0) {
+      // Small delay to ensure React Flow has rendered the nodes
+      const timer = setTimeout(() => {
+        fitView({ padding: 0.2, duration: 300 })
+      }, 100)
+      return () => clearTimeout(timer)
+    }
+  }, [nodes.length, fitView])
+
   if (loading) {
     return (
       <div className={styles.container}>
@@ -681,6 +696,7 @@ const TopologyPage: React.FC = () => {
           }}
           defaultViewport={{ x: 0, y: 0, zoom: 0.7 }}
           attributionPosition="bottom-left"
+          style={{ width: '100%', height: '100%' }}
         >
           <Background />
           <Controls />
@@ -744,6 +760,15 @@ const TopologyPage: React.FC = () => {
         </div>
       </div>
     </div>
+  )
+}
+
+// Wrapper component that provides ReactFlow context
+const TopologyPage: React.FC = () => {
+  return (
+    <ReactFlowProvider>
+      <TopologyFlow />
+    </ReactFlowProvider>
   )
 }
 


### PR DESCRIPTION
Reorganize dashboard navigation structure to match the Python CLI's
config.yaml format (signals, decisions, providers) as requested by
@Xunzhuo  in PR #1019 comments.

Frontend Changes:
- Update ConfigNav.tsx sections: signals, decisions, models,
  router-config, topology (replacing old prompt-guard, similarity-cache,
  intelligent-routing, tools-selection, observability, classification-api)
- Add dedicated renderers in ConfigPage.tsx for each new section:
  * renderSignalsSection() - keywords, embeddings, domains, preferences
  * renderDecisionsSection() - routing rules with priorities & plugins
  * renderModelsSection() - provider models and endpoints
  * renderRouterConfigSection() - cache, prompt guard, tools, observability
- Update Layout.tsx sidebar buttons for new navigation structure
- Set default active section to 'signals' in App.tsx

Backend Changes:
- Add RouterDefaultsHandler for reading .vllm-sr/router-defaults.yaml
- Add UpdateRouterDefaultsHandler for writing router-defaults.yaml
- Register new API endpoints: /api/router/config/defaults,
  /api/router/config/defaults/update

This separates user config (config.yaml) from system defaults
(router-defaults.yaml) and provides a cleaner dashboard experience.

Relates to #1019
