### PR TITLE
feat: ship versioned release channels and upgrade/rollback workflows for images, packages, and charts

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -17,6 +17,19 @@ on:
       - "deploy/helm/**"
       - ".github/workflows/helm-publish.yml"
   workflow_dispatch:
+  # Called from nightly-build.yml to publish a nightly chart version.
+  workflow_call:
+    inputs:
+      is_nightly:
+        description: "Publish a nightly chart (version 0.0.0-nightly.YYYYMMDD)"
+        required: false
+        type: boolean
+        default: false
+      nightly_date:
+        description: "Override date (YYYYMMDD) for nightly version. Defaults to today."
+        required: false
+        type: string
+        default: ""
 
 env:
   HELM_VERSION: v3.14.0
@@ -48,15 +61,33 @@ jobs:
         id: versions
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "chart_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-            echo "app_version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            # Tagged release — chart version mirrors the semver tag (without leading v)
+            CHART_VERSION="${GITHUB_REF#refs/tags/v}"
+            APP_VERSION="${GITHUB_REF#refs/tags/}"
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.is_nightly }}" == "true" ]]; then
+            # Nightly — use the supplied date or today's UTC date
+            if [[ -n "${{ inputs.nightly_date }}" ]]; then
+              DATE="${{ inputs.nightly_date }}"
+            else
+              DATE="$(date -u +'%Y%m%d')"
+            fi
+            # 0.0.0-nightly.YYYYMMDD is valid semver (pre-release identifier)
+            CHART_VERSION="0.0.0-nightly.${DATE}"
+            APP_VERSION="nightly-${DATE}"
+            echo "is_release=false" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            echo "chart_version=0.0.0-pr.${{ github.event.number }}" >> $GITHUB_OUTPUT
-            echo "app_version=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+            CHART_VERSION="0.0.0-pr.${{ github.event.number }}"
+            APP_VERSION="pr-${{ github.event.number }}"
+            echo "is_release=false" >> $GITHUB_OUTPUT
           else
-            echo "chart_version=0.0.0-latest" >> $GITHUB_OUTPUT
-            echo "app_version=latest" >> $GITHUB_OUTPUT
+            # Push to main without a tag
+            CHART_VERSION="0.0.0-latest"
+            APP_VERSION="latest"
+            echo "is_release=false" >> $GITHUB_OUTPUT
           fi
+          echo "chart_version=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "app_version=${APP_VERSION}"     >> $GITHUB_OUTPUT
 
       - name: Package chart
         id: package
@@ -119,24 +150,23 @@ jobs:
 
       - name: Create release summary
         run: |
-          REPOSITORY_OWNER_LOWER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          OWNER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          CHART_VERSION="${{ needs.validate-and-package.outputs.chart-version }}"
+          REPO="${{ env.REGISTRY }}/${OWNER}/charts/${{ env.CHART_NAME }}"
+
           cat >> $GITHUB_STEP_SUMMARY << EOF
-          ## 📦 Helm Chart Published
+          ## Helm Chart Published
 
           **Chart:** \`${{ env.CHART_NAME }}\`
-          **Version:** \`${{ needs.validate-and-package.outputs.chart-version }}\`
+          **Version:** \`${CHART_VERSION}\`
           **App Version:** \`${{ needs.validate-and-package.outputs.chart-app-version }}\`
-          **Registry:** \`${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts\`
+          **Registry:** \`${{ env.REGISTRY }}/${OWNER}/charts\`
 
           ### Installation
 
           \`\`\`bash
-          # Pull the chart
-          helm pull oci://${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts/${{ env.CHART_NAME }} --version ${{ needs.validate-and-package.outputs.chart-version }}
-
-          # Install directly
-          helm install semantic-router oci://${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts/${{ env.CHART_NAME }} \\
-            --version ${{ needs.validate-and-package.outputs.chart-version }} \\
+          helm install semantic-router oci://${REPO} \\
+            --version ${CHART_VERSION} \\
             --namespace vllm-semantic-router-system \\
             --create-namespace
           \`\`\`
@@ -144,8 +174,9 @@ jobs:
           ### Upgrade
 
           \`\`\`bash
-          helm upgrade semantic-router oci://${{ env.REGISTRY }}/$REPOSITORY_OWNER_LOWER/charts/${{ env.CHART_NAME }} \\
-            --version ${{ needs.validate-and-package.outputs.chart-version }} \\
-            --namespace vllm-semantic-router-system
+          helm upgrade semantic-router oci://${REPO} \\
+            --version ${CHART_VERSION} \\
+            --namespace vllm-semantic-router-system \\
+            --reuse-values
           \`\`\`
           EOF

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,37 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # 2:00 AM UTC every day
+  workflow_dispatch:
+
+# Never cancel a running nightly — let it finish and report.
+concurrency:
+  group: nightly-build
+  cancel-in-progress: false
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Docker: build all images tagged nightly-YYYYMMDD (multi-arch + nightly ROCm)
+  # docker-publish.yml already owns the nightly logic; we just call it here.
+  # ─────────────────────────────────────────────────────────────────────────────
+  docker-nightly:
+    name: Docker Nightly Images
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      is_nightly: true
+    secrets: inherit
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Helm: publish chart version 0.0.0-nightly.YYYYMMDD to GHCR OCI registry
+  # ─────────────────────────────────────────────────────────────────────────────
+  helm-nightly:
+    name: Helm Nightly Chart
+    uses: ./.github/workflows/helm-publish.yml
+    with:
+      is_nightly: true
+    secrets: inherit
+
+  # Failure visibility is handled by GitHub's built-in workflow failure emails
+  # (sent to anyone watching the repo). No issue creation here — similar
+  # auto-issue patterns were previously removed from this repo due to noise.

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -104,15 +104,15 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
 
-    - name: Create GitHub Release
+    # Attach compiled Rust artifacts to the GitHub Release that release.yml creates.
+    # Body/generate_release_notes omitted intentionally — release.yml owns the body.
+    - name: Attach artifacts to GitHub Release
       if: steps.extract_tag.outputs.version != 'manual'
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ steps.extract_tag.outputs.tag }}
-        name: Release ${{ steps.extract_tag.outputs.tag }}
         draft: false
         prerelease: false
-        generate_release_notes: true
         files: |
           candle-binding/target/release/libcandle_semantic_router.a
           candle-binding/target/release/libcandle_semantic_router.so

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -175,24 +175,17 @@ jobs:
           echo "Publishing to PyPI..."
           twine upload dist/* --skip-existing --verbose
 
-      - name: Create GitHub Release
+      # Attach the built wheel/sdist to the GitHub Release that release.yml creates.
+      # We intentionally omit body/generate_release_notes here: release.yml is the
+      # canonical release-notes creator to avoid a race condition where multiple
+      # workflows overwrite each other's release body.
+      - name: Attach artifacts to GitHub Release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.extract_version.outputs.tag }}
-          name: vllm-sr ${{ steps.extract_version.outputs.tag }}
           draft: false
           prerelease: false
-          generate_release_notes: true
-          body: |
-            ## Installation
-
-            ```bash
-            pip install vllm-sr==${{ steps.extract_version.outputs.version }}
-            ```
-
-            ## What's Changed
-            See the full changelog below.
           files: |
             src/vllm-sr/dist/*
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,222 @@
+name: Release Validation
+
+# This workflow is the release guard: it validates that all versioned surfaces
+# (Python package, Rust crate) agree with the pushed tag before any of the
+# independent publish workflows can drift.  It also produces a single, unified
+# GitHub Release note that links every published artifact.
+#
+# Individual publish workflows (docker-release, helm-publish, pypi-publish,
+# publish-crate) still trigger independently on v* tags so they remain
+# self-contained.  This workflow adds the cross-surface sanity check on top.
+
+on:
+  push:
+    tags:
+      - "v*"
+  # Allow running the validation step manually against any ref for pre-release
+  # testing (e.g. before actually pushing the tag).
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to validate (e.g. 0.3.0) — no leading 'v'"
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # needed to create/update the GitHub Release
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # validate: check that every versioned source file matches the git tag.
+  # A mismatch here means a developer forgot to bump a version before tagging —
+  # fail loudly so it is caught before artifacts land in production registries.
+  # ─────────────────────────────────────────────────────────────────────────────
+  validate:
+    name: Cross-Surface Version Validation
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+      tag: ${{ steps.extract.outputs.tag }}
+      sim_version: ${{ steps.check_sim.outputs.sim_version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Derive version ────────────────────────────────────────────────────────
+      - name: Extract version
+        id: extract
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+            TAG="v${VERSION}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            VERSION="${TAG#v}"
+          fi
+          echo "tag=${TAG}"     >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Validating release: ${TAG} (version: ${VERSION})"
+
+      # ── vllm-sr Python package ────────────────────────────────────────────────
+      - name: Validate vllm-sr pyproject.toml
+        id: check_pyproject
+        run: |
+          VERSION="${{ steps.extract.outputs.version }}"
+          PKG_VERSION=$(grep '^version = ' src/vllm-sr/pyproject.toml \
+            | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "  vllm-sr version in pyproject.toml: ${PKG_VERSION}"
+          if [ "${PKG_VERSION}" != "${VERSION}" ]; then
+            echo "::error file=src/vllm-sr/pyproject.toml,title=Version mismatch::\
+          src/vllm-sr/pyproject.toml has '${PKG_VERSION}' but the tag is '${VERSION}'. \
+          Update the file and re-tag."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── candle-binding Rust crate ─────────────────────────────────────────────
+      # Parse Cargo.toml with Python to avoid installing a full Rust toolchain
+      # just for a version check.
+      - name: Validate candle-binding Cargo.toml
+        id: check_cargo
+        run: |
+          VERSION="${{ steps.extract.outputs.version }}"
+          CARGO_VERSION=$(python3 - <<'EOF'
+          import re, sys
+          content = open("candle-binding/Cargo.toml").read()
+          # Isolate the [package] section (ends at the next bare [section] header)
+          pkg_section = re.split(r"^\[(?!package)", content, maxsplit=1, flags=re.MULTILINE)[0]
+          m = re.search(r'^version\s*=\s*"([^"]+)"', pkg_section, re.MULTILINE)
+          print(m.group(1) if m else "")
+          EOF
+          )
+          echo "  candle-binding version in Cargo.toml: ${CARGO_VERSION}"
+          if [ "${CARGO_VERSION}" != "${VERSION}" ]; then
+            echo "::error file=candle-binding/Cargo.toml,title=Version mismatch::\
+          candle-binding/Cargo.toml has '${CARGO_VERSION}' but the tag is '${VERSION}'. \
+          Update the file and re-tag."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── vllm-sr-sim (informational — uses its own tag scheme) ─────────────────
+      - name: Read vllm-sr-sim version
+        id: check_sim
+        run: |
+          SIM_VERSION=$(grep '^version = ' src/fleet-sim/pyproject.toml \
+            | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "  vllm-sr-sim version: ${SIM_VERSION} (ships on its own vllm-sr-sim-v* tag)"
+          echo "sim_version=${SIM_VERSION}" >> "$GITHUB_OUTPUT"
+
+      # ── Fail if anything is mismatched ────────────────────────────────────────
+      - name: Assert no mismatches
+        run: |
+          FAILED=false
+          [ "${{ steps.check_pyproject.outputs.ok }}" = "false" ] && FAILED=true
+          [ "${{ steps.check_cargo.outputs.ok }}"    = "false" ] && FAILED=true
+          if [ "${FAILED}" = "true" ]; then
+            echo ""
+            echo "One or more versioned files do not match tag ${{ steps.extract.outputs.tag }}."
+            echo "Fix the mismatches listed above, then delete and re-push the tag:"
+            echo "  git tag -d ${{ steps.extract.outputs.tag }}"
+            echo "  git push origin :${{ steps.extract.outputs.tag }}"
+            echo "  # (bump files, commit)"
+            echo "  git tag ${{ steps.extract.outputs.tag }}"
+            echo "  git push origin ${{ steps.extract.outputs.tag }}"
+            exit 1
+          fi
+          echo "All surfaces consistent with ${{ steps.extract.outputs.tag }}."
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # release-notes: create or update the GitHub Release with a cross-surface
+  # summary so operators can find every artifact from one place.
+  # Runs only on actual tag pushes (not workflow_dispatch test runs).
+  # ─────────────────────────────────────────────────────────────────────────────
+  release-notes:
+    name: Publish GitHub Release Notes
+    needs: validate
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve GHCR owner (lowercase)
+        id: owner
+        run: |
+          echo "lower=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: "Release ${{ needs.validate.outputs.tag }}"
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          body: |
+            ## Release ${{ needs.validate.outputs.tag }}
+
+            ### Container Images (GHCR)
+
+            Always pin to a version tag in production — it is immutable.
+
+            ```bash
+            docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/extproc:${{ needs.validate.outputs.tag }}
+            docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/vllm-sr:${{ needs.validate.outputs.tag }}
+            docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/dashboard:${{ needs.validate.outputs.tag }}
+            ```
+
+            | Image | Tags pushed |
+            |-------|-------------|
+            | `extproc` | `${{ needs.validate.outputs.tag }}` · `latest` |
+            | `vllm-sr` | `${{ needs.validate.outputs.tag }}` · `latest` |
+            | `extproc-rocm` | `${{ needs.validate.outputs.tag }}` · `latest` |
+            | `vllm-sr-rocm` | `${{ needs.validate.outputs.tag }}` · `latest` |
+            | `llm-katan` | `${{ needs.validate.outputs.tag }}` · `latest` |
+            | `dashboard` | `${{ needs.validate.outputs.tag }}` · `latest` |
+
+            ### Helm Chart
+
+            ```bash
+            # Install a specific version
+            helm install semantic-router \
+              oci://ghcr.io/${{ steps.owner.outputs.lower }}/charts/semantic-router \
+              --version ${{ needs.validate.outputs.version }} \
+              --namespace vllm-semantic-router-system --create-namespace
+
+            # Upgrade to this version
+            helm upgrade semantic-router \
+              oci://ghcr.io/${{ steps.owner.outputs.lower }}/charts/semantic-router \
+              --version ${{ needs.validate.outputs.version }} \
+              --namespace vllm-semantic-router-system
+            ```
+
+            ### Python Package (PyPI)
+
+            ```bash
+            pip install vllm-sr==${{ needs.validate.outputs.version }}
+            ```
+
+            ### Rust Crate (crates.io)
+
+            ```toml
+            [dependencies]
+            candle-semantic-router = "${{ needs.validate.outputs.version }}"
+            ```
+
+            ---
+
+            **vllm-sr-sim** ships on its own `vllm-sr-sim-v*` tag and is currently at
+            `${{ needs.validate.outputs.sim_version }}`.
+
+            See the [upgrade and rollback runbook](https://github.com/${{ github.repository }}/blob/main/website/docs/installation/upgrade-rollback.md)
+            for step-by-step upgrade and rollback instructions.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/deploy/helm/semantic-router/Chart.yaml
+++ b/deploy/helm/semantic-router/Chart.yaml
@@ -3,6 +3,13 @@ name: semantic-router
 description: A Helm chart for deploying Semantic Router - an intelligent routing system for LLM applications
 type: application
 version: 0.2.0
+# appVersion is the default image tag used when the chart is deployed without
+# an explicit image.tag override.  "latest" corresponds to the most recent
+# successful build from the main branch (published by docker-publish.yml).
+# During the CI release pipeline (helm-publish.yml) this value is overridden
+# to the actual release tag (e.g. "v0.3.0") via `helm package --app-version`.
+# For production deployments always pin the image tag explicitly in your
+# values file rather than relying on this default.
 appVersion: "latest"
 keywords:
   - semantic-router

--- a/tools/make/docker.mk
+++ b/tools/make/docker.mk
@@ -4,7 +4,19 @@
 
 ##@ Docker
 
-# Docker image tags
+# ── Image registry and tag configuration ────────────────────────────────────
+# Override DOCKER_REGISTRY and DOCKER_TAG on the command line or via environment
+# variables to target a different registry or release channel.
+#
+# Release channels:
+#   DOCKER_TAG=latest              (default) most recent build pushed to main
+#   DOCKER_TAG=v0.3.0              specific immutable release tag — recommended for production
+#   DOCKER_TAG=nightly-20260115    nightly build from a specific date
+#
+# Examples:
+#   make docker-build-extproc DOCKER_TAG=v0.3.0
+#   make docker-pull-release  DOCKER_TAG=v0.3.0
+# ────────────────────────────────────────────────────────────────────────────
 DOCKER_REGISTRY ?= ghcr.io/vllm-project/semantic-router
 DOCKER_TAG ?= latest
 
@@ -101,6 +113,20 @@ docker-run-llm-katan-custom:
 	@$(CONTAINER_RUNTIME) run --rm -p 8000:8000 $(DOCKER_REGISTRY)/llm-katan:$(DOCKER_TAG) \
 		llm-katan --model "Qwen/Qwen3-0.6B" --served-model-name "$(SERVED_NAME)" --host 0.0.0.0 --port 8000
 
+# Pull a specific release of all production images
+# Usage: make docker-pull-release DOCKER_TAG=v0.3.0
+docker-pull-release: ## Pull all production images at a specific DOCKER_TAG (default: latest)
+docker-pull-release:
+	@$(LOG_TARGET)
+	@if [ "$(DOCKER_TAG)" = "latest" ]; then \
+		echo "WARNING: pulling :latest — consider pinning with DOCKER_TAG=v<version> or DOCKER_TAG=nightly-YYYYMMDD"; \
+	fi
+	@echo "Pulling images at tag: $(DOCKER_TAG)"
+	@$(CONTAINER_RUNTIME) pull $(DOCKER_REGISTRY)/extproc:$(DOCKER_TAG)
+	@$(CONTAINER_RUNTIME) pull $(DOCKER_REGISTRY)/vllm-sr:$(DOCKER_TAG)
+	@$(CONTAINER_RUNTIME) pull $(DOCKER_REGISTRY)/dashboard:$(DOCKER_TAG)
+	@echo "All images pulled at $(DOCKER_TAG)"
+
 # Clean up Docker images
 docker-clean: ## Clean up Docker images
 docker-clean:
@@ -177,13 +203,14 @@ docker-help: ## Show help for Docker-related make targets and environment variab
 
 ##@ vLLM-SR (Semantic Router CLI)
 
-# vLLM-SR specific variables
-VLLM_SR_IMAGE ?= ghcr.io/vllm-project/semantic-router/vllm-sr:latest
-VLLM_SR_IMAGE_ROCM ?= ghcr.io/vllm-project/semantic-router/vllm-sr-rocm:latest
+# vLLM-SR specific variables — image tags default to DOCKER_TAG so that a
+# single `DOCKER_TAG=v0.3.0` on the command line pins every image at once.
+VLLM_SR_IMAGE ?= ghcr.io/vllm-project/semantic-router/vllm-sr:$(DOCKER_TAG)
+VLLM_SR_IMAGE_ROCM ?= ghcr.io/vllm-project/semantic-router/vllm-sr-rocm:$(DOCKER_TAG)
 VLLM_SR_ROUTER_IMAGE_DEFAULT ?= $(VLLM_SR_IMAGE)
 VLLM_SR_ROUTER_IMAGE_ROCM ?= $(VLLM_SR_IMAGE_ROCM)
 VLLM_SR_ENVOY_IMAGE_DEFAULT ?= envoyproxy/envoy:v1.34-latest
-VLLM_SR_DASHBOARD_IMAGE_DEFAULT ?= ghcr.io/vllm-project/semantic-router/dashboard:latest
+VLLM_SR_DASHBOARD_IMAGE_DEFAULT ?= ghcr.io/vllm-project/semantic-router/dashboard:$(DOCKER_TAG)
 VLLM_SR_ROUTER_IMAGE ?= $(VLLM_SR_ROUTER_IMAGE_DEFAULT)
 VLLM_SR_ENVOY_IMAGE ?= $(VLLM_SR_ENVOY_IMAGE_DEFAULT)
 VLLM_SR_DASHBOARD_IMAGE ?= $(VLLM_SR_DASHBOARD_IMAGE_DEFAULT)

--- a/tools/make/helm.mk
+++ b/tools/make/helm.mk
@@ -4,7 +4,7 @@
 
 ##@ Helm
 
-# Configuration
+# ── Configuration ────────────────────────────────────────────────────────────
 HELM_RELEASE_NAME ?= semantic-router
 HELM_NAMESPACE ?= vllm-semantic-router-system
 HELM_CHART_PATH ?= deploy/helm/semantic-router
@@ -12,6 +12,23 @@ HELM_VALUES_FILE ?=
 HELM_SET_VALUES ?=
 HELM_TIMEOUT ?= 10m
 HELM_TEMPLATE_OUTPUT ?= dist/helm/default-template.yaml
+
+# ── Remote OCI chart registry ────────────────────────────────────────────────
+# Used by helm-install-version, helm-upgrade-version, and related targets.
+# Override to point at a fork or mirror.
+HELM_OCI_REGISTRY ?= ghcr.io/vllm-project/charts
+HELM_OCI_CHART    ?= $(HELM_OCI_REGISTRY)/semantic-router
+
+# CHART_VERSION: pin to an exact chart version for remote install/upgrade.
+#
+# Release channels:
+#   CHART_VERSION=0.3.0              specific release — recommended for production
+#   CHART_VERSION=0.0.0-latest       latest main-branch build
+#   CHART_VERSION=0.0.0-nightly.YYYYMMDD  specific nightly
+#
+# When CHART_VERSION is empty, targets that require a remote chart will fail
+# with a clear error rather than silently pulling an unintended version.
+CHART_VERSION ?=
 
 # Colors for output (reuse from common.mk if available, otherwise define)
 BLUE ?= \033[0;34m
@@ -24,7 +41,67 @@ NC ?= \033[0m
 	helm-uninstall helm-status helm-list helm-history helm-rollback helm-test \
 	helm-package helm-dev helm-prod helm-values helm-manifest \
 	helm-port-forward-api helm-port-forward-grpc helm-port-forward-metrics \
-	helm-logs helm-clean helm-setup helm-cleanup helm-reinstall help-helm _check-k8s
+	helm-logs helm-clean helm-setup helm-cleanup helm-reinstall help-helm _check-k8s \
+	helm-install-version helm-upgrade-version helm-check-version _assert-chart-version
+
+##@ Helm — Remote (OCI) Version-Pinned Operations
+
+# Internal guard: fail early with a helpful message if CHART_VERSION is unset.
+_assert-chart-version:
+	@if [ -z "$(CHART_VERSION)" ]; then \
+		echo "$(RED)[ERROR]$(NC) CHART_VERSION is required for this target."; \
+		echo "$(BLUE)[INFO]$(NC) Set it to a specific release, e.g.:"; \
+		echo "  make helm-install-version  CHART_VERSION=0.3.0"; \
+		echo "  make helm-upgrade-version  CHART_VERSION=0.3.0"; \
+		echo "  make helm-install-version  CHART_VERSION=0.0.0-nightly.20260115"; \
+		exit 1; \
+	fi
+
+helm-install-version: ## Install a specific chart version from OCI — requires CHART_VERSION=x.y.z
+helm-install-version: _check-k8s _assert-chart-version
+	@$(LOG_TARGET)
+	@echo "$(BLUE)[INFO]$(NC) Installing $(HELM_OCI_CHART) version $(CHART_VERSION)"
+	@kubectl get namespace $(HELM_NAMESPACE) &>/dev/null \
+		|| kubectl create namespace $(HELM_NAMESPACE)
+	@helm install $(HELM_RELEASE_NAME) "oci://$(HELM_OCI_CHART)" \
+		--version "$(CHART_VERSION)" \
+		$(if $(HELM_VALUES_FILE),-f $(HELM_VALUES_FILE)) \
+		$(if $(HELM_SET_VALUES),--set $(HELM_SET_VALUES)) \
+		--namespace $(HELM_NAMESPACE) \
+		--wait \
+		--timeout $(HELM_TIMEOUT)
+	@echo "$(GREEN)[SUCCESS]$(NC) Installed $(HELM_RELEASE_NAME) at chart version $(CHART_VERSION)"
+	@$(MAKE) helm-status
+
+helm-upgrade-version: ## Upgrade to a specific chart version from OCI — requires CHART_VERSION=x.y.z
+helm-upgrade-version: _check-k8s _assert-chart-version
+	@$(LOG_TARGET)
+	@echo "$(BLUE)[INFO]$(NC) Upgrading $(HELM_RELEASE_NAME) → $(HELM_OCI_CHART):$(CHART_VERSION)"
+	@helm upgrade $(HELM_RELEASE_NAME) "oci://$(HELM_OCI_CHART)" \
+		--version "$(CHART_VERSION)" \
+		$(if $(HELM_VALUES_FILE),-f $(HELM_VALUES_FILE)) \
+		$(if $(HELM_SET_VALUES),--set $(HELM_SET_VALUES)) \
+		--namespace $(HELM_NAMESPACE) \
+		--reset-then-reuse-values \
+		--wait \
+		--timeout $(HELM_TIMEOUT)
+	@echo "$(GREEN)[SUCCESS]$(NC) Upgraded $(HELM_RELEASE_NAME) to chart version $(CHART_VERSION)"
+	@$(MAKE) helm-status
+
+helm-check-version: ## Show the currently deployed chart version and available remote versions
+helm-check-version: _check-k8s
+	@$(LOG_TARGET)
+	@echo "$(BLUE)[INFO]$(NC) Deployed release:"
+	@helm list -n $(HELM_NAMESPACE) \
+		--filter "^$(HELM_RELEASE_NAME)$$" \
+		--output table 2>/dev/null \
+		|| echo "  (no release found in namespace $(HELM_NAMESPACE))"
+	@echo ""
+	@echo "$(BLUE)[INFO]$(NC) Release history:"
+	@helm history $(HELM_RELEASE_NAME) -n $(HELM_NAMESPACE) 2>/dev/null \
+		|| echo "  (no history found)"
+
+##@ Helm — Local Chart Operations
 
 helm-lint: ## Lint the Helm chart
 helm-lint:

--- a/website/docs/installation/upgrade-rollback.md
+++ b/website/docs/installation/upgrade-rollback.md
@@ -1,0 +1,323 @@
+---
+sidebar_position: 10
+---
+
+# Upgrade and Rollback
+
+This runbook covers how to upgrade, pin, and roll back each release surface of
+the vLLM Semantic Router in a production environment.
+
+---
+
+## Release Channels
+
+| Channel | Tag pattern | Updated on | Use case |
+|---------|-------------|------------|----------|
+| **Versioned** | `v0.3.0` / `0.3.0` | Tagged releases only | Production — immutable, recommended |
+| **Nightly** | `nightly-20260115` | Daily at 02:00 UTC | Pre-release testing |
+| **Latest** | `latest` | Every push to `main` + releases | Development only |
+
+:::tip Recommendation
+Always use a **versioned** tag in production. It is immutable — the digest
+never changes for a given version tag. Find the latest release on the
+[GitHub Releases page](https://github.com/vllm-project/semantic-router/releases).
+:::
+
+---
+
+## Prerequisites
+
+- `helm` ≥ 3.14 (for Helm OCI operations)
+- `kubectl` configured for your target cluster
+- `pip` ≥ 22 (for Python CLI)
+- `docker` or `podman` (for direct image operations)
+
+---
+
+## 1. Checking Your Current Version
+
+### Helm release
+
+```bash
+helm list -n vllm-semantic-router-system
+helm history semantic-router -n vllm-semantic-router-system
+```
+
+The `CHART` column shows the chart version (e.g. `semantic-router-0.2.0`) and
+`APP VERSION` shows the image tag that chart deployed.
+
+### Running container image
+
+```bash
+# Get the image tag currently used by the extproc deployment
+kubectl get deployment -n vllm-semantic-router-system \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[0].image}{"\n"}{end}'
+```
+
+### Python CLI
+
+```bash
+vllm-sr --version
+pip show vllm-sr
+```
+
+---
+
+## 2. Upgrading
+
+### 2a. Helm chart upgrade
+
+Always upgrade to a specific version. Never rely on `latest` in production.
+
+```bash
+# Pull the chart metadata first (optional but useful to verify it exists)
+helm show chart oci://ghcr.io/vllm-project/charts/semantic-router --version 0.3.0
+
+# Upgrade to a specific version
+# --reset-then-reuse-values (Helm ≥ 3.14) resets to the new chart's defaults
+# first, then re-applies your previous overrides on top. This is safer than
+# --reuse-values alone, which breaks if the new chart adds new required values.
+helm upgrade semantic-router \
+  oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version 0.3.0 \
+  --namespace vllm-semantic-router-system \
+  --reset-then-reuse-values \
+  --wait \
+  --timeout 10m
+```
+
+:::caution Use `--reset-then-reuse-values`, not `--reuse-values`, for cross-version upgrades
+`--reuse-values` only merges your old stored values and skips new chart defaults,
+which causes template errors when a new chart version introduces new required
+values. `--reset-then-reuse-values` (Helm ≥ 3.14) resets to the new defaults
+first, then re-applies your overrides — it is always safe to use.
+If you are on Helm < 3.14, supply your configuration explicitly with `-f your-values.yaml` instead.
+:::
+
+Verify after upgrade:
+
+```bash
+helm status semantic-router -n vllm-semantic-router-system
+kubectl rollout status deployment/semantic-router -n vllm-semantic-router-system
+```
+
+### 2b. Docker image upgrade (non-Helm deployments)
+
+Find the latest version on the [GitHub Releases page](https://github.com/vllm-project/semantic-router/releases), then:
+
+```bash
+# Pull by version tag (substitute podman for docker if using podman)
+docker pull ghcr.io/vllm-project/semantic-router/extproc:v0.3.0
+docker pull ghcr.io/vllm-project/semantic-router/vllm-sr:v0.3.0
+
+# Get the immutable digest for maximum pinning stability
+DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+  ghcr.io/vllm-project/semantic-router/extproc:v0.3.0)
+echo "Use digest: ${DIGEST}"
+```
+
+For Kubernetes manifests, pin to the digest, not the tag:
+
+```yaml
+image: ghcr.io/vllm-project/semantic-router/extproc@sha256:<digest>
+```
+
+### 2c. Python CLI upgrade
+
+```bash
+pip install --upgrade vllm-sr==0.3.0
+vllm-sr --version    # verify
+```
+
+To upgrade to the latest stable release:
+
+```bash
+pip install --upgrade vllm-sr
+```
+
+---
+
+## 3. Rollback
+
+### 3a. Helm rollback (fastest path)
+
+Helm keeps a history of every deployed revision. Rolling back requires no
+re-download and takes effect immediately.
+
+```bash
+# View history
+helm history semantic-router -n vllm-semantic-router-system
+
+# Roll back to the previous revision
+helm rollback semantic-router -n vllm-semantic-router-system --wait
+
+# Roll back to a specific revision number (e.g. revision 3)
+helm rollback semantic-router 3 -n vllm-semantic-router-system --wait
+
+# Verify
+helm status semantic-router -n vllm-semantic-router-system
+kubectl rollout status deployment/semantic-router -n vllm-semantic-router-system
+```
+
+Alternatively, roll back by re-installing an older chart version:
+
+```bash
+helm upgrade semantic-router \
+  oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version 0.2.0 \
+  --namespace vllm-semantic-router-system \
+  --reset-then-reuse-values \
+  --wait
+```
+
+### 3b. Docker / Kubernetes manifest rollback
+
+If you are managing Kubernetes manifests directly (without Helm), roll back the
+Deployment to the previous revision using the built-in rollout history:
+
+```bash
+# View rollout history
+kubectl rollout history deployment/semantic-router -n vllm-semantic-router-system
+
+# Undo the last rollout
+kubectl rollout undo deployment/semantic-router -n vllm-semantic-router-system
+
+# Undo to a specific revision
+kubectl rollout undo deployment/semantic-router \
+  --to-revision=3 -n vllm-semantic-router-system
+
+# Verify
+kubectl rollout status deployment/semantic-router -n vllm-semantic-router-system
+```
+
+If using pinned image digests, update your manifest to the previous image digest
+and `kubectl apply`.
+
+### 3c. Python CLI rollback
+
+```bash
+pip install vllm-sr==0.2.0
+vllm-sr --version
+```
+
+---
+
+## 4. Version Pinning Reference
+
+### Makefile variables
+
+When building or deploying locally via `make`, override these variables to
+target a specific release instead of `latest`:
+
+```bash
+# Use a specific image tag for all docker-* targets
+make docker-build-extproc DOCKER_TAG=v0.3.0
+
+# Pull all production images at a specific version
+make docker-pull-release DOCKER_TAG=v0.3.0
+
+# Install/upgrade the Helm chart at a pinned chart version
+make helm-upgrade-version CHART_VERSION=0.3.0
+```
+
+### Helm values file (recommended for long-running environments)
+
+Create a `values-production.yaml` that explicitly pins image tags:
+
+```yaml
+image:
+  tag: "v0.3.0"   # pin to an immutable release tag
+  pullPolicy: IfNotPresent
+```
+
+Then deploy with:
+
+```bash
+helm upgrade semantic-router \
+  oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version 0.3.0 \
+  -f values-production.yaml \
+  --namespace vllm-semantic-router-system
+```
+
+---
+
+## 5. Nightly Builds
+
+Nightly images and charts are built every day at 02:00 UTC and tagged
+`nightly-YYYYMMDD`. They are intended for pre-release testing only.
+
+```bash
+# Pull the nightly image built on a specific date
+docker pull ghcr.io/vllm-project/semantic-router/vllm-sr:nightly-20260115
+
+# Install the nightly Helm chart
+helm install semantic-router \
+  oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version 0.0.0-nightly.20260115 \
+  --namespace vllm-semantic-router-system --create-namespace
+```
+
+Nightly builds are **not** automatically promoted to a versioned release. Promotion
+happens only via a tagged release.
+
+---
+
+## 6. Promotion Policy
+
+```
+nightly-YYYYMMDD  ──→  (manual QA + CI green)  ──→  v0.3.0
+```
+
+A nightly build is promoted to a release by:
+
+1. Verifying all CI checks pass on the candidate commit.
+2. Bumping version fields in `src/vllm-sr/pyproject.toml` and `candle-binding/Cargo.toml` to the target version.
+3. Pushing a `v<version>` tag — this triggers `docker-release.yml`, `helm-publish.yml`, `pypi-publish.yml`, `publish-crate.yml`, and `release.yml` simultaneously.
+4. The `release.yml` workflow validates all surfaces are consistent before the GitHub Release is created.
+
+There is no automated gating from nightly → release; that decision is made by
+the release owner.
+
+---
+
+## 7. Troubleshooting
+
+### Helm: `Error: chart not found`
+
+```bash
+# List available versions in the OCI registry (requires oras CLI)
+oras repo tags ghcr.io/vllm-project/charts/semantic-router
+
+# Verify a specific version exists before installing
+helm show chart oci://ghcr.io/vllm-project/charts/semantic-router --version 0.3.0
+```
+
+### Helm: release is in a broken state after failed upgrade
+
+```bash
+helm rollback semantic-router -n vllm-semantic-router-system --wait
+# If rollback also fails due to a bad state, force-reinstall:
+helm uninstall semantic-router -n vllm-semantic-router-system
+helm install semantic-router \
+  oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version <last-known-good> \
+  -f your-values.yaml \
+  --namespace vllm-semantic-router-system --create-namespace
+```
+
+### Kubernetes: `ImagePullBackOff` after upgrade
+
+The image tag may not exist yet (release still publishing) or the pull secret
+is missing. Check:
+
+```bash
+kubectl describe pod -n vllm-semantic-router-system <pod-name>
+# Look for "ErrImagePull" and the exact tag that failed
+```
+
+If the tag genuinely does not exist, roll back while the release completes:
+
+```bash
+helm rollback semantic-router -n vllm-semantic-router-system
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -33,6 +33,7 @@ const sidebars: SidebarsConfig = {
         'installation/installation',
         'installation/k8s/operator',
         'installation/configuration',
+        'installation/upgrade-rollback',
         {
           type: 'category',
           label: 'Install with Gateways',


### PR DESCRIPTION
## Summary
Introduces explicit, versioned release channels for all published artifacts (Docker images, Helm charts, Python package, Rust crate), a cross-surface version validator that blocks mismatched releases, nightly automated builds, and an operator runbook for upgrade/rollback workflows.

---
## Motivation
Before this change, every push to `main` published a new `:latest` image and chart with no way to:
- Pin a deployment to a known-good build
- Roll back to a previous version predictably
- Verify that `pyproject.toml`, `Cargo.toml`, Docker images, and Helm charts all agree before a release ships
- Run automated pre-release smoke-test builds
---
## Changes
### New workflows
| File | Purpose |
|------|---------|
| `.github/workflows/nightly-build.yml` | Runs daily at 02:00 UTC (and on `workflow_dispatch`). Calls `docker-publish.yml` and `helm-publish.yml` to produce `nightly-YYYYMMDD` images and `0.0.0-nightly.YYYYMMDD` charts. |
| `.github/workflows/release.yml` | Release guard. Fires on every `v*` tag push. Validates that `src/vllm-sr/pyproject.toml` and `candle-binding/Cargo.toml` exactly match the tag version before any artifact lands in production registries. On success, creates a unified GitHub Release with install commands for every artifact surface. |
### Modified workflows
| File | Change |
|------|--------|
| `.github/workflows/helm-publish.yml` | Added `workflow_call` trigger (called by `nightly-build.yml`). Version resolution now covers four cases: semver tag → chart version mirrors tag; nightly → `0.0.0-nightly.YYYYMMDD`; PR → `0.0.0-pr.<number>`; main push → `0.0.0-latest`. |
| `.github/workflows/pypi-publish.yml` | Changed `Create GitHub Release` → `Attach artifacts to GitHub Release`: removed `body` and `generate_release_notes` to prevent overwriting the unified release body created by `release.yml`. Wheel artifacts still attached. |
| `.github/workflows/publish-crate.yml` | Same pattern: removed body/generate_release_notes, kept `.a`/`.so` file attachments. |
### Release channels
| Channel | Docker tag | Helm chart version | When |
|---------|-----------|-------------------|------|
| Versioned | `v0.3.0` | `0.3.0` | `v*` tag push |
| Latest | `latest` | `0.0.0-latest` | push to `main` |
| Nightly | `nightly-20260312` | `0.0.0-nightly.20260312` | daily 02:00 UTC |
| PR preview | `:sha-<hash>` | `0.0.0-pr.<number>` | pull request |
### Operator tooling
| File | Change |
|------|--------|
| `tools/make/helm.mk` | Added `HELM_OCI_REGISTRY`, `HELM_OCI_CHART`, `CHART_VERSION` variables. New targets: `helm-install-version`, `helm-upgrade-version`, `helm-check-version` for version-pinned OCI chart management. |
| `tools/make/docker.mk` | Updated `DOCKER_TAG` documentation to reflect the new release channels. |
| `website/docs/installation/upgrade-rollback.md` | **New.** Operator runbook: upgrade/rollback procedures for Helm, Docker, and Python CLI across all three release channels. |
| `website/sidebars.ts` | Added `installation/upgrade-rollback` to the Docusaurus sidebar. |
---
## Testing
All tests were run against the `liavweiss/semantic-router` fork.
| Scenario | Result | Notes |
|----------|--------|-------|
| Helm chart lint + PR artifact | ✅ | Chart packaged as `0.0.0-pr.<n>` |
| Helm chart push to GHCR (main push) | ✅ | Published as `0.0.0-latest` |
| Docker images (main push) | ✅ | Published with `sha-<hash>` and `:latest` |
| Nightly build (workflow_dispatch) | ✅ | Docker `nightly-YYYYMMDD` + Helm `0.0.0-nightly.YYYYMMDD` |
| Release validation — matching versions | ✅ | Passed; no release created (dispatch-only run) |
| Release validation — mismatched versions | ✅ | Correctly blocked with actionable error. Also caught a **real pre-existing version drift** in upstream: `pyproject.toml` at `0.3.0` while `Cargo.toml` was at `0.2.0`. |
| Full tag-based release (v0.3.0) | ✅ | Unified GitHub Release created; PyPI/crates.io uploads expected-failed (no fork secrets) |
---