### PR TITLE
fix(precommit): add python3-venv so agent-pr-gate works locally

### DIFF
--- a/tools/docker/Dockerfile.precommit
+++ b/tools/docker/Dockerfile.precommit
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     shellcheck \
     python3 \
     python3-pip \
+    python3-venv \
     libssl-dev \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

The precommit Docker image installs `python3` and `python3-pip` but not `python3-venv`. `python3-venv` is a separate apt package on Debian that provides the `ensurepip` module needed by `python3 -m venv`. Without it, `make agent-bootstrap` (called by `make precommit-local` and `make agent-pr-gate`) fails inside the container.

## Diagnosis

Run against the published upstream image:

```
$ docker run --rm ghcr.io/vllm-project/semantic-router/precommit:latest \
    python3 -c 'import ensurepip'
ModuleNotFoundError: No module named 'ensurepip'

$ docker run --rm ghcr.io/vllm-project/semantic-router/precommit:latest \
    dpkg -l | grep -E "python3-venv|ensurepip"
(no python3-venv package installed)
```

The container's own Python tooling sidesteps this by installing system-wide with `PIP_BREAK_SYSTEM_PACKAGES=1` (Dockerfile.precommit line 5), but `make agent-bootstrap` mounted from the host genuinely needs venv support to create the harness venv at `/app/.venv-agent`. The error a contributor sees:

```
Creating /app/.venv-agent...
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt install python3.13-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.
```

## Fix

Add `python3-venv` to the apt install line. One line.

## Verification

Built the image locally with this change and confirmed:

- `python3 -c 'import ensurepip'` succeeds (`/usr/lib/python3.13/ensurepip/__init__.py`)
- `python3 -m venv /tmp/x` creates a working venv (Python 3.13.5)
- `dpkg -l | grep python3` now lists `python3-venv` and `python3.13-venv` (the latter pulled in as a dependency)
- `make PRECOMMIT_CONTAINER=<locally-built-fixed-image> precommit-local` advances past `agent-bootstrap` (previously died there at `agent-venv-install`)

## Impact

Unblocks `make agent-pr-gate` and `make precommit-local` for any contributor running them locally. No behavior change for CI: GHA runners install Python via `actions/setup-python` before any container interaction, so the bug is invisible on the CI path. This is purely a local-developer-experience fix.