### PR TITLE
[Feat] Increase timeout limits to 1200s for long-running requests

### DIFF
--- a/deploy/amd/config.yaml
+++ b/deploy/amd/config.yaml
@@ -9,7 +9,7 @@ listeners:
   - name: "http-8899"
     address: "0.0.0.0"
     port: 8899
-    timeout: "300s"
+    timeout: "1200s"
 
 # Signals - Classification signals for routing
 signals:

--- a/src/vllm-sr/cli/templates/envoy.template.yaml
+++ b/src/vllm-sr/cli/templates/envoy.template.yaml
@@ -36,8 +36,8 @@ static_resources:
                       exact: "{{ model.name }}"
                 route:
                   cluster: {{ model.cluster_name }}_cluster
-                  timeout: {{ listener.timeout | default('600s') }}
-                  idleTimeout: 600s
+                  timeout: {{ listener.timeout | default('1200s') }}
+                  idleTimeout: 1200s
                   # Rewrite Host header to match upstream server
                   host_rewrite_literal: "{{ model.endpoints[0].address }}"
                   {% if model.path_prefix %}
@@ -59,8 +59,8 @@ static_resources:
                       exact: "{{ model.name }}"
                 route:
                   cluster: anthropic_api_cluster
-                  timeout: {{ listener.timeout | default('600s') }}
-                  idleTimeout: 600s
+                  timeout: {{ listener.timeout | default('1200s') }}
+                  idleTimeout: 1200s
                   host_rewrite_literal: "api.anthropic.com"
               {% endfor %}
               # Default route (no x-selected-model header)
@@ -73,7 +73,7 @@ static_resources:
                   {% else %}
                   cluster: vllm_static_cluster
                   {% endif %}
-                  timeout: {{ listener.timeout | default('600s') }}
+                  timeout: {{ listener.timeout | default('1200s') }}
                   {% if models %}
                   # Rewrite Host header to match upstream server
                   host_rewrite_literal: "{{ models[0].endpoints[0].address }}"
@@ -94,13 +94,13 @@ static_resources:
               grpc_service:
                 envoy_grpc:
                   cluster_name: extproc_service
-                timeout: 600s
+                timeout: 1200s
               processing_mode:
                 request_header_mode: "SEND"
                 response_header_mode: "SEND"
                 request_body_mode: "BUFFERED"
                 response_body_mode: "BUFFERED"
-              message_timeout: {{ listener.timeout | default('600s') }}
+              message_timeout: {{ listener.timeout | default('1200s') }}
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -115,7 +115,7 @@ static_resources:
   clusters:
   # ExtProc service (semantic router)
   - name: extproc_service
-    connect_timeout: 600s
+    connect_timeout: 1200s
     type: STATIC
     lb_policy: ROUND_ROBIN
     http2_protocol_options: {}
@@ -150,7 +150,7 @@ static_resources:
   {% for model in models %}
   # Cluster for model: {{ model.name }}
   - name: {{ model.cluster_name }}_cluster
-    connect_timeout: 600s
+    connect_timeout: 1200s
     type: {{ model.cluster_type }}
     {% if model.cluster_type == 'LOGICAL_DNS' %}
     dns_lookup_family: V4_ONLY
@@ -189,7 +189,7 @@ static_resources:
   - name: anthropic_api_cluster
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
-    connect_timeout: 600s
+    connect_timeout: 1200s
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: anthropic_api_cluster

--- a/src/vllm-sr/cli/templates/router-defaults.yaml
+++ b/src/vllm-sr/cli/templates/router-defaults.yaml
@@ -173,7 +173,7 @@ looper:
   # Endpoint points to Envoy (same container), which handles load balancing and auth
   # Port should match listener port (default: 8888)
   endpoint: "http://localhost:8899/v1/chat/completions"
-  timeout_seconds: 120  # Timeout in seconds for each model call
+  timeout_seconds: 1200  # Timeout in seconds for each model call
   headers: {}  # Optional headers (e.g., {"Authorization": "Bearer xxx"})
 
 clear_route_cache: true


### PR DESCRIPTION
## Description

This PR increases timeout limits across the system from 300s/600s to 1200s to better support long-running model inference requests.

## Changes

- **deploy/amd/config.yaml**: Increase listener timeout from 300s to 1200s
- **src/vllm-sr/cli/templates/envoy.template.yaml**: 
  - Update route timeouts from 600s to 1200s
  - Update idle timeout to 1200s for all routes
  - Increase extproc service timeout and message timeout to 1200s
  - Update cluster connect timeouts to 1200s
- **src/vllm-sr/cli/templates/router-defaults.yaml**: Increase looper timeout from 120s to 1200s

## Motivation

This change allows the system to handle longer-running model inference requests without timing out, improving support for:
- Complex queries requiring extended processing time
- Large context processing
- Models with slower inference speeds
- High-load scenarios where requests may queue longer

## Testing

- [ ] Configuration files validated
- [ ] Timeout behavior tested with long-running requests
- [ ] No regression in normal request handling

---

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

- [x] Make sure the code changes pass the pre-commit checks.
- [x] Sign-off your commit by using <code>-s</code> when doing <code>git commit</code>
- [x] Try to classify PRs for easy understanding of the- [x] Try to classify PRs for easy understandit]`, and `[CI]`.