### PR TITLE
[Router] test: verify conversation DSL trigger can gate tools config

### DIFF
--- a/src/semantic-router/pkg/dsl/taxonomy_dsl_test.go
+++ b/src/semantic-router/pkg/dsl/taxonomy_dsl_test.go
@@ -287,6 +287,65 @@ ROUTE adaptive_tools {
 	assertDynamicRetrievalConfig(t, toolsCfg.DynamicRetrieval)
 }
 
+func TestCompileConversationTriggeredToolsDynamicRetrieval(t *testing.T) {
+	input := `
+SIGNAL conversation multi_turn_tool_flow {
+  feature: {
+    type: "count"
+    source: { type: "assistant_tool_cycle" }
+  }
+  predicate: { gte: 1 }
+}
+
+ROUTE agentic_tools {
+  PRIORITY 180
+  WHEN conversation("multi_turn_tool_flow")
+  MODEL "agent-model"
+  PLUGIN tools {
+    enabled: true
+    mode: "passthrough"
+    semantic_selection: true
+    strategy: "custom"
+    dynamic_retrieval: {
+      enabled: true
+      strategy: "hybrid_history"
+      history_window: 8
+      weights: { semantic: 1.0, history: 0.7, decision_prior: 0.2, repetition_penalty: 0.1 }
+      min_history_confidence: 0.4
+      fallback_on_low_confidence: true
+    }
+  }
+}
+`
+
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("Compile errors: %v", errs)
+	}
+	if len(cfg.ConversationRules) != 1 {
+		t.Fatalf("expected 1 conversation rule, got %d", len(cfg.ConversationRules))
+	}
+	if len(cfg.Decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(cfg.Decisions))
+	}
+
+	decision := cfg.Decisions[0]
+	if decision.Rules.Operator != "AND" || len(decision.Rules.Conditions) != 1 {
+		t.Fatalf("compiled route rules = %+v", decision.Rules)
+	}
+	cond := decision.Rules.Conditions[0]
+	if cond.Type != config.SignalTypeConversation || cond.Name != "multi_turn_tool_flow" {
+		t.Fatalf("WHEN condition = %+v", cond)
+	}
+
+	toolsCfg := decision.GetToolsConfig()
+	if toolsCfg == nil {
+		t.Fatal("expected tools plugin")
+	}
+	assertToolsPluginStrategy(t, toolsCfg)
+	assertDynamicRetrievalConfig(t, toolsCfg.DynamicRetrieval)
+}
+
 func assertToolsPluginStrategy(t *testing.T, cfg *config.ToolsPluginConfig) {
 	t.Helper()
 

--- a/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
@@ -7,7 +7,9 @@ import (
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/openai/openai-go"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/dsl"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
 )
 
@@ -161,6 +163,119 @@ func TestRetrieverE2E_NilRegistryFallsBackWithSuffix(t *testing.T) {
 	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
 	if strategyHeader != "embedding-fallback" {
 		t.Errorf("expected strategy header 'embedding-fallback', got %q", strategyHeader)
+	}
+}
+
+func TestRetrieverE2E_ConversationTriggeredRouteAppliesToolsStrategy(t *testing.T) {
+	compiled, errs := dsl.Compile(`
+SIGNAL conversation multi_turn_tool_flow {
+  feature: {
+    type: "count"
+    source: { type: "assistant_tool_cycle" }
+  }
+  predicate: { gte: 1 }
+}
+
+ROUTE agentic_tools {
+  PRIORITY 180
+  WHEN conversation("multi_turn_tool_flow")
+  MODEL "agent-model"
+  PLUGIN tools {
+    enabled: true
+    mode: "passthrough"
+    semantic_selection: true
+    strategy: "custom"
+    dynamic_retrieval: {
+      enabled: true
+      strategy: "hybrid_history"
+      history_window: 8
+    }
+  }
+}
+`)
+	if len(errs) > 0 {
+		t.Fatalf("Compile errors: %v", errs)
+	}
+
+	reg := tools.NewRegistry()
+	reg.Register("custom", &stubRetriever{
+		strategyID: "custom",
+		results:    []tools.ToolSimilarity{sampleTool("search"), sampleTool("calculate")},
+		confidence: 0.95,
+	})
+
+	router := makeToolsRouter(t, reg)
+	router.Config.ConversationRules = compiled.ConversationRules
+	router.Config.Decisions = compiled.Decisions
+	router.Classifier = &classification.Classifier{Config: router.Config}
+
+	req := &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("Find the deployment runbook."),
+			assistantToolCallMessage("search_docs"),
+			openai.ToolMessage("deployment runbook content", "call-search-docs"),
+			openai.UserMessage("Summarize the deployment steps."),
+		},
+	}
+	req.ToolChoice.OfAuto.Value = "auto"
+
+	ctx := &RequestContext{
+		Headers:   map[string]string{},
+		RequestID: "conversation-triggered-tools",
+	}
+
+	history := extractSignalConversationHistory(req)
+	signalInput := router.prepareSignalEvaluationInput(history)
+
+	signals, err := router.evaluateSignalsForDecision("auto", signalInput, history.nonUserMessages, ctx)
+	if err != nil {
+		t.Fatalf("evaluateSignalsForDecision returned unexpected error: %v", err)
+	}
+	if len(signals.MatchedConversationRules) != 1 || signals.MatchedConversationRules[0] != "multi_turn_tool_flow" {
+		t.Fatalf("matched conversation rules = %v, want [multi_turn_tool_flow]", signals.MatchedConversationRules)
+	}
+
+	result, fallbackModel := router.runDecisionEngine("auto", ctx, signals)
+	if fallbackModel != "" {
+		t.Fatalf("expected no fallback model, got %q", fallbackModel)
+	}
+	if result == nil || result.Decision == nil {
+		t.Fatal("expected a matched decision")
+	}
+	if result.Decision.Name != "agentic_tools" {
+		t.Fatalf("matched decision = %q, want agentic_tools", result.Decision.Name)
+	}
+
+	router.applyDecisionResultToContext(result, ctx)
+
+	toolsCfg := ctx.VSRSelectedDecision.GetToolsConfig()
+	if toolsCfg == nil {
+		t.Fatal("selected decision missing tools config")
+	}
+	if toolsCfg.EffectiveStrategy() != "custom" {
+		t.Fatalf("tools strategy = %q, want custom", toolsCfg.EffectiveStrategy())
+	}
+	if !toolsCfg.DynamicRetrievalEnabled() {
+		t.Fatal("expected dynamic retrieval to remain attached to the selected decision")
+	}
+
+	userContent, nonUserMessages := extractUserAndNonUserContent(req)
+	resp := &ext_proc.ProcessingResponse{}
+	err = router.handleToolSelection(req, userContent, nonUserMessages, &resp, ctx)
+	if err != nil {
+		t.Fatalf("handleToolSelection returned unexpected error: %v", err)
+	}
+
+	if len(req.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(req.Tools))
+	}
+	if req.Tools[0].Function.Name != "search" {
+		t.Fatalf("expected first tool to be search, got %q", req.Tools[0].Function.Name)
+	}
+
+	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
+	if strategyHeader != "custom" {
+		t.Fatalf("expected strategy header custom, got %q", strategyHeader)
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_retriever_e2e_test.go
@@ -167,6 +167,57 @@ func TestRetrieverE2E_NilRegistryFallsBackWithSuffix(t *testing.T) {
 }
 
 func TestRetrieverE2E_ConversationTriggeredRouteAppliesToolsStrategy(t *testing.T) {
+	router := makeConversationTriggeredToolsRouter(t)
+	req := newConversationTriggeredToolsRequest()
+	ctx := &RequestContext{
+		Headers:   map[string]string{},
+		RequestID: "conversation-triggered-tools",
+	}
+
+	assertConversationTriggeredDecisionMatch(t, router, req, ctx)
+
+	userContent, nonUserMessages := extractUserAndNonUserContent(req)
+	resp := &ext_proc.ProcessingResponse{}
+	err := router.handleToolSelection(req, userContent, nonUserMessages, &resp, ctx)
+	if err != nil {
+		t.Fatalf("handleToolSelection returned unexpected error: %v", err)
+	}
+
+	if len(req.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(req.Tools))
+	}
+	if req.Tools[0].Function.Name != "search" {
+		t.Fatalf("expected first tool to be search, got %q", req.Tools[0].Function.Name)
+	}
+
+	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
+	if strategyHeader != "custom" {
+		t.Fatalf("expected strategy header custom, got %q", strategyHeader)
+	}
+}
+
+func makeConversationTriggeredToolsRouter(t *testing.T) *OpenAIRouter {
+	t.Helper()
+
+	compiled := mustCompileConversationTriggeredToolsDSL(t)
+
+	reg := tools.NewRegistry()
+	reg.Register("custom", &stubRetriever{
+		strategyID: "custom",
+		results:    []tools.ToolSimilarity{sampleTool("search"), sampleTool("calculate")},
+		confidence: 0.95,
+	})
+
+	router := makeToolsRouter(t, reg)
+	router.Config.ConversationRules = compiled.ConversationRules
+	router.Config.Decisions = compiled.Decisions
+	router.Classifier = &classification.Classifier{Config: router.Config}
+	return router
+}
+
+func mustCompileConversationTriggeredToolsDSL(t *testing.T) *config.RouterConfig {
+	t.Helper()
+
 	compiled, errs := dsl.Compile(`
 SIGNAL conversation multi_turn_tool_flow {
   feature: {
@@ -196,19 +247,10 @@ ROUTE agentic_tools {
 	if len(errs) > 0 {
 		t.Fatalf("Compile errors: %v", errs)
 	}
+	return compiled
+}
 
-	reg := tools.NewRegistry()
-	reg.Register("custom", &stubRetriever{
-		strategyID: "custom",
-		results:    []tools.ToolSimilarity{sampleTool("search"), sampleTool("calculate")},
-		confidence: 0.95,
-	})
-
-	router := makeToolsRouter(t, reg)
-	router.Config.ConversationRules = compiled.ConversationRules
-	router.Config.Decisions = compiled.Decisions
-	router.Classifier = &classification.Classifier{Config: router.Config}
-
+func newConversationTriggeredToolsRequest() *openai.ChatCompletionNewParams {
 	req := &openai.ChatCompletionNewParams{
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage("Find the deployment runbook."),
@@ -218,11 +260,16 @@ ROUTE agentic_tools {
 		},
 	}
 	req.ToolChoice.OfAuto.Value = "auto"
+	return req
+}
 
-	ctx := &RequestContext{
-		Headers:   map[string]string{},
-		RequestID: "conversation-triggered-tools",
-	}
+func assertConversationTriggeredDecisionMatch(
+	t *testing.T,
+	router *OpenAIRouter,
+	req *openai.ChatCompletionNewParams,
+	ctx *RequestContext,
+) {
+	t.Helper()
 
 	history := extractSignalConversationHistory(req)
 	signalInput := router.prepareSignalEvaluationInput(history)
@@ -257,25 +304,6 @@ ROUTE agentic_tools {
 	}
 	if !toolsCfg.DynamicRetrievalEnabled() {
 		t.Fatal("expected dynamic retrieval to remain attached to the selected decision")
-	}
-
-	userContent, nonUserMessages := extractUserAndNonUserContent(req)
-	resp := &ext_proc.ProcessingResponse{}
-	err = router.handleToolSelection(req, userContent, nonUserMessages, &resp, ctx)
-	if err != nil {
-		t.Fatalf("handleToolSelection returned unexpected error: %v", err)
-	}
-
-	if len(req.Tools) != 2 {
-		t.Fatalf("expected 2 tools, got %d", len(req.Tools))
-	}
-	if req.Tools[0].Function.Name != "search" {
-		t.Fatalf("expected first tool to be search, got %q", req.Tools[0].Function.Name)
-	}
-
-	strategyHeader := getHeaderValue(resp, "x-vsr-tools-strategy")
-	if strategyHeader != "custom" {
-		t.Fatalf("expected strategy header custom, got %q", strategyHeader)
 	}
 }
 


### PR DESCRIPTION
Related to the follow-up review question on the DSL support work.

## Purpose

- Add focused tests to check whether an existing DSL trigger, `conversation(...)`, can gate route-local `tools` config.
- Add one DSL compile test and one extproc integration test for that flow.
- Affected module(s): `Router`

## Test Plan

```
cd src/semantic-router
go test -v ./pkg/dsl -run 'TestCompileToolsPluginDynamicRetrieval$|TestCompileConversationTriggeredToolsDynamicRetrieval$'

LD_LIBRARY_PATH=/home/shelton/Github/semantic-router/candle-binding/target/release:/home/shelton/Github/semantic-router/ml-binding/target/release:/home/shelton/Github/semantic-router/nlp-binding/target/release \
go test -v ./pkg/extproc -run 'TestRetrieverE2E_RegisteredStrategyToolsReachRequest$|TestRetrieverE2E_ConversationTriggeredRouteAppliesToolsStrategy$'
```

## Test Result
- The focused DSL tests passed locally.
- The focused extproc tests passed locally.
- This verifies that an existing DSL trigger can gate route-local tools config, but does not prove full runtime activation of the dynamic_retrieval / hybrid_history path itself.