### PR TITLE
[Router] Add DSL recipe for Session State

### DIFF
--- a/deploy/recipes/session-state.dsl
+++ b/deploy/recipes/session-state.dsl
@@ -1,0 +1,23 @@
+# =============================================================================
+# SESSION STATE SCHEMA RECIPE
+# =============================================================================
+
+SESSION_STATE session_routing {
+  # Conversation turn counter — incremented by the router each turn.
+  turn_number: int
+
+  # Name of the model that served the most recent assistant turn.
+  current_model: string
+
+  # Accumulated spend for this session in USD, updated after each turn.
+  cumulative_cost_usd: float
+
+  # Exponential moving average of per-turn cost; tracks spend momentum.
+  retry_count_ema: float
+
+  # Exponential moving average of quality scores from the eval pipeline.
+  quality_score_ema: float
+
+  # Fraction of the KV cache that was warm on the most recent turn (0–1).
+  kv_cache_warm: float
+}

--- a/deploy/recipes/session-state.yaml
+++ b/deploy/recipes/session-state.yaml
@@ -1,0 +1,16 @@
+routing:
+  session_states:
+    - name: session_routing
+      fields:
+        - name: turn_number
+          type: int
+        - name: current_model
+          type: string
+        - name: cumulative_cost_usd
+          type: float
+        - name: retry_count_ema
+          type: float
+        - name: quality_score_ema
+          type: float
+        - name: kv_cache_warm
+          type: float

--- a/src/semantic-router/pkg/dsl/maintained_asset_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/maintained_asset_roundtrip_test.go
@@ -374,6 +374,29 @@ func ruleTreeContainsNegatedSignal(node *config.RuleCombination, signalType stri
 	return ruleTreeContainsSignal(node, false, signalType, name)
 }
 
+func TestMaintainedSessionStateRecipeAssetsStayInSync(t *testing.T) {
+	dslPath := filepath.Join("..", "..", "..", "..", "deploy", "recipes", "session-state.dsl")
+	yamlPath := filepath.Join("..", "..", "..", "..", "deploy", "recipes", "session-state.yaml")
+
+	dslData, err := os.ReadFile(dslPath)
+	if err != nil {
+		t.Fatalf("failed to read session-state.dsl: %v", err)
+	}
+	want, errs := Compile(string(dslData))
+	if len(errs) > 0 {
+		t.Fatalf("Compile errors for session-state.dsl: %v", errs)
+	}
+
+	got, err := config.Parse(yamlPath)
+	if err != nil {
+		t.Fatalf("failed to parse session-state.yaml: %v", err)
+	}
+
+	if !reflect.DeepEqual(got.SessionStates, want.SessionStates) {
+		t.Fatalf("session-state DSL/YAML assets diverged\nwant: %+v\ngot:  %+v", want.SessionStates, got.SessionStates)
+	}
+}
+
 func ruleTreeContainsSignal(node *config.RuleCombination, negated bool, signalType string, name string) bool {
 	if node == nil {
 		return false


### PR DESCRIPTION
Closes #1764

## Purpose

- What does this PR change?

Follow up to https://github.com/vllm-project/semantic-router/pull/1763, to add a session state recipe as requested in https://github.com/vllm-project/semantic-router/pull/1763#discussion_r3068461608

- Why is this change needed?

Validation

- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

Router

## Test Plan

- What commands, checks, or manual steps should reviewers use?

Validate the new DSL recipe:
```bash
cd src/semantic-router
go run ./cmd/dsl validate ../../deploy/recipes/session-state.dsl
go run ./cmd/dsl compile \
     -o ../../deploy/recipes/session-state.yaml \
     ../../deploy/recipes/session-state.dsl
go test ./pkg/config -run TestMaintainedSessionStateRecipeAssetsStayInSync -count=1
```

- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?

All commands pass.

- Any follow-up risks, gaps, or blockers?

No

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
