### PR TITLE
refactor: simplify searchLayerHybridInternal by returning sorted indices

### DIFF
--- a/src/semantic-router/pkg/cache/hybrid_cache_hnsw.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_hnsw.go
@@ -199,7 +199,8 @@ func (h *HybridCache) searchLayerHybridInternal(
 		}
 	}
 
-	return collectHybridSearchResults(buf.results)
+	// return the indexes of the results sorted by similarity (nearest first)
+	return buf.results.sortedIndicesAsc()
 }
 
 // selectNeighborsHybrid selects the best neighbors from candidates (hybrid version).
@@ -316,16 +317,4 @@ func shouldStopHybridSearch(currentDist float32, results *maxHeap) bool {
 
 func hitHybridThreshold(similarity float32, threshold *float32) bool {
 	return threshold != nil && similarity >= *threshold
-}
-
-func collectHybridSearchResults(results *maxHeap) []int {
-	resultIDs := make([]int, 0, results.len())
-	for results.len() > 0 {
-		idx, _ := results.pop()
-		resultIDs = append(resultIDs, idx)
-	}
-	for i, j := 0, len(resultIDs)-1; i < j; i, j = i+1, j-1 {
-		resultIDs[i], resultIDs[j] = resultIDs[j], resultIDs[i]
-	}
-	return resultIDs
 }


### PR DESCRIPTION

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

- What does this PR change?
This PR is the downstream of #1553  and #1787.  
  - The former PR refactored the hybrid_cache and encapsulated the common logic of "Extracting ID from `results` and sorting by similarity"([ref1](https://github.com/vllm-project/semantic-router/pull/1553/changes#diff-21c8a15c455bf88d9a6b303ec1c34e3a3dafa1fa2349c25378bccd688a83af06L1156-L1157), [ref2](https://github.com/vllm-project/semantic-router/pull/1553/changes#diff-21c8a15c455bf88d9a6b303ec1c34e3a3dafa1fa2349c25378bccd688a83af06L1021) ) into helper `collectHybridSearchResults` . 
  - The latter PR enabled `result(type: maxheap)` returning internal IDs in ascending distance(nearest first) directly through `func (h *maxHeap) sortedIndicesAsc() []int`.
<img width="300" height="270" alt="patch1" src="https://github.com/user-attachments/assets/720e7801-feda-4367-9a81-43f691243050" />

- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
