### PR TITLE
[Router] Fix hybrid HNSW layer entry-point propagation

### DIFF
--- a/src/semantic-router/pkg/cache/cache_test.go
+++ b/src/semantic-router/pkg/cache/cache_test.go
@@ -3944,6 +3944,83 @@ func TestHNSWSearchLayerAndInsertionRegressions(t *testing.T) {
 			t.Fatalf("expected inserted node 4 to connect to D via carried entry point, got %v", inserted.neighbors[0])
 		}
 	})
+
+	t.Run("connectHybridNodeLayers carries the layer entry point into lower-layer neighbor selection", func(t *testing.T) {
+		// Hybrid graph layout mirrors the in-memory insertion regression above:
+		//   layer 1: A <-> B
+		//   layer 0: A <-> C, B <-> D
+		//
+		// New node F is inserted at level 1. The layer 1 search from A should
+		// find B and carry B into the layer 0 search. Without that update, layer 0
+		// restarts from A and links F to C instead of D.
+		embeddings := [][]float32{
+			{0.30}, // A: global entry point
+			{0.95}, // B: better upper-layer entry point for F
+			{0.35}, // C: layer-0 neighbor reachable from A
+			{1.00}, // D: layer-0 neighbor reachable from B
+			{1.00}, // F: new node to connect
+		}
+
+		nodeA := &HNSWNode{
+			entryIndex: 0,
+			neighbors: map[int][]int{
+				1: {1},
+				0: {2},
+			},
+			maxLayer: 1,
+		}
+		nodeB := &HNSWNode{
+			entryIndex: 1,
+			neighbors: map[int][]int{
+				1: {0},
+				0: {3},
+			},
+			maxLayer: 1,
+		}
+		nodeC := &HNSWNode{
+			entryIndex: 2,
+			neighbors: map[int][]int{
+				0: {0},
+			},
+			maxLayer: 0,
+		}
+		nodeD := &HNSWNode{
+			entryIndex: 3,
+			neighbors: map[int][]int{
+				0: {1},
+			},
+			maxLayer: 0,
+		}
+
+		cache := &HybridCache{
+			hnswIndex: &HNSWIndex{
+				nodes: []*HNSWNode{nodeA, nodeB, nodeC, nodeD},
+				nodeIndex: map[int]*HNSWNode{
+					0: nodeA,
+					1: nodeB,
+					2: nodeC,
+					3: nodeD,
+				},
+				entryPoint:     0,
+				maxLayer:       1,
+				efConstruction: 1,
+				M:              1,
+				Mmax:           1,
+				Mmax0:          1,
+				ml:             1,
+			},
+			embeddings: embeddings,
+			idMap:      map[int]string{},
+		}
+
+		nodeF := newHybridNode(4, 1)
+		cache.registerHybridNode(4, nodeF)
+		cache.connectHybridNodeLayers(nodeF, 4, embeddings[4], 1, cache.hnswIndex.entryPoint)
+
+		if !slices.Equal(nodeF.neighbors[0], []int{3}) {
+			t.Fatalf("expected hybrid node 4 to connect to D via carried entry point, got %v", nodeF.neighbors[0])
+		}
+	})
 }
 
 // BenchmarkLargeScale tests HNSW vs Linear at scales where HNSW shows advantages (10K-100K entries)

--- a/src/semantic-router/pkg/cache/hybrid_cache_hnsw.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_hnsw.go
@@ -117,9 +117,12 @@ func (h *HybridCache) hybridLayerCandidates(entryPoint, layer int) []int {
 }
 
 func (h *HybridCache) connectHybridNodeLayers(node *HNSWNode, entryIndex int, embedding []float32, level, currNearest int) {
-	for lc := level; lc >= 0; lc-- {
+	for lc := min(level, h.hnswIndex.maxLayer); lc >= 0; lc-- {
 		neighbors := h.searchLayerHybrid(embedding, h.hnswIndex.efConstruction, lc, []int{currNearest})
 		h.linkHybridNeighbors(node, entryIndex, lc, h.selectNeighborsHybrid(neighbors, h.hybridNeighborLimit(lc)))
+		if len(neighbors) > 0 {
+			currNearest = neighbors[0]
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

- What does this PR change?
&emsp;&emsp; Fixed hybrid cache HNSW insertion so each layer search carries its nearest result into the next layer per standard HNSW algorithm description.
- Why is this change needed?
&emsp;&emsp;[Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs](https://dl.acm.org/doi/10.1109/TPAMI.2018.2889473)
<img width="225" height="255" alt="heap_sr" src="https://github.com/user-attachments/assets/3a77d9f7-e293-42b4-baad-1925d782051a" />

- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`
&emsp;&emsp; Router

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
