### PR TITLE
[Docs] Add coding agent manifests for Claude Code, Open Code, and Cursor

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,67 @@
+## vLLM Semantic Router
+
+This repository implements an intelligent LLM request router that sits as an Envoy ExtProc filter. It classifies requests using semantic signals and routes them to appropriate model backends.
+
+## Source of Truth
+
+1. `AGENTS.md` — short agent entrypoint
+2. `docs/agent/README.md` — full system of record
+3. `tools/agent/` — executable rule layer (manifests, scripts, skills)
+4. `tools/make/agent.mk` — canonical Make targets
+5. Nearest local `AGENTS.md` for hotspot directories
+
+## Key Commands
+
+- `make vllm-sr-dev` — build local dev image
+- `vllm-sr serve --image-pull-policy never` — run locally
+- `make agent-validate` — validate harness-only changes
+- `make agent-lint CHANGED_FILES="..."` — lint changed files
+- `make agent-ci-gate CHANGED_FILES="..."` — CI gate for changed files
+- `make agent-pr-gate` — full local PR baseline
+- `make test-semantic-router` — Go router tests
+- `make test-binding` — Rust binding tests
+- `make go-lint` / `make go-lint-fix` — Go linting
+- `make e2e-test` — end-to-end tests
+
+## Commit Trajectory and PR Scoping
+
+Structure commits as a reviewable trajectory — each commit is one logical step:
+
+1. Separate concerns into distinct commits (refactor, logic, tests).
+2. Each commit must compile and pass lint — never break the tree mid-sequence.
+3. Commit messages describe the "why", not just the "what".
+4. Sign off all commits: `git commit -s -m "message"` (DCO required).
+
+PR scoping rules:
+- Narrow the blast radius — touch only files necessary for the change.
+- One subsystem per PR when possible; don't mix unrelated cleanups.
+- PR titles use module prefixes: `[Router]`, `[Dashboard]`, `[Operator]`, `[Docs]`, `[CI/Build]`
+- Include a Test Plan section with validation steps and outcomes.
+- Behavior-visible changes need E2E test updates unless pure refactor.
+- Read nearest local `AGENTS.md` before editing hotspot directories.
+
+## Architecture
+
+- Layer model: signal → decision → algorithm → plugin → global
+- One main responsibility per file; extract rather than extend hotspots.
+- Interfaces only at true seams; no premature abstraction.
+
+### Subsystems
+
+- `src/semantic-router/` — Go router (Envoy ExtProc)
+- `src/vllm-sr/` — Python CLI and local dev tools
+- `candle-binding/`, `ml-binding/`, `nlp-binding/` — Rust inference bindings
+- `dashboard/` — Web UI (React frontend, Go backend)
+- `deploy/operator/` — Kubernetes operator and CRDs
+- `e2e/` — End-to-end test framework
+- `tools/` — Automation, agent harness, Make includes
+
+### Hotspot Directories (check local AGENTS.md first)
+
+- `src/semantic-router/pkg/config/`
+- `src/semantic-router/pkg/extproc/`
+- `src/vllm-sr/cli/`
+- `deploy/operator/api/v1alpha1/`
+- `deploy/operator/controllers/`
+- `dashboard/frontend/src/`
+- `dashboard/backend/handlers/`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,6 +74,23 @@ Flag missing validation when:
 - harness-only changes do not update the relevant source-of-truth docs or executable rules
 - contributor-interface changes drift away from the canonical harness entrypoints
 
+## Commit Trajectory and PR Scoping
+
+When generating or suggesting changes, structure commits as a reviewable trajectory:
+
+1. Separate concerns into distinct commits (refactor, logic, tests).
+2. Each commit must compile and pass lint — never break the tree mid-sequence.
+3. Commit messages describe the "why", not just the "what".
+4. Sign off all commits with `-s` (DCO required).
+
+PR scoping expectations:
+
+- Narrow the blast radius — touch only files necessary for the change.
+- One subsystem per PR when possible; don't mix unrelated cleanups into a feature PR.
+- PR titles use module-aligned prefixes: `[Router]`, `[Dashboard]`, `[Docs]`, `[CI/Build]`, `[Operator]`, etc.
+- Include a Test Plan section describing validation steps and outcomes.
+- Behavior-visible changes need E2E test updates unless the change is a pure refactor.
+
 ## Review Output Style
 
 Prioritize findings about:

--- a/.gitignore
+++ b/.gitignore
@@ -127,25 +127,23 @@ results/
 reports/
 test-results/
 
-# AI tooling regulation docs
-# Ignore Copilot/Claude/Cursor rule docs anywhere in the repo
+# AI tooling — block personal/local agent configs in subdirectories
 **/[Cc]laude*.md
 **/[Cc]ursor*.md
 .github/[Cc]laude*.md
 .github/[Cc]ursor*.md
+**/.cursorrules
+**/.cursorrules.*
 
-# Cursor editor rules files
-.cursorrules
-.cursorrules.*
+# Allow only the root-level agent manifests that are intentionally tracked
+!/CLAUDE.md
+!/.cursorrules
 
 # augment editor rules
 .augment
 
 # Local agent harness artifacts
 .agent-harness/
-
-# Claude Code configuration (should not be committed)
-CLAUDE.md
 
 # Dashboard frontend (React + TypeScript + Vite)
 dashboard/frontend/node_modules/

--- a/.opencode.yaml
+++ b/.opencode.yaml
@@ -1,0 +1,43 @@
+# Open Code configuration for vLLM Semantic Router
+# See: https://opencode.ai/docs/configuration
+
+name: vllm-semantic-router
+description: Intelligent LLM request router using Envoy ExtProc for semantic classification and model selection.
+
+instructions: |
+  This is the vLLM Semantic Router repository. It routes LLM inference requests
+  to appropriate model backends based on semantic signals (reasoning complexity,
+  PII detection, jailbreak detection, etc.).
+
+  ## Key Entry Points
+  - AGENTS.md — agent harness entrypoint
+  - docs/agent/README.md — full agent documentation
+  - CONTRIBUTING.md — contributor guide
+
+  ## Development
+  - Local dev: `make vllm-sr-dev && vllm-sr serve --image-pull-policy never`
+  - Run tests: `make test-semantic-router` (Go), `make test-binding` (Rust)
+  - Lint: `make go-lint`, `pre-commit run --all-files`
+  - Validate: `make agent-validate`, `make agent-ci-gate CHANGED_FILES="..."`
+  - Full PR gate: `make agent-pr-gate`
+
+  ## Commit Trajectory and PR Scoping
+  - Structure commits as a reviewable trajectory: one logical step per commit.
+  - Separate concerns: refactor in one commit, new logic next, tests after.
+  - Each commit must compile and pass lint — never break the tree mid-sequence.
+  - Sign off commits: `git commit -s` (DCO required).
+  - Narrow the blast radius: touch only files necessary for the change.
+  - One subsystem per PR when possible; don't mix unrelated cleanups.
+  - PR titles use module prefixes: [Router], [Dashboard], [Operator], [Docs], etc.
+  - Include a Test Plan section with validation steps and outcomes.
+  - Behavior-visible changes need E2E test updates unless pure refactor.
+  - Read the nearest local AGENTS.md before editing hotspot directories.
+
+  ## Architecture
+  - Layer model: signal → decision → algorithm → plugin → global
+  - One responsibility per file; legacy hotspots are debt, not precedent.
+  - Go router: src/semantic-router/
+  - Python CLI: src/vllm-sr/
+  - Rust bindings: candle-binding/, ml-binding/, nlp-binding/
+  - Dashboard: dashboard/ (React + Go)
+  - Operator: deploy/operator/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ vllm-sr serve --image-pull-policy never
 ```
 
 For AMD ROCm:
+
 ```bash
 make vllm-sr-dev VLLM_SR_PLATFORM=amd
 vllm-sr serve --image-pull-policy never --platform amd
@@ -61,6 +62,7 @@ make go-lint                 # Go lint
 make go-lint-fix             # Go lint with auto-fix
 make check-go-mod-tidy       # verify Go modules
 pre-commit run --all-files   # all pre-commit hooks
+markdownlint -c tools/linter/markdown/markdownlint.yaml "**/*.md"  # Markdown lint
 ```
 
 ## Commit Trajectory and PR Scoping
@@ -121,6 +123,7 @@ This repo has a full agent harness. For complex tasks:
 4. Validate with the canonical gates before marking work complete.
 
 The executable rule layer lives in:
+
 - `tools/agent/repo-manifest.yaml`
 - `tools/agent/task-matrix.yaml`
 - `tools/agent/skill-registry.yaml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# Claude Code Instructions
+
+This file configures Claude Code for the vLLM Semantic Router repository.
+
+## Repository Overview
+
+vLLM Semantic Router is an intelligent request router for LLM inference that sits as an Envoy ExtProc filter. It classifies incoming requests and routes them to appropriate model backends based on semantic signals (reasoning complexity, PII, jailbreak detection, etc.).
+
+### Key Subsystems
+
+- `src/semantic-router/` — Go router (Envoy ExtProc server, config, routing logic)
+- `src/vllm-sr/` — Python CLI for local dev workflow
+- `candle-binding/`, `ml-binding/`, `nlp-binding/` — Rust inference bindings
+- `dashboard/` — Web UI (React frontend + Go backend)
+- `deploy/operator/` — Kubernetes operator and CRDs
+- `e2e/` — End-to-end test framework (kind/Kubernetes)
+- `tools/agent/` — Agent harness manifests and scripts
+- `tools/make/` — Canonical Make targets
+
+## Development Workflow
+
+### Local Setup
+
+```bash
+make vllm-sr-dev
+vllm-sr serve --image-pull-policy never
+```
+
+For AMD ROCm:
+```bash
+make vllm-sr-dev VLLM_SR_PLATFORM=amd
+vllm-sr serve --image-pull-policy never --platform amd
+```
+
+### Validation Commands (use smallest gate first)
+
+```bash
+make agent-validate          # harness-only changes
+make agent-lint CHANGED_FILES="path/one,path/two"
+make agent-ci-gate CHANGED_FILES="path/one,path/two"
+make agent-pr-gate           # full local PR baseline
+make test-and-build-local    # reproduces CI Test And Build job
+make agent-feature-gate ENV=cpu CHANGED_FILES="path/one,path/two"
+```
+
+### Running Tests
+
+```bash
+make test-binding            # Rust bindings
+make test-semantic-router    # Go router
+make test-category-classifier
+make test-pii-classifier
+make test-jailbreak-classifier
+make e2e-test                # full E2E (requires kind cluster)
+```
+
+### Linting
+
+```bash
+make go-lint                 # Go lint
+make go-lint-fix             # Go lint with auto-fix
+make check-go-mod-tidy       # verify Go modules
+pre-commit run --all-files   # all pre-commit hooks
+```
+
+## Commit Trajectory and PR Scoping
+
+### Commit Structure
+
+Structure commits as a reviewable trajectory — each commit should represent one logical step that builds on the previous:
+
+1. **Separate concerns into distinct commits**: refactoring in one commit, new logic in the next, tests in another.
+2. **Each commit must compile and pass lint**: never leave the tree broken mid-sequence.
+3. **Commit messages describe the "why"**: e.g., `extract helper to reduce hotspot responsibility` not `move code`.
+4. **Sign off all commits**: `git commit -s -m "message"` (DCO required).
+
+### PR Scoping
+
+- **Narrow the blast radius**: touch only the files and subsystems necessary for the change. Do not mix unrelated cleanups or drive-by fixes into a feature PR.
+- **One subsystem per PR when possible**: a Router change should not also refactor the Dashboard unless they are tightly coupled.
+- **PR titles use module-aligned prefixes**: `[Router]`, `[Dashboard]`, `[Docs]`, `[CI/Build]`, `[Operator]`, etc.
+- **Include a Test Plan section**: describe what was validated and how.
+- Behavior-visible routing, startup, config, Docker, CLI, or API changes require E2E test updates unless pure refactor.
+
+### Example Commit Trajectory
+
+```
+commit 1: [Router] extract PII signal helper from processor hotspot
+commit 2: [Router] add configurable PII threshold to signal helper
+commit 3: [Router] add unit tests for PII threshold edge cases
+commit 4: [Router] update E2E test for new PII threshold behavior
+```
+
+This makes review incremental — reviewers can follow the reasoning step by step.
+
+## Architecture Rules
+
+- **Layer model**: `signal` → `decision` → `algorithm` → `plugin` → `global`
+- Keep modules narrow: one main responsibility per file.
+- Legacy hotspots are debt, not precedent. Do not grow their responsibility.
+- Interfaces belong only at true seams.
+- Read the nearest local `AGENTS.md` before editing hotspot directories.
+
+### Hotspot Directories (check local AGENTS.md first)
+
+- `src/semantic-router/pkg/config/`
+- `src/semantic-router/pkg/extproc/`
+- `src/vllm-sr/cli/`
+- `deploy/operator/api/v1alpha1/`
+- `deploy/operator/controllers/`
+- `dashboard/frontend/src/`
+- `dashboard/backend/handlers/`
+
+## Agent Harness
+
+This repo has a full agent harness. For complex tasks:
+
+1. Read `AGENTS.md` for the entrypoint.
+2. Read `docs/agent/README.md` for the full system of record.
+3. Run `make agent-report ENV=cpu CHANGED_FILES="..."` to get routed context.
+4. Validate with the canonical gates before marking work complete.
+
+The executable rule layer lives in:
+- `tools/agent/repo-manifest.yaml`
+- `tools/agent/task-matrix.yaml`
+- `tools/agent/skill-registry.yaml`
+- `tools/agent/structure-rules.yaml`
+- `tools/make/agent.mk`


### PR DESCRIPTION
Closes #1890

## Purpose

- Adds agent-friendly manifests for Claude Code (`CLAUDE.md`), Open Code (`.opencode.yaml`), and Cursor (`.cursorrules`) that describe the repo surface, dev/test harness, and commit trajectory guidance.
- Updates the existing `.github/copilot-instructions.md` with commit trajectory and PR scoping guidance.
- Updates `.gitignore` to allow root-level agent manifests while still blocking personal configs in subdirectories.
- Helps coding agents understand the repo structure and produce narrowly-scoped, reviewable PRs.
- Affects: `Docs`

## Test Plan

- Verify new files exist at repo root: `CLAUDE.md`, `.opencode.yaml`, `.cursorrules`
- Verify `git check-ignore` blocks subdirectory agent configs but allows root-level ones
- Verify `.github/copilot-instructions.md` includes the new commit trajectory section

## Test Result

- All three manifests created and tracked by git
- `git check-ignore -v src/CLAUDE.md src/.cursorrules` confirms subdirectory configs are still blocked
- `git check-ignore -v CLAUDE.md .cursorrules .opencode.yaml` confirms root-level files pass through
- No follow-up blockers