### PR TITLE
feat(selection): add Elo storage, RouterDC embeddings, and AutoMix cascading

### DIFF
--- a/examples/model_selection_enhanced.yaml
+++ b/examples/model_selection_enhanced.yaml
@@ -1,0 +1,119 @@
+# Example configuration demonstrating the enhanced model selection features
+# This config showcases:
+# 1. Elo Persistent Storage - ratings survive restarts
+# 2. RouterDC Model Embeddings - models described with natural language
+# 3. AutoMix Confidence Cascading - cost-aware escalation
+# 4. Quality Score Config - per-model quality estimates for cost-quality tradeoffs
+# 5. Feedback REST API - submit feedback via POST /api/v1/feedback
+
+backend_models:
+  models:
+    - id: "llama3.2:3b"
+      description: "Fast, efficient model for simple queries and basic chat"
+      capabilities: ["chat", "simple-qa", "translation"]
+      param_size: "3b"
+      quality_score: 0.65  # Lower quality but fast and cheap
+      pricing:
+        prompt_per_1m: 0.05
+        completion_per_1m: 0.15
+
+    - id: "phi4"
+      description: "Code generation specialist, optimized for Python and Go programming"
+      capabilities: ["code", "code-review", "debugging", "documentation"]
+      param_size: "14b"
+      quality_score: 0.85  # Good quality for code tasks
+      pricing:
+        prompt_per_1m: 0.20
+        completion_per_1m: 0.60
+
+    - id: "llama3.3:70b"
+      description: "Large model for complex reasoning, analysis, and creative tasks"
+      capabilities: ["reasoning", "analysis", "creative", "math", "complex-qa"]
+      param_size: "70b"
+      quality_score: 0.95  # Highest quality
+      pricing:
+        prompt_per_1m: 1.00
+        completion_per_1m: 3.00
+
+  endpoints:
+    - name: "ollama-local"
+      url: "http://localhost:11434/v1/chat/completions"
+
+# Decision routing with model selection algorithms
+decisions:
+  - name: "coding"
+    classifier:
+      examples:
+        - "Write a Python function that..."
+        - "Debug this code..."
+        - "How do I implement..."
+    algorithm:
+      type: "confidence"
+      confidence:
+        # Use cost-aware cascading (AutoMix-style)
+        escalation_order: "cost"  # Options: "size", "cost", "automix"
+        confidence_method: "margin"
+        threshold: 0.6
+    targets:
+      - model: "phi4"
+      - model: "llama3.3:70b"  # Fallback for complex code
+
+  - name: "reasoning"
+    classifier:
+      examples:
+        - "Explain why..."
+        - "Analyze the implications..."
+        - "Compare and contrast..."
+    algorithm:
+      type: "confidence"
+      confidence:
+        # POMDP-optimized escalation with quality/cost tradeoff
+        escalation_order: "automix"
+        cost_quality_tradeoff: 0.3  # Favor quality (0.0) vs cost (1.0)
+        threshold: 0.7
+    targets:
+      - model: "llama3.2:3b"
+      - model: "llama3.3:70b"
+
+  - name: "general"
+    classifier:
+      examples:
+        - "Hello"
+        - "What is..."
+        - "Tell me about..."
+    algorithm:
+      # Use Elo-based selection with persistent storage
+      type: "elo"
+      elo:
+        initial_rating: 1500
+        k_factor: 32
+        category_weighted: true
+        storage_path: "/var/lib/vsr/elo_ratings.json"  # Ratings persist across restarts
+        auto_save_interval: "30s"
+    targets:
+      - model: "llama3.2:3b"
+      - model: "phi4"
+      - model: "llama3.3:70b"
+
+  - name: "embedding_match"
+    classifier:
+      examples:
+        - "Query that should match model capabilities"
+    algorithm:
+      # RouterDC uses model descriptions for embedding-based matching
+      type: "router_dc"
+      router_dc:
+        temperature: 0.07
+        min_similarity: 0.3
+        require_descriptions: true  # Fail if models lack descriptions
+        use_capabilities: true      # Include capabilities in embedding
+    targets:
+      - model: "llama3.2:3b"
+      - model: "phi4"
+      - model: "llama3.3:70b"
+
+# Default decision when no match
+default_decision:
+  name: "fallback"
+  model: "llama3.2:3b"
+

--- a/src/semantic-router/pkg/apiserver/route_feedback.go
+++ b/src/semantic-router/pkg/apiserver/route_feedback.go
@@ -1,0 +1,150 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection"
+)
+
+// FeedbackRequest represents a request to submit model selection feedback
+type FeedbackRequest struct {
+	// Query is the original query that was processed
+	Query string `json:"query,omitempty"`
+
+	// WinnerModel is the model that was preferred (required)
+	WinnerModel string `json:"winner_model"`
+
+	// LoserModel is the model that was not preferred (optional)
+	LoserModel string `json:"loser_model,omitempty"`
+
+	// Tie indicates if both models performed equally
+	Tie bool `json:"tie,omitempty"`
+
+	// DecisionName is the category/decision context (optional)
+	DecisionName string `json:"decision_name,omitempty"`
+}
+
+// FeedbackResponse represents the response from feedback submission
+type FeedbackResponse struct {
+	Success   bool   `json:"success"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+}
+
+// handleFeedback handles POST /api/v1/feedback for submitting model selection feedback
+func (s *ClassificationAPIServer) handleFeedback(w http.ResponseWriter, r *http.Request) {
+	var req FeedbackRequest
+	if err := s.parseJSONRequest(r, &req); err != nil {
+		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+		return
+	}
+
+	// Validate required field
+	if req.WinnerModel == "" {
+		s.writeErrorResponse(w, http.StatusBadRequest, "MISSING_WINNER", "winner_model is required")
+		return
+	}
+
+	// Get the Elo selector from the global registry
+	selector, ok := selection.GlobalRegistry.Get(selection.MethodElo)
+	if !ok {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "ELO_NOT_CONFIGURED",
+			"Elo selection is not configured. Enable elo selection to use feedback API.")
+		return
+	}
+
+	// Create feedback object
+	feedback := &selection.Feedback{
+		Query:        req.Query,
+		WinnerModel:  req.WinnerModel,
+		LoserModel:   req.LoserModel,
+		Tie:          req.Tie,
+		DecisionName: req.DecisionName,
+		Timestamp:    time.Now().Unix(),
+	}
+
+	// Submit feedback to the selector
+	ctx := context.Background()
+	if err := selector.UpdateFeedback(ctx, feedback); err != nil {
+		logging.Errorf("[FeedbackAPI] Failed to update feedback: %v", err)
+		s.writeErrorResponse(w, http.StatusInternalServerError, "FEEDBACK_FAILED", err.Error())
+		return
+	}
+
+	logging.Infof("[FeedbackAPI] Feedback recorded: winner=%s, loser=%s, tie=%v, decision=%s",
+		req.WinnerModel, req.LoserModel, req.Tie, req.DecisionName)
+
+	// Return success response
+	response := FeedbackResponse{
+		Success:   true,
+		Message:   "Feedback recorded successfully",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	s.writeJSONResponse(w, http.StatusOK, response)
+}
+
+// RatingInfo represents a single model's rating information for API response
+type RatingInfo struct {
+	Model  string  `json:"model"`
+	Rating float64 `json:"rating"`
+	Wins   int     `json:"wins"`
+	Losses int     `json:"losses"`
+	Ties   int     `json:"ties"`
+}
+
+// handleGetRatings handles GET /api/v1/ratings for retrieving current Elo ratings
+func (s *ClassificationAPIServer) handleGetRatings(w http.ResponseWriter, r *http.Request) {
+	// Get the Elo selector from the global registry
+	selector, ok := selection.GlobalRegistry.Get(selection.MethodElo)
+	if !ok {
+		s.writeErrorResponse(w, http.StatusServiceUnavailable, "ELO_NOT_CONFIGURED",
+			"Elo selection is not configured. Enable elo selection to view ratings.")
+		return
+	}
+
+	// Type assert to get the EloSelector
+	eloSelector, ok := selector.(*selection.EloSelector)
+	if !ok {
+		s.writeErrorResponse(w, http.StatusInternalServerError, "INTERNAL_ERROR",
+			"Failed to get Elo selector instance")
+		return
+	}
+
+	// Get optional category filter from query params
+	category := r.URL.Query().Get("category")
+
+	// Get ratings using existing GetLeaderboard method
+	leaderboard := eloSelector.GetLeaderboard(category)
+
+	// Convert to API response format
+	ratings := make([]RatingInfo, 0, len(leaderboard))
+	for _, r := range leaderboard {
+		ratings = append(ratings, RatingInfo{
+			Model:  r.Model,
+			Rating: r.Rating,
+			Wins:   r.Wins,
+			Losses: r.Losses,
+			Ties:   r.Ties,
+		})
+	}
+
+	// Format response
+	categoryLabel := category
+	if categoryLabel == "" {
+		categoryLabel = "global"
+	}
+
+	response := map[string]interface{}{
+		"ratings":   ratings,
+		"category":  categoryLabel,
+		"count":     len(ratings),
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}
+
+	s.writeJSONResponse(w, http.StatusOK, response)
+}

--- a/src/semantic-router/pkg/apiserver/route_feedback_test.go
+++ b/src/semantic-router/pkg/apiserver/route_feedback_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package apiserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection"
+)
+
+func TestHandleFeedback_Success(t *testing.T) {
+	// Register a test Elo selector
+	cfg := &selection.EloConfig{
+		InitialRating: 1500.0,
+		KFactor:       32.0,
+	}
+	eloSelector := selection.NewEloSelector(cfg)
+	selection.GlobalRegistry.Register(selection.MethodElo, eloSelector)
+
+	// Create test server
+	server := &ClassificationAPIServer{}
+
+	// Create request
+	reqBody := FeedbackRequest{
+		WinnerModel:  "gpt-4",
+		LoserModel:   "llama-70b",
+		DecisionName: "coding",
+		Query:        "Write a function",
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/feedback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Call handler
+	server.handleFeedback(w, req)
+
+	// Check response
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp FeedbackResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	if !resp.Success {
+		t.Errorf("Expected success=true, got false: %s", resp.Message)
+	}
+
+	t.Logf("✅ Feedback API works! Response: %+v", resp)
+}
+
+func TestHandleFeedback_MissingWinner(t *testing.T) {
+	server := &ClassificationAPIServer{}
+
+	reqBody := FeedbackRequest{
+		WinnerModel: "", // Missing!
+		LoserModel:  "llama-70b",
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/feedback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.handleFeedback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for missing winner, got %d", w.Code)
+	}
+
+	t.Logf("✅ Missing winner validation works!")
+}
+
+func TestHandleGetRatings_Success(t *testing.T) {
+	// Register a test Elo selector with some ratings
+	cfg := &selection.EloConfig{
+		InitialRating: 1500.0,
+		KFactor:       32.0,
+	}
+	eloSelector := selection.NewEloSelector(cfg)
+
+	// Add some test feedback to create ratings
+	err := eloSelector.UpdateFeedback(context.Background(), &selection.Feedback{
+		WinnerModel:  "gpt-4",
+		LoserModel:   "llama-70b",
+		DecisionName: "coding",
+	})
+	if err != nil {
+		t.Fatalf("Failed to update feedback: %v", err)
+	}
+
+	selection.GlobalRegistry.Register(selection.MethodElo, eloSelector)
+
+	server := &ClassificationAPIServer{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ratings?category=coding", nil)
+	w := httptest.NewRecorder()
+
+	server.handleGetRatings(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	t.Logf("✅ Get Ratings API works! Response: %s", w.Body.String())
+}

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -128,6 +128,10 @@ func (s *ClassificationAPIServer) setupRoutes() *http.ServeMux {
 	// Metrics endpoints
 	mux.HandleFunc("GET /metrics/classification", s.handleClassificationMetrics)
 
+	// Model selection feedback endpoints
+	mux.HandleFunc("POST /api/v1/feedback", s.handleFeedback)
+	mux.HandleFunc("GET /api/v1/ratings", s.handleGetRatings)
+
 	// Configuration endpoints
 	mux.HandleFunc("GET /config/classification", s.handleGetConfig)
 	mux.HandleFunc("PUT /config/classification", s.handleUpdateConfig)

--- a/src/semantic-router/pkg/looper/confidence.go
+++ b/src/semantic-router/pkg/looper/confidence.go
@@ -18,6 +18,7 @@ package looper
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
@@ -25,9 +26,75 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openai/openai-go"
+
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
+
+// SelfVerificationPrompt is the prompt template for AutoMix self-verification
+// The model evaluates its own answer and provides a confidence score
+const SelfVerificationPrompt = `You are evaluating the quality of an AI assistant's response.
+
+Original Question: %s
+
+AI's Response: %s
+
+Rate the quality and correctness of this response on a scale of 0.0 to 1.0:
+- 1.0 = Completely correct, comprehensive, and well-explained
+- 0.8 = Mostly correct with minor issues
+- 0.6 = Partially correct but missing important details
+- 0.4 = Has some correct elements but significant errors
+- 0.2 = Mostly incorrect or irrelevant
+- 0.0 = Completely wrong or harmful
+
+Respond with ONLY a JSON object in this format:
+{"confidence": 0.X, "reason": "brief explanation"}
+`
+
+// SelfVerificationResult represents the parsed result of self-verification
+type SelfVerificationResult struct {
+	Confidence float64 `json:"confidence"`
+	Reason     string  `json:"reason"`
+}
+
+// parseSelfVerification parses the model's self-verification response
+func parseSelfVerification(response string) (*SelfVerificationResult, error) {
+	// Try to extract JSON from the response
+	response = strings.TrimSpace(response)
+
+	// Find JSON object in response
+	startIdx := strings.Index(response, "{")
+	endIdx := strings.LastIndex(response, "}")
+	if startIdx == -1 || endIdx == -1 || endIdx < startIdx {
+		// Try to extract just a number
+		re := regexp.MustCompile(`([0-9]+\.?[0-9]*)`)
+		matches := re.FindStringSubmatch(response)
+		if len(matches) >= 2 {
+			confidence, err := strconv.ParseFloat(matches[1], 64)
+			if err == nil && confidence >= 0 && confidence <= 1 {
+				return &SelfVerificationResult{Confidence: confidence, Reason: "parsed from numeric response"}, nil
+			}
+		}
+		return nil, fmt.Errorf("no valid JSON or confidence value found in response")
+	}
+
+	jsonStr := response[startIdx : endIdx+1]
+	var result SelfVerificationResult
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse self-verification JSON: %w", err)
+	}
+
+	// Clamp confidence to valid range
+	if result.Confidence < 0 {
+		result.Confidence = 0
+	}
+	if result.Confidence > 1 {
+		result.Confidence = 1
+	}
+
+	return &result, nil
+}
 
 // ConfidenceLooper implements confidence model selection.
 // It tries smaller models first and escalates to larger models if confidence is low.
@@ -110,9 +177,126 @@ func sortModelRefsBySize(refs []config.ModelRef, modelParams map[string]config.M
 	return sorted
 }
 
+// sortModelRefsByCost sorts ModelRefs by their pricing (cheapest first)
+// Uses prompt_per_1m from ModelParams.Pricing
+func sortModelRefsByCost(refs []config.ModelRef, modelParams map[string]config.ModelParams) []config.ModelRef {
+	sorted := make([]config.ModelRef, len(refs))
+	copy(sorted, refs)
+
+	// Helper function to get cost for a model ref
+	getCost := func(ref config.ModelRef) float64 {
+		if modelParams != nil {
+			if params, ok := modelParams[ref.Model]; ok {
+				return params.Pricing.PromptPer1M
+			}
+		}
+		return math.MaxFloat64 // Unknown cost goes last
+	}
+
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return getCost(sorted[i]) < getCost(sorted[j])
+	})
+
+	return sorted
+}
+
+// sortModelRefsByAutoMix sorts ModelRefs using POMDP-inspired cost-quality optimization
+// Models are scored by: value = (1 - tradeoff) * quality + tradeoff * (1 - normalized_cost)
+// Lower tradeoff values favor quality; higher values favor cost savings
+func sortModelRefsByAutoMix(refs []config.ModelRef, modelParams map[string]config.ModelParams, tradeoff float64) []config.ModelRef {
+	sorted := make([]config.ModelRef, len(refs))
+	copy(sorted, refs)
+
+	// First, compute min/max cost for normalization
+	minCost, maxCost := math.MaxFloat64, 0.0
+	for _, ref := range refs {
+		if modelParams != nil {
+			if params, ok := modelParams[ref.Model]; ok {
+				cost := params.Pricing.PromptPer1M
+				if cost > 0 {
+					if cost < minCost {
+						minCost = cost
+					}
+					if cost > maxCost {
+						maxCost = cost
+					}
+				}
+			}
+		}
+	}
+
+	// Prevent division by zero
+	costRange := maxCost - minCost
+	if costRange <= 0 {
+		costRange = 1.0
+	}
+
+	// Helper to compute AutoMix value for a model
+	getValue := func(ref config.ModelRef) float64 {
+		quality := 0.5   // Default quality estimate
+		costScore := 0.5 // Default cost score (mid-range)
+
+		if modelParams != nil {
+			if params, ok := modelParams[ref.Model]; ok {
+				// Use configured QualityScore if available
+				if params.QualityScore > 0 && params.QualityScore <= 1.0 {
+					quality = params.QualityScore
+				} else {
+					// Fallback: estimate quality from param_size (larger = higher quality)
+					size := parseParamSize(params.ParamSize)
+					if size > 0 {
+						// Normalize size: assume 1B-70B range maps to 0.3-1.0 quality
+						quality = 0.3 + 0.7*math.Min(float64(size)/70000, 1.0)
+					}
+				}
+
+				// Normalize cost: 0 = most expensive, 1 = cheapest
+				cost := params.Pricing.PromptPer1M
+				if cost > 0 && costRange > 0 {
+					costScore = 1.0 - (cost-minCost)/costRange
+				}
+			}
+		}
+
+		// POMDP-inspired value function:
+		// value = (1 - tradeoff) * quality + tradeoff * costScore
+		// When tradeoff = 0: pure quality ordering
+		// When tradeoff = 1: pure cost ordering (cheapest first)
+		// When tradeoff = 0.3: favor quality but consider cost
+		value := (1-tradeoff)*quality + tradeoff*costScore
+		return value
+	}
+
+	// Sort by value ascending (start with lower-value/cheaper models for cascading)
+	// This matches AutoMix behavior: try cheaper/smaller models first
+	sort.SliceStable(sorted, func(i, j int) bool {
+		// For cascading: we want to try "worse" (cheaper/smaller) models first
+		// So we sort by value ASCENDING to start with lower-value options
+		return getValue(sorted[i]) < getValue(sorted[j])
+	})
+
+	return sorted
+}
+
+// getEscalationOrder returns the configured escalation order, defaulting to "size"
+func getEscalationOrder(cfg *config.ConfidenceAlgorithmConfig) string {
+	if cfg == nil || cfg.EscalationOrder == "" {
+		return "size"
+	}
+	return cfg.EscalationOrder
+}
+
+// getCostQualityTradeoff returns the configured tradeoff, defaulting to 0.3
+func getCostQualityTradeoff(cfg *config.ConfidenceAlgorithmConfig) float64 {
+	if cfg == nil || cfg.CostQualityTradeoff <= 0 {
+		return 0.3
+	}
+	return cfg.CostQualityTradeoff
+}
+
 // ConfidenceEvaluator evaluates model response confidence based on configured method
 type ConfidenceEvaluator struct {
-	Method        string  // "avg_logprob", "margin", or "hybrid"
+	Method        string  // "avg_logprob", "margin", "hybrid", or "self_verify" (AutoMix)
 	Threshold     float64 // Threshold for the chosen method
 	LogprobWeight float64 // Weight for logprob in hybrid mode
 	MarginWeight  float64 // Weight for margin in hybrid mode
@@ -148,6 +332,8 @@ func NewConfidenceEvaluator(cfg *config.ConfidenceAlgorithmConfig) *ConfidenceEv
 			eval.Threshold = 0.5 // Moderate confidence
 		case "hybrid":
 			eval.Threshold = 0.5 // Normalized score
+		case "self_verify":
+			eval.Threshold = 0.7 // AutoMix paper default
 		}
 	}
 
@@ -224,7 +410,16 @@ func (e *ConfidenceEvaluator) Evaluate(resp *ModelResponse) (float64, bool) {
 
 // NeedsLogprobs returns whether this evaluator needs logprobs enabled
 func (e *ConfidenceEvaluator) NeedsLogprobs() bool {
-	return true // All methods need logprobs
+	// self_verify uses model self-assessment, not logprobs
+	if e.Method == "self_verify" {
+		return false
+	}
+	return true // All other methods need logprobs
+}
+
+// IsSelfVerify returns true if using AutoMix self-verification method
+func (e *ConfidenceEvaluator) IsSelfVerify() bool {
+	return e.Method == "self_verify"
 }
 
 // NeedsTopLogprobs returns the number of top_logprobs needed (0 if not needed)
@@ -266,11 +461,28 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		TopLogprobs: evaluator.NeedsTopLogprobs(),
 	}
 
-	// Sort models by size (smallest first)
-	sortedRefs := sortModelRefsBySize(req.ModelRefs, req.ModelParams)
+	// Sort models based on configured escalation order
+	escalationOrder := getEscalationOrder(sizeAwareCfg)
+	var sortedRefs []config.ModelRef
 
-	logging.Infof("[ConfidenceLooper] Starting with %d models, method=%s, threshold=%.4f, on_error=%s, streaming=%v",
-		len(sortedRefs), evaluator.Method, evaluator.Threshold, onError, req.IsStreaming)
+	switch escalationOrder {
+	case "cost":
+		// AutoMix-style: order by pricing (cheapest first)
+		sortedRefs = sortModelRefsByCost(req.ModelRefs, req.ModelParams)
+		logging.Infof("[ConfidenceLooper] Using cost-based escalation order (cheapest first)")
+	case "automix":
+		// POMDP-optimized: cost-quality tradeoff
+		tradeoff := getCostQualityTradeoff(sizeAwareCfg)
+		sortedRefs = sortModelRefsByAutoMix(req.ModelRefs, req.ModelParams, tradeoff)
+		logging.Infof("[ConfidenceLooper] Using AutoMix escalation order (tradeoff=%.2f)", tradeoff)
+	default:
+		// Default: order by param_size (smallest first)
+		sortedRefs = sortModelRefsBySize(req.ModelRefs, req.ModelParams)
+		logging.Infof("[ConfidenceLooper] Using size-based escalation order (smallest first)")
+	}
+
+	logging.Infof("[ConfidenceLooper] Starting with %d models, method=%s, threshold=%.4f, on_error=%s, streaming=%v, escalation=%s",
+		len(sortedRefs), evaluator.Method, evaluator.Threshold, onError, req.IsStreaming, escalationOrder)
 
 	// Helper to get param_size for logging
 	getParamSize := func(modelName string) string {
@@ -324,11 +536,21 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		lastResponse = resp
 		modelsUsed = append(modelsUsed, modelName)
 
-		// Evaluate confidence using configured method
-		confidence, meetsThreshold := evaluator.Evaluate(resp)
+		var confidence float64
+		var meetsThreshold bool
 
-		logging.Infof("[ConfidenceLooper] Model %s: confidence=%.4f (method=%s), threshold=%.4f, meets=%v",
-			modelName, confidence, evaluator.Method, evaluator.Threshold, meetsThreshold)
+		// Evaluate confidence using configured method
+		if evaluator.IsSelfVerify() {
+			// AutoMix self-verification: ask the model to evaluate its own answer
+			confidence, meetsThreshold = l.performSelfVerification(ctx, req, modelName, resp.Content, accessKey, evaluator.Threshold)
+			logging.Infof("[ConfidenceLooper] Model %s: self-verification confidence=%.4f, threshold=%.4f, meets=%v",
+				modelName, confidence, evaluator.Threshold, meetsThreshold)
+		} else {
+			// Standard logprob-based confidence evaluation
+			confidence, meetsThreshold = evaluator.Evaluate(resp)
+			logging.Infof("[ConfidenceLooper] Model %s: confidence=%.4f (method=%s), threshold=%.4f, meets=%v",
+				modelName, confidence, evaluator.Method, evaluator.Threshold, meetsThreshold)
+		}
 
 		if meetsThreshold {
 			logging.Infof("[ConfidenceLooper] Confidence acceptable, using model %s", modelName)
@@ -355,6 +577,145 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		return l.formatConfidenceStreamingResponse(agg, modelsUsed, iteration)
 	}
 	return l.formatConfidenceJSONResponse(agg, modelsUsed, iteration)
+}
+
+// performSelfVerification implements AutoMix self-verification
+// The model evaluates its own answer and returns a confidence score
+// This is the "True AutoMix Cascading" from the paper (arXiv:2310.12963)
+func (l *ConfidenceLooper) performSelfVerification(
+	ctx context.Context,
+	req *Request,
+	modelName string,
+	responseContent string,
+	accessKey string,
+	threshold float64,
+) (float64, bool) {
+	// Extract original question from the request
+	originalQuestion := l.extractQuestionFromRequest(req.OriginalRequest)
+	if originalQuestion == "" {
+		logging.Warnf("[SelfVerify] Could not extract original question, using logprob fallback")
+		return 0.5, false // Return neutral confidence if we can't extract question
+	}
+
+	// Build self-verification prompt
+	verificationPrompt := fmt.Sprintf(SelfVerificationPrompt, originalQuestion, responseContent)
+
+	// Create a new request for self-verification
+	verifyRequest := l.buildSelfVerificationRequest(verificationPrompt)
+	if verifyRequest == nil {
+		logging.Warnf("[SelfVerify] Failed to build verification request, using fallback")
+		return 0.5, false
+	}
+
+	logging.Infof("[SelfVerify] Asking %s to verify its own response", modelName)
+
+	// Call the same model to evaluate its answer
+	verifyResp, err := l.client.CallModel(ctx, verifyRequest, modelName, false, 0, nil, accessKey)
+	if err != nil {
+		logging.Warnf("[SelfVerify] Self-verification call failed: %v, using fallback", err)
+		return 0.5, false
+	}
+
+	// Parse the self-verification result
+	result, err := parseSelfVerification(verifyResp.Content)
+	if err != nil {
+		logging.Warnf("[SelfVerify] Failed to parse self-verification response: %v", err)
+		// Try to use logprobs as fallback
+		if verifyResp.AverageLogprob != 0 {
+			confidence := normalizeLogprob(verifyResp.AverageLogprob)
+			return confidence, confidence >= threshold
+		}
+		return 0.5, false
+	}
+
+	logging.Infof("[SelfVerify] Model self-assessment: confidence=%.2f, reason=%s",
+		result.Confidence, result.Reason)
+
+	return result.Confidence, result.Confidence >= threshold
+}
+
+// extractQuestionFromRequest extracts the user's question from the original request
+// Uses JSON marshaling for robust extraction across SDK versions
+func (l *ConfidenceLooper) extractQuestionFromRequest(originalRequest *openai.ChatCompletionNewParams) string {
+	if originalRequest == nil {
+		return ""
+	}
+
+	// Marshal to JSON and parse to extract messages
+	data, err := json.Marshal(originalRequest)
+	if err != nil {
+		return ""
+	}
+
+	var reqMap map[string]interface{}
+	if err := json.Unmarshal(data, &reqMap); err != nil {
+		return ""
+	}
+
+	messages, ok := reqMap["messages"].([]interface{})
+	if !ok || len(messages) == 0 {
+		return ""
+	}
+
+	// Find the last user message
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg, ok := messages[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role == "user" {
+			// Content can be a string or array of parts
+			switch content := msg["content"].(type) {
+			case string:
+				return content
+			case []interface{}:
+				// Array of content parts
+				for _, part := range content {
+					if partMap, ok := part.(map[string]interface{}); ok {
+						if partMap["type"] == "text" {
+							if text, ok := partMap["text"].(string); ok {
+								return text
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// buildSelfVerificationRequest creates a new request for self-verification
+// Returns a new ChatCompletionNewParams for the verification call
+func (l *ConfidenceLooper) buildSelfVerificationRequest(verificationPrompt string) *openai.ChatCompletionNewParams {
+	// Build request via JSON for SDK compatibility
+	verifyReqData := map[string]interface{}{
+		"model": "auto",
+		"messages": []map[string]string{
+			{
+				"role":    "user",
+				"content": verificationPrompt,
+			},
+		},
+		"max_tokens":  256,
+		"temperature": 0.1,
+	}
+
+	data, err := json.Marshal(verifyReqData)
+	if err != nil {
+		logging.Errorf("[SelfVerify] Failed to marshal verification request: %v", err)
+		return nil
+	}
+
+	var params openai.ChatCompletionNewParams
+	if err := json.Unmarshal(data, &params); err != nil {
+		logging.Errorf("[SelfVerify] Failed to unmarshal verification request: %v", err)
+		return nil
+	}
+
+	return &params
 }
 
 // formatConfidenceJSONResponse creates response with confidence algorithm type

--- a/src/semantic-router/pkg/looper/confidence_test.go
+++ b/src/semantic-router/pkg/looper/confidence_test.go
@@ -1,0 +1,168 @@
+package looper
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestSortModelRefsBySize(t *testing.T) {
+	modelParams := map[string]config.ModelParams{
+		"large":  {ParamSize: "70b"},
+		"medium": {ParamSize: "13b"},
+		"small":  {ParamSize: "7b"},
+	}
+
+	models := []config.ModelRef{
+		{Model: "large"},
+		{Model: "small"},
+		{Model: "medium"},
+	}
+
+	sorted := sortModelRefsBySize(models, modelParams)
+
+	// Should sort by size (smallest first): small(7b) < medium(13b) < large(70b)
+	if len(sorted) != 3 {
+		t.Errorf("Expected 3 models, got %d", len(sorted))
+	}
+
+	if sorted[0].Model != "small" {
+		t.Errorf("Expected small first (7b), got %s", sorted[0].Model)
+	}
+	if sorted[1].Model != "medium" {
+		t.Errorf("Expected medium second (13b), got %s", sorted[1].Model)
+	}
+	if sorted[2].Model != "large" {
+		t.Errorf("Expected large third (70b), got %s", sorted[2].Model)
+	}
+}
+
+func TestSortModelRefsByCost(t *testing.T) {
+	modelParams := map[string]config.ModelParams{
+		"expensive": {Pricing: config.ModelPricing{PromptPer1M: 30.0}},
+		"medium":    {Pricing: config.ModelPricing{PromptPer1M: 1.0}},
+		"cheap":     {Pricing: config.ModelPricing{PromptPer1M: 0.1}},
+	}
+
+	models := []config.ModelRef{
+		{Model: "expensive"},
+		{Model: "cheap"},
+		{Model: "medium"},
+	}
+
+	sorted := sortModelRefsByCost(models, modelParams)
+
+	// Should sort by cost (cheapest first)
+	if len(sorted) != 3 {
+		t.Errorf("Expected 3 models, got %d", len(sorted))
+	}
+
+	if sorted[0].Model != "cheap" {
+		t.Errorf("Expected cheap first (0.1), got %s", sorted[0].Model)
+	}
+	if sorted[1].Model != "medium" {
+		t.Errorf("Expected medium second (1.0), got %s", sorted[1].Model)
+	}
+	if sorted[2].Model != "expensive" {
+		t.Errorf("Expected expensive third (30.0), got %s", sorted[2].Model)
+	}
+}
+
+func TestConfidenceEvaluator_Creation(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		wantLogprobs bool
+		wantSelfVer  bool
+	}{
+		{"avg_logprob", "avg_logprob", true, false},
+		{"margin", "margin", true, false},
+		{"hybrid", "hybrid", true, false},
+		{"self_verify", "self_verify", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.ConfidenceAlgorithmConfig{
+				ConfidenceMethod: tt.method,
+			}
+			eval := NewConfidenceEvaluator(cfg)
+
+			if eval.NeedsLogprobs() != tt.wantLogprobs {
+				t.Errorf("NeedsLogprobs() = %v, want %v", eval.NeedsLogprobs(), tt.wantLogprobs)
+			}
+
+			if eval.IsSelfVerify() != tt.wantSelfVer {
+				t.Errorf("IsSelfVerify() = %v, want %v", eval.IsSelfVerify(), tt.wantSelfVer)
+			}
+		})
+	}
+}
+
+func TestEvaluate_Logprobs(t *testing.T) {
+	eval := &ConfidenceEvaluator{
+		Method:    "avg_logprob",
+		Threshold: 0.5,
+	}
+
+	resp := &ModelResponse{
+		Content:        "Test response",
+		AverageLogprob: -0.3, // Close to 0 = high confidence
+		AverageMargin:  0.3,
+	}
+
+	confidence, _ := eval.Evaluate(resp)
+
+	if confidence < 0 || confidence > 1 {
+		t.Errorf("Confidence out of range: %f", confidence)
+	}
+
+	t.Logf("Logprob -0.3 normalized to confidence: %f", confidence)
+}
+
+func TestEvaluate_Margin(t *testing.T) {
+	eval := &ConfidenceEvaluator{
+		Method:    "margin",
+		Threshold: 0.1,
+	}
+
+	resp := &ModelResponse{
+		Content:        "Test response",
+		AverageLogprob: -0.5,
+		AverageMargin:  2.0,
+	}
+
+	confidence, meets := eval.Evaluate(resp)
+
+	t.Logf("Margin 2.0 normalized to confidence: %f, meets threshold 0.1: %v", confidence, meets)
+
+	if confidence < 0.3 {
+		t.Errorf("Margin 2.0 should normalize to ~0.49, got %f", confidence)
+	}
+
+	if !meets {
+		t.Errorf("Should meet threshold 0.1 with normalized confidence %f", confidence)
+	}
+}
+
+func TestNormalizeMargin(t *testing.T) {
+	tests := []struct {
+		margin    float64
+		minExpect float64
+		maxExpect float64
+	}{
+		{0.0, 0.0, 0.0},
+		{0.5, 0.1, 0.2},
+		{2.0, 0.4, 0.6},
+		{5.0, 0.8, 1.0},
+		{10.0, 0.95, 1.0},
+	}
+
+	for _, tt := range tests {
+		result := normalizeMargin(tt.margin)
+		if result < tt.minExpect || result > tt.maxExpect {
+			t.Errorf("normalizeMargin(%f) = %f, want between %f and %f",
+				tt.margin, result, tt.minExpect, tt.maxExpect)
+		}
+	}
+}

--- a/src/semantic-router/pkg/selection/automix.go
+++ b/src/semantic-router/pkg/selection/automix.go
@@ -133,10 +133,16 @@ func (a *AutoMixSelector) InitializeFromConfig(modelConfig map[string]config.Mod
 	defer a.capMu.Unlock()
 
 	for model, params := range modelConfig {
+		// Use configured quality score if available, otherwise default to 0.8
+		qualityScore := params.QualityScore
+		if qualityScore <= 0 || qualityScore > 1.0 {
+			qualityScore = 0.8 // Default quality estimate
+		}
+
 		cap := &ModelCapability{
 			Model:            model,
 			Cost:             params.Pricing.PromptPer1M,
-			AvgQuality:       0.8,                        // Default quality estimate
+			AvgQuality:       qualityScore,
 			VerificationProb: 0.7,                        // Default verification probability
 			ParamSize:        a.estimateParamSize(model), // Estimate from model name
 		}

--- a/src/semantic-router/pkg/selection/factory.go
+++ b/src/semantic-router/pkg/selection/factory.go
@@ -101,6 +101,12 @@ func (f *Factory) Create() Selector {
 		if f.embeddingFunc != nil {
 			routerDCSelector.SetEmbeddingFunc(f.embeddingFunc)
 		}
+		// Initialize model embeddings from descriptions in model config
+		if f.modelConfig != nil {
+			if err := routerDCSelector.InitializeFromConfig(f.modelConfig); err != nil {
+				logging.Errorf("[SelectionFactory] RouterDC initialization failed: %v", err)
+			}
+		}
 		selector = routerDCSelector
 
 	case MethodAutoMix:
@@ -163,6 +169,12 @@ func (f *Factory) CreateAll() *Registry {
 	routerDCSelector := NewRouterDCSelector(routerDCCfg)
 	if f.embeddingFunc != nil {
 		routerDCSelector.SetEmbeddingFunc(f.embeddingFunc)
+	}
+	// Initialize model embeddings from descriptions in model config
+	if f.modelConfig != nil {
+		if err := routerDCSelector.InitializeFromConfig(f.modelConfig); err != nil {
+			logging.Errorf("[SelectionFactory] RouterDC initialization failed: %v", err)
+		}
 	}
 	registry.Register(MethodRouterDC, routerDCSelector)
 

--- a/src/semantic-router/pkg/selection/storage.go
+++ b/src/semantic-router/pkg/selection/storage.go
@@ -1,0 +1,456 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// EloStorage defines the interface for persisting Elo ratings
+// This allows ratings to survive restarts and enables different storage backends
+type EloStorage interface {
+	// LoadRatings loads ratings for a specific category from storage
+	// Returns empty map if category doesn't exist (not an error)
+	LoadRatings(category string) (map[string]*ModelRating, error)
+
+	// SaveRatings persists ratings for a specific category
+	SaveRatings(category string, ratings map[string]*ModelRating) error
+
+	// LoadAllRatings loads all ratings across all categories
+	// Returns a map of category -> model -> rating
+	LoadAllRatings() (map[string]map[string]*ModelRating, error)
+
+	// SaveAllRatings persists all ratings across all categories
+	SaveAllRatings(ratings map[string]map[string]*ModelRating) error
+
+	// Close releases any resources held by the storage backend
+	Close() error
+}
+
+// StoredRatings represents the JSON structure for persisted ratings
+type StoredRatings struct {
+	// Version for future format migrations
+	Version int `json:"version"`
+
+	// LastUpdated timestamp
+	LastUpdated time.Time `json:"last_updated"`
+
+	// GlobalRatings are category-independent ratings
+	GlobalRatings map[string]*ModelRating `json:"global_ratings"`
+
+	// CategoryRatings are per-category ratings (category -> model -> rating)
+	CategoryRatings map[string]map[string]*ModelRating `json:"category_ratings"`
+}
+
+// FileEloStorage implements EloStorage using a JSON file
+type FileEloStorage struct {
+	path     string
+	mu       sync.RWMutex
+	dirty    bool
+	stopChan chan struct{}
+	doneChan chan struct{}
+}
+
+// NewFileEloStorage creates a new file-based storage backend
+// The path should be a writable file path (e.g., "/var/lib/vsr/elo_ratings.json")
+func NewFileEloStorage(path string) (*FileEloStorage, error) {
+	// Ensure directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	storage := &FileEloStorage{
+		path:     path,
+		stopChan: make(chan struct{}),
+		doneChan: make(chan struct{}),
+	}
+
+	logging.Infof("[EloStorage] Initialized file storage: %s", path)
+	return storage, nil
+}
+
+// LoadRatings loads ratings for a specific category
+func (f *FileEloStorage) LoadRatings(category string) (map[string]*ModelRating, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	stored, err := f.loadFromFile()
+	if err != nil {
+		return nil, err
+	}
+
+	if category == "" || category == "_global" {
+		return stored.GlobalRatings, nil
+	}
+
+	if ratings, ok := stored.CategoryRatings[category]; ok {
+		return ratings, nil
+	}
+
+	return make(map[string]*ModelRating), nil
+}
+
+// SaveRatings saves ratings for a specific category
+func (f *FileEloStorage) SaveRatings(category string, ratings map[string]*ModelRating) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	stored, err := f.loadFromFile()
+	if err != nil {
+		// If file doesn't exist, create new structure
+		stored = &StoredRatings{
+			Version:         1,
+			GlobalRatings:   make(map[string]*ModelRating),
+			CategoryRatings: make(map[string]map[string]*ModelRating),
+		}
+	}
+
+	if category == "" || category == "_global" {
+		stored.GlobalRatings = ratings
+	} else {
+		if stored.CategoryRatings == nil {
+			stored.CategoryRatings = make(map[string]map[string]*ModelRating)
+		}
+		stored.CategoryRatings[category] = ratings
+	}
+
+	stored.LastUpdated = time.Now()
+
+	return f.saveToFile(stored)
+}
+
+// LoadAllRatings loads all ratings from storage
+func (f *FileEloStorage) LoadAllRatings() (map[string]map[string]*ModelRating, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	stored, err := f.loadFromFile()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]map[string]*ModelRating)
+
+	// Add global ratings under special key
+	if len(stored.GlobalRatings) > 0 {
+		result["_global"] = stored.GlobalRatings
+	}
+
+	// Add category ratings
+	for cat, ratings := range stored.CategoryRatings {
+		result[cat] = ratings
+	}
+
+	return result, nil
+}
+
+// SaveAllRatings saves all ratings to storage
+func (f *FileEloStorage) SaveAllRatings(ratings map[string]map[string]*ModelRating) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	stored := &StoredRatings{
+		Version:         1,
+		LastUpdated:     time.Now(),
+		GlobalRatings:   make(map[string]*ModelRating),
+		CategoryRatings: make(map[string]map[string]*ModelRating),
+	}
+
+	for cat, catRatings := range ratings {
+		if cat == "_global" {
+			stored.GlobalRatings = catRatings
+		} else {
+			stored.CategoryRatings[cat] = catRatings
+		}
+	}
+
+	return f.saveToFile(stored)
+}
+
+// Close stops background operations and releases resources
+func (f *FileEloStorage) Close() error {
+	close(f.stopChan)
+	<-f.doneChan
+	logging.Infof("[EloStorage] Closed file storage: %s", f.path)
+	return nil
+}
+
+// loadFromFile reads the storage file with defensive error handling
+func (f *FileEloStorage) loadFromFile() (*StoredRatings, error) {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Return empty structure if file doesn't exist
+			return &StoredRatings{
+				Version:         1,
+				GlobalRatings:   make(map[string]*ModelRating),
+				CategoryRatings: make(map[string]map[string]*ModelRating),
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to read storage file: %w", err)
+	}
+
+	// Handle empty file gracefully
+	if len(data) == 0 {
+		logging.Warnf("[EloStorage] Storage file is empty, returning fresh state: %s", f.path)
+		return &StoredRatings{
+			Version:         1,
+			GlobalRatings:   make(map[string]*ModelRating),
+			CategoryRatings: make(map[string]map[string]*ModelRating),
+		}, nil
+	}
+
+	var stored StoredRatings
+	if err := json.Unmarshal(data, &stored); err != nil {
+		// Create backup of corrupted file before returning error
+		backupPath := f.path + ".corrupted"
+		if backupErr := os.WriteFile(backupPath, data, 0o644); backupErr == nil {
+			logging.Errorf("[EloStorage] Corrupted file backed up to: %s", backupPath)
+		}
+		return nil, fmt.Errorf("failed to parse storage file (backup saved to %s.corrupted): %w", f.path, err)
+	}
+
+	// Initialize nil maps
+	if stored.GlobalRatings == nil {
+		stored.GlobalRatings = make(map[string]*ModelRating)
+	}
+	if stored.CategoryRatings == nil {
+		stored.CategoryRatings = make(map[string]map[string]*ModelRating)
+	}
+
+	// Validate and sanitize ratings
+	f.sanitizeRatings(stored.GlobalRatings)
+	for _, categoryRatings := range stored.CategoryRatings {
+		f.sanitizeRatings(categoryRatings)
+	}
+
+	return &stored, nil
+}
+
+// sanitizeRatings ensures all ratings have valid values
+func (f *FileEloStorage) sanitizeRatings(ratings map[string]*ModelRating) {
+	for model, rating := range ratings {
+		if rating == nil {
+			delete(ratings, model)
+			continue
+		}
+		// Ensure rating is within reasonable bounds (100-3000)
+		if rating.Rating < 100 {
+			logging.Warnf("[EloStorage] Model %s has suspiciously low rating %.2f, clamping to 100", model, rating.Rating)
+			rating.Rating = 100
+		}
+		if rating.Rating > 3000 {
+			logging.Warnf("[EloStorage] Model %s has suspiciously high rating %.2f, clamping to 3000", model, rating.Rating)
+			rating.Rating = 3000
+		}
+		// Ensure wins/losses/ties are non-negative
+		if rating.Wins < 0 {
+			rating.Wins = 0
+		}
+		if rating.Losses < 0 {
+			rating.Losses = 0
+		}
+		if rating.Ties < 0 {
+			rating.Ties = 0
+		}
+	}
+}
+
+// saveToFile writes the storage file atomically
+func (f *FileEloStorage) saveToFile(stored *StoredRatings) error {
+	data, err := json.MarshalIndent(stored, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal ratings: %w", err)
+	}
+
+	// Write to temp file first for atomic operation
+	tmpPath := f.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpPath, f.path); err != nil {
+		// Cleanup temp file on failure
+		_ = os.Remove(tmpPath) // Intentionally ignore error during cleanup
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	logging.Debugf("[EloStorage] Saved ratings to %s", f.path)
+	return nil
+}
+
+// StartAutoSave starts a background goroutine that periodically saves dirty ratings
+func (f *FileEloStorage) StartAutoSave(interval time.Duration, getAll func() map[string]map[string]*ModelRating) {
+	go func() {
+		defer close(f.doneChan)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-f.stopChan:
+				// Final save before shutdown
+				if f.dirty {
+					ratings := getAll()
+					if err := f.SaveAllRatings(ratings); err != nil {
+						logging.Errorf("[EloStorage] Failed final save: %v", err)
+					}
+				}
+				return
+			case <-ticker.C:
+				if f.dirty {
+					ratings := getAll()
+					if err := f.SaveAllRatings(ratings); err != nil {
+						logging.Errorf("[EloStorage] Auto-save failed: %v", err)
+					} else {
+						f.dirty = false
+					}
+				}
+			}
+		}
+	}()
+}
+
+// MarkDirty marks that ratings have changed and need to be saved
+func (f *FileEloStorage) MarkDirty() {
+	f.dirty = true
+}
+
+// MemoryEloStorage implements EloStorage using in-memory storage (for testing)
+type MemoryEloStorage struct {
+	mu       sync.RWMutex
+	global   map[string]*ModelRating
+	category map[string]map[string]*ModelRating
+}
+
+// NewMemoryEloStorage creates a new in-memory storage backend
+func NewMemoryEloStorage() *MemoryEloStorage {
+	return &MemoryEloStorage{
+		global:   make(map[string]*ModelRating),
+		category: make(map[string]map[string]*ModelRating),
+	}
+}
+
+// LoadRatings loads ratings for a specific category
+func (m *MemoryEloStorage) LoadRatings(category string) (map[string]*ModelRating, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if category == "" || category == "_global" {
+		result := make(map[string]*ModelRating)
+		for k, v := range m.global {
+			result[k] = v
+		}
+		return result, nil
+	}
+
+	if ratings, ok := m.category[category]; ok {
+		result := make(map[string]*ModelRating)
+		for k, v := range ratings {
+			result[k] = v
+		}
+		return result, nil
+	}
+
+	return make(map[string]*ModelRating), nil
+}
+
+// SaveRatings saves ratings for a specific category
+func (m *MemoryEloStorage) SaveRatings(category string, ratings map[string]*ModelRating) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if category == "" || category == "_global" {
+		m.global = make(map[string]*ModelRating)
+		for k, v := range ratings {
+			m.global[k] = v
+		}
+	} else {
+		if m.category == nil {
+			m.category = make(map[string]map[string]*ModelRating)
+		}
+		m.category[category] = make(map[string]*ModelRating)
+		for k, v := range ratings {
+			m.category[category][k] = v
+		}
+	}
+
+	return nil
+}
+
+// LoadAllRatings loads all ratings from storage
+func (m *MemoryEloStorage) LoadAllRatings() (map[string]map[string]*ModelRating, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make(map[string]map[string]*ModelRating)
+
+	if len(m.global) > 0 {
+		result["_global"] = make(map[string]*ModelRating)
+		for k, v := range m.global {
+			result["_global"][k] = v
+		}
+	}
+
+	for cat, ratings := range m.category {
+		result[cat] = make(map[string]*ModelRating)
+		for k, v := range ratings {
+			result[cat][k] = v
+		}
+	}
+
+	return result, nil
+}
+
+// SaveAllRatings saves all ratings to storage
+func (m *MemoryEloStorage) SaveAllRatings(ratings map[string]map[string]*ModelRating) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.global = make(map[string]*ModelRating)
+	m.category = make(map[string]map[string]*ModelRating)
+
+	for cat, catRatings := range ratings {
+		if cat == "_global" {
+			for k, v := range catRatings {
+				m.global[k] = v
+			}
+		} else {
+			m.category[cat] = make(map[string]*ModelRating)
+			for k, v := range catRatings {
+				m.category[cat][k] = v
+			}
+		}
+	}
+
+	return nil
+}
+
+// Close is a no-op for memory storage
+func (m *MemoryEloStorage) Close() error {
+	return nil
+}

--- a/src/semantic-router/pkg/selection/storage_test.go
+++ b/src/semantic-router/pkg/selection/storage_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileEloStorage_SaveAndLoad(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "elo-storage-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	storagePath := filepath.Join(tmpDir, "ratings.json")
+
+	// Create storage
+	storage, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+
+	// Test saving global ratings
+	globalRatings := map[string]*ModelRating{
+		"model-a": {Model: "model-a", Rating: 1550.0, Wins: 10, Losses: 5},
+		"model-b": {Model: "model-b", Rating: 1450.0, Wins: 5, Losses: 10},
+	}
+
+	err = storage.SaveRatings("_global", globalRatings)
+	if err != nil {
+		t.Fatalf("Failed to save global ratings: %v", err)
+	}
+
+	// Test saving category ratings
+	categoryRatings := map[string]*ModelRating{
+		"model-a": {Model: "model-a", Rating: 1600.0, Wins: 15, Losses: 3},
+		"model-b": {Model: "model-b", Rating: 1400.0, Wins: 3, Losses: 15},
+	}
+
+	err = storage.SaveRatings("code", categoryRatings)
+	if err != nil {
+		t.Fatalf("Failed to save category ratings: %v", err)
+	}
+
+	// Create new storage instance to test loading
+	storage2, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("Failed to create second storage: %v", err)
+	}
+
+	// Load and verify global ratings
+	loadedGlobal, err := storage2.LoadRatings("_global")
+	if err != nil {
+		t.Fatalf("Failed to load global ratings: %v", err)
+	}
+
+	if len(loadedGlobal) != 2 {
+		t.Errorf("Expected 2 global ratings, got %d", len(loadedGlobal))
+	}
+
+	if loadedGlobal["model-a"].Rating != 1550.0 {
+		t.Errorf("Expected model-a rating 1550.0, got %f", loadedGlobal["model-a"].Rating)
+	}
+
+	// Load and verify category ratings
+	loadedCategory, err := storage2.LoadRatings("code")
+	if err != nil {
+		t.Fatalf("Failed to load category ratings: %v", err)
+	}
+
+	if len(loadedCategory) != 2 {
+		t.Errorf("Expected 2 category ratings, got %d", len(loadedCategory))
+	}
+
+	if loadedCategory["model-a"].Rating != 1600.0 {
+		t.Errorf("Expected model-a category rating 1600.0, got %f", loadedCategory["model-a"].Rating)
+	}
+}
+
+func TestFileEloStorage_LoadNonExistent(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "elo-storage-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	storagePath := filepath.Join(tmpDir, "nonexistent.json")
+
+	storage, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+
+	// Loading from non-existent file should return empty map
+	ratings, err := storage.LoadRatings("_global")
+	if err != nil {
+		t.Fatalf("Unexpected error loading from non-existent file: %v", err)
+	}
+
+	if len(ratings) != 0 {
+		t.Errorf("Expected empty ratings, got %d", len(ratings))
+	}
+}
+
+func TestFileEloStorage_SaveAllAndLoadAll(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "elo-storage-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	storagePath := filepath.Join(tmpDir, "ratings.json")
+
+	storage, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+
+	// Create ratings for multiple categories
+	allRatings := map[string]map[string]*ModelRating{
+		"_global": {
+			"model-a": {Model: "model-a", Rating: 1500.0},
+		},
+		"code": {
+			"model-a": {Model: "model-a", Rating: 1600.0},
+			"model-b": {Model: "model-b", Rating: 1400.0},
+		},
+		"chat": {
+			"model-b": {Model: "model-b", Rating: 1550.0},
+		},
+	}
+
+	err = storage.SaveAllRatings(allRatings)
+	if err != nil {
+		t.Fatalf("Failed to save all ratings: %v", err)
+	}
+
+	// Load all ratings
+	loaded, err := storage.LoadAllRatings()
+	if err != nil {
+		t.Fatalf("Failed to load all ratings: %v", err)
+	}
+
+	if len(loaded) != 3 {
+		t.Errorf("Expected 3 categories, got %d", len(loaded))
+	}
+
+	if len(loaded["code"]) != 2 {
+		t.Errorf("Expected 2 models in code category, got %d", len(loaded["code"]))
+	}
+}
+
+func TestMemoryEloStorage(t *testing.T) {
+	storage := NewMemoryEloStorage()
+
+	// Test save and load
+	ratings := map[string]*ModelRating{
+		"model-a": {Model: "model-a", Rating: 1550.0},
+	}
+
+	err := storage.SaveRatings("test", ratings)
+	if err != nil {
+		t.Fatalf("Failed to save: %v", err)
+	}
+
+	loaded, err := storage.LoadRatings("test")
+	if err != nil {
+		t.Fatalf("Failed to load: %v", err)
+	}
+
+	if len(loaded) != 1 {
+		t.Errorf("Expected 1 rating, got %d", len(loaded))
+	}
+
+	if loaded["model-a"].Rating != 1550.0 {
+		t.Errorf("Expected rating 1550.0, got %f", loaded["model-a"].Rating)
+	}
+}
+
+func TestEloSelector_WithStorage(t *testing.T) {
+	// Create memory storage
+	storage := NewMemoryEloStorage()
+
+	// Pre-populate storage with ratings
+	if err := storage.SaveRatings("_global", map[string]*ModelRating{
+		"model-a": {Model: "model-a", Rating: 1600.0, Wins: 20, Losses: 5},
+		"model-b": {Model: "model-b", Rating: 1400.0, Wins: 5, Losses: 20},
+	}); err != nil {
+		t.Fatalf("Failed to save ratings: %v", err)
+	}
+
+	// Create config with storage
+	cfg := &EloConfig{
+		InitialRating:    DefaultEloRating,
+		KFactor:          EloKFactor,
+		CategoryWeighted: true,
+		MinComparisons:   5,
+	}
+
+	// Create selector and set storage
+	selector := NewEloSelector(cfg)
+	selector.SetStorage(storage)
+
+	// Load from storage
+	err := selector.loadFromStorage()
+	if err != nil {
+		t.Fatalf("Failed to load from storage: %v", err)
+	}
+
+	// Verify ratings were loaded
+	rating := selector.getGlobalRating("model-a")
+	if rating == nil {
+		t.Fatal("Expected model-a rating, got nil")
+	}
+
+	if rating.Rating != 1600.0 {
+		t.Errorf("Expected rating 1600.0, got %f", rating.Rating)
+	}
+}
+
+func TestFileEloStorage_EmptyFile(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "elo-storage-test-empty")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	storagePath := filepath.Join(tmpDir, "empty.json")
+
+	// Create empty file
+	if writeErr := os.WriteFile(storagePath, []byte{}, 0o644); writeErr != nil {
+		t.Fatalf("Failed to create empty file: %v", writeErr)
+	}
+
+	// Create storage - should not fail on empty file
+	storage, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("Failed to create storage with empty file: %v", err)
+	}
+
+	// Load should return empty ratings, not error
+	ratings, err := storage.LoadRatings("_global")
+	if err != nil {
+		t.Errorf("Expected no error on empty file, got: %v", err)
+	}
+
+	if len(ratings) != 0 {
+		t.Errorf("Expected empty ratings, got %d", len(ratings))
+	}
+}
+
+func TestFileEloStorage_CorruptedFile(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "elo-storage-test-corrupt")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	storagePath := filepath.Join(tmpDir, "corrupted.json")
+
+	// Create corrupted JSON file
+	if writeErr := os.WriteFile(storagePath, []byte("not valid json {{{"), 0o644); writeErr != nil {
+		t.Fatalf("Failed to create corrupted file: %v", writeErr)
+	}
+
+	// Create storage (this succeeds - loading is lazy)
+	storage, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+
+	// LoadRatings should fail on corrupted file
+	_, err = storage.LoadRatings("_global")
+	if err == nil {
+		t.Error("Expected error when loading corrupted file, got nil")
+	}
+
+	// Check that backup was created
+	backupPath := storagePath + ".corrupted"
+	if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
+		t.Error("Expected backup file to be created")
+	}
+}
+
+func TestFileEloStorage_InvalidRatings(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "elo-storage-test-invalid")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	storagePath := filepath.Join(tmpDir, "invalid.json")
+
+	// Create file with out-of-bounds ratings
+	invalidJSON := `{
+		"version": 1,
+		"global_ratings": {
+			"model-a": {"model": "model-a", "rating": -500, "wins": -10, "losses": 5},
+			"model-b": {"model": "model-b", "rating": 5000, "wins": 10, "losses": -5}
+		},
+		"category_ratings": {}
+	}`
+	if writeErr := os.WriteFile(storagePath, []byte(invalidJSON), 0o644); writeErr != nil {
+		t.Fatalf("Failed to create invalid file: %v", writeErr)
+	}
+
+	// Create storage
+	storage, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("Failed to create storage: %v", err)
+	}
+
+	// Load ratings - should succeed with sanitized values
+	ratings, err := storage.LoadRatings("_global")
+	if err != nil {
+		t.Fatalf("Failed to load ratings: %v", err)
+	}
+
+	// Check that ratings were clamped
+	if ratings["model-a"].Rating != 100 {
+		t.Errorf("Expected model-a rating to be clamped to 100, got %f", ratings["model-a"].Rating)
+	}
+	if ratings["model-b"].Rating != 3000 {
+		t.Errorf("Expected model-b rating to be clamped to 3000, got %f", ratings["model-b"].Rating)
+	}
+
+	// Check that negative wins/losses were fixed
+	if ratings["model-a"].Wins != 0 {
+		t.Errorf("Expected model-a wins to be 0, got %d", ratings["model-a"].Wins)
+	}
+	if ratings["model-b"].Losses != 0 {
+		t.Errorf("Expected model-b losses to be 0, got %d", ratings["model-b"].Losses)
+	}
+}


### PR DESCRIPTION
## Summary

Implements [#1102](https://github.com/vllm-project/semantic-router/issues/1102): Model Selection Core Algorithm Enhancements for v0.2-Athena

This PR adds the P0 requirements from #1102 plus select items from the "Future Enhancements" in PR #1089.

---

## What's Included

### 1. Elo Persistent Storage (P0)

The Elo rating system now persists ratings to disk, surviving restarts and enabling long-term model quality tracking.

**How Elo Storage Works:**

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  User Feedback: "gpt-4 gave better answer than mistral-7b"                  │
│                                    │                                        │
│                                    ▼                                        │
│              ┌─────────────────────────────────────────┐                    │
│              │         EloSelector.UpdateFeedback()    │                    │
│              │                                         │                    │
│              │  gpt-4:    1520 → 1536  (+16)          │                    │
│              │  mistral:  1480 → 1464  (-16)          │                    │
│              └─────────────────────────────────────────┘                    │
│                                    │                                        │
│                                    ▼                                        │
│              ┌─────────────────────────────────────────┐                    │
│              │         FileEloStorage.SaveRatings()    │                    │
│              │                                         │                    │
│              │  /var/lib/vsr/elo.json                 │  ← Persisted!      │
│              │  {                                      │                    │
│              │    "gpt-4": {"rating": 1536, ...},     │                    │
│              │    "mistral-7b": {"rating": 1464, ...} │                    │
│              │  }                                      │                    │
│              └─────────────────────────────────────────┘                    │
│                                                                             │
│  On VSR Restart:                                                            │
│  ───────────────                                                            │
│              ┌─────────────────────────────────────────┐                    │
│              │  FileEloStorage.LoadRatings()          │                    │
│              │  → Ratings restored from disk           │  ← No data loss!   │
│              └─────────────────────────────────────────┘                    │
└─────────────────────────────────────────────────────────────────────────────┘
```

**Features:**

- `EloStorage` interface with `FileEloStorage` implementation
- JSON file-based persistence with configurable `storage_path`
- Auto-save with configurable `auto_save_interval` (default: 5 minutes)
- Thread-safe concurrent access with filemutex locking
- Loads ratings on startup, saves on feedback update
- Atomic writes (write to temp file, then rename)
- Graceful handling of missing files on first startup

**Configuration (per-decision, aligned with PR #1089):**

```yaml
decisions:
  - name: tech
    modelRefs:
      - model: "llama3.2:3b"
      - model: "phi4"
      - model: "gemma3:27b"
    algorithm:
      type: "elo"
      elo:
        k_factor: 32
        category_weighted: true
        storage_path: "/var/lib/vsr/elo.json"   # NEW: Where to persist ratings
        auto_save_interval: "5m"                 # NEW: Auto-save frequency
```

---

### 2. RouterDC Model Selection (P0)

RouterDC uses embedding search to match queries to the best LLM based on model descriptions.

**How RouterDC Works:**

```
User Query: "Write a Python function to sort a list"
    │
    ▼
┌─────────────────────────────────────┐
│   Embedding Function                │  ← candle_binding.GetEmbedding
│   (converts text to vectors)        │
└─────────────────────────────────────┘
    │
    ├──▶ Query Embedding [0.12, -0.34, ...]
    │
    │    Model Descriptions (from config):
    │    ├─ "gpt-4: Advanced reasoning model..."     → [0.15, -0.32, ...]
    │    └─ "mistral-7b: Fast, efficient model..."   → [-0.23, 0.45, ...]
    │
    ▼
┌─────────────────────────────────────┐
│   Cosine Similarity Matching        │
└─────────────────────────────────────┘
    │
    ▼
Best Match: gpt-4 (similarity: 0.89)
```

**Features:**

- `description` and `capabilities` fields in `ModelParams`
- Descriptions are embedded using `candle_binding.GetEmbedding`
- Query-to-model matching via cosine similarity
- `require_descriptions` validation flag

**Model Configuration:**

```yaml
backend_models:
  model_config:
    gpt-4:
      description: "Advanced reasoning model with strong coding and math capabilities"
      capabilities: ["coding", "math", "reasoning", "analysis"]
      quality_score: 0.95
      pricing:
        prompt_per_1m: 30.0
        completion_per_1m: 60.0
    
    mistral-7b:
      description: "Fast and efficient model for simple queries and quick answers"
      capabilities: ["chat", "simple_qa"]
      quality_score: 0.70
      pricing:
        prompt_per_1m: 0.50
        completion_per_1m: 0.50
```

**Decision Configuration (per-decision, aligned with PR #1089):**

```yaml
decisions:
  - name: embedding_match
    modelRefs:
      - model: "gpt-4"
      - model: "mistral-7b"
    algorithm:
      type: "router_dc"
      router_dc:
        temperature: 0.07
        require_descriptions: true    # NEW: Validate all models have descriptions
        use_capabilities: true        # NEW: Include capabilities in embeddings
```

---

### 3. AutoMix + Confidence Cascading (P0)

Implements cost-aware model escalation based on the AutoMix paper (arXiv:2310.12963). When a model's response has low confidence, VSR automatically escalates to a more capable (and costlier) model.

**How Confidence Cascading Works:**

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  User Query: "Explain the Riemann hypothesis"                               │
│                                    │                                        │
│                                    ▼                                        │
│  ┌─────────────────────────────────────────────────────────────────────┐   │
│  │  Step 1: Try smallest/cheapest model first                          │   │
│  │                                                                      │   │
│  │  mistral-7b ($0.50/1M tokens)                                       │   │
│  │  Response: "The Riemann hypothesis is about prime numbers..."        │   │
│  │  Confidence: 0.45 ← Below threshold (0.7)                           │   │
│  └─────────────────────────────────────────────────────────────────────┘   │
│                                    │                                        │
│                                    ▼  ESCALATE                              │
│  ┌─────────────────────────────────────────────────────────────────────┐   │
│  │  Step 2: Try next model by cost                                      │   │
│  │                                                                      │   │
│  │  gpt-4 ($30/1M tokens)                                              │   │
│  │  Response: "The Riemann hypothesis, proposed in 1859..."            │   │
│  │  Confidence: 0.92 ← Above threshold ✓                               │   │
│  └─────────────────────────────────────────────────────────────────────┘   │
│                                    │                                        │
│                                    ▼                                        │
│  Return gpt-4's response to user                                            │
└─────────────────────────────────────────────────────────────────────────────┘
```

**Escalation Order Options:**

| Order | Description | Use Case |
|-------|-------------|----------|
| `"size"` | Sort by model size (parameters) | Simple: small → large |
| `"cost"` | Sort by `pricing.prompt_per_1m` | Cost optimization |
| `"automix"` | POMDP-based quality-cost tradeoff | Best overall efficiency |

**Self-Verification Mode (Full AutoMix):**

When `confidence_method: "self_verify"` is enabled, the model evaluates its own answer:

```
┌──────────────────────────────────────────────────────────────────────┐
│  1. Model generates response                                         │
│  2. VSR asks model: "Rate your confidence in this answer (0-1)"     │
│  3. If self-rating < threshold → escalate to next model             │
│  4. Repeat until confident or all models tried                       │
└──────────────────────────────────────────────────────────────────────┘
```

**Configuration (per-decision, aligned with PR #1089):**

```yaml
decisions:
  - name: reasoning
    modelRefs:
      - model: "mistral-7b"      # Cheapest, tried first
      - model: "gpt-4"           # Most expensive, fallback
    algorithm:
      type: "confidence"
      confidence:
        confidence_method: "self_verify"  # or "logprob", "entropy"
        escalation_order: "cost"          # NEW: or "size", "automix"
        threshold: 0.7
        self_verify_prompt: "Rate your confidence..."  # Optional custom prompt
```

---

### 4. Feedback REST API

External systems can now submit feedback and retrieve Elo ratings via HTTP API.

**API Endpoints:**

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  POST /api/v1/feedback                                                      │
│  ─────────────────────                                                      │
│  Submit comparison feedback for Elo updates                                 │
│                                                                             │
│  Request:                          Response:                                │
│  {                                 {                                        │
│    "winner": "gpt-4",               "success": true,                       │
│    "loser": "mistral-7b",           "winner_rating": 1536,                 │
│    "category": "coding"             "loser_rating": 1464                   │
│  }                                 }                                        │
├─────────────────────────────────────────────────────────────────────────────┤
│  GET /api/v1/ratings?category=coding                                        │
│  ───────────────────────────────────                                        │
│  Retrieve Elo leaderboard for a category                                    │
│                                                                             │
│  Response:                                                                  │
│  {                                                                          │
│    "category": "coding",                                                    │
│    "ratings": [                                                             │
│      {"model": "gpt-4", "rating": 1536, "games": 142},                     │
│      {"model": "claude-3", "rating": 1512, "games": 98},                   │
│      {"model": "mistral-7b", "rating": 1464, "games": 156}                 │
│    ]                                                                        │
│  }                                                                          │
└─────────────────────────────────────────────────────────────────────────────┘
```

**Automatic Signal-to-Elo Feedback:**

VSR's existing `FeedbackDetector` automatically updates Elo ratings based on user behavior signals:

```
┌──────────────────────────────────────────────────────────────────────┐
│  User says: "Thanks, that's exactly what I needed!"                  │
│                         │                                            │
│                         ▼                                            │
│  FeedbackDetector classifies as: "satisfied"                         │
│                         │                                            │
│                         ▼                                            │
│  EloSelector.UpdateFeedback(winner=currentModel, loser=nil)         │
│  → Model's rating increases (win without opponent)                   │
├──────────────────────────────────────────────────────────────────────┤
│  User says: "That's wrong, the answer is actually..."                │
│                         │                                            │
│                         ▼                                            │
│  FeedbackDetector classifies as: "wrong_answer"                      │
│                         │                                            │
│                         ▼                                            │
│  EloSelector.UpdateFeedbackLoss(loser=currentModel)                  │
│  → Model's rating decreases                                          │
└──────────────────────────────────────────────────────────────────────┘
```

---

### 5. Quality Score Configuration

Model quality is now configurable per-model instead of using a hardcoded default. This affects AutoMix's POMDP calculations.

**How Quality Scores Are Used:**

```
┌─────────────────────────────────────────────────────────────────────────────┐
│  AutoMix POMDP Calculation                                                  │
│  ─────────────────────────                                                  │
│                                                                             │
│  Expected Value = Quality × Probability_of_Success - Cost                   │
│                                                                             │
│  Model          Quality    Cost/1M    Expected Value                        │
│  ─────────────  ─────────  ─────────  ──────────────                        │
│  gpt-4          0.95       $30.00     High quality, high cost              │
│  claude-3       0.90       $15.00     Good balance                          │
│  mistral-7b     0.70       $0.50      Lower quality, very cheap            │
│                                                                             │
│  AutoMix picks the model with best expected value for each query type.      │
└─────────────────────────────────────────────────────────────────────────────┘
```

**Configuration:**

```yaml
backend_models:
  model_config:
    gpt-4:
      quality_score: 0.95    # High quality (0.0 - 1.0)
      pricing:
        prompt_per_1m: 30.0
    mistral-7b:
      quality_score: 0.70    # Lower quality but cheap
      pricing:
        prompt_per_1m: 0.50
```

**Default Behavior:**

- If `quality_score` is not set, defaults to `0.8`
- Quality scores should reflect your experience with each model's accuracy
- Higher scores mean the model is more likely to be selected for complex queries

---

## Items From PR #1089 "Future Enhancements" - Traceability

| Item | Status | Notes |
|------|--------|-------|
| Feedback REST API | ✅ Implemented | `POST /api/v1/feedback`, `GET /api/v1/ratings` + auto signal feedback |
| Model Embeddings Config | ✅ Implemented | `description` + `capabilities` fields in `ModelParams` |
| Quality Score Config | ✅ Implemented | `QualityScore` field in `ModelParams`, used by AutoMix |
| True AutoMix Cascading | ✅ Implemented | `escalation_order: "automix"` + `confidence_method: "self_verify"` |
| RouterDC Training | ❌ Future | Will be integrated into VSR core with Candle |
| Prometheus Metrics | ❌ Tracked in #1093 | Separate issue for metrics |

---

## Complete Configuration Example (Aligned with PR #1089)

**Model Configuration (backend_models):**

```yaml
backend_models:
  model_config:
    gpt-4:
      description: "Advanced reasoning model with strong coding and math capabilities"
      capabilities: ["coding", "math", "reasoning", "analysis"]
      quality_score: 0.95
      pricing:
        prompt_per_1m: 30.0
        completion_per_1m: 60.0
    
    claude-3-sonnet:
      description: "Balanced model for general tasks with good instruction following"
      capabilities: ["writing", "analysis", "coding"]
      quality_score: 0.88
      pricing:
        prompt_per_1m: 3.0
        completion_per_1m: 15.0
    
    mistral-7b:
      description: "Fast and efficient model for simple queries and quick answers"
      capabilities: ["chat", "simple_qa"]
      quality_score: 0.70
      pricing:
        prompt_per_1m: 0.50
        completion_per_1m: 0.50
```

**Per-Decision Algorithm Configuration (NO global model_selection section):**

```yaml
decisions:
  - name: tech
    modelRefs:
      - model: "llama3.2:3b"
      - model: "phi4"
      - model: "gemma3:27b"
    algorithm:
      type: "elo"
      elo:
        k_factor: 32
        category_weighted: true
        storage_path: "/var/lib/vsr/elo.json"
        auto_save_interval: "5m"

  - name: finance
    modelRefs:
      - model: "gpt-4"
      - model: "claude-3-sonnet"
    algorithm:
      type: "automix"
      automix:
        cost_quality_tradeoff: 0.4

  - name: general
    modelRefs:
      - model: "gpt-4"
      - model: "mistral-7b"
    algorithm:
      type: "hybrid"
      hybrid:
        elo_weight: 0.3
        router_dc_weight: 0.3
        automix_weight: 0.2
        cost_weight: 0.2
```

---

## Testing

- ✅ Unit tests for all new components (`storage_test.go`, `confidence_test.go`, `route_feedback_test.go`)
- ✅ All existing tests pass
- ✅ Pre-commit checks pass

---

## Breaking Changes

None - all new fields are optional with sensible defaults:

| Field | Default | Required |
|-------|---------|----------|
| `storage_path` | (none, in-memory) | No |
| `description` | (none) | Only if `require_descriptions: true` |
| `quality_score` | `0.8` | No |
| `escalation_order` | `"size"` | No |
| `confidence_method` | `"logprob"` | No |

---

## Future Work

- **RouterDC Training**: Will be integrated into VSR core using Candle for seamless training and inference
- **Dashboard UI**: Ratings visualization (per maintainer feedback)
- **Redis Storage**: Distributed storage for multi-replica deployments

---

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] Documentation updated (example config)
- [x] Signed-off-by included in commits (DCO)
- [x] No security issues introduced
- [x] Pre-commit checks pass locally

