### PR TITLE
feat(extproc): detect ClientProtocol from :path header

### DIFF
--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -50,6 +50,12 @@ const (
 	APIFormatAnthropic = "anthropic"
 )
 
+// ClientProtocol* identifies the inbound wire format; distinct from APIFormat (upstream backend).
+const (
+	ClientProtocolOpenAI    = "openai"
+	ClientProtocolAnthropic = "anthropic"
+)
+
 // RouterConfig represents the main configuration for the LLM Router.
 type RouterConfig struct {
 	ConfigSource ConfigSource      `yaml:"config_source,omitempty"`

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -51,8 +51,9 @@ const (
 )
 
 // ClientProtocol* identifies the inbound wire format; distinct from APIFormat (upstream backend).
+// The zero value (empty string) is treated as OpenAI-compatible; additional constants will be
+// introduced as follow-up changes add explicit consumers.
 const (
-	ClientProtocolOpenAI    = "openai"
 	ClientProtocolAnthropic = "anthropic"
 )
 

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -24,6 +24,7 @@ func (r *OpenAIRouter) handleRequestHeaders(v *ext_proc.ProcessingRequest_Reques
 	method, path := captureRequestHeaders(v, ctx, r.skipProcessingEnabled())
 
 	setRequestHeaderSpanAttributes(span, ctx, method, path)
+	detectClientProtocol(path, ctx)
 
 	// Honor x-vsr-skip-processing as early as possible: once captured we bypass
 	// every router-side header check (replay API, validation, response-API

--- a/src/semantic-router/pkg/extproc/processor_req_header_endpoints.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_endpoints.go
@@ -134,10 +134,13 @@ func extractResponseIDFromInputItemsPath(path string) string {
 	return ""
 }
 
-// /v1/messages → Anthropic; everything else defaults to OpenAI (empty string).
+// detectClientProtocol classifies the inbound wire format from the request path.
+// Paths under /v1/messages (the Anthropic Messages API surface, including
+// /v1/messages/count_tokens) are tagged as Anthropic; everything else falls
+// through to the OpenAI-compatible default represented by the zero value.
 func detectClientProtocol(path string, ctx *RequestContext) {
 	if strings.HasPrefix(path, "/v1/messages") {
 		ctx.ClientProtocol = config.ClientProtocolAnthropic
-		logging.Infof("Detected Anthropic client protocol from path: %s", path)
+		logging.Debugf("Detected Anthropic client protocol from path: %s", path)
 	}
 }

--- a/src/semantic-router/pkg/extproc/processor_req_header_endpoints.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_endpoints.go
@@ -5,6 +5,7 @@ import (
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
@@ -131,4 +132,12 @@ func extractResponseIDFromInputItemsPath(path string) string {
 		return responseID
 	}
 	return ""
+}
+
+// /v1/messages → Anthropic; everything else defaults to OpenAI (empty string).
+func detectClientProtocol(path string, ctx *RequestContext) {
+	if strings.HasPrefix(path, "/v1/messages") {
+		ctx.ClientProtocol = config.ClientProtocolAnthropic
+		logging.Infof("Detected Anthropic client protocol from path: %s", path)
+	}
 }

--- a/src/semantic-router/pkg/extproc/processor_req_header_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_test.go
@@ -255,6 +255,7 @@ func TestDetectClientProtocol(t *testing.T) {
 	}{
 		{name: "anthropic messages path", path: "/v1/messages", wantProto: config.ClientProtocolAnthropic},
 		{name: "anthropic messages with query", path: "/v1/messages?stream=true", wantProto: config.ClientProtocolAnthropic},
+		{name: "anthropic count tokens subpath", path: "/v1/messages/count_tokens", wantProto: config.ClientProtocolAnthropic},
 		{name: "openai chat completions", path: "/v1/chat/completions", wantProto: ""},
 		{name: "openai responses", path: "/v1/responses", wantProto: ""},
 		{name: "openai models", path: "/v1/models", wantProto: ""},

--- a/src/semantic-router/pkg/extproc/processor_req_header_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_test.go
@@ -7,6 +7,8 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
 type requestHeaderTestCase struct {
@@ -242,5 +244,57 @@ func assertImmediateErrorResponse(
 	}
 	if decoded.Error.Message != wantMessage {
 		t.Fatalf("expected error message %q, got %q", wantMessage, decoded.Error.Message)
+	}
+}
+
+func TestDetectClientProtocol(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantProto string
+	}{
+		{name: "anthropic messages path", path: "/v1/messages", wantProto: config.ClientProtocolAnthropic},
+		{name: "anthropic messages with query", path: "/v1/messages?stream=true", wantProto: config.ClientProtocolAnthropic},
+		{name: "openai chat completions", path: "/v1/chat/completions", wantProto: ""},
+		{name: "openai responses", path: "/v1/responses", wantProto: ""},
+		{name: "openai models", path: "/v1/models", wantProto: ""},
+		{name: "root path", path: "/", wantProto: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &RequestContext{Headers: make(map[string]string)}
+			detectClientProtocol(tt.path, ctx)
+			if ctx.ClientProtocol != tt.wantProto {
+				t.Fatalf("detectClientProtocol(%q): got ClientProtocol=%q, want %q", tt.path, ctx.ClientProtocol, tt.wantProto)
+			}
+		})
+	}
+}
+
+func TestHandleRequestHeadersSetsClientProtocol(t *testing.T) {
+	router := &OpenAIRouter{}
+
+	tests := []struct {
+		name      string
+		path      string
+		wantProto string
+	}{
+		{name: "anthropic messages sets protocol", path: "/v1/messages", wantProto: config.ClientProtocolAnthropic},
+		{name: "openai chat keeps default", path: "/v1/chat/completions", wantProto: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestHeaders := newRequestHeaders("POST", tt.path)
+			ctx := &RequestContext{Headers: make(map[string]string)}
+			_, err := router.handleRequestHeaders(requestHeaders, ctx)
+			if err != nil {
+				t.Fatalf("handleRequestHeaders failed: %v", err)
+			}
+			if ctx.ClientProtocol != tt.wantProto {
+				t.Fatalf("got ClientProtocol=%q, want %q", ctx.ClientProtocol, tt.wantProto)
+			}
+		})
 	}
 }

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -197,6 +197,10 @@ type RequestContext struct {
 	// Empty string means standard OpenAI-compatible backend (no transformation needed)
 	APIFormat string
 
+	// ClientProtocol identifies the inbound wire format (e.g., "anthropic" for /v1/messages).
+	// Empty string means OpenAI-compatible (the default).
+	ClientProtocol string
+
 	// RAG (Retrieval-Augmented Generation) tracking
 	RAGRetrievedContext string  // Retrieved context from RAG plugin
 	RAGBackend          string  // Backend used for retrieval ("milvus", "external_api", "mcp", "hybrid")


### PR DESCRIPTION
> **RFC**: #1946 — design rationale, alternatives considered, decisions invited from maintainers

Foundational change for native Anthropic `/v1/messages` ingress. Adds a typed
`ClientProtocol` field on `RequestContext`, populated from envoy's `:path`
pseudo-header before any routing decision runs. No body parsing, no routing
change, no request rewriting — just the protocol-detection primitive that
downstream changes will branch on.

Adopts and refines @samzong's previously open #1473, with credit preserved via
Co-authored-by trailer.

## Commits

1. **`[Router] detect Anthropic client protocol from :path header`** (samzong,
   cherry-picked) — adds `ClientProtocolAnthropic` constant, `ClientProtocol`
   field on `RequestContext`, `detectClientProtocol(path, ctx)` helper, tests.
2. **`[Router] tighten ClientProtocol detection contract`** — three
   review-feedback refinements:
   - Drop unused `ClientProtocolOpenAI` constant; the zero-value default
     already handles the OpenAI case. Will be re-introduced when an explicit
     consumer lands.
   - Demote the per-request "detected Anthropic client protocol" log from
     `Infof` to `Debugf` to avoid noise on a hot path.
   - Expand the `detectClientProtocol` doc comment to make explicit that
     `HasPrefix("/v1/messages")` intentionally also matches the
     `/v1/messages/count_tokens` helper endpoint; add a test case documenting
     that intent.

## Why now

This is the first in a small series implementing native Anthropic ingress
(tracking issue #1404). Follow-up changes will add: the `/v1/messages` allow-list,
the Anthropic inbound parser, a protocol-neutral intermediate representation,
the outbound emitter, and Anthropic SSE response translation. Landing the
detection primitive first lets the rest branch on `ctx.ClientProtocol` without
each change re-inventing the dispatch.

## Test plan

- [x] `make agent-lint CHANGED_FILES=...` — golangci-lint, pre-commit hooks,
      supply-chain scan, reference-config test all clean
- [x] `go vet ./pkg/config/... ./pkg/extproc/...` clean
- [x] `go build ./pkg/config/... ./pkg/extproc/...` clean
- [x] DCO sign-off on both commits
- [ ] Upstream CI (`test-and-build`, `integration-test`, `build_pr (*)`) — runs
      once this PR is marked ready

## Related

- Picks up #1473 (open since 2026-03; rebased onto current main with credit)
- Tracking issue: #1404
- Builds on the symmetric work in #1922 and #1926 (custom Anthropic upstream
  routing and SSE translation)

Co-authored-by: samzong <samzong.lu@gmail.com>
