### PR TITLE
fix: use enhancement label instead of non-existent feature request label

### DIFF
--- a/.github/ISSUE_TEMPLATE/001_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/001_feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Feature request
-labels: ["feature request"]
+labels: ["enhancement"]
 title: "feature: <title>"
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

The feature request issue template (`.github/ISSUE_TEMPLATE/001_feature_request.yaml`) referenced a `feature request` label which does not exist in the repository. The repo uses `enhancement` instead.

## Changes

- Changed `labels: ["feature request"]` to `labels: ["enhancement"]` in `.github/ISSUE_TEMPLATE/001_feature_request.yaml`

## Testing

- Verified the repo label inventory via GitHub API confirms `enhancement` exists and `feature request` does not
- No code logic changed; only issue template metadata

Fixes vllm-project/semantic-router#1599