### PR TITLE
[Router] Add `SESSION_STATE` declarations to the Routing DSL

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -467,6 +467,22 @@ routing:
           - name: support_escalated
             gte: 0.45
 
+  session_states:
+    - name: session_routing
+      fields:
+        - name: turn_number
+          type: int
+        - name: current_model
+          type: string
+        - name: cumulative_cost_usd
+          type: float
+        - name: retry_count_ema
+          type: float
+        - name: quality_score_ema
+          type: float
+        - name: kv_cache_warm
+          type: float
+
   decisions:
     - name: static_business_route
       description: Static fallback for standard business traffic.

--- a/src/semantic-router/pkg/config/canonical_config.go
+++ b/src/semantic-router/pkg/config/canonical_config.go
@@ -20,10 +20,11 @@ type CanonicalConfig struct {
 
 // CanonicalRouting contains the DSL-owned routing surface.
 type CanonicalRouting struct {
-	ModelCards  []RoutingModel       `yaml:"modelCards,omitempty"`
-	Signals     CanonicalSignals     `yaml:"signals,omitempty"`
-	Projections CanonicalProjections `yaml:"projections,omitempty"`
-	Decisions   []Decision           `yaml:"decisions,omitempty"`
+	ModelCards    []RoutingModel       `yaml:"modelCards,omitempty"`
+	Signals       CanonicalSignals     `yaml:"signals,omitempty"`
+	Projections   CanonicalProjections `yaml:"projections,omitempty"`
+	Decisions     []Decision           `yaml:"decisions,omitempty"`
+	SessionStates []SessionStateConfig `yaml:"session_states,omitempty"`
 }
 
 // CanonicalSignals groups routing signals under routing.signals.
@@ -105,6 +106,7 @@ func applyCanonicalRoutingState(cfg *RouterConfig, canonical *CanonicalConfig) {
 	ensureModelRefDefaults(cfg.Decisions)
 	cfg.Signals = normalizeSignals(canonical.Routing.Signals, cfg.Decisions)
 	cfg.Projections = normalizeProjections(canonical.Routing.Projections)
+	cfg.SessionStates = append([]SessionStateConfig(nil), canonical.Routing.SessionStates...)
 	cfg.ModelConfig = make(map[string]ModelParams)
 
 	for _, model := range canonicalRoutingModels(canonical.Routing) {

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -46,10 +46,11 @@ func CanonicalRoutingFromRouterConfig(cfg *RouterConfig) CanonicalRouting {
 	}
 
 	return CanonicalRouting{
-		ModelCards:  routingModelsFromRouterConfig(cfg),
-		Signals:     canonicalSignalsFromRouterConfig(cfg),
-		Projections: canonicalProjectionsFromRouterConfig(cfg),
-		Decisions:   copyDecisions(cfg.Decisions),
+		ModelCards:    routingModelsFromRouterConfig(cfg),
+		Signals:       canonicalSignalsFromRouterConfig(cfg),
+		Projections:   canonicalProjectionsFromRouterConfig(cfg),
+		Decisions:     copyDecisions(cfg.Decisions),
+		SessionStates: append([]SessionStateConfig(nil), cfg.SessionStates...),
 	}
 }
 

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -185,6 +185,7 @@ type IntelligentRouting struct {
 	Strategy        string               `yaml:"strategy,omitempty"`
 	ModelSelection  ModelSelectionConfig `yaml:"model_selection,omitempty"`
 	ReasoningConfig `yaml:",inline"`
+	SessionStates   []SessionStateConfig `yaml:"session_states,omitempty"`
 }
 
 // BackendModels captures configured backend endpoints and model metadata.

--- a/src/semantic-router/pkg/config/reference_config_public_surface_test.go
+++ b/src/semantic-router/pkg/config/reference_config_public_surface_test.go
@@ -51,6 +51,17 @@ func assertReferenceConfigRoutingCoverage(t testingT, root map[string]interface{
 	assertReferenceConfigSignalCoverage(t, mustMapAt(t, routing, "signals"))
 	assertReferenceConfigProjectionCoverage(t, mustMapAt(t, routing, "projections"))
 	assertReferenceConfigDecisionCoverage(t, mustSliceAt(t, routing, "decisions"))
+	assertReferenceConfigSessionStateCoverage(t, mustSliceAt(t, routing, "session_states"))
+}
+
+func assertReferenceConfigSessionStateCoverage(t testingT, sessionStates []interface{}) {
+	assertSliceUnionCoversStructFields(t, sessionStates, reflect.TypeOf(SessionStateConfig{}), "routing.session_states")
+	assertSliceUnionCoversStructFields(
+		t,
+		collectNestedSliceItems(t, sessionStates, "fields", "routing.session_states"),
+		reflect.TypeOf(SessionStateFieldConfig{}),
+		"routing.session_states[].fields",
+	)
 }
 
 func assertReferenceConfigSignalCoverage(t testingT, signals map[string]interface{}) {

--- a/src/semantic-router/pkg/config/session_state_config.go
+++ b/src/semantic-router/pkg/config/session_state_config.go
@@ -1,0 +1,14 @@
+package config
+
+// SessionStateFieldConfig is one typed field inside a SESSION_STATE declaration.
+type SessionStateFieldConfig struct {
+	Name     string `yaml:"name"`
+	TypeName string `yaml:"type"`
+}
+
+// SessionStateConfig represents a SESSION_STATE declaration, naming the
+// cross-turn fields that session-aware routing policies can reference.
+type SessionStateConfig struct {
+	Name   string                    `yaml:"name"`
+	Fields []SessionStateFieldConfig `yaml:"fields,omitempty"`
+}

--- a/src/semantic-router/pkg/dsl/ast.go
+++ b/src/semantic-router/pkg/dsl/ast.go
@@ -39,6 +39,7 @@ type rawTopLevel struct {
 	Model        *rawModelDecl        `parser:"| @@"`
 	Plugin       *rawPluginDecl       `parser:"| @@"`
 	TestBlock    *rawTestBlockDecl    `parser:"| @@"`
+	SessionState *rawSessionStateDecl `parser:"| @@"`
 }
 
 // rawTestBlockDecl: TEST <name> { entries... }
@@ -53,6 +54,13 @@ type rawTestEntryDecl struct {
 	Pos       lexer.Position
 	Query     string `parser:"@String"`
 	RouteName string `parser:"Arrow @(Ident | String)"`
+}
+
+// rawSessionStateDecl: SESSION_STATE <name> { fields... }
+type rawSessionStateDecl struct {
+	Pos    lexer.Position
+	Name   string        `parser:"'SESSION_STATE' @(Ident | String)"`
+	Fields []*FieldEntry `parser:"'{' @@* '}'"`
 }
 
 // rawSignalDecl: SIGNAL <type> <name> { fields... }
@@ -247,6 +255,20 @@ type Program struct {
 	Models               []*ModelDecl
 	Plugins              []*PluginDecl
 	TestBlocks           []*TestBlockDecl
+	SessionStates        []*SessionStateDecl
+}
+
+// SessionStateField is one typed field in a SessionStateDecl.
+type SessionStateField struct {
+	Name     string
+	TypeName string // "int", "string", or "float"
+}
+
+// SessionStateDecl represents a SESSION_STATE top-level declaration.
+type SessionStateDecl struct {
+	Name   string
+	Fields []SessionStateField
+	Pos    Position
 }
 
 // ProjectionPartitionDecl declares a mutually exclusive partition of signals.

--- a/src/semantic-router/pkg/dsl/compiler.go
+++ b/src/semantic-router/pkg/dsl/compiler.go
@@ -59,8 +59,24 @@ func (c *Compiler) compile() {
 	// 5. Compile top-level model catalog
 	c.compileModels()
 
-	// 6. Compile routes (decisions)
+	// 6. Compile session state declarations
+	c.compileSessionStates()
+
+	// 7. Compile routes (decisions)
 	c.compileRoutes()
+}
+
+func (c *Compiler) compileSessionStates() {
+	for _, decl := range c.prog.SessionStates {
+		ss := config.SessionStateConfig{Name: decl.Name}
+		for _, f := range decl.Fields {
+			ss.Fields = append(ss.Fields, config.SessionStateFieldConfig{
+				Name:     f.Name,
+				TypeName: f.TypeName,
+			})
+		}
+		c.config.SessionStates = append(c.config.SessionStates, ss)
+	}
 }
 
 func (c *Compiler) compileProjectionPartitions() {

--- a/src/semantic-router/pkg/dsl/decompiler.go
+++ b/src/semantic-router/pkg/dsl/decompiler.go
@@ -32,6 +32,18 @@ type pluginTemplate struct {
 	usageCount int
 }
 
+// ---------- Session State Decompilation ----------
+
+func (d *decompiler) decompileSessionStates() {
+	for _, ss := range d.cfg.SessionStates {
+		d.write("SESSION_STATE %s {\n", quoteName(ss.Name))
+		for _, f := range ss.Fields {
+			d.write("  %s: %s\n", f.Name, f.TypeName)
+		}
+		d.write("}\n\n")
+	}
+}
+
 // ---------- Signal Decompilation ----------
 
 func (d *decompiler) decompileSignals() {

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -5562,3 +5562,153 @@ func assertConflictFreeRoundTrip(t *testing.T, cfg *config.RouterConfig) {
 		t.Errorf("re-parsed projection partitions = %d, want 1", len(prog2.ProjectionPartitions))
 	}
 }
+
+// ---------- SESSION_STATE Tests ----------
+
+const sessionStateDSL = `SESSION_STATE session_routing {
+  turn_number: int
+  current_model: string
+  cumulative_cost_usd: float
+  retry_count_ema: float
+  quality_score_ema: float
+  kv_cache_warm: float
+}`
+
+func TestCompileSessionState(t *testing.T) {
+	cfg, errs := Compile(sessionStateDSL)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.SessionStates) != 1 {
+		t.Fatalf("expected 1 SessionState in config, got %d", len(cfg.SessionStates))
+	}
+	ss := cfg.SessionStates[0]
+	if ss.Name != "session_routing" {
+		t.Errorf("name: expected %q, got %q", "session_routing", ss.Name)
+	}
+	wantFields := []struct{ name, typeName string }{
+		{"turn_number", "int"},
+		{"current_model", "string"},
+		{"cumulative_cost_usd", "float"},
+		{"retry_count_ema", "float"},
+		{"quality_score_ema", "float"},
+		{"kv_cache_warm", "float"},
+	}
+	if len(ss.Fields) != len(wantFields) {
+		t.Fatalf("expected %d fields, got %d", len(wantFields), len(ss.Fields))
+	}
+	for i, w := range wantFields {
+		if ss.Fields[i].Name != w.name || ss.Fields[i].TypeName != w.typeName {
+			t.Errorf("field[%d]: expected {%s: %s}, got {%s: %s}",
+				i, w.name, w.typeName, ss.Fields[i].Name, ss.Fields[i].TypeName)
+		}
+	}
+}
+
+func TestSessionStateRoundTrip(t *testing.T) {
+	cfg, errs := Compile(sessionStateDSL)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	dslText, err := DecompileRouting(cfg)
+	if err != nil {
+		t.Fatalf("decompile error: %v", err)
+	}
+	if !strings.Contains(dslText, "SESSION_STATE session_routing") {
+		t.Errorf("round-trip lost SESSION_STATE declaration\nDSL:\n%s", dslText)
+	}
+	// Types must survive as bare identifiers, not quoted strings.
+	for _, typeName := range []string{"int", "string", "float"} {
+		if !strings.Contains(dslText, ": "+typeName) {
+			t.Errorf("round-trip DSL missing bare type %q\nDSL:\n%s", typeName, dslText)
+		}
+	}
+	prog2, errs2 := Parse(dslText)
+	if len(errs2) > 0 {
+		t.Fatalf("re-parse errors after round-trip: %v\nDSL:\n%s", errs2, dslText)
+	}
+	if len(prog2.SessionStates) != 1 {
+		t.Fatalf("re-parsed session states = %d, want 1\nDSL:\n%s", len(prog2.SessionStates), dslText)
+	}
+	if prog2.SessionStates[0].Name != "session_routing" {
+		t.Errorf("round-trip name: expected %q, got %q", "session_routing", prog2.SessionStates[0].Name)
+	}
+}
+
+func TestSessionStateRoundTripAST(t *testing.T) {
+	cfg, errs := Compile(sessionStateDSL)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	prog := DecompileToAST(cfg)
+	if len(prog.SessionStates) != 1 {
+		t.Fatalf("expected 1 SessionState in AST round-trip, got %d", len(prog.SessionStates))
+	}
+	ss := prog.SessionStates[0]
+	if ss.Name != "session_routing" {
+		t.Errorf("AST round-trip name: expected %q, got %q", "session_routing", ss.Name)
+	}
+	if len(ss.Fields) != 6 {
+		t.Errorf("AST round-trip field count: expected 6, got %d", len(ss.Fields))
+	}
+}
+
+func TestValidateSessionStateDuplicateName(t *testing.T) {
+	input := `
+SESSION_STATE foo { x: int }
+SESSION_STATE foo { y: string }
+`
+	diags, _ := Validate(input)
+	found := false
+	for _, d := range diags {
+		if d.Level == DiagConstraint && strings.Contains(d.Message, "duplicate") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DiagConstraint for duplicate SESSION_STATE name, got: %v", diags)
+	}
+}
+
+func TestValidateSessionStateInvalidType(t *testing.T) {
+	input := `SESSION_STATE foo { x: bool }`
+	diags, _ := Validate(input)
+	found := false
+	for _, d := range diags {
+		if d.Level == DiagConstraint &&
+			strings.Contains(d.Message, "invalid type") &&
+			strings.Contains(d.Message, "bool") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DiagConstraint for invalid type %q, got: %v", "bool", diags)
+	}
+}
+
+func TestValidateSessionStateDuplicateField(t *testing.T) {
+	input := `SESSION_STATE foo { x: int, x: string }`
+	diags, _ := Validate(input)
+	found := false
+	for _, d := range diags {
+		if d.Level == DiagConstraint && strings.Contains(d.Message, "duplicate field") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DiagConstraint for duplicate field name, got: %v", diags)
+	}
+}
+
+func TestValidateSessionStateValidTypes(t *testing.T) {
+	input := `SESSION_STATE ok { a: int, b: string, c: float }`
+	diags, _ := Validate(input)
+	for _, d := range diags {
+		if d.Level == DiagConstraint {
+			t.Errorf("unexpected constraint diagnostic for valid types: %v", d)
+		}
+	}
+}

--- a/src/semantic-router/pkg/dsl/parser.go
+++ b/src/semantic-router/pkg/dsl/parser.go
@@ -75,6 +75,7 @@ func Parse(input string) (*Program, []error) {
 		prog.Models = append(prog.Models, resolved.Models...)
 		prog.Plugins = append(prog.Plugins, resolved.Plugins...)
 		prog.TestBlocks = append(prog.TestBlocks, resolved.TestBlocks...)
+		prog.SessionStates = append(prog.SessionStates, resolved.SessionStates...)
 		allErrors = append(allErrors, lowerErrs...)
 	}
 
@@ -91,7 +92,7 @@ func splitTopLevelBlocks(input string) []string {
 	var blocks []string
 	depth := 0
 	start := 0
-	keywords := []string{"DECISION_TREE", "PROJECTION", "SIGNAL", "ROUTE", "MODEL", "PLUGIN", "TEST"}
+	keywords := []string{"SESSION_STATE", "DECISION_TREE", "PROJECTION", "SIGNAL", "ROUTE", "MODEL", "PLUGIN", "TEST"}
 
 	for i := 0; i < len(input); i++ {
 		ch := input[i]
@@ -181,6 +182,8 @@ func rawToProgram(raw *rawProgram) (*Program, []error) {
 			prog.Plugins = append(prog.Plugins, rawToPlugin(entry.Plugin))
 		case entry.TestBlock != nil:
 			prog.TestBlocks = append(prog.TestBlocks, rawToTestBlock(entry.TestBlock))
+		case entry.SessionState != nil:
+			prog.SessionStates = append(prog.SessionStates, rawToSessionState(entry.SessionState))
 		}
 	}
 	if hasDirectRoutes && treeCount > 0 {
@@ -340,6 +343,30 @@ func rawToTestBlock(r *rawTestBlockDecl) *TestBlockDecl {
 		})
 	}
 	return tb
+}
+
+func rawToSessionState(r *rawSessionStateDecl) *SessionStateDecl {
+	decl := &SessionStateDecl{
+		Name: unquoteIdent(r.Name),
+		Pos:  posFromLexer(r.Pos),
+	}
+	for _, entry := range r.Fields {
+		if entry == nil || entry.Value == nil {
+			continue
+		}
+		typeName := ""
+		// Bare identifiers (int, string, float) arrive via Val.BareStr.
+		if entry.Value.BareStr != nil {
+			typeName = *entry.Value.BareStr
+		} else if entry.Value.Str != nil {
+			typeName = unquote(*entry.Value.Str)
+		}
+		decl.Fields = append(decl.Fields, SessionStateField{
+			Name:     entry.Key,
+			TypeName: typeName,
+		})
+	}
+	return decl
 }
 
 func rawToSignal(r *rawSignalDecl) *SignalDecl {

--- a/src/semantic-router/pkg/dsl/routing_contract.go
+++ b/src/semantic-router/pkg/dsl/routing_contract.go
@@ -41,6 +41,7 @@ func DecompileRouting(cfg *config.RouterConfig) (string, error) {
 	d.extractPluginTemplates()
 
 	if len(cfg.SessionStates) > 0 {
+		d.writeSection("SESSION_STATES")
 		d.decompileSessionStates()
 	}
 

--- a/src/semantic-router/pkg/dsl/routing_contract.go
+++ b/src/semantic-router/pkg/dsl/routing_contract.go
@@ -40,6 +40,10 @@ func DecompileRouting(cfg *config.RouterConfig) (string, error) {
 	d.pluginTemplates = make(map[string]*pluginTemplate)
 	d.extractPluginTemplates()
 
+	if len(cfg.SessionStates) > 0 {
+		d.decompileSessionStates()
+	}
+
 	d.writeSection("SIGNALS")
 	d.decompileSignals()
 
@@ -64,10 +68,24 @@ func DecompileRouting(cfg *config.RouterConfig) (string, error) {
 func DecompileRoutingToAST(cfg *config.RouterConfig) *Program {
 	d := &decompiler{cfg: cfg}
 	prog := &Program{}
+	d.appendSessionStatesToProgram(prog)
 	d.appendSignalsToProgram(prog)
 	d.appendModelsToProgram(prog)
 	d.appendRoutesToProgram(prog)
 	return prog
+}
+
+func (d *decompiler) appendSessionStatesToProgram(prog *Program) {
+	for _, ss := range d.cfg.SessionStates {
+		decl := &SessionStateDecl{Name: ss.Name}
+		for _, f := range ss.Fields {
+			decl.Fields = append(decl.Fields, SessionStateField{
+				Name:     f.Name,
+				TypeName: f.TypeName,
+			})
+		}
+		prog.SessionStates = append(prog.SessionStates, decl)
+	}
 }
 
 func (d *decompiler) appendSignalsToProgram(prog *Program) {

--- a/src/semantic-router/pkg/dsl/validator_conflicts.go
+++ b/src/semantic-router/pkg/dsl/validator_conflicts.go
@@ -17,6 +17,47 @@ func (v *Validator) checkConflicts() {
 	v.checkProjections()
 	v.checkTestBlocks()
 	v.checkTierConstraints()
+	v.checkSessionStates()
+}
+
+// checkSessionStates validates SESSION_STATE declarations for duplicate names,
+// invalid field types, duplicate field names, and empty names.
+func (v *Validator) checkSessionStates() {
+	seen := make(map[string]bool)
+	validTypes := map[string]bool{"int": true, "string": true, "float": true}
+
+	for _, ss := range v.prog.SessionStates {
+		if ss.Name == "" {
+			v.addDiag(DiagConstraint, ss.Pos, "SESSION_STATE: name cannot be empty", nil)
+			continue
+		}
+		if seen[ss.Name] {
+			v.addDiag(DiagConstraint, ss.Pos,
+				fmt.Sprintf("SESSION_STATE %q: duplicate declaration name", ss.Name), nil)
+			continue
+		}
+		seen[ss.Name] = true
+
+		fieldsSeen := make(map[string]bool)
+		for _, f := range ss.Fields {
+			if f.Name == "" {
+				v.addDiag(DiagConstraint, ss.Pos,
+					fmt.Sprintf("SESSION_STATE %q: field name cannot be empty", ss.Name), nil)
+				continue
+			}
+			if fieldsSeen[f.Name] {
+				v.addDiag(DiagConstraint, ss.Pos,
+					fmt.Sprintf("SESSION_STATE %q: duplicate field name %q", ss.Name, f.Name), nil)
+				continue
+			}
+			fieldsSeen[f.Name] = true
+			if !validTypes[f.TypeName] {
+				v.addDiag(DiagConstraint, ss.Pos,
+					fmt.Sprintf("SESSION_STATE %q: field %q has invalid type %q (supported: int, string, float)",
+						ss.Name, f.Name, f.TypeName), nil)
+			}
+		}
+	}
 }
 
 // checkDomainSignalOverlap detects MMLU category strings shared by two or more


### PR DESCRIPTION
<!-- markdownlint-disable -->

Closes #1744

## Purpose

- What does this PR change?

Add SESSION_STATE declarations to the routing DSL

- Why is this change needed?

So session-aware policies can reference named cross-turn state instead of ad hoc runtime fields.

- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

`Router`

## Test Plan

- What commands, checks, or manual steps should reviewers use?

```
make agent-report ENV=cpu CHANGED_FILES="src/semantic-router/pkg/config/canonical_config.go,src/semantic-router/pkg/config/canonical_export.go,src/semantic-router/pkg/config/config.go,src/semantic-router/pkg/config/reference_config_public_surface_test.go,src/semantic-router/pkg/config/session_state_config.go,src/semantic-router/pkg/dsl/ast.go,src/semantic-router/pkg/dsl/compiler.go,src/semantic-router/pkg/dsl/decompiler.go,src/semantic-router/pkg/dsl/dsl_test.go,src/semantic-router/pkg/dsl/parser.go,src/semantic-router/pkg/dsl/routing_contract.go,src/semantic-router/pkg/dsl/validator_conflicts.go"
make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/config/canonical_config.go,src/semantic-router/pkg/config/canonical_export.go,src/semantic-router/pkg/config/config.go,src/semantic-router/pkg/config/reference_config_public_surface_test.go,src/semantic-router/pkg/config/session_state_config.go,src/semantic-router/pkg/dsl/ast.go,src/semantic-router/pkg/dsl/compiler.go,src/semantic-router/pkg/dsl/decompiler.go,src/semantic-router/pkg/dsl/dsl_test.go,src/semantic-router/pkg/dsl/parser.go,src/semantic-router/pkg/dsl/routing_contract.go,src/semantic-router/pkg/dsl/validator_conflicts.go"
make test-semantic-router
```

- Why is this validation sufficient for the affected module(s)?

This PR only adds initial DSL support for session states. It does not add any useful user-facing value yet, and instead preps for future PRs to provide that value. Unit testing should be enough.

## Test Result

- What were the actual results?

It all passes.

- Any follow-up risks, gaps, or blockers?

N/A

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
