### PR TITLE
feat:dynamic tool history signals

### DIFF
--- a/src/semantic-router/pkg/extproc/request_signal_history.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history.go
@@ -1,6 +1,10 @@
 package extproc
 
-import "github.com/openai/openai-go"
+import (
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+)
 
 type signalConversationHistory struct {
 	currentUserMessage string
@@ -17,6 +21,7 @@ type signalConversationHistory struct {
 	toolDefinitionCount    int
 	assistantToolCallCount int
 	completedToolCycles    int
+	assistantToolNames     []string
 }
 
 func signalConversationHistoryFromFastExtract(result *FastExtractResult) signalConversationHistory {
@@ -36,6 +41,24 @@ func signalConversationHistoryFromFastExtract(result *FastExtractResult) signalC
 		toolDefinitionCount:    result.ToolDefinitionCount,
 		assistantToolCallCount: result.AssistantToolCallCount,
 		completedToolCycles:    result.CompletedToolCycles,
+		assistantToolNames:     append([]string(nil), result.AssistantToolNames...),
+	}
+}
+
+func extractToolTransitionContextFromRequest(req *openai.ChatCompletionNewParams, historyWindow int, ctx *RequestContext) tools.ToolTransitionContext {
+	if req == nil {
+		return toolTransitionContextFromConversationHistory(signalConversationHistory{}, historyWindow, ctx)
+	}
+	return toolTransitionContextFromConversationHistory(extractSignalConversationHistory(req), historyWindow, ctx)
+}
+
+func toolTransitionContextFromConversationHistory(history signalConversationHistory, historyWindow int, ctx *RequestContext) tools.ToolTransitionContext {
+	return tools.ToolTransitionContext{
+		RecentToolNames:  recentToolNames(history.assistantToolNames, historyWindow),
+		TurnIndex:        history.userMessageCount,
+		ToolCycleCount:   history.completedToolCycles,
+		SelectedDecision: selectedDecisionName(ctx),
+		SelectedCategory: selectedCategoryName(ctx),
 	}
 }
 
@@ -67,6 +90,7 @@ func extractSignalConversationHistory(req *openai.ChatCompletionNewParams) signa
 			}
 			history.hasAssistantReply = true
 			history.assistantToolCallCount += len(msg.OfAssistant.ToolCalls)
+			history.assistantToolNames = append(history.assistantToolNames, toolNamesFromAssistantMessage(msg)...)
 		case "developer":
 			history.hasDeveloperMessage = true
 			if textContent != "" {
@@ -80,6 +104,46 @@ func extractSignalConversationHistory(req *openai.ChatCompletionNewParams) signa
 
 	history.toolDefinitionCount = countSDKToolDefinitions(req)
 	return history
+}
+
+func toolNamesFromAssistantMessage(msg openai.ChatCompletionMessageParamUnion) []string {
+	if msg.OfAssistant == nil || len(msg.OfAssistant.ToolCalls) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(msg.OfAssistant.ToolCalls))
+	for _, toolCall := range msg.OfAssistant.ToolCalls {
+		if toolCall.Function.Name != "" {
+			names = append(names, toolCall.Function.Name)
+		}
+	}
+	return names
+}
+
+func recentToolNames(names []string, historyWindow int) []string {
+	if len(names) == 0 {
+		return nil
+	}
+	if historyWindow <= 0 || historyWindow >= len(names) {
+		return append([]string(nil), names...)
+	}
+	return append([]string(nil), names[len(names)-historyWindow:]...)
+}
+
+func selectedDecisionName(ctx *RequestContext) string {
+	if ctx == nil {
+		return ""
+	}
+	if ctx.VSRSelectedDecision != nil {
+		return ctx.VSRSelectedDecision.Name
+	}
+	return ctx.VSRSelectedDecisionName
+}
+
+func selectedCategoryName(ctx *RequestContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return ctx.VSRSelectedCategory
 }
 
 func countSDKToolDefinitions(req *openai.ChatCompletionNewParams) int {

--- a/src/semantic-router/pkg/extproc/request_signal_history.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history.go
@@ -55,8 +55,8 @@ func extractToolTransitionContextFromRequest(req *openai.ChatCompletionNewParams
 func toolTransitionContextFromConversationHistory(history signalConversationHistory, historyWindow int, ctx *RequestContext) tools.ToolTransitionContext {
 	return tools.ToolTransitionContext{
 		RecentToolNames:  recentToolNames(history.assistantToolNames, historyWindow),
-		TurnIndex:        history.userMessageCount,
-		ToolCycleCount:   history.completedToolCycles,
+		UserMessageCount: history.userMessageCount,
+		ToolResultCount:  history.completedToolCycles,
 		SelectedDecision: selectedDecisionName(ctx),
 		SelectedCategory: selectedCategoryName(ctx),
 	}

--- a/src/semantic-router/pkg/extproc/request_signal_history_test.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
 )
 
@@ -34,6 +35,113 @@ func TestExtractSignalConversationHistory_ChatCompletionsMixedRoles(t *testing.T
 	assert.Equal(t, []string{"first question"}, history.priorUserMessages)
 	assert.Equal(t, []string{"System prompt", "first answer"}, history.nonUserMessages)
 	assert.True(t, history.hasAssistantReply)
+}
+
+func TestExtractToolTransitionContextFromRequest_ChatCompletionsNoToolCalls(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("hello"),
+		},
+	}
+
+	transition := extractToolTransitionContextFromRequest(req, 2, nil)
+
+	assert.Nil(t, transition.RecentToolNames)
+	assert.Equal(t, 1, transition.TurnIndex)
+	assert.Equal(t, 0, transition.ToolCycleCount)
+	assert.Empty(t, transition.SelectedDecision)
+	assert.Empty(t, transition.SelectedCategory)
+}
+
+func TestExtractToolTransitionContextFromRequest_ChatCompletionsToolHistory(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Find deployment details."),
+			assistantToolCallMessage("search", "lookup", "summarize"),
+			openai.ToolMessage("search result", "call-search"),
+			openai.ToolMessage("lookup result", "call-lookup"),
+			openai.ToolMessage("summary result", "call-summarize"),
+			openai.UserMessage("Now write the result."),
+		},
+	}
+
+	transition := extractToolTransitionContextFromRequest(req, 2, &RequestContext{
+		VSRSelectedCategory: "coding",
+		VSRSelectedDecision: &config.Decision{Name: "agent-tools"},
+	})
+
+	assert.Equal(t, []string{"lookup", "summarize"}, transition.RecentToolNames)
+	assert.Equal(t, 2, transition.TurnIndex)
+	assert.Equal(t, 3, transition.ToolCycleCount)
+	assert.Equal(t, "agent-tools", transition.SelectedDecision)
+	assert.Equal(t, "coding", transition.SelectedCategory)
+}
+
+func TestToolTransitionContextFromConversationHistoryPreservesAllToolsWhenWindowUnset(t *testing.T) {
+	history := signalConversationHistory{
+		userMessageCount:    2,
+		completedToolCycles: 1,
+		assistantToolNames:  []string{"read_file", "list_dir", "run_tests"},
+	}
+
+	transition := toolTransitionContextFromConversationHistory(history, 0, &RequestContext{
+		VSRSelectedDecisionName: "fallback-decision",
+		VSRSelectedCategory:     "maintenance",
+	})
+
+	assert.Equal(t, []string{"read_file", "list_dir", "run_tests"}, transition.RecentToolNames)
+	assert.Equal(t, 2, transition.TurnIndex)
+	assert.Equal(t, 1, transition.ToolCycleCount)
+	assert.Equal(t, "fallback-decision", transition.SelectedDecision)
+	assert.Equal(t, "maintenance", transition.SelectedCategory)
+}
+
+func TestToolTransitionContextFromConversationHistoryPreservesAllToolsWhenWindowNegative(t *testing.T) {
+	history := signalConversationHistory{
+		assistantToolNames: []string{"read_file", "list_dir", "run_tests"},
+	}
+
+	transition := toolTransitionContextFromConversationHistory(history, -1, nil)
+
+	assert.Equal(t, []string{"read_file", "list_dir", "run_tests"}, transition.RecentToolNames)
+}
+
+func TestToolTransitionContextFromConversationHistoryCopiesRecentTools(t *testing.T) {
+	history := signalConversationHistory{
+		assistantToolNames: []string{"a", "b", "c", "d"},
+	}
+
+	transition := toolTransitionContextFromConversationHistory(history, 2, nil)
+
+	assert.Equal(t, []string{"c", "d"}, transition.RecentToolNames)
+	history.assistantToolNames[2] = "mutated"
+	assert.Equal(t, []string{"c", "d"}, transition.RecentToolNames)
+}
+
+func TestExtractToolTransitionContextFromRequest_NilRequestAndContext(t *testing.T) {
+	transition := extractToolTransitionContextFromRequest(nil, 2, nil)
+
+	assert.Nil(t, transition.RecentToolNames)
+	assert.Equal(t, 0, transition.TurnIndex)
+	assert.Equal(t, 0, transition.ToolCycleCount)
+	assert.Empty(t, transition.SelectedDecision)
+	assert.Empty(t, transition.SelectedCategory)
+}
+
+func TestExtractToolTransitionContextFromRequestCountsCompletedToolResultsOnly(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Fetch several facts."),
+			assistantToolCallMessage("search", "lookup", "summarize"),
+			openai.ToolMessage("search result", "call-search"),
+		},
+	}
+
+	transition := extractToolTransitionContextFromRequest(req, 0, nil)
+
+	assert.Equal(t, []string{"search", "lookup", "summarize"}, transition.RecentToolNames)
+	assert.Equal(t, 1, transition.TurnIndex)
+	assert.Equal(t, 1, transition.ToolCycleCount)
 }
 
 func TestSignalConversationHistoryFromFastExtract_PreservesResponseAPIUserChain(t *testing.T) {
@@ -79,4 +187,92 @@ func TestSignalConversationHistoryFromFastExtract_PreservesResponseAPIUserChain(
 	assert.Equal(t, []string{"Hello"}, history.priorUserMessages)
 	assert.Equal(t, []string{"Remember my name is Alice.", "Hi there!"}, history.nonUserMessages)
 	assert.True(t, history.hasAssistantReply)
+}
+
+func TestSignalConversationHistoryFromFastExtract_ResponseAPITranslationPreservesToolNames(t *testing.T) {
+	store := NewMockResponseStore()
+	store.responses["resp_with_tool"] = &responseapi.StoredResponse{
+		ID:     "resp_with_tool",
+		Model:  "gpt-4",
+		Status: responseapi.StatusCompleted,
+		Input: []responseapi.InputItem{{
+			Type:    responseapi.ItemTypeMessage,
+			Role:    responseapi.RoleUser,
+			Content: json.RawMessage(`"Search the docs."`),
+		}},
+		Output: []responseapi.OutputItem{{
+			Type:      responseapi.ItemTypeFunctionCall,
+			CallID:    "call_search",
+			Name:      "search_docs",
+			Arguments: `{"query":"router"}`,
+			Status:    responseapi.StatusCompleted,
+		}, {
+			Type:   responseapi.ItemTypeFunctionCallOutput,
+			CallID: "call_search",
+			Output: `{"result":"found"}`,
+			Status: responseapi.StatusCompleted,
+		}},
+	}
+
+	filter := NewResponseAPIFilter(store)
+	requestBody := []byte(`{
+		"model": "gpt-4",
+		"input": "Summarize the result.",
+		"previous_response_id": "resp_with_tool"
+	}`)
+
+	respCtx, translatedBody, err := filter.TranslateRequest(context.Background(), requestBody)
+	require.NoError(t, err)
+	require.NotNil(t, respCtx)
+
+	fast, err := extractContentFast(translatedBody)
+	require.NoError(t, err)
+
+	history := signalConversationHistoryFromFastExtract(fast)
+	transition := toolTransitionContextFromConversationHistory(history, 1, nil)
+
+	assert.Equal(t, []string{"search_docs"}, fast.AssistantToolNames)
+	assert.Equal(t, []string{"search_docs"}, history.assistantToolNames)
+	assert.Equal(t, []string{"search_docs"}, transition.RecentToolNames)
+	assert.Equal(t, 2, transition.TurnIndex)
+	assert.Equal(t, 1, transition.ToolCycleCount)
+}
+
+func TestSignalConversationHistoryFromFastExtract_PreservesToolTransitionNames(t *testing.T) {
+	fast := &FastExtractResult{
+		UserContent:            "Now run the tests.",
+		UserMessageCount:       2,
+		ToolMessageCount:       2,
+		AssistantToolCallCount: 2,
+		CompletedToolCycles:    2,
+		AssistantToolNames:     []string{"read_file", "run_tests"},
+	}
+
+	history := signalConversationHistoryFromFastExtract(fast)
+	transition := toolTransitionContextFromConversationHistory(history, 1, nil)
+
+	assert.Equal(t, []string{"run_tests"}, transition.RecentToolNames)
+	assert.Equal(t, 2, transition.TurnIndex)
+	assert.Equal(t, 2, transition.ToolCycleCount)
+
+	fast.AssistantToolNames[1] = "mutated"
+	assert.Equal(t, []string{"run_tests"}, transition.RecentToolNames)
+}
+
+func assistantToolCallMessage(names ...string) openai.ChatCompletionMessageParamUnion {
+	toolCalls := make([]openai.ChatCompletionMessageToolCallParam, 0, len(names))
+	for _, name := range names {
+		toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
+			ID: "call-" + name,
+			Function: openai.ChatCompletionMessageToolCallFunctionParam{
+				Name:      name,
+				Arguments: "{}",
+			},
+		})
+	}
+	return openai.ChatCompletionMessageParamUnion{
+		OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+			ToolCalls: toolCalls,
+		},
+	}
 }

--- a/src/semantic-router/pkg/extproc/request_signal_history_test.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history_test.go
@@ -47,8 +47,8 @@ func TestExtractToolTransitionContextFromRequest_ChatCompletionsNoToolCalls(t *t
 	transition := extractToolTransitionContextFromRequest(req, 2, nil)
 
 	assert.Nil(t, transition.RecentToolNames)
-	assert.Equal(t, 1, transition.TurnIndex)
-	assert.Equal(t, 0, transition.ToolCycleCount)
+	assert.Equal(t, 1, transition.UserMessageCount)
+	assert.Equal(t, 0, transition.ToolResultCount)
 	assert.Empty(t, transition.SelectedDecision)
 	assert.Empty(t, transition.SelectedCategory)
 }
@@ -71,8 +71,8 @@ func TestExtractToolTransitionContextFromRequest_ChatCompletionsToolHistory(t *t
 	})
 
 	assert.Equal(t, []string{"lookup", "summarize"}, transition.RecentToolNames)
-	assert.Equal(t, 2, transition.TurnIndex)
-	assert.Equal(t, 3, transition.ToolCycleCount)
+	assert.Equal(t, 2, transition.UserMessageCount)
+	assert.Equal(t, 3, transition.ToolResultCount)
 	assert.Equal(t, "agent-tools", transition.SelectedDecision)
 	assert.Equal(t, "coding", transition.SelectedCategory)
 }
@@ -90,8 +90,8 @@ func TestToolTransitionContextFromConversationHistoryPreservesAllToolsWhenWindow
 	})
 
 	assert.Equal(t, []string{"read_file", "list_dir", "run_tests"}, transition.RecentToolNames)
-	assert.Equal(t, 2, transition.TurnIndex)
-	assert.Equal(t, 1, transition.ToolCycleCount)
+	assert.Equal(t, 2, transition.UserMessageCount)
+	assert.Equal(t, 1, transition.ToolResultCount)
 	assert.Equal(t, "fallback-decision", transition.SelectedDecision)
 	assert.Equal(t, "maintenance", transition.SelectedCategory)
 }
@@ -122,8 +122,8 @@ func TestExtractToolTransitionContextFromRequest_NilRequestAndContext(t *testing
 	transition := extractToolTransitionContextFromRequest(nil, 2, nil)
 
 	assert.Nil(t, transition.RecentToolNames)
-	assert.Equal(t, 0, transition.TurnIndex)
-	assert.Equal(t, 0, transition.ToolCycleCount)
+	assert.Equal(t, 0, transition.UserMessageCount)
+	assert.Equal(t, 0, transition.ToolResultCount)
 	assert.Empty(t, transition.SelectedDecision)
 	assert.Empty(t, transition.SelectedCategory)
 }
@@ -140,8 +140,8 @@ func TestExtractToolTransitionContextFromRequestCountsCompletedToolResultsOnly(t
 	transition := extractToolTransitionContextFromRequest(req, 0, nil)
 
 	assert.Equal(t, []string{"search", "lookup", "summarize"}, transition.RecentToolNames)
-	assert.Equal(t, 1, transition.TurnIndex)
-	assert.Equal(t, 1, transition.ToolCycleCount)
+	assert.Equal(t, 1, transition.UserMessageCount)
+	assert.Equal(t, 1, transition.ToolResultCount)
 }
 
 func TestSignalConversationHistoryFromFastExtract_PreservesResponseAPIUserChain(t *testing.T) {
@@ -234,8 +234,8 @@ func TestSignalConversationHistoryFromFastExtract_ResponseAPITranslationPreserve
 	assert.Equal(t, []string{"search_docs"}, fast.AssistantToolNames)
 	assert.Equal(t, []string{"search_docs"}, history.assistantToolNames)
 	assert.Equal(t, []string{"search_docs"}, transition.RecentToolNames)
-	assert.Equal(t, 2, transition.TurnIndex)
-	assert.Equal(t, 1, transition.ToolCycleCount)
+	assert.Equal(t, 2, transition.UserMessageCount)
+	assert.Equal(t, 1, transition.ToolResultCount)
 }
 
 func TestSignalConversationHistoryFromFastExtract_PreservesToolTransitionNames(t *testing.T) {
@@ -252,8 +252,8 @@ func TestSignalConversationHistoryFromFastExtract_PreservesToolTransitionNames(t
 	transition := toolTransitionContextFromConversationHistory(history, 1, nil)
 
 	assert.Equal(t, []string{"run_tests"}, transition.RecentToolNames)
-	assert.Equal(t, 2, transition.TurnIndex)
-	assert.Equal(t, 2, transition.ToolCycleCount)
+	assert.Equal(t, 2, transition.UserMessageCount)
+	assert.Equal(t, 2, transition.ToolResultCount)
 
 	fast.AssistantToolNames[1] = "mutated"
 	assert.Equal(t, []string{"run_tests"}, transition.RecentToolNames)

--- a/src/semantic-router/pkg/extproc/utils_fast.go
+++ b/src/semantic-router/pkg/extproc/utils_fast.go
@@ -29,6 +29,7 @@ type FastExtractResult struct {
 	ToolDefinitionCount    int
 	AssistantToolCallCount int
 	CompletedToolCycles    int
+	AssistantToolNames     []string
 }
 
 // extractContentFast extracts model, stream, message content, and the first
@@ -121,8 +122,11 @@ func countAssistantToolCalls(msg gjson.Result, result *FastExtractResult) {
 	if !toolCalls.Exists() || !toolCalls.IsArray() {
 		return
 	}
-	toolCalls.ForEach(func(_, _ gjson.Result) bool {
+	toolCalls.ForEach(func(_, toolCall gjson.Result) bool {
 		result.AssistantToolCallCount++
+		if name := toolCall.Get("function.name").String(); name != "" {
+			result.AssistantToolNames = append(result.AssistantToolNames, name)
+		}
 		return true
 	})
 }

--- a/src/semantic-router/pkg/extproc/utils_fast_test.go
+++ b/src/semantic-router/pkg/extproc/utils_fast_test.go
@@ -652,5 +652,6 @@ func TestExtractContentFast_ConversationFacts(t *testing.T) {
 	assert.Equal(t, 3, r.ToolMessageCount, "three tool messages")
 	assert.Equal(t, 3, r.ToolDefinitionCount, "three tool definitions")
 	assert.Equal(t, 3, r.AssistantToolCallCount, "three tool_calls total (2+1)")
+	assert.Equal(t, []string{"read_file", "list_dir", "write_file"}, r.AssistantToolNames, "tool call names should preserve conversation order")
 	assert.Equal(t, 3, r.CompletedToolCycles, "three completed tool cycles")
 }

--- a/src/semantic-router/pkg/tools/tool_transition.go
+++ b/src/semantic-router/pkg/tools/tool_transition.go
@@ -6,14 +6,13 @@ type ToolTransitionContext struct {
 	// order after applying the configured history window. It is nil when no prior
 	// tool calls are present.
 	RecentToolNames []string
-	// TurnIndex is the current user turn number as a 1-based count of user
-	// messages observed in the request history. It is 0 when no user message is
-	// present.
-	TurnIndex int
-	// ToolCycleCount counts completed tool result messages observed so far. A
+	// UserMessageCount is the number of user messages observed in the request
+	// history. It is 0 when no user message is present.
+	UserMessageCount int
+	// ToolResultCount counts completed tool result messages observed so far. A
 	// single assistant message with three parallel tool calls followed by three
 	// tool result messages contributes 3 here.
-	ToolCycleCount int
+	ToolResultCount int
 	// SelectedDecision is the decision selected at the call site, if selection has
 	// already happened. It is empty when transition context is extracted before
 	// decision selection.

--- a/src/semantic-router/pkg/tools/tool_transition.go
+++ b/src/semantic-router/pkg/tools/tool_transition.go
@@ -1,0 +1,24 @@
+package tools
+
+// ToolTransitionContext summarizes request history facts used by tool retrievers.
+type ToolTransitionContext struct {
+	// RecentToolNames contains assistant tool-call function names in oldest-to-newest
+	// order after applying the configured history window. It is nil when no prior
+	// tool calls are present.
+	RecentToolNames []string
+	// TurnIndex is the current user turn number as a 1-based count of user
+	// messages observed in the request history. It is 0 when no user message is
+	// present.
+	TurnIndex int
+	// ToolCycleCount counts completed tool result messages observed so far. A
+	// single assistant message with three parallel tool calls followed by three
+	// tool result messages contributes 3 here.
+	ToolCycleCount int
+	// SelectedDecision is the decision selected at the call site, if selection has
+	// already happened. It is empty when transition context is extracted before
+	// decision selection.
+	SelectedDecision string
+	// SelectedCategory is the category selected at the call site, if category
+	// selection has already happened. It is empty when extracted earlier.
+	SelectedCategory string
+}


### PR DESCRIPTION
Closes #1838

## Purpose

- Rename two fields in `ToolTransitionContext` for clarity:
  - `TurnIndex` → `UserMessageCount`: the field is a 1-based count of user messages, not a 0-based index. The name `TurnIndex` conflicts with the existing `RequestContext.TurnIndex` which is 0-based (prior turns count), creating an off-by-one trap for callers.
  - `ToolCycleCount` → `ToolResultCount`: the field counts individual tool result messages, not full assistant→tool_calls→tool_results round trips. A single assistant message with 3 parallel tool calls followed by 3 result messages contributes 3, not 1.
- Affects: `Router`

## Test Plan

go test ./pkg/extproc/... -run "TestExtractToolTransitionContext|TestToolTransitionContext|TestSignalConversationHistoryFromFastExtract"



No behavior change — pure rename. Existing tests cover nil request, nil context, window=0, window=-1, windowed slice, mutation isolation, and the Response API translation path.

## Test Result

All 9 targeted tests pass. Build clean with `go build ./pkg/tools/... ./pkg/extproc/...`.

No follow-up risks. The renamed fields are local to `ToolTransitionContext` which has no callers outside this PR's diff.