### PR TITLE
[Fix][CLI] preserve timeout output in vllm-sr tests

### DIFF
--- a/e2e/testing/vllm-sr-cli/cli_test_base.py
+++ b/e2e/testing/vllm-sr-cli/cli_test_base.py
@@ -25,6 +25,15 @@ import yaml
 HTTP_STATUS_OK = 200
 
 
+def _coerce_timeout_stream(value: str | bytes | None) -> str:
+    """Normalize TimeoutExpired output/stderr values into text."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
+
+
 class CLITestBase(unittest.TestCase):
     """Base class for vLLM-SR CLI tests."""
 
@@ -245,9 +254,18 @@ class CLITestBase(unittest.TestCase):
 
             return result.returncode, stdout, stderr
 
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
             print(f"Command timed out after {timeout}s")
-            return -1, "", f"Command timed out after {timeout} seconds"
+            stdout = _coerce_timeout_stream(
+                getattr(exc, "stdout", None) or getattr(exc, "output", None)
+            )
+            stderr = _coerce_timeout_stream(getattr(exc, "stderr", None))
+            timeout_message = f"Command timed out after {timeout} seconds"
+            if stderr:
+                stderr = f"{stderr.rstrip()}\n{timeout_message}"
+            else:
+                stderr = timeout_message
+            return -1, stdout, stderr
         except Exception as e:
             print(f"Command failed with exception: {e}")
             return -1, "", str(e)

--- a/e2e/testing/vllm-sr-cli/test_unit_runtime_topology.py
+++ b/e2e/testing/vllm-sr-cli/test_unit_runtime_topology.py
@@ -26,6 +26,7 @@ class TestCLITestBaseRuntimeTopology(unittest.TestCase):
     def setUp(self):
         self.base = CLITestBase(methodName="runTest")
         self.base.container_runtime = "docker"
+        self.base.test_dir = os.getcwd()
 
     def _mock_statuses(self, statuses_by_name: dict[str, str]):
         def side_effect(command, *, timeout, **_kwargs):
@@ -142,6 +143,22 @@ class TestCLITestBaseRuntimeTopology(unittest.TestCase):
             side_effect=lambda name: "/usr/bin/podman" if name == "podman" else None,
         ), self.assertRaisesRegex(RuntimeError, "Podman is installed but unsupported"):
             CLITestBase._detect_container_runtime()
+
+    @mock.patch.object(CLITestBase, "_run_subprocess")
+    def test_run_cli_preserves_partial_output_on_timeout(self, run_subprocess):
+        run_subprocess.side_effect = subprocess.TimeoutExpired(
+            cmd=["vllm-sr", "serve"],
+            timeout=30,
+            output="Created bootstrap setup config\n",
+            stderr="Waiting for Dashboard to become healthy...\n",
+        )
+
+        return_code, stdout, stderr = self.base.run_cli(["serve"], timeout=30)
+
+        self.assertEqual(return_code, -1)
+        self.assertIn("bootstrap setup config", stdout)
+        self.assertIn("dashboard to become healthy", stderr.lower())
+        self.assertIn("command timed out after 30 seconds", stderr.lower())
 
 
 class TestCLITestRunnerRuntimeDetection(unittest.TestCase):


### PR DESCRIPTION
## What changed
- preserve partial stdout/stderr when `CLITestBase.run_cli()` times out instead of replacing all output with a timeout-only message
- add unit coverage to lock that timeout-output behavior in the CLI test harness

## Why
`test_serve_bootstraps_missing_config_file` can reach bootstrap and still occasionally exceed the test timeout. When that happened, the helper discarded the already-emitted bootstrap logs, so the assertion only saw `Command timed out after 30 seconds` and failed even though bootstrap had already happened.

## Impact
- reduces flakiness in the `vllm-sr` CLI unit suite
- keeps the Docker-only / no-Podman policy unchanged

## Validation
- `python -m unittest test_unit_runtime_topology.py`
- `python -m unittest test_unit_serve.py`
- `make vllm-sr-test`
