### PR TITLE
[Router] Normalize embedding model handling across cache backends

### DIFF
--- a/src/semantic-router/pkg/cache/cache.go
+++ b/src/semantic-router/pkg/cache/cache.go
@@ -108,3 +108,16 @@ func userScopeNamespace(userID string) string {
 	digest := sha256.Sum256([]byte(userID))
 	return fmt.Sprintf("%x", digest[:8])
 }
+
+
+const defaultEmbeddingModel = "bert"
+
+// normalizeEmbeddingModel normalizes the embedding model name by trimming whitespace and converting to lowercase.
+// If the resulting model name is empty, it returns "bert" as the default embedding model.
+func normalizeEmbeddingModel(model string) string {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if normalized == "" {
+		return defaultEmbeddingModel
+	}
+	return normalized
+}

--- a/src/semantic-router/pkg/cache/cache.go
+++ b/src/semantic-router/pkg/cache/cache.go
@@ -109,7 +109,6 @@ func userScopeNamespace(userID string) string {
 	return fmt.Sprintf("%x", digest[:8])
 }
 
-
 const defaultEmbeddingModel = "bert"
 
 // normalizeEmbeddingModel normalizes the embedding model name by trimming whitespace and converting to lowercase.

--- a/src/semantic-router/pkg/cache/inmemory_cache.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache.go
@@ -4,7 +4,6 @@ package cache
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -128,11 +127,8 @@ func NewInMemoryCache(options InMemoryCacheOptions) *InMemoryCache {
 		efSearch = 50 // Default value
 	}
 
-	// Set default embedding model if not specified, normalize to lowercase
-	embeddingModel := strings.ToLower(strings.TrimSpace(options.EmbeddingModel))
-	if embeddingModel == "" {
-		embeddingModel = "bert" // Default: BERT (fastest, lowest memory)
-	}
+	// Store the canonical model name used by embedding dispatch.
+	embeddingModel := normalizeEmbeddingModel(options.EmbeddingModel)
 
 	logging.ComponentEvent("cache", "inmemory_cache_init_started", map[string]interface{}{
 		"enabled":              options.Enabled,
@@ -190,8 +186,7 @@ func (c *InMemoryCache) CheckConnection() error {
 
 // generateEmbedding generates an embedding using the configured model
 func (c *InMemoryCache) generateEmbedding(text string) ([]float32, error) {
-	// Normalize to lowercase for case-insensitive comparison
-	modelName := strings.ToLower(strings.TrimSpace(c.embeddingModel))
+	modelName := c.embeddingModel
 
 	switch modelName {
 	case "qwen3":
@@ -224,7 +219,7 @@ func (c *InMemoryCache) generateEmbedding(text string) ([]float32, error) {
 			return nil, err
 		}
 		return output.Embedding, nil
-	case "bert", "":
+	case "bert":
 		// Use traditional GetEmbedding for BERT (default)
 		return candle_binding.GetEmbedding(text, 0)
 	default:

--- a/src/semantic-router/pkg/cache/milvus_cache.go
+++ b/src/semantic-router/pkg/cache/milvus_cache.go
@@ -90,11 +90,7 @@ func NewMilvusCache(options MilvusCacheOptions) (*MilvusCache, error) {
 		return nil, fmt.Errorf("failed to create Milvus client: %w", err)
 	}
 
-	// Default to "bert" if no embedding model specified
-	embeddingModel := options.EmbeddingModel
-	if embeddingModel == "" {
-		embeddingModel = "bert"
-	}
+	embeddingModel := normalizeEmbeddingModel(options.EmbeddingModel)
 
 	cache := &MilvusCache{
 		client:              milvusClient,
@@ -253,9 +249,6 @@ func (c *MilvusCache) initializeCollection() error {
 // getEmbedding generates an embedding based on the configured embedding model
 func (c *MilvusCache) getEmbedding(text string) ([]float32, error) {
 	modelName := c.embeddingModel
-	if modelName == "" {
-		modelName = "bert"
-	}
 
 	switch modelName {
 	case "qwen3":
@@ -286,7 +279,7 @@ func (c *MilvusCache) getEmbedding(text string) ([]float32, error) {
 			return nil, err
 		}
 		return output.Embedding, nil
-	case "bert", "":
+	case "bert":
 		// Use traditional GetEmbedding for BERT (default)
 		return candle_binding.GetEmbedding(text, 0)
 	default:

--- a/src/semantic-router/pkg/cache/qdrant_cache.go
+++ b/src/semantic-router/pkg/cache/qdrant_cache.go
@@ -56,10 +56,7 @@ func NewQdrantCache(opts QdrantCacheOptions) (*QdrantCache, error) {
 	if collectionName == "" {
 		collectionName = "semantic_cache"
 	}
-	embeddingModel := opts.EmbeddingModel
-	if embeddingModel == "" {
-		embeddingModel = "bert"
-	}
+	embeddingModel := normalizeEmbeddingModel(opts.EmbeddingModel)
 
 	client, err := qdrant.NewClient(&qdrant.Config{
 		Host:   opts.Config.Host,
@@ -146,7 +143,9 @@ func (c *QdrantCache) ensureCollection() error {
 }
 
 func (c *QdrantCache) getEmbedding(text string) ([]float32, error) {
-	switch c.embeddingModel {
+	modelName := c.embeddingModel
+
+	switch modelName {
 	case "qwen3":
 		out, err := candle_binding.GetEmbeddingBatched(text, "qwen3", 0)
 		if err != nil {
@@ -171,8 +170,10 @@ func (c *QdrantCache) getEmbedding(text string) ([]float32, error) {
 			return nil, err
 		}
 		return out.Embedding, nil
-	default: // "bert" or ""
+	case "bert":
 		return candle_binding.GetEmbedding(text, 0)
+	default:
+		return nil, fmt.Errorf("unsupported embedding model: %s (must be 'bert', 'qwen3', 'gemma', 'mmbert', or 'multimodal')", c.embeddingModel)
 	}
 }
 

--- a/src/semantic-router/pkg/cache/redis_cache.go
+++ b/src/semantic-router/pkg/cache/redis_cache.go
@@ -84,11 +84,7 @@ func NewRedisCache(options RedisCacheOptions) (*RedisCache, error) {
 		Protocol: 2, // Use RESP2 protocol for compatibility
 	})
 
-	// Default to "bert" if no embedding model specified
-	embeddingModel := options.EmbeddingModel
-	if embeddingModel == "" {
-		embeddingModel = "bert"
-	}
+	embeddingModel := normalizeEmbeddingModel(options.EmbeddingModel)
 
 	cache := &RedisCache{
 		client:              redisClient,
@@ -219,7 +215,7 @@ func (c *RedisCache) initializeIndex() error {
 
 // getEmbedding generates an embedding based on the configured embedding model
 func (c *RedisCache) getEmbedding(text string) ([]float32, error) {
-	modelName := strings.ToLower(strings.TrimSpace(c.embeddingModel))
+	modelName := c.embeddingModel
 
 	switch modelName {
 	case "qwen3":
@@ -250,7 +246,7 @@ func (c *RedisCache) getEmbedding(text string) ([]float32, error) {
 			return nil, err
 		}
 		return output.Embedding, nil
-	case "bert", "":
+	case "bert":
 		// Use traditional GetEmbedding for BERT (default)
 		return candle_binding.GetEmbedding(text, 0)
 	default:

--- a/src/semantic-router/pkg/cache/valkey_cache.go
+++ b/src/semantic-router/pkg/cache/valkey_cache.go
@@ -95,10 +95,7 @@ func NewValkeyCache(options ValkeyCacheOptions) (*ValkeyCache, error) {
 		return nil, fmt.Errorf("failed to create Valkey client: %w", err)
 	}
 
-	embeddingModel := options.EmbeddingModel
-	if embeddingModel == "" {
-		embeddingModel = "bert"
-	}
+	embeddingModel := normalizeEmbeddingModel(options.EmbeddingModel)
 
 	cache := &ValkeyCache{
 		client:              valkeyClient,
@@ -186,7 +183,7 @@ func (c *ValkeyCache) initializeIndex() error {
 
 // getEmbedding generates an embedding based on the configured embedding model
 func (c *ValkeyCache) getEmbedding(text string) ([]float32, error) {
-	modelName := strings.ToLower(strings.TrimSpace(c.embeddingModel))
+	modelName := c.embeddingModel
 
 	switch modelName {
 	case "qwen3":
@@ -217,7 +214,7 @@ func (c *ValkeyCache) getEmbedding(text string) ([]float32, error) {
 			return nil, err
 		}
 		return output.Embedding, nil
-	case "bert", "":
+	case "bert":
 		// Use traditional GetEmbedding for BERT (default)
 		return candle_binding.GetEmbedding(text, 0)
 	default:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

- What does this PR change?
&emsp;&emsp; This PR normalized `embedding_model` handling across memory, Milvus, Qdrant, Redis, and Valkey backends by adding a shared helper. 
&emsp;&emsp; Also removed duplicate getter-level fallback logic so embedding dispatch consumes canonical model names.
- Why is this change needed?
&emsp;&emsp; Happened to encounter an unexpected error from Qdrant backend and find that there's some difference between the handing of embedding model names across different cache backends.
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`
&emsp;&emsp; Router

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
