### PR TITLE
fix: switch default domain classifier to mmBERT-32K (52.6% → 65.6%)

### DIFF
--- a/src/semantic-router/pkg/config/registry.go
+++ b/src/semantic-router/pkg/config/registry.go
@@ -66,17 +66,16 @@ type ModelSpec struct {
 var DefaultModelRegistry = []ModelSpec{
 	// Domain/Intent Classification
 	{
-		LocalPath:           "models/mom-domain-classifier",
-		RepoID:              "LLM-Semantic-Router/lora_intent_classifier_bert-base-uncased_model",
-		Aliases:             []string{"domain-classifier", "intent-classifier", "category-classifier", "category_classifier_modernbert-base_model", "lora_intent_classifier_bert-base-uncased_model"},
-		Purpose:             PurposeDomainClassification,
-		Description:         "Domain/intent classifier using BERT-base-uncased LoRA adapter. Can be used with ModernBERT-base-32k base model for extended context, but LoRA weights were trained on 512-token context.",
-		ParameterSize:       "149M (ModernBERT-base-32k) + classifier",
-		UsesLoRA:            true,
-		NumClasses:          14,    // MMLU categories
-		MaxContextLength:    512,   // LoRA weights trained on 512 tokens - safe maximum
-		BaseModelMaxContext: 32768, // Base model (ModernBERT-base-32k) supports 32K, but use with caution beyond MaxContextLength
-		Tags:                []string{"classification", "lora", "mmlu", "domain", "modernbert"},
+		LocalPath:        "models/mom-domain-classifier",
+		RepoID:           "llm-semantic-router/mmbert32k-intent-classifier-merged",
+		Aliases:          []string{"domain-classifier", "intent-classifier", "category-classifier", "category_classifier_modernbert-base_model", "lora_intent_classifier_bert-base-uncased_model"},
+		Purpose:          PurposeDomainClassification,
+		Description:      "mmBERT-32K merged intent classifier for MMLU-Pro categories",
+		ParameterSize:    "307M",
+		UsesLoRA:         false,
+		NumClasses:       14, // MMLU categories
+		MaxContextLength: 32768,
+		Tags:             []string{"classification", "merged", "mmlu", "domain", "mmbert-32k"},
 	},
 
 	// PII Detection - BERT LoRA

--- a/src/semantic-router/pkg/config/registry_max_context_test.go
+++ b/src/semantic-router/pkg/config/registry_max_context_test.go
@@ -5,21 +5,15 @@ import (
 )
 
 // TestMaxContextLength_SafeValues verifies that MaxContextLength reflects
-// the actual training context length (512 tokens) for BERT LoRA models,
-// while BaseModelMaxContext indicates the base model's capability (32K)
+// the model's supported context length
 func TestMaxContextLength_SafeValues(t *testing.T) {
-	// Test Domain Classifier
+	// Test Domain Classifier (mmBERT-32K merged model)
 	domainModel := GetModelByPath("models/mom-domain-classifier")
 	if domainModel == nil {
 		t.Fatal("Domain classifier model not found")
 	}
-	// MaxContextLength should be 512 (trained context length)
-	if domainModel.MaxContextLength != 512 {
-		t.Errorf("Domain Classifier: Expected MaxContextLength=512 (trained length), got %d", domainModel.MaxContextLength)
-	}
-	// BaseModelMaxContext should be 32768 (base model capability)
-	if domainModel.BaseModelMaxContext != 32768 {
-		t.Errorf("Domain Classifier: Expected BaseModelMaxContext=32768 (base model supports 32K), got %d", domainModel.BaseModelMaxContext)
+	if domainModel.MaxContextLength != 32768 {
+		t.Errorf("Domain Classifier: Expected MaxContextLength=32768, got %d", domainModel.MaxContextLength)
 	}
 
 	// Test PII Detector
@@ -50,16 +44,13 @@ func TestMaxContextLength_SafeValues(t *testing.T) {
 // TestMaxContextLength_ByAlias verifies that MaxContextLength and BaseModelMaxContext
 // are correct when accessing models by their aliases
 func TestMaxContextLength_ByAlias(t *testing.T) {
-	// Test Domain Classifier by alias
+	// Test Domain Classifier by alias (mmBERT-32K merged model)
 	domainByAlias := GetModelByPath("domain-classifier")
 	if domainByAlias == nil {
 		t.Fatal("Domain classifier not found by alias")
 	}
-	if domainByAlias.MaxContextLength != 512 {
-		t.Errorf("Domain Classifier (by alias): Expected MaxContextLength=512, got %d", domainByAlias.MaxContextLength)
-	}
-	if domainByAlias.BaseModelMaxContext != 32768 {
-		t.Errorf("Domain Classifier (by alias): Expected BaseModelMaxContext=32768, got %d", domainByAlias.BaseModelMaxContext)
+	if domainByAlias.MaxContextLength != 32768 {
+		t.Errorf("Domain Classifier (by alias): Expected MaxContextLength=32768, got %d", domainByAlias.MaxContextLength)
 	}
 
 	// Test PII Detector by alias

--- a/src/semantic-router/pkg/config/registry_test.go
+++ b/src/semantic-router/pkg/config/registry_test.go
@@ -25,7 +25,7 @@ func TestToLegacyRegistry_IncludesAliases(t *testing.T) {
 		"mmbert-pii-detector",
 	)
 	assertRegistryAliases(t, registry,
-		"LLM-Semantic-Router/lora_intent_classifier_bert-base-uncased_model",
+		"llm-semantic-router/mmbert32k-intent-classifier-merged",
 		"models/mom-domain-classifier",
 		"models/category_classifier_modernbert-base_model",
 		"models/lora_intent_classifier_bert-base-uncased_model",


### PR DESCRIPTION
## Summary

Switch the default domain classifier from BERT-base + LoRA (`LLM-Semantic-Router/lora_intent_classifier_bert-base-uncased_model`) to the mmBERT-32K merged model (`llm-semantic-router/mmbert32k-intent-classifier-merged`).

Benchmark on 994 unseen queries shows **52.6% → 65.6% accuracy** (+13 points). The biggest gains are in the weakest domains: engineering 15.5%→70.4%, business 9.9%→53.5%, history 23.9%→60.6%.

Full benchmark data and methodology in #1485.

## What changed

**`registry.go`** — Updated the `mom-domain-classifier` entry:
- `RepoID`: `LLM-Semantic-Router/lora_intent_classifier_bert-base-uncased_model` → `llm-semantic-router/mmbert32k-intent-classifier-merged`
- `UsesLoRA`: `true` → `false` (merged model, no LoRA adapter needed)
- `MaxContextLength`: `512` → `32768` (merged model natively supports 32K, no LoRA training limitation)
- Removed `BaseModelMaxContext` field (not needed when the model directly supports full context)

**`registry_test.go`** — Updated expected repo ID to match the new default.

**`registry_max_context_test.go`** — Updated expected `MaxContextLength` from 512 to 32768 for the domain classifier, since the merged model is not constrained by LoRA training length.

## Backwards compatibility

- All existing aliases (`domain-classifier`, `intent-classifier`, `category-classifier`, `lora_intent_classifier_bert-base-uncased_model`, etc.) still resolve to `models/mom-domain-classifier`. Existing configs that reference the old model name will continue to work — they'll just get the better model.
- The `models/mom-domain-classifier` local path is unchanged, so deployment scripts and config files don't need updates.

## Resource impact

| Metric | BERT+LoRA (old) | mmBERT-32K (new) |
|--------|:-:|:-:|
| Inference speed | 14ms/query | 22ms/query |
| RAM | ~420 MB | ~1.2 GB |
| Disk | 419 MB | 1.2 GB |
| Accuracy (994 queries) | 52.6% | 65.6% |

## Benchmark tool

A standalone benchmark script (994 labeled test queries, runs in ~24s on CPU) will be submitted as a separate PR to `src/training/model_eval/`.

Fixes #1485