### PR TITLE
[Router] Add bounded candidate iteration to DSL

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -16,6 +16,7 @@ Inside canonical `config.yaml`:
 - `routing.projections` carries cross-signal coordination and derived routing outputs
 - `routing.projections.partitions` is the canonical runtime home for exclusive domain or embedding partitions; DSL authoring uses `PROJECTION partition`
 - `routing.projections.scores` and `routing.projections.mappings` let maintained configs turn learned and heuristic signals into named routing bands that decisions can reference with `type: projection`
+- `routing.decisions[].candidateIterations` carries bounded DSL `FOR ... IN` metadata for candidate-model authoring; it is declarative selection policy input, not a general scripting runtime
 - request-shape detectors such as `routing.signals.structure` stay in the signal layer as typed named facts; numeric thresholds live inside the detector config instead of turning decisions into a free-form expression language
 - structure `density` features now use built-in multilingual text-unit normalization; the contract no longer exposes a per-rule `normalize_by` switch
 - the dashboard and DSL builder now expose the same projection surface directly; see `website/docs/tutorials/signal/projections.md` and the maintained `deploy/recipes/balance.{yaml,dsl}` pair for end-to-end usage
@@ -37,6 +38,7 @@ Inside canonical `config.yaml`:
 - `composite/`: nested AND/OR/NOT cases
 
 Decision fragments may reference `modelRefs[].lora_name`, but those adapter names must be declared in the base config's `routing.modelCards[].loras`.
+Candidate iteration fragments must stay bounded to `decision.candidates` or an explicit model list and feed existing decision outputs such as `MODEL <iterator>`.
 
 `config/algorithm/` is organized by routing policy:
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -497,6 +497,19 @@ routing:
         - model: qwen3-8b
           use_reasoning: false
           reasoning_description: Prefer fast, direct business answers.
+      candidateIterations:
+        - variable: candidate
+          source: models
+          models:
+            - model: qwen3-8b
+              lora_name: business-adapter
+              weight: 1.0
+              use_reasoning: false
+              reasoning_description: Candidate iteration reference model for DSL authoring coverage.
+              reasoning_effort: low
+          outputs:
+            - type: model
+              value: candidate
       algorithm:
         type: static
       plugins:

--- a/deploy/recipes/bounded-candidate-iteration.dsl
+++ b/deploy/recipes/bounded-candidate-iteration.dsl
@@ -1,0 +1,50 @@
+# =============================================================================
+# BOUNDED CANDIDATE ITERATION RECIPE
+# =============================================================================
+
+SIGNAL keyword business_request {
+  operator: "OR"
+  keywords: ["business plan", "market analysis", "pricing strategy", "go to market"]
+}
+
+SIGNAL keyword complex_reasoning_request {
+  operator: "OR"
+  keywords: ["compare tradeoffs", "step by step", "deep analysis", "reason through"]
+}
+
+# =============================================================================
+# MODELS
+# =============================================================================
+
+MODEL qwen3-8b {
+  context_window_size: 32768
+}
+
+MODEL qwen3-32b {
+  context_window_size: 131072
+}
+
+# =============================================================================
+# ROUTES
+# =============================================================================
+
+ROUTE iterate_existing_candidates (description = "Iterate over the route's declared candidate models.") {
+  PRIORITY 100
+  WHEN keyword("business_request")
+
+  MODEL "qwen3-8b" (reasoning = false)
+  MODEL "qwen3-32b" (reasoning = true, effort = "medium")
+
+  FOR candidate IN decision.candidates {
+    MODEL candidate
+  }
+}
+
+ROUTE iterate_explicit_candidates (description = "Declare a bounded candidate list directly in the iteration source.") {
+  PRIORITY 90
+  WHEN keyword("complex_reasoning_request")
+
+  FOR candidate IN ["qwen3-8b" (reasoning = false), "qwen3-32b" (reasoning = true, effort = "medium")] {
+    MODEL candidate
+  }
+}

--- a/src/semantic-router/pkg/config/decision_config.go
+++ b/src/semantic-router/pkg/config/decision_config.go
@@ -2,14 +2,32 @@ package config
 
 // Decision represents a routing decision that combines multiple rules with boolean logic.
 type Decision struct {
-	Name        string           `yaml:"name"`
-	Description string           `yaml:"description,omitempty"`
-	Priority    int              `yaml:"priority,omitempty"`
-	Tier        int              `yaml:"tier,omitempty"`
-	Rules       RuleCombination  `yaml:"rules"`
-	ModelRefs   []ModelRef       `yaml:"modelRefs,omitempty"`
-	Algorithm   *AlgorithmConfig `yaml:"algorithm,omitempty"`
-	Plugins     []DecisionPlugin `yaml:"plugins,omitempty"`
+	Name                string                     `yaml:"name"`
+	Description         string                     `yaml:"description,omitempty"`
+	Priority            int                        `yaml:"priority,omitempty"`
+	Tier                int                        `yaml:"tier,omitempty"`
+	Rules               RuleCombination            `yaml:"rules"`
+	ModelRefs           []ModelRef                 `yaml:"modelRefs,omitempty"`
+	Algorithm           *AlgorithmConfig           `yaml:"algorithm,omitempty"`
+	Plugins             []DecisionPlugin           `yaml:"plugins,omitempty"`
+	CandidateIterations []CandidateIterationConfig `yaml:"candidateIterations,omitempty"`
+}
+
+// CandidateIterationConfig is the canonical, bounded representation of a DSL
+// FOR ... IN block over candidate models. It is declarative metadata consumed
+// by selection/policy layers, not a runtime script.
+type CandidateIterationConfig struct {
+	Variable string                           `yaml:"variable"`
+	Source   string                           `yaml:"source"`
+	Models   []ModelRef                       `yaml:"models,omitempty"`
+	Outputs  []CandidateIterationOutputConfig `yaml:"outputs,omitempty"`
+}
+
+// CandidateIterationOutputConfig describes how an iteration feeds an existing
+// routing construct. The initial supported output is type=model, value=<var>.
+type CandidateIterationOutputConfig struct {
+	Type  string `yaml:"type"`
+	Value string `yaml:"value,omitempty"`
 }
 
 // AlgorithmConfig defines how multiple models should be executed and aggregated.

--- a/src/semantic-router/pkg/config/reference_config_public_surface_test.go
+++ b/src/semantic-router/pkg/config/reference_config_public_surface_test.go
@@ -201,6 +201,25 @@ func assertReferenceConfigDecisionCoverage(t testingT, decisions []interface{}) 
 		reflect.TypeOf(ModelRef{}),
 		"routing.decisions[].modelRefs",
 	)
+	candidateIterations := collectNestedSliceItems(t, decisions, "candidateIterations", "routing.decisions")
+	assertSliceUnionCoversStructFields(
+		t,
+		candidateIterations,
+		reflect.TypeOf(CandidateIterationConfig{}),
+		"routing.decisions[].candidateIterations",
+	)
+	assertSliceUnionCoversStructFields(
+		t,
+		collectNestedSliceItems(t, candidateIterations, "models", "routing.decisions[].candidateIterations"),
+		reflect.TypeOf(ModelRef{}),
+		"routing.decisions[].candidateIterations[].models",
+	)
+	assertSliceUnionCoversStructFields(
+		t,
+		collectNestedSliceItems(t, candidateIterations, "outputs", "routing.decisions[].candidateIterations"),
+		reflect.TypeOf(CandidateIterationOutputConfig{}),
+		"routing.decisions[].candidateIterations[].outputs",
+	)
 	assertSliceUnionCoversStructFields(
 		t,
 		collectChildMapsFromSlice(t, decisions, "algorithm", "routing.decisions"),

--- a/src/semantic-router/pkg/config/validator_candidate_iteration_test.go
+++ b/src/semantic-router/pkg/config/validator_candidate_iteration_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// minimalDecision returns a Decision with one ModelRef pre-filled so tests
+// only need to set the fields under test.
+func minimalDecision(name string) Decision {
+	return Decision{
+		Name:      name,
+		ModelRefs: []ModelRef{{Model: "base-model"}},
+	}
+}
+
+func TestValidateCandidateIterationAcceptsDecisionCandidatesSource(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{
+			Variable: "candidate",
+			Source:   "decision.candidates",
+			Outputs:  []CandidateIterationOutputConfig{{Type: "model", Value: "candidate"}},
+		},
+	}
+	if err := validateDecisionCandidateIterations(d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCandidateIterationAcceptsExplicitModelSource(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{
+			Variable: "c",
+			Source:   "models",
+			Models:   []ModelRef{{Model: "small-model"}, {Model: "large-model"}},
+			Outputs:  []CandidateIterationOutputConfig{{Type: "model", Value: "c"}},
+		},
+	}
+	if err := validateDecisionCandidateIterations(d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCandidateIterationRejectsEmptyVariable(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{Variable: "", Source: "decision.candidates"},
+	}
+	err := validateDecisionCandidateIterations(d)
+	if err == nil {
+		t.Fatal("expected error for empty variable, got nil")
+	}
+	if !strings.Contains(err.Error(), "variable cannot be empty") {
+		t.Fatalf("error message = %q, want to contain 'variable cannot be empty'", err.Error())
+	}
+}
+
+func TestValidateCandidateIterationRejectsUnsupportedSource(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{Variable: "c", Source: "runtime.models"},
+	}
+	err := validateDecisionCandidateIterations(d)
+	if err == nil {
+		t.Fatal("expected error for unsupported source, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported source") {
+		t.Fatalf("error message = %q, want to contain 'unsupported source'", err.Error())
+	}
+}
+
+func TestValidateCandidateIterationRejectsDecisionCandidatesWithNoModelRefs(t *testing.T) {
+	d := Decision{
+		Name: "route",
+		CandidateIterations: []CandidateIterationConfig{
+			{Variable: "c", Source: "decision.candidates"},
+		},
+	}
+	err := validateDecisionCandidateIterations(d)
+	if err == nil {
+		t.Fatal("expected error when decision.candidates used without modelRefs, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-empty modelRefs") {
+		t.Fatalf("error message = %q, want to contain 'non-empty modelRefs'", err.Error())
+	}
+}
+
+func TestValidateCandidateIterationRejectsEmptyModelList(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{Variable: "c", Source: "models", Models: nil},
+	}
+	err := validateDecisionCandidateIterations(d)
+	if err == nil {
+		t.Fatal("expected error for empty models list, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one model") {
+		t.Fatalf("error message = %q, want to contain 'at least one model'", err.Error())
+	}
+}
+
+func TestValidateCandidateIterationRejectsBlankModelName(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{Variable: "c", Source: "models", Models: []ModelRef{{Model: ""}}},
+	}
+	err := validateDecisionCandidateIterations(d)
+	if err == nil {
+		t.Fatal("expected error for blank model name, got nil")
+	}
+	if !strings.Contains(err.Error(), "model name cannot be empty") {
+		t.Fatalf("error message = %q, want to contain 'model name cannot be empty'", err.Error())
+	}
+}
+
+func TestValidateCandidateIterationRejectsUnsupportedOutputType(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{
+			Variable: "c",
+			Source:   "decision.candidates",
+			Outputs:  []CandidateIterationOutputConfig{{Type: "policy", Value: "c"}},
+		},
+	}
+	err := validateDecisionCandidateIterations(d)
+	if err == nil {
+		t.Fatal("expected error for unsupported output type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported output type") {
+		t.Fatalf("error message = %q, want to contain 'unsupported output type'", err.Error())
+	}
+}
+
+func TestValidateCandidateIterationRejectsOutputNotReferencingVariable(t *testing.T) {
+	d := minimalDecision("route")
+	d.CandidateIterations = []CandidateIterationConfig{
+		{
+			Variable: "c",
+			Source:   "decision.candidates",
+			Outputs:  []CandidateIterationOutputConfig{{Type: "model", Value: "other"}},
+		},
+	}
+	err := validateDecisionCandidateIterations(d)
+	if err == nil {
+		t.Fatal("expected error when output value does not match iterator variable, got nil")
+	}
+	if !strings.Contains(err.Error(), "reference variable") {
+		t.Fatalf("error message = %q, want to contain 'reference variable'", err.Error())
+	}
+}

--- a/src/semantic-router/pkg/config/validator_decision.go
+++ b/src/semantic-router/pkg/config/validator_decision.go
@@ -22,6 +22,9 @@ func validateDecisionModelContracts(cfg *RouterConfig) error {
 		if err := validateDecisionAlgorithmConfig(decision.Name, decision.Algorithm); err != nil {
 			return err
 		}
+		if err := validateDecisionCandidateIterations(decision); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -39,6 +42,64 @@ func validateDecisionModelRefs(cfg *RouterConfig, decision Decision) error {
 		}
 		if err := validateLoRAName(cfg, modelRef.Model, modelRef.LoRAName); err != nil {
 			return fmt.Errorf("decision '%s', model '%s': %w", decision.Name, modelRef.Model, err)
+		}
+	}
+	return nil
+}
+
+func validateDecisionCandidateIterations(decision Decision) error {
+	for i, iter := range decision.CandidateIterations {
+		context := fmt.Sprintf("decision '%s', candidateIterations[%d]", decision.Name, i)
+		if err := validateDecisionCandidateIteration(decision, iter, context); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDecisionCandidateIteration(decision Decision, iter CandidateIterationConfig, context string) error {
+	if strings.TrimSpace(iter.Variable) == "" {
+		return fmt.Errorf("%s: variable cannot be empty", context)
+	}
+	if err := validateDecisionCandidateIterationSource(decision, iter, context); err != nil {
+		return err
+	}
+	return validateDecisionCandidateIterationOutputs(iter, context)
+}
+
+func validateDecisionCandidateIterationSource(decision Decision, iter CandidateIterationConfig, context string) error {
+	switch strings.TrimSpace(iter.Source) {
+	case "decision.candidates":
+		if len(decision.ModelRefs) == 0 {
+			return fmt.Errorf("%s: source decision.candidates requires non-empty modelRefs", context)
+		}
+	case "models":
+		return validateDecisionCandidateIterationModels(iter.Models, context)
+	default:
+		return fmt.Errorf("%s: unsupported source %q", context, iter.Source)
+	}
+	return nil
+}
+
+func validateDecisionCandidateIterationModels(models []ModelRef, context string) error {
+	if len(models) == 0 {
+		return fmt.Errorf("%s: source models requires at least one model", context)
+	}
+	for j, modelRef := range models {
+		if strings.TrimSpace(modelRef.Model) == "" {
+			return fmt.Errorf("%s, models[%d]: model name cannot be empty", context, j)
+		}
+	}
+	return nil
+}
+
+func validateDecisionCandidateIterationOutputs(iter CandidateIterationConfig, context string) error {
+	for j, output := range iter.Outputs {
+		if output.Type != "model" {
+			return fmt.Errorf("%s, outputs[%d]: unsupported output type %q", context, j, output.Type)
+		}
+		if output.Value != iter.Variable {
+			return fmt.Errorf("%s, outputs[%d]: model output must reference variable %q", context, j, iter.Variable)
 		}
 	}
 	return nil

--- a/src/semantic-router/pkg/dsl/ast.go
+++ b/src/semantic-router/pkg/dsl/ast.go
@@ -111,13 +111,14 @@ type rawDecisionTreeElseBranch struct {
 
 // rawDecisionTreeItem is a route-like statement inside one DECISION_TREE branch.
 type rawDecisionTreeItem struct {
-	Pos         lexer.Position
-	Name        *string       `parser:"  'NAME' @(Ident | String)"`
-	Description *string       `parser:"| 'DESCRIPTION' @String"`
-	Tier        *int          `parser:"| 'TIER' @Int"`
-	Model       *rawModelList `parser:"| 'MODEL' @@"`
-	Algorithm   *rawAlgoSpec  `parser:"| 'ALGORITHM' @@"`
-	Plugin      *rawPluginRef `parser:"| 'PLUGIN' @@"`
+	Pos          lexer.Position
+	Name         *string              `parser:"  'NAME' @(Ident | String)"`
+	Description  *string              `parser:"| 'DESCRIPTION' @String"`
+	Tier         *int                 `parser:"| 'TIER' @Int"`
+	Model        *rawModelList        `parser:"| 'MODEL' @@"`
+	Algorithm    *rawAlgoSpec         `parser:"| 'ALGORITHM' @@"`
+	Plugin       *rawPluginRef        `parser:"| 'PLUGIN' @@"`
+	CandidateFor *rawCandidateForDecl `parser:"| @@"`
 }
 
 // rawModelDecl: MODEL <name> { fields... }
@@ -136,14 +137,38 @@ type RouteOpt struct {
 
 // rawRouteItem: a single element inside a route body
 type rawRouteItem struct {
-	Pos         lexer.Position
-	Priority    *int          `parser:"  'PRIORITY' @Int"`
-	Tier        *int          `parser:"| 'TIER' @Int"`
-	When        *BoolExprTop  `parser:"| 'WHEN' @@"`
-	Model       *rawModelList `parser:"| 'MODEL' @@"`
-	Algorithm   *rawAlgoSpec  `parser:"| 'ALGORITHM' @@"`
-	Plugin      *rawPluginRef `parser:"| 'PLUGIN' @@"`
-	Description *string       `parser:"| 'DESCRIPTION' @String"`
+	Pos          lexer.Position
+	Priority     *int                 `parser:"  'PRIORITY' @Int"`
+	Tier         *int                 `parser:"| 'TIER' @Int"`
+	When         *BoolExprTop         `parser:"| 'WHEN' @@"`
+	Model        *rawModelList        `parser:"| 'MODEL' @@"`
+	Algorithm    *rawAlgoSpec         `parser:"| 'ALGORITHM' @@"`
+	Plugin       *rawPluginRef        `parser:"| 'PLUGIN' @@"`
+	Description  *string              `parser:"| 'DESCRIPTION' @String"`
+	CandidateFor *rawCandidateForDecl `parser:"| @@"`
+}
+
+// rawCandidateForDecl: FOR <var> IN decision.candidates|[models...] { body... }
+type rawCandidateForDecl struct {
+	Pos    lexer.Position
+	Var    string                       `parser:"'FOR' @Ident"`
+	Source *rawCandidateIterationSource `parser:"'IN' @@"`
+	Body   []*rawCandidateIterationItem `parser:"'{' @@* '}'"`
+}
+
+// rawCandidateIterationSource is either the current decision candidate set or
+// an explicit bounded model list.
+type rawCandidateIterationSource struct {
+	Ref    *string       `parser:"  @(Ident | String)"`
+	Models *rawModelList `parser:"| '[' @@ ']'"`
+}
+
+// rawCandidateIterationItem is a structured output inside a bounded candidate
+// iteration block. The initial surface only feeds MODEL outputs back into the
+// existing decision model-ref contract.
+type rawCandidateIterationItem struct {
+	Pos   lexer.Position
+	Model *rawModelList `parser:"'MODEL' @@"`
 }
 
 // rawPluginDecl: PLUGIN <name> <type> { fields... }
@@ -354,15 +379,36 @@ type SignalDecl struct {
 
 // RouteDecl represents a ROUTE declaration.
 type RouteDecl struct {
-	Name        string
-	Description string
-	Priority    int
-	Tier        int
-	When        BoolExpr
-	Models      []*ModelRef
-	Algorithm   *AlgoSpec
-	Plugins     []*PluginRef
-	Pos         Position
+	Name                string
+	Description         string
+	Priority            int
+	Tier                int
+	When                BoolExpr
+	Models              []*ModelRef
+	Algorithm           *AlgoSpec
+	Plugins             []*PluginRef
+	CandidateIterations []*CandidateIterationDecl
+	Pos                 Position
+}
+
+// CandidateIterationDecl represents a bounded FOR ... IN block over candidate
+// models. Source is either "decision.candidates" or "models".
+type CandidateIterationDecl struct {
+	Variable string
+	Source   string
+	Models   []*ModelRef
+	Outputs  []*CandidateIterationOutputDecl
+	Pos      Position
+}
+
+// CandidateIterationOutputDecl describes how the iteration feeds an existing
+// routing construct. The initial output type is "model" with Value equal to the
+// iteration variable.
+type CandidateIterationOutputDecl struct {
+	Type   string
+	Value  string
+	Models []*ModelRef
+	Pos    Position
 }
 
 // ModelDecl represents a top-level model catalog entry.

--- a/src/semantic-router/pkg/dsl/candidate_iteration.go
+++ b/src/semantic-router/pkg/dsl/candidate_iteration.go
@@ -1,0 +1,56 @@
+package dsl
+
+import "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+
+// iterEmitsVariable reports whether the iteration has at least one MODEL output
+// that references the iterator variable, which is the canonical
+// bounded-iteration output contract.
+func iterEmitsVariable(iter config.CandidateIterationConfig) bool {
+	for _, output := range iter.Outputs {
+		if output.Type == "model" && output.Value == iter.Variable {
+			return true
+		}
+	}
+	return false
+}
+
+func rawToCandidateIteration(r *rawCandidateForDecl) *CandidateIterationDecl {
+	iter := &CandidateIterationDecl{
+		Variable: r.Var,
+		Source:   "decision.candidates",
+		Pos:      posFromLexer(r.Pos),
+	}
+	if r.Source != nil {
+		switch {
+		case r.Source.Ref != nil:
+			iter.Source = unquoteIdent(*r.Source.Ref)
+		case r.Source.Models != nil:
+			iter.Source = "models"
+			for _, model := range r.Source.Models.Models {
+				iter.Models = append(iter.Models, rawToModelRef(model))
+			}
+		}
+	}
+	for _, item := range r.Body {
+		if item.Model == nil {
+			continue
+		}
+		iter.Outputs = append(iter.Outputs, rawToCandidateIterationModelOutput(item))
+	}
+	return iter
+}
+
+func rawToCandidateIterationModelOutput(item *rawCandidateIterationItem) *CandidateIterationOutputDecl {
+	output := &CandidateIterationOutputDecl{
+		Type: "model",
+		Pos:  posFromLexer(item.Pos),
+	}
+	for _, model := range item.Model.Models {
+		ref := rawToModelRef(model)
+		output.Models = append(output.Models, ref)
+		if output.Value == "" {
+			output.Value = ref.Model
+		}
+	}
+	return output
+}

--- a/src/semantic-router/pkg/dsl/compiler.go
+++ b/src/semantic-router/pkg/dsl/compiler.go
@@ -615,7 +615,6 @@ func (c *Compiler) compileCandidateIteration(iter *CandidateIterationDecl) confi
 	return compiled
 }
 
-
 func (c *Compiler) compileBoolExpr(expr BoolExpr) config.RuleCombination {
 	switch e := expr.(type) {
 	case *BoolAnd:

--- a/src/semantic-router/pkg/dsl/compiler.go
+++ b/src/semantic-router/pkg/dsl/compiler.go
@@ -510,29 +510,20 @@ func (c *Compiler) compileRoutes() {
 
 		// Compile MODEL list
 		for _, m := range r.Models {
-			ref := config.ModelRef{
-				Model:    m.Model,
-				LoRAName: m.LoRA,
-				Weight:   m.Weight,
-			}
-			if m.Reasoning != nil {
-				ref.UseReasoning = m.Reasoning
-			}
-			if m.Effort != "" {
-				ref.ReasoningEffort = m.Effort
-			}
-			decision.ModelRefs = append(decision.ModelRefs, ref)
+			c.appendModelRef(&decision, m)
+		}
 
-			// Populate model_config for route-local model metadata fields.
-			if m.ParamSize != "" {
-				if c.config.ModelConfig == nil {
-					c.config.ModelConfig = make(map[string]config.ModelParams)
+		// Compile bounded candidate iteration blocks. Explicit model sources
+		// that emit MODEL <variable> feed the existing decision ModelRefs
+		// contract so selectors still receive candidates through the canonical
+		// SelectionContext.CandidateModels path.
+		for _, iter := range r.CandidateIterations {
+			compiled := c.compileCandidateIteration(iter)
+			decision.CandidateIterations = append(decision.CandidateIterations, compiled)
+			if compiled.Source == "models" && iterEmitsVariable(compiled) {
+				for _, model := range iter.Models {
+					c.appendModelRefIfMissing(&decision, model)
 				}
-				mc := c.config.ModelConfig[m.Model]
-				if m.ParamSize != "" {
-					mc.ParamSize = m.ParamSize
-				}
-				c.config.ModelConfig[m.Model] = mc
 			}
 		}
 
@@ -552,6 +543,78 @@ func (c *Compiler) compileRoutes() {
 		c.config.Decisions = append(c.config.Decisions, decision)
 	}
 }
+
+func (c *Compiler) appendModelRef(decision *config.Decision, m *ModelRef) {
+	if decision == nil || m == nil {
+		return
+	}
+	ref := config.ModelRef{
+		Model:    m.Model,
+		LoRAName: m.LoRA,
+		Weight:   m.Weight,
+	}
+	if m.Reasoning != nil {
+		ref.UseReasoning = m.Reasoning
+	}
+	if m.Effort != "" {
+		ref.ReasoningEffort = m.Effort
+	}
+	decision.ModelRefs = append(decision.ModelRefs, ref)
+
+	// Populate model_config for route-local model metadata fields.
+	if m.ParamSize != "" {
+		if c.config.ModelConfig == nil {
+			c.config.ModelConfig = make(map[string]config.ModelParams)
+		}
+		mc := c.config.ModelConfig[m.Model]
+		mc.ParamSize = m.ParamSize
+		c.config.ModelConfig[m.Model] = mc
+	}
+}
+
+func (c *Compiler) appendModelRefIfMissing(decision *config.Decision, m *ModelRef) {
+	if decision == nil || m == nil {
+		return
+	}
+	for _, existing := range decision.ModelRefs {
+		if existing.Model == m.Model && existing.LoRAName == m.LoRA {
+			return
+		}
+	}
+	c.appendModelRef(decision, m)
+}
+
+func (c *Compiler) compileCandidateIteration(iter *CandidateIterationDecl) config.CandidateIterationConfig {
+	if iter == nil {
+		return config.CandidateIterationConfig{}
+	}
+	compiled := config.CandidateIterationConfig{
+		Variable: iter.Variable,
+		Source:   iter.Source,
+	}
+	for _, model := range iter.Models {
+		ref := config.ModelRef{
+			Model:    model.Model,
+			LoRAName: model.LoRA,
+			Weight:   model.Weight,
+		}
+		if model.Reasoning != nil {
+			ref.UseReasoning = model.Reasoning
+		}
+		if model.Effort != "" {
+			ref.ReasoningEffort = model.Effort
+		}
+		compiled.Models = append(compiled.Models, ref)
+	}
+	for _, output := range iter.Outputs {
+		compiled.Outputs = append(compiled.Outputs, config.CandidateIterationOutputConfig{
+			Type:  output.Type,
+			Value: output.Value,
+		})
+	}
+	return compiled
+}
+
 
 func (c *Compiler) compileBoolExpr(expr BoolExpr) config.RuleCombination {
 	switch e := expr.(type) {

--- a/src/semantic-router/pkg/dsl/decision_tree.go
+++ b/src/semantic-router/pkg/dsl/decision_tree.go
@@ -70,22 +70,7 @@ func decisionTreeBranchToRoute(
 	}
 
 	for _, item := range branch.body {
-		switch {
-		case item.Name != nil:
-			route.Name = unquoteIdent(*item.Name)
-		case item.Description != nil:
-			route.Description = unquote(*item.Description)
-		case item.Tier != nil:
-			route.Tier = *item.Tier
-		case item.Model != nil:
-			for _, model := range item.Model.Models {
-				route.Models = append(route.Models, rawToModelRef(model))
-			}
-		case item.Algorithm != nil:
-			route.Algorithm = rawToAlgo(item.Algorithm)
-		case item.Plugin != nil:
-			route.Plugins = append(route.Plugins, rawToPluginRef(item.Plugin))
-		}
+		applyDecisionTreeItemToRoute(route, item)
 	}
 
 	if len(route.Models) == 0 {
@@ -105,6 +90,27 @@ func decisionTreeBranchToRoute(
 	route.When = andExprs(conditions)
 
 	return route, nil
+}
+
+func applyDecisionTreeItemToRoute(route *RouteDecl, item *rawDecisionTreeItem) {
+	switch {
+	case item.Name != nil:
+		route.Name = unquoteIdent(*item.Name)
+	case item.Description != nil:
+		route.Description = unquote(*item.Description)
+	case item.Tier != nil:
+		route.Tier = *item.Tier
+	case item.Model != nil:
+		for _, model := range item.Model.Models {
+			route.Models = append(route.Models, rawToModelRef(model))
+		}
+	case item.Algorithm != nil:
+		route.Algorithm = rawToAlgo(item.Algorithm)
+	case item.Plugin != nil:
+		route.Plugins = append(route.Plugins, rawToPluginRef(item.Plugin))
+	case item.CandidateFor != nil:
+		route.CandidateIterations = append(route.CandidateIterations, rawToCandidateIteration(item.CandidateFor))
+	}
 }
 
 func generatedDecisionTreeBranchName(treeName string, branchIndex int) string {

--- a/src/semantic-router/pkg/dsl/decompiler.go
+++ b/src/semantic-router/pkg/dsl/decompiler.go
@@ -387,8 +387,10 @@ func (d *decompiler) decompileDecisions() {
 			d.write("  WHEN %s\n", ruleExpr)
 		}
 
+		omitModelList := candidateIterationsCoverModelRefs(dec)
+
 		// MODEL list
-		if len(dec.ModelRefs) > 0 {
+		if len(dec.ModelRefs) > 0 && !omitModelList {
 			d.write("  MODEL ")
 			for i, mr := range dec.ModelRefs {
 				if i > 0 {
@@ -401,6 +403,11 @@ func (d *decompiler) decompileDecisions() {
 				}
 			}
 			d.write("\n")
+		}
+
+		// Bounded candidate iteration
+		for _, iter := range dec.CandidateIterations {
+			d.decompileCandidateIteration(iter)
 		}
 
 		// ALGORITHM
@@ -426,6 +433,82 @@ func (d *decompiler) decompileDecisions() {
 
 		d.write("}\n\n")
 	}
+}
+
+func (d *decompiler) decompileCandidateIteration(iter config.CandidateIterationConfig) {
+	source := iter.Source
+	if source == "models" {
+		source = decompileCandidateIterationModelSource(iter.Models)
+	}
+	d.write("  FOR %s IN %s {\n", sanitizeName(iter.Variable), source)
+	for _, output := range iter.Outputs {
+		if output.Type == "model" {
+			d.write("    MODEL %s\n", sanitizeName(output.Value))
+		}
+	}
+	d.write("  }\n")
+}
+
+func decompileCandidateIterationModelSource(models []config.ModelRef) string {
+	if len(models) == 0 {
+		return "[]"
+	}
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i, model := range models {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(strconv.Quote(model.Model))
+		opts := candidateIterationModelRefOptions(&model)
+		if opts != "" {
+			sb.WriteString(" (")
+			sb.WriteString(opts)
+			sb.WriteString(")")
+		}
+	}
+	sb.WriteString("]")
+	return sb.String()
+}
+
+func candidateIterationModelRefOptions(model *config.ModelRef) string {
+	var opts []string
+	if model.UseReasoning != nil {
+		opts = append(opts, fmt.Sprintf("reasoning = %t", *model.UseReasoning))
+	}
+	if model.ReasoningEffort != "" {
+		opts = append(opts, fmt.Sprintf("effort = %q", model.ReasoningEffort))
+	}
+	if model.LoRAName != "" {
+		opts = append(opts, fmt.Sprintf("lora = %q", model.LoRAName))
+	}
+	if model.Weight != 0 {
+		opts = append(opts, fmt.Sprintf("weight = %s", strconv.FormatFloat(model.Weight, 'f', -1, 64)))
+	}
+	return strings.Join(opts, ", ")
+}
+
+func candidateIterationsCoverModelRefs(dec config.Decision) bool {
+	// The MODEL omission optimization is only proven for one explicit-model
+	// iteration that emits MODEL <iterator>. Multiple iterations require a
+	// merge/order/dedup contract before they can safely cover ModelRefs.
+	if len(dec.CandidateIterations) != 1 {
+		return false
+	}
+	iter := dec.CandidateIterations[0]
+	if iter.Source != "models" || !iterEmitsVariable(iter) {
+		return false
+	}
+	if len(dec.ModelRefs) != len(iter.Models) {
+		return false
+	}
+	for i := range dec.ModelRefs {
+		if dec.ModelRefs[i].Model != iter.Models[i].Model ||
+			dec.ModelRefs[i].LoRAName != iter.Models[i].LoRAName {
+			return false
+		}
+	}
+	return true
 }
 
 func decompileRuleNode(node *config.RuleCombination) string {
@@ -1268,7 +1351,38 @@ func (d *decompiler) decisionToRoute(dec *config.Decision) *RouteDecl {
 		route.Plugins = append(route.Plugins, ref)
 	}
 
+	for _, iter := range dec.CandidateIterations {
+		route.CandidateIterations = append(route.CandidateIterations, candidateIterationConfigToDecl(iter))
+	}
+
 	return route
+}
+
+func candidateIterationConfigToDecl(iter config.CandidateIterationConfig) *CandidateIterationDecl {
+	decl := &CandidateIterationDecl{
+		Variable: iter.Variable,
+		Source:   iter.Source,
+	}
+	for _, model := range iter.Models {
+		decl.Models = append(decl.Models, configModelRefToDSLModelRef(model))
+	}
+	for _, output := range iter.Outputs {
+		decl.Outputs = append(decl.Outputs, &CandidateIterationOutputDecl{
+			Type:  output.Type,
+			Value: output.Value,
+		})
+	}
+	return decl
+}
+
+func configModelRefToDSLModelRef(model config.ModelRef) *ModelRef {
+	return &ModelRef{
+		Model:     model.Model,
+		Reasoning: model.UseReasoning,
+		Effort:    model.ReasoningEffort,
+		LoRA:      model.LoRAName,
+		Weight:    model.Weight,
+	}
 }
 
 func decompileRuleNodeToExpr(node *config.RuleCombination) BoolExpr {

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -5712,3 +5712,231 @@ func TestValidateSessionStateValidTypes(t *testing.T) {
 		}
 	}
 }
+
+func TestParseCandidateIterationOverDecisionCandidates(t *testing.T) {
+	input := `ROUTE switch_gate {
+  MODEL "small-model", "large-model"
+  FOR candidate IN decision.candidates {
+    MODEL candidate
+  }
+}`
+
+	prog, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if len(prog.Routes) != 1 {
+		t.Fatalf("routes = %d, want 1", len(prog.Routes))
+	}
+	route := prog.Routes[0]
+	if len(route.CandidateIterations) != 1 {
+		t.Fatalf("candidate iterations = %d, want 1", len(route.CandidateIterations))
+	}
+	iter := route.CandidateIterations[0]
+	if iter.Variable != "candidate" || iter.Source != "decision.candidates" {
+		t.Fatalf("iteration = variable %q source %q, want candidate decision.candidates", iter.Variable, iter.Source)
+	}
+	if len(iter.Outputs) != 1 || iter.Outputs[0].Type != "model" || iter.Outputs[0].Value != "candidate" {
+		t.Fatalf("unexpected iteration outputs: %+v", iter.Outputs)
+	}
+}
+
+func TestCompileExplicitCandidateIterationFeedsModelRefs(t *testing.T) {
+	input := `ROUTE switch_gate {
+  FOR candidate IN ["small-model", "large-model"] {
+    MODEL candidate
+  }
+}`
+
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.Decisions) != 1 {
+		t.Fatalf("decisions = %d, want 1", len(cfg.Decisions))
+	}
+	decision := cfg.Decisions[0]
+	if len(decision.ModelRefs) != 2 {
+		t.Fatalf("model refs = %d, want 2", len(decision.ModelRefs))
+	}
+	if decision.ModelRefs[0].Model != "small-model" || decision.ModelRefs[1].Model != "large-model" {
+		t.Fatalf("model refs = %+v, want small-model, large-model", decision.ModelRefs)
+	}
+	if len(decision.CandidateIterations) != 1 {
+		t.Fatalf("candidate iterations = %d, want 1", len(decision.CandidateIterations))
+	}
+	if decision.CandidateIterations[0].Source != "models" {
+		t.Fatalf("candidate source = %q, want models", decision.CandidateIterations[0].Source)
+	}
+}
+
+func TestCandidateIterationRoundTrip(t *testing.T) {
+	input := `ROUTE switch_gate {
+  MODEL "small-model", "large-model"
+  FOR candidate IN decision.candidates {
+    MODEL candidate
+  }
+}`
+
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	dslText, err := Decompile(cfg)
+	if err != nil {
+		t.Fatalf("decompile error: %v", err)
+	}
+	if !strings.Contains(dslText, "FOR candidate IN decision.candidates") {
+		t.Fatalf("decompiled DSL missing candidate iteration:\n%s", dslText)
+	}
+	if !strings.Contains(dslText, "MODEL candidate") {
+		t.Fatalf("decompiled DSL missing candidate MODEL output:\n%s", dslText)
+	}
+	recompiled, errs := Compile(dslText)
+	if len(errs) > 0 {
+		t.Fatalf("recompile errors: %v\nDSL:\n%s", errs, dslText)
+	}
+	if len(recompiled.Decisions) != 1 || len(recompiled.Decisions[0].CandidateIterations) != 1 {
+		t.Fatalf("recompiled candidate iteration missing: %+v", recompiled.Decisions)
+	}
+}
+
+func TestValidateCandidateIterationRejectsUnboundedSource(t *testing.T) {
+	input := `ROUTE switch_gate {
+  MODEL "small-model"
+  FOR candidate IN runtime.models {
+    MODEL candidate
+  }
+}`
+
+	diagnostics, errs := Validate(input)
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	for _, diag := range diagnostics {
+		if strings.Contains(diag.Message, "unsupported candidate iteration source") {
+			return
+		}
+	}
+	t.Fatalf("expected unsupported candidate iteration source diagnostic, got: %+v", diagnostics)
+}
+
+// TestDecisionTreeCandidateIteration verifies that a FOR ... IN block inside a
+// DECISION_TREE branch is parsed and compiled correctly. The branch still
+// requires at least one MODEL directive; the iteration is additive metadata.
+func TestDecisionTreeCandidateIteration(t *testing.T) {
+	input := `SIGNAL keyword kw_fast { keywords: ["fast"] }
+DECISION_TREE session_switch {
+  IF keyword("kw_fast") {
+    MODEL "fast-model"
+    FOR candidate IN decision.candidates {
+      MODEL candidate
+    }
+  } ELSE {
+    MODEL "slow-model"
+  }
+}`
+
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.Decisions) != 2 {
+		t.Fatalf("decisions = %d, want 2", len(cfg.Decisions))
+	}
+	// Branch 01 has the iteration; branch 02 (ELSE) does not.
+	ifBranch := cfg.Decisions[0]
+	if len(ifBranch.CandidateIterations) != 1 {
+		t.Fatalf("if-branch candidate iterations = %d, want 1", len(ifBranch.CandidateIterations))
+	}
+	iter := ifBranch.CandidateIterations[0]
+	if iter.Variable != "candidate" || iter.Source != "decision.candidates" {
+		t.Fatalf("iteration variable=%q source=%q, want candidate decision.candidates", iter.Variable, iter.Source)
+	}
+	elseBranch := cfg.Decisions[1]
+	if len(elseBranch.CandidateIterations) != 0 {
+		t.Fatalf("else-branch candidate iterations = %d, want 0", len(elseBranch.CandidateIterations))
+	}
+}
+
+// TestCandidateIterationEmptyBodyIsValid confirms that a FOR block with no
+// outputs parses and validates without a hard error (it carries no outputs, so
+// the validator emits no constraint diagnostic for empty output lists).
+func TestCandidateIterationEmptyBodyIsValid(t *testing.T) {
+	input := `ROUTE switch_gate {
+  MODEL "small-model", "large-model"
+  FOR candidate IN decision.candidates {
+  }
+}`
+
+	prog, errs := Parse(input)
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	iter := prog.Routes[0].CandidateIterations[0]
+	if len(iter.Outputs) != 0 {
+		t.Fatalf("expected 0 outputs for empty FOR body, got %d", len(iter.Outputs))
+	}
+
+	// Validate must not produce a constraint diagnostic for the empty body itself.
+	diagnostics, errs := Validate(input)
+	if len(errs) > 0 {
+		t.Fatalf("validate errors: %v", errs)
+	}
+	for _, diag := range diagnostics {
+		if diag.Level == DiagConstraint && strings.Contains(diag.Message, "FOR candidate") {
+			t.Fatalf("unexpected constraint diagnostic for empty body: %s", diag.Message)
+		}
+	}
+}
+
+// TestExplicitModelListRoundTripOmitsModelDirective verifies that when an
+// explicit model-list iteration covers exactly the same models as ModelRefs,
+// the decompiler suppresses the redundant MODEL directive and the round-trip
+// still produces a valid, compilable DSL with the iteration intact.
+func TestExplicitModelListRoundTripOmitsModelDirective(t *testing.T) {
+	input := `ROUTE switch_gate {
+  FOR candidate IN ["small-model", "large-model"] {
+    MODEL candidate
+  }
+}`
+
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+
+	dslText, err := Decompile(cfg)
+	if err != nil {
+		t.Fatalf("decompile error: %v", err)
+	}
+
+	// The standalone MODEL directive must be absent because the iteration covers it.
+	lines := strings.Split(dslText, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "MODEL") && !strings.Contains(line, "FOR") && trimmed == "MODEL \"small-model\", \"large-model\"" {
+			t.Fatalf("decompiled DSL contains redundant MODEL directive that should have been omitted:\n%s", dslText)
+		}
+	}
+
+	// The iteration must be present.
+	if !strings.Contains(dslText, "FOR candidate IN") {
+		t.Fatalf("decompiled DSL missing candidate iteration:\n%s", dslText)
+	}
+
+	// Round-trip must recompile cleanly and preserve the iteration.
+	recompiled, errs := Compile(dslText)
+	if len(errs) > 0 {
+		t.Fatalf("recompile errors: %v\nDSL:\n%s", errs, dslText)
+	}
+	if len(recompiled.Decisions) != 1 {
+		t.Fatalf("recompiled decisions = %d, want 1", len(recompiled.Decisions))
+	}
+	if len(recompiled.Decisions[0].CandidateIterations) != 1 {
+		t.Fatalf("recompiled candidate iterations = %d, want 1", len(recompiled.Decisions[0].CandidateIterations))
+	}
+	if len(recompiled.Decisions[0].ModelRefs) != 2 {
+		t.Fatalf("recompiled model refs = %d, want 2", len(recompiled.Decisions[0].ModelRefs))
+	}
+}

--- a/src/semantic-router/pkg/dsl/parser.go
+++ b/src/semantic-router/pkg/dsl/parser.go
@@ -410,6 +410,8 @@ func rawToRoute(r *rawRouteDecl) *RouteDecl {
 			route.Plugins = append(route.Plugins, rawToPluginRef(item.Plugin))
 		case item.Description != nil:
 			route.Description = unquote(*item.Description)
+		case item.CandidateFor != nil:
+			route.CandidateIterations = append(route.CandidateIterations, rawToCandidateIteration(item.CandidateFor))
 		}
 	}
 
@@ -639,6 +641,8 @@ const (
 	TOKEN_WHEN
 	TOKEN_MODEL
 	TOKEN_ALGORITHM
+	TOKEN_FOR
+	TOKEN_IN
 	TOKEN_AND
 	TOKEN_OR
 	TOKEN_NOT
@@ -660,7 +664,8 @@ func (t TokenType) String() string {
 		TOKEN_BOOL: "BOOL", TOKEN_COMMENT: "COMMENT", TOKEN_SIGNAL: "SIGNAL",
 		TOKEN_ROUTE: "ROUTE", TOKEN_PLUGIN: "PLUGIN", TOKEN_PRIORITY: "PRIORITY",
 		TOKEN_WHEN: "WHEN", TOKEN_MODEL: "MODEL", TOKEN_ALGORITHM: "ALGORITHM",
-		TOKEN_AND: "AND", TOKEN_OR: "OR", TOKEN_NOT: "NOT", TOKEN_LBRACE: "{", TOKEN_RBRACE: "}",
+		TOKEN_FOR: "FOR", TOKEN_IN: "IN", TOKEN_AND: "AND", TOKEN_OR: "OR", TOKEN_NOT: "NOT",
+		TOKEN_LBRACE: "{", TOKEN_RBRACE: "}",
 		TOKEN_LPAREN: "(", TOKEN_RPAREN: ")", TOKEN_LBRACKET: "[",
 		TOKEN_RBRACKET: "]", TOKEN_COLON: ":", TOKEN_COMMA: ",", TOKEN_EQUALS: "=",
 	}
@@ -693,6 +698,7 @@ func Lex(input string) ([]Token, []error) {
 		"PLUGIN": TOKEN_PLUGIN, "TEST": TOKEN_IDENT,
 		"PRIORITY": TOKEN_PRIORITY, "TIER": TOKEN_IDENT, "WHEN": TOKEN_WHEN,
 		"MODEL": TOKEN_MODEL, "ALGORITHM": TOKEN_ALGORITHM,
+		"FOR": TOKEN_FOR, "IN": TOKEN_IN,
 		"AND": TOKEN_AND, "OR": TOKEN_OR, "NOT": TOKEN_NOT,
 		"true": TOKEN_BOOL, "false": TOKEN_BOOL,
 	}
@@ -772,6 +778,7 @@ func LookupIdent(ident string) TokenType {
 		"PLUGIN": TOKEN_PLUGIN, "TEST": TOKEN_IDENT,
 		"PRIORITY": TOKEN_PRIORITY, "TIER": TOKEN_IDENT, "WHEN": TOKEN_WHEN,
 		"MODEL": TOKEN_MODEL, "ALGORITHM": TOKEN_ALGORITHM,
+		"FOR": TOKEN_FOR, "IN": TOKEN_IN,
 		"AND": TOKEN_AND, "OR": TOKEN_OR, "NOT": TOKEN_NOT,
 		"true": TOKEN_BOOL, "false": TOKEN_BOOL,
 	}

--- a/src/semantic-router/pkg/dsl/validator.go
+++ b/src/semantic-router/pkg/dsl/validator.go
@@ -229,11 +229,7 @@ func (v *Validator) extractSymbolTable() *SymbolTable {
 		modelSet[name] = true
 	}
 	for _, route := range v.prog.Routes {
-		for _, m := range route.Models {
-			if m.Model != "" {
-				modelSet[m.Model] = true
-			}
-		}
+		addRouteModelsToSymbolSet(modelSet, route)
 	}
 	st.Models = keysOfBool(modelSet)
 
@@ -271,7 +267,11 @@ func (v *Validator) checkRouteReferences(route *RouteDecl) {
 		}
 	}
 
-	if len(route.Models) == 0 {
+	for _, iter := range route.CandidateIterations {
+		v.checkCandidateIterationReferences(route, iter)
+	}
+
+	if !routeHasModelCandidates(route) {
 		v.addDiag(DiagWarning, route.Pos,
 			fmt.Sprintf("Route %q has no MODEL specified. Add MODEL \"<model_name>\" inside the route body", route.Name),
 			nil,
@@ -496,6 +496,10 @@ func (v *Validator) checkRouteConstraints(r *RouteDecl) {
 	// Check algorithm constraints
 	if r.Algorithm != nil {
 		v.checkAlgorithmConstraints(r.Algorithm, context)
+	}
+
+	for _, iter := range r.CandidateIterations {
+		v.checkCandidateIterationConstraints(r, iter, context)
 	}
 }
 

--- a/src/semantic-router/pkg/dsl/validator_candidate_iteration.go
+++ b/src/semantic-router/pkg/dsl/validator_candidate_iteration.go
@@ -1,0 +1,116 @@
+package dsl
+
+import "fmt"
+
+func addRouteModelsToSymbolSet(modelSet map[string]bool, route *RouteDecl) {
+	for _, m := range route.Models {
+		if m.Model != "" {
+			modelSet[m.Model] = true
+		}
+	}
+	for _, iter := range route.CandidateIterations {
+		for _, m := range iter.Models {
+			if m.Model != "" {
+				modelSet[m.Model] = true
+			}
+		}
+	}
+}
+
+func (v *Validator) checkCandidateIterationReferences(route *RouteDecl, iter *CandidateIterationDecl) {
+	if iter == nil {
+		return
+	}
+	for _, mr := range iter.Models {
+		if mr.Model == "" || v.modelNames[mr.Model] {
+			v.checkRouteLoRAReference(route, mr)
+			continue
+		}
+		v.addDiag(DiagWarning, mr.Pos,
+			fmt.Sprintf("Model %q is not declared in the top-level model catalog", mr.Model),
+			v.suggestModel(mr.Model),
+		)
+	}
+}
+
+func routeHasModelCandidates(route *RouteDecl) bool {
+	if len(route.Models) > 0 {
+		return true
+	}
+	for _, iter := range route.CandidateIterations {
+		if iter.Source == "models" && len(iter.Models) > 0 && candidateIterationDeclEmitsVariableModel(iter) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *Validator) checkCandidateIterationConstraints(route *RouteDecl, iter *CandidateIterationDecl, routeContext string) {
+	if iter == nil {
+		return
+	}
+	context := fmt.Sprintf("%s FOR %s", routeContext, iter.Variable)
+	v.checkCandidateIterationVariable(iter, context)
+	v.checkCandidateIterationSource(route, iter, context)
+	v.checkCandidateIterationOutputs(iter, context)
+}
+
+func (v *Validator) checkCandidateIterationVariable(iter *CandidateIterationDecl, context string) {
+	if iter.Variable == "" {
+		v.addDiag(DiagConstraint, iter.Pos,
+			fmt.Sprintf("%s: iterator variable is required", context),
+			nil,
+		)
+	}
+}
+
+func (v *Validator) checkCandidateIterationSource(route *RouteDecl, iter *CandidateIterationDecl, context string) {
+	switch iter.Source {
+	case "decision.candidates":
+		if len(route.Models) == 0 {
+			v.addDiag(DiagConstraint, iter.Pos,
+				fmt.Sprintf("%s: decision.candidates requires MODEL candidates in the same route", context),
+				nil,
+			)
+		}
+	case "models":
+		if len(iter.Models) == 0 {
+			v.addDiag(DiagConstraint, iter.Pos,
+				fmt.Sprintf("%s: explicit model source must contain at least one model", context),
+				nil,
+			)
+		}
+	default:
+		v.addDiag(DiagConstraint, iter.Pos,
+			fmt.Sprintf("%s: unsupported candidate iteration source %q. Supported sources: decision.candidates or an explicit model list", context, iter.Source),
+			nil,
+		)
+	}
+}
+
+func (v *Validator) checkCandidateIterationOutputs(iter *CandidateIterationDecl, context string) {
+	for _, output := range iter.Outputs {
+		if output.Type != "model" {
+			v.addDiag(DiagConstraint, output.Pos,
+				fmt.Sprintf("%s: unsupported candidate iteration output %q. Supported output: MODEL %s", context, output.Type, iter.Variable),
+				nil,
+			)
+			continue
+		}
+		if output.Value != iter.Variable {
+			v.addDiag(DiagConstraint, output.Pos,
+				fmt.Sprintf("%s: MODEL output must reference iterator variable %q, got %q", context, iter.Variable, output.Value),
+				nil,
+			)
+		}
+	}
+}
+
+func candidateIterationDeclEmitsVariableModel(iter *CandidateIterationDecl) bool {
+	for _, output := range iter.Outputs {
+		if output.Type == "model" && output.Value == iter.Variable {
+			return true
+		}
+	}
+	return false
+}

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -63,7 +63,7 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, history s
 // The algorithm parameter allows per-decision algorithm override (aligned with looper pattern).
 // The categoryName parameter is the detected domain category (e.g., "physics", "math") for ML feature vectors.
 // Returns the selected model and the method name used for logging.
-func (r *OpenAIRouter) selectModelFromCandidates(modelRefs []config.ModelRef, decisionName string, query string, algorithm *config.AlgorithmConfig, categoryName string) (*config.ModelRef, string) {
+func (r *OpenAIRouter) selectModelFromCandidates(modelRefs []config.ModelRef, decisionName string, query string, algorithm *config.AlgorithmConfig, categoryName string, candidateIterations []config.CandidateIterationConfig) (*config.ModelRef, string) {
 	if len(modelRefs) == 0 {
 		return nil, ""
 	}
@@ -97,6 +97,7 @@ func (r *OpenAIRouter) selectModelFromCandidates(modelRefs []config.ModelRef, de
 		DecisionName:               decisionName,
 		CategoryName:               categoryName,
 		CandidateModels:            modelRefs,
+		CandidateIterations:        candidateIterations,
 		CostWeight:                 costWeight,
 		QualityWeight:              qualityWeight,
 		LatencyAwareTPOTPercentile: latencyAwareTPOTPercentile,

--- a/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
@@ -221,6 +221,7 @@ func (r *OpenAIRouter) selectDecisionRuntimeModel(
 		userContent,
 		result.Decision.Algorithm,
 		categoryName,
+		result.Decision.CandidateIterations,
 	)
 	selectedModel := selectedModelRef.Model
 	selectionFields := map[string]interface{}{

--- a/src/semantic-router/pkg/selection/selector.go
+++ b/src/semantic-router/pkg/selection/selector.go
@@ -156,6 +156,10 @@ type SelectionContext struct {
 	// CandidateModels is the list of models to select from
 	CandidateModels []config.ModelRef
 
+	// CandidateIterations carries bounded DSL FOR ... IN metadata for selectors
+	// that opt into session-aware candidate policy evaluation.
+	CandidateIterations []config.CandidateIterationConfig
+
 	// CostWeight indicates how much to weight cost in selection (0.0-1.0)
 	// Higher values prefer cheaper models
 	CostWeight float64

--- a/website/docs/proposals/unified-config-contract-v0-3.md
+++ b/website/docs/proposals/unified-config-contract-v0-3.md
@@ -66,7 +66,7 @@ DSL now owns only:
 - `routing.modelCards`
 - `routing.signals`
 - `routing.projections` for signal coordination and derived routing outputs
-- `routing.decisions`
+- `routing.decisions`, including bounded candidate-iteration metadata used by DSL `FOR ... IN` authoring
 
 It no longer owns endpoints, API keys, listeners, or router-global runtime settings.
 
@@ -80,6 +80,7 @@ Model semantics and deployment bindings are now separated explicitly:
 - `providers.models` carries per-model access bindings directly
 - each `providers.models[].backend_refs[]` item carries its own transport and auth fields such as `endpoint`, `base_url`, `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env`
 - `routing.decisions[].modelRefs[].lora_name` resolves against the matching `routing.modelCards[].loras` entry, so `lora_name` is now part of the supported routing contract instead of a runtime-only escape hatch
+- `routing.decisions[].candidateIterations` is bounded to `decision.candidates` or explicit model lists and remains declarative metadata for the selection layer, not a second policy interpreter
 
 ## Global defaults
 


### PR DESCRIPTION
Closes #1748

## Purpose

- Add bounded candidate iteration support to the Semantic Router DSL.
- Support declarative `FOR <var> IN decision.candidates { MODEL <var> }` blocks for iterating over the current route candidate set.
- Support declarative `FOR <var> IN ["model-a", "model-b"] { MODEL <var> }` blocks for explicit bounded model lists.
- Compile explicit model-list iterations into the existing `routing.decisions[].modelRefs` contract while preserving the structured iteration metadata in `routing.decisions[].candidateIterations`.
- Preserve candidate iteration blocks through decompiler round trips.
- Validate candidate iteration constraints, including supported sources, non-empty explicit model lists, and requiring `MODEL` outputs to reference the iterator variable.
- Pass candidate iteration metadata through selection context for future selector behavior without introducing a runtime script interpreter.
- Affected modules: `Router` / `Docs`

## Test Plan

- Run focused DSL tests to verify parsing, compilation, validation, decision-tree handling, and round-trip decompilation.
- Run config tests to verify canonical config validation and reference config surface coverage.
- Run selection/extproc package tests to verify the new metadata plumbing does not regress routing request handling.
- Run the repo-native semantic-router test target.
- Run the repo-native agent CI gate for the changed Router and Docs surfaces.

## Test Result

- Passed: `go test ./pkg/dsl`
- Passed: `go test ./pkg/config ./pkg/selection ./pkg/extproc`
- Passed: `make test-semantic-router`
- Passed: `PATH="/Users/liuqihao/Developer/semantic-router/.venv-agent/bin:$PATH" make agent-ci-gate ...`
- Passed: `git diff --check`
- Observed existing non-fatal warnings during the full gate:
  - Rust warnings in the candle binding build.
  - Linker warning for missing local `candle-binding/target/release`.
  - Vectorstore test warning for an expected failed Redis connection to `192.0.2.1:6379`.
- Follow-up risk: selector-specific runtime behavior for consuming `candidateIterations` is intentionally not implemented in this PR; this PR only adds the bounded DSL/config representation and safe metadata plumbing.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change
