### PR TITLE
[UI] Fix Web Search tooltip placement in composer

### DIFF
--- a/dashboard/frontend/src/components/ChatComponent.module.css
+++ b/dashboard/frontend/src/components/ChatComponent.module.css
@@ -917,7 +917,8 @@ body.playground-fullscreen .container {
   background: rgba(44, 45, 49, 0.82);
   border: none;
   border-radius: 28px;
-  overflow: hidden;
+  /* visible so composer tooltips (e.g. Web Search) can sit outside the pill */
+  overflow: visible;
   transition: all var(--transition-base);
   position: relative;
   z-index: 1;
@@ -975,6 +976,13 @@ body.playground-fullscreen .container {
   display: flex;
   align-items: center;
   gap: 0.4rem;
+}
+
+.inputActionsEnd {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
 }
 
 .composerButtons {
@@ -1095,6 +1103,16 @@ body.playground-fullscreen .container {
 .inputActionButton:hover::before {
   opacity: 1;
   visibility: visible;
+}
+
+.inputActionButton.inputActionButtonTooltipEnd::before {
+  bottom: auto;
+  top: 50%;
+  left: auto;
+  right: 100%;
+  transform: translateY(calc(-50% - 5px));
+  margin-bottom: 0;
+  margin-right: 10px;
 }
 
 /* Search Toggle Active State */

--- a/dashboard/frontend/src/components/ChatComponent.module.css
+++ b/dashboard/frontend/src/components/ChatComponent.module.css
@@ -917,7 +917,6 @@ body.playground-fullscreen .container {
   background: rgba(44, 45, 49, 0.82);
   border: none;
   border-radius: 28px;
-  /* visible so composer tooltips (e.g. Web Search) can sit outside the pill */
   overflow: visible;
   transition: all var(--transition-base);
   position: relative;

--- a/dashboard/frontend/src/components/ChatComponentControls.tsx
+++ b/dashboard/frontend/src/components/ChatComponentControls.tsx
@@ -108,10 +108,10 @@ export const ToolToggle = ({
 }) => {
   return (
     <button
-      className={`${styles.inputActionButton} ${enabled ? styles.searchToggleActive : ''}`}
+      className={`${styles.inputActionButton} ${styles.inputActionButtonTooltipEnd} ${enabled ? styles.searchToggleActive : ''}`}
       onClick={onToggle}
       disabled={disabled}
-      data-tooltip={enabled ? 'Web Search enabled' : 'Enable Web Search'}
+      data-tooltip={enabled ? 'Web Search Enabled' : 'Enable Web Search'}
     >
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
         <circle cx="12" cy="12" r="10" />


### PR DESCRIPTION
Closes #1794

## Purpose

- What does this PR change?
Dashboard: Adjusts the playground composer so the Web Search control’s CSS tooltip (data-tooltip) no longer sits over the textarea placeholder.

- Why is this change needed?
To improve the user experience 


Tested:
<img width="559" height="121" alt="Screenshot 2026-04-17 at 5 35 06 PM" src="https://github.com/user-attachments/assets/557bbbe0-cd88-4914-b06e-49c77e7ba0bd" />
<img width="359" height="109" alt="Screenshot 2026-04-17 at 5 35 11 PM" src="https://github.com/user-attachments/assets/b9db28a8-b25f-413f-adb0-b61c5f451356" />

