### PR TITLE
Add a local-up-router.sh script for dockerless environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ _run:
 		-f tools/make/models.mk \
 		-f tools/make/pre-commit.mk \
 		-f tools/make/docker.mk \
+		-f tools/make/dockerless.mk \
 		-f tools/make/kube.mk \
 		-f tools/make/helm.mk \
 		-f tools/make/observability.mk \

--- a/scripts/local-up-router.sh
+++ b/scripts/local-up-router.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+
+SR_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${SR_ROOT}"
+
+# This script builds and runs a local router instance along with an Envoy
+# proxy configured to route traffic to it. It is intended for development
+# and testing purposes in a dockerless environment.
+
+SR_LOG_LEVEL=${SR_LOG_LEVEL:-"info"}
+# Dump config at debug level
+if [[ "${SR_LOG_LEVEL}" == "debug" ]]; then
+  set -x
+fi
+
+API_HOST_IP=${API_HOST_IP:-"127.0.0.1"} # Used for all components
+
+# Router proxy (Envoy) settings
+# TODO: generate the envoy config dynamically based on 
+# the ROUTER_API_PORT and ENVOY_PROXY_PORT values
+ENVOY_PROXY_PORT=${ENVOY_PROXY_PORT:-"8801"}
+ENVOY_CONFIG=${ENVOY_CONFIG:-"config/envoy.yaml"}
+ENVOY_VERSION=${ENVOY_VERSION:-"1.35.4"}
+
+# Router settings
+ROUTER_API_PORT=${ROUTER_API_PORT:-"8080"}
+ROUTER_CONFIG=${ROUTER_CONFIG:-"config/config.yaml"}
+
+# Script settings
+FUNC_E_VERSION=${FUNC_E_VERSION:-"v1.3.0"}
+LOG_DIR=${LOG_DIR:-"/tmp"}
+WAIT_FOR_URL_ROUTER_SERVER=${WAIT_FOR_URL_ROUTER_SERVER:-60}
+MAX_TIME_FOR_URL_ROUTER_SERVER=${MAX_TIME_FOR_URL_ROUTER_SERVER:-1}
+set +x
+
+# Stop right away if the build fails
+set -e
+
+function usage {
+  echo "This script starts a local router instance along with an Envoy proxy."
+  echo "Example 0: scripts/local-up-router.sh -h  (this 'help' usage description)"
+  echo "Example 1: scripts/local-up-router.sh -o bin (run from make build)"
+  echo "Example 2: scripts/local-up-router.sh (build a local copy of the source)"
+  echo "Example 3: ROUTER_CONFIG=\"config/config.yaml\" \\"
+  echo "           scripts/local-up-router.sh (build a local copy of the source with a specific config file)"
+  echo ""
+  echo "-d         dry-run: prepare for running commands, then show their command lines instead of running them"
+}
+
+### Allow user to supply the source directory.
+BIN_OUT=${BIN_OUT:-}
+DRY_RUN=
+while getopts "dho:O" OPTION
+do
+    case ${OPTION} in
+        d)
+            echo "skipping running commands"
+            DRY_RUN=1
+            ;;
+        o)
+            echo "skipping build"
+            BIN_OUT="${OPTARG}"
+            echo "using source ${BIN_OUT}"
+            ;;
+        h)
+            usage
+            exit
+            ;;
+        ?)
+            usage
+            exit
+            ;;
+    esac
+done
+
+if [ -z "${BIN_OUT}" ]; then
+    BIN_OUT="${SR_ROOT}/bin"
+    make -C "${SR_ROOT}" build
+else
+    echo "skipped the build because BIN_OUT was set (${BIN_OUT})"
+fi
+
+# run executes the command specified by its parameters if DRY_RUN is empty,
+# otherwise it prints them.
+#
+# The first parameter must be the name of the semantic router components.
+# It is only used when printing the command in dry-run mode.
+# The second parameter is a log file for the command. It may be empty.
+function run {
+    local what="$1"
+    local log="$2"
+    shift
+    shift
+    if [[ -z "${DRY_RUN}" ]]; then
+        if [[ -z "${log}" ]]; then
+            "${@}"
+        else
+            "${@}" >"${log}" 2>&1
+        fi
+    else
+        echo "RUN ${what}: ${*}"
+    fi
+}
+# Downloads the models required by the router.
+function download_models {
+  echo "Downloading models..."
+  run "download-models" "" "${BIN_OUT}/router" \
+    --config "${ROUTER_CONFIG}" --download-only
+}
+
+function wait_for_url() {
+  local url=$1
+  local prefix=${2:-}
+  local wait=${3:-1}
+  local times=${4:-30}
+  local maxtime=${5:-1}
+
+  command -v curl >/dev/null || {
+    error_log "curl must be installed"
+    exit 1
+  }
+
+  local i
+  for i in $(seq 1 "${times}"); do
+    local out
+    if out=$(curl --max-time "${maxtime}" -gkfs "${@:6}" "${url}" 2>/dev/null); then
+      info_log "On try ${i}, ${prefix}: ${out}"
+      return 0
+    fi
+    sleep "${wait}"
+  done
+  error_log "Timed out waiting for ${prefix} to answer at ${url}; tried ${times} waiting ${wait} between each"
+  return 1
+}
+
+
+# Starts the router in the background, logging to ROUTER_LOG.
+function start_router {
+  echo "Starting router..."
+  ROUTER_LOG=${LOG_DIR}/router.log
+  run "router" "${ROUTER_LOG}" "${BIN_OUT}/router" \
+    --api-port "${ROUTER_API_PORT}" \
+    --config "${ROUTER_CONFIG}" &
+  ROUTER_PID=$!
+
+  if [[ -z "${DRY_RUN}" ]]; then
+      # Wait for router to come up before launching the rest of the components.
+      echo "Waiting for router to come up"
+      wait_for_url "http://${API_HOST_IP}:${ROUTER_API_PORT}/health" "router: " 1 "${WAIT_FOR_URL_ROUTER_SERVER}" "${MAX_TIME_FOR_URL_ROUTER_SERVER}" \
+          || { echo "check router logs: ${ROUTER_LOG}" ; exit 1 ; }
+  fi
+}
+
+# Installs func-e into BIN_OUT if it is not already installed there.
+function install_func_e_if_needed {
+  echo "Checking func-e Installation at ${BIN_OUT}"
+  if ! command -v "${BIN_OUT}/func-e" &> /dev/null ; then
+    echo "func-e Installation not found at ${BIN_OUT}"
+    install_func_e
+  fi
+}
+
+# Installs func-e into BIN_OUT.
+function install_func_e {
+  echo "Installing func-e..."
+  curl -sSL https://func-e.io/install.sh | bash -s -- -b "${BIN_OUT}" "${FUNC_E_VERSION}"
+}
+
+# Starts Envoy in the background, logging to ENVOY_LOG.
+function start_envoy {
+  echo "Starting Envoy..."
+  run "func-e" "" "${BIN_OUT}/func-e" use "${ENVOY_VERSION}"
+  ENVOY_LOG=${LOG_DIR}/envoy.log
+  run "envoy" "${ENVOY_LOG}" "${BIN_OUT}/func-e" "run" \
+    --config-path "${ENVOY_CONFIG}" \
+    --component-log-level "ext_proc:trace,router:trace,http:trace" &
+  ENVOY_PID=$!
+}
+
+# Prints success message with configuration details.
+function print_success {
+  if [[ -n "${DRY_RUN}" ]]; then
+    return
+  fi
+
+  echo "The local semantic router is running. Press Ctrl-C to shut it down."
+
+# TODO: add support for dashboard via make dashboard-build-backend and npm run dev
+  cat <<EOF
+Configurations:
+  Router: ${ROUTER_CONFIG}
+  Envoy: ${ENVOY_CONFIG}
+
+Endpoints:
+  * Router Endpoint: http://${API_HOST_IP}:${ROUTER_API_PORT}
+  * Envoy Proxy Endpoint: http://${API_HOST_IP}:${ENVOY_PROXY_PORT}
+
+Logs:
+  ${ROUTER_LOG:-}
+  ${ENVOY_LOG:-}
+EOF
+}
+
+# Prints a colored message with an optional prefix.
+function print_color {
+  message=$1
+  prefix=${2:+$2: } # add colon only if defined
+  color=${3:-1}     # default is red
+  echo -n "$(tput bold)$(tput setaf "${color}")"
+  echo "${prefix}${message}"
+  echo -n "$(tput sgr0)"
+}
+
+function info_log {
+  print_color "$1" "I$(date "+%m%d %H:%M:%S")]" 2
+}
+
+# Prints a warning log message with timestamp.
+function warning_log {
+  print_color "$1" "W$(date "+%m%d %H:%M:%S")]" 3
+}
+
+# Prints an error log message with timestamp.
+function error_log {
+  print_color "$1" "E$(date "+%m%d %H:%M:%S")]" 1
+}
+
+# Check if all processes are still running. Prints a warning once each time
+# a process dies unexpectedly.
+function healthcheck {
+  if [[ -n "${ROUTER_PID-}" ]] && ! kill -0 "${ROUTER_PID}" 2>/dev/null; then
+    warning_log "router terminated unexpectedly, see ${ROUTER_LOG}"
+    ROUTER_PID=
+  fi
+
+  if [[ -n "${ENVOY_PID-}" ]] && ! kill -0 "${ENVOY_PID}" 2>/dev/null; then
+    warning_log "envoy terminated unexpectedly, see ${ENVOY_LOG}"
+    ENVOY_PID=
+  fi
+}
+
+# Reads in stdin and adds it line by line to the array provided. This can be
+# used instead of "mapfile -t", and is bash 3 compatible.  If the named array
+# exists and is an array, it will be overwritten.  Otherwise it will be unset
+# and recreated.
+function read-array {
+  if [[ -z "$1" ]]; then
+    echo "usage: ${FUNCNAME[0]} <varname>" >&2
+    return 1
+  fi
+  if [[ -n $(declare -p "$1" 2>/dev/null) ]]; then
+    if ! declare -p "$1" 2>/dev/null | grep -q '^declare -a'; then
+      echo "${FUNCNAME[0]}: $1 is defined but isn't an array" >&2
+      return 2
+    fi
+  fi
+  # shellcheck disable=SC2034 # this variable _is_ used
+  local __read_array_i=0
+  while IFS= read -r "$1[__read_array_i++]"; do :; done
+  if ! eval "[[ \${$1[--__read_array_i]} ]]"; then
+    unset "$1[__read_array_i]" # ensures last element isn't empty
+  fi
+}
+
+# Cleans up background processes on exit.
+function cleanup {
+  echo "Cleaning up..."
+
+  [[ -n "${ROUTER_PID-}" ]] && read-array ROUTER_PIDS < <(pgrep -P "${ROUTER_PID}" ; ps -o pid= -p "${ROUTER_PID}")
+  [[ -n "${ROUTER_PIDS-}" ]] && kill "${ROUTER_PIDS[@]}" 2>/dev/null
+
+  [[ -n "${ENVOY_PID-}" ]] && read-array ENVOY_PIDS < <(pgrep -P "${ENVOY_PID}" ; ps -o pid= -p "${ENVOY_PID}")
+  [[ -n "${ENVOY_PIDS-}" ]] && kill "${ENVOY_PIDS[@]}" 2>/dev/null
+
+  exit 0
+}
+
+trap cleanup EXIT
+trap cleanup INT
+
+# Main script execution
+download_models
+start_router
+install_func_e_if_needed
+start_envoy
+print_success
+
+# Health check loop
+if [[ -z "${DRY_RUN}" ]]; then
+  while true; do sleep 1; healthcheck; done
+fi

--- a/tools/make/dockerless.mk
+++ b/tools/make/dockerless.mk
@@ -1,0 +1,9 @@
+# ======== local.mk =============
+# = Everything For Dockerless   =
+# ======== local.mk ============
+
+##@ Dockerless
+
+local-up-router: ## Start local semantic-router
+	echo "Starting local semantic-router with Envoy proxy..."
+	@scripts/local-up-router.sh


### PR DESCRIPTION
Ref #1051

```
~/vllm/semantic-router(add-local-up-router-script) # scripts/local-up-router.sh
make: Entering directory '/root/vllm/semantic-router.add-local-up-router-script'
make[1]: Entering directory '/root/vllm/semantic-router.add-local-up-router-script'
==================> Running rust ============> ...
Loading Rust environment from /root/.cargo/env...
Building Rust library with CUDA support...
💡 Tip: For 20-30% speedup on RTX 3090+/A100/H100, use: make rust ENABLE_FLASH_ATTN=1
    Finished `release` profile [optimized] target(s) in 0.22s
==================> Running build-router ============> ...
make[1]: Leaving directory '/root/vllm/semantic-router.add-local-up-router-script'
make: Leaving directory '/root/vllm/semantic-router.add-local-up-router-script'
Downloading models...
[HAMi-core Msg(43797:140275711119360:libvgpu.c:873)]: Initializing.....
[HAMi-core Warn(43797:140275711119360:multiprocess_memory_limit.c:608)]: Kick dead proc 41784

##          ##  ##        ##        ##      ##    ######    ########
 ##        ##   ##        ##        ###    ###   ##    ##   ##    ##
  ##      ##    ##        ##        ####  ####   ##         ##    ##
   ##    ##     ##        ##        ## #### ##    ####     ########
    ##  ##      ##        ##        ##  ##  ##       ##    ##  ##
     ####       ##        ##        ##      ##   ##    ##   ##   ##
      ##        ########  ########  ##      ##    ######    ##    ##

{"level":"info","ts":"2026-01-13T06:56:04","caller":"main.go:256","msg":"Installing required models..."}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"main.go:265","msg":"MoM Families: 10 unique models (total 80 registry aliases)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"main.go:290","msg":"HF_ENDPOINT: https://hf-mirror.com; HF_TOKEN: <not set>; HF_HOME: /root/data/hf-home"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:130","msg":"✓ models/mom-embedding-pro (ready)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:130","msg":"✓ models/mom-domain-classifier (ready)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:130","msg":"✓ models/mom-pii-classifier (ready)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:130","msg":"✓ models/mom-jailbreak-classifier (ready)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:130","msg":"✓ models/mom-halugate-sentinel (ready)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:130","msg":"✓ models/mom-halugate-detector (ready)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:130","msg":"✓ models/mom-halugate-explainer (ready)"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"downloader.go:135","msg":"All 7 models are ready"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"main.go:296","msg":"All required models are ready"}
{"level":"info","ts":"2026-01-13T06:56:04","caller":"main.go:76","msg":"Download-only mode: models downloaded successfully, exiting"}
Starting router...
Waiting for router to come up
I0113 06:56:11]: On try 8, router: : {"status": "healthy", "service": "classification-api"}
Checking func-e Installation at scripts/../bin
Starting Envoy...
1.35.4 is already downloaded
The local semantic router is running. Press Ctrl-C to shut it down.
Configurations:
  Router: config/config.yaml
  Envoy: config/envoy.yaml

Endpoints:
  * Router Endpoint: http://127.0.0.1:8080
  * Envoy Proxy Endpoint: http://127.0.0.1:8801

Logs:
  /tmp/router.log
  /tmp/envoy.log
```

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [ ] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/semantic-router/blob/main/CONTRIBUTING.md) checks.
- [ ] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [ ] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to semantic-router! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[CLI]</code> for changes to the command-line interface tools.</li>
    <li><code>[Dashboard]</code> for changes to the dashboard or web UI.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>
