### PR TITLE
[Router][Bugfix] Replace timestamp-seeded *rand.Rand with math/rand/v2 in RLDrivenSelector

### DIFF
--- a/src/semantic-router/pkg/selection/rl_driven.go
+++ b/src/semantic-router/pkg/selection/rl_driven.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"strings"
 	"sync"
@@ -192,7 +192,8 @@ type BetaDistribution struct {
 
 // Sample draws a sample from the Beta distribution
 // Uses the gamma distribution method: X ~ Beta(a,b) = Gamma(a,1) / (Gamma(a,1) + Gamma(b,1))
-func (b *BetaDistribution) Sample(rng *rand.Rand) float64 {
+// Backed by math/rand/v2 package-level functions, which are concurrency-safe.
+func (b *BetaDistribution) Sample() float64 {
 	// Handle edge cases
 	if b.Alpha <= 0 {
 		b.Alpha = 1.0
@@ -201,8 +202,8 @@ func (b *BetaDistribution) Sample(rng *rand.Rand) float64 {
 		b.Beta = 1.0
 	}
 
-	x := gammaVariate(rng, b.Alpha)
-	y := gammaVariate(rng, b.Beta)
+	x := gammaVariate(b.Alpha)
+	y := gammaVariate(b.Beta)
 
 	if x+y == 0 {
 		return 0.5
@@ -228,11 +229,12 @@ func (b *BetaDistribution) Variance() float64 {
 }
 
 // gammaVariate generates a random variate from Gamma(alpha, 1) distribution
-// Uses Marsaglia and Tsang's method for alpha >= 1
-func gammaVariate(rng *rand.Rand, alpha float64) float64 {
+// Uses Marsaglia and Tsang's method for alpha >= 1.
+// Backed by math/rand/v2 package-level functions, which are concurrency-safe.
+func gammaVariate(alpha float64) float64 {
 	if alpha < 1 {
 		// For alpha < 1, use the transformation: Gamma(alpha) = Gamma(alpha+1) * U^(1/alpha)
-		return gammaVariate(rng, alpha+1) * math.Pow(rng.Float64(), 1/alpha)
+		return gammaVariate(alpha+1) * math.Pow(rand.Float64(), 1/alpha)
 	}
 
 	d := alpha - 1.0/3.0
@@ -241,7 +243,7 @@ func gammaVariate(rng *rand.Rand, alpha float64) float64 {
 	for {
 		var x, v float64
 		for {
-			x = rng.NormFloat64()
+			x = rand.NormFloat64()
 			v = 1.0 + c*x
 			if v > 0 {
 				break
@@ -249,7 +251,7 @@ func gammaVariate(rng *rand.Rand, alpha float64) float64 {
 		}
 
 		v = v * v * v
-		u := rng.Float64()
+		u := rand.Float64()
 
 		if u < 1.0-0.0331*(x*x)*(x*x) {
 			return d * v
@@ -292,8 +294,8 @@ type ModelPreference struct {
 type RLDrivenSelector struct {
 	config *RLDrivenConfig
 
-	// rng is the random number generator (thread-safe via mutex)
-	rng *rand.Rand
+	// Random numbers are drawn from math/rand/v2 package-level functions, which
+	// are concurrency-safe. There is no per-selector PRNG state to guard.
 
 	// Global preferences (shared across all users)
 	globalPreferences map[string]*ModelPreference
@@ -343,7 +345,6 @@ func NewRLDrivenSelector(cfg *RLDrivenConfig) *RLDrivenSelector {
 
 	selector := &RLDrivenSelector{
 		config:              cfg,
-		rng:                 rand.New(rand.NewSource(time.Now().UnixNano())),
 		globalPreferences:   make(map[string]*ModelPreference),
 		userPreferences:     make(map[string]map[string]*ModelPreference),
 		categoryPreferences: make(map[string]map[string]*ModelPreference),
@@ -531,7 +532,7 @@ func (r *RLDrivenSelector) Select(ctx context.Context, selCtx *SelectionContext)
 		sampledValues = make(map[string]float64)
 
 		for _, pref := range preferences {
-			sample := pref.Distribution.Sample(r.rng)
+			sample := pref.Distribution.Sample()
 
 			// Apply cost adjustment if enabled
 			if r.config.CostAwareness && r.config.CostWeight > 0 {
@@ -564,7 +565,7 @@ func (r *RLDrivenSelector) Select(ctx context.Context, selCtx *SelectionContext)
 		// Epsilon-greedy exploration
 		explorationRate := r.getCurrentExplorationRate(selectionNum)
 
-		if r.rng.Float64() < explorationRate {
+		if rand.Float64() < explorationRate {
 			// Explore: select random model (prefer cheaper if cost-aware)
 			selectedModel = r.selectRandomModel(selCtx.CandidateModels)
 			selectedScore = 0.5
@@ -737,7 +738,7 @@ func (r *RLDrivenSelector) SelectMultiRound(ctx context.Context, selCtx *Selecti
 
 	for _, pref := range preferences {
 		// Sample from distribution for exploration
-		sample := pref.Distribution.Sample(r.rng)
+		sample := pref.Distribution.Sample()
 
 		// Apply cost awareness
 		if r.config.CostAwareness && r.config.CostWeight > 0 {
@@ -1157,7 +1158,7 @@ func (r *RLDrivenSelector) applyCostBonus(model string, score float64) float64 {
 func (r *RLDrivenSelector) selectRandomModel(candidates []config.ModelRef) *config.ModelRef {
 	if !r.config.CostAwareness || len(r.modelCosts) == 0 {
 		// Uniform random
-		idx := r.rng.Intn(len(candidates))
+		idx := rand.IntN(len(candidates))
 		return &candidates[idx]
 	}
 
@@ -1177,15 +1178,15 @@ func (r *RLDrivenSelector) selectRandomModel(candidates []config.ModelRef) *conf
 	// Weight towards cheaper models (first third has 50% chance)
 	idx := 0
 	if len(sorted) > 2 {
-		if r.rng.Float64() < 0.5 {
+		if rand.Float64() < 0.5 {
 			// Pick from cheaper third
-			idx = r.rng.Intn(len(sorted) / 3)
+			idx = rand.IntN(len(sorted) / 3)
 		} else {
 			// Pick uniformly from rest
-			idx = r.rng.Intn(len(sorted))
+			idx = rand.IntN(len(sorted))
 		}
 	} else {
-		idx = r.rng.Intn(len(sorted))
+		idx = rand.IntN(len(sorted))
 	}
 
 	return &sorted[idx]

--- a/src/semantic-router/pkg/selection/rl_driven_test.go
+++ b/src/semantic-router/pkg/selection/rl_driven_test.go
@@ -19,7 +19,7 @@ package selection
 import (
 	"context"
 	"math"
-	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -67,13 +67,12 @@ func TestBetaDistribution_Sample(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dist := &BetaDistribution{Alpha: tt.alpha, Beta: tt.beta}
-			rng := rand.New(rand.NewSource(42))
 
 			// Sample many times and compute average
 			numSamples := 10000
 			sum := 0.0
 			for i := 0; i < numSamples; i++ {
-				sum += dist.Sample(rng)
+				sum += dist.Sample()
 			}
 			avg := sum / float64(numSamples)
 
@@ -653,4 +652,100 @@ func TestRLDrivenSelector_InitializeFromConfig(t *testing.T) {
 			t.Error("Model-a should have higher alpha due to higher score")
 		}
 	}
+}
+
+func TestRLDrivenSelector_ConcurrentSelect(t *testing.T) {
+	candidates := []config.ModelRef{
+		{Model: "model-a"},
+		{Model: "model-b"},
+		{Model: "model-c"},
+		{Model: "model-d"},
+	}
+
+	cases := []struct {
+		name string
+		cfg  *RLDrivenConfig
+	}{
+		{
+			name: "thompson sampling path",
+			cfg: &RLDrivenConfig{
+				UseThompsonSampling:   true,
+				EnablePersonalization: false,
+				CostAwareness:         false,
+			},
+		},
+		{
+			name: "epsilon-greedy exploration path",
+			cfg: &RLDrivenConfig{
+				UseThompsonSampling:   false,
+				EnablePersonalization: false,
+				ExplorationRate:       1.0, // force exploration branch (rand.Float64)
+				MinExploration:        1.0,
+				CostAwareness:         false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hammerSelect(t, NewRLDrivenSelector(tc.cfg), candidates)
+		})
+	}
+}
+
+func hammerSelect(t *testing.T, selector *RLDrivenSelector, candidates []config.ModelRef) {
+	t.Helper()
+
+	const (
+		goroutines = 32
+		iterations = 50
+	)
+	selCtx := &SelectionContext{
+		DecisionName:    "concurrent-test",
+		CandidateModels: candidates,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				res, err := selector.Select(context.Background(), selCtx)
+				if err != nil {
+					t.Errorf("Select() error = %v", err)
+					return
+				}
+				if res.SelectedModel == "" {
+					t.Errorf("Select() returned empty model")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestBetaDistribution_ConcurrentSample(t *testing.T) {
+	dist := &BetaDistribution{Alpha: 3.0, Beta: 5.0}
+
+	const (
+		goroutines = 32
+		samples    = 200
+	)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < samples; i++ {
+				v := dist.Sample()
+				if v < 0 || v > 1 {
+					t.Errorf("Sample() out of [0,1]: %v", v)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
Closes #xxxx

## Purpose

- What does this PR change?
Switch to `math/rand/v2` package-level functions (concurrency-safe by contract), drop the lying comment and per-selector PRNG state, and add race-detector tests pinning the contract. Continuation of #1822.

- Why is this change needed?
RLDrivenSelector's `*rand.Rand` field is annotated "thread-safe via mutex" but no such mutex exists. Thompson sampling and exploration paths read/write the shared PRNG concurrently from ExtProc request goroutines, silently distorting model-selection statistics. The `time.Now().UnixNano()` seed also produces identical sequences across pods that start in the same nanosecond. 
- Which module(s) does this affect? `Router` 

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
