### PR TITLE
fix: resolve model config by provider model ID

### DIFF
--- a/src/semantic-router/pkg/config/canonical_config.go
+++ b/src/semantic-router/pkg/config/canonical_config.go
@@ -366,8 +366,11 @@ func normalizeExternalModelIDsFromProviderModel(model CanonicalProviderModel) ma
 		}
 		result[key] = model.ProviderModelID
 	}
+	// When no backend_refs are defined (metadata-only provider model),
+	// still store the provider_model_id so pricing lookups by provider
+	// model ID (e.g. from Envoy AI Gateway) can resolve to this model.
 	if len(result) == 0 {
-		return nil
+		result["default"] = model.ProviderModelID
 	}
 	return result
 }

--- a/src/semantic-router/pkg/config/canonical_loader_test.go
+++ b/src/semantic-router/pkg/config/canonical_loader_test.go
@@ -503,6 +503,60 @@ routing:
 	}
 }
 
+func TestGetModelPricingResolvesProviderModelIDFromCanonicalConfig(t *testing.T) {
+	canonicalYAML := []byte(`
+version: v0.3
+listeners:
+  - name: http
+    address: 0.0.0.0
+    port: 8888
+providers:
+  defaults:
+    default_model: claude-haiku
+  models:
+    - name: claude-haiku
+      provider_model_id: eu.anthropic.claude-haiku-4-5-20251001-v1:0
+      pricing:
+        currency: USD
+        prompt_per_1m: 1.00
+        completion_per_1m: 5.00
+routing:
+  modelCards:
+    - name: claude-haiku
+      modality: ar
+  decisions:
+    - name: default
+      priority: 1
+      rules:
+        operator: OR
+        conditions:
+          - type: domain
+            name: general
+      modelRefs:
+        - model: claude-haiku
+`)
+
+	cfg, err := ParseYAMLBytes(canonicalYAML)
+	if err != nil {
+		t.Fatalf("ParseYAMLBytes returned error: %v", err)
+	}
+
+	// Model with no backend_refs should still have ExternalModelIDs populated
+	params := cfg.ModelConfig["claude-haiku"]
+	if len(params.ExternalModelIDs) == 0 {
+		t.Fatal("expected ExternalModelIDs to be populated for metadata-only model")
+	}
+
+	// Pricing lookup by provider model ID should work
+	prompt, completion, currency, ok := cfg.GetModelPricing("eu.anthropic.claude-haiku-4-5-20251001-v1:0")
+	if !ok {
+		t.Fatal("expected pricing lookup by provider model ID to succeed")
+	}
+	if prompt != 1.00 || completion != 5.00 || currency != "USD" {
+		t.Fatalf("provider ID lookup: got prompt=%v completion=%v currency=%q", prompt, completion, currency)
+	}
+}
+
 func TestGetModelPricingTreatsExplicitZeroPricingAsConfigured(t *testing.T) {
 	cfg := &RouterConfig{
 		BackendModels: BackendModels{
@@ -529,6 +583,49 @@ func TestGetModelPricingTreatsExplicitZeroPricingAsConfigured(t *testing.T) {
 			completionPer1M,
 			currency,
 		)
+	}
+}
+
+func TestGetModelPricingResolvesProviderModelID(t *testing.T) {
+	cfg := &RouterConfig{
+		BackendModels: BackendModels{
+			ModelConfig: map[string]ModelParams{
+				"claude-opus-4-6": {
+					Pricing: ModelPricing{
+						Currency:        "USD",
+						PromptPer1M:     5.50,
+						CompletionPer1M: 27.50,
+					},
+					ExternalModelIDs: map[string]string{
+						"default": "eu.anthropic.claude-opus-4-6-v1",
+					},
+				},
+			},
+		},
+	}
+
+	// Lookup by short name should work as before
+	prompt, completion, currency, ok := cfg.GetModelPricing("claude-opus-4-6")
+	if !ok {
+		t.Fatal("expected pricing lookup by short name to succeed")
+	}
+	if prompt != 5.50 || completion != 27.50 || currency != "USD" {
+		t.Fatalf("short name lookup: got prompt=%v completion=%v currency=%q", prompt, completion, currency)
+	}
+
+	// Lookup by provider model ID (Envoy AI Gateway rewrites to this)
+	prompt, completion, currency, ok = cfg.GetModelPricing("eu.anthropic.claude-opus-4-6-v1")
+	if !ok {
+		t.Fatal("expected pricing lookup by provider model ID to succeed")
+	}
+	if prompt != 5.50 || completion != 27.50 || currency != "USD" {
+		t.Fatalf("provider ID lookup: got prompt=%v completion=%v currency=%q", prompt, completion, currency)
+	}
+
+	// Unknown model should still return false
+	_, _, _, ok = cfg.GetModelPricing("nonexistent-model")
+	if ok {
+		t.Fatal("expected pricing lookup for unknown model to return false")
 	}
 }
 

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -81,10 +81,30 @@ func (c *RouterConfig) GetModelForDecisionIndex(index int) string {
 	return c.DefaultModel
 }
 
+// resolveModelConfig looks up a model by name, falling back to a reverse
+// lookup through ExternalModelIDs (provider_model_id) when the name is not
+// a direct key in ModelConfig. This handles the case where the Envoy AI
+// Gateway rewrites the model field to the provider model ID.
+func (c *RouterConfig) resolveModelConfig(modelName string) (ModelParams, bool) {
+	if params, ok := c.ModelConfig[modelName]; ok {
+		return params, true
+	}
+	for _, params := range c.ModelConfig {
+		for _, extID := range params.ExternalModelIDs {
+			if extID == modelName {
+				return params, true
+			}
+		}
+	}
+	return ModelParams{}, false
+}
+
 // GetModelPricing returns pricing per 1M tokens and its currency for the given model.
 // The currency indicates the unit of the returned rates (e.g., "USD").
+// Accepts both short names ("claude-haiku-4-5") and provider model IDs
+// ("eu.anthropic.claude-haiku-4-5-20251001-v1:0").
 func (c *RouterConfig) GetModelPricing(modelName string) (promptPer1M float64, completionPer1M float64, currency string, ok bool) {
-	if modelConfig, okc := c.ModelConfig[modelName]; okc {
+	if modelConfig, okc := c.resolveModelConfig(modelName); okc {
 		p := modelConfig.Pricing
 		// Treat an explicit zero-price entry as configured pricing when a currency is
 		// present so self-hosted/free models still produce cost=0 and savings data.


### PR DESCRIPTION
 ## Summary 
When the Envoy AI Gateway rewrites the model field to the provider model ID
    (e.g. `eu.anthropic.claude-haiku-4-5-20251001-v1:0`), pricing lookups fail
    because `GetModelPricing` only matches on the short model name.
  - Add `resolveModelConfig` helper that falls back to a reverse lookup through
    `ExternalModelIDs` when the short name is not found.
  - Fix `normalizeExternalModelIDsFromProviderModel` to store a `"default"` entry
    for metadata-only provider models (no `backend_refs`), so the reverse lookup
    can still resolve them.
  ## Test plan
  - [x] `TestGetModelPricingResolvesProviderModelID` — verifies lookup by short name,
    by provider model ID, and returns false for unknown models
  - [x] `TestGetModelPricingResolvesProviderModelIDFromCanonicalConfig` — end-to-end
    test parsing canonical YAML with a metadata-only model and resolving pricing
    by provider model ID