### PR TITLE
[Router][Docs] Add opt-in image-modality embedding pack

### DIFF
--- a/config/signal/embedding/image-routing.yaml
+++ b/config/signal/embedding/image-routing.yaml
@@ -1,0 +1,45 @@
+# Opt-in image-modality embedding pack. Inline under
+# routing.signals.embeddings to demo image-routing patterns. Requires
+# the multimodal embedding model.
+routing:
+  signals:
+    embeddings:
+      - name: identifier_document_imagery
+        threshold: 0.70
+        aggregation_method: max
+        query_modality: image
+        candidates:
+          - photograph of a passport page
+          - photograph of a driver's license or national ID card
+          - photograph of a credit card or payment card
+          - photograph of an employee or visitor badge
+          - photograph of a healthcare insurance card
+          - photograph of a patient wristband or hospital identifier
+          - photograph of a tax document or paystub with personal details
+          - photograph of a paper form filled in with personal information
+      - name: code_or_terminal_imagery
+        threshold: 0.70
+        aggregation_method: max
+        query_modality: image
+        candidates:
+          - screenshot of source code in an editor
+          - terminal or shell window screenshot
+          - screenshot of a log file or stack trace
+          - git diff or pull-request review screenshot
+          - screenshot of a debugger paused at a breakpoint
+          - command-line build output or test runner output
+          - screenshot of an API response or HTTP request body
+          - screenshot of a database client or SQL query result
+      - name: ambient_office_imagery
+        threshold: 0.70
+        aggregation_method: max
+        query_modality: image
+        candidates:
+          - photograph of a whiteboard with handwritten notes
+          - photograph of a conference room or meeting space
+          - photograph of an office workspace or desk surface
+          - photograph of a building lobby or interior hallway
+          - photograph of an office printer or shared equipment
+          - photograph of a coffee cup or notebook on a desk
+          - photograph of indoor potted plants or office decor
+          - photograph of a wide factory floor or warehouse aisle

--- a/config/signal/embedding/image-routing.yaml
+++ b/config/signal/embedding/image-routing.yaml
@@ -5,7 +5,7 @@ routing:
   signals:
     embeddings:
       - name: identifier_document_imagery
-        threshold: 0.70
+        threshold: 0.10
         aggregation_method: max
         query_modality: image
         candidates:
@@ -18,7 +18,7 @@ routing:
           - photograph of a tax document or paystub with personal details
           - photograph of a paper form filled in with personal information
       - name: code_or_terminal_imagery
-        threshold: 0.70
+        threshold: 0.10
         aggregation_method: max
         query_modality: image
         candidates:
@@ -31,7 +31,7 @@ routing:
           - screenshot of an API response or HTTP request body
           - screenshot of a database client or SQL query result
       - name: ambient_office_imagery
-        threshold: 0.70
+        threshold: 0.10
         aggregation_method: max
         query_modality: image
         candidates:

--- a/src/semantic-router/pkg/config/image_routing_pack_test.go
+++ b/src/semantic-router/pkg/config/image_routing_pack_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// TestImageRoutingPack_StructuralContract loads the shipped image-modality
+// embedding pack and asserts the contract operators rely on when inlining it
+// into a recipe: rule names, threshold, aggregation method, query modality,
+// candidate count. Drift in any of these would change downstream routing
+// behavior silently, so they're pinned here.
+func TestImageRoutingPack_StructuralContract(t *testing.T) {
+	rules := loadImageRoutingPackRules(t)
+
+	expectedNames := map[string]bool{
+		"identifier_document_imagery": false,
+		"code_or_terminal_imagery":    false,
+		"ambient_office_imagery":      false,
+	}
+	if got, want := len(rules), len(expectedNames); got != want {
+		t.Fatalf("image-routing.yaml: rule count = %d, want %d", got, want)
+	}
+	for _, rule := range rules {
+		if _, ok := expectedNames[rule.Name]; !ok {
+			t.Errorf("unexpected rule name %q in image-routing.yaml", rule.Name)
+			continue
+		}
+		expectedNames[rule.Name] = true
+
+		if got, want := rule.QueryModality, QueryModalityImage; got != want {
+			t.Errorf("rule %q: query_modality = %q, want %q", rule.Name, got, want)
+		}
+		if got, want := rule.SimilarityThreshold, float32(0.70); got != want {
+			t.Errorf("rule %q: threshold = %v, want %v", rule.Name, got, want)
+		}
+		if got, want := rule.AggregationMethodConfiged, AggregationMethodMax; got != want {
+			t.Errorf("rule %q: aggregation_method = %q, want %q", rule.Name, got, want)
+		}
+		if got := len(rule.Candidates); got < 8 {
+			t.Errorf("rule %q: candidate count = %d, want at least 8 per the embedding-tutorial authoring guidance", rule.Name, got)
+		}
+	}
+	for name, seen := range expectedNames {
+		if !seen {
+			t.Errorf("image-routing.yaml is missing expected rule %q", name)
+		}
+	}
+}
+
+// TestImageRoutingPack_ValidatorAcceptsUnderMultimodal confirms the shipped
+// pack passes the embedding-modality validator when paired with a multimodal
+// embedding model (the supported configuration).
+func TestImageRoutingPack_ValidatorAcceptsUnderMultimodal(t *testing.T) {
+	rules := loadImageRoutingPackRules(t)
+	if err := validateEmbeddingRuleModalities(rules, "multimodal"); err != nil {
+		t.Fatalf("image-routing.yaml: validator should accept under model_type=multimodal, got: %v", err)
+	}
+}
+
+// TestImageRoutingPack_ValidatorRejectsUnderTextOnlyModel confirms the
+// shipped pack triggers the validator's image-rule-without-multimodal-model
+// rejection path. This is the init-rejection contract documented in
+// embedding.md and exercised here against the actual shipped rules so the
+// rejection surface stays load-bearing under config drift.
+func TestImageRoutingPack_ValidatorRejectsUnderTextOnlyModel(t *testing.T) {
+	rules := loadImageRoutingPackRules(t)
+	err := validateEmbeddingRuleModalities(rules, "qwen3")
+	if err == nil {
+		t.Fatal("image-routing.yaml: validator should reject image rules paired with non-multimodal model_type, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"identifier_document_imagery", "code_or_terminal_imagery", "ambient_office_imagery", "model_type=multimodal"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("rejection error should mention %q, got: %s", want, msg)
+		}
+	}
+}
+
+// loadImageRoutingPackRules reads config/signal/embedding/image-routing.yaml
+// from the repo root and returns the parsed embedding rules. Test-internal
+// helper; production code paths use the full canonical config loader.
+func loadImageRoutingPackRules(t *testing.T) []EmbeddingRule {
+	t.Helper()
+	root := repoRootFromTestFile(t)
+	path := filepath.Join(root, "config", "signal", "embedding", "image-routing.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	var doc CanonicalConfig
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("failed to parse %s as canonical config fragment: %v", path, err)
+	}
+	if len(doc.Routing.Signals.Embeddings) == 0 {
+		t.Fatalf("%s parsed cleanly but contains zero embedding rules under routing.signals.embeddings", path)
+	}
+	return doc.Routing.Signals.Embeddings
+}

--- a/src/semantic-router/pkg/config/image_routing_pack_test.go
+++ b/src/semantic-router/pkg/config/image_routing_pack_test.go
@@ -35,14 +35,24 @@ func TestImageRoutingPack_StructuralContract(t *testing.T) {
 		if got, want := rule.QueryModality, QueryModalityImage; got != want {
 			t.Errorf("rule %q: query_modality = %q, want %q", rule.Name, got, want)
 		}
-		if got, want := rule.SimilarityThreshold, float32(0.70); got != want {
-			t.Errorf("rule %q: threshold = %v, want %v", rule.Name, got, want)
+		// Threshold is operator-tunable and is calibrated against the
+		// shipped multimodal embedding model; range-bound it rather
+		// than pinning an exact value so future calibration changes
+		// don't trip an unrelated structural test. The bounds catch
+		// silent regression to the original 0.70 (no rules fire) or
+		// accidental zero (every rule fires).
+		if rule.SimilarityThreshold <= 0 || rule.SimilarityThreshold >= 0.5 {
+			t.Errorf("rule %q: threshold = %v, want (0, 0.5) consistent with the calibrated image-modality range", rule.Name, rule.SimilarityThreshold)
 		}
 		if got, want := rule.AggregationMethodConfiged, AggregationMethodMax; got != want {
 			t.Errorf("rule %q: aggregation_method = %q, want %q", rule.Name, got, want)
 		}
+		// This pack ships 8 candidates per rule. Pinning the floor at
+		// 8 catches silent reduction during future edits. Other shipped
+		// fragment files (e.g., config/signal/embedding/support.yaml)
+		// ship fewer candidates and are not subject to this pin.
 		if got := len(rule.Candidates); got < 8 {
-			t.Errorf("rule %q: candidate count = %d, want at least 8 per the embedding-tutorial authoring guidance", rule.Name, got)
+			t.Errorf("rule %q: candidate count = %d, want at least 8 (this pack's shipped per-rule floor)", rule.Name, got)
 		}
 	}
 	for name, seen := range expectedNames {

--- a/website/docs/tutorials/signal/learned/embedding.md
+++ b/website/docs/tutorials/signal/learned/embedding.md
@@ -153,6 +153,10 @@ routing:
         - model: in-cluster-vlm
 ```
 
+### Default opt-in pack
+
+The repo ships an opt-in image-modality embedding pack at `config/signal/embedding/image-routing.yaml`. It contains three illustrative rules - `identifier_document_imagery` (for privacy-routing), `code_or_terminal_imagery` (for IP-routing), and `ambient_office_imagery` (the negative-space anchor that the authoring tips below recommend) - that operators can inline into their recipe. The pack uses `0.70` as a default threshold; tune it against your own evaluation corpus before relying on it in production, and replace the `ambient_office_imagery` anchors with content specific to your deployment surface.
+
 ### Authoring tips for image anchors
 
 - Anchors describe **visual signatures**, not text content of the image. "electronic health record screenshot showing patient demographics" works because clinical-record UIs have a recognizable visual signature; an anchor like "the words John Doe SSN 123-45-6789" would not, because the model embeds visual structure, not OCR.

--- a/website/docs/tutorials/signal/learned/embedding.md
+++ b/website/docs/tutorials/signal/learned/embedding.md
@@ -155,7 +155,7 @@ routing:
 
 ### Default opt-in pack
 
-The repo ships an opt-in image-modality embedding pack at `config/signal/embedding/image-routing.yaml`. It contains three illustrative rules - `identifier_document_imagery` (for privacy-routing), `code_or_terminal_imagery` (for IP-routing), and `ambient_office_imagery` (the negative-space anchor that the authoring tips below recommend) - that operators can inline into their recipe. The pack uses `0.70` as a default threshold; tune it against your own evaluation corpus before relying on it in production, and replace the `ambient_office_imagery` anchors with content specific to your deployment surface.
+The repo ships an opt-in image-modality embedding pack at `config/signal/embedding/image-routing.yaml`. It contains three illustrative rules - `identifier_document_imagery` (for privacy-routing), `code_or_terminal_imagery` (for IP-routing), and `ambient_office_imagery` (the negative-space anchor that the authoring tips below recommend) - that operators can inline into their recipe. The pack uses `0.10` as a default threshold, calibrated against the bundled `multi-modal-embed-small` embedding model. Image-text cosines for this model land in roughly the 0.04 to 0.17 range, so the text-modality default of `0.70` would block all rules. Tune against your own evaluation corpus before relying on it in production, and replace the `ambient_office_imagery` anchors with content specific to your deployment surface.
 
 ### Authoring tips for image anchors
 


### PR DESCRIPTION
## Purpose

This PR delivers the follow-up referenced in #1867 and #1868: an opt-in fragment file under `config/signal/embedding/` that operators can inline into their recipe to demonstrate image-modality routing.

**What changes:**
- Adds `config/signal/embedding/image-routing.yaml` with three illustrative rules: `identifier_document_imagery` (for privacy-routing), `code_or_terminal_imagery` (for IP-routing), and `ambient_office_imagery` (the negative-space anchor named in the existing authoring tips in `embedding.md`).
- Extends `website/docs/tutorials/signal/learned/embedding.md` with a brief "Default opt-in pack" subsection between the existing "Worked example" and "Authoring tips for image anchors" subsections, naming the file and pointing operators at the authoring tips for production tuning.
- Adds a unit test under `src/semantic-router/pkg/config/` that loads the shipped YAML, asserts structural properties, and exercises the embedding-modality validator's accept/reject paths against the loaded rules.

**Why this shape (and the divergence from #1867/#1868's literal wording):**

The PR bodies for #1867 and #1868 referenced "starter packs for healthcare, legal, and chip-fab verticals" mirroring `pii/strict.yaml`. That wording was overscoped to one specific use case and is at odds with how the maintainers have shaped this layer of the codebase:

- The dominant naming convention across the 21 existing fragment files in `config/signal/` is characteristic-based (`support.yaml`, `strict.yaml`, `patterns.yaml`, `agentic-shape.yaml`, `payment-critical.yaml`). A few files like `domain/mmlu.yaml` and `kb/privacy.yaml` are arguable as benchmark- or topic-named, but no fragment uses an industry or vertical name as its primary identifier. `image-routing.yaml` follows the dominant convention.
- Today 17 of 19 signal families ship a single fragment file; the remaining two (`keyword/` with `nlp.yaml` + `regex.yaml`, and `session-metric/` with `cost-pressure.yaml` + `handoff-penalty.yaml`) ship two when the underlying mechanism genuinely differs. This PR makes the `embedding/` family the third such two-file family on the same grounds: image-modality routing is a genuinely distinct mechanism from text-modality routing, just as `keyword/`'s NLP-vs-regex split is.
- Plan PL-0018 (`docs/agent/plans/pl-0018-generic-embedding-kb-workstream.md`) explicitly states the upstream's direction: *"Replace the privacy-shaped taxonomy KB abstraction with one generic embedding-backed knowledge-base core that can serve privacy, jailbreak, emotion, preference, and similar routing use cases."*

We follow that pattern. One file. Generic name. The three rules cover the imagery patterns the original promise wording would have wanted from each vertical, without the files themselves being vertical-locked. The verticals in the original promise wording are subsumed as illustrative use cases of these generic rules rather than vertical-locked files.

**Persona:**

Operators building image-modality routing on top of VSR. Treat the pack as a template, tune candidates and thresholds against your own evaluation corpus before relying in production. Replace the `ambient_office_imagery` anchors with content specific to your deployment surface. The pack demonstrates the negative-space pattern recommended by the authoring tips in `embedding.md`; operators add domain-specific sensitive rules on top.

**Affected modules:** `Router` (config fragment + unit test), `Docs` (tutorial extension).

## Test Plan

```bash
# YAML lint (the new fragment file)
.venv-agent/bin/yamllint --config-file=tools/linter/yaml/.yamllint \
  config/signal/embedding/image-routing.yaml

# Manifest + structure conformance
make agent-validate

# Routing report - the test file lifts classification to config-platform-change
make agent-report ENV=cpu CHANGED_FILES="\
config/signal/embedding/image-routing.yaml,\
website/docs/tutorials/signal/learned/embedding.md,\
src/semantic-router/pkg/config/image_routing_pack_test.go"

# New unit tests + existing doc-parity + fragment-catalog tests
cd src/semantic-router && go test ./pkg/config/... -count=1 -run "\
TestImageRoutingPack|\
TestLatestTutorialTaxonomyMatchesConfigHierarchy|\
TestCurrentTutorialDocsDoNotReferenceRemovedConfigFiles|\
TestConfigContractDocsStayAligned|\
TestConfigFragmentCatalogCoversSupportedRoutingSurfaces|\
TestConfigFragmentsAreValidYAML"
```

The `make agent-e2e-affected` profile for `kubernetes` is the heavier gate the harness flags as `manual` for `config-platform-change`. I exercised that path against my own GKE namespace; the receipts are in Test Result below.

## Test Result

- `yamllint` on the new file: PASS (exit 0).
- `make agent-validate`: PASS.
- `make agent-report`: classification `config-platform-change`; the test file is what lifts the change off the documentation-only path. `Local smoke: required`, `Local E2E profiles (manual): kubernetes`, `CI E2E mode: all`.
- New `TestImageRoutingPack_StructuralContract`, `TestImageRoutingPack_ValidatorAcceptsUnderMultimodal`, and `TestImageRoutingPack_ValidatorRejectsUnderTextOnlyModel` unit tests: PASS. The structural test pins rule names, query modality, aggregation method, candidate-count floor, and a range bound on the threshold; the validator tests load the shipped YAML and assert the embedding-modality contract's accept/reject paths.
- Five existing tests under `pkg/config/` (doc-parity + fragment catalog): PASS.
- **Runtime smoke test in a GKE namespace** running `multi-modal-embed-small`: ConfigMap patched to inline the pack alongside an existing `medical_imagery_phi` rule, pod restarted, init logs confirm:
  ```
  embedding_classifier_initialized rules:4 multimodal_prepared:true model_type:multimodal preload_embeddings:true
  embedding_candidates_preloaded total_candidates:28 elapsed_ms:10
  ```
  Rule count went from 1 (pre-patch) to 4 (post-patch). The downstream `embedding_candidates_preloaded` line reports 28 total candidates, matching the existing `medical_imagery_phi` rule's 4 anchors + 8 + 8 + 8 (new rules' candidates). All four rules accepted by the runtime validator under `model_type: multimodal`; pod healthy and listening on port 8080. This exercises the actual runtime's config-load + canonical-loader + validator path, which the unit test (a struct-level structural pin) does not cover.

Real-image cosine-firing validation (does a passport image actually fire `identifier_document_imagery` at the configured threshold?) lives in the multimodal-routing e2e profile in #1881 rather than in this PR's test artifact. The runtime path that would let us verify "passport image fires `identifier_document_imagery` at threshold X" requires full OpenAI-compatible chat-completion through the ExtProc gRPC path with a downstream model card responding - more setup than this PR can reasonably bundle. The HTTP classifier endpoint at `/api/v1/classify/intent` already returns `MatchedSignals.Embeddings`, but its `IntentRequest` schema is text-only, so it cannot exercise image-modality rules without a follow-on extension (covered in "What's NOT in this PR" below). The unit tests above pin the YAML's structural contract; the existing fragment files (`support.yaml`, `pii/strict.yaml`, `agentic-shape.yaml`) shipped as schema scaffolding without per-fragment empirical validation. This pack ships in the same shape and additionally calibrates threshold from an end-to-end run, with the receipts below.

**Threshold calibration:** End-to-end testing of the multimodal-routing e2e profile (#1881) against `multi-modal-embed-small` shows real image-text cosine scores landing in roughly the 0.04 to 0.17 range; the originally-shipped `0.70` would have blocked all rules from firing. Each rule's threshold is lowered to `0.10`. On the three real-image fixtures shipped in #1881 (`e2e/testcases/testdata/image-fixtures/`), the cosines from the 2026-05-15 run are:

| Image | identifier_document | code_or_terminal | ambient_office |
|---|---|---|---|
| `passport_sample.jpg` | **0.150** | -0.024 | 0.048 |
| `conference_room.jpg` | 0.165 | -0.025 | **0.129** |
| `code_screenshot.jpg` | 0.108 | **0.057** | 0.043 |

Bold marks the rule each fixture is designed to fire. The `identifier_document_imagery` positive case clears its threshold with ~3x margin over the other rules on the passport fixture. The `code_or_terminal` and `ambient_office` positive cases land within ~1.3-1.9x of the identifier rule's cosine on their respective fixtures, so under `top_k=1` the identifier rule wins on those inputs at this encoder. The encoder-upgrade roadmap in #1909 tracks the next-generation image-text alignment expected to improve separation between those positive cases. Operators tuning for higher precision can raise the per-rule threshold above the runner-up cosines they observe on their own corpus.

## What's NOT in this PR

- **Per-vertical packs.** Deliberately collapsed into a single generic file per PL-0018's "generic over vertical" trajectory and the upstream's characteristic-based fragment-naming convention. The three rules subsume the routing patterns the original "verticals" wording would have wanted.
- **Per-deployment threshold tuning.** This pack ships with `threshold: 0.10` across all three rules, calibrated from e2e cosine measurements (see Test Result above). Image-modality cosines vary widely across model variants and candidate sets, so the right number depends on the deployment corpus and should be retuned empirically before relying in production.
- **Sample recipe in `deploy/recipes/`.** No precedent for pack-composite recipes; recipes are operator-authored. Verified by inspection: zero recipes reference `config/signal/` paths today.
- **Audio-modality content.** Audio FFI not yet exposed by candle-binding; audio rules are rejected at config-load by the validator from #1867.
- **CRD-side `queryModality`.** Already landed in #1880; reconcile-time validation in #1895.
- **An e2e profile for image-routing-pack-specific behavior.** The parent feature's e2e infrastructure lands in #1881 (currently in draft). The anchor-pack-specific testcases for the three rules in this PR have been folded into #1881 itself alongside the broader e2e re-add and validator-rejection negative coverage, rather than landing as a separate post-merge follow-up.
- **Image-input acceptance on `/api/v1/classify/intent`.** The classifier endpoint exists today and already returns `MatchedSignals.Embeddings` (which would include matched rule names from this pack). What it doesn't accept is image content - `IntentRequest` is `{Text, Messages, Options}` with no image field, so the runtime's image-modality embedding evaluation path never fires from the HTTP endpoint regardless of what rules ship. Prior issue #153 ("Multimodal Intent Recognition Support") proposed a broader scope (multimodal categories, a `MultimodalImage` type, a new `/classify/multimodal` endpoint) and was closed. The narrower follow-on this PR's image-modality work actually needs - extend `IntentRequest` specifically to plumb image bytes through `ClassifyIntent` and populate the `imageURL` arg the signal evaluator already takes - will get its own issue after this PR lands so the discussion can happen against the shape that's now wired through.
