### PR TITLE
[Doc] Update stale references to removed download-mmbert-embedding target

### DIFF
--- a/config/config-rag-example.yaml
+++ b/config/config-rag-example.yaml
@@ -13,7 +13,7 @@ bert_model:
   use_cpu: true
 
 # Embedding models — mmBERT 2D Matryoshka for high-quality multilingual embeddings
-# Download with: make download-mmbert-embedding
+# Model downloads automatically on router startup, or run: make download-models
 embedding_models:
   mmbert_model_path: "models/mom-embedding-ultra"
   use_cpu: true

--- a/config/intelligent-routing/in-tree/embedding-mmbert.yaml
+++ b/config/intelligent-routing/in-tree/embedding-mmbert.yaml
@@ -3,7 +3,7 @@
 # - Layer early exit: 3/6/11/22 layers (speedup: 7x/3.6x/2x/1x)
 # - Dimension reduction: 64/128/256/512/768
 #
-# Download model: make download-mmbert-embedding
+# Model downloads automatically on router startup, or run: make download-models
 # Run: make run-router CONFIG_FILE=config/intelligent-routing/in-tree/embedding-mmbert.yaml
 
 semantic_cache:

--- a/deploy/operator/config/samples/vllm.ai_v1alpha1_semanticrouter_mmbert.yaml
+++ b/deploy/operator/config/samples/vllm.ai_v1alpha1_semanticrouter_mmbert.yaml
@@ -38,7 +38,7 @@ spec:
   config:
     # Embedding models configuration with mmBERT 2D Matryoshka
     embedding_models:
-      # Path to mmBERT model (download using: make download-mmbert-embedding)
+      # Path to mmBERT model (downloads automatically on startup, or run: make download-models)
       mmbert_model_path: "models/mmbert-embedding"
       use_cpu: true
 


### PR DESCRIPTION
## Summary

Update 3 config file comments that reference the removed `make download-mmbert-embedding` target (#1278) to point to the router's built-in downloader.

## Changes

Comments only — no code changes.

| File | Before | After |
|------|--------|-------|
| `config/config-rag-example.yaml` | `# Download with: make download-mmbert-embedding` | `# Model downloads automatically on router startup, or run: make download-models` |
| `config/intelligent-routing/in-tree/embedding-mmbert.yaml` | `# Download model: make download-mmbert-embedding` | same |
| `deploy/operator/config/samples/...mmbert.yaml` | `# (download using: make download-mmbert-embedding)` | `# (downloads automatically on startup, or run: make download-models)` |

FIX #1324