### PR TITLE
[Router] Fix OpenAI reasoning effort request mutation

### DIFF
--- a/src/semantic-router/pkg/config/config_test.go
+++ b/src/semantic-router/pkg/config/config_test.go
@@ -1270,6 +1270,24 @@ default_model: "my-alias"
 				Expect(resolved).To(Equal("Qwen/Qwen2.5-14B-Instruct"))
 			})
 
+			It("should match aliases to provider model IDs", func() {
+				cfg := &RouterConfig{
+					BackendModels: BackendModels{
+						ModelConfig: map[string]ModelParams{
+							"my-alias": {
+								ExternalModelIDs: map[string]string{
+									"openai": "gpt-5-mini",
+								},
+							},
+						},
+					},
+				}
+
+				Expect(cfg.ModelNameMatches("my-alias", "gpt-5-mini")).To(BeTrue())
+				Expect(cfg.ModelNameMatches("gpt-5-mini", "my-alias")).To(BeTrue())
+				Expect(cfg.ModelNameMatches("other", "gpt-5-mini")).To(BeFalse())
+			})
+
 			It("should default to vllm type when endpoint has no type set", func() {
 				configContent := `
 vllm_endpoints:

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -10,27 +10,36 @@ import (
 
 // GetModelReasoningFamily returns the reasoning family configuration for a given model name
 func (rc *RouterConfig) GetModelReasoningFamily(modelName string) *ReasoningFamilyConfig {
-	if rc == nil || rc.ModelConfig == nil || rc.ReasoningFamilies == nil {
+	familyName, ok := rc.GetModelReasoningFamilyName(modelName)
+	if !ok {
 		return nil
 	}
 
-	// Look up the model in model_config
-	modelParams, exists := rc.ModelConfig[modelName]
-	if !exists || modelParams.ReasoningFamily == "" {
-		_, baseParams, fallback := rc.resolveLoRABaseModel(modelName)
-		if !fallback || baseParams.ReasoningFamily == "" {
-			return nil
-		}
-		modelParams = baseParams
-	}
-
-	// Look up the reasoning family configuration
-	familyConfig, exists := rc.ReasoningFamilies[modelParams.ReasoningFamily]
+	familyConfig, exists := rc.ReasoningFamilies[familyName]
 	if !exists {
 		return nil
 	}
 
 	return &familyConfig
+}
+
+func (rc *RouterConfig) GetModelReasoningFamilyName(modelName string) (string, bool) {
+	if rc == nil || rc.ModelConfig == nil || rc.ReasoningFamilies == nil {
+		return "", false
+	}
+
+	// Look up the model in model_config, including provider_model_id/external IDs
+	// because request-body mutation may already have rewritten the model field.
+	modelParams, exists := rc.resolveModelConfig(modelName)
+	if !exists || modelParams.ReasoningFamily == "" {
+		_, baseParams, fallback := rc.resolveLoRABaseModel(modelName)
+		if !fallback || baseParams.ReasoningFamily == "" {
+			return "", false
+		}
+		modelParams = baseParams
+	}
+	_, exists = rc.ReasoningFamilies[modelParams.ReasoningFamily]
+	return modelParams.ReasoningFamily, exists
 }
 
 // GetEffectiveAutoModelName returns the effective auto model name for automatic model selection

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -42,6 +42,33 @@ func (rc *RouterConfig) GetModelReasoningFamilyName(modelName string) (string, b
 	return modelParams.ReasoningFamily, exists
 }
 
+func (rc *RouterConfig) ModelNameMatches(candidateName string, modelName string) bool {
+	if candidateName == modelName {
+		return true
+	}
+	if rc == nil || rc.ModelConfig == nil {
+		return false
+	}
+
+	candidateKey, candidateExists := rc.resolveModelConfigKey(candidateName)
+	modelKey, modelExists := rc.resolveModelConfigKey(modelName)
+	return candidateExists && modelExists && candidateKey == modelKey
+}
+
+func (c *RouterConfig) resolveModelConfigKey(modelName string) (string, bool) {
+	if _, ok := c.ModelConfig[modelName]; ok {
+		return modelName, true
+	}
+	for configuredName, params := range c.ModelConfig {
+		for _, extID := range params.ExternalModelIDs {
+			if extID == modelName {
+				return configuredName, true
+			}
+		}
+	}
+	return "", false
+}
+
 // GetEffectiveAutoModelName returns the effective auto model name for automatic model selection
 // Returns the configured AutoModelName if set, otherwise defaults to "MoM"
 // This is the primary model name that triggers automatic routing

--- a/src/semantic-router/pkg/extproc/processor_req_body.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body.go
@@ -179,7 +179,19 @@ func (r *OpenAIRouter) handleAutoModelRouting(openAIRequest *openai.ChatCompleti
 	upstreamModel := r.resolveModelNameForEndpoint(matchedModel, selectedEndpointName)
 
 	// Modify request body with resolved model name, reasoning mode, and system prompt
-	modifiedBody, err := r.modifyRequestBodyForAutoRouting(openAIRequest, upstreamModel, decisionName, reasoningDecision.UseReasoning, ctx)
+	profile, profileErr := r.Config.GetProviderProfileForEndpoint(selectedEndpointName)
+	if profileErr != nil {
+		return nil, fmt.Errorf("auto routing provider profile: %w", profileErr)
+	}
+
+	modifiedBody, err := r.modifyRequestBodyForAutoRouting(
+		openAIRequest,
+		upstreamModel,
+		decisionName,
+		reasoningDecision.UseReasoning,
+		profile,
+		ctx,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -67,6 +67,7 @@ func (r *OpenAIRouter) modifyRequestBodyForAutoRouting(
 	matchedModel string,
 	decisionName string,
 	useReasoning bool,
+	profile *config.ProviderProfile,
 	ctx *RequestContext,
 ) ([]byte, error) {
 	openAIRequest.Model = matchedModel
@@ -79,7 +80,12 @@ func (r *OpenAIRouter) modifyRequestBodyForAutoRouting(
 	}
 
 	if decisionName != "" {
-		modifiedBody, err = r.setReasoningModeToRequestBody(modifiedBody, useReasoning, decisionName)
+		modifiedBody, err = r.setReasoningModeToRequestBodyForProvider(
+			modifiedBody,
+			useReasoning,
+			decisionName,
+			profile,
+		)
 		if err != nil {
 			logging.Errorf("Error setting reasoning mode %v to request: %v", useReasoning, err)
 			metrics.RecordRequestError(matchedModel, "serialization_error")

--- a/src/semantic-router/pkg/extproc/req_filter_reason.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason.go
@@ -12,6 +12,16 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
 
+type reasoningRequestMutation struct {
+	requestMap              map[string]interface{}
+	chatTemplateKwargs      map[string]interface{}
+	model                   string
+	originalReasoningEffort interface{}
+	hasOriginalEffort       bool
+	appliedEffort           string
+	reasoningApplied        bool
+}
+
 func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled bool, categoryName string) ([]byte, error) {
 	return r.setReasoningModeToRequestBodyForProvider(requestBody, enabled, categoryName, nil)
 }
@@ -23,148 +33,199 @@ func (r *OpenAIRouter) setReasoningModeToRequestBodyForProvider(
 	categoryName string,
 	profile *config.ProviderProfile,
 ) ([]byte, error) {
-	// Parse the JSON request body
-	var requestMap map[string]interface{}
-	if err := json.Unmarshal(requestBody, &requestMap); err != nil {
-		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	mutation, err := parseReasoningRequestMutation(requestBody)
+	if err != nil {
+		return nil, err
 	}
-
-	// Determine model for kwargs and logging
-	model := consts.UnknownLabel
-	if modelValue, ok := requestMap["model"]; ok {
-		if modelStr, ok := modelValue.(string); ok {
-			model = modelStr
-		}
-	}
-
-	// Get original reasoning effort for potential preservation
-	originalReasoningEffort, hasOriginalEffort := requestMap["reasoning_effort"]
-	if !hasOriginalEffort {
-		originalReasoningEffort = "low" // Default for compatibility
-	}
-
-	// Keep any user-provided chat_template_kwargs and only override the reasoning-related
-	// parameter when needed (do not drop unrelated chat_template_kwargs keys).
-	chatTemplateKwargs := map[string]interface{}{}
-	if v, ok := requestMap["chat_template_kwargs"]; ok {
-		if m, ok := v.(map[string]interface{}); ok && m != nil {
-			chatTemplateKwargs = m
-		}
-	}
-
-	// Clear reasoning_effort by default to avoid leaking unsupported or irrelevant reasoning
-	// parameters to models. We will re-set it as needed (e.g., preserve for reasoning_effort
-	// families when disabled, or set configured effort when enabled).
-	delete(requestMap, "reasoning_effort")
-
-	appliedEffort := ""
-
-	var reasoningApplied bool
-
+	familyConfig := r.getModelReasoningFamily(mutation.model)
 	if enabled {
-		familyConfig := r.getModelReasoningFamily(model)
-		if familyConfig == nil {
-			// Model has no reasoning family configured
-			reasoningApplied = false
-		} else {
-			switch familyConfig.Type {
-			case "chat_template_kwargs":
-				chatTemplateKwargs[familyConfig.Parameter] = true
-				requestMap["chat_template_kwargs"] = chatTemplateKwargs
-				reasoningApplied = true
-			case "reasoning_effort":
-				effort := r.getReasoningEffort(categoryName, model)
-				if usesTopLevelReasoningEffort(profile) {
-					requestMap[familyConfig.Parameter] = effort
-				} else {
-					// Put reasoning_effort inside chat_template_kwargs (vLLM requirement)
-					chatTemplateKwargs[familyConfig.Parameter] = effort
-					requestMap["chat_template_kwargs"] = chatTemplateKwargs
-				}
-				appliedEffort = effort
-				reasoningApplied = true
-			default:
-				// Unknown reasoning syntax type - don't apply anything
-				reasoningApplied = false
-			}
-		}
+		r.applyEnabledReasoningMutation(mutation, familyConfig, categoryName, profile)
 	} else {
-		// When reasoning is disabled, apply the appropriate "disable" syntax for models
-		// that require an explicit flag (e.g. Qwen3/DeepSeek), and preserve
-		// reasoning_effort for models that use it (e.g. gpt-oss).
-		familyConfig := r.getModelReasoningFamily(model)
-		if familyConfig != nil {
-			switch familyConfig.Type {
-			case "reasoning_effort":
-				if usesTopLevelReasoningEffort(profile) {
-					if hasOriginalEffort {
-						requestMap[familyConfig.Parameter] = originalReasoningEffort
-					}
-				} else {
-					// For vLLM reasoning_effort models, set effort in chat_template_kwargs.
-					chatTemplateKwargs[familyConfig.Parameter] = originalReasoningEffort
-					requestMap["chat_template_kwargs"] = chatTemplateKwargs
-				}
-				if s, ok := originalReasoningEffort.(string); ok {
-					appliedEffort = s
-				}
-			case "chat_template_kwargs":
-				// Some models default to "thinking enabled" unless explicitly disabled.
-				// Inject an explicit disable flag (e.g. enable_thinking=false / thinking=false).
-				chatTemplateKwargs[familyConfig.Parameter] = false
-				requestMap["chat_template_kwargs"] = chatTemplateKwargs
-			default:
-				// Unknown reasoning syntax type - keep fields cleared.
-			}
-		}
-		reasoningApplied = false
-		// For models without a reasoning family, fields remain cleared.
+		applyDisabledReasoningMutation(mutation, familyConfig, profile)
 	}
 
-	// Log based on what actually happened
-	if enabled && !reasoningApplied {
-		logging.Infof("No reasoning support for model: %s (no reasoning family configured)", model)
-	} else if reasoningApplied {
-		logging.Infof("Applied reasoning mode (enabled: %v) with effort (%s) to model: %s", enabled, appliedEffort, model)
-	} else {
-		logging.Infof("Reasoning mode disabled for model: %s", model)
-	}
+	logReasoningMutation(mutation, enabled)
+	r.recordReasoningMutationMetrics(mutation, enabled, familyConfig)
 
-	// Record metrics for template usage and effort when enabled
-	if enabled {
-		familyConfig := r.getModelReasoningFamily(model)
-		modelFamily := consts.UnknownLabel
-		templateParam := "reasoning_effort" // default fallback
-
-		if familyConfig != nil {
-			// Use the model's actual reasoning family name from model_config
-			if r.Config != nil {
-				if familyName, exists := r.Config.GetModelReasoningFamilyName(model); exists {
-					modelFamily = familyName
-				}
-			}
-
-			if familyConfig.Type == "chat_template_kwargs" {
-				templateParam = familyConfig.Parameter
-			} else {
-				templateParam = "reasoning_effort"
-			}
-		}
-
-		// Record template usage and effort
-		metrics.RecordReasoningTemplateUsage(modelFamily, templateParam)
-		if appliedEffort != "" {
-			metrics.RecordReasoningEffortUsage(modelFamily, appliedEffort)
-		}
-	}
-
-	// Serialize back to JSON
-	modifiedBody, err := json.Marshal(requestMap)
+	modifiedBody, err := json.Marshal(mutation.requestMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize modified request: %w", err)
 	}
 
 	return modifiedBody, nil
+}
+
+func parseReasoningRequestMutation(requestBody []byte) (*reasoningRequestMutation, error) {
+	var requestMap map[string]interface{}
+	if err := json.Unmarshal(requestBody, &requestMap); err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	originalReasoningEffort, hasOriginalEffort := requestMap["reasoning_effort"]
+	if !hasOriginalEffort {
+		originalReasoningEffort = "low"
+	}
+	// Normalize the request before applying the selected family syntax. The
+	// top-level field is restored only for providers that accept it; vLLM-style
+	// backends receive reasoning_effort through chat_template_kwargs instead.
+	delete(requestMap, "reasoning_effort")
+
+	return &reasoningRequestMutation{
+		requestMap:              requestMap,
+		chatTemplateKwargs:      extractChatTemplateKwargs(requestMap),
+		model:                   extractReasoningRequestModel(requestMap),
+		originalReasoningEffort: originalReasoningEffort,
+		hasOriginalEffort:       hasOriginalEffort,
+	}, nil
+}
+
+func extractReasoningRequestModel(requestMap map[string]interface{}) string {
+	modelValue, ok := requestMap["model"]
+	if !ok {
+		return consts.UnknownLabel
+	}
+	model, ok := modelValue.(string)
+	if !ok {
+		return consts.UnknownLabel
+	}
+	return model
+}
+
+func extractChatTemplateKwargs(requestMap map[string]interface{}) map[string]interface{} {
+	kwargs, ok := requestMap["chat_template_kwargs"].(map[string]interface{})
+	if !ok || kwargs == nil {
+		return map[string]interface{}{}
+	}
+	return kwargs
+}
+
+func (r *OpenAIRouter) applyEnabledReasoningMutation(
+	mutation *reasoningRequestMutation,
+	familyConfig *config.ReasoningFamilyConfig,
+	categoryName string,
+	profile *config.ProviderProfile,
+) {
+	if familyConfig == nil {
+		return
+	}
+	switch familyConfig.Type {
+	case "chat_template_kwargs":
+		mutation.chatTemplateKwargs[familyConfig.Parameter] = true
+		mutation.requestMap["chat_template_kwargs"] = mutation.chatTemplateKwargs
+		mutation.reasoningApplied = true
+	case "reasoning_effort":
+		effort := r.getReasoningEffort(categoryName, mutation.model)
+		applyReasoningEffortField(mutation, familyConfig.Parameter, effort, profile)
+		mutation.appliedEffort = effort
+		mutation.reasoningApplied = true
+	default:
+		return
+	}
+}
+
+func applyDisabledReasoningMutation(
+	mutation *reasoningRequestMutation,
+	familyConfig *config.ReasoningFamilyConfig,
+	profile *config.ProviderProfile,
+) {
+	if familyConfig == nil {
+		return
+	}
+	switch familyConfig.Type {
+	case "reasoning_effort":
+		preserveReasoningEffort(mutation, familyConfig.Parameter, profile)
+	case "chat_template_kwargs":
+		// Some chat-template models default to thinking enabled, so disabled
+		// reasoning still needs an explicit false flag for those families.
+		mutation.chatTemplateKwargs[familyConfig.Parameter] = false
+		mutation.requestMap["chat_template_kwargs"] = mutation.chatTemplateKwargs
+	default:
+		return
+	}
+}
+
+func applyReasoningEffortField(
+	mutation *reasoningRequestMutation,
+	parameter string,
+	effort string,
+	profile *config.ProviderProfile,
+) {
+	if usesTopLevelReasoningEffort(profile) {
+		mutation.requestMap[parameter] = effort
+		return
+	}
+	// Local vLLM-compatible reasoning_effort models expect the value under
+	// chat_template_kwargs, not as an OpenAI top-level request field.
+	mutation.chatTemplateKwargs[parameter] = effort
+	mutation.requestMap["chat_template_kwargs"] = mutation.chatTemplateKwargs
+}
+
+func preserveReasoningEffort(
+	mutation *reasoningRequestMutation,
+	parameter string,
+	profile *config.ProviderProfile,
+) {
+	if usesTopLevelReasoningEffort(profile) {
+		// When routing to OpenAI with reasoning disabled, keep a user-supplied
+		// top-level effort but do not synthesize a new one.
+		if mutation.hasOriginalEffort {
+			mutation.requestMap[parameter] = mutation.originalReasoningEffort
+		}
+	} else {
+		// Non-OpenAI reasoning_effort families preserve the effective effort in
+		// chat_template_kwargs so backends that require the template arg still see it.
+		mutation.chatTemplateKwargs[parameter] = mutation.originalReasoningEffort
+		mutation.requestMap["chat_template_kwargs"] = mutation.chatTemplateKwargs
+	}
+	if effort, ok := mutation.originalReasoningEffort.(string); ok {
+		mutation.appliedEffort = effort
+	}
+}
+
+func logReasoningMutation(mutation *reasoningRequestMutation, enabled bool) {
+	if enabled && !mutation.reasoningApplied {
+		logging.Infof("No reasoning support for model: %s (no reasoning family configured)", mutation.model)
+		return
+	}
+	if mutation.reasoningApplied {
+		logging.Infof("Applied reasoning mode (enabled: %v) with effort (%s) to model: %s", enabled, mutation.appliedEffort, mutation.model)
+		return
+	}
+	logging.Infof("Reasoning mode disabled for model: %s", mutation.model)
+}
+
+func (r *OpenAIRouter) recordReasoningMutationMetrics(
+	mutation *reasoningRequestMutation,
+	enabled bool,
+	familyConfig *config.ReasoningFamilyConfig,
+) {
+	if !enabled {
+		return
+	}
+	modelFamily, templateParam := r.reasoningMetricLabels(mutation.model, familyConfig)
+	metrics.RecordReasoningTemplateUsage(modelFamily, templateParam)
+	if mutation.appliedEffort != "" {
+		metrics.RecordReasoningEffortUsage(modelFamily, mutation.appliedEffort)
+	}
+}
+
+func (r *OpenAIRouter) reasoningMetricLabels(
+	model string,
+	familyConfig *config.ReasoningFamilyConfig,
+) (string, string) {
+	if familyConfig == nil {
+		return consts.UnknownLabel, "reasoning_effort"
+	}
+	modelFamily := consts.UnknownLabel
+	if r.Config != nil {
+		if familyName, exists := r.Config.GetModelReasoningFamilyName(model); exists {
+			modelFamily = familyName
+		}
+	}
+	if familyConfig.Type == "chat_template_kwargs" {
+		return modelFamily, familyConfig.Parameter
+	}
+	return modelFamily, "reasoning_effort"
 }
 
 func usesTopLevelReasoningEffort(profile *config.ProviderProfile) bool {
@@ -175,6 +236,8 @@ func usesTopLevelReasoningEffort(profile *config.ProviderProfile) bool {
 	if err != nil {
 		return false
 	}
+	// The official OpenAI API accepts reasoning_effort as a top-level field;
+	// OpenAI-compatible local servers keep the vLLM chat_template_kwargs form.
 	return strings.EqualFold(u.Hostname(), "api.openai.com")
 }
 
@@ -185,21 +248,14 @@ func (r *OpenAIRouter) getReasoningEffort(categoryName string, modelName string)
 		return "medium"
 	}
 
-	// Find the decision and model configuration
 	for _, decision := range r.Config.Decisions {
-		if decision.Name == categoryName {
-			// Find the specific model in the decision's model refs
-			for _, modelRef := range decision.ModelRefs {
-				if modelRef.Model == modelName {
-					// Use model-specific effort if configured
-					if modelRef.ReasoningEffort != "" {
-						return modelRef.ReasoningEffort
-					}
-					break
-				}
-			}
-			break
+		if decision.Name != categoryName {
+			continue
 		}
+		if effort := r.reasoningEffortForDecision(decision, modelName); effort != "" {
+			return effort
+		}
+		break
 	}
 
 	// Fall back to global default if configured
@@ -211,17 +267,22 @@ func (r *OpenAIRouter) getReasoningEffort(categoryName string, modelName string)
 	return "medium"
 }
 
+func (r *OpenAIRouter) reasoningEffortForDecision(decision config.Decision, modelName string) string {
+	for _, modelRef := range decision.ModelRefs {
+		if !r.Config.ModelNameMatches(modelRef.Model, modelName) {
+			continue
+		}
+		return modelRef.ReasoningEffort
+	}
+	return ""
+}
+
 // getModelReasoningFamily finds the reasoning family configuration for a model using the config system
 func (r *OpenAIRouter) getModelReasoningFamily(model string) *config.ReasoningFamilyConfig {
 	if r.Config == nil {
 		return nil
 	}
 	return r.Config.GetModelReasoningFamily(model)
-}
-
-// buildReasoningRequestFields returns the appropriate fields to add to the request based on model config
-func (r *OpenAIRouter) buildReasoningRequestFields(model string, useReasoning bool, categoryName string) (map[string]interface{}, string) {
-	return r.buildReasoningRequestFieldsForProvider(model, useReasoning, categoryName, nil)
 }
 
 func (r *OpenAIRouter) buildReasoningRequestFieldsForProvider(

--- a/src/semantic-router/pkg/extproc/req_filter_reason.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason.go
@@ -3,6 +3,8 @@ package extproc
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/consts"
@@ -10,8 +12,17 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
 
-// setReasoningModeToRequestBody adds chat_template_kwargs to the JSON request body
 func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled bool, categoryName string) ([]byte, error) {
+	return r.setReasoningModeToRequestBodyForProvider(requestBody, enabled, categoryName, nil)
+}
+
+// setReasoningModeToRequestBodyForProvider adds provider-compatible reasoning fields to the JSON request body.
+func (r *OpenAIRouter) setReasoningModeToRequestBodyForProvider(
+	requestBody []byte,
+	enabled bool,
+	categoryName string,
+	profile *config.ProviderProfile,
+) ([]byte, error) {
 	// Parse the JSON request body
 	var requestMap map[string]interface{}
 	if err := json.Unmarshal(requestBody, &requestMap); err != nil {
@@ -63,9 +74,13 @@ func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled
 				reasoningApplied = true
 			case "reasoning_effort":
 				effort := r.getReasoningEffort(categoryName, model)
-				// Put reasoning_effort inside chat_template_kwargs (vLLM requirement)
-				chatTemplateKwargs[familyConfig.Parameter] = effort
-				requestMap["chat_template_kwargs"] = chatTemplateKwargs
+				if usesTopLevelReasoningEffort(profile) {
+					requestMap[familyConfig.Parameter] = effort
+				} else {
+					// Put reasoning_effort inside chat_template_kwargs (vLLM requirement)
+					chatTemplateKwargs[familyConfig.Parameter] = effort
+					requestMap["chat_template_kwargs"] = chatTemplateKwargs
+				}
 				appliedEffort = effort
 				reasoningApplied = true
 			default:
@@ -81,9 +96,15 @@ func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled
 		if familyConfig != nil {
 			switch familyConfig.Type {
 			case "reasoning_effort":
-				// For reasoning_effort models, set effort in chat_template_kwargs
-				chatTemplateKwargs[familyConfig.Parameter] = originalReasoningEffort
-				requestMap["chat_template_kwargs"] = chatTemplateKwargs
+				if usesTopLevelReasoningEffort(profile) {
+					if hasOriginalEffort {
+						requestMap[familyConfig.Parameter] = originalReasoningEffort
+					}
+				} else {
+					// For vLLM reasoning_effort models, set effort in chat_template_kwargs.
+					chatTemplateKwargs[familyConfig.Parameter] = originalReasoningEffort
+					requestMap["chat_template_kwargs"] = chatTemplateKwargs
+				}
 				if s, ok := originalReasoningEffort.(string); ok {
 					appliedEffort = s
 				}
@@ -117,9 +138,9 @@ func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled
 
 		if familyConfig != nil {
 			// Use the model's actual reasoning family name from model_config
-			if r.Config != nil && r.Config.ModelConfig != nil {
-				if modelParams, exists := r.Config.ModelConfig[model]; exists && modelParams.ReasoningFamily != "" {
-					modelFamily = modelParams.ReasoningFamily
+			if r.Config != nil {
+				if familyName, exists := r.Config.GetModelReasoningFamilyName(model); exists {
+					modelFamily = familyName
 				}
 			}
 
@@ -144,6 +165,17 @@ func (r *OpenAIRouter) setReasoningModeToRequestBody(requestBody []byte, enabled
 	}
 
 	return modifiedBody, nil
+}
+
+func usesTopLevelReasoningEffort(profile *config.ProviderProfile) bool {
+	if profile == nil || profile.Type != "openai" || profile.BaseURL == "" {
+		return false
+	}
+	u, err := url.Parse(profile.BaseURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), "api.openai.com")
 }
 
 // getReasoningEffort returns the reasoning effort level for a given decision and model
@@ -189,6 +221,15 @@ func (r *OpenAIRouter) getModelReasoningFamily(model string) *config.ReasoningFa
 
 // buildReasoningRequestFields returns the appropriate fields to add to the request based on model config
 func (r *OpenAIRouter) buildReasoningRequestFields(model string, useReasoning bool, categoryName string) (map[string]interface{}, string) {
+	return r.buildReasoningRequestFieldsForProvider(model, useReasoning, categoryName, nil)
+}
+
+func (r *OpenAIRouter) buildReasoningRequestFieldsForProvider(
+	model string,
+	useReasoning bool,
+	categoryName string,
+	profile *config.ProviderProfile,
+) (map[string]interface{}, string) {
 	familyConfig := r.getModelReasoningFamily(model)
 	if familyConfig == nil {
 		// No reasoning family configured for this model - don't apply any reasoning syntax
@@ -210,6 +251,9 @@ func (r *OpenAIRouter) buildReasoningRequestFields(model string, useReasoning bo
 		return map[string]interface{}{"chat_template_kwargs": kwargs}, ""
 	case "reasoning_effort":
 		effort := r.getReasoningEffort(categoryName, model)
+		if usesTopLevelReasoningEffort(profile) {
+			return map[string]interface{}{familyConfig.Parameter: effort}, effort
+		}
 		// Put reasoning_effort inside chat_template_kwargs (vLLM requirement)
 		kwargs := map[string]interface{}{
 			familyConfig.Parameter: effort,

--- a/src/semantic-router/pkg/extproc/req_filter_reason_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason_test.go
@@ -485,6 +485,12 @@ func TestGetReasoningEffort(t *testing.T) {
 									ReasoningEffort: "low",
 								},
 							},
+							{
+								Model: "model-openai",
+								ModelReasoningControl: config.ModelReasoningControl{
+									ReasoningEffort: "high",
+								},
+							},
 						},
 					},
 					{
@@ -494,6 +500,15 @@ func TestGetReasoningEffort(t *testing.T) {
 								Model: "model-c",
 								// No reasoning effort specified
 							},
+						},
+					},
+				},
+			},
+			BackendModels: config.BackendModels{
+				ModelConfig: map[string]config.ModelParams{
+					"model-openai": {
+						ExternalModelIDs: map[string]string{
+							"openai": "gpt-5-mini",
 						},
 					},
 				},
@@ -518,6 +533,12 @@ func TestGetReasoningEffort(t *testing.T) {
 			categoryName:   "math",
 			modelName:      "model-b",
 			expectedEffort: "low",
+		},
+		{
+			name:           "Provider model ID resolves model-specific effort",
+			categoryName:   "math",
+			modelName:      "gpt-5-mini",
+			expectedEffort: "high",
 		},
 		{
 			name:           "Falls back to default",
@@ -671,6 +692,12 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 									ReasoningEffort: "low",
 								},
 							},
+							{
+								Model: "openai-alias",
+								ModelReasoningControl: config.ModelReasoningControl{
+									ReasoningEffort: "high",
+								},
+							},
 						},
 					},
 				},
@@ -682,6 +709,12 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 					},
 					"gpt-oss-model": {
 						ReasoningFamily: "gpt-oss",
+					},
+					"openai-alias": {
+						ReasoningFamily: "gpt-oss",
+						ExternalModelIDs: map[string]string{
+							"openai": "gpt-5-mini",
+						},
 					},
 					"phi4": {
 						// No reasoning family
@@ -698,6 +731,7 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 		categoryName       string
 		expectNil          bool
 		expectEffortReturn string
+		profile            *config.ProviderProfile
 		verifyFunc         func(t *testing.T, fields map[string]interface{})
 	}{
 		{
@@ -732,6 +766,23 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 			},
 		},
 		{
+			name:               "OpenAI provider model ID uses modelRef effort",
+			model:              "gpt-5-mini",
+			useReasoning:       true,
+			categoryName:       "test",
+			expectNil:          false,
+			expectEffortReturn: "high",
+			profile:            &config.ProviderProfile{Type: "openai", BaseURL: "https://api.openai.com/v1"},
+			verifyFunc: func(t *testing.T, fields map[string]interface{}) {
+				require.NotNil(t, fields)
+				reasoningEffort, exists := fields["reasoning_effort"]
+				require.True(t, exists)
+				assert.Equal(t, "high", reasoningEffort)
+				_, hasChatTemplate := fields["chat_template_kwargs"]
+				assert.False(t, hasChatTemplate)
+			},
+		},
+		{
 			name:         "Reasoning disabled",
 			model:        "deepseek-v3",
 			useReasoning: false,
@@ -749,7 +800,12 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fields, effort := router.buildReasoningRequestFields(tt.model, tt.useReasoning, tt.categoryName)
+			fields, effort := router.buildReasoningRequestFieldsForProvider(
+				tt.model,
+				tt.useReasoning,
+				tt.categoryName,
+				tt.profile,
+			)
 
 			if tt.expectNil {
 				assert.Nil(t, fields)

--- a/src/semantic-router/pkg/extproc/req_filter_reason_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason_test.go
@@ -10,118 +10,20 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
-// TestReasoningModeComprehensive provides comprehensive test coverage for reasoning mode functionality
+// TestReasoningModeComprehensive provides comprehensive test coverage for reasoning mode functionality.
 func TestReasoningModeComprehensive(t *testing.T) {
-	// Create a router with all reasoning families configured
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: config.ReasoningConfig{
-					DefaultReasoningEffort: "medium",
-					ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
-						"deepseek": {
-							Type:      "chat_template_kwargs",
-							Parameter: "thinking",
-						},
-						"qwen3": {
-							Type:      "chat_template_kwargs",
-							Parameter: "enable_thinking",
-						},
-						"gpt-oss": {
-							Type:      "reasoning_effort",
-							Parameter: "reasoning_effort",
-						},
-						"gpt": {
-							Type:      "reasoning_effort",
-							Parameter: "reasoning_effort",
-						},
-						"claude": {
-							Type:      "chat_template_kwargs",
-							Parameter: "thinking",
-						},
-					},
-				},
-				Decisions: []config.Decision{
-					{
-						Name:        "math",
-						Description: "Math problems",
-						Priority:    100,
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "deepseek-v3",
-								ModelReasoningControl: config.ModelReasoningControl{
-									UseReasoning:    boolPtr(true),
-									ReasoningEffort: "high",
-								},
-							},
-						},
-					},
-					{
-						Name:        "code",
-						Description: "Coding tasks",
-						Priority:    90,
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "qwen3-model",
-								ModelReasoningControl: config.ModelReasoningControl{
-									UseReasoning:    boolPtr(true),
-									ReasoningEffort: "medium",
-								},
-							},
-						},
-					},
-					{
-						Name:        "creative",
-						Description: "Creative writing",
-						Priority:    80,
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "claude-opus",
-								ModelReasoningControl: config.ModelReasoningControl{
-									UseReasoning: boolPtr(false),
-								},
-							},
-						},
-					},
-				},
-			},
-			BackendModels: config.BackendModels{
-				ModelConfig: map[string]config.ModelParams{
-					"deepseek-v3": {
-						ReasoningFamily: "deepseek",
-					},
-					"qwen3-model": {
-						ReasoningFamily: "qwen3",
-					},
-					"gpt-oss-model": {
-						ReasoningFamily: "gpt-oss",
-					},
-					"claude-opus": {
-						ReasoningFamily: "claude",
-					},
-					"phi4": {
-						// No reasoning family
-					},
-				},
-			},
-		},
-	}
+	router := newComprehensiveReasoningRouter()
 
-	tests := []struct {
-		name                          string
-		model                         string
-		categoryName                  string
-		enableReasoning               bool
-		initialReasoningEffort        interface{}
-		expectChatTemplateKwargs      bool
-		expectedChatTemplateParam     string
-		expectedChatTemplateValue     interface{}
-		expectReasoningEffortKey      bool
-		expectedReasoningEffort       string
-		expectBothFieldsAbsent        bool
-		expectOriginalEffortPreserved bool
-	}{
-		// Test 1: DeepSeek with reasoning enabled - should use chat_template_kwargs
+	for _, tt := range comprehensiveReasoningModeCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			modifiedRequest := setReasoningModeForCase(t, router, tt)
+			assertReasoningModeCase(t, modifiedRequest, tt)
+		})
+	}
+}
+
+func comprehensiveReasoningModeCases() []reasoningModeCase {
+	return []reasoningModeCase{
 		{
 			name:                      "DeepSeek - reasoning enabled",
 			model:                     "deepseek-v3",
@@ -132,7 +34,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectedChatTemplateValue: true,
 			expectReasoningEffortKey:  false,
 		},
-		// Test 2: DeepSeek with reasoning disabled - should clear all fields
 		{
 			name:                      "DeepSeek - reasoning disabled",
 			model:                     "deepseek-v3",
@@ -143,7 +44,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectedChatTemplateParam: "thinking",
 			expectedChatTemplateValue: false,
 		},
-		// Test 3: Qwen3 with reasoning enabled - should use enable_thinking
 		{
 			name:                      "Qwen3 - reasoning enabled",
 			model:                     "qwen3-model",
@@ -154,7 +54,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectedChatTemplateValue: true,
 			expectReasoningEffortKey:  false,
 		},
-		// Test 4: Qwen3 with reasoning disabled - should clear all fields
 		{
 			name:                      "Qwen3 - reasoning disabled",
 			model:                     "qwen3-model",
@@ -165,7 +64,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectedChatTemplateParam: "enable_thinking",
 			expectedChatTemplateValue: false,
 		},
-		// Test 5: GPT-OSS with reasoning enabled - should use chat_template_kwargs with reasoning_effort inside
 		{
 			name:                      "GPT-OSS - reasoning enabled with high effort",
 			model:                     "gpt-oss-model",
@@ -173,10 +71,9 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			enableReasoning:           true,
 			expectChatTemplateKwargs:  true,
 			expectedChatTemplateParam: "reasoning_effort",
-			expectedChatTemplateValue: "medium", // Falls back to default
+			expectedChatTemplateValue: "medium",
 			expectReasoningEffortKey:  false,
 		},
-		// Test 6: GPT-OSS with reasoning disabled - should preserve reasoning_effort inside chat_template_kwargs
 		{
 			name:                      "GPT-OSS - reasoning disabled preserves effort",
 			model:                     "gpt-oss-model",
@@ -188,7 +85,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectedChatTemplateValue: "low",
 			expectReasoningEffortKey:  false,
 		},
-		// Test 7: Claude with reasoning enabled
 		{
 			name:                      "Claude - reasoning enabled",
 			model:                     "claude-opus",
@@ -198,7 +94,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectedChatTemplateParam: "thinking",
 			expectedChatTemplateValue: true,
 		},
-		// Test 8: Claude with reasoning disabled
 		{
 			name:                      "Claude - reasoning disabled",
 			model:                     "claude-opus",
@@ -208,7 +103,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectedChatTemplateParam: "thinking",
 			expectedChatTemplateValue: false,
 		},
-		// Test 9: Phi4 (no reasoning family) - should not add any fields
 		{
 			name:                   "Phi4 - no reasoning family, enabled",
 			model:                  "phi4",
@@ -216,7 +110,6 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			enableReasoning:        true,
 			expectBothFieldsAbsent: true,
 		},
-		// Test 10: Phi4 with reasoning disabled - should clear everything
 		{
 			name:                   "Phi4 - no reasoning family, disabled",
 			model:                  "phi4",
@@ -226,96 +119,10 @@ func TestReasoningModeComprehensive(t *testing.T) {
 			expectBothFieldsAbsent: true,
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Prepare request body
-			requestBody := map[string]interface{}{
-				"model": tt.model,
-				"messages": []map[string]string{
-					{"role": "user", "content": "test message"},
-				},
-			}
-			if tt.initialReasoningEffort != nil {
-				requestBody["reasoning_effort"] = tt.initialReasoningEffort
-			}
-
-			requestBytes, err := json.Marshal(requestBody)
-			require.NoError(t, err)
-
-			// Call setReasoningModeToRequestBody
-			modifiedBytes, err := router.setReasoningModeToRequestBody(requestBytes, tt.enableReasoning, tt.categoryName)
-			require.NoError(t, err)
-
-			// Parse modified request
-			var modifiedRequest map[string]interface{}
-			err = json.Unmarshal(modifiedBytes, &modifiedRequest)
-			require.NoError(t, err)
-
-			// Verify expectations
-			if tt.expectBothFieldsAbsent {
-				_, hasChatTemplate := modifiedRequest["chat_template_kwargs"]
-				_, hasReasoningEffort := modifiedRequest["reasoning_effort"]
-				assert.False(t, hasChatTemplate, "chat_template_kwargs should be absent")
-				assert.False(t, hasReasoningEffort, "reasoning_effort should be absent")
-			}
-
-			if tt.expectChatTemplateKwargs {
-				chatTemplateKwargs, exists := modifiedRequest["chat_template_kwargs"]
-				require.True(t, exists, "chat_template_kwargs should exist")
-
-				kwargs, ok := chatTemplateKwargs.(map[string]interface{})
-				require.True(t, ok, "chat_template_kwargs should be a map")
-
-				value, paramExists := kwargs[tt.expectedChatTemplateParam]
-				require.True(t, paramExists, "Expected parameter %s should exist", tt.expectedChatTemplateParam)
-				assert.Equal(t, tt.expectedChatTemplateValue, value, "chat_template_kwargs[%s] value mismatch", tt.expectedChatTemplateParam)
-
-				// When chat_template_kwargs is set, reasoning_effort should NOT be present
-				_, hasReasoningEffort := modifiedRequest["reasoning_effort"]
-				assert.False(t, hasReasoningEffort, "reasoning_effort should not exist when chat_template_kwargs is used")
-			}
-
-			if tt.expectReasoningEffortKey {
-				reasoningEffort, exists := modifiedRequest["reasoning_effort"]
-				require.True(t, exists, "reasoning_effort should exist")
-
-				if tt.expectOriginalEffortPreserved {
-					assert.Equal(t, tt.initialReasoningEffort, reasoningEffort, "Original reasoning_effort should be preserved")
-				} else {
-					assert.Equal(t, tt.expectedReasoningEffort, reasoningEffort, "reasoning_effort value mismatch")
-				}
-
-				// When reasoning_effort is set, chat_template_kwargs should NOT be present
-				_, hasChatTemplate := modifiedRequest["chat_template_kwargs"]
-				assert.False(t, hasChatTemplate, "chat_template_kwargs should not exist when reasoning_effort is used")
-			}
-		})
-	}
 }
 
 func TestChatTemplateKwargsPreservedWhenTogglingReasoning(t *testing.T) {
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: config.ReasoningConfig{
-					ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
-						"qwen3": {
-							Type:      "chat_template_kwargs",
-							Parameter: "enable_thinking",
-						},
-					},
-				},
-			},
-			BackendModels: config.BackendModels{
-				ModelConfig: map[string]config.ModelParams{
-					"qwen3-model": {
-						ReasoningFamily: "qwen3",
-					},
-				},
-			},
-		},
-	}
+	router := newQwen3ReasoningRouter()
 
 	makeBody := func() []byte {
 		b, _ := json.Marshal(map[string]interface{}{
@@ -335,9 +142,7 @@ func TestChatTemplateKwargsPreservedWhenTogglingReasoning(t *testing.T) {
 		modified, err := router.setReasoningModeToRequestBody(makeBody(), false, "any")
 		require.NoError(t, err)
 
-		var out map[string]interface{}
-		require.NoError(t, json.Unmarshal(modified, &out))
-
+		out := unmarshalReasoningRequest(t, modified)
 		ctk, ok := out["chat_template_kwargs"].(map[string]interface{})
 		require.True(t, ok, "expected chat_template_kwargs to be a map")
 		assert.Equal(t, "bar", ctk["foo"])
@@ -348,9 +153,7 @@ func TestChatTemplateKwargsPreservedWhenTogglingReasoning(t *testing.T) {
 		modified, err := router.setReasoningModeToRequestBody(makeBody(), true, "any")
 		require.NoError(t, err)
 
-		var out map[string]interface{}
-		require.NoError(t, json.Unmarshal(modified, &out))
-
+		out := unmarshalReasoningRequest(t, modified)
 		ctk, ok := out["chat_template_kwargs"].(map[string]interface{})
 		require.True(t, ok, "expected chat_template_kwargs to be a map")
 		assert.Equal(t, "bar", ctk["foo"])
@@ -358,69 +161,9 @@ func TestChatTemplateKwargsPreservedWhenTogglingReasoning(t *testing.T) {
 	})
 }
 
-// TestReasoningEffortLevels tests all reasoning effort levels
+// TestReasoningEffortLevels tests all reasoning effort levels.
 func TestReasoningEffortLevels(t *testing.T) {
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: config.ReasoningConfig{
-					DefaultReasoningEffort: "medium",
-					ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
-						"gpt-oss": {
-							Type:      "reasoning_effort",
-							Parameter: "reasoning_effort",
-						},
-					},
-				},
-				Decisions: []config.Decision{
-					{
-						Name: "low-effort-task",
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "gpt-oss-model",
-								ModelReasoningControl: config.ModelReasoningControl{
-									UseReasoning:    boolPtr(true),
-									ReasoningEffort: "low",
-								},
-							},
-						},
-					},
-					{
-						Name: "medium-effort-task",
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "gpt-oss-model",
-								ModelReasoningControl: config.ModelReasoningControl{
-									UseReasoning:    boolPtr(true),
-									ReasoningEffort: "medium",
-								},
-							},
-						},
-					},
-					{
-						Name: "high-effort-task",
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "gpt-oss-model",
-								ModelReasoningControl: config.ModelReasoningControl{
-									UseReasoning:    boolPtr(true),
-									ReasoningEffort: "high",
-								},
-							},
-						},
-					},
-				},
-			},
-			BackendModels: config.BackendModels{
-				ModelConfig: map[string]config.ModelParams{
-					"gpt-oss-model": {
-						ReasoningFamily: "gpt-oss",
-					},
-				},
-			},
-		},
-	}
-
+	router := newReasoningEffortLevelsRouter()
 	efforts := []struct {
 		categoryName   string
 		expectedEffort string
@@ -432,126 +175,38 @@ func TestReasoningEffortLevels(t *testing.T) {
 
 	for _, tt := range efforts {
 		t.Run("Effort_"+tt.expectedEffort, func(t *testing.T) {
-			requestBody := map[string]interface{}{
-				"model": "gpt-oss-model",
-				"messages": []map[string]string{
-					{"role": "user", "content": "test"},
-				},
-			}
-
-			requestBytes, err := json.Marshal(requestBody)
-			require.NoError(t, err)
-
-			modifiedBytes, err := router.setReasoningModeToRequestBody(requestBytes, true, tt.categoryName)
-			require.NoError(t, err)
-
-			var modifiedRequest map[string]interface{}
-			err = json.Unmarshal(modifiedBytes, &modifiedRequest)
-			require.NoError(t, err)
-
-			// reasoning_effort should be inside chat_template_kwargs for GPT-OSS models
-			chatTemplateKwargs, exists := modifiedRequest["chat_template_kwargs"]
-			require.True(t, exists, "chat_template_kwargs should exist")
-			kwargs, ok := chatTemplateKwargs.(map[string]interface{})
-			require.True(t, ok, "chat_template_kwargs should be a map")
-			reasoningEffort, exists := kwargs["reasoning_effort"]
-			require.True(t, exists, "reasoning_effort should exist in chat_template_kwargs")
-			assert.Equal(t, tt.expectedEffort, reasoningEffort)
+			modifiedRequest := setReasoningMode(
+				t,
+				router,
+				"gpt-oss-model",
+				nil,
+				true,
+				tt.categoryName,
+			)
+			assertChatTemplateReasoningField(
+				t,
+				modifiedRequest,
+				"reasoning_effort",
+				tt.expectedEffort,
+			)
 		})
 	}
 }
 
-// TestGetReasoningEffort tests the getReasoningEffort method
+// TestGetReasoningEffort tests the getReasoningEffort method.
 func TestGetReasoningEffort(t *testing.T) {
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: config.ReasoningConfig{
-					DefaultReasoningEffort: "medium",
-				},
-				Decisions: []config.Decision{
-					{
-						Name: "math",
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "model-a",
-								ModelReasoningControl: config.ModelReasoningControl{
-									ReasoningEffort: "high",
-								},
-							},
-							{
-								Model: "model-b",
-								ModelReasoningControl: config.ModelReasoningControl{
-									ReasoningEffort: "low",
-								},
-							},
-							{
-								Model: "model-openai",
-								ModelReasoningControl: config.ModelReasoningControl{
-									ReasoningEffort: "high",
-								},
-							},
-						},
-					},
-					{
-						Name: "code",
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "model-c",
-								// No reasoning effort specified
-							},
-						},
-					},
-				},
-			},
-			BackendModels: config.BackendModels{
-				ModelConfig: map[string]config.ModelParams{
-					"model-openai": {
-						ExternalModelIDs: map[string]string{
-							"openai": "gpt-5-mini",
-						},
-					},
-				},
-			},
-		},
-	}
-
+	router := newReasoningEffortLookupRouter()
 	tests := []struct {
 		name           string
 		categoryName   string
 		modelName      string
 		expectedEffort string
 	}{
-		{
-			name:           "Model-specific high effort",
-			categoryName:   "math",
-			modelName:      "model-a",
-			expectedEffort: "high",
-		},
-		{
-			name:           "Model-specific low effort",
-			categoryName:   "math",
-			modelName:      "model-b",
-			expectedEffort: "low",
-		},
-		{
-			name:           "Provider model ID resolves model-specific effort",
-			categoryName:   "math",
-			modelName:      "gpt-5-mini",
-			expectedEffort: "high",
-		},
-		{
-			name:           "Falls back to default",
-			categoryName:   "code",
-			modelName:      "model-c",
-			expectedEffort: "medium",
-		},
-		{
-			name:           "Unknown category falls back to default",
-			categoryName:   "unknown",
-			modelName:      "model-a",
-			expectedEffort: "medium",
-		},
+		{"Model-specific high effort", "math", "model-a", "high"},
+		{"Model-specific low effort", "math", "model-b", "low"},
+		{"Provider model ID resolves model-specific effort", "math", "gpt-5-mini", "high"},
+		{"Falls back to default", "code", "model-c", "medium"},
+		{"Unknown category falls back to default", "unknown", "model-a", "medium"},
 	}
 
 	for _, tt := range tests {
@@ -562,47 +217,9 @@ func TestGetReasoningEffort(t *testing.T) {
 	}
 }
 
-// TestGetModelReasoningFamily tests the getModelReasoningFamily method
+// TestGetModelReasoningFamily tests the getModelReasoningFamily method.
 func TestGetModelReasoningFamily(t *testing.T) {
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: config.ReasoningConfig{
-					ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
-						"deepseek": {
-							Type:      "chat_template_kwargs",
-							Parameter: "thinking",
-						},
-						"qwen3": {
-							Type:      "chat_template_kwargs",
-							Parameter: "enable_thinking",
-						},
-						"gpt-oss": {
-							Type:      "reasoning_effort",
-							Parameter: "reasoning_effort",
-						},
-					},
-				},
-			},
-			BackendModels: config.BackendModels{
-				ModelConfig: map[string]config.ModelParams{
-					"deepseek-v3": {
-						ReasoningFamily: "deepseek",
-					},
-					"qwen3-7b": {
-						ReasoningFamily: "qwen3",
-					},
-					"gpt-oss-model": {
-						ReasoningFamily: "gpt-oss",
-					},
-					"phi4": {
-						// No reasoning family
-					},
-				},
-			},
-		},
-	}
-
+	router := newModelReasoningFamilyRouter()
 	tests := []struct {
 		name          string
 		model         string
@@ -610,120 +227,30 @@ func TestGetModelReasoningFamily(t *testing.T) {
 		expectedType  string
 		expectedParam string
 	}{
-		{
-			name:          "DeepSeek family",
-			model:         "deepseek-v3",
-			expectNil:     false,
-			expectedType:  "chat_template_kwargs",
-			expectedParam: "thinking",
-		},
-		{
-			name:          "Qwen3 family",
-			model:         "qwen3-7b",
-			expectNil:     false,
-			expectedType:  "chat_template_kwargs",
-			expectedParam: "enable_thinking",
-		},
-		{
-			name:          "GPT-OSS family",
-			model:         "gpt-oss-model",
-			expectNil:     false,
-			expectedType:  "reasoning_effort",
-			expectedParam: "reasoning_effort",
-		},
-		{
-			name:      "No reasoning family",
-			model:     "phi4",
-			expectNil: true,
-		},
-		{
-			name:      "Unknown model",
-			model:     "unknown",
-			expectNil: true,
-		},
+		{"DeepSeek family", "deepseek-v3", false, "chat_template_kwargs", "thinking"},
+		{"Qwen3 family", "qwen3-7b", false, "chat_template_kwargs", "enable_thinking"},
+		{"GPT-OSS family", "gpt-oss-model", false, "reasoning_effort", "reasoning_effort"},
+		{name: "No reasoning family", model: "phi4", expectNil: true},
+		{name: "Unknown model", model: "unknown", expectNil: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			family := router.getModelReasoningFamily(tt.model)
-
 			if tt.expectNil {
 				assert.Nil(t, family)
-			} else {
-				require.NotNil(t, family)
-				assert.Equal(t, tt.expectedType, family.Type)
-				assert.Equal(t, tt.expectedParam, family.Parameter)
+				return
 			}
+			require.NotNil(t, family)
+			assert.Equal(t, tt.expectedType, family.Type)
+			assert.Equal(t, tt.expectedParam, family.Parameter)
 		})
 	}
 }
 
-// TestBuildReasoningRequestFields tests the buildReasoningRequestFields method
+// TestBuildReasoningRequestFields tests the buildReasoningRequestFieldsForProvider method.
 func TestBuildReasoningRequestFields(t *testing.T) {
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: config.ReasoningConfig{
-					DefaultReasoningEffort: "medium",
-					ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
-						"deepseek": {
-							Type:      "chat_template_kwargs",
-							Parameter: "thinking",
-						},
-						"gpt-oss": {
-							Type:      "reasoning_effort",
-							Parameter: "reasoning_effort",
-						},
-					},
-				},
-				Decisions: []config.Decision{
-					{
-						Name: "test",
-						ModelRefs: []config.ModelRef{
-							{
-								Model: "deepseek-v3",
-								ModelReasoningControl: config.ModelReasoningControl{
-									ReasoningEffort: "high",
-								},
-							},
-							{
-								Model: "gpt-oss-model",
-								ModelReasoningControl: config.ModelReasoningControl{
-									ReasoningEffort: "low",
-								},
-							},
-							{
-								Model: "openai-alias",
-								ModelReasoningControl: config.ModelReasoningControl{
-									ReasoningEffort: "high",
-								},
-							},
-						},
-					},
-				},
-			},
-			BackendModels: config.BackendModels{
-				ModelConfig: map[string]config.ModelParams{
-					"deepseek-v3": {
-						ReasoningFamily: "deepseek",
-					},
-					"gpt-oss-model": {
-						ReasoningFamily: "gpt-oss",
-					},
-					"openai-alias": {
-						ReasoningFamily: "gpt-oss",
-						ExternalModelIDs: map[string]string{
-							"openai": "gpt-5-mini",
-						},
-					},
-					"phi4": {
-						// No reasoning family
-					},
-				},
-			},
-		},
-	}
-
+	router := newBuildReasoningRequestFieldsRouter()
 	tests := []struct {
 		name               string
 		model              string
@@ -739,13 +266,8 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 			model:        "deepseek-v3",
 			useReasoning: true,
 			categoryName: "test",
-			expectNil:    false,
 			verifyFunc: func(t *testing.T, fields map[string]interface{}) {
-				require.NotNil(t, fields)
-				chatTemplate, exists := fields["chat_template_kwargs"]
-				require.True(t, exists)
-				kwargs := chatTemplate.(map[string]interface{})
-				assert.Equal(t, true, kwargs["thinking"])
+				assertReasoningRequestField(t, fields, "thinking", true)
 			},
 		},
 		{
@@ -753,16 +275,9 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 			model:              "gpt-oss-model",
 			useReasoning:       true,
 			categoryName:       "test",
-			expectNil:          false,
 			expectEffortReturn: "low",
 			verifyFunc: func(t *testing.T, fields map[string]interface{}) {
-				require.NotNil(t, fields)
-				chatTemplate, exists := fields["chat_template_kwargs"]
-				require.True(t, exists)
-				kwargs := chatTemplate.(map[string]interface{})
-				effort, exists := kwargs["reasoning_effort"]
-				require.True(t, exists)
-				assert.Equal(t, "low", effort)
+				assertReasoningRequestField(t, fields, "reasoning_effort", "low")
 			},
 		},
 		{
@@ -770,7 +285,6 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 			model:              "gpt-5-mini",
 			useReasoning:       true,
 			categoryName:       "test",
-			expectNil:          false,
 			expectEffortReturn: "high",
 			profile:            &config.ProviderProfile{Type: "openai", BaseURL: "https://api.openai.com/v1"},
 			verifyFunc: func(t *testing.T, fields map[string]interface{}) {
@@ -782,20 +296,8 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 				assert.False(t, hasChatTemplate)
 			},
 		},
-		{
-			name:         "Reasoning disabled",
-			model:        "deepseek-v3",
-			useReasoning: false,
-			categoryName: "test",
-			expectNil:    true,
-		},
-		{
-			name:         "No reasoning family",
-			model:        "phi4",
-			useReasoning: true,
-			categoryName: "test",
-			expectNil:    true,
-		},
+		{name: "Reasoning disabled", model: "deepseek-v3", categoryName: "test", expectNil: true},
+		{name: "No reasoning family", model: "phi4", useReasoning: true, categoryName: "test", expectNil: true},
 	}
 
 	for _, tt := range tests {
@@ -806,46 +308,14 @@ func TestBuildReasoningRequestFields(t *testing.T) {
 				tt.categoryName,
 				tt.profile,
 			)
-
-			if tt.expectNil {
-				assert.Nil(t, fields)
-				assert.Empty(t, effort)
-			} else {
-				if tt.verifyFunc != nil {
-					tt.verifyFunc(t, fields)
-				}
-				if tt.expectEffortReturn != "" {
-					assert.Equal(t, tt.expectEffortReturn, effort)
-				}
-			}
+			assertBuiltReasoningRequestFields(t, fields, effort, tt.expectNil, tt.expectEffortReturn, tt.verifyFunc)
 		})
 	}
 }
 
-// TestReasoningModeEdgeCases tests edge cases and error conditions
+// TestReasoningModeEdgeCases tests edge cases and error conditions.
 func TestReasoningModeEdgeCases(t *testing.T) {
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: config.ReasoningConfig{
-					DefaultReasoningEffort: "medium",
-					ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
-						"deepseek": {
-							Type:      "chat_template_kwargs",
-							Parameter: "thinking",
-						},
-					},
-				},
-			},
-			BackendModels: config.BackendModels{
-				ModelConfig: map[string]config.ModelParams{
-					"deepseek-v3": {
-						ReasoningFamily: "deepseek",
-					},
-				},
-			},
-		},
-	}
+	router := newDeepSeekReasoningRouter()
 
 	t.Run("Empty request body", func(t *testing.T) {
 		_, err := router.setReasoningModeToRequestBody([]byte("{}"), true, "test")
@@ -858,35 +328,356 @@ func TestReasoningModeEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Large request body", func(t *testing.T) {
-		largeRequest := map[string]interface{}{
-			"model":    "deepseek-v3",
-			"messages": make([]map[string]string, 1000),
-		}
-		for i := 0; i < 1000; i++ {
-			largeRequest["messages"].([]map[string]string)[i] = map[string]string{
-				"role":    "user",
-				"content": "test message",
-			}
-		}
-		requestBytes, _ := json.Marshal(largeRequest)
+		requestBytes, _ := json.Marshal(largeReasoningRequest())
 		modifiedBytes, err := router.setReasoningModeToRequestBody(requestBytes, true, "test")
 		assert.NoError(t, err)
 		assert.NotNil(t, modifiedBytes)
 	})
 
 	t.Run("Nil config", func(t *testing.T) {
-		nilRouter := &OpenAIRouter{
-			Config: nil,
-		}
-		effort := nilRouter.getReasoningEffort("test", "model")
-		assert.Equal(t, "medium", effort)
-
-		family := nilRouter.getModelReasoningFamily("model")
-		assert.Nil(t, family)
+		nilRouter := &OpenAIRouter{Config: nil}
+		assert.Equal(t, "medium", nilRouter.getReasoningEffort("test", "model"))
+		assert.Nil(t, nilRouter.getModelReasoningFamily("model"))
 	})
 }
 
-// Helper function to create bool pointer
+type reasoningModeCase struct {
+	name                          string
+	model                         string
+	categoryName                  string
+	enableReasoning               bool
+	initialReasoningEffort        interface{}
+	expectChatTemplateKwargs      bool
+	expectedChatTemplateParam     string
+	expectedChatTemplateValue     interface{}
+	expectReasoningEffortKey      bool
+	expectedReasoningEffort       string
+	expectBothFieldsAbsent        bool
+	expectOriginalEffortPreserved bool
+}
+
+func newReasoningRouter(
+	reasoningConfig config.ReasoningConfig,
+	decisions []config.Decision,
+	modelConfig map[string]config.ModelParams,
+) *OpenAIRouter {
+	return &OpenAIRouter{
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				ReasoningConfig: reasoningConfig,
+				Decisions:       decisions,
+			},
+			BackendModels: config.BackendModels{ModelConfig: modelConfig},
+		},
+	}
+}
+
+func newComprehensiveReasoningRouter() *OpenAIRouter {
+	return newReasoningRouter(
+		config.ReasoningConfig{
+			DefaultReasoningEffort: "medium",
+			ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+				"deepseek": {Type: "chat_template_kwargs", Parameter: "thinking"},
+				"qwen3":    {Type: "chat_template_kwargs", Parameter: "enable_thinking"},
+				"gpt-oss":  {Type: "reasoning_effort", Parameter: "reasoning_effort"},
+				"gpt":      {Type: "reasoning_effort", Parameter: "reasoning_effort"},
+				"claude":   {Type: "chat_template_kwargs", Parameter: "thinking"},
+			},
+		},
+		[]config.Decision{
+			reasoningDecision("math", "Math problems", 100, "deepseek-v3", boolPtr(true), "high"),
+			reasoningDecision("code", "Coding tasks", 90, "qwen3-model", boolPtr(true), "medium"),
+			reasoningDecision("creative", "Creative writing", 80, "claude-opus", boolPtr(false), ""),
+		},
+		map[string]config.ModelParams{
+			"deepseek-v3":   {ReasoningFamily: "deepseek"},
+			"qwen3-model":   {ReasoningFamily: "qwen3"},
+			"gpt-oss-model": {ReasoningFamily: "gpt-oss"},
+			"claude-opus":   {ReasoningFamily: "claude"},
+			"phi4":          {},
+		},
+	)
+}
+
+func newQwen3ReasoningRouter() *OpenAIRouter {
+	return newReasoningRouter(
+		config.ReasoningConfig{
+			ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+				"qwen3": {Type: "chat_template_kwargs", Parameter: "enable_thinking"},
+			},
+		},
+		nil,
+		map[string]config.ModelParams{"qwen3-model": {ReasoningFamily: "qwen3"}},
+	)
+}
+
+func newReasoningEffortLevelsRouter() *OpenAIRouter {
+	return newReasoningRouter(
+		config.ReasoningConfig{
+			DefaultReasoningEffort: "medium",
+			ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+				"gpt-oss": {Type: "reasoning_effort", Parameter: "reasoning_effort"},
+			},
+		},
+		[]config.Decision{
+			reasoningDecision("low-effort-task", "", 0, "gpt-oss-model", boolPtr(true), "low"),
+			reasoningDecision("medium-effort-task", "", 0, "gpt-oss-model", boolPtr(true), "medium"),
+			reasoningDecision("high-effort-task", "", 0, "gpt-oss-model", boolPtr(true), "high"),
+		},
+		map[string]config.ModelParams{"gpt-oss-model": {ReasoningFamily: "gpt-oss"}},
+	)
+}
+
+func newReasoningEffortLookupRouter() *OpenAIRouter {
+	return newReasoningRouter(
+		config.ReasoningConfig{DefaultReasoningEffort: "medium"},
+		[]config.Decision{
+			{
+				Name: "math",
+				ModelRefs: []config.ModelRef{
+					{Model: "model-a", ModelReasoningControl: config.ModelReasoningControl{ReasoningEffort: "high"}},
+					{Model: "model-b", ModelReasoningControl: config.ModelReasoningControl{ReasoningEffort: "low"}},
+					{Model: "model-openai", ModelReasoningControl: config.ModelReasoningControl{ReasoningEffort: "high"}},
+				},
+			},
+			{Name: "code", ModelRefs: []config.ModelRef{{Model: "model-c"}}},
+		},
+		map[string]config.ModelParams{
+			"model-openai": {
+				ExternalModelIDs: map[string]string{"openai": "gpt-5-mini"},
+			},
+		},
+	)
+}
+
+func newModelReasoningFamilyRouter() *OpenAIRouter {
+	return newReasoningRouter(
+		config.ReasoningConfig{
+			ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+				"deepseek": {Type: "chat_template_kwargs", Parameter: "thinking"},
+				"qwen3":    {Type: "chat_template_kwargs", Parameter: "enable_thinking"},
+				"gpt-oss":  {Type: "reasoning_effort", Parameter: "reasoning_effort"},
+			},
+		},
+		nil,
+		map[string]config.ModelParams{
+			"deepseek-v3":   {ReasoningFamily: "deepseek"},
+			"qwen3-7b":      {ReasoningFamily: "qwen3"},
+			"gpt-oss-model": {ReasoningFamily: "gpt-oss"},
+			"phi4":          {},
+		},
+	)
+}
+
+func newBuildReasoningRequestFieldsRouter() *OpenAIRouter {
+	return newReasoningRouter(
+		config.ReasoningConfig{
+			DefaultReasoningEffort: "medium",
+			ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+				"deepseek": {Type: "chat_template_kwargs", Parameter: "thinking"},
+				"gpt-oss":  {Type: "reasoning_effort", Parameter: "reasoning_effort"},
+			},
+		},
+		[]config.Decision{{
+			Name: "test",
+			ModelRefs: []config.ModelRef{
+				{Model: "deepseek-v3", ModelReasoningControl: config.ModelReasoningControl{ReasoningEffort: "high"}},
+				{Model: "gpt-oss-model", ModelReasoningControl: config.ModelReasoningControl{ReasoningEffort: "low"}},
+				{Model: "openai-alias", ModelReasoningControl: config.ModelReasoningControl{ReasoningEffort: "high"}},
+			},
+		}},
+		map[string]config.ModelParams{
+			"deepseek-v3":   {ReasoningFamily: "deepseek"},
+			"gpt-oss-model": {ReasoningFamily: "gpt-oss"},
+			"openai-alias": {
+				ReasoningFamily: "gpt-oss",
+				ExternalModelIDs: map[string]string{
+					"openai": "gpt-5-mini",
+				},
+			},
+			"phi4": {},
+		},
+	)
+}
+
+func newDeepSeekReasoningRouter() *OpenAIRouter {
+	return newReasoningRouter(
+		config.ReasoningConfig{
+			DefaultReasoningEffort: "medium",
+			ReasoningFamilies: map[string]config.ReasoningFamilyConfig{
+				"deepseek": {Type: "chat_template_kwargs", Parameter: "thinking"},
+			},
+		},
+		nil,
+		map[string]config.ModelParams{"deepseek-v3": {ReasoningFamily: "deepseek"}},
+	)
+}
+
+func reasoningDecision(name string, description string, priority int, model string, useReasoning *bool, effort string) config.Decision {
+	return config.Decision{
+		Name:        name,
+		Description: description,
+		Priority:    priority,
+		ModelRefs: []config.ModelRef{{
+			Model: model,
+			ModelReasoningControl: config.ModelReasoningControl{
+				UseReasoning:    useReasoning,
+				ReasoningEffort: effort,
+			},
+		}},
+	}
+}
+
+func setReasoningModeForCase(t *testing.T, router *OpenAIRouter, tt reasoningModeCase) map[string]interface{} {
+	t.Helper()
+	return setReasoningMode(t, router, tt.model, tt.initialReasoningEffort, tt.enableReasoning, tt.categoryName)
+}
+
+func setReasoningMode(
+	t *testing.T,
+	router *OpenAIRouter,
+	model string,
+	initialReasoningEffort interface{},
+	enableReasoning bool,
+	categoryName string,
+) map[string]interface{} {
+	t.Helper()
+	requestBytes := marshalReasoningRequest(t, model, initialReasoningEffort)
+	modifiedBytes, err := router.setReasoningModeToRequestBody(requestBytes, enableReasoning, categoryName)
+	require.NoError(t, err)
+	return unmarshalReasoningRequest(t, modifiedBytes)
+}
+
+func marshalReasoningRequest(t *testing.T, model string, initialReasoningEffort interface{}) []byte {
+	t.Helper()
+	requestBody := map[string]interface{}{
+		"model": model,
+		"messages": []map[string]string{
+			{"role": "user", "content": "test message"},
+		},
+	}
+	if initialReasoningEffort != nil {
+		requestBody["reasoning_effort"] = initialReasoningEffort
+	}
+	requestBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+	return requestBytes
+}
+
+func unmarshalReasoningRequest(t *testing.T, requestBytes []byte) map[string]interface{} {
+	t.Helper()
+	var request map[string]interface{}
+	require.NoError(t, json.Unmarshal(requestBytes, &request))
+	return request
+}
+
+func assertReasoningModeCase(t *testing.T, modifiedRequest map[string]interface{}, tt reasoningModeCase) {
+	t.Helper()
+	if tt.expectBothFieldsAbsent {
+		assertNoReasoningFields(t, modifiedRequest)
+	}
+	if tt.expectChatTemplateKwargs {
+		assertChatTemplateReasoningField(
+			t,
+			modifiedRequest,
+			tt.expectedChatTemplateParam,
+			tt.expectedChatTemplateValue,
+		)
+		assertReasoningEffortAbsent(t, modifiedRequest)
+	}
+	if tt.expectReasoningEffortKey {
+		assertReasoningEffortField(t, modifiedRequest, tt)
+		assertChatTemplateAbsent(t, modifiedRequest)
+	}
+}
+
+func assertNoReasoningFields(t *testing.T, request map[string]interface{}) {
+	t.Helper()
+	assertChatTemplateAbsent(t, request)
+	assertReasoningEffortAbsent(t, request)
+}
+
+func assertChatTemplateReasoningField(t *testing.T, request map[string]interface{}, param string, value interface{}) {
+	t.Helper()
+	chatTemplateKwargs, exists := request["chat_template_kwargs"]
+	require.True(t, exists, "chat_template_kwargs should exist")
+
+	kwargs, ok := chatTemplateKwargs.(map[string]interface{})
+	require.True(t, ok, "chat_template_kwargs should be a map")
+
+	actualValue, paramExists := kwargs[param]
+	require.True(t, paramExists, "Expected parameter %s should exist", param)
+	assert.Equal(t, value, actualValue, "chat_template_kwargs[%s] value mismatch", param)
+}
+
+func assertReasoningEffortField(t *testing.T, request map[string]interface{}, tt reasoningModeCase) {
+	t.Helper()
+	reasoningEffort, exists := request["reasoning_effort"]
+	require.True(t, exists, "reasoning_effort should exist")
+	if tt.expectOriginalEffortPreserved {
+		assert.Equal(t, tt.initialReasoningEffort, reasoningEffort, "Original reasoning_effort should be preserved")
+		return
+	}
+	assert.Equal(t, tt.expectedReasoningEffort, reasoningEffort, "reasoning_effort value mismatch")
+}
+
+func assertChatTemplateAbsent(t *testing.T, request map[string]interface{}) {
+	t.Helper()
+	_, hasChatTemplate := request["chat_template_kwargs"]
+	assert.False(t, hasChatTemplate, "chat_template_kwargs should be absent")
+}
+
+func assertReasoningEffortAbsent(t *testing.T, request map[string]interface{}) {
+	t.Helper()
+	_, hasReasoningEffort := request["reasoning_effort"]
+	assert.False(t, hasReasoningEffort, "reasoning_effort should be absent")
+}
+
+func assertReasoningRequestField(t *testing.T, fields map[string]interface{}, key string, value interface{}) {
+	t.Helper()
+	require.NotNil(t, fields)
+	chatTemplate, exists := fields["chat_template_kwargs"]
+	require.True(t, exists)
+	kwargs := chatTemplate.(map[string]interface{})
+	assert.Equal(t, value, kwargs[key])
+}
+
+func assertBuiltReasoningRequestFields(
+	t *testing.T,
+	fields map[string]interface{},
+	effort string,
+	expectNil bool,
+	expectedEffort string,
+	verifyFunc func(t *testing.T, fields map[string]interface{}),
+) {
+	t.Helper()
+	if expectNil {
+		assert.Nil(t, fields)
+		assert.Empty(t, effort)
+		return
+	}
+	if verifyFunc != nil {
+		verifyFunc(t, fields)
+	}
+	if expectedEffort != "" {
+		assert.Equal(t, expectedEffort, effort)
+	}
+}
+
+func largeReasoningRequest() map[string]interface{} {
+	largeRequest := map[string]interface{}{
+		"model":    "deepseek-v3",
+		"messages": make([]map[string]string, 1000),
+	}
+	for i := 0; i < 1000; i++ {
+		largeRequest["messages"].([]map[string]string)[i] = map[string]string{
+			"role":    "user",
+			"content": "test message",
+		}
+	}
+	return largeRequest
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
Closes #1901

## Purpose

OpenAI expects `reasoning_effort` as a top-level request field. Before this
change, auto-routed requests could send that value in vLLM's
`chat_template_kwargs` shape, which is correct for local vLLM backends but not
for the OpenAI API.

This PR fixes the request mutation so:

- OpenAI provider backends receive top-level `reasoning_effort`.
- vLLM-compatible backends keep receiving `chat_template_kwargs.reasoning_effort`.
- Per-decision `modelRefs[].reasoning_effort` is still found after routing
  rewrites a logical model name like `test-model` to a provider model ID like
  `gpt-5-mini`.
- Affected module: `Router`.

For example:

```yaml
providers:
  models:
    - name: test-model
      provider_model_id: gpt-5-mini

routing:
  decisions:
    - name: default_route
      modelRefs:
        - model: test-model
          use_reasoning: true
          reasoning_effort: high
```

Before this fix:

- The decision is configured for `test-model`.
- During request mutation, the request body model has already been rewritten to
  `gpt-5-mini`.
- `getReasoningEffort(categoryName, model)` used `gpt-5-mini` to match
  `modelRefs[].model`.
- That did not match `test-model`, so `reasoning_effort: high` was not applied.
- The router fell back to `default_reasoning_effort` or `"medium"`.

After this fix:

- `ModelNameMatches` treats `test-model` and its provider model ID
  `gpt-5-mini` as the same configured model.
- `getReasoningEffort` can find `modelRefs[].reasoning_effort: high`.
- The OpenAI path sends that value as top-level `reasoning_effort: "high"`.

## Test Plan

- Reviewers can validate the changed-file scope with:

  ```bash
  GO_FILES="src/semantic-router/pkg/config/helper.go,src/semantic-router/pkg/config/config_test.go,src/semantic-router/pkg/extproc/processor_req_body.go,src/semantic-router/pkg/extproc/processor_req_body_routing.go,src/semantic-router/pkg/extproc/req_filter_reason.go,src/semantic-router/pkg/extproc/req_filter_reason_test.go"

  make agent-report ENV=cpu CHANGED_FILES="$GO_FILES"
  make agent-ci-gate CHANGED_FILES="$GO_FILES"
  ```

- Run Go-specific checks for the affected router/config code:

  ```bash
  make check-go-mod-tidy
  make go-lint
  make test-semantic-router
  ```

- For behavior validation, exercise an auto-routing request that selects an OpenAI provider profile with a reasoning-capable model and confirm the upstream JSON body contains top-level `reasoning_effort` and does not contain `chat_template_kwargs.reasoning_effort`.
- Confirm the selected decision's per-model `reasoning_effort` wins even when the request body model has already been rewritten to the provider-facing model ID.
- Also verify an equivalent vLLM/local provider path still sends `reasoning_effort` inside `chat_template_kwargs`.

## Test Result

- `make check-go-mod-tidy` passed.
- `make go-lint` passed.
- `make test-semantic-router` 

  ```text
  Ran 258 of 292 Specs in 4.177 seconds
  SUCCESS! -- 258 Passed | 0 Failed | 0 Pending | 34 Skipped
  ```

- `make agent-report ENV=cpu` passed.
- `make agent-lint CHANGED_FILES="$GO_FILES"` currently reports `funlen` on
  existing test functions in
  `src/semantic-router/pkg/extproc/req_filter_reason_test.go`.
- Commit is DCO signed off.

## Notes For Reviewers

- The format switch is intentionally provider-specific: OpenAI API receives top-level `reasoning_effort`; vLLM-compatible backends keep the existing `chat_template_kwargs` shape.
- The reasoning-family and reasoning-effort lookups now support provider-facing model names via config resolution, which matters after auto-routing rewrites the request `model` to an upstream model ID.
- The request mutation code was split into smaller helpers to keep the behavior
  readable as provider-specific handling was added. The old function mixed JSON
  parsing, field normalization, enabled/disabled reasoning behavior, effort
  preservation, logging, and metrics in one nested block; the refactor keeps
  those steps separate while preserving the existing vLLM behavior.
- The remaining changed-file lint findings are limited to test-code function
  length in `req_filter_reason_test.go`. I think this is acceptable for the
  current PR scope; satisfying the lint rule would require restructuring that
  test file. Please confirm whether you want that test refactor included here.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
