### PR TITLE
Fix playground open_web proxy routing

### DIFF
--- a/dashboard/backend/handlers/openweb.go
+++ b/dashboard/backend/handlers/openweb.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -57,9 +56,12 @@ var (
 
 // OpenWebRequest represents a web page fetch request
 type OpenWebRequest struct {
-	URL       string `json:"url"`
-	Timeout   int    `json:"timeout,omitempty"`    // Timeout (seconds)
-	ForceJina bool   `json:"force_jina,omitempty"` // Force using Jina
+	URL        string `json:"url"`
+	Timeout    int    `json:"timeout,omitempty"`     // Timeout (seconds)
+	ForceJina  bool   `json:"force_jina,omitempty"`  // Force using Jina
+	Format     string `json:"format,omitempty"`      // markdown (default) or json
+	MaxLength  int    `json:"max_length,omitempty"`  // Maximum returned content length
+	WithImages bool   `json:"with_images,omitempty"` // Enable Jina image-alt enrichment
 }
 
 // OpenWebResponse represents a web page fetch response
@@ -121,12 +123,56 @@ func cleanHTMLContent(html string) (title string, content string) {
 	return title, content
 }
 
+func normalizeOpenWebFormat(format string) string {
+	if strings.EqualFold(format, "json") {
+		return "json"
+	}
+	return "markdown"
+}
+
+func normalizeOpenWebMaxLength(maxLength int) int {
+	if maxLength <= 0 || maxLength > openWebMaxContentLength {
+		return openWebMaxContentLength
+	}
+	return maxLength
+}
+
+func truncateOpenWebContent(content string, maxLength int) (string, bool) {
+	if len(content) > maxLength {
+		return content[:maxLength] + "\n\n...[Content truncated]", true
+	}
+	return content, false
+}
+
+func extractMarkdownTitle(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "# "))
+		}
+	}
+	return "Untitled"
+}
+
+func shouldPreferJinaFetch(targetURL string, req OpenWebRequest) bool {
+	if req.ForceJina || req.WithImages {
+		return true
+	}
+
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		return false
+	}
+
+	return strings.HasSuffix(strings.ToLower(parsedURL.Path), ".pdf")
+}
+
 // ========================
 // Fetch Functions
 // ========================
 
 // fetchDirect fetches web page directly
-func fetchWebDirect(targetURL string, timeout time.Duration) (*OpenWebResponse, error) {
+func fetchWebDirect(targetURL string, timeout time.Duration, maxLength int) (*OpenWebResponse, error) {
 	log.Printf("[OpenWeb:Direct] Starting fetch: %s", targetURL)
 	startTime := time.Now()
 
@@ -155,10 +201,7 @@ func fetchWebDirect(targetURL string, timeout time.Duration) (*OpenWebResponse, 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		if strings.Contains(err.Error(), "timeout") {
-			return nil, fmt.Errorf("request timeout")
-		}
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, wrapOpenWebRequestError(err)
 	}
 	defer resp.Body.Close()
 
@@ -185,226 +228,20 @@ func fetchWebDirect(targetURL string, timeout time.Duration) (*OpenWebResponse, 
 
 	log.Printf("[OpenWeb:Direct] Cleaned content length: %d characters", len(content))
 
-	truncated := false
-	if len(content) > openWebMaxContentLength {
-		content = content[:openWebMaxContentLength] + "\n\n...[Content truncated]"
-		truncated = true
-		log.Printf("[OpenWeb:Direct] Content truncated to %d characters", openWebMaxContentLength)
+	result := buildOpenWebResponse(
+		openWebFetchedContent{
+			url:     targetURL,
+			title:   title,
+			content: content,
+		},
+		maxLength,
+		"direct",
+	)
+	if result.Truncated {
+		log.Printf("[OpenWeb:Direct] Content truncated to %d characters", maxLength)
 	}
 
 	log.Printf("[OpenWeb:Direct] ✅ Fetch succeeded, total elapsed: %v", time.Since(startTime))
 
-	return &OpenWebResponse{
-		URL:       targetURL,
-		Title:     title,
-		Content:   content,
-		Length:    len(content),
-		Truncated: truncated,
-		Method:    "direct",
-	}, nil
-}
-
-// fetchWithJina fetches web page using Jina Reader API
-func fetchWebWithJina(targetURL string, timeout time.Duration) (*OpenWebResponse, error) {
-	log.Printf("[OpenWeb:Jina] Starting fetch: %s", targetURL)
-	startTime := time.Now()
-
-	jinaURL := fmt.Sprintf("%s/%s", jinaReaderBaseURL, targetURL)
-	log.Printf("[OpenWeb:Jina] Jina URL: %s", jinaURL)
-
-	client := &http.Client{Timeout: timeout}
-
-	req, err := http.NewRequest("GET", jinaURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Timeout", fmt.Sprintf("%d", int(timeout.Seconds())))
-	req.Header.Set("X-No-Cache", "true")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		if strings.Contains(err.Error(), "timeout") {
-			return nil, fmt.Errorf("request timeout")
-		}
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	log.Printf("[OpenWeb:Jina] Response status: %d, elapsed: %v", resp.StatusCode, time.Since(startTime))
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Parse JSON response
-	var result struct {
-		Data struct {
-			URL     string `json:"url"`
-			Title   string `json:"title"`
-			Content string `json:"content"`
-		} `json:"data"`
-		URL     string `json:"url"`
-		Title   string `json:"title"`
-		Content string `json:"content"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	// Prefer data field
-	content := result.Data.Content
-	if content == "" {
-		content = result.Content
-	}
-	title := result.Data.Title
-	if title == "" {
-		title = result.Title
-	}
-	if title == "" {
-		title = "Untitled"
-	}
-	actualURL := result.Data.URL
-	if actualURL == "" {
-		actualURL = result.URL
-	}
-	if actualURL == "" {
-		actualURL = targetURL
-	}
-
-	if content == "" {
-		return nil, fmt.Errorf("response content is empty")
-	}
-
-	log.Printf("[OpenWeb:Jina] Got title: %s", title)
-	log.Printf("[OpenWeb:Jina] Original content length: %d characters", len(content))
-
-	truncated := false
-	if len(content) > openWebMaxContentLength {
-		content = content[:openWebMaxContentLength] + "\n\n...[Content truncated]"
-		truncated = true
-		log.Printf("[OpenWeb:Jina] Content truncated to %d characters", openWebMaxContentLength)
-	}
-
-	log.Printf("[OpenWeb:Jina] ✅ Fetch succeeded, total elapsed: %v", time.Since(startTime))
-
-	return &OpenWebResponse{
-		URL:       actualURL,
-		Title:     title,
-		Content:   content,
-		Length:    len(content),
-		Truncated: truncated,
-		Method:    "jina",
-	}, nil
-}
-
-// ========================
-// HTTP Handler
-// ========================
-
-// OpenWebHandler handles web page fetch requests
-func OpenWebHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Set CORS headers
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-
-		// Handle preflight request
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-
-		// Only allow POST requests
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		// Parse request
-		var req OpenWebRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			log.Printf("[OpenWeb] Failed to parse request: %v", err)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(OpenWebResponse{
-				Error: "Invalid request format",
-			})
-			return
-		}
-
-		// Validate URL
-		if req.URL == "" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(OpenWebResponse{
-				Error: "URL cannot be empty",
-			})
-			return
-		}
-
-		// Validate URL format
-		parsedURL, err := url.Parse(req.URL)
-		if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(OpenWebResponse{
-				URL:   req.URL,
-				Error: "Invalid URL format",
-			})
-			return
-		}
-
-		// Calculate timeout
-		timeout := openWebDefaultTimeout
-		if req.Timeout > 0 {
-			timeout = time.Duration(req.Timeout) * time.Second
-			if timeout > openWebMaxTimeout {
-				timeout = openWebMaxTimeout
-			}
-		}
-
-		log.Printf("[OpenWeb] Request: url=%s, timeout=%v, force_jina=%v", req.URL, timeout, req.ForceJina)
-
-		var result *OpenWebResponse
-		var fetchErr error
-
-		// Strategy 1: If not forcing Jina, try direct fetch first
-		if !req.ForceJina {
-			log.Printf("[OpenWeb] Strategy 1: Trying direct fetch...")
-			result, fetchErr = fetchWebDirect(req.URL, timeout)
-			if fetchErr == nil {
-				log.Printf("[OpenWeb] ✅ Direct fetch succeeded")
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(result)
-				return
-			}
-			log.Printf("[OpenWeb] ⚠️ Direct fetch failed: %v", fetchErr)
-			log.Printf("[OpenWeb] Strategy 2: Falling back to Jina Reader...")
-		} else {
-			log.Printf("[OpenWeb] Skipping direct fetch, using Jina Reader directly")
-		}
-
-		// Strategy 2: Use Jina Reader
-		result, fetchErr = fetchWebWithJina(req.URL, timeout)
-		if fetchErr == nil {
-			log.Printf("[OpenWeb] ✅ Jina Reader fetch succeeded")
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(result)
-			return
-		}
-
-		// Both methods failed
-		log.Printf("[OpenWeb] ❌ All fetch methods failed: %v", fetchErr)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadGateway)
-		_ = json.NewEncoder(w).Encode(OpenWebResponse{
-			URL:   req.URL,
-			Error: fmt.Sprintf("Unable to fetch web content: %v", fetchErr),
-		})
-	}
+	return result, nil
 }

--- a/dashboard/backend/handlers/openweb_handler.go
+++ b/dashboard/backend/handlers/openweb_handler.go
@@ -1,0 +1,157 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type openWebFetchPlan struct {
+	request   OpenWebRequest
+	timeout   time.Duration
+	format    string
+	maxLength int
+	forceJina bool
+}
+
+func OpenWebHandler() http.HandlerFunc {
+	return handleOpenWeb
+}
+
+func handleOpenWeb(w http.ResponseWriter, r *http.Request) {
+	setOpenWebCORSHeaders(w)
+
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	req, err := decodeOpenWebRequest(r)
+	if err != nil {
+		log.Printf("[OpenWeb] Failed to parse request: %v", err)
+		writeOpenWebJSON(w, http.StatusBadRequest, OpenWebResponse{Error: "Invalid request format"})
+		return
+	}
+
+	if invalidResponse, ok := validateOpenWebRequest(req); ok {
+		writeOpenWebJSON(w, http.StatusBadRequest, invalidResponse)
+		return
+	}
+
+	plan := buildOpenWebFetchPlan(req)
+	logOpenWebFetchPlan(plan)
+
+	result, fetchErr := fetchOpenWeb(plan)
+	if fetchErr != nil {
+		log.Printf("[OpenWeb] ❌ All fetch methods failed: %v", fetchErr)
+		writeOpenWebJSON(w, http.StatusBadGateway, OpenWebResponse{
+			URL:   req.URL,
+			Error: fmt.Sprintf("Unable to fetch web content: %v", fetchErr),
+		})
+		return
+	}
+
+	writeOpenWebJSON(w, http.StatusOK, *result)
+}
+
+func setOpenWebCORSHeaders(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+}
+
+func decodeOpenWebRequest(r *http.Request) (OpenWebRequest, error) {
+	var req OpenWebRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return OpenWebRequest{}, err
+	}
+	return req, nil
+}
+
+func validateOpenWebRequest(req OpenWebRequest) (OpenWebResponse, bool) {
+	if req.URL == "" {
+		return OpenWebResponse{Error: "URL cannot be empty"}, true
+	}
+
+	parsedURL, err := url.Parse(req.URL)
+	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+		return OpenWebResponse{
+			URL:   req.URL,
+			Error: "Invalid URL format",
+		}, true
+	}
+
+	return OpenWebResponse{}, false
+}
+
+func buildOpenWebFetchPlan(req OpenWebRequest) openWebFetchPlan {
+	timeout := openWebDefaultTimeout
+	if req.Timeout > 0 {
+		timeout = time.Duration(req.Timeout) * time.Second
+		if timeout > openWebMaxTimeout {
+			timeout = openWebMaxTimeout
+		}
+	}
+
+	return openWebFetchPlan{
+		request:   req,
+		timeout:   timeout,
+		format:    normalizeOpenWebFormat(req.Format),
+		maxLength: normalizeOpenWebMaxLength(req.MaxLength),
+		forceJina: shouldPreferJinaFetch(req.URL, req),
+	}
+}
+
+func logOpenWebFetchPlan(plan openWebFetchPlan) {
+	log.Printf(
+		"[OpenWeb] Request: url=%s, timeout=%v, force_jina=%v, format=%s, max_length=%d, with_images=%v",
+		plan.request.URL,
+		plan.timeout,
+		plan.forceJina,
+		plan.format,
+		plan.maxLength,
+		plan.request.WithImages,
+	)
+}
+
+func fetchOpenWeb(plan openWebFetchPlan) (*OpenWebResponse, error) {
+	if !plan.forceJina {
+		log.Printf("[OpenWeb] Strategy 1: Trying direct fetch...")
+		result, err := fetchWebDirect(plan.request.URL, plan.timeout, plan.maxLength)
+		if err == nil {
+			log.Printf("[OpenWeb] ✅ Direct fetch succeeded")
+			return result, nil
+		}
+		log.Printf("[OpenWeb] ⚠️ Direct fetch failed: %v", err)
+		log.Printf("[OpenWeb] Strategy 2: Falling back to Jina Reader...")
+	} else {
+		log.Printf("[OpenWeb] Skipping direct fetch, using Jina Reader directly")
+	}
+
+	result, err := fetchWebWithJina(
+		plan.request.URL,
+		plan.timeout,
+		plan.format,
+		plan.maxLength,
+		plan.request.WithImages,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[OpenWeb] ✅ Jina Reader fetch succeeded")
+	return result, nil
+}
+
+func writeOpenWebJSON(w http.ResponseWriter, status int, response OpenWebResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/dashboard/backend/handlers/openweb_jina.go
+++ b/dashboard/backend/handlers/openweb_jina.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type openWebFetchedContent struct {
+	url     string
+	title   string
+	content string
+}
+
+type jinaReaderResponse struct {
+	Data struct {
+		URL     string `json:"url"`
+		Title   string `json:"title"`
+		Content string `json:"content"`
+	} `json:"data"`
+	URL     string `json:"url"`
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+func fetchWebWithJina(targetURL string, timeout time.Duration, outputFormat string, maxLength int, withImages bool) (*OpenWebResponse, error) {
+	log.Printf("[OpenWeb:Jina] Starting fetch: %s", targetURL)
+	startTime := time.Now()
+
+	req, err := newJinaRequest(targetURL, timeout, outputFormat, withImages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		return nil, wrapOpenWebRequestError(err)
+	}
+	defer resp.Body.Close()
+
+	log.Printf("[OpenWeb:Jina] Response status: %d, elapsed: %v", resp.StatusCode, time.Since(startTime))
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	fetchedContent, err := parseJinaResponse(resp.Body, outputFormat, targetURL)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[OpenWeb:Jina] Got title: %s", fetchedContent.title)
+	log.Printf("[OpenWeb:Jina] Original content length: %d characters", len(fetchedContent.content))
+
+	result := buildOpenWebResponse(fetchedContent, maxLength, "jina")
+	if result.Truncated {
+		log.Printf("[OpenWeb:Jina] Content truncated to %d characters", maxLength)
+	}
+
+	log.Printf("[OpenWeb:Jina] ✅ Fetch succeeded, total elapsed: %v", time.Since(startTime))
+	return result, nil
+}
+
+func newJinaRequest(targetURL string, timeout time.Duration, outputFormat string, withImages bool) (*http.Request, error) {
+	jinaURL := fmt.Sprintf("%s/%s", jinaReaderBaseURL, targetURL)
+	log.Printf("[OpenWeb:Jina] Jina URL: %s", jinaURL)
+
+	req, err := http.NewRequest("GET", jinaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if outputFormat == "json" {
+		req.Header.Set("Accept", "application/json")
+	}
+	req.Header.Set("X-Timeout", fmt.Sprintf("%d", int(timeout.Seconds())))
+	req.Header.Set("X-No-Cache", "true")
+	if withImages {
+		req.Header.Set("X-With-Generated-Alt", "true")
+	}
+
+	return req, nil
+}
+
+func parseJinaResponse(body io.Reader, outputFormat string, targetURL string) (openWebFetchedContent, error) {
+	if outputFormat == "json" {
+		return parseJinaJSONResponse(body, targetURL)
+	}
+	return parseJinaMarkdownResponse(body, targetURL)
+}
+
+func parseJinaJSONResponse(body io.Reader, targetURL string) (openWebFetchedContent, error) {
+	var result jinaReaderResponse
+	if err := json.NewDecoder(body).Decode(&result); err != nil {
+		return openWebFetchedContent{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	content := result.Data.Content
+	if content == "" {
+		content = result.Content
+	}
+	if content == "" {
+		return openWebFetchedContent{}, fmt.Errorf("response content is empty")
+	}
+
+	title := result.Data.Title
+	if title == "" {
+		title = result.Title
+	}
+
+	actualURL := targetURL
+	if result.Data.URL != "" {
+		actualURL = result.Data.URL
+	} else if result.URL != "" {
+		actualURL = result.URL
+	}
+
+	return openWebFetchedContent{
+		url:     actualURL,
+		title:   title,
+		content: content,
+	}, nil
+}
+
+func parseJinaMarkdownResponse(body io.Reader, targetURL string) (openWebFetchedContent, error) {
+	contentBytes, err := io.ReadAll(body)
+	if err != nil {
+		return openWebFetchedContent{}, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	content := string(contentBytes)
+	if content == "" {
+		return openWebFetchedContent{}, fmt.Errorf("response content is empty")
+	}
+
+	return openWebFetchedContent{
+		url:     targetURL,
+		title:   extractMarkdownTitle(content),
+		content: content,
+	}, nil
+}
+
+func buildOpenWebResponse(content openWebFetchedContent, maxLength int, method string) *OpenWebResponse {
+	title := content.title
+	if title == "" {
+		title = "Untitled"
+	}
+
+	truncatedContent, truncated := truncateOpenWebContent(content.content, maxLength)
+	return &OpenWebResponse{
+		URL:       content.url,
+		Title:     title,
+		Content:   truncatedContent,
+		Length:    len(truncatedContent),
+		Truncated: truncated,
+		Method:    method,
+	}
+}
+
+func wrapOpenWebRequestError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if containsOpenWebTimeout(err) {
+		return fmt.Errorf("request timeout")
+	}
+	return fmt.Errorf("request failed: %w", err)
+}
+
+func containsOpenWebTimeout(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "timeout")
+}

--- a/dashboard/backend/handlers/openweb_test.go
+++ b/dashboard/backend/handlers/openweb_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import "testing"
+
+func TestShouldPreferJinaFetch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		req  OpenWebRequest
+		want bool
+	}{
+		{
+			name: "ordinary html stays on direct-first path",
+			url:  "https://example.com/article",
+			req:  OpenWebRequest{},
+			want: false,
+		},
+		{
+			name: "explicit force_jina wins",
+			url:  "https://example.com/article",
+			req: OpenWebRequest{
+				ForceJina: true,
+			},
+			want: true,
+		},
+		{
+			name: "with_images keeps jina path",
+			url:  "https://example.com/article",
+			req: OpenWebRequest{
+				WithImages: true,
+			},
+			want: true,
+		},
+		{
+			name: "pdf urls keep jina path",
+			url:  "https://example.com/guide.pdf",
+			req:  OpenWebRequest{},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shouldPreferJinaFetch(tt.url, tt.req); got != tt.want {
+				t.Fatalf("shouldPreferJinaFetch(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeOpenWebMaxLength(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeOpenWebMaxLength(0); got != openWebMaxContentLength {
+		t.Fatalf("normalizeOpenWebMaxLength(0) = %d, want %d", got, openWebMaxContentLength)
+	}
+
+	if got := normalizeOpenWebMaxLength(1200); got != 1200 {
+		t.Fatalf("normalizeOpenWebMaxLength(1200) = %d, want 1200", got)
+	}
+
+	if got := normalizeOpenWebMaxLength(openWebMaxContentLength + 1); got != openWebMaxContentLength {
+		t.Fatalf(
+			"normalizeOpenWebMaxLength(max+1) = %d, want %d",
+			got,
+			openWebMaxContentLength,
+		)
+	}
+}

--- a/dashboard/frontend/e2e/playground.spec.ts
+++ b/dashboard/frontend/e2e/playground.spec.ts
@@ -20,6 +20,50 @@ function chatStreamBody(content: string, reasoning = ''): string {
   return initialLine + [...reasoningLines, ...contentLines].join('') + 'data: [DONE]\n\n';
 }
 
+function chatToolCallBody(
+  toolName: string,
+  args: Record<string, unknown>,
+  callId = 'call_open_web_1',
+): string {
+  return JSON.stringify({
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: callId,
+              type: 'function',
+              function: {
+                name: toolName,
+                arguments: JSON.stringify(args),
+              },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+  });
+}
+
+function chatJsonBody(content: string): string {
+  return JSON.stringify({
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content,
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  });
+}
+
 async function mockStreamingChatFetch(
   page: import('@playwright/test').Page,
   chunks: string[],
@@ -258,6 +302,60 @@ test.describe('Playground Chat Component', () => {
     
     // Input should be cleared after sending
     await expect(input).toHaveValue('');
+  });
+
+  test('routes open_web through the backend proxy', async ({ page }) => {
+    let chatRequestCount = 0;
+    let openWebRequestBody: Record<string, unknown> | null = null;
+
+    await page.route('**/api/tools/open-web', async (route) => {
+      openWebRequestBody = route.request().postDataJSON() as Record<string, unknown>;
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          url: 'https://example.com/article',
+          title: 'Example Article',
+          content: 'Example content returned by the backend proxy.',
+          length: 46,
+          truncated: false,
+          method: 'direct',
+        }),
+      });
+    });
+
+    await page.route('**/api/router/v1/chat/completions', async (route) => {
+      chatRequestCount += 1;
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: chatRequestCount === 1
+          ? chatToolCallBody('open_web', {
+              url: 'https://example.com/article',
+              format: 'markdown',
+              max_length: 15000,
+            })
+          : chatJsonBody('The page was fetched through the backend proxy.'),
+      });
+    });
+
+    await page.getByPlaceholder('Ask me anything...').fill('Open an article for me');
+    await page.getByRole('button', { name: 'Send message' }).click();
+
+    await expect(page.getByText('The page was fetched through the backend proxy.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Example Article')).toBeVisible({ timeout: 10000 });
+
+    expect(openWebRequestBody).toMatchObject({
+      url: 'https://example.com/article',
+      timeout: 30,
+      force_jina: false,
+      format: 'markdown',
+      max_length: 15000,
+      with_images: false,
+    });
+    expect(chatRequestCount).toBe(2);
   });
 
   test('handles API error gracefully', async ({ page }) => {

--- a/dashboard/frontend/src/tools/executors/openWeb.ts
+++ b/dashboard/frontend/src/tools/executors/openWeb.ts
@@ -1,12 +1,11 @@
 /**
  * Open Web Tool Executor
- * 网页内容提取工具执行器
+ * Web content extraction tool executor
  * 
- * 参考 DuckDuckGo MCP Server 的 jina_fetch.py 实现
- * - 使用 Jina Reader API (r.jina.ai) 抓取网页
- * - 支持 markdown/json 输出格式
- * - 支持内容长度限制
- * - 支持图片 alt 文本生成
+ * Fetches web content through the dashboard backend proxy
+ * - Avoids TLS/CORS issues from browser-side requests to third-party services
+ * - Preserves the existing open_web argument contract
+ * - Keeps the response shape stable
  */
 
 import { createTool } from '../registry'
@@ -17,20 +16,17 @@ export type { OpenWebArgs, OpenWebResult }
 
 // ========== Constants ==========
 
-/** Jina Reader API base URL */
-const JINA_READER_BASE_URL = 'https://r.jina.ai/'
-
-/** 默认最大内容长度（字符） */
+/** Default maximum content length in characters */
 const DEFAULT_MAX_LENGTH = 15000
 
-/** 默认超时时间（秒） */
+/** Default timeout in seconds */
 const DEFAULT_TIMEOUT = 30
 
 // ========== Helper Functions ==========
 
 /**
- * 验证 URL 格式
- * 对应 Python: _validate_url
+ * Validate URL format
+ * Mirrors Python: _validate_url
  */
 function validateUrl(url: string): void {
   if (!url || typeof url !== 'string') {
@@ -51,30 +47,8 @@ function validateUrl(url: string): void {
 }
 
 /**
- * 构建请求头
- * 对应 Python: _build_headers
- */
-function buildHeaders(outputFormat: string, withImages: boolean): Record<string, string> {
-  const headers: Record<string, string> = {
-    'x-no-cache': 'true',
-  }
-
-  if (outputFormat.toLowerCase() === 'json') {
-    headers['Accept'] = 'application/json'
-  } else if (outputFormat.toLowerCase() !== 'markdown') {
-    console.warn(`[OpenWeb] Unsupported format: ${outputFormat}. Using markdown as default.`)
-  }
-
-  if (withImages) {
-    headers['X-With-Generated-Alt'] = 'true'
-  }
-
-  return headers
-}
-
-/**
- * 截断内容
- * 对应 Python: _truncate_content
+ * Truncate content
+ * Mirrors Python: _truncate_content
  */
 function truncateContent(content: string, maxLength: number | null): { content: string; truncated: boolean } {
   if (maxLength && content.length > maxLength) {
@@ -86,47 +60,25 @@ function truncateContent(content: string, maxLength: number | null): { content: 
   return { content, truncated: false }
 }
 
-/**
- * 处理响应数据
- * 对应 Python: _process_response
- */
-function processResponse(
-  data: unknown,
-  outputFormat: string,
-  maxLength: number | null
-): { title: string; content: string; truncated: boolean } {
-  if (outputFormat.toLowerCase() === 'json') {
-    const jsonData = data as Record<string, unknown>
-    let content = String(jsonData.content || '')
-    let truncated = false
+interface OpenWebProxyResponse {
+  url?: string
+  title?: string
+  content?: string
+  length?: number
+  truncated?: boolean
+  error?: string
+}
 
-    if (maxLength && content.length > maxLength) {
-      const result = truncateContent(content, maxLength)
-      content = result.content
-      truncated = result.truncated
-    }
-
-    return {
-      title: String(jsonData.title || 'Untitled'),
-      content,
-      truncated,
-    }
+function isPdfUrl(url: string): boolean {
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith('.pdf')
+  } catch {
+    return false
   }
-
-  // markdown 格式
-  const text = typeof data === 'string' ? data : String(data)
-  const { content, truncated } = truncateContent(text, maxLength)
-  
-  // 尝试从 markdown 中提取标题
-  const titleMatch = text.match(/^#\s+(.+)$/m)
-  const title = titleMatch ? titleMatch[1] : 'Untitled'
-
-  return { title, content, truncated }
 }
 
 /**
- * 使用 Jina Reader 抓取 URL
- * 对应 Python: fetch_url
+ * Fetch a URL through the dashboard backend proxy
  */
 async function fetchUrl(
   url: string,
@@ -136,57 +88,75 @@ async function fetchUrl(
   context: ToolExecutionContext
 ): Promise<OpenWebResult> {
   validateUrl(url)
-  const headers = buildHeaders(outputFormat, withImages)
-  // 注意：不使用 encodeURIComponent，因为 Jina Reader 接受完整的原始 URL
-  // Python 版本使用 quote(url)，默认 safe='/'，也不会编码 URL 中的斜杠
-  const jinaUrl = `${JINA_READER_BASE_URL}${url}`
   const startTime = Date.now()
 
-  console.log(`[OpenWeb] 开始抓取: ${url}`)
-  console.log(`[OpenWeb] Jina URL: ${jinaUrl}`)
-  console.log(`[OpenWeb] 输出格式: ${outputFormat}, 包含图片: ${withImages}`)
+  console.log(`[OpenWeb] Starting fetch: ${url}`)
+  console.log(`[OpenWeb] Output format: ${outputFormat}, include images: ${withImages}`)
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT * 1000)
 
   try {
-    const response = await fetch(jinaUrl, {
-      method: 'GET',
+    const response = await fetch('/api/tools/open-web', {
+      method: 'POST',
       headers: {
-        ...headers,
+        'Content-Type': 'application/json',
         ...context.headers,
       },
+      body: JSON.stringify({
+        url,
+        timeout: DEFAULT_TIMEOUT,
+        // Prefer direct server-side fetches for ordinary pages, but preserve
+        // Jina-only paths for PDFs and image-alt enrichment.
+        force_jina: withImages || isPdfUrl(url),
+        format: outputFormat,
+        max_length: maxLength,
+        with_images: withImages,
+      }),
       signal: context.signal || controller.signal,
     })
 
     clearTimeout(timeoutId)
     const responseTime = Date.now() - startTime
 
-    console.log(`[OpenWeb] 响应状态: ${response.status} ${response.statusText}`)
-    console.log(`[OpenWeb] 响应耗时: ${responseTime}ms`)
+    console.log(`[OpenWeb] Response status: ${response.status} ${response.statusText}`)
+    console.log(`[OpenWeb] Response time: ${responseTime}ms`)
+
+    let payload: OpenWebProxyResponse | null = null
+    const contentType = response.headers.get('content-type') || ''
+
+    if (contentType.includes('application/json')) {
+      const parsedPayload = await response.json()
+      payload = parsedPayload as OpenWebProxyResponse
+    } else {
+      const text = await response.text()
+      payload = { error: text || response.statusText }
+    }
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      throw new Error(payload?.error || `HTTP ${response.status}: ${response.statusText}`)
     }
 
-    let data: unknown
-    if (outputFormat.toLowerCase() === 'json') {
-      data = await response.json()
-    } else {
-      data = await response.text()
+    if (payload?.error) {
+      throw new Error(payload.error)
     }
 
-    const { title, content, truncated } = processResponse(data, outputFormat, maxLength)
+    const rawContent = typeof payload?.content === 'string' ? payload.content : ''
+    const truncationResult = truncateContent(rawContent, maxLength)
+    const content = truncationResult.content
+    const truncated = Boolean(payload?.truncated) || truncationResult.truncated
+    const title = payload?.title || 'Untitled'
+    const resolvedUrl = payload?.url || url
 
-    console.log(`[OpenWeb] 获取标题: ${title}`)
-    console.log(`[OpenWeb] 内容长度: ${content.length} 字符`)
+    console.log(`[OpenWeb] Resolved title: ${title}`)
+    console.log(`[OpenWeb] Content length: ${content.length} chars`)
     if (truncated) {
-      console.log(`[OpenWeb] 内容已截断`)
+      console.log(`[OpenWeb] Content truncated`)
     }
-    console.log(`[OpenWeb] ✅ 抓取成功，总耗时: ${Date.now() - startTime}ms`)
+    console.log(`[OpenWeb] Success, total time: ${Date.now() - startTime}ms`)
 
     return {
-      url,
+      url: resolvedUrl,
       title,
       content,
       length: content.length,
@@ -195,10 +165,10 @@ async function fetchUrl(
   } catch (error) {
     const elapsed = Date.now() - startTime
     if (error instanceof Error && error.name === 'AbortError') {
-      console.error(`[OpenWeb] ❌ 请求超时 (${DEFAULT_TIMEOUT}s)`)
+      console.error(`[OpenWeb] Request timed out (${DEFAULT_TIMEOUT}s)`)
       throw new Error(`Error fetching URL (${url}): Request timeout`)
     }
-    console.error(`[OpenWeb] ❌ 抓取失败 (${elapsed}ms):`, error)
+    console.error(`[OpenWeb] Fetch failed (${elapsed}ms):`, error)
     throw new Error(`Error fetching URL (${url}): ${error instanceof Error ? error.message : String(error)}`)
   } finally {
     clearTimeout(timeoutId)
@@ -209,7 +179,7 @@ async function fetchUrl(
 
 /**
  * Validate open web arguments
- * 对应 Python: jina_fetch 的参数验证
+ * Mirrors Python: jina_fetch argument validation
  */
 function validateOpenWebArgs(args: unknown): OpenWebArgs {
   if (typeof args !== 'object' || args === null) {
@@ -218,7 +188,7 @@ function validateOpenWebArgs(args: unknown): OpenWebArgs {
 
   const { url, format, max_length, with_images } = args as Record<string, unknown>
 
-  // 验证 url（必需）
+  // Validate required url
   if (!url) {
     throw new Error('Missing required parameter: url')
   }
@@ -226,7 +196,7 @@ function validateOpenWebArgs(args: unknown): OpenWebArgs {
     throw new Error('url must be a non-empty string')
   }
 
-  // 验证 format
+  // Validate format
   let parsedFormat: 'markdown' | 'json' = 'markdown'
   if (format !== undefined) {
     const fmt = String(format).toLowerCase()
@@ -236,7 +206,7 @@ function validateOpenWebArgs(args: unknown): OpenWebArgs {
     parsedFormat = fmt as 'markdown' | 'json'
   }
 
-  // 验证 max_length
+  // Validate max_length
   let parsedMaxLength: number | undefined = DEFAULT_MAX_LENGTH
   if (max_length !== undefined && max_length !== null) {
     const len = typeof max_length === 'number' ? max_length : parseInt(String(max_length), 10)
@@ -246,7 +216,7 @@ function validateOpenWebArgs(args: unknown): OpenWebArgs {
     parsedMaxLength = len
   }
 
-  // 验证 with_images
+  // Validate with_images
   const parsedWithImages = typeof with_images === 'boolean' ? with_images : false
 
   return {
@@ -261,7 +231,7 @@ function validateOpenWebArgs(args: unknown): OpenWebArgs {
 
 /**
  * Execute open web
- * 对应 Python: jina_fetch
+ * Mirrors Python: jina_fetch
  */
 async function executeOpenWeb(
   args: OpenWebArgs,
@@ -275,7 +245,7 @@ async function executeOpenWeb(
   } = args
 
   console.log(`\n${'='.repeat(60)}`)
-  console.log(`[OpenWeb] 🚀 开始抓取网页`)
+  console.log(`[OpenWeb] Starting web fetch`)
   console.log(`[OpenWeb] URL: ${url}`)
   console.log(`[OpenWeb] Format: ${format}, MaxLength: ${max_length}, WithImages: ${with_images}`)
   console.log(`${'='.repeat(60)}`)
@@ -305,7 +275,7 @@ function formatOpenWebResult(result: OpenWebResult): string {
 
 /**
  * Open Web Tool Definition
- * 对应 Python: @mcp.tool() jina_fetch
+ * Mirrors Python: @mcp.tool() jina_fetch
  */
 export const openWebTool = createTool<OpenWebArgs, OpenWebResult>({
   metadata: {
@@ -314,7 +284,7 @@ export const openWebTool = createTool<OpenWebArgs, OpenWebResult>({
     category: 'search',
     icon: 'globe',
     enabled: true,
-    version: '2.0.0',
+    version: '2.1.0',
   },
 
   definition: {
@@ -322,7 +292,7 @@ export const openWebTool = createTool<OpenWebArgs, OpenWebResult>({
     function: {
       name: 'open_web',
       description:
-        'Fetch a URL and convert it to markdown or JSON using Jina Reader. Supports HTML and PDF content extraction.',
+        'Fetch a URL through the dashboard backend proxy and return extracted page content. Supports HTML and PDF extraction.',
       parameters: {
         type: 'object',
         properties: {


### PR DESCRIPTION
## Summary

This PR routes Playground `open_web` requests through the dashboard backend proxy instead of fetching `r.jina.ai` directly from the browser.

It keeps the existing tool contract intact, adds backend support for `format`, `max_length`, and `with_images`, and introduces a safer fetch strategy:
- prefer direct server-side fetches for normal pages
- keep Jina for PDFs and image-enrichment flows
- fall back to Jina when direct fetch fails

## Why

Browser-side fetching was fragile and surfaced TLS/CORS-style failures such as certificate errors from third-party endpoints. Moving the request to the backend makes `open_web` more reliable while preserving the current Playground UX.

## Validation

- `make dashboard-check`
- `go test ./handlers -run 'TestShouldPreferJinaFetch|TestNormalizeOpenWebMaxLength'`
- `npx playwright test e2e/playground.spec.ts --grep 'routes open_web through the backend proxy'`
