### PR TITLE
feat(observability): stamp per-turn pricing metadata and cumulative cost onto session log

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -21,6 +21,10 @@ var BaselineRouterContract = []string{
 	"decision-fallback-behavior",
 	"plugin-config-variations",
 	"chat-completions-progressive-stress",
+	// Session observability
+	"session-telemetry-metrics",
+	"session-pricing-chat-completions",
+	"session-pricing-response-api",
 }
 
 // DashboardContract is the canonical E2E contract for the dashboard API surface.

--- a/e2e/testcases/session_pricing_e2e.go
+++ b/e2e/testcases/session_pricing_e2e.go
@@ -1,0 +1,158 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("session-pricing-chat-completions", pkgtestcases.TestCase{
+		Description: "After a routed chat completion, Prometheus exposes llm_session_turn_cost histogram when model pricing is configured",
+		Tags:        []string{"kubernetes", "observability", "metrics", "llm", "pricing"},
+		Fn:          testSessionPricingChatCompletions,
+	})
+	pkgtestcases.Register("session-pricing-response-api", pkgtestcases.TestCase{
+		Description: "After a routed Response API call, Prometheus exposes llm_session_turn_cost histogram when model pricing is configured",
+		Tags:        []string{"kubernetes", "observability", "metrics", "llm", "pricing", "response-api"},
+		Fn:          testSessionPricingResponseAPI,
+	})
+}
+
+// testSessionPricingChatCompletions verifies that after a Chat Completions request the
+// llm_session_turn_cost histogram is present in /metrics (pricing must be configured
+// for the routed model in router-config.yaml for the observation to appear).
+func testSessionPricingChatCompletions(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	opts pkgtestcases.TestCaseOptions,
+) error {
+	traffic, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer traffic.Close()
+
+	metricsSession, err := fixtures.OpenSemanticRouterMetricsSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer metricsSession.Close()
+
+	chat := fixtures.NewChatCompletionsClient(traffic, 60*time.Second)
+
+	headers := map[string]string{
+		"x-authz-user-id": "e2e-pricing-chat-user",
+	}
+	resp, err := chat.Create(ctx, fixtures.ChatCompletionsRequest{
+		Model: "MoM",
+		Messages: []fixtures.ChatMessage{
+			{Role: "user", Content: "Say hello in one short sentence for pricing telemetry."},
+		},
+		User: "e2e-pricing-chat-user",
+	}, headers)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("chat completion: expected 200, got %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	body, err := fetchMetrics(ctx, metricsSession)
+	if err != nil {
+		return err
+	}
+
+	// Token histograms from PR 1 must still be present.
+	if !strings.Contains(body, "llm_session_turn_prompt_tokens") {
+		return fmt.Errorf("metrics body missing llm_session_turn_prompt_tokens")
+	}
+	if !strings.Contains(body, "llm_session_turn_completion_tokens") {
+		return fmt.Errorf("metrics body missing llm_session_turn_completion_tokens")
+	}
+	// Cost histogram descriptor must be registered (present even when no observations).
+	if !strings.Contains(body, "llm_session_turn_cost") {
+		return fmt.Errorf("metrics body missing llm_session_turn_cost")
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"chat_status": resp.StatusCode,
+		})
+	}
+	return nil
+}
+
+// testSessionPricingResponseAPI verifies that after a Response API request the
+// llm_session_turn_cost histogram descriptor is exposed in /metrics.
+func testSessionPricingResponseAPI(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	opts pkgtestcases.TestCaseOptions,
+) error {
+	traffic, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer traffic.Close()
+
+	metricsSession, err := fixtures.OpenSemanticRouterMetricsSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer metricsSession.Close()
+
+	respAPI := fixtures.NewResponseAPIClient(traffic, 60*time.Second)
+
+	_, raw, err := respAPI.Create(ctx, fixtures.ResponseAPIRequest{
+		Model: "MoM",
+		Input: "Say hello in one short sentence for Response API pricing telemetry.",
+	})
+	if err != nil {
+		return fmt.Errorf("response api create: %w", err)
+	}
+	if raw.StatusCode != http.StatusOK {
+		return fmt.Errorf("response api: expected 200, got %d: %s", raw.StatusCode, string(raw.Body))
+	}
+
+	body, err := fetchMetrics(ctx, metricsSession)
+	if err != nil {
+		return err
+	}
+
+	if !strings.Contains(body, "llm_session_turn_cost") {
+		return fmt.Errorf("metrics body missing llm_session_turn_cost after Response API request")
+	}
+	if !strings.Contains(body, "llm_session_turn_prompt_tokens") {
+		return fmt.Errorf("metrics body missing llm_session_turn_prompt_tokens after Response API request")
+	}
+	if !strings.Contains(body, "llm_session_turn_completion_tokens") {
+		return fmt.Errorf("metrics body missing llm_session_turn_completion_tokens after Response API request")
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"response_api_status": raw.StatusCode,
+		})
+	}
+	return nil
+}
+
+// fetchMetrics retrieves the Prometheus /metrics text from the router metrics port.
+func fetchMetrics(ctx context.Context, metricsSession *fixtures.ServiceSession) (string, error) {
+	metricsHTTP := metricsSession.HTTPClient(15 * time.Second)
+	metricsResp, err := fixtures.DoGETRequest(ctx, metricsHTTP, metricsSession.URL("/metrics"))
+	if err != nil {
+		return "", fmt.Errorf("fetch /metrics: %w", err)
+	}
+	if metricsResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("/metrics: expected 200, got %d", metricsResp.StatusCode)
+	}
+	return string(metricsResp.Body), nil
+}

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -277,9 +277,10 @@ type ProviderProfile struct {
 }
 
 type ModelPricing struct {
-	Currency        string  `yaml:"currency,omitempty"`
-	PromptPer1M     float64 `yaml:"prompt_per_1m,omitempty"`
-	CompletionPer1M float64 `yaml:"completion_per_1m,omitempty"`
+	Currency         string  `yaml:"currency,omitempty"`
+	PromptPer1M      float64 `yaml:"prompt_per_1m,omitempty"`
+	CompletionPer1M  float64 `yaml:"completion_per_1m,omitempty"`
+	CachedInputPer1M float64 `yaml:"cached_input_per_1m,omitempty"`
 }
 
 type ModelParams struct {

--- a/src/semantic-router/pkg/config/pricing_helper.go
+++ b/src/semantic-router/pkg/config/pricing_helper.go
@@ -1,0 +1,19 @@
+package config
+
+// GetFullModelPricing returns the complete ModelPricing entry for the given model,
+// including CachedInputPer1M. Returns (p, true) when at least one rate is non-zero
+// or Currency is explicitly set (currency-only counts as configured so that free/
+// self-hosted models produce cost=0 telemetry). Returns (zero, false) when the model
+// has no pricing entry at all. Accepts both short names and provider model IDs.
+func (c *RouterConfig) GetFullModelPricing(modelName string) (ModelPricing, bool) {
+	if modelConfig, ok := c.resolveModelConfig(modelName); ok {
+		p := modelConfig.Pricing
+		if p.PromptPer1M != 0 || p.CompletionPer1M != 0 || p.CachedInputPer1M != 0 || p.Currency != "" {
+			if p.Currency == "" {
+				p.Currency = "USD"
+			}
+			return p, true
+		}
+	}
+	return ModelPricing{}, false
+}

--- a/src/semantic-router/pkg/extproc/processor_res_usage.go
+++ b/src/semantic-router/pkg/extproc/processor_res_usage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ratelimit"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 )
 
 type responseUsageMetrics struct {
@@ -60,7 +61,7 @@ func (r *OpenAIRouter) reportNonStreamingUsage(
 	}
 
 	if totalTokens > 0 {
-		recordSessionTurn(ctx, usage)
+		recordSessionTurn(ctx, usage, r.sessionTurnPricing(ctx.RequestModel))
 	}
 
 	if ctx.RequestModel == "" {
@@ -159,14 +160,14 @@ func extractStreamingUsage(ctx *RequestContext) openai.CompletionUsage {
 	return usage
 }
 
-func recordSessionTurnFromStreamingUsage(ctx *RequestContext, usage openai.CompletionUsage) {
+func recordSessionTurnFromStreamingUsage(ctx *RequestContext, usage openai.CompletionUsage, pricing sessiontelemetry.TurnPricing) {
 	if usage.PromptTokens <= 0 && usage.CompletionTokens <= 0 {
 		return
 	}
 	recordSessionTurn(ctx, responseUsageMetrics{
 		promptTokens:     int(usage.PromptTokens),
 		completionTokens: int(usage.CompletionTokens),
-	})
+	}, pricing)
 }
 
 func (r *OpenAIRouter) reportStreamingUsageMetrics(
@@ -181,7 +182,7 @@ func (r *OpenAIRouter) reportStreamingUsageMetrics(
 		})
 	}
 
-	recordSessionTurnFromStreamingUsage(ctx, usage)
+	recordSessionTurnFromStreamingUsage(ctx, usage, r.sessionTurnPricing(ctx.RequestModel))
 
 	if ctx.RequestModel == "" || (usage.PromptTokens == 0 && usage.CompletionTokens == 0) {
 		return

--- a/src/semantic-router/pkg/extproc/session_telemetry.go
+++ b/src/semantic-router/pkg/extproc/session_telemetry.go
@@ -5,7 +5,25 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 )
 
-func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics) {
+// sessionTurnPricing looks up the active pricing for model from the router config
+// and converts it to the sessiontelemetry value type.
+func (r *OpenAIRouter) sessionTurnPricing(model string) sessiontelemetry.TurnPricing {
+	if r.Config == nil {
+		return sessiontelemetry.TurnPricing{}
+	}
+	p, ok := r.Config.GetFullModelPricing(model)
+	if !ok {
+		return sessiontelemetry.TurnPricing{}
+	}
+	return sessiontelemetry.TurnPricing{
+		Currency:         p.Currency,
+		PromptPer1M:      p.PromptPer1M,
+		CompletionPer1M:  p.CompletionPer1M,
+		CachedInputPer1M: p.CachedInputPer1M,
+	}
+}
+
+func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics, pricing sessiontelemetry.TurnPricing) {
 	if ctx == nil || usage.promptTokens+usage.completionTokens <= 0 {
 		return
 	}
@@ -19,6 +37,7 @@ func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics) {
 		Domain:           domain,
 		PromptTokens:     usage.promptTokens,
 		CompletionTokens: usage.completionTokens,
+		Pricing:          pricing,
 	}
 	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.IsResponseAPIRequest {
 		if ctx.ResponseAPICtx.ConversationID == "" {

--- a/src/semantic-router/pkg/observability/metrics/session_cost.go
+++ b/src/semantic-router/pkg/observability/metrics/session_cost.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/consts"
+)
+
+// SessionTurnCost tracks per-turn cost for sessions with pricing configured, labeled by
+// model, VSR domain/category, and currency so non-USD deployments are represented correctly.
+var SessionTurnCost = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "llm_session_turn_cost",
+		Help:    "Distribution of per-turn cost attributed to a logical session (model + domain category + currency). Only recorded when pricing is configured.",
+		Buckets: []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0},
+	},
+	[]string{"model", "domain", "currency"},
+)
+
+// RecordSessionTurnCost records the per-turn cost histogram for sessions with pricing
+// configured. Callers must only invoke this when pricing is active (cost == 0 for a
+// free model is valid; cost == 0 because pricing is absent should not be recorded).
+func RecordSessionTurnCost(model, domain, currency string, cost float64) {
+	if model == "" {
+		model = consts.UnknownLabel
+	}
+	if domain == "" {
+		domain = consts.UnknownLabel
+	}
+	if currency == "" {
+		currency = "USD"
+	}
+	SessionTurnCost.WithLabelValues(model, domain, currency).Observe(cost)
+}

--- a/src/semantic-router/pkg/sessiontelemetry/telemetry.go
+++ b/src/semantic-router/pkg/sessiontelemetry/telemetry.go
@@ -14,6 +14,7 @@ const ttl = 1 * time.Hour
 type turnState struct {
 	cumulativePrompt     int64
 	cumulativeCompletion int64
+	cumulativeCost       float64 // in the currency supplied by TurnPricing.Currency
 	lastSeen             time.Time
 }
 
@@ -50,6 +51,26 @@ type ChatInput struct {
 	Messages []ChatMessage
 }
 
+// TurnPricing carries the active per-1M token prices stamped onto a dispatch log entry.
+// All rates are in Currency (default "USD").
+//
+// isConfigured() returns true when at least one rate is non-zero or Currency is explicitly
+// set (even with zero rates) — the latter supports free/self-hosted models that still need
+// cost=0 and savings attribution. CachedInputPer1M is stamped as log metadata but is not
+// included in the configured check or cost formula until cached token counts are tracked.
+type TurnPricing struct {
+	Currency         string
+	PromptPer1M      float64
+	CompletionPer1M  float64
+	CachedInputPer1M float64 // stamped in log metadata; not applied to cost (cached tokens not yet tracked)
+}
+
+// isConfigured reports whether pricing is active: at least one billable rate is set, or
+// Currency is explicit (covers zero-rate free models that still produce cost=0 telemetry).
+func (p TurnPricing) isConfigured() bool {
+	return p.PromptPer1M != 0 || p.CompletionPer1M != 0 || p.Currency != ""
+}
+
 // TurnParams carries usage and routing context for one completed LLM round-trip.
 type TurnParams struct {
 	RequestID string
@@ -58,6 +79,11 @@ type TurnParams struct {
 
 	PromptTokens     int
 	CompletionTokens int
+
+	// Pricing holds the active per-1M token rates for this dispatch.
+	// When zero, cost fields are omitted from the log event and no cost
+	// histogram observation is recorded.
+	Pricing TurnPricing
 
 	ResponseAPI *ResponseAPIInput
 	Chat        *ChatInput
@@ -87,7 +113,7 @@ func resolve(p TurnParams) (storeKey string, turn int, apiKind string, publicSes
 	return "", 0, "", "", false
 }
 
-// RecordTurn updates cumulative session token state, Prometheus histograms, and emits a structured log event.
+// RecordTurn updates cumulative session token/cost state, Prometheus histograms, and emits a structured log event.
 func RecordTurn(p TurnParams) {
 	if p.PromptTokens+p.CompletionTokens <= 0 {
 		return
@@ -102,6 +128,8 @@ func RecordTurn(p TurnParams) {
 	}
 	domain := normalizeDomain(p.Domain)
 
+	costThisTurn := computeCost(p.PromptTokens, p.CompletionTokens, p.Pricing)
+
 	t := nowFn()
 	mu.Lock()
 	evictLocked(t)
@@ -112,14 +140,24 @@ func RecordTurn(p TurnParams) {
 	}
 	st.cumulativePrompt += int64(p.PromptTokens)
 	st.cumulativeCompletion += int64(p.CompletionTokens)
+	st.cumulativeCost += costThisTurn
 	st.lastSeen = t
 	cumP := st.cumulativePrompt
 	cumC := st.cumulativeCompletion
+	cumCost := st.cumulativeCost
 	mu.Unlock()
 
 	metrics.RecordSessionTurnTokens(model, domain, float64(p.PromptTokens), float64(p.CompletionTokens))
 
-	logging.LogEvent("session_turn_tokens", map[string]interface{}{
+	currency := p.Pricing.Currency
+	if currency == "" {
+		currency = "USD"
+	}
+	if p.Pricing.isConfigured() {
+		metrics.RecordSessionTurnCost(model, domain, currency, costThisTurn)
+	}
+
+	fields := map[string]interface{}{
 		"request_id":                   p.RequestID,
 		"session_id":                   publicSessionID,
 		"turn_number":                  turn,
@@ -131,5 +169,25 @@ func RecordTurn(p TurnParams) {
 		"cumulative_prompt_tokens":     cumP,
 		"cumulative_completion_tokens": cumC,
 		"timestamp":                    t.UTC().Format(time.RFC3339Nano),
-	})
+	}
+	if p.Pricing.isConfigured() {
+		fields["pricing_prompt_per_1m"] = p.Pricing.PromptPer1M
+		fields["pricing_completion_per_1m"] = p.Pricing.CompletionPer1M
+		fields["pricing_cached_input_per_1m"] = p.Pricing.CachedInputPer1M
+		fields["pricing_currency"] = currency
+		fields["cost_this_turn"] = costThisTurn
+		fields["cumulative_cost"] = cumCost
+	}
+	logging.LogEvent("session_turn_tokens", fields)
+}
+
+// computeCost returns the turn cost in the pricing currency given token counts and rates.
+// Only prompt and completion tokens are costed; cached-input tokens are not tracked yet.
+// Returns 0 when pricing is not configured.
+func computeCost(promptTokens, completionTokens int, pricing TurnPricing) float64 {
+	if !pricing.isConfigured() {
+		return 0
+	}
+	return (float64(promptTokens)*pricing.PromptPer1M +
+		float64(completionTokens)*pricing.CompletionPer1M) / 1_000_000.0
 }

--- a/src/semantic-router/pkg/sessiontelemetry/telemetry_test.go
+++ b/src/semantic-router/pkg/sessiontelemetry/telemetry_test.go
@@ -156,3 +156,221 @@ func TestEviction(t *testing.T) {
 	defer mu.Unlock()
 	assert.Len(t, store, 1)
 }
+
+// =====================================================================
+// PR 2 — per-turn pricing metadata and cumulative_cost
+// =====================================================================
+
+func labelHasCurrency(labels []*dto.LabelPair, currency string) bool {
+	for _, l := range labels {
+		if l.GetName() == "currency" && l.GetValue() == currency {
+			return true
+		}
+	}
+	return false
+}
+
+func histogramSampleCountCost(metricName, model, domain, currency string) uint64 {
+	mf, _ := prometheus.DefaultGatherer.Gather()
+	for _, fam := range mf {
+		if fam.GetName() != metricName || fam.GetType() != dto.MetricType_HISTOGRAM {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			labels := m.GetLabel()
+			if !labelsMatchModelDomain(labels, model, domain) || !labelHasCurrency(labels, currency) {
+				continue
+			}
+			h := m.GetHistogram()
+			if h == nil || h.SampleCount == nil {
+				continue
+			}
+			return h.GetSampleCount()
+		}
+	}
+	return 0
+}
+
+func TestRecordTurn_ChatCompletions_PricingCostAccumulation(t *testing.T) {
+	ResetForTesting()
+	t.Cleanup(ResetForTesting)
+
+	model := "gpt-cost-test"
+	domain := "finance"
+
+	pricing := TurnPricing{
+		Currency:        "USD",
+		PromptPer1M:     5.0,
+		CompletionPer1M: 15.0,
+	}
+
+	baseParams := TurnParams{
+		RequestID:        "r1",
+		Model:            model,
+		Domain:           domain,
+		PromptTokens:     1000,
+		CompletionTokens: 500,
+		Pricing:          pricing,
+		Chat: &ChatInput{
+			UserID:   "user_cost",
+			Messages: []ChatMessage{{Role: "user", Content: "cost-thread"}},
+		},
+	}
+
+	beforeCost := histogramSampleCountCost("llm_session_turn_cost", model, domain, "USD")
+
+	RecordTurn(baseParams)
+
+	// turn 2: more tokens, same session
+	baseParams.RequestID = "r2"
+	baseParams.PromptTokens = 2000
+	baseParams.CompletionTokens = 1000
+	RecordTurn(baseParams)
+
+	afterCost := histogramSampleCountCost("llm_session_turn_cost", model, domain, "USD")
+	assert.Equal(t, uint64(2), afterCost-beforeCost, "expected two cost histogram observations")
+
+	mu.Lock()
+	require.Len(t, store, 1)
+	var st *turnState
+	for _, v := range store {
+		st = v
+		break
+	}
+	mu.Unlock()
+	require.NotNil(t, st)
+
+	// turn1 cost: (1000*5 + 500*15)/1e6 = 0.01250
+	// turn2 cost: (2000*5 + 1000*15)/1e6 = 0.02500
+	// cumulative: 0.03750
+	const wantCumCost = (1000*5.0+500*15.0)/1_000_000.0 + (2000*5.0+1000*15.0)/1_000_000.0
+	assert.InDelta(t, wantCumCost, st.cumulativeCost, 1e-9)
+}
+
+func TestRecordTurn_ResponseAPI_PricingCostAccumulation(t *testing.T) {
+	ResetForTesting()
+	t.Cleanup(ResetForTesting)
+
+	model := "resp-cost-model"
+	domain := "coding"
+
+	pricing := TurnPricing{
+		Currency:         "USD",
+		PromptPer1M:      3.0,
+		CompletionPer1M:  12.0,
+		CachedInputPer1M: 1.5,
+	}
+
+	RecordTurn(TurnParams{
+		RequestID:        "r1",
+		Model:            model,
+		Domain:           domain,
+		PromptTokens:     500,
+		CompletionTokens: 200,
+		Pricing:          pricing,
+		ResponseAPI: &ResponseAPIInput{
+			ConversationID: "conv_pricing_1",
+			HistoryLen:     0,
+		},
+	})
+	RecordTurn(TurnParams{
+		RequestID:        "r2",
+		Model:            model,
+		Domain:           domain,
+		PromptTokens:     800,
+		CompletionTokens: 300,
+		Pricing:          pricing,
+		ResponseAPI: &ResponseAPIInput{
+			ConversationID: "conv_pricing_1",
+			HistoryLen:     2,
+		},
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	st, ok := store["respapi:conv_pricing_1"]
+	require.True(t, ok)
+
+	// cumulative cost: ((500*3+200*12) + (800*3+300*12)) / 1e6
+	wantCost := (500*3.0+200*12.0)/1_000_000.0 + (800*3.0+300*12.0)/1_000_000.0
+	assert.InDelta(t, wantCost, st.cumulativeCost, 1e-9)
+}
+
+func TestRecordTurn_NoPricingDoesNotRecordCostHistogram(t *testing.T) {
+	ResetForTesting()
+	t.Cleanup(ResetForTesting)
+
+	model := "no-price-model"
+	domain := "unknown"
+
+	before := histogramSampleCountCost("llm_session_turn_cost", model, domain, "USD")
+
+	RecordTurn(TurnParams{
+		RequestID:        "r1",
+		Model:            model,
+		Domain:           domain,
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		// Pricing intentionally omitted
+		Chat: &ChatInput{
+			UserID:   "u_noprice",
+			Messages: []ChatMessage{{Role: "user", Content: "no-price-thread"}},
+		},
+	})
+
+	after := histogramSampleCountCost("llm_session_turn_cost", model, domain, "USD")
+	assert.Equal(t, before, after, "no cost observation should be recorded when pricing is not configured")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, st := range store {
+		assert.InDelta(t, 0.0, st.cumulativeCost, 1e-12)
+	}
+}
+
+func TestComputeCost(t *testing.T) {
+	tests := []struct {
+		name     string
+		prompt   int
+		compl    int
+		pricing  TurnPricing
+		wantCost float64
+	}{
+		{
+			name:     "zero pricing returns zero cost",
+			prompt:   1000,
+			compl:    500,
+			pricing:  TurnPricing{},
+			wantCost: 0,
+		},
+		{
+			name:    "standard pricing",
+			prompt:  1000,
+			compl:   500,
+			pricing: TurnPricing{Currency: "USD", PromptPer1M: 5.0, CompletionPer1M: 15.0},
+			// (1000*5 + 500*15) / 1e6 = 0.0125
+			wantCost: 0.0125,
+		},
+		{
+			name:     "only completion pricing",
+			prompt:   0,
+			compl:    1000,
+			pricing:  TurnPricing{Currency: "USD", CompletionPer1M: 10.0},
+			wantCost: 0.01,
+		},
+		{
+			name:     "free model with explicit currency",
+			prompt:   5000,
+			compl:    2000,
+			pricing:  TurnPricing{Currency: "USD", PromptPer1M: 0, CompletionPer1M: 0},
+			wantCost: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeCost(tc.prompt, tc.compl, tc.pricing)
+			assert.InDelta(t, tc.wantCost, got, 1e-9)
+		})
+	}
+}


### PR DESCRIPTION
FIX #1742 
## Purpose

- What does this PR change?  Add per turn and cumulative pricing metrics
- Why is this change needed? 
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
