### PR TITLE
[Feat][Dashboard]: Add Router Replay visualization page to dashboard

### DIFF
--- a/dashboard/backend/router/router.go
+++ b/dashboard/backend/router/router.go
@@ -319,6 +319,17 @@ func Setup(cfg *config.Config) *http.ServeMux {
 				envoyProxy.ServeHTTP(w, r)
 				return
 			}
+			// Route router_replay to Envoy proxy
+			if envoyProxy != nil && strings.HasPrefix(r.URL.Path, "/api/router/v1/router_replay") {
+				// Strip /api/router prefix and forward to Envoy
+				r.URL.Path = strings.TrimPrefix(r.URL.Path, "/api/router")
+				log.Printf("Proxying router_replay to Envoy: %s %s", r.Method, r.URL.Path)
+				if middleware.HandleCORSPreflight(w, r) {
+					return
+				}
+				envoyProxy.ServeHTTP(w, r)
+				return
+			}
 			rp.ServeHTTP(w, r)
 		})
 		log.Printf("Router API proxy configured: %s (excluding /api/router/config/*)", cfg.RouterAPIURL)

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import TopologyPage from './pages/TopologyPage'
 import TracingPage from './pages/TracingPage'
 import StatusPage from './pages/StatusPage'
 import LogsPage from './pages/LogsPage'
+import ReplayPage from './pages/ReplayPage'
 import EvaluationPage from './pages/EvaluationPage'
 import { ConfigSection } from './components/ConfigNav'
 import { ReadonlyProvider } from './contexts/ReadonlyContext'
@@ -162,6 +163,17 @@ const App: React.FC = () => {
                 onConfigSectionChange={(section) => setConfigSection(section as ConfigSection)}
               >
                 <LogsPage />
+              </Layout>
+            }
+          />
+          <Route
+            path="/replay"
+            element={
+              <Layout
+                configSection={configSection}
+                onConfigSectionChange={(section) => setConfigSection(section as ConfigSection)}
+              >
+                <ReplayPage />
               </Layout>
             }
           />

--- a/dashboard/frontend/src/components/CollapsibleSection.module.css
+++ b/dashboard/frontend/src/components/CollapsibleSection.module.css
@@ -1,0 +1,74 @@
+/* Collapsible Section Component */
+.container {
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  cursor: pointer;
+  width: 100%;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+  text-align: left;
+}
+
+.header:hover {
+  background: rgba(118, 185, 0, 0.1);
+  border-color: var(--color-primary);
+}
+
+.header:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.icon {
+  font-size: 0.75rem;
+  transition: transform 0.2s ease;
+  display: inline-block;
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.iconExpanded {
+  transform: rotate(90deg);
+}
+
+.title {
+  flex: 1;
+  text-align: left;
+}
+
+.truncatedBadge {
+  padding: 0.125rem 0.5rem;
+  background: rgba(234, 179, 8, 0.15);
+  border-radius: var(--radius-sm);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--color-warning, #eab308);
+  flex-shrink: 0;
+}
+
+.content {
+  margin-top: 0.5rem;
+  animation: expandContent 0.2s ease;
+}
+
+@keyframes expandContent {
+  from {
+    opacity: 0;
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    max-height: 1000px;
+  }
+}

--- a/dashboard/frontend/src/components/CollapsibleSection.tsx
+++ b/dashboard/frontend/src/components/CollapsibleSection.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import styles from './CollapsibleSection.module.css'
+
+interface CollapsibleSectionProps {
+  id: string
+  title: string
+  content: React.ReactNode
+  isTruncated?: boolean
+  defaultExpanded?: boolean
+  onToggle?: (isExpanded: boolean) => void
+}
+
+const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
+  id,
+  title,
+  content,
+  isTruncated = false,
+  defaultExpanded = false,
+  onToggle
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+
+  const handleToggle = () => {
+    const newExpanded = !isExpanded
+    setIsExpanded(newExpanded)
+    onToggle?.(newExpanded)
+  }
+
+  return (
+    <div className={styles.container}>
+      <button
+        className={styles.header}
+        onClick={handleToggle}
+        aria-expanded={isExpanded}
+        aria-controls={`collapsible-content-${id}`}
+      >
+        <span className={`${styles.icon} ${isExpanded ? styles.iconExpanded : ''}`}>
+          ▶
+        </span>
+        <span className={styles.title}>
+          {isExpanded ? 'Hide' : 'Show'} {title}
+        </span>
+        {isTruncated && (
+          <span className={styles.truncatedBadge}>Truncated</span>
+        )}
+      </button>
+      {isExpanded && (
+        <div
+          id={`collapsible-content-${id}`}
+          className={styles.content}
+          role="region"
+          aria-labelledby={`collapsible-header-${id}`}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CollapsibleSection

--- a/dashboard/frontend/src/components/DataTable.module.css
+++ b/dashboard/frontend/src/components/DataTable.module.css
@@ -3,9 +3,9 @@
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  overflow-x: auto;
-  overflow-y: hidden;
+  overflow: auto;
   -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
+  max-height: 100%;
 }
 
 .table {
@@ -17,7 +17,10 @@
 /* Table Header */
 .thead {
   background: #252525;
-  border-bottom: 2px solid var(--color-primary);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: inset 0 -2px 0 0 var(--color-primary);
 }
 
 .th {

--- a/dashboard/frontend/src/components/Layout.tsx
+++ b/dashboard/frontend/src/components/Layout.tsx
@@ -16,7 +16,7 @@ const Layout: React.FC<LayoutProps> = ({ children, configSection, onConfigSectio
   const navigate = useNavigate()
   const isConfigPage = location.pathname === '/config'
   const isSystemPage = isConfigPage && configSection === 'router-config'
-  const isObservabilityPage = ['/status', '/logs', '/monitoring', '/tracing', '/evaluation'].includes(location.pathname)
+  const isObservabilityPage = ['/status', '/logs', '/monitoring', '/tracing', '/evaluation', '/replay'].includes(location.pathname)
 
   // Close system dropdown when clicking outside
   useEffect(() => {
@@ -161,6 +161,13 @@ const Layout: React.FC<LayoutProps> = ({ children, configSection, onConfigSectio
                     onClick={() => setSystemDropdownOpen(false)}
                   >
                     Evaluation
+                  </NavLink>
+                  <NavLink
+                    to="/replay"
+                    className={`${styles.dropdownItem} ${location.pathname === '/replay' ? styles.dropdownItemActive : ''}`}
+                    onClick={() => setSystemDropdownOpen(false)}
+                  >
+                    Router Replay
                   </NavLink>
                 </div>
               )}

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -30,6 +30,8 @@
   --color-border: #333333;
   --color-border-hover: #444444;
   --color-shadow: rgba(0, 0, 0, 0.5);
+  --color-surface: #1f1f1f;
+  --color-primary-hover: #8fd400;
 
   /* Glow effects */
   --glow-primary: 0 0 20px rgba(118, 185, 0, 0.3);

--- a/dashboard/frontend/src/pages/ReplayPage.module.css
+++ b/dashboard/frontend/src/pages/ReplayPage.module.css
@@ -1,0 +1,374 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem;
+  gap: 1rem;
+  background-color: var(--color-bg);
+  overflow: hidden;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 4rem;
+  color: var(--color-text-secondary);
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Header */
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+.headerLeft {
+  flex: 1;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.titleIcon {
+  width: 28px;
+  height: 28px;
+  color: var(--color-primary);
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  margin: 0.5rem 0 0 0;
+}
+
+.refreshButton {
+  background: var(--color-primary);
+  color: white;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.refreshButton:hover {
+  background: var(--color-primary-hover);
+}
+
+.autoRefreshToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.autoRefreshToggle input {
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+/* Error State */
+.error {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-danger);
+  flex-shrink: 0;
+}
+
+.errorIcon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+
+.filterSelect {
+  padding: 0.5rem 0.75rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.filterSelect:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.filterSelect:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Records Table - container for DataTable */
+.recordsSection {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: auto;
+}
+
+/* Filters row - additional dropdowns below TableHeader */
+.filtersRow {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
+.timestamp {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.requestId {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  cursor: help;
+}
+
+.requestId span:hover {
+  color: var(--color-primary);
+}
+
+.decision {
+  font-weight: 500;
+}
+
+.category {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  background: rgba(0, 212, 255, 0.15);
+  color: var(--color-accent-cyan, #00d4ff);
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.modelChange {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.modelName {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--color-text);
+  padding: 0.25rem 0.5rem;
+  background: rgba(118, 185, 0, 0.08);
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+}
+
+.modelArrow {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.statusBadge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.statusSuccess {
+  background: rgba(118, 185, 0, 0.15);
+  color: var(--color-primary);
+}
+
+.statusError {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--color-danger);
+}
+
+.indicators {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  transition: all var(--transition-fast, 150ms);
+}
+
+.indicatorActive {
+  color: var(--color-primary);
+  background: rgba(118, 185, 0, 0.1);
+}
+
+.indicatorIcon {
+  width: 14px;
+  height: 14px;
+}
+
+/* Empty State */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.emptyState p {
+  color: var(--color-text-secondary);
+  max-width: 500px;
+}
+
+.emptyHint {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  max-width: 500px;
+}
+
+.configHint {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--color-primary);
+  text-align: left;
+  white-space: pre;
+}
+
+.emptySubtext {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  opacity: 0.7;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
+.paginationButton {
+  padding: 0.5rem 1rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.paginationButton:hover:not(:disabled) {
+  background: var(--color-surface);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.paginationButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.paginationInfo {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  padding: 0 1rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+    gap: 1rem;
+  }
+
+  .header {
+    flex-direction: column;
+  }
+
+  .headerRight {
+    flex-wrap: wrap;
+  }
+
+  .filtersRow {
+    flex-direction: column;
+  }
+
+  .pagination {
+    flex-wrap: wrap;
+  }
+
+  .title {
+    font-size: 1.25rem;
+  }
+}

--- a/dashboard/frontend/src/pages/ReplayPage.tsx
+++ b/dashboard/frontend/src/pages/ReplayPage.tsx
@@ -1,0 +1,758 @@
+import React, { useEffect, useState, useCallback, useMemo } from 'react'
+import { DataTable, Column } from '../components/DataTable'
+import TableHeader from '../components/TableHeader'
+import ViewModal, { ViewSection, ViewField } from '../components/ViewModal'
+import CollapsibleSection from '../components/CollapsibleSection'
+import { formatDate } from '../types/evaluation'
+import styles from './ReplayPage.module.css'
+
+// Types based on the backend store/store.go
+interface Signal {
+  keyword?: string[]
+  embedding?: string[]
+  domain?: string[]
+  fact_check?: string[]
+  user_feedback?: string[]
+  preference?: string[]
+}
+
+interface ReplayRecord {
+  id: string
+  timestamp: string
+  request_id?: string
+  decision?: string
+  category?: string
+  original_model?: string
+  selected_model?: string
+  reasoning_mode?: string
+  confidence_score?: number
+  selection_method?: string
+  signals: Signal
+  request_body?: string
+  response_body?: string
+  response_status?: number
+  from_cache?: boolean
+  streaming?: boolean
+  request_body_truncated?: boolean
+  response_body_truncated?: boolean
+}
+
+interface ReplayListResponse {
+  object: string
+  count: number
+  data: ReplayRecord[]
+}
+
+type FilterType = 'all' | 'cached' | 'streamed'
+
+const ReplayPage: React.FC = () => {
+  const [records, setRecords] = useState<ReplayRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [autoRefresh, setAutoRefresh] = useState(false)
+  
+  // UI state
+  const [searchTerm, setSearchTerm] = useState('')
+  const [filter, setFilter] = useState<FilterType>('all')
+  const [decisionFilter, setDecisionFilter] = useState<string>('all')
+  const [modelFilter, setModelFilter] = useState<string>('all')
+  
+  // ViewModal state
+  const [viewModalOpen, setViewModalOpen] = useState(false)
+  const [selectedRecordForModal, setSelectedRecordForModal] = useState<ReplayRecord | null>(null)
+  const [modalLoading, setModalLoading] = useState(false)
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageSize] = useState(25)
+
+  // Get unique decisions for filter dropdown
+  const uniqueDecisions = useMemo(() => {
+    const decisions = new Set<string>()
+    records.forEach(r => {
+      if (r.decision) decisions.add(r.decision)
+    })
+    return Array.from(decisions).sort()
+  }, [records])
+
+  // Get unique models for filter dropdown
+  const uniqueModels = useMemo(() => {
+    const models = new Set<string>()
+    records.forEach(r => {
+      if (r.selected_model) models.add(r.selected_model)
+      if (r.original_model) models.add(r.original_model)
+    })
+    return Array.from(models).sort()
+  }, [records])
+
+  const fetchRecords = useCallback(async () => {
+    try {
+      const response = await fetch('/api/router/v1/router_replay')
+      if (!response.ok) {
+        throw new Error(`Failed to fetch records: ${response.statusText}`)
+      }
+      const data: ReplayListResponse = await response.json()
+      // Sort by timestamp descending (newest first)
+      const sortedData = (data.data || []).sort((a, b) => 
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      )
+      setRecords(sortedData)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchRecords()
+    
+    if (autoRefresh) {
+      const interval = setInterval(fetchRecords, 5000)
+      return () => clearInterval(interval)
+    }
+  }, [fetchRecords, autoRefresh])
+
+  // Filter and search records
+  const filteredRecords = useMemo(() => {
+    return records.filter(record => {
+      // Apply cache/stream filter
+      if (filter === 'cached' && !record.from_cache) return false
+      if (filter === 'streamed' && !record.streaming) return false
+      
+      // Apply decision filter
+      if (decisionFilter !== 'all' && record.decision !== decisionFilter) return false
+      
+      // Apply model filter
+      if (modelFilter !== 'all') {
+        const matchesModel = record.selected_model === modelFilter || record.original_model === modelFilter
+        if (!matchesModel) return false
+      }
+      
+      // Apply search (by request ID only, per requirements)
+      if (searchTerm) {
+        const term = searchTerm.toLowerCase()
+        const matchesRequestId = record.request_id?.toLowerCase().includes(term)
+        if (!matchesRequestId) return false
+      }
+      
+      return true
+    })
+  }, [records, filter, decisionFilter, modelFilter, searchTerm])
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [filter, decisionFilter, modelFilter, searchTerm])
+
+  // Pagination calculations
+  const totalPages = Math.ceil(filteredRecords.length / pageSize)
+  const paginatedRecords = useMemo(() => {
+    const startIndex = (currentPage - 1) * pageSize
+    return filteredRecords.slice(startIndex, startIndex + pageSize)
+  }, [filteredRecords, currentPage, pageSize])
+
+  const formatJson = (jsonStr: string | undefined) => {
+    if (!jsonStr) return null
+    try {
+      return JSON.stringify(JSON.parse(jsonStr), null, 2)
+    } catch {
+      return jsonStr
+    }
+  }
+
+
+  // Build ViewModal sections from record (according to requirements)
+  const buildRecordSections = (record: ReplayRecord): ViewSection[] => {
+    const sections: ViewSection[] = []
+
+    // 1. Decision Information
+    sections.push({
+      title: 'Decision Information',
+      fields: [
+        { label: 'Decision name', value: record.decision || '-' },
+        {
+          label: 'Category',
+          value: record.signals?.domain?.length
+            ? record.signals.domain.join(', ')
+            : record.category || '-'
+        },
+        {
+          label: 'Confidence score',
+          value: record.confidence_score !== undefined
+            ? `${(record.confidence_score * 100).toFixed(1)}%`
+            : '-'
+        },
+        { label: 'Reasoning mode', value: record.reasoning_mode || '-' }
+      ]
+    })
+
+    // 2. Model Selection
+    sections.push({
+      title: 'Model Selection',
+      fields: [
+        { label: 'Original model', value: record.original_model || '-' },
+        { label: 'Selected model', value: record.selected_model || '-' },
+        { label: 'Selection method/strategy', value: record.selection_method || '-' }
+      ]
+    })
+
+    // 3. Signals
+    const signalFields: ViewField[] = []
+    
+    if (record.signals?.keyword?.length) {
+      signalFields.push({
+        label: 'Keyword matches',
+        value: (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {record.signals.keyword.map((kw, i) => (
+              <span key={i} style={{
+                padding: '0.25rem 0.75rem',
+                background: 'rgba(118, 185, 0, 0.1)',
+                borderRadius: '4px',
+                fontSize: '0.875rem',
+                fontFamily: 'var(--font-mono)'
+              }}>
+                {kw}
+              </span>
+            ))}
+          </div>
+        ),
+        fullWidth: true
+      })
+    }
+    
+    if (record.signals?.embedding?.length) {
+      signalFields.push({
+        label: 'Embedding matches',
+        value: (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {record.signals.embedding.map((emb, i) => (
+              <span key={i} style={{
+                padding: '0.25rem 0.75rem',
+                background: 'rgba(0, 212, 255, 0.1)',
+                borderRadius: '4px',
+                fontSize: '0.875rem',
+                fontFamily: 'var(--font-mono)'
+              }}>
+                {emb}
+              </span>
+            ))}
+          </div>
+        ),
+        fullWidth: true
+      })
+    }
+    
+    if (record.signals?.domain?.length) {
+      signalFields.push({
+        label: 'Domain matches',
+        value: (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {record.signals.domain.map((dom, i) => (
+              <span key={i} style={{
+                padding: '0.25rem 0.75rem',
+                background: 'rgba(147, 51, 234, 0.1)',
+                borderRadius: '4px',
+                fontSize: '0.875rem'
+              }}>
+                {dom}
+              </span>
+            ))}
+          </div>
+        ),
+        fullWidth: true
+      })
+    }
+    
+    if (record.signals?.fact_check?.length) {
+      signalFields.push({
+        label: 'Fact check results',
+        value: (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {record.signals.fact_check.map((fc, i) => (
+              <span key={i} style={{
+                padding: '0.25rem 0.75rem',
+                background: 'rgba(34, 197, 94, 0.1)',
+                borderRadius: '4px',
+                fontSize: '0.875rem'
+              }}>
+                {fc}
+              </span>
+            ))}
+          </div>
+        ),
+        fullWidth: true
+      })
+    }
+    
+    if (record.signals?.user_feedback?.length) {
+      signalFields.push({
+        label: 'User feedback',
+        value: (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {record.signals.user_feedback.map((uf, i) => (
+              <span key={i} style={{
+                padding: '0.25rem 0.75rem',
+                background: 'rgba(236, 72, 153, 0.1)',
+                borderRadius: '4px',
+                fontSize: '0.875rem'
+              }}>
+                {uf}
+              </span>
+            ))}
+          </div>
+        ),
+        fullWidth: true
+      })
+    }
+    
+    if (record.signals?.preference?.length) {
+      signalFields.push({
+        label: 'Preference signals',
+        value: (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+            {record.signals.preference.map((pref, i) => (
+              <span key={i} style={{
+                padding: '0.25rem 0.75rem',
+                background: 'rgba(234, 179, 8, 0.1)',
+                borderRadius: '4px',
+                fontSize: '0.875rem'
+              }}>
+                {pref}
+              </span>
+            ))}
+          </div>
+        ),
+        fullWidth: true
+      })
+    }
+
+    if (signalFields.length > 0) {
+      sections.push({
+        title: 'Signals',
+        fields: signalFields
+      })
+    }
+
+    // 4. Plugin Status
+    sections.push({
+      title: 'Plugin Status',
+      fields: [
+        {
+          label: 'Cache',
+          value: record.from_cache ? 'Hit' : 'Miss'
+        },
+        {
+          label: 'Streaming',
+          value: record.streaming ? 'On' : 'Off'
+        },
+        {
+          label: 'Response status code',
+          value: record.response_status ? (
+            <span style={{
+              padding: '0.25rem 0.75rem',
+              background: record.response_status < 400 ? 'rgba(118, 185, 0, 0.15)' : 'rgba(239, 68, 68, 0.15)',
+              borderRadius: '4px',
+              fontSize: '0.875rem',
+              fontWeight: 600
+            }}>
+              {record.response_status}
+            </span>
+          ) : '-'
+        }
+      ]
+    })
+
+    // 5. Request/Response (Collapsible)
+    const requestResponseFields: ViewField[] = []
+    
+    if (record.request_body) {
+      requestResponseFields.push({
+        label: 'Request body',
+        value: (
+          <CollapsibleSection
+            id={`request-${record.id}`}
+            title="request body"
+            isTruncated={record.request_body_truncated || false}
+            defaultExpanded={false}
+            content={
+              <pre style={{
+                margin: 0,
+                padding: '0.75rem',
+                background: 'var(--color-bg-tertiary)',
+                border: '1px solid var(--color-border)',
+                borderRadius: '4px',
+                fontSize: '0.8rem',
+                fontFamily: 'var(--font-mono)',
+                maxHeight: '400px',
+                overflow: 'auto',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word'
+              }}>
+                {formatJson(record.request_body) || record.request_body}
+              </pre>
+            }
+          />
+        ),
+        fullWidth: true
+      })
+    }
+
+    if (record.response_body) {
+      requestResponseFields.push({
+        label: 'Response body',
+        value: (
+          <CollapsibleSection
+            id={`response-${record.id}`}
+            title="response body"
+            isTruncated={record.response_body_truncated || false}
+            defaultExpanded={false}
+            content={
+              <pre style={{
+                margin: 0,
+                padding: '0.75rem',
+                background: 'var(--color-bg-tertiary)',
+                border: '1px solid var(--color-border)',
+                borderRadius: '4px',
+                fontSize: '0.8rem',
+                fontFamily: 'var(--font-mono)',
+                maxHeight: '400px',
+                overflow: 'auto',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word'
+              }}>
+                {formatJson(record.response_body) || record.response_body}
+              </pre>
+            }
+          />
+        ),
+        fullWidth: true
+      })
+    }
+
+    if (requestResponseFields.length > 0) {
+      sections.push({
+        title: 'Request/Response',
+        fields: requestResponseFields
+      })
+    }
+
+    return sections
+  }
+
+  // Handle view record in modal - fetch fresh data from API
+  const handleViewRecord = async (record: ReplayRecord) => {
+    setModalLoading(true)
+    setViewModalOpen(true)
+    
+    try {
+      // Fetch fresh record data by ID to ensure we have latest data
+      const response = await fetch(`/api/router/v1/router_replay/${record.id}`)
+      if (response.ok) {
+        const freshRecord = await response.json()
+        setSelectedRecordForModal(freshRecord)
+      } else {
+        // Fallback to cached data if API call fails
+        setSelectedRecordForModal(record)
+      }
+    } catch {
+      // Fallback to cached data on error
+      setSelectedRecordForModal(record)
+    } finally {
+      setModalLoading(false)
+    }
+  }
+  
+  // Handle close modal
+  const handleCloseModal = () => {
+    setViewModalOpen(false)
+    setSelectedRecordForModal(null)
+  }
+
+  // Define table columns for DataTable component
+  const tableColumns: Column<ReplayRecord>[] = [
+    {
+      key: 'request_id',
+      header: 'Request ID',
+      width: '280px',
+      render: (row) => (
+        <span className={styles.requestId} title={row.request_id || ''}>
+          {row.request_id || '-'}
+        </span>
+      )
+    },
+    {
+      key: 'timestamp',
+      header: 'Created',
+      width: '130px',
+      sortable: true,
+      render: (row) => (
+        <span className={styles.timestamp}>{formatDate(row.timestamp)}</span>
+      )
+    },
+    {
+      key: 'decision',
+      header: 'Decision',
+      width: '180px',
+      sortable: true,
+      render: (row) => <span className={styles.decision}>{row.decision || '-'}</span>
+    },
+    {
+      key: 'category',
+      header: 'Category',
+      width: '140px',
+      render: (row) => (
+        row.signals?.domain?.length ? (
+          <span className={styles.category}>{row.signals.domain[0]}</span>
+        ) : row.category ? (
+          <span className={styles.category}>{row.category}</span>
+        ) : <span>-</span>
+      )
+    },
+    {
+      key: 'model',
+      header: 'Model Change',
+      width: '380px',
+      render: (row) => (
+        <div className={styles.modelChange}>
+          <span className={styles.modelName}>{row.original_model || '-'}</span>
+          <span className={styles.modelArrow}>→</span>
+          <span className={styles.modelName}>{row.selected_model || '-'}</span>
+        </div>
+      )
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      width: '70px',
+      align: 'center',
+      render: (row) => (
+        <span className={`${styles.statusBadge} ${
+          row.response_status && row.response_status < 400 
+            ? styles.statusSuccess 
+            : styles.statusError
+        }`}>
+          {row.response_status || '-'}
+        </span>
+      )
+    },
+    {
+      key: 'flags',
+      header: 'Flags',
+      width: '160px',
+      render: (row) => (
+        <div className={styles.indicators}>
+          <span className={`${styles.indicator} ${row.from_cache ? styles.indicatorActive : ''}`}>
+            <svg className={styles.indicatorIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+            </svg>
+            Cache
+          </span>
+          <span className={`${styles.indicator} ${row.streaming ? styles.indicatorActive : ''}`}>
+            <svg className={styles.indicatorIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+            </svg>
+            Stream
+          </span>
+        </div>
+      )
+    }
+  ]
+
+
+  // Loading state
+  if (loading && records.length === 0) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>
+          <div className={styles.spinner}></div>
+          <p>Loading router replay records...</p>
+        </div>
+      </div>
+    )
+  }
+
+  // List View
+  return ( 
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <h1 className={styles.title}>
+            <svg className={styles.titleIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polygon points="5 3 19 12 5 21 5 3" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+            Router Replay
+          </h1>
+          <p className={styles.subtitle}>
+            View and analyze routing decision records for debugging and analysis.
+          </p>
+        </div>
+        <div className={styles.headerRight}>
+          <label className={styles.autoRefreshToggle}>
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+            />
+            <span>Auto-refresh</span>
+          </label>
+          <button onClick={fetchRecords} className={styles.refreshButton}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M23 4v6h-6M1 20v-6h6" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Only show error banner if we have records (refresh failed) - not when router_replay is disabled */}
+      {error && records.length > 0 && (
+        <div className={styles.error}>
+          <svg className={styles.errorIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="12" y1="8" x2="12" y2="12"/>
+            <line x1="12" y1="16" x2="12.01" y2="16"/>
+          </svg>
+          <span>{error}</span>
+        </div>
+      )}
+
+      <TableHeader
+        title="Routing Records"
+        count={filteredRecords.length}
+        searchPlaceholder="Search by Request ID..."
+        searchValue={searchTerm}
+        onSearchChange={setSearchTerm}
+      />
+
+      <div className={styles.filtersRow}>
+        <select
+          className={styles.filterSelect}
+          value={decisionFilter}
+          onChange={(e) => setDecisionFilter(e.target.value)}
+          disabled={uniqueDecisions.length === 0}
+        >
+          <option value="all">All Decisions</option>
+          {uniqueDecisions.map(decision => (
+            <option key={decision} value={decision}>{decision}</option>
+          ))}
+        </select>
+        <select
+          className={styles.filterSelect}
+          value={modelFilter}
+          onChange={(e) => setModelFilter(e.target.value)}
+          disabled={uniqueModels.length === 0}
+        >
+          <option value="all">All Models</option>
+          {uniqueModels.map(model => (
+            <option key={model} value={model}>{model}</option>
+          ))}
+        </select>
+        <select
+          className={styles.filterSelect}
+          value={filter}
+          onChange={(e) => setFilter(e.target.value as FilterType)}
+        >
+          <option value="all">Cache Status</option>
+          <option value="cached">Cached Only</option>
+          <option value="streamed">Streamed Only</option>
+        </select>
+      </div>
+
+      <div className={styles.recordsSection}>
+
+        {/* Show config hint only when NO records exist at all (not from filtering) */}
+        {records.length === 0 && !loading && (
+          <div className={styles.emptyState}>
+            {error ? (
+              <div className={styles.emptyHint}>
+                <p>Router Replay may not be enabled. To enable it, add this to your config.yaml:</p>
+                <pre className={styles.configHint}>{`router_replay:
+  enabled: true
+  store_backend: memory  # or redis, postgres
+  max_records: 200
+  capture_request_body: true
+  capture_response_body: true`}</pre>
+                <p className={styles.emptySubtext}>Then restart the router and send some requests.</p>
+              </div>
+            ) : (
+              <div className={styles.emptyHint}>
+                <p>Router replay records will appear here once requests are processed.</p>
+                <p className={styles.emptySubtext}>Send a chat completion request through the router to see it here.</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Always show DataTable - it handles empty state internally */}
+        {(records.length > 0 || loading) && (
+          <DataTable
+            columns={tableColumns}
+            data={paginatedRecords}
+            keyExtractor={(row) => row.id}
+            onView={handleViewRecord}
+            emptyMessage="No records match your search"
+          />
+        )}
+      </div>
+
+      {/* Pagination Controls - outside scrollable area */}
+      {totalPages > 1 && (
+        <div className={styles.pagination}>
+          <button
+            className={styles.paginationButton}
+            onClick={() => setCurrentPage(1)}
+            disabled={currentPage === 1}
+          >
+            First
+          </button>
+          <button
+            className={styles.paginationButton}
+            onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+            disabled={currentPage === 1}
+          >
+            Previous
+          </button>
+          
+          <span className={styles.paginationInfo}>
+            Page {currentPage} of {totalPages} ({filteredRecords.length} records)
+          </span>
+          
+          <button
+            className={styles.paginationButton}
+            onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+            disabled={currentPage === totalPages}
+          >
+            Next
+          </button>
+          <button
+            className={styles.paginationButton}
+            onClick={() => setCurrentPage(totalPages)}
+            disabled={currentPage === totalPages}
+          >
+            Last
+          </button>
+        </div>
+      )}
+
+
+      {/* View Modal */}
+      <ViewModal
+        isOpen={viewModalOpen}
+        onClose={handleCloseModal}
+        title={modalLoading 
+          ? 'Loading...'
+          : selectedRecordForModal?.request_id 
+            ? `Record: ${selectedRecordForModal.request_id.substring(0, 8)}...`
+            : `Record: ${selectedRecordForModal?.decision || selectedRecordForModal?.id || ''}`
+        }
+        sections={selectedRecordForModal ? buildRecordSections(selectedRecordForModal) : []}
+      />
+    </div>
+  )
+}
+
+export default ReplayPage

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -65,6 +65,7 @@ type RequestContext struct {
 	VSRSelectedDecisionConfidence float64          // Confidence score from DecisionEngine evaluation
 	VSRReasoningMode              string           // "on" or "off" - whether reasoning mode was determined to be used
 	VSRSelectedModel              string           // The model selected by VSR
+	VSRSelectionMethod            string           // Model selection algorithm used (e.g., "elo", "static", "router_dc")
 	VSRCacheHit                   bool             // Whether this request hit the cache
 	VSRInjectedSystemPrompt       bool             // Whether a system prompt was injected into the request
 	VSRSelectedDecision           *config.Decision // The decision object selected by DecisionEngine (for plugins)

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -136,12 +136,14 @@ func (r *OpenAIRouter) startRouterReplay(
 	}
 
 	rec := routerreplay.RoutingRecord{
-		RequestID:     ctx.RequestID,
-		Decision:      decisionName,
-		Category:      ctx.VSRSelectedCategory,
-		OriginalModel: originalModel,
-		SelectedModel: modelForRecord,
-		ReasoningMode: reasoningMode,
+		RequestID:       ctx.RequestID,
+		Decision:        decisionName,
+		Category:        ctx.VSRSelectedCategory,
+		OriginalModel:   originalModel,
+		SelectedModel:   modelForRecord,
+		ReasoningMode:   reasoningMode,
+		ConfidenceScore: ctx.VSRSelectedDecisionConfidence,
+		SelectionMethod: ctx.VSRSelectionMethod,
 		Signals: routerreplay.Signal{
 			Keyword:      ctx.VSRMatchedKeywords,
 			Embedding:    ctx.VSRMatchedEmbeddings,

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -178,7 +178,6 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, userConte
 	}
 	// Store category in context for response headers
 	ctx.VSRSelectedCategory = categoryName
-	ctx.VSRSelectedDecisionConfidence = evaluationConfidence
 
 	// Note: VSRMatchedKeywords is already set from signals.MatchedKeywordRules (line 61)
 	// We should NOT overwrite it with result.MatchedKeywords which contains actual keywords
@@ -186,6 +185,7 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, userConte
 
 	decisionName = result.Decision.Name
 	evaluationConfidence = result.Confidence
+	ctx.VSRSelectedDecisionConfidence = evaluationConfidence
 	logging.Infof("Decision Evaluation Result: decision=%s, category=%s, confidence=%.3f, matched_rules=%v",
 		decisionName, categoryName, evaluationConfidence, result.MatchedRules)
 
@@ -214,6 +214,7 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, userConte
 				decisionName, selectedModel, usedMethod)
 		}
 		ctx.VSRSelectedModel = selectedModel
+		ctx.VSRSelectionMethod = usedMethod
 
 		// Determine reasoning mode from the selected model's configuration
 		if selectedModelRef.UseReasoning != nil {
@@ -240,6 +241,8 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, userConte
 	} else {
 		// No model refs in decision, use default model
 		selectedModel = r.Config.DefaultModel
+		ctx.VSRSelectedModel = selectedModel
+		ctx.VSRSelectionMethod = "default"
 		logging.Infof("No model refs in decision %s, using default model: %s", decisionName, selectedModel)
 	}
 

--- a/src/semantic-router/pkg/extproc/req_filter_looper.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper.go
@@ -96,6 +96,7 @@ func (r *OpenAIRouter) handleLooperExecution(
 	// Update context with looper results
 	reqCtx.RequestModel = resp.Model
 	reqCtx.VSRSelectedModel = resp.Model
+	reqCtx.VSRSelectionMethod = resp.AlgorithmType
 
 	// Capture router replay information if enabled
 	// Use first model from ModelsUsed as the "selected" model for replay
@@ -104,6 +105,12 @@ func (r *OpenAIRouter) handleLooperExecution(
 		selectedModel = resp.ModelsUsed[0]
 	}
 	r.startRouterReplay(reqCtx, openAIRequest.Model, selectedModel, decision.Name)
+
+	// Update router replay with success status (looper returns immediate response with 200)
+	r.updateRouterReplayStatus(reqCtx, 200, false)
+
+	// Attach response body to router replay record
+	r.attachRouterReplayResponse(reqCtx, resp.Body, true)
 
 	// Create immediate response with detailed headers
 	return r.createLooperResponse(resp), nil

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -25,6 +25,8 @@ type Record struct {
 	OriginalModel         string    `json:"original_model,omitempty"`
 	SelectedModel         string    `json:"selected_model,omitempty"`
 	ReasoningMode         string    `json:"reasoning_mode,omitempty"`
+	ConfidenceScore       float64   `json:"confidence_score,omitempty"`
+	SelectionMethod       string    `json:"selection_method,omitempty"`
 	Signals               Signal    `json:"signals"`
 	RequestBody           string    `json:"request_body,omitempty"`
 	ResponseBody          string    `json:"response_body,omitempty"`

--- a/src/vllm-sr/cli/templates/router-defaults.yaml
+++ b/src/vllm-sr/cli/templates/router-defaults.yaml
@@ -19,6 +19,16 @@ response_api:
   ttl_seconds: 86400       # 24 hours
   max_responses: 1000
 
+# Router Replay Configuration
+# Records all routing decisions for debugging and analysis
+router_replay:
+  enabled: true
+  store_backend: "memory"  # Options: "memory"
+  max_records: 1000
+  capture_request_body: true
+  capture_response_body: true
+  max_body_bytes: 4096
+
 semantic_cache:
   enabled: true
   backend_type: "memory"  # Options: "memory", "milvus", or "hybrid"


### PR DESCRIPTION
## Summary

This PR adding a **Router Replay** visualization page to the dashboard, enabling users to view and debug routing decisions with detailed metadata including signals, model selections, and plugin status.

## Features

- **List View**: Sortable table with request ID, timestamp, decision, category, model changes, cache status, and response status
- **Filtering**: Filter by decision name, category, status, and cache hit
- **Search**: Real-time search by request ID
- **Pagination**: 25 records per page with navigation controls
- **Expandable Rows**: View detailed signals (keyword, embedding, domain, fact_check, user_feedback, preference) and plugin status
- **Request/Response Inspection**: Collapsible sections for body content

## Changes

### Frontend (New Files)
| File | Description |
|------|-------------|
| `ReplayPage.tsx` | Main page component with table, filters, and pagination |
| `ReplayPage.module.css` | Page-specific styles |
| `CollapsibleSection.tsx` | Reusable expandable content component |
| `CollapsibleSection.module.css` | Collapsible section styles |

### Frontend (Modified)
| File | Description |
|------|-------------|
| `App.tsx` | Added `/replay` route |
| `Layout.tsx` | Added Router Replay to System dropdown menu |
| `DataTable.module.css` | Added sticky headers and vertical scroll support |
| `index.css` | Fixed missing CSS variables (`--color-surface`, `--color-primary-hover`) used in StatusPage/LogsPage |

### Backend (Modified)
| File | Description |
|------|-------------|
| `store/store.go` | Added `ConfidenceScore` and `SelectionMethod` fields to replay records |
| `recorder.go` | Populate new fields from VSR context |
| `req_filter_looper.go` | Added router replay support for looper execution |
| `req_filter_classification.go` | Added selection method capture |
| `router.go` | Dashboard backend proxy endpoint |

## Known Limitations / Follow-up Work

The following plugin status fields from the original requirements (#1197) are **not included** in this PR as they require additional backend support:

| Field | Description | Status |
|-------|-------------|--------|
| Guardrails | enabled/disabled, results | 🔜 Requires BE support |
| RAG | context retrieved | 🔜 Requires BE support |
| Hallucination detection | results | 🔜 Requires BE support |

> **Note**: These fields will be added in a follow-up PR that includes both frontend display and backend support for capturing this data. The current implementation supports: **Cache** (hit/miss) and **Streaming** (on/off)..


## Related Issue
Closes #1197


## Test Plan

- [x] Navigate to System > Router Replay in dashboard
- [x] Verify table displays with correct columns and data
- [x] Test filtering by decision, category, status, cache
- [x] Test search by request ID
- [x] Test pagination (next/previous)
- [x] Expand rows to view signals and plugin status
- [x] Verify sticky headers remain visible when scrolling