### PR TITLE
[CLI] Fix host parsing and path rewrite in Envoy config generator

### DIFF
--- a/src/vllm-sr/cli/config_generator.py
+++ b/src/vllm-sr/cli/config_generator.py
@@ -114,12 +114,10 @@ def generate_envoy_config_from_user_config(
 
             if "://" in endpoint_str:
                 parsed = urlparse(endpoint_str)
-                host = parsed.netloc
+                host = parsed.hostname or parsed.netloc
                 path = parsed.path.rstrip("/")
                 protocol = parsed.scheme or backend.protocol
                 port = parsed.port or (443 if protocol == "https" else 80)
-                if parsed.port is None and ":" in host:
-                    host = parsed.hostname or host
             else:
                 protocol = backend.protocol
 
@@ -155,6 +153,7 @@ def generate_envoy_config_from_user_config(
                     "name": backend.name or f"backend-{index + 1}",
                     "address": host,
                     "port": int(port),
+                    "host_authority": f"{host}:{port}" if int(port) not in (80, 443) else host,
                     "path": path,
                     "weight": backend.weight,
                     "protocol": protocol,

--- a/src/vllm-sr/cli/config_generator.py
+++ b/src/vllm-sr/cli/config_generator.py
@@ -153,7 +153,9 @@ def generate_envoy_config_from_user_config(
                     "name": backend.name or f"backend-{index + 1}",
                     "address": host,
                     "port": int(port),
-                    "host_authority": f"{host}:{port}" if int(port) not in (80, 443) else host,
+                    "host_authority": (
+                        f"{host}:{port}" if int(port) not in (80, 443) else host
+                    ),
                     "path": path,
                     "weight": backend.weight,
                     "protocol": protocol,

--- a/src/vllm-sr/cli/templates/envoy.template.yaml
+++ b/src/vllm-sr/cli/templates/envoy.template.yaml
@@ -39,13 +39,13 @@ static_resources:
                   timeout: {{ listener.timeout | default('1200s') }}
                   idleTimeout: 1200s
                   # Rewrite Host header to match upstream server
-                  host_rewrite_literal: "{{ model.endpoints[0].address }}"
+                  host_rewrite_literal: "{{ model.endpoints[0].host_authority }}"
                   {% if model.path_prefix %}
                   # Prepend path prefix to all requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions)
                   regex_rewrite:
                     pattern:
                       google_re2: {}
-                      regex: "^(.*)$"
+                      regex: "^/v1(.*)$"
                     substitution: "{{ model.path_prefix }}\\1"
                   {% endif %}
               {% endfor %}
@@ -76,14 +76,14 @@ static_resources:
                   timeout: {{ listener.timeout | default('1200s') }}
                   {% if models %}
                   # Rewrite Host header to match upstream server
-                  host_rewrite_literal: "{{ models[0].endpoints[0].address }}"
+                  host_rewrite_literal: "{{ models[0].endpoints[0].host_authority }}"
                   {% endif %}
                   {% if models and models[0].path_prefix %}
                   # Prepend path prefix to all requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions)
                   regex_rewrite:
                     pattern:
                       google_re2: {}
-                      regex: "^(.*)$"
+                      regex: "^/v1(.*)$"
                     substitution: "{{ models[0].path_prefix }}\\1"
                   {% endif %}
           http_filters:

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -215,7 +215,6 @@ routing:
     assert route_action["regex_rewrite"]["substitution"] == "/compatible-mode/v1\\1"
 
 
-
 def test_generate_envoy_config_uses_logical_dns_for_api_only_router_fallback(
     tmp_path, monkeypatch
 ):

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -84,6 +84,138 @@ routing:
     assert endpoint["hostname"] == "vllm-sr-router-container"
 
 
+def _model_route(rendered_config, model_name):
+    """Find the route entry whose x-selected-model header matches *model_name*."""
+    listener = rendered_config["static_resources"]["listeners"][0]
+    hcm = listener["filter_chains"][0]["filters"][0]["typed_config"]
+    routes = hcm["route_config"]["virtual_hosts"][0]["routes"]
+    for route in routes:
+        headers = route.get("match", {}).get("headers", [])
+        for h in headers:
+            if h.get("name") == "x-selected-model":
+                if h.get("string_match", {}).get("exact") == model_name:
+                    return route
+    raise AssertionError(f"route for model {model_name!r} not found")
+
+
+def test_backend_ref_ip_port_path_produces_correct_envoy_cluster_and_route(
+    tmp_path, monkeypatch
+):
+    """Backend ref http://10.0.0.1:8000/v1 should split into address=10.0.0.1,
+    port=8000, host_authority=10.0.0.1:8000, path_prefix=/v1, and the route
+    should use regex ^/v1(.*)$ to avoid duplicating /v1."""
+    rendered = _render_envoy_config(
+        tmp_path,
+        monkeypatch,
+        """
+version: v0.3
+listeners:
+  - name: "http-8899"
+    address: "0.0.0.0"
+    port: 8899
+providers:
+  defaults:
+    default_model: "test-model"
+  models:
+    - name: "test-model"
+      backend_refs:
+        - name: "primary"
+          endpoint: "http://10.0.0.1:8000/v1"
+          weight: 100
+routing:
+  modelCards:
+    - name: "test-model"
+  decisions:
+    - name: "default-route"
+      description: "default route"
+      priority: 100
+      rules:
+        operator: "AND"
+        conditions: []
+      modelRefs:
+        - model: "test-model"
+          use_reasoning: false
+""",
+        extproc_host="localhost",
+        router_api_host="localhost",
+    )
+
+    # --- cluster assertions ---
+    cluster = _cluster_by_name(rendered, "test_model_cluster")
+    assert cluster["type"] == "STATIC"
+    ep = cluster["load_assignment"]["endpoints"][0]["lb_endpoints"][0]["endpoint"]
+    assert ep["address"]["socket_address"]["address"] == "10.0.0.1"
+    assert ep["address"]["socket_address"]["port_value"] == 8000
+
+    # --- route assertions ---
+    route = _model_route(rendered, "test-model")
+    route_action = route["route"]
+    assert route_action["host_rewrite_literal"] == "10.0.0.1:8000"
+    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1(.*)$"
+    assert route_action["regex_rewrite"]["substitution"] == "/v1\\1"
+
+
+def test_backend_ref_domain_with_path_produces_correct_envoy_cluster_and_route(
+    tmp_path, monkeypatch
+):
+    """Backend ref https://api.example.com/compatible-mode/v1 should produce
+    address=api.example.com, port=443, host_authority=api.example.com (standard
+    port omitted), LOGICAL_DNS cluster, and regex_rewrite for path prefix."""
+    rendered = _render_envoy_config(
+        tmp_path,
+        monkeypatch,
+        """
+version: v0.3
+listeners:
+  - name: "http-8899"
+    address: "0.0.0.0"
+    port: 8899
+providers:
+  defaults:
+    default_model: "test-model"
+  models:
+    - name: "test-model"
+      backend_refs:
+        - name: "primary"
+          endpoint: "https://api.example.com/compatible-mode/v1/"
+          weight: 100
+routing:
+  modelCards:
+    - name: "test-model"
+  decisions:
+    - name: "default-route"
+      description: "default route"
+      priority: 100
+      rules:
+        operator: "AND"
+        conditions: []
+      modelRefs:
+        - model: "test-model"
+          use_reasoning: false
+""",
+        extproc_host="localhost",
+        router_api_host="localhost",
+    )
+
+    # --- cluster assertions ---
+    cluster = _cluster_by_name(rendered, "test_model_cluster")
+    assert cluster["type"] == "LOGICAL_DNS"
+    assert cluster["dns_lookup_family"] == "V4_ONLY"
+    ep = cluster["load_assignment"]["endpoints"][0]["lb_endpoints"][0]["endpoint"]
+    assert ep["address"]["socket_address"]["address"] == "api.example.com"
+    assert ep["address"]["socket_address"]["port_value"] == 443
+    assert ep["hostname"] == "api.example.com"
+
+    # --- route assertions ---
+    route = _model_route(rendered, "test-model")
+    route_action = route["route"]
+    # standard port 443 → host_authority should omit port
+    assert route_action["host_rewrite_literal"] == "api.example.com"
+    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1(.*)$"
+    assert route_action["regex_rewrite"]["substitution"] == "/compatible-mode/v1\\1"
+
+
+
 def test_generate_envoy_config_uses_logical_dns_for_api_only_router_fallback(
     tmp_path, monkeypatch
 ):

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -92,9 +92,10 @@ def _model_route(rendered_config, model_name):
     for route in routes:
         headers = route.get("match", {}).get("headers", [])
         for h in headers:
-            if h.get("name") == "x-selected-model":
-                if h.get("string_match", {}).get("exact") == model_name:
-                    return route
+            if h.get("name") == "x-selected-model" and h.get(
+                "string_match", {}
+            ).get("exact") == model_name:
+                return route
     raise AssertionError(f"route for model {model_name!r} not found")
 
 

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -92,9 +92,10 @@ def _model_route(rendered_config, model_name):
     for route in routes:
         headers = route.get("match", {}).get("headers", [])
         for h in headers:
-            if h.get("name") == "x-selected-model" and h.get(
-                "string_match", {}
-            ).get("exact") == model_name:
+            if (
+                h.get("name") == "x-selected-model"
+                and h.get("string_match", {}).get("exact") == model_name
+            ):
                 return route
     raise AssertionError(f"route for model {model_name!r} not found")
 


### PR DESCRIPTION


<!-- markdownlint-disable -->
<!-- PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.-->

Closes #1766

<!---## Purpose-->

<!--- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build` -->
<!--
## Summary

- Fix `config_generator.py` to use `parsed.hostname` instead of `parsed.netloc` so the `address`
  field never includes the port suffix. Add a `host_authority` field for Envoy `host_rewrite_literal`
  that formats `host:port` for non-standard ports and plain `host` for 80/443.
  - Fix `envoy.template.yaml` regex_rewrite from `^(.*)$` to `^/v1(.*)$` to prevent `/v1` path
  duplication when `path_prefix` is set.
  - Add two test cases covering `http://ip:port/v1` and `https://domain/path` backend ref formats.

## Motivation

  When a model backend ref is configured with a full URL like `http://10.0.0.1:8000/v1`:

  1. **`host_rewrite_literal` was wrong** — `urlparse().netloc` returns `10.0.0.1:8000`, which was
  stored as `address` and fed into `host_rewrite_literal`. Meanwhile port was already parsed
  separately into `port_value`, so the Host header and socket address were inconsistent.

  2. **`regex_rewrite` duplicated `/v1`** — The regex `^(.*)$` captured the entire inbound path (e.g.
  `/v1/chat/completions`) and prepended `path_prefix` (`/v1`), producing `/v1/v1/chat/completions`.

  ## Changes

  | File | Change |
  |------|--------|
  | `config_generator.py` | Use `parsed.hostname` for host; add `host_authority` field; remove
  redundant port-stripping fallback |
  | `envoy.template.yaml` | Use `host_authority` in `host_rewrite_literal`; fix regex to `^/v1(.*)$` |
  | `test_config_generator.py` | Add `test_backend_ref_ip_port_path_*` and
  `test_backend_ref_domain_with_path_*` |

## Test Plan
-->

<!---
- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?
 -->
 
 <!---
- [x] `http://10.0.0.1:8000/v1` → address=`10.0.0.1`, port=`8000`, host_authority=`10.0.0.1:8000`,
  regex=`^/v1(.*)$`, STATIC cluster
- [x] `https://api.example.com/compatible-mode` → address=`api.example.com`, port=`443`,
  host_authority=`api.example.com`, regex substitution=`/compatible-mode\1`, LOGICAL_DNS cluster
- [x] Existing tests pass (4/4)

## Test Result
 -->
<!---
- What were the actual results?
- Any follow-up risks, gaps, or blockers?
 -->
 
 <!---
 All 4 tests pass (`pytest src/vllm-sr/tests/test_config_generator.py -v`):

  | Test | Status |
  |------|--------|
  | `test_generate_envoy_config_uses_logical_dns_for_split_extproc_host` (existing) | PASS |
  | `test_backend_ref_ip_port_path_produces_correct_envoy_cluster_and_route` (new) | PASS |
  | `test_backend_ref_domain_with_path_produces_correct_envoy_cluster_and_route` (new) | PASS |
  | `test_generate_envoy_config_uses_logical_dns_for_api_only_router_fallback` (existing) | PASS |
 -->

## Purpose

  - **What**: Fix two bugs in `config_generator.py` and `envoy.template.yaml` when backend refs use a
  full URL like `http://10.0.0.1:8000/v1`. Add two test cases.
  - **Why**:
    1. `host_rewrite_literal` received raw `urlparse().netloc` (e.g. `10.0.0.1:8000`) as the `address`
   field while port was parsed separately — the Host header was inconsistent with the socket address.
    2. `regex_rewrite` used `^(.*)$` which captured the full inbound path including `/v1`, then
  prepended `path_prefix` again, producing `/v1/v1/chat/completions`.
  - **Module**: `CLI` (`src/vllm-sr/cli/` and `src/vllm-sr/tests/`)

  ### Changes

  | File | Change |
  |------|--------|
  | `config_generator.py` | Use `parsed.hostname` instead of `parsed.netloc` for host; add `host_authority` field; remove redundant port-stripping fallback |
  | `envoy.template.yaml` | Use `host_authority` in `host_rewrite_literal`; fix regex from `^(.*)$` to `^/v1(.*)$` |
  | `test_config_generator.py` | Add `test_backend_ref_ip_port_path_*` and `test_backend_ref_domain_with_path_*` |

  ## Test Plan

  ```bash
  python -m pytest src/vllm-sr/tests/test_config_generator.py -v
 ```
 
  - test_backend_ref_ip_port_path_* — validates http://10.0.0.1:8000/v1 produces address=10.0.0.1,
  port=8000, host_authority=10.0.0.1:8000, regex=^/v1(.*)$, STATIC cluster
  - test_backend_ref_domain_with_path_* — validates https://api.example.com/compatible-mode produces
  address=api.example.com, port=443, host_authority=api.example.com (standard port omitted), regex
  substitution=/compatible-mode\1, LOGICAL_DNS cluster
  - Sufficient because the two new tests cover the exact code paths changed, and existing tests
  confirm no regression on non-URL endpoint formats

  Test Result

  All 4 tests pass:

  | Test | Status | Validates |
  |------|--------|-----------|
  | `test_generate_envoy_config_uses_logical_dns_for_split_extproc_host` (existing) | PASS | No regression |
  | `test_backend_ref_ip_port_path_produces_correct_envoy_cluster_and_route` (new) | PASS | host parsing fix (`parsed.hostname` vs `netloc`), `host_authority` field, regex fix (`^/v1(.*)$`) |
  | `test_backend_ref_domain_with_path_produces_correct_envoy_cluster_and_route` (new) | PASS | regex fix, `host_authority` omits standard port `:443`, template `host_rewrite_literal` switch to `host_authority` |
  | `test_generate_envoy_config_uses_logical_dns_for_api_only_router_fallback` (existing) | PASS | No regression |

 <!---
  Risks/gaps:
  - regex_rewrite assumes inbound path starts with /v1 — safe because Envoy listeners in this project
  only expose /v1/* endpoints
  - No live Envoy e2e test — generated YAML is validated structurally; runtime behavior covered by
  docker-compose integration environment
  -->
---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
