### PR TITLE
feat(memory): add retention scoring and pruning with MemoryBank formula

### DIFF
--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -967,9 +967,27 @@ type MemoryConfig struct {
 	// Default: 0.6
 	DefaultSimilarityThreshold float32 `yaml:"default_similarity_threshold,omitempty"`
 
+	// QualityScoring configures retention scoring and pruning parameters (MemoryBank-style).
+	// Access tracking (LastAccessed, AccessCount) is always active; pruning runs only when PruneUser is called.
+	QualityScoring MemoryQualityScoringConfig `yaml:"quality_scoring,omitempty"`
+
 	// Note: Query rewriting and fact extraction are enabled by defining
 	// external_models with model_role="memory_rewrite" or "memory_extraction".
 	// Use FindExternalModelByRole() to check if enabled and get config.
+}
+
+// MemoryQualityScoringConfig configures retention scoring and pruning (MemoryBank-style).
+// Access tracking (LastAccessed, AccessCount) is always active when memory is enabled.
+// R = exp(-t_days/S), S = InitialStrengthDays + AccessCount; delete when R < PruneThreshold.
+type MemoryQualityScoringConfig struct {
+	// InitialStrengthDays is S0: initial strength in days (default: 30). Higher = slower decay for new memories.
+	InitialStrengthDays int `yaml:"initial_strength_days,omitempty"`
+
+	// PruneThreshold is delta: delete memories with R < PruneThreshold (default: 0.1).
+	PruneThreshold float64 `yaml:"prune_threshold,omitempty"`
+
+	// MaxMemoriesPerUser caps memories per user; if over, lowest-R memories are deleted first (0 = no cap).
+	MaxMemoriesPerUser int `yaml:"max_memories_per_user,omitempty"`
 }
 
 // MemoryMilvusConfig contains Milvus-specific configuration for memory storage.

--- a/src/semantic-router/pkg/memory/score.go
+++ b/src/semantic-router/pkg/memory/score.go
@@ -1,0 +1,80 @@
+package memory
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+const (
+	// DefaultInitialStrengthDays is the fallback S0 when config omits initial_strength_days or sets it to 0.
+	DefaultInitialStrengthDays = 30
+
+	// DefaultPruneThreshold is the fallback delta when config omits prune_threshold or sets it to 0.
+	DefaultPruneThreshold = 0.1
+
+	// MinStrength prevents division by zero when S = S0 + AccessCount somehow reaches 0 or below.
+	MinStrength = 1.0
+)
+
+// RetentionScore computes the MemoryBank-style retention score R = exp(-t_days/S).
+// t_days = (now - lastAccessed) in fractional days; S = initialStrengthDays + accessCount.
+// Higher R means the memory is "stronger" (keep); lower R means prune when R < threshold.
+func RetentionScore(lastAccessed time.Time, accessCount int, initialStrengthDays int, now time.Time) float64 {
+	if initialStrengthDays <= 0 {
+		initialStrengthDays = DefaultInitialStrengthDays
+	}
+	tDays := now.Sub(lastAccessed).Hours() / 24
+	if tDays < 0 {
+		tDays = 0
+	}
+	S := float64(initialStrengthDays) + float64(accessCount)
+	if S <= 0 {
+		S = MinStrength
+	}
+	return math.Exp(-tDays / S)
+}
+
+// PruneCandidates returns IDs to delete: entries with R < delta, then lowest-R entries
+// until at most maxPerUser remain. initialStrength and delta use the same semantics as
+// RetentionScore and PruneThreshold; maxPerUser 0 means no cap.
+func PruneCandidates(entries []MemoryPruneEntry, now time.Time, initialStrength int, delta float64, maxPerUser int) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	if initialStrength <= 0 {
+		initialStrength = DefaultInitialStrengthDays
+	}
+	if delta <= 0 {
+		delta = DefaultPruneThreshold
+	}
+
+	type scored struct {
+		id string
+		R  float64
+	}
+	scoredList := make([]scored, 0, len(entries))
+	for _, e := range entries {
+		R := RetentionScore(e.LastAccessed, e.AccessCount, initialStrength, now)
+		scoredList = append(scoredList, scored{id: e.ID, R: R})
+	}
+	sort.Slice(scoredList, func(i, j int) bool { return scoredList[i].R < scoredList[j].R })
+
+	var toDelete []string
+	for _, s := range scoredList {
+		if s.R < delta {
+			toDelete = append(toDelete, s.id)
+		}
+	}
+	keepCount := len(scoredList) - len(toDelete)
+	if maxPerUser > 0 && keepCount > maxPerUser {
+		needToDelete := keepCount - maxPerUser
+		for i := 0; i < len(scoredList) && needToDelete > 0; i++ {
+			if scoredList[i].R >= delta {
+				toDelete = append(toDelete, scoredList[i].id)
+				needToDelete--
+			}
+		}
+	}
+	return toDelete
+}

--- a/src/semantic-router/pkg/memory/score_test.go
+++ b/src/semantic-router/pkg/memory/score_test.go
@@ -1,0 +1,131 @@
+package memory
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetentionScore_ZeroTime(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	lastAccessed := now
+	R := RetentionScore(lastAccessed, 0, 30, now)
+	assert.InDelta(t, 1.0, R, 1e-9)
+}
+
+func TestRetentionScore_DefaultS0(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	lastAccessed := now.Add(-15 * 24 * time.Hour)
+	R := RetentionScore(lastAccessed, 0, 0, now)
+	expect := math.Exp(-15.0 / 30.0)
+	assert.InDelta(t, expect, R, 1e-9)
+}
+
+func TestRetentionScore_HalfLife(t *testing.T) {
+	S0 := 30
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	lastAccessed := now.Add(-30 * 24 * time.Hour)
+	R := RetentionScore(lastAccessed, 0, S0, now)
+	assert.InDelta(t, math.Exp(-1), R, 1e-6)
+}
+
+func TestRetentionScore_AccessCountIncreasesStrength(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	lastAccessed := now.Add(-30 * 24 * time.Hour)
+	R0 := RetentionScore(lastAccessed, 0, 30, now)
+	R10 := RetentionScore(lastAccessed, 10, 30, now)
+	R100 := RetentionScore(lastAccessed, 100, 30, now)
+	assert.Less(t, R0, R10)
+	assert.Less(t, R10, R100)
+	assert.InDelta(t, math.Exp(-30.0/40.0), R10, 1e-6)
+}
+
+func TestRetentionScore_NegativeTimeClampedToZero(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	lastAccessed := now.Add(1 * time.Hour)
+	R := RetentionScore(lastAccessed, 0, 30, now)
+	assert.InDelta(t, 1.0, R, 1e-9)
+}
+
+func TestRetentionScore_FractionalDays(t *testing.T) {
+	// 12 hours ago → tDays = 0.5, verifies sub-day precision in the decay formula
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	lastAccessed := now.Add(-12 * time.Hour)
+	R := RetentionScore(lastAccessed, 0, 30, now)
+	assert.InDelta(t, math.Exp(-0.5/30.0), R, 1e-9)
+}
+
+func TestRetentionScore_ZeroStrengthFallback(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	lastAccessed := now.Add(-10 * 24 * time.Hour)
+	R := RetentionScore(lastAccessed, -30, 30, now)
+	assert.InDelta(t, math.Exp(-10), R, 1e-6)
+}
+
+func TestRetentionScore_ZeroValueLastAccessed(t *testing.T) {
+	// Pre-existing memories without last_accessed would have time.Time{} (year 0001).
+	// Without the ListForPrune fallback, this would give R ≈ 0 and cause immediate pruning.
+	// This test documents the raw behavior — ListForPrune guards against this at the Milvus layer.
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	zeroTime := time.Time{}
+	R := RetentionScore(zeroTime, 0, 30, now)
+	// ~740,000 days since year 0001 → R is effectively 0
+	assert.Less(t, R, 1e-100, "Zero-value LastAccessed produces R ≈ 0 (protected by ListForPrune fallback)")
+}
+
+func TestRetentionScore_UsesNamedConstants(t *testing.T) {
+	// Verify the named constants are the expected values
+	assert.Equal(t, 30, DefaultInitialStrengthDays)
+	assert.InDelta(t, 0.1, DefaultPruneThreshold, 1e-9)
+	assert.InDelta(t, 1.0, MinStrength, 1e-9)
+}
+
+func TestPruneCandidates_Empty(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	ids := PruneCandidates(nil, now, 30, 0.1, 0)
+	assert.Empty(t, ids)
+	ids = PruneCandidates([]MemoryPruneEntry{}, now, 30, 0.1, 0)
+	assert.Empty(t, ids)
+}
+
+func TestPruneCandidates_BelowThreshold(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	entries := []MemoryPruneEntry{
+		{ID: "keep", LastAccessed: now.Add(-60 * 24 * time.Hour), AccessCount: 0},
+		{ID: "drop", LastAccessed: now.Add(-100 * 24 * time.Hour), AccessCount: 0},
+	}
+	ids := PruneCandidates(entries, now, 30, 0.1, 0)
+	require.Len(t, ids, 1)
+	assert.Equal(t, "drop", ids[0])
+}
+
+func TestPruneCandidates_MaxMemoriesPerUser(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	entries := []MemoryPruneEntry{
+		{ID: "a", LastAccessed: now.Add(-5 * 24 * time.Hour), AccessCount: 0},
+		{ID: "b", LastAccessed: now.Add(-20 * 24 * time.Hour), AccessCount: 0},
+		{ID: "c", LastAccessed: now.Add(-40 * 24 * time.Hour), AccessCount: 0},
+	}
+	ids := PruneCandidates(entries, now, 30, 0.1, 2)
+	require.Len(t, ids, 1)
+	assert.Equal(t, "c", ids[0])
+}
+
+func TestPruneCandidates_ThresholdAndCap(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	entries := []MemoryPruneEntry{
+		{ID: "drop_weak", LastAccessed: now.Add(-90 * 24 * time.Hour), AccessCount: 0},
+		{ID: "keep1", LastAccessed: now.Add(-1 * 24 * time.Hour), AccessCount: 0},
+		{ID: "keep2", LastAccessed: now.Add(-2 * 24 * time.Hour), AccessCount: 0},
+		{ID: "drop_low_r1", LastAccessed: now.Add(-25 * 24 * time.Hour), AccessCount: 0},
+		{ID: "drop_low_r2", LastAccessed: now.Add(-30 * 24 * time.Hour), AccessCount: 0},
+	}
+	ids := PruneCandidates(entries, now, 30, 0.1, 2)
+	require.Len(t, ids, 3)
+	assert.Contains(t, ids, "drop_weak")
+	assert.Contains(t, ids, "drop_low_r1")
+	assert.Contains(t, ids, "drop_low_r2")
+}

--- a/src/semantic-router/pkg/memory/types.go
+++ b/src/semantic-router/pkg/memory/types.go
@@ -70,8 +70,11 @@ type Memory struct {
 	// UpdatedAt is when the memory was last modified
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 
-	// AccessCount tracks how often this memory is retrieved
+	// AccessCount tracks how often this memory is retrieved (used for retention score S = S0 + AccessCount)
 	AccessCount int `json:"access_count"`
+
+	// LastAccessed is when the memory was last retrieved (used for retention score t and reinforcement)
+	LastAccessed time.Time `json:"last_accessed,omitempty"`
 
 	// Importance is a score for prioritizing memories (0.0 to 1.0)
 	Importance float32 `json:"importance"`

--- a/src/vllm-sr/cli/templates/config.template.yaml
+++ b/src/vllm-sr/cli/templates/config.template.yaml
@@ -727,6 +727,14 @@ memory:
   embedding_model: "bert"  # "bert" (fast) or "qwen3" (quality)
   similarity_threshold: 0.7
   
+  # Quality scoring: MemoryBank-style retention scoring R = exp(-t/S)
+  # Access tracking (LastAccessed, AccessCount) is always active when memory is enabled.
+  # Pruning runs only when PruneUser is called externally.
+  quality_scoring:
+    initial_strength_days: 30   # S0: higher = slower decay for new memories
+    prune_threshold: 0.1        # δ: delete memories with R < threshold
+    max_memories_per_user: 1000 # 0 = no cap
+
   # Security: auth header for trusted user_id (optional)
   # auth_user_id_header: "x-authenticated-user-id"
   # require_auth_header: false


### PR DESCRIPTION

Implement memory quality scoring based on the MemoryBank retention
formula from "MemoryBank: Enhancing Large Language Models with
Long-Term Memory" (Zhong et al., 2024). [https://arxiv.org/pdf/2305.10250](url)

The core formula is:

`  R = exp(-t / S),  where S = S0 + AccessCount
`

- R is the retention score (0–1)
- t is days since last access
- S is memory strength that grows with each retrieval. 

Memories with R < δ (prune threshold) are candidates for deletion.

Changes:

- Add `MemoryQualityScoringConfig` to config with `initial_strength_days`, `prune_threshold`, and `max_memories_per_user` parameters
- Add `LastAccessed` field to `Memory` type for tracking retrieval time
- Implement `RetentionScore` and `PruneCandidates` in `pkg/memory/score.go` with named constants  (`DefaultInitialStrengthDays=30`, `DefaultPruneThreshold=0.1`, `MinStrength=1.0`)
- Add background access tracking via `recordRetrievalBatch` goroutine in `Retrieve` to avoid latency impact on the retrieval path
- Refactor `Update` from `Delete`+`Insert` to atomic `Upsert`, reducing Milvus operations and eliminating data loss window
- Expand `Get` to return embedding vector for `Upsert` integrity
- Add `ListForPrune` and `PruneUser` with zero-value `LastAccessed` guard that falls back to `created_at` for pre-existing memories (prevents accidental mass deletion on first `PruneUser` call)
- Add `upsert` helper method for building Milvus columns with `last_accessed` and `access_count` in metadata JSON
- Add 13 unit tests for scoring and pruning logic in `pkg/memory/score_test.go`
- Add 4 E2E integration tests (`AccessTrackingTest`) with direct Milvus metadata verification via `MilvusVerifier.get_memory_metadata`

Resolves #1291 