### PR TITLE
[Router][Bugfix]: parseBestMatch select best match from all KNN candidates

### DIFF
--- a/src/semantic-router/pkg/cache/valkey_cache_helpers.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_helpers.go
@@ -104,16 +104,12 @@ type searchMatch struct {
 // Returns nil when no valid match is found.
 func parseBestMatch(searchResult interface{}) *searchMatch {
 	resultsArray, ok := searchResult.([]interface{})
-	if !ok || len(resultsArray) < 1 {
+	if !ok || len(resultsArray) < 2 {
 		return nil
 	}
 
 	totalResults, ok := resultsArray[0].(int64)
 	if !ok || totalResults == 0 {
-		return nil
-	}
-
-	if len(resultsArray) < 2 {
 		return nil
 	}
 

--- a/src/semantic-router/pkg/cache/valkey_cache_helpers.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_helpers.go
@@ -123,29 +123,37 @@ func parseBestMatch(searchResult interface{}) *searchMatch {
 		return nil
 	}
 
+	// FT.SEARCH returns results ordered by distance, but Go map iteration
+	// in the valkey-glide response loses that ordering. Iterate all docs and
+	// pick the best one.
+	var best *searchMatch
 	for _, docValue := range docMap {
 		fieldsMap, mapOk := docValue.(map[string]interface{})
 		if !mapOk {
 			logging.Debugf("ValkeyCache.FindSimilarWithThreshold: invalid fields format, expected map, got %T", docValue)
-			return nil
+			continue
 		}
 
-		match := &searchMatch{}
 		distanceVal, exists := fieldsMap["vector_distance"]
 		if !exists {
-			return nil
+			continue
 		}
 
-		if _, err := fmt.Sscanf(fmt.Sprint(distanceVal), "%f", &match.distance); err != nil {
+		var distance float64
+		if _, err := fmt.Sscanf(fmt.Sprint(distanceVal), "%f", &distance); err != nil {
 			logging.Debugf("ValkeyCache.FindSimilarWithThreshold: failed to parse distance value: %v", err)
-			return nil
+			continue
 		}
 
-		match.responseBody = fieldsMap["response_body"]
-		return match // Only process the first (best) document
+		if best == nil || distance < best.distance {
+			best = &searchMatch{
+				distance:     distance,
+				responseBody: fieldsMap["response_body"],
+			}
+		}
 	}
 
-	return nil
+	return best
 }
 
 // escapeTagValue escapes punctuation and whitespace in a string so it can be

--- a/src/semantic-router/pkg/cache/valkey_cache_helpers_test.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_helpers_test.go
@@ -1,0 +1,81 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBestMatch_SelectsSmallestDistance(t *testing.T) {
+	// Simulate a FT.SEARCH result with 3 documents.
+	// Go map iteration order is random, so the function must
+	// always return the doc with the smallest distance.
+	searchResult := []interface{}{
+		int64(3),
+		map[string]interface{}{
+			"cache:doc1": map[string]interface{}{
+				"vector_distance": "0.50",
+				"response_body":   "resp_worst",
+			},
+			"cache:doc2": map[string]interface{}{
+				"vector_distance": "0.05",
+				"response_body":   "resp_best",
+			},
+			"cache:doc3": map[string]interface{}{
+				"vector_distance": "0.30",
+				"response_body":   "resp_mid",
+			},
+		},
+	}
+
+	// Run multiple times to defeat random map iteration order.
+	for i := 0; i < 50; i++ {
+		match := parseBestMatch(searchResult)
+		assert.NotNil(t, match)
+		assert.InDelta(t, 0.05, match.distance, 1e-9)
+		assert.Equal(t, "resp_best", match.responseBody)
+	}
+}
+
+func TestParseBestMatch_SingleDoc(t *testing.T) {
+	searchResult := []interface{}{
+		int64(1),
+		map[string]interface{}{
+			"cache:only": map[string]interface{}{
+				"vector_distance": "0.12",
+				"response_body":   "only_resp",
+			},
+		},
+	}
+
+	match := parseBestMatch(searchResult)
+	assert.NotNil(t, match)
+	assert.InDelta(t, 0.12, match.distance, 1e-9)
+	assert.Equal(t, "only_resp", match.responseBody)
+}
+
+func TestParseBestMatch_EmptyResults(t *testing.T) {
+	assert.Nil(t, parseBestMatch(nil))
+	assert.Nil(t, parseBestMatch([]interface{}{int64(0)}))
+	assert.Nil(t, parseBestMatch([]interface{}{}))
+}
+
+func TestParseBestMatch_SkipsInvalidDocs(t *testing.T) {
+	searchResult := []interface{}{
+		int64(2),
+		map[string]interface{}{
+			"cache:bad": "not_a_map",
+			"cache:good": map[string]interface{}{
+				"vector_distance": "0.10",
+				"response_body":   "good_resp",
+			},
+		},
+	}
+
+	match := parseBestMatch(searchResult)
+	assert.NotNil(t, match)
+	assert.InDelta(t, 0.10, match.distance, 1e-9)
+	assert.Equal(t, "good_resp", match.responseBody)
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
`parseBestMatch` relies on Go map iteration order to pick the "best" KNN result, but Go maps have randomized iteration order. When `Search.TopK > 1`, this returns a random candidate instead of the closest match, causing false cache misses, non-deterministic behavior, and inaccurate similarity metrics.


## Purpose

- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Router` 

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
