### PR TITLE
feat(memory): add configurable num_partitions for Milvus

### DIFF
--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -815,6 +815,11 @@ type MemoryMilvusConfig struct {
 
 	// Embedding dimension (default: 384 for all-MiniLM-L6-v2)
 	Dimension int `yaml:"dimension,omitempty"`
+
+	// NumPartitions for partition key distribution (default: 16, max: 1024)
+	// Higher values improve per-user query performance at scale.
+	// Recommendation: 64 for <100K users, 256 for 100K-1M users.
+	NumPartitions int `yaml:"num_partitions,omitempty"`
 }
 
 // ResponseAPIConfig configures the Response API for stateful conversations.

--- a/src/vllm-sr/cli/templates/config.template.yaml
+++ b/src/vllm-sr/cli/templates/config.template.yaml
@@ -641,3 +641,22 @@ providers:
 
   # Default reasoning effort level
   default_reasoning_effort: "low"
+
+# Memory - Agentic Memory for cross-session context (requires Milvus)
+memory:
+  enabled: false
+  auto_store: true
+  
+  milvus:
+    address: "localhost:19530"
+    collection: "agentic_memory"
+    dimension: 384  # 384=bert (fast), 1024=qwen3 (quality)
+    # Partitions for user_id routing: 16 (default), 64 (<10K users), 256 (<1M users)
+    num_partitions: 64
+  
+  embedding_model: "bert"  # "bert" (fast) or "qwen3" (quality)
+  similarity_threshold: 0.7
+  
+  # Security: auth header for trusted user_id (optional)
+  # auth_user_id_header: "x-authenticated-user-id"
+  # require_auth_header: false


### PR DESCRIPTION
Add NumPartitions configuration option to control partition key
distribution in Milvus memory storage, improving query performance
scalability.

Changes:
- Add NumPartitions field to MemoryMilvusConfig (default: 16, max: 1024)
- Use configured num_partitions in CreateCollection call
- Add user_id as partition key (IsPartitionKey: true)
- Extend MockMilvusClient to capture schema for testing
- Add TestMilvusStore_Schema_UserIDPartitionKey test
- Add memory config example to config.template.yaml

The partition key enables Milvus to route queries to specific
partitions based on user_id hash, reducing search scope from O(N)
to O(N/partitions) for per-user memory retrieval.


See also: https://milvus.io/docs/use-partition-key.md

Resolves #1290