### PR TITLE
[Bugfix] [Dashboard]: restore ML Setup link in navigation menu

### DIFF
--- a/dashboard/frontend/src/components/LayoutNavSupport.ts
+++ b/dashboard/frontend/src/components/LayoutNavSupport.ts
@@ -59,6 +59,7 @@ export const ANALYSIS_OPERATIONS_MENU_SECTIONS: LayoutMenuSection[] = [
   {
     title: 'Operations',
     items: [
+      { kind: 'route', label: 'ML Setup', to: '/ml-setup' },
       { kind: 'config', label: 'Router Config', configSection: 'router-config' },
       { kind: 'config', label: 'MCP Servers', configSection: 'mcp' },
       { kind: 'route', label: 'Status', to: '/status' },

--- a/dashboard/frontend/src/pages/DashboardPage.tsx
+++ b/dashboard/frontend/src/pages/DashboardPage.tsx
@@ -554,6 +554,12 @@ const DashboardPage: React.FC = () => {
                 </svg>
                 Run Evaluation
               </button>
+              <button className={styles.quickLink} onClick={() => navigate('/ml-setup')}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" />
+                </svg>
+                ML Setup
+              </button>
               <button className={styles.quickLink} onClick={() => navigate('/config/models')}>
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                   <rect x="2" y="3" width="20" height="18" rx="3" /><path d="M8 7v10M16 7v10" />


### PR DESCRIPTION
The ML Setup page was added in PR #1342 but its navigation link was dropped when Layout was refactored to data-driven LayoutNavSupport.ts. Add ML Setup entry to the Operations menu section and a quick action button on the Dashboard page.

Closes (https://github.com/vllm-project/semantic-router/issues/1481)

## Summary

- Scope:
- Primary skill:
- Impacted surfaces:
- Conditional surfaces intentionally skipped:
- Behavior-visible change: `yes` / `no`
- Debt entry: `none` / `TDxxx`

## Validation

- Environment: `cpu-local` / `amd-local` / `not run`
- Fast gate:
- Feature gate:
- Local smoke / E2E:
- CI expectations / blockers:

## Checklist

- [x] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
- [x] If the PR spans multiple categories, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Source-of-truth docs or indexed debt entries were updated when applicable
- [x] The validation results above reflect the actual commands or blockers for this change

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
