### PR TITLE
test: e2e tests to verify tool selection

### DIFF
--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -193,7 +193,7 @@ jobs:
           set +e
           if [ "${{ matrix.profile }}" = "kubernetes" ]; then
             # Temporarily skip the stress / pressure coverage until the suite is stable again.
-            KUBERNETES_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,rule-condition-logic,decision-fallback-behavior,plugin-config-variations"
+            KUBERNETES_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations"
             make e2e-test E2E_PROFILE=${{ matrix.profile }} E2E_TESTS="${KUBERNETES_CI_TESTS}" E2E_VERBOSE=true E2E_KEEP_CLUSTER=false
             TEST_EXIT_CODE=$?
             set -e

--- a/e2e/pkg/fixtures/chat.go
+++ b/e2e/pkg/fixtures/chat.go
@@ -2,6 +2,7 @@ package fixtures
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"time"
 )
@@ -12,12 +13,29 @@ type ChatMessage struct {
 	Content string `json:"content"`
 }
 
+// ChatTool is a minimal OpenAI-format tool definition for E2E requests.
+type ChatTool struct {
+	Type     string       `json:"type"`
+	Function ChatToolFunc `json:"function"`
+}
+
+// ChatToolFunc is the function payload for a chat tool.
+type ChatToolFunc struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
 // ChatCompletionsRequest is the typed request for /v1/chat/completions.
 type ChatCompletionsRequest struct {
 	Model    string        `json:"model"`
 	Messages []ChatMessage `json:"messages"`
 	// User is optional; forwarded for per-user routing and session correlation in tests.
 	User string `json:"user,omitempty"`
+	// Tools is optional; used by tool_selection filter-mode E2E contracts.
+	Tools []ChatTool `json:"tools,omitempty"`
+	// ToolChoice is optional; when omitted the gateway uses default auto behavior.
+	ToolChoice json.RawMessage `json:"tool_choice,omitempty"`
 }
 
 // ChatCompletionsClient talks to the routed chat-completions API.

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -17,6 +17,7 @@ var BaselineRouterContract = []string{
 	"jailbreak-detection",
 	"decision-priority-selection",
 	"plugin-chain-execution",
+	"tool-selection",
 	"rule-condition-logic",
 	"decision-fallback-behavior",
 	"plugin-config-variations",

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -51,6 +51,159 @@ config:
           - type: fast_response
             configuration:
               message: Your request contains personal information. Please remove any sensitive data and try again.
+      - name: tool_selection_add_weather_decision
+        description: Contract route for tool_selection add mode (weather-aligned retrieval)
+        priority: 500
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: tool_selection_add_weather
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: tools
+            configuration:
+              enabled: true
+              mode: passthrough
+              semantic_selection: false
+          - type: tool_selection
+            configuration:
+              enabled: true
+              mode: add
+              top_k: 3
+              similarity_threshold: 0.01
+              strategy: default
+      - name: tool_selection_add_calc_decision
+        description: Contract route for tool_selection add mode (math-aligned retrieval)
+        priority: 500
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: tool_selection_add_calc
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: tools
+            configuration:
+              enabled: true
+              mode: passthrough
+              semantic_selection: false
+          - type: tool_selection
+            configuration:
+              enabled: true
+              mode: add
+              top_k: 3
+              similarity_threshold: 0.01
+              strategy: default
+      - name: tool_selection_filter_decision
+        description: Contract route for tool_selection filter mode
+        priority: 500
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: tool_selection_filter
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: tools
+            configuration:
+              enabled: true
+              mode: passthrough
+              semantic_selection: false
+          - type: tool_selection
+            configuration:
+              enabled: true
+              mode: filter
+              relevance_threshold: 0.22
+              preserve_count: 2
+      - name: tool_selection_filter_threshold_decision
+        description: Contract route for tool_selection filter mode with strict relevance threshold
+        priority: 500
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: tool_selection_filter_threshold
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: tools
+            configuration:
+              enabled: true
+              mode: passthrough
+              semantic_selection: false
+          - type: tool_selection
+            configuration:
+              enabled: true
+              mode: filter
+              relevance_threshold: 0.95
+              preserve_count: 1
+      - name: tool_selection_add_topk_one_decision
+        description: Contract route for tool_selection add mode with alternate top_k
+        priority: 500
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: tool_selection_add_topk_one
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: tools
+            configuration:
+              enabled: true
+              mode: passthrough
+              semantic_selection: false
+          - type: tool_selection
+            configuration:
+              enabled: true
+              mode: add
+              top_k: 1
+              similarity_threshold: 0.01
+              strategy: default
+      - name: tool_selection_with_system_prompt_decision
+        description: Contract route for tool_selection stacked with system_prompt plugin
+        priority: 500
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: tool_selection_with_system_prompt
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: tools
+            configuration:
+              enabled: true
+              mode: passthrough
+              semantic_selection: false
+          - type: tool_selection
+            configuration:
+              enabled: true
+              mode: add
+              top_k: 2
+              similarity_threshold: 0.01
+              strategy: default
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: "Contract route: system_prompt + tool_selection (non-PII path)."
+              mode: append
       - name: business_decision
         description: Business and management related queries
         priority: 10
@@ -376,6 +529,36 @@ config:
             - SSN
             - credit card
           case_sensitive: false
+        - name: tool_selection_add_weather
+          operator: OR
+          keywords:
+            - __TOOL_SELECTION_ADD_WEATHER__
+          case_sensitive: false
+        - name: tool_selection_add_calc
+          operator: OR
+          keywords:
+            - __TOOL_SELECTION_ADD_CALC__
+          case_sensitive: false
+        - name: tool_selection_filter
+          operator: OR
+          keywords:
+            - __TOOL_SELECTION_FILTER__
+          case_sensitive: false
+        - name: tool_selection_filter_threshold
+          operator: OR
+          keywords:
+            - __TOOL_SELECTION_FILTER_THRESHOLD__
+          case_sensitive: false
+        - name: tool_selection_add_topk_one
+          operator: OR
+          keywords:
+            - __TOOL_SELECTION_ADD_TOPK_ONE__
+          case_sensitive: false
+        - name: tool_selection_with_system_prompt
+          operator: OR
+          keywords:
+            - __TOOL_SELECTION_WITH_SYSTEM_PROMPT__
+          case_sensitive: false
       domains:
         - name: business
           description: Business, corporate strategy, management, finance, marketing
@@ -505,6 +688,64 @@ config:
         similarity_threshold: 0.2
         tools_db_path: config/tools_db.json
         fallback_to_empty: true
+toolsDb:
+  - tool:
+      type: function
+      function:
+        name: get_weather
+        description: Get current weather information for a location
+        parameters:
+          type: object
+          properties:
+            location:
+              type: string
+              description: City and region to query
+          required:
+            - location
+    description: Weather forecast and current weather lookup for city-based requests.
+    category: weather
+    tags:
+      - weather
+      - forecast
+      - temperature
+  - tool:
+      type: function
+      function:
+        name: calculate
+        description: Perform mathematical calculations
+        parameters:
+          type: object
+          properties:
+            expression:
+              type: string
+              description: Mathematical expression to evaluate
+          required:
+            - expression
+    description: Math computation helper for arithmetic and equation solving.
+    category: math
+    tags:
+      - math
+      - calculator
+      - arithmetic
+  - tool:
+      type: function
+      function:
+        name: search_web
+        description: Search web resources for recent information
+        parameters:
+          type: object
+          properties:
+            query:
+              type: string
+              description: Search query text
+          required:
+            - query
+    description: Web search utility for current events and external information retrieval.
+    category: search
+    tags:
+      - search
+      - web
+      - internet
 resources:
   limits:
     cpu: "2"

--- a/e2e/testcases/tool_selection_e2e.go
+++ b/e2e/testcases/tool_selection_e2e.go
@@ -1,0 +1,306 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("tool-selection", pkgtestcases.TestCase{
+		Description: "Decision plugin tool_selection: add, filter, threshold, config variants, and PII precedence",
+		Tags:        []string{"kubernetes", "plugin", "tool-selection"},
+		Fn:          testToolSelectionE2E,
+	})
+}
+
+type toolSelectionE2ECase struct {
+	Name                    string
+	Prompt                  string
+	Tools                   []fixtures.ChatTool
+	ExpectDecision          string
+	ExpectFastResponse      *bool
+	ExpectToolsStrategy     string
+	ExpectConfidenceGT      float64
+	ExpectInjectedSysPrompt *bool
+}
+
+func defaultContractTools(minObjectParams json.RawMessage) []fixtures.ChatTool {
+	return []fixtures.ChatTool{
+		{Type: "function", Function: fixtures.ChatToolFunc{Name: "get_weather", Description: "Get current weather information for a location", Parameters: minObjectParams}},
+		{Type: "function", Function: fixtures.ChatToolFunc{Name: "calculate", Description: "Perform mathematical calculations", Parameters: minObjectParams}},
+		{Type: "function", Function: fixtures.ChatToolFunc{Name: "search_web", Description: "Search web resources for recent information", Parameters: minObjectParams}},
+	}
+}
+
+func toolSelectionContractCases(minObjectParams json.RawMessage) []toolSelectionE2ECase {
+	contractTools := defaultContractTools(minObjectParams)
+	cases := []toolSelectionE2ECase{
+		{
+			Name:                "add_mode_weather_query",
+			Prompt:              "__TOOL_SELECTION_ADD_WEATHER__ What is the weather forecast for Boston tomorrow?",
+			Tools:               contractTools,
+			ExpectDecision:      "tool_selection_add_weather_decision",
+			ExpectToolsStrategy: "default",
+			ExpectConfidenceGT:  0.01,
+		},
+		{
+			Name:                "add_mode_math_query",
+			Prompt:              "__TOOL_SELECTION_ADD_CALC__ Compute 17 * 23 using the calculator tool.",
+			Tools:               contractTools,
+			ExpectDecision:      "tool_selection_add_calc_decision",
+			ExpectToolsStrategy: "default",
+			ExpectConfidenceGT:  0.01,
+		},
+		{
+			Name:                "filter_mode_drops_irrelevant_tools",
+			Prompt:              "__TOOL_SELECTION_FILTER__ Will it rain in Seattle this weekend?",
+			ExpectDecision:      "tool_selection_filter_decision",
+			ExpectToolsStrategy: "filter",
+			ExpectConfidenceGT:  0.01,
+			Tools: []fixtures.ChatTool{
+				{Type: "function", Function: fixtures.ChatToolFunc{Name: "get_weather", Description: "Get current weather information for a location", Parameters: minObjectParams}},
+				{Type: "function", Function: fixtures.ChatToolFunc{Name: "contract_noise_alpha", Description: "Unrelated tool for cataloguing antique spoons", Parameters: minObjectParams}},
+				{Type: "function", Function: fixtures.ChatToolFunc{Name: "contract_noise_beta", Description: "Metadata about underground subway tile patterns", Parameters: minObjectParams}},
+			},
+		},
+		{
+			Name:                "filter_mode_strict_threshold",
+			Prompt:              "__TOOL_SELECTION_FILTER_THRESHOLD__ Compare rainfall totals in Portland OR vs Seattle WA.",
+			ExpectDecision:      "tool_selection_filter_threshold_decision",
+			ExpectToolsStrategy: "filter",
+			ExpectConfidenceGT:  0.01,
+			Tools: []fixtures.ChatTool{
+				{Type: "function", Function: fixtures.ChatToolFunc{Name: "get_weather", Description: "Get current weather information for a location", Parameters: minObjectParams}},
+				{Type: "function", Function: fixtures.ChatToolFunc{Name: "calculate", Description: "Perform mathematical calculations", Parameters: minObjectParams}},
+				{Type: "function", Function: fixtures.ChatToolFunc{Name: "contract_noise_gamma", Description: "Low relevance filler about knitting patterns", Parameters: minObjectParams}},
+			},
+		},
+		{
+			Name:                "add_mode_alternate_top_k",
+			Prompt:              "__TOOL_SELECTION_ADD_TOPK_ONE__ Summarize how search_web could help research climate papers.",
+			Tools:               contractTools,
+			ExpectDecision:      "tool_selection_add_topk_one_decision",
+			ExpectToolsStrategy: "default",
+			ExpectConfidenceGT:  0.01,
+		},
+		{
+			Name:                    "stacked_system_prompt_and_tool_selection",
+			Prompt:                  "__TOOL_SELECTION_WITH_SYSTEM_PROMPT__ Plan a short hiking trip; check weather for Mount Rainier.",
+			Tools:                   contractTools,
+			ExpectDecision:          "tool_selection_with_system_prompt_decision",
+			ExpectToolsStrategy:     "default",
+			ExpectConfidenceGT:      0.01,
+			ExpectInjectedSysPrompt: boolPtr(true),
+		},
+	}
+	frTrue := true
+	cases = append(cases, toolSelectionE2ECase{
+		Name:               "pii_decision_runs_before_tool_selection",
+		Prompt:             "__TOOL_SELECTION_ADD_WEATHER__ My payment card is 4111111111111111 and I need a weather forecast for Miami.",
+		ExpectDecision:     "block_pii",
+		ExpectFastResponse: &frTrue,
+	})
+	return cases
+}
+
+func testToolSelectionE2E(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] tool_selection contract (add / filter / threshold / stacked plugins / PII precedence)")
+	}
+
+	session, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	chat := fixtures.NewChatCompletionsClient(session, 45*time.Second)
+	minObjectParams := json.RawMessage(`{"type":"object","properties":{}}`)
+	cases := toolSelectionContractCases(minObjectParams)
+
+	var failed int
+	var firstErr error
+	for _, tc := range cases {
+		if err := runToolSelectionCase(ctx, chat, tc, opts.Verbose); err != nil {
+			failed++
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %w", tc.Name, err)
+			}
+			if opts.Verbose {
+				fmt.Printf("[Test] FAIL %s: %v\n", tc.Name, err)
+			}
+		} else if opts.Verbose {
+			fmt.Printf("[Test] OK   %s\n", tc.Name)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"cases_total":  len(cases),
+			"cases_failed": failed,
+			"cases_passed": len(cases) - failed,
+		})
+	}
+
+	if failed > 0 {
+		if firstErr != nil {
+			return fmt.Errorf("tool_selection: %d/%d cases failed: %w", failed, len(cases), firstErr)
+		}
+		return fmt.Errorf("tool_selection: %d/%d cases failed", failed, len(cases))
+	}
+	return nil
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func runToolSelectionCase(
+	ctx context.Context,
+	chat *fixtures.ChatCompletionsClient,
+	tc toolSelectionE2ECase,
+	verbose bool,
+) error {
+	req := buildToolSelectionChatRequest(tc)
+	resp, err := chat.Create(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	decision := resp.Headers.Get("x-vsr-selected-decision")
+	if err := assertToolSelectionDecision(tc, decision, resp.Headers); err != nil {
+		return err
+	}
+	if err := assertToolSelectionFastResponse(tc, resp.Headers); err != nil {
+		return err
+	}
+	if err := assertToolSelectionStrategy(tc, decision, resp.Headers); err != nil {
+		return err
+	}
+	if err := assertToolSelectionConfidence(tc, decision, resp.Headers); err != nil {
+		return err
+	}
+	if err := assertInjectedSystemPrompt(tc, resp.Headers); err != nil {
+		return err
+	}
+	if verbose {
+		logToolSelectionHeaders(decision, resp.Headers)
+	}
+	return nil
+}
+
+func buildToolSelectionChatRequest(tc toolSelectionE2ECase) fixtures.ChatCompletionsRequest {
+	req := fixtures.ChatCompletionsRequest{
+		Model: "MoM",
+		Messages: []fixtures.ChatMessage{
+			{Role: "user", Content: tc.Prompt},
+		},
+		Tools: tc.Tools,
+	}
+	if len(tc.Tools) > 0 {
+		req.ToolChoice = json.RawMessage(`"auto"`)
+	}
+	return req
+}
+
+func assertToolSelectionDecision(tc toolSelectionE2ECase, decision string, h http.Header) error {
+	if tc.ExpectDecision == "" || decision == tc.ExpectDecision {
+		return nil
+	}
+	return fmt.Errorf("decision: want %q got %q (headers=%s)", tc.ExpectDecision, decision, summarizeToolHeaders(h))
+}
+
+func assertToolSelectionFastResponse(tc toolSelectionE2ECase, h http.Header) error {
+	if tc.ExpectFastResponse == nil {
+		return nil
+	}
+	fr := h.Get("x-vsr-fast-response") == "true"
+	if fr == *tc.ExpectFastResponse {
+		return nil
+	}
+	return fmt.Errorf("x-vsr-fast-response: want %v got %v", *tc.ExpectFastResponse, fr)
+}
+
+func assertToolSelectionStrategy(tc toolSelectionE2ECase, decision string, h http.Header) error {
+	if tc.ExpectToolsStrategy == "" {
+		return nil
+	}
+	strategy := h.Get("x-vsr-tools-strategy")
+	if strategy == "" {
+		return nil
+	}
+	if tc.ExpectToolsStrategy == "default" {
+		if strings.HasPrefix(strategy, "default") {
+			return nil
+		}
+		return fmt.Errorf("x-vsr-tools-strategy: want prefix %q got %q", tc.ExpectToolsStrategy, strategy)
+	}
+	if strategy == tc.ExpectToolsStrategy {
+		return nil
+	}
+	return fmt.Errorf("x-vsr-tools-strategy: want %q got %q", tc.ExpectToolsStrategy, strategy)
+}
+
+func assertToolSelectionConfidence(tc toolSelectionE2ECase, decision string, h http.Header) error {
+	if tc.ExpectConfidenceGT <= 0 || tc.ExpectFastResponse != nil {
+		return nil
+	}
+	confStr := h.Get("x-vsr-tools-confidence")
+	if confStr == "" {
+		return nil
+	}
+	conf, err := strconv.ParseFloat(confStr, 64)
+	if err != nil {
+		return fmt.Errorf("parse x-vsr-tools-confidence %q: %w", confStr, err)
+	}
+	if conf > tc.ExpectConfidenceGT {
+		return nil
+	}
+	return fmt.Errorf("x-vsr-tools-confidence: want > %.4f got %.4f", tc.ExpectConfidenceGT, conf)
+}
+
+func assertInjectedSystemPrompt(tc toolSelectionE2ECase, h http.Header) error {
+	if tc.ExpectInjectedSysPrompt == nil {
+		return nil
+	}
+	inj := h.Get("x-vsr-injected-system-prompt") == "true"
+	if inj == *tc.ExpectInjectedSysPrompt {
+		return nil
+	}
+	return fmt.Errorf("x-vsr-injected-system-prompt: want %v got %v", *tc.ExpectInjectedSysPrompt, inj)
+}
+
+func logToolSelectionHeaders(decision string, h http.Header) {
+	fmt.Printf("  decision=%q strategy=%q confidence=%q latency_ms=%q fast=%q\n",
+		decision,
+		h.Get("x-vsr-tools-strategy"),
+		h.Get("x-vsr-tools-confidence"),
+		h.Get("x-vsr-tools-latency-ms"),
+		h.Get("x-vsr-fast-response"),
+	)
+}
+
+func summarizeToolHeaders(h http.Header) string {
+	var b strings.Builder
+	for _, k := range []string{
+		"x-vsr-selected-decision",
+		"x-vsr-fast-response",
+		"x-vsr-tools-strategy",
+		"x-vsr-tools-confidence",
+		"x-vsr-tools-latency-ms",
+		"x-vsr-injected-system-prompt",
+	} {
+		b.WriteString(fmt.Sprintf("%s=%q ", k, h.Get(k)))
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
@@ -39,6 +39,7 @@ func makeToolsRouter(t *testing.T, reg *tools.Registry) *OpenAIRouter {
 				Tools: config.ToolsConfig{
 					TopK:            2,
 					FallbackToEmpty: true,
+					ToolsDBPath:     "config/tools_db.json",
 				},
 			},
 		},
@@ -164,6 +165,89 @@ func TestRetrieverE2E_NilRegistryFallsBackWithSuffix(t *testing.T) {
 	}
 }
 
+func TestToolSelectionAddModeE2E_InjectsToolsFromRetriever(t *testing.T) {
+	reg := tools.NewRegistry()
+	reg.Register("default", &stubRetriever{
+		strategyID: "default",
+		results:    []tools.ToolSimilarity{sampleTool("get_weather")},
+		confidence: 0.88,
+	})
+
+	router := makeToolsRouter(t, reg)
+
+	req := &openai.ChatCompletionNewParams{}
+	req.ToolChoice.OfAuto.Value = "auto"
+	resp := &ext_proc.ProcessingResponse{}
+
+	err := router.handleToolSelection(req, "Will it rain in Seattle tomorrow?", nil, &resp, &RequestContext{
+		VSRSelectedDecision: &config.Decision{
+			Name: "tool-selection-add",
+			Plugins: []config.DecisionPlugin{
+				mustToolSelectionDecisionPlugin(t, &config.ToolSelectionPluginConfig{
+					Enabled:  true,
+					Mode:     config.ToolSelectionModeAdd,
+					Strategy: "default",
+					TopK:     1,
+				}),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleToolSelection returned unexpected error: %v", err)
+	}
+	if len(req.Tools) != 1 {
+		t.Fatalf("expected add mode to inject 1 tool, got %d", len(req.Tools))
+	}
+	if req.Tools[0].Function.Name != "get_weather" {
+		t.Fatalf("expected injected tool to be get_weather, got %q", req.Tools[0].Function.Name)
+	}
+
+	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
+	if strategyHeader != "default" {
+		t.Fatalf("expected strategy header 'default', got %q", strategyHeader)
+	}
+}
+
+func TestToolSelectionFilterModeE2E_KeepsToolsForEmptyQuery(t *testing.T) {
+	router := makeToolsRouter(t, nil)
+
+	req := &openai.ChatCompletionNewParams{
+		Tools: []openai.ChatCompletionToolParam{
+			{Function: openai.FunctionDefinitionParam{Name: "get_weather"}},
+			{Function: openai.FunctionDefinitionParam{Name: "calculate"}},
+		},
+	}
+	req.ToolChoice.OfAuto.Value = "auto"
+	resp := &ext_proc.ProcessingResponse{}
+
+	err := router.runToolSelectionPluginFilter(
+		req,
+		"",
+		&resp,
+		&RequestContext{VSRSelectedDecision: &config.Decision{Name: "tool-selection-filter"}},
+		&config.ToolSelectionPluginConfig{
+			Enabled:            true,
+			Mode:               config.ToolSelectionModeFilter,
+			RelevanceThreshold: float32Ptr(0.99),
+			PreserveCount:      1,
+		},
+	)
+	if err != nil {
+		t.Fatalf("runToolSelectionPluginFilter returned unexpected error: %v", err)
+	}
+	if len(req.Tools) != 2 {
+		t.Fatalf("expected filter mode to keep 2 tools for empty query, got %d", len(req.Tools))
+	}
+	if req.Tools[0].Function.Name != "get_weather" || req.Tools[1].Function.Name != "calculate" {
+		t.Fatalf("expected original tools to be preserved, got %q and %q", req.Tools[0].Function.Name, req.Tools[1].Function.Name)
+	}
+
+	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
+	if strategyHeader != config.ToolSelectionModeFilter {
+		t.Fatalf("expected strategy header %q, got %q", config.ToolSelectionModeFilter, strategyHeader)
+	}
+}
+
 // mustToolsDecisionPlugin encodes a ToolsPluginConfig into a DecisionPlugin.
 func mustToolsDecisionPlugin(t *testing.T, cfg *config.ToolsPluginConfig) config.DecisionPlugin {
 	t.Helper()
@@ -172,6 +256,19 @@ func mustToolsDecisionPlugin(t *testing.T, cfg *config.ToolsPluginConfig) config
 		t.Fatalf("NewStructuredPayload: %v", err)
 	}
 	return config.DecisionPlugin{Type: config.DecisionPluginTools, Configuration: payload}
+}
+
+func mustToolSelectionDecisionPlugin(t *testing.T, cfg *config.ToolSelectionPluginConfig) config.DecisionPlugin {
+	t.Helper()
+	payload, err := config.NewStructuredPayload(cfg)
+	if err != nil {
+		t.Fatalf("NewStructuredPayload: %v", err)
+	}
+	return config.DecisionPlugin{Type: config.DecisionPluginToolSelection, Configuration: payload}
+}
+
+func float32Ptr(v float32) *float32 {
+	return &v
 }
 
 // getHeaderValue extracts a header value from the ProcessingResponse for assertions.


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes https://github.com/vllm-project/semantic-router/issues/1142

## Purpose

- What does this PR change?

1.Add and integrate tool-selection contract testing.

2.Add tool-selection related routes and data to the AI ​​Gateway test configuration (e2e/profiles/ai-gateway/values.yaml):

3.Add end-to-end test cases (e2e/testcases/tool_selection_e2e.go): covering add, filter, strict threshold, stacked plugins, and PII priority.

4.Supplement extproc side tests (src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go): Add targeted tests for add/filter modes to verify tool injection and policy header behavior.

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
