### PR TITLE
fix: flaky TestValkeyStoreInteg_List ordering in CI

### DIFF
--- a/src/semantic-router/pkg/memory/valkey_store_helpers.go
+++ b/src/semantic-router/pkg/memory/valkey_store_helpers.go
@@ -42,7 +42,7 @@ func (v *ValkeyStore) recordRetrievalBatch(ids []string) {
 func (v *ValkeyStore) recordRetrieval(ctx context.Context, id string) error {
 	key := v.hashKey(id)
 	now := time.Now()
-	nowUnix := strconv.FormatInt(now.Unix(), 10)
+	nowUnix := strconv.FormatInt(now.UnixMilli(), 10)
 
 	// Increment access_count atomically.
 	_, err := v.client.CustomCommand(ctx, []string{"HINCRBY", key, "access_count", "1"})
@@ -439,8 +439,8 @@ func valkeyBuildHashFields(memory *Memory, embedding []float32) (map[string]stri
 		"source":       source,
 		"metadata":     string(metadataJSON),
 		"embedding":    string(valkeyFloat32ToBytes(embedding)),
-		"created_at":   strconv.FormatInt(memory.CreatedAt.Unix(), 10),
-		"updated_at":   strconv.FormatInt(memory.UpdatedAt.Unix(), 10),
+		"created_at":   strconv.FormatInt(memory.CreatedAt.UnixMilli(), 10),
+		"updated_at":   strconv.FormatInt(memory.UpdatedAt.UnixMilli(), 10),
 		"access_count": strconv.Itoa(memory.AccessCount),
 		"importance":   strconv.FormatFloat(float64(memory.Importance), 'f', -1, 32),
 	}, nil
@@ -539,16 +539,14 @@ func valkeyFieldsToMemory(fields map[string]string) *Memory {
 
 	if createdAtStr := fields["created_at"]; createdAtStr != "" {
 		if ts, err := strconv.ParseInt(createdAtStr, 10, 64); err == nil {
-			mem.CreatedAt = time.Unix(ts, 0)
+			mem.CreatedAt = time.UnixMilli(ts)
 		}
 	}
 	if updatedAtStr := fields["updated_at"]; updatedAtStr != "" {
 		if ts, err := strconv.ParseInt(updatedAtStr, 10, 64); err == nil {
-			mem.UpdatedAt = time.Unix(ts, 0)
+			mem.UpdatedAt = time.UnixMilli(ts)
 		}
 	}
-
-	// Restore embedding from binary blob
 	if embStr := fields["embedding"]; embStr != "" {
 		mem.Embedding = valkeyBytesToFloat32([]byte(embStr))
 	}
@@ -579,12 +577,12 @@ func valkeyFieldsMapToMemory(fields map[string]interface{}) *Memory {
 
 	if createdAtStr, ok := fields["created_at"].(string); ok && createdAtStr != "" {
 		if ts, err := strconv.ParseInt(createdAtStr, 10, 64); err == nil {
-			mem.CreatedAt = time.Unix(ts, 0)
+			mem.CreatedAt = time.UnixMilli(ts)
 		}
 	}
 	if updatedAtStr, ok := fields["updated_at"].(string); ok && updatedAtStr != "" {
 		if ts, err := strconv.ParseInt(updatedAtStr, 10, 64); err == nil {
-			mem.UpdatedAt = time.Unix(ts, 0)
+			mem.UpdatedAt = time.UnixMilli(ts)
 		}
 	}
 

--- a/src/semantic-router/pkg/memory/valkey_store_integration_test.go
+++ b/src/semantic-router/pkg/memory/valkey_store_integration_test.go
@@ -526,14 +526,19 @@ func TestValkeyStoreInteg_List(t *testing.T) {
 	ctx := context.Background()
 
 	userID := fmt.Sprintf("list_user_%d", time.Now().UnixNano())
+	// Use explicit staggered timestamps with 100ms gaps to guarantee distinct
+	// created_at values. This is deterministic regardless of Store() execution
+	// speed or Valkey version.
+	baseTime := time.Now().Add(-5 * time.Second)
 	for i := 0; i < 5; i++ {
-		require.NoError(t, store.Store(ctx, &Memory{
-			ID:      fmt.Sprintf("mem_list_%s_%d", userID, i),
-			Type:    MemoryTypeSemantic,
-			Content: fmt.Sprintf("List test memory number %d", i),
-			UserID:  userID,
-		}))
-		time.Sleep(50 * time.Millisecond) // ensure different timestamps
+		mem := &Memory{
+			ID:        fmt.Sprintf("mem_list_%s_%d", userID, i),
+			Type:      MemoryTypeSemantic,
+			Content:   fmt.Sprintf("List test memory number %d", i),
+			UserID:    userID,
+			CreatedAt: baseTime.Add(time.Duration(i) * 100 * time.Millisecond),
+		}
+		require.NoError(t, store.Store(ctx, mem))
 	}
 	time.Sleep(500 * time.Millisecond)
 


### PR DESCRIPTION
TestValkeyStoreInteg_List fails intermittently in CI with "memories should be sorted by created_at descending". The root cause: created_at was stored as Unix seconds (time.Now().Unix()), but List() uses FT.SEARCH SORTBY created_at DESC. When multiple Store() calls complete within the same second (common on fast CI runners), they share the same created_at value and SORTBY returns them in undefined order.

#### Changes

- Store created_at and updated_at as milliseconds (UnixMilli) instead of seconds so sub-second inserts are always distinguishable by SORTBY
- Use explicit staggered timestamps (100ms gaps) in the List integration test instead of relying on wall-clock timing, making the test deterministic regardless of execution speed

#### Context

- Introduced by #1739 (Valkey memory backend)
- First observed in #1786 CI: [test-and-build failure](https://github.com/vllm-project/semantic-router/actions/runs/24501203156/job/71608176058?pr=1786)