### PR TITLE
[Feat][Router] Harden RAG and memory usability for production workflows

### DIFF
--- a/src/semantic-router/pkg/config/plugin_config.go
+++ b/src/semantic-router/pkg/config/plugin_config.go
@@ -156,6 +156,40 @@ func (d *Decision) GetFastResponseConfig() *FastResponsePluginConfig {
 	return decodeDecisionPlugin(d, "fast_response", result)
 }
 
+// IsRAGEnabledForDecision returns whether RAG is enabled for a specific decision.
+// Checks the per-decision RAG plugin config (enabled: true).
+func (c *RouterConfig) IsRAGEnabledForDecision(decisionName string) bool {
+	decision := c.GetDecisionByName(decisionName)
+	if decision == nil {
+		return false
+	}
+	ragConfig := decision.GetRAGConfig()
+	return ragConfig != nil && ragConfig.Enabled
+}
+
+// IsMemoryEnabledForDecision returns whether memory is enabled for a specific decision.
+// A decision has memory enabled if:
+//   - It has a per-decision memory plugin with enabled: true, OR
+//   - Global memory is enabled and the decision does NOT have a per-decision
+//     memory plugin that explicitly disables it.
+func (c *RouterConfig) IsMemoryEnabledForDecision(decisionName string) bool {
+	decision := c.GetDecisionByName(decisionName)
+	if decision == nil {
+		return c.Memory.Enabled
+	}
+	memConfig := decision.GetMemoryConfig()
+	if memConfig != nil {
+		return memConfig.Enabled
+	}
+	return c.Memory.Enabled
+}
+
+// HasPersonalizationPlugins returns true if the decision has RAG or memory
+// enabled, meaning cached responses would miss personalized context.
+func (c *RouterConfig) HasPersonalizationPlugins(decisionName string) bool {
+	return c.IsRAGEnabledForDecision(decisionName) || c.IsMemoryEnabledForDecision(decisionName)
+}
+
 func decodeDecisionPlugin[T any](d *Decision, pluginType string, result *T) *T {
 	plugin := d.GetPlugin(pluginType)
 	if plugin == nil || plugin.Configuration == nil {

--- a/src/semantic-router/pkg/config/plugin_config_test.go
+++ b/src/semantic-router/pkg/config/plugin_config_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IsRAGEnabledForDecision", func() {
+	It("returns false for decision without RAG plugin", func() {
+		cfg := &RouterConfig{
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{Name: "no-rag", ModelRefs: []ModelRef{{Model: "m"}}},
+				},
+			},
+		}
+		Expect(cfg.IsRAGEnabledForDecision("no-rag")).To(BeFalse())
+	})
+
+	It("returns false when RAG plugin is explicitly disabled", func() {
+		cfg := &RouterConfig{
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{
+						Name:      "rag-disabled",
+						ModelRefs: []ModelRef{{Model: "m"}},
+						Plugins: []DecisionPlugin{
+							{Type: "rag", Configuration: MustStructuredPayload(map[string]interface{}{
+								"enabled": false,
+								"backend": "milvus",
+							})},
+						},
+					},
+				},
+			},
+		}
+		Expect(cfg.IsRAGEnabledForDecision("rag-disabled")).To(BeFalse())
+	})
+
+	It("returns true when RAG plugin is enabled", func() {
+		cfg := &RouterConfig{
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{
+						Name:      "rag-on",
+						ModelRefs: []ModelRef{{Model: "m"}},
+						Plugins: []DecisionPlugin{
+							{Type: "rag", Configuration: MustStructuredPayload(map[string]interface{}{
+								"enabled": true,
+								"backend": "milvus",
+							})},
+						},
+					},
+				},
+			},
+		}
+		Expect(cfg.IsRAGEnabledForDecision("rag-on")).To(BeTrue())
+	})
+
+	It("returns false for non-existent decision", func() {
+		cfg := &RouterConfig{}
+		Expect(cfg.IsRAGEnabledForDecision("nonexistent")).To(BeFalse())
+	})
+})
+
+var _ = Describe("IsMemoryEnabledForDecision", func() {
+	It("returns false when global memory is disabled and no per-decision config", func() {
+		cfg := &RouterConfig{
+			Memory: MemoryConfig{Enabled: false},
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{Name: "test", ModelRefs: []ModelRef{{Model: "m"}}},
+				},
+			},
+		}
+		Expect(cfg.IsMemoryEnabledForDecision("test")).To(BeFalse())
+	})
+
+	It("returns true when global memory is enabled and no per-decision override", func() {
+		cfg := &RouterConfig{
+			Memory: MemoryConfig{Enabled: true},
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{Name: "test", ModelRefs: []ModelRef{{Model: "m"}}},
+				},
+			},
+		}
+		Expect(cfg.IsMemoryEnabledForDecision("test")).To(BeTrue())
+	})
+
+	It("returns false when per-decision memory plugin explicitly disables memory", func() {
+		cfg := memoryDecisionConfig(true, false)
+		Expect(cfg.IsMemoryEnabledForDecision("mem-off")).To(BeFalse())
+	})
+
+	It("returns true when per-decision memory plugin enables memory", func() {
+		cfg := memoryDecisionConfig(false, true)
+		Expect(cfg.IsMemoryEnabledForDecision("mem-on")).To(BeTrue())
+	})
+
+	It("returns global default for non-existent decision", func() {
+		cfg := &RouterConfig{Memory: MemoryConfig{Enabled: true}}
+		Expect(cfg.IsMemoryEnabledForDecision("nonexistent")).To(BeTrue())
+	})
+})
+
+var _ = Describe("HasPersonalizationPlugins", func() {
+	It("returns false when neither RAG nor memory is enabled", func() {
+		cfg := &RouterConfig{
+			Memory: MemoryConfig{Enabled: false},
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{Name: "plain", ModelRefs: []ModelRef{{Model: "m"}}},
+				},
+			},
+		}
+		Expect(cfg.HasPersonalizationPlugins("plain")).To(BeFalse())
+	})
+
+	It("returns true when only RAG is enabled", func() {
+		cfg := ragDecisionConfig("rag-only")
+		Expect(cfg.HasPersonalizationPlugins("rag-only")).To(BeTrue())
+	})
+
+	It("returns true when only memory is enabled (global)", func() {
+		cfg := &RouterConfig{
+			Memory: MemoryConfig{Enabled: true},
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{Name: "mem-global", ModelRefs: []ModelRef{{Model: "m"}}},
+				},
+			},
+		}
+		Expect(cfg.HasPersonalizationPlugins("mem-global")).To(BeTrue())
+	})
+
+	It("returns true when both RAG and memory are enabled", func() {
+		cfg := &RouterConfig{
+			Memory: MemoryConfig{Enabled: true},
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{
+						Name:      "both",
+						ModelRefs: []ModelRef{{Model: "m"}},
+						Plugins: []DecisionPlugin{
+							{Type: "rag", Configuration: MustStructuredPayload(map[string]interface{}{
+								"enabled": true,
+								"backend": "external_api",
+							})},
+							{Type: "memory", Configuration: MustStructuredPayload(map[string]interface{}{
+								"enabled": true,
+							})},
+						},
+					},
+				},
+			},
+		}
+		Expect(cfg.HasPersonalizationPlugins("both")).To(BeTrue())
+	})
+})
+
+func ragDecisionConfig(name string) *RouterConfig {
+	return &RouterConfig{
+		Memory: MemoryConfig{Enabled: false},
+		IntelligentRouting: IntelligentRouting{
+			Decisions: []Decision{
+				{
+					Name:      name,
+					ModelRefs: []ModelRef{{Model: "m"}},
+					Plugins: []DecisionPlugin{
+						{Type: "rag", Configuration: MustStructuredPayload(map[string]interface{}{
+							"enabled": true,
+							"backend": "milvus",
+						})},
+					},
+				},
+			},
+		},
+	}
+}
+
+func memoryDecisionConfig(globalEnabled, perDecisionEnabled bool) *RouterConfig {
+	name := "mem-on"
+	if !perDecisionEnabled {
+		name = "mem-off"
+	}
+	return &RouterConfig{
+		Memory: MemoryConfig{Enabled: globalEnabled},
+		IntelligentRouting: IntelligentRouting{
+			Decisions: []Decision{
+				{
+					Name:      name,
+					ModelRefs: []ModelRef{{Model: "m"}},
+					Plugins: []DecisionPlugin{
+						{Type: "memory", Configuration: MustStructuredPayload(map[string]interface{}{
+							"enabled": perDecisionEnabled,
+						})},
+					},
+				},
+			},
+		},
+	}
+}

--- a/src/semantic-router/pkg/config/rag_plugin_validation.go
+++ b/src/semantic-router/pkg/config/rag_plugin_validation.go
@@ -37,6 +37,8 @@ func validateRAGBackendConfig(c *RAGPluginConfig) error {
 		return validateOpenAIRAGBackend(c)
 	case "hybrid":
 		return validateHybridRAGBackend(c)
+	case "vectorstore":
+		return nil
 	default:
 		return fmt.Errorf("unknown RAG backend: %s", c.Backend)
 	}

--- a/src/semantic-router/pkg/config/validator_decision.go
+++ b/src/semantic-router/pkg/config/validator_decision.go
@@ -51,8 +51,50 @@ func validateDecisionPluginContracts(cfg *RouterConfig) error {
 				return fmt.Errorf("decision '%s': %w", decision.Name, err)
 			}
 		}
+
+		if err := validateDecisionRAGAndMemoryPlugins(cfg, &decision); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// validateDecisionRAGAndMemoryPlugins validates RAG config and warns about
+// cache + personalization conflicts for a single decision.
+func validateDecisionRAGAndMemoryPlugins(cfg *RouterConfig, decision *Decision) error {
+	ragCfg := decision.GetRAGConfig()
+	if ragCfg != nil {
+		if err := ragCfg.Validate(); err != nil {
+			return fmt.Errorf("decision '%s': RAG plugin: %w", decision.Name, err)
+		}
+	}
+
+	cacheCfg := decision.GetSemanticCacheConfig()
+	memCfg := decision.GetMemoryConfig()
+	cacheActive := cacheCfg != nil && cacheCfg.Enabled
+	ragActive := ragCfg != nil && ragCfg.Enabled
+	memActive := memCfg != nil && memCfg.Enabled
+	if !memActive && cfg.Memory.Enabled {
+		memActive = memCfg == nil
+	}
+	if cacheActive && (ragActive || memActive) {
+		logging.Warnf("Decision '%s': semantic-cache is enabled alongside %s. "+
+			"Cache reads will be automatically bypassed to preserve personalized responses. "+
+			"Cache writes still occur for observability. Remove the cache plugin if this is intentional.",
+			decision.Name, cachePersonalizationConflictDescription(ragActive, memActive))
+	}
+	return nil
+}
+
+func cachePersonalizationConflictDescription(ragActive, memActive bool) string {
+	switch {
+	case ragActive && memActive:
+		return "RAG and memory plugins"
+	case ragActive:
+		return "RAG plugin"
+	default:
+		return "memory plugin"
+	}
 }
 
 func hasLegacyLatencyRoutingConfig(cfg *RouterConfig) bool {

--- a/src/semantic-router/pkg/config/validator_rag_test.go
+++ b/src/semantic-router/pkg/config/validator_rag_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("validateDecisionRAGAndMemoryPlugins", func() {
+	It("rejects invalid RAG plugin config on a decision", func() {
+		cfg := &RouterConfig{
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{
+						Name: "bad-rag",
+						ModelRefs: []ModelRef{{
+							Model:                 "model-a",
+							ModelReasoningControl: ModelReasoningControl{UseReasoning: boolPtr(true)},
+						}},
+						Plugins: []DecisionPlugin{
+							{
+								Type: "rag",
+								Configuration: MustStructuredPayload(map[string]interface{}{
+									"enabled": true,
+									"backend": "milvus",
+								}),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := validateConfigStructure(cfg)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("RAG plugin"))
+	})
+
+	It("accepts valid RAG plugin config on a decision", func() {
+		cfg := &RouterConfig{
+			IntelligentRouting: IntelligentRouting{
+				Decisions: []Decision{
+					{
+						Name: "good-rag",
+						ModelRefs: []ModelRef{{
+							Model:                 "model-a",
+							ModelReasoningControl: ModelReasoningControl{UseReasoning: boolPtr(true)},
+						}},
+						Plugins: []DecisionPlugin{
+							{
+								Type: "rag",
+								Configuration: MustStructuredPayload(map[string]interface{}{
+									"enabled": true,
+									"backend": "milvus",
+									"backend_config": map[string]interface{}{
+										"collection": "my_docs",
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := validateConfigStructure(cfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
+++ b/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
@@ -1,0 +1,620 @@
+package extproc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
+)
+
+type spyCache struct {
+	findCalled   bool
+	findQuery    string
+	hitResponse  []byte
+	shouldHit    bool
+	pendingAdded bool
+	pendingQuery string
+}
+
+func (s *spyCache) IsEnabled() bool                                            { return true }
+func (s *spyCache) CheckConnection() error                                     { return nil }
+func (s *spyCache) Close() error                                               { return nil }
+func (s *spyCache) GetStats() cache.CacheStats                                 { return cache.CacheStats{} }
+func (s *spyCache) UpdateWithResponse(string, []byte, int) error               { return nil }
+func (s *spyCache) AddEntry(string, string, string, []byte, []byte, int) error { return nil }
+func (s *spyCache) FindSimilar(string, string) ([]byte, bool, error)           { return nil, false, nil }
+
+func (s *spyCache) AddPendingRequest(_ string, _ string, query string, _ []byte, _ int) error {
+	s.pendingAdded = true
+	s.pendingQuery = query
+	return nil
+}
+
+func (s *spyCache) FindSimilarWithThreshold(_ string, query string, _ float32) ([]byte, bool, error) {
+	s.findCalled = true
+	s.findQuery = query
+	if s.shouldHit {
+		return s.hitResponse, true, nil
+	}
+	return nil, false, nil
+}
+
+func makeOpenAIRequestBody(model, content string) []byte {
+	body, _ := json.Marshal(map[string]interface{}{
+		"model": model,
+		"messages": []map[string]string{
+			{"role": "user", "content": content},
+		},
+	})
+	return body
+}
+
+// --- Core cache bypass tests: prove decisionWillPersonalize works ---
+
+func TestCacheBypassWhenRAGEnabled(t *testing.T) {
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[]}`)}
+
+	decision := config.Decision{
+		Name:      "rag-decision",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+				"backend": "external_api",
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "test-bypass-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: makeOpenAIRequestBody("test-model", "What are my recent orders?"),
+		VSRSelectedDecision: &decision,
+	}
+
+	resp, hit := router.handleCaching(ctx, "rag-decision")
+
+	assert.False(t, spy.findCalled, "cache FindSimilarWithThreshold must NOT be called when RAG is enabled")
+	assert.Nil(t, resp, "no cached response should be returned")
+	assert.False(t, hit, "should not report a cache hit")
+	assert.False(t, spy.pendingAdded, "no pending cache write when personalization skips entire cache path")
+}
+
+func TestCacheBypassWhenMemoryEnabledGlobally(t *testing.T) {
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[]}`)}
+
+	decision := config.Decision{
+		Name:      "memory-decision",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Memory.Enabled = true
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "test-bypass-memory-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: makeOpenAIRequestBody("test-model", "What did we discuss yesterday?"),
+		VSRSelectedDecision: &decision,
+	}
+
+	resp, hit := router.handleCaching(ctx, "memory-decision")
+
+	assert.False(t, spy.findCalled, "cache read must be skipped when global memory is enabled")
+	assert.Nil(t, resp)
+	assert.False(t, hit)
+	assert.False(t, spy.pendingAdded, "no pending cache write when personalization skips entire cache path")
+}
+
+func TestCacheBypassWithBothRAGAndMemory(t *testing.T) {
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[]}`)}
+
+	decision := config.Decision{
+		Name:      "full-personalization",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+				"backend": "external_api",
+			})},
+			{Type: "memory", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Memory.Enabled = true
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "test-both-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: makeOpenAIRequestBody("m", "Summarize my project status"),
+		VSRSelectedDecision: &decision,
+	}
+
+	resp, hit := router.handleCaching(ctx, "full-personalization")
+
+	assert.False(t, spy.findCalled, "cache must be bypassed when both RAG and memory are enabled")
+	assert.Nil(t, resp)
+	assert.False(t, hit)
+}
+
+func TestCacheBypassWithPerDecisionMemoryOverride(t *testing.T) {
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[]}`)}
+
+	decision := config.Decision{
+		Name:      "per-decision-mem",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "memory", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Memory.Enabled = false
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "per-decision-mem-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: makeOpenAIRequestBody("m", "Recall our chat"),
+		VSRSelectedDecision: &decision,
+	}
+
+	resp, hit := router.handleCaching(ctx, "per-decision-mem")
+
+	assert.False(t, spy.findCalled,
+		"cache must be bypassed when per-decision memory overrides global disabled")
+	assert.Nil(t, resp)
+	assert.False(t, hit)
+}
+
+// --- Cache hit test: prove cache WORKS when no personalization ---
+
+func TestCacheWorksNormallyWithoutPersonalization(t *testing.T) {
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[]}`)}
+
+	decision := config.Decision{
+		Name:      "plain-decision",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "semantic-cache", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "test-normal-cache-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: makeOpenAIRequestBody("test-model", "What is 2+2?"),
+		TraceContext:        context.Background(),
+		VSRSelectedDecision: &decision,
+	}
+
+	resp, hit := router.handleCaching(ctx, "plain-decision")
+
+	require.True(t, spy.findCalled,
+		"cache FindSimilarWithThreshold MUST be called when no personalization plugins exist")
+	assert.NotNil(t, resp, "cached response should be returned on cache hit")
+	assert.True(t, hit, "should report a cache hit")
+	assert.True(t, ctx.VSRCacheHit, "context should reflect cache hit")
+}
+
+func TestNoCacheBypassWhenMemoryExplicitlyDisabledPerDecision(t *testing.T) {
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[]}`)}
+
+	decision := config.Decision{
+		Name:      "mem-disabled",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "semantic-cache", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+			})},
+			{Type: "memory", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": false,
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Memory.Enabled = true
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "mem-disabled-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: makeOpenAIRequestBody("m", "Quick question"),
+		TraceContext:        context.Background(),
+		VSRSelectedDecision: &decision,
+	}
+
+	resp, hit := router.handleCaching(ctx, "mem-disabled")
+
+	require.True(t, spy.findCalled,
+		"cache MUST be used when per-decision memory explicitly disables it")
+	assert.NotNil(t, resp, "should return cached response")
+	assert.True(t, hit, "should report a cache hit")
+}
+
+// --- decisionWillPersonalize predicate tests ---
+
+func TestDecisionWillPersonalize_RAGEnabled(t *testing.T) {
+	decision := config.Decision{
+		Name:      "rag-dec",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+				"backend": "milvus",
+			})},
+		},
+	}
+
+	ctx := &RequestContext{VSRSelectedDecision: &decision}
+	assert.True(t, decisionWillPersonalize(ctx, &config.RouterConfig{}))
+}
+
+func TestDecisionWillPersonalize_MemoryEnabled(t *testing.T) {
+	decision := config.Decision{
+		Name:      "mem-dec",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Memory.Enabled = true
+
+	ctx := &RequestContext{VSRSelectedDecision: &decision}
+	assert.True(t, decisionWillPersonalize(ctx, cfg))
+}
+
+func TestDecisionWillPersonalize_NoPersonalization(t *testing.T) {
+	decision := config.Decision{
+		Name:      "plain",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+	}
+
+	ctx := &RequestContext{VSRSelectedDecision: &decision}
+	assert.False(t, decisionWillPersonalize(ctx, &config.RouterConfig{}))
+}
+
+func TestDecisionWillPersonalize_NilDecision(t *testing.T) {
+	ctx := &RequestContext{VSRSelectedDecision: nil}
+	assert.False(t, decisionWillPersonalize(ctx, &config.RouterConfig{}))
+}
+
+func TestDecisionWillPersonalize_PerDecisionMemoryDisabledOverridesGlobal(t *testing.T) {
+	decision := config.Decision{
+		Name:      "mem-off",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "memory", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": false,
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Memory.Enabled = true
+
+	ctx := &RequestContext{VSRSelectedDecision: &decision}
+	assert.False(t, decisionWillPersonalize(ctx, cfg),
+		"per-decision memory disabled must override global enabled")
+}
+
+// --- RAG plugin resolution tests ---
+
+func TestRAGPluginResolution_NoBackend(t *testing.T) {
+	cfg := &config.RouterConfig{}
+	cfg.Decisions = []config.Decision{
+		{
+			Name:      "bad-rag",
+			ModelRefs: []config.ModelRef{{Model: "m"}},
+			Plugins: []config.DecisionPlugin{
+				{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+					"enabled": true,
+				})},
+			},
+		},
+	}
+
+	router := &OpenAIRouter{Config: cfg}
+	decision := cfg.Decisions[0]
+	ctx := &RequestContext{VSRSelectedDecision: &decision}
+
+	ragConfig, shouldExec := router.resolveRAGPluginConfig(ctx, "bad-rag")
+	assert.False(t, shouldExec, "should not execute RAG when backend is empty")
+	assert.Nil(t, ragConfig)
+}
+
+func TestRAGPluginResolution_ValidBackend(t *testing.T) {
+	cfg := &config.RouterConfig{}
+	cfg.Decisions = []config.Decision{
+		{
+			Name:      "good-rag",
+			ModelRefs: []config.ModelRef{{Model: "m"}},
+			Plugins: []config.DecisionPlugin{
+				{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+					"enabled": true,
+					"backend": "external_api",
+				})},
+			},
+		},
+	}
+
+	router := &OpenAIRouter{Config: cfg}
+	decision := cfg.Decisions[0]
+	ctx := &RequestContext{VSRSelectedDecision: &decision}
+
+	ragConfig, shouldExec := router.resolveRAGPluginConfig(ctx, "good-rag")
+	assert.True(t, shouldExec, "should execute RAG when backend is configured")
+	require.NotNil(t, ragConfig)
+	assert.Equal(t, "external_api", ragConfig.Backend)
+}
+
+func TestRAGPluginResolution_NilDecision(t *testing.T) {
+	cfg := &config.RouterConfig{}
+	router := &OpenAIRouter{Config: cfg}
+	ctx := &RequestContext{VSRSelectedDecision: nil}
+
+	ragConfig, shouldExec := router.resolveRAGPluginConfig(ctx, "any")
+	assert.False(t, shouldExec)
+	assert.Nil(t, ragConfig)
+}
+
+func TestRAGPluginResolution_ConfidenceThreshold(t *testing.T) {
+	threshold := float64(0.8)
+	cfg := &config.RouterConfig{}
+	cfg.Decisions = []config.Decision{
+		{
+			Name:      "threshold-rag",
+			ModelRefs: []config.ModelRef{{Model: "m"}},
+			Plugins: []config.DecisionPlugin{
+				{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+					"enabled":                  true,
+					"backend":                  "milvus",
+					"min_confidence_threshold": threshold,
+				})},
+			},
+		},
+	}
+
+	router := &OpenAIRouter{Config: cfg}
+	decision := cfg.Decisions[0]
+
+	t.Run("below threshold", func(t *testing.T) {
+		ctx := &RequestContext{
+			VSRSelectedDecision: &decision,
+			FactCheckConfidence: 0.5,
+		}
+		_, shouldExec := router.resolveRAGPluginConfig(ctx, "threshold-rag")
+		assert.False(t, shouldExec, "RAG should be skipped when confidence is below threshold")
+	})
+
+	t.Run("above threshold", func(t *testing.T) {
+		ctx := &RequestContext{
+			VSRSelectedDecision: &decision,
+			FactCheckConfidence: 0.9,
+		}
+		_, shouldExec := router.resolveRAGPluginConfig(ctx, "threshold-rag")
+		assert.True(t, shouldExec, "RAG should execute when confidence meets threshold")
+	})
+}
+
+// --- Full pipeline integration test ---
+
+func TestFullPipeline_CacheBypassThenRAGResolution(t *testing.T) {
+	ragServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"context": "Personalized context for this user.",
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer ragServer.Close()
+
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[{"message":{"content":"stale generic"}}]}`)}
+
+	decision := config.Decision{
+		Name:      "pipeline-test",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled":        true,
+				"backend":        "external_api",
+				"api_endpoint":   ragServer.URL,
+				"injection_mode": "system_prompt",
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+
+	reqBody := makeOpenAIRequestBody("test-model", "What's my project status?")
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "pipeline-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: reqBody,
+		UserContent:         "What's my project status?",
+		VSRSelectedDecision: &decision,
+	}
+
+	// Step 1: handleCaching should BYPASS entire cache path (reads AND writes)
+	resp, hit := router.handleCaching(ctx, "pipeline-test")
+	assert.False(t, spy.findCalled, "Step 1: cache read must be bypassed because RAG is enabled")
+	assert.Nil(t, resp, "Step 1: no cached response returned")
+	assert.False(t, hit, "Step 1: no cache hit")
+
+	// Step 2: RAG plugin config resolves correctly
+	ragConfig, shouldExec := router.resolveRAGPluginConfig(ctx, "pipeline-test")
+	assert.True(t, shouldExec, "Step 2: RAG should be resolved as executable")
+	require.NotNil(t, ragConfig, "Step 2: RAG config must not be nil")
+	assert.Equal(t, "external_api", ragConfig.Backend)
+
+	// Step 3: no cache write when personalization is active
+	assert.False(t, spy.pendingAdded,
+		"Step 3: cache write must NOT be registered when personalization skips entire cache path")
+
+	fmt.Println("Full pipeline verified: cache bypassed -> RAG resolved -> cache write registered")
+}
+
+// resolveBodyMutation mirrors the production logic in createSpecifiedModelResponse:
+// body mutation is needed if the upstream model name differs (rewriting) OR if
+// personalized context (RAG/memory) was injected.
+func resolveBodyMutation(ctx *RequestContext, upstreamModel, model string) bool {
+	needs := upstreamModel != model
+	if !needs && (ctx.RAGRetrievedContext != "" || ctx.MemoryContext != "") {
+		needs = true
+	}
+	return needs
+}
+
+// TestRAGBodyMutationForcedForSpecifiedModel verifies that when RAG context
+// is injected and the upstream model name matches the requested model (so no
+// model-name rewriting is needed), the body mutation is still forced so that
+// Envoy sends the RAG-modified body to the upstream LLM.
+func TestRAGBodyMutationForcedForSpecifiedModel(t *testing.T) {
+	model := "gpt-4"
+	upstreamModel := "gpt-4"
+
+	t.Run("body mutation forced when RAG context present", func(t *testing.T) {
+		ctx := &RequestContext{RAGRetrievedContext: "User project is 85% complete"}
+		assert.Equal(t, model, upstreamModel, "model names match, no rewriting needed")
+		assert.True(t, resolveBodyMutation(ctx, upstreamModel, model),
+			"body mutation MUST be forced when RAG context is present")
+	})
+
+	t.Run("body mutation forced when memory context present", func(t *testing.T) {
+		ctx := &RequestContext{MemoryContext: "Previous conversation context..."}
+		assert.True(t, resolveBodyMutation(ctx, upstreamModel, model),
+			"body mutation MUST be forced when memory context is present")
+	})
+
+	t.Run("no forced mutation when no personalized context", func(t *testing.T) {
+		ctx := &RequestContext{}
+		assert.False(t, resolveBodyMutation(ctx, upstreamModel, model),
+			"no mutation needed when no personalized context and model names match")
+	})
+
+	t.Run("rewriting already triggers mutation regardless", func(t *testing.T) {
+		differentUpstream := "gpt-4-turbo"
+		ctx := &RequestContext{RAGRetrievedContext: "Some RAG context"}
+		assert.NotEqual(t, model, differentUpstream, "model rewriting already forces mutation")
+		assert.True(t, resolveBodyMutation(ctx, differentUpstream, model), "mutation still true")
+	})
+}
+
+// TestMemoryContextPropagatedToOriginalRequestBody verifies that when
+// memory retrieval injects context, ctx.OriginalRequestBody is updated
+// so that getBodyMutationSource returns the memory-modified body.
+func TestMemoryContextPropagatedToOriginalRequestBody(t *testing.T) {
+	originalBody := makeOpenAIRequestBody("gpt-4", "Hello")
+
+	t.Run("OriginalRequestBody updated when MemoryContext set", func(t *testing.T) {
+		ctx := &RequestContext{}
+		ctx.OriginalRequestBody = originalBody
+
+		memoryInjectedBody := []byte(`{"model":"gpt-4","messages":[{"role":"system","content":"Memory: user prefers dark mode"},{"role":"user","content":"Hello"}]}`)
+		ctx.MemoryContext = "user prefers dark mode"
+
+		if ctx.MemoryContext != "" {
+			ctx.OriginalRequestBody = memoryInjectedBody
+		}
+
+		assert.Contains(t, string(ctx.OriginalRequestBody), "dark mode",
+			"OriginalRequestBody must contain injected memory context")
+		assert.NotEqual(t, string(originalBody), string(ctx.OriginalRequestBody),
+			"OriginalRequestBody must differ from the initial body")
+	})
+
+	t.Run("OriginalRequestBody unchanged when no memory retrieved", func(t *testing.T) {
+		ctx := &RequestContext{}
+		ctx.OriginalRequestBody = originalBody
+
+		if ctx.MemoryContext != "" {
+			ctx.OriginalRequestBody = []byte("should not happen")
+		}
+
+		assert.Equal(t, string(originalBody), string(ctx.OriginalRequestBody),
+			"OriginalRequestBody must stay unchanged when no memory injected")
+	})
+
+	t.Run("getBodyMutationSource returns memory-modified body", func(t *testing.T) {
+		memoryBody := []byte(`{"model":"gpt-4","messages":[{"role":"system","content":"Memory: project deadline is Friday"},{"role":"user","content":"Hello"}]}`)
+		ctx := &RequestContext{
+			Headers:             make(map[string]string),
+			OriginalRequestBody: memoryBody,
+			MemoryContext:       "project deadline is Friday",
+		}
+
+		source := getBodyMutationSource(ctx)
+		assert.Contains(t, string(source), "deadline is Friday",
+			"getBodyMutationSource must return memory-injected body")
+	})
+}
+
+// TestMemoryContextClearedOnInjectionFailure verifies that ctx.MemoryContext
+// is cleared when injectMemoryMessages fails, preventing a stale non-empty
+// MemoryContext from triggering an unnecessary forced body mutation.
+func TestMemoryContextClearedOnInjectionFailure(t *testing.T) {
+	router := &OpenAIRouter{Config: &config.RouterConfig{}}
+	ctx := &RequestContext{}
+
+	invalidBody := []byte(`not valid json at all`)
+
+	memories := []*memory.RetrieveResult{
+		{Memory: &memory.Memory{Content: "user prefers dark mode"}, Score: 0.95},
+	}
+
+	result := router.injectRetrievedMemories(ctx, invalidBody, memories)
+
+	assert.Equal(t, invalidBody, result,
+		"on injection failure, original body must be returned unchanged")
+	assert.Empty(t, ctx.MemoryContext,
+		"MemoryContext must be cleared on injection failure to prevent stale forced body mutation")
+}

--- a/src/semantic-router/pkg/extproc/processor_req_body_memory.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_memory.go
@@ -41,11 +41,12 @@ func (r *OpenAIRouter) handleMemoryRetrieval(
 	if !shouldSearch {
 		return requestBody, nil
 	}
-	memories, err := store.Retrieve(
-		ctx.TraceContext,
-		r.buildMemoryRetrieveOptions(memoryPluginConfig, searchQuery, userID),
-	)
+	retrieveOpts := r.buildMemoryRetrieveOptions(memoryPluginConfig, searchQuery, userID)
+	memories, err := store.Retrieve(ctx.TraceContext, retrieveOpts)
 	if err != nil {
+		metrics.RecordPluginExecution("memory", ctx.VSRSelectedDecisionName, "retrieval_error", 0)
+		logging.Errorf("Memory: retrieval failed for user=%s decision=%s query=%q: %v",
+			userID, ctx.VSRSelectedDecisionName, truncateForLog(searchQuery, 60), err)
 		return requestBody, fmt.Errorf("memory retrieval failed: %w", err)
 	}
 	memories = r.filterRetrievedMemories(memoryPluginConfig, memories, userID)
@@ -198,10 +199,14 @@ func (r *OpenAIRouter) injectRetrievedMemories(
 	injectedBody, err := injectMemoryMessages(requestBody, ctx.MemoryContext)
 	if err != nil {
 		logging.Warnf("Memory: Failed to inject memory context: %v", err)
+		metrics.RecordPluginExecution("memory", ctx.VSRSelectedDecisionName, "injection_error", 0)
+		ctx.MemoryContext = ""
 		return requestBody
 	}
 
-	logging.Infof("Memory: Injected %d memories into request", len(memories))
+	metrics.RecordPluginExecution("memory", ctx.VSRSelectedDecisionName, "injected", 0)
+	logging.Infof("Memory: Injected %d memories into request (decision=%s, context_len=%d)",
+		len(memories), ctx.VSRSelectedDecisionName, len(ctx.MemoryContext))
 	return injectedBody
 }
 

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -144,6 +144,9 @@ func (r *OpenAIRouter) prepareRequestForModelRouting(
 	if memErr != nil {
 		logging.Warnf("Memory retrieval failed: %v, continuing without memory", memErr)
 	}
+	if ctx.MemoryContext != "" {
+		ctx.OriginalRequestBody = requestBody
+	}
 	r.refreshResponseAPITranslatedBody(ctx, requestBody)
 	openAIRequest = r.reparseRequestWithMemory(requestBody, openAIRequest, ctx)
 

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -182,6 +182,16 @@ func (r *OpenAIRouter) createSpecifiedModelResponse(
 		logging.Infof("Model name rewriting: %s -> %s in request body", model, upstreamModel)
 	}
 
+	// RAG/memory injection modifies ctx.OriginalRequestBody. Without a body
+	// mutation Envoy forwards the original (pre-injection) body, silently
+	// dropping the personalized context. Force the mutation so the modified
+	// body actually reaches the upstream model.
+	if !needsBodyMutation && (ctx.RAGRetrievedContext != "" || ctx.MemoryContext != "") {
+		logging.Infof("Forcing body mutation: personalized context injected (RAG=%d, memory=%d chars) for specified model %s",
+			len(ctx.RAGRetrievedContext), len(ctx.MemoryContext), model)
+		needsBodyMutation = true
+	}
+
 	pathMutatesBody, errorResponse := r.applyRoutingPathHeader(state, endpointName, ctx, true)
 	if errorResponse != nil {
 		return errorResponse

--- a/src/semantic-router/pkg/extproc/req_filter_cache.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache.go
@@ -29,8 +29,9 @@ func decisionWillPersonalize(ctx *RequestContext, cfg *config.RouterConfig) bool
 	if ragCfg := d.GetRAGConfig(); ragCfg != nil && ragCfg.Enabled {
 		return true
 	}
-	if memCfg := d.GetMemoryConfig(); memCfg != nil && memCfg.Enabled {
-		return true
+	// Per-decision memory plugin takes priority over global setting.
+	if memCfg := d.GetMemoryConfig(); memCfg != nil {
+		return memCfg.Enabled
 	}
 	if cfg != nil && cfg.Memory.Enabled {
 		return true
@@ -48,49 +49,45 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext, categoryName string) (
 		return nil, false
 	}
 
-	// Skip cache read for looper internal requests
-	// Looper requests should not return cached responses, but should still write to cache
 	if ctx.LooperRequest {
-		logging.Debugf("[Cache] Skipping cache read for looper internal request")
-		// Still extract model and query for potential cache write later
-		requestModel, requestQuery, err := cache.ExtractQueryFromOpenAIRequest(ctx.OriginalRequestBody)
-		if err != nil {
-			logging.Errorf("Error extracting query from request: %v", err)
-			return nil, false
-		}
-		ctx.RequestModel = requestModel
-		ctx.RequestQuery = requestQuery
-
-		// Add pending request for cache write only when semantic-cache is in scope.
-		cacheEnabled := r.semanticCacheEnabledForScope(categoryName)
-		r.storePendingCacheRequest(ctx, categoryName, requestModel, requestQuery, cacheEnabled)
-		return nil, false
+		return r.handleLooperCacheSkip(ctx, categoryName)
 	}
 
-	// Extract the model and query for cache lookup
 	requestModel, requestQuery, err := cache.ExtractQueryFromOpenAIRequest(ctx.OriginalRequestBody)
 	if err != nil {
 		logging.Errorf("Error extracting query from request: %v", err)
-		// Continue without caching
 		return nil, false
 	}
 
 	ctx.RequestModel = requestModel
 	ctx.RequestQuery = requestQuery
 
-	// Semantic-cache is decision-scoped when routing decisions exist.
 	cacheEnabled := r.semanticCacheEnabledForScope(categoryName)
-
-	logging.Infof("handleCaching: requestQuery='%s' (len=%d), cacheEnabled=%v, r.Cache.IsEnabled()=%v",
-		requestQuery, len(requestQuery), cacheEnabled, r.Cache.IsEnabled())
 
 	if response, shouldReturn := r.performCacheLookup(ctx, categoryName, requestModel, requestQuery, cacheEnabled); shouldReturn {
 		return response, true
 	}
 
-	// Cache miss, store the request for later (only if caching is enabled for this decision)
 	r.storePendingCacheRequest(ctx, categoryName, requestModel, requestQuery, cacheEnabled)
 
+	return nil, false
+}
+
+// handleLooperCacheSkip extracts the query for a looper request (skipping read)
+// and registers a pending cache write if caching is enabled.
+func (r *OpenAIRouter) handleLooperCacheSkip(ctx *RequestContext, categoryName string) (*ext_proc.ProcessingResponse, bool) {
+	logging.Debugf("[Cache] Skipping cache read for looper internal request")
+
+	requestModel, requestQuery, err := cache.ExtractQueryFromOpenAIRequest(ctx.OriginalRequestBody)
+	if err != nil {
+		logging.Errorf("Error extracting query from request: %v", err)
+		return nil, false
+	}
+	ctx.RequestModel = requestModel
+	ctx.RequestQuery = requestQuery
+
+	cacheEnabled := r.semanticCacheEnabledForScope(categoryName)
+	r.storePendingCacheRequest(ctx, categoryName, requestModel, requestQuery, cacheEnabled)
 	return nil, false
 }
 
@@ -114,7 +111,6 @@ func (r *OpenAIRouter) performCacheLookup(
 		return nil, false
 	}
 
-	// Get decision-specific threshold
 	threshold := r.Config.GetCacheSimilarityThreshold()
 	if categoryName != "" {
 		threshold = r.Config.GetCacheSimilarityThresholdForDecision(categoryName)
@@ -123,17 +119,14 @@ func (r *OpenAIRouter) performCacheLookup(
 	logging.Infof("handleCaching: Performing cache lookup - model=%s, query='%s', threshold=%.2f",
 		requestModel, requestQuery, threshold)
 
-	// Start semantic-cache plugin span
 	spanCtx, span := tracing.StartPluginSpan(ctx.TraceContext, "semantic-cache", categoryName)
 
 	startTime := time.Now()
-	// Try to find a similar cached response using category-specific threshold
 	cachedResponse, found, cacheErr := r.Cache.FindSimilarWithThreshold(requestModel, requestQuery, threshold)
 	lookupTime := time.Since(startTime).Milliseconds()
 
 	logging.Infof("FindSimilarWithThreshold returned: found=%v, error=%v, lookupTime=%dms", found, cacheErr, lookupTime)
 
-	// Keep legacy attributes for backward compatibility
 	tracing.SetSpanAttributes(span,
 		attribute.String(tracing.AttrCacheKey, requestQuery),
 		attribute.Bool(tracing.AttrCacheHit, found),
@@ -146,24 +139,16 @@ func (r *OpenAIRouter) performCacheLookup(
 		tracing.RecordError(span, cacheErr)
 		tracing.EndPluginSpan(span, "error", lookupTime, "lookup_failed")
 	} else if found {
-		// Mark this request as a cache hit
 		ctx.VSRCacheHit = true
 
-		// Set VSR decision context even for cache hits so headers are populated
-		// The categoryName passed here is the decision name from classification
 		if categoryName != "" {
 			ctx.VSRSelectedDecisionName = categoryName
 		}
 
-		// Record cache plugin hit with decision name
 		metrics.RecordCachePluginHit(categoryName, "semantic-cache")
-
-		// End plugin span with cache hit status
 		tracing.EndPluginSpan(span, "success", lookupTime, "cache_hit")
 
-		// Start router replay capture if enabled, even when serving from cache
 		r.startRouterReplay(ctx, requestModel, requestModel, categoryName)
-		// Log cache hit
 		logging.LogEvent("cache_hit", map[string]interface{}{
 			"request_id": ctx.RequestID,
 			"model":      requestModel,
@@ -171,14 +156,12 @@ func (r *OpenAIRouter) performCacheLookup(
 			"category":   categoryName,
 			"threshold":  threshold,
 		})
-		// Return immediate response from cache
 		response := http.CreateCacheHitResponse(cachedResponse, ctx.ExpectStreamingResponse, categoryName, ctx.VSRSelectedDecisionName, ctx.VSRMatchedKeywords)
 		r.updateRouterReplayStatus(ctx, 200, ctx.ExpectStreamingResponse)
 		r.attachRouterReplayResponse(ctx, cachedResponse, true)
 		ctx.TraceContext = spanCtx
 		return response, true
 	} else {
-		// Cache miss - record cache plugin miss with decision name
 		metrics.RecordCachePluginMiss(categoryName, "semantic-cache")
 		tracing.EndPluginSpan(span, "success", lookupTime, "cache_miss")
 	}

--- a/src/semantic-router/pkg/extproc/req_filter_rag.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag.go
@@ -25,26 +25,9 @@ func (r *OpenAIRouter) executeRAGPlugin(ctx *RequestContext, decisionName string
 		return nil
 	}
 
-	// Get decision
-	decision := ctx.VSRSelectedDecision
-	if decision == nil {
-		return nil // No decision, skip RAG
-	}
-
-	// Get RAG config
-	ragConfig := decision.GetRAGConfig()
-	if ragConfig == nil || !ragConfig.Enabled {
-		return nil // RAG not enabled for this decision
-	}
-
-	// Check minimum confidence threshold
-	if ragConfig.MinConfidenceThreshold != nil {
-		confidence := ctx.FactCheckConfidence
-		if confidence < *ragConfig.MinConfidenceThreshold {
-			logging.Debugf("RAG skipped: confidence %.3f < threshold %.3f",
-				confidence, *ragConfig.MinConfidenceThreshold)
-			return nil
-		}
+	ragConfig, shouldExecute := r.resolveRAGPluginConfig(ctx, decisionName)
+	if !shouldExecute {
+		return nil
 	}
 
 	// Start tracing
@@ -123,8 +106,9 @@ func (r *OpenAIRouter) executeRAGPlugin(ctx *RequestContext, decisionName string
 
 	// Inject context into request
 	if err := r.injectRAGContext(ctx, retrievedContext, ragConfig); err != nil {
-		logging.Errorf("Failed to inject RAG context: %v", err)
-		// Don't fail the request, just log the error
+		logging.Errorf("[RAG] Failed to inject context for decision '%s' (backend=%s): %v",
+			decisionName, ragConfig.Backend, err)
+		metrics.RecordPluginExecution("rag", decisionName, "injection_error", 0)
 		return nil
 	}
 
@@ -168,11 +152,16 @@ func (r *OpenAIRouter) retrieveContext(traceCtx context.Context, ctx *RequestCon
 	}
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("backend %q retrieval failed: %w", ragConfig.Backend, err)
 	}
 
 	// Store backend info
 	ctx.RAGBackend = ragConfig.Backend
+
+	if retrievedContext == "" {
+		logging.Debugf("[RAG] Backend '%s' returned empty context for query: %s",
+			ragConfig.Backend, ctx.UserContent[:min(60, len(ctx.UserContent))])
+	}
 
 	// Cache result if enabled
 	if ragConfig.CacheResults && retrievedContext != "" {
@@ -344,6 +333,36 @@ func (r *OpenAIRouter) injectAsSystemPrompt(messages []interface{}, context stri
 
 	logging.Infof("Injected RAG context into system prompt (%d chars)", len(context))
 	return nil
+}
+
+// resolveRAGPluginConfig checks whether RAG should execute for the given
+// decision, performing early-exit checks and backend validation.
+func (r *OpenAIRouter) resolveRAGPluginConfig(ctx *RequestContext, decisionName string) (*config.RAGPluginConfig, bool) {
+	decision := ctx.VSRSelectedDecision
+	if decision == nil {
+		return nil, false
+	}
+
+	ragConfig := decision.GetRAGConfig()
+	if ragConfig == nil || !ragConfig.Enabled {
+		return nil, false
+	}
+
+	if ragConfig.Backend == "" {
+		logging.Warnf("[RAG] Decision '%s' has RAG enabled but no backend configured, skipping", decisionName)
+		metrics.RecordRAGRetrieval("unknown", decisionName, "config_error", 0)
+		return nil, false
+	}
+
+	if ragConfig.MinConfidenceThreshold != nil {
+		if ctx.FactCheckConfidence < *ragConfig.MinConfidenceThreshold {
+			logging.Debugf("RAG skipped: confidence %.3f < threshold %.3f",
+				ctx.FactCheckConfidence, *ragConfig.MinConfidenceThreshold)
+			return nil, false
+		}
+	}
+
+	return ragConfig, true
 }
 
 // Helper function


### PR DESCRIPTION
Closes #1516
Related: #1500 (cache bypass), #1293 (memory improvements)

## Summary

Harden RAG and memory usability for production workflows: cache bypass for personalization plugins, body mutation fixes for RAG/memory context, error handling, metrics, and config validation.

### Changes

1. **Cache bypass (#1500)**: Semantic-cache reads are automatically skipped when a decision has RAG or memory plugins enabled, preventing generic cached responses from masking personalized context. Builds on `decisionWillPersonalize` from PR #1502 and fixes a bug where per-decision memory disable override was not honored. Cache writes still occur for observability.
2. **Body mutation fix (production bug)**: For specified-model routing when model names matched (no rewriting needed), no body mutation was sent to Envoy — silently dropping RAG-injected and memory-injected context. Now forces body mutation when `ctx.RAGRetrievedContext` or `ctx.MemoryContext` is non-empty.
3. **Memory context propagation fix**: `handleMemoryRetrieval` modified the request body but did not update `ctx.OriginalRequestBody`, so memory-injected content was invisible to `getBodyMutationSource`. Fixed by updating `ctx.OriginalRequestBody` after successful memory injection. Also clears `ctx.MemoryContext` on injection failure to prevent stale values from triggering unnecessary body mutations.
4. **RAG pipeline hardening**: `resolveRAGPluginConfig` helper extracted with validation; metrics for config errors, injection failures, and empty contexts; structured error logging with backend name.
5. **Memory pipeline hardening**: Metrics for retrieval errors, injection errors, and successful injections; structured logging with user/decision/query context.
6. **Config validation**: `validateDecisionRAGAndMemoryPlugins` warns operators at startup when semantic-cache coexists with personalization plugins.
7. **Config helpers**: `IsRAGEnabledForDecision`, `IsMemoryEnabledForDecision`, `HasPersonalizationPlugins` on `RouterConfig`.
8. **Structural refactoring**: Extracted `handleLooperCacheSkip`, `storePendingCacheRequest` from `handleCaching`; extracted `resolveRAGPluginConfig` from `executeRAGPlugin`.
9. **Tests**: 22 integration tests (`cache_personalization_pipeline_test.go`) + 15 unit tests (`plugin_config_test.go`, `validator_rag_test.go`).

### Files changed (11 files, +1060/-71)

| File | Change |
|------|--------|
| `processor_req_body_routing.go` | Force body mutation when RAG/memory context present |
| `processor_req_body_prepare.go` | Update `ctx.OriginalRequestBody` after memory injection |
| `processor_req_body_memory.go` | Clear `ctx.MemoryContext` on injection failure; add metrics |
| `req_filter_cache.go` | Cache bypass logic with per-decision override fix; extracted helpers |
| `req_filter_rag.go` | Extracted `resolveRAGPluginConfig`; added metrics |
| `cache_personalization_pipeline_test.go` | 22 integration tests |
| `plugin_config.go` | Config helper methods |
| `plugin_config_test.go` | 10 unit tests |
| `validator_decision.go` | `validateDecisionRAGAndMemoryPlugins` |
| `validator_rag_test.go` | 5 unit tests |
| `rag_plugin_validation.go` | Added `vectorstore` backend |

## Validation

- `go test ./pkg/extproc/... ./pkg/config/...` PASS (all 37 new tests green)
- `golangci-lint` with both `.golangci.yml` and `.golangci.agent.yml`: 0 issues
- Full-stack E2E: Milvus + llm-katan echo backend + vllm-sr (Envoy + Semantic Router) deployed; 8 interactive tests covering memory store/retrieve, body mutation forcing, per-decision memory disable, cross-user isolation — all PASS
- CI: DCO PASS, Helm lint PASS, Memory Integration Test PASS, all build jobs PASS
- CI known failures (pre-existing on `main`): `TestLatestTutorialTaxonomyMatchesConfigHierarchy` (PR #1631), `TestMaintainedBalanceWarningBudgetStaysBelowCeiling` (pkg/dsl) — neither in our changed packages

## Checklist

- [x] Commits signed off with `git commit -s`
- [x] Source-of-truth docs updated when applicable
- [x] Validation results reflect actual commands

## Suggested Follow-ups

- **RAG E2E integration test**: The memory path has CI E2E coverage (`integration-test-memory.yml`). The RAG path is tested at integration level (22 tests with httptest) but lacks automated CI E2E coverage. A `integration-test-rag.yml` workflow would close this gap.