### PR TITLE
fix(dashboard): stop setup wizard validation loop

### DIFF
--- a/dashboard/frontend/e2e/setup-wizard.spec.ts
+++ b/dashboard/frontend/e2e/setup-wizard.spec.ts
@@ -56,6 +56,104 @@ const importedConfig = {
 };
 
 test.describe("Setup wizard routing import", () => {
+  test("validates the default from-scratch config once and reaches ready", async ({
+    page,
+  }) => {
+    let validateCallCount = 0;
+    let validatePayload: Record<string, unknown> | null = null;
+
+    await mockAuthenticatedAppShell(page, {
+      setupState: {
+        setupMode: true,
+        listenerPort: 8700,
+        models: 0,
+        decisions: 0,
+        hasModels: false,
+        hasDecisions: false,
+        canActivate: false,
+      },
+      settings: {
+        readonlyMode: false,
+        setupMode: true,
+        platform: "",
+        envoyUrl: "",
+      },
+    });
+
+    await page.route("**/api/setup/validate", async (route) => {
+      validateCallCount += 1;
+      validatePayload = route.request().postDataJSON() as Record<
+        string,
+        unknown
+      >;
+      await route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          valid: true,
+          config: validatePayload?.config,
+          models: 1,
+          decisions: 1,
+          signals: 0,
+          canActivate: true,
+        }),
+      });
+    });
+
+    await page.goto("/setup");
+
+    await expect(
+      page.getByRole("heading", { name: "Connect your first model" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Next" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Choose how routing should begin" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Next" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Review and activate" }),
+    ).toBeVisible();
+    await expect
+      .poll(() => validatePayload)
+      .toEqual({
+        config: {
+          providers: {
+            models: [
+              {
+                name: "openai/gpt-oss-120b",
+                endpoints: [
+                  {
+                    name: "primary",
+                    weight: 100,
+                    endpoint: "vllm-gpt-oss-120b:8000",
+                    protocol: "http",
+                  },
+                ],
+              },
+            ],
+            default_model: "openai/gpt-oss-120b",
+          },
+          decisions: [
+            {
+              name: "default-route",
+              description:
+                "Generated during setup to route all requests to the default model.",
+              priority: 100,
+              rules: { operator: "AND", conditions: [] },
+              modelRefs: [
+                { model: "openai/gpt-oss-120b", use_reasoning: false },
+              ],
+            },
+          ],
+        },
+      });
+    await expect(page.getByText("Ready")).toBeVisible();
+    await page.waitForTimeout(300);
+    await expect.poll(() => validateCallCount).toBe(1);
+  });
+
   test("imports a remote config and carries it into review", async ({
     page,
   }) => {

--- a/dashboard/frontend/src/pages/SetupWizardPage.tsx
+++ b/dashboard/frontend/src/pages/SetupWizardPage.tsx
@@ -134,11 +134,17 @@ const SetupWizardPage: React.FC = () => {
   const validationSignature = draftConfig ? JSON.stringify(draftConfig) : "";
 
   useEffect(() => {
-    if (currentStep !== 2 || !draftConfig) {
+    if (currentStep !== 2 || !validationSignature) {
       return;
     }
 
     let cancelled = false;
+    // Scratch configs are rebuilt on every render, so key auto-validation off a
+    // stable serialized payload instead of object identity.
+    const validationPayload = JSON.parse(validationSignature) as Record<
+      string,
+      unknown
+    >;
 
     const runValidation = async () => {
       setValidationState("validating");
@@ -146,12 +152,12 @@ const SetupWizardPage: React.FC = () => {
       setActivationError(null);
 
       try {
-        const result = await validateSetupConfig(draftConfig);
+        const result = await validateSetupConfig(validationPayload);
         if (cancelled) {
           return;
         }
 
-        setValidatedConfig(result.config ?? draftConfig);
+        setValidatedConfig(result.config ?? validationPayload);
         setValidatedCounts({
           models: result.models,
           decisions: result.decisions,
@@ -178,7 +184,7 @@ const SetupWizardPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [currentStep, draftConfig, validationSignature]);
+  }, [currentStep, validationSignature]);
 
   const addModel = () => {
     setModels((prev) => [...prev, createModelDraft(prev.length + 1)]);


### PR DESCRIPTION
## Summary
- stop the setup review auto-validation effect from retriggering on every render in from-scratch mode
- validate against a stable serialized payload so the review step can settle to Ready after a successful response
- add a Playwright regression test that covers the default from-scratch onboarding path and asserts validate only runs once

## Root cause
The review-step effect depended on `draftConfig`, and the from-scratch draft is rebuilt on every render. That kept retriggering validation and resetting the UI back to `validating` even after `/api/setup/validate` had already returned `valid: true`.

## Validation
- make dashboard-check
- cd dashboard/frontend && npx playwright test e2e/setup-wizard.spec.ts
- make agent-ci-gate CHANGED_FILES="dashboard/frontend/src/pages/SetupWizardPage.tsx dashboard/frontend/e2e/setup-wizard.spec.ts"