### PR TITLE
feat(anthropic): native /v1/messages ingress — IR envelope + inbound parser

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -8,6 +8,7 @@ var RouterSmoke = []string{
 // BaselineRouterContract is the canonical full router contract owned by the kubernetes baseline profile.
 var BaselineRouterContract = []string{
 	"chat-completions-request",
+	"anthropic-messages-request",
 	"apiserver-runtime-config-endpoints",
 	"apiserver-classification-endpoints",
 	"chat-completions-stress-request",

--- a/e2e/testcases/anthropic_messages_request.go
+++ b/e2e/testcases/anthropic_messages_request.go
@@ -1,0 +1,143 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-messages-request", pkgtestcases.TestCase{
+		Description: "Send POST /v1/messages with an Anthropic Messages body and verify 200 OK and routing",
+		Tags:        []string{"anthropic", "functional", "routing"},
+		Fn:          testAnthropicMessagesRequest,
+	})
+}
+
+// testAnthropicMessagesRequest exercises the inbound Anthropic Messages API
+// path end-to-end: the router must accept POST /v1/messages, tag the request
+// as Anthropic-protocol, parse the Anthropic body into the shared IR, run
+// routing, and forward the translated request to the OpenAI-shaped backend.
+// We only assert on properties the router controls (status, decision header,
+// non-empty body); the free-text response payload is mock-backend dependent.
+func testAnthropicMessagesRequest(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing POST /v1/messages round-trip")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	resp, err := sendAnthropicMessagesRequest(ctx, anthropicMessagesRequestBody{
+		Model:     "MoM",
+		MaxTokens: 64,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "Explain the difference between TCP and UDP."},
+		},
+	}, localPort)
+	if err != nil {
+		return fmt.Errorf("anthropic messages request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	decision := resp.Header.Get("x-vsr-selected-decision")
+	selectedModel := resp.Header.Get("x-vsr-selected-model")
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code":     resp.StatusCode,
+			"response_length": len(body),
+			"decision":        decision,
+			"selected_model":  selectedModel,
+		})
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200 for /v1/messages, got %d: %s",
+			resp.StatusCode, truncateString(string(body), 200))
+	}
+
+	if len(body) == 0 {
+		return fmt.Errorf("expected non-empty response body for /v1/messages")
+	}
+
+	// Body must be JSON the router synthesized — assert it parses, regardless
+	// of which wire shape (OpenAI or Anthropic) the current PR emits. Later
+	// PRs in the series tighten this to the Anthropic Messages shape.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("response body is not valid JSON: %w (body=%s)", err,
+			truncateString(string(body), 200))
+	}
+
+	// Routing must have happened: at least one of the decision/model headers
+	// must be set, otherwise the request bypassed the routing pipeline.
+	if decision == "" && selectedModel == "" {
+		return fmt.Errorf("expected x-vsr-selected-decision or x-vsr-selected-model header to be set")
+	}
+
+	return nil
+}
+
+// anthropicMessage is the minimal Anthropic content shape for E2E requests
+// (string content only; richer content blocks are exercised by the
+// passthrough test on the IRExtensions branch).
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// anthropicMessagesRequestBody is the minimal POST /v1/messages payload
+// used by the Anthropic e2e suite. max_tokens is required by the Anthropic
+// Messages API; everything else mirrors the SDK shape.
+type anthropicMessagesRequestBody struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	Messages  []anthropicMessage `json:"messages"`
+	System    string             `json:"system,omitempty"`
+	Stream    bool               `json:"stream,omitempty"`
+}
+
+// sendAnthropicMessagesRequest POSTs an Anthropic Messages body to the
+// router's /v1/messages surface and returns the raw response so callers
+// can inspect both headers and body.
+func sendAnthropicMessagesRequest(
+	ctx context.Context,
+	body anthropicMessagesRequestBody,
+	localPort string,
+) (*http.Response, error) {
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%s/v1/messages", localPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// anthropic-version is required by the official Anthropic API. The router
+	// does not currently gate on it but real SDK clients always send it.
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do: %w", err)
+	}
+	return resp, nil
+}

--- a/src/semantic-router/pkg/anthropic/inbound.go
+++ b/src/semantic-router/pkg/anthropic/inbound.go
@@ -1,0 +1,772 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/shared/constant"
+	"github.com/tidwall/gjson"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+// SourceProtocolAnthropic is the SourceProtocol stamp set on IRExtensions
+// by ParseAnthropicRequest. Mirrors config.ClientProtocolAnthropic but is
+// duplicated here to avoid creating an extproc → config → anthropic cycle.
+const SourceProtocolAnthropic = "anthropic"
+
+// ParseAnthropicRequest translates a raw Anthropic /v1/messages JSON body
+// into the protocol-neutral IR pair (*openai.ChatCompletionNewParams plus
+// *ir.IRExtensions).
+//
+// Behavior contract:
+//
+//   - Returns a non-nil error only when the JSON is structurally invalid
+//     or a required field is missing.
+//   - Unknown block types (e.g. redacted_thinking, search_result) are
+//     warn-and-dropped via IRExtensions.Warnings; they never fail the parse.
+//   - cache_control markers on any block are captured into
+//     IRExtensions.CacheControl AND the marked block continues to be
+//     translated into the OpenAI IR (the marker is a sidecar, not a
+//     gate).
+//   - tool_result.is_error is preserved as an IRExtensions warning
+//     (Reason="tool_result_is_error", Detail=tool_use_id) so the
+//     round-trip back through ToAnthropicRequestBody can restore the
+//     flag.
+//   - Array-form tool_result content (text + image parts) is preserved as
+//     OpenAI tool-message array content; only the text payload survives
+//     today because the OpenAI tool-message shape does not carry image
+//     parts, but the image content is recorded into Warnings so an
+//     Anthropic-backend emitter can reconstruct it.
+//   - The OpenAI request always has a populated MaxTokens (Anthropic
+//     requires it; we default to DefaultMaxTokens=4096 when absent to
+//     match the symmetric outbound emitter).
+func ParseAnthropicRequest(body []byte) (*openai.ChatCompletionNewParams, *ir.IRExtensions, error) {
+	if !gjson.ValidBytes(body) {
+		return nil, nil, fmt.Errorf("anthropic request body is not valid JSON")
+	}
+
+	model := gjson.GetBytes(body, "model")
+	if !model.Exists() || model.Type != gjson.String || model.String() == "" {
+		return nil, nil, fmt.Errorf("anthropic request: model field is required")
+	}
+
+	params := &openai.ChatCompletionNewParams{
+		Model: model.String(),
+	}
+	ext := &ir.IRExtensions{SourceProtocol: SourceProtocolAnthropic}
+
+	convertSamplingParams(body, params, ext)
+	convertSystem(gjson.GetBytes(body, "system"), params, ext)
+	convertMessages(gjson.GetBytes(body, "messages"), params, ext)
+	convertTools(gjson.GetBytes(body, "tools"), params, ext)
+	convertToolChoice(gjson.GetBytes(body, "tool_choice"), params, ext)
+	convertMetadata(gjson.GetBytes(body, "metadata"), params, ext)
+	convertThinking(gjson.GetBytes(body, "thinking"), ext)
+	captureTopLevelCacheControl(body, ext)
+
+	return params, ext, nil
+}
+
+func convertSamplingParams(body []byte, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	params.MaxTokens = openai.Int(readMaxTokens(body))
+	applyNumericSampling(body, params, ext)
+	applyStopSequences(body, params)
+	if beta := gjson.GetBytes(body, "anthropic_beta"); beta.Exists() && beta.Type == gjson.String {
+		ext.AnthropicBeta = beta.String()
+	}
+}
+
+func readMaxTokens(body []byte) int64 {
+	if mt := gjson.GetBytes(body, "max_tokens"); mt.Exists() && mt.Type == gjson.Number {
+		return mt.Int()
+	}
+	return DefaultMaxTokens
+}
+
+func applyNumericSampling(body []byte, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	if t := gjson.GetBytes(body, "temperature"); t.Exists() && t.Type == gjson.Number {
+		params.Temperature = openai.Float(t.Float())
+	}
+	if tp := gjson.GetBytes(body, "top_p"); tp.Exists() && tp.Type == gjson.Number {
+		params.TopP = openai.Float(tp.Float())
+	}
+	if tk := gjson.GetBytes(body, "top_k"); tk.Exists() && tk.Type == gjson.Number {
+		v := tk.Int()
+		ext.TopK = &v
+	}
+}
+
+func applyStopSequences(body []byte, params *openai.ChatCompletionNewParams) {
+	stop := gjson.GetBytes(body, "stop_sequences")
+	if !stop.Exists() || !stop.IsArray() {
+		return
+	}
+	var seqs []string
+	stop.ForEach(func(_, v gjson.Result) bool {
+		if v.Type == gjson.String && v.String() != "" {
+			seqs = append(seqs, v.String())
+		}
+		return true
+	})
+	if len(seqs) > 0 {
+		params.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: seqs}
+	}
+}
+
+func convertSystem(system gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	if !system.Exists() {
+		return
+	}
+
+	if system.Type == gjson.String {
+		text := system.String()
+		if text != "" {
+			params.Messages = append(params.Messages, openai.SystemMessage(text))
+		}
+		return
+	}
+	if !system.IsArray() {
+		ext.AppendWarning(ir.Warning{
+			Field:    "system",
+			Reason:   "unsupported_type",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   fmt.Sprintf("system must be string or array, got %s", system.Type.String()),
+		})
+		return
+	}
+
+	var parts []openai.ChatCompletionContentPartTextParam
+	system.ForEach(func(idx, block gjson.Result) bool {
+		blockID := fmt.Sprintf("system.%d", idx.Int())
+		text := block.Get("text").String()
+		if text == "" {
+			return true
+		}
+		parts = append(parts, openai.ChatCompletionContentPartTextParam{Text: text})
+
+		spec := SystemBlockSpec(blockID, text, block)
+		ext.SystemBlocks = append(ext.SystemBlocks, spec)
+		captureCacheControl(blockID, block.Get("cache_control"), ext)
+		return true
+	})
+	if len(parts) > 0 {
+		params.Messages = append(params.Messages, openai.SystemMessage(parts))
+	}
+}
+
+// SystemBlockSpec is exported so emitters in the same package can rebuild
+// outbound system arrays without duplicating the field-mapping logic.
+func SystemBlockSpec(blockID, text string, block gjson.Result) ir.SystemBlock {
+	var cc *ir.CacheControlSpec
+	if raw := block.Get("cache_control"); raw.Exists() {
+		spec := parseCacheControlSpec(raw)
+		cc = &spec
+	}
+	return ir.SystemBlock{BlockID: blockID, Text: text, CacheControl: cc}
+}
+
+func convertMessages(messages gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	if !messages.Exists() || !messages.IsArray() {
+		return
+	}
+	messages.ForEach(func(idx, msg gjson.Result) bool {
+		convertMessage(int(idx.Int()), msg, params, ext)
+		return true
+	})
+}
+
+func convertMessage(msgIdx int, msg gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	role := msg.Get("role").String()
+	content := msg.Get("content")
+
+	switch role {
+	case "user":
+		convertUserMessage(msgIdx, content, params, ext)
+	case "assistant":
+		convertAssistantMessage(msgIdx, content, params, ext)
+	default:
+		ext.AppendWarning(ir.Warning{
+			Field:    fmt.Sprintf("messages[%d].role", msgIdx),
+			Reason:   "unsupported_role",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   fmt.Sprintf("role %q is not user or assistant", role),
+		})
+	}
+}
+
+func convertUserMessage(msgIdx int, content gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	// Anthropic user-turn content is either a plain string, in which case
+	// it becomes one OpenAI user message, or an array of blocks. The array
+	// case is heterogeneous: text/image parts contribute to the user
+	// message, while tool_result blocks emit their own tool-role messages
+	// in document order alongside (or replacing) the user message.
+	if content.Type == gjson.String {
+		text := content.String()
+		if text != "" {
+			params.Messages = append(params.Messages, openai.UserMessage(text))
+		}
+		return
+	}
+	if !content.IsArray() {
+		return
+	}
+
+	var userParts []openai.ChatCompletionContentPartUnionParam
+
+	flushUserParts := func() {
+		if len(userParts) == 0 {
+			return
+		}
+		params.Messages = append(params.Messages, openai.UserMessage(userParts))
+		userParts = nil
+	}
+
+	content.ForEach(func(idx, block gjson.Result) bool {
+		blockID := fmt.Sprintf("messages[%d].content[%d]", msgIdx, idx.Int())
+		captureCacheControl(blockID, block.Get("cache_control"), ext)
+		userParts = dispatchUserBlock(blockID, block, userParts, params, ext, flushUserParts)
+		return true
+	})
+
+	flushUserParts()
+}
+
+// dispatchAssistantBlock applies one assistant-turn content block.
+// text → textParts (one OfText entry per block, preserving order),
+// tool_use → toolCalls (assembled into ToolCalls on the assistant message),
+// thinking → ext.ThinkingSignatures for round-trip,
+// redacted_thinking / server_tool_use / unknown → ext.Warnings.
+func dispatchAssistantBlock(
+	blockID string,
+	block gjson.Result,
+	textParts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion,
+	toolCalls []openai.ChatCompletionMessageToolCallParam,
+	ext *ir.IRExtensions,
+) (
+	[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion,
+	[]openai.ChatCompletionMessageToolCallParam,
+) {
+	switch block.Get("type").String() {
+	case "text":
+		if text := block.Get("text").String(); text != "" {
+			textParts = append(textParts, openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion{
+				OfText: &openai.ChatCompletionContentPartTextParam{Text: text},
+			})
+		}
+	case "tool_use":
+		if call, ok := convertToolUseBlock(blockID, block, ext); ok {
+			toolCalls = append(toolCalls, call)
+		}
+	case "thinking":
+		captureThinkingBlock(blockID, block, ext)
+	case "redacted_thinking":
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID + ".type",
+			Reason:   "unsupported_block_type",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   "redacted_thinking blocks are dropped (out of scope for PR2)",
+		})
+	case "server_tool_use":
+		captureServerToolUse(blockID, block, ext)
+	default:
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID + ".type",
+			Reason:   "unsupported_block_type",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   fmt.Sprintf("assistant-turn block type %q is not handled", block.Get("type").String()),
+		})
+	}
+	return textParts, toolCalls
+}
+
+// dispatchUserBlock applies one user-turn content block. Inline parts
+// (text/image) accumulate into userParts; tool_result blocks flush and
+// emit a separate tool-role message in document order; sidecar-only
+// blocks (document/thinking/server_tool_use) are captured into ext.
+func dispatchUserBlock(
+	blockID string,
+	block gjson.Result,
+	userParts []openai.ChatCompletionContentPartUnionParam,
+	params *openai.ChatCompletionNewParams,
+	ext *ir.IRExtensions,
+	flushUserParts func(),
+) []openai.ChatCompletionContentPartUnionParam {
+	switch block.Get("type").String() {
+	case "text":
+		if text := block.Get("text").String(); text != "" {
+			userParts = append(userParts, openai.TextContentPart(text))
+		}
+	case "image":
+		if part, ok := convertImageBlock(blockID, block, ext); ok {
+			userParts = append(userParts, part)
+		}
+	case "tool_result":
+		// tool_result terminates the running user-message batch and emits
+		// a tool-role message in place so the original document order
+		// user[text] → tool_result → user[text] becomes the equivalent
+		// sequence of OpenAI messages.
+		flushUserParts()
+		if toolMsg, ok := convertToolResultBlock(blockID, block, ext); ok {
+			params.Messages = append(params.Messages, toolMsg)
+		}
+	case "document":
+		captureDocumentBlock(blockID, block, ext)
+	case "thinking", "redacted_thinking":
+		captureThinkingBlock(blockID, block, ext)
+	case "server_tool_use":
+		captureServerToolUse(blockID, block, ext)
+	default:
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID + ".type",
+			Reason:   "unsupported_block_type",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   fmt.Sprintf("user-turn block type %q is not handled", block.Get("type").String()),
+		})
+	}
+	return userParts
+}
+
+func convertAssistantMessage(msgIdx int, content gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	asst := openai.ChatCompletionAssistantMessageParam{Role: constant.Assistant("assistant")}
+
+	if content.Type == gjson.String {
+		text := content.String()
+		if text != "" {
+			asst.Content.OfString = param.NewOpt(text)
+		}
+		params.Messages = append(params.Messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
+		return
+	}
+	if !content.IsArray() {
+		params.Messages = append(params.Messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
+		return
+	}
+
+	var textParts []openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion
+	var toolCalls []openai.ChatCompletionMessageToolCallParam
+
+	content.ForEach(func(idx, block gjson.Result) bool {
+		blockID := fmt.Sprintf("messages[%d].content[%d]", msgIdx, idx.Int())
+		captureCacheControl(blockID, block.Get("cache_control"), ext)
+		textParts, toolCalls = dispatchAssistantBlock(blockID, block, textParts, toolCalls, ext)
+		return true
+	})
+
+	if len(textParts) > 0 {
+		asst.Content.OfArrayOfContentParts = textParts
+	}
+	if len(toolCalls) > 0 {
+		asst.ToolCalls = toolCalls
+	}
+
+	params.Messages = append(params.Messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
+}
+
+func convertImageBlock(blockID string, block gjson.Result, ext *ir.IRExtensions) (openai.ChatCompletionContentPartUnionParam, bool) {
+	source := block.Get("source")
+	if !source.Exists() {
+		ext.AppendWarning(ir.Warning{Field: blockID + ".source", Reason: "missing_source", Severity: ir.WarningSeverityLossy})
+		return openai.ChatCompletionContentPartUnionParam{}, false
+	}
+	switch source.Get("type").String() {
+	case "base64":
+		mediaType := source.Get("media_type").String()
+		data := source.Get("data").String()
+		if mediaType == "" || data == "" {
+			ext.AppendWarning(ir.Warning{Field: blockID + ".source", Reason: "incomplete_base64", Severity: ir.WarningSeverityLossy})
+			return openai.ChatCompletionContentPartUnionParam{}, false
+		}
+		url := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
+		return openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{URL: url}), true
+	case "url":
+		url := source.Get("url").String()
+		if url == "" {
+			ext.AppendWarning(ir.Warning{Field: blockID + ".source.url", Reason: "missing_url", Severity: ir.WarningSeverityLossy})
+			return openai.ChatCompletionContentPartUnionParam{}, false
+		}
+		return openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{URL: url}), true
+	case "file", "file_id":
+		fileID := source.Get("file_id").String()
+		if fileID == "" {
+			fileID = source.Get("id").String()
+		}
+		if fileID == "" {
+			ext.AppendWarning(ir.Warning{Field: blockID + ".source.file_id", Reason: "missing_file_id", Severity: ir.WarningSeverityLossy})
+			return openai.ChatCompletionContentPartUnionParam{}, false
+		}
+		// OpenAI image_url does not have a file_id concept; we synthesize
+		// a file_id: URI scheme so the IR remains self-describing and warn
+		// so any OpenAI-backend emitter knows to resolve or drop it.
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID + ".source",
+			Reason:   "image_file_id_unresolved",
+			Severity: ir.WarningSeverityInfo,
+			Detail:   "image source type=file_id requires backend-specific resolution",
+		})
+		return openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{URL: "file_id:" + fileID}), true
+	default:
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID + ".source.type",
+			Reason:   "unsupported_image_source",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   fmt.Sprintf("image source.type %q is not handled", source.Get("type").String()),
+		})
+		return openai.ChatCompletionContentPartUnionParam{}, false
+	}
+}
+
+func convertToolResultBlock(blockID string, block gjson.Result, ext *ir.IRExtensions) (openai.ChatCompletionMessageParamUnion, bool) {
+	toolUseID := strings.TrimSpace(block.Get("tool_use_id").String())
+	if toolUseID == "" {
+		ext.AppendWarning(ir.Warning{Field: blockID + ".tool_use_id", Reason: "missing_tool_use_id", Severity: ir.WarningSeverityError})
+		return openai.ChatCompletionMessageParamUnion{}, false
+	}
+	isError := block.Get("is_error").Bool()
+
+	textContent, imageCount := flattenToolResultContent(blockID, block.Get("content"), ext)
+
+	toolMsg := openai.ChatCompletionToolMessageParam{
+		Role:       constant.Tool("tool"),
+		ToolCallID: toolUseID,
+	}
+	if textContent != "" {
+		toolMsg.Content = openai.ChatCompletionToolMessageParamContentUnion{
+			OfString: param.NewOpt(textContent),
+		}
+	}
+
+	if isError {
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID + ".is_error",
+			Reason:   "tool_result_is_error",
+			Severity: ir.WarningSeverityInfo,
+			Detail:   toolUseID,
+		})
+	}
+	if imageCount > 0 {
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID + ".content",
+			Reason:   "tool_result_image_dropped",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   fmt.Sprintf("%d image part(s) on tool_result %s preserved only in IRExtensions", imageCount, toolUseID),
+		})
+	}
+
+	return openai.ChatCompletionMessageParamUnion{OfTool: &toolMsg}, true
+}
+
+// flattenToolResultContent walks a tool_result content field and returns
+// the concatenated text payload plus the count of image parts seen. Image
+// parts are not surfaced into the OpenAI tool message (the shape does not
+// support them) but the count drives a lossy warning so the outbound side
+// can reconstruct or escalate.
+func flattenToolResultContent(blockID string, content gjson.Result, ext *ir.IRExtensions) (string, int) {
+	if !content.Exists() {
+		return "", 0
+	}
+	if content.Type == gjson.String {
+		return content.String(), 0
+	}
+	if !content.IsArray() {
+		return "", 0
+	}
+
+	var texts []string
+	imageCount := 0
+	content.ForEach(func(idx, part gjson.Result) bool {
+		partID := fmt.Sprintf("%s.content[%d]", blockID, idx.Int())
+		switch part.Get("type").String() {
+		case "text":
+			if t := part.Get("text").String(); t != "" {
+				texts = append(texts, t)
+			}
+		case "image":
+			imageCount++
+		case "document":
+			ext.AppendWarning(ir.Warning{
+				Field:    partID,
+				Reason:   "tool_result_document_dropped",
+				Severity: ir.WarningSeverityLossy,
+			})
+		default:
+			ext.AppendWarning(ir.Warning{
+				Field:    partID,
+				Reason:   "unsupported_tool_result_part",
+				Severity: ir.WarningSeverityLossy,
+				Detail:   fmt.Sprintf("type %q", part.Get("type").String()),
+			})
+		}
+		return true
+	})
+	if len(texts) == 1 {
+		return texts[0], imageCount
+	}
+	return strings.Join(texts, "\n"), imageCount
+}
+
+func convertToolUseBlock(blockID string, block gjson.Result, ext *ir.IRExtensions) (openai.ChatCompletionMessageToolCallParam, bool) {
+	id := strings.TrimSpace(block.Get("id").String())
+	name := strings.TrimSpace(block.Get("name").String())
+	if id == "" || name == "" {
+		ext.AppendWarning(ir.Warning{
+			Field:    blockID,
+			Reason:   "incomplete_tool_use",
+			Severity: ir.WarningSeverityError,
+			Detail:   "tool_use requires id and name",
+		})
+		return openai.ChatCompletionMessageToolCallParam{}, false
+	}
+
+	args := "{}"
+	if input := block.Get("input"); input.Exists() {
+		// gjson Raw preserves the original JSON shape; if the SDK that
+		// produced the body emitted a structured object, we keep it.
+		args = input.Raw
+	}
+
+	return openai.ChatCompletionMessageToolCallParam{
+		ID:   id,
+		Type: constant.Function("function"),
+		Function: openai.ChatCompletionMessageToolCallFunctionParam{
+			Name:      name,
+			Arguments: args,
+		},
+	}, true
+}
+
+func convertTools(tools gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	if !tools.Exists() || !tools.IsArray() {
+		return
+	}
+	var out []openai.ChatCompletionToolParam
+	tools.ForEach(func(idx, tool gjson.Result) bool {
+		path := fmt.Sprintf("tools[%d]", idx.Int())
+		toolType := tool.Get("type").String()
+		switch toolType {
+		case "", "custom":
+			if fp, ok := convertCustomTool(path, tool, ext); ok {
+				out = append(out, fp)
+			}
+		default:
+			captureServerToolDefinition(path, toolType, tool, ext)
+		}
+		return true
+	})
+	if len(out) > 0 {
+		params.Tools = out
+	}
+}
+
+func convertCustomTool(path string, tool gjson.Result, ext *ir.IRExtensions) (openai.ChatCompletionToolParam, bool) {
+	name := strings.TrimSpace(tool.Get("name").String())
+	if name == "" {
+		ext.AppendWarning(ir.Warning{Field: path + ".name", Reason: "missing_name", Severity: ir.WarningSeverityError})
+		return openai.ChatCompletionToolParam{}, false
+	}
+	fp := openai.ChatCompletionToolParam{
+		Function: shared.FunctionDefinitionParam{Name: name},
+	}
+	if desc := tool.Get("description"); desc.Exists() && desc.String() != "" {
+		fp.Function.Description = openai.String(desc.String())
+	}
+	if schema := tool.Get("input_schema"); schema.Exists() {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(schema.Raw), &parsed); err == nil {
+			fp.Function.Parameters = parsed
+		} else {
+			ext.AppendWarning(ir.Warning{
+				Field:    path + ".input_schema",
+				Reason:   "invalid_schema",
+				Severity: ir.WarningSeverityLossy,
+				Detail:   err.Error(),
+			})
+		}
+	}
+	if strict := tool.Get("strict"); strict.Exists() && strict.Type == gjson.True {
+		ext.SetToolStrict(name, true)
+	}
+	return fp, true
+}
+
+func captureServerToolDefinition(path, toolType string, tool gjson.Result, ext *ir.IRExtensions) {
+	spec := ir.ServerToolSpec{
+		Type: toolType,
+		Name: tool.Get("name").String(),
+	}
+	if schema := tool.Get("input_schema"); schema.Exists() {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(schema.Raw), &parsed); err == nil {
+			spec.Parameters = parsed
+		}
+	}
+	ext.ServerTools = append(ext.ServerTools, spec)
+	ext.AppendWarning(ir.Warning{
+		Field:    path + ".type",
+		Reason:   "server_tool_captured",
+		Severity: ir.WarningSeverityInfo,
+		Detail:   fmt.Sprintf("server-tool type %q preserved in IRExtensions", toolType),
+	})
+}
+
+func convertToolChoice(tc gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	if !tc.Exists() {
+		return
+	}
+	tcType := tc.Get("type").String()
+	switch tcType {
+	case "auto":
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: param.NewOpt("auto"),
+		}
+	case "none":
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: param.NewOpt("none"),
+		}
+	case "any":
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: param.NewOpt("required"),
+		}
+	case "tool":
+		name := tc.Get("name").String()
+		if name != "" {
+			params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+				OfChatCompletionNamedToolChoice: &openai.ChatCompletionNamedToolChoiceParam{
+					Type: constant.Function("function"),
+					Function: openai.ChatCompletionNamedToolChoiceFunctionParam{
+						Name: name,
+					},
+				},
+			}
+		}
+	default:
+		ext.AppendWarning(ir.Warning{
+			Field:    "tool_choice.type",
+			Reason:   "unsupported_tool_choice",
+			Severity: ir.WarningSeverityLossy,
+			Detail:   fmt.Sprintf("tool_choice.type %q is not handled", tcType),
+		})
+	}
+	if disable := tc.Get("disable_parallel_tool_use"); disable.Exists() && disable.Type == gjson.True {
+		ext.ToolChoiceDisableParallel = true
+		// Mirror to the OpenAI native parallel_tool_calls field (the OAI
+		// inverse of the Anthropic disable flag).
+		params.ParallelToolCalls = openai.Bool(false)
+	}
+}
+
+func convertMetadata(metadata gjson.Result, params *openai.ChatCompletionNewParams, ext *ir.IRExtensions) {
+	if !metadata.Exists() {
+		return
+	}
+	if uid := metadata.Get("user_id"); uid.Exists() && uid.Type == gjson.String && uid.String() != "" {
+		ext.MetadataUserID = uid.String()
+		params.User = openai.String(uid.String())
+	}
+}
+
+func convertThinking(thinking gjson.Result, ext *ir.IRExtensions) {
+	if !thinking.Exists() {
+		return
+	}
+	tType := thinking.Get("type").String()
+	if tType == "" {
+		return
+	}
+	spec := &ir.ThinkingSpec{
+		Type:    tType,
+		Display: thinking.Get("display").String(),
+	}
+	if b := thinking.Get("budget_tokens"); b.Exists() && b.Type == gjson.Number {
+		spec.BudgetTokens = b.Int()
+	}
+	ext.Thinking = spec
+}
+
+func captureCacheControl(blockID string, cc gjson.Result, ext *ir.IRExtensions) {
+	if !cc.Exists() {
+		return
+	}
+	ext.SetCacheControl(blockID, parseCacheControlSpec(cc))
+}
+
+func parseCacheControlSpec(cc gjson.Result) ir.CacheControlSpec {
+	return ir.CacheControlSpec{
+		Type: cc.Get("type").String(),
+		TTL:  cc.Get("ttl").String(),
+	}
+}
+
+func captureTopLevelCacheControl(body []byte, ext *ir.IRExtensions) {
+	cc := gjson.GetBytes(body, "cache_control")
+	if !cc.Exists() {
+		return
+	}
+	ext.SetCacheControl("$.cache_control", parseCacheControlSpec(cc))
+}
+
+func captureThinkingBlock(blockID string, block gjson.Result, ext *ir.IRExtensions) {
+	if sig := block.Get("signature").String(); sig != "" {
+		ext.SetThinkingSignature(blockID, sig)
+	}
+}
+
+func captureDocumentBlock(blockID string, block gjson.Result, ext *ir.IRExtensions) {
+	doc := ir.DocumentBlock{BlockID: blockID}
+	source := block.Get("source")
+	if source.Exists() {
+		doc.SourceType = source.Get("type").String()
+		doc.MediaType = source.Get("media_type").String()
+		switch doc.SourceType {
+		case "base64", "text":
+			doc.Data = source.Get("data").String()
+		case "url":
+			doc.Data = source.Get("url").String()
+		case "file", "file_id":
+			doc.Data = source.Get("file_id").String()
+			if doc.Data == "" {
+				doc.Data = source.Get("id").String()
+			}
+		case "content":
+			source.Get("content").ForEach(func(idx, sub gjson.Result) bool {
+				doc.InlineContent = append(doc.InlineContent, ir.SystemBlock{
+					BlockID: fmt.Sprintf("%s.source.content[%d]", blockID, idx.Int()),
+					Text:    sub.Get("text").String(),
+				})
+				return true
+			})
+		}
+	}
+	if citations := block.Get("citations.enabled"); citations.Type == gjson.True {
+		doc.Citations = true
+		ext.CitationsEnabled = true
+	}
+	if raw := block.Get("cache_control"); raw.Exists() {
+		spec := parseCacheControlSpec(raw)
+		doc.CacheControl = &spec
+	}
+	ext.Documents = append(ext.Documents, doc)
+}
+
+func captureServerToolUse(blockID string, block gjson.Result, ext *ir.IRExtensions) {
+	spec := ir.ServerToolSpec{
+		Type: "server_tool_use",
+		Name: block.Get("name").String(),
+	}
+	if input := block.Get("input"); input.Exists() {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(input.Raw), &parsed); err == nil {
+			spec.Parameters = parsed
+		}
+	}
+	ext.ServerTools = append(ext.ServerTools, spec)
+	ext.AppendWarning(ir.Warning{
+		Field:    blockID,
+		Reason:   "server_tool_use_captured",
+		Severity: ir.WarningSeverityInfo,
+	})
+}

--- a/src/semantic-router/pkg/anthropic/inbound_test.go
+++ b/src/semantic-router/pkg/anthropic/inbound_test.go
@@ -1,0 +1,640 @@
+package anthropic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+func TestParseAnthropicRequest_RejectsInvalidJSON(t *testing.T) {
+	if _, _, err := ParseAnthropicRequest([]byte("{not json")); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseAnthropicRequest_RequiresModel(t *testing.T) {
+	_, _, err := ParseAnthropicRequest([]byte(`{"messages":[{"role":"user","content":"hi"}]}`))
+	if err == nil {
+		t.Fatal("expected error when model missing")
+	}
+}
+
+func TestParseAnthropicRequest_StampsSourceProtocol(t *testing.T) {
+	_, ext, err := ParseAnthropicRequest([]byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ext == nil || ext.SourceProtocol != SourceProtocolAnthropic {
+		t.Fatalf("expected SourceProtocol=anthropic, got %+v", ext)
+	}
+}
+
+func TestParseAnthropicRequest_PlainTextRoundTrip(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-7","max_tokens":1024,"messages":[{"role":"user","content":"hello world"}]}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.Model != "claude-opus-4-7" {
+		t.Fatalf("model: got %q", params.Model)
+	}
+	if params.MaxTokens.Value != 1024 {
+		t.Fatalf("max_tokens: got %d, want 1024", params.MaxTokens.Value)
+	}
+	if len(params.Messages) != 1 {
+		t.Fatalf("messages: got %d, want 1", len(params.Messages))
+	}
+	if params.Messages[0].OfUser == nil {
+		t.Fatalf("expected user message, got %+v", params.Messages[0])
+	}
+	if got := params.Messages[0].OfUser.Content.OfString.Value; got != "hello world" {
+		t.Fatalf("user content: got %q, want hello world", got)
+	}
+	if ext.SourceProtocol != SourceProtocolAnthropic {
+		t.Fatalf("source protocol: got %q", ext.SourceProtocol)
+	}
+}
+
+func TestParseAnthropicRequest_DefaultsMaxTokens(t *testing.T) {
+	body := []byte(`{"model":"claude","messages":[{"role":"user","content":"x"}]}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.MaxTokens.Value != DefaultMaxTokens {
+		t.Fatalf("expected default max_tokens=%d, got %d", DefaultMaxTokens, params.MaxTokens.Value)
+	}
+}
+
+func TestParseAnthropicRequest_SystemString(t *testing.T) {
+	body := []byte(`{"model":"claude","system":"be helpful","messages":[{"role":"user","content":"hi"}]}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Messages) != 2 {
+		t.Fatalf("expected 2 messages (system+user), got %d", len(params.Messages))
+	}
+	if params.Messages[0].OfSystem == nil {
+		t.Fatalf("expected system message at index 0, got %+v", params.Messages[0])
+	}
+	if len(ext.SystemBlocks) != 0 {
+		t.Fatalf("expected no SystemBlocks for string system, got %+v", ext.SystemBlocks)
+	}
+}
+
+func TestParseAnthropicRequest_SystemArrayWithCacheControl(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"system": [
+			{"type": "text", "text": "block A", "cache_control": {"type": "ephemeral", "ttl": "5m"}},
+			{"type": "text", "text": "block B"}
+		],
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Messages) != 2 {
+		t.Fatalf("expected system+user, got %d", len(params.Messages))
+	}
+	if len(ext.SystemBlocks) != 2 {
+		t.Fatalf("expected 2 SystemBlocks, got %d", len(ext.SystemBlocks))
+	}
+	if got := ext.CacheControl["system.0"].TTL; got != "5m" {
+		t.Fatalf("cache_control ttl for system.0: got %q, want 5m", got)
+	}
+	if _, present := ext.CacheControl["system.1"]; present {
+		t.Fatal("expected no cache_control for system.1")
+	}
+}
+
+func TestParseAnthropicRequest_UserArrayWithText(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "part one"},
+				{"type": "text", "text": "part two"}
+			]
+		}]
+	}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Messages) != 1 {
+		t.Fatalf("expected one user message, got %d", len(params.Messages))
+	}
+	parts := params.Messages[0].OfUser.Content.OfArrayOfContentParts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 content parts, got %d", len(parts))
+	}
+}
+
+func TestParseAnthropicRequest_ImageBase64(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "look"},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR=="}}
+			]
+		}]
+	}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parts := params.Messages[0].OfUser.Content.OfArrayOfContentParts
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(parts))
+	}
+	if parts[1].OfImageURL == nil {
+		t.Fatalf("expected image part at index 1, got %+v", parts[1])
+	}
+	if got := parts[1].OfImageURL.ImageURL.URL; got != "data:image/png;base64,iVBOR==" {
+		t.Fatalf("image url: got %q", got)
+	}
+}
+
+func TestParseAnthropicRequest_ImageURL(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{"role":"user","content":[{"type":"image","source":{"type":"url","url":"https://example.com/x.png"}}]}]
+	}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parts := params.Messages[0].OfUser.Content.OfArrayOfContentParts
+	if parts[0].OfImageURL == nil || parts[0].OfImageURL.ImageURL.URL != "https://example.com/x.png" {
+		t.Fatalf("image url unexpected: %+v", parts[0])
+	}
+}
+
+func TestParseAnthropicRequest_ImageFileID(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{"role":"user","content":[{"type":"image","source":{"type":"file","file_id":"file_abc"}}]}]
+	}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parts := params.Messages[0].OfUser.Content.OfArrayOfContentParts
+	if parts[0].OfImageURL == nil || parts[0].OfImageURL.ImageURL.URL != "file_id:file_abc" {
+		t.Fatalf("image file_id url unexpected: %+v", parts[0])
+	}
+	if !hasWarning(ext, "image_file_id_unresolved") {
+		t.Fatalf("expected image_file_id_unresolved warning, got %+v", ext.Warnings)
+	}
+}
+
+func TestParseAnthropicRequest_ToolUseAndToolResult(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [
+			{"role": "user", "content": "search the docs"},
+			{"role": "assistant", "content": [
+				{"type": "text", "text": "looking it up"},
+				{"type": "tool_use", "id": "tu_1", "name": "search", "input": {"q": "vsr"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "tu_1", "content": "vsr is a router"}
+			]}
+		]
+	}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(params.Messages))
+	}
+	if params.Messages[1].OfAssistant == nil {
+		t.Fatalf("expected assistant message at index 1")
+	}
+	if len(params.Messages[1].OfAssistant.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call on assistant, got %d", len(params.Messages[1].OfAssistant.ToolCalls))
+	}
+	call := params.Messages[1].OfAssistant.ToolCalls[0]
+	if call.ID != "tu_1" || call.Function.Name != "search" {
+		t.Fatalf("tool call unexpected: %+v", call)
+	}
+	if !strings.Contains(call.Function.Arguments, `"q"`) {
+		t.Fatalf("tool arguments missing q: %q", call.Function.Arguments)
+	}
+	if params.Messages[2].OfTool == nil {
+		t.Fatalf("expected tool message at index 2")
+	}
+	if params.Messages[2].OfTool.ToolCallID != "tu_1" {
+		t.Fatalf("tool_call_id: got %q", params.Messages[2].OfTool.ToolCallID)
+	}
+	if params.Messages[2].OfTool.Content.OfString.Value != "vsr is a router" {
+		t.Fatalf("tool content: got %q", params.Messages[2].OfTool.Content.OfString.Value)
+	}
+}
+
+func TestParseAnthropicRequest_ToolResultArrayContent(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "user",
+			"content": [{
+				"type": "tool_result",
+				"tool_use_id": "tu_1",
+				"content": [
+					{"type": "text", "text": "first chunk"},
+					{"type": "text", "text": "second chunk"},
+					{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc"}}
+				]
+			}]
+		}]
+	}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Messages) != 1 || params.Messages[0].OfTool == nil {
+		t.Fatalf("expected single tool message, got %+v", params.Messages)
+	}
+	gotContent := params.Messages[0].OfTool.Content.OfString.Value
+	if !strings.Contains(gotContent, "first chunk") || !strings.Contains(gotContent, "second chunk") {
+		t.Fatalf("expected both text chunks in content, got %q", gotContent)
+	}
+	if !hasWarning(ext, "tool_result_image_dropped") {
+		t.Fatalf("expected tool_result_image_dropped warning, got %+v", ext.Warnings)
+	}
+}
+
+func TestParseAnthropicRequest_ToolResultIsError(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "user",
+			"content": [{
+				"type": "tool_result",
+				"tool_use_id": "tu_99",
+				"is_error": true,
+				"content": "boom"
+			}]
+		}]
+	}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasWarningWithDetail(ext, "tool_result_is_error", "tu_99") {
+		t.Fatalf("expected tool_result_is_error warning for tu_99, got %+v", ext.Warnings)
+	}
+}
+
+func TestParseAnthropicRequest_TopK(t *testing.T) {
+	body := []byte(`{"model":"claude","top_k":40,"messages":[{"role":"user","content":"hi"}]}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ext.TopK == nil || *ext.TopK != 40 {
+		t.Fatalf("top_k: got %+v, want 40", ext.TopK)
+	}
+}
+
+func TestParseAnthropicRequest_MetadataUserID(t *testing.T) {
+	body := []byte(`{"model":"claude","metadata":{"user_id":"user-abc"},"messages":[{"role":"user","content":"hi"}]}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ext.MetadataUserID != "user-abc" {
+		t.Fatalf("metadata user id: got %q", ext.MetadataUserID)
+	}
+	if params.User.Value != "user-abc" {
+		t.Fatalf("params.User: got %q", params.User.Value)
+	}
+}
+
+func TestParseAnthropicRequest_Thinking(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"thinking": {"type": "enabled", "budget_tokens": 8000, "display": "summarized"},
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ext.Thinking == nil {
+		t.Fatal("expected Thinking to be set")
+	}
+	if ext.Thinking.Type != "enabled" || ext.Thinking.BudgetTokens != 8000 || ext.Thinking.Display != "summarized" {
+		t.Fatalf("thinking unexpected: %+v", ext.Thinking)
+	}
+}
+
+func TestParseAnthropicRequest_ToolsWithStrict(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [
+			{"name": "search", "description": "search docs", "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}, "strict": true},
+			{"name": "calc", "input_schema": {"type": "object"}}
+		]
+	}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(params.Tools))
+	}
+	if params.Tools[0].Function.Name != "search" {
+		t.Fatalf("tools[0] name: got %q", params.Tools[0].Function.Name)
+	}
+	if params.Tools[0].Function.Description.Value != "search docs" {
+		t.Fatalf("tools[0] description: got %q", params.Tools[0].Function.Description.Value)
+	}
+	if !ext.ToolStrict["search"] {
+		t.Fatalf("expected strict=true for search, got %+v", ext.ToolStrict)
+	}
+	if ext.ToolStrict["calc"] {
+		t.Fatalf("expected strict=false (or absent) for calc, got %+v", ext.ToolStrict)
+	}
+}
+
+func TestParseAnthropicRequest_ToolChoiceAuto(t *testing.T) {
+	body := []byte(`{"model":"claude","tool_choice":{"type":"auto"},"messages":[{"role":"user","content":"x"}]}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.ToolChoice.OfAuto.Value != "auto" {
+		t.Fatalf("tool_choice: got %+v", params.ToolChoice)
+	}
+}
+
+func TestParseAnthropicRequest_ToolChoiceAny(t *testing.T) {
+	body := []byte(`{"model":"claude","tool_choice":{"type":"any"},"messages":[{"role":"user","content":"x"}]}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.ToolChoice.OfAuto.Value != "required" {
+		t.Fatalf("any → required mapping failed: got %+v", params.ToolChoice)
+	}
+}
+
+func TestParseAnthropicRequest_ToolChoiceNamed(t *testing.T) {
+	body := []byte(`{"model":"claude","tool_choice":{"type":"tool","name":"search"},"messages":[{"role":"user","content":"x"}]}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.ToolChoice.OfChatCompletionNamedToolChoice == nil {
+		t.Fatal("expected named tool choice")
+	}
+	if params.ToolChoice.OfChatCompletionNamedToolChoice.Function.Name != "search" {
+		t.Fatalf("named tool: got %+v", params.ToolChoice.OfChatCompletionNamedToolChoice)
+	}
+}
+
+func TestParseAnthropicRequest_ToolChoiceDisableParallel(t *testing.T) {
+	body := []byte(`{"model":"claude","tool_choice":{"type":"auto","disable_parallel_tool_use":true},"messages":[{"role":"user","content":"x"}]}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ext.ToolChoiceDisableParallel {
+		t.Fatal("expected ToolChoiceDisableParallel=true")
+	}
+	if params.ParallelToolCalls.Value {
+		t.Fatal("expected ParallelToolCalls=false on OpenAI side")
+	}
+}
+
+func TestParseAnthropicRequest_TemperatureTopPStop(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"temperature": 0.7,
+		"top_p": 0.9,
+		"stop_sequences": ["END", "STOP"],
+		"messages": [{"role": "user", "content": "x"}]
+	}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.Temperature.Value != 0.7 {
+		t.Fatalf("temperature: got %v", params.Temperature.Value)
+	}
+	if params.TopP.Value != 0.9 {
+		t.Fatalf("top_p: got %v", params.TopP.Value)
+	}
+	if len(params.Stop.OfStringArray) != 2 {
+		t.Fatalf("stop sequences: got %+v", params.Stop)
+	}
+}
+
+func TestParseAnthropicRequest_DocumentBlock(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "user",
+			"content": [{
+				"type": "document",
+				"source": {"type": "base64", "media_type": "application/pdf", "data": "JVBERi0="},
+				"citations": {"enabled": true}
+			}]
+		}]
+	}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ext.Documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(ext.Documents))
+	}
+	doc := ext.Documents[0]
+	if doc.SourceType != "base64" || doc.MediaType != "application/pdf" {
+		t.Fatalf("document fields unexpected: %+v", doc)
+	}
+	if !doc.Citations || !ext.CitationsEnabled {
+		t.Fatal("expected citations enabled")
+	}
+}
+
+func TestParseAnthropicRequest_ServerToolUse(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "assistant",
+			"content": [{"type": "server_tool_use", "name": "web_search", "input": {"q": "x"}}]
+		}]
+	}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ext.ServerTools) != 1 {
+		t.Fatalf("expected 1 server tool capture, got %d", len(ext.ServerTools))
+	}
+	if ext.ServerTools[0].Name != "web_search" {
+		t.Fatalf("server tool name: got %q", ext.ServerTools[0].Name)
+	}
+}
+
+func TestParseAnthropicRequest_ServerToolDefinition(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{"role": "user", "content": "x"}],
+		"tools": [{"type": "web_search_20250305", "name": "web_search"}]
+	}`)
+	params, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Tools) != 0 {
+		t.Fatalf("expected no OpenAI tools (server tool captured instead), got %d", len(params.Tools))
+	}
+	if len(ext.ServerTools) != 1 || ext.ServerTools[0].Type != "web_search_20250305" {
+		t.Fatalf("server tool capture unexpected: %+v", ext.ServerTools)
+	}
+}
+
+func TestParseAnthropicRequest_RedactedThinkingWarnAndDrop(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "assistant",
+			"content": [{"type": "redacted_thinking", "data": "opaque"}]
+		}]
+	}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasWarning(ext, "unsupported_block_type") {
+		t.Fatalf("expected unsupported_block_type warning for redacted_thinking, got %+v", ext.Warnings)
+	}
+}
+
+func TestParseAnthropicRequest_ThinkingBlockSignature(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "assistant",
+			"content": [{"type": "thinking", "thinking": "let me think", "signature": "sig-xyz"}]
+		}]
+	}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := ext.ThinkingSignatures["messages[0].content[0]"]; got != "sig-xyz" {
+		t.Fatalf("thinking signature: got %q, want sig-xyz", got)
+	}
+}
+
+func TestParseAnthropicRequest_ToolUseInputPreservesStructuredJSON(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "assistant",
+			"content": [{"type": "tool_use", "id": "tu_x", "name": "f", "input": {"nested": {"a": 1, "b": [1,2,3]}}}]
+		}]
+	}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := params.Messages[0].OfAssistant.ToolCalls[0].Function.Arguments
+	if !strings.Contains(args, `"nested"`) || !strings.Contains(args, `[1,2,3]`) {
+		t.Fatalf("structured input not preserved: %q", args)
+	}
+}
+
+func TestParseAnthropicRequest_AnthropicBetaCaptured(t *testing.T) {
+	body := []byte(`{"model":"claude","anthropic_beta":"files-api-2025-04-14","messages":[{"role":"user","content":"x"}]}`)
+	_, ext, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ext.AnthropicBeta != "files-api-2025-04-14" {
+		t.Fatalf("anthropic_beta: got %q", ext.AnthropicBeta)
+	}
+}
+
+func TestParseAnthropicRequest_PreservesDocumentOrderUserToolUser(t *testing.T) {
+	body := []byte(`{
+		"model": "claude",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "before"},
+				{"type": "tool_result", "tool_use_id": "tu_1", "content": "mid"},
+				{"type": "text", "text": "after"}
+			]
+		}]
+	}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expected message sequence: user(before), tool(mid), user(after).
+	if len(params.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(params.Messages))
+	}
+	if params.Messages[0].OfUser == nil {
+		t.Fatalf("msg[0] should be user")
+	}
+	// First user message uses array content of one text part.
+	parts := params.Messages[0].OfUser.Content.OfArrayOfContentParts
+	if len(parts) != 1 || parts[0].OfText.Text != "before" {
+		t.Fatalf("first user content unexpected: %+v", parts)
+	}
+	if params.Messages[1].OfTool == nil {
+		t.Fatalf("msg[1] should be tool")
+	}
+	if params.Messages[2].OfUser == nil {
+		t.Fatalf("msg[2] should be user")
+	}
+}
+
+// --- test helpers ---
+
+func hasWarning(ext *ir.IRExtensions, reason string) bool {
+	if ext == nil {
+		return false
+	}
+	for _, w := range ext.Warnings {
+		if w.Reason == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWarningWithDetail(ext *ir.IRExtensions, reason, detail string) bool {
+	if ext == nil {
+		return false
+	}
+	for _, w := range ext.Warnings {
+		if w.Reason == reason && w.Detail == detail {
+			return true
+		}
+	}
+	return false
+}
+
+// Compile-time guard: ensure ParseAnthropicRequest is callable in the
+// shape downstream extproc dispatch expects.
+var _ = func() (*openai.ChatCompletionNewParams, *ir.IRExtensions, error) {
+	return ParseAnthropicRequest(nil)
+}

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
@@ -88,6 +88,133 @@ func TestHandleAnthropicRouting_AllowsStreaming(t *testing.T) {
 	}
 }
 
+// TestParseRequestForProtocol_OpenAIDefault verifies the dispatch keeps
+// the OpenAI fast path byte-identical when ClientProtocol is empty.
+func TestParseRequestForProtocol_OpenAIDefault(t *testing.T) {
+	ctx := &RequestContext{Headers: map[string]string{}}
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	req, err := parseRequestForProtocol(ctx, body)
+	if err != nil {
+		t.Fatalf("parseRequestForProtocol: %v", err)
+	}
+	if req == nil || req.Model != "gpt-4" {
+		t.Fatalf("unexpected req: %+v", req)
+	}
+	if ctx.IRExtensions != nil {
+		t.Fatalf("expected nil IRExtensions for OpenAI, got %+v", ctx.IRExtensions)
+	}
+}
+
+// TestParseRequestForProtocol_AnthropicSetsIRExtensions verifies that an
+// Anthropic-shape body routes through ParseAnthropicRequest and the
+// resulting IRExtensions is stashed on the context for downstream
+// emitters and plugins.
+func TestParseRequestForProtocol_AnthropicSetsIRExtensions(t *testing.T) {
+	ctx := &RequestContext{
+		Headers:        map[string]string{":path": "/v1/messages"},
+		ClientProtocol: config.ClientProtocolAnthropic,
+	}
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"max_tokens": 2048,
+		"system": [{"type": "text", "text": "be precise", "cache_control": {"type": "ephemeral", "ttl": "5m"}}],
+		"top_k": 40,
+		"metadata": {"user_id": "user-abc"},
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+	}`)
+	req, err := parseRequestForProtocol(ctx, body)
+	if err != nil {
+		t.Fatalf("parseRequestForProtocol: %v", err)
+	}
+	if req == nil || req.Model != "claude-opus-4-7" {
+		t.Fatalf("unexpected req: %+v", req)
+	}
+	if req.MaxTokens.Value != 2048 {
+		t.Fatalf("max_tokens: got %d", req.MaxTokens.Value)
+	}
+	if req.User.Value != "user-abc" {
+		t.Fatalf("user: got %q", req.User.Value)
+	}
+	if ctx.IRExtensions == nil {
+		t.Fatal("expected ctx.IRExtensions to be populated")
+	}
+	if ctx.IRExtensions.SourceProtocol != "anthropic" {
+		t.Fatalf("source protocol: got %q", ctx.IRExtensions.SourceProtocol)
+	}
+	if ctx.IRExtensions.MetadataUserID != "user-abc" {
+		t.Fatalf("metadata user id: got %q", ctx.IRExtensions.MetadataUserID)
+	}
+	if _, ok := ctx.IRExtensions.CacheControl["system.0"]; !ok {
+		t.Fatalf("expected cache control on system.0, got %+v", ctx.IRExtensions.CacheControl)
+	}
+	if ctx.IRExtensions.TopK == nil || *ctx.IRExtensions.TopK != 40 {
+		t.Fatalf("top_k: got %+v", ctx.IRExtensions.TopK)
+	}
+}
+
+// TestParseRequestForProtocol_AnthropicRejectsInvalidBody confirms that
+// parse failures surface as Go errors and do not partially populate
+// IRExtensions on the context.
+func TestParseRequestForProtocol_AnthropicRejectsInvalidBody(t *testing.T) {
+	ctx := &RequestContext{
+		Headers:        map[string]string{":path": "/v1/messages"},
+		ClientProtocol: config.ClientProtocolAnthropic,
+	}
+	if _, err := parseRequestForProtocol(ctx, []byte("{not-json")); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if ctx.IRExtensions != nil {
+		t.Fatalf("expected no IRExtensions on parse failure, got %+v", ctx.IRExtensions)
+	}
+}
+
+// TestValidateAnthropicRequestBody covers the protocol-keyed validation
+// branch added to validateRequestBody. The router error response is the
+// authoritative gate that an OpenAI-shape body validator would otherwise
+// have rejected an Anthropic body for.
+func TestValidateAnthropicRequestBody(t *testing.T) {
+	router := &OpenAIRouter{}
+	tests := []struct {
+		name      string
+		body      string
+		wantError bool
+	}{
+		{name: "valid minimal", body: `{"model":"claude","messages":[{"role":"user","content":"hi"}]}`},
+		{name: "valid with system array", body: `{"model":"claude","system":[{"type":"text","text":"s"}],"messages":[{"role":"user","content":"hi"}]}`},
+		{name: "missing model", body: `{"messages":[{"role":"user","content":"hi"}]}`, wantError: true},
+		{name: "empty model", body: `{"model":"","messages":[{"role":"user","content":"hi"}]}`, wantError: true},
+		{name: "missing messages", body: `{"model":"claude"}`, wantError: true},
+		{name: "messages not array", body: `{"model":"claude","messages":"hi"}`, wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := router.validateAnthropicRequestBody([]byte(tt.body))
+			if tt.wantError && resp == nil {
+				t.Fatalf("expected error response, got nil")
+			}
+			if !tt.wantError && resp != nil {
+				t.Fatalf("expected nil response, got %+v", resp)
+			}
+		})
+	}
+}
+
+// TestValidateRequestBody_AnthropicRoutesThroughAnthropicValidator
+// asserts that the protocol-keyed branch is taken when ClientProtocol is
+// "anthropic" — without the branch, validateRequestBody short-circuits
+// on the /v1/chat/completions path check and accepts ill-formed bodies.
+func TestValidateRequestBody_AnthropicRoutesThroughAnthropicValidator(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{
+		Headers:        map[string]string{":path": "/v1/messages"},
+		ClientProtocol: config.ClientProtocolAnthropic,
+	}
+	resp := router.validateRequestBody([]byte(`{"messages":[{"role":"user","content":"hi"}]}`), ctx)
+	if resp == nil {
+		t.Fatal("expected validation error for missing model")
+	}
+}
+
 func containsJSONField(t *testing.T, body []byte, key string, want bool) bool {
 	t.Helper()
 	var parsed map[string]interface{}

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
@@ -45,7 +46,7 @@ func (r *OpenAIRouter) extractFastRequestState(
 	requestBody []byte,
 	ctx *RequestContext,
 ) (*FastExtractResult, error) {
-	fast, err := extractContentFast(requestBody)
+	fast, err := extractRequestSignalsForProtocol(ctx.ClientProtocol, requestBody)
 	if err != nil {
 		logging.Errorf("Error extracting request fields: %v", err)
 		metrics.RecordRequestError(ctx.RequestModel, "parse_error")
@@ -59,6 +60,20 @@ func (r *OpenAIRouter) extractFastRequestState(
 		ctx.ExpectStreamingResponse = true
 	}
 	return fast, nil
+}
+
+// extractRequestSignalsForProtocol dispatches the gjson-based fast-extract
+// walker by inbound wire format. OpenAI is the default (empty protocol);
+// Anthropic /v1/messages uses the variant that understands the Anthropic
+// content-block shape. Downstream signal consumers see the same
+// FastExtractResult contract regardless of source protocol.
+func extractRequestSignalsForProtocol(clientProtocol string, body []byte) (*FastExtractResult, error) {
+	switch clientProtocol {
+	case config.ClientProtocolAnthropic:
+		return extractContentFastAnthropic(body)
+	default:
+		return extractContentFast(body)
+	}
 }
 
 func (r *OpenAIRouter) runRequestPreRoutingStages(

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
@@ -74,6 +75,24 @@ func extractRequestSignalsForProtocol(clientProtocol string, body []byte) (*Fast
 	default:
 		return extractContentFast(body)
 	}
+}
+
+// parseRequestForProtocol dispatches body parsing by inbound wire format.
+// OpenAI is the default; Anthropic /v1/messages routes through the
+// dedicated inbound parser, whose IRExtensions output is stashed on the
+// request context for downstream emitters and plugins.
+func parseRequestForProtocol(ctx *RequestContext, requestBody []byte) (*openai.ChatCompletionNewParams, error) {
+	if ctx.ClientProtocol != config.ClientProtocolAnthropic {
+		return parseOpenAIRequest(requestBody)
+	}
+	openAIRequest, ext, err := anthropic.ParseAnthropicRequest(requestBody)
+	if err != nil {
+		return nil, err
+	}
+	if ext != nil {
+		ctx.IRExtensions = ext
+	}
+	return openAIRequest, nil
 }
 
 func (r *OpenAIRouter) runRequestPreRoutingStages(
@@ -158,9 +177,9 @@ func (r *OpenAIRouter) prepareRequestForModelRouting(
 ) (*openai.ChatCompletionNewParams, *ext_proc.ProcessingResponse, error) {
 	r.maybeForceImageGenerationModality(userContent, ctx)
 
-	openAIRequest, err := parseOpenAIRequest(requestBody)
+	openAIRequest, err := parseRequestForProtocol(ctx, requestBody)
 	if err != nil {
-		logging.Errorf("Error parsing OpenAI request for routing: %v", err)
+		logging.Errorf("Error parsing request for routing: %v", err)
 		metrics.RecordRequestError(ctx.RequestModel, "parse_error")
 		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid request body: %v", err)
 	}
@@ -239,7 +258,7 @@ func (r *OpenAIRouter) reparseRequestWithMemory(
 		return openAIRequest
 	}
 
-	updatedReq, err := parseOpenAIRequest(requestBody)
+	updatedReq, err := parseRequestForProtocol(ctx, requestBody)
 	if err != nil {
 		logging.ComponentErrorEvent("extproc", "memory_request_reparse_failed", map[string]interface{}{
 			"request_id": ctx.RequestID,

--- a/src/semantic-router/pkg/extproc/processor_req_body_validation.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_validation.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
 
@@ -33,6 +34,10 @@ func (r *OpenAIRouter) validateRequestBody(requestBody []byte, ctx *RequestConte
 		return nil
 	}
 
+	if ctx.ClientProtocol == config.ClientProtocolAnthropic {
+		return r.validateAnthropicRequestBody(requestBody)
+	}
+
 	path := normalizeRequestPath(ctx.Headers[":path"])
 	if path != "" && path != "/v1/chat/completions" {
 		return nil
@@ -46,5 +51,25 @@ func (r *OpenAIRouter) validateRequestBody(requestBody []byte, ctx *RequestConte
 		return r.createErrorResponse(400, "messages field must be an array")
 	}
 
+	return nil
+}
+
+// validateAnthropicRequestBody runs the minimum shape checks the
+// Anthropic Messages spec mandates before the SDK parser ever sees the
+// body. We do not duplicate the parser's per-block validation here —
+// just the two top-level fields whose absence makes the rest of the
+// pipeline ill-defined.
+func (r *OpenAIRouter) validateAnthropicRequestBody(requestBody []byte) *ext_proc.ProcessingResponse {
+	model := gjson.GetBytes(requestBody, "model")
+	if !model.Exists() || model.Type != gjson.String || model.String() == "" {
+		return r.createErrorResponse(400, "model field is required")
+	}
+	messages := gjson.GetBytes(requestBody, "messages")
+	if !messages.Exists() {
+		return r.createErrorResponse(400, "messages field is required")
+	}
+	if !messages.IsArray() {
+		return r.createErrorResponse(400, "messages field must be an array")
+	}
 	return nil
 }

--- a/src/semantic-router/pkg/extproc/processor_req_header_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_test.go
@@ -247,6 +247,43 @@ func assertImmediateErrorResponse(
 	}
 }
 
+func TestValidateRequestHeaders_V1Messages(t *testing.T) {
+	router := &OpenAIRouter{}
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus typev3.StatusCode // 0 means request should pass validation
+	}{
+		{name: "POST /v1/messages allowed", method: "POST", path: "/v1/messages"},
+		{name: "POST /v1/messages with query allowed", method: "POST", path: "/v1/messages?stream=true"},
+		{name: "GET /v1/messages returns 405", method: "GET", path: "/v1/messages", wantStatus: typev3.StatusCode_MethodNotAllowed},
+		{name: "PUT /v1/messages returns 405", method: "PUT", path: "/v1/messages", wantStatus: typev3.StatusCode_MethodNotAllowed},
+		{name: "DELETE /v1/messages returns 405", method: "DELETE", path: "/v1/messages", wantStatus: typev3.StatusCode_MethodNotAllowed},
+		{name: "/v1/messages/anything still 404", method: "POST", path: "/v1/messages/count_tokens", wantStatus: typev3.StatusCode_NotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := router.validateRequestHeaders(tt.method, tt.path)
+			if tt.wantStatus == 0 {
+				if response != nil {
+					t.Fatalf("expected nil response for %s %s, got %+v", tt.method, tt.path, response)
+				}
+				return
+			}
+			if response == nil {
+				t.Fatalf("expected immediate response for %s %s, got nil", tt.method, tt.path)
+			}
+			immediate := response.GetImmediateResponse()
+			if immediate == nil || immediate.Status == nil || immediate.Status.Code != tt.wantStatus {
+				t.Fatalf("expected status %v for %s %s, got %v", tt.wantStatus, tt.method, tt.path, immediate.Status)
+			}
+		})
+	}
+}
+
 func TestDetectClientProtocol(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/src/semantic-router/pkg/extproc/processor_req_header_validation.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_validation.go
@@ -12,6 +12,8 @@ func (r *OpenAIRouter) validateRequestHeaders(method string, path string) *ext_p
 	switch normalizedPath {
 	case "/v1/chat/completions":
 		return validateAllowedMethod(r, method, "POST")
+	case "/v1/messages":
+		return validateAllowedMethod(r, method, "POST")
 	case "/v1/models":
 		return validateAllowedMethod(r, method, "GET")
 	case "/v1/responses":

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/projectiontrace"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ratelimit"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
@@ -200,6 +201,12 @@ type RequestContext struct {
 	// ClientProtocol identifies the inbound wire format (e.g., "anthropic" for /v1/messages).
 	// Empty string means OpenAI-compatible (the default).
 	ClientProtocol string
+
+	// IRExtensions carries protocol-specific fields that have no home in
+	// the OpenAI-shape IR (*openai.ChatCompletionNewParams). Inbound
+	// parsers populate it for non-OpenAI clients; outbound emitters and
+	// plugins read from it. Nil for plain OpenAI requests.
+	IRExtensions *ir.IRExtensions
 
 	// RAG (Retrieval-Augmented Generation) tracking
 	RAGRetrievedContext string  // Retrieved context from RAG plugin

--- a/src/semantic-router/pkg/extproc/utils_fast_anthropic.go
+++ b/src/semantic-router/pkg/extproc/utils_fast_anthropic.go
@@ -1,0 +1,217 @@
+package extproc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// extractContentFastAnthropic mirrors extractContentFast for the Anthropic
+// /v1/messages request shape so the conversation-signal family computes
+// equivalent fast-path signals regardless of inbound protocol.
+//
+// The shape differs from OpenAI in three ways that matter for fast
+// extraction:
+//
+//  1. system is either a string or a TextBlockParam[] — when present, it
+//     counts as one system message regardless of array length, and its
+//     text contributes to the conversation transcript.
+//  2. user / assistant content blocks carry image data under the
+//     image.source object (base64 / url / file_id), not under image_url.
+//  3. tool_use blocks appear inline on assistant turns; tool_result blocks
+//     appear inline on user turns under the same content array.
+//
+// We accept the cost of walking the inbound body twice (once here, once
+// in ParseAnthropicRequest in commit 4) because fast-extract has to run
+// before validation, classification, and the SDK parse — short-circuiting
+// here lets fast_response / rate limit / cache short-circuits avoid the
+// SDK allocation in the common case.
+func extractContentFastAnthropic(body []byte) (*FastExtractResult, error) {
+	r := &FastExtractResult{}
+	if err := extractModelAndStreamFast(body, r); err != nil {
+		return nil, err
+	}
+
+	if system := gjson.GetBytes(body, "system"); system.Exists() {
+		consumeFastExtractAnthropicSystem(system, r)
+	}
+
+	if messages := gjson.GetBytes(body, "messages"); messages.Exists() && messages.IsArray() {
+		messages.ForEach(func(_, msg gjson.Result) bool {
+			consumeFastExtractAnthropicMessage(msg, r)
+			return true
+		})
+	}
+
+	if tools := gjson.GetBytes(body, "tools"); tools.Exists() && tools.IsArray() {
+		tools.ForEach(func(_, _ gjson.Result) bool {
+			r.ToolDefinitionCount++
+			return true
+		})
+	}
+
+	return r, nil
+}
+
+func consumeFastExtractAnthropicSystem(system gjson.Result, result *FastExtractResult) {
+	text := extractAnthropicSystemText(system)
+	// Anthropic's system field is one logical system message regardless of
+	// whether it arrived as a plain string or as an array of TextBlockParam
+	// entries. Mirror that by counting it as one entry, matching how the
+	// OpenAI fast extractor counts a single role=system message.
+	result.SystemMessageCount++
+	if text != "" {
+		result.NonUserMessages = append(result.NonUserMessages, text)
+	}
+}
+
+func extractAnthropicSystemText(system gjson.Result) string {
+	if system.Type == gjson.String {
+		return system.String()
+	}
+	if !system.IsArray() {
+		return ""
+	}
+	var parts []string
+	system.ForEach(func(_, block gjson.Result) bool {
+		if t := block.Get("text").String(); t != "" {
+			parts = append(parts, t)
+		}
+		return true
+	})
+	return strings.Join(parts, " ")
+}
+
+func consumeFastExtractAnthropicMessage(msg gjson.Result, result *FastExtractResult) {
+	role := msg.Get("role").String()
+	content := msg.Get("content")
+
+	text := extractAnthropicTextFromContent(content)
+	hasToolResult, hasToolUse := scanAnthropicBlockTypes(content)
+
+	switch role {
+	case "user":
+		result.UserMessageCount++
+		recordAnthropicUserMessage(result, text, content)
+		if hasToolResult {
+			// Anthropic carries tool_result blocks inline on user turns;
+			// in the OpenAI shape these become tool-role messages, so
+			// count them on the tool channel as well to keep downstream
+			// signal parity.
+			result.ToolMessageCount++
+			result.ToolResultCount++
+		}
+	case "assistant":
+		result.AssistantMessageCount++
+		recordFastExtractNonUserMessage(result, role, text)
+		if hasToolUse {
+			countAnthropicAssistantToolUses(content, result)
+		}
+	}
+}
+
+func recordAnthropicUserMessage(result *FastExtractResult, text string, content gjson.Result) {
+	if result.FirstImageURL == "" {
+		result.FirstImageURL = extractAnthropicImageURLFromContent(content)
+	}
+	if text == "" {
+		return
+	}
+	if result.UserContent != "" {
+		result.PriorUserMessages = append(result.PriorUserMessages, result.UserContent)
+	}
+	result.UserContent = text
+}
+
+func countAnthropicAssistantToolUses(content gjson.Result, result *FastExtractResult) {
+	if !content.IsArray() {
+		return
+	}
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() != "tool_use" {
+			return true
+		}
+		result.AssistantToolCallCount++
+		if name := block.Get("name").String(); name != "" {
+			result.AssistantToolNames = append(result.AssistantToolNames, name)
+		}
+		return true
+	})
+}
+
+// extractAnthropicTextFromContent collects the text payload from an
+// Anthropic content field. Plain string content (the common short-message
+// shape) is returned verbatim; array content yields a space-joined string
+// of every text block in document order.
+func extractAnthropicTextFromContent(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if !content.IsArray() {
+		return ""
+	}
+	var parts []string
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() != "text" {
+			return true
+		}
+		if t := block.Get("text").String(); t != "" {
+			parts = append(parts, t)
+		}
+		return true
+	})
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return strings.Join(parts, " ")
+}
+
+func scanAnthropicBlockTypes(content gjson.Result) (hasToolResult bool, hasToolUse bool) {
+	if !content.IsArray() {
+		return false, false
+	}
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").String() {
+		case "tool_result":
+			hasToolResult = true
+		case "tool_use":
+			hasToolUse = true
+		}
+		return true
+	})
+	return hasToolResult, hasToolUse
+}
+
+// extractAnthropicImageURLFromContent returns the first safe-to-surface
+// image reference from an Anthropic content array. Only inline base64
+// sources are returned (the same SSRF-safety policy as the OpenAI fast
+// extractor); URL and file_id sources are silently skipped here and
+// handled by the full inbound parser.
+func extractAnthropicImageURLFromContent(content gjson.Result) string {
+	if !content.IsArray() {
+		return ""
+	}
+	var found string
+	content.ForEach(func(_, block gjson.Result) bool {
+		if block.Get("type").String() != "image" {
+			return true
+		}
+		source := block.Get("source")
+		if source.Get("type").String() != "base64" {
+			return true
+		}
+		mediaType := source.Get("media_type").String()
+		data := source.Get("data").String()
+		if mediaType == "" || data == "" {
+			return true
+		}
+		candidate := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
+		if isSafeImageDataURL(candidate) {
+			found = candidate
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/src/semantic-router/pkg/extproc/utils_fast_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/utils_fast_anthropic_test.go
@@ -1,0 +1,248 @@
+package extproc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractContentFastAnthropic_MissingModel(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	if _, err := extractContentFastAnthropic(body); err == nil {
+		t.Fatal("expected error for missing model field")
+	}
+}
+
+func TestExtractContentFastAnthropic_StringContentAndSystem(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"system": "you are helpful",
+		"messages": [
+			{"role": "user", "content": "hello"}
+		]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Fatalf("model: got %q, want claude-opus-4-7", got.Model)
+	}
+	if got.UserContent != "hello" {
+		t.Fatalf("user content: got %q, want hello", got.UserContent)
+	}
+	if got.UserMessageCount != 1 {
+		t.Fatalf("user count: got %d, want 1", got.UserMessageCount)
+	}
+	if got.SystemMessageCount != 1 {
+		t.Fatalf("system count: got %d, want 1", got.SystemMessageCount)
+	}
+	if len(got.NonUserMessages) != 1 || got.NonUserMessages[0] != "you are helpful" {
+		t.Fatalf("non-user messages: got %+v", got.NonUserMessages)
+	}
+}
+
+func TestExtractContentFastAnthropic_ArraySystem(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"system": [
+			{"type": "text", "text": "block one"},
+			{"type": "text", "text": "block two"}
+		],
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Array system is still one logical system message; both texts join.
+	if got.SystemMessageCount != 1 {
+		t.Fatalf("system count: got %d, want 1", got.SystemMessageCount)
+	}
+	if len(got.NonUserMessages) != 1 {
+		t.Fatalf("expected one joined non-user message, got %+v", got.NonUserMessages)
+	}
+	if !strings.Contains(got.NonUserMessages[0], "block one") || !strings.Contains(got.NonUserMessages[0], "block two") {
+		t.Fatalf("expected both blocks joined, got %q", got.NonUserMessages[0])
+	}
+}
+
+func TestExtractContentFastAnthropic_ArrayUserContentJoinsText(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "part one"},
+				{"type": "text", "text": "part two"}
+			]
+		}]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got.UserContent, "part one") || !strings.Contains(got.UserContent, "part two") {
+		t.Fatalf("expected both parts in user content, got %q", got.UserContent)
+	}
+}
+
+func TestExtractContentFastAnthropic_StreamFlag(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"stream": true,
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Stream {
+		t.Fatal("expected stream=true")
+	}
+}
+
+func TestExtractContentFastAnthropic_ImageBase64(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "what is this"},
+				{
+					"type": "image",
+					"source": {
+						"type": "base64",
+						"media_type": "image/png",
+						"data": "iVBORw0KGgo="
+					}
+				}
+			]
+		}]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "data:image/png;base64,iVBORw0KGgo="
+	if got.FirstImageURL != want {
+		t.Fatalf("first image url: got %q, want %q", got.FirstImageURL, want)
+	}
+}
+
+func TestExtractContentFastAnthropic_ImageURLNotSurfaced(t *testing.T) {
+	// URL and file_id image sources are not surfaced through the fast path
+	// to preserve SSRF safety; the full inbound parser handles them.
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"messages": [{
+			"role": "user",
+			"content": [{
+				"type": "image",
+				"source": {"type": "url", "url": "https://example.com/x.png"}
+			}]
+		}]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.FirstImageURL != "" {
+		t.Fatalf("expected empty image url for non-base64 source, got %q", got.FirstImageURL)
+	}
+}
+
+func TestExtractContentFastAnthropic_ToolUseCountedOnAssistant(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"messages": [
+			{"role": "user", "content": "search the docs"},
+			{"role": "assistant", "content": [
+				{"type": "text", "text": "let me search"},
+				{"type": "tool_use", "id": "tu_1", "name": "web_search", "input": {"q": "x"}},
+				{"type": "tool_use", "id": "tu_2", "name": "calc", "input": {}}
+			]}
+		]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AssistantToolCallCount != 2 {
+		t.Fatalf("assistant tool calls: got %d, want 2", got.AssistantToolCallCount)
+	}
+	if len(got.AssistantToolNames) != 2 || got.AssistantToolNames[0] != "web_search" || got.AssistantToolNames[1] != "calc" {
+		t.Fatalf("assistant tool names: got %+v", got.AssistantToolNames)
+	}
+}
+
+func TestExtractContentFastAnthropic_ToolResultCountedOnUser(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"messages": [
+			{"role": "user", "content": "search"},
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "tu_1", "name": "web_search", "input": {}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "tu_1", "content": "result"}
+			]}
+		]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ToolMessageCount != 1 || got.ToolResultCount != 1 {
+		t.Fatalf("tool message/result counts: got %d/%d, want 1/1", got.ToolMessageCount, got.ToolResultCount)
+	}
+	// Both user turns still counted; the tool_result-bearing user turn does
+	// not have plain text content so it should not become UserContent.
+	if got.UserMessageCount != 2 {
+		t.Fatalf("user message count: got %d, want 2", got.UserMessageCount)
+	}
+	if got.UserContent != "search" {
+		t.Fatalf("user content: got %q, want %q", got.UserContent, "search")
+	}
+}
+
+func TestExtractContentFastAnthropic_CountsToolDefinitions(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-opus-4-7",
+		"messages": [{"role": "user", "content": "x"}],
+		"tools": [
+			{"name": "a", "input_schema": {}},
+			{"name": "b", "input_schema": {}},
+			{"name": "c", "input_schema": {}}
+		]
+	}`)
+	got, err := extractContentFastAnthropic(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ToolDefinitionCount != 3 {
+		t.Fatalf("tool definitions: got %d, want 3", got.ToolDefinitionCount)
+	}
+}
+
+func TestExtractRequestSignalsForProtocol_DispatchesByProtocol(t *testing.T) {
+	openaiBody := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	anthropicBody := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	// OpenAI default — uses the original walker; string content extracted.
+	got, err := extractRequestSignalsForProtocol("", openaiBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.UserContent != "hi" || got.Model != "gpt-4" {
+		t.Fatalf("openai dispatch unexpected: %+v", got)
+	}
+
+	// Anthropic — the variant walker handles inline array text blocks.
+	got, err = extractRequestSignalsForProtocol("anthropic", anthropicBody)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.UserContent != "hi" || got.Model != "claude-opus-4-7" {
+		t.Fatalf("anthropic dispatch unexpected: %+v", got)
+	}
+}

--- a/src/semantic-router/pkg/ir/extensions.go
+++ b/src/semantic-router/pkg/ir/extensions.go
@@ -1,0 +1,174 @@
+package ir
+
+// IRExtensions is the sidecar envelope attached to a request context when the
+// inbound payload carries fields that have no representation in
+// *openai.ChatCompletionNewParams.
+//
+// Inbound parsers populate it; outbound emitters and plugins read from it;
+// nil means the request is plain OpenAI-shape and no extensions exist.
+//
+// Block IDs (the keys in CacheControl and ThinkingSignatures) are stable
+// JSON-paths derived from the original request body (e.g. "system.0",
+// "messages[3].content[1]") so plugins can mutate the IR core without
+// invalidating sidecar lookups.
+type IRExtensions struct {
+	// SourceProtocol mirrors RequestContext.ClientProtocol at parse time
+	// (e.g. "anthropic"). Stamped by the inbound parser so downstream
+	// consumers do not need to look at the context separately.
+	SourceProtocol string
+
+	// SystemBlocks preserves array-form system prompts when the inbound
+	// shape was a TextBlockParam[] rather than a plain string, so the
+	// outbound emitter can reconstruct the multi-block form.
+	SystemBlocks []SystemBlock
+
+	// CacheControl captures cache_control markers from any block in the
+	// request, keyed by stable block ID. The marked block itself is still
+	// translated into the OpenAI IR; this map exists so the emitter can
+	// re-attach the marker on the outbound side.
+	CacheControl map[string]CacheControlSpec
+
+	// Thinking captures the extended-thinking directive
+	// (type/budget/display). nil means the inbound request did not request
+	// extended thinking.
+	Thinking *ThinkingSpec
+
+	// MetadataUserID mirrors metadata.user_id from the Anthropic request.
+	// Also mirrored into params.User for plugins that key on the OpenAI
+	// user field.
+	MetadataUserID string
+
+	// TopK preserves the Anthropic top_k sampling parameter. There is no
+	// OpenAI equivalent; OpenAI-backend emitters should append a Warning
+	// and drop it.
+	TopK *int64
+
+	// ServerTools captures server-side tool definitions (web_search,
+	// bash, code_execution, text_editor). The emitter decides whether the
+	// backend supports them; OpenAI emitters warn-and-drop.
+	ServerTools []ServerToolSpec
+
+	// ToolChoiceDisableParallel mirrors
+	// tool_choice.disable_parallel_tool_use. False is both the zero value
+	// and the protocol default.
+	ToolChoiceDisableParallel bool
+
+	// ToolStrict captures the per-tool strict-schema flag
+	// (tools[].strict), keyed by function name.
+	ToolStrict map[string]bool
+
+	// Documents captures Anthropic-native document blocks. OpenAI
+	// emitters warn-and-drop.
+	Documents []DocumentBlock
+
+	// CitationsEnabled mirrors any document.citations.enabled=true seen
+	// on a document block.
+	CitationsEnabled bool
+
+	// ThinkingSignatures stores opaque per-thinking-block signatures that
+	// must round-trip for multi-turn extended-thinking continuity, keyed
+	// by stable block ID.
+	ThinkingSignatures map[string]string
+
+	// AnthropicBeta captures the raw anthropic-beta header value, if
+	// present, for later header-pass-through work. The parser only
+	// records; it does not act on the value.
+	AnthropicBeta string
+
+	// Warnings accumulates parse- and emit-time observations. Surfaced via
+	// response headers, structured logging, and metrics.
+	Warnings []Warning
+}
+
+// AppendWarning is nil-safe: when e is nil the call is a no-op, so callers
+// in OpenAI-only code paths (where IRExtensions is nil) do not need to
+// guard.
+func (e *IRExtensions) AppendWarning(w Warning) {
+	if e == nil {
+		return
+	}
+	e.Warnings = append(e.Warnings, w)
+}
+
+// SetCacheControl is nil-safe and lazily initializes the underlying map.
+func (e *IRExtensions) SetCacheControl(blockID string, spec CacheControlSpec) {
+	if e == nil {
+		return
+	}
+	if e.CacheControl == nil {
+		e.CacheControl = make(map[string]CacheControlSpec)
+	}
+	e.CacheControl[blockID] = spec
+}
+
+// SetThinkingSignature is nil-safe and lazily initializes the underlying map.
+func (e *IRExtensions) SetThinkingSignature(blockID, signature string) {
+	if e == nil {
+		return
+	}
+	if e.ThinkingSignatures == nil {
+		e.ThinkingSignatures = make(map[string]string)
+	}
+	e.ThinkingSignatures[blockID] = signature
+}
+
+// SetToolStrict is nil-safe and lazily initializes the underlying map.
+func (e *IRExtensions) SetToolStrict(toolName string, strict bool) {
+	if e == nil {
+		return
+	}
+	if e.ToolStrict == nil {
+		e.ToolStrict = make(map[string]bool)
+	}
+	e.ToolStrict[toolName] = strict
+}
+
+// SystemBlock records the shape of one Anthropic system block. When the
+// inbound system field was a plain string, no SystemBlocks are emitted —
+// only when the inbound used the TextBlockParam[] form.
+type SystemBlock struct {
+	BlockID      string
+	Text         string
+	CacheControl *CacheControlSpec
+}
+
+// CacheControlSpec mirrors anthropic.CacheControlEphemeralParam. Type is
+// always "ephemeral" today (the only Anthropic-supported value); TTL is one
+// of "5m", "1h", or "" (use the model default).
+type CacheControlSpec struct {
+	Type string
+	TTL  string
+}
+
+// ThinkingSpec mirrors the Anthropic thinking-config object. Display
+// distinguishes summarized vs omitted reasoning output; empty means the
+// inbound did not pin a display mode.
+type ThinkingSpec struct {
+	Type         string
+	Display      string
+	BudgetTokens int64
+}
+
+// ServerToolSpec captures a server-side tool definition. Parameters is the
+// raw, untyped tool-config map so the outbound emitter can decide what to
+// send to a server-tool-capable backend.
+type ServerToolSpec struct {
+	Type       string
+	Name       string
+	Parameters map[string]any
+}
+
+// DocumentBlock captures one Anthropic document block. SourceType is one
+// of "base64", "url", "text", "content", "file"; MediaType is the MIME
+// type when known; Data is the source payload (URL, base64 bytes, or
+// inline text) keyed by SourceType. InlineContent holds the parsed
+// sub-blocks when SourceType is "content" (custom-chunked documents).
+type DocumentBlock struct {
+	BlockID       string
+	SourceType    string
+	MediaType     string
+	Data          string
+	Citations     bool
+	CacheControl  *CacheControlSpec
+	InlineContent []SystemBlock
+}

--- a/src/semantic-router/pkg/ir/extensions_test.go
+++ b/src/semantic-router/pkg/ir/extensions_test.go
@@ -1,0 +1,88 @@
+package ir
+
+import (
+	"testing"
+)
+
+func TestAppendWarning_NilSafe(t *testing.T) {
+	var ext *IRExtensions
+	ext.AppendWarning(Warning{Field: "x", Reason: "dropped"})
+}
+
+func TestAppendWarning_AppendsToSlice(t *testing.T) {
+	ext := &IRExtensions{}
+	ext.AppendWarning(Warning{Field: "a", Reason: "dropped", Severity: WarningSeverityLossy})
+	ext.AppendWarning(Warning{Field: "b", Reason: "coerced", Severity: WarningSeverityInfo})
+
+	if len(ext.Warnings) != 2 {
+		t.Fatalf("expected 2 warnings, got %d", len(ext.Warnings))
+	}
+	if ext.Warnings[0].Field != "a" || ext.Warnings[0].Severity != WarningSeverityLossy {
+		t.Fatalf("first warning unexpected: %+v", ext.Warnings[0])
+	}
+	if ext.Warnings[1].Field != "b" || ext.Warnings[1].Severity != WarningSeverityInfo {
+		t.Fatalf("second warning unexpected: %+v", ext.Warnings[1])
+	}
+}
+
+func TestSetCacheControl_NilSafe(t *testing.T) {
+	var ext *IRExtensions
+	ext.SetCacheControl("system.0", CacheControlSpec{Type: "ephemeral", TTL: "5m"})
+}
+
+func TestSetCacheControl_LazyInit(t *testing.T) {
+	ext := &IRExtensions{}
+	ext.SetCacheControl("system.0", CacheControlSpec{Type: "ephemeral", TTL: "5m"})
+	ext.SetCacheControl("messages[0].content[1]", CacheControlSpec{Type: "ephemeral", TTL: "1h"})
+
+	if got := ext.CacheControl["system.0"].TTL; got != "5m" {
+		t.Fatalf("expected ttl=5m, got %q", got)
+	}
+	if got := ext.CacheControl["messages[0].content[1]"].TTL; got != "1h" {
+		t.Fatalf("expected ttl=1h, got %q", got)
+	}
+}
+
+func TestSetThinkingSignature_LazyInit(t *testing.T) {
+	ext := &IRExtensions{}
+	ext.SetThinkingSignature("messages[2].content[0]", "sig-abc")
+
+	if got := ext.ThinkingSignatures["messages[2].content[0]"]; got != "sig-abc" {
+		t.Fatalf("expected signature=sig-abc, got %q", got)
+	}
+}
+
+func TestSetToolStrict_LazyInit(t *testing.T) {
+	ext := &IRExtensions{}
+	ext.SetToolStrict("search", true)
+	ext.SetToolStrict("calc", false)
+
+	if !ext.ToolStrict["search"] {
+		t.Fatalf("expected strict=true for search")
+	}
+	if ext.ToolStrict["calc"] {
+		t.Fatalf("expected strict=false for calc")
+	}
+}
+
+func TestNilExtensions_AccessorsAreNoOps(t *testing.T) {
+	var ext *IRExtensions
+	ext.SetCacheControl("x", CacheControlSpec{})
+	ext.SetThinkingSignature("x", "y")
+	ext.SetToolStrict("x", true)
+	ext.AppendWarning(Warning{})
+}
+
+func TestWarningSeverityValues(t *testing.T) {
+	// Stability check: severities are part of the wire contract via metrics
+	// labels, so document their integer values.
+	if WarningSeverityInfo != 0 {
+		t.Fatalf("WarningSeverityInfo must be 0, got %d", WarningSeverityInfo)
+	}
+	if WarningSeverityLossy != 1 {
+		t.Fatalf("WarningSeverityLossy must be 1, got %d", WarningSeverityLossy)
+	}
+	if WarningSeverityError != 2 {
+		t.Fatalf("WarningSeverityError must be 2, got %d", WarningSeverityError)
+	}
+}

--- a/src/semantic-router/pkg/ir/warnings.go
+++ b/src/semantic-router/pkg/ir/warnings.go
@@ -1,0 +1,38 @@
+// Package ir contains protocol-neutral intermediate-representation extension
+// types. The IR core remains *openai.ChatCompletionNewParams (the existing
+// router contract); IRExtensions is an additive sidecar populated by inbound
+// parsers for fields that do not have an OpenAI-native home.
+//
+// Nil is the canonical "absent" value: an OpenAI inbound request leaves
+// IRExtensions nil end-to-end, and every accessor on *IRExtensions is
+// nil-safe.
+package ir
+
+// WarningSeverity classifies translation observations for observability.
+// Lossy warnings indicate data was discarded or coerced; Info warnings are
+// non-actionable; Error warnings indicate translation could not preserve a
+// required field.
+type WarningSeverity int
+
+const (
+	// WarningSeverityInfo is non-actionable context, surfaced for diagnostics only.
+	WarningSeverityInfo WarningSeverity = iota
+	// WarningSeverityLossy indicates a field was dropped or coerced during translation.
+	WarningSeverityLossy
+	// WarningSeverityError indicates a required field could not be preserved.
+	WarningSeverityError
+)
+
+// Warning surfaces a single translation observation. Warnings flow through
+// the response header pipeline (X-VSR-Translation-Warning, future PR),
+// structured logging, and Prometheus counters.
+//
+// Field is a dotted JSON path into the inbound body (e.g.
+// "messages[3].content[1].cache_control.ttl") so post-hoc analysis can map
+// the warning back to the originating client payload.
+type Warning struct {
+	Field    string
+	Reason   string
+	Severity WarningSeverity
+	Detail   string
+}


### PR DESCRIPTION
> **RFC**: #1946 — design rationale, alternatives considered, decisions invited from maintainers

Second PR in the native Anthropic `/v1/messages` ingress series (tracking #1404).
Now that #1937 has merged, this is the next PR in the series and its diff
reflects PR2-only content.

## What

Adds the machinery to turn an inbound Anthropic Messages request into the
protocol-neutral IR the rest of the ExtProc pipeline already consumes. With
#1937 supplying the `ClientProtocol` primitive, this PR makes `/v1/messages`
a first-class ingress alongside `/v1/chat/completions` and `/v1/responses`.

## Commits

1. **`[Router] add IRExtensions envelope for non-OpenAI-native fields`** —
   new `pkg/ir` package with the `IRExtensions` struct (cache_control sidecar,
   ServerTools, anthropic-beta header, top_k, thinking config, document blocks,
   metadata.user_id) and a `Warnings` aggregator. Nil-safe by design.
2. **`[Router] allow POST /v1/messages in request header validation`** —
   adds `/v1/messages` to the endpoint allow-list so the request reaches the
   body phase. POST only; other methods return 405.
3. **`[Router] add Anthropic variant of extractContentFast`** —
   gjson-only fast path that pulls a stable digest of the Anthropic body for
   the same cache/dedup contexts the OpenAI variant feeds.
4. **`[Router] add Anthropic inbound parser for /v1/messages requests`** —
   the heavy one. `ParseAnthropicRequest` produces a
   (`*openai.ChatCompletionNewParams`, `*ir.IRExtensions`) pair. Block-type
   coverage: text / image (base64/url/file_id) / tool_use / tool_result
   (string content, array content, is_error) / thinking (with signature
   round-trip) / document / system as string-or-array with per-block
   cache_control / tools (custom + server) / tool_choice (auto/none/any/named)
   with `disable_parallel_tool_use` mirrored to OpenAI `ParallelToolCalls` /
   `metadata.user_id` mirrored to `params.User` / `top_k`, anthropic-beta,
   redacted_thinking warn-and-drop. cache_control markers captured into the
   sidecar map keyed by stable JSON-path block IDs so plugins can mutate the
   IR without invalidating sidecar lookups.
5. **`[Router] route /v1/messages requests through Anthropic inbound parser`** —
   wires the dispatch: `ClientProtocol == "anthropic"` branches the request-body
   pipeline through `ParseAnthropicRequest` and a new
   `validateAnthropicRequestBody`. Memory reparse is protocol-aware so plugin
   mutations rebuild the IR through the right parser.

## What's still to come

This PR series is mid-flight. Follow-ups:

- **PR3** — header pass-through policy, `x-claude-code-session-id` mirroring,
  lossiness warnings surfaced as response headers.
- **PR4** — Anthropic outbound emitter for non-streaming responses (IR →
  Anthropic body shape, including `cache_control` round-trip via the sidecar).
- **PR5** — Anthropic SSE re-emit for streaming responses (will also fix the
  thinking-delta / signature-delta drops noted in the existing
  `client_stream.go` default case).

A small **sibling bug-fix PR** (separate from this series) for the
pre-existing `pkg/anthropic/client.go` defects (`tool_result.is_error`
silently dropped; `tool_result` array content flattened to empty string)
will land in parallel.

## Test plan

- [x] `make agent-lint CHANGED_FILES=...` clean (golangci-lint with project
      config, pre-commit hooks, supply-chain scan, reference-config test)
- [x] `go vet` and `go build` clean on touched packages
- [x] DCO sign-off on all 5 commits, SSH-signed
- [x] Block-type coverage exercised by `inbound_test.go` (~640 LOC of
      table-driven assertions; covers each block type, cache_control sidecar,
      tool_choice variants, server tools, lossiness warnings)
- [x] Dispatch wiring exercised by `processor_req_body_anthropic_test.go`
- [x] E2E test added: `e2e/testcases/anthropic_messages_request.go` (`anthropic-messages-request`) — POST `/v1/messages` returns 200 with JSON body and routing headers; registered in BaselineRouterContract
- [ ] Upstream CI — runs once this PR is marked ready

## Why now

Lays the body-phase foundation so PR3/PR4/PR5 can layer the response side
(header passthrough, outbound emission, streaming translation) without
re-inventing the dispatch. After PR2 lands, the request side of Anthropic
ingress is feature-complete; what remains is the response side and the
ergonomic edges.

## Related

- Builds on #1937 (PR1: ClientProtocol detection, now merged)
- Tracking issue: #1404 (dual-protocol entry points)
- Symmetric to the existing OpenAI→Anthropic emitter in #1922 / streaming in #1926


