### PR TITLE
[Bugfix][Router] Wrong /v1-suffixed OpenAI base URLs for vector store search

### DIFF
--- a/src/semantic-router/pkg/config/rag_plugin.go
+++ b/src/semantic-router/pkg/config/rag_plugin.go
@@ -128,7 +128,7 @@ type OpenAIRAGConfig struct {
 	// Can be created via OpenAI API or referenced if already exists
 	VectorStoreID string `json:"vector_store_id" yaml:"vector_store_id"`
 
-	// OpenAI API base URL (defaults to https://api.openai.com/v1)
+	// OpenAI API base URL (defaults to https://api.openai.com)
 	BaseURL string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 
 	// OpenAI API key (required)

--- a/src/semantic-router/pkg/extproc/req_filter_rag_openai.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_openai.go
@@ -23,7 +23,7 @@ func (r *OpenAIRouter) retrieveFromOpenAI(traceCtx context.Context, ctx *Request
 
 	baseURL := openaiConfig.BaseURL
 	if baseURL == "" {
-		baseURL = "https://api.openai.com/v1"
+		baseURL = "https://api.openai.com"
 	}
 
 	query := ctx.UserContent

--- a/src/semantic-router/pkg/openai/vectorstore.go
+++ b/src/semantic-router/pkg/openai/vectorstore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -30,7 +31,7 @@ func NewVectorStoreClient(baseURL string, apiKey string) *VectorStoreClient {
 				IdleConnTimeout:     90 * time.Second,
 			},
 		},
-		baseURL: baseURL,
+		baseURL: strings.TrimRight(strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1"), "/"),
 		apiKey:  apiKey,
 	}
 }

--- a/src/semantic-router/pkg/openai/vectorstore_test.go
+++ b/src/semantic-router/pkg/openai/vectorstore_test.go
@@ -78,6 +78,23 @@ func TestVectorStoreClient_SearchVectorStore(t *testing.T) {
 	}
 }
 
+func TestVectorStoreClient_SearchVectorStore_WithVersionedBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/v1/vector_stores/vs_123/search" {
+			t.Errorf("Unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewVectorStoreClient(server.URL+"/v1", "test-key")
+	_, err := client.SearchVectorStore(context.Background(), "vs_123", "test query", 10, nil)
+	if err != nil {
+		t.Fatalf("SearchVectorStore failed with versioned base URL: %v", err)
+	}
+}
+
 func TestVectorStoreClient_ListVectorStores(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" || r.URL.Path != "/v1/vector_stores" {


### PR DESCRIPTION
OpenAI RAG direct search would build URLs as .../v1/v1/vector_stores/... when base_url already ended with /v1, causing vector store retrieval to fail against valid OpenAI-compatible endpoints.

## Summary

- Scope:
- Primary skill:
- Impacted surfaces:
- Conditional surfaces intentionally skipped:
- Behavior-visible change: `yes` / `no`
- Debt entry: `none` / `TDxxx`

## Validation

- Environment: `cpu-local` / `amd-local` / `not run`
- Fast gate:
- Feature gate:
- Local smoke / E2E:
- CI expectations / blockers:

## Checklist

- [x] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
- [ ] If the PR spans multiple categories, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] Source-of-truth docs or indexed debt entries were updated when applicable
- [ ] The validation results above reflect the actual commands or blockers for this change

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
