### PR TITLE
feat: support hierarchical projection composition and dependency ordering

### DIFF
--- a/dashboard/frontend/src/pages/ConfigPageProjectionsSection.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageProjectionsSection.tsx
@@ -196,7 +196,7 @@ export default function ConfigPageProjectionsSection({
       type: 'json',
       required: true,
       description:
-        'JSON array of { type, name, weight, value_source?, match?, miss? } objects. Supported value_source: "binary" (default), "confidence", "raw".',
+        'JSON array of { type, name, weight, value_source?, match?, miss? } objects. Supported value_source: "binary" (default), "confidence", "raw". Use type "projection" with value_source "score" to reference earlier projection scores, or value_source "confidence" to reference mapping output confidences.',
       placeholder:
         '[{"type":"embedding","name":"technical_support","weight":0.18,"value_source":"confidence"}]',
     },

--- a/src/semantic-router/pkg/classification/classifier_projections.go
+++ b/src/semantic-router/pkg/classification/classifier_projections.go
@@ -29,6 +29,7 @@ var projectionMatchAccessors = map[string]projectionMatchAccessor{
 	config.SignalTypeKB:            func(results *SignalResults) []string { return results.MatchedKBRules },
 	config.SignalTypeConversation:  func(results *SignalResults) []string { return results.MatchedConversationRules },
 	config.SignalTypeSessionMetric: func(results *SignalResults) []string { return results.MatchedSessionMetricRules },
+	config.SignalTypeProjection:    func(results *SignalResults) []string { return results.MatchedProjectionRules },
 }
 
 func (c *Classifier) applyProjections(results *SignalResults) *SignalResults {
@@ -46,24 +47,105 @@ func (c *Classifier) applyProjections(results *SignalResults) *SignalResults {
 		results.SignalConfidences = make(map[string]float64)
 	}
 
-	for _, score := range c.Config.Projections.Scores {
-		results.ProjectionScores[score.Name] = projectionScoreValue(score, results)
+	orderedScores := topologicalScoreOrder(c.Config.Projections.Scores, c.Config.Projections.Mappings)
+
+	mappingBySource := make(map[string][]config.ProjectionMapping, len(c.Config.Projections.Mappings))
+	for _, mapping := range c.Config.Projections.Mappings {
+		mappingBySource[mapping.Source] = append(mappingBySource[mapping.Source], mapping)
 	}
 
-	for _, mapping := range c.Config.Projections.Mappings {
-		scoreValue, ok := results.ProjectionScores[mapping.Source]
-		if !ok {
-			continue
+	for _, score := range orderedScores {
+		results.ProjectionScores[score.Name] = projectionScoreValue(score, results)
+
+		for _, mapping := range mappingBySource[score.Name] {
+			scoreValue := results.ProjectionScores[mapping.Source]
+			output, matched := matchProjectionOutput(mapping, scoreValue)
+			if !matched {
+				continue
+			}
+			results.MatchedProjectionRules = append(results.MatchedProjectionRules, output.Name)
+			results.SignalConfidences[signalConfidenceKey(config.SignalTypeProjection, output.Name)] = projectionOutputConfidence(mapping, output, scoreValue)
 		}
-		output, matched := matchProjectionOutput(mapping, scoreValue)
-		if !matched {
-			continue
-		}
-		results.MatchedProjectionRules = append(results.MatchedProjectionRules, output.Name)
-		results.SignalConfidences[signalConfidenceKey(config.SignalTypeProjection, output.Name)] = projectionOutputConfidence(mapping, output, scoreValue)
 	}
 
 	return results
+}
+
+func hasProjectionDependency(scores []config.ProjectionScore) bool {
+	for _, s := range scores {
+		for _, inp := range s.Inputs {
+			if strings.EqualFold(strings.TrimSpace(inp.Type), config.SignalTypeProjection) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func buildScoreAdjacency(scores []config.ProjectionScore, outputToSource map[string]string) map[string][]string {
+	adj := make(map[string][]string, len(scores))
+	for _, s := range scores {
+		for _, inp := range s.Inputs {
+			if !strings.EqualFold(strings.TrimSpace(inp.Type), config.SignalTypeProjection) {
+				continue
+			}
+			vs := strings.ToLower(strings.TrimSpace(inp.ValueSource))
+			if vs == "confidence" {
+				if src, ok := outputToSource[inp.Name]; ok {
+					adj[s.Name] = append(adj[s.Name], src)
+				}
+			} else {
+				adj[s.Name] = append(adj[s.Name], inp.Name)
+			}
+		}
+	}
+	return adj
+}
+
+func topologicalScoreOrder(scores []config.ProjectionScore, mappings []config.ProjectionMapping) []config.ProjectionScore {
+	if !hasProjectionDependency(scores) {
+		return scores
+	}
+
+	byName := make(map[string]config.ProjectionScore, len(scores))
+	for _, s := range scores {
+		byName[s.Name] = s
+	}
+
+	outputToSource := make(map[string]string)
+	for _, m := range mappings {
+		for _, out := range m.Outputs {
+			if out.Name != "" {
+				outputToSource[out.Name] = m.Source
+			}
+		}
+	}
+
+	adj := buildScoreAdjacency(scores, outputToSource)
+	state := make(map[string]int, len(scores))
+	ordered := make([]config.ProjectionScore, 0, len(scores))
+
+	var visit func(name string)
+	visit = func(name string) {
+		if state[name] != 0 {
+			return
+		}
+		state[name] = 1
+		for _, dep := range adj[name] {
+			if _, ok := byName[dep]; ok {
+				visit(dep)
+			}
+		}
+		if s, ok := byName[name]; ok {
+			ordered = append(ordered, s)
+		}
+	}
+
+	for _, s := range scores {
+		visit(s.Name)
+	}
+
+	return ordered
 }
 
 func projectionScoreValue(score config.ProjectionScore, results *SignalResults) float64 {
@@ -75,11 +157,15 @@ func projectionScoreValue(score config.ProjectionScore, results *SignalResults) 
 }
 
 func projectionInputValue(input config.ProjectionScoreInput, results *SignalResults) float64 {
-	if strings.EqualFold(strings.TrimSpace(input.Type), config.ProjectionInputKBMetric) {
+	normalizedType := strings.ToLower(strings.TrimSpace(input.Type))
+	if normalizedType == config.ProjectionInputKBMetric {
 		if results.KBMetricValues == nil {
 			return 0
 		}
 		return results.KBMetricValues[kbMetricKey(input.KB, input.Metric)]
+	}
+	if normalizedType == config.SignalTypeProjection {
+		return projectionInputProjectionValue(input, results)
 	}
 	switch strings.ToLower(strings.TrimSpace(input.ValueSource)) {
 	case "raw":
@@ -116,6 +202,22 @@ func projectionInputBinaryValue(input config.ProjectionScoreInput, results *Sign
 		return matchValue
 	}
 	return input.Miss
+}
+
+func projectionInputProjectionValue(input config.ProjectionScoreInput, results *SignalResults) float64 {
+	switch strings.ToLower(strings.TrimSpace(input.ValueSource)) {
+	case "confidence":
+		if results.SignalConfidences == nil {
+			return 0
+		}
+		key := signalConfidenceKey(config.SignalTypeProjection, input.Name)
+		return results.SignalConfidences[key]
+	default:
+		if results.ProjectionScores == nil {
+			return 0
+		}
+		return results.ProjectionScores[input.Name]
+	}
 }
 
 func kbMetricKey(kbName, metric string) string {

--- a/src/semantic-router/pkg/classification/classifier_projections_test.go
+++ b/src/semantic-router/pkg/classification/classifier_projections_test.go
@@ -124,13 +124,13 @@ func TestProjectionInputValueRawReadsSignalValues(t *testing.T) {
 						Method: "weighted_sum",
 						Inputs: []config.ProjectionScoreInput{
 							{
-								Type:        "structure",
+								Type:        config.SignalTypeStructure,
 								Name:        "many_questions",
 								Weight:      0.5,
 								ValueSource: "raw",
 							},
 							{
-								Type:        "conversation",
+								Type:        config.SignalTypeConversation,
 								Name:        "tool_loop_deep",
 								Weight:      0.3,
 								ValueSource: "raw",
@@ -172,6 +172,66 @@ func TestProjectionInputValueRawReadsSignalValues(t *testing.T) {
 	}
 }
 
+func TestApplyProjectionsScoreConsumesEarlierScore(t *testing.T) {
+	classifier := &Classifier{
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				Projections: config.Projections{
+					Scores: []config.ProjectionScore{
+						{
+							Name:   "difficulty_score",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeKeyword, Name: "markers", Weight: 1.0},
+							},
+						},
+						{
+							Name:   "verification_pressure",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeProjection, Name: "difficulty_score", Weight: 0.5, ValueSource: "score"},
+								{Type: config.SignalTypeFactCheck, Name: "needs_check", Weight: 0.5},
+							},
+						},
+					},
+					Mappings: []config.ProjectionMapping{
+						{
+							Name:   "pressure_band",
+							Source: "verification_pressure",
+							Method: "threshold_bands",
+							Outputs: []config.ProjectionMappingOutput{
+								{Name: "low_pressure", LT: float64Ptr(0.5)},
+								{Name: "high_pressure", GTE: float64Ptr(0.5)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := &SignalResults{
+		MatchedKeywordRules:   []string{"markers"},
+		MatchedFactCheckRules: []string{"needs_check"},
+	}
+
+	got := classifier.applyProjections(results)
+	if got == nil {
+		t.Fatal("applyProjections returned nil")
+	}
+	diffScore := got.ProjectionScores["difficulty_score"]
+	if diffScore != 1.0 {
+		t.Fatalf("difficulty_score = %.3f, want 1.0", diffScore)
+	}
+	vpScore := got.ProjectionScores["verification_pressure"]
+	if vpScore != 1.0 {
+		t.Fatalf("verification_pressure = %.3f, want 1.0 (0.5*1.0 + 0.5*1.0)", vpScore)
+	}
+	if len(got.MatchedProjectionRules) != 1 || got.MatchedProjectionRules[0] != "high_pressure" {
+		t.Fatalf("matched projection rules = %v, want [high_pressure]", got.MatchedProjectionRules)
+	}
+}
+
 func TestProjectionInputValueRawReturnsZeroWhenMissing(t *testing.T) {
 	classifier := &Classifier{
 		Config: &config.RouterConfig{
@@ -181,7 +241,7 @@ func TestProjectionInputValueRawReturnsZeroWhenMissing(t *testing.T) {
 						Name:   "absent_score",
 						Method: "weighted_sum",
 						Inputs: []config.ProjectionScoreInput{{
-							Type:        "structure",
+							Type:        config.SignalTypeStructure,
 							Name:        "nonexistent_signal",
 							Weight:      1.0,
 							ValueSource: "raw",
@@ -211,9 +271,71 @@ func TestProjectionInputValueRawReturnsZeroWhenMissing(t *testing.T) {
 	}
 }
 
+func TestApplyProjectionsScoreConsumesConfidence(t *testing.T) {
+	classifier := &Classifier{
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				Projections: config.Projections{
+					Scores: []config.ProjectionScore{
+						{
+							Name:   "base_score",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeKeyword, Name: "k1", Weight: 1.0},
+							},
+						},
+						{
+							Name:   "combo_score",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeProjection, Name: "base_band_high", Weight: 1.0, ValueSource: "confidence"},
+							},
+						},
+					},
+					Mappings: []config.ProjectionMapping{
+						{
+							Name:   "base_mapping",
+							Source: "base_score",
+							Method: "threshold_bands",
+							Outputs: []config.ProjectionMappingOutput{
+								{Name: "base_band_high", GTE: float64Ptr(0.5)},
+							},
+						},
+						{
+							Name:   "combo_mapping",
+							Source: "combo_score",
+							Method: "threshold_bands",
+							Outputs: []config.ProjectionMappingOutput{
+								{Name: "combo_high", GTE: float64Ptr(0.1)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := &SignalResults{
+		MatchedKeywordRules: []string{"k1"},
+	}
+
+	got := classifier.applyProjections(results)
+	if got == nil {
+		t.Fatal("applyProjections returned nil")
+	}
+	confidence, ok := got.SignalConfidences["projection:base_band_high"]
+	if !ok || confidence <= 0 {
+		t.Fatalf("expected positive confidence for base_band_high, got %.3f (ok=%v)", confidence, ok)
+	}
+	comboScore := got.ProjectionScores["combo_score"]
+	if comboScore <= 0 {
+		t.Fatalf("combo_score = %.3f, want positive (fed by base_band_high confidence)", comboScore)
+	}
+}
+
 func TestProjectionInputValueRawReturnsZeroWhenNilMap(t *testing.T) {
 	result := projectionInputValue(config.ProjectionScoreInput{
-		Type:        "structure",
+		Type:        config.SignalTypeStructure,
 		Name:        "any",
 		Weight:      1.0,
 		ValueSource: "raw",
@@ -234,7 +356,7 @@ func TestProjectionMixedRawAndConfidenceInputs(t *testing.T) {
 						Method: "weighted_sum",
 						Inputs: []config.ProjectionScoreInput{
 							{
-								Type:        "structure",
+								Type:        config.SignalTypeStructure,
 								Name:        "many_questions",
 								Weight:      0.4,
 								ValueSource: "raw",
@@ -287,7 +409,7 @@ func TestProjectionMixedRawAndConfidenceInputs(t *testing.T) {
 
 func TestProjectionInputValueRawNegativeValues(t *testing.T) {
 	result := projectionInputValue(config.ProjectionScoreInput{
-		Type:        "structure",
+		Type:        config.SignalTypeStructure,
 		Name:        "neg_signal",
 		Weight:      1.0,
 		ValueSource: "raw",
@@ -322,7 +444,7 @@ func TestProjectionInputValueRawCaseInsensitive(t *testing.T) {
 
 func TestProjectionInputValueRawExplicitZero(t *testing.T) {
 	result := projectionInputValue(config.ProjectionScoreInput{
-		Type:        "structure",
+		Type:        config.SignalTypeStructure,
 		Name:        "zero_signal",
 		Weight:      1.0,
 		ValueSource: "raw",
@@ -339,7 +461,7 @@ func TestProjectionInputValueRawExplicitZero(t *testing.T) {
 
 func TestProjectionInputValueRawLargeValues(t *testing.T) {
 	result := projectionInputValue(config.ProjectionScoreInput{
-		Type:        "structure",
+		Type:        config.SignalTypeStructure,
 		Name:        "token_count",
 		Weight:      1.0,
 		ValueSource: "raw",
@@ -351,6 +473,150 @@ func TestProjectionInputValueRawLargeValues(t *testing.T) {
 
 	if result != 128000.0 {
 		t.Fatalf("expected 128000 for large raw value, got %.1f", result)
+	}
+}
+
+func TestApplyProjectionsThreeLevelChain(t *testing.T) {
+	classifier := &Classifier{
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				Projections: config.Projections{
+					Scores: []config.ProjectionScore{
+						{
+							Name:   "level_1",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeKeyword, Name: "k1", Weight: 1.0},
+							},
+						},
+						{
+							Name:   "level_2",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeProjection, Name: "level_1", Weight: 0.5, ValueSource: "score"},
+							},
+						},
+						{
+							Name:   "level_3",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeProjection, Name: "level_2", Weight: 0.5, ValueSource: "score"},
+							},
+						},
+					},
+					Mappings: []config.ProjectionMapping{
+						{
+							Name:   "final_band",
+							Source: "level_3",
+							Method: "threshold_bands",
+							Outputs: []config.ProjectionMappingOutput{
+								{Name: "final_high", GTE: float64Ptr(0.1)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := &SignalResults{
+		MatchedKeywordRules: []string{"k1"},
+	}
+
+	got := classifier.applyProjections(results)
+	if got == nil {
+		t.Fatal("applyProjections returned nil")
+	}
+	if got.ProjectionScores["level_1"] != 1.0 {
+		t.Fatalf("level_1 = %.3f, want 1.0", got.ProjectionScores["level_1"])
+	}
+	if got.ProjectionScores["level_2"] != 0.5 {
+		t.Fatalf("level_2 = %.3f, want 0.5", got.ProjectionScores["level_2"])
+	}
+	if got.ProjectionScores["level_3"] != 0.25 {
+		t.Fatalf("level_3 = %.3f, want 0.25", got.ProjectionScores["level_3"])
+	}
+}
+
+func TestTopologicalScoreOrderIndependentOfDeclaration(t *testing.T) {
+	scores := []config.ProjectionScore{
+		{
+			Name:   "derived",
+			Method: "weighted_sum",
+			Inputs: []config.ProjectionScoreInput{
+				{Type: config.SignalTypeProjection, Name: "base", Weight: 1.0, ValueSource: "score"},
+			},
+		},
+		{
+			Name:   "base",
+			Method: "weighted_sum",
+			Inputs: []config.ProjectionScoreInput{
+				{Type: config.SignalTypeKeyword, Name: "k1", Weight: 1.0},
+			},
+		},
+	}
+
+	ordered := topologicalScoreOrder(scores, nil)
+	if len(ordered) != 2 {
+		t.Fatalf("expected 2 scores, got %d", len(ordered))
+	}
+	if ordered[0].Name != "base" {
+		t.Fatalf("expected base first in topological order, got %s", ordered[0].Name)
+	}
+	if ordered[1].Name != "derived" {
+		t.Fatalf("expected derived second in topological order, got %s", ordered[1].Name)
+	}
+}
+
+func TestApplyProjectionsReverseDeclarationOrder(t *testing.T) {
+	classifier := &Classifier{
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				Projections: config.Projections{
+					Scores: []config.ProjectionScore{
+						{
+							Name:   "derived",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeProjection, Name: "base", Weight: 1.0, ValueSource: "score"},
+							},
+						},
+						{
+							Name:   "base",
+							Method: "weighted_sum",
+							Inputs: []config.ProjectionScoreInput{
+								{Type: config.SignalTypeKeyword, Name: "k1", Weight: 1.0},
+							},
+						},
+					},
+					Mappings: []config.ProjectionMapping{
+						{
+							Name:   "band",
+							Source: "derived",
+							Method: "threshold_bands",
+							Outputs: []config.ProjectionMappingOutput{
+								{Name: "band_high", GTE: float64Ptr(0.5)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results := &SignalResults{MatchedKeywordRules: []string{"k1"}}
+	got := classifier.applyProjections(results)
+	if got == nil {
+		t.Fatal("applyProjections returned nil")
+	}
+	if got.ProjectionScores["base"] != 1.0 {
+		t.Fatalf("base = %.3f, want 1.0", got.ProjectionScores["base"])
+	}
+	if got.ProjectionScores["derived"] != 1.0 {
+		t.Fatalf("derived = %.3f, want 1.0", got.ProjectionScores["derived"])
+	}
+	if len(got.MatchedProjectionRules) != 1 || got.MatchedProjectionRules[0] != "band_high" {
+		t.Fatalf("matched = %v, want [band_high]", got.MatchedProjectionRules)
 	}
 }
 

--- a/src/semantic-router/pkg/classification/classifier_signal_eval.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_eval.go
@@ -175,17 +175,42 @@ func (c *Classifier) expandProjectionDependencies(usedSignals map[string]bool) {
 		if !ok {
 			continue
 		}
-		score, ok := scoreByName[scoreName]
-		if !ok {
+		c.expandScoreInputs(scoreName, scoreByName, sourceByOutput, usedSignals, make(map[string]bool))
+	}
+}
+
+func (c *Classifier) expandScoreInputs(
+	scoreName string,
+	scoreByName map[string]config.ProjectionScore,
+	sourceByOutput map[string]string,
+	usedSignals map[string]bool,
+	visited map[string]bool,
+) {
+	if visited[scoreName] {
+		return
+	}
+	visited[scoreName] = true
+
+	score, ok := scoreByName[scoreName]
+	if !ok {
+		return
+	}
+	for _, input := range score.Inputs {
+		if strings.EqualFold(input.Type, config.ProjectionInputKBMetric) {
+			usedSignals[strings.ToLower(config.SignalTypeKB+":"+input.KB)] = true
 			continue
 		}
-		for _, input := range score.Inputs {
-			if strings.EqualFold(input.Type, config.ProjectionInputKBMetric) {
-				usedSignals[strings.ToLower(config.SignalTypeKB+":"+input.KB)] = true
-				continue
+		if strings.EqualFold(input.Type, config.SignalTypeProjection) {
+			dep := input.Name
+			if strings.EqualFold(strings.TrimSpace(input.ValueSource), "confidence") {
+				if src, ok := sourceByOutput[strings.ToLower(dep)]; ok {
+					dep = src
+				}
 			}
-			usedSignals[strings.ToLower(input.Type+":"+input.Name)] = true
+			c.expandScoreInputs(dep, scoreByName, sourceByOutput, usedSignals, visited)
+			continue
 		}
+		usedSignals[strings.ToLower(input.Type+":"+input.Name)] = true
 	}
 }
 

--- a/src/semantic-router/pkg/config/validator_projection.go
+++ b/src/semantic-router/pkg/config/validator_projection.go
@@ -17,6 +17,10 @@ func validateProjectionContracts(cfg *RouterConfig) error {
 	if err != nil {
 		return err
 	}
+	err = validateProjectionScoreDependencyOrder(cfg.Projections.Scores, cfg.Projections.Mappings)
+	if err != nil {
+		return err
+	}
 	for _, decision := range cfg.Decisions {
 		if err := validateDecisionProjectionReferences(decision.Name, &decision.Rules, outputNames); err != nil {
 			return err
@@ -145,12 +149,116 @@ func containsProjectionMember(members []string, target string) bool {
 func validateProjectionScores(cfg *RouterConfig) (map[string]struct{}, error) {
 	names := make(map[string]struct{}, len(cfg.Projections.Scores))
 	declaredSignals := projectionDeclaredSignals(cfg)
+	outputToSource := projectionOutputToSourceScore(cfg.Projections.Mappings)
 	for _, score := range cfg.Projections.Scores {
-		if err := validateProjectionScore(score, names, declaredSignals, cfg); err != nil {
+		if err := validateProjectionScore(score, names, declaredSignals, cfg, outputToSource); err != nil {
 			return nil, err
 		}
 	}
 	return names, nil
+}
+
+func projectionOutputToSourceScore(mappings []ProjectionMapping) map[string]string {
+	m := make(map[string]string)
+	for _, mapping := range mappings {
+		for _, output := range mapping.Outputs {
+			if output.Name != "" {
+				m[output.Name] = mapping.Source
+			}
+		}
+	}
+	return m
+}
+
+func buildProjectionScoreAdj(scores []ProjectionScore, outputToSource map[string]string) map[string][]string {
+	adj := make(map[string][]string, len(scores))
+	for _, score := range scores {
+		for _, input := range score.Inputs {
+			if !strings.EqualFold(input.Type, SignalTypeProjection) {
+				continue
+			}
+			vs := strings.ToLower(strings.TrimSpace(input.ValueSource))
+			if vs == "confidence" {
+				if src, ok := outputToSource[input.Name]; ok {
+					adj[score.Name] = append(adj[score.Name], src)
+				}
+			} else {
+				adj[score.Name] = append(adj[score.Name], input.Name)
+			}
+		}
+	}
+	return adj
+}
+
+func formatCyclePath(path []string, name string) string {
+	cycle := make([]string, len(path)+1)
+	copy(cycle, path)
+	cycle[len(path)] = name
+	for i, n := range cycle {
+		if n == name {
+			return strings.Join(cycle[i:], " -> ")
+		}
+	}
+	return strings.Join(cycle, " -> ")
+}
+
+func validateProjectionScoreDependencyOrder(scores []ProjectionScore, mappings []ProjectionMapping) error {
+	nameIndex := make(map[string]int, len(scores))
+	for i, s := range scores {
+		nameIndex[s.Name] = i
+	}
+
+	outputToSource := projectionOutputToSourceScore(mappings)
+	adj := buildProjectionScoreAdj(scores, outputToSource)
+	if len(adj) == 0 {
+		return nil
+	}
+
+	const (
+		unvisited = 0
+		visiting  = 1
+		visited   = 2
+	)
+	state := make(map[string]int, len(scores))
+	var path []string
+
+	var visit func(name string) error
+	visit = func(name string) error {
+		if state[name] == visited {
+			return nil
+		}
+		if state[name] == visiting {
+			return fmt.Errorf(
+				"routing.projections.scores: dependency cycle detected: %s",
+				formatCyclePath(path, name),
+			)
+		}
+		state[name] = visiting
+		path = append(path, name)
+		for _, dep := range adj[name] {
+			if _, ok := nameIndex[dep]; !ok {
+				return fmt.Errorf(
+					"routing.projections.scores[%q]: projection input references undefined score %q",
+					name, dep,
+				)
+			}
+			if err := visit(dep); err != nil {
+				return err
+			}
+		}
+		path = path[:len(path)-1]
+		state[name] = visited
+		return nil
+	}
+
+	for _, score := range scores {
+		if state[score.Name] == unvisited {
+			if err := visit(score.Name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func validateProjectionScore(
@@ -158,6 +266,7 @@ func validateProjectionScore(
 	names map[string]struct{},
 	declaredSignals map[string]map[string]struct{},
 	cfg *RouterConfig,
+	outputToSource map[string]string,
 ) error {
 	if score.Name == "" {
 		return fmt.Errorf("routing.projections.scores: name cannot be empty")
@@ -173,7 +282,7 @@ func validateProjectionScore(
 		return fmt.Errorf("routing.projections.scores[%q]: inputs cannot be empty", score.Name)
 	}
 	for _, input := range score.Inputs {
-		if err := validateProjectionScoreInput(score.Name, input, declaredSignals, cfg); err != nil {
+		if err := validateProjectionScoreInput(score.Name, input, declaredSignals, cfg, outputToSource); err != nil {
 			return err
 		}
 	}
@@ -185,6 +294,7 @@ func validateProjectionScoreInput(
 	input ProjectionScoreInput,
 	declaredSignals map[string]map[string]struct{},
 	cfg *RouterConfig,
+	outputToSource map[string]string,
 ) error {
 	if !isProjectionInputTypeSupported(input.Type) {
 		return fmt.Errorf(
@@ -198,6 +308,9 @@ func validateProjectionScoreInput(
 	if strings.EqualFold(input.Type, ProjectionInputKBMetric) {
 		return validateKBMetricProjectionInput(cfg, scoreName, input)
 	}
+	if strings.EqualFold(input.Type, SignalTypeProjection) {
+		return validateProjectionInputProjectionRef(scoreName, input, outputToSource)
+	}
 	if !projectionInputDeclared(declaredSignals, input.Type, input.Name) {
 		return fmt.Errorf(
 			"routing.projections.scores[%q]: input %s(%q) is not declared in routing.signals",
@@ -207,6 +320,35 @@ func validateProjectionScoreInput(
 		)
 	}
 	return validateProjectionInputValueSource(scoreName, input)
+}
+
+func validateProjectionInputProjectionRef(scoreName string, input ProjectionScoreInput, outputToSource map[string]string) error {
+	if input.Name == "" {
+		return fmt.Errorf(
+			"routing.projections.scores[%q]: projection input requires a name referencing a declared score or mapping output",
+			scoreName,
+		)
+	}
+	switch strings.ToLower(strings.TrimSpace(input.ValueSource)) {
+	case "", "score":
+		return nil
+	case "confidence":
+		if _, ok := outputToSource[input.Name]; !ok {
+			return fmt.Errorf(
+				"routing.projections.scores[%q]: projection input %q with value_source \"confidence\" references undefined mapping output",
+				scoreName,
+				input.Name,
+			)
+		}
+		return nil
+	default:
+		return fmt.Errorf(
+			"routing.projections.scores[%q]: projection input %q has unsupported value_source %q (supported: score, confidence)",
+			scoreName,
+			input.Name,
+			input.ValueSource,
+		)
+	}
 }
 
 func validateProjectionInputValueSource(scoreName string, input ProjectionScoreInput) error {
@@ -244,7 +386,8 @@ func isProjectionInputTypeSupported(signalType string) bool {
 		SignalTypeKB,
 		SignalTypeConversation,
 		SignalTypeSessionMetric,
-		ProjectionInputKBMetric:
+		ProjectionInputKBMetric,
+		SignalTypeProjection:
 		return true
 	default:
 		return false

--- a/src/semantic-router/pkg/config/validator_projection_test.go
+++ b/src/semantic-router/pkg/config/validator_projection_test.go
@@ -130,6 +130,164 @@ func TestValidateProjectionInputValueSourceRejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestValidateProjectionScoreDependencyOrder_ValidChain(t *testing.T) {
+	scores := []ProjectionScore{
+		{
+			Name:   "base_score",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{{Type: "keyword", Name: "k1", Weight: 1.0}},
+		},
+		{
+			Name:   "derived_score",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{
+				{Type: SignalTypeProjection, Name: "base_score", Weight: 0.8, ValueSource: "score"},
+			},
+		},
+	}
+	if err := validateProjectionScoreDependencyOrder(scores, nil); err != nil {
+		t.Fatalf("expected no error for valid chain, got: %v", err)
+	}
+}
+
+func TestValidateProjectionScoreDependencyOrder_RejectsCycle(t *testing.T) {
+	scores := []ProjectionScore{
+		{
+			Name:   "alpha",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{
+				{Type: SignalTypeProjection, Name: "beta", Weight: 1.0},
+			},
+		},
+		{
+			Name:   "beta",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{
+				{Type: SignalTypeProjection, Name: "alpha", Weight: 1.0},
+			},
+		},
+	}
+	err := validateProjectionScoreDependencyOrder(scores, nil)
+	if err == nil {
+		t.Fatal("expected cycle detection error")
+	}
+	if !strings.Contains(err.Error(), "dependency cycle") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateProjectionScoreDependencyOrder_RejectsSelfRef(t *testing.T) {
+	scores := []ProjectionScore{
+		{
+			Name:   "self_loop",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{
+				{Type: SignalTypeProjection, Name: "self_loop", Weight: 1.0},
+			},
+		},
+	}
+	err := validateProjectionScoreDependencyOrder(scores, nil)
+	if err == nil {
+		t.Fatal("expected self-reference cycle error")
+	}
+	if !strings.Contains(err.Error(), "dependency cycle") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateProjectionScoreDependencyOrder_RejectsUndefined(t *testing.T) {
+	scores := []ProjectionScore{
+		{
+			Name:   "uses_missing",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{
+				{Type: SignalTypeProjection, Name: "nonexistent", Weight: 1.0},
+			},
+		},
+	}
+	err := validateProjectionScoreDependencyOrder(scores, nil)
+	if err == nil {
+		t.Fatal("expected undefined reference error")
+	}
+	if !strings.Contains(err.Error(), "undefined score") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateProjectionScoreDependencyOrder_ThreeNodeCycle(t *testing.T) {
+	scores := []ProjectionScore{
+		{Name: "a", Method: "weighted_sum", Inputs: []ProjectionScoreInput{
+			{Type: SignalTypeProjection, Name: "b", Weight: 1.0},
+		}},
+		{Name: "b", Method: "weighted_sum", Inputs: []ProjectionScoreInput{
+			{Type: SignalTypeProjection, Name: "c", Weight: 1.0},
+		}},
+		{Name: "c", Method: "weighted_sum", Inputs: []ProjectionScoreInput{
+			{Type: SignalTypeProjection, Name: "a", Weight: 1.0},
+		}},
+	}
+	err := validateProjectionScoreDependencyOrder(scores, nil)
+	if err == nil {
+		t.Fatal("expected cycle detection error for 3-node cycle")
+	}
+	if !strings.Contains(err.Error(), "dependency cycle") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateProjectionInputProjectionRef_ValidScoreSource(t *testing.T) {
+	err := validateProjectionInputProjectionRef("test_score", ProjectionScoreInput{
+		Type: SignalTypeProjection, Name: "other_score", Weight: 0.5, ValueSource: "score",
+	}, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateProjectionInputProjectionRef_ValidConfidenceSource(t *testing.T) {
+	outputToSource := map[string]string{"other_output": "some_score"}
+	err := validateProjectionInputProjectionRef("test_score", ProjectionScoreInput{
+		Type: SignalTypeProjection, Name: "other_output", Weight: 0.5, ValueSource: "confidence",
+	}, outputToSource)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateProjectionInputProjectionRef_ConfidenceRejectsUndefinedOutput(t *testing.T) {
+	outputToSource := map[string]string{"known_output": "some_score"}
+	err := validateProjectionInputProjectionRef("test_score", ProjectionScoreInput{
+		Type: SignalTypeProjection, Name: "unknown_output", Weight: 0.5, ValueSource: "confidence",
+	}, outputToSource)
+	if err == nil {
+		t.Fatal("expected error for undefined mapping output")
+	}
+	if !strings.Contains(err.Error(), "undefined mapping output") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateProjectionInputProjectionRef_EmptyName(t *testing.T) {
+	err := validateProjectionInputProjectionRef("test_score", ProjectionScoreInput{
+		Type: SignalTypeProjection, Name: "", Weight: 0.5,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty projection input name")
+	}
+}
+
+func TestValidateProjectionInputProjectionRef_InvalidValueSource(t *testing.T) {
+	err := validateProjectionInputProjectionRef("test_score", ProjectionScoreInput{
+		Type: SignalTypeProjection, Name: "other", Weight: 0.5, ValueSource: "invalid",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid value_source")
+	}
+	if !strings.Contains(err.Error(), "unsupported value_source") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseRoutingYAMLBytesAcceptsRawValueSource(t *testing.T) {
 	yaml := []byte(`
 routing:
@@ -175,3 +333,199 @@ routing:
 		t.Fatalf("value_source = %q, want %q", cfg.Projections.Scores[0].Inputs[0].ValueSource, "raw")
 	}
 }
+
+func TestIsProjectionInputTypeSupported_ConversationAndProjection(t *testing.T) {
+	for _, typ := range []string{SignalTypeConversation, SignalTypeProjection} {
+		if !isProjectionInputTypeSupported(typ) {
+			t.Fatalf("expected supported input type %q", typ)
+		}
+	}
+}
+
+func TestParseRoutingYAMLBytesAcceptsProjectionToProjectionRef(t *testing.T) {
+	yaml := []byte(fmt.Sprintf(`
+routing:
+  signals:
+    keywords:
+      - name: reasoning_markers
+        operator: OR
+        keywords: ["reason carefully"]
+  projections:
+    scores:
+      - name: base_score
+        method: weighted_sum
+        inputs:
+          - type: keyword
+            name: reasoning_markers
+            weight: 0.6
+      - name: derived_score
+        method: weighted_sum
+        inputs:
+          - type: %s
+            name: base_score
+            value_source: score
+            weight: 0.8
+    mappings:
+      - name: derived_band
+        source: derived_score
+        method: threshold_bands
+        outputs:
+          - name: high_derived
+            gte: 0.5
+  decisions:
+    - name: test_route
+      rules:
+        operator: AND
+        conditions:
+          - type: projection
+            name: high_derived
+      modelRefs:
+        - model: test-model
+`, SignalTypeProjection))
+
+	cfg, err := ParseRoutingYAMLBytes(yaml)
+	if err != nil {
+		t.Fatalf("expected valid config, got error: %v", err)
+	}
+	if len(cfg.Projections.Scores) != 2 {
+		t.Fatalf("expected 2 scores, got %d", len(cfg.Projections.Scores))
+	}
+}
+
+func TestParseRoutingYAMLBytesAcceptsConfidenceProjectionRef(t *testing.T) {
+	yaml := []byte(`
+routing:
+  signals:
+    keywords:
+      - name: reasoning_markers
+        operator: OR
+        keywords: ["reason carefully"]
+  projections:
+    scores:
+      - name: base_score
+        method: weighted_sum
+        inputs:
+          - type: keyword
+            name: reasoning_markers
+            weight: 0.6
+      - name: composite_score
+        method: weighted_sum
+        inputs:
+          - type: projection
+            name: high_base
+            value_source: confidence
+            weight: 0.7
+    mappings:
+      - name: base_band
+        source: base_score
+        method: threshold_bands
+        outputs:
+          - name: high_base
+            gte: 0.5
+      - name: composite_band
+        source: composite_score
+        method: threshold_bands
+        outputs:
+          - name: high_composite
+            gte: 0.3
+  decisions:
+    - name: test_route
+      rules:
+        operator: AND
+        conditions:
+          - type: projection
+            name: high_composite
+      modelRefs:
+        - model: test-model
+`)
+
+	cfg, err := ParseRoutingYAMLBytes(yaml)
+	if err != nil {
+		t.Fatalf("expected valid config with confidence projection ref, got error: %v", err)
+	}
+	if len(cfg.Projections.Scores) != 2 {
+		t.Fatalf("expected 2 scores, got %d", len(cfg.Projections.Scores))
+	}
+}
+
+func TestParseRoutingYAMLBytesRejectsUndefinedConfidenceOutput(t *testing.T) {
+	yaml := []byte(`
+routing:
+  signals:
+    keywords:
+      - name: reasoning_markers
+        operator: OR
+        keywords: ["reason carefully"]
+  projections:
+    scores:
+      - name: base_score
+        method: weighted_sum
+        inputs:
+          - type: keyword
+            name: reasoning_markers
+            weight: 0.6
+      - name: composite_score
+        method: weighted_sum
+        inputs:
+          - type: projection
+            name: nonexistent_output
+            value_source: confidence
+            weight: 0.7
+    mappings:
+      - name: base_band
+        source: base_score
+        method: threshold_bands
+        outputs:
+          - name: high_base
+            gte: 0.5
+  decisions:
+    - name: test_route
+      rules:
+        operator: AND
+        conditions:
+          - type: projection
+            name: high_base
+      modelRefs:
+        - model: test-model
+`)
+
+	_, err := ParseRoutingYAMLBytes(yaml)
+	if err == nil {
+		t.Fatal("expected error for undefined confidence output reference")
+	}
+	if !strings.Contains(err.Error(), "undefined mapping output") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateProjectionScoreDependencyOrder_ConfidenceResolvesToSourceScore(t *testing.T) {
+	scores := []ProjectionScore{
+		{
+			Name:   "base_score",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{{Type: "keyword", Name: "k1", Weight: 1.0}},
+		},
+		{
+			Name:   "derived_score",
+			Method: "weighted_sum",
+			Inputs: []ProjectionScoreInput{
+				{Type: SignalTypeProjection, Name: "high_band", Weight: 0.8, ValueSource: "confidence"},
+			},
+		},
+	}
+	mappings := []ProjectionMapping{
+		{
+			Name:   "base_mapping",
+			Source: "base_score",
+			Method: "threshold_bands",
+			Outputs: []ProjectionMappingOutput{
+				{Name: "high_band", GTE: float64Ptr(0.5)},
+			},
+		},
+	}
+	if err := validateProjectionScoreDependencyOrder(scores, mappings); err != nil {
+		t.Fatalf("expected no error for confidence ref resolving to valid source score, got: %v", err)
+	}
+}
+
+func float64Ptr(v float64) *float64 { return &v }

--- a/src/semantic-router/pkg/dsl/validator_conflicts.go
+++ b/src/semantic-router/pkg/dsl/validator_conflicts.go
@@ -518,8 +518,17 @@ func (v *Validator) checkProjections() {
 			continue
 		}
 		scoreNames[score.Name] = true
-		v.checkProjectionScore(score)
 	}
+	validated := make(map[string]bool, len(scoreNames))
+	for _, score := range v.prog.ProjectionScores {
+		if score.Name == "" || !scoreNames[score.Name] || validated[score.Name] {
+			continue
+		}
+		validated[score.Name] = true
+		v.checkProjectionScore(score, scoreNames)
+	}
+
+	v.checkProjectionScoreCycles()
 
 	outputNames := make(map[string]bool)
 	for _, mapping := range v.prog.ProjectionMappings {
@@ -531,7 +540,7 @@ func (v *Validator) checkProjections() {
 	}
 }
 
-func (v *Validator) checkProjectionScore(score *ProjectionScoreDecl) {
+func (v *Validator) checkProjectionScore(score *ProjectionScoreDecl, scoreNames map[string]bool) {
 	context := fmt.Sprintf("PROJECTION score %s", score.Name)
 	if score.Method == "" {
 		score.Method = "weighted_sum"
@@ -550,11 +559,35 @@ func (v *Validator) checkProjectionScore(score *ProjectionScoreDecl) {
 	}
 
 	for _, input := range score.Inputs {
-		v.checkProjectionScoreInput(context, score.Pos, input)
+		v.checkProjectionScoreInput(context, score.Pos, input, scoreNames)
 	}
 }
 
-func (v *Validator) checkProjectionScoreInput(context string, pos Position, input *ProjectionScoreInputDecl) {
+func (v *Validator) checkProjectionScoreInputProjectionRef(context string, pos Position, input *ProjectionScoreInputDecl, scoreNames map[string]bool) {
+	if input.SignalName == "" {
+		v.addDiag(DiagConstraint, pos,
+			fmt.Sprintf("%s: projection input requires a name referencing a declared score or mapping output", context), nil)
+		return
+	}
+	switch input.ValueSource {
+	case "", "score":
+		if !scoreNames[input.SignalName] {
+			v.addDiag(DiagWarning, pos,
+				fmt.Sprintf("%s: projection input %q references undeclared score", context, input.SignalName), nil)
+		}
+	case "confidence":
+		if !v.isProjectionOutputDefined(input.SignalName) {
+			v.addDiag(DiagWarning, pos,
+				fmt.Sprintf("%s: projection input %q with value_source \"confidence\" references undeclared mapping output", context, input.SignalName), nil)
+		}
+	default:
+		v.addDiag(DiagConstraint, pos,
+			fmt.Sprintf("%s: projection input %q has unsupported value_source %q (supported: score, confidence)",
+				context, input.SignalName, input.ValueSource), nil)
+	}
+}
+
+func (v *Validator) checkProjectionScoreInput(context string, pos Position, input *ProjectionScoreInputDecl, scoreNames map[string]bool) {
 	if input == nil {
 		return
 	}
@@ -571,6 +604,10 @@ func (v *Validator) checkProjectionScoreInput(context string, pos Position, inpu
 			),
 			nil,
 		)
+		return
+	}
+	if strings.EqualFold(input.SignalType, config.SignalTypeProjection) {
+		v.checkProjectionScoreInputProjectionRef(context, pos, input, scoreNames)
 		return
 	}
 	if !v.isSignalDefined(input.SignalType, input.SignalName) {
@@ -618,7 +655,8 @@ func isProjectionInputTypeSupported(signalType string) bool {
 		config.SignalTypePII,
 		config.SignalTypeKB,
 		config.SignalTypeSessionMetric,
-		config.ProjectionInputKBMetric:
+		config.ProjectionInputKBMetric,
+		config.SignalTypeProjection:
 		return true
 	default:
 		return false

--- a/src/semantic-router/pkg/dsl/validator_projection_deps.go
+++ b/src/semantic-router/pkg/dsl/validator_projection_deps.go
@@ -1,0 +1,113 @@
+package dsl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func dslFormatCyclePath(path []string, name string) string {
+	cycle := make([]string, len(path)+1)
+	copy(cycle, path)
+	cycle[len(path)] = name
+	for i, n := range cycle {
+		if n == name {
+			return strings.Join(cycle[i:], " -> ")
+		}
+	}
+	return strings.Join(cycle, " -> ")
+}
+
+func (v *Validator) dslOutputToSourceScore() map[string]string {
+	m := make(map[string]string, len(v.prog.ProjectionMappings))
+	for _, mapping := range v.prog.ProjectionMappings {
+		for _, output := range mapping.Outputs {
+			if output != nil && output.Name != "" {
+				m[output.Name] = mapping.Source
+			}
+		}
+	}
+	return m
+}
+
+func (v *Validator) isProjectionOutputDefined(name string) bool {
+	for _, mapping := range v.prog.ProjectionMappings {
+		for _, output := range mapping.Outputs {
+			if output != nil && output.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func buildDSLScoreCycleAdj(
+	scores []*ProjectionScoreDecl,
+	outputToSource map[string]string,
+) (map[string][]string, map[string]Position) {
+	adj := make(map[string][]string, len(scores))
+	posMap := make(map[string]Position, len(scores))
+	for _, score := range scores {
+		posMap[score.Name] = score.Pos
+		for _, input := range score.Inputs {
+			if !strings.EqualFold(input.SignalType, config.SignalTypeProjection) {
+				continue
+			}
+			dep := input.SignalName
+			if strings.EqualFold(input.ValueSource, "confidence") {
+				if src, ok := outputToSource[dep]; ok {
+					dep = src
+				}
+			}
+			adj[score.Name] = append(adj[score.Name], dep)
+		}
+	}
+	return adj, posMap
+}
+
+func (v *Validator) checkProjectionScoreCycles() {
+	outputToSource := v.dslOutputToSourceScore()
+	adj, posMap := buildDSLScoreCycleAdj(v.prog.ProjectionScores, outputToSource)
+
+	if len(adj) == 0 {
+		return
+	}
+
+	const (
+		unvisited = 0
+		visiting  = 1
+		visited   = 2
+	)
+	state := make(map[string]int, len(v.prog.ProjectionScores))
+	var path []string
+
+	var visit func(name string)
+	visit = func(name string) {
+		if state[name] == visited {
+			return
+		}
+		if state[name] == visiting {
+			v.addDiag(
+				DiagConstraint,
+				posMap[name],
+				fmt.Sprintf("PROJECTION score dependency cycle detected: %s", dslFormatCyclePath(path, name)),
+				nil,
+			)
+			return
+		}
+		state[name] = visiting
+		path = append(path, name)
+		for _, dep := range adj[name] {
+			visit(dep)
+		}
+		path = path[:len(path)-1]
+		state[name] = visited
+	}
+
+	for _, score := range v.prog.ProjectionScores {
+		if state[score.Name] == unvisited {
+			visit(score.Name)
+		}
+	}
+}

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -59,7 +59,7 @@ class ProjectionScoreInput(BaseModel):
     kb: Optional[str] = None
     metric: Optional[str] = None
     weight: float
-    value_source: Optional[Literal["binary", "confidence", "raw"]] = None
+    value_source: Optional[Literal["binary", "confidence", "raw", "score"]] = None
     match: Optional[float] = None
     miss: Optional[float] = None
 

--- a/src/vllm-sr/cli/validator.py
+++ b/src/vllm-sr/cli/validator.py
@@ -541,6 +541,93 @@ def validate_algorithm_configurations(config: UserConfig) -> List[ValidationErro
     return errors
 
 
+def validate_projection_score_dependencies(
+    config: UserConfig,
+) -> List[ValidationError]:
+    """Validate that projection scores have no dependency cycles."""
+    errors: List[ValidationError] = []
+    projections = getattr(getattr(config, "routing", None), "projections", None)
+    if not projections:
+        return errors
+
+    scores = getattr(projections, "scores", None) or []
+    score_names = {s.name for s in scores if s.name}
+
+    output_to_source: dict[str, str] = {}
+    for mapping in getattr(projections, "mappings", None) or []:
+        source_score = getattr(mapping, "source", None)
+        if not source_score:
+            continue
+        for output in getattr(mapping, "outputs", None) or []:
+            output_name = getattr(output, "name", None)
+            if output_name:
+                output_to_source[output_name] = source_score
+
+    adj: dict[str, list[str]] = {}
+    for score in scores:
+        deps: list[str] = []
+        for inp in getattr(score, "inputs", None) or []:
+            if (getattr(inp, "type", "") or "").lower() != "projection":
+                continue
+            dep_name = getattr(inp, "name", None)
+            if not dep_name:
+                continue
+            vs = (getattr(inp, "value_source", "") or "").strip().lower()
+            if vs == "confidence":
+                src = output_to_source.get(dep_name)
+                if not src:
+                    errors.append(
+                        ValidationError(
+                            field=f"routing.projections.scores[{score.name}]",
+                            message=f'projection input references undefined mapping output "{dep_name}"',
+                        )
+                    )
+                    continue
+                deps.append(src)
+            else:
+                if dep_name not in score_names:
+                    errors.append(
+                        ValidationError(
+                            field=f"routing.projections.scores[{score.name}]",
+                            message=f'projection input references undefined score "{dep_name}"',
+                        )
+                    )
+                    continue
+                deps.append(dep_name)
+        adj[score.name] = deps
+
+    unvisited, visiting, visited = 0, 1, 2
+    state: dict[str, int] = {s.name: unvisited for s in scores}
+    path: list[str] = []
+
+    def visit(name: str) -> None:
+        if state.get(name) == visited:
+            return
+        if state.get(name) == visiting:
+            cycle = [*list(path), name]
+            start = cycle.index(name)
+            cycle_str = " -> ".join(cycle[start:])
+            errors.append(
+                ValidationError(
+                    field="routing.projections.scores",
+                    message=f"dependency cycle detected: {cycle_str}",
+                )
+            )
+            return
+        state[name] = visiting
+        path.append(name)
+        for dep in adj.get(name, []):
+            visit(dep)
+        path.pop()
+        state[name] = visited
+
+    for score in scores:
+        if state.get(score.name) == unvisited:
+            visit(score.name)
+
+    return errors
+
+
 def validate_user_config(config: UserConfig) -> List[ValidationError]:
     """
     Validate user configuration.
@@ -572,6 +659,9 @@ def validate_user_config(config: UserConfig) -> List[ValidationError]:
 
     # Validate algorithm configurations
     errors.extend(validate_algorithm_configurations(config))
+
+    # Validate projection score dependency ordering
+    errors.extend(validate_projection_score_dependencies(config))
 
     if errors:
         log.warning(f"Found {len(errors)} validation error(s)")

--- a/website/docs/tutorials/projection/scores.md
+++ b/website/docs/tutorials/projection/scores.md
@@ -147,10 +147,10 @@ PROJECTION score difficulty_score {
 |-------|---------|
 | `name` | score identifier |
 | `method` | currently `weighted_sum` |
-| `inputs[].type` | signal family to read from |
-| `inputs[].name` | declared signal name |
+| `inputs[].type` | signal family to read from, or `projection` to reference an earlier score or mapping output |
+| `inputs[].name` | declared signal name; for `type: projection` with `value_source: score` (default) this is a score name, with `value_source: confidence` this is a mapping output name |
 | `inputs[].weight` | contribution multiplier; negative weights lower the score |
-| `inputs[].value_source` | `binary`, `confidence`, or `raw` behavior |
+| `inputs[].value_source` | `binary`, `confidence`, `raw`, or `score` (for projection inputs); `confidence` on a `projection` input reads a mapping output's calibrated confidence |
 | `inputs[].match` / `inputs[].miss` | explicit values for binary mode |
 
 ## Configuration
@@ -179,6 +179,72 @@ Do not use scores when:
 - Document why each weight exists, especially when mixing confidence-bearing learned signals with heuristic signals.
 - Prefer scores for numeric aggregation and keep `routing.decisions` focused on readable boolean composition.
 - Use negative weights when a matched signal should actively lower the tier, as `balance` does for obviously simple requests.
+
+## Hierarchical Composition
+
+Scores can reference earlier projection scores or mapping output confidences using `type: projection`. This enables layered routing constructs where one score builds on another.
+
+### Score-to-Score Reference
+
+Use `value_source: score` (or omit `value_source`) to read a previously computed score value:
+
+```yaml
+routing:
+  projections:
+    scores:
+      - name: difficulty_score
+        method: weighted_sum
+        inputs:
+          - type: keyword
+            name: reasoning_request_markers
+            weight: 0.6
+            value_source: confidence
+
+      - name: verification_pressure
+        method: weighted_sum
+        inputs:
+          - type: projection
+            name: difficulty_score
+            value_source: score
+            weight: 0.8
+          - type: fact_check
+            name: needs_fact_check
+            weight: 0.4
+
+    mappings:
+      - name: verification_band
+        source: verification_pressure
+        method: threshold_bands
+        outputs:
+          - name: needs_deep_verify
+            gte: 0.7
+          - name: standard_verify
+            lt: 0.7
+```
+
+### Confidence Reference
+
+Use `value_source: confidence` to read the calibrated confidence from a mapping output band:
+
+```yaml
+- type: projection
+  name: needs_deep_verify
+  value_source: confidence
+  weight: 0.5
+```
+
+### Dependency Ordering
+
+Scores can be declared in any order. The runtime evaluates them in topological order so that dependencies are always resolved before dependents. Cycles are rejected at config validation time.
+
+### Config Fields for Projection Inputs
+
+| Field | Meaning |
+|-------|---------|
+| `type` | `projection` |
+| `name` | declared score name (for `value_source: score`) or mapping output name (for `value_source: confidence`) |
+| `value_source` | `score` (read raw score value) or `confidence` (read mapping output confidence) |
+| `weight` | contribution multiplier |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Adds support for hierarchical projection composition, allowing projection score inputs to reference other projection scores or mapping output confidences using `type: projection`. Scores are evaluated in topological order with cycle detection and undefined reference rejection at validation time.

**Changes:**
- **Config validation** (`validator_projection.go`): Added `validateProjectionScoreDependencyOrder` with DFS-based topological sort and cycle detection, plus `validateProjectionInputProjectionRef` for `type: projection` input validation. Confidence refs (`value_source: confidence`) correctly resolve through mapping outputs to their source score for dependency ordering.
- **Runtime evaluation** (`classifier_projections.go`): Scores evaluate in topological order; added `projectionInputProjectionValue` for reading from `ProjectionScores` or `SignalConfidences`. Dependency graph builders resolve confidence refs to source scores.
- **Signal expansion** (`classifier_signal_eval.go`): Recursive `expandScoreInputs` resolves transitive dependencies for projection-type inputs, including confidence-based refs that resolve through mapping outputs.
- **DSL validation** (`validator_conflicts.go`, `validator_projection_deps.go`): Cycle detection and projection input validation in DSL layer. Confidence refs validate against mapping output names (not score names) and resolve to source scores for cycle detection.
- **Python CLI** (`validator.py`): Mirrored cycle detection and undefined reference checking with confidence-ref awareness.
- **Dashboard** (`ConfigPageProjectionsSection.tsx`): Updated help text to document both score and confidence value sources for projection inputs.
- **Documentation** (`scores.md`): Added "Hierarchical Composition" section with examples for both score-to-score and confidence-based references.

The DSL parser, compiler, and decompiler already handle `value_source` generically for all input types, so no changes were needed there — only the validation and runtime layers required updates.

## Test Plan

- [x] Config validation tests: valid chains, 2-node/3-node/self-referencing cycles, undefined refs, value_source validation
- [x] Confidence ref validation: valid confidence refs to mapping outputs, rejection of undefined outputs, dependency ordering through confidence-to-source resolution
- [x] Runtime tests: score-to-score consumption, confidence consumption, 3-level chains, topological order independence from declaration order
- [x] Full YAML end-to-end: config with confidence projection refs parses and validates correctly
- [x] DSL tests: existing projection tests continue to pass
- [x] All tests pass with race detector (`go test -race`)
- [x] CI-equivalent lint (`golangci-lint` with `.golangci.agent.yml`) — zero issues from changed files
- [x] Python ruff lint — clean

## Before and After

### Before

Projection composition was shallow — scores could only read base signals (keyword, embedding, etc.), and mappings could only read one score. Layered routing constructs like "difficulty → verification pressure → premium reasoning overlay" required flattening everything into a single oversized score or pushing logic into decision rules.

```yaml
scores:
  - name: difficulty_score
    inputs:
      - type: keyword           # can only read base signals
        name: reasoning_markers
        weight: 0.6
```

### After

Scores can now reference earlier projection scores (`value_source: score`) or mapping output confidences (`value_source: confidence`). The runtime evaluates scores in topological order, and config validation rejects cycles and undefined references.

```yaml
scores:
  - name: difficulty_score
    inputs:
      - type: keyword
        name: reasoning_markers
        weight: 0.6
  - name: verification_pressure
    inputs:
      - type: projection         # references an earlier score
        name: difficulty_score
        value_source: score
        weight: 0.8
      - type: projection         # references a mapping output confidence
        name: is_complex
        value_source: confidence
        weight: 0.5
```

Closes #1758