### PR TITLE
feat(replay): track Responses API function_call items

### DIFF
--- a/dashboard/backend/router/router_replay_redaction.go
+++ b/dashboard/backend/router/router_replay_redaction.go
@@ -196,6 +196,16 @@ func redactToolTraceMap(toolTrace map[string]any) bool {
 			step["content_redacted"] = true
 			changed = true
 		}
+		if rawArguments, ok := step["raw_arguments"].(string); ok && strings.TrimSpace(rawArguments) != "" {
+			step["raw_arguments"] = ""
+			step["content_redacted"] = true
+			changed = true
+		}
+		if rawOutput, ok := step["raw_output"].(string); ok && strings.TrimSpace(rawOutput) != "" {
+			step["raw_output"] = ""
+			step["content_redacted"] = true
+			changed = true
+		}
 	}
 
 	return changed

--- a/dashboard/backend/router/router_replay_redaction_test.go
+++ b/dashboard/backend/router/router_replay_redaction_test.go
@@ -23,8 +23,8 @@ func TestRedactReplayResponseBodyRemovesSensitiveFields(t *testing.T) {
 			"tool_names":["lookup_price"],
 			"steps":[
 				{"type":"user_input","text":"sensitive user prompt"},
-				{"type":"assistant_tool_call","tool_name":"lookup_price","arguments":"{\"ticker\":\"NVDA\"}"},
-				{"type":"client_tool_result","tool_name":"lookup_price","text":"sensitive tool result"},
+				{"type":"assistant_tool_call","tool_name":"lookup_price","arguments":"{\"ticker\":\"NVDA\"}","raw_arguments":"{\"ticker\":\"NVDA\"}"},
+				{"type":"client_tool_result","tool_name":"lookup_price","text":"sensitive tool result","raw_output":"{\"price\":950.25}"},
 				{"type":"assistant_final_response","text":"sensitive final answer"}
 			]
 		}
@@ -73,6 +73,12 @@ func TestRedactReplayResponseBodyRemovesSensitiveFields(t *testing.T) {
 		}
 		if got, ok := step["arguments"]; ok && got != "" {
 			t.Fatalf("step %d arguments = %#v, want empty string", index, got)
+		}
+		if got, ok := step["raw_arguments"]; ok && got != "" {
+			t.Fatalf("step %d raw_arguments = %#v, want empty string", index, got)
+		}
+		if got, ok := step["raw_output"]; ok && got != "" {
+			t.Fatalf("step %d raw_output = %#v, want empty string", index, got)
 		}
 	}
 

--- a/dashboard/frontend/src/pages/insightsPageTypes.ts
+++ b/dashboard/frontend/src/pages/insightsPageTypes.ts
@@ -25,6 +25,8 @@ export interface ToolTraceStep {
   tool_name?: string
   tool_call_id?: string
   arguments?: string
+  raw_arguments?: string
+  raw_output?: string
   status?: string
   content_redacted?: boolean
 }

--- a/src/semantic-router/pkg/extproc/replay_tool_trace.go
+++ b/src/semantic-router/pkg/extproc/replay_tool_trace.go
@@ -88,48 +88,35 @@ func (collector *replayToolTraceCollector) addUserText(source string, role strin
 	collector.addTextStep(replayToolStepUserInput, source, role, text)
 }
 
-func (collector *replayToolTraceCollector) addAssistantToolCall(
-	source string,
-	role string,
-	toolName string,
-	toolCallID string,
-	arguments string,
-) {
-	collector.steps = append(collector.steps, routerreplay.ToolTraceStep{
-		Type:       replayToolStepAssistantToolCall,
-		Source:     source,
-		Role:       role,
-		ToolName:   toolName,
-		ToolCallID: toolCallID,
-		Arguments:  arguments,
-	})
-	if toolCallID != "" && toolName != "" {
-		collector.toolNamesByCallID[toolCallID] = toolName
+func (collector *replayToolTraceCollector) addAssistantToolCall(step routerreplay.ToolTraceStep) {
+	step.Type = replayToolStepAssistantToolCall
+	collector.steps = append(collector.steps, step)
+	if step.ToolCallID != "" && step.ToolName != "" {
+		collector.toolNamesByCallID[step.ToolCallID] = step.ToolName
 	}
 }
 
 func (collector *replayToolTraceCollector) addToolResult(source string, role string, raw json.RawMessage, toolCallID string) {
-	collector.addToolResultText(source, role, extractReplayJSONText(raw), collector.toolNamesByCallID[toolCallID], toolCallID)
-}
-
-func (collector *replayToolTraceCollector) addToolResultText(
-	source string,
-	role string,
-	text string,
-	toolName string,
-	toolCallID string,
-) {
-	if text == "" && toolName == "" && toolCallID == "" {
-		return
+	rawOutput := ""
+	if len(raw) > 0 && string(raw) != "null" {
+		rawOutput = string(raw)
 	}
-	collector.steps = append(collector.steps, routerreplay.ToolTraceStep{
-		Type:       replayToolStepClientToolResult,
+	collector.addToolResultStep(routerreplay.ToolTraceStep{
 		Source:     source,
 		Role:       role,
-		Text:       text,
-		ToolName:   toolName,
+		Text:       extractReplayJSONText(raw),
+		ToolName:   collector.toolNamesByCallID[toolCallID],
 		ToolCallID: toolCallID,
+		RawOutput:  rawOutput,
 	})
+}
+
+func (collector *replayToolTraceCollector) addToolResultStep(step routerreplay.ToolTraceStep) {
+	if step.Text == "" && step.ToolName == "" && step.ToolCallID == "" && step.RawOutput == "" {
+		return
+	}
+	step.Type = replayToolStepClientToolResult
+	collector.steps = append(collector.steps, step)
 }
 
 func (collector *replayToolTraceCollector) addAssistantFinalResponse(source string, role string, raw json.RawMessage) {
@@ -222,12 +209,13 @@ func buildReplayStreamingToolTrace(ctx *RequestContext) *routerreplay.ToolTrace 
 				continue
 			}
 			steps = append(steps, routerreplay.ToolTraceStep{
-				Type:       replayToolStepAssistantToolCall,
-				Source:     replayToolSourceStream,
-				Role:       "assistant",
-				ToolName:   call.Name,
-				ToolCallID: call.ID,
-				Arguments:  call.Arguments,
+				Type:         replayToolStepAssistantToolCall,
+				Source:       replayToolSourceStream,
+				Role:         "assistant",
+				ToolName:     call.Name,
+				ToolCallID:   call.ID,
+				Arguments:    call.Arguments,
+				RawArguments: call.Arguments,
 			})
 		}
 	}
@@ -276,7 +264,14 @@ func buildReplayTraceFromChatMessage(
 ) *routerreplay.ToolTrace {
 	collector := newReplayToolTraceCollector(len(message.ToolCalls) + 1)
 	for _, toolCall := range message.ToolCalls {
-		collector.addAssistantToolCall(source, message.Role, toolCall.Function.Name, toolCall.ID, toolCall.Function.Arguments)
+		collector.addAssistantToolCall(routerreplay.ToolTraceStep{
+			Source:       source,
+			Role:         message.Role,
+			ToolName:     toolCall.Function.Name,
+			ToolCallID:   toolCall.ID,
+			Arguments:    toolCall.Function.Arguments,
+			RawArguments: toolCall.Function.Arguments,
+		})
 	}
 	collector.addAssistantFinalResponse(source, message.Role, message.Content)
 	return collector.trace()
@@ -375,7 +370,9 @@ func replayToolTraceStepsEqual(
 		left.Text == right.Text &&
 		left.ToolName == right.ToolName &&
 		left.ToolCallID == right.ToolCallID &&
-		left.Arguments == right.Arguments
+		left.Arguments == right.Arguments &&
+		left.RawArguments == right.RawArguments &&
+		left.RawOutput == right.RawOutput
 }
 
 func replayToolTraceStepLabel(stepType string) string {
@@ -504,13 +501,14 @@ func appendReplayChatRequestMessage(collector *replayToolTraceCollector, message
 		collector.addUserInput(replayToolSourceRequest, message.Role, message.Content)
 	case "assistant":
 		for _, toolCall := range message.ToolCalls {
-			collector.addAssistantToolCall(
-				replayToolSourceRequest,
-				message.Role,
-				toolCall.Function.Name,
-				toolCall.ID,
-				toolCall.Function.Arguments,
-			)
+			collector.addAssistantToolCall(routerreplay.ToolTraceStep{
+				Source:       replayToolSourceRequest,
+				Role:         message.Role,
+				ToolName:     toolCall.Function.Name,
+				ToolCallID:   toolCall.ID,
+				Arguments:    toolCall.Function.Arguments,
+				RawArguments: toolCall.Function.Arguments,
+			})
 		}
 	case "tool":
 		collector.addToolResult(replayToolSourceRequest, message.Role, message.Content, message.ToolCallID)
@@ -549,7 +547,14 @@ func appendReplayResponseAPIRequestItem(collector *replayToolTraceCollector, ite
 	case "message":
 		appendReplayResponseAPIUserMessage(collector, item)
 	case "function_call":
-		collector.addAssistantToolCall(replayToolSourceRequest, "assistant", item.Name, item.CallID, item.Arguments)
+		collector.addAssistantToolCall(routerreplay.ToolTraceStep{
+			Source:       replayToolSourceRequest,
+			Role:         "assistant",
+			ToolName:     item.Name,
+			ToolCallID:   item.CallID,
+			Arguments:    item.Arguments,
+			RawArguments: item.Arguments,
+		})
 	case "function_call_output":
 		collector.addToolResult(replayToolSourceRequest, "tool", item.Output, item.CallID)
 	}
@@ -558,7 +563,14 @@ func appendReplayResponseAPIRequestItem(collector *replayToolTraceCollector, ite
 func appendReplayResponseAPIResponseItem(collector *replayToolTraceCollector, item replayToolTraceResponseAPIItem) {
 	switch item.Type {
 	case "function_call":
-		collector.addAssistantToolCall(replayToolSourceResponse, "assistant", item.Name, item.CallID, item.Arguments)
+		collector.addAssistantToolCall(routerreplay.ToolTraceStep{
+			Source:       replayToolSourceResponse,
+			Role:         "assistant",
+			ToolName:     item.Name,
+			ToolCallID:   item.CallID,
+			Arguments:    item.Arguments,
+			RawArguments: item.Arguments,
+		})
 	case "function_call_output":
 		collector.addToolResult(replayToolSourceResponse, "tool", item.Output, item.CallID)
 	case "message":

--- a/src/semantic-router/pkg/extproc/replay_tool_trace_test.go
+++ b/src/semantic-router/pkg/extproc/replay_tool_trace_test.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -165,10 +166,17 @@ func TestParseChatCompletionRequestToolTracePreservesNullToolResult(t *testing.T
 
 	if assert.NotNil(t, trace) {
 		assert.Len(t, trace.Steps, 3)
+
+		// Chat Completions tool call step should preserve RawArguments.
+		assert.Equal(t, replayToolStepAssistantToolCall, trace.Steps[1].Type)
+		assert.JSONEq(t, "{\"location\":\"San Francisco\"}", trace.Steps[1].RawArguments)
+
+		// Null tool result: Text, RawOutput should both be empty.
 		assert.Equal(t, replayToolStepClientToolResult, trace.Steps[2].Type)
 		assert.Equal(t, "get_weather", trace.Steps[2].ToolName)
 		assert.Equal(t, "call_weather", trace.Steps[2].ToolCallID)
 		assert.Empty(t, trace.Steps[2].Text)
+		assert.Empty(t, trace.Steps[2].RawOutput)
 	}
 }
 
@@ -190,5 +198,221 @@ func TestBuildReplayStreamingToolTrace(t *testing.T) {
 		assert.Equal(t, "LLM Final Response", trace.Stage)
 		assert.Equal(t, []string{"get_weather"}, trace.ToolNames)
 		assert.Len(t, trace.Steps, 2)
+
+		// Streaming tool call step should preserve RawArguments.
+		assert.Equal(t, replayToolStepAssistantToolCall, trace.Steps[0].Type)
+		assert.JSONEq(t, "{\"location\":\"San Francisco\"}", trace.Steps[0].RawArguments)
+	}
+}
+
+func TestParseResponseAPIResponseToolTraceWithComplexContent(t *testing.T) {
+	trace := parseResponseAPIResponseToolTrace([]byte(`{
+		"output": [
+			{
+				"type": "function_call",
+				"call_id": "call_weather",
+				"name": "get_weather",
+				"arguments": "{\"location\":\"San Francisco\"}"
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{"type": "output_text", "text": "The weather is sunny."}
+				]
+			}
+		]
+	}`))
+
+	if assert.NotNil(t, trace) {
+		assert.Equal(t, "LLM Tool Call -> LLM Final Response", trace.Flow)
+		assert.Len(t, trace.Steps, 2)
+		assert.Equal(t, replayToolStepAssistantToolCall, trace.Steps[0].Type)
+		assert.Equal(t, "call_weather", trace.Steps[0].ToolCallID)
+		assert.Equal(t, "get_weather", trace.Steps[0].ToolName)
+		assert.JSONEq(t, "{\"location\":\"San Francisco\"}", trace.Steps[0].RawArguments)
+		assert.Equal(t, replayToolStepAssistantFinalResponse, trace.Steps[1].Type)
+		assert.Equal(t, "The weather is sunny.", trace.Steps[1].Text)
+	}
+}
+
+func TestParseResponseAPIRequestToolTraceMultiToolStructuredOutput(t *testing.T) {
+	trace := parseResponseAPIRequestToolTrace([]byte(`[
+		{
+			"type": "message",
+			"role": "user",
+			"content": "Find weather and news."
+		},
+		{
+			"type": "function_call",
+			"call_id": "call_weather",
+			"name": "get_weather",
+			"arguments": "{\"location\":\"San Francisco\"}"
+		},
+		{
+			"type": "function_call_output",
+			"call_id": "call_weather",
+			"output": {"temperature": "18C", "condition": "sunny"}
+		},
+		{
+			"type": "function_call",
+			"call_id": "call_news",
+			"name": "get_news",
+			"arguments": "{\"topic\":\"tech\"}"
+		},
+		{
+			"type": "function_call_output",
+			"call_id": "call_news",
+			"output": [{"headline": "AI advances", "source": "TechDaily"}]
+		}
+	]`))
+
+	if assert.NotNil(t, trace) {
+		assert.Equal(t, "User Query -> LLM Tool Call -> Client Tool Result -> LLM Tool Call -> Client Tool Result", trace.Flow)
+		assert.Len(t, trace.Steps, 5)
+
+		// First tool call
+		assert.Equal(t, replayToolStepAssistantToolCall, trace.Steps[1].Type)
+		assert.Equal(t, "call_weather", trace.Steps[1].ToolCallID)
+		assert.Equal(t, "get_weather", trace.Steps[1].ToolName)
+		assert.JSONEq(t, "{\"location\":\"San Francisco\"}", trace.Steps[1].RawArguments)
+
+		// First structured output
+		assert.Equal(t, replayToolStepClientToolResult, trace.Steps[2].Type)
+		assert.Equal(t, "call_weather", trace.Steps[2].ToolCallID)
+		assert.Equal(t, "get_weather", trace.Steps[2].ToolName)
+		assert.JSONEq(t, `{"temperature":"18C","condition":"sunny"}`, trace.Steps[2].RawOutput)
+		assert.Contains(t, trace.Steps[2].Text, "temperature")
+
+		// Second tool call
+		assert.Equal(t, replayToolStepAssistantToolCall, trace.Steps[3].Type)
+		assert.Equal(t, "call_news", trace.Steps[3].ToolCallID)
+		assert.Equal(t, "get_news", trace.Steps[3].ToolName)
+		assert.JSONEq(t, "{\"topic\":\"tech\"}", trace.Steps[3].RawArguments)
+
+		// Second structured output (array)
+		assert.Equal(t, replayToolStepClientToolResult, trace.Steps[4].Type)
+		assert.Equal(t, "call_news", trace.Steps[4].ToolCallID)
+		assert.Equal(t, "get_news", trace.Steps[4].ToolName)
+		assert.JSONEq(t, `[{"headline":"AI advances","source":"TechDaily"}]`, trace.Steps[4].RawOutput)
+	}
+}
+
+func TestResponseAPIToolTraceRoundTrip(t *testing.T) {
+	requestTrace := parseResponseAPIRequestToolTrace([]byte(`[
+		{
+			"type": "message",
+			"role": "user",
+			"content": "What's the weather?"
+		},
+		{
+			"type": "function_call",
+			"call_id": "call_weather_123",
+			"name": "get_weather",
+			"arguments": "{\"city\":\"Berlin\"}"
+		},
+		{
+			"type": "function_call_output",
+			"call_id": "call_weather_123",
+			"output": {"temp": 22, "unit": "C"}
+		}
+	]`))
+
+	responseTrace := parseResponseAPIResponseToolTrace([]byte(`{
+		"output": [
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": "It is 22C in Berlin."
+			}
+		]
+	}`))
+
+	merged := mergeReplayToolTraces(requestTrace, responseTrace)
+	if !assert.NotNil(t, merged) {
+		return
+	}
+	assert.Len(t, merged.Steps, 4)
+
+	// Round-trip through JSON marshal/unmarshal to verify persistence fidelity.
+	serialized, err := json.Marshal(merged)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var restored routerreplay.ToolTrace
+	if !assert.NoError(t, json.Unmarshal(serialized, &restored)) {
+		return
+	}
+
+	if !assert.Len(t, restored.Steps, 4) {
+		return
+	}
+
+	// Verify call_id -> ToolCallID survives round-trip.
+	assert.Equal(t, "call_weather_123", restored.Steps[1].ToolCallID)
+	assert.Equal(t, "call_weather_123", restored.Steps[2].ToolCallID)
+
+	// Verify raw arguments preserved as exact string through round-trip.
+	assert.JSONEq(t, "{\"city\":\"Berlin\"}", restored.Steps[1].RawArguments)
+
+	// Verify raw structured output preserved as exact string through round-trip.
+	// This confirms that RawOutput (a string field) is not altered by JSON
+	// marshal/unmarshal — e.g. numeric values like 22 stay as "22" not "22.0".
+	assert.Equal(t, restored.Steps[2].RawOutput, merged.Steps[2].RawOutput)
+	assert.JSONEq(t, `{"temp":22,"unit":"C"}`, restored.Steps[2].RawOutput)
+
+	// Verify text extracted from structured output is present.
+	assert.Contains(t, restored.Steps[2].Text, "temp")
+
+	// Verify flow and stage survive round-trip.
+	assert.Equal(t, merged.Flow, restored.Flow)
+	assert.Equal(t, merged.Stage, restored.Stage)
+	assert.Equal(t, merged.ToolNames, restored.ToolNames)
+}
+
+func TestBuildReplayStreamingToolTracePreservesResponseAPICallID(t *testing.T) {
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+		},
+		StreamingContent: "It is 18C and sunny in San Francisco.",
+		StreamingToolCalls: map[int]*StreamingToolCallState{
+			0: {
+				ID:        "call_weather_123",
+				Name:      "get_weather",
+				Arguments: "{\"location\":\"San Francisco\"}",
+			},
+			1: {
+				ID:        "call_news_456",
+				Name:      "get_news",
+				Arguments: "{\"topic\":\"tech\"}",
+			},
+		},
+	}
+
+	trace := buildReplayStreamingToolTrace(ctx)
+	if assert.NotNil(t, trace) {
+		// Flow deduplicates consecutive identical step labels, so two assistant_tool_calls
+		// collapse into a single "LLM Tool Call" label.
+		assert.Equal(t, "LLM Tool Call -> LLM Final Response", trace.Flow)
+		assert.Equal(t, []string{"get_weather", "get_news"}, trace.ToolNames)
+		assert.Len(t, trace.Steps, 3)
+
+		// First streamed tool call should preserve call_id as ToolCallID.
+		assert.Equal(t, replayToolStepAssistantToolCall, trace.Steps[0].Type)
+		assert.Equal(t, "call_weather_123", trace.Steps[0].ToolCallID)
+		assert.Equal(t, "get_weather", trace.Steps[0].ToolName)
+		assert.JSONEq(t, "{\"location\":\"San Francisco\"}", trace.Steps[0].RawArguments)
+
+		// Second streamed tool call should preserve call_id as ToolCallID.
+		assert.Equal(t, replayToolStepAssistantToolCall, trace.Steps[1].Type)
+		assert.Equal(t, "call_news_456", trace.Steps[1].ToolCallID)
+		assert.Equal(t, "get_news", trace.Steps[1].ToolName)
+		assert.JSONEq(t, "{\"topic\":\"tech\"}", trace.Steps[1].RawArguments)
+
+		// Final assistant response.
+		assert.Equal(t, replayToolStepAssistantFinalResponse, trace.Steps[2].Type)
+		assert.Equal(t, "It is 18C and sunny in San Francisco.", trace.Steps[2].Text)
 	}
 }

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -57,6 +57,11 @@ type ToolTraceStep struct {
 	ToolName   string `json:"tool_name,omitempty"`
 	ToolCallID string `json:"tool_call_id,omitempty"`
 	Arguments  string `json:"arguments,omitempty"`
+	// RawArguments preserves the original arguments JSON.
+	// Currently identical to Arguments because no normalization is performed,
+	// but retained for fidelity in case future processing diverges.
+	RawArguments string `json:"raw_arguments,omitempty"`
+	RawOutput    string `json:"raw_output,omitempty"`
 }
 
 // Record represents a routing decision record with metadata and captured payloads.


### PR DESCRIPTION
Closes #1781

## Purpose

**What does this PR change?**
Add `RawArguments` and `RawOutput` fields to `ToolTraceStep` to preserve original JSON of Responses API tool inputs/outputs. Refactor collector methods to accept struct params. Fix redaction leak for new fields.

**Why is this change needed?**
The current tool trace conversion loses fidelity when handling Responses API structured outputs — raw JSON gets extracted to plain text, making round-trip reconstruction impossible.

**Which module(s) does this affect?** 
Router / Dashboard

## Test Plan
**What commands, checks, or manual steps should reviewers use?**
```bash
cd src/semantic-router && go test ./pkg/extproc/ ./pkg/routerreplay/... -v -count=1
cd dashboard/backend && go test ./router/ -v -count=1
```
**Why is this validation sufficient for the affected module(s)?**
Round-trip test covers JSON marshal/unmarshal fidelity for new fields
Redaction test verifies raw_arguments/raw_output are blanked for read-only users
Multi-tool and streaming paths covered with new assertions
Storage backends (Postgres/Redis/Milvus) use JSONB serialization of the full struct, so new omitempty fields are automatically handled

## Test Result
**What were the actual results?**
All tests pass: pkg/extproc, pkg/routerreplay, dashboard/backend/router.
**Any follow-up risks, gaps, or blockers?**
Responses API streaming path (response.function_call_arguments.delta) does not yet generate tool traces — out of scope for this PR.
RawArguments currently equals Arguments in all code paths; divergence expected when argument normalization is added later.


