### PR TITLE
Fix the models missing and wrong model reference and the tests

### DIFF
--- a/src/semantic-router/pkg/config/registry.go
+++ b/src/semantic-router/pkg/config/registry.go
@@ -70,11 +70,11 @@ var DefaultModelRegistry = []ModelSpec{
 		Tags:             []string{"classification", "lora", "mmlu", "domain", "bert"},
 	},
 
-	// PII Detection
+	// PII Detection - BERT LoRA
 	{
 		LocalPath:        "models/mom-pii-classifier",
 		RepoID:           "LLM-Semantic-Router/lora_pii_detector_bert-base-uncased_model",
-		Aliases:          []string{"pii-detector", "pii-classifier", "privacy-guard", "pii_classifier_modernbert-base_presidio_token_model", "pii_classifier_modernbert-base_model", "lora_pii_detector_bert-base-uncased_model"},
+		Aliases:          []string{"pii-detector", "pii-classifier", "privacy-guard", "lora_pii_detector_bert-base-uncased_model"},
 		Purpose:          PurposePIIDetection,
 		Description:      "BERT-based PII detector with LoRA adapters for 35 PII types",
 		ParameterSize:    "110M + LoRA",
@@ -84,11 +84,25 @@ var DefaultModelRegistry = []ModelSpec{
 		Tags:             []string{"pii", "privacy", "lora", "token-classification", "bert"},
 	},
 
+	// PII Detection - ModernBERT (Token-level)
+	{
+		LocalPath:        "models/mom-mmbert-pii-detector",
+		RepoID:           "llm-semantic-router/mmbert-pii-detector-merged",
+		Aliases:          []string{"mmbert-pii-detector", "mmbert-pii-detector-merged", "pii_classifier_modernbert-base_presidio_token_model", "pii_classifier_modernbert-base_model", "pii_classifier_modernbert_model", "pii_classifier_modernbert_ai4privacy_token_model"},
+		Purpose:          PurposePIIDetection,
+		Description:      "ModernBERT-based merged PII detector for token-level classification",
+		ParameterSize:    "149M",
+		UsesLoRA:         false,
+		NumClasses:       35, // PII types
+		MaxContextLength: 8192,
+		Tags:             []string{"pii", "privacy", "modernbert", "token-classification", "merged"},
+	},
+
 	// Jailbreak Detection
 	{
 		LocalPath:        "models/mom-jailbreak-classifier",
 		RepoID:           "LLM-Semantic-Router/lora_jailbreak_classifier_bert-base-uncased_model",
-		Aliases:          []string{"jailbreak-detector", "prompt-guard", "safety-classifier", "jailbreak_classifier_modernbert-base_model", "lora_jailbreak_classifier_bert-base-uncased_model"},
+		Aliases:          []string{"jailbreak-detector", "prompt-guard", "safety-classifier", "jailbreak_classifier_modernbert-base_model", "lora_jailbreak_classifier_bert-base-uncased_model", "jailbreak_classifier_modernbert_model"},
 		Purpose:          PurposeJailbreakDetection,
 		Description:      "BERT-based jailbreak/prompt injection detector with LoRA adapters",
 		ParameterSize:    "110M + LoRA",

--- a/src/semantic-router/pkg/config/registry_test.go
+++ b/src/semantic-router/pkg/config/registry_test.go
@@ -7,21 +7,38 @@ import (
 func TestToLegacyRegistry_IncludesAliases(t *testing.T) {
 	registry := ToLegacyRegistry()
 
-	// Test PII model paths
-	piiRepo := "LLM-Semantic-Router/lora_pii_detector_bert-base-uncased_model"
-	piiTests := []string{
+	// Test BERT LoRA PII model paths
+	piiLoraRepo := "LLM-Semantic-Router/lora_pii_detector_bert-base-uncased_model"
+	piiLoraTests := []string{
 		"models/mom-pii-classifier",
-		"models/pii_classifier_modernbert-base_presidio_token_model",
-		"models/pii_classifier_modernbert-base_model",
 		"models/lora_pii_detector_bert-base-uncased_model",
 		"models/pii-detector",
 		"pii-detector",
 	}
-	for _, path := range piiTests {
+	for _, path := range piiLoraTests {
 		if repo, ok := registry[path]; !ok {
 			t.Errorf("Expected %s to be in registry", path)
-		} else if repo != piiRepo {
-			t.Errorf("Expected %s to map to %s, got %s", path, piiRepo, repo)
+		} else if repo != piiLoraRepo {
+			t.Errorf("Expected %s to map to %s, got %s", path, piiLoraRepo, repo)
+		}
+	}
+
+	// Test ModernBERT PII model paths
+	piiModernBertRepo := "llm-semantic-router/mmbert-pii-detector-merged"
+	piiModernBertTests := []string{
+		"models/mom-mmbert-pii-detector",
+		"models/pii_classifier_modernbert-base_presidio_token_model",
+		"models/pii_classifier_modernbert-base_model",
+		"models/pii_classifier_modernbert_model",
+		"models/pii_classifier_modernbert_ai4privacy_token_model",
+		"models/mmbert-pii-detector",
+		"mmbert-pii-detector",
+	}
+	for _, path := range piiModernBertTests {
+		if repo, ok := registry[path]; !ok {
+			t.Errorf("Expected %s to be in registry", path)
+		} else if repo != piiModernBertRepo {
+			t.Errorf("Expected %s to map to %s, got %s", path, piiModernBertRepo, repo)
 		}
 	}
 
@@ -47,6 +64,7 @@ func TestToLegacyRegistry_IncludesAliases(t *testing.T) {
 	jailbreakTests := []string{
 		"models/mom-jailbreak-classifier",
 		"models/jailbreak_classifier_modernbert-base_model",
+		"models/jailbreak_classifier_modernbert_model",
 		"models/lora_jailbreak_classifier_bert-base-uncased_model",
 		"models/jailbreak-detector",
 		"jailbreak-detector",
@@ -70,13 +88,13 @@ func TestGetModelByPath_FindsByAlias(t *testing.T) {
 		t.Errorf("Expected LocalPath to be models/mom-pii-classifier, got %s", model.LocalPath)
 	}
 
-	// Test finding by old alias
+	// Test finding by old alias (now maps to ModernBERT model)
 	model = GetModelByPath("models/pii_classifier_modernbert-base_presidio_token_model")
 	if model == nil {
 		t.Fatal("Expected to find model by old alias path")
 	}
-	if model.LocalPath != "models/mom-pii-classifier" {
-		t.Errorf("Expected LocalPath to be models/mom-pii-classifier, got %s", model.LocalPath)
+	if model.LocalPath != "models/mom-mmbert-pii-detector" {
+		t.Errorf("Expected LocalPath to be models/mom-mmbert-pii-detector, got %s", model.LocalPath)
 	}
 
 	// Test finding by short alias


### PR DESCRIPTION
Added three missing aliases to registry.go:
  - pii_classifier_modernbert_model
  - pii_classifier_modernbert_ai4privacy_token_model
  - jailbreak_classifier_modernbert_model

  Updated corresponding tests to verify the new aliases resolve correctly.