### PR TITLE
docs(i18n):  Fix missing Chinese translations

### DIFF
--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -407,6 +407,12 @@
   "homepage.hero.secondaryCta": {
     "message": "阅读白皮书"
   },
+  "homepage.hero.modelBand.eyebrow": {
+    "message": "系统大脑"
+  },
+  "homepage.hero.modelBand.copy": {
+    "message": "用系统大脑连接所有模型"
+  },    
   "homepage.stats.signals.label": {
     "message": "信号"
   },

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
@@ -8,7 +8,7 @@
     "description": "The description for the blog used in SEO"
   },
   "sidebar.title": {
-    "message": "Recent Posts",
+    "message": "近期发布",
     "description": "The label for the left sidebar"
   }
 }

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
@@ -7,6 +7,10 @@
     "message": "概述",
     "description": "The label for category Overview in sidebar tutorialSidebar"
   },
+  "sidebar.tutorialSidebar.category.Installation": {
+    "message": "安装",
+    "description": "The label for category Installation in sidebar tutorialSidebar"
+  },  
   "sidebar.tutorialSidebar.category.Quickstart": {
     "message": "快速开始",
     "description": "The label for category Quickstart in sidebar tutorialSidebar"

--- a/website/src/theme/BlogLayout/index.tsx
+++ b/website/src/theme/BlogLayout/index.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx'
 import Layout from '@theme/Layout'
 import BlogSidebar from '@theme/BlogSidebar'
 import type { Props } from '@theme/BlogLayout'
+import Translate, { translate } from '@docusaurus/Translate'
 import { PillLink, SectionLabel } from '@site/src/components/site/Chrome'
 
 export default function BlogLayout(props: Props): React.ReactNode {
@@ -10,16 +11,24 @@ export default function BlogLayout(props: Props): React.ReactNode {
   const hasSidebar = sidebar && sidebar.items.length > 0
   const title = typeof layoutProps.title === 'string'
     ? layoutProps.title
-    : 'Journal'
+    : translate({
+        id: 'blog.layout.title',
+        message: 'Journal',
+      })
   const description = typeof layoutProps.description === 'string'
     ? layoutProps.description
-    : 'Release notes, field reports, and research commentary from the vLLM Semantic Router project.'
+    : translate({
+        id: 'blog.layout.description',
+        message: 'Release notes, field reports, and research commentary from the vLLM Semantic Router project.',
+      })
 
   return (
     <Layout {...layoutProps}>
       <header className="site-blog-masthead">
         <div className="site-shell-container">
-          <SectionLabel>Blog</SectionLabel>
+          <SectionLabel>
+            <Translate id="blog.layout.sectionLabel">Blog</Translate>
+          </SectionLabel>
           <div className="site-blog-masthead__row">
             <div className="site-blog-masthead__copy">
               <h1>{title}</h1>


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

This PR fixes missing Chinese translations across several main/docs/blog pages 
## Test Plan

- Reviewed the modified localization files manually
- Previewed the affected text changes locally
- Verified that the updated Chinese text renders correctly

## Test Result

The corrected Chinese translations are displayed properly on the checked pages, with no obvious rendering issues.


