### PR TITLE
[Doc] Add arXiv 2603.23013 to website research

### DIFF
--- a/website/src/data/researchContent.js
+++ b/website/src/data/researchContent.js
@@ -144,6 +144,20 @@ export const researchPapers = [
     sortOrder: 58,
   },
   {
+    id: 'knowledge-access-beats-model-size',
+    type: 'paper',
+    title: 'Knowledge Access Beats Model Size: Memory Augmented Routing for Persistent AI Agents',
+    authors: 'Xunzhuo Liu, Bowei He, Xue Liu, Andy Luo, Haichen Zhang, Huamin Chen',
+    venue: 'arXiv Technical Report',
+    year: '2026',
+    abstract: 'We show that conversational memory and retrieval-grounded routing let a lightweight 8B model recover most of a 235B model’s performance on persistent user-specific queries while cutting effective inference cost by 96%.',
+    links: [
+      { type: 'paper', url: 'https://arxiv.org/abs/2603.23013', label: 'Paper' },
+    ],
+    featured: true,
+    sortOrder: 59,
+  },
+  {
     id: 'when-to-reason',
     type: 'paper',
     title: 'When to Reason: Semantic Router for vLLM',


### PR DESCRIPTION
## Summary

- Scope: add the newly released arXiv paper 2603.23013 to the website research publications data used by the publications page and research carousel.
- Primary skill: `cross-stack-bugfix` (selected by `make agent-report` for this changed-file set).
- Impacted surfaces: `docs_examples`
- Conditional surfaces intentionally skipped: `local_e2e`, `ci_e2e` because `make agent-report` classified this as `documentation-only` with no smoke, E2E, or feature-test requirements.
- Behavior-visible change: `yes`
- Debt entry: `none`

## Validation

- Environment: `cpu-local`
- Fast gate: `PATH="/Users/bitliu/vs/.venv-agent/bin:$PATH" make agent-report ENV=cpu CHANGED_FILES="website/src/data/researchContent.js"`
- Feature gate: not run (`agent-report` returned no validation commands for this documentation-only change)
- Local smoke / E2E: not run (`agent-report` classified this change as documentation-only)
- CI expectations / blockers: `npm run build` passed in `website/` for both `en` and `zh-Hans`; `PATH="/Users/bitliu/vs/.venv-agent/bin:$PATH" pre-commit run --files website/src/data/researchContent.js` passed. The local `.git/hooks/pre-commit` script is pinned to `/usr/bin/python3`, which lacks the repo's `tree_sitter` dependency, so I used `git commit -n -s` after running the equivalent checks in the repo venv.

## Checklist

- [x] PR title uses the repo prefix format: `[Doc]`
- [x] If the PR spans multiple categories, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Source-of-truth docs or indexed debt entries were updated when applicable
- [x] The validation results above reflect the actual commands or blockers for this change
