### PR TITLE
[Router][Bugfix] router_replay: fix silent postgres INSERT failure that leaves dashboard Insight empty

### DIFF
--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -321,6 +321,11 @@ func persistReplayRecord(
 ) bool {
 	replayID, err := recorder.AddRecord(record)
 	if err != nil {
+		logging.ComponentErrorEvent("extproc", "router_replay_persist_failed", map[string]interface{}{
+			"request_id": ctx.RequestID,
+			"decision":   record.Decision,
+			"error":      err.Error(),
+		})
 		return false
 	}
 	ctx.RouterReplayID = replayID

--- a/src/semantic-router/pkg/extproc/router_replay_setup.go
+++ b/src/semantic-router/pkg/extproc/router_replay_setup.go
@@ -255,11 +255,15 @@ func createReplayPostgresStore(globalCfg *config.RouterReplayConfig) (store.Stor
 	if err != nil {
 		return nil, fmt.Errorf("failed to create postgres store: %w", err)
 	}
+	tableName := pgConfig.TableName
+	if tableName == "" {
+		tableName = store.DefaultPostgresTableName
+	}
 	logging.Debugf(
 		"Router replay using postgres backend (host=%s, db=%s, table=%s, ttl=%ds, async=%v)",
 		pgConfig.Host,
 		pgConfig.Database,
-		pgConfig.TableName,
+		tableName,
 		globalCfg.TTLSeconds,
 		globalCfg.AsyncWrites,
 	)

--- a/src/semantic-router/pkg/routerreplay/store/postgres.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres.go
@@ -13,6 +13,31 @@ import (
 
 const DefaultPostgresTableName = "router_replay_records"
 
+// postgresInsertQueryTemplate is the parameterized INSERT statement used by
+// PostgresStore.Add. The single %s slot receives the validated table name.
+//
+// The column list, the $N placeholders, and the slice returned by
+// postgresInsertRecord.args() must stay in sync — a mismatch silently breaks
+// every replay write (postgres returns "more target columns than expressions"
+// or vice versa, which is then swallowed by the Recorder). The invariant is
+// guarded by TestPostgresInsertQueryColumnArgsAlignment.
+const postgresInsertQueryTemplate = `
+		INSERT INTO %s (
+			id, timestamp, request_id, decision, decision_tier, decision_priority, category,
+			original_model, selected_model, reasoning_mode,
+			signals, projections, projection_scores, signal_confidences, signal_values, tool_trace, projection_trace,
+			request_body, response_body, response_status,
+			from_cache, streaming, request_body_truncated, response_body_truncated,
+			guardrails_enabled, jailbreak_enabled, pii_enabled,
+			prompt, prompt_truncated, tool_definitions, tool_definitions_truncated,
+			rag_enabled, rag_backend, rag_context_length, rag_similarity_score,
+			hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
+			prompt_tokens, completion_tokens, total_tokens,
+			actual_cost, baseline_cost, cost_savings, currency, baseline_model,
+			session_id, turn_index, previous_response_id, conversation_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51)
+	`
+
 // PostgresStore implements Storage using PostgreSQL as the backend.
 type PostgresStore struct {
 	db          *sql.DB
@@ -182,22 +207,7 @@ func (p *PostgresStore) Add(ctx context.Context, record Record) (string, error) 
 	}
 
 	//nolint:gosec // tableName is validated during store creation
-	query := fmt.Sprintf(`
-		INSERT INTO %s (
-			id, timestamp, request_id, decision, decision_tier, decision_priority, category,
-			original_model, selected_model, reasoning_mode,
-			signals, projections, projection_scores, signal_confidences, signal_values, tool_trace, projection_trace,
-			request_body, response_body, response_status,
-			from_cache, streaming, request_body_truncated, response_body_truncated,
-			guardrails_enabled, jailbreak_enabled, pii_enabled,
-			prompt, prompt_truncated, tool_definitions, tool_definitions_truncated,
-			rag_enabled, rag_backend, rag_context_length, rag_similarity_score,
-			hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
-			prompt_tokens, completion_tokens, total_tokens,
-			actual_cost, baseline_cost, cost_savings, currency, baseline_model,
-			session_id, turn_index, previous_response_id, conversation_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50)
-	`, p.tableName)
+	query := fmt.Sprintf(postgresInsertQueryTemplate, p.tableName)
 
 	fn := func() error {
 		_, err := p.db.ExecContext(ctx, query, insertRecord.args()...)

--- a/src/semantic-router/pkg/routerreplay/store/postgres_insert_query_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_insert_query_test.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPostgresInsertQueryColumnArgsAlignment pins the three-way invariant
+// between the INSERT column list, the $N placeholder list, and the slice
+// returned by postgresInsertRecord.args().
+//
+// Background: PR #1857 added projection_trace to the column list but forgot
+// to add $51 to the VALUES clause. Postgres rejected every write with
+// "INSERT has more target columns than expressions"; the error was swallowed
+// by persistReplayRecord and the dashboard Insight panel silently stayed
+// empty for 25 days before anyone noticed.
+func TestPostgresInsertQueryColumnArgsAlignment(t *testing.T) {
+	cols := extractInsertColumns(t, postgresInsertQueryTemplate)
+	if len(cols) == 0 {
+		t.Fatalf("could not extract column list from postgresInsertQueryTemplate")
+	}
+
+	placeholders := extractInsertPlaceholders(t, postgresInsertQueryTemplate)
+	if len(placeholders) == 0 {
+		t.Fatalf("could not extract placeholder list from postgresInsertQueryTemplate")
+	}
+
+	args := samplePostgresInsertArgs(t)
+
+	if len(cols) != len(placeholders) {
+		t.Errorf("column / placeholder count mismatch: %d columns vs %d placeholders\ncolumns=%v\nplaceholders=%v",
+			len(cols), len(placeholders), cols, placeholders)
+	}
+	if len(cols) != len(args) {
+		t.Errorf("column / args count mismatch: %d columns vs %d args from postgresInsertRecord.args()",
+			len(cols), len(args))
+	}
+	if len(placeholders) != len(args) {
+		t.Errorf("placeholder / args count mismatch: %d placeholders vs %d args", len(placeholders), len(args))
+	}
+
+	for i, p := range placeholders {
+		want := "$" + itoa(i+1)
+		if p != want {
+			t.Errorf("placeholder #%d is %q, expected %q (placeholders must be sequential $1..$N)", i+1, p, want)
+		}
+	}
+}
+
+// extractInsertColumns parses the column list between
+// `INSERT INTO %s (` and `) VALUES`.
+func extractInsertColumns(t *testing.T, tmpl string) []string {
+	t.Helper()
+	start := strings.Index(tmpl, "INSERT INTO %s (")
+	if start < 0 {
+		return nil
+	}
+	start += len("INSERT INTO %s (")
+	end := strings.Index(tmpl[start:], ") VALUES")
+	if end < 0 {
+		return nil
+	}
+	raw := tmpl[start : start+end]
+	parts := strings.Split(raw, ",")
+	cols := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			continue
+		}
+		cols = append(cols, trimmed)
+	}
+	return cols
+}
+
+// extractInsertPlaceholders parses the $N placeholders after `VALUES (`.
+func extractInsertPlaceholders(t *testing.T, tmpl string) []string {
+	t.Helper()
+	re := regexp.MustCompile(`\$\d+`)
+	valuesIdx := strings.Index(tmpl, "VALUES (")
+	if valuesIdx < 0 {
+		return nil
+	}
+	return re.FindAllString(tmpl[valuesIdx:], -1)
+}
+
+// samplePostgresInsertArgs builds a minimal Record, runs it through the
+// production insert-record builder, and returns the resulting args slice.
+// We do not assert specific values — only the slice length.
+func samplePostgresInsertArgs(t *testing.T) []interface{} {
+	t.Helper()
+	rec := Record{
+		ID:        "test-id",
+		Timestamp: time.Now().UTC(),
+	}
+	built, err := newPostgresInsertRecord(rec)
+	if err != nil {
+		t.Fatalf("newPostgresInsertRecord: %v", err)
+	}
+	return built.args()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Summary

Three related bugs that compound into one user-visible problem: **dashboards backed by `store_backend: postgres` show an empty Insight panel** even when traffic flows successfully through the router.

| # | File | Bug | Severity |
|---|------|-----|----------|
| 1 | `pkg/routerreplay/store/postgres.go` | `INSERT` lists 51 columns but `VALUES` only has 50 `$N` placeholders — every write fails | **Functional regression** |
| 2 | `pkg/extproc/recorder.go` | `persistReplayRecord` swallows `AddRecord` errors with `return false` and no log | **Observability gap** — concealed #1 for 25 days |
| 3 | `pkg/extproc/router_replay_setup.go` | Init log prints raw `pgConfig.TableName` (often empty) instead of the effective table | **Cosmetic** — sent me on a 30-min detour while debugging |

#1 is the root cause; the column / placeholder count went out of sync in [#1857](https://github.com/vllm-project/semantic-router/pull/1857) (2026-05-01) when `projection_trace` was added to the column list without a matching `$51` in `VALUES`. Postgres rejects every write with:

```
ERROR: INSERT has more target columns than expressions at character 877
```

#2 is the reason this stayed undiscovered for ~25 days: `recorder.AddRecord` returns the postgres error, but `persistReplayRecord` discards it and returns `false`. Nothing — no log, no metric — surfaces the failure to operators.

## Reproduction (on `origin/main` before fix)

```bash
# Postgres logs reveal what dashboard hides:
docker exec vllm-sr-postgres psql -U router -d vsr \
  -c "ALTER SYSTEM SET log_statement = 'all';" \
  -c "SELECT pg_reload_conf();"

# Any auto-routed request:
curl -X POST http://localhost:8999/v1/chat/completions \
  -d '{"model":"auto","messages":[{"role":"user","content":"Show a Python decorator example"}],"max_tokens":30}'
```

Postgres log:
```
ERROR: INSERT has more target columns than expressions at character 877
        INSERT INTO router_replay_records (
```

Router log: completely silent on the failure. `record_count` from `/v1/router_replay/aggregate` stays at 0 even though traffic flowed.

## Fixes

### Commit 1 — `add missing $51 placeholder for projection_trace column`
- Add `$51` to the `VALUES (...)` clause.
- Extract the INSERT into a named `postgresInsertQueryTemplate` constant with a comment naming the three-way invariant (columns / placeholders / `args()`).
- Add `TestPostgresInsertQueryColumnArgsAlignment` which parses the template and asserts the counts match. Test catches the original bug with a precise message:
  ```
  column / placeholder count mismatch: 51 columns vs 50 placeholders
  placeholder / args count mismatch: 50 placeholders vs 51 args
  ```

### Commit 2 — `log AddRecord failures instead of swallowing`
- Emit `router_replay_persist_failed` component error event with `request_id`, `decision`, and the error message.
- Matches the existing style of `router_replay_status_update_failed` (recorder.go:355), `router_replay_hallucination_update_failed` (line 430), and `router_replay_usage_update_failed` (line 452).
- Pure observability change — no behaviour change on the happy path.

### Commit 3 — `log the effective postgres table name`
- `createReplayPostgresStore` now resolves `pgConfig.TableName == ""` to `store.DefaultPostgresTableName` before logging, so the init log matches what `PostgresStore` actually uses.

## Verification

### Unit tests
```
$ go test ./pkg/routerreplay/...
ok  	github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay        	0.006s
ok  	github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store  	0.007s
```

Regression test verified: temporarily reverting only the `$51` addition makes `TestPostgresInsertQueryColumnArgsAlignment` fail with the exact mismatch above, confirming it pins the invariant.

`go vet ./pkg/routerreplay/... ./pkg/extproc/...` — clean.
`gofmt -d` — clean.

### End-to-end (local docker image rebuilt from this branch)

Before fix (`vllm-sr:latest` baseline image):
```
postgres router_replay_records rows:   0
/v1/router_replay/aggregate record_count: 0
available_decisions: []
available_models:    []
```

After fix (local rebuild of `src/vllm-sr/Dockerfile`):
```
postgres router_replay_records rows:   5
/v1/router_replay/aggregate record_count: 5
available_decisions: ['external_when_not_confidential', 'internal_default']
available_models:    ['auto', 'claude-opus-4-7', 'qwen3-122b']
token_volume:        {input_tokens: 55, output_tokens: 50, total_tokens: 105}
```

`router_replay_start` event now appears in the router log per successful request:
```json
{
  "msg": "router_replay_start",
  "event": "router_replay_start",
  "decision": "external_when_not_confidential",
  "selected_model": "claude-opus-4-7",
  "replay_id": "33ccdd533ef42eb7a035f696af60d4ac",
  "original_model": "auto",
  "request_id": "8a1f781e-2267-48c1-a2d9-9b5125edfeb9"
}
```

## Risk and scope

- All three changes are scoped to the `routerreplay` write path and the postgres backend specifically.
- No behavioural change for the `memory`, `redis`, `milvus`, or `qdrant` backends (those store implementations were unaffected by #1857).
- The regression test is pure (no postgres dependency) — runs in the existing `go test ./pkg/routerreplay/store/` CI lane.
- Public API unchanged.

## Related

- Introduced by #1857 (column added without matching placeholder).
- Touches files last edited by #1107, #1579, #1601, #1760, #1857.