### PR TITLE
[Bugfix][selection]: make FileEloStorage dirty flag race-safe

### DIFF
--- a/src/semantic-router/pkg/selection/storage.go
+++ b/src/semantic-router/pkg/selection/storage.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -67,7 +68,7 @@ type StoredRatings struct {
 type FileEloStorage struct {
 	path     string
 	mu       sync.RWMutex
-	dirty    bool
+	dirty    atomic.Bool
 	stopChan chan struct{}
 	doneChan chan struct{}
 }
@@ -314,20 +315,20 @@ func (f *FileEloStorage) StartAutoSave(interval time.Duration, getAll func() map
 			select {
 			case <-f.stopChan:
 				// Final save before shutdown
-				if f.dirty {
+				if f.dirty.Swap(false) {
 					ratings := getAll()
 					if err := f.SaveAllRatings(ratings); err != nil {
+						f.dirty.Store(true)
 						logging.Errorf("[EloStorage] Failed final save: %v", err)
 					}
 				}
 				return
 			case <-ticker.C:
-				if f.dirty {
+				if f.dirty.Swap(false) {
 					ratings := getAll()
 					if err := f.SaveAllRatings(ratings); err != nil {
+						f.dirty.Store(true)
 						logging.Errorf("[EloStorage] Auto-save failed: %v", err)
-					} else {
-						f.dirty = false
 					}
 				}
 			}
@@ -337,7 +338,7 @@ func (f *FileEloStorage) StartAutoSave(interval time.Duration, getAll func() map
 
 // MarkDirty marks that ratings have changed and need to be saved
 func (f *FileEloStorage) MarkDirty() {
-	f.dirty = true
+	f.dirty.Store(true)
 }
 
 // MemoryEloStorage implements EloStorage using in-memory storage (for testing)


### PR DESCRIPTION
Replace FileEloStorage.dirty with atomic.Bool and clear the dirty bit with Swap(false) before autosave persists ratings. This removes the data race between MarkDirty and the autosave goroutine and avoids dropping a concurrent dirty write after a successful save.

Closes #xxxx

## Summary

- Scope:
- Primary skill:
- Impacted surfaces:
- Conditional surfaces intentionally skipped:
- Behavior-visible change: `yes` / `no`
- Debt entry: `none` / `TDxxx`

## Validation

- Environment: `cpu-local` / `amd-local` / `not run`
- Fast gate:
- Feature gate:
- Local smoke / E2E:
- CI expectations / blockers:

## Checklist

- [x] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
- [ ] If the PR spans multiple categories, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] Source-of-truth docs or indexed debt entries were updated when applicable
- [ ] The validation results above reflect the actual commands or blockers for this change

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
