### PR TITLE
[CLI] Add unit coverage for python config file loader follow-up to #1872

### DIFF
--- a/src/vllm-sr/tests/test_config_file_loaders.py
+++ b/src/vllm-sr/tests/test_config_file_loaders.py
@@ -1,0 +1,162 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+config_translator = importlib.import_module("cli.config_translator")
+parser = importlib.import_module("cli.parser")
+utils = importlib.import_module("cli.utils")
+
+load_profile_values = config_translator.load_profile_values
+ConfigParseError = parser.ConfigParseError
+load_config_file = parser.load_config_file
+parse_user_config = parser.parse_user_config
+find_config_file = utils.find_config_file
+
+
+def write_minimal_config(path: Path) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": "v0.3",
+                "listeners": [
+                    {"name": "http-8899", "address": "0.0.0.0", "port": 8899}
+                ],
+                "providers": {
+                    "defaults": {"default_model": "demo-model"},
+                    "models": [
+                        {
+                            "name": "demo-model",
+                            "backend_refs": [{"endpoint": "127.0.0.1:8000"}],
+                        }
+                    ],
+                },
+                "routing": {
+                    "modelCards": [{"name": "demo-model"}],
+                    "decisions": [
+                        {
+                            "name": "default-route",
+                            "description": "fallback",
+                            "priority": 100,
+                            "rules": {"operator": "AND", "conditions": []},
+                            "modelRefs": [{"model": "demo-model"}],
+                        }
+                    ],
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_parse_user_config_rejects_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.yaml"
+
+    with pytest.raises(ConfigParseError, match="Configuration file not found"):
+        parse_user_config(str(missing))
+
+
+def test_parse_user_config_rejects_invalid_yaml(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("version: v0.3\nrouting: [broken\n", encoding="utf-8")
+
+    with pytest.raises(ConfigParseError, match="Invalid YAML syntax"):
+        parse_user_config(str(config_path))
+
+
+def test_parse_user_config_rejects_empty_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(ConfigParseError, match="Configuration file is empty"):
+        parse_user_config(str(config_path))
+
+
+def test_load_config_file_rejects_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.yaml"
+
+    with pytest.raises(ConfigParseError, match="Configuration file not found"):
+        load_config_file(str(missing))
+
+
+def test_load_config_file_rejects_invalid_yaml(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("version: v0.3\nproviders: [broken\n", encoding="utf-8")
+
+    with pytest.raises(ConfigParseError, match="Invalid YAML syntax"):
+        load_config_file(str(config_path))
+
+
+def test_load_config_file_returns_mapping(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    write_minimal_config(config_path)
+
+    loaded = load_config_file(str(config_path))
+
+    assert loaded["version"] == "v0.3"
+    assert loaded["providers"]["defaults"]["default_model"] == "demo-model"
+
+
+def test_find_config_file_returns_explicit_file_path(tmp_path: Path) -> None:
+    config_path = tmp_path / "custom.yaml"
+    config_path.write_text("version: v0.3\n", encoding="utf-8")
+
+    found = find_config_file(path=str(tmp_path), file=str(config_path))
+
+    assert found == str(config_path.resolve())
+
+
+def test_find_config_file_finds_root_config_yaml(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("version: v0.3\n", encoding="utf-8")
+
+    found = find_config_file(path=str(tmp_path))
+
+    assert found == str(config_path.resolve())
+
+
+def test_find_config_file_finds_nested_config_yaml(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_path = config_dir / "config.yaml"
+    config_path.write_text("version: v0.3\n", encoding="utf-8")
+
+    found = find_config_file(path=str(tmp_path))
+
+    assert found == str(config_path.resolve())
+
+
+def test_find_config_file_raises_when_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Config file not found"):
+        find_config_file(path=str(tmp_path))
+
+
+def test_load_profile_values_returns_none_without_profile(tmp_path: Path) -> None:
+    assert load_profile_values(None, str(tmp_path)) is None
+
+
+def test_load_profile_values_returns_none_when_profile_file_missing(
+    tmp_path: Path,
+) -> None:
+    assert load_profile_values("dev", str(tmp_path)) is None
+
+
+def test_load_profile_values_loads_named_profile(tmp_path: Path) -> None:
+    profile_path = tmp_path / "values-dev.yaml"
+    profile_path.write_text(
+        yaml.safe_dump(
+            {"image": {"tag": "dev"}, "dependencies": {"observability": {}}}
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_profile_values("dev", str(tmp_path))
+
+    assert loaded == {"image": {"tag": "dev"}, "dependencies": {"observability": {}}}


### PR DESCRIPTION
## Purpose

- This PR is a follow-up to #1872.
- It adds direct unit coverage for Python-side config file loading paths under `src/vllm-sr/cli/`.
- The new tests cover:
  - `parse_user_config(...)`
  - `load_config_file(...)`
  - `find_config_file(...)`
  - `load_profile_values(...)`
- The new coverage focuses on missing files, invalid YAML, empty config content, config discovery behavior, and named Helm profile values loading.
- Which module(s) does this affect? `CLI`
- No additional Valkey test was added because the Valkey code paths in Semantic Router do not load a separate config file from disk. `ValkeyCache` and `ValkeyStore` consume inline Valkey config from the main router config loader, so there is no separate Valkey `config_path`-style loader to exercise here.

## Test Plan

- Run:
  - `pytest src/vllm-sr/tests/test_config_file_loaders.py`
- Review the new test cases in:
  - `src/vllm-sr/tests/test_config_file_loaders.py`
- Why is this validation sufficient for the affected module(s)?
  - These tests directly exercise the Python loader functions responsible for reading config files from disk and cover both expected success cases and the main failure modes.

## Test Result

- Result:
  - 
<img width="1068" height="392" alt="image" src="https://github.com/user-attachments/assets/b0bc2574-4740-45f3-a9b1-018b5a763105" />

- Any follow-up risks, gaps, or blockers?
  - Test execution emits pre-existing Pydantic v2 deprecation warnings from `src/vllm-sr/cli/models.py` related to class-based `Config`.
  - Those warnings are not introduced by this PR and do not affect the test results.
