### PR TITLE
[Router][Doc] Align privacy recipe with balance mock aliases

### DIFF
--- a/deploy/recipes/privacy/README.md
+++ b/deploy/recipes/privacy/README.md
@@ -8,6 +8,13 @@ The maintained assets live here:
 - `privacy-router.dsl`
 - `privacy.probes.yaml`
 
+The current bindings mirror the `balance` recipe's model set:
+
+- local lane: `local/private-qwen` backed by `qwen/qwen3.5-rocm`
+- frontier lane: `cloud/frontier-reasoning` backed by the `anthropic/claude-opus-4.6` alias
+
+Both lanes currently use the same `balance`-style mock alias catalog on the shared `vllm:8000` backend rather than calling a live external provider.
+
 ## Design Goals
 
 - Route PII, private code, and internal documents to `local/private-qwen`.
@@ -39,8 +46,8 @@ This recipe intentionally exaggerates the spread:
 
 | Model | Prompt / 1M | Completion / 1M | Why |
 |---|---|---|---|
-| `local/private-qwen` | `$0.00` | `$0.00` | Self-hosted default and privacy lane |
-| `cloud/frontier-reasoning` | `$1.20` | `$4.80` | Expensive frontier lane for non-sensitive deep reasoning only |
+| `local/private-qwen` | `$0.00` | `$0.00` | Self-hosted default and privacy lane, backed by `qwen/qwen3.5-rocm` |
+| `cloud/frontier-reasoning` | `$1.80` | `$7.20` | Most expensive balance-tier alias, mocked through the shared `vllm:8000` backend as `anthropic/claude-opus-4.6` for non-sensitive deep reasoning only |
 
 These values are example prices for routing economics and Insights demos, not vendor billing quotes.
 

--- a/deploy/recipes/privacy/privacy-router.yaml
+++ b/deploy/recipes/privacy/privacy-router.yaml
@@ -13,9 +13,6 @@ providers:
       qwen3:
         type: chat_template_kwargs
         parameter: enable_thinking
-      gpt:
-        type: reasoning_effort
-        parameter: reasoning.effort
     default_reasoning_effort: medium
   # Example pricing intentionally exaggerates the local-vs-cloud spread so
   # Insights makes privacy-preserving savings obvious. These are not vendor
@@ -23,7 +20,7 @@ providers:
   models:
     - name: local/private-qwen
       reasoning_family: qwen3
-      provider_model_id: replace-with-local-vllm-model
+      provider_model_id: qwen/qwen3.5-rocm
       api_format: openai
       pricing:
         currency: USD
@@ -36,21 +33,17 @@ providers:
           type: vllm
           weight: 1
     - name: cloud/frontier-reasoning
-      reasoning_family: gpt
-      provider_model_id: replace-with-cloud-frontier-model
+      reasoning_family: qwen3
+      provider_model_id: anthropic/claude-opus-4.6
       api_format: openai
       pricing:
         currency: USD
-        prompt_per_1m: 1.20
-        completion_per_1m: 4.80
+        prompt_per_1m: 1.80
+        completion_per_1m: 7.20
       backend_refs:
-        - name: openai-frontier
-          base_url: https://api.openai.com/v1
-          provider: openai
-          type: openai
-          auth_header: Authorization
-          auth_prefix: Bearer
-          api_key_env: OPENAI_API_KEY
+        - name: vllm_primary
+          endpoint: vllm:8000
+          protocol: http
           weight: 1
 
 routing:


### PR DESCRIPTION
## Summary

- Scope: align the privacy recipe provider bindings with the balance recipe's local/mock alias catalog
- Primary skill: `cross-stack-bugfix`
- Impacted surfaces: `none` reported by `make agent-report`
- Conditional surfaces intentionally skipped: `none`
- Behavior-visible change: `yes`
- Debt entry: `none`

## Validation

- Environment: `cpu-local`
- Fast gate: `make agent-lint CHANGED_FILES="deploy/recipes/privacy/privacy-router.yaml deploy/recipes/privacy/README.md"`
- Feature gate: `make agent-feature-gate ENV=cpu CHANGED_FILES="deploy/recipes/privacy/privacy-router.yaml deploy/recipes/privacy/README.md"` (`No feature-only commands matched.`)
- Local smoke / E2E: `not run` (`No affected local E2E profiles.`)
- CI expectations / blockers: `make agent-ci-gate CHANGED_FILES="deploy/recipes/privacy/privacy-router.yaml deploy/recipes/privacy/README.md"` (`No fast commands matched.`)

Additional checks:

- `go run ./cmd/dsl validate ../../deploy/recipes/privacy/privacy-router.dsl`
- `go run ./cmd/dsl compile -o /tmp/privacy-router.compiled.yaml ../../deploy/recipes/privacy/privacy-router.dsl`
- `go test ./pkg/config -run TestMaintainedConfigAssetsUseCanonicalV03Contract -count=1`

## Checklist

- [x] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
- [x] If the PR spans multiple categories, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Source-of-truth docs or indexed debt entries were updated when applicable
- [x] The validation results above reflect the actual commands or blockers for this change