### PR TITLE
[Router] Fix: wire Valkey config into createSemanticCache

### DIFF
--- a/src/semantic-router/pkg/extproc/router_components.go
+++ b/src/semantic-router/pkg/extproc/router_components.go
@@ -58,6 +58,7 @@ func createSemanticCache(cfg *config.RouterConfig) (cache.CacheBackend, error) {
 		TTLSeconds:          semanticCacheCfg.TTLSeconds,
 		EvictionPolicy:      cache.EvictionPolicyType(semanticCacheCfg.EvictionPolicy),
 		Redis:               semanticCacheCfg.Redis,
+		Valkey:              semanticCacheCfg.Valkey,
 		Milvus:              semanticCacheCfg.Milvus,
 		EmbeddingModel:      detectSemanticCacheEmbeddingModel(cfg),
 	}


### PR DESCRIPTION
## Summary

- The `Valkey` field was missing from the `CacheConfig` struct initialization in `createSemanticCache`, causing the Valkey semantic cache backend to always fail with `"valkey configuration is required"` even when properly configured in the router config.
- This is a one-liner fix adding `Valkey: semanticCacheCfg.Valkey` alongside the existing `Redis` and `Milvus` fields.
