### PR TITLE
[Operator] Validate embedding modality contracts on IntelligentRoute reconcile

### DIFF
--- a/docs/agent/tech-debt/README.md
+++ b/docs/agent/tech-debt/README.md
@@ -78,6 +78,7 @@ Keep the numeric index unique within `docs/agent/tech-debt/`.
 - [TD037 Dev Integration Environment Ownership and Shared-Suite Topology Still Diverge Across CLI, Kind, and CI](td-037-dev-integration-env-ownership-and-shared-suite-topology.md)
 - [TD038 Custom Chat Completions Structs Duplicate Official OpenAI SDK Types](td-038-custom-chat-completions-structs.md)
 - [TD039 Control Planes Still Depend on Router Runtime Internals Instead of Contract-Owned Seams](td-039-control-plane-contract-ownership-collapse.md)
+- [TD040 Kubernetes Reconcile Path Skips File-Config Family Validators](td-040-reconcile-path-skips-family-validators.md)
 
 ## Architecture Review Coverage Map
 

--- a/docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md
+++ b/docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md
@@ -42,3 +42,16 @@ Either way, the embedding-modality wrapper exported by the slice PR remains vali
 - `Reconciler.validateAndUpdate` no longer needs to call individual exported validators (or, equivalently, the exported validators become internal again because the dispatch covers them).
 - The test pattern in `reconciler_embedding_modality_test.go` is replaced by a single dispatch-level test that asserts every K8s-safe contract fires on the reconcile path, with the per-family unit tests remaining the source of truth for branch coverage.
 - Validators currently skipped on the K8s path that need to be re-enabled: `validateDomainContracts`, `validateStructureContracts`, `validateReaskContracts`, `validateProjectionContracts`, `validateKnowledgeBaseContracts`, `validateConversationContracts`, `validateDecisionContracts` (insofar as it applies to non-CRD-shape concerns), `validateModalityContracts`, `validateModelSelectionConfig`, `validateAdvancedToolFilteringConfig`. Per-family applicability should be confirmed during the unification design pass.
+
+## Recipe for closing another slice (template established by the embedding slice)
+
+The unification path described in Desired End State above is the preferred end state. Until that lands, slices can be closed incrementally with the mirror-per-slice pattern this debt entry's first slice established. To close another family validator's slice on the K8s reconcile path:
+
+1. In `pkg/config/validator_<family>.go`, export a wrapper that mirrors the private validator 1:1: `ValidateXContracts(cfg *RouterConfig) error`. Match the `validate(cfg)` shape used by every other family validator in `validator.go`'s dispatch table so the K8s call site reads the same as the file-config dispatch.
+2. Call it from `Reconciler.validateAndUpdate` in `pkg/k8s/reconciler.go` after `ParseYAMLBytes` returns and `ConfigSource = ConfigSourceKubernetes` is set, before `onConfigUpdate`.
+3. On validation failure, mark pool and route `Ready=False, Reason=ValidationFailed` mirroring the existing pattern in `validateAndUpdate` and return a `fmt.Errorf %w`-wrapped error so callers can `errors.Unwrap` to retrieve the underlying validator error.
+4. Add a reconciler-level integration test mirroring `pkg/k8s/reconciler_embedding_modality_test.go`. Use controller-runtime's `fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(...).WithObjects(pool, route).Build()` to drive a real `Reconciler.validateAndUpdate` call, then assert both the returned error AND the persisted Ready conditions on both refetched CRs. Verify the load-bearing property by removing the new validation block and confirming the rejection cases fail.
+5. Update this entry's "Validators currently skipped" list above to remove the slice you closed.
+6. When all listed validators are closed via this pattern (or the unification path lands), close TD040 per `tech-debt/README.md`'s retirement policy.
+
+The mirror-per-slice path is acceptable for incremental closure but is not the desired end state. If a unification PR (selective early-return or per-validator opt-in) is feasible, that is preferred over N more mirror-PRs.

--- a/docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md
+++ b/docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md
@@ -1,0 +1,44 @@
+# TD040: Kubernetes Reconcile Path Skips File-Config Family Validators
+
+## Status
+
+Open
+
+## Scope
+
+`pkg/config` validator dispatch and `pkg/k8s` reconciler integration
+
+## Summary
+
+`validateConfigStructure` in `src/semantic-router/pkg/config/validator.go` early-returns when `cfg.ConfigSource == ConfigSourceKubernetes`, skipping every per-family validator the file-config path runs. The early-return was originally added because `decisions` and `model_config` are loaded from CRDs in K8s mode and the file-config-shape assertions did not apply to them. The unintended consequence is that contract validators which DO apply equally to both sources are also skipped on the K8s reconcile path. CRD-loaded configs can therefore be admitted and marked Ready when the same configuration loaded from file would be rejected.
+
+PR #1880's review surfaced one slice of this gap (embedding-modality contracts). The follow-up PR closes the embedding slice by exporting `ValidateEmbeddingContracts` from `pkg/config` and calling it explicitly from `Reconciler.validateAndUpdate` after `ParseYAMLBytes`. The remaining family validators that the early-return still bypasses on the K8s path are tracked here.
+
+## Evidence
+
+- [src/semantic-router/pkg/config/validator.go](../../../src/semantic-router/pkg/config/validator.go) lines 89-119: `validateConfigStructure` early-return at lines 93-95; the validator dispatch table at lines 100-112 enumerates every family validator skipped when the early-return fires.
+- [src/semantic-router/pkg/k8s/reconciler.go](../../../src/semantic-router/pkg/k8s/reconciler.go): `validateAndUpdate` invokes `config.ParseYAMLBytes` (which calls `validateConfigStructure`) on the K8s reconcile path; the embedding-modality slice is now applied directly after `ParseYAMLBytes` returns.
+- [src/semantic-router/pkg/config/validator_embedding.go](../../../src/semantic-router/pkg/config/validator_embedding.go): the embedding-modality validator and the exported `ValidateEmbeddingContracts` wrapper the embedding-slice PR added.
+- [src/semantic-router/pkg/k8s/reconciler_embedding_modality_test.go](../../../src/semantic-router/pkg/k8s/reconciler_embedding_modality_test.go): the reconcile-path test that exercises the embedding slice through a real `Reconciler.validateAndUpdate` call.
+
+## Why It Matters
+
+- The K8s reconcile path is the operator-mode entrypoint. Every CRD that contradicts a runtime contract the validator can detect should be marked `Ready=False` with a clear message, not admitted silently.
+- The validators currently skipped each protect a real invariant (domain coverage, projection consistency, knowledge-base wiring, conversation rules, decision graph integrity, modality contracts, model-selection consistency, tool-filtering consistency). A contributor who ships any of these contracts via CRDs gets the same false-Ready failure mode rootfs identified for embedding modality on PR #1880.
+- One-off mirroring per validator (the pattern the embedding-slice PR uses) does not scale. As file-config validators evolve, the K8s reconcile path will keep drifting unless the dispatch is unified.
+
+## Desired End State
+
+A single dispatch surface that runs every K8s-safe family validator on both code paths. Two design directions are plausible; either retires the gap:
+
+- **Selective early-return**: split `validateConfigStructure` into a Kubernetes-safe subset (everything except `decisions` and `model_config` shape checks) and a file-only subset. K8s reconcile calls the safe subset; file-config calls both.
+- **Per-validator opt-in**: tag each family validator with a `KubernetesSafe bool` (or move them into separate dispatch lists). `validateConfigStructure` runs the right list based on `ConfigSource`.
+
+Either way, the embedding-modality wrapper exported by the slice PR remains valid as a public seam for callers that want to validate a single contract without dispatching the whole set.
+
+## Exit Criteria
+
+- The K8s reconcile path runs the same family-validator surface that file-config does, except for the explicitly-K8s-incompatible cases (`decisions`, `model_config` shape) which are documented and tagged.
+- `Reconciler.validateAndUpdate` no longer needs to call individual exported validators (or, equivalently, the exported validators become internal again because the dispatch covers them).
+- The test pattern in `reconciler_embedding_modality_test.go` is replaced by a single dispatch-level test that asserts every K8s-safe contract fires on the reconcile path, with the per-family unit tests remaining the source of truth for branch coverage.
+- Validators currently skipped on the K8s path that need to be re-enabled: `validateDomainContracts`, `validateStructureContracts`, `validateReaskContracts`, `validateProjectionContracts`, `validateKnowledgeBaseContracts`, `validateConversationContracts`, `validateDecisionContracts` (insofar as it applies to non-CRD-shape concerns), `validateModalityContracts`, `validateModelSelectionConfig`, `validateAdvancedToolFilteringConfig`. Per-family applicability should be confirmed during the unification design pass.

--- a/src/semantic-router/pkg/config/validator_embedding.go
+++ b/src/semantic-router/pkg/config/validator_embedding.go
@@ -16,6 +16,20 @@ func validateEmbeddingContracts(cfg *RouterConfig) error {
 	return validateEmbeddingRuleModalities(cfg.EmbeddingRules, cfg.EmbeddingModels.EmbeddingConfig.ModelType)
 }
 
+// ValidateEmbeddingContracts is the exported counterpart of the private
+// validateEmbeddingContracts function. It exists so packages outside pkg/config
+// (notably the reconciler in pkg/k8s) can apply the embedding-modality
+// contract directly, since validateConfigStructure short-circuits on
+// ConfigSource == ConfigSourceKubernetes and would otherwise let CRD-loaded
+// configs skip a contract that file-loaded configs are held to.
+//
+// The signature mirrors the private function 1:1 and the call site reads
+// ValidateEmbeddingContracts(cfg) so the contract has a single canonical
+// shape regardless of source.
+func ValidateEmbeddingContracts(cfg *RouterConfig) error {
+	return validateEmbeddingContracts(cfg)
+}
+
 // validateEmbeddingRuleModalities checks every embedding rule's declared
 // query_modality is recognized and compatible with the configured embedding
 // model. Returns a non-nil error listing every misconfigured rule, or nil
@@ -28,9 +42,8 @@ func validateEmbeddingContracts(cfg *RouterConfig) error {
 //     in mismatched spaces.
 //   - "audio": rejected at config-load with a clear "planned" message. The
 //     schema accepts the value so future configs do not need to migrate, but
-//     the candle-binding MultiModalEncodeAudioFromBase64 FFI is not yet
-//     exposed, so any rule declaring audio cannot be served and is loud-failed
-//     early.
+//     the audio FFI is not yet exposed by candle-binding, so any rule
+//     declaring audio cannot be served and is loud-failed early.
 //   - any other value: rejected as an unknown modality so a typo like "imag"
 //     cannot silently drop a rule out of every classification path.
 func validateEmbeddingRuleModalities(rules []EmbeddingRule, modelType string) error {
@@ -50,7 +63,7 @@ func validateEmbeddingRuleModalities(rules []EmbeddingRule, modelType string) er
 			}
 		case QueryModalityAudio:
 			problems = append(problems, fmt.Sprintf(
-				"embedding rule %q declares query_modality=audio, but the audio FFI (MultiModalEncodeAudioFromBase64) is not yet exposed by candle-binding. Audio query support is planned; remove the rule or set query_modality to text/image until the FFI lands",
+				"embedding rule %q declares query_modality=audio, but the audio FFI is not yet exposed by candle-binding. Audio query support is planned; remove the rule or set query_modality to text/image until the FFI lands",
 				rule.Name))
 		default:
 			problems = append(problems, fmt.Sprintf(

--- a/src/semantic-router/pkg/config/validator_embedding_test.go
+++ b/src/semantic-router/pkg/config/validator_embedding_test.go
@@ -51,7 +51,7 @@ func TestValidateEmbeddingRuleModalities_RejectsAudioWithComingLaterMessage(t *t
 		t.Fatal("expected error for audio rule (FFI not yet wired), got nil")
 	}
 	msg := err.Error()
-	for _, want := range []string{"rig_walkie_talkie_audio", "MultiModalEncodeAudioFromBase64", "planned"} {
+	for _, want := range []string{"rig_walkie_talkie_audio", "audio FFI", "planned"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error should contain %q, got: %s", want, msg)
 		}
@@ -128,6 +128,38 @@ func TestValidateEmbeddingContracts_RoutesThroughTopLevelConfig(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "img_rule") {
 		t.Errorf("error should name the offending rule, got: %s", err.Error())
+	}
+}
+
+// TestValidateEmbeddingContracts_ExportedWrapperMatchesInternal confirms the
+// exported wrapper added for the K8s reconcile path forwards to the same
+// private function the file-config path uses. Branch coverage is owned by
+// the TestValidateEmbeddingRuleModalities_* and
+// TestValidateEmbeddingContracts_* tests above; this single case exists only
+// to fail loudly if the wrapper ever drifts from the private function.
+func TestValidateEmbeddingContracts_ExportedWrapperMatchesInternal(t *testing.T) {
+	cfg := &RouterConfig{
+		IntelligentRouting: IntelligentRouting{
+			Signals: Signals{
+				EmbeddingRules: []EmbeddingRule{
+					{Name: "img_rule", Candidates: []string{"x"}, QueryModality: QueryModalityImage},
+				},
+			},
+		},
+		InlineModels: InlineModels{
+			EmbeddingModels: EmbeddingModels{
+				EmbeddingConfig: HNSWConfig{ModelType: "qwen3"},
+			},
+		},
+	}
+	exportedErr := ValidateEmbeddingContracts(cfg)
+	internalErr := validateEmbeddingContracts(cfg)
+	if (exportedErr == nil) != (internalErr == nil) {
+		t.Fatalf("exported wrapper diverged from internal: exported=%v internal=%v", exportedErr, internalErr)
+	}
+	if exportedErr != nil && exportedErr.Error() != internalErr.Error() {
+		t.Errorf("exported wrapper error text drifted from internal:\n  exported: %s\n  internal: %s",
+			exportedErr.Error(), internalErr.Error())
 	}
 }
 

--- a/src/semantic-router/pkg/k8s/reconciler.go
+++ b/src/semantic-router/pkg/k8s/reconciler.go
@@ -263,6 +263,19 @@ func (r *Reconciler) validateAndUpdate(ctx context.Context, pool *v1alpha1.Intel
 	}
 	newConfig.ConfigSource = config.ConfigSourceKubernetes
 
+	// When staticConfig.ConfigSource is ConfigSourceKubernetes (the
+	// operator-mode default), the canonical bytes inherit that value
+	// and ParseYAMLBytes's call to validateConfigStructure early-returns
+	// before the per-family validators fire. Apply the embedding contract
+	// directly here so the K8s path holds CRDs to the same contract
+	// file-config holds files to. See td-040 for the broader gap this
+	// slice closes.
+	if err := config.ValidateEmbeddingContracts(newConfig); err != nil {
+		r.updatePoolStatus(ctx, pool, metav1.ConditionFalse, "ValidationFailed", err.Error())
+		r.updateRouteStatus(ctx, route, metav1.ConditionFalse, "ValidationFailed", err.Error())
+		return fmt.Errorf("embedding modality validation failed: %w", err)
+	}
+
 	// Call update callback
 	if r.onConfigUpdate != nil {
 		if err := r.onConfigUpdate(newConfig); err != nil {

--- a/src/semantic-router/pkg/k8s/reconciler_embedding_modality_test.go
+++ b/src/semantic-router/pkg/k8s/reconciler_embedding_modality_test.go
@@ -1,0 +1,332 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/apis/vllm.ai/v1alpha1"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestReconcileEmbeddingModalityValidation drives a real Reconciler instance
+// through validateAndUpdate using controller-runtime's fake client, verifying
+// that the embedding-modality contract is enforced on the K8s reconcile path
+// (the gap rootfs identified in PR #1880's review).
+//
+// This test must not pass if the validation block in
+// reconciler.go::validateAndUpdate is removed; that property is what makes
+// it the load-bearing artifact for the contract this PR adds.
+//
+// TODO: once an embedding-modality e2e profile lands (#1881), consider
+// migrating to the fixture-driven pattern used by
+// dynamic_config_regression_test.go.
+func TestReconcileEmbeddingModalityValidation(t *testing.T) {
+	cases := []reconcileEmbeddingModalityCase{
+		{
+			name:              "AudioRejected",
+			queryModality:     "audio",
+			ruleName:          "audio_rule_under_test",
+			baseModelType:     "multimodal",
+			wantValidationErr: true,
+			errSubstrings:     []string{"audio_rule_under_test", "audio FFI", "planned"},
+		},
+		{
+			name:              "ImageWithoutMultimodalRejected",
+			queryModality:     "image",
+			ruleName:          "image_rule_under_test",
+			baseModelType:     "qwen3",
+			wantValidationErr: true,
+			errSubstrings:     []string{"image_rule_under_test", "model_type=multimodal"},
+		},
+		{
+			name:              "ImageWithMultimodalAccepted",
+			queryModality:     "image",
+			ruleName:          "image_rule_under_test",
+			baseModelType:     "multimodal",
+			wantValidationErr: false,
+		},
+		{
+			name:              "TextOnlyAccepted",
+			queryModality:     "text",
+			ruleName:          "text_rule_under_test",
+			baseModelType:     "qwen3",
+			wantValidationErr: false,
+		},
+		{
+			// The legacy backward-compat path: rules authored before #1880
+			// omit queryModality entirely. EffectiveQueryModality resolves
+			// "" to text downstream, so the validator must accept this
+			// regardless of the configured embedding model_type. Regression
+			// canary for every IntelligentRoute that predates the field.
+			name:              "OmittedModalityAccepted",
+			queryModality:     "",
+			ruleName:          "omitted_modality_rule_under_test",
+			baseModelType:     "qwen3",
+			wantValidationErr: false,
+		},
+		{
+			name:              "UnknownModalityRejected",
+			queryModality:     "imag",
+			ruleName:          "unknown_modality_rule_under_test",
+			baseModelType:     "multimodal",
+			wantValidationErr: true,
+			errSubstrings:     []string{"unknown_modality_rule_under_test", "unknown query_modality"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runReconcileEmbeddingModalityCase(t, tc)
+		})
+	}
+}
+
+// reconcileEmbeddingModalityCase is one row in the embedding-modality
+// reconcile-path validation table. ruleName is named explicitly per case
+// so the OmittedModalityAccepted case (queryModality = "") still has a
+// meaningful rule name and so the per-case names cannot drift away from
+// the substrings the assertion table expects.
+type reconcileEmbeddingModalityCase struct {
+	name              string
+	queryModality     string
+	ruleName          string
+	baseModelType     string
+	wantValidationErr bool
+	errSubstrings     []string
+}
+
+// runReconcileEmbeddingModalityCase builds a Reconciler with a fake K8s
+// client, runs validateAndUpdate, and asserts the returned error and the
+// status conditions on the reconciled pool and route.
+func runReconcileEmbeddingModalityCase(t *testing.T, tc reconcileEmbeddingModalityCase) {
+	t.Helper()
+
+	const namespace = "default"
+	pool := buildEmbeddingModalityPool(namespace)
+	route := buildEmbeddingModalityRoute(namespace, tc.ruleName, tc.queryModality)
+	staticConfig := buildEmbeddingModalityStaticConfig(tc.baseModelType)
+
+	reconciler := buildEmbeddingModalityReconciler(t, namespace, staticConfig, pool, route)
+	gotErr := reconciler.validateAndUpdate(context.Background(), pool, route)
+
+	assertEmbeddingModalityResult(t, tc, gotErr)
+	assertEmbeddingModalityStatus(t, reconciler, namespace, tc)
+}
+
+// buildEmbeddingModalityPool returns a minimal IntelligentPool sufficient
+// for the converter and the downstream embedding-modality validation.
+func buildEmbeddingModalityPool(namespace string) *v1alpha1.IntelligentPool {
+	return &v1alpha1.IntelligentPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "embedding-modality-pool",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.IntelligentPoolSpec{
+			DefaultModel: "deepseek-v3",
+			Models: []v1alpha1.ModelConfig{
+				{Name: "deepseek-v3"},
+			},
+		},
+	}
+}
+
+// buildEmbeddingModalityRoute returns a minimal IntelligentRoute carrying
+// exactly one EmbeddingSignal with the requested QueryModality, plus a
+// matching decision so the converter has a complete graph to translate.
+func buildEmbeddingModalityRoute(namespace, ruleName, queryModality string) *v1alpha1.IntelligentRoute {
+	return &v1alpha1.IntelligentRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "embedding-modality-route",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.IntelligentRouteSpec{
+			Signals: v1alpha1.Signals{
+				Embeddings: []v1alpha1.EmbeddingSignal{
+					{
+						Name:              ruleName,
+						Threshold:         0.7,
+						Candidates:        []string{"anchor phrase"},
+						AggregationMethod: "max",
+						QueryModality:     queryModality,
+					},
+				},
+			},
+			Decisions: []v1alpha1.Decision{
+				{
+					Name:     "decision_under_test",
+					Priority: 100,
+					Signals: v1alpha1.SignalCombination{
+						Operator: "AND",
+						Conditions: []v1alpha1.SignalCondition{
+							{Type: "embedding", Name: ruleName},
+						},
+					},
+					ModelRefs: []v1alpha1.ModelRef{
+						{Model: "deepseek-v3"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildEmbeddingModalityStaticConfig returns the static base RouterConfig
+// the operator would supply to the reconciler. ConfigSource is set to
+// Kubernetes to mirror operator-mode bootstrap, which is the path where
+// validateConfigStructure early-returns and PR-C closes the resulting gap.
+func buildEmbeddingModalityStaticConfig(modelType string) *config.RouterConfig {
+	return &config.RouterConfig{
+		ConfigSource: config.ConfigSourceKubernetes,
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				EmbeddingConfig: config.HNSWConfig{
+					ModelType: modelType,
+				},
+			},
+		},
+	}
+}
+
+// buildEmbeddingModalityReconciler wires a Reconciler around a fake K8s
+// client preloaded with the pool and route under test. Status subresources
+// for both CRDs are explicitly registered so updatePoolStatus and
+// updateRouteStatus exercise the same Status().Update path the controller
+// uses in production.
+func buildEmbeddingModalityReconciler(
+	t *testing.T,
+	namespace string,
+	staticConfig *config.RouterConfig,
+	pool *v1alpha1.IntelligentPool,
+	route *v1alpha1.IntelligentRoute,
+) *Reconciler {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.IntelligentPool{}, &v1alpha1.IntelligentRoute{}).
+		WithObjects(pool, route).
+		Build()
+
+	return &Reconciler{
+		client:         fakeClient,
+		scheme:         scheme,
+		namespace:      namespace,
+		converter:      NewCRDConverter(),
+		staticConfig:   staticConfig,
+		onConfigUpdate: func(*config.RouterConfig) error { return nil },
+	}
+}
+
+// assertEmbeddingModalityResult applies the case's expectations to the
+// validateAndUpdate return value. The accepted cases must return nil; the
+// rejected cases must return a wrapped embedding-validation error whose
+// message contains every named substring.
+func assertEmbeddingModalityResult(t *testing.T, tc reconcileEmbeddingModalityCase, gotErr error) {
+	t.Helper()
+
+	if !tc.wantValidationErr {
+		if gotErr != nil {
+			t.Fatalf("validateAndUpdate: expected no error for %s + model_type=%s, got: %v",
+				tc.queryModality, tc.baseModelType, gotErr)
+		}
+		return
+	}
+
+	if gotErr == nil {
+		t.Fatalf("validateAndUpdate: expected error, got nil")
+	}
+
+	const wantPrefix = "embedding modality validation failed:"
+	if !strings.HasPrefix(gotErr.Error(), wantPrefix) {
+		t.Errorf("error should start with %q so callers can pattern-match the failure class, got: %s",
+			wantPrefix, gotErr.Error())
+	}
+
+	if errors.Unwrap(gotErr) == nil {
+		t.Error("error should wrap the underlying validator error via fmt.Errorf %w so errors.Unwrap can retrieve it")
+	}
+
+	for _, want := range tc.errSubstrings {
+		if !strings.Contains(gotErr.Error(), want) {
+			t.Errorf("error should contain %q, got: %s", want, gotErr.Error())
+		}
+	}
+}
+
+// assertEmbeddingModalityStatus re-fetches the reconciled pool and route
+// from the fake client and asserts the Ready condition matches the expected
+// admission outcome. Validation failures must mark both CRs Ready=False
+// with Reason=ValidationFailed; accepted configs must mark both Ready=True.
+func assertEmbeddingModalityStatus(
+	t *testing.T,
+	reconciler *Reconciler,
+	namespace string,
+	tc reconcileEmbeddingModalityCase,
+) {
+	t.Helper()
+
+	wantStatus := metav1.ConditionTrue
+	wantReason := "Ready"
+	if tc.wantValidationErr {
+		wantStatus = metav1.ConditionFalse
+		wantReason = "ValidationFailed"
+	}
+
+	ctx := context.Background()
+	var refetchedPool v1alpha1.IntelligentPool
+	if err := reconciler.client.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      "embedding-modality-pool",
+	}, &refetchedPool); err != nil {
+		t.Fatalf("Get pool after reconcile: %v", err)
+	}
+	assertReadyCondition(t, "pool", refetchedPool.Status.Conditions, wantStatus, wantReason)
+
+	var refetchedRoute v1alpha1.IntelligentRoute
+	if err := reconciler.client.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      "embedding-modality-route",
+	}, &refetchedRoute); err != nil {
+		t.Fatalf("Get route after reconcile: %v", err)
+	}
+	assertReadyCondition(t, "route", refetchedRoute.Status.Conditions, wantStatus, wantReason)
+}
+
+// assertReadyCondition fails the test if the named CR's Ready condition
+// does not match the expected status and reason.
+func assertReadyCondition(
+	t *testing.T,
+	subject string,
+	conditions []metav1.Condition,
+	wantStatus metav1.ConditionStatus,
+	wantReason string,
+) {
+	t.Helper()
+
+	for _, c := range conditions {
+		if c.Type != "Ready" {
+			continue
+		}
+		if c.Status != wantStatus {
+			t.Errorf("%s Ready condition status = %s, want %s", subject, c.Status, wantStatus)
+		}
+		if c.Reason != wantReason {
+			t.Errorf("%s Ready condition reason = %q, want %q", subject, c.Reason, wantReason)
+		}
+		return
+	}
+	t.Errorf("%s has no Ready condition; want status=%s reason=%q", subject, wantStatus, wantReason)
+}

--- a/tools/agent/repo-manifest.yaml
+++ b/tools/agent/repo-manifest.yaml
@@ -192,6 +192,7 @@ docs:
   - docs/agent/tech-debt/td-037-dev-integration-env-ownership-and-shared-suite-topology.md
   - docs/agent/tech-debt/td-038-custom-chat-completions-structs.md
   - docs/agent/tech-debt/td-039-control-plane-contract-ownership-collapse.md
+  - docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md
   - docs/agent/glossary.md
   - docs/agent/adr/README.md
   - docs/agent/adr/adr-0001-harness-layering.md
@@ -504,6 +505,9 @@ doc_governance:
     - path: docs/agent/tech-debt/td-039-control-plane-contract-ownership-collapse.md
       steward: agent-contract
       freshness: update when the TD039 debt record changes materially
+    - path: docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md
+      steward: agent-contract
+      freshness: update when the TD040 debt record changes materially
     - path: docs/agent/glossary.md
       steward: agent-contract
       freshness: update when harness terms or categories change


### PR DESCRIPTION
## Summary

Mirror the file-config embedding-modality validation in the Kubernetes reconcile path. Closes the gap identified in #1880's review where the operator could admit and mark Ready a CRD config the file-config validator would reject.

## Background

PR #1880 added `queryModality` to the IntelligentRoute EmbeddingSignal CRD. The runtime contract (in `validator_embedding.go`) is stricter than the new CRD surface:

- `query_modality=image` is only allowed when `global.model_catalog.embeddings.semantic.embedding_config.model_type=multimodal`
- `query_modality=audio` is rejected as not yet supported (the audio FFI is not exposed by candle-binding)

`validateConfigStructure` early-returns for `ConfigSourceKubernetes`, so `validateEmbeddingContracts` never runs for CRD-loaded configs. The reconciler still applies the config and marks the CRs Ready.

## Changes

- Export `ValidateEmbeddingContracts(cfg *RouterConfig) error` in `validator_embedding.go` as a thin wrapper around the existing private `validateEmbeddingContracts`. The signature mirrors the per-family validators in `validator.go`'s dispatch table so the K8s call site reads the same as the file-config dispatch.
- Call it from `Reconciler.validateAndUpdate` after `ParseYAMLBytes` returns and `ConfigSource` is set. On validation failure, mark pool and route `Ready=False, Reason=ValidationFailed` and return a `fmt.Errorf %w`-wrapped error.
- Reconciler-level integration test (`reconciler_embedding_modality_test.go`) drives a real `Reconciler.validateAndUpdate` call through controller-runtime's fake client. Six cases cover the validator branches: `AudioRejected`, `ImageWithoutMultimodalRejected`, `ImageWithMultimodalAccepted`, `TextOnlyAccepted`, `OmittedModalityAccepted` (the legacy/backward-compat path), and `UnknownModalityRejected`. Each case asserts both the returned error AND the persisted Ready conditions on both refetched CRs.

## Why option A (mirror) over option B (narrow CRD enum)

Option B is implementable. Dropping `audio` from the kubebuilder enum plus a CEL admission rule on IntelligentRoute that conditions `queryModality: image` on the operator's SemanticRouter declaring `embeddingConfig.modelType: multimodal` would express the cross-resource invariant at admission. The reasons option A is the better choice for this PR:

1. Single source of truth across config sources. The embedding-modality contract already lives in `validateEmbeddingRuleModalities`; the file-config path runs it via `validateConfigStructure`. This PR makes the K8s reconcile path call the same validator. Option B would fork enforcement across CEL admission (schema-side) and the Go validator (runtime-side), so the contract has to be kept in sync in two places when it evolves.
2. The CRD enum stays forward-compatible. When the audio FFI lands the validator widens; the schema does not need to migrate.
3. The cross-resource invariant (image rules require `model_type=multimodal`) is what option B's CEL piece would actually carry. The kubebuilder enum on `queryModality` (already added in #1880) handles the typo case at admission; the cross-resource piece is what would need separate CEL plumbing under option B. Option A covers both invariants in one Go validator with no new admission surface.
4. No new operator-side dependency. Option B would require a CEL ruleset maintained alongside the validator, with its own test surface and its own coverage gaps when the validator's rules change.

## Tracked debt

This PR closes the embedding slice of a broader gap. `validateConfigStructure` early-returns for `ConfigSource == ConfigSourceKubernetes` and skips every other family validator (domain, structure, reask, projection, knowledge_base, conversation, decision, modality, model_selection, advanced_tool_filtering). The remaining slices are tracked in [`docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md`](docs/agent/tech-debt/td-040-reconcile-path-skips-family-validators.md).

## Test plan

- [x] `make agent-validate` clean
- [x] `make agent-lint CHANGED_FILES=...` clean
- [x] `make agent-ci-lint CHANGED_FILES=...` clean (the gate that bit prior PRs)
- [x] `make agent-feature-gate ENV=cpu CHANGED_FILES=...` clean end-to-end (Docker-backed; behavior-visible since operator admits configs differently)
- [x] New `TestValidateEmbeddingContracts_ExportedWrapperMatchesInternal` passes
- [x] New `TestReconcileEmbeddingModalityValidation` passes (6 cases) and exercises a real `Reconciler.validateAndUpdate` call via controller-runtime's fake client
- [x] Verified the load-bearing property by branch surgery: removing the new validation block from `reconciler.go` causes the rejection cases to fail; restored block, all cases pass again
- [ ] `make agent-pr-gate` - blocked locally by an unrelated upstream issue: the precommit-local Docker image at `ghcr.io/vllm-project/semantic-router/precommit:latest` is missing `python3-venv`, so `make agent-bootstrap` inside the container fails at `python3 -m venv`. Companion fix opened as #1894 (one-line apt addition). Once #1894 lands and the image is rebuilt, this gate runs locally; CI's `Test And Build` workflow runs `make test` directly outside that container, so the bug is invisible there
- [ ] `make test-and-build-local` - flaky on `pkg/memory.TestGenerateMemoryID`, which calls `generateMemoryID()` twice in immediate succession and asserts inequality; the function uses a nanosecond timestamp and collides under fast clocks. Pre-existing flake, unrelated to this PR's surface

## Related

- Follow-up to #1880 (review feedback from @rootfs)
- Companion to #1881 (e2e re-add for image-modality routing)
- Tracked debt: TD040 (reconcile-path family-validator gap, embedding slice closed here)
