### PR TITLE
[Feat]: add response-level jailbreak detection filter

### DIFF
--- a/e2e/testing/09-memory-features-test.py
+++ b/e2e/testing/09-memory-features-test.py
@@ -5,7 +5,7 @@ Memory Features E2E Test Suite — Risk-Based, Milvus-First
 Organized by priority derived from risk/return analysis (see ISSUE_1293_REVIEW.md):
 
   P0 Security:
-    - UserIsolationTest: Cross-user memory leak (MINJA/InjecMEM attack surface)
+    - UserIsolationTest: Cross-user memory leak prevention
 
   P1 Pipeline Correctness:
     - MemoryInjectionPipelineTest: The fundamental store -> extract -> inject contract

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -1136,7 +1136,7 @@ type MemoryQualityScoringConfig struct {
 // MemoryReflectionConfig configures the pre-injection validation gate.
 // Retrieved memories pass through heuristic filters before being injected
 // into the LLM request. This improves accuracy by removing stale/redundant
-// context and hardens against MINJA-style memory poisoning attacks.
+// context.
 type MemoryReflectionConfig struct {
 	// Enabled turns the reflection gate on/off (default: true when memory is enabled)
 	Enabled *bool `yaml:"enabled,omitempty"`
@@ -2233,7 +2233,7 @@ type ModelRef struct {
 
 // DecisionPlugin represents a plugin configuration for a decision
 type DecisionPlugin struct {
-	// Type specifies the plugin type. Permitted values: "semantic-cache", "jailbreak", "pii", "system_prompt", "header_mutation", "hallucination", "router_replay", "memory", "fast_response".
+	// Type specifies the plugin type. Permitted values: "semantic-cache", "jailbreak", "pii", "system_prompt", "header_mutation", "hallucination", "response_jailbreak", "router_replay", "memory", "fast_response".
 	Type string `yaml:"type" json:"type"`
 
 	// Configuration is the raw configuration for this plugin
@@ -2292,6 +2292,25 @@ type HeaderMutationPluginConfig struct {
 type HeaderPair struct {
 	Name  string `json:"name" yaml:"name"`
 	Value string `json:"value" yaml:"value"`
+}
+
+// ResponseJailbreakPluginConfig represents configuration for response-level jailbreak
+// detection. When enabled, the jailbreak classifier runs on the LLM response body to
+// catch adversarial content that passed input-level detection — including memory
+// poisoning patterns such as entity redirection and data reassignment (arXiv:2503.03704).
+type ResponseJailbreakPluginConfig struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+
+	// Threshold is the classifier confidence threshold for flagging.
+	// Responses with confidence >= Threshold are treated as jailbreak content.
+	// Default: uses the global prompt_guard threshold.
+	Threshold float32 `json:"threshold,omitempty" yaml:"threshold,omitempty"`
+
+	// Action specifies what to do when jailbreak content is detected in the response.
+	// "header" - add warning headers to response (default)
+	// "block"  - return an error response instead of the original
+	// "none"   - no action, only log and metrics (still gates memory storage)
+	Action string `json:"action,omitempty" yaml:"action,omitempty"`
 }
 
 // HallucinationPluginConfig represents configuration for hallucination detection plugin
@@ -2554,6 +2573,21 @@ func (d *Decision) GetHallucinationConfig() *HallucinationPluginConfig {
 	result := &HallucinationPluginConfig{}
 	if err := unmarshalPluginConfig(config, result); err != nil {
 		logging.Errorf("Failed to unmarshal hallucination config: %v", err)
+		return nil
+	}
+	return result
+}
+
+// GetResponseJailbreakConfig returns the response_jailbreak plugin configuration
+func (d *Decision) GetResponseJailbreakConfig() *ResponseJailbreakPluginConfig {
+	config := d.GetPluginConfig("response_jailbreak")
+	if config == nil {
+		return nil
+	}
+
+	result := &ResponseJailbreakPluginConfig{}
+	if err := unmarshalPluginConfig(config, result); err != nil {
+		logging.Errorf("Failed to unmarshal response_jailbreak config: %v", err)
 		return nil
 	}
 	return result

--- a/src/semantic-router/pkg/extproc/processor_req_body.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body.go
@@ -1065,7 +1065,8 @@ func (r *OpenAIRouter) handleMemoryRetrieval(
 	}
 	logging.Infof("Memory: found %d memories for user=%s", len(memories), userID)
 
-	// Step 6: Memory filter -- validate memories before injection
+	// Step 6: Memory filter -- validate memories before injection.
+	// ReflectionGate applies recency decay, dedup, and token budget.
 	var perDecisionReflection *config.MemoryReflectionConfig
 	if memoryPluginConfig != nil && memoryPluginConfig.Reflection != nil {
 		perDecisionReflection = memoryPluginConfig.Reflection

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -105,10 +105,15 @@ type RequestContext struct {
 	EnhancedHallucinationInfo *EnhancedHallucinationInfo // Detailed NLI info (when use_nli enabled)
 	UnverifiedFactualResponse bool                       // True if fact-check needed but no tools to verify against
 
-	// Jailbreak Detection Results
-	JailbreakDetected   bool    // True if jailbreak was detected
+	// Jailbreak Detection Results (request-level, from signal classification)
+	JailbreakDetected   bool    // True if jailbreak was detected in user input
 	JailbreakType       string  // Type of jailbreak detected
 	JailbreakConfidence float32 // Confidence score of jailbreak detection
+
+	// Response-level Jailbreak Detection Results (from response body scanning)
+	ResponseJailbreakDetected   bool    // True if jailbreak content detected in LLM response
+	ResponseJailbreakType       string  // Type of jailbreak detected in response
+	ResponseJailbreakConfidence float32 // Confidence score of response jailbreak detection
 
 	// PII Detection Results
 	PIIDetected bool     // True if PII was detected

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -226,35 +226,6 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 		}
 	}
 
-	// Memory chunk storage (async, if auto_store enabled)
-	// Stores current turn directly in vector store -- no LLM extraction overhead.
-	autoStoreEnabled := extractAutoStore(ctx)
-	if !autoStoreEnabled && r.Config != nil && r.Config.Memory.AutoStore {
-		logging.Infof("extractAutoStore: Falling back to global config, AutoStore=%v", r.Config.Memory.AutoStore)
-		autoStoreEnabled = true
-	}
-	logging.Infof("Memory store check: MemoryExtractor=%v, autoStore=%v, jailbreakPassed=%v",
-		r.MemoryExtractor != nil, autoStoreEnabled, !ctx.JailbreakDetected)
-	if r.MemoryExtractor != nil && autoStoreEnabled && !ctx.JailbreakDetected {
-		currentUserMessage := extractCurrentUserMessage(ctx)
-		currentAssistantResponse := extractAssistantResponseText(responseBody)
-		go func() {
-			bgCtx := context.Background()
-			sessionID, userID, history, err := extractMemoryInfo(ctx)
-			if err != nil {
-				logging.Errorf("Memory store failed: %v", err)
-				return
-			}
-
-			logging.Infof("Memory store: sessionID=%s, userID=%s, userMsg=%d chars, assistantMsg=%d chars, history=%d msgs",
-				sessionID, userID, len(currentUserMessage), len(currentAssistantResponse), len(history))
-
-			if err := r.MemoryExtractor.ProcessResponseWithHistory(bgCtx, sessionID, userID, currentUserMessage, currentAssistantResponse, history); err != nil {
-				logging.Warnf("Memory store failed: %v", err)
-			}
-		}()
-	}
-
 	// Translate response for Response API requests
 	finalBody := responseBody
 	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.IsResponseAPIRequest && r.ResponseAPIFilter != nil {
@@ -285,10 +256,44 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 		}
 	}
 
+	// Perform response-level jailbreak detection if enabled
+	if jailbreakResponse := r.performResponseJailbreakDetection(ctx, responseBody); jailbreakResponse != nil {
+		return jailbreakResponse, nil
+	}
+
 	// Perform hallucination detection if enabled and conditions are met
 	if hallucinationResponse := r.performHallucinationDetection(ctx, responseBody); hallucinationResponse != nil {
 		// Hallucination detected and action is "block" - return error response
 		return hallucinationResponse, nil
+	}
+
+	// Memory chunk storage (async, if auto_store enabled)
+	// Runs AFTER response-level detection so ctx flags are set for gating.
+	autoStoreEnabled := extractAutoStore(ctx)
+	if !autoStoreEnabled && r.Config != nil && r.Config.Memory.AutoStore {
+		logging.Infof("extractAutoStore: Falling back to global config, AutoStore=%v", r.Config.Memory.AutoStore)
+		autoStoreEnabled = true
+	}
+	logging.Infof("Memory store check: MemoryExtractor=%v, autoStore=%v",
+		r.MemoryExtractor != nil, autoStoreEnabled)
+	if r.MemoryExtractor != nil && autoStoreEnabled {
+		currentUserMessage := extractCurrentUserMessage(ctx)
+		currentAssistantResponse := extractAssistantResponseText(responseBody)
+		go func() {
+			bgCtx := context.Background()
+			sessionID, userID, history, err := extractMemoryInfo(ctx)
+			if err != nil {
+				logging.Errorf("Memory store failed: %v", err)
+				return
+			}
+
+			logging.Infof("Memory store: sessionID=%s, userID=%s, userMsg=%d chars, assistantMsg=%d chars, history=%d msgs",
+				sessionID, userID, len(currentUserMessage), len(currentAssistantResponse), len(history))
+
+			if err := r.MemoryExtractor.ProcessResponseWithHistory(bgCtx, sessionID, userID, currentUserMessage, currentAssistantResponse, history); err != nil {
+				logging.Warnf("Memory store failed: %v", err)
+			}
+		}()
 	}
 
 	// Check unverified factual response if hallucination plugin is enabled
@@ -314,6 +319,11 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 				},
 			},
 		},
+	}
+
+	// Apply response jailbreak warning based on configured action
+	if ctx.ResponseJailbreakDetected {
+		modifiedBody, response = r.applyResponseJailbreakWarning(response, ctx, modifiedBody)
 	}
 
 	// Apply hallucination warning based on configured action

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -182,6 +182,10 @@ func (r *OpenAIRouter) startRouterReplay(
 		JailbreakType:       ctx.JailbreakType,
 		JailbreakConfidence: ctx.JailbreakConfidence,
 
+		ResponseJailbreakDetected:   ctx.ResponseJailbreakDetected,
+		ResponseJailbreakType:       ctx.ResponseJailbreakType,
+		ResponseJailbreakConfidence: ctx.ResponseJailbreakConfidence,
+
 		PIIDetected: ctx.PIIDetected,
 		PIIEntities: ctx.PIIEntities,
 		PIIBlocked:  ctx.PIIBlocked,

--- a/src/semantic-router/pkg/extproc/res_filter_jailbreak.go
+++ b/src/semantic-router/pkg/extproc/res_filter_jailbreak.go
@@ -1,0 +1,187 @@
+package extproc
+
+import (
+	"fmt"
+	"time"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+)
+
+// performResponseJailbreakDetection runs the jailbreak classifier on the LLM
+// response body to catch adversarial content that passed input-level detection.
+// Returns a blocking response if the action is "block"; otherwise returns nil
+// and sets ctx.ResponseJailbreakDetected for downstream handling.
+func (r *OpenAIRouter) performResponseJailbreakDetection(ctx *RequestContext, responseBody []byte) *ext_proc.ProcessingResponse {
+	if !r.shouldPerformResponseJailbreakDetection(ctx) {
+		return nil
+	}
+
+	assistantContent := extractAssistantContentFromResponse(responseBody)
+	if assistantContent == "" {
+		logging.Debugf("No assistant content to check for response jailbreak")
+		return nil
+	}
+
+	rjCfg := ctx.VSRSelectedDecision.GetResponseJailbreakConfig()
+	threshold := rjCfg.Threshold
+	if threshold <= 0 && r.Config != nil {
+		threshold = r.Config.PromptGuard.Threshold
+	}
+	if threshold <= 0 {
+		threshold = 0.5
+	}
+
+	start := time.Now()
+	isJailbreak, jailbreakType, confidence, err := r.Classifier.CheckForJailbreakWithThreshold(assistantContent, threshold)
+	latency := time.Since(start).Seconds()
+
+	decisionName := ""
+	if ctx.VSRSelectedDecision != nil {
+		decisionName = ctx.VSRSelectedDecision.Name
+	}
+
+	if err != nil {
+		logging.Errorf("Response jailbreak detection failed: %v", err)
+		metrics.RecordPluginError("response_jailbreak", "detection_error")
+		return nil
+	}
+
+	if isJailbreak {
+		ctx.ResponseJailbreakDetected = true
+		ctx.ResponseJailbreakType = jailbreakType
+		ctx.ResponseJailbreakConfidence = confidence
+
+		metrics.RecordPluginExecution("response_jailbreak", decisionName, "detected", latency)
+		logging.Warnf("Response jailbreak detected: type=%s, confidence=%.3f", jailbreakType, confidence)
+
+		action := r.getResponseJailbreakAction(ctx.VSRSelectedDecision)
+		if action == "block" {
+			logging.Infof("Response jailbreak action is 'block', returning error response")
+			return r.createErrorResponse(403, "Response blocked: jailbreak content detected in LLM output")
+		}
+		logging.Infof("Response jailbreak detected, action is '%s'", action)
+	} else {
+		metrics.RecordPluginExecution("response_jailbreak", decisionName, "not_detected", latency)
+		logging.Debugf("No jailbreak detected in response: confidence=%.3f", confidence)
+	}
+
+	return nil
+}
+
+// shouldPerformResponseJailbreakDetection checks whether response-level
+// jailbreak detection should run for the current request.
+func (r *OpenAIRouter) shouldPerformResponseJailbreakDetection(ctx *RequestContext) bool {
+	if r.Classifier == nil || !r.Classifier.IsJailbreakEnabled() {
+		return false
+	}
+
+	if ctx.VSRSelectedDecision == nil {
+		return false
+	}
+
+	rjCfg := ctx.VSRSelectedDecision.GetResponseJailbreakConfig()
+	if rjCfg == nil || !rjCfg.Enabled {
+		logging.Debugf("Skipping response jailbreak detection: not enabled for decision %s",
+			ctx.VSRSelectedDecisionName)
+		return false
+	}
+
+	return true
+}
+
+// getResponseJailbreakAction returns the configured action for response jailbreak.
+// Defaults to "header".
+func (r *OpenAIRouter) getResponseJailbreakAction(decision *config.Decision) string {
+	if decision == nil {
+		return "header"
+	}
+
+	rjCfg := decision.GetResponseJailbreakConfig()
+	if rjCfg == nil {
+		return "header"
+	}
+
+	action := rjCfg.Action
+	if action == "" {
+		return "header"
+	}
+
+	return action
+}
+
+// applyResponseJailbreakWarning applies the response jailbreak warning based
+// on the configured action (header or none). Block is handled earlier via an
+// immediate error response.
+func (r *OpenAIRouter) applyResponseJailbreakWarning(response *ext_proc.ProcessingResponse, ctx *RequestContext, responseBody []byte) ([]byte, *ext_proc.ProcessingResponse) {
+	if !ctx.ResponseJailbreakDetected {
+		return responseBody, response
+	}
+
+	action := r.getResponseJailbreakAction(ctx.VSRSelectedDecision)
+
+	switch action {
+	case "header":
+		return responseBody, r.addResponseJailbreakWarningHeaders(response, ctx)
+	case "none":
+		logging.Infof("Response jailbreak detected but action is 'none', skipping warning")
+		return responseBody, response
+	default:
+		return responseBody, r.addResponseJailbreakWarningHeaders(response, ctx)
+	}
+}
+
+// addResponseJailbreakWarningHeaders adds response jailbreak detection headers.
+func (r *OpenAIRouter) addResponseJailbreakWarningHeaders(response *ext_proc.ProcessingResponse, ctx *RequestContext) *ext_proc.ProcessingResponse {
+	if !ctx.ResponseJailbreakDetected {
+		return response
+	}
+
+	bodyResponse, ok := response.Response.(*ext_proc.ProcessingResponse_ResponseBody)
+	if !ok {
+		return response
+	}
+
+	headerMutation := &ext_proc.HeaderMutation{
+		SetHeaders: []*core.HeaderValueOption{
+			{
+				Header: &core.HeaderValue{
+					Key:      headers.ResponseJailbreakDetected,
+					RawValue: []byte("true"),
+				},
+			},
+			{
+				Header: &core.HeaderValue{
+					Key:      headers.ResponseJailbreakType,
+					RawValue: []byte(ctx.ResponseJailbreakType),
+				},
+			},
+			{
+				Header: &core.HeaderValue{
+					Key:      headers.ResponseJailbreakConfidence,
+					RawValue: []byte(fmt.Sprintf("%.3f", ctx.ResponseJailbreakConfidence)),
+				},
+			},
+		},
+	}
+
+	if bodyResponse.ResponseBody.Response == nil {
+		bodyResponse.ResponseBody.Response = &ext_proc.CommonResponse{}
+	}
+
+	if bodyResponse.ResponseBody.Response.HeaderMutation != nil {
+		bodyResponse.ResponseBody.Response.HeaderMutation.SetHeaders = append(
+			bodyResponse.ResponseBody.Response.HeaderMutation.SetHeaders,
+			headerMutation.SetHeaders...,
+		)
+	} else {
+		bodyResponse.ResponseBody.Response.HeaderMutation = headerMutation
+	}
+
+	return response
+}

--- a/src/semantic-router/pkg/extproc/res_filter_jailbreak_test.go
+++ b/src/semantic-router/pkg/extproc/res_filter_jailbreak_test.go
@@ -1,0 +1,206 @@
+package extproc
+
+import (
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+)
+
+var _ = Describe("Response Jailbreak Filter", func() {
+	var (
+		router *OpenAIRouter
+		cfg    *config.RouterConfig
+	)
+
+	createDecisionWithResponseJailbreak := func(enabled bool, action string) *config.Decision {
+		return &config.Decision{
+			Name: "test_decision",
+			Plugins: []config.DecisionPlugin{
+				{
+					Type: "response_jailbreak",
+					Configuration: map[string]interface{}{
+						"enabled":   enabled,
+						"threshold": 0.5,
+						"action":    action,
+					},
+				},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		cfg = &config.RouterConfig{}
+		router = &OpenAIRouter{
+			Config: cfg,
+		}
+	})
+
+	Describe("shouldPerformResponseJailbreakDetection", func() {
+		It("should return false when classifier is nil", func() {
+			ctx := &RequestContext{
+				VSRSelectedDecision: createDecisionWithResponseJailbreak(true, "header"),
+			}
+			Expect(router.shouldPerformResponseJailbreakDetection(ctx)).To(BeFalse())
+		})
+
+		It("should return false when decision is nil", func() {
+			ctx := &RequestContext{
+				VSRSelectedDecision: nil,
+			}
+			Expect(router.shouldPerformResponseJailbreakDetection(ctx)).To(BeFalse())
+		})
+
+		It("should return false when plugin not enabled", func() {
+			ctx := &RequestContext{
+				VSRSelectedDecision: createDecisionWithResponseJailbreak(false, "header"),
+			}
+			Expect(router.shouldPerformResponseJailbreakDetection(ctx)).To(BeFalse())
+		})
+
+		It("should return false when no response_jailbreak plugin configured", func() {
+			decision := &config.Decision{
+				Name:    "test_decision",
+				Plugins: []config.DecisionPlugin{},
+			}
+			ctx := &RequestContext{
+				VSRSelectedDecision: decision,
+			}
+			Expect(router.shouldPerformResponseJailbreakDetection(ctx)).To(BeFalse())
+		})
+	})
+
+	Describe("getResponseJailbreakAction", func() {
+		It("should return 'header' when decision is nil", func() {
+			Expect(router.getResponseJailbreakAction(nil)).To(Equal("header"))
+		})
+
+		It("should return 'header' when no plugin configured", func() {
+			decision := &config.Decision{
+				Name:    "test_decision",
+				Plugins: []config.DecisionPlugin{},
+			}
+			Expect(router.getResponseJailbreakAction(decision)).To(Equal("header"))
+		})
+
+		It("should return 'header' when action not specified", func() {
+			decision := &config.Decision{
+				Name: "test_decision",
+				Plugins: []config.DecisionPlugin{
+					{
+						Type: "response_jailbreak",
+						Configuration: map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+			}
+			Expect(router.getResponseJailbreakAction(decision)).To(Equal("header"))
+		})
+
+		It("should return 'block' when action is block", func() {
+			Expect(router.getResponseJailbreakAction(
+				createDecisionWithResponseJailbreak(true, "block"),
+			)).To(Equal("block"))
+		})
+
+		It("should return 'none' when action is none", func() {
+			Expect(router.getResponseJailbreakAction(
+				createDecisionWithResponseJailbreak(true, "none"),
+			)).To(Equal("none"))
+		})
+
+		It("should return 'header' when action is header", func() {
+			Expect(router.getResponseJailbreakAction(
+				createDecisionWithResponseJailbreak(true, "header"),
+			)).To(Equal("header"))
+		})
+	})
+
+	Describe("applyResponseJailbreakWarning", func() {
+		It("should not modify response when no jailbreak detected", func() {
+			ctx := &RequestContext{
+				ResponseJailbreakDetected: false,
+			}
+			response := createMockBodyResponse()
+			body := []byte(`{"choices":[{"message":{"content":"hello"}}]}`)
+
+			resultBody, resultResp := router.applyResponseJailbreakWarning(response, ctx, body)
+			Expect(resultBody).To(Equal(body))
+			Expect(resultResp).To(Equal(response))
+		})
+
+		It("should add headers when action is header", func() {
+			ctx := &RequestContext{
+				ResponseJailbreakDetected:   true,
+				ResponseJailbreakType:       "entity_redirection",
+				ResponseJailbreakConfidence: 0.85,
+				VSRSelectedDecision:         createDecisionWithResponseJailbreak(true, "header"),
+			}
+			response := createMockBodyResponse()
+			body := []byte(`{"choices":[{"message":{"content":"hello"}}]}`)
+
+			_, resultResp := router.applyResponseJailbreakWarning(response, ctx, body)
+
+			bodyResp, ok := resultResp.Response.(*ext_proc.ProcessingResponse_ResponseBody)
+			Expect(ok).To(BeTrue())
+			Expect(bodyResp.ResponseBody.Response).NotTo(BeNil())
+			Expect(bodyResp.ResponseBody.Response.HeaderMutation).NotTo(BeNil())
+
+			foundDetected := false
+			foundType := false
+			foundConfidence := false
+			for _, h := range bodyResp.ResponseBody.Response.HeaderMutation.SetHeaders {
+				switch h.Header.Key {
+				case headers.ResponseJailbreakDetected:
+					foundDetected = true
+					Expect(string(h.Header.RawValue)).To(Equal("true"))
+				case headers.ResponseJailbreakType:
+					foundType = true
+					Expect(string(h.Header.RawValue)).To(Equal("entity_redirection"))
+				case headers.ResponseJailbreakConfidence:
+					foundConfidence = true
+					Expect(string(h.Header.RawValue)).To(Equal("0.850"))
+				}
+			}
+			Expect(foundDetected).To(BeTrue())
+			Expect(foundType).To(BeTrue())
+			Expect(foundConfidence).To(BeTrue())
+		})
+
+		It("should not add headers when action is none", func() {
+			ctx := &RequestContext{
+				ResponseJailbreakDetected:   true,
+				ResponseJailbreakType:       "entity_redirection",
+				ResponseJailbreakConfidence: 0.85,
+				VSRSelectedDecision:         createDecisionWithResponseJailbreak(true, "none"),
+			}
+			response := createMockBodyResponse()
+			body := []byte(`{"choices":[{"message":{"content":"hello"}}]}`)
+
+			resultBody, _ := router.applyResponseJailbreakWarning(response, ctx, body)
+			Expect(resultBody).To(Equal(body))
+		})
+	})
+
+	Describe("GetResponseJailbreakConfig", func() {
+		It("should return nil when no plugin configured", func() {
+			decision := &config.Decision{
+				Name:    "test",
+				Plugins: []config.DecisionPlugin{},
+			}
+			Expect(decision.GetResponseJailbreakConfig()).To(BeNil())
+		})
+
+		It("should parse config correctly", func() {
+			decision := createDecisionWithResponseJailbreak(true, "block")
+			rjCfg := decision.GetResponseJailbreakConfig()
+			Expect(rjCfg).NotTo(BeNil())
+			Expect(rjCfg.Enabled).To(BeTrue())
+			Expect(rjCfg.Threshold).To(BeNumerically("~", 0.5, 0.01))
+			Expect(rjCfg.Action).To(Equal("block"))
+		})
+	})
+})

--- a/src/semantic-router/pkg/extproc/router.go
+++ b/src/semantic-router/pkg/extproc/router.go
@@ -398,7 +398,7 @@ func NewOpenAIRouter(configPath string) (*OpenAIRouter, error) {
 		}
 	}
 
-	// Create memory chunk store (direct conversation storage, no LLM extraction)
+	// Create memory chunk store (direct conversation storage, no LLM extraction).
 	var memoryExtractor *memory.MemoryExtractor
 	if memoryEnabled && memoryStore != nil {
 		memoryExtractor = memory.NewMemoryChunkStore(memoryStore)

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -173,6 +173,21 @@ const (
 	VerificationContextMissing = "x-vsr-verification-context-missing"
 )
 
+// Response Jailbreak Detection Headers
+// These headers are added to responses when response-level jailbreak detection
+// finds adversarial content (e.g., memory poisoning patterns) in the LLM response.
+const (
+	// ResponseJailbreakDetected indicates that jailbreak content was detected in the LLM response.
+	// Value: "true"
+	ResponseJailbreakDetected = "x-vsr-response-jailbreak-detected"
+
+	// ResponseJailbreakType specifies the type of jailbreak detected in the response.
+	ResponseJailbreakType = "x-vsr-response-jailbreak-type"
+
+	// ResponseJailbreakConfidence indicates the confidence level of the response jailbreak detection.
+	ResponseJailbreakConfidence = "x-vsr-response-jailbreak-confidence"
+)
+
 // Auth Backend Injected Headers
 // These headers are set by the external authorization service (Authorino, Envoy Gateway JWT,
 // oauth2-proxy, etc.) after successful user authentication.

--- a/src/semantic-router/pkg/headers/headers_test.go
+++ b/src/semantic-router/pkg/headers/headers_test.go
@@ -31,6 +31,10 @@ func TestHeaderConstants(t *testing.T) {
 		{"FactCheckNeeded", FactCheckNeeded, "x-vsr-fact-check-needed"},
 		{"UnverifiedFactualResponse", UnverifiedFactualResponse, "x-vsr-unverified-factual-response"},
 		{"VerificationContextMissing", VerificationContextMissing, "x-vsr-verification-context-missing"},
+		// Response jailbreak detection headers
+		{"ResponseJailbreakDetected", ResponseJailbreakDetected, "x-vsr-response-jailbreak-detected"},
+		{"ResponseJailbreakType", ResponseJailbreakType, "x-vsr-response-jailbreak-type"},
+		{"ResponseJailbreakConfidence", ResponseJailbreakConfidence, "x-vsr-response-jailbreak-confidence"},
 	}
 
 	for _, tt := range tests {

--- a/src/semantic-router/pkg/memory/reflection.go
+++ b/src/semantic-router/pkg/memory/reflection.go
@@ -11,12 +11,9 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
-// Default block patterns are intentionally empty. The primary adversarial
-// content gate is SR's jailbreak classifier which runs on the request path;
-// only requests that pass the classifier reach the LLM and produce memories.
-// The write-path fallback lives in sanitize.go for when the classifier is
-// disabled. Users can add custom patterns via config if needed.
-var defaultBlockPatterns []string
+// defaultBlockPatterns is empty by default.
+// Operators can add custom block_patterns via MemoryReflectionConfig.
+var defaultBlockPatterns = []string{}
 
 // ReflectionGate filters retrieved memories before injection using heuristic
 // rules: recency decay, redundancy dedup, and token budget enforcement.

--- a/src/semantic-router/pkg/memory/types.go
+++ b/src/semantic-router/pkg/memory/types.go
@@ -67,6 +67,17 @@ type Memory struct {
 
 	// Importance is a score for prioritizing memories (0.0 to 1.0)
 	Importance float32 `json:"importance"`
+
+	// --- Provenance fields ---
+
+	// CreatedByUserID is the user whose conversation produced this memory.
+	CreatedByUserID string `json:"created_by_user_id,omitempty"`
+
+	// ConversationID is the session that produced this memory.
+	ConversationID string `json:"conversation_id,omitempty"`
+
+	// CreatedVia records the creation method: "llm_extraction", "api", "import".
+	CreatedVia string `json:"created_via,omitempty"`
 }
 
 // RetrieveResult represents a memory retrieved from search with its relevance score

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -173,11 +173,18 @@ func LogFields(r RoutingRecord, event string) map[string]interface{} {
 		fields["jailbreak_enabled"] = r.JailbreakEnabled
 		fields["pii_enabled"] = r.PIIEnabled
 
-		// Jailbreak detection results
+		// Jailbreak detection results (request-level)
 		if r.JailbreakDetected {
 			fields["jailbreak_detected"] = r.JailbreakDetected
 			fields["jailbreak_type"] = r.JailbreakType
 			fields["jailbreak_confidence"] = r.JailbreakConfidence
+		}
+
+		// Response jailbreak detection results
+		if r.ResponseJailbreakDetected {
+			fields["response_jailbreak_detected"] = r.ResponseJailbreakDetected
+			fields["response_jailbreak_type"] = r.ResponseJailbreakType
+			fields["response_jailbreak_confidence"] = r.ResponseJailbreakConfidence
 		}
 
 		// PII detection results

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -44,10 +44,15 @@ type Record struct {
 	JailbreakEnabled  bool `json:"jailbreak_enabled,omitempty"`
 	PIIEnabled        bool `json:"pii_enabled,omitempty"`
 
-	// Jailbreak Detection Results
+	// Jailbreak Detection Results (request-level)
 	JailbreakDetected   bool    `json:"jailbreak_detected,omitempty"`
 	JailbreakType       string  `json:"jailbreak_type,omitempty"`
 	JailbreakConfidence float32 `json:"jailbreak_confidence,omitempty"`
+
+	// Response Jailbreak Detection Results
+	ResponseJailbreakDetected   bool    `json:"response_jailbreak_detected,omitempty"`
+	ResponseJailbreakType       string  `json:"response_jailbreak_type,omitempty"`
+	ResponseJailbreakConfidence float32 `json:"response_jailbreak_confidence,omitempty"`
 
 	// PII Detection Results
 	PIIDetected bool     `json:"pii_detected,omitempty"`

--- a/src/vllm-sr/cli/templates/config.template.yaml
+++ b/src/vllm-sr/cli/templates/config.template.yaml
@@ -730,6 +730,12 @@ memory:
     prune_threshold: 0.1        # δ: delete memories with R < threshold
     max_memories_per_user: 1000 # 0 = no cap
 
+  # Content jailbreak detection on write path (arXiv:2503.03704)
+  # Runs the jailbreak classifier on response content before storing as memory.
+  content_validation:
+    enabled: true               # on by default when memory is enabled
+    threshold: 0.5              # jailbreak classifier confidence threshold
+
   # Security: auth header for trusted user_id (optional)
   # auth_user_id_header: "x-authenticated-user-id"
   # require_auth_header: false

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -2044,6 +2044,45 @@ This workflow ensures your configuration is:
 - Version controlled for tracking changes
 - Optimized for your specific use case
 
+## Response Jailbreak Detection
+
+Response-level jailbreak detection runs the jailbreak classifier on the **LLM response body** to catch adversarial content that passed input-level detection. This complements the existing input-level jailbreak detection (which scans user requests) by adding a second layer that scans what the LLM actually generates.
+
+The `response_jailbreak` plugin follows the same pattern as the existing `hallucination` plugin — it runs as a general response filter with configurable actions.
+
+### Configuration
+
+Add the `response_jailbreak` plugin to any decision:
+
+```yaml
+decisions:
+  - name: my_decision
+    plugins:
+      - type: response_jailbreak
+        configuration:
+          enabled: true
+          threshold: 0.5    # classifier confidence threshold (default: prompt_guard threshold)
+          action: header     # "header", "block", or "none"
+```
+
+### Actions
+
+| Action | Behavior |
+|--------|----------|
+| `header` | Add `x-vsr-response-jailbreak-*` warning headers to the response (default) |
+| `block` | Return a 403 error response instead of the original |
+| `none` | Log and record metrics only, pass the response through unchanged |
+
+### Response Headers
+
+When `action: header` is configured and jailbreak content is detected:
+
+| Header | Description |
+|--------|-------------|
+| `x-vsr-response-jailbreak-detected` | Set to `true` when jailbreak content is detected |
+| `x-vsr-response-jailbreak-type` | Type of jailbreak detected |
+| `x-vsr-response-jailbreak-confidence` | Confidence score of the detection |
+
 ## Next Steps
 
 - **[Installation Guide](installation.md)** - Setup instructions


### PR DESCRIPTION
## Summary

Adds a `response_jailbreak` plugin that runs the jailbreak classifier on the
LLM **response body**, complementing the existing input-level jailbreak detection.
This follows the same pattern as the existing hallucination response filter.

Motivated by research on memory-targeted attacks
([arXiv:2503.03704](https://arxiv.org/abs/2503.03704)), where adversarial
content in LLM responses can go undetected by input-only scanning.

### What's included

- **`res_filter_jailbreak.go`** — response filter with configurable actions
  (`header`, `block`, `none`), mirroring `res_filter_hallucination.go`
- **`ResponseJailbreakPluginConfig`** — per-decision plugin configuration
- **`x-vsr-response-jailbreak-*` headers** — detection metadata passed to clients
- **`ResponseJailbreakDetected/Type/Confidence`** fields on `RequestContext`
  and router replay records
- Unit tests and documentation

### What's NOT included (separate PR)

Memory protection (gating memory storage with the response jailbreak flag,
removing `ContentValidator`) will follow in a dedicated PR.

## Example configuration

decisions:
  - name: general_chat
    plugins:
      - type: response_jailbreak
        configuration:
          enabled: true
          threshold: 0.5
          action: header   # "header" | "block" | "none"
