### PR TITLE
[E2E] Centralize Helm release defaults in deployer

### DIFF
--- a/e2e/pkg/helm/deployer.go
+++ b/e2e/pkg/helm/deployer.go
@@ -294,3 +294,54 @@ type InstallOptions struct {
 	// Timeout is the timeout for waiting
 	Timeout string
 }
+
+// Clone returns a copy that callers can safely mutate without changing shared defaults.
+func (o InstallOptions) Clone() InstallOptions {
+	cloned := o
+	cloned.ValuesFiles = append([]string(nil), o.ValuesFiles...)
+	if o.Set != nil {
+		cloned.Set = make(map[string]string, len(o.Set))
+		for key, value := range o.Set {
+			cloned.Set[key] = value
+		}
+	}
+	return cloned
+}
+
+var (
+	SemanticRouterRelease = InstallOptions{
+		ReleaseName: "semantic-router",
+		Chart:       "deploy/helm/semantic-router",
+		Namespace:   "vllm-semantic-router-system",
+		Wait:        true,
+		Timeout:     "30m",
+	}
+
+	EnvoyGatewayRelease = InstallOptions{
+		ReleaseName: "eg",
+		Chart:       "oci://docker.io/envoyproxy/gateway-helm",
+		Namespace:   "envoy-gateway-system",
+		Version:     "v1.6.0",
+		ValuesFiles: []string{"https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-values.yaml"},
+		Wait:        true,
+		Timeout:     "10m",
+	}
+
+	AIGatewayCRDRelease = InstallOptions{
+		ReleaseName: "aieg-crd",
+		Chart:       "oci://docker.io/envoyproxy/ai-gateway-crds-helm",
+		Namespace:   "envoy-ai-gateway-system",
+		Version:     "v0.4.0",
+		Wait:        true,
+		Timeout:     "10m",
+	}
+
+	AIGatewayRelease = InstallOptions{
+		ReleaseName: "aieg",
+		Chart:       "oci://docker.io/envoyproxy/ai-gateway-helm",
+		Namespace:   "envoy-ai-gateway-system",
+		Version:     "v0.4.0",
+		Wait:        true,
+		Timeout:     "10m",
+	}
+)

--- a/e2e/pkg/helm/deployer_test.go
+++ b/e2e/pkg/helm/deployer_test.go
@@ -1,0 +1,92 @@
+package helm
+
+import "testing"
+
+func TestInstallOptionsCloneCopiesMutableFields(t *testing.T) {
+	original := InstallOptions{
+		ReleaseName: "release",
+		Chart:       "chart",
+		Namespace:   "namespace",
+		ValuesFiles: []string{"values.yaml"},
+		Set: map[string]string{
+			"key": "value",
+		},
+		Wait:    true,
+		Timeout: "10m",
+	}
+
+	cloned := original.Clone()
+	cloned.ValuesFiles[0] = "mutated.yaml"
+	cloned.Set["key"] = "mutated"
+
+	if original.ValuesFiles[0] != "values.yaml" {
+		t.Fatalf("expected values files to remain unchanged, got %#v", original.ValuesFiles)
+	}
+	if original.Set["key"] != "value" {
+		t.Fatalf("expected set values to remain unchanged, got %#v", original.Set)
+	}
+}
+
+func TestCatalogedGatewayInstallOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		options   InstallOptions
+		release   string
+		namespace string
+		version   string
+		timeout   string
+	}{
+		{
+			name:      "semantic router",
+			options:   SemanticRouterRelease,
+			release:   "semantic-router",
+			namespace: "vllm-semantic-router-system",
+			version:   "",
+			timeout:   "30m",
+		},
+		{
+			name:      "envoy gateway",
+			options:   EnvoyGatewayRelease,
+			release:   "eg",
+			namespace: "envoy-gateway-system",
+			version:   "v1.6.0",
+			timeout:   "10m",
+		},
+		{
+			name:      "ai gateway crd",
+			options:   AIGatewayCRDRelease,
+			release:   "aieg-crd",
+			namespace: "envoy-ai-gateway-system",
+			version:   "v0.4.0",
+			timeout:   "10m",
+		},
+		{
+			name:      "ai gateway",
+			options:   AIGatewayRelease,
+			release:   "aieg",
+			namespace: "envoy-ai-gateway-system",
+			version:   "v0.4.0",
+			timeout:   "10m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.options.ReleaseName != tt.release {
+				t.Fatalf("expected release %q, got %q", tt.release, tt.options.ReleaseName)
+			}
+			if tt.options.Namespace != tt.namespace {
+				t.Fatalf("expected namespace %q, got %q", tt.namespace, tt.options.Namespace)
+			}
+			if tt.options.Version != tt.version {
+				t.Fatalf("expected version %q, got %q", tt.version, tt.options.Version)
+			}
+			if tt.options.Timeout != tt.timeout {
+				t.Fatalf("expected timeout %q, got %q", tt.timeout, tt.options.Timeout)
+			}
+			if !tt.options.Wait {
+				t.Fatal("expected cataloged release to wait for readiness")
+			}
+		})
+	}
+}

--- a/e2e/pkg/stacks/gateway/stack.go
+++ b/e2e/pkg/stacks/gateway/stack.go
@@ -15,39 +15,22 @@ import (
 )
 
 const (
-	namespaceSemanticRouter = "vllm-semantic-router-system"
-	namespaceEnvoyGateway   = "envoy-gateway-system"
-	namespaceAIGateway      = "envoy-ai-gateway-system"
-
-	releaseSemanticRouter = "semantic-router"
-	releaseEnvoyGateway   = "eg"
-	releaseAIGatewayCRD   = "aieg-crd"
-	releaseAIGateway      = "aieg"
-
 	deploymentSemanticRouter = "semantic-router"
 	deploymentEnvoyGateway   = "envoy-gateway"
 	deploymentAIGateway      = "ai-gateway-controller"
 
-	chartPathSemanticRouter = "deploy/helm/semantic-router"
-	chartEnvoyGateway       = "oci://docker.io/envoyproxy/gateway-helm"
-	chartAIGatewayCRD       = "oci://docker.io/envoyproxy/ai-gateway-crds-helm"
-	chartAIGateway          = "oci://docker.io/envoyproxy/ai-gateway-helm"
-	envoyGatewayValuesURL   = "https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-values.yaml"
-
 	imageRepository = "ghcr.io/vllm-project/semantic-router/extproc"
 	imagePullPolicy = "Never"
 
-	timeoutSemanticRouterInstall = "30m"
-	timeoutHelmInstall           = "10m"
-	timeoutServiceRetry          = 10 * time.Minute
-	intervalServiceRetry         = 5 * time.Second
-	timeoutDeploymentWait        = 30 * time.Minute
+	timeoutServiceRetry   = 10 * time.Minute
+	intervalServiceRetry  = 5 * time.Second
+	timeoutDeploymentWait = 30 * time.Minute
 )
 
 var defaultVerifyDeployments = []helpers.DeploymentRef{
-	{Namespace: namespaceSemanticRouter, Name: deploymentSemanticRouter},
-	{Namespace: namespaceEnvoyGateway, Name: deploymentEnvoyGateway},
-	{Namespace: namespaceAIGateway, Name: deploymentAIGateway},
+	{Namespace: helm.SemanticRouterRelease.Namespace, Name: deploymentSemanticRouter},
+	{Namespace: helm.EnvoyGatewayRelease.Namespace, Name: deploymentEnvoyGateway},
+	{Namespace: helm.AIGatewayRelease.Namespace, Name: deploymentAIGateway},
 }
 
 // Config describes a reusable semantic-router + Envoy Gateway + AI Gateway test stack.
@@ -83,7 +66,7 @@ func New(config Config) *Stack {
 func DefaultServiceConfig() framework.ServiceConfig {
 	return framework.ServiceConfig{
 		LabelSelector: "gateway.envoyproxy.io/owning-gateway-namespace=default,gateway.envoyproxy.io/owning-gateway-name=semantic-router",
-		Namespace:     namespaceEnvoyGateway,
+		Namespace:     helm.EnvoyGatewayRelease.Namespace,
 		ServicePort:   "80",
 	}
 }
@@ -131,53 +114,34 @@ func (s *Stack) ApplyPrerequisites(ctx context.Context, opts *framework.SetupOpt
 // DeployCore installs semantic-router, Envoy Gateway, and Envoy AI Gateway.
 func (s *Stack) DeployCore(ctx context.Context, opts *framework.SetupOptions) error {
 	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+	envoyGatewayRelease := helm.EnvoyGatewayRelease.Clone()
+	aiGatewayCRDRelease := helm.AIGatewayCRDRelease.Clone()
+	aiGatewayRelease := helm.AIGatewayRelease.Clone()
 
 	s.log(opts.Verbose, "Installing semantic-router")
 	if err := deployer.Install(ctx, s.semanticRouterInstallOptions(opts)); err != nil {
 		return fmt.Errorf("install semantic-router: %w", err)
 	}
-	if err := deployer.WaitForDeployment(ctx, namespaceSemanticRouter, deploymentSemanticRouter, timeoutDeploymentWait); err != nil {
+	if err := deployer.WaitForDeployment(ctx, helm.SemanticRouterRelease.Namespace, deploymentSemanticRouter, timeoutDeploymentWait); err != nil {
 		return fmt.Errorf("wait for semantic-router: %w", err)
 	}
 
 	s.log(opts.Verbose, "Installing Envoy Gateway")
-	if err := deployer.Install(ctx, helm.InstallOptions{
-		ReleaseName: releaseEnvoyGateway,
-		Chart:       chartEnvoyGateway,
-		Namespace:   namespaceEnvoyGateway,
-		Version:     "v1.6.0",
-		ValuesFiles: []string{envoyGatewayValuesURL},
-		Wait:        true,
-		Timeout:     timeoutHelmInstall,
-	}); err != nil {
+	if err := deployer.Install(ctx, envoyGatewayRelease); err != nil {
 		return fmt.Errorf("install Envoy Gateway: %w", err)
 	}
-	if err := deployer.WaitForDeployment(ctx, namespaceEnvoyGateway, deploymentEnvoyGateway, timeoutDeploymentWait); err != nil {
+	if err := deployer.WaitForDeployment(ctx, helm.EnvoyGatewayRelease.Namespace, deploymentEnvoyGateway, timeoutDeploymentWait); err != nil {
 		return fmt.Errorf("wait for Envoy Gateway: %w", err)
 	}
 
 	s.log(opts.Verbose, "Installing Envoy AI Gateway")
-	if err := deployer.Install(ctx, helm.InstallOptions{
-		ReleaseName: releaseAIGatewayCRD,
-		Chart:       chartAIGatewayCRD,
-		Namespace:   namespaceAIGateway,
-		Version:     "v0.4.0",
-		Wait:        true,
-		Timeout:     timeoutHelmInstall,
-	}); err != nil {
+	if err := deployer.Install(ctx, aiGatewayCRDRelease); err != nil {
 		return fmt.Errorf("install Envoy AI Gateway CRDs: %w", err)
 	}
-	if err := deployer.Install(ctx, helm.InstallOptions{
-		ReleaseName: releaseAIGateway,
-		Chart:       chartAIGateway,
-		Namespace:   namespaceAIGateway,
-		Version:     "v0.4.0",
-		Wait:        true,
-		Timeout:     timeoutHelmInstall,
-	}); err != nil {
+	if err := deployer.Install(ctx, aiGatewayRelease); err != nil {
 		return fmt.Errorf("install Envoy AI Gateway: %w", err)
 	}
-	if err := deployer.WaitForDeployment(ctx, namespaceAIGateway, deploymentAIGateway, timeoutDeploymentWait); err != nil {
+	if err := deployer.WaitForDeployment(ctx, helm.AIGatewayRelease.Namespace, deploymentAIGateway, timeoutDeploymentWait); err != nil {
 		return fmt.Errorf("wait for Envoy AI Gateway: %w", err)
 	}
 
@@ -241,23 +205,21 @@ func (s *Stack) CleanupPrerequisites(ctx context.Context, opts *framework.Teardo
 // UninstallCore removes the shared Helm releases with best-effort cleanup semantics.
 func (s *Stack) UninstallCore(ctx context.Context, opts *framework.TeardownOptions) {
 	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
-	bestEffort := []struct {
-		release   string
-		namespace string
-	}{
-		{release: releaseAIGatewayCRD, namespace: namespaceAIGateway},
-		{release: releaseAIGateway, namespace: namespaceAIGateway},
-		{release: releaseEnvoyGateway, namespace: namespaceEnvoyGateway},
-		{release: releaseSemanticRouter, namespace: namespaceSemanticRouter},
+	bestEffort := []helm.InstallOptions{
+		helm.AIGatewayCRDRelease,
+		helm.AIGatewayRelease,
+		helm.EnvoyGatewayRelease,
+		helm.SemanticRouterRelease,
 	}
 	for _, release := range bestEffort {
-		if err := deployer.Uninstall(ctx, release.release, release.namespace); err != nil {
-			s.log(opts.Verbose, "Warning: failed to uninstall %s/%s: %v", release.namespace, release.release, err)
+		if err := deployer.Uninstall(ctx, release.ReleaseName, release.Namespace); err != nil {
+			s.log(opts.Verbose, "Warning: failed to uninstall %s/%s: %v", release.Namespace, release.ReleaseName, err)
 		}
 	}
 }
 
 func (s *Stack) semanticRouterInstallOptions(opts *framework.SetupOptions) helm.InstallOptions {
+	installOptions := helm.SemanticRouterRelease.Clone()
 	setValues := map[string]string{
 		"image.repository": imageRepository,
 		"image.tag":        opts.ImageTag,
@@ -268,19 +230,13 @@ func (s *Stack) semanticRouterInstallOptions(opts *framework.SetupOptions) helm.
 	}
 
 	valuesFiles := []string{s.config.SemanticRouterValuesFile}
-	if extraValuesFile, ok := opts.ValuesFiles[releaseSemanticRouter]; ok && extraValuesFile != "" {
+	if extraValuesFile, ok := opts.ValuesFiles[helm.SemanticRouterRelease.ReleaseName]; ok && extraValuesFile != "" {
 		valuesFiles = append(valuesFiles, extraValuesFile)
 	}
 
-	return helm.InstallOptions{
-		ReleaseName: releaseSemanticRouter,
-		Chart:       chartPathSemanticRouter,
-		Namespace:   namespaceSemanticRouter,
-		ValuesFiles: valuesFiles,
-		Set:         setValues,
-		Wait:        true,
-		Timeout:     timeoutSemanticRouterInstall,
-	}
+	installOptions.ValuesFiles = valuesFiles
+	installOptions.Set = setValues
+	return installOptions
 }
 
 func (s *Stack) waitForService(

--- a/e2e/pkg/stacks/gateway/stack_test.go
+++ b/e2e/pkg/stacks/gateway/stack_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helm"
 )
 
 func TestSemanticRouterInstallOptionsUsesBaseValuesFileByDefault(t *testing.T) {
@@ -30,7 +31,7 @@ func TestSemanticRouterInstallOptionsAppendsWorkspaceOverlay(t *testing.T) {
 	opts := stack.semanticRouterInstallOptions(&framework.SetupOptions{
 		ImageTag: "test-image",
 		ValuesFiles: map[string]string{
-			releaseSemanticRouter: "workspace-models.yaml",
+			helm.SemanticRouterRelease.ReleaseName: "workspace-models.yaml",
 		},
 	})
 


### PR DESCRIPTION

## Purpose

- What does this PR change?  
  - Centralize Helm release metadata used by E2E tests by defining canonical InstallOptions constants in `deployer.go`, and update the gateway stack to use InstallOptions.Clone() so per-install mutations don't affect shared defaults.
- Why is this change needed?
  - Removes duplicated release/chart/version/values/timeouts across the codebase, makes defaults easier to maintain, and prevents bugs from shared mutable fields (slices/maps) when tests modify install options.
- Which module(s) does this affect?
  - `E2E` 
