### PR TITLE
[CLI] Update config models to Pydantic ConfigDict

### DIFF
--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .algorithms import AlgorithmConfig, ModelRef
 
@@ -173,80 +173,73 @@ class ContextRule(BaseModel):
 class StructureSource(BaseModel):
     """Source selector for structure-based signals."""
 
+    model_config = ConfigDict(extra="forbid")
+
     type: str
     pattern: Optional[str] = None
     keywords: Optional[List[str]] = None
     case_sensitive: bool = False
     sequences: Optional[List[List[str]]] = None
 
-    class Config:
-        extra = "forbid"
-
 
 class StructureFeature(BaseModel):
     """Typed request-shape feature extractor."""
 
+    model_config = ConfigDict(extra="forbid")
+
     type: str
     source: StructureSource
-
-    class Config:
-        extra = "forbid"
 
 
 class NumericPredicate(BaseModel):
     """Numeric threshold predicate for structure signals."""
+
+    model_config = ConfigDict(extra="forbid")
 
     gt: Optional[float] = None
     gte: Optional[float] = None
     lt: Optional[float] = None
     lte: Optional[float] = None
 
-    class Config:
-        extra = "forbid"
-
 
 class StructureRule(BaseModel):
     """Request-shape routing signal configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     description: Optional[str] = None
     feature: StructureFeature
     predicate: Optional[NumericPredicate] = None
 
-    class Config:
-        extra = "forbid"
-
 
 class ConversationSource(BaseModel):
     """Source selector for conversation-shape signals."""
 
+    model_config = ConfigDict(extra="forbid")
+
     type: str
     role: Optional[str] = None
-
-    class Config:
-        extra = "forbid"
 
 
 class ConversationFeature(BaseModel):
     """Typed conversation-shape feature extractor."""
 
+    model_config = ConfigDict(extra="forbid")
+
     type: str
     source: ConversationSource
-
-    class Config:
-        extra = "forbid"
 
 
 class ConversationRule(BaseModel):
     """Conversation-shape routing signal configuration."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     description: Optional[str] = None
     feature: ConversationFeature
     predicate: Optional[NumericPredicate] = None
-
-    class Config:
-        extra = "forbid"
 
 
 class ComplexityCandidates(BaseModel):
@@ -270,6 +263,8 @@ class PrototypeScoringConfig(BaseModel):
 class EmbeddingClassifierConfig(BaseModel):
     """Embedding classifier tuning, including prototype-aware label scoring controls."""
 
+    model_config = ConfigDict(extra="allow")
+
     model_type: Optional[str] = None
     preload_embeddings: Optional[bool] = None
     target_dimension: Optional[int] = None
@@ -278,9 +273,6 @@ class EmbeddingClassifierConfig(BaseModel):
     top_k: Optional[int] = None
     min_score_threshold: Optional[float] = None
     prototype_scoring: Optional[PrototypeScoringConfig] = None
-
-    class Config:
-        extra = "allow"
 
 
 class ComplexityRule(BaseModel):
@@ -761,6 +753,8 @@ class ImageGenPluginConfig(BaseModel):
 class Decision(BaseModel):
     """Routing decision configuration."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
     description: str
     priority: int
@@ -768,9 +762,6 @@ class Decision(BaseModel):
     modelRefs: List[ModelRef] = Field(alias="modelRefs")
     algorithm: Optional[AlgorithmConfig] = None  # Multi-model orchestration algorithm
     plugins: Optional[List[PluginConfig]] = []
-
-    class Config:
-        populate_by_name = True
 
 
 class ModelPricing(BaseModel):
@@ -881,17 +872,19 @@ class Providers(BaseModel):
 class Routing(BaseModel):
     """Canonical routing block."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     model_cards: List[RoutingModel] = Field(default_factory=list, alias="modelCards")
     signals: Signals = Field(default_factory=Signals)
     projections: Projections = Field(default_factory=Projections)
     decisions: List[Decision] = Field(default_factory=list)
 
-    class Config:
-        populate_by_name = True
-
 
 class EmbeddingModelsConfig(BaseModel):
     """Embedding models configuration for memory and semantic features."""
+
+    # Preserve advanced nested fields when users pass through custom config blocks.
+    model_config = ConfigDict(extra="allow")
 
     qwen3_model_path: Optional[str] = Field(
         None, description="Path to Qwen3-Embedding model"
@@ -916,13 +909,11 @@ class EmbeddingModelsConfig(BaseModel):
     )
     use_cpu: bool = Field(True, description="Use CPU for inference")
 
-    class Config:
-        # Preserve advanced nested fields when users pass through custom config blocks.
-        extra = "allow"
-
 
 class UserConfig(BaseModel):
     """Canonical v0.3 user configuration."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     version: str
     listeners: List[Listener] = Field(default_factory=list)
@@ -938,10 +929,6 @@ class UserConfig(BaseModel):
     @property
     def decisions(self) -> List[Decision]:
         return self.routing.decisions
-
-    class Config:
-        populate_by_name = True
-        extra = "forbid"
 
 
 # Resolve forward references for recursive condition trees.


### PR DESCRIPTION
## Purpose
- Swap CLI Pydantic models from old inner `Config` classes to `ConfigDict`.
- Same behavior, less warning noise. tiny cleanup, real paper cut.
- Affects: `CLI`.

Related: no matching open issue/PR found via `gh` search.

## Repro
- Install the CLI deps as usual, current env resolves `pydantic==2.13.4` from `pydantic>=2.0.0`.
- Run `python -m pytest -q src/vllm-sr/tests` before this change.
- Tests pass, but `cli/models.py` throws 12 `PydanticDeprecatedSince20` warnings. no infra quota, cloud limit, or weird edge needed; just import the supported pydantic v2 path.

## Test Plan
- Promote Pydantic v2 deprecation warnings to errors and import `cli.models`.
- Run CLI unit tests.
- Run changed-file lint / harness checks.

## Test Result
- `../../.venv-agent/bin/python` import with `PydanticDeprecatedSince20` as error: passed
- `.venv-agent/bin/python -m pytest -q src/vllm-sr/tests`: 277 passed
- `make vllm-sr-test`: 39 tests, 33 ran, 6 skipped, passed
- `make agent-validate`: passed
- `make agent-ci-gate CHANGED_FILES="src/vllm-sr/cli/models.py"`: changed-file lint passed