### PR TITLE
agent: surface loop-mode policy in harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This file is the short entrypoint for coding agents. The detailed human-readable
 ## Native Discovery vs Routed Context
 
 - Root startup should always discover this [AGENTS.md](AGENTS.md) entrypoint and the thin repo-native bridge at [.agents/skills/harness/SKILL.md](.agents/skills/harness/SKILL.md).
-- Full task routing, primary-skill resolution, local-rule surfacing, and validation planning still come from `make agent-report ENV=cpu|amd CHANGED_FILES="..."`.
+- Full task routing, primary-skill resolution, local-rule surfacing, loop-mode guidance, and validation planning still come from `make agent-report ENV=cpu|amd CHANGED_FILES="..."`.
 - `tools/agent/**` remains the canonical harness source; `.agents/skills/**` is only a discovery bridge.
 
 If you need real AMD model deployment details instead of the minimal smoke path, also read [deploy/amd/README.md](deploy/amd/README.md) and [deploy/recipes/balance.yaml](deploy/recipes/balance.yaml).
@@ -29,6 +29,7 @@ If you need real AMD model deployment details instead of the minimal smoke path,
 - Use the local image flow for local-dev behavior. Do not invent another serve path.
 - Start from a project-level primary skill. Fragment skills are support material, not the default entrypoint.
 - Run the smallest relevant gate first: `make agent-validate`, `make agent-lint`, `make agent-ci-gate`, then `make agent-feature-gate`.
+- Drive the active task to its reported completion boundary: fix failures and rerun the applicable gates until the current change or subtask is done, and do not hand off on the first failing run.
 - Treat docs-only and website-only edits as lightweight unless the task matrix says otherwise.
 - Contributor workflow, issue or PR intake rules, and maintainer label taxonomy live in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/**`, and `.prowlabels.yaml`; commits intended for PRs must use `git commit -s`.
 - Behavior-visible routing, startup, config, Docker, CLI, or API changes need E2E updates unless the change is a pure refactor.

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -7,7 +7,7 @@ This directory is the human-readable system of record for the repository's agent
 ## Start Here
 
 - [context-management.md](context-management.md)
-  - task-first progressive disclosure and `agent-report` context-pack flow
+  - task-first progressive disclosure, loop-mode guidance, and `agent-report` context-pack flow
 - [repo-map.md](repo-map.md)
   - repo layout, hotspots, entrypoints, and high-risk areas
 - [environments.md](environments.md)
@@ -26,7 +26,7 @@ This directory is the human-readable system of record for the repository's agent
 - [governance.md](governance.md)
   - rule layering, source-of-truth policy, and working-note policy
 - [plans/README.md](plans/README.md)
-  - when to use execution plans, how they differ from ADRs/debt, and the current plan inventory
+  - when to use execution plans for long-horizon completion loops, how they differ from ADRs/debt, and the current plan inventory
 - [tech-debt-register.md](tech-debt-register.md)
   - landing page and policy for repository technical debt
 - [tech-debt/README.md](tech-debt/README.md)
@@ -67,7 +67,7 @@ This directory is the human-readable system of record for the repository's agent
   - `make agent-validate`
   - `make agent-scorecard`
   - `make agent-report ENV=cpu CHANGED_FILES="..."`
-    - emits validation commands plus a task-first context pack
+    - emits validation commands, loop policy, and a task-first context pack
 
 ## Contributor Interface
 

--- a/docs/agent/context-management.md
+++ b/docs/agent/context-management.md
@@ -6,7 +6,7 @@ This document defines how the harness exposes the minimum useful context for a t
 
 - `AGENTS.md` should stay short and navigational.
 - `docs/agent/*` should stay canonical, but the set is now large enough that agents need a task-first read path.
-- `make agent-report ENV=cpu|amd CHANGED_FILES="..."` should resolve not only validation, but also the minimum context pack for the task.
+- `make agent-report ENV=cpu|amd CHANGED_FILES="..."` should resolve not only validation, but also the minimum context pack and loop policy for the task.
 
 ## Disclosure Layers
 
@@ -16,6 +16,7 @@ This document defines how the harness exposes the minimum useful context for a t
 - `L1` task contract
   - resolved primary skill
   - fragment skills
+  - loop mode and execution-plan guidance for the active task
   - the `## Must Read` links referenced by those skills
 - `L2` surface context
   - only docs and executable sources for the impacted surfaces
@@ -26,12 +27,12 @@ This document defines how the harness exposes the minimum useful context for a t
 
 ## Context Pack Flow
 
-1. Resolve changed files through `make agent-report ENV=cpu|amd CHANGED_FILES="..."`.
+1. Resolve changed files through `make agent-report ENV=cpu|amd CHANGED_FILES="..."` so the harness can emit the active skill, loop mode, execution-plan guidance, and validation commands.
 2. Select the primary skill and fragment skills from `tools/agent/skill-registry.yaml`.
 3. Pull the skill `## Must Read` references from the active `SKILL.md` files.
 4. Add surface-specific references from `tools/agent/context-map.yaml`.
 5. Add nearest local `AGENTS.md` files for hotspot paths when applicable.
-6. Add resume references such as plans or debt only as low-priority follow-up context.
+6. Add resume references such as plans or debt as low-priority follow-up context, then promote them into the active loop when the task becomes long-horizon, multi-loop, or unresolved.
 
 ## Source of Truth
 

--- a/docs/agent/feature-complete-checklist.md
+++ b/docs/agent/feature-complete-checklist.md
@@ -13,6 +13,12 @@ A feature is not done until all applicable checks below are satisfied.
 - Behavior-sensitive E2E coverage uses explicit acceptance thresholds instead of report-only metrics
 - CI covers the remaining affected profiles
 
+## Loop Completion
+
+- A task is not done when a failing gate is merely observed.
+- The active loop continues until the applicable gates pass for the current change or subtask, or an external blocker is explicitly reported.
+- Long-horizon multi-subtask work keeps its execution plan current as part of the done state.
+
 ## E2E Expectation
 
 - If user-visible behavior changes, update or add at least one E2E case

--- a/docs/agent/governance.md
+++ b/docs/agent/governance.md
@@ -32,6 +32,15 @@ This document defines how the repository's agent rules are layered and maintaine
 - Record durable harness decisions in [adr/README.md](adr/README.md) and the ADR files it indexes.
 - Do not use ADRs for temporary execution plans, one-off migrations, or debt items that have not yet reached a durable decision.
 
+## Default Task Loop
+
+- Every task follows the canonical loop surfaced by `make agent-report`.
+- Start from the resolved skill and context, make the smallest viable change, run the applicable gate, and treat failing runs as continuation signals instead of handoff points.
+- `tools/agent/task-matrix.yaml` classifies rule sets as `lightweight` or `completion`.
+- `lightweight` tasks close when the applicable gates for the current change pass or a real external blocker is recorded.
+- `completion` tasks close when the active subtask and its applicable gates pass; if the work spans multiple ordered loops or must resume across sessions, create or update an execution plan.
+- Stop a loop early only for real external blockers or when another unfinished in-scope subtask can advance while the blocker is pending.
+
 ## What Does Not Belong in the Canonical Harness
 
 - one-off CI repair loops

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -28,6 +28,13 @@ This document defines the harness-side validation ladder for repository changes.
 - Use `make agent-ci-lint CHANGED_FILES="..."` when you want the same changed-file lint path that the pre-commit workflow runs in CI.
 - Use `ENV=amd` when platform behavior, AMD defaults, or ROCm image selection are affected.
 
+## Loop Handling
+
+- `make agent-report` resolves the task loop mode from `tools/agent/task-matrix.yaml`.
+- `lightweight` tasks keep iterating until the applicable gates for the current change pass or a real external blocker is recorded.
+- `completion` tasks keep iterating until the active subtask passes its applicable gates; when the work spans multiple ordered loops or sessions, move the task state into an execution plan.
+- A failing lint, test, smoke, integration, or E2E run is not a handoff point. Fix the issue or narrow the failing surface, then rerun the smallest relevant gate until the current completion boundary is satisfied.
+
 ## Environment Expectations
 
 - `cpu-local`

--- a/tools/agent/scripts/agent_models.py
+++ b/tools/agent/scripts/agent_models.py
@@ -20,6 +20,8 @@ class ResolvedContext:
     workflow_integration_suites: list[str] = field(default_factory=list)
     ci_e2e_mode: str = "none"
     doc_only: bool = False
+    loop_mode: str = "completion"
+    execution_plan_policy: str = "long_horizon"
 
     def to_json(self) -> str:
         return json.dumps(self.__dict__, indent=2, sort_keys=True)
@@ -38,14 +40,48 @@ class ResolvedContext:
             ),
             "AGENT_CI_E2E_MODE": self.ci_e2e_mode,
             "AGENT_DOC_ONLY": str(self.doc_only).lower(),
+            "AGENT_LOOP_MODE": self.loop_mode,
+            "AGENT_EXECUTION_PLAN_POLICY": self.execution_plan_policy,
         }
         return "\n".join(f"{key}={shlex.quote(value)}" for key, value in values.items())
+
+    def execution_plan_summary(self) -> str:
+        policy_labels = {
+            "none": "not required by default",
+            "long_horizon": "required for long-horizon multi-loop work",
+            "always": "required",
+        }
+        return policy_labels.get(self.execution_plan_policy, self.execution_plan_policy)
+
+    def failure_policy_summary(self) -> str:
+        if self.loop_mode == "lightweight":
+            return (
+                "fix failures and rerun the smallest applicable gate until the current "
+                "change passes or a real blocker is recorded"
+            )
+        return (
+            "fix failures and rerun the smallest applicable gate until the active "
+            "subtask passes; continue across subtasks until the task boundary is met "
+            "or a real blocker is recorded"
+        )
+
+    def stop_condition_summary(self) -> str:
+        if self.loop_mode == "lightweight":
+            return "applicable gates pass for the current change"
+        if self.execution_plan_policy == "always":
+            return "all execution-plan tasks and exit criteria pass"
+        return (
+            "active subtask passes its applicable gates; when the work becomes "
+            "long-horizon or cross-session, keep an execution plan current"
+        )
 
     def to_summary(self) -> str:
         lines = [
             "Agent Context",
             f"  Changed files: {len(self.changed_files)}",
             f"  Matched rules: {', '.join(self.matched_rules) or 'none'}",
+            f"  Loop mode: {self.loop_mode}",
+            f"  Execution plan: {self.execution_plan_summary()}",
             f"  Fast tests: {', '.join(self.fast_tests) or 'none'}",
             f"  Feature tests: {', '.join(self.feature_tests) or 'none'}",
             f"  Local smoke: {'required' if self.requires_local_smoke else 'not required'}",
@@ -53,6 +89,8 @@ class ResolvedContext:
             "  Workflow integration suites: "
             + (", ".join(self.workflow_integration_suites) or "none"),
             f"  CI E2E mode: {self.ci_e2e_mode}",
+            f"  Failure policy: {self.failure_policy_summary()}",
+            f"  Stop condition: {self.stop_condition_summary()}",
         ]
         if self.ci_e2e_profiles:
             lines.append(f"  CI E2E profiles: {', '.join(self.ci_e2e_profiles)}")

--- a/tools/agent/scripts/agent_resolution.py
+++ b/tools/agent/scripts/agent_resolution.py
@@ -111,6 +111,19 @@ def unique_preserve_order(values: Iterable[str]) -> list[str]:
     return result
 
 
+DEFAULT_LOOP_MODE = "completion"
+DEFAULT_EXECUTION_PLAN_POLICY = "long_horizon"
+LOOP_MODE_PRIORITY = {
+    "lightweight": 0,
+    "completion": 1,
+}
+EXECUTION_PLAN_POLICY_PRIORITY = {
+    "none": 0,
+    "long_horizon": 1,
+    "always": 2,
+}
+
+
 def match_task_matrix_rules(
     task_matrix: dict, changed_files: list[str], local_rule_path_set: set[str]
 ) -> tuple[list[dict], list[str], list[str], bool]:
@@ -203,6 +216,27 @@ def is_doc_only_rule_set(matched_rules: list[dict]) -> bool:
     )
 
 
+def resolve_loop_mode(matched_rules: list[dict]) -> str:
+    if not matched_rules:
+        return DEFAULT_LOOP_MODE
+    return max(
+        (rule.get("loop_mode", DEFAULT_LOOP_MODE) for rule in matched_rules),
+        key=lambda mode: LOOP_MODE_PRIORITY.get(mode, -1),
+    )
+
+
+def resolve_execution_plan_policy(matched_rules: list[dict]) -> str:
+    if not matched_rules:
+        return DEFAULT_EXECUTION_PLAN_POLICY
+    return max(
+        (
+            rule.get("execution_plan_policy", DEFAULT_EXECUTION_PLAN_POLICY)
+            for rule in matched_rules
+        ),
+        key=lambda policy: EXECUTION_PLAN_POLICY_PRIORITY.get(policy, -1),
+    )
+
+
 def resolve_context(changed_files: list[str]) -> ResolvedContext:
     repo_manifest, task_matrix, e2e_map, _, _ = load_manifests()
     local_rule_path_set = local_agent_rule_paths(repo_manifest)
@@ -213,6 +247,8 @@ def resolve_context(changed_files: list[str]) -> ResolvedContext:
         resolve_e2e_profiles(changed_files, e2e_map, local_rule_path_set)
     )
     doc_only = is_doc_only_rule_set(matched_rules)
+    loop_mode = resolve_loop_mode(matched_rules)
+    execution_plan_policy = resolve_execution_plan_policy(matched_rules)
     if doc_only:
         local_profiles = []
     return ResolvedContext(
@@ -226,6 +262,8 @@ def resolve_context(changed_files: list[str]) -> ResolvedContext:
         workflow_integration_suites=unique_preserve_order(targeted_workflow_suites),
         ci_e2e_mode=ci_mode,
         doc_only=doc_only,
+        loop_mode=loop_mode,
+        execution_plan_policy=execution_plan_policy,
     )
 
 

--- a/tools/agent/scripts/agent_validation.py
+++ b/tools/agent/scripts/agent_validation.py
@@ -24,6 +24,9 @@ from agent_support import (
     validate_glob,
 )
 
+VALID_LOOP_MODES = {"lightweight", "completion"}
+VALID_EXECUTION_PLAN_POLICIES = {"none", "long_horizon", "always"}
+
 
 def validate_supported_envs(
     repo_manifest: dict, skill_registry: dict, make_targets: set[str], errors: list[str]
@@ -82,6 +85,26 @@ def validate_task_matrix(
     task_matrix: dict, make_targets: set[str], errors: list[str]
 ) -> None:
     for rule in task_matrix["rules"]:
+        loop_mode = rule.get("loop_mode")
+        execution_plan_policy = rule.get("execution_plan_policy")
+        if loop_mode not in VALID_LOOP_MODES:
+            errors.append(
+                f"Task rule '{rule['name']}' has invalid loop_mode '{loop_mode}'"
+            )
+        if execution_plan_policy not in VALID_EXECUTION_PLAN_POLICIES:
+            errors.append(
+                "Task rule "
+                f"'{rule['name']}' has invalid execution_plan_policy "
+                f"'{execution_plan_policy}'"
+            )
+        if rule.get("doc_only", False) and loop_mode != "lightweight":
+            errors.append(
+                f"Documentation-only task rule '{rule['name']}' must use loop_mode 'lightweight'"
+            )
+        if execution_plan_policy == "always" and loop_mode != "completion":
+            errors.append(
+                f"Task rule '{rule['name']}' cannot require execution plans outside completion mode"
+            )
         commands = [*rule.get("fast_tests", []), *rule.get("feature_tests", [])]
         for command in commands:
             append_missing_make_target(

--- a/tools/agent/task-matrix.yaml
+++ b/tools/agent/task-matrix.yaml
@@ -3,6 +3,8 @@ version: 1
 rules:
   - name: repo-docs
     doc_only: true
+    loop_mode: lightweight
+    execution_plan_policy: long_horizon
     paths:
       - docs/**
       - website/**
@@ -13,6 +15,8 @@ rules:
     requires_local_smoke: false
   - name: agent_text
     doc_only: true
+    loop_mode: lightweight
+    execution_plan_policy: long_horizon
     paths:
       - AGENTS.md
       - docs/agent/**
@@ -40,6 +44,8 @@ rules:
     requires_local_smoke: false
   - name: agent_exec
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - tools/agent/*.yaml
       - tools/agent/scripts/**
@@ -55,6 +61,8 @@ rules:
     requires_local_smoke: false
   - name: vllm-sr-cli
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - src/vllm-sr/**
       - src/vllm-sr/Dockerfile*
@@ -67,6 +75,8 @@ rules:
     requires_local_smoke: true
   - name: fleet-sim
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - src/fleet-sim/**
     fast_tests:
@@ -75,6 +85,8 @@ rules:
     requires_local_smoke: false
   - name: memory-integration
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - e2e/testing/09-memory-features-test.py
       - e2e/testing/run_memory_integration.sh
@@ -88,6 +100,8 @@ rules:
     requires_local_smoke: false
   - name: router-core
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - src/semantic-router/**
     fast_tests:
@@ -96,6 +110,8 @@ rules:
     requires_local_smoke: true
   - name: rust-bindings
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - candle-binding/**
       - ml-binding/**
@@ -107,6 +123,8 @@ rules:
     requires_local_smoke: false
   - name: dashboard
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - dashboard/**
     fast_tests:
@@ -115,6 +133,8 @@ rules:
     requires_local_smoke: true
   - name: e2e-framework
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - e2e/pkg/**
       - e2e/cmd/**
@@ -127,6 +147,8 @@ rules:
     requires_local_smoke: false
   - name: operator-stack
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - deploy/operator/**
       - deploy/kubernetes/crds/**
@@ -137,6 +159,8 @@ rules:
     requires_local_smoke: false
   - name: training-stack
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - src/training/**
       - tools/make/models.mk
@@ -147,6 +171,8 @@ rules:
     requires_local_smoke: false
   - name: make-and-ci
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - Makefile
       - tools/make/**
@@ -156,6 +182,8 @@ rules:
     requires_local_smoke: true
   - name: ci-general
     doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
     paths:
       - .github/workflows/**
     fast_tests:


### PR DESCRIPTION
## Summary
- add rule-driven loop metadata to the harness task matrix and agent report output
- document the default lightweight vs completion task loop in the canonical harness docs
- validate loop-mode and execution-plan policy values in the harness validation layer

## Testing
- make agent-validate
- make agent-ci-gate CHANGED_FILES="AGENTS.md,docs/agent/README.md,docs/agent/governance.md,docs/agent/context-management.md,docs/agent/testing-strategy.md,docs/agent/feature-complete-checklist.md,tools/agent/task-matrix.yaml,tools/agent/scripts/agent_models.py,tools/agent/scripts/agent_resolution.py,tools/agent/scripts/agent_validation.py"