### PR TITLE
[Router][Bugfix]: Pre-check search module version before FT.CREATE

### DIFF
--- a/src/semantic-router/pkg/cache/valkey_cache.go
+++ b/src/semantic-router/pkg/cache/valkey_cache.go
@@ -116,22 +116,29 @@ func NewValkeyCache(options ValkeyCacheOptions) (*ValkeyCache, error) {
 	}
 	logging.Debugf("ValkeyCache: successfully connected to Valkey")
 
-	versionCtx, versionCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer versionCancel()
-	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, valkeyClient, valkeyutil.SearchModuleMinVersion); err != nil {
+	logging.Debugf("ValkeyCache: initializing index '%s'", valkeyConfig.Index.Name)
+	if err := cache.initializeSearchIndex(); err != nil {
+		logging.Debugf("ValkeyCache: initialization failed: %v", err)
 		valkeyClient.Close()
 		return nil, err
-	}
-
-	logging.Debugf("ValkeyCache: initializing index '%s'", valkeyConfig.Index.Name)
-	if err := cache.initializeIndex(); err != nil {
-		logging.Debugf("ValkeyCache: failed to initialize index: %v", err)
-		valkeyClient.Close()
-		return nil, fmt.Errorf("failed to initialize index: %w", err)
 	}
 	logging.Debugf("ValkeyCache: initialization complete")
 
 	return cache, nil
+}
+
+// initializeSearchIndex runs the valkey-search module version pre-check and
+// then sets up the FT index.
+func (c *ValkeyCache) initializeSearchIndex() error {
+	versionCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, c.client, valkeyutil.SearchModuleMinVersion); err != nil {
+		return err
+	}
+	if err := c.initializeIndex(); err != nil {
+		return fmt.Errorf("failed to initialize index: %w", err)
+	}
+	return nil
 }
 
 // initializeIndex sets up the Valkey index for vector search

--- a/src/semantic-router/pkg/cache/valkey_cache.go
+++ b/src/semantic-router/pkg/cache/valkey_cache.go
@@ -16,6 +16,7 @@ import (
 	routerconfig "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	valkeyutil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/valkey"
 )
 
 // ValkeyCache provides a scalable semantic cache implementation using Valkey with vector search
@@ -114,6 +115,13 @@ func NewValkeyCache(options ValkeyCacheOptions) (*ValkeyCache, error) {
 		return nil, err
 	}
 	logging.Debugf("ValkeyCache: successfully connected to Valkey")
+
+	versionCtx, versionCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer versionCancel()
+	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, valkeyClient, valkeyutil.SearchModuleMinVersion); err != nil {
+		valkeyClient.Close()
+		return nil, err
+	}
 
 	logging.Debugf("ValkeyCache: initializing index '%s'", valkeyConfig.Index.Name)
 	if err := cache.initializeIndex(); err != nil {

--- a/src/semantic-router/pkg/cache/valkey_cache_integration_edge_test.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_integration_edge_test.go
@@ -145,9 +145,10 @@ func TestValkeyCacheIntegration_ErrorScenarios(t *testing.T) {
 			t.Skipf("Failed to initialize BERT model: %v", err)
 		}
 
+		host, port := valkeyIntegrationAddr()
 		valkeyConfig := &config.ValkeyConfig{}
-		valkeyConfig.Connection.Host = "localhost"
-		valkeyConfig.Connection.Port = 6379
+		valkeyConfig.Connection.Host = host
+		valkeyConfig.Connection.Port = port
 
 		valkeyConfig.Index.Name = "nonexistent_idx"
 		valkeyConfig.Index.Prefix = "doc:"

--- a/src/semantic-router/pkg/cache/valkey_cache_integration_test.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_integration_test.go
@@ -17,6 +17,26 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
+// valkeyIntegrationAddr returns the Valkey host/port for integration tests,
+// honoring VALKEY_HOST / VALKEY_PORT env vars and falling back to localhost:6379.
+// In CI, VALKEY_PORT is set to 6380 because Redis Stack occupies 6379; connecting
+// to 6379 would hit RediSearch (which also registers a module named "search"),
+// not valkey-search.
+func valkeyIntegrationAddr() (string, int) {
+	host := "localhost"
+	port := 6379
+
+	if v := os.Getenv("VALKEY_HOST"); v != "" {
+		host = v
+	}
+	if v := os.Getenv("VALKEY_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			port = p
+		}
+	}
+	return host, port
+}
+
 // These tests require:
 //  1. A running Valkey instance with search module.
 //     Default: localhost:6379 (standalone / local-only).
@@ -36,18 +56,7 @@ func setupValkeyCacheIntegration(t *testing.T) *ValkeyCache {
 		t.Skipf("Failed to initialize BERT model: %v", err)
 	}
 
-	// Get Valkey connection details from environment or use defaults
-	valkeyHost := "localhost"
-	valkeyPort := 6379
-
-	if host := os.Getenv("VALKEY_HOST"); host != "" {
-		valkeyHost = host
-	}
-	if portStr := os.Getenv("VALKEY_PORT"); portStr != "" {
-		if port, err := strconv.Atoi(portStr); err == nil {
-			valkeyPort = port
-		}
-	}
+	valkeyHost, valkeyPort := valkeyIntegrationAddr()
 
 	// Create Valkey config
 	valkeyConfig := &config.ValkeyConfig{}
@@ -406,9 +415,10 @@ func TestValkeyCacheIntegration_IsEnabled(t *testing.T) {
 	assert.True(t, cache.IsEnabled(), "Cache should be enabled")
 
 	// Test disabled cache
+	host, port := valkeyIntegrationAddr()
 	valkeyConfig := &config.ValkeyConfig{}
-	valkeyConfig.Connection.Host = "localhost"
-	valkeyConfig.Connection.Port = 6379
+	valkeyConfig.Connection.Host = host
+	valkeyConfig.Connection.Port = port
 
 	disabledCache, err := NewValkeyCache(ValkeyCacheOptions{
 		Enabled: false,
@@ -421,9 +431,10 @@ func TestValkeyCacheIntegration_IsEnabled(t *testing.T) {
 }
 
 func TestValkeyCacheIntegration_DisabledCache(t *testing.T) {
+	host, port := valkeyIntegrationAddr()
 	valkeyConfig := &config.ValkeyConfig{}
-	valkeyConfig.Connection.Host = "localhost"
-	valkeyConfig.Connection.Port = 6379
+	valkeyConfig.Connection.Host = host
+	valkeyConfig.Connection.Port = port
 
 	cache, err := NewValkeyCache(ValkeyCacheOptions{
 		Enabled: false,
@@ -471,9 +482,10 @@ func TestValkeyCacheIntegration_FLATIndexType(t *testing.T) {
 		t.Skipf("Failed to initialize BERT model: %v", err)
 	}
 
+	host, port := valkeyIntegrationAddr()
 	valkeyConfig := &config.ValkeyConfig{}
-	valkeyConfig.Connection.Host = "localhost"
-	valkeyConfig.Connection.Port = 6379
+	valkeyConfig.Connection.Host = host
+	valkeyConfig.Connection.Port = port
 	valkeyConfig.Connection.Database = 0
 
 	valkeyConfig.Index.Name = fmt.Sprintf("test_flat_idx_%d", time.Now().UnixNano())
@@ -603,9 +615,10 @@ func TestValkeyCacheIntegration_L2MetricType(t *testing.T) {
 		t.Skipf("Failed to initialize BERT model: %v", err)
 	}
 
+	host, port := valkeyIntegrationAddr()
 	valkeyConfig := &config.ValkeyConfig{}
-	valkeyConfig.Connection.Host = "localhost"
-	valkeyConfig.Connection.Port = 6379
+	valkeyConfig.Connection.Host = host
+	valkeyConfig.Connection.Port = port
 	valkeyConfig.Connection.Database = 0
 
 	valkeyConfig.Index.Name = fmt.Sprintf("test_l2_idx_%d", time.Now().UnixNano())
@@ -652,9 +665,10 @@ func TestValkeyCacheIntegration_IPMetricType(t *testing.T) {
 		t.Skipf("Failed to initialize BERT model: %v", err)
 	}
 
+	host, port := valkeyIntegrationAddr()
 	valkeyConfig := &config.ValkeyConfig{}
-	valkeyConfig.Connection.Host = "localhost"
-	valkeyConfig.Connection.Port = 6379
+	valkeyConfig.Connection.Host = host
+	valkeyConfig.Connection.Port = port
 	valkeyConfig.Connection.Database = 0
 
 	valkeyConfig.Index.Name = fmt.Sprintf("test_ip_idx_%d", time.Now().UnixNano())

--- a/src/semantic-router/pkg/memory/valkey_store.go
+++ b/src/semantic-router/pkg/memory/valkey_store.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	valkeyutil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/valkey"
 )
 
 // errValkeyMemoryAlreadyExists is returned by Store when a memory with the same ID already exists.
@@ -114,6 +115,13 @@ func NewValkeyStore(options ValkeyStoreOptions) (*ValkeyStore, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), indexTimeout)
 	defer cancel()
+
+	versionCtx, versionCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer versionCancel()
+	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, store.client, valkeyutil.SearchModuleMinVersion); err != nil {
+		return nil, err
+	}
+
 	if err := store.ensureIndex(ctx); err != nil {
 		return nil, fmt.Errorf("failed to ensure index exists: %w", err)
 	}

--- a/src/semantic-router/pkg/memory/valkey_store.go
+++ b/src/semantic-router/pkg/memory/valkey_store.go
@@ -116,20 +116,28 @@ func NewValkeyStore(options ValkeyStoreOptions) (*ValkeyStore, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), indexTimeout)
 	defer cancel()
 
-	versionCtx, versionCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer versionCancel()
-	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, store.client, valkeyutil.SearchModuleMinVersion); err != nil {
+	if err := store.initializeSearchIndex(ctx); err != nil {
 		return nil, err
-	}
-
-	if err := store.ensureIndex(ctx); err != nil {
-		return nil, fmt.Errorf("failed to ensure index exists: %w", err)
 	}
 
 	logging.Infof("ValkeyStore: initialized with index='%s', prefix='%s', embedding_model='%s', dimension=%d",
 		store.indexName, store.collectionPrefix, store.embeddingConfig.Model, store.dimension)
 
 	return store, nil
+}
+
+// initializeSearchIndex runs the valkey-search module version pre-check and then
+// ensures the FT index exists.
+func (v *ValkeyStore) initializeSearchIndex(ctx context.Context) error {
+	versionCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, v.client, valkeyutil.SearchModuleMinVersion); err != nil {
+		return err
+	}
+	if err := v.ensureIndex(ctx); err != nil {
+		return fmt.Errorf("failed to ensure index exists: %w", err)
+	}
+	return nil
 }
 
 // ensureIndex checks if the FT index exists and creates it if not.

--- a/src/semantic-router/pkg/memory/valkey_store.go
+++ b/src/semantic-router/pkg/memory/valkey_store.go
@@ -129,7 +129,7 @@ func NewValkeyStore(options ValkeyStoreOptions) (*ValkeyStore, error) {
 // initializeSearchIndex runs the valkey-search module version pre-check and then
 // ensures the FT index exists.
 func (v *ValkeyStore) initializeSearchIndex(ctx context.Context) error {
-	versionCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	versionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, v.client, valkeyutil.SearchModuleMinVersion); err != nil {
 		return err

--- a/src/semantic-router/pkg/utils/valkey/version.go
+++ b/src/semantic-router/pkg/utils/valkey/version.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package valkey contains shared helpers for Valkey-backed components
+// (vector store, semantic cache, agentic memory).
+package valkey
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// SearchModuleMinVersion is the minimum valkey-search version required for the
+// TEXT field type used in our FT.CREATE schemas.
+const SearchModuleMinVersion uint32 = (1 << 16) | (2 << 8) // 1.2.0 == 0x010200
+
+// ModuleLister is the minimal subset of *glide.Client we depend on, abstracted
+// for testability.
+type ModuleLister interface {
+	CustomCommand(ctx context.Context, args []string) (any, error)
+}
+
+// EnsureSearchModuleVersion runs MODULE LIST and returns an error if the loaded
+// `search` module is missing or has a version below minPacked.
+func EnsureSearchModuleVersion(ctx context.Context, client ModuleLister, minPacked uint32) error {
+	raw, err := client.CustomCommand(ctx, []string{"MODULE", "LIST"})
+	if err != nil {
+		logging.Warnf("valkey: MODULE LIST failed (%v), skipping search module version pre-check", err)
+		return nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		logging.Warnf("valkey: MODULE LIST returned unexpected type %T, skipping pre-check", raw)
+		return nil
+	}
+
+	for _, entry := range arr {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := m["name"].(string); name != "search" {
+			continue
+		}
+		verRaw, ok := m["ver"].(int64)
+		if !ok || verRaw < 0 || verRaw > math.MaxUint32 {
+			logging.Warnf("valkey: search module 'ver' has unexpected type/value, skipping pre-check")
+			return nil
+		}
+		ver := uint32(verRaw)
+		if ver < minPacked {
+			return fmt.Errorf("valkey-search %s detected, requires >= %s",
+				formatVersion(ver), formatVersion(minPacked))
+		}
+		return nil
+	}
+	return fmt.Errorf("valkey-search module not loaded, requires >= %s",
+		formatVersion(minPacked))
+}
+
+// formatVersion renders a packed version int as "M.N.P" for error messages.
+func formatVersion(packed uint32) string {
+	return fmt.Sprintf("%d.%d.%d", (packed>>16)&0xFF, (packed>>8)&0xFF, packed&0xFF)
+}

--- a/src/semantic-router/pkg/utils/valkey/version_test.go
+++ b/src/semantic-router/pkg/utils/valkey/version_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package valkey
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeClient struct {
+	response any
+	err      error
+}
+
+func (f *fakeClient) CustomCommand(_ context.Context, _ []string) (any, error) {
+	return f.response, f.err
+}
+
+func mod(name string, ver int64) map[string]any {
+	return map[string]any{"name": name, "ver": ver}
+}
+
+func TestEnsureSearchModuleVersion(t *testing.T) {
+	cases := []struct {
+		name        string
+		response    any
+		respErr     error
+		wantErr     bool
+		errContains []string
+	}{
+		{name: "1.2.0 passes", response: []any{mod("search", 0x010200)}},
+		{name: "1.2.1 passes", response: []any{mod("search", 0x010201)}},
+		{name: "2.0.0 passes", response: []any{mod("search", 0x020000)}},
+		{name: "search alongside other modules", response: []any{mod("bf", 0x010001), mod("search", 0x010200), mod("json", 0x010002)}},
+		{
+			name: "1.0.0 rejected", response: []any{mod("search", 0x010000)},
+			wantErr: true, errContains: []string{"1.0.0", "1.2.0"},
+		},
+		{
+			name: "1.1.0 rejected", response: []any{mod("search", 0x010100)},
+			wantErr: true, errContains: []string{"1.1.0", "1.2.0"},
+		},
+		{
+			name: "no search module", response: []any{mod("bf", 0x010001), mod("json", 0x010002)},
+			wantErr: true, errContains: []string{"not loaded", "1.2.0"},
+		},
+		{
+			name: "empty list", response: []any{},
+			wantErr: true, errContains: []string{"not loaded"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeClient{response: tc.response, err: tc.respErr}
+			err := EnsureSearchModuleVersion(context.Background(), client, SearchModuleMinVersion)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				for _, sub := range tc.errContains {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q missing %q", err.Error(), sub)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/src/semantic-router/pkg/vectorstore/valkey_backend.go
+++ b/src/semantic-router/pkg/vectorstore/valkey_backend.go
@@ -28,6 +28,8 @@ import (
 
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	glideconfig "github.com/valkey-io/valkey-glide/go/v2/config"
+
+	valkeyutil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/valkey"
 )
 
 // ValkeyBackendConfig holds configuration for the Valkey vector store backend.
@@ -136,6 +138,13 @@ func NewValkeyBackend(cfg ValkeyBackendConfig) (*ValkeyBackend, error) {
 	if err != nil {
 		client.Close()
 		return nil, fmt.Errorf("failed to ping Valkey at %s:%d: %w", host, port, err)
+	}
+
+	versionCtx, versionCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer versionCancel()
+	if err := valkeyutil.EnsureSearchModuleVersion(versionCtx, client, valkeyutil.SearchModuleMinVersion); err != nil {
+		client.Close()
+		return nil, err
 	}
 
 	return &ValkeyBackend{


### PR DESCRIPTION
<!-- markdownlint-disable -->
Adds a startup version pre-check so users running valkey-search < 1.2.0                                                                                                                          see an actionable error instead of the opaque `Invalid: field type for  field 'X': Unknown argument 'TEXT'` that FT.CREATE currently emits.                                           
Fixes #1776.

## Purpose

- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Router`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
