### PR TITLE
Fix release versioning and publish tag artifacts

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [extproc, extproc-rocm, llm-katan, vllm-sr, vllm-sr-rocm]
+        image: [dashboard, extproc, extproc-rocm, llm-katan, vllm-sr, vllm-sr-rocm]
       fail-fast: false
 
     steps:
@@ -182,7 +182,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [extproc, llm-katan, vllm-sr]
+        image: [dashboard, extproc, llm-katan, vllm-sr]
         platform: [linux/amd64, linux/arm64]
       fail-fast: false
 
@@ -548,7 +548,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [extproc, llm-katan, vllm-sr]
+        image: [dashboard, extproc, llm-katan, vllm-sr]
       fail-fast: false
 
     steps:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -52,6 +52,48 @@ jobs:
           ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/extproc:${{ steps.extract_tag.outputs.tag }}
           ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/extproc:latest
 
+  build_and_push_vllm_sr:
+    if: github.repository == 'vllm-project/semantic-router'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Extract tag name
+      id: extract_tag
+      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+    - name: Set lowercase repository owner
+      run: echo "REPOSITORY_OWNER_LOWER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push vllm-sr Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./src/vllm-sr/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/vllm-sr:${{ steps.extract_tag.outputs.tag }}
+          ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/vllm-sr:latest
+
   build_and_push_extproc_rocm:
     if: github.repository == 'vllm-project/semantic-router'
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -7,11 +7,15 @@ on:
       - main
     paths:
       - "deploy/helm/**"
+      - ".github/workflows/helm-publish.yml"
   push:
     branches:
       - main
+    tags:
+      - "v*"
     paths:
       - "deploy/helm/**"
+      - ".github/workflows/helm-publish.yml"
   workflow_dispatch:
 
 env:
@@ -29,6 +33,8 @@ jobs:
       contents: read
     outputs:
       chart-name: ${{ steps.package.outputs.name }}
+      chart-version: ${{ steps.versions.outputs.chart_version }}
+      chart-app-version: ${{ steps.versions.outputs.app_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v4
@@ -38,19 +44,54 @@ jobs:
       - name: Lint chart
         run: helm lint ${{ env.CHART_PATH }}
 
+      - name: Resolve chart versions
+        id: versions
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "chart_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            echo "app_version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "chart_version=0.0.0-pr.${{ github.event.number }}" >> $GITHUB_OUTPUT
+            echo "app_version=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "chart_version=0.0.0-latest" >> $GITHUB_OUTPUT
+            echo "app_version=latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Package chart
         id: package
         run: |
-          helm package -u ${{ env.CHART_PATH }} --version v0.0.0-latest --destination .
+          helm package -u ${{ env.CHART_PATH }} \
+            --version "${{ steps.versions.outputs.chart_version }}" \
+            --app-version "${{ steps.versions.outputs.app_version }}" \
+            --destination .
           echo "name=$(ls *.tgz)" >> $GITHUB_OUTPUT
 
       - name: Upload packaged chart
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: helm-chart
           path: "*.tgz"
           retention-days: 1
+
+      - name: Create package summary
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          ## Helm Chart Package
+
+          - Chart: \`${{ env.CHART_NAME }}\`
+          - Version: \`${{ steps.versions.outputs.chart_version }}\`
+          - App Version: \`${{ steps.versions.outputs.app_version }}\`
+          - Package: \`${{ steps.package.outputs.name }}\`
+          - Event: \`${{ github.event_name }}\`
+          EOF
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            cat >> $GITHUB_STEP_SUMMARY << EOF
+
+          This PR run uploads the packaged chart as the \`helm-chart\` workflow artifact.
+          EOF
+          fi
 
   publish-chart:
     name: Publish to GHCR
@@ -83,18 +124,19 @@ jobs:
           ## 📦 Helm Chart Published
 
           **Chart:** \`${{ env.CHART_NAME }}\`
-          **Version:** \`v0.0.0-latest\`
+          **Version:** \`${{ needs.validate-and-package.outputs.chart-version }}\`
+          **App Version:** \`${{ needs.validate-and-package.outputs.chart-app-version }}\`
           **Registry:** \`${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts\`
 
           ### Installation
 
           \`\`\`bash
           # Pull the chart
-          helm pull oci://${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts/${{ env.CHART_NAME }} --version v0.0.0-latest
+          helm pull oci://${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts/${{ env.CHART_NAME }} --version ${{ needs.validate-and-package.outputs.chart-version }}
 
           # Install directly
           helm install semantic-router oci://${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts/${{ env.CHART_NAME }} \\
-            --version v0.0.0-latest \\
+            --version ${{ needs.validate-and-package.outputs.chart-version }} \\
             --namespace vllm-semantic-router-system \\
             --create-namespace
           \`\`\`
@@ -103,7 +145,7 @@ jobs:
 
           \`\`\`bash
           helm upgrade semantic-router oci://${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts/${{ env.CHART_NAME }} \\
-            --version v0.0.0-latest \\
+            --version ${{ needs.validate-and-package.outputs.chart-version }} \\
             --namespace vllm-semantic-router-system
           \`\`\`
           EOF

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - develop
+    tags:
+      - 'v*'
     paths:
       - 'deploy/operator/**'
       - '.github/workflows/operator-ci.yml'
@@ -154,7 +156,11 @@ jobs:
         id: operator-remote-tags
         if: github.event_name != 'pull_request'
         run: |
-          TAG="${{ github.sha }}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG="${{ github.sha }}"
+          fi
           TAGS="ghcr.io/${REPOSITORY_OWNER_LOWER}/semantic-router/operator:${TAG},ghcr.io/${REPOSITORY_OWNER_LOWER}/semantic-router/operator:latest"
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
@@ -162,7 +168,11 @@ jobs:
         id: bundle-remote-tags
         if: github.event_name != 'pull_request'
         run: |
-          TAG="${{ github.sha }}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG="${{ github.sha }}"
+          fi
           TAGS="ghcr.io/${REPOSITORY_OWNER_LOWER}/semantic-router/operator-bundle:${TAG},ghcr.io/${REPOSITORY_OWNER_LOWER}/semantic-router/operator-bundle:latest"
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 

--- a/candle-binding/Cargo.lock
+++ b/candle-binding/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "candle-semantic-router"
-version = "0.4.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/candle-binding/Cargo.toml
+++ b/candle-binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candle-semantic-router"
-version = "0.4.0"
+version = "0.2.0"
 edition = "2021"
 description = "Go bindings for Candle BERT semantic similarity model for LLM routing"
 license = "MIT OR Apache-2.0"

--- a/deploy/helm/semantic-router/Chart.yaml
+++ b/deploy/helm/semantic-router/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: semantic-router
 description: A Helm chart for deploying Semantic Router - an intelligent routing system for LLM applications
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"
 keywords:
   - semantic-router

--- a/deploy/helm/semantic-router/templates/configmap.yaml
+++ b/deploy/helm/semantic-router/templates/configmap.yaml
@@ -4,6 +4,7 @@
 {{- $observability := (get $config "observability") | default (dict) -}}
 {{- $tracing := (get $observability "tracing") | default (dict) -}}
 {{- $tracingExporter := (get $tracing "exporter") | default (dict) -}}
+{{- $tracingResource := (get $tracing "resource") | default (dict) -}}
 {{- $semanticBackend := (get $semanticCache "backend_type") | default "" -}}
 {{- $responseBackend := (get $responseAPI "store_backend") | default "" -}}
 {{- $responseEnabled := (get $responseAPI "enabled") | default false -}}
@@ -28,8 +29,15 @@
 {{- if and $tracingEnabled .Values.dependencies.observability.jaeger.enabled -}}
 {{- $_ := set $tracingExporter "endpoint" (include "semantic-router.jaeger.otlpEndpoint" .) -}}
 {{- $_ := set $tracing "exporter" $tracingExporter -}}
-{{- $_ := set $observability "tracing" $tracing -}}
 {{- end -}}
+
+{{- if and (gt (len $tracingResource) 0) .Chart.AppVersion (eq ((get $tracingResource "service_version") | default "") "") -}}
+{{- $_ := set $tracingResource "service_version" .Chart.AppVersion -}}
+{{- end -}}
+{{- if gt (len $tracingResource) 0 -}}
+{{- $_ := set $tracing "resource" $tracingResource -}}
+{{- end -}}
+{{- $_ := set $observability "tracing" $tracing -}}
 
 {{- $_ := set $config "semantic_cache" $semanticCache -}}
 {{- $_ := set $config "response_api" $responseAPI -}}

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image tag (overrides the image tag whose default is the chart appVersion)
-  tag: "latest"
+  tag: ""
 
 # -- Image pull secrets for private registries
 imagePullSecrets: []
@@ -326,7 +326,7 @@ config:
         rate: 1.0
       resource:
         service_name: "vllm-semantic-router"
-        service_version: "v0.1.0"
+        service_version: ""
         deployment_environment: "development"
 
 # Tools database configuration

--- a/src/vllm-sr/cli/__init__.py
+++ b/src/vllm-sr/cli/__init__.py
@@ -1,3 +1,31 @@
 """vLLM Semantic Router CLI package."""
 
-__version__ = "0.1.0"
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+_PYPROJECT_VERSION_PATTERN = re.compile(
+    r'^version = "(?P<version>[^"]+)"$', re.MULTILINE
+)
+
+
+def _load_version() -> str:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    try:
+        match = _PYPROJECT_VERSION_PATTERN.search(
+            pyproject_path.read_text(encoding="utf-8")
+        )
+    except FileNotFoundError:
+        match = None
+    if match is not None:
+        return match.group("version")
+
+    try:
+        return version("vllm-sr")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = _load_version()

--- a/src/vllm-sr/cli/consts.py
+++ b/src/vllm-sr/cli/consts.py
@@ -1,10 +1,12 @@
 """Constants for vLLM Semantic Router CLI."""
 
+from cli import __version__
+
 # Docker image configuration
 VLLM_SR_DOCKER_IMAGE_DEFAULT = "ghcr.io/vllm-project/semantic-router/vllm-sr:latest"
 VLLM_SR_DOCKER_IMAGE_ROCM = "ghcr.io/vllm-project/semantic-router/vllm-sr-rocm:latest"
 VLLM_SR_DOCKER_IMAGE_DEV = "vllm-sr:dev"
-VLLM_SR_DOCKER_IMAGE_RELEASE = "vllm-sr:0.1.0"
+VLLM_SR_DOCKER_IMAGE_RELEASE = f"vllm-sr:{__version__}"
 VLLM_SR_DOCKER_NAME = "vllm-sr-container"
 PLATFORM_AMD = "amd"
 

--- a/src/vllm-sr/cli/templates/router-defaults.yaml
+++ b/src/vllm-sr/cli/templates/router-defaults.yaml
@@ -233,7 +233,7 @@ observability:
       rate: 1.0  # Sampling rate for probabilistic (0.0-1.0)
     resource:
       service_name: "vllm-sr"
-      service_version: "v0.1.0"
+      service_version: "v0.2.0"
       deployment_environment: "development"
 
 # Looper Configuration

--- a/src/vllm-sr/pyproject.toml
+++ b/src/vllm-sr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vllm-sr"
-version = "0.1.0.beta.2"
+version = "0.2.0"
 description = "vLLM Semantic Router - Intelligent routing for Mixture-of-Models"
 authors = [{name = "vLLM-SR Team"}]
 readme = "README.md"
@@ -54,4 +54,3 @@ packages = ["cli", "cli.commands", "cli.templates"]
 [tool.pytest.ini_options]
 addopts = ["-v"]
 testpaths = ["tests"]
-

--- a/src/vllm-sr/tests/test_cli_main.py
+++ b/src/vllm-sr/tests/test_cli_main.py
@@ -1,10 +1,30 @@
+import re
+import sys
 from pathlib import Path
 
 import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from cli.bootstrap import BootstrapResult
 from cli.commands import runtime as runtime_commands
 from cli.main import main
 from click.testing import CliRunner
+
+_PYPROJECT_VERSION_PATTERN = re.compile(
+    r'^version = "(?P<version>[^"]+)"$', re.MULTILINE
+)
+
+
+def _project_version() -> str:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    match = _PYPROJECT_VERSION_PATTERN.search(
+        pyproject_path.read_text(encoding="utf-8")
+    )
+    assert match is not None
+    return match.group("version")
 
 
 def test_cli_help_lists_registered_commands():
@@ -24,6 +44,16 @@ def test_cli_help_lists_registered_commands():
         "dashboard",
     ):
         assert command_name in result.output
+
+
+def test_cli_version_matches_project_metadata():
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["--version"])
+    expected_version = _project_version()
+
+    assert result.exit_code == 0
+    assert result.output.strip() == f"vllm-sr version: {expected_version}"
 
 
 def test_inject_algorithm_into_config_updates_all_decisions(tmp_path: Path):

--- a/src/vllm-sr/uv.lock
+++ b/src/vllm-sr/uv.lock
@@ -910,7 +910,7 @@ wheels = [
 
 [[package]]
 name = "vllm-sr"
-version = "0.1.0b2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- align `vllm-sr` Python package and `candle-semantic-router` crate versions with the `v0.2.0` release tag
- make CLI/chart defaults derive from release metadata instead of stale hard-coded versions
- ensure tag releases publish versioned Docker/ROCm/operator artifacts and a versioned Helm chart
- expose packaged Helm chart artifacts on PR runs and include dashboard in PR/main Docker build matrices

## Validation
- `pytest /Users/bitliu/vs/src/vllm-sr/tests/test_cli_main.py`
- `make agent-lint CHANGED_FILES="src/vllm-sr/pyproject.toml src/vllm-sr/cli/__init__.py src/vllm-sr/cli/consts.py src/vllm-sr/cli/templates/router-defaults.yaml src/vllm-sr/tests/test_cli_main.py src/vllm-sr/uv.lock candle-binding/Cargo.toml candle-binding/Cargo.lock .github/workflows/docker-release.yml .github/workflows/docker-publish.yml .github/workflows/helm-publish.yml .github/workflows/operator-ci.yml deploy/helm/semantic-router/Chart.yaml deploy/helm/semantic-router/values.yaml deploy/helm/semantic-router/templates/configmap.yaml"`
- `make vllm-sr-test`
- `make test-binding-minimal`
- `make agent-validate`
- `helm lint deploy/helm/semantic-router`
- packaged and rendered Helm chart at version `0.2.0` to confirm default image/app/service versions resolve to `v0.2.0`

## Notes
- `make test-binding-lora` still fails in the current environment because required LoRA/embedding models are missing or return Hugging Face 404s; this predates the version/publish changes.
