### PR TITLE
[Bindings] Apply SigLIP image normalization in vision encoder

### DIFF
--- a/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
+++ b/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
@@ -431,6 +431,19 @@ fn prepare_bert_attention_mask(mask: &Tensor, dtype: DType) -> candle_core::Resu
 // SigLIP Vision Encoder
 // ============================================================================
 
+/// Per-channel mean for SigLIP image normalization.
+///
+/// From SigLIP base / SigLIP2 `preprocessor_config.json`. The Go-side
+/// `decodeAndResizeImage` in semantic-router.go produces CHW float32 pixels
+/// in `[0, 1]`. SigLIP was trained on inputs in `[-1, 1]`, normalized via
+/// `(x - mean) / std` per channel. We apply that normalization here, in the
+/// Rust encoder, so the Go side stays unchanged and the activations land in
+/// the distribution the model expects.
+const IMAGE_MEAN: [f32; 3] = [0.5, 0.5, 0.5];
+
+/// Per-channel std for SigLIP image normalization. See `IMAGE_MEAN`.
+const IMAGE_STD: [f32; 3] = [0.5, 0.5, 0.5];
+
 #[derive(Clone)]
 struct SigLIPPatchEmbedding {
     projection: candle_nn::Conv2d,
@@ -629,7 +642,22 @@ impl SigLIPVisionEncoder {
 
     /// Returns pooler_output: [batch, hidden_size]
     fn forward(&self, pixel_values: &Tensor) -> candle_core::Result<Tensor> {
-        let mut xs = self.patch_embedding.forward(pixel_values)?;
+        // SigLIP expects inputs in [-1, 1], normalized via (x - mean) / std
+        // per channel using IMAGE_MEAN / IMAGE_STD from the model's
+        // preprocessor_config.json. The Go-side image decoder produces pixels
+        // in [0, 1]; apply the normalization here so activations sit in the
+        // input distribution the encoder was trained on.
+        let device = pixel_values.device();
+        let dtype = pixel_values.dtype();
+        // Shape [1, 3, 1, 1] broadcasts cleanly against [B, 3, H, W].
+        let mean = Tensor::from_slice(&IMAGE_MEAN, (1, 3, 1, 1), device)?.to_dtype(dtype)?;
+        let std = Tensor::from_slice(&IMAGE_STD, (1, 3, 1, 1), device)?.to_dtype(dtype)?;
+        let normalized = pixel_values
+            .broadcast_sub(&mean)?
+            .broadcast_div(&std)?
+            .contiguous()?;
+
+        let mut xs = self.patch_embedding.forward(&normalized)?;
         for layer in &self.layers {
             xs = layer.forward(&xs)?;
         }
@@ -1305,6 +1333,47 @@ mod tests {
         let mask = Tensor::ones((2, 10), DType::U32, &device).unwrap();
         let ext = prepare_bert_attention_mask(&mask, DType::F32).unwrap();
         assert_eq!(ext.dims(), &[2, 1, 1, 10]);
+    }
+
+    #[test]
+    fn test_siglip_image_normalization_constants() {
+        // SigLIP image normalization maps [0, 1] -> [-1, 1] via
+        // (x - 0.5) / 0.5. Validate the arithmetic on a known input that
+        // spans the full [0, 1] range INCLUDING the 0.5 midpoint, using
+        // the IMAGE_MEAN / IMAGE_STD constants and the same broadcast
+        // pattern as SigLIPVisionEncoder::forward.
+        let device = Device::Cpu;
+        // [1, 3, 1, 3] tensor with values 0.0, 0.5, 1.0 per channel to
+        // exercise both endpoints and the midpoint.
+        let pixels = Tensor::from_slice(
+            &[
+                0.0f32, 0.5, 1.0, // channel 0
+                0.0, 0.5, 1.0, // channel 1
+                0.0, 0.5, 1.0, // channel 2
+            ],
+            (1, 3, 1, 3),
+            &device,
+        )
+        .unwrap();
+        let mean = Tensor::from_slice(&IMAGE_MEAN, (1, 3, 1, 1), &device).unwrap();
+        let std = Tensor::from_slice(&IMAGE_STD, (1, 3, 1, 1), &device).unwrap();
+        let normalized = pixels
+            .broadcast_sub(&mean)
+            .unwrap()
+            .broadcast_div(&std)
+            .unwrap();
+        let out: Vec<f32> = normalized.flatten_all().unwrap().to_vec1().unwrap();
+        // Expected per-element: 0.0 -> -1.0, 0.5 -> 0.0, 1.0 -> +1.0,
+        // all within tol.
+        let expected = [-1.0f32, 0.0, 1.0, -1.0, 0.0, 1.0, -1.0, 0.0, 1.0];
+        for (got, want) in out.iter().zip(expected.iter()) {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "normalized pixel {} differs from expected {}",
+                got,
+                want
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Refs #1909

## Purpose

- **What does this PR change?** Adds `IMAGE_MEAN` / `IMAGE_STD` constants and applies `(pixels - mean) / std` per channel inside `SigLIPVisionEncoder::forward` (in `candle-binding/src/model_architectures/embedding/multimodal_embedding.rs`) before patch embedding. SigLIP was trained on inputs in `[-1, 1]`, normalized via the per-channel mean/std declared in the model's `preprocessor_config.json` (both 0.5 for SigLIP base and SigLIP2). The Go-side `decodeAndResizeImage` in `semantic-router.go` returns CHW float32 pixels in `[0, 1]`; the prior Rust code consumed those directly, so vision activations sat in the wrong input distribution.
- **Why is this change needed?** On an apples-to-apples passport probe against multi-modal-embed-small (same real-photographic fixture measured both by candle-binding and by the Python production-path pipeline), normalization closes roughly 74% of the residual drift between candle-binding and the Python reference encoder (2.9% drift down to 0.8% drift on the top anchor). Normalization is therefore a correctness fix, not a polish item.
- **Why now / why with PR #1927?** This is the sister to PR #1927, which fixes the SigLIP attentional probe pooling head. PR #1927 fixes the pooling path; this PR fixes the preprocessing path. Together they bring `SigLIPVisionEncoder` to within 1% of the Python reference on the passport probe, and they together unblock the image-modality pack follow-up work referenced in the merged PR #1896.
- **Which module(s) does this affect?** `Bindings` (only `candle-binding/`).

## Test Plan

- Build candle-binding from `candle-binding/`:
  - `cargo build --release --no-default-features --features accelerate`
- Run the normalization-constants unit test:
  - `cargo test --release --no-default-features --features accelerate --lib model_architectures::embedding::multimodal_embedding::tests::test_siglip_image_normalization_constants`
- Run the rest of the existing non-`#[ignore]` tests in the same module to confirm no regression:
  - `cargo test --release --no-default-features --features accelerate --lib model_architectures::embedding::multimodal_embedding`
- For end-to-end empirical verification, reviewers can use the verification branch pinned to commit `8a7e990a596152ec0022c4975b828a737a86d80a`. The receipt directory is at `https://github.com/shraderdm/semantic-router/tree/8a7e990a596152ec0022c4975b828a737a86d80a/docs/probe-2026-05-20-calibration` and contains the apples-to-apples passport-probe artifacts: candle-binding pre-norm and post-norm CSVs, the Python reference CSV, and the probe script that reproduces the Python reference. The same commit also carries both the pooling-head fix (PR #1927's content) and the normalization fix (this PR's content) layered on top.

## Test Result

- `cargo build --release --no-default-features --features accelerate`: succeeds in ~1m16s on M2. The build emits pre-existing crate-wide warnings (unused imports, `unexpected cfg condition value: metal`, `rand::thread_rng` / `rand::Rng::gen` deprecations) but no new warnings introduced by this PR's diff.
- `cargo test ... test_siglip_image_normalization_constants`: passes. The test builds a known `[0, 1]` input tensor, applies `(x - IMAGE_MEAN) / IMAGE_STD` with the same `broadcast_sub` / `broadcast_div` pattern as `SigLIPVisionEncoder::forward`, and asserts each element maps to the expected `[-1, 1]` value within `1e-6`.
- `cargo test ... model_architectures::embedding::multimodal_embedding`: 4 passed, 0 failed, 32 ignored (model-file-dependent integration tests).
- `cargo fmt --all --check`: clean.

**Apples-to-apples passport probe vs Python reference**:

All three rows below measure cosine on the same `inrule_identifier_passport.jpg` fixture (a public-domain Taiwan MOFA passport specimen sourced from Wikipedia; placeholder data, no real identity depicted) against the same `"photograph of a passport page"` anchor text. The candle-binding rows reflect the post-pooling-fix encoder (PR #1927's content) with and without this PR's normalization fix. The Python reference reproduces the production-path multi-modal-embed-small pipeline directly via HuggingFace `transformers` (SigLIP-base-patch16-512 vision_model.pooler_output -> trained Linear(768->384) projection -> L2-normalize for images; MiniLM-L6 mean-pool -> L2-normalize for text).

| Encoder state | Cosine on real passport fixture | Drift from Python reference |
| --- | --- | --- |
| Post-pooling-fix, pre-norm | 0.6843 | 2.9% |
| Post-pooling-fix, post-norm (this PR) | 0.6991 | 0.8% |
| Python reference (production-path pipeline) | 0.7044 | (baseline) |

Normalization closes roughly 74% of the residual drift between candle-binding and the Python reference encoder.

All three values are backed by committed receipts on the verification branch under `docs/probe-2026-05-20-calibration/`: the candle-binding pre-norm and post-norm cosines live in `calibration_2026_05_20_{prenorm,postnorm}_full.csv`; the Python reference cosine lives in `mmes_2026_05_21_full.csv`; the probe script that produced the Python reference (`probe_mmes_20img.py`) is committed alongside. The directory's `README.md` documents the methodology and provides example `awk` queries that return each row from the corresponding CSV directly.

**Follow-up risks / gaps**: none for the normalization fix itself. The sparse-pack rule definitions, anchor lists, and per-deployment threshold tuning are out of scope here and will land as follow-up work to the merged #1896 sparse-pack.
