### PR TITLE
Add Valkey configuration to semantic cache

### DIFF
--- a/src/semantic-router/pkg/extproc/router_components.go
+++ b/src/semantic-router/pkg/extproc/router_components.go
@@ -59,6 +59,7 @@ func createSemanticCache(cfg *config.RouterConfig) (cache.CacheBackend, error) {
 		EvictionPolicy:      cache.EvictionPolicyType(semanticCacheCfg.EvictionPolicy),
 		Redis:               semanticCacheCfg.Redis,
 		Milvus:              semanticCacheCfg.Milvus,
+		Valkey:              semanticCacheCfg.Valkey,
 		EmbeddingModel:      detectSemanticCacheEmbeddingModel(cfg),
 	}
 


### PR DESCRIPTION
Pass Valkey configuration from semantic cache config to CacheConfig initialization in router components.