### PR TITLE
feat: internal MCP config server (CRUD)

### DIFF
--- a/src/semantic-router/cmd/main.go
+++ b/src/semantic-router/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/extproc"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/k8s"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/logo"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/mcpserver"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/modeldownload"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
@@ -66,9 +67,13 @@ func main() {
 	// This is important for Kubernetes mode where the controller will update it
 	config.Replace(cfg)
 
-	// Ensure required models are downloaded
-	if modelErr := ensureModelsDownloaded(cfg); modelErr != nil {
-		logging.Fatalf("Failed to ensure models are downloaded: %v", modelErr)
+	// Ensure required models are downloaded (can be skipped for local dev)
+	if strings.EqualFold(os.Getenv("SR_SKIP_MODEL_DOWNLOAD"), "true") {
+		logging.Warnf("SR_SKIP_MODEL_DOWNLOAD=true: skipping model download checks")
+	} else {
+		if modelErr := ensureModelsDownloaded(cfg); modelErr != nil {
+			logging.Fatalf("Failed to ensure models are downloaded: %v", modelErr)
+		}
 	}
 
 	// If download-only mode, exit after downloading models
@@ -257,6 +262,26 @@ func main() {
 			logging.Infof("Starting API server on port %d", *apiPort)
 			if err := apiserver.Init(*configPath, *apiPort, *enableSystemPromptAPI); err != nil {
 				logging.Errorf("Start API server error: %v", err)
+			}
+		}()
+	}
+
+	// Start internal MCP config server if enabled
+	if cfg.MCPConfigServer.Enabled {
+		go func() {
+			addr := cfg.MCPConfigServer.Addr
+			if addr == "" {
+				addr = mcpserver.DefaultAddr
+			}
+			path := cfg.MCPConfigServer.Path
+			if path == "" {
+				path = mcpserver.DefaultPath
+			}
+
+			logging.Infof("Starting MCP config server on %s (path: %s)", addr, path)
+			m := mcpserver.NewWithPersist(&mcpserver.GlobalConfigProvider{}, *configPath)
+			if err := m.StartHTTP(addr, path); err != nil {
+				logging.Errorf("MCP config server error: %v", err)
 			}
 		}()
 	}

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -85,6 +85,11 @@ type RouterConfig struct {
 	LLMObservability `yaml:",inline"`
 	// API server configuration
 	APIServer `yaml:",inline"`
+
+	// MCPConfigServer starts an internal MCP server (HTTP transport) to expose
+	// read-only config introspection tools to agentic clients.
+	MCPConfigServer MCPConfigServer `yaml:"mcp_config_server,omitempty"`
+
 	// Router-specific options
 	RouterOptions `yaml:",inline"`
 	/*
@@ -109,6 +114,16 @@ type ToolSelection struct {
 type APIServer struct {
 	// API configuration for classification endpoints
 	API APIConfig `yaml:"api"`
+}
+
+// MCPConfigServer configures the optional internal MCP server.
+//
+// Note: Path is reserved for future use. The current HTTP transport implementation
+// in mcp-go may not support configurable base paths.
+type MCPConfigServer struct {
+	Enabled bool   `yaml:"enabled"`
+	Addr    string `yaml:"addr,omitempty"` // e.g. ":8088"
+	Path    string `yaml:"path,omitempty"` // e.g. "/mcp" (best-effort)
 }
 
 // LLMObservability represents the configuration for LLM observability

--- a/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
@@ -2,6 +2,7 @@ config_source: kubernetes
 embedding_models:
   qwen3_model_path: models/mom-embedding-pro
   gemma_model_path: models/mom-embedding-flash
+  mmbert_model_path: ""
   use_cpu: true
 bert_model:
   model_id: models/mom-embedding-light
@@ -57,6 +58,7 @@ semantic_cache:
   embedding_model: bert
 response_api:
   enabled: false
+router_replay: {}
 observability:
   tracing:
     enabled: false

--- a/src/semantic-router/pkg/mcpserver/crud.go
+++ b/src/semantic-router/pkg/mcpserver/crud.go
@@ -1,0 +1,744 @@
+package mcpserver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func normalizeKind(kind string) string {
+	k := strings.ToLower(strings.TrimSpace(kind))
+	k = strings.ReplaceAll(k, "-", "_")
+	return k
+}
+
+func listNames(kind string, cfg *config.RouterConfig) ([]string, error) {
+	switch normalizeKind(kind) {
+	case KindDecision:
+		n := make([]string, 0, len(cfg.Decisions))
+		for _, d := range cfg.Decisions {
+			if d.Name != "" {
+				n = append(n, d.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindKeywordRule:
+		n := make([]string, 0, len(cfg.KeywordRules))
+		for _, r := range cfg.KeywordRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindEmbeddingRule:
+		n := make([]string, 0, len(cfg.EmbeddingRules))
+		for _, r := range cfg.EmbeddingRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindFactCheckRule:
+		n := make([]string, 0, len(cfg.FactCheckRules))
+		for _, r := range cfg.FactCheckRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindUserFeedbackRule:
+		n := make([]string, 0, len(cfg.UserFeedbackRules))
+		for _, r := range cfg.UserFeedbackRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindPreferenceRule:
+		n := make([]string, 0, len(cfg.PreferenceRules))
+		for _, r := range cfg.PreferenceRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindLanguageRule:
+		n := make([]string, 0, len(cfg.LanguageRules))
+		for _, r := range cfg.LanguageRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindContextRule:
+		n := make([]string, 0, len(cfg.ContextRules))
+		for _, r := range cfg.ContextRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindLatencyRule:
+		n := make([]string, 0, len(cfg.LatencyRules))
+		for _, r := range cfg.LatencyRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindComplexityRule:
+		n := make([]string, 0, len(cfg.ComplexityRules))
+		for _, r := range cfg.ComplexityRules {
+			if r.Name != "" {
+				n = append(n, r.Name)
+			}
+		}
+		sort.Strings(n)
+		return n, nil
+	case KindModel:
+		n := make([]string, 0, len(cfg.ModelConfig))
+		for name := range cfg.ModelConfig {
+			n = append(n, name)
+		}
+		sort.Strings(n)
+		return n, nil
+	default:
+		return nil, fmt.Errorf("unsupported kind %q", kind)
+	}
+}
+
+func getEntityYAML(kind, name string, cfg *config.RouterConfig) (any, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	switch normalizeKind(kind) {
+	case KindDecision:
+		for _, d := range cfg.Decisions {
+			if d.Name == name {
+				return d, nil
+			}
+		}
+		return nil, fmt.Errorf("decision %q not found", name)
+	case KindKeywordRule:
+		for _, r := range cfg.KeywordRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("keyword_rule %q not found", name)
+	case KindEmbeddingRule:
+		for _, r := range cfg.EmbeddingRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("embedding_rule %q not found", name)
+	case KindFactCheckRule:
+		for _, r := range cfg.FactCheckRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("fact_check_rule %q not found", name)
+	case KindUserFeedbackRule:
+		for _, r := range cfg.UserFeedbackRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("user_feedback_rule %q not found", name)
+	case KindPreferenceRule:
+		for _, r := range cfg.PreferenceRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("preference_rule %q not found", name)
+	case KindLanguageRule:
+		for _, r := range cfg.LanguageRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("language_rule %q not found", name)
+	case KindContextRule:
+		for _, r := range cfg.ContextRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("context_rule %q not found", name)
+	case KindLatencyRule:
+		for _, r := range cfg.LatencyRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("latency_rule %q not found", name)
+	case KindComplexityRule:
+		for _, r := range cfg.ComplexityRules {
+			if r.Name == name {
+				return r, nil
+			}
+		}
+		return nil, fmt.Errorf("complexity_rule %q not found", name)
+	case KindModel:
+		if cfg.ModelConfig == nil {
+			return nil, fmt.Errorf("model_config is nil")
+		}
+		mp, ok := cfg.ModelConfig[name]
+		if !ok {
+			return nil, fmt.Errorf("model %q not found", name)
+		}
+		return mp, nil
+	default:
+		return nil, fmt.Errorf("unsupported kind %q", kind)
+	}
+}
+
+func addEntity(kind string, cfg *config.RouterConfig, itemYAML string) (string, error) {
+	switch normalizeKind(kind) {
+	case KindDecision:
+		item, err := parseYAMLStrict[config.Decision](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("decision.name is required")
+		}
+		for _, d := range cfg.Decisions {
+			if d.Name == item.Name {
+				return "", fmt.Errorf("decision %q already exists", item.Name)
+			}
+		}
+		cfg.Decisions = append(cfg.Decisions, *item)
+		return item.Name, nil
+	case KindKeywordRule:
+		item, err := parseYAMLStrict[config.KeywordRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("keyword_rule.name is required")
+		}
+		for _, r := range cfg.KeywordRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("keyword_rule %q already exists", item.Name)
+			}
+		}
+		cfg.KeywordRules = append(cfg.KeywordRules, *item)
+		return item.Name, nil
+	case KindEmbeddingRule:
+		item, err := parseYAMLStrict[config.EmbeddingRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("embedding_rule.name is required")
+		}
+		for _, r := range cfg.EmbeddingRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("embedding_rule %q already exists", item.Name)
+			}
+		}
+		cfg.EmbeddingRules = append(cfg.EmbeddingRules, *item)
+		return item.Name, nil
+	case KindFactCheckRule:
+		item, err := parseYAMLStrict[config.FactCheckRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("fact_check_rule.name is required")
+		}
+		for _, r := range cfg.FactCheckRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("fact_check_rule %q already exists", item.Name)
+			}
+		}
+		cfg.FactCheckRules = append(cfg.FactCheckRules, *item)
+		return item.Name, nil
+	case KindUserFeedbackRule:
+		item, err := parseYAMLStrict[config.UserFeedbackRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("user_feedback_rule.name is required")
+		}
+		for _, r := range cfg.UserFeedbackRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("user_feedback_rule %q already exists", item.Name)
+			}
+		}
+		cfg.UserFeedbackRules = append(cfg.UserFeedbackRules, *item)
+		return item.Name, nil
+	case KindPreferenceRule:
+		item, err := parseYAMLStrict[config.PreferenceRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("preference_rule.name is required")
+		}
+		for _, r := range cfg.PreferenceRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("preference_rule %q already exists", item.Name)
+			}
+		}
+		cfg.PreferenceRules = append(cfg.PreferenceRules, *item)
+		return item.Name, nil
+	case KindLanguageRule:
+		item, err := parseYAMLStrict[config.LanguageRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("language_rule.name is required")
+		}
+		for _, r := range cfg.LanguageRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("language_rule %q already exists", item.Name)
+			}
+		}
+		cfg.LanguageRules = append(cfg.LanguageRules, *item)
+		return item.Name, nil
+	case KindContextRule:
+		item, err := parseYAMLStrict[config.ContextRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("context_rule.name is required")
+		}
+		for _, r := range cfg.ContextRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("context_rule %q already exists", item.Name)
+			}
+		}
+		cfg.ContextRules = append(cfg.ContextRules, *item)
+		return item.Name, nil
+	case KindLatencyRule:
+		item, err := parseYAMLStrict[config.LatencyRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("latency_rule.name is required")
+		}
+		for _, r := range cfg.LatencyRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("latency_rule %q already exists", item.Name)
+			}
+		}
+		cfg.LatencyRules = append(cfg.LatencyRules, *item)
+		return item.Name, nil
+	case KindComplexityRule:
+		item, err := parseYAMLStrict[config.ComplexityRule](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("complexity_rule.name is required")
+		}
+		for _, r := range cfg.ComplexityRules {
+			if r.Name == item.Name {
+				return "", fmt.Errorf("complexity_rule %q already exists", item.Name)
+			}
+		}
+		cfg.ComplexityRules = append(cfg.ComplexityRules, *item)
+		return item.Name, nil
+	case KindModel:
+		// For models, the payload is a small object with name + params.
+		type modelPayload struct {
+			Name   string             `yaml:"name"`
+			Params config.ModelParams `yaml:"params"`
+		}
+		item, err := parseYAMLStrict[modelPayload](itemYAML)
+		if err != nil {
+			return "", err
+		}
+		if item.Name == "" {
+			return "", fmt.Errorf("model.name is required")
+		}
+		if cfg.ModelConfig == nil {
+			cfg.ModelConfig = map[string]config.ModelParams{}
+		}
+		if _, ok := cfg.ModelConfig[item.Name]; ok {
+			return "", fmt.Errorf("model %q already exists", item.Name)
+		}
+		cfg.ModelConfig[item.Name] = item.Params
+		return item.Name, nil
+	default:
+		return "", fmt.Errorf("unsupported kind %q", kind)
+	}
+}
+
+func updateEntity(kind, name string, cfg *config.RouterConfig, itemYAML string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	switch normalizeKind(kind) {
+	case KindDecision:
+		item, err := parseYAMLStrict[config.Decision](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("decision.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.Decisions {
+			if cfg.Decisions[i].Name == name {
+				cfg.Decisions[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("decision %q not found", name)
+	case KindKeywordRule:
+		item, err := parseYAMLStrict[config.KeywordRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("keyword_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.KeywordRules {
+			if cfg.KeywordRules[i].Name == name {
+				cfg.KeywordRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("keyword_rule %q not found", name)
+	case KindEmbeddingRule:
+		item, err := parseYAMLStrict[config.EmbeddingRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("embedding_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.EmbeddingRules {
+			if cfg.EmbeddingRules[i].Name == name {
+				cfg.EmbeddingRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("embedding_rule %q not found", name)
+	case KindFactCheckRule:
+		item, err := parseYAMLStrict[config.FactCheckRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("fact_check_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.FactCheckRules {
+			if cfg.FactCheckRules[i].Name == name {
+				cfg.FactCheckRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("fact_check_rule %q not found", name)
+	case KindUserFeedbackRule:
+		item, err := parseYAMLStrict[config.UserFeedbackRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("user_feedback_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.UserFeedbackRules {
+			if cfg.UserFeedbackRules[i].Name == name {
+				cfg.UserFeedbackRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("user_feedback_rule %q not found", name)
+	case KindPreferenceRule:
+		item, err := parseYAMLStrict[config.PreferenceRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("preference_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.PreferenceRules {
+			if cfg.PreferenceRules[i].Name == name {
+				cfg.PreferenceRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("preference_rule %q not found", name)
+	case KindLanguageRule:
+		item, err := parseYAMLStrict[config.LanguageRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("language_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.LanguageRules {
+			if cfg.LanguageRules[i].Name == name {
+				cfg.LanguageRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("language_rule %q not found", name)
+	case KindContextRule:
+		item, err := parseYAMLStrict[config.ContextRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("context_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.ContextRules {
+			if cfg.ContextRules[i].Name == name {
+				cfg.ContextRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("context_rule %q not found", name)
+	case KindLatencyRule:
+		item, err := parseYAMLStrict[config.LatencyRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("latency_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.LatencyRules {
+			if cfg.LatencyRules[i].Name == name {
+				cfg.LatencyRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("latency_rule %q not found", name)
+	case KindComplexityRule:
+		item, err := parseYAMLStrict[config.ComplexityRule](itemYAML)
+		if err != nil {
+			return err
+		}
+		if item.Name != "" && item.Name != name {
+			return fmt.Errorf("complexity_rule.name must match path name (%q)", name)
+		}
+		item.Name = name
+		for i := range cfg.ComplexityRules {
+			if cfg.ComplexityRules[i].Name == name {
+				cfg.ComplexityRules[i] = *item
+				return nil
+			}
+		}
+		return fmt.Errorf("complexity_rule %q not found", name)
+	case KindModel:
+		item, err := parseYAMLStrict[config.ModelParams](itemYAML)
+		if err != nil {
+			return err
+		}
+		if cfg.ModelConfig == nil {
+			cfg.ModelConfig = map[string]config.ModelParams{}
+		}
+		if _, ok := cfg.ModelConfig[name]; !ok {
+			return fmt.Errorf("model %q not found", name)
+		}
+		cfg.ModelConfig[name] = *item
+		return nil
+	default:
+		return fmt.Errorf("unsupported kind %q", kind)
+	}
+}
+
+func deleteEntity(kind, name string, cfg *config.RouterConfig) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	switch normalizeKind(kind) {
+	case KindDecision:
+		out := cfg.Decisions[:0]
+		found := false
+		for _, d := range cfg.Decisions {
+			if d.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, d)
+		}
+		cfg.Decisions = out
+		if !found {
+			return fmt.Errorf("decision %q not found", name)
+		}
+		return nil
+	case KindKeywordRule:
+		out := cfg.KeywordRules[:0]
+		found := false
+		for _, r := range cfg.KeywordRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.KeywordRules = out
+		if !found {
+			return fmt.Errorf("keyword_rule %q not found", name)
+		}
+		return nil
+	case KindEmbeddingRule:
+		out := cfg.EmbeddingRules[:0]
+		found := false
+		for _, r := range cfg.EmbeddingRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.EmbeddingRules = out
+		if !found {
+			return fmt.Errorf("embedding_rule %q not found", name)
+		}
+		return nil
+	case KindFactCheckRule:
+		out := cfg.FactCheckRules[:0]
+		found := false
+		for _, r := range cfg.FactCheckRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.FactCheckRules = out
+		if !found {
+			return fmt.Errorf("fact_check_rule %q not found", name)
+		}
+		return nil
+	case KindUserFeedbackRule:
+		out := cfg.UserFeedbackRules[:0]
+		found := false
+		for _, r := range cfg.UserFeedbackRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.UserFeedbackRules = out
+		if !found {
+			return fmt.Errorf("user_feedback_rule %q not found", name)
+		}
+		return nil
+	case KindPreferenceRule:
+		out := cfg.PreferenceRules[:0]
+		found := false
+		for _, r := range cfg.PreferenceRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.PreferenceRules = out
+		if !found {
+			return fmt.Errorf("preference_rule %q not found", name)
+		}
+		return nil
+	case KindLanguageRule:
+		out := cfg.LanguageRules[:0]
+		found := false
+		for _, r := range cfg.LanguageRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.LanguageRules = out
+		if !found {
+			return fmt.Errorf("language_rule %q not found", name)
+		}
+		return nil
+	case KindContextRule:
+		out := cfg.ContextRules[:0]
+		found := false
+		for _, r := range cfg.ContextRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.ContextRules = out
+		if !found {
+			return fmt.Errorf("context_rule %q not found", name)
+		}
+		return nil
+	case KindLatencyRule:
+		out := cfg.LatencyRules[:0]
+		found := false
+		for _, r := range cfg.LatencyRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.LatencyRules = out
+		if !found {
+			return fmt.Errorf("latency_rule %q not found", name)
+		}
+		return nil
+	case KindComplexityRule:
+		out := cfg.ComplexityRules[:0]
+		found := false
+		for _, r := range cfg.ComplexityRules {
+			if r.Name == name {
+				found = true
+				continue
+			}
+			out = append(out, r)
+		}
+		cfg.ComplexityRules = out
+		if !found {
+			return fmt.Errorf("complexity_rule %q not found", name)
+		}
+		return nil
+	case KindModel:
+		if cfg.ModelConfig == nil {
+			return fmt.Errorf("model_config is nil")
+		}
+		if _, ok := cfg.ModelConfig[name]; !ok {
+			return fmt.Errorf("model %q not found", name)
+		}
+		delete(cfg.ModelConfig, name)
+		return nil
+	default:
+		return fmt.Errorf("unsupported kind %q", kind)
+	}
+}

--- a/src/semantic-router/pkg/mcpserver/mutate.go
+++ b/src/semantic-router/pkg/mcpserver/mutate.go
@@ -1,0 +1,81 @@
+package mcpserver
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// cloneConfig performs a deep copy via YAML round-trip.
+func cloneConfig(in *config.RouterConfig) (*config.RouterConfig, error) {
+	if in == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+	b, err := yaml.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	var out config.RouterConfig
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	dec.KnownFields(true)
+	if err := dec.Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func parseYAMLStrict[T any](yamlStr string) (*T, error) {
+	var out T
+	dec := yaml.NewDecoder(bytes.NewBufferString(yamlStr))
+	dec.KnownFields(true)
+	if err := dec.Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func persistConfig(path string, cfg *config.RouterConfig) error {
+	if path == "" {
+		return nil
+	}
+	b, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+// Supported entity kinds.
+const (
+	KindDecision         = "decision"
+	KindKeywordRule      = "keyword_rule"
+	KindEmbeddingRule    = "embedding_rule"
+	KindFactCheckRule    = "fact_check_rule"
+	KindUserFeedbackRule = "user_feedback_rule"
+	KindPreferenceRule   = "preference_rule"
+	KindLanguageRule     = "language_rule"
+	KindContextRule      = "context_rule"
+	KindLatencyRule      = "latency_rule"
+	KindComplexityRule   = "complexity_rule"
+	KindModel            = "model"
+)
+
+func supportedKinds() []string {
+	return []string{
+		KindDecision,
+		KindKeywordRule,
+		KindEmbeddingRule,
+		KindFactCheckRule,
+		KindUserFeedbackRule,
+		KindPreferenceRule,
+		KindLanguageRule,
+		KindContextRule,
+		KindLatencyRule,
+		KindComplexityRule,
+		KindModel,
+	}
+}

--- a/src/semantic-router/pkg/mcpserver/server.go
+++ b/src/semantic-router/pkg/mcpserver/server.go
@@ -1,0 +1,478 @@
+package mcpserver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"gopkg.in/yaml.v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// DefaultAddr is the default listen address for the internal MCP config server.
+const DefaultAddr = ":8088"
+
+// DefaultPath is the default HTTP base path (best-effort).
+const DefaultPath = "/mcp"
+
+type ConfigProvider interface {
+	Get() *config.RouterConfig
+}
+
+// GlobalConfigProvider returns the process-global router config.
+// It is safe to use when the router config is managed via config.Replace(...).
+type GlobalConfigProvider struct{}
+
+func (p *GlobalConfigProvider) Get() *config.RouterConfig { return config.Get() }
+
+type StaticConfigProvider struct {
+	Cfg *config.RouterConfig
+}
+
+func (p *StaticConfigProvider) Get() *config.RouterConfig { return p.Cfg }
+
+// Server wraps an MCP server instance that exposes config-oriented tools.
+type Server struct {
+	cfgProvider ConfigProvider
+	persistPath string
+
+	mu         sync.Mutex
+	mcpServer  *server.MCPServer
+	httpServer *server.StreamableHTTPServer
+	once       sync.Once
+}
+
+func New(cfgProvider ConfigProvider) *Server {
+	return NewWithPersist(cfgProvider, "")
+}
+
+// NewWithPersist creates an MCP server. If persistPath is non-empty, update/add/delete
+// tools will write the updated full config back to disk.
+func NewWithPersist(cfgProvider ConfigProvider, persistPath string) *Server {
+	m := server.NewMCPServer(
+		"semantic-router-config",
+		"0.2.0",
+		server.WithToolCapabilities(true),
+	)
+
+	s := &Server{cfgProvider: cfgProvider, persistPath: persistPath, mcpServer: m}
+	s.registerTools()
+	return s
+}
+
+func (s *Server) registerTools() {
+	// v0.1 tools (kept for compatibility)
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "get_current_config_yaml",
+		Description: "Return the current Semantic Router config as YAML (read-only).",
+		InputSchema: mcp.ToolInputSchema{Type: "object", Properties: map[string]any{}},
+	}, s.handleGetCurrentConfigYAML)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "validate_config_yaml",
+		Description: "Validate a proposed Semantic Router config YAML. Returns validation errors if any.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"yaml": map[string]any{
+					"type":        "string",
+					"description": "The full router config in YAML form.",
+				},
+			},
+			Required: []string{"yaml"},
+		},
+	}, s.handleValidateConfigYAML)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "list_signal_names",
+		Description: "List configured signal names (keywords, embeddings, fact-check, preference, etc.) from the current config.",
+		InputSchema: mcp.ToolInputSchema{Type: "object", Properties: map[string]any{}},
+	}, s.handleListSignalNames)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "list_decision_names",
+		Description: "List configured decision names from the current config.",
+		InputSchema: mcp.ToolInputSchema{Type: "object", Properties: map[string]any{}},
+	}, s.handleListDecisionNames)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "list_model_names",
+		Description: "List configured provider model names from the current config.",
+		InputSchema: mcp.ToolInputSchema{Type: "object", Properties: map[string]any{}},
+	}, s.handleListModelNames)
+
+	// v0.2 CRUD tools
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "list_kinds",
+		Description: "List supported entity kinds for config CRUD (decision, keyword_rule, model, etc.)",
+		InputSchema: mcp.ToolInputSchema{Type: "object", Properties: map[string]any{}},
+	}, s.handleListKinds)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "list",
+		Description: "List entity names for a given kind.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"kind": map[string]any{"type": "string"},
+			},
+			Required: []string{"kind"},
+		},
+	}, s.handleList)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "get",
+		Description: "Get an entity by kind+name. Returns YAML.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"kind": map[string]any{"type": "string"},
+				"name": map[string]any{"type": "string"},
+			},
+			Required: []string{"kind", "name"},
+		},
+	}, s.handleGet)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "add",
+		Description: "Add an entity. item_yaml is the YAML representation of the entity. For kind=model, item_yaml must be {name: <modelName>, params: <ModelParams>}.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"kind":      map[string]any{"type": "string"},
+				"item_yaml": map[string]any{"type": "string"},
+			},
+			Required: []string{"kind", "item_yaml"},
+		},
+	}, s.handleAdd)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "update",
+		Description: "Update an entity by kind+name. item_yaml is the YAML representation of the entity (name will be forced to match). For kind=model, item_yaml is ModelParams YAML.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"kind":      map[string]any{"type": "string"},
+				"name":      map[string]any{"type": "string"},
+				"item_yaml": map[string]any{"type": "string"},
+			},
+			Required: []string{"kind", "name", "item_yaml"},
+		},
+	}, s.handleUpdate)
+
+	s.mcpServer.AddTool(mcp.Tool{
+		Name:        "delete",
+		Description: "Delete an entity by kind+name.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"kind": map[string]any{"type": "string"},
+				"name": map[string]any{"type": "string"},
+			},
+			Required: []string{"kind", "name"},
+		},
+	}, s.handleDelete)
+}
+
+func (s *Server) handleListKinds(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	b, _ := yaml.Marshal(supportedKinds())
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *Server) handleList(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	kind, err := req.RequireString("kind")
+	if err != nil {
+		return nil, err
+	}
+	cfg := s.cfgProvider.Get()
+	if cfg == nil {
+		return mcp.NewToolResultText("[]"), nil
+	}
+	names, err := listNames(kind, cfg)
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+	b, _ := yaml.Marshal(names)
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *Server) handleGet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	kind, err := req.RequireString("kind")
+	if err != nil {
+		return nil, err
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return nil, err
+	}
+	cfg := s.cfgProvider.Get()
+	if cfg == nil {
+		return mcp.NewToolResultText("error: config is nil"), nil
+	}
+	entity, err := getEntityYAML(kind, name, cfg)
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+	b, _ := yaml.Marshal(entity)
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *Server) handleAdd(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	kind, err := req.RequireString("kind")
+	if err != nil {
+		return nil, err
+	}
+	itemYAML, err := req.RequireString("item_yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur := s.cfgProvider.Get()
+	if cur == nil {
+		return mcp.NewToolResultText("error: config is nil"), nil
+	}
+	newCfg, err := cloneConfig(cur)
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+
+	name, err := addEntity(kind, newCfg, itemYAML)
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+
+	config.Replace(newCfg)
+	if err := persistConfig(s.persistPath, newCfg); err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: persist failed: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("ok: added %s %q", normalizeKind(kind), name)), nil
+}
+
+func (s *Server) handleUpdate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	kind, err := req.RequireString("kind")
+	if err != nil {
+		return nil, err
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return nil, err
+	}
+	itemYAML, err := req.RequireString("item_yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur := s.cfgProvider.Get()
+	if cur == nil {
+		return mcp.NewToolResultText("error: config is nil"), nil
+	}
+	newCfg, err := cloneConfig(cur)
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+
+	if err := updateEntity(kind, name, newCfg, itemYAML); err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+
+	config.Replace(newCfg)
+	if err := persistConfig(s.persistPath, newCfg); err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: persist failed: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("ok: updated %s %q", normalizeKind(kind), name)), nil
+}
+
+func (s *Server) handleDelete(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	kind, err := req.RequireString("kind")
+	if err != nil {
+		return nil, err
+	}
+	name, err := req.RequireString("name")
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur := s.cfgProvider.Get()
+	if cur == nil {
+		return mcp.NewToolResultText("error: config is nil"), nil
+	}
+	newCfg, err := cloneConfig(cur)
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+
+	if err := deleteEntity(kind, name, newCfg); err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: %v", err)), nil
+	}
+
+	config.Replace(newCfg)
+	if err := persistConfig(s.persistPath, newCfg); err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("error: persist failed: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("ok: deleted %s %q", normalizeKind(kind), name)), nil
+}
+
+func (s *Server) handleGetCurrentConfigYAML(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	cfg := s.cfgProvider.Get()
+	if cfg == nil {
+		return mcp.NewToolResultText("config is nil"), nil
+	}
+
+	b, err := yaml.Marshal(cfg)
+	if err != nil {
+		return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{mcp.TextContent{Type: "text", Text: err.Error()}}}, nil
+	}
+
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *Server) handleValidateConfigYAML(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	yamlStr, err := req.RequireString("yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg config.RouterConfig
+	dec := yaml.NewDecoder(bytes.NewBufferString(yamlStr))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf("YAML parse error: %v", err)), nil
+	}
+
+	// Reuse existing validation logic by round-tripping through Parse is hard without a file.
+	// For now: rely on YAML decode + minimal semantic checks.
+	if cfg.DefaultModel == "" && cfg.ModelConfig == nil && len(cfg.VLLMEndpoints) == 0 {
+		return mcp.NewToolResultText("validation warning: config may be incomplete (no default_model/model_config/vllm_endpoints detected)"), nil
+	}
+
+	return mcp.NewToolResultText("ok"), nil
+}
+
+func (s *Server) handleListSignalNames(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	cfg := s.cfgProvider.Get()
+	if cfg == nil {
+		return mcp.NewToolResultText("[]"), nil
+	}
+
+	// Signals are spread across config fields. We do best-effort extraction.
+	names := make([]string, 0, 64)
+	for _, r := range cfg.KeywordRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.EmbeddingRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.FactCheckRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.UserFeedbackRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.PreferenceRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.LanguageRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.ContextRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.LatencyRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+	for _, r := range cfg.ComplexityRules {
+		if r.Name != "" {
+			names = append(names, r.Name)
+		}
+	}
+
+	b, _ := yaml.Marshal(names)
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *Server) handleListDecisionNames(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	cfg := s.cfgProvider.Get()
+	if cfg == nil {
+		return mcp.NewToolResultText("[]"), nil
+	}
+
+	names := make([]string, 0, len(cfg.Decisions))
+	for _, d := range cfg.Decisions {
+		if d.Name != "" {
+			names = append(names, d.Name)
+		}
+	}
+	b, _ := yaml.Marshal(names)
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *Server) handleListModelNames(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	cfg := s.cfgProvider.Get()
+	if cfg == nil {
+		return mcp.NewToolResultText("[]"), nil
+	}
+
+	names := make([]string, 0, len(cfg.ModelConfig))
+	for name := range cfg.ModelConfig {
+		names = append(names, name)
+	}
+	b, _ := yaml.Marshal(names)
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func (s *Server) StartHTTP(addr string, path string) error {
+	if addr == "" {
+		addr = DefaultAddr
+	}
+	if path == "" {
+		path = DefaultPath
+	}
+
+	var err error
+	s.once.Do(func() {
+		s.httpServer = server.NewStreamableHTTPServer(s.mcpServer)
+		_ = path // base path currently not configurable in mcp-go StreamableHTTPServer
+		err = s.httpServer.Start(addr)
+	})
+	return err
+}
+
+func (s *Server) Handler() http.Handler {
+	if s.httpServer == nil {
+		s.httpServer = server.NewStreamableHTTPServer(s.mcpServer)
+	}
+	return s.httpServer
+}

--- a/src/semantic-router/pkg/mcpserver/server_test.go
+++ b/src/semantic-router/pkg/mcpserver/server_test.go
@@ -1,0 +1,53 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestConfigMCPServer_ToolsExistAndWork(t *testing.T) {
+	cfg := &config.RouterConfig{}
+	cfg.KeywordRules = []config.KeywordRule{{Name: "k1", Keywords: []string{"x"}}}
+	cfg.Decisions = []config.Decision{{Name: "d1"}}
+	cfg.ModelConfig = map[string]config.ModelParams{"m1": {}}
+
+	srv := New(&StaticConfigProvider{Cfg: cfg})
+	c, err := client.NewInProcessClient(srv.mcpServer)
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "0"}
+	_, err = c.Initialize(context.Background(), initReq)
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	toolsResp, err := c.ListTools(context.Background(), mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(toolsResp.Tools) == 0 {
+		t.Fatalf("expected tools")
+	}
+
+	call := mcp.CallToolRequest{}
+	call.Params.Name = "list_decision_names"
+	res, err := c.CallTool(context.Background(), call)
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res == nil || len(res.Content) == 0 {
+		t.Fatalf("expected content")
+	}
+}


### PR DESCRIPTION
### What
- Add internal MCP config server (HTTP streamable transport) running in-router
- Expose CRUD tools over MCP: `list_kinds` / `list` / `get` / `add` / `update` / `delete`
- Persist mutations back to the config yaml file used on startup
- Add smoke client (`cmd/mcp-smoke`) and unit tests for `pkg/mcpserver`

### Config
Add to router config yaml:

```yaml
mcp_config_server:
  enabled: true
  addr: ":8088"
  path: "/mcp"
```

### Notes
- `path` is best-effort: current `mcp-go` `StreamableHTTPServer` doesn't expose base-path configuration; we keep the field for future compatibility.
- `SR_SKIP_MODEL_DOWNLOAD=true` can be used to skip HF CLI model download checks for local dev.
