### PR TITLE
[Router] refactor(memory): dedupe MilvusStore type-filter builder

### DIFF
--- a/src/semantic-router/pkg/memory/milvus_store.go
+++ b/src/semantic-router/pkg/memory/milvus_store.go
@@ -213,6 +213,19 @@ func (m *MilvusStore) ensureCollection(ctx context.Context) error {
 	return nil
 }
 
+// buildTypeFilter returns a Milvus filter fragment matching any of the given
+// memory types, e.g. `(memory_type == "short_term" || memory_type == "long_term")`.
+func buildTypeFilter(types []MemoryType) string {
+	if len(types) == 0 {
+		return ""
+	}
+	parts := make([]string, len(types))
+	for i, t := range types {
+		parts[i] = fmt.Sprintf("memory_type == %q", string(t))
+	}
+	return "(" + strings.Join(parts, " || ") + ")"
+}
+
 // Retrieve searches for memories in Milvus with similarity threshold filtering
 func (m *MilvusStore) Retrieve(ctx context.Context, opts RetrieveOptions) ([]*RetrieveResult, error) {
 	startTime := time.Now()
@@ -270,16 +283,8 @@ func (m *MilvusStore) Retrieve(ctx context.Context, opts RetrieveOptions) ([]*Re
 	filterExpr := fmt.Sprintf("user_id == \"%s\"", opts.UserID)
 
 	// Add memory type filter if specified
-	if len(opts.Types) > 0 {
-		typeFilter := "("
-		for i, memType := range opts.Types {
-			if i > 0 {
-				typeFilter += " || "
-			}
-			typeFilter += fmt.Sprintf("memory_type == \"%s\"", string(memType))
-		}
-		typeFilter += ")"
-		filterExpr = fmt.Sprintf("%s && %s", filterExpr, typeFilter)
+	if tf := buildTypeFilter(opts.Types); tf != "" {
+		filterExpr = fmt.Sprintf("%s && %s", filterExpr, tf)
 	}
 
 	logging.Debugf("MilvusStore.Retrieve: filter expression: %s", filterExpr)
@@ -937,16 +942,8 @@ func (m *MilvusStore) List(ctx context.Context, opts ListOptions) (*ListResult, 
 	// Build filter expression
 	filterExpr := fmt.Sprintf("user_id == \"%s\"", opts.UserID)
 
-	if len(opts.Types) > 0 {
-		typeFilter := "("
-		for i, memType := range opts.Types {
-			if i > 0 {
-				typeFilter += " || "
-			}
-			typeFilter += fmt.Sprintf("memory_type == \"%s\"", string(memType))
-		}
-		typeFilter += ")"
-		filterExpr = fmt.Sprintf("%s && %s", filterExpr, typeFilter)
+	if tf := buildTypeFilter(opts.Types); tf != "" {
+		filterExpr = fmt.Sprintf("%s && %s", filterExpr, tf)
 	}
 
 	outputFields := []string{"id", "content", "user_id", "memory_type", "metadata", "created_at", "updated_at"}
@@ -1273,16 +1270,8 @@ func (m *MilvusStore) ForgetByScope(ctx context.Context, scope MemoryScope) erro
 	}
 
 	// Add type filter if specified
-	if len(scope.Types) > 0 {
-		typeFilter := "("
-		for i, memType := range scope.Types {
-			if i > 0 {
-				typeFilter += " || "
-			}
-			typeFilter += fmt.Sprintf("memory_type == \"%s\"", string(memType))
-		}
-		typeFilter += ")"
-		filterExpr = fmt.Sprintf("%s && %s", filterExpr, typeFilter)
+	if tf := buildTypeFilter(scope.Types); tf != "" {
+		filterExpr = fmt.Sprintf("%s && %s", filterExpr, tf)
 	}
 
 	logging.Debugf("MilvusStore.ForgetByScope: delete expression: %s", filterExpr)
@@ -1311,16 +1300,8 @@ func (m *MilvusStore) forgetByScopeWithQuery(ctx context.Context, scope MemorySc
 	filterExpr := fmt.Sprintf("user_id == \"%s\"", scope.UserID)
 
 	// Add type filter if specified
-	if len(scope.Types) > 0 {
-		typeFilter := "("
-		for i, memType := range scope.Types {
-			if i > 0 {
-				typeFilter += " || "
-			}
-			typeFilter += fmt.Sprintf("memory_type == \"%s\"", string(memType))
-		}
-		typeFilter += ")"
-		filterExpr = fmt.Sprintf("%s && %s", filterExpr, typeFilter)
+	if tf := buildTypeFilter(scope.Types); tf != "" {
+		filterExpr = fmt.Sprintf("%s && %s", filterExpr, tf)
 	}
 
 	outputFields := []string{"id", "metadata"}


### PR DESCRIPTION
<!-- markdownlint-disable -->

Retrieve, List, ForgetByScope, and forgetByScopeWithQuery each held  a byte-identical 8-line loop that built a  `(memory_type == "x" || ...)` fragment. Four literal copies mean any  future tweak to the filter grammar has to be applied in lockstep and will drift the first time someone misses one.

## Purpose

- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Router`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
