### PR TITLE
[Bugfix](make): bootstrap agent tooling via .venv-agent to avoid PEP 668 on Homebrew Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 *.pyz
 __pycache__/
 .venv/
+.venv-agent/
 pii_env/
 
 # Python build artifacts

--- a/tools/make/agent.mk
+++ b/tools/make/agent.mk
@@ -17,6 +17,11 @@ AGENT_REPORT_WRITE ?=
 AGENT_REPORT_WRITE_PATH ?=
 AGENT_REPORT_CONTEXT_DETAIL ?= compact
 
+# Repo-local venv for harness deps (avoids PEP 668 / externally-managed-environment on Homebrew Python).
+AGENT_VENV ?= $(CURDIR)/.venv-agent
+AGENT_PYTHON ?= $(AGENT_VENV)/bin/python
+AGENT_PRE_COMMIT ?= $(AGENT_VENV)/bin/pre-commit
+
 agent-help: ## Show help for agent-specific targets
 	@echo "Agent commands:"
 	@echo "  make agent-bootstrap"
@@ -36,10 +41,16 @@ agent-help: ## Show help for agent-specific targets
 	@echo "  make agent-e2e-affected CHANGED_FILES=\"...\""
 	@echo "  make agent-feature-gate ENV=cpu|amd CHANGED_FILES=\"...\""
 
-agent-bootstrap: ## Install agent validation tooling
+agent-venv-install: ## Create $(AGENT_VENV) and install harness Python requirements
+	@if [ ! -x "$(AGENT_PYTHON)" ]; then \
+		echo "Creating $(AGENT_VENV)..."; \
+		python3 -m venv "$(AGENT_VENV)"; \
+	fi
+	@"$(AGENT_PYTHON)" -m pip install -r tools/agent/requirements.txt
+
+agent-bootstrap: agent-venv-install ## Install agent validation tooling
 	@$(LOG_TARGET)
 	@echo "Installing agent Python tooling..."
-	@python3 -m pip install -r tools/agent/requirements.txt
 	@if command -v npm >/dev/null 2>&1; then \
 		npm install -g markdownlint-cli@0.43.0 >/dev/null 2>&1 || true; \
 	fi
@@ -57,11 +68,11 @@ agent-bootstrap: ## Install agent validation tooling
 
 agent-validate: agent-bootstrap ## Validate the shared agent harness manifests and docs
 	@$(LOG_TARGET)
-	@python3 tools/agent/scripts/agent_gate.py validate
+	@"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py validate
 
 agent-scorecard: agent-bootstrap ## Show the current harness governance scorecard
 	@$(LOG_TARGET)
-	@python3 tools/agent/scripts/agent_gate.py scorecard --format summary
+	@"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py scorecard --format summary
 
 agent-dev: ## Build the canonical local development image for the selected environment
 	@$(LOG_TARGET)
@@ -71,9 +82,9 @@ agent-dev: ## Build the canonical local development image for the selected envir
 		$(MAKE) vllm-sr-dev VLLM_SR_TOPOLOGY=$(VLLM_SR_TOPOLOGY); \
 	fi
 
-agent-serve-local: ## Start vllm-sr with the canonical local image flow
+agent-serve-local: agent-venv-install ## Start vllm-sr with the canonical local image flow
 	@$(LOG_TARGET)
-	@DEFAULT_CONFIG="$$(python3 tools/agent/scripts/agent_gate.py resolve-env --env "$(ENV)" --field smoke_config)"; \
+	@DEFAULT_CONFIG="$$( "$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py resolve-env --env "$(ENV)" --field smoke_config)"; \
 	CONFIG_PATH="$(AGENT_SERVE_CONFIG)"; \
 	if [ -z "$$CONFIG_PATH" ]; then \
 		CONFIG_PATH="$$DEFAULT_CONFIG"; \
@@ -98,7 +109,7 @@ agent-stop-local: ## Stop local vllm-sr services
 
 agent-lint: agent-bootstrap ## Run lint and structure gates for changed files
 	@$(LOG_TARGET)
-	@RAW_FILES="$$(python3 tools/agent/scripts/agent_gate.py changed-files --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)")"; \
+	@RAW_FILES="$$( "$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py changed-files --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)")"; \
 	if [ -z "$$RAW_FILES" ]; then \
 		echo "No changed files detected."; \
 		exit 0; \
@@ -106,23 +117,23 @@ agent-lint: agent-bootstrap ## Run lint and structure gates for changed files
 	FILE_ARGS="$$(printf '%s\n' "$$RAW_FILES" | paste -sd' ' -)"; \
 	CSV_FILES="$$(printf '%s\n' "$$RAW_FILES" | paste -sd',' -)"; \
 	echo "Running baseline pre-commit checks..."; \
-	pre-commit run --files $$FILE_ARGS && \
+	"$(AGENT_PRE_COMMIT)" run --files $$FILE_ARGS && \
 	echo "Running Python lint..." && \
-	python3 tools/agent/scripts/agent_gate.py run-python-lint --changed-files "$$CSV_FILES" && \
+	"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py run-python-lint --changed-files "$$CSV_FILES" && \
 	echo "Running Go structural lint..." && \
-	python3 tools/agent/scripts/agent_gate.py run-go-lint --base-ref "$(AGENT_BASE_REF)" --changed-files "$$CSV_FILES" && \
+	"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py run-go-lint --base-ref "$(AGENT_BASE_REF)" --changed-files "$$CSV_FILES" && \
 	echo "Running reference config contract lint..." && \
-	python3 tools/agent/scripts/agent_gate.py run-config-contract-lint --changed-files "$$CSV_FILES" && \
+	"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py run-config-contract-lint --changed-files "$$CSV_FILES" && \
 	echo "Running Rust lint..." && \
-	python3 tools/agent/scripts/agent_gate.py run-rust-lint --changed-files "$$CSV_FILES" && \
+	"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py run-rust-lint --changed-files "$$CSV_FILES" && \
 	echo "Running structure checks..." && \
-	python3 tools/agent/scripts/structure_check.py --base-ref "$(AGENT_BASE_REF)" $$FILE_ARGS
+	"$(AGENT_PYTHON)" tools/agent/scripts/structure_check.py --base-ref "$(AGENT_BASE_REF)" $$FILE_ARGS
 
 agent-fast-gate: ## Run the fast gate: manifest validation, lint, and lightweight tests
 	@$(LOG_TARGET)
 	@$(MAKE) agent-validate
 	@$(MAKE) agent-lint CHANGED_FILES="$(CHANGED_FILES)" AGENT_BASE_REF="$(AGENT_BASE_REF)"
-	@python3 tools/agent/scripts/agent_gate.py run-tests --mode fast --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"
+	@"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py run-tests --mode fast --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"
 
 agent-ci-lint: agent-bootstrap ## Reproduce the CI changed-file lint gate locally
 	@$(LOG_TARGET)
@@ -141,20 +152,20 @@ agent-ci-lint: agent-bootstrap ## Reproduce the CI changed-file lint gate locall
 	$(MAKE) codespell-tracked && \
 	$(MAKE) agent-fast-gate CHANGED_FILES="$(CHANGED_FILES)" AGENT_BASE_REF="$$BASE_REF"
 
-agent-report: ## Show primary skill, impacted surfaces, and validation commands
+agent-report: agent-venv-install ## Show primary skill, impacted surfaces, and validation commands
 	@$(LOG_TARGET)
 	@if [ -n "$(AGENT_REPORT_WRITE_PATH)" ]; then \
-		python3 tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --context-detail "$(AGENT_REPORT_CONTEXT_DETAIL)" --write "$(AGENT_REPORT_WRITE_PATH)"; \
+		"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --context-detail "$(AGENT_REPORT_CONTEXT_DETAIL)" --write "$(AGENT_REPORT_WRITE_PATH)"; \
 	elif [ -n "$(AGENT_REPORT_WRITE)" ]; then \
-		python3 tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --context-detail "$(AGENT_REPORT_CONTEXT_DETAIL)" --write-default; \
+		"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --context-detail "$(AGENT_REPORT_CONTEXT_DETAIL)" --write-default; \
 	else \
-		python3 tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --context-detail "$(AGENT_REPORT_CONTEXT_DETAIL)"; \
+		"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --context-detail "$(AGENT_REPORT_CONTEXT_DETAIL)"; \
 	fi
 
 agent-ci-gate: ## Run the repo-standard fast CI gate
 	@$(LOG_TARGET)
 	@$(MAKE) agent-report ENV="$(ENV)" CHANGED_FILES="$(CHANGED_FILES)" AGENT_BASE_REF="$(AGENT_BASE_REF)"
-	@python3 tools/agent/scripts/agent_gate.py resolve --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --format summary
+	@"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py resolve --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --format summary
 	@$(MAKE) agent-fast-gate CHANGED_FILES="$(CHANGED_FILES)" AGENT_BASE_REF="$(AGENT_BASE_REF)"
 
 agent-smoke-local: ## Validate local container, router, envoy, and dashboard health
@@ -215,9 +226,9 @@ agent-smoke-local: ## Validate local container, router, envoy, and dashboard hea
 	done; \
 	echo "Local smoke checks passed"
 
-agent-e2e-affected: ## Run local E2E profiles affected by the changed files
+agent-e2e-affected: agent-venv-install ## Run local E2E profiles affected by the changed files
 	@$(LOG_TARGET)
-	@python3 tools/agent/scripts/agent_gate.py run-e2e --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"
+	@"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py run-e2e --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"
 
 test-and-build-local: ## Reproduce the CI Test And Build job locally
 	@$(LOG_TARGET)
@@ -241,15 +252,15 @@ agent-feature-gate: ## Run lint, targeted tests, local smoke, and a final report
 	@$(LOG_TARGET)
 	@set -e; \
 	$(MAKE) agent-ci-gate CHANGED_FILES="$(CHANGED_FILES)" AGENT_BASE_REF="$(AGENT_BASE_REF)"; \
-	python3 tools/agent/scripts/agent_gate.py run-tests --mode feature-only --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"; \
-	if [ "$$(python3 tools/agent/scripts/agent_gate.py needs-smoke --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)")" = "true" ]; then \
+	"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py run-tests --mode feature-only --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"; \
+	if [ "$$( "$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py needs-smoke --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)")" = "true" ]; then \
 		trap '$(MAKE) agent-stop-local ENV=$(ENV) AGENT_STACK_NAME="$(AGENT_STACK_NAME)" AGENT_PORT_OFFSET="$(AGENT_PORT_OFFSET)" >/dev/null 2>&1 || true' EXIT; \
 		$(MAKE) agent-dev ENV=$(ENV); \
 		$(MAKE) agent-serve-local ENV=$(ENV) AGENT_STACK_NAME="$(AGENT_STACK_NAME)" AGENT_PORT_OFFSET="$(AGENT_PORT_OFFSET)"; \
 		$(MAKE) agent-smoke-local AGENT_STACK_NAME="$(AGENT_STACK_NAME)" AGENT_PORT_OFFSET="$(AGENT_PORT_OFFSET)"; \
 	fi; \
-	python3 tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"
+	"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)"
 
-.PHONY: agent-help agent-bootstrap agent-ci-lint agent-dev agent-serve-local agent-stop-local \
+.PHONY: agent-help agent-venv-install agent-bootstrap agent-ci-lint agent-dev agent-serve-local agent-stop-local \
 	agent-validate agent-lint agent-fast-gate agent-report agent-ci-gate agent-smoke-local agent-e2e-affected \
 	test-and-build-local agent-pr-gate agent-feature-gate

--- a/tools/make/linter.mk
+++ b/tools/make/linter.mk
@@ -4,6 +4,10 @@
 
 ##@ Linter
 
+# codespell is installed into .venv-agent by tools/make/agent.mk (agent-venv-install).
+AGENT_VENV ?= $(CURDIR)/.venv-agent
+AGENT_CODESPELL ?= $(AGENT_VENV)/bin/codespell
+
 markdown-lint: ## Lint all markdown files in the project
 	@$(LOG_TARGET)
 	markdownlint -c tools/linter/markdown/markdownlint.yaml "**/*.md" \
@@ -37,12 +41,12 @@ yaml-lint: ## Lint all YAML files in the project
 codespell: CODESPELL_SKIP := $(shell cat tools/linter/codespell/.codespell.skip | tr \\n ',')
 codespell: ## Check for common misspellings in code and docs
 	@$(LOG_TARGET)
-	codespell --skip $(CODESPELL_SKIP) --ignore-words tools/linter/codespell/.codespell.ignorewords --check-filenames
+	"$(AGENT_CODESPELL)" --skip $(CODESPELL_SKIP) --ignore-words tools/linter/codespell/.codespell.ignorewords --check-filenames
 
 codespell-tracked: CODESPELL_SKIP := $(shell cat tools/linter/codespell/.codespell.skip | tr \\n ',')
 codespell-tracked: ## Check for common misspellings in tracked code and docs
 	@$(LOG_TARGET)
-	git ls-files -z | xargs -0 codespell --skip $(CODESPELL_SKIP) --ignore-words tools/linter/codespell/.codespell.ignorewords --check-filenames
+	git ls-files -z | xargs -0 "$(AGENT_CODESPELL)" --skip $(CODESPELL_SKIP) --ignore-words tools/linter/codespell/.codespell.ignorewords --check-filenames
 
 shellcheck: ## Lint all shell scripts in the project
 	@$(LOG_TARGET)

--- a/tools/make/pre-commit.mk
+++ b/tools/make/pre-commit.mk
@@ -2,14 +2,15 @@
 
 PRECOMMIT_CONTAINER := ghcr.io/vllm-project/semantic-router/precommit:latest
 
-precommit-install: ## Install pre-commit Python package
-precommit-install:
-	pip install pre-commit
+AGENT_PRE_COMMIT ?= $(CURDIR)/.venv-agent/bin/pre-commit
 
-precommit-check: ## Run pre-commit checks on all relevant files
-precommit-check:
+precommit-install: ## Install pre-commit into the agent harness venv
+precommit-install:
+	@$(MAKE) agent-venv-install
+
+precommit-check: agent-venv-install ## Run pre-commit checks on all relevant files
 	@echo "Running pre-commit on all tracked files..."
-	@pre-commit run --all-files
+	@"$(AGENT_PRE_COMMIT)" run --all-files
 
 # Run the full CI pre-commit pipeline in a Docker container.
 # This mirrors .github/workflows/pre-commit.yml by running both


### PR DESCRIPTION

Closes https://github.com/vllm-project/semantic-router/issues/1598


## Checklist

- [ ] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
- [ ] If the PR spans multiple categories, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] Source-of-truth docs or indexed debt entries were updated when applicable
- [ ] The validation results above reflect the actual commands or blockers for this change

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
