### PR TITLE
[Doc]: improve skill scores for semantic-router

### DIFF
--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vllm-semantic-router-harness
-description: Use for any task inside the vLLM Semantic Router repository. It bridges native skill discovery into the repo harness entrypoint, canonical agent-report routing flow, repo-local skill registry, and validation commands without duplicating the canonical rules.
+description: Bridges native skill discovery into the vLLM Semantic Router repository harness, routing tasks through the canonical agent-report flow, repo-local skill registry, and validation commands. Use when starting any task inside the vLLM Semantic Router repository to resolve the correct primary skill, read canonical docs, and run harness validation.
 ---
 
 # vLLM Semantic Router Harness

--- a/tools/agent/skills/algorithm-selection-change/SKILL.md
+++ b/tools/agent/skills/algorithm-selection-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: algorithm-selection-change
 category: primary
-description: Use when changing per-decision candidate-model selection after a decision matches.
+description: Modifies candidate-model selection logic that runs after a routing decision matches, including ranking, cost-aware routing, and latency-aware model choice. Use when changing how the router selects which model serves a matched decision, updating candidate ranking algorithms, or adjusting model cost/latency trade-offs.
 ---
 
 # Algorithm Selection Change
@@ -10,6 +10,14 @@ description: Use when changing per-decision candidate-model selection after a de
 
 - Change model-selection logic that runs after a decision matches
 - Change per-decision candidate ranking, cost-aware routing, or latency-aware model choice
+
+## Workflow
+
+1. Read change surfaces, module boundaries, and Go router playbook for context
+2. Modify algorithm selection logic (ranking, cost, latency routing)
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate all constraints pass
+5. Verify selection behavior is covered by targeted tests and affected E2E profiles
 
 ## Must Read
 

--- a/tools/agent/skills/algorithm-selection/SKILL.md
+++ b/tools/agent/skills/algorithm-selection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: algorithm-selection
 category: fragment
-description: Per-decision candidate-model selection after a decision matches.
+description: Implements candidate-model selection logic that runs after a routing decision matches, including model ranking, cost-aware routing, and latency-aware model choice. Use when reading or modifying how the router picks which model serves a matched decision.
 ---
 
 # Algorithm Selection
@@ -9,6 +9,13 @@ description: Per-decision candidate-model selection after a decision matches.
 ## Trigger
 
 - The primary skill touches candidate-model selection after a decision matches
+
+## Workflow
+
+1. Read module boundaries and Go router playbook to understand selection entry points
+2. Modify candidate-model selection logic (ranking, cost, latency)
+3. Run `make test-semantic-router` to validate selection behavior
+4. Verify algorithm code, selection metadata, and tests agree on selection behavior
 
 ## Must Read
 

--- a/tools/agent/skills/architecture-guardrails/SKILL.md
+++ b/tools/agent/skills/architecture-guardrails/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: architecture-guardrails
 category: fragment
-description: Structural limits, dependency boundaries, interface placement, and preferred composition-oriented design patterns.
+description: Enforces structural rules, dependency boundaries, interface placement, and composition-oriented design patterns across the codebase. Use when making non-trivial code changes to verify module boundaries, check dependency direction, or validate that new code follows the project's architecture conventions.
 ---
 
 # Architecture Guardrails
@@ -9,6 +9,13 @@ description: Structural limits, dependency boundaries, interface placement, and 
 ## Trigger
 
 - Load this fragment for any non-trivial code change
+
+## Workflow
+
+1. Read architecture guardrails, module boundaries, and structure rules for applicable constraints
+2. Make code changes while respecting dependency boundaries and interface placement
+3. Run `make agent-lint CHANGED_FILES="..."` to validate structure rules
+4. Verify changed code passes all structure rules and stays modular
 
 ## Must Read
 

--- a/tools/agent/skills/binding-ffi/SKILL.md
+++ b/tools/agent/skills/binding-ffi/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: binding-ffi
 category: fragment
-description: Native bindings and FFI layers used by router-side classifiers or signal evaluation.
+description: Builds and maintains native Rust/C bindings and FFI layers that connect router-side classifiers and signal evaluation to compiled model runtimes. Use when adding or modifying native model bindings, updating FFI interfaces, or changing how the router calls into compiled classifier code.
 ---
 
 # Binding FFI
@@ -22,6 +22,14 @@ description: Native bindings and FFI layers used by router-side classifiers or s
 ## Stop Conditions
 
 - Native code cannot be compiled or validated in the current environment
+
+## Workflow
+
+1. Read the Rust bindings playbook to understand the FFI interface patterns
+2. Modify native binding code or FFI layer interfaces
+3. Run `make test-binding-minimal` to validate basic binding functionality
+4. Run `make test-binding-lora` if LoRA-related bindings are affected
+5. Verify binding interface and router call sites stay aligned
 
 ## Must Read
 

--- a/tools/agent/skills/classifier-post-training/SKILL.md
+++ b/tools/agent/skills/classifier-post-training/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: classifier-post-training
 category: primary
-description: Use when changing model-classifier fine-tuning, post-training data flows, or training artifacts that feed runtime behavior.
+description: Modifies model-classifier fine-tuning scripts, post-training data flows, and training artifacts that feed the router runtime. Use when changing training configurations, updating post-training data pipelines, modifying classifier artifact formats, or adjusting how training outputs are consumed by runtime components.
 ---
 
 # Classifier Post Training
@@ -10,6 +10,14 @@ description: Use when changing model-classifier fine-tuning, post-training data 
 
 - Change model-classifier fine-tuning scripts or training docs
 - Change runtime-facing classifier artifacts or post-training workflow expectations
+
+## Workflow
+
+1. Read change surfaces, model classifier README, and tech debt docs for context
+2. Modify fine-tuning scripts, post-training workflows, or artifact expectations
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to verify surface alignment
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate all constraints
+5. Record any runtime-facing artifact contract mismatches as indexed debt entries
 
 ## Must Read
 

--- a/tools/agent/skills/config-platform-change/SKILL.md
+++ b/tools/agent/skills/config-platform-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: config-platform-change
 category: primary
-description: Use when a config representation must stay aligned across router config, CLI schema, dashboard config UI, and platform translation layers.
+description: Synchronizes config representations across router config, Python CLI schema, dashboard config UI, DSL, and Kubernetes translation layers. Use when adding or changing a config concept that spans multiple surfaces, updating config translation logic, or addressing config representation debt across deployment targets.
 ---
 
 # Config Platform Change
@@ -11,6 +11,14 @@ description: Use when a config representation must stay aligned across router co
 - Change a config concept that exists in router config and Python CLI schema
 - Change config translation between router config, dashboard config UI, DSL, or Kubernetes forms
 - Work on config complexity or representation debt across deployment surfaces
+
+## Workflow
+
+1. Read change surfaces and module boundaries to identify all config layers affected
+2. Modify the config concept across all touched surfaces (router, CLI, dashboard, DSL, k8s)
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to verify surface consistency
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate constraints
+5. Record any intentional remaining mismatches as indexed debt entries
 
 ## Must Read
 

--- a/tools/agent/skills/cross-stack-bugfix/SKILL.md
+++ b/tools/agent/skills/cross-stack-bugfix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cross-stack-bugfix
 category: primary
-description: Use when fixing a multi-surface issue that does not map cleanly to a narrower project-level skill.
+description: Diagnoses and fixes bugs that span multiple layers (runtime, CLI, UI, platform, tests) requiring coordinated changes across surfaces. Use when a bug does not map cleanly to a narrower skill, the fix touches more than one surface, or changes need cross-cutting validation.
 ---
 
 # Cross Stack Bugfix
@@ -10,6 +10,14 @@ description: Use when fixing a multi-surface issue that does not map cleanly to 
 
 - A bug spans multiple layers and no narrower primary skill clearly applies
 - The fix needs coordinated changes across runtime, CLI, UI, platform, or test surfaces
+
+## Workflow
+
+1. Read change surfaces and feature-complete checklist to identify all impacted layers
+2. Diagnose the bug across affected surfaces (runtime, CLI, UI, platform, tests)
+3. Implement coordinated fixes across all impacted surfaces
+4. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to verify all surfaces are accounted for
+5. Promote any remaining mismatches into indexed debt entries
 
 ## Must Read
 

--- a/tools/agent/skills/dashboard-config-ui/SKILL.md
+++ b/tools/agent/skills/dashboard-config-ui/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dashboard-config-ui
 category: fragment
-description: Dashboard config editor, config display, and mutation-flow details.
+description: Modifies dashboard configuration editor forms, config display components, and mutation-flow logic that connects the UI to the router config contract. Use when editing dashboard config forms, updating how config values are displayed, or changing the mutation flow between the dashboard UI and the router/CLI schema.
 ---
 
 # Dashboard Config UI
@@ -22,6 +22,13 @@ description: Dashboard config editor, config display, and mutation-flow details.
 ## Stop Conditions
 
 - Dashboard serialization conflicts with router or CLI contract
+
+## Workflow
+
+1. Read change surfaces doc to understand config UI dependencies
+2. Modify dashboard config forms, display components, or mutation-flow logic
+3. Run `make dashboard-check` to validate UI consistency
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to verify alignment with router and CLI schema
 
 ## Must Read
 

--- a/tools/agent/skills/dashboard-console-backend/SKILL.md
+++ b/tools/agent/skills/dashboard-console-backend/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dashboard-console-backend
 category: fragment
-description: Dashboard backend, persistence, auth/session, and server-side console behavior.
+description: Modifies dashboard backend handlers, persistence layer, authentication, session management, and server-side console behavior. Use when changing dashboard API endpoints, updating database queries, modifying auth/session logic, or adjusting server-side console functionality.
 ---
 
 # Dashboard Console Backend
@@ -9,6 +9,13 @@ description: Dashboard backend, persistence, auth/session, and server-side conso
 ## Trigger
 
 - The primary skill touches dashboard backend handlers, persistence, auth, or session behavior
+
+## Workflow
+
+1. Read change surfaces and tech debt docs to understand backend dependencies
+2. Modify backend handlers, persistence, auth, or session behavior
+3. Run `make dashboard-check` to validate UI and backend consistency
+4. Verify backend console handlers, persistence, and callers stay aligned
 
 ## Must Read
 

--- a/tools/agent/skills/dashboard-console-platform-change/SKILL.md
+++ b/tools/agent/skills/dashboard-console-platform-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dashboard-console-platform-change
 category: primary
-description: Use when changing dashboard backend, console persistence, auth, or control-plane behavior behind the dashboard surface.
+description: Modifies dashboard backend APIs, console persistence, authentication, session management, and control-plane behavior behind the dashboard surface. Use when changing server-side dashboard handlers, updating auth/session logic, modifying storage behavior, or addressing enterprise-console platform debt.
 ---
 
 # Dashboard Console Platform Change
@@ -11,6 +11,14 @@ description: Use when changing dashboard backend, console persistence, auth, or 
 - Change dashboard backend APIs, persistence, or console-side server behavior
 - Change dashboard auth, session, or storage behavior
 - Work on dashboard enterprise-console platform debt
+
+## Workflow
+
+1. Read change surfaces and tech debt docs to understand dashboard platform dependencies
+2. Modify backend APIs, persistence, auth, or session logic
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate constraints
+5. Document any new auth, storage, or session behavior in the canonical harness or create a debt entry
 
 ## Must Read
 

--- a/tools/agent/skills/dashboard-surface-change/SKILL.md
+++ b/tools/agent/skills/dashboard-surface-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dashboard-surface-change
 category: primary
-description: Use when changing frontend dashboard config, topology, or playground surfaces that reflect router behavior.
+description: Modifies frontend dashboard surfaces including config editing UI, topology visualization, and playground reveal/display components that reflect router behavior. Use when changing how routing metadata is presented in the dashboard, updating config editing forms, modifying topology graph rendering, or adjusting playground response display.
 ---
 
 # Dashboard Surface Change
@@ -10,6 +10,13 @@ description: Use when changing frontend dashboard config, topology, or playgroun
 
 - Change config editing UI, topology visualization, or playground reveal or display
 - Change frontend handling of routing metadata or router-backed config
+
+## Workflow
+
+1. Read change surfaces and feature-complete checklist to understand dashboard dependencies
+2. Modify config editing UI, topology visualization, or playground display components
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate alignment with router and CLI contracts
 
 ## Must Read
 

--- a/tools/agent/skills/decision-logic-change/SKILL.md
+++ b/tools/agent/skills/decision-logic-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: decision-logic-change
 category: primary
-description: Use when changing boolean control logic that combines signals and route conditions into decisions.
+description: Modifies boolean decision predicates, thresholds, gates, and priority-driven routing branches that combine signals into routing decisions. Use when changing how signals are evaluated into boolean logic, adding or removing decision gates, or adjusting threshold-based routing behavior.
 ---
 
 # Decision Logic Change
@@ -10,6 +10,14 @@ description: Use when changing boolean control logic that combines signals and r
 
 - Change decision predicates, thresholds, gates, or priority-driven routing branches
 - Change how signals are combined into boolean control logic
+
+## Workflow
+
+1. Read change surfaces, module boundaries, and Go router playbook for decision logic context
+2. Modify decision predicates, thresholds, gates, or priority-driven routing branches
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate all constraints
+5. Verify boolean decision behavior is covered by targeted tests and affected E2E profiles
 
 ## Must Read
 

--- a/tools/agent/skills/decision-logic/SKILL.md
+++ b/tools/agent/skills/decision-logic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: decision-logic
 category: fragment
-description: Boolean decision composition and control logic.
+description: Implements boolean decision predicates, thresholds, and control-logic that combine signals and route conditions into routing decisions. Use when modifying conditional routing rules, adding decision predicates, or changing threshold logic in the Go router.
 ---
 
 # Decision Logic
@@ -9,6 +9,13 @@ description: Boolean decision composition and control logic.
 ## Trigger
 
 - The primary skill touches decision predicates, thresholds, or control-logic code
+
+## Workflow
+
+1. Read module boundaries and Go router playbook to understand predicate structure
+2. Modify decision predicates, thresholds, or control-logic code
+3. Run `make test-semantic-router` to validate decision behavior
+4. Verify decision predicates, thresholds, and tests describe the same behavior
 
 ## Must Read
 

--- a/tools/agent/skills/dsl-crd/SKILL.md
+++ b/tools/agent/skills/dsl-crd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dsl-crd
 category: fragment
-description: DSL and Kubernetes translation details between router config and platform-facing forms.
+description: Maintains the translation layer between the router DSL configuration and Kubernetes CRD manifests, including DSL emission, parsing, and config-to-k8s mapping. Use when modifying how router config is translated to Kubernetes resources, updating DSL parsers, or changing CRD field mappings.
 ---
 
 # DSL CRD
@@ -9,6 +9,14 @@ description: DSL and Kubernetes translation details between router config and pl
 ## Trigger
 
 - The primary skill touches DSL emission/parsing or router-to-Kubernetes translation
+
+## Workflow
+
+1. Read change surfaces doc to understand DSL/CRD translation dependencies
+2. Modify DSL emission, parsing, or router-to-Kubernetes translation code
+3. Run `make test-semantic-router` to validate router-side behavior
+4. Run `make build-e2e` to verify end-to-end Kubernetes translation
+5. Confirm DSL and Kubernetes translation layers remain aligned with the router config contract
 
 ## Must Read
 

--- a/tools/agent/skills/e2e-selection/SKILL.md
+++ b/tools/agent/skills/e2e-selection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: e2e-selection
 category: fragment
-description: Affected local and CI E2E profile selection using the repo-local profile map.
+description: Selects which local and CI end-to-end test profiles are affected by a code change, using the repo-local profile map. Use when a change could affect E2E test behavior and the correct test profiles need to be identified and executed.
 ---
 
 # E2E Selection
@@ -22,6 +22,13 @@ description: Affected local and CI E2E profile selection using the repo-local pr
 ## Stop Conditions
 
 - The affected profile cannot be determined from the current mapping and needs manual classification
+
+## Workflow
+
+1. Read the E2E profile map to understand which profiles cover which surfaces
+2. Run `make agent-e2e-affected CHANGED_FILES="..."` to identify affected profiles
+3. Run `make e2e-test E2E_PROFILE=<profile>` for each affected profile
+4. Verify local and CI E2E expectations are explicit and match the profile map
 
 ## Must Read
 

--- a/tools/agent/skills/feature-complete-checklist/SKILL.md
+++ b/tools/agent/skills/feature-complete-checklist/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: feature-complete-checklist
 category: support
-description: Repository-standard completion checklist and reporting shape before closing a task.
+description: Runs the repository-standard completion checklist before closing a task, verifying all surfaces are validated, E2E profiles pass, and any remaining gaps are documented as tech debt. Use when a primary skill is nearly done and the close-out report needs to be generated.
 ---
 
 # Feature Complete Checklist
@@ -22,6 +22,13 @@ description: Repository-standard completion checklist and reporting shape before
 ## Stop Conditions
 
 - Validation gaps are still unresolved or intentionally skipped without explanation
+
+## Workflow
+
+1. Read the feature-complete checklist to understand required close-out steps
+2. Run `make agent-ci-gate CHANGED_FILES="..."` to validate CI constraints
+3. Run `make agent-feature-gate ENV=cpu|amd CHANGED_FILES="..."` to verify feature readiness
+4. Generate the final report with primary skill, impacted surfaces, validation results, and any debt entries
 
 ## Must Read
 

--- a/tools/agent/skills/harness-contract-change/SKILL.md
+++ b/tools/agent/skills/harness-contract-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: harness-contract-change
 category: primary
-description: Use when changing the repository's agent contract, docs index, manifests, validation scripts, or contributor-facing harness wrappers.
+description: Modifies the repository's agent contract including AGENTS.md, docs index, manifests, validation scripts, and contributor-facing harness wrappers. Use when updating agent documentation, changing repo manifests, editing validation scripts, modifying CI/workflow classification, or updating contributor-facing guides like README.md, CONTRIBUTING.md, or the PR template.
 ---
 
 # Harness Contract Change
@@ -25,6 +25,14 @@ description: Use when changing the repository's agent contract, docs index, mani
 
 - The edit would create a second conflicting source of truth instead of updating the canonical one
 - The rule change cannot be enforced or validated in the same change
+
+## Workflow
+
+1. Read agent README, governance docs, and tech debt register for current contract state
+2. Modify agent contract docs, manifests, validation scripts, or contributor wrappers
+3. Run `make agent-validate` to check alignment between docs and manifests
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to verify all surfaces pass
+5. Record any durable code/spec divergence as indexed debt entries
 
 ## Must Read
 

--- a/tools/agent/skills/harness-governance/SKILL.md
+++ b/tools/agent/skills/harness-governance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: harness-governance
 category: fragment
-description: Human-readable docs, executable manifests, and contributor interfaces that define the repository's shared agent contract.
+description: Maintains the repository's shared agent contract by updating human-readable docs, executable manifests, and contributor-facing harness wrappers. Use when editing AGENTS.md, repo-manifest.yaml, task-matrix.yaml, governance docs, or any contributor-facing harness interface.
 ---
 
 # Harness Governance
@@ -23,6 +23,14 @@ description: Human-readable docs, executable manifests, and contributor interfac
 ## Stop Conditions
 
 - The harness change would leave the indexed docs and executable rules inconsistent
+
+## Workflow
+
+1. Read governance docs and repo manifest to understand current contract state
+2. Edit shared harness docs, manifests, or contributor-facing wrappers
+3. Run `make agent-validate` to check alignment between docs and manifests
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to verify all surfaces pass
+5. Promote any durable gaps into indexed debt entries if not retired in this change
 
 ## Must Read
 

--- a/tools/agent/skills/header-contract-change/SKILL.md
+++ b/tools/agent/skills/header-contract-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: header-contract-change
 category: primary
-description: Use when adding or changing request or response header contracts and the downstream user-visible reveal or display path.
+description: Adds, renames, removes, or changes the meaning of `x-vsr-*` HTTP headers and updates the downstream reveal/display path in dashboard and playground surfaces. Use when modifying router header contracts, changing how routing metadata is emitted in headers, or updating UI header allowlists.
 ---
 
 # Header Contract Change
@@ -11,6 +11,14 @@ description: Use when adding or changing request or response header contracts an
 - Add a new `x-vsr-*` header
 - Rename, remove, or change the meaning of an existing router header
 - Change how dashboard or playground surfaces reveal routing metadata
+
+## Workflow
+
+1. Read change surfaces and feature-complete checklist for header contract dependencies
+2. Modify header constants, emission logic, or UI allowlists
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate alignment
+5. Verify header constants, emission, and UI allowlists remain aligned with relevant test coverage
 
 ## Must Read
 

--- a/tools/agent/skills/k8s-operator-change/SKILL.md
+++ b/tools/agent/skills/k8s-operator-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: k8s-operator-change
 category: primary
-description: Use when changing operator APIs, CRDs, or Kubernetes control-plane behavior for semantic-router deployments.
+description: Modifies Kubernetes operator APIs, CRD schemas, and control-plane reconciliation behavior for semantic-router deployments. Use when updating operator controller logic, changing CRD field definitions, modifying config translation to Kubernetes resources, or adjusting deployment control-plane behavior.
 ---
 
 # Kubernetes Operator Change
@@ -10,6 +10,14 @@ description: Use when changing operator APIs, CRDs, or Kubernetes control-plane 
 
 - Change operator APIs, CRDs, or controller-facing config translation
 - Change Kubernetes deployment control-plane behavior for semantic-router
+
+## Workflow
+
+1. Read change surfaces, feature-complete checklist, and module boundaries for operator context
+2. Modify operator APIs, CRDs, or controller-facing config translation
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate all constraints
+5. Verify operator APIs, CRDs, and router-facing translation stay aligned
 
 ## Must Read
 

--- a/tools/agent/skills/k8s-operator/SKILL.md
+++ b/tools/agent/skills/k8s-operator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: k8s-operator
 category: fragment
-description: Operator APIs, CRDs, and Kubernetes control-plane behavior.
+description: Manages Kubernetes operator APIs, Custom Resource Definitions (CRDs), and control-plane reconciliation logic for the semantic router. Use when modifying CRD schemas, updating operator controller logic, or changing how the router integrates with the Kubernetes API.
 ---
 
 # Kubernetes Operator
@@ -9,6 +9,13 @@ description: Operator APIs, CRDs, and Kubernetes control-plane behavior.
 ## Trigger
 
 - The primary skill touches operator APIs, CRDs, or Kubernetes control-plane logic
+
+## Workflow
+
+1. Read change surfaces and module boundaries to understand operator integration points
+2. Modify operator APIs, CRDs, or controller logic
+3. Run `make generate-crd` to regenerate CRD manifests from API changes
+4. Verify operator APIs, CRDs, and controller-facing config agree on the same contract
 
 ## Must Read
 

--- a/tools/agent/skills/local-dev-amd/SKILL.md
+++ b/tools/agent/skills/local-dev-amd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: local-dev-amd
 category: fragment
-description: Canonical AMD-local image build, serve, and smoke workflow.
+description: Builds Docker images, starts local servers, and runs smoke tests for the AMD/ROCm development environment. Use when validating changes locally on AMD hardware, building AMD container images, or running AMD-specific smoke and E2E tests.
 ---
 
 # Local Dev AMD
@@ -21,6 +21,14 @@ description: Canonical AMD-local image build, serve, and smoke workflow.
 ## Stop Conditions
 
 - AMD-local smoke cannot be run or platform image mapping is unavailable
+
+## Workflow
+
+1. Read AMD-local docs and environment config to understand the AMD build setup
+2. Build the AMD image with `make agent-dev ENV=amd`
+3. Start the local server with `make agent-serve-local ENV=amd`
+4. Run smoke tests with `make agent-smoke-local` to validate the build
+5. Verify the default AMD smoke config starts successfully without unexpected fallbacks
 
 ## Must Read
 

--- a/tools/agent/skills/local-dev-cpu/SKILL.md
+++ b/tools/agent/skills/local-dev-cpu/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: local-dev-cpu
 category: fragment
-description: Canonical CPU-local image build, serve, and smoke workflow.
+description: Builds Docker images, starts local servers, and runs smoke tests for the CPU-only development environment. Use when validating changes locally on CPU, building CPU container images, or running CPU-specific smoke and E2E tests.
 ---
 
 # Local Dev CPU
@@ -21,6 +21,14 @@ description: Canonical CPU-local image build, serve, and smoke workflow.
 ## Stop Conditions
 
 - CPU-local smoke cannot be run in the current workspace/runtime
+
+## Workflow
+
+1. Read environment docs and CLI Docker playbook to understand the CPU build setup
+2. Build the CPU image with `make agent-dev ENV=cpu`
+3. Start the local server with `make agent-serve-local ENV=cpu`
+4. Run smoke tests with `make agent-smoke-local` to validate the build
+5. Verify `vllm-sr status all` and dashboard smoke checks pass
 
 ## Must Read
 

--- a/tools/agent/skills/maintainer-issue-pr-management/SKILL.md
+++ b/tools/agent/skills/maintainer-issue-pr-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: maintainer-issue-pr-management
 category: support
-description: Maintainer workflow for GitHub issue and pull-request creation, updates, triage labels, and closeout metadata.
+description: Manages GitHub issue and pull-request lifecycle including creation, updates, triage labelling, and closeout metadata using canonical templates and repository taxonomy. Use when a maintainer asks to create, update, close, or triage GitHub issues or PRs, or when issue creation requires codebase analysis for scope, labels, or acceptance criteria.
 ---
 
 # Maintainer Issue And PR Management

--- a/tools/agent/skills/playground-reveal/SKILL.md
+++ b/tools/agent/skills/playground-reveal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: playground-reveal
 category: fragment
-description: Playground response rendering, reveal overlays, and user-visible route metadata presentation.
+description: Modifies playground chat rendering, reveal overlays, and user-visible route metadata display in the dashboard. Use when changing how routing decisions are presented to users, updating reveal overlay content, or adjusting playground response formatting.
 ---
 
 # Playground Reveal
@@ -9,6 +9,13 @@ description: Playground response rendering, reveal overlays, and user-visible ro
 ## Trigger
 
 - The primary skill touches playground chat rendering, reveal overlays, or user-visible route metadata
+
+## Workflow
+
+1. Read change surfaces doc to understand playground reveal dependencies
+2. Modify playground rendering, reveal overlays, or route metadata display
+3. Run `make dashboard-check` to validate UI consistency
+4. Verify reveal surfaces stay aligned with emitted metadata and user-visible expectations
 
 ## Must Read
 

--- a/tools/agent/skills/plugin-end-to-end/SKILL.md
+++ b/tools/agent/skills/plugin-end-to-end/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plugin-end-to-end
 category: primary
-description: Use when changing plugin config or plugin runtime behavior that spans router config, post-decision processing, optional CLI/UI exposure, and E2E.
+description: Implements end-to-end plugin changes spanning router config, post-decision processing, optional CLI/UI exposure, and E2E test coverage. Use when adding a new plugin type, changing plugin config schema or execution semantics, updating plugin chain behavior, or modifying plugin-exposed metadata across surfaces.
 ---
 
 # Plugin End to End
@@ -11,6 +11,14 @@ description: Use when changing plugin config or plugin runtime behavior that spa
 - Add or change a plugin type
 - Change plugin config schema, execution semantics, or plugin-exposed metadata
 - Update plugin chain behavior that affects runtime or tests
+
+## Workflow
+
+1. Read change surfaces, module boundaries, and Go router playbook for plugin context
+2. Modify plugin config schema, execution semantics, or chain behavior
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate all constraints
+5. Verify plugin config, runtime behavior, tests, and E2E cover the changed plugin path
 
 ## Must Read
 

--- a/tools/agent/skills/plugin-runtime/SKILL.md
+++ b/tools/agent/skills/plugin-runtime/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plugin-runtime
 category: fragment
-description: Post-decision plugin processing for request or response handling.
+description: Modifies post-decision plugin hooks that transform requests or responses in the routing pipeline. Use when adding, changing, or debugging plugin-controlled request filtering, response transformation, or middleware processing in the Go router.
 ---
 
 # Plugin Runtime
@@ -9,6 +9,13 @@ description: Post-decision plugin processing for request or response handling.
 ## Trigger
 
 - The primary skill touches plugin-controlled request or response processing
+
+## Workflow
+
+1. Read module boundaries and Go router playbook to understand plugin hook points
+2. Modify plugin runtime code (request/response handlers, config hooks)
+3. Run `make test-semantic-router` to verify behavior
+4. Confirm plugin runtime behavior, config hooks, and tests stay aligned
 
 ## Must Read
 

--- a/tools/agent/skills/python-cli-runtime/SKILL.md
+++ b/tools/agent/skills/python-cli-runtime/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: python-cli-runtime
 category: fragment
-description: Python CLI command orchestration, local image management, and serve or status runtime behavior.
+description: Manages Python CLI command orchestration including startup, serve, bootstrap, status checks, and local Docker image management. Use when modifying CLI startup sequences, changing how local images are built or managed, updating serve behavior, or adjusting status command output.
 ---
 
 # Python CLI Runtime
@@ -9,6 +9,14 @@ description: Python CLI command orchestration, local image management, and serve
 ## Trigger
 
 - The primary skill touches CLI startup, serve, bootstrap, status, or local image behavior
+
+## Workflow
+
+1. Read environment docs, CLI Docker playbook, and CLI AGENTS.md for runtime context
+2. Modify CLI startup, serve, bootstrap, status, or local image behavior
+3. Run `make vllm-sr-test` to validate CLI unit behavior
+4. Run `make agent-serve-local ENV=cpu|amd` to verify local smoke behavior
+5. Confirm CLI runtime orchestration and local smoke behavior stay aligned
 
 ## Must Read
 

--- a/tools/agent/skills/python-cli-schema/SKILL.md
+++ b/tools/agent/skills/python-cli-schema/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: python-cli-schema
 category: fragment
-description: Python CLI schema, parser, validator, merger, and config-translation details.
+description: Maintains the Python CLI argument schema, parser, validator, merger, and config-translation layer that mirrors the router config contract. Use when modifying CLI argument definitions, updating config validation rules, changing how CLI inputs are merged, or adjusting config translation between CLI and router formats.
 ---
 
 # Python CLI Schema
@@ -9,6 +9,13 @@ description: Python CLI schema, parser, validator, merger, and config-translatio
 ## Trigger
 
 - The primary skill touches `src/vllm-sr/cli` schema or translation code
+
+## Workflow
+
+1. Read the vllm-sr CLI Docker playbook to understand the schema and translation patterns
+2. Modify CLI schema, parser, validator, merger, or config-translation code
+3. Run `make vllm-sr-test` to validate unit-level schema behavior
+4. Run `make vllm-sr-test-integration` to verify end-to-end CLI contract alignment
 
 ## Must Read
 

--- a/tools/agent/skills/signal-end-to-end/SKILL.md
+++ b/tools/agent/skills/signal-end-to-end/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: signal-end-to-end
 category: primary
-description: Use when adding or changing a signal that spans router config, signal extraction, CLI schema, optional bindings, dashboard surfaces, and E2E.
+description: Implements end-to-end signal changes spanning router config, signal extraction, CLI schema, optional bindings, dashboard surfaces, and E2E test coverage. Use when adding a new signal type, changing signal configuration or extraction logic, updating CLI schema for signal parameters, or modifying how signals are displayed in the dashboard.
 ---
 
 # Signal End to End
@@ -11,6 +11,14 @@ description: Use when adding or changing a signal that spans router config, sign
 - Add a new signal type or signal rule shape
 - Change how an existing signal is configured, extracted, emitted, or displayed
 - Touch router signal config plus Python CLI schema in the same feature
+
+## Workflow
+
+1. Read change surfaces, module boundaries, and playbooks for signal context
+2. Modify signal config, extraction, CLI schema, and dashboard surfaces as needed
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to identify all impacted surfaces
+4. Run `make agent-ci-gate CHANGED_FILES="..."` to validate signal contract alignment
+5. Verify router config, signal extraction, and CLI schema stay aligned with relevant E2E coverage
 
 ## Must Read
 

--- a/tools/agent/skills/signal-runtime/SKILL.md
+++ b/tools/agent/skills/signal-runtime/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: signal-runtime
 category: fragment
-description: Signal extraction and text-understanding runtime paths.
+description: Modifies signal extraction and text-understanding runtime code that produces facts consumed by decision logic. Use when adding new signals, changing classifier runtime behavior, or updating how the router extracts features from input text.
 ---
 
 # Signal Runtime
@@ -9,6 +9,13 @@ description: Signal extraction and text-understanding runtime paths.
 ## Trigger
 
 - The primary skill touches signal extraction or classifier runtime code
+
+## Workflow
+
+1. Read module boundaries and Go router playbook to understand signal extraction paths
+2. Modify signal extraction or classifier runtime code
+3. Run `make test-semantic-router` to verify extracted facts match expectations
+4. Confirm signal extraction code, emitted facts, and targeted tests stay aligned
 
 ## Must Read
 

--- a/tools/agent/skills/startup-chain-change/SKILL.md
+++ b/tools/agent/skills/startup-chain-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: startup-chain-change
 category: primary
-description: Use when changing local image build, serve or bootstrap logic, or canonical smoke behavior.
+description: Modifies the local startup chain including image build, container serve/bootstrap logic, and canonical smoke test behavior. Use when changing `vllm-sr serve` behavior, image selection or pull policy, container startup sequences, local Docker/Make bootstrap, or canonical smoke config.
 ---
 
 # Startup Chain Change
@@ -11,6 +11,14 @@ description: Use when changing local image build, serve or bootstrap logic, or c
 - Change `vllm-sr serve`, image selection, pull policy, or container startup behavior
 - Change canonical local smoke config or agent smoke flow
 - Change local Docker or Make bootstrap behavior
+
+## Workflow
+
+1. Read environment docs and CLI Docker playbook for startup chain context
+2. Modify serve, bootstrap, image selection, or smoke config
+3. Run `make agent-report ENV=cpu|amd CHANGED_FILES="..."` to identify impacted surfaces
+4. Run `make agent-feature-gate ENV=cpu|amd CHANGED_FILES="..."` to validate startup behavior
+5. Verify the canonical local serve path works with the default smoke config
 
 ## Must Read
 

--- a/tools/agent/skills/topology-visualization/SKILL.md
+++ b/tools/agent/skills/topology-visualization/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: topology-visualization
 category: fragment
-description: Topology graph APIs, parsing, and frontend visualization details.
+description: Modifies topology graph APIs, data parsers, layout algorithms, and frontend rendering components that visualize routing topology. Use when changing how topology graphs are fetched, parsed, laid out, or rendered in the dashboard.
 ---
 
 # Topology Visualization
@@ -9,6 +9,13 @@ description: Topology graph APIs, parsing, and frontend visualization details.
 ## Trigger
 
 - The primary skill touches topology graph APIs, parsers, layout, or topology rendering
+
+## Workflow
+
+1. Read change surfaces doc to understand topology visualization dependencies
+2. Modify topology graph APIs, parsers, layout, or rendering components
+3. Run `make dashboard-check` to validate UI consistency
+4. Verify topology renderers and data sources agree on the same graph semantics
 
 ## Must Read
 

--- a/tools/agent/skills/training-model-classifier/SKILL.md
+++ b/tools/agent/skills/training-model-classifier/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: training-model-classifier
 category: fragment
-description: Model-classifier fine-tuning, training scripts, and runtime-facing artifact expectations.
+description: Manages model-classifier fine-tuning workflows, training scripts, and runtime-facing artifact expectations. Use when modifying training configurations, updating training data pipelines, changing model hyperparameters, or adjusting how training artifacts are consumed by the router runtime.
 ---
 
 # Training Model Classifier
@@ -9,6 +9,13 @@ description: Model-classifier fine-tuning, training scripts, and runtime-facing 
 ## Trigger
 
 - The primary skill touches model-classifier training scripts, docs, or artifact expectations
+
+## Workflow
+
+1. Read the model classifier README and tech debt docs for current training setup
+2. Modify training scripts, configurations, or artifact expectations
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to verify alignment
+4. Confirm training scripts, docs, and artifact expectations stay aligned
 
 ## Must Read
 


### PR DESCRIPTION
Hullo @rootfs @Xunzhuo 👋

## Summary

- Scope: All 35 agent skills across `tools/agent/skills/` and `.agents/skills/`
- Primary skill: `harness-contract-change`
- Impacted surfaces: `harness_docs`
- Conditional surfaces intentionally skipped: none
- Behavior-visible change: `no`
- Debt entry: `none`

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/0b7fc9e0-4a0b-48dc-83a5-22a373217ca9" />

Here's the full before/after in text form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| plugin-runtime | 19% | 86% | +67% |
| algorithm-selection | 22% | 79% | +57% |
| harness-governance | 30% | 86% | +56% |
| decision-logic | 26% | 79% | +53% |
| signal-runtime | 26% | 79% | +53% |
| playground-reveal | 27% | 79% | +52% |
| topology-visualization | 35% | 86% | +51% |
| architecture-guardrails | 30% | 79% | +49% |
| algorithm-selection-change | 30% | 79% | +49% |
| k8s-operator | 37% | 86% | +49% |
| binding-ffi | 34% | 79% | +45% |
| dsl-crd | 41% | 86% | +45% |
| cross-stack-bugfix | 30% | 74% | +44% |
| e2e-selection | 39% | 81% | +42% |
| dashboard-console-backend | 46% | 86% | +40% |
| config-platform-change | 46% | 85% | +39% |
| feature-complete-checklist | 40% | 79% | +39% |
| dashboard-console-platform-change | 41% | 79% | +38% | 
| dashboard-config-ui | 43% | 79% | +36% |
| python-cli-schema | 43% | 79% | +36% |
| training-model-classifier | 39% | 74% | +35% |
| maintainer-issue-pr-management | 51% | 85% | +34% | 
| classifier-post-training | 46% | 79% | +33% |
| decision-logic-change | 46% | 79% | +33% |
| k8s-operator-change | 46% | 79% | +33% |
| python-cli-runtime | 46% | 79% | +33% |
| header-contract-change | 54% | 86% | +32% |
| harness-contract-change | 61% | 93% | +32% |
| dashboard-surface-change | 50% | 79% | +29% |
| plugin-end-to-end | 50% | 79% | +29% |
| harness | 55% | 80% | +25% |
| local-dev-amd | 45% | 94% | +49% |
| local-dev-cpu | 45% | 94% | +49% |
| signal-end-to-end | 59% | 79% | +20% |
| startup-chain-change | 61% | 79% | +18% |

**Average improvement: +39 percentage points across 35 skills.**

## Validation

- Environment: `not run`
- Fast gate: N/A (documentation-only change)
- Feature gate: N/A
- Local smoke / E2E: N/A
- CI expectations / blockers: None — these are SKILL.md metadata improvements only, no runtime code affected

## Checklist

- [x] PR title uses the repo prefix format: `[Doc]`
- [x] Commits in this PR are signed off with `git commit -s`
- [-] Source-of-truth docs or indexed debt entries were updated when applicable
- [-] The validation results above reflect the actual commands or blockers for this change

<details>
<summary>What changed</summary>

Every SKILL.md received two targeted improvements:

1. **Expanded frontmatter descriptions** — replaced vague jargon with concrete action verbs and added explicit "Use when..." clauses so agents can reliably select the right skill
2. **Added Workflow sections** — 3-5 numbered steps showing the sequence of operations (read docs → make changes → run validation → verify acceptance) so agents follow a clear process

All existing file references, commands, surfaces, stop conditions, and acceptance criteria were preserved exactly. No runtime code was touched.

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - @popey - if you hit any snags.

Thanks in advance 🙏
