### PR TITLE
fix: update InMemoryCache test to match cross-model cache sharing behavior

### DIFF
--- a/src/semantic-router/pkg/cache/cache_test.go
+++ b/src/semantic-router/pkg/cache/cache_test.go
@@ -824,11 +824,12 @@ development:
 			Expect(found).To(BeTrue()) // Should find exact match
 			Expect(response).To(Equal([]byte("response")))
 
-			// Search for different model (should not match)
+			// Search for different model - should match due to cross-model cache sharing
+			// (model filtering removed to improve cache hit rates)
 			response, found, err = inMemoryCache.FindSimilar("different-model", "test query")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(BeFalse()) // Should not match different model
-			Expect(response).To(BeNil())
+			Expect(found).To(BeTrue())
+			Expect(response).To(Equal([]byte("response")))
 		})
 
 		It("should handle AddPendingRequest and UpdateWithResponse", func() {


### PR DESCRIPTION
## Problem
The test `"should handle FindSimilar operation with embeddings"` was failing because it expected model filtering, but `InMemoryCache` (like Milvus and Redis caches) supports cross-model cache sharing where entries can be matched across different models.

## Solution
Updated the test to expect cross-model cache hits, aligning with the documented design intent. The test now verifies that a query with a different model name can still match a cached entry if the semantic similarity is high enough.