### PR TITLE
[Docs] Align PR template with vLLM style

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,33 @@
+<!-- markdownlint-disable -->
+PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.
+
 Closes #xxxx
 
-## Summary
+## Purpose
 
-- Scope:
-- Primary skill:
-- Impacted surfaces:
-- Conditional surfaces intentionally skipped:
-- Behavior-visible change: `yes` / `no`
-- Debt entry: `none` / `TDxxx`
+- What does this PR change?
+- Why is this change needed?
+- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`
 
-## Validation
+## Test Plan
 
-- Environment: `cpu-local` / `amd-local` / `not run`
-- Fast gate:
-- Feature gate:
-- Local smoke / E2E:
-- CI expectations / blockers:
+- What commands, checks, or manual steps should reviewers use?
+- Why is this validation sufficient for the affected module(s)?
 
-## Checklist
+## Test Result
 
-- [ ] PR title uses the repo prefix format: `[Bugfix]`, `[CI/Build]`, `[CLI]`, `[Dashboard]`, `[Doc]`, `[Feat]`, `[Router]`, or `[Misc]`
-- [ ] If the PR spans multiple categories, the title includes all relevant prefixes
+- What were the actual results?
+- Any follow-up risks, gaps, or blockers?
+
+---
+<details>
+<summary>Semantic Router PR Checklist</summary>
+
+- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
+- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
 - [ ] Commits in this PR are signed off with `git commit -s`
-- [ ] Source-of-truth docs or indexed debt entries were updated when applicable
-- [ ] The validation results above reflect the actual commands or blockers for this change
+- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change
+
+</details>
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,10 +270,10 @@ make precommit-local
    - Unit tests for all components
 
 2. **Create a pull request** with:
-   - A classified PR title using the repository prefixes from [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md), such as `[Doc] Clarify PR title guidance` or `[Router][CI/Build] Tighten affected test selection`
-   - Clear description of changes
+   - A module-aligned PR title using the repository prefixes from [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md), such as `[Docs][CI/Build] Align PR template with vLLM` or `[Router][Dashboard] Tighten route visibility in the console`
+   - A clear `Purpose` section describing the change and affected module(s)
    - Reference to any related issues
-   - Test results and validation steps
+   - A `Test Plan` and `Test Result` section with the actual validation steps and outcomes
 
 3. **Address review feedback** promptly
 

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -80,7 +80,7 @@ This directory is the human-readable system of record for the repository's agent
   - contributor workflow, validation expectations, and the `git commit -s` signoff requirement
 - [../../.github/copilot-instructions.md](../../.github/copilot-instructions.md)
 - [../../.github/PULL_REQUEST_TEMPLATE.md](../../.github/PULL_REQUEST_TEMPLATE.md)
-  - PR title classification, required change summary and validation fields, and the review checklist
+  - PR title classification, affected-module context, required validation fields, and the review checklist
 - [../../.github/ISSUE_TEMPLATE/001_feature_request.yaml](../../.github/ISSUE_TEMPLATE/001_feature_request.yaml)
 - [../../.github/ISSUE_TEMPLATE/002_bug_report.yaml](../../.github/ISSUE_TEMPLATE/002_bug_report.yaml)
 - [../../.prowlabels.yaml](../../.prowlabels.yaml)

--- a/tools/agent/skills/maintainer-issue-pr-management/SKILL.md
+++ b/tools/agent/skills/maintainer-issue-pr-management/SKILL.md
@@ -51,7 +51,7 @@ description: Manages GitHub issue and pull-request lifecycle including creation,
    - If changed paths are known or can be estimated, run `make agent-report ENV=cpu|amd CHANGED_FILES="..."` to resolve the primary skill, impacted surfaces, and expected validation.
 2. Classify the artifact before writing.
    - Issues use the canonical issue templates as the schema for title and body.
-   - PRs use the canonical PR template as the schema for title, summary, impacted surfaces, skipped surfaces, debt entry, and validation fields.
+   - PRs use the canonical PR template as the schema for title, purpose, affected modules, test plan or results, and checklist expectations.
 3. Apply canonical labels and naming.
    - For issues, start from the template defaults such as `bug` or `feature request`.
    - Add maintainer labels from `.prowlabels.yaml`; today that taxonomy includes `area` labels and `priority` labels.
@@ -81,4 +81,4 @@ description: Manages GitHub issue and pull-request lifecycle including creation,
 
 - Issue and PR management requests are grounded in the current repo state rather than memory
 - Issue drafts include the canonical title/body shape plus the correct default and maintainer-applied labels
-- PR drafts or updates include the canonical title classification, signoff expectation, summary fields, and validation results or blockers
+- PR drafts or updates include the canonical title classification, signoff expectation, affected-module context, and validation results or blockers


### PR DESCRIPTION
## Purpose

- Align the PR template with vLLM's `Purpose` / `Test Plan` / `Test Result` structure.
- Replace harness-specific metadata fields with module-aligned guidance for semantic-router contributors.
- Update contributor-facing docs and maintainer guidance so the template, docs, and PR management instructions stay consistent.

## Test Plan

- `make agent-validate`
- `make agent-ci-gate CHANGED_FILES=".github/PULL_REQUEST_TEMPLATE.md,CONTRIBUTING.md,docs/agent/README.md,tools/agent/skills/maintainer-issue-pr-management/SKILL.md"`

## Test Result

- Passed: `make agent-validate`
- Passed: `make agent-ci-gate CHANGED_FILES=".github/PULL_REQUEST_TEMPLATE.md,CONTRIBUTING.md,docs/agent/README.md,tools/agent/skills/maintainer-issue-pr-management/SKILL.md"`
- This is a docs-only contributor workflow change, so no local smoke or E2E run was required.
