### PR TITLE
feat: wire dynamic retriever into extproc tool selection flow

### DIFF
--- a/src/semantic-router/pkg/config/tools_plugin.go
+++ b/src/semantic-router/pkg/config/tools_plugin.go
@@ -6,6 +6,10 @@ const (
 	ToolsPluginModeNone        = "none"
 	ToolsPluginModePassthrough = "passthrough"
 	ToolsPluginModeFiltered    = "filtered"
+
+	// ToolsStrategyDefault is the strategy name used when no explicit strategy
+	// is configured.  It resolves to the embedding-similarity retriever.
+	ToolsStrategyDefault = "default"
 )
 
 // ToolsPluginConfig represents per-decision tool handling.
@@ -16,6 +20,10 @@ type ToolsPluginConfig struct {
 	SemanticSelection *bool    `json:"semantic_selection,omitempty" yaml:"semantic_selection,omitempty"`
 	AllowTools        []string `json:"allow_tools,omitempty" yaml:"allow_tools,omitempty"`
 	BlockTools        []string `json:"block_tools,omitempty" yaml:"block_tools,omitempty"`
+	// Strategy names the retriever strategy to use for semantic tool selection.
+	// When empty, EffectiveStrategy returns ToolsStrategyDefault.
+	// The value must match a name registered in the router's tools.Registry.
+	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 }
 
 // GetToolsConfig returns the tools plugin configuration.
@@ -30,6 +38,15 @@ func (c *ToolsPluginConfig) EffectiveMode() string {
 		return ToolsPluginModePassthrough
 	}
 	return c.Mode
+}
+
+// EffectiveStrategy returns the retriever strategy name, defaulting to
+// ToolsStrategyDefault when none is configured.
+func (c *ToolsPluginConfig) EffectiveStrategy() string {
+	if c == nil || c.Strategy == "" {
+		return ToolsStrategyDefault
+	}
+	return c.Strategy
 }
 
 // SelectionEnabled reports whether semantic tool selection is allowed for this plugin.

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -1,9 +1,12 @@
 package extproc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -11,6 +14,7 @@ import (
 	"github.com/openai/openai-go/packages/param"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
@@ -21,15 +25,13 @@ const (
 	candidatePoolMinSize    = 20
 )
 
-// handleToolSelectionForRequest handles tool selection for the request
+// handleToolSelectionForRequest handles tool selection for the request.
 func (r *OpenAIRouter) handleToolSelectionForRequest(openAIRequest *openai.ChatCompletionNewParams, response *ext_proc.ProcessingResponse, ctx *RequestContext) {
 	userContent, nonUserMessages := extractUserAndNonUserContent(openAIRequest)
-
 	if err := r.handleToolSelection(openAIRequest, userContent, nonUserMessages, &response, ctx); err != nil {
 		logging.Errorf("Error in tool selection: %v", err)
 		// Continue without failing the request
 	}
-
 	if clearToolChoiceWhenNoTools(openAIRequest) {
 		if err := r.updateRequestWithTools(openAIRequest, &response, ctx); err != nil {
 			logging.Errorf("Error clearing invalid tool_choice without tools: %v", err)
@@ -37,42 +39,39 @@ func (r *OpenAIRouter) handleToolSelectionForRequest(openAIRequest *openai.ChatC
 	}
 }
 
-// handleToolSelection handles automatic tool selection based on semantic similarity
-func (r *OpenAIRouter) handleToolSelection(openAIRequest *openai.ChatCompletionNewParams, userContent string, nonUserMessages []string, response **ext_proc.ProcessingResponse, ctx *RequestContext) error {
-	toolsCfg := resolveDecisionToolsConfig(ctx)
-	if toolsCfg == nil || !toolsCfg.Enabled {
+func (r *OpenAIRouter) applySelectedTools(
+	openAIRequest *openai.ChatCompletionNewParams,
+	selectedTools []openai.ChatCompletionToolParam,
+	strategyID string,
+	confidence float32,
+	latency time.Duration,
+	classificationText string,
+) error {
+	if len(selectedTools) == 0 {
+		if r.Config.Tools.FallbackToEmpty {
+			logging.Infof("No suitable tools found, falling back to no tools")
+			openAIRequest.Tools = nil
+		} else {
+			logging.Infof("No suitable tools found above threshold")
+			openAIRequest.Tools = []openai.ChatCompletionToolParam{}
+		}
 		return nil
 	}
-
-	finished, err := r.applyDecisionToolsPluginMode(openAIRequest, response, ctx, toolsCfg)
-	if err != nil || finished {
+	sdkTools, err := convertToSDKTools(selectedTools)
+	if err != nil {
+		metrics.RecordRequestError(openAIRequest.Model, "serialization_error")
 		return err
 	}
-
-	if openAIRequest.ToolChoice.OfAuto.Value != "auto" {
-		return nil
-	}
-	if !toolsCfg.SelectionEnabled() {
-		return r.updateRequestWithTools(openAIRequest, response, ctx)
-	}
-
-	classificationText := toolClassificationText(userContent, nonUserMessages)
-	if classificationText == "" {
-		logging.Infof("No content available for tool classification")
-		return nil
-	}
-
-	if !r.ToolsDatabase.IsEnabled() {
-		logging.Infof("Tools database is disabled")
-		return nil
-	}
-
-	return r.runSemanticToolSelectionAndUpdate(openAIRequest, response, ctx, toolsCfg, classificationText)
+	openAIRequest.Tools = sdkTools
+	logging.Infof("Auto-selected %d tools via strategy %q (confidence=%.3f, latency=%s) for query: %s",
+		len(sdkTools), strategyID, confidence, latency.Round(time.Millisecond), classificationText)
+	return nil
 }
 
-// applyDecisionToolsPluginMode enforces per-decision none / filtered / passthrough. The boolean is
-// true when the request body has already been finalized for this path (caller returns).
-func (r *OpenAIRouter) applyDecisionToolsPluginMode(
+// handleEarlyToolModes applies the tool plugin mode (none, filtered, passthrough)
+// and returns true if the caller should proceed to semantic tool selection.
+// If it returns false, the request has already been updated and the caller must return nil.
+func (r *OpenAIRouter) handleEarlyToolModes(
 	openAIRequest *openai.ChatCompletionNewParams,
 	response **ext_proc.ProcessingResponse,
 	ctx *RequestContext,
@@ -82,44 +81,50 @@ func (r *OpenAIRouter) applyDecisionToolsPluginMode(
 	case config.ToolsPluginModeNone:
 		logging.Infof("[ToolsPlugin] Decision %q has mode=none, stripping all tools", ctx.VSRSelectedDecision.Name)
 		openAIRequest.Tools = nil
-		return true, r.updateRequestWithTools(openAIRequest, response, ctx)
+		if err := r.updateRequestWithTools(openAIRequest, response, ctx); err != nil {
+			return false, err
+		}
+		return false, nil
+
 	case config.ToolsPluginModeFiltered:
 		openAIRequest.Tools = filterToolsByDecisionPolicy(openAIRequest.Tools, toolsCfg.AllowTools, toolsCfg.BlockTools)
 		if openAIRequest.ToolChoice.OfAuto.Value != "auto" {
 			logging.Infof("[ToolsPlugin] Decision %q filtered explicit tools to %d entries", ctx.VSRSelectedDecision.Name, len(openAIRequest.Tools))
-			return true, r.updateRequestWithTools(openAIRequest, response, ctx)
+			if err := r.updateRequestWithTools(openAIRequest, response, ctx); err != nil {
+				return false, err
+			}
+			return false, nil
 		}
+		return true, nil
+
 	case config.ToolsPluginModePassthrough:
-		// Semantic selection may run below.
+		return openAIRequest.ToolChoice.OfAuto.Value == "auto", nil
+
 	default:
 		return false, fmt.Errorf("tools plugin: unsupported mode %q", toolsCfg.Mode)
 	}
-	return false, nil
 }
 
-func toolClassificationText(userContent string, nonUserMessages []string) string {
-	if len(userContent) > 0 {
-		return userContent
-	}
-	if len(nonUserMessages) > 0 {
-		return strings.Join(nonUserMessages, " ")
-	}
-	return ""
-}
-
-func (r *OpenAIRouter) runSemanticToolSelectionAndUpdate(
+// runSemanticToolSelection performs the retrieval, observability reporting,
+// fallback handling and final tool application after the earlier mode checks
+// have determined that semantic selection should run.
+func (r *OpenAIRouter) runSemanticToolSelection(
 	openAIRequest *openai.ChatCompletionNewParams,
+	classificationText string,
 	response **ext_proc.ProcessingResponse,
 	ctx *RequestContext,
 	toolsCfg *config.ToolsPluginConfig,
-	classificationText string,
 ) error {
-	selectedTools, toolErr := r.findToolsForQuery(classificationText, ctx, toolsCfg, openAIRequest)
+	selectedTools, strategyID, confidence, latency, toolErr := r.findToolsForQuery(classificationText, ctx, toolsCfg)
+
+	emitToolObservability(response, strategyID, confidence, latency)
+	metrics.RecordToolsRetrieval(strategyID, latency.Seconds())
+
 	if toolErr != nil {
 		return r.handleToolSelectionError(openAIRequest, response, ctx, toolErr)
 	}
 
-	if err := applySelectedToolsToOpenAIRequest(r, openAIRequest, selectedTools, classificationText, ctx); err != nil {
+	if err := r.applySelectedTools(openAIRequest, selectedTools, strategyID, confidence, latency, classificationText); err != nil {
 		return err
 	}
 	return r.updateRequestWithTools(openAIRequest, response, ctx)
@@ -140,66 +145,155 @@ func (r *OpenAIRouter) handleToolSelectionError(
 	return toolErr
 }
 
-func applySelectedToolsToOpenAIRequest(
-	r *OpenAIRouter,
+// handleToolSelection handles automatic tool selection based on semantic similarity.
+func (r *OpenAIRouter) handleToolSelection(
 	openAIRequest *openai.ChatCompletionNewParams,
-	selectedTools []openai.ChatCompletionToolParam,
-	classificationText string,
+	userContent string,
+	nonUserMessages []string,
+	response **ext_proc.ProcessingResponse,
 	ctx *RequestContext,
 ) error {
-	if len(selectedTools) == 0 {
-		applyNoToolsFromSelection(r, openAIRequest)
+	toolsCfg := resolveDecisionToolsConfig(ctx)
+	if toolsCfg == nil || !toolsCfg.Enabled {
 		return nil
 	}
-	sdkTools, err := convertToSDKTools(selectedTools)
+
+	shouldContinue, err := r.handleEarlyToolModes(openAIRequest, response, ctx, toolsCfg)
 	if err != nil {
-		metrics.RecordRequestError(getModelFromCtx(ctx), "serialization_error")
 		return err
 	}
-	openAIRequest.Tools = sdkTools
-	logging.Infof("Auto-selected %d tools for query: %s", len(sdkTools), classificationText)
-	return nil
-}
-
-func applyNoToolsFromSelection(r *OpenAIRouter, openAIRequest *openai.ChatCompletionNewParams) {
-	if r.Config.Tools.FallbackToEmpty {
-		logging.Infof("No suitable tools found, falling back to no tools")
-		openAIRequest.Tools = nil
-		return
+	if !shouldContinue {
+		return nil
 	}
-	logging.Infof("No suitable tools found above threshold")
-	openAIRequest.Tools = []openai.ChatCompletionToolParam{}
+
+	if !toolsCfg.SelectionEnabled() {
+		return r.updateRequestWithTools(openAIRequest, response, ctx)
+	}
+
+	// Build classification text.
+	var classificationText string
+	if len(userContent) > 0 {
+		classificationText = userContent
+	} else if len(nonUserMessages) > 0 {
+		classificationText = strings.Join(nonUserMessages, " ")
+	}
+	if classificationText == "" {
+		logging.Infof("No content available for tool classification")
+		return nil
+	}
+
+	if !r.ToolsDatabase.IsEnabled() {
+		logging.Infof("Tools database is disabled")
+		return nil
+	}
+
+	return r.runSemanticToolSelection(openAIRequest, classificationText, response, ctx, toolsCfg)
 }
 
-// findToolsForQuery discovers candidate tools via semantic similarity, applying
-// advanced filtering when configured.
-func (r *OpenAIRouter) findToolsForQuery(query string, ctx *RequestContext, toolsCfg *config.ToolsPluginConfig, openAIRequest *openai.ChatCompletionNewParams) ([]openai.ChatCompletionToolParam, error) {
+// executeRetrieval resolves the retriever for strategyID from the registry and
+// runs it. If the registry is nil or the strategy is not found, it falls back
+// to ToolsDatabase directly and marks the returned StrategyID with "-fallback".
+func (r *OpenAIRouter) executeRetrieval(ctx context.Context, query, strategyID string, topK int) (tools.RetrievalResult, error) {
+	if r.ToolsRegistry != nil {
+		if retriever, ok := r.ToolsRegistry.Get(strategyID); ok {
+			return retriever.Retrieve(ctx, query, topK)
+		}
+
+		// Named strategy not found — try "default" before falling back to DB
+		if retriever, ok := r.ToolsRegistry.Get("default"); ok {
+			logging.Warnf("[ToolsPlugin] strategy %q not found, falling back to default", strategyID)
+			result, err := retriever.Retrieve(ctx, query, topK)
+			result.StrategyID = strategyID + "-fallback"
+			return result, err
+		}
+
+		logging.Warnf("[ToolsPlugin] strategy %q not found in registry, using ToolsDatabase directly", strategyID)
+	} else {
+		logging.Warnf("[ToolsPlugin] registry not initialized for strategy %q, using ToolsDatabase directly", strategyID)
+	}
+
+	results, err := r.ToolsDatabase.FindSimilarToolsWithScores(query, topK)
+	if err != nil {
+		return tools.RetrievalResult{StrategyID: strategyID + "-fallback"}, err
+	}
+
+	confidence := float32(0)
+	if len(results) > 0 {
+		confidence = results[0].Similarity
+	}
+
+	return tools.RetrievalResult{
+		Tools:      results,
+		Confidence: confidence,
+		StrategyID: strategyID + "-fallback",
+	}, nil
+}
+
+// findToolsForQuery resolves the retriever strategy from the registry, executes
+// retrieval, applies advanced filtering, and returns the final tool list together
+// with the strategy name, top-1 confidence score, and retrieval wall-clock time.
+func (r *OpenAIRouter) findToolsForQuery(query string, ctx *RequestContext, toolsCfg *config.ToolsPluginConfig) ([]openai.ChatCompletionToolParam, string, float32, time.Duration, error) {
 	topK := r.Config.Tools.TopK
 	if topK <= 0 {
 		topK = 3
 	}
 
+	strategyID := toolsCfg.EffectiveStrategy()
+	poolSize := resolveCandidatePoolSize(r.Config.Tools.AdvancedFiltering, topK)
 	advanced := mergeAdvancedToolFiltering(r.Config.Tools.AdvancedFiltering, toolsCfg)
-	if advanced == nil || !advanced.Enabled {
-		return r.ToolsDatabase.FindSimilarTools(query, topK)
+
+	if advanced != nil && advanced.Enabled {
+		poolSize = resolveCandidatePoolSize(advanced, topK)
 	}
 
-	candidates, err := r.ToolsDatabase.FindSimilarToolsWithScores(query, resolveCandidatePoolSize(advanced, topK))
+	retrievalCtx := context.Background()
+	if ctx != nil && ctx.TraceContext != nil {
+		retrievalCtx = ctx.TraceContext
+	}
+
+	start := time.Now()
+	retrieved, err := r.executeRetrieval(retrievalCtx, query, strategyID, poolSize)
+	latency := time.Since(start)
+
 	if err != nil {
-		return nil, err
+		return nil, retrieved.StrategyID, 0, latency, err
 	}
 
-	category := resolveCategory(advanced, ctx)
-	if config.IsHybridHistoryRetrieval(advanced) {
-		hz := config.ResolveHybridHistoryHorizon(advanced)
-		toolNames := extractRecentAssistantToolCallNames(openAIRequest, hz)
-		dec := 0.0
-		if ctx != nil {
-			dec = ctx.VSRSelectedDecisionConfidence
-		}
-		return tools.FilterAndRankToolsWithConversation(query, candidates, topK, advanced, category, toolNames, dec), nil
+	if advanced == nil || !advanced.Enabled {
+		return selectTopKTools(retrieved.Tools, topK), retrieved.StrategyID, retrieved.Confidence, latency, nil
 	}
-	return tools.FilterAndRankTools(query, candidates, topK, advanced, category), nil
+
+	selected := tools.FilterAndRankTools(query, retrieved.Tools, topK, advanced, resolveCategory(advanced, ctx))
+	return selected, retrieved.StrategyID, retrieved.Confidence, latency, nil
+}
+
+// emitToolObservability writes the three x-vsr-tools-* headers into the
+// in-flight ProcessingResponse so they reach the client as response headers.
+func emitToolObservability(response **ext_proc.ProcessingResponse, strategyID string, confidence float32, latency time.Duration) {
+	if response == nil || *response == nil {
+		return
+	}
+	commonResponse := ensureRequestBodyCommonResponse(response)
+	if commonResponse.HeaderMutation == nil {
+		commonResponse.HeaderMutation = &ext_proc.HeaderMutation{}
+	}
+	setHeaderValue(commonResponse.HeaderMutation, headers.VSRToolsStrategy, strategyID)
+	setHeaderValue(commonResponse.HeaderMutation, headers.VSRToolsConfidence, strconv.FormatFloat(float64(confidence), 'f', 4, 32))
+	setHeaderValue(commonResponse.HeaderMutation, headers.VSRToolsLatencyMs, strconv.FormatInt(latency.Milliseconds(), 10))
+}
+
+// selectTopKTools returns the top-K entries from candidates by similarity
+// without applying advanced filtering.
+func selectTopKTools(candidates []tools.ToolSimilarity, topK int) []openai.ChatCompletionToolParam {
+	limit := topK
+	if limit <= 0 || limit > len(candidates) {
+		limit = len(candidates)
+	}
+	selected := make([]openai.ChatCompletionToolParam, 0, limit)
+	for i := 0; i < limit; i++ {
+		selected = append(selected, candidates[i].Entry.Tool)
+	}
+	return selected
 }
 
 func resolveCandidatePoolSize(advanced *config.AdvancedToolFilteringConfig, topK int) int {
@@ -244,7 +338,6 @@ func mergeAdvancedToolFiltering(base *config.AdvancedToolFilteringConfig, toolsC
 	if toolsCfg == nil || toolsCfg.EffectiveMode() != config.ToolsPluginModeFiltered {
 		return base
 	}
-
 	allowTools, blockTools := mergeToolFilters(base, toolsCfg)
 	if base == nil {
 		return &config.AdvancedToolFilteringConfig{
@@ -253,7 +346,6 @@ func mergeAdvancedToolFiltering(base *config.AdvancedToolFilteringConfig, toolsC
 			BlockTools: blockTools,
 		}
 	}
-
 	merged := *base
 	merged.AllowTools = allowTools
 	merged.BlockTools = blockTools
@@ -269,7 +361,6 @@ func mergeToolFilters(base *config.AdvancedToolFilteringConfig, toolsCfg *config
 	}
 	pluginAllow := append([]string(nil), toolsCfg.AllowTools...)
 	pluginBlock := append([]string(nil), toolsCfg.BlockTools...)
-
 	return intersectToolAllowLists(globalAllow, pluginAllow), unionToolBlockLists(globalBlock, pluginBlock)
 }
 
@@ -280,12 +371,10 @@ func intersectToolAllowLists(left, right []string) []string {
 	case len(right) == 0:
 		return append([]string(nil), left...)
 	}
-
 	rightSet := make(map[string]struct{}, len(right))
 	for _, value := range right {
 		rightSet[strings.ToLower(strings.TrimSpace(value))] = struct{}{}
 	}
-
 	result := make([]string, 0, min(len(left), len(right)))
 	seen := make(map[string]struct{})
 	for _, value := range left {
@@ -351,7 +440,6 @@ func filterToolsByDecisionPolicy(tools []openai.ChatCompletionToolParam, allowTo
 	for _, t := range blockTools {
 		blockSet[t] = true
 	}
-
 	filtered := make([]openai.ChatCompletionToolParam, 0, len(tools))
 	for _, tool := range tools {
 		name := tool.Function.Name
@@ -366,37 +454,29 @@ func filterToolsByDecisionPolicy(tools []openai.ChatCompletionToolParam, allowTo
 	return filtered
 }
 
-// updateRequestWithTools updates the request body with the selected tools
+// updateRequestWithTools updates the request body with the selected tools.
 func (r *OpenAIRouter) updateRequestWithTools(openAIRequest *openai.ChatCompletionNewParams, response **ext_proc.ProcessingResponse, ctx *RequestContext) error {
-	// Re-serialize the request with modified tools and preserved stream parameter
 	modifiedBody, err := serializeOpenAIRequestWithStream(openAIRequest, ctx.ExpectStreamingResponse)
 	if err != nil {
 		return err
 	}
-
-	// Create body mutation with the modified body
 	bodyMutation := &ext_proc.BodyMutation{
 		Mutation: &ext_proc.BodyMutation_Body{
 			Body: modifiedBody,
 		},
 	}
-
 	commonResponse := ensureRequestBodyCommonResponse(response)
 	commonResponse.Status = ext_proc.CommonResponse_CONTINUE
 	commonResponse.BodyMutation = bodyMutation
 	if commonResponse.HeaderMutation == nil {
 		commonResponse.HeaderMutation = &ext_proc.HeaderMutation{}
 	}
-
 	ensureHeaderRemoved(commonResponse.HeaderMutation, "content-length")
 	setHeaderValue(commonResponse.HeaderMutation, "content-length", fmt.Sprintf("%d", len(modifiedBody)))
-
-	// Check if route cache should be cleared
 	if r.shouldClearRouteCache() {
 		commonResponse.ClearRouteCache = true
 		logging.Debugf("Setting ClearRouteCache=true (feature enabled) in updateRequestWithTools")
 	}
-
 	return nil
 }
 
@@ -428,7 +508,6 @@ func clearToolChoiceWhenNoTools(openAIRequest *openai.ChatCompletionNewParams) b
 	if openAIRequest == nil || len(openAIRequest.Tools) > 0 || !hasToolChoice(openAIRequest) {
 		return false
 	}
-
 	logging.Infof("[ToolsPlugin] Clearing tool_choice because no tools are present in the upstream request")
 	openAIRequest.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{}
 	return true
@@ -438,7 +517,6 @@ func hasToolChoice(openAIRequest *openai.ChatCompletionNewParams) bool {
 	if openAIRequest == nil {
 		return false
 	}
-
 	return !param.IsOmitted(openAIRequest.ToolChoice.OfAuto) ||
 		openAIRequest.ToolChoice.OfChatCompletionNamedToolChoice != nil
 }

--- a/src/semantic-router/pkg/extproc/req_filter_tools_observability_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_observability_test.go
@@ -1,0 +1,41 @@
+package extproc
+
+import (
+	"time"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+)
+
+var _ = Describe("emitToolObservability", func() {
+	var response *ext_proc.ProcessingResponse
+
+	BeforeEach(func() {
+		response = &ext_proc.ProcessingResponse{}
+	})
+
+	It("sets all three x-vsr-tools-* headers", func() {
+		emitToolObservability(&response, "default", 0.87, 4*time.Millisecond)
+
+		common := response.GetRequestBody().GetResponse()
+		Expect(common).NotTo(BeNil())
+
+		headerMap := make(map[string]string)
+		for _, opt := range common.HeaderMutation.SetHeaders {
+			headerMap[opt.Header.Key] = opt.Header.Value
+		}
+
+		Expect(headerMap[headers.VSRToolsStrategy]).To(Equal("default"))
+		Expect(headerMap[headers.VSRToolsConfidence]).To(Equal("0.8700"))
+		Expect(headerMap[headers.VSRToolsLatencyMs]).To(Equal("4"))
+	})
+
+	It("does nothing when strategy is empty", func() {
+		var nilResponse *ext_proc.ProcessingResponse
+		emitToolObservability(&nilResponse, "", 0, 0)
+		Expect(nilResponse).To(BeNil())
+	})
+})

--- a/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
@@ -1,0 +1,192 @@
+package extproc
+
+import (
+	"context"
+	"testing"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+)
+
+// stubRetriever is a test double that returns a fixed RetrievalResult.
+type stubRetriever struct {
+	strategyID string
+	results    []tools.ToolSimilarity
+	confidence float32
+}
+
+func (s *stubRetriever) Retrieve(_ context.Context, _ string, _ int) (tools.RetrievalResult, error) {
+	return tools.RetrievalResult{
+		Tools:      s.results,
+		Confidence: s.confidence,
+		StrategyID: s.strategyID,
+	}, nil
+}
+
+// makeToolsRouter builds a minimal OpenAIRouter wired for tool selection tests.
+func makeToolsRouter(t *testing.T, reg *tools.Registry) *OpenAIRouter {
+	t.Helper()
+	db := tools.NewToolsDatabase(tools.ToolsDatabaseOptions{
+		Enabled:             true,
+		SimilarityThreshold: 0.5,
+	})
+	return &OpenAIRouter{
+		Config: &config.RouterConfig{
+			ToolSelection: config.ToolSelection{
+				Tools: config.ToolsConfig{
+					TopK:            2,
+					FallbackToEmpty: true,
+				},
+			},
+		},
+		ToolsDatabase: db,
+		ToolsRegistry: reg,
+	}
+}
+
+// makeToolsPluginConfig builds a per-decision tools config for a given strategy.
+func makeToolsPluginConfig(strategy string) *config.ToolsPluginConfig {
+	return &config.ToolsPluginConfig{
+		Enabled:  true,
+		Mode:     config.ToolsPluginModePassthrough,
+		Strategy: strategy,
+	}
+}
+
+// sampleTool returns a minimal ChatCompletionToolParam for use in tests.
+func sampleTool(name string) tools.ToolSimilarity {
+	return tools.ToolSimilarity{
+		Entry: tools.ToolEntry{
+			Tool: openai.ChatCompletionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name: name,
+				},
+			},
+		},
+		Similarity: 0.9,
+	}
+}
+
+func TestRetrieverE2E_RegisteredStrategyToolsReachRequest(t *testing.T) {
+	reg := tools.NewRegistry()
+	reg.Register("custom", &stubRetriever{
+		strategyID: "custom",
+		results:    []tools.ToolSimilarity{sampleTool("search"), sampleTool("calculate")},
+		confidence: 0.95,
+	})
+
+	router := makeToolsRouter(t, reg)
+	toolsCfg := makeToolsPluginConfig("custom")
+
+	req := &openai.ChatCompletionNewParams{}
+	req.ToolChoice.OfAuto.Value = "auto"
+	resp := &ext_proc.ProcessingResponse{}
+
+	err := router.handleToolSelection(req, "find the weather in Paris", nil, &resp, &RequestContext{
+		VSRSelectedDecision: &config.Decision{
+			Name: "test-decision",
+			Plugins: []config.DecisionPlugin{
+				mustToolsDecisionPlugin(t, toolsCfg),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleToolSelection returned unexpected error: %v", err)
+	}
+	if len(req.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(req.Tools))
+	}
+	if req.Tools[0].Function.Name != "search" {
+		t.Errorf("expected first tool to be 'search', got %q", req.Tools[0].Function.Name)
+	}
+}
+
+func TestRetrieverE2E_UnknownStrategyFallsBackToDBWithSuffix(t *testing.T) {
+	reg := tools.NewRegistry()
+	// register only "default", not "bm25"
+	// reg.Register("default", &stubRetriever{
+	// 	strategyID: "default",
+	// 	results:    []tools.ToolSimilarity{sampleTool("fallback-tool")},
+	// 	confidence: 0.5,
+	// })
+
+	router := makeToolsRouter(t, reg)
+	toolsCfg := makeToolsPluginConfig("bm25")
+
+	req := &openai.ChatCompletionNewParams{}
+	req.ToolChoice.OfAuto.Value = "auto"
+	resp := &ext_proc.ProcessingResponse{}
+
+	err := router.handleToolSelection(req, "some query", nil, &resp, &RequestContext{
+		VSRSelectedDecision: &config.Decision{
+			Name: "test-decision",
+			Plugins: []config.DecisionPlugin{
+				mustToolsDecisionPlugin(t, toolsCfg),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
+	if strategyHeader != "bm25-fallback" {
+		t.Errorf("expected strategy header 'bm25-fallback', got %q", strategyHeader)
+	}
+}
+
+func TestRetrieverE2E_NilRegistryFallsBackWithSuffix(t *testing.T) {
+	router := makeToolsRouter(t, nil) // nil registry
+	toolsCfg := makeToolsPluginConfig("embedding")
+
+	req := &openai.ChatCompletionNewParams{}
+	req.ToolChoice.OfAuto.Value = "auto"
+	resp := &ext_proc.ProcessingResponse{}
+
+	err := router.handleToolSelection(req, "some query", nil, &resp, &RequestContext{
+		VSRSelectedDecision: &config.Decision{
+			Name: "test-decision",
+			Plugins: []config.DecisionPlugin{
+				mustToolsDecisionPlugin(t, toolsCfg),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
+	if strategyHeader != "embedding-fallback" {
+		t.Errorf("expected strategy header 'embedding-fallback', got %q", strategyHeader)
+	}
+}
+
+// mustToolsDecisionPlugin encodes a ToolsPluginConfig into a DecisionPlugin.
+func mustToolsDecisionPlugin(t *testing.T, cfg *config.ToolsPluginConfig) config.DecisionPlugin {
+	t.Helper()
+	payload, err := config.NewStructuredPayload(cfg)
+	if err != nil {
+		t.Fatalf("NewStructuredPayload: %v", err)
+	}
+	return config.DecisionPlugin{Type: config.DecisionPluginTools, Configuration: payload}
+}
+
+// getHeaderValue extracts a header value from the ProcessingResponse for assertions.
+func getHeaderValue(resp *ext_proc.ProcessingResponse, key string) string {
+	if resp == nil {
+		return ""
+	}
+	rb := resp.GetRequestBody()
+	if rb == nil || rb.GetResponse() == nil || rb.GetResponse().HeaderMutation == nil {
+		return ""
+	}
+	for _, h := range rb.GetResponse().HeaderMutation.SetHeaders {
+		if h.Header != nil && h.Header.Key == key {
+			return h.Header.Value
+		}
+	}
+	return ""
+}

--- a/src/semantic-router/pkg/extproc/router.go
+++ b/src/semantic-router/pkg/extproc/router.go
@@ -29,6 +29,7 @@ type OpenAIRouter struct {
 	ClassificationService *services.ClassificationService
 	Cache                 cache.CacheBackend
 	ToolsDatabase         *tools.ToolsDatabase
+	ToolsRegistry         *tools.Registry // retriever strategy registry
 	ResponseAPIFilter     *ResponseAPIFilter
 	ReplayRecorder        *routerreplay.Recorder
 	ReplayStoreShared     bool
@@ -138,7 +139,7 @@ func (r *OpenAIRouter) LoadToolsDatabase() error {
 	}
 
 	if r.Config.Tools.ToolsDBPath == "" {
-		logging.Warnf("Tools database enabled but no tools file path configured")
+		logging.Warnf("Tools database enabled but no tools file path configured; skipping load")
 		return nil
 	}
 
@@ -146,6 +147,17 @@ func (r *OpenAIRouter) LoadToolsDatabase() error {
 		return err
 	}
 
-	logging.Infof("Tools database loaded successfully from: %s", r.Config.Tools.ToolsDBPath)
+	// Wire the default embedding retriever into the registry now that
+	// the database is loaded and embeddings are available.
+	r.ToolsRegistry = tools.NewRegistry()
+	r.ToolsRegistry.Register("default", tools.NewEmbeddingRetriever(r.ToolsDatabase))
+
 	return nil
+}
+
+func (r *OpenAIRouter) RegisterToolStrategy(name string, retriever tools.Retriever) {
+	if r.ToolsRegistry == nil {
+		r.ToolsRegistry = tools.NewRegistry()
+	}
+	r.ToolsRegistry.Register(name, retriever)
 }

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -80,6 +80,18 @@ const (
 	// RouterReplayID carries the identifier for a captured replay record.
 	// Value: opaque replay token
 	RouterReplayID = "x-vsr-replay-id"
+
+	// VSRToolsStrategy is the name of the retriever strategy that was used
+	// during semantic tool selection for this request.
+	VSRToolsStrategy = "x-vsr-tools-strategy"
+
+	// VSRToolsConfidence is the similarity score (0–1) of the highest-ranked
+	// tool returned by the retriever.  Emitted only when tool selection runs.
+	VSRToolsConfidence = "x-vsr-tools-confidence"
+
+	// VSRToolsLatencyMs is the wall-clock time in milliseconds spent inside
+	// the retriever for this request.
+	VSRToolsLatencyMs = "x-vsr-tools-latency-ms"
 )
 
 // VSR Signal Tracking Headers

--- a/src/semantic-router/pkg/observability/metrics/metrics.go
+++ b/src/semantic-router/pkg/observability/metrics/metrics.go
@@ -326,6 +326,18 @@ var (
 		},
 		[]string{"fallback_reason", "fallback_strategy"},
 	)
+
+	// toolsRetrievalDuration tracks wall-clock time spent inside the retriever
+	// per request, partitioned by strategy name.  Use RecordToolsRetrieval to
+	// observe values.
+	toolsRetrievalDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "vsr_tools_retrieval_duration_seconds",
+			Help:    "Wall-clock time spent in the tool retriever, by strategy.",
+			Buckets: []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1},
+		},
+		[]string{"strategy"},
+	)
 )
 
 // RecordModelRequest increments the counter for requests to a specific model
@@ -776,4 +788,10 @@ func RecordEntropyClassificationMetrics(
 	if latencySeconds > 0 {
 		RecordEntropyClassificationLatency(latencySeconds)
 	}
+}
+
+// RecordToolsRetrieval records the retrieval latency for the given strategy.
+// strategyID must match the value returned in RetrievalResult.StrategyID.
+func RecordToolsRetrieval(strategyID string, durationSeconds float64) {
+	toolsRetrievalDuration.WithLabelValues(strategyID).Observe(durationSeconds)
 }

--- a/src/semantic-router/pkg/tools/embedding_retriever.go
+++ b/src/semantic-router/pkg/tools/embedding_retriever.go
@@ -1,0 +1,43 @@
+// Package tools provides tool selection and filtering capabilities
+// for the semantic router.
+package tools
+
+import "context"
+
+// EmbeddingRetriever implements Retriever using cosine-similarity search
+// against the in-process ToolsDatabase.  It is registered as the "default"
+// strategy and requires no external dependencies beyond the database that the
+// router already initialises at startup.
+type EmbeddingRetriever struct {
+	db *ToolsDatabase
+}
+
+// NewEmbeddingRetriever returns an EmbeddingRetriever backed by db.
+// db must not be nil.
+func NewEmbeddingRetriever(db *ToolsDatabase) *EmbeddingRetriever {
+	if db == nil {
+		panic("tools: NewEmbeddingRetriever called with nil ToolsDatabase")
+	}
+	return &EmbeddingRetriever{db: db}
+}
+
+// Retrieve returns up to topK tools ranked by embedding similarity.
+// The Confidence field of the result is the similarity score of the
+// highest-ranked tool, or 0 when no tools are returned.
+func (e *EmbeddingRetriever) Retrieve(_ context.Context, query string, topK int) (RetrievalResult, error) {
+	candidates, err := e.db.FindSimilarToolsWithScores(query, topK)
+	if err != nil {
+		return RetrievalResult{StrategyID: "default"}, err
+	}
+
+	confidence := float32(0)
+	if len(candidates) > 0 {
+		confidence = candidates[0].Similarity
+	}
+
+	return RetrievalResult{
+		Tools:      candidates,
+		Confidence: confidence,
+		StrategyID: "default",
+	}, nil
+}

--- a/src/semantic-router/pkg/tools/retriever.go
+++ b/src/semantic-router/pkg/tools/retriever.go
@@ -1,0 +1,37 @@
+package tools
+
+import "context"
+
+// RetrievalResult holds selected tools plus metadata for observability.
+type RetrievalResult struct {
+	Tools      []ToolSimilarity
+	Confidence float32 // top-1 similarity score, 0 if none
+	StrategyID string
+}
+
+// Retriever is the interface every tool-retrieval strategy must satisfy.
+type Retriever interface {
+	Retrieve(ctx context.Context, query string, topK int) (RetrievalResult, error)
+}
+
+// Registry maps strategy names to Retriever implementations.
+type Registry struct {
+	strategies map[string]Retriever
+}
+
+func NewRegistry() *Registry {
+	return &Registry{strategies: make(map[string]Retriever)}
+}
+
+func (r *Registry) Register(name string, s Retriever) {
+	if s == nil {
+		panic("tools: Register called with nil Retriever for strategy " + name)
+	}
+	r.strategies[name] = s
+}
+
+// Get returns the named strategy, falling back to "default" if not found.
+func (r *Registry) Get(name string) (Retriever, bool) {
+	s, ok := r.strategies[name]
+	return s, ok
+}

--- a/src/semantic-router/pkg/tools/retriever_test.go
+++ b/src/semantic-router/pkg/tools/retriever_test.go
@@ -1,0 +1,99 @@
+package tools_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+)
+
+// fakeRetriever is a test double for the Retriever interface.
+type fakeRetriever struct {
+	id     string
+	result tools.RetrievalResult
+	err    error
+}
+
+func (f *fakeRetriever) Retrieve(_ context.Context, _ string, _ int) (tools.RetrievalResult, error) {
+	return f.result, f.err
+}
+
+var _ = Describe("Registry", func() {
+	var reg *tools.Registry
+
+	BeforeEach(func() {
+		reg = tools.NewRegistry()
+	})
+
+	Describe("Get", func() {
+		It("returns the named strategy when registered", func() {
+			r := &fakeRetriever{id: "named"}
+			reg.Register("named", r)
+
+			got, ok := reg.Get("named")
+			Expect(ok).To(BeTrue())
+			Expect(got).To(Equal(r))
+		})
+
+		It("returns false when named strategy is absent, even if default exists", func() {
+			def := &fakeRetriever{id: "default"}
+			reg.Register("default", def)
+
+			_, ok := reg.Get("nonexistent")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("returns false when neither named nor default is registered", func() {
+			_, ok := reg.Get("anything")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("prefers the exact name over the default fallback", func() {
+			exact := &fakeRetriever{id: "exact"}
+			def := &fakeRetriever{id: "default"}
+			reg.Register("exact", exact)
+			reg.Register("default", def)
+
+			got, ok := reg.Get("exact")
+			Expect(ok).To(BeTrue())
+			Expect(got).To(Equal(exact))
+		})
+	})
+
+	Describe("Register", func() {
+		It("panics when given a nil Retriever", func() {
+			Expect(func() { reg.Register("bad", nil) }).To(Panic())
+		})
+	})
+})
+
+var _ = Describe("EmbeddingRetriever", func() {
+	It("panics when constructed with a nil ToolsDatabase", func() {
+		Expect(func() { tools.NewEmbeddingRetriever(nil) }).To(Panic())
+	})
+
+	It("returns zero confidence when the database returns no results", func() {
+		db := tools.NewToolsDatabase(tools.ToolsDatabaseOptions{
+			Enabled:             false,
+			SimilarityThreshold: 0.5,
+		})
+		r := tools.NewEmbeddingRetriever(db)
+		result, err := r.Retrieve(context.Background(), "weather", 3)
+		// disabled DB returns empty slice, not an error
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Confidence).To(Equal(float32(0)))
+		Expect(result.StrategyID).To(Equal("default"))
+	})
+})
+
+var _ = Describe("fakeRetriever propagates errors", func() {
+	It("surfaces the error returned by the underlying retriever", func() {
+		boom := errors.New("retrieval failed")
+		r := &fakeRetriever{err: boom}
+		_, err := r.Retrieve(context.Background(), "query", 3)
+		Expect(err).To(MatchError(boom))
+	})
+})


### PR DESCRIPTION
Fixes #1837

## Purpose

- Wires a pluggable retriever strategy registry into the extproc tool selection hot path and adds per-request observability fields for strategy name, confidence, and latency.
- The retriever strategy was initially hardcoded; `ToolsDatabase` was called directly with no abstraction and there was no visibility into how tool selection performed per request.
- Affects: `Router`

## Test Plan

```bash
make go-lint
make check-go-mod-tidy
make agent-ci-lint CHANGED_FILES="src/semantic-router/pkg/tools/retriever.go,src/semantic-router/pkg/tools/embedding_retriever.go,src/semantic-router/pkg/config/tools_plugin.go,src/semantic-router/pkg/extproc/req_filter_tools.go,src/semantic-router/pkg/headers/headers.go,src/semantic-router/pkg/observability/metrics/metrics.go,src/semantic-router/pkg/extproc/router.go"
go test ./pkg/config/... -count=1
make test-semantic-router
```

## Test Result

- `make go-lint` - 0 issues
- `make check-go-mod-tidy` - passed
- `make agent-ci-lint` — all checks passed including codespell, gofmt, golangci-lint, reference config contract test
- `go test ./pkg/config/... -count=1` - passed including `TestToolsPluginConfigValidate`
- `make test-semantic-router` - 258 Passed | 0 Failed

### Special notes for reviewers (if applicable)

This is my first PR to `vllm-project/semantic-router`, so I’m happy to iterate based on any feedback. Thanks!