### PR TITLE
[Router] fix HNSW insertion entry-point descent in in-memory cache

### DIFF
--- a/src/semantic-router/pkg/cache/cache_test.go
+++ b/src/semantic-router/pkg/cache/cache_test.go
@@ -3759,8 +3759,8 @@ func BenchmarkHNSWRebuild(b *testing.B) {
 	}
 }
 
-func TestSearchLayerHeapManagement(t *testing.T) {
-	t.Run("retains the closest neighbor when ef is saturated", func(t *testing.T) {
+func TestHNSWSearchLayerAndInsertionRegressions(t *testing.T) {
+	t.Run("searchLayer returns nearest-first results after ef trimming", func(t *testing.T) {
 		// Regression fixture: with the previous max-heap candidates/min-heap results
 		// mix, trimming to ef would evict the best element instead of the worst.
 		queryEmbedding := []float32{1.0}
@@ -3803,15 +3803,12 @@ func TestSearchLayerHeapManagement(t *testing.T) {
 
 		results := index.searchLayer(queryEmbedding, index.entryPoint, 1, 0, entries)
 
-		if !slices.Contains(results, 1) {
-			t.Fatalf("expected results to contain best neighbor 1, got %v", results)
-		}
-		if slices.Contains(results, 0) {
-			t.Fatalf("expected results to drop entry point 0 once ef trimmed, got %v", results)
+		if !slices.Equal(results, []int{1}) {
+			t.Fatalf("expected nearest-first results [1] after ef trimming, got %v", results)
 		}
 	})
 
-	t.Run("continues exploring even when next candidate looks worse", func(t *testing.T) {
+	t.Run("searchLayer returns nearest-first results after exploring through a worse intermediate candidate", func(t *testing.T) {
 		// Regression fixture: the break condition used the wrong polarity so the
 		// search stopped before expanding the intermediate (worse) vertex, making
 		// the actual best neighbor unreachable.
@@ -3865,8 +3862,85 @@ func TestSearchLayerHeapManagement(t *testing.T) {
 
 		results := index.searchLayer(queryEmbedding, index.entryPoint, 2, 0, entries)
 
-		if !slices.Contains(results, 2) {
-			t.Fatalf("expected results to reach best neighbor 2 via intermediate node, got %v", results)
+		if !slices.Equal(results, []int{2, 0}) {
+			t.Fatalf("expected nearest-first results [2 0] after exploring through intermediate node, got %v", results)
+		}
+	})
+
+	t.Run("addNode carries the upper-layer entry point into lower-layer neighbor selection", func(t *testing.T) {
+		// Graph layout:
+		//   layer 1: A <-> B
+		//   layer 0: A <-> C, B <-> D
+		//
+		// New node F is inserted at level 0. Its embedding is much closer to B/D
+		// than to A/C, so the correct insertion flow must first descend from the
+		// global entry point A to B on layer 1, then start the layer 0 search from
+		// B and connect F to D. The previous implementation incorrectly restarted
+		// layer 0 from A and linked F to C instead.
+		entries := []CacheEntry{
+			{Embedding: []float32{0.30}}, // A: global entry point
+			{Embedding: []float32{0.95}}, // B: better upper-layer entry point for F
+			{Embedding: []float32{0.35}}, // C: layer-0 neighbor reachable from A
+			{Embedding: []float32{1.00}}, // D: layer-0 neighbor reachable from B
+			{Embedding: []float32{1.00}}, // F: new node to insert
+		}
+
+		nodeA := &HNSWNode{
+			entryIndex: 0,
+			neighbors: map[int][]int{
+				1: {1},
+				0: {2},
+			},
+			maxLayer: 1,
+		}
+		nodeB := &HNSWNode{
+			entryIndex: 1,
+			neighbors: map[int][]int{
+				1: {0},
+				0: {3},
+			},
+			maxLayer: 1,
+		}
+		nodeC := &HNSWNode{
+			entryIndex: 2,
+			neighbors: map[int][]int{
+				0: {0},
+			},
+			maxLayer: 0,
+		}
+		nodeD := &HNSWNode{
+			entryIndex: 3,
+			neighbors: map[int][]int{
+				0: {1},
+			},
+			maxLayer: 0,
+		}
+
+		index := &HNSWIndex{
+			nodes: []*HNSWNode{nodeA, nodeB, nodeC, nodeD},
+			nodeIndex: map[int]*HNSWNode{
+				0: nodeA,
+				1: nodeB,
+				2: nodeC,
+				3: nodeD,
+			},
+			entryPoint:     0,
+			maxLayer:       1,
+			efConstruction: 1,
+			M:              1,
+			Mmax:           1,
+			Mmax0:          1,
+			ml:             0, // Force the inserted node F to level 0 deterministically.
+		}
+
+		index.addNode(4, entries[4].Embedding, entries)
+
+		inserted := index.nodeIndex[4]
+		if inserted == nil {
+			t.Fatal("expected inserted node 4 to be present in nodeIndex")
+		}
+		if !slices.Equal(inserted.neighbors[0], []int{3}) {
+			t.Fatalf("expected inserted node 4 to connect to D via carried entry point, got %v", inserted.neighbors[0])
 		}
 	})
 }

--- a/src/semantic-router/pkg/cache/inmemory_cache.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache.go
@@ -1174,12 +1174,15 @@ func (h *HNSWIndex) addNode(entryIndex int, embedding []float32, entries []Cache
 	for lc := min(level, h.maxLayer); lc >= 0; lc-- {
 		candidates := h.searchLayer(embedding, currentEntryPoint, h.efConstruction, lc, entries)
 
-		// Select M nearest neighbors
+		// Select M nearest neighbors from sorted candidates returned from searchLayer (nearest first, farthest last)
 		M := h.Mmax
 		if lc == 0 {
 			M = h.Mmax0
 		}
-		neighbors := h.selectOrderedNeighborIndices(candidates, M)
+		neighbors := candidates
+		if len(neighbors) > M {
+			neighbors = neighbors[:M]
+		}
 
 		// Add bidirectional links
 		node.neighbors[lc] = neighbors
@@ -1235,7 +1238,7 @@ func (h *HNSWIndex) searchKNN(queryEmbedding []float32, k, ef int, entries []Cac
 
 // searchLayer searches for nearest neighbors at a specific layer.
 //
-// It returns candidate entry indices ordered by ascending distance(nearest first, farthest last).
+// It returns candidate entry indices ordered by ascending distance (nearest first, farthest last).
 func (h *HNSWIndex) searchLayer(queryEmbedding []float32, entryPoint, ef, layer int, entries []CacheEntry) []int {
 	visited := make(map[int]bool)
 	candidates := newMinHeap() // set of candidates, explore closest candidate first
@@ -1288,22 +1291,6 @@ func (h *HNSWIndex) searchLayer(queryEmbedding []float32, entryPoint, ef, layer 
 	}
 
 	return results.sortedIndicesAsc()
-}
-
-// selectOrderedNeighborIndices truncates an already distance-ordered result without recomputing distances.
-// The input must be ordered nearest-first.
-func (h *HNSWIndex) selectOrderedNeighborIndices(candidates []int, m int) []int {
-	if len(candidates) == 0 || m <= 0 {
-		return []int{}
-	}
-
-	if len(candidates) > m {
-		candidates = candidates[:m]
-	}
-
-	result := make([]int, 0, len(candidates))
-	result = append(result, candidates...)
-	return result
 }
 
 // selectNeighbors selects the best neighbors by sorting by distance

--- a/src/semantic-router/pkg/cache/inmemory_cache.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache.go
@@ -5,6 +5,7 @@ package cache
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1161,16 +1162,24 @@ func (h *HNSWIndex) addNode(entryIndex int, embedding []float32, entries []Cache
 		return
 	}
 
+	currentEntryPoint := h.entryPoint
+	for lc := h.maxLayer; lc > level; lc-- {
+		candidates := h.searchLayer(embedding, currentEntryPoint, 1, lc, entries)
+		if len(candidates) > 0 {
+			currentEntryPoint = candidates[0]
+		}
+	}
+
 	// Find nearest neighbors and connect
 	for lc := min(level, h.maxLayer); lc >= 0; lc-- {
-		candidates := h.searchLayer(embedding, h.entryPoint, h.efConstruction, lc, entries)
+		candidates := h.searchLayer(embedding, currentEntryPoint, h.efConstruction, lc, entries)
 
 		// Select M nearest neighbors
 		M := h.Mmax
 		if lc == 0 {
 			M = h.Mmax0
 		}
-		neighbors := h.selectNeighbors(candidates, M, embedding, entries)
+		neighbors := h.selectOrderedNeighborIndices(candidates, M)
 
 		// Add bidirectional links
 		node.neighbors[lc] = neighbors
@@ -1188,6 +1197,10 @@ func (h *HNSWIndex) addNode(entryIndex int, embedding []float32, entries []Cache
 					n.neighbors[lc] = h.selectNeighbors(n.neighbors[lc], M, entries[neighborIdx].Embedding, entries)
 				}
 			}
+		}
+
+		if len(candidates) > 0 {
+			currentEntryPoint = candidates[0]
 		}
 	}
 
@@ -1220,7 +1233,9 @@ func (h *HNSWIndex) searchKNN(queryEmbedding []float32, k, ef int, entries []Cac
 	return h.searchLayer(queryEmbedding, currentNearest, ef, 0, entries)
 }
 
-// searchLayer searches for nearest neighbors at a specific layer
+// searchLayer searches for nearest neighbors at a specific layer.
+//
+// It returns candidate entry indices ordered by ascending distance(nearest first, farthest last).
 func (h *HNSWIndex) searchLayer(queryEmbedding []float32, entryPoint, ef, layer int, entries []CacheEntry) []int {
 	visited := make(map[int]bool)
 	candidates := newMinHeap() // set of candidates, explore closest candidate first
@@ -1272,7 +1287,23 @@ func (h *HNSWIndex) searchLayer(queryEmbedding []float32, entryPoint, ef, layer 
 		}
 	}
 
-	return results.items()
+	return results.sortedIndicesAsc()
+}
+
+// selectOrderedNeighborIndices truncates an already distance-ordered result without recomputing distances.
+// The input must be ordered nearest-first.
+func (h *HNSWIndex) selectOrderedNeighborIndices(candidates []int, m int) []int {
+	if len(candidates) == 0 || m <= 0 {
+		return []int{}
+	}
+
+	if len(candidates) > m {
+		candidates = candidates[:m]
+	}
+
+	result := make([]int, 0, len(candidates))
+	result = append(result, candidates...)
+	return result
 }
 
 // selectNeighbors selects the best neighbors by sorting by distance
@@ -1448,12 +1479,21 @@ func (h *maxHeap) peekDist() float32 {
 	return h.data[0].dist
 }
 
-func (h *maxHeap) items() []int {
-	result := make([]int, len(h.data))
-	for i, item := range h.data {
-		result[i] = item.index
+// sortedIndicesAsc exports the heap contents as entry indices ordered by ascending distance (nearest first).
+func (h *maxHeap) sortedIndicesAsc() []int {
+	result := make([]heapItem, len(h.data))
+	copy(result, h.data)
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].dist < result[j].dist
+	})
+
+	indices := make([]int, len(result))
+	for i, item := range result {
+		indices[i] = item.index
 	}
-	return result
+
+	return indices
 }
 
 func (h *maxHeap) bubbleUp(i int) {


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

- What does this PR change?
&emsp;&emsp; This PR tried to fix the in-memory [HNSW](https://dl.acm.org/doi/10.1109/TPAMI.2018.2889473) insertion path so the entry point is updated layer by layer during decent
<img width="500" height="564" alt="hnsw" src="https://github.com/user-attachments/assets/0aa7b61f-6e82-4fec-8b5b-b18f8ab2a6f1" />


- Why is this change needed?

- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`
&emsp;&emsp; Router

## Test Plan
~~&emsp;&emsp; I'm so sorry that this PR is static code review only without a unit test since I do not currently have a reliable way to deterministically exercise and assert internal HNSW graph-construction path in isolation.~~

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
