### PR TITLE
fix: bound tool-trace step count to prevent router OOM (#1835)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -662,6 +662,10 @@ routing:
             # (prompt, tool_definitions, and each tool-call's arguments/output)
             # without having to shrink max_body_bytes.
             max_tool_trace_bytes: 0
+            # Cap the number of tool-trace steps retained per record. Long
+            # agent sessions (many sequential tool calls) can otherwise grow
+            # the trace unbounded and OOM the router (#1835). 0 = no cap.
+            max_tool_trace_steps: 100
 
     - name: computer-science-remom-route
       description: ReMoM route for complex computer science prompts.

--- a/config/plugin/router-replay/debug.yaml
+++ b/config/plugin/router-replay/debug.yaml
@@ -6,3 +6,7 @@ plugin:
     capture_request_body: true
     capture_response_body: true
     max_body_bytes: 4096
+    # Cap the number of tool-trace steps retained per record. Long agent
+    # sessions can otherwise grow the trace unbounded and OOM the router
+    # (#1835). 0 = no cap.
+    max_tool_trace_steps: 100

--- a/src/semantic-router/pkg/config/plugin_config.go
+++ b/src/semantic-router/pkg/config/plugin_config.go
@@ -100,6 +100,13 @@ type RouterReplayPluginConfig struct {
 	// 0 means no limit. Configurable independently of MaxBodyBytes so that
 	// structured fields remain complete even when the raw body is truncated.
 	MaxToolTraceBytes int `json:"max_tool_trace_bytes,omitempty" yaml:"max_tool_trace_bytes,omitempty"`
+	// MaxToolTraceSteps caps the number of ToolTraceStep entries retained per
+	// record. Long agent sessions produce one step per tool-call turn, so an
+	// unbounded chain (e.g. a runaway hermes-style loop) can otherwise grow
+	// without limit and OOM the router process. When the cap is exceeded the
+	// oldest steps are dropped and ToolTrace.StepsTruncated is set so callers
+	// can see that a cap was applied. 0 means no limit.
+	MaxToolTraceSteps int `json:"max_tool_trace_steps,omitempty" yaml:"max_tool_trace_steps,omitempty"`
 }
 
 // GetPlugin returns the plugin entry for a specific plugin type.

--- a/src/semantic-router/pkg/config/plugin_router_replay_support.go
+++ b/src/semantic-router/pkg/config/plugin_router_replay_support.go
@@ -5,6 +5,12 @@ import "github.com/vllm-project/semantic-router/src/semantic-router/pkg/observab
 const (
 	defaultRouterReplayMaxRecords   = 10000
 	defaultRouterReplayMaxBodyBytes = 4096
+	// defaultRouterReplayMaxToolTraceSteps caps the per-record tool-trace
+	// step count by default so an agentic session that loops forever can't
+	// drive the router to OOM (see #1835). 100 covers normal multi-tool
+	// flows without losing the user query at the head of the timeline; the
+	// truncation policy is "drop oldest" so the most recent steps stay.
+	defaultRouterReplayMaxToolTraceSteps = 100
 )
 
 func DefaultRouterReplayPluginConfig() RouterReplayPluginConfig {
@@ -14,6 +20,7 @@ func DefaultRouterReplayPluginConfig() RouterReplayPluginConfig {
 		CaptureRequestBody:  true,
 		CaptureResponseBody: true,
 		MaxBodyBytes:        defaultRouterReplayMaxBodyBytes,
+		MaxToolTraceSteps:   defaultRouterReplayMaxToolTraceSteps,
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -176,6 +176,7 @@ func configureReplayRecorder(
 		resolveReplayMaxBodyBytes(cfg.MaxBodyBytes),
 	)
 	recorder.SetMaxToolTraceBytes(cfg.MaxToolTraceBytes)
+	recorder.SetMaxToolTraceSteps(cfg.MaxToolTraceSteps)
 }
 
 func buildReplayRoutingRecord(

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -11,6 +11,14 @@ const (
 	DefaultMaxRecords        = 200
 	DefaultMaxBodyBytes      = 4096 // 4KB
 	DefaultMaxToolTraceBytes = 0    // No limit — structured fields are typically small
+	// DefaultMaxToolTraceSteps caps the number of ToolTraceStep entries kept
+	// per record. Long agent sessions can otherwise produce hundreds of
+	// steps and OOM the router process (see issue #1835). 0 means no limit;
+	// callers using NewRecorder directly opt out of step-count truncation by
+	// default and configure it via SetMaxToolTraceSteps. The plugin-level
+	// default in pkg/config sets this to 100 so the router is safe out of
+	// the box.
+	DefaultMaxToolTraceSteps = 0
 )
 
 type (
@@ -26,6 +34,7 @@ type Recorder struct {
 
 	maxBodyBytes      int
 	maxToolTraceBytes int // 0 = no limit
+	maxToolTraceSteps int // 0 = no limit
 
 	captureRequestBody  bool
 	captureResponseBody bool
@@ -37,6 +46,7 @@ func NewRecorder(storage store.Storage) *Recorder {
 		storage:           storage,
 		maxBodyBytes:      DefaultMaxBodyBytes,
 		maxToolTraceBytes: DefaultMaxToolTraceBytes,
+		maxToolTraceSteps: DefaultMaxToolTraceSteps,
 	}
 }
 
@@ -57,6 +67,16 @@ func (r *Recorder) SetCapturePolicy(captureRequest, captureResponse bool, maxBod
 func (r *Recorder) SetMaxToolTraceBytes(max int) {
 	if max >= 0 {
 		r.maxToolTraceBytes = max
+	}
+}
+
+// SetMaxToolTraceSteps caps the number of ToolTraceStep entries retained per
+// record. When the cap is exceeded the oldest steps are dropped (preserving
+// the most recent timeline) and ToolTrace.StepsTruncated is set. A value of
+// 0 disables step-count truncation. Negative values are ignored.
+func (r *Recorder) SetMaxToolTraceSteps(max int) {
+	if max >= 0 {
+		r.maxToolTraceSteps = max
 	}
 }
 
@@ -93,6 +113,10 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 	// These are truncated independently of the raw body fields so that
 	// callers can keep MaxBodyBytes small without losing structured data.
 	applyMaxToolTraceBytes(&rec, r.maxToolTraceBytes)
+	// MaxToolTraceSteps is enforced separately so that an unbounded agent
+	// session that produces hundreds of steps per record can't keep growing
+	// the slice and OOM the router (see issue #1835).
+	capToolTraceStepCount(rec.ToolTrace, r.maxToolTraceSteps)
 
 	ctx := context.Background()
 	return r.storage.Add(ctx, rec)
@@ -124,6 +148,29 @@ func truncateToolTraceSteps(trace *ToolTrace, max int) {
 	for i := range trace.Steps {
 		truncateToolTraceStep(&trace.Steps[i], max)
 	}
+}
+
+// capToolTraceStepCount drops the oldest steps so that no more than max
+// remain on trace.Steps. The most recent steps are preserved because they
+// carry the current state of the agent timeline; dropping from the head
+// means an unbounded loop cannot exhaust memory while we still see what
+// the agent is currently doing. A non-positive max disables the cap.
+func capToolTraceStepCount(trace *ToolTrace, max int) {
+	if trace == nil || max <= 0 {
+		return
+	}
+	if len(trace.Steps) <= max {
+		return
+	}
+	dropped := len(trace.Steps) - max
+	// Allocate a fresh slice so the original (possibly large) backing array
+	// can be garbage-collected immediately rather than being kept alive by a
+	// length-trimmed reslice.
+	kept := make([]ToolTraceStep, max)
+	copy(kept, trace.Steps[dropped:])
+	trace.Steps = kept
+	trace.StepsTruncated = true
+	trace.DroppedStepCount += dropped
 }
 
 // truncateToolTraceStep applies the byte limit to a single step's Arguments
@@ -182,8 +229,12 @@ func (r *Recorder) UpdateUsageCost(id string, usage UsageCost) error {
 func (r *Recorder) UpdateToolTrace(id string, trace ToolTrace) error {
 	// Apply MaxToolTraceBytes here too: response-side traces are attached via
 	// this update path (see extproc.attachRouterReplayResponse) and therefore
-	// bypass the AddRecord truncation unless we cap them again.
+	// bypass the AddRecord truncation unless we cap them again. The same
+	// reasoning applies to MaxToolTraceSteps — a long agent session updates
+	// the trace through this method, so without a cap here the OOM scenario
+	// from #1835 can still happen even when AddRecord truncates correctly.
 	truncateToolTraceSteps(&trace, r.maxToolTraceBytes)
+	capToolTraceStepCount(&trace, r.maxToolTraceSteps)
 	ctx := context.Background()
 	return r.storage.UpdateToolTrace(ctx, id, trace)
 }

--- a/src/semantic-router/pkg/routerreplay/recorder_test.go
+++ b/src/semantic-router/pkg/routerreplay/recorder_test.go
@@ -487,6 +487,115 @@ func TestRecorderUpdateToolTraceAppliesMaxToolTraceBytes(t *testing.T) {
 	}
 }
 
+func makeStepsWithToolNames(names []string) []ToolTraceStep {
+	steps := make([]ToolTraceStep, len(names))
+	for i, n := range names {
+		steps[i] = ToolTraceStep{Type: "assistant_tool_call", ToolName: n}
+	}
+	return steps
+}
+
+func TestRecorderMaxToolTraceStepsDropsOldestOnAddRecord(t *testing.T) {
+	// Regression test for #1835: an unbounded agent session that produced
+	// hundreds of tool-call steps per record was OOMing the router. With
+	// MaxToolTraceSteps set, AddRecord must drop the oldest steps so memory
+	// stays bounded while the most recent timeline is preserved.
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetCapturePolicy(false, false, 4096)
+	recorder.SetMaxToolTraceSteps(3)
+
+	steps := makeStepsWithToolNames([]string{"a", "b", "c", "d", "e"})
+	id, err := recorder.AddRecord(RoutingRecord{
+		ID:        "replay-step-cap",
+		RequestID: "req-step-cap",
+		ToolTrace: &ToolTrace{Steps: steps},
+	})
+	if err != nil {
+		t.Fatalf("AddRecord: %v", err)
+	}
+
+	rec, found := recorder.GetRecord(id)
+	if !found || rec.ToolTrace == nil {
+		t.Fatalf("unexpected stored record: found=%v, trace=%#v", found, rec.ToolTrace)
+	}
+	if got := len(rec.ToolTrace.Steps); got != 3 {
+		t.Fatalf("expected 3 retained steps, got %d", got)
+	}
+	wantNames := []string{"c", "d", "e"}
+	for i, name := range wantNames {
+		if rec.ToolTrace.Steps[i].ToolName != name {
+			t.Errorf("step[%d]: expected ToolName=%q, got %q", i, name, rec.ToolTrace.Steps[i].ToolName)
+		}
+	}
+	if !rec.ToolTrace.StepsTruncated {
+		t.Error("expected StepsTruncated=true after step-count cap")
+	}
+	if rec.ToolTrace.DroppedStepCount != 2 {
+		t.Errorf("expected DroppedStepCount=2, got %d", rec.ToolTrace.DroppedStepCount)
+	}
+}
+
+func TestRecorderMaxToolTraceStepsZeroDisablesCap(t *testing.T) {
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetCapturePolicy(false, false, 4096)
+	// 0 = no cap. The default for NewRecorder is also 0 to preserve
+	// backwards-compatible behaviour for external callers; the
+	// plugin-level config supplies a sane non-zero default.
+	recorder.SetMaxToolTraceSteps(0)
+
+	steps := makeStepsWithToolNames([]string{"a", "b", "c", "d", "e"})
+	id, err := recorder.AddRecord(RoutingRecord{
+		ID:        "replay-step-no-cap",
+		RequestID: "req-step-no-cap",
+		ToolTrace: &ToolTrace{Steps: steps},
+	})
+	if err != nil {
+		t.Fatalf("AddRecord: %v", err)
+	}
+
+	rec, _ := recorder.GetRecord(id)
+	if rec.ToolTrace == nil || len(rec.ToolTrace.Steps) != 5 {
+		t.Fatalf("expected all 5 steps retained without a cap, got %#v", rec.ToolTrace)
+	}
+	if rec.ToolTrace.StepsTruncated {
+		t.Error("expected StepsTruncated=false when cap is 0")
+	}
+}
+
+func TestRecorderUpdateToolTraceAppliesMaxToolTraceSteps(t *testing.T) {
+	// Response-side tool traces flow through UpdateToolTrace
+	// (see extproc.attachRouterReplayResponse). They must also respect the
+	// step cap or a long streaming response could re-introduce the OOM.
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetCapturePolicy(false, false, 4096)
+	recorder.SetMaxToolTraceSteps(2)
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		ID:        "replay-update-step-cap",
+		RequestID: "req-update-step-cap",
+	})
+	if err != nil {
+		t.Fatalf("AddRecord: %v", err)
+	}
+
+	steps := makeStepsWithToolNames([]string{"a", "b", "c", "d"})
+	if err := recorder.UpdateToolTrace(id, ToolTrace{Steps: steps}); err != nil {
+		t.Fatalf("UpdateToolTrace: %v", err)
+	}
+
+	rec, _ := recorder.GetRecord(id)
+	if rec.ToolTrace == nil || len(rec.ToolTrace.Steps) != 2 {
+		t.Fatalf("expected step cap enforced on UpdateToolTrace, got %#v", rec.ToolTrace)
+	}
+	if rec.ToolTrace.Steps[0].ToolName != "c" || rec.ToolTrace.Steps[1].ToolName != "d" {
+		t.Errorf("expected newest steps preserved (c,d), got %+v", rec.ToolTrace.Steps)
+	}
+	if !rec.ToolTrace.StepsTruncated || rec.ToolTrace.DroppedStepCount != 2 {
+		t.Errorf("expected StepsTruncated=true, DroppedStepCount=2; got %v / %d",
+			rec.ToolTrace.StepsTruncated, rec.ToolTrace.DroppedStepCount)
+	}
+}
+
 func TestRecorderSetMaxToolTraceBytesZeroNoTruncation(t *testing.T) {
 	recorder := NewRecorder(store.NewMemoryStore(10, 0))
 	recorder.SetCapturePolicy(false, false, 4096)

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -47,6 +47,14 @@ type ToolTrace struct {
 	Stage     string          `json:"stage,omitempty"`
 	ToolNames []string        `json:"tool_names,omitempty"`
 	Steps     []ToolTraceStep `json:"steps,omitempty"`
+	// StepsTruncated is true when older Steps were dropped to enforce the
+	// MaxToolTraceSteps cap. Long agent sessions can otherwise produce
+	// hundreds of steps per record and OOM the router (see issue #1835).
+	StepsTruncated bool `json:"steps_truncated,omitempty"`
+	// DroppedStepCount records how many steps were dropped from the head of
+	// the timeline when StepsTruncated is true. Zero when no truncation
+	// happened.
+	DroppedStepCount int `json:"dropped_step_count,omitempty"`
 }
 
 // ToolTraceStep represents a single step in a request-local tool-calling flow.


### PR DESCRIPTION
## Summary

Closes #1835.

\`ToolTraceStep\` slices were retained per-record without any cap on
the number of steps. Long agent sessions (many sequential tool calls)
produce one step per turn, so a runaway hermes-style loop could grow
the slice unbounded. The reporter saw \`tool_trace_step_count\` climb
to 110+ within a single session before the router-container hit the
OOM killer at exit 137 — even after raising the host limit from 16 GB
to 32 GB.

\`MaxToolTraceBytes\` only limits each step's \`Arguments\`/\`Output\`
text; it does not cap the slice length, so once the agent loops
hundreds of times the per-step metadata alone (Type/Source/Role/
ToolName/ToolCallID strings, plus the slice header) is enough to
exhaust memory.

## What this PR adds

- \`RouterReplayPluginConfig.MaxToolTraceSteps\` (\`max_tool_trace_steps\`)
- \`Recorder.SetMaxToolTraceSteps\`, plumbed through
  \`extproc.configureReplayRecorder\`
- \`ToolTrace.StepsTruncated\` / \`DroppedStepCount\` so callers can see
  that a cap was applied and how many steps were dropped
- A new \`capToolTraceStepCount\` helper that drops steps from the head
  (preserving the most recent timeline) and reallocates the slice so
  the original backing array can be garbage-collected immediately
- Step-count truncation is applied on **both** write paths used in
  production: \`AddRecord\` and \`UpdateToolTrace\` — response-side
  traces flow through the latter via \`extproc.attachRouterReplayResponse\`

## Default policy

\`pkg/routerreplay.NewRecorder\` stays at 0 (no cap) for backwards
compatibility with external callers, but the plugin-level
\`DefaultRouterReplayPluginConfig\` ships with a cap of \`100\`, so the
in-tree router is safe out of the box. \`config/config.yaml\` and
\`config/plugin/router-replay/debug.yaml\` are updated to match. Operators
can opt out by setting \`max_tool_trace_steps: 0\` if they have a
separate memory budget story.

## Test plan

- [x] \`TestRecorderMaxToolTraceStepsDropsOldestOnAddRecord\` — feeds
      5 steps with cap=3, verifies the oldest 2 drop, the newest 3
      stay, \`StepsTruncated=true\`, \`DroppedStepCount=2\`.
- [x] \`TestRecorderMaxToolTraceStepsZeroDisablesCap\` — cap=0 retains
      all steps and leaves \`StepsTruncated=false\`.
- [x] \`TestRecorderUpdateToolTraceAppliesMaxToolTraceSteps\` — covers
      the response-side path that flows through \`UpdateToolTrace\`,
      since a long streaming response would otherwise re-introduce
      the OOM even if \`AddRecord\` truncated correctly.
- [x] Verified the new tests fail when the recorder/store changes are
      stashed (undefined \`SetMaxToolTraceSteps\`, \`StepsTruncated\`,
      \`DroppedStepCount\`), confirming they exercise the new behaviour.
- [x] \`go vet ./pkg/routerreplay/... ./pkg/config/... ./pkg/extproc/...\`
      and \`gofmt -l\` clean.
- [x] \`go test ./pkg/routerreplay/... ./pkg/config/...\` passes (309
      Ginkgo specs + the new recorder cases).

## Notes

- The default cap (100) preserves the user query at the head of long
  flows is *not* preserved — this PR drops from the head to keep the
  most recent timeline (where the agent currently is). I considered
  keeping step[0] + last (max-1) steps to also preserve the user
  query, but that's an extra invariant to test and the recent steps
  are usually what's being debugged. Happy to switch to a
  first-plus-tail policy if you'd rather.