### PR TITLE
fix: external model config not picked up from defaults (#1405)

### DIFF
--- a/src/semantic-router/pkg/classification/vllm_client.go
+++ b/src/semantic-router/pkg/classification/vllm_client.go
@@ -23,7 +23,11 @@ type VLLMClient struct {
 
 // NewVLLMClient creates a new vLLM REST API client for classifiers
 func NewVLLMClient(endpoint *config.ClassifierVLLMEndpoint) *VLLMClient {
-	baseURL := fmt.Sprintf("http://%s:%d", endpoint.Address, endpoint.Port)
+	scheme := endpoint.Protocol
+	if scheme == "" {
+		scheme = "http"
+	}
+	baseURL := fmt.Sprintf("%s://%s:%d", scheme, endpoint.Address, endpoint.Port)
 
 	return &VLLMClient{
 		httpClient: &http.Client{

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -1734,6 +1734,10 @@ type ClassifierVLLMEndpoint struct {
 	// Port of the vLLM endpoint
 	Port int `yaml:"port"`
 
+	// Protocol for the endpoint ("http" or "https"). Defaults to "http".
+	// +optional
+	Protocol string `yaml:"protocol,omitempty"`
+
 	// Optional name identifier for the endpoint (for logging and debugging)
 	Name string `yaml:"name,omitempty"`
 

--- a/src/semantic-router/pkg/extproc/req_filter_memory.go
+++ b/src/semantic-router/pkg/extproc/req_filter_memory.go
@@ -313,7 +313,11 @@ func ResolveQueryRewriteConfig(routerCfg *config.RouterConfig) *ResolvedLLMConfi
 		return nil
 	}
 
-	endpoint := fmt.Sprintf("http://%s:%d", externalCfg.ModelEndpoint.Address, externalCfg.ModelEndpoint.Port)
+	scheme := externalCfg.ModelEndpoint.Protocol
+	if scheme == "" {
+		scheme = "http"
+	}
+	endpoint := fmt.Sprintf("%s://%s:%d", scheme, externalCfg.ModelEndpoint.Address, externalCfg.ModelEndpoint.Port)
 	return &ResolvedLLMConfig{
 		Endpoint:       endpoint,
 		Model:          externalCfg.ModelName,


### PR DESCRIPTION
## Summary

Fixes #1405 — external model configuration from `router-defaults.yaml` is silently dropped during config merge.

### Root Cause

Three interconnected bugs in the config merge/translate pipeline:

1. **Config overwrite** (`merger.py` → `merge_configs()`): `merged.update(provider_config)` unconditionally replaces `external_models` from defaults with an empty list when users don't specify any in `config.yaml`.
2. **Endpoint parsing crash** (`merger.py` → `translate_external_models()`): Naive `split(":")` breaks for URLs with schemes (e.g. `https://host:443`).
3. **Hardcoded HTTP protocol** (`vllm_client.go`, `req_filter_memory.go`): `ClassifierVLLMEndpoint` lacks a `Protocol` field, so `NewVLLMClient()` and `ResolveQueryRewriteConfig()` hardcode `http://`.

### Fixes

| Bug | Fix | File |
|-----|-----|------|
| Config overwrite | Skip `external_models` key in `provider_config` when empty, so defaults survive | `merger.py` |
| Endpoint parsing | New `_parse_endpoint()` using `urlparse()` | `merger.py` |
| Hardcoded HTTP | Add `Protocol` field to `ClassifierVLLMEndpoint`; use it in URL construction (default: `"http"`) | `config.go`, `vllm_client.go`, `req_filter_memory.go` |