### PR TITLE
[Docs] Update router API matrix for Anthropic upstream support

### DIFF
--- a/website/docs/api/router.md
+++ b/website/docs/api/router.md
@@ -30,7 +30,7 @@ These are upstream model protocols the router can target after routing. They are
 | Backend model API | Upstream path | Status | Notes |
 | --- | --- | --- | --- |
 | OpenAI-compatible Chat Completions | `/chat/completions` | Supported | Default family used for OpenAI-compatible backends |
-| Anthropic Messages API | `/v1/messages` | Supported | Router converts OpenAI-style requests to Anthropic format before forwarding |
+| Anthropic Messages API | `/v1/messages` | Supported | Converts OpenAI-style requests (including tools); upstream host and path from `backend_refs` |
 | vLLM Omni Chat Completions | `/chat/completions` | Supported | Used for omni and image-generation backends such as `vllm_omni` |
 
 Provider families with OpenAI-compatible chat-completions defaults include `openai`, `azure-openai`, `bedrock`, `gemini`, and `vertex-ai`.
@@ -84,6 +84,8 @@ Minimal request:
 - Anthropic support lives in the backend model API layer.
 - Client ingress is still OpenAI-style Chat Completions or Responses API, not `POST /v1/messages`.
 - The router converts the upstream request to Anthropic `POST /v1/messages` and converts the response back to OpenAI-compatible output.
+- Upstream host, path, and optional `extra_headers` come from `backend_refs` and the endpoint provider profile (`base_url`, optional `chat_path`).
+- OpenAI-style `tools`, `tool_calls`, and `tool` messages are converted for Anthropic backends.
 - Streaming is not supported for Anthropic-backed routing.
 
 ### vLLM Omni and Multimodal/Image Generation

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/router.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/router.md
@@ -39,7 +39,7 @@ Router 是通常通过 Envoy 暴露的数据面 HTTP 接口。
 | 后端模型 API | 上游路径 | 状态 | 说明 |
 | --- | --- | --- | --- |
 | OpenAI 兼容 Chat Completions | `/chat/completions` | 支持 | OpenAI 兼容后端的默认族 |
-| Anthropic Messages API | `/v1/messages` | 支持 | 转发前将 OpenAI 风格请求转换为 Anthropic 格式 |
+| Anthropic Messages API | `/v1/messages` | 支持 | 将 OpenAI 风格请求（含 tools）转换为 Anthropic 格式；上游主机与路径来自 `backend_refs` |
 | vLLM Omni Chat Completions | `/chat/completions` | 支持 | 用于 omni 与图像生成等后端，例如 `vllm_omni` |
 
 默认使用 OpenAI 兼容 chat-completions 的 provider 族包括 `openai`、`azure-openai`、`bedrock`、`gemini`、`vertex-ai`。
@@ -93,6 +93,8 @@ Router 是通常通过 Envoy 暴露的数据面 HTTP 接口。
 - Anthropic 支持位于后端模型 API 层。
 - 客户端入口仍是 OpenAI 风格的 Chat Completions 或 Responses API，而不是 `POST /v1/messages`。
 - Router 将上游请求转为 Anthropic `POST /v1/messages`，再将响应转回 OpenAI 兼容输出。
+- 上游主机、路径及可选 `extra_headers` 来自 `backend_refs` 与端点 provider profile（`base_url`、可选 `chat_path`）。
+- OpenAI 风格的 `tools`、`tool_calls` 与 `tool` 消息会转换为 Anthropic 后端格式。
 - 基于 Anthropic 的路由不支持流式。
 
 ### vLLM Omni 与多模态/图像生成


### PR DESCRIPTION
## Summary

Follow-up to #1922 per review feedback from @rootfs.

- Update the **Backend Model API** matrix in `website/docs/api/router.md` to note Anthropic tool conversion and upstream host/path from `backend_refs`.
- Add brief Anthropic API bullets for profile-driven upstream settings (`base_url`, `chat_path`, `extra_headers`) and OpenAI-style tool message conversion.
- Mirror the same changes in the zh-Hans router API doc.

## Test plan

- [x] Reviewed rendered markdown locally (table alignment and section consistency with existing Configuration Linkage bullets)
- [ ] Netlify docs preview (if triggered on PR)


Made with [Cursor](https://cursor.com)