### PR TITLE
[Router] add Anthropic streaming with OpenAI SSE translation

### DIFF
--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -34,6 +34,10 @@ type HeaderKeyValue struct {
 // messagesPath should include any base_url prefix (e.g. /Anthropic/v1/messages for AMD).
 // When empty, AnthropicMessagesPath (/v1/messages) is used.
 func BuildRequestHeaders(apiKey string, bodyLength int, messagesPath string) []HeaderKeyValue {
+	return buildRequestHeaders(apiKey, bodyLength, messagesPath, false)
+}
+
+func buildRequestHeaders(apiKey string, bodyLength int, messagesPath string, streaming bool) []HeaderKeyValue {
 	if strings.TrimSpace(messagesPath) == "" {
 		messagesPath = AnthropicMessagesPath
 	}
@@ -43,6 +47,9 @@ func BuildRequestHeaders(apiKey string, bodyLength int, messagesPath string) []H
 		{Key: "accept-encoding", Value: "identity"},
 		{Key: ":path", Value: messagesPath},
 		{Key: "content-length", Value: fmt.Sprintf("%d", bodyLength)},
+	}
+	if streaming {
+		headers = append(headers, HeaderKeyValue{Key: "accept", Value: "text/event-stream"})
 	}
 	if strings.TrimSpace(apiKey) != "" {
 		headers = append([]HeaderKeyValue{{Key: "x-api-key", Value: apiKey}}, headers...)

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -1,0 +1,357 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go"
+	"github.com/tidwall/sjson"
+)
+
+// StreamState tracks Anthropic SSE events while translating to OpenAI SSE.
+type StreamState struct {
+	MessageID           string
+	Created             int64
+	RoleSent            bool
+	BlockIndexToToolIdx map[int64]int
+	NextToolIdx         int
+}
+
+// NewStreamState returns initialized stream translation state.
+func NewStreamState() *StreamState {
+	return &StreamState{
+		BlockIndexToToolIdx: make(map[int64]int),
+	}
+}
+
+// TransformSSEChunkToOpenAI converts Anthropic SSE bytes from Envoy into OpenAI SSE.
+// streamDone is true when message_stop is observed.
+func TransformSSEChunkToOpenAI(
+	anthropicChunk []byte,
+	state *StreamState,
+	model string,
+) ([]byte, bool, error) {
+	if state == nil {
+		state = NewStreamState()
+	}
+
+	// Some gateways (Vertex AI, APIM) already return OpenAI-compatible SSE.
+	if looksLikeOpenAIStreamChunk(anthropicChunk) {
+		return anthropicChunk, bytes.Contains(anthropicChunk, []byte("[DONE]")), nil
+	}
+
+	var out bytes.Buffer
+	streamDone := false
+	for _, data := range extractSSEDataLines(anthropicChunk) {
+		var event anthropic.MessageStreamEventUnion
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue
+		}
+		chunks, done, err := transformStreamEvent(event, state, model)
+		if err != nil {
+			return nil, false, err
+		}
+		if done {
+			streamDone = true
+		}
+		for _, chunk := range chunks {
+			out.Write(formatOpenAISSELine(chunk))
+		}
+	}
+
+	if streamDone {
+		out.WriteString("data: [DONE]\n\n")
+	}
+
+	return out.Bytes(), streamDone, nil
+}
+
+func extractSSEDataLines(chunk []byte) [][]byte {
+	var lines [][]byte
+	for _, line := range bytes.Split(chunk, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			payload := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+			if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+				continue
+			}
+			lines = append(lines, payload)
+			continue
+		}
+		if line[0] == '{' {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func transformStreamEvent(
+	event anthropic.MessageStreamEventUnion,
+	state *StreamState,
+	model string,
+) ([][]byte, bool, error) {
+	switch event.Type {
+	case "message_start":
+		return handleMessageStart(event, state, model)
+	case "content_block_start":
+		return handleContentBlockStart(event, state, model)
+	case "content_block_delta":
+		return handleContentBlockDelta(event, state, model)
+	case "message_delta":
+		return handleMessageDelta(event, state, model)
+	case "message_stop":
+		return nil, true, nil
+	case "content_block_stop", "ping", "vertex_event":
+		return nil, false, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+func looksLikeOpenAIStreamChunk(chunk []byte) bool {
+	return bytes.Contains(chunk, []byte(`"object":"chat.completion.chunk"`)) ||
+		bytes.Contains(chunk, []byte(`"object": "chat.completion.chunk"`)) ||
+		(bytes.Contains(chunk, []byte(`"choices"`)) && bytes.Contains(chunk, []byte(`"delta"`)))
+}
+
+func handleMessageStart(
+	event anthropic.MessageStreamEventUnion,
+	state *StreamState,
+	model string,
+) ([][]byte, bool, error) {
+	start := event.AsMessageStart()
+	if start.Message.ID != "" {
+		state.MessageID = start.Message.ID
+	}
+	if state.Created == 0 {
+		state.Created = time.Now().Unix()
+	}
+	if state.RoleSent {
+		return nil, false, nil
+	}
+	state.RoleSent = true
+	chunk, err := buildOpenAIStreamChunk(state, model, openai.ChatCompletionChunkChoiceDelta{
+		Role: "assistant",
+	})
+	return [][]byte{chunk}, false, err
+}
+
+func handleContentBlockStart(
+	event anthropic.MessageStreamEventUnion,
+	state *StreamState,
+	model string,
+) ([][]byte, bool, error) {
+	start := event.AsContentBlockStart()
+	block := start.ContentBlock
+
+	switch block.Type {
+	case "text":
+		if strings.TrimSpace(block.Text) == "" {
+			return nil, false, nil
+		}
+		chunk, err := buildOpenAIStreamChunk(state, model, openai.ChatCompletionChunkChoiceDelta{
+			Content: block.Text,
+		})
+		return [][]byte{chunk}, false, err
+	case "tool_use", "server_tool_use":
+		toolIdx := state.NextToolIdx
+		state.NextToolIdx++
+		state.BlockIndexToToolIdx[start.Index] = toolIdx
+		chunk, err := buildOpenAIStreamToolChunk(state, model, toolIdx, block.ID, block.Name, "")
+		return [][]byte{chunk}, false, err
+	default:
+		return nil, false, nil
+	}
+}
+
+func handleContentBlockDelta(
+	event anthropic.MessageStreamEventUnion,
+	state *StreamState,
+	model string,
+) ([][]byte, bool, error) {
+	deltaEvent := event.AsContentBlockDelta()
+	delta := deltaEvent.Delta
+
+	switch delta.Type {
+	case "text_delta":
+		textDelta := delta.AsTextDelta()
+		if textDelta.Text == "" {
+			return nil, false, nil
+		}
+		chunk, err := buildOpenAIStreamChunk(state, model, openai.ChatCompletionChunkChoiceDelta{
+			Content: textDelta.Text,
+		})
+		return [][]byte{chunk}, false, err
+	case "input_json_delta":
+		toolIdx, ok := state.BlockIndexToToolIdx[deltaEvent.Index]
+		if !ok {
+			return nil, false, nil
+		}
+		jsonDelta := delta.AsInputJSONDelta()
+		chunk, err := buildOpenAIStreamToolChunk(state, model, toolIdx, "", "", jsonDelta.PartialJSON)
+		return [][]byte{chunk}, false, err
+	default:
+		return nil, false, nil
+	}
+}
+
+func handleMessageDelta(
+	event anthropic.MessageStreamEventUnion,
+	state *StreamState,
+	model string,
+) ([][]byte, bool, error) {
+	deltaEvent := event.AsMessageDelta()
+	finishReason := mapAnthropicStopReasonToOpenAI(deltaEvent.Delta.StopReason)
+
+	chunk, err := buildOpenAIStreamFinishChunk(state, model, finishReason, deltaEvent.Usage)
+	if err != nil {
+		return nil, false, err
+	}
+	if chunk == nil {
+		return nil, false, nil
+	}
+	return [][]byte{chunk}, false, nil
+}
+
+func buildOpenAIStreamChunk(
+	state *StreamState,
+	model string,
+	delta openai.ChatCompletionChunkChoiceDelta,
+) ([]byte, error) {
+	chunk := openai.ChatCompletionChunk{
+		ID:      state.MessageID,
+		Object:  "chat.completion.chunk",
+		Created: state.Created,
+		Model:   model,
+		Choices: []openai.ChatCompletionChunkChoice{{
+			Index: 0,
+			Delta: delta,
+		}},
+	}
+	return json.Marshal(chunk)
+}
+
+func buildOpenAIStreamToolChunk(
+	state *StreamState,
+	model string,
+	toolIdx int,
+	id string,
+	name string,
+	arguments string,
+) ([]byte, error) {
+	toolCall := openai.ChatCompletionChunkChoiceDeltaToolCall{
+		Index: int64(toolIdx),
+	}
+	if id != "" {
+		toolCall.ID = id
+	}
+	if name != "" {
+		toolCall.Type = "function"
+		toolCall.Function.Name = name
+	}
+	if arguments != "" {
+		if toolCall.Type == "" {
+			toolCall.Type = "function"
+		}
+		toolCall.Function.Arguments = arguments
+	}
+
+	chunk := openai.ChatCompletionChunk{
+		ID:      state.MessageID,
+		Object:  "chat.completion.chunk",
+		Created: state.Created,
+		Model:   model,
+		Choices: []openai.ChatCompletionChunkChoice{{
+			Index: 0,
+			Delta: openai.ChatCompletionChunkChoiceDelta{
+				ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{toolCall},
+			},
+		}},
+	}
+	return json.Marshal(chunk)
+}
+
+func buildOpenAIStreamFinishChunk(
+	state *StreamState,
+	model string,
+	finishReason string,
+	usage anthropic.MessageDeltaUsage,
+) ([]byte, error) {
+	if finishReason == "" && usage.InputTokens == 0 && usage.OutputTokens == 0 {
+		return nil, nil
+	}
+
+	choice := openai.ChatCompletionChunkChoice{
+		Index: 0,
+		Delta: openai.ChatCompletionChunkChoiceDelta{},
+	}
+	if finishReason != "" {
+		choice.FinishReason = finishReason
+	}
+
+	chunk := openai.ChatCompletionChunk{
+		ID:      state.MessageID,
+		Object:  "chat.completion.chunk",
+		Created: state.Created,
+		Model:   model,
+		Choices: []openai.ChatCompletionChunkChoice{choice},
+	}
+	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+		chunk.Usage = openai.CompletionUsage{
+			PromptTokens:     usage.InputTokens,
+			CompletionTokens: usage.OutputTokens,
+			TotalTokens:      usage.InputTokens + usage.OutputTokens,
+		}
+	}
+	return json.Marshal(chunk)
+}
+
+func mapAnthropicStopReasonToOpenAI(reason anthropic.StopReason) string {
+	switch reason {
+	case anthropic.StopReasonEndTurn, anthropic.StopReasonStopSequence:
+		return "stop"
+	case anthropic.StopReasonMaxTokens:
+		return "length"
+	case anthropic.StopReasonToolUse:
+		return "tool_calls"
+	default:
+		if reason == "" {
+			return ""
+		}
+		return "stop"
+	}
+}
+
+func formatOpenAISSELine(chunkJSON []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("data: ")
+	buf.Write(chunkJSON)
+	buf.WriteString("\n\n")
+	return buf.Bytes()
+}
+
+// WithStreamingRequestBody adds stream=true to an Anthropic request JSON body.
+func WithStreamingRequestBody(body []byte) ([]byte, error) {
+	return withStreamFlag(body)
+}
+
+// BuildStreamingRequestHeaders returns headers for a streaming Anthropic request.
+func BuildStreamingRequestHeaders(apiKey string, bodyLength int, messagesPath string) []HeaderKeyValue {
+	return buildRequestHeaders(apiKey, bodyLength, messagesPath, true)
+}
+
+// withStreamFlag adds stream=true to an Anthropic request JSON body.
+func withStreamFlag(body []byte) ([]byte, error) {
+	out, err := sjson.SetBytes(body, "stream", true)
+	if err != nil {
+		return nil, fmt.Errorf("set stream flag: %w", err)
+	}
+	return out, nil
+}

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -39,11 +39,6 @@ func TransformSSEChunkToOpenAI(
 		state = NewStreamState()
 	}
 
-	// Some gateways (Vertex AI, APIM) already return OpenAI-compatible SSE.
-	if looksLikeOpenAIStreamChunk(anthropicChunk) {
-		return anthropicChunk, bytes.Contains(anthropicChunk, []byte("[DONE]")), nil
-	}
-
 	var out bytes.Buffer
 	streamDone := false
 	for _, data := range extractSSEDataLines(anthropicChunk) {
@@ -113,12 +108,6 @@ func transformStreamEvent(
 	default:
 		return nil, false, nil
 	}
-}
-
-func looksLikeOpenAIStreamChunk(chunk []byte) bool {
-	return bytes.Contains(chunk, []byte(`"object":"chat.completion.chunk"`)) ||
-		bytes.Contains(chunk, []byte(`"object": "chat.completion.chunk"`)) ||
-		(bytes.Contains(chunk, []byte(`"choices"`)) && bytes.Contains(chunk, []byte(`"delta"`)))
 }
 
 func handleMessageStart(

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -1,0 +1,139 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithStreamingRequestBody_SetsStreamFlag(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: simpleUserMsg("hi"),
+	}
+
+	body, err := ToAnthropicRequestBody(req)
+	require.NoError(t, err)
+
+	streamingBody, err := WithStreamingRequestBody(body)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(streamingBody, &parsed))
+	assert.Equal(t, true, parsed["stream"])
+}
+
+func TestBuildStreamingRequestHeaders_Accept(t *testing.T) {
+	headers := BuildStreamingRequestHeaders("key", 10, "")
+	accept := ""
+	for _, h := range headers {
+		if h.Key == "accept" {
+			accept = h.Value
+		}
+	}
+	assert.Equal(t, "text/event-stream", accept)
+}
+
+func TestTransformSSEChunkToOpenAI_TextStream(t *testing.T) {
+	state := NewStreamState()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hello"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}`,
+		`{"type":"message_stop"}`,
+	}
+	chunk := buildAnthropicSSE(events...)
+
+	out, done, err := TransformSSEChunkToOpenAI([]byte(chunk), state, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done)
+	assert.Contains(t, string(out), "data: ")
+	assert.Contains(t, string(out), "Hello")
+	assert.Contains(t, string(out), " world")
+	assert.Contains(t, string(out), "data: [DONE]")
+	assert.Contains(t, string(out), `"role":"assistant"`)
+	assert.Contains(t, string(out), `"finish_reason":"stop"`)
+}
+
+func TestTransformSSEChunkToOpenAI_ToolUseStream(t *testing.T) {
+	state := NewStreamState()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Paris\"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":12}}`,
+		`{"type":"message_stop"}`,
+	}
+	chunk := buildAnthropicSSE(events...)
+
+	out, done, err := TransformSSEChunkToOpenAI([]byte(chunk), state, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done)
+	body := string(out)
+	assert.Contains(t, body, "tool_calls")
+	assert.Contains(t, body, "toolu_01")
+	assert.Contains(t, body, "get_weather")
+	assert.Contains(t, body, `"finish_reason":"tool_calls"`)
+	assert.Contains(t, body, "Paris")
+}
+
+func TestTransformSSEChunkToOpenAI_AccumulatesToolArguments(t *testing.T) {
+	state := NewStreamState()
+	start := buildAnthropicSSE(
+		`{"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}`,
+	)
+	_, _, err := TransformSSEChunkToOpenAI([]byte(start), state, "claude-sonnet-4-5")
+	require.NoError(t, err)
+
+	delta := buildAnthropicSSE(
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Paris\"}"}}`,
+	)
+	out, _, err := TransformSSEChunkToOpenAI([]byte(delta), state, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "Paris")
+}
+
+func buildAnthropicSSE(events ...string) string {
+	var b strings.Builder
+	for _, event := range events {
+		b.WriteString("event: ")
+		var typed struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal([]byte(event), &typed)
+		b.WriteString(typed.Type)
+		b.WriteString("\ndata: ")
+		b.WriteString(event)
+		b.WriteString("\n\n")
+	}
+	return b.String()
+}
+
+func TestTransformSSEChunkToOpenAI_PassthroughOpenAIFormat(t *testing.T) {
+	state := NewStreamState()
+	openAIChunk := []byte(`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"}}]}
+
+data: [DONE]
+
+`)
+	out, done, err := TransformSSEChunkToOpenAI(openAIChunk, state, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done)
+	assert.Equal(t, string(openAIChunk), string(out))
+}
+
+func TestMapAnthropicStopReasonToOpenAI(t *testing.T) {
+	assert.Equal(t, "stop", mapAnthropicStopReasonToOpenAI(anthropic.StopReasonEndTurn))
+	assert.Equal(t, "length", mapAnthropicStopReasonToOpenAI(anthropic.StopReasonMaxTokens))
+	assert.Equal(t, "tool_calls", mapAnthropicStopReasonToOpenAI(anthropic.StopReasonToolUse))
+}

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -119,19 +119,6 @@ func buildAnthropicSSE(events ...string) string {
 	return b.String()
 }
 
-func TestTransformSSEChunkToOpenAI_PassthroughOpenAIFormat(t *testing.T) {
-	state := NewStreamState()
-	openAIChunk := []byte(`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"}}]}
-
-data: [DONE]
-
-`)
-	out, done, err := TransformSSEChunkToOpenAI(openAIChunk, state, "claude-sonnet-4-5")
-	require.NoError(t, err)
-	assert.True(t, done)
-	assert.Equal(t, string(openAIChunk), string(out))
-}
-
 func TestMapAnthropicStopReasonToOpenAI(t *testing.T) {
 	assert.Equal(t, "stop", mapAnthropicStopReasonToOpenAI(anthropic.StopReasonEndTurn))
 	assert.Equal(t, "length", mapAnthropicStopReasonToOpenAI(anthropic.StopReasonMaxTokens))

--- a/src/semantic-router/pkg/extproc/processor_core.go
+++ b/src/semantic-router/pkg/extproc/processor_core.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
@@ -87,6 +88,9 @@ func (r *OpenAIRouter) handleProcessReceiveError(ctx *RequestContext, err error)
 	if ctx.IsStreamingResponse && !ctx.StreamingComplete {
 		ctx.StreamingAborted = true
 		logging.Debugf("Streaming response aborted before completion, will not cache")
+	}
+	if ctx.APIFormat == config.APIFormatAnthropic && ctx.IsStreamingResponse {
+		releaseAnthropicStreamState(ctx)
 	}
 
 	if errors.Is(err, io.EOF) {

--- a/src/semantic-router/pkg/extproc/processor_core.go
+++ b/src/semantic-router/pkg/extproc/processor_core.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
@@ -88,9 +87,6 @@ func (r *OpenAIRouter) handleProcessReceiveError(ctx *RequestContext, err error)
 	if ctx.IsStreamingResponse && !ctx.StreamingComplete {
 		ctx.StreamingAborted = true
 		logging.Debugf("Streaming response aborted before completion, will not cache")
-	}
-	if ctx.APIFormat == config.APIFormatAnthropic && ctx.IsStreamingResponse {
-		releaseAnthropicStreamState(ctx)
 	}
 
 	if errors.Is(err, io.EOF) {

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
@@ -74,9 +74,6 @@ func (r *OpenAIRouter) prepareAnthropicRoutingRequest(
 	ctx.RequestModel = targetModel
 	ctx.VSRSelectedModel = targetModel
 	ctx.APIFormat = config.APIFormatAnthropic
-	if streaming {
-		ctx.AnthropicStream = anthropic.NewStreamState()
-	}
 	if decisionName != "" {
 		ctx.VSRSelectedDecision = r.Config.GetDecisionByName(decisionName)
 	}

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
@@ -74,6 +74,9 @@ func (r *OpenAIRouter) prepareAnthropicRoutingRequest(
 	ctx.RequestModel = targetModel
 	ctx.VSRSelectedModel = targetModel
 	ctx.APIFormat = config.APIFormatAnthropic
+	if streaming {
+		ctx.AnthropicStream = anthropic.NewStreamState()
+	}
 	if decisionName != "" {
 		ctx.VSRSelectedDecision = r.Config.GetDecisionByName(decisionName)
 	}

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
@@ -24,13 +24,6 @@ func (r *OpenAIRouter) handleAnthropicRouting(
 	ctx *RequestContext,
 ) (*ext_proc.ProcessingResponse, error) {
 	logging.Infof("Routing to Anthropic API via Envoy for model: %s (original: %s)", targetModel, originalModel)
-	if ctx.ExpectStreamingResponse {
-		logging.Warnf("Streaming not supported for Anthropic backend, rejecting request for model: %s", targetModel)
-		return r.createErrorResponse(
-			400,
-			"Streaming is not supported for Anthropic models. Please set stream=false in your request.",
-		), nil
-	}
 
 	accessKey, anthropicBody, errorResponse := r.prepareAnthropicRoutingRequest(
 		openAIRequest,
@@ -64,15 +57,26 @@ func (r *OpenAIRouter) prepareAnthropicRoutingRequest(
 	}
 
 	openAIRequest.Model = targetModel
+	streaming := ctx.ExpectStreamingResponse
 	anthropicBody, err := anthropic.ToAnthropicRequestBody(openAIRequest)
 	if err != nil {
 		logging.Errorf("Failed to transform request to Anthropic format: %v", err)
 		return "", nil, r.createErrorResponse(500, fmt.Sprintf("Request transformation error: %v", err))
 	}
+	if streaming {
+		anthropicBody, err = anthropic.WithStreamingRequestBody(anthropicBody)
+		if err != nil {
+			logging.Errorf("Failed to enable Anthropic streaming on request: %v", err)
+			return "", nil, r.createErrorResponse(500, fmt.Sprintf("Request transformation error: %v", err))
+		}
+	}
 
 	ctx.RequestModel = targetModel
 	ctx.VSRSelectedModel = targetModel
 	ctx.APIFormat = config.APIFormatAnthropic
+	if streaming {
+		ctx.AnthropicStream = anthropic.NewStreamState()
+	}
 	if decisionName != "" {
 		ctx.VSRSelectedDecision = r.Config.GetDecisionByName(decisionName)
 	}
@@ -114,7 +118,12 @@ func (r *OpenAIRouter) buildAnthropicRoutingResponse(
 	}
 
 	bodyLength := len(anthropicBody)
-	anthropicHeaders := anthropic.BuildRequestHeaders(accessKey, bodyLength, messagesPath)
+	var anthropicHeaders []anthropic.HeaderKeyValue
+	if ctx.ExpectStreamingResponse {
+		anthropicHeaders = anthropic.BuildStreamingRequestHeaders(accessKey, bodyLength, messagesPath)
+	} else {
+		anthropicHeaders = anthropic.BuildRequestHeaders(accessKey, bodyLength, messagesPath)
+	}
 	setHeaders := make([]*core.HeaderValueOption, 0, len(anthropicHeaders)+8)
 	for _, header := range anthropicHeaders {
 		setHeaders = append(setHeaders, &core.HeaderValueOption{

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
@@ -79,6 +79,9 @@ func TestHandleAnthropicRouting_AllowsStreaming(t *testing.T) {
 	if response == nil {
 		t.Fatal("expected routing response for streaming anthropic request")
 	}
+	if ctx.AnthropicStream == nil {
+		t.Fatal("expected anthropic stream state to be initialized")
+	}
 	body := response.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
 	if !containsJSONField(t, body, "stream", true) {
 		t.Fatalf("expected stream=true in anthropic body, got %s", string(body))

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/authz"
@@ -48,4 +49,51 @@ func TestHandleAnthropicRoutingStartsRouterReplay(t *testing.T) {
 	if ctx.RouterReplayID == "" {
 		t.Fatal("expected router replay to start on anthropic routing path")
 	}
+}
+
+func TestHandleAnthropicRouting_AllowsStreaming(t *testing.T) {
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{},
+		CredentialResolver: authz.NewCredentialResolver(
+			authz.NewHeaderInjectionProvider(map[string]string{
+				string(authz.ProviderAnthropic): "x-user-anthropic-key",
+			}),
+		),
+	}
+	router.CredentialResolver.SetFailOpen(true)
+
+	request, err := parseOpenAIRequest([]byte(`{"model":"claude","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("parseOpenAIRequest failed: %v", err)
+	}
+
+	ctx := &RequestContext{
+		Headers:                 map[string]string{},
+		ExpectStreamingResponse: true,
+		OriginalRequestBody:     []byte(`{"model":"claude","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}
+	response, err := router.handleAnthropicRouting(request, "claude", "claude-sonnet-4.6", "", ctx)
+	if err != nil {
+		t.Fatalf("handleAnthropicRouting failed: %v", err)
+	}
+	if response == nil {
+		t.Fatal("expected routing response for streaming anthropic request")
+	}
+	if ctx.AnthropicStream == nil {
+		t.Fatal("expected anthropic stream state to be initialized")
+	}
+	body := response.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	if !containsJSONField(t, body, "stream", true) {
+		t.Fatalf("expected stream=true in anthropic body, got %s", string(body))
+	}
+}
+
+func containsJSONField(t *testing.T, body []byte, key string, want bool) bool {
+	t.Helper()
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	got, ok := parsed[key].(bool)
+	return ok && got == want
 }

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
@@ -79,9 +79,6 @@ func TestHandleAnthropicRouting_AllowsStreaming(t *testing.T) {
 	if response == nil {
 		t.Fatal("expected routing response for streaming anthropic request")
 	}
-	if ctx.AnthropicStream == nil {
-		t.Fatal("expected anthropic stream state to be initialized")
-	}
 	body := response.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
 	if !containsJSONField(t, body, "stream", true) {
 		t.Fatalf("expected stream=true in anthropic body, got %s", string(body))

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -27,6 +27,10 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 		return looperResponse, nil
 	}
 
+	if ctx.IsStreamingResponse && ctx.APIFormat == config.APIFormatAnthropic {
+		return r.handleAnthropicStreamingResponseBody(v.ResponseBody.Body, ctx), nil
+	}
+
 	responseBody, anthropicTransformed, err := r.normalizeProviderResponseBody(v.ResponseBody.Body, ctx)
 	if err != nil {
 		return r.createErrorResponse(502, fmt.Sprintf("Response transformation error: %v", err)), nil

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -1,50 +1,13 @@
 package extproc
 
 import (
-	"fmt"
 	"strings"
-	"sync"
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
-
-// anthropicStreamStates holds per-request Anthropic→OpenAI SSE translation state.
-// Entries are keyed by RequestID (or request context pointer when RequestID is unset)
-// and must be removed on stream completion or ext_proc stream teardown (see
-// releaseAnthropicStreamState and handleProcessReceiveError).
-var anthropicStreamStates sync.Map
-
-func anthropicStreamStateKey(ctx *RequestContext) string {
-	if ctx == nil {
-		return ""
-	}
-	if ctx.RequestID != "" {
-		return ctx.RequestID
-	}
-	return fmt.Sprintf("%p", ctx)
-}
-
-func getAnthropicStreamState(ctx *RequestContext) *anthropic.StreamState {
-	key := anthropicStreamStateKey(ctx)
-	if key == "" {
-		return anthropic.NewStreamState()
-	}
-	if v, ok := anthropicStreamStates.Load(key); ok {
-		return v.(*anthropic.StreamState)
-	}
-	state := anthropic.NewStreamState()
-	actual, _ := anthropicStreamStates.LoadOrStore(key, state)
-	return actual.(*anthropic.StreamState)
-}
-
-func releaseAnthropicStreamState(ctx *RequestContext) {
-	if key := anthropicStreamStateKey(ctx); key != "" {
-		anthropicStreamStates.Delete(key)
-	}
-}
 
 // handleAnthropicStreamingResponseBody translates Anthropic SSE into OpenAI
 // chat.completion.chunk SSE, then reuses the standard streaming accumulator path.
@@ -55,21 +18,22 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 	recordStreamingTTFT(ctx)
 	ensureStreamingState(ctx)
 
-	streamState := getAnthropicStreamState(ctx)
+	if ctx.AnthropicStream == nil {
+		ctx.AnthropicStream = anthropic.NewStreamState()
+	}
+
 	transformed, streamDone, err := anthropic.TransformSSEChunkToOpenAI(
 		responseBody,
-		streamState,
+		ctx.AnthropicStream,
 		ctx.RequestModel,
 	)
 	if err != nil {
 		logging.Errorf("Failed to transform Anthropic streaming chunk: %v", err)
-		releaseAnthropicStreamState(ctx)
 		return buildResponseBodyContinueResponse(nil, nil)
 	}
 	if len(transformed) == 0 {
 		if streamDone {
 			r.finalizeStreamingResponse(ctx)
-			releaseAnthropicStreamState(ctx)
 		}
 		return buildResponseBodyContinueResponse(nil, nil)
 	}
@@ -80,7 +44,6 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 
 	if strings.Contains(chunkStr, "data: [DONE]") || streamDone {
 		r.finalizeStreamingResponse(ctx)
-		releaseAnthropicStreamState(ctx)
 	}
 
 	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -1,0 +1,52 @@
+package extproc
+
+import (
+	"strings"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// handleAnthropicStreamingResponseBody translates Anthropic SSE into OpenAI
+// chat.completion.chunk SSE, then reuses the standard streaming accumulator path.
+func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
+	responseBody []byte,
+	ctx *RequestContext,
+) *ext_proc.ProcessingResponse {
+	recordStreamingTTFT(ctx)
+	ensureStreamingState(ctx)
+
+	if ctx.AnthropicStream == nil {
+		ctx.AnthropicStream = anthropic.NewStreamState()
+	}
+
+	transformed, streamDone, err := anthropic.TransformSSEChunkToOpenAI(
+		responseBody,
+		ctx.AnthropicStream,
+		ctx.RequestModel,
+	)
+	if err != nil {
+		logging.Errorf("Failed to transform Anthropic streaming chunk: %v", err)
+		return buildResponseBodyContinueResponse(nil, nil)
+	}
+	if len(transformed) == 0 {
+		if streamDone {
+			r.finalizeStreamingResponse(ctx)
+		}
+		return buildResponseBodyContinueResponse(nil, nil)
+	}
+
+	chunkStr := string(transformed)
+	ctx.StreamingChunks = append(ctx.StreamingChunks, chunkStr)
+	r.parseStreamingChunk(chunkStr, ctx)
+
+	if strings.Contains(chunkStr, "data: [DONE]") || streamDone {
+		r.finalizeStreamingResponse(ctx)
+	}
+
+	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{
+		Mutation: &ext_proc.BodyMutation_Body{Body: transformed},
+	}, nil)
+}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -1,13 +1,50 @@
 package extproc
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
+
+// anthropicStreamStates holds per-request Anthropic→OpenAI SSE translation state.
+// Entries are keyed by RequestID (or request context pointer when RequestID is unset)
+// and must be removed on stream completion or ext_proc stream teardown (see
+// releaseAnthropicStreamState and handleProcessReceiveError).
+var anthropicStreamStates sync.Map
+
+func anthropicStreamStateKey(ctx *RequestContext) string {
+	if ctx == nil {
+		return ""
+	}
+	if ctx.RequestID != "" {
+		return ctx.RequestID
+	}
+	return fmt.Sprintf("%p", ctx)
+}
+
+func getAnthropicStreamState(ctx *RequestContext) *anthropic.StreamState {
+	key := anthropicStreamStateKey(ctx)
+	if key == "" {
+		return anthropic.NewStreamState()
+	}
+	if v, ok := anthropicStreamStates.Load(key); ok {
+		return v.(*anthropic.StreamState)
+	}
+	state := anthropic.NewStreamState()
+	actual, _ := anthropicStreamStates.LoadOrStore(key, state)
+	return actual.(*anthropic.StreamState)
+}
+
+func releaseAnthropicStreamState(ctx *RequestContext) {
+	if key := anthropicStreamStateKey(ctx); key != "" {
+		anthropicStreamStates.Delete(key)
+	}
+}
 
 // handleAnthropicStreamingResponseBody translates Anthropic SSE into OpenAI
 // chat.completion.chunk SSE, then reuses the standard streaming accumulator path.
@@ -18,22 +55,21 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 	recordStreamingTTFT(ctx)
 	ensureStreamingState(ctx)
 
-	if ctx.AnthropicStream == nil {
-		ctx.AnthropicStream = anthropic.NewStreamState()
-	}
-
+	streamState := getAnthropicStreamState(ctx)
 	transformed, streamDone, err := anthropic.TransformSSEChunkToOpenAI(
 		responseBody,
-		ctx.AnthropicStream,
+		streamState,
 		ctx.RequestModel,
 	)
 	if err != nil {
 		logging.Errorf("Failed to transform Anthropic streaming chunk: %v", err)
+		releaseAnthropicStreamState(ctx)
 		return buildResponseBodyContinueResponse(nil, nil)
 	}
 	if len(transformed) == 0 {
 		if streamDone {
 			r.finalizeStreamingResponse(ctx)
+			releaseAnthropicStreamState(ctx)
 		}
 		return buildResponseBodyContinueResponse(nil, nil)
 	}
@@ -44,6 +80,7 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 
 	if strings.Contains(chunkStr, "data: [DONE]") || streamDone {
 		r.finalizeStreamingResponse(ctx)
+		releaseAnthropicStreamState(ctx)
 	}
 
 	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
@@ -1,0 +1,50 @@
+package extproc
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestHandleAnthropicStreamingResponseBody_TranslatesSSE(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{
+		APIFormat:           config.APIFormatAnthropic,
+		RequestModel:        "claude-sonnet-4-5",
+		AnthropicStream:     anthropic.NewStreamState(),
+		StreamingMetadata:   make(map[string]interface{}),
+		ProcessingStartTime: time.Now().Add(-10 * time.Millisecond),
+	}
+	anthropicChunk := strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":0}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		"",
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}`,
+		"",
+		"event: message_stop",
+		`data: {"type":"message_stop"}`,
+		"",
+	}, "\n")
+
+	resp := router.handleAnthropicStreamingResponseBody([]byte(anthropicChunk), ctx)
+	require.NotNil(t, resp)
+	body := resp.GetResponseBody().GetResponse().GetBodyMutation().GetBody()
+	require.NotEmpty(t, body)
+	assert.Contains(t, string(body), "chat.completion.chunk")
+	assert.Contains(t, string(body), "Hi")
+	assert.True(t, ctx.StreamingComplete)
+	assert.Equal(t, "Hi", ctx.StreamingContent)
+}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
@@ -18,9 +19,9 @@ func TestHandleAnthropicStreamingResponseBody_TranslatesSSE(t *testing.T) {
 		},
 	}
 	ctx := &RequestContext{
-		RequestID:           "test-anthropic-stream",
 		APIFormat:           config.APIFormatAnthropic,
 		RequestModel:        "claude-sonnet-4-5",
+		AnthropicStream:     anthropic.NewStreamState(),
 		StreamingMetadata:   make(map[string]interface{}),
 		ProcessingStartTime: time.Now().Add(-10 * time.Millisecond),
 	}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestHandleAnthropicStreamingResponseBody_TranslatesSSE(t *testing.T) {
 	router := &OpenAIRouter{
-		Config: &config.Config{
+		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: false},
 		},
 	}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
@@ -8,16 +8,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
 func TestHandleAnthropicStreamingResponseBody_TranslatesSSE(t *testing.T) {
-	router := &OpenAIRouter{}
+	router := &OpenAIRouter{
+		Config: &config.Config{
+			SemanticCache: config.SemanticCache{Enabled: false},
+		},
+	}
 	ctx := &RequestContext{
+		RequestID:           "test-anthropic-stream",
 		APIFormat:           config.APIFormatAnthropic,
 		RequestModel:        "claude-sonnet-4-5",
-		AnthropicStream:     anthropic.NewStreamState(),
 		StreamingMetadata:   make(map[string]interface{}),
 		ProcessingStartTime: time.Now().Add(-10 * time.Millisecond),
 	}

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -6,7 +6,6 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/projectiontrace"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ratelimit"
@@ -57,9 +56,8 @@ type RequestContext struct {
 	ProcessingStartTime time.Time
 
 	// Streaming detection
-	ExpectStreamingResponse bool                   // set from request Accept header or stream parameter
-	IsStreamingResponse     bool                   // set from response Content-Type
-	AnthropicStream         *anthropic.StreamState // Anthropic SSE → OpenAI translation state
+	ExpectStreamingResponse bool // set from request Accept header or stream parameter
+	IsStreamingResponse     bool // set from response Content-Type
 
 	// Semi-streaming body handler (non-nil when Envoy sends STREAMED body chunks)
 	StreamedBody *StreamedBodyHandler

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/projectiontrace"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ratelimit"
@@ -58,6 +59,7 @@ type RequestContext struct {
 	// Streaming detection
 	ExpectStreamingResponse bool // set from request Accept header or stream parameter
 	IsStreamingResponse     bool // set from response Content-Type
+	AnthropicStream         *anthropic.StreamState // Anthropic SSE → OpenAI translation state
 
 	// Semi-streaming body handler (non-nil when Envoy sends STREAMED body chunks)
 	StreamedBody *StreamedBodyHandler

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/projectiontrace"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ratelimit"
@@ -56,8 +57,9 @@ type RequestContext struct {
 	ProcessingStartTime time.Time
 
 	// Streaming detection
-	ExpectStreamingResponse bool // set from request Accept header or stream parameter
-	IsStreamingResponse     bool // set from response Content-Type
+	ExpectStreamingResponse bool                   // set from request Accept header or stream parameter
+	IsStreamingResponse     bool                   // set from response Content-Type
+	AnthropicStream         *anthropic.StreamState // Anthropic SSE → OpenAI translation state
 
 	// Semi-streaming body handler (non-nil when Envoy sends STREAMED body chunks)
 	StreamedBody *StreamedBodyHandler

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -57,8 +57,8 @@ type RequestContext struct {
 	ProcessingStartTime time.Time
 
 	// Streaming detection
-	ExpectStreamingResponse bool // set from request Accept header or stream parameter
-	IsStreamingResponse     bool // set from response Content-Type
+	ExpectStreamingResponse bool                   // set from request Accept header or stream parameter
+	IsStreamingResponse     bool                   // set from response Content-Type
 	AnthropicStream         *anthropic.StreamState // Anthropic SSE → OpenAI translation state
 
 	// Semi-streaming body handler (non-nil when Envoy sends STREAMED body chunks)

--- a/website/docs/api/router.md
+++ b/website/docs/api/router.md
@@ -86,7 +86,7 @@ Minimal request:
 - The router converts the upstream request to Anthropic `POST /v1/messages` and converts the response back to OpenAI-compatible output.
 - Upstream host, path, and optional `extra_headers` come from `backend_refs` and the endpoint provider profile (`base_url`, optional `chat_path`).
 - OpenAI-style `tools`, `tool_calls`, and `tool` messages are converted for Anthropic backends.
-- Streaming is not supported for Anthropic-backed routing.
+- Streaming (`stream: true`) is supported; Anthropic SSE is translated to OpenAI `chat.completion.chunk` SSE, including tool-call deltas.
 
 ### vLLM Omni and Multimodal/Image Generation
 


### PR DESCRIPTION
## Purpose

- Enable `stream: true` for models with `api_format: anthropic` by translating Anthropic SSE into OpenAI `chat.completion.chunk` SSE (text and tool-call deltas).
- Route Anthropic streaming through dedicated extproc helpers so the existing OpenAI streaming path (`processor_res_body_streaming.go`) stays unchanged.
- Add streaming request helpers (`WithStreamingRequestBody`, `BuildStreamingRequestHeaders`) and response translation in `pkg/anthropic/client_stream.go`.

**Why is this change needed?** Anthropic-backed routing previously rejected streaming requests and, when enabled experimentally, could break chunked responses by running SSE fragments through non-streaming JSON normalization.

**Which module(s) does this affect?** `Router`, `Docs`

### Design notes

- **Protocol translation** (`pkg/anthropic/client_stream.go`): Anthropic SSE events → OpenAI `chat.completion.chunk` bytes.
- **ExtProc wiring** (`processor_res_body_streaming_anthropic.go`): body mutation for translated SSE; reuses shared streaming accumulation (`StreamingChunks`, cache, metrics).
- **Per-request translator state**: `RequestContext.AnthropicStream` holds multi-chunk SSE mapping state; initialized when routing a streaming Anthropic request.
- **OpenAI backends**: unchanged passthrough path in `processor_res_body_streaming.go` (no format translation).

## Test Plan

```bash
make agent-lint CHANGED_FILES="src/semantic-router/pkg/anthropic/client.go,src/semantic-router/pkg/anthropic/client_stream.go,src/semantic-router/pkg/anthropic/client_stream_test.go,src/semantic-router/pkg/extproc/processor_core.go,src/semantic-router/pkg/extproc/processor_req_body_anthropic.go,src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go,src/semantic-router/pkg/extproc/processor_res_body.go,src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go,src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go,src/semantic-router/pkg/extproc/request_context.go,website/docs/api/router.md"

cd src/semantic-router
go test ./pkg/anthropic/... ./pkg/extproc/... -run 'Anthropic|TransformSSE' -count=1
```

Manual (router on :8899, Anthropic/Vertex-backed model):

```bash
curl -N --http1.1 http://localhost:8899/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Accept: text/event-stream" \
  -d '{"model":"<anthropic-model>","stream":true,"messages":[{"role":"user","content":"hi"}],"max_tokens":64}'
```

## Test Result

- `make agent-lint` on changed files: passed (go fmt, go lint, md fmt)
- `go test ./pkg/anthropic/...` and Anthropic extproc tests: passed locally where bindings are available
- Manual curl against Vertex/APIM Anthropic backend: streaming `data:` chunks and `data: [DONE]` observed

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.