### PR TITLE
feat(router-replay): add GET /v1/router_replay/trajectory endpoint

### DIFF
--- a/src/semantic-router/pkg/extproc/router_replay_api.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api.go
@@ -60,6 +60,8 @@ func (r *OpenAIRouter) handleRouterReplayAPI(method string, path string) *ext_pr
 		return r.handleRouterReplayListAPI(method, rawQuery)
 	case normalizedPath == routerReplayAggregatePath:
 		return r.handleRouterReplayAggregateAPI(method, rawQuery)
+	case normalizedPath == routerReplayTrajectoryPath:
+		return r.handleRouterReplayTrajectoryAPI(method, rawQuery)
 	case strings.HasPrefix(normalizedPath, routerReplayAPIBasePath+"/"):
 		replayID := strings.TrimPrefix(normalizedPath, routerReplayAPIBasePath+"/")
 		return r.handleRouterReplayRecordAPI(method, replayID)

--- a/src/semantic-router/pkg/extproc/router_replay_trajectory.go
+++ b/src/semantic-router/pkg/extproc/router_replay_trajectory.go
@@ -1,0 +1,168 @@
+package extproc
+
+import (
+	"net/url"
+	"slices"
+	"strings"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+)
+
+const routerReplayTrajectoryPath = routerReplayAPIBasePath + "/trajectory"
+
+type trajectoryFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type trajectoryToolCall struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Function trajectoryFunctionCall `json:"function"`
+}
+
+type trajectoryMessage struct {
+	Role       string               `json:"role"`
+	Content    string               `json:"content,omitempty"`
+	ToolCalls  []trajectoryToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string               `json:"tool_call_id,omitempty"`
+}
+
+type routerReplayTrajectoryResponse struct {
+	Object      string              `json:"object"`
+	SessionID   string              `json:"session_id"`
+	RecordCount int                 `json:"record_count"`
+	Messages    []trajectoryMessage `json:"messages"`
+}
+
+// handleRouterReplayTrajectoryAPI serves GET /v1/router_replay/trajectory?session_id={id}.
+// It converts stored ToolTrace steps into a flat OpenAI Chat Completions message list,
+// coalescing consecutive assistant_tool_call steps into a single assistant message.
+//
+// NOTE: session_id is currently matched against RequestID. A dedicated session index
+// will be added once session tracking lands (Issue 1).
+func (r *OpenAIRouter) handleRouterReplayTrajectoryAPI(
+	method string,
+	rawQuery string,
+) *ext_proc.ProcessingResponse {
+	if method != "GET" {
+		return r.createErrorResponse(405, "method not allowed")
+	}
+
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return r.createErrorResponse(400, "invalid query parameters")
+	}
+
+	sessionID := strings.TrimSpace(values.Get("session_id"))
+	if sessionID == "" {
+		return r.createErrorResponse(400, "session_id is required")
+	}
+
+	records := filterTrajectoryRecordsBySession(r.collectRouterReplayRecords(), sessionID)
+	// collectRouterReplayRecords returns newest-first; trajectory needs chronological order.
+	reverseRoutingRecords(records)
+
+	payload := routerReplayTrajectoryResponse{
+		Object:      "router_replay.trajectory",
+		SessionID:   sessionID,
+		RecordCount: len(records),
+		Messages:    buildTrajectoryMessages(records),
+	}
+	return r.createRouterReplayJSONResponse(200, payload)
+}
+
+// filterTrajectoryRecordsBySession returns records whose RequestID matches sessionID.
+func filterTrajectoryRecordsBySession(
+	records []routerreplay.RoutingRecord,
+	sessionID string,
+) []routerreplay.RoutingRecord {
+	matched := make([]routerreplay.RoutingRecord, 0)
+	for _, record := range records {
+		if record.RequestID == sessionID {
+			matched = append(matched, record)
+		}
+	}
+	return matched
+}
+
+func reverseRoutingRecords(records []routerreplay.RoutingRecord) {
+	slices.Reverse(records)
+}
+
+// buildTrajectoryMessages converts replay records into an OpenAI-format message list.
+// Consecutive assistant_tool_call steps are coalesced into a single assistant message
+// with multiple tool_calls, matching OpenAI's expected format.
+func buildTrajectoryMessages(records []routerreplay.RoutingRecord) []trajectoryMessage {
+	messages := make([]trajectoryMessage, 0)
+	var pendingToolCalls []trajectoryToolCall
+
+	flushToolCalls := func() {
+		if len(pendingToolCalls) == 0 {
+			return
+		}
+		messages = append(messages, trajectoryMessage{
+			Role:      "assistant",
+			ToolCalls: pendingToolCalls,
+		})
+		pendingToolCalls = nil
+	}
+
+	for _, record := range records {
+		for _, step := range trajectoryStepsForRecord(record) {
+			if step.Type == replayToolStepAssistantToolCall {
+				pendingToolCalls = append(pendingToolCalls, trajectoryToolCall{
+					ID:   step.ToolCallID,
+					Type: "function",
+					Function: trajectoryFunctionCall{
+						Name:      step.ToolName,
+						Arguments: step.Arguments,
+					},
+				})
+				continue
+			}
+			flushToolCalls()
+			if msg := trajectoryMessageFromStep(step); msg != nil {
+				messages = append(messages, *msg)
+			}
+		}
+	}
+	flushToolCalls()
+	return messages
+}
+
+// trajectoryStepsForRecord returns the ToolTraceStep slice for a record.
+// If ToolTrace is nil or empty, it falls back to parsing the stored request/response bodies.
+func trajectoryStepsForRecord(record routerreplay.RoutingRecord) []routerreplay.ToolTraceStep {
+	if record.ToolTrace != nil && len(record.ToolTrace.Steps) > 0 {
+		return record.ToolTrace.Steps
+	}
+	trace := fallbackTrajectoryTrace(record)
+	if trace != nil {
+		return trace.Steps
+	}
+	return nil
+}
+
+// fallbackTrajectoryTrace parses request_body and response_body as Chat Completions
+// payloads when tool_trace is absent.
+func fallbackTrajectoryTrace(record routerreplay.RoutingRecord) *routerreplay.ToolTrace {
+	requestTrace := parseChatCompletionRequestToolTrace([]byte(record.RequestBody))
+	responseTrace := parseChatCompletionResponseToolTrace([]byte(record.ResponseBody))
+	return mergeReplayToolTraces(requestTrace, responseTrace)
+}
+
+func trajectoryMessageFromStep(step routerreplay.ToolTraceStep) *trajectoryMessage {
+	switch step.Type {
+	case replayToolStepUserInput:
+		return &trajectoryMessage{Role: "user", Content: step.Text}
+	case replayToolStepClientToolResult:
+		return &trajectoryMessage{Role: "tool", Content: step.Text, ToolCallID: step.ToolCallID}
+	case replayToolStepAssistantFinalResponse:
+		return &trajectoryMessage{Role: "assistant", Content: step.Text}
+	default:
+		return nil
+	}
+}

--- a/src/semantic-router/pkg/extproc/router_replay_trajectory_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_trajectory_test.go
@@ -1,0 +1,294 @@
+package extproc
+
+import (
+	"testing"
+	"time"
+
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
+)
+
+// newTrajectoryTestRouter builds a router with two records sharing a session ID.
+// The first record has a user_input + assistant_tool_call + client_tool_result.
+// The second record has an assistant_final_response.
+func newTrajectoryTestRouter(t *testing.T) (*OpenAIRouter, string) {
+	t.Helper()
+	sessionID := "sess-abc123"
+	recorder := routerreplay.NewRecorder(store.NewMemoryStore(10, 0))
+
+	_, err := recorder.AddRecord(routerreplay.RoutingRecord{
+		ID:        "traj-1",
+		RequestID: sessionID,
+		Timestamp: time.Unix(1, 0).UTC(),
+		ToolTrace: &routerreplay.ToolTrace{
+			Steps: []routerreplay.ToolTraceStep{
+				{Type: replayToolStepUserInput, Role: "user", Text: "what is the weather?"},
+				{Type: replayToolStepAssistantToolCall, Role: "assistant", ToolName: "get_weather", ToolCallID: "call-1", Arguments: `{"city":"NYC"}`},
+				{Type: replayToolStepClientToolResult, Role: "tool", Text: "sunny", ToolCallID: "call-1"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to add record: %v", err)
+	}
+
+	_, err = recorder.AddRecord(routerreplay.RoutingRecord{
+		ID:        "traj-2",
+		RequestID: sessionID,
+		Timestamp: time.Unix(2, 0).UTC(),
+		ToolTrace: &routerreplay.ToolTrace{
+			Steps: []routerreplay.ToolTraceStep{
+				{Type: replayToolStepAssistantFinalResponse, Role: "assistant", Text: "It is sunny in NYC."},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to add record: %v", err)
+	}
+
+	return &OpenAIRouter{
+		ReplayRecorders: map[string]*routerreplay.Recorder{"default": recorder},
+	}, sessionID
+}
+
+func TestHandleRouterReplayTrajectoryConvertsToolTraceToOpenAIMessages(t *testing.T) {
+	router, sessionID := newTrajectoryTestRouter(t)
+
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay/trajectory?session_id="+sessionID)
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate trajectory response")
+	}
+
+	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
+	assertStringField(t, body, "object", "router_replay.trajectory")
+	assertStringField(t, body, "session_id", sessionID)
+	assertIntField(t, body, "record_count", 2)
+
+	messages := mustTrajectoryMessages(t, body)
+	if len(messages) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(messages))
+	}
+
+	assertStringField(t, messages[0], "role", "user")
+	assertStringField(t, messages[0], "content", "what is the weather?")
+
+	assertStringField(t, messages[1], "role", "assistant")
+	toolCalls := mustTrajectoryToolCalls(t, messages[1])
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(toolCalls))
+	}
+	assertStringField(t, toolCalls[0], "id", "call-1")
+	assertStringField(t, toolCalls[0], "type", "function")
+	fn := mustTrajectoryFunction(t, toolCalls[0])
+	assertStringField(t, fn, "name", "get_weather")
+	assertStringField(t, fn, "arguments", `{"city":"NYC"}`)
+
+	assertStringField(t, messages[2], "role", "tool")
+	assertStringField(t, messages[2], "content", "sunny")
+	assertStringField(t, messages[2], "tool_call_id", "call-1")
+
+	assertStringField(t, messages[3], "role", "assistant")
+	assertStringField(t, messages[3], "content", "It is sunny in NYC.")
+}
+
+func TestHandleRouterReplayTrajectoryCoalescesConsecutiveToolCalls(t *testing.T) {
+	recorder := routerreplay.NewRecorder(store.NewMemoryStore(10, 0))
+	sessionID := "sess-multi-tool"
+
+	_, err := recorder.AddRecord(routerreplay.RoutingRecord{
+		ID:        "traj-multi",
+		RequestID: sessionID,
+		Timestamp: time.Unix(1, 0).UTC(),
+		ToolTrace: &routerreplay.ToolTrace{
+			Steps: []routerreplay.ToolTraceStep{
+				{Type: replayToolStepUserInput, Role: "user", Text: "run both tools"},
+				{Type: replayToolStepAssistantToolCall, Role: "assistant", ToolName: "tool_a", ToolCallID: "call-a", Arguments: `{}`},
+				{Type: replayToolStepAssistantToolCall, Role: "assistant", ToolName: "tool_b", ToolCallID: "call-b", Arguments: `{}`},
+				{Type: replayToolStepClientToolResult, Role: "tool", Text: "result-a", ToolCallID: "call-a"},
+				{Type: replayToolStepClientToolResult, Role: "tool", Text: "result-b", ToolCallID: "call-b"},
+				{Type: replayToolStepAssistantFinalResponse, Role: "assistant", Text: "done"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to add record: %v", err)
+	}
+
+	router := &OpenAIRouter{
+		ReplayRecorders: map[string]*routerreplay.Recorder{"default": recorder},
+	}
+
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay/trajectory?session_id="+sessionID)
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate trajectory response")
+	}
+
+	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
+	messages := mustTrajectoryMessages(t, body)
+
+	// Expect: user, assistant(2 tool_calls), tool, tool, assistant(final) = 5 messages
+	if len(messages) != 5 {
+		t.Fatalf("expected 5 messages after coalescing, got %d", len(messages))
+	}
+
+	assertStringField(t, messages[0], "role", "user")
+
+	assertStringField(t, messages[1], "role", "assistant")
+	toolCalls := mustTrajectoryToolCalls(t, messages[1])
+	if len(toolCalls) != 2 {
+		t.Fatalf("expected 2 coalesced tool calls, got %d", len(toolCalls))
+	}
+	assertStringField(t, toolCalls[0], "id", "call-a")
+	assertStringField(t, toolCalls[1], "id", "call-b")
+
+	if _, hasContent := messages[1]["content"]; hasContent {
+		t.Fatal("assistant tool-call message should not have content field")
+	}
+
+	assertStringField(t, messages[2], "role", "tool")
+	assertStringField(t, messages[2], "tool_call_id", "call-a")
+	assertStringField(t, messages[3], "role", "tool")
+	assertStringField(t, messages[3], "tool_call_id", "call-b")
+	assertStringField(t, messages[4], "role", "assistant")
+	assertStringField(t, messages[4], "content", "done")
+}
+
+func TestHandleRouterReplayTrajectoryFallsBackToBodyParsing(t *testing.T) {
+	recorder := routerreplay.NewRecorder(store.NewMemoryStore(10, 0))
+	sessionID := "sess-fallback"
+
+	requestBody := `{"messages":[{"role":"user","content":"hello"},{"role":"assistant","tool_calls":[{"id":"call-x","type":"function","function":{"name":"my_tool","arguments":"{}"}}]},{"role":"tool","content":"tool result","tool_call_id":"call-x"}]}`
+	responseBody := `{"choices":[{"message":{"role":"assistant","content":"final"}}]}`
+
+	_, err := recorder.AddRecord(routerreplay.RoutingRecord{
+		ID:           "traj-fallback",
+		RequestID:    sessionID,
+		Timestamp:    time.Unix(1, 0).UTC(),
+		RequestBody:  requestBody,
+		ResponseBody: responseBody,
+		// ToolTrace intentionally nil
+	})
+	if err != nil {
+		t.Fatalf("failed to add record: %v", err)
+	}
+
+	router := &OpenAIRouter{
+		ReplayRecorders: map[string]*routerreplay.Recorder{"default": recorder},
+	}
+
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay/trajectory?session_id="+sessionID)
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate trajectory response")
+	}
+
+	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
+	assertIntField(t, body, "record_count", 1)
+
+	messages := mustTrajectoryMessages(t, body)
+	if len(messages) == 0 {
+		t.Fatal("expected messages from body fallback, got none")
+	}
+
+	// The last message should be the assistant final response from the response body.
+	last := messages[len(messages)-1]
+	assertStringField(t, last, "role", "assistant")
+	assertStringField(t, last, "content", "final")
+}
+
+func TestHandleRouterReplayTrajectoryReturnsEmptyMessagesForUnknownSession(t *testing.T) {
+	router, _ := newTrajectoryTestRouter(t)
+
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay/trajectory?session_id=unknown")
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate trajectory response")
+	}
+
+	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
+	assertStringField(t, body, "object", "router_replay.trajectory")
+	assertIntField(t, body, "record_count", 0)
+
+	messages := mustTrajectoryMessages(t, body)
+	if len(messages) != 0 {
+		t.Fatalf("expected 0 messages for unknown session, got %d", len(messages))
+	}
+}
+
+func TestHandleRouterReplayTrajectoryMethodNotAllowed(t *testing.T) {
+	router, sessionID := newTrajectoryTestRouter(t)
+
+	response := router.handleRouterReplayAPI("POST", "/v1/router_replay/trajectory?session_id="+sessionID)
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate error response")
+	}
+	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_MethodNotAllowed {
+		t.Fatalf("expected 405 status, got %v", got)
+	}
+}
+
+func TestHandleRouterReplayTrajectoryMissingSessionID(t *testing.T) {
+	router, _ := newTrajectoryTestRouter(t)
+
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay/trajectory")
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate error response")
+	}
+	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_BadRequest {
+		t.Fatalf("expected 400 status, got %v", got)
+	}
+
+	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
+	errBody, ok := body["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error payload, got %#v", body)
+	}
+	if got := errBody["message"]; got != "session_id is required" {
+		t.Fatalf("unexpected error message: %#v", got)
+	}
+}
+
+// --- helpers ---
+
+func mustTrajectoryMessages(t *testing.T, body map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+	raw, ok := body["messages"].([]interface{})
+	if !ok {
+		t.Fatalf("expected messages array, got %#v", body["messages"])
+	}
+	msgs := make([]map[string]interface{}, 0, len(raw))
+	for _, item := range raw {
+		msg, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected message object, got %#v", item)
+		}
+		msgs = append(msgs, msg)
+	}
+	return msgs
+}
+
+func mustTrajectoryToolCalls(t *testing.T, msg map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+	raw, ok := msg["tool_calls"].([]interface{})
+	if !ok {
+		t.Fatalf("expected tool_calls array, got %#v", msg["tool_calls"])
+	}
+	calls := make([]map[string]interface{}, 0, len(raw))
+	for _, item := range raw {
+		call, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected tool call object, got %#v", item)
+		}
+		calls = append(calls, call)
+	}
+	return calls
+}
+
+func mustTrajectoryFunction(t *testing.T, toolCall map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	fn, ok := toolCall["function"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected function object, got %#v", toolCall["function"])
+	}
+	return fn
+}


### PR DESCRIPTION
## Summary
- Adds `GET /v1/router_replay/trajectory?session_id={id}` to convert stored `ToolTrace` steps into a flat OpenAI Chat Completions message list for use with evaluation frameworks (agentevals, Braintrust, LangSmith, etc.)
- Consecutive `assistant_tool_call` steps are coalesced into a single assistant message with multiple `tool_calls` per OpenAI spec
- Falls back to parsing `request_body`/`response_body` when `tool_trace` is nil

## Changes
- `router_replay_trajectory.go` — new handler, response structs, conversion logic
- `router_replay_trajectory_test.go` — 6 tests (conversion, coalescing, fallback, error cases)
- `router_replay_api.go` — wired new path into switch before `/{id}` catch-all

## Test plan
- [x] `cd src/semantic-router && CGO_ENABLED=1 SR_TEST_MODE=true go test -v ./pkg/extproc/... -run "Trajectory"`
- [x] Verify response format matches OpenAI Chat Completions spec
- [x] Test with both Chat Completions and Responses API source records

Closes #1779
