### PR TITLE
[Router][CLI] Custom Anthropic upstream routing and tool calling

### DIFF
--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/openai/openai-go"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -30,16 +31,23 @@ type HeaderKeyValue struct {
 }
 
 // BuildRequestHeaders returns the headers needed for an Anthropic API request.
-// Returns headers as simple key-value pairs to avoid coupling to Envoy types.
-func BuildRequestHeaders(apiKey string, bodyLength int) []HeaderKeyValue {
-	return []HeaderKeyValue{
-		{Key: "x-api-key", Value: apiKey},
+// messagesPath should include any base_url prefix (e.g. /Anthropic/v1/messages for AMD).
+// When empty, AnthropicMessagesPath (/v1/messages) is used.
+func BuildRequestHeaders(apiKey string, bodyLength int, messagesPath string) []HeaderKeyValue {
+	if strings.TrimSpace(messagesPath) == "" {
+		messagesPath = AnthropicMessagesPath
+	}
+	headers := []HeaderKeyValue{
 		{Key: "anthropic-version", Value: AnthropicAPIVersion},
 		{Key: "content-type", Value: "application/json"},
 		{Key: "accept-encoding", Value: "identity"},
-		{Key: ":path", Value: AnthropicMessagesPath},
+		{Key: ":path", Value: messagesPath},
 		{Key: "content-length", Value: fmt.Sprintf("%d", bodyLength)},
 	}
+	if strings.TrimSpace(apiKey) != "" {
+		headers = append([]HeaderKeyValue{{Key: "x-api-key", Value: apiKey}}, headers...)
+	}
+	return headers
 }
 
 // HeadersToRemove returns headers that should be removed when routing to Anthropic.
@@ -51,21 +59,9 @@ func HeadersToRemove() []string {
 // This is used for Envoy-routed requests where the router transforms the body
 // before forwarding to Anthropic via Envoy.
 func ToAnthropicRequestBody(openAIRequest *openai.ChatCompletionNewParams) ([]byte, error) {
-	var messages []anthropic.MessageParam
-	var systemPrompt string
-
-	// Process messages - extract system prompt separately (Anthropic requirement)
-	for _, msg := range openAIRequest.Messages {
-		switch {
-		case msg.OfSystem != nil:
-			systemPrompt = extractSystemContent(msg.OfSystem)
-		case msg.OfUser != nil:
-			content := extractUserContent(msg.OfUser)
-			messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(content)))
-		case msg.OfAssistant != nil:
-			content := extractAssistantContent(msg.OfAssistant)
-			messages = append(messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(content)))
-		}
+	systemPrompt, messages, err := buildAnthropicMessages(openAIRequest.Messages)
+	if err != nil {
+		return nil, err
 	}
 
 	// Determine max tokens (required for Anthropic)
@@ -87,6 +83,10 @@ func ToAnthropicRequestBody(openAIRequest *openai.ChatCompletionNewParams) ([]by
 		params.System = []anthropic.TextBlockParam{
 			{Text: systemPrompt},
 		}
+	}
+
+	if err := applyOpenAIToolsToAnthropicParams(&params, openAIRequest); err != nil {
+		return nil, err
 	}
 
 	// Set optional parameters
@@ -118,13 +118,7 @@ func ToOpenAIResponseBody(anthropicResponse []byte, model string) ([]byte, error
 
 	logging.Debugf("Parsed Anthropic response - ID: %s, Content blocks: %d, StopReason: %s", resp.ID, len(resp.Content), resp.StopReason)
 
-	// Extract text content
-	var content string
-	for _, block := range resp.Content {
-		if block.Type == "text" {
-			content += block.Text
-		}
-	}
+	toolCalls, content := openAIToolCallsFromAnthropicContent(resp.Content)
 
 	// Map stop reason
 	finishReason := "stop"
@@ -132,6 +126,9 @@ func ToOpenAIResponseBody(anthropicResponse []byte, model string) ([]byte, error
 	case anthropic.StopReasonMaxTokens:
 		finishReason = "length"
 	case anthropic.StopReasonToolUse:
+		finishReason = "tool_calls"
+	}
+	if len(toolCalls) > 0 && finishReason == "stop" {
 		finishReason = "tool_calls"
 	}
 
@@ -143,8 +140,9 @@ func ToOpenAIResponseBody(anthropicResponse []byte, model string) ([]byte, error
 		Choices: []openai.ChatCompletionChoice{{
 			Index: 0,
 			Message: openai.ChatCompletionMessage{
-				Role:    "assistant",
-				Content: content,
+				Role:      "assistant",
+				Content:   content,
+				ToolCalls: toolCalls,
 			},
 			FinishReason: finishReason,
 		}},
@@ -198,4 +196,242 @@ func extractAssistantContent(msg *openai.ChatCompletionAssistantMessageParam) st
 		}
 	}
 	return strings.Join(parts, " ")
+}
+
+func buildAnthropicMessages(
+	messages []openai.ChatCompletionMessageParamUnion,
+) (string, []anthropic.MessageParam, error) {
+	var systemPrompt string
+	var anthropicMessages []anthropic.MessageParam
+
+	for _, msg := range messages {
+		switch {
+		case msg.OfSystem != nil:
+			systemPrompt = extractSystemContent(msg.OfSystem)
+		case msg.OfUser != nil:
+			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(
+				anthropic.NewTextBlock(extractUserContent(msg.OfUser)),
+			))
+		case msg.OfAssistant != nil:
+			blocks, err := assistantContentBlocks(msg.OfAssistant)
+			if err != nil {
+				return "", nil, err
+			}
+			if len(blocks) > 0 {
+				anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(blocks...))
+			}
+		case msg.OfTool != nil:
+			toolUseID := strings.TrimSpace(msg.OfTool.ToolCallID)
+			if toolUseID == "" {
+				return "", nil, fmt.Errorf("tool message missing tool_call_id")
+			}
+			content := extractToolMessageContent(msg.OfTool)
+			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(
+				anthropic.NewToolResultBlock(toolUseID, content, false),
+			))
+		default:
+			logging.Debugf("Skipping unsupported OpenAI message role in Anthropic conversion")
+		}
+	}
+
+	return systemPrompt, anthropicMessages, nil
+}
+
+func extractToolMessageContent(msg *openai.ChatCompletionToolMessageParam) string {
+	if msg.Content.OfString.Value != "" {
+		return msg.Content.OfString.Value
+	}
+	var parts []string
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		if part.Text != "" {
+			parts = append(parts, part.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func assistantContentBlocks(
+	msg *openai.ChatCompletionAssistantMessageParam,
+) ([]anthropic.ContentBlockParamUnion, error) {
+	var blocks []anthropic.ContentBlockParamUnion
+
+	content := extractAssistantContent(msg)
+	if content != "" {
+		blocks = append(blocks, anthropic.NewTextBlock(content))
+	}
+
+	for _, toolCall := range msg.ToolCalls {
+		toolUseID := strings.TrimSpace(toolCall.ID)
+		if toolUseID == "" {
+			return nil, fmt.Errorf("assistant tool_call missing id")
+		}
+		name := strings.TrimSpace(toolCall.Function.Name)
+		if name == "" {
+			return nil, fmt.Errorf("assistant tool_call %s missing function name", toolUseID)
+		}
+		input, err := parseToolCallArguments(toolCall.Function.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("assistant tool_call %s: %w", toolUseID, err)
+		}
+		blocks = append(blocks, anthropic.NewToolUseBlock(toolUseID, input, name))
+	}
+
+	return blocks, nil
+}
+
+func parseToolCallArguments(arguments string) (any, error) {
+	trimmed := strings.TrimSpace(arguments)
+	if trimmed == "" {
+		return map[string]any{}, nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return nil, fmt.Errorf("invalid tool arguments JSON: %w", err)
+	}
+	return parsed, nil
+}
+
+func applyOpenAIToolsToAnthropicParams(
+	params *anthropic.MessageNewParams,
+	openAIRequest *openai.ChatCompletionNewParams,
+) error {
+	if openAIRequest == nil {
+		return nil
+	}
+
+	if len(openAIRequest.Tools) > 0 {
+		tools, err := openAIToolsToAnthropic(openAIRequest.Tools)
+		if err != nil {
+			return err
+		}
+		params.Tools = tools
+	}
+
+	toolChoice, hasChoice := openAIToolChoiceToAnthropic(openAIRequest.ToolChoice)
+	if hasChoice {
+		params.ToolChoice = toolChoice
+	}
+	return nil
+}
+
+func openAIToolsToAnthropic(tools []openai.ChatCompletionToolParam) ([]anthropic.ToolUnionParam, error) {
+	result := make([]anthropic.ToolUnionParam, 0, len(tools))
+	for index, tool := range tools {
+		if tool.Type != "" && tool.Type != "function" {
+			logging.Debugf("Skipping non-function OpenAI tool type %q at index %d", tool.Type, index)
+			continue
+		}
+		name := strings.TrimSpace(tool.Function.Name)
+		if name == "" {
+			return nil, fmt.Errorf("tools[%d]: function name is required", index)
+		}
+
+		inputSchema, err := functionParametersToAnthropicSchema(tool.Function.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("tools[%d] (%s): %w", index, name, err)
+		}
+
+		toolParam := anthropic.ToolParam{
+			Name:        name,
+			InputSchema: inputSchema,
+			Type:        anthropic.ToolTypeCustom,
+		}
+		if desc := strings.TrimSpace(tool.Function.Description.Value); desc != "" {
+			toolParam.Description = anthropic.String(desc)
+		}
+		result = append(result, anthropic.ToolUnionParam{OfTool: &toolParam})
+	}
+	return result, nil
+}
+
+func functionParametersToAnthropicSchema(
+	parameters openai.FunctionParameters,
+) (anthropic.ToolInputSchemaParam, error) {
+	schema := anthropic.ToolInputSchemaParam{
+		Type: "object",
+	}
+	if parameters == nil {
+		return schema, nil
+	}
+
+	raw, err := json.Marshal(parameters)
+	if err != nil {
+		return schema, fmt.Errorf("marshal function parameters: %w", err)
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return schema, fmt.Errorf("parse function parameters: %w", err)
+	}
+	if schema.Type == "" {
+		schema.Type = "object"
+	}
+	return schema, nil
+}
+
+func openAIToolChoiceToAnthropic(
+	choice openai.ChatCompletionToolChoiceOptionUnionParam,
+) (anthropic.ToolChoiceUnionParam, bool) {
+	if !param.IsOmitted(choice.OfAuto) {
+		value := strings.TrimSpace(choice.OfAuto.Value)
+		switch value {
+		case "", "auto":
+			return anthropic.ToolChoiceUnionParam{
+				OfAuto: &anthropic.ToolChoiceAutoParam{},
+			}, true
+		case "none":
+			none := anthropic.NewToolChoiceNoneParam()
+			return anthropic.ToolChoiceUnionParam{OfNone: &none}, true
+		case "required", "any":
+			return anthropic.ToolChoiceUnionParam{
+				OfAny: &anthropic.ToolChoiceAnyParam{},
+			}, true
+		default:
+			logging.Debugf("Unknown OpenAI tool_choice auto value %q, defaulting to auto", value)
+			return anthropic.ToolChoiceUnionParam{
+				OfAuto: &anthropic.ToolChoiceAutoParam{},
+			}, true
+		}
+	}
+
+	if choice.OfChatCompletionNamedToolChoice != nil {
+		name := strings.TrimSpace(choice.OfChatCompletionNamedToolChoice.Function.Name)
+		if name == "" {
+			return anthropic.ToolChoiceUnionParam{}, false
+		}
+		return anthropic.ToolChoiceParamOfTool(name), true
+	}
+
+	return anthropic.ToolChoiceUnionParam{}, false
+}
+
+func openAIToolCallsFromAnthropicContent(
+	blocks []anthropic.ContentBlockUnion,
+) ([]openai.ChatCompletionMessageToolCall, string) {
+	var contentParts []string
+	var toolCalls []openai.ChatCompletionMessageToolCall
+
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				contentParts = append(contentParts, block.Text)
+			}
+		case "tool_use":
+			arguments := string(block.Input)
+			if len(block.Input) == 0 {
+				arguments = "{}"
+			}
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: openai.ChatCompletionMessageToolCallFunction{
+					Name:      block.Name,
+					Arguments: arguments,
+				},
+			})
+		default:
+			logging.Debugf("Skipping unsupported Anthropic content block type %q in OpenAI response conversion", block.Type)
+		}
+	}
+
+	return toolCalls, strings.Join(contentParts, "")
 }

--- a/src/semantic-router/pkg/anthropic/client_test.go
+++ b/src/semantic-router/pkg/anthropic/client_test.go
@@ -207,8 +207,13 @@ func TestToOpenAIResponseBody_MaxTokensStopReason(t *testing.T) {
 
 func TestToOpenAIResponseBody_ToolUseStopReason(t *testing.T) {
 	anthropicResp := &anthropic.Message{
-		ID:         "msg_123",
-		Content:    []anthropic.ContentBlockUnion{{Type: "text", Text: "Using tool..."}},
+		ID: "msg_123",
+		Content: []anthropic.ContentBlockUnion{{
+			Type:  "tool_use",
+			ID:    "call_abc",
+			Name:  "get_weather",
+			Input: json.RawMessage(`{"city":"Paris"}`),
+		}},
 		StopReason: anthropic.StopReasonToolUse,
 		Usage:      anthropic.Usage{InputTokens: 10, OutputTokens: 20},
 	}
@@ -224,6 +229,9 @@ func TestToOpenAIResponseBody_ToolUseStopReason(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "tool_calls", result.Choices[0].FinishReason)
+	require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+	assert.Equal(t, "call_abc", result.Choices[0].Message.ToolCalls[0].ID)
+	assert.Equal(t, "get_weather", result.Choices[0].Message.ToolCalls[0].Function.Name)
 }
 
 func TestToOpenAIResponseBody_MultipleContentBlocks(t *testing.T) {
@@ -251,7 +259,7 @@ func TestToOpenAIResponseBody_MultipleContentBlocks(t *testing.T) {
 }
 
 func TestBuildRequestHeaders(t *testing.T) {
-	headers := BuildRequestHeaders("test-api-key", 1024)
+	headers := BuildRequestHeaders("test-api-key", 1024, "")
 
 	// Check we have all expected headers
 	headerMap := make(map[string]string)
@@ -264,6 +272,23 @@ func TestBuildRequestHeaders(t *testing.T) {
 	assert.Equal(t, "application/json", headerMap["content-type"])
 	assert.Equal(t, AnthropicMessagesPath, headerMap[":path"])
 	assert.Equal(t, "1024", headerMap["content-length"])
+
+	custom := BuildRequestHeaders("key", 10, "/Anthropic/v1/messages")
+	customMap := make(map[string]string)
+	for _, h := range custom {
+		customMap[h.Key] = h.Value
+	}
+	assert.Equal(t, "/Anthropic/v1/messages", customMap[":path"])
+}
+
+func TestBuildRequestHeaders_OmitsEmptyAPIKey(t *testing.T) {
+	headers := BuildRequestHeaders("", 512, "")
+	headerMap := make(map[string]string)
+	for _, h := range headers {
+		headerMap[h.Key] = h.Value
+	}
+	_, hasKey := headerMap["x-api-key"]
+	assert.False(t, hasKey)
 }
 
 func TestHeadersToRemove(t *testing.T) {
@@ -271,6 +296,95 @@ func TestHeadersToRemove(t *testing.T) {
 
 	assert.Contains(t, headers, "authorization")
 	assert.Contains(t, headers, "content-length")
+}
+
+func TestToAnthropicRequestBody_WithTools(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{OfUser: &openai.ChatCompletionUserMessageParam{
+				Content: openai.ChatCompletionUserMessageParamContentUnion{
+					OfString: openai.String("What's the weather in Paris?"),
+				},
+			}},
+		},
+		Tools: []openai.ChatCompletionToolParam{{
+			Type: "function",
+			Function: openai.FunctionDefinitionParam{
+				Name:        "get_weather",
+				Description: openai.String("Get weather for a city"),
+				Parameters: openai.FunctionParameters{
+					"type": "object",
+					"properties": map[string]any{
+						"city": map[string]any{"type": "string"},
+					},
+					"required": []any{"city"},
+				},
+			},
+		}},
+		ToolChoice: openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String("auto"),
+		},
+	}
+
+	body, err := ToAnthropicRequestBody(req)
+	require.NoError(t, err)
+
+	var parsed anthropic.MessageNewParams
+	require.NoError(t, json.Unmarshal(body, &parsed))
+
+	require.Len(t, parsed.Tools, 1)
+	require.NotNil(t, parsed.Tools[0].OfTool)
+	assert.Equal(t, "get_weather", parsed.Tools[0].OfTool.Name)
+	assert.Equal(t, anthropic.ToolTypeCustom, parsed.Tools[0].OfTool.Type)
+
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &wire))
+	var tools []map[string]any
+	require.NoError(t, json.Unmarshal(wire["tools"], &tools))
+	require.Len(t, tools, 1)
+	assert.Equal(t, "custom", tools[0]["type"])
+}
+
+func TestToAnthropicRequestBody_WithToolHistory(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{OfUser: &openai.ChatCompletionUserMessageParam{
+				Content: openai.ChatCompletionUserMessageParamContentUnion{
+					OfString: openai.String("Weather in Paris?"),
+				},
+			}},
+			{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				ToolCalls: []openai.ChatCompletionMessageToolCallParam{{
+					ID:   "call_abc",
+					Type: "function",
+					Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name:      "get_weather",
+						Arguments: `{"city":"Paris"}`,
+					},
+				}},
+			}},
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				ToolCallID: "call_abc",
+				Content: openai.ChatCompletionToolMessageParamContentUnion{
+					OfString: openai.String(`{"temp_c": 18}`),
+				},
+			}},
+		},
+	}
+
+	body, err := ToAnthropicRequestBody(req)
+	require.NoError(t, err)
+
+	var parsed anthropic.MessageNewParams
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	require.Len(t, parsed.Messages, 3)
+
+	assistant := parsed.Messages[1]
+	assert.Equal(t, anthropic.MessageParamRoleAssistant, assistant.Role)
+	require.NotNil(t, assistant.Content[0].OfToolUse)
+	assert.Equal(t, "call_abc", assistant.Content[0].OfToolUse.ID)
 }
 
 func TestExtractSystemContent_StringContent(t *testing.T) {

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
@@ -10,7 +10,6 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/authz"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
-	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
@@ -43,6 +42,7 @@ func (r *OpenAIRouter) handleAnthropicRouting(
 		return errorResponse, nil
 	}
 	logging.Infof("Transformed request for Anthropic API, body size: %d bytes", len(anthropicBody))
+	r.startRouterReplay(ctx, originalModel, targetModel, decisionName)
 	return r.buildAnthropicRoutingResponse(targetModel, accessKey, anthropicBody, ctx), nil
 }
 
@@ -86,8 +86,36 @@ func (r *OpenAIRouter) buildAnthropicRoutingResponse(
 	anthropicBody []byte,
 	ctx *RequestContext,
 ) *ext_proc.ProcessingResponse {
-	anthropicHeaders := anthropic.BuildRequestHeaders(accessKey, len(anthropicBody))
-	setHeaders := make([]*core.HeaderValueOption, 0, len(anthropicHeaders)+2)
+	endpoint, endpointName, err := r.selectEndpointForModel(ctx, targetModel)
+	if err != nil {
+		logging.Errorf("Anthropic routing endpoint selection failed for model %s: %v", targetModel, err)
+		return r.createErrorResponse(500, fmt.Sprintf("Endpoint selection error: %v", err))
+	}
+	if accessKey == "" && endpointName != "" {
+		if ep, ok := r.Config.GetEndpointByName(endpointName); ok && ep.APIKey != "" {
+			accessKey = ep.APIKey
+		}
+	}
+
+	messagesPath := anthropic.AnthropicMessagesPath
+	profile, profileErr := r.Config.GetProviderProfileForEndpoint(endpointName)
+	if profileErr != nil {
+		logging.Errorf("Anthropic routing profile resolution failed for endpoint %s: %v", endpointName, profileErr)
+		return r.createErrorResponse(500, "Internal routing error. Contact your administrator.")
+	}
+	if profile != nil {
+		if chatPath, pathErr := profile.ResolveChatPath(); pathErr != nil {
+			logging.Errorf("Anthropic routing chat path resolution failed for endpoint %s: %v", endpointName, pathErr)
+			return r.createErrorResponse(500, "Internal routing error. Contact your administrator.")
+		} else if chatPath != "" {
+			messagesPath = chatPath
+			logging.Infof("Anthropic upstream path for model %s: %s", targetModel, messagesPath)
+		}
+	}
+
+	bodyLength := len(anthropicBody)
+	anthropicHeaders := anthropic.BuildRequestHeaders(accessKey, bodyLength, messagesPath)
+	setHeaders := make([]*core.HeaderValueOption, 0, len(anthropicHeaders)+8)
 	for _, header := range anthropicHeaders {
 		setHeaders = append(setHeaders, &core.HeaderValueOption{
 			Header: &core.HeaderValue{
@@ -96,13 +124,9 @@ func (r *OpenAIRouter) buildAnthropicRoutingResponse(
 			},
 		})
 	}
-	setHeaders = append(setHeaders, &core.HeaderValueOption{
-		Header: &core.HeaderValue{
-			Key:      headers.SelectedModel,
-			RawValue: []byte(targetModel),
-		},
-	})
-	setHeaders = append(setHeaders, r.startUpstreamSpanAndInjectHeaders(targetModel, "api.anthropic.com", ctx)...)
+	appendProfileHeaders(&setHeaders, profile)
+	appendRoutingHeaders(&setHeaders, targetModel, endpoint)
+	setHeaders = append(setHeaders, r.startUpstreamSpanAndInjectHeaders(targetModel, endpoint, ctx)...)
 	r.recordRoutingLatency(ctx)
 
 	return &ext_proc.ProcessingResponse{

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
@@ -1,0 +1,51 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/authz"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestHandleAnthropicRoutingStartsRouterReplay(t *testing.T) {
+	cfg := &config.RouterConfig{
+		RouterReplay: config.RouterReplayConfig{Enabled: true, StoreBackend: "memory"},
+		IntelligentRouting: config.IntelligentRouting{
+			Decisions: []config.Decision{
+				{Name: "simple-queries", ModelRefs: []config.ModelRef{{Model: "claude-sonnet-4.6"}}},
+			},
+		},
+	}
+	recorders := initializeReplayRecorders(cfg)
+	router := &OpenAIRouter{
+		Config:          cfg,
+		ReplayRecorders: recorders,
+		CredentialResolver: authz.NewCredentialResolver(
+			authz.NewHeaderInjectionProvider(map[string]string{
+				string(authz.ProviderAnthropic): "x-user-anthropic-key",
+			}),
+		),
+	}
+	router.CredentialResolver.SetFailOpen(true)
+
+	request, err := parseOpenAIRequest([]byte(`{"model":"MoM","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("parseOpenAIRequest failed: %v", err)
+	}
+
+	ctx := &RequestContext{
+		Headers:                  map[string]string{},
+		RouterReplayPluginConfig: cfg.EffectiveRouterReplayConfigForDecision("simple-queries"),
+		OriginalRequestBody:      []byte(`{"model":"MoM","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	response, err := router.handleAnthropicRouting(request, "MoM", "claude-sonnet-4.6", "simple-queries", ctx)
+	if err != nil {
+		t.Fatalf("handleAnthropicRouting failed: %v", err)
+	}
+	if response == nil {
+		t.Fatal("expected routing response")
+	}
+	if ctx.RouterReplayID == "" {
+		t.Fatal("expected router replay to start on anthropic routing path")
+	}
+}

--- a/src/vllm-sr/cli/config_generator.py
+++ b/src/vllm-sr/cli/config_generator.py
@@ -14,6 +14,20 @@ from cli.utils import get_logger
 log = get_logger(__name__)
 
 
+def _uses_shared_anthropic_cluster(model) -> bool:
+    """Use api.anthropic.com only when no custom upstream host is configured."""
+    if not model.backend_refs:
+        return True
+    for backend in model.backend_refs:
+        upstream = (backend.endpoint or backend.base_url or "").lower()
+        if not upstream:
+            continue
+        if "api.anthropic.com" in upstream:
+            continue
+        return False
+    return True
+
+
 def _is_ip_address(host: str) -> bool:
     """
     Check if a host string is an IP address (IPv4 or IPv6).
@@ -99,12 +113,16 @@ def generate_envoy_config_from_user_config(
     for model in user_config.providers.models:
         # Handle external API models (e.g., Anthropic) - they use shared clusters
         if model.api_format and model.api_format in EXTERNAL_API_MODEL_FORMATS:
-            if model.api_format == "anthropic":
+            if model.api_format == "anthropic" and _uses_shared_anthropic_cluster(
+                model
+            ):
                 anthropic_models.append({"name": model.name})
                 log.info(
                     f"  Anthropic model: {model.name} (will use shared anthropic_api_cluster)"
                 )
-            continue
+                continue
+            if model.api_format == "anthropic":
+                log.info(f"  Anthropic model: {model.name} (dedicated cluster)")
 
         endpoints = []
         has_https = False

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 CLI_ROOT = Path(__file__).resolve().parents[1]
@@ -215,6 +216,58 @@ routing:
     assert route_action["host_rewrite_literal"] == "api.example.com"
     assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1(.*)$"
     assert route_action["regex_rewrite"]["substitution"] == "/compatible-mode/v1\\1"
+
+
+def test_generate_envoy_config_custom_anthropic_upstream_rewrites_host(
+    tmp_path, monkeypatch
+):
+    rendered = _render_envoy_config(
+        tmp_path,
+        monkeypatch,
+        """
+version: v0.3
+listeners:
+  - name: "http-8899"
+    address: "0.0.0.0"
+    port: 8899
+providers:
+  defaults:
+    default_model: "claude-sonnet-4.6"
+  models:
+    - name: "claude-sonnet-4.6"
+      api_format: "anthropic"
+      backend_refs:
+        - name: "anthropic-primary"
+          endpoint: "domain.com:443"
+          protocol: "https"
+          weight: 100
+          base_url: "https://domain.com/Anthropic"
+          type: "anthropic"
+          provider: "anthropic"
+routing:
+  modelCards:
+    - name: "claude-sonnet-4.6"
+  decisions:
+    - name: "default-route"
+      description: "default route"
+      priority: 100
+      rules:
+        operator: "AND"
+        conditions: []
+      modelRefs:
+        - model: "claude-sonnet-4.6"
+          use_reasoning: false
+""",
+        extproc_host="vllm-sr-router-container",
+        router_api_host="vllm-sr-router-container",
+    )
+
+    route = _model_route(rendered, "claude-sonnet-4.6")
+    assert route["route"]["cluster"] == "claude_sonnet_4.6_cluster"
+    assert route["route"]["host_rewrite_literal"] == "domain.com"
+
+    with pytest.raises(AssertionError):
+        _cluster_by_name(rendered, "anthropic_api_cluster")
 
 
 def test_generate_envoy_config_uses_logical_dns_for_api_only_router_fallback(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

## Purpose

- What does this PR change?

  **CLI (`config_generator.py`):** Anthropic models with `api_format: anthropic` no longer always use the hardcoded `anthropic_api_cluster` (`api.anthropic.com`). A model is only placed on the shared cluster when every `backend_ref` targets the default Anthropic host; otherwise Envoy gets a per-model cluster and `host_rewrite_literal` from `backend_refs` (same path as OpenAI/vLLM backends).

  **Router (`processor_req_body_anthropic.go`):** Anthropic routing now resolves the upstream chat path from the provider profile (`base_url` + `/v1/messages`), applies `extra_headers` from the endpoint profile (e.g. API gateway subscription keys), selects the real endpoint for tracing (instead of a hardcoded host), and starts router replay on the Anthropic path so Routing Insights records MoM → Claude decisions.

  **Router (`client.go` / `client_test.go`):** Merges OpenAI-style tool definitions and tool-result history into Anthropic Messages API request/response bodies for Envoy-routed traffic, with unit tests for round-trips and custom `:path` headers.

- Why is this change needed?

  Today, any `api_format: anthropic` model is skipped in Envoy generation and forced onto `anthropic_api_cluster` → `api.anthropic.com`, while extproc already rewrites bodies and paths from `backend_refs`. That breaks deployments that expose the Anthropic API on another host (enterprise gateways, proxies, or vendor-hosted endpoints). Requests reach the wrong upstream (empty/HTML/401 responses) even when config lists the correct `endpoint` and `base_url`.

  Tool calling for routed Claude models also requires converting OpenAI `tools` / `tool_calls` / `tool` messages to Anthropic `tools` and content blocks; without this, MoM-routed sessions that rely on tools fail at the transform layer.

- Which module(s) does this affect?

  `Router`, `CLI`

## Test Plan

- What commands, checks, or manual steps should reviewers use?

  Automated:

  ```bash
  cd src/vllm-sr
  pytest tests/test_config_generator.py::test_generate_envoy_config_custom_anthropic_upstream_rewrites_host -v

  cd src/semantic-router
  go test ./pkg/anthropic/... -count=1
  go test ./pkg/extproc/... -run 'Anthropic|HandleAnthropic' -count=1
  ```

  Manual (local gateway):

  1. Configure a model with `api_format: anthropic`, `endpoint: <your-host>:443`, and `base_url: https://<your-host>/<prefix>`.
  2. Run `vllm-sr serve` and confirm generated `.vllm-sr/envoy.yaml` uses `<model>_cluster` → your host (not `anthropic_api_cluster`).
  3. Send a MoM or `x-selected-model` routed request; verify router logs show `Anthropic upstream path: /<prefix>/v1/messages` and a JSON (non-HTML) upstream response.

- Why is this validation sufficient for the affected module(s)?

  The generator test locks the Envoy regression (dedicated cluster + `host_rewrite_literal` from config). Anthropic and extproc unit tests cover tool conversion, header/path building, and replay-on-anthropic-path. Manual steps exercise the full extproc + Envoy path that caused 502s when the shared cluster ignored `backend_refs`.

## Test Result

- `test_generate_envoy_config_custom_anthropic_upstream_rewrites_host` — verifies `claude_sonnet_4.6_cluster`, `host_rewrite_literal: domain.com`, and absence of `anthropic_api_cluster` (test uses a neutral host name).
- Local gateway validation (non-upstream host): after regenerating Envoy config, traffic routes to the configured host; 502s from `api.anthropic.com` misrouting are resolved. Upstream 4xx on large Claude Code/tool payloads are a separate provider/request-shape concern.
- Full `go test ./pkg/extproc/...` may require Rust binding artifacts in the developer environment; targeted tests above are the intended CI surface for this diff.

- Follow-up risks / gaps:

  - Native Claude Code `POST /v1/messages` ingress is still normalized via the OpenAI chat body path; very large tool histories may need additional error passthrough on upstream 4xx.
  - A follow-up could remove the `anthropic_models` / `anthropic_api_cluster` template branch entirely so all Anthropic backends use one generator code path.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, ...
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](https://github.com/vllm-project/semantic-router/blob/main/CONTRIBUTING.md) for the full contributor workflow and commit guidance.

Made with [Cursor](https://cursor.com)