### PR TITLE
[Misc] Fix memory E2E tests with black

### DIFF
--- a/e2e/testing/memory_tests/base.py
+++ b/e2e/testing/memory_tests/base.py
@@ -200,9 +200,7 @@ class MilvusVerifier:
                 return None
 
             except Exception as e:
-                print(
-                    f"⚠️  Milvus metadata query failed (attempt {attempt + 1}): {e}"
-                )
+                print(f"⚠️  Milvus metadata query failed (attempt {attempt + 1}): {e}")
                 if attempt < max_retries - 1:
                     time.sleep(2)
                     continue

--- a/e2e/testing/memory_tests/test_isolation.py
+++ b/e2e/testing/memory_tests/test_isolation.py
@@ -20,9 +20,7 @@ class UserIsolationTest(MemoryFeaturesTest):
         self.user_a_secret = "My secret PIN is 9876"
         self.user_b_secret = "My password is hunter2"
 
-    def _store_secret_with_followup(
-        self, secret: str, user_id: str, followup: str
-    ):
+    def _store_secret_with_followup(self, secret: str, user_id: str, followup: str):
         """Store a secret and send a follow-up turn for a user."""
         result = self.send_memory_request(
             message=f"Remember this: {secret}",
@@ -104,9 +102,7 @@ class UserIsolationTest(MemoryFeaturesTest):
                 f"{output[:PREVIEW_LENGTH]}"
             )
         else:
-            self.print_test_result(
-                True, "User B correctly cannot see User A's secret"
-            )
+            self.print_test_result(True, "User B correctly cannot see User A's secret")
 
     def test_03_user_a_can_see_own_memory(self):
         """User A should be able to see their own secret from Milvus."""
@@ -156,13 +152,9 @@ class UserIsolationTest(MemoryFeaturesTest):
         user_b_leak = self.milvus.search_memories(self.user_b, "9876")
 
         if user_a_leak:
-            self.fail(
-                "SECURITY: User A's Milvus partition contains User B's password!"
-            )
+            self.fail("SECURITY: User A's Milvus partition contains User B's password!")
         if user_b_leak:
-            self.fail(
-                "SECURITY: User B's Milvus partition contains User A's PIN!"
-            )
+            self.fail("SECURITY: User B's Milvus partition contains User A's PIN!")
 
         print(
             f"   ✓ Milvus isolation verified: "
@@ -217,6 +209,4 @@ class UserIsolationTest(MemoryFeaturesTest):
         if b_saw_a_pin:
             self.fail("SECURITY VIOLATION: User B saw User A's PIN from Milvus")
 
-        self.print_test_result(
-            True, "Bidirectional isolation verified at Milvus level"
-        )
+        self.print_test_result(True, "Bidirectional isolation verified at Milvus level")

--- a/e2e/testing/memory_tests/test_storage.py
+++ b/e2e/testing/memory_tests/test_storage.py
@@ -132,7 +132,9 @@ class PluginCombinationTest(MemoryFeaturesTest):
             self.fail("Failed to query memory")
 
         output = query_result.get("_output_text", "").lower()
-        print(f"   Response: {query_result.get('_output_text', '')[:PREVIEW_LENGTH]}...")
+        print(
+            f"   Response: {query_result.get('_output_text', '')[:PREVIEW_LENGTH]}..."
+        )
 
         # Since this is a NEW session, "phoenix" can ONLY come from Milvus memory
         if "phoenix" in output:


### PR DESCRIPTION
Closes #xxxx

## Summary

This is a formatting-only follow-up to PR #1433 to make the newly added memory E2E tests conform to the repository's current `black` pre-commit rule.

- Scope:
- Primary skill:
- Impacted surfaces:
- Conditional surfaces intentionally skipped:
- Behavior-visible change: `yes` / `no`
- Debt entry: `none` / `TDxxx`

## Validation

- Environment: `cpu-local` / `amd-local` / `not run`
- Fast gate:
- Feature gate:
- Local smoke / E2E:
- CI expectations / blockers:

## Checklist

- [x] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
- [ ] If the PR spans multiple categories, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] Source-of-truth docs or indexed debt entries were updated when applicable
- [ ] The validation results above reflect the actual commands or blockers for this change

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
