### PR TITLE
[Router] Add cache affinity routing bias

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -61,16 +61,17 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, history s
 // selectModelFromCandidates uses the configured selection algorithm to choose the best model
 // from the decision's candidate models. Falls back to first model if selection fails.
 // The algorithm parameter allows per-decision algorithm override (aligned with looper pattern).
-// The categoryName parameter is the detected domain category (e.g., "physics", "math") for ML feature vectors.
+// The selCtx parameter carries the pre-built SelectionContext, including request-time
+// inputs such as query text, candidate models, and cache-affinity signals.
 // Returns the selected model and the method name used for logging.
-func (r *OpenAIRouter) selectModelFromCandidates(modelRefs []config.ModelRef, decisionName string, query string, algorithm *config.AlgorithmConfig, categoryName string, candidateIterations []config.CandidateIterationConfig) (*config.ModelRef, string) {
-	if len(modelRefs) == 0 {
+func (r *OpenAIRouter) selectModelFromCandidates(selCtx *selection.SelectionContext, algorithm *config.AlgorithmConfig) (*config.ModelRef, string) {
+	if selCtx == nil || len(selCtx.CandidateModels) == 0 {
 		return nil, ""
 	}
 
 	// If only one model, no need for selection algorithm
-	if len(modelRefs) == 1 {
-		return &modelRefs[0], "single"
+	if len(selCtx.CandidateModels) == 1 {
+		return &selCtx.CandidateModels[0], "single"
 	}
 
 	// Determine selection method: per-decision algorithm takes precedence over global config
@@ -85,14 +86,49 @@ func (r *OpenAIRouter) selectModelFromCandidates(modelRefs []config.ModelRef, de
 	// Fallback to first model if no selector available
 	if selector == nil {
 		logging.Warnf("[ModelSelection] No selector available for method %s, using first model", method)
-		return &modelRefs[0], string(method)
+		return &selCtx.CandidateModels[0], string(method)
 	}
 
-	// Build selection context with cost/quality weights
+	// Perform selection
+	result, err := selector.Select(context.Background(), selCtx)
+	if err != nil {
+		logging.Warnf("[ModelSelection] Selection failed: %v, using first model", err)
+		return &selCtx.CandidateModels[0], string(method)
+	}
+
+	// Find the selected model in the candidates
+	for i := range selCtx.CandidateModels {
+		if selCtx.CandidateModels[i].Model == result.SelectedModel ||
+			selCtx.CandidateModels[i].LoRAName == result.SelectedModel {
+			logging.Infof("[ModelSelection] Selected %s (method=%s, score=%.4f, confidence=%.2f): %s",
+				result.SelectedModel, method, result.Score, result.Confidence, result.Reasoning)
+			selection.RecordSelection(string(method), selCtx.DecisionName, result.SelectedModel, result.Tier, result.Score)
+			return &selCtx.CandidateModels[i], string(method)
+		}
+	}
+
+	// Fallback if selected model not found in candidates (shouldn't happen)
+	logging.Warnf("[ModelSelection] Selected model %s not found in candidates, using first model", result.SelectedModel)
+	return &selCtx.CandidateModels[0], string(method)
+}
+
+// buildSelectionContext assembles the runtime inputs shared by selection
+// algorithms. Static policy comes from AlgorithmConfig; dynamic request-time
+// signals stay in SelectionContext so selectors do not need to reach back into
+// extproc state.
+func (r *OpenAIRouter) buildSelectionContext(
+	modelRefs []config.ModelRef,
+	decisionName string,
+	query string,
+	algorithm *config.AlgorithmConfig,
+	categoryName string,
+	candidateIterations []config.CandidateIterationConfig,
+	reqCtx *RequestContext,
+) *selection.SelectionContext {
 	costWeight, qualityWeight := r.getSelectionWeights(algorithm)
 	latencyAwareTPOTPercentile, latencyAwareTTFTPercentile := r.getLatencyAwarePercentiles(algorithm)
 
-	selCtx := &selection.SelectionContext{
+	return &selection.SelectionContext{
 		Query:                      query,
 		DecisionName:               decisionName,
 		CategoryName:               categoryName,
@@ -102,29 +138,37 @@ func (r *OpenAIRouter) selectModelFromCandidates(modelRefs []config.ModelRef, de
 		QualityWeight:              qualityWeight,
 		LatencyAwareTPOTPercentile: latencyAwareTPOTPercentile,
 		LatencyAwareTTFTPercentile: latencyAwareTTFTPercentile,
+		CacheAffinityCtx:           r.buildCacheAffinityContext(reqCtx, modelRefs),
+	}
+}
+
+// buildCacheAffinityContext extracts the pre-dispatch continuation signals used
+// by the cache-affinity estimator. Nil request context cleanly disables the
+// estimator without forcing call sites to add extra branching.
+func (r *OpenAIRouter) buildCacheAffinityContext(reqCtx *RequestContext, modelRefs []config.ModelRef) *selection.CacheAffinityContext {
+	if reqCtx == nil {
+		return nil
 	}
 
-	// Perform selection
-	result, err := selector.Select(context.Background(), selCtx)
-	if err != nil {
-		logging.Warnf("[ModelSelection] Selection failed: %v, using first model", err)
-		return &modelRefs[0], string(method)
-	}
-
-	// Find the selected model in the candidates
-	for i := range modelRefs {
-		if modelRefs[i].Model == result.SelectedModel ||
-			modelRefs[i].LoRAName == result.SelectedModel {
-			logging.Infof("[ModelSelection] Selected %s (method=%s, score=%.4f, confidence=%.2f): %s",
-				result.SelectedModel, method, result.Score, result.Confidence, result.Reasoning)
-			selection.RecordSelection(string(method), decisionName, result.SelectedModel, result.Tier, result.Score)
-			return &modelRefs[i], string(method)
+	// Missing model window metadata is valid; the estimator treats it as a
+	// neutral fit score rather than as an error.
+	var windows map[string]int
+	if r.Config != nil && r.Config.ModelConfig != nil {
+		windows = make(map[string]int, len(modelRefs))
+		for _, ref := range modelRefs {
+			if params, ok := r.Config.ModelConfig[ref.Model]; ok {
+				windows[ref.Model] = params.ContextWindowSize
+			}
 		}
 	}
-
-	// Fallback if selected model not found in candidates (shouldn't happen)
-	logging.Warnf("[ModelSelection] Selected model %s not found in candidates, using first model", result.SelectedModel)
-	return &modelRefs[0], string(method)
+	return &selection.CacheAffinityContext{
+		TurnIndex:           reqCtx.TurnIndex,
+		PreviousModel:       reqCtx.PreviousModel,
+		PreviousResponseID:  reqCtx.PreviousResponseID,
+		HistoryTokens:       reqCtx.HistoryTokenCount,
+		ContextTokens:       reqCtx.VSRContextTokenCount,
+		ModelContextWindows: windows,
+	}
 }
 
 // getSelectionMethod determines which selection algorithm to use.
@@ -195,13 +239,13 @@ func (r *OpenAIRouter) processUserFeedbackForElo(userFeedbackSignals []string, m
 		return
 	}
 
-	// Process each feedback signal
 	// Get decision name safely
 	decisionName := ""
 	if ctx.VSRSelectedDecision != nil {
 		decisionName = ctx.VSRSelectedDecision.Name
 	}
 
+	// Process each feedback signal
 	for _, signal := range userFeedbackSignals {
 		var feedback *selection.Feedback
 

--- a/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
@@ -215,14 +215,16 @@ func (r *OpenAIRouter) selectDecisionRuntimeModel(
 		return selectedModel, entropy.ReasoningDecision{}
 	}
 
-	selectedModelRef, usedMethod := r.selectModelFromCandidates(
+	selCtx := r.buildSelectionContext(
 		result.Decision.ModelRefs,
 		decisionName,
 		userContent,
 		result.Decision.Algorithm,
 		categoryName,
 		result.Decision.CandidateIterations,
+		ctx,
 	)
+	selectedModelRef, usedMethod := r.selectModelFromCandidates(selCtx, result.Decision.Algorithm)
 	selectedModel := selectedModelRef.Model
 	selectionFields := map[string]interface{}{
 		"request_id":        ctx.RequestID,

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -79,6 +79,16 @@ type RequestContext struct {
 	PreviousModel       string  // Model used in the immediately preceding turn; empty on first turn
 	CacheWarmthEstimate float64 // [0,1] from EstimateCacheProbability; 0.5 = unknown
 
+	// HistoryTokenCount is the estimated token count of conversation history,
+	// excluding the current turn. Source priority: provider usage accumulation
+	// (resp.Usage.InputTokens + OutputTokens) > char/4 text fallback.
+	HistoryTokenCount int
+
+	// PreviousResponseID is the Response API previous_response_id field.
+	// Non-empty value is a strong explicit continuation signal even when
+	// HistoryTokenCount is zero (server-side conversation state).
+	PreviousResponseID string
+
 	// VSR decision tracking
 	VSRSelectedCategory           string           // The category from domain classification (MMLU category)
 	VSRSelectedDecisionName       string           // The decision name from DecisionEngine evaluation

--- a/src/semantic-router/pkg/extproc/session_transition.go
+++ b/src/semantic-router/pkg/extproc/session_transition.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 )
 
@@ -19,11 +20,13 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 	isResponseAPI := ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.IsResponseAPIRequest
 	if isResponseAPI {
 		ctx.SessionID = ctx.ResponseAPICtx.ConversationID
+		ctx.PreviousResponseID = ctx.ResponseAPICtx.PreviousResponseID
 		history := ctx.ResponseAPICtx.ConversationHistory
 		ctx.TurnIndex = len(history)
 		if len(history) > 0 {
 			ctx.PreviousModel = history[len(history)-1].Model
 		}
+		ctx.HistoryTokenCount = historyTokensFromStoredResponses(history)
 		return
 	}
 
@@ -41,6 +44,7 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 	populateChatCompletionSessionIDIfNeeded(ctx)
 
 	ctx.TurnIndex = sessiontelemetry.ChatTurnNumber(sessionTransitionChatMessages(ctx.ChatCompletionMessages)) - 1
+	ctx.HistoryTokenCount = historyTokensFromChatMessages(ctx.ChatCompletionMessages)
 	// TODO: populate PreviousModel for Chat Completions once per-turn model history is available.
 }
 
@@ -74,4 +78,60 @@ func sessionTransitionChatMessages(messages []ChatCompletionMessage) []sessionte
 		}
 	}
 	return converted
+}
+
+func historyTokensFromStoredResponses(history []*responseapi.StoredResponse) int {
+	total := 0
+	for _, resp := range history {
+		if resp == nil {
+			continue
+		}
+		if resp.Usage != nil {
+			total += resp.Usage.InputTokens + resp.Usage.OutputTokens
+		} else {
+			total += estimateStoredResponseTokens(resp)
+		}
+	}
+	return total
+}
+
+const historyTokensCap = 8192
+
+func estimateStoredResponseTokens(resp *responseapi.StoredResponse) int {
+	total := 0
+	for _, item := range resp.Input {
+		total += estimateTokenLength(extractContentFromInputItem(item))
+	}
+
+	if resp.OutputText != "" {
+		return total + estimateTokenLength(resp.OutputText)
+	}
+
+	for _, item := range resp.Output {
+		total += estimateTokenLength(extractContentFromOutputItem(item))
+	}
+
+	return total
+}
+
+func historyTokensFromChatMessages(messages []ChatCompletionMessage) int {
+	if len(messages) == 0 {
+		return 0
+	}
+	prior := messages
+	if messages[len(messages)-1].Role == "user" {
+		prior = messages[:len(messages)-1]
+	}
+	total := 0
+	for _, msg := range prior {
+		total += estimateTokenLength(msg.Content)
+		if total >= historyTokensCap {
+			return historyTokensCap
+		}
+	}
+	return total
+}
+
+func estimateTokenLength(text string) int {
+	return len(text) / 4
 }

--- a/src/semantic-router/pkg/extproc/session_transition.go
+++ b/src/semantic-router/pkg/extproc/session_transition.go
@@ -23,8 +23,11 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 		ctx.PreviousResponseID = ctx.ResponseAPICtx.PreviousResponseID
 		history := ctx.ResponseAPICtx.ConversationHistory
 		ctx.TurnIndex = len(history)
-		if len(history) > 0 {
-			ctx.PreviousModel = history[len(history)-1].Model
+		for i := len(history) - 1; i >= 0; i-- {
+			if history[i] != nil {
+				ctx.PreviousModel = history[i].Model
+				break
+			}
 		}
 		ctx.HistoryTokenCount = historyTokensFromStoredResponses(history)
 		return
@@ -90,6 +93,9 @@ func historyTokensFromStoredResponses(history []*responseapi.StoredResponse) int
 			total += resp.Usage.InputTokens + resp.Usage.OutputTokens
 		} else {
 			total += estimateStoredResponseTokens(resp)
+		}
+		if total >= historyTokensCap {
+			return historyTokensCap
 		}
 	}
 	return total

--- a/src/semantic-router/pkg/extproc/session_transition_test.go
+++ b/src/semantic-router/pkg/extproc/session_transition_test.go
@@ -96,6 +96,33 @@ func TestPopulateSessionTransitionFields_ResponseAPI_NilResponseInHistory(t *tes
 	assert.Equal(t, 70, ctx.HistoryTokenCount)
 }
 
+func TestPopulateSessionTransitionFields_ResponseAPI_NilLastEntryDoesNotPanic(t *testing.T) {
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv-nil-last",
+			ConversationHistory: []*responseapi.StoredResponse{
+				{Model: "model-a", Usage: &responseapi.Usage{InputTokens: 50, OutputTokens: 20}},
+				nil,
+			},
+		},
+	}
+
+	require.NotPanics(t, func() { populateSessionTransitionFields(ctx) })
+	assert.Equal(t, "model-a", ctx.PreviousModel)
+	assert.Equal(t, 70, ctx.HistoryTokenCount)
+}
+
+func TestHistoryTokensFromStoredResponses_CapsAtHistoryTokensCap(t *testing.T) {
+	bigUsage := &responseapi.Usage{InputTokens: 5000, OutputTokens: 4000}
+	history := []*responseapi.StoredResponse{
+		{Model: "m", Usage: bigUsage},
+		{Model: "m", Usage: bigUsage},
+		{Model: "m", Usage: bigUsage},
+	}
+	assert.Equal(t, historyTokensCap, historyTokensFromStoredResponses(history))
+}
+
 func TestPopulateSessionTransitionFields_ChatCompletionsFirstTurnIgnoresSystemMessages(t *testing.T) {
 	ctx := &RequestContext{
 		Headers: map[string]string{

--- a/src/semantic-router/pkg/extproc/session_transition_test.go
+++ b/src/semantic-router/pkg/extproc/session_transition_test.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ func TestPopulateSessionTransitionFields_ResponseAPI(t *testing.T) {
 		ResponseAPICtx: &ResponseAPIContext{
 			IsResponseAPIRequest: true,
 			ConversationID:       "conv-123",
+			PreviousResponseID:   "resp-abc",
 			ConversationHistory: []*responseapi.StoredResponse{
 				{Model: "deepseek-v3"},
 				{Model: "deepseek-r1"},
@@ -28,6 +30,70 @@ func TestPopulateSessionTransitionFields_ResponseAPI(t *testing.T) {
 	assert.Equal(t, "conv-123", ctx.SessionID)
 	assert.Equal(t, 2, ctx.TurnIndex)
 	assert.Equal(t, "deepseek-r1", ctx.PreviousModel)
+	assert.Equal(t, "resp-abc", ctx.PreviousResponseID)
+}
+
+func TestPopulateSessionTransitionFields_ResponseAPI_HistoryTokens_UsagePresent(t *testing.T) {
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv-tok",
+			ConversationHistory: []*responseapi.StoredResponse{
+				{
+					Model: "model-a",
+					Usage: &responseapi.Usage{InputTokens: 100, OutputTokens: 50},
+				},
+				{
+					Model: "model-a",
+					Usage: &responseapi.Usage{InputTokens: 200, OutputTokens: 80},
+				},
+			},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, 430, ctx.HistoryTokenCount)
+}
+
+func TestPopulateSessionTransitionFields_ResponseAPI_HistoryTokens_FallbackIncludesInputAndOutput(t *testing.T) {
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv-fallback",
+			ConversationHistory: []*responseapi.StoredResponse{
+				{
+					Model: "model-a",
+					Input: []responseapi.InputItem{{
+						Type:    responseapi.ItemTypeMessage,
+						Role:    responseapi.RoleUser,
+						Content: json.RawMessage(`"abcdefgh"`),
+					}},
+					OutputText: "abcdefgh",
+				},
+			},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, 4, ctx.HistoryTokenCount)
+}
+
+func TestPopulateSessionTransitionFields_ResponseAPI_NilResponseInHistory(t *testing.T) {
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv-nil",
+			ConversationHistory: []*responseapi.StoredResponse{
+				nil,
+				{Model: "model-a", Usage: &responseapi.Usage{InputTokens: 50, OutputTokens: 20}},
+			},
+		},
+	}
+
+	require.NotPanics(t, func() { populateSessionTransitionFields(ctx) })
+	assert.Equal(t, 70, ctx.HistoryTokenCount)
 }
 
 func TestPopulateSessionTransitionFields_ChatCompletionsFirstTurnIgnoresSystemMessages(t *testing.T) {
@@ -109,4 +175,52 @@ func TestPopulateSessionTransitionFields_ChatCompletionsEmptyThreadUsesRidFromRe
 	populateSessionTransitionFields(ctx)
 
 	require.True(t, strings.HasPrefix(ctx.SessionID, "rid-"))
+}
+
+func TestHistoryTokensFromChatMessages_Empty(t *testing.T) {
+	assert.Equal(t, 0, historyTokensFromChatMessages(nil))
+	assert.Equal(t, 0, historyTokensFromChatMessages([]ChatCompletionMessage{}))
+}
+
+func TestHistoryTokensFromChatMessages_ExcludesLastUserTurn(t *testing.T) {
+	msgs := []ChatCompletionMessage{
+		{Role: "system", Content: "abcd"},
+		{Role: "user", Content: "abcdefgh"},
+		{Role: "assistant", Content: "abcdefghij"},
+		{Role: "user", Content: "current"},
+	}
+	assert.Equal(t, 5, historyTokensFromChatMessages(msgs))
+}
+
+func TestHistoryTokensFromChatMessages_SingleUserMessage_ZeroHistory(t *testing.T) {
+	msgs := []ChatCompletionMessage{
+		{Role: "user", Content: "hello world"},
+	}
+	assert.Equal(t, 0, historyTokensFromChatMessages(msgs))
+}
+
+func TestEstimateTokenLength(t *testing.T) {
+	assert.Equal(t, 0, estimateTokenLength(""))
+	assert.Equal(t, 1, estimateTokenLength("abcd"))
+	assert.Equal(t, 3, estimateTokenLength("abcdefghijkl"))
+}
+
+func TestEstimateStoredResponseTokens_FallsBackToOutputItems(t *testing.T) {
+	stored := &responseapi.StoredResponse{
+		Input: []responseapi.InputItem{{
+			Type:    responseapi.ItemTypeMessage,
+			Role:    responseapi.RoleUser,
+			Content: json.RawMessage(`"abcdefgh"`),
+		}},
+		Output: []responseapi.OutputItem{{
+			Type: responseapi.ItemTypeMessage,
+			Role: responseapi.RoleAssistant,
+			Content: []responseapi.ContentPart{{
+				Type: responseapi.ContentTypeOutputText,
+				Text: "abcdefgh",
+			}},
+		}},
+	}
+
+	assert.Equal(t, 4, estimateStoredResponseTokens(stored))
 }

--- a/src/semantic-router/pkg/selection/cache_affinity.go
+++ b/src/semantic-router/pkg/selection/cache_affinity.go
@@ -98,16 +98,17 @@ type CacheAffinityResult struct {
 	LambdaReq float64
 }
 
-// ComputeCacheAffinityAdjustments applies a bounded pre-dispatch cache-affinity
-// bias during hybrid model selection.
+// ComputeCacheAffinityAdjustments returns per-model score adjustments for
+// pre-dispatch cache-affinity bias during hybrid model selection.
 //
-// The estimator produces a signed affinity effect A_m in (-1,1) and combines
-// it with evidence confidence C_m and an ambiguity-gated lambda so that:
+// Each adjustment is an additive delta the caller applies to the base score:
 //
-//	final_score(m) = base_score(m) + lambda_req * C_m * A_m
+//	Adjustments[m] = lambda_req * C_m * A_m
 //
-// |adjustment| is bounded by affinityMaxLambda, keeping cache-affinity as a
-// tie-breaker that cannot override strong quality or cost signals.
+// where A_m is a signed affinity effect in (-1,1), C_m is evidence confidence,
+// and lambda_req is an ambiguity-gated multiplier. |Adjustments[m]| is bounded
+// by affinityMaxLambda, keeping cache-affinity as a tie-breaker that cannot
+// override strong quality or cost signals.
 func ComputeCacheAffinityAdjustments(
 	ctx *CacheAffinityContext,
 	candidates []config.ModelRef,

--- a/src/semantic-router/pkg/selection/cache_affinity.go
+++ b/src/semantic-router/pkg/selection/cache_affinity.go
@@ -1,0 +1,272 @@
+package selection
+
+import (
+	"math"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// CacheAffinityContext carries the request-time session signals used by the
+// pre-dispatch cache-affinity estimator.
+//
+// These fields capture runtime evidence for the current request. The selection
+// request path carries them directly, while AlgorithmConfig remains available
+// for future tunable weights if we choose to expose them.
+type CacheAffinityContext struct {
+	// TurnIndex is the number of prior turns in this session (0 = first turn).
+	TurnIndex int
+
+	// PreviousModel is the model used in the immediately preceding turn.
+	// Empty means either first turn or unavailable history.
+	PreviousModel string
+
+	// PreviousResponseID is the Response API previous_response_id field.
+	// It provides an explicit continuation signal for server-side conversation
+	// chains and inline-history requests alike.
+	PreviousResponseID string
+
+	// HistoryTokens estimates the token count of prior conversation state,
+	// excluding the current user turn.
+	HistoryTokens int
+
+	// ContextTokens is the total token count for the current request context.
+	ContextTokens int
+
+	// ModelContextWindows maps model name -> ContextWindowSize from ModelParams.
+	// Entries that are absent contribute a neutral window-fit score.
+	ModelContextWindows map[string]int
+}
+
+const (
+	// affinityMaxLambda bounds the maximum absolute score adjustment.
+	// This keeps cache-affinity as a tie-breaker layered on top of the base
+	// hybrid score instead of letting it override strong quality/cost signals.
+	affinityMaxLambda = 0.14
+
+	// affinityGapThreshold is the top-2 base-score margin at which ambiguity
+	// collapses to zero. Clear base-score separation keeps the hybrid result
+	// anchored on the base scorer alone.
+	affinityGapThreshold = 0.20
+
+	// historyMassNorm and turnDepthNorm normalize request-time continuity signals
+	// into [0,1] before they are combined into W_req.
+	historyMassNorm = 4096.0
+
+	turnDepthNorm = 4.0
+)
+
+// These constants implement the heuristic from "Pre-Dispatch Cache-Affinity
+// Estimator — Final". Keep them explicit so the bounded scoring behavior is
+// easy to audit and compare against the design note.
+const (
+	// W_req weights combine request-level continuation evidence. They should sum
+	// to 1.0 so the normalized signal remains easy to reason about.
+	wrReuse = 0.45
+	wrMass  = 0.30
+	wrTurn  = 0.25
+
+	// wrPreviousResponseFloor keeps a small continuation signal for Response API
+	// chains that rely on server-side history instead of resending messages.
+	wrPreviousResponseFloor = 0.15
+
+	// E_m weights shape per-candidate signed affinity before tanh squashing.
+	// same_model terms reward staying on the previous model for continuation-
+	// heavy requests; emDiffPenalty pushes against switching when W_req is high;
+	// emFit introduces a small context-window fit correction.
+	emSameBase    = 0.50
+	emSameReuse   = 0.35
+	emSameTurn    = 0.15
+	emDiffPenalty = 0.35
+	emFit         = 0.15
+
+	// C_m weights shape evidence confidence. This gates how much trust to place
+	// in A_m before applying the bounded lambda-scaled adjustment.
+	cmBase        = 0.15
+	cmReuse       = 0.35
+	cmMass        = 0.20
+	cmTurn        = 0.15
+	cmFit         = 0.15
+	cmHasPrev     = 0.15
+	cmNoPrevScale = 0.60
+)
+
+// CacheAffinityResult returns both the per-model score deltas and the
+// request-level diagnostics that produced them.
+type CacheAffinityResult struct {
+	// Adjustments maps model name -> additive score delta.
+	Adjustments map[string]float64
+
+	// WReq is the request-level continuation sensitivity in [0,1].
+	WReq float64
+
+	// LambdaReq is the ambiguity-gated multiplier applied to all candidates for
+	// this request. A zero value leaves the base scores unchanged.
+	LambdaReq float64
+}
+
+// ComputeCacheAffinityAdjustments applies a bounded pre-dispatch cache-
+// affinity bias during hybrid model selection.
+//
+// The estimator produces a signed affinity effect A_m in (-1,1) and combines
+// it with evidence confidence C_m and an ambiguity-gated lambda so that:
+//
+//	final_score(m) = base_score(m) + lambda_req * C_m * A_m
+//
+// Production contract:
+//   - inputs come from request-time session and candidate metadata
+//   - zero adjustment cleanly preserves the base score for first-turn,
+//     single-candidate, or unambiguous requests
+//   - |adjustment| stays bounded by affinityMaxLambda, keeping cache-affinity
+//     as a tie-breaker or gentle bias on close calls
+func ComputeCacheAffinityAdjustments(
+	ctx *CacheAffinityContext,
+	candidates []config.ModelRef,
+	baseScores map[string]float64,
+) CacheAffinityResult {
+	// Fast paths for requests with minimal runtime context or with a single
+	// effective candidate.
+	if ctx == nil || len(candidates) < 2 {
+		return CacheAffinityResult{}
+	}
+
+	// hasContinuation is the coarse gate from Step 1. Continuation requests
+	// activate the request-level sensitivity calculation below.
+	hasContinuation := ctx.TurnIndex > 0 ||
+		ctx.HistoryTokens > 0 ||
+		ctx.PreviousResponseID != ""
+	if !hasContinuation {
+		return CacheAffinityResult{}
+	}
+
+	result := CacheAffinityResult{}
+
+	// Step 1: request continuation sensitivity W_req.
+	contextTokens := math.Max(float64(ctx.ContextTokens), 1)
+	reuseRatio := clampF(float64(ctx.HistoryTokens)/contextTokens, 0, 1)
+	historyMass := clampF(float64(ctx.HistoryTokens)/historyMassNorm, 0, 1)
+	turnDepth := clampF(float64(ctx.TurnIndex)/turnDepthNorm, 0, 1)
+
+	wReq := clampF(wrReuse*reuseRatio+wrMass*historyMass+wrTurn*turnDepth, 0, 1)
+	if ctx.PreviousResponseID != "" {
+		wReq = math.Max(wReq, wrPreviousResponseFloor)
+	}
+	result.WReq = wReq
+
+	// Step 4: ambiguity-gated lambda over the current base scores.
+	// gap12 is best_score - second_best_score across the candidate set.
+	gap12 := computeGap12(baseScores, candidates)
+	ambiguity := clampF(1.0-gap12/affinityGapThreshold, 0, 1)
+	lambdaReq := affinityMaxLambda * wReq * ambiguity
+	result.LambdaReq = lambdaReq
+
+	// A strong base winner keeps the diagnostics while preserving the base
+	// scores as-is.
+	if lambdaReq == 0 {
+		return result
+	}
+
+	// Step 2/3/5: per-candidate signed affinity, evidence confidence, then the
+	// bounded additive adjustment.
+	result.Adjustments = make(map[string]float64, len(candidates))
+	hasPrev := boolToFloat64(ctx.PreviousModel != "")
+
+	for _, candidate := range candidates {
+		name := candidate.Model
+
+		sameModel := boolToFloat64(ctx.PreviousModel != "" && name == ctx.PreviousModel)
+		windowSize := ctx.ModelContextWindows[name]
+		fitM := computeFitM(ctx.ContextTokens, windowSize)
+
+		// A_m is a signed effect size that captures the direction and strength of
+		// cache-affinity for this candidate.
+		eM := emSameBase*sameModel +
+			emSameReuse*sameModel*reuseRatio +
+			emSameTurn*sameModel*turnDepth -
+			emDiffPenalty*(1-sameModel)*wReq +
+			emFit*(fitM-0.5)
+		aM := math.Tanh(eM)
+
+		// C_m captures how much evidence supports using the affinity signal.
+		cRaw := clampF(
+			cmBase+
+				cmReuse*reuseRatio+
+				cmMass*historyMass+
+				cmTurn*turnDepth+
+				cmFit*fitM+
+				cmHasPrev*hasPrev,
+			0, 1,
+		)
+		cM := cRaw
+		if ctx.PreviousModel == "" {
+			cM = cmNoPrevScale * cRaw
+		}
+
+		// cache_adjustment(m) = lambda_req * C_m * A_m
+		result.Adjustments[name] = lambdaReq * cM * aM
+	}
+
+	logging.Debugf(
+		"[CacheAffinity] W_req=%.3f gap12=%.4f ambiguity=%.3f lambda=%.4f "+
+			"(turn=%d history=%d ctx=%d prev=%q)",
+		wReq, gap12, ambiguity, lambdaReq,
+		ctx.TurnIndex, ctx.HistoryTokens, ctx.ContextTokens, ctx.PreviousModel,
+	)
+
+	return result
+}
+
+// computeFitM implements the per-candidate context-window fit from the design
+// note. A missing window size contributes the neutral fit score of 0.5.
+func computeFitM(contextTokens, windowSize int) float64 {
+	if windowSize <= 0 {
+		return 0.5
+	}
+	w := float64(windowSize)
+	c := float64(contextTokens)
+	switch {
+	case c <= 0.50*w:
+		return 1.0
+	case c <= 0.75*w:
+		return 0.7
+	case c <= 1.00*w:
+		return 0.3
+	default:
+		return 0.0
+	}
+}
+
+// computeGap12 returns best_score - second_best_score over the active
+// candidate set. Hybrid selection uses it to decide whether the base result is
+// ambiguous enough for cache-affinity to matter.
+func computeGap12(baseScores map[string]float64, candidates []config.ModelRef) float64 {
+	best := -math.MaxFloat64
+	second := -math.MaxFloat64
+	for _, c := range candidates {
+		s := baseScores[c.Model]
+		if s > best {
+			second = best
+			best = s
+		} else if s > second {
+			second = s
+		}
+	}
+	if second == -math.MaxFloat64 {
+		return 0
+	}
+	return best - second
+}
+
+// boolToFloat64 keeps the estimator formulas close to the math notation from
+// the design doc, where indicator terms are written as 0/1 variables.
+func boolToFloat64(b bool) float64 {
+	if b {
+		return 1.0
+	}
+	return 0.0
+}
+
+// clampF restricts a float to the closed interval [lo, hi].
+func clampF(v, lo, hi float64) float64 {
+	return math.Max(lo, math.Min(v, hi))
+}

--- a/src/semantic-router/pkg/selection/cache_affinity.go
+++ b/src/semantic-router/pkg/selection/cache_affinity.go
@@ -9,10 +9,6 @@ import (
 
 // CacheAffinityContext carries the request-time session signals used by the
 // pre-dispatch cache-affinity estimator.
-//
-// These fields capture runtime evidence for the current request. The selection
-// request path carries them directly, while AlgorithmConfig remains available
-// for future tunable weights if we choose to expose them.
 type CacheAffinityContext struct {
 	// TurnIndex is the number of prior turns in this session (0 = first turn).
 	TurnIndex int
@@ -56,9 +52,6 @@ const (
 	turnDepthNorm = 4.0
 )
 
-// These constants implement the heuristic from "Pre-Dispatch Cache-Affinity
-// Estimator — Final". Keep them explicit so the bounded scoring behavior is
-// easy to audit and compare against the design note.
 const (
 	// W_req weights combine request-level continuation evidence. They should sum
 	// to 1.0 so the normalized signal remains easy to reason about.
@@ -105,33 +98,26 @@ type CacheAffinityResult struct {
 	LambdaReq float64
 }
 
-// ComputeCacheAffinityAdjustments applies a bounded pre-dispatch cache-
-// affinity bias during hybrid model selection.
+// ComputeCacheAffinityAdjustments applies a bounded pre-dispatch cache-affinity
+// bias during hybrid model selection.
 //
 // The estimator produces a signed affinity effect A_m in (-1,1) and combines
 // it with evidence confidence C_m and an ambiguity-gated lambda so that:
 //
 //	final_score(m) = base_score(m) + lambda_req * C_m * A_m
 //
-// Production contract:
-//   - inputs come from request-time session and candidate metadata
-//   - zero adjustment cleanly preserves the base score for first-turn,
-//     single-candidate, or unambiguous requests
-//   - |adjustment| stays bounded by affinityMaxLambda, keeping cache-affinity
-//     as a tie-breaker or gentle bias on close calls
+// |adjustment| is bounded by affinityMaxLambda, keeping cache-affinity as a
+// tie-breaker that cannot override strong quality or cost signals.
 func ComputeCacheAffinityAdjustments(
 	ctx *CacheAffinityContext,
 	candidates []config.ModelRef,
 	baseScores map[string]float64,
 ) CacheAffinityResult {
-	// Fast paths for requests with minimal runtime context or with a single
-	// effective candidate.
 	if ctx == nil || len(candidates) < 2 {
 		return CacheAffinityResult{}
 	}
 
-	// hasContinuation is the coarse gate from Step 1. Continuation requests
-	// activate the request-level sensitivity calculation below.
+	// Requests without prior context do not benefit from cache affinity.
 	hasContinuation := ctx.TurnIndex > 0 ||
 		ctx.HistoryTokens > 0 ||
 		ctx.PreviousResponseID != ""
@@ -141,7 +127,7 @@ func ComputeCacheAffinityAdjustments(
 
 	result := CacheAffinityResult{}
 
-	// Step 1: request continuation sensitivity W_req.
+	// W_req: request-level continuation sensitivity in [0,1].
 	contextTokens := math.Max(float64(ctx.ContextTokens), 1)
 	reuseRatio := clampF(float64(ctx.HistoryTokens)/contextTokens, 0, 1)
 	historyMass := clampF(float64(ctx.HistoryTokens)/historyMassNorm, 0, 1)
@@ -153,20 +139,18 @@ func ComputeCacheAffinityAdjustments(
 	}
 	result.WReq = wReq
 
-	// Step 4: ambiguity-gated lambda over the current base scores.
-	// gap12 is best_score - second_best_score across the candidate set.
+	// lambda_req: ambiguity-gated multiplier. Computed before the per-candidate
+	// loop so a clear base winner can exit without allocating per-candidate state.
 	gap12 := computeGap12(baseScores, candidates)
 	ambiguity := clampF(1.0-gap12/affinityGapThreshold, 0, 1)
 	lambdaReq := affinityMaxLambda * wReq * ambiguity
 	result.LambdaReq = lambdaReq
 
-	// A strong base winner keeps the diagnostics while preserving the base
-	// scores as-is.
 	if lambdaReq == 0 {
 		return result
 	}
 
-	// Step 2/3/5: per-candidate signed affinity, evidence confidence, then the
+	// Per-candidate: signed affinity A_m, evidence confidence C_m, and the
 	// bounded additive adjustment.
 	result.Adjustments = make(map[string]float64, len(candidates))
 	hasPrev := boolToFloat64(ctx.PreviousModel != "")
@@ -178,7 +162,7 @@ func ComputeCacheAffinityAdjustments(
 		windowSize := ctx.ModelContextWindows[name]
 		fitM := computeFitM(ctx.ContextTokens, windowSize)
 
-		// A_m is a signed effect size that captures the direction and strength of
+		// A_m: signed effect size capturing the direction and strength of
 		// cache-affinity for this candidate.
 		eM := emSameBase*sameModel +
 			emSameReuse*sameModel*reuseRatio +
@@ -187,7 +171,7 @@ func ComputeCacheAffinityAdjustments(
 			emFit*(fitM-0.5)
 		aM := math.Tanh(eM)
 
-		// C_m captures how much evidence supports using the affinity signal.
+		// C_m: evidence confidence gating how much to trust the affinity signal.
 		cRaw := clampF(
 			cmBase+
 				cmReuse*reuseRatio+
@@ -202,7 +186,6 @@ func ComputeCacheAffinityAdjustments(
 			cM = cmNoPrevScale * cRaw
 		}
 
-		// cache_adjustment(m) = lambda_req * C_m * A_m
 		result.Adjustments[name] = lambdaReq * cM * aM
 	}
 
@@ -216,8 +199,8 @@ func ComputeCacheAffinityAdjustments(
 	return result
 }
 
-// computeFitM implements the per-candidate context-window fit from the design
-// note. A missing window size contributes the neutral fit score of 0.5.
+// computeFitM returns a per-candidate context-window fit in {0.0, 0.3, 0.7, 1.0}.
+// A missing or zero window size returns the neutral score of 0.5.
 func computeFitM(contextTokens, windowSize int) float64 {
 	if windowSize <= 0 {
 		return 0.5
@@ -236,9 +219,9 @@ func computeFitM(contextTokens, windowSize int) float64 {
 	}
 }
 
-// computeGap12 returns best_score - second_best_score over the active
-// candidate set. Hybrid selection uses it to decide whether the base result is
-// ambiguous enough for cache-affinity to matter.
+// computeGap12 returns best_score - second_best_score over the candidate set.
+// A large gap means the base scorer already has a clear winner and cache-affinity
+// should not interfere.
 func computeGap12(baseScores map[string]float64, candidates []config.ModelRef) float64 {
 	best := -math.MaxFloat64
 	second := -math.MaxFloat64
@@ -257,8 +240,7 @@ func computeGap12(baseScores map[string]float64, candidates []config.ModelRef) f
 	return best - second
 }
 
-// boolToFloat64 keeps the estimator formulas close to the math notation from
-// the design doc, where indicator terms are written as 0/1 variables.
+// boolToFloat64 converts a bool to a 0/1 float64 for use in scoring formulas.
 func boolToFloat64(b bool) float64 {
 	if b {
 		return 1.0

--- a/src/semantic-router/pkg/selection/cache_affinity_bench_test.go
+++ b/src/semantic-router/pkg/selection/cache_affinity_bench_test.go
@@ -1,0 +1,95 @@
+package selection
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// Baseline scenarios used across all benchmarks.
+var (
+	benchCandidates = []config.ModelRef{
+		{Model: "model-a"},
+		{Model: "model-b"},
+		{Model: "model-c"},
+	}
+	benchWindows = map[string]int{
+		"model-a": 128000,
+		"model-b": 32000,
+		"model-c": 8192,
+	}
+	benchBaseScores = map[string]float64{
+		"model-a": 0.52,
+		"model-b": 0.50,
+		"model-c": 0.48,
+	}
+)
+
+// BenchmarkComputeCacheAffinityAdjustments_NoOp measures the fast-path cost
+// (first turn — all early exits fire, zero allocations expected).
+func BenchmarkComputeCacheAffinityAdjustments_NoOp(b *testing.B) {
+	affCtx := &CacheAffinityContext{
+		TurnIndex:           0,
+		HistoryTokens:       0,
+		PreviousResponseID:  "",
+		ContextTokens:       500,
+		ModelContextWindows: benchWindows,
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		ComputeCacheAffinityAdjustments(affCtx, benchCandidates, benchBaseScores)
+	}
+}
+
+// BenchmarkComputeCacheAffinityAdjustments_Active measures the full-path cost
+// for a typical multi-turn session with 3 candidates and known windows.
+func BenchmarkComputeCacheAffinityAdjustments_Active(b *testing.B) {
+	affCtx := &CacheAffinityContext{
+		TurnIndex:           3,
+		PreviousModel:       "model-a",
+		HistoryTokens:       2048,
+		ContextTokens:       3000,
+		ModelContextWindows: benchWindows,
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		ComputeCacheAffinityAdjustments(affCtx, benchCandidates, benchBaseScores)
+	}
+}
+
+// BenchmarkComputeCacheAffinityAdjustments_StrongWinner measures cost when
+// gap12 collapses lambda to zero (ambiguity gate fires early).
+func BenchmarkComputeCacheAffinityAdjustments_StrongWinner(b *testing.B) {
+	affCtx := &CacheAffinityContext{
+		TurnIndex:           3,
+		PreviousModel:       "model-a",
+		HistoryTokens:       2048,
+		ContextTokens:       3000,
+		ModelContextWindows: benchWindows,
+	}
+	strongScores := map[string]float64{
+		"model-a": 0.9,
+		"model-b": 0.1,
+		"model-c": 0.1,
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		ComputeCacheAffinityAdjustments(affCtx, benchCandidates, strongScores)
+	}
+}
+
+// BenchmarkComputeGap12 isolates the gap computation used for the ambiguity gate.
+func BenchmarkComputeGap12(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		computeGap12(benchBaseScores, benchCandidates)
+	}
+}
+
+// BenchmarkComputeFitM covers the context-fit switch statement.
+func BenchmarkComputeFitM(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		computeFitM(3000, 32000)
+	}
+}

--- a/src/semantic-router/pkg/selection/cache_affinity_test.go
+++ b/src/semantic-router/pkg/selection/cache_affinity_test.go
@@ -1,0 +1,173 @@
+package selection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func makeAffCtx(turnIndex, historyTokens, contextTokens int, previousModel, previousResponseID string, windows map[string]int) *CacheAffinityContext {
+	return &CacheAffinityContext{
+		TurnIndex:           turnIndex,
+		PreviousModel:       previousModel,
+		PreviousResponseID:  previousResponseID,
+		HistoryTokens:       historyTokens,
+		ContextTokens:       contextTokens,
+		ModelContextWindows: windows,
+	}
+}
+
+func makeCandidates(names ...string) []config.ModelRef {
+	refs := make([]config.ModelRef, len(names))
+	for i, n := range names {
+		refs[i] = config.ModelRef{Model: n}
+	}
+	return refs
+}
+
+func equalBase(candidates ...string) map[string]float64 {
+	m := make(map[string]float64, len(candidates))
+	for _, c := range candidates {
+		m[c] = 0.5
+	}
+	return m
+}
+
+func TestCacheAffinity_FirstTurn_ZeroAdjustment(t *testing.T) {
+	affCtx := makeAffCtx(0, 0, 500, "", "", nil)
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("a", "b"), equalBase("a", "b"))
+
+	assert.Equal(t, 0.0, result.WReq)
+	assert.Equal(t, 0.0, result.LambdaReq)
+	for _, adj := range result.Adjustments {
+		assert.Equal(t, 0.0, adj)
+	}
+}
+
+func TestCacheAffinity_PreviousResponseID_TriggersContinuation(t *testing.T) {
+	affCtx := makeAffCtx(0, 0, 500, "model-a", "resp-xyz", nil)
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("model-a", "model-b"), equalBase("model-a", "model-b"))
+
+	assert.Greater(t, result.LambdaReq, 0.0)
+	assert.GreaterOrEqual(t, result.WReq, wrPreviousResponseFloor)
+	assert.Greater(t, result.Adjustments["model-a"], 0.0)
+}
+
+func TestCacheAffinity_SingleCandidate_ZeroAdjustment(t *testing.T) {
+	affCtx := makeAffCtx(3, 1000, 1500, "model-a", "", nil)
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("model-a"), map[string]float64{"model-a": 0.8})
+
+	assert.Equal(t, 0.0, result.LambdaReq)
+	assert.Equal(t, 0.0, result.Adjustments["model-a"])
+}
+
+func TestCacheAffinity_StrongBaseWinner_CollapseToZero(t *testing.T) {
+	affCtx := makeAffCtx(4, 2000, 3000, "model-a", "", nil)
+	baseScores := map[string]float64{"model-a": 0.9, "model-b": 0.1}
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("model-a", "model-b"), baseScores)
+
+	assert.Equal(t, 0.0, result.LambdaReq)
+	for _, adj := range result.Adjustments {
+		assert.Equal(t, 0.0, adj)
+	}
+}
+
+func TestCacheAffinity_SameModelHighReuse_PositiveAdjustment(t *testing.T) {
+	affCtx := makeAffCtx(3, 3200, 4000, "model-a", "", nil)
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("model-a", "model-b"), equalBase("model-a", "model-b"))
+
+	require.Greater(t, result.LambdaReq, 0.0)
+	assert.Greater(t, result.Adjustments["model-a"], 0.0)
+	assert.Less(t, result.Adjustments["model-b"], 0.0)
+}
+
+func TestCacheAffinity_DifferentModel_NegativeWhenHeavyContinuation(t *testing.T) {
+	affCtx := makeAffCtx(4, 3000, 3500, "model-a", "", nil)
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("model-a", "model-b"), equalBase("model-a", "model-b"))
+
+	require.Greater(t, result.WReq, 0.5)
+	assert.Less(t, result.Adjustments["model-b"], 0.0)
+}
+
+func TestCacheAffinity_ContextOverflow_ZeroFit(t *testing.T) {
+	windows := map[string]int{
+		"small-model": 2048,
+		"large-model": 128000,
+	}
+	overflowCtx := makeAffCtx(2, 2000, 3000, "small-model", "", windows)
+	neutralCtx := makeAffCtx(2, 2000, 3000, "small-model", "", nil)
+	overflow := ComputeCacheAffinityAdjustments(
+		overflowCtx,
+		makeCandidates("small-model", "large-model"),
+		equalBase("small-model", "large-model"),
+	)
+	neutral := ComputeCacheAffinityAdjustments(
+		neutralCtx,
+		makeCandidates("small-model", "large-model"),
+		equalBase("small-model", "large-model"),
+	)
+
+	require.Greater(t, overflow.LambdaReq, 0.0)
+	assert.Less(t, overflow.Adjustments["small-model"], neutral.Adjustments["small-model"])
+	assert.Greater(t, overflow.Adjustments["large-model"], neutral.Adjustments["large-model"])
+}
+
+func TestCacheAffinity_UnknownWindow_NeutralFit(t *testing.T) {
+	affCtx := makeAffCtx(2, 1000, 2000, "model-a", "", nil)
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("model-a", "model-b"), equalBase("model-a", "model-b"))
+
+	require.Greater(t, result.LambdaReq, 0.0)
+	assert.Greater(t, result.Adjustments["model-a"], 0.0)
+}
+
+func TestCacheAffinity_AdjustmentBounded(t *testing.T) {
+	windows := map[string]int{"model-a": 128000, "model-b": 128000}
+	affCtx := makeAffCtx(10, 8000, 8000, "model-a", "resp-1", windows)
+	result := ComputeCacheAffinityAdjustments(affCtx, makeCandidates("model-a", "model-b"), equalBase("model-a", "model-b"))
+
+	for _, adj := range result.Adjustments {
+		assert.LessOrEqual(t, adj, affinityMaxLambda)
+		assert.GreaterOrEqual(t, adj, -affinityMaxLambda)
+	}
+}
+
+func TestComputeFitM(t *testing.T) {
+	cases := []struct {
+		ctx    int
+		window int
+		want   float64
+	}{
+		{500, 0, 0.5},
+		{1000, 4000, 1.0},
+		{2200, 4000, 0.7},
+		{3200, 4000, 0.3},
+		{5000, 4000, 0.0},
+		{2000, 4000, 1.0},
+		{3000, 4000, 0.7},
+		{4000, 4000, 0.3},
+	}
+	for _, tc := range cases {
+		got := computeFitM(tc.ctx, tc.window)
+		assert.Equal(t, tc.want, got)
+	}
+}
+
+func TestComputeGap12(t *testing.T) {
+	candidates := []config.ModelRef{{Model: "a"}, {Model: "b"}, {Model: "c"}}
+
+	t.Run("standard gap", func(t *testing.T) {
+		scores := map[string]float64{"a": 0.9, "b": 0.6, "c": 0.3}
+		assert.InDelta(t, 0.3, computeGap12(scores, candidates), 1e-9)
+	})
+	t.Run("tied scores", func(t *testing.T) {
+		scores := map[string]float64{"a": 0.5, "b": 0.5, "c": 0.5}
+		assert.Equal(t, 0.0, computeGap12(scores, candidates))
+	})
+	t.Run("single candidate", func(t *testing.T) {
+		single := []config.ModelRef{{Model: "a"}}
+		assert.Equal(t, 0.0, computeGap12(map[string]float64{"a": 0.8}, single))
+	})
+}

--- a/src/semantic-router/pkg/selection/hybrid.go
+++ b/src/semantic-router/pkg/selection/hybrid.go
@@ -217,6 +217,8 @@ func (h *HybridSelector) Select(ctx context.Context, selCtx *SelectionContext) (
 		h.applyCostAdjustment(combinedScores, selCtx.CostWeight)
 	}
 
+	h.applyCacheAffinity(combinedScores, selCtx)
+
 	logging.Infof("[HybridSelector] Combining scores (weights: elo=%.2f, dc=%.2f, am=%.2f, cost=%.2f):",
 		h.config.EloWeight, h.config.RouterDCWeight, h.config.AutoMixWeight, h.config.CostWeight)
 	for _, model := range selCtx.CandidateModels {
@@ -234,19 +236,7 @@ func (h *HybridSelector) Select(ctx context.Context, selCtx *SelectionContext) (
 			model.Model, eloScore, dcScore, amScore, combinedScores[model.Model])
 	}
 
-	// Find best model
-	var bestModel *config.ModelRef
-	var bestScore float64
-
-	for i := range selCtx.CandidateModels {
-		model := &selCtx.CandidateModels[i]
-		score := combinedScores[model.Model]
-
-		if score > bestScore || bestModel == nil {
-			bestScore = score
-			bestModel = model
-		}
-	}
+	bestModel, bestScore := h.selectBestModel(selCtx.CandidateModels, combinedScores)
 
 	if bestModel == nil {
 		return nil, fmt.Errorf("could not select a model")
@@ -255,17 +245,7 @@ func (h *HybridSelector) Select(ctx context.Context, selCtx *SelectionContext) (
 	// Calculate confidence from component agreement
 	confidence := h.calculateConfidence(componentResults, bestModel.Model)
 
-	// Record component agreement metric for evolution tracking
-	if len(componentResults) > 1 {
-		agreementRatio := float64(0)
-		for _, r := range componentResults {
-			if r.SelectedModel == bestModel.Model {
-				agreementRatio++
-			}
-		}
-		agreementRatio /= float64(len(componentResults))
-		RecordComponentAgreement(agreementRatio)
-	}
+	h.recordComponentAgreement(componentResults, bestModel.Model)
 
 	// Build reasoning
 	reasoning := h.buildReasoning(componentScores, bestModel.Model)
@@ -282,6 +262,52 @@ func (h *HybridSelector) Select(ctx context.Context, selCtx *SelectionContext) (
 		Reasoning:     reasoning,
 		AllScores:     combinedScores,
 	}, nil
+}
+
+func (h *HybridSelector) applyCacheAffinity(combinedScores map[string]float64, selCtx *SelectionContext) {
+	if selCtx.CacheAffinityCtx == nil {
+		return
+	}
+
+	affinityResult := ComputeCacheAffinityAdjustments(
+		selCtx.CacheAffinityCtx, selCtx.CandidateModels, combinedScores)
+	for model, adj := range affinityResult.Adjustments {
+		if adj != 0 {
+			combinedScores[model] += adj
+		}
+	}
+}
+
+func (h *HybridSelector) selectBestModel(candidates []config.ModelRef, combinedScores map[string]float64) (*config.ModelRef, float64) {
+	var bestModel *config.ModelRef
+	var bestScore float64
+
+	for i := range candidates {
+		model := &candidates[i]
+		score := combinedScores[model.Model]
+
+		if score > bestScore || bestModel == nil {
+			bestScore = score
+			bestModel = model
+		}
+	}
+
+	return bestModel, bestScore
+}
+
+func (h *HybridSelector) recordComponentAgreement(componentResults []*SelectionResult, bestModel string) {
+	if len(componentResults) <= 1 {
+		return
+	}
+
+	agreementRatio := float64(0)
+	for _, r := range componentResults {
+		if r.SelectedModel == bestModel {
+			agreementRatio++
+		}
+	}
+	agreementRatio /= float64(len(componentResults))
+	RecordComponentAgreement(agreementRatio)
 }
 
 // UpdateFeedback propagates feedback to all component selectors

--- a/src/semantic-router/pkg/selection/selector.go
+++ b/src/semantic-router/pkg/selection/selector.go
@@ -181,6 +181,9 @@ type SelectionContext struct {
 
 	// LatencyAwareTTFTPercentile is the configured TTFT percentile (1-100) for latency_aware selection
 	LatencyAwareTTFTPercentile int
+
+	// CacheAffinityCtx carries request-time session signals for cache-affinity estimation.
+	CacheAffinityCtx *CacheAffinityContext
 }
 
 // SelectionResult contains the result of a model selection decision


### PR DESCRIPTION
## Purpose

- Add a bounded pre-dispatch cache-affinity bias to hybrid model selection so multi-turn continuation requests can prefer cache-friendly candidates without overriding strong base signals. (#1775)
- Thread request-time continuation signals from extproc into selection, including turn index, previous model, previous response ID, history tokens, and model context windows.
- Add unit tests and benchmarks for the estimator and for session-transition token accounting used by cache-affinity routing.
- Affected module: `Router`

## Test Plan

- Run `env GOCACHE=/tmp/semantic-router-go-build-cache go test ./pkg/extproc -run 'TestPopulateSessionTransitionFields|TestHistoryTokensFromChatMessages|TestEstimateStoredResponseTokens' -count=1 -timeout=120s` from `src/semantic-router`
- Run `env GOCACHE=/tmp/semantic-router-go-build-cache go test ./pkg/selection -run 'Test.*CacheAffinity|TestCompute.*|TestHybrid.*CacheAffinity' -count=1 -timeout=120s` from `src/semantic-router`
- Review the new cache-affinity unit tests and benchmark coverage under `src/semantic-router/pkg/selection`

## Test Result

- Both targeted test commands passed locally.
- `pkg/extproc` passed with linker warnings about local Candle search paths, but no test failures.
- `pkg/selection` passed with no test failures.
- Residual risk is limited to broader integration behavior in full router flows, which is not covered by the targeted package tests above.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>