### PR TITLE
fix(website): show docs links on homepage nav

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -156,14 +156,13 @@ const config: Config = {
         },
         {
           type: 'docsVersionDropdown',
-          className: 'nav-docs-only',
           position: 'right',
           dropdownActiveClassDisabled: true,
         },
         {
           type: 'docSidebar',
           sidebarId: 'tutorialSidebar',
-          className: 'nav-docs-only nav-primary',
+          className: 'nav-primary',
           position: 'left',
           label: 'Docs',
         },


### PR DESCRIPTION
## Summary
- Remove homepage-specific hiding class from docs navigation entries.

This change updates the navbar config to stop marking Docs and version dropdown with `nav-docs-only`, so the docs links are visible on the homepage as well.

## Testing
- Verified diff is limited to `website/docusaurus.config.ts`.
- Manual expectation: docs items should now appear on homepage navbar.
