### PR TITLE
config: lazy-validate default knowledge bases (#1829)

### DIFF
--- a/src/semantic-router/pkg/config/taxonomy_config_test.go
+++ b/src/semantic-router/pkg/config/taxonomy_config_test.go
@@ -278,6 +278,50 @@ routing:
 	}
 }
 
+// Regression test for vllm-project/semantic-router#1829: stock Helm/operator
+// deployments without bundled KB asset files would fatal at startup because
+// canonical defaults (privacy_kb, mmlu_kb) get merged into every router config
+// and the validator unconditionally tried to open their labels manifests.
+//
+// Fix: only load the on-disk manifest for KBs that are actually referenced by
+// a routing.signals.kb[] rule. Defaults that nobody references skip the load.
+func TestValidateKnowledgeBaseContractsAcceptsUnreferencedDefaultKBsWithoutAssets(t *testing.T) {
+	missingAssetsRoot := t.TempDir() // exists, but contains no labels manifest
+
+	cfg := &RouterConfig{
+		ConfigBaseDir: missingAssetsRoot,
+		KnowledgeBases: []KnowledgeBaseConfig{
+			{
+				Name: "privacy_kb",
+				Source: KnowledgeBaseSource{
+					Path:     "knowledge_bases/privacy/",
+					Manifest: "labels.json",
+				},
+				Threshold: 0.55,
+			},
+			{
+				Name: "mmlu_kb",
+				Source: KnowledgeBaseSource{
+					Path:     "knowledge_bases/mmlu/",
+					Manifest: "labels.json",
+				},
+				Threshold: 0.25,
+			},
+		},
+		// No KBRules — neither default KB is referenced, so neither manifest
+		// should be loaded. Pre-fix this would have errored with
+		// "failed to load labels manifest: open .../labels.json: no such file".
+	}
+
+	if err := validateKnowledgeBaseContracts(cfg); err != nil {
+		t.Fatalf(
+			"unreferenced default KBs without bundled assets must not fail "+
+				"validation, got: %v",
+			err,
+		)
+	}
+}
+
 func TestValidateKnowledgeBaseContractsRejectsUnknownKB(t *testing.T) {
 	cfg := &RouterConfig{
 		IntelligentRouting: IntelligentRouting{

--- a/src/semantic-router/pkg/config/validator_projection.go
+++ b/src/semantic-router/pkg/config/validator_projection.go
@@ -548,7 +548,12 @@ func validateKBMetricProjectionInput(
 	if input.KB == "" {
 		return fmt.Errorf("routing.projections.scores[%q]: kb_metric inputs require kb", scoreName)
 	}
-	kbs, _, err := knowledgeBaseDefinitions(cfg)
+	// Projection validation needs the KB config map but not the on-disk manifest;
+	// treat any kb_metric-referenced KB as referenced so its config flows through
+	// without forcing us to load asset files for unrelated KBs. See #1829.
+	referenced := referencedKnowledgeBaseNames(cfg)
+	referenced[input.KB] = struct{}{}
+	kbs, _, err := knowledgeBaseDefinitions(cfg, referenced)
 	if err != nil {
 		return err
 	}

--- a/src/semantic-router/pkg/config/validator_taxonomy.go
+++ b/src/semantic-router/pkg/config/validator_taxonomy.go
@@ -7,7 +7,8 @@ import (
 )
 
 func validateKnowledgeBaseContracts(cfg *RouterConfig) error {
-	kbs, definitions, err := knowledgeBaseDefinitions(cfg)
+	referenced := referencedKnowledgeBaseNames(cfg)
+	kbs, definitions, err := knowledgeBaseDefinitions(cfg, referenced)
 	if err != nil {
 		return err
 	}
@@ -20,6 +21,19 @@ func validateKnowledgeBaseContracts(cfg *RouterConfig) error {
 	}
 
 	return nil
+}
+
+// referencedKnowledgeBaseNames returns the set of knowledge-base names that
+// are actually referenced by a routing.signals.kb[] rule. Default KBs that
+// nobody references can skip the on-disk manifest load below — see #1829.
+func referencedKnowledgeBaseNames(cfg *RouterConfig) map[string]struct{} {
+	out := make(map[string]struct{}, len(cfg.KBRules))
+	for _, rule := range cfg.KBRules {
+		if rule.KB != "" {
+			out[rule.KB] = struct{}{}
+		}
+	}
+	return out
 }
 
 func validateKnowledgeBaseSignalRule(
@@ -72,7 +86,7 @@ func validateKnowledgeBaseSignalTarget(rule KBSignalRule, kb KnowledgeBaseConfig
 	}
 }
 
-func knowledgeBaseDefinitions(cfg *RouterConfig) (map[string]KnowledgeBaseConfig, map[string]KnowledgeBaseDefinition, error) {
+func knowledgeBaseDefinitions(cfg *RouterConfig, referenced map[string]struct{}) (map[string]KnowledgeBaseConfig, map[string]KnowledgeBaseDefinition, error) {
 	kbs := make(map[string]KnowledgeBaseConfig, len(cfg.KnowledgeBases))
 	definitions := make(map[string]KnowledgeBaseDefinition, len(cfg.KnowledgeBases))
 	for _, kb := range cfg.KnowledgeBases {
@@ -89,6 +103,18 @@ func knowledgeBaseDefinitions(cfg *RouterConfig) (map[string]KnowledgeBaseConfig
 			return nil, nil, fmt.Errorf("global.model_catalog.kbs[%q]: threshold must be between 0 and 1", kb.Name)
 		}
 		if cfg.ConfigBaseDir == "" && !filepath.IsAbs(kb.Source.Path) {
+			kbs[kb.Name] = kb
+			continue
+		}
+
+		// #1829: defaults like privacy_kb and mmlu_kb get merged into every router
+		// config via canonical defaults. Stock Helm/operator deployments without
+		// bundled KB assets shouldn't fatal at startup just because nobody asked
+		// the router to use those KBs. Only load the on-disk labels manifest for
+		// KBs that a routing.signals.kb[] rule actually references; unreferenced
+		// KBs keep the basic config validation above (name, source.path,
+		// threshold) but skip the manifest read.
+		if _, isReferenced := referenced[kb.Name]; !isReferenced {
 			kbs[kb.Name] = kb
 			continue
 		}


### PR DESCRIPTION
## Problem

Stock Helm / operator deployments without bundled KB asset files fatal at startup:

```
{"level":"fatal","msg":"runtime_config_load_failed",
 "error":"global.model_catalog.kbs[\"privacy_kb\"]: failed to load labels manifest:
 open /app/config/.../knowledge_bases/privacy/labels.json: no such file or directory"}
```

`defaultCanonicalKnowledgeBases()` in `canonical_defaults.go` unconditionally injects two default KBs (`privacy_kb`, `mmlu_kb`) into every router config. Their on-disk labels manifests then get loaded eagerly during `validateKnowledgeBaseContracts` → `knowledgeBaseDefinitions`. A user that never references either KB in `routing.signals.kb[]` still pays for the file open and dies if KB assets aren't on disk.

#1829 captures this with the full repro.

## Fix

Pre-compute the set of KB names actually referenced by `routing.signals.kb[]` rules, and only load the on-disk labels manifest for those KBs. Unreferenced KBs (typically the merged-in defaults) keep the basic config validation — name non-empty, source.path non-empty, threshold ∈ [0, 1] — but skip the manifest read.

A KB that *becomes* referenced — either by a user-authored `kb` signal rule, or by a `routing.projections.scores[]` `kb_metric` input that points at it — still has its manifest loaded and validated, so a genuinely-misconfigured referenced KB still surfaces the manifest-load error.

`knowledgeBaseDefinitions` gains an explicit `referenced map[string]struct{}` parameter; both call sites (`validator_taxonomy.go` and `validator_projection.go`) thread it through. The projection caller treats its `kb_metric` input target as referenced so the manifest still flows through validation when that path is taken.

## Test

New regression test `TestValidateKnowledgeBaseContractsAcceptsUnreferencedDefaultKBsWithoutAssets` in `taxonomy_config_test.go`: constructs a config with both default KBs pointing at a missing `labels.json` under a tempdir `ConfigBaseDir`, no `KBRules` referencing either. Pre-fix this errored with the manifest-load message; with the fix it returns nil.

Existing `TestValidateKnowledgeBaseContractsResolvesManifestBindings` exercises the referenced-KB path end to end — that still passes, confirming the manifest load + label/group/metric validation is unchanged when a rule references the KB. Existing `TestValidateKnowledgeBaseContractsRejectsUnknownKB` / `TestValidateKnowledgeBaseContractsRejectsUnknownTargetValue` confirm the negative paths haven't drifted.

```
$ go test ./pkg/config/
ok  	github.com/vllm-project/semantic-router/src/semantic-router/pkg/config	2.196s
```

## Closes

Fixes #1829.