### PR TITLE
feat(anthropic): SSE streaming emitter + thinking-delta drop fixes

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -11,6 +11,7 @@ var BaselineRouterContract = []string{
 	"anthropic-messages-request",
 	"anthropic-messages-protocol-headers",
 	"anthropic-messages-response-shape",
+	"anthropic-messages-streaming",
 	"apiserver-runtime-config-endpoints",
 	"apiserver-classification-endpoints",
 	"chat-completions-stress-request",

--- a/e2e/testcases/anthropic_messages_streaming.go
+++ b/e2e/testcases/anthropic_messages_streaming.go
@@ -84,7 +84,7 @@ func testAnthropicMessagesStreaming(ctx context.Context, client *kubernetes.Clie
 			resp.StatusCode, truncateString(string(body), 200))
 	}
 
-	events, err := consumeAnthropicSSE(resp)
+	events, parseErrors, err := consumeAnthropicSSE(resp)
 	if err != nil {
 		return fmt.Errorf("failed to consume SSE stream: %w", err)
 	}
@@ -96,6 +96,9 @@ func testAnthropicMessagesStreaming(ctx context.Context, client *kubernetes.Clie
 		}
 		for name, c := range counts {
 			details["event_"+name] = c
+		}
+		if len(parseErrors) > 0 {
+			details["parse_errors"] = parseErrors
 		}
 		opts.SetDetails(details)
 	}
@@ -143,6 +146,7 @@ func sendAnthropicMessagesStreamingRequest(
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("anthropic-version", "2023-06-01")
 
+	// Streaming responses can take longer than the 30 s non-streaming default.
 	httpClient := &http.Client{Timeout: 60 * time.Second}
 	return httpClient.Do(req)
 }
@@ -156,8 +160,14 @@ func sendAnthropicMessagesStreamingRequest(
 // separated by a blank line. The emitter may also send ping events
 // (just an event line plus an empty-data line); those are recorded so
 // keepalive can be observed but are not asserted on.
-func consumeAnthropicSSE(resp *http.Response) ([]anthropicStreamingEvent, error) {
+//
+// parseErrors accumulates any json.Unmarshal failures on data: lines so
+// callers can surface them via opts.SetDetails for CI diagnostics. A
+// non-nil parse error does not abort consumption — the event is still
+// recorded with a nil Data map so sequence assertions can continue.
+func consumeAnthropicSSE(resp *http.Response) ([]anthropicStreamingEvent, []string, error) {
 	var events []anthropicStreamingEvent
+	var parseErrors []string
 	scanner := bufio.NewScanner(resp.Body)
 	// SSE frames can be larger than the default 64 KiB scanner buffer
 	// for long content_block_delta lines.
@@ -173,7 +183,11 @@ func consumeAnthropicSSE(resp *http.Response) ([]anthropicStreamingEvent, error)
 			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 			pending.Data = nil
 			if data != "" {
-				_ = json.Unmarshal([]byte(data), &pending.Data)
+				if err := json.Unmarshal([]byte(data), &pending.Data); err != nil {
+					// Record the error so CI logs show the malformed payload
+					// rather than a cryptic downstream assertion failure.
+					parseErrors = append(parseErrors, fmt.Sprintf("event %q: %v", pending.Name, err))
+				}
 			}
 		case line == "":
 			if pending.Name != "" {
@@ -186,9 +200,9 @@ func consumeAnthropicSSE(resp *http.Response) ([]anthropicStreamingEvent, error)
 		events = append(events, pending)
 	}
 	if err := scanner.Err(); err != nil {
-		return events, fmt.Errorf("scanner: %w", err)
+		return events, parseErrors, fmt.Errorf("scanner: %w", err)
 	}
-	return events, nil
+	return events, parseErrors, nil
 }
 
 // countAnthropicEvents tallies how many times each event name appeared.

--- a/e2e/testcases/anthropic_messages_streaming.go
+++ b/e2e/testcases/anthropic_messages_streaming.go
@@ -1,0 +1,229 @@
+package testcases
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-messages-streaming", pkgtestcases.TestCase{
+		Description: "Verify streaming /v1/messages response emits the Anthropic SSE event sequence",
+		Tags:        []string{"anthropic", "streaming", "sse"},
+		Fn:          testAnthropicMessagesStreaming,
+	})
+}
+
+// anthropicStreamingEvent captures the per-line shape of an SSE frame:
+// the "event:" name and the parsed "data:" payload. Sufficient for
+// sequence-and-presence assertions; the field set inside each event
+// is documented per-event-type by the Anthropic Messages API.
+type anthropicStreamingEvent struct {
+	Name string
+	Data map[string]interface{}
+}
+
+// requiredAnthropicEventSequence is the strict ordering the SSE emitter
+// must produce for a single-content-block response. message_start opens,
+// at least one content_block (start + delta(s) + stop) per block, then
+// message_delta carrying the terminal stop_reason, then message_stop
+// closes. The emitter is free to interleave ping events; those are
+// keepalive and intentionally not in this sequence.
+var requiredAnthropicEventSequence = []string{
+	"message_start",
+	"content_block_start",
+	"content_block_delta",
+	"content_block_stop",
+	"message_delta",
+	"message_stop",
+}
+
+// testAnthropicMessagesStreaming asserts the SSE event sequence on a
+// streaming /v1/messages response: at least one message_start, at least
+// one content_block triplet (start/delta/stop), one message_delta with a
+// stop_reason, and exactly one message_stop. These are the framing
+// invariants any Anthropic SDK relies on to know when a response has
+// fully arrived; missing any of them stalls or breaks the client.
+func testAnthropicMessagesStreaming(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Verifying streaming /v1/messages SSE event sequence")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	resp, err := sendAnthropicMessagesStreamingRequest(ctx, anthropicMessagesRequestBody{
+		Model:     "MoM",
+		MaxTokens: 64,
+		Stream:    true,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "Count to three."},
+		},
+	}, localPort)
+	if err != nil {
+		return fmt.Errorf("anthropic streaming request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 200 for streaming /v1/messages, got %d: %s",
+			resp.StatusCode, truncateString(string(body), 200))
+	}
+
+	events, err := consumeAnthropicSSE(resp)
+	if err != nil {
+		return fmt.Errorf("failed to consume SSE stream: %w", err)
+	}
+
+	counts := countAnthropicEvents(events)
+	if opts.SetDetails != nil {
+		details := map[string]interface{}{
+			"total_events": len(events),
+		}
+		for name, c := range counts {
+			details["event_"+name] = c
+		}
+		opts.SetDetails(details)
+	}
+
+	return assertAnthropicStreamingInvariants(events, counts)
+}
+
+// assertAnthropicStreamingInvariants validates the framing rules for an
+// Anthropic SSE stream: every required event type appears at least once,
+// the events arrive in the documented order, and exactly one terminal
+// message_stop closes the stream.
+func assertAnthropicStreamingInvariants(events []anthropicStreamingEvent, counts map[string]int) error {
+	for _, required := range requiredAnthropicEventSequence {
+		if counts[required] == 0 {
+			return fmt.Errorf("missing required Anthropic event %q in stream (saw %v)", required, counts)
+		}
+	}
+	if counts["message_stop"] != 1 {
+		return fmt.Errorf("expected exactly one message_stop event, got %d", counts["message_stop"])
+	}
+	if err := assertEventOrder(events, requiredAnthropicEventSequence); err != nil {
+		return err
+	}
+	return nil
+}
+
+// sendAnthropicMessagesStreamingRequest POSTs a streaming /v1/messages
+// body and returns the raw response so the caller can read SSE frames.
+func sendAnthropicMessagesStreamingRequest(
+	ctx context.Context,
+	body anthropicMessagesRequestBody,
+	localPort string,
+) (*http.Response, error) {
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%s/v1/messages", localPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+	return httpClient.Do(req)
+}
+
+// consumeAnthropicSSE reads an Anthropic-format SSE stream into a slice
+// of {name, data} frames. Each Anthropic SSE frame is a pair of lines:
+//
+//	event: <name>
+//	data: <json>
+//
+// separated by a blank line. The emitter may also send ping events
+// (just an event line plus an empty-data line); those are recorded so
+// keepalive can be observed but are not asserted on.
+func consumeAnthropicSSE(resp *http.Response) ([]anthropicStreamingEvent, error) {
+	var events []anthropicStreamingEvent
+	scanner := bufio.NewScanner(resp.Body)
+	// SSE frames can be larger than the default 64 KiB scanner buffer
+	// for long content_block_delta lines.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var pending anthropicStreamingEvent
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			pending.Name = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			pending.Data = nil
+			if data != "" {
+				_ = json.Unmarshal([]byte(data), &pending.Data)
+			}
+		case line == "":
+			if pending.Name != "" {
+				events = append(events, pending)
+			}
+			pending = anthropicStreamingEvent{}
+		}
+	}
+	if pending.Name != "" {
+		events = append(events, pending)
+	}
+	if err := scanner.Err(); err != nil {
+		return events, fmt.Errorf("scanner: %w", err)
+	}
+	return events, nil
+}
+
+// countAnthropicEvents tallies how many times each event name appeared.
+func countAnthropicEvents(events []anthropicStreamingEvent) map[string]int {
+	counts := make(map[string]int, len(requiredAnthropicEventSequence))
+	for _, ev := range events {
+		counts[ev.Name]++
+	}
+	return counts
+}
+
+// assertEventOrder verifies that the events of interest appear in the
+// expected order (ignoring interleaved events such as ping or repeated
+// content_block_delta frames). The check walks the actual stream once
+// and advances through the expected sequence whenever it finds the
+// next expected name.
+func assertEventOrder(events []anthropicStreamingEvent, expected []string) error {
+	idx := 0
+	for _, ev := range events {
+		if idx >= len(expected) {
+			break
+		}
+		if ev.Name == expected[idx] {
+			idx++
+		}
+	}
+	if idx < len(expected) {
+		var seen []string
+		for _, ev := range events {
+			seen = append(seen, ev.Name)
+		}
+		return fmt.Errorf(
+			"event sequence broken: expected %v in order, got %v (matched %d/%d)",
+			expected, seen, idx, len(expected),
+		)
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -10,30 +10,50 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go"
 	"github.com/tidwall/sjson"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
 // StreamState tracks Anthropic SSE events while translating to OpenAI SSE.
 type StreamState struct {
-	MessageID           string
-	Created             int64
-	RoleSent            bool
-	BlockIndexToToolIdx map[int64]int
-	NextToolIdx         int
+	MessageID                  string
+	Created                    int64
+	RoleSent                   bool
+	BlockIndexToToolIdx        map[int64]int
+	NextToolIdx                int
+	BlockIndexToThinkingActive map[int64]bool
 }
 
 // NewStreamState returns initialized stream translation state.
 func NewStreamState() *StreamState {
 	return &StreamState{
-		BlockIndexToToolIdx: make(map[int64]int),
+		BlockIndexToToolIdx:        make(map[int64]int),
+		BlockIndexToThinkingActive: make(map[int64]bool),
 	}
+}
+
+// extractedSSELine carries one parsed `data:` payload along with the most
+// recent `event:` header above it. The header lets us route Anthropic
+// `event: error` lines into the error arm of transformStreamEvent — those
+// lines unmarshal as `{"type":"error",...}` which the switch otherwise
+// drops silently.
+type extractedSSELine struct {
+	Data    []byte
+	IsError bool
 }
 
 // TransformSSEChunkToOpenAI converts Anthropic SSE bytes from Envoy into OpenAI SSE.
 // streamDone is true when message_stop is observed.
+//
+// ext is optional; when non-nil, signature_delta events are captured into
+// ext.ThinkingSignatures so the symmetric outbound emitter can replay them
+// on multi-turn requests. Pass nil for the existing OpenAI-client cell
+// where signatures have no downstream consumer.
 func TransformSSEChunkToOpenAI(
 	anthropicChunk []byte,
 	state *StreamState,
 	model string,
+	ext *ir.IRExtensions,
 ) ([]byte, bool, error) {
 	if state == nil {
 		state = NewStreamState()
@@ -41,12 +61,23 @@ func TransformSSEChunkToOpenAI(
 
 	var out bytes.Buffer
 	streamDone := false
-	for _, data := range extractSSEDataLines(anthropicChunk) {
-		var event anthropic.MessageStreamEventUnion
-		if err := json.Unmarshal(data, &event); err != nil {
+	for _, line := range extractSSEDataLines(anthropicChunk) {
+		if line.IsError {
+			chunks, err := handleErrorEvent(line.Data, state, model)
+			if err != nil {
+				return nil, false, err
+			}
+			for _, chunk := range chunks {
+				out.Write(formatOpenAISSELine(chunk))
+			}
 			continue
 		}
-		chunks, done, err := transformStreamEvent(event, state, model)
+
+		var event anthropic.MessageStreamEventUnion
+		if err := json.Unmarshal(line.Data, &event); err != nil {
+			continue
+		}
+		chunks, done, err := transformStreamEvent(event, state, model, ext)
 		if err != nil {
 			return nil, false, err
 		}
@@ -65,11 +96,24 @@ func TransformSSEChunkToOpenAI(
 	return out.Bytes(), streamDone, nil
 }
 
-func extractSSEDataLines(chunk []byte) [][]byte {
-	var lines [][]byte
-	for _, line := range bytes.Split(chunk, []byte("\n")) {
-		line = bytes.TrimSpace(line)
+// extractSSEDataLines walks the Anthropic SSE framing in chunk and yields
+// each `data:` payload along with whether the preceding `event:` header
+// flagged it as an error event. Lines that begin with `{` (some
+// transports omit the `data:` prefix) are surfaced as ordinary payloads.
+func extractSSEDataLines(chunk []byte) []extractedSSELine {
+	var lines []extractedSSELine
+	currentEvent := ""
+	for _, raw := range bytes.Split(chunk, []byte("\n")) {
+		line := bytes.TrimSpace(raw)
 		if len(line) == 0 {
+			// Blank line terminates the current SSE event; reset the
+			// per-event header tracker so the next data: line is not
+			// mis-classified as belonging to a stale event header.
+			currentEvent = ""
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("event:")) {
+			currentEvent = string(bytes.TrimSpace(bytes.TrimPrefix(line, []byte("event:"))))
 			continue
 		}
 		if bytes.HasPrefix(line, []byte("data:")) {
@@ -77,11 +121,17 @@ func extractSSEDataLines(chunk []byte) [][]byte {
 			if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
 				continue
 			}
-			lines = append(lines, payload)
+			lines = append(lines, extractedSSELine{
+				Data:    payload,
+				IsError: currentEvent == "error",
+			})
 			continue
 		}
 		if line[0] == '{' {
-			lines = append(lines, line)
+			lines = append(lines, extractedSSELine{
+				Data:    line,
+				IsError: currentEvent == "error",
+			})
 		}
 	}
 	return lines
@@ -91,6 +141,7 @@ func transformStreamEvent(
 	event anthropic.MessageStreamEventUnion,
 	state *StreamState,
 	model string,
+	ext *ir.IRExtensions,
 ) ([][]byte, bool, error) {
 	switch event.Type {
 	case "message_start":
@@ -98,13 +149,19 @@ func transformStreamEvent(
 	case "content_block_start":
 		return handleContentBlockStart(event, state, model)
 	case "content_block_delta":
-		return handleContentBlockDelta(event, state, model)
+		return handleContentBlockDelta(event, state, model, ext)
 	case "message_delta":
 		return handleMessageDelta(event, state, model)
 	case "message_stop":
 		return nil, true, nil
 	case "content_block_stop", "ping", "vertex_event":
 		return nil, false, nil
+	case "error":
+		// Some transports surface error events as ordinary
+		// MessageStreamEventUnion entries (no `event: error` header).
+		// Route them through the same error pipeline.
+		chunks, err := handleErrorEvent([]byte(event.RawJSON()), state, model)
+		return chunks, false, err
 	default:
 		return nil, false, nil
 	}
@@ -155,6 +212,15 @@ func handleContentBlockStart(
 		state.BlockIndexToToolIdx[start.Index] = toolIdx
 		chunk, err := buildOpenAIStreamToolChunk(state, model, toolIdx, block.ID, block.Name, "")
 		return [][]byte{chunk}, false, err
+	case "thinking":
+		// Mark the block index as a thinking block so subsequent
+		// thinking_delta and signature_delta events can be routed back to
+		// it. Emit a bootstrap chunk carrying an empty reasoning_content
+		// string so downstream consumers see the field appear (mirroring
+		// the text case's bootstrap content).
+		state.BlockIndexToThinkingActive[start.Index] = true
+		chunk, err := buildOpenAIReasoningChunk(state, model, "")
+		return [][]byte{chunk}, false, err
 	default:
 		return nil, false, nil
 	}
@@ -164,6 +230,7 @@ func handleContentBlockDelta(
 	event anthropic.MessageStreamEventUnion,
 	state *StreamState,
 	model string,
+	ext *ir.IRExtensions,
 ) ([][]byte, bool, error) {
 	deltaEvent := event.AsContentBlockDelta()
 	delta := deltaEvent.Delta
@@ -186,9 +253,63 @@ func handleContentBlockDelta(
 		jsonDelta := delta.AsInputJSONDelta()
 		chunk, err := buildOpenAIStreamToolChunk(state, model, toolIdx, "", "", jsonDelta.PartialJSON)
 		return [][]byte{chunk}, false, err
+	case "thinking_delta":
+		return handleThinkingDelta(deltaEvent, state, model)
+	case "signature_delta":
+		return handleSignatureDelta(deltaEvent, state, ext)
 	default:
 		return nil, false, nil
 	}
+}
+
+// handleThinkingDelta translates an Anthropic thinking_delta into an OpenAI
+// chunk carrying delta.reasoning_content. Returns nil for deltas that arrive
+// without a matching content_block_start (orphan deltas cannot be routed).
+func handleThinkingDelta(
+	deltaEvent anthropic.ContentBlockDeltaEvent,
+	state *StreamState,
+	model string,
+) ([][]byte, bool, error) {
+	if !state.BlockIndexToThinkingActive[deltaEvent.Index] {
+		return nil, false, nil
+	}
+	thinkingDelta := deltaEvent.Delta.AsThinkingDelta()
+	if thinkingDelta.Thinking == "" {
+		return nil, false, nil
+	}
+	chunk, err := buildOpenAIReasoningChunk(state, model, thinkingDelta.Thinking)
+	return [][]byte{chunk}, false, err
+}
+
+// handleSignatureDelta captures the per-block signature into IRExtensions
+// so the symmetric outbound emitter can replay it on multi-turn requests.
+// Signatures have no representation on the OpenAI envelope; with nil ext
+// (the existing OpenAI-client cell), the signature is dropped — no consumer.
+func handleSignatureDelta(
+	deltaEvent anthropic.ContentBlockDeltaEvent,
+	state *StreamState,
+	ext *ir.IRExtensions,
+) ([][]byte, bool, error) {
+	if ext == nil {
+		return nil, false, nil
+	}
+	if !state.BlockIndexToThinkingActive[deltaEvent.Index] {
+		return nil, false, nil
+	}
+	sigDelta := deltaEvent.Delta.AsSignatureDelta()
+	if sigDelta.Signature == "" {
+		return nil, false, nil
+	}
+	ext.SetThinkingSignature(thinkingBlockKey(deltaEvent.Index), sigDelta.Signature)
+	return nil, false, nil
+}
+
+// thinkingBlockKey is the stable IRExtensions.ThinkingSignatures key for
+// a thinking block at Anthropic content_block index. Mirrors the
+// non-streaming inverse helper in client.go so a request that becomes
+// streaming mid-way does not double-store signatures.
+func thinkingBlockKey(blockIdx int64) string {
+	return fmt.Sprintf("content[%d]", blockIdx)
 }
 
 func handleMessageDelta(
@@ -209,6 +330,46 @@ func handleMessageDelta(
 	return [][]byte{chunk}, false, nil
 }
 
+// handleErrorEvent maps an Anthropic `event: error` data payload onto an
+// OpenAI terminal chunk. Per the plan's Q4 resolution: emit
+// finish_reason="error" plus a synthetic content delta carrying the error
+// message, so clients that ignore the non-standard finish_reason still
+// see the human-readable failure in the assistant text stream.
+func handleErrorEvent(data []byte, state *StreamState, model string) ([][]byte, error) {
+	var envelope anthropicErrorEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		// Malformed error payload; surface a generic message so the
+		// client at least sees that the stream aborted abnormally.
+		envelope = anthropicErrorEnvelope{
+			Type: "error",
+			Error: anthropicErrorDetail{
+				Type:    anthropicErrorTypeAPI,
+				Message: "unparsable Anthropic error event",
+			},
+		}
+	}
+	message := envelope.Error.Message
+	if message == "" {
+		message = "Anthropic upstream error"
+	}
+
+	contentChunk, err := buildOpenAIStreamChunk(state, model, openai.ChatCompletionChunkChoiceDelta{
+		Content: fmt.Sprintf("[error: %s] %s", envelope.Error.Type, message),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	finishChunk, err := buildOpenAIStreamFinishChunk(state, model, "error", anthropic.MessageDeltaUsage{})
+	if err != nil {
+		return nil, err
+	}
+	if finishChunk == nil {
+		return [][]byte{contentChunk}, nil
+	}
+	return [][]byte{contentChunk, finishChunk}, nil
+}
+
 func buildOpenAIStreamChunk(
 	state *StreamState,
 	model string,
@@ -225,6 +386,23 @@ func buildOpenAIStreamChunk(
 		}},
 	}
 	return json.Marshal(chunk)
+}
+
+// buildOpenAIReasoningChunk emits an OpenAI chunk carrying
+// `reasoning_content` on the delta. The OpenAI Go SDK's delta struct has
+// no first-class reasoning_content field, so the value is injected via
+// sjson after marshal — keeping interop with vsr's existing convention
+// (the non-streaming path reads reasoning_content the same way).
+func buildOpenAIReasoningChunk(state *StreamState, model string, reasoning string) ([]byte, error) {
+	base, err := buildOpenAIStreamChunk(state, model, openai.ChatCompletionChunkChoiceDelta{})
+	if err != nil {
+		return nil, err
+	}
+	withReasoning, err := sjson.SetBytes(base, "choices.0.delta.reasoning_content", reasoning)
+	if err != nil {
+		return nil, fmt.Errorf("inject reasoning_content: %w", err)
+	}
+	return withReasoning, nil
 }
 
 func buildOpenAIStreamToolChunk(

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -14,21 +14,51 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
-// StreamState tracks Anthropic SSE events while translating to OpenAI SSE.
+// StreamState tracks per-request streaming translation state. The struct
+// is shared by both directions:
+//
+//   - Inbound (Anthropic SSE → OpenAI SSE), driven by TransformSSEChunkToOpenAI:
+//     uses MessageID, Created, RoleSent, BlockIndexToToolIdx, NextToolIdx,
+//     BlockIndexToThinkingActive.
+//
+//   - Outbound (OpenAI SSE → Anthropic SSE), driven by the PR5 emitter:
+//     uses MessageStartSent, MessageStopSent, NextBlockIndex, the Open*
+//     pointers tracking which block index is currently open, the
+//     ToolIdxToBlockIndex / ToolUseEmittedStart maps mirroring the inbound
+//     pair in the reverse direction, LastChunkAt for the ping keepalive
+//     ticker, and InitialUsage for the message_start usage placeholder.
+//
+// One ClientProtocol per request means only one direction is active at a
+// time, so the two sub-sets never collide on the same instance.
 type StreamState struct {
+	// Inbound direction (Anthropic → OpenAI).
 	MessageID                  string
 	Created                    int64
 	RoleSent                   bool
 	BlockIndexToToolIdx        map[int64]int
 	NextToolIdx                int
 	BlockIndexToThinkingActive map[int64]bool
+
+	// Outbound direction (OpenAI → Anthropic).
+	MessageStartSent     bool
+	MessageStopSent      bool
+	NextBlockIndex       int64
+	OpenTextBlockIndex   *int64
+	OpenThinkingBlockIdx *int64
+	ToolIdxToBlockIndex  map[int]int64
+	ToolUseEmittedStart  map[int]bool
+	LastChunkAt          time.Time
+	InitialUsage         anthropic.Usage
 }
 
-// NewStreamState returns initialized stream translation state.
+// NewStreamState returns initialized stream translation state with maps
+// allocated for both directions.
 func NewStreamState() *StreamState {
 	return &StreamState{
 		BlockIndexToToolIdx:        make(map[int64]int),
 		BlockIndexToThinkingActive: make(map[int64]bool),
+		ToolIdxToBlockIndex:        make(map[int]int64),
+		ToolUseEmittedStart:        make(map[int]bool),
 	}
 }
 

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -181,7 +181,7 @@ func transformStreamEvent(
 	case "content_block_delta":
 		return handleContentBlockDelta(event, state, model, ext)
 	case "message_delta":
-		return handleMessageDelta(event, state, model)
+		return handleMessageDelta(event, state, model, ext)
 	case "message_stop":
 		return nil, true, nil
 	case "content_block_stop", "ping", "vertex_event":
@@ -209,6 +209,11 @@ func handleMessageStart(
 	if state.Created == 0 {
 		state.Created = time.Now().Unix()
 	}
+	// Capture the upstream's initial usage so the symmetric outbound
+	// emitter (sse_out.go) can echo it onto its synthesized
+	// message_start event, preserving the per-request input token
+	// count clients use to seed their usage accumulators.
+	state.InitialUsage = start.Message.Usage
 	if state.RoleSent {
 		return nil, false, nil
 	}
@@ -346,9 +351,22 @@ func handleMessageDelta(
 	event anthropic.MessageStreamEventUnion,
 	state *StreamState,
 	model string,
+	ext *ir.IRExtensions,
 ) ([][]byte, bool, error) {
 	deltaEvent := event.AsMessageDelta()
 	finishReason := mapAnthropicStopReasonToOpenAI(deltaEvent.Delta.StopReason)
+
+	// Capture Anthropic-only stop reasons ("pause_turn", "refusal")
+	// onto the IR sidecar so the symmetric outbound emitter can
+	// surface them verbatim on the client's message_delta. OpenAI's
+	// finish_reason alphabet has no equivalent, so without this
+	// round-trip the value would be lossily mapped to end_turn.
+	if ext != nil && isAnthropicOnlyStopReason(deltaEvent.Delta.StopReason) {
+		ext.AnthropicStopReason = string(deltaEvent.Delta.StopReason)
+		if deltaEvent.Delta.StopSequence != "" {
+			ext.AnthropicStopSequence = deltaEvent.Delta.StopSequence
+		}
+	}
 
 	chunk, err := buildOpenAIStreamFinishChunk(state, model, finishReason, deltaEvent.Usage)
 	if err != nil {
@@ -358,6 +376,20 @@ func handleMessageDelta(
 		return nil, false, nil
 	}
 	return [][]byte{chunk}, false, nil
+}
+
+// isAnthropicOnlyStopReason returns true for stop_reason values that
+// have no equivalent in the OpenAI finish_reason alphabet and must
+// round-trip via IRExtensions to survive the OpenAI normalization
+// step. "end_turn", "max_tokens", "tool_use", "stop_sequence", and
+// "refusal" all map onto OpenAI tokens; "pause_turn" does not.
+func isAnthropicOnlyStopReason(reason anthropic.StopReason) bool {
+	switch reason {
+	case anthropic.StopReasonPauseTurn:
+		return true
+	default:
+		return false
+	}
 }
 
 // handleErrorEvent maps an Anthropic `event: error` data payload onto an

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -378,12 +378,16 @@ func handleMessageDelta(
 
 // isAnthropicOnlyStopReason returns true for stop_reason values that
 // have no equivalent in the OpenAI finish_reason alphabet and must
-// round-trip via IRExtensions to survive the OpenAI normalization
-// step. "end_turn", "max_tokens", "tool_use", "stop_sequence", and
-// "refusal" all map onto OpenAI tokens; "pause_turn" does not.
+// round-trip via IRExtensions to survive the OpenAI normalization step.
+//
+// The full set: pause_turn, refusal, and stop_sequence all map onto
+// "stop" in mapAnthropicStopReasonToOpenAI (refusal via the default arm,
+// stop_sequence explicitly). The outbound emitter restores the original
+// value from IRExtensions so an Anthropic client in a double-Anthropic
+// cell sees the correct stop_reason.
 func isAnthropicOnlyStopReason(reason anthropic.StopReason) bool {
 	switch reason {
-	case anthropic.StopReasonPauseTurn:
+	case anthropic.StopReasonPauseTurn, anthropic.StopReasonRefusal, anthropic.StopReasonStopSequence:
 		return true
 	default:
 		return false

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -23,10 +23,10 @@ import (
 //
 //   - Outbound (OpenAI SSE → Anthropic SSE), driven by the PR5 emitter:
 //     uses MessageStartSent, MessageStopSent, NextBlockIndex, the Open*
-//     pointers tracking which block index is currently open, the
-//     ToolIdxToBlockIndex / ToolUseEmittedStart maps mirroring the inbound
-//     pair in the reverse direction, LastChunkAt for the ping keepalive
-//     ticker, and InitialUsage for the message_start usage placeholder.
+//     pointers tracking which block index is currently open,
+//     ToolIdxToBlockIndex (the reverse of the inbound pair),
+//     LastChunkAt for the ping keepalive ticker, and InitialUsage for the
+//     message_start usage placeholder.
 //
 // One ClientProtocol per request means only one direction is active at a
 // time, so the two sub-sets never collide on the same instance.
@@ -46,7 +46,6 @@ type StreamState struct {
 	OpenTextBlockIndex   *int64
 	OpenThinkingBlockIdx *int64
 	ToolIdxToBlockIndex  map[int]int64
-	ToolUseEmittedStart  map[int]bool
 	LastChunkAt          time.Time
 	InitialUsage         anthropic.Usage
 }
@@ -58,7 +57,6 @@ func NewStreamState() *StreamState {
 		BlockIndexToToolIdx:        make(map[int64]int),
 		BlockIndexToThinkingActive: make(map[int64]bool),
 		ToolIdxToBlockIndex:        make(map[int]int64),
-		ToolUseEmittedStart:        make(map[int]bool),
 	}
 }
 

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
 func TestWithStreamingRequestBody_SetsStreamFlag(t *testing.T) {
@@ -51,7 +53,7 @@ func TestTransformSSEChunkToOpenAI_TextStream(t *testing.T) {
 	}
 	chunk := buildAnthropicSSE(events...)
 
-	out, done, err := TransformSSEChunkToOpenAI([]byte(chunk), state, "claude-sonnet-4-5")
+	out, done, err := TransformSSEChunkToOpenAI([]byte(chunk), state, "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
 	assert.True(t, done)
 	assert.Contains(t, string(out), "data: ")
@@ -75,7 +77,7 @@ func TestTransformSSEChunkToOpenAI_ToolUseStream(t *testing.T) {
 	}
 	chunk := buildAnthropicSSE(events...)
 
-	out, done, err := TransformSSEChunkToOpenAI([]byte(chunk), state, "claude-sonnet-4-5")
+	out, done, err := TransformSSEChunkToOpenAI([]byte(chunk), state, "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
 	assert.True(t, done)
 	body := string(out)
@@ -92,15 +94,121 @@ func TestTransformSSEChunkToOpenAI_AccumulatesToolArguments(t *testing.T) {
 		`{"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
 		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}`,
 	)
-	_, _, err := TransformSSEChunkToOpenAI([]byte(start), state, "claude-sonnet-4-5")
+	_, _, err := TransformSSEChunkToOpenAI([]byte(start), state, "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
 
 	delta := buildAnthropicSSE(
 		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Paris\"}"}}`,
 	)
-	out, _, err := TransformSSEChunkToOpenAI([]byte(delta), state, "claude-sonnet-4-5")
+	out, _, err := TransformSSEChunkToOpenAI([]byte(delta), state, "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "Paris")
+}
+
+// TestTransformSSEChunkToOpenAI_ThinkingBlockStart asserts that an
+// Anthropic content_block_start with type "thinking" surfaces a
+// reasoning_content bootstrap on the OpenAI envelope instead of being
+// silently dropped (pre-fix behavior).
+func TestTransformSSEChunkToOpenAI_ThinkingBlockStart(t *testing.T) {
+	state := NewStreamState()
+	events := buildAnthropicSSE(
+		`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+	)
+	out, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"reasoning_content"`)
+	assert.True(t, state.BlockIndexToThinkingActive[0], "block index should be tracked as thinking")
+}
+
+// TestTransformSSEChunkToOpenAI_ThinkingDelta asserts that thinking_delta
+// events emit reasoning_content with the delta text.
+func TestTransformSSEChunkToOpenAI_ThinkingDelta(t *testing.T) {
+	state := NewStreamState()
+	events := buildAnthropicSSE(
+		`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think about this..."}}`,
+	)
+	out, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, `"reasoning_content":"Let me think about this..."`)
+}
+
+// TestTransformSSEChunkToOpenAI_ThinkingDelta_WithoutBlockStart_Drops
+// asserts that thinking_delta events arriving without a preceding
+// content_block_start are dropped (cannot be routed to a block).
+func TestTransformSSEChunkToOpenAI_ThinkingDelta_WithoutBlockStart_Drops(t *testing.T) {
+	state := NewStreamState()
+	events := buildAnthropicSSE(
+		`{"type":"content_block_delta","index":7,"delta":{"type":"thinking_delta","thinking":"orphan"}}`,
+	)
+	out, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "orphan")
+}
+
+// TestTransformSSEChunkToOpenAI_SignatureDelta asserts that signature_delta
+// events capture the signature into IRExtensions.ThinkingSignatures.
+func TestTransformSSEChunkToOpenAI_SignatureDelta(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{}
+	events := buildAnthropicSSE(
+		`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_abc123"}}`,
+	)
+	_, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", ext)
+	require.NoError(t, err)
+	assert.Equal(t, "sig_abc123", ext.ThinkingSignatures["content[0]"])
+}
+
+// TestTransformSSEChunkToOpenAI_SignatureDelta_NilExt_NoPanic asserts
+// that the existing OpenAI-client cell (which passes nil ext) is
+// unaffected by signature_delta events.
+func TestTransformSSEChunkToOpenAI_SignatureDelta_NilExt_NoPanic(t *testing.T) {
+	state := NewStreamState()
+	events := buildAnthropicSSE(
+		`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_xyz"}}`,
+	)
+	out, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "sig_xyz", "signature should not leak onto OpenAI stream")
+}
+
+// TestTransformSSEChunkToOpenAI_ErrorEvent asserts that an
+// `event: error` SSE line surfaces as an OpenAI chunk carrying both the
+// error message in delta.content and finish_reason="error" — instead of
+// being silently dropped (pre-fix behavior).
+func TestTransformSSEChunkToOpenAI_ErrorEvent(t *testing.T) {
+	state := NewStreamState()
+	raw := "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"upstream is overloaded\"}}\n\n"
+	out, _, err := TransformSSEChunkToOpenAI([]byte(raw), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, "overloaded_error")
+	assert.Contains(t, body, "upstream is overloaded")
+	assert.Contains(t, body, `"finish_reason":"error"`)
+}
+
+// TestTransformSSEChunkToOpenAI_ErrorEvent_NoHeader asserts that an error
+// payload sent without an `event: error` header (some transports) is
+// still surfaced via the MessageStreamEventUnion error type arm.
+func TestTransformSSEChunkToOpenAI_ErrorEvent_NoHeader(t *testing.T) {
+	state := NewStreamState()
+	raw := "data: {\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"slow down\"}}\n\n"
+	out, _, err := TransformSSEChunkToOpenAI([]byte(raw), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, "rate_limit_error")
+	assert.Contains(t, body, "slow down")
+}
+
+func TestExtractSSEDataLines_TracksEventHeader(t *testing.T) {
+	raw := "event: error\ndata: {\"type\":\"error\"}\n\nevent: message_start\ndata: {\"type\":\"message_start\"}\n\n"
+	lines := extractSSEDataLines([]byte(raw))
+	require.Len(t, lines, 2)
+	assert.True(t, lines[0].IsError, "first line should be tagged as error")
+	assert.False(t, lines[1].IsError, "second line should not be tagged after blank-line reset")
 }
 
 func buildAnthropicSSE(events ...string) string {

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -272,6 +272,40 @@ func TestTransformSSEChunkToOpenAI_StandardStopReasonNotCaptured(t *testing.T) {
 	assert.Empty(t, ext.AnthropicStopReason, "mappable stop_reason should round-trip via standard mapping")
 }
 
+// TestTransformSSEChunkToOpenAI_RefusalCaptured asserts that a streaming
+// Anthropic response with stop_reason "refusal" is captured onto ext so
+// the outbound emitter can surface it verbatim. Before this fix only
+// pause_turn was captured; refusal fell through to the default arm
+// (mapped to "stop") and was lost on round-trips.
+func TestTransformSSEChunkToOpenAI_RefusalCaptured(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{}
+	events := buildAnthropicSSE(
+		`{"type":"message_delta","delta":{"stop_reason":"refusal","stop_sequence":null},"usage":{"output_tokens":12}}`,
+	)
+	_, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", ext)
+	require.NoError(t, err)
+	assert.Equal(t, "refusal", ext.AnthropicStopReason, "refusal must be captured into ext")
+	assert.Empty(t, ext.AnthropicStopSequence, "stop_sequence string must be empty for refusal")
+}
+
+// TestTransformSSEChunkToOpenAI_StopSequenceCaptured asserts that a
+// streaming response with stop_reason "stop_sequence" captures both the
+// reason and the stop_sequence string onto ext. The non-streaming sibling
+// (captureAnthropicStopReasonIntoExt) captures the string; streaming must
+// now match.
+func TestTransformSSEChunkToOpenAI_StopSequenceCaptured(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{}
+	events := buildAnthropicSSE(
+		`{"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"DONE"},"usage":{"output_tokens":8}}`,
+	)
+	_, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", ext)
+	require.NoError(t, err)
+	assert.Equal(t, "stop_sequence", ext.AnthropicStopReason, "stop_sequence reason must be captured")
+	assert.Equal(t, "DONE", ext.AnthropicStopSequence, "stop_sequence string must be captured")
+}
+
 func TestExtractSSEDataLines_TracksEventHeader(t *testing.T) {
 	raw := "event: error\ndata: {\"type\":\"error\"}\n\nevent: message_start\ndata: {\"type\":\"message_start\"}\n\n"
 	lines := extractSSEDataLines([]byte(raw))

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -13,6 +13,31 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
+// TestNewStreamState_InitializesOutboundFields asserts that
+// NewStreamState allocates the outbound-direction maps and leaves the
+// outbound bookkeeping flags at zero values so the symmetric emitter can
+// rely on them being non-nil and false on the first chunk.
+func TestNewStreamState_InitializesOutboundFields(t *testing.T) {
+	state := NewStreamState()
+
+	// Inbound maps remain allocated as before.
+	require.NotNil(t, state.BlockIndexToToolIdx)
+	require.NotNil(t, state.BlockIndexToThinkingActive)
+
+	// Outbound maps are allocated so the emitter can write without a
+	// nil-map panic on first use.
+	require.NotNil(t, state.ToolIdxToBlockIndex)
+	require.NotNil(t, state.ToolUseEmittedStart)
+
+	// Outbound bookkeeping starts unset.
+	assert.False(t, state.MessageStartSent)
+	assert.False(t, state.MessageStopSent)
+	assert.Equal(t, int64(0), state.NextBlockIndex)
+	assert.Nil(t, state.OpenTextBlockIndex)
+	assert.Nil(t, state.OpenThinkingBlockIdx)
+	assert.True(t, state.LastChunkAt.IsZero())
+}
+
 func TestWithStreamingRequestBody_SetsStreamFlag(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		Model:    "claude-sonnet-4-5",

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -27,7 +27,6 @@ func TestNewStreamState_InitializesOutboundFields(t *testing.T) {
 	// Outbound maps are allocated so the emitter can write without a
 	// nil-map panic on first use.
 	require.NotNil(t, state.ToolIdxToBlockIndex)
-	require.NotNil(t, state.ToolUseEmittedStart)
 
 	// Outbound bookkeeping starts unset.
 	assert.False(t, state.MessageStartSent)

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -228,6 +228,51 @@ func TestTransformSSEChunkToOpenAI_ErrorEvent_NoHeader(t *testing.T) {
 	assert.Contains(t, body, "slow down")
 }
 
+// TestTransformSSEChunkToOpenAI_CapturesInitialUsage asserts that
+// the inbound translator captures the message_start.usage block onto
+// state.InitialUsage so the outbound emitter can echo it on its
+// synthesized message_start event during round-trips.
+func TestTransformSSEChunkToOpenAI_CapturesInitialUsage(t *testing.T) {
+	state := NewStreamState()
+	events := buildAnthropicSSE(
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":42,"output_tokens":1,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}}`,
+	)
+	_, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), state.InitialUsage.InputTokens)
+	assert.Equal(t, int64(10), state.InitialUsage.CacheReadInputTokens)
+	assert.Equal(t, int64(5), state.InitialUsage.CacheCreationInputTokens)
+}
+
+// TestTransformSSEChunkToOpenAI_AnthropicOnlyStopReason asserts that
+// pause_turn round-trips through IRExtensions because the OpenAI
+// finish_reason alphabet has no equivalent.
+func TestTransformSSEChunkToOpenAI_AnthropicOnlyStopReason(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{}
+	events := buildAnthropicSSE(
+		`{"type":"message_delta","delta":{"stop_reason":"pause_turn","stop_sequence":null},"usage":{"output_tokens":50}}`,
+	)
+	_, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", ext)
+	require.NoError(t, err)
+	assert.Equal(t, "pause_turn", ext.AnthropicStopReason)
+}
+
+// TestTransformSSEChunkToOpenAI_StandardStopReasonNotCaptured asserts
+// that mappable stop reasons (end_turn, tool_use, etc.) are NOT
+// stashed onto ext — only the Anthropic-only ones need the round-trip
+// because the mappable ones survive OpenAI normalization.
+func TestTransformSSEChunkToOpenAI_StandardStopReasonNotCaptured(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{}
+	events := buildAnthropicSSE(
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":50}}`,
+	)
+	_, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", ext)
+	require.NoError(t, err)
+	assert.Empty(t, ext.AnthropicStopReason, "mappable stop_reason should round-trip via standard mapping")
+}
+
 func TestExtractSSEDataLines_TracksEventHeader(t *testing.T) {
 	raw := "event: error\ndata: {\"type\":\"error\"}\n\nevent: message_start\ndata: {\"type\":\"message_start\"}\n\n"
 	lines := extractSSEDataLines([]byte(raw))

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -141,7 +141,11 @@ func TestTransformSSEChunkToOpenAI_ThinkingBlockStart(t *testing.T) {
 	out, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(out), `"reasoning_content"`)
-	assert.True(t, state.BlockIndexToThinkingActive[0], "block index should be tracked as thinking")
+	// Assert the key is present before asserting its value: a bare map
+	// read returns the bool zero value, so a missing key would silently
+	// pass assert.True's negation. require.Contains fails loudly instead.
+	require.Contains(t, state.BlockIndexToThinkingActive, int64(0), "block index 0 must be tracked as thinking")
+	assert.True(t, state.BlockIndexToThinkingActive[0], "block index 0 should be marked thinking-active")
 }
 
 // TestTransformSSEChunkToOpenAI_ThinkingDelta asserts that thinking_delta

--- a/src/semantic-router/pkg/anthropic/sse_out.go
+++ b/src/semantic-router/pkg/anthropic/sse_out.go
@@ -1,0 +1,589 @@
+// Anthropic outbound emitter: streaming response shape.
+//
+// EmitAnthropicSSEChunk is the symmetric counterpart to
+// TransformSSEChunkToOpenAI in client_stream.go. It walks the OpenAI
+// chat.completion.chunk SSE stream that vsr's response pipeline
+// produces and re-emits each delta as the corresponding Anthropic SSE
+// event sequence — message_start, content_block_start,
+// content_block_delta (text_delta / input_json_delta / thinking_delta /
+// signature_delta), content_block_stop, message_delta, message_stop —
+// so an Anthropic-SDK client can consume the byte stream without
+// translation.
+//
+// # State machine
+//
+// The emitter is driven by the StreamState struct in client_stream.go.
+// Outbound bookkeeping tracks which Anthropic content_block index is
+// currently open (OpenTextBlockIndex / OpenThinkingBlockIdx /
+// ToolIdxToBlockIndex), whether message_start / message_stop have been
+// emitted, and when the last chunk arrived (for the ping ticker
+// elsewhere). Anthropic strictness requires that every
+// content_block_start is paired with a content_block_stop before
+// message_delta, and that two distinct block types never share the same
+// block index — the open-block pointers enforce both invariants.
+//
+// # Tool_use accumulation
+//
+// OpenAI tool-call deltas arrive as repeated entries for the same
+// tool_calls[i] index, with id/name on the first delta and
+// function.arguments fragments on subsequent deltas. The first delta
+// for index i opens a new Anthropic content_block_start with type
+// tool_use, id, name, and input: {}. Subsequent argument fragments
+// stream as content_block_delta events of type input_json_delta. The
+// Anthropic SDK accumulator concatenates partial_json fragments and
+// overwrites the {} placeholder at content_block_stop.
+//
+// # Thinking blocks
+//
+// Thinking content reaches this emitter as delta.reasoning_content on
+// the OpenAI envelope (PR #1718 convention; the streaming bug-fix
+// commit in this stack populates that field from upstream
+// thinking_delta events). Signatures are stashed in
+// IRExtensions.ThinkingSignatures by the inbound translator and
+// replayed here as content_block_delta of type signature_delta keyed
+// by Anthropic block index.
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+// EmitAnthropicSSEChunk converts one OpenAI chat.completion.chunk SSE
+// payload (the bytes Envoy hands to the response-body callback) into
+// the corresponding Anthropic SSE event sequence.
+//
+// Contract:
+//   - state must be the same per-request *StreamState across calls.
+//   - Returns (sseBytes, streamDone, err). streamDone is true after the
+//     terminal message_stop event has been emitted.
+//   - Tolerates a nil ext (zero cache/server-tool counters; no
+//     Anthropic-only stop reasons; no thinking signatures).
+//   - The OpenAI "data: [DONE]" marker is consumed and never echoed
+//     onto the wire — message_stop is its Anthropic equivalent and is
+//     emitted in response to the prior chunk's finish_reason.
+//   - Never emits a content_block_start without a paired
+//     content_block_stop before the terminal message_delta.
+func EmitAnthropicSSEChunk(
+	openAIChunk []byte,
+	state *StreamState,
+	ext *ir.IRExtensions,
+	model string,
+) ([]byte, bool, error) {
+	if state == nil {
+		state = NewStreamState()
+	}
+
+	var out bytes.Buffer
+	streamDone := false
+	for _, line := range extractSSEDataLines(openAIChunk) {
+		// Inbound error event surfaces here too because the OpenAI
+		// envelope inherits the upstream error flag from
+		// extractSSEDataLines. Emit a spec-compliant Anthropic error
+		// event followed by a terminal message_stop so the client
+		// observes a clean stream end.
+		if line.IsError {
+			out.Write(emitAnthropicError("api_error", string(line.Data)))
+			out.Write(emitMessageStop())
+			state.MessageStopSent = true
+			streamDone = true
+			continue
+		}
+
+		var chunk openai.ChatCompletionChunk
+		if err := json.Unmarshal(line.Data, &chunk); err != nil {
+			// Skip malformed chunks rather than aborting the stream;
+			// the SSE format already allows non-data lines.
+			continue
+		}
+
+		events, done, err := emitChunkEvents(chunk, state, ext, model)
+		if err != nil {
+			return nil, false, err
+		}
+		out.Write(events)
+		if done {
+			streamDone = true
+		}
+	}
+	return out.Bytes(), streamDone, nil
+}
+
+// emitChunkEvents handles one parsed OpenAI chunk by driving the
+// outbound state machine described at the top of this file.
+func emitChunkEvents(
+	chunk openai.ChatCompletionChunk,
+	state *StreamState,
+	ext *ir.IRExtensions,
+	model string,
+) ([]byte, bool, error) {
+	var out bytes.Buffer
+
+	if !state.MessageStartSent {
+		// Capture the upstream message ID if present so the emitted
+		// message_start carries an identifier the client can use for
+		// correlation.
+		if state.MessageID == "" && chunk.ID != "" {
+			state.MessageID = chunk.ID
+		}
+		out.Write(emitMessageStart(state, model))
+		state.MessageStartSent = true
+	}
+
+	if len(chunk.Choices) == 0 {
+		// Usage-only chunks (no choices) still drive the terminal
+		// emission if usage arrived after finish_reason on a prior
+		// chunk. Without choices there is nothing else to emit.
+		return out.Bytes(), false, nil
+	}
+	choice := chunk.Choices[0]
+	delta := choice.Delta
+
+	// Reasoning content opens or extends a thinking block. Always
+	// processed first so it precedes text/tool blocks at the same
+	// chunk's wire position (Anthropic spec orders thinking before
+	// text/tool_use).
+	if reasoning := openAIDeltaReasoning(delta); reasoning != "" {
+		out.Write(emitThinkingDelta(state, reasoning))
+	}
+
+	if delta.Content != "" {
+		out.Write(emitTextDelta(state, delta.Content))
+	}
+
+	for _, tc := range delta.ToolCalls {
+		out.Write(emitToolCallDelta(state, tc))
+	}
+
+	out.Write(replayPendingSignature(state, ext))
+
+	if isTerminalChunk(choice.FinishReason, chunk) {
+		out.Write(emitTerminalEvents(state, choice.FinishReason, chunk.Usage, ext))
+		return out.Bytes(), true, nil
+	}
+
+	return out.Bytes(), false, nil
+}
+
+// replayPendingSignature emits a signature_delta if a signature for
+// the currently-open thinking block was captured by the inbound
+// translator. Reuses the same thinkingBlockKey helper as the inbound
+// side so a streaming round-trip preserves the per-block signature
+// without double-storage. The signature is consumed (removed from ext)
+// after replay so subsequent chunks for the same block do not re-emit.
+func replayPendingSignature(state *StreamState, ext *ir.IRExtensions) []byte {
+	if ext == nil || state.OpenThinkingBlockIdx == nil {
+		return nil
+	}
+	key := thinkingBlockKey(*state.OpenThinkingBlockIdx)
+	sig, ok := ext.ThinkingSignatures[key]
+	if !ok || sig == "" {
+		return nil
+	}
+	delete(ext.ThinkingSignatures, key)
+	return emitSignatureDelta(state, sig)
+}
+
+// isTerminalChunk reports whether an OpenAI chunk should trigger the
+// terminal Anthropic event sequence (close blocks, message_delta,
+// message_stop). OpenAI providers may surface finish_reason and usage
+// on the same chunk or on separate chunks; either signal terminates.
+func isTerminalChunk(finishReason string, chunk openai.ChatCompletionChunk) bool {
+	return finishReason != "" || chunkHasUsage(chunk)
+}
+
+// emitTerminalEvents closes any open content blocks then emits the
+// terminal message_delta + message_stop pair. Marks the state as
+// done so callers can stop the ping ticker.
+func emitTerminalEvents(state *StreamState, finishReason string, usage openai.CompletionUsage, ext *ir.IRExtensions) []byte {
+	var buf bytes.Buffer
+	buf.Write(closeAllOpenBlocks(state))
+	buf.Write(emitMessageDelta(finishReason, usage, ext))
+	buf.Write(emitMessageStop())
+	state.MessageStopSent = true
+	return buf.Bytes()
+}
+
+// emitMessageStart returns the bytes for an Anthropic message_start
+// event carrying an empty content array and a placeholder usage shape.
+// The cumulative message_delta.usage event at end-of-stream supplies
+// the real counts.
+func emitMessageStart(state *StreamState, model string) []byte {
+	usage := state.InitialUsage
+	// Per Anthropic spec the initial usage carries input_tokens (known
+	// up front) plus output_tokens: 1 as a placeholder so clients can
+	// initialize accumulators.
+	if usage.OutputTokens == 0 {
+		usage.OutputTokens = 1
+	}
+	payload := map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id":            state.MessageID,
+			"type":          "message",
+			"role":          "assistant",
+			"model":         model,
+			"content":       []any{},
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage":         usage,
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("message_start", data)
+}
+
+// emitTextDelta opens a text block if none is currently open and emits
+// a content_block_delta carrying the text. Any open thinking or tool
+// block is closed first to maintain Anthropic's invariant that one
+// block type owns each block index.
+func emitTextDelta(state *StreamState, text string) []byte {
+	var buf bytes.Buffer
+	if state.OpenTextBlockIndex == nil {
+		buf.Write(closeNonTextBlocks(state))
+		idx := state.NextBlockIndex
+		state.NextBlockIndex++
+		state.OpenTextBlockIndex = &idx
+		buf.Write(emitContentBlockStartText(idx))
+	}
+	buf.Write(emitContentBlockDeltaText(*state.OpenTextBlockIndex, text))
+	return buf.Bytes()
+}
+
+// emitThinkingDelta opens a thinking block if none is currently open
+// and emits a content_block_delta carrying the reasoning text. Any
+// open text or tool block is closed first.
+func emitThinkingDelta(state *StreamState, reasoning string) []byte {
+	var buf bytes.Buffer
+	if state.OpenThinkingBlockIdx == nil {
+		buf.Write(closeNonThinkingBlocks(state))
+		idx := state.NextBlockIndex
+		state.NextBlockIndex++
+		state.OpenThinkingBlockIdx = &idx
+		buf.Write(emitContentBlockStartThinking(idx))
+	}
+	buf.Write(emitContentBlockDeltaThinking(*state.OpenThinkingBlockIdx, reasoning))
+	return buf.Bytes()
+}
+
+// emitSignatureDelta emits a signature_delta for the currently-open
+// thinking block, then closes that block. Anthropic clients expect the
+// signature as the final delta of a thinking block.
+func emitSignatureDelta(state *StreamState, signature string) []byte {
+	if state.OpenThinkingBlockIdx == nil {
+		return nil
+	}
+	var buf bytes.Buffer
+	buf.Write(emitContentBlockDeltaSignature(*state.OpenThinkingBlockIdx, signature))
+	buf.Write(emitContentBlockStop(*state.OpenThinkingBlockIdx))
+	state.OpenThinkingBlockIdx = nil
+	return buf.Bytes()
+}
+
+// emitToolCallDelta opens a tool_use block on the first delta for a
+// given tool index and emits input_json_delta for any argument
+// fragment. The block stays open until closeAllOpenBlocks is called at
+// stream termination.
+func emitToolCallDelta(state *StreamState, tc openai.ChatCompletionChunkChoiceDeltaToolCall) []byte {
+	toolIdx := int(tc.Index)
+	var buf bytes.Buffer
+	blockIdx, seen := state.ToolIdxToBlockIndex[toolIdx]
+	if !seen {
+		buf.Write(closeNonToolBlocks(state))
+		blockIdx = state.NextBlockIndex
+		state.NextBlockIndex++
+		state.ToolIdxToBlockIndex[toolIdx] = blockIdx
+		buf.Write(emitContentBlockStartToolUse(blockIdx, tc.ID, tc.Function.Name))
+		state.ToolUseEmittedStart[toolIdx] = true
+	}
+	if tc.Function.Arguments != "" {
+		buf.Write(emitContentBlockDeltaInputJSON(blockIdx, tc.Function.Arguments))
+	}
+	return buf.Bytes()
+}
+
+// closeAllOpenBlocks emits content_block_stop for every block currently
+// tracked as open and clears the bookkeeping. Called once at stream
+// termination before message_delta / message_stop.
+func closeAllOpenBlocks(state *StreamState) []byte {
+	var buf bytes.Buffer
+	if state.OpenTextBlockIndex != nil {
+		buf.Write(emitContentBlockStop(*state.OpenTextBlockIndex))
+		state.OpenTextBlockIndex = nil
+	}
+	if state.OpenThinkingBlockIdx != nil {
+		buf.Write(emitContentBlockStop(*state.OpenThinkingBlockIdx))
+		state.OpenThinkingBlockIdx = nil
+	}
+	for toolIdx, blockIdx := range state.ToolIdxToBlockIndex {
+		buf.Write(emitContentBlockStop(blockIdx))
+		delete(state.ToolIdxToBlockIndex, toolIdx)
+		delete(state.ToolUseEmittedStart, toolIdx)
+	}
+	return buf.Bytes()
+}
+
+// closeNonTextBlocks closes any open thinking or tool blocks before
+// opening a new text block.
+func closeNonTextBlocks(state *StreamState) []byte {
+	var buf bytes.Buffer
+	if state.OpenThinkingBlockIdx != nil {
+		buf.Write(emitContentBlockStop(*state.OpenThinkingBlockIdx))
+		state.OpenThinkingBlockIdx = nil
+	}
+	for toolIdx, blockIdx := range state.ToolIdxToBlockIndex {
+		buf.Write(emitContentBlockStop(blockIdx))
+		delete(state.ToolIdxToBlockIndex, toolIdx)
+		delete(state.ToolUseEmittedStart, toolIdx)
+	}
+	return buf.Bytes()
+}
+
+// closeNonThinkingBlocks closes any open text or tool blocks before
+// opening a new thinking block.
+func closeNonThinkingBlocks(state *StreamState) []byte {
+	var buf bytes.Buffer
+	if state.OpenTextBlockIndex != nil {
+		buf.Write(emitContentBlockStop(*state.OpenTextBlockIndex))
+		state.OpenTextBlockIndex = nil
+	}
+	for toolIdx, blockIdx := range state.ToolIdxToBlockIndex {
+		buf.Write(emitContentBlockStop(blockIdx))
+		delete(state.ToolIdxToBlockIndex, toolIdx)
+		delete(state.ToolUseEmittedStart, toolIdx)
+	}
+	return buf.Bytes()
+}
+
+// closeNonToolBlocks closes any open text or thinking block before
+// opening a new tool block.
+func closeNonToolBlocks(state *StreamState) []byte {
+	var buf bytes.Buffer
+	if state.OpenTextBlockIndex != nil {
+		buf.Write(emitContentBlockStop(*state.OpenTextBlockIndex))
+		state.OpenTextBlockIndex = nil
+	}
+	if state.OpenThinkingBlockIdx != nil {
+		buf.Write(emitContentBlockStop(*state.OpenThinkingBlockIdx))
+		state.OpenThinkingBlockIdx = nil
+	}
+	return buf.Bytes()
+}
+
+// emitContentBlockStartText returns the bytes for a content_block_start
+// of type text at the given index.
+func emitContentBlockStartText(idx int64) []byte {
+	payload := map[string]any{
+		"type":  "content_block_start",
+		"index": idx,
+		"content_block": map[string]any{
+			"type": "text",
+			"text": "",
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_start", data)
+}
+
+// emitContentBlockStartToolUse returns the bytes for a
+// content_block_start of type tool_use. Anthropic spec requires the
+// input field to be present; an empty object {} is the canonical
+// placeholder for "real value arrives via input_json_delta events".
+func emitContentBlockStartToolUse(idx int64, id, name string) []byte {
+	payload := map[string]any{
+		"type":  "content_block_start",
+		"index": idx,
+		"content_block": map[string]any{
+			"type":  "tool_use",
+			"id":    id,
+			"name":  name,
+			"input": map[string]any{},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_start", data)
+}
+
+// emitContentBlockStartThinking returns the bytes for a
+// content_block_start of type thinking with an empty thinking string.
+func emitContentBlockStartThinking(idx int64) []byte {
+	payload := map[string]any{
+		"type":  "content_block_start",
+		"index": idx,
+		"content_block": map[string]any{
+			"type":     "thinking",
+			"thinking": "",
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_start", data)
+}
+
+// emitContentBlockDeltaText returns a content_block_delta carrying a
+// text_delta.
+func emitContentBlockDeltaText(idx int64, text string) []byte {
+	payload := map[string]any{
+		"type":  "content_block_delta",
+		"index": idx,
+		"delta": map[string]any{
+			"type": "text_delta",
+			"text": text,
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_delta", data)
+}
+
+// emitContentBlockDeltaThinking returns a content_block_delta carrying
+// a thinking_delta.
+func emitContentBlockDeltaThinking(idx int64, thinking string) []byte {
+	payload := map[string]any{
+		"type":  "content_block_delta",
+		"index": idx,
+		"delta": map[string]any{
+			"type":     "thinking_delta",
+			"thinking": thinking,
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_delta", data)
+}
+
+// emitContentBlockDeltaSignature returns a content_block_delta carrying
+// a signature_delta.
+func emitContentBlockDeltaSignature(idx int64, signature string) []byte {
+	payload := map[string]any{
+		"type":  "content_block_delta",
+		"index": idx,
+		"delta": map[string]any{
+			"type":      "signature_delta",
+			"signature": signature,
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_delta", data)
+}
+
+// emitContentBlockDeltaInputJSON returns a content_block_delta carrying
+// an input_json_delta fragment for a tool_use block.
+func emitContentBlockDeltaInputJSON(idx int64, partialJSON string) []byte {
+	payload := map[string]any{
+		"type":  "content_block_delta",
+		"index": idx,
+		"delta": map[string]any{
+			"type":         "input_json_delta",
+			"partial_json": partialJSON,
+		},
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_delta", data)
+}
+
+// emitContentBlockStop returns a content_block_stop at the given index.
+func emitContentBlockStop(idx int64) []byte {
+	payload := map[string]any{
+		"type":  "content_block_stop",
+		"index": idx,
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("content_block_stop", data)
+}
+
+// emitMessageDelta returns the terminal message_delta carrying the
+// final stop_reason / stop_sequence / cumulative usage. Reuses PR4's
+// helpers so streaming and non-streaming output are byte-identical for
+// the same upstream signal.
+func emitMessageDelta(finishReason string, usage openai.CompletionUsage, ext *ir.IRExtensions) []byte {
+	stopReason, stopSequence := mapOpenAIFinishReasonToAnthropic(finishReason, ext)
+	anthropicUsage := buildAnthropicUsage(usage, ext)
+
+	payload := map[string]any{
+		"type": "message_delta",
+		"delta": map[string]any{
+			"stop_reason":   stopReason,
+			"stop_sequence": stopSequence,
+		},
+		"usage": anthropicUsage,
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("message_delta", data)
+}
+
+// emitMessageStop returns the terminal message_stop event.
+func emitMessageStop() []byte {
+	payload := map[string]any{
+		"type": "message_stop",
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("message_stop", data)
+}
+
+// emitAnthropicError emits an error event in Anthropic SSE shape.
+// Reuses the same envelope used by the non-streaming emitter so error
+// payloads are structurally identical across the two cells.
+func emitAnthropicError(errorType, message string) []byte {
+	envelope := anthropicErrorEnvelope{
+		Type: "error",
+		Error: anthropicErrorDetail{
+			Type:    errorType,
+			Message: message,
+		},
+	}
+	data, _ := json.Marshal(envelope)
+	return formatAnthropicSSEEvent("error", data)
+}
+
+// EmitAnthropicPingEvent returns the bytes for a single ping event.
+// Consumed by the keepalive ticker in the extproc dispatcher.
+func EmitAnthropicPingEvent() []byte {
+	payload := map[string]any{
+		"type": "ping",
+	}
+	data, _ := json.Marshal(payload)
+	return formatAnthropicSSEEvent("ping", data)
+}
+
+// formatAnthropicSSEEvent renders one named SSE event in the wire shape
+// Anthropic uses: "event: <name>\ndata: <json>\n\n". The named event
+// header is what distinguishes Anthropic SSE from the OpenAI shape
+// (which uses bare data: lines).
+func formatAnthropicSSEEvent(eventName string, payload []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("event: ")
+	buf.WriteString(eventName)
+	buf.WriteByte('\n')
+	buf.WriteString("data: ")
+	buf.Write(payload)
+	buf.WriteString("\n\n")
+	return buf.Bytes()
+}
+
+// chunkHasUsage returns true when an OpenAI chunk carries a non-zero
+// usage object. OpenAI streams may put usage on a chunk separate from
+// the one carrying finish_reason, so the emitter treats either as
+// "this is the terminal signal".
+func chunkHasUsage(chunk openai.ChatCompletionChunk) bool {
+	u := chunk.Usage
+	return u.PromptTokens != 0 || u.CompletionTokens != 0 || u.TotalTokens != 0
+}
+
+// openAIDeltaReasoning extracts the non-standard reasoning_content
+// field from an OpenAI chunk delta. The OpenAI Go SDK preserves
+// unknown fields in delta.JSON.ExtraFields; vsr's convention (matching
+// PR #1718 on the non-streaming side) reads it from there. Returns
+// the empty string when the delta carries no reasoning_content.
+func openAIDeltaReasoning(delta openai.ChatCompletionChunkChoiceDelta) string {
+	extra, ok := delta.JSON.ExtraFields["reasoning_content"]
+	if !ok {
+		return ""
+	}
+	var reasoning string
+	if err := json.Unmarshal([]byte(extra.Raw()), &reasoning); err != nil {
+		return ""
+	}
+	return reasoning
+}

--- a/src/semantic-router/pkg/anthropic/sse_out.go
+++ b/src/semantic-router/pkg/anthropic/sse_out.go
@@ -151,9 +151,17 @@ func emitChunkEvents(
 	}
 
 	if len(chunk.Choices) == 0 {
-		// Usage-only chunks (no choices) still drive the terminal
-		// emission if usage arrived after finish_reason on a prior
-		// chunk. Without choices there is nothing else to emit.
+		// Usage-only chunk (no choices). If it carries usage and no prior
+		// chunk has already driven the terminal sequence, treat it as the
+		// terminal chunk so message_stop still fires — otherwise an Anthropic
+		// client would hang waiting for an end event. In the common path the
+		// finish_reason chunk already sent message_stop (caught by the
+		// MessageStopSent guard above), so this only fires when usage is the
+		// sole terminal signal. With no choices there is nothing else to emit.
+		if chunkHasUsage(chunk) {
+			out.Write(emitTerminalEvents(state, "", chunk.Usage, ext))
+			return out.Bytes(), true, nil
+		}
 		return out.Bytes(), false, nil
 	}
 	choice := chunk.Choices[0]

--- a/src/semantic-router/pkg/anthropic/sse_out.go
+++ b/src/semantic-router/pkg/anthropic/sse_out.go
@@ -47,6 +47,7 @@ package anthropic
 import (
 	"bytes"
 	"encoding/json"
+	"sort"
 
 	"github.com/openai/openai-go"
 
@@ -85,8 +86,14 @@ func EmitAnthropicSSEChunk(
 		// envelope inherits the upstream error flag from
 		// extractSSEDataLines. Emit a spec-compliant Anthropic error
 		// event followed by a terminal message_stop so the client
-		// observes a clean stream end.
+		// observes a clean stream end. Guard on MessageStopSent so a
+		// second error chunk (or an error chunk after a normal terminal)
+		// does not produce a duplicate message_stop.
 		if line.IsError {
+			if state.MessageStopSent {
+				streamDone = true
+				continue
+			}
 			out.Write(emitAnthropicError("api_error", string(line.Data)))
 			out.Write(emitMessageStop())
 			state.MessageStopSent = true
@@ -121,6 +128,15 @@ func emitChunkEvents(
 	ext *ir.IRExtensions,
 	model string,
 ) ([]byte, bool, error) {
+	// message_stop must fire exactly once. If a backend legally splits
+	// finish_reason and usage across two chunks, the second chunk also
+	// satisfies isTerminalChunk and would call emitTerminalEvents again.
+	// Return early so the caller sees (nil, true, nil) rather than a
+	// second message_stop on the wire.
+	if state.MessageStopSent {
+		return nil, true, nil
+	}
+
 	var out bytes.Buffer
 
 	if !state.MessageStartSent {
@@ -298,7 +314,6 @@ func emitToolCallDelta(state *StreamState, tc openai.ChatCompletionChunkChoiceDe
 		state.NextBlockIndex++
 		state.ToolIdxToBlockIndex[toolIdx] = blockIdx
 		buf.Write(emitContentBlockStartToolUse(blockIdx, tc.ID, tc.Function.Name))
-		state.ToolUseEmittedStart[toolIdx] = true
 	}
 	if tc.Function.Arguments != "" {
 		buf.Write(emitContentBlockDeltaInputJSON(blockIdx, tc.Function.Arguments))
@@ -309,6 +324,11 @@ func emitToolCallDelta(state *StreamState, tc openai.ChatCompletionChunkChoiceDe
 // closeAllOpenBlocks emits content_block_stop for every block currently
 // tracked as open and clears the bookkeeping. Called once at stream
 // termination before message_delta / message_stop.
+//
+// Tool blocks are closed in ascending block-index order to produce a
+// deterministic event sequence for streams with multiple concurrent
+// tool calls. Go map iteration order is non-deterministic; sorting by
+// block index (not tool index) matches Anthropic's content[] position.
 func closeAllOpenBlocks(state *StreamState) []byte {
 	var buf bytes.Buffer
 	if state.OpenTextBlockIndex != nil {
@@ -319,10 +339,18 @@ func closeAllOpenBlocks(state *StreamState) []byte {
 		buf.Write(emitContentBlockStop(*state.OpenThinkingBlockIdx))
 		state.OpenThinkingBlockIdx = nil
 	}
-	for toolIdx, blockIdx := range state.ToolIdxToBlockIndex {
-		buf.Write(emitContentBlockStop(blockIdx))
+	// Sort tool indices by their assigned block index so the wire order
+	// is stable regardless of Go's map iteration randomness.
+	toolIdxs := make([]int, 0, len(state.ToolIdxToBlockIndex))
+	for toolIdx := range state.ToolIdxToBlockIndex {
+		toolIdxs = append(toolIdxs, toolIdx)
+	}
+	sort.Slice(toolIdxs, func(i, j int) bool {
+		return state.ToolIdxToBlockIndex[toolIdxs[i]] < state.ToolIdxToBlockIndex[toolIdxs[j]]
+	})
+	for _, toolIdx := range toolIdxs {
+		buf.Write(emitContentBlockStop(state.ToolIdxToBlockIndex[toolIdx]))
 		delete(state.ToolIdxToBlockIndex, toolIdx)
-		delete(state.ToolUseEmittedStart, toolIdx)
 	}
 	return buf.Bytes()
 }
@@ -338,7 +366,6 @@ func closeNonTextBlocks(state *StreamState) []byte {
 	for toolIdx, blockIdx := range state.ToolIdxToBlockIndex {
 		buf.Write(emitContentBlockStop(blockIdx))
 		delete(state.ToolIdxToBlockIndex, toolIdx)
-		delete(state.ToolUseEmittedStart, toolIdx)
 	}
 	return buf.Bytes()
 }
@@ -354,7 +381,6 @@ func closeNonThinkingBlocks(state *StreamState) []byte {
 	for toolIdx, blockIdx := range state.ToolIdxToBlockIndex {
 		buf.Write(emitContentBlockStop(blockIdx))
 		delete(state.ToolIdxToBlockIndex, toolIdx)
-		delete(state.ToolUseEmittedStart, toolIdx)
 	}
 	return buf.Bytes()
 }

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -1,0 +1,227 @@
+package anthropic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+// buildOpenAISSE builds an OpenAI SSE byte stream from one or more
+// chunk JSON strings, in the wire shape vsr's response pipeline
+// produces.
+func buildOpenAISSE(chunks ...string) []byte {
+	var b strings.Builder
+	for _, c := range chunks {
+		b.WriteString("data: ")
+		b.WriteString(c)
+		b.WriteString("\n\n")
+	}
+	return []byte(b.String())
+}
+
+// TestEmitAnthropicSSEChunk_TextOnly asserts the minimal happy path:
+// one OpenAI chunk with text content followed by one chunk with
+// finish_reason produces the spec-correct Anthropic event sequence.
+func TestEmitAnthropicSSEChunk_TextOnly(t *testing.T) {
+	state := NewStreamState()
+	input := buildOpenAISSE(
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`,
+	)
+
+	out, done, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done)
+	body := string(out)
+
+	// Spec-correct event order.
+	startIdx := strings.Index(body, "event: message_start")
+	blockStartIdx := strings.Index(body, "event: content_block_start")
+	blockDeltaIdx := strings.Index(body, "event: content_block_delta")
+	blockStopIdx := strings.Index(body, "event: content_block_stop")
+	messageDeltaIdx := strings.Index(body, "event: message_delta")
+	messageStopIdx := strings.Index(body, "event: message_stop")
+
+	require.GreaterOrEqual(t, startIdx, 0, "message_start present")
+	require.Greater(t, blockStartIdx, startIdx, "content_block_start after message_start")
+	require.Greater(t, blockDeltaIdx, blockStartIdx, "content_block_delta after content_block_start")
+	require.Greater(t, blockStopIdx, blockDeltaIdx, "content_block_stop after deltas")
+	require.Greater(t, messageDeltaIdx, blockStopIdx, "message_delta after content_block_stop")
+	require.Greater(t, messageStopIdx, messageDeltaIdx, "message_stop last")
+
+	assert.Contains(t, body, `"text":"Hello"`)
+	assert.Contains(t, body, `"text":" world"`)
+	assert.Contains(t, body, `"stop_reason":"end_turn"`)
+	assert.True(t, state.MessageStartSent)
+	assert.True(t, state.MessageStopSent)
+}
+
+// TestEmitAnthropicSSEChunk_ToolUseAccumulation asserts that
+// fragmented tool-call argument deltas surface as repeated
+// input_json_delta events whose partial_json strings concatenate into
+// the original arguments.
+func TestEmitAnthropicSSEChunk_ToolUseAccumulation(t *testing.T) {
+	state := NewStreamState()
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"ci"}}]},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ty\":\"Paris\"}"}}]},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+	)
+
+	out, done, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done)
+	body := string(out)
+
+	assert.Contains(t, body, `"type":"tool_use"`)
+	assert.Contains(t, body, `"id":"call_1"`)
+	assert.Contains(t, body, `"name":"get_weather"`)
+	assert.Contains(t, body, `"partial_json":"{\"ci"`)
+	assert.Contains(t, body, `"partial_json":"ty\":\"Paris\"}"`)
+	assert.Contains(t, body, `"stop_reason":"tool_use"`)
+
+	// Exactly one content_block_start for the tool_use block.
+	assert.Equal(t, 1, strings.Count(body, "event: content_block_start"))
+}
+
+// TestEmitAnthropicSSEChunk_TextThenToolUse asserts that switching
+// content types within a stream closes the previous block before
+// opening the new one — a non-negotiable Anthropic spec invariant.
+func TestEmitAnthropicSSEChunk_TextThenToolUse(t *testing.T) {
+	state := NewStreamState()
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"thinking..."},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"f","arguments":"{}"}}]},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+
+	out, _, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+
+	// Two starts (text + tool_use), two stops.
+	assert.Equal(t, 2, strings.Count(body, "event: content_block_start"))
+	assert.Equal(t, 2, strings.Count(body, "event: content_block_stop"))
+
+	// The text content_block_stop appears before the tool_use
+	// content_block_start (no overlap).
+	firstStop := strings.Index(body, "event: content_block_stop")
+	toolStart := strings.Index(body, `"type":"tool_use"`)
+	assert.Less(t, firstStop, toolStart, "text block must close before tool_use opens")
+}
+
+// TestEmitAnthropicSSEChunk_ReasoningContent asserts that
+// reasoning_content on OpenAI delta surfaces as an Anthropic thinking
+// block. This is the round-trip half that goes with commit 1's
+// upstream thinking_delta → reasoning_content translation.
+func TestEmitAnthropicSSEChunk_ReasoningContent(t *testing.T) {
+	state := NewStreamState()
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"I should compute"},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"content":" the answer."},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":3,"total_tokens":6}}`,
+	)
+
+	out, _, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+
+	assert.Contains(t, body, `"type":"thinking"`)
+	assert.Contains(t, body, `"thinking":"I should compute"`)
+	assert.Contains(t, body, `"text":" the answer."`)
+
+	// Thinking block opens at index 0, text at index 1.
+	thinkingStart := strings.Index(body, `"type":"thinking"`)
+	textStart := strings.Index(body, `"type":"text"`)
+	assert.Less(t, thinkingStart, textStart, "thinking block precedes text per spec")
+}
+
+// TestEmitAnthropicSSEChunk_SignatureReplay asserts that signatures
+// captured by the inbound translator into IRExtensions are replayed as
+// signature_delta events on the outbound side, then the thinking block
+// is closed.
+func TestEmitAnthropicSSEChunk_SignatureReplay(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{
+		ThinkingSignatures: map[string]string{
+			thinkingBlockKey(0): "sig_xyz",
+		},
+	}
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"reasoning"},"finish_reason":null}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+
+	out, _, err := EmitAnthropicSSEChunk(input, state, ext, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+
+	assert.Contains(t, body, `"type":"signature_delta"`)
+	assert.Contains(t, body, `"signature":"sig_xyz"`)
+	// Signature is consumed (so we don't double-emit on later chunks).
+	_, stillPresent := ext.ThinkingSignatures[thinkingBlockKey(0)]
+	assert.False(t, stillPresent, "signature should be consumed after replay")
+}
+
+// TestEmitAnthropicSSEChunk_NilExt asserts the emitter tolerates a nil
+// ext gracefully — the existing OpenAI-client cell may call without
+// an IRExtensions sidecar.
+func TestEmitAnthropicSSEChunk_NilExt(t *testing.T) {
+	state := NewStreamState()
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+
+	out, done, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done)
+	assert.Contains(t, string(out), `"type":"text"`)
+}
+
+// TestEmitAnthropicSSEChunk_NilState asserts that a nil StreamState
+// is initialized rather than panicking, matching the inbound
+// translator's tolerance.
+func TestEmitAnthropicSSEChunk_NilState(t *testing.T) {
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+	out, done, err := EmitAnthropicSSEChunk(input, nil, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done)
+	assert.NotEmpty(t, out)
+}
+
+// TestEmitAnthropicSSEChunk_LengthFinish asserts length finish_reason
+// maps to max_tokens stop_reason on the wire.
+func TestEmitAnthropicSSEChunk_LengthFinish(t *testing.T) {
+	state := NewStreamState()
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"truncated"},"finish_reason":"length"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+	out, _, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"stop_reason":"max_tokens"`)
+}
+
+// TestEmitAnthropicPingEvent asserts the standalone ping helper emits
+// the spec-correct wire shape.
+func TestEmitAnthropicPingEvent(t *testing.T) {
+	out := string(EmitAnthropicPingEvent())
+	assert.Contains(t, out, "event: ping")
+	assert.Contains(t, out, `"type":"ping"`)
+	assert.True(t, strings.HasSuffix(out, "\n\n"), "SSE event must terminate with blank line")
+}
+
+// TestFormatAnthropicSSEEvent asserts the SSE framing helper produces
+// the wire shape Anthropic clients expect — event header, data line,
+// terminating blank line.
+func TestFormatAnthropicSSEEvent(t *testing.T) {
+	out := string(formatAnthropicSSEEvent("message_start", []byte(`{"type":"message_start"}`)))
+	assert.Equal(t, "event: message_start\ndata: {\"type\":\"message_start\"}\n\n", out)
+}

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -341,6 +341,35 @@ func TestEmitAnthropicSSEChunk_SplitFinishReasonAndUsage(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(combined, "event: message_stop"), "exactly one message_stop total across split chunks")
 }
 
+// TestEmitAnthropicSSEChunk_UsageOnlyTerminal covers a backend that ends
+// the stream with a usage-only chunk (no choices, no prior finish_reason).
+// The emitter must treat usage as the terminal signal and fire message_stop,
+// otherwise an Anthropic client hangs waiting for an end event. This differs
+// from SplitFinishReasonAndUsage, where finish_reason already drove the
+// terminal sequence and the usage chunk is a guarded no-op.
+func TestEmitAnthropicSSEChunk_UsageOnlyTerminal(t *testing.T) {
+	state := NewStreamState()
+
+	// Chunk 1: content only, no finish_reason.
+	chunk1 := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}]}`,
+	)
+	_, done1, err := EmitAnthropicSSEChunk(chunk1, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.False(t, done1, "content-only chunk must not end the stream")
+
+	// Chunk 2: usage-only terminal — empty choices, usage present, never a
+	// finish_reason. This is the sole terminal signal.
+	chunk2 := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`,
+	)
+	out2, done2, err := EmitAnthropicSSEChunk(chunk2, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done2, "usage-only terminal chunk must end the stream")
+	assert.Equal(t, 1, strings.Count(string(out2), "event: message_stop"), "usage-only terminal must emit exactly one message_stop")
+	assert.True(t, state.MessageStopSent, "MessageStopSent must be set after usage-only terminal")
+}
+
 // TestEmitAnthropicSSEChunk_ErrorPath covers the IsError emitter branch:
 // an error event followed by terminal state flags and no second emission.
 func TestEmitAnthropicSSEChunk_ErrorPath(t *testing.T) {

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -218,6 +218,64 @@ func TestEmitAnthropicPingEvent(t *testing.T) {
 	assert.True(t, strings.HasSuffix(out, "\n\n"), "SSE event must terminate with blank line")
 }
 
+// TestEmitAnthropicSSEChunk_CacheUsageRoundTrip asserts that cache
+// counters captured on IRExtensions (typically populated by the
+// inbound translator for the Anthropic→Anthropic cell) land on the
+// terminal message_delta.usage so an Anthropic client sees the same
+// cache_read / cache_creation breakdown the upstream produced.
+func TestEmitAnthropicSSEChunk_CacheUsageRoundTrip(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{
+		CacheReadInputTokens:     120,
+		CacheCreationInputTokens: 80,
+	}
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+	out, _, err := EmitAnthropicSSEChunk(input, state, ext, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, `"cache_read_input_tokens":120`)
+	assert.Contains(t, body, `"cache_creation_input_tokens":80`)
+}
+
+// TestEmitAnthropicSSEChunk_AnthropicOnlyStopReasonOverride asserts
+// that an Anthropic-only stop_reason captured on ext overrides the
+// OpenAI-derived mapping on the outbound message_delta.
+func TestEmitAnthropicSSEChunk_AnthropicOnlyStopReasonOverride(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{
+		AnthropicStopReason: "pause_turn",
+	}
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+	out, _, err := EmitAnthropicSSEChunk(input, state, ext, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"stop_reason":"pause_turn"`)
+}
+
+// TestEmitAnthropicSSEChunk_InitialUsageEcho asserts that an initial
+// usage captured on the inbound side reaches the outbound
+// message_start payload, preserving the input_tokens count clients use
+// to seed their usage accumulators.
+func TestEmitAnthropicSSEChunk_InitialUsageEcho(t *testing.T) {
+	state := NewStreamState()
+	state.InitialUsage.InputTokens = 99
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":99,"completion_tokens":1,"total_tokens":100}}`,
+	)
+	out, _, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+	// message_start.usage carries InitialUsage.InputTokens.
+	startIdx := strings.Index(body, "event: message_start")
+	deltaIdx := strings.Index(body, "event: message_delta")
+	require.Greater(t, deltaIdx, startIdx)
+	messageStartBlock := body[startIdx:deltaIdx]
+	assert.Contains(t, messageStartBlock, `"input_tokens":99`)
+}
+
 // TestFormatAnthropicSSEEvent asserts the SSE framing helper produces
 // the wire shape Anthropic clients expect — event header, data line,
 // terminating blank line.

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -368,6 +368,44 @@ func TestEmitAnthropicSSEChunk_UsageOnlyTerminal(t *testing.T) {
 	assert.True(t, done2, "usage-only terminal chunk must end the stream")
 	assert.Equal(t, 1, strings.Count(string(out2), "event: message_stop"), "usage-only terminal must emit exactly one message_stop")
 	assert.True(t, state.MessageStopSent, "MessageStopSent must be set after usage-only terminal")
+	// The open text block must be closed before the terminal events.
+	assert.Equal(t, 1, strings.Count(string(out2), "event: content_block_stop"), "open text block must be closed by the usage-only terminal")
+}
+
+// TestEmitAnthropicSSEChunk_UsageOnlyTerminalClosesThinkingAndToolBlocks
+// guards the other two branches of closeAllOpenBlocks reached on the
+// usage-only terminal path: a thinking block and tool blocks left open
+// when the stream ends with a usage-only chunk. Each open block must
+// receive a content_block_stop before message_delta/message_stop, or an
+// Anthropic SDK accumulator sees an unterminated block and breaks.
+func TestEmitAnthropicSSEChunk_UsageOnlyTerminalClosesThinkingAndToolBlocks(t *testing.T) {
+	state := NewStreamState()
+
+	// Open a thinking block, then two tool blocks, all without a
+	// finish_reason, then end with a usage-only terminal chunk.
+	chunks := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"hmm"}}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"a","arguments":"{}"}}]}}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"b","arguments":"{}"}}]}}]}`,
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[],"usage":{"prompt_tokens":4,"completion_tokens":3,"total_tokens":7}}`,
+	)
+
+	out, done, err := EmitAnthropicSSEChunk(chunks, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done, "usage-only terminal must end the stream")
+	body := string(out)
+
+	// One thinking block + two tool blocks = three content_block_start,
+	// and all three must be closed (three content_block_stop) before the
+	// single terminal message_stop.
+	assert.Equal(t, 3, strings.Count(body, "event: content_block_start"), "thinking + two tool blocks must each open")
+	assert.Equal(t, 3, strings.Count(body, "event: content_block_stop"), "every open block must be closed on the usage-only terminal")
+	assert.Equal(t, 1, strings.Count(body, "event: message_stop"), "exactly one message_stop")
+	lastStop := strings.LastIndex(body, "event: content_block_stop")
+	msgStop := strings.Index(body, "event: message_stop")
+	require.GreaterOrEqual(t, lastStop, 0)
+	require.GreaterOrEqual(t, msgStop, 0)
+	assert.Less(t, lastStop, msgStop, "all content_block_stop events must precede message_stop")
 }
 
 // TestEmitAnthropicSSEChunk_ErrorPath covers the IsError emitter branch:
@@ -395,6 +433,29 @@ func TestEmitAnthropicSSEChunk_ErrorPath(t *testing.T) {
 	require.NoError(t, err2)
 	assert.True(t, streamDone2)
 	assert.Equal(t, 0, strings.Count(string(out2), "event: message_stop"), "no second message_stop on re-entry")
+}
+
+// TestEmitAnthropicSSEChunk_ErrorAsFirstChunk locks the contract for an
+// error that arrives before any content (MessageStartSent == false): the
+// emitter sends a standalone error event followed by message_stop, with
+// NO message_start. This matches Anthropic's own streaming API, which
+// surfaces an early request failure as a bare error event rather than
+// opening a message lifecycle first. The test guards against a future
+// change that would synthesize a spurious message_start here.
+func TestEmitAnthropicSSEChunk_ErrorAsFirstChunk(t *testing.T) {
+	state := NewStreamState() // MessageStartSent == false: error is the first chunk
+
+	errInput := []byte("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"overloaded\"}}\n\n")
+	out, streamDone, err := EmitAnthropicSSEChunk(errInput, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+
+	assert.True(t, streamDone, "error-first chunk must end the stream")
+	assert.True(t, state.MessageStopSent, "MessageStopSent must be set after an error-first chunk")
+	assert.Contains(t, body, "event: error", "error event must be emitted")
+	assert.Equal(t, 1, strings.Count(body, "event: message_stop"), "exactly one message_stop")
+	assert.NotContains(t, body, "event: message_start",
+		"a pre-content error must not synthesize a message_start (matches Anthropic API)")
 }
 
 // TestEmitAnthropicSSEChunk_DeterministicToolClose asserts that

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -54,6 +54,10 @@ func TestEmitAnthropicSSEChunk_TextOnly(t *testing.T) {
 	require.Greater(t, messageDeltaIdx, blockStopIdx, "message_delta after content_block_stop")
 	require.Greater(t, messageStopIdx, messageDeltaIdx, "message_stop last")
 
+	// Exactly-once invariant: the emitter must never produce a second
+	// message_stop regardless of how the upstream split finish_reason and usage.
+	assert.Equal(t, 1, strings.Count(body, "event: message_stop"), "message_stop exactly once")
+
 	assert.Contains(t, body, `"text":"Hello"`)
 	assert.Contains(t, body, `"text":" world"`)
 	assert.Contains(t, body, `"stop_reason":"end_turn"`)
@@ -282,4 +286,103 @@ func TestEmitAnthropicSSEChunk_InitialUsageEcho(t *testing.T) {
 func TestFormatAnthropicSSEEvent(t *testing.T) {
 	out := string(formatAnthropicSSEEvent("message_start", []byte(`{"type":"message_start"}`)))
 	assert.Equal(t, "event: message_start\ndata: {\"type\":\"message_start\"}\n\n", out)
+}
+
+// TestEmitAnthropicSSEChunk_SplitFinishReasonAndUsage asserts that when
+// an OpenAI-compatible backend legally splits finish_reason and usage
+// across two separate chunks, message_stop appears exactly once on the
+// wire. Before the idempotency guard, the second chunk (usage-only)
+// also satisfied isTerminalChunk, causing a second message_stop.
+func TestEmitAnthropicSSEChunk_SplitFinishReasonAndUsage(t *testing.T) {
+	state := NewStreamState()
+
+	// Chunk 1: finish_reason present, no usage.
+	chunk1 := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`,
+	)
+	out1, done1, err := EmitAnthropicSSEChunk(chunk1, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done1, "finish_reason chunk must set streamDone")
+	assert.Equal(t, 1, strings.Count(string(out1), "event: message_stop"), "exactly one message_stop after finish_reason chunk")
+
+	// Chunk 2: usage-only, no finish_reason. The idempotency guard must
+	// suppress a second call to emitTerminalEvents.
+	chunk2 := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{}}],"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}`,
+	)
+	out2, done2, err := EmitAnthropicSSEChunk(chunk2, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.True(t, done2, "post-terminal usage chunk must still report streamDone")
+	assert.Equal(t, 0, strings.Count(string(out2), "event: message_stop"), "no second message_stop from usage-only chunk")
+
+	// Total across both chunks: exactly one message_stop.
+	combined := string(out1) + string(out2)
+	assert.Equal(t, 1, strings.Count(combined, "event: message_stop"), "exactly one message_stop total across split chunks")
+}
+
+// TestEmitAnthropicSSEChunk_ErrorPath covers the IsError emitter branch:
+// an error event followed by terminal state flags and no second emission.
+func TestEmitAnthropicSSEChunk_ErrorPath(t *testing.T) {
+	state := NewStreamState()
+	state.MessageStartSent = true // simulate mid-stream error
+
+	// Synthesize an extractedSSELine with IsError=true by building the
+	// wire bytes the way extractSSEDataLines produces for error events.
+	errInput := []byte("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"overloaded\"}}\n\n")
+
+	out, streamDone, err := EmitAnthropicSSEChunk(errInput, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+
+	assert.True(t, streamDone, "error path must set streamDone")
+	assert.True(t, state.MessageStopSent, "MessageStopSent must be true after error emission")
+	assert.Contains(t, body, "event: error", "error event must be emitted")
+	assert.Contains(t, body, "event: message_stop", "message_stop must follow error event")
+	assert.Equal(t, 1, strings.Count(body, "event: message_stop"), "exactly one message_stop after error")
+
+	// A second call with IsError must not produce another message_stop.
+	out2, streamDone2, err2 := EmitAnthropicSSEChunk(errInput, state, nil, "claude-sonnet-4-5")
+	require.NoError(t, err2)
+	assert.True(t, streamDone2)
+	assert.Equal(t, 0, strings.Count(string(out2), "event: message_stop"), "no second message_stop on re-entry")
+}
+
+// TestEmitAnthropicSSEChunk_DeterministicToolClose asserts that
+// closeAllOpenBlocks emits content_block_stop events in ascending
+// block-index order even when the underlying map iteration is
+// non-deterministic. Multi-tool streams previously produced an
+// unpredictable content_block_stop sequence because Go map iteration
+// order is randomised per program.
+func TestEmitAnthropicSSEChunk_DeterministicToolClose(t *testing.T) {
+	// Feed two tool calls and let the stream terminate. Run many times
+	// to surface any non-determinism.
+	for range 50 {
+		state := NewStreamState()
+		input := buildOpenAISSE(
+			// Tool 0 opens first.
+			`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_0","type":"function","function":{"name":"alpha","arguments":""}}]},"finish_reason":null}]}`,
+			// Tool 1 opens second.
+			`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_1","type":"function","function":{"name":"beta","arguments":""}}]},"finish_reason":null}]}`,
+			// Terminal chunk closes both.
+			`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+		)
+
+		out, done, err := EmitAnthropicSSEChunk(input, state, nil, "claude-sonnet-4-5")
+		require.NoError(t, err)
+		assert.True(t, done)
+
+		body := string(out)
+		// Both blocks must have a stop event.
+		assert.Equal(t, 2, strings.Count(body, "event: content_block_stop"), "both tool blocks must be closed")
+
+		// Block index 1 (alpha) must have its stop before block index 2 (beta).
+		// The emitter assigns block indices starting from 0 for the first
+		// tool and 1 for the second, so "index":1 stop precedes "index":2 stop.
+		firstStop := strings.Index(body, `"index":1`)
+		secondStop := strings.Index(body, `"index":2`)
+		// Both stops must appear; first tool's stop must come first.
+		require.Greater(t, firstStop, 0, "first tool block stop index must be present")
+		require.Greater(t, secondStop, 0, "second tool block stop index must be present")
+		assert.Less(t, firstStop, secondStop, "tool block stops must appear in block-index order")
+	}
 }

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -396,14 +396,18 @@ func TestEmitAnthropicSSEChunk_DeterministicToolClose(t *testing.T) {
 		// Both blocks must have a stop event.
 		assert.Equal(t, 2, strings.Count(body, "event: content_block_stop"), "both tool blocks must be closed")
 
-		// Block index 1 (alpha) must have its stop before block index 2 (beta).
-		// The emitter assigns block indices starting from 0 for the first
-		// tool and 1 for the second, so "index":1 stop precedes "index":2 stop.
-		firstStop := strings.Index(body, `"index":1`)
-		secondStop := strings.Index(body, `"index":2`)
-		// Both stops must appear; first tool's stop must come first.
-		require.Greater(t, firstStop, 0, "first tool block stop index must be present")
-		require.Greater(t, secondStop, 0, "second tool block stop index must be present")
-		assert.Less(t, firstStop, secondStop, "tool block stops must appear in block-index order")
+		// The emitter assigns block indices sequentially starting from 0:
+		// tool 0 → block 0, tool 1 → block 1. Within the content_block_stop
+		// events, the stop for index 0 must appear before the stop for index 1.
+		// Scope the search to the stop-events section because message_start also
+		// carries "index":0 earlier in the stream.
+		stopStart := strings.Index(body, "event: content_block_stop")
+		require.GreaterOrEqual(t, stopStart, 0, "content_block_stop events must be present")
+		stopSection := body[stopStart:]
+		firstStopInSection := strings.Index(stopSection, `"index":0`)
+		secondStopInSection := strings.Index(stopSection, `"index":1`)
+		require.GreaterOrEqual(t, firstStopInSection, 0, "first tool block stop (index 0) must be present")
+		require.Positive(t, secondStopInSection, "second tool block stop (index 1) must be present")
+		assert.Less(t, firstStopInSection, secondStopInSection, "tool block stops must appear in block-index ascending order")
 	}
 }

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -259,6 +259,27 @@ func TestEmitAnthropicSSEChunk_AnthropicOnlyStopReasonOverride(t *testing.T) {
 	assert.Contains(t, string(out), `"stop_reason":"pause_turn"`)
 }
 
+// TestEmitAnthropicSSEChunk_StopSequenceVariant asserts that when
+// ext.AnthropicStopReason is "stop_sequence" the outbound message_delta
+// carries both stop_reason:"stop_sequence" and a non-nil stop_sequence
+// field with the sequence string. This exercises mapOpenAIFinishReasonToAnthropic's
+// stop_sequence branch end-to-end.
+func TestEmitAnthropicSSEChunk_StopSequenceVariant(t *testing.T) {
+	state := NewStreamState()
+	ext := &ir.IRExtensions{
+		AnthropicStopReason:   "stop_sequence",
+		AnthropicStopSequence: "DONE",
+	}
+	input := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	)
+	out, _, err := EmitAnthropicSSEChunk(input, state, ext, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, `"stop_reason":"stop_sequence"`)
+	assert.Contains(t, body, `"stop_sequence":"DONE"`)
+}
+
 // TestEmitAnthropicSSEChunk_InitialUsageEcho asserts that an initial
 // usage captured on the inbound side reaches the outbound
 // message_start payload, preserving the input_tokens count clients use

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -27,7 +27,23 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 		return looperResponse, nil
 	}
 
-	if ctx.IsStreamingResponse && ctx.APIFormat == config.APIFormatAnthropic {
+	// Anthropic clients on the streaming path always go through the
+	// outbound emitter so the client sees Anthropic-shape SSE,
+	// regardless of upstream APIFormat. The dispatcher branch order
+	// matters: this check precedes the older
+	// handleAnthropicStreamingResponseBody branch because the
+	// double-Anthropic cell (Anthropic client + Anthropic backend)
+	// would otherwise match the legacy branch and the client would
+	// receive OpenAI SSE.
+	if ctx.IsStreamingResponse && ctx.ClientProtocol == config.ClientProtocolAnthropic {
+		return r.handleAnthropicClientStreamingResponseBody(v.ResponseBody.Body, ctx), nil
+	}
+
+	// Legacy branch: OpenAI client hitting an Anthropic backend. The
+	// extra ClientProtocol guard prevents the new Anthropic-client
+	// branch from being shadowed by this one.
+	if ctx.IsStreamingResponse && ctx.APIFormat == config.APIFormatAnthropic &&
+		ctx.ClientProtocol != config.ClientProtocolAnthropic {
 		return r.handleAnthropicStreamingResponseBody(v.ResponseBody.Body, ctx), nil
 	}
 

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
@@ -63,6 +63,15 @@ func ensureStreamingState(ctx *RequestContext) {
 }
 
 func (r *OpenAIRouter) finalizeStreamingResponse(ctx *RequestContext) {
+	// Idempotency guard: finalization records completion-latency metrics,
+	// ends the inflight token, and attaches the replay body — all of which
+	// must happen exactly once. The Anthropic-client streaming cell can
+	// reach this twice for one stream (the emitter's streamDone fires on
+	// one chunk, then a later terminal chunk still matches the
+	// "data: [DONE]" guard), so a second entry must be a no-op.
+	if ctx.StreamingComplete {
+		return
+	}
 	ctx.StreamingComplete = true
 	logging.ComponentDebugEvent("extproc", "streaming_response_finalized", map[string]interface{}{
 		"model":            ctx.RequestModel,

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -26,6 +26,7 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 		responseBody,
 		ctx.AnthropicStream,
 		ctx.RequestModel,
+		nil,
 	)
 	if err != nil {
 		logging.Errorf("Failed to transform Anthropic streaming chunk: %v", err)

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -22,11 +22,17 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 		ctx.AnthropicStream = anthropic.NewStreamState()
 	}
 
+	// Pass IRExtensions through so the merged Anthropic→OpenAI cell
+	// captures cache counters, stop_reason round-trip fields, and
+	// per-block thinking signatures onto the request-scoped sidecar.
+	// Even for an OpenAI client the IR fields keep observability,
+	// router replay, and downstream non-streaming responses consistent
+	// with the streaming case.
 	transformed, streamDone, err := anthropic.TransformSSEChunkToOpenAI(
 		responseBody,
 		ctx.AnthropicStream,
 		ctx.RequestModel,
-		nil,
+		ctx.IRExtensions,
 	)
 	if err != nil {
 		logging.Errorf("Failed to transform Anthropic streaming chunk: %v", err)

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
@@ -1,0 +1,102 @@
+package extproc
+
+import (
+	"strings"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// handleAnthropicClientStreamingResponseBody dispatches streaming
+// responses for clients that called the /v1/messages endpoint
+// (ClientProtocol == "anthropic"). The body Envoy hands us may be in
+// either Anthropic SSE (when the upstream is an Anthropic backend) or
+// OpenAI SSE (when the upstream is an OpenAI backend); both arrive on
+// this path because the inbound parser already pinned the client to
+// the Anthropic protocol. The function:
+//
+//  1. translates Anthropic upstream SSE to OpenAI SSE first, so the
+//     accounting accumulator, plugins, and the outbound emitter all
+//     see the uniform OpenAI shape vsr's pipeline expects;
+//  2. runs the standard OpenAI streaming accumulator to update the
+//     per-request StreamingMetadata / usage (and flag HasStreamingChunks)
+//     so metrics, cache, and replay continue to work;
+//  3. re-emits the OpenAI chunk as Anthropic SSE via
+//     anthropic.EmitAnthropicSSEChunk and returns those bytes via
+//     BodyMutation so the client sees Anthropic-shape events.
+//
+// This is the symmetric counterpart to
+// handleAnthropicStreamingResponseBody (which handles OpenAI clients
+// hitting an Anthropic backend); the two share the AnthropicStream
+// state but only one runs per request because ClientProtocol is pinned
+// at the inbound parser.
+func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
+	responseBody []byte,
+	ctx *RequestContext,
+) *ext_proc.ProcessingResponse {
+	recordStreamingTTFT(ctx)
+	ensureStreamingState(ctx)
+	if ctx.AnthropicStream == nil {
+		ctx.AnthropicStream = anthropic.NewStreamState()
+	}
+
+	openAIBytes, err := r.translateUpstreamToOpenAI(responseBody, ctx)
+	if err != nil {
+		logging.Errorf("Failed to translate upstream streaming chunk to OpenAI: %v", err)
+		return buildResponseBodyContinueResponse(nil, nil)
+	}
+
+	chunkStr := string(openAIBytes)
+	if chunkStr != "" {
+		ctx.HasStreamingChunks = true
+		r.parseStreamingChunk(chunkStr, ctx)
+	}
+
+	anthropicBytes, streamDone, err := anthropic.EmitAnthropicSSEChunk(
+		openAIBytes, ctx.AnthropicStream, ctx.IRExtensions, ctx.RequestModel,
+	)
+	if err != nil {
+		logging.Errorf("Failed to emit Anthropic SSE chunk: %v", err)
+		return buildResponseBodyContinueResponse(nil, nil)
+	}
+
+	if streamDone || strings.Contains(chunkStr, "data: [DONE]") {
+		r.finalizeStreamingResponse(ctx)
+	}
+
+	// Always replace the body, even when our emitter produced zero
+	// bytes for this chunk. A nil BodyMutation makes Envoy forward the
+	// raw upstream chunk unmodified, which would leak Anthropic-shape
+	// bytes from the backend onto the wire on top of the Anthropic
+	// events we have already synthesized — most visibly a second
+	// message_stop event after the emitter's own message_stop. Once we
+	// have entered this handler we own the wire, so an empty mutation
+	// is the correct way to swallow upstream noise.
+	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{
+		Mutation: &ext_proc.BodyMutation_Body{Body: anthropicBytes},
+	}, nil)
+}
+
+// translateUpstreamToOpenAI normalizes the upstream SSE bytes into the
+// OpenAI chunk shape. Anthropic upstreams go through
+// TransformSSEChunkToOpenAI so plugins and the emitter see uniform IR;
+// OpenAI upstreams pass through unchanged. Returns the normalized
+// bytes and any translator error.
+func (r *OpenAIRouter) translateUpstreamToOpenAI(
+	responseBody []byte,
+	ctx *RequestContext,
+) ([]byte, error) {
+	if ctx.APIFormat != config.APIFormatAnthropic {
+		return responseBody, nil
+	}
+	translated, _, err := anthropic.TransformSSEChunkToOpenAI(
+		responseBody, ctx.AnthropicStream, ctx.RequestModel, ctx.IRExtensions,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return translated, nil
+}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
@@ -2,6 +2,7 @@ package extproc
 
 import (
 	"strings"
+	"time"
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
@@ -9,6 +10,13 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
+
+// anthropicPingCadence is how long the emitter waits between
+// surfacing keepalive pings. Matches the observed upstream cadence
+// (~15s) and the Claude Code SDK's idle tolerance.
+//
+// Hardcoded in v1; can be made configurable in a follow-up if operators ask.
+const anthropicPingCadence = 15 * time.Second
 
 // handleAnthropicClientStreamingResponseBody dispatches streaming
 // responses for clients that called the /v1/messages endpoint
@@ -43,6 +51,14 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 		ctx.AnthropicStream = anthropic.NewStreamState()
 	}
 
+	// Inject a keepalive ping if the gap since the last chunk crossed
+	// the cadence threshold. Anthropic clients (including the SDK
+	// MessageStream accumulator) treat pings as no-ops; the value is
+	// keeping middleboxes from severing the long-lived connection
+	// during sparse-token windows. The ping is prepended below so it
+	// reaches the client before this chunk's content events.
+	pingBytes := maybeEmitPing(ctx.AnthropicStream)
+
 	openAIBytes, err := r.translateUpstreamToOpenAI(responseBody, ctx)
 	if err != nil {
 		logging.Errorf("Failed to translate upstream streaming chunk to OpenAI: %v", err)
@@ -67,6 +83,15 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 		r.finalizeStreamingResponse(ctx)
 	}
 
+	// Stamp the chunk-arrival time so the next pass can compute the
+	// silence gap for ping injection. Done after the emitter so a
+	// chunk that produced no bytes still extends the keepalive window
+	// (otherwise zero-emit chunks would fire a ping on every call).
+	ctx.AnthropicStream.LastChunkAt = time.Now()
+
+	combined := make([]byte, 0, len(pingBytes)+len(anthropicBytes))
+	combined = append(combined, pingBytes...)
+	combined = append(combined, anthropicBytes...)
 	// Always replace the body, even when our emitter produced zero
 	// bytes for this chunk. A nil BodyMutation makes Envoy forward the
 	// raw upstream chunk unmodified, which would leak Anthropic-shape
@@ -76,8 +101,23 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 	// have entered this handler we own the wire, so an empty mutation
 	// is the correct way to swallow upstream noise.
 	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{
-		Mutation: &ext_proc.BodyMutation_Body{Body: anthropicBytes},
+		Mutation: &ext_proc.BodyMutation_Body{Body: combined},
 	}, nil)
+}
+
+// maybeEmitPing returns ping event bytes when the gap since the last
+// chunk arrival crossed anthropicPingCadence. Returns nil otherwise.
+// A zero LastChunkAt (first chunk after stream init) suppresses the
+// ping — the spec only asks for pings during sparse-token windows, not
+// for synthetic pings before any content has flowed.
+func maybeEmitPing(state *anthropic.StreamState) []byte {
+	if state == nil || state.LastChunkAt.IsZero() {
+		return nil
+	}
+	if time.Since(state.LastChunkAt) < anthropicPingCadence {
+		return nil
+	}
+	return anthropic.EmitAnthropicPingEvent()
 }
 
 // translateUpstreamToOpenAI normalizes the upstream SSE bytes into the

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
@@ -132,6 +132,9 @@ func (r *OpenAIRouter) translateUpstreamToOpenAI(
 	if ctx.APIFormat != config.APIFormatAnthropic {
 		return responseBody, nil
 	}
+	// streamDone is intentionally discarded here; finalization is driven by
+	// the outbound emitter's own streamDone return in
+	// handleAnthropicClientStreamingResponseBody, not by the inbound translator.
 	translated, _, err := anthropic.TransformSSEChunkToOpenAI(
 		responseBody, ctx.AnthropicStream, ctx.RequestModel, ctx.IRExtensions,
 	)

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
@@ -62,7 +62,7 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 	openAIBytes, err := r.translateUpstreamToOpenAI(responseBody, ctx)
 	if err != nil {
 		logging.Errorf("Failed to translate upstream streaming chunk to OpenAI: %v", err)
-		return buildResponseBodyContinueResponse(nil, nil)
+		return emptyAnthropicBodyMutation()
 	}
 
 	chunkStr := string(openAIBytes)
@@ -76,7 +76,7 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 	)
 	if err != nil {
 		logging.Errorf("Failed to emit Anthropic SSE chunk: %v", err)
-		return buildResponseBodyContinueResponse(nil, nil)
+		return emptyAnthropicBodyMutation()
 	}
 
 	if streamDone || strings.Contains(chunkStr, "data: [DONE]") {
@@ -92,16 +92,22 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 	combined := make([]byte, 0, len(pingBytes)+len(anthropicBytes))
 	combined = append(combined, pingBytes...)
 	combined = append(combined, anthropicBytes...)
-	// Always replace the body, even when our emitter produced zero
-	// bytes for this chunk. A nil BodyMutation makes Envoy forward the
-	// raw upstream chunk unmodified, which would leak Anthropic-shape
-	// bytes from the backend onto the wire on top of the Anthropic
-	// events we have already synthesized — most visibly a second
-	// message_stop event after the emitter's own message_stop. Once we
-	// have entered this handler we own the wire, so an empty mutation
-	// is the correct way to swallow upstream noise.
 	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{
 		Mutation: &ext_proc.BodyMutation_Body{Body: combined},
+	}, nil)
+}
+
+// emptyAnthropicBodyMutation returns a non-nil BodyMutation carrying an
+// empty body. Once execution enters the Anthropic-client streaming
+// handler, vsr owns the wire: every return must replace the body so
+// Envoy never forwards the raw upstream chunk. A nil BodyMutation would
+// make Envoy pass the upstream bytes through unmodified, leaking
+// Anthropic-shape backend frames on top of the events we synthesize —
+// most visibly a second message_stop. Error and zero-emission paths use
+// this so that invariant holds even when we have no content to send.
+func emptyAnthropicBodyMutation() *ext_proc.ProcessingResponse {
+	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{
+		Mutation: &ext_proc.BodyMutation_Body{Body: []byte{}},
 	}, nil)
 }
 

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -132,29 +133,132 @@ func TestHandleAnthropicClientStreamingResponseBody_EmptyStream(t *testing.T) {
 	assert.Equal(t, []byte{}, mutation.GetBody(), "empty input must yield empty (not nil) mutation body")
 }
 
-// TestHandleAnthropicClientStreamingResponseBody_MidStreamError asserts
-// that when EmitAnthropicSSEChunk returns an error (e.g. state == nil),
-// the handler returns a non-nil response with an empty mutation rather
-// than panicking or returning nil (which would forward raw upstream bytes).
+// TestHandleAnthropicClientStreamingResponseBody_UnparsableChunk asserts
+// that an unparsable upstream chunk is handled gracefully: the emitter
+// emits no bytes (and returns no error — bad JSON is swallowed, not
+// surfaced), and the handler still returns a non-nil response carrying a
+// non-nil empty BodyMutation so Envoy suppresses the upstream chunk
+// rather than forwarding the raw bytes.
 //
-// We trigger the error path indirectly: pass a body that will parse into
-// a valid OpenAI chunk but set state to nil in the context so the emitter
-// cannot proceed. The handler must recover gracefully.
-func TestHandleAnthropicClientStreamingResponseBody_MidStreamError(t *testing.T) {
+// Note: this exercises the empty-emission path, NOT the err != nil
+// branch. EmitAnthropicSSEChunk does not return an error for malformed
+// data; it returns empty output. The handler's error branches are
+// covered separately where a real translator error can be induced.
+func TestHandleAnthropicClientStreamingResponseBody_UnparsableChunk(t *testing.T) {
 	router := newTestRouter()
-	ctx := newAnthropicStreamCtx(nil) // nil state causes graceful nil-init inside emitter
-
-	// A malformed upstream that fails translation will cause translateUpstreamToOpenAI
-	// to return an error via TransformSSEChunkToOpenAI's unmarshal.
-	// Use a non-Anthropic format so the translator is bypassed and we get
-	// well-formed but minimal OpenAI SSE bytes fed into EmitAnthropicSSEChunk.
+	ctx := newAnthropicStreamCtx(anthropic.NewStreamState())
+	// OpenAI format bypasses the Anthropic translator, feeding the bytes
+	// straight to the emitter, which cannot parse them and emits nothing.
 	ctx.APIFormat = config.APIFormatOpenAI
-	// Deliberately corrupt the chunk so emitChunkEvents gets a bad json.Unmarshal.
 	badChunk := []byte("data: not-valid-json\n\n")
 
 	resp := router.handleAnthropicClientStreamingResponseBody(badChunk, ctx)
-	require.NotNil(t, resp, "handler must not return nil on parse error")
-	// The response must be a BodyResponse (not a header or other type) to
-	// remain consistent with the streaming response pipeline.
-	require.NotNil(t, resp.GetResponseBody())
+	require.NotNil(t, resp, "handler must not return nil on unparsable input")
+	mutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, mutation, "BodyMutation must be set even for unparsable input")
+	assert.Equal(t, []byte{}, mutation.GetBody(), "unparsable input must yield empty (not nil) mutation body")
+}
+
+// TestHandleResponseBody_StreamingDispatchMatrix locks the four-cell
+// streaming dispatch in handleResponseBody:
+//
+//	ClientProtocol × APIFormat → handler → wire shape
+//	-------------------------------------------------------------
+//	anthropic  × anthropic  → AnthropicClient streamer → Anthropic SSE
+//	anthropic  × openai     → AnthropicClient streamer → Anthropic SSE
+//	openai     × anthropic  → legacy Anthropic streamer → OpenAI SSE
+//	openai     × openai     → generic OpenAI streamer   → pass-through
+//
+// The branch ordering at processor_res_body.go matters: the Anthropic
+// *client* branch must precede the legacy Anthropic *backend* branch, or
+// the double-Anthropic cell would fall through and emit OpenAI SSE to an
+// Anthropic client. This test asserts each cell reaches the right handler
+// by inspecting the observable wire shape, so a future reordering or a
+// missing ClientProtocol guard fails loudly.
+func TestHandleResponseBody_StreamingDispatchMatrix(t *testing.T) {
+	openAIChunk := `data: {"id":"c","object":"chat.completion.chunk","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}` + "\n\n"
+	anthropicChunk := strings.Join([]string{
+		"event: content_block_delta",
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		"", "",
+	}, "\n")
+
+	cases := []struct {
+		name           string
+		clientProtocol string
+		apiFormat      string
+		body           string
+		// wantAnthropicWire asserts the client sees Anthropic SSE (event: lines).
+		wantAnthropicWire bool
+		// wantOpenAIChunkWire asserts the client sees OpenAI chat.completion.chunk SSE.
+		wantOpenAIChunkWire bool
+	}{
+		{
+			name:              "anthropic client + anthropic backend → Anthropic SSE",
+			clientProtocol:    config.ClientProtocolAnthropic,
+			apiFormat:         config.APIFormatAnthropic,
+			body:              anthropicChunk,
+			wantAnthropicWire: true,
+		},
+		{
+			name:              "anthropic client + openai backend → Anthropic SSE",
+			clientProtocol:    config.ClientProtocolAnthropic,
+			apiFormat:         config.APIFormatOpenAI,
+			body:              openAIChunk,
+			wantAnthropicWire: true,
+		},
+		{
+			name:                "openai client + anthropic backend → OpenAI SSE",
+			clientProtocol:      "",
+			apiFormat:           config.APIFormatAnthropic,
+			body:                anthropicChunk,
+			wantOpenAIChunkWire: true,
+		},
+		{
+			name:                "openai client + openai backend → OpenAI pass-through",
+			clientProtocol:      "",
+			apiFormat:           config.APIFormatOpenAI,
+			body:                openAIChunk,
+			wantOpenAIChunkWire: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := newTestRouter()
+			ctx := &RequestContext{
+				IsStreamingResponse: true,
+				ClientProtocol:      tc.clientProtocol,
+				APIFormat:           tc.apiFormat,
+				RequestModel:        "claude-sonnet-4-5",
+				StreamingMetadata:   make(map[string]interface{}),
+				ProcessingStartTime: time.Now().Add(-10 * time.Millisecond),
+			}
+			v := &ext_proc.ProcessingRequest_ResponseBody{
+				ResponseBody: &ext_proc.HttpBody{Body: []byte(tc.body)},
+			}
+
+			resp, err := router.handleResponseBody(v, ctx)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// The Anthropic-client cells own the wire and always replace the
+			// body; the OpenAI-client cells route through handlers that emit
+			// their accumulated chunk (anthropic backend) or pass through
+			// (openai backend). We inspect whatever body mutation is present.
+			mutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+			var wire string
+			if mutation != nil {
+				wire = string(mutation.GetBody())
+			}
+
+			if tc.wantAnthropicWire {
+				assert.Contains(t, wire, "event:", "anthropic-client cell must emit Anthropic SSE to the wire")
+				assert.NotContains(t, wire, "chat.completion.chunk", "anthropic-client cell must not leak OpenAI chunk shape")
+			}
+			if tc.wantOpenAIChunkWire {
+				assert.NotContains(t, wire, "event: content_block", "openai-client cell must not emit Anthropic content_block events")
+			}
+		})
+	}
 }

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
@@ -1,0 +1,72 @@
+package extproc
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestHandleAnthropicClientStreamingResponseBody_SuppressesUpstreamTail
+// is the regression test for the duplicate message_stop bug observed in
+// the double-Anthropic streaming cell (Anthropic client + Anthropic
+// backend).
+//
+// Symptoms before the fix: the emitter synthesized a clean message_stop
+// when the prior chunk's message_delta carried usage; the very last
+// chunk (which contained only the upstream message_stop frame) made the
+// emitter produce zero bytes; the handler then returned a nil
+// BodyMutation, which made Envoy forward the upstream bytes verbatim,
+// resulting in a second (raw, whitespace-formatted) message_stop on the
+// wire.
+//
+// The fix replaces the body unconditionally so an empty-emission chunk
+// suppresses the upstream tail. This test feeds the terminal Anthropic
+// message_stop frame to the handler with state that already has
+// MessageStopSent=true (simulating the earlier emission) and asserts
+// the returned body is the empty mutation, not nil.
+func TestHandleAnthropicClientStreamingResponseBody_SuppressesUpstreamTail(t *testing.T) {
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{
+			SemanticCache: config.SemanticCache{Enabled: false},
+		},
+	}
+	state := anthropic.NewStreamState()
+	state.MessageStartSent = true
+	state.MessageStopSent = true
+	state.LastChunkAt = time.Now()
+
+	ctx := &RequestContext{
+		APIFormat:           config.APIFormatAnthropic,
+		ClientProtocol:      config.ClientProtocolAnthropic,
+		RequestModel:        "claude-sonnet-4-5",
+		AnthropicStream:     state,
+		StreamingMetadata:   make(map[string]interface{}),
+		ProcessingStartTime: time.Now().Add(-10 * time.Millisecond),
+	}
+
+	// Terminal-only chunk from the upstream: message_stop with the
+	// trailing-whitespace JSON formatting that some upstream backends emit.
+	upstreamTail := strings.Join([]string{
+		"event: message_stop",
+		`data: {"type":"message_stop"         }`,
+		"",
+	}, "\n")
+
+	resp := router.handleAnthropicClientStreamingResponseBody([]byte(upstreamTail), ctx)
+	require.NotNil(t, resp)
+	mutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, mutation, "BodyMutation must be set so envoy does not forward upstream bytes")
+
+	body := mutation.GetBody()
+	bodyStr := string(body)
+	assert.NotContains(t, bodyStr, "message_stop",
+		"emitter must not let the upstream message_stop leak through after its own message_stop already fired")
+	assert.NotContains(t, bodyStr, "         }",
+		"trailing-whitespace upstream formatting must not appear on the wire")
+}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
@@ -12,6 +12,30 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
+// newTestRouter returns a minimal OpenAIRouter suitable for unit tests
+// that invoke response-body handlers. The router has semantic cache
+// disabled so it does not attempt Redis lookups.
+func newTestRouter() *OpenAIRouter {
+	return &OpenAIRouter{
+		Config: &config.RouterConfig{
+			SemanticCache: config.SemanticCache{Enabled: false},
+		},
+	}
+}
+
+// newAnthropicStreamCtx returns a RequestContext wired for the Anthropic
+// client streaming path with the supplied StreamState.
+func newAnthropicStreamCtx(state *anthropic.StreamState) *RequestContext {
+	return &RequestContext{
+		APIFormat:           config.APIFormatAnthropic,
+		ClientProtocol:      config.ClientProtocolAnthropic,
+		RequestModel:        "claude-sonnet-4-5",
+		AnthropicStream:     state,
+		StreamingMetadata:   make(map[string]interface{}),
+		ProcessingStartTime: time.Now().Add(-10 * time.Millisecond),
+	}
+}
+
 // TestHandleAnthropicClientStreamingResponseBody_SuppressesUpstreamTail
 // is the regression test for the duplicate message_stop bug observed in
 // the double-Anthropic streaming cell (Anthropic client + Anthropic
@@ -31,24 +55,12 @@ import (
 // MessageStopSent=true (simulating the earlier emission) and asserts
 // the returned body is the empty mutation, not nil.
 func TestHandleAnthropicClientStreamingResponseBody_SuppressesUpstreamTail(t *testing.T) {
-	router := &OpenAIRouter{
-		Config: &config.RouterConfig{
-			SemanticCache: config.SemanticCache{Enabled: false},
-		},
-	}
+	router := newTestRouter()
 	state := anthropic.NewStreamState()
 	state.MessageStartSent = true
 	state.MessageStopSent = true
 	state.LastChunkAt = time.Now()
-
-	ctx := &RequestContext{
-		APIFormat:           config.APIFormatAnthropic,
-		ClientProtocol:      config.ClientProtocolAnthropic,
-		RequestModel:        "claude-sonnet-4-5",
-		AnthropicStream:     state,
-		StreamingMetadata:   make(map[string]interface{}),
-		ProcessingStartTime: time.Now().Add(-10 * time.Millisecond),
-	}
+	ctx := newAnthropicStreamCtx(state)
 
 	// Terminal-only chunk from the upstream: message_stop with the
 	// trailing-whitespace JSON formatting that some upstream backends emit.
@@ -69,4 +81,80 @@ func TestHandleAnthropicClientStreamingResponseBody_SuppressesUpstreamTail(t *te
 		"emitter must not let the upstream message_stop leak through after its own message_stop already fired")
 	assert.NotContains(t, bodyStr, "         }",
 		"trailing-whitespace upstream formatting must not appear on the wire")
+}
+
+// TestHandleAnthropicClientStreamingResponseBody_PingInterleave asserts
+// that maybeEmitPing fires when the silence gap since the last chunk
+// crosses anthropicPingCadence. The ping bytes must appear before the
+// content bytes in the mutation body so the client's idle watchdog is
+// satisfied before the next token arrives.
+func TestHandleAnthropicClientStreamingResponseBody_PingInterleave(t *testing.T) {
+	router := newTestRouter()
+	state := anthropic.NewStreamState()
+	// Set LastChunkAt far in the past to guarantee a ping on the next call.
+	state.LastChunkAt = time.Now().Add(-(anthropicPingCadence + time.Second))
+	ctx := newAnthropicStreamCtx(state)
+
+	// OpenAI-shaped chunk (no Anthropic translation needed because
+	// APIFormat is not set to Anthropic for this sub-test).
+	ctx.APIFormat = config.APIFormatOpenAI
+	chunk := `data: {"id":"c","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}` + "\n\n"
+
+	resp := router.handleAnthropicClientStreamingResponseBody([]byte(chunk), ctx)
+	require.NotNil(t, resp)
+	mutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, mutation, "BodyMutation must always be set")
+
+	body := string(mutation.GetBody())
+	pingIdx := strings.Index(body, "event: ping")
+	require.GreaterOrEqual(t, pingIdx, 0, "ping event must be present in output")
+
+	// Ping must come before the content events in the same mutation body.
+	contentIdx := strings.Index(body, "event: message_start")
+	if contentIdx >= 0 {
+		assert.Less(t, pingIdx, contentIdx, "ping must precede content events")
+	}
+}
+
+// TestHandleAnthropicClientStreamingResponseBody_EmptyStream asserts that
+// an empty byte slice does not crash the handler and returns a sensible
+// (non-nil, empty body) BodyMutation so Envoy suppresses the empty
+// upstream chunk rather than forwarding nil.
+func TestHandleAnthropicClientStreamingResponseBody_EmptyStream(t *testing.T) {
+	router := newTestRouter()
+	ctx := newAnthropicStreamCtx(anthropic.NewStreamState())
+
+	resp := router.handleAnthropicClientStreamingResponseBody([]byte{}, ctx)
+	require.NotNil(t, resp, "handler must not return nil on empty input")
+	mutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, mutation, "BodyMutation must be set even for empty input")
+	// Empty body is the correct suppression signal; nil would leak upstream bytes.
+	assert.Equal(t, []byte{}, mutation.GetBody(), "empty input must yield empty (not nil) mutation body")
+}
+
+// TestHandleAnthropicClientStreamingResponseBody_MidStreamError asserts
+// that when EmitAnthropicSSEChunk returns an error (e.g. state == nil),
+// the handler returns a non-nil response with an empty mutation rather
+// than panicking or returning nil (which would forward raw upstream bytes).
+//
+// We trigger the error path indirectly: pass a body that will parse into
+// a valid OpenAI chunk but set state to nil in the context so the emitter
+// cannot proceed. The handler must recover gracefully.
+func TestHandleAnthropicClientStreamingResponseBody_MidStreamError(t *testing.T) {
+	router := newTestRouter()
+	ctx := newAnthropicStreamCtx(nil) // nil state causes graceful nil-init inside emitter
+
+	// A malformed upstream that fails translation will cause translateUpstreamToOpenAI
+	// to return an error via TransformSSEChunkToOpenAI's unmarshal.
+	// Use a non-Anthropic format so the translator is bypassed and we get
+	// well-formed but minimal OpenAI SSE bytes fed into EmitAnthropicSSEChunk.
+	ctx.APIFormat = config.APIFormatOpenAI
+	// Deliberately corrupt the chunk so emitChunkEvents gets a bad json.Unmarshal.
+	badChunk := []byte("data: not-valid-json\n\n")
+
+	resp := router.handleAnthropicClientStreamingResponseBody(badChunk, ctx)
+	require.NotNil(t, resp, "handler must not return nil on parse error")
+	// The response must be a BodyResponse (not a header or other type) to
+	// remain consistent with the streaming response pipeline.
+	require.NotNil(t, resp.GetResponseBody())
 }

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
@@ -183,43 +183,55 @@ func TestHandleResponseBody_StreamingDispatchMatrix(t *testing.T) {
 		"", "",
 	}, "\n")
 
+	// Each cell routes to a distinct handler with an observably distinct
+	// result, so the assertions positively distinguish the four handlers
+	// rather than checking only for the absence of a shape:
+	//   - anthropic-client cells: handler replaces the body with Anthropic
+	//     SSE (non-nil mutation containing "event:", never OpenAI chunk shape).
+	//   - openai client + anthropic backend: legacy handler emits the
+	//     translated OpenAI chunk (non-nil mutation containing
+	//     "chat.completion.chunk").
+	//   - openai client + openai backend: generic streamer passes through
+	//     with a nil BodyMutation (no rewrite).
+	const (
+		wireAnthropic = "anthropic-sse"   // non-nil mutation, Anthropic events
+		wireOpenAI    = "openai-chunk"    // non-nil mutation, OpenAI chunk shape
+		wirePassThru  = "passthrough-nil" // nil mutation (no rewrite)
+	)
 	cases := []struct {
 		name           string
 		clientProtocol string
 		apiFormat      string
 		body           string
-		// wantAnthropicWire asserts the client sees Anthropic SSE (event: lines).
-		wantAnthropicWire bool
-		// wantOpenAIChunkWire asserts the client sees OpenAI chat.completion.chunk SSE.
-		wantOpenAIChunkWire bool
+		wantWire       string
 	}{
 		{
-			name:              "anthropic client + anthropic backend → Anthropic SSE",
-			clientProtocol:    config.ClientProtocolAnthropic,
-			apiFormat:         config.APIFormatAnthropic,
-			body:              anthropicChunk,
-			wantAnthropicWire: true,
+			name:           "anthropic client + anthropic backend → Anthropic SSE",
+			clientProtocol: config.ClientProtocolAnthropic,
+			apiFormat:      config.APIFormatAnthropic,
+			body:           anthropicChunk,
+			wantWire:       wireAnthropic,
 		},
 		{
-			name:              "anthropic client + openai backend → Anthropic SSE",
-			clientProtocol:    config.ClientProtocolAnthropic,
-			apiFormat:         config.APIFormatOpenAI,
-			body:              openAIChunk,
-			wantAnthropicWire: true,
+			name:           "anthropic client + openai backend → Anthropic SSE",
+			clientProtocol: config.ClientProtocolAnthropic,
+			apiFormat:      config.APIFormatOpenAI,
+			body:           openAIChunk,
+			wantWire:       wireAnthropic,
 		},
 		{
-			name:                "openai client + anthropic backend → OpenAI SSE",
-			clientProtocol:      "",
-			apiFormat:           config.APIFormatAnthropic,
-			body:                anthropicChunk,
-			wantOpenAIChunkWire: true,
+			name:           "openai client + anthropic backend → OpenAI SSE",
+			clientProtocol: "",
+			apiFormat:      config.APIFormatAnthropic,
+			body:           anthropicChunk,
+			wantWire:       wireOpenAI,
 		},
 		{
-			name:                "openai client + openai backend → OpenAI pass-through",
-			clientProtocol:      "",
-			apiFormat:           config.APIFormatOpenAI,
-			body:                openAIChunk,
-			wantOpenAIChunkWire: true,
+			name:           "openai client + openai backend → OpenAI pass-through",
+			clientProtocol: "",
+			apiFormat:      config.APIFormatOpenAI,
+			body:           openAIChunk,
+			wantWire:       wirePassThru,
 		},
 	}
 
@@ -242,22 +254,21 @@ func TestHandleResponseBody_StreamingDispatchMatrix(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 
-			// The Anthropic-client cells own the wire and always replace the
-			// body; the OpenAI-client cells route through handlers that emit
-			// their accumulated chunk (anthropic backend) or pass through
-			// (openai backend). We inspect whatever body mutation is present.
 			mutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
-			var wire string
-			if mutation != nil {
-				wire = string(mutation.GetBody())
-			}
 
-			if tc.wantAnthropicWire {
+			switch tc.wantWire {
+			case wireAnthropic:
+				require.NotNil(t, mutation, "anthropic-client cell must replace the body")
+				wire := string(mutation.GetBody())
 				assert.Contains(t, wire, "event:", "anthropic-client cell must emit Anthropic SSE to the wire")
 				assert.NotContains(t, wire, "chat.completion.chunk", "anthropic-client cell must not leak OpenAI chunk shape")
-			}
-			if tc.wantOpenAIChunkWire {
+			case wireOpenAI:
+				require.NotNil(t, mutation, "openai-client + anthropic-backend cell must emit the translated chunk")
+				wire := string(mutation.GetBody())
+				assert.Contains(t, wire, "chat.completion.chunk", "legacy Anthropic handler must emit OpenAI chunk shape")
 				assert.NotContains(t, wire, "event: content_block", "openai-client cell must not emit Anthropic content_block events")
+			case wirePassThru:
+				assert.Nil(t, mutation, "openai client + openai backend must pass through with a nil BodyMutation (no rewrite)")
 			}
 		})
 	}


### PR DESCRIPTION
> **RFC**: #1946 — design rationale, alternatives considered, decisions invited from maintainers

Fifth and final PR in the native Anthropic `/v1/messages` ingress series
(tracking #1404). Stacks on #1940 → #1939. #1937 and #1938 have merged.

After PR5 lands, the full request/response round-trip for native Anthropic
ingress (non-streaming AND streaming) is feature-complete.

## What

Symmetric inverse of #1926 (Anthropic→OpenAI SSE translation). Converts an
OpenAI-shaped streaming response into the Anthropic SSE event sequence so
`/v1/messages` clients (Claude Code, anthropic-sdk-go) consume it without
their own translation layer.

Also fixes **four pre-existing silent drops** in the existing Anthropic→OpenAI
streaming path (`pkg/anthropic/client_stream.go` `default:` branch): thinking
content-block start, thinking_delta, signature_delta, and `event: error`. These
have been silently affecting any deployment streaming from an Anthropic
backend with Opus 4.7 adaptive thinking — clients see empty thinking blocks
and missing error surfaces. Fixed first so the rest of the PR builds on a
correct baseline.

## Commits

1. **`[Router] fix dropped Anthropic streaming events for thinking and errors`** —
   the bug fix. Adds typed handlers for `thinking` content-block start,
   `thinking_delta`, `signature_delta`, and `event: error` SSE events that the
   `default:` branch previously dropped. Adds optional `*ir.IRExtensions`
   parameter to `TransformSSEChunkToOpenAI` (existing caller passes nil;
   backward-compatible). Surfaces upstream errors as
   `finish_reason: "error"` + synthetic content delta carrying the message.
2. **`[Router] extend StreamState with OpenAI-to-Anthropic direction fields`** —
   reuses the existing `StreamState` struct from #1926; adds
   `NextBlockIndex`, `OpenTextBlockIndex`, `OpenThinkingBlockIdx`,
   `ToolIdxToBlockIndex`, `LastChunkAt`, `InitialUsage` (tool start emission is tracked via `ToolIdxToBlockIndex` presence, not a separate flag).
3. **`[Router] add Anthropic outbound SSE emitter`** — heavy commit. New
   `pkg/anthropic/sse_out.go` with `EmitAnthropicSSEChunk` and per-event
   helpers (`message_start`, `content_block_start/_delta/_stop` per text /
   thinking / tool_use, `message_delta`, `message_stop`). Pure function;
   no extproc wiring. Reuses `buildAnthropicUsage` and
   `mapOpenAIFinishReasonToAnthropic` from PR4's `outbound.go`.
4. **`[Router] route Anthropic clients through SSE emitter on streaming response`** —
   new dispatcher branch in `handleResponseBody`; tightens the existing #1926
   branch to fire only when the client is NOT Anthropic. New
   `handleAnthropicClientStreamingResponseBody` handles the "double-Anthropic"
   cell (Anthropic client + Anthropic backend). The handler always replaces
   the response body with the emitter's bytes (even when the emitter produced
   nothing for a given chunk) so the raw upstream Anthropic frames never leak
   through on top of our synthesized events. Regression test
   `TestHandleAnthropicClientStreamingResponseBody_SuppressesUpstreamTail`
   locks this in. (See "Bug-fix during E2E verification" below.)
5. **`[Router] add ping keepalive for Anthropic streaming responses`** —
   15-second ping cadence. Implemented as a chunk-handler-driven check
   (emit a ping if it's been ≥15s since the last event) rather than a
   per-request goroutine. Rationale: in Envoy ext_proc, bytes can only be
   emitted during response callbacks. A goroutine could enqueue but cannot
   actually push during true backend silence, so the goroutine's incremental
   value is small and the lifecycle complexity is real. Pure helper
   `maybeEmitPing` keeps the surface compatible if reviewers prefer a
   goroutine approach later.
6. **`[Router] propagate cache and stop-reason fields through streaming emitter`** —
   `ext.CacheReadInputTokens`, `AnthropicStopReason`, and `signature_delta`
   capture into `ThinkingSignatures` so the streaming path matches the
   non-streaming PR4 round-trip.

## Notable design decisions

- **Ping keepalive (chunk-driven, not goroutine)**: see commit 5 message above.
  This diverges from the original plan; documented in the commit message for
  reviewer engagement.
- **"Double-Anthropic" cell** (Anthropic client + Anthropic backend) resolved
  by branch ordering: PR5's `ClientProtocol == "anthropic"` branch fires
  first, then the existing #1926 branch is tightened to
  `APIFormat == Anthropic && ClientProtocol != "anthropic"`. One-line
  condition change but load-bearing; `TestHandleResponseBody_StreamingDispatchMatrix` covers
  all four cells.
- **Thinking emission**: structurally-correct events (`content_block_start`
  with `type: "thinking"`, `thinking_delta` events) but TODO placeholder
  on the user-visible text content, mirroring PR4's approach. One-line fix
  when upstream #1718 lands.
- **Anthropic-client streaming handler owns the wire unconditionally** (added
  in v2 after E2E verification, folded into commit 4): once
  `handleAnthropicClientStreamingResponseBody` runs, every response body
  callback returns a `BodyMutation` carrying the emitter's bytes — even when
  those bytes are empty. A `nil` BodyMutation would make Envoy forward the
  raw upstream chunk unmodified, which leaks Anthropic frames from the
  backend onto the wire on top of the events we synthesized.

## Bug-fix during E2E verification

A duplicate `message_stop` event was observed during the streaming E2E test
through the double-Anthropic cell. Symptom: client received two
`event: message_stop` frames at end-of-stream — the first was the emitter's
clean synthesized stop (emitted on the prior chunk's `message_delta` +
usage), the second was the raw upstream `message_stop` (visible by its
trailing-whitespace JSON formatting from the backend) passed through Envoy
unmodified. Root cause: the handler returned a `nil` BodyMutation when the
emitter produced zero bytes for the terminal chunk (which contained only
the upstream `message_stop` → `[DONE]` after translation), and Envoy then
forwarded the original upstream bytes. Fix folded into commit 4: always
replace the body, never return a nil mutation once we're in this handler.
Regression test added.

## Deferred / known follow-ups

- **Golden SSE fixture round-trip tests** (~12 fixture pairs): deferred —
  the extproc test binary cannot link locally (Rust CGO bindings absent),
  so end-to-end fixture tests would defer verification to PR review without
  local sign-off. Pure-function emitter tests in `sse_out_test.go` cover
  the state machine. Recommend filing as a follow-up.
- **E2E SDK contract test** (`e2e/testing/10-anthropic-sdk-contract.py`):
  also deferred — needs live infrastructure.
- **Goroutine-based ping** (if reviewers prefer): pure helper
  `maybeEmitPing` is the seam.

## What's next (sibling PR, not in this series)

A small **sibling bug-fix PR** for the pre-existing `pkg/anthropic/client.go`
non-streaming defects (`tool_result.is_error` silently dropped; `tool_result`
array content flattened to empty string). Separate from this series — the
client.go defects are in a different code path from this PR's streaming work.

## Test plan

- [x] `make agent-lint` clean on all 7 files
- [x] `go vet`/`go build`/`go test` clean on `pkg/anthropic/...` (the bulk
      of PR5; pure-function SSE emitter state-machine tests)
- [x] DCO sign-off on all 6 commits, SSH-signed
- [x] Per-commit trajectory verified
- [x] Bug-fix regression tests in `client_stream_test.go` lock the
      4-event-drop fixes
- [x] `sse_out_test.go` (~285 LOC) exercises `EmitAnthropicSSEChunk` state
      machine: message_start emitted once, content_block_start/_stop per
      block, tool_use input_json_delta partial-args accumulation,
      message_delta with stop_reason, ping cadence
- [x] E2E streaming verification against a real Anthropic-shape backend
      (vertex against an Anthropic-shape backend): exactly one `message_stop` event per
      stream, spec-correct ordering, non-streaming round-trip unaffected.
      Surfaced and fixed the duplicate-message_stop bug above.
- [x] E2E test added: `e2e/testcases/anthropic_messages_streaming.go` (`anthropic-messages-streaming`) — consumes SSE from streaming `/v1/messages`, asserts `message_start` → `content_block_start` → `content_block_delta`+ → `content_block_stop` → `message_delta` → `message_stop` event ordering with exactly one terminal `message_stop`
- [ ] Upstream CI — runs once this PR is marked ready

## Related

- Stacks on #1940, #1939
- Builds on #1938 (PR2: IR + inbound parser, now merged)
- Builds on #1937 (PR1: ClientProtocol detection, now merged)
- Tracking issue: #1404
- Symmetric inverse of #1926 (Anthropic→OpenAI SSE)
- Adjacent: #1718 (Anthropic thinking response, draft — would supply the
  one-line fix for the thinking-block text placeholder)




