### PR TITLE
feat: implement hybrid history-aware retriever strategy

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1697,6 +1697,7 @@ global:
       fallback_to_empty: true
       advanced_filtering:
         enabled: true
+        retrieval_strategy: weighted
         candidate_pool_size: 50
         min_lexical_overlap: 1
         min_combined_score: 0.42
@@ -1710,6 +1711,14 @@ global:
         category_confidence_threshold: 0.7
         allow_tools: [docs.search, tickets.lookup]
         block_tools: [admin.delete]
+        hybrid_history:
+          history_horizon: 8
+          min_history_steps: 1
+          history_confidence_threshold: 0
+          weight_semantic: 1
+          weight_history_transition: 1
+          weight_decision_prior: 1
+          repetition_penalty_strength: 0
     looper:
       endpoint: http://localhost:8899/v1/chat/completions
       model_endpoints:

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -193,15 +193,28 @@ type ToolFilteringWeights struct {
 }
 
 type AdvancedToolFilteringConfig struct {
-	Enabled                     bool                 `yaml:"enabled"`
-	CandidatePoolSize           *int                 `yaml:"candidate_pool_size,omitempty"`
-	MinLexicalOverlap           *int                 `yaml:"min_lexical_overlap,omitempty"`
-	MinCombinedScore            *float32             `yaml:"min_combined_score,omitempty"`
-	Weights                     ToolFilteringWeights `yaml:"weights,omitempty"`
-	UseCategoryFilter           *bool                `yaml:"use_category_filter,omitempty"`
-	CategoryConfidenceThreshold *float32             `yaml:"category_confidence_threshold,omitempty"`
-	AllowTools                  []string             `yaml:"allow_tools,omitempty"`
-	BlockTools                  []string             `yaml:"block_tools,omitempty"`
+	Enabled                     bool                              `yaml:"enabled"`
+	RetrievalStrategy           string                            `yaml:"retrieval_strategy,omitempty"`
+	CandidatePoolSize           *int                              `yaml:"candidate_pool_size,omitempty"`
+	MinLexicalOverlap           *int                              `yaml:"min_lexical_overlap,omitempty"`
+	MinCombinedScore            *float32                          `yaml:"min_combined_score,omitempty"`
+	Weights                     ToolFilteringWeights              `yaml:"weights,omitempty"`
+	UseCategoryFilter           *bool                             `yaml:"use_category_filter,omitempty"`
+	CategoryConfidenceThreshold *float32                          `yaml:"category_confidence_threshold,omitempty"`
+	AllowTools                  []string                          `yaml:"allow_tools,omitempty"`
+	BlockTools                  []string                          `yaml:"block_tools,omitempty"`
+	HybridHistory               *HybridHistoryToolRetrievalConfig `yaml:"hybrid_history,omitempty"`
+}
+
+// HybridHistoryToolRetrievalConfig tunes hybrid_history retrieval (semantic + short history + priors + repetition).
+type HybridHistoryToolRetrievalConfig struct {
+	HistoryHorizon             *int     `yaml:"history_horizon,omitempty"`
+	MinHistorySteps            *int     `yaml:"min_history_steps,omitempty"`
+	HistoryConfidenceThreshold *float32 `yaml:"history_confidence_threshold,omitempty"`
+	WeightSemantic             *float32 `yaml:"weight_semantic,omitempty"`
+	WeightHistoryTransition    *float32 `yaml:"weight_history_transition,omitempty"`
+	WeightDecisionPrior        *float32 `yaml:"weight_decision_prior,omitempty"`
+	RepetitionPenaltyStrength  *float32 `yaml:"repetition_penalty_strength,omitempty"`
 }
 
 type ToolsConfig struct {

--- a/src/semantic-router/pkg/config/reference_config_global_test.go
+++ b/src/semantic-router/pkg/config/reference_config_global_test.go
@@ -147,6 +147,12 @@ func assertReferenceConfigIntegrationGlobalCoverage(t testingT, integrations map
 	assertMapCoversStructFields(t, mustMapAt(t, tools, "advanced_filtering"), reflect.TypeOf(AdvancedToolFilteringConfig{}), "global.integrations.tools.advanced_filtering")
 	assertMapCoversStructFields(
 		t,
+		mustMapAt(t, tools, "advanced_filtering", "hybrid_history"),
+		reflect.TypeOf(HybridHistoryToolRetrievalConfig{}),
+		"global.integrations.tools.advanced_filtering.hybrid_history",
+	)
+	assertMapCoversStructFields(
+		t,
 		mustMapAt(t, tools, "advanced_filtering", "weights"),
 		reflect.TypeOf(ToolFilteringWeights{}),
 		"global.integrations.tools.advanced_filtering.weights",

--- a/src/semantic-router/pkg/config/tool_retrieval.go
+++ b/src/semantic-router/pkg/config/tool_retrieval.go
@@ -1,0 +1,40 @@
+package config
+
+import "strings"
+
+const (
+	// ToolRetrievalStrategyWeighted is the default: embedding + lexical/tag/name/category weights.
+	ToolRetrievalStrategyWeighted = "weighted"
+	// ToolRetrievalStrategyHybridHistory combines semantic similarity with short-horizon tool history.
+	ToolRetrievalStrategyHybridHistory = "hybrid_history"
+)
+
+// EffectiveToolRetrievalStrategy returns normalized strategy; empty defaults to weighted.
+func EffectiveToolRetrievalStrategy(advanced *AdvancedToolFilteringConfig) string {
+	if advanced == nil {
+		return ToolRetrievalStrategyWeighted
+	}
+	s := strings.TrimSpace(strings.ToLower(advanced.RetrievalStrategy))
+	if s == "" {
+		return ToolRetrievalStrategyWeighted
+	}
+	return s
+}
+
+// IsHybridHistoryRetrieval reports whether advanced filtering should use hybrid_history ranking.
+func IsHybridHistoryRetrieval(advanced *AdvancedToolFilteringConfig) bool {
+	return EffectiveToolRetrievalStrategy(advanced) == ToolRetrievalStrategyHybridHistory
+}
+
+// ResolveHybridHistoryHorizon returns the max assistant tool names to read from history.
+func ResolveHybridHistoryHorizon(advanced *AdvancedToolFilteringConfig) int {
+	const defaultHorizon = 8
+	if advanced == nil || advanced.HybridHistory == nil || advanced.HybridHistory.HistoryHorizon == nil {
+		return defaultHorizon
+	}
+	h := *advanced.HybridHistory.HistoryHorizon
+	if h <= 0 {
+		return defaultHorizon
+	}
+	return h
+}

--- a/src/semantic-router/pkg/config/validator_tool_filtering.go
+++ b/src/semantic-router/pkg/config/validator_tool_filtering.go
@@ -1,17 +1,34 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func validateAdvancedToolFilteringConfig(cfg *RouterConfig) error {
 	if cfg == nil || cfg.Tools.AdvancedFiltering == nil {
 		return nil
 	}
-
 	advanced := cfg.Tools.AdvancedFiltering
 	if !advanced.Enabled {
 		return nil
 	}
+	if err := validateAdvancedToolFilteringIntFields(advanced); err != nil {
+		return err
+	}
+	if err := validateAdvancedToolFilteringCoreFloats(advanced); err != nil {
+		return err
+	}
+	if err := validateToolFilteringWeightFloats(advanced.Weights); err != nil {
+		return err
+	}
+	if err := validateRetrievalStrategyValue(advanced.RetrievalStrategy); err != nil {
+		return err
+	}
+	return validateHybridHistorySubconfig(advanced.HybridHistory)
+}
 
+func validateAdvancedToolFilteringIntFields(advanced *AdvancedToolFilteringConfig) error {
 	for _, field := range []struct {
 		name  string
 		value *int
@@ -23,7 +40,10 @@ func validateAdvancedToolFilteringConfig(cfg *RouterConfig) error {
 			return err
 		}
 	}
+	return nil
+}
 
+func validateAdvancedToolFilteringCoreFloats(advanced *AdvancedToolFilteringConfig) error {
 	for _, field := range []struct {
 		name  string
 		value *float32
@@ -35,22 +55,67 @@ func validateAdvancedToolFilteringConfig(cfg *RouterConfig) error {
 			return err
 		}
 	}
+	return nil
+}
 
+func validateToolFilteringWeightFloats(weights ToolFilteringWeights) error {
 	for _, field := range []struct {
 		name  string
 		value *float32
 	}{
-		{"embed", advanced.Weights.Embed},
-		{"lexical", advanced.Weights.Lexical},
-		{"tag", advanced.Weights.Tag},
-		{"name", advanced.Weights.Name},
-		{"category", advanced.Weights.Category},
+		{"embed", weights.Embed},
+		{"lexical", weights.Lexical},
+		{"tag", weights.Tag},
+		{"name", weights.Name},
+		{"category", weights.Category},
 	} {
 		if err := validateAdvancedToolFilteringUnitFloat("weights."+field.name, field.value); err != nil {
 			return err
 		}
 	}
+	return nil
+}
 
+func validateRetrievalStrategyValue(strategy string) error {
+	s := strings.TrimSpace(strings.ToLower(strategy))
+	if s == "" {
+		return nil
+	}
+	if s == ToolRetrievalStrategyWeighted || s == ToolRetrievalStrategyHybridHistory {
+		return nil
+	}
+	return fmt.Errorf("tools.advanced_filtering.retrieval_strategy must be %q or %q", ToolRetrievalStrategyWeighted, ToolRetrievalStrategyHybridHistory)
+}
+
+func validateHybridHistorySubconfig(h *HybridHistoryToolRetrievalConfig) error {
+	if h == nil {
+		return nil
+	}
+	for _, field := range []struct {
+		name  string
+		value *int
+	}{
+		{"history_horizon", h.HistoryHorizon},
+		{"min_history_steps", h.MinHistorySteps},
+	} {
+		if err := validateAdvancedToolFilteringNonNegativeInt("hybrid_history."+field.name, field.value); err != nil {
+			return err
+		}
+	}
+	for _, field := range []struct {
+		name  string
+		value *float32
+	}{
+		{"history_confidence_threshold", h.HistoryConfidenceThreshold},
+		{"weight_semantic", h.WeightSemantic},
+		{"weight_history_transition", h.WeightHistoryTransition},
+		{"weight_decision_prior", h.WeightDecisionPrior},
+		{"repetition_penalty_strength", h.RepetitionPenaltyStrength},
+	} {
+		if err := validateAdvancedToolFilteringUnitFloat("hybrid_history."+field.name, field.value); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -44,21 +44,9 @@ func (r *OpenAIRouter) handleToolSelection(openAIRequest *openai.ChatCompletionN
 		return nil
 	}
 
-	switch toolsCfg.EffectiveMode() {
-	case config.ToolsPluginModeNone:
-		logging.Infof("[ToolsPlugin] Decision %q has mode=none, stripping all tools", ctx.VSRSelectedDecision.Name)
-		openAIRequest.Tools = nil
-		return r.updateRequestWithTools(openAIRequest, response, ctx)
-	case config.ToolsPluginModeFiltered:
-		openAIRequest.Tools = filterToolsByDecisionPolicy(openAIRequest.Tools, toolsCfg.AllowTools, toolsCfg.BlockTools)
-		if openAIRequest.ToolChoice.OfAuto.Value != "auto" {
-			logging.Infof("[ToolsPlugin] Decision %q filtered explicit tools to %d entries", ctx.VSRSelectedDecision.Name, len(openAIRequest.Tools))
-			return r.updateRequestWithTools(openAIRequest, response, ctx)
-		}
-	case config.ToolsPluginModePassthrough:
-		// No explicit-tool filtering; semantic selection may still run below.
-	default:
-		return fmt.Errorf("tools plugin: unsupported mode %q", toolsCfg.Mode)
+	finished, err := r.applyDecisionToolsPluginMode(openAIRequest, response, ctx, toolsCfg)
+	if err != nil || finished {
+		return err
 	}
 
 	if openAIRequest.ToolChoice.OfAuto.Value != "auto" {
@@ -68,14 +56,7 @@ func (r *OpenAIRouter) handleToolSelection(openAIRequest *openai.ChatCompletionN
 		return r.updateRequestWithTools(openAIRequest, response, ctx)
 	}
 
-	// Get text for tools classification
-	var classificationText string
-	if len(userContent) > 0 {
-		classificationText = userContent
-	} else if len(nonUserMessages) > 0 {
-		classificationText = strings.Join(nonUserMessages, " ")
-	}
-
+	classificationText := toolClassificationText(userContent, nonUserMessages)
 	if classificationText == "" {
 		logging.Infof("No content available for tool classification")
 		return nil
@@ -86,41 +67,113 @@ func (r *OpenAIRouter) handleToolSelection(openAIRequest *openai.ChatCompletionN
 		return nil
 	}
 
-	selectedTools, toolErr := r.findToolsForQuery(classificationText, ctx, toolsCfg)
+	return r.runSemanticToolSelectionAndUpdate(openAIRequest, response, ctx, toolsCfg, classificationText)
+}
+
+// applyDecisionToolsPluginMode enforces per-decision none / filtered / passthrough. The boolean is
+// true when the request body has already been finalized for this path (caller returns).
+func (r *OpenAIRouter) applyDecisionToolsPluginMode(
+	openAIRequest *openai.ChatCompletionNewParams,
+	response **ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+	toolsCfg *config.ToolsPluginConfig,
+) (bool, error) {
+	switch toolsCfg.EffectiveMode() {
+	case config.ToolsPluginModeNone:
+		logging.Infof("[ToolsPlugin] Decision %q has mode=none, stripping all tools", ctx.VSRSelectedDecision.Name)
+		openAIRequest.Tools = nil
+		return true, r.updateRequestWithTools(openAIRequest, response, ctx)
+	case config.ToolsPluginModeFiltered:
+		openAIRequest.Tools = filterToolsByDecisionPolicy(openAIRequest.Tools, toolsCfg.AllowTools, toolsCfg.BlockTools)
+		if openAIRequest.ToolChoice.OfAuto.Value != "auto" {
+			logging.Infof("[ToolsPlugin] Decision %q filtered explicit tools to %d entries", ctx.VSRSelectedDecision.Name, len(openAIRequest.Tools))
+			return true, r.updateRequestWithTools(openAIRequest, response, ctx)
+		}
+	case config.ToolsPluginModePassthrough:
+		// Semantic selection may run below.
+	default:
+		return false, fmt.Errorf("tools plugin: unsupported mode %q", toolsCfg.Mode)
+	}
+	return false, nil
+}
+
+func toolClassificationText(userContent string, nonUserMessages []string) string {
+	if len(userContent) > 0 {
+		return userContent
+	}
+	if len(nonUserMessages) > 0 {
+		return strings.Join(nonUserMessages, " ")
+	}
+	return ""
+}
+
+func (r *OpenAIRouter) runSemanticToolSelectionAndUpdate(
+	openAIRequest *openai.ChatCompletionNewParams,
+	response **ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+	toolsCfg *config.ToolsPluginConfig,
+	classificationText string,
+) error {
+	selectedTools, toolErr := r.findToolsForQuery(classificationText, ctx, toolsCfg, openAIRequest)
 	if toolErr != nil {
-		if r.Config.Tools.FallbackToEmpty {
-			logging.Warnf("Tool selection failed, falling back to no tools: %v", toolErr)
-			openAIRequest.Tools = nil
-			return r.updateRequestWithTools(openAIRequest, response, ctx)
-		}
-		metrics.RecordRequestError(getModelFromCtx(ctx), "classification_failed")
-		return toolErr
+		return r.handleToolSelectionError(openAIRequest, response, ctx, toolErr)
 	}
 
-	if len(selectedTools) == 0 {
-		if r.Config.Tools.FallbackToEmpty {
-			logging.Infof("No suitable tools found, falling back to no tools")
-			openAIRequest.Tools = nil
-		} else {
-			logging.Infof("No suitable tools found above threshold")
-			openAIRequest.Tools = []openai.ChatCompletionToolParam{}
-		}
-	} else {
-		sdkTools, err := convertToSDKTools(selectedTools)
-		if err != nil {
-			metrics.RecordRequestError(getModelFromCtx(ctx), "serialization_error")
-			return err
-		}
-		openAIRequest.Tools = sdkTools
-		logging.Infof("Auto-selected %d tools for query: %s", len(sdkTools), classificationText)
+	if err := applySelectedToolsToOpenAIRequest(r, openAIRequest, selectedTools, classificationText, ctx); err != nil {
+		return err
 	}
-
 	return r.updateRequestWithTools(openAIRequest, response, ctx)
+}
+
+func (r *OpenAIRouter) handleToolSelectionError(
+	openAIRequest *openai.ChatCompletionNewParams,
+	response **ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+	toolErr error,
+) error {
+	if r.Config.Tools.FallbackToEmpty {
+		logging.Warnf("Tool selection failed, falling back to no tools: %v", toolErr)
+		openAIRequest.Tools = nil
+		return r.updateRequestWithTools(openAIRequest, response, ctx)
+	}
+	metrics.RecordRequestError(getModelFromCtx(ctx), "classification_failed")
+	return toolErr
+}
+
+func applySelectedToolsToOpenAIRequest(
+	r *OpenAIRouter,
+	openAIRequest *openai.ChatCompletionNewParams,
+	selectedTools []openai.ChatCompletionToolParam,
+	classificationText string,
+	ctx *RequestContext,
+) error {
+	if len(selectedTools) == 0 {
+		applyNoToolsFromSelection(r, openAIRequest)
+		return nil
+	}
+	sdkTools, err := convertToSDKTools(selectedTools)
+	if err != nil {
+		metrics.RecordRequestError(getModelFromCtx(ctx), "serialization_error")
+		return err
+	}
+	openAIRequest.Tools = sdkTools
+	logging.Infof("Auto-selected %d tools for query: %s", len(sdkTools), classificationText)
+	return nil
+}
+
+func applyNoToolsFromSelection(r *OpenAIRouter, openAIRequest *openai.ChatCompletionNewParams) {
+	if r.Config.Tools.FallbackToEmpty {
+		logging.Infof("No suitable tools found, falling back to no tools")
+		openAIRequest.Tools = nil
+		return
+	}
+	logging.Infof("No suitable tools found above threshold")
+	openAIRequest.Tools = []openai.ChatCompletionToolParam{}
 }
 
 // findToolsForQuery discovers candidate tools via semantic similarity, applying
 // advanced filtering when configured.
-func (r *OpenAIRouter) findToolsForQuery(query string, ctx *RequestContext, toolsCfg *config.ToolsPluginConfig) ([]openai.ChatCompletionToolParam, error) {
+func (r *OpenAIRouter) findToolsForQuery(query string, ctx *RequestContext, toolsCfg *config.ToolsPluginConfig, openAIRequest *openai.ChatCompletionNewParams) ([]openai.ChatCompletionToolParam, error) {
 	topK := r.Config.Tools.TopK
 	if topK <= 0 {
 		topK = 3
@@ -136,7 +189,17 @@ func (r *OpenAIRouter) findToolsForQuery(query string, ctx *RequestContext, tool
 		return nil, err
 	}
 
-	return tools.FilterAndRankTools(query, candidates, topK, advanced, resolveCategory(advanced, ctx)), nil
+	category := resolveCategory(advanced, ctx)
+	if config.IsHybridHistoryRetrieval(advanced) {
+		hz := config.ResolveHybridHistoryHorizon(advanced)
+		toolNames := extractRecentAssistantToolCallNames(openAIRequest, hz)
+		dec := 0.0
+		if ctx != nil {
+			dec = ctx.VSRSelectedDecisionConfidence
+		}
+		return tools.FilterAndRankToolsWithConversation(query, candidates, topK, advanced, category, toolNames, dec), nil
+	}
+	return tools.FilterAndRankTools(query, candidates, topK, advanced, category), nil
 }
 
 func resolveCandidatePoolSize(advanced *config.AdvancedToolFilteringConfig, topK int) int {

--- a/src/semantic-router/pkg/extproc/request_signal_history.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history.go
@@ -1,6 +1,10 @@
 package extproc
 
-import "github.com/openai/openai-go"
+import (
+	"strings"
+
+	"github.com/openai/openai-go"
+)
 
 type signalConversationHistory struct {
 	currentUserMessage string
@@ -87,4 +91,28 @@ func countSDKToolDefinitions(req *openai.ChatCompletionNewParams) int {
 		return 0
 	}
 	return len(req.Tools)
+}
+
+// extractRecentAssistantToolCallNames returns the last horizon assistant function names in chat order
+// (tool_calls across messages appended in request message order).
+func extractRecentAssistantToolCallNames(req *openai.ChatCompletionNewParams, horizon int) []string {
+	if req == nil || horizon <= 0 {
+		return nil
+	}
+	var names []string
+	for _, msg := range req.Messages {
+		if msg.OfAssistant == nil {
+			continue
+		}
+		for _, tc := range msg.OfAssistant.ToolCalls {
+			n := strings.TrimSpace(tc.Function.Name)
+			if n != "" {
+				names = append(names, n)
+			}
+		}
+	}
+	if len(names) > horizon {
+		names = names[len(names)-horizon:]
+	}
+	return names
 }

--- a/src/semantic-router/pkg/extproc/request_signal_history_test.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history_test.go
@@ -78,6 +78,7 @@ func TestSignalConversationHistoryFromFastExtract_PreservesResponseAPIUserChain(
 	assert.Equal(t, "What is my name again?", history.currentUserMessage)
 	assert.Equal(t, []string{"Hello"}, history.priorUserMessages)
 	assert.Equal(t, []string{"Remember my name is Alice.", "Hi there!"}, history.nonUserMessages)
+	assert.True(t, history.hasAssistantReply)
 }
 
 func TestExtractRecentAssistantToolCallNames(t *testing.T) {

--- a/src/semantic-router/pkg/extproc/request_signal_history_test.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history_test.go
@@ -78,5 +78,23 @@ func TestSignalConversationHistoryFromFastExtract_PreservesResponseAPIUserChain(
 	assert.Equal(t, "What is my name again?", history.currentUserMessage)
 	assert.Equal(t, []string{"Hello"}, history.priorUserMessages)
 	assert.Equal(t, []string{"Remember my name is Alice.", "Hi there!"}, history.nonUserMessages)
-	assert.True(t, history.hasAssistantReply)
+}
+
+func TestExtractRecentAssistantToolCallNames(t *testing.T) {
+	raw := []byte(`{
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "assistant", "content": null, "tool_calls": [
+				{"id": "c1", "type": "function", "function": {"name": "foo", "arguments": "{}"}}
+			]},
+			{"role": "assistant", "content": null, "tool_calls": [
+				{"id": "c2", "type": "function", "function": {"name": "bar", "arguments": "{}"}},
+				{"id": "c3", "type": "function", "function": {"name": "baz", "arguments": "{}"}}
+			]}
+		]
+	}`)
+	req, err := parseOpenAIRequest(raw)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"foo", "bar", "baz"}, extractRecentAssistantToolCallNames(req, 10))
+	assert.Equal(t, []string{"bar", "baz"}, extractRecentAssistantToolCallNames(req, 2))
 }

--- a/src/semantic-router/pkg/tools/hybrid_history.go
+++ b/src/semantic-router/pkg/tools/hybrid_history.go
@@ -77,12 +77,18 @@ func filterAndRankHybridHistory(
 ) []openai.ChatCompletionToolParam {
 	cfg := resolveHybridHistoryParams(advanced.HybridHistory)
 	names := trimToolHistory(toolHistory, cfg.historyHorizon)
+	a := newHybridRankArgs(query, names, cfg, advanced, selectedCategory, decisionConfidence)
 
 	if shouldFallbackHybridToSemantic(names, cfg) {
-		return selectTopKBySimilarity(filtered, topK)
+		passing := make([]ToolSimilarity, 0, len(filtered))
+		for _, candidate := range filtered {
+			if _, ok := hybridCandidateScore(candidate, a); ok {
+				passing = append(passing, candidate)
+			}
+		}
+		return selectTopKBySimilarity(passing, topK)
 	}
 
-	a := newHybridRankArgs(query, names, cfg, advanced, selectedCategory, decisionConfidence)
 	scored := make([]scoredCandidate, 0, len(filtered))
 	for _, candidate := range filtered {
 		if h, ok := hybridCandidateScore(candidate, a); ok {
@@ -91,7 +97,7 @@ func filterAndRankHybridHistory(
 	}
 
 	if len(scored) == 0 {
-		return selectTopKBySimilarity(filtered, topK)
+		return []openai.ChatCompletionToolParam{}
 	}
 	sortScoredCandidatesByCombinedThenSimilarity(scored)
 	return topKToolsFromScored(scored, topK)

--- a/src/semantic-router/pkg/tools/hybrid_history.go
+++ b/src/semantic-router/pkg/tools/hybrid_history.go
@@ -1,0 +1,277 @@
+package tools
+
+import (
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type hybridHistoryResolved struct {
+	historyHorizon             int
+	minHistorySteps            int
+	historyConfidenceThreshold float32
+	wSemantic                  float32
+	wHistory                   float32
+	wPrior                     float32
+	repetitionPenaltyStrength  float32
+}
+
+func resolveHybridHistoryParams(h *config.HybridHistoryToolRetrievalConfig) hybridHistoryResolved {
+	// Defaults avoid inventing tuned coefficients: equal weights = maximum-entropy prior for the
+	// three additive terms until metrics-driven calibration; repetition penalty off until enabled;
+	// confidence threshold 0 = do not downgrade to semantic-only based on historySignalStrength
+	// (only min_history_steps still triggers fallback).
+	const (
+		defHorizon     = 8
+		defMinSteps    = 1
+		defConfThresh  = float32(0)
+		defWSem        = float32(1)
+		defWHist       = float32(1)
+		defWPrior      = float32(1)
+		defRepStrength = float32(0)
+	)
+	out := hybridHistoryResolved{
+		historyHorizon:             defHorizon,
+		minHistorySteps:            defMinSteps,
+		historyConfidenceThreshold: defConfThresh,
+		wSemantic:                  defWSem,
+		wHistory:                   defWHist,
+		wPrior:                     defWPrior,
+		repetitionPenaltyStrength:  defRepStrength,
+	}
+	if h == nil {
+		return out
+	}
+	if h.HistoryHorizon != nil && *h.HistoryHorizon > 0 {
+		out.historyHorizon = *h.HistoryHorizon
+	}
+	if h.MinHistorySteps != nil && *h.MinHistorySteps > 0 {
+		out.minHistorySteps = *h.MinHistorySteps
+	}
+	if h.HistoryConfidenceThreshold != nil {
+		out.historyConfidenceThreshold = *h.HistoryConfidenceThreshold
+	}
+	if h.WeightSemantic != nil {
+		out.wSemantic = *h.WeightSemantic
+	}
+	if h.WeightHistoryTransition != nil {
+		out.wHistory = *h.WeightHistoryTransition
+	}
+	if h.WeightDecisionPrior != nil {
+		out.wPrior = *h.WeightDecisionPrior
+	}
+	if h.RepetitionPenaltyStrength != nil {
+		out.repetitionPenaltyStrength = *h.RepetitionPenaltyStrength
+	}
+	return out
+}
+
+func filterAndRankHybridHistory(
+	query string,
+	filtered []ToolSimilarity,
+	topK int,
+	advanced *config.AdvancedToolFilteringConfig,
+	selectedCategory string,
+	toolHistory []string,
+	decisionConfidence float64,
+) []openai.ChatCompletionToolParam {
+	cfg := resolveHybridHistoryParams(advanced.HybridHistory)
+	names := trimToolHistory(toolHistory, cfg.historyHorizon)
+
+	if shouldFallbackHybridToSemantic(names, cfg) {
+		return selectTopKBySimilarity(filtered, topK)
+	}
+
+	a := newHybridRankArgs(query, names, cfg, advanced, selectedCategory, decisionConfidence)
+	scored := make([]scoredCandidate, 0, len(filtered))
+	for _, candidate := range filtered {
+		if h, ok := hybridCandidateScore(candidate, a); ok {
+			scored = append(scored, scoredCandidate{ToolSimilarity: candidate, CombinedScore: h})
+		}
+	}
+
+	if len(scored) == 0 {
+		return selectTopKBySimilarity(filtered, topK)
+	}
+	sortScoredCandidatesByCombinedThenSimilarity(scored)
+	return topKToolsFromScored(scored, topK)
+}
+
+type hybridRankArgs struct {
+	querySet           map[string]struct{}
+	minOverlap         int
+	minCombined        float32
+	lastTool           string
+	names              []string
+	wSum               float32
+	cfg                hybridHistoryResolved
+	repStrength        float32
+	selectedCategory   string
+	decisionConfidence float64
+}
+
+func newHybridRankArgs(
+	query string,
+	names []string,
+	cfg hybridHistoryResolved,
+	advanced *config.AdvancedToolFilteringConfig,
+	selectedCategory string,
+	decisionConfidence float64,
+) hybridRankArgs {
+	lastTool := ""
+	if len(names) > 0 {
+		lastTool = names[len(names)-1]
+	}
+	minO, minC := minLexicalOverlapAndMinCombined(advanced)
+	w := cfg.wSemantic + cfg.wHistory + cfg.wPrior
+	if w <= 0 {
+		w = 1
+	}
+	return hybridRankArgs{
+		querySet:           tokenSet(tokenize(query)),
+		minOverlap:         minO,
+		minCombined:        minC,
+		lastTool:           lastTool,
+		names:              names,
+		wSum:               w,
+		cfg:                cfg,
+		repStrength:        cfg.repetitionPenaltyStrength,
+		selectedCategory:   selectedCategory,
+		decisionConfidence: decisionConfidence,
+	}
+}
+
+func hybridCandidateScore(candidate ToolSimilarity, a hybridRankArgs) (float32, bool) {
+	nameT := tokenize(candidate.Entry.Tool.Function.Name)
+	descT := tokenize(candidate.Entry.Description)
+	catT := tokenize(candidate.Entry.Category)
+	lexicalTokens := make([]string, 0, len(nameT)+len(descT)+len(catT))
+	lexicalTokens = append(lexicalTokens, nameT...)
+	lexicalTokens = append(lexicalTokens, descT...)
+	lexicalTokens = append(lexicalTokens, catT...)
+
+	lexicalOverlap := countOverlap(a.querySet, lexicalTokens)
+	if a.minOverlap > 0 && lexicalOverlap < a.minOverlap {
+		return 0, false
+	}
+
+	sim := clamp01(candidate.Similarity)
+	candName := candidate.Entry.Tool.Function.Name
+	hTrans := historyTransitionScore(a.lastTool, candName, a.names)
+	prior := decisionCategoryPriorScore(a.selectedCategory, candidate.Entry.Category, a.decisionConfidence)
+	rep := repetitionPenalty(candName, a.names, a.repStrength)
+
+	hyb := (a.cfg.wSemantic*sim + a.cfg.wHistory*hTrans + a.cfg.wPrior*prior) / a.wSum
+	hyb -= rep
+	if hyb < 0 {
+		hyb = 0
+	}
+	if hyb < a.minCombined {
+		return 0, false
+	}
+	return hyb, true
+}
+
+func trimToolHistory(names []string, horizon int) []string {
+	if len(names) == 0 || horizon <= 0 {
+		return names
+	}
+	if len(names) <= horizon {
+		return append([]string(nil), names...)
+	}
+	return append([]string(nil), names[len(names)-horizon:]...)
+}
+
+func shouldFallbackHybridToSemantic(names []string, cfg hybridHistoryResolved) bool {
+	if len(names) < cfg.minHistorySteps {
+		return true
+	}
+	if cfg.historyConfidenceThreshold > 0 &&
+		historySignalStrength(names, cfg.historyHorizon) < cfg.historyConfidenceThreshold {
+		return true
+	}
+	return false
+}
+
+// historySignalStrength estimates how much we can trust bigram/repetition structure in the window.
+func historySignalStrength(names []string, horizon int) float32 {
+	if len(names) == 0 {
+		return 0
+	}
+	cov := float32(len(names)) / float32(max(1, horizon))
+	uniq := map[string]struct{}{}
+	for _, n := range names {
+		uniq[n] = struct{}{}
+	}
+	diversity := float32(1)
+	if len(uniq) == 1 && len(names) >= 4 {
+		diversity = 0.35
+	}
+	return minFloat32(1, cov*diversity)
+}
+
+func historyTransitionScore(lastTool, candidateName string, history []string) float32 {
+	if lastTool == "" {
+		return 0.5
+	}
+	var fromLast, toCand int
+	for i := 0; i < len(history)-1; i++ {
+		if history[i] == lastTool {
+			fromLast++
+			if history[i+1] == candidateName {
+				toCand++
+			}
+		}
+	}
+	if fromLast > 0 {
+		return float32(toCand) / float32(fromLast)
+	}
+	// No observed (last->*) edge: discourage immediate same-tool repeat.
+	if candidateName == lastTool {
+		return 0.12
+	}
+	return 0.62
+}
+
+func decisionCategoryPriorScore(selectedCategory, toolCategory string, decisionConfidence float64) float32 {
+	cat := categoryMatchScore(selectedCategory, toolCategory)
+	d := float32(decisionConfidence)
+	if decisionConfidence != decisionConfidence { // NaN
+		d = 0
+	}
+	if d < 0 {
+		d = 0
+	}
+	if d > 1 {
+		d = 1
+	}
+	return cat * (0.45 + 0.55*d)
+}
+
+func repetitionPenalty(candidateName string, history []string, strength float32) float32 {
+	if strength <= 0 || len(history) == 0 {
+		return 0
+	}
+	var count int
+	for _, h := range history {
+		if h == candidateName {
+			count++
+		}
+	}
+	if count == 0 {
+		return 0
+	}
+	// Penalize redundant re-selection; first occurrence is not penalized.
+	excess := count - 1
+	if excess < 0 {
+		excess = 0
+	}
+	return strength * float32(excess) * 0.35
+}
+
+func minFloat32(a, b float32) float32 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/src/semantic-router/pkg/tools/hybrid_history_test.go
+++ b/src/semantic-router/pkg/tools/hybrid_history_test.go
@@ -1,0 +1,145 @@
+package tools_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+)
+
+var _ = Describe("FilterAndRankToolsWithConversation hybrid_history", func() {
+	It("falls back to semantic-only ranking when history is too short", func() {
+		minSteps := 2
+		th := float32(0.05)
+		advanced := &config.AdvancedToolFilteringConfig{
+			Enabled:           true,
+			RetrievalStrategy: config.ToolRetrievalStrategyHybridHistory,
+			HybridHistory: &config.HybridHistoryToolRetrievalConfig{
+				MinHistorySteps:            &minSteps,
+				HistoryConfidenceThreshold: &th,
+			},
+		}
+		candidates := []tools.ToolSimilarity{
+			candidate("alpha", "desc", "c", nil, 0.9),
+			candidate("beta", "desc", "c", nil, 0.5),
+		}
+		selected := tools.FilterAndRankToolsWithConversation("q", candidates, 2, advanced, "", []string{"alpha"}, 0.9)
+		Expect(selected).To(HaveLen(2))
+		Expect(selected[0].Function.Name).To(Equal("alpha"))
+	})
+
+	It("ranks by transition when last tool predicts the next", func() {
+		advanced := &config.AdvancedToolFilteringConfig{
+			Enabled:           true,
+			RetrievalStrategy: config.ToolRetrievalStrategyHybridHistory,
+		}
+		// History: tool_a -> tool_b, then tool_b -> tool_b (last call is tool_b)
+		hist := []string{"tool_a", "tool_b", "tool_b"}
+		candidates := []tools.ToolSimilarity{
+			candidate("tool_b", "next after b", "c", nil, 0.5),
+			candidate("tool_c", "other", "c", nil, 0.5),
+		}
+		selected := tools.FilterAndRankToolsWithConversation("query", candidates, 2, advanced, "", hist, 0.5)
+		Expect(selected[0].Function.Name).To(Equal("tool_b"))
+	})
+
+	It("applies repetition penalty when the same tool appears often in the window", func() {
+		rep := float32(0.5)
+		advanced := &config.AdvancedToolFilteringConfig{
+			Enabled:           true,
+			RetrievalStrategy: config.ToolRetrievalStrategyHybridHistory,
+			HybridHistory: &config.HybridHistoryToolRetrievalConfig{
+				RepetitionPenaltyStrength: &rep,
+			},
+		}
+		hist := []string{"spam", "spam", "spam", "pivot_step"}
+		candidates := []tools.ToolSimilarity{
+			candidate("spam", "does spam", "c", nil, 0.99),
+			candidate("other", "does other", "c", nil, 0.4),
+		}
+		selected := tools.FilterAndRankToolsWithConversation("q", candidates, 2, advanced, "", hist, 0.9)
+		Expect(selected[0].Function.Name).To(Equal("other"))
+	})
+})
+
+// hybrid_history signal strength: integration-style checks that fallback matches pure semantic order,
+// while full hybrid can reorder when transition strongly favors a lower-similarity tool (multi-step plan).
+var _ = Describe("hybrid_history fallback vs active hybrid (realistic scenarios)", func() {
+	// Shared scenario: query matches both tools lexically; semantic-only would prefer high_rank.
+	// History mimics "already called next_tool twice after open_session" — transition favors next_tool again.
+	historyFavoringNextTool := []string{"open_session", "next_tool", "next_tool"}
+	highThenLow := []tools.ToolSimilarity{
+		candidate("high_rank", "generic assistant description user query", "misc", nil, 0.96),
+		candidate("next_tool", "specialized follow-up chain step", "misc", nil, 0.38),
+	}
+
+	It("falls back to semantic-only when history_signal_strength is below history_confidence_threshold", func() {
+		// len=3, horizon=8 -> strength = 3/8 * diversity(1) = 0.375; threshold 0.99 forces fallback.
+		th := float32(0.99)
+		advanced := &config.AdvancedToolFilteringConfig{
+			Enabled:           true,
+			RetrievalStrategy: config.ToolRetrievalStrategyHybridHistory,
+			HybridHistory: &config.HybridHistoryToolRetrievalConfig{
+				HistoryConfidenceThreshold: &th,
+			},
+		}
+		selected := tools.FilterAndRankToolsWithConversation(
+			"assistant query user description",
+			highThenLow,
+			2,
+			advanced,
+			"",
+			historyFavoringNextTool,
+			0.85,
+		)
+		Expect(selected).To(HaveLen(2))
+		Expect(selected[0].Function.Name).To(Equal("high_rank"), "pure semantic: highest similarity first")
+		Expect(selected[1].Function.Name).To(Equal("next_tool"))
+	})
+
+	It("does not fall back when history_signal_strength meets history_confidence_threshold — hybrid can outrank by transition", func() {
+		// Same history and candidates; threshold 0.2 so 0.375 > 0.2 — run hybrid. Transition from last
+		// `next_tool` strongly supports another `next_tool` call; that beats high_rank on embedding alone.
+		th := float32(0.2)
+		advanced := &config.AdvancedToolFilteringConfig{
+			Enabled:           true,
+			RetrievalStrategy: config.ToolRetrievalStrategyHybridHistory,
+			HybridHistory: &config.HybridHistoryToolRetrievalConfig{
+				HistoryConfidenceThreshold: &th,
+			},
+		}
+		selected := tools.FilterAndRankToolsWithConversation(
+			"assistant query user description",
+			highThenLow,
+			2,
+			advanced,
+			"",
+			historyFavoringNextTool,
+			0.85,
+		)
+		Expect(selected).To(HaveLen(2))
+		Expect(selected[0].Function.Name).To(Equal("next_tool"), "transition + equal weights should promote the plan-consistent tool")
+		Expect(selected[1].Function.Name).To(Equal("high_rank"))
+	})
+
+	It("falls back to semantic-only when transcript has fewer tool steps than min_history_steps (cold start)", func() {
+		minSteps := 3
+		advanced := &config.AdvancedToolFilteringConfig{
+			Enabled:           true,
+			RetrievalStrategy: config.ToolRetrievalStrategyHybridHistory,
+			HybridHistory: &config.HybridHistoryToolRetrievalConfig{
+				MinHistorySteps: &minSteps,
+			},
+		}
+		// Only one prior tool in window — not enough for hybrid per policy.
+		hist := []string{"only_prior_tool"}
+		candidates := []tools.ToolSimilarity{
+			candidate("strong_match", "matches query vocabulary", "misc", nil, 0.91),
+			candidate("weak_match", "looser text match", "misc", nil, 0.42),
+		}
+		selected := tools.FilterAndRankToolsWithConversation("query words strong vocabulary", candidates, 2, advanced, "", hist, 0.7)
+		Expect(selected[0].Function.Name).To(Equal("strong_match"))
+		Expect(selected[1].Function.Name).To(Equal("weak_match"))
+	})
+})

--- a/src/semantic-router/pkg/tools/relevance.go
+++ b/src/semantic-router/pkg/tools/relevance.go
@@ -14,6 +14,20 @@ import (
 
 // FilterAndRankTools applies advanced filtering and ranking to tool candidates.
 func FilterAndRankTools(query string, candidates []ToolSimilarity, topK int, advanced *config.AdvancedToolFilteringConfig, selectedCategory string) []openai.ChatCompletionToolParam {
+	return FilterAndRankToolsWithConversation(query, candidates, topK, advanced, selectedCategory, nil, 0)
+}
+
+// FilterAndRankToolsWithConversation is like FilterAndRankTools but supplies assistant tool-call
+// history and decision confidence for hybrid_history retrieval.
+func FilterAndRankToolsWithConversation(
+	query string,
+	candidates []ToolSimilarity,
+	topK int,
+	advanced *config.AdvancedToolFilteringConfig,
+	selectedCategory string,
+	toolHistory []string,
+	decisionConfidence float64,
+) []openai.ChatCompletionToolParam {
 	if len(candidates) == 0 {
 		return []openai.ChatCompletionToolParam{}
 	}
@@ -24,68 +38,95 @@ func FilterAndRankTools(query string, candidates []ToolSimilarity, topK int, adv
 	filtered := applyAllowBlockFilters(candidates, advanced.AllowTools, advanced.BlockTools)
 	filtered = applyCategoryFilter(filtered, advanced.UseCategoryFilter, selectedCategory)
 
+	if config.IsHybridHistoryRetrieval(advanced) {
+		return filterAndRankHybridHistory(query, filtered, topK, advanced, selectedCategory, toolHistory, decisionConfidence)
+	}
+	return filterAndRankWeightedLexical(query, filtered, topK, advanced, selectedCategory)
+}
+
+func filterAndRankWeightedLexical(query string, filtered []ToolSimilarity, topK int, advanced *config.AdvancedToolFilteringConfig, selectedCategory string) []openai.ChatCompletionToolParam {
 	queryTokens := tokenize(query)
 	querySet := tokenSet(queryTokens)
 	queryTokenCount := len(queryTokens)
 
 	weights := resolveWeights(advanced.Weights)
 	weightSum := weights.embed + weights.lexical + weights.tag + weights.name + weights.category
-	minOverlap := 0
-	if advanced.MinLexicalOverlap != nil {
-		minOverlap = *advanced.MinLexicalOverlap
-	}
-
-	minCombined := float32(0)
-	if advanced.MinCombinedScore != nil {
-		minCombined = *advanced.MinCombinedScore
-	}
+	minOverlap, minCombined := minLexicalOverlapAndMinCombined(advanced)
 
 	scored := make([]scoredCandidate, 0, len(filtered))
 	for _, candidate := range filtered {
-		nameTokens := tokenize(candidate.Entry.Tool.Function.Name)
-		descriptionTokens := tokenize(candidate.Entry.Description)
-		categoryTokens := tokenize(candidate.Entry.Category)
-		tagTokens := collectTagTokens(candidate.Entry.Tags)
-
-		lexicalTokens := make([]string, 0, len(nameTokens)+len(descriptionTokens)+len(categoryTokens))
-		lexicalTokens = append(lexicalTokens, nameTokens...)
-		lexicalTokens = append(lexicalTokens, descriptionTokens...)
-		lexicalTokens = append(lexicalTokens, categoryTokens...)
-
-		lexicalOverlap := countOverlap(querySet, lexicalTokens)
-		if minOverlap > 0 && lexicalOverlap < minOverlap {
-			continue
+		if combined, ok := weightedCandidateCombinedScore(
+			candidate, querySet, queryTokenCount, selectedCategory, weights, weightSum, minOverlap, minCombined,
+		); ok {
+			scored = append(scored, scoredCandidate{ToolSimilarity: candidate, CombinedScore: combined})
 		}
-
-		lexicalScore := scoreOverlap(queryTokenCount, lexicalOverlap)
-		tagScore := scoreOverlap(len(tagTokens), countOverlap(querySet, tagTokens))
-		nameScore := nameMatchScore(nameTokens, querySet)
-		categoryScore := categoryMatchScore(selectedCategory, candidate.Entry.Category)
-		similarityScore := clamp01(candidate.Similarity)
-
-		combinedScore := float32(0)
-		if weightSum > 0 {
-			combinedScore = (weights.embed*similarityScore +
-				weights.lexical*lexicalScore +
-				weights.tag*tagScore +
-				weights.name*nameScore +
-				weights.category*categoryScore) / weightSum
-		}
-
-		if combinedScore < minCombined {
-			continue
-		}
-
-		scored = append(scored, scoredCandidate{
-			ToolSimilarity: candidate,
-			CombinedScore:  combinedScore,
-		})
 	}
 
 	if len(scored) == 0 {
 		return []openai.ChatCompletionToolParam{}
 	}
 
+	sortScoredCandidatesByCombinedThenSimilarity(scored)
+
+	return topKToolsFromScored(scored, topK)
+}
+
+func minLexicalOverlapAndMinCombined(advanced *config.AdvancedToolFilteringConfig) (minOverlap int, minCombined float32) {
+	if advanced.MinLexicalOverlap != nil {
+		minOverlap = *advanced.MinLexicalOverlap
+	}
+	if advanced.MinCombinedScore != nil {
+		minCombined = *advanced.MinCombinedScore
+	}
+	return minOverlap, minCombined
+}
+
+func weightedCandidateCombinedScore(
+	candidate ToolSimilarity,
+	querySet map[string]struct{},
+	queryTokenCount int,
+	selectedCategory string,
+	weights resolvedWeights,
+	weightSum float32,
+	minOverlap int,
+	minCombined float32,
+) (float32, bool) {
+	nameTokens := tokenize(candidate.Entry.Tool.Function.Name)
+	descriptionTokens := tokenize(candidate.Entry.Description)
+	categoryTokens := tokenize(candidate.Entry.Category)
+	tagTokens := collectTagTokens(candidate.Entry.Tags)
+
+	lexicalTokens := make([]string, 0, len(nameTokens)+len(descriptionTokens)+len(categoryTokens))
+	lexicalTokens = append(lexicalTokens, nameTokens...)
+	lexicalTokens = append(lexicalTokens, descriptionTokens...)
+	lexicalTokens = append(lexicalTokens, categoryTokens...)
+
+	lexicalOverlap := countOverlap(querySet, lexicalTokens)
+	if minOverlap > 0 && lexicalOverlap < minOverlap {
+		return 0, false
+	}
+
+	lexicalScore := scoreOverlap(queryTokenCount, lexicalOverlap)
+	tagScore := scoreOverlap(len(tagTokens), countOverlap(querySet, tagTokens))
+	nameScore := nameMatchScore(nameTokens, querySet)
+	categoryScore := categoryMatchScore(selectedCategory, candidate.Entry.Category)
+	similarityScore := clamp01(candidate.Similarity)
+
+	var combined float32
+	if weightSum > 0 {
+		combined = (weights.embed*similarityScore +
+			weights.lexical*lexicalScore +
+			weights.tag*tagScore +
+			weights.name*nameScore +
+			weights.category*categoryScore) / weightSum
+	}
+	if combined < minCombined {
+		return 0, false
+	}
+	return combined, true
+}
+
+func sortScoredCandidatesByCombinedThenSimilarity(scored []scoredCandidate) {
 	sort.Slice(scored, func(i, j int) bool {
 		if scored[i].CombinedScore == scored[j].CombinedScore {
 			if scored[i].Similarity == scored[j].Similarity {
@@ -95,18 +136,18 @@ func FilterAndRankTools(query string, candidates []ToolSimilarity, topK int, adv
 		}
 		return scored[i].CombinedScore > scored[j].CombinedScore
 	})
+}
 
+func topKToolsFromScored(scored []scoredCandidate, topK int) []openai.ChatCompletionToolParam {
 	limit := topK
 	if limit <= 0 || limit > len(scored) {
 		limit = len(scored)
 	}
-
-	selected := make([]openai.ChatCompletionToolParam, 0, limit)
+	out := make([]openai.ChatCompletionToolParam, 0, limit)
 	for i := 0; i < limit; i++ {
-		selected = append(selected, scored[i].Entry.Tool)
+		out = append(out, scored[i].Entry.Tool)
 	}
-
-	return selected
+	return out
 }
 
 type scoredCandidate struct {


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes https://github.com/vllm-project/semantic-router/issues/1834

## Purpose

- What does this PR change?
A hybrid history-aware tool recall strategy has been added to the advanced filtering section of global.integrations.tools: in addition to semantic relevance, candidate tools are ranked by combining recent assistant tool call sequences (short window transitions, decision/class priors, repetition penalties, etc.); and a pure semantic ranking is reverted to a configurable threshold when there is a "weak historical signal". The YAML examples, model configuration types, validation, and history extraction and routing logic in extproc have also been updated accordingly.

- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

1.`It falls back to semantic-only ranking when history is too short`: With the shortest history step count and a low confidence threshold configured, it's shown that a short history will revert to pure similarity ranking (alpha remains first).

2.`Ranks by transition when the last tool predicts the next`: When candidate embeddings are the same, it's shown that when the previous step in the history was tool_b, the transition score will rank tool_b before tool_c.

3.`Applies repetition penalty when the same tool often appears in the window`: With repetition penalty enabled and the history ending with pivot_step, it's shown that even if spam has higher similarity, it will be pushed down to second place, with other tools ranking first.

4.`Falls back to semantic-only ranking when history_signal_strength is below history_confidence_threshold`: Setting history_confidence_threshold to an extremely high value shows that the overall historical signal is not strong enough, leading to a regression, consistent with purely semantic ranking (high_rank is before next_tool).

5.`It does not fall back when history_signal_strength meets history_confidence_threshold `: When the same set of history and candidates is used, but the threshold is lowered, it proves that mixed ranking works, and the shift allows the less similar `next_tool` to surpass `high_rank`.

6.`It falls back to semantic-only when the transcript has fewer tool steps than `min_history_steps` (cold start)`: When at least 3 history steps are required but there is only 1 tool name in the dialogue, it proves that not meeting `min_history_steps` will revert to ranking by query similarity (strong_match before weak_match).

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
