### PR TITLE
fix(classification): eliminate O(N²) BM25/N-gram classify amplification

### DIFF
--- a/src/semantic-router/pkg/classification/keyword_classifier.go
+++ b/src/semantic-router/pkg/classification/keyword_classifier.go
@@ -264,6 +264,21 @@ func (c *KeywordClassifier) ClassifyWithKeywords(text string) (string, []string,
 	return category, keywords, err
 }
 
+// classifyState holds per-call lazy caches so the BM25 / N-gram classifiers
+// are invoked at most once per ClassifyWithKeywordsAndCount call, regardless
+// of how many BM25 / N-gram rule refs appear in ruleOrder.
+//
+// Without this cache, an outer loop with N BM25 refs invokes the full BM25
+// classify N times — and each call internally iterates all rules until first
+// match — yielding O(N^2) work plus N CString allocations of the full prompt.
+type classifyState struct {
+	regexIdx    int
+	bm25Cached  bool
+	bm25Result  nlp_binding.MatchResult
+	ngramCached bool
+	ngramResult nlp_binding.MatchResult
+}
+
 // ClassifyWithKeywordsAndCount performs keyword-based classification and returns:
 // - category: the matched rule name (or "" if no match)
 // - matchedKeywords: slice of keywords that matched
@@ -274,10 +289,10 @@ func (c *KeywordClassifier) ClassifyWithKeywords(text string) (string, []string,
 // Rules are evaluated in the order they were defined in the config (first-match semantics),
 // regardless of method. Each rule is dispatched to its respective engine.
 func (c *KeywordClassifier) ClassifyWithKeywordsAndCount(text string) (string, []string, int, int, error) {
-	regexIdx := 0
+	state := classifyState{}
 
 	for _, ref := range c.ruleOrder {
-		match, err := c.classifyRule(text, ref, &regexIdx)
+		match, err := c.classifyRule(text, ref, &state)
 		if err != nil {
 			return "", nil, 0, 0, err
 		}
@@ -289,10 +304,14 @@ func (c *KeywordClassifier) ClassifyWithKeywordsAndCount(text string) (string, [
 	return "", nil, 0, 0, nil
 }
 
-func (c *KeywordClassifier) classifyRule(text string, ref ruleRef, regexIdx *int) (ruleMatch, error) {
+func (c *KeywordClassifier) classifyRule(text string, ref ruleRef, state *classifyState) (ruleMatch, error) {
 	switch ref.method {
 	case "bm25":
-		result := c.bm25Classifier.Classify(text)
+		if !state.bm25Cached {
+			state.bm25Result = c.bm25Classifier.Classify(text)
+			state.bm25Cached = true
+		}
+		result := state.bm25Result
 		if !result.Matched || result.RuleName != ref.name {
 			return ruleMatch{}, nil
 		}
@@ -304,7 +323,11 @@ func (c *KeywordClassifier) classifyRule(text string, ref ruleRef, regexIdx *int
 			totalKeywords: result.TotalKeywords,
 		}, nil
 	case "ngram":
-		result := c.ngramClassifier.Classify(text)
+		if !state.ngramCached {
+			state.ngramResult = c.ngramClassifier.Classify(text)
+			state.ngramCached = true
+		}
+		result := state.ngramResult
 		if !result.Matched || result.RuleName != ref.name {
 			return ruleMatch{}, nil
 		}
@@ -316,7 +339,7 @@ func (c *KeywordClassifier) classifyRule(text string, ref ruleRef, regexIdx *int
 			totalKeywords: result.TotalKeywords,
 		}, nil
 	case "regex":
-		return c.classifyRegexRule(text, regexIdx)
+		return c.classifyRegexRule(text, &state.regexIdx)
 	default:
 		return ruleMatch{}, nil
 	}

--- a/src/semantic-router/pkg/classification/keyword_classifier_n2_test.go
+++ b/src/semantic-router/pkg/classification/keyword_classifier_n2_test.go
@@ -1,0 +1,193 @@
+package classification
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// makeBM25Rules builds n distinct BM25 rules whose keywords do NOT appear in
+// the test prompt, so first-match short-circuit inside Rust is never taken.
+// This is the realistic shape of the production hot path: many signals, few
+// (or zero) matches per request.
+func makeBM25Rules(n int) []config.KeywordRule {
+	pool := []string{
+		"alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
+		"golf", "hotel", "india", "juliet", "kilo", "lima",
+		"mike", "november", "oscar", "papa", "quebec", "romeo",
+		"sierra", "tango", "uniform", "victor", "whiskey", "xray",
+		"yankee", "zulu", "anode", "binary", "carbon", "dynamo",
+	}
+	rules := make([]config.KeywordRule, n)
+	for i := 0; i < n; i++ {
+		rules[i] = config.KeywordRule{
+			Name:          fmt.Sprintf("rule_%02d", i),
+			Operator:      "OR",
+			Method:        "bm25",
+			Keywords:      []string{pool[i%len(pool)]},
+			BM25Threshold: 0.1,
+		}
+	}
+	return rules
+}
+
+// TestBM25_NoCallAmplificationOnMixedRules verifies that with N BM25 rules
+// configured, calling Classify still returns the correct match. This is a
+// behaviour regression guard for the cache fix: the cache must not change
+// observable results.
+func TestBM25_CorrectnessAcrossManyRules(t *testing.T) {
+	rules := makeBM25Rules(30)
+	// Inject a rule that *does* match, in the middle of the list.
+	rules[20] = config.KeywordRule{
+		Name:          "matching_rule",
+		Operator:      "OR",
+		Method:        "bm25",
+		Keywords:      []string{"observability", "telemetry"},
+		BM25Threshold: 0.1,
+	}
+
+	kc, err := NewKeywordClassifier(rules)
+	if err != nil {
+		t.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer kc.Free()
+
+	got, _, err := kc.ClassifyWithKeywords("we need better observability for this service")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if got != "matching_rule" {
+		t.Fatalf("expected matching_rule, got %q", got)
+	}
+}
+
+// TestBM25_FirstMatchPriorityPreserved ensures that when multiple BM25 rules
+// could match, the one declared first in config wins (matches existing
+// first-match-by-config-order semantics).
+func TestBM25_FirstMatchPriorityPreserved(t *testing.T) {
+	rules := []config.KeywordRule{
+		{
+			Name: "a_first", Operator: "OR", Method: "bm25",
+			Keywords: []string{"observability"}, BM25Threshold: 0.1,
+		},
+		{
+			Name: "b_second", Operator: "OR", Method: "bm25",
+			Keywords: []string{"observability"}, BM25Threshold: 0.1,
+		},
+	}
+	kc, err := NewKeywordClassifier(rules)
+	if err != nil {
+		t.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer kc.Free()
+
+	got, _, err := kc.ClassifyWithKeywords("observability matters")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if got != "a_first" {
+		t.Fatalf("expected a_first to win by config order, got %q", got)
+	}
+}
+
+// TestMixedMethodOrderPreserved ensures that interleaving regex/bm25/ngram
+// rules still respects ruleOrder for first-match semantics, with the cache.
+func TestMixedMethodOrderPreserved(t *testing.T) {
+	rules := []config.KeywordRule{
+		{
+			Name: "bm25_a", Operator: "OR", Method: "bm25",
+			Keywords: []string{"alpha"}, BM25Threshold: 0.1,
+		},
+		{
+			Name: "regex_b", Operator: "OR", Method: "regex",
+			Keywords: []string{"observability"},
+		},
+		{
+			Name: "bm25_c", Operator: "OR", Method: "bm25",
+			Keywords: []string{"telemetry"}, BM25Threshold: 0.1,
+		},
+	}
+	kc, err := NewKeywordClassifier(rules)
+	if err != nil {
+		t.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer kc.Free()
+
+	// Prompt matches regex_b only — should return regex_b, not bm25_a or bm25_c.
+	got, _, err := kc.ClassifyWithKeywords("observability is key")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if got != "regex_b" {
+		t.Fatalf("expected regex_b, got %q", got)
+	}
+}
+
+// longChinesePrompt builds a ~6.7KB Traditional-Chinese prompt similar to the
+// production "L-ZH" benchmark cell.
+func longChinesePrompt() string {
+	chunk := "我們的內部知識庫搜尋最近開始出現相關性下降的問題：top-3 命中率從 0.78 " +
+		"掉到 0.61，但 embedding 模型沒有換、索引也沒有重建。同事懷疑是新加入的 " +
+		"中英文混用文件影響了向量分布。請以系統化的方式描述：要怎麼確認問題、" +
+		"怎麼量化影響、以及在不重訓模型的前提下有哪些補救策略？請按照診斷步驟、" +
+		"量化方法、緩解方案三段回答。\n\n"
+	return strings.Repeat(chunk, 15)
+}
+
+// BenchmarkBM25_LongChinese_30Rules measures the realistic worst case from the
+// signal-latency report: N=30 BM25 rules, long Chinese prompt, no rule matches
+// (so Rust never short-circuits). On unfixed upstream this took ~54ms per
+// classify in production metrics. With the per-call cache it should drop into
+// the low-millisecond range.
+func BenchmarkBM25_LongChinese_30Rules(b *testing.B) {
+	rules := makeBM25Rules(30)
+	kc, err := NewKeywordClassifier(rules)
+	if err != nil {
+		b.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer kc.Free()
+	prompt := longChinesePrompt()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = kc.ClassifyWithKeywords(prompt)
+	}
+}
+
+// BenchmarkBM25_LongChinese_5Rules is the lower-N reference point.
+func BenchmarkBM25_LongChinese_5Rules(b *testing.B) {
+	rules := makeBM25Rules(5)
+	kc, err := NewKeywordClassifier(rules)
+	if err != nil {
+		b.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer kc.Free()
+	prompt := longChinesePrompt()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = kc.ClassifyWithKeywords(prompt)
+	}
+}
+
+// BenchmarkBM25_ShortEnglish_30Rules confirms short prompts stay fast (the
+// case where the N^2 bug was previously invisible).
+func BenchmarkBM25_ShortEnglish_30Rules(b *testing.B) {
+	rules := makeBM25Rules(30)
+	kc, err := NewKeywordClassifier(rules)
+	if err != nil {
+		b.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer kc.Free()
+	prompt := "What is the time complexity of binary search?"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = kc.ClassifyWithKeywords(prompt)
+	}
+}


### PR DESCRIPTION
# fix(classification): eliminate O(N²) BM25/N-gram classify amplification

## Summary

`KeywordClassifier.ClassifyWithKeywordsAndCount` invokes
`bm25Classifier.Classify(text)` (and `ngramClassifier.Classify`) **once per
`ruleRef`** of that method in `ruleOrder`. Each call internally iterates **all
BM25 rules with first-match semantics**. With `N` BM25 rules this is `O(N²)`
work, plus `N` CString allocations of the full prompt and `N` `to_lowercase()`
passes over it inside Rust.

The bug is invisible for short English prompts, but degrades long-prompt
throughput severely — especially for Chinese / CJK content where the
`Language::English` BM25 tokenizer can't short-circuit.

## Reproducible numbers

Go benchmark (added in this PR), 12th Gen i7-12700, 30 BM25 rules whose
keywords don't match the prompt (so Rust runs all inner rule iterations):

| Test                        | Before (upstream) | After (this PR) | Speedup    |
| --------------------------- | ----------------:| --------------:| ----------:|
| Long Chinese (6.7 KB) × N=30| **501 ms/op**    | **17 ms/op**   | **29.6×**  |
| Long Chinese (6.7 KB) × N=5 | 14.2 ms/op       | 2.78 ms/op     | 5.1×       |
| Short English (45 B) × N=30 | 1.58 ms/op       | 56 µs/op       | 28.2×      |
| Short English (allocs)      | 115 allocs/op    | 7 allocs/op    | 16.4× less |

Speedups match the theoretical `N² → N` reduction (`30² / 30 ≈ 30×`).

End-to-end production impact (sampled via Prometheus
`llm_signal_extraction_latency_seconds` on a build with 30 keyword signals):

| signal_count | signal_extraction p50 (before) |
| -----------: | -----------------------------: |
| 5            | 3.5 ms                         |
| 15           | 17 ms                          |
| **30**       | **54 ms**                      |

For a 6.7 KB Chinese prompt this manifested as **+531 ms** TTFT. With this
fix the per-classify cost should drop into the low-millisecond range.

## Root cause

```go
// keyword_classifier.go (before)
for _, ref := range c.ruleOrder {                  // outer: N iterations
    case "bm25":
        result := c.bm25Classifier.Classify(text)  // full classify each time
        if result.RuleName != ref.name {           //   ↑ Rust also iterates all rules
            return ruleMatch{}, nil                //     until first match
        }
```

Two layers of N stacked: the Go outer loop calls `Classify` for every BM25
rule, and `Bm25Classifier::classify` (Rust, `bm25_classifier.rs`) iterates
all rules in `self.rules` looking for the first match. Worst case: N × N
rule evaluations per request. Each FFI call also re-`CString`s the full
prompt and re-`to_lowercase()`s it on the Rust side.

`Classify(text)` is a deterministic pure function over `(text, classifier
state)`, so calling it N times produces the same answer N times — just
discarding `N-1` of them.

## Fix

Introduce a per-request `classifyState` that lazily caches the BM25 /
N-gram result on first dispatch and reuses it for subsequent refs of the
same method. Net diff in `keyword_classifier.go` is **+29 / -6 lines**:

```go
type classifyState struct {
    regexIdx    int
    bm25Cached  bool
    bm25Result  nlp_binding.MatchResult
    ngramCached bool
    ngramResult nlp_binding.MatchResult
}

case "bm25":
    if !state.bm25Cached {
        state.bm25Result = c.bm25Classifier.Classify(text)
        state.bm25Cached = true
    }
    result := state.bm25Result
    // ... existing name-check + return logic unchanged
```

## Semantic preservation

The cache is opaque to callers. Mixed-method first-match semantics are
preserved because:

* `ruleOrder` traversal is unchanged — regex still evaluates in declared
  order, BM25/N-gram refs still respect their position.
* Cache is lazy — never populated unless a BM25/N-gram ref is actually
  reached.
* `Classify(text)` is deterministic, so a single cached result is
  observationally indistinguishable from `N` repeated calls.

Mental walk-through for an interleaved config
`[bm25_A, regex_X, bm25_B]` where only `bm25_B` matches:

| Iter | ref     | Before              | After                          |
| ---- | ------- | ------------------- | ------------------------------ |
| 1    | bm25_A  | Classify → bm25_B → discarded | Classify → cache RuleName=bm25_B → discarded |
| 2    | regex_X | regex check         | regex check                    |
| 3    | bm25_B  | Classify (again) → bm25_B → match | read cache → match  |

Identical end result; one FFI call instead of two.

## Tests

* All existing BM25 / N-gram / mixed-method / CJK regression tests pass
  unchanged.
* 3 new behaviour-regression tests in
  `keyword_classifier_n2_test.go`:
  * `TestBM25_CorrectnessAcrossManyRules` — 30 rules, only one matches in
    the middle, ensures the cache returns the right rule name.
  * `TestBM25_FirstMatchPriorityPreserved` — two rules with overlapping
    keywords, verifies the config-first one wins.
  * `TestMixedMethodOrderPreserved` — interleaved BM25/regex/BM25,
    verifies regex match in middle is still picked even when BM25 rules
    bracket it.
* 3 new benchmarks for the perf claims above.

## Risk

Low. The change is additive (new struct + lazy cache) inside one function.
No public API change. No FFI/ABI change. No config or schema change. No
behaviour change for any test case I could construct.

## Out of scope

* Tokenizer choice for non-English text (`Language::English` everywhere)
  — separately addressable; not part of the N² fix.
* Returning all matching BM25 rules in a single Rust call — would
  simplify the Go side further but requires FFI struct changes.
* Hot-prompt caching — different optimization layer.

## Acknowledgements

Bug was discovered while profiling signal-routing TTFT. Microbenchmark in
the bench/ directory of the original work, but not included in this PR
(out of scope for upstream).
