### PR TITLE
Revert "feat(domain-signal): add UseModernBERT factory branch for category classifier"

### DIFF
--- a/src/semantic-router/pkg/classification/classifier.go
+++ b/src/semantic-router/pkg/classification/classifier.go
@@ -72,26 +72,6 @@ func createMmBERT32KCategoryInitializer() CategoryInitializer {
 	return &MmBERT32KCategoryInitializerImpl{}
 }
 
-// ModernBERTCategoryInitializerImpl initializes ModernBERT directly, bypassing
-// the CandleBERT auto-detection path. Required when use_modernbert is set
-// explicitly so that ClassifyWithProbabilities has a live ModernBERT backend.
-type ModernBERTCategoryInitializerImpl struct{}
-
-func (c *ModernBERTCategoryInitializerImpl) Init(modelID string, useCPU bool, numClasses ...int) error {
-	logging.Infof("Initializing ModernBERT category classifier (explicit): %s", modelID)
-	err := candle_binding.InitModernBertClassifier(modelID, useCPU)
-	if err != nil {
-		return fmt.Errorf("failed to initialize ModernBERT category classifier: %w", err)
-	}
-	logging.Infof("Initialized ModernBERT category classifier (explicit mode)")
-	return nil
-}
-
-// createModernBERTCategoryInitializer creates a ModernBERT-specific category initializer
-func createModernBERTCategoryInitializer() CategoryInitializer {
-	return &ModernBERTCategoryInitializerImpl{}
-}
-
 type CategoryInference interface {
 	Classify(text string) (candle_binding.ClassResult, error)
 	ClassifyWithProbabilities(text string) (candle_binding.ClassResultWithProbs, error)
@@ -142,23 +122,6 @@ func (c *MmBERT32KCategoryInferenceImpl) ClassifyWithProbabilities(text string) 
 // createMmBERT32KCategoryInference creates mmBERT-32K category inference
 func createMmBERT32KCategoryInference() CategoryInference {
 	return &MmBERT32KCategoryInferenceImpl{}
-}
-
-// ModernBERTCategoryInferenceImpl calls ModernBERT FFI directly for both
-// Classify and ClassifyWithProbabilities — no CandleBERT fallback chain.
-type ModernBERTCategoryInferenceImpl struct{}
-
-func (c *ModernBERTCategoryInferenceImpl) Classify(text string) (candle_binding.ClassResult, error) {
-	return candle_binding.ClassifyModernBertText(text)
-}
-
-func (c *ModernBERTCategoryInferenceImpl) ClassifyWithProbabilities(text string) (candle_binding.ClassResultWithProbs, error) {
-	return candle_binding.ClassifyModernBertTextWithProbabilities(text)
-}
-
-// createModernBERTCategoryInference creates ModernBERT-specific category inference
-func createModernBERTCategoryInference() CategoryInference {
-	return &ModernBERTCategoryInferenceImpl{}
 }
 
 type JailbreakInitializer interface {
@@ -786,10 +749,6 @@ func NewClassifier(cfg *config.RouterConfig, categoryMapping *CategoryMapping, p
 			logging.Infof("Using mmBERT-32K for intent/category classification (32K context, YaRN RoPE)")
 			categoryInitializer = createMmBERT32KCategoryInitializer()
 			categoryInference = createMmBERT32KCategoryInference()
-		} else if cfg.UseModernBERT {
-			logging.Infof("Using ModernBERT for category classification (with probability distribution support)")
-			categoryInitializer = createModernBERTCategoryInitializer()
-			categoryInference = createModernBERTCategoryInference()
 		} else {
 			categoryInitializer = createCategoryInitializer()
 			categoryInference = createCategoryInference()


### PR DESCRIPTION
Reverts vllm-project/semantic-router#1532

cc @noalimoy can you take a look at the regression of e2e tests? i will revert this now for letting other PR passing CI