### PR TITLE
[Doc] tolerate README admonition list style

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ For detailed setup options, platform notes, and troubleshooting, see the **[Docs
 
 > [!IMPORTANT]
 > Online [playground](https://play.vllm-semantic-router.com) default credentials:
+>
+> <!-- markdownlint-disable MD004 MD032 -->
 > + username: `love@vllm-sr.ai`
 > + password: `vllm-sr`
+> <!-- markdownlint-enable MD004 MD032 -->
 
 ## Goals
 


### PR DESCRIPTION
## Summary

- Scope: keep the existing `> + username/password` formatting in the top-level README playground admonition while scoping markdownlint tolerance to that block only.
- Primary skill: `harness-contract-change`
- Impacted surfaces: `contributor_interface`
- Conditional surfaces intentionally skipped: `harness_exec`, `ci_e2e`
- Behavior-visible change: `no`
- Debt entry: `none`

## Validation

- Environment: `cpu-local`
- Fast gate: `make agent-report ENV=cpu CHANGED_FILES="README.md"` (docs-only classification; no fast tests required), `make agent-lint CHANGED_FILES="README.md"`
- Feature gate: `not run` (docs-only classification)
- Local smoke / E2E: `not run` (not required)
- CI expectations / blockers: `make markdown-lint` and `make agent-validate` both pass locally; no known blockers.

## Checklist

- [x] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
- [x] If the PR spans multiple categories, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Source-of-truth docs or indexed debt entries were updated when applicable
- [x] The validation results above reflect the actual commands or blockers for this change
