### PR TITLE
[Router]: Fix timestamp-based fake randomness with math/rand/v2 in selectLevel

### DIFF
--- a/src/semantic-router/pkg/cache/cache_test.go
+++ b/src/semantic-router/pkg/cache/cache_test.go
@@ -4813,7 +4813,7 @@ func BenchmarkHNSWFixComparison(b *testing.B) {
 	dims := 384
 	sizes := []int{1000, 5000, 10000, 20000}
 
-	b.Logf("| N | 修复前层级 | 修复后层级 | 修复前/query | 修复后/query | 线性/query | 修复前加速比 | 修复后加速比 |")
+	b.Logf("| N | Degen layers | Fixed layers | Degen/query | Fixed/query | Linear/query | Degen speedup | Fixed speedup |")
 	b.Logf("|---|-----------|-----------|-------------|-------------|-----------|-------------|-------------|")
 
 	for _, n := range sizes {
@@ -4877,7 +4877,7 @@ func BenchmarkHNSWFixComparison(b *testing.B) {
 		degenSpeedup := float64(linearPerQuery) / float64(degenPerQuery)
 		fixedSpeedup := float64(linearPerQuery) / float64(fixedPerQuery)
 
-		b.Logf("| %d | %d层 | %d层 | %v | %v | %v | **%.1fx** | **%.1fx** |",
+		b.Logf("| %d | %d layers | %d layers | %v | %v | %v | **%.1fx** | **%.1fx** |",
 			n, len(degenLayers), len(fixedLayers),
 			degenPerQuery.Round(time.Microsecond),
 			fixedPerQuery.Round(time.Microsecond),

--- a/src/semantic-router/pkg/hnsw/hnsw.go
+++ b/src/semantic-router/pkg/hnsw/hnsw.go
@@ -14,8 +14,10 @@
 package hnsw
 
 import (
+	"cmp"
 	"math"
 	"math/rand/v2"
+	"slices"
 	"sync"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -333,26 +335,31 @@ func (h *Index) searchLayer(queryEmbedding []float32, entryPoint, ef, layer int)
 				continue
 			}
 			visited[neighborID] = true
-
-			neighborNode, ok := h.nodes[neighborID]
-			if !ok {
-				continue
-			}
-			dist := h.distance(queryEmbedding, neighborNode.Embedding)
-
-			if results.len() >= ef && dist >= results.peekDist() {
-				continue
-			}
-
-			candidates.push(neighborID, dist)
-			results.push(neighborID, dist)
-			if results.len() > ef {
-				results.pop()
-			}
+			h.tryAddNeighbor(queryEmbedding, neighborID, ef, candidates, results)
 		}
 	}
 
 	return results.items()
+}
+
+// tryAddNeighbor evaluates a single neighbor and pushes it into the search
+// heaps when it improves the current top-ef result set.
+func (h *Index) tryAddNeighbor(queryEmbedding []float32, neighborID, ef int, candidates *minHeap, results *maxHeap) {
+	neighborNode, ok := h.nodes[neighborID]
+	if !ok {
+		return
+	}
+	dist := h.distance(queryEmbedding, neighborNode.Embedding)
+
+	if results.len() >= ef && dist >= results.peekDist() {
+		return
+	}
+
+	candidates.push(neighborID, dist)
+	results.push(neighborID, dist)
+	if results.len() > ef {
+		results.pop()
+	}
 }
 
 // selectNeighbors selects the best neighbors by sorting by distance
@@ -365,44 +372,32 @@ func (h *Index) selectNeighbors(candidateIDs []int, m int, queryEmb []float32) [
 		return candidateIDs
 	}
 
-	// Create a temporary slice with distances for sorting
 	type neighborDist struct {
 		id   int
 		dist float32
 	}
 
 	neighbors := make([]neighborDist, 0, len(candidateIDs))
-
-	// Compute distance from query to each candidate
 	for _, id := range candidateIDs {
-		if node, ok := h.nodes[id]; ok {
-			if len(node.Embedding) != len(queryEmb) {
-				continue // Skip dimension mismatch
-			}
-			neighbors = append(neighbors, neighborDist{
-				id:   id,
-				dist: h.distance(queryEmb, node.Embedding),
-			})
+		node, ok := h.nodes[id]
+		if !ok || len(node.Embedding) != len(queryEmb) {
+			continue
 		}
+		neighbors = append(neighbors, neighborDist{
+			id:   id,
+			dist: h.distance(queryEmb, node.Embedding),
+		})
 	}
 
-	// Sort by distance (ascending - smallest distance first)
-	// Use selection sort since m is typically small (16-32)
-	for i := 0; i < m && i < len(neighbors); i++ {
-		minIdx := i
-		for j := i + 1; j < len(neighbors); j++ {
-			if neighbors[j].dist < neighbors[minIdx].dist {
-				minIdx = j
-			}
-		}
-		if minIdx != i {
-			neighbors[i], neighbors[minIdx] = neighbors[minIdx], neighbors[i]
-		}
-	}
+	slices.SortFunc(neighbors, func(a, b neighborDist) int {
+		return cmp.Compare(a.dist, b.dist)
+	})
 
-	// Return the m nearest neighbors
+	if m > len(neighbors) {
+		m = len(neighbors)
+	}
 	result := make([]int, 0, m)
-	for i := 0; i < m && i < len(neighbors); i++ {
+	for i := 0; i < m; i++ {
 		result = append(result, neighbors[i].id)
 	}
 	return result

--- a/src/semantic-router/pkg/hnsw/hnsw.go
+++ b/src/semantic-router/pkg/hnsw/hnsw.go
@@ -15,8 +15,8 @@ package hnsw
 
 import (
 	"math"
+	"math/rand/v2"
 	"sync"
-	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
@@ -238,8 +238,7 @@ func (h *Index) Clear() {
 
 // selectLevel randomly selects a level for a new node
 func (h *Index) selectLevel() int {
-	// Use exponential decay probability
-	r := -math.Log(math.Max(1e-9, 1.0-float64(time.Now().UnixNano()%1000000)/1000000.0))
+	r := -math.Log(math.Max(1e-9, 1.0-rand.Float64()))
 	return int(r * h.ml)
 }
 
@@ -335,19 +334,20 @@ func (h *Index) searchLayer(queryEmbedding []float32, entryPoint, ef, layer int)
 			}
 			visited[neighborID] = true
 
-			if neighborNode, ok := h.nodes[neighborID]; ok {
-				dist := h.distance(queryEmbedding, neighborNode.Embedding)
+			neighborNode, ok := h.nodes[neighborID]
+			if !ok {
+				continue
+			}
+			dist := h.distance(queryEmbedding, neighborNode.Embedding)
 
-				if results.len() < ef {
-					candidates.push(neighborID, dist)
-					results.push(neighborID, dist)
-				} else if dist < results.peekDist() {
-					candidates.push(neighborID, dist)
-					results.push(neighborID, dist)
-					if results.len() > ef {
-						results.pop()
-					}
-				}
+			if results.len() >= ef && dist >= results.peekDist() {
+				continue
+			}
+
+			candidates.push(neighborID, dist)
+			results.push(neighborID, dist)
+			if results.len() > ef {
+				results.pop()
 			}
 		}
 	}


### PR DESCRIPTION
Switch to math/rand/v2's concurrency-safe rand.Float64(), mirroring the fix PR #1822 applied to pkg/cache/{inmemory_cache,hybrid_cache_hnsw}.go. pkg/hnsw is a sibling library implementation with no current importers, so this aligns it with the actively-used cache HNSW indexes ahead of any future wiring.

> The changes in `searchLayer` rewrote inner loop with early-continue guards. Nesting drops 6→3, passing structure-check.

## Purpose

- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Router`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
