### PR TITLE
Fix KB lint regressions and sparse config fixture

### DIFF
--- a/src/semantic-router/pkg/apiserver/route_kb_map_test.go
+++ b/src/semantic-router/pkg/apiserver/route_kb_map_test.go
@@ -34,7 +34,7 @@ func stubKnowledgeBaseMapEmbeddings(t *testing.T) {
 	})
 }
 
-func TestHandleKnowledgeBaseMapEndpoints(t *testing.T) {
+func TestHandleKnowledgeBaseMapMetadataEndpoint(t *testing.T) {
 	apiServer, _, _ := newTestKnowledgeBaseAPIServer(t)
 	stubKnowledgeBaseMapEmbeddings(t)
 
@@ -63,6 +63,11 @@ func TestHandleKnowledgeBaseMapEndpoints(t *testing.T) {
 	if len(metadata.Groups) == 0 {
 		t.Fatalf("expected kb groups in metadata, got %+v", metadata)
 	}
+}
+
+func TestHandleKnowledgeBaseMapDataEndpoint(t *testing.T) {
+	apiServer, _, _ := newTestKnowledgeBaseAPIServer(t)
+	stubKnowledgeBaseMapEmbeddings(t)
 
 	dataReq := httptest.NewRequest(http.MethodGet, "/config/kbs/privacy_kb/map/data.ndjson", nil)
 	dataReq.SetPathValue("name", "privacy_kb")

--- a/src/semantic-router/pkg/apiserver/route_kbs.go
+++ b/src/semantic-router/pkg/apiserver/route_kbs.go
@@ -49,13 +49,8 @@ func (s *ClassificationAPIServer) handleGetKnowledgeBase(w http.ResponseWriter, 
 }
 
 func (s *ClassificationAPIServer) handleCreateKnowledgeBase(w http.ResponseWriter, r *http.Request) {
-	cfg := s.currentConfig()
-	if cfg == nil {
-		s.writeErrorResponse(w, http.StatusInternalServerError, "CONFIG_UNAVAILABLE", "Classification config not available")
-		return
-	}
-	if s.configPath == "" {
-		s.writeErrorResponse(w, http.StatusInternalServerError, "NO_CONFIG_PATH", "Router configPath not set")
+	cfg, ok := s.writableKnowledgeBaseConfig(w)
+	if !ok {
 		return
 	}
 
@@ -92,13 +87,8 @@ func (s *ClassificationAPIServer) handleCreateKnowledgeBase(w http.ResponseWrite
 }
 
 func (s *ClassificationAPIServer) handleUpdateKnowledgeBase(w http.ResponseWriter, r *http.Request) {
-	cfg := s.currentConfig()
-	if cfg == nil {
-		s.writeErrorResponse(w, http.StatusInternalServerError, "CONFIG_UNAVAILABLE", "Classification config not available")
-		return
-	}
-	if s.configPath == "" {
-		s.writeErrorResponse(w, http.StatusInternalServerError, "NO_CONFIG_PATH", "Router configPath not set")
+	cfg, ok := s.writableKnowledgeBaseConfig(w)
+	if !ok {
 		return
 	}
 
@@ -141,13 +131,8 @@ func (s *ClassificationAPIServer) handleUpdateKnowledgeBase(w http.ResponseWrite
 }
 
 func (s *ClassificationAPIServer) handleDeleteKnowledgeBase(w http.ResponseWriter, r *http.Request) {
-	cfg := s.currentConfig()
-	if cfg == nil {
-		s.writeErrorResponse(w, http.StatusInternalServerError, "CONFIG_UNAVAILABLE", "Classification config not available")
-		return
-	}
-	if s.configPath == "" {
-		s.writeErrorResponse(w, http.StatusInternalServerError, "NO_CONFIG_PATH", "Router configPath not set")
+	cfg, ok := s.writableKnowledgeBaseConfig(w)
+	if !ok {
 		return
 	}
 
@@ -209,6 +194,19 @@ func rollbackManagedKnowledgeBaseRemoval(txn *managedKnowledgeBaseAssetsTxn, com
 		return
 	}
 	txn.Rollback()
+}
+
+func (s *ClassificationAPIServer) writableKnowledgeBaseConfig(w http.ResponseWriter) (*config.RouterConfig, bool) {
+	cfg := s.currentConfig()
+	if cfg == nil {
+		s.writeErrorResponse(w, http.StatusInternalServerError, "CONFIG_UNAVAILABLE", "Classification config not available")
+		return nil, false
+	}
+	if s.configPath == "" {
+		s.writeErrorResponse(w, http.StatusInternalServerError, "NO_CONFIG_PATH", "Router configPath not set")
+		return nil, false
+	}
+	return cfg, true
 }
 
 func (s *ClassificationAPIServer) persistManagedKnowledgeBase(

--- a/src/semantic-router/pkg/modeldownload/config_parser_test.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser_test.go
@@ -394,8 +394,6 @@ global:
     embeddings:
       semantic:
         use_cpu: false
-      bert:
-        use_cpu: false
     modules:
       prompt_guard:
         use_cpu: false


### PR DESCRIPTION
## Summary
- split the knowledge-base map endpoint test so the metadata and NDJSON assertions stay under the cyclomatic complexity limit
- extract a shared writable knowledge-base config precondition helper so the delete handler stays under the statement-count limit without changing behavior
- remove the deprecated `global.model_catalog.embeddings.bert` fixture entry from the sparse AMD modeldownload test so it matches the canonical v0.3 config contract

## Validation
- `make agent-lint CHANGED_FILES="src/semantic-router/pkg/apiserver/route_kb_map_test.go,src/semantic-router/pkg/apiserver/route_kbs.go,src/semantic-router/pkg/modeldownload/config_parser_test.go"`
- `make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/apiserver/route_kb_map_test.go,src/semantic-router/pkg/apiserver/route_kbs.go,src/semantic-router/pkg/modeldownload/config_parser_test.go"`
- `cd src/semantic-router && go test ./pkg/apiserver -run 'TestHandleKnowledgeBaseMapMetadataEndpoint|TestHandleKnowledgeBaseMapDataEndpoint|TestHandleKnowledgeBaseMapMissingKnowledgeBase'`
- `cd src/semantic-router && go test ./pkg/modeldownload -run 'TestBuildModelSpecsIncludesRouterOwnedDefaultsForSparseAMDGlobalOverride|TestBuildModelSpecsIncludesRouterOwnedDefaultsForScratchCanonicalConfig'`
