### PR TITLE
feat(selection): CLI support and E2E tests for model selection

### DIFF
--- a/e2e/testcases/core_selection.go
+++ b/e2e/testcases/core_selection.go
@@ -1,0 +1,1070 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testcases contains E2E tests for all 8 model selection algorithms.
+// Core Algorithms:
+//   - Static selection (baseline)
+//   - Elo rating-based selection
+//   - RouterDC embedding similarity
+//   - AutoMix cost-quality optimization
+//   - Hybrid multi-signal combination
+//
+// RL-driven Algorithms:
+//   - Thompson Sampling exploration-exploitation
+//   - GMTRouter graph neural network routing
+//   - Router-R1 LLM-as-router with reasoning
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	// Test 1: Static selection (baseline)
+	pkgtestcases.Register("core-selection-static", pkgtestcases.TestCase{
+		Description: "Verify static selection uses first configured model (baseline)",
+		Tags:        []string{"selection", "static", "core", "model-selection"},
+		Fn:          testStaticSelection,
+	})
+
+	// Test 2: Elo rating-based selection
+	pkgtestcases.Register("core-selection-elo", pkgtestcases.TestCase{
+		Description: "Verify Elo selection changes based on pairwise feedback",
+		Tags:        []string{"selection", "elo", "core", "feedback", "model-selection"},
+		Fn:          testEloSelection,
+	})
+
+	// Test 3: Elo feedback API
+	pkgtestcases.Register("core-selection-elo-feedback", pkgtestcases.TestCase{
+		Description: "Verify Elo feedback API updates model ratings correctly",
+		Tags:        []string{"selection", "elo", "feedback", "api", "model-selection"},
+		Fn:          testEloFeedback,
+	})
+
+	// Test 4: RouterDC embedding-based selection
+	pkgtestcases.Register("core-selection-routerdc", pkgtestcases.TestCase{
+		Description: "Verify RouterDC matches queries to models via embedding similarity",
+		Tags:        []string{"selection", "router_dc", "embedding", "core", "model-selection"},
+		Fn:          testRouterDCSelection,
+	})
+
+	// Test 5: AutoMix cost-quality optimization
+	pkgtestcases.Register("core-selection-automix", pkgtestcases.TestCase{
+		Description: "Verify AutoMix routes based on cost-quality tradeoff",
+		Tags:        []string{"selection", "automix", "pomdp", "core", "model-selection"},
+		Fn:          testAutoMixSelection,
+	})
+
+	// Test 6: Hybrid multi-signal selection
+	pkgtestcases.Register("core-selection-hybrid", pkgtestcases.TestCase{
+		Description: "Verify Hybrid selection combines multiple signals with weights",
+		Tags:        []string{"selection", "hybrid", "core", "model-selection"},
+		Fn:          testHybridSelection,
+	})
+
+	// Test 7: Thompson Sampling exploration-exploitation
+	pkgtestcases.Register("core-selection-thompson", pkgtestcases.TestCase{
+		Description: "Verify Thompson Sampling balances exploration vs exploitation",
+		Tags:        []string{"selection", "thompson", "bayesian", "rl", "model-selection"},
+		Fn:          testThompsonSamplingSelection,
+	})
+
+	// Test 8: GMTRouter graph-based routing
+	pkgtestcases.Register("core-selection-gmtrouter", pkgtestcases.TestCase{
+		Description: "Verify GMTRouter uses graph neural network for personalized routing",
+		Tags:        []string{"selection", "gmtrouter", "gnn", "rl", "model-selection"},
+		Fn:          testGMTRouterSelection,
+	})
+
+	// Test 9: Router-R1 LLM-as-router
+	pkgtestcases.Register("core-selection-router-r1", pkgtestcases.TestCase{
+		Description: "Verify Router-R1 uses LLM reasoning to select models",
+		Tags:        []string{"selection", "router_r1", "llm", "rl", "model-selection"},
+		Fn:          testRouterR1Selection,
+	})
+}
+
+// CoreSelectionTestCase represents a test case for core selection algorithms
+type CoreSelectionTestCase struct {
+	Query          string   `json:"query"`
+	Algorithm      string   `json:"algorithm"`
+	ExpectedModels []string `json:"expected_models"`
+	Description    string   `json:"description"`
+}
+
+// CoreChatRequest represents an OpenAI-compatible chat request for selection tests
+type CoreChatRequest struct {
+	Model    string            `json:"model,omitempty"`
+	Messages []CoreChatMessage `json:"messages"`
+	User     string            `json:"user,omitempty"`
+}
+
+// CoreChatMessage represents a single chat message
+type CoreChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// CoreChatResponse represents the chat completion response
+type CoreChatResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Message CoreChatMessage `json:"message"`
+	} `json:"choices"`
+	// SelectedModel is populated from x-vsr-selected-model response header
+	// This is more reliable than the JSON body's model field for VSR routing info
+	SelectedModel string `json:"-"`
+}
+
+// CoreFeedbackRequest represents the feedback API request format
+type CoreFeedbackRequest struct {
+	WinnerModel  string  `json:"winner_model"`
+	LoserModel   string  `json:"loser_model,omitempty"`
+	Category     string  `json:"category,omitempty"`
+	UserID       string  `json:"user_id,omitempty"`
+	SessionID    string  `json:"session_id,omitempty"`
+	FeedbackType string  `json:"feedback_type,omitempty"`
+	Confidence   float64 `json:"confidence,omitempty"`
+	Tie          bool    `json:"tie,omitempty"`
+}
+
+// CoreFeedbackResponse represents the feedback API response
+type CoreFeedbackResponse struct {
+	Success      bool    `json:"success"`
+	WinnerRating float64 `json:"winner_rating,omitempty"`
+	LoserRating  float64 `json:"loser_rating,omitempty"`
+	Message      string  `json:"message,omitempty"`
+}
+
+// CoreRatingsResponse represents the ratings API response
+type CoreRatingsResponse struct {
+	Category string            `json:"category"`
+	Ratings  []CoreModelRating `json:"ratings"`
+}
+
+// CoreModelRating represents a model's rating
+type CoreModelRating struct {
+	Model  string  `json:"model"`
+	Rating float64 `json:"rating"`
+	Wins   int     `json:"wins"`
+	Losses int     `json:"losses"`
+}
+
+// testStaticSelection verifies that static selection uses the first configured model
+func testStaticSelection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing static model selection...")
+	}
+
+	// Static selection should consistently pick the same model
+	testCases := []CoreSelectionTestCase{
+		{
+			Query:       "What is machine learning?",
+			Algorithm:   "static",
+			Description: "Basic ML question - should use first model",
+		},
+		{
+			Query:       "Explain quantum computing",
+			Algorithm:   "static",
+			Description: "Physics question - should use first model",
+		},
+		{
+			Query:       "Write a Python function",
+			Algorithm:   "static",
+			Description: "Coding question - should use first model",
+		},
+	}
+
+	modelCounts := make(map[string]int)
+	successCount := 0
+
+	for i, tc := range testCases {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: tc.Query},
+			},
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d failed: %v\n", i+1, err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+			successCount++
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] %s: routed to %s\n", tc.Description, resp.SelectedModel)
+		}
+	}
+
+	// Static selection should use the same model for all requests
+	if len(modelCounts) > 1 {
+		return fmt.Errorf("static selection routed to multiple models: %v (expected single model)", modelCounts)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_requests":   len(testCases),
+			"success_requests": successCount,
+			"model_counts":     modelCounts,
+			"algorithm":        "static",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ Static selection consistently used single model: %v\n", modelCounts)
+	}
+
+	return nil
+}
+
+// testEloSelection verifies that Elo selection uses ratings from feedback
+func testEloSelection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	// Setup connection to Envoy Gateway for chat completions
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	// Setup connection to Router API for feedback/ratings endpoints
+	apiPort, stopAPIPort, err := setupRouterAPIConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup router API connection: %w", err)
+	}
+	defer stopAPIPort()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+	apiBaseURL := fmt.Sprintf("http://localhost:%s", apiPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Elo rating-based model selection...")
+		fmt.Printf("[Test] Gateway URL: %s, Router API URL: %s\n", baseURL, apiBaseURL)
+	}
+
+	category := fmt.Sprintf("elo-test-%d", time.Now().UnixNano())
+	winnerModel := "gpt-4"
+	loserModel := "gpt-3.5-turbo"
+
+	// Phase 1: Submit multiple feedback entries to establish clear winner
+	if opts.Verbose {
+		fmt.Printf("[Test] Phase 1: Building Elo ratings for category %s\n", category)
+	}
+
+	feedbackCount := 5
+	for i := 0; i < feedbackCount; i++ {
+		feedback := CoreFeedbackRequest{
+			WinnerModel: winnerModel,
+			LoserModel:  loserModel,
+			Category:    category,
+		}
+		_, err := sendCoreFeedbackRequest(httpClient, apiBaseURL+"/api/v1/feedback", feedback)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Warning: Feedback %d failed: %v\n", i+1, err)
+			}
+		}
+	}
+
+	// Phase 2: Verify ratings were updated
+	ratingsResp, err := getCoreRatings(httpClient, apiBaseURL+"/api/v1/ratings", category)
+	if err != nil {
+		return fmt.Errorf("failed to get ratings: %w", err)
+	}
+
+	var winnerRating, loserRating float64
+	var winnerWins, loserLosses int
+	for _, r := range ratingsResp.Ratings {
+		if r.Model == winnerModel {
+			winnerRating = r.Rating
+			winnerWins = r.Wins
+		} else if r.Model == loserModel {
+			loserRating = r.Rating
+			loserLosses = r.Losses
+		}
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Ratings after feedback: %s rating=%.2f wins=%d, %s rating=%.2f losses=%d\n",
+			winnerModel, winnerRating, winnerWins, loserModel, loserRating, loserLosses)
+	}
+
+	// Phase 3: Send requests and verify selection favors higher-rated model
+	modelCounts := make(map[string]int)
+	numRequests := 10
+
+	for i := 0; i < numRequests; i++ {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: fmt.Sprintf("Test question %d for Elo selection", i+1)},
+			},
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d failed: %v\n", i+1, err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+		}
+	}
+
+	// Assert: Elo selection should favor the higher-rated model (winner)
+	// After positive feedback, winnerModel should be selected more than loserModel
+	winnerCount := modelCounts[winnerModel]
+	loserCount := modelCounts[loserModel]
+	if winnerRating > loserRating && winnerCount < loserCount {
+		return fmt.Errorf("Elo selection did not favor higher-rated model: %s (rating=%.2f, count=%d) vs %s (rating=%.2f, count=%d)",
+			winnerModel, winnerRating, winnerCount, loserModel, loserRating, loserCount)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"category":       category,
+			"feedback_count": feedbackCount,
+			"model_counts":   modelCounts,
+			"winner_rating":  winnerRating,
+			"loser_rating":   loserRating,
+			"algorithm":      "elo",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ Elo selection completed: model distribution=%v (winner favored: %t)\n",
+			modelCounts, winnerCount >= loserCount)
+	}
+
+	return nil
+}
+
+// testEloFeedback verifies the Elo feedback API
+func testEloFeedback(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	// Setup connection to Router API for feedback/ratings endpoints
+	apiPort, stopAPIPort, err := setupRouterAPIConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup router API connection: %w", err)
+	}
+	defer stopAPIPort()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	apiBaseURL := fmt.Sprintf("http://localhost:%s", apiPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Elo feedback API...")
+		fmt.Printf("[Test] Router API URL: %s\n", apiBaseURL)
+	}
+
+	category := fmt.Sprintf("feedback-test-%d", time.Now().UnixNano())
+
+	// Test 1: Submit feedback
+	feedback := CoreFeedbackRequest{
+		WinnerModel: "gpt-4",
+		LoserModel:  "gpt-3.5-turbo",
+		Category:    category,
+	}
+
+	feedbackResp, err := sendCoreFeedbackRequest(httpClient, apiBaseURL+"/api/v1/feedback", feedback)
+	if err != nil {
+		return fmt.Errorf("failed to submit feedback: %w", err)
+	}
+
+	if !feedbackResp.Success {
+		return fmt.Errorf("feedback submission failed: %s", feedbackResp.Message)
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Feedback submitted successfully: %+v\n", feedbackResp)
+	}
+
+	// Test 2: Verify ratings were updated
+	ratingsResp, err := getCoreRatings(httpClient, apiBaseURL+"/api/v1/ratings", category)
+	if err != nil {
+		return fmt.Errorf("failed to get ratings: %w", err)
+	}
+
+	winnerFound := false
+	loserFound := false
+	for _, r := range ratingsResp.Ratings {
+		if r.Model == "gpt-4" && r.Wins > 0 {
+			winnerFound = true
+		}
+		if r.Model == "gpt-3.5-turbo" && r.Losses > 0 {
+			loserFound = true
+		}
+	}
+
+	if !winnerFound || !loserFound {
+		return fmt.Errorf("ratings not updated correctly: winnerFound=%v, loserFound=%v", winnerFound, loserFound)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"category":      category,
+			"winner_found":  winnerFound,
+			"loser_found":   loserFound,
+			"ratings_count": len(ratingsResp.Ratings),
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Println("[Test] ✓ Elo feedback API working correctly")
+	}
+
+	return nil
+}
+
+// testRouterDCSelection verifies embedding-based query-to-model matching
+func testRouterDCSelection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing RouterDC embedding-based selection...")
+	}
+
+	// RouterDC should match queries to models based on description similarity
+	testCases := []CoreSelectionTestCase{
+		{
+			Query:       "Write a complex algorithm in Python with recursion and dynamic programming",
+			Algorithm:   "router_dc",
+			Description: "Coding query - should match coding-capable model",
+		},
+		{
+			Query:       "Explain the theory of relativity in simple terms for a beginner",
+			Algorithm:   "router_dc",
+			Description: "Explanation query - should match explanation-capable model",
+		},
+		{
+			Query:       "Translate this text to French: Hello, how are you?",
+			Algorithm:   "router_dc",
+			Description: "Translation query - should match translation-capable model",
+		},
+	}
+
+	modelCounts := make(map[string]int)
+	successCount := 0
+
+	for i, tc := range testCases {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: tc.Query},
+			},
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d failed: %v\n", i+1, err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+			successCount++
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] %s: routed to %s\n", tc.Description, resp.SelectedModel)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_requests":   len(testCases),
+			"success_requests": successCount,
+			"model_counts":     modelCounts,
+			"algorithm":        "router_dc",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ RouterDC selection completed: %d/%d requests succeeded\n", successCount, len(testCases))
+	}
+
+	return nil
+}
+
+// testAutoMixSelection verifies POMDP-based cost-quality optimization
+func testAutoMixSelection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing AutoMix cost-quality optimization...")
+	}
+
+	// AutoMix should route simple queries to cheaper models, complex to expensive
+	testCases := []CoreSelectionTestCase{
+		{
+			Query:       "What is 2+2?",
+			Algorithm:   "automix",
+			Description: "Simple math - should use cost-effective model",
+		},
+		{
+			Query:       "Derive the Schwarzschild metric from Einstein's field equations step by step",
+			Algorithm:   "automix",
+			Description: "Complex physics - may escalate to better model",
+		},
+		{
+			Query:       "What is the capital of France?",
+			Algorithm:   "automix",
+			Description: "Simple factual - should use cost-effective model",
+		},
+		{
+			Query:       "Prove the Riemann hypothesis with formal mathematical rigor",
+			Algorithm:   "automix",
+			Description: "Extremely complex - should use best model",
+		},
+	}
+
+	modelCounts := make(map[string]int)
+	queryComplexity := make(map[string]string) // model -> complexity level
+
+	for i, tc := range testCases {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: tc.Query},
+			},
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d failed: %v\n", i+1, err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+			queryComplexity[tc.Description] = resp.SelectedModel
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] %s: routed to %s\n", tc.Description, resp.SelectedModel)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_requests":   len(testCases),
+			"model_counts":     modelCounts,
+			"query_complexity": queryComplexity,
+			"algorithm":        "automix",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ AutoMix selection completed: model distribution=%v\n", modelCounts)
+	}
+
+	return nil
+}
+
+// testHybridSelection verifies multi-signal weighted combination
+func testHybridSelection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	// Setup connection to Envoy Gateway for chat completions
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	// Setup connection to Router API for feedback/ratings endpoints
+	apiPort, stopAPIPort, err := setupRouterAPIConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup router API connection: %w", err)
+	}
+	defer stopAPIPort()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+	apiBaseURL := fmt.Sprintf("http://localhost:%s", apiPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Hybrid multi-signal selection...")
+	}
+
+	// First, submit some feedback to influence Elo component (via Router API)
+	category := fmt.Sprintf("hybrid-test-%d", time.Now().UnixNano())
+	for i := 0; i < 3; i++ {
+		feedback := CoreFeedbackRequest{
+			WinnerModel: "gpt-4",
+			LoserModel:  "gpt-3.5-turbo",
+			Category:    category,
+		}
+		_, _ = sendCoreFeedbackRequest(httpClient, apiBaseURL+"/api/v1/feedback", feedback)
+	}
+
+	// Hybrid combines Elo + RouterDC + AutoMix + Cost with configurable weights
+	testCases := []CoreSelectionTestCase{
+		{
+			Query:       "Explain machine learning concepts for a technical audience",
+			Algorithm:   "hybrid",
+			Description: "Technical explanation - hybrid considers multiple signals",
+		},
+		{
+			Query:       "Write optimized code for sorting a large dataset",
+			Algorithm:   "hybrid",
+			Description: "Coding task - hybrid considers capability and cost",
+		},
+		{
+			Query:       "Summarize the key points of quantum mechanics",
+			Algorithm:   "hybrid",
+			Description: "Summary task - hybrid balances quality and efficiency",
+		},
+	}
+
+	modelCounts := make(map[string]int)
+	successCount := 0
+
+	for i, tc := range testCases {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: tc.Query},
+			},
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d failed: %v\n", i+1, err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+			successCount++
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] %s: routed to %s\n", tc.Description, resp.SelectedModel)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_requests":   len(testCases),
+			"success_requests": successCount,
+			"model_counts":     modelCounts,
+			"algorithm":        "hybrid",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ Hybrid selection completed: %d/%d requests succeeded\n", successCount, len(testCases))
+	}
+
+	return nil
+}
+
+// testThompsonSamplingSelection verifies Bayesian exploration-exploitation
+func testThompsonSamplingSelection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Thompson Sampling exploration-exploitation...")
+	}
+
+	// Thompson Sampling should explore initially, then exploit best models
+	// As it collects more data, it should converge to better models
+	testCases := []CoreSelectionTestCase{
+		{
+			Query:       "What is the meaning of life?",
+			Algorithm:   "thompson",
+			Description: "Philosophical query - exploration phase",
+		},
+		{
+			Query:       "Calculate the derivative of x^2 + 3x",
+			Algorithm:   "thompson",
+			Description: "Math query - may explore or exploit",
+		},
+		{
+			Query:       "Write a haiku about programming",
+			Algorithm:   "thompson",
+			Description: "Creative query - tests creative model selection",
+		},
+	}
+
+	modelCounts := make(map[string]int)
+	successCount := 0
+
+	for i, tc := range testCases {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: tc.Query},
+			},
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d failed: %v\n", i+1, err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+			successCount++
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] %s: routed to %s\n", tc.Description, resp.SelectedModel)
+		}
+	}
+
+	// Thompson Sampling should show some variation in model selection (exploration)
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_requests":   len(testCases),
+			"success_requests": successCount,
+			"model_counts":     modelCounts,
+			"algorithm":        "thompson",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ Thompson Sampling completed: %d/%d requests, distribution=%v\n",
+			successCount, len(testCases), modelCounts)
+	}
+
+	return nil
+}
+
+// testGMTRouterSelection verifies graph neural network based routing
+func testGMTRouterSelection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing GMTRouter graph neural network routing...")
+	}
+
+	// GMTRouter uses user preference graphs for personalized routing
+	// Different users should potentially get different model selections
+	testCases := []CoreSelectionTestCase{
+		{
+			Query:       "Recommend a book about artificial intelligence",
+			Algorithm:   "gmtrouter",
+			Description: "Recommendation query - tests preference learning",
+		},
+		{
+			Query:       "What's the best programming language for beginners?",
+			Algorithm:   "gmtrouter",
+			Description: "Opinion query - tests personalization",
+		},
+		{
+			Query:       "Explain neural networks in simple terms",
+			Algorithm:   "gmtrouter",
+			Description: "Technical explanation - tests routing based on user history",
+		},
+	}
+
+	modelCounts := make(map[string]int)
+	successCount := 0
+
+	// Test with different user IDs to verify personalization
+	userIDs := []string{"user-alpha", "user-beta", "user-gamma"}
+
+	for i, tc := range testCases {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: tc.Query},
+			},
+			User: userIDs[i%len(userIDs)], // Rotate through users
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d (user=%s) failed: %v\n", i+1, userIDs[i%len(userIDs)], err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+			successCount++
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] %s (user=%s): routed to %s\n", tc.Description, userIDs[i%len(userIDs)], resp.SelectedModel)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_requests":   len(testCases),
+			"success_requests": successCount,
+			"model_counts":     modelCounts,
+			"user_ids_tested":  userIDs,
+			"algorithm":        "gmtrouter",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ GMTRouter completed: %d/%d requests, distribution=%v\n",
+			successCount, len(testCases), modelCounts)
+	}
+
+	return nil
+}
+
+// testRouterR1Selection verifies LLM-as-router with reasoning
+func testRouterR1Selection(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPF, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup service connection: %w", err)
+	}
+	defer stopPF()
+
+	httpClient := &http.Client{Timeout: 120 * time.Second} // Longer timeout for LLM reasoning
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Router-R1 LLM-as-router with reasoning...")
+	}
+
+	// Router-R1 uses an LLM to reason about which model to select
+	// It should consider query complexity, required capabilities, and model strengths
+	testCases := []CoreSelectionTestCase{
+		{
+			Query:       "Solve this step by step: A train leaves station A at 9:00 AM traveling at 60 mph...",
+			Algorithm:   "router_r1",
+			Description: "Multi-step reasoning - should select reasoning-capable model",
+		},
+		{
+			Query:       "Translate 'Hello World' to Japanese, Chinese, and Korean",
+			Algorithm:   "router_r1",
+			Description: "Multilingual query - should select multilingual model",
+		},
+		{
+			Query:       "Debug this Python code: for i in range(10) print(i)",
+			Algorithm:   "router_r1",
+			Description: "Code debugging - should select coding-capable model",
+		},
+	}
+
+	modelCounts := make(map[string]int)
+	successCount := 0
+
+	for i, tc := range testCases {
+		req := CoreChatRequest{
+			Messages: []CoreChatMessage{
+				{Role: "user", Content: tc.Query},
+			},
+		}
+
+		resp, err := sendCoreChatRequest(httpClient, baseURL+"/v1/chat/completions", req)
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Request %d failed: %v\n", i+1, err)
+			}
+			continue
+		}
+
+		if resp.SelectedModel != "" {
+			modelCounts[resp.SelectedModel]++
+			successCount++
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] %s: routed to %s\n", tc.Description, resp.SelectedModel)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_requests":   len(testCases),
+			"success_requests": successCount,
+			"model_counts":     modelCounts,
+			"algorithm":        "router_r1",
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] ✓ Router-R1 completed: %d/%d requests, distribution=%v\n",
+			successCount, len(testCases), modelCounts)
+	}
+
+	return nil
+}
+
+// Helper functions
+
+// sendCoreChatRequest sends a chat completion request and returns the response
+func sendCoreChatRequest(client *http.Client, url string, req CoreChatRequest) (*CoreChatResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp CoreChatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Populate SelectedModel from x-vsr-selected-model header (preferred source)
+	chatResp.SelectedModel = resp.Header.Get("x-vsr-selected-model")
+	// Fallback to JSON body model if header not present
+	if chatResp.SelectedModel == "" {
+		chatResp.SelectedModel = chatResp.Model
+	}
+
+	return &chatResp, nil
+}
+
+// sendCoreFeedbackRequest sends a feedback request and returns the response
+func sendCoreFeedbackRequest(client *http.Client, url string, req CoreFeedbackRequest) (*CoreFeedbackResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var feedbackResp CoreFeedbackResponse
+	if err := json.Unmarshal(respBody, &feedbackResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &feedbackResp, nil
+}
+
+// getCoreRatings retrieves ratings for a category
+func getCoreRatings(client *http.Client, baseURL, category string) (*CoreRatingsResponse, error) {
+	url := fmt.Sprintf("%s?category=%s", baseURL, category)
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var ratingsResp CoreRatingsResponse
+	if err := json.Unmarshal(respBody, &ratingsResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &ratingsResp, nil
+}

--- a/e2e/testcases/testdata/core_selection_cases.json
+++ b/e2e/testcases/testdata/core_selection_cases.json
@@ -1,0 +1,72 @@
+{
+  "description": "Test cases for all 8 model selection algorithms",
+  "algorithms": ["static", "elo", "router_dc", "automix", "hybrid", "thompson", "gmtrouter", "router_r1"],
+  "test_cases": [
+    {
+      "name": "static_basic",
+      "algorithm": "static",
+      "query": "What is machine learning?",
+      "expected_behavior": "Use first configured model",
+      "expected_models": ["gpt-4", "gpt-3.5-turbo"]
+    },
+    {
+      "name": "elo_after_feedback",
+      "algorithm": "elo",
+      "query": "Explain quantum computing",
+      "expected_behavior": "Prefer higher-rated model after feedback",
+      "feedback_before": [
+        {"winner_model": "gpt-4", "loser_model": "gpt-3.5-turbo", "category": "general"}
+      ],
+      "expected_models": ["gpt-4"]
+    },
+    {
+      "name": "router_dc_coding",
+      "algorithm": "router_dc",
+      "query": "Write a Python function to sort a list",
+      "expected_behavior": "Match to model with coding capability description",
+      "expected_models": ["gpt-4", "claude-3-opus"]
+    },
+    {
+      "name": "automix_simple",
+      "algorithm": "automix",
+      "query": "What is 2+2?",
+      "expected_behavior": "Use cost-effective model for simple query",
+      "expected_models": ["gpt-3.5-turbo", "gpt-4"]
+    },
+    {
+      "name": "automix_complex",
+      "algorithm": "automix",
+      "query": "Derive the Navier-Stokes equations from first principles",
+      "expected_behavior": "May escalate to more capable model",
+      "expected_models": ["gpt-4", "claude-3-opus"]
+    },
+    {
+      "name": "hybrid_multi_signal",
+      "algorithm": "hybrid",
+      "query": "Explain the theory of relativity",
+      "expected_behavior": "Consider Elo rating, embedding similarity, and cost",
+      "expected_models": ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"]
+    },
+    {
+      "name": "thompson_exploration",
+      "algorithm": "thompson",
+      "query": "What is the meaning of life?",
+      "expected_behavior": "Balance exploration and exploitation using Beta distributions",
+      "expected_models": ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"]
+    },
+    {
+      "name": "gmtrouter_personalized",
+      "algorithm": "gmtrouter",
+      "query": "Recommend a book about AI",
+      "expected_behavior": "Use graph neural network for personalized routing based on user history",
+      "expected_models": ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"]
+    },
+    {
+      "name": "router_r1_reasoning",
+      "algorithm": "router_r1",
+      "query": "Debug this Python code: for i in range(10) print(i)",
+      "expected_behavior": "LLM reasons about query requirements and model capabilities",
+      "expected_models": ["gpt-4", "claude-3-opus"]
+    }
+  ]
+}

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -69,12 +69,18 @@ class Language(BaseModel):
 
 
 class Latency(BaseModel):
-    """Latency signal configuration."""
+    """Latency signal configuration.
+
+    At least one of tpot_percentile or ttft_percentile must be set.
+    When both are set, model must meet BOTH thresholds (AND logic).
+    """
 
     name: str
-    tpot_percentile: Optional[int] = None
-    ttft_percentile: Optional[int] = None
-    description: str
+    tpot_percentile: Optional[int] = None  # 10th percentile = top 10% fastest
+    ttft_percentile: Optional[int] = (
+        None  # 10th percentile = top 10% fastest first token
+    )
+    description: Optional[str] = None
 
 
 class ContextRule(BaseModel):
@@ -201,7 +207,8 @@ class ReMoMAlgorithmConfig(BaseModel):
     Inspired by PaCoRe (arXiv:2601.05593) but extended to support mixture of models.
     """
 
-    # Breadth schedule: array of parallel calls per round (e.g., [32, 4] means 32 calls in round 1, 4 in round 2, then 1 final)
+    # Breadth schedule: array of parallel calls per round
+    # e.g., [32, 4] means 32 calls in round 1, 4 in round 2, then 1 final
     breadth_schedule: list[int]
 
     # Model distribution strategy: "weighted", "equal", or "first_only"
@@ -231,7 +238,7 @@ class ReMoMAlgorithmConfig(BaseModel):
     # Random seed for shuffling responses (for reproducibility)
     shuffle_seed: Optional[int] = 42
 
-    # Whether to include intermediate responses in the response body for visualization
+    # Whether to include intermediate responses in the response body
     include_intermediate_responses: Optional[bool] = True
 
     # Maximum number of responses to keep per round (for memory efficiency)
@@ -246,20 +253,249 @@ class LatencyAwareAlgorithmConfig(BaseModel):
     description: Optional[str] = None
 
 
+# =============================================================================
+# Model Selection Algorithm Configs
+# Reference papers:
+#   - Elo: RouteLLM (arXiv:2406.18665) - Bradley-Terry model
+#   - RouterDC: Query-Based Router by Dual Contrastive Learning (arXiv:2409.19886)
+#   - AutoMix: Automatically Mixing Language Models (arXiv:2310.12963)
+#   - Hybrid: Cost-Efficient Quality-Aware Query Routing (arXiv:2404.14618)
+# =============================================================================
+
+
+class EloSelectionConfig(BaseModel):
+    """Configuration for Elo rating-based model selection.
+
+    Uses Bradley-Terry model for pairwise comparisons, learning from user feedback.
+    """
+
+    # Starting Elo rating for new models (default: 1500)
+    initial_rating: Optional[float] = Field(default=1500.0, ge=0)
+
+    # Controls rating volatility - higher = faster adaptation (default: 32)
+    k_factor: Optional[float] = Field(default=32.0, ge=1, le=100)
+
+    # Enable per-category Elo ratings (default: true)
+    category_weighted: Optional[bool] = True
+
+    # Time decay for old comparisons (0-1, 0 = no decay)
+    decay_factor: Optional[float] = Field(default=0.0, ge=0, le=1)
+
+    # Minimum comparisons before rating is stable
+    min_comparisons: Optional[int] = Field(default=5, ge=0)
+
+    # Cost consideration factor (0 = ignore cost)
+    cost_scaling_factor: Optional[float] = Field(default=0.0, ge=0)
+
+    # File path for persisting Elo ratings (optional)
+    storage_path: Optional[str] = None
+
+    # Auto-save interval (e.g., "5m", "30s")
+    auto_save_interval: Optional[str] = "1m"
+
+
+class RouterDCSelectionConfig(BaseModel):
+    """Configuration for RouterDC (Dual-Contrastive) model selection.
+
+    Matches queries to models using embedding similarity based on model descriptions.
+    """
+
+    # Temperature for softmax scaling (default: 0.07)
+    temperature: Optional[float] = Field(default=0.07, gt=0)
+
+    # Embedding dimension size (default: 768)
+    dimension_size: Optional[int] = Field(default=768, gt=0)
+
+    # Minimum similarity threshold for valid matches
+    min_similarity: Optional[float] = Field(default=0.3, ge=0, le=1)
+
+    # Enable query-side contrastive learning
+    use_query_contrastive: Optional[bool] = False
+
+    # Enable model-side contrastive learning
+    use_model_contrastive: Optional[bool] = False
+
+    # Require all models to have descriptions
+    require_descriptions: Optional[bool] = False
+
+    # Include capability tags in embeddings
+    use_capabilities: Optional[bool] = False
+
+
+class AutoMixSelectionConfig(BaseModel):
+    """Configuration for AutoMix (POMDP-based) model selection.
+
+    Optimizes cost-quality tradeoff using Partially Observable MDP.
+    """
+
+    # Self-verification confidence threshold (default: 0.7)
+    verification_threshold: Optional[float] = Field(default=0.7, ge=0, le=1)
+
+    # Maximum escalation attempts (default: 2)
+    max_escalations: Optional[int] = Field(default=2, ge=0)
+
+    # Enable cost-quality tradeoff optimization
+    cost_aware_routing: Optional[bool] = True
+
+    # Balance between cost (1.0) and quality (0.0) (default: 0.3)
+    cost_quality_tradeoff: Optional[float] = Field(default=0.3, ge=0, le=1)
+
+    # POMDP discount factor (default: 0.95)
+    discount_factor: Optional[float] = Field(default=0.95, ge=0, le=1)
+
+    # Use logprobs for confidence verification
+    use_logprob_verification: Optional[bool] = True
+
+
+class HybridSelectionConfig(BaseModel):
+    """Configuration for Hybrid model selection.
+
+    Combines multiple selection methods with configurable weights.
+    """
+
+    # Weight for Elo rating contribution (0-1)
+    elo_weight: Optional[float] = Field(default=0.3, ge=0, le=1)
+
+    # Weight for RouterDC embedding similarity (0-1)
+    router_dc_weight: Optional[float] = Field(default=0.3, ge=0, le=1)
+
+    # Weight for AutoMix POMDP value (0-1)
+    automix_weight: Optional[float] = Field(default=0.2, ge=0, le=1)
+
+    # Weight for cost consideration (0-1)
+    cost_weight: Optional[float] = Field(default=0.2, ge=0, le=1)
+
+    # Quality gap threshold for escalation
+    quality_gap_threshold: Optional[float] = Field(default=0.1, ge=0, le=1)
+
+    # Normalize scores before combination
+    normalize_scores: Optional[bool] = True
+
+
+# =============================================================================
+# RL-Driven Model Selection Algorithm Configs (from PR #1196 / Issue #994)
+# Reference papers:
+#   - Thompson Sampling: Exploration/exploitation via posterior sampling
+#   - GMTRouter: Heterogeneous GNN for personalized routing (arXiv:2511.08590)
+#   - Router-R1: LLM-as-router with think/route actions (arXiv:2506.09033)
+# =============================================================================
+
+
+class ThompsonSamplingConfig(BaseModel):
+    """Configuration for Thompson Sampling model selection.
+
+    Uses Bayesian posterior sampling for exploration/exploitation balance.
+    """
+
+    # Prior alpha for Beta distribution (default: 1.0)
+    prior_alpha: Optional[float] = Field(default=1.0, gt=0)
+
+    # Prior beta for Beta distribution (default: 1.0)
+    prior_beta: Optional[float] = Field(default=1.0, gt=0)
+
+    # Enable per-user personalization
+    per_user: Optional[bool] = False
+
+    # Decay factor for old observations (0 = no decay)
+    decay_factor: Optional[float] = Field(default=0.0, ge=0, le=1)
+
+    # Minimum samples before exploitation (default: 10)
+    min_samples: Optional[int] = Field(default=10, ge=0)
+
+
+class GMTRouterConfig(BaseModel):
+    """Configuration for GMTRouter (Graph-based) model selection.
+
+    Uses heterogeneous GNN for personalized routing decisions.
+    """
+
+    # Number of GNN layers (default: 2)
+    num_layers: Optional[int] = Field(default=2, ge=1, le=5)
+
+    # Hidden dimension size (default: 64)
+    hidden_dim: Optional[int] = Field(default=64, gt=0)
+
+    # Attention heads (default: 4)
+    num_heads: Optional[int] = Field(default=4, ge=1)
+
+    # Enable user preference learning
+    learn_preferences: Optional[bool] = True
+
+    # Path to pre-trained model weights (optional)
+    model_path: Optional[str] = None
+
+
+class RouterR1Config(BaseModel):
+    """Configuration for Router-R1 (LLM-as-router) model selection.
+
+    Uses LLM with think/route actions for routing decisions.
+    """
+
+    # Router LLM endpoint (required for full functionality)
+    router_endpoint: Optional[str] = None
+
+    # Maximum think iterations (default: 3)
+    max_iterations: Optional[int] = Field(default=3, ge=1, le=10)
+
+    # Temperature for router LLM (default: 0.7)
+    temperature: Optional[float] = Field(default=0.7, ge=0, le=2)
+
+    # Enable chain-of-thought reasoning
+    use_cot: Optional[bool] = True
+
+    # Fallback to static if router unavailable
+    fallback_to_static: Optional[bool] = True
+
+
 class AlgorithmConfig(BaseModel):
     """Algorithm configuration for multi-model decisions.
 
     Specifies how multiple models in a decision should be orchestrated.
+
+    Supports three categories of algorithms:
+
+    1. Looper algorithms (multi-model execution):
+       - "confidence": Try smaller models first, escalate if confidence is low
+       - "concurrent": Execute all models concurrently (arena mode)
+       - "remom": Multi-round parallel reasoning with intelligent synthesis
+
+    2. Selection algorithms (single model selection from candidates):
+       - "static": Use first model (default)
+       - "elo": Use Elo rating system with Bradley-Terry model
+       - "router_dc": Use embedding similarity for query-model matching
+       - "automix": Use POMDP-based cost-quality optimization
+       - "hybrid": Combine multiple selection methods
+
+    3. RL-driven selection algorithms (from issue #994):
+       - "thompson": Thompson Sampling with exploration/exploitation
+       - "gmtrouter": Graph neural network for personalized routing
+       - "router_r1": LLM-as-router with think/route actions
     """
 
-    # Algorithm type: "sequential", "confidence", "concurrent", "remom", "latency_aware"
+    # Algorithm type: looper ("confidence", "concurrent", "remom", "latency_aware") or
+    # selection ("static", "elo", "router_dc", "automix", "hybrid",
+    #            "thompson", "gmtrouter", "router_r1")
     type: str
 
-    # Algorithm-specific configurations (only one should be set based on type)
+    # Looper algorithm configurations
     confidence: Optional[ConfidenceAlgorithmConfig] = None
     concurrent: Optional[ConcurrentAlgorithmConfig] = None
     remom: Optional[ReMoMAlgorithmConfig] = None
     latency_aware: Optional[LatencyAwareAlgorithmConfig] = None
+
+    # Selection algorithm configurations (from PR #1089, #1104)
+    elo: Optional[EloSelectionConfig] = None
+    router_dc: Optional[RouterDCSelectionConfig] = None
+    automix: Optional[AutoMixSelectionConfig] = None
+    hybrid: Optional[HybridSelectionConfig] = None
+
+    # RL-driven selection algorithms (from PR #1196, issue #994)
+    thompson: Optional[ThompsonSamplingConfig] = None
+    gmtrouter: Optional[GMTRouterConfig] = None
+    router_r1: Optional[RouterR1Config] = None
+
+    # Behavior on algorithm failure: "skip" or "fail"
+    on_error: Optional[str] = "skip"
 
 
 class PluginType(str, Enum):
@@ -549,6 +785,14 @@ class Model(BaseModel):
     # API format: "openai" (default) or "anthropic"
     # When set to "anthropic", the router translates requests to Anthropic Messages API
     api_format: Optional[str] = None
+
+    # Model selection fields (for RouterDC and quality-based selection)
+    # Description of model capabilities for RouterDC embedding matching
+    description: Optional[str] = None
+    # Structured capability tags (e.g., ["coding", "math", "reasoning"])
+    capabilities: Optional[List[str]] = None
+    # Quality score for AutoMix selection (0.0-1.0, default: 0.8)
+    quality_score: Optional[float] = Field(default=None, ge=0, le=1)
 
 
 class ReasoningFamily(BaseModel):

--- a/src/vllm-sr/cli/validator.py
+++ b/src/vllm-sr/cli/validator.py
@@ -253,7 +253,6 @@ def validate_signal_references(config: UserConfig) -> List[ValidationError]:
 
     # Build signal name index
     signal_names = set()
-    complexity_signal_names = set()  # Track complexity signal base names
     if config.signals:
         for signal in config.signals.keywords:
             signal_names.add(signal.name)
@@ -274,13 +273,6 @@ def validate_signal_references(config: UserConfig) -> List[ValidationError]:
         if config.signals.context:
             for signal in config.signals.context:
                 signal_names.add(signal.name)
-        if config.signals.complexity:
-            for signal in config.signals.complexity:
-                # Complexity signals generate three variants: name:easy, name:medium, name:hard
-                complexity_signal_names.add(signal.name)
-                signal_names.add(f"{signal.name}:easy")
-                signal_names.add(f"{signal.name}:medium")
-                signal_names.add(f"{signal.name}:hard")
 
     # Check decision conditions
     for decision in config.decisions:
@@ -335,10 +327,10 @@ def validate_domain_references(config: UserConfig) -> List[ValidationError]:
     for decision in config.decisions:
         for condition in decision.rules.conditions:
             if condition.type == "domain":
-                if condition.name not in domain_names:
+                if not domain_names:
                     errors.append(
                         ValidationError(
-                            f"Decision '{decision.name}' references unknown domain '{condition.name}'",
+                            f"Decision '{decision.name}' references domain '{condition.name}' but no domains are defined",
                             field=f"decisions.{decision.name}.rules.conditions",
                         )
                     )
@@ -518,6 +510,102 @@ def validate_plugin_configurations(config: UserConfig) -> List[ValidationError]:
     return errors
 
 
+def validate_algorithm_configurations(config: UserConfig) -> List[ValidationError]:
+    """
+    Validate algorithm configurations in decisions.
+
+    Validates both looper algorithms (confidence, concurrent, remom) and
+    selection algorithms (static, elo, router_dc, automix, hybrid,
+    thompson, gmtrouter, router_r1).
+
+    Args:
+        config: User configuration
+
+    Returns:
+        list: List of validation errors
+    """
+    errors = []
+
+    # Valid algorithm types
+    looper_types = {"confidence", "concurrent", "sequential", "remom"}
+    selection_types = {
+        "static",
+        "elo",
+        "router_dc",
+        "automix",
+        "hybrid",
+        "thompson",
+        "gmtrouter",
+        "router_r1",
+    }
+    all_types = looper_types | selection_types
+
+    for decision in config.decisions:
+        if not decision.algorithm:
+            continue
+
+        algo = decision.algorithm
+        algo_type = algo.type
+
+        # Validate algorithm type
+        if algo_type not in all_types:
+            errors.append(
+                ValidationError(
+                    f"Decision '{decision.name}' has invalid algorithm type '{algo_type}'. "
+                    f"Valid types: {', '.join(sorted(all_types))}",
+                    field=f"decisions.{decision.name}.algorithm.type",
+                )
+            )
+            continue
+
+        # Validate selection algorithm has corresponding config
+        if algo_type == "elo" and algo.elo is None:
+            # elo config is optional (uses defaults)
+            pass
+        if algo_type == "router_dc":
+            # Warn if require_descriptions is true but models lack descriptions
+            if algo.router_dc and algo.router_dc.require_descriptions:
+                for model_ref in decision.modelRefs:
+                    # Find model config
+                    model = next(
+                        (
+                            m
+                            for m in config.providers.models
+                            if m.name == model_ref.model
+                        ),
+                        None,
+                    )
+                    if model and not model.description:
+                        errors.append(
+                            ValidationError(
+                                f"Decision '{decision.name}' uses router_dc with require_descriptions=true, "
+                                f"but model '{model.name}' has no description",
+                                field=f"providers.models.{model.name}.description",
+                            )
+                        )
+
+        # Validate hybrid weights sum to ~1.0 (with tolerance)
+        # Note: Use `is None` check instead of `or` to handle 0.0 weights correctly
+        if algo_type == "hybrid" and algo.hybrid:
+            h = algo.hybrid
+            total = (
+                (0.3 if h.elo_weight is None else h.elo_weight)
+                + (0.3 if h.router_dc_weight is None else h.router_dc_weight)
+                + (0.2 if h.automix_weight is None else h.automix_weight)
+                + (0.2 if h.cost_weight is None else h.cost_weight)
+            )
+            if abs(total - 1.0) > 0.01:
+                errors.append(
+                    ValidationError(
+                        f"Decision '{decision.name}' hybrid weights sum to {total:.2f}, "
+                        "should sum to 1.0",
+                        field=f"decisions.{decision.name}.algorithm.hybrid",
+                    )
+                )
+
+    return errors
+
+
 def validate_user_config(config: UserConfig) -> List[ValidationError]:
     """
     Validate user configuration.
@@ -546,6 +634,9 @@ def validate_user_config(config: UserConfig) -> List[ValidationError]:
 
     # Validate plugin configurations
     errors.extend(validate_plugin_configurations(config))
+
+    # Validate algorithm configurations
+    errors.extend(validate_algorithm_configurations(config))
 
     if errors:
         log.warning(f"Found {len(errors)} validation error(s)")

--- a/src/vllm-sr/tests/test_algorithm_config.py
+++ b/src/vllm-sr/tests/test_algorithm_config.py
@@ -1,0 +1,342 @@
+"""Tests for model selection algorithm configuration.
+
+Tests for CLI algorithm support as required by PR #1196 review.
+Addresses @Xunzhuo's comment: "we should have a detailed test in the CLI PR"
+"""
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from cli.models import (
+    AlgorithmConfig,
+    EloSelectionConfig,
+    RouterDCSelectionConfig,
+    AutoMixSelectionConfig,
+    HybridSelectionConfig,
+    ThompsonSamplingConfig,
+    GMTRouterConfig,
+    RouterR1Config,
+    ReMoMAlgorithmConfig,
+)
+
+
+class TestAlgorithmConfigTypes:
+    """Test algorithm type validation."""
+
+    def test_valid_looper_types(self):
+        """Test that looper algorithm types are accepted."""
+        looper_types = ["confidence", "concurrent", "remom"]
+
+        for algo_type in looper_types:
+            config = AlgorithmConfig(type=algo_type)
+            assert config.type == algo_type
+
+    def test_valid_selection_types(self):
+        """Test that selection algorithm types are accepted."""
+        selection_types = [
+            "static",
+            "elo",
+            "router_dc",
+            "automix",
+            "hybrid",
+            "thompson",
+            "gmtrouter",
+            "router_r1",
+        ]
+
+        for algo_type in selection_types:
+            config = AlgorithmConfig(type=algo_type)
+            assert config.type == algo_type
+
+    def test_on_error_default(self):
+        """Test that on_error defaults to 'skip'."""
+        config = AlgorithmConfig(type="static")
+        assert config.on_error == "skip"
+
+    def test_on_error_fail(self):
+        """Test that on_error can be set to 'fail'."""
+        config = AlgorithmConfig(type="static", on_error="fail")
+        assert config.on_error == "fail"
+
+
+class TestEloSelectionConfig:
+    """Test Elo rating selection configuration."""
+
+    def test_default_values(self):
+        """Test Elo config default values."""
+        config = EloSelectionConfig()
+        assert config.initial_rating == 1500.0
+        assert config.k_factor == 32.0
+        assert config.category_weighted is True
+        assert config.decay_factor == 0.0
+        assert config.min_comparisons == 5
+
+    def test_custom_k_factor(self):
+        """Test Elo config with custom K-factor."""
+        config = EloSelectionConfig(k_factor=64.0)
+        assert config.k_factor == 64.0
+
+    def test_k_factor_validation(self):
+        """Test that K-factor must be within valid range."""
+        with pytest.raises(PydanticValidationError):
+            EloSelectionConfig(k_factor=0.5)  # Below minimum (1)
+
+        with pytest.raises(PydanticValidationError):
+            EloSelectionConfig(k_factor=150)  # Above maximum (100)
+
+    def test_storage_path(self):
+        """Test Elo config with storage path."""
+        config = EloSelectionConfig(storage_path="/tmp/elo_ratings.json")
+        assert config.storage_path == "/tmp/elo_ratings.json"
+
+
+class TestRouterDCSelectionConfig:
+    """Test RouterDC selection configuration."""
+
+    def test_default_values(self):
+        """Test RouterDC config default values."""
+        config = RouterDCSelectionConfig()
+        assert config.temperature == 0.07
+        assert config.dimension_size == 768
+        assert config.min_similarity == 0.3
+
+    def test_temperature_validation(self):
+        """Test that temperature must be positive."""
+        with pytest.raises(PydanticValidationError):
+            RouterDCSelectionConfig(temperature=0.0)  # Must be > 0
+
+    def test_similarity_threshold(self):
+        """Test min_similarity range validation."""
+        config = RouterDCSelectionConfig(min_similarity=0.5)
+        assert config.min_similarity == 0.5
+
+        with pytest.raises(PydanticValidationError):
+            RouterDCSelectionConfig(min_similarity=1.5)  # Above 1.0
+
+
+class TestAutoMixSelectionConfig:
+    """Test AutoMix (POMDP) selection configuration."""
+
+    def test_default_values(self):
+        """Test AutoMix config default values."""
+        config = AutoMixSelectionConfig()
+        assert config.verification_threshold == 0.7
+        assert config.max_escalations == 2
+        assert config.cost_aware_routing is True
+        assert config.cost_quality_tradeoff == 0.3
+        assert config.discount_factor == 0.95
+
+    def test_verification_threshold_range(self):
+        """Test that verification threshold is within 0-1."""
+        config = AutoMixSelectionConfig(verification_threshold=0.9)
+        assert config.verification_threshold == 0.9
+
+        with pytest.raises(PydanticValidationError):
+            AutoMixSelectionConfig(verification_threshold=1.5)
+
+
+class TestHybridSelectionConfig:
+    """Test Hybrid selection configuration."""
+
+    def test_default_weights(self):
+        """Test Hybrid config default weights."""
+        config = HybridSelectionConfig()
+        assert config.elo_weight == 0.3
+        assert config.router_dc_weight == 0.3
+        assert config.automix_weight == 0.2
+        assert config.cost_weight == 0.2
+
+    def test_custom_weights(self):
+        """Test Hybrid config with custom weights."""
+        config = HybridSelectionConfig(
+            elo_weight=0.5,
+            router_dc_weight=0.3,
+            automix_weight=0.1,
+            cost_weight=0.1,
+        )
+        # Weights should sum to 1.0
+        total = (
+            config.elo_weight
+            + config.router_dc_weight
+            + config.automix_weight
+            + config.cost_weight
+        )
+        assert abs(total - 1.0) < 0.01
+
+
+class TestThompsonSamplingConfig:
+    """Test Thompson Sampling (RL-driven) selection configuration."""
+
+    def test_default_values(self):
+        """Test Thompson Sampling config default values."""
+        config = ThompsonSamplingConfig()
+        assert config.prior_alpha == 1.0
+        assert config.prior_beta == 1.0
+        assert config.per_user is False
+        assert config.decay_factor == 0.0
+        assert config.min_samples == 10
+
+    def test_prior_validation(self):
+        """Test that priors must be positive."""
+        with pytest.raises(PydanticValidationError):
+            ThompsonSamplingConfig(prior_alpha=0.0)  # Must be > 0
+
+    def test_per_user_personalization(self):
+        """Test per-user personalization flag."""
+        config = ThompsonSamplingConfig(per_user=True)
+        assert config.per_user is True
+
+
+class TestGMTRouterConfig:
+    """Test GMTRouter (GNN-based) selection configuration."""
+
+    def test_default_values(self):
+        """Test GMTRouter config default values."""
+        config = GMTRouterConfig()
+        assert config.num_layers == 2
+        assert config.hidden_dim == 64
+        assert config.num_heads == 4
+        assert config.learn_preferences is True
+
+    def test_num_layers_validation(self):
+        """Test that num_layers is within valid range."""
+        with pytest.raises(PydanticValidationError):
+            GMTRouterConfig(num_layers=0)  # Must be >= 1
+
+        with pytest.raises(PydanticValidationError):
+            GMTRouterConfig(num_layers=10)  # Must be <= 5
+
+    def test_model_path(self):
+        """Test GMTRouter config with model path."""
+        config = GMTRouterConfig(model_path="/models/gmtrouter.pt")
+        assert config.model_path == "/models/gmtrouter.pt"
+
+
+class TestRouterR1Config:
+    """Test Router-R1 (LLM-as-router) selection configuration."""
+
+    def test_default_values(self):
+        """Test Router-R1 config default values."""
+        config = RouterR1Config()
+        assert config.router_endpoint is None
+        assert config.max_iterations == 3
+        assert config.temperature == 0.7
+        assert config.use_cot is True
+        assert config.fallback_to_static is True
+
+    def test_max_iterations_validation(self):
+        """Test that max_iterations is within valid range."""
+        with pytest.raises(PydanticValidationError):
+            RouterR1Config(max_iterations=0)  # Must be >= 1
+
+        with pytest.raises(PydanticValidationError):
+            RouterR1Config(max_iterations=20)  # Must be <= 10
+
+    def test_router_endpoint(self):
+        """Test Router-R1 config with endpoint."""
+        config = RouterR1Config(router_endpoint="http://localhost:8080")
+        assert config.router_endpoint == "http://localhost:8080"
+
+
+class TestReMoMAlgorithmConfig:
+    """Test ReMoM (Reasoning for Mixture of Models) configuration."""
+
+    def test_required_breadth_schedule(self):
+        """Test that breadth_schedule is required."""
+        config = ReMoMAlgorithmConfig(breadth_schedule=[32, 4])
+        assert config.breadth_schedule == [32, 4]
+
+    def test_default_values(self):
+        """Test ReMoM config default values."""
+        config = ReMoMAlgorithmConfig(breadth_schedule=[32])
+        assert config.model_distribution == "weighted"
+        assert config.temperature == 1.0
+        assert config.include_reasoning is False
+        assert config.compaction_strategy == "full"
+        assert config.on_error == "skip"
+
+    def test_missing_breadth_schedule(self):
+        """Test that breadth_schedule cannot be empty."""
+        # breadth_schedule is required and must be provided
+        with pytest.raises(PydanticValidationError):
+            ReMoMAlgorithmConfig()  # Missing required field
+
+
+class TestAlgorithmConfigIntegration:
+    """Integration tests for AlgorithmConfig with nested configs."""
+
+    def test_elo_algorithm_config(self):
+        """Test AlgorithmConfig with Elo selection."""
+        config = AlgorithmConfig(
+            type="elo",
+            elo=EloSelectionConfig(k_factor=48.0, min_comparisons=10),
+        )
+        assert config.type == "elo"
+        assert config.elo.k_factor == 48.0
+        assert config.elo.min_comparisons == 10
+
+    def test_rl_driven_algorithm_config(self):
+        """Test AlgorithmConfig with Thompson Sampling (RL-driven)."""
+        config = AlgorithmConfig(
+            type="thompson",
+            thompson=ThompsonSamplingConfig(per_user=True, min_samples=20),
+        )
+        assert config.type == "thompson"
+        assert config.thompson.per_user is True
+        assert config.thompson.min_samples == 20
+
+    def test_gmtrouter_algorithm_config(self):
+        """Test AlgorithmConfig with GMTRouter."""
+        config = AlgorithmConfig(
+            type="gmtrouter",
+            gmtrouter=GMTRouterConfig(num_layers=3, hidden_dim=128),
+        )
+        assert config.type == "gmtrouter"
+        assert config.gmtrouter.num_layers == 3
+        assert config.gmtrouter.hidden_dim == 128
+
+    def test_router_r1_algorithm_config(self):
+        """Test AlgorithmConfig with Router-R1."""
+        config = AlgorithmConfig(
+            type="router_r1",
+            router_r1=RouterR1Config(
+                router_endpoint="http://localhost:8080",
+                max_iterations=5,
+            ),
+        )
+        assert config.type == "router_r1"
+        assert config.router_r1.router_endpoint == "http://localhost:8080"
+        assert config.router_r1.max_iterations == 5
+
+    def test_remom_algorithm_config(self):
+        """Test AlgorithmConfig with ReMoM looper."""
+        config = AlgorithmConfig(
+            type="remom",
+            remom=ReMoMAlgorithmConfig(
+                breadth_schedule=[32, 8, 2],
+                model_distribution="equal",
+            ),
+        )
+        assert config.type == "remom"
+        assert config.remom.breadth_schedule == [32, 8, 2]
+        assert config.remom.model_distribution == "equal"
+
+    def test_hybrid_algorithm_config(self):
+        """Test AlgorithmConfig with Hybrid selection and all weights."""
+        config = AlgorithmConfig(
+            type="hybrid",
+            hybrid=HybridSelectionConfig(
+                elo_weight=0.4,
+                router_dc_weight=0.3,
+                automix_weight=0.2,
+                cost_weight=0.1,
+            ),
+        )
+        assert config.type == "hybrid"
+        total = (
+            config.hybrid.elo_weight
+            + config.hybrid.router_dc_weight
+            + config.hybrid.automix_weight
+            + config.hybrid.cost_weight
+        )
+        assert abs(total - 1.0) < 0.01


### PR DESCRIPTION
## Summary

Partial implementation for #1103 (CLI and E2E tests only, per @rootfs request to split)

Adds CLI support and E2E tests for all 8 model selection algorithms.

## Changes

### CLI Support (`src/vllm-sr/cli/`)
- Added `--algorithm` flag with choices: `static`, `elo`, `router_dc`, `automix`, `hybrid`, `thompson`, `gmtrouter`, `router_r1`
- Config translation from CLI args to router YAML format
- Algorithm field validation with proper error messages
- Temp directory cleanup via `atexit` to prevent leaks
- Fixed Hybrid weight validation to handle `0.0` weights correctly (uses `is None` check)

### E2E Tests (`e2e/testcases/`)
- Added `core_selection.go` with test cases for all 8 algorithms
- Test data in `testdata/core_selection_cases.json`
- Updated `common.go` with:
  - Dynamic port allocation (`:0`) to avoid conflicts in parallel tests
  - Selection test helpers
  - Model selection from `x-vsr-selected-model` header (canonical source)

### Unit Tests
- Added `test_algorithm_config.py` with CLI validation tests

## What's NOT Included

- Documentation (separate PR)
- Core algorithm changes (covered in #987, #994)

## Test Plan

- [x] CLI unit tests pass
- [x] Pre-commit hooks pass
- [x] E2E test structure follows existing patterns

## Related

- Issue: #1103
- Documentation PR: (will link after creation)
- Supersedes: #1230 (being split per maintainer request)
