### PR TITLE
[Router] Add DSL support for tools dynamic retrieval

### DIFF
--- a/src/semantic-router/pkg/dsl/compiler.go
+++ b/src/semantic-router/pkg/dsl/compiler.go
@@ -1159,22 +1159,7 @@ func (c *Compiler) buildDecisionPlugin(pluginType string, fields map[string]Valu
 		setPluginConfig(cfg)
 
 	case "tools":
-		cfg := config.ToolsPluginConfig{}
-		if v, ok := getBoolField(fields, "enabled"); ok {
-			cfg.Enabled = v
-		}
-		if v, ok := getStringField(fields, "mode"); ok {
-			cfg.Mode = v
-		}
-		if v, ok := getBoolField(fields, "semantic_selection"); ok {
-			cfg.SemanticSelection = &v
-		}
-		if values, ok := getStringArrayField(fields, "allow_tools"); ok {
-			cfg.AllowTools = values
-		}
-		if values, ok := getStringArrayField(fields, "block_tools"); ok {
-			cfg.BlockTools = values
-		}
+		cfg := c.compileToolsPlugin(fields)
 		setPluginConfig(cfg)
 
 	default:
@@ -1218,6 +1203,76 @@ func (c *Compiler) compileRAGPlugin(fields map[string]Value) config.RAGPluginCon
 		}
 	}
 	return cfg
+}
+
+func (c *Compiler) compileToolsPlugin(fields map[string]Value) config.ToolsPluginConfig {
+	cfg := config.ToolsPluginConfig{}
+	if v, ok := getBoolField(fields, "enabled"); ok {
+		cfg.Enabled = v
+	}
+	if v, ok := getStringField(fields, "mode"); ok {
+		cfg.Mode = v
+	}
+	if v, ok := getBoolField(fields, "semantic_selection"); ok {
+		cfg.SemanticSelection = &v
+	}
+	if values, ok := getStringArrayField(fields, "allow_tools"); ok {
+		cfg.AllowTools = values
+	}
+	if values, ok := getStringArrayField(fields, "block_tools"); ok {
+		cfg.BlockTools = values
+	}
+	if v, ok := getStringField(fields, "strategy"); ok {
+		cfg.Strategy = v
+	}
+	if raw, ok := fields["dynamic_retrieval"]; ok {
+		if obj, ok := raw.(ObjectValue); ok {
+			cfg.DynamicRetrieval = compileDynamicRetrievalConfig(obj.Fields)
+		}
+	}
+	return cfg
+}
+
+func compileDynamicRetrievalConfig(fields map[string]Value) *config.DynamicRetrievalConfig {
+	cfg := &config.DynamicRetrievalConfig{}
+	if v, ok := getBoolField(fields, "enabled"); ok {
+		cfg.Enabled = v
+	}
+	if v, ok := getStringField(fields, "strategy"); ok {
+		cfg.Strategy = v
+	}
+	if v, ok := getIntField(fields, "history_window"); ok {
+		cfg.HistoryWindow = v
+	}
+	if v, ok := getFloat64Field(fields, "min_history_confidence"); ok {
+		cfg.MinHistoryConfidence = v
+	}
+	if v, ok := getBoolField(fields, "fallback_on_low_confidence"); ok {
+		cfg.FallbackOnLowConfidence = v
+	}
+	if raw, ok := fields["weights"]; ok {
+		if obj, ok := raw.(ObjectValue); ok {
+			cfg.Weights = compileDynamicRetrievalWeights(obj.Fields)
+		}
+	}
+	return cfg
+}
+
+func compileDynamicRetrievalWeights(fields map[string]Value) *config.DynamicRetrievalWeights {
+	weights := &config.DynamicRetrievalWeights{}
+	if v, ok := getFloat64Field(fields, "semantic"); ok {
+		weights.Semantic = v
+	}
+	if v, ok := getFloat64Field(fields, "history"); ok {
+		weights.History = v
+	}
+	if v, ok := getFloat64Field(fields, "decision_prior"); ok {
+		weights.DecisionPrior = v
+	}
+	if v, ok := getFloat64Field(fields, "repetition_penalty"); ok {
+		weights.RepetitionPenalty = v
+	}
+	return weights
 }
 
 // compileComposerObj converts an ObjectValue representing a composer (RuleCombination)

--- a/src/semantic-router/pkg/dsl/decompiler.go
+++ b/src/semantic-router/pkg/dsl/decompiler.go
@@ -774,11 +774,17 @@ func decompilePluginConfig(p *config.DecisionPlugin) string {
 		if cfg.SemanticSelection != nil {
 			fmt.Fprintf(&sb, "    semantic_selection: %v\n", *cfg.SemanticSelection)
 		}
+		if cfg.Strategy != "" {
+			fmt.Fprintf(&sb, "    strategy: %q\n", cfg.Strategy)
+		}
 		if len(cfg.AllowTools) > 0 {
 			fmt.Fprintf(&sb, "    allow_tools: %s\n", formatStringArray(cfg.AllowTools))
 		}
 		if len(cfg.BlockTools) > 0 {
 			fmt.Fprintf(&sb, "    block_tools: %s\n", formatStringArray(cfg.BlockTools))
+		}
+		if cfg.DynamicRetrieval != nil {
+			fmt.Fprintf(&sb, "    dynamic_retrieval: %s\n", formatPluginConfigValue(dynamicRetrievalConfigMap(cfg.DynamicRetrieval)))
 		}
 	case "rag":
 		cfg, ok := decodePluginConfig[config.RAGPluginConfig](p)
@@ -1599,6 +1605,98 @@ func stringsToArray(items []string) ArrayValue {
 	return ArrayValue{Items: vals}
 }
 
+func dynamicRetrievalConfigMap(cfg *config.DynamicRetrievalConfig) map[string]interface{} {
+	if cfg == nil {
+		return nil
+	}
+	values := map[string]interface{}{}
+	if cfg.Enabled {
+		values["enabled"] = true
+	}
+	if cfg.Strategy != "" {
+		values["strategy"] = cfg.Strategy
+	}
+	if cfg.HistoryWindow != 0 {
+		values["history_window"] = cfg.HistoryWindow
+	}
+	if cfg.Weights != nil {
+		values["weights"] = dynamicRetrievalWeightsMap(cfg.Weights)
+	}
+	if cfg.MinHistoryConfidence != 0 {
+		values["min_history_confidence"] = cfg.MinHistoryConfidence
+	}
+	if cfg.FallbackOnLowConfidence {
+		values["fallback_on_low_confidence"] = true
+	}
+	return values
+}
+
+func dynamicRetrievalWeightsMap(weights *config.DynamicRetrievalWeights) map[string]interface{} {
+	if weights == nil {
+		return nil
+	}
+	values := map[string]interface{}{}
+	if weights.Semantic != 0 {
+		values["semantic"] = weights.Semantic
+	}
+	if weights.History != 0 {
+		values["history"] = weights.History
+	}
+	if weights.DecisionPrior != 0 {
+		values["decision_prior"] = weights.DecisionPrior
+	}
+	if weights.RepetitionPenalty != 0 {
+		values["repetition_penalty"] = weights.RepetitionPenalty
+	}
+	return values
+}
+
+func dynamicRetrievalObjectValue(cfg *config.DynamicRetrievalConfig) ObjectValue {
+	fields := map[string]Value{}
+	if cfg == nil {
+		return ObjectValue{Fields: fields}
+	}
+	if cfg.Enabled {
+		fields["enabled"] = BoolValue{V: true}
+	}
+	if cfg.Strategy != "" {
+		fields["strategy"] = StringValue{V: cfg.Strategy}
+	}
+	if cfg.HistoryWindow != 0 {
+		fields["history_window"] = IntValue{V: cfg.HistoryWindow}
+	}
+	if cfg.Weights != nil {
+		fields["weights"] = dynamicRetrievalWeightsObjectValue(cfg.Weights)
+	}
+	if cfg.MinHistoryConfidence != 0 {
+		fields["min_history_confidence"] = FloatValue{V: cfg.MinHistoryConfidence}
+	}
+	if cfg.FallbackOnLowConfidence {
+		fields["fallback_on_low_confidence"] = BoolValue{V: true}
+	}
+	return ObjectValue{Fields: fields}
+}
+
+func dynamicRetrievalWeightsObjectValue(weights *config.DynamicRetrievalWeights) ObjectValue {
+	fields := map[string]Value{}
+	if weights == nil {
+		return ObjectValue{Fields: fields}
+	}
+	if weights.Semantic != 0 {
+		fields["semantic"] = FloatValue{V: weights.Semantic}
+	}
+	if weights.History != 0 {
+		fields["history"] = FloatValue{V: weights.History}
+	}
+	if weights.DecisionPrior != 0 {
+		fields["decision_prior"] = FloatValue{V: weights.DecisionPrior}
+	}
+	if weights.RepetitionPenalty != 0 {
+		fields["repetition_penalty"] = FloatValue{V: weights.RepetitionPenalty}
+	}
+	return ObjectValue{Fields: fields}
+}
+
 func structureFeatureValue(feature config.StructureFeature) ObjectValue {
 	fields := map[string]Value{
 		"type":   StringValue{V: feature.Type},
@@ -2030,11 +2128,17 @@ func pluginConfigToFields(p *config.DecisionPlugin) map[string]Value {
 		if cfg.SemanticSelection != nil {
 			fields["semantic_selection"] = BoolValue{V: *cfg.SemanticSelection}
 		}
+		if cfg.Strategy != "" {
+			fields["strategy"] = StringValue{V: cfg.Strategy}
+		}
 		if len(cfg.AllowTools) > 0 {
 			fields["allow_tools"] = stringsToArray(cfg.AllowTools)
 		}
 		if len(cfg.BlockTools) > 0 {
 			fields["block_tools"] = stringsToArray(cfg.BlockTools)
+		}
+		if cfg.DynamicRetrieval != nil {
+			fields["dynamic_retrieval"] = dynamicRetrievalObjectValue(cfg.DynamicRetrieval)
 		}
 	case "rag":
 		cfg, ok := decodePluginConfig[config.RAGPluginConfig](p)

--- a/src/semantic-router/pkg/dsl/decompiler_plugin_config_test.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_config_test.go
@@ -55,6 +55,62 @@ routing:
 	assertRouterReplayPluginRoundTrip(t, compiled.Decisions[0])
 }
 
+func TestDecompileRoutingRoundTripsToolsDynamicRetrievalPluginConfig(t *testing.T) {
+	cfg := mustParseRoutingPluginConfigTest(t, `
+version: v0.3
+routing:
+  modelCards:
+    - name: "test-model"
+  signals:
+    domains:
+      - name: test
+        description: test
+  decisions:
+    - name: plugin_route
+      priority: 100
+      rules:
+        operator: AND
+        conditions:
+          - type: domain
+            name: test
+      modelRefs:
+        - model: test-model
+      plugins:
+        - type: tools
+          configuration:
+            enabled: true
+            mode: passthrough
+            semantic_selection: true
+            strategy: custom
+            dynamic_retrieval:
+              enabled: true
+              strategy: hybrid_history
+              history_window: 8
+              min_history_confidence: 0.4
+              fallback_on_low_confidence: true
+              weights:
+                semantic: 1.0
+                history: 0.7
+                decision_prior: 0.2
+                repetition_penalty: 0.1
+`)
+
+	dslText := mustDecompileRoutingPluginConfigTest(t, cfg)
+	assertDecompiledPluginConfigContains(t, dslText, []string{
+		`PLUGIN tools`,
+		`strategy: "custom"`,
+		`dynamic_retrieval: {`,
+		`strategy: "hybrid_history"`,
+		`history_window: 8`,
+		`min_history_confidence: 0.4`,
+		`fallback_on_low_confidence: true`,
+		`weights: { decision_prior: 0.2, history: 0.7, repetition_penalty: 0.1, semantic: 1 }`,
+	})
+
+	compiled := mustCompileRoutingPluginConfigTest(t, dslText)
+	assertToolsPluginDynamicRetrievalRoundTrip(t, compiled.Decisions[0])
+}
+
 func mustParseRoutingPluginConfigTest(t *testing.T, configYAML string) *config.RouterConfig {
 	t.Helper()
 
@@ -128,6 +184,33 @@ func assertRouterReplayPluginRoundTrip(t *testing.T, decision config.Decision) {
 	if pluginConfig.MaxRecords != 1000 || !pluginConfig.CaptureRequestBody || !pluginConfig.CaptureResponseBody || pluginConfig.MaxBodyBytes != 4096 {
 		t.Fatalf("router_replay config = %#v", pluginConfig)
 	}
+}
+
+func assertToolsPluginDynamicRetrievalRoundTrip(t *testing.T, decision config.Decision) {
+	t.Helper()
+
+	plugin := findDecisionPluginForTest(t, decision, "tools")
+	var pluginConfig config.ToolsPluginConfig
+	if err := config.UnmarshalPluginConfig(plugin.Configuration, &pluginConfig); err != nil {
+		t.Fatalf("tools decode error: %v", err)
+	}
+	if !pluginConfig.Enabled {
+		t.Fatal("tools.enabled = false, want true")
+	}
+	assertRoundTripToolsPluginBasics(t, &pluginConfig)
+	assertDynamicRetrievalConfig(t, pluginConfig.DynamicRetrieval)
+}
+
+func assertRoundTripToolsPluginBasics(t *testing.T, cfg *config.ToolsPluginConfig) {
+	t.Helper()
+
+	if cfg.Mode != config.ToolsPluginModePassthrough {
+		t.Fatalf("tools.mode = %q", cfg.Mode)
+	}
+	if cfg.SemanticSelection == nil || !*cfg.SemanticSelection {
+		t.Fatalf("tools.semantic_selection = %#v", cfg.SemanticSelection)
+	}
+	assertToolsPluginStrategy(t, cfg)
 }
 
 func findDecisionPluginForTest(t *testing.T, decision config.Decision, pluginType string) config.DecisionPlugin {

--- a/src/semantic-router/pkg/dsl/taxonomy_dsl_test.go
+++ b/src/semantic-router/pkg/dsl/taxonomy_dsl_test.go
@@ -248,3 +248,90 @@ ROUTE local_standard {
 	assertToolsMode(2, config.ToolsPluginModeFiltered)
 	assertToolsMode(3, config.ToolsPluginModePassthrough)
 }
+
+func TestCompileToolsPluginDynamicRetrieval(t *testing.T) {
+	input := `
+ROUTE adaptive_tools {
+  PRIORITY 200
+  PLUGIN tools {
+    enabled: true
+    mode: "passthrough"
+    semantic_selection: true
+    strategy: "custom"
+    dynamic_retrieval: {
+      enabled: true
+      strategy: "hybrid_history"
+      history_window: 8
+      weights: { semantic: 1.0, history: 0.7, decision_prior: 0.2, repetition_penalty: 0.1 }
+      min_history_confidence: 0.4
+      fallback_on_low_confidence: true
+    }
+  }
+  MODEL "adaptive-model"
+}
+`
+
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("Compile errors: %v", errs)
+	}
+	if len(cfg.Decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(cfg.Decisions))
+	}
+
+	toolsCfg := cfg.Decisions[0].GetToolsConfig()
+	if toolsCfg == nil {
+		t.Fatal("expected tools plugin")
+	}
+	assertToolsPluginStrategy(t, toolsCfg)
+	assertDynamicRetrievalConfig(t, toolsCfg.DynamicRetrieval)
+}
+
+func assertToolsPluginStrategy(t *testing.T, cfg *config.ToolsPluginConfig) {
+	t.Helper()
+
+	if cfg.Strategy != "custom" {
+		t.Fatalf("tools strategy = %q, want custom", cfg.Strategy)
+	}
+}
+
+func assertDynamicRetrievalConfig(t *testing.T, dyn *config.DynamicRetrievalConfig) {
+	t.Helper()
+
+	if dyn == nil {
+		t.Fatal("expected dynamic_retrieval config")
+	}
+	assertDynamicRetrievalCore(t, dyn)
+	assertDynamicRetrievalWeights(t, dyn.Weights)
+}
+
+func assertDynamicRetrievalCore(t *testing.T, dyn *config.DynamicRetrievalConfig) {
+	t.Helper()
+
+	if !dyn.Enabled {
+		t.Error("dynamic_retrieval.enabled = false, want true")
+	}
+	if dyn.Strategy != config.DynamicRetrievalStrategyHybridHistory {
+		t.Errorf("dynamic_retrieval.strategy = %q", dyn.Strategy)
+	}
+	if dyn.HistoryWindow != 8 {
+		t.Errorf("dynamic_retrieval.history_window = %d", dyn.HistoryWindow)
+	}
+	if dyn.MinHistoryConfidence != 0.4 {
+		t.Errorf("dynamic_retrieval.min_history_confidence = %v", dyn.MinHistoryConfidence)
+	}
+	if !dyn.FallbackOnLowConfidence {
+		t.Error("dynamic_retrieval.fallback_on_low_confidence = false, want true")
+	}
+}
+
+func assertDynamicRetrievalWeights(t *testing.T, weights *config.DynamicRetrievalWeights) {
+	t.Helper()
+
+	if weights == nil {
+		t.Fatal("expected dynamic_retrieval.weights")
+	}
+	if weights.Semantic != 1.0 || weights.History != 0.7 || weights.DecisionPrior != 0.2 || weights.RepetitionPenalty != 0.1 {
+		t.Errorf("unexpected dynamic_retrieval.weights = %+v", *weights)
+	}
+}


### PR DESCRIPTION
Follow-up to #1832 

## Purpose

- Add missing DSL compiler/decompiler support for the `tools` plugin's `strategy` and `dynamic_retrieval` fields.
- This change is needed because the config contract already supports those fields, but the DSL layer could not author or round-trip them cleanly.
- Affected module(s): `Router`

## Test Plan

- Run the focused DSL tests from the Go module root:
  ```
  cd src/semantic-router
  go test -v ./pkg/dsl -run 'TestCompileToolsPlugin$|TestCompileToolsPluginDynamicRetrieval$|TestDecompileRoutingPreservesRawPluginConfigMaps$|TestDecompileRoutingRoundTripsToolsDynamicRetrievalPluginConfig$' 
  ```
- This validation is sufficient because the change is limited to the DSL translation layer in pkg/dsl and does not modify extproc or live runtime tool-selection behavior.

## Test Result
- Tests passed locally.
<img width="806" height="188" alt="image" src="https://github.com/user-attachments/assets/b2da0273-d1a5-4d5f-9da9-8db3efd8d9ed" />

- Follow-up risk/gap: dynamic_retrieval now round-trips through DSL, but this PR does not implement runtime wiring for dynamic retrieval behavior.