### PR TITLE
feature: Persist SessionID and TurnIndex into replay records for multi-turn trajectory stitching

### DIFF
--- a/e2e/testcases/router_replay_restart_recovery.go
+++ b/e2e/testcases/router_replay_restart_recovery.go
@@ -58,10 +58,13 @@ func triggerReplayRecordBeforeRestart(ctx context.Context, client *kubernetes.Cl
 	chatClient := fixtures.NewChatCompletionsClient(session, 30*time.Second)
 	resp, err := chatClient.Create(ctx, fixtures.ChatCompletionsRequest{
 		Model: "auto",
+		User:  "e2e-replay-user",
 		Messages: []fixtures.ChatMessage{
 			{Role: "user", Content: "What is 2+2? Reply with just the number."},
 		},
-	}, nil)
+	}, map[string]string{
+		"x-authz-user-id": "e2e-replay-user",
+	})
 	if err != nil {
 		return "", fmt.Errorf("chat completion failed: %w", err)
 	}
@@ -82,6 +85,9 @@ func triggerReplayRecordBeforeRestart(ctx context.Context, client *kubernetes.Cl
 	if err := assertPostgresReplayRecordStored(ctx, client, recordID, opts); err != nil {
 		return "", fmt.Errorf("replay record not confirmed in Postgres before restart: %w", err)
 	}
+	if err := assertReplayRecordHasSessionMetadata(session, recordID, opts.Verbose); err != nil {
+		return "", err
+	}
 	return recordID, nil
 }
 
@@ -92,9 +98,11 @@ type replayListResponse struct {
 	Data   json.RawMessage `json:"data"`
 }
 
-// replayRecordSummary captures only the id field from a replay record.
+// replayRecordSummary captures fields read from replay API JSON.
 type replayRecordSummary struct {
-	ID string `json:"id"`
+	ID        string `json:"id"`
+	SessionID string `json:"session_id"`
+	TurnIndex int    `json:"turn_index"`
 }
 
 // fetchFirstReplayRecordID calls GET /v1/router_replay?limit=1 and returns the
@@ -129,6 +137,28 @@ func fetchFirstReplayRecordID(session *fixtures.ServiceSession, verbose bool) (s
 		return "", fmt.Errorf("replay record has empty ID")
 	}
 	return records[0].ID, nil
+}
+
+func assertReplayRecordHasSessionMetadata(session *fixtures.ServiceSession, recordID string, verbose bool) error {
+	httpClient := session.HTTPClient(30 * time.Second)
+	raw, err := fixtures.DoGETRequest(context.Background(), httpClient, session.BaseURL()+"/v1/router_replay/"+recordID)
+	if err != nil {
+		return fmt.Errorf("GET replay record for session metadata: %w", err)
+	}
+	if raw.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET replay record returned status %d: %s", raw.StatusCode, string(raw.Body))
+	}
+	var rec replayRecordSummary
+	if err := raw.DecodeJSON(&rec); err != nil {
+		return fmt.Errorf("decode replay record: %w", err)
+	}
+	if rec.SessionID == "" {
+		return fmt.Errorf("replay record %s missing session_id", recordID)
+	}
+	if verbose {
+		fmt.Printf("[Test] Replay session_id=%q turn_index=%d\n", rec.SessionID, rec.TurnIndex)
+	}
+	return nil
 }
 
 func prettyJSON(data []byte) string {
@@ -260,6 +290,9 @@ func fetchReplayRecordOnce(ctx context.Context, client *kubernetes.Clientset, op
 	}
 	if record.ID != recordID {
 		return fmt.Errorf("replay record ID mismatch: got %s, expected %s", record.ID, recordID)
+	}
+	if record.SessionID == "" {
+		return fmt.Errorf("replay record %s missing session_id after restart", recordID)
 	}
 
 	if opts.Verbose {

--- a/src/semantic-router/pkg/extproc/memory_helpers.go
+++ b/src/semantic-router/pkg/extproc/memory_helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/tidwall/gjson"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
@@ -115,6 +116,49 @@ func deriveSessionIDFromMessages(messages []ChatCompletionMessage, userID string
 	// Create SHA256 hash and take first 16 chars
 	hash := sha256.Sum256([]byte(builder.String()))
 	return "cc-" + hex.EncodeToString(hash[:])[:16]
+}
+
+const sessionMessageFingerprintMaxRunes = 100
+
+// deriveSessionIDFromMessagesStructure builds a session ID from the full message
+// list (roles + truncated content). Used when no stable user ID is available.
+// Prefix "cc-full-" distinguishes IDs from deriveSessionIDFromMessages (cc-).
+func deriveSessionIDFromMessagesStructure(messages []ChatCompletionMessage) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i := range messages {
+		if i > 0 {
+			b.WriteByte('|')
+		}
+		b.WriteString(messages[i].Role)
+		b.WriteByte(':')
+		content := messages[i].Content
+		if len(content) > sessionMessageFingerprintMaxRunes {
+			content = content[:sessionMessageFingerprintMaxRunes]
+		}
+		b.WriteString(content)
+	}
+	hash := sha256.Sum256([]byte(b.String()))
+	return "cc-full-" + hex.EncodeToString(hash[:])[:16]
+}
+
+// deriveSessionIDFromRequestID returns a deterministic pseudo-session from
+// RequestID (or x-request-id header) when no message-based session exists.
+func deriveSessionIDFromRequestID(ctx *RequestContext) string {
+	if ctx == nil {
+		return ""
+	}
+	rid := strings.TrimSpace(ctx.RequestID)
+	if rid == "" {
+		rid = strings.TrimSpace(headerValueCI(ctx, headers.RequestID))
+	}
+	if rid == "" {
+		return ""
+	}
+	hash := sha256.Sum256([]byte("rid:" + rid))
+	return "rid-" + hex.EncodeToString(hash[:])[:16]
 }
 
 // convertChatCompletionMessages converts ChatCompletionMessage[] to SDK message unions.

--- a/src/semantic-router/pkg/extproc/memory_helpers_chat_completions_test.go
+++ b/src/semantic-router/pkg/extproc/memory_helpers_chat_completions_test.go
@@ -126,3 +126,20 @@ func TestDeriveSessionIDFromMessages(t *testing.T) {
 	assert.NotEqual(t, sessionID1, sessionID3)
 	assert.True(t, strings.HasPrefix(sessionID1, "cc-"))
 }
+
+func TestDeriveSessionIDFromMessagesStructure(t *testing.T) {
+	msgs := []ChatCompletionMessage{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "Hello"},
+	}
+	a := deriveSessionIDFromMessagesStructure(msgs)
+	b := deriveSessionIDFromMessagesStructure(msgs)
+	c := deriveSessionIDFromMessagesStructure([]ChatCompletionMessage{
+		{Role: "user", Content: "Different"},
+	})
+
+	assert.True(t, strings.HasPrefix(a, "cc-full-"))
+	assert.Equal(t, a, b)
+	assert.NotEqual(t, a, c)
+	assert.Empty(t, deriveSessionIDFromMessagesStructure(nil))
+}

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -110,6 +110,8 @@ func (r *OpenAIRouter) startRouterReplay(
 		return
 	}
 
+	populateReplaySessionIfNeeded(ctx)
+
 	recorder := r.resolveReplayRecorder(decisionName)
 	if recorder == nil {
 		return
@@ -127,6 +129,33 @@ func shouldStartRouterReplay(ctx *RequestContext) bool {
 		return false
 	}
 	return ctx.RouterReplayID == ""
+}
+
+// populateReplaySessionIfNeeded fills ChatCompletionMessages and session fields
+// when startRouterReplay runs before prepareRequestForModelRouting (e.g.
+// fast_response, semantic-cache hit, looper-internal).
+func populateReplaySessionIfNeeded(ctx *RequestContext) {
+	if ctx == nil {
+		return
+	}
+	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.IsResponseAPIRequest {
+		populateSessionTransitionFields(ctx)
+		return
+	}
+	if len(ctx.ChatCompletionMessages) > 0 {
+		populateSessionTransitionFields(ctx)
+		return
+	}
+	body := ctx.OriginalRequestBody
+	if len(body) == 0 {
+		return
+	}
+	openAIRequest, err := parseOpenAIRequest(body)
+	if err != nil {
+		return
+	}
+	ctx.ChatCompletionMessages = extractChatCompletionMessages(openAIRequest)
+	populateSessionTransitionFields(ctx)
 }
 
 func (r *OpenAIRouter) resolveReplayRecorder(decisionName string) *routerreplay.Recorder {
@@ -158,6 +187,8 @@ func buildReplayRoutingRecord(
 	decisionTier, decisionPriority := replayDecisionMetadata(ctx)
 	record := routerreplay.RoutingRecord{
 		RequestID:         ctx.RequestID,
+		SessionID:         ctx.SessionID,
+		TurnIndex:         ctx.TurnIndex,
 		Decision:          decisionName,
 		DecisionTier:      decisionTier,
 		DecisionPriority:  decisionPriority,
@@ -197,6 +228,10 @@ func buildReplayRoutingRecord(
 		RAGContextLength:     len(ctx.RAGRetrievedContext),
 		RAGSimilarityScore:   ctx.RAGSimilarityScore,
 		HallucinationEnabled: hallucinationEnabled,
+	}
+	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.IsResponseAPIRequest {
+		record.PreviousResponseID = ctx.ResponseAPICtx.PreviousResponseID
+		record.ConversationID = ctx.ResponseAPICtx.ConversationID
 	}
 	if len(ctx.OriginalRequestBody) > 0 {
 		record.RequestBody = string(ctx.OriginalRequestBody)

--- a/src/semantic-router/pkg/extproc/recorder_test.go
+++ b/src/semantic-router/pkg/extproc/recorder_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
-func TestBuildReplayRoutingRecordCapturesRoutingMetadata(t *testing.T) {
-	ctx := &RequestContext{
+func replayRoutingRecordMetadataTestContext() *RequestContext {
+	return &RequestContext{
 		RequestID:                     "req-1",
 		SessionID:                     "sess-replay-test",
 		TurnIndex:                     2,
@@ -40,8 +40,10 @@ func TestBuildReplayRoutingRecordCapturesRoutingMetadata(t *testing.T) {
 			"reask:persistently_dissatisfied": 2,
 		},
 	}
+}
 
-	record := buildReplayRoutingRecord(ctx, "model-a", "model-b", "balance")
+func TestBuildReplayRoutingRecordCapturesSessionAndDecisionMetadata(t *testing.T) {
+	record := buildReplayRoutingRecord(replayRoutingRecordMetadataTestContext(), "model-a", "model-b", "balance")
 	if record.SessionID != "sess-replay-test" {
 		t.Fatalf("expected session_id copied, got %q", record.SessionID)
 	}
@@ -66,6 +68,10 @@ func TestBuildReplayRoutingRecordCapturesRoutingMetadata(t *testing.T) {
 	if got := record.SignalValues["reask:persistently_dissatisfied"]; got != 2 {
 		t.Fatalf("expected signal value 2, got %v", got)
 	}
+}
+
+func TestBuildReplayRoutingRecordCapturesSignalMetadata(t *testing.T) {
+	record := buildReplayRoutingRecord(replayRoutingRecordMetadataTestContext(), "model-a", "model-b", "balance")
 	if !reflect.DeepEqual(record.Signals.Modality, []string{"AR"}) {
 		t.Fatalf("unexpected modality signals: %#v", record.Signals.Modality)
 	}

--- a/src/semantic-router/pkg/extproc/recorder_test.go
+++ b/src/semantic-router/pkg/extproc/recorder_test.go
@@ -10,6 +10,8 @@ import (
 func TestBuildReplayRoutingRecordCapturesRoutingMetadata(t *testing.T) {
 	ctx := &RequestContext{
 		RequestID:                     "req-1",
+		SessionID:                     "sess-replay-test",
+		TurnIndex:                     2,
 		VSRSelectedCategory:           "math",
 		VSRReasoningMode:              "on",
 		VSRSelectedDecisionConfidence: 0.91,
@@ -40,6 +42,12 @@ func TestBuildReplayRoutingRecordCapturesRoutingMetadata(t *testing.T) {
 	}
 
 	record := buildReplayRoutingRecord(ctx, "model-a", "model-b", "balance")
+	if record.SessionID != "sess-replay-test" {
+		t.Fatalf("expected session_id copied, got %q", record.SessionID)
+	}
+	if record.TurnIndex != 2 {
+		t.Fatalf("expected turn_index=2, got %d", record.TurnIndex)
+	}
 	if record.DecisionTier != 3 {
 		t.Fatalf("expected decision tier=3, got %d", record.DecisionTier)
 	}
@@ -72,5 +80,26 @@ func TestBuildReplayRoutingRecordCapturesRoutingMetadata(t *testing.T) {
 	}
 	if !reflect.DeepEqual(record.Signals.KB, []string{"privacy_kb"}) {
 		t.Fatalf("unexpected kb signals: %#v", record.Signals.KB)
+	}
+}
+
+func TestBuildReplayRoutingRecord_ResponseAPIChainFields(t *testing.T) {
+	ctx := &RequestContext{
+		RequestID: "req-resp-1",
+		SessionID: "conv-chain",
+		TurnIndex: 2,
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv-chain",
+			PreviousResponseID:   "resp_prev_1",
+		},
+	}
+	record := buildReplayRoutingRecord(ctx, "model-a", "model-b", "balance")
+	if record.SessionID != "conv-chain" || record.TurnIndex != 2 {
+		t.Fatalf("unexpected session fields: session_id=%q turn_index=%d", record.SessionID, record.TurnIndex)
+	}
+	if record.ConversationID != "conv-chain" || record.PreviousResponseID != "resp_prev_1" {
+		t.Fatalf("unexpected response API persistence: conversation_id=%q previous_response_id=%q",
+			record.ConversationID, record.PreviousResponseID)
 	}
 }

--- a/src/semantic-router/pkg/extproc/router_replay_api.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api.go
@@ -25,6 +25,7 @@ type routerReplayFilters struct {
 	decision    string
 	model       string
 	cacheStatus string
+	sessionID   string
 }
 
 type routerReplayListQuery struct {
@@ -200,9 +201,10 @@ func parseRouterReplayListQuery(rawQuery string) (routerReplayListQuery, error) 
 
 func parseRouterReplayFilters(values url.Values) (routerReplayFilters, error) {
 	filters := routerReplayFilters{
-		search:   strings.TrimSpace(values.Get("search")),
-		decision: strings.TrimSpace(values.Get("decision")),
-		model:    strings.TrimSpace(values.Get("model")),
+		search:    strings.TrimSpace(values.Get("search")),
+		decision:  strings.TrimSpace(values.Get("decision")),
+		model:     strings.TrimSpace(values.Get("model")),
+		sessionID: strings.TrimSpace(values.Get("session_id")),
 	}
 
 	cacheStatus := strings.TrimSpace(values.Get("cache_status"))
@@ -263,6 +265,9 @@ func doesRouterReplayRecordMatchFilters(
 		return false
 	}
 	if filters.model != "" && !doesModelMatch(record, filters.model) {
+		return false
+	}
+	if filters.sessionID != "" && record.SessionID != filters.sessionID {
 		return false
 	}
 	if search != "" && !strings.Contains(strings.ToLower(record.RequestID), search) {

--- a/src/semantic-router/pkg/extproc/router_replay_api_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api_test.go
@@ -132,6 +132,34 @@ func TestHandleRouterReplayAPIListRespectsOffset(t *testing.T) {
 	}
 }
 
+func TestHandleRouterReplayAPIListFiltersBySessionID(t *testing.T) {
+	recorder := routerreplay.NewRecorder(store.NewMemoryStore(20, 0))
+	ts := time.Unix(1000, 0).UTC()
+	for _, rec := range []routerreplay.RoutingRecord{
+		{ID: "replay-s1-a", Decision: "decision-a", RequestID: "r1", SessionID: "sess-alpha", Timestamp: ts},
+		{ID: "replay-s2", Decision: "decision-a", RequestID: "r2", SessionID: "sess-beta", Timestamp: ts.Add(time.Minute)},
+		{ID: "replay-s1-b", Decision: "decision-a", RequestID: "r3", SessionID: "sess-alpha", Timestamp: ts.Add(2 * time.Minute)},
+	} {
+		if _, err := recorder.AddRecord(rec); err != nil {
+			t.Fatalf("failed to add replay record: %v", err)
+		}
+	}
+	router := &OpenAIRouter{
+		ReplayRecorders: map[string]*routerreplay.Recorder{
+			"decision-a": recorder,
+		},
+	}
+
+	body := mustReplayListBody(t, router, "/v1/router_replay?session_id=sess-alpha&limit=10")
+	assertReplayPage(t, body, 2, 2, 10, 0)
+	data := mustReplayData(t, body["data"])
+	for _, row := range data {
+		if row["session_id"] != "sess-alpha" {
+			t.Fatalf("expected session_id=sess-alpha, got %#v", row["session_id"])
+		}
+	}
+}
+
 func TestHandleRouterReplayAPIListRejectsInvalidQuery(t *testing.T) {
 	router, _ := newReplayAPITestRouter(t)
 

--- a/src/semantic-router/pkg/extproc/session_transition.go
+++ b/src/semantic-router/pkg/extproc/session_transition.go
@@ -1,6 +1,9 @@
 package extproc
 
 import (
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 )
@@ -24,16 +27,34 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 		return
 	}
 
-	if len(ctx.ChatCompletionMessages) > 0 {
-		userID := extractUserID(ctx)
-		if userID == "" {
-			logging.Debugf("Session: no user ID, skipping session ID derivation")
-		} else {
-			ctx.SessionID = deriveSessionIDFromMessages(ctx.ChatCompletionMessages, userID)
-		}
-		ctx.TurnIndex = sessiontelemetry.ChatTurnNumber(sessionTransitionChatMessages(ctx.ChatCompletionMessages)) - 1
-		// TODO: populate PreviousModel for Chat Completions once per-turn model history is available.
+	if sid := strings.TrimSpace(headerValueCI(ctx, headers.XSessionID)); sid != "" {
+		ctx.SessionID = sid
 	}
+
+	if len(ctx.ChatCompletionMessages) == 0 {
+		if ctx.SessionID == "" {
+			ctx.SessionID = deriveSessionIDFromRequestID(ctx)
+		}
+		return
+	}
+
+	if ctx.SessionID == "" {
+		userID := extractUserID(ctx)
+		if userID != "" {
+			ctx.SessionID = deriveSessionIDFromMessages(ctx.ChatCompletionMessages, userID)
+		} else {
+			ctx.SessionID = deriveSessionIDFromMessagesStructure(ctx.ChatCompletionMessages)
+			if ctx.SessionID == "" {
+				ctx.SessionID = deriveSessionIDFromRequestID(ctx)
+			}
+			if ctx.SessionID == "" {
+				logging.Debugf("Session: could not derive session ID for chat completion request")
+			}
+		}
+	}
+
+	ctx.TurnIndex = sessiontelemetry.ChatTurnNumber(sessionTransitionChatMessages(ctx.ChatCompletionMessages)) - 1
+	// TODO: populate PreviousModel for Chat Completions once per-turn model history is available.
 }
 
 func sessionTransitionChatMessages(messages []ChatCompletionMessage) []sessiontelemetry.ChatMessage {

--- a/src/semantic-router/pkg/extproc/session_transition.go
+++ b/src/semantic-router/pkg/extproc/session_transition.go
@@ -38,23 +38,31 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 		return
 	}
 
-	if ctx.SessionID == "" {
-		userID := extractUserID(ctx)
-		if userID != "" {
-			ctx.SessionID = deriveSessionIDFromMessages(ctx.ChatCompletionMessages, userID)
-		} else {
-			ctx.SessionID = deriveSessionIDFromMessagesStructure(ctx.ChatCompletionMessages)
-			if ctx.SessionID == "" {
-				ctx.SessionID = deriveSessionIDFromRequestID(ctx)
-			}
-			if ctx.SessionID == "" {
-				logging.Debugf("Session: could not derive session ID for chat completion request")
-			}
-		}
-	}
+	populateChatCompletionSessionIDIfNeeded(ctx)
 
 	ctx.TurnIndex = sessiontelemetry.ChatTurnNumber(sessionTransitionChatMessages(ctx.ChatCompletionMessages)) - 1
 	// TODO: populate PreviousModel for Chat Completions once per-turn model history is available.
+}
+
+// populateChatCompletionSessionIDIfNeeded sets ctx.SessionID when not already
+// pinned (e.g. by x-session-id). Kept separate to avoid deep nesting in
+// populateSessionTransitionFields (nestif).
+func populateChatCompletionSessionIDIfNeeded(ctx *RequestContext) {
+	if ctx.SessionID != "" {
+		return
+	}
+	userID := extractUserID(ctx)
+	if userID != "" {
+		ctx.SessionID = deriveSessionIDFromMessages(ctx.ChatCompletionMessages, userID)
+		return
+	}
+	ctx.SessionID = deriveSessionIDFromMessagesStructure(ctx.ChatCompletionMessages)
+	if ctx.SessionID == "" {
+		ctx.SessionID = deriveSessionIDFromRequestID(ctx)
+	}
+	if ctx.SessionID == "" {
+		logging.Debugf("Session: could not derive session ID for chat completion request")
+	}
 }
 
 func sessionTransitionChatMessages(messages []ChatCompletionMessage) []sessiontelemetry.ChatMessage {

--- a/src/semantic-router/pkg/extproc/session_transition_test.go
+++ b/src/semantic-router/pkg/extproc/session_transition_test.go
@@ -1,11 +1,13 @@
 package extproc
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
 )
 
@@ -64,4 +66,47 @@ func TestPopulateSessionTransitionFields_ChatCompletionsCountsPriorAssistantTurn
 
 	assert.Equal(t, 1, ctx.TurnIndex)
 	assert.Empty(t, ctx.PreviousModel)
+}
+
+func TestPopulateSessionTransitionFields_XSessionIDHeaderOverridesDerivation(t *testing.T) {
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.AuthzUserID: "user-123",
+			headers.XSessionID:  "client-defined-session",
+		},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, "client-defined-session", ctx.SessionID)
+	assert.Equal(t, 0, ctx.TurnIndex)
+}
+
+func TestPopulateSessionTransitionFields_ChatCompletionsNoUserUsesStructureHash(t *testing.T) {
+	ctx := &RequestContext{
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "Hello without auth header"},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	require.True(t, strings.HasPrefix(ctx.SessionID, "cc-full-"))
+	assert.Equal(t, 0, ctx.TurnIndex)
+}
+
+func TestPopulateSessionTransitionFields_ChatCompletionsEmptyThreadUsesRidFromRequestID(t *testing.T) {
+	ctx := &RequestContext{
+		RequestID: "upstream-req-abc",
+		Headers: map[string]string{
+			headers.RequestID: "hdr-req-xyz",
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	require.True(t, strings.HasPrefix(ctx.SessionID, "rid-"))
 }

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -18,6 +18,10 @@ const (
 	// This header is case-insensitive when read from incoming requests.
 	RequestID = "x-request-id"
 
+	// XSessionID allows clients to pin a stable session identifier for Chat Completions
+	// when router-derived session IDs are insufficient.
+	XSessionID = "x-session-id"
+
 	// DisableRouterMemory allows clients to opt-out of router-managed memory injection.
 	// This prevents "silent double injection" when applications use SDK-managed memory
 	// systems like Mem0, LangMem, LangGraph, or OpenClaw.

--- a/src/semantic-router/pkg/memory/valkey_store_helpers.go
+++ b/src/semantic-router/pkg/memory/valkey_store_helpers.go
@@ -206,6 +206,17 @@ func (v *ValkeyStore) parseListSearchResults(result any) []*Memory {
 		memories = append(memories, mem)
 	}
 
+	// valkey-glide returns matched docs in a single map; iterating that map in
+	// Go does not preserve FT.SEARCH SORTBY order (same issue as vectorstore
+	// parseSearchResults). Re-sort client-side by created_at descending.
+	sort.SliceStable(memories, func(i, j int) bool {
+		ti, tj := memories[i].CreatedAt, memories[j].CreatedAt
+		if ti.Equal(tj) {
+			return memories[i].ID > memories[j].ID
+		}
+		return ti.After(tj)
+	})
+
 	return memories
 }
 

--- a/src/semantic-router/pkg/memory/valkey_store_test.go
+++ b/src/semantic-router/pkg/memory/valkey_store_test.go
@@ -524,6 +524,9 @@ func TestValkeyStore_ParseListSearchResults(t *testing.T) {
 
 		memories := store.parseListSearchResults(result)
 		require.Len(t, memories, 2)
+		// Newer created_at first (client-side sort; map iteration order is undefined).
+		assert.Equal(t, "mem_2", memories[0].ID)
+		assert.Equal(t, "mem_1", memories[1].ID)
 	})
 }
 

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -272,10 +272,20 @@ func LogFields(r RoutingRecord, event string) map[string]interface{} {
 		"selection_method":  r.SelectionMethod,
 		"request_id":        r.RequestID,
 		"timestamp":         r.Timestamp,
+		"turn_index":        r.TurnIndex,
 		"from_cache":        r.FromCache,
 		"streaming":         r.Streaming,
 		"response_status":   r.ResponseStatus,
 		"signals":           logSignalFields(r.Signals),
+	}
+	if r.SessionID != "" {
+		fields["session_id"] = r.SessionID
+	}
+	if r.ConversationID != "" {
+		fields["conversation_id"] = r.ConversationID
+	}
+	if r.PreviousResponseID != "" {
+		fields["previous_response_id"] = r.PreviousResponseID
 	}
 	if len(r.Projections) > 0 {
 		fields["projections"] = r.Projections

--- a/src/semantic-router/pkg/routerreplay/recorder_test.go
+++ b/src/semantic-router/pkg/routerreplay/recorder_test.go
@@ -138,6 +138,8 @@ func TestLogFieldsIncludesOptionalReplayMetadata(t *testing.T) {
 
 	fields := LogFields(record, "router_replay_complete")
 	assertFieldValue(t, fields, "event", "router_replay_complete")
+	assertFieldValue(t, fields, "session_id", "sess-log-test")
+	assertFieldValue(t, fields, "turn_index", 5)
 	assertFieldValue(t, fields, "replay_id", record.ID)
 	assertFieldValue(t, fields, "decision_tier", 2)
 	assertFieldValue(t, fields, "decision_priority", 100)
@@ -179,6 +181,8 @@ func richReplayRoutingRecord(
 		ConfidenceScore:   0.91,
 		SelectionMethod:   "router_dc",
 		RequestID:         "req-1",
+		SessionID:         "sess-log-test",
+		TurnIndex:         5,
 		Timestamp:         timestamp,
 		FromCache:         true,
 		Streaming:         true,

--- a/src/semantic-router/pkg/routerreplay/store/postgres.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres.go
@@ -127,15 +127,23 @@ func (p *PostgresStore) createTable(ctx context.Context) error {
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS cost_savings DOUBLE PRECISION;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS currency VARCHAR(32);
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS baseline_model VARCHAR(255);
+		ALTER TABLE %s ADD COLUMN IF NOT EXISTS session_id VARCHAR(255);
+		ALTER TABLE %s ADD COLUMN IF NOT EXISTS turn_index INTEGER;
+		ALTER TABLE %s ADD COLUMN IF NOT EXISTS previous_response_id VARCHAR(255);
+		ALTER TABLE %s ADD COLUMN IF NOT EXISTS conversation_id VARCHAR(255);
 		CREATE INDEX IF NOT EXISTS idx_%s_timestamp ON %s (timestamp DESC);
 		CREATE INDEX IF NOT EXISTS idx_%s_created_at ON %s (created_at);
 		CREATE INDEX IF NOT EXISTS idx_%s_request_id ON %s (request_id);
 		CREATE INDEX IF NOT EXISTS idx_%s_decision_timestamp ON %s (decision, timestamp DESC);
 		CREATE INDEX IF NOT EXISTS idx_%s_selected_model_timestamp ON %s (selected_model, timestamp DESC);
+		CREATE INDEX IF NOT EXISTS idx_%s_session_timestamp ON %s (session_id, timestamp DESC);
 	`, p.tableName,
-		p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName,
 		p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName,
-		p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName)
+		p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName,
+		p.tableName, p.tableName, p.tableName,
+		p.tableName, p.tableName, p.tableName, p.tableName,
+		p.tableName, p.tableName, p.tableName, p.tableName,
+		p.tableName, p.tableName, p.tableName, p.tableName)
 
 	_, err := p.db.ExecContext(ctx, query)
 	return err
@@ -175,8 +183,9 @@ func (p *PostgresStore) Add(ctx context.Context, record Record) (string, error) 
 			rag_enabled, rag_backend, rag_context_length, rag_similarity_score,
 			hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
 			prompt_tokens, completion_tokens, total_tokens,
-			actual_cost, baseline_cost, cost_savings, currency, baseline_model
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42)
+			actual_cost, baseline_cost, cost_savings, currency, baseline_model,
+			session_id, turn_index, previous_response_id, conversation_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46)
 	`, p.tableName)
 
 	fn := func() error {

--- a/src/semantic-router/pkg/routerreplay/store/postgres_record_codec.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_record_codec.go
@@ -26,6 +26,14 @@ func nullableStringArg(value *string) interface{} {
 	return *value
 }
 
+// emptyStringSQL maps "" to SQL NULL for optional VARCHAR columns.
+func emptyStringSQL(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
 func assignUsageCostFields(
 	record *Record,
 	promptTokens sql.NullInt64,

--- a/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
@@ -18,7 +18,8 @@ const postgresRecordSelectColumns = `
 	rag_enabled, rag_backend, rag_context_length, rag_similarity_score,
 	hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
 	prompt_tokens, completion_tokens, total_tokens,
-	actual_cost, baseline_cost, cost_savings, currency, baseline_model
+	actual_cost, baseline_cost, cost_savings, currency, baseline_model,
+	session_id, turn_index, previous_response_id, conversation_id
 `
 
 type postgresRowScanner interface {
@@ -53,6 +54,10 @@ type postgresRecordRow struct {
 	costSavings            sql.NullFloat64
 	currency               sql.NullString
 	baselineModel          sql.NullString
+	sessionID              sql.NullString
+	turnIndex              sql.NullInt64
+	previousResponseID     sql.NullString
+	conversationID         sql.NullString
 }
 
 func newPostgresInsertRecord(record Record) (postgresInsertRecord, error) {
@@ -160,6 +165,10 @@ func (record postgresInsertRecord) args() []interface{} {
 		nullableFloat64Arg(record.record.CostSavings),
 		nullableStringArg(record.record.Currency),
 		nullableStringArg(record.record.BaselineModel),
+		emptyStringSQL(record.record.SessionID),
+		record.record.TurnIndex,
+		emptyStringSQL(record.record.PreviousResponseID),
+		emptyStringSQL(record.record.ConversationID),
 	}
 }
 
@@ -234,6 +243,10 @@ func (row *postgresRecordRow) scanDestinations() []interface{} {
 		&row.costSavings,
 		&row.currency,
 		&row.baselineModel,
+		&row.sessionID,
+		&row.turnIndex,
+		&row.previousResponseID,
+		&row.conversationID,
 	}
 }
 
@@ -270,5 +283,17 @@ func (row *postgresRecordRow) decode() (Record, error) {
 		row.currency,
 		row.baselineModel,
 	)
+	if row.sessionID.Valid {
+		row.record.SessionID = row.sessionID.String
+	}
+	if row.turnIndex.Valid {
+		row.record.TurnIndex = int(row.turnIndex.Int64)
+	}
+	if row.previousResponseID.Valid {
+		row.record.PreviousResponseID = row.previousResponseID.String
+	}
+	if row.conversationID.Valid {
+		row.record.ConversationID = row.conversationID.String
+	}
 	return row.record, nil
 }

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -69,6 +69,10 @@ type Record struct {
 	ID                    string             `json:"id"`
 	Timestamp             time.Time          `json:"timestamp"`
 	RequestID             string             `json:"request_id,omitempty"`
+	SessionID             string             `json:"session_id,omitempty"`
+	TurnIndex             int                `json:"turn_index"`
+	PreviousResponseID    string             `json:"previous_response_id,omitempty"`
+	ConversationID        string             `json:"conversation_id,omitempty"`
 	Decision              string             `json:"decision,omitempty"`
 	DecisionTier          int                `json:"decision_tier"`
 	DecisionPriority      int                `json:"decision_priority"`


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes https://github.com/vllm-project/semantic-router/issues/1778

## Purpose

Add and persist the following fields to the router replay records (store.Record / RoutingRecord): session_id and turn_index; in the Responses API scenario, add previous_response_id and conversation_id.

buildReplayRoutingRecord writes these fields from RequestContext / ResponseAPICtx; before startRouterReplay, populateReplaySessionIfNeeded to complete any messages that may not have been parsed on the CC path, then run populateSessionTransitionFields.

Session derivation: supports x-session-id overriding; uses full message fingerprint (cc-full-…) when no user is specified; if that fails, uses rid-… (based on RequestID / x-request-id); can also fall back to rid- when there are no messages.

GET /v1/router_replay list supports precise filtering with ?session_id=.

Postgres: New column + idx_<table>_session_timestamp; Redis/Milvus automatically includes the new field with JSON records.

Added session-related log fields to routerreplay.LogFields.

Unit tests (extproc / routerreplay / session / memory_helpers) and E2E (validating session_id in replay restart test cases) are updated accordingly.

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
