### PR TITLE
feat: introduce pluggable tool retriever interface and registry

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -20,7 +20,6 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
 )
 
-
 // handleToolSelectionForRequest handles tool selection for the request.
 func (r *OpenAIRouter) handleToolSelectionForRequest(openAIRequest *openai.ChatCompletionNewParams, response *ext_proc.ProcessingResponse, ctx *RequestContext) {
 	userContent, nonUserMessages := extractUserAndNonUserContent(openAIRequest)

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -20,10 +20,6 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
 )
 
-const (
-	candidatePoolMultiplier = 5
-	candidatePoolMinSize    = 20
-)
 
 // handleToolSelectionForRequest handles tool selection for the request.
 func (r *OpenAIRouter) handleToolSelectionForRequest(openAIRequest *openai.ChatCompletionNewParams, response *ext_proc.ProcessingResponse, ctx *RequestContext) {
@@ -111,11 +107,12 @@ func (r *OpenAIRouter) handleEarlyToolModes(
 func (r *OpenAIRouter) runSemanticToolSelection(
 	openAIRequest *openai.ChatCompletionNewParams,
 	classificationText string,
+	historySummary string,
 	response **ext_proc.ProcessingResponse,
 	ctx *RequestContext,
 	toolsCfg *config.ToolsPluginConfig,
 ) error {
-	selectedTools, strategyID, confidence, latency, toolErr := r.findToolsForQuery(classificationText, ctx, toolsCfg)
+	selectedTools, strategyID, confidence, latency, toolErr := r.findToolsForQuery(classificationText, historySummary, ctx, toolsCfg)
 
 	emitToolObservability(response, strategyID, confidence, latency)
 	metrics.RecordToolsRetrieval(strategyID, latency.Seconds())
@@ -170,12 +167,19 @@ func (r *OpenAIRouter) handleToolSelection(
 		return r.updateRequestWithTools(openAIRequest, response, ctx)
 	}
 
-	// Build classification text.
+	// Build classification text and a compact history summary for retrieval.
 	var classificationText string
 	if len(userContent) > 0 {
 		classificationText = userContent
 	} else if len(nonUserMessages) > 0 {
 		classificationText = strings.Join(nonUserMessages, " ")
+	}
+	var historySummary string
+	if len(nonUserMessages) > 0 {
+		historySummary = strings.Join(nonUserMessages, " ")
+	}
+	if historySummary == classificationText {
+		historySummary = ""
 	}
 	if classificationText == "" {
 		logging.Infof("No content available for tool classification")
@@ -187,22 +191,22 @@ func (r *OpenAIRouter) handleToolSelection(
 		return nil
 	}
 
-	return r.runSemanticToolSelection(openAIRequest, classificationText, response, ctx, toolsCfg)
+	return r.runSemanticToolSelection(openAIRequest, classificationText, historySummary, response, ctx, toolsCfg)
 }
 
 // executeRetrieval resolves the retriever for strategyID from the registry and
-// runs it. If the registry is nil or the strategy is not found, it falls back
-// to ToolsDatabase directly and marks the returned StrategyID with "-fallback".
-func (r *OpenAIRouter) executeRetrieval(ctx context.Context, query, strategyID string, topK int) (tools.RetrievalResult, error) {
+// runs it with in. If the registry is nil or the strategy is not found, it falls
+// back to ToolsDatabase directly and marks the returned StrategyID with "-fallback".
+func (r *OpenAIRouter) executeRetrieval(ctx context.Context, strategyID string, in tools.RetrievalInput) (tools.RetrievalResult, error) {
 	if r.ToolsRegistry != nil {
 		if retriever, ok := r.ToolsRegistry.Get(strategyID); ok {
-			return retriever.Retrieve(ctx, query, topK)
+			return retriever.Retrieve(ctx, in)
 		}
 
 		// Named strategy not found — try "default" before falling back to DB
-		if retriever, ok := r.ToolsRegistry.Get("default"); ok {
+		if retriever, ok := r.ToolsRegistry.Get(tools.StrategyDefault); ok {
 			logging.Warnf("[ToolsPlugin] strategy %q not found, falling back to default", strategyID)
-			result, err := retriever.Retrieve(ctx, query, topK)
+			result, err := retriever.Retrieve(ctx, in)
 			result.StrategyID = strategyID + "-fallback"
 			return result, err
 		}
@@ -212,7 +216,8 @@ func (r *OpenAIRouter) executeRetrieval(ctx context.Context, query, strategyID s
 		logging.Warnf("[ToolsPlugin] registry not initialized for strategy %q, using ToolsDatabase directly", strategyID)
 	}
 
-	results, err := r.ToolsDatabase.FindSimilarToolsWithScores(query, topK)
+	pool := in.EffectivePoolSize()
+	results, err := r.ToolsDatabase.FindSimilarToolsWithScores(in.Query, pool)
 	if err != nil {
 		return tools.RetrievalResult{StrategyID: strategyID + "-fallback"}, err
 	}
@@ -232,7 +237,11 @@ func (r *OpenAIRouter) executeRetrieval(ctx context.Context, query, strategyID s
 // findToolsForQuery resolves the retriever strategy from the registry, executes
 // retrieval, applies advanced filtering, and returns the final tool list together
 // with the strategy name, top-1 confidence score, and retrieval wall-clock time.
-func (r *OpenAIRouter) findToolsForQuery(query string, ctx *RequestContext, toolsCfg *config.ToolsPluginConfig) ([]openai.ChatCompletionToolParam, string, float32, time.Duration, error) {
+func (r *OpenAIRouter) findToolsForQuery(
+	query, historySummary string,
+	ctx *RequestContext,
+	toolsCfg *config.ToolsPluginConfig,
+) ([]openai.ChatCompletionToolParam, string, float32, time.Duration, error) {
 	topK := r.Config.Tools.TopK
 	if topK <= 0 {
 		topK = 3
@@ -246,13 +255,15 @@ func (r *OpenAIRouter) findToolsForQuery(query string, ctx *RequestContext, tool
 		poolSize = resolveCandidatePoolSize(advanced, topK)
 	}
 
+	retrievalIn := newToolRetrievalInput(query, historySummary, topK, poolSize, ctx)
+
 	retrievalCtx := context.Background()
 	if ctx != nil && ctx.TraceContext != nil {
 		retrievalCtx = ctx.TraceContext
 	}
 
 	start := time.Now()
-	retrieved, err := r.executeRetrieval(retrievalCtx, query, strategyID, poolSize)
+	retrieved, err := r.executeRetrieval(retrievalCtx, strategyID, retrievalIn)
 	latency := time.Since(start)
 
 	if err != nil {
@@ -298,14 +309,14 @@ func selectTopKTools(candidates []tools.ToolSimilarity, topK int) []openai.ChatC
 
 func resolveCandidatePoolSize(advanced *config.AdvancedToolFilteringConfig, topK int) int {
 	if advanced == nil {
-		return max(topK*candidatePoolMultiplier, candidatePoolMinSize)
+		return max(topK*tools.DefaultCandidatePoolMultiplier, tools.DefaultCandidatePoolMin)
 	}
 	var size int
 	switch {
 	case advanced.CandidatePoolSize != nil && *advanced.CandidatePoolSize > 0:
 		size = *advanced.CandidatePoolSize
 	case advanced.CandidatePoolSize == nil:
-		size = max(topK*candidatePoolMultiplier, candidatePoolMinSize)
+		size = max(topK*tools.DefaultCandidatePoolMultiplier, tools.DefaultCandidatePoolMin)
 	default:
 		size = topK
 	}
@@ -313,6 +324,29 @@ func resolveCandidatePoolSize(advanced *config.AdvancedToolFilteringConfig, topK
 		size = topK
 	}
 	return size
+}
+
+func newToolRetrievalInput(
+	query, historySummary string,
+	topK, poolSize int,
+	ctx *RequestContext,
+) tools.RetrievalInput {
+	in := tools.RetrievalInput{
+		Query:          query,
+		HistorySummary: historySummary,
+		TopK:           topK,
+		PoolSize:       poolSize,
+	}
+	if ctx == nil {
+		return in
+	}
+	in.Category = ctx.VSRSelectedCategory
+	in.DecisionName = ctx.VSRSelectedDecisionName
+	if ctx.VSRSelectedDecision != nil && in.DecisionName == "" {
+		in.DecisionName = ctx.VSRSelectedDecision.Name
+	}
+	in.DecisionConfidence = ctx.VSRSelectedDecisionConfidence
+	return in
 }
 
 func resolveCategory(advanced *config.AdvancedToolFilteringConfig, ctx *RequestContext) string {

--- a/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
@@ -18,7 +18,7 @@ type stubRetriever struct {
 	confidence float32
 }
 
-func (s *stubRetriever) Retrieve(_ context.Context, _ string, _ int) (tools.RetrievalResult, error) {
+func (s *stubRetriever) Retrieve(_ context.Context, _ tools.RetrievalInput) (tools.RetrievalResult, error) {
 	return tools.RetrievalResult{
 		Tools:      s.results,
 		Confidence: s.confidence,

--- a/src/semantic-router/pkg/extproc/router.go
+++ b/src/semantic-router/pkg/extproc/router.go
@@ -151,13 +151,12 @@ func (r *OpenAIRouter) LoadToolsDatabase() error {
 
 	// Wire the default embedding retriever into the registry now that
 	// the database is loaded and embeddings are available.
-	r.ToolsRegistry = tools.NewRegistry()
-	r.ToolsRegistry.Register("default", tools.NewEmbeddingRetriever(r.ToolsDatabase))
+	r.ToolsRegistry = tools.NewDefaultRegistry(r.ToolsDatabase)
 
 	return nil
 }
 
-func (r *OpenAIRouter) RegisterToolStrategy(name string, retriever tools.Retriever) {
+func (r *OpenAIRouter) RegisterToolStrategy(name string, retriever tools.ToolRetriever) {
 	if r.ToolsRegistry == nil {
 		r.ToolsRegistry = tools.NewRegistry()
 	}

--- a/src/semantic-router/pkg/tools/embedding_retriever.go
+++ b/src/semantic-router/pkg/tools/embedding_retriever.go
@@ -4,7 +4,7 @@ package tools
 
 import "context"
 
-// EmbeddingRetriever implements Retriever using cosine-similarity search
+// EmbeddingRetriever implements ToolRetriever using cosine-similarity search
 // against the in-process ToolsDatabase.  It is registered as the "default"
 // strategy and requires no external dependencies beyond the database that the
 // router already initialises at startup.
@@ -21,13 +21,15 @@ func NewEmbeddingRetriever(db *ToolsDatabase) *EmbeddingRetriever {
 	return &EmbeddingRetriever{db: db}
 }
 
-// Retrieve returns up to topK tools ranked by embedding similarity.
+// Retrieve returns up to in.EffectivePoolSize() tools ranked by embedding
+// similarity. HistorySummary, category, and decision fields are ignored.
 // The Confidence field of the result is the similarity score of the
 // highest-ranked tool, or 0 when no tools are returned.
-func (e *EmbeddingRetriever) Retrieve(_ context.Context, query string, topK int) (RetrievalResult, error) {
-	candidates, err := e.db.FindSimilarToolsWithScores(query, topK)
+func (e *EmbeddingRetriever) Retrieve(_ context.Context, in RetrievalInput) (RetrievalResult, error) {
+	pool := in.EffectivePoolSize()
+	candidates, err := e.db.FindSimilarToolsWithScores(in.Query, pool)
 	if err != nil {
-		return RetrievalResult{StrategyID: "default"}, err
+		return RetrievalResult{StrategyID: StrategyDefault}, err
 	}
 
 	confidence := float32(0)
@@ -38,6 +40,6 @@ func (e *EmbeddingRetriever) Retrieve(_ context.Context, query string, topK int)
 	return RetrievalResult{
 		Tools:      candidates,
 		Confidence: confidence,
-		StrategyID: "default",
+		StrategyID: StrategyDefault,
 	}, nil
 }

--- a/src/semantic-router/pkg/tools/retrieval_input.go
+++ b/src/semantic-router/pkg/tools/retrieval_input.go
@@ -1,0 +1,39 @@
+package tools
+
+// Default candidate-pool heuristics match extproc when advanced filtering is off.
+const (
+	DefaultCandidatePoolMultiplier = 5
+	DefaultCandidatePoolMin        = 20
+)
+
+// StrategyDefault is the built-in embedding-similarity retriever name.
+const StrategyDefault = "default"
+
+// RetrievalInput carries shared context for tool retrieval. Strategies use the
+// fields they need; others may be left empty.
+type RetrievalInput struct {
+	Query              string
+	HistorySummary     string
+	Category           string
+	DecisionName       string
+	DecisionConfidence float64
+	// TopK is the desired number of tools after post-retrieval filtering.
+	TopK int
+	// PoolSize is how many candidates to pull from the index (before advanced filters).
+	PoolSize int
+}
+
+// EffectivePoolSize returns PoolSize, or a conservative default when unset
+// (aligned with the legacy single-path behavior).
+func (in RetrievalInput) EffectivePoolSize() int {
+	if in.PoolSize > 0 {
+		return in.PoolSize
+	}
+	if in.TopK > 0 {
+		if n := in.TopK * DefaultCandidatePoolMultiplier; n > DefaultCandidatePoolMin {
+			return n
+		}
+		return DefaultCandidatePoolMin
+	}
+	return DefaultCandidatePoolMin
+}

--- a/src/semantic-router/pkg/tools/retriever.go
+++ b/src/semantic-router/pkg/tools/retriever.go
@@ -9,29 +9,42 @@ type RetrievalResult struct {
 	StrategyID string
 }
 
-// Retriever is the interface every tool-retrieval strategy must satisfy.
-type Retriever interface {
-	Retrieve(ctx context.Context, query string, topK int) (RetrievalResult, error)
+// ToolRetriever is the pluggable interface for tool-candidate retrieval.
+// Implementations are registered by name on Registry and selected from
+// plugin config (e.g. tools strategy on a matched decision).
+type ToolRetriever interface {
+	Retrieve(ctx context.Context, in RetrievalInput) (RetrievalResult, error)
 }
 
-// Registry maps strategy names to Retriever implementations.
+// Retriever is a type alias for ToolRetriever.
+type Retriever = ToolRetriever
+
+// Registry maps strategy names to ToolRetriever implementations.
 type Registry struct {
-	strategies map[string]Retriever
+	strategies map[string]ToolRetriever
 }
 
 func NewRegistry() *Registry {
-	return &Registry{strategies: make(map[string]Retriever)}
+	return &Registry{strategies: make(map[string]ToolRetriever)}
 }
 
-func (r *Registry) Register(name string, s Retriever) {
+// NewDefaultRegistry returns a registry with the embedding-similarity strategy
+// registered as StrategyDefault.
+func NewDefaultRegistry(db *ToolsDatabase) *Registry {
+	r := NewRegistry()
+	r.Register(StrategyDefault, NewEmbeddingRetriever(db))
+	return r
+}
+
+func (r *Registry) Register(name string, s ToolRetriever) {
 	if s == nil {
-		panic("tools: Register called with nil Retriever for strategy " + name)
+		panic("tools: Register called with nil ToolRetriever for strategy " + name)
 	}
 	r.strategies[name] = s
 }
 
-// Get returns the named strategy, falling back to "default" if not found.
-func (r *Registry) Get(name string) (Retriever, bool) {
+// Get returns the named strategy.
+func (r *Registry) Get(name string) (ToolRetriever, bool) {
 	s, ok := r.strategies[name]
 	return s, ok
 }

--- a/src/semantic-router/pkg/tools/retriever_test.go
+++ b/src/semantic-router/pkg/tools/retriever_test.go
@@ -10,16 +10,44 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
 )
 
-// fakeRetriever is a test double for the Retriever interface.
+// fakeRetriever is a test double for the ToolRetriever interface.
 type fakeRetriever struct {
 	id     string
 	result tools.RetrievalResult
 	err    error
 }
 
-func (f *fakeRetriever) Retrieve(_ context.Context, _ string, _ int) (tools.RetrievalResult, error) {
+func (f *fakeRetriever) Retrieve(_ context.Context, _ tools.RetrievalInput) (tools.RetrievalResult, error) {
 	return f.result, f.err
 }
+
+var _ = Describe("RetrievalInput.EffectivePoolSize", func() {
+	It("uses PoolSize when set", func() {
+		in := tools.RetrievalInput{PoolSize: 42, TopK: 2}
+		Expect(in.EffectivePoolSize()).To(Equal(42))
+	})
+
+	It("derives from TopK when PoolSize is zero", func() {
+		in := tools.RetrievalInput{TopK: 10}
+		Expect(in.EffectivePoolSize()).To(Equal(50)) // 10*5
+	})
+
+	It("floors to DefaultCandidatePoolMin for small TopK", func() {
+		in := tools.RetrievalInput{TopK: 1}
+		Expect(in.EffectivePoolSize()).To(Equal(tools.DefaultCandidatePoolMin))
+	})
+})
+
+var _ = Describe("NewDefaultRegistry", func() {
+	It("registers the embedding strategy", func() {
+		db := tools.NewToolsDatabase(tools.ToolsDatabaseOptions{Enabled: false, SimilarityThreshold: 0.5})
+		reg := tools.NewDefaultRegistry(db)
+		r, ok := reg.Get(tools.StrategyDefault)
+		Expect(ok).To(BeTrue())
+		_, err := r.Retrieve(context.Background(), tools.RetrievalInput{Query: "q", TopK: 1, PoolSize: 1})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
 
 var _ = Describe("Registry", func() {
 	var reg *tools.Registry
@@ -64,7 +92,7 @@ var _ = Describe("Registry", func() {
 	})
 
 	Describe("Register", func() {
-		It("panics when given a nil Retriever", func() {
+		It("panics when given a nil ToolRetriever", func() {
 			Expect(func() { reg.Register("bad", nil) }).To(Panic())
 		})
 	})
@@ -81,11 +109,11 @@ var _ = Describe("EmbeddingRetriever", func() {
 			SimilarityThreshold: 0.5,
 		})
 		r := tools.NewEmbeddingRetriever(db)
-		result, err := r.Retrieve(context.Background(), "weather", 3)
+		result, err := r.Retrieve(context.Background(), tools.RetrievalInput{Query: "weather", TopK: 3, PoolSize: 3})
 		// disabled DB returns empty slice, not an error
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Confidence).To(Equal(float32(0)))
-		Expect(result.StrategyID).To(Equal("default"))
+		Expect(result.StrategyID).To(Equal(tools.StrategyDefault))
 	})
 })
 
@@ -93,7 +121,7 @@ var _ = Describe("fakeRetriever propagates errors", func() {
 	It("surfaces the error returned by the underlying retriever", func() {
 		boom := errors.New("retrieval failed")
 		r := &fakeRetriever{err: boom}
-		_, err := r.Retrieve(context.Background(), "query", 3)
+		_, err := r.Retrieve(context.Background(), tools.RetrievalInput{Query: "query", TopK: 3, PoolSize: 3})
 		Expect(err).To(MatchError(boom))
 	})
 })


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes https://github.com/vllm-project/semantic-router/issues/1833

## Purpose

- What does this PR change?

1.Introducing a pluggable tool retrieval interface, ToolRetriever (Retriever being its alias), in pkg/tools. Retrieve(ctx, RetrievalInput) replaces the original (ctx, query, topK).

2.Adding RetrievalInput: It uniformly carries query, dialogue history summary, category, decision name/confidence, TopK, and PoolSize; EffectivePoolSize() maintains the same logic as before when the pool size is not set.

3.Adding NewDefaultRegistry(db) and StrategyDefault, registering the default embedding similarity retrieval as default; LoadToolsDatabase now uses this factory.

4.EmbeddingRetriever only queries the database based on Query + EffectivePoolSize(); the remaining fields are used by subsequent strategies.

5.extproc is only responsible for orchestration: concatenating newToolRetrievalInput, calling the registry/rolling back to the database by strategy name; handleToolSelection takes non-user messages as HistorySummary (set to null if duplicated with classification).

- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

1.retriever_test.go: Added 3 test cases for RetrievalInput.EffectivePoolSize; added NewDefaultRegistry registration and callability test cases; Registry / Register / fakeRetriever / EmbeddingRetriever were adjusted according to the new interface.

2.req_filter_tools_retriever_e2e_test.go: stubRetriever was changed to implement the new interface (no new e2e test cases).

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
