### PR TITLE
config: add decision-level dynamic tool retrieval contract (#1832)

### DIFF
--- a/src/semantic-router/pkg/config/tools_plugin.go
+++ b/src/semantic-router/pkg/config/tools_plugin.go
@@ -10,6 +10,13 @@ const (
 	// ToolsStrategyDefault is the strategy name used when no explicit strategy
 	// is configured.  It resolves to the embedding-similarity retriever.
 	ToolsStrategyDefault = "default"
+
+	// Dynamic retrieval strategy names.  These are decision-scoped knobs that
+	// describe how the retriever combines semantic similarity with optional
+	// per-decision tool-call history.  Behavior is implemented in subsequent
+	// issues; this contract only fixes the configuration surface.
+	DynamicRetrievalStrategySemanticOnly  = "semantic_only"
+	DynamicRetrievalStrategyHybridHistory = "hybrid_history"
 )
 
 // ToolsPluginConfig represents per-decision tool handling.
@@ -24,6 +31,52 @@ type ToolsPluginConfig struct {
 	// When empty, EffectiveStrategy returns ToolsStrategyDefault.
 	// The value must match a name registered in the router's tools.Registry.
 	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	// DynamicRetrieval configures history-aware tool retrieval behavior.  When
+	// nil or with Enabled=false, the existing semantic-similarity retriever is
+	// used unchanged.  See issue #1832 for the contract scope; implementation
+	// of the strategies and the persisted-priors layer is staged in #1839.
+	DynamicRetrieval *DynamicRetrievalConfig `json:"dynamic_retrieval,omitempty" yaml:"dynamic_retrieval,omitempty"`
+}
+
+// DynamicRetrievalConfig is the decision-scoped contract for history-aware
+// tool retrieval.  It is intentionally additive: when nil, when Enabled is
+// false, or when omitted from configuration, the router behaves exactly as
+// before this contract was introduced.
+type DynamicRetrievalConfig struct {
+	// Enabled gates the entire dynamic retrieval path.  When false, none of
+	// the other fields are consulted and the validator skips range checks.
+	Enabled bool `json:"enabled" yaml:"enabled"`
+	// Strategy selects the retrieval algorithm.  Must be one of
+	// DynamicRetrievalStrategySemanticOnly or DynamicRetrievalStrategyHybridHistory.
+	// When empty, EffectiveStrategy returns DynamicRetrievalStrategySemanticOnly.
+	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	// HistoryWindow is the number of recent tool-call observations the
+	// retriever may inspect when Strategy is hybrid_history.  Required to be
+	// at least 1 when the hybrid strategy is active.  Ignored otherwise.
+	HistoryWindow int `json:"history_window,omitempty" yaml:"history_window,omitempty"`
+	// Weights blends the per-source signals when Strategy is hybrid_history.
+	// When nil, sensible defaults are used by the retriever (semantic 1.0,
+	// history 1.0, decision_prior 0.0, repetition_penalty 0.0).
+	Weights *DynamicRetrievalWeights `json:"weights,omitempty" yaml:"weights,omitempty"`
+	// MinHistoryConfidence is the per-decision confidence threshold below
+	// which the retriever treats history evidence as too weak to use.  Must
+	// be in [0.0, 1.0].
+	MinHistoryConfidence float64 `json:"min_history_confidence,omitempty" yaml:"min_history_confidence,omitempty"`
+	// FallbackOnLowConfidence, when true, instructs the retriever to fall
+	// back to the semantic-only ranking whenever the history evidence does
+	// not clear MinHistoryConfidence.
+	FallbackOnLowConfidence bool `json:"fallback_on_low_confidence,omitempty" yaml:"fallback_on_low_confidence,omitempty"`
+}
+
+// DynamicRetrievalWeights holds the combination weights for the hybrid
+// retriever.  Each weight is a non-negative scalar; the retriever normalizes
+// internally before applying them.  Zero weights mean the corresponding
+// signal is ignored.
+type DynamicRetrievalWeights struct {
+	Semantic          float64 `json:"semantic,omitempty" yaml:"semantic,omitempty"`
+	History           float64 `json:"history,omitempty" yaml:"history,omitempty"`
+	DecisionPrior     float64 `json:"decision_prior,omitempty" yaml:"decision_prior,omitempty"`
+	RepetitionPenalty float64 `json:"repetition_penalty,omitempty" yaml:"repetition_penalty,omitempty"`
 }
 
 // GetToolsConfig returns the tools plugin configuration.
@@ -58,4 +111,25 @@ func (c *ToolsPluginConfig) SelectionEnabled() bool {
 		return true
 	}
 	return *c.SemanticSelection
+}
+
+// DynamicRetrievalEnabled reports whether the decision opts in to dynamic
+// retrieval.  Returns false for nil receivers and for configurations where
+// the dynamic_retrieval block is unset or disabled.
+func (c *ToolsPluginConfig) DynamicRetrievalEnabled() bool {
+	if c == nil || c.DynamicRetrieval == nil {
+		return false
+	}
+	return c.DynamicRetrieval.Enabled
+}
+
+// EffectiveStrategy returns the dynamic retrieval strategy, defaulting to
+// DynamicRetrievalStrategySemanticOnly when the receiver is nil or has no
+// strategy configured.  The default mirrors the pre-#1832 behavior so that
+// callers can rely on a non-empty strategy name without nil-checking.
+func (d *DynamicRetrievalConfig) EffectiveStrategy() string {
+	if d == nil || d.Strategy == "" {
+		return DynamicRetrievalStrategySemanticOnly
+	}
+	return d.Strategy
 }

--- a/src/semantic-router/pkg/config/tools_plugin_test.go
+++ b/src/semantic-router/pkg/config/tools_plugin_test.go
@@ -1,0 +1,292 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+var _ = Describe("ToolsPluginConfig", func() {
+	Describe("Validate", registerToolsValidationSpecs)
+	Describe("DynamicRetrieval helpers", registerToolsDynamicRetrievalAccessorSpecs)
+	Describe("YAML round-trip", registerToolsDynamicRetrievalYAMLSpecs)
+})
+
+func registerToolsValidationSpecs() {
+	It("accepts an empty disabled config", func() {
+		cfg := &ToolsPluginConfig{}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("accepts a passthrough config without dynamic_retrieval", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+		}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("accepts a config with dynamic_retrieval disabled", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled: false,
+				// Other fields intentionally invalid; should be ignored when disabled.
+				Strategy:             "garbage",
+				MinHistoryConfidence: -5.0,
+			},
+		}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("accepts a semantic_only dynamic_retrieval config", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:  true,
+				Strategy: DynamicRetrievalStrategySemanticOnly,
+			},
+		}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("accepts a hybrid_history config with valid weights", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:              true,
+				Strategy:             DynamicRetrievalStrategyHybridHistory,
+				HistoryWindow:        10,
+				MinHistoryConfidence: 0.5,
+				Weights: &DynamicRetrievalWeights{
+					Semantic:          1.0,
+					History:           0.7,
+					DecisionPrior:     0.2,
+					RepetitionPenalty: 0.1,
+				},
+			},
+		}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("rejects an unknown strategy name", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:  true,
+				Strategy: "not_a_real_strategy",
+			},
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("dynamic_retrieval.strategy must be one of"))
+	})
+
+	It("rejects history_window < 1 when strategy is hybrid_history", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:       true,
+				Strategy:      DynamicRetrievalStrategyHybridHistory,
+				HistoryWindow: 0,
+			},
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("history_window must be >= 1"))
+	})
+
+	It("permits history_window=0 when strategy is semantic_only", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:       true,
+				Strategy:      DynamicRetrievalStrategySemanticOnly,
+				HistoryWindow: 0,
+			},
+		}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("rejects min_history_confidence below 0", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:              true,
+				Strategy:             DynamicRetrievalStrategySemanticOnly,
+				MinHistoryConfidence: -0.1,
+			},
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("min_history_confidence must be between 0.0 and 1.0"))
+	})
+
+	It("rejects min_history_confidence above 1", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:              true,
+				Strategy:             DynamicRetrievalStrategySemanticOnly,
+				MinHistoryConfidence: 1.5,
+			},
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("min_history_confidence must be between 0.0 and 1.0"))
+	})
+
+	It("rejects a negative weight", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:       true,
+				Strategy:      DynamicRetrievalStrategyHybridHistory,
+				HistoryWindow: 5,
+				Weights: &DynamicRetrievalWeights{
+					Semantic: -0.5,
+				},
+			},
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("weights.semantic must be non-negative"))
+	})
+
+	It("accepts zero weights as a way to disable individual signals", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:       true,
+				Strategy:      DynamicRetrievalStrategyHybridHistory,
+				HistoryWindow: 5,
+				Weights: &DynamicRetrievalWeights{
+					Semantic:          1.0,
+					History:           0.0,
+					DecisionPrior:     0.0,
+					RepetitionPenalty: 0.0,
+				},
+			},
+		}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+}
+
+func registerToolsDynamicRetrievalAccessorSpecs() {
+	It("returns false for DynamicRetrievalEnabled when receiver is nil", func() {
+		var c *ToolsPluginConfig
+		Expect(c.DynamicRetrievalEnabled()).To(BeFalse())
+	})
+
+	It("returns false for DynamicRetrievalEnabled when block is unset", func() {
+		c := &ToolsPluginConfig{Enabled: true}
+		Expect(c.DynamicRetrievalEnabled()).To(BeFalse())
+	})
+
+	It("returns false for DynamicRetrievalEnabled when block is disabled", func() {
+		c := &ToolsPluginConfig{
+			Enabled:          true,
+			DynamicRetrieval: &DynamicRetrievalConfig{Enabled: false},
+		}
+		Expect(c.DynamicRetrievalEnabled()).To(BeFalse())
+	})
+
+	It("returns true for DynamicRetrievalEnabled when block is enabled", func() {
+		c := &ToolsPluginConfig{
+			Enabled:          true,
+			DynamicRetrieval: &DynamicRetrievalConfig{Enabled: true},
+		}
+		Expect(c.DynamicRetrievalEnabled()).To(BeTrue())
+	})
+
+	It("defaults EffectiveStrategy to semantic_only for nil receiver", func() {
+		var d *DynamicRetrievalConfig
+		Expect(d.EffectiveStrategy()).To(Equal(DynamicRetrievalStrategySemanticOnly))
+	})
+
+	It("defaults EffectiveStrategy to semantic_only when Strategy is empty", func() {
+		d := &DynamicRetrievalConfig{Enabled: true}
+		Expect(d.EffectiveStrategy()).To(Equal(DynamicRetrievalStrategySemanticOnly))
+	})
+
+	It("returns the configured strategy when set", func() {
+		d := &DynamicRetrievalConfig{
+			Enabled:  true,
+			Strategy: DynamicRetrievalStrategyHybridHistory,
+		}
+		Expect(d.EffectiveStrategy()).To(Equal(DynamicRetrievalStrategyHybridHistory))
+	})
+}
+
+func registerToolsDynamicRetrievalYAMLSpecs() {
+	It("unmarshals a full dynamic_retrieval block from YAML", func() {
+		cfgYAML := `
+enabled: true
+mode: passthrough
+dynamic_retrieval:
+  enabled: true
+  strategy: hybrid_history
+  history_window: 8
+  weights:
+    semantic: 1.0
+    history: 0.7
+    decision_prior: 0.2
+    repetition_penalty: 0.1
+  min_history_confidence: 0.4
+  fallback_on_low_confidence: true
+`
+		cfg := &ToolsPluginConfig{}
+		Expect(yaml.Unmarshal([]byte(cfgYAML), cfg)).To(Succeed())
+
+		Expect(cfg.DynamicRetrievalEnabled()).To(BeTrue())
+		Expect(cfg.DynamicRetrieval.EffectiveStrategy()).To(Equal(DynamicRetrievalStrategyHybridHistory))
+		Expect(cfg.DynamicRetrieval.HistoryWindow).To(Equal(8))
+		Expect(cfg.DynamicRetrieval.MinHistoryConfidence).To(Equal(0.4))
+		Expect(cfg.DynamicRetrieval.FallbackOnLowConfidence).To(BeTrue())
+		Expect(cfg.DynamicRetrieval.Weights).NotTo(BeNil())
+		Expect(cfg.DynamicRetrieval.Weights.Semantic).To(Equal(1.0))
+		Expect(cfg.DynamicRetrieval.Weights.History).To(Equal(0.7))
+		Expect(cfg.DynamicRetrieval.Weights.DecisionPrior).To(Equal(0.2))
+		Expect(cfg.DynamicRetrieval.Weights.RepetitionPenalty).To(Equal(0.1))
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("treats an absent dynamic_retrieval block as nil", func() {
+		cfgYAML := `
+enabled: true
+mode: passthrough
+`
+		cfg := &ToolsPluginConfig{}
+		Expect(yaml.Unmarshal([]byte(cfgYAML), cfg)).To(Succeed())
+
+		Expect(cfg.DynamicRetrieval).To(BeNil())
+		Expect(cfg.DynamicRetrievalEnabled()).To(BeFalse())
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("surfaces validation errors from a bad YAML config", func() {
+		cfgYAML := `
+enabled: true
+mode: passthrough
+dynamic_retrieval:
+  enabled: true
+  strategy: bogus
+`
+		cfg := &ToolsPluginConfig{}
+		Expect(yaml.Unmarshal([]byte(cfgYAML), cfg)).To(Succeed())
+
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("dynamic_retrieval.strategy must be one of"))
+	})
+}

--- a/src/semantic-router/pkg/config/tools_plugin_test.go
+++ b/src/semantic-router/pkg/config/tools_plugin_test.go
@@ -97,8 +97,8 @@ func registerValidationAcceptSpecs() {
 func registerValidationRejectSpecs() {
 	It("an unknown strategy name", func() {
 		cfg := &ToolsPluginConfig{
-			Enabled: true,
-			Mode:    ToolsPluginModePassthrough,
+			Enabled:          true,
+			Mode:             ToolsPluginModePassthrough,
 			DynamicRetrieval: &DynamicRetrievalConfig{Enabled: true, Strategy: "not_a_real_strategy"},
 		}
 		err := cfg.Validate()

--- a/src/semantic-router/pkg/config/tools_plugin_test.go
+++ b/src/semantic-router/pkg/config/tools_plugin_test.go
@@ -7,32 +7,31 @@ import (
 )
 
 var _ = Describe("ToolsPluginConfig", func() {
-	Describe("Validate", registerToolsValidationSpecs)
+	Describe("Validate", func() {
+		Context("accepts", registerValidationAcceptSpecs)
+		Context("rejects", registerValidationRejectSpecs)
+	})
 	Describe("DynamicRetrieval helpers", registerToolsDynamicRetrievalAccessorSpecs)
 	Describe("YAML round-trip", registerToolsDynamicRetrievalYAMLSpecs)
 })
 
-func registerToolsValidationSpecs() {
-	It("accepts an empty disabled config", func() {
+func registerValidationAcceptSpecs() {
+	It("an empty disabled config", func() {
 		cfg := &ToolsPluginConfig{}
 		Expect(cfg.Validate()).To(Succeed())
 	})
 
-	It("accepts a passthrough config without dynamic_retrieval", func() {
-		cfg := &ToolsPluginConfig{
-			Enabled: true,
-			Mode:    ToolsPluginModePassthrough,
-		}
+	It("a passthrough config without dynamic_retrieval", func() {
+		cfg := &ToolsPluginConfig{Enabled: true, Mode: ToolsPluginModePassthrough}
 		Expect(cfg.Validate()).To(Succeed())
 	})
 
-	It("accepts a config with dynamic_retrieval disabled", func() {
+	It("a config with dynamic_retrieval disabled (other fields ignored)", func() {
 		cfg := &ToolsPluginConfig{
 			Enabled: true,
 			Mode:    ToolsPluginModePassthrough,
 			DynamicRetrieval: &DynamicRetrievalConfig{
-				Enabled: false,
-				// Other fields intentionally invalid; should be ignored when disabled.
+				Enabled:              false,
 				Strategy:             "garbage",
 				MinHistoryConfidence: -5.0,
 			},
@@ -40,7 +39,7 @@ func registerToolsValidationSpecs() {
 		Expect(cfg.Validate()).To(Succeed())
 	})
 
-	It("accepts a semantic_only dynamic_retrieval config", func() {
+	It("a semantic_only dynamic_retrieval config", func() {
 		cfg := &ToolsPluginConfig{
 			Enabled: true,
 			Mode:    ToolsPluginModePassthrough,
@@ -52,7 +51,7 @@ func registerToolsValidationSpecs() {
 		Expect(cfg.Validate()).To(Succeed())
 	})
 
-	It("accepts a hybrid_history config with valid weights", func() {
+	It("a hybrid_history config with valid weights", func() {
 		cfg := &ToolsPluginConfig{
 			Enabled: true,
 			Mode:    ToolsPluginModePassthrough,
@@ -61,47 +60,13 @@ func registerToolsValidationSpecs() {
 				Strategy:             DynamicRetrievalStrategyHybridHistory,
 				HistoryWindow:        10,
 				MinHistoryConfidence: 0.5,
-				Weights: &DynamicRetrievalWeights{
-					Semantic:          1.0,
-					History:           0.7,
-					DecisionPrior:     0.2,
-					RepetitionPenalty: 0.1,
-				},
+				Weights:              &DynamicRetrievalWeights{Semantic: 1.0, History: 0.7, DecisionPrior: 0.2, RepetitionPenalty: 0.1},
 			},
 		}
 		Expect(cfg.Validate()).To(Succeed())
 	})
 
-	It("rejects an unknown strategy name", func() {
-		cfg := &ToolsPluginConfig{
-			Enabled: true,
-			Mode:    ToolsPluginModePassthrough,
-			DynamicRetrieval: &DynamicRetrievalConfig{
-				Enabled:  true,
-				Strategy: "not_a_real_strategy",
-			},
-		}
-		err := cfg.Validate()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("dynamic_retrieval.strategy must be one of"))
-	})
-
-	It("rejects history_window < 1 when strategy is hybrid_history", func() {
-		cfg := &ToolsPluginConfig{
-			Enabled: true,
-			Mode:    ToolsPluginModePassthrough,
-			DynamicRetrieval: &DynamicRetrievalConfig{
-				Enabled:       true,
-				Strategy:      DynamicRetrievalStrategyHybridHistory,
-				HistoryWindow: 0,
-			},
-		}
-		err := cfg.Validate()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("history_window must be >= 1"))
-	})
-
-	It("permits history_window=0 when strategy is semantic_only", func() {
+	It("history_window=0 when strategy is semantic_only", func() {
 		cfg := &ToolsPluginConfig{
 			Enabled: true,
 			Mode:    ToolsPluginModePassthrough,
@@ -114,37 +79,7 @@ func registerToolsValidationSpecs() {
 		Expect(cfg.Validate()).To(Succeed())
 	})
 
-	It("rejects min_history_confidence below 0", func() {
-		cfg := &ToolsPluginConfig{
-			Enabled: true,
-			Mode:    ToolsPluginModePassthrough,
-			DynamicRetrieval: &DynamicRetrievalConfig{
-				Enabled:              true,
-				Strategy:             DynamicRetrievalStrategySemanticOnly,
-				MinHistoryConfidence: -0.1,
-			},
-		}
-		err := cfg.Validate()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("min_history_confidence must be between 0.0 and 1.0"))
-	})
-
-	It("rejects min_history_confidence above 1", func() {
-		cfg := &ToolsPluginConfig{
-			Enabled: true,
-			Mode:    ToolsPluginModePassthrough,
-			DynamicRetrieval: &DynamicRetrievalConfig{
-				Enabled:              true,
-				Strategy:             DynamicRetrievalStrategySemanticOnly,
-				MinHistoryConfidence: 1.5,
-			},
-		}
-		err := cfg.Validate()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("min_history_confidence must be between 0.0 and 1.0"))
-	})
-
-	It("rejects a negative weight", func() {
+	It("zero weights (disabling individual signals)", func() {
 		cfg := &ToolsPluginConfig{
 			Enabled: true,
 			Mode:    ToolsPluginModePassthrough,
@@ -152,33 +87,67 @@ func registerToolsValidationSpecs() {
 				Enabled:       true,
 				Strategy:      DynamicRetrievalStrategyHybridHistory,
 				HistoryWindow: 5,
-				Weights: &DynamicRetrievalWeights{
-					Semantic: -0.5,
+				Weights:       &DynamicRetrievalWeights{Semantic: 1.0},
+			},
+		}
+		Expect(cfg.Validate()).To(Succeed())
+	})
+}
+
+func registerValidationRejectSpecs() {
+	It("an unknown strategy name", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{Enabled: true, Strategy: "not_a_real_strategy"},
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("dynamic_retrieval.strategy must be one of"))
+	})
+
+	It("history_window < 1 when strategy is hybrid_history", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled: true, Strategy: DynamicRetrievalStrategyHybridHistory, HistoryWindow: 0,
+			},
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("history_window must be >= 1"))
+	})
+
+	It("min_history_confidence outside [0,1]", func() {
+		for _, v := range []float64{-0.1, 1.5} {
+			cfg := &ToolsPluginConfig{
+				Enabled: true,
+				Mode:    ToolsPluginModePassthrough,
+				DynamicRetrieval: &DynamicRetrievalConfig{
+					Enabled: true, Strategy: DynamicRetrievalStrategySemanticOnly, MinHistoryConfidence: v,
 				},
+			}
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("min_history_confidence must be between 0.0 and 1.0"))
+		}
+	})
+
+	It("a negative weight", func() {
+		cfg := &ToolsPluginConfig{
+			Enabled: true,
+			Mode:    ToolsPluginModePassthrough,
+			DynamicRetrieval: &DynamicRetrievalConfig{
+				Enabled:       true,
+				Strategy:      DynamicRetrievalStrategyHybridHistory,
+				HistoryWindow: 5,
+				Weights:       &DynamicRetrievalWeights{Semantic: -0.5},
 			},
 		}
 		err := cfg.Validate()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("weights.semantic must be non-negative"))
-	})
-
-	It("accepts zero weights as a way to disable individual signals", func() {
-		cfg := &ToolsPluginConfig{
-			Enabled: true,
-			Mode:    ToolsPluginModePassthrough,
-			DynamicRetrieval: &DynamicRetrievalConfig{
-				Enabled:       true,
-				Strategy:      DynamicRetrievalStrategyHybridHistory,
-				HistoryWindow: 5,
-				Weights: &DynamicRetrievalWeights{
-					Semantic:          1.0,
-					History:           0.0,
-					DecisionPrior:     0.0,
-					RepetitionPenalty: 0.0,
-				},
-			},
-		}
-		Expect(cfg.Validate()).To(Succeed())
 	})
 }
 

--- a/src/semantic-router/pkg/config/tools_plugin_validation.go
+++ b/src/semantic-router/pkg/config/tools_plugin_validation.go
@@ -26,5 +26,62 @@ func (c *ToolsPluginConfig) Validate() error {
 		}
 	}
 
+	if err := c.DynamicRetrieval.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validate checks the dynamic_retrieval block for legal strategy names and
+// numeric ranges.  When the receiver is nil or Enabled is false, validation
+// is a no-op so that adding the block to a config never breaks existing
+// deployments that leave it disabled.
+func (d *DynamicRetrievalConfig) Validate() error {
+	if d == nil || !d.Enabled {
+		return nil
+	}
+
+	switch d.Strategy {
+	case "", DynamicRetrievalStrategySemanticOnly, DynamicRetrievalStrategyHybridHistory:
+	default:
+		return fmt.Errorf("tools plugin: dynamic_retrieval.strategy must be one of %q or %q",
+			DynamicRetrievalStrategySemanticOnly, DynamicRetrievalStrategyHybridHistory)
+	}
+
+	if d.EffectiveStrategy() == DynamicRetrievalStrategyHybridHistory && d.HistoryWindow < 1 {
+		return fmt.Errorf("tools plugin: dynamic_retrieval.history_window must be >= 1 when strategy=%q",
+			DynamicRetrievalStrategyHybridHistory)
+	}
+
+	if d.MinHistoryConfidence < 0.0 || d.MinHistoryConfidence > 1.0 {
+		return fmt.Errorf("tools plugin: dynamic_retrieval.min_history_confidence must be between 0.0 and 1.0")
+	}
+
+	if d.Weights != nil {
+		if err := d.Weights.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Validate ensures each weight is non-negative.  Zero weights are permitted
+// and mean the corresponding signal is ignored by the retriever.
+func (w *DynamicRetrievalWeights) Validate() error {
+	if w == nil {
+		return nil
+	}
+	for name, val := range map[string]float64{
+		"semantic":           w.Semantic,
+		"history":            w.History,
+		"decision_prior":     w.DecisionPrior,
+		"repetition_penalty": w.RepetitionPenalty,
+	} {
+		if val < 0.0 {
+			return fmt.Errorf("tools plugin: dynamic_retrieval.weights.%s must be non-negative", name)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Adds the `dynamic_retrieval` block to `ToolsPluginConfig` per #1832, so #1839 can iterate the retriever behavior without further public-schema churn.

Default behavior is unchanged when the block is absent or `enabled: false`.

```yaml
tools:
  enabled: true
  dynamic_retrieval:
    enabled: true
    strategy: hybrid_history
    history_window: 10
    weights:
      semantic: 1.0
      history: 0.7
      decision_prior: 0.2
      repetition_penalty: 0.1
    min_history_confidence: 0.5
    fallback_on_low_confidence: true
```

Closes #1832.