### PR TITLE
[Feat][CLI]: add Python CLI support for RAG plugin

### DIFF
--- a/src/vllm-sr/cli/templates/config.template.yaml
+++ b/src/vllm-sr/cli/templates/config.template.yaml
@@ -395,6 +395,8 @@ decisions:
           name: "math_keywords"
         - type: "domain"
           name: "math"
+        - type: "fact_check"
+          name: "needs_fact_check"
     modelRefs:
       - model: "openai/gpt-oss-120b"
         use_reasoning: true
@@ -407,6 +409,29 @@ decisions:
         configuration:
           enabled: true
           similarity_threshold: 0.92
+      # RAG Plugin: Retrieval-Augmented Generation
+      # Supports backends: milvus, external_api, openai, mcp, hybrid
+      - type: "rag"
+        configuration:
+          enabled: true
+          backend: "external_api"       # Backend type
+          top_k: 5                      # Number of documents to retrieve
+          similarity_threshold: 0.75   # Min similarity (0.0-1.0)
+          injection_mode: "tool_role"  # How to inject context
+          on_failure: "skip"           # Continue if retrieval fails
+          cache_results: true          # Cache for performance
+          cache_ttl_seconds: 300       # 5 minutes cache
+          backend_config:
+            endpoint: "http://host.docker.internal:8001/search"
+            request_format: "elasticsearch"
+            timeout_seconds: 10
+      # Hallucination Detection: Verify LLM response against RAG context
+      # When RAG uses injection_mode: "tool_role", the retrieved context is
+      # available as tool results for fact-checking the LLM response
+      - type: "hallucination"
+        configuration:
+          enabled: true
+          hallucination_action: "header"
       # Router Replay plugin: Capture routing decisions for debugging
       # Records accessible via /v1/router_replay API endpoint
       - type: "router_replay"
@@ -414,7 +439,7 @@ decisions:
           enabled: true
           max_records: 200              # Maximum records in memory (default: 200)
           capture_request_body: true   # Capture request payloads (default: false)
-          capture_response_body: false  # Capture response payloads (default: false)
+          capture_response_body: true  # Capture response payloads (default: false)
           max_body_bytes: 4096          # Max bytes per body, truncates if exceeded (default: 4096)
 
   - name: "physics_problems"

--- a/src/vllm-sr/cli/validator.py
+++ b/src/vllm-sr/cli/validator.py
@@ -12,6 +12,7 @@ from cli.models import (
     HallucinationPluginConfig,
     RouterReplayPluginConfig,
     MemoryPluginConfig,
+    RAGPluginConfig,
 )
 from pydantic import ValidationError as PydanticValidationError
 from cli.utils import getLogger
@@ -243,6 +244,7 @@ def validate_plugin_configurations(config: UserConfig) -> List[ValidationError]:
         PluginType.HALLUCINATION.value: HallucinationPluginConfig,
         PluginType.ROUTER_REPLAY.value: RouterReplayPluginConfig,
         PluginType.MEMORY.value: MemoryPluginConfig,
+        PluginType.RAG.value: RAGPluginConfig,
     }
 
     for decision in config.decisions:

--- a/src/vllm-sr/tests/test_plugin_parsing.py
+++ b/src/vllm-sr/tests/test_plugin_parsing.py
@@ -9,6 +9,7 @@ from cli.models import (
     PluginConfig,
     PluginType,
     RouterReplayPluginConfig,
+    RAGPluginConfig,
 )
 from cli.parser import parse_user_config
 from cli.validator import validate_user_config
@@ -27,6 +28,7 @@ class TestPluginTypeValidation:
             PluginType.HEADER_MUTATION.value,
             PluginType.HALLUCINATION.value,
             PluginType.ROUTER_REPLAY.value,
+            PluginType.RAG.value,
         ]
 
         for plugin_type in valid_types:
@@ -305,6 +307,243 @@ providers:
             os.unlink(temp_path)
 
 
+class TestRAGPluginConfig:
+    """Test RAG plugin configuration."""
+
+    def test_valid_rag_config_all_fields(self):
+        """Test RAGPluginConfig accepts all valid fields."""
+        config = RAGPluginConfig(
+            enabled=True,
+            backend="external_api",
+            similarity_threshold=0.75,
+            top_k=5,
+            max_context_length=4096,
+            injection_mode="tool_role",
+            backend_config={
+                "endpoint": "http://rag-service:8000/v1/search",
+                "request_format": "openai",
+                "timeout_seconds": 10,
+            },
+            on_failure="skip",
+            cache_results=True,
+            cache_ttl_seconds=300,
+            min_confidence_threshold=0.5,
+        )
+        assert config.enabled is True
+        assert config.backend == "external_api"
+        assert config.similarity_threshold == 0.75
+        assert config.top_k == 5
+        assert config.max_context_length == 4096
+        assert config.injection_mode == "tool_role"
+        assert config.backend_config["endpoint"] == "http://rag-service:8000/v1/search"
+        assert config.backend_config["request_format"] == "openai"
+        assert config.on_failure == "skip"
+        assert config.cache_results is True
+        assert config.cache_ttl_seconds == 300
+        assert config.min_confidence_threshold == 0.5
+
+    def test_rag_config_required_fields_only(self):
+        """Test RAGPluginConfig with only required fields (enabled + backend).
+        All optional fields should default to None.
+        """
+        config = RAGPluginConfig(enabled=True, backend="milvus")
+        assert config.enabled is True
+        assert config.backend == "milvus"
+        assert config.similarity_threshold is None
+        assert config.top_k is None
+        assert config.max_context_length is None
+        assert config.injection_mode is None
+        assert config.backend_config is None
+        assert config.on_failure is None
+        assert config.cache_results is None
+        assert config.cache_ttl_seconds is None
+        assert config.min_confidence_threshold is None
+
+    def test_rag_config_missing_required_fields(self):
+        """Test that missing required fields (enabled, backend) raise errors."""
+        with pytest.raises(PydanticValidationError, match="enabled"):
+            RAGPluginConfig(backend="external_api")
+
+        with pytest.raises(PydanticValidationError, match="backend"):
+            RAGPluginConfig(enabled=True)
+
+    def test_rag_config_field_constraints(self):
+        """Test that Pydantic field constraints reject out-of-range values.
+
+        Covers: similarity_threshold (0.0-1.0), top_k (>=1),
+        max_context_length (>=1), cache_ttl_seconds (>=1),
+        min_confidence_threshold (0.0-1.0).
+        """
+        # similarity_threshold > 1.0
+        with pytest.raises(PydanticValidationError):
+            RAGPluginConfig(enabled=True, backend="milvus", similarity_threshold=1.1)
+
+        # similarity_threshold < 0.0
+        with pytest.raises(PydanticValidationError):
+            RAGPluginConfig(enabled=True, backend="milvus", similarity_threshold=-0.1)
+
+        # top_k must be >= 1
+        with pytest.raises(PydanticValidationError):
+            RAGPluginConfig(enabled=True, backend="milvus", top_k=0)
+
+        # cache_ttl_seconds must be >= 1
+        with pytest.raises(PydanticValidationError):
+            RAGPluginConfig(enabled=True, backend="milvus", cache_ttl_seconds=0)
+
+        # min_confidence_threshold > 1.0
+        with pytest.raises(PydanticValidationError):
+            RAGPluginConfig(
+                enabled=True, backend="milvus", min_confidence_threshold=1.1
+            )
+
+    def test_rag_plugin_in_full_config(self):
+        """Test RAG plugin end-to-end: YAML parsing + validation.
+
+        Verifies that a complete YAML config with a RAG plugin can be
+        parsed into Pydantic models and passes validation without errors.
+        """
+        config_yaml = """
+version: v0.1
+listeners:
+  - name: "http-8888"
+    address: "0.0.0.0"
+    port: 8888
+signals:
+  keywords:
+    - name: "test_keywords"
+      operator: "OR"
+      keywords: ["test"]
+  domains:
+    - name: "test"
+      description: "Test domain"
+decisions:
+  - name: "test_decision"
+    description: "Test decision with RAG"
+    priority: 100
+    rules:
+      operator: "OR"
+      conditions:
+        - type: "keyword"
+          name: "test_keywords"
+    modelRefs:
+      - model: "test_model"
+    plugins:
+      - type: "rag"
+        configuration:
+          enabled: true
+          backend: "external_api"
+          top_k: 5
+          similarity_threshold: 0.75
+          injection_mode: "tool_role"
+          on_failure: "skip"
+          cache_results: true
+          cache_ttl_seconds: 300
+          backend_config:
+            endpoint: "http://rag-service:8000/v1/search"
+            request_format: "openai"
+            timeout_seconds: 10
+providers:
+  models:
+    - name: "test_model"
+      endpoints:
+        - name: "ep1"
+          weight: 1
+          endpoint: "localhost:8000"
+  default_model: "test_model"
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            temp_path = f.name
+
+        try:
+            config = parse_user_config(temp_path)
+            assert len(config.decisions) == 1
+            assert len(config.decisions[0].plugins) == 1
+
+            plugin = config.decisions[0].plugins[0]
+            assert plugin.type.value == "rag"
+            assert plugin.configuration["enabled"] is True
+            assert plugin.configuration["backend"] == "external_api"
+            assert plugin.configuration["top_k"] == 5
+            assert plugin.configuration["similarity_threshold"] == 0.75
+            assert plugin.configuration["injection_mode"] == "tool_role"
+            assert plugin.configuration["on_failure"] == "skip"
+            assert plugin.configuration["cache_results"] is True
+            assert plugin.configuration["cache_ttl_seconds"] == 300
+            assert (
+                plugin.configuration["backend_config"]["endpoint"]
+                == "http://rag-service:8000/v1/search"
+            )
+            assert plugin.configuration["backend_config"]["request_format"] == "openai"
+
+            errors = validate_user_config(config)
+            assert len(errors) == 0, f"Unexpected validation errors: {errors}"
+        finally:
+            os.unlink(temp_path)
+
+    def test_invalid_rag_config_in_full_yaml(self):
+        """Test that invalid RAG configuration is caught by the validator.
+
+        Uses similarity_threshold=1.5 (exceeds 0.0-1.0) and top_k="invalid"
+        (wrong type) to verify the validation pipeline catches bad RAG configs.
+        """
+        config_yaml = """
+version: v0.1
+listeners:
+  - name: "http-8888"
+    address: "0.0.0.0"
+    port: 8888
+signals:
+  keywords:
+    - name: "test_keywords"
+      operator: "OR"
+      keywords: ["test"]
+  domains:
+    - name: "test"
+      description: "Test domain"
+decisions:
+  - name: "test_decision"
+    description: "Test decision with invalid RAG"
+    priority: 100
+    rules:
+      operator: "OR"
+      conditions:
+        - type: "keyword"
+          name: "test_keywords"
+    modelRefs:
+      - model: "test_model"
+    plugins:
+      - type: "rag"
+        configuration:
+          enabled: true
+          backend: "external_api"
+          similarity_threshold: 1.5
+          top_k: "invalid"
+providers:
+  models:
+    - name: "test_model"
+      endpoints:
+        - name: "ep1"
+          weight: 1
+          endpoint: "localhost:8000"
+  default_model: "test_model"
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            temp_path = f.name
+
+        try:
+            config = parse_user_config(temp_path)
+            errors = validate_user_config(config)
+            assert len(errors) > 0
+            error_messages = [str(e) for e in errors]
+            assert any("rag" in msg.lower() for msg in error_messages)
+        finally:
+            os.unlink(temp_path)
+
+
 class TestMultiplePlugins:
     """Test configurations with multiple plugins."""
 
@@ -373,5 +612,108 @@ providers:
 
             errors = validate_user_config(config)
             assert len(errors) == 0
+        finally:
+            os.unlink(temp_path)
+
+    def test_multiple_plugins_with_rag(self):
+        """Test decision with RAG plugin alongside other plugins.
+
+        This validates the real-world use case from config.template.yaml
+        where RAG is used together with system_prompt, semantic-cache,
+        and router_replay in the same decision.
+
+        Reference: src/semantic-router/pkg/extproc/req_filter_rag.go
+        """
+        config_yaml = """
+version: v0.1
+listeners:
+  - name: "http-8888"
+    address: "0.0.0.0"
+    port: 8888
+signals:
+  keywords:
+    - name: "test_keywords"
+      operator: "OR"
+      keywords: ["test"]
+  domains:
+    - name: "test"
+      description: "Test domain"
+decisions:
+  - name: "test_decision"
+    description: "Decision with RAG and other plugins"
+    priority: 100
+    rules:
+      operator: "OR"
+      conditions:
+        - type: "keyword"
+          name: "test_keywords"
+    modelRefs:
+      - model: "test_model"
+    plugins:
+      - type: "system_prompt"
+        configuration:
+          enabled: true
+          system_prompt: "You are a knowledge assistant."
+      - type: "rag"
+        configuration:
+          enabled: true
+          backend: "external_api"
+          top_k: 5
+          similarity_threshold: 0.75
+          injection_mode: "tool_role"
+          on_failure: "skip"
+          cache_results: true
+          cache_ttl_seconds: 300
+          backend_config:
+            endpoint: "http://rag-service:8000/v1/search"
+            request_format: "openai"
+            timeout_seconds: 10
+      - type: "semantic-cache"
+        configuration:
+          enabled: true
+          similarity_threshold: 0.92
+      - type: "router_replay"
+        configuration:
+          enabled: true
+          max_records: 200
+providers:
+  models:
+    - name: "test_model"
+      endpoints:
+        - name: "ep1"
+          weight: 1
+          endpoint: "localhost:8000"
+  default_model: "test_model"
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            temp_path = f.name
+
+        try:
+            config = parse_user_config(temp_path)
+            assert len(config.decisions[0].plugins) == 4
+
+            plugin_types = [p.type.value for p in config.decisions[0].plugins]
+            assert "system_prompt" in plugin_types
+            assert "rag" in plugin_types
+            assert "semantic-cache" in plugin_types
+            assert "router_replay" in plugin_types
+
+            # Verify RAG plugin configuration is correctly parsed
+            rag_plugin = next(
+                p for p in config.decisions[0].plugins if p.type.value == "rag"
+            )
+            assert rag_plugin.configuration["enabled"] is True
+            assert rag_plugin.configuration["backend"] == "external_api"
+            assert rag_plugin.configuration["top_k"] == 5
+            assert (
+                rag_plugin.configuration["backend_config"]["endpoint"]
+                == "http://rag-service:8000/v1/search"
+            )
+
+            # Validate entire config (no errors expected)
+            errors = validate_user_config(config)
+            assert len(errors) == 0, f"Unexpected validation errors: {errors}"
         finally:
             os.unlink(temp_path)

--- a/src/vllm-sr/tests/test_plugin_yaml_generation.py
+++ b/src/vllm-sr/tests/test_plugin_yaml_generation.py
@@ -190,6 +190,107 @@ providers:
         finally:
             os.unlink(temp_path)
 
+    def test_rag_plugin_in_generated_yaml(self):
+        """Test that RAG plugin is correctly serialized in generated YAML."""
+        config_yaml = """
+version: v0.1
+listeners:
+  - name: "http-8888"
+    address: "0.0.0.0"
+    port: 8888
+signals:
+  keywords:
+    - name: "test_keywords"
+      operator: "OR"
+      keywords: ["test"]
+  domains:
+    - name: "test"
+      description: "Test domain"
+decisions:
+  - name: "test_decision"
+    description: "Test decision with RAG"
+    priority: 100
+    rules:
+      operator: "OR"
+      conditions:
+        - type: "keyword"
+          name: "test_keywords"
+    modelRefs:
+      - model: "test_model"
+    plugins:
+      - type: "rag"
+        configuration:
+          enabled: true
+          backend: "external_api"
+          top_k: 5
+          similarity_threshold: 0.75
+          injection_mode: "tool_role"
+          on_failure: "skip"
+          cache_results: true
+          cache_ttl_seconds: 300
+          backend_config:
+            endpoint: "http://rag-service:8000/v1/search"
+            request_format: "openai"
+            timeout_seconds: 10
+providers:
+  models:
+    - name: "test_model"
+      endpoints:
+        - name: "ep1"
+          weight: 1
+          endpoint: "localhost:8000"
+  default_model: "test_model"
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config_yaml)
+            temp_path = f.name
+
+        try:
+            config = parse_user_config(temp_path)
+            defaults = load_embedded_defaults()
+            merged = merge_configs(config, defaults)
+
+            # Check that plugins are in merged config
+            assert "decisions" in merged
+            assert len(merged["decisions"]) > 0
+
+            decision = merged["decisions"][0]
+            assert "plugins" in decision
+            assert len(decision["plugins"]) > 0
+
+            # Find RAG plugin
+            rag_plugin = next(
+                (p for p in decision["plugins"] if p["type"] == "rag"), None
+            )
+            assert rag_plugin is not None, "RAG plugin not found in merged config"
+            assert rag_plugin["configuration"]["enabled"] is True
+            assert rag_plugin["configuration"]["backend"] == "external_api"
+            assert rag_plugin["configuration"]["top_k"] == 5
+            assert rag_plugin["configuration"]["similarity_threshold"] == 0.75
+            assert rag_plugin["configuration"]["injection_mode"] == "tool_role"
+            assert rag_plugin["configuration"]["on_failure"] == "skip"
+            assert rag_plugin["configuration"]["cache_results"] is True
+            assert rag_plugin["configuration"]["cache_ttl_seconds"] == 300
+            assert (
+                rag_plugin["configuration"]["backend_config"]["endpoint"]
+                == "http://rag-service:8000/v1/search"
+            )
+            assert (
+                rag_plugin["configuration"]["backend_config"]["request_format"]
+                == "openai"
+            )
+
+            # Test YAML serialization
+            yaml_output = yaml.dump(merged, default_flow_style=False, sort_keys=False)
+            assert "rag" in yaml_output
+            assert "external_api" in yaml_output
+            assert "top_k: 5" in yaml_output
+            assert "injection_mode: tool_role" in yaml_output
+            assert "cache_results: true" in yaml_output
+        finally:
+            os.unlink(temp_path)
+
     def test_plugin_configuration_preserved(self):
         """Test that all plugin configuration fields are preserved in generated YAML."""
         config_yaml = """


### PR DESCRIPTION

## Summary

This PR enables the Python CLI to recognize and validate `type: "rag"` plugin configurations, closing the last gap between the Go router's 8 supported plugin types and the Python CLI. It also wires a complete RAG → Fact-Check → Hallucination Detection pipeline example in the config template with full test coverage.

## Motivation

The Go router supports 8 plugin types. The Python CLI supported 7 of them but rejected `type: "rag"` with this error:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for UserConfig
decisions.X.plugins.Y.type
  Input should be 'semantic-cache', 'jailbreak', 'pii', 'system_prompt',
  'header_mutation', 'hallucination' or 'router_replay'
```

## Related Issue

Closes #1255

## Files Changed

| File | Description |
|------|-------------|
| `src/vllm-sr/cli/models.py` | Added `RAG = "rag"` to `PluginType` enum and `RAGPluginConfig` Pydantic model with 11 validated fields matching the Go struct |
| `src/vllm-sr/cli/validator.py` | Registered `RAGPluginConfig` in the `config_models` validation mapping |
| `src/vllm-sr/cli/templates/config.template.yaml` | Added RAG + `hallucination` + `fact_check` pipeline example in the `math_problems` decision |
| `src/vllm-sr/tests/test_plugin_parsing.py` | **NEW** - 7 new RAG tests: all fields, required-only, missing required, constraints, full YAML parse, invalid config, multi-plugin |
| `src/vllm-sr/tests/test_plugin_yaml_generation.py` | Added `test_rag_plugin_in_generated_yaml` to verify RAG survives parse -> merge -> serialize |

## RAG + Fact-Check + Hallucination Detection pipeline

The three plugins work together as a verification pipeline on each request:

```
1. Fact-Check signal       ->  2. RAG retrieval          ->  3. Hallucination detection
   Evaluates if the query       Fetches relevant context      Compares LLM response
   needs factual verification   from knowledge base           against retrieved context
   (ctx.FactCheckNeeded)        (ctx.ToolResultsContext)      to detect unsupported claims
```

- **Fact-Check** (`type: "fact_check"` condition in rules): Sets `ctx.FactCheckNeeded = true` when the query matches. This gates both RAG retrieval and hallucination detection.
- **RAG** (`injection_mode: "tool_role"`): Retrieves context and stores it in `ctx.ToolResultsContext`, sets `ctx.HasToolsForFactCheck = true`.
- **Hallucination Detection**: Uses the RAG context as ground truth to verify the LLM response. Only runs when all three conditions are met: `hallucination_enabled`, `FactCheckNeeded`, and `HasToolsForFactCheck`.

**Configuration example** (from `config.template.yaml` — `math_problems` decision):

```yaml
rules:
  operator: "OR"
  conditions:
    - type: "keyword"
      name: "math_keywords"
    - type: "domain"
      name: "math"
    - type: "fact_check"
      name: "needs_fact_check"        # 1. Gates the pipeline
plugins:
  - type: "rag"
    configuration:
      enabled: true
      backend: "external_api"
      top_k: 5
      similarity_threshold: 0.75
      injection_mode: "tool_role"     # 2. Retrieves context
      on_failure: "skip"
      cache_results: true
      cache_ttl_seconds: 300
      backend_config:
        endpoint: "http://host.docker.internal:8001/search"
        request_format: "elasticsearch"
        timeout_seconds: 10
  - type: "hallucination"
    configuration:
      enabled: true
      hallucination_action: "header"  # 3. Verifies response
```

## RAGPluginConfig fields

| Field | Type | Required | Constraint |
|-------|------|----------|------------|
| `enabled` | bool | yes | -- |
| `backend` | str | yes | milvus, external_api, openai, mcp, hybrid |
| `similarity_threshold` | float | no | 0.0--1.0 |
| `top_k` | int | no | >= 1 |
| `max_context_length` | int | no | >= 1 |
| `injection_mode` | str | no | tool_role, system_prompt |
| `backend_config` | dict | no | backend-specific nested config |
| `on_failure` | str | no | skip, block, warn |
| `cache_results` | bool | no | -- |
| `cache_ttl_seconds` | int | no | >= 1 |
| `min_confidence_threshold` | float | no | 0.0--1.0 |

## Test plan

- [x] 20 unit/integration tests pass (`pytest tests/ -v`, 0.33s)
- [x] RAG tests follow the same structure as existing `router_replay` tests
- [x] `vllm-sr validate --config config.template.yaml` passes with `rag: 1, hallucination: 1` recognized
- [x] `vllm-sr init` generates config template with RAG example
- [x] End-to-end test via dashboard replay page