### PR TITLE
 [Feat][Router]: Implement Router Replay plugin for debugging routing decisions

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_req_body.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body.go
@@ -193,6 +193,9 @@ func (r *OpenAIRouter) handleAutoModelRouting(openAIRequest *openai.ChatCompleti
 	// Save the actual model for token tracking
 	ctx.RequestModel = matchedModel
 
+	// Capture router replay information if enabled
+	r.startRouterReplay(ctx, originalModel, matchedModel, decisionName)
+
 	// Handle tool selection
 	r.handleToolSelectionForRequest(openAIRequest, response, ctx)
 

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -55,6 +55,10 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 				logging.Errorf("Failed to cache streaming response: %v", err)
 				// Continue even if caching fails
 			}
+
+			// For replay logging, attach the reconstructed assistant content if enabled
+			replayPayload := []byte(ctx.StreamingContent)
+			r.attachRouterReplayResponse(ctx, replayPayload, true)
 		}
 
 		// For streaming chunks, just continue (chunks are forwarded immediately)
@@ -239,6 +243,9 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 			},
 		}
 	}
+
+	// Capture replay response payload if enabled
+	r.attachRouterReplayResponse(ctx, finalBody, true)
 
 	return response, nil
 }

--- a/src/semantic-router/pkg/extproc/processor_res_header.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header.go
@@ -65,6 +65,9 @@ func (r *OpenAIRouter) handleResponseHeaders(v *ext_proc.ProcessingRequest_Respo
 		}
 	}
 
+	// Update router replay metadata with status code and streaming flag
+	r.updateRouterReplayStatus(ctx, statusCode, ctx != nil && ctx.IsStreamingResponse)
+
 	// Prepare response headers with VSR decision tracking headers if applicable
 	var headerMutation *ext_proc.HeaderMutation
 
@@ -185,6 +188,16 @@ func (r *OpenAIRouter) handleResponseHeaders(v *ext_proc.ProcessingRequest_Respo
 				Header: &core.HeaderValue{
 					Key:      headers.VSRMatchedPreference,
 					RawValue: []byte(strings.Join(ctx.VSRMatchedPreference, ",")),
+				},
+			})
+		}
+
+		// Attach router replay identifier when available
+		if ctx.RouterReplayID != "" {
+			setHeaders = append(setHeaders, &core.HeaderValueOption{
+				Header: &core.HeaderValue{
+					Key:      headers.RouterReplayID,
+					RawValue: []byte(ctx.RouterReplayID),
 				},
 			})
 		}

--- a/src/semantic-router/pkg/extproc/req_filter_cache.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache.go
@@ -75,6 +75,8 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext, categoryName string) (
 				ctx.VSRSelectedDecisionName = categoryName
 			}
 
+			// Start router replay capture if enabled, even when serving from cache
+			r.startRouterReplay(ctx, requestModel, requestModel, categoryName)
 			// Log cache hit
 			logging.LogEvent("cache_hit", map[string]interface{}{
 				"request_id": ctx.RequestID,
@@ -85,6 +87,8 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext, categoryName string) (
 			})
 			// Return immediate response from cache
 			response := http.CreateCacheHitResponse(cachedResponse, ctx.ExpectStreamingResponse, categoryName, ctx.VSRSelectedDecisionName, ctx.VSRMatchedKeywords)
+			r.updateRouterReplayStatus(ctx, 200, ctx.ExpectStreamingResponse)
+			r.attachRouterReplayResponse(ctx, cachedResponse, true)
 			ctx.TraceContext = spanCtx
 			return response, true
 		}

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -49,6 +49,10 @@ const (
 	// VSRCacheHit indicates that the response was served from cache.
 	// Value: "true"
 	VSRCacheHit = "x-vsr-cache-hit"
+
+	// RouterReplayID carries the identifier for a captured replay record.
+	// Value: opaque replay token
+	RouterReplayID = "x-vsr-replay-id"
 )
 
 // VSR Signal Tracking Headers

--- a/src/semantic-router/pkg/k8s/converter.go
+++ b/src/semantic-router/pkg/k8s/converter.go
@@ -263,6 +263,20 @@ func validatePluginConfiguration(pluginType string, rawConfig []byte) error {
 			}
 		}
 
+	case "router_replay":
+		var cfg config.RouterReplayPluginConfig
+		decoder := json.NewDecoder(bytes.NewReader(rawConfig))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&cfg); err != nil {
+			return fmt.Errorf("failed to unmarshal router_replay config: %w", err)
+		}
+		if cfg.MaxRecords < 0 {
+			return fmt.Errorf("router_replay max_records cannot be negative")
+		}
+		if cfg.MaxBodyBytes < 0 {
+			return fmt.Errorf("router_replay max_body_bytes cannot be negative")
+		}
+
 	default:
 		return fmt.Errorf("unknown plugin type: %s", pluginType)
 	}

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -1,0 +1,282 @@
+package routerreplay
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultMaxRecords   = 200
+	DefaultMaxBodyBytes = 4096 // 4KB
+)
+
+type Signal struct {
+	Keyword      []string `json:"keyword,omitempty"`
+	Embedding    []string `json:"embedding,omitempty"`
+	Domain       []string `json:"domain,omitempty"`
+	FactCheck    []string `json:"fact_check,omitempty"`
+	UserFeedback []string `json:"user_feedback,omitempty"`
+	Preference   []string `json:"preference,omitempty"`
+}
+
+type RoutingRecord struct {
+	ID                    string    `json:"id"`
+	Timestamp             time.Time `json:"timestamp"`
+	RequestID             string    `json:"request_id,omitempty"`
+	Decision              string    `json:"decision,omitempty"`
+	Category              string    `json:"category,omitempty"`
+	OriginalModel         string    `json:"original_model,omitempty"`
+	SelectedModel         string    `json:"selected_model,omitempty"`
+	ReasoningMode         string    `json:"reasoning_mode,omitempty"`
+	Signals               Signal    `json:"signals"`
+	RequestBody           string    `json:"request_body,omitempty"`
+	ResponseBody          string    `json:"response_body,omitempty"`
+	ResponseStatus        int       `json:"response_status,omitempty"`
+	FromCache             bool      `json:"from_cache,omitempty"`
+	Streaming             bool      `json:"streaming,omitempty"`
+	RequestBodyTruncated  bool      `json:"request_body_truncated,omitempty"`
+	ResponseBodyTruncated bool      `json:"response_body_truncated,omitempty"`
+}
+
+type Recorder struct {
+	mu sync.Mutex
+
+	records []*RoutingRecord
+	byID    map[string]*RoutingRecord
+
+	maxRecords   int
+	maxBodyBytes int
+
+	captureRequestBody  bool
+	captureResponseBody bool
+}
+
+func NewRecorder(maxRecords int) *Recorder {
+	if maxRecords <= 0 {
+		maxRecords = DefaultMaxRecords
+	}
+
+	return &Recorder{
+		records:      make([]*RoutingRecord, 0, maxRecords),
+		byID:         make(map[string]*RoutingRecord),
+		maxRecords:   maxRecords,
+		maxBodyBytes: DefaultMaxBodyBytes,
+	}
+}
+
+func (r *Recorder) SetCapturePolicy(captureRequest, captureResponse bool, maxBodyBytes int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.captureRequestBody = captureRequest
+	r.captureResponseBody = captureResponse
+
+	if maxBodyBytes > 0 {
+		r.maxBodyBytes = maxBodyBytes
+	} else {
+		r.maxBodyBytes = DefaultMaxBodyBytes
+	}
+}
+
+func (r *Recorder) ShouldCaptureRequest() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.captureRequestBody
+}
+
+func (r *Recorder) ShouldCaptureResponse() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.captureResponseBody
+}
+
+func (r *Recorder) SetMaxRecords(max int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if max <= 0 {
+		max = DefaultMaxRecords
+	}
+	r.maxRecords = max
+
+	for len(r.records) > r.maxRecords {
+		oldest := r.records[0]
+		delete(r.byID, oldest.ID)
+		r.records = r.records[1:]
+	}
+}
+
+func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if rec.ID == "" {
+		id, err := generateID()
+		if err != nil {
+			return "", err
+		}
+		rec.ID = id
+	}
+
+	if rec.Timestamp.IsZero() {
+		rec.Timestamp = time.Now().UTC()
+	}
+
+	if r.captureRequestBody && len(rec.RequestBody) > r.maxBodyBytes {
+		rec.RequestBody = rec.RequestBody[:r.maxBodyBytes]
+		rec.RequestBodyTruncated = true
+	}
+
+	if r.captureResponseBody && len(rec.ResponseBody) > r.maxBodyBytes {
+		rec.ResponseBody = rec.ResponseBody[:r.maxBodyBytes]
+		rec.ResponseBodyTruncated = true
+	}
+
+	if len(r.records) >= r.maxRecords {
+		oldest := r.records[0]
+		delete(r.byID, oldest.ID)
+		r.records = r.records[1:]
+	}
+
+	copyRec := rec
+	r.records = append(r.records, &copyRec)
+	r.byID[copyRec.ID] = &copyRec
+
+	return copyRec.ID, nil
+}
+
+func (r *Recorder) UpdateStatus(id string, status int, fromCache bool, streaming bool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rec, ok := r.byID[id]
+	if !ok {
+		return fmt.Errorf("record with ID %s not found", id)
+	}
+
+	if status != 0 {
+		rec.ResponseStatus = status
+	}
+	rec.FromCache = rec.FromCache || fromCache
+	rec.Streaming = rec.Streaming || streaming
+
+	return nil
+}
+
+func (r *Recorder) AttachRequest(id string, requestBody []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rec, ok := r.byID[id]
+	if !ok {
+		return fmt.Errorf("record with ID %s not found", id)
+	}
+
+	if !r.captureRequestBody {
+		return nil
+	}
+
+	body, truncated := truncateBody(requestBody, r.maxBodyBytes)
+	rec.RequestBody = body
+	rec.RequestBodyTruncated = rec.RequestBodyTruncated || truncated
+
+	return nil
+}
+
+func (r *Recorder) AttachResponse(id string, responseBody []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rec, ok := r.byID[id]
+	if !ok {
+		return fmt.Errorf("record with ID %s not found", id)
+	}
+
+	if !r.captureResponseBody {
+		return nil
+	}
+
+	body, truncated := truncateBody(responseBody, r.maxBodyBytes)
+	rec.ResponseBody = body
+	rec.ResponseBodyTruncated = rec.ResponseBodyTruncated || truncated
+
+	return nil
+}
+
+// GetRecord returns a copy of the record with the given ID.
+func (r *Recorder) GetRecord(id string) (RoutingRecord, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rec, ok := r.byID[id]
+	if !ok {
+		return RoutingRecord{}, false
+	}
+
+	return *rec, true
+}
+
+func (r *Recorder) ListAllRecords() []RoutingRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]RoutingRecord, 0, len(r.records))
+	for _, rec := range r.records {
+		out = append(out, *rec)
+	}
+	return out
+}
+
+func generateID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func truncateBody(body []byte, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(body) <= maxBytes {
+		return string(body), false
+	}
+	return string(body[:maxBytes]), true
+}
+
+func (r *RoutingRecord) LogFields(event string) map[string]interface{} {
+	fields := map[string]interface{}{
+		"event":           event,
+		"replay_id":       r.ID,
+		"decision":        r.Decision,
+		"category":        r.Category,
+		"original_model":  r.OriginalModel,
+		"selected_model":  r.SelectedModel,
+		"reasoning_mode":  r.ReasoningMode,
+		"request_id":      r.RequestID,
+		"timestamp":       r.Timestamp,
+		"from_cache":      r.FromCache,
+		"streaming":       r.Streaming,
+		"response_status": r.ResponseStatus,
+		"signals": map[string]interface{}{
+			"keyword":       r.Signals.Keyword,
+			"embedding":     r.Signals.Embedding,
+			"domain":        r.Signals.Domain,
+			"fact_check":    r.Signals.FactCheck,
+			"user_feedback": r.Signals.UserFeedback,
+			"preference":    r.Signals.Preference,
+		},
+	}
+
+	if r.RequestBody != "" {
+		fields["request_body"] = r.RequestBody
+		fields["request_body_truncated"] = r.RequestBodyTruncated
+	}
+	if r.ResponseBody != "" {
+		fields["response_body"] = r.ResponseBody
+		fields["response_body_truncated"] = r.ResponseBodyTruncated
+	}
+
+	return fields
+}


### PR DESCRIPTION
This PR adds a new `router_replay` decision plugin that records routing decisions, matched signals, selected models, and optionally captures request/response bodies. Records are stored in an in-memory ring buffer and exposed via REST API for debugging and analysis.

## Key Changes

- **New package**: `pkg/routerreplay` - in-memory ring buffer recorder
- **Config**: Added `RouterReplayPluginConfig` (enabled, max_records, capture bodies, max_body_bytes)
- **API endpoints**: 
  - `GET /v1/router_replay` - list records
  - `GET /v1/router_replay/{id}` - get specific record
- **Integration**: Capture on routing, cache hits, and response completion
- **Header**: Add `x-vsr-replay-id` to responses when enabled
- **Logging**: Structured events for `router_replay_start` and `router_replay_complete`


## Configuration Example

```yaml
decisions:
  - name: "math_decision"
    plugins:
      - type: "router_replay"
        configuration:
          enabled: true
          max_records: 100
          capture_request_body: true
          capture_response_body: true
          max_body_bytes: 2048
 ```
## Testing
Tested with Docker Compose stack:
1. Curl request:
```
curl -X POST http://localhost:8801/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "auto", "messages": [{"role": "user", "content": "What is 2+2?"}]}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   806  100   730  100    76   1647    171 --:--:-- --:--:-- --:--:--  1819
{
  "id": "chatcmpl-cache-1768399572",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "logprobs": {
        "content": null,
        "refusal": null
      },
      "message": {
        "content": "[mock-qwen3] You said: What is 2+2?",
        "refusal": "",
        "role": "assistant",
        "annotations": null,
        "audio": {
          "id": "",
          "data": "",
          "expires_at": 0,
          "transcript": ""
        },
        "function_call": {
          "arguments": "",
          "name": ""
        },
        "tool_calls": null
      }
    }
  ],
  "created": 1768399572,
  "model": "qwen3",
  "object": "chat.completion",
  "service_tier": "",
  "system_fingerprint": "mock-vllm",
  "usage": {
    "completion_tokens": 9,
    "prompt_tokens": 40,
    "total_tokens": 49,
    "completion_tokens_details": {
      "accepted_prediction_tokens": 0,
      "audio_tokens": 0,
      "reasoning_tokens": 0,
      "rejected_prediction_tokens": 0
    },
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": 0
    }
  }
 ```
2. API Response for replay 
```
curl http://localhost:8801/v1/router_replay | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1148  100  1148    0     0   189k      0 --:--:-- --:--:-- --:--:--  224k
{
  "count": 1,
  "data": [
    {
      "id": "08b5ccea7f63eab925827d4605fa9891",
      "timestamp": "2026-01-14T13:57:32.51708509Z",
      "request_id": "4a424ac7-b631-4053-bbc3-a5eecba11b1c",
      "decision": "math_decision",
      "category": "math",
      "original_model": "auto",
      "selected_model": "qwen3",
      "reasoning_mode": "on",
      "signals": {
        "domain": [
          "math"
        ]
      },
      "request_body": "{\"model\": \"auto\", \"messages\": [{\"role\": \"user\", \"content\": \"What is 2+2?\"}]}",
      "response_body": "{\"id\":\"cmpl-mock-123\",\"object\":\"chat.completion\",\"created\":1768399052,\"model\":\"qwen3\",\"system_fingerprint\":\"mock-vllm\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"[mock-qwen3] You said: What is 2+2?\"},\"finish_reason\":\"stop\",\"logprobs\":null}],\"usage\":{\"prompt_tokens\":40,\"completion_tokens\":9,\"total_tokens\":49,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}},\"token_usage\":{\"prompt_tokens\":40,\"completion_tokens\":9,\"total_tokens\":49,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}}}",
      "response_status": 200
    }
  ],
  "object": "router_replay.list"
}
```
3. Semantic Router Logs
```
{"level":"info","ts":"2026-01-14T13:57:32","caller":"req_filter_sys_prompt.go:156","msg":"Added category-specific system prompt to the beginning of messages (mode: replace)"}
{"level":"info","ts":"2026-01-14T13:57:32","caller":"processor_req_body.go:355","msg":"createRoutingResponse: modifiedBody length=295, model=qwen3, endpoint=172.28.0.10:8000"}
{"level":"info","ts":"2026-01-14T13:57:32","caller":"recorder.go:23","msg":"routing_decision","decision":"math_decision","reasoning_enabled":true,"reasoning_effort":"high","routing_latency_ms":1091,"event":"routing_decision","reason_code":"auto_routing","original_model":"auto","selected_model":"qwen3","request_id":"4a424ac7-b631-4053-bbc3-a5eecba11b1c"}
{"level":"info","ts":"2026-01-14T13:57:32","caller":"recorder.go:155","msg":"router_replay_start","selected_model":"qwen3","timestamp":"2026-01-14T13:57:32","from_cache":false,"decision":"math_decision","request_id":"4a424ac7-b631-4053-bbc3-a5eecba11b1c","response_status":0,"request_body":"{\"model\": \"auto\", \"messages\": [{\"role\": \"user\", \"content\": \"What is 2+2?\"}]}","reasoning_mode":"on","streaming":false,"request_body_truncated":false,"category":"math","original_model":"auto","signals":{"domain":["math"],"embedding":null,"fact_check":null,"keyword":null,"preference":null,"user_feedback":null},"event":"router_replay_start","replay_id":"08b5ccea7f63eab925827d4605fa9891"}
{"level":"info","ts":"2026-01-14T13:57:32","caller":"processor_res_body.go:131","msg":"llm_usage","currency":"unknown","event":"llm_usage","request_id":"4a424ac7-b631-4053-bbc3-a5eecba11b1c","model":"qwen3","total_tokens":49,"pricing":"not_configured","prompt_tokens":40,"completion_tokens":9,"completion_latency_ms":1097,"cost":0}
{"level":"info","ts":"2026-01-14T13:57:32","caller":"processor_res_body.go:153","msg":"Cache updated for request ID: 4a424ac7-b631-4053-bbc3-a5eecba11b1c"}
{"level":"info","ts":"2026-01-14T13:57:32","caller":"req_filter_fact_check.go:118","msg":"Skipping hallucination detection: classifier not available or hallucination detection not enabled"}
{"level":"info","ts":"2026-01-14T13:57:32","caller":"recorder.go:183","msg":"router_replay_complete","response_body":"{\"id\":\"cmpl-mock-123\",\"object\":\"chat.completion\",\"created\":1768399052,\"model\":\"qwen3\",\"system_fingerprint\":\"mock-vllm\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"[mock-qwen3] You said: What is 2+2?\"},\"finish_reason\":\"stop\",\"logprobs\":null}],\"usage\":{\"prompt_tokens\":40,\"completion_tokens\":9,\"total_tokens\":49,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}},\"token_usage\":{\"prompt_tokens\":40,\"completion_tokens\":9,\"total_tokens\":49,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}}}","response_body_truncated":false,"request_body":"{\"model\": \"auto\", \"messages\": [{\"role\": \"user\", \"content\": \"What is 2+2?\"}]}","replay_id":"08b5ccea7f63eab925827d4605fa9891","selected_model":"qwen3","timestamp":"2026-01-14T13:57:32","streaming":false,"category":"math","original_model":"auto","request_body_truncated":false,"signals":{"domain":["math"],"embedding":null,"fact_check":null,"keyword":null,"preference":null,"user_feedback":null},"decision":"math_decision","reasoning_mode":"on","from_cache":false,"response_status":200,"event":"router_replay_complete","request_id":"4a424ac7-b631-4053-bbc3-a5eecba11b1c"}
```
FIX #991 


---

- [x] Make sure the code changes pass the [pre-commit](https://github.com/vllm-project/semantic-router/blob/main/CONTRIBUTING.md) checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the type of changes, such as `[Bugfix]`, `[Feat]`, and `[CI]`.

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> Detailed Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to semantic-router! Before submitting the pull request, please ensure the PR meets the following criteria. This helps us maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Please try to classify PRs for easy understanding of the type of changes. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[CLI]</code> for changes to the command-line interface tools.</li>
    <li><code>[Dashboard]</code> for changes to the dashboard or web UI.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Feat]</code> for new features in the cluster (e.g., autoscaling, disaggregated prefill, etc.).</li>
    <li><code>[Router]</code> for changes to the <code>vllm_router</code> (e.g., routing algorithm, router observability, etc.).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>Pass all linter checks. Please use <code>pre-commit</code> to format your code. See <code>README.md</code> for installation.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li> Please include sufficient tests to ensure the change is stay correct and robust. This includes both unit tests and integration tests.</li>
</ul>

<h3>DCO and Signed-off-by</h3>
<p>When contributing changes to this project, you must agree to the <a href="https://github.com/vllm-project/vllm/blob/main/DCO">DCO</a>. Commits must include a <code>Signed-off-by:</code> header which certifies agreement with the terms of the DCO.</p>
<p>Using <code>-s</code> with <code>git commit</code> will automatically add this header.</p>

<h3>What to Expect for the Reviews</h3>
