### PR TITLE
[Router] add policy version store with shadow/activate/revert lifecycle

### DIFF
--- a/docs/agent/plans/README.md
+++ b/docs/agent/plans/README.md
@@ -87,6 +87,7 @@ Keep the numeric index unique within `docs/agent/plans/`.
 - [pl-0023-dashboard-dsl-natural-language-mode-loop.md](pl-0023-dashboard-dsl-natural-language-mode-loop.md)
 - [pl-0024-balance-recipe-simplification-loop.md](pl-0024-balance-recipe-simplification-loop.md)
 - [pl-0025-prototype-aware-embedding-backed-signal-scoring-loop.md](pl-0025-prototype-aware-embedding-backed-signal-scoring-loop.md)
+- [pl-0030-session-aware-model-switch-workstream.md](pl-0030-session-aware-model-switch-workstream.md)
 
 ## Completed Execution Plans
 

--- a/docs/agent/plans/pl-0030-session-aware-model-switch-workstream.md
+++ b/docs/agent/plans/pl-0030-session-aware-model-switch-workstream.md
@@ -1,0 +1,155 @@
+# Session-Aware Model-Switch Offline Weight Updates
+
+## Goal
+
+- Train offline weight updates for session-aware model-switch policies so learned tuning can build on logged routing evidence without becoming a runtime dependency.
+- Provide a versioning and rollout contract so learned weights can be shadowed, compared, and reverted independently from the runtime code path.
+- Compose with the existing shadow-mode `model_switch_gate` rather than replacing stable heuristic fallbacks.
+
+## Scope
+
+- `src/semantic-router/pkg/selection/offline_dataset.go` — offline dataset contract
+- `src/semantic-router/pkg/selection/offline_updater.go` — batch weight updater
+- `src/semantic-router/pkg/selection/policy_version.go` — versioned weight storage and rollout
+- `src/semantic-router/pkg/selection/offline_metrics.go` — observability for offline operations
+- `src/semantic-router/pkg/selection/offline_test.go` — unit tests
+- `src/semantic-router/pkg/routerreplay/store/store.go` — data source (read-only)
+- `src/semantic-router/pkg/observability/metrics/session_telemetry_metrics.go` — existing telemetry
+
+## Architecture
+
+### Data Flow
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌───────────────────┐
+│  RouterReplay    │────▶│ OfflineDataset   │────▶│  OfflineUpdater   │
+│  Store (records) │     │ Builder          │     │  (batch replay)   │
+└─────────────────┘     └──────────────────┘     └───────────────────┘
+                                                          │
+                                                          ▼
+┌─────────────────┐     ┌──────────────────┐     ┌───────────────────┐
+│  RLDrivenSel.   │◀────│ PolicyVersion    │◀────│ PolicyVersionStore│
+│  (runtime)      │     │ (active weights) │     │ (versioned disk)  │
+└─────────────────┘     └──────────────────┘     └───────────────────┘
+                                ▲
+                                │ shadow comparison
+                                ▼
+                        ┌──────────────────┐
+                        │ ModelSwitchGate   │
+                        │ (shadow/enforce)  │
+                        └──────────────────┘
+```
+
+### Offline Dataset Contract
+
+The `OfflineDatasetRecord` captures:
+
+1. **Session telemetry** — session_id, turn_index, user_id, decision_name
+2. **Transition logs** — previous_model, cache_warmth, net_switch_advantage, handoff_penalty
+3. **Lookup table evidence** — quality_gap and handoff penalties from existing lookup tables
+4. **Feedback signals** — explicit pairwise feedback, implicit detection, response status
+
+Records are assembled by an `OfflineDatasetBuilder` that reads from the RouterReplay store
+and joins transition evidence from model_switch_gate audit logs.
+
+### Policy Versioning
+
+Policy versions follow a lifecycle: `candidate → shadow → active → retired`.
+
+- **candidate**: Produced by offline updater, not yet evaluated.
+- **shadow**: Being compared against the active version in real traffic (model_switch_gate shadow mode).
+- **active**: Drives real routing decisions via the RLDrivenSelector.
+- **retired**: Kept for audit and rollback.
+
+A `PolicyManifest` tracks which version is active and which is shadowed. Operators
+can promote, shadow, or revert versions independently via the PolicyVersionStore API.
+
+### Composition with ModelSwitchGate Shadow Mode
+
+The model_switch_gate already supports `shadow` and `enforce` modes. Offline weight
+updates compose as follows:
+
+1. Offline updater produces a **candidate** policy version from historical data.
+2. Operator promotes candidate to **shadow** via `PolicyVersionStore.Shadow(id)`.
+3. At request time, the RLDrivenSelector uses the **active** weights for real decisions.
+4. A shadow evaluator simultaneously scores with the **shadow** weights and records
+   `ShadowComparison` events (agreement rate, score deltas).
+5. `ShadowComparisonTotal` and `ShadowComparisonScoreDelta` metrics let operators
+   monitor divergence in dashboards before promotion.
+6. When satisfied, operator promotes shadow to active via `PolicyVersionStore.Activate(id)`.
+7. The previous active version is automatically retired but remains on disk for rollback.
+
+This ensures:
+
+- Rule-based and heuristic fallbacks are never removed — they remain the final authority
+  when the model_switch_gate is in `enforce` mode.
+- Learned weights are always auditable and reversible.
+- No training or external services are required at request time.
+
+### Not Goals
+
+- Mandatory online learning at request time.
+- Removing rule-based or heuristic fallback paths.
+- Shipping a black-box policy with no inspection hooks.
+- Making external training services a runtime dependency.
+
+## Exit Criteria
+
+- [x] `OWU001` Define offline dataset contract types sourced from session telemetry, transition logs, lookup tables, and feedback signals.
+- [x] `OWU002` Implement versioned policy weight storage with shadow/compare/revert lifecycle.
+- [x] `OWU003` Implement offline batch updater that replays historical records and produces candidate weights.
+- [x] `OWU004` Add Prometheus metrics for offline update runs, policy activations, and shadow comparisons.
+- [x] `OWU005` Add unit tests for dataset contract, versioned storage, offline updater, and version comparison.
+- [x] `OWU006` Document composition with shadow-mode model_switch_gate in this workstream plan.
+
+## Task List
+
+- [x] `OWU001` Define offline dataset contract types sourced from session telemetry, transition logs, lookup tables, and feedback signals.
+- [x] `OWU002` Implement versioned policy weight storage with shadow/compare/revert lifecycle.
+- [x] `OWU003` Implement offline batch updater that replays historical records and produces candidate weights.
+- [x] `OWU004` Add Prometheus metrics for offline update runs, policy activations, and shadow comparisons.
+- [x] `OWU005` Add unit tests for dataset contract, versioned storage, offline updater, and version comparison.
+- [x] `OWU006` Document composition with shadow-mode model_switch_gate in this workstream plan.
+- [ ] `OWU007` Implement `OfflineDatasetBuilder` that reads from RouterReplay store and joins transition evidence.
+- [ ] `OWU008` Wire policy version loading into `RLDrivenSelector` initialization path.
+- [ ] `OWU009` Add shadow evaluator that runs shadow-version scoring in parallel at request time.
+- [ ] `OWU010` Add E2E test for offline weight update → shadow → promote flow.
+
+## Current Loop
+
+- Loop opened on 2026-05-10 from issue #1750.
+- Completed in this loop:
+  - defined the offline dataset contract (`OfflineDatasetRecord`, `OfflineOutcome`, `OfflineTransitionEvidence`)
+  - implemented `PolicyVersionStore` with full lifecycle management (candidate/shadow/active/retired)
+  - implemented `OfflineUpdater` with parent-weight blending, transition penalties, and min-observation thresholds
+  - added Prometheus metrics for offline operations and shadow comparisons
+  - added unit tests covering all offline subsystem components
+  - documented architecture and composition with model_switch_gate shadow mode
+
+## Decision Log
+
+- 2026-05-10: Chose Beta distribution accumulation (same as online `UpdateFeedback`) for offline replay rather than introducing a separate reward model. Keeps the weight format identical across online and offline paths, simplifying version promotion.
+- 2026-05-10: Added `MinRecordsPerModel` threshold so models with sparse offline evidence keep their parent-version priors unchanged, preventing noisy updates from small samples.
+- 2026-05-10: Policy versions are file-backed JSON rather than database-backed to keep the offline path zero-dependency and operator-friendly for inspection.
+
+## Follow-up Debt / ADR Links
+
+- `OfflineDatasetBuilder` implementation depends on RouterReplay store query capabilities (session-range queries). May need a store extension for windowed reads.
+- Shadow evaluator integration into the ExtProc hot path must respect latency budgets. Consider async recording or bounded channel.
+- No ADR required yet — this is additive infrastructure that does not change the runtime decision contract.
+
+## Validation
+
+```bash
+make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/selection/offline_dataset.go,src/semantic-router/pkg/selection/offline_updater.go,src/semantic-router/pkg/selection/policy_version.go,src/semantic-router/pkg/selection/offline_metrics.go,src/semantic-router/pkg/selection/offline_test.go,docs/agent/plans/pl-0030-session-aware-model-switch-workstream.md"
+make test-semantic-router
+```
+
+## References
+
+- Umbrella: #1513
+- This issue: #1750
+- Related feedback work: #1512
+- Model switch gate: `src/semantic-router/pkg/selection/model_switch_gate.go`
+- RL-driven selector: `src/semantic-router/pkg/selection/rl_driven.go`
+- Session telemetry: `src/semantic-router/pkg/observability/metrics/session_telemetry_metrics.go`

--- a/src/semantic-router/pkg/selection/offline_dataset.go
+++ b/src/semantic-router/pkg/selection/offline_dataset.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"context"
+	"time"
+)
+
+// OfflineDatasetRecord is a single training observation for offline weight updates.
+// It captures the routing decision, outcome, and session context from a completed
+// request so that an offline trainer can replay and learn from historical evidence.
+type OfflineDatasetRecord struct {
+	// SessionID groups records into multi-turn conversations.
+	SessionID string `json:"session_id"`
+
+	// TurnIndex is the zero-based position of this turn within the session.
+	TurnIndex int `json:"turn_index"`
+
+	// DecisionName is the matched routing decision (category context).
+	DecisionName string `json:"decision_name,omitempty"`
+
+	// CategoryName is the detected domain category (e.g. "math", "coding").
+	CategoryName string `json:"category_name,omitempty"`
+
+	// UserID identifies the user for personalized weight learning.
+	UserID string `json:"user_id,omitempty"`
+
+	// SelectedModel is the model that was actually served.
+	SelectedModel string `json:"selected_model"`
+
+	// CandidateModels lists all models that were eligible at decision time.
+	CandidateModels []string `json:"candidate_models"`
+
+	// SelectionMethod records which algorithm made the routing decision.
+	SelectionMethod string `json:"selection_method"`
+
+	// SelectionScore is the score assigned to the selected model.
+	SelectionScore float64 `json:"selection_score"`
+
+	// SelectionConfidence is the confidence of the selection.
+	SelectionConfidence float64 `json:"selection_confidence"`
+
+	// AllScores maps every candidate model to its score at decision time.
+	AllScores map[string]float64 `json:"all_scores,omitempty"`
+
+	// Outcome captures post-decision quality evidence.
+	Outcome OfflineOutcome `json:"outcome"`
+
+	// TransitionEvidence captures model-switch context when this turn changed models.
+	TransitionEvidence *OfflineTransitionEvidence `json:"transition_evidence,omitempty"`
+
+	// SignalValues captures the signal strengths at decision time.
+	SignalValues map[string]float64 `json:"signal_values,omitempty"`
+
+	// Timestamp is when the routing decision was made.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// OfflineOutcome captures the quality and cost signals that arrive after a
+// routing decision, forming the reward signal for offline training.
+type OfflineOutcome struct {
+	// FeedbackType is the type of feedback observed.
+	// Values: "explicit", "implicit_satisfied", "implicit_need_clarification",
+	// "implicit_wrong_answer", "implicit_want_different", ""
+	FeedbackType string `json:"feedback_type,omitempty"`
+
+	// FeedbackConfidence is how certain the feedback detection was (0.0-1.0).
+	FeedbackConfidence float64 `json:"feedback_confidence,omitempty"`
+
+	// Won is true when this model was preferred in a pairwise comparison.
+	Won *bool `json:"won,omitempty"`
+
+	// Tie is true when neither model was preferred.
+	Tie bool `json:"tie,omitempty"`
+
+	// OpponentModel is the model compared against (for pairwise feedback).
+	OpponentModel string `json:"opponent_model,omitempty"`
+
+	// PromptTokens is the number of prompt tokens consumed.
+	PromptTokens int `json:"prompt_tokens,omitempty"`
+
+	// CompletionTokens is the number of completion tokens generated.
+	CompletionTokens int `json:"completion_tokens,omitempty"`
+
+	// ActualCost is the dollar cost of this request.
+	ActualCost float64 `json:"actual_cost,omitempty"`
+
+	// ResponseStatus is the HTTP status code of the response.
+	ResponseStatus int `json:"response_status,omitempty"`
+}
+
+// OfflineTransitionEvidence records the context when a session switches models
+// mid-conversation, so offline trainers can learn handoff penalties and cache warmth
+// effects from historical data.
+type OfflineTransitionEvidence struct {
+	// PreviousModel is the model used on the prior turn.
+	PreviousModel string `json:"previous_model"`
+
+	// CacheWarmth is the estimated KV-cache warmth at switch time (0=cold, 1=warm).
+	CacheWarmth float64 `json:"cache_warmth"`
+
+	// CacheWarmthOK indicates whether CacheWarmth was backed by reliable evidence.
+	CacheWarmthOK bool `json:"cache_warmth_ok"`
+
+	// SwitchDecision records whether the gate allowed or blocked the switch.
+	SwitchDecision string `json:"switch_decision,omitempty"`
+
+	// NetSwitchAdvantage is the computed advantage at switch time.
+	NetSwitchAdvantage float64 `json:"net_switch_advantage"`
+
+	// HandoffPenalty is the penalty applied for switching.
+	HandoffPenalty float64 `json:"handoff_penalty"`
+}
+
+// OfflineDataset is a batch of records ready for offline weight training.
+type OfflineDataset struct {
+	// Version is the schema version for forward compatibility.
+	Version int `json:"version"`
+
+	// CreatedAt is when this dataset was assembled.
+	CreatedAt time.Time `json:"created_at"`
+
+	// WindowStart is the earliest record timestamp in the dataset.
+	WindowStart time.Time `json:"window_start"`
+
+	// WindowEnd is the latest record timestamp in the dataset.
+	WindowEnd time.Time `json:"window_end"`
+
+	// Records are the training observations, ordered by (session_id, turn_index).
+	Records []OfflineDatasetRecord `json:"records"`
+
+	// SessionCount is the number of distinct sessions in the dataset.
+	SessionCount int `json:"session_count"`
+
+	// TransitionCount is the number of mid-session model switches.
+	TransitionCount int `json:"transition_count"`
+}
+
+// OfflineDatasetBuilder assembles an OfflineDataset from a replay store reader.
+type OfflineDatasetBuilder interface {
+	// Build constructs an offline dataset covering [windowStart, windowEnd).
+	// The implementation reads from the replay store and joins transition evidence.
+	Build(ctx context.Context, windowStart, windowEnd time.Time) (*OfflineDataset, error)
+}

--- a/src/semantic-router/pkg/selection/offline_metrics.go
+++ b/src/semantic-router/pkg/selection/offline_metrics.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// OfflineUpdateTotal counts offline weight update runs.
+	// Labels: status (success/error)
+	OfflineUpdateTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llm_offline_weight_update_total",
+			Help: "Total offline weight update runs by status.",
+		},
+		[]string{"status"},
+	)
+
+	// OfflineUpdateRecordsProcessed counts records consumed per offline run.
+	OfflineUpdateRecordsProcessed = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "llm_offline_weight_update_records_processed_total",
+			Help: "Total records processed across all offline weight update runs.",
+		},
+	)
+
+	// PolicyVersionActivations counts policy version promotions.
+	// Labels: version_id, source (offline_batch/online/manual/import)
+	PolicyVersionActivations = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llm_policy_version_activations_total",
+			Help: "Total policy version activations by version and source.",
+		},
+		[]string{"version_id", "source"},
+	)
+
+	// ShadowComparisonTotal counts shadow comparisons between active and shadow policies.
+	// Labels: agreed (true/false)
+	ShadowComparisonTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llm_shadow_comparison_total",
+			Help: "Total shadow comparisons between active and candidate policies.",
+		},
+		[]string{"agreed"},
+	)
+
+	// ShadowComparisonScoreDelta tracks the score difference between active and shadow policies.
+	ShadowComparisonScoreDelta = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "llm_shadow_comparison_score_delta",
+			Help:    "Distribution of score deltas (shadow - active) in shadow comparisons.",
+			Buckets: []float64{-0.5, -0.3, -0.2, -0.1, -0.05, 0, 0.05, 0.1, 0.2, 0.3, 0.5},
+		},
+	)
+)
+
+// RecordOfflineUpdate records the result of an offline weight update run.
+func RecordOfflineUpdate(success bool, recordCount int) {
+	status := "success"
+	if !success {
+		status = "error"
+	}
+	OfflineUpdateTotal.WithLabelValues(status).Inc()
+	if success {
+		OfflineUpdateRecordsProcessed.Add(float64(recordCount))
+	}
+}
+
+// RecordPolicyActivation records a policy version activation event.
+func RecordPolicyActivation(versionID, source string) {
+	PolicyVersionActivations.WithLabelValues(versionID, source).Inc()
+}
+
+// RecordShadowComparison records a shadow comparison between active and candidate.
+func RecordShadowComparison(comparison ShadowComparison) {
+	agreed := "false"
+	if comparison.Agreed {
+		agreed = "true"
+	}
+	ShadowComparisonTotal.WithLabelValues(agreed).Inc()
+	ShadowComparisonScoreDelta.Observe(comparison.ShadowScore - comparison.ActiveScore)
+}

--- a/src/semantic-router/pkg/selection/offline_test.go
+++ b/src/semantic-router/pkg/selection/offline_test.go
@@ -1,0 +1,559 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestOfflineUpdater_EmptyDataset(t *testing.T) {
+	updater := NewOfflineUpdater(nil)
+	_, err := updater.Update(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil dataset")
+	}
+	_, err = updater.Update(context.Background(), &OfflineDataset{}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty dataset")
+	}
+}
+
+func TestOfflineUpdater_BasicWinLoss(t *testing.T) {
+	updater := NewOfflineUpdater(DefaultOfflineUpdaterConfig())
+	now := time.Now()
+
+	dataset := &OfflineDataset{
+		Version:      1,
+		CreatedAt:    now,
+		WindowStart:  now.Add(-24 * time.Hour),
+		WindowEnd:    now,
+		SessionCount: 1,
+		Records: []OfflineDatasetRecord{
+			{
+				SessionID:       "s1",
+				TurnIndex:       0,
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
+				SelectionMethod: "rl_driven",
+				Outcome: OfflineOutcome{
+					Won:           boolPtr(true),
+					OpponentModel: "gpt-4o-mini",
+				},
+				Timestamp: now.Add(-23 * time.Hour),
+			},
+			{
+				SessionID:       "s1",
+				TurnIndex:       1,
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
+				SelectionMethod: "rl_driven",
+				Outcome: OfflineOutcome{
+					Won:           boolPtr(true),
+					OpponentModel: "gpt-4o-mini",
+				},
+				Timestamp: now.Add(-22 * time.Hour),
+			},
+			{
+				SessionID:       "s1",
+				TurnIndex:       2,
+				SelectedModel:   "gpt-4o-mini",
+				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
+				SelectionMethod: "rl_driven",
+				Outcome: OfflineOutcome{
+					Won:           boolPtr(true),
+					OpponentModel: "gpt-4o",
+				},
+				Timestamp: now.Add(-21 * time.Hour),
+			},
+			{
+				SessionID:       "s1",
+				TurnIndex:       3,
+				SelectedModel:   "gpt-4o-mini",
+				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
+				SelectionMethod: "rl_driven",
+				Outcome: OfflineOutcome{
+					Won:           boolPtr(true),
+					OpponentModel: "gpt-4o",
+				},
+				Timestamp: now.Add(-20 * time.Hour),
+			},
+			{
+				SessionID:       "s1",
+				TurnIndex:       4,
+				SelectedModel:   "gpt-4o-mini",
+				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
+				SelectionMethod: "rl_driven",
+				Outcome: OfflineOutcome{
+					Won:           boolPtr(true),
+					OpponentModel: "gpt-4o",
+				},
+				Timestamp: now.Add(-19 * time.Hour),
+			},
+		},
+	}
+
+	version, err := updater.Update(context.Background(), dataset, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if version.Status != PolicyStatusCandidate {
+		t.Errorf("expected candidate status, got %s", version.Status)
+	}
+	if version.Source != "offline_batch" {
+		t.Errorf("expected offline_batch source, got %s", version.Source)
+	}
+
+	// gpt-4o: 2 wins (as selected), 3 losses (as opponent) => alpha=1+2=3, beta=1+3=4
+	gpt4o := version.Weights.Global["gpt-4o"]
+	if gpt4o == nil {
+		t.Fatal("expected gpt-4o in global weights")
+	}
+	if gpt4o.Distribution.Alpha != 3.0 {
+		t.Errorf("expected gpt-4o alpha=3.0, got %.1f", gpt4o.Distribution.Alpha)
+	}
+	if gpt4o.Distribution.Beta != 4.0 {
+		t.Errorf("expected gpt-4o beta=4.0, got %.1f", gpt4o.Distribution.Beta)
+	}
+
+	// gpt-4o-mini: 3 wins (as selected), 2 losses (as opponent) => alpha=1+3=4, beta=1+2=3
+	mini := version.Weights.Global["gpt-4o-mini"]
+	if mini == nil {
+		t.Fatal("expected gpt-4o-mini in global weights")
+	}
+	if mini.Distribution.Alpha != 4.0 {
+		t.Errorf("expected gpt-4o-mini alpha=4.0, got %.1f", mini.Distribution.Alpha)
+	}
+	if mini.Distribution.Beta != 3.0 {
+		t.Errorf("expected gpt-4o-mini beta=3.0, got %.1f", mini.Distribution.Beta)
+	}
+}
+
+func TestOfflineUpdater_TransitionPenalty(t *testing.T) {
+	cfg := DefaultOfflineUpdaterConfig()
+	cfg.TransitionPenaltyWeight = 0.5
+	cfg.MinRecordsPerModel = 1
+	updater := NewOfflineUpdater(cfg)
+	now := time.Now()
+
+	dataset := &OfflineDataset{
+		Version:         1,
+		CreatedAt:       now,
+		WindowStart:     now.Add(-1 * time.Hour),
+		WindowEnd:       now,
+		SessionCount:    1,
+		TransitionCount: 1,
+		Records: []OfflineDatasetRecord{
+			{
+				SessionID:       "s1",
+				TurnIndex:       1,
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o", "claude-3"},
+				SelectionMethod: "rl_driven",
+				Outcome:         OfflineOutcome{Won: boolPtr(true), OpponentModel: "claude-3"},
+				TransitionEvidence: &OfflineTransitionEvidence{
+					PreviousModel: "claude-3",
+					CacheWarmth:   0.8,
+					CacheWarmthOK: true,
+				},
+				Timestamp: now.Add(-30 * time.Minute),
+			},
+		},
+	}
+
+	version, err := updater.Update(context.Background(), dataset, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// claude-3 gets: 1 loss (as opponent) + 0.5 transition penalty
+	claude := version.Weights.Global["claude-3"]
+	if claude == nil {
+		t.Fatal("expected claude-3 in global weights")
+	}
+	// beta should be 1 (prior) + 1 (opponent loss) + 0.5 (transition) = 2.5
+	if claude.Distribution.Beta != 2.5 {
+		t.Errorf("expected claude-3 beta=2.5, got %.1f", claude.Distribution.Beta)
+	}
+}
+
+func TestOfflineUpdater_ParentWeightBlending(t *testing.T) {
+	cfg := DefaultOfflineUpdaterConfig()
+	cfg.MinRecordsPerModel = 10 // High threshold so sparse model keeps parent weights
+	updater := NewOfflineUpdater(cfg)
+	now := time.Now()
+
+	parentWeights := &PolicyWeights{
+		Global: map[string]*ModelPreference{
+			"gpt-4o": {
+				Model:             "gpt-4o",
+				Distribution:      BetaDistribution{Alpha: 10.0, Beta: 5.0},
+				TotalInteractions: 15,
+			},
+			"claude-3": {
+				Model:             "claude-3",
+				Distribution:      BetaDistribution{Alpha: 8.0, Beta: 8.0},
+				TotalInteractions: 16,
+			},
+		},
+	}
+
+	dataset := &OfflineDataset{
+		Version:      1,
+		CreatedAt:    now,
+		WindowStart:  now.Add(-1 * time.Hour),
+		WindowEnd:    now,
+		SessionCount: 1,
+		Records: []OfflineDatasetRecord{
+			{
+				SessionID:       "s1",
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o"},
+				Outcome:         OfflineOutcome{Won: boolPtr(true)},
+				Timestamp:       now,
+			},
+		},
+	}
+
+	version, err := updater.Update(context.Background(), dataset, parentWeights)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// gpt-4o has only 1 record < MinRecordsPerModel=10, should keep parent weights
+	gpt4o := version.Weights.Global["gpt-4o"]
+	if gpt4o.Distribution.Alpha != 10.0 || gpt4o.Distribution.Beta != 5.0 {
+		t.Errorf("expected parent weights for sparse model, got alpha=%.1f beta=%.1f",
+			gpt4o.Distribution.Alpha, gpt4o.Distribution.Beta)
+	}
+
+	// claude-3 had no new records, should be carried forward from parent
+	claude := version.Weights.Global["claude-3"]
+	if claude == nil {
+		t.Fatal("expected claude-3 carried forward from parent")
+	}
+	if claude.Distribution.Alpha != 8.0 {
+		t.Errorf("expected claude-3 alpha=8.0, got %.1f", claude.Distribution.Alpha)
+	}
+}
+
+func TestOfflineUpdater_CategoryWeights(t *testing.T) {
+	cfg := DefaultOfflineUpdaterConfig()
+	cfg.MinRecordsPerModel = 1
+	updater := NewOfflineUpdater(cfg)
+	now := time.Now()
+
+	dataset := &OfflineDataset{
+		Version:      1,
+		CreatedAt:    now,
+		WindowStart:  now.Add(-1 * time.Hour),
+		WindowEnd:    now,
+		SessionCount: 1,
+		Records: []OfflineDatasetRecord{
+			{
+				SessionID:       "s1",
+				DecisionName:    "math",
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o"},
+				Outcome:         OfflineOutcome{Won: boolPtr(true)},
+				Timestamp:       now,
+			},
+		},
+	}
+
+	version, err := updater.Update(context.Background(), dataset, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if version.Weights.Category == nil || version.Weights.Category["math"] == nil {
+		t.Fatal("expected math category weights")
+	}
+	mathGpt4o := version.Weights.Category["math"]["gpt-4o"]
+	if mathGpt4o == nil {
+		t.Fatal("expected gpt-4o in math category")
+	}
+	if mathGpt4o.Distribution.Alpha != 2.0 {
+		t.Errorf("expected alpha=2.0, got %.1f", mathGpt4o.Distribution.Alpha)
+	}
+}
+
+func TestOfflineUpdater_ImplicitFeedbackWeight(t *testing.T) {
+	cfg := DefaultOfflineUpdaterConfig()
+	cfg.ImplicitFeedbackWeight = 0.5
+	cfg.MinRecordsPerModel = 1
+	updater := NewOfflineUpdater(cfg)
+	now := time.Now()
+
+	dataset := &OfflineDataset{
+		Version:      1,
+		CreatedAt:    now,
+		WindowStart:  now.Add(-1 * time.Hour),
+		WindowEnd:    now,
+		SessionCount: 1,
+		Records: []OfflineDatasetRecord{
+			{
+				SessionID:       "s1",
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o"},
+				Outcome: OfflineOutcome{
+					Won:                boolPtr(true),
+					FeedbackType:       "implicit_satisfied",
+					FeedbackConfidence: 0.8,
+				},
+				Timestamp: now,
+			},
+		},
+	}
+
+	version, err := updater.Update(context.Background(), dataset, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gpt4o := version.Weights.Global["gpt-4o"]
+	// weight = 0.5 * 0.8 = 0.4, so alpha = 1 + 0.4 = 1.4
+	if gpt4o.Distribution.Alpha != 1.4 {
+		t.Errorf("expected alpha=1.4, got %.1f", gpt4o.Distribution.Alpha)
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	a := &PolicyVersion{
+		ID: "v1",
+		Weights: PolicyWeights{
+			Global: map[string]*ModelPreference{
+				"gpt-4o": {Model: "gpt-4o", Distribution: BetaDistribution{Alpha: 10, Beta: 5}},
+				"claude": {Model: "claude", Distribution: BetaDistribution{Alpha: 5, Beta: 5}},
+			},
+		},
+	}
+	b := &PolicyVersion{
+		ID: "v2",
+		Weights: PolicyWeights{
+			Global: map[string]*ModelPreference{
+				"gpt-4o": {Model: "gpt-4o", Distribution: BetaDistribution{Alpha: 12, Beta: 4}},
+				"llama":  {Model: "llama", Distribution: BetaDistribution{Alpha: 3, Beta: 7}},
+			},
+		},
+	}
+
+	diffs := CompareVersions(a, b)
+	if len(diffs) != 3 {
+		t.Fatalf("expected 3 model diffs, got %d", len(diffs))
+	}
+
+	// Check sorted order: claude, gpt-4o, llama
+	if diffs[0].Model != "claude" {
+		t.Errorf("expected first diff to be claude, got %s", diffs[0].Model)
+	}
+	if diffs[1].Model != "gpt-4o" {
+		t.Errorf("expected second diff to be gpt-4o, got %s", diffs[1].Model)
+	}
+
+	// gpt-4o: mean_a = 10/15 ≈ 0.667, mean_b = 12/16 = 0.75
+	if diffs[1].MeanDelta < 0.08 || diffs[1].MeanDelta > 0.09 {
+		t.Errorf("expected gpt-4o mean_delta ≈ 0.083, got %.3f", diffs[1].MeanDelta)
+	}
+}
+
+func TestPolicyVersionStore_SaveLoadActivate(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "policy-version-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	store, err := NewPolicyVersionStore(filepath.Join(tmpDir, "policies"))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	v1 := &PolicyVersion{
+		ID:        "v1",
+		CreatedAt: time.Now(),
+		Source:    "manual",
+		Status:    PolicyStatusCandidate,
+		Weights: PolicyWeights{
+			Global: map[string]*ModelPreference{
+				"gpt-4o": {Model: "gpt-4o", Distribution: BetaDistribution{Alpha: 5, Beta: 3}},
+			},
+		},
+	}
+
+	if err := store.Save(v1); err != nil {
+		t.Fatalf("save v1: %v", err)
+	}
+
+	loaded, err := store.Load("v1")
+	if err != nil {
+		t.Fatalf("load v1: %v", err)
+	}
+	if loaded.ID != "v1" {
+		t.Errorf("expected v1, got %s", loaded.ID)
+	}
+	if loaded.Weights.Global["gpt-4o"].Distribution.Alpha != 5 {
+		t.Errorf("expected alpha=5, got %.1f", loaded.Weights.Global["gpt-4o"].Distribution.Alpha)
+	}
+
+	// Activate v1
+	if err := store.Activate("v1"); err != nil {
+		t.Fatalf("activate v1: %v", err)
+	}
+
+	manifest, err := store.LoadManifest()
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if manifest.ActiveVersion != "v1" {
+		t.Errorf("expected active version v1, got %s", manifest.ActiveVersion)
+	}
+
+	// Save v2 and shadow it
+	v2 := &PolicyVersion{
+		ID:       "v2",
+		ParentID: "v1",
+		Source:   "offline_batch",
+		Status:   PolicyStatusCandidate,
+		Weights: PolicyWeights{
+			Global: map[string]*ModelPreference{
+				"gpt-4o": {Model: "gpt-4o", Distribution: BetaDistribution{Alpha: 8, Beta: 4}},
+			},
+		},
+	}
+	if err := store.Save(v2); err != nil {
+		t.Fatalf("save v2: %v", err)
+	}
+	if err := store.Shadow("v2"); err != nil {
+		t.Fatalf("shadow v2: %v", err)
+	}
+
+	manifest, err = store.LoadManifest()
+	if err != nil {
+		t.Fatalf("load manifest after shadow: %v", err)
+	}
+	if manifest.ShadowVersion != "v2" {
+		t.Errorf("expected shadow version v2, got %s", manifest.ShadowVersion)
+	}
+	if manifest.ActiveVersion != "v1" {
+		t.Errorf("expected active still v1, got %s", manifest.ActiveVersion)
+	}
+
+	// Promote v2 to active (v1 gets retired)
+	if err := store.Activate("v2"); err != nil {
+		t.Fatalf("activate v2: %v", err)
+	}
+
+	manifest, err = store.LoadManifest()
+	if err != nil {
+		t.Fatalf("load manifest after promote: %v", err)
+	}
+	if manifest.ActiveVersion != "v2" {
+		t.Errorf("expected active version v2, got %s", manifest.ActiveVersion)
+	}
+	if manifest.ShadowVersion != "" {
+		t.Errorf("expected empty shadow after promote, got %s", manifest.ShadowVersion)
+	}
+
+	// v1 should be retired
+	v1Loaded, err := store.Load("v1")
+	if err != nil {
+		t.Fatalf("load v1 after retire: %v", err)
+	}
+	if v1Loaded.Status != PolicyStatusRetired {
+		t.Errorf("expected v1 retired, got %s", v1Loaded.Status)
+	}
+}
+
+func TestPolicyVersionStore_Revert(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "policy-revert-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck // cleanup in test
+
+	store, err := NewPolicyVersionStore(filepath.Join(tmpDir, "policies"))
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	v1 := &PolicyVersion{ID: "v1", Source: "manual", Status: PolicyStatusCandidate,
+		Weights: PolicyWeights{Global: map[string]*ModelPreference{}}}
+	v2 := &PolicyVersion{ID: "v2", Source: "offline_batch", Status: PolicyStatusCandidate,
+		Weights: PolicyWeights{Global: map[string]*ModelPreference{}}}
+
+	_ = store.Save(v1)
+	_ = store.Save(v2)
+	_ = store.Activate("v1")
+	_ = store.Activate("v2")
+
+	// Revert to v1
+	if err := store.Revert("v1"); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+
+	manifest, _ := store.LoadManifest()
+	if manifest.ActiveVersion != "v1" {
+		t.Errorf("expected v1 after revert, got %s", manifest.ActiveVersion)
+	}
+
+	v2Loaded, _ := store.Load("v2")
+	if v2Loaded.Status != PolicyStatusRetired {
+		t.Errorf("expected v2 retired after revert, got %s", v2Loaded.Status)
+	}
+}
+
+func TestOfflineUpdater_ServerError(t *testing.T) {
+	cfg := DefaultOfflineUpdaterConfig()
+	cfg.MinRecordsPerModel = 1
+	updater := NewOfflineUpdater(cfg)
+	now := time.Now()
+
+	dataset := &OfflineDataset{
+		Version:      1,
+		CreatedAt:    now,
+		WindowStart:  now.Add(-1 * time.Hour),
+		WindowEnd:    now,
+		SessionCount: 1,
+		Records: []OfflineDatasetRecord{
+			{
+				SessionID:       "s1",
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o"},
+				Outcome:         OfflineOutcome{ResponseStatus: 500},
+				Timestamp:       now,
+			},
+		},
+	}
+
+	version, err := updater.Update(context.Background(), dataset, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gpt4o := version.Weights.Global["gpt-4o"]
+	// Server error adds 0.5 to beta: beta = 1 (prior) + 0.5 = 1.5
+	if gpt4o.Distribution.Beta != 1.5 {
+		t.Errorf("expected beta=1.5 for server error, got %.1f", gpt4o.Distribution.Beta)
+	}
+}

--- a/src/semantic-router/pkg/selection/offline_test.go
+++ b/src/semantic-router/pkg/selection/offline_test.go
@@ -368,6 +368,45 @@ func TestOfflineUpdater_ImplicitFeedbackWeight(t *testing.T) {
 	}
 }
 
+func TestOfflineUpdater_ExplicitFeedbackFullWeight(t *testing.T) {
+	cfg := DefaultOfflineUpdaterConfig()
+	cfg.ImplicitFeedbackWeight = 0.5
+	cfg.MinRecordsPerModel = 1
+	updater := NewOfflineUpdater(cfg)
+	now := time.Now()
+
+	dataset := &OfflineDataset{
+		Version:      1,
+		CreatedAt:    now,
+		WindowStart:  now.Add(-1 * time.Hour),
+		WindowEnd:    now,
+		SessionCount: 1,
+		Records: []OfflineDatasetRecord{
+			{
+				SessionID:       "s1",
+				SelectedModel:   "gpt-4o",
+				CandidateModels: []string{"gpt-4o"},
+				Outcome: OfflineOutcome{
+					Won:          boolPtr(true),
+					FeedbackType: "explicit",
+				},
+				Timestamp: now,
+			},
+		},
+	}
+
+	version, err := updater.Update(context.Background(), dataset, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gpt4o := version.Weights.Global["gpt-4o"]
+	// Explicit feedback should get full weight (1.0), so alpha = 1 + 1.0 = 2.0
+	if gpt4o.Distribution.Alpha != 2.0 {
+		t.Errorf("expected alpha=2.0 for explicit feedback, got %.1f", gpt4o.Distribution.Alpha)
+	}
+}
+
 func TestCompareVersions(t *testing.T) {
 	a := &PolicyVersion{
 		ID: "v1",

--- a/src/semantic-router/pkg/selection/offline_test.go
+++ b/src/semantic-router/pkg/selection/offline_test.go
@@ -26,6 +26,91 @@ import (
 
 func boolPtr(v bool) *bool { return &v }
 
+func offlineWinRecord(turnIndex int, selectedModel, opponentModel string, timestamp time.Time) OfflineDatasetRecord {
+	return OfflineDatasetRecord{
+		SessionID:       "s1",
+		TurnIndex:       turnIndex,
+		SelectedModel:   selectedModel,
+		CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
+		SelectionMethod: "rl_driven",
+		Outcome: OfflineOutcome{
+			Won:           boolPtr(true),
+			OpponentModel: opponentModel,
+		},
+		Timestamp: timestamp,
+	}
+}
+
+func gpt4oPolicyVersion(id, parentID, source string, alpha, beta float64) *PolicyVersion {
+	return &PolicyVersion{
+		ID:        id,
+		ParentID:  parentID,
+		CreatedAt: time.Now(),
+		Source:    source,
+		Status:    PolicyStatusCandidate,
+		Weights: PolicyWeights{
+			Global: map[string]*ModelPreference{
+				"gpt-4o": {Model: "gpt-4o", Distribution: BetaDistribution{Alpha: alpha, Beta: beta}},
+			},
+		},
+	}
+}
+
+func emptyPolicyVersion(id, source string) *PolicyVersion {
+	return &PolicyVersion{
+		ID:      id,
+		Source:  source,
+		Status:  PolicyStatusCandidate,
+		Weights: PolicyWeights{Global: map[string]*ModelPreference{}},
+	}
+}
+
+func savePolicyVersion(t *testing.T, store *PolicyVersionStore, version *PolicyVersion) {
+	t.Helper()
+	if err := store.Save(version); err != nil {
+		t.Fatalf("save %s: %v", version.ID, err)
+	}
+}
+
+func activatePolicyVersion(t *testing.T, store *PolicyVersionStore, versionID string) {
+	t.Helper()
+	if err := store.Activate(versionID); err != nil {
+		t.Fatalf("activate %s: %v", versionID, err)
+	}
+}
+
+func shadowPolicyVersion(t *testing.T, store *PolicyVersionStore, versionID string) {
+	t.Helper()
+	if err := store.Shadow(versionID); err != nil {
+		t.Fatalf("shadow %s: %v", versionID, err)
+	}
+}
+
+func requireManifestVersions(t *testing.T, store *PolicyVersionStore, activeVersion, shadowVersion string) {
+	t.Helper()
+	manifest, err := store.LoadManifest()
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if manifest.ActiveVersion != activeVersion {
+		t.Errorf("expected active version %s, got %s", activeVersion, manifest.ActiveVersion)
+	}
+	if manifest.ShadowVersion != shadowVersion {
+		t.Errorf("expected shadow version %s, got %s", shadowVersion, manifest.ShadowVersion)
+	}
+}
+
+func requirePolicyStatus(t *testing.T, store *PolicyVersionStore, versionID string, status PolicyStatus) {
+	t.Helper()
+	version, err := store.Load(versionID)
+	if err != nil {
+		t.Fatalf("load %s: %v", versionID, err)
+	}
+	if version.Status != status {
+		t.Errorf("expected %s status %s, got %s", versionID, status, version.Status)
+	}
+}
+
 func TestOfflineUpdater_EmptyDataset(t *testing.T) {
 	updater := NewOfflineUpdater(nil)
 	_, err := updater.Update(context.Background(), nil, nil)
@@ -49,66 +134,11 @@ func TestOfflineUpdater_BasicWinLoss(t *testing.T) {
 		WindowEnd:    now,
 		SessionCount: 1,
 		Records: []OfflineDatasetRecord{
-			{
-				SessionID:       "s1",
-				TurnIndex:       0,
-				SelectedModel:   "gpt-4o",
-				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
-				SelectionMethod: "rl_driven",
-				Outcome: OfflineOutcome{
-					Won:           boolPtr(true),
-					OpponentModel: "gpt-4o-mini",
-				},
-				Timestamp: now.Add(-23 * time.Hour),
-			},
-			{
-				SessionID:       "s1",
-				TurnIndex:       1,
-				SelectedModel:   "gpt-4o",
-				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
-				SelectionMethod: "rl_driven",
-				Outcome: OfflineOutcome{
-					Won:           boolPtr(true),
-					OpponentModel: "gpt-4o-mini",
-				},
-				Timestamp: now.Add(-22 * time.Hour),
-			},
-			{
-				SessionID:       "s1",
-				TurnIndex:       2,
-				SelectedModel:   "gpt-4o-mini",
-				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
-				SelectionMethod: "rl_driven",
-				Outcome: OfflineOutcome{
-					Won:           boolPtr(true),
-					OpponentModel: "gpt-4o",
-				},
-				Timestamp: now.Add(-21 * time.Hour),
-			},
-			{
-				SessionID:       "s1",
-				TurnIndex:       3,
-				SelectedModel:   "gpt-4o-mini",
-				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
-				SelectionMethod: "rl_driven",
-				Outcome: OfflineOutcome{
-					Won:           boolPtr(true),
-					OpponentModel: "gpt-4o",
-				},
-				Timestamp: now.Add(-20 * time.Hour),
-			},
-			{
-				SessionID:       "s1",
-				TurnIndex:       4,
-				SelectedModel:   "gpt-4o-mini",
-				CandidateModels: []string{"gpt-4o", "gpt-4o-mini"},
-				SelectionMethod: "rl_driven",
-				Outcome: OfflineOutcome{
-					Won:           boolPtr(true),
-					OpponentModel: "gpt-4o",
-				},
-				Timestamp: now.Add(-19 * time.Hour),
-			},
+			offlineWinRecord(0, "gpt-4o", "gpt-4o-mini", now.Add(-23*time.Hour)),
+			offlineWinRecord(1, "gpt-4o", "gpt-4o-mini", now.Add(-22*time.Hour)),
+			offlineWinRecord(2, "gpt-4o-mini", "gpt-4o", now.Add(-21*time.Hour)),
+			offlineWinRecord(3, "gpt-4o-mini", "gpt-4o", now.Add(-20*time.Hour)),
+			offlineWinRecord(4, "gpt-4o-mini", "gpt-4o", now.Add(-19*time.Hour)),
 		},
 	}
 
@@ -389,21 +419,9 @@ func TestPolicyVersionStore_SaveLoadActivate(t *testing.T) {
 		t.Fatalf("failed to create store: %v", err)
 	}
 
-	v1 := &PolicyVersion{
-		ID:        "v1",
-		CreatedAt: time.Now(),
-		Source:    "manual",
-		Status:    PolicyStatusCandidate,
-		Weights: PolicyWeights{
-			Global: map[string]*ModelPreference{
-				"gpt-4o": {Model: "gpt-4o", Distribution: BetaDistribution{Alpha: 5, Beta: 3}},
-			},
-		},
-	}
+	v1 := gpt4oPolicyVersion("v1", "", "manual", 5, 3)
 
-	if err := store.Save(v1); err != nil {
-		t.Fatalf("save v1: %v", err)
-	}
+	savePolicyVersion(t, store, v1)
 
 	loaded, err := store.Load("v1")
 	if err != nil {
@@ -417,72 +435,21 @@ func TestPolicyVersionStore_SaveLoadActivate(t *testing.T) {
 	}
 
 	// Activate v1
-	if err := store.Activate("v1"); err != nil {
-		t.Fatalf("activate v1: %v", err)
-	}
-
-	manifest, err := store.LoadManifest()
-	if err != nil {
-		t.Fatalf("load manifest: %v", err)
-	}
-	if manifest.ActiveVersion != "v1" {
-		t.Errorf("expected active version v1, got %s", manifest.ActiveVersion)
-	}
+	activatePolicyVersion(t, store, "v1")
+	requireManifestVersions(t, store, "v1", "")
 
 	// Save v2 and shadow it
-	v2 := &PolicyVersion{
-		ID:       "v2",
-		ParentID: "v1",
-		Source:   "offline_batch",
-		Status:   PolicyStatusCandidate,
-		Weights: PolicyWeights{
-			Global: map[string]*ModelPreference{
-				"gpt-4o": {Model: "gpt-4o", Distribution: BetaDistribution{Alpha: 8, Beta: 4}},
-			},
-		},
-	}
-	if err := store.Save(v2); err != nil {
-		t.Fatalf("save v2: %v", err)
-	}
-	if err := store.Shadow("v2"); err != nil {
-		t.Fatalf("shadow v2: %v", err)
-	}
-
-	manifest, err = store.LoadManifest()
-	if err != nil {
-		t.Fatalf("load manifest after shadow: %v", err)
-	}
-	if manifest.ShadowVersion != "v2" {
-		t.Errorf("expected shadow version v2, got %s", manifest.ShadowVersion)
-	}
-	if manifest.ActiveVersion != "v1" {
-		t.Errorf("expected active still v1, got %s", manifest.ActiveVersion)
-	}
+	v2 := gpt4oPolicyVersion("v2", "v1", "offline_batch", 8, 4)
+	savePolicyVersion(t, store, v2)
+	shadowPolicyVersion(t, store, "v2")
+	requireManifestVersions(t, store, "v1", "v2")
 
 	// Promote v2 to active (v1 gets retired)
-	if err := store.Activate("v2"); err != nil {
-		t.Fatalf("activate v2: %v", err)
-	}
-
-	manifest, err = store.LoadManifest()
-	if err != nil {
-		t.Fatalf("load manifest after promote: %v", err)
-	}
-	if manifest.ActiveVersion != "v2" {
-		t.Errorf("expected active version v2, got %s", manifest.ActiveVersion)
-	}
-	if manifest.ShadowVersion != "" {
-		t.Errorf("expected empty shadow after promote, got %s", manifest.ShadowVersion)
-	}
+	activatePolicyVersion(t, store, "v2")
+	requireManifestVersions(t, store, "v2", "")
 
 	// v1 should be retired
-	v1Loaded, err := store.Load("v1")
-	if err != nil {
-		t.Fatalf("load v1 after retire: %v", err)
-	}
-	if v1Loaded.Status != PolicyStatusRetired {
-		t.Errorf("expected v1 retired, got %s", v1Loaded.Status)
-	}
+	requirePolicyStatus(t, store, "v1", PolicyStatusRetired)
 }
 
 func TestPolicyVersionStore_Revert(t *testing.T) {
@@ -497,10 +464,8 @@ func TestPolicyVersionStore_Revert(t *testing.T) {
 		t.Fatalf("failed to create store: %v", err)
 	}
 
-	v1 := &PolicyVersion{ID: "v1", Source: "manual", Status: PolicyStatusCandidate,
-		Weights: PolicyWeights{Global: map[string]*ModelPreference{}}}
-	v2 := &PolicyVersion{ID: "v2", Source: "offline_batch", Status: PolicyStatusCandidate,
-		Weights: PolicyWeights{Global: map[string]*ModelPreference{}}}
+	v1 := emptyPolicyVersion("v1", "manual")
+	v2 := emptyPolicyVersion("v2", "offline_batch")
 
 	_ = store.Save(v1)
 	_ = store.Save(v2)

--- a/src/semantic-router/pkg/selection/offline_updater.go
+++ b/src/semantic-router/pkg/selection/offline_updater.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -172,7 +173,7 @@ func (u *OfflineUpdater) getOrCreate(m map[string]*betaAccumulator, model string
 
 func (u *OfflineUpdater) recordWeight(rec OfflineDatasetRecord) float64 {
 	weight := 1.0
-	if rec.Outcome.FeedbackType != "" {
+	if strings.HasPrefix(rec.Outcome.FeedbackType, "implicit") {
 		weight = u.config.ImplicitFeedbackWeight
 		if rec.Outcome.FeedbackConfidence > 0 {
 			weight *= rec.Outcome.FeedbackConfidence

--- a/src/semantic-router/pkg/selection/offline_updater.go
+++ b/src/semantic-router/pkg/selection/offline_updater.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// OfflineUpdaterConfig configures the offline weight update process.
+type OfflineUpdaterConfig struct {
+	// ImplicitFeedbackWeight controls weight of auto-detected feedback signals
+	// during offline replay (same semantics as RLDrivenConfig.ImplicitFeedbackWeight).
+	ImplicitFeedbackWeight float64
+
+	// TransitionPenaltyWeight controls how much model-switch transitions
+	// penalize the switched-away model's Beta distribution.
+	TransitionPenaltyWeight float64
+
+	// MinRecordsPerModel is the minimum number of observations required before
+	// a model's offline weights are considered meaningful. Models below this
+	// threshold keep their prior-version weights unchanged.
+	MinRecordsPerModel int
+
+	// ParentVersionID is the version these weights are derived from.
+	// The offline updater blends new evidence with the parent's priors.
+	ParentVersionID string
+}
+
+// DefaultOfflineUpdaterConfig returns sensible defaults.
+func DefaultOfflineUpdaterConfig() *OfflineUpdaterConfig {
+	return &OfflineUpdaterConfig{
+		ImplicitFeedbackWeight:  0.5,
+		TransitionPenaltyWeight: 0.3,
+		MinRecordsPerModel:      5,
+	}
+}
+
+// OfflineUpdater replays an OfflineDataset and produces a new PolicyVersion
+// with updated Beta distribution weights. It does not touch runtime state;
+// the caller is responsible for persisting and activating the result.
+type OfflineUpdater struct {
+	config *OfflineUpdaterConfig
+}
+
+// NewOfflineUpdater creates a new offline updater.
+func NewOfflineUpdater(cfg *OfflineUpdaterConfig) *OfflineUpdater {
+	if cfg == nil {
+		cfg = DefaultOfflineUpdaterConfig()
+	}
+	return &OfflineUpdater{config: cfg}
+}
+
+// Update replays the dataset and returns a candidate PolicyVersion.
+// If parentWeights is non-nil, the new weights are blended with the parent's
+// priors so that models with few observations retain stable estimates.
+func (u *OfflineUpdater) Update(ctx context.Context, dataset *OfflineDataset, parentWeights *PolicyWeights) (*PolicyVersion, error) {
+	if dataset == nil || len(dataset.Records) == 0 {
+		return nil, fmt.Errorf("empty dataset")
+	}
+
+	// Accumulate per-scope Beta distribution updates.
+	global := make(map[string]*betaAccumulator)
+	category := make(map[string]map[string]*betaAccumulator)
+	user := make(map[string]map[string]*betaAccumulator)
+
+	for _, rec := range dataset.Records {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		weight := u.recordWeight(rec)
+
+		// Apply outcome feedback to the selected model.
+		u.applyOutcome(global, rec.SelectedModel, rec.Outcome, weight)
+
+		if rec.DecisionName != "" {
+			if category[rec.DecisionName] == nil {
+				category[rec.DecisionName] = make(map[string]*betaAccumulator)
+			}
+			u.applyOutcome(category[rec.DecisionName], rec.SelectedModel, rec.Outcome, weight)
+		}
+
+		if rec.UserID != "" {
+			if user[rec.UserID] == nil {
+				user[rec.UserID] = make(map[string]*betaAccumulator)
+			}
+			u.applyOutcome(user[rec.UserID], rec.SelectedModel, rec.Outcome, weight)
+		}
+
+		// Apply transition penalty if a model switch occurred.
+		if rec.TransitionEvidence != nil && rec.TransitionEvidence.PreviousModel != "" {
+			penalty := u.config.TransitionPenaltyWeight
+			acc := u.getOrCreate(global, rec.TransitionEvidence.PreviousModel)
+			acc.beta += penalty
+			acc.count++
+		}
+	}
+
+	// Build PolicyWeights from accumulators, blending with parent priors.
+	weights := PolicyWeights{
+		Global:   u.finalize(global, parentGlobal(parentWeights)),
+		Category: u.finalizeScoped(category, parentCategory(parentWeights)),
+		User:     u.finalizeScoped(user, parentUser(parentWeights)),
+	}
+
+	versionID := fmt.Sprintf("offline-%s", time.Now().UTC().Format("20060102-150405"))
+	version := &PolicyVersion{
+		ID:        versionID,
+		ParentID:  u.config.ParentVersionID,
+		CreatedAt: time.Now().UTC(),
+		Source:    "offline_batch",
+		DatasetWindow: &TimeWindow{
+			Start: dataset.WindowStart,
+			End:   dataset.WindowEnd,
+		},
+		TrainingStats: &TrainingStats{
+			RecordCount:     len(dataset.Records),
+			SessionCount:    dataset.SessionCount,
+			TransitionCount: dataset.TransitionCount,
+			FeedbackCount:   countFeedback(dataset),
+		},
+		Status:  PolicyStatusCandidate,
+		Weights: weights,
+	}
+
+	logging.ComponentEvent("selection", "offline_update_complete", map[string]interface{}{
+		"version_id":         versionID,
+		"record_count":       len(dataset.Records),
+		"session_count":      dataset.SessionCount,
+		"global_model_count": len(weights.Global),
+	})
+
+	return version, nil
+}
+
+// betaAccumulator tracks incremental Beta distribution updates.
+type betaAccumulator struct {
+	alpha float64
+	beta  float64
+	count int
+}
+
+func (u *OfflineUpdater) getOrCreate(m map[string]*betaAccumulator, model string) *betaAccumulator {
+	acc, ok := m[model]
+	if !ok {
+		acc = &betaAccumulator{}
+		m[model] = acc
+	}
+	return acc
+}
+
+func (u *OfflineUpdater) recordWeight(rec OfflineDatasetRecord) float64 {
+	weight := 1.0
+	if rec.Outcome.FeedbackType != "" {
+		weight = u.config.ImplicitFeedbackWeight
+		if rec.Outcome.FeedbackConfidence > 0 {
+			weight *= rec.Outcome.FeedbackConfidence
+		}
+	}
+	return weight
+}
+
+func (u *OfflineUpdater) applyOutcome(scope map[string]*betaAccumulator, model string, outcome OfflineOutcome, weight float64) {
+	acc := u.getOrCreate(scope, model)
+	acc.count++
+
+	if outcome.Won != nil {
+		if *outcome.Won {
+			if outcome.Tie {
+				acc.alpha += 0.5 * weight
+				acc.beta += 0.5 * weight
+			} else {
+				acc.alpha += weight
+			}
+		} else {
+			if outcome.Tie {
+				acc.alpha += 0.5 * weight
+				acc.beta += 0.5 * weight
+			} else {
+				acc.beta += weight
+			}
+		}
+	}
+
+	// Apply opponent's inverse outcome.
+	if outcome.OpponentModel != "" && outcome.Won != nil {
+		opp := u.getOrCreate(scope, outcome.OpponentModel)
+		opp.count++
+		if *outcome.Won {
+			if outcome.Tie {
+				opp.alpha += 0.5 * weight
+				opp.beta += 0.5 * weight
+			} else {
+				opp.beta += weight
+			}
+		} else {
+			if outcome.Tie {
+				opp.alpha += 0.5 * weight
+				opp.beta += 0.5 * weight
+			} else {
+				opp.alpha += weight
+			}
+		}
+	}
+
+	// Implicit outcome from response status.
+	if outcome.ResponseStatus >= 500 {
+		acc.beta += weight * 0.5
+	}
+}
+
+func (u *OfflineUpdater) finalize(accs map[string]*betaAccumulator, parent map[string]*ModelPreference) map[string]*ModelPreference {
+	result := make(map[string]*ModelPreference, len(accs))
+
+	for model, acc := range accs {
+		// Start from parent prior or uniform prior.
+		priorAlpha, priorBeta := 1.0, 1.0
+		if parent != nil {
+			if p, ok := parent[model]; ok {
+				priorAlpha = p.Distribution.Alpha
+				priorBeta = p.Distribution.Beta
+			}
+		}
+
+		pref := &ModelPreference{
+			Model: model,
+			Distribution: BetaDistribution{
+				Alpha: priorAlpha + acc.alpha,
+				Beta:  priorBeta + acc.beta,
+			},
+			TotalInteractions: acc.count,
+			LastUpdated:       time.Now().UTC(),
+		}
+
+		// If too few observations, keep the parent prior unchanged.
+		if acc.count < u.config.MinRecordsPerModel && parent != nil {
+			if p, ok := parent[model]; ok {
+				pref = p
+			}
+		}
+
+		result[model] = pref
+	}
+
+	// Carry forward parent models that had no new observations.
+	if parent != nil {
+		for model, p := range parent {
+			if _, seen := result[model]; !seen {
+				result[model] = p
+			}
+		}
+	}
+
+	return result
+}
+
+func (u *OfflineUpdater) finalizeScoped(scoped map[string]map[string]*betaAccumulator, parent map[string]map[string]*ModelPreference) map[string]map[string]*ModelPreference {
+	if len(scoped) == 0 && len(parent) == 0 {
+		return nil
+	}
+	result := make(map[string]map[string]*ModelPreference, len(scoped))
+	for scope, accs := range scoped {
+		var parentScope map[string]*ModelPreference
+		if parent != nil {
+			parentScope = parent[scope]
+		}
+		result[scope] = u.finalize(accs, parentScope)
+	}
+	// Carry forward parent scopes with no new data.
+	if parent != nil {
+		for scope, prefs := range parent {
+			if _, seen := result[scope]; !seen {
+				result[scope] = prefs
+			}
+		}
+	}
+	return result
+}
+
+// CompareVersions produces a summary comparing two policy versions' weight
+// distributions for all models that appear in either version.
+func CompareVersions(a, b *PolicyVersion) []ModelWeightDiff {
+	models := make(map[string]bool)
+	for m := range a.Weights.Global {
+		models[m] = true
+	}
+	for m := range b.Weights.Global {
+		models[m] = true
+	}
+
+	diffs := make([]ModelWeightDiff, 0, len(models))
+	for model := range models {
+		d := ModelWeightDiff{Model: model}
+		if p, ok := a.Weights.Global[model]; ok {
+			d.AlphaA = p.Distribution.Alpha
+			d.BetaA = p.Distribution.Beta
+			d.MeanA = p.Distribution.Mean()
+		}
+		if p, ok := b.Weights.Global[model]; ok {
+			d.AlphaB = p.Distribution.Alpha
+			d.BetaB = p.Distribution.Beta
+			d.MeanB = p.Distribution.Mean()
+		}
+		d.MeanDelta = d.MeanB - d.MeanA
+		diffs = append(diffs, d)
+	}
+
+	sort.Slice(diffs, func(i, j int) bool {
+		return diffs[i].Model < diffs[j].Model
+	})
+	return diffs
+}
+
+// ModelWeightDiff summarizes the weight difference for a single model
+// between two policy versions.
+type ModelWeightDiff struct {
+	Model     string  `json:"model"`
+	AlphaA    float64 `json:"alpha_a"`
+	BetaA     float64 `json:"beta_a"`
+	MeanA     float64 `json:"mean_a"`
+	AlphaB    float64 `json:"alpha_b"`
+	BetaB     float64 `json:"beta_b"`
+	MeanB     float64 `json:"mean_b"`
+	MeanDelta float64 `json:"mean_delta"`
+}
+
+func countFeedback(ds *OfflineDataset) int {
+	n := 0
+	for _, r := range ds.Records {
+		if r.Outcome.Won != nil || r.Outcome.FeedbackType != "" {
+			n++
+		}
+	}
+	return n
+}
+
+func parentGlobal(pw *PolicyWeights) map[string]*ModelPreference {
+	if pw == nil {
+		return nil
+	}
+	return pw.Global
+}
+
+func parentCategory(pw *PolicyWeights) map[string]map[string]*ModelPreference {
+	if pw == nil {
+		return nil
+	}
+	return pw.Category
+}
+
+func parentUser(pw *PolicyWeights) map[string]map[string]*ModelPreference {
+	if pw == nil {
+		return nil
+	}
+	return pw.User
+}

--- a/src/semantic-router/pkg/selection/offline_updater.go
+++ b/src/semantic-router/pkg/selection/offline_updater.go
@@ -186,48 +186,33 @@ func (u *OfflineUpdater) applyOutcome(scope map[string]*betaAccumulator, model s
 	acc.count++
 
 	if outcome.Won != nil {
-		if *outcome.Won {
-			if outcome.Tie {
-				acc.alpha += 0.5 * weight
-				acc.beta += 0.5 * weight
-			} else {
-				acc.alpha += weight
-			}
-		} else {
-			if outcome.Tie {
-				acc.alpha += 0.5 * weight
-				acc.beta += 0.5 * weight
-			} else {
-				acc.beta += weight
-			}
-		}
+		applyWinLoss(acc, *outcome.Won, outcome.Tie, weight)
 	}
 
 	// Apply opponent's inverse outcome.
 	if outcome.OpponentModel != "" && outcome.Won != nil {
 		opp := u.getOrCreate(scope, outcome.OpponentModel)
 		opp.count++
-		if *outcome.Won {
-			if outcome.Tie {
-				opp.alpha += 0.5 * weight
-				opp.beta += 0.5 * weight
-			} else {
-				opp.beta += weight
-			}
-		} else {
-			if outcome.Tie {
-				opp.alpha += 0.5 * weight
-				opp.beta += 0.5 * weight
-			} else {
-				opp.alpha += weight
-			}
-		}
+		applyWinLoss(opp, !*outcome.Won, outcome.Tie, weight)
 	}
 
 	// Implicit outcome from response status.
 	if outcome.ResponseStatus >= 500 {
 		acc.beta += weight * 0.5
 	}
+}
+
+func applyWinLoss(acc *betaAccumulator, won, tie bool, weight float64) {
+	if tie {
+		acc.alpha += 0.5 * weight
+		acc.beta += 0.5 * weight
+		return
+	}
+	if won {
+		acc.alpha += weight
+		return
+	}
+	acc.beta += weight
 }
 
 func (u *OfflineUpdater) finalize(accs map[string]*betaAccumulator, parent map[string]*ModelPreference) map[string]*ModelPreference {
@@ -264,11 +249,9 @@ func (u *OfflineUpdater) finalize(accs map[string]*betaAccumulator, parent map[s
 	}
 
 	// Carry forward parent models that had no new observations.
-	if parent != nil {
-		for model, p := range parent {
-			if _, seen := result[model]; !seen {
-				result[model] = p
-			}
+	for model, p := range parent {
+		if _, seen := result[model]; !seen {
+			result[model] = p
 		}
 	}
 
@@ -288,11 +271,9 @@ func (u *OfflineUpdater) finalizeScoped(scoped map[string]map[string]*betaAccumu
 		result[scope] = u.finalize(accs, parentScope)
 	}
 	// Carry forward parent scopes with no new data.
-	if parent != nil {
-		for scope, prefs := range parent {
-			if _, seen := result[scope]; !seen {
-				result[scope] = prefs
-			}
+	for scope, prefs := range parent {
+		if _, seen := result[scope]; !seen {
+			result[scope] = prefs
 		}
 	}
 	return result

--- a/src/semantic-router/pkg/selection/policy_version.go
+++ b/src/semantic-router/pkg/selection/policy_version.go
@@ -216,8 +216,8 @@ func (s *PolicyVersionStore) Activate(versionID string) error {
 
 	// Retire the current active version
 	if manifest.ActiveVersion != "" && manifest.ActiveVersion != versionID {
-		prev, err := s.Load(manifest.ActiveVersion)
-		if err == nil {
+		prev, loadErr := s.Load(manifest.ActiveVersion)
+		if loadErr == nil {
 			prev.Status = PolicyStatusRetired
 			if saveErr := s.Save(prev); saveErr != nil {
 				logging.Warnf("[PolicyVersionStore] Failed to retire previous version %s: %v", prev.ID, saveErr)

--- a/src/semantic-router/pkg/selection/policy_version.go
+++ b/src/semantic-router/pkg/selection/policy_version.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// PolicyVersion identifies a snapshot of learned weights that can be activated,
+// shadowed, compared, or reverted independently from the runtime code path.
+type PolicyVersion struct {
+	// ID is a unique identifier (e.g. "v3", "offline-2026-05-10-1400").
+	ID string `json:"id"`
+
+	// ParentID is the version this was derived from (empty for the initial version).
+	ParentID string `json:"parent_id,omitempty"`
+
+	// CreatedAt is when this version was produced.
+	CreatedAt time.Time `json:"created_at"`
+
+	// Source describes how the weights were produced.
+	// Values: "online" (runtime UpdateFeedback), "offline_batch", "manual", "import".
+	Source string `json:"source"`
+
+	// DatasetWindow records the time window of data used for offline training.
+	DatasetWindow *TimeWindow `json:"dataset_window,omitempty"`
+
+	// TrainingStats summarizes what went into producing this version.
+	TrainingStats *TrainingStats `json:"training_stats,omitempty"`
+
+	// Status is the rollout state of this version.
+	// Values: "candidate", "shadow", "active", "retired".
+	Status PolicyStatus `json:"status"`
+
+	// Weights holds the learned Beta distribution parameters per scope.
+	Weights PolicyWeights `json:"weights"`
+}
+
+// TimeWindow represents a time range.
+type TimeWindow struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// TrainingStats summarizes what data was used to produce a policy version.
+type TrainingStats struct {
+	RecordCount     int `json:"record_count"`
+	SessionCount    int `json:"session_count"`
+	TransitionCount int `json:"transition_count"`
+	FeedbackCount   int `json:"feedback_count"`
+}
+
+// PolicyStatus is the rollout state of a policy version.
+type PolicyStatus string
+
+const (
+	// PolicyStatusCandidate means the version was produced but not yet evaluated.
+	PolicyStatusCandidate PolicyStatus = "candidate"
+
+	// PolicyStatusShadow means the version is being evaluated in shadow mode
+	// alongside the active version, without affecting real routing decisions.
+	PolicyStatusShadow PolicyStatus = "shadow"
+
+	// PolicyStatusActive means this version drives real routing decisions.
+	PolicyStatusActive PolicyStatus = "active"
+
+	// PolicyStatusRetired means this version was deactivated (kept for audit).
+	PolicyStatusRetired PolicyStatus = "retired"
+)
+
+// PolicyWeights holds learned parameters at each scope level.
+type PolicyWeights struct {
+	// Global preferences (model -> preference).
+	Global map[string]*ModelPreference `json:"global,omitempty"`
+
+	// Category preferences (category -> model -> preference).
+	Category map[string]map[string]*ModelPreference `json:"category,omitempty"`
+
+	// User preferences (user_id -> model -> preference).
+	User map[string]map[string]*ModelPreference `json:"user,omitempty"`
+}
+
+// PolicyVersionStore manages versioned policy weights on disk.
+// Versions are stored as individual JSON files in a directory, with a
+// manifest tracking the active and shadow versions.
+type PolicyVersionStore struct {
+	dir string
+	mu  sync.RWMutex
+}
+
+// PolicyManifest tracks which versions are active and shadowed.
+type PolicyManifest struct {
+	ActiveVersion string          `json:"active_version"`
+	ShadowVersion string          `json:"shadow_version,omitempty"`
+	Versions      []PolicyVersion `json:"versions"`
+}
+
+// NewPolicyVersionStore creates a store rooted at dir.
+func NewPolicyVersionStore(dir string) (*PolicyVersionStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create policy version directory: %w", err)
+	}
+	return &PolicyVersionStore{dir: dir}, nil
+}
+
+// Save persists a policy version to disk.
+func (s *PolicyVersionStore) Save(version *PolicyVersion) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := json.MarshalIndent(version, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal policy version: %w", err)
+	}
+
+	path := s.versionPath(version.ID)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write policy version: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename policy version: %w", err)
+	}
+
+	logging.Infof("[PolicyVersionStore] Saved version %s (status=%s)", version.ID, version.Status)
+	return nil
+}
+
+// Load reads a policy version from disk.
+func (s *PolicyVersionStore) Load(versionID string) (*PolicyVersion, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := os.ReadFile(s.versionPath(versionID))
+	if err != nil {
+		return nil, fmt.Errorf("read policy version %s: %w", versionID, err)
+	}
+
+	var version PolicyVersion
+	if err := json.Unmarshal(data, &version); err != nil {
+		return nil, fmt.Errorf("parse policy version %s: %w", versionID, err)
+	}
+	return &version, nil
+}
+
+// LoadManifest reads the manifest that tracks active/shadow versions.
+func (s *PolicyVersionStore) LoadManifest() (*PolicyManifest, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := os.ReadFile(s.manifestPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &PolicyManifest{}, nil
+		}
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	var manifest PolicyManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	return &manifest, nil
+}
+
+// SaveManifest writes the manifest atomically.
+func (s *PolicyVersionStore) SaveManifest(manifest *PolicyManifest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	path := s.manifestPath()
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename manifest: %w", err)
+	}
+	return nil
+}
+
+// Activate promotes a version to active, retiring the previous active version.
+func (s *PolicyVersionStore) Activate(versionID string) error {
+	manifest, err := s.LoadManifest()
+	if err != nil {
+		return err
+	}
+
+	// Retire the current active version
+	if manifest.ActiveVersion != "" && manifest.ActiveVersion != versionID {
+		prev, err := s.Load(manifest.ActiveVersion)
+		if err == nil {
+			prev.Status = PolicyStatusRetired
+			if saveErr := s.Save(prev); saveErr != nil {
+				logging.Warnf("[PolicyVersionStore] Failed to retire previous version %s: %v", prev.ID, saveErr)
+			}
+		}
+	}
+
+	version, err := s.Load(versionID)
+	if err != nil {
+		return err
+	}
+	version.Status = PolicyStatusActive
+	if err := s.Save(version); err != nil {
+		return err
+	}
+
+	manifest.ActiveVersion = versionID
+	if manifest.ShadowVersion == versionID {
+		manifest.ShadowVersion = ""
+	}
+	return s.SaveManifest(manifest)
+}
+
+// Shadow sets a version as the shadow for comparison against the active version.
+func (s *PolicyVersionStore) Shadow(versionID string) error {
+	manifest, err := s.LoadManifest()
+	if err != nil {
+		return err
+	}
+
+	version, err := s.Load(versionID)
+	if err != nil {
+		return err
+	}
+	version.Status = PolicyStatusShadow
+	if err := s.Save(version); err != nil {
+		return err
+	}
+
+	manifest.ShadowVersion = versionID
+	return s.SaveManifest(manifest)
+}
+
+// Revert retires the current active version and promotes the specified version.
+func (s *PolicyVersionStore) Revert(versionID string) error {
+	return s.Activate(versionID)
+}
+
+func (s *PolicyVersionStore) versionPath(id string) string {
+	return filepath.Join(s.dir, fmt.Sprintf("policy_%s.json", id))
+}
+
+func (s *PolicyVersionStore) manifestPath() string {
+	return filepath.Join(s.dir, "manifest.json")
+}
+
+// ShadowComparison records the difference between active and shadow policy
+// decisions for a single routing event, enabling operators to evaluate
+// offline-trained weights before promotion.
+type ShadowComparison struct {
+	// SessionID is the session context of the comparison.
+	SessionID string `json:"session_id"`
+
+	// ActiveVersion is the version that made the live decision.
+	ActiveVersion string `json:"active_version"`
+
+	// ShadowVersion is the version being evaluated.
+	ShadowVersion string `json:"shadow_version"`
+
+	// ActiveModel is the model selected by the active policy.
+	ActiveModel string `json:"active_model"`
+
+	// ShadowModel is the model the shadow policy would have selected.
+	ShadowModel string `json:"shadow_model"`
+
+	// Agreed is true when both policies chose the same model.
+	Agreed bool `json:"agreed"`
+
+	// ActiveScore is the active policy's score for its chosen model.
+	ActiveScore float64 `json:"active_score"`
+
+	// ShadowScore is the shadow policy's score for its chosen model.
+	ShadowScore float64 `json:"shadow_score"`
+
+	// Timestamp is when the comparison was made.
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/tools/agent/repo-manifest.yaml
+++ b/tools/agent/repo-manifest.yaml
@@ -150,6 +150,7 @@ docs:
   - docs/agent/plans/pl-0027-router-runtime-composition-root-convergence-loop.md
   - docs/agent/plans/pl-0028-knowledge-base-seed-and-steady-state-convergence-loop.md
   - docs/agent/plans/pl-0029-control-plane-contract-boundary-ratchet.md
+  - docs/agent/plans/pl-0030-session-aware-model-switch-workstream.md
   - docs/agent/state-taxonomy-and-inventory.md
   - docs/agent/tech-debt-register.md
   - docs/agent/tech-debt/README.md
@@ -378,6 +379,9 @@ doc_governance:
     - path: docs/agent/plans/pl-0029-control-plane-contract-boundary-ratchet.md
       steward: agent-contract
       freshness: update at the start and end of each control-plane contract boundary ratchet loop and after each completed loop task
+    - path: docs/agent/plans/pl-0030-session-aware-model-switch-workstream.md
+      steward: router-core
+      freshness: update at the start and end of each session-aware offline weight update loop and after each completed loop task
     - path: docs/agent/state-taxonomy-and-inventory.md
       steward: agent-contract
       freshness: update when the runtime or dashboard state inventory, durability taxonomy, or persistence guidance changes materially


### PR DESCRIPTION
Closes #1750

## Purpose

- Adds offline weight update infrastructure for session-aware model-switch policies: dataset contract, batch updater, versioned policy storage, and observability metrics.
- Learned tuning can now build on logged routing evidence without becoming a runtime dependency.
- Affects `Router` / `Docs`

## Test Plan

- `go build ./pkg/selection/` and `go vet ./pkg/selection/` pass
- `make agent-validate` passes
- `make agent-lint` passes (markdown and agent changed-files lint)
- Unit tests cover: win/loss updates, transition penalties, parent blending, category weights, implicit feedback weighting, server errors, version comparison, and full store save/load/activate/shadow/revert lifecycle

## Test Result

- Build, vet, gofmt, agent-validate, and markdown lint all pass
- `go test` requires Rust native bindings not available locally; will run in CI
- Follow-up: `OfflineDatasetBuilder` (RouterReplay store reader) and shadow evaluator wiring into ExtProc hot path remain as open tasks in pl-0030

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>