### PR TITLE
feat(memory): use authz framework header for user_id extraction

### DIFF
--- a/e2e/testing/09-memory-features-test.py
+++ b/e2e/testing/09-memory-features-test.py
@@ -313,7 +313,10 @@ class MemoryFeaturesTest(SemanticRouterTestBase):
             response = requests.post(
                 self.responses_url,
                 json=payload,
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "x-authz-user-id": user,
+                },
                 timeout=self.timeout,
             )
 

--- a/src/semantic-router/pkg/extproc/processor_req_body.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body.go
@@ -1075,17 +1075,8 @@ func (r *OpenAIRouter) getMemoryStore() *memory.MilvusStore {
 	return r.MemoryStore
 }
 
-// getUserIDFromContext extracts user ID from Response API context or request.
+// getUserIDFromContext extracts user ID from the trusted auth header (x-authz-user-id).
+// Falls back to untrusted metadata["user_id"] only for development/testing without an auth layer.
 func (r *OpenAIRouter) getUserIDFromContext(ctx *RequestContext) string {
-	// Check Response API context first
-	// userID is provided via metadata.user_id (OpenAI API spec-compliant)
-	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.OriginalRequest != nil {
-		if ctx.ResponseAPICtx.OriginalRequest.Metadata != nil {
-			if userID, ok := ctx.ResponseAPICtx.OriginalRequest.Metadata["user_id"]; ok {
-				return userID
-			}
-		}
-	}
-
-	return ""
+	return extractUserID(ctx)
 }

--- a/src/semantic-router/pkg/extproc/user_id_dev.go
+++ b/src/semantic-router/pkg/extproc/user_id_dev.go
@@ -1,0 +1,38 @@
+//go:build dev
+
+package extproc
+
+import (
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// extractUserID extracts user ID with priority: auth header > metadata fallback.
+//
+// DEV BUILD: This development version includes a fallback to metadata["user_id"].
+// This is UNTRUSTED (client-provided) and should ONLY be used for development/testing.
+//
+// Priority 1: Auth header (x-authz-user-id) injected by the external auth service
+// (Authorino, Envoy Gateway JWT, oauth2-proxy, etc.). This is the trusted source.
+//
+// Priority 2: metadata["user_id"] from the Response API request body.
+// This is untrusted (client-provided) and intended for development/testing only.
+func extractUserID(ctx *RequestContext) string {
+	// Check auth header first (trusted source, injected by auth backend)
+	if userID, ok := ctx.Headers[headers.AuthzUserID]; ok && userID != "" {
+		logging.Debugf("Memory: Using user_id from auth header (%s)", headers.AuthzUserID)
+		return userID
+	}
+
+	// DEV-ONLY: Fallback to metadata["user_id"] (untrusted, for development/testing)
+	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.OriginalRequest != nil {
+		if ctx.ResponseAPICtx.OriginalRequest.Metadata != nil {
+			if userID, ok := ctx.ResponseAPICtx.OriginalRequest.Metadata["user_id"]; ok && userID != "" {
+				logging.Warnf("Memory: Using user_id from request metadata (DEV BUILD - UNTRUSTED fallback)")
+				return userID
+			}
+		}
+	}
+
+	return ""
+}

--- a/src/semantic-router/pkg/extproc/user_id_dev_test.go
+++ b/src/semantic-router/pkg/extproc/user_id_dev_test.go
@@ -1,0 +1,124 @@
+//go:build dev
+
+package extproc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+)
+
+// =============================================================================
+// extractUserID Tests (Dev build only - tests metadata fallback)
+// =============================================================================
+
+func TestExtractUserID_AuthHeaderTakesPrecedence(t *testing.T) {
+	// Auth header (x-authz-user-id) takes precedence over metadata["user_id"]
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.AuthzUserID: "user_from_auth",
+		},
+		ResponseAPICtx: &ResponseAPIContext{
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Metadata: map[string]string{
+					"user_id": "user_from_metadata",
+				},
+			},
+		},
+	}
+
+	result := extractUserID(ctx)
+	assert.Equal(t, "user_from_auth", result, "auth header should take precedence over metadata")
+}
+
+func TestExtractUserID_FallbackToMetadataWhenNoAuthHeader(t *testing.T) {
+	// No auth header, falls back to metadata["user_id"]
+	ctx := &RequestContext{
+		Headers: map[string]string{},
+		ResponseAPICtx: &ResponseAPIContext{
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Metadata: map[string]string{
+					"user_id": "user_from_metadata",
+				},
+			},
+		},
+	}
+
+	result := extractUserID(ctx)
+	assert.Equal(t, "user_from_metadata", result, "should fall back to metadata when auth header absent")
+}
+
+func TestExtractUserID_EmptyAuthHeaderFallsBackToMetadata(t *testing.T) {
+	// Auth header present but empty, falls back to metadata
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.AuthzUserID: "",
+		},
+		ResponseAPICtx: &ResponseAPIContext{
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Metadata: map[string]string{
+					"user_id": "user_from_metadata",
+				},
+			},
+		},
+	}
+
+	result := extractUserID(ctx)
+	assert.Equal(t, "user_from_metadata", result, "empty auth header should fall back to metadata")
+}
+
+// =============================================================================
+// extractMemoryInfo Tests (Dev build only - tests metadata fallback path)
+// =============================================================================
+
+func TestExtractMemoryInfo_FallbackToMetadata(t *testing.T) {
+	// No auth header, falls back to metadata["user_id"] (dev-only behavior)
+	ctx := &RequestContext{
+		RequestID: "req_123",
+		Headers:   map[string]string{},
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv_from_translate",
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Metadata: map[string]string{
+					"user_id": "user_from_metadata",
+				},
+			},
+		},
+	}
+
+	sessionID, userID, history, err := extractMemoryInfo(ctx)
+
+	require.NoError(t, err, "should not return error when falling back to metadata")
+	assert.Equal(t, "conv_from_translate", sessionID)
+	assert.Equal(t, "user_from_metadata", userID, "should fall back to metadata when no auth header")
+	assert.Empty(t, history)
+}
+
+func TestExtractMemoryInfo_UserIDFromMetadataOnly(t *testing.T) {
+	// Tests that metadata["user_id"] works as a source in dev builds
+	ctx := &RequestContext{
+		RequestID: "req_123",
+		Headers:   map[string]string{},
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv_from_translate",
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Metadata: map[string]string{
+					"user_id": "user_from_metadata",
+				},
+			},
+		},
+	}
+
+	sessionID, userID, history, err := extractMemoryInfo(ctx)
+
+	require.NoError(t, err, "should not return error when userID is provided via metadata")
+	assert.Equal(t, "conv_from_translate", sessionID)
+	assert.Equal(t, "user_from_metadata", userID)
+	assert.Empty(t, history)
+}

--- a/src/semantic-router/pkg/extproc/user_id_prod.go
+++ b/src/semantic-router/pkg/extproc/user_id_prod.go
@@ -1,0 +1,27 @@
+//go:build !dev
+
+package extproc
+
+import (
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// extractUserID extracts user ID from the trusted auth header only.
+//
+// PRODUCTION BUILD: This version ONLY uses the auth header (x-authz-user-id)
+// injected by the external auth service. There is NO fallback to metadata["user_id"]
+// to prevent bypassing the authorization gate.
+//
+// The auth header is injected by the external auth service (Authorino, Envoy Gateway JWT,
+// oauth2-proxy, etc.) and is the only trusted source for user identity.
+func extractUserID(ctx *RequestContext) string {
+	// Check auth header (trusted source, injected by auth backend)
+	if userID, ok := ctx.Headers[headers.AuthzUserID]; ok && userID != "" {
+		logging.Debugf("Memory: Using user_id from auth header (%s)", headers.AuthzUserID)
+		return userID
+	}
+
+	// PRODUCTION: No fallback - auth header is the only trusted source
+	return ""
+}

--- a/src/semantic-router/pkg/extproc/user_id_prod_test.go
+++ b/src/semantic-router/pkg/extproc/user_id_prod_test.go
@@ -1,0 +1,52 @@
+//go:build !dev
+
+package extproc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+)
+
+// =============================================================================
+// extractUserID Tests (Production build - no metadata fallback)
+// =============================================================================
+
+func TestExtractUserID_NoFallbackToMetadataInProduction(t *testing.T) {
+	// In production, metadata["user_id"] should be ignored
+	ctx := &RequestContext{
+		Headers: map[string]string{},
+		ResponseAPICtx: &ResponseAPIContext{
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Metadata: map[string]string{
+					"user_id": "user_from_metadata",
+				},
+			},
+		},
+	}
+
+	result := extractUserID(ctx)
+	assert.Empty(t, result, "production build should not fall back to metadata")
+}
+
+func TestExtractUserID_EmptyAuthHeaderNoFallbackInProduction(t *testing.T) {
+	// In production, empty auth header should NOT fall back to metadata
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.AuthzUserID: "",
+		},
+		ResponseAPICtx: &ResponseAPIContext{
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Metadata: map[string]string{
+					"user_id": "user_from_metadata",
+				},
+			},
+		},
+	}
+
+	result := extractUserID(ctx)
+	assert.Empty(t, result, "production build should not fall back to metadata even with empty auth header")
+}

--- a/src/semantic-router/pkg/extproc/user_id_test.go
+++ b/src/semantic-router/pkg/extproc/user_id_test.go
@@ -1,0 +1,48 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+)
+
+// =============================================================================
+// extractUserID Tests (Common to both dev and prod builds)
+// =============================================================================
+
+func TestExtractUserID_AuthHeaderOnly(t *testing.T) {
+	// Auth header present, no metadata
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.AuthzUserID: "user_from_auth",
+		},
+	}
+
+	result := extractUserID(ctx)
+	assert.Equal(t, "user_from_auth", result)
+}
+
+func TestExtractUserID_NoAuthHeaderNoMetadata(t *testing.T) {
+	// Neither auth header nor metadata present
+	ctx := &RequestContext{
+		Headers: map[string]string{},
+	}
+
+	result := extractUserID(ctx)
+	assert.Empty(t, result, "should return empty string when no user ID source available")
+}
+
+func TestExtractUserID_UnrelatedHeaderIgnored(t *testing.T) {
+	// Unrelated headers should not be used as user ID
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			"x-custom-user-id": "user_from_wrong_header",
+			"authorization":    "Bearer token123",
+		},
+	}
+
+	result := extractUserID(ctx)
+	assert.Empty(t, result, "should not use unrelated headers as user ID")
+}

--- a/tools/make/build-run-test.mk
+++ b/tools/make/build-run-test.mk
@@ -9,11 +9,18 @@ build: ## Build the Rust library and Golang binding
 build: $(if $(CI),rust-ci,rust) build-router
 
 # Build router (conditionally use rust-ci in CI environments)
+# Development build: Use DEV=true to enable untrusted metadata["user_id"] fallback for testing
+# Example: make build-router DEV=true
+# Production builds (default) only accept user_id from auth headers (x-authz-user-id)
 build-router: ## Build the router binary
 build-router: $(if $(CI),rust-ci,rust)
 	@$(LOG_TARGET)
 	@mkdir -p bin
-	@cd src/semantic-router && go build --tags=milvus -o ../../bin/router cmd/main.go
+ifdef DEV
+	@cd src/semantic-router && go build -tags=dev,milvus -o ../../bin/router cmd/main.go
+else
+	@cd src/semantic-router && go build -tags=milvus -o ../../bin/router cmd/main.go
+endif
 
 # Run the router
 run-router: ## Run the router with the specified config


### PR DESCRIPTION
Use the standard x-authz-user-id header from the authz framework
(PR #1315) instead of custom per-memory config fields. This prevents
user_id spoofing by trusting only headers injected by the external
auth layer (Authorino, Envoy Gateway JWT, oauth2-proxy, etc.).

Changes:
- Add extractUserID() with priority: auth header > metadata fallback
- Update extractMemoryInfo() and getUserIDFromContext() to use it
- Fallback to metadata["user_id"] for development/testing without
  an auth layer

Tests:
- AuthHeaderTakesPrecedence: auth header wins over metadata
- AuthHeaderOnly: works without metadata present
- FallbackToMetadataWhenNoAuthHeader: dev/testing flexibility
- EmptyAuthHeaderFallsBackToMetadata: empty header handled
- NoAuthHeaderNoMetadata: returns empty string
- UnrelatedHeaderIgnored: only x-authz-user-id is recognized

Resolves #1229