### PR TITLE
feat: refactor tool selection as a decision plugin with add/filter modes

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -596,6 +596,20 @@ routing:
               - search_web
             block_tools:
               - exec_cmd
+        # Disabled sample: add mode only (filter fields belong under mode: filter; see legal_confidence_route).
+        - type: tool_selection
+          configuration:
+            enabled: false
+            mode: add
+            tools_db_path: config/tools_db.json
+            top_k: 5
+            similarity_threshold: 0.30
+            strategy: default
+            fallback_to_empty: false
+            advanced_filtering:
+              enabled: true
+              candidate_pool_size: 30
+              min_combined_score: 0.4
 
     - name: legal_confidence_route
       description: Confidence-routed legal and factual traffic.
@@ -638,6 +652,13 @@ routing:
             hallucination_action: annotate
             unverified_factual_action: warn
             include_hallucination_details: true
+        # Disabled sample: filter mode only (reference config union coverage for ToolSelectionPluginConfig filter fields).
+        - type: tool_selection
+          configuration:
+            enabled: false
+            mode: filter
+            relevance_threshold: 0.25
+            preserve_count: 2
 
     - name: health_ratings_route
       description: Ratings-based route for health requests that need fact verification.

--- a/config/plugin/tool-selection/add-from-database.yaml
+++ b/config/plugin/tool-selection/add-from-database.yaml
@@ -1,0 +1,11 @@
+plugin:
+  type: tool_selection
+  configuration:
+    enabled: true
+    mode: add
+    tools_db_path: config/tools_db.json
+    top_k: 5
+    similarity_threshold: 0.35
+    advanced_filtering:
+      enabled: true
+      min_combined_score: 0.4

--- a/config/plugin/tool-selection/filter-request-tools.yaml
+++ b/config/plugin/tool-selection/filter-request-tools.yaml
@@ -1,0 +1,7 @@
+plugin:
+  type: tool_selection
+  configuration:
+    enabled: true
+    mode: filter
+    relevance_threshold: 0.25
+    preserve_count: 2

--- a/src/semantic-router/pkg/config/docs_contract_algorithm_plugin_test.go
+++ b/src/semantic-router/pkg/config/docs_contract_algorithm_plugin_test.go
@@ -44,6 +44,7 @@ var pluginTutorialBuckets = map[string]string{
 	"router-replay":      "retrieval-and-memory",
 	"semantic-cache":     "retrieval-and-memory",
 	"system-prompt":      "response-and-mutation",
+	"tool-selection":     "response-and-mutation",
 	"tools":              "response-and-mutation",
 }
 

--- a/src/semantic-router/pkg/config/reference_config_routing_surface_test.go
+++ b/src/semantic-router/pkg/config/reference_config_routing_surface_test.go
@@ -89,6 +89,7 @@ func assertReferenceCorePluginCoverage(t testingT, pluginsByType map[string][]ma
 	assertPluginConfigCoverage(t, pluginsByType["response_jailbreak"], reflect.TypeOf(ResponseJailbreakPluginConfig{}), "response_jailbreak")
 	assertPluginConfigCoverage(t, pluginsByType["router_replay"], reflect.TypeOf(RouterReplayPluginConfig{}), "router_replay")
 	assertPluginConfigCoverage(t, pluginsByType["request_params"], reflect.TypeOf(RequestParamsPluginConfig{}), "request_params")
+	assertPluginConfigCoverage(t, pluginsByType["tool_selection"], reflect.TypeOf(ToolSelectionPluginConfig{}), "tool_selection")
 }
 
 func assertReferenceNestedPluginCoverage(t testingT, pluginsByType map[string][]map[string]interface{}) {

--- a/src/semantic-router/pkg/config/routing_surface_catalog.go
+++ b/src/semantic-router/pkg/config/routing_surface_catalog.go
@@ -14,6 +14,7 @@ const (
 	DecisionPluginImageGen          = "image_gen"
 	DecisionPluginFastResponse      = "fast_response"
 	DecisionPluginRequestParams     = "request_params"
+	DecisionPluginToolSelection     = "tool_selection"
 )
 
 var supportedSignalTypes = []string{
@@ -50,6 +51,7 @@ var supportedDecisionPluginTypes = []string{
 	DecisionPluginRouterReplay,
 	DecisionPluginSemanticCache,
 	DecisionPluginSystemPrompt,
+	DecisionPluginToolSelection,
 	DecisionPluginTools,
 }
 

--- a/src/semantic-router/pkg/config/tool_selection_plugin.go
+++ b/src/semantic-router/pkg/config/tool_selection_plugin.go
@@ -1,0 +1,37 @@
+package config
+
+const (
+	ToolSelectionModeAdd    = "add"
+	ToolSelectionModeFilter = "filter"
+)
+
+// ToolSelectionPluginConfig configures semantic tool add/filter on a matched decision.
+// This is separate from the legacy "tools" plugin (passthrough/filtered/none routing).
+type ToolSelectionPluginConfig struct {
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Mode    string `json:"mode,omitempty" yaml:"mode,omitempty"`
+
+	// --- Add mode (database retrieval) ---
+	ToolsDBPath         string                       `json:"tools_db_path,omitempty" yaml:"tools_db_path,omitempty"`
+	TopK                int                          `json:"top_k,omitempty" yaml:"top_k,omitempty"`
+	SimilarityThreshold *float32                     `json:"similarity_threshold,omitempty" yaml:"similarity_threshold,omitempty"`
+	AdvancedFiltering   *AdvancedToolFilteringConfig `json:"advanced_filtering,omitempty" yaml:"advanced_filtering,omitempty"`
+	Strategy            string                       `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	FallbackToEmpty     *bool                        `json:"fallback_to_empty,omitempty" yaml:"fallback_to_empty,omitempty"`
+
+	// --- Filter mode (subset of request.tools) ---
+	RelevanceThreshold *float32 `json:"relevance_threshold,omitempty" yaml:"relevance_threshold,omitempty"`
+	PreserveCount      int      `json:"preserve_count,omitempty" yaml:"preserve_count,omitempty"`
+}
+
+func (d *Decision) GetToolSelectionConfig() *ToolSelectionPluginConfig {
+	result := &ToolSelectionPluginConfig{}
+	return decodeDecisionPlugin(d, DecisionPluginToolSelection, result)
+}
+
+func (c *ToolSelectionPluginConfig) EffectiveStrategy() string {
+	if c == nil || c.Strategy == "" {
+		return ToolsStrategyDefault
+	}
+	return c.Strategy
+}

--- a/src/semantic-router/pkg/config/tool_selection_plugin_validation.go
+++ b/src/semantic-router/pkg/config/tool_selection_plugin_validation.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (c *ToolSelectionPluginConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	if !c.Enabled {
+		return nil
+	}
+	mode, err := normalizeToolSelectionMode(c.Mode)
+	if err != nil {
+		return err
+	}
+	if err := c.validateModeConstraints(mode); err != nil {
+		return err
+	}
+	return c.validateAdvancedFiltering()
+}
+
+func normalizeToolSelectionMode(mode string) (string, error) {
+	trimmed := strings.TrimSpace(mode)
+	if trimmed == "" {
+		return ToolSelectionModeAdd, nil
+	}
+	switch trimmed {
+	case ToolSelectionModeAdd, ToolSelectionModeFilter:
+		return trimmed, nil
+	default:
+		return "", fmt.Errorf("tool_selection plugin: mode must be %q or %q", ToolSelectionModeAdd, ToolSelectionModeFilter)
+	}
+}
+
+func (c *ToolSelectionPluginConfig) validateModeConstraints(mode string) error {
+	if mode == ToolSelectionModeAdd {
+		if c.TopK < 0 {
+			return fmt.Errorf("tool_selection plugin: top_k must be >= 0")
+		}
+		return nil
+	}
+	if c.PreserveCount < 0 {
+		return fmt.Errorf("tool_selection plugin: preserve_count must be >= 0")
+	}
+	if c.RelevanceThreshold == nil {
+		return nil
+	}
+	if *c.RelevanceThreshold < 0 || *c.RelevanceThreshold > 1 {
+		return fmt.Errorf("tool_selection plugin: relevance_threshold must be between 0 and 1")
+	}
+	return nil
+}
+
+func (c *ToolSelectionPluginConfig) validateAdvancedFiltering() error {
+	if c.AdvancedFiltering == nil || !c.AdvancedFiltering.Enabled {
+		return nil
+	}
+	if err := validateAdvancedToolFilteringIntFields(c.AdvancedFiltering); err != nil {
+		return fmt.Errorf("tool_selection plugin: advanced_filtering: %w", err)
+	}
+	if err := validateAdvancedToolFilteringCoreFloats(c.AdvancedFiltering); err != nil {
+		return fmt.Errorf("tool_selection plugin: advanced_filtering: %w", err)
+	}
+	if err := validateToolFilteringWeightFloats(c.AdvancedFiltering.Weights); err != nil {
+		return fmt.Errorf("tool_selection plugin: advanced_filtering: %w", err)
+	}
+	if err := validateRetrievalStrategyValue(c.AdvancedFiltering.RetrievalStrategy); err != nil {
+		return fmt.Errorf("tool_selection plugin: advanced_filtering: %w", err)
+	}
+	if err := validateHybridHistorySubconfig(c.AdvancedFiltering.HybridHistory); err != nil {
+		return fmt.Errorf("tool_selection plugin: advanced_filtering: %w", err)
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/config/tool_selection_plugin_validation_test.go
+++ b/src/semantic-router/pkg/config/tool_selection_plugin_validation_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"testing"
+)
+
+func float32Ptr(v float32) *float32 { return &v }
+
+func TestToolSelectionPluginValidate_FilterModeNilThresholdOK(t *testing.T) {
+	c := ToolSelectionPluginConfig{
+		Enabled:            true,
+		Mode:               ToolSelectionModeFilter,
+		PreserveCount:      2,
+		RelevanceThreshold: nil,
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToolSelectionPluginValidate_FilterModeExplicitThreshold_OK(t *testing.T) {
+	c := ToolSelectionPluginConfig{
+		Enabled:            true,
+		Mode:               ToolSelectionModeFilter,
+		PreserveCount:      2,
+		RelevanceThreshold: float32Ptr(0.42),
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToolSelectionPluginValidate_ModeInvalid_Err(t *testing.T) {
+	c := ToolSelectionPluginConfig{Enabled: true, Mode: "bogus"}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/src/semantic-router/pkg/config/validator_decision.go
+++ b/src/semantic-router/pkg/config/validator_decision.go
@@ -112,6 +112,11 @@ func validateDecisionPluginContracts(cfg *RouterConfig) error {
 				return fmt.Errorf("decision '%s': %w", decision.Name, err)
 			}
 		}
+		if tsCfg := decision.GetToolSelectionConfig(); tsCfg != nil {
+			if err := tsCfg.Validate(); err != nil {
+				return fmt.Errorf("decision '%s': %w", decision.Name, err)
+			}
+		}
 
 		if imageGenCfg := decision.GetImageGenConfig(); imageGenCfg != nil {
 			if err := imageGenCfg.Validate(); err != nil {

--- a/src/semantic-router/pkg/dsl/compiler.go
+++ b/src/semantic-router/pkg/dsl/compiler.go
@@ -1129,6 +1129,35 @@ func (c *Compiler) buildDecisionPlugin(pluginType string, fields map[string]Valu
 		}
 		setPluginConfig(cfg)
 
+	case "tool_selection":
+		dp.Type = "tool_selection"
+		cfg := config.ToolSelectionPluginConfig{}
+		if v, ok := getBoolField(fields, "enabled"); ok {
+			cfg.Enabled = v
+		}
+		if v, ok := getStringField(fields, "mode"); ok {
+			cfg.Mode = v
+		}
+		if v, ok := getIntField(fields, "top_k"); ok {
+			cfg.TopK = v
+		}
+		if v, ok := getFloat32Field(fields, "similarity_threshold"); ok {
+			cfg.SimilarityThreshold = &v
+		}
+		if v, ok := getStringField(fields, "tools_db_path"); ok {
+			cfg.ToolsDBPath = v
+		}
+		if v, ok := getFloat32Field(fields, "relevance_threshold"); ok {
+			cfg.RelevanceThreshold = &v
+		}
+		if v, ok := getIntField(fields, "preserve_count"); ok {
+			cfg.PreserveCount = v
+		}
+		if v, ok := getStringField(fields, "strategy"); ok {
+			cfg.Strategy = v
+		}
+		setPluginConfig(cfg)
+
 	case "tools":
 		cfg := config.ToolsPluginConfig{}
 		if v, ok := getBoolField(fields, "enabled"); ok {

--- a/src/semantic-router/pkg/dsl/decompiler.go
+++ b/src/semantic-router/pkg/dsl/decompiler.go
@@ -728,6 +728,38 @@ func decompilePluginConfig(p *config.DecisionPlugin) string {
 		if cfg.StripUnknown {
 			fmt.Fprintf(&sb, "    strip_unknown: true\n")
 		}
+	case "tool_selection":
+		cfg, ok := decodePluginConfig[config.ToolSelectionPluginConfig](p)
+		if !ok {
+			break
+		}
+		if cfg.Enabled {
+			fmt.Fprintf(&sb, "    enabled: true\n")
+		}
+		if cfg.Mode != "" {
+			fmt.Fprintf(&sb, "    mode: %q\n", cfg.Mode)
+		}
+		if cfg.ToolsDBPath != "" {
+			fmt.Fprintf(&sb, "    tools_db_path: %q\n", cfg.ToolsDBPath)
+		}
+		if cfg.TopK != 0 {
+			fmt.Fprintf(&sb, "    top_k: %d\n", cfg.TopK)
+		}
+		if cfg.SimilarityThreshold != nil {
+			fmt.Fprintf(&sb, "    similarity_threshold: %v\n", *cfg.SimilarityThreshold)
+		}
+		if cfg.Strategy != "" {
+			fmt.Fprintf(&sb, "    strategy: %q\n", cfg.Strategy)
+		}
+		if cfg.FallbackToEmpty != nil && *cfg.FallbackToEmpty {
+			fmt.Fprintf(&sb, "    fallback_to_empty: true\n")
+		}
+		if cfg.RelevanceThreshold != nil {
+			fmt.Fprintf(&sb, "    relevance_threshold: %v\n", *cfg.RelevanceThreshold)
+		}
+		if cfg.PreserveCount != 0 {
+			fmt.Fprintf(&sb, "    preserve_count: %d\n", cfg.PreserveCount)
+		}
 	case "tools":
 		cfg, ok := decodePluginConfig[config.ToolsPluginConfig](p)
 		if !ok {
@@ -1954,6 +1986,35 @@ func pluginConfigToFields(p *config.DecisionPlugin) map[string]Value {
 		}
 		if cfg.StripUnknown {
 			fields["strip_unknown"] = BoolValue{V: true}
+		}
+	case "tool_selection":
+		cfg, ok := decodePluginConfig[config.ToolSelectionPluginConfig](p)
+		if !ok {
+			return fields
+		}
+		if cfg.Enabled {
+			fields["enabled"] = BoolValue{V: true}
+		}
+		if cfg.Mode != "" {
+			fields["mode"] = StringValue{V: cfg.Mode}
+		}
+		if cfg.ToolsDBPath != "" {
+			fields["tools_db_path"] = StringValue{V: cfg.ToolsDBPath}
+		}
+		if cfg.TopK != 0 {
+			fields["top_k"] = IntValue{V: cfg.TopK}
+		}
+		if cfg.SimilarityThreshold != nil {
+			fields["similarity_threshold"] = FloatValue{V: float64(*cfg.SimilarityThreshold)}
+		}
+		if cfg.Strategy != "" {
+			fields["strategy"] = StringValue{V: cfg.Strategy}
+		}
+		if cfg.RelevanceThreshold != nil {
+			fields["relevance_threshold"] = FloatValue{V: float64(*cfg.RelevanceThreshold)}
+		}
+		if cfg.PreserveCount != 0 {
+			fields["preserve_count"] = IntValue{V: cfg.PreserveCount}
 		}
 	case "tools":
 		cfg, ok := decodePluginConfig[config.ToolsPluginConfig](p)

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -41,9 +41,15 @@ func (r *OpenAIRouter) applySelectedTools(
 	confidence float32,
 	latency time.Duration,
 	classificationText string,
+	fallbackToEmptyOverride *bool,
 ) error {
+	fallbackEmpty := r.Config.Tools.FallbackToEmpty
+	if fallbackToEmptyOverride != nil {
+		fallbackEmpty = *fallbackToEmptyOverride
+	}
+
 	if len(selectedTools) == 0 {
-		if r.Config.Tools.FallbackToEmpty {
+		if fallbackEmpty {
 			logging.Infof("No suitable tools found, falling back to no tools")
 			openAIRequest.Tools = nil
 		} else {
@@ -117,10 +123,10 @@ func (r *OpenAIRouter) runSemanticToolSelection(
 	metrics.RecordToolsRetrieval(strategyID, latency.Seconds())
 
 	if toolErr != nil {
-		return r.handleToolSelectionError(openAIRequest, response, ctx, toolErr)
+		return r.handleToolSelectionError(openAIRequest, response, ctx, toolErr, r.Config.Tools.FallbackToEmpty)
 	}
 
-	if err := r.applySelectedTools(openAIRequest, selectedTools, strategyID, confidence, latency, classificationText); err != nil {
+	if err := r.applySelectedTools(openAIRequest, selectedTools, strategyID, confidence, latency, classificationText, nil); err != nil {
 		return err
 	}
 	return r.updateRequestWithTools(openAIRequest, response, ctx)
@@ -131,8 +137,9 @@ func (r *OpenAIRouter) handleToolSelectionError(
 	response **ext_proc.ProcessingResponse,
 	ctx *RequestContext,
 	toolErr error,
+	fallbackToEmpty bool,
 ) error {
-	if r.Config.Tools.FallbackToEmpty {
+	if fallbackToEmpty {
 		logging.Warnf("Tool selection failed, falling back to no tools: %v", toolErr)
 		openAIRequest.Tools = nil
 		return r.updateRequestWithTools(openAIRequest, response, ctx)
@@ -149,7 +156,21 @@ func (r *OpenAIRouter) handleToolSelection(
 	response **ext_proc.ProcessingResponse,
 	ctx *RequestContext,
 ) error {
+	if ctx.VSRSelectedDecision == nil {
+		return nil
+	}
+
+	tsPlugin := ctx.VSRSelectedDecision.GetToolSelectionConfig()
 	toolsCfg := resolveDecisionToolsConfig(ctx)
+
+	handled, err := r.handleToolSelectionDecisionPlugin(openAIRequest, userContent, nonUserMessages, response, ctx, tsPlugin, toolsCfg)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+
 	if toolsCfg == nil || !toolsCfg.Enabled {
 		return nil
 	}
@@ -166,21 +187,8 @@ func (r *OpenAIRouter) handleToolSelection(
 		return r.updateRequestWithTools(openAIRequest, response, ctx)
 	}
 
-	// Build classification text and a compact history summary for retrieval.
-	var classificationText string
-	if len(userContent) > 0 {
-		classificationText = userContent
-	} else if len(nonUserMessages) > 0 {
-		classificationText = strings.Join(nonUserMessages, " ")
-	}
-	var historySummary string
-	if len(nonUserMessages) > 0 {
-		historySummary = strings.Join(nonUserMessages, " ")
-	}
-	if historySummary == classificationText {
-		historySummary = ""
-	}
-	if classificationText == "" {
+	classificationText, historySummary, ok := buildToolClassificationText(userContent, nonUserMessages)
+	if !ok {
 		logging.Infof("No content available for tool classification")
 		return nil
 	}
@@ -193,10 +201,79 @@ func (r *OpenAIRouter) handleToolSelection(
 	return r.runSemanticToolSelection(openAIRequest, classificationText, historySummary, response, ctx, toolsCfg)
 }
 
+func (r *OpenAIRouter) handleToolSelectionDecisionPlugin(
+	openAIRequest *openai.ChatCompletionNewParams,
+	userContent string,
+	nonUserMessages []string,
+	response **ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+	tsPlugin *config.ToolSelectionPluginConfig,
+	toolsCfg *config.ToolsPluginConfig,
+) (bool, error) {
+	if tsPlugin == nil || !tsPlugin.Enabled {
+		return false, nil
+	}
+	earlyCfg := toolsCfg
+	if earlyCfg == nil || !earlyCfg.Enabled {
+		earlyCfg = &config.ToolsPluginConfig{Enabled: true, Mode: config.ToolsPluginModePassthrough}
+	}
+
+	shouldContinue, err := r.handleEarlyToolModes(openAIRequest, response, ctx, earlyCfg)
+	if err != nil {
+		return false, err
+	}
+	if !shouldContinue {
+		return true, nil
+	}
+
+	classificationText, historySummary, ok := buildToolClassificationText(userContent, nonUserMessages)
+	if !ok {
+		logging.Infof("No content available for tool classification")
+		return true, nil
+	}
+
+	mode := strings.TrimSpace(tsPlugin.Mode)
+	if mode == "" {
+		mode = config.ToolSelectionModeAdd
+	}
+
+	switch mode {
+	case config.ToolSelectionModeFilter:
+		return true, r.runToolSelectionPluginFilter(openAIRequest, classificationText, response, ctx, tsPlugin)
+	case config.ToolSelectionModeAdd:
+		return true, r.runToolSelectionPluginAdd(openAIRequest, classificationText, historySummary, response, ctx, tsPlugin, toolsCfg)
+	default:
+		return false, fmt.Errorf("tool_selection plugin: unsupported mode %q", mode)
+	}
+}
+
+func (r *OpenAIRouter) retrievalViaEmbeddingDatabase(strategyID string, in tools.RetrievalInput, db *tools.ToolsDatabase) (tools.RetrievalResult, error) {
+	pool := in.EffectivePoolSize()
+	results, err := db.FindSimilarToolsWithScoresMinSimilarity(in.Query, pool, in.MinSimilarity)
+	if err != nil {
+		return tools.RetrievalResult{StrategyID: strategyID}, err
+	}
+	confidence := float32(0)
+	if len(results) > 0 {
+		confidence = results[0].Similarity
+	}
+	return tools.RetrievalResult{
+		Tools:      results,
+		Confidence: confidence,
+		StrategyID: strategyID,
+	}, nil
+}
+
 // executeRetrieval resolves the retriever for strategyID from the registry and
 // runs it with in. If the registry is nil or the strategy is not found, it falls
 // back to ToolsDatabase directly and marks the returned StrategyID with "-fallback".
-func (r *OpenAIRouter) executeRetrieval(ctx context.Context, strategyID string, in tools.RetrievalInput) (tools.RetrievalResult, error) {
+//
+// scopedEmbDB, when non-nil, forces retrieval against that database via embedding
+// similarity (registry strategies are skipped).
+func (r *OpenAIRouter) executeRetrieval(ctx context.Context, strategyID string, in tools.RetrievalInput, scopedEmbDB *tools.ToolsDatabase) (tools.RetrievalResult, error) {
+	if scopedEmbDB != nil {
+		return r.retrievalViaEmbeddingDatabase(strategyID+"-scoped", in, scopedEmbDB)
+	}
 	if r.ToolsRegistry != nil {
 		if retriever, ok := r.ToolsRegistry.Get(strategyID); ok {
 			return retriever.Retrieve(ctx, in)
@@ -216,7 +293,7 @@ func (r *OpenAIRouter) executeRetrieval(ctx context.Context, strategyID string, 
 	}
 
 	pool := in.EffectivePoolSize()
-	results, err := r.ToolsDatabase.FindSimilarToolsWithScores(in.Query, pool)
+	results, err := r.ToolsDatabase.FindSimilarToolsWithScoresMinSimilarity(in.Query, pool, in.MinSimilarity)
 	if err != nil {
 		return tools.RetrievalResult{StrategyID: strategyID + "-fallback"}, err
 	}
@@ -245,16 +322,30 @@ func (r *OpenAIRouter) findToolsForQuery(
 	if topK <= 0 {
 		topK = 3
 	}
-
-	strategyID := toolsCfg.EffectiveStrategy()
-	poolSize := resolveCandidatePoolSize(r.Config.Tools.AdvancedFiltering, topK)
 	advanced := mergeAdvancedToolFiltering(r.Config.Tools.AdvancedFiltering, toolsCfg)
+	return r.findToolsForQueryExt(query, historySummary, ctx, toolsCfg, topK, advanced, toolsCfg.EffectiveStrategy(), nil, r.Config.Tools.SimilarityThreshold)
+}
 
+func (r *OpenAIRouter) findToolsForQueryExt(
+	query, historySummary string,
+	ctx *RequestContext,
+	toolsCfg *config.ToolsPluginConfig,
+	topK int,
+	advanced *config.AdvancedToolFilteringConfig,
+	strategyID string,
+	scopedEmbDB *tools.ToolsDatabase,
+	minSimilarity *float32,
+) ([]openai.ChatCompletionToolParam, string, float32, time.Duration, error) {
+	if topK <= 0 {
+		topK = 3
+	}
+
+	poolSize := resolveCandidatePoolSize(r.Config.Tools.AdvancedFiltering, topK)
 	if advanced != nil && advanced.Enabled {
 		poolSize = resolveCandidatePoolSize(advanced, topK)
 	}
 
-	retrievalIn := newToolRetrievalInput(query, historySummary, topK, poolSize, ctx)
+	retrievalIn := newToolRetrievalInput(query, historySummary, topK, poolSize, ctx, minSimilarity)
 
 	retrievalCtx := context.Background()
 	if ctx != nil && ctx.TraceContext != nil {
@@ -262,7 +353,7 @@ func (r *OpenAIRouter) findToolsForQuery(
 	}
 
 	start := time.Now()
-	retrieved, err := r.executeRetrieval(retrievalCtx, strategyID, retrievalIn)
+	retrieved, err := r.executeRetrieval(retrievalCtx, strategyID, retrievalIn, scopedEmbDB)
 	latency := time.Since(start)
 
 	if err != nil {
@@ -329,12 +420,14 @@ func newToolRetrievalInput(
 	query, historySummary string,
 	topK, poolSize int,
 	ctx *RequestContext,
+	minSimilarity *float32,
 ) tools.RetrievalInput {
 	in := tools.RetrievalInput{
 		Query:          query,
 		HistorySummary: historySummary,
 		TopK:           topK,
 		PoolSize:       poolSize,
+		MinSimilarity:  minSimilarity,
 	}
 	if ctx == nil {
 		return in

--- a/src/semantic-router/pkg/extproc/req_tool_selection_filter_embed.go
+++ b/src/semantic-router/pkg/extproc/req_tool_selection_filter_embed.go
@@ -1,0 +1,155 @@
+package extproc
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+)
+
+// toolEmbeddingText builds a phrase for embedding from an OpenAI-format tool (name + optional description).
+func toolEmbeddingText(t openai.ChatCompletionToolParam) string {
+	name := strings.TrimSpace(t.Function.Name)
+	var parts []string
+	if name != "" {
+		parts = append(parts, name)
+	}
+	if !param.IsOmitted(t.Function.Description) {
+		if d := strings.TrimSpace(t.Function.Description.Value); d != "" {
+			parts = append(parts, d)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+func dotProductFloat32(a, b []float32) float32 {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	var s float32
+	for i := 0; i < n; i++ {
+		s += a[i] * b[i]
+	}
+	return s
+}
+
+type scoredRequestTool struct {
+	tool  openai.ChatCompletionToolParam
+	score float32
+	order int
+}
+
+// filterRequestToolsAgainstQuerySemantic scores each OpenAI-format tool definition against queryText
+// using embedding dot-products (same pipeline as ToolDatabase retrieval).
+func filterRequestToolsAgainstQuerySemantic(
+	queryText string,
+	requestTools []openai.ChatCompletionToolParam,
+	modelType string,
+	targetDim int,
+	relevanceThreshold float32,
+	preserveCount int,
+) ([]openai.ChatCompletionToolParam, float32, error) {
+	if len(requestTools) == 0 {
+		return nil, 0, nil
+	}
+	trimmedQuery := strings.TrimSpace(queryText)
+	if trimmedQuery == "" {
+		out := make([]openai.ChatCompletionToolParam, len(requestTools))
+		copy(out, requestTools)
+		return out, 0, nil
+	}
+	qOut, err := candle_binding.GetEmbeddingWithModelType(trimmedQuery, modelType, targetDim)
+	if err != nil {
+		return nil, 0, fmt.Errorf("tool_selection filter: query embedding: %w", err)
+	}
+
+	scored, err := scoreToolsBySemanticSimilarity(requestTools, qOut.Embedding, modelType, targetDim)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].score == scored[j].score {
+			return scored[i].order < scored[j].order
+		}
+		return scored[i].score > scored[j].score
+	})
+	maxScore := float32(0)
+	if len(scored) > 0 {
+		maxScore = scored[0].score
+	}
+
+	kept := keepByRelevanceThreshold(scored, relevanceThreshold)
+
+	if preserveCount <= 0 || len(kept) >= preserveCount {
+		return kept, maxScore, nil
+	}
+
+	kept = preserveTopScoredTools(scored, kept, preserveCount)
+	return kept, maxScore, nil
+}
+
+func scoreToolsBySemanticSimilarity(
+	requestTools []openai.ChatCompletionToolParam,
+	queryEmbedding []float32,
+	modelType string,
+	targetDim int,
+) ([]scoredRequestTool, error) {
+	scored := make([]scoredRequestTool, 0, len(requestTools))
+	for i, tool := range requestTools {
+		embeddingText := toolEmbeddingText(tool)
+		if embeddingText == "" {
+			embeddingText = tool.Function.Name
+		}
+		tOut, err := candle_binding.GetEmbeddingWithModelType(embeddingText, modelType, targetDim)
+		if err != nil {
+			return nil, fmt.Errorf("tool_selection filter: embedding tool %q: %w", tool.Function.Name, err)
+		}
+		scored = append(scored, scoredRequestTool{
+			tool:  tool,
+			score: dotProductFloat32(queryEmbedding, tOut.Embedding),
+			order: i,
+		})
+	}
+	return scored, nil
+}
+
+func keepByRelevanceThreshold(scored []scoredRequestTool, relevanceThreshold float32) []openai.ChatCompletionToolParam {
+	kept := make([]openai.ChatCompletionToolParam, 0, len(scored))
+	for _, s := range scored {
+		if s.score >= relevanceThreshold {
+			kept = append(kept, s.tool)
+		}
+	}
+	return kept
+}
+
+func preserveTopScoredTools(
+	scored []scoredRequestTool,
+	kept []openai.ChatCompletionToolParam,
+	preserveCount int,
+) []openai.ChatCompletionToolParam {
+	needed := preserveCount - len(kept)
+	seen := make(map[string]struct{}, len(kept))
+	for _, t := range kept {
+		seen[strings.ToLower(strings.TrimSpace(t.Function.Name))] = struct{}{}
+	}
+	for _, s := range scored {
+		if needed == 0 {
+			break
+		}
+		key := strings.ToLower(strings.TrimSpace(s.tool.Function.Name))
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		kept = append(kept, s.tool)
+		needed--
+	}
+	return kept
+}

--- a/src/semantic-router/pkg/extproc/req_tool_selection_filter_embed_test.go
+++ b/src/semantic-router/pkg/extproc/req_tool_selection_filter_embed_test.go
@@ -1,0 +1,21 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+)
+
+func TestToolEmbeddingText_IncludesDescription(t *testing.T) {
+	tp := openai.ChatCompletionToolParam{
+		Type: "function",
+		Function: openai.FunctionDefinitionParam{
+			Name:        "alpha",
+			Description: param.NewOpt("desc here"),
+		},
+	}
+	if got := toolEmbeddingText(tp); got != "alpha desc here" {
+		t.Fatalf("unexpected text: %q", got)
+	}
+}

--- a/src/semantic-router/pkg/extproc/req_tool_selection_plugin.go
+++ b/src/semantic-router/pkg/extproc/req_tool_selection_plugin.go
@@ -1,0 +1,150 @@
+package extproc
+
+import (
+	"strings"
+	"time"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+)
+
+func buildToolClassificationText(userContent string, nonUserMessages []string) (classificationText string, historySummary string, ok bool) {
+	if len(userContent) > 0 {
+		classificationText = userContent
+	} else if len(nonUserMessages) > 0 {
+		classificationText = strings.Join(nonUserMessages, " ")
+	}
+	if len(nonUserMessages) > 0 {
+		historySummary = strings.Join(nonUserMessages, " ")
+	}
+	if historySummary == classificationText {
+		historySummary = ""
+	}
+	if strings.TrimSpace(classificationText) == "" {
+		return "", "", false
+	}
+	return classificationText, historySummary, true
+}
+
+func (r *OpenAIRouter) effectiveToolSelectionFallback(plugin *config.ToolSelectionPluginConfig) bool {
+	if plugin != nil && plugin.FallbackToEmpty != nil {
+		return *plugin.FallbackToEmpty
+	}
+	return r.Config.Tools.FallbackToEmpty
+}
+
+func mergeToolSelectionAdvanced(plugin *config.ToolSelectionPluginConfig, global *config.AdvancedToolFilteringConfig, toolsCfg *config.ToolsPluginConfig) *config.AdvancedToolFilteringConfig {
+	base := global
+	if plugin != nil && plugin.AdvancedFiltering != nil {
+		base = plugin.AdvancedFiltering
+	}
+	return mergeAdvancedToolFiltering(base, toolsCfg)
+}
+
+func effectivePluginToolTopK(plugin *config.ToolSelectionPluginConfig, global int) int {
+	if plugin != nil && plugin.TopK > 0 {
+		return plugin.TopK
+	}
+	if global > 0 {
+		return global
+	}
+	return 3
+}
+
+func (r *OpenAIRouter) runToolSelectionPluginAdd(
+	openAIRequest *openai.ChatCompletionNewParams,
+	classificationText, historySummary string,
+	response **ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+	ts *config.ToolSelectionPluginConfig,
+	toolsCfg *config.ToolsPluginConfig,
+) error {
+	db, forceDirectEmbedding, err := r.toolDatabaseForSelectionPlugin(ts)
+	if err != nil {
+		return r.handleToolSelectionError(openAIRequest, response, ctx, err, r.effectiveToolSelectionFallback(ts))
+	}
+	if db == nil || !db.IsEnabled() {
+		logging.Infof("[tool_selection] add mode skipped: database disabled or unloaded")
+		return nil
+	}
+
+	topK := effectivePluginToolTopK(ts, r.Config.Tools.TopK)
+	strategyID := ts.EffectiveStrategy()
+	minSim := ts.SimilarityThreshold
+	if minSim == nil {
+		minSim = r.Config.Tools.SimilarityThreshold
+	}
+	advanced := mergeToolSelectionAdvanced(ts, r.Config.Tools.AdvancedFiltering, toolsCfg)
+
+	var scopedDB *tools.ToolsDatabase
+	if forceDirectEmbedding {
+		scopedDB = db
+	}
+
+	selectedTools, strategyOut, confidence, latency, toolErr := r.findToolsForQueryExt(
+		classificationText,
+		historySummary,
+		ctx,
+		toolsCfg,
+		topK,
+		advanced,
+		strategyID,
+		scopedDB,
+		minSim,
+	)
+
+	emitToolObservability(response, strategyOut, confidence, latency)
+	metrics.RecordToolsRetrieval(strategyOut, latency.Seconds())
+
+	if toolErr != nil {
+		return r.handleToolSelectionError(openAIRequest, response, ctx, toolErr, r.effectiveToolSelectionFallback(ts))
+	}
+
+	if err := r.applySelectedTools(openAIRequest, selectedTools, strategyOut, confidence, latency, classificationText, ts.FallbackToEmpty); err != nil {
+		return err
+	}
+	return r.updateRequestWithTools(openAIRequest, response, ctx)
+}
+
+func (r *OpenAIRouter) runToolSelectionPluginFilter(
+	openAIRequest *openai.ChatCompletionNewParams,
+	classificationText string,
+	response **ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+	ts *config.ToolSelectionPluginConfig,
+) error {
+	em := r.Config.EmbeddingModels
+	thresh := float32(0.25)
+	if ts.RelevanceThreshold != nil {
+		thresh = *ts.RelevanceThreshold
+	}
+
+	start := time.Now()
+	filtered, confidence, ferr := filterRequestToolsAgainstQuerySemantic(
+		classificationText,
+		openAIRequest.Tools,
+		em.EmbeddingConfig.ModelType,
+		em.EmbeddingConfig.TargetDimension,
+		thresh,
+		ts.PreserveCount,
+	)
+	latency := time.Since(start)
+
+	strategyLabel := config.ToolSelectionModeFilter
+	emitToolObservability(response, strategyLabel, confidence, latency)
+	metrics.RecordToolsRetrieval(strategyLabel, latency.Seconds())
+
+	if ferr != nil {
+		return r.handleToolSelectionError(openAIRequest, response, ctx, ferr, r.effectiveToolSelectionFallback(ts))
+	}
+
+	if err := r.applySelectedTools(openAIRequest, filtered, strategyLabel, confidence, latency, classificationText, ts.FallbackToEmpty); err != nil {
+		return err
+	}
+	return r.updateRequestWithTools(openAIRequest, response, ctx)
+}

--- a/src/semantic-router/pkg/extproc/router.go
+++ b/src/semantic-router/pkg/extproc/router.go
@@ -2,6 +2,7 @@ package extproc
 
 import (
 	"encoding/json"
+	"sync"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -31,6 +32,8 @@ type OpenAIRouter struct {
 	Cache                 cache.CacheBackend
 	ToolsDatabase         *tools.ToolsDatabase
 	ToolsRegistry         *tools.Registry // retriever strategy registry
+	toolSelectionDBMu     sync.Mutex
+	toolSelectionDBByPath map[string]*tools.ToolsDatabase
 	ResponseAPIFilter     *ResponseAPIFilter
 	ReplayRecorder        *routerreplay.Recorder
 	ReplayStoreShared     bool

--- a/src/semantic-router/pkg/extproc/tool_db_cache.go
+++ b/src/semantic-router/pkg/extproc/tool_db_cache.go
@@ -1,0 +1,90 @@
+package extproc
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+)
+
+func (r *OpenAIRouter) resolveToolDatabasePath(path string) string {
+	if r == nil || r.Config == nil {
+		return strings.TrimSpace(path)
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = strings.TrimSpace(r.Config.Tools.ToolsDBPath)
+	}
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	base := strings.TrimSpace(r.Config.ConfigBaseDir)
+	if base == "" {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(base, path))
+}
+
+func (r *OpenAIRouter) getOrLoadToolDatabaseForSelection(absPath string) (*tools.ToolsDatabase, error) {
+	if r == nil || r.Config == nil {
+		return nil, fmt.Errorf("tool_selection: router configuration missing")
+	}
+	if absPath == "" {
+		return nil, fmt.Errorf("tool_selection: tools database path resolved empty")
+	}
+
+	primaryAbs := r.resolveToolDatabasePath(r.Config.Tools.ToolsDBPath)
+	if r.ToolsDatabase != nil && absPath == primaryAbs && r.ToolsDatabase.IsEnabled() {
+		return r.ToolsDatabase, nil
+	}
+
+	r.toolSelectionDBMu.Lock()
+	defer r.toolSelectionDBMu.Unlock()
+	if r.toolSelectionDBByPath == nil {
+		r.toolSelectionDBByPath = make(map[string]*tools.ToolsDatabase)
+	}
+	if db, ok := r.toolSelectionDBByPath[absPath]; ok && db != nil {
+		return db, nil
+	}
+
+	emb := r.Config.EmbeddingModels
+	db := tools.NewToolsDatabase(tools.ToolsDatabaseOptions{
+		Enabled:             true,
+		SimilarityThreshold: 0,
+		ModelType:           emb.EmbeddingConfig.ModelType,
+		TargetDimension:     emb.EmbeddingConfig.TargetDimension,
+	})
+	if err := db.LoadToolsFromFile(absPath); err != nil {
+		return nil, err
+	}
+	r.toolSelectionDBByPath[absPath] = db
+	logging.Infof("tool_selection: loaded tools database %q (%d tools)", absPath, db.GetToolCount())
+	return db, nil
+}
+
+func (r *OpenAIRouter) toolDatabaseForSelectionPlugin(sel *config.ToolSelectionPluginConfig) (*tools.ToolsDatabase, bool, error) {
+	if r == nil || sel == nil {
+		return nil, false, fmt.Errorf("tool_selection: invalid selection config")
+	}
+	resolved := r.resolveToolDatabasePath(sel.ToolsDBPath)
+	if resolved == "" {
+		return nil, false, fmt.Errorf("tool_selection add mode: tools_db_path and global tools.tools_db_path are empty")
+	}
+
+	primaryAbs := r.resolveToolDatabasePath(r.Config.Tools.ToolsDBPath)
+	if resolved == primaryAbs && r.ToolsDatabase != nil && r.ToolsDatabase.IsEnabled() {
+		return r.ToolsDatabase, false, nil
+	}
+
+	db, err := r.getOrLoadToolDatabaseForSelection(resolved)
+	if err != nil {
+		return nil, false, err
+	}
+	return db, true, nil
+}

--- a/src/semantic-router/pkg/k8s/converter.go
+++ b/src/semantic-router/pkg/k8s/converter.go
@@ -361,12 +361,24 @@ var pluginConfigurationValidators = map[string]func([]byte) error{
 	"system_prompt":   validateSystemPromptPluginConfig,
 	"header_mutation": validateHeaderMutationPluginConfig,
 	"router_replay":   validateRouterReplayPluginConfig,
+	"tool_selection":  validateToolSelectionPluginConfigRaw,
 }
 
 func decodePluginConfiguration(rawConfig []byte, target any) error {
 	decoder := json.NewDecoder(bytes.NewReader(rawConfig))
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(target)
+}
+
+func validateToolSelectionPluginConfigRaw(rawConfig []byte) error {
+	var cfg config.ToolSelectionPluginConfig
+	if err := decodePluginConfiguration(rawConfig, &cfg); err != nil {
+		return fmt.Errorf("failed to unmarshal tool_selection config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validateSemanticCachePluginConfig(rawConfig []byte) error {

--- a/src/semantic-router/pkg/tools/embedding_retriever.go
+++ b/src/semantic-router/pkg/tools/embedding_retriever.go
@@ -27,7 +27,7 @@ func NewEmbeddingRetriever(db *ToolsDatabase) *EmbeddingRetriever {
 // highest-ranked tool, or 0 when no tools are returned.
 func (e *EmbeddingRetriever) Retrieve(_ context.Context, in RetrievalInput) (RetrievalResult, error) {
 	pool := in.EffectivePoolSize()
-	candidates, err := e.db.FindSimilarToolsWithScores(in.Query, pool)
+	candidates, err := e.db.FindSimilarToolsWithScoresMinSimilarity(in.Query, pool, in.MinSimilarity)
 	if err != nil {
 		return RetrievalResult{StrategyID: StrategyDefault}, err
 	}

--- a/src/semantic-router/pkg/tools/retrieval_input.go
+++ b/src/semantic-router/pkg/tools/retrieval_input.go
@@ -21,6 +21,9 @@ type RetrievalInput struct {
 	TopK int
 	// PoolSize is how many candidates to pull from the index (before advanced filters).
 	PoolSize int
+	// MinSimilarity optionally overrides the ToolsDatabase similarity floor for this retrieval.
+	// When nil the database configured threshold is used.
+	MinSimilarity *float32
 }
 
 // EffectivePoolSize returns PoolSize, or a conservative default when unset

--- a/src/semantic-router/pkg/tools/tools.go
+++ b/src/semantic-router/pkg/tools/tools.go
@@ -201,6 +201,13 @@ func (db *ToolsDatabase) AddTool(tool openai.ChatCompletionToolParam, descriptio
 	return nil
 }
 
+func (db *ToolsDatabase) similarityFloor(minOverride *float32) float32 {
+	if minOverride != nil {
+		return *minOverride
+	}
+	return db.similarityThreshold
+}
+
 // FindSimilarTools finds the most similar tools based on the query
 func (db *ToolsDatabase) FindSimilarTools(query string, topK int) ([]openai.ChatCompletionToolParam, error) {
 	results, err := db.FindSimilarToolsWithScores(query, topK)
@@ -218,6 +225,12 @@ func (db *ToolsDatabase) FindSimilarTools(query string, topK int) ([]openai.Chat
 
 // FindSimilarToolsWithScores finds the most similar tools based on the query and returns scores.
 func (db *ToolsDatabase) FindSimilarToolsWithScores(query string, topK int) ([]ToolSimilarity, error) {
+	return db.FindSimilarToolsWithScoresMinSimilarity(query, topK, nil)
+}
+
+// FindSimilarToolsWithScoresMinSimilarity is like FindSimilarToolsWithScores but allows overriding
+// the minimum similarity cutoff for this query (embedding dot-product scores).
+func (db *ToolsDatabase) FindSimilarToolsWithScoresMinSimilarity(query string, topK int, minSimilarity *float32) ([]ToolSimilarity, error) {
 	if !db.enabled {
 		return []ToolSimilarity{}, nil
 	}
@@ -241,12 +254,11 @@ func (db *ToolsDatabase) FindSimilarToolsWithScores(query string, topK int) ([]T
 			dotProduct += queryEmbedding[i] * entry.Embedding[i]
 		}
 
-		// Debug logging to see similarity scores
+		floor := db.similarityFloor(minSimilarity)
 		logging.Debugf("Tool '%s' similarity score: %.4f (threshold: %.4f)",
-			entry.Tool.Function.Name, dotProduct, db.similarityThreshold)
+			entry.Tool.Function.Name, dotProduct, floor)
 
-		// Only consider if above threshold
-		if dotProduct >= db.similarityThreshold {
+		if dotProduct >= floor {
 			results = append(results, ToolSimilarity{
 				Entry:      entry,
 				Similarity: dotProduct,

--- a/website/docs/tutorials/plugin/tool-selection.md
+++ b/website/docs/tutorials/plugin/tool-selection.md
@@ -1,0 +1,52 @@
+# Tool Selection
+
+## Overview
+
+`tool_selection` is a decision plugin that controls how tools are chosen for a matched route.  
+It supports two modes:
+
+- `add`: retrieve tools from a tools database
+- `filter`: filter tools that are already present in the incoming request
+
+It aligns to fragments under `config/plugin/tool-selection/`.
+
+## Key Advantages
+
+- Separates route decision logic from tool retrieval/filter behavior.
+- Supports both database-driven tool addition and request-tool semantic filtering.
+- Keeps compatibility with route-local tool policies while making selection behavior explicit.
+
+## What Problem Does It Solve?
+
+Different routes need different tool-selection behavior. Some routes should add tools from a curated database, while others should keep only the most relevant tools from the caller-provided set. `tool_selection` provides one plugin contract for both cases, with per-route controls such as threshold, `top_k`, and preserve behavior.
+
+## When to Use
+
+- when a decision should add the most relevant tools from `tools_db`
+- when a decision should semantically filter caller-provided `tools`
+- when per-route tool selection mode must be explicit and configurable
+
+## Configuration
+
+Use this fragment under `routing.decisions[].plugins`:
+
+```yaml
+plugin:
+  type: tool_selection
+  configuration:
+    enabled: true
+    mode: filter
+    relevance_threshold: 0.55
+    preserve_count: 2
+```
+
+For add mode:
+
+```yaml
+plugin:
+  type: tool_selection
+  configuration:
+    enabled: true
+    mode: add
+    top_k: 5
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -174,6 +174,7 @@ const sidebars: SidebarsConfig = {
                 'tutorials/plugin/image-gen',
                 'tutorials/plugin/request-params',
                 'tutorials/plugin/system-prompt',
+                'tutorials/plugin/tool-selection',
                 'tutorials/plugin/tools',
               ],
             },


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

part of https://github.com/vllm-project/semantic-router/issues/1142

## Purpose

- What does this PR change?

1.The tool selection mechanism has been refactored into the decision plugin `tool_selection`, supporting two modes: `add` (retrieving supplementary data from `tools_db`) and `filter` (semantic filtering of tools within the request).

2.Configuration contracts and validation have been improved: a new configuration structure and validation logic for `tool_selection` have been added, and it has been integrated into the decision plugin's parsing/routing plane directory to ensure the configuration layer is usable and verifiable.

3.The runtime execution chain (extproc) has been extended: `tool_selection` is executed first during request processing, covering add/filter branches, threshold/retention quantity behavior, and fallback handling for failures.

4.Tool retrieval capabilities have been enhanced: parameters such as minimum similarity have been added to the search input and database search, supporting finer-grained control over filtering results.

- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
