### PR TITLE
feat(anthropic): header pass-through, session-id mirroring, and lossiness response headers

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -14,7 +14,7 @@ top-to-bottom; the first non-empty value wins.
 |---|-----------------------------------------|--------------------------------------------------------------------------------------------------|
 | 1 | `ResponseAPICtx.ConversationID`         | Response API only. Stamped by the Response API extractor.                                        |
 | 2 | `x-session-id` header                   | Explicit operator/SDK pin. Highest-priority client-supplied source.                              |
-| 3 | `x-claude-code-session-id` header       | Per-conversation UUID emitted by the Claude Code CLI on `/v1/messages` requests.                 |
+| 3 | `x-claude-code-session-id` header       | Opaque per-conversation token emitted by the Claude Code CLI on `/v1/messages` requests. The router passes it through verbatim and does not validate format. |
 | 4 | `metadata.user_id` (Anthropic body)     | Mirrored by the Anthropic inbound parser into `IRExtensions.MetadataUserID`. Prefixed `ant-md-`. |
 | 5 | `deriveSessionIDFromMessages`           | Fingerprint over the message thread plus the resolved authz user.                                |
 | 6 | `deriveSessionIDFromMessagesStructure`  | Fingerprint over message structure when no user identity is available.                           |

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,52 @@
+# Session identification
+
+The router derives a session identifier (`RequestContext.SessionID`) for
+every request so session-aware plugins, memory operations, and telemetry
+agree on a single key. This document describes the priority order and
+the stability contract.
+
+## Priority order
+
+`populateSessionTransitionFields` evaluates the following sources
+top-to-bottom; the first non-empty value wins.
+
+| # | Source                                  | Provenance                                                                                       |
+|---|-----------------------------------------|--------------------------------------------------------------------------------------------------|
+| 1 | `ResponseAPICtx.ConversationID`         | Response API only. Stamped by the Response API extractor.                                        |
+| 2 | `x-session-id` header                   | Explicit operator/SDK pin. Highest-priority client-supplied source.                              |
+| 3 | `x-claude-code-session-id` header       | Per-conversation UUID emitted by the Claude Code CLI on `/v1/messages` requests.                 |
+| 4 | `metadata.user_id` (Anthropic body)     | Mirrored by the Anthropic inbound parser into `IRExtensions.MetadataUserID`. Prefixed `ant-md-`. |
+| 5 | `deriveSessionIDFromMessages`           | Fingerprint over the message thread plus the resolved authz user.                                |
+| 6 | `deriveSessionIDFromMessagesStructure`  | Fingerprint over message structure when no user identity is available.                           |
+| 7 | `deriveSessionIDFromRequestID`          | SHA-256 of `x-request-id`. Last resort.                                                          |
+
+### Why this order
+
+- (1) and (2) are pinning sources controlled by the deployment or the
+  client; they must override any router-derived value.
+- (3) sits above (4) because the Claude Code header is per-conversation
+  whereas `metadata.user_id` is per-installation (the same value across
+  unrelated conversations).
+- (4) gives non-Claude-Code Anthropic SDK users that set
+  `metadata.user_id` a stable seed before the message-fingerprint
+  fallbacks engage.
+- (5)–(7) are the pre-existing chat-completion fallbacks and remain
+  unchanged.
+
+## Stability contract
+
+The header values at (2) and (3) pass through verbatim. The router does
+not hash, salt, or namespace them. Plugins receive whatever the client
+sent, modulo whitespace trimming.
+
+If a deployment needs to namespace session IDs for privacy reasons (for
+example to map a Claude Code UUID into an internal per-tenant key), run
+a hashing plugin in front of the router and have it write the
+transformed value into `x-session-id` before the request reaches the
+router. The router will then surface the hashed value because
+`x-session-id` outranks `x-claude-code-session-id`.
+
+The `ant-md-` prefix at (4) is part of the wire contract: it lets
+session-aware code distinguish a value seeded from `metadata.user_id`
+from a value seeded by a header. Renaming the prefix is a breaking
+change for any plugin pattern-matching on the namespace.

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -9,6 +9,7 @@ var RouterSmoke = []string{
 var BaselineRouterContract = []string{
 	"chat-completions-request",
 	"anthropic-messages-request",
+	"anthropic-messages-protocol-headers",
 	"apiserver-runtime-config-endpoints",
 	"apiserver-classification-endpoints",
 	"chat-completions-stress-request",

--- a/e2e/testcases/anthropic_messages_headers.go
+++ b/e2e/testcases/anthropic_messages_headers.go
@@ -1,0 +1,90 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-messages-protocol-headers", pkgtestcases.TestCase{
+		Description: "Verify x-vsr-inbound-protocol/x-vsr-outbound-protocol markers and absence of lossiness warnings for clean /v1/messages requests",
+		Tags:        []string{"anthropic", "headers", "observability"},
+		Fn:          testAnthropicMessagesProtocolHeaders,
+	})
+}
+
+// testAnthropicMessagesProtocolHeaders asserts that the response of a clean
+// /v1/messages request carries the protocol-marker headers the router emits
+// for every translated request, and that no lossiness warnings are reported
+// when the request body uses only fields the router knows how to translate.
+// These headers are the operator-facing contract introduced by the warnings
+// PR; their presence is what makes a translation cell observable from the
+// outside without scraping internal logs.
+func testAnthropicMessagesProtocolHeaders(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Verifying protocol marker headers on /v1/messages response")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	// Use a deliberately plain request body: only fields the inbound parser
+	// translates without warnings (model, max_tokens, single text message,
+	// optional system string). Anything richer would risk warnings that
+	// later PRs in the series may add.
+	resp, err := sendAnthropicMessagesRequest(ctx, anthropicMessagesRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		System:    "You are a helpful assistant.",
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "Hello."},
+		},
+	}, localPort)
+	if err != nil {
+		return fmt.Errorf("anthropic messages request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	inbound := resp.Header.Get("x-vsr-inbound-protocol")
+	outbound := resp.Header.Get("x-vsr-outbound-protocol")
+	lossiness := resp.Header.Get("x-vsr-lossiness-warnings")
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code":       resp.StatusCode,
+			"inbound_protocol":  inbound,
+			"outbound_protocol": outbound,
+			"lossiness":         lossiness,
+		})
+	}
+
+	if inbound != "anthropic" {
+		return fmt.Errorf("expected x-vsr-inbound-protocol=anthropic, got %q", inbound)
+	}
+	// Outbound protocol depends on the backend the router selected. In the
+	// kubernetes e2e profile the backend is OpenAI-shaped (llm-katan), so
+	// outbound must be openai. If a future profile points the backend at
+	// an Anthropic-native endpoint this assertion would tighten there.
+	if outbound != "openai" {
+		return fmt.Errorf("expected x-vsr-outbound-protocol=openai for kubernetes profile, got %q", outbound)
+	}
+	if lossiness != "" {
+		return fmt.Errorf("expected no x-vsr-lossiness-warnings for clean request, got %q", lossiness)
+	}
+
+	return nil
+}

--- a/e2e/testcases/anthropic_messages_headers.go
+++ b/e2e/testcases/anthropic_messages_headers.go
@@ -59,6 +59,11 @@ func testAnthropicMessagesProtocolHeaders(ctx context.Context, client *kubernete
 		return fmt.Errorf("expected status 200, got %d", resp.StatusCode)
 	}
 
+	// Header names are duplicated as string literals here because the
+	// e2e module (e2e/go.mod) is intentionally decoupled from the
+	// router module (src/semantic-router/go.mod) and does not import
+	// pkg/headers. If a header name changes upstream, this test must
+	// be updated explicitly.
 	inbound := resp.Header.Get("x-vsr-inbound-protocol")
 	outbound := resp.Header.Get("x-vsr-outbound-protocol")
 	lossiness := resp.Header.Get("x-vsr-lossiness-warnings")
@@ -75,10 +80,11 @@ func testAnthropicMessagesProtocolHeaders(ctx context.Context, client *kubernete
 	if inbound != "anthropic" {
 		return fmt.Errorf("expected x-vsr-inbound-protocol=anthropic, got %q", inbound)
 	}
-	// Outbound protocol depends on the backend the router selected. In the
-	// kubernetes e2e profile the backend is OpenAI-shaped (llm-katan), so
-	// outbound must be openai. If a future profile points the backend at
-	// an Anthropic-native endpoint this assertion would tighten there.
+	// Outbound protocol depends on the backend the router selected. In
+	// the kubernetes e2e profile the backend is OpenAI-shaped, so
+	// outbound must be openai. If a future profile points the backend
+	// at an Anthropic-native endpoint this assertion would tighten
+	// there.
 	if outbound != "openai" {
 		return fmt.Errorf("expected x-vsr-outbound-protocol=openai for kubernetes profile, got %q", outbound)
 	}

--- a/src/semantic-router/pkg/anthropic/inbound_test.go
+++ b/src/semantic-router/pkg/anthropic/inbound_test.go
@@ -609,7 +609,7 @@ func TestParseAnthropicRequest_PreservesDocumentOrderUserToolUser(t *testing.T) 
 
 // --- test helpers ---
 
-func hasWarning(ext *ir.IRExtensions, reason string) bool {
+func hasWarning(ext *ir.IRExtensions, reason ir.WarningReason) bool {
 	if ext == nil {
 		return false
 	}
@@ -621,7 +621,7 @@ func hasWarning(ext *ir.IRExtensions, reason string) bool {
 	return false
 }
 
-func hasWarningWithDetail(ext *ir.IRExtensions, reason, detail string) bool {
+func hasWarningWithDetail(ext *ir.IRExtensions, reason ir.WarningReason, detail string) bool {
 	if ext == nil {
 		return false
 	}

--- a/src/semantic-router/pkg/extproc/extproc_test.go
+++ b/src/semantic-router/pkg/extproc/extproc_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -2206,7 +2207,11 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 	assert.NotNil(t, headerMutation, "HeaderMutation should not be nil for successful non-cached response")
 
 	setHeaders := headerMutation.GetSetHeaders()
-	assert.Len(t, setHeaders, 4, "Should have 4 VSR headers")
+	// 4 standard decision headers + x-vsr-inbound-protocol +
+	// x-vsr-outbound-protocol (translation-cell markers added by the
+	// Anthropic ingress series; emitted on every non-cache-hit response
+	// so operators can identify the cell that handled the request).
+	assert.Len(t, setHeaders, 6, "Should have 6 VSR headers")
 
 	// Verify each header
 	headerMap := make(map[string]string)
@@ -2218,6 +2223,8 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 	assert.Equal(t, "on", headerMap["x-vsr-selected-reasoning"])
 	assert.Equal(t, "deepseek-v31", headerMap["x-vsr-selected-model"])
 	assert.Equal(t, "true", headerMap["x-vsr-injected-system-prompt"])
+	assert.Equal(t, "openai", headerMap["x-vsr-inbound-protocol"])
+	assert.Equal(t, "openai", headerMap["x-vsr-outbound-protocol"])
 }
 
 func TestVSRHeadersNotAddedOnCacheHit(t *testing.T) {
@@ -2287,9 +2294,23 @@ func TestVSRHeadersNotAddedOnErrorResponse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 
-	// Verify VSR headers were NOT added due to error status
+	// Decision/signal headers are NOT added on error responses, but the
+	// translation-cell protocol markers (x-vsr-inbound-protocol and
+	// x-vsr-outbound-protocol) ride on every non-cache-hit response —
+	// success or error — so operators can identify which translation
+	// cell handled a failed request. See processor_res_header_mutation.go.
 	headerMutation := response.GetResponseHeaders().GetResponse().GetHeaderMutation()
-	assert.Nil(t, headerMutation, "HeaderMutation should be nil for error response")
+	require.NotNil(t, headerMutation, "HeaderMutation should carry protocol markers even on error")
+	setHeaders := headerMutation.GetSetHeaders()
+	assert.Len(t, setHeaders, 2, "Error response should have only the 2 protocol-marker headers")
+	headerMap := make(map[string]string)
+	for _, header := range setHeaders {
+		headerMap[header.Header.Key] = string(header.Header.RawValue)
+	}
+	assert.Equal(t, "openai", headerMap["x-vsr-inbound-protocol"])
+	assert.Equal(t, "openai", headerMap["x-vsr-outbound-protocol"])
+	assert.NotContains(t, headerMap, "x-vsr-selected-category", "decision headers must not appear on error")
+	assert.NotContains(t, headerMap, "x-vsr-selected-model", "decision headers must not appear on error")
 }
 
 func TestVSRHeadersPartialInformation(t *testing.T) {
@@ -2329,7 +2350,10 @@ func TestVSRHeadersPartialInformation(t *testing.T) {
 	assert.NotNil(t, headerMutation)
 
 	setHeaders := headerMutation.GetSetHeaders()
-	assert.Len(t, setHeaders, 3, "Should have 3 VSR headers (excluding empty reasoning mode, but including injected-system-prompt)")
+	// 3 standard decision headers (excluding empty reasoning mode, but
+	// including injected-system-prompt) + 2 translation-cell protocol
+	// markers (x-vsr-inbound-protocol + x-vsr-outbound-protocol).
+	assert.Len(t, setHeaders, 5, "Should have 5 VSR headers")
 
 	// Verify each header
 	headerMap := make(map[string]string)

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -272,6 +272,7 @@ func (r *OpenAIRouter) buildRouteHeaderState(
 	}
 	state.removeHeaders = append(state.removeHeaders, r.CredentialResolver.HeadersToStrip()...)
 	appendProfileHeaders(&state.setHeaders, profile)
+	appendCapturedPassThroughHeaders(&state.setHeaders, profile, ctx)
 	appendRoutingHeaders(&state.setHeaders, model)
 
 	return state, nil
@@ -336,6 +337,39 @@ func appendProfileHeaders(setHeaders *[]*core.HeaderValueOption, profile *config
 		return
 	}
 	for key, value := range profile.ExtraHeaders {
+		*setHeaders = append(*setHeaders, &core.HeaderValueOption{
+			Header: &core.HeaderValue{Key: key, RawValue: []byte(value)},
+		})
+	}
+}
+
+// appendCapturedPassThroughHeaders layers inbound Anthropic
+// pass-through headers (captured at the request-header phase into
+// IRExtensions) under the provider-profile pin. ExtraHeaders wins on
+// any collision so deployments can pin a known-tested anthropic-version
+// without the client forcing a different one.
+func appendCapturedPassThroughHeaders(
+	setHeaders *[]*core.HeaderValueOption,
+	profile *config.ProviderProfile,
+	ctx *RequestContext,
+) {
+	if ctx == nil || ctx.IRExtensions == nil {
+		return
+	}
+	captured := map[string]string{
+		"anthropic-version":                         ctx.IRExtensions.InboundAnthropicVersion,
+		"anthropic-beta":                            ctx.IRExtensions.InboundAnthropicBeta,
+		"anthropic-dangerous-direct-browser-access": ctx.IRExtensions.InboundDangerousDirectBrowserAccess,
+	}
+	for key, value := range captured {
+		if value == "" {
+			continue
+		}
+		if profile != nil {
+			if _, pinned := profile.ExtraHeaders[key]; pinned {
+				continue
+			}
+		}
 		*setHeaders = append(*setHeaders, &core.HeaderValueOption{
 			Header: &core.HeaderValue{Key: key, RawValue: []byte(value)},
 		})

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -362,22 +362,18 @@ func appendCapturedPassThroughHeaders(
 	if ctx == nil || ctx.IRExtensions == nil {
 		return
 	}
-	captured := map[string]string{
-		"anthropic-version":                         ctx.IRExtensions.InboundAnthropicVersion,
-		"anthropic-beta":                            ctx.IRExtensions.InboundAnthropicBeta,
-		"anthropic-dangerous-direct-browser-access": ctx.IRExtensions.InboundDangerousDirectBrowserAccess,
-	}
-	for key, value := range captured {
+	for _, h := range anthropicPassThroughHeaders {
+		value := h.read(ctx.IRExtensions)
 		if value == "" {
 			continue
 		}
 		if profile != nil {
-			if _, pinned := profile.ExtraHeaders[key]; pinned {
+			if _, pinned := profile.ExtraHeaders[h.name]; pinned {
 				continue
 			}
 		}
 		*setHeaders = append(*setHeaders, &core.HeaderValueOption{
-			Header: &core.HeaderValue{Key: key, RawValue: []byte(value)},
+			Header: &core.HeaderValue{Key: h.name, RawValue: []byte(value)},
 		})
 	}
 }

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -348,6 +348,12 @@ func appendProfileHeaders(setHeaders *[]*core.HeaderValueOption, profile *config
 // IRExtensions) under the provider-profile pin. ExtraHeaders wins on
 // any collision so deployments can pin a known-tested anthropic-version
 // without the client forcing a different one.
+//
+// Sibling mechanism: requests routed to an Anthropic-native upstream
+// take a different path that forwards the same headers via
+// anthropic.BuildRequestHeadersWithPassthrough (pkg/anthropic), using
+// the AnthropicPassthrough carrier on RequestContext. The two paths
+// fire on disjoint routing branches.
 func appendCapturedPassThroughHeaders(
 	setHeaders *[]*core.HeaderValueOption,
 	profile *config.ProviderProfile,

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -10,7 +10,9 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/tracing"
 )
@@ -26,6 +28,7 @@ func (r *OpenAIRouter) handleRequestHeaders(v *ext_proc.ProcessingRequest_Reques
 
 	setRequestHeaderSpanAttributes(span, ctx, method, path)
 	detectClientProtocol(path, ctx)
+	applyHeaderPassThroughPolicy(ctx)
 
 	// Honor x-vsr-skip-processing as early as possible: once captured we bypass
 	// every router-side header check (replay API, validation, response-API
@@ -175,6 +178,101 @@ func buildIdentityEncodingRequestMutation() *ext_proc.HeaderMutation {
 				Value: "identity",
 			},
 		}},
+	}
+}
+
+// hopByHopDropList is the set of HTTP framing headers we strip from
+// ctx.Headers before any downstream filter or body-phase routing sees
+// them. Envoy already strips most of these from the request before
+// extproc receives it; we re-apply the policy as defense-in-depth and
+// to make the contract explicit in code.
+var hopByHopDropList = []string{
+	"host",
+	"content-length",
+	"connection",
+	"keep-alive",
+	"proxy-connection",
+	"transfer-encoding",
+	"upgrade",
+	"te",
+	"trailer",
+	"expect",
+}
+
+// anthropicPassThroughHeader names a header captured from an Anthropic
+// inbound request so the body-phase routing step can layer the value
+// under the provider-profile pin. Stored on IRExtensions; downstream
+// reads decide whether to forward.
+type anthropicPassThroughHeader struct {
+	name   string
+	assign func(ext *ir.IRExtensions, value string)
+}
+
+var anthropicPassThroughHeaders = []anthropicPassThroughHeader{
+	{
+		name:   "anthropic-version",
+		assign: func(ext *ir.IRExtensions, v string) { ext.InboundAnthropicVersion = v },
+	},
+	{
+		name:   "anthropic-beta",
+		assign: func(ext *ir.IRExtensions, v string) { ext.InboundAnthropicBeta = v },
+	},
+	{
+		name:   "anthropic-dangerous-direct-browser-access",
+		assign: func(ext *ir.IRExtensions, v string) { ext.InboundDangerousDirectBrowserAccess = v },
+	},
+}
+
+// applyHeaderPassThroughPolicy enforces the request-header pass-through
+// contract: hop-by-hop framing headers are stripped from ctx.Headers
+// (defense-in-depth — Envoy already filters most), and on Anthropic
+// ingress the named pass-through headers are captured into
+// IRExtensions so the body-phase routing step can layer them under any
+// provider-profile pin.
+//
+// KEEP-by-default for everything else: ctx.Headers retains the inbound
+// view of any header not in the drop list. The body-phase routing step
+// decides what to forward to the upstream.
+func applyHeaderPassThroughPolicy(ctx *RequestContext) {
+	if ctx == nil || ctx.Headers == nil {
+		return
+	}
+
+	for _, name := range hopByHopDropList {
+		delete(ctx.Headers, name)
+	}
+
+	if ctx.ClientProtocol != config.ClientProtocolAnthropic {
+		return
+	}
+	capturePassThroughHeaders(ctx)
+}
+
+// capturePassThroughHeaders records the inbound values of the named
+// Anthropic pass-through headers into IRExtensions. The PR2 inbound
+// parser may already have allocated IRExtensions when this runs (it
+// runs at body-parse time, after the header phase); both call sites
+// tolerate the other running first.
+func capturePassThroughHeaders(ctx *RequestContext) {
+	captured := make(map[string]string, len(anthropicPassThroughHeaders))
+	for _, h := range anthropicPassThroughHeaders {
+		if v := strings.TrimSpace(headerValueCI(ctx, h.name)); v != "" {
+			captured[h.name] = v
+		}
+	}
+	if len(captured) == 0 {
+		return
+	}
+
+	if ctx.IRExtensions == nil {
+		ctx.IRExtensions = &ir.IRExtensions{
+			SourceProtocol: ctx.ClientProtocol,
+		}
+	}
+	for _, h := range anthropicPassThroughHeaders {
+		if v, ok := captured[h.name]; ok {
+			h.assign(ctx.IRExtensions, v)
+		}
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -202,24 +202,31 @@ var hopByHopDropList = []string{
 // anthropicPassThroughHeader names a header captured from an Anthropic
 // inbound request so the body-phase routing step can layer the value
 // under the provider-profile pin. Stored on IRExtensions; downstream
-// reads decide whether to forward.
+// reads decide whether to forward. `anthropicPassThroughHeaders` is
+// the canonical list: both capture (request-header phase) and forward
+// (request-body routing phase via appendCapturedPassThroughHeaders)
+// iterate it, so adding a new header only requires one entry here.
 type anthropicPassThroughHeader struct {
 	name   string
 	assign func(ext *ir.IRExtensions, value string)
+	read   func(ext *ir.IRExtensions) string
 }
 
 var anthropicPassThroughHeaders = []anthropicPassThroughHeader{
 	{
 		name:   "anthropic-version",
 		assign: func(ext *ir.IRExtensions, v string) { ext.InboundAnthropicVersion = v },
+		read:   func(ext *ir.IRExtensions) string { return ext.InboundAnthropicVersion },
 	},
 	{
 		name:   "anthropic-beta",
 		assign: func(ext *ir.IRExtensions, v string) { ext.InboundAnthropicBeta = v },
+		read:   func(ext *ir.IRExtensions) string { return ext.InboundAnthropicBeta },
 	},
 	{
 		name:   "anthropic-dangerous-direct-browser-access",
 		assign: func(ext *ir.IRExtensions, v string) { ext.InboundDangerousDirectBrowserAccess = v },
+		read:   func(ext *ir.IRExtensions) string { return ext.InboundDangerousDirectBrowserAccess },
 	},
 }
 

--- a/src/semantic-router/pkg/extproc/processor_req_header_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_test.go
@@ -9,6 +9,7 @@ import (
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
 type requestHeaderTestCase struct {
@@ -376,4 +377,147 @@ func TestHandleRequestHeadersSetsClientProtocol(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyHeaderPassThroughPolicy_DropsHopByHopHeaders(t *testing.T) {
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			"host":              "example.com",
+			"content-length":    "42",
+			"connection":        "keep-alive",
+			"keep-alive":        "timeout=5",
+			"transfer-encoding": "chunked",
+			"upgrade":           "websocket",
+			"te":                "trailers",
+			"trailer":           "Expires",
+			"expect":            "100-continue",
+			"proxy-connection":  "keep-alive",
+			"x-keep-this":       "kept",
+		},
+	}
+
+	applyHeaderPassThroughPolicy(ctx)
+
+	for _, dropped := range []string{
+		"host", "content-length", "connection", "keep-alive", "transfer-encoding",
+		"upgrade", "te", "trailer", "expect", "proxy-connection",
+	} {
+		if _, ok := ctx.Headers[dropped]; ok {
+			t.Errorf("expected %q to be dropped, but it is still present", dropped)
+		}
+	}
+	if got := ctx.Headers["x-keep-this"]; got != "kept" {
+		t.Errorf("expected x-keep-this preserved, got %q", got)
+	}
+}
+
+func TestApplyHeaderPassThroughPolicy_CapturesAnthropicHeadersOnAnthropicIngress(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		Headers: map[string]string{
+			"anthropic-version":                         "2024-10-22",
+			"anthropic-beta":                            "prompt-caching-2024-07-31",
+			"anthropic-dangerous-direct-browser-access": "true",
+		},
+	}
+
+	applyHeaderPassThroughPolicy(ctx)
+
+	if ctx.IRExtensions == nil {
+		t.Fatalf("expected IRExtensions to be allocated")
+	}
+	if got := ctx.IRExtensions.InboundAnthropicVersion; got != "2024-10-22" {
+		t.Errorf("InboundAnthropicVersion = %q, want %q", got, "2024-10-22")
+	}
+	if got := ctx.IRExtensions.InboundAnthropicBeta; got != "prompt-caching-2024-07-31" {
+		t.Errorf("InboundAnthropicBeta = %q, want %q", got, "prompt-caching-2024-07-31")
+	}
+	if got := ctx.IRExtensions.InboundDangerousDirectBrowserAccess; got != "true" {
+		t.Errorf("InboundDangerousDirectBrowserAccess = %q, want %q", got, "true")
+	}
+	if got := ctx.IRExtensions.SourceProtocol; got != config.ClientProtocolAnthropic {
+		t.Errorf("SourceProtocol = %q, want %q", got, config.ClientProtocolAnthropic)
+	}
+	// KEEP-by-default: the captured headers also remain in ctx.Headers.
+	if got := ctx.Headers["anthropic-version"]; got != "2024-10-22" {
+		t.Errorf("expected anthropic-version preserved in headers, got %q", got)
+	}
+}
+
+func TestApplyHeaderPassThroughPolicy_DoesNotCaptureOnOpenAIIngress(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: "",
+		Headers: map[string]string{
+			"anthropic-beta": "should-not-be-captured",
+		},
+	}
+
+	applyHeaderPassThroughPolicy(ctx)
+
+	if ctx.IRExtensions != nil {
+		t.Errorf("expected IRExtensions to remain nil on OpenAI ingress, got %+v", ctx.IRExtensions)
+	}
+	// KEEP-by-default still applies: the header passes through verbatim.
+	if got := ctx.Headers["anthropic-beta"]; got != "should-not-be-captured" {
+		t.Errorf("expected anthropic-beta preserved verbatim, got %q", got)
+	}
+}
+
+func TestApplyHeaderPassThroughPolicy_ToleratesExistingIRExtensions(t *testing.T) {
+	pre := &ir.IRExtensions{
+		SourceProtocol: config.ClientProtocolAnthropic,
+		MetadataUserID: "user-existing",
+	}
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		IRExtensions:   pre,
+		Headers: map[string]string{
+			"anthropic-version": "2023-06-01",
+		},
+	}
+
+	applyHeaderPassThroughPolicy(ctx)
+
+	if ctx.IRExtensions != pre {
+		t.Errorf("expected existing IRExtensions pointer to be reused")
+	}
+	if got := ctx.IRExtensions.InboundAnthropicVersion; got != "2023-06-01" {
+		t.Errorf("InboundAnthropicVersion = %q, want %q", got, "2023-06-01")
+	}
+	if got := ctx.IRExtensions.MetadataUserID; got != "user-existing" {
+		t.Errorf("expected existing MetadataUserID preserved, got %q", got)
+	}
+}
+
+func TestApplyHeaderPassThroughPolicy_HandlesMixedCaseHeaderKeys(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		Headers: map[string]string{
+			"Anthropic-Version": "2024-10-22",
+		},
+	}
+
+	applyHeaderPassThroughPolicy(ctx)
+
+	if ctx.IRExtensions == nil || ctx.IRExtensions.InboundAnthropicVersion != "2024-10-22" {
+		t.Errorf("expected mixed-case header captured, got %+v", ctx.IRExtensions)
+	}
+}
+
+func TestApplyHeaderPassThroughPolicy_NoCapturesWhenHeadersAbsent(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		Headers:        map[string]string{},
+	}
+
+	applyHeaderPassThroughPolicy(ctx)
+
+	if ctx.IRExtensions != nil {
+		t.Errorf("expected IRExtensions to remain nil when no pass-through headers present")
+	}
+}
+
+func TestApplyHeaderPassThroughPolicy_NilSafe(t *testing.T) {
+	applyHeaderPassThroughPolicy(nil)
+	applyHeaderPassThroughPolicy(&RequestContext{})
 }

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -151,10 +151,11 @@ func formatLossinessEntry(w ir.Warning) string {
 
 // sanitizeWarningField percent-encodes the format separators ',' and
 // ';' so a pathological JSON-path field name cannot break the
-// single-line encoding. PR2's parser never produces such paths; this is
-// belt-and-suspenders.
+// single-line encoding, and strips CR/LF so a hostile value cannot
+// inject a new header line. PR2's parser never produces such paths;
+// this is belt-and-suspenders.
 func sanitizeWarningField(field string) string {
-	if !strings.ContainsAny(field, ",;") {
+	if !strings.ContainsAny(field, ",;\r\n") {
 		return field
 	}
 	var sb strings.Builder
@@ -165,6 +166,10 @@ func sanitizeWarningField(field string) string {
 			sb.WriteString("%2C")
 		case ';':
 			sb.WriteString("%3B")
+		case '\r':
+			sb.WriteString("%0D")
+		case '\n':
+			sb.WriteString("%0A")
 		default:
 			sb.WriteRune(r)
 		}

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -9,7 +9,22 @@ import (
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
+
+// lossinessHeaderSizeLimit caps the encoded x-vsr-lossiness-warnings
+// header at a conservative size well under any HTTP/2 frame limit.
+// >50 warnings already represent a deeper translation regression worth
+// investigating via the structured log rather than the header.
+const lossinessHeaderSizeLimit = 4096
+
+// protocolDefault is the wire-shape token emitted in x-vsr-inbound-
+// protocol / x-vsr-outbound-protocol when the request context did not
+// resolve an explicit protocol. The router's default contract is
+// OpenAI-compatible.
+const protocolDefault = "openai"
 
 type responseHeaderMutationBuilder struct {
 	setHeaders []*core.HeaderValueOption
@@ -71,6 +86,115 @@ func (builder *responseHeaderMutationBuilder) addJoined(key string, values []str
 	builder.addString(key, strings.Join(values, ","))
 }
 
+// addLossinessWarnings encodes ctx.IRExtensions.Warnings into the
+// x-vsr-lossiness-warnings header, increments the per-warning Prometheus
+// counter, and emits a structured log event per warning. Returns
+// without emitting anything when warnings is empty.
+//
+// Format: comma-separated entries, each "severity;reason;field". The
+// optional Warning.Detail stays out of the header (lives in the
+// structured log) to keep the header short. If the encoded list would
+// exceed lossinessHeaderSizeLimit the builder truncates and appends a
+// synthetic "error;warnings_truncated;count=N" trailer.
+func (builder *responseHeaderMutationBuilder) addLossinessWarnings(
+	ctx *RequestContext,
+	warnings []ir.Warning,
+) {
+	if len(warnings) == 0 {
+		return
+	}
+
+	inbound := normalizeProtocol(ctx.ClientProtocol)
+	outbound := normalizeProtocol(ctx.APIFormat)
+
+	var sb strings.Builder
+	truncatedAt := -1
+	for i, w := range warnings {
+		entry := formatLossinessEntry(w)
+		separatorLen := 0
+		if sb.Len() > 0 {
+			separatorLen = 1
+		}
+		if sb.Len()+separatorLen+len(entry) > lossinessHeaderSizeLimit && sb.Len() > 0 {
+			truncatedAt = i
+			break
+		}
+		if separatorLen > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(entry)
+		recordWarning(ctx, inbound, outbound, w)
+	}
+
+	if truncatedAt >= 0 {
+		trailer := fmt.Sprintf("%s;%s;count=%d",
+			ir.WarningSeverityError,
+			ir.ReasonWarningsTruncated,
+			len(warnings)-truncatedAt,
+		)
+		if sb.Len() > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(trailer)
+	}
+
+	builder.addString(headers.VSRLossinessWarnings, sb.String())
+}
+
+func formatLossinessEntry(w ir.Warning) string {
+	return fmt.Sprintf("%s;%s;%s",
+		w.Severity,
+		sanitizeWarningField(w.Reason),
+		sanitizeWarningField(w.Field),
+	)
+}
+
+// sanitizeWarningField percent-encodes the format separators ',' and
+// ';' so a pathological JSON-path field name cannot break the
+// single-line encoding. PR2's parser never produces such paths; this is
+// belt-and-suspenders.
+func sanitizeWarningField(field string) string {
+	if !strings.ContainsAny(field, ",;") {
+		return field
+	}
+	var sb strings.Builder
+	sb.Grow(len(field))
+	for _, r := range field {
+		switch r {
+		case ',':
+			sb.WriteString("%2C")
+		case ';':
+			sb.WriteString("%3B")
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+func recordWarning(ctx *RequestContext, inbound, outbound string, w ir.Warning) {
+	metrics.RecordTranslationWarning(inbound, outbound, w.Severity.String(), w.Reason)
+	logging.ComponentDebugEvent("extproc", "translation_lossy", map[string]interface{}{
+		"request_id":        ctx.RequestID,
+		"inbound_protocol":  inbound,
+		"outbound_protocol": outbound,
+		"field":             w.Field,
+		"reason":            w.Reason,
+		"severity":          w.Severity.String(),
+		"detail":            w.Detail,
+	})
+}
+
+// normalizeProtocol returns the canonical protocol token for headers
+// and metrics, defaulting empty to "openai".
+func normalizeProtocol(value string) string {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return protocolDefault
+	}
+	return v
+}
+
 func (builder *responseHeaderMutationBuilder) mutation() *ext_proc.HeaderMutation {
 	if len(builder.setHeaders) == 0 {
 		return nil
@@ -82,11 +206,40 @@ func buildResponseHeaderMutation(
 	ctx *RequestContext,
 	isSuccessful bool,
 ) *ext_proc.HeaderMutation {
-	if ctx == nil || !isSuccessful || ctx.VSRCacheHit {
+	if ctx == nil {
 		return nil
 	}
 
 	builder := newResponseHeaderMutationBuilder()
+
+	// Protocol markers and lossiness warnings ride on every response
+	// (success or 4xx/5xx) so clients can always tell which translation
+	// cell handled the call. Cache-hit responses are an exception: the
+	// IRExtensions.Warnings slice is per-request, so a cached response
+	// would attribute warnings from a different request — we skip the
+	// new headers entirely on cache hits and let the cached payload
+	// flow unchanged.
+	if !ctx.VSRCacheHit {
+		builder.addString(headers.VSRInboundProtocol, normalizeProtocol(ctx.ClientProtocol))
+		builder.addString(headers.VSROutboundProtocol, normalizeProtocol(ctx.APIFormat))
+		if ctx.IRExtensions != nil {
+			builder.addLossinessWarnings(ctx, ctx.IRExtensions.Warnings)
+		}
+	}
+
+	if !isSuccessful || ctx.VSRCacheHit {
+		return builder.mutation()
+	}
+
+	addStandardDecisionHeaders(builder, ctx)
+	addMatchedSignalHeaders(builder, ctx)
+	return builder.mutation()
+}
+
+// addStandardDecisionHeaders adds the per-request decision headers
+// (selected category, model, reasoning, modality, etc.) emitted only on
+// successful non-cache-hit responses.
+func addStandardDecisionHeaders(builder *responseHeaderMutationBuilder, ctx *RequestContext) {
 	builder.addString(headers.VSRSelectedCategory, ctx.VSRSelectedCategory)
 	builder.addString(headers.VSRSelectedDecision, ctx.VSRSelectedDecisionName)
 	if ctx.VSRSelectedDecisionName != "" {
@@ -103,6 +256,16 @@ func buildResponseHeaderMutation(
 	builder.addString(headers.VSRSelectedModel, ctx.VSRSelectedModel)
 	builder.addString(headers.VSRSessionPhase, sessionPolicyPhase(ctx))
 	builder.addBool(headers.VSRInjectedSystemPrompt, ctx.VSRInjectedSystemPrompt)
+	builder.addString(headers.RouterReplayID, ctx.RouterReplayID)
+	if ctx.VSRCacheSimilarity > 0 {
+		builder.addFloat("x-vsr-cache-similarity", float64(ctx.VSRCacheSimilarity))
+	}
+}
+
+// addMatchedSignalHeaders adds the signal-evaluation headers (matched
+// keywords, embeddings, etc.) describing which signal rules fired for
+// this request.
+func addMatchedSignalHeaders(builder *responseHeaderMutationBuilder, ctx *RequestContext) {
 	builder.addJoined(headers.VSRMatchedKeywords, ctx.VSRMatchedKeywords)
 	builder.addJoined(headers.VSRMatchedEmbeddings, ctx.VSRMatchedEmbeddings)
 	builder.addJoined(headers.VSRMatchedDomains, ctx.VSRMatchedDomains)
@@ -122,11 +285,6 @@ func buildResponseHeaderMutation(
 	builder.addJoined(headers.VSRMatchedKB, ctx.VSRMatchedKB)
 	builder.addJoined(headers.VSRMatchedConversation, ctx.VSRMatchedConversation)
 	builder.addJoined(headers.VSRMatchedProjection, ctx.VSRMatchedProjection)
-	builder.addString(headers.RouterReplayID, ctx.RouterReplayID)
-	if ctx.VSRCacheSimilarity > 0 {
-		builder.addFloat("x-vsr-cache-similarity", float64(ctx.VSRCacheSimilarity))
-	}
-	return builder.mutation()
 }
 
 func sessionPolicyPhase(ctx *RequestContext) string {

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -144,7 +144,7 @@ func (builder *responseHeaderMutationBuilder) addLossinessWarnings(
 func formatLossinessEntry(w ir.Warning) string {
 	return fmt.Sprintf("%s;%s;%s",
 		w.Severity,
-		sanitizeWarningField(w.Reason),
+		sanitizeWarningField(string(w.Reason)),
 		sanitizeWarningField(w.Field),
 	)
 }
@@ -178,7 +178,7 @@ func sanitizeWarningField(field string) string {
 }
 
 func recordWarning(ctx *RequestContext, inbound, outbound string, w ir.Warning) {
-	metrics.RecordTranslationWarning(inbound, outbound, w.Severity.String(), w.Reason)
+	metrics.RecordTranslationWarning(inbound, outbound, w.Severity.String(), string(w.Reason))
 	logging.ComponentDebugEvent("extproc", "translation_lossy", map[string]interface{}{
 		"request_id":        ctx.RequestID,
 		"inbound_protocol":  inbound,

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -1,12 +1,16 @@
 package extproc
 
 import (
+	"strings"
 	"testing"
 
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
 func TestBuildResponseHeaderMutation_IncludesExtendedMatchedSignalHeaders(t *testing.T) {
@@ -27,10 +31,7 @@ func TestBuildResponseHeaderMutation_IncludesExtendedMatchedSignalHeaders(t *tes
 	mutation := buildResponseHeaderMutation(ctx, true)
 	require.NotNil(t, mutation)
 
-	headerMap := map[string]string{}
-	for _, header := range mutation.SetHeaders {
-		headerMap[header.Header.Key] = string(header.Header.RawValue)
-	}
+	headerMap := mutationToMap(mutation.SetHeaders)
 
 	assert.Equal(t, "complexity:hard", headerMap[headers.VSRMatchedComplexity])
 	assert.Equal(t, "AR", headerMap[headers.VSRMatchedModality])
@@ -55,14 +56,201 @@ func TestBuildResponseHeaderMutation_EmitsZeroDecisionConfidence(t *testing.T) {
 	mutation := buildResponseHeaderMutation(ctx, true)
 	require.NotNil(t, mutation)
 
-	headerMap := map[string]string{}
-	for _, header := range mutation.SetHeaders {
-		headerMap[header.Header.Key] = string(header.Header.RawValue)
-	}
+	headerMap := mutationToMap(mutation.SetHeaders)
 
 	assert.Equal(t, "agentic_routing", headerMap[headers.VSRSelectedDecision])
 	assert.Equal(t, "0.0000", headerMap[headers.VSRSelectedConfidence])
 	assert.Equal(t, "qwen-small", headerMap[headers.VSRSelectedModel])
 	assert.Equal(t, "provider_state", headerMap[headers.VSRSessionPhase])
 	assert.Equal(t, "42", headerMap[headers.VSRContextTokenCount])
+}
+
+func TestBuildResponseHeaderMutation_ProtocolMarkersDefaultToOpenAI(t *testing.T) {
+	ctx := &RequestContext{}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "openai", headerMap[headers.VSRInboundProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSROutboundProtocol])
+}
+
+func TestBuildResponseHeaderMutation_ProtocolMarkersReflectAnthropicIngress(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		APIFormat:      config.APIFormatAnthropic,
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "anthropic", headerMap[headers.VSRInboundProtocol])
+	assert.Equal(t, "anthropic", headerMap[headers.VSROutboundProtocol])
+}
+
+func TestBuildResponseHeaderMutation_ProtocolMarkersEmittedOnFailedResponse(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, false)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "anthropic", headerMap[headers.VSRInboundProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSROutboundProtocol])
+
+	// Existing pre-PR3 markers stay gated by isSuccessful.
+	assert.NotContains(t, headerMap, headers.VSRSelectedCategory)
+}
+
+func TestBuildResponseHeaderMutation_CacheHitSkipsNewHeaders(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		VSRCacheHit:    true,
+		IRExtensions: &ir.IRExtensions{
+			Warnings: []ir.Warning{{Field: "top_k", Reason: "dropped", Severity: ir.WarningSeverityLossy}},
+		},
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	assert.Nil(t, mutation, "cache hit should produce no header mutation")
+}
+
+func TestBuildResponseHeaderMutation_NilContextReturnsNil(t *testing.T) {
+	assert.Nil(t, buildResponseHeaderMutation(nil, true))
+}
+
+func TestAddLossinessWarnings_EmptyProducesNoHeader(t *testing.T) {
+	ctx := &RequestContext{ClientProtocol: config.ClientProtocolAnthropic}
+	builder := newResponseHeaderMutationBuilder()
+
+	builder.addLossinessWarnings(ctx, nil)
+	builder.addLossinessWarnings(ctx, []ir.Warning{})
+
+	mutation := builder.mutation()
+	assert.Nil(t, mutation, "no warnings should produce no header")
+}
+
+func TestAddLossinessWarnings_SingleEntry(t *testing.T) {
+	ctx := &RequestContext{ClientProtocol: config.ClientProtocolAnthropic}
+	builder := newResponseHeaderMutationBuilder()
+
+	builder.addLossinessWarnings(ctx, []ir.Warning{{
+		Field:    "top_k",
+		Reason:   string(ir.ReasonTopKDropOnOpenAIBackend),
+		Severity: ir.WarningSeverityLossy,
+	}})
+
+	headerMap := mutationToMap(builder.setHeaders)
+	assert.Equal(t,
+		"lossy;top_k_drop_on_openai_backend;top_k",
+		headerMap[headers.VSRLossinessWarnings],
+	)
+}
+
+func TestAddLossinessWarnings_MultipleEntriesCommaSeparated(t *testing.T) {
+	ctx := &RequestContext{ClientProtocol: config.ClientProtocolAnthropic}
+	builder := newResponseHeaderMutationBuilder()
+
+	builder.addLossinessWarnings(ctx, []ir.Warning{
+		{Field: "messages[0].content[2]", Reason: string(ir.ReasonUnsupportedBlockType), Severity: ir.WarningSeverityLossy},
+		{Field: "top_k", Reason: string(ir.ReasonDropped), Severity: ir.WarningSeverityLossy},
+		{Field: "tool_choice.disable_parallel_tool_use", Reason: string(ir.ReasonCoercedString), Severity: ir.WarningSeverityInfo},
+	})
+
+	headerMap := mutationToMap(builder.setHeaders)
+	assert.Equal(t,
+		"lossy;unsupported_block_type;messages[0].content[2],"+
+			"lossy;dropped;top_k,"+
+			"info;coerced_string;tool_choice.disable_parallel_tool_use",
+		headerMap[headers.VSRLossinessWarnings],
+	)
+}
+
+func TestAddLossinessWarnings_TruncationAppendsTrailer(t *testing.T) {
+	ctx := &RequestContext{ClientProtocol: config.ClientProtocolAnthropic}
+	builder := newResponseHeaderMutationBuilder()
+
+	const total = 500
+	warnings := make([]ir.Warning, total)
+	for i := range warnings {
+		warnings[i] = ir.Warning{
+			Field:    "messages[0].content[" + strings.Repeat("x", 16) + "]",
+			Reason:   string(ir.ReasonUnsupportedBlockType),
+			Severity: ir.WarningSeverityLossy,
+		}
+	}
+
+	builder.addLossinessWarnings(ctx, warnings)
+
+	headerMap := mutationToMap(builder.setHeaders)
+	got := headerMap[headers.VSRLossinessWarnings]
+
+	assert.NotEmpty(t, got)
+	// The encoded list lives close to 4 KB; the trailer itself adds a
+	// few dozen bytes more.
+	assert.LessOrEqual(t, len(got), lossinessHeaderSizeLimit+128)
+	assert.Contains(t, got, "error;warnings_truncated;count=")
+}
+
+func TestAddLossinessWarnings_SanitizesSeparatorsInFieldPaths(t *testing.T) {
+	ctx := &RequestContext{ClientProtocol: config.ClientProtocolAnthropic}
+	builder := newResponseHeaderMutationBuilder()
+
+	builder.addLossinessWarnings(ctx, []ir.Warning{{
+		Field:    "weird;field,name",
+		Reason:   "dropped;extra,bits",
+		Severity: ir.WarningSeverityLossy,
+	}})
+
+	headerMap := mutationToMap(builder.setHeaders)
+	assert.Equal(t,
+		"lossy;dropped%3Bextra%2Cbits;weird%3Bfield%2Cname",
+		headerMap[headers.VSRLossinessWarnings],
+	)
+}
+
+func TestBuildResponseHeaderMutation_EmitsWarningsAlongsideStandardHeaders(t *testing.T) {
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		APIFormat:      "openai",
+		IRExtensions: &ir.IRExtensions{
+			Warnings: []ir.Warning{{
+				Field:    "top_k",
+				Reason:   string(ir.ReasonTopKDropOnOpenAIBackend),
+				Severity: ir.WarningSeverityLossy,
+			}},
+		},
+		VSRSelectedCategory: "math",
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "anthropic", headerMap[headers.VSRInboundProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSROutboundProtocol])
+	assert.Equal(t,
+		"lossy;top_k_drop_on_openai_backend;top_k",
+		headerMap[headers.VSRLossinessWarnings],
+	)
+	assert.Equal(t, "math", headerMap[headers.VSRSelectedCategory])
+}
+
+func TestNormalizeProtocol(t *testing.T) {
+	assert.Equal(t, "openai", normalizeProtocol(""))
+	assert.Equal(t, "openai", normalizeProtocol("  "))
+	assert.Equal(t, "anthropic", normalizeProtocol("anthropic"))
+	assert.Equal(t, "anthropic", normalizeProtocol(" anthropic "))
+}
+
+func mutationToMap(setHeaders []*core.HeaderValueOption) map[string]string {
+	headerMap := make(map[string]string, len(setHeaders))
+	for _, h := range setHeaders {
+		headerMap[h.Header.Key] = string(h.Header.RawValue)
+	}
+	return headerMap
 }

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -111,7 +111,7 @@ func TestBuildResponseHeaderMutation_CacheHitSkipsNewHeaders(t *testing.T) {
 		ClientProtocol: config.ClientProtocolAnthropic,
 		VSRCacheHit:    true,
 		IRExtensions: &ir.IRExtensions{
-			Warnings: []ir.Warning{{Field: "top_k", Reason: "dropped", Severity: ir.WarningSeverityLossy}},
+			Warnings: []ir.Warning{{Field: "top_k", Reason: ir.ReasonDropped, Severity: ir.WarningSeverityLossy}},
 		},
 	}
 
@@ -140,7 +140,7 @@ func TestAddLossinessWarnings_SingleEntry(t *testing.T) {
 
 	builder.addLossinessWarnings(ctx, []ir.Warning{{
 		Field:    "top_k",
-		Reason:   string(ir.ReasonTopKDropOnOpenAIBackend),
+		Reason:   ir.ReasonTopKDropOnOpenAIBackend,
 		Severity: ir.WarningSeverityLossy,
 	}})
 
@@ -156,9 +156,9 @@ func TestAddLossinessWarnings_MultipleEntriesCommaSeparated(t *testing.T) {
 	builder := newResponseHeaderMutationBuilder()
 
 	builder.addLossinessWarnings(ctx, []ir.Warning{
-		{Field: "messages[0].content[2]", Reason: string(ir.ReasonUnsupportedBlockType), Severity: ir.WarningSeverityLossy},
-		{Field: "top_k", Reason: string(ir.ReasonDropped), Severity: ir.WarningSeverityLossy},
-		{Field: "tool_choice.disable_parallel_tool_use", Reason: string(ir.ReasonCoercedString), Severity: ir.WarningSeverityInfo},
+		{Field: "messages[0].content[2]", Reason: ir.ReasonUnsupportedBlockType, Severity: ir.WarningSeverityLossy},
+		{Field: "top_k", Reason: ir.ReasonDropped, Severity: ir.WarningSeverityLossy},
+		{Field: "tool_choice.disable_parallel_tool_use", Reason: ir.ReasonCoercedString, Severity: ir.WarningSeverityInfo},
 	})
 
 	headerMap := mutationToMap(builder.setHeaders)
@@ -179,7 +179,7 @@ func TestAddLossinessWarnings_TruncationAppendsTrailer(t *testing.T) {
 	for i := range warnings {
 		warnings[i] = ir.Warning{
 			Field:    "messages[0].content[" + strings.Repeat("x", 16) + "]",
-			Reason:   string(ir.ReasonUnsupportedBlockType),
+			Reason:   ir.ReasonUnsupportedBlockType,
 			Severity: ir.WarningSeverityLossy,
 		}
 	}
@@ -202,7 +202,7 @@ func TestAddLossinessWarnings_SanitizesSeparatorsInFieldPaths(t *testing.T) {
 
 	builder.addLossinessWarnings(ctx, []ir.Warning{{
 		Field:    "weird;field,name",
-		Reason:   "dropped;extra,bits",
+		Reason:   ir.WarningReason("dropped;extra,bits"),
 		Severity: ir.WarningSeverityLossy,
 	}})
 
@@ -219,7 +219,7 @@ func TestAddLossinessWarnings_SanitizesCRLFInFieldPaths(t *testing.T) {
 
 	builder.addLossinessWarnings(ctx, []ir.Warning{{
 		Field:    "field\r\nx-injected: pwned",
-		Reason:   "rea\nson",
+		Reason:   ir.WarningReason("rea\nson"),
 		Severity: ir.WarningSeverityLossy,
 	}})
 
@@ -238,7 +238,7 @@ func TestBuildResponseHeaderMutation_EmitsWarningsAlongsideStandardHeaders(t *te
 		IRExtensions: &ir.IRExtensions{
 			Warnings: []ir.Warning{{
 				Field:    "top_k",
-				Reason:   string(ir.ReasonTopKDropOnOpenAIBackend),
+				Reason:   ir.ReasonTopKDropOnOpenAIBackend,
 				Severity: ir.WarningSeverityLossy,
 			}},
 		},

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -213,6 +213,24 @@ func TestAddLossinessWarnings_SanitizesSeparatorsInFieldPaths(t *testing.T) {
 	)
 }
 
+func TestAddLossinessWarnings_SanitizesCRLFInFieldPaths(t *testing.T) {
+	ctx := &RequestContext{ClientProtocol: config.ClientProtocolAnthropic}
+	builder := newResponseHeaderMutationBuilder()
+
+	builder.addLossinessWarnings(ctx, []ir.Warning{{
+		Field:    "field\r\nx-injected: pwned",
+		Reason:   "rea\nson",
+		Severity: ir.WarningSeverityLossy,
+	}})
+
+	headerMap := mutationToMap(builder.setHeaders)
+	got := headerMap[headers.VSRLossinessWarnings]
+	assert.NotContains(t, got, "\r")
+	assert.NotContains(t, got, "\n")
+	assert.Contains(t, got, "%0D%0A")
+	assert.Contains(t, got, "rea%0Ason")
+}
+
 func TestBuildResponseHeaderMutation_EmitsWarningsAlongsideStandardHeaders(t *testing.T) {
 	ctx := &RequestContext{
 		ClientProtocol: config.ClientProtocolAnthropic,

--- a/src/semantic-router/pkg/extproc/session_transition.go
+++ b/src/semantic-router/pkg/extproc/session_transition.go
@@ -39,6 +39,12 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 		ctx.SessionID = sid
 	}
 
+	if ctx.SessionID == "" {
+		if sid := deriveSessionIDFromAnthropicSignals(ctx); sid != "" {
+			ctx.SessionID = sid
+		}
+	}
+
 	if len(ctx.ChatCompletionMessages) == 0 {
 		if ctx.SessionID == "" {
 			ctx.SessionID = deriveSessionIDFromRequestID(ctx)
@@ -95,6 +101,36 @@ func populateLastSessionObservation(ctx *RequestContext) {
 	}
 	ctx.SessionIdleSeconds = idleFor.Seconds()
 	ctx.SessionIdleKnown = true
+}
+
+// deriveSessionIDFromAnthropicSignals returns a session-ID candidate
+// from Anthropic-shape transport and body signals. Two sources, evaluated
+// in order:
+//
+//  1. x-claude-code-session-id — per-conversation UUID emitted by the
+//     Claude Code CLI on every /v1/messages request in a thread. Returned
+//     verbatim so plugins can map sessions back to the client-declared
+//     conversation; operators wanting privacy should run a hashing plugin
+//     in front.
+//  2. metadata.user_id — populated by the PR2 Anthropic inbound parser
+//     into IRExtensions.MetadataUserID. Returned with an "ant-md-" prefix
+//     so the namespace is distinguishable from other derivation sources.
+//
+// Returns empty string when neither signal is present, leaving the caller
+// to fall through to the chat-message fingerprint fallbacks.
+func deriveSessionIDFromAnthropicSignals(ctx *RequestContext) string {
+	if ctx == nil {
+		return ""
+	}
+	if sid := strings.TrimSpace(headerValueCI(ctx, headers.XClaudeCodeSessionID)); sid != "" {
+		return sid
+	}
+	if ctx.IRExtensions != nil {
+		if uid := strings.TrimSpace(ctx.IRExtensions.MetadataUserID); uid != "" {
+			return "ant-md-" + uid
+		}
+	}
+	return ""
 }
 
 // populateChatCompletionSessionIDIfNeeded sets ctx.SessionID when not already

--- a/src/semantic-router/pkg/extproc/session_transition_test.go
+++ b/src/semantic-router/pkg/extproc/session_transition_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 )
@@ -252,6 +253,119 @@ func TestEstimateTokenLength(t *testing.T) {
 	assert.Equal(t, 0, estimateTokenLength(""))
 	assert.Equal(t, 1, estimateTokenLength("abcd"))
 	assert.Equal(t, 3, estimateTokenLength("abcdefghijkl"))
+}
+
+func TestPopulateSessionTransitionFields_ClaudeCodeSessionID_UsedWhenXSessionIDAbsent(t *testing.T) {
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.XClaudeCodeSessionID: "cc-uuid-1",
+		},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, "cc-uuid-1", ctx.SessionID)
+}
+
+func TestPopulateSessionTransitionFields_XSessionIDOutranksClaudeCodeSessionID(t *testing.T) {
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.XSessionID:           "pinned",
+			headers.XClaudeCodeSessionID: "cc-uuid-2",
+		},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, "pinned", ctx.SessionID)
+}
+
+func TestPopulateSessionTransitionFields_ClaudeCodeSessionIDOutranksMetadataUserID(t *testing.T) {
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.XClaudeCodeSessionID: "cc-uuid-3",
+		},
+		IRExtensions: &ir.IRExtensions{
+			MetadataUserID: "user-zzz",
+		},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, "cc-uuid-3", ctx.SessionID)
+}
+
+func TestPopulateSessionTransitionFields_MetadataUserIDSeedsSessionWhenNoTransportHeader(t *testing.T) {
+	ctx := &RequestContext{
+		IRExtensions: &ir.IRExtensions{
+			MetadataUserID: "user-abc",
+		},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, "ant-md-user-abc", ctx.SessionID)
+}
+
+func TestPopulateSessionTransitionFields_ResponseAPIConversationOutranksAnthropicSignals(t *testing.T) {
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			ConversationID:       "conv-1",
+		},
+		Headers: map[string]string{
+			headers.XClaudeCodeSessionID: "cc-uuid-4",
+		},
+		IRExtensions: &ir.IRExtensions{
+			MetadataUserID: "user-xyz",
+		},
+	}
+
+	populateSessionTransitionFields(ctx)
+
+	assert.Equal(t, "conv-1", ctx.SessionID)
+}
+
+func TestPopulateSessionTransitionFields_ClaudeCodeSessionID_StableAcrossRequests(t *testing.T) {
+	uuid := "cc-uuid-stable"
+	ctxA := &RequestContext{
+		Headers: map[string]string{
+			headers.XClaudeCodeSessionID: uuid,
+		},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "first"},
+		},
+	}
+	ctxB := &RequestContext{
+		Headers: map[string]string{
+			headers.XClaudeCodeSessionID: uuid,
+		},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "second"},
+		},
+	}
+
+	populateSessionTransitionFields(ctxA)
+	populateSessionTransitionFields(ctxB)
+
+	assert.Equal(t, ctxA.SessionID, ctxB.SessionID)
+}
+
+func TestDeriveSessionIDFromAnthropicSignals_NilSafe(t *testing.T) {
+	assert.Empty(t, deriveSessionIDFromAnthropicSignals(nil))
+	assert.Empty(t, deriveSessionIDFromAnthropicSignals(&RequestContext{}))
 }
 
 func TestEstimateStoredResponseTokens_FallsBackToOutputItems(t *testing.T) {

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -22,6 +22,14 @@ const (
 	// when router-derived session IDs are insufficient.
 	XSessionID = "x-session-id"
 
+	// XClaudeCodeSessionID is the per-conversation UUID the Claude Code CLI
+	// emits on every /v1/messages request belonging to the same chat thread.
+	// The router mirrors this into RequestContext.SessionID with priority
+	// below x-session-id (operator/SDK override) but above metadata.user_id
+	// and the message-fingerprint fallbacks. See docs/sessions.md for the
+	// full priority order.
+	XClaudeCodeSessionID = "x-claude-code-session-id"
+
 	// DisableRouterMemory allows clients to opt-out of router-managed memory injection.
 	// This prevents "silent double injection" when applications use SDK-managed memory
 	// systems like Mem0, LangMem, LangGraph, or OpenClaw.

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -193,6 +193,29 @@ const (
 	VSRFastResponse = "x-vsr-fast-response"
 )
 
+// VSR Protocol Markers and Translation Warnings
+// These headers are emitted on every non-cache-hit response (including 4xx
+// and 5xx) so clients can always tell which translation cell handled the
+// call and what was lost during translation.
+const (
+	// VSRInboundProtocol describes the wire format of the inbound request
+	// as seen by the router (e.g. "openai", "anthropic"). Defaults to
+	// "openai" when no other protocol was detected.
+	VSRInboundProtocol = "x-vsr-inbound-protocol"
+
+	// VSROutboundProtocol describes the wire format of the outbound
+	// request sent to the upstream backend. Defaults to "openai" when no
+	// explicit APIFormat was resolved.
+	VSROutboundProtocol = "x-vsr-outbound-protocol"
+
+	// VSRLossinessWarnings carries a structured, semicolon-separated
+	// list of translation observations emitted by the inbound parser
+	// during a lossy translation. Each entry is "severity;reason;field";
+	// entries are comma-separated. Absent when no warnings were
+	// produced.
+	VSRLossinessWarnings = "x-vsr-lossiness-warnings"
+)
+
 // Legacy Security Headers (kept for backward compatibility with replay recorder)
 // New signal-driven architecture uses x-vsr-matched-jailbreak and x-vsr-matched-pii instead.
 const (

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -208,11 +208,10 @@ const (
 	// explicit APIFormat was resolved.
 	VSROutboundProtocol = "x-vsr-outbound-protocol"
 
-	// VSRLossinessWarnings carries a structured, semicolon-separated
-	// list of translation observations emitted by the inbound parser
-	// during a lossy translation. Each entry is "severity;reason;field";
-	// entries are comma-separated. Absent when no warnings were
-	// produced.
+	// VSRLossinessWarnings carries a structured, comma-separated list
+	// of translation observations emitted by the inbound parser during
+	// a lossy translation. Each entry is "severity;reason;field".
+	// Absent when no warnings were produced.
 	VSRLossinessWarnings = "x-vsr-lossiness-warnings"
 )
 

--- a/src/semantic-router/pkg/ir/extensions.go
+++ b/src/semantic-router/pkg/ir/extensions.go
@@ -75,6 +75,23 @@ type IRExtensions struct {
 	// records; it does not act on the value.
 	AnthropicBeta string
 
+	// InboundAnthropicVersion captures the inbound anthropic-version
+	// header value on Anthropic-shape ingress so the body-phase routing
+	// step can layer it under the provider-profile pin when the profile
+	// did not supply one.
+	InboundAnthropicVersion string
+
+	// InboundAnthropicBeta captures the inbound anthropic-beta header
+	// value on Anthropic-shape ingress for header pass-through. Duplicates
+	// AnthropicBeta from the body parser path on purpose: the header is
+	// captured at the request-header phase before the body has been seen.
+	InboundAnthropicBeta string
+
+	// InboundDangerousDirectBrowserAccess captures the
+	// anthropic-dangerous-direct-browser-access header value on Anthropic
+	// ingress for pass-through to compatible backends.
+	InboundDangerousDirectBrowserAccess string
+
 	// Warnings accumulates parse- and emit-time observations. Surfaced via
 	// response headers, structured logging, and metrics.
 	Warnings []Warning

--- a/src/semantic-router/pkg/ir/warning_reasons.go
+++ b/src/semantic-router/pkg/ir/warning_reasons.go
@@ -1,0 +1,79 @@
+package ir
+
+// WarningReason is the stable machine token surfaced in the
+// x-vsr-lossiness-warnings response header and in the
+// vsr_translation_lossy_total metric "reason" label.
+//
+// Stability contract: existing reason tokens are part of the wire/metric
+// contract. New reasons may be added freely (clients tolerate unknown
+// values); renames are breaking and require a CHANGELOG entry.
+type WarningReason string
+
+const (
+	// ReasonDropped indicates a field was discarded with no equivalent on
+	// the outbound side.
+	ReasonDropped WarningReason = "dropped"
+
+	// ReasonCoercedString indicates a structured value was flattened to a
+	// string (e.g. tool_choice option object collapsed to a string).
+	ReasonCoercedString WarningReason = "coerced_string"
+
+	// ReasonUnsupportedBlockType indicates a content block whose type is
+	// not representable in the OpenAI IR was dropped (e.g.
+	// redacted_thinking).
+	ReasonUnsupportedBlockType WarningReason = "unsupported_block_type"
+
+	// ReasonUnsupportedSubtype indicates a sub-field of an otherwise
+	// supported block could not be translated (e.g. document source
+	// variant unknown to the emitter).
+	ReasonUnsupportedSubtype WarningReason = "unsupported_subtype"
+
+	// ReasonImageFileIDUnresolved indicates an Anthropic image-by-file_id
+	// reference could not be resolved against the Files API and was
+	// dropped.
+	ReasonImageFileIDUnresolved WarningReason = "image_file_id_unresolved"
+
+	// ReasonRedactedThinkingDropped indicates a redacted_thinking block
+	// was dropped because the OpenAI IR has no equivalent.
+	ReasonRedactedThinkingDropped WarningReason = "redacted_thinking_dropped"
+
+	// ReasonSignatureDropOnOpenAIBackend indicates a thinking-block
+	// signature was discarded because the outbound OpenAI backend cannot
+	// round-trip it.
+	ReasonSignatureDropOnOpenAIBackend WarningReason = "signature_drop_on_openai_backend"
+
+	// ReasonServerToolDropOnOpenAIBackend indicates an Anthropic
+	// server-side tool (web_search, bash, etc.) was dropped because the
+	// OpenAI backend does not expose an equivalent.
+	ReasonServerToolDropOnOpenAIBackend WarningReason = "server_tool_drop_on_openai_backend"
+
+	// ReasonTopKDropOnOpenAIBackend indicates the Anthropic top_k
+	// sampling parameter was dropped on an OpenAI backend (no
+	// equivalent).
+	ReasonTopKDropOnOpenAIBackend WarningReason = "top_k_drop_on_openai_backend"
+
+	// ReasonBetaDropOnOpenAIBackend indicates the anthropic-beta header
+	// was dropped on an OpenAI backend (no equivalent).
+	ReasonBetaDropOnOpenAIBackend WarningReason = "beta_drop_on_openai_backend"
+
+	// ReasonWarningsTruncated is the synthetic trailer emitted by the
+	// response-header builder when the encoded warnings list exceeds the
+	// header size limit. The associated field carries the count of
+	// dropped entries.
+	ReasonWarningsTruncated WarningReason = "warnings_truncated"
+)
+
+// String returns the lowercase token representation of the severity used
+// in the response header and metric label.
+func (s WarningSeverity) String() string {
+	switch s {
+	case WarningSeverityInfo:
+		return "info"
+	case WarningSeverityLossy:
+		return "lossy"
+	case WarningSeverityError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}

--- a/src/semantic-router/pkg/ir/warning_reasons.go
+++ b/src/semantic-router/pkg/ir/warning_reasons.go
@@ -62,18 +62,3 @@ const (
 	// dropped entries.
 	ReasonWarningsTruncated WarningReason = "warnings_truncated"
 )
-
-// String returns the lowercase token representation of the severity used
-// in the response header and metric label.
-func (s WarningSeverity) String() string {
-	switch s {
-	case WarningSeverityInfo:
-		return "info"
-	case WarningSeverityLossy:
-		return "lossy"
-	case WarningSeverityError:
-		return "error"
-	default:
-		return "unknown"
-	}
-}

--- a/src/semantic-router/pkg/ir/warning_reasons_test.go
+++ b/src/semantic-router/pkg/ir/warning_reasons_test.go
@@ -1,0 +1,43 @@
+package ir
+
+import "testing"
+
+func TestWarningSeverity_String(t *testing.T) {
+	cases := []struct {
+		severity WarningSeverity
+		want     string
+	}{
+		{WarningSeverityInfo, "info"},
+		{WarningSeverityLossy, "lossy"},
+		{WarningSeverityError, "error"},
+		{WarningSeverity(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.severity.String(); got != tc.want {
+			t.Errorf("WarningSeverity(%d).String() = %q, want %q", tc.severity, got, tc.want)
+		}
+	}
+}
+
+func TestWarningReason_StableTokens(t *testing.T) {
+	// Locks the initial vocabulary in PR3. Renaming an existing reason is
+	// a breaking change for clients pattern-matching on header values.
+	expected := map[WarningReason]string{
+		ReasonDropped:                       "dropped",
+		ReasonCoercedString:                 "coerced_string",
+		ReasonUnsupportedBlockType:          "unsupported_block_type",
+		ReasonUnsupportedSubtype:            "unsupported_subtype",
+		ReasonImageFileIDUnresolved:         "image_file_id_unresolved",
+		ReasonRedactedThinkingDropped:       "redacted_thinking_dropped",
+		ReasonSignatureDropOnOpenAIBackend:  "signature_drop_on_openai_backend",
+		ReasonServerToolDropOnOpenAIBackend: "server_tool_drop_on_openai_backend",
+		ReasonTopKDropOnOpenAIBackend:       "top_k_drop_on_openai_backend",
+		ReasonBetaDropOnOpenAIBackend:       "beta_drop_on_openai_backend",
+		ReasonWarningsTruncated:             "warnings_truncated",
+	}
+	for reason, want := range expected {
+		if string(reason) != want {
+			t.Errorf("WarningReason value drift: got %q, want %q", string(reason), want)
+		}
+	}
+}

--- a/src/semantic-router/pkg/ir/warnings.go
+++ b/src/semantic-router/pkg/ir/warnings.go
@@ -32,7 +32,22 @@ const (
 // the warning back to the originating client payload.
 type Warning struct {
 	Field    string
-	Reason   string
+	Reason   WarningReason
 	Severity WarningSeverity
 	Detail   string
+}
+
+// String returns the lowercase token representation of the severity used
+// in the response header and metric label.
+func (s WarningSeverity) String() string {
+	switch s {
+	case WarningSeverityInfo:
+		return "info"
+	case WarningSeverityLossy:
+		return "lossy"
+	case WarningSeverityError:
+		return "error"
+	default:
+		return "unknown"
+	}
 }

--- a/src/semantic-router/pkg/observability/metrics/translation_metrics.go
+++ b/src/semantic-router/pkg/observability/metrics/translation_metrics.go
@@ -1,0 +1,38 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// TranslationLossyTotal counts translation warnings observed at the
+// response-header phase, partitioned by inbound/outbound protocol pair,
+// severity, and reason. Used by post-deployment dashboards to detect
+// protocol-pair regressions and to size lossiness across the fleet.
+var TranslationLossyTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "vsr_translation_lossy_total",
+		Help: "Total translation warnings emitted by the inbound parser, partitioned by protocol pair, severity, and reason.",
+	},
+	[]string{"from", "to", "severity", "reason"},
+)
+
+// RecordTranslationWarning increments the translation-warning counter
+// for one warning observed at the response-header phase. Empty
+// from/to/reason fall back to "unknown" so dashboard queries never see
+// the empty-string label.
+func RecordTranslationWarning(from, to, severity, reason string) {
+	if from == "" {
+		from = "unknown"
+	}
+	if to == "" {
+		to = "unknown"
+	}
+	if severity == "" {
+		severity = "unknown"
+	}
+	if reason == "" {
+		reason = "unknown"
+	}
+	TranslationLossyTotal.WithLabelValues(from, to, severity, reason).Inc()
+}

--- a/src/semantic-router/pkg/observability/metrics/translation_metrics.go
+++ b/src/semantic-router/pkg/observability/metrics/translation_metrics.go
@@ -11,7 +11,7 @@ import (
 // protocol-pair regressions and to size lossiness across the fleet.
 var TranslationLossyTotal = promauto.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "vsr_translation_lossy_total",
+		Name: "llm_translation_lossy_total",
 		Help: "Total translation warnings emitted by the inbound parser, partitioned by protocol pair, severity, and reason.",
 	},
 	[]string{"from", "to", "severity", "reason"},

--- a/src/semantic-router/pkg/observability/metrics/translation_metrics_test.go
+++ b/src/semantic-router/pkg/observability/metrics/translation_metrics_test.go
@@ -1,0 +1,62 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordTranslationWarning_IncrementsCounter(t *testing.T) {
+	TranslationLossyTotal.Reset()
+
+	RecordTranslationWarning("anthropic", "openai", "lossy", "top_k_drop_on_openai_backend")
+	RecordTranslationWarning("anthropic", "openai", "lossy", "top_k_drop_on_openai_backend")
+	RecordTranslationWarning("anthropic", "openai", "info", "coerced_string")
+
+	got := testutil.ToFloat64(TranslationLossyTotal.WithLabelValues(
+		"anthropic", "openai", "lossy", "top_k_drop_on_openai_backend",
+	))
+	if got != 2 {
+		t.Fatalf("expected lossy/top_k counter=2, got %v", got)
+	}
+
+	got = testutil.ToFloat64(TranslationLossyTotal.WithLabelValues(
+		"anthropic", "openai", "info", "coerced_string",
+	))
+	if got != 1 {
+		t.Fatalf("expected info/coerced counter=1, got %v", got)
+	}
+}
+
+func TestRecordTranslationWarning_EmptyLabelsBecomeUnknown(t *testing.T) {
+	TranslationLossyTotal.Reset()
+
+	RecordTranslationWarning("", "", "", "")
+
+	got := testutil.ToFloat64(TranslationLossyTotal.WithLabelValues(
+		"unknown", "unknown", "unknown", "unknown",
+	))
+	if got != 1 {
+		t.Fatalf("expected unknown-labelled counter=1, got %v", got)
+	}
+}
+
+func TestRecordTranslationWarning_LabelIndependence(t *testing.T) {
+	TranslationLossyTotal.Reset()
+
+	RecordTranslationWarning("anthropic", "openai", "lossy", "dropped")
+	RecordTranslationWarning("openai", "anthropic", "lossy", "dropped")
+
+	got := testutil.ToFloat64(TranslationLossyTotal.WithLabelValues(
+		"anthropic", "openai", "lossy", "dropped",
+	))
+	if got != 1 {
+		t.Fatalf("expected anthropic→openai counter=1, got %v", got)
+	}
+	got = testutil.ToFloat64(TranslationLossyTotal.WithLabelValues(
+		"openai", "anthropic", "lossy", "dropped",
+	))
+	if got != 1 {
+		t.Fatalf("expected openai→anthropic counter=1, got %v", got)
+	}
+}


### PR DESCRIPTION
> **RFC**: #1946 — design rationale, alternatives considered, decisions invited from maintainers

Third PR in the native Anthropic `/v1/messages` ingress series (tracking #1404).
Now that #1937 and #1938 have merged, this is the next PR in the series.

## What

Wires the ergonomic edges of native Anthropic ingress: pass Anthropic-specific
client headers through to the upstream, mirror `x-claude-code-session-id` into
the existing session-aware machinery, and surface lossy-translation events
(captured by the PR2 parser) as structured response headers so clients can
detect when their request was downgraded.

## Commits

1. **`[Router] enumerate translation-warning reasons and add metric`** — typed
   `WarningReason` vocabulary in `pkg/ir/warning_reasons.go` plus a
   `vsr_translation_lossy_total` counter in
   `pkg/observability/metrics/translation_metrics.go`. Pure additive, no
   behavior.
2. **`[Router] mirror x-claude-code-session-id into RequestContext.SessionID`** —
   slots the Claude Code per-conversation UUID into the existing session
   priority chain (between `x-session-id` and the message-fingerprint
   fallbacks). Documented full priority order in `docs/sessions.md`.
3. **`[Router] add header pass-through policy for Anthropic ingress`** —
   explicit DROP set, named capture into new `IRExtensions.Inbound*` fields,
   forwarding via the existing `ProviderProfile.ExtraHeaders` mechanism. No
   new top-level file — surgical additions to existing processors.
4. **`[Router] surface translation warnings and protocol markers on responses`** —
   emits three new response headers when the request went through translation:
   - `x-vsr-inbound-protocol` and `x-vsr-outbound-protocol` — machine-readable
     markers describing the wire-shape transformation
   - `x-vsr-lossiness-warnings` — semicolon-separated
     `severity;reason;field` triples, 4 KB capped with a
     `warnings_truncated` marker. Format is grep-friendly and JSON-free.
   Gated to NOT emit on cache-hit responses (the cached body was translated
   under different inputs; emitting fresh markers would mislead).

## Notable design decisions

- **Header format**: semicolon-separated triples, not a JSON blob.
  Operators tail logs; a 4 KB cap with explicit truncation marker keeps the
  header bounded while preserving the worst-case warning load.
- **Session-id priority** (documented in `docs/sessions.md`):
  `ResponseAPICtx.ConversationID > x-session-id > x-claude-code-session-id >
  metadata.user_id (ant-md-* prefix) > derived fingerprints`. Existing behavior
  preserved; Claude Code's UUID slots in cleanly.
- **Cache-hit gating**: none of the three new headers appear on cache-hit
  responses. The body was translated with a different set of inputs; emitting
  fresh protocol markers and lossiness warnings would describe the live cell,
  not the cached body. Strict reading of the plan only excluded the lossiness
  header from cache hits, but applying the same rule to the protocol markers
  is more consistent and avoids contradicting the existing
  `x-vsr-cache-hit` semantics. Reviewer feedback welcome.
- **`anthropic-version` not synthesized**: if neither the client nor the
  ProviderProfile sets it, the request goes through without the header. We
  treat that as a deployment misconfiguration rather than silently injecting
  a guessed version.

## What's still to come

- **PR4** — Anthropic outbound emitter for non-streaming responses (IR →
  Anthropic body shape, including `cache_control` round-trip via the sidecar
  populated by PR2).
- **PR5** — Anthropic SSE re-emit for streaming responses (will also fix the
  thinking-delta / signature-delta drops noted in the existing
  `client_stream.go` default case).
- A small **sibling bug-fix PR** for the pre-existing `pkg/anthropic/client.go`
  defects (`tool_result.is_error` silently dropped; array content flattened
  to empty string) — separate from this series.

## Test plan

- [x] `make agent-lint CHANGED_FILES=...` clean (golangci-lint with project
      config, pre-commit hooks, supply-chain scan, reference-config test,
      structure checks)
- [x] `go vet` and `go build` clean on touched packages
- [x] DCO sign-off on all 4 commits, SSH-signed
- [x] Session-id priority covered by `session_transition_test.go` (new)
- [x] Header pass-through covered by `processor_req_header_test.go` (extended)
- [x] Response-header emission, truncation, sanitization, and cache-hit
      gating covered by `processor_res_header_mutation_test.go` (extended)
- [x] `WarningReason` and metric covered by `pkg/ir/warning_reasons_test.go`
      and `pkg/observability/metrics/translation_metrics_test.go` (new)
- [x] E2E test added: `e2e/testcases/anthropic_messages_headers.go` (`anthropic-messages-protocol-headers`) — asserts `x-vsr-inbound-protocol: anthropic`, `x-vsr-outbound-protocol: openai`, and absence of `x-vsr-lossiness-warnings` on a clean `/v1/messages` request
- [ ] Upstream CI — runs once this PR is marked ready

## Related

- Builds on #1938 (PR2: IR + inbound parser, now merged)
- Builds on #1937 (PR1: ClientProtocol detection, now merged)
- Tracking issue: #1404


