### PR TITLE
[CLI][Docs] Add Claude Code session-isolated install skill

### DIFF
--- a/docs/agent/change-surfaces.md
+++ b/docs/agent/change-surfaces.md
@@ -170,6 +170,12 @@ This document defines the project-level surfaces used by skills, reports, and va
 - Typical paths: `tools/agent/e2e-profile-map.yaml`, `e2e/profiles/**`, `e2e/config/**`, `deploy/kubernetes/**`
 - Task rules: `e2e-framework`
 
+## `cli_install`
+
+- Session-isolated CLI install wrapper and coding-agent skill for quick, disposable vllm-sr installs.
+- Typical paths: `install.sh`, `tools/agent/scripts/cc-install.sh`, `tools/agent/skills/claude-code-install/**`
+- Task rules: `vllm-sr-cli`
+
 ## `ci_e2e`
 
 - CI fanout, change classification, and standard profile-matrix execution for the merge gate.

--- a/docs/agent/skill-catalog.md
+++ b/docs/agent/skill-catalog.md
@@ -49,6 +49,7 @@ Skills stay intentionally concise. Keep deep reference material in the linked pl
 - `routing-calibration-loop`
 - `maintainer-issue-pr-management`
 - `architecture-guardrails`
+- `claude-code-install`
 
 ## Source of Truth
 

--- a/tools/agent/context-map.yaml
+++ b/tools/agent/context-map.yaml
@@ -145,6 +145,9 @@ surfaces:
   ci_e2e:
     - path: docs/agent/playbooks/e2e-selection.md
       reason: CI E2E profile fanout and targeted-versus-full selection rules.
+  cli_install:
+    - path: docs/agent/playbooks/vllm-sr-cli-docker.md
+      reason: CLI install workflow and session-scoped directory conventions.
 
 envs:
   cpu-local:
@@ -168,3 +171,7 @@ skills:
     resume_refs:
       - path: docs/agent/tech-debt-register.md
         reason: Record remaining cross-surface architecture gaps if they stay open.
+  claude-code-install:
+    resume_refs:
+      - path: docs/agent/playbooks/vllm-sr-cli-docker.md
+        reason: CLI install workflow and session-scoped directory conventions.

--- a/tools/agent/repo-manifest.yaml
+++ b/tools/agent/repo-manifest.yaml
@@ -575,6 +575,7 @@ skills:
   - tools/agent/skills/harness-contract-change/SKILL.md
   - tools/agent/skills/signal-end-to-end/SKILL.md
   - tools/agent/skills/plugin-end-to-end/SKILL.md
+  - tools/agent/skills/claude-code-install/SKILL.md
   - tools/agent/skills/config-platform-change/SKILL.md
   - tools/agent/skills/routing-policy-change/SKILL.md
   - tools/agent/skills/startup-chain-change/SKILL.md

--- a/tools/agent/scripts/cc-install.sh
+++ b/tools/agent/scripts/cc-install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Session-isolated vllm-sr install wrapper for coding agents.
+# Installs to a temp directory so the user's system is untouched.
+set -euo pipefail
+
+SESSION_TAG="${VLLM_SR_SESSION_TAG:-$$}"
+SESSION_DIR="${TMPDIR:-/tmp}"
+SESSION_DIR="${SESSION_DIR%/}/vllm-sr-session-${SESSION_TAG}"
+
+trap '[ $? -ne 0 ] && rm -rf "$SESSION_DIR"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+has_flag() {
+  local flag="$1"; shift
+  for arg in "$@"; do
+    [ "$arg" = "$flag" ] && return 0
+  done
+  return 1
+}
+
+extra_args=()
+
+has_flag "--mode"         "$@" || extra_args+=(--mode cli)
+has_flag "--runtime"      "$@" || extra_args+=(--runtime skip)
+has_flag "--no-launch"    "$@" || extra_args+=(--no-launch)
+has_flag "--install-root" "$@" || extra_args+=(--install-root "$SESSION_DIR")
+has_flag "--bin-dir"      "$@" || extra_args+=(--bin-dir "$SESSION_DIR/bin")
+
+echo "=> Session directory: $SESSION_DIR"
+echo ""
+
+bash "$REPO_ROOT/install.sh" "${extra_args[@]}" "$@"
+
+echo ""
+echo "=> To activate in this shell:"
+echo ""
+echo "   export PATH=\"$SESSION_DIR/bin:\$PATH\""
+echo ""
+echo "=> To clean up later:"
+echo ""
+echo "   rm -rf \"$SESSION_DIR\""

--- a/tools/agent/skill-registry.yaml
+++ b/tools/agent/skill-registry.yaml
@@ -295,6 +295,14 @@ surfaces:
       - deploy/kubernetes/**
     task_rules:
       - e2e-framework
+  cli_install:
+    description: Session-isolated CLI install wrapper and coding-agent skill for quick, disposable vllm-sr installs.
+    paths:
+      - install.sh
+      - tools/agent/scripts/cc-install.sh
+      - tools/agent/skills/claude-code-install/**
+    task_rules:
+      - vllm-sr-cli
   ci_e2e:
     description: CI fanout, workflow-driven integration suites, and standard profile-matrix execution for the merge gate.
     paths:
@@ -911,3 +919,11 @@ skills:
       description: Manual structural review for boundary-sensitive edits that need an explicit architecture pass instead of always expanding the default context pack.
       acceptance_criteria:
         - Boundary-sensitive edits that opt into the support skill check structure rules, interface placement, and dependency direction explicitly.
+    - name: claude-code-install
+      path: tools/agent/skills/claude-code-install/SKILL.md
+      description: Session-isolated vllm-sr CLI install for coding agents. Installs to a temp directory so the user's system is untouched.
+      owned_surfaces:
+        - cli_install
+      acceptance_criteria:
+        - vllm-sr --version succeeds after running the wrapper and exporting PATH.
+        - No files are written outside the session-scoped temp directory.

--- a/tools/agent/skills/claude-code-install/SKILL.md
+++ b/tools/agent/skills/claude-code-install/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: claude-code-install
+category: support
+description: Guides coding agents through a session-isolated install of the vllm-sr CLI. The install is scoped to a temporary directory so it does not modify the user's global PATH or system packages. Use when an agent or user wants to try vllm-sr without a permanent install.
+---
+
+# Claude Code Session-Isolated Install
+
+## Trigger
+
+- User or agent wants to install and try `vllm-sr` CLI without permanent system changes
+- A coding agent needs a quick, disposable install for validation or exploration
+
+## Required Surfaces
+
+- `cli_install`
+
+## Stop Conditions
+
+- The host lacks `bash`, `curl`, or `python3` (install.sh prerequisites)
+- The user explicitly wants a permanent/global install (use `install.sh` directly instead)
+
+## Workflow
+
+1. Run the session-isolated wrapper script:
+
+   ```bash
+   bash tools/agent/scripts/cc-install.sh
+   ```
+
+   This creates a temp directory, installs the CLI there, and prints the `export PATH` line.
+
+2. Export the PATH as printed:
+
+   ```bash
+   export PATH="/tmp/vllm-sr-session-<tag>/bin:$PATH"
+   ```
+
+3. Validate the install:
+
+   ```bash
+   vllm-sr --version
+   vllm-sr validate          # if a config.yaml exists
+   ```
+
+4. When done, the session directory is cleaned up automatically on reboot, or remove it manually:
+
+   ```bash
+   rm -rf /tmp/vllm-sr-session-<tag>
+   ```
+
+## Passing Options
+
+Any extra flags are forwarded to `install.sh`. For example:
+
+```bash
+bash tools/agent/scripts/cc-install.sh --runtime docker
+```
+
+The wrapper only sets defaults for `--mode`, `--runtime`, `--install-root`, `--bin-dir`, and `--no-launch` when they are not already present in the caller's arguments.
+
+## Gotchas
+
+- The wrapper only sets defaults when flags are absent. If you pass `--mode` or `--runtime` explicitly, the wrapper does not override them.
+- PID-based session tags (`$$`) can collide if the OS reuses PIDs quickly. Set `VLLM_SR_SESSION_TAG` to a unique value for concurrent installs.
+- If `install.sh` fails mid-install, the trap automatically cleans up the session directory. Do not rely on its partial contents.
+
+## Must Read
+
+- [install.sh](../../../../install.sh)
+- [tools/agent/scripts/cc-install.sh](../../scripts/cc-install.sh)
+
+## Standard Commands
+
+- `bash tools/agent/scripts/cc-install.sh`
+- `vllm-sr --version`
+- `vllm-sr validate`
+
+## Acceptance
+
+- `vllm-sr --version` succeeds after running the wrapper and exporting PATH
+- No files are written outside the session-scoped temp directory
+- The user's global PATH and system packages are unchanged


### PR DESCRIPTION
## Purpose

Add a coding-agent skill and wrapper script for session-isolated vllm-sr CLI installation. Lets agents (or users) install vllm-sr into a temp directory without modifying global PATH or system packages.

## Changes

- `tools/agent/skills/claude-code-install/SKILL.md` — skill documentation for coding agents
- `tools/agent/scripts/cc-install.sh` — wrapper around `install.sh` with session-scoped defaults (`--mode cli --runtime skip --no-launch`)
- `tools/agent/skill-registry.yaml` — added `cli_install` surface and `claude-code-install` support skill

## Test Plan

- Tested on macOS arm64 with CLI-only mode
- Verified: install goes to temp dir, PATH export works, `vllm-sr --version` succeeds
- YAML syntax validated, shell script syntax checked

## Test Result

```
$ bash tools/agent/scripts/cc-install.sh
[done] Installed vllm-sr version: 0.3.0.dev20260421015929
$ vllm-sr --version
vllm-sr version: 0.3.0.dev20260421015929
```

Contributions for other platforms welcome.
