### PR TITLE
[E2E]: e2e test for Persist SessionID and TurnIndex into replay records

### DIFF
--- a/e2e/profiles/router-replay/profile.go
+++ b/e2e/profiles/router-replay/profile.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
 	gatewaystack "github.com/vllm-project/semantic-router/e2e/pkg/stacks/gateway"
+
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
 )
 
 const (
@@ -58,6 +60,8 @@ func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions)
 func (p *Profile) GetTestCases() []string {
 	return []string{
 		"router-replay-restart-recovery",
+		"router-replay-session-list-filter",
+		"router-replay-session-turn-progression",
 	}
 }
 

--- a/e2e/testcases/router_replay_session_metadata.go
+++ b/e2e/testcases/router_replay_session_metadata.go
@@ -1,0 +1,210 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("router-replay-session-list-filter", pkgtestcases.TestCase{
+		Description: "GET /v1/router_replay?session_id= returns only replay rows for that session (x-session-id pinned chats)",
+		Tags:        []string{"router-replay", "functional", "router-replay-api"},
+		Fn:          testRouterReplaySessionListFilter,
+	})
+	pkgtestcases.Register("router-replay-session-turn-progression", pkgtestcases.TestCase{
+		Description: "Two chat completions in the same x-session-id produce increasing turn_index on replay records",
+		Tags:        []string{"router-replay", "functional", "router-replay-api"},
+		Fn:          testRouterReplaySessionTurnProgression,
+	})
+}
+
+func testRouterReplaySessionListFilter(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Router replay: session_id list filter")
+	}
+	session, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("open session: %w", err)
+	}
+	defer session.Close()
+
+	base := fmt.Sprintf("e2e_rs_%d", time.Now().UnixNano())
+	sessA := base + "_a"
+	sessB := base + "_b"
+
+	if err := postChatCompletionsWithReplayHeaders(ctx, session, postChatOpts{
+		sessionID: sessA,
+		userID:    "e2e-replay-sess-user",
+		content:   "router replay list filter — request A " + base,
+	}); err != nil {
+		return err
+	}
+	time.Sleep(2 * time.Second)
+	if err := postChatCompletionsWithReplayHeaders(ctx, session, postChatOpts{
+		sessionID: sessB,
+		userID:    "e2e-replay-sess-user",
+		content:   "router replay list filter — request B " + base,
+	}); err != nil {
+		return err
+	}
+	time.Sleep(2 * time.Second)
+
+	if err := assertReplayListAllMatchSessionID(session, sessA, opts.Verbose); err != nil {
+		return fmt.Errorf("session A filter: %w", err)
+	}
+	if err := assertReplayListAllMatchSessionID(session, sessB, opts.Verbose); err != nil {
+		return fmt.Errorf("session B filter: %w", err)
+	}
+	return nil
+}
+
+func testRouterReplaySessionTurnProgression(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Router replay: turn_index across two turns (same x-session-id)")
+	}
+	session, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("open session: %w", err)
+	}
+	defer session.Close()
+
+	sess := fmt.Sprintf("e2e_turn_%d", time.Now().UnixNano())
+	user := "e2e-replay-turn-user"
+
+	if err := postChatCompletionsWithReplayHeaders(ctx, session, postChatOpts{
+		sessionID: sess,
+		userID:    user,
+		messages: []fixtures.ChatMessage{
+			{Role: "user", Content: "turn progression first message " + sess},
+		},
+	}); err != nil {
+		return err
+	}
+	time.Sleep(2 * time.Second)
+	if err := postChatCompletionsWithReplayHeaders(ctx, session, postChatOpts{
+		sessionID: sess,
+		userID:    user,
+		messages: []fixtures.ChatMessage{
+			{Role: "user", Content: "turn progression first message " + sess},
+			{Role: "assistant", Content: "mock assistant reply for e2e"},
+			{Role: "user", Content: "turn progression follow-up " + sess},
+		},
+	}); err != nil {
+		return err
+	}
+	time.Sleep(2 * time.Second)
+
+	items, err := fetchReplayListForSession(session, sess, 20)
+	if err != nil {
+		return err
+	}
+	if len(items) < 2 {
+		return fmt.Errorf("expected at least 2 replay rows for session %q, got %d", sess, len(items))
+	}
+
+	minTurn, maxTurn := items[0].TurnIndex, items[0].TurnIndex
+	for _, it := range items {
+		if it.TurnIndex < minTurn {
+			minTurn = it.TurnIndex
+		}
+		if it.TurnIndex > maxTurn {
+			maxTurn = it.TurnIndex
+		}
+	}
+	if maxTurn <= minTurn {
+		return fmt.Errorf("expected turn_index range for session %q (min=%d max=%d across %d rows)",
+			sess, minTurn, maxTurn, len(items))
+	}
+	if opts.Verbose {
+		fmt.Printf("[Test] session %q replay rows=%d turn_index min=%d max=%d\n", sess, len(items), minTurn, maxTurn)
+	}
+	return nil
+}
+
+type postChatOpts struct {
+	sessionID string
+	userID    string
+	content   string
+	messages  []fixtures.ChatMessage
+}
+
+func postChatCompletionsWithReplayHeaders(ctx context.Context, session *fixtures.ServiceSession, o postChatOpts) error {
+	msgs := o.messages
+	if len(msgs) == 0 {
+		msgs = []fixtures.ChatMessage{{Role: "user", Content: o.content}}
+	}
+	chat := fixtures.NewChatCompletionsClient(session, 45*time.Second)
+	resp, err := chat.Create(ctx, fixtures.ChatCompletionsRequest{
+		Model:    "auto",
+		User:     o.userID,
+		Messages: msgs,
+	}, map[string]string{
+		"x-authz-user-id": o.userID,
+		"x-session-id":    o.sessionID,
+	})
+	if err != nil {
+		return fmt.Errorf("chat completions: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("chat completions status %d: %s", resp.StatusCode, string(resp.Body))
+	}
+	return nil
+}
+
+// replayListItem is a subset of router replay JSON for list endpoints.
+type replayListItem struct {
+	ID        string `json:"id"`
+	SessionID string `json:"session_id"`
+	TurnIndex int    `json:"turn_index"`
+	Timestamp string `json:"timestamp"`
+}
+
+func assertReplayListAllMatchSessionID(session *fixtures.ServiceSession, wantSession string, verbose bool) error {
+	items, err := fetchReplayListForSession(session, wantSession, 50)
+	if err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return fmt.Errorf("session_id=%q: expected at least one replay row", wantSession)
+	}
+	for _, it := range items {
+		if it.SessionID != wantSession {
+			return fmt.Errorf("row %s: session_id=%q, want %q", it.ID, it.SessionID, wantSession)
+		}
+	}
+	if verbose {
+		fmt.Printf("[Test] session_id=%q list count=%d\n", wantSession, len(items))
+	}
+	return nil
+}
+
+func fetchReplayListForSession(session *fixtures.ServiceSession, sessionID string, limit int) ([]replayListItem, error) {
+	q := url.Values{}
+	q.Set("session_id", sessionID)
+	q.Set("limit", fmt.Sprintf("%d", limit))
+	httpClient := session.HTTPClient(30 * time.Second)
+	raw, err := fixtures.DoGETRequest(context.Background(), httpClient, session.BaseURL()+"/v1/router_replay?"+q.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("GET router_replay list: %w", err)
+	}
+	if raw.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET router_replay list status %d: %s", raw.StatusCode, string(raw.Body))
+	}
+	var listResp replayListResponse
+	if err := raw.DecodeJSON(&listResp); err != nil {
+		return nil, fmt.Errorf("decode list: %w", err)
+	}
+	var items []replayListItem
+	if err := json.Unmarshal(listResp.Data, &items); err != nil {
+		return nil, fmt.Errorf("decode list data: %w", err)
+	}
+	return items, nil
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

related to https://github.com/vllm-project/semantic-router/pull/1800#issuecomment-4275539084

## Purpose

- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

router-replay-session-list-filter

Verifies the router replay list API (GET /v1/router_replay?session_id=…) only returns replay rows for that session: two different x-session-id values each get their own chat completion, then each session’s list is checked so every row’s session_id matches the queried session (no cross-session leakage when listing by session_id).

router-replay-session-turn-progression

Verifies multi-turn behavior under one x-session-id: two chat-completions calls with the same session id yield at least two replay rows whose turn_index values span a range (min < max), i.e. turn indices advance across turns rather than staying flat for that session.

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

```
[Test] Chat completion succeeded — waiting for replay record
[Test] Replay list response (pre-restart):
{
    "object": "router_replay.list",
    "count": 1,
    "total": 1,
    "limit": 1,
    "offset": 0,
    "has_more": false,
    "data": [
      {
        "id": "667ee07ba3f1be2290d8b4cf5359885f",
        "timestamp": "2026-04-21T15:48:28.701614Z",
        "request_id": "6fd4041b-7b6b-4011-9ab2-c18f69b6a510",
        "session_id": "cc-d3dda1e6d99dc662",
        "turn_index": 0,
        "decision": "default_decision",
        "decision_tier": 0,
        "decision_priority": 1,
        "original_model": "auto",
        "selected_model": "openai/gpt-oss-20b",
        "reasoning_mode": "off",
        "signals": {},
        "tool_trace": {
          "flow": "User Query -\u003e LLM Final Response",
          "stage": "LLM Final Response",
          "steps": [
            {
              "type": "user_input",
              "source": "request",
              "role": "user",
              "text": "What is 2+2? Reply with just the number.",
              "api_type": "chat_completions"
            },
            {
              "type": "assistant_final_response",
              "source": "response",
              "role": "assistant",
              "text": "{\"mock\":\"mock-vllm\",\"model\":\"openai/gpt-oss-20b\",\"roles\":[\"user\"],\"system\":[],\"total_messages\":1,\"user\":[\"What is 2+2? Reply with just the number.\"]}",
              "api_type": "chat_completions"
            }
          ]
        },
        "request_body": "{\"model\":\"auto\",\"messages\":[{\"role\":\"user\",\"content\":\"What is 2+2? Reply with just the number.\"}],\"user\":\"e2e-replay-user\"}",
        "response_body": "{\"id\":\"cmpl-mock-123\",\"object\":\"chat.completion\",\"created\":1776786508,\"model\":\"openai/gpt-oss-20b\",\"system_fingerprint\":\"mock-vllm\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"mock\\\":\\\"mock-vllm\\\",\\\"model\\\":\\\"openai/gpt-oss-20b\\\",\\\"roles\\\":[\\\"user\\\"],\\\"system\\\":[],\\\"total_messages\\\":1,\\\"user\\\":[\\\"What is 2+2? Reply with just the number.\\\"]}\"},\"finish_reason\":\"stop\",\"logprobs\":null}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":38,\"total_tokens\":48,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}},\"token_usage\":{\"prompt_tokens\":10,\"completion_tokens\":38,\"total_tokens\":48,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}}}",
        "response_status": 200,
        "prompt": "What is 2+2? Reply with just the number.",
        "prompt_tokens": 10,
        "completion_tokens": 38,
        "total_tokens": 48
      }
    ]
  }
[Test] Postgres CLI: kubectl exec -n default postgres-6dcc4ff66-g645c -- psql -U router -d vsr -t -A -c SELECT COUNT(*) FROM router_replay WHERE id = '667ee07ba3f1be2290d8b4cf5359885f'
[Test] Postgres CLI output: 1
[Test] Replay record 667ee07ba3f1be2290d8b4cf5359885f confirmed in Postgres
[Test] Replay session_id="cc-d3dda1e6d99dc662" turn_index=0
[Helper] Stopping port forwarding to envoy-gateway-system/envoy-default-semantic-router-ad1612c8
[Test] Deleting semantic-router pod semantic-router-77b6bddccf-bzf2f to simulate restart
[Test] Old pod semantic-router-77b6bddccf-bzf2f terminated
[Test] Waiting for semantic-router deployment to recover (timeout=5m0s)
[Helper] Deployment vllm-semantic-router-system/semantic-router is healthy (1/1 replicas ready)
[Helper] Found service: envoy-default-semantic-router-ad1612c8 (matched by labels: gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=semantic-router in namespace: envoy-gateway-system)
[Helper] Starting port-forward to service envoy-gateway-system/envoy-default-semantic-router-ad1612c8 (45577:80)
[Helper] Found running pod: envoy-default-semantic-router-ad1612c8-78b6fcf8f8-mtx6b
Forwarding from 127.0.0.1:45577 -> 10080
Forwarding from [::1]:45577 -> 10080
[Helper] Port forwarding is ready
Handling connection for 45577
[Test] Replay record response (post-restart):
{
    "id": "667ee07ba3f1be2290d8b4cf5359885f",
    "timestamp": "2026-04-21T15:48:28.701614Z",
    "request_id": "6fd4041b-7b6b-4011-9ab2-c18f69b6a510",
    "session_id": "cc-d3dda1e6d99dc662",
    "turn_index": 0,
    "decision": "default_decision",
    "decision_tier": 0,
    "decision_priority": 1,
    "original_model": "auto",
    "selected_model": "openai/gpt-oss-20b",
    "reasoning_mode": "off",
    "signals": {},
    "tool_trace": {
      "flow": "User Query -\u003e LLM Final Response",
      "stage": "LLM Final Response",
      "steps": [
        {
          "type": "user_input",
          "source": "request",
          "role": "user",
          "text": "What is 2+2? Reply with just the number.",
          "api_type": "chat_completions"
        },
        {
          "type": "assistant_final_response",
          "source": "response",
          "role": "assistant",
          "text": "{\"mock\":\"mock-vllm\",\"model\":\"openai/gpt-oss-20b\",\"roles\":[\"user\"],\"system\":[],\"total_messages\":1,\"user\":[\"What is 2+2? Reply with just the number.\"]}",
          "api_type": "chat_completions"
        }
      ]
    },
    "request_body": "{\"model\":\"auto\",\"messages\":[{\"role\":\"user\",\"content\":\"What is 2+2? Reply with just the number.\"}],\"user\":\"e2e-replay-user\"}",
    "response_body": "{\"id\":\"cmpl-mock-123\",\"object\":\"chat.completion\",\"created\":1776786508,\"model\":\"openai/gpt-oss-20b\",\"system_fingerprint\":\"mock-vllm\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"mock\\\":\\\"mock-vllm\\\",\\\"model\\\":\\\"openai/gpt-oss-20b\\\",\\\"roles\\\":[\\\"user\\\"],\\\"system\\\":[],\\\"total_messages\\\":1,\\\"user\\\":[\\\"What is 2+2? Reply with just the number.\\\"]}\"},\"finish_reason\":\"stop\",\"logprobs\":null}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":38,\"total_tokens\":48,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}},\"token_usage\":{\"prompt_tokens\":10,\"completion_tokens\":38,\"total_tokens\":48,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0}}}",
    "response_status": 200,
    "prompt": "What is 2+2? Reply with just the number.",
    "prompt_tokens": 10,
    "completion_tokens": 38,
    "total_tokens": 48
  }
[Test] Replay record 667ee07ba3f1be2290d8b4cf5359885f survived restart
[Helper] Stopping port forwarding to envoy-gateway-system/envoy-default-semantic-router-ad1612c8
[Runner] ✅ Test router-replay-restart-recovery passed (39.314728063s)
[Runner] Running test: router-replay-session-list-filter
[Test] Router replay: session_id list filter
[Helper] Found service: envoy-default-semantic-router-ad1612c8 (matched by labels: gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=semantic-router in namespace: envoy-gateway-system)
[Helper] Starting port-forward to service envoy-gateway-system/envoy-default-semantic-router-ad1612c8 (39133:80)
[Helper] Found running pod: envoy-default-semantic-router-ad1612c8-78b6fcf8f8-mtx6b
Forwarding from 127.0.0.1:39133 -> 10080
Forwarding from [::1]:39133 -> 10080
[Helper] Port forwarding is ready
Handling connection for 39133
[Test] session_id="e2e_rs_1776786548002439665_a" list count=1
[Test] session_id="e2e_rs_1776786548002439665_b" list count=1
[Helper] Stopping port forwarding to envoy-gateway-system/envoy-default-semantic-router-ad1612c8
[Runner] ✅ Test router-replay-session-list-filter passed (6.05555439s)
[Runner] Running test: router-replay-session-turn-progression
[Test] Router replay: turn_index across two turns (same x-session-id)
[Helper] Found service: envoy-default-semantic-router-ad1612c8 (matched by labels: gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=semantic-router in namespace: envoy-gateway-system)
[Helper] Starting port-forward to service envoy-gateway-system/envoy-default-semantic-router-ad1612c8 (43207:80)
[Helper] Found running pod: envoy-default-semantic-router-ad1612c8-78b6fcf8f8-mtx6b
Forwarding from 127.0.0.1:43207 -> 10080
Forwarding from [::1]:43207 -> 10080
[Helper] Port forwarding is ready
Handling connection for 43207
[Test] session "e2e_turn_1776786554058478722" replay rows=2 turn_index min=0 max=1
[Helper] Stopping port forwarding to envoy-gateway-system/envoy-default-semantic-router-ad1612c8
[Runner] ✅ Test router-replay-session-turn-progression passed (6.048700686s)
================================================================================
TEST RESULTS
================================================================================
✅ PASSED - router-replay-restart-recovery (39.314728063s)
✅ PASSED - router-replay-session-list-filter (6.05555439s)
✅ PASSED - router-replay-session-turn-progression (6.048700686s)
================================================================================
Total: 3 | Passed: 3 | Failed: 0
================================================================================
```

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
