### PR TITLE
[Doc] Polish homepage and team website surfaces

### DIFF
--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -369,7 +369,7 @@
     "message": "快速开始"
   },
   "homepage.hero.publicBeta": {
-    "message": "在线体验"
+    "message": "抢先体验"
   },
   "homepage.aiTech.label": {
     "message": "基于编码器模型"
@@ -1295,10 +1295,10 @@
     "message": "IBM 研究科学家，专注于 AI 研究和 LLM 推理。"
   },
   "team.members.XunzhuoLiu.role": {
-    "message": "AI 网络"
+    "message": "智能路由"
   },
   "team.members.XunzhuoLiu.bio": {
-    "message": "腾讯 AI 网络工程师，领导 vLLM Semantic Router 开发并推动项目愿景。"
+    "message": "专注于将集体智能带入 LLM 系统。"
   },
   "team.members.SenanZedan.role": {
     "message": "研发经理"

--- a/website/src/components/site/CapabilityGlyph.tsx
+++ b/website/src/components/site/CapabilityGlyph.tsx
@@ -72,17 +72,15 @@ function PluginGlyph(): JSX.Element {
 function LanguageGlyph(): JSX.Element {
   return (
     <>
-      <rect x="18" y="26" width="42" height="30" rx="8" {...strokeProps} />
-      <path d="M30 36h18m-18 10h13m-13 10h9" {...strokeProps} opacity="0.78" />
-      <path d="M60 41h18" {...strokeProps} />
-      <path d="M78 41l10-10m-10 10l10 10" {...strokeProps} />
-      <circle cx="98" cy="31" r="8" {...strokeProps} />
-      <circle cx="98" cy="61" r="8" {...strokeProps} />
-      <path d="M88 41v10m0 0h20" {...strokeProps} />
-      <path d="M98 39v-4m-3 3h6" {...strokeProps} opacity="0.7" />
-      <path d="M95 61h6" {...strokeProps} opacity="0.7" />
-      <circle cx="98" cy="31" r="2.6" fill="currentColor" opacity="0.18" />
-      <circle cx="98" cy="61" r="2.6" fill="currentColor" opacity="0.18" />
+      <circle cx="34" cy="48" r="12" {...strokeProps} />
+      <path d="M46 48h20" {...strokeProps} />
+      <path d="M66 48l9-9m-9 9l9 9" {...strokeProps} />
+      <path d="M82 30h28v12H82zm0 24h28v12H82z" {...strokeProps} />
+      <path d="M96 42v12" {...strokeProps} opacity="0.72" />
+      <path d="M74 48h8m28 0h8" {...strokeProps} opacity="0.78" />
+      <circle cx="34" cy="48" r="3.2" fill="currentColor" opacity="0.18" />
+      <circle cx="96" cy="36" r="2.8" fill="currentColor" opacity="0.18" />
+      <circle cx="96" cy="60" r="2.8" fill="currentColor" opacity="0.18" />
     </>
   )
 }

--- a/website/src/pages/community/team.module.css
+++ b/website/src/pages/community/team.module.css
@@ -139,6 +139,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.42rem;
   min-height: 2.45rem;
   padding: 0.55rem 0.9rem;
   border: 1px solid var(--site-border);
@@ -151,6 +152,12 @@
     background 180ms ease,
     color 180ms ease,
     border-color 180ms ease;
+}
+
+.actionLink svg,
+.actionButton svg {
+  flex-shrink: 0;
+  font-size: 0.9rem;
 }
 
 .actionLink:hover,

--- a/website/src/pages/community/team.tsx
+++ b/website/src/pages/community/team.tsx
@@ -53,12 +53,12 @@ const allTeamMembers: TeamMember[] = [
   },
   {
     name: 'Xunzhuo Liu',
-    role: <Translate id="team.members.XunzhuoLiu.role">AI Networking</Translate>,
-    company: 'Tencent',
+    role: <Translate id="team.members.XunzhuoLiu.role">Intelligent Routing</Translate>,
+    company: 'vLLM',
     avatar: '/img/team/xunzhuo.png',
     github: 'https://github.com/Xunzhuo',
     linkedin: 'https://www.linkedin.com/in/bitliu/',
-    bio: <Translate id="team.members.XunzhuoLiu.bio">AI Networking at Tencent, leading the development of vLLM Semantic Router and driving the project vision.</Translate>,
+    bio: <Translate id="team.members.XunzhuoLiu.bio">Focus on bringing collective intelligence to the LLM systems.</Translate>,
     memberType: 'maintainer',
   },
   {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -144,8 +144,8 @@
   border: 1px solid var(--site-border);
   border-radius: 1.2rem;
   background:
-    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.07), transparent 34%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 38%),
+    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.035), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.016), transparent 34%),
     var(--site-surface);
   text-align: center;
   transition:
@@ -169,14 +169,14 @@
   align-items: center;
   justify-content: center;
   padding: 1rem 1.2rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 1rem;
   background:
-    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.06), transparent 62%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015)),
-    rgba(255, 255, 255, 0.015);
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.028), transparent 58%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.022), rgba(255, 255, 255, 0.006)),
+    rgba(255, 255, 255, 0.008);
   color: rgba(255, 255, 255, 0.52);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .capabilityGlyph {
@@ -202,11 +202,14 @@
 .capabilityCard:hover {
   transform: translateY(-3px);
   border-color: var(--site-border-strong);
-  background: var(--site-surface-alt);
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.04), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 34%),
+    var(--site-surface-alt);
 }
 
 .capabilityCard:hover .capabilityVisual {
-  color: rgba(255, 255, 255, 0.84);
+  color: rgba(255, 255, 255, 0.78);
 }
 
 .capabilityCard:hover .capabilityGlyph {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -73,7 +73,7 @@ const capabilityCards: CapabilityCard[] = [
     kind: 'language',
     title: translate({
       id: 'homepage.capabilities.language.title',
-      message: 'Neural-symbolic language driven',
+      message: 'Intent-to-policy compile',
     }),
     text: translate({
       id: 'homepage.capabilities.language.text',
@@ -229,8 +229,12 @@ function DitherHero(): JSX.Element {
             )}
             actions={(
               <>
-                <PillLink to="/docs/intro">
-                  <Translate id="homepage.hero.primaryCta">Read the docs</Translate>
+                <PillLink
+                  href="https://play.vllm-semantic-router.com/"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  <Translate id="homepage.hero.publicBeta">Public Beta</Translate>
                 </PillLink>
                 <PillLink to="/white-paper" muted>
                   <Translate id="homepage.hero.secondaryCta">Open white paper</Translate>


### PR DESCRIPTION
## Summary

- Scope: polish the homepage CTA, capability cards, and community team cards on the website.
- Primary skill: `cross-stack-bugfix` resolved by `make agent-report` for website-only `docs_examples` changes.
- Impacted surfaces: `docs_examples`
- Conditional surfaces intentionally skipped: `local_e2e`, `ci_e2e` were not hit because the task matrix classified this change as documentation-only website work.
- Behavior-visible change: `yes`
- Debt entry: `none`

## Validation

- Environment: `cpu-local`
- Fast gate: none (matched rule: `repo-docs`)
- Feature gate: not run; documentation-only website change
- Local smoke / E2E: not required by the harness for this change
- CI expectations / blockers:
  - `make agent-ci-gate CHANGED_FILES="website/src/pages/index.tsx website/src/pages/index.module.css website/src/pages/community/team.tsx website/src/pages/community/team.module.css website/i18n/zh-Hans/code.json website/src/components/site/CapabilityGlyph.tsx"`
  - `npm run build`
  - visual verification on local Docusaurus serve for `/`, `/zh-Hans/`, and `/community/team`

## Checklist

- [x] PR title uses the repo prefix format: `[Doc]`
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Source-of-truth docs or indexed debt entries were updated when applicable
- [x] The validation results above reflect the actual commands for this change
