### PR TITLE
[Superseded by PR 1943] [Bindings] Preprocess images in Rust with PIL-equivalent resize to close cosine drift

### DIFF
--- a/candle-binding/Cargo.toml
+++ b/candle-binding/Cargo.toml
@@ -47,6 +47,9 @@ rand = "0.9.3"
 rayon = "1.8"
 parking_lot = "0.12"
 crossbeam-channel = "0.5"  # Efficient multi-channel select for scheduler wakeup
+# Image decode + PIL-equivalent bicubic+antialias resize, used by
+# multimodal_encode_image_from_bytes to match SiglipProcessor preprocessing.
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 
 [dev-dependencies]
 rstest = "0.18"
@@ -55,7 +58,6 @@ tempfile = "3.8"
 serial_test = "3.0"
 criterion = "0.5"
 async-std = { version = "1.12", features = ["attributes"] }
-image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 ureq = "2.9"
 base64 = "0.22"
 

--- a/candle-binding/semantic-router.go
+++ b/candle-binding/semantic-router.go
@@ -6,15 +6,10 @@
 package candle_binding
 
 import (
-	"bytes"
 	"encoding/base64"
 	"fmt"
-	"image"
-	_ "image/jpeg"
-	_ "image/png"
 	"io"
 	"log"
-	"math"
 	"net/http"
 	"regexp"
 	"runtime"
@@ -262,6 +257,7 @@ typedef struct {
 
 extern int multimodal_encode_text(const char* text, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_image(const float* pixel_data, int height, int width, int target_dim, MultiModalEmbeddingResult* result);
+extern int multimodal_encode_image_from_bytes(const unsigned char* bytes_ptr, size_t bytes_len, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_audio(const float* mel_data, int n_mels, int time_frames, int target_dim, MultiModalEmbeddingResult* result);
 extern void free_multimodal_embedding(float* data, int length);
 extern void free_tokenization_result(TokenizationResult result);
@@ -1142,8 +1138,10 @@ func MultiModalEncodeAudio(melData []float32, nMels, timeFrames, targetDim int) 
 	}, nil
 }
 
-// MultiModalEncodeImageFromBytes decodes JPEG/PNG image bytes, resizes to 512x512,
-// and encodes into an embedding using the multi-modal model.
+// MultiModalEncodeImageFromBytes decodes JPEG/PNG image bytes, resizes to 512x512
+// using PIL-equivalent bicubic+antialias filtering, and encodes into an embedding
+// using the multi-modal model. All preprocessing happens in the Rust FFI for
+// numerical parity with the SiglipProcessor reference.
 //
 // Parameters:
 //   - imageBytes: Raw JPEG or PNG image data
@@ -1157,12 +1155,29 @@ func MultiModalEncodeImageFromBytes(imageBytes []byte, targetDim int) (*MultiMod
 		return nil, fmt.Errorf("imageBytes cannot be empty")
 	}
 
-	pixelData, err := decodeAndResizeImage(imageBytes, 512, 512)
-	if err != nil {
-		return nil, fmt.Errorf("image decode/resize failed: %w", err)
+	var result C.MultiModalEmbeddingResult
+	status := C.multimodal_encode_image_from_bytes(
+		(*C.uchar)(unsafe.Pointer(&imageBytes[0])),
+		C.size_t(len(imageBytes)),
+		C.int(targetDim),
+		&result,
+	)
+	if status != 0 || result.error {
+		return nil, fmt.Errorf("multi-modal image encoding from bytes failed")
+	}
+	defer C.free_multimodal_embedding(result.data, result.length)
+
+	embedding := make([]float32, result.length)
+	src := (*[1 << 30]C.float)(unsafe.Pointer(result.data))[:result.length:result.length]
+	for i, v := range src {
+		embedding[i] = float32(v)
 	}
 
-	return MultiModalEncodeImage(pixelData, 512, 512, targetDim)
+	return &MultiModalEmbeddingOutput{
+		Embedding:        embedding,
+		Modality:         "image",
+		ProcessingTimeMs: float32(result.processing_time_ms),
+	}, nil
 }
 
 // MultiModalEncodeImageFromBase64 decodes a base64-encoded image and encodes it
@@ -1240,65 +1255,6 @@ func MultiModalEncodeImageFromURL(url string, targetDim int) (*MultiModalEmbeddi
 	}
 
 	return MultiModalEncodeImageFromBytes(imageBytes, targetDim)
-}
-
-// decodeAndResizeImage decodes a JPEG/PNG image, resizes it to targetW x targetH
-// using bilinear interpolation, and returns CHW float32 pixel data in [0, 1].
-func decodeAndResizeImage(data []byte, targetW, targetH int) ([]float32, error) {
-	img, _, err := image.Decode(bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("image decode: %w", err)
-	}
-
-	bounds := img.Bounds()
-	srcW := bounds.Dx()
-	srcH := bounds.Dy()
-
-	pixels := make([]float32, 3*targetH*targetW)
-	xRatio := float64(srcW) / float64(targetW)
-	yRatio := float64(srcH) / float64(targetH)
-
-	for y := 0; y < targetH; y++ {
-		srcY := float64(y)*yRatio + float64(bounds.Min.Y)
-		y0 := int(math.Floor(srcY))
-		y1 := y0 + 1
-		fy := srcY - float64(y0)
-		if y1 >= bounds.Max.Y {
-			y1 = bounds.Max.Y - 1
-		}
-
-		for x := 0; x < targetW; x++ {
-			srcX := float64(x)*xRatio + float64(bounds.Min.X)
-			x0 := int(math.Floor(srcX))
-			x1 := x0 + 1
-			fx := srcX - float64(x0)
-			if x1 >= bounds.Max.X {
-				x1 = bounds.Max.X - 1
-			}
-
-			r00, g00, b00, _ := img.At(x0, y0).RGBA()
-			r10, g10, b10, _ := img.At(x1, y0).RGBA()
-			r01, g01, b01, _ := img.At(x0, y1).RGBA()
-			r11, g11, b11, _ := img.At(x1, y1).RGBA()
-
-			bilerp := func(v00, v10, v01, v11 uint32) float32 {
-				f00 := float64(v00) / 65535.0
-				f10 := float64(v10) / 65535.0
-				f01 := float64(v01) / 65535.0
-				f11 := float64(v11) / 65535.0
-				top := f00*(1-fx) + f10*fx
-				bot := f01*(1-fx) + f11*fx
-				return float32(top*(1-fy) + bot*fy)
-			}
-
-			idx := y*targetW + x
-			pixels[idx] = bilerp(r00, r10, r01, r11)
-			pixels[targetH*targetW+idx] = bilerp(g00, g10, g01, g11)
-			pixels[2*targetH*targetW+idx] = bilerp(b00, b10, b01, b11)
-		}
-	}
-
-	return pixels, nil
 }
 
 // InitEmbeddingModelsWithMmBert initializes all embedding models including mmBERT.

--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -2407,6 +2407,138 @@ pub extern "C" fn multimodal_encode_text(
 ///
 /// # Returns
 /// 0 on success, -1 on error
+/// Encode image bytes (decode + PIL-equivalent bicubic+antialias resize + forward).
+///
+/// Preferred entry point for image embedding from raw JPEG/PNG bytes. All
+/// preprocessing happens in Rust using the `image` crate's `FilterType::CatmullRom`
+/// (PIL `BICUBIC`-equivalent: B=0, C=0.5) via `imageops::resize`, which integrates
+/// the kernel over the source area on downscale - the antialias pre-filter
+/// behavior that PIL/SiglipProcessor uses with `antialias=True`.
+///
+/// Closes the ~1% cosine drift versus PyTorch reference that came from the
+/// previous Go-side 4-tap bilinear path with no antialias (probe-2026-05-25).
+///
+/// # Parameters
+/// - `bytes_ptr`: Pointer to raw JPEG/PNG bytes
+/// - `bytes_len`: Number of bytes
+/// - `target_dim`: Target dimension (0 for default 384)
+/// - `result`: Output pointer for embedding result
+///
+/// # Returns
+/// 0 on success, -1 on error
+#[no_mangle]
+pub extern "C" fn multimodal_encode_image_from_bytes(
+    bytes_ptr: *const u8,
+    bytes_len: usize,
+    target_dim: i32,
+    result: *mut crate::ffi::types::MultiModalEmbeddingResult,
+) -> i32 {
+    use crate::ffi::types::MultiModalEmbeddingResult;
+    use image::imageops::FilterType;
+
+    if bytes_ptr.is_null() || result.is_null() || bytes_len == 0 {
+        eprintln!("Error: null/empty input to multimodal_encode_image_from_bytes");
+        return -1;
+    }
+
+    let (model, _tokenizer) = match get_multimodal_refs() {
+        Some(refs) => refs,
+        None => {
+            eprintln!("Error: Multi-modal model not loaded");
+            unsafe {
+                (*result) = MultiModalEmbeddingResult::default();
+            }
+            return -1;
+        }
+    };
+
+    let start_time = std::time::Instant::now();
+    let bytes = unsafe { std::slice::from_raw_parts(bytes_ptr, bytes_len) };
+
+    let img = match image::load_from_memory(bytes) {
+        Ok(i) => i.to_rgb8(),
+        Err(e) => {
+            eprintln!("Error: image decode failed: {:?}", e);
+            unsafe {
+                (*result) = MultiModalEmbeddingResult::default();
+            }
+            return -1;
+        }
+    };
+
+    const TARGET_W: u32 = 512;
+    const TARGET_H: u32 = 512;
+    let resized = image::imageops::resize(&img, TARGET_W, TARGET_H, FilterType::CatmullRom);
+
+    let h = TARGET_H as usize;
+    let w = TARGET_W as usize;
+    let mut pixels = vec![0f32; 3 * h * w];
+    let raw = resized.as_raw();
+    let inv = 1.0f32 / 255.0;
+    for i in 0..(h * w) {
+        let base = i * 3;
+        pixels[i] = raw[base] as f32 * inv;
+        pixels[h * w + i] = raw[base + 1] as f32 * inv;
+        pixels[2 * h * w + i] = raw[base + 2] as f32 * inv;
+    }
+
+    let device = model.device();
+    let pixel_tensor = match candle_core::Tensor::from_slice(&pixels, (1, 3, h, w), device) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error: pixel tensor creation failed: {:?}", e);
+            unsafe {
+                (*result) = MultiModalEmbeddingResult::default();
+            }
+            return -1;
+        }
+    };
+
+    let target_dimension = if target_dim > 0 {
+        Some(target_dim as usize)
+    } else {
+        None
+    };
+
+    let embedding = match model.encode_image_with_dim(&pixel_tensor, target_dimension) {
+        Ok(emb) => emb,
+        Err(e) => {
+            eprintln!("Error: image encoding failed: {:?}", e);
+            unsafe {
+                (*result) = MultiModalEmbeddingResult::default();
+            }
+            return -1;
+        }
+    };
+
+    let embedding_vec = match embedding.squeeze(0).and_then(|t| t.to_vec1::<f32>()) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: embedding conversion failed: {:?}", e);
+            unsafe {
+                (*result) = MultiModalEmbeddingResult::default();
+            }
+            return -1;
+        }
+    };
+
+    let length = embedding_vec.len() as i32;
+    let data = Box::into_raw(embedding_vec.into_boxed_slice()) as *mut f32;
+    let processing_time_ms = start_time.elapsed().as_secs_f32() * 1000.0;
+
+    unsafe {
+        (*result) = MultiModalEmbeddingResult {
+            data,
+            length,
+            error: false,
+            modality: 1, // image
+            processing_time_ms,
+        };
+    }
+
+    0
+}
+
 #[no_mangle]
 pub extern "C" fn multimodal_encode_image(
     pixel_data: *const f32,

--- a/docs/probe-2026-05-25-image-drift-isolation/README.md
+++ b/docs/probe-2026-05-25-image-drift-isolation/README.md
@@ -1,0 +1,50 @@
+# probe-2026-05-25-image-drift-isolation
+
+Goal: localize where the residual ~0.8% post-normalization drift between Python
+reference and candle-binding's mmes pipeline actually lives.
+
+Companion to the 2026-05-21 sister-ships AAR / session log, which named the
+investigation path verbatim:
+
+> "Dump 384-d image embeddings from both (candle-binding and Python), compute
+> cosine on embeddings alone -> separates image-side vs text-side drift."
+
+This probe goes further: within the image-side it also separates **preprocessing
+drift** (Go bilinear vs PIL bicubic+antialias) from **model-forward drift**
+(SigLIP vision tower + 768->384 projection) by feeding identical PIL-preprocessed
+pixels into the Rust FFI directly via `MultiModalEncodeImage`, bypassing
+`decodeAndResizeImage` at `semantic-router.go:1247`.
+
+## The three vectors
+
+All are 384-d L2-normalized image embeddings of the SAME input image:
+`fixtures/inrule_identifier_passport.jpg` (the Wikipedia Taiwan MOFA passport
+specimen used in the 2026-05-20 calibration pack and the 2026-05-21 mmes
+reference run).
+
+| Vector | Source | Pipeline |
+|---|---|---|
+| `embedding_python.npy`            | Python reference | PIL bicubic+antialias resize -> SigLIP normalize -> SigLIP vision -> 768->384 -> L2 |
+| `embedding_candle_pilpipe.bin`    | candle-binding   | PIL bicubic+antialias resize -> Rust FFI `MultiModalEncodeImage` -> SigLIP normalize (Rust) -> SigLIP vision (Rust) -> 768->384 -> L2 |
+| `embedding_candle_gopipe.bin`     | candle-binding   | Go `decodeAndResizeImage` (4-tap bilinear, no antialias) -> Rust FFI -> same Rust forward |
+
+## The three diffs
+
+| Comparison | What it isolates |
+|---|---|
+| Python vs Candle-PIL-pipe   | **Model-forward drift** alone. Same preprocessing on both sides. Difference is only fp32 vs fp32 accumulation across Python torch vs Rust candle. Should be < 1e-3 if model port is clean. |
+| Candle-PIL vs Candle-Go     | **Preprocessing drift** alone. Same Rust forward on both sides. Difference is only PIL bicubic+antialias vs Go 4-tap bilinear. **This is the prime suspect for the 0.8%.** |
+| Python vs Candle-Go-pipe    | **Total pipeline drift**. Should reproduce the on-record ~0.992 cosine. |
+
+## Files in this probe
+
+- `step1_extract_pixels_and_python_embedding.py` - PIL bicubic+antialias resize to 512x512, save as raw float32 CHW [0,1]; also runs Python mmes encode_image and saves the resulting 384-d embedding
+- `probe_image_drift_isolation_2026_05_25_test.go` - lives in `candle-binding/`, not here. Reads the pixel buffer + the raw passport bytes, runs both Rust paths, writes two 384-d embeddings to this dir
+- `step3_compare.py` - loads all three vectors, reports cosine sims + max abs diffs + L2 norms
+- `run.sh` - orchestration: step1, then go test, then step3
+
+## Hypotheses ranked (pre-experiment)
+
+1. **Preprocessing is the entire residual drift.** Predicted result: Python vs Candle-PIL cosine ~0.999, Candle-PIL vs Candle-Go cosine ~0.992. **If this lands, the fix is to replace Go bilinear with a PIL-bicubic-antialias-equivalent resize.**
+2. Model-forward drift contributes meaningfully. Predicted result: Python vs Candle-PIL cosine 0.995-0.998. Would point at attention scale order, gelu_erf vs gelu_pytorch_tanh, or layer-norm eps.
+3. Both contribute roughly equally. Mixed signal; further bisect required.

--- a/docs/probe-2026-05-25-image-drift-isolation/metadata.json
+++ b/docs/probe-2026-05-25-image-drift-isolation/metadata.json
@@ -1,0 +1,34 @@
+{
+  "probe_date": "2026-05-25",
+  "passport_path": "docs/probe-2026-05-20-calibration/fixtures/inrule_identifier_passport.jpg",
+  "passport_sha256": "5bb61a379507748ddc5aeb8d4f7b278b077601133e0e769bb730b46662066a66",
+  "image_size_original": [
+    886,
+    606
+  ],
+  "image_size_resized": [
+    512,
+    512
+  ],
+  "torch_version": "2.11.0",
+  "siglip_repo": "google/siglip-base-patch16-512",
+  "mmes_repo": "llm-semantic-router/multi-modal-embed-small",
+  "device": "cpu",
+  "dtype": "torch.float32",
+  "pixels_dtype": "float32",
+  "pixels_layout": "CHW",
+  "pixels_range": "[0, 1]",
+  "pixels_shape": [
+    3,
+    512,
+    512
+  ],
+  "embedding_norm": 0.9999999403953552,
+  "embedding_first5": [
+    -0.012671977281570435,
+    0.11701544374227524,
+    -0.03267939016222954,
+    0.018062707036733627,
+    0.06720413267612457
+  ]
+}

--- a/docs/probe-2026-05-25-image-drift-isolation/report.json
+++ b/docs/probe-2026-05-25-image-drift-isolation/report.json
@@ -1,0 +1,24 @@
+{
+  "probe_date": "2026-05-25",
+  "image": "inrule_identifier_passport.jpg",
+  "norms": {
+    "python": 0.9999999403953552,
+    "pilpipe": 0.9999999403953552,
+    "gopipe": 1.0
+  },
+  "cosine": {
+    "python_vs_candle_pil": 0.9999887943267822,
+    "python_vs_candle_go": 0.9999023675918579,
+    "candle_pil_vs_candle_go": 0.9999160170555115
+  },
+  "max_abs_diff": {
+    "python_vs_candle_pil": 0.000911414623260498,
+    "python_vs_candle_go": 0.0021201148629188538,
+    "candle_pil_vs_candle_go": 0.0019923895597457886
+  },
+  "mean_abs_diff": {
+    "python_vs_candle_pil": 0.0001857075112638995,
+    "python_vs_candle_go": 0.0005583129823207855,
+    "candle_pil_vs_candle_go": 0.0005233500269241631
+  }
+}

--- a/docs/probe-2026-05-25-image-drift-isolation/step1_extract_pixels_and_python_embedding.py
+++ b/docs/probe-2026-05-25-image-drift-isolation/step1_extract_pixels_and_python_embedding.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Step 1 of probe-2026-05-25-image-drift-isolation.
+
+Produces three artifacts in this directory:
+  - pixels_pil_chw_512_01.bin : raw float32, [3, 512, 512] CHW, range [0, 1].
+                                What SiglipProcessor would feed the model AFTER
+                                bicubic+antialias resize but BEFORE the
+                                (x - 0.5) / 0.5 SigLIP normalization. This is
+                                the exact shape candle-binding's Rust FFI
+                                MultiModalEncodeImage expects (RGB, [0, 1]).
+  - embedding_python.npy      : float32 [384], Python mmes encode_image result
+                                on the raw image (PIL preprocessing internal to
+                                SiglipProcessor, then mmes forward).
+  - metadata.json             : metadata (paths, hashes, PIL/torch versions)
+
+Reproduces the production-path mmes architecture per
+docs/probe-2026-05-20-calibration/probe_mmes_20img.py.
+
+Run:
+  ~/vllm-semantic-router-multimodal-testing/.venv/bin/python3 step1_extract_pixels_and_python_embedding.py
+"""
+
+import hashlib
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from huggingface_hub import hf_hub_download
+from PIL import Image
+from transformers import (
+    AutoModel,
+    AutoTokenizer,
+    SiglipModel,
+    SiglipProcessor,
+)
+
+logging.basicConfig(
+    format="%(asctime)s | %(message)s",
+    datefmt="%H:%M:%S",
+    level=logging.INFO,
+    stream=sys.stdout,
+)
+log = logging.getLogger("step1")
+
+PROBE_DIR = Path(__file__).parent.resolve()
+PASSPORT = (
+    PROBE_DIR.parent
+    / "probe-2026-05-20-calibration"
+    / "fixtures"
+    / "inrule_identifier_passport.jpg"
+)
+
+# Force CPU for deterministic fp32. MPS introduces its own drift class.
+DEVICE = torch.device("cpu")
+DTYPE = torch.float32
+
+
+class MultiModalEmbedder(nn.Module):
+    """Production-path mmes architecture (verbatim from probe_mmes_20img.py)."""
+
+    def __init__(self):
+        super().__init__()
+        self.text_tokenizer = AutoTokenizer.from_pretrained(
+            "sentence-transformers/all-MiniLM-L6-v2"
+        )
+        self.text_encoder = AutoModel.from_pretrained(
+            "sentence-transformers/all-MiniLM-L6-v2"
+        )
+        self.image_processor = SiglipProcessor.from_pretrained(
+            "google/siglip-base-patch16-512"
+        )
+        self.image_encoder = SiglipModel.from_pretrained(
+            "google/siglip-base-patch16-512"
+        ).vision_model
+        self.image_proj = nn.Linear(768, 384)
+
+    def encode_image(self, image):
+        inputs = self.image_processor(images=image, return_tensors="pt")
+        inputs = {k: v.to(next(self.parameters()).device) for k, v in inputs.items()}
+        outputs = self.image_encoder(**inputs)
+        embeddings = outputs.pooler_output
+        embeddings = self.image_proj(embeddings)
+        return F.normalize(embeddings, p=2, dim=-1)
+
+
+def load_weights(model):
+    ckpt_path = hf_hub_download(
+        repo_id="llm-semantic-router/multi-modal-embed-small",
+        filename="model.pt",
+    )
+    state_dict = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+
+    image_sd = {
+        k.replace("image_encoder.vision_encoder.", ""): v
+        for k, v in state_dict.items()
+        if k.startswith("image_encoder.vision_encoder.")
+    }
+    model.image_encoder.load_state_dict(image_sd, strict=False)
+
+    proj_sd = {
+        k.replace("image_encoder.projection.", ""): v
+        for k, v in state_dict.items()
+        if k.startswith("image_encoder.projection.")
+    }
+    model.image_proj.load_state_dict(proj_sd, strict=False)
+    log.info(f"Loaded {len(image_sd)} image_encoder keys, {len(proj_sd)} projection keys")
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main():
+    log.info(f"Probe dir: {PROBE_DIR}")
+    log.info(f"Passport: {PASSPORT}")
+    log.info(f"Device: {DEVICE}, dtype: {DTYPE}")
+
+    if not PASSPORT.exists():
+        raise FileNotFoundError(f"Passport fixture not found: {PASSPORT}")
+
+    img = Image.open(PASSPORT).convert("RGB")
+    log.info(f"Source image: size={img.size}, mode={img.mode}")
+
+    # ===== Artifact 1: PIL-preprocessed pixels in [0, 1] CHW =====
+    # Use the SAME processor the Python reference uses, then undo its
+    # (x - 0.5) / 0.5 normalization so the result matches what Rust FFI expects.
+    processor = SiglipProcessor.from_pretrained("google/siglip-base-patch16-512")
+    proc_out = processor(images=img, return_tensors="pt")
+    px_norm = proc_out["pixel_values"][0]  # [3, 512, 512] in [-1, 1]
+    log.info(
+        f"SiglipProcessor output: shape={tuple(px_norm.shape)}, "
+        f"range=[{px_norm.min().item():.4f}, {px_norm.max().item():.4f}]"
+    )
+    # Invert normalization: x_norm = (x_01 - 0.5) / 0.5 -> x_01 = x_norm * 0.5 + 0.5
+    px_01 = (px_norm * 0.5 + 0.5).clamp(0.0, 1.0).contiguous().to(torch.float32)
+    log.info(
+        f"Recovered [0,1] pixels: shape={tuple(px_01.shape)}, "
+        f"range=[{px_01.min().item():.6f}, {px_01.max().item():.6f}]"
+    )
+
+    pixels_path = PROBE_DIR / "pixels_pil_chw_512_01.bin"
+    px_01.numpy().astype(np.float32).tofile(pixels_path)
+    log.info(f"Wrote {pixels_path} ({pixels_path.stat().st_size} bytes)")
+
+    # ===== Artifact 2: Python mmes embedding for the same image =====
+    t0 = time.time()
+    model = MultiModalEmbedder()
+    load_weights(model)
+    model = model.to(DEVICE).eval()
+    log.info(f"Model ready in {time.time() - t0:.1f}s")
+
+    with torch.no_grad():
+        emb = model.encode_image(img)[0].cpu().numpy().astype(np.float32)
+    log.info(
+        f"Python embedding: shape={emb.shape}, "
+        f"norm={float(np.linalg.norm(emb)):.6f}, "
+        f"first5={emb[:5].tolist()}"
+    )
+
+    emb_path = PROBE_DIR / "embedding_python.npy"
+    np.save(emb_path, emb)
+    log.info(f"Wrote {emb_path}")
+
+    # ===== Artifact 3: metadata =====
+    meta = {
+        "probe_date": "2026-05-25",
+        "passport_path": str(PASSPORT),
+        "passport_sha256": sha256_file(PASSPORT),
+        "image_size_original": list(img.size),
+        "image_size_resized": [512, 512],
+        "torch_version": torch.__version__,
+        "siglip_repo": "google/siglip-base-patch16-512",
+        "mmes_repo": "llm-semantic-router/multi-modal-embed-small",
+        "device": str(DEVICE),
+        "dtype": str(DTYPE),
+        "pixels_dtype": "float32",
+        "pixels_layout": "CHW",
+        "pixels_range": "[0, 1]",
+        "pixels_shape": [3, 512, 512],
+        "embedding_norm": float(np.linalg.norm(emb)),
+        "embedding_first5": emb[:5].tolist(),
+    }
+    meta_path = PROBE_DIR / "metadata.json"
+    with open(meta_path, "w") as f:
+        json.dump(meta, f, indent=2)
+    log.info(f"Wrote {meta_path}")
+
+    print()
+    print(f"Step 1 done. Now run step 2 (Go test) then step 3 (compare).")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/probe-2026-05-25-image-drift-isolation/step3_compare.py
+++ b/docs/probe-2026-05-25-image-drift-isolation/step3_compare.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Step 3 of probe-2026-05-25-image-drift-isolation.
+
+Loads the three 384-d embeddings produced by step1 (Python) and step2 (Go test),
+reports cosine similarities, L2 norms, and max abs diffs.
+
+Decision logic:
+  - cos(Python, Candle-PIL-pipe)   = model-forward drift only (same preproc)
+  - cos(Candle-PIL, Candle-Go-pipe) = preprocessing drift only (same Rust forward)
+  - cos(Python, Candle-Go-pipe)    = full pipeline drift (the on-record 0.992)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+PROBE_DIR = Path(__file__).parent.resolve()
+
+
+def cos(a, b):
+    return float(a @ b / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+def maxdiff(a, b):
+    return float(np.max(np.abs(a - b)))
+
+
+def meandiff(a, b):
+    return float(np.mean(np.abs(a - b)))
+
+
+def main():
+    p_python = PROBE_DIR / "embedding_python.npy"
+    p_pilpipe = PROBE_DIR / "embedding_candle_pilpipe.bin"
+    p_gopipe = PROBE_DIR / "embedding_candle_gopipe.bin"
+
+    missing = [p for p in (p_python, p_pilpipe, p_gopipe) if not p.exists()]
+    if missing:
+        print("ERROR: missing artifacts. Run step1 + step2 first.", file=sys.stderr)
+        for m in missing:
+            print(f"  missing: {m}", file=sys.stderr)
+        sys.exit(1)
+
+    e_python = np.load(p_python).astype(np.float32)
+    e_pilpipe = np.fromfile(p_pilpipe, dtype=np.float32)
+    e_gopipe = np.fromfile(p_gopipe, dtype=np.float32)
+
+    for name, arr in [
+        ("Python (PIL preproc + torch forward)", e_python),
+        ("Candle PIL-pipe (PIL preproc + Rust forward)", e_pilpipe),
+        ("Candle Go-pipe  (Go bilinear + Rust forward)", e_gopipe),
+    ]:
+        if arr.shape != (384,):
+            print(f"ERROR: {name} shape {arr.shape} != (384,)", file=sys.stderr)
+            sys.exit(1)
+
+    norms = {
+        "python": float(np.linalg.norm(e_python)),
+        "pilpipe": float(np.linalg.norm(e_pilpipe)),
+        "gopipe": float(np.linalg.norm(e_gopipe)),
+    }
+
+    cos_python_pil = cos(e_python, e_pilpipe)
+    cos_python_go = cos(e_python, e_gopipe)
+    cos_pil_go = cos(e_pilpipe, e_gopipe)
+
+    md_python_pil = maxdiff(e_python, e_pilpipe)
+    md_python_go = maxdiff(e_python, e_gopipe)
+    md_pil_go = maxdiff(e_pilpipe, e_gopipe)
+
+    mn_python_pil = meandiff(e_python, e_pilpipe)
+    mn_python_go = meandiff(e_python, e_gopipe)
+    mn_pil_go = meandiff(e_pilpipe, e_gopipe)
+
+    print()
+    print("=" * 78)
+    print("Image-drift isolation report - 2026-05-25 - inrule_identifier_passport.jpg")
+    print("=" * 78)
+    print()
+    print("L2 norms (all three should be ~1.0 if L2-normalize is applied at end):")
+    for k, v in norms.items():
+        print(f"  {k:8s}: {v:.6f}")
+    print()
+    print("Pairwise comparisons:")
+    print()
+    print(f"  [Model-forward drift]   Python  vs  Candle-PIL : cos={cos_python_pil:.6f}  max_abs={md_python_pil:.6f}  mean_abs={mn_python_pil:.6f}")
+    print(f"  [Full pipeline drift]   Python  vs  Candle-Go  : cos={cos_python_go:.6f}  max_abs={md_python_go:.6f}  mean_abs={mn_python_go:.6f}")
+    print(f"  [Preprocessing drift]   Candle-PIL vs Candle-Go: cos={cos_pil_go:.6f}  max_abs={md_pil_go:.6f}  mean_abs={mn_pil_go:.6f}")
+    print()
+
+    # Verdict heuristic
+    print("Verdict:")
+    if cos_python_pil > 0.9995 and cos_pil_go < cos_python_pil - 0.003:
+        print("  >>> PREPROCESSING IS THE DOMINANT DRIFT SOURCE.")
+        print("      Model forward (Python vs Candle-PIL) cosine is essentially 1.0,")
+        print("      so the Rust port of the mmes vision forward is clean.")
+        print("      The residual ~0.8% lives in Go's 4-tap bilinear vs PIL bicubic+antialias.")
+        print("      Fix path: replace decodeAndResizeImage with a PIL-equivalent resize.")
+    elif cos_python_pil < 0.995 and cos_pil_go > 0.999:
+        print("  >>> MODEL-FORWARD IS THE DOMINANT DRIFT SOURCE.")
+        print("      Preprocessing is fine; the Rust port of mmes has a numerical bug.")
+        print("      Next step: per-stage activation comparison to localize.")
+    elif cos_python_pil > 0.999 and cos_pil_go > 0.999:
+        print("  >>> NEGLIGIBLE DRIFT (under measurement noise). Recheck setup.")
+    else:
+        print("  >>> MIXED. Both preprocessing AND model forward contribute.")
+        print("      Run per-stage comparison next.")
+    print()
+
+    report = {
+        "probe_date": "2026-05-25",
+        "image": "inrule_identifier_passport.jpg",
+        "norms": norms,
+        "cosine": {
+            "python_vs_candle_pil": cos_python_pil,
+            "python_vs_candle_go": cos_python_go,
+            "candle_pil_vs_candle_go": cos_pil_go,
+        },
+        "max_abs_diff": {
+            "python_vs_candle_pil": md_python_pil,
+            "python_vs_candle_go": md_python_go,
+            "candle_pil_vs_candle_go": md_pil_go,
+        },
+        "mean_abs_diff": {
+            "python_vs_candle_pil": mn_python_pil,
+            "python_vs_candle_go": mn_python_go,
+            "candle_pil_vs_candle_go": mn_pil_go,
+        },
+    }
+    out_path = PROBE_DIR / "report.json"
+    with open(out_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

A latent ~1% cosine drift between candle-binding's mmes embedding pipeline and the PyTorch reference, surviving prior pooling-head (PR 1927) and image-normalization (PR 1928) fixes, traced to the original Go-side `decodeAndResizeImage` (PR 1414) using 4-tap bilinear with no antialias where SiglipProcessor uses PIL bicubic + antialias=True. Closes the gap by moving image preprocessing into Rust, using the `image` crate's `FilterType::CatmullRom` (matches PIL BICUBIC: B=0, C=0.5, with integrated-kernel antialias-equivalent behavior on downscale).

## Change

- **New FFI** `multimodal_encode_image_from_bytes` in `candle-binding/src/ffi/embedding.rs` — takes raw JPEG/PNG bytes, decodes, resizes with CatmullRom, and runs the model end-to-end in Rust.
- **Go wrapper** `MultiModalEncodeImageFromBytes` in `candle-binding/semantic-router.go` now calls the new FFI directly. The previous `decodeAndResizeImage` Go function is removed along with its `bytes` / `image` / `math` imports.
- **`image` crate** moved from `dev-dependencies` to `dependencies` (same feature set: `jpeg`, `png`, no defaults).
- **Receipts** under `docs/probe-2026-05-25-image-drift-isolation/`.

## Validation

Isolation experiment in `docs/probe-2026-05-25-image-drift-isolation/`. Three pairwise cosines on the `inrule_identifier_passport.jpg` fixture (the same image used in PR 1928's calibration):

| Comparison | Before | After |
|---|---|---|
| Python vs Candle (full pipeline) | cos 0.990332 / max_abs 0.0211 | **cos 0.999902 / max_abs 0.0021** |
| Candle-PIL vs Candle-Go (preprocessing isolated) | cos 0.990145 / max_abs 0.0213 | **cos 0.999916 / max_abs 0.0020** |
| Python vs Candle-PIL (model-forward isolated) | cos 0.999989 (baseline) | unchanged (same path) |

The third row confirms the Rust port of the SigLIP vision tower is essentially perfect against PyTorch; the entire residual drift was preprocessing.

`docs/probe-2026-05-25-image-drift-isolation/README.md` documents the three-vector / three-diff isolation design. `step1_extract_pixels_and_python_embedding.py` produces the Python reference embedding + PIL-preprocessed pixel buffer. `step3_compare.py` reads the three embeddings and emits the verdict report. `report.json` is the canonical committed numbers.

## Dependency note

The cosine numbers above assume PR 1927 (pooling head) and PR 1928 (image normalization) are merged or stacked locally — both ship alongside this fix to land mmes at full PyTorch parity. This preprocessing fix is **functionally independent** of those PRs and **does not touch** `multimodal_embedding.rs`; the diff is fully decoupled.

## Test plan

- [ ] CI passes on this branch
- [ ] Existing `TestMultiModalEncodeImageFromBytes` (cat/dog/car) integration test passes through the new FFI path
- [ ] Reproduce: `python step1_extract_pixels_and_python_embedding.py` then `python step3_compare.py` after running the new FFI against the fixture
- [ ] Confirm no regression on other multi-modal callers (`MultiModalEncodeImageFromBase64`, `MultiModalEncodeImageFromURL`) — they route through `MultiModalEncodeImageFromBytes` so they inherit the fix