### PR TITLE
[Router][CLI] restore hybrid_history retrieval wiring and advanced_filtering schema parity

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -117,7 +117,7 @@ func (r *OpenAIRouter) runSemanticToolSelection(
 	ctx *RequestContext,
 	toolsCfg *config.ToolsPluginConfig,
 ) error {
-	selectedTools, strategyID, confidence, latency, toolErr := r.findToolsForQuery(classificationText, historySummary, ctx, toolsCfg)
+	selectedTools, strategyID, confidence, latency, toolErr := r.findToolsForQuery(openAIRequest, classificationText, historySummary, ctx, toolsCfg)
 
 	emitToolObservability(response, strategyID, confidence, latency)
 	metrics.RecordToolsRetrieval(strategyID, latency.Seconds())
@@ -314,6 +314,7 @@ func (r *OpenAIRouter) executeRetrieval(ctx context.Context, strategyID string, 
 // retrieval, applies advanced filtering, and returns the final tool list together
 // with the strategy name, top-1 confidence score, and retrieval wall-clock time.
 func (r *OpenAIRouter) findToolsForQuery(
+	openAIRequest *openai.ChatCompletionNewParams,
 	query, historySummary string,
 	ctx *RequestContext,
 	toolsCfg *config.ToolsPluginConfig,
@@ -323,10 +324,11 @@ func (r *OpenAIRouter) findToolsForQuery(
 		topK = 3
 	}
 	advanced := mergeAdvancedToolFiltering(r.Config.Tools.AdvancedFiltering, toolsCfg)
-	return r.findToolsForQueryExt(query, historySummary, ctx, toolsCfg, topK, advanced, toolsCfg.EffectiveStrategy(), nil, r.Config.Tools.SimilarityThreshold)
+	return r.findToolsForQueryExt(openAIRequest, query, historySummary, ctx, toolsCfg, topK, advanced, toolsCfg.EffectiveStrategy(), nil, r.Config.Tools.SimilarityThreshold)
 }
 
 func (r *OpenAIRouter) findToolsForQueryExt(
+	openAIRequest *openai.ChatCompletionNewParams,
 	query, historySummary string,
 	ctx *RequestContext,
 	toolsCfg *config.ToolsPluginConfig,
@@ -362,6 +364,24 @@ func (r *OpenAIRouter) findToolsForQueryExt(
 
 	if advanced == nil || !advanced.Enabled {
 		return selectTopKTools(retrieved.Tools, topK), retrieved.StrategyID, retrieved.Confidence, latency, nil
+	}
+
+	if config.IsHybridHistoryRetrieval(advanced) {
+		transition := extractToolTransitionContextFromRequest(openAIRequest, config.ResolveHybridHistoryHorizon(advanced), ctx)
+		decisionConfidence := float64(0)
+		if ctx != nil {
+			decisionConfidence = float64(ctx.VSRSelectedDecisionConfidence)
+		}
+		selected := tools.FilterAndRankToolsWithConversation(
+			query,
+			retrieved.Tools,
+			topK,
+			advanced,
+			resolveCategory(advanced, ctx),
+			transition.RecentToolNames,
+			decisionConfidence,
+		)
+		return selected, retrieved.StrategyID, retrieved.Confidence, latency, nil
 	}
 
 	selected := tools.FilterAndRankTools(query, retrieved.Tools, topK, advanced, resolveCategory(advanced, ctx))

--- a/src/semantic-router/pkg/extproc/req_filter_tools_hybrid_history_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_hybrid_history_test.go
@@ -1,0 +1,153 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+)
+
+// hybridHistoryCandidate constructs a ToolSimilarity with the given name and
+// similarity score. Description is intentionally distinct from the test query
+// so lexical overlap stays zero and the weighted-mode score depends only on
+// the similarity component.
+func hybridHistoryCandidate(name string, similarity float32) tools.ToolSimilarity {
+	return tools.ToolSimilarity{
+		Entry: tools.ToolEntry{
+			Tool: openai.ChatCompletionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name: name,
+				},
+			},
+			Description: "irrelevant payload " + name,
+		},
+		Similarity: similarity,
+	}
+}
+
+// requestWithABAToolHistory builds a *ChatCompletionNewParams whose messages
+// carry an alternating assistant tool_call history of [toolA, toolB, toolA].
+// This is the minimum shape that gives historyTransitionScore a non-zero
+// (toolA -> toolB) edge to observe.
+func requestWithABAToolHistory(toolA, toolB string) *openai.ChatCompletionNewParams {
+	return &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("turn 1"),
+			assistantToolCallMessage(toolA),
+			openai.ToolMessage("result", "call-"+toolA),
+			openai.UserMessage("turn 2"),
+			assistantToolCallMessage(toolB),
+			openai.ToolMessage("result", "call-"+toolB),
+			openai.UserMessage("turn 3"),
+			assistantToolCallMessage(toolA),
+			openai.ToolMessage("result", "call-"+toolA),
+			openai.UserMessage("please continue the workflow"),
+		},
+	}
+}
+
+// TestFindToolsForQueryExt_HybridHistoryPromotesHistoryConsistentTool asserts
+// that the hybrid_history wiring is alive end-to-end inside extproc:
+// when retrieval_strategy=hybrid_history is configured and the request carries
+// an assistant tool_call history of [tool_a, tool_b, tool_a], the ranker must
+// promote tool_b (history-consistent next step) above tool_a despite tool_a
+// having a higher raw similarity score.
+//
+// Regression nail for the wiring lost in PR #1841: prior to restoring it,
+// findToolsForQueryExt called FilterAndRankTools with the conversation history
+// hard-coded to nil/0, so the strategy had no observable effect even when the
+// caller opted in via config.
+func TestFindToolsForQueryExt_HybridHistoryPromotesHistoryConsistentTool(t *testing.T) {
+	reg := tools.NewRegistry()
+	reg.Register("default", &stubRetriever{
+		strategyID: "default",
+		results: []tools.ToolSimilarity{
+			hybridHistoryCandidate("tool_a", 0.95), // higher sim, A->A is the unseen edge
+			hybridHistoryCandidate("tool_b", 0.55), // lower sim, A->B is the observed edge
+		},
+		confidence: 0.95,
+	})
+
+	router := makeToolsRouter(t, reg)
+	toolsCfg := makeToolsPluginConfig("default")
+	advanced := &config.AdvancedToolFilteringConfig{
+		Enabled:           true,
+		RetrievalStrategy: config.ToolRetrievalStrategyHybridHistory,
+	}
+
+	req := requestWithABAToolHistory("tool_a", "tool_b")
+
+	selected, _, _, _, err := router.findToolsForQueryExt(
+		req,
+		"please continue the workflow",
+		"",
+		&RequestContext{},
+		toolsCfg,
+		2,
+		advanced,
+		toolsCfg.EffectiveStrategy(),
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("findToolsForQueryExt returned unexpected error: %v", err)
+	}
+	if len(selected) != 2 {
+		t.Fatalf("expected 2 selected tools, got %d", len(selected))
+	}
+	if selected[0].Function.Name != "tool_b" {
+		t.Fatalf("hybrid_history must promote history-consistent tool_b above higher-similarity tool_a; got order [%q, %q]",
+			selected[0].Function.Name, selected[1].Function.Name)
+	}
+}
+
+// TestFindToolsForQueryExt_DefaultStrategyIgnoresToolHistory asserts that the
+// default (weighted/unset) retrieval path ignores assistant tool_call history
+// and ranks by similarity, matching pre-fix behavior. This pins down the
+// symmetric concern that a future change cannot accidentally flip the default
+// path into hybrid mode.
+func TestFindToolsForQueryExt_DefaultStrategyIgnoresToolHistory(t *testing.T) {
+	reg := tools.NewRegistry()
+	reg.Register("default", &stubRetriever{
+		strategyID: "default",
+		results: []tools.ToolSimilarity{
+			hybridHistoryCandidate("tool_a", 0.95),
+			hybridHistoryCandidate("tool_b", 0.55),
+		},
+		confidence: 0.95,
+	})
+
+	router := makeToolsRouter(t, reg)
+	toolsCfg := makeToolsPluginConfig("default")
+	advanced := &config.AdvancedToolFilteringConfig{
+		Enabled: true,
+		// RetrievalStrategy left empty -> EffectiveToolRetrievalStrategy returns "weighted"
+	}
+
+	req := requestWithABAToolHistory("tool_a", "tool_b")
+
+	selected, _, _, _, err := router.findToolsForQueryExt(
+		req,
+		"please continue the workflow",
+		"",
+		&RequestContext{},
+		toolsCfg,
+		2,
+		advanced,
+		toolsCfg.EffectiveStrategy(),
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("findToolsForQueryExt returned unexpected error: %v", err)
+	}
+	if len(selected) != 2 {
+		t.Fatalf("expected 2 selected tools, got %d", len(selected))
+	}
+	if selected[0].Function.Name != "tool_a" {
+		t.Fatalf("default (weighted) strategy must rank by similarity and ignore tool history; got order [%q, %q]",
+			selected[0].Function.Name, selected[1].Function.Name)
+	}
+}

--- a/src/semantic-router/pkg/extproc/req_tool_selection_plugin.go
+++ b/src/semantic-router/pkg/extproc/req_tool_selection_plugin.go
@@ -87,6 +87,7 @@ func (r *OpenAIRouter) runToolSelectionPluginAdd(
 	}
 
 	selectedTools, strategyOut, confidence, latency, toolErr := r.findToolsForQueryExt(
+		openAIRequest,
 		classificationText,
 		historySummary,
 		ctx,

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -530,6 +530,65 @@ class ToolsPluginConfig(BaseModel):
     block_tools: Optional[List[str]] = None
 
 
+class ToolFilteringWeights(BaseModel):
+    """Weights for tool_selection advanced_filtering combined score.
+
+    Mirrors the Go-side `config.ToolFilteringWeights`. All weights are optional
+    pointers on the Go side; non-negative is the only structural constraint.
+    Cross-field rules (e.g. weights-all-zero) are enforced by the Go validator.
+    """
+
+    embed: Optional[float] = Field(default=None, ge=0.0)
+    lexical: Optional[float] = Field(default=None, ge=0.0)
+    tag: Optional[float] = Field(default=None, ge=0.0)
+    name: Optional[float] = Field(default=None, ge=0.0)
+    category: Optional[float] = Field(default=None, ge=0.0)
+
+
+class HybridHistoryConfig(BaseModel):
+    """Sub-config for `retrieval_strategy: hybrid_history`.
+
+    Mirrors the Go-side `config.HybridHistoryToolRetrievalConfig`. Cross-field
+    semantic rules (e.g. min_history_steps > history_horizon) are enforced by
+    the Go validator; this layer only mirrors the schema surface so Pydantic
+    stops dropping the subtree.
+    """
+
+    history_horizon: Optional[int] = Field(default=None, ge=0)
+    min_history_steps: Optional[int] = Field(default=None, ge=0)
+    history_confidence_threshold: Optional[float] = Field(
+        default=None, ge=0.0, le=1.0
+    )
+    weight_semantic: Optional[float] = Field(default=None, ge=0.0)
+    weight_history_transition: Optional[float] = Field(default=None, ge=0.0)
+    weight_decision_prior: Optional[float] = Field(default=None, ge=0.0)
+    repetition_penalty_strength: Optional[float] = Field(default=None, ge=0.0)
+
+
+class AdvancedToolFilteringConfig(BaseModel):
+    """Advanced filtering layer applied on top of semantic retrieval.
+
+    Mirrors the Go-side `config.AdvancedToolFilteringConfig`. The Go side
+    treats `retrieval_strategy: hybrid_history` as opt-in; without this model
+    the nested subtree was silently dropped by Pydantic and the Go router
+    received an effectively empty advanced_filtering block.
+    """
+
+    enabled: Optional[bool] = None
+    retrieval_strategy: Optional[Literal["weighted", "hybrid_history"]] = None
+    candidate_pool_size: Optional[int] = Field(default=None, ge=0)
+    min_lexical_overlap: Optional[int] = Field(default=None, ge=0)
+    min_combined_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    weights: Optional[ToolFilteringWeights] = None
+    use_category_filter: Optional[bool] = None
+    category_confidence_threshold: Optional[float] = Field(
+        default=None, ge=0.0, le=1.0
+    )
+    allow_tools: Optional[List[str]] = None
+    block_tools: Optional[List[str]] = None
+    hybrid_history: Optional[HybridHistoryConfig] = None
+
+
 class ToolSelectionPluginConfig(BaseModel):
     """Configuration for tool_selection plugin (semantic add/filter on request tools)."""
 
@@ -542,6 +601,7 @@ class ToolSelectionPluginConfig(BaseModel):
     fallback_to_empty: Optional[bool] = None
     relevance_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     preserve_count: Optional[int] = Field(default=None, ge=0)
+    advanced_filtering: Optional[AdvancedToolFilteringConfig] = None
 
 
 class SystemPromptPluginConfig(BaseModel):

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -556,9 +556,7 @@ class HybridHistoryConfig(BaseModel):
 
     history_horizon: Optional[int] = Field(default=None, ge=0)
     min_history_steps: Optional[int] = Field(default=None, ge=0)
-    history_confidence_threshold: Optional[float] = Field(
-        default=None, ge=0.0, le=1.0
-    )
+    history_confidence_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     weight_semantic: Optional[float] = Field(default=None, ge=0.0)
     weight_history_transition: Optional[float] = Field(default=None, ge=0.0)
     weight_decision_prior: Optional[float] = Field(default=None, ge=0.0)
@@ -581,9 +579,7 @@ class AdvancedToolFilteringConfig(BaseModel):
     min_combined_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     weights: Optional[ToolFilteringWeights] = None
     use_category_filter: Optional[bool] = None
-    category_confidence_threshold: Optional[float] = Field(
-        default=None, ge=0.0, le=1.0
-    )
+    category_confidence_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     allow_tools: Optional[List[str]] = None
     block_tools: Optional[List[str]] = None
     hybrid_history: Optional[HybridHistoryConfig] = None

--- a/src/vllm-sr/tests/test_plugin_parsing.py
+++ b/src/vllm-sr/tests/test_plugin_parsing.py
@@ -11,6 +11,7 @@ from cli.models import (
     PluginType,
     RouterReplayPluginConfig,
     RAGPluginConfig,
+    ToolSelectionPluginConfig,
 )
 from cli.config_migration import migrate_config_data
 from cli.parser import parse_user_config
@@ -620,3 +621,69 @@ providers:
             assert any("rag" in msg.lower() for msg in error_messages)
         finally:
             os.unlink(temp_path)
+
+
+class TestToolSelectionAdvancedFiltering:
+    """Test tool_selection plugin's advanced_filtering subtree.
+
+    Pins down the schema parity with the Go-side
+    `config.AdvancedToolFilteringConfig`. Before this surface was modeled,
+    `ToolSelectionPluginConfig` had no `advanced_filtering` field and Pydantic
+    silently dropped the subtree, so users opting into
+    `retrieval_strategy: hybrid_history` ended up with a config equivalent to
+    no advanced filtering at all.
+    """
+
+    def test_hybrid_history_round_trips_without_field_loss(self):
+        """advanced_filtering.hybrid_history survives model_validate -> model_dump."""
+        cfg = ToolSelectionPluginConfig.model_validate(
+            {
+                "enabled": True,
+                "mode": "add",
+                "tools_db_path": "config/tools_db.json",
+                "top_k": 5,
+                "advanced_filtering": {
+                    "enabled": True,
+                    "retrieval_strategy": "hybrid_history",
+                    "hybrid_history": {
+                        "history_horizon": 8,
+                        "weight_history_transition": 2.0,
+                    },
+                },
+            }
+        )
+
+        dump = cfg.model_dump(exclude_none=True)
+        assert "advanced_filtering" in dump
+        assert dump["advanced_filtering"]["retrieval_strategy"] == "hybrid_history"
+        assert dump["advanced_filtering"]["hybrid_history"]["history_horizon"] == 8
+        assert (
+            dump["advanced_filtering"]["hybrid_history"]["weight_history_transition"]
+            == 2.0
+        )
+
+    def test_invalid_retrieval_strategy_rejected(self):
+        """retrieval_strategy must be 'weighted' or 'hybrid_history'."""
+        with pytest.raises(PydanticValidationError):
+            ToolSelectionPluginConfig.model_validate(
+                {
+                    "enabled": True,
+                    "advanced_filtering": {
+                        "enabled": True,
+                        "retrieval_strategy": "bogus",
+                    },
+                }
+            )
+
+    def test_invalid_threshold_rejected(self):
+        """category_confidence_threshold must be in [0.0, 1.0]."""
+        with pytest.raises(PydanticValidationError):
+            ToolSelectionPluginConfig.model_validate(
+                {
+                    "enabled": True,
+                    "advanced_filtering": {
+                        "enabled": True,
+                        "category_confidence_threshold": 1.5,
+                    },
+                }
+            )


### PR DESCRIPTION

Closes #1934

## Purpose

- What does this PR change?
  Restores the `hybrid_history` retrieval path end-to-end. Router-side: re-thread `*openai.ChatCompletionNewParams` into `findToolsForQueryExt` and call `tools.FilterAndRankToolsWithConversation` with `RecentToolNames` + `VSRSelectedDecisionConfidence` when `IsHybridHistoryRetrieval(advanced)`. CLI-side: extend `ToolSelectionPluginConfig` with `advanced_filtering` (backed by `AdvancedToolFilteringConfig` / `HybridHistoryConfig` / `ToolFilteringWeights`) so Pydantic stops dropping the subtree.

- Why is this change needed?
 See linked issue. Router wiring regressed in #1841; CLI gap was acknowledged in #1916 as a known follow-up.

- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

`Router`, `CLI`.

## Test Plan

- What commands, checks, or manual steps should reviewers use?

  Automated (Go):

  ```bash
  cd src/semantic-router
  go test ./pkg/extproc/... -run "TestRetrieverE2E|TestToolSelection|TestFindToolsForQueryExt" -count=1
  go test ./pkg/tools/... -count=1
  ```

  Reviewers should look for:

  - Both new cases in `req_filter_tools_hybrid_history_test.go` green: `TestFindToolsForQueryExt_HybridHistoryPromotesHistoryConsistentTool` proves the wiring is live; `TestFindToolsForQueryExt_DefaultStrategyIgnoresToolHistory` pins down that the default (weighted/unset) path stays byte-identical and cannot accidentally flip into hybrid mode.
  - `pkg/tools/hybrid_history_test.go` (8 pre-existing cases) untouched and passing — algorithm-side behavior unchanged.

  Automated (Python):

  ```bash
  cd src/vllm-sr
  pytest tests/test_plugin_parsing.py -v
  ```

  Reviewers should look for:

  - `TestToolSelectionAdvancedFiltering` (3 new cases) green: round-trip without field loss, invalid `retrieval_strategy` literal rejected, invalid `category_confidence_threshold` rejected.
  - Existing `TestToolSelectionPluginConfig` cases still green.


  Reviewers should look for:

  - `TestToolSelectionAdvancedFiltering` (3 new cases) green: round-trip without field loss, invalid `retrieval_strategy` literal rejected, invalid `category_confidence_threshold` rejected.
  - Existing `TestToolSelectionPluginConfig` cases still green.

- Why is this validation sufficient for the affected module(s)?

 Algorithm code in `pkg/tools/` is untouched and already covered by `pkg/tools/hybrid_history_test.go`. The new extproc-layer test pins the wiring that was lost in #1841 and asserts the default path does not regress, which is the exact surface this PR touches on the Router side. On the CLI side this only mirrors a Go-side schema in Pydantic; Go-side semantic rules (e.g. `weights` all-zero, `min_history_steps > history_horizon`) remain authoritative and are intentionally not duplicated here.

## Test Result

- What were the actual results?

  - Go: `pkg/extproc/...` with the targeted run filter — **7 passed** (5 pre-existing `TestRetrieverE2E_*` / `TestToolSelection*` cases + 2 new `TestFindToolsForQueryExt_*` cases).
  - Python: `pytest tests/test_plugin_parsing.py` — **18 passed** (15 pre-existing + 3 new `TestToolSelectionAdvancedFiltering` cases).
  - Pydantic round-trip on the issue's minimal repro: `advanced_filtering.hybrid_history` now survives `model_validate -> model_dump` instead of being silently dropped.

- Any follow-up risks, gaps, or blockers?

  - **No known blockers.** `extractToolTransitionContextFromRequest` already had unit coverage from #1856; this PR re-attaches its only intended production caller. Default `retrieval_strategy` paths are byte-equivalent to today.



---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
