### PR TITLE
docs(paper): expand memory section with lifecycle figure and retentio…

### DIFF
--- a/paper/references.bib
+++ b/paper/references.bib
@@ -436,3 +436,10 @@
   year      = {2012},
   publisher = {Now Publishers}
 }
+
+@article{zhong2023memorybank,
+  title   = {MemoryBank: Enhancing Large Language Models with Long-Term Memory},
+  author  = {Zhong, Wanjun and Guo, Lianghong and Gao, Qiqi and Ye, He and Wang, Yanlin},
+  journal = {arXiv preprint arXiv:2305.10250},
+  year    = {2023}
+}

--- a/paper/sections/memory_rag.tex
+++ b/paper/sections/memory_rag.tex
@@ -9,6 +9,7 @@ We describe the memory and RAG subsystems that operate as plugins within the rou
 \subsection{Persistent Memory}
 
 The memory system maintains user-scoped knowledge across conversation sessions, enabling personalized routing and context-aware responses.
+\Cref{fig:memory_lifecycle} illustrates the full memory lifecycle.
 
 \textbf{Memory extraction.}
 An LLM-based extractor analyzes conversation turns to identify user-specific facts, classified into three types:
@@ -19,9 +20,86 @@ An LLM-based extractor analyzes conversation turns to identify user-specific fac
 \textbf{Deduplication.}
 Before storage, extracted facts undergo similarity-based deduplication against existing memories, preventing redundant entries that would degrade retrieval precision.
 
+\textbf{Retrieval gating.}
+Not every query benefits from memory retrieval.
+A lightweight heuristic determines whether memory search is warranted by filtering out general fact-check queries, tool-augmented requests, and simple greetings, avoiding unnecessary embedding lookups and reducing latency for queries where personal context is irrelevant.
+
 \textbf{Retrieval.}
 At query time, relevant memories are retrieved via embedding similarity search over the user's memory store, formatted as context, and injected into the system message.
 An optional query-rewriting step reformulates the user's query for improved retrieval recall.
+
+\textbf{Retention scoring and pruning.}
+Memory stores grow unbounded without lifecycle management.
+We adopt an exponential decay model inspired by the Ebbinghaus forgetting curve~\cite{zhong2023memorybank}:
+\begin{equation}
+  R = e^{-t/S}, \quad S = S_0 + n_{\text{access}}
+\end{equation}
+where $t$ is the time in days since last retrieval, $S_0$ is the initial strength (default 30 days), and $n_{\text{access}}$ is the cumulative access count.
+Each retrieval reinforces the memory by incrementing $n_{\text{access}}$, slowing future decay.
+Memories falling below a retention threshold $R < \delta$ become pruning candidates.
+An optional per-user capacity limit evicts the lowest-scoring entries when the store exceeds a configurable maximum.
+
+\begin{figure}[H]
+\centering
+\begin{tikzpicture}[
+    node distance=0.6cm and 0.8cm,
+    box/.style={draw, rounded corners, fill=blue!8, minimum width=2.2cm,
+                minimum height=0.8cm, align=center, font=\small},
+    storebox/.style={draw, rounded corners, fill=green!10, minimum width=2.2cm,
+                minimum height=0.8cm, align=center, font=\small},
+    typebox/.style={draw, rounded corners, fill=orange!10,
+                minimum height=0.55cm, align=center, font=\scriptsize},
+    arr/.style={->, >=stealth, thick},
+    darr/.style={->, >=stealth, thick, dashed},
+    lbl/.style={font=\scriptsize, text=gray}
+]
+
+% --- Write path (top row) ---
+\node[box] (conv) {Conversation\\Turns};
+\node[box, right=of conv] (extract) {LLM\\Extraction};
+\node[box, right=of extract] (dedup) {Dedup\\Check};
+\node[storebox, right=of dedup] (store) {Memory\\Store};
+
+\draw[arr] (conv) -- (extract);
+\draw[arr] (extract) -- (dedup);
+\draw[arr] (dedup) -- node[above, lbl] {new} (store);
+
+% Memory types below extraction
+\node[typebox, below=0.4cm of extract, xshift=-1.2cm] (sem) {semantic};
+\node[typebox, right=0.2cm of sem] (proc) {procedural};
+\node[typebox, right=0.2cm of proc] (epis) {episodic};
+\draw[darr] (extract) -- (proc);
+
+% Dedup "update existing" loops back above store
+\draw[darr] (dedup.north) -- ++(0,0.45) -| node[above, lbl, pos=0.25] {update existing} (store.north);
+
+% --- Read path (bottom row) ---
+\node[box, below=2.8cm of conv] (query) {User\\Query};
+\node[box, right=of query] (gate) {Retrieval\\Gating};
+\node[box, right=of gate] (retrieve) {Similarity\\Search};
+\node[box, right=of retrieve] (inject) {Inject into\\System Msg};
+
+\draw[arr] (query) -- (gate);
+\draw[arr] (gate) -- node[above, lbl] {pass} (retrieve);
+\draw[arr] (retrieve) -- (inject);
+
+% Store feeds into retrieval
+\draw[arr] (store.south) -- ++(0,-1.15) -| (retrieve.north);
+
+% Skip arrow from gate
+\draw[darr] (gate.south) -- ++(0,-0.5) node[below, lbl] {skip};
+
+% Retrieval reinforces memory (feedback arrow on the right)
+\draw[darr] (inject.north) -- ++(0,0.6) node[right, lbl] {$n_{\text{access}}$\,+\,1} |- (store.east);
+
+% --- Path labels ---
+\node[lbl, above=0.08cm of conv, xshift=1.2cm] {\textit{Write path}};
+\node[lbl, above=0.08cm of query, xshift=1.2cm] {\textit{Read path}};
+
+\end{tikzpicture}
+\caption{Memory lifecycle. The write path extracts facts from conversations, deduplicates against existing entries, and stores new memories. The read path gates retrieval, searches by embedding similarity, and injects context. Each retrieval increments $n_{\text{access}}$, reinforcing the memory's retention score.}
+\label{fig:memory_lifecycle}
+\end{figure}
 
 \subsection{Retrieval-Augmented Generation}
 


### PR DESCRIPTION
## Summary

Review and expand the Persistent Memory subsection (12.1) of the white paper.

## Changes

- Add **retrieval gating** paragraph — describes the heuristic that skips memory search for irrelevant queries (fact-checks, tool requests, greetings)
- Add **retention scoring and pruning** paragraph — Ebbinghaus-inspired decay formula `R = e^{-t/S}` with access-count reinforcement and threshold-based pruning
- Add **memory lifecycle TikZ figure** — write path (extraction → dedup → store) and read path (gating → search → injection)
- Add **MemoryBank citation** (Zhong et al., 2023) to `references.bib`

> **Note:** The retention scoring and pruning content depends on #1313 which has not been merged yet. Please hold this PR until that one lands.


## Related Issues

Contributes to #1332