### PR TITLE
feat(dashboard): add Elo ratings page and feedback UI for model selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ dashboard/frontend/dist/
 dashboard/frontend/build/
 dashboard/frontend/.vite/
 dashboard/frontend/*.local
+dashboard/frontend/test-results/
+dashboard/frontend/playwright-report/
 
 # Dashboard backend build artifacts
 dashboard/backend/dashboard-backend

--- a/dashboard/frontend/e2e/feedback-buttons.spec.ts
+++ b/dashboard/frontend/e2e/feedback-buttons.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * FeedbackButtons E2E tests.
+ *
+ * FeedbackButtons render inside the ChatComponent when an assistant message
+ * has a model ID (from `x-vsr-selected-model` header). We mock the chat
+ * completions endpoint to produce a response that triggers FeedbackButtons,
+ * then test the feedback submission flow.
+ */
+
+const MOCK_MODEL = 'llama3.2:3b';
+
+function chatStreamBody(content: string, model: string): string {
+  const lines = content.split('').map((char) =>
+    `data: ${JSON.stringify({
+      choices: [{ delta: { content: char } }],
+      model,
+    })}\n\n`
+  );
+  return lines.join('') + 'data: [DONE]\n\n';
+}
+
+test.describe('FeedbackButtons', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/router/v1/chat/completions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'x-vsr-selected-model': MOCK_MODEL,
+          'x-vsr-selected-decision': 'tech',
+        },
+        body: chatStreamBody('Hello, this is a test response.', MOCK_MODEL),
+      });
+    });
+
+    await page.goto('/playground');
+  });
+
+  test('thumbs up sends correct feedback payload', async ({ page }) => {
+    let feedbackPayload: Record<string, unknown> | null = null;
+
+    await page.route('**/api/router/api/v1/feedback', async (route) => {
+      feedbackPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ success: true, message: 'Feedback recorded' }),
+      });
+    });
+
+    const input = page.getByPlaceholder(/ask me anything|type a message/i);
+    await input.fill('What is machine learning?');
+    await page.getByRole('button', { name: /send|📤/i }).click();
+    await expect(page.getByText('Hello, this is a test response.')).toBeVisible({ timeout: 10000 });
+
+    const thumbsUp = page.getByRole('button', { name: /good response/i });
+    await expect(thumbsUp).toBeVisible({ timeout: 5000 });
+    await thumbsUp.click();
+
+    expect(feedbackPayload).not.toBeNull();
+    expect(feedbackPayload!.winner_model).toBe(MOCK_MODEL);
+    expect(feedbackPayload!.decision_name).toBe('tech');
+    await expect(page.getByText('Feedback Sent!')).toBeVisible({ timeout: 3000 });
+  });
+
+  test('handles feedback API error gracefully', async ({ page }) => {
+    await page.route('**/api/router/api/v1/feedback', async (route) => {
+      await route.fulfill({
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: { message: 'Server unavailable' } }),
+      });
+    });
+
+    const input = page.getByPlaceholder(/ask me anything|type a message/i);
+    await input.fill('Test error handling');
+    await page.getByRole('button', { name: /send|📤/i }).click();
+    await expect(page.getByText('Hello, this is a test response.')).toBeVisible({ timeout: 10000 });
+
+    const thumbsUp = page.getByRole('button', { name: /good response/i });
+    await expect(thumbsUp).toBeVisible({ timeout: 5000 });
+    await thumbsUp.click();
+
+    await expect(page.getByText(/server unavailable/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('thumbs down in single-model mode selects visually without error', async ({ page }) => {
+    const input = page.getByPlaceholder(/ask me anything|type a message/i);
+    await input.fill('Test thumbs down');
+    await page.getByRole('button', { name: /send|📤/i }).click();
+    await expect(page.getByText('Hello, this is a test response.')).toBeVisible({ timeout: 10000 });
+
+    const thumbsDown = page.getByRole('button', { name: /bad response/i });
+    await expect(thumbsDown).toBeVisible({ timeout: 5000 });
+    await thumbsDown.click();
+
+    // Should select visually (aria-pressed=true), no error message
+    await expect(thumbsDown).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByRole('alert')).not.toBeVisible();
+  });
+
+  test('can toggle from up to down (only submits once)', async ({ page }) => {
+    let feedbackCallCount = 0;
+
+    await page.route('**/api/router/api/v1/feedback', async (route) => {
+      feedbackCallCount++;
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    const input = page.getByPlaceholder(/ask me anything|type a message/i);
+    await input.fill('Test toggle');
+    await page.getByRole('button', { name: /send|📤/i }).click();
+    await expect(page.getByText('Hello, this is a test response.')).toBeVisible({ timeout: 10000 });
+
+    const thumbsUp = page.getByRole('button', { name: /good response/i });
+    const thumbsDown = page.getByRole('button', { name: /bad response/i });
+    await expect(thumbsUp).toBeVisible({ timeout: 5000 });
+
+    // Click thumbs up first
+    await thumbsUp.click();
+    await expect(page.getByText('Feedback Sent!')).toBeVisible({ timeout: 3000 });
+    expect(feedbackCallCount).toBe(1);
+
+    // Now toggle to thumbs down - should change visual but NOT call API again
+    await thumbsDown.click();
+    await expect(thumbsDown).toHaveAttribute('aria-pressed', 'true');
+    await expect(thumbsUp).toHaveAttribute('aria-pressed', 'false');
+    expect(feedbackCallCount).toBe(1); // Still 1 - no second API call
+
+    // Toggle back to thumbs up - still no extra API call (UP → DOWN → UP)
+    await thumbsUp.click();
+    await expect(thumbsUp).toHaveAttribute('aria-pressed', 'true');
+    await expect(thumbsDown).toHaveAttribute('aria-pressed', 'false');
+    expect(feedbackCallCount).toBe(1); // Still 1 - deterministic single submission
+  });
+
+  test('buttons disabled during loading', async ({ page }) => {
+    await page.route('**/api/router/api/v1/feedback', async (route) => {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    const input = page.getByPlaceholder(/ask me anything|type a message/i);
+    await input.fill('Test disabled');
+    await page.getByRole('button', { name: /send|📤/i }).click();
+    await expect(page.getByText('Hello, this is a test response.')).toBeVisible({ timeout: 10000 });
+
+    const thumbsUp = page.getByRole('button', { name: /good response/i });
+    await expect(thumbsUp).toBeVisible({ timeout: 5000 });
+    await thumbsUp.click();
+
+    // During loading, buttons should be disabled
+    await expect(thumbsUp).toBeDisabled();
+  });
+});

--- a/dashboard/frontend/e2e/ratings-full-verify.spec.ts
+++ b/dashboard/frontend/e2e/ratings-full-verify.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Full verification against REAL Semantic Router (llama3.2:3b, phi4 in Elo ratings).
+ * Run: npx playwright test e2e/ratings-full-verify.spec.ts -c playwright.live.config.ts
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Ratings Page - Full Verification', () => {
+  test('1-2. Navigate to /ratings and verify structure', async ({ page }) => {
+    await page.goto('/ratings');
+    await page.waitForLoadState('networkidle');
+
+    await page.screenshot({ path: 'test-results/01-ratings-page.png', fullPage: true });
+
+    // Elo Leaderboard heading
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText('Elo Leaderboard');
+
+    // Table columns
+    await expect(page.getByRole('columnheader', { name: '#' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Model' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Rating' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Games' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Wins' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Losses' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Ties' })).toBeVisible();
+
+    // At least 2 models: llama3.2:3b and phi4
+    await expect(page.getByText('llama3.2:3b')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('phi4')).toBeVisible();
+
+    const rows = page.locator('tbody tr');
+    const count = await rows.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Models sorted by rating descending - first row should have higher rating
+    const firstRow = rows.first();
+    const secondRow = rows.nth(1);
+    const firstRating = await firstRow.locator('td').nth(2).textContent();
+    const secondRating = await secondRow.locator('td').nth(2).textContent();
+    expect(parseInt(firstRating || '0', 10)).toBeGreaterThanOrEqual(parseInt(secondRating || '0', 10));
+
+    // Games = Wins + Losses + Ties for each row
+    for (let i = 0; i < Math.min(count, 5); i++) {
+      const row = rows.nth(i);
+      const games = parseInt(await row.locator('td').nth(3).textContent() || '0', 10);
+      const wins = parseInt(await row.locator('td').nth(4).textContent() || '0', 10);
+      const losses = parseInt(await row.locator('td').nth(5).textContent() || '0', 10);
+      const ties = parseInt(await row.locator('td').nth(6).textContent() || '0', 10);
+      expect(games).toBe(wins + losses + ties);
+    }
+  });
+
+  test('3. Category filter - type "tech"', async ({ page }) => {
+    await page.goto('/ratings');
+    await page.waitForLoadState('networkidle');
+
+    const customInput = page.getByPlaceholder('e.g. coding');
+    await customInput.fill('tech');
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({ path: 'test-results/03-tech-category.png', fullPage: true });
+
+    // Section should show tech category
+    await expect(page.getByText(/Leaderboard — tech/i)).toBeVisible({ timeout: 5000 });
+
+    // Data should load (may show tech data or same data if mock doesn't filter)
+    const rows = page.locator('tbody tr');
+    await expect(rows.first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('4. Clear category - verify global data', async ({ page }) => {
+    await page.goto('/ratings');
+    await page.waitForLoadState('networkidle');
+
+    const customInput = page.getByPlaceholder('e.g. coding');
+    await customInput.fill('tech');
+    await page.waitForTimeout(800);
+    await customInput.clear();
+    await page.waitForTimeout(1000);
+
+    await expect(page.getByText(/Leaderboard — global/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('llama3.2:3b')).toBeVisible();
+    await expect(page.getByText('phi4')).toBeVisible();
+  });
+
+  test('5. Auto-refresh toggle', async ({ page }) => {
+    await page.goto('/ratings');
+    await page.waitForLoadState('networkidle');
+
+    const checkbox = page.getByLabel('Auto-refresh');
+    await expect(checkbox).toBeChecked();
+    await checkbox.click();
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+  });
+
+  test('6. Refresh button updates timestamp', async ({ page }) => {
+    await page.goto('/ratings');
+    await page.waitForLoadState('networkidle');
+
+    const updatedEl = page.getByText(/Updated \d{1,2}:\d{2}:\d{2}/);
+    await expect(updatedEl).toBeVisible();
+
+    await page.waitForTimeout(1100);
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await expect(page.getByText('Loading leaderboard…')).toBeVisible({ timeout: 1000 }).catch(() => {});
+
+    await expect(updatedEl).toBeVisible({ timeout: 5000 });
+    const after = await updatedEl.textContent();
+    expect(after).toMatch(/Updated \d{1,2}:\d{2}:\d{2}/);
+  });
+
+  test('7-9. Playground nav and Ratings link', async ({ page }) => {
+    await page.goto('/playground');
+    await page.waitForLoadState('networkidle');
+
+    const ratingsLink = page.getByRole('link', { name: 'Ratings' });
+    await expect(ratingsLink).toBeVisible();
+
+    await ratingsLink.click();
+    await expect(page).toHaveURL(/\/ratings/);
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Elo Leaderboard');
+    await expect(page.getByText('llama3.2:3b')).toBeVisible();
+
+    await page.screenshot({ path: 'test-results/09-back-to-ratings.png', fullPage: true });
+  });
+});

--- a/dashboard/frontend/e2e/ratings.spec.ts
+++ b/dashboard/frontend/e2e/ratings.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+
+// Mock ratings data matching the user's expected mock API (gpt-4 #1 with 1410)
+const MOCK_RATINGS = [
+  { model: 'gpt-4', rating: 1410, wins: 10, losses: 2, ties: 1 },
+  { model: 'gemma2:9b', rating: 1350, wins: 8, losses: 4, ties: 2 },
+  { model: 'llama3.2:3b', rating: 1280, wins: 6, losses: 5, ties: 1 },
+  { model: 'phi4', rating: 1200, wins: 5, losses: 6, ties: 0 },
+  { model: 'mistral-7b', rating: 1150, wins: 4, losses: 8, ties: 1 },
+];
+
+function mockRatingsResponse() {
+  return {
+    ratings: MOCK_RATINGS,
+    category: 'global',
+    count: MOCK_RATINGS.length,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+test.describe('Ratings Page', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the ratings API for consistent test results
+    await page.route('**/api/router/api/v1/ratings**', async (route) => {
+      const url = new URL(route.request().url());
+      const category = url.searchParams.get('category') || 'global';
+      const response = mockRatingsResponse();
+      response.category = category || 'global';
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(response),
+      });
+    });
+  });
+
+  test('1. Page loads with expected structure', async ({ page }) => {
+    await page.goto('/ratings');
+
+    // Wait for table to load (either with data or loading state)
+    await page.waitForSelector('table, .loading', { timeout: 5000 });
+
+    // Note: Page shows "Elo Leaderboard" not "Model Leaderboard"
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toBeVisible();
+    await expect(heading).toContainText('Leaderboard');
+
+    // Table columns: #, Model, Rating, Games, Wins, Losses, Ties
+    await expect(page.getByRole('columnheader', { name: '#' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Model' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Rating' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Games' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Wins' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Losses' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Ties' })).toBeVisible();
+
+    // Category dropdown and auto-refresh toggle
+    await expect(page.getByLabel('Auto-refresh')).toBeVisible();
+    await expect(page.getByRole('combobox', { name: /category/i })).toBeVisible();
+  });
+
+  test('2. Models sorted by rating descending, gpt-4 is #1 with 1410', async ({ page }) => {
+    await page.goto('/ratings');
+
+    // Wait for data to load
+    await expect(page.getByText('gpt-4')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('1410')).toBeVisible();
+
+    // gpt-4 should be in first data row (rank 1)
+    const firstRow = page.locator('tbody tr').first();
+    await expect(firstRow).toContainText('gpt-4');
+    await expect(firstRow).toContainText('1'); // rank
+    await expect(firstRow).toContainText('1410');
+  });
+
+  test('3. All 5 models display in table', async ({ page }) => {
+    await page.goto('/ratings');
+
+    for (const m of ['gpt-4', 'gemma2:9b', 'llama3.2:3b', 'phi4', 'mistral-7b']) {
+      await expect(page.getByText(m, { exact: true })).toBeVisible({ timeout: 5000 });
+    }
+
+    const rows = page.locator('tbody tr');
+    await expect(rows).toHaveCount(5);
+  });
+
+  test('4. Auto-refresh checkbox toggles off', async ({ page }) => {
+    await page.goto('/ratings');
+    await expect(page.getByText('gpt-4')).toBeVisible({ timeout: 5000 });
+
+    const checkbox = page.getByLabel('Auto-refresh');
+    await expect(checkbox).toBeChecked();
+    await checkbox.click();
+    await expect(checkbox).not.toBeChecked();
+  });
+
+  test('5. Refresh button updates last updated time', async ({ page }) => {
+    await page.goto('/ratings');
+    await expect(page.getByText('gpt-4')).toBeVisible({ timeout: 5000 });
+
+    const updatedRegex = /Updated \d{1,2}:\d{2}:\d{2}/;
+    await expect(page.getByText(updatedRegex)).toBeVisible();
+
+    // Small delay to ensure timestamp can change
+    await page.waitForTimeout(1100);
+    await page.getByRole('button', { name: 'Refresh' }).click();
+
+    // Wait for loading to finish
+    await expect(page.getByText('Loading leaderboard…')).toBeVisible({ timeout: 1000 }).catch(() => {});
+    await expect(page.getByText('gpt-4')).toBeVisible({ timeout: 5000 });
+
+    const afterText = await page.getByText(updatedRegex).textContent();
+    // Timestamp should be visible (may or may not change within same second)
+    expect(afterText).toMatch(updatedRegex);
+  });
+
+  test('6. Custom category "coding" shows data (mock does not filter)', async ({ page }) => {
+    await page.goto('/ratings');
+    await expect(page.getByText('gpt-4')).toBeVisible({ timeout: 5000 });
+
+    const customInput = page.getByPlaceholder('e.g. coding');
+    await customInput.fill('coding');
+    await page.waitForTimeout(500); // Allow debounce / refetch
+
+    // Data should still show (mock returns same data for any category)
+    await expect(page.getByText('gpt-4')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('tbody tr')).toHaveCount(5);
+  });
+
+  test('7. Ratings link in main page navigation', async ({ page }) => {
+    // Use /playground - root "/" is a landing page without nav bar
+    await page.goto('/playground');
+    const ratingsLink = page.getByRole('link', { name: 'Ratings' });
+    await expect(ratingsLink).toBeVisible();
+  });
+
+  test('8. Ratings nav link navigates to ratings page', async ({ page }) => {
+    await page.goto('/playground');
+    await page.getByRole('link', { name: 'Ratings' }).click();
+    await expect(page).toHaveURL(/\/ratings/);
+    await expect(page.getByText('gpt-4')).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/dashboard/frontend/playwright.live.config.ts
+++ b/dashboard/frontend/playwright.live.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// For tests against already-running stack (no webServer).
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  reporter: 'list',
+  use: { baseURL: 'http://localhost:3001' },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import LogsPage from './pages/LogsPage'
 import ReplayPage from './pages/ReplayPage'
 import EvaluationPage from './pages/EvaluationPage'
 import MLSetupPage from './pages/MLSetupPage'
+import RatingsPage from './pages/RatingsPage'
 import { ConfigSection } from './components/ConfigNav'
 import { ReadonlyProvider } from './contexts/ReadonlyContext'
 
@@ -197,6 +198,17 @@ const App: React.FC = () => {
                 onConfigSectionChange={(section) => setConfigSection(section as ConfigSection)}
               >
                 <MLSetupPage />
+              </Layout>
+            }
+          />
+          <Route
+            path="/ratings"
+            element={
+              <Layout
+                configSection={configSection}
+                onConfigSectionChange={(section) => setConfigSection(section as ConfigSection)}
+              >
+                <RatingsPage />
               </Layout>
             }
           />

--- a/dashboard/frontend/src/components/ChatComponent.module.css
+++ b/dashboard/frontend/src/components/ChatComponent.module.css
@@ -518,13 +518,20 @@ body.playground-fullscreen .container {
   color: var(--color-text-secondary);
 }
 
+/* Wrapper for action bar + feedback buttons */
+.messageActionRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
+}
+
 /* Message action bar - bottom toolbar like CodeBuddy */
 .messageActionBar {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding-top: 0.75rem;
-  margin-top: 0.5rem;
 }
 
 .actionButton {
@@ -823,6 +830,14 @@ body.playground-fullscreen .container {
   font-size: var(--text-sm);
   line-height: 1.6;
   word-break: break-word;
+}
+
+.choiceActions {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg-secondary);
 }
 
 /* Footer for platform branding */

--- a/dashboard/frontend/src/components/FeedbackButtons.module.css
+++ b/dashboard/frontend/src/components/FeedbackButtons.module.css
@@ -1,0 +1,90 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.error {
+  font-size: 0.75rem;
+  color: var(--color-danger);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dismissError {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.btn:hover:not(:disabled) {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-color: var(--color-primary);
+}
+
+.btn:disabled {
+  cursor: default;
+  opacity: 0.8;
+}
+
+.thumbsUp.selected {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.thumbsDown.selected {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+}
+
+.sentLabel {
+  font-size: 0.7rem;
+  color: var(--color-success);
+  font-weight: 500;
+  white-space: nowrap;
+  margin-left: 0.25rem;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/dashboard/frontend/src/components/FeedbackButtons.tsx
+++ b/dashboard/frontend/src/components/FeedbackButtons.tsx
@@ -1,0 +1,171 @@
+import React, { useState, useCallback } from 'react'
+import styles from './FeedbackButtons.module.css'
+
+const FEEDBACK_API = '/api/router/api/v1/feedback'
+
+export interface FeedbackSubmitParams {
+  winnerModel: string
+  loserModel?: string
+  category?: string
+  query?: string
+  tie?: boolean
+}
+
+interface FeedbackButtonsProps {
+  /** Model ID for this response */
+  modelId: string
+  /** Optional category/decision name */
+  category?: string
+  /** Optional query for context */
+  query?: string
+  /** When in A/B mode, other model IDs (thumbs down picks other as winner) */
+  otherModelIds?: string[]
+  onSuccess?: () => void
+  onError?: (message: string) => void
+}
+
+const FeedbackButtons: React.FC<FeedbackButtonsProps> = ({
+  modelId,
+  category,
+  query,
+  otherModelIds = [],
+  onSuccess,
+  onError
+}) => {
+  // Which button is visually selected: 'up', 'down', or null
+  const [selection, setSelection] = useState<'up' | 'down' | null>(null)
+  // Whether feedback has been submitted to the API (only happens once)
+  const [submitted, setSubmitted] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const clearError = () => setErrorMessage(null)
+
+  const submitFeedback = useCallback(async (params: FeedbackSubmitParams) => {
+    const body: Record<string, unknown> = {
+      winner_model: params.winnerModel,
+      decision_name: params.category || undefined,
+      query: params.query || undefined,
+      tie: params.tie ?? false
+    }
+    if (params.loserModel) body.loser_model = params.loserModel
+
+    const res = await fetch(FEEDBACK_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      const err = data?.error
+      const msg = (err && typeof err === 'object' && typeof err.message === 'string')
+        ? err.message
+        : (typeof data?.message === 'string' ? data.message : res.statusText)
+      throw new Error(msg || 'Feedback request failed')
+    }
+    return data
+  }, [])
+
+  const handleClick = useCallback(async (direction: 'up' | 'down') => {
+    if (loading) return
+
+    // If same button clicked again, do nothing
+    if (selection === direction) return
+
+    // Toggle visual selection
+    setSelection(direction)
+    setErrorMessage(null)
+
+    // Only submit to API once
+    if (submitted) return
+
+    // Determine if we can submit for this direction
+    if (direction === 'up') {
+      // Thumbs up: winner = this model
+      setLoading(true)
+      try {
+        await submitFeedback({ winnerModel: modelId, category, query })
+        setSubmitted(true)
+        onSuccess?.()
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to submit feedback'
+        setErrorMessage(message)
+        setSelection(null) // Reset on error so user can retry
+        onError?.(message)
+      } finally {
+        setLoading(false)
+      }
+    } else if (direction === 'down' && otherModelIds.length > 0) {
+      // Thumbs down in A/B mode: other model wins, this model loses
+      setLoading(true)
+      try {
+        await submitFeedback({
+          winnerModel: otherModelIds[0],
+          loserModel: modelId,
+          category,
+          query
+        })
+        setSubmitted(true)
+        onSuccess?.()
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to submit feedback'
+        setErrorMessage(message)
+        setSelection(null)
+        onError?.(message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    // Thumbs down in single-model mode: visual only.
+    // API requires winner_model, which we can't provide without a comparison model.
+  }, [loading, selection, submitted, submitFeedback, modelId, category, query, otherModelIds, onSuccess, onError])
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.wrapper} role="group" aria-label="Feedback">
+        <button
+          type="button"
+          className={`${styles.btn} ${styles.thumbsUp} ${selection === 'up' ? styles.selected : ''}`}
+          onClick={() => handleClick('up')}
+          disabled={loading}
+          title={selection === 'up' ? 'Good response (selected)' : 'Good response'}
+          aria-label={selection === 'up' ? 'Good response (selected)' : 'Good response'}
+          aria-pressed={selection === 'up'}
+        >
+          {loading && selection === 'up' ? (
+            <span className={styles.spinner} aria-hidden />
+          ) : (
+            <span aria-hidden>👍</span>
+          )}
+        </button>
+        <button
+          type="button"
+          className={`${styles.btn} ${styles.thumbsDown} ${selection === 'down' ? styles.selected : ''}`}
+          onClick={() => handleClick('down')}
+          disabled={loading}
+          title={selection === 'down' ? 'Bad response (selected)' : 'Bad response'}
+          aria-label={selection === 'down' ? 'Bad response (selected)' : 'Bad response'}
+          aria-pressed={selection === 'down'}
+        >
+          {loading && selection === 'down' ? (
+            <span className={styles.spinner} aria-hidden />
+          ) : (
+            <span aria-hidden>👎</span>
+          )}
+        </button>
+      </div>
+      {submitted && (
+        <span className={styles.sentLabel}>Feedback Sent!</span>
+      )}
+      {errorMessage && (
+        <div className={styles.error} role="alert">
+          {errorMessage}
+          <button type="button" className={styles.dismissError} onClick={clearError} aria-label="Dismiss">×</button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default FeedbackButtons

--- a/dashboard/frontend/src/components/Layout.tsx
+++ b/dashboard/frontend/src/components/Layout.tsx
@@ -119,6 +119,15 @@ const Layout: React.FC<LayoutProps> = ({ children, configSection, onConfigSectio
               ML Setup
             </NavLink>
 
+            <NavLink
+              to="/ratings"
+              className={({ isActive }) =>
+                isActive ? `${styles.navLink} ${styles.navLinkActive}` : styles.navLink
+              }
+            >
+              Ratings
+            </NavLink>
+
             {/* System Dropdown (includes router-config and observability) */}
             <div className={styles.systemDropdown}>
               <button
@@ -296,6 +305,9 @@ const Layout: React.FC<LayoutProps> = ({ children, configSection, onConfigSectio
             </NavLink>
             <NavLink to="/ml-setup" className={styles.mobileNavLink} onClick={() => setMobileMenuOpen(false)}>
               ML Setup
+            </NavLink>
+            <NavLink to="/ratings" className={styles.mobileNavLink} onClick={() => setMobileMenuOpen(false)}>
+              Ratings
             </NavLink>
             <div className={styles.mobileNavSection}>
               <div className={styles.mobileNavSectionTitle}>System</div>

--- a/dashboard/frontend/src/components/RatingsTable.module.css
+++ b/dashboard/frontend/src/components/RatingsTable.module.css
@@ -1,0 +1,69 @@
+.wrapper {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.loading {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.table th {
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.table tbody tr:hover {
+  background: var(--color-bg);
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.rankCol {
+  width: 3rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.modelCol {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.ratingCol {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.gamesCol,
+.winsCol,
+.lossesCol,
+.tiesCol {
+  text-align: right;
+  color: var(--color-text-secondary);
+}
+
+.emptyCell {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-text-secondary);
+}

--- a/dashboard/frontend/src/components/RatingsTable.tsx
+++ b/dashboard/frontend/src/components/RatingsTable.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import styles from './RatingsTable.module.css'
+
+export interface RatingRow {
+  model: string
+  rating: number
+  wins: number
+  losses: number
+  ties: number
+}
+
+interface RatingsTableProps {
+  ratings: RatingRow[]
+  category: string
+  loading?: boolean
+}
+
+const RatingsTable: React.FC<RatingsTableProps> = ({ ratings, category, loading }) => {
+  if (loading) {
+    return (
+      <div className={styles.wrapper}>
+        <div className={styles.loading}>Loading leaderboard…</div>
+      </div>
+    )
+  }
+
+  const games = (r: RatingRow) => r.wins + r.losses + r.ties
+  const sorted = [...ratings].sort((a, b) => b.rating - a.rating)
+
+  return (
+    <div className={styles.wrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.rankCol}>#</th>
+            <th className={styles.modelCol}>Model</th>
+            <th className={styles.ratingCol}>Rating</th>
+            <th className={styles.gamesCol}>Games</th>
+            <th className={styles.winsCol}>Wins</th>
+            <th className={styles.lossesCol}>Losses</th>
+            <th className={styles.tiesCol}>Ties</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.length === 0 ? (
+            <tr>
+              <td colSpan={7} className={styles.emptyCell}>
+                No ratings yet for category “{category}”. Submit feedback in the Playground to build the leaderboard.
+              </td>
+            </tr>
+          ) : (
+            sorted.map((r, idx) => (
+              <tr key={r.model}>
+                <td className={styles.rankCol}>{idx + 1}</td>
+                <td className={styles.modelCol}>{r.model}</td>
+                <td className={styles.ratingCol}>{Math.round(r.rating)}</td>
+                <td className={styles.gamesCol}>{games(r)}</td>
+                <td className={styles.winsCol}>{r.wins}</td>
+                <td className={styles.lossesCol}>{r.losses}</td>
+                <td className={styles.tiesCol}>{r.ties}</td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default RatingsTable

--- a/dashboard/frontend/src/pages/Ratings.module.css
+++ b/dashboard/frontend/src/pages/Ratings.module.css
@@ -1,0 +1,165 @@
+.container {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  min-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.headerLeft {
+  flex: 1;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.titleIcon {
+  font-size: 1.5rem;
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  margin: 0.5rem 0 0 0;
+}
+
+.autoRefreshToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.autoRefreshToggle input {
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+.refreshButton {
+  background: var(--color-primary);
+  color: white;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.refreshButton:hover {
+  background: var(--color-primary-hover);
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.categoryLabel {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.categorySelect {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  min-width: 140px;
+}
+
+.categoryInput {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  width: 120px;
+}
+
+.error {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-danger);
+}
+
+.errorIcon {
+  font-size: 1.25rem;
+}
+
+.section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 300px;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.sectionTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.lastUpdated {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .header {
+    flex-direction: column;
+  }
+
+  .headerRight {
+    flex-wrap: wrap;
+  }
+}

--- a/dashboard/frontend/src/pages/RatingsPage.tsx
+++ b/dashboard/frontend/src/pages/RatingsPage.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import styles from './Ratings.module.css'
+import RatingsTable from '../components/RatingsTable'
+import type { RatingRow } from '../components/RatingsTable'
+
+const RATINGS_API = '/api/router/api/v1/ratings'
+const DEFAULT_CATEGORY = ''
+const REFRESH_INTERVAL_MS = 15000
+
+interface RatingsResponse {
+  category: string
+  ratings: RatingRow[]
+  count: number
+  timestamp?: string
+}
+
+const RatingsPage: React.FC = () => {
+  const [ratings, setRatings] = useState<RatingRow[]>([])
+  const [category, setCategory] = useState(DEFAULT_CATEGORY)
+  const [customCategory, setCustomCategory] = useState('')
+  const [categories, setCategories] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const [autoRefresh, setAutoRefresh] = useState(true)
+
+  const effectiveCategory = customCategory.trim() || category
+
+  const fetchRatings = useCallback(async () => {
+    const eff = customCategory.trim() || category
+    try {
+      const url = eff ? `${RATINGS_API}?category=${encodeURIComponent(eff)}` : RATINGS_API
+      const response = await fetch(url)
+      if (!response.ok) {
+        const errBody = await response.text()
+        let msg = response.statusText
+        try {
+          const j = JSON.parse(errBody)
+          const err = j?.error
+          if (err && typeof err.message === 'string') msg = err.message
+          else if (typeof j?.message === 'string') msg = j.message
+        } catch {
+          if (errBody) msg = errBody.slice(0, 200)
+        }
+        throw new Error(msg)
+      }
+      const data: RatingsResponse = await response.json()
+      setRatings(data.ratings || [])
+      setLastUpdated(new Date())
+      setError(null)
+      if (data.ratings?.length && data.category && data.category !== 'global') {
+        setCategories((prev) =>
+          prev.includes(data.category) ? prev : [...prev, data.category].sort()
+        )
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load ratings')
+      setRatings([])
+    } finally {
+      setLoading(false)
+    }
+  }, [category, customCategory])
+
+  useEffect(() => {
+    fetchRatings()
+    if (autoRefresh) {
+      const interval = setInterval(fetchRatings, REFRESH_INTERVAL_MS)
+      return () => clearInterval(interval)
+    }
+  }, [fetchRatings, autoRefresh])
+
+  const categoryLabel = effectiveCategory || 'global'
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <h1 className={styles.title}>
+            <span className={styles.titleIcon}>📊</span>
+            Elo Leaderboard
+          </h1>
+          <p className={styles.subtitle}>
+            Model rankings by category. Submit feedback in the Playground to update ratings.
+          </p>
+        </div>
+        <div className={styles.headerRight}>
+          <label className={styles.autoRefreshToggle}>
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+            />
+            Auto-refresh
+          </label>
+          <button type="button" className={styles.refreshButton} onClick={() => { setLoading(true); fetchRatings() }}>
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.controls}>
+        <label className={styles.categoryLabel} htmlFor="ratings-category">
+          Category
+        </label>
+        <select
+          id="ratings-category"
+          className={styles.categorySelect}
+          value={category}
+          onChange={(e) => { setCategory(e.target.value); setCustomCategory('') }}
+        >
+          <option value="">global</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <label className={styles.categoryLabel} htmlFor="ratings-custom-category">
+          Or custom
+        </label>
+        <input
+          id="ratings-custom-category"
+          type="text"
+          className={styles.categoryInput}
+          placeholder="e.g. coding"
+          value={customCategory}
+          onChange={(e) => setCustomCategory(e.target.value)}
+        />
+      </div>
+
+      {error && (
+        <div className={styles.error}>
+          <span className={styles.errorIcon}>⚠️</span>
+          {error}
+        </div>
+      )}
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Leaderboard — {categoryLabel}</h2>
+          {lastUpdated && (
+            <span className={styles.lastUpdated}>
+              Updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+        <RatingsTable ratings={ratings} category={categoryLabel} loading={loading} />
+      </section>
+    </div>
+  )
+}
+
+export default RatingsPage


### PR DESCRIPTION
## Summary

- Add `/ratings` page with Elo leaderboard table, category filtering (dropdown + custom), auto-refresh toggle, and manual refresh
- Integrate thumbs up/down feedback buttons into Playground chat responses (single-model and A/B comparison modes)
- Add navigation links (desktop + mobile) and routing for the new Ratings page

## Details

**Ratings Page** (`RatingsPage.tsx`, `RatingsTable.tsx`):
- Fetches from `GET /api/v1/ratings?category=X` with 15s auto-refresh
- Displays model rankings sorted by Elo rating: #, Model, Rating, Games (W+L+T), Wins, Losses, Ties
- Category filter with dropdown and custom text input
- Graceful error handling with user-friendly messages

**Feedback Buttons** (`FeedbackButtons.tsx`):
- Thumbs up/down on completed assistant messages (gated by `x-vsr-selected-model` header)
- Submits to `POST /api/v1/feedback` with `winner_model`, `loser_model`, `decision_name`, `query`
- Single API submission guarantee: users can toggle visual selection freely, but feedback is recorded exactly once
- A/B mode: thumbs down on one model = thumbs up for the other
- Single-model mode: thumbs down is visual-only (API requires `winner_model`)
- Loading spinner, error display with dismiss, "Feedback Sent!" confirmation

**Testing**:
- 8 Playwright E2E tests for Ratings page (mocked API, CI-safe)
- 5 Playwright E2E tests for FeedbackButtons (payload verification, error handling, toggle/single-submission, loading states)
- 6 Playwright E2E tests for live stack verification
- Verified against real Semantic Router with 3 models across 5 categories (coding, math, creative, general, tech)
- Category isolation confirmed: each category maintains independent Elo leaderboard


## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vite build` — production build clean
- [x] 13/13 CI-safe E2E tests pass
- [x] 6/6 live stack E2E tests pass 
- [x] Multi-category feedback verified (5 categories, 3 models)


Closes #1128


#########################################################################

<img width="1152" height="671" alt="image" src="https://github.com/user-attachments/assets/4a8c2a85-4984-43ec-ac73-fb07ae9c4d27" />


<img width="1145" height="949" alt="image" src="https://github.com/user-attachments/assets/1ad42fd7-7ea3-416d-ba92-699fd5ce8e93" />

