### PR TITLE
fix(stability): recover signal panics and cap tool-trace step growth

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -662,6 +662,10 @@ routing:
             # (prompt, tool_definitions, and each tool-call's arguments/output)
             # without having to shrink max_body_bytes.
             max_tool_trace_bytes: 0
+            # 0 = no step limit. Set to a positive integer (e.g. 50) to bound
+            # memory usage in long-running agentic sessions where each tool-call
+            # turn appends to the Steps slice and the derived Flow string.
+            max_tool_trace_steps: 0
 
     - name: computer-science-remom-route
       description: ReMoM route for complex computer science prompts.

--- a/src/semantic-router/pkg/classification/classifier_signal_dispatch.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_dispatch.go
@@ -1,10 +1,12 @@
 package classification
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
 
 type signalDispatch struct {
@@ -108,6 +110,7 @@ func runSignalDispatchers(dispatchers []signalDispatch, usedSignals map[string]b
 			wg.Add(1)
 			go func(dispatch signalDispatch) {
 				defer wg.Done()
+				defer recoverSignalPanic(dispatch.signalType, dispatch.name)
 				dispatch.evaluate()
 			}(d)
 			continue
@@ -117,4 +120,19 @@ func runSignalDispatchers(dispatchers []signalDispatch, usedSignals map[string]b
 			logging.Debugf("[Signal Computation] %s signal not used in any decision, skipping evaluation", d.name)
 		}
 	}
+}
+
+// recoverSignalPanic recovers from a panic in a signal evaluator goroutine,
+// logs the incident, and records a metric so operators can alert on it.
+// Without this, a classifier panic (e.g. triggered by an unusually long prompt
+// causing an out-of-bounds access in a Rust binding) would propagate up through
+// the goroutine scheduler and crash the entire router process silently.
+func recoverSignalPanic(signalType, signalName string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	msg := fmt.Sprintf("%v", r)
+	logging.Errorf("[Signal Computation] panic recovered in %s signal (%s): %s", signalName, signalType, msg)
+	metrics.RecordSignalPanic(signalType, signalName)
 }

--- a/src/semantic-router/pkg/classification/classifier_signal_dispatch_panic_test.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_dispatch_panic_test.go
@@ -1,0 +1,98 @@
+package classification
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestRunSignalDispatchersPanicRecovery verifies that a panic inside a signal
+// evaluator goroutine does not propagate to the caller. Before this fix a panic
+// would crash the whole router process; now it is recovered, logged, and counted.
+func TestRunSignalDispatchersPanicRecovery(t *testing.T) {
+	panicDispatcher := signalDispatch{
+		signalType: "keyword",
+		name:       "Keyword",
+		evaluate: func() {
+			panic("simulated classifier out-of-bounds on long prompt")
+		},
+	}
+	okDispatcher := signalDispatch{
+		signalType: "context",
+		name:       "Context",
+		evaluate:   func() {},
+	}
+
+	usedSignals := map[string]bool{
+		"keyword:test": true,
+		"context:test": true,
+	}
+	ready := map[string]bool{
+		"keyword": true,
+		"context": true,
+	}
+
+	var wg sync.WaitGroup
+	// Must not panic — the test process would crash if recovery is missing.
+	runSignalDispatchers([]signalDispatch{panicDispatcher, okDispatcher}, usedSignals, ready, &wg)
+	wg.Wait()
+}
+
+// TestRunSignalDispatchersMultiplePanicsRecovered ensures that a panic in one
+// goroutine does not prevent other signal evaluators from completing.
+func TestRunSignalDispatchersMultiplePanicsRecovered(t *testing.T) {
+	var completed sync.Map
+
+	dispatchers := []signalDispatch{
+		{
+			signalType: "keyword",
+			name:       "Keyword",
+			evaluate: func() {
+				panic("keyword panic")
+			},
+		},
+		{
+			signalType: "context",
+			name:       "Context",
+			evaluate: func() {
+				completed.Store("context", true)
+			},
+		},
+		{
+			signalType: "embedding",
+			name:       "Embedding",
+			evaluate: func() {
+				panic("embedding panic")
+			},
+		},
+		{
+			signalType: "language",
+			name:       "Language",
+			evaluate: func() {
+				completed.Store("language", true)
+			},
+		},
+	}
+
+	usedSignals := map[string]bool{
+		"keyword:a":   true,
+		"context:b":   true,
+		"embedding:c": true,
+		"language:d":  true,
+	}
+	ready := map[string]bool{
+		"keyword":   true,
+		"context":   true,
+		"embedding": true,
+		"language":  true,
+	}
+
+	var wg sync.WaitGroup
+	runSignalDispatchers(dispatchers, usedSignals, ready, &wg)
+	wg.Wait()
+
+	for _, name := range []string{"context", "language"} {
+		if _, ok := completed.Load(name); !ok {
+			t.Errorf("signal %q did not complete — panic in sibling goroutine blocked it", name)
+		}
+	}
+}

--- a/src/semantic-router/pkg/config/plugin_config.go
+++ b/src/semantic-router/pkg/config/plugin_config.go
@@ -100,6 +100,12 @@ type RouterReplayPluginConfig struct {
 	// 0 means no limit. Configurable independently of MaxBodyBytes so that
 	// structured fields remain complete even when the raw body is truncated.
 	MaxToolTraceBytes int `json:"max_tool_trace_bytes,omitempty" yaml:"max_tool_trace_bytes,omitempty"`
+	// MaxToolTraceSteps caps the number of tool-call steps retained per request.
+	// Long-running agentic sessions can accumulate hundreds of steps; without a
+	// cap the Steps slice and the derived Flow string grow linearly per turn and
+	// are held in memory for every concurrent session, eventually triggering OOM.
+	// 0 means no limit. Recommended production default: 50.
+	MaxToolTraceSteps int `json:"max_tool_trace_steps,omitempty" yaml:"max_tool_trace_steps,omitempty"`
 }
 
 // GetPlugin returns the plugin entry for a specific plugin type.

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -176,6 +176,7 @@ func configureReplayRecorder(
 		resolveReplayMaxBodyBytes(cfg.MaxBodyBytes),
 	)
 	recorder.SetMaxToolTraceBytes(cfg.MaxToolTraceBytes)
+	recorder.SetMaxToolTraceSteps(cfg.MaxToolTraceSteps)
 }
 
 func buildReplayRoutingRecord(

--- a/src/semantic-router/pkg/extproc/router_replay_setup.go
+++ b/src/semantic-router/pkg/extproc/router_replay_setup.go
@@ -113,6 +113,7 @@ func createReplayRecorder(
 	recorder := routerreplay.NewRecorder(storage)
 	recorder.SetCapturePolicy(pluginCfg.CaptureRequestBody, pluginCfg.CaptureResponseBody, maxBodyBytes)
 	recorder.SetMaxToolTraceBytes(pluginCfg.MaxToolTraceBytes)
+	recorder.SetMaxToolTraceSteps(pluginCfg.MaxToolTraceSteps)
 	return recorder, nil
 }
 
@@ -127,6 +128,7 @@ func createSharedReplayRecorder(
 		resolveReplayMaxBodyBytes(pluginCfg.MaxBodyBytes),
 	)
 	recorder.SetMaxToolTraceBytes(pluginCfg.MaxToolTraceBytes)
+	recorder.SetMaxToolTraceSteps(pluginCfg.MaxToolTraceSteps)
 	return recorder
 }
 

--- a/src/semantic-router/pkg/observability/metrics/signal_decision_plugin_metrics.go
+++ b/src/semantic-router/pkg/observability/metrics/signal_decision_plugin_metrics.go
@@ -8,6 +8,17 @@ import (
 )
 
 var (
+	// SignalPanicTotal tracks panics recovered inside signal evaluator goroutines.
+	// A non-zero value indicates a classifier crashed mid-evaluation; the router
+	// continued serving but that signal was skipped for the affected request.
+	SignalPanicTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llm_signal_panic_total",
+			Help: "Total number of panics recovered in signal evaluator goroutines",
+		},
+		[]string{"signal_type", "signal_name"},
+	)
+
 	// SignalExtractionTotal tracks the total number of signal extractions by type and name
 	SignalExtractionTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -100,6 +111,17 @@ var (
 		[]string{"plugin_type", "error_reason"},
 	)
 )
+
+// RecordSignalPanic records a recovered panic from a signal evaluator goroutine.
+func RecordSignalPanic(signalType, signalName string) {
+	if signalType == "" {
+		signalType = consts.UnknownLabel
+	}
+	if signalName == "" {
+		signalName = consts.UnknownLabel
+	}
+	SignalPanicTotal.WithLabelValues(signalType, signalName).Inc()
+}
 
 // RecordSignalExtraction records a signal extraction event
 func RecordSignalExtraction(signalType, signalName string, latencySeconds float64) {

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -11,6 +11,7 @@ const (
 	DefaultMaxRecords        = 200
 	DefaultMaxBodyBytes      = 4096 // 4KB
 	DefaultMaxToolTraceBytes = 0    // No limit — structured fields are typically small
+	DefaultMaxToolTraceSteps = 0    // No limit by default; set to ~50 in production to prevent OOM
 )
 
 type (
@@ -26,6 +27,7 @@ type Recorder struct {
 
 	maxBodyBytes      int
 	maxToolTraceBytes int // 0 = no limit
+	maxToolTraceSteps int // 0 = no limit
 
 	captureRequestBody  bool
 	captureResponseBody bool
@@ -48,6 +50,16 @@ func (r *Recorder) SetCapturePolicy(captureRequest, captureResponse bool, maxBod
 		r.maxBodyBytes = maxBodyBytes
 	} else {
 		r.maxBodyBytes = DefaultMaxBodyBytes
+	}
+}
+
+// SetMaxToolTraceSteps sets the maximum number of tool-call steps retained per
+// record. Steps beyond the cap are silently dropped (oldest kept, newest dropped)
+// so that long agentic sessions do not accumulate unbounded memory.
+// A value of 0 disables the cap.
+func (r *Recorder) SetMaxToolTraceSteps(max int) {
+	if max >= 0 {
+		r.maxToolTraceSteps = max
 	}
 }
 
@@ -89,6 +101,10 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 		rec.ResponseBodyTruncated = true
 	}
 
+	// Cap tool-trace steps before any other field truncation so that
+	// Flow / ToolNames derived from the steps slice are also bounded.
+	capToolTraceSteps(&rec, r.maxToolTraceSteps)
+
 	// Apply MaxToolTraceBytes to structured tool-trace fields.
 	// These are truncated independently of the raw body fields so that
 	// callers can keep MaxBodyBytes small without losing structured data.
@@ -96,6 +112,18 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 
 	ctx := context.Background()
 	return r.storage.Add(ctx, rec)
+}
+
+// capToolTraceSteps limits the number of steps retained in a record's ToolTrace.
+// When an agentic session accumulates hundreds of tool calls the Steps slice grows
+// linearly per turn and is held in memory for every concurrent session. Keeping only
+// the first max steps bounds memory growth without losing the earliest context.
+// A non-positive max disables the cap.
+func capToolTraceSteps(rec *RoutingRecord, max int) {
+	if max <= 0 || rec.ToolTrace == nil || len(rec.ToolTrace.Steps) <= max {
+		return
+	}
+	rec.ToolTrace.Steps = rec.ToolTrace.Steps[:max]
 }
 
 // applyMaxToolTraceBytes truncates structured tool-trace text fields to max
@@ -180,6 +208,10 @@ func (r *Recorder) UpdateUsageCost(id string, usage UsageCost) error {
 }
 
 func (r *Recorder) UpdateToolTrace(id string, trace ToolTrace) error {
+	// Cap steps first so Flow / ToolNames derived from them are also bounded.
+	if r.maxToolTraceSteps > 0 && len(trace.Steps) > r.maxToolTraceSteps {
+		trace.Steps = trace.Steps[:r.maxToolTraceSteps]
+	}
 	// Apply MaxToolTraceBytes here too: response-side traces are attached via
 	// this update path (see extproc.attachRouterReplayResponse) and therefore
 	// bypass the AddRecord truncation unless we cap them again.

--- a/src/semantic-router/pkg/routerreplay/recorder_tool_trace_steps_test.go
+++ b/src/semantic-router/pkg/routerreplay/recorder_tool_trace_steps_test.go
@@ -1,0 +1,143 @@
+package routerreplay
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
+)
+
+func makeSteps(n int) []ToolTraceStep {
+	steps := make([]ToolTraceStep, n)
+	for i := range steps {
+		steps[i] = ToolTraceStep{Type: "assistant_tool_call", ToolName: "tool"}
+	}
+	return steps
+}
+
+// TestSetMaxToolTraceStepsCapsBelowLimit verifies that records with fewer steps
+// than the cap are stored unchanged.
+func TestSetMaxToolTraceStepsCapsBelowLimit(t *testing.T) {
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetMaxToolTraceSteps(50)
+
+	_, err := recorder.AddRecord(RoutingRecord{
+		ID:        "r1",
+		Decision:  "d",
+		RequestID: "req",
+		ToolTrace: &ToolTrace{Steps: makeSteps(10)},
+	})
+	if err != nil {
+		t.Fatalf("AddRecord failed: %v", err)
+	}
+}
+
+// TestSetMaxToolTraceStepsCapsAboveLimit is the primary regression for #1835:
+// a session with 200 tool-call steps must be truncated to the configured cap.
+func TestSetMaxToolTraceStepsCapsAboveLimit(t *testing.T) {
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetMaxToolTraceSteps(50)
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		ID:        "r2",
+		Decision:  "d",
+		RequestID: "req",
+		ToolTrace: &ToolTrace{Steps: makeSteps(200)},
+	})
+	if err != nil {
+		t.Fatalf("AddRecord failed: %v", err)
+	}
+
+	records := recorder.ListAllRecords()
+	var found *RoutingRecord
+	for i := range records {
+		if records[i].ID == id {
+			found = &records[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("record %q not found after AddRecord", id)
+	}
+	if found.ToolTrace == nil {
+		t.Fatal("expected ToolTrace to be set")
+	}
+	if len(found.ToolTrace.Steps) != 50 {
+		t.Errorf("expected steps capped at 50, got %d", len(found.ToolTrace.Steps))
+	}
+}
+
+// TestSetMaxToolTraceStepsZeroMeansNoLimit confirms that 0 disables the cap.
+func TestSetMaxToolTraceStepsZeroMeansNoLimit(t *testing.T) {
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetMaxToolTraceSteps(0)
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		ID:        "r3",
+		Decision:  "d",
+		RequestID: "req",
+		ToolTrace: &ToolTrace{Steps: makeSteps(500)},
+	})
+	if err != nil {
+		t.Fatalf("AddRecord failed: %v", err)
+	}
+
+	records := recorder.ListAllRecords()
+	var found *RoutingRecord
+	for i := range records {
+		if records[i].ID == id {
+			found = &records[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("record %q not found", id)
+	}
+	if len(found.ToolTrace.Steps) != 500 {
+		t.Errorf("expected all 500 steps with no cap, got %d", len(found.ToolTrace.Steps))
+	}
+}
+
+// TestUpdateToolTraceCapsSteps ensures the cap is enforced on the update path
+// (used when response-side traces are attached after request recording).
+func TestUpdateToolTraceCapsSteps(t *testing.T) {
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetMaxToolTraceSteps(30)
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		ID:        "r4",
+		Decision:  "d",
+		RequestID: "req",
+	})
+	if err != nil {
+		t.Fatalf("AddRecord failed: %v", err)
+	}
+
+	err = recorder.UpdateToolTrace(id, ToolTrace{Steps: makeSteps(100)})
+	if err != nil {
+		t.Fatalf("UpdateToolTrace failed: %v", err)
+	}
+
+	records := recorder.ListAllRecords()
+	var found *RoutingRecord
+	for i := range records {
+		if records[i].ID == id {
+			found = &records[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("record %q not found", id)
+	}
+	if found.ToolTrace == nil {
+		t.Fatal("expected ToolTrace to be set after update")
+	}
+	if len(found.ToolTrace.Steps) != 30 {
+		t.Errorf("expected steps capped at 30 after update, got %d", len(found.ToolTrace.Steps))
+	}
+}
+
+// TestCapToolTraceStepsNilTrace confirms nil ToolTrace is handled safely.
+func TestCapToolTraceStepsNilTrace(t *testing.T) {
+	rec := &RoutingRecord{ID: "r5", ToolTrace: nil}
+	capToolTraceSteps(rec, 10) // must not panic
+}

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -315,6 +315,7 @@ type Config struct {
 	AsyncWrites       bool   // Enable asynchronous writes
 	MaxBodyBytes      int    // Maximum bytes to store for request/response bodies
 	MaxToolTraceBytes int    // Maximum bytes for each structured tool-trace field (0 = no limit)
+	MaxToolTraceSteps int    // Maximum number of tool-call steps to retain per record (0 = no limit)
 
 	// Backend-specific configurations
 	Redis    *RedisConfig


### PR DESCRIPTION
## Purpose

Fixes two P0 production stability issues: silent router crashes from unrecovered signal panics (#1843) and OOM container kills from unbounded tool-trace step growth (#1835).

**Affected modules:** `[Router][Classification][RouterReplay][Observability]`

---

## Fix 1 — Signal dispatcher panic recovery (closes #1843)

### Root cause

Signal evaluators run concurrently in goroutines inside `runSignalDispatchers`. A panic in any evaluator (e.g. an out-of-bounds access in a Rust binding triggered by an unusually long prompt) propagated through the goroutine scheduler and killed the router process with no log output and no metric.

### Fix

Add `recoverSignalPanic` as a deferred recovery in every signal goroutine. On a recovered panic it:
1. Logs `[Signal Computation] panic recovered in <name> signal (<type>): <message>` at ERROR level
2. Increments a new `llm_signal_panic_total{signal_type, signal_name}` Prometheus counter

The request continues serving with the remaining signals; only the panicked signal's result is missing for that request. Operators can now alert on `llm_signal_panic_total > 0` instead of discovering the crash in a post-mortem.

### Changed files

| File | Change |
|------|--------|
| `pkg/classification/classifier_signal_dispatch.go` | Add `defer recoverSignalPanic(...)` in each goroutine; add `recoverSignalPanic` helper |
| `pkg/observability/metrics/signal_decision_plugin_metrics.go` | Add `llm_signal_panic_total` counter + `RecordSignalPanic` function |
| `pkg/classification/classifier_signal_dispatch_panic_test.go` | 2 tests: single panic recovered; sibling goroutines still complete |

---

## Fix 2 — Tool-trace step cap to prevent OOM (closes #1835)

### Root cause

Long-running agentic sessions append one `ToolTraceStep` per tool-call turn to `ToolTrace.Steps`. This slice (and the derived `Flow` string) is held in memory for every concurrent session with no upper bound. A reporter running a Hermes agent observed 112+ steps and 63K-token prompt contexts per session; with many concurrent sessions the container accumulates gigabytes of retained state until the OOM killer fires (exit code 137).

### Fix

Add a `MaxToolTraceSteps` config field (`max_tool_trace_steps`) that caps the Steps slice to the first N steps on both the `AddRecord` and `UpdateToolTrace` paths. Default `0` preserves the existing unlimited behavior. Recommended production value: **50**.

### Changed files

| File | Change |
|------|--------|
| `pkg/config/plugin_config.go` | Add `MaxToolTraceSteps` to `RouterReplayPluginConfig` |
| `pkg/routerreplay/recorder.go` | Add `maxToolTraceSteps` field, `SetMaxToolTraceSteps`, `capToolTraceSteps`; apply on `AddRecord` and `UpdateToolTrace` |
| `pkg/routerreplay/store/store.go` | Add `MaxToolTraceSteps` to `store.Config` |
| `pkg/extproc/router_replay_setup.go` | Wire `SetMaxToolTraceSteps` in both recorder construction paths |
| `pkg/extproc/recorder.go` | Wire `SetMaxToolTraceSteps` in `configureReplayRecorder` |
| `config/config.yaml` | Document `max_tool_trace_steps: 0` in reference config |
| `pkg/routerreplay/recorder_tool_trace_steps_test.go` | 5 tests: below cap unchanged; above cap truncated; zero = no limit; update path capped; nil trace safe |

---

## Test Plan

- [x] `go build ./...` — clean build
- [x] `go test ./pkg/config/...` — all 309 tests pass
- [x] `go test ./pkg/routerreplay/...` — all recorder tests pass (5 new)
- [x] `go test ./pkg/decision/...` — all pass
- [x] 2 new panic recovery tests: single panic does not crash process; sibling goroutines still complete

## Test Results

```
ok  pkg/config          0.492s
ok  pkg/routerreplay    0.279s
ok  pkg/decision        0.510s
```

Fixes #1843
Fixes #1835