### PR TITLE
[Docs] Add token-budget-aware pool routing paper to website research

### DIFF
--- a/website/src/data/researchContent.js
+++ b/website/src/data/researchContent.js
@@ -187,6 +187,20 @@ export const researchPapers = [
     sortOrder: 59.5,
   },
   {
+    id: 'token-budget-aware-pool-routing',
+    type: 'paper',
+    title: 'Token-Budget-Aware Pool Routing for Cost-Efficient LLM Inference',
+    authors: 'Huamin Chen, Xunzhuo Liu, Junchen Jiang, Bowei He, Xue Liu',
+    venue: 'arXiv Technical Report',
+    year: '2026',
+    abstract: 'We propose token-budget-aware pool routing, which estimates each request’s total token budget using a self-calibrating bytes-per-token ratio and dispatches it to short or long vLLM pools to cut fleet cost while avoiding KV-cache failures.',
+    links: [
+      { type: 'paper', url: 'https://arxiv.org/abs/2604.09613', label: 'Paper' },
+    ],
+    featured: true,
+    sortOrder: 59.75,
+  },
+  {
     id: 'when-to-reason',
     type: 'paper',
     title: 'When to Reason: Semantic Router for vLLM',


### PR DESCRIPTION
## Purpose
- Add the arXiv paper 2604.09613 (Token-Budget-Aware Pool Routing for Cost-Efficient LLM Inference) to the website research data source.
- Make the new paper show up automatically in the homepage research carousel and the /publications page.
- Affects module(s): Docs

## Test Plan
- make agent-report ENV=cpu CHANGED_FILES="website/src/data/researchContent.js"
- make docs-lint
- make docs-build
- git push -u xunzhuo feature/add-token-budget-routing-paper

## Test Result
- make agent-report ENV=cpu CHANGED_FILES="website/src/data/researchContent.js": classified as documentation-only and lightweight.
- make docs-lint: passed; an existing unrelated warning remains in website/src/components/Threads/index.tsx for @typescript-eslint/no-explicit-any.
- make docs-build: passed for en and zh-Hans; existing unrelated zh-Hans broken-anchor warnings remain.
- Repo-native pre-commit and pre-push checks passed for this branch.

No known blockers for this change.