### PR TITLE
[Router] Reduce HybridCache rebuild preallocation

### DIFF
--- a/src/semantic-router/pkg/cache/hybrid_cache.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache.go
@@ -44,9 +44,7 @@ var searchBufferPool = sync.Pool{
 func getSearchBuffers() *searchBuffers {
 	buf := searchBufferPool.Get().(*searchBuffers)
 	// Clear maps and heaps for reuse
-	for k := range buf.visited {
-		delete(buf.visited, k)
-	}
+	clear(buf.visited)
 	buf.candidates.data = buf.candidates.data[:0]
 	buf.results.data = buf.results.data[:0]
 	return buf
@@ -283,8 +281,9 @@ func (h *HybridCache) RebuildFromMilvus(ctx context.Context) error {
 	defer h.mu.Unlock()
 
 	// Clear existing index
-	h.embeddings = make([][]float32, 0, len(embeddings))
-	h.idMap = make(map[int]string)
+	loadLimit := min(len(embeddings), h.maxMemoryEntries)
+	h.embeddings = make([][]float32, 0, loadLimit)
+	h.idMap = make(map[int]string, loadLimit)
 	h.hnswIndex = newHNSWIndex(h.hnswIndex.M, h.hnswIndex.efConstruction)
 
 	// Rebuild HNSW index with progress logging


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

- What does this PR change?
    This PR attempted to reduce over-allocation during `func (h *HybridCache) RebuildFromMilvus`. BTW, it also did a small clean up.
> [go builtin `clear` added in go1.21](https://pkg.go.dev/builtin#clear):  The clear built-in function clears maps and slices. For maps, clear deletes all entries, resulting in an empty map.

- Why is this change needed?
   The rebuild loop. loads at most `h.maxMemoryEntries` into the in-memory HNSW index,  the previous code preallocated `embeddings` using the full number of entries return by Milvus.

- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`
 Router

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
