### PR TITLE
[CI][E2E]: Add Redis Responses API test profiles

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -37,6 +37,10 @@ on:
         value: ${{ jobs.filter.outputs.e2e_production_stack }}
       e2e_response_api:
         value: ${{ jobs.filter.outputs.e2e_response_api }}
+      e2e_response_api_redis:
+        value: ${{ jobs.filter.outputs.e2e_response_api_redis }}
+      e2e_response_api_redis_cluster:
+        value: ${{ jobs.filter.outputs.e2e_response_api_redis_cluster }}
       e2e_common:
         value: ${{ jobs.filter.outputs.e2e_common }}
 
@@ -62,6 +66,8 @@ jobs:
       e2e_routing_strategies: ${{ steps.changes.outputs.e2e_routing_strategies }}
       e2e_production_stack: ${{ steps.changes.outputs.e2e_production_stack }}
       e2e_response_api: ${{ steps.changes.outputs.e2e_response_api }}
+      e2e_response_api_redis: ${{ steps.changes.outputs.e2e_response_api_redis }}
+      e2e_response_api_redis_cluster: ${{ steps.changes.outputs.e2e_response_api_redis_cluster }}
       e2e_common: ${{ steps.changes.outputs.e2e_common }}
     steps:
       - uses: actions/checkout@v4
@@ -136,6 +142,12 @@ jobs:
               - 'e2e/profiles/production-stack/**'
             e2e_response_api:
               - 'e2e/profiles/response-api/**'
+            e2e_response_api_redis:
+              - 'e2e/profiles/response-api-redis/**'
+              - 'deploy/kubernetes/response-api/**'
+            e2e_response_api_redis_cluster:
+              - 'e2e/profiles/response-api-redis-cluster/**'
+              - 'deploy/kubernetes/response-api/redis-cluster.yaml'
             # Common e2e code that affects all profiles
             e2e_common:
               - 'e2e/pkg/**'

--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -40,7 +40,7 @@ jobs:
              [[ "${{ needs.changes.outputs.core }}" == "true" ]] || \
              [[ "${{ github.event_name }}" == "schedule" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo 'profiles=["ai-gateway", "aibrix", "routing-strategies", "dynamic-config", "llm-d", "istio", "production-stack", "response-api"]' >> $GITHUB_OUTPUT
+            echo 'profiles=["ai-gateway", "aibrix", "routing-strategies", "dynamic-config", "llm-d", "istio", "production-stack", "response-api", "response-api-redis", "response-api-redis-cluster"]' >> $GITHUB_OUTPUT                          
             echo 'should_run=true' >> $GITHUB_OUTPUT
             echo "Running all profiles due to common/core changes or push/schedule/manual trigger"
             exit 0
@@ -56,6 +56,8 @@ jobs:
           [[ "${{ needs.changes.outputs.e2e_production_stack }}" == "true" ]] && profiles+=("production-stack")
           [[ "${{ needs.changes.outputs.e2e_dynamic_config }}" == "true" ]] && profiles+=("dynamic-config")
           [[ "${{ needs.changes.outputs.e2e_response_api }}" == "true" ]] && profiles+=("response-api")
+          [[ "${{ needs.changes.outputs.e2e_response_api_redis }}" == "true" ]] && profiles+=("response-api-redis")
+          [[ "${{ needs.changes.outputs.e2e_response_api_redis_cluster }}" == "true" ]] && profiles+=("response-api-redis-cluster")
 
           # Convert to JSON array
           if [ ${#profiles[@]} -eq 0 ]; then

--- a/deploy/kubernetes/response-api/redis-cluster.yaml
+++ b/deploy/kubernetes/response-api/redis-cluster.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-cluster-config
+  namespace: default
+data:
+  redis.conf: |
+    port 6379
+    bind 0.0.0.0
+    protected-mode no
+    cluster-enabled yes
+    cluster-config-file nodes.conf
+    cluster-node-timeout 5000
+    appendonly no
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-cluster
+  namespace: default
+spec:
+  clusterIP: None
+  selector:
+    app: redis-cluster
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-cluster
+  namespace: default
+spec:
+  serviceName: redis-cluster
+  replicas: 3
+  selector:
+    matchLabels:
+      app: redis-cluster
+  template:
+    metadata:
+      labels:
+        app: redis-cluster
+    spec:
+      containers:
+      - name: redis
+        image: redis:7.2-alpine
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+          protocol: TCP
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        command:
+        - sh
+        - -c
+        - redis-server /etc/redis/redis.conf --cluster-announce-ip ${POD_IP}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/redis
+          readOnly: true
+        - name: data
+          mountPath: /data
+        readinessProbe:
+          tcpSocket:
+            port: 6379
+          initialDelaySeconds: 1
+          periodSeconds: 2
+      volumes:
+      - name: config
+        configMap:
+          name: redis-cluster-config
+      - name: data
+        emptyDir: {}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redis-cluster-create
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        app: redis-cluster-create
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: redis-cli
+        image: redis:7.2-alpine
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          for i in 0 1 2; do
+            until redis-cli -h redis-cluster-${i}.redis-cluster.default.svc.cluster.local -p 6379 ping >/dev/null 2>&1; do
+              sleep 1
+            done
+          done
+          if redis-cli -h redis-cluster-0.redis-cluster.default.svc.cluster.local -p 6379 cluster info 2>/dev/null | grep -q "cluster_state:ok"; then
+            exit 0
+          fi
+          redis-cli --cluster create \
+            redis-cluster-0.redis-cluster.default.svc.cluster.local:6379 \
+            redis-cluster-1.redis-cluster.default.svc.cluster.local:6379 \
+            redis-cluster-2.redis-cluster.default.svc.cluster.local:6379 \
+            --cluster-replicas 0 --cluster-yes

--- a/deploy/kubernetes/response-api/redis.yaml
+++ b/deploy/kubernetes/response-api/redis.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7.2-alpine
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+          protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 6379
+          initialDelaySeconds: 1
+          periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: default
+spec:
+  selector:
+    app: redis
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+    protocol: TCP

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,7 +18,9 @@ The framework follows a **separation of concerns** design:
 - **istio**: Tests Semantic Router with Istio service mesh integration
 - **production-stack**: Tests vLLM Production Stack configurations
 - **llm-d**: Tests Semantic Router with LLM-D distributed inference
-- **response-api**: Tests Response API endpoints (POST/GET/DELETE /v1/responses)
+- **response-api**: Tests Responses API endpoints (POST/GET/DELETE /v1/responses)
+- **response-api-redis**: Tests Responses API endpoints with Redis storage backend
+- **response-api-redis-cluster**: Tests Responses API endpoints with Redis Cluster backend
 - **dynamo**: Tests with Nvidia Dynamo (future)
 
 ## Directory Structure

--- a/e2e/cmd/e2e/main.go
+++ b/e2e/cmd/e2e/main.go
@@ -17,6 +17,8 @@ import (
 	llmd "github.com/vllm-project/semantic-router/e2e/profiles/llm-d"
 	productionstack "github.com/vllm-project/semantic-router/e2e/profiles/production-stack"
 	responseapi "github.com/vllm-project/semantic-router/e2e/profiles/response-api"
+	responseapiredis "github.com/vllm-project/semantic-router/e2e/profiles/response-api-redis"
+	responseapirediscluster "github.com/vllm-project/semantic-router/e2e/profiles/response-api-redis-cluster"
 	routingstrategies "github.com/vllm-project/semantic-router/e2e/profiles/routing-strategies"
 
 	// Import profiles to register test cases
@@ -27,6 +29,8 @@ import (
 	_ "github.com/vllm-project/semantic-router/e2e/profiles/llm-d"
 	_ "github.com/vllm-project/semantic-router/e2e/profiles/production-stack"
 	_ "github.com/vllm-project/semantic-router/e2e/profiles/response-api"
+	_ "github.com/vllm-project/semantic-router/e2e/profiles/response-api-redis"
+	_ "github.com/vllm-project/semantic-router/e2e/profiles/response-api-redis-cluster"
 	_ "github.com/vllm-project/semantic-router/e2e/profiles/routing-strategies"
 )
 
@@ -125,6 +129,10 @@ func getProfile(name string) (framework.Profile, error) {
 		return productionstack.NewProfile(), nil
 	case "response-api":
 		return responseapi.NewProfile(), nil
+	case "response-api-redis":
+		return responseapiredis.NewProfile(), nil
+	case "response-api-redis-cluster":
+		return responseapirediscluster.NewProfile(), nil
 	case "routing-strategies":
 		return routingstrategies.NewProfile(), nil
 	default:

--- a/e2e/pkg/framework/runner.go
+++ b/e2e/pkg/framework/runner.go
@@ -253,7 +253,7 @@ func (r *Runner) buildAndLoadImages(ctx context.Context) error {
 
 	// Profiles may require additional local images beyond extproc.
 	switch r.profile.Name() {
-	case "response-api":
+	case "response-api", "response-api-redis", "response-api-redis-cluster":
 		mockOpts := docker.BuildOptions{
 			Dockerfile:   "tools/mock-vllm/Dockerfile",
 			Tag:          "ghcr.io/vllm-project/semantic-router/mock-vllm:latest",

--- a/e2e/pkg/profiles/responseapi/redis_profile.go
+++ b/e2e/pkg/profiles/responseapi/redis_profile.go
@@ -1,0 +1,374 @@
+package responseapi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helm"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+)
+
+const (
+	// Namespace constants
+	namespaceSemanticRouter = "vllm-semantic-router-system"
+	namespaceEnvoyGateway   = "envoy-gateway-system"
+	namespaceAIGateway      = "envoy-ai-gateway-system"
+
+	// Release name constants
+	releaseSemanticRouter = "semantic-router"
+	releaseEnvoyGateway   = "eg"
+	releaseAIGatewayCRD   = "aieg-crd"
+	releaseAIGateway      = "aieg"
+
+	// Deployment name constants
+	deploymentSemanticRouter = "semantic-router"
+	deploymentEnvoyGateway   = "envoy-gateway"
+	deploymentAIGateway      = "ai-gateway-controller"
+
+	// Chart and URL constants
+	chartPathSemanticRouter = "deploy/helm/semantic-router"
+	chartEnvoyGateway       = "oci://docker.io/envoyproxy/gateway-helm"
+	chartAIGatewayCRD       = "oci://docker.io/envoyproxy/ai-gateway-crds-helm"
+	chartAIGateway          = "oci://docker.io/envoyproxy/ai-gateway-helm"
+	envoyGatewayValuesURL   = "https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-values.yaml"
+
+	// Shared manifest paths
+	mockVLLMManifest   = "deploy/kubernetes/response-api/mock-vllm.yaml"
+	gatewayAPIManifest = "deploy/kubernetes/response-api/gwapi-resources.yaml"
+
+	// Timeout constants
+	timeoutSemanticRouterInstall = "30m"
+	timeoutHelmInstall           = "10m"
+	timeoutDeploymentWait        = 30 * time.Minute
+	timeoutServiceRetry          = 10 * time.Minute
+	intervalServiceRetry         = 5 * time.Second
+
+	// Image constants
+	imageRepository = "ghcr.io/vllm-project/semantic-router/extproc"
+	imagePullPolicy = "Never"
+
+	// Label selector constants
+	labelSelectorGateway = "gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=semantic-router"
+)
+
+// RedisProfile implements the shared setup for Redis-backed Response API profiles.
+type RedisProfile struct {
+	verbose       bool
+	name          string
+	description   string
+	valuesFile    string
+	redisManifest string
+}
+
+// NewRedisProfile constructs a shared Redis-backed Response API profile.
+func NewRedisProfile(name, description, valuesFile, redisManifest string) *RedisProfile {
+	return &RedisProfile{
+		name:          name,
+		description:   description,
+		valuesFile:    valuesFile,
+		redisManifest: redisManifest,
+	}
+}
+
+// Name returns the profile name.
+func (p *RedisProfile) Name() string {
+	return p.name
+}
+
+// Description returns the profile description.
+func (p *RedisProfile) Description() string {
+	return p.description
+}
+
+// Setup deploys all required components for Response API testing.
+func (p *RedisProfile) Setup(ctx context.Context, opts *framework.SetupOptions) error {
+	p.verbose = opts.Verbose
+	p.log("Setting up Response API Redis test environment")
+
+	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+
+	// Step 1: Deploy Redis (required before semantic-router starts)
+	p.log("Step 1/6: Deploying Redis")
+	if err := p.deployRedis(ctx, opts); err != nil {
+		return fmt.Errorf("failed to deploy redis: %w", err)
+	}
+
+	// Step 2: Deploy Semantic Router with Response API (Redis) enabled
+	p.log("Step 2/6: Deploying Semantic Router with Response API (Redis)")
+	if err := p.deploySemanticRouter(ctx, deployer, opts); err != nil {
+		return fmt.Errorf("failed to deploy semantic router: %w", err)
+	}
+
+	// Step 3: Deploy Envoy Gateway
+	p.log("Step 3/6: Deploying Envoy Gateway")
+	if err := p.deployEnvoyGateway(ctx, deployer, opts); err != nil {
+		return fmt.Errorf("failed to deploy envoy gateway: %w", err)
+	}
+
+	// Step 4: Deploy Envoy AI Gateway
+	p.log("Step 4/6: Deploying Envoy AI Gateway")
+	if err := p.deployEnvoyAIGateway(ctx, deployer, opts); err != nil {
+		return fmt.Errorf("failed to deploy envoy ai gateway: %w", err)
+	}
+
+	// Step 5: Deploy Gateway API resources
+	p.log("Step 5/6: Deploying Gateway API resources")
+	if err := p.deployGatewayResources(ctx, opts); err != nil {
+		return fmt.Errorf("failed to deploy gateway resources: %w", err)
+	}
+
+	// Step 6: Verify all components are ready
+	p.log("Step 6/6: Verifying all components are ready")
+	if err := p.verifyEnvironment(ctx, opts); err != nil {
+		return fmt.Errorf("failed to verify environment: %w", err)
+	}
+
+	p.log("Response API Redis test environment setup complete")
+	return nil
+}
+
+// Teardown cleans up all deployed resources.
+func (p *RedisProfile) Teardown(ctx context.Context, opts *framework.TeardownOptions) error {
+	p.verbose = opts.Verbose
+	p.log("Tearing down Response API Redis test environment")
+
+	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+
+	p.log("Cleaning up Gateway API resources and Redis")
+	if err := p.cleanupGatewayResources(ctx, opts); err != nil {
+		p.log("Warning: Failed to cleanup Gateway API resources: %v", err)
+	}
+
+	p.log("Uninstalling Envoy AI Gateway")
+	deployer.Uninstall(ctx, releaseAIGatewayCRD, namespaceAIGateway)
+	deployer.Uninstall(ctx, releaseAIGateway, namespaceAIGateway)
+
+	p.log("Uninstalling Envoy Gateway")
+	deployer.Uninstall(ctx, releaseEnvoyGateway, namespaceEnvoyGateway)
+
+	p.log("Uninstalling Semantic Router")
+	deployer.Uninstall(ctx, releaseSemanticRouter, namespaceSemanticRouter)
+
+	p.log("Response API Redis test environment teardown complete")
+	return nil
+}
+
+// GetTestCases returns the list of test cases for this profile.
+func (p *RedisProfile) GetTestCases() []string {
+	return []string{
+		"response-api-create",
+		"response-api-get",
+		"response-api-delete",
+		"response-api-input-items",
+		"response-api-conversation-chaining",
+		"response-api-ttl-expiry",
+	}
+}
+
+// GetServiceConfig returns the service configuration for accessing the deployed service.
+func (p *RedisProfile) GetServiceConfig() framework.ServiceConfig {
+	return framework.ServiceConfig{
+		LabelSelector: labelSelectorGateway,
+		Namespace:     namespaceEnvoyGateway,
+		PortMapping:   "8080:80",
+	}
+}
+
+func (p *RedisProfile) deploySemanticRouter(ctx context.Context, deployer *helm.Deployer, opts *framework.SetupOptions) error {
+	installOpts := helm.InstallOptions{
+		ReleaseName: releaseSemanticRouter,
+		Chart:       chartPathSemanticRouter,
+		Namespace:   namespaceSemanticRouter,
+		ValuesFiles: []string{p.valuesFile},
+		Set: map[string]string{
+			"image.repository": imageRepository,
+			"image.tag":        opts.ImageTag,
+			"image.pullPolicy": imagePullPolicy,
+		},
+		Wait:    true,
+		Timeout: timeoutSemanticRouterInstall,
+	}
+
+	if err := deployer.Install(ctx, installOpts); err != nil {
+		return err
+	}
+
+	if err := deployer.WaitForDeployment(ctx, namespaceSemanticRouter, deploymentSemanticRouter, timeoutDeploymentWait); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *RedisProfile) deployRedis(ctx context.Context, opts *framework.SetupOptions) error {
+	if err := p.kubectlApply(ctx, opts.KubeConfig, p.redisManifest); err != nil {
+		return fmt.Errorf("failed to apply redis: %w", err)
+	}
+	return nil
+}
+
+func (p *RedisProfile) deployEnvoyGateway(ctx context.Context, deployer *helm.Deployer, _ *framework.SetupOptions) error {
+	installOpts := helm.InstallOptions{
+		ReleaseName: releaseEnvoyGateway,
+		Chart:       chartEnvoyGateway,
+		Namespace:   namespaceEnvoyGateway,
+		Version:     "v1.6.0",
+		ValuesFiles: []string{envoyGatewayValuesURL},
+		Wait:        true,
+		Timeout:     timeoutHelmInstall,
+	}
+
+	if err := deployer.Install(ctx, installOpts); err != nil {
+		return err
+	}
+
+	return deployer.WaitForDeployment(ctx, namespaceEnvoyGateway, deploymentEnvoyGateway, timeoutDeploymentWait)
+}
+
+func (p *RedisProfile) deployEnvoyAIGateway(ctx context.Context, deployer *helm.Deployer, _ *framework.SetupOptions) error {
+	// Install AI Gateway CRDs
+	crdOpts := helm.InstallOptions{
+		ReleaseName: releaseAIGatewayCRD,
+		Chart:       chartAIGatewayCRD,
+		Namespace:   namespaceAIGateway,
+		Version:     "v0.4.0",
+		Wait:        true,
+		Timeout:     timeoutHelmInstall,
+	}
+
+	if err := deployer.Install(ctx, crdOpts); err != nil {
+		return err
+	}
+
+	// Install AI Gateway
+	installOpts := helm.InstallOptions{
+		ReleaseName: releaseAIGateway,
+		Chart:       chartAIGateway,
+		Namespace:   namespaceAIGateway,
+		Version:     "v0.4.0",
+		Wait:        true,
+		Timeout:     timeoutHelmInstall,
+	}
+
+	if err := deployer.Install(ctx, installOpts); err != nil {
+		return err
+	}
+
+	return deployer.WaitForDeployment(ctx, namespaceAIGateway, deploymentAIGateway, timeoutDeploymentWait)
+}
+
+func (p *RedisProfile) deployGatewayResources(ctx context.Context, opts *framework.SetupOptions) error {
+	if err := p.kubectlApply(ctx, opts.KubeConfig, mockVLLMManifest); err != nil {
+		return fmt.Errorf("failed to apply mock-vllm: %w", err)
+	}
+
+	if err := p.kubectlApply(ctx, opts.KubeConfig, gatewayAPIManifest); err != nil {
+		return fmt.Errorf("failed to apply gateway API resources: %w", err)
+	}
+
+	return nil
+}
+
+func (p *RedisProfile) verifyEnvironment(ctx context.Context, opts *framework.SetupOptions) error {
+	// Create Kubernetes client
+	config, err := clientcmd.BuildConfigFromFlags("", opts.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	startTime := time.Now()
+	p.log("Waiting for Envoy Gateway service to be ready...")
+
+	var envoyService string
+	for {
+		envoyService, err = helpers.GetEnvoyServiceName(ctx, client, labelSelectorGateway, p.verbose)
+		if err == nil {
+			podErr := helpers.VerifyServicePodsRunning(ctx, client, namespaceEnvoyGateway, envoyService, p.verbose)
+			if podErr == nil {
+				p.log("Envoy Gateway service is ready: %s", envoyService)
+				break
+			}
+			if p.verbose {
+				p.log("Envoy service found but pods not ready: %v", podErr)
+			}
+			err = fmt.Errorf("service pods not ready: %w", podErr)
+		}
+
+		if time.Since(startTime) >= timeoutServiceRetry {
+			return fmt.Errorf("failed to get Envoy service with running pods after %v: %w", timeoutServiceRetry, err)
+		}
+
+		if p.verbose {
+			p.log("Envoy service not ready, retrying in %v... (elapsed: %v)",
+				intervalServiceRetry, time.Since(startTime).Round(time.Second))
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(intervalServiceRetry):
+		}
+	}
+
+	p.log("Verifying all deployments are healthy...")
+
+	if err := helpers.CheckDeployment(ctx, client, namespaceSemanticRouter, deploymentSemanticRouter, p.verbose); err != nil {
+		return fmt.Errorf("semantic-router deployment not healthy: %w", err)
+	}
+
+	if err := helpers.CheckDeployment(ctx, client, namespaceEnvoyGateway, deploymentEnvoyGateway, p.verbose); err != nil {
+		return fmt.Errorf("envoy-gateway deployment not healthy: %w", err)
+	}
+
+	p.log("All components are ready")
+	return nil
+}
+
+func (p *RedisProfile) cleanupGatewayResources(ctx context.Context, opts *framework.TeardownOptions) error {
+	if err := p.kubectlDelete(ctx, opts.KubeConfig, gatewayAPIManifest); err != nil {
+		return fmt.Errorf("failed to delete gateway API resources: %w", err)
+	}
+	if err := p.kubectlDelete(ctx, opts.KubeConfig, mockVLLMManifest); err != nil {
+		return fmt.Errorf("failed to delete mock-vllm: %w", err)
+	}
+	if err := p.kubectlDelete(ctx, opts.KubeConfig, p.redisManifest); err != nil {
+		return fmt.Errorf("failed to delete redis: %w", err)
+	}
+	return nil
+}
+
+func (p *RedisProfile) kubectlApply(ctx context.Context, kubeConfig, manifest string) error {
+	return p.runKubectl(ctx, kubeConfig, "apply", "-f", manifest)
+}
+
+func (p *RedisProfile) kubectlDelete(ctx context.Context, kubeConfig, manifest string) error {
+	return p.runKubectl(ctx, kubeConfig, "delete", "-f", manifest, "--ignore-not-found=true")
+}
+
+func (p *RedisProfile) runKubectl(ctx context.Context, kubeConfig string, args ...string) error {
+	args = append(args, "--kubeconfig", kubeConfig)
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	if p.verbose {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	return cmd.Run()
+}
+
+func (p *RedisProfile) log(format string, args ...interface{}) {
+	if p.verbose {
+		fmt.Printf("[%s] "+format+"\n", append([]interface{}{p.name}, args...)...)
+	}
+}

--- a/e2e/profiles/response-api-redis-cluster/profile.go
+++ b/e2e/profiles/response-api-redis-cluster/profile.go
@@ -1,0 +1,25 @@
+package responseapirediscluster
+
+import "github.com/vllm-project/semantic-router/e2e/pkg/profiles/responseapi"
+
+const (
+	valuesFile           = "e2e/profiles/response-api-redis-cluster/values.yaml"
+	redisClusterManifest = "deploy/kubernetes/response-api/redis-cluster.yaml"
+)
+
+// Profile implements the Response API Redis Cluster test profile.
+type Profile struct {
+	*responseapi.RedisProfile
+}
+
+// NewProfile creates a new Response API Redis Cluster profile.
+func NewProfile() *Profile {
+	return &Profile{
+		RedisProfile: responseapi.NewRedisProfile(
+			"response-api-redis-cluster",
+			"Tests Response API endpoints using Redis Cluster storage backend",
+			valuesFile,
+			redisClusterManifest,
+		),
+	}
+}

--- a/e2e/profiles/response-api-redis-cluster/values.yaml
+++ b/e2e/profiles/response-api-redis-cluster/values.yaml
@@ -1,0 +1,101 @@
+# Response API Redis Cluster E2E Test Profile Values
+replicaCount: 1
+
+image:
+  repository: ghcr.io/vllm-project/semantic-router/extproc
+  tag: latest
+  pullPolicy: Never
+
+config:
+  # Response API Configuration - Redis Cluster backend
+  response_api:
+    enabled: true
+    store_backend: "redis"
+    ttl_seconds: 10
+    max_responses: 1000
+    redis:
+      cluster_mode: true
+      cluster_addresses:
+        - "redis-cluster-0.redis-cluster.default.svc.cluster.local:6379"
+        - "redis-cluster-1.redis-cluster.default.svc.cluster.local:6379"
+        - "redis-cluster-2.redis-cluster.default.svc.cluster.local:6379"
+      key_prefix: "sr:"
+      pool_size: 10
+      min_idle_conns: 2
+      max_retries: 3
+      dial_timeout: 5
+      read_timeout: 3
+      write_timeout: 3
+
+  # vLLM Endpoints - required for Response API to forward requests
+  vllm_endpoints:
+    - name: "test-endpoint"
+      address: "mock-vllm.default.svc.cluster.local"
+      port: 8000
+      weight: 1
+
+  # Minimal model config to satisfy validation (matches mock-vllm /v1/models)
+  model_config:
+    "openai/gpt-oss-20b":
+      use_reasoning: false
+      preferred_endpoints: ["test-endpoint"]
+
+  # Minimal categories and decisions to satisfy validation
+  categories:
+    - name: other
+      description: "General knowledge and miscellaneous topics"
+      mmlu_categories: ["other"]
+
+  strategy: "priority"
+
+  decisions:
+    - name: "default_decision"
+      description: "Default catch-all decision"
+      priority: 1
+      rules:
+        operator: "OR"
+        conditions:
+          - type: "domain"
+            name: "other"
+      modelRefs:
+        - model: "openai/gpt-oss-20b"
+          use_reasoning: false
+
+  default_model: "openai/gpt-oss-20b"
+
+  # Classifier configuration - disable PII and category models for Response API
+  classifier:
+    category_model:
+      model_id: ""
+      threshold: 0.6
+      use_cpu: true
+      use_modernbert: false
+      category_mapping_path: ""
+    pii_model:
+      model_id: ""
+      threshold: 1.0
+      use_cpu: true
+      pii_mapping_path: ""
+
+  api:
+    batch_classification:
+      max_batch_size: 100
+      concurrency_threshold: 5
+      max_concurrency: 8
+      metrics:
+        enabled: true
+        detailed_goroutine_tracking: false
+        high_resolution_timing: false
+        sample_rate: 1.0
+
+  observability:
+    tracing:
+      enabled: false
+
+resources:
+  limits:
+    cpu: "2"
+    memory: "2Gi"
+  requests:
+    cpu: "500m"
+    memory: "1Gi"

--- a/e2e/profiles/response-api-redis/profile.go
+++ b/e2e/profiles/response-api-redis/profile.go
@@ -1,0 +1,25 @@
+package responseapiredis
+
+import "github.com/vllm-project/semantic-router/e2e/pkg/profiles/responseapi"
+
+const (
+	valuesFile    = "e2e/profiles/response-api-redis/values.yaml"
+	redisManifest = "deploy/kubernetes/response-api/redis.yaml"
+)
+
+// Profile implements the Response API Redis test profile.
+type Profile struct {
+	*responseapi.RedisProfile
+}
+
+// NewProfile creates a new Response API Redis profile.
+func NewProfile() *Profile {
+	return &Profile{
+		RedisProfile: responseapi.NewRedisProfile(
+			"response-api-redis",
+			"Tests Response API endpoints using Redis storage backend",
+			valuesFile,
+			redisManifest,
+		),
+	}
+}

--- a/e2e/profiles/response-api-redis/values.yaml
+++ b/e2e/profiles/response-api-redis/values.yaml
@@ -1,0 +1,99 @@
+# Response API Redis E2E Test Profile Values
+replicaCount: 1
+
+image:
+  repository: ghcr.io/vllm-project/semantic-router/extproc
+  tag: latest
+  pullPolicy: Never
+
+config:
+  # Response API Configuration - Redis backend
+  response_api:
+    enabled: true
+    store_backend: "redis"
+    ttl_seconds: 10
+    max_responses: 1000
+    redis:
+      address: "redis.default.svc.cluster.local:6379"
+      password: ""
+      db: 0
+      key_prefix: "sr:"
+      pool_size: 10
+      min_idle_conns: 2
+      max_retries: 3
+      dial_timeout: 5
+      read_timeout: 3
+      write_timeout: 3
+
+  # vLLM Endpoints - required for Response API to forward requests
+  vllm_endpoints:
+    - name: "test-endpoint"
+      address: "mock-vllm.default.svc.cluster.local"
+      port: 8000
+      weight: 1
+
+  # Minimal model config to satisfy validation (matches mock-vllm /v1/models)
+  model_config:
+    "openai/gpt-oss-20b":
+      use_reasoning: false
+      preferred_endpoints: ["test-endpoint"]
+
+  # Minimal categories and decisions to satisfy validation
+  categories:
+    - name: other
+      description: "General knowledge and miscellaneous topics"
+      mmlu_categories: ["other"]
+
+  strategy: "priority"
+
+  decisions:
+    - name: "default_decision"
+      description: "Default catch-all decision"
+      priority: 1
+      rules:
+        operator: "OR"
+        conditions:
+          - type: "domain"
+            name: "other"
+      modelRefs:
+        - model: "openai/gpt-oss-20b"
+          use_reasoning: false
+
+  default_model: "openai/gpt-oss-20b"
+
+  # Classifier configuration - disable PII and category models for Response API
+  classifier:
+    category_model:
+      model_id: ""
+      threshold: 0.6
+      use_cpu: true
+      use_modernbert: false
+      category_mapping_path: ""
+    pii_model:
+      model_id: ""
+      threshold: 1.0
+      use_cpu: true
+      pii_mapping_path: ""
+
+  api:
+    batch_classification:
+      max_batch_size: 100
+      concurrency_threshold: 5
+      max_concurrency: 8
+      metrics:
+        enabled: true
+        detailed_goroutine_tracking: false
+        high_resolution_timing: false
+        sample_rate: 1.0
+
+  observability:
+    tracing:
+      enabled: false
+
+resources:
+  limits:
+    cpu: "2"
+    memory: "2Gi"
+  requests:
+    cpu: "500m"
+    memory: "1Gi"


### PR DESCRIPTION
## Summary
This PR implements Redis-backed Response API profiles for the E2E testing framework in both standalone and cluster modes, including TTL expiry validation.

## Changes
- New E2E profiles: `response-api-redis`, `response-api-redis-cluster`
- Redis + Redis Cluster Kubernetes manifests
- Shared Redis profile logic to avoid duplication
- TTL expiry test added to Response API E2E
- CI workflow updated to include the new Redis profiles

## Testing
- `make e2e-test E2E_PROFILE=response-api-redis`
- `make e2e-test E2E_PROFILE=response-api-redis-cluster`

**Test Results:**
✅ 6/6 tests passing (100% success rate)
⏱️ Duration: **14m**
🔧 Profile: Response API Redis (standalone)

✅ 6/6 tests passing (100% success rate)
⏱️ Duration: **14m52s**  
🔧 Profile: Response API Redis Cluster