### PR TITLE
fix: add golangci-lint exclusions for pre-existing violations

### DIFF
--- a/tools/linter/go/.golangci.agent.yml
+++ b/tools/linter/go/.golangci.agent.yml
@@ -109,6 +109,17 @@ linters:
           - gocognit
           - nestif
         path: (^|/)src/semantic-router/pkg/decision/engine_category_kb_test\.go$
+      - linters:
+          - cyclop
+          - errcheck
+          - funlen
+          - gocognit
+          - nestif
+        path: (^|/)src/semantic-router/pkg/modelselection/benchmark_runner\.go$
+      - linters:
+          - cyclop
+          - errcheck
+        path: (^|/)src/semantic-router/pkg/classification/vllm_client\.go$
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
## Summary
- Adds `golangci-lint` exclusion rules in `.golangci.agent.yml` for pre-existing code quality violations in `benchmark_runner.go` (cyclop, errcheck, funlen, gocognit, nestif) and `vllm_client.go` (cyclop, errcheck)
- These violations exist on `main` and are unrelated to any PR's changes, but get flagged by the changed-file lint pipeline when a PR touches these files
- Exclusion pattern is consistent with existing entries for other legacy files in the config

## Test plan
- [ ] CI `Run pre-commit hooks check file lint` passes
- [ ] No new violations introduced

Closes #1700