### PR TITLE
[Feat][Router Replay]: Enhance with complexity signal and plugin status display

### DIFF
--- a/dashboard/frontend/src/components/ReplayCharts.tsx
+++ b/dashboard/frontend/src/components/ReplayCharts.tsx
@@ -23,6 +23,7 @@ interface Signal {
   language?: string[]
   latency?: string[]
   context?: string[]
+  complexity?: string[]
 }
 
 interface ReplayRecord {
@@ -141,6 +142,7 @@ const ReplayCharts: React.FC<ReplayChartsProps> = ({ records }) => {
       if (signals.language?.length) counts['language'] = (counts['language'] || 0) + signals.language.length
       if (signals.latency?.length) counts['latency'] = (counts['latency'] || 0) + signals.latency.length
       if (signals.context?.length) counts['context'] = (counts['context'] || 0) + signals.context.length
+      if (signals.complexity?.length) counts['complexity'] = (counts['complexity'] || 0) + signals.complexity.length
     })
     return Object.entries(counts)
       .sort((a, b) => b[1] - a[1])

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -97,6 +97,16 @@ type RequestContext struct {
 	EnhancedHallucinationInfo *EnhancedHallucinationInfo // Detailed NLI info (when use_nli enabled)
 	UnverifiedFactualResponse bool                       // True if fact-check needed but no tools to verify against
 
+	// Jailbreak Detection Results
+	JailbreakDetected   bool    // True if jailbreak was detected
+	JailbreakType       string  // Type of jailbreak detected
+	JailbreakConfidence float32 // Confidence score of jailbreak detection
+
+	// PII Detection Results
+	PIIDetected bool     // True if PII was detected
+	PIIEntities []string // PII entity types detected (e.g., ["EMAIL", "PHONE_NUMBER"])
+	PIIBlocked  bool     // True if request was blocked due to PII policy violation
+
 	// Tracing context
 	TraceContext context.Context // OpenTelemetry trace context for span propagation
 	UpstreamSpan trace.Span      // Span for tracking upstream vLLM request duration

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -295,6 +295,9 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 		}
 	}
 
+	// Update router replay with hallucination detection results if enabled
+	r.updateRouterReplayHallucinationStatus(ctx)
+
 	// Capture replay response payload if enabled
 	r.attachRouterReplayResponse(ctx, finalBody, true)
 

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -135,6 +135,24 @@ func (r *OpenAIRouter) startRouterReplay(
 		modelForRecord = originalModel
 	}
 
+	// Determine plugin status from decision configuration
+	var jailbreakEnabled, piiEnabled, hallucinationEnabled bool
+	if ctx.VSRSelectedDecision != nil {
+		if jailbreakCfg := ctx.VSRSelectedDecision.GetJailbreakConfig(); jailbreakCfg != nil {
+			jailbreakEnabled = jailbreakCfg.Enabled
+		}
+		if piiCfg := ctx.VSRSelectedDecision.GetPIIConfig(); piiCfg != nil {
+			piiEnabled = piiCfg.Enabled
+		}
+		if hallucinationCfg := ctx.VSRSelectedDecision.GetHallucinationConfig(); hallucinationCfg != nil {
+			hallucinationEnabled = hallucinationCfg.Enabled
+		}
+	}
+	guardrailsEnabled := jailbreakEnabled || piiEnabled
+
+	// Determine RAG status from context
+	ragEnabled := ctx.RAGRetrievedContext != ""
+
 	rec := routerreplay.RoutingRecord{
 		RequestID:       ctx.RequestID,
 		Decision:        decisionName,
@@ -154,9 +172,29 @@ func (r *OpenAIRouter) startRouterReplay(
 			Language:     ctx.VSRMatchedLanguage,
 			Latency:      ctx.VSRMatchedLatency,
 			Context:      ctx.VSRMatchedContext,
+			Complexity:   ctx.VSRMatchedComplexity,
 		},
 		Streaming: ctx.ExpectStreamingResponse,
 		FromCache: ctx.VSRCacheHit,
+
+		GuardrailsEnabled: guardrailsEnabled,
+		JailbreakEnabled:  jailbreakEnabled,
+		PIIEnabled:        piiEnabled,
+
+		JailbreakDetected:   ctx.JailbreakDetected,
+		JailbreakType:       ctx.JailbreakType,
+		JailbreakConfidence: ctx.JailbreakConfidence,
+
+		PIIDetected: ctx.PIIDetected,
+		PIIEntities: ctx.PIIEntities,
+		PIIBlocked:  ctx.PIIBlocked,
+
+		RAGEnabled:         ragEnabled,
+		RAGBackend:         ctx.RAGBackend,
+		RAGContextLength:   len(ctx.RAGRetrievedContext),
+		RAGSimilarityScore: ctx.RAGSimilarityScore,
+
+		HallucinationEnabled: hallucinationEnabled,
 	}
 
 	// Attach request body directly; recorder will enforce capture + truncation
@@ -224,5 +262,39 @@ func (r *OpenAIRouter) attachRouterReplayResponse(ctx *RequestContext, responseB
 				routerreplay.LogFields(rec, "router_replay_complete"),
 			)
 		}
+	}
+}
+
+// updateRouterReplayHallucinationStatus updates the hallucination detection results in the replay record.
+func (r *OpenAIRouter) updateRouterReplayHallucinationStatus(ctx *RequestContext) {
+	if ctx == nil || ctx.RouterReplayID == "" {
+		return
+	}
+
+	// Only update if hallucination detection was enabled
+	if ctx.VSRSelectedDecision == nil {
+		return
+	}
+	hallucinationConfig := ctx.VSRSelectedDecision.GetHallucinationConfig()
+	if hallucinationConfig == nil || !hallucinationConfig.Enabled {
+		return
+	}
+
+	recorder := ctx.RouterReplayRecorder
+	if recorder == nil {
+		recorder = r.ReplayRecorder
+	}
+	if recorder == nil {
+		return
+	}
+
+	err := recorder.UpdateHallucinationStatus(
+		ctx.RouterReplayID,
+		ctx.HallucinationDetected,
+		ctx.HallucinationConfidence,
+		ctx.HallucinationSpans,
+	)
+	if err != nil {
+		logging.Errorf("Failed to update router replay hallucination status: %v", err)
 	}
 }

--- a/src/semantic-router/pkg/extproc/req_filter_jailbreak.go
+++ b/src/semantic-router/pkg/extproc/req_filter_jailbreak.go
@@ -70,6 +70,11 @@ func (r *OpenAIRouter) performJailbreaks(ctx *RequestContext, userContent string
 				}
 			}
 
+			// Track jailbreak detection in context for replay recording
+			ctx.JailbreakDetected = true
+			ctx.JailbreakType = jailbreakType
+			ctx.JailbreakConfidence = confidence
+
 			// Keep legacy attributes for backward compatibility
 			tracing.SetSpanAttributes(span,
 				attribute.Bool(tracing.AttrJailbreakDetected, true),

--- a/src/semantic-router/pkg/extproc/req_filter_pii.go
+++ b/src/semantic-router/pkg/extproc/req_filter_pii.go
@@ -27,6 +27,10 @@ func (r *OpenAIRouter) performPIIDetection(ctx *RequestContext, userContent stri
 		return nil
 	}
 
+	// Track PII detection in context for replay recording
+	ctx.PIIDetected = true
+	ctx.PIIEntities = detectedPII
+
 	// Check PII policy
 	return r.checkPIIPolicy(ctx, detectedPII, decisionName)
 }
@@ -121,6 +125,9 @@ func (r *OpenAIRouter) checkPIIPolicy(ctx *RequestContext, detectedPII []string,
 	if allowed {
 		return nil
 	}
+
+	// Track PII blocked in context for replay recording
+	ctx.PIIBlocked = true
 
 	// Decision violates PII policy - return error
 	logging.Warnf("Decision %s violates PII policy, blocking request", decisionName)

--- a/src/semantic-router/pkg/routerreplay/store/memory.go
+++ b/src/semantic-router/pkg/routerreplay/store/memory.go
@@ -143,6 +143,23 @@ func (m *MemoryStore) AttachResponse(ctx context.Context, id string, body string
 	return nil
 }
 
+// UpdateHallucinationStatus updates hallucination detection results for a record.
+func (m *MemoryStore) UpdateHallucinationStatus(ctx context.Context, id string, detected bool, confidence float32, spans []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rec, ok := m.byID[id]
+	if !ok {
+		return fmt.Errorf("record with ID %s not found", id)
+	}
+
+	rec.HallucinationDetected = detected
+	rec.HallucinationConfidence = confidence
+	rec.HallucinationSpans = spans
+
+	return nil
+}
+
 // Close is a no-op for memory storage.
 func (m *MemoryStore) Close() error {
 	return nil

--- a/src/semantic-router/pkg/routerreplay/store/milvus.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus.go
@@ -436,6 +436,23 @@ func (m *MilvusStore) AttachResponse(ctx context.Context, id string, body string
 	return m.upsertRecord(ctx, record)
 }
 
+// UpdateHallucinationStatus updates hallucination detection results for a record.
+func (m *MilvusStore) UpdateHallucinationStatus(ctx context.Context, id string, detected bool, confidence float32, spans []string) error {
+	record, found, err := m.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("record with ID %s not found", id)
+	}
+
+	record.HallucinationDetected = detected
+	record.HallucinationConfidence = confidence
+	record.HallucinationSpans = spans
+
+	return m.upsertRecord(ctx, record)
+}
+
 // upsertRecord updates a record by deleting and reinserting.
 func (m *MilvusStore) upsertRecord(ctx context.Context, record Record) error {
 	// Marshal record

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -16,6 +16,7 @@ type Signal struct {
 	Language     []string `json:"language,omitempty"`
 	Latency      []string `json:"latency,omitempty"`
 	Context      []string `json:"context,omitempty"`
+	Complexity   []string `json:"complexity,omitempty"`
 }
 
 // Record represents a routing decision record with metadata and captured payloads.
@@ -38,6 +39,33 @@ type Record struct {
 	Streaming             bool      `json:"streaming,omitempty"`
 	RequestBodyTruncated  bool      `json:"request_body_truncated,omitempty"`
 	ResponseBodyTruncated bool      `json:"response_body_truncated,omitempty"`
+
+	// Guardrails
+	GuardrailsEnabled bool `json:"guardrails_enabled,omitempty"`
+	JailbreakEnabled  bool `json:"jailbreak_enabled,omitempty"`
+	PIIEnabled        bool `json:"pii_enabled,omitempty"`
+
+	// Jailbreak Detection Results
+	JailbreakDetected   bool    `json:"jailbreak_detected,omitempty"`
+	JailbreakType       string  `json:"jailbreak_type,omitempty"`
+	JailbreakConfidence float32 `json:"jailbreak_confidence,omitempty"`
+
+	// PII Detection Results
+	PIIDetected bool     `json:"pii_detected,omitempty"`
+	PIIEntities []string `json:"pii_entities,omitempty"`
+	PIIBlocked  bool     `json:"pii_blocked,omitempty"`
+
+	// RAG (Retrieval-Augmented Generation)
+	RAGEnabled         bool    `json:"rag_enabled,omitempty"`
+	RAGBackend         string  `json:"rag_backend,omitempty"`
+	RAGContextLength   int     `json:"rag_context_length,omitempty"`
+	RAGSimilarityScore float32 `json:"rag_similarity_score,omitempty"`
+
+	// Hallucination Detection
+	HallucinationEnabled    bool     `json:"hallucination_enabled,omitempty"`
+	HallucinationDetected   bool     `json:"hallucination_detected,omitempty"`
+	HallucinationConfidence float32  `json:"hallucination_confidence,omitempty"`
+	HallucinationSpans      []string `json:"hallucination_spans,omitempty"`
 }
 
 // Storage is the interface that all storage backends must implement.
@@ -59,6 +87,9 @@ type Storage interface {
 
 	// AttachResponse updates the response body for an existing record.
 	AttachResponse(ctx context.Context, id string, body string, truncated bool) error
+
+	// UpdateHallucinationStatus updates hallucination detection results for an existing record.
+	UpdateHallucinationStatus(ctx context.Context, id string, detected bool, confidence float32, spans []string) error
 
 	// Close releases resources held by the storage backend.
 	Close() error


### PR DESCRIPTION
## Summary

This PR enhances the Router Replay visualization page to display comprehensive plugin status and the missing complexity signal, enabling better debugging of routing decisions.

- Add complexity signal capture and display with visual difficulty indicators (hard/easy)
- Add Guardrails status display (Jailbreak detection, PII detection with blocked/found states)
- Add RAG integration details (backend, context length, similarity score)
- Add Hallucination detection results (confidence, unsupported spans)
- Implement `UpdateHallucinationStatus()` across all storage backends

## Features

- **Complexity Signal**: Color-coded badges (red for `:hard`, green for `:easy`)
- **Guardrails Status**: Shows Jailbreak/PII detection with confidence scores
- **RAG Details**: Backend type, context length, and similarity score
- **Hallucination Detection**: Confidence percentage and unsupported spans list

## Changes

### Backend

| File | Description |
|------|-------------|
| `store/store.go` | Added fields for Complexity, Guardrails, RAG, Hallucination |
| `extproc/recorder.go` | Capture plugin statuses from decision config |
| `extproc/processor_req_header.go` | Added context fields for detection results |
| `extproc/req_filter_jailbreak.go` | Track jailbreak detection in context |
| `extproc/req_filter_pii.go` | Track PII detection in context |
| `extproc/processor_res_body.go` | Update hallucination status after response |
| `routerreplay/recorder.go` | Add `UpdateHallucinationStatus()` and enhanced logging |
| `store/{memory,redis,postgres,milvus}.go` | Implement hallucination status updates |

### Frontend

| File | Description |
|------|-------------|
| `ReplayPage.tsx` | Display complexity signals, Guardrails, RAG, Hallucination status |
| `ReplayCharts.tsx` | Include complexity in signal counting |

## Test plan

- [x] Start router with config containing complexity signals
- [x] Send requests that trigger hard/easy complexity classification
- [x] Verify complexity badges appear in Router Replay page
- [x] Send jailbreak attempt, verify detection shown in Guardrails section
- [x] Send PII request, verify PII detection/blocked status shown
- [x] Send request through RAG-enabled decision, verify RAG details shown
- [x] Verify hallucination detection results appear after response