### PR TITLE
feat: complete language signal support

### DIFF
--- a/dashboard/frontend/src/components/ChatComponent.tsx
+++ b/dashboard/frontend/src/components/ChatComponent.tsx
@@ -166,6 +166,7 @@ const ChatComponent = ({
         'x-vsr-matched-fact-check',
         'x-vsr-matched-user-feedback',
         'x-vsr-matched-preference',
+        'x-vsr-matched-language',
         // Looper headers
         'x-vsr-looper-model',
         'x-vsr-looper-models-used',

--- a/dashboard/frontend/src/components/HeaderDisplay.tsx
+++ b/dashboard/frontend/src/components/HeaderDisplay.tsx
@@ -62,6 +62,10 @@ const HEADER_INFO: Record<string, { label: string; type: 'info' | 'success' | 'w
     label: 'Preference',
     type: 'info',
   },
+  'x-vsr-matched-language': {
+    label: 'Language',
+    type: 'info',
+  },
   // Looper headers
   'x-vsr-looper-models-used': {
     label: 'Collaborative Models',

--- a/dashboard/frontend/src/components/HeaderReveal.tsx
+++ b/dashboard/frontend/src/components/HeaderReveal.tsx
@@ -65,6 +65,10 @@ const HEADER_INFO: Record<string, { label: string; description: string }> = {
     label: 'Signal: Preference',
     description: 'User preference match',
   },
+  'x-vsr-matched-language': {
+    label: 'Signal: Language',
+    description: 'Detected language match',
+  },
   // Looper headers
   'x-vsr-looper-model': {
     label: 'Final Model',

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -75,6 +75,7 @@ type RequestContext struct {
 	VSRMatchedFactCheck    []string // Matched fact-check signals
 	VSRMatchedUserFeedback []string // Matched user feedback signals
 	VSRMatchedPreference   []string // Matched preference signals
+	VSRMatchedLanguage     []string // Matched language signals
 
 	// Endpoint tracking for windowed metrics
 	SelectedEndpoint string // The endpoint address selected for this request

--- a/src/semantic-router/pkg/extproc/processor_res_header.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header.go
@@ -205,6 +205,15 @@ func (r *OpenAIRouter) handleResponseHeaders(v *ext_proc.ProcessingRequest_Respo
 			})
 		}
 
+		if len(ctx.VSRMatchedLanguage) > 0 {
+			setHeaders = append(setHeaders, &core.HeaderValueOption{
+				Header: &core.HeaderValue{
+					Key:      headers.VSRMatchedLanguage,
+					RawValue: []byte(strings.Join(ctx.VSRMatchedLanguage, ",")),
+				},
+			})
+		}
+
 		// Attach router replay identifier when available
 		if ctx.RouterReplayID != "" {
 			setHeaders = append(setHeaders, &core.HeaderValueOption{

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -55,15 +55,16 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, userConte
 	ctx.VSRMatchedFactCheck = signals.MatchedFactCheckRules
 	ctx.VSRMatchedUserFeedback = signals.MatchedUserFeedbackRules
 	ctx.VSRMatchedPreference = signals.MatchedPreferenceRules
+	ctx.VSRMatchedLanguage = signals.MatchedLanguageRules
 
 	// Set fact-check context fields from signal results
 	// This replaces the old performFactCheckClassification call to avoid duplicate computation
 	r.setFactCheckFromSignals(ctx, signals.MatchedFactCheckRules)
 
 	// Log signal evaluation results
-	logging.Infof("Signal evaluation results: keyword=%v, embedding=%v, domain=%v, fact_check=%v, user_feedback=%v, preference=%v",
+	logging.Infof("Signal evaluation results: keyword=%v, embedding=%v, domain=%v, fact_check=%v, user_feedback=%v, preference=%v, language=%v",
 		signals.MatchedKeywordRules, signals.MatchedEmbeddingRules, signals.MatchedDomainRules,
-		signals.MatchedFactCheckRules, signals.MatchedUserFeedbackRules, signals.MatchedPreferenceRules)
+		signals.MatchedFactCheckRules, signals.MatchedUserFeedbackRules, signals.MatchedPreferenceRules, signals.MatchedLanguageRules)
 
 	// Perform decision evaluation using pre-computed signals
 	// This is ALWAYS done when decisions are configured, regardless of model type,

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -82,6 +82,10 @@ const (
 	// VSRMatchedPreference contains comma-separated list of matched preference signals.
 	// Example: "creative_writing,technical_analysis"
 	VSRMatchedPreference = "x-vsr-matched-preference"
+
+	// VSRMatchedLanguage contains comma-separated list of matched language signals.
+	// Example: "en,zh,es"
+	VSRMatchedLanguage = "x-vsr-matched-language"
 )
 
 // Security Headers

--- a/src/vllm-sr/cli/merger.py
+++ b/src/vllm-sr/cli/merger.py
@@ -119,6 +119,27 @@ def translate_preference_signals(preferences: list) -> list:
     return rules
 
 
+def translate_language_signals(languages: list) -> list:
+    """
+    Translate language signals to router format.
+
+    Args:
+        languages: List of Language objects
+
+    Returns:
+        list: Router language rules
+    """
+    rules = []
+    for signal in languages:
+        rule = {
+            "name": signal.name,
+        }
+        if signal.description:
+            rule["description"] = signal.description
+        rules.append(rule)
+    return rules
+
+
 def translate_external_models(external_models: list) -> list:
     """
     Translate external models to router format.
@@ -352,6 +373,12 @@ def merge_configs(user_config: UserConfig, defaults: Dict[str, Any]) -> Dict[str
             log.info(
                 f"  Added {len(user_config.signals.preferences)} preference signals"
             )
+
+        if user_config.signals.language and len(user_config.signals.language) > 0:
+            merged["language_rules"] = translate_language_signals(
+                user_config.signals.language
+            )
+            log.info(f"  Added {len(user_config.signals.language)} language signals")
 
         # Translate domains to categories
         if user_config.signals.domains:

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -60,6 +60,13 @@ class Preference(BaseModel):
     description: str
 
 
+class Language(BaseModel):
+    """Language detection signal configuration."""
+
+    name: str
+    description: str
+
+
 class Signals(BaseModel):
     """All signal configurations."""
 
@@ -69,6 +76,7 @@ class Signals(BaseModel):
     fact_check: Optional[List[FactCheck]] = []
     user_feedbacks: Optional[List[UserFeedback]] = []
     preferences: Optional[List[Preference]] = []
+    language: Optional[List[Language]] = []
 
 
 class Condition(BaseModel):


### PR DESCRIPTION
## Description

This PR completes the end-to-end implementation of the **language signal** feature, fixing bugs where language signals were configured but not working properly. The language signal detection was already implemented in the backend Go code, but was missing critical integration points in the Python CLI, response headers, and dashboard visualization.

## Problem

User reported that configuring language signals in `config.yaml` produced no results. Investigation revealed three missing pieces:

1. **Python CLI** - No support for translating language signal configuration
2. **Response Headers** - Language signal results were not exposed via HTTP headers
3. **Dashboard** - No visualization for language signals in the playground UI

## Solution

### Backend (Go) - 4 files changed

**`src/semantic-router/pkg/headers/headers.go`**
- Added `VSRMatchedLanguage` header constant

**`src/semantic-router/pkg/extproc/processor_req_header.go`**
- Added `VSRMatchedLanguage` field to `RequestContext` struct

**`src/semantic-router/pkg/extproc/req_filter_classification.go`**
- Store language signal results in request context
- Updated logging to include language signal

**`src/semantic-router/pkg/extproc/processor_res_header.go`**
- Added language signal to response headers (`x-vsr-matched-language`)

### Python CLI - 2 files changed

**`src/vllm-sr/cli/models.py`**
- Added `Language` Pydantic model
- Added `language` field to `Signals` class

**`src/vllm-sr/cli/merger.py`**
- Added `translate_language_signals()` function
- Integrated language signal processing in `merge_configs()`

### Dashboard (Frontend) - 3 files changed

**`dashboard/frontend/src/components/ChatComponent.tsx`**
- Added `x-vsr-matched-language` to header extraction list

**`dashboard/frontend/src/components/HeaderDisplay.tsx`**
- Added language signal display configuration

**`dashboard/frontend/src/components/HeaderReveal.tsx`**
- Added language signal to the "Signal Driven Decision" reveal animation

## How to Implement a New Signal (Complete Guide)

This PR serves as a reference for implementing new signal types. Here's the complete checklist:

### 1. Backend Go Implementation

- [ ] **Signal Classifier** (`src/semantic-router/pkg/classification/`)
  - Implement signal detection logic (e.g., `language_classifier.go`)
  - Add signal evaluation in `classifier.go` `EvaluateAllSignals()`

- [ ] **Configuration** (`src/semantic-router/pkg/config/config.go`)
  - Add signal rules struct (e.g., `LanguageRule`)
  - Add rules field to `Config` struct

- [ ] **Headers** (`src/semantic-router/pkg/headers/headers.go`)
  - Add header constant (e.g., `VSRMatchedLanguage`)

- [ ] **Request Context** (`src/semantic-router/pkg/extproc/processor_req_header.go`)
  - Add matched signal field to `RequestContext`

- [ ] **Signal Storage** (`src/semantic-router/pkg/extproc/req_filter_classification.go`)
  - Store signal results in context
  - Update logging

- [ ] **Response Headers** (`src/semantic-router/pkg/extproc/processor_res_header.go`)
  - Add signal to response headers

### 2. Python CLI Implementation

- [ ] **Models** (`src/vllm-sr/cli/models.py`)
  - Add Pydantic model for signal configuration
  - Add signal field to `Signals` class

- [ ] **Config Merger** (`src/vllm-sr/cli/merger.py`)
  - Add `translate_*_signals()` function
  - Integrate in `merge_configs()`

### 3. Dashboard Frontend Implementation

- [ ] **Chat Component** (`dashboard/frontend/src/components/ChatComponent.tsx`)
  - Add header key to extraction list

- [ ] **Header Display** (`dashboard/frontend/src/components/HeaderDisplay.tsx`)
  - Add signal to `HEADER_INFO` mapping

- [ ] **Header Reveal** (`dashboard/frontend/src/components/HeaderReveal.tsx`)
  - Add signal to reveal animation mapping

## Local Verification

### Quick Start with Make
```bash
# Start the entire stack (router + dashboard + observability)
make vllm-sr-start

# The dashboard will be available at http://localhost:3001
# The router API will be at http://localhost:8080