### PR TITLE
feat(responsestore): default Response API backend to Redis for restart-safe storage

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1108,10 +1108,6 @@ global:
       store_backend: redis
       ttl_seconds: 86400
       max_responses: 2000
-      milvus:
-        address: milvus:19530
-        database: responses
-        collection: response_records
       redis:
         address: redis:6379
         password: redis-secret

--- a/docs/agent/state-taxonomy-and-inventory.md
+++ b/docs/agent/state-taxonomy-and-inventory.md
@@ -51,7 +51,7 @@ Use it to answer three questions before adding or changing a stateful feature:
 
 | Surface | Primary owner | Current backend / default | Current durability class | Restart behavior today | Scale risk | Recommended direction |
 | --- | --- | --- | --- | --- | --- | --- |
-| Response API stored responses and conversations | router runtime, `src/semantic-router/pkg/responsestore/**` | Default `memory`; optional Redis or Milvus via config | `shared_durable_workflow_state` presented as `ephemeral_request_state` by default | Router restart drops retained response history unless operators override the backend | User-visible conversation continuity is implicit, non-HA, and replica-local by default | Keep metadata and conversation chain in a durable server-owned store by default for product use. Prefer relational storage for metadata and queryability; keep large payloads in blob/object storage only if needed later. |
+| Response API stored responses and conversations | router runtime, `src/semantic-router/pkg/responsestore/**` | Default `redis`; optional `memory` for local dev only | `shared_durable_workflow_state` | Response and conversation history survives restart when using the default Redis backend. The `memory` backend emits a startup warning and loses all data on restart. | Replica-local only when `memory` is explicitly selected; Redis backend is shared across replicas | Keep metadata and conversation chain in a durable server-owned store by default for product use. Prefer relational storage for metadata and queryability; keep large payloads in blob/object storage only if needed later. |
 | Router replay records | router runtime, `src/semantic-router/pkg/routerreplay/**`, `src/semantic-router/pkg/extproc/router_replay_setup.go` | Default `memory`; optional Redis, Postgres, Milvus | `audit_analytics_telemetry` presented as `ephemeral_request_state` by default | Restart drops replay history when default backend is used | Debuggability and audit posture degrade under restart and multi-replica routing | Prefer Postgres for durable operator-facing replay history. Keep Redis only for transient debug buffers and Milvus only when semantic replay search is explicitly needed. |
 | Semantic cache entries | router runtime, `src/semantic-router/pkg/cache/**` | Default `memory`; optional Redis, Milvus, hybrid | `ephemeral_request_state` in local dev; shared cache in scaled deploys | Restart flushes cache; replicas do not share hot entries by default | Cold-start latency, inconsistent cache hit rates, and uneven behavior across replicas | Keep this as cache, not a database table. Prefer Redis or hybrid shared backends for scaled deployments; document memory backend as local/dev or single-node only. |
 | RAG retrieval result cache | router runtime, `src/semantic-router/pkg/extproc/req_filter_rag_cache.go` | Process-wide singleton in-memory LRU with TTL | `ephemeral_request_state` | Restart flushes cache; cache is global per process, not per tenant or replica | Hidden shared mutable state, no observability, no durability, and no multi-replica coherence | Keep as optional cache only. Move to a pluggable shared cache backend if this becomes performance-critical, or document as local process optimization. |
@@ -78,7 +78,6 @@ Use it to answer three questions before adding or changing a stateful feature:
 
 ## Default Memory-Backed Surfaces To Treat As High Risk
 
-- `global.services.response_api.store_backend = memory`
 - `global.services.router_replay.store_backend = memory`
 - `global.stores.semantic_cache.backend_type = memory`
 - `global.stores.vector_store.backend_type = memory` in dashboard defaults when enabled
@@ -109,4 +108,4 @@ Use it to answer three questions before adding or changing a stateful feature:
 2. Make router metadata and replay or response history restart-safe where the product already exposes those surfaces.
 3. Move dashboard workflow state off in-memory maps and browser-only storage into server-owned durable records.
 4. Add a persisted deployed-config projection so dashboard and future APIs stop reparsing YAML and DSL for every query path.
-5. Add restart and recovery coverage in E2E for at least one router state surface and one dashboard workflow.
+5. Add restart and recovery coverage in E2E for at least one router state surface and one dashboard workflow. (Response API restart-recovery E2E test added in `e2e/testcases/response_api_restart_recovery.go`, registered in Redis profile.)

--- a/e2e/profiles/response-api-shared/redis_profile.go
+++ b/e2e/profiles/response-api-shared/redis_profile.go
@@ -66,6 +66,7 @@ func (p *RedisProfile) GetTestCases() []string {
 		"response-api-edge-special-characters",
 		"response-api-edge-concurrent-requests",
 		"response-api-ttl-expiry",
+		"response-api-restart-recovery",
 	}
 }
 

--- a/e2e/testcases/response_api_restart_recovery.go
+++ b/e2e/testcases/response_api_restart_recovery.go
@@ -1,0 +1,228 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	semanticRouterNamespace  = "vllm-semantic-router-system"
+	semanticRouterDeployment = "semantic-router"
+	semanticRouterPodLabel   = "app=semantic-router"
+
+	restartRecoveryTimeout  = 5 * time.Minute
+	restartRecoveryInterval = 5 * time.Second
+	restartKeyTTLSeconds    = 600
+)
+
+func init() {
+	pkgtestcases.Register("response-api-restart-recovery", pkgtestcases.TestCase{
+		Description: "Response API data stored in Redis survives a semantic-router pod restart",
+		Tags:        []string{"response-api", "functional", "redis", "restart"},
+		Fn:          testResponseAPIRestartRecovery,
+	})
+}
+
+func testResponseAPIRestartRecovery(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Response API: restart recovery (Redis persistence)")
+	}
+
+	responseID, model, err := createResponseBeforeRestart(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	if err := deleteSemanticRouterPod(ctx, client, opts); err != nil {
+		return err
+	}
+
+	if err := waitForSemanticRouterReady(ctx, client, opts); err != nil {
+		return err
+	}
+
+	return verifyResponseAfterRestart(ctx, client, opts, responseID, model)
+}
+
+func createResponseBeforeRestart(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) (string, string, error) {
+	session, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open session for pre-restart create: %w", err)
+	}
+	defer session.Close()
+
+	storeTrue := true
+	apiClient := fixtures.NewResponseAPIClient(session, 30*time.Second)
+	apiResp, _, err := apiClient.Create(ctx, fixtures.ResponseAPIRequest{
+		Model:        "openai/gpt-oss-20b",
+		Input:        "What is the speed of light?",
+		Instructions: "You are a physics assistant.",
+		Store:        &storeTrue,
+		Metadata:     map[string]string{"test": "restart-recovery"},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create response before restart: %w", err)
+	}
+
+	if apiResp.ID == "" || !strings.HasPrefix(apiResp.ID, "resp_") {
+		return "", "", fmt.Errorf("invalid response ID: %s", apiResp.ID)
+	}
+
+	if err := assertRedisResponseStored(ctx, client, apiResp.ID, opts); err != nil {
+		return "", "", fmt.Errorf("response not found in Redis before restart: %w", err)
+	}
+
+	// The profile may use a short TTL (e.g. 10s) for the TTL-expiry test.
+	// Extend this key so it survives the multi-minute restart cycle.
+	if err := extendRedisKeyTTL(ctx, client, apiResp.ID, restartKeyTTLSeconds, opts); err != nil {
+		return "", "", fmt.Errorf("failed to extend Redis TTL for restart test: %w", err)
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Created response %s (model=%s) — stored in Redis with extended TTL\n", apiResp.ID, apiResp.Model)
+	}
+
+	return apiResp.ID, apiResp.Model, nil
+}
+
+func deleteSemanticRouterPod(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	pods, err := client.CoreV1().Pods(semanticRouterNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: semanticRouterPodLabel,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list semantic-router pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no semantic-router pods found in %s", semanticRouterNamespace)
+	}
+
+	podName := pods.Items[0].Name
+	if opts.Verbose {
+		fmt.Printf("[Test] Deleting semantic-router pod %s to simulate restart\n", podName)
+	}
+
+	if err := client.CoreV1().Pods(semanticRouterNamespace).Delete(ctx, podName, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete semantic-router pod %s: %w", podName, err)
+	}
+
+	return waitForOldPodTerminated(ctx, client, podName, opts)
+}
+
+// waitForOldPodTerminated blocks until the deleted pod is gone, so
+// WaitForDeploymentReady won't return prematurely from stale status.
+func waitForOldPodTerminated(ctx context.Context, client *kubernetes.Clientset, podName string, opts pkgtestcases.TestCaseOptions) error {
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		_, err := client.CoreV1().Pods(semanticRouterNamespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Old pod %s terminated\n", podName)
+			}
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("old pod %s still exists after 2m", podName)
+}
+
+func waitForSemanticRouterReady(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Printf("[Test] Waiting for semantic-router deployment to recover (timeout=%s)\n", restartRecoveryTimeout)
+	}
+
+	return helpers.WaitForDeploymentReady(
+		ctx, client,
+		semanticRouterNamespace, semanticRouterDeployment,
+		restartRecoveryTimeout, restartRecoveryInterval,
+		opts.Verbose,
+	)
+}
+
+func verifyResponseAfterRestart(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions, responseID, expectedModel string) error {
+	// The pod may pass readiness checks before the Response API / Redis
+	// connection is fully initialized. Poll until the GET succeeds.
+	const verifyTimeout = 90 * time.Second
+	deadline := time.Now().Add(verifyTimeout)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		session, err := fixtures.OpenServiceSession(ctx, client, opts)
+		if err != nil {
+			lastErr = err
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		apiClient := fixtures.NewResponseAPIClient(session, 30*time.Second)
+		apiResp, _, err := apiClient.Get(ctx, responseID)
+		session.Close()
+
+		if err != nil {
+			lastErr = err
+			if opts.Verbose {
+				fmt.Printf("[Test] GET %s not ready yet: %v — retrying\n", responseID, err)
+			}
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		if apiResp.ID != responseID {
+			return fmt.Errorf("response ID mismatch after restart: got %s, expected %s", apiResp.ID, responseID)
+		}
+		if apiResp.Object != "response" {
+			return fmt.Errorf("invalid object type after restart: %s", apiResp.Object)
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] Response %s survived restart (model=%s, status=%s)\n", apiResp.ID, apiResp.Model, apiResp.Status)
+		}
+		if opts.SetDetails != nil {
+			opts.SetDetails(map[string]interface{}{
+				"response_id":    responseID,
+				"survived":       true,
+				"model":          apiResp.Model,
+				"status":         apiResp.Status,
+				"expected_model": expectedModel,
+			})
+		}
+		return nil
+	}
+
+	return fmt.Errorf("response %s not retrievable after %s: %w", responseID, verifyTimeout, lastErr)
+}
+
+func extendRedisKeyTTL(ctx context.Context, client *kubernetes.Clientset, responseID string, ttlSeconds int, opts pkgtestcases.TestCaseOptions) error {
+	podName, useCluster, found, err := getRedisPod(ctx, client)
+	if err != nil {
+		return err
+	}
+	if !found {
+		if opts.Verbose {
+			fmt.Println("[Test] Redis pod not found; skipping TTL extension")
+		}
+		return nil
+	}
+
+	key := redisResponseKeyPrefix + responseID
+	output, err := execRedisCli(ctx, podName, useCluster, opts.Verbose,
+		"EXPIRE", key, fmt.Sprintf("%d", ttlSeconds))
+	if err != nil {
+		return fmt.Errorf("EXPIRE failed for key %s: %w", key, err)
+	}
+	if strings.TrimSpace(output) != "1" {
+		return fmt.Errorf("EXPIRE returned %q for key %s (expected 1)", output, key)
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Extended TTL on %s to %ds\n", key, ttlSeconds)
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/config/canonical_defaults.go
+++ b/src/semantic-router/pkg/config/canonical_defaults.go
@@ -30,7 +30,7 @@ func defaultCanonicalServiceGlobal() CanonicalServiceGlobal {
 	return CanonicalServiceGlobal{
 		ResponseAPI: ResponseAPIConfig{
 			Enabled:      true,
-			StoreBackend: "memory",
+			StoreBackend: "redis",
 			TTLSeconds:   86400,
 			MaxResponses: 1000,
 		},

--- a/src/semantic-router/pkg/config/canonical_loader_test.go
+++ b/src/semantic-router/pkg/config/canonical_loader_test.go
@@ -303,7 +303,7 @@ global:
 	if !cfg.ResponseAPI.Enabled {
 		t.Fatal("expected sparse global override to preserve default response_api.enabled=true")
 	}
-	if cfg.ResponseAPI.StoreBackend != "memory" {
+	if cfg.ResponseAPI.StoreBackend != "redis" {
 		t.Fatalf("expected response api backend to keep default, got %q", cfg.ResponseAPI.StoreBackend)
 	}
 	if cfg.ResponseAPI.TTLSeconds != 86400 {

--- a/src/semantic-router/pkg/config/reference_config_global_test.go
+++ b/src/semantic-router/pkg/config/reference_config_global_test.go
@@ -49,7 +49,6 @@ func assertReferenceConfigAPIServiceCoverage(t testingT, api map[string]interfac
 
 func assertReferenceConfigResponseAPIServiceCoverage(t testingT, responseAPI map[string]interface{}) {
 	assertMapCoversStructFields(t, responseAPI, reflect.TypeOf(ResponseAPIConfig{}), "global.services.response_api")
-	assertMapCoversStructFields(t, mustMapAt(t, responseAPI, "milvus"), reflect.TypeOf(ResponseAPIMilvusConfig{}), "global.services.response_api.milvus")
 	assertMapCoversStructFields(t, mustMapAt(t, responseAPI, "redis"), reflect.TypeOf(ResponseAPIRedisConfig{}), "global.services.response_api.redis")
 }
 

--- a/src/semantic-router/pkg/config/runtime_config.go
+++ b/src/semantic-router/pkg/config/runtime_config.go
@@ -262,19 +262,16 @@ type MemoryMilvusConfig struct {
 	NumPartitions int    `yaml:"num_partitions,omitempty"`
 }
 
+// ResponseAPIConfig controls response and conversation history storage.
+// StoreBackend defaults to "redis" for durable storage that survives router
+// restarts. Set to "memory" only for local development — all history is lost
+// when the router process exits.
 type ResponseAPIConfig struct {
-	Enabled      bool                    `yaml:"enabled"`
-	StoreBackend string                  `yaml:"store_backend,omitempty"`
-	TTLSeconds   int                     `yaml:"ttl_seconds,omitempty"`
-	MaxResponses int                     `yaml:"max_responses,omitempty"`
-	Milvus       ResponseAPIMilvusConfig `yaml:"milvus,omitempty"`
-	Redis        ResponseAPIRedisConfig  `yaml:"redis,omitempty"`
-}
-
-type ResponseAPIMilvusConfig struct {
-	Address    string `yaml:"address"`
-	Database   string `yaml:"database,omitempty"`
-	Collection string `yaml:"collection,omitempty"`
+	Enabled      bool                   `yaml:"enabled"`
+	StoreBackend string                 `yaml:"store_backend,omitempty"`
+	TTLSeconds   int                    `yaml:"ttl_seconds,omitempty"`
+	MaxResponses int                    `yaml:"max_responses,omitempty"`
+	Redis        ResponseAPIRedisConfig `yaml:"redis,omitempty"`
 }
 
 type ResponseAPIRedisConfig struct {

--- a/src/semantic-router/pkg/extproc/router_storage.go
+++ b/src/semantic-router/pkg/extproc/router_storage.go
@@ -14,11 +14,6 @@ func createResponseStore(cfg *config.RouterConfig) (responsestore.ResponseStore,
 		Memory: responsestore.MemoryStoreConfig{
 			MaxResponses: cfg.ResponseAPI.MaxResponses,
 		},
-		Milvus: responsestore.MilvusStoreConfig{
-			Address:            cfg.ResponseAPI.Milvus.Address,
-			Database:           cfg.ResponseAPI.Milvus.Database,
-			ResponseCollection: cfg.ResponseAPI.Milvus.Collection,
-		},
 		Redis: responsestore.RedisStoreConfig{
 			Address:          cfg.ResponseAPI.Redis.Address,
 			Password:         cfg.ResponseAPI.Redis.Password,

--- a/src/semantic-router/pkg/responsestore/factory.go
+++ b/src/semantic-router/pkg/responsestore/factory.go
@@ -2,29 +2,25 @@ package responsestore
 
 import (
 	"fmt"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
 // NewStore creates a new store based on the configuration.
 func NewStore(config StoreConfig) (CombinedStore, error) {
 	if !config.Enabled {
-		// Return a disabled memory store
 		return NewMemoryStore(StoreConfig{Enabled: false})
 	}
 
 	switch config.BackendType {
 	case MemoryStoreType, "":
+		logging.Warnf("Response API store_backend is set to %q — all response and conversation "+
+			"history will be lost on router restart. Use \"redis\" for durable storage in production.",
+			"memory")
 		return NewMemoryStore(config)
-	case MilvusStoreType:
-		return NewMilvusStore(config)
 	case RedisStoreType:
 		return NewRedisStore(config)
 	default:
 		return nil, fmt.Errorf("unknown store backend type: %s", config.BackendType)
 	}
-}
-
-// NewMilvusStore creates a new Milvus-based store.
-// This is a placeholder that will be implemented in a separate file.
-func NewMilvusStore(config StoreConfig) (CombinedStore, error) {
-	return nil, fmt.Errorf("milvus store not yet implemented")
 }

--- a/src/semantic-router/pkg/responsestore/interface.go
+++ b/src/semantic-router/pkg/responsestore/interface.go
@@ -107,9 +107,6 @@ type StoreConfig struct {
 	// Memory backend configuration
 	Memory MemoryStoreConfig `yaml:"memory,omitempty"`
 
-	// Milvus backend configuration
-	Milvus MilvusStoreConfig `yaml:"milvus,omitempty"`
-
 	// Redis backend configuration
 	Redis RedisStoreConfig `yaml:"redis,omitempty"`
 }
@@ -120,9 +117,6 @@ type StoreBackendType string
 const (
 	// MemoryStoreType is the in-memory store backend.
 	MemoryStoreType StoreBackendType = "memory"
-
-	// MilvusStoreType is the Milvus store backend.
-	MilvusStoreType StoreBackendType = "milvus"
 
 	// RedisStoreType is the Redis store backend.
 	RedisStoreType StoreBackendType = "redis"
@@ -135,24 +129,6 @@ type MemoryStoreConfig struct {
 
 	// MaxConversations is the maximum number of conversations to store.
 	MaxConversations int `yaml:"max_conversations"`
-}
-
-// MilvusStoreConfig contains configuration for the Milvus store.
-type MilvusStoreConfig struct {
-	// Address is the Milvus server address (e.g., "localhost:19530").
-	Address string `yaml:"address"`
-
-	// Database is the Milvus database name.
-	Database string `yaml:"database,omitempty"`
-
-	// ResponseCollection is the collection name for responses.
-	ResponseCollection string `yaml:"response_collection"`
-
-	// ConversationCollection is the collection name for conversations.
-	ConversationCollection string `yaml:"conversation_collection"`
-
-	// ConfigPath is the path to additional Milvus configuration.
-	ConfigPath string `yaml:"config_path,omitempty"`
 }
 
 // RedisStoreConfig contains configuration for the Redis store.

--- a/website/docs/tutorials/global/api-and-observability.md
+++ b/website/docs/tutorials/global/api-and-observability.md
@@ -46,8 +46,17 @@ global:
   services:
     response_api:
       enabled: true
-      store_backend: memory
+      store_backend: redis        # default; use "memory" only for local development
+      redis:
+        address: "redis:6379"
 ```
+
+The `store_backend` field controls where response and conversation history is persisted. Available backends:
+
+| Backend | Durability | Use case |
+|---------|-----------|----------|
+| `redis` | Survives router restart, shared across replicas | Production (default) |
+| `memory` | Lost on router restart | Local development only |
 
 ### Observability
 


### PR DESCRIPTION

## Summary

Change the Response API `store_backend` default from `memory` to `redis` so that response and conversation history survives router restarts without any user configuration. Remove the Milvus backend stub that was never implemented (always returned an error), and add an E2E restart-recovery test that proves data persists across a pod restart.

This is a **partial implementation** of #1608 — handling only the Response API state component. The remaining components (Router Replay, Vector Store metadata, File metadata, Startup Status) will be addressed in follow-up PRs.

## Changes

**Default and runtime behavior:**
- Change `StoreBackend` default from `"memory"` to `"redis"` in `canonical_defaults.go`
- Add `logging.Warnf` in `factory.go` when `memory` backend is selected, warning that all history will be lost on restart
- Add Go doc comment on `ResponseAPIConfig` documenting the durability contract

**Milvus stub removal:**
- Remove `MilvusStoreType` constant, `MilvusStoreConfig` struct, and `Milvus` field from `responsestore/interface.go`
- Remove `NewMilvusStore` stub function and `case MilvusStoreType` from `responsestore/factory.go`
- Remove `ResponseAPIMilvusConfig` struct and `Milvus` field from `config/runtime_config.go`
- Remove Milvus wiring from `extproc/router_storage.go`
- Remove `milvus:` block from `config/config.yaml`
- Remove Milvus struct coverage assertion from `reference_config_global_test.go`

**Testing:**
- Add `e2e/testcases/response_api_restart_recovery.go` — creates a response, verifies it in Redis, deletes the semantic-router pod, waits for recovery, and asserts the response survives
- Register `response-api-restart-recovery` in the Redis profile's `GetTestCases()`

**Documentation:**
- Update `website/docs/tutorials/global/api-and-observability.md` with backend durability table and updated example
- Update `canonical_loader_test.go` assertion to expect `"redis"` default

## Testing

- Unit tests updated and passing (`canonical_loader_test.go`, `reference_config_global_test.go`)
- Static analysis: `go vet` passes on all modified packages
- New E2E test `response-api-restart-recovery` registered in Redis profile (tags: `response-api`, `functional`, `redis`, `restart`)

> **Note:** The `response-api-restart-recovery` test is registered in the `response-api-redis` E2E profile. CI currently runs only the memory-backed `response-api` profile (`RESPONSE_API_SUITE_PROFILES=response-api`). The test will execute automatically once the Redis profile is enabled in CI.

```bash
# Run locally (requires Kind cluster + HF_TOKEN)
make e2e-test E2E_PROFILE=response-api-redis E2E_TESTS=response-api-restart-recovery
```

## Related Issues

Relates to #1608