### PR TITLE
feat(anthropic): outbound emitter for non-streaming responses

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -59,6 +59,8 @@ on:
         value: ${{ jobs.filter.outputs.e2e_authz_rbac }}
       e2e_streaming:
         value: ${{ jobs.filter.outputs.e2e_streaming }}
+      e2e_anthropic_shim:
+        value: ${{ jobs.filter.outputs.e2e_anthropic_shim }}
       e2e_common:
         value: ${{ jobs.filter.outputs.e2e_common }}
 
@@ -95,6 +97,7 @@ jobs:
       e2e_multi_endpoint: ${{ steps.changes.outputs.e2e_multi_endpoint }}
       e2e_authz_rbac: ${{ steps.changes.outputs.e2e_authz_rbac }}
       e2e_streaming: ${{ steps.changes.outputs.e2e_streaming }}
+      e2e_anthropic_shim: ${{ steps.changes.outputs.e2e_anthropic_shim }}
       e2e_common: ${{ steps.changes.outputs.e2e_common }}
     steps:
       - uses: actions/checkout@v4
@@ -243,6 +246,11 @@ jobs:
               - 'e2e/profiles/streaming/**'
               - 'deploy/kubernetes/streaming/**'
               - 'src/semantic-router/pkg/extproc/processor_req_body_streamed*.go'
+            e2e_anthropic_shim:
+              - 'e2e/profiles/anthropic-shim/**'
+              - 'e2e/testing/anthropic-shim/**'
+              - 'deploy/kubernetes/anthropic-backend/**'
+              - 'src/semantic-router/pkg/anthropic/outbound*.go'
             # Common e2e code that affects all profiles
             e2e_common:
               - 'e2e/pkg/**'

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -30,6 +30,7 @@ Standard CI-backed profiles:
 - **multi-endpoint**: Environment-specific routing and safety policy behavior
 - **authz-rbac**: Authz-driven routing and per-user rate limiting
 - **streaming**: Streamed request-body and streaming-cache behavior
+- **anthropic-shim**: Anthropic-shape backend (llama.cpp + shim) for verifying outbound translation cells — cache-cycle, stop-reason mapping, and request-side field preservation
 - **dashboard**: Dashboard API surface — health, status, config read, deploy preview, config versions, and input validation
 
 Manual-only profiles:
@@ -59,6 +60,7 @@ Manual-only profiles:
 | `multi-endpoint` | `chat-completions-request` | Environment-specific safety policies |
 | `authz-rbac` | `chat-completions-request` | Authz and rate-limiting behavior |
 | `streaming` | none | Streaming request-body and SSE cache behavior |
+| `anthropic-shim` | none | Outbound Anthropic translation cell — cache, stop-reason, and request-side field preservation |
 | `dashboard` | none | Dashboard HTTP API contract |
 | `dynamo` | none | GPU and batching behavior |
 | `rag-hybrid-search` | none | RAG vector-store and hybrid-search behavior |

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -10,6 +10,7 @@ var BaselineRouterContract = []string{
 	"chat-completions-request",
 	"anthropic-messages-request",
 	"anthropic-messages-protocol-headers",
+	"anthropic-messages-response-shape",
 	"apiserver-runtime-config-endpoints",
 	"apiserver-classification-endpoints",
 	"chat-completions-stress-request",

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -48,6 +48,16 @@ var DashboardContract = []string{
 	"security-policy-apply",
 }
 
+// AnthropicShimContract is the test suite that exercises the Anthropic-
+// shaped backend (llama.cpp + anthropic-shim). These tests require the
+// anthropic-shim profile and will not run correctly against the baseline
+// OpenAI-shaped backends because they assert on Anthropic-specific
+// behaviour such as cache-token synthesis and stop-reason mapping.
+var AnthropicShimContract = []string{
+	"anthropic-messages-cache-cycle",
+	"anthropic-messages-stop-sequence",
+}
+
 // Combine preserves order while removing duplicate testcase names.
 func Combine(groups ...[]string) []string {
 	size := 0

--- a/e2e/profiles/all/imports.go
+++ b/e2e/profiles/all/imports.go
@@ -5,6 +5,7 @@ import (
 	agentgateway "github.com/vllm-project/semantic-router/e2e/profiles/agentgateway"
 	aigateway "github.com/vllm-project/semantic-router/e2e/profiles/ai-gateway"
 	aibrix "github.com/vllm-project/semantic-router/e2e/profiles/aibrix"
+	anthropicshim "github.com/vllm-project/semantic-router/e2e/profiles/anthropic-shim"
 	authzrbac "github.com/vllm-project/semantic-router/e2e/profiles/authz-rbac"
 	dashboard "github.com/vllm-project/semantic-router/e2e/profiles/dashboard"
 	dynamicconfig "github.com/vllm-project/semantic-router/e2e/profiles/dynamic-config"
@@ -37,6 +38,7 @@ func init() {
 	register("agentgateway", func() framework.Profile { return agentgateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("kubernetes", func() framework.Profile { return aigateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("aibrix", func() framework.Profile { return aibrix.NewProfile() }, framework.ProfileCapabilities{})
+	register("anthropic-shim", func() framework.Profile { return anthropicshim.NewProfile() }, framework.ProfileCapabilities{})
 	register("authz-rbac", func() framework.Profile { return authzrbac.NewProfile() }, framework.ProfileCapabilities{})
 	register("dashboard", func() framework.Profile { return dashboard.NewProfile() }, framework.ProfileCapabilities{})
 	register("dynamic-config", func() framework.Profile { return dynamicconfig.NewProfile() }, framework.ProfileCapabilities{})

--- a/e2e/profiles/anthropic-shim/README.md
+++ b/e2e/profiles/anthropic-shim/README.md
@@ -1,0 +1,43 @@
+# anthropic-shim profile
+
+## What this profile is for
+
+This profile exercises the outbound emitter's Anthropic-shaped response
+path end-to-end by routing requests at a backend that natively speaks
+the Anthropic Messages API: `llama.cpp` (`llama-server`) behind the
+`anthropic-shim` Python proxy.
+
+It is needed because the baseline `kubernetes` profile routes Anthropic
+clients at an OpenAI-shaped backend (the mock-vLLM simulator), so the
+emitter's cache-token propagation and stop-reason mapping paths are only
+partially exercised there. Tests that assert on
+`usage.cache_creation_input_tokens` or `stop_reason == "stop_sequence"`
+must run against a backend that actually synthesises those fields.
+
+## What it deploys
+
+| Component | Description |
+| --- | --- |
+| Envoy Gateway + Envoy AI Gateway | Shared gateway stack (same as `kubernetes` / `multi-endpoint`) |
+| Semantic Router (ExtProc) | Built locally (`e2e-test` image tag) |
+| `anthropic-backend-qwen` | `llama-server` + `anthropic-shim` sidecar in `anthropic-backend-system` namespace |
+
+The `anthropic-shim` sidecar translates system arrays, tool-result
+content, and synthesises prompt-cache token counters from
+`x-vsr-test-session-id`-scoped prefix hashes so tests can assert on
+cache-creation vs cache-read cycles without a real Anthropic API key.
+
+## When to use it
+
+Run this profile when adding or validating tests for:
+
+- `usage.cache_creation_input_tokens` / `usage.cache_read_input_tokens`
+- `stop_reason == "stop_sequence"` vs `"end_turn"`
+- Request-side header and field preservation (via `/debug/last-request`)
+- Any test in `testmatrix.AnthropicShimContract`
+
+## Running the profile
+
+```bash
+make e2e-test PROFILE=anthropic-shim
+```

--- a/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
+++ b/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
@@ -1,0 +1,258 @@
+# Anthropic-Shim Backend Resources
+#
+# Deploys the Qwen-flavoured anthropic-shim backend (llama.cpp + Python shim)
+# and exposes it to Envoy AI Gateway so the router can forward Anthropic-
+# protocol requests to it.
+#
+# The backend runs in the anthropic-backend-system namespace (created by
+# deploy/kubernetes/anthropic-backend/base/namespace.yaml). The shim Service
+# exposes port 9080; port 8080 (llama-server) is cluster-internal only.
+
+# ── Namespace ────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: anthropic-backend-system
+---
+# ── PersistentVolumeClaim (model cache) ──────────────────────────────────────
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: anthropic-backend-models-qwen
+  namespace: anthropic-backend-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+# ── Deployment (llama-server + anthropic-shim sidecar) ───────────────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anthropic-backend-qwen
+  namespace: anthropic-backend-system
+  labels:
+    app: anthropic-backend-qwen
+    app.kubernetes.io/name: anthropic-backend
+    app.kubernetes.io/part-of: semantic-router-workspaces
+    model-alias: qwen2.5-0.5b-instruct
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: anthropic-backend-qwen
+      app.kubernetes.io/name: anthropic-backend
+  template:
+    metadata:
+      labels:
+        app: anthropic-backend-qwen
+        app.kubernetes.io/name: anthropic-backend
+        app.kubernetes.io/part-of: semantic-router-workspaces
+        model-alias: qwen2.5-0.5b-instruct
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+
+      initContainers:
+        - name: model-downloader
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          # Root required for pip install into a fresh image and for writing to
+          # the PVC; main containers run confined under fsGroup 1000.
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -e
+              MODEL_FILE="Qwen2.5-0.5B-Instruct-Q4_K_M.gguf"
+              TARGET="/cache/models/${MODEL_FILE}"
+              mkdir -p /cache/models
+              if [ -f "$TARGET" ]; then
+                echo "Model already cached."
+                exit 0
+              fi
+              pip install --no-cache-dir "huggingface_hub[cli]"
+              hf download "bartowski/Qwen2.5-0.5B-Instruct-GGUF" "$MODEL_FILE" --local-dir /cache/models
+          env:
+            - name: MODEL_REPO
+              value: "bartowski/Qwen2.5-0.5B-Instruct-GGUF"
+            - name: MODEL_FILE
+              value: "Qwen2.5-0.5B-Instruct-Q4_K_M.gguf"
+          volumeMounts:
+            - name: models-volume
+              mountPath: /cache/models
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+
+      containers:
+        - name: llama-server
+          image: ghcr.io/ggml-org/llama.cpp:server
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--model"
+            - "/cache/models/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf"
+            - "--jinja"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "-c"
+            - "4096"
+          ports:
+            - name: llama
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: models-volume
+              mountPath: /cache/models
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: llama
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: llama
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: llama
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 18
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+
+        - name: anthropic-shim
+          image: ghcr.io/vllm-project/semantic-router/anthropic-shim:e2e-test
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: shim
+              containerPort: 9080
+              protocol: TCP
+          env:
+            - name: ANTHROPIC_SHIM_UPSTREAM_URL
+              value: "http://127.0.0.1:8080"
+            - name: ANTHROPIC_SHIM_HOST
+              value: "0.0.0.0"
+            - name: ANTHROPIC_SHIM_PORT
+              value: "9080"
+            - name: ANTHROPIC_SHIM_SESSION_HEADER
+              value: "x-vsr-test-session-id"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: shim
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: shim
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+
+      volumes:
+        - name: models-volume
+          persistentVolumeClaim:
+            claimName: anthropic-backend-models-qwen
+---
+# ── Service (shim port only) ──────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: anthropic-backend-qwen
+  namespace: anthropic-backend-system
+  labels:
+    app: anthropic-backend-qwen
+    app.kubernetes.io/name: anthropic-backend
+    app.kubernetes.io/part-of: semantic-router-workspaces
+    model-alias: qwen2.5-0.5b-instruct
+spec:
+  type: ClusterIP
+  selector:
+    app: anthropic-backend-qwen
+    app.kubernetes.io/name: anthropic-backend
+  ports:
+    - name: http
+      port: 9080
+      targetPort: shim
+      protocol: TCP
+---
+# ── Envoy AI Gateway Backend + AIServiceBackend ───────────────────────────────
+# The router uses the Anthropic schema so the AI Gateway knows to translate
+# outbound requests to Anthropic Messages shape before forwarding.
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIServiceBackend
+metadata:
+  name: anthropic-backend-qwen
+  namespace: default
+spec:
+  schema:
+    name: Anthropic
+  backendRef:
+    name: anthropic-backend-qwen
+    kind: Backend
+    group: gateway.envoyproxy.io
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: anthropic-backend-qwen
+  namespace: default
+spec:
+  endpoints:
+    - fqdn:
+        hostname: anthropic-backend-qwen.anthropic-backend-system.svc.cluster.local
+        port: 9080

--- a/e2e/profiles/anthropic-shim/gateway-resources/gwapi-resources.yaml
+++ b/e2e/profiles/anthropic-shim/gateway-resources/gwapi-resources.yaml
@@ -1,0 +1,141 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: semantic-router
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: semantic-router
+  namespace: default
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          resources: {}
+  logging:
+    level:
+      default: debug
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: semantic-router
+  namespace: default
+spec:
+  gatewayClassName: semantic-router
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: semantic-router
+---
+# Buffer limit for AI workloads (matches other profiles)
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: semantic-router
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: semantic-router
+  connection:
+    bufferLimit: 50Mi
+---
+# AIGatewayRoute — sends all model traffic to the anthropic-shim backend.
+# The AI Gateway uses the Anthropic schema declared on AIServiceBackend so
+# outbound requests arrive at the shim in Anthropic Messages shape.
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIGatewayRoute
+metadata:
+  name: semantic-router
+  namespace: default
+spec:
+  parentRefs:
+    - name: semantic-router
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: MoM
+      backendRefs:
+        - name: anthropic-backend-qwen
+      timeouts:
+        request: 120s
+        backendRequest: 120s
+    # Default fallback — catch-all for any unmatched model alias
+    - backendRefs:
+        - name: anthropic-backend-qwen
+      timeouts:
+        request: 120s
+        backendRequest: 120s
+---
+# EnvoyPatchPolicy to add ExtProc filter for semantic-router
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyPatchPolicy
+metadata:
+  name: ai-gateway-prepost-extproc-patch-policy
+  namespace: default
+spec:
+  jsonPatches:
+    - name: default/semantic-router/http
+      operation:
+        op: add
+        path: /default_filter_chain/filters/0/typed_config/http_filters/0
+        value:
+          name: semantic-router-extproc
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            allow_mode_override: true
+            grpcService:
+              envoyGrpc:
+                authority: semantic-router.vllm-semantic-router-system:50051
+                clusterName: semantic-router
+              timeout: 120s
+            message_timeout: 120s
+            processing_mode:
+              request_body_mode: BUFFERED
+              request_header_mode: SEND
+              request_trailer_mode: SKIP
+              response_body_mode: BUFFERED
+              response_header_mode: SEND
+              response_trailer_mode: SKIP
+      type: type.googleapis.com/envoy.config.listener.v3.Listener
+    - name: semantic-router
+      operation:
+        op: add
+        path: ''
+        value:
+          connect_timeout: 120s
+          http2_protocol_options: {}
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: semantic-router
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: semantic-router.vllm-semantic-router-system.svc.cluster.local
+                          port_value: 50051
+          name: semantic-router
+          type: STRICT_DNS
+      type: type.googleapis.com/envoy.config.cluster.v3.Cluster
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: semantic-router
+  type: JSONPatch

--- a/e2e/profiles/anthropic-shim/profile.go
+++ b/e2e/profiles/anthropic-shim/profile.go
@@ -1,0 +1,77 @@
+package anthropicshim
+
+import (
+	"context"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+	gatewaystack "github.com/vllm-project/semantic-router/e2e/pkg/stacks/gateway"
+	"github.com/vllm-project/semantic-router/e2e/pkg/testmatrix"
+
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
+)
+
+const valuesFile = "e2e/profiles/anthropic-shim/values.yaml"
+
+var (
+	resourceManifests = []string{
+		"e2e/profiles/anthropic-shim/gateway-resources/backend.yaml",
+		"e2e/profiles/anthropic-shim/gateway-resources/gwapi-resources.yaml",
+	}
+	waitDeployments = []helpers.DeploymentRef{
+		{Namespace: "anthropic-backend-system", Name: "anthropic-backend-qwen"},
+	}
+)
+
+// Profile implements the anthropic-shim test profile.
+//
+// It deploys the anthropic-shim backend (llama.cpp + the Python translation
+// shim) and points the Envoy AI Gateway routing at it so that Anthropic-
+// protocol requests reach an endpoint that speaks Anthropic Messages natively.
+// This is required for cache-cycle and stop-sequence assertions that exercise
+// the outbound emitter's buildAnthropicUsage and stop-reason mapping paths.
+type Profile struct {
+	stack *gatewaystack.Stack
+}
+
+// NewProfile creates a new anthropic-shim profile.
+func NewProfile() *Profile {
+	return &Profile{
+		stack: gatewaystack.New(gatewaystack.Config{
+			Name:                     "anthropic-shim",
+			SemanticRouterValuesFile: valuesFile,
+			ResourceManifests:        resourceManifests,
+			WaitDeployments:          waitDeployments,
+		}),
+	}
+}
+
+// Name returns the profile name.
+func (p *Profile) Name() string {
+	return "anthropic-shim"
+}
+
+// Description returns the profile description.
+func (p *Profile) Description() string {
+	return "Tests Anthropic /v1/messages response shape and cache-cycle behaviour against the llama.cpp anthropic-shim backend"
+}
+
+// Setup deploys the shared gateway stack and anthropic-shim backend.
+func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error {
+	return p.stack.Setup(ctx, opts)
+}
+
+// Teardown removes the shared gateway stack and anthropic-shim backend.
+func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions) error {
+	return p.stack.Teardown(ctx, opts)
+}
+
+// GetTestCases returns the list of test cases for this profile.
+func (p *Profile) GetTestCases() []string {
+	return testmatrix.AnthropicShimContract
+}
+
+// GetServiceConfig returns the service configuration for accessing the deployed service.
+func (p *Profile) GetServiceConfig() framework.ServiceConfig {
+	return p.stack.ServiceConfig()
+}

--- a/e2e/profiles/anthropic-shim/values.yaml
+++ b/e2e/profiles/anthropic-shim/values.yaml
@@ -1,0 +1,87 @@
+replicaCount: 1
+image:
+  repository: ghcr.io/vllm-project/semantic-router/extproc
+  pullPolicy: Never
+  tag: e2e-test
+service:
+  type: ClusterIP
+  port: 8080
+config:
+  version: v0.3
+  listeners: []
+  providers:
+    defaults:
+      default_model: MoM
+    models:
+      - name: MoM
+        backend_refs:
+          - name: anthropic-backend-qwen
+            # The shim's Service exposes port 9080 (the Python FastAPI layer).
+            # Requests from the router arrive as Anthropic Messages bodies;
+            # the shim forwards them to llama-server after translation.
+            endpoint: anthropic-backend-qwen.anthropic-backend-system.svc.cluster.local:9080
+            weight: 1
+            type: anthropic
+  routing:
+    decisions:
+      - name: route_to_anthropic_shim
+        description: Route all requests to the anthropic-shim backend
+        priority: 50
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: all_requests
+        modelRefs:
+          - model: MoM
+            use_reasoning: false
+    signals:
+      keywords:
+        - name: all_requests
+          operator: OR
+          keywords:
+            # Catch-all routing; the AIGatewayRoute also has a bare fallback
+            # rule in gwapi-resources.yaml. Both are intentional — the router
+            # needs a signal match to route, and the gateway provides a
+            # safety-net in case the router produces no match.
+            - ""
+    modelCards:
+      - name: MoM
+        param_size: 0.5b
+        description: Qwen2.5-0.5B-Instruct via llama.cpp + anthropic-shim
+        capabilities:
+          - chat
+        quality_score: 0.5
+  global:
+    model_catalog:
+      kbs: []
+    router:
+      clear_route_cache: true
+      strategy: priority
+    services:
+      observability:
+        metrics:
+          enabled: true
+        tracing:
+          enabled: false
+      api:
+        batch_classification:
+          max_batch_size: 100
+          concurrency_threshold: 5
+          max_concurrency: 8
+    stores:
+      semantic_cache:
+        enabled: false
+        embedding_model: mmbert
+      memory:
+        embedding_model: mmbert
+      vector_store:
+        embedding_model: mmbert
+    integrations: {}
+resources:
+  limits:
+    cpu: 2000m
+    memory: 8Gi
+  requests:
+    cpu: 500m
+    memory: 2Gi

--- a/e2e/testcases/anthropic_messages_cache_cycle.go
+++ b/e2e/testcases/anthropic_messages_cache_cycle.go
@@ -1,0 +1,203 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-messages-cache-cycle", pkgtestcases.TestCase{
+		Description: "Verify cache_creation_input_tokens on first request and cache_read_input_tokens on repeat (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "cache", "functional"},
+		Fn:          testAnthropicMessagesCacheCycle,
+	})
+}
+
+// anthropicCacheBlock is the content block shape used in the system array for
+// cache-cycle testing. It carries cache_control so the shim treats the
+// system prefix as a cacheable boundary.
+type anthropicCacheBlock struct {
+	Type         string                 `json:"type"`
+	Text         string                 `json:"text"`
+	CacheControl map[string]interface{} `json:"cache_control,omitempty"`
+}
+
+// anthropicCacheRequestBody is the POST /v1/messages payload for cache-cycle
+// tests. system is an array (scenario 8) so the shim can detect the
+// cache_control marker and synthesise usage counters accordingly.
+type anthropicCacheRequestBody struct {
+	Model     string                `json:"model"`
+	MaxTokens int                   `json:"max_tokens"`
+	System    []anthropicCacheBlock `json:"system"`
+	Messages  []anthropicMessage    `json:"messages"`
+}
+
+// anthropicCacheUsage holds the subset of the usage object the cache-cycle
+// test cares about. Other fields are intentionally ignored.
+type anthropicCacheUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// anthropicCacheResponse mirrors the Anthropic Messages wire shape for the
+// fields needed by cache-cycle assertions.
+type anthropicCacheResponse struct {
+	ID         string              `json:"id"`
+	Type       string              `json:"type"`
+	StopReason string              `json:"stop_reason"`
+	Usage      anthropicCacheUsage `json:"usage"`
+}
+
+// testAnthropicMessagesCacheCycle exercises scenarios 1, 2, and 8:
+//
+//   - Scenario 8: system is an array with cache_control on at least one block.
+//   - Scenario 1: first request with a new cache prefix must set
+//     usage.cache_creation_input_tokens > 0 and
+//     usage.cache_read_input_tokens == 0.
+//   - Scenario 2: second request with the same prefix must set
+//     usage.cache_read_input_tokens > 0.
+//
+// Both requests share the same x-vsr-test-session-id header so the shim's
+// per-session tracker sees the prefix repeat. The router's outbound emitter
+// must propagate the synthesised usage fields onto the Anthropic-shaped
+// response unchanged; any loss or zero-overwrite fails the test.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesCacheCycle(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing cache-cycle assertions on /v1/messages")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	sessionID := fmt.Sprintf("cache-cycle-%d", time.Now().UnixNano())
+
+	body := anthropicCacheRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		System: []anthropicCacheBlock{
+			{
+				Type: "text",
+				Text: "You are a helpful assistant. Answer concisely.",
+				CacheControl: map[string]interface{}{
+					"type": "ephemeral",
+				},
+			},
+		},
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "Say one word."},
+		},
+	}
+
+	resp1, body1, err := sendCacheRequest(ctx, body, sessionID, localPort)
+	if err != nil {
+		return fmt.Errorf("request 1 failed: %w", err)
+	}
+
+	if resp1.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200 for request 1, got %d", resp1.StatusCode)
+	}
+	if body1.Usage.CacheCreationInputTokens <= 0 {
+		return fmt.Errorf(
+			"scenario 1: expected cache_creation_input_tokens > 0 on first request, got %d",
+			body1.Usage.CacheCreationInputTokens,
+		)
+	}
+	if body1.Usage.CacheReadInputTokens != 0 {
+		return fmt.Errorf(
+			"scenario 1: expected cache_read_input_tokens == 0 on first request, got %d",
+			body1.Usage.CacheReadInputTokens,
+		)
+	}
+
+	resp2, body2, err := sendCacheRequest(ctx, body, sessionID, localPort)
+	if err != nil {
+		return fmt.Errorf("request 2 failed: %w", err)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code_req1":           resp1.StatusCode,
+			"cache_creation_tokens_req1": body1.Usage.CacheCreationInputTokens,
+			"cache_read_tokens_req1":     body1.Usage.CacheReadInputTokens,
+			"status_code_req2":           resp2.StatusCode,
+			"cache_creation_tokens_req2": body2.Usage.CacheCreationInputTokens,
+			"cache_read_tokens_req2":     body2.Usage.CacheReadInputTokens,
+		})
+	}
+
+	if resp2.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200 for request 2, got %d", resp2.StatusCode)
+	}
+	if body2.Usage.CacheReadInputTokens <= 0 {
+		return fmt.Errorf(
+			"scenario 2: expected cache_read_input_tokens > 0 on repeat request, got %d",
+			body2.Usage.CacheReadInputTokens,
+		)
+	}
+	if body2.Usage.CacheCreationInputTokens != 0 {
+		return fmt.Errorf(
+			"scenario 2: expected cache_creation_input_tokens == 0 on repeat request, got %d",
+			body2.Usage.CacheCreationInputTokens,
+		)
+	}
+
+	return nil
+}
+
+// sendCacheRequest posts an anthropicCacheRequestBody to /v1/messages with
+// the given session header and returns the parsed response.
+func sendCacheRequest(
+	ctx context.Context,
+	body anthropicCacheRequestBody,
+	sessionID string,
+	localPort string,
+) (*http.Response, anthropicCacheResponse, error) {
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return nil, anthropicCacheResponse{}, fmt.Errorf("marshal: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%s/v1/messages", localPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, anthropicCacheResponse{}, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("x-vsr-test-session-id", sessionID)
+
+	httpClient := &http.Client{Timeout: 120 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, anthropicCacheResponse{}, fmt.Errorf("do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp, anthropicCacheResponse{}, fmt.Errorf("read response body: %w", err)
+	}
+	var parsed anthropicCacheResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return resp, anthropicCacheResponse{}, fmt.Errorf(
+			"unmarshal response: %w (body=%s)", err, truncateString(string(raw), 200),
+		)
+	}
+	return resp, parsed, nil
+}

--- a/e2e/testcases/anthropic_messages_response_shape.go
+++ b/e2e/testcases/anthropic_messages_response_shape.go
@@ -1,0 +1,131 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-messages-response-shape", pkgtestcases.TestCase{
+		Description: "Verify non-streaming /v1/messages response is in Anthropic Messages API shape",
+		Tags:        []string{"anthropic", "response-shape"},
+		Fn:          testAnthropicMessagesResponseShape,
+	})
+}
+
+// anthropicMessageResponse mirrors the Anthropic Messages API wire shape
+// well enough for E2E structural assertions. Free-text content and exact
+// usage values are mock-backend dependent and intentionally untyped here.
+type anthropicMessageResponse struct {
+	ID         string            `json:"id"`
+	Type       string            `json:"type"`
+	Role       string            `json:"role"`
+	Model      string            `json:"model"`
+	Content    []json.RawMessage `json:"content"`
+	StopReason string            `json:"stop_reason"`
+	Usage      json.RawMessage   `json:"usage"`
+}
+
+// validAnthropicStopReasons enumerates the stop_reason values defined by
+// the Anthropic Messages API. The outbound emitter PR maps OpenAI finish
+// reasons into this set; any value outside it indicates the emitter
+// either bypassed the mapping or invented a new token.
+var validAnthropicStopReasons = map[string]struct{}{
+	"end_turn":      {},
+	"max_tokens":    {},
+	"stop_sequence": {},
+	"tool_use":      {},
+	"pause_turn":    {},
+	"refusal":       {},
+}
+
+// testAnthropicMessagesResponseShape asserts the outbound emitter rewrites
+// the OpenAI ChatCompletion body the router normalizes to back into the
+// Anthropic Messages wire shape, so an Anthropic-SDK client (Claude Code,
+// anthropic-sdk-go) can deserialize it without custom adapters.
+func testAnthropicMessagesResponseShape(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Verifying response is in Anthropic Messages shape")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	resp, err := sendAnthropicMessagesRequest(ctx, anthropicMessagesRequestBody{
+		Model:     "MoM",
+		MaxTokens: 64,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "Say hi in one word."},
+		},
+	}, localPort)
+	if err != nil {
+		return fmt.Errorf("anthropic messages request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200, got %d: %s", resp.StatusCode, truncateString(string(body), 200))
+	}
+
+	var parsed anthropicMessageResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("response body is not Anthropic-shaped JSON: %w (body=%s)",
+			err, truncateString(string(body), 200))
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code":    resp.StatusCode,
+			"id":             parsed.ID,
+			"type":           parsed.Type,
+			"role":           parsed.Role,
+			"stop_reason":    parsed.StopReason,
+			"content_blocks": len(parsed.Content),
+			"has_usage":      len(parsed.Usage) > 0,
+		})
+	}
+
+	return assertAnthropicMessageShape(parsed)
+}
+
+// assertAnthropicMessageShape enforces the per-field invariants the
+// outbound emitter is responsible for; kept as a helper so the test
+// function stays under the project's cyclomatic-complexity ceiling.
+func assertAnthropicMessageShape(parsed anthropicMessageResponse) error {
+	if parsed.ID == "" {
+		return fmt.Errorf("expected non-empty id in Anthropic response")
+	}
+	if parsed.Type != "message" {
+		return fmt.Errorf("expected type=\"message\", got %q", parsed.Type)
+	}
+	if parsed.Role != "assistant" {
+		return fmt.Errorf("expected role=\"assistant\", got %q", parsed.Role)
+	}
+	// content must always be a (possibly empty) array, never null.
+	if parsed.Content == nil {
+		return fmt.Errorf("expected content array (may be empty), got null")
+	}
+	if _, ok := validAnthropicStopReasons[parsed.StopReason]; !ok {
+		return fmt.Errorf("stop_reason %q is not a valid Anthropic value", parsed.StopReason)
+	}
+	// usage block must be present (input_tokens/output_tokens are upstream
+	// of vsr but the emitter is responsible for surfacing it).
+	if len(parsed.Usage) == 0 {
+		return fmt.Errorf("expected usage object in Anthropic response, got empty")
+	}
+	return nil
+}

--- a/e2e/testcases/anthropic_messages_stop_sequence.go
+++ b/e2e/testcases/anthropic_messages_stop_sequence.go
@@ -1,0 +1,141 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-messages-stop-sequence", pkgtestcases.TestCase{
+		Description: "Verify stop_reason=stop_sequence when stop_sequences is set and model triggers it (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "stop-reason", "functional"},
+		Fn:          testAnthropicMessagesStopSequence,
+	})
+}
+
+// testAnthropicMessagesStopSequence asserts that the outbound emitter maps
+// the upstream finish_reason to "stop_sequence" when the request carried
+// stop_sequences and the model's output triggered one.
+//
+// The system prompt directs the tiny Qwen model to emit "STOP" verbatim,
+// which — if followed — causes llama-server to set finish_reason=stop and
+// return the stop token in stop_reason. The shim passes this through; the
+// router's mapOpenAIFinishReasonToAnthropic must then label the response
+// stop_reason as "stop_sequence" (not "end_turn").
+//
+// NOTE: This test depends on the tiny Qwen2.5-0.5B model in the
+// anthropic-shim profile following the "say STOP exactly" instruction. If
+// the model does not reliably emit the sentinel in CI, prefer replacing
+// "STOP" with a sentinel the model emits unconditionally (e.g. the EOS
+// token) over adding retry loops or sleeps.
+//
+// TODO: If this test flakes due to model instruction-following variability,
+// swap the stop_sequences value for a string the model outputs in all
+// completions (e.g. a fixed suffix in the system prompt) rather than
+// introducing any retry or timing-based workaround.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesStopSequence(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing stop_sequence assertion on /v1/messages")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	body := stopSequenceRequestBody{
+		Model:         "MoM",
+		MaxTokens:     50,
+		StopSequences: []string{"STOP"},
+		System:        "You must end every response with the word STOP in capital letters, on its own line.",
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "Please respond and end with STOP."},
+		},
+	}
+
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%s/v1/messages", localPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	httpClient := &http.Client{Timeout: 120 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+	var parsed anthropicStopResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return fmt.Errorf(
+			"unmarshal response: %w (body=%s)", err, truncateString(string(raw), 200),
+		)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code": resp.StatusCode,
+			"stop_reason": parsed.StopReason,
+		})
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200, got %d: %s",
+			resp.StatusCode, truncateString(string(raw), 200))
+	}
+
+	if parsed.StopReason != "stop_sequence" {
+		return fmt.Errorf(
+			"expected stop_reason=stop_sequence, got %q — "+
+				"the model may not have emitted the sentinel; "+
+				"if this flakes in CI replace the stop string with "+
+				"a sentinel the model emits unconditionally",
+			parsed.StopReason,
+		)
+	}
+
+	return nil
+}
+
+// anthropicStopResponse is the minimal parse target for stop-sequence
+// assertions. Only stop_reason is needed; using a local type avoids a
+// dependency on anthropicCacheResponse from the sibling cache-cycle test.
+type anthropicStopResponse struct {
+	StopReason string `json:"stop_reason"`
+}
+
+// stopSequenceRequestBody is the POST /v1/messages payload for the
+// stop-sequence assertion. stop_sequences is what triggers the mapping in
+// mapOpenAIFinishReasonToAnthropic; system uses a string (not array) so
+// cache_control synthesis is not involved.
+type stopSequenceRequestBody struct {
+	Model         string             `json:"model"`
+	MaxTokens     int                `json:"max_tokens"`
+	StopSequences []string           `json:"stop_sequences"`
+	System        string             `json:"system,omitempty"`
+	Messages      []anthropicMessage `json:"messages"`
+}

--- a/e2e/testing/anthropic-shim/README.md
+++ b/e2e/testing/anthropic-shim/README.md
@@ -17,6 +17,25 @@ Everything else (image blocks, `top_k`, `metadata.user_id`,
 `tool_result.is_error`, headers like `anthropic-version` and
 `anthropic-beta`, streaming SSE) is forwarded verbatim.
 
+## Debug endpoint
+
+`GET /debug/last-request` returns the most recent translated Anthropic
+Messages body that the shim forwarded to llama-server for a given
+session, plus the original inbound headers. This allows e2e tests to
+assert on request-side preservation (header forwarding, field
+translation) without log-scraping.
+
+The session is identified by the `x-vsr-test-session-id` request
+header or the same-named query parameter. Returns 404 when no request
+has been seen for that session yet.
+
+```bash
+curl -s 'http://127.0.0.1:9080/debug/last-request' \
+  -H 'x-vsr-test-session-id: my-session' | jq .
+```
+
+The in-memory store is bounded to 32 sessions with LRU eviction.
+
 ## Layout
 
 ```

--- a/e2e/testing/anthropic-shim/anthropic_shim/app.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/app.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections import OrderedDict
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -46,6 +47,9 @@ _HOP_BY_HOP = {
     "upgrade",
 }
 
+# Maximum number of sessions the request store will track before LRU eviction.
+_MAX_REQUEST_STORE_SESSIONS = 32
+
 
 def _filtered_headers(headers: dict[str, str]) -> dict[str, str]:
     return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
@@ -69,6 +73,52 @@ class SessionCacheTracker:
         already_seen = prefix in bucket
         bucket.add(prefix)
         return already_seen
+
+
+class RequestStore:
+    """Per-session ring buffer (size 1) of the most recent request the shim
+    was about to forward.
+
+    Stores the translated request body alongside the headers the shim received,
+    so tests can inspect what would have reached upstream without scraping logs.
+    Note: ``record()`` is called *before* the upstream POST, so an upstream
+    failure leaves a stale entry for that session. This is acceptable for a
+    test-only shim — callers should treat the stored body as "last attempted
+    forward", not "last successful forward".
+
+    Bounded to ``_MAX_REQUEST_STORE_SESSIONS`` sessions with LRU eviction so
+    long-running multi-session test suites do not leak memory.
+
+    Concurrency: safe only under a single-worker async event loop (the default
+    uvicorn deployment for this shim). Multi-worker deployment would shard
+    sessions across processes non-deterministically. Inbound headers are stored
+    verbatim, including credentials (``Authorization`` etc.); acceptable
+    because the shim is loopback-only test infrastructure.
+    """
+
+    def __init__(self) -> None:
+        # OrderedDict gives O(1) LRU move-to-end semantics.
+        self._store: OrderedDict[str, dict[str, Any]] = OrderedDict()
+
+    def record(
+        self,
+        session_id: str,
+        body: dict[str, Any],
+        headers: dict[str, str],
+    ) -> None:
+        """Store the most recent forwarded body + headers for ``session_id``."""
+        if session_id in self._store:
+            self._store.move_to_end(session_id)
+        elif len(self._store) >= _MAX_REQUEST_STORE_SESSIONS:
+            self._store.popitem(last=False)  # evict LRU entry
+        self._store[session_id] = {"body": body, "headers": headers}
+
+    def get(self, session_id: str) -> dict[str, Any] | None:
+        """Return the most recent entry for ``session_id``, or None."""
+        entry = self._store.get(session_id)
+        if entry is not None:
+            self._store.move_to_end(session_id)
+        return entry
 
 
 def create_app(
@@ -104,12 +154,37 @@ def create_app(
     app = FastAPI(title="anthropic-shim", version="0.1.0", lifespan=lifespan)
     app.state.upstream = upstream
     app.state.tracker = SessionCacheTracker()
+    app.state.request_store = RequestStore()
     app.state.session_header = session_header_name
     app.state.client = client
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:
         return {"status": "ok", "upstream": upstream}
+
+    @app.get("/debug/last-request")
+    async def debug_last_request(request: Request) -> Response:
+        """Return the most recent translated request for the given session.
+
+        The session is identified by the configured session header key (default
+        ``x-vsr-test-session-id``) supplied as either a request header or a
+        query parameter (header takes precedence). Both paths use the same
+        configurable key so that reconfiguring ANTHROPIC_SHIM_SESSION_HEADER
+        does not leave query-param lookups pointing at the literal default.
+        Returns 404 when no request has been seen for that session yet.
+        """
+        session_id = (
+            request.headers.get(app.state.session_header)
+            or request.query_params.get(app.state.session_header)
+            or "__global__"
+        )
+        entry = app.state.request_store.get(session_id)
+        if entry is None:
+            return JSONResponse(
+                status_code=404,
+                content={"error": "not_found", "session_id": session_id},
+            )
+        return JSONResponse(content={"session_id": session_id, **entry})
 
     @app.post("/v1/messages")
     async def messages(request: Request) -> Response:
@@ -150,6 +225,10 @@ async def _handle_messages(request: Request, app: FastAPI) -> Response:
     is_streaming = bool(body.get("stream"))
     if is_streaming:
         return await _proxy_stream(app, "/v1/messages", body, headers)
+
+    # Record what the shim is about to forward so /debug/last-request can
+    # return the translated body + inbound headers for test assertions.
+    app.state.request_store.record(session_id, body, dict(request.headers))
 
     upstream_response = await app.state.client.post(
         "/v1/messages",

--- a/e2e/testing/anthropic-shim/tests/test_app.py
+++ b/e2e/testing/anthropic-shim/tests/test_app.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import httpx
 import pytest
-from anthropic_shim.app import create_app
+from anthropic_shim.app import _MAX_REQUEST_STORE_SESSIONS, create_app
 
 
 class _UpstreamRecorder:
@@ -195,3 +195,174 @@ async def test_invalid_json_returns_400(
         headers={"content-type": "application/json"},
     )
     assert response.status_code == 400
+
+
+# ── /debug/last-request tests ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_debug_last_request_returns_404_before_any_request(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    response = await client.get(
+        "/debug/last-request",
+        headers={"x-vsr-test-session-id": "session-new"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_debug_last_request_returns_translated_body_after_messages_post(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    payload = {
+        "model": "qwen-test",
+        "system": [
+            {"type": "text", "text": "You are helpful."},
+            {"type": "text", "text": "Be concise."},
+        ],
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 16,
+    }
+    session = "debug-session-1"
+    await client.post(
+        "/v1/messages", json=payload, headers={"x-vsr-test-session-id": session}
+    )
+
+    response = await client.get(
+        "/debug/last-request",
+        headers={"x-vsr-test-session-id": session},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    # The shim joins the system array before forwarding.
+    assert data["body"]["system"] == "You are helpful.\nBe concise."
+    assert data["session_id"] == session
+    assert "headers" in data
+
+
+@pytest.mark.asyncio
+async def test_debug_last_request_session_via_query_param(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    payload = {
+        "model": "qwen-test",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 8,
+    }
+    session = "debug-qp-session"
+    await client.post(
+        "/v1/messages", json=payload, headers={"x-vsr-test-session-id": session}
+    )
+
+    # Retrieve via query param instead of header.
+    response = await client.get(
+        f"/debug/last-request?x-vsr-test-session-id={session}",
+    )
+    assert response.status_code == 200
+    assert response.json()["session_id"] == session
+
+
+@pytest.mark.asyncio
+async def test_debug_last_request_reflects_most_recent_request(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    session = "debug-overwrite-session"
+    for content in ("first", "second"):
+        await client.post(
+            "/v1/messages",
+            json={
+                "model": "qwen-test",
+                "messages": [{"role": "user", "content": content}],
+                "max_tokens": 8,
+            },
+            headers={"x-vsr-test-session-id": session},
+        )
+
+    response = await client.get(
+        "/debug/last-request",
+        headers={"x-vsr-test-session-id": session},
+    )
+    assert response.status_code == 200
+    # Only the most recent request is retained.
+    assert response.json()["body"]["messages"][0]["content"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_debug_last_request_session_isolation(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    payload_a = {
+        "model": "qwen-test",
+        "messages": [{"role": "user", "content": "alpha"}],
+        "max_tokens": 8,
+    }
+    payload_b = {
+        "model": "qwen-test",
+        "messages": [{"role": "user", "content": "beta"}],
+        "max_tokens": 8,
+    }
+    await client.post(
+        "/v1/messages", json=payload_a, headers={"x-vsr-test-session-id": "alpha"}
+    )
+    await client.post(
+        "/v1/messages", json=payload_b, headers={"x-vsr-test-session-id": "beta"}
+    )
+
+    resp_a = await client.get(
+        "/debug/last-request", headers={"x-vsr-test-session-id": "alpha"}
+    )
+    resp_b = await client.get(
+        "/debug/last-request", headers={"x-vsr-test-session-id": "beta"}
+    )
+    assert resp_a.json()["body"]["messages"][0]["content"] == "alpha"
+    assert resp_b.json()["body"]["messages"][0]["content"] == "beta"
+
+
+@pytest.mark.asyncio
+async def test_request_store_lru_evicts_oldest_session(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    """Filling _MAX_REQUEST_STORE_SESSIONS+1 sessions evicts the oldest."""
+    client, _ = client_with_upstream
+    # Session IDs in insertion order; the first one must be evicted.
+    session_ids = [
+        f"lru-session-{i:03d}" for i in range(_MAX_REQUEST_STORE_SESSIONS + 1)
+    ]
+
+    for sid in session_ids:
+        await client.post(
+            "/v1/messages",
+            json={
+                "model": "qwen-test",
+                "messages": [{"role": "user", "content": sid}],
+                "max_tokens": 8,
+            },
+            headers={"x-vsr-test-session-id": sid},
+        )
+
+    # The oldest session must have been evicted.
+    evicted = session_ids[0]
+    resp_evicted = await client.get(
+        "/debug/last-request",
+        headers={"x-vsr-test-session-id": evicted},
+    )
+    assert (
+        resp_evicted.status_code == 404
+    ), f"expected evicted session {evicted!r} to return 404, got {resp_evicted.status_code}"
+
+    # The most recent _MAX_REQUEST_STORE_SESSIONS sessions must still be present.
+    for sid in session_ids[1:]:
+        resp = await client.get(
+            "/debug/last-request",
+            headers={"x-vsr-test-session-id": sid},
+        )
+        assert (
+            resp.status_code == 200
+        ), f"expected session {sid!r} to be present, got {resp.status_code}"
+        assert resp.json()["body"]["messages"][0]["content"] == sid

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -141,6 +141,16 @@ func ToOpenAIResponseBody(anthropicResponse []byte, model string) ([]byte, error
 	return toOpenAIResponseBody(anthropicResponse, model, nil)
 }
 
+// ToOpenAIResponseBodyWithExt is the IRExtensions-aware form of
+// ToOpenAIResponseBody. When ext is non-nil the parser stashes the
+// Anthropic-only stop_reason, cache usage counters, server-tool counts,
+// and thinking-block signatures onto it so the symmetric outbound
+// emitter (EmitAnthropicResponse) can replay them on the response body.
+// Pass nil ext for byte-identical behavior with the original entrypoint.
+func ToOpenAIResponseBodyWithExt(anthropicResponse []byte, model string, ext *ir.IRExtensions) ([]byte, error) {
+	return toOpenAIResponseBody(anthropicResponse, model, ext)
+}
+
 // toOpenAIResponseBody is the internal form that exposes the
 // IRExtensions side channel. It is called by ToOpenAIResponseBody with a
 // nil ext to preserve the existing inverse cell byte-for-byte; the

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/openai/openai-go"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
@@ -127,136 +127,27 @@ func ToAnthropicRequestBodyWithPassthrough(openAIRequest *openai.ChatCompletionN
 	return json.Marshal(params)
 }
 
-// resolveMaxTokens picks max_tokens with Anthropic's required default.
-func resolveMaxTokens(req *openai.ChatCompletionNewParams) int64 {
-	switch {
-	case req.MaxCompletionTokens.Value > 0:
-		return req.MaxCompletionTokens.Value
-	case req.MaxTokens.Value > 0:
-		return req.MaxTokens.Value
-	default:
-		return DefaultMaxTokens
-	}
-}
-
-// buildSystem returns the Anthropic system array. When pt carries
-// SystemBlocks (array-form system from inbound), each block is emitted with
-// its cache_control marker; otherwise it falls back to the string-form system
-// derived from the OpenAI messages, preserving today's behaviour byte-for-byte.
-func buildSystem(systemPrompt string, pt *AnthropicPassthrough) []anthropic.TextBlockParam {
-	if pt != nil && len(pt.SystemBlocks) > 0 {
-		out := make([]anthropic.TextBlockParam, 0, len(pt.SystemBlocks))
-		for _, sb := range pt.SystemBlocks {
-			block := anthropic.TextBlockParam{Text: sb.Text}
-			if sb.CacheControl != nil {
-				block.CacheControl = toSDKCacheControl(*sb.CacheControl)
-			}
-			out = append(out, block)
-		}
-		return out
-	}
-	if systemPrompt == "" {
-		return nil
-	}
-	return []anthropic.TextBlockParam{{Text: systemPrompt}}
-}
-
-// applySampling sets temperature, top_p, and stop_sequences from the OpenAI
-// request, plus top_k from the passthrough when present.
-func applySampling(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, pt *AnthropicPassthrough) {
-	if req.Temperature.Valid() {
-		params.Temperature = anthropic.Float(req.Temperature.Value)
-	}
-	if req.TopP.Valid() {
-		params.TopP = anthropic.Float(req.TopP.Value)
-	}
-	if len(req.Stop.OfStringArray) > 0 {
-		params.StopSequences = req.Stop.OfStringArray
-	} else if req.Stop.OfString.Value != "" {
-		params.StopSequences = []string{req.Stop.OfString.Value}
-	}
-	if pt != nil && pt.TopK != nil {
-		params.TopK = anthropic.Int(*pt.TopK)
-	}
-}
-
-// applyMetadata emits metadata.user_id from the passthrough when set, falling
-// back to the OpenAI request's `user` field as the conventional mapping.
-func applyMetadata(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, pt *AnthropicPassthrough) {
-	userID := ""
-	if pt != nil && pt.MetadataUserID != "" {
-		userID = pt.MetadataUserID
-	} else if req != nil && req.User.Valid() && req.User.Value != "" {
-		userID = req.User.Value
-	}
-	if userID == "" {
-		return
-	}
-	params.Metadata = anthropic.MetadataParam{UserID: anthropic.String(userID)}
-}
-
-// applyToolsCacheControl attaches cache_control markers to tool definitions
-// based on the `tools[i]` keys in the passthrough.
-func applyToolsCacheControl(params *anthropic.MessageNewParams, pt *AnthropicPassthrough) {
-	if pt == nil || len(pt.CacheControl) == 0 {
-		return
-	}
-	for i := range params.Tools {
-		spec, ok := pt.CacheControl[fmt.Sprintf("tools[%d]", i)]
-		if !ok {
-			continue
-		}
-		if params.Tools[i].OfTool != nil {
-			params.Tools[i].OfTool.CacheControl = toSDKCacheControl(spec)
-		}
-	}
-}
-
-// applyMessagesCacheControl attaches per-content-block cache_control markers
-// to the outbound user/assistant messages. Markers whose `messages[i].content[j]`
-// key no longer matches a block on the outbound side are silently dropped to
-// match the surrounding lossy-translation discipline.
-func applyMessagesCacheControl(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
-	if pt == nil || len(pt.CacheControl) == 0 {
-		return
-	}
-	for i := range messages {
-		for j := range messages[i].Content {
-			spec, ok := pt.CacheControl[fmt.Sprintf("messages[%d].content[%d]", i, j)]
-			if !ok {
-				continue
-			}
-			sdkCC := toSDKCacheControl(spec)
-			block := &messages[i].Content[j]
-			switch {
-			case block.OfText != nil:
-				block.OfText.CacheControl = sdkCC
-			case block.OfImage != nil:
-				block.OfImage.CacheControl = sdkCC
-			case block.OfToolUse != nil:
-				block.OfToolUse.CacheControl = sdkCC
-			case block.OfToolResult != nil:
-				block.OfToolResult.CacheControl = sdkCC
-			}
-		}
-	}
-}
-
-// toSDKCacheControl converts the package-local CacheControlSpec into the SDK's
-// CacheControlEphemeralParam. Type defaults to "ephemeral" (the only value the
-// SDK supports today); TTL is forwarded when set.
-func toSDKCacheControl(spec CacheControlSpec) anthropic.CacheControlEphemeralParam {
-	cc := anthropic.NewCacheControlEphemeralParam()
-	if spec.TTL != "" {
-		cc.TTL = anthropic.CacheControlEphemeralTTL(spec.TTL)
-	}
-	return cc
-}
-
 // ToOpenAIResponseBody transforms an Anthropic API response to OpenAI format.
 // This is used for Envoy-routed requests where the router transforms the response
 // after receiving it from Anthropic via Envoy.
+//
+// Behavior contract for the legacy inverse cell (OpenAI client, Anthropic
+// backend) is preserved: thinking, citations, and server_tool_use blocks
+// are silently dropped because they have no OpenAI representation. The
+// internal helpers accept an optional *ir.IRExtensions so the symmetric
+// outbound emitter (EmitAnthropicResponse) can capture the dropped state
+// for replay on the Anthropic→Anthropic round-trip cell.
 func ToOpenAIResponseBody(anthropicResponse []byte, model string) ([]byte, error) {
+	return toOpenAIResponseBody(anthropicResponse, model, nil)
+}
+
+// toOpenAIResponseBody is the internal form that exposes the
+// IRExtensions side channel. It is called by ToOpenAIResponseBody with a
+// nil ext to preserve the existing inverse cell byte-for-byte; the
+// Anthropic→Anthropic outbound cell calls it with a non-nil ext so the
+// stop_reason, cache usage, and server-tool counts survive the
+// flattening that the OpenAI envelope cannot represent.
+func toOpenAIResponseBody(anthropicResponse []byte, model string, ext *ir.IRExtensions) ([]byte, error) {
 	logging.Debugf("Raw Anthropic response (%d bytes): %s", len(anthropicResponse), string(anthropicResponse))
 
 	var resp anthropic.Message
@@ -267,18 +158,11 @@ func ToOpenAIResponseBody(anthropicResponse []byte, model string) ([]byte, error
 	logging.Debugf("Parsed Anthropic response - ID: %s, Content blocks: %d, StopReason: %s", resp.ID, len(resp.Content), resp.StopReason)
 
 	toolCalls, content := openAIToolCallsFromAnthropicContent(resp.Content)
+	extractThinkingBlocks(resp.Content, ext)
+	captureAnthropicStopReasonIntoExt(resp.StopReason, resp.StopSequence, ext)
+	extractAnthropicUsageIntoExt(resp.Usage, ext)
 
-	// Map stop reason
-	finishReason := "stop"
-	switch resp.StopReason {
-	case anthropic.StopReasonMaxTokens:
-		finishReason = "length"
-	case anthropic.StopReasonToolUse:
-		finishReason = "tool_calls"
-	}
-	if len(toolCalls) > 0 && finishReason == "stop" {
-		finishReason = "tool_calls"
-	}
+	finishReason := openAIFinishReasonFromAnthropic(resp.StopReason, len(toolCalls))
 
 	openAIResp := &openai.ChatCompletion{
 		ID:      resp.ID,
@@ -304,457 +188,91 @@ func ToOpenAIResponseBody(anthropicResponse []byte, model string) ([]byte, error
 	return json.Marshal(openAIResp)
 }
 
-// extractSystemContent extracts text from a system message
-func extractSystemContent(msg *openai.ChatCompletionSystemMessageParam) string {
-	if msg.Content.OfString.Value != "" {
-		return msg.Content.OfString.Value
+// openAIFinishReasonFromAnthropic maps Anthropic's StopReason alphabet
+// onto the smaller OpenAI finish_reason set. Anthropic-only values
+// ("pause_turn", "refusal") collapse to "stop" because the inverse
+// cell cannot surface them in the OpenAI envelope; the lossy capture
+// happens in captureAnthropicStopReasonIntoExt for callers that wired
+// IRExtensions.
+func openAIFinishReasonFromAnthropic(stopReason anthropic.StopReason, toolCallCount int) string {
+	finishReason := "stop"
+	switch stopReason {
+	case anthropic.StopReasonMaxTokens:
+		finishReason = "length"
+	case anthropic.StopReasonToolUse:
+		finishReason = "tool_calls"
 	}
-	var parts []string
-	for _, part := range msg.Content.OfArrayOfContentParts {
-		if part.Text != "" {
-			parts = append(parts, part.Text)
-		}
+	if toolCallCount > 0 && finishReason == "stop" {
+		finishReason = "tool_calls"
 	}
-	return strings.Join(parts, " ")
+	return finishReason
 }
 
-// extractUserContent extracts text from a user message. Kept for
-// backwards-compatibility with callers that only need the flattened text
-// representation; userMessageBlocks is the structured form used by the
-// outbound writer (which also preserves image blocks).
-func extractUserContent(msg *openai.ChatCompletionUserMessageParam) string {
-	if msg.Content.OfString.Value != "" {
-		return msg.Content.OfString.Value
-	}
-	var parts []string
-	for _, part := range msg.Content.OfArrayOfContentParts {
-		if part.OfText != nil {
-			parts = append(parts, part.OfText.Text)
-		}
-	}
-	return strings.Join(parts, " ")
-}
-
-// userMessageBlocks converts an OpenAI user message into a slice of Anthropic
-// content blocks, preserving image_url parts as Anthropic image blocks. This
-// fixes the long-standing drop where image content (OpenAI-shape OfImageURL)
-// was flattened to an empty string by extractUserContent, causing the model to
-// report "I don't see any image attached" on the upstream side.
-func userMessageBlocks(msg *openai.ChatCompletionUserMessageParam) []anthropic.ContentBlockParamUnion {
-	if msg.Content.OfString.Value != "" {
-		return []anthropic.ContentBlockParamUnion{anthropic.NewTextBlock(msg.Content.OfString.Value)}
-	}
-	var blocks []anthropic.ContentBlockParamUnion
-	var textParts []string
-	flushText := func() {
-		if len(textParts) > 0 {
-			blocks = append(blocks, anthropic.NewTextBlock(strings.Join(textParts, " ")))
-			textParts = nil
-		}
-	}
-	for _, part := range msg.Content.OfArrayOfContentParts {
-		switch {
-		case part.OfText != nil:
-			textParts = append(textParts, part.OfText.Text)
-		case part.OfImageURL != nil:
-			flushText()
-			if block, ok := openAIImageURLToAnthropicBlock(part.OfImageURL.ImageURL.URL); ok {
-				blocks = append(blocks, block)
-			}
-		}
-	}
-	flushText()
-	return blocks
-}
-
-// openAIImageURLToAnthropicBlock parses an OpenAI image_url value into an
-// Anthropic image block. Both data-URI (data:image/<type>;base64,<data>) and
-// plain URL forms are supported; unrecognised shapes are skipped.
-func openAIImageURLToAnthropicBlock(url string) (anthropic.ContentBlockParamUnion, bool) {
-	const dataURIPrefix = "data:"
-	if strings.HasPrefix(url, dataURIPrefix) {
-		mediaType, data, ok := parseDataURI(url)
-		if !ok {
-			return anthropic.ContentBlockParamUnion{}, false
-		}
-		return anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
-			Data:      data,
-			MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
-		}), true
-	}
-	if url == "" {
-		return anthropic.ContentBlockParamUnion{}, false
-	}
-	return anthropic.NewImageBlock(anthropic.URLImageSourceParam{URL: url}), true
-}
-
-// parseDataURI extracts the media type and base64-encoded payload from a data
-// URI of the form `data:<media-type>;base64,<data>`. Returns ok=false for any
-// other shape.
-func parseDataURI(uri string) (mediaType, data string, ok bool) {
-	const prefix = "data:"
-	if !strings.HasPrefix(uri, prefix) {
-		return "", "", false
-	}
-	rest := uri[len(prefix):]
-	comma := strings.IndexByte(rest, ',')
-	if comma < 0 {
-		return "", "", false
-	}
-	header := rest[:comma]
-	payload := rest[comma+1:]
-	if !strings.Contains(header, ";base64") {
-		return "", "", false
-	}
-	mediaType = strings.TrimSuffix(header, ";base64")
-	if mediaType == "" {
-		return "", "", false
-	}
-	return mediaType, payload, true
-}
-
-// applyUserMessageImageBlocks appends image blocks captured in the passthrough
-// to the matching user message. Indexing is user-message-only (index 0 = first
-// user message in messages[]). When the index is out of range, images are
-// silently dropped to match the surrounding lossy-translation discipline.
-func applyUserMessageImageBlocks(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
-	if pt == nil || len(pt.UserMessageImageBlocks) == 0 {
+// captureAnthropicStopReasonIntoExt records Anthropic-only stop reasons
+// ("pause_turn", "refusal", "stop_sequence") on the IRExtensions side
+// channel so the symmetric outbound emitter can override the
+// OpenAI-derived finish_reason mapping. The OpenAI finish_reason
+// alphabet collapses all three to "stop", losing the distinction; the
+// emitter restores it from this side channel. StopSequence is recorded
+// only when the upstream stop reason was "stop_sequence" (the only case
+// it is meaningful). Nil-safe.
+func captureAnthropicStopReasonIntoExt(
+	stopReason anthropic.StopReason,
+	stopSequence string,
+	ext *ir.IRExtensions,
+) {
+	if ext == nil {
 		return
 	}
-	userIdx := -1
-	for i := range messages {
-		if messages[i].Role != anthropic.MessageParamRoleUser {
-			continue
-		}
-		userIdx++
-		images, ok := pt.UserMessageImageBlocks[userIdx]
-		if !ok {
-			continue
-		}
-		for _, img := range images {
-			block, ok := buildImageBlockFromSource(img.Source)
-			if !ok {
-				continue
-			}
-			messages[i].Content = append(messages[i].Content, block)
-		}
+	switch stopReason {
+	case anthropic.StopReasonPauseTurn, anthropic.StopReasonRefusal, anthropic.StopReasonStopSequence:
+		ext.AnthropicStopReason = string(stopReason)
+	}
+	if stopReason == anthropic.StopReasonStopSequence && stopSequence != "" {
+		ext.AnthropicStopSequence = stopSequence
 	}
 }
 
-// applyToolResultPassthrough overwrites tool_result blocks with the passthrough
-// payload: is_error: true is restored from pt.ToolResultErrors, and array
-// content (text + image blocks) is restored from pt.ToolResultArrayContent.
-// Matches by tool_use_id; missing keys leave the block as today's
-// translation produced it.
-func applyToolResultPassthrough(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
-	if pt == nil || (len(pt.ToolResultErrors) == 0 && len(pt.ToolResultArrayContent) == 0) {
+// extractThinkingBlocks records signatures from any "thinking" content
+// blocks into IRExtensions so the Anthropic outbound emitter can
+// reconstruct the multi-turn extended-thinking continuity that the
+// OpenAI envelope cannot represent. Nil-safe; legacy callers see no
+// behavior change because the OpenAI envelope itself never carried
+// these blocks.
+func extractThinkingBlocks(blocks []anthropic.ContentBlockUnion, ext *ir.IRExtensions) {
+	if ext == nil {
 		return
 	}
-	for i := range messages {
-		for j := range messages[i].Content {
-			tr := messages[i].Content[j].OfToolResult
-			if tr == nil || tr.ToolUseID == "" {
-				continue
-			}
-			if isErr, ok := pt.ToolResultErrors[tr.ToolUseID]; ok && isErr {
-				tr.IsError = anthropic.Bool(true)
-			}
-			if blocks, ok := pt.ToolResultArrayContent[tr.ToolUseID]; ok && len(blocks) > 0 {
-				tr.Content = toSDKToolResultContent(blocks)
-			}
-		}
-	}
-}
-
-func toSDKToolResultContent(blocks []ToolResultContentBlock) []anthropic.ToolResultBlockParamContentUnion {
-	out := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(blocks))
-	for _, b := range blocks {
-		switch b.Type {
-		case "text":
-			out = append(out, anthropic.ToolResultBlockParamContentUnion{
-				OfText: &anthropic.TextBlockParam{Text: b.Text},
-			})
-		case "image":
-			if b.Source == nil {
-				continue
-			}
-			img, ok := buildImageParamFromSource(*b.Source)
-			if !ok {
-				continue
-			}
-			out = append(out, anthropic.ToolResultBlockParamContentUnion{OfImage: img})
-		}
-	}
-	return out
-}
-
-// buildImageParamFromSource is the variant of buildImageBlockFromSource that
-// returns the raw *ImageBlockParam needed by ToolResultBlockParamContentUnion
-// (which embeds ImageBlockParam directly rather than via NewImageBlock).
-func buildImageParamFromSource(src ImageSource) (*anthropic.ImageBlockParam, bool) {
-	switch src.Type {
-	case "base64":
-		if src.Data == "" || src.MediaType == "" {
-			return nil, false
-		}
-		return &anthropic.ImageBlockParam{
-			Source: anthropic.ImageBlockParamSourceUnion{
-				OfBase64: &anthropic.Base64ImageSourceParam{
-					Data:      src.Data,
-					MediaType: anthropic.Base64ImageSourceMediaType(src.MediaType),
-				},
-			},
-		}, true
-	case "url":
-		if src.URL == "" {
-			return nil, false
-		}
-		return &anthropic.ImageBlockParam{
-			Source: anthropic.ImageBlockParamSourceUnion{
-				OfURL: &anthropic.URLImageSourceParam{URL: src.URL},
-			},
-		}, true
-	}
-	return nil, false
-}
-
-func buildImageBlockFromSource(src ImageSource) (anthropic.ContentBlockParamUnion, bool) {
-	switch src.Type {
-	case "base64":
-		if src.Data == "" || src.MediaType == "" {
-			return anthropic.ContentBlockParamUnion{}, false
-		}
-		return anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
-			Data:      src.Data,
-			MediaType: anthropic.Base64ImageSourceMediaType(src.MediaType),
-		}), true
-	case "url":
-		if src.URL == "" {
-			return anthropic.ContentBlockParamUnion{}, false
-		}
-		return anthropic.NewImageBlock(anthropic.URLImageSourceParam{URL: src.URL}), true
-	}
-	return anthropic.ContentBlockParamUnion{}, false
-}
-
-// extractAssistantContent extracts text from an assistant message
-func extractAssistantContent(msg *openai.ChatCompletionAssistantMessageParam) string {
-	if msg.Content.OfString.Value != "" {
-		return msg.Content.OfString.Value
-	}
-	var parts []string
-	for _, part := range msg.Content.OfArrayOfContentParts {
-		if part.OfText != nil {
-			parts = append(parts, part.OfText.Text)
-		}
-	}
-	return strings.Join(parts, " ")
-}
-
-func buildAnthropicMessages(
-	messages []openai.ChatCompletionMessageParamUnion,
-) (string, []anthropic.MessageParam, error) {
-	var systemPrompt string
-	var anthropicMessages []anthropic.MessageParam
-
-	for _, msg := range messages {
-		switch {
-		case msg.OfSystem != nil:
-			systemPrompt = extractSystemContent(msg.OfSystem)
-		case msg.OfUser != nil:
-			blocks := userMessageBlocks(msg.OfUser)
-			if len(blocks) > 0 {
-				anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(blocks...))
-			}
-		case msg.OfAssistant != nil:
-			blocks, err := assistantContentBlocks(msg.OfAssistant)
-			if err != nil {
-				return "", nil, err
-			}
-			if len(blocks) > 0 {
-				anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(blocks...))
-			}
-		case msg.OfTool != nil:
-			toolUseID := strings.TrimSpace(msg.OfTool.ToolCallID)
-			if toolUseID == "" {
-				return "", nil, fmt.Errorf("tool message missing tool_call_id")
-			}
-			content := extractToolMessageContent(msg.OfTool)
-			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(
-				anthropic.NewToolResultBlock(toolUseID, content, false),
-			))
-		default:
-			logging.Debugf("Skipping unsupported OpenAI message role in Anthropic conversion")
-		}
-	}
-
-	return systemPrompt, anthropicMessages, nil
-}
-
-func extractToolMessageContent(msg *openai.ChatCompletionToolMessageParam) string {
-	if msg.Content.OfString.Value != "" {
-		return msg.Content.OfString.Value
-	}
-	var parts []string
-	for _, part := range msg.Content.OfArrayOfContentParts {
-		if part.Text != "" {
-			parts = append(parts, part.Text)
-		}
-	}
-	return strings.Join(parts, " ")
-}
-
-func assistantContentBlocks(
-	msg *openai.ChatCompletionAssistantMessageParam,
-) ([]anthropic.ContentBlockParamUnion, error) {
-	var blocks []anthropic.ContentBlockParamUnion
-
-	content := extractAssistantContent(msg)
-	if content != "" {
-		blocks = append(blocks, anthropic.NewTextBlock(content))
-	}
-
-	for _, toolCall := range msg.ToolCalls {
-		toolUseID := strings.TrimSpace(toolCall.ID)
-		if toolUseID == "" {
-			return nil, fmt.Errorf("assistant tool_call missing id")
-		}
-		name := strings.TrimSpace(toolCall.Function.Name)
-		if name == "" {
-			return nil, fmt.Errorf("assistant tool_call %s missing function name", toolUseID)
-		}
-		input, err := parseToolCallArguments(toolCall.Function.Arguments)
-		if err != nil {
-			return nil, fmt.Errorf("assistant tool_call %s: %w", toolUseID, err)
-		}
-		blocks = append(blocks, anthropic.NewToolUseBlock(toolUseID, input, name))
-	}
-
-	return blocks, nil
-}
-
-func parseToolCallArguments(arguments string) (any, error) {
-	trimmed := strings.TrimSpace(arguments)
-	if trimmed == "" {
-		return map[string]any{}, nil
-	}
-	var parsed any
-	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
-		return nil, fmt.Errorf("invalid tool arguments JSON: %w", err)
-	}
-	return parsed, nil
-}
-
-func applyOpenAIToolsToAnthropicParams(
-	params *anthropic.MessageNewParams,
-	openAIRequest *openai.ChatCompletionNewParams,
-) error {
-	if openAIRequest == nil {
-		return nil
-	}
-
-	if len(openAIRequest.Tools) > 0 {
-		tools, err := openAIToolsToAnthropic(openAIRequest.Tools)
-		if err != nil {
-			return err
-		}
-		params.Tools = tools
-	}
-
-	toolChoice, hasChoice := openAIToolChoiceToAnthropic(openAIRequest.ToolChoice)
-	if hasChoice {
-		params.ToolChoice = toolChoice
-	}
-	return nil
-}
-
-func openAIToolsToAnthropic(tools []openai.ChatCompletionToolParam) ([]anthropic.ToolUnionParam, error) {
-	result := make([]anthropic.ToolUnionParam, 0, len(tools))
-	for index, tool := range tools {
-		if tool.Type != "" && tool.Type != "function" {
-			logging.Debugf("Skipping non-function OpenAI tool type %q at index %d", tool.Type, index)
+	thinkingIndex := 0
+	for _, block := range blocks {
+		if block.Type != "thinking" {
 			continue
 		}
-		name := strings.TrimSpace(tool.Function.Name)
-		if name == "" {
-			return nil, fmt.Errorf("tools[%d]: function name is required", index)
+		blockID := fmt.Sprintf("content[%d]", thinkingIndex)
+		thinkingIndex++
+		if block.Signature != "" {
+			ext.SetThinkingSignature(blockID, block.Signature)
 		}
-
-		inputSchema, err := functionParametersToAnthropicSchema(tool.Function.Parameters)
-		if err != nil {
-			return nil, fmt.Errorf("tools[%d] (%s): %w", index, name, err)
-		}
-
-		toolParam := anthropic.ToolParam{
-			Name:        name,
-			InputSchema: inputSchema,
-			Type:        anthropic.ToolTypeCustom,
-		}
-		if desc := strings.TrimSpace(tool.Function.Description.Value); desc != "" {
-			toolParam.Description = anthropic.String(desc)
-		}
-		result = append(result, anthropic.ToolUnionParam{OfTool: &toolParam})
 	}
-	return result, nil
 }
 
-func functionParametersToAnthropicSchema(
-	parameters openai.FunctionParameters,
-) (anthropic.ToolInputSchemaParam, error) {
-	schema := anthropic.ToolInputSchemaParam{
-		Type: "object",
+// extractAnthropicUsageIntoExt copies the Anthropic-native usage
+// counters (cache_*, server_tool_use) onto IRExtensions so the
+// symmetric outbound emitter can replay them on the response body.
+// OpenAI's CompletionUsage envelope has no slot for cache or
+// server-tool counts, so without this side channel those values are
+// dropped on the floor. Nil-safe.
+func extractAnthropicUsageIntoExt(u anthropic.Usage, ext *ir.IRExtensions) {
+	if ext == nil {
+		return
 	}
-	if parameters == nil {
-		return schema, nil
+	ext.CacheReadInputTokens = u.CacheReadInputTokens
+	ext.CacheCreationInputTokens = u.CacheCreationInputTokens
+	ext.Ephemeral5mInputTokens = u.CacheCreation.Ephemeral5mInputTokens
+	ext.Ephemeral1hInputTokens = u.CacheCreation.Ephemeral1hInputTokens
+	if u.ServerToolUse.WebSearchRequests > 0 {
+		ext.SetServerToolUseCount("web_search", u.ServerToolUse.WebSearchRequests)
 	}
-
-	raw, err := json.Marshal(parameters)
-	if err != nil {
-		return schema, fmt.Errorf("marshal function parameters: %w", err)
-	}
-	if err := json.Unmarshal(raw, &schema); err != nil {
-		return schema, fmt.Errorf("parse function parameters: %w", err)
-	}
-	if schema.Type == "" {
-		schema.Type = "object"
-	}
-	return schema, nil
-}
-
-func openAIToolChoiceToAnthropic(
-	choice openai.ChatCompletionToolChoiceOptionUnionParam,
-) (anthropic.ToolChoiceUnionParam, bool) {
-	if !param.IsOmitted(choice.OfAuto) {
-		value := strings.TrimSpace(choice.OfAuto.Value)
-		switch value {
-		case "", "auto":
-			return anthropic.ToolChoiceUnionParam{
-				OfAuto: &anthropic.ToolChoiceAutoParam{},
-			}, true
-		case "none":
-			none := anthropic.NewToolChoiceNoneParam()
-			return anthropic.ToolChoiceUnionParam{OfNone: &none}, true
-		case "required", "any":
-			return anthropic.ToolChoiceUnionParam{
-				OfAny: &anthropic.ToolChoiceAnyParam{},
-			}, true
-		default:
-			logging.Debugf("Unknown OpenAI tool_choice auto value %q, defaulting to auto", value)
-			return anthropic.ToolChoiceUnionParam{
-				OfAuto: &anthropic.ToolChoiceAutoParam{},
-			}, true
-		}
-	}
-
-	if choice.OfChatCompletionNamedToolChoice != nil {
-		name := strings.TrimSpace(choice.OfChatCompletionNamedToolChoice.Function.Name)
-		if name == "" {
-			return anthropic.ToolChoiceUnionParam{}, false
-		}
-		return anthropic.ToolChoiceParamOfTool(name), true
-	}
-
-	return anthropic.ToolChoiceUnionParam{}, false
 }
 
 func openAIToolCallsFromAnthropicContent(

--- a/src/semantic-router/pkg/anthropic/client_test.go
+++ b/src/semantic-router/pkg/anthropic/client_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
 func TestToAnthropicRequestBody_BasicConversion(t *testing.T) {
@@ -409,6 +411,170 @@ func TestExtractUserContent_StringContent(t *testing.T) {
 	result := extractUserContent(msg)
 
 	assert.Equal(t, "Hello there!", result)
+}
+
+func TestOpenAIFinishReasonFromAnthropic(t *testing.T) {
+	cases := []struct {
+		name          string
+		stopReason    anthropic.StopReason
+		toolCallCount int
+		want          string
+	}{
+		{name: "end_turn maps to stop", stopReason: anthropic.StopReasonEndTurn, want: "stop"},
+		{name: "max_tokens maps to length", stopReason: anthropic.StopReasonMaxTokens, want: "length"},
+		{name: "tool_use maps to tool_calls", stopReason: anthropic.StopReasonToolUse, want: "tool_calls"},
+		{name: "stop with tool calls upgrades to tool_calls", stopReason: anthropic.StopReasonEndTurn, toolCallCount: 1, want: "tool_calls"},
+		{name: "pause_turn collapses to stop", stopReason: anthropic.StopReasonPauseTurn, want: "stop"},
+		{name: "refusal collapses to stop", stopReason: anthropic.StopReasonRefusal, want: "stop"},
+		{name: "stop_sequence collapses to stop", stopReason: anthropic.StopReasonStopSequence, want: "stop"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := openAIFinishReasonFromAnthropic(tc.stopReason, tc.toolCallCount)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCaptureAnthropicStopReasonIntoExt_PauseTurn(t *testing.T) {
+	ext := &ir.IRExtensions{}
+	captureAnthropicStopReasonIntoExt(anthropic.StopReasonPauseTurn, "", ext)
+	assert.Equal(t, "pause_turn", ext.AnthropicStopReason)
+	assert.Empty(t, ext.AnthropicStopSequence)
+}
+
+func TestCaptureAnthropicStopReasonIntoExt_Refusal(t *testing.T) {
+	ext := &ir.IRExtensions{}
+	captureAnthropicStopReasonIntoExt(anthropic.StopReasonRefusal, "", ext)
+	assert.Equal(t, "refusal", ext.AnthropicStopReason)
+}
+
+func TestCaptureAnthropicStopReasonIntoExt_StopSequence(t *testing.T) {
+	ext := &ir.IRExtensions{}
+	captureAnthropicStopReasonIntoExt(anthropic.StopReasonStopSequence, "###END###", ext)
+	assert.Equal(t, "stop_sequence", ext.AnthropicStopReason,
+		"stop_sequence must be captured so the outbound emitter can restore it; "+
+			"OpenAI finish_reason collapses it to \"stop\"")
+	assert.Equal(t, "###END###", ext.AnthropicStopSequence)
+}
+
+func TestCaptureAnthropicStopReasonIntoExt_StopSequenceWithoutSequenceString(t *testing.T) {
+	// Defensive: even if the upstream omits the matched sequence string,
+	// the stop_reason itself must still round-trip so the emitter
+	// reports stop_sequence rather than end_turn.
+	ext := &ir.IRExtensions{}
+	captureAnthropicStopReasonIntoExt(anthropic.StopReasonStopSequence, "", ext)
+	assert.Equal(t, "stop_sequence", ext.AnthropicStopReason)
+	assert.Empty(t, ext.AnthropicStopSequence)
+}
+
+func TestCaptureAnthropicStopReasonIntoExt_EndTurnLeavesExtClean(t *testing.T) {
+	ext := &ir.IRExtensions{}
+	captureAnthropicStopReasonIntoExt(anthropic.StopReasonEndTurn, "", ext)
+	assert.Empty(t, ext.AnthropicStopReason)
+	assert.Empty(t, ext.AnthropicStopSequence)
+}
+
+func TestCaptureAnthropicStopReasonIntoExt_NilSafe(t *testing.T) {
+	captureAnthropicStopReasonIntoExt(anthropic.StopReasonRefusal, "", nil)
+}
+
+func TestExtractThinkingBlocks_PopulatesSignatures(t *testing.T) {
+	blocks := []anthropic.ContentBlockUnion{
+		{Type: "thinking", Thinking: "let me reason...", Signature: "sig-1"},
+		{Type: "text", Text: "the answer is 42"},
+		{Type: "thinking", Thinking: "and another...", Signature: "sig-2"},
+	}
+	ext := &ir.IRExtensions{}
+	extractThinkingBlocks(blocks, ext)
+
+	assert.Equal(t, "sig-1", ext.ThinkingSignatures["content[0]"])
+	assert.Equal(t, "sig-2", ext.ThinkingSignatures["content[1]"])
+}
+
+func TestExtractThinkingBlocks_SkipsEmptySignatures(t *testing.T) {
+	blocks := []anthropic.ContentBlockUnion{
+		{Type: "thinking", Thinking: "no signature here"},
+	}
+	ext := &ir.IRExtensions{}
+	extractThinkingBlocks(blocks, ext)
+	assert.Empty(t, ext.ThinkingSignatures)
+}
+
+func TestExtractThinkingBlocks_NilSafe(t *testing.T) {
+	blocks := []anthropic.ContentBlockUnion{{Type: "thinking", Signature: "sig"}}
+	extractThinkingBlocks(blocks, nil)
+}
+
+func TestExtractAnthropicUsageIntoExt_PopulatesAllFields(t *testing.T) {
+	u := anthropic.Usage{
+		InputTokens:              100,
+		OutputTokens:             50,
+		CacheReadInputTokens:     120,
+		CacheCreationInputTokens: 80,
+		CacheCreation: anthropic.CacheCreation{
+			Ephemeral5mInputTokens: 30,
+			Ephemeral1hInputTokens: 50,
+		},
+		ServerToolUse: anthropic.ServerToolUsage{
+			WebSearchRequests: 2,
+		},
+	}
+	ext := &ir.IRExtensions{}
+	extractAnthropicUsageIntoExt(u, ext)
+
+	assert.Equal(t, int64(120), ext.CacheReadInputTokens)
+	assert.Equal(t, int64(80), ext.CacheCreationInputTokens)
+	assert.Equal(t, int64(30), ext.Ephemeral5mInputTokens)
+	assert.Equal(t, int64(50), ext.Ephemeral1hInputTokens)
+	assert.Equal(t, int64(2), ext.ServerToolUseCounts["web_search"])
+}
+
+func TestExtractAnthropicUsageIntoExt_OmitsServerToolWhenZero(t *testing.T) {
+	u := anthropic.Usage{
+		InputTokens:  10,
+		OutputTokens: 5,
+	}
+	ext := &ir.IRExtensions{}
+	extractAnthropicUsageIntoExt(u, ext)
+	assert.Empty(t, ext.ServerToolUseCounts, "no server tool keys for zero counts")
+}
+
+func TestExtractAnthropicUsageIntoExt_NilSafe(t *testing.T) {
+	extractAnthropicUsageIntoExt(anthropic.Usage{InputTokens: 1}, nil)
+}
+
+// ToOpenAIResponseBody must remain byte-identical for the legacy
+// OpenAI-client / Anthropic-backend cell after the refactor. The new
+// helpers accept an ext but the legacy entrypoint passes nil.
+func TestToOpenAIResponseBody_NoSideEffectsOnNilExt(t *testing.T) {
+	anthropicResp := &anthropic.Message{
+		ID: "msg_refactor",
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "thinking", Thinking: "reasoning...", Signature: "sig-xyz"},
+			{Type: "text", Text: "answer"},
+		},
+		StopReason: anthropic.StopReasonRefusal,
+		Usage: anthropic.Usage{
+			InputTokens:              10,
+			OutputTokens:             5,
+			CacheReadInputTokens:     7,
+			CacheCreationInputTokens: 3,
+		},
+	}
+	body, err := json.Marshal(anthropicResp)
+	require.NoError(t, err)
+
+	out, err := ToOpenAIResponseBody(body, "claude-sonnet-4-5")
+	require.NoError(t, err)
+
+	var oa openai.ChatCompletion
+	require.NoError(t, json.Unmarshal(out, &oa))
+	assert.Equal(t, "msg_refactor", oa.ID)
+	// Refusal collapses to "stop" in the OpenAI envelope; no side
+	// channel exists for the legacy entrypoint to expose it.
+	assert.Equal(t, "stop", oa.Choices[0].FinishReason)
+	assert.Equal(t, "answer", oa.Choices[0].Message.Content)
 }
 
 func TestExtractAssistantContent_StringContent(t *testing.T) {

--- a/src/semantic-router/pkg/anthropic/client_test.go
+++ b/src/semantic-router/pkg/anthropic/client_test.go
@@ -577,6 +577,75 @@ func TestToOpenAIResponseBody_NoSideEffectsOnNilExt(t *testing.T) {
 	assert.Equal(t, "answer", oa.Choices[0].Message.Content)
 }
 
+func TestToOpenAIResponseBodyWithExt_PopulatesIRExtensions(t *testing.T) {
+	anthropicResp := &anthropic.Message{
+		ID: "msg_ext",
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "thinking", Thinking: "reasoning", Signature: "sig-1"},
+			{Type: "text", Text: "answer"},
+		},
+		StopReason: anthropic.StopReasonPauseTurn,
+		Usage: anthropic.Usage{
+			InputTokens:              100,
+			OutputTokens:             50,
+			CacheReadInputTokens:     200,
+			CacheCreationInputTokens: 75,
+			CacheCreation: anthropic.CacheCreation{
+				Ephemeral5mInputTokens: 25,
+				Ephemeral1hInputTokens: 50,
+			},
+			ServerToolUse: anthropic.ServerToolUsage{WebSearchRequests: 4},
+		},
+	}
+	body, err := json.Marshal(anthropicResp)
+	require.NoError(t, err)
+
+	ext := &ir.IRExtensions{SourceProtocol: SourceProtocolAnthropic}
+	out, err := ToOpenAIResponseBodyWithExt(body, "claude-opus-4-7", ext)
+	require.NoError(t, err)
+
+	// Returned envelope is OpenAI-shape (parser does not change with ext).
+	var oa openai.ChatCompletion
+	require.NoError(t, json.Unmarshal(out, &oa))
+	assert.Equal(t, "msg_ext", oa.ID)
+
+	// Ext is populated with the values the OpenAI envelope cannot carry.
+	assert.Equal(t, "pause_turn", ext.AnthropicStopReason)
+	assert.Equal(t, int64(200), ext.CacheReadInputTokens)
+	assert.Equal(t, int64(75), ext.CacheCreationInputTokens)
+	assert.Equal(t, int64(25), ext.Ephemeral5mInputTokens)
+	assert.Equal(t, int64(50), ext.Ephemeral1hInputTokens)
+	assert.Equal(t, int64(4), ext.ServerToolUseCounts["web_search"])
+	assert.Equal(t, "sig-1", ext.ThinkingSignatures["content[0]"])
+}
+
+func TestToOpenAIResponseBodyWithExt_NilExtMatchesLegacyEntrypoint(t *testing.T) {
+	anthropicResp := &anthropic.Message{
+		ID: "msg_nil_ext",
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: "x"},
+		},
+		StopReason: anthropic.StopReasonEndTurn,
+		Usage:      anthropic.Usage{InputTokens: 1, OutputTokens: 1},
+	}
+	body, err := json.Marshal(anthropicResp)
+	require.NoError(t, err)
+
+	legacyOut, err := ToOpenAIResponseBody(body, "m")
+	require.NoError(t, err)
+
+	withExtOut, err := ToOpenAIResponseBodyWithExt(body, "m", nil)
+	require.NoError(t, err)
+
+	// Identical apart from the "created" Unix timestamp.
+	var legacy, withExt openai.ChatCompletion
+	require.NoError(t, json.Unmarshal(legacyOut, &legacy))
+	require.NoError(t, json.Unmarshal(withExtOut, &withExt))
+	legacy.Created = 0
+	withExt.Created = 0
+	assert.Equal(t, legacy, withExt)
+}
+
 func TestExtractAssistantContent_StringContent(t *testing.T) {
 	msg := &openai.ChatCompletionAssistantMessageParam{
 		Content: openai.ChatCompletionAssistantMessageParamContentUnion{

--- a/src/semantic-router/pkg/anthropic/outbound.go
+++ b/src/semantic-router/pkg/anthropic/outbound.go
@@ -1,0 +1,386 @@
+// Anthropic outbound emitter: non-streaming response shape.
+//
+// EmitAnthropicResponse is the symmetric counterpart to
+// ToOpenAIResponseBody (in client.go). It rewrites the OpenAI
+// ChatCompletion envelope that vsr's pipeline normalizes to back into
+// a wire-shaped anthropic.Message JSON body so that an Anthropic-SDK
+// client (anthropic-sdk-go, anthropic-python, Claude Code SDK) can
+// unmarshal it without translation.
+//
+// # cache_control vs cache usage
+//
+// The Anthropic spec defines cache_control as a request-side field
+// only: it tells the backend which prompt segments to cache. The
+// response carries usage counters (cache_creation_input_tokens,
+// cache_read_input_tokens, cache_creation.ephemeral_5m_input_tokens,
+// cache_creation.ephemeral_1h_input_tokens) that report what the
+// cache actually did — not cache_control markers. This emitter
+// therefore never re-attaches cache_control markers to response
+// content blocks. The request-side markers captured in
+// IRExtensions.CacheControl are preserved for plugin replay (e.g.
+// router replay re-rendering the request) but have no echo on the
+// response. The cache *usage* counters round-trip through
+// IRExtensions.CacheRead/CreationInputTokens etc., populated by the
+// inverse helpers in client.go when the upstream was Anthropic.
+//
+// # Thinking blocks
+//
+// PR #1718 upstream is in flight to add reasoning_content extraction
+// from the OpenAI envelope so that on the Anthropic→Anthropic cell the
+// emitter can surface the actual model-produced thinking text. Until
+// that lands, the emitter uses a placeholder when
+// IRExtensions.ThinkingSignatures contains entries but the OpenAI body
+// has no reconstructable text. The structural shape (thinking blocks
+// precede text/tool_use blocks; each carries its opaque signature) is
+// correct; only the user-visible text is empty.
+// TODO(upstream-1718): replace the placeholder with reasoning_content
+// extraction once https://github.com/vllm-project/semantic-router/pull/1718
+// lands.
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+// thinkingTextPlaceholder is emitted when IRExtensions carries a
+// thinking signature but no reasoning_content has been surfaced into
+// the OpenAI envelope by an upstream extractor (PR #1718 territory).
+// Empty string is invalid per the Anthropic spec (the field is
+// required), so a short placeholder keeps the response structurally
+// valid while signalling to the client that the structured thinking
+// text was not preserved through the OpenAI normalization step.
+const thinkingTextPlaceholder = "[thinking content not preserved through OpenAI normalization]"
+
+// anthropicErrorTypeAPI is the catch-all error_type token used when no
+// more specific Anthropic-defined type fits. See
+// https://platform.claude.com/docs/en/api/messages#errors.
+const anthropicErrorTypeAPI = "api_error"
+
+// anthropicMessageResponse mirrors the wire shape of anthropic.Message
+// for marshalling. Using a dedicated struct keeps the emitter's wire
+// output independent of the SDK type's required-field strictness (the
+// SDK type has required fields that fail to marshal cleanly when zero
+// values would be valid on the wire, e.g. ServerToolUse.ServiceTier).
+type anthropicMessageResponse struct {
+	ID           string                  `json:"id"`
+	Type         string                  `json:"type"`
+	Role         string                  `json:"role"`
+	Model        string                  `json:"model"`
+	Content      []anthropicContentBlock `json:"content"`
+	StopReason   anthropic.StopReason    `json:"stop_reason"`
+	StopSequence *string                 `json:"stop_sequence"`
+	Usage        anthropicUsageResponse  `json:"usage"`
+}
+
+// anthropicContentBlock is a single union shape covering all
+// emitter-supported content-block types. Only the fields relevant to
+// the block's Type are populated; the rest are omitted via
+// omitempty/omitzero so the wire output matches the Anthropic spec.
+type anthropicContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	Thinking  string          `json:"thinking,omitempty"`
+	Signature string          `json:"signature,omitempty"`
+}
+
+// anthropicUsageResponse mirrors the wire shape of anthropic.Usage
+// with the cache_creation and server_tool_use sub-objects elided when
+// they are entirely zero. Per the Anthropic spec these objects are
+// optional on the wire; including them when empty inflates response
+// size and confuses clients that test object presence.
+type anthropicUsageResponse struct {
+	InputTokens              int64                          `json:"input_tokens"`
+	OutputTokens             int64                          `json:"output_tokens"`
+	CacheCreationInputTokens int64                          `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64                          `json:"cache_read_input_tokens"`
+	CacheCreation            *anthropicCacheCreationUsage   `json:"cache_creation,omitempty"`
+	ServerToolUse            *anthropicServerToolUsageBlock `json:"server_tool_use,omitempty"`
+}
+
+type anthropicCacheCreationUsage struct {
+	Ephemeral5mInputTokens int64 `json:"ephemeral_5m_input_tokens"`
+	Ephemeral1hInputTokens int64 `json:"ephemeral_1h_input_tokens"`
+}
+
+type anthropicServerToolUsageBlock struct {
+	WebSearchRequests int64 `json:"web_search_requests"`
+}
+
+// anthropicErrorEnvelope is the wire shape Anthropic uses for all
+// error responses on POST /v1/messages.
+type anthropicErrorEnvelope struct {
+	Type  string               `json:"type"`
+	Error anthropicErrorDetail `json:"error"`
+}
+
+type anthropicErrorDetail struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// EmitAnthropicResponse rewrites an OpenAI ChatCompletion response
+// body into the Anthropic Message wire shape so an Anthropic-SDK
+// client can consume it directly.
+//
+// Contract:
+//   - Returns (nil, err) only when responseBody is not valid OpenAI
+//     ChatCompletion JSON.
+//   - Tolerates a nil ext (zero usage; no warnings appended) so that
+//     defensive callers do not need to guard.
+//   - Always emits a non-null content array (possibly empty when the
+//     model produced no text and no tool calls).
+//   - When IRExtensions.ThinkingSignatures contains entries, the
+//     corresponding thinking blocks precede text/tool_use blocks per
+//     the Anthropic spec.
+//   - When IRExtensions.AnthropicStopReason is non-empty (Anthropic-only
+//     stop reasons "pause_turn" or "refusal"), it overrides the
+//     OpenAI-derived mapping.
+func EmitAnthropicResponse(responseBody []byte, ext *ir.IRExtensions, model string) ([]byte, error) {
+	var oa openai.ChatCompletion
+	if err := json.Unmarshal(responseBody, &oa); err != nil {
+		return nil, fmt.Errorf("anthropic outbound: parse OpenAI response: %w", err)
+	}
+
+	choice := openai.ChatCompletionChoice{}
+	if len(oa.Choices) > 0 {
+		choice = oa.Choices[0]
+	}
+
+	stopReason, stopSequence := mapOpenAIFinishReasonToAnthropic(choice.FinishReason, ext)
+	content := buildAnthropicContent(choice, ext)
+	usage := buildAnthropicUsage(oa.Usage, ext)
+
+	resp := anthropicMessageResponse{
+		ID:           oa.ID,
+		Type:         "message",
+		Role:         "assistant",
+		Model:        model,
+		Content:      content,
+		StopReason:   stopReason,
+		StopSequence: stopSequence,
+		Usage:        usage,
+	}
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic outbound: marshal response: %w", err)
+	}
+	return out, nil
+}
+
+// EmitAnthropicError builds an Anthropic error-envelope body. Pure
+// helper — marshalling cannot fail for this fixed shape, so no error
+// return.
+//
+// errorType should be one of the Anthropic-defined tokens
+// ("invalid_request_error", "authentication_error", "permission_error",
+// "not_found_error", "request_too_large", "rate_limit_error",
+// "api_error", "timeout_error", "overloaded_error"). An empty or
+// unknown errorType is coerced to "api_error" to keep the response
+// structurally valid.
+func EmitAnthropicError(errorType, message string) []byte {
+	if errorType == "" {
+		errorType = anthropicErrorTypeAPI
+	}
+	envelope := anthropicErrorEnvelope{
+		Type: "error",
+		Error: anthropicErrorDetail{
+			Type:    errorType,
+			Message: message,
+		},
+	}
+	// Marshal cannot fail for this fixed struct shape.
+	out, _ := json.Marshal(envelope)
+	return out
+}
+
+// buildAnthropicContent walks the OpenAI choice's Message.Content,
+// Message.Refusal, Message.ToolCalls and any thinking signatures from
+// ext to produce the Anthropic content[] array in document order:
+// thinking blocks first (spec requirement), then text, then tool_use
+// blocks. Refusal text is surfaced as a text block; the refusal
+// stop_reason is set in mapOpenAIFinishReasonToAnthropic.
+func buildAnthropicContent(choice openai.ChatCompletionChoice, ext *ir.IRExtensions) []anthropicContentBlock {
+	blocks := make([]anthropicContentBlock, 0)
+
+	// Thinking blocks precede text per Anthropic spec.
+	if ext != nil {
+		for _, blockID := range orderedThinkingBlockIDs(ext) {
+			signature := ext.ThinkingSignatures[blockID]
+			blocks = append(blocks, anthropicContentBlock{
+				Type:      "thinking",
+				Thinking:  thinkingTextPlaceholder,
+				Signature: signature,
+			})
+		}
+	}
+
+	// Text block from either Message.Content or Message.Refusal.
+	// Refusal takes precedence: if both are populated the model
+	// produced a structured refusal and the content field is just an
+	// echo (vsr-internal jailbreak/hallucination synthesis surfaces
+	// the refusal text in Message.Refusal, not Message.Content).
+	textPayload := choice.Message.Content
+	if choice.Message.Refusal != "" {
+		textPayload = choice.Message.Refusal
+	}
+	if textPayload != "" {
+		blocks = append(blocks, anthropicContentBlock{
+			Type: "text",
+			Text: textPayload,
+		})
+	}
+
+	// Tool calls.
+	for _, tc := range choice.Message.ToolCalls {
+		input := json.RawMessage(tc.Function.Arguments)
+		if len(input) == 0 {
+			input = json.RawMessage("{}")
+		}
+		blocks = append(blocks, anthropicContentBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+
+	return blocks
+}
+
+// orderedThinkingBlockIDs returns thinking block IDs from ext in a
+// deterministic order (sorted lexicographically). Map iteration is
+// non-deterministic in Go; stability matters because the wire output
+// must be reproducible for round-trip tests and so clients keying on
+// block index see a consistent layout.
+func orderedThinkingBlockIDs(ext *ir.IRExtensions) []string {
+	if ext == nil || len(ext.ThinkingSignatures) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(ext.ThinkingSignatures))
+	for id := range ext.ThinkingSignatures {
+		ids = append(ids, id)
+	}
+	// Lexicographic sort matches the "content[0]", "content[1]"
+	// emission order used by the inverse extractor in client.go.
+	sortStrings(ids)
+	return ids
+}
+
+// sortStrings is a small wrapper to keep the stdlib sort import out
+// of the public surface and make the call site self-documenting.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// buildAnthropicUsage maps OpenAI completion usage onto the Anthropic
+// usage envelope, layering in the cache and server-tool counters from
+// ext when they were captured by the inverse helpers. When the
+// upstream was an OpenAI backend (no cache, no server tools), ext's
+// counters are all zero and the cache_creation / server_tool_use
+// sub-objects are omitted from the wire output. A
+// ReasonCacheUnavailableOnOpenAIBackend info warning is appended in
+// that case so observability captures the structural difference.
+func buildAnthropicUsage(usage openai.CompletionUsage, ext *ir.IRExtensions) anthropicUsageResponse {
+	out := anthropicUsageResponse{
+		InputTokens:  usage.PromptTokens,
+		OutputTokens: usage.CompletionTokens,
+	}
+	if ext == nil {
+		return out
+	}
+
+	out.CacheReadInputTokens = ext.CacheReadInputTokens
+	out.CacheCreationInputTokens = ext.CacheCreationInputTokens
+	if ext.Ephemeral5mInputTokens > 0 || ext.Ephemeral1hInputTokens > 0 {
+		out.CacheCreation = &anthropicCacheCreationUsage{
+			Ephemeral5mInputTokens: ext.Ephemeral5mInputTokens,
+			Ephemeral1hInputTokens: ext.Ephemeral1hInputTokens,
+		}
+	}
+	if count, ok := ext.ServerToolUseCounts["web_search"]; ok && count > 0 {
+		out.ServerToolUse = &anthropicServerToolUsageBlock{
+			WebSearchRequests: count,
+		}
+	}
+
+	if ext.SourceProtocol == SourceProtocolAnthropic &&
+		ext.CacheReadInputTokens == 0 &&
+		ext.CacheCreationInputTokens == 0 &&
+		ext.Ephemeral5mInputTokens == 0 &&
+		ext.Ephemeral1hInputTokens == 0 {
+		ext.AppendWarning(ir.Warning{
+			Field:    "usage.cache",
+			Reason:   ir.ReasonCacheUnavailableOnOpenAIBackend,
+			Severity: ir.WarningSeverityInfo,
+			Detail:   "Anthropic client received cache-free response (typically OpenAI backend)",
+		})
+	}
+
+	return out
+}
+
+// mapOpenAIFinishReasonToAnthropic maps the OpenAI finish_reason
+// alphabet onto the Anthropic stop_reason vocabulary. When ext carries
+// an Anthropic-only stop reason ("pause_turn", "refusal") captured on
+// the round-trip, that override wins.
+//
+// The returned stop_sequence is non-nil only for stop_reason ==
+// "stop_sequence". OpenAI does not surface which sequence matched, so
+// the value comes from ext.AnthropicStopSequence when available
+// (round-trip from an Anthropic upstream) or is nil otherwise.
+func mapOpenAIFinishReasonToAnthropic(finish string, ext *ir.IRExtensions) (anthropic.StopReason, *string) {
+	if ext != nil && ext.AnthropicStopReason != "" {
+		stopReason := anthropic.StopReason(ext.AnthropicStopReason)
+		if stopReason == anthropic.StopReasonStopSequence && ext.AnthropicStopSequence != "" {
+			seq := ext.AnthropicStopSequence
+			return stopReason, &seq
+		}
+		return stopReason, nil
+	}
+
+	switch finish {
+	case "stop":
+		return anthropic.StopReasonEndTurn, nil
+	case "length":
+		return anthropic.StopReasonMaxTokens, nil
+	case "tool_calls":
+		return anthropic.StopReasonToolUse, nil
+	case "content_filter":
+		return anthropic.StopReasonRefusal, nil
+	case "":
+		// Empty finish_reason can appear on synthesized error
+		// responses or streaming-aborted bodies; default to
+		// end_turn but flag for observability so unexpected
+		// upstream behavior is detectable.
+		ext.AppendWarning(ir.Warning{
+			Field:    "finish_reason",
+			Reason:   ir.ReasonAnthropicStopReasonCoerced,
+			Severity: ir.WarningSeverityInfo,
+			Detail:   "empty OpenAI finish_reason coerced to end_turn",
+		})
+		return anthropic.StopReasonEndTurn, nil
+	default:
+		// Unknown finish_reason — coerce to end_turn and warn.
+		ext.AppendWarning(ir.Warning{
+			Field:    "finish_reason",
+			Reason:   ir.ReasonAnthropicStopReasonCoerced,
+			Severity: ir.WarningSeverityInfo,
+			Detail:   fmt.Sprintf("unknown OpenAI finish_reason %q coerced to end_turn", finish),
+		})
+		return anthropic.StopReasonEndTurn, nil
+	}
+}

--- a/src/semantic-router/pkg/anthropic/outbound.go
+++ b/src/semantic-router/pkg/anthropic/outbound.go
@@ -41,6 +41,7 @@ package anthropic
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go"
@@ -272,18 +273,8 @@ func orderedThinkingBlockIDs(ext *ir.IRExtensions) []string {
 	}
 	// Lexicographic sort matches the "content[0]", "content[1]"
 	// emission order used by the inverse extractor in client.go.
-	sortStrings(ids)
+	sort.Strings(ids)
 	return ids
-}
-
-// sortStrings is a small wrapper to keep the stdlib sort import out
-// of the public surface and make the call site self-documenting.
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j-1] > s[j]; j-- {
-			s[j-1], s[j] = s[j], s[j-1]
-		}
-	}
 }
 
 // buildAnthropicUsage maps OpenAI completion usage onto the Anthropic
@@ -292,8 +283,9 @@ func sortStrings(s []string) {
 // upstream was an OpenAI backend (no cache, no server tools), ext's
 // counters are all zero and the cache_creation / server_tool_use
 // sub-objects are omitted from the wire output. A
-// ReasonCacheUnavailableOnOpenAIBackend info warning is appended in
-// that case so observability captures the structural difference.
+// ReasonCacheFieldsAbsent info warning is appended when an Anthropic-
+// source response has all-zero cache counters, so observability can
+// distinguish a legitimately uncached response from a translation gap.
 func buildAnthropicUsage(usage openai.CompletionUsage, ext *ir.IRExtensions) anthropicUsageResponse {
 	out := anthropicUsageResponse{
 		InputTokens:  usage.PromptTokens,
@@ -324,9 +316,9 @@ func buildAnthropicUsage(usage openai.CompletionUsage, ext *ir.IRExtensions) ant
 		ext.Ephemeral1hInputTokens == 0 {
 		ext.AppendWarning(ir.Warning{
 			Field:    "usage.cache",
-			Reason:   ir.ReasonCacheUnavailableOnOpenAIBackend,
+			Reason:   ir.ReasonCacheFieldsAbsent,
 			Severity: ir.WarningSeverityInfo,
-			Detail:   "Anthropic client received cache-free response (typically OpenAI backend)",
+			Detail:   "Anthropic client received response with no cache fields populated",
 		})
 	}
 

--- a/src/semantic-router/pkg/anthropic/outbound_test.go
+++ b/src/semantic-router/pkg/anthropic/outbound_test.go
@@ -321,12 +321,12 @@ func TestEmitAnthropicResponse_OpenAIBackendOmitsCacheObjectAndWarns(t *testing.
 	require.NotEmpty(t, ext.Warnings)
 	var sawCacheWarning bool
 	for _, w := range ext.Warnings {
-		if w.Reason == ir.ReasonCacheUnavailableOnOpenAIBackend {
+		if w.Reason == ir.ReasonCacheFieldsAbsent {
 			sawCacheWarning = true
 			assert.Equal(t, ir.WarningSeverityInfo, w.Severity)
 		}
 	}
-	assert.True(t, sawCacheWarning, "expected cache_unavailable warning")
+	assert.True(t, sawCacheWarning, "expected cache_fields_absent warning")
 }
 
 func TestEmitAnthropicResponse_EmptyContentReturnsEmptyArray(t *testing.T) {
@@ -496,14 +496,23 @@ func TestRoundTrip_AnthropicResponse_StopReasonAndUsage(t *testing.T) {
 	assert.Equal(t, original.Usage.CacheCreation.Ephemeral1hInputTokens, restored.Usage.CacheCreation.Ephemeral1hInputTokens)
 }
 
-func TestSortStrings_StableOrder(t *testing.T) {
-	// Internal helper sanity check — content[10] must sort after
-	// content[2] under lexicographic order; that's acceptable because
-	// the inverse extractor uses sequential indices without padding
-	// and signatures in practice never exceed a single-digit count.
-	in := []string{"content[2]", "content[1]", "content[0]"}
-	sortStrings(in)
-	assert.Equal(t, []string{"content[0]", "content[1]", "content[2]"}, in)
+func TestOrderedThinkingBlockIDs_LexicographicOrder(t *testing.T) {
+	// Verify orderedThinkingBlockIDs returns IDs in deterministic
+	// lexicographic order. Multi-digit indices sort by byte value, not
+	// by parsed integer, so "content[10]" precedes "content[1]" because
+	// '0' (0x30) < ']' (0x5D) at the first differing byte. The SSE
+	// emitter consumes this for replay ordering and requires only
+	// determinism, not numeric ordering.
+	ext := &ir.IRExtensions{
+		ThinkingSignatures: map[string]string{
+			"content[2]":  "sig2",
+			"content[10]": "sig10",
+			"content[1]":  "sig1",
+			"content[0]":  "sig0",
+		},
+	}
+	got := orderedThinkingBlockIDs(ext)
+	assert.Equal(t, []string{"content[0]", "content[10]", "content[1]", "content[2]"}, got)
 }
 
 func TestEmitAnthropicResponse_PreservesIDAndModel(t *testing.T) {

--- a/src/semantic-router/pkg/anthropic/outbound_test.go
+++ b/src/semantic-router/pkg/anthropic/outbound_test.go
@@ -1,0 +1,528 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+// buildOpenAIBody is a test helper that returns a marshalled OpenAI
+// ChatCompletion body fitting the given fields. Keeping the helper
+// inline avoids a testdata fixture explosion for shapes that are tiny.
+func buildOpenAIBody(t *testing.T, choice openai.ChatCompletionChoice, usage openai.CompletionUsage, id string) []byte {
+	t.Helper()
+	cc := &openai.ChatCompletion{
+		ID:      id,
+		Object:  "chat.completion",
+		Model:   "claude-sonnet-4-5",
+		Choices: []openai.ChatCompletionChoice{choice},
+		Usage:   usage,
+	}
+	body, err := json.Marshal(cc)
+	require.NoError(t, err)
+	return body
+}
+
+func parseAnthropicResponse(t *testing.T, body []byte) anthropic.Message {
+	t.Helper()
+	var msg anthropic.Message
+	require.NoError(t, json.Unmarshal(body, &msg), "anthropic-sdk-go must unmarshal emitted body")
+	return msg
+}
+
+func TestEmitAnthropicResponse_PlainText(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message: openai.ChatCompletionMessage{
+				Role:    "assistant",
+				Content: "Hello, world!",
+			},
+		},
+		openai.CompletionUsage{PromptTokens: 5, CompletionTokens: 3},
+		"msg_text_only",
+	)
+
+	out, err := EmitAnthropicResponse(body, nil, "claude-opus-4-7")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+
+	assert.Equal(t, "msg_text_only", msg.ID)
+	assert.Equal(t, "message", string(msg.Type))
+	assert.Equal(t, "assistant", string(msg.Role))
+	assert.Equal(t, "claude-opus-4-7", string(msg.Model))
+	assert.Equal(t, anthropic.StopReasonEndTurn, msg.StopReason)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "text", msg.Content[0].Type)
+	assert.Equal(t, "Hello, world!", msg.Content[0].Text)
+	assert.Equal(t, int64(5), msg.Usage.InputTokens)
+	assert.Equal(t, int64(3), msg.Usage.OutputTokens)
+}
+
+func TestEmitAnthropicResponse_SingleToolCall(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "tool_calls",
+			Message: openai.ChatCompletionMessage{
+				Role: "assistant",
+				ToolCalls: []openai.ChatCompletionMessageToolCall{{
+					ID:   "call_abc",
+					Type: "function",
+					Function: openai.ChatCompletionMessageToolCallFunction{
+						Name:      "get_weather",
+						Arguments: `{"city":"Paris"}`,
+					},
+				}},
+			},
+		},
+		openai.CompletionUsage{PromptTokens: 10, CompletionTokens: 20},
+		"msg_tool_use",
+	)
+
+	out, err := EmitAnthropicResponse(body, nil, "claude-opus-4-7")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+
+	assert.Equal(t, anthropic.StopReasonToolUse, msg.StopReason)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "tool_use", msg.Content[0].Type)
+	assert.Equal(t, "call_abc", msg.Content[0].ID)
+	assert.Equal(t, "get_weather", msg.Content[0].Name)
+	assert.JSONEq(t, `{"city":"Paris"}`, string(msg.Content[0].Input))
+}
+
+func TestEmitAnthropicResponse_TextPlusToolCall(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "tool_calls",
+			Message: openai.ChatCompletionMessage{
+				Role:    "assistant",
+				Content: "Looking up the weather.",
+				ToolCalls: []openai.ChatCompletionMessageToolCall{{
+					ID: "call_1",
+					Function: openai.ChatCompletionMessageToolCallFunction{
+						Name:      "get_weather",
+						Arguments: `{"city":"NYC"}`,
+					},
+				}},
+			},
+		},
+		openai.CompletionUsage{PromptTokens: 15, CompletionTokens: 25},
+		"msg_text_and_tool",
+	)
+
+	out, err := EmitAnthropicResponse(body, nil, "claude-opus-4-7")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+
+	require.Len(t, msg.Content, 2)
+	assert.Equal(t, "text", msg.Content[0].Type, "text precedes tool_use in document order")
+	assert.Equal(t, "tool_use", msg.Content[1].Type)
+}
+
+func TestEmitAnthropicResponse_EmptyToolCallArguments(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "tool_calls",
+			Message: openai.ChatCompletionMessage{
+				ToolCalls: []openai.ChatCompletionMessageToolCall{{
+					ID: "call_x",
+					Function: openai.ChatCompletionMessageToolCallFunction{
+						Name:      "noop",
+						Arguments: "",
+					},
+				}},
+			},
+		},
+		openai.CompletionUsage{},
+		"msg_empty_args",
+	)
+
+	out, err := EmitAnthropicResponse(body, nil, "model")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.JSONEq(t, `{}`, string(msg.Content[0].Input))
+}
+
+func TestEmitAnthropicResponse_ThinkingSignaturePrecedesText(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message: openai.ChatCompletionMessage{
+				Role:    "assistant",
+				Content: "Forty-two.",
+			},
+		},
+		openai.CompletionUsage{PromptTokens: 8, CompletionTokens: 3},
+		"msg_thinking",
+	)
+
+	ext := &ir.IRExtensions{
+		SourceProtocol:     SourceProtocolAnthropic,
+		ThinkingSignatures: map[string]string{"content[0]": "sig-deadbeef"},
+	}
+	out, err := EmitAnthropicResponse(body, ext, "claude-opus-4-7")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+
+	require.Len(t, msg.Content, 2)
+	assert.Equal(t, "thinking", msg.Content[0].Type)
+	assert.Equal(t, "sig-deadbeef", msg.Content[0].Signature)
+	assert.NotEmpty(t, msg.Content[0].Thinking, "placeholder fills until PR #1718 lands")
+	assert.Equal(t, "text", msg.Content[1].Type)
+	assert.Equal(t, "Forty-two.", msg.Content[1].Text)
+}
+
+func TestEmitAnthropicResponse_StopReasonLength(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "length",
+			Message:      openai.ChatCompletionMessage{Content: "Truncated..."},
+		},
+		openai.CompletionUsage{PromptTokens: 10, CompletionTokens: 100},
+		"msg_length",
+	)
+	out, err := EmitAnthropicResponse(body, nil, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, anthropic.StopReasonMaxTokens, msg.StopReason)
+}
+
+func TestEmitAnthropicResponse_StopReasonContentFilter(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "content_filter",
+			Message:      openai.ChatCompletionMessage{Refusal: "I cannot help with that."},
+		},
+		openai.CompletionUsage{},
+		"msg_refusal",
+	)
+	out, err := EmitAnthropicResponse(body, nil, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, anthropic.StopReasonRefusal, msg.StopReason)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "text", msg.Content[0].Type)
+	assert.Equal(t, "I cannot help with that.", msg.Content[0].Text)
+}
+
+func TestEmitAnthropicResponse_AnthropicStopReasonOverride_PauseTurn(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Content: "Partial..."},
+		},
+		openai.CompletionUsage{},
+		"msg_pause",
+	)
+	ext := &ir.IRExtensions{
+		SourceProtocol:      SourceProtocolAnthropic,
+		AnthropicStopReason: string(anthropic.StopReasonPauseTurn),
+	}
+	out, err := EmitAnthropicResponse(body, ext, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, anthropic.StopReasonPauseTurn, msg.StopReason)
+	assert.Empty(t, msg.StopSequence)
+}
+
+func TestEmitAnthropicResponse_StopSequenceOverride(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Content: "Truncated by ###END"},
+		},
+		openai.CompletionUsage{},
+		"msg_seq",
+	)
+	ext := &ir.IRExtensions{
+		SourceProtocol:        SourceProtocolAnthropic,
+		AnthropicStopReason:   string(anthropic.StopReasonStopSequence),
+		AnthropicStopSequence: "###END",
+	}
+	out, err := EmitAnthropicResponse(body, ext, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, anthropic.StopReasonStopSequence, msg.StopReason)
+	assert.Equal(t, "###END", msg.StopSequence)
+}
+
+func TestEmitAnthropicResponse_CacheUsageRoundTrip(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Content: "cached"},
+		},
+		openai.CompletionUsage{PromptTokens: 200, CompletionTokens: 10},
+		"msg_cache",
+	)
+	ext := &ir.IRExtensions{
+		SourceProtocol:           SourceProtocolAnthropic,
+		CacheReadInputTokens:     120,
+		CacheCreationInputTokens: 80,
+		Ephemeral5mInputTokens:   30,
+		Ephemeral1hInputTokens:   50,
+	}
+	out, err := EmitAnthropicResponse(body, ext, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, int64(120), msg.Usage.CacheReadInputTokens)
+	assert.Equal(t, int64(80), msg.Usage.CacheCreationInputTokens)
+	assert.Equal(t, int64(30), msg.Usage.CacheCreation.Ephemeral5mInputTokens)
+	assert.Equal(t, int64(50), msg.Usage.CacheCreation.Ephemeral1hInputTokens)
+}
+
+func TestEmitAnthropicResponse_ServerToolUseCounts(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Content: "searched"},
+		},
+		openai.CompletionUsage{},
+		"msg_server_tool",
+	)
+	ext := &ir.IRExtensions{
+		SourceProtocol:      SourceProtocolAnthropic,
+		ServerToolUseCounts: map[string]int64{"web_search": 3},
+		// non-zero cache so the OpenAI-backend warning does not fire
+		CacheReadInputTokens: 1,
+	}
+	out, err := EmitAnthropicResponse(body, ext, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, int64(3), msg.Usage.ServerToolUse.WebSearchRequests)
+}
+
+func TestEmitAnthropicResponse_OpenAIBackendOmitsCacheObjectAndWarns(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Content: "no cache"},
+		},
+		openai.CompletionUsage{PromptTokens: 20, CompletionTokens: 10},
+		"msg_openai_backend",
+	)
+	ext := &ir.IRExtensions{
+		SourceProtocol: SourceProtocolAnthropic,
+	}
+	out, err := EmitAnthropicResponse(body, ext, "m")
+	require.NoError(t, err)
+
+	// cache_creation must be absent in the raw JSON output.
+	assert.NotContains(t, string(out), `"cache_creation":`)
+
+	// Info warning recorded so observability captures the structural diff.
+	require.NotEmpty(t, ext.Warnings)
+	var sawCacheWarning bool
+	for _, w := range ext.Warnings {
+		if w.Reason == ir.ReasonCacheUnavailableOnOpenAIBackend {
+			sawCacheWarning = true
+			assert.Equal(t, ir.WarningSeverityInfo, w.Severity)
+		}
+	}
+	assert.True(t, sawCacheWarning, "expected cache_unavailable warning")
+}
+
+func TestEmitAnthropicResponse_EmptyContentReturnsEmptyArray(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Role: "assistant"},
+		},
+		openai.CompletionUsage{},
+		"msg_empty",
+	)
+	out, err := EmitAnthropicResponse(body, nil, "m")
+	require.NoError(t, err)
+
+	// Distinguish "null" from "[]" at the wire level so Anthropic
+	// SDK clients that test typeof content === "object" do not trip.
+	assert.Contains(t, string(out), `"content":[]`)
+	assert.NotContains(t, string(out), `"content":null`)
+}
+
+func TestEmitAnthropicResponse_UnknownFinishReasonFallsBackWithWarning(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "something_unexpected",
+			Message:      openai.ChatCompletionMessage{Content: "ok"},
+		},
+		openai.CompletionUsage{},
+		"msg_unknown_finish",
+	)
+	ext := &ir.IRExtensions{SourceProtocol: SourceProtocolAnthropic}
+	out, err := EmitAnthropicResponse(body, ext, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, anthropic.StopReasonEndTurn, msg.StopReason)
+
+	var sawCoerced bool
+	for _, w := range ext.Warnings {
+		if w.Reason == ir.ReasonAnthropicStopReasonCoerced {
+			sawCoerced = true
+		}
+	}
+	assert.True(t, sawCoerced, "expected anthropic_stop_reason_coerced warning")
+}
+
+func TestEmitAnthropicResponse_EmptyFinishReasonCoerces(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			Message: openai.ChatCompletionMessage{Content: "synth"},
+		},
+		openai.CompletionUsage{},
+		"msg_empty_finish",
+	)
+	ext := &ir.IRExtensions{SourceProtocol: SourceProtocolAnthropic}
+	out, err := EmitAnthropicResponse(body, ext, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, anthropic.StopReasonEndTurn, msg.StopReason)
+}
+
+func TestEmitAnthropicResponse_InvalidJSONReturnsError(t *testing.T) {
+	_, err := EmitAnthropicResponse([]byte("not json"), nil, "m")
+	assert.Error(t, err)
+}
+
+func TestEmitAnthropicResponse_NoChoicesEmitsEmptyContent(t *testing.T) {
+	cc := &openai.ChatCompletion{
+		ID:      "msg_no_choices",
+		Object:  "chat.completion",
+		Model:   "m",
+		Choices: nil,
+		Usage:   openai.CompletionUsage{PromptTokens: 1},
+	}
+	body, err := json.Marshal(cc)
+	require.NoError(t, err)
+	out, err := EmitAnthropicResponse(body, nil, "m")
+	require.NoError(t, err)
+	msg := parseAnthropicResponse(t, out)
+	assert.Equal(t, "msg_no_choices", msg.ID)
+	assert.Empty(t, msg.Content)
+	assert.Equal(t, anthropic.StopReasonEndTurn, msg.StopReason)
+}
+
+func TestEmitAnthropicError_KnownTypes(t *testing.T) {
+	cases := []struct {
+		errorType string
+		message   string
+	}{
+		{"invalid_request_error", "bad request"},
+		{"authentication_error", "no key"},
+		{"permission_error", "forbidden"},
+		{"not_found_error", "missing"},
+		{"request_too_large", "too big"},
+		{"rate_limit_error", "slow down"},
+		{"api_error", "server hiccup"},
+		{"timeout_error", "timed out"},
+		{"overloaded_error", "try again"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.errorType, func(t *testing.T) {
+			body := EmitAnthropicError(tc.errorType, tc.message)
+			var env struct {
+				Type  string `json:"type"`
+				Error struct {
+					Type    string `json:"type"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(body, &env))
+			assert.Equal(t, "error", env.Type)
+			assert.Equal(t, tc.errorType, env.Error.Type)
+			assert.Equal(t, tc.message, env.Error.Message)
+		})
+	}
+}
+
+func TestEmitAnthropicError_EmptyErrorTypeCoercesToAPIError(t *testing.T) {
+	body := EmitAnthropicError("", "boom")
+	var env struct {
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	assert.Equal(t, "api_error", env.Error.Type)
+}
+
+// Round-trip: feed an Anthropic Message through the inverse helper
+// (toOpenAIResponseBody with a populated ext), then through the
+// outbound emitter, and assert the structural identity holds for the
+// fields PR4 promises to round-trip.
+func TestRoundTrip_AnthropicResponse_StopReasonAndUsage(t *testing.T) {
+	original := &anthropic.Message{
+		ID: "msg_round_trip",
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: "Hello"},
+		},
+		StopReason: anthropic.StopReasonPauseTurn,
+		Usage: anthropic.Usage{
+			InputTokens:              50,
+			OutputTokens:             20,
+			CacheReadInputTokens:     30,
+			CacheCreationInputTokens: 10,
+			CacheCreation: anthropic.CacheCreation{
+				Ephemeral5mInputTokens: 6,
+				Ephemeral1hInputTokens: 4,
+			},
+		},
+	}
+	originalBody, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	ext := &ir.IRExtensions{SourceProtocol: SourceProtocolAnthropic}
+	openaiBody, err := toOpenAIResponseBody(originalBody, "claude-opus-4-7", ext)
+	require.NoError(t, err)
+
+	out, err := EmitAnthropicResponse(openaiBody, ext, "claude-opus-4-7")
+	require.NoError(t, err)
+	restored := parseAnthropicResponse(t, out)
+
+	assert.Equal(t, original.ID, restored.ID)
+	assert.Equal(t, original.StopReason, restored.StopReason)
+	assert.Equal(t, original.Usage.InputTokens, restored.Usage.InputTokens)
+	assert.Equal(t, original.Usage.OutputTokens, restored.Usage.OutputTokens)
+	assert.Equal(t, original.Usage.CacheReadInputTokens, restored.Usage.CacheReadInputTokens)
+	assert.Equal(t, original.Usage.CacheCreationInputTokens, restored.Usage.CacheCreationInputTokens)
+	assert.Equal(t, original.Usage.CacheCreation.Ephemeral5mInputTokens, restored.Usage.CacheCreation.Ephemeral5mInputTokens)
+	assert.Equal(t, original.Usage.CacheCreation.Ephemeral1hInputTokens, restored.Usage.CacheCreation.Ephemeral1hInputTokens)
+}
+
+func TestSortStrings_StableOrder(t *testing.T) {
+	// Internal helper sanity check — content[10] must sort after
+	// content[2] under lexicographic order; that's acceptable because
+	// the inverse extractor uses sequential indices without padding
+	// and signatures in practice never exceed a single-digit count.
+	in := []string{"content[2]", "content[1]", "content[0]"}
+	sortStrings(in)
+	assert.Equal(t, []string{"content[0]", "content[1]", "content[2]"}, in)
+}
+
+func TestEmitAnthropicResponse_PreservesIDAndModel(t *testing.T) {
+	body := buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "stop",
+			Message:      openai.ChatCompletionMessage{Content: "x"},
+		},
+		openai.CompletionUsage{},
+		"msg_preserve_id",
+	)
+	out, err := EmitAnthropicResponse(body, nil, "claude-haiku-4-5")
+	require.NoError(t, err)
+
+	// Spot-check the raw wire output: id and model must be present
+	// as top-level strings (Anthropic SDK clients key on them).
+	s := string(out)
+	assert.Contains(t, s, `"id":"msg_preserve_id"`)
+	assert.Contains(t, s, `"model":"claude-haiku-4-5"`)
+	assert.Contains(t, s, `"type":"message"`)
+	assert.Contains(t, s, `"role":"assistant"`)
+}

--- a/src/semantic-router/pkg/anthropic/request_body.go
+++ b/src/semantic-router/pkg/anthropic/request_body.go
@@ -1,0 +1,599 @@
+// Package-level request-body construction helpers for the Anthropic format.
+//
+// This file contains the private helper functions that implement the
+// OpenAI→Anthropic request body translation called by the public entry
+// points ToAnthropicRequestBody and ToAnthropicRequestBodyWithPassthrough
+// (in client.go). Keeping them here lets client.go stay focused on the
+// public API surface and the symmetric response-path helpers.
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// resolveMaxTokens picks max_tokens with Anthropic's required default.
+func resolveMaxTokens(req *openai.ChatCompletionNewParams) int64 {
+	switch {
+	case req.MaxCompletionTokens.Value > 0:
+		return req.MaxCompletionTokens.Value
+	case req.MaxTokens.Value > 0:
+		return req.MaxTokens.Value
+	default:
+		return DefaultMaxTokens
+	}
+}
+
+// buildSystem returns the Anthropic system array. When pt carries
+// SystemBlocks (array-form system from inbound), each block is emitted with
+// its cache_control marker; otherwise it falls back to the string-form system
+// derived from the OpenAI messages, preserving today's behaviour byte-for-byte.
+func buildSystem(systemPrompt string, pt *AnthropicPassthrough) []anthropic.TextBlockParam {
+	if pt != nil && len(pt.SystemBlocks) > 0 {
+		out := make([]anthropic.TextBlockParam, 0, len(pt.SystemBlocks))
+		for _, sb := range pt.SystemBlocks {
+			block := anthropic.TextBlockParam{Text: sb.Text}
+			if sb.CacheControl != nil {
+				block.CacheControl = toSDKCacheControl(*sb.CacheControl)
+			}
+			out = append(out, block)
+		}
+		return out
+	}
+	if systemPrompt == "" {
+		return nil
+	}
+	return []anthropic.TextBlockParam{{Text: systemPrompt}}
+}
+
+// applySampling sets temperature, top_p, and stop_sequences from the OpenAI
+// request, plus top_k from the passthrough when present.
+func applySampling(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, pt *AnthropicPassthrough) {
+	if req.Temperature.Valid() {
+		params.Temperature = anthropic.Float(req.Temperature.Value)
+	}
+	if req.TopP.Valid() {
+		params.TopP = anthropic.Float(req.TopP.Value)
+	}
+	if len(req.Stop.OfStringArray) > 0 {
+		params.StopSequences = req.Stop.OfStringArray
+	} else if req.Stop.OfString.Value != "" {
+		params.StopSequences = []string{req.Stop.OfString.Value}
+	}
+	if pt != nil && pt.TopK != nil {
+		params.TopK = anthropic.Int(*pt.TopK)
+	}
+}
+
+// applyMetadata emits metadata.user_id from the passthrough when set, falling
+// back to the OpenAI request's `user` field as the conventional mapping.
+func applyMetadata(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, pt *AnthropicPassthrough) {
+	userID := ""
+	if pt != nil && pt.MetadataUserID != "" {
+		userID = pt.MetadataUserID
+	} else if req != nil && req.User.Valid() && req.User.Value != "" {
+		userID = req.User.Value
+	}
+	if userID == "" {
+		return
+	}
+	params.Metadata = anthropic.MetadataParam{UserID: anthropic.String(userID)}
+}
+
+// applyToolsCacheControl attaches cache_control markers to tool definitions
+// based on the `tools[i]` keys in the passthrough.
+func applyToolsCacheControl(params *anthropic.MessageNewParams, pt *AnthropicPassthrough) {
+	if pt == nil || len(pt.CacheControl) == 0 {
+		return
+	}
+	for i := range params.Tools {
+		spec, ok := pt.CacheControl[fmt.Sprintf("tools[%d]", i)]
+		if !ok {
+			continue
+		}
+		if params.Tools[i].OfTool != nil {
+			params.Tools[i].OfTool.CacheControl = toSDKCacheControl(spec)
+		}
+	}
+}
+
+// applyMessagesCacheControl attaches per-content-block cache_control markers
+// to the outbound user/assistant messages. Markers whose `messages[i].content[j]`
+// key no longer matches a block on the outbound side are silently dropped to
+// match the surrounding lossy-translation discipline.
+func applyMessagesCacheControl(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
+	if pt == nil || len(pt.CacheControl) == 0 {
+		return
+	}
+	for i := range messages {
+		for j := range messages[i].Content {
+			spec, ok := pt.CacheControl[fmt.Sprintf("messages[%d].content[%d]", i, j)]
+			if !ok {
+				continue
+			}
+			sdkCC := toSDKCacheControl(spec)
+			block := &messages[i].Content[j]
+			switch {
+			case block.OfText != nil:
+				block.OfText.CacheControl = sdkCC
+			case block.OfImage != nil:
+				block.OfImage.CacheControl = sdkCC
+			case block.OfToolUse != nil:
+				block.OfToolUse.CacheControl = sdkCC
+			case block.OfToolResult != nil:
+				block.OfToolResult.CacheControl = sdkCC
+			}
+		}
+	}
+}
+
+// toSDKCacheControl converts the package-local CacheControlSpec into the SDK's
+// CacheControlEphemeralParam. Type defaults to "ephemeral" (the only value the
+// SDK supports today); TTL is forwarded when set.
+func toSDKCacheControl(spec CacheControlSpec) anthropic.CacheControlEphemeralParam {
+	cc := anthropic.NewCacheControlEphemeralParam()
+	if spec.TTL != "" {
+		cc.TTL = anthropic.CacheControlEphemeralTTL(spec.TTL)
+	}
+	return cc
+}
+
+// extractSystemContent extracts text from a system message
+func extractSystemContent(msg *openai.ChatCompletionSystemMessageParam) string {
+	if msg.Content.OfString.Value != "" {
+		return msg.Content.OfString.Value
+	}
+	var parts []string
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		if part.Text != "" {
+			parts = append(parts, part.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// extractUserContent extracts text from a user message. Kept for
+// backwards-compatibility with callers that only need the flattened text
+// representation; userMessageBlocks is the structured form used by the
+// outbound writer (which also preserves image blocks).
+func extractUserContent(msg *openai.ChatCompletionUserMessageParam) string {
+	if msg.Content.OfString.Value != "" {
+		return msg.Content.OfString.Value
+	}
+	var parts []string
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		if part.OfText != nil {
+			parts = append(parts, part.OfText.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// userMessageBlocks converts an OpenAI user message into a slice of Anthropic
+// content blocks, preserving image_url parts as Anthropic image blocks. This
+// fixes the long-standing drop where image content (OpenAI-shape OfImageURL)
+// was flattened to an empty string by extractUserContent, causing the model to
+// report "I don't see any image attached" on the upstream side.
+func userMessageBlocks(msg *openai.ChatCompletionUserMessageParam) []anthropic.ContentBlockParamUnion {
+	if msg.Content.OfString.Value != "" {
+		return []anthropic.ContentBlockParamUnion{anthropic.NewTextBlock(msg.Content.OfString.Value)}
+	}
+	var blocks []anthropic.ContentBlockParamUnion
+	var textParts []string
+	flushText := func() {
+		if len(textParts) > 0 {
+			blocks = append(blocks, anthropic.NewTextBlock(strings.Join(textParts, " ")))
+			textParts = nil
+		}
+	}
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		switch {
+		case part.OfText != nil:
+			textParts = append(textParts, part.OfText.Text)
+		case part.OfImageURL != nil:
+			flushText()
+			if block, ok := openAIImageURLToAnthropicBlock(part.OfImageURL.ImageURL.URL); ok {
+				blocks = append(blocks, block)
+			}
+		}
+	}
+	flushText()
+	return blocks
+}
+
+// openAIImageURLToAnthropicBlock parses an OpenAI image_url value into an
+// Anthropic image block. Both data-URI (data:image/<type>;base64,<data>) and
+// plain URL forms are supported; unrecognised shapes are skipped.
+func openAIImageURLToAnthropicBlock(url string) (anthropic.ContentBlockParamUnion, bool) {
+	const dataURIPrefix = "data:"
+	if strings.HasPrefix(url, dataURIPrefix) {
+		mediaType, data, ok := parseDataURI(url)
+		if !ok {
+			return anthropic.ContentBlockParamUnion{}, false
+		}
+		return anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
+			Data:      data,
+			MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
+		}), true
+	}
+	if url == "" {
+		return anthropic.ContentBlockParamUnion{}, false
+	}
+	return anthropic.NewImageBlock(anthropic.URLImageSourceParam{URL: url}), true
+}
+
+// parseDataURI extracts the media type and base64-encoded payload from a data
+// URI of the form `data:<media-type>;base64,<data>`. Returns ok=false for any
+// other shape.
+func parseDataURI(uri string) (mediaType, data string, ok bool) {
+	const prefix = "data:"
+	if !strings.HasPrefix(uri, prefix) {
+		return "", "", false
+	}
+	rest := uri[len(prefix):]
+	comma := strings.IndexByte(rest, ',')
+	if comma < 0 {
+		return "", "", false
+	}
+	header := rest[:comma]
+	payload := rest[comma+1:]
+	if !strings.Contains(header, ";base64") {
+		return "", "", false
+	}
+	mediaType = strings.TrimSuffix(header, ";base64")
+	if mediaType == "" {
+		return "", "", false
+	}
+	return mediaType, payload, true
+}
+
+// applyUserMessageImageBlocks appends image blocks captured in the passthrough
+// to the matching user message. Indexing is user-message-only (index 0 = first
+// user message in messages[]). When the index is out of range, images are
+// silently dropped to match the surrounding lossy-translation discipline.
+func applyUserMessageImageBlocks(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
+	if pt == nil || len(pt.UserMessageImageBlocks) == 0 {
+		return
+	}
+	userIdx := -1
+	for i := range messages {
+		if messages[i].Role != anthropic.MessageParamRoleUser {
+			continue
+		}
+		userIdx++
+		images, ok := pt.UserMessageImageBlocks[userIdx]
+		if !ok {
+			continue
+		}
+		for _, img := range images {
+			block, ok := buildImageBlockFromSource(img.Source)
+			if !ok {
+				continue
+			}
+			messages[i].Content = append(messages[i].Content, block)
+		}
+	}
+}
+
+// applyToolResultPassthrough overwrites tool_result blocks with the passthrough
+// payload: is_error: true is restored from pt.ToolResultErrors, and array
+// content (text + image blocks) is restored from pt.ToolResultArrayContent.
+// Matches by tool_use_id; missing keys leave the block as today's
+// translation produced it.
+func applyToolResultPassthrough(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
+	if pt == nil || (len(pt.ToolResultErrors) == 0 && len(pt.ToolResultArrayContent) == 0) {
+		return
+	}
+	for i := range messages {
+		for j := range messages[i].Content {
+			tr := messages[i].Content[j].OfToolResult
+			if tr == nil || tr.ToolUseID == "" {
+				continue
+			}
+			if isErr, ok := pt.ToolResultErrors[tr.ToolUseID]; ok && isErr {
+				tr.IsError = anthropic.Bool(true)
+			}
+			if blocks, ok := pt.ToolResultArrayContent[tr.ToolUseID]; ok && len(blocks) > 0 {
+				tr.Content = toSDKToolResultContent(blocks)
+			}
+		}
+	}
+}
+
+func toSDKToolResultContent(blocks []ToolResultContentBlock) []anthropic.ToolResultBlockParamContentUnion {
+	out := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			out = append(out, anthropic.ToolResultBlockParamContentUnion{
+				OfText: &anthropic.TextBlockParam{Text: b.Text},
+			})
+		case "image":
+			if b.Source == nil {
+				continue
+			}
+			img, ok := buildImageParamFromSource(*b.Source)
+			if !ok {
+				continue
+			}
+			out = append(out, anthropic.ToolResultBlockParamContentUnion{OfImage: img})
+		}
+	}
+	return out
+}
+
+// buildImageParamFromSource is the variant of buildImageBlockFromSource that
+// returns the raw *ImageBlockParam needed by ToolResultBlockParamContentUnion
+// (which embeds ImageBlockParam directly rather than via NewImageBlock).
+func buildImageParamFromSource(src ImageSource) (*anthropic.ImageBlockParam, bool) {
+	switch src.Type {
+	case "base64":
+		if src.Data == "" || src.MediaType == "" {
+			return nil, false
+		}
+		return &anthropic.ImageBlockParam{
+			Source: anthropic.ImageBlockParamSourceUnion{
+				OfBase64: &anthropic.Base64ImageSourceParam{
+					Data:      src.Data,
+					MediaType: anthropic.Base64ImageSourceMediaType(src.MediaType),
+				},
+			},
+		}, true
+	case "url":
+		if src.URL == "" {
+			return nil, false
+		}
+		return &anthropic.ImageBlockParam{
+			Source: anthropic.ImageBlockParamSourceUnion{
+				OfURL: &anthropic.URLImageSourceParam{URL: src.URL},
+			},
+		}, true
+	}
+	return nil, false
+}
+
+func buildImageBlockFromSource(src ImageSource) (anthropic.ContentBlockParamUnion, bool) {
+	switch src.Type {
+	case "base64":
+		if src.Data == "" || src.MediaType == "" {
+			return anthropic.ContentBlockParamUnion{}, false
+		}
+		return anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
+			Data:      src.Data,
+			MediaType: anthropic.Base64ImageSourceMediaType(src.MediaType),
+		}), true
+	case "url":
+		if src.URL == "" {
+			return anthropic.ContentBlockParamUnion{}, false
+		}
+		return anthropic.NewImageBlock(anthropic.URLImageSourceParam{URL: src.URL}), true
+	}
+	return anthropic.ContentBlockParamUnion{}, false
+}
+
+// extractAssistantContent extracts text from an assistant message
+func extractAssistantContent(msg *openai.ChatCompletionAssistantMessageParam) string {
+	if msg.Content.OfString.Value != "" {
+		return msg.Content.OfString.Value
+	}
+	var parts []string
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		if part.OfText != nil {
+			parts = append(parts, part.OfText.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func buildAnthropicMessages(
+	messages []openai.ChatCompletionMessageParamUnion,
+) (string, []anthropic.MessageParam, error) {
+	var systemPrompt string
+	var anthropicMessages []anthropic.MessageParam
+
+	for _, msg := range messages {
+		switch {
+		case msg.OfSystem != nil:
+			systemPrompt = extractSystemContent(msg.OfSystem)
+		case msg.OfUser != nil:
+			blocks := userMessageBlocks(msg.OfUser)
+			if len(blocks) > 0 {
+				anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(blocks...))
+			}
+		case msg.OfAssistant != nil:
+			blocks, err := assistantContentBlocks(msg.OfAssistant)
+			if err != nil {
+				return "", nil, err
+			}
+			if len(blocks) > 0 {
+				anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(blocks...))
+			}
+		case msg.OfTool != nil:
+			toolUseID := strings.TrimSpace(msg.OfTool.ToolCallID)
+			if toolUseID == "" {
+				return "", nil, fmt.Errorf("tool message missing tool_call_id")
+			}
+			content := extractToolMessageContent(msg.OfTool)
+			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(
+				anthropic.NewToolResultBlock(toolUseID, content, false),
+			))
+		default:
+			logging.Debugf("Skipping unsupported OpenAI message role in Anthropic conversion")
+		}
+	}
+
+	return systemPrompt, anthropicMessages, nil
+}
+
+func extractToolMessageContent(msg *openai.ChatCompletionToolMessageParam) string {
+	if msg.Content.OfString.Value != "" {
+		return msg.Content.OfString.Value
+	}
+	var parts []string
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		if part.Text != "" {
+			parts = append(parts, part.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func assistantContentBlocks(
+	msg *openai.ChatCompletionAssistantMessageParam,
+) ([]anthropic.ContentBlockParamUnion, error) {
+	var blocks []anthropic.ContentBlockParamUnion
+
+	content := extractAssistantContent(msg)
+	if content != "" {
+		blocks = append(blocks, anthropic.NewTextBlock(content))
+	}
+
+	for _, toolCall := range msg.ToolCalls {
+		toolUseID := strings.TrimSpace(toolCall.ID)
+		if toolUseID == "" {
+			return nil, fmt.Errorf("assistant tool_call missing id")
+		}
+		name := strings.TrimSpace(toolCall.Function.Name)
+		if name == "" {
+			return nil, fmt.Errorf("assistant tool_call %s missing function name", toolUseID)
+		}
+		input, err := parseToolCallArguments(toolCall.Function.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("assistant tool_call %s: %w", toolUseID, err)
+		}
+		blocks = append(blocks, anthropic.NewToolUseBlock(toolUseID, input, name))
+	}
+
+	return blocks, nil
+}
+
+func parseToolCallArguments(arguments string) (any, error) {
+	trimmed := strings.TrimSpace(arguments)
+	if trimmed == "" {
+		return map[string]any{}, nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return nil, fmt.Errorf("invalid tool arguments JSON: %w", err)
+	}
+	return parsed, nil
+}
+
+func applyOpenAIToolsToAnthropicParams(
+	params *anthropic.MessageNewParams,
+	openAIRequest *openai.ChatCompletionNewParams,
+) error {
+	if openAIRequest == nil {
+		return nil
+	}
+
+	if len(openAIRequest.Tools) > 0 {
+		tools, err := openAIToolsToAnthropic(openAIRequest.Tools)
+		if err != nil {
+			return err
+		}
+		params.Tools = tools
+	}
+
+	toolChoice, hasChoice := openAIToolChoiceToAnthropic(openAIRequest.ToolChoice)
+	if hasChoice {
+		params.ToolChoice = toolChoice
+	}
+	return nil
+}
+
+func openAIToolsToAnthropic(tools []openai.ChatCompletionToolParam) ([]anthropic.ToolUnionParam, error) {
+	result := make([]anthropic.ToolUnionParam, 0, len(tools))
+	for index, tool := range tools {
+		if tool.Type != "" && tool.Type != "function" {
+			logging.Debugf("Skipping non-function OpenAI tool type %q at index %d", tool.Type, index)
+			continue
+		}
+		name := strings.TrimSpace(tool.Function.Name)
+		if name == "" {
+			return nil, fmt.Errorf("tools[%d]: function name is required", index)
+		}
+
+		inputSchema, err := functionParametersToAnthropicSchema(tool.Function.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("tools[%d] (%s): %w", index, name, err)
+		}
+
+		toolParam := anthropic.ToolParam{
+			Name:        name,
+			InputSchema: inputSchema,
+			Type:        anthropic.ToolTypeCustom,
+		}
+		if desc := strings.TrimSpace(tool.Function.Description.Value); desc != "" {
+			toolParam.Description = anthropic.String(desc)
+		}
+		result = append(result, anthropic.ToolUnionParam{OfTool: &toolParam})
+	}
+	return result, nil
+}
+
+func functionParametersToAnthropicSchema(
+	parameters openai.FunctionParameters,
+) (anthropic.ToolInputSchemaParam, error) {
+	schema := anthropic.ToolInputSchemaParam{
+		Type: "object",
+	}
+	if parameters == nil {
+		return schema, nil
+	}
+
+	raw, err := json.Marshal(parameters)
+	if err != nil {
+		return schema, fmt.Errorf("marshal function parameters: %w", err)
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return schema, fmt.Errorf("parse function parameters: %w", err)
+	}
+	if schema.Type == "" {
+		schema.Type = "object"
+	}
+	return schema, nil
+}
+
+func openAIToolChoiceToAnthropic(
+	choice openai.ChatCompletionToolChoiceOptionUnionParam,
+) (anthropic.ToolChoiceUnionParam, bool) {
+	if !param.IsOmitted(choice.OfAuto) {
+		value := strings.TrimSpace(choice.OfAuto.Value)
+		switch value {
+		case "", "auto":
+			return anthropic.ToolChoiceUnionParam{
+				OfAuto: &anthropic.ToolChoiceAutoParam{},
+			}, true
+		case "none":
+			none := anthropic.NewToolChoiceNoneParam()
+			return anthropic.ToolChoiceUnionParam{OfNone: &none}, true
+		case "required", "any":
+			return anthropic.ToolChoiceUnionParam{
+				OfAny: &anthropic.ToolChoiceAnyParam{},
+			}, true
+		default:
+			logging.Debugf("Unknown OpenAI tool_choice auto value %q, defaulting to auto", value)
+			return anthropic.ToolChoiceUnionParam{
+				OfAuto: &anthropic.ToolChoiceAutoParam{},
+			}, true
+		}
+	}
+
+	if choice.OfChatCompletionNamedToolChoice != nil {
+		name := strings.TrimSpace(choice.OfChatCompletionNamedToolChoice.Function.Name)
+		if name == "" {
+			return anthropic.ToolChoiceUnionParam{}, false
+		}
+		return anthropic.ToolChoiceParamOfTool(name), true
+	}
+
+	return anthropic.ToolChoiceUnionParam{}, false
+}

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -64,7 +64,13 @@ func (r *OpenAIRouter) normalizeProviderResponseBody(
 		return responseBody, false, nil
 	}
 
-	transformedBody, err := anthropic.ToOpenAIResponseBody(responseBody, ctx.RequestModel)
+	// Pass IRExtensions through so the Anthropic-only stop reason, cache
+	// usage counters, server-tool counts, and thinking-block signatures
+	// land on the per-request sidecar. The Anthropic outbound emitter
+	// (translateResponseBodyForClient → EmitAnthropicResponse) replays
+	// them on the response body so an Anthropic client sees the same
+	// fields the upstream actually produced.
+	transformedBody, err := anthropic.ToOpenAIResponseBodyWithExt(responseBody, ctx.RequestModel, ctx.IRExtensions)
 	if err != nil {
 		logging.Errorf("Failed to transform Anthropic response to OpenAI format: %v", err)
 		return nil, false, err

--- a/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
@@ -5,6 +5,8 @@ import (
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
@@ -19,10 +21,10 @@ func (r *OpenAIRouter) handleNonStreamingResponseBody(
 	r.calibrateTokenEstimator(ctx, usage.promptTokens)
 	r.updateResponseCache(ctx, responseBody)
 
-	finalBody := r.translateResponseBodyForClient(ctx, responseBody)
+	finalBody, clientTransformed := r.translateResponseBodyForClient(ctx, responseBody)
 	bodyMutation, headerMutation := buildInitialResponseMutations(
 		finalBody,
-		initialBodyTransformed || isResponseAPIRequest(ctx),
+		initialBodyTransformed || clientTransformed,
 	)
 
 	if jailbreakResponse := r.performResponseJailbreakDetection(ctx, responseBody); jailbreakResponse != nil {
@@ -41,12 +43,30 @@ func (r *OpenAIRouter) handleNonStreamingResponseBody(
 	return response
 }
 
+// translateResponseBodyForClient dispatches body rewriting based on the
+// inbound client protocol. Returns the rewritten body and a flag
+// indicating whether a rewrite happened, so callers know whether to
+// emit a body mutation downstream.
+//
+// Branch order matters: ClientProtocol "anthropic" and Response API are
+// mutually exclusive (different inbound paths — /v1/messages vs
+// /v1/responses), but pinning the Anthropic branch first keeps the
+// dispatcher reading top-down by likelihood.
 func (r *OpenAIRouter) translateResponseBodyForClient(
 	ctx *RequestContext,
 	responseBody []byte,
-) []byte {
+) ([]byte, bool) {
+	if ctx != nil && ctx.ClientProtocol == config.ClientProtocolAnthropic {
+		translated, err := anthropic.EmitAnthropicResponse(responseBody, ctx.IRExtensions, ctx.RequestModel)
+		if err != nil {
+			logging.Errorf("Anthropic outbound emit failed: %v", err)
+			return anthropic.EmitAnthropicError("api_error", err.Error()), true
+		}
+		return translated, true
+	}
+
 	if !isResponseAPIRequest(ctx) || r.ResponseAPIFilter == nil {
-		return responseBody
+		return responseBody, false
 	}
 
 	translatedBody, err := r.ResponseAPIFilter.TranslateResponse(
@@ -56,11 +76,11 @@ func (r *OpenAIRouter) translateResponseBodyForClient(
 	)
 	if err != nil {
 		logging.Errorf("Response API translation error: %v", err)
-		return responseBody
+		return responseBody, false
 	}
 
 	logging.Infof("Response API: Translated response to Response API format")
-	return translatedBody
+	return translatedBody, true
 }
 
 func buildInitialResponseMutations(

--- a/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
@@ -56,7 +56,14 @@ func (r *OpenAIRouter) translateResponseBodyForClient(
 	ctx *RequestContext,
 	responseBody []byte,
 ) ([]byte, bool) {
-	if ctx != nil && ctx.ClientProtocol == config.ClientProtocolAnthropic {
+	// Defensive: a nil ctx cannot match either dispatcher branch and the
+	// downstream isResponseAPIRequest dereference would panic. Treat as
+	// plain OpenAI pass-through.
+	if ctx == nil {
+		return responseBody, false
+	}
+
+	if ctx.ClientProtocol == config.ClientProtocolAnthropic {
 		translated, err := anthropic.EmitAnthropicResponse(responseBody, ctx.IRExtensions, ctx.RequestModel)
 		if err != nil {
 			logging.Errorf("Anthropic outbound emit failed: %v", err)

--- a/src/semantic-router/pkg/extproc/processor_res_body_pipeline_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_pipeline_test.go
@@ -1,0 +1,125 @@
+package extproc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+// translateResponseBodyForClient is the protocol-keyed dispatcher
+// that PR4 wired the Anthropic outbound emitter into. The tests below
+// cover its three branches: Anthropic ingress (rewrite to Anthropic
+// shape), Response API ingress (existing behavior), and plain OpenAI
+// ingress (byte-identical pass-through).
+
+func openaiResponseBytes(t *testing.T, id, content, finishReason string) []byte {
+	t.Helper()
+	cc := &openai.ChatCompletion{
+		ID:     id,
+		Object: "chat.completion",
+		Model:  "claude-sonnet-4-5",
+		Choices: []openai.ChatCompletionChoice{{
+			Index: 0,
+			Message: openai.ChatCompletionMessage{
+				Role:    "assistant",
+				Content: content,
+			},
+			FinishReason: finishReason,
+		}},
+		Usage: openai.CompletionUsage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+	body, err := json.Marshal(cc)
+	require.NoError(t, err)
+	return body
+}
+
+func TestTranslateResponseBodyForClient_AnthropicRewrite(t *testing.T) {
+	r := &OpenAIRouter{}
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		RequestModel:   "claude-opus-4-7",
+		IRExtensions: &ir.IRExtensions{
+			SourceProtocol: "anthropic",
+		},
+	}
+	input := openaiResponseBytes(t, "msg_a1", "hello from anthropic client", "stop")
+
+	out, transformed := r.translateResponseBodyForClient(ctx, input)
+	require.True(t, transformed)
+
+	var msg anthropic.Message
+	require.NoError(t, json.Unmarshal(out, &msg))
+	assert.Equal(t, "msg_a1", msg.ID)
+	assert.Equal(t, "message", string(msg.Type))
+	assert.Equal(t, anthropic.StopReasonEndTurn, msg.StopReason)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "hello from anthropic client", msg.Content[0].Text)
+}
+
+func TestTranslateResponseBodyForClient_AnthropicEmitFailureReturnsErrorEnvelope(t *testing.T) {
+	r := &OpenAIRouter{}
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		RequestModel:   "claude-opus-4-7",
+		IRExtensions:   &ir.IRExtensions{SourceProtocol: "anthropic"},
+	}
+	out, transformed := r.translateResponseBodyForClient(ctx, []byte("not json"))
+	require.True(t, transformed)
+
+	var env struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	assert.Equal(t, "error", env.Type)
+	assert.Equal(t, "api_error", env.Error.Type)
+	assert.NotEmpty(t, env.Error.Message)
+}
+
+func TestTranslateResponseBodyForClient_OpenAIIngressUnchanged(t *testing.T) {
+	r := &OpenAIRouter{}
+	ctx := &RequestContext{
+		// ClientProtocol empty == plain OpenAI ingress.
+	}
+	input := openaiResponseBytes(t, "msg_oa", "unchanged", "stop")
+
+	out, transformed := r.translateResponseBodyForClient(ctx, input)
+	assert.False(t, transformed, "OpenAI ingress must not flag a rewrite")
+	assert.Equal(t, string(input), string(out), "OpenAI ingress must be byte-identical")
+}
+
+func TestTranslateResponseBodyForClient_NilContextOpenAIPath(t *testing.T) {
+	r := &OpenAIRouter{}
+	input := openaiResponseBytes(t, "msg_nilctx", "x", "stop")
+	out, transformed := r.translateResponseBodyForClient(nil, input)
+	assert.False(t, transformed)
+	assert.Equal(t, string(input), string(out))
+}
+
+func TestBuildInitialResponseMutations_NoTransformShortCircuits(t *testing.T) {
+	bodyMut, headerMut := buildInitialResponseMutations([]byte("anything"), false)
+	assert.Nil(t, bodyMut)
+	assert.Nil(t, headerMut)
+}
+
+func TestBuildInitialResponseMutations_TransformProducesMutations(t *testing.T) {
+	bodyMut, headerMut := buildInitialResponseMutations([]byte("body"), true)
+	require.NotNil(t, bodyMut)
+	require.NotNil(t, headerMut)
+	assert.Equal(t, []byte("body"), bodyMut.GetBody())
+	assert.Contains(t, headerMut.RemoveHeaders, "content-length")
+}

--- a/src/semantic-router/pkg/ir/extensions.go
+++ b/src/semantic-router/pkg/ir/extensions.go
@@ -92,6 +92,47 @@ type IRExtensions struct {
 	// ingress for pass-through to compatible backends.
 	InboundDangerousDirectBrowserAccess string
 
+	// CacheReadInputTokens mirrors anthropic.Usage.CacheReadInputTokens
+	// from the upstream response. Captured by the Anthropic→OpenAI
+	// normalization step so the symmetric Anthropic outbound emitter can
+	// replay it. Zero for OpenAI backends.
+	CacheReadInputTokens int64
+
+	// CacheCreationInputTokens mirrors
+	// anthropic.Usage.CacheCreationInputTokens. Same capture/replay
+	// trajectory as CacheReadInputTokens.
+	CacheCreationInputTokens int64
+
+	// Ephemeral5mInputTokens mirrors
+	// anthropic.Usage.CacheCreation.Ephemeral5mInputTokens, the 5-minute
+	// TTL slice of the cache-creation breakdown. Zero when the upstream
+	// did not populate the per-TTL breakdown.
+	Ephemeral5mInputTokens int64
+
+	// Ephemeral1hInputTokens mirrors
+	// anthropic.Usage.CacheCreation.Ephemeral1hInputTokens, the 1-hour
+	// TTL slice of the cache-creation breakdown.
+	Ephemeral1hInputTokens int64
+
+	// ServerToolUseCounts mirrors anthropic.Usage.ServerToolUse counters
+	// keyed by tool name ("web_search", "web_fetch"). Empty when the
+	// upstream returned no server-tool invocations or when the backend is
+	// OpenAI.
+	ServerToolUseCounts map[string]int64
+
+	// AnthropicStopReason captures the upstream Anthropic stop_reason when
+	// it is one of the Anthropic-only values that has no OpenAI
+	// equivalent ("pause_turn", "refusal"). When non-empty it overrides
+	// the OpenAI-derived stop_reason on the outbound emit path. Empty for
+	// stop_reasons that round-trip cleanly through OpenAI finish_reason.
+	AnthropicStopReason string
+
+	// AnthropicStopSequence mirrors anthropic.Message.StopSequence and is
+	// non-empty only when stop_reason == "stop_sequence". OpenAI
+	// finish_reason "length"/"stop" does not surface which sequence
+	// matched, so this is populated only on Anthropic-backend cells.
+	AnthropicStopSequence string
+
 	// Warnings accumulates parse- and emit-time observations. Surfaced via
 	// response headers, structured logging, and metrics.
 	Warnings []Warning
@@ -138,6 +179,20 @@ func (e *IRExtensions) SetToolStrict(toolName string, strict bool) {
 		e.ToolStrict = make(map[string]bool)
 	}
 	e.ToolStrict[toolName] = strict
+}
+
+// SetServerToolUseCount is nil-safe and lazily initializes the underlying
+// map. Zero counts are recorded as-is so callers can distinguish "tool not
+// invoked" (absent key) from "tool invoked zero times" (rare; present key
+// with zero value).
+func (e *IRExtensions) SetServerToolUseCount(toolName string, count int64) {
+	if e == nil {
+		return
+	}
+	if e.ServerToolUseCounts == nil {
+		e.ServerToolUseCounts = make(map[string]int64)
+	}
+	e.ServerToolUseCounts[toolName] = count
 }
 
 // SystemBlock records the shape of one Anthropic system block. When the

--- a/src/semantic-router/pkg/ir/extensions_test.go
+++ b/src/semantic-router/pkg/ir/extensions_test.go
@@ -70,7 +70,49 @@ func TestNilExtensions_AccessorsAreNoOps(t *testing.T) {
 	ext.SetCacheControl("x", CacheControlSpec{})
 	ext.SetThinkingSignature("x", "y")
 	ext.SetToolStrict("x", true)
+	ext.SetServerToolUseCount("web_search", 1)
 	ext.AppendWarning(Warning{})
+}
+
+func TestSetServerToolUseCount_LazyInit(t *testing.T) {
+	ext := &IRExtensions{}
+	ext.SetServerToolUseCount("web_search", 3)
+	ext.SetServerToolUseCount("web_fetch", 0)
+
+	if got := ext.ServerToolUseCounts["web_search"]; got != 3 {
+		t.Fatalf("expected web_search=3, got %d", got)
+	}
+	if _, ok := ext.ServerToolUseCounts["web_fetch"]; !ok {
+		t.Fatalf("expected web_fetch key present even when count is zero")
+	}
+}
+
+func TestResponseUsageFields_ZeroValueDefaults(t *testing.T) {
+	// Newly added response-side fields must default to zero / nil so
+	// that an OpenAI-only request that never touches the Anthropic
+	// emit path leaves them untouched.
+	ext := &IRExtensions{}
+	if ext.CacheReadInputTokens != 0 {
+		t.Errorf("CacheReadInputTokens default = %d, want 0", ext.CacheReadInputTokens)
+	}
+	if ext.CacheCreationInputTokens != 0 {
+		t.Errorf("CacheCreationInputTokens default = %d, want 0", ext.CacheCreationInputTokens)
+	}
+	if ext.Ephemeral5mInputTokens != 0 {
+		t.Errorf("Ephemeral5mInputTokens default = %d, want 0", ext.Ephemeral5mInputTokens)
+	}
+	if ext.Ephemeral1hInputTokens != 0 {
+		t.Errorf("Ephemeral1hInputTokens default = %d, want 0", ext.Ephemeral1hInputTokens)
+	}
+	if ext.ServerToolUseCounts != nil {
+		t.Errorf("ServerToolUseCounts default = %v, want nil", ext.ServerToolUseCounts)
+	}
+	if ext.AnthropicStopReason != "" {
+		t.Errorf("AnthropicStopReason default = %q, want empty", ext.AnthropicStopReason)
+	}
+	if ext.AnthropicStopSequence != "" {
+		t.Errorf("AnthropicStopSequence default = %q, want empty", ext.AnthropicStopSequence)
+	}
 }
 
 func TestWarningSeverityValues(t *testing.T) {

--- a/src/semantic-router/pkg/ir/warning_reasons.go
+++ b/src/semantic-router/pkg/ir/warning_reasons.go
@@ -62,11 +62,12 @@ const (
 	// dropped entries.
 	ReasonWarningsTruncated WarningReason = "warnings_truncated"
 
-	// ReasonCacheUnavailableOnOpenAIBackend indicates an Anthropic client
-	// received a response from an OpenAI backend that has no cache
-	// support, so usage.cache_* fields are zero by definition. Info-level
-	// so it does not surface as a lossy warning in the response header.
-	ReasonCacheUnavailableOnOpenAIBackend WarningReason = "cache_unavailable_on_openai_backend"
+	// ReasonCacheFieldsAbsent indicates an Anthropic-source response had all
+	// cache usage counters at zero. This covers both the case where the user
+	// did not annotate any prompt segment with cache_control (no cache was
+	// requested) and the case where an OpenAI backend was used (no cache
+	// support). Info-level so it does not surface as a lossy warning.
+	ReasonCacheFieldsAbsent WarningReason = "cache_fields_absent"
 
 	// ReasonAnthropicStopReasonCoerced indicates an OpenAI finish_reason
 	// could not be mapped to a known Anthropic stop_reason and was

--- a/src/semantic-router/pkg/ir/warning_reasons.go
+++ b/src/semantic-router/pkg/ir/warning_reasons.go
@@ -61,4 +61,16 @@ const (
 	// header size limit. The associated field carries the count of
 	// dropped entries.
 	ReasonWarningsTruncated WarningReason = "warnings_truncated"
+
+	// ReasonCacheUnavailableOnOpenAIBackend indicates an Anthropic client
+	// received a response from an OpenAI backend that has no cache
+	// support, so usage.cache_* fields are zero by definition. Info-level
+	// so it does not surface as a lossy warning in the response header.
+	ReasonCacheUnavailableOnOpenAIBackend WarningReason = "cache_unavailable_on_openai_backend"
+
+	// ReasonAnthropicStopReasonCoerced indicates an OpenAI finish_reason
+	// could not be mapped to a known Anthropic stop_reason and was
+	// coerced to "end_turn". Surfaced for diagnostics so clients can
+	// detect unexpected upstream behavior.
+	ReasonAnthropicStopReasonCoerced WarningReason = "anthropic_stop_reason_coerced"
 )

--- a/src/semantic-router/pkg/ir/warning_reasons_test.go
+++ b/src/semantic-router/pkg/ir/warning_reasons_test.go
@@ -23,19 +23,19 @@ func TestWarningReason_StableTokens(t *testing.T) {
 	// Locks the initial vocabulary in PR3. Renaming an existing reason is
 	// a breaking change for clients pattern-matching on header values.
 	expected := map[WarningReason]string{
-		ReasonDropped:                         "dropped",
-		ReasonCoercedString:                   "coerced_string",
-		ReasonUnsupportedBlockType:            "unsupported_block_type",
-		ReasonUnsupportedSubtype:              "unsupported_subtype",
-		ReasonImageFileIDUnresolved:           "image_file_id_unresolved",
-		ReasonRedactedThinkingDropped:         "redacted_thinking_dropped",
-		ReasonSignatureDropOnOpenAIBackend:    "signature_drop_on_openai_backend",
-		ReasonServerToolDropOnOpenAIBackend:   "server_tool_drop_on_openai_backend",
-		ReasonTopKDropOnOpenAIBackend:         "top_k_drop_on_openai_backend",
-		ReasonBetaDropOnOpenAIBackend:         "beta_drop_on_openai_backend",
-		ReasonWarningsTruncated:               "warnings_truncated",
-		ReasonCacheUnavailableOnOpenAIBackend: "cache_unavailable_on_openai_backend",
-		ReasonAnthropicStopReasonCoerced:      "anthropic_stop_reason_coerced",
+		ReasonDropped:                       "dropped",
+		ReasonCoercedString:                 "coerced_string",
+		ReasonUnsupportedBlockType:          "unsupported_block_type",
+		ReasonUnsupportedSubtype:            "unsupported_subtype",
+		ReasonImageFileIDUnresolved:         "image_file_id_unresolved",
+		ReasonRedactedThinkingDropped:       "redacted_thinking_dropped",
+		ReasonSignatureDropOnOpenAIBackend:  "signature_drop_on_openai_backend",
+		ReasonServerToolDropOnOpenAIBackend: "server_tool_drop_on_openai_backend",
+		ReasonTopKDropOnOpenAIBackend:       "top_k_drop_on_openai_backend",
+		ReasonBetaDropOnOpenAIBackend:       "beta_drop_on_openai_backend",
+		ReasonWarningsTruncated:             "warnings_truncated",
+		ReasonCacheFieldsAbsent:             "cache_fields_absent",
+		ReasonAnthropicStopReasonCoerced:    "anthropic_stop_reason_coerced",
 	}
 	for reason, want := range expected {
 		if string(reason) != want {

--- a/src/semantic-router/pkg/ir/warning_reasons_test.go
+++ b/src/semantic-router/pkg/ir/warning_reasons_test.go
@@ -23,17 +23,19 @@ func TestWarningReason_StableTokens(t *testing.T) {
 	// Locks the initial vocabulary in PR3. Renaming an existing reason is
 	// a breaking change for clients pattern-matching on header values.
 	expected := map[WarningReason]string{
-		ReasonDropped:                       "dropped",
-		ReasonCoercedString:                 "coerced_string",
-		ReasonUnsupportedBlockType:          "unsupported_block_type",
-		ReasonUnsupportedSubtype:            "unsupported_subtype",
-		ReasonImageFileIDUnresolved:         "image_file_id_unresolved",
-		ReasonRedactedThinkingDropped:       "redacted_thinking_dropped",
-		ReasonSignatureDropOnOpenAIBackend:  "signature_drop_on_openai_backend",
-		ReasonServerToolDropOnOpenAIBackend: "server_tool_drop_on_openai_backend",
-		ReasonTopKDropOnOpenAIBackend:       "top_k_drop_on_openai_backend",
-		ReasonBetaDropOnOpenAIBackend:       "beta_drop_on_openai_backend",
-		ReasonWarningsTruncated:             "warnings_truncated",
+		ReasonDropped:                         "dropped",
+		ReasonCoercedString:                   "coerced_string",
+		ReasonUnsupportedBlockType:            "unsupported_block_type",
+		ReasonUnsupportedSubtype:              "unsupported_subtype",
+		ReasonImageFileIDUnresolved:           "image_file_id_unresolved",
+		ReasonRedactedThinkingDropped:         "redacted_thinking_dropped",
+		ReasonSignatureDropOnOpenAIBackend:    "signature_drop_on_openai_backend",
+		ReasonServerToolDropOnOpenAIBackend:   "server_tool_drop_on_openai_backend",
+		ReasonTopKDropOnOpenAIBackend:         "top_k_drop_on_openai_backend",
+		ReasonBetaDropOnOpenAIBackend:         "beta_drop_on_openai_backend",
+		ReasonWarningsTruncated:               "warnings_truncated",
+		ReasonCacheUnavailableOnOpenAIBackend: "cache_unavailable_on_openai_backend",
+		ReasonAnthropicStopReasonCoerced:      "anthropic_stop_reason_coerced",
 	}
 	for reason, want := range expected {
 		if string(reason) != want {

--- a/tools/agent/e2e-profile-map.yaml
+++ b/tools/agent/e2e-profile-map.yaml
@@ -148,6 +148,16 @@ profile_rules:
       - e2e/profiles/streaming/**
       - deploy/kubernetes/streaming/**
       - src/semantic-router/pkg/extproc/processor_req_body_streamed*.go
+  anthropic-shim:
+    owner: e2e
+    coverage_role: anthropic-shape-backend-translation-contracts
+    selection_mode: full-ci
+    summary: Anthropic-shape backend (llama.cpp + shim) for verifying outbound translation cells — cache-cycle synthesis, stop-reason mapping, and request-side field preservation.
+    paths:
+      - e2e/profiles/anthropic-shim/**
+      - e2e/testing/anthropic-shim/**
+      - deploy/kubernetes/anthropic-backend/**
+      - src/semantic-router/pkg/anthropic/outbound*.go
 
 manual_profile_rules:
   response-api:


### PR DESCRIPTION
> **RFC**: #1946 — design rationale, alternatives considered, decisions invited from maintainers

Fourth PR in the native Anthropic `/v1/messages` ingress series (tracking
#1404). Stacks on #1939 (PR3). #1937 and #1938 have merged.

## What

Symmetric inverse of PR2's `ParseAnthropicRequest`: takes the OpenAI-shaped
response that flows out of the upstream backend and renders it as an Anthropic
Messages API response body shape that `/v1/messages` clients (Claude Code,
anthropic-sdk-go) expect.

After PR4 lands, the non-streaming request/response round-trip for native
Anthropic ingress is feature-complete. Streaming is PR5.

## Commits

1. **`[Router] add response-side usage and stop-reason fields to IRExtensions`** —
   new `AnthropicStopReason`, `AnthropicStopSequence`, `CacheCreationInputTokens`,
   `CacheReadInputTokens`, `Ephemeral5mInputTokens`, `Ephemeral1hInputTokens`,
   `ServerToolUseCounts` fields on `IRExtensions`. Pure type additions; nil-safe
   setters; no behavior. Lands first so the next commit's refactor compiles.
2. **`[Router] extract shared Anthropic response-shape helpers from client.go`** —
   refactor only. Extracts helpers that both the existing `ToOpenAIResponseBody`
   (converts Anthropic-backend responses to OpenAI shape on the way out) and
   the new outbound emitter share. Preserves the `default:` silent-drop of
   thinking / citations / server_tool_use into `IRExtensions` so they survive
   the round-trip into the outbound emitter.
3. **`[Router] add Anthropic outbound emitter for non-streaming responses`** —
   the heavy commit. `EmitAnthropicResponse(*openai.ChatCompletion, *ir.IRExtensions)`
   builds an Anthropic Messages response body: content blocks (text, tool_use,
   thinking placeholder), `stop_reason` mapping (OpenAI `finish_reason` →
   Anthropic vocabulary), `usage` fields (`input_tokens`, `output_tokens`,
   `cache_creation_input_tokens`, `cache_read_input_tokens`, `cache_creation`
   breakdown when populated). `EmitAnthropicError` wraps translation failures
   in the Anthropic error envelope shape. Pure functions — no extproc wiring
   in this commit.
4. **`[Router] route Anthropic clients through outbound emitter on response`** —
   wires the dispatch: `ctx.ClientProtocol == "anthropic"` branches the
   response-body translation through `EmitAnthropicResponse`. Protocol-keyed
   error envelope branch on translation failure.
5. **`[Router] propagate cache and server-tool usage into outbound emitter`** —
   populates `IRExtensions.CacheCreationInputTokens` etc. during
   `normalizeProviderResponseBody` so the outbound emitter sees them. Closes
   the round-trip for cache usage accounting.

## Important spec clarification

The plan initially called for "cache_control round-trip" on the response side.
After reading the Anthropic spec carefully: **`cache_control` is request-side
only**. The response carries cache usage *counters*
(`cache_creation_input_tokens`, `cache_read_input_tokens`, `cache_creation`
breakdown), not `cache_control` markers. PR4 emits the counters when present
and documents this distinction in the `pkg/anthropic/outbound.go` package
doc so future readers don't conflate the two halves.

## Thinking emission (placeholder)

Anthropic's response `thinking` block has a non-trivial shape (text + signature
round-trip) and there's an open upstream PR (#1718 by @eformat) addressing
this on the OpenAI-client / Anthropic-backend cell. PR4 emits a structurally-
correct `thinking` block when `IRExtensions.ThinkingSignatures` is populated
but leaves the user-visible text as a placeholder with a TODO pointing at
#1718. When #1718 lands, the placeholder becomes the real text in a one-line
fix. PR4 does not block on #1718.

## Notable design decisions

- **Commit ordering swap**: original plan had refactor before IR fields. The
  refactor references the new IR fields, so refactor-first commits don't
  compile. PR4 lands IR fields first, then refactor. Trajectory and final
  state unchanged.
- **Nil `IRExtensions` tolerated**: `EmitAnthropicResponse` accepts `nil` ext
  and emits a structurally-correct minimal response. Useful for error paths
  and pre-PR3 deployments.
- **`stop_sequence` only when explicitly set**: emitted only from
  `ext.AnthropicStopSequence` (round-trip from upstream); never reverse-
  engineered from response text.
- **OpenAI `refusal` finish_reason** maps to a text block carrying the refusal
  string plus `stop_reason: "refusal"`. `stop_details` is not emitted (would
  require an `IRExtensions` extension beyond PR4 scope; the spec accepts a
  refusal stop without `stop_details`).

## Deferred / known follow-ups

- **extproc end-to-end test**: `pkg/extproc/processor_res_body_anthropic_test.go`
  is gated on Rust CGO bindings; deferred to land where the bindings exist (CI).
  The pipeline-level dispatcher test
  (`processor_res_body_pipeline_test.go`) covers the dispatch and the
  Anthropic-emit-failure error envelope without CGO.
- **Synthesized-error envelope dispatcher** for jailbreak / hallucination
  filters that mutate response bodies: those filters today only add headers
  (default `header` action). The opt-in `body` action would clobber an
  Anthropic envelope. PR4 leaves them on the OpenAI path; an Anthropic-aware
  dispatcher belongs in a follow-up (would also benefit PR5 streaming).
- **`anthropic-sdk-go` `ServerToolUsage`** currently exposes only
  `WebSearchRequests`; `web_fetch_requests` isn't surfaced upstream. The IR
  `ServerToolUseCounts` field is map-keyed so additional usage families
  slot in cleanly when the SDK adds them.

## What's still to come in this series

- **PR5** — Anthropic SSE re-emit for streaming responses. Will also fix
  the thinking-delta / signature-delta drops in the existing
  `client_stream.go` default case.
- A small **sibling bug-fix PR** (separate from this series) for the
  pre-existing `pkg/anthropic/client.go` defects (`tool_result.is_error`
  silently dropped; `tool_result` array content flattened to empty string).

## Test plan

- [x] `make agent-lint CHANGED_FILES=...` clean (golangci-lint, pre-commit
      hooks, supply-chain scan, reference-config test, structure checks)
- [x] `go vet`, `go build`, `go test` clean on `pkg/anthropic/...` and
      `pkg/ir/...` (both Rust-free; the bulk of PR4 lives here)
- [x] DCO sign-off on all 5 commits, SSH-signed
- [x] Per-commit trajectory verified — each of the 5 commits independently
      compiles and vets
- [x] Outbound emitter covered by `outbound_test.go` (~528 LOC of table-
      driven assertions: text content, tool_use, thinking placeholder,
      stop_reason mapping for each OpenAI finish_reason variant,
      stop_sequence pass-through, usage with/without cache fields, error
      envelope shape, nil-ext tolerance)
- [x] Refactor covered by extended `client_test.go` (helpers still work for
      `ToOpenAIResponseBody`)
- [x] Dispatch wiring covered by `processor_res_body_pipeline_test.go`
- [x] E2E test added: `e2e/testcases/anthropic_messages_response_shape.go` (`anthropic-messages-response-shape`) — parses `/v1/messages` response as Anthropic Messages object, asserts `id`/`type=message`/`role=assistant`/`content` array/valid `stop_reason`/`usage` block
- [ ] Upstream CI — runs once this PR is marked ready

## Related

- Stacks on #1939 (PR3)
- Builds on #1938 (PR2: IR + inbound parser, now merged)
- Builds on #1937 (PR1: ClientProtocol detection, now merged)
- Tracking issue: #1404
- Adjacent: #1718 (Anthropic thinking response, draft — would unblock the
  thinking-block text placeholder in PR4 commit 3)
- Symmetric to: #1922 (custom Anthropic upstream routing, merged)



