### PR TITLE
[Feat][Router]: add Llama Stack as a VectorStoreBackend for RAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ _run:
 		-f tools/make/linter.mk \
 		-f tools/make/milvus.mk \
 		-f tools/make/redis.mk \
+		-f tools/make/llama-stack.mk \
 		-f tools/make/models.mk \
 		-f tools/make/pre-commit.mk \
 		-f tools/make/docker.mk \

--- a/config/config-rag-example.yaml
+++ b/config/config-rag-example.yaml
@@ -21,7 +21,7 @@ embedding_models:
 # Vector Store — local document ingestion and search
 vector_store:
   enabled: true
-  backend_type: "memory"         # "memory" (dev/testing) or "milvus" (production)
+  backend_type: "memory"         # "memory" (dev/testing), "milvus" (production), or "llama_stack"
   file_storage_dir: "/tmp/vsr-data"
   max_file_size_mb: 50
   embedding_model: "mmbert"      # "bert", "qwen3", "gemma", "mmbert"
@@ -39,6 +39,11 @@ vector_store:
   #   connection:
   #     host: "localhost"
   #     port: 19530
+  # llama_stack:
+  #   endpoint: "http://localhost:8321"
+  #   embedding_model: "all-MiniLM-L6-v2"
+  #   # auth_token: ""                # optional bearer token
+  #   # request_timeout_seconds: 30   # optional HTTP timeout
 
 # Semantic cache (independent of vector store)
 semantic_cache:

--- a/e2e/cmd/e2e/main.go
+++ b/e2e/cmd/e2e/main.go
@@ -19,6 +19,7 @@ import (
 	mlmodelselection "github.com/vllm-project/semantic-router/e2e/profiles/ml-model-selection"
 	multiendpoint "github.com/vllm-project/semantic-router/e2e/profiles/multi-endpoint"
 	productionstack "github.com/vllm-project/semantic-router/e2e/profiles/production-stack"
+	ragllamastack "github.com/vllm-project/semantic-router/e2e/profiles/rag-llama-stack"
 	responseapi "github.com/vllm-project/semantic-router/e2e/profiles/response-api"
 	responseapiredis "github.com/vllm-project/semantic-router/e2e/profiles/response-api-redis"
 	responseapirediscluster "github.com/vllm-project/semantic-router/e2e/profiles/response-api-redis-cluster"
@@ -42,6 +43,9 @@ import (
 
 	// Multi-endpoint profile
 	_ "github.com/vllm-project/semantic-router/e2e/profiles/multi-endpoint"
+
+	// RAG with Llama Stack profile
+	_ "github.com/vllm-project/semantic-router/e2e/profiles/rag-llama-stack"
 )
 
 const version = "v1.0.0"
@@ -151,6 +155,8 @@ func getProfile(name string) (framework.Profile, error) {
 		return multiendpoint.NewProfile(), nil
 	case "authz-rbac":
 		return authzrbac.NewProfile(), nil
+	case "rag-llama-stack":
+		return ragllamastack.NewProfile(), nil
 	default:
 		return nil, fmt.Errorf("unknown profile: %s", name)
 	}

--- a/e2e/profiles/rag-llama-stack/manifests/llama-stack.yaml
+++ b/e2e/profiles/rag-llama-stack/manifests/llama-stack.yaml
@@ -1,0 +1,74 @@
+---
+# Llama Stack Namespace (must be created before Deployment and Service)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llama-stack-system
+---
+# Llama Stack Deployment for E2E testing
+# Provides vector store backend via OpenAI-compatible REST API
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-stack
+  namespace: llama-stack-system
+  labels:
+    app: llama-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llama-stack
+  template:
+    metadata:
+      labels:
+        app: llama-stack
+    spec:
+      # Disable Kubernetes service-link env vars to prevent collision:
+      # K8s auto-injects LLAMA_STACK_PORT=tcp://... for the Service,
+      # but the Llama Stack CLI expects LLAMA_STACK_PORT to be an integer.
+      enableServiceLinks: false
+      containers:
+        - name: llama-stack
+          image: llamastack/distribution-starter:0.5.0
+          args: ["--port", "8321"]
+          ports:
+            - containerPort: 8321
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: 8321
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: 8321
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-stack
+  namespace: llama-stack-system
+  labels:
+    app: llama-stack
+spec:
+  type: ClusterIP
+  selector:
+    app: llama-stack
+  ports:
+    - port: 8321
+      targetPort: 8321
+      protocol: TCP
+      name: http

--- a/e2e/profiles/rag-llama-stack/profile.go
+++ b/e2e/profiles/rag-llama-stack/profile.go
@@ -1,0 +1,318 @@
+package ragllamastack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helm"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+
+	// Import testcases package to register all test cases via their init() functions
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
+)
+
+const (
+	// Chart and file path constants
+	chartPathSemanticRouter = "deploy/helm/semantic-router"
+	valuesFile              = "e2e/profiles/rag-llama-stack/values.yaml"
+	llamaStackManifest      = "e2e/profiles/rag-llama-stack/manifests/llama-stack.yaml"
+
+	// Timeout constants
+	timeoutSemanticRouterInstall = "30m"
+	timeoutDeploymentWait        = 30 * time.Minute
+	timeoutLlamaStackReady       = 10 * time.Minute
+	intervalServiceRetry         = 5 * time.Second
+	timeoutHTTPRequest           = 60 * time.Second
+	delayPortForwardReady        = 2 * time.Second
+
+	// Image constants
+	imageRepository = "ghcr.io/vllm-project/semantic-router/extproc"
+	imagePullPolicy = "Never"
+	llamaStackImage = "llamastack/distribution-starter:0.5.0"
+
+	// Namespace constants
+	namespaceSemanticRouter = "vllm-semantic-router-system"
+)
+
+// Profile implements the RAG with Llama Stack test profile
+type Profile struct {
+	verbose bool
+}
+
+// NewProfile creates a new RAG Llama Stack profile
+func NewProfile() *Profile {
+	return &Profile{}
+}
+
+// Name returns the profile name
+func (p *Profile) Name() string {
+	return "rag-llama-stack"
+}
+
+// Description returns the profile description
+func (p *Profile) Description() string {
+	return "Tests RAG vector store pipeline with Llama Stack backend"
+}
+
+// Setup deploys all required components for RAG Llama Stack testing.
+// This profile does not deploy Envoy Gateway because the rag-vectorstore
+// test connects directly to the Semantic Router API server (port 8080).
+func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error {
+	p.verbose = opts.Verbose
+	p.log("Setting up RAG Llama Stack test environment")
+
+	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+
+	// Step 1: Deploy Llama Stack
+	p.log("Step 1/3: Deploying Llama Stack")
+	if err := p.deployLlamaStack(ctx, opts); err != nil {
+		return fmt.Errorf("failed to deploy llama stack: %w", err)
+	}
+
+	// Step 2: Deploy Semantic Router
+	p.log("Step 2/3: Deploying Semantic Router")
+	if err := p.deploySemanticRouter(ctx, deployer, opts); err != nil {
+		return fmt.Errorf("failed to deploy semantic router: %w", err)
+	}
+
+	// Step 3: Verify all components are ready
+	p.log("Step 3/3: Verifying all components are ready")
+	if err := p.verifyEnvironment(ctx, opts); err != nil {
+		return fmt.Errorf("failed to verify environment: %w", err)
+	}
+
+	p.log("RAG Llama Stack test environment setup complete")
+	return nil
+}
+
+// Teardown cleans up all deployed resources
+func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions) error {
+	p.verbose = opts.Verbose
+	p.log("Tearing down RAG Llama Stack test environment")
+
+	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+
+	// Clean up in reverse order
+	p.log("Uninstalling Semantic Router")
+	deployer.Uninstall(ctx, "semantic-router", namespaceSemanticRouter)
+
+	p.log("Removing Llama Stack")
+	p.kubectlDelete(ctx, opts.KubeConfig, llamaStackManifest)
+
+	p.log("RAG Llama Stack test environment teardown complete")
+	return nil
+}
+
+// GetTestCases returns the list of test cases for this profile
+func (p *Profile) GetTestCases() []string {
+	return []string{
+		"rag-vectorstore",
+	}
+}
+
+// GetServiceConfig returns the service configuration for accessing the deployed service.
+func (p *Profile) GetServiceConfig() framework.ServiceConfig {
+	return framework.ServiceConfig{
+		Name:        "semantic-router",
+		Namespace:   namespaceSemanticRouter,
+		PortMapping: "8080:8080",
+	}
+}
+
+func (p *Profile) deployLlamaStack(ctx context.Context, opts *framework.SetupOptions) error {
+	// Pre-pull Llama Stack image and load into Kind cluster to avoid
+	// slow or failing image pulls from within the cluster nodes
+	p.log("Pulling Llama Stack image: %s", llamaStackImage)
+	pullCmd := exec.CommandContext(ctx, "docker", "pull", llamaStackImage)
+	if p.verbose {
+		pullCmd.Stdout = os.Stdout
+		pullCmd.Stderr = os.Stderr
+	}
+	if err := pullCmd.Run(); err != nil {
+		return fmt.Errorf("failed to pull llama stack image: %w", err)
+	}
+
+	p.log("Loading Llama Stack image into Kind cluster: %s", opts.ClusterName)
+	loadCmd := exec.CommandContext(ctx, "kind", "load", "docker-image", llamaStackImage, "--name", opts.ClusterName)
+	if p.verbose {
+		loadCmd.Stdout = os.Stdout
+		loadCmd.Stderr = os.Stderr
+	}
+	if err := loadCmd.Run(); err != nil {
+		return fmt.Errorf("failed to load llama stack image to Kind: %w", err)
+	}
+
+	// Apply Llama Stack Kubernetes manifests
+	if err := p.kubectlApply(ctx, opts.KubeConfig, llamaStackManifest); err != nil {
+		return fmt.Errorf("failed to apply llama stack manifests: %w", err)
+	}
+
+	// Wait for Llama Stack deployment to be ready
+	config, err := clientcmd.BuildConfigFromFlags("", opts.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	startTime := time.Now()
+	for {
+		if err := helpers.CheckDeployment(ctx, client, "llama-stack-system", "llama-stack", p.verbose); err == nil {
+			break
+		}
+		if time.Since(startTime) >= timeoutLlamaStackReady {
+			return fmt.Errorf("llama stack deployment not ready after %v", timeoutLlamaStackReady)
+		}
+
+		p.log("Llama Stack not ready, retrying in %v...", intervalServiceRetry)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(intervalServiceRetry):
+		}
+	}
+
+	// Register embedding model via port-forward
+	p.log("Registering embedding model in Llama Stack")
+	if err := p.registerEmbeddingModel(ctx, opts); err != nil {
+		p.log("Warning: failed to register embedding model: %v", err)
+		// Don't fail — model may already be registered
+	}
+
+	return nil
+}
+
+func (p *Profile) registerEmbeddingModel(ctx context.Context, opts *framework.SetupOptions) error {
+	// Port-forward to Llama Stack to register the model
+	cmd := exec.CommandContext(ctx, "kubectl",
+		"--kubeconfig", opts.KubeConfig,
+		"port-forward", "-n", "llama-stack-system", "svc/llama-stack", "18321:8321")
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start port-forward: %w", err)
+	}
+	defer func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill() //nolint:errcheck
+		}
+		cmd.Wait() //nolint:errcheck
+	}()
+
+	// Wait for port-forward to be ready
+	time.Sleep(delayPortForwardReady)
+
+	// Register the embedding model
+	body, err := json.Marshal(map[string]interface{}{
+		"model_id":    "all-MiniLM-L6-v2",
+		"provider_id": "sentence-transformers",
+		"model_type":  "embedding",
+		"metadata":    map[string]interface{}{"embedding_dimension": 384},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal model registration body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "http://localhost:18321/v1/models", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	httpClient := &http.Client{Timeout: timeoutHTTPRequest}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusConflict {
+		p.log("Embedding model registered successfully")
+		return nil
+	}
+
+	return fmt.Errorf("unexpected status %d when registering model", resp.StatusCode)
+}
+
+func (p *Profile) deploySemanticRouter(ctx context.Context, deployer *helm.Deployer, opts *framework.SetupOptions) error {
+	installOpts := helm.InstallOptions{
+		ReleaseName: "semantic-router",
+		Chart:       chartPathSemanticRouter,
+		Namespace:   namespaceSemanticRouter,
+		ValuesFiles: []string{valuesFile},
+		Set: map[string]string{
+			"image.repository": imageRepository,
+			"image.tag":        opts.ImageTag,
+			"image.pullPolicy": imagePullPolicy,
+		},
+		Wait:    true,
+		Timeout: timeoutSemanticRouterInstall,
+	}
+
+	if err := deployer.Install(ctx, installOpts); err != nil {
+		return err
+	}
+
+	return deployer.WaitForDeployment(ctx, namespaceSemanticRouter, "semantic-router", timeoutDeploymentWait)
+}
+
+func (p *Profile) verifyEnvironment(ctx context.Context, opts *framework.SetupOptions) error {
+	config, err := clientcmd.BuildConfigFromFlags("", opts.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	p.log("Verifying all deployments are healthy...")
+
+	if err := helpers.CheckDeployment(ctx, client, "llama-stack-system", "llama-stack", p.verbose); err != nil {
+		return fmt.Errorf("llama-stack deployment not healthy: %w", err)
+	}
+
+	if err := helpers.CheckDeployment(ctx, client, namespaceSemanticRouter, "semantic-router", p.verbose); err != nil {
+		return fmt.Errorf("semantic-router deployment not healthy: %w", err)
+	}
+
+	p.log("All deployments are healthy")
+	return nil
+}
+
+func (p *Profile) kubectlApply(ctx context.Context, kubeConfig, manifest string) error {
+	return p.runKubectl(ctx, kubeConfig, "apply", "-f", manifest)
+}
+
+func (p *Profile) kubectlDelete(ctx context.Context, kubeConfig, manifest string) error {
+	return p.runKubectl(ctx, kubeConfig, "delete", "--ignore-not-found", "-f", manifest)
+}
+
+func (p *Profile) runKubectl(ctx context.Context, kubeConfig string, args ...string) error {
+	args = append(args, "--kubeconfig", kubeConfig)
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	if p.verbose {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	return cmd.Run()
+}
+
+func (p *Profile) log(format string, args ...interface{}) {
+	if p.verbose {
+		fmt.Printf("[RAG-Llama-Stack] "+format+"\n", args...)
+	}
+}

--- a/e2e/profiles/rag-llama-stack/values.yaml
+++ b/e2e/profiles/rag-llama-stack/values.yaml
@@ -1,0 +1,77 @@
+# Semantic Router Configuration for RAG with Llama Stack E2E Tests
+config:
+  bert_model:
+    model_id: models/mom-embedding-light
+    threshold: 0.6
+    use_cpu: true
+
+  # Embedding models for vector store ingestion
+  embedding_models:
+    mmbert_model_path: "models/mom-embedding-ultra"
+    use_cpu: true
+
+  # Vector Store with Llama Stack backend
+  vector_store:
+    enabled: true
+    backend_type: "llama_stack"
+    file_storage_dir: "/tmp/vsr-data"
+    max_file_size_mb: 50
+    embedding_model: "mmbert"
+    embedding_dimension: 384
+    ingestion_workers: 2
+    supported_formats:
+      - ".txt"
+      - ".md"
+    llama_stack:
+      endpoint: "http://llama-stack.llama-stack-system.svc.cluster.local:8321"
+      embedding_model: "sentence-transformers/all-MiniLM-L6-v2"
+      request_timeout_seconds: 120
+
+  # Minimal decision config for E2E
+  model_config:
+    "base-model":
+      reasoning_family: "qwen3"
+      loras:
+        - name: "general-expert"
+          description: "General-purpose adapter"
+
+  categories:
+    - name: other
+      description: "General knowledge and miscellaneous topics"
+
+  decisions:
+    - name: other_decision
+      description: "General knowledge and miscellaneous topics"
+      priority: 1
+      rules:
+        operator: "OR"
+        conditions:
+          - type: "domain"
+            name: "other"
+      modelRefs:
+        - model: base-model
+          lora_name: general-expert
+          use_reasoning: false
+
+  strategy: "priority"
+  default_model: general-expert
+
+  semantic_cache:
+    enabled: false
+
+  classifier:
+    category_model:
+      model_id: "models/mom-domain-classifier"
+      use_modernbert: true
+      threshold: 0.6
+      use_cpu: true
+      category_mapping_path: "models/mom-domain-classifier/category_mapping.json"
+    pii_model:
+      model_id: "models/mom-pii-classifier"
+      use_modernbert: false
+      threshold: 0.9
+      use_cpu: true
+      pii_mapping_path: "models/mom-pii-classifier/pii_type_mapping.json"
+
+  prompt_guard:
+    enabled: false

--- a/src/semantic-router/pkg/extproc/req_filter_rag_vectorstore.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_vectorstore.go
@@ -75,10 +75,13 @@ func (r *OpenAIRouter) retrieveFromVectorStore(traceCtx context.Context, ctx *Re
 	}
 
 	// Build filter.
-	var filter map[string]interface{}
+	// Llama Stack searches by text, not embedding. Pass the query text via
+	// the filter map so it can use it.
+	filter := map[string]interface{}{
+		"_query_text": query,
+	}
 	if len(vsConfig.FileIDs) > 0 {
-		// If specific file IDs are configured, filter to those.
-		filter = map[string]interface{}{"file_id": vsConfig.FileIDs[0]}
+		filter["file_id"] = vsConfig.FileIDs[0]
 	}
 
 	// Search.

--- a/src/semantic-router/pkg/vectorstore/config_test.go
+++ b/src/semantic-router/pkg/vectorstore/config_test.go
@@ -69,7 +69,7 @@ var _ = Describe("VectorStoreConfig", func() {
 			}
 			err := cfg.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("must be 'memory' or 'milvus'"))
+			Expect(err.Error()).To(ContainSubstring("must be 'memory', 'milvus', or 'llama_stack'"))
 		})
 	})
 

--- a/src/semantic-router/pkg/vectorstore/factory.go
+++ b/src/semantic-router/pkg/vectorstore/factory.go
@@ -20,19 +20,31 @@ import "fmt"
 
 // BackendType constants for selecting a vector store backend.
 const (
-	BackendTypeMemory = "memory"
-	BackendTypeMilvus = "milvus"
+	BackendTypeMemory     = "memory"
+	BackendTypeMilvus     = "milvus"
+	BackendTypeLlamaStack = "llama_stack"
 )
 
+// BackendConfigs aggregates configuration for all supported backends.
+// Only the config matching the selected backendType is used; others are ignored.
+type BackendConfigs struct {
+	Memory     MemoryBackendConfig
+	Milvus     MilvusBackendConfig
+	LlamaStack LlamaStackBackendConfig
+}
+
 // NewBackend creates a VectorStoreBackend based on the given type.
-// For "memory", milvusCfg is ignored. For "milvus", memoryCfg is ignored.
-func NewBackend(backendType string, memoryCfg MemoryBackendConfig, milvusCfg MilvusBackendConfig) (VectorStoreBackend, error) {
+// Only the config field matching backendType is used; others are ignored.
+func NewBackend(backendType string, cfgs BackendConfigs) (VectorStoreBackend, error) {
 	switch backendType {
 	case BackendTypeMemory:
-		return NewMemoryBackend(memoryCfg), nil
+		return NewMemoryBackend(cfgs.Memory), nil
 	case BackendTypeMilvus:
-		return NewMilvusBackend(milvusCfg)
+		return NewMilvusBackend(cfgs.Milvus)
+	case BackendTypeLlamaStack:
+		return NewLlamaStackBackend(cfgs.LlamaStack)
 	default:
-		return nil, fmt.Errorf("unsupported backend type: %s (supported: %s, %s)", backendType, BackendTypeMemory, BackendTypeMilvus)
+		return nil, fmt.Errorf("unsupported backend type: %s (supported: %s, %s, %s)",
+			backendType, BackendTypeMemory, BackendTypeMilvus, BackendTypeLlamaStack)
 	}
 }

--- a/src/semantic-router/pkg/vectorstore/llama_stack_backend.go
+++ b/src/semantic-router/pkg/vectorstore/llama_stack_backend.go
@@ -1,0 +1,468 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vectorstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// LlamaStackBackendConfig holds configuration for the Llama Stack backend.
+type LlamaStackBackendConfig struct {
+	// Endpoint is the base URL of the Llama Stack server (e.g. "http://localhost:8321").
+	Endpoint string
+
+	// AuthToken is an optional bearer token for authentication.
+	AuthToken string
+
+	// EmbeddingModel is the embedding model registered in Llama Stack.
+	// Llama Stack uses this model to embed chunks and queries internally.
+	// If empty, Llama Stack uses its configured default model.
+	EmbeddingModel string
+
+	// EmbeddingDimension is the embedding dimension to pass when creating
+	// vector stores. If 0, Llama Stack auto-detects from the model.
+	EmbeddingDimension int
+
+	// RequestTimeoutSeconds is the HTTP timeout. Default: 30.
+	RequestTimeoutSeconds int
+}
+
+// LlamaStackBackend implements VectorStoreBackend by delegating to a
+// locally-running Llama Stack instance via its REST API.
+//
+// Design note: Llama Stack's OpenAI-compatible API generates its own vector
+// store IDs (e.g. "vs_abc123") rather than using the name we pass during
+// creation. This backend maintains an in-memory name→ID mapping (storeIDs)
+// that is populated on CreateCollection and lazily refreshed via the list API
+// when a name isn't cached (e.g. after a process restart).
+//
+// For InsertChunks, we send the pre-computed embeddings from EmbeddedChunk
+// to the vector-io/insert API. For Search, we use the query text passed via
+// the filter map ("_query_text" key) since Llama Stack's search endpoint
+// operates on text queries, not embedding vectors.
+type LlamaStackBackend struct {
+	endpoint       string
+	authToken      string
+	embeddingModel string
+	embeddingDim   int
+	httpClient     *http.Client
+
+	// storeIDs maps our vectorStoreID (name) to Llama Stack's generated ID.
+	storeIDs map[string]string
+	mu       sync.RWMutex
+}
+
+// NewLlamaStackBackend creates a new Llama Stack vector store backend.
+func NewLlamaStackBackend(cfg LlamaStackBackendConfig) (*LlamaStackBackend, error) {
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("llama stack endpoint is required")
+	}
+
+	// Strip trailing slash to avoid double-slash in URLs.
+	endpoint := strings.TrimRight(cfg.Endpoint, "/")
+
+	timeout := cfg.RequestTimeoutSeconds
+	if timeout <= 0 {
+		timeout = 30
+	}
+
+	return &LlamaStackBackend{
+		endpoint:       endpoint,
+		authToken:      cfg.AuthToken,
+		embeddingModel: cfg.EmbeddingModel,
+		embeddingDim:   cfg.EmbeddingDimension,
+		httpClient: &http.Client{
+			Timeout: time.Duration(timeout) * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		storeIDs: make(map[string]string),
+	}, nil
+}
+
+// CreateCollection creates a new vector store in Llama Stack.
+// Maps to: POST /v1/vector_stores
+//
+// The response contains a generated ID (e.g. "vs_abc123") which is cached
+// in the storeIDs map for use by all subsequent operations.
+func (l *LlamaStackBackend) CreateCollection(ctx context.Context, vectorStoreID string, dimension int) error {
+	body := map[string]interface{}{
+		"name": vectorStoreID,
+	}
+
+	if l.embeddingModel != "" {
+		body["embedding_model"] = l.embeddingModel
+	}
+	dim := dimension
+	if dim <= 0 {
+		dim = l.embeddingDim
+	}
+	if dim > 0 {
+		body["embedding_dimension"] = dim
+	}
+
+	resp, err := l.doRequest(ctx, http.MethodPost, "/v1/vector_stores", body)
+	if err != nil {
+		return fmt.Errorf("failed to create vector store %s in Llama Stack: %w", vectorStoreID, err)
+	}
+
+	// Parse the generated ID from the response and cache the name→ID mapping.
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return fmt.Errorf("failed to parse create response for vector store %s: %w", vectorStoreID, err)
+	}
+	if result.ID == "" {
+		return fmt.Errorf("llama stack returned empty ID for vector store %s", vectorStoreID)
+	}
+
+	l.mu.Lock()
+	l.storeIDs[vectorStoreID] = result.ID
+	l.mu.Unlock()
+
+	logging.Infof("Llama Stack vector store created: id=%s, name=%s", result.ID, vectorStoreID)
+	return nil
+}
+
+// DeleteCollection deletes a vector store from Llama Stack.
+// Maps to: DELETE /v1/vector_stores/{vector_store_id}
+func (l *LlamaStackBackend) DeleteCollection(ctx context.Context, vectorStoreID string) error {
+	storeID, err := l.resolveStoreID(ctx, vectorStoreID)
+	if err != nil {
+		// If the store doesn't exist, treat as a no-op for idempotency.
+		if strings.Contains(err.Error(), "not found") {
+			return nil
+		}
+		return fmt.Errorf("failed to resolve vector store %s: %w", vectorStoreID, err)
+	}
+
+	_, err = l.doRequest(ctx, http.MethodDelete, "/v1/vector_stores/"+storeID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete vector store %s from Llama Stack: %w", vectorStoreID, err)
+	}
+
+	// Remove from cache after successful deletion.
+	l.mu.Lock()
+	delete(l.storeIDs, vectorStoreID)
+	l.mu.Unlock()
+
+	return nil
+}
+
+// CollectionExists checks whether a vector store is registered in Llama Stack.
+// Maps to: GET /v1/vector_stores/{vector_store_id}
+func (l *LlamaStackBackend) CollectionExists(ctx context.Context, vectorStoreID string) (bool, error) {
+	storeID, err := l.resolveStoreID(ctx, vectorStoreID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check vector store %s in Llama Stack: %w", vectorStoreID, err)
+	}
+
+	_, err = l.doRequest(ctx, http.MethodGet, "/v1/vector_stores/"+storeID, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "status 404") || strings.Contains(err.Error(), "status 400") {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check vector store %s in Llama Stack: %w", vectorStoreID, err)
+	}
+	return true, nil
+}
+
+// InsertChunks inserts pre-embedded chunks into a Llama Stack vector store.
+// Maps to: POST /v1/vector-io/insert
+//
+// Each chunk must include a pre-computed embedding (EmbeddedChunk.Embedding).
+func (l *LlamaStackBackend) InsertChunks(ctx context.Context, vectorStoreID string, chunks []EmbeddedChunk) error {
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	storeID, err := l.resolveStoreID(ctx, vectorStoreID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve vector store %s for insert: %w", vectorStoreID, err)
+	}
+
+	// Build chunks in Llama Stack v0.5 format: content, chunk_id,
+	// chunk_metadata, embedding, embedding_model, embedding_dimension.
+	lsChunks := make([]map[string]interface{}, len(chunks))
+	for i, c := range chunks {
+		embDim := len(c.Embedding)
+		if embDim == 0 {
+			embDim = l.embeddingDim
+		}
+
+		// Convert []float32 to []float64 for JSON serialization consistency.
+		embedding := make([]float64, len(c.Embedding))
+		for j, v := range c.Embedding {
+			embedding[j] = float64(v)
+		}
+
+		lsChunks[i] = map[string]interface{}{
+			"content":  c.Content,
+			"chunk_id": c.ID,
+			"chunk_metadata": map[string]interface{}{
+				"document_id": c.ID,
+				"source":      c.Filename,
+			},
+			"metadata": map[string]interface{}{
+				"file_id":     c.FileID,
+				"filename":    c.Filename,
+				"chunk_index": c.ChunkIndex,
+			},
+			"embedding":           embedding,
+			"embedding_model":     l.embeddingModel,
+			"embedding_dimension": embDim,
+		}
+	}
+
+	body := map[string]interface{}{
+		"vector_store_id": storeID,
+		"chunks":          lsChunks,
+	}
+
+	_, err = l.doRequest(ctx, http.MethodPost, "/v1/vector-io/insert", body)
+	if err != nil {
+		return fmt.Errorf("failed to insert %d chunks into vector store %s in Llama Stack: %w",
+			len(chunks), vectorStoreID, err)
+	}
+
+	logging.Debugf("Inserted %d chunks into Llama Stack vector store %s (id=%s)", len(chunks), vectorStoreID, storeID)
+	return nil
+}
+
+// DeleteByFileID removes all chunks belonging to a file from the vector store.
+// Maps to: DELETE /v1/vector_stores/{vector_store_id}/files/{file_id}
+func (l *LlamaStackBackend) DeleteByFileID(ctx context.Context, vectorStoreID string, fileID string) error {
+	storeID, err := l.resolveStoreID(ctx, vectorStoreID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			logging.Warnf("Vector store %s not found in Llama Stack, nothing to delete", vectorStoreID)
+			return nil
+		}
+		return fmt.Errorf("failed to resolve vector store %s for file deletion: %w", vectorStoreID, err)
+	}
+
+	path := fmt.Sprintf("/v1/vector_stores/%s/files/%s", storeID, fileID)
+	_, err = l.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "status 404") {
+			logging.Warnf("File %s not found in Llama Stack vector store %s (may already be deleted)", fileID, vectorStoreID)
+			return nil
+		}
+		return fmt.Errorf("failed to delete file %s from vector store %s in Llama Stack: %w",
+			fileID, vectorStoreID, err)
+	}
+	return nil
+}
+
+// Search performs a text-based similarity search in a Llama Stack vector store.
+// Maps to: POST /v1/vector_stores/{vector_store_id}/search
+//
+// Llama Stack searches by text query, not by embedding vector. The query text
+// must be passed via filter["_query_text"]; the queryEmbedding param is ignored.
+func (l *LlamaStackBackend) Search(
+	ctx context.Context, vectorStoreID string, queryEmbedding []float32,
+	topK int, threshold float32, filter map[string]interface{},
+) ([]SearchResult, error) {
+	queryText, ok := filter["_query_text"].(string)
+	if !ok || queryText == "" {
+		return nil, fmt.Errorf(
+			"llama_stack backend requires '_query_text' in the filter map for search; " +
+				"Llama Stack searches by text query, not by embedding vector")
+	}
+
+	storeID, err := l.resolveStoreID(ctx, vectorStoreID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve vector store %s for search: %w", vectorStoreID, err)
+	}
+
+	body := map[string]interface{}{
+		"query":           queryText,
+		"max_num_results": topK,
+	}
+
+	if fid, ok := filter["file_id"].(string); ok && fid != "" {
+		body["filters"] = map[string]interface{}{
+			"type":  "eq",
+			"key":   "file_id",
+			"value": fid,
+		}
+	}
+
+	path := fmt.Sprintf("/v1/vector_stores/%s/search", storeID)
+	resp, err := l.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search vector store %s in Llama Stack: %w", vectorStoreID, err)
+	}
+
+	var searchResp struct {
+		Data []struct {
+			Content  []map[string]interface{} `json:"content"`
+			FileID   string                   `json:"file_id"`
+			Filename string                   `json:"filename"`
+			Score    float64                  `json:"score"`
+		} `json:"data"`
+	}
+	if jsonErr := json.Unmarshal(resp, &searchResp); jsonErr != nil {
+		return nil, fmt.Errorf("failed to parse Llama Stack search response: %w", jsonErr)
+	}
+
+	var results []SearchResult
+	for _, hit := range searchResp.Data {
+		if float32(hit.Score) < threshold {
+			continue
+		}
+
+		// Llama Stack returns content as [{type: "text", text: "..."}].
+		content := ""
+		for _, c := range hit.Content {
+			if c["type"] == "text" {
+				if text, ok := c["text"].(string); ok {
+					content = text
+					break
+				}
+			}
+		}
+
+		results = append(results, SearchResult{
+			FileID:   hit.FileID,
+			Filename: hit.Filename,
+			Content:  content,
+			Score:    hit.Score,
+		})
+	}
+
+	return results, nil
+}
+
+// Close releases HTTP client resources.
+func (l *LlamaStackBackend) Close() error {
+	l.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// resolveStoreID maps a vectorStoreID (name) to Llama Stack's generated ID.
+// Checks the in-memory cache first, then falls back to listing all stores
+// via the API (handles process restarts where the cache is empty).
+func (l *LlamaStackBackend) resolveStoreID(ctx context.Context, name string) (string, error) {
+	l.mu.RLock()
+	if id, ok := l.storeIDs[name]; ok {
+		l.mu.RUnlock()
+		return id, nil
+	}
+	l.mu.RUnlock()
+
+	// Cache miss — list all vector stores and find by name.
+	resp, err := l.doRequest(ctx, http.MethodGet, "/v1/vector_stores", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to list vector stores while resolving %q: %w", name, err)
+	}
+
+	var listResp struct {
+		Data []struct {
+			ID        string `json:"id"`
+			Name      string `json:"name"`
+			CreatedAt int64  `json:"created_at"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &listResp); err != nil {
+		return "", fmt.Errorf("failed to parse vector store list: %w", err)
+	}
+
+	// Find the most recently created store with the matching name.
+	var bestID string
+	var bestTime int64
+	for _, s := range listResp.Data {
+		if s.Name == name && s.CreatedAt >= bestTime {
+			bestID = s.ID
+			bestTime = s.CreatedAt
+		}
+	}
+
+	if bestID == "" {
+		return "", fmt.Errorf("vector store %q not found in Llama Stack", name)
+	}
+
+	l.mu.Lock()
+	l.storeIDs[name] = bestID
+	l.mu.Unlock()
+
+	return bestID, nil
+}
+
+// doRequest is the shared HTTP helper for all Llama Stack API calls.
+func (l *LlamaStackBackend) doRequest(
+	ctx context.Context, method, path string, body interface{},
+) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonBytes, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonBytes)
+	}
+
+	url := l.endpoint + path
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if l.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+l.authToken)
+	}
+
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request to Llama Stack failed (%s %s): %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Llama Stack response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errMsg := string(respBody)
+		if len(errMsg) > 500 {
+			errMsg = errMsg[:500] + "..."
+		}
+		return nil, fmt.Errorf("llama stack API error: %s %s returned status %d: %s",
+			method, path, resp.StatusCode, errMsg)
+	}
+
+	return respBody, nil
+}

--- a/src/semantic-router/pkg/vectorstore/llama_stack_backend_test.go
+++ b/src/semantic-router/pkg/vectorstore/llama_stack_backend_test.go
@@ -1,0 +1,1128 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vectorstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Compile-time interface check.
+var _ VectorStoreBackend = (*LlamaStackBackend)(nil)
+
+var _ = Describe("LlamaStackBackend", func() {
+	Context("NewLlamaStackBackend (constructor)", func() {
+		It("should create backend with valid config", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint: "http://localhost:8321",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(b).NotTo(BeNil())
+			Expect(b.endpoint).To(Equal("http://localhost:8321"))
+			Expect(b.storeIDs).NotTo(BeNil())
+		})
+
+		It("should fail when endpoint is empty", func() {
+			_, err := NewLlamaStackBackend(LlamaStackBackendConfig{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("endpoint is required"))
+		})
+
+		It("should strip trailing slash from endpoint", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint: "http://localhost:8321/",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(b.endpoint).To(Equal("http://localhost:8321"))
+		})
+
+		It("should use default timeout of 30 seconds when not specified", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint: "http://localhost:8321",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(b.httpClient.Timeout.Seconds()).To(Equal(30.0))
+		})
+
+		It("should use custom timeout when specified", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:              "http://localhost:8321",
+				RequestTimeoutSeconds: 60,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(b.httpClient.Timeout.Seconds()).To(Equal(60.0))
+		})
+
+		It("should store embedding model and dimension", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:           "http://localhost:8321",
+				EmbeddingModel:     "all-MiniLM-L6-v2",
+				EmbeddingDimension: 384,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(b.embeddingModel).To(Equal("all-MiniLM-L6-v2"))
+			Expect(b.embeddingDim).To(Equal(384))
+		})
+	})
+
+	Context("CreateCollection", func() {
+		It("should POST to /v1/vector_stores and cache the generated ID", func() {
+			var receivedBody map[string]interface{}
+			var receivedMethod, receivedPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedMethod = r.Method
+				receivedPath = r.URL.Path
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id": "vs_gen_abc123", "name": "my-store"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:           server.URL,
+				EmbeddingModel:     "all-MiniLM-L6-v2",
+				EmbeddingDimension: 384,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.CreateCollection(context.Background(), "my-store", 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedMethod).To(Equal("POST"))
+			Expect(receivedPath).To(Equal("/v1/vector_stores"))
+			Expect(receivedBody["name"]).To(Equal("my-store"))
+			Expect(receivedBody["embedding_model"]).To(Equal("all-MiniLM-L6-v2"))
+			Expect(receivedBody["embedding_dimension"]).To(BeNumerically("==", 384))
+
+			// Verify the generated ID was cached.
+			Expect(b.storeIDs["my-store"]).To(Equal("vs_gen_abc123"))
+		})
+
+		It("should prefer passed dimension over config dimension", func() {
+			var receivedBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id": "vs_gen_abc123"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:           server.URL,
+				EmbeddingDimension: 384,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.CreateCollection(context.Background(), "my-store", 768)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody["embedding_dimension"]).To(BeNumerically("==", 768))
+		})
+
+		It("should not include embedding fields when not configured", func() {
+			var receivedBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id": "vs_gen_abc123"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.CreateCollection(context.Background(), "my-store", 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedBody).NotTo(HaveKey("embedding_model"))
+			Expect(receivedBody).NotTo(HaveKey("embedding_dimension"))
+		})
+
+		It("should return error on server failure", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error": "db unavailable"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.CreateCollection(context.Background(), "my-store", 768)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to create vector store"))
+		})
+
+		It("should return error when response has empty ID", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"name": "my-store"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.CreateCollection(context.Background(), "my-store", 768)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("empty ID"))
+		})
+	})
+
+	Context("resolveStoreID", func() {
+		It("should return cached ID when available", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: "http://unused"})
+			Expect(err).NotTo(HaveOccurred())
+
+			b.storeIDs["my-store"] = "vs_cached_123"
+
+			id, err := b.resolveStoreID(context.Background(), "my-store")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal("vs_cached_123"))
+		})
+
+		It("should list stores and resolve by name on cache miss", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "GET" && r.URL.Path == "/v1/vector_stores" {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{
+						"data": [
+							{"id": "vs_older", "name": "my-store", "created_at": 100},
+							{"id": "vs_newer", "name": "my-store", "created_at": 200},
+							{"id": "vs_other", "name": "other-store", "created_at": 300}
+						]
+					}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			id, err := b.resolveStoreID(context.Background(), "my-store")
+			Expect(err).NotTo(HaveOccurred())
+			// Should pick the newest one (created_at=200).
+			Expect(id).To(Equal("vs_newer"))
+			// Should be cached now.
+			Expect(b.storeIDs["my-store"]).To(Equal("vs_newer"))
+		})
+
+		It("should return error when store name not found in list", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = b.resolveStoreID(context.Background(), "nonexistent")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+
+	Context("DeleteCollection", func() {
+		It("should resolve the store ID and send DELETE", func() {
+			var receivedMethod, receivedPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedMethod = r.Method
+				receivedPath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			err = b.DeleteCollection(context.Background(), "my-store")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedMethod).To(Equal("DELETE"))
+			Expect(receivedPath).To(Equal("/v1/vector_stores/vs_gen_abc123"))
+
+			// Cache should be cleared after delete.
+			_, cached := b.storeIDs["my-store"]
+			Expect(cached).To(BeFalse())
+		})
+
+		It("should treat missing store as no-op", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// List returns empty — store not found.
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.DeleteCollection(context.Background(), "nonexistent")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return error on server failure during delete", func() {
+			callCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if r.Method == "DELETE" {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(`{"error": "internal"}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			err = b.DeleteCollection(context.Background(), "my-store")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to delete vector store"))
+		})
+	})
+
+	Context("CollectionExists", func() {
+		It("should return true when store exists (resolved from cache)", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "GET" && r.URL.Path == "/v1/vector_stores/vs_gen_abc123" {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"id": "vs_gen_abc123"}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			exists, err := b.CollectionExists(context.Background(), "my-store")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+		})
+
+		It("should return false when store not found (resolve fails)", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// List returns empty.
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			exists, err := b.CollectionExists(context.Background(), "nonexistent")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should return false when GET returns 404", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v1/vector_stores/vs_gen_abc123" {
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"error": "not found"}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			exists, err := b.CollectionExists(context.Background(), "my-store")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should return false when GET returns 400 (Llama Stack not-found variant)", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v1/vector_stores/vs_gen_abc123" {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(`{"error": {"detail": "Vector_store not found"}}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			exists, err := b.CollectionExists(context.Background(), "my-store")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should return error for other server errors", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v1/vector_stores/vs_gen_abc123" {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(`{"error": "db down"}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			_, err = b.CollectionExists(context.Background(), "my-store")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to check vector store"))
+		})
+	})
+
+	Context("InsertChunks", func() {
+		It("should POST to /v1/vector-io/insert with correct body format", func() {
+			var receivedBody map[string]interface{}
+			var receivedPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedPath = r.URL.Path
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:       server.URL,
+				EmbeddingModel: "all-MiniLM-L6-v2",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			chunks := []EmbeddedChunk{
+				{
+					ID:         "c1",
+					FileID:     "file_001",
+					Filename:   "doc.txt",
+					Content:    "hello world",
+					Embedding:  []float32{0.1, 0.2, 0.3},
+					ChunkIndex: 0,
+				},
+			}
+			err = b.InsertChunks(context.Background(), "my-store", chunks)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedPath).To(Equal("/v1/vector-io/insert"))
+			Expect(receivedBody["vector_store_id"]).To(Equal("vs_gen_abc123"))
+
+			receivedChunks := receivedBody["chunks"].([]interface{})
+			Expect(receivedChunks).To(HaveLen(1))
+
+			chunk := receivedChunks[0].(map[string]interface{})
+			Expect(chunk["content"]).To(Equal("hello world"))
+			Expect(chunk["chunk_id"]).To(Equal("c1"))
+			Expect(chunk["embedding_model"]).To(Equal("all-MiniLM-L6-v2"))
+			Expect(chunk["embedding_dimension"]).To(BeNumerically("==", 3))
+
+			embedding := chunk["embedding"].([]interface{})
+			Expect(embedding).To(HaveLen(3))
+			Expect(embedding[0]).To(BeNumerically("~", 0.1, 0.001))
+
+			chunkMeta := chunk["chunk_metadata"].(map[string]interface{})
+			Expect(chunkMeta["document_id"]).To(Equal("c1"))
+
+			meta := chunk["metadata"].(map[string]interface{})
+			Expect(meta["file_id"]).To(Equal("file_001"))
+			Expect(meta["filename"]).To(Equal("doc.txt"))
+			Expect(meta["chunk_index"]).To(BeNumerically("==", 0))
+		})
+
+		It("should send multiple chunks in one request", func() {
+			var receivedBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			chunks := []EmbeddedChunk{
+				{ID: "c1", Content: "first", Embedding: []float32{0.1}},
+				{ID: "c2", Content: "second", Embedding: []float32{0.2}},
+				{ID: "c3", Content: "third", Embedding: []float32{0.3}},
+			}
+			err = b.InsertChunks(context.Background(), "my-store", chunks)
+			Expect(err).NotTo(HaveOccurred())
+
+			receivedChunks := receivedBody["chunks"].([]interface{})
+			Expect(receivedChunks).To(HaveLen(3))
+		})
+
+		It("should skip request when chunks are empty", func() {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.InsertChunks(context.Background(), "my-store", []EmbeddedChunk{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requestCount).To(Equal(0))
+		})
+
+		It("should return error on server failure", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error": "insert failed"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			chunks := []EmbeddedChunk{{ID: "c1", Content: "hello", Embedding: []float32{0.1}}}
+			err = b.InsertChunks(context.Background(), "my-store", chunks)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to insert"))
+		})
+	})
+
+	Context("DeleteByFileID", func() {
+		It("should resolve store ID and send DELETE to correct path", func() {
+			var receivedMethod, receivedPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedMethod = r.Method
+				receivedPath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			err = b.DeleteByFileID(context.Background(), "my-store", "file_001")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedMethod).To(Equal("DELETE"))
+			Expect(receivedPath).To(Equal("/v1/vector_stores/vs_gen_abc123/files/file_001"))
+		})
+
+		It("should treat 404 as success (idempotent)", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error": "not found"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			err = b.DeleteByFileID(context.Background(), "my-store", "file_gone")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should treat missing store as no-op", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.DeleteByFileID(context.Background(), "nonexistent", "file_001")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return error for other server errors", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "DELETE" {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(`{"error": "db error"}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			err = b.DeleteByFileID(context.Background(), "my-store", "file_001")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to delete file"))
+		})
+	})
+
+	Context("Search", func() {
+		It("should resolve store ID and POST to search endpoint", func() {
+			var receivedBody map[string]interface{}
+			var receivedPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedPath = r.URL.Path
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			filter := map[string]interface{}{"_query_text": "what is kubernetes?"}
+			_, err = b.Search(context.Background(), "my-store", nil, 5, 0, filter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedPath).To(Equal("/v1/vector_stores/vs_gen_abc123/search"))
+			Expect(receivedBody["query"]).To(Equal("what is kubernetes?"))
+			Expect(receivedBody["max_num_results"]).To(BeNumerically("==", 5))
+		})
+
+		It("should parse results correctly", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := `{
+					"data": [
+						{
+							"content": [{"type": "text", "text": "Kubernetes is a container orchestrator"}],
+							"file_id": "file_001",
+							"filename": "k8s.txt",
+							"score": 0.95
+						},
+						{
+							"content": [{"type": "text", "text": "Docker runs containers"}],
+							"file_id": "file_002",
+							"filename": "docker.txt",
+							"score": 0.82
+						}
+					]
+				}`
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(resp))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			filter := map[string]interface{}{"_query_text": "what is kubernetes?"}
+			results, err := b.Search(context.Background(), "my-store", nil, 10, 0, filter)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(2))
+
+			Expect(results[0].Content).To(Equal("Kubernetes is a container orchestrator"))
+			Expect(results[0].FileID).To(Equal("file_001"))
+			Expect(results[0].Filename).To(Equal("k8s.txt"))
+			Expect(results[0].Score).To(BeNumerically("~", 0.95, 0.001))
+
+			Expect(results[1].Content).To(Equal("Docker runs containers"))
+			Expect(results[1].Score).To(BeNumerically("~", 0.82, 0.001))
+		})
+
+		It("should apply threshold filtering", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := `{
+					"data": [
+						{"content": [{"type": "text", "text": "high score"}], "score": 0.95},
+						{"content": [{"type": "text", "text": "low score"}], "score": 0.30}
+					]
+				}`
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(resp))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			filter := map[string]interface{}{"_query_text": "test"}
+			results, err := b.Search(context.Background(), "my-store", nil, 10, 0.5, filter)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Content).To(Equal("high score"))
+		})
+
+		It("should fail when _query_text is missing from filter", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: "http://unused"})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = b.Search(context.Background(), "vs_abc123", nil, 5, 0, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("_query_text"))
+		})
+
+		It("should fail when _query_text is empty string", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: "http://unused"})
+			Expect(err).NotTo(HaveOccurred())
+
+			filter := map[string]interface{}{"_query_text": ""}
+			_, err = b.Search(context.Background(), "vs_abc123", nil, 5, 0, filter)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("_query_text"))
+		})
+
+		It("should include file_id filter when provided", func() {
+			var receivedBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			filter := map[string]interface{}{
+				"_query_text": "test",
+				"file_id":     "file_001",
+			}
+			_, err = b.Search(context.Background(), "my-store", nil, 5, 0, filter)
+			Expect(err).NotTo(HaveOccurred())
+
+			filters := receivedBody["filters"].(map[string]interface{})
+			Expect(filters["type"]).To(Equal("eq"))
+			Expect(filters["key"]).To(Equal("file_id"))
+			Expect(filters["value"]).To(Equal("file_001"))
+		})
+
+		It("should not include filters when file_id is not provided", func() {
+			var receivedBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			filter := map[string]interface{}{"_query_text": "test"}
+			_, err = b.Search(context.Background(), "my-store", nil, 5, 0, filter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedBody).NotTo(HaveKey("filters"))
+		})
+
+		It("should handle empty data array", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			filter := map[string]interface{}{"_query_text": "no matches"}
+			results, err := b.Search(context.Background(), "my-store", nil, 5, 0, filter)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+
+		It("should return error on server failure", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error": "search failed"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+			b.storeIDs["my-store"] = "vs_gen_abc123"
+
+			filter := map[string]interface{}{"_query_text": "test"}
+			_, err = b.Search(context.Background(), "my-store", nil, 5, 0, filter)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to search"))
+		})
+	})
+
+	Context("Close", func() {
+		It("should not return an error", func() {
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: "http://localhost:8321"})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("doRequest (HTTP helper via public methods)", func() {
+		It("should add Authorization header when auth token is set", func() {
+			var receivedAuthHeader string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedAuthHeader = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id": "vs_gen_abc123"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:  server.URL,
+				AuthToken: "my-secret-token",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_ = b.CreateCollection(context.Background(), "test", 768)
+			Expect(receivedAuthHeader).To(Equal("Bearer my-secret-token"))
+		})
+
+		It("should not add Authorization header when auth token is empty", func() {
+			var receivedAuthHeader string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedAuthHeader = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id": "vs_gen_abc123"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			_ = b.CreateCollection(context.Background(), "test", 768)
+			Expect(receivedAuthHeader).To(BeEmpty())
+		})
+
+		It("should set Content-Type to application/json", func() {
+			var receivedContentType string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedContentType = r.Header.Get("Content-Type")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id": "vs_gen_abc123"}`))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			_ = b.CreateCollection(context.Background(), "test", 768)
+			Expect(receivedContentType).To(Equal("application/json"))
+		})
+
+		It("should truncate long error messages from server", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(strings.Repeat("x", 1000)))
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{Endpoint: server.URL})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = b.CreateCollection(context.Background(), "test", 768)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("..."))
+		})
+	})
+
+	Context("end-to-end flow with mock server", func() {
+		It("should create, insert, search, and delete through a single mock", func() {
+			var createdID string
+			stores := make(map[string]string) // id -> name
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				// CreateCollection
+				case r.Method == "POST" && r.URL.Path == "/v1/vector_stores":
+					var body map[string]interface{}
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					createdID = fmt.Sprintf("vs_%s", body["name"])
+					stores[createdID] = body["name"].(string)
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintf(w, `{"id": "%s", "name": "%s"}`, createdID, body["name"])
+
+				// ListStores (for resolveStoreID)
+				case r.Method == "GET" && r.URL.Path == "/v1/vector_stores":
+					data := "["
+					i := 0
+					for id, name := range stores {
+						if i > 0 {
+							data += ","
+						}
+						data += fmt.Sprintf(`{"id": "%s", "name": "%s", "created_at": %d}`, id, name, 100+i)
+						i++
+					}
+					data += "]"
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintf(w, `{"data": %s}`, data)
+
+				// CollectionExists
+				case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/v1/vector_stores/"):
+					id := strings.TrimPrefix(r.URL.Path, "/v1/vector_stores/")
+					if _, ok := stores[id]; ok {
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprintf(w, `{"id": "%s"}`, id)
+					} else {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"error": "not found"}`))
+					}
+
+				// InsertChunks
+				case r.Method == "POST" && r.URL.Path == "/v1/vector-io/insert":
+					w.WriteHeader(http.StatusNoContent)
+
+				// Search
+				case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/search"):
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{
+						"data": [
+							{"content": [{"type": "text", "text": "found it"}], "score": 0.9}
+						]
+					}`))
+
+				// DeleteCollection
+				case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/v1/vector_stores/"):
+					id := strings.TrimPrefix(r.URL.Path, "/v1/vector_stores/")
+					delete(stores, id)
+					w.WriteHeader(http.StatusOK)
+
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			b, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:       server.URL,
+				EmbeddingModel: "test-model",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			ctx := context.Background()
+
+			// Create
+			err = b.CreateCollection(ctx, "e2e-store", 384)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Exists
+			exists, err := b.CollectionExists(ctx, "e2e-store")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+
+			// Insert
+			chunks := []EmbeddedChunk{
+				{ID: "c1", Content: "test content", Embedding: []float32{0.1, 0.2}},
+			}
+			err = b.InsertChunks(ctx, "e2e-store", chunks)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Search
+			filter := map[string]interface{}{"_query_text": "test"}
+			results, err := b.Search(ctx, "e2e-store", nil, 5, 0, filter)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Content).To(Equal("found it"))
+
+			// Delete
+			err = b.DeleteCollection(ctx, "e2e-store")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Exists after delete
+			exists, err = b.CollectionExists(ctx, "e2e-store")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+	})
+
+	Context("integration tests (require Llama Stack)", func() {
+		skipLlamaStack := os.Getenv("SKIP_LLAMA_STACK_TESTS") != "false"
+
+		var (
+			endpoint       string
+			embeddingModel string
+		)
+
+		BeforeEach(func() {
+			if skipLlamaStack {
+				Skip("Skipping Llama Stack tests (set SKIP_LLAMA_STACK_TESTS=false to enable)")
+			}
+
+			endpoint = os.Getenv("LLAMA_STACK_ENDPOINT")
+			if endpoint == "" {
+				endpoint = "http://localhost:8321"
+			}
+			embeddingModel = os.Getenv("LLAMA_STACK_EMBEDDING_MODEL")
+			if embeddingModel == "" {
+				embeddingModel = "sentence-transformers/all-MiniLM-L6-v2"
+			}
+		})
+
+		It("should create, check, and delete a collection", func() {
+			backend, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:       endpoint,
+				EmbeddingModel: embeddingModel,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer backend.Close()
+
+			ctx := context.Background()
+			vsID := "test_integration_ls"
+
+			// Clean up in case previous test left data.
+			_ = backend.DeleteCollection(ctx, vsID)
+
+			err = backend.CreateCollection(ctx, vsID, 384)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = backend.DeleteCollection(ctx, vsID) }()
+
+			exists, err := backend.CollectionExists(ctx, vsID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue())
+
+			err = backend.DeleteCollection(ctx, vsID)
+			Expect(err).NotTo(HaveOccurred())
+
+			exists, err = backend.CollectionExists(ctx, vsID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should insert chunks with embeddings and search", func() {
+			backend, err := NewLlamaStackBackend(LlamaStackBackendConfig{
+				Endpoint:           endpoint,
+				EmbeddingModel:     embeddingModel,
+				EmbeddingDimension: 384,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer backend.Close()
+
+			ctx := context.Background()
+			vsID := "test_search_ls"
+
+			_ = backend.DeleteCollection(ctx, vsID)
+
+			err = backend.CreateCollection(ctx, vsID, 384)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = backend.DeleteCollection(ctx, vsID) }()
+
+			// Generate embeddings via Llama Stack's inference API.
+			embeddings, err := generateTestEmbeddings(endpoint, embeddingModel, []string{
+				"Kubernetes orchestrates containers across clusters",
+				"Docker builds and runs container images",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(embeddings).To(HaveLen(2))
+
+			chunks := []EmbeddedChunk{
+				{ID: "c1", FileID: "f1", Filename: "k8s.txt", Content: "Kubernetes orchestrates containers across clusters", Embedding: embeddings[0], ChunkIndex: 0},
+				{ID: "c2", FileID: "f1", Filename: "k8s.txt", Content: "Docker builds and runs container images", Embedding: embeddings[1], ChunkIndex: 1},
+			}
+			err = backend.InsertChunks(ctx, vsID, chunks)
+			Expect(err).NotTo(HaveOccurred())
+
+			filter := map[string]interface{}{"_query_text": "what is kubernetes?"}
+			results, err := backend.Search(ctx, vsID, nil, 5, 0, filter)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(results)).To(BeNumerically(">=", 1))
+		})
+	})
+})
+
+// generateTestEmbeddings calls Llama Stack's inference API to generate
+// embeddings for the given texts. Used only in integration tests.
+func generateTestEmbeddings(endpoint, model string, texts []string) ([][]float32, error) {
+	body := map[string]interface{}{
+		"model": model,
+		"input": texts,
+	}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(endpoint+"/v1/embeddings", "application/json", strings.NewReader(string(jsonBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to call embeddings API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embeddings response: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("embeddings API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var embResp struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &embResp); err != nil {
+		return nil, fmt.Errorf("failed to parse embeddings response: %w", err)
+	}
+
+	result := make([][]float32, len(embResp.Data))
+	for i, d := range embResp.Data {
+		result[i] = d.Embedding
+	}
+	return result, nil
+}

--- a/src/semantic-router/pkg/vectorstore/memory_backend_test.go
+++ b/src/semantic-router/pkg/vectorstore/memory_backend_test.go
@@ -271,7 +271,7 @@ var _ = Describe("cosineSimilarity", func() {
 
 var _ = Describe("NewBackend factory", func() {
 	It("should create memory backend", func() {
-		b, err := NewBackend(BackendTypeMemory, MemoryBackendConfig{}, MilvusBackendConfig{})
+		b, err := NewBackend(BackendTypeMemory, BackendConfigs{Memory: MemoryBackendConfig{}})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(b).NotTo(BeNil())
 
@@ -280,15 +280,34 @@ var _ = Describe("NewBackend factory", func() {
 	})
 
 	It("should return error for unsupported type", func() {
-		_, err := NewBackend("redis", MemoryBackendConfig{}, MilvusBackendConfig{})
+		_, err := NewBackend("redis", BackendConfigs{})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("unsupported backend type"))
 	})
 
 	It("should return error for milvus without address", func() {
-		_, err := NewBackend(BackendTypeMilvus, MemoryBackendConfig{}, MilvusBackendConfig{})
+		_, err := NewBackend(BackendTypeMilvus, BackendConfigs{})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("milvus address is required"))
+	})
+
+	It("should create llama_stack backend", func() {
+		b, err := NewBackend(BackendTypeLlamaStack, BackendConfigs{
+			LlamaStack: LlamaStackBackendConfig{
+				Endpoint: "http://localhost:8321",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(b).NotTo(BeNil())
+
+		_, ok := b.(*LlamaStackBackend)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("should return error for llama_stack without endpoint", func() {
+		_, err := NewBackend(BackendTypeLlamaStack, BackendConfigs{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("endpoint is required"))
 	})
 })
 

--- a/src/semantic-router/pkg/vectorstore/types.go
+++ b/src/semantic-router/pkg/vectorstore/types.go
@@ -35,7 +35,7 @@ type VectorStore struct {
 	FileCounts   FileCounts             `json:"file_counts"`
 	ExpiresAfter *ExpirationPolicy      `json:"expires_after,omitempty"`
 	Metadata     map[string]interface{} `json:"metadata,omitempty"`
-	BackendType  string                 `json:"backend_type"` // "milvus", "memory"
+	BackendType  string                 `json:"backend_type"` // "memory", "milvus", "llama_stack"
 }
 
 // FileCounts tracks the processing status of files in a vector store.

--- a/tools/make/build-run-test.mk
+++ b/tools/make/build-run-test.mk
@@ -62,14 +62,15 @@ run-router-onnx: build-router-onnx
 		./bin/router-onnx -config=$${ONNX_CONFIG_FILE:-config/config.onnx-binding-test.yaml} --enable-system-prompt-api=true
 
 # Unit test semantic-router
-# By default, Milvus and Redis tests are skipped. To enable them, set SKIP_MILVUS_TESTS=false and/or SKIP_REDIS_TESTS=false
-# Example: make test-semantic-router SKIP_MILVUS_TESTS=false
+# By default, Milvus, Redis, and Llama Stack tests are skipped. To enable them, set the relevant env var to false.
+# Example: make test-semantic-router SKIP_MILVUS_TESTS=false SKIP_LLAMA_STACK_TESTS=false
 test-semantic-router: ## Run unit tests for semantic-router (set SKIP_MILVUS_TESTS=false to enable Milvus tests)
 test-semantic-router: build-router
 	@$(LOG_TARGET)
 	@export LD_LIBRARY_PATH=${PWD}/candle-binding/target/release:${PWD}/ml-binding/target/release:${PWD}/nlp-binding/target/release && \
 	export SKIP_MILVUS_TESTS=$${SKIP_MILVUS_TESTS:-true} && \
 	export SKIP_REDIS_TESTS=$${SKIP_REDIS_TESTS:-true} && \
+	export SKIP_LLAMA_STACK_TESTS=$${SKIP_LLAMA_STACK_TESTS:-true} && \
 	export SR_TEST_MODE=true && \
 		cd src/semantic-router && CGO_ENABLED=1 go test -v $$(go list ./...)
 

--- a/tools/make/e2e.mk
+++ b/tools/make/e2e.mk
@@ -49,6 +49,11 @@ e2e-test-dynamo: ## Run E2E tests with Dynamo profile (requires 3+ GPUs)
 e2e-test-dynamo: E2E_PROFILE=dynamo
 e2e-test-dynamo: e2e-test
 
+# Run E2E tests with RAG Llama Stack profile
+e2e-test-rag-llama-stack: ## Run E2E tests with RAG Llama Stack profile
+e2e-test-rag-llama-stack: E2E_PROFILE=rag-llama-stack
+e2e-test-rag-llama-stack: e2e-test
+
 # Run E2E tests and keep cluster for debugging
 e2e-test-debug: ## Run E2E tests and keep cluster for debugging
 e2e-test-debug: E2E_KEEP_CLUSTER=true
@@ -105,6 +110,7 @@ e2e-help: ## Show help for E2E testing
 	@echo "  istio            - Test Semantic Router with Istio service mesh"
 	@echo "  llm-d            - Test Semantic Router with LLM-D"
 	@echo "  production-stack - Test Semantic Router in production-like stack (HA/LB/Obs)"
+	@echo "  rag-llama-stack  - Test RAG vector store pipeline with Llama Stack backend"
 	@echo "  response-api     - Test Response API endpoints (POST/GET/DELETE /v1/responses)"
 	@echo ""
 	@echo "Environment Variables:"

--- a/tools/make/llama-stack.mk
+++ b/tools/make/llama-stack.mk
@@ -1,0 +1,84 @@
+# ======== llama-stack.mk ========
+# = Everything For Llama Stack  =
+# ======== llama-stack.mk ========
+
+##@ Llama Stack
+
+LLAMA_STACK_CONTAINER_NAME ?= llama-stack-vectorstore
+LLAMA_STACK_PORT ?= 8321
+LLAMA_STACK_IMAGE ?= llamastack/distribution-starter:0.5.0
+LLAMA_STACK_DATA_DIR ?= /tmp/llama-stack-data
+LLAMA_STACK_EMBEDDING_MODEL_ID ?= all-MiniLM-L6-v2
+LLAMA_STACK_EMBEDDING_DIMENSION ?= 384
+
+# Llama Stack container management
+start-llama-stack: ## Start Llama Stack container for testing
+	@$(LOG_TARGET)
+	@if $(CONTAINER_RUNTIME) ps --filter "name=$(LLAMA_STACK_CONTAINER_NAME)" --format "{{.Names}}" | grep -q $(LLAMA_STACK_CONTAINER_NAME); then \
+		echo "Llama Stack container is already running"; \
+	else \
+		$(CONTAINER_RUNTIME) rm $(LLAMA_STACK_CONTAINER_NAME) 2>/dev/null || true; \
+		mkdir -p $(LLAMA_STACK_DATA_DIR); \
+		$(CONTAINER_RUNTIME) run -d \
+			--name $(LLAMA_STACK_CONTAINER_NAME) \
+			-p $(LLAMA_STACK_PORT):$(LLAMA_STACK_PORT) \
+			-v $(LLAMA_STACK_DATA_DIR):/root/.llama \
+			$(LLAMA_STACK_IMAGE) \
+			--port $(LLAMA_STACK_PORT); \
+		echo "Waiting for Llama Stack to be ready..."; \
+		for i in $$(seq 1 30); do \
+			if curl -sf http://localhost:$(LLAMA_STACK_PORT)/v1/health > /dev/null 2>&1; then \
+				echo "Llama Stack is ready at localhost:$(LLAMA_STACK_PORT)"; \
+				break; \
+			fi; \
+			if [ $$i -eq 30 ]; then \
+				echo "Warning: Llama Stack health check timed out (may still be starting)"; \
+			fi; \
+			sleep 2; \
+		done; \
+		echo "Registering embedding model $(LLAMA_STACK_EMBEDDING_MODEL_ID)..."; \
+		curl -sf -X POST http://localhost:$(LLAMA_STACK_PORT)/v1/models \
+			-H "Content-Type: application/json" \
+			-d '{"model_id":"$(LLAMA_STACK_EMBEDDING_MODEL_ID)","provider_id":"sentence-transformers","model_type":"embedding","metadata":{"embedding_dimension":$(LLAMA_STACK_EMBEDDING_DIMENSION)}}' \
+			> /dev/null 2>&1 && echo "Model registered successfully" || echo "Model registration skipped (may already exist)"; \
+	fi
+
+stop-llama-stack: ## Stop and remove Llama Stack container
+	@$(LOG_TARGET)
+	@$(CONTAINER_RUNTIME) stop $(LLAMA_STACK_CONTAINER_NAME) || true
+	@$(CONTAINER_RUNTIME) rm $(LLAMA_STACK_CONTAINER_NAME) || true
+	@echo "Llama Stack container stopped and removed"
+
+restart-llama-stack: stop-llama-stack start-llama-stack ## Restart Llama Stack container
+
+llama-stack-status: ## Show status of Llama Stack container
+	@$(LOG_TARGET)
+	@if $(CONTAINER_RUNTIME) ps --filter "name=$(LLAMA_STACK_CONTAINER_NAME)" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | grep -q $(LLAMA_STACK_CONTAINER_NAME); then \
+		echo "Llama Stack container is running:"; \
+		$(CONTAINER_RUNTIME) ps --filter "name=$(LLAMA_STACK_CONTAINER_NAME)" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"; \
+		echo ""; \
+		echo "Health check:"; \
+		curl -sf http://localhost:$(LLAMA_STACK_PORT)/v1/health && echo " OK" || echo " UNHEALTHY"; \
+	else \
+		echo "Llama Stack container is not running"; \
+		echo "Run 'make start-llama-stack' to start it"; \
+	fi
+
+clean-llama-stack: stop-llama-stack ## Clean up Llama Stack data
+	@$(LOG_TARGET)
+	@echo "Cleaning up Llama Stack data..."
+	@sudo rm -rf $(LLAMA_STACK_DATA_DIR) || rm -rf $(LLAMA_STACK_DATA_DIR)
+	@echo "Llama Stack data directory cleaned"
+
+# Test vector store with Llama Stack backend
+test-llama-stack-vectorstore: start-llama-stack rust ## Run Llama Stack vector store integration tests
+	@$(LOG_TARGET)
+	@echo "Testing vector store with Llama Stack backend..."
+	@export LD_LIBRARY_PATH=$${PWD}/candle-binding/target/release:$${PWD}/ml-binding/target/release && \
+	export SKIP_LLAMA_STACK_TESTS=false && \
+	export LLAMA_STACK_ENDPOINT=http://localhost:$(LLAMA_STACK_PORT) && \
+	export LLAMA_STACK_EMBEDDING_MODEL=$${LLAMA_STACK_EMBEDDING_MODEL:-sentence-transformers/$(LLAMA_STACK_EMBEDDING_MODEL_ID)} && \
+	export SR_TEST_MODE=true && \
+		cd src/semantic-router && CGO_ENABLED=1 go test -v -count=1 \
+		./pkg/vectorstore/ -ginkgo.focus="LlamaStack"
+	@echo "Consider running 'make stop-llama-stack' when done testing"

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -46,6 +46,17 @@ semantic_cache:
   ttl_seconds: 3600
   eviction_policy: "fifo"  # Options: "fifo", "lru", "lfu"
 
+# Vector Store — local document ingestion and search (RAG)
+vector_store:
+  enabled: false
+  backend_type: "memory"  # Options: "memory", "milvus", or "llama_stack"
+  file_storage_dir: "/tmp/vsr-data"
+  embedding_model: "bert"
+  embedding_dimension: 384
+  # llama_stack:
+  #   endpoint: "http://localhost:8321"
+  #   embedding_model: "sentence-transformers/all-MiniLM-L6-v2"
+
 # Tool auto-selection
 tools:
   enabled: false


### PR DESCRIPTION

### Summary

Add Llama Stack as a new `VectorStoreBackend` for the RAG pipeline, enabling document ingestion and semantic search through Meta's Llama Stack REST API.

This PR delivers the full integration across four layers:
- **Backend implementation** with unit and integration tests
- **Makefile targets** for local Llama Stack setup and testing
- **E2E profile** for Kubernetes-based validation in Kind clusters
- **Documentation** updates for user-facing configuration

### Motivation

Llama Stack provides a lightweight, self-hosted vector store backend that is OpenAI API-compatible, making it an accessible option for RAG workloads without requiring external services like Milvus. Enterprises already running Llama Stack can reuse their existing infrastructure instead of deploying a separate vector DB. This was requested in #1305 to expand the range of supported vector store backends.

### API Approach and Design Decisions

Following guidance from [Francisco](https://github.com/franciscojavierarceo) (Llama Stack maintainer), we use the **OpenAI-compatible API** instead of the `rag_tool`. However, Llama Stack's API and vSR's `VectorStoreBackend` interface differ in how they handle embeddings and resource identity, which required three key design choices:

**1. Search: text query vs. embedding vector**

The `VectorStoreBackend.Search()` interface passes a `queryEmbedding []float32` (a pre-computed embedding vector), but Llama Stack's search endpoint (`POST /v1/vector_stores/{id}/search`) expects a **text query string** -- it handles embedding internally. This is a fundamental mismatch.

**Solution:** The original query text is passed through `filter["_query_text"]` from the caller. Both `route_vectorstore.go` (REST API handler) and `req_filter_rag_vectorstore.go` (ExtProc filter) inject the query text into the filter map before calling `Search()`. The Llama Stack backend reads this text and sends it to the search endpoint, ignoring the embedding vector. Other backends (memory, milvus) safely ignore this extra filter key.

**2. InsertChunks: pre-chunked data vs. file upload**

the OpenAI-compatible file upload endpoint (`POST /v1/vector_stores/{id}/files`), accepts a raw file and handles chunking + embedding internally. But vSR's ingestion pipeline already chunks and embeds documents before calling `InsertChunks()`, passing `[]EmbeddedChunk` objects (text content + pre-computed embeddings).

**Solution:** For InsertChunks, we use the lower-level `POST /v1/vector-io/insert` endpoint, which accepts individual chunks with their text content. The pre-computed embeddings from vSR are not sent -- Llama Stack re-embeds using its own configured model (`sentence-transformers/all-MiniLM-L6-v2`), ensuring consistency between insert and search embeddings.

**3. ID mapping: vSR names vs. Llama Stack IDs**

vSR and Llama Stack each generate their own IDs for the same vector store (e.g., vSR: `vs_6a37f067-...`, Llama Stack: `vs_21c1db0f-...`). The backend keeps a `storeIDs` map to translate between the two, populated at creation time and refreshed via `resolveStoreID()` if needed.

**API mapping summary:**

| VectorStoreBackend method | Llama Stack endpoint | API layer |
|---------------------------|---------------------|-----------|
| `CreateCollection` | `POST /v1/vector_stores` | OpenAI-compatible |
| `DeleteCollection` | `DELETE /v1/vector_stores/{id}` | OpenAI-compatible |
| `CollectionExists` | `GET /v1/vector_stores/{id}` | OpenAI-compatible |
| `Search` | `POST /v1/vector_stores/{id}/search` | OpenAI-compatible |
| `InsertChunks` | `POST /v1/vector-io/insert` | Low-level vector-io |
| `DeleteByFileID` | In-memory tracking + re-insert | Application-level |

### Changes

#### Phase 1: Backend Implementation

| File | Change |
|------|--------|
| `pkg/vectorstore/llama_stack_backend.go` | **New** - Full `VectorStoreBackend` implementation |
| `pkg/vectorstore/factory.go` | Register `"llama_stack"` backend type in factory |
| `pkg/vectorstore/types.go` | Add `BackendTypeLlamaStack` constant |
| `pkg/config/vectorstore.go` | Add `LlamaStackConfig` struct with endpoint, model, dimension |
| `cmd/main.go` | Wire Llama Stack config into server initialization |
| `pkg/apiserver/route_vectorstore.go` | Inject `_query_text` into filter map before Search |
| `pkg/extproc/req_filter_rag_vectorstore.go` | Inject `_query_text` into filter map before Search |
| `config/config-rag-example.yaml` | Add Llama Stack example configuration |

#### Phase 2: Tests

| File | Change |
|------|--------|
| `pkg/vectorstore/llama_stack_backend_test.go` | **New** - Unit tests (httptest mock) + integration tests |
| `pkg/vectorstore/memory_backend_test.go` | Add shared test helpers |

**Test coverage:**
- **Unit tests** using `httptest` mock server covering all CRUD operations, error handling, edge cases, timeout behavior, and concurrent access
- **Integration tests** against a live Llama Stack instance covering the full lifecycle: create store -> insert chunks -> search -> delete
- Integration tests gated behind `SKIP_LLAMA_STACK_TESTS` env var (default: `true`)

#### Phase 3: Makefile Integration

| File | Change |
|------|--------|
| `tools/make/llama-stack.mk` | **New** - Targets for Llama Stack setup and testing |
| `tools/make/build-run-test.mk` | Add `SKIP_LLAMA_STACK_TESTS` (default: `true`) to `test-semantic-router` |
| `Makefile` | Include `llama-stack.mk` |

**Available targets:**
```
make start-llama-stack             # Start Llama Stack + auto-register embedding model
make stop-llama-stack              # Stop Llama Stack
make restart-llama-stack           # Restart Llama Stack
make status-llama-stack            # Show status
make clean-llama-stack             # Remove Llama Stack
make test-llama-stack-vectorstore  # Run integration tests against Docker-based Llama Stack
```

#### Phase 4: E2E Profile & Documentation

| File | Change |
|------|--------|
| `e2e/profiles/rag-llama-stack/profile.go` | **New** - E2E profile implementation |
| `e2e/profiles/rag-llama-stack/values.yaml` | **New** - Helm values configuring `backend_type: "llama_stack"` with in-cluster endpoint |
| `e2e/profiles/rag-llama-stack/manifests/llama-stack.yaml` | **New** - K8s Namespace + Deployment + Service |
| `e2e/cmd/e2e/main.go` | Register `rag-llama-stack` profile |
| `tools/make/e2e.mk` | Add `e2e-test-rag-llama-stack` convenience target |
| `website/docs/installation/configuration.md` | Document `vector_store` with `llama_stack` option |

**Runs test case:** `rag-vectorstore` (backend-agnostic, validates full RAG pipeline)

### How to Test

**Unit tests (no infrastructure needed):**
```bash
make test-semantic-router
```

**Integration tests (requires Docker):**
```bash
make test-llama-stack-vectorstore
```

**E2E tests (requires Kind + Docker):**
```bash
make e2e-test-rag-llama-stack
```

### Configuration Example

```yaml
vector_store:
  enabled: true
  backend_type: "llama_stack"
  file_storage_dir: "/tmp/vsr-data"
  embedding_model: "mmbert"
  embedding_dimension: 384
  llama_stack:
    endpoint: "http://localhost:8321"
    embedding_model: "sentence-transformers/all-MiniLM-L6-v2"
```

### Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Unit tests pass (`make test-semantic-router`)
- [x] Linter checks pass (errcheck, gofumpt, staticcheck)
- [x] Integration tests pass (`make test-llama-stack-vectorstore`)
- [x] E2E tests pass (`make e2e-test-rag-llama-stack`)

### Dependencies

- **Llama Stack image:** `llamastack/distribution-starter:0.5.0`
- **Embedding model:** `sentence-transformers/all-MiniLM-L6-v2` (384 dimensions)
- No new Go module dependencies (`go.mod` unchanged) -- the backend uses Go's standard `net/http` for all REST calls to Llama Stack, avoiding an external SDK

Resolves #1305
