### PR TITLE
fix(anthropic): preserve client passthrough fields through ToAnthropicRequestBody

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -23,6 +23,7 @@ var BaselineRouterContract = []string{
 	"decision-fallback-behavior",
 	"plugin-config-variations",
 	"chat-completions-progressive-stress",
+	"anthropic-passthrough-openai-regression",
 	// Session observability
 	"session-telemetry-metrics",
 	"session-pricing-chat-completions",

--- a/e2e/testcases/anthropic_passthrough_regression.go
+++ b/e2e/testcases/anthropic_passthrough_regression.go
@@ -1,0 +1,93 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-passthrough-openai-regression", pkgtestcases.TestCase{
+		Description: "Verify the Anthropic passthrough carrier does not regress OpenAI chat completions requests",
+		Tags:        []string{"anthropic", "passthrough", "regression"},
+		Fn:          testAnthropicPassthroughOpenAIRegression,
+	})
+}
+
+// testAnthropicPassthroughOpenAIRegression guards the OpenAI request path
+// against regressions introduced by the Anthropic passthrough carrier.
+//
+// The passthrough machinery (cache_control replay, anthropic-version
+// forwarding, image-block preservation, multi-block system reassembly)
+// only fires when routing prepares an Anthropic-native upstream request.
+// The e2e backend (llm-katan) is OpenAI-shaped, so the positive path is
+// not exercisable here without scope-expanding the e2e infrastructure to
+// add an Anthropic-native mock — explicitly out of scope for this PR.
+//
+// What is exercisable: this test sends a standard OpenAI request and
+// asserts a clean 200 round-trip with routing headers. That guards
+// against the case where the new carrier construction code accidentally
+// breaks the dominant OpenAI traffic shape (regression). Per-field
+// behavior of the carrier itself (cache_control, image blocks,
+// anthropic-version) is covered by unit tests in
+// src/semantic-router/pkg/anthropic.
+func testAnthropicPassthroughOpenAIRegression(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic passthrough] OpenAI regression: verifying OpenAI path is unaffected")
+	}
+
+	session, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	chatClient := fixtures.NewChatCompletionsClient(session, 30*time.Second)
+	resp, err := chatClient.Create(ctx, fixtures.ChatCompletionsRequest{
+		Model: "MoM",
+		Messages: []fixtures.ChatMessage{
+			{Role: "user", Content: "Briefly describe how DNS resolution works."},
+		},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("openai chat completions request failed: %w", err)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code":     resp.StatusCode,
+			"response_length": len(resp.Body),
+			"decision":        resp.Headers.Get("x-vsr-selected-decision"),
+			"selected_model":  resp.Headers.Get("x-vsr-selected-model"),
+		})
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200 for openai /v1/chat/completions, got %d: %s",
+			resp.StatusCode, truncateString(string(resp.Body), 200))
+	}
+	if len(resp.Body) == 0 {
+		return fmt.Errorf("expected non-empty response body")
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(resp.Body, &parsed); err != nil {
+		return fmt.Errorf("response body is not valid JSON: %w", err)
+	}
+
+	// At least one routing header must be set; otherwise the request bypassed
+	// the routing pipeline and the regression check is meaningless.
+	if resp.Headers.Get("x-vsr-selected-decision") == "" &&
+		resp.Headers.Get("x-vsr-selected-model") == "" {
+		return fmt.Errorf("expected x-vsr-selected-decision or x-vsr-selected-model header to be set")
+	}
+
+	return nil
+}

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -120,6 +120,7 @@ func ToAnthropicRequestBodyWithPassthrough(openAIRequest *openai.ChatCompletionN
 	applyToolsCacheControl(&params, pt)
 	applyMessagesCacheControl(params.Messages, pt)
 	applyUserMessageImageBlocks(params.Messages, pt)
+	applyToolResultPassthrough(params.Messages, pt)
 	applySampling(&params, openAIRequest, pt)
 	applyMetadata(&params, openAIRequest, pt)
 
@@ -438,6 +439,83 @@ func applyUserMessageImageBlocks(messages []anthropic.MessageParam, pt *Anthropi
 			messages[i].Content = append(messages[i].Content, block)
 		}
 	}
+}
+
+// applyToolResultPassthrough overwrites tool_result blocks with the passthrough
+// payload: is_error: true is restored from pt.ToolResultErrors, and array
+// content (text + image blocks) is restored from pt.ToolResultArrayContent.
+// Matches by tool_use_id; missing keys leave the block as today's
+// translation produced it.
+func applyToolResultPassthrough(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
+	if pt == nil || (len(pt.ToolResultErrors) == 0 && len(pt.ToolResultArrayContent) == 0) {
+		return
+	}
+	for i := range messages {
+		for j := range messages[i].Content {
+			tr := messages[i].Content[j].OfToolResult
+			if tr == nil || tr.ToolUseID == "" {
+				continue
+			}
+			if isErr, ok := pt.ToolResultErrors[tr.ToolUseID]; ok && isErr {
+				tr.IsError = anthropic.Bool(true)
+			}
+			if blocks, ok := pt.ToolResultArrayContent[tr.ToolUseID]; ok && len(blocks) > 0 {
+				tr.Content = toSDKToolResultContent(blocks)
+			}
+		}
+	}
+}
+
+func toSDKToolResultContent(blocks []ToolResultContentBlock) []anthropic.ToolResultBlockParamContentUnion {
+	out := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			out = append(out, anthropic.ToolResultBlockParamContentUnion{
+				OfText: &anthropic.TextBlockParam{Text: b.Text},
+			})
+		case "image":
+			if b.Source == nil {
+				continue
+			}
+			img, ok := buildImageParamFromSource(*b.Source)
+			if !ok {
+				continue
+			}
+			out = append(out, anthropic.ToolResultBlockParamContentUnion{OfImage: img})
+		}
+	}
+	return out
+}
+
+// buildImageParamFromSource is the variant of buildImageBlockFromSource that
+// returns the raw *ImageBlockParam needed by ToolResultBlockParamContentUnion
+// (which embeds ImageBlockParam directly rather than via NewImageBlock).
+func buildImageParamFromSource(src ImageSource) (*anthropic.ImageBlockParam, bool) {
+	switch src.Type {
+	case "base64":
+		if src.Data == "" || src.MediaType == "" {
+			return nil, false
+		}
+		return &anthropic.ImageBlockParam{
+			Source: anthropic.ImageBlockParamSourceUnion{
+				OfBase64: &anthropic.Base64ImageSourceParam{
+					Data:      src.Data,
+					MediaType: anthropic.Base64ImageSourceMediaType(src.MediaType),
+				},
+			},
+		}, true
+	case "url":
+		if src.URL == "" {
+			return nil, false
+		}
+		return &anthropic.ImageBlockParam{
+			Source: anthropic.ImageBlockParamSourceUnion{
+				OfURL: &anthropic.URLImageSourceParam{URL: src.URL},
+			},
+		}, true
+	}
+	return nil, false
 }
 
 func buildImageBlockFromSource(src ImageSource) (anthropic.ContentBlockParamUnion, bool) {

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -96,6 +96,7 @@ func ToAnthropicRequestBodyWithPassthrough(openAIRequest *openai.ChatCompletionN
 	}
 	applyToolsCacheControl(&params, pt)
 	applyMessagesCacheControl(params.Messages, pt)
+	applyUserMessageImageBlocks(params.Messages, pt)
 	applySampling(&params, openAIRequest, pt)
 	applyMetadata(&params, openAIRequest, pt)
 
@@ -293,7 +294,10 @@ func extractSystemContent(msg *openai.ChatCompletionSystemMessageParam) string {
 	return strings.Join(parts, " ")
 }
 
-// extractUserContent extracts text from a user message
+// extractUserContent extracts text from a user message. Kept for
+// backwards-compatibility with callers that only need the flattened text
+// representation; userMessageBlocks is the structured form used by the
+// outbound writer (which also preserves image blocks).
 func extractUserContent(msg *openai.ChatCompletionUserMessageParam) string {
 	if msg.Content.OfString.Value != "" {
 		return msg.Content.OfString.Value
@@ -305,6 +309,131 @@ func extractUserContent(msg *openai.ChatCompletionUserMessageParam) string {
 		}
 	}
 	return strings.Join(parts, " ")
+}
+
+// userMessageBlocks converts an OpenAI user message into a slice of Anthropic
+// content blocks, preserving image_url parts as Anthropic image blocks. This
+// fixes the long-standing drop where image content (OpenAI-shape OfImageURL)
+// was flattened to an empty string by extractUserContent, causing the model to
+// report "I don't see any image attached" on the upstream side.
+func userMessageBlocks(msg *openai.ChatCompletionUserMessageParam) []anthropic.ContentBlockParamUnion {
+	if msg.Content.OfString.Value != "" {
+		return []anthropic.ContentBlockParamUnion{anthropic.NewTextBlock(msg.Content.OfString.Value)}
+	}
+	var blocks []anthropic.ContentBlockParamUnion
+	var textParts []string
+	flushText := func() {
+		if len(textParts) > 0 {
+			blocks = append(blocks, anthropic.NewTextBlock(strings.Join(textParts, " ")))
+			textParts = nil
+		}
+	}
+	for _, part := range msg.Content.OfArrayOfContentParts {
+		switch {
+		case part.OfText != nil:
+			textParts = append(textParts, part.OfText.Text)
+		case part.OfImageURL != nil:
+			flushText()
+			if block, ok := openAIImageURLToAnthropicBlock(part.OfImageURL.ImageURL.URL); ok {
+				blocks = append(blocks, block)
+			}
+		}
+	}
+	flushText()
+	return blocks
+}
+
+// openAIImageURLToAnthropicBlock parses an OpenAI image_url value into an
+// Anthropic image block. Both data-URI (data:image/<type>;base64,<data>) and
+// plain URL forms are supported; unrecognised shapes are skipped.
+func openAIImageURLToAnthropicBlock(url string) (anthropic.ContentBlockParamUnion, bool) {
+	const dataURIPrefix = "data:"
+	if strings.HasPrefix(url, dataURIPrefix) {
+		mediaType, data, ok := parseDataURI(url)
+		if !ok {
+			return anthropic.ContentBlockParamUnion{}, false
+		}
+		return anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
+			Data:      data,
+			MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
+		}), true
+	}
+	if url == "" {
+		return anthropic.ContentBlockParamUnion{}, false
+	}
+	return anthropic.NewImageBlock(anthropic.URLImageSourceParam{URL: url}), true
+}
+
+// parseDataURI extracts the media type and base64-encoded payload from a data
+// URI of the form `data:<media-type>;base64,<data>`. Returns ok=false for any
+// other shape.
+func parseDataURI(uri string) (mediaType, data string, ok bool) {
+	const prefix = "data:"
+	if !strings.HasPrefix(uri, prefix) {
+		return "", "", false
+	}
+	rest := uri[len(prefix):]
+	comma := strings.IndexByte(rest, ',')
+	if comma < 0 {
+		return "", "", false
+	}
+	header := rest[:comma]
+	payload := rest[comma+1:]
+	if !strings.Contains(header, ";base64") {
+		return "", "", false
+	}
+	mediaType = strings.TrimSuffix(header, ";base64")
+	if mediaType == "" {
+		return "", "", false
+	}
+	return mediaType, payload, true
+}
+
+// applyUserMessageImageBlocks appends image blocks captured in the passthrough
+// to the matching user message. Indexing is user-message-only (index 0 = first
+// user message in messages[]). When the index is out of range, images are
+// silently dropped to match the surrounding lossy-translation discipline.
+func applyUserMessageImageBlocks(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
+	if pt == nil || len(pt.UserMessageImageBlocks) == 0 {
+		return
+	}
+	userIdx := -1
+	for i := range messages {
+		if messages[i].Role != anthropic.MessageParamRoleUser {
+			continue
+		}
+		userIdx++
+		images, ok := pt.UserMessageImageBlocks[userIdx]
+		if !ok {
+			continue
+		}
+		for _, img := range images {
+			block, ok := buildImageBlockFromSource(img.Source)
+			if !ok {
+				continue
+			}
+			messages[i].Content = append(messages[i].Content, block)
+		}
+	}
+}
+
+func buildImageBlockFromSource(src ImageSource) (anthropic.ContentBlockParamUnion, bool) {
+	switch src.Type {
+	case "base64":
+		if src.Data == "" || src.MediaType == "" {
+			return anthropic.ContentBlockParamUnion{}, false
+		}
+		return anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
+			Data:      src.Data,
+			MediaType: anthropic.Base64ImageSourceMediaType(src.MediaType),
+		}), true
+	case "url":
+		if src.URL == "" {
+			return anthropic.ContentBlockParamUnion{}, false
+		}
+		return anthropic.NewImageBlock(anthropic.URLImageSourceParam{URL: src.URL}), true
+	}
+	return anthropic.ContentBlockParamUnion{}, false
 }
 
 // extractAssistantContent extracts text from an assistant message
@@ -332,9 +461,10 @@ func buildAnthropicMessages(
 		case msg.OfSystem != nil:
 			systemPrompt = extractSystemContent(msg.OfSystem)
 		case msg.OfUser != nil:
-			anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(
-				anthropic.NewTextBlock(extractUserContent(msg.OfUser)),
-			))
+			blocks := userMessageBlocks(msg.OfUser)
+			if len(blocks) > 0 {
+				anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(blocks...))
+			}
 		case msg.OfAssistant != nil:
 			blocks, err := assistantContentBlocks(msg.OfAssistant)
 			if err != nil {

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -64,52 +64,84 @@ func HeadersToRemove() []string {
 
 // ToAnthropicRequestBody transforms an OpenAI-format request to Anthropic API format (JSON).
 // This is used for Envoy-routed requests where the router transforms the body
-// before forwarding to Anthropic via Envoy.
+// before forwarding to Anthropic via Envoy. Equivalent to calling
+// ToAnthropicRequestBodyWithPassthrough with a nil passthrough.
 func ToAnthropicRequestBody(openAIRequest *openai.ChatCompletionNewParams) ([]byte, error) {
+	return ToAnthropicRequestBodyWithPassthrough(openAIRequest, nil)
+}
+
+// ToAnthropicRequestBodyWithPassthrough transforms an OpenAI-format request to
+// Anthropic API format and replays Anthropic-only fields carried in pt.
+//
+// Passing a nil passthrough is byte-identical to ToAnthropicRequestBody —
+// existing callers and behaviour are preserved. When pt is non-nil, fields
+// without an OpenAI representation (cache_control markers, top_k,
+// metadata.user_id, multi-block system prompts, image blocks, tool_result
+// error/array content) are emitted on the outbound body.
+func ToAnthropicRequestBodyWithPassthrough(openAIRequest *openai.ChatCompletionNewParams, pt *AnthropicPassthrough) ([]byte, error) {
 	systemPrompt, messages, err := buildAnthropicMessages(openAIRequest.Messages)
 	if err != nil {
 		return nil, err
 	}
 
-	// Determine max tokens (required for Anthropic)
-	maxTokens := DefaultMaxTokens
-	if openAIRequest.MaxCompletionTokens.Value > 0 {
-		maxTokens = openAIRequest.MaxCompletionTokens.Value
-	} else if openAIRequest.MaxTokens.Value > 0 {
-		maxTokens = openAIRequest.MaxTokens.Value
-	}
-
 	params := anthropic.MessageNewParams{
 		Model:     anthropic.Model(openAIRequest.Model),
 		Messages:  messages,
-		MaxTokens: maxTokens,
-	}
-
-	// Set system prompt if present
-	if systemPrompt != "" {
-		params.System = []anthropic.TextBlockParam{
-			{Text: systemPrompt},
-		}
+		MaxTokens: resolveMaxTokens(openAIRequest),
+		System:    buildSystem(systemPrompt, pt),
 	}
 
 	if err := applyOpenAIToolsToAnthropicParams(&params, openAIRequest); err != nil {
 		return nil, err
 	}
-
-	// Set optional parameters
-	if openAIRequest.Temperature.Valid() {
-		params.Temperature = anthropic.Float(openAIRequest.Temperature.Value)
-	}
-	if openAIRequest.TopP.Valid() {
-		params.TopP = anthropic.Float(openAIRequest.TopP.Value)
-	}
-	if len(openAIRequest.Stop.OfStringArray) > 0 {
-		params.StopSequences = openAIRequest.Stop.OfStringArray
-	} else if openAIRequest.Stop.OfString.Value != "" {
-		params.StopSequences = []string{openAIRequest.Stop.OfString.Value}
-	}
+	applySampling(&params, openAIRequest, pt)
+	applyMetadata(&params, openAIRequest, pt)
 
 	return json.Marshal(params)
+}
+
+// resolveMaxTokens picks max_tokens with Anthropic's required default.
+func resolveMaxTokens(req *openai.ChatCompletionNewParams) int64 {
+	switch {
+	case req.MaxCompletionTokens.Value > 0:
+		return req.MaxCompletionTokens.Value
+	case req.MaxTokens.Value > 0:
+		return req.MaxTokens.Value
+	default:
+		return DefaultMaxTokens
+	}
+}
+
+// buildSystem returns the Anthropic system array. When no passthrough is
+// supplied (or its SystemBlocks slice is empty), it falls back to the
+// string-form system derived from the OpenAI messages, preserving today's
+// behaviour byte-for-byte.
+func buildSystem(systemPrompt string, _ *AnthropicPassthrough) []anthropic.TextBlockParam {
+	if systemPrompt == "" {
+		return nil
+	}
+	return []anthropic.TextBlockParam{{Text: systemPrompt}}
+}
+
+// applySampling sets temperature, top_p, and stop_sequences from the OpenAI
+// request. Reserved for future top_k replay from passthrough.
+func applySampling(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, _ *AnthropicPassthrough) {
+	if req.Temperature.Valid() {
+		params.Temperature = anthropic.Float(req.Temperature.Value)
+	}
+	if req.TopP.Valid() {
+		params.TopP = anthropic.Float(req.TopP.Value)
+	}
+	if len(req.Stop.OfStringArray) > 0 {
+		params.StopSequences = req.Stop.OfStringArray
+	} else if req.Stop.OfString.Value != "" {
+		params.StopSequences = []string{req.Stop.OfString.Value}
+	}
+}
+
+// applyMetadata is the metadata.user_id replay hook. Reserved for future use:
+// today's behaviour does not emit metadata, so this is a no-op when pt is nil.
+func applyMetadata(_ *anthropic.MessageNewParams, _ *openai.ChatCompletionNewParams, _ *AnthropicPassthrough) {
 }
 
 // ToOpenAIResponseBody transforms an Anthropic API response to OpenAI format.

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -32,17 +32,37 @@ type HeaderKeyValue struct {
 
 // BuildRequestHeaders returns the headers needed for an Anthropic API request.
 // messagesPath should include any base_url prefix (e.g. /Anthropic/v1/messages for AMD).
-// When empty, AnthropicMessagesPath (/v1/messages) is used.
+// When empty, AnthropicMessagesPath (/v1/messages) is used. Equivalent to
+// BuildRequestHeadersWithPassthrough with a nil passthrough.
 func BuildRequestHeaders(apiKey string, bodyLength int, messagesPath string) []HeaderKeyValue {
-	return buildRequestHeaders(apiKey, bodyLength, messagesPath, false)
+	return buildRequestHeaders(apiKey, bodyLength, messagesPath, false, nil)
 }
 
-func buildRequestHeaders(apiKey string, bodyLength int, messagesPath string, streaming bool) []HeaderKeyValue {
+// BuildRequestHeadersWithPassthrough is the passthrough-aware form of
+// BuildRequestHeaders. When pt.AnthropicVersion is non-empty it overrides the
+// package default; when pt.AnthropicBeta is non-empty an anthropic-beta header
+// is appended. Passing a nil passthrough is byte-identical to
+// BuildRequestHeaders.
+//
+// Header precedence (lowest to highest) is documented for callers that
+// combine this output with profile-supplied headers: package default <
+// passthrough < profile pin. Callers that append profile headers AFTER this
+// function's output (the convention in pkg/extproc) get this precedence for
+// free: a later HeaderValueOption with the same key wins on the Envoy side.
+func BuildRequestHeadersWithPassthrough(apiKey string, bodyLength int, messagesPath string, pt *AnthropicPassthrough) []HeaderKeyValue {
+	return buildRequestHeaders(apiKey, bodyLength, messagesPath, false, pt)
+}
+
+func buildRequestHeaders(apiKey string, bodyLength int, messagesPath string, streaming bool, pt *AnthropicPassthrough) []HeaderKeyValue {
 	if strings.TrimSpace(messagesPath) == "" {
 		messagesPath = AnthropicMessagesPath
 	}
+	version := AnthropicAPIVersion
+	if pt != nil && pt.AnthropicVersion != "" {
+		version = pt.AnthropicVersion
+	}
 	headers := []HeaderKeyValue{
-		{Key: "anthropic-version", Value: AnthropicAPIVersion},
+		{Key: "anthropic-version", Value: version},
 		{Key: "content-type", Value: "application/json"},
 		{Key: "accept-encoding", Value: "identity"},
 		{Key: ":path", Value: messagesPath},
@@ -50,6 +70,9 @@ func buildRequestHeaders(apiKey string, bodyLength int, messagesPath string, str
 	}
 	if streaming {
 		headers = append(headers, HeaderKeyValue{Key: "accept", Value: "text/event-stream"})
+	}
+	if pt != nil && pt.AnthropicBeta != "" {
+		headers = append(headers, HeaderKeyValue{Key: "anthropic-beta", Value: pt.AnthropicBeta})
 	}
 	if strings.TrimSpace(apiKey) != "" {
 		headers = append([]HeaderKeyValue{{Key: "x-api-key", Value: apiKey}}, headers...)

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -94,6 +94,8 @@ func ToAnthropicRequestBodyWithPassthrough(openAIRequest *openai.ChatCompletionN
 	if err := applyOpenAIToolsToAnthropicParams(&params, openAIRequest); err != nil {
 		return nil, err
 	}
+	applyToolsCacheControl(&params, pt)
+	applyMessagesCacheControl(params.Messages, pt)
 	applySampling(&params, openAIRequest, pt)
 	applyMetadata(&params, openAIRequest, pt)
 
@@ -112,11 +114,22 @@ func resolveMaxTokens(req *openai.ChatCompletionNewParams) int64 {
 	}
 }
 
-// buildSystem returns the Anthropic system array. When no passthrough is
-// supplied (or its SystemBlocks slice is empty), it falls back to the
-// string-form system derived from the OpenAI messages, preserving today's
-// behaviour byte-for-byte.
-func buildSystem(systemPrompt string, _ *AnthropicPassthrough) []anthropic.TextBlockParam {
+// buildSystem returns the Anthropic system array. When pt carries
+// SystemBlocks (array-form system from inbound), each block is emitted with
+// its cache_control marker; otherwise it falls back to the string-form system
+// derived from the OpenAI messages, preserving today's behaviour byte-for-byte.
+func buildSystem(systemPrompt string, pt *AnthropicPassthrough) []anthropic.TextBlockParam {
+	if pt != nil && len(pt.SystemBlocks) > 0 {
+		out := make([]anthropic.TextBlockParam, 0, len(pt.SystemBlocks))
+		for _, sb := range pt.SystemBlocks {
+			block := anthropic.TextBlockParam{Text: sb.Text}
+			if sb.CacheControl != nil {
+				block.CacheControl = toSDKCacheControl(*sb.CacheControl)
+			}
+			out = append(out, block)
+		}
+		return out
+	}
 	if systemPrompt == "" {
 		return nil
 	}
@@ -124,8 +137,8 @@ func buildSystem(systemPrompt string, _ *AnthropicPassthrough) []anthropic.TextB
 }
 
 // applySampling sets temperature, top_p, and stop_sequences from the OpenAI
-// request. Reserved for future top_k replay from passthrough.
-func applySampling(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, _ *AnthropicPassthrough) {
+// request, plus top_k from the passthrough when present.
+func applySampling(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, pt *AnthropicPassthrough) {
 	if req.Temperature.Valid() {
 		params.Temperature = anthropic.Float(req.Temperature.Value)
 	}
@@ -137,11 +150,82 @@ func applySampling(params *anthropic.MessageNewParams, req *openai.ChatCompletio
 	} else if req.Stop.OfString.Value != "" {
 		params.StopSequences = []string{req.Stop.OfString.Value}
 	}
+	if pt != nil && pt.TopK != nil {
+		params.TopK = anthropic.Int(*pt.TopK)
+	}
 }
 
-// applyMetadata is the metadata.user_id replay hook. Reserved for future use:
-// today's behaviour does not emit metadata, so this is a no-op when pt is nil.
-func applyMetadata(_ *anthropic.MessageNewParams, _ *openai.ChatCompletionNewParams, _ *AnthropicPassthrough) {
+// applyMetadata emits metadata.user_id from the passthrough when set, falling
+// back to the OpenAI request's `user` field as the conventional mapping.
+func applyMetadata(params *anthropic.MessageNewParams, req *openai.ChatCompletionNewParams, pt *AnthropicPassthrough) {
+	userID := ""
+	if pt != nil && pt.MetadataUserID != "" {
+		userID = pt.MetadataUserID
+	} else if req != nil && req.User.Valid() && req.User.Value != "" {
+		userID = req.User.Value
+	}
+	if userID == "" {
+		return
+	}
+	params.Metadata = anthropic.MetadataParam{UserID: anthropic.String(userID)}
+}
+
+// applyToolsCacheControl attaches cache_control markers to tool definitions
+// based on the `tools[i]` keys in the passthrough.
+func applyToolsCacheControl(params *anthropic.MessageNewParams, pt *AnthropicPassthrough) {
+	if pt == nil || len(pt.CacheControl) == 0 {
+		return
+	}
+	for i := range params.Tools {
+		spec, ok := pt.CacheControl[fmt.Sprintf("tools[%d]", i)]
+		if !ok {
+			continue
+		}
+		if params.Tools[i].OfTool != nil {
+			params.Tools[i].OfTool.CacheControl = toSDKCacheControl(spec)
+		}
+	}
+}
+
+// applyMessagesCacheControl attaches per-content-block cache_control markers
+// to the outbound user/assistant messages. Markers whose `messages[i].content[j]`
+// key no longer matches a block on the outbound side are silently dropped to
+// match the surrounding lossy-translation discipline.
+func applyMessagesCacheControl(messages []anthropic.MessageParam, pt *AnthropicPassthrough) {
+	if pt == nil || len(pt.CacheControl) == 0 {
+		return
+	}
+	for i := range messages {
+		for j := range messages[i].Content {
+			spec, ok := pt.CacheControl[fmt.Sprintf("messages[%d].content[%d]", i, j)]
+			if !ok {
+				continue
+			}
+			sdkCC := toSDKCacheControl(spec)
+			block := &messages[i].Content[j]
+			switch {
+			case block.OfText != nil:
+				block.OfText.CacheControl = sdkCC
+			case block.OfImage != nil:
+				block.OfImage.CacheControl = sdkCC
+			case block.OfToolUse != nil:
+				block.OfToolUse.CacheControl = sdkCC
+			case block.OfToolResult != nil:
+				block.OfToolResult.CacheControl = sdkCC
+			}
+		}
+	}
+}
+
+// toSDKCacheControl converts the package-local CacheControlSpec into the SDK's
+// CacheControlEphemeralParam. Type defaults to "ephemeral" (the only value the
+// SDK supports today); TTL is forwarded when set.
+func toSDKCacheControl(spec CacheControlSpec) anthropic.CacheControlEphemeralParam {
+	cc := anthropic.NewCacheControlEphemeralParam()
+	if spec.TTL != "" {
+		cc.TTL = anthropic.CacheControlEphemeralTTL(spec.TTL)
+	}
+	return cc
 }
 
 // ToOpenAIResponseBody transforms an Anthropic API response to OpenAI format.

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -1,0 +1,147 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type byteEqFixture struct {
+	name string
+	req  *openai.ChatCompletionNewParams
+}
+
+func fixtureBasicUserOnly() byteEqFixture {
+	return byteEqFixture{
+		name: "basic_user_only",
+		req: &openai.ChatCompletionNewParams{
+			Model: "claude-sonnet-4-5",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				userStringMessage("Hello, world!"),
+			},
+		},
+	}
+}
+
+func fixtureWithSystemPrompt() byteEqFixture {
+	return byteEqFixture{
+		name: "with_system_prompt",
+		req: &openai.ChatCompletionNewParams{
+			Model: "claude-sonnet-4-5",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				systemStringMessage("You are helpful."),
+				userStringMessage("Hi"),
+			},
+		},
+	}
+}
+
+func fixtureWithOptionalSamplingParams() byteEqFixture {
+	return byteEqFixture{
+		name: "with_optional_sampling_params",
+		req: &openai.ChatCompletionNewParams{
+			Model:       "claude-sonnet-4-5",
+			Temperature: openai.Float(0.7),
+			TopP:        openai.Float(0.9),
+			MaxTokens:   openai.Int(1024),
+			Stop: openai.ChatCompletionNewParamsStopUnion{
+				OfStringArray: []string{"END", "STOP"},
+			},
+			Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("Hello")},
+		},
+	}
+}
+
+func fixtureMultiTurn() byteEqFixture {
+	return byteEqFixture{
+		name: "multi_turn",
+		req: &openai.ChatCompletionNewParams{
+			Model: "claude-sonnet-4-5",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				userStringMessage("What is 2+2?"),
+				assistantStringMessage("2+2 equals 4."),
+				userStringMessage("And 3+3?"),
+			},
+		},
+	}
+}
+
+func fixtureWithToolHistory() byteEqFixture {
+	return byteEqFixture{
+		name: "with_tool_history",
+		req: &openai.ChatCompletionNewParams{
+			Model: "claude-sonnet-4-5",
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				userStringMessage("Weather in Paris?"),
+				{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+					ToolCalls: []openai.ChatCompletionMessageToolCallParam{{
+						ID:   "call_abc",
+						Type: "function",
+						Function: openai.ChatCompletionMessageToolCallFunctionParam{
+							Name:      "get_weather",
+							Arguments: `{"city":"Paris"}`,
+						},
+					}},
+				}},
+				{OfTool: &openai.ChatCompletionToolMessageParam{
+					ToolCallID: "call_abc",
+					Content: openai.ChatCompletionToolMessageParamContentUnion{
+						OfString: openai.String(`{"temp_c": 18}`),
+					},
+				}},
+			},
+		},
+	}
+}
+
+func userStringMessage(s string) openai.ChatCompletionMessageParamUnion {
+	return openai.ChatCompletionMessageParamUnion{OfUser: &openai.ChatCompletionUserMessageParam{
+		Content: openai.ChatCompletionUserMessageParamContentUnion{OfString: openai.String(s)},
+	}}
+}
+
+func systemStringMessage(s string) openai.ChatCompletionMessageParamUnion {
+	return openai.ChatCompletionMessageParamUnion{OfSystem: &openai.ChatCompletionSystemMessageParam{
+		Content: openai.ChatCompletionSystemMessageParamContentUnion{OfString: openai.String(s)},
+	}}
+}
+
+func assistantStringMessage(s string) openai.ChatCompletionMessageParamUnion {
+	return openai.ChatCompletionMessageParamUnion{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+		Content: openai.ChatCompletionAssistantMessageParamContentUnion{OfString: openai.String(s)},
+	}}
+}
+
+// fixturesForByteEqualityCheck mirrors the request shapes exercised in
+// client_test.go and compat_test.go, so the legacy entrypoint is checked
+// against the passthrough-aware entrypoint with nil over the full surface
+// today's tests cover.
+func fixturesForByteEqualityCheck() []byteEqFixture {
+	return []byteEqFixture{
+		fixtureBasicUserOnly(),
+		fixtureWithSystemPrompt(),
+		fixtureWithOptionalSamplingParams(),
+		fixtureMultiTurn(),
+		fixtureWithToolHistory(),
+	}
+}
+
+// TestToAnthropicRequestBodyWithPassthrough_NilIsByteIdenticalToLegacy is the
+// safety net that lets subsequent commits replay Anthropic-only fields without
+// risking regression for callers that don't pass a passthrough.
+func TestToAnthropicRequestBodyWithPassthrough_NilIsByteIdenticalToLegacy(t *testing.T) {
+	for _, fx := range fixturesForByteEqualityCheck() {
+		t.Run(fx.name, func(t *testing.T) {
+			legacy, err := ToAnthropicRequestBody(fx.req)
+			require.NoError(t, err)
+
+			withPT, err := ToAnthropicRequestBodyWithPassthrough(fx.req, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, string(legacy), string(withPT),
+				"passthrough-aware entrypoint must be byte-identical when pt is nil")
+		})
+	}
+}

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -474,6 +474,100 @@ func TestBuildStreamingRequestHeadersWithPassthrough_PreservesAcceptAndBeta(t *t
 	assert.Equal(t, "messages-2023-12-15", got["anthropic-beta"])
 }
 
+// withToolResultRequest builds a request whose third message is an OpenAI
+// tool message that the writer translates into an Anthropic tool_result block.
+func withToolResultRequest() *openai.ChatCompletionNewParams {
+	return &openai.ChatCompletionNewParams{
+		Model: "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			userStringMessage("weather?"),
+			{OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+				ToolCalls: []openai.ChatCompletionMessageToolCallParam{{
+					ID:   "call_abc",
+					Type: "function",
+					Function: openai.ChatCompletionMessageToolCallFunctionParam{
+						Name:      "get_weather",
+						Arguments: `{"city":"Paris"}`,
+					},
+				}},
+			}},
+			{OfTool: &openai.ChatCompletionToolMessageParam{
+				ToolCallID: "call_abc",
+				Content: openai.ChatCompletionToolMessageParamContentUnion{
+					OfString: openai.String("backend error"),
+				},
+			}},
+		},
+	}
+}
+
+func TestReplay_ToolResultErrorPreserved(t *testing.T) {
+	req := withToolResultRequest()
+	pt := &AnthropicPassthrough{
+		ToolResultErrors: map[string]bool{"call_abc": true},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+
+	// The tool_result lives on messages[2] (the user-wrapped tool message).
+	isErr := gjson.GetBytes(body, "messages.2.content.0.is_error")
+	require.True(t, isErr.Exists())
+	assert.True(t, isErr.Bool())
+}
+
+func TestReplay_ToolResultErrorDefaultsToFalse(t *testing.T) {
+	// Today's translation always emits is_error (SDK NewToolResultBlock sets
+	// it via param.Bool). With no passthrough flag set, the value remains the
+	// default false; the passthrough only flips it to true when present.
+	req := withToolResultRequest()
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, &AnthropicPassthrough{})
+	require.NoError(t, err)
+	isErr := gjson.GetBytes(body, "messages.2.content.0.is_error")
+	require.True(t, isErr.Exists())
+	assert.False(t, isErr.Bool())
+}
+
+func TestReplay_ToolResultArrayContent_TextAndImageMix(t *testing.T) {
+	req := withToolResultRequest()
+	pt := &AnthropicPassthrough{
+		ToolResultArrayContent: map[string][]ToolResultContentBlock{
+			"call_abc": {
+				{Type: "text", Text: "see image"},
+				{Type: "image", Source: &ImageSource{
+					Type: "base64", MediaType: "image/jpeg", Data: "BBBB",
+				}},
+			},
+		},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+
+	content := gjson.GetBytes(body, "messages.2.content.0.content").Array()
+	require.Len(t, content, 2)
+	assert.Equal(t, "text", content[0].Get("type").String())
+	assert.Equal(t, "see image", content[0].Get("text").String())
+	assert.Equal(t, "image", content[1].Get("type").String())
+	assert.Equal(t, "base64", content[1].Get("source.type").String())
+	assert.Equal(t, "image/jpeg", content[1].Get("source.media_type").String())
+	assert.Equal(t, "BBBB", content[1].Get("source.data").String())
+}
+
+func TestReplay_ToolResultUnknownIDLeavesBlockUntouched(t *testing.T) {
+	// An ID in the passthrough that doesn't match an outbound tool_result
+	// must not affect the existing block's is_error value (defaults to false).
+	req := withToolResultRequest()
+	pt := &AnthropicPassthrough{
+		ToolResultErrors: map[string]bool{"call_other": true},
+	}
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	isErr := gjson.GetBytes(body, "messages.2.content.0.is_error")
+	require.True(t, isErr.Exists())
+	assert.False(t, isErr.Bool())
+}
+
 func headerMap(headers []HeaderKeyValue) map[string]string {
 	out := make(map[string]string, len(headers))
 	for _, h := range headers {

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -430,6 +430,58 @@ func TestOpenAIShape_ImageURLPlainURLBecomesAnthropicURLImage(t *testing.T) {
 	assert.Equal(t, "https://example.com/cat.png", content[0].Get("source.url").String())
 }
 
+func TestBuildRequestHeadersWithPassthrough_NilByteIdenticalToLegacy(t *testing.T) {
+	legacy := BuildRequestHeaders("k", 100, "")
+	pt := BuildRequestHeadersWithPassthrough("k", 100, "", nil)
+	assert.Equal(t, legacy, pt)
+}
+
+func TestBuildRequestHeadersWithPassthrough_VersionOverridesDefault(t *testing.T) {
+	headers := BuildRequestHeadersWithPassthrough("k", 1, "", &AnthropicPassthrough{
+		AnthropicVersion: "2024-10-22",
+	})
+	got := headerMap(headers)
+	assert.Equal(t, "2024-10-22", got["anthropic-version"])
+}
+
+func TestBuildRequestHeadersWithPassthrough_VersionFallsBackToDefault(t *testing.T) {
+	headers := BuildRequestHeadersWithPassthrough("k", 1, "", &AnthropicPassthrough{})
+	got := headerMap(headers)
+	assert.Equal(t, AnthropicAPIVersion, got["anthropic-version"])
+}
+
+func TestBuildRequestHeadersWithPassthrough_BetaForwarded(t *testing.T) {
+	headers := BuildRequestHeadersWithPassthrough("k", 1, "", &AnthropicPassthrough{
+		AnthropicBeta: "prompt-caching-2024-07-31",
+	})
+	got := headerMap(headers)
+	assert.Equal(t, "prompt-caching-2024-07-31", got["anthropic-beta"])
+}
+
+func TestBuildRequestHeadersWithPassthrough_BetaOmittedWhenEmpty(t *testing.T) {
+	headers := BuildRequestHeadersWithPassthrough("k", 1, "", &AnthropicPassthrough{})
+	got := headerMap(headers)
+	_, ok := got["anthropic-beta"]
+	assert.False(t, ok)
+}
+
+func TestBuildStreamingRequestHeadersWithPassthrough_PreservesAcceptAndBeta(t *testing.T) {
+	headers := BuildStreamingRequestHeadersWithPassthrough("k", 1, "", &AnthropicPassthrough{
+		AnthropicBeta: "messages-2023-12-15",
+	})
+	got := headerMap(headers)
+	assert.Equal(t, "text/event-stream", got["accept"])
+	assert.Equal(t, "messages-2023-12-15", got["anthropic-beta"])
+}
+
+func headerMap(headers []HeaderKeyValue) map[string]string {
+	out := make(map[string]string, len(headers))
+	for _, h := range headers {
+		out[h.Key] = h.Value
+	}
+	return out
+}
+
 func TestReplay_ToolCacheControl(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		Model:    "claude-sonnet-4-5",

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 type byteEqFixture struct {
@@ -144,4 +145,173 @@ func TestToAnthropicRequestBodyWithPassthrough_NilIsByteIdenticalToLegacy(t *tes
 				"passthrough-aware entrypoint must be byte-identical when pt is nil")
 		})
 	}
+}
+
+func TestReplay_TopK(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	k := int64(40)
+	pt := &AnthropicPassthrough{TopK: &k}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	assert.Equal(t, int64(40), gjson.GetBytes(body, "top_k").Int())
+}
+
+func TestReplay_TopK_OmittedWhenNil(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, &AnthropicPassthrough{})
+	require.NoError(t, err)
+	assert.False(t, gjson.GetBytes(body, "top_k").Exists())
+}
+
+func TestReplay_MetadataUserID(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	pt := &AnthropicPassthrough{MetadataUserID: "alice"}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", gjson.GetBytes(body, "metadata.user_id").String())
+}
+
+func TestReplay_MetadataPrefersPassthroughOverOpenAIUser(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		User:     openai.String("openai-user"),
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	pt := &AnthropicPassthrough{MetadataUserID: "passthrough-user"}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	assert.Equal(t, "passthrough-user", gjson.GetBytes(body, "metadata.user_id").String())
+}
+
+func TestReplay_MetadataFallsBackToOpenAIUser(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		User:     openai.String("openai-user"),
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, &AnthropicPassthrough{})
+	require.NoError(t, err)
+	assert.Equal(t, "openai-user", gjson.GetBytes(body, "metadata.user_id").String())
+}
+
+func TestReplay_SystemArrayWithCacheControl(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	pt := &AnthropicPassthrough{
+		SystemBlocks: []SystemBlock{
+			{Text: "You are helpful.", CacheControl: &CacheControlSpec{Type: "ephemeral", TTL: "5m"}},
+			{Text: "Be concise."},
+		},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+
+	system := gjson.GetBytes(body, "system")
+	require.True(t, system.IsArray())
+	systemArr := system.Array()
+	require.Len(t, systemArr, 2)
+	assert.Equal(t, "You are helpful.", systemArr[0].Get("text").String())
+	assert.Equal(t, "ephemeral", systemArr[0].Get("cache_control.type").String())
+	assert.Equal(t, "5m", systemArr[0].Get("cache_control.ttl").String())
+	assert.Equal(t, "Be concise.", systemArr[1].Get("text").String())
+	assert.False(t, systemArr[1].Get("cache_control").Exists())
+}
+
+func TestReplay_SystemArrayOverridesStringFormSystem(t *testing.T) {
+	// An OpenAI-derived system string is overridden by passthrough SystemBlocks.
+	req := &openai.ChatCompletionNewParams{
+		Model: "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			systemStringMessage("derived from OpenAI"),
+			userStringMessage("hi"),
+		},
+	}
+	pt := &AnthropicPassthrough{
+		SystemBlocks: []SystemBlock{{Text: "from passthrough"}},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	systemArr := gjson.GetBytes(body, "system").Array()
+	require.Len(t, systemArr, 1)
+	assert.Equal(t, "from passthrough", systemArr[0].Get("text").String())
+}
+
+func TestReplay_PerMessageCacheControl_OnExistingTextBlock(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hello")},
+	}
+	pt := &AnthropicPassthrough{
+		CacheControl: map[string]CacheControlSpec{
+			"messages[0].content[0]": {Type: "ephemeral", TTL: "1h"},
+		},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	cc := gjson.GetBytes(body, "messages.0.content.0.cache_control")
+	require.True(t, cc.Exists())
+	assert.Equal(t, "ephemeral", cc.Get("type").String())
+	assert.Equal(t, "1h", cc.Get("ttl").String())
+}
+
+func TestReplay_CacheControlDroppedWhenBlockMissing(t *testing.T) {
+	// A marker for messages[5].content[0] when only one message exists must
+	// not error; the marker is silently dropped.
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hello")},
+	}
+	pt := &AnthropicPassthrough{
+		CacheControl: map[string]CacheControlSpec{
+			"messages[5].content[0]": {Type: "ephemeral"},
+		},
+	}
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	assert.False(t, gjson.GetBytes(body, "messages.0.content.0.cache_control").Exists())
+}
+
+func TestReplay_ToolCacheControl(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+		Tools: []openai.ChatCompletionToolParam{{
+			Type: "function",
+			Function: openai.FunctionDefinitionParam{
+				Name: "get_weather",
+				Parameters: openai.FunctionParameters{
+					"type": "object",
+				},
+			},
+		}},
+	}
+	pt := &AnthropicPassthrough{
+		CacheControl: map[string]CacheControlSpec{
+			"tools[0]": {Type: "ephemeral", TTL: "5m"},
+		},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	cc := gjson.GetBytes(body, "tools.0.cache_control")
+	require.True(t, cc.Exists())
+	assert.Equal(t, "ephemeral", cc.Get("type").String())
+	assert.Equal(t, "5m", cc.Get("ttl").String())
 }

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -288,6 +288,148 @@ func TestReplay_CacheControlDroppedWhenBlockMissing(t *testing.T) {
 	assert.False(t, gjson.GetBytes(body, "messages.0.content.0.cache_control").Exists())
 }
 
+func TestReplay_ImageBlocksReachedOutboundUserMessage_Base64(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("what is this")},
+	}
+	pt := &AnthropicPassthrough{
+		UserMessageImageBlocks: map[int][]ImageBlock{
+			0: {{Source: ImageSource{Type: "base64", MediaType: "image/png", Data: "AAAA"}}},
+		},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+
+	content := gjson.GetBytes(body, "messages.0.content").Array()
+	require.Len(t, content, 2)
+	assert.Equal(t, "text", content[0].Get("type").String())
+	assert.Equal(t, "image", content[1].Get("type").String())
+	assert.Equal(t, "base64", content[1].Get("source.type").String())
+	assert.Equal(t, "image/png", content[1].Get("source.media_type").String())
+	assert.Equal(t, "AAAA", content[1].Get("source.data").String())
+}
+
+func TestReplay_ImageBlocksReachedOutboundUserMessage_URL(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("describe this")},
+	}
+	pt := &AnthropicPassthrough{
+		UserMessageImageBlocks: map[int][]ImageBlock{
+			0: {{Source: ImageSource{Type: "url", URL: "https://example.com/cat.png"}}},
+		},
+	}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	content := gjson.GetBytes(body, "messages.0.content").Array()
+	require.Len(t, content, 2)
+	assert.Equal(t, "url", content[1].Get("source.type").String())
+	assert.Equal(t, "https://example.com/cat.png", content[1].Get("source.url").String())
+}
+
+func TestReplay_ImageBlocksMapToUserMessageIndexOnly(t *testing.T) {
+	// Assistant messages are skipped when counting user-message indices.
+	req := &openai.ChatCompletionNewParams{
+		Model: "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			userStringMessage("first"),
+			assistantStringMessage("ack"),
+			userStringMessage("second"),
+		},
+	}
+	pt := &AnthropicPassthrough{
+		UserMessageImageBlocks: map[int][]ImageBlock{
+			1: {{Source: ImageSource{Type: "url", URL: "https://example.com/b.png"}}},
+		},
+	}
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	// Image should land on messages[2] (user index 1), not messages[1] (assistant).
+	assert.Len(t, gjson.GetBytes(body, "messages.0.content").Array(), 1)
+	assert.Len(t, gjson.GetBytes(body, "messages.1.content").Array(), 1)
+	assert.Len(t, gjson.GetBytes(body, "messages.2.content").Array(), 2)
+	assert.Equal(t, "image", gjson.GetBytes(body, "messages.2.content.1.type").String())
+}
+
+func TestReplay_ImageBlocksDroppedWhenIndexOutOfRange(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	pt := &AnthropicPassthrough{
+		UserMessageImageBlocks: map[int][]ImageBlock{
+			5: {{Source: ImageSource{Type: "url", URL: "https://example.com/a.png"}}},
+		},
+	}
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	assert.Len(t, gjson.GetBytes(body, "messages.0.content").Array(), 1)
+}
+
+// OpenAI-shape image_url inbound -> Anthropic image block.
+// Closes the OpenAI-client/Anthropic-backend cell for image content. No
+// passthrough required for this path: the OpenAI message itself carries the
+// image part.
+func TestOpenAIShape_ImageURLDataURIBecomesAnthropicImageBlock(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{OfUser: &openai.ChatCompletionUserMessageParam{
+				Content: openai.ChatCompletionUserMessageParamContentUnion{
+					OfArrayOfContentParts: []openai.ChatCompletionContentPartUnionParam{
+						{OfText: &openai.ChatCompletionContentPartTextParam{Text: "what is this"}},
+						{OfImageURL: &openai.ChatCompletionContentPartImageParam{
+							ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
+								URL: "data:image/png;base64,AAAA",
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	body, err := ToAnthropicRequestBody(req)
+	require.NoError(t, err)
+	content := gjson.GetBytes(body, "messages.0.content").Array()
+	require.Len(t, content, 2)
+	assert.Equal(t, "text", content[0].Get("type").String())
+	assert.Equal(t, "what is this", content[0].Get("text").String())
+	assert.Equal(t, "image", content[1].Get("type").String())
+	assert.Equal(t, "base64", content[1].Get("source.type").String())
+	assert.Equal(t, "image/png", content[1].Get("source.media_type").String())
+	assert.Equal(t, "AAAA", content[1].Get("source.data").String())
+}
+
+func TestOpenAIShape_ImageURLPlainURLBecomesAnthropicURLImage(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{OfUser: &openai.ChatCompletionUserMessageParam{
+				Content: openai.ChatCompletionUserMessageParamContentUnion{
+					OfArrayOfContentParts: []openai.ChatCompletionContentPartUnionParam{
+						{OfImageURL: &openai.ChatCompletionContentPartImageParam{
+							ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
+								URL: "https://example.com/cat.png",
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	body, err := ToAnthropicRequestBody(req)
+	require.NoError(t, err)
+	content := gjson.GetBytes(body, "messages.0.content").Array()
+	require.Len(t, content, 1)
+	assert.Equal(t, "image", content[0].Get("type").String())
+	assert.Equal(t, "url", content[0].Get("source.type").String())
+	assert.Equal(t, "https://example.com/cat.png", content[0].Get("source.url").String())
+}
+
 func TestReplay_ToolCacheControl(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		Model:    "claude-sonnet-4-5",

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -332,8 +332,16 @@ func WithStreamingRequestBody(body []byte) ([]byte, error) {
 }
 
 // BuildStreamingRequestHeaders returns headers for a streaming Anthropic request.
+// Equivalent to BuildStreamingRequestHeadersWithPassthrough with a nil passthrough.
 func BuildStreamingRequestHeaders(apiKey string, bodyLength int, messagesPath string) []HeaderKeyValue {
-	return buildRequestHeaders(apiKey, bodyLength, messagesPath, true)
+	return buildRequestHeaders(apiKey, bodyLength, messagesPath, true, nil)
+}
+
+// BuildStreamingRequestHeadersWithPassthrough is the passthrough-aware form of
+// BuildStreamingRequestHeaders. See BuildRequestHeadersWithPassthrough for the
+// header precedence contract.
+func BuildStreamingRequestHeadersWithPassthrough(apiKey string, bodyLength int, messagesPath string, pt *AnthropicPassthrough) []HeaderKeyValue {
+	return buildRequestHeaders(apiKey, bodyLength, messagesPath, true, pt)
 }
 
 // withStreamFlag adds stream=true to an Anthropic request JSON body.

--- a/src/semantic-router/pkg/anthropic/passthrough.go
+++ b/src/semantic-router/pkg/anthropic/passthrough.go
@@ -1,0 +1,332 @@
+// Package anthropic - passthrough carrier for Anthropic-only request fields.
+//
+// The default request-body translation in this package takes an OpenAI-shape
+// ChatCompletionNewParams and produces an Anthropic-shape MessageNewParams.
+// Several Anthropic-only fields have no OpenAI representation (cache_control
+// markers, top_k, metadata.user_id, multi-block system prompts with per-block
+// markers, image content blocks, tool_result.is_error, tool_result with array
+// content, anthropic-version, anthropic-beta). When those fields are present on
+// the inbound request, today's translation silently drops them.
+//
+// AnthropicPassthrough is a per-request sidecar that the caller populates from
+// the raw inbound body (or supplies directly when the upstream IR knows the
+// shape) and ToAnthropicRequestBodyWithPassthrough consumes during rebuild.
+// Every consumer treats a nil *AnthropicPassthrough as "no passthrough, use
+// today's defaults", so existing callers remain byte-identical.
+package anthropic
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+)
+
+// AnthropicPassthrough carries Anthropic-only request fields that have no
+// OpenAI representation, so the outbound write path can replay them on the
+// request body and headers. Lifetime is one request: built by the caller from
+// the raw inbound body (or supplied directly by upstream IR), consumed by
+// ToAnthropicRequestBodyWithPassthrough and BuildRequestHeadersWithPassthrough,
+// then discarded.
+type AnthropicPassthrough struct {
+	// AnthropicVersion is the inbound anthropic-version header value. Empty
+	// means "use the package default" (AnthropicAPIVersion).
+	AnthropicVersion string
+
+	// AnthropicBeta is the inbound anthropic-beta header value, comma-separated
+	// per Anthropic convention. Empty means "do not emit".
+	AnthropicBeta string
+
+	// TopK preserves the Anthropic top_k sampling parameter. nil means "not set
+	// on inbound; do not emit".
+	TopK *int64
+
+	// MetadataUserID populates metadata.user_id on the outbound body. Empty
+	// means "do not emit".
+	MetadataUserID string
+
+	// SystemBlocks preserves array-form system prompts. When non-empty,
+	// overrides the string-form system derived from OpenAI messages.
+	SystemBlocks []SystemBlock
+
+	// CacheControl maps stable block IDs to cache_control markers. Block IDs
+	// match the JSON-path convention: "system[i]",
+	// "messages[i].content[j]", "tools[i]". The emitter applies markers
+	// best-effort: when the block exists on the outbound side, attach; when an
+	// upstream mutation removed the block, drop silently.
+	CacheControl map[string]CacheControlSpec
+
+	// ToolResultErrors maps tool_call_id to the is_error flag, so the emitter
+	// can restore is_error: true on the matching outbound tool_result.
+	ToolResultErrors map[string]bool
+
+	// ToolResultArrayContent maps tool_call_id to the preserved array content
+	// (text + image blocks) for tool_result blocks whose original content was
+	// an array rather than a plain string.
+	ToolResultArrayContent map[string][]ToolResultContentBlock
+
+	// UserMessageImageBlocks maps user-message index to image blocks dropped by
+	// the OpenAI-side flatten. The emitter re-attaches them to the
+	// corresponding user message on the outbound side. Indices are counted
+	// against user messages only (i.e. index 0 is the first user message,
+	// regardless of any preceding system or assistant messages).
+	UserMessageImageBlocks map[int][]ImageBlock
+}
+
+// SystemBlock represents one element of an array-form Anthropic system prompt.
+type SystemBlock struct {
+	Text         string
+	CacheControl *CacheControlSpec
+}
+
+// CacheControlSpec captures the Anthropic cache_control marker. Type is always
+// "ephemeral" today; TTL is one of "", "5m", "1h".
+type CacheControlSpec struct {
+	Type string
+	TTL  string
+}
+
+// ToolResultContentBlock represents one block of a tool_result content array.
+// Type is "text" or "image"; only the matching fields are populated.
+type ToolResultContentBlock struct {
+	Type   string
+	Text   string
+	Source *ImageSource
+}
+
+// ImageBlock represents a user-message image content block.
+type ImageBlock struct {
+	Source ImageSource
+}
+
+// ImageSource represents the source of an image content block. Type is
+// "base64" or "url"; only the matching fields are populated.
+type ImageSource struct {
+	Type      string
+	MediaType string
+	Data      string
+	URL       string
+}
+
+// SetHeadersFromIncoming populates AnthropicVersion and AnthropicBeta from a
+// case-insensitive lookup of the incoming request header map. Empty header
+// values are ignored so the package default applies.
+func (p *AnthropicPassthrough) SetHeadersFromIncoming(headers map[string]string) {
+	if p == nil || len(headers) == 0 {
+		return
+	}
+	for k, v := range headers {
+		if v == "" {
+			continue
+		}
+		switch lowerASCII(k) {
+		case "anthropic-version":
+			p.AnthropicVersion = v
+		case "anthropic-beta":
+			p.AnthropicBeta = v
+		}
+	}
+}
+
+// lowerASCII lower-cases ASCII letters in s. HTTP header names are ASCII per
+// RFC 7230, so strings.ToLower (which is Unicode-aware) is unnecessary
+// overhead.
+func lowerASCII(s string) string {
+	b := []byte(s)
+	for i := 0; i < len(b); i++ {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+// BuildPassthroughFromAnthropicBody parses the raw Anthropic-shape JSON body
+// and returns a populated passthrough carrier. Lenient: malformed JSON or
+// unrecognised shapes are silently skipped so the outbound path falls back to
+// today's defaults rather than failing the request. Returns (nil, nil) when
+// the input is empty.
+func BuildPassthroughFromAnthropicBody(raw []byte) (*AnthropicPassthrough, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	pt := &AnthropicPassthrough{}
+	captureSamplingAndMetadata(raw, pt)
+	captureSystemBlocks(raw, pt)
+	captureMessages(raw, pt)
+	captureTools(raw, pt)
+	return pt, nil
+}
+
+func captureSamplingAndMetadata(raw []byte, pt *AnthropicPassthrough) {
+	if v := gjson.GetBytes(raw, "top_k"); v.Exists() && v.Type == gjson.Number {
+		k := v.Int()
+		pt.TopK = &k
+	}
+	if v := gjson.GetBytes(raw, "metadata.user_id"); v.Exists() && v.Type == gjson.String {
+		pt.MetadataUserID = v.String()
+	}
+}
+
+func captureSystemBlocks(raw []byte, pt *AnthropicPassthrough) {
+	sys := gjson.GetBytes(raw, "system")
+	if !sys.IsArray() {
+		return
+	}
+	sys.ForEach(func(i, block gjson.Result) bool {
+		sb := SystemBlock{Text: block.Get("text").String()}
+		if cc := block.Get("cache_control"); cc.Exists() {
+			spec := parsePassthroughCacheControl(cc)
+			sb.CacheControl = &spec
+			pt.setCacheControl(fmt.Sprintf("system[%d]", i.Int()), spec)
+		}
+		pt.SystemBlocks = append(pt.SystemBlocks, sb)
+		return true
+	})
+}
+
+func captureMessages(raw []byte, pt *AnthropicPassthrough) {
+	userMsgIndex := -1
+	gjson.GetBytes(raw, "messages").ForEach(func(mi, msg gjson.Result) bool {
+		isUser := msg.Get("role").String() == "user"
+		if isUser {
+			userMsgIndex++
+		}
+		msg.Get("content").ForEach(func(ci, content gjson.Result) bool {
+			captureContentBlock(pt, mi.Int(), ci.Int(), isUser, userMsgIndex, content)
+			return true
+		})
+		return true
+	})
+}
+
+func captureContentBlock(pt *AnthropicPassthrough, mi, ci int64, isUser bool, userMsgIndex int, content gjson.Result) {
+	if cc := content.Get("cache_control"); cc.Exists() {
+		pt.setCacheControl(fmt.Sprintf("messages[%d].content[%d]", mi, ci), parsePassthroughCacheControl(cc))
+	}
+	switch content.Get("type").String() {
+	case "image":
+		if isUser {
+			if img, ok := parseImageBlock(content); ok {
+				pt.appendImageBlock(userMsgIndex, img)
+			}
+		}
+	case "tool_result":
+		captureToolResult(pt, content)
+	}
+}
+
+func captureToolResult(pt *AnthropicPassthrough, content gjson.Result) {
+	id := content.Get("tool_use_id").String()
+	if id == "" {
+		return
+	}
+	if content.Get("is_error").Bool() {
+		pt.setToolResultError(id, true)
+	}
+	if c := content.Get("content"); c.IsArray() {
+		if blocks := parseToolResultBlocks(c); len(blocks) > 0 {
+			pt.setToolResultArrayContent(id, blocks)
+		}
+	}
+}
+
+func captureTools(raw []byte, pt *AnthropicPassthrough) {
+	gjson.GetBytes(raw, "tools").ForEach(func(i, tool gjson.Result) bool {
+		if cc := tool.Get("cache_control"); cc.Exists() {
+			pt.setCacheControl(fmt.Sprintf("tools[%d]", i.Int()), parsePassthroughCacheControl(cc))
+		}
+		return true
+	})
+}
+
+func parsePassthroughCacheControl(cc gjson.Result) CacheControlSpec {
+	spec := CacheControlSpec{Type: cc.Get("type").String()}
+	if spec.Type == "" {
+		spec.Type = "ephemeral"
+	}
+	if ttl := cc.Get("ttl").String(); ttl != "" {
+		spec.TTL = ttl
+	}
+	return spec
+}
+
+func parseImageBlock(content gjson.Result) (ImageBlock, bool) {
+	source := content.Get("source")
+	if !source.Exists() {
+		return ImageBlock{}, false
+	}
+	src := parseImageSource(source)
+	if src.Type == "" {
+		return ImageBlock{}, false
+	}
+	return ImageBlock{Source: src}, true
+}
+
+func parseImageSource(source gjson.Result) ImageSource {
+	srcType := source.Get("type").String()
+	switch srcType {
+	case "base64":
+		return ImageSource{
+			Type:      "base64",
+			MediaType: source.Get("media_type").String(),
+			Data:      source.Get("data").String(),
+		}
+	case "url":
+		return ImageSource{
+			Type: "url",
+			URL:  source.Get("url").String(),
+		}
+	}
+	return ImageSource{}
+}
+
+func parseToolResultBlocks(content gjson.Result) []ToolResultContentBlock {
+	var blocks []ToolResultContentBlock
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").String() {
+		case "text":
+			blocks = append(blocks, ToolResultContentBlock{
+				Type: "text",
+				Text: block.Get("text").String(),
+			})
+		case "image":
+			src := parseImageSource(block.Get("source"))
+			if src.Type != "" {
+				blocks = append(blocks, ToolResultContentBlock{
+					Type:   "image",
+					Source: &src,
+				})
+			}
+		}
+		return true
+	})
+	return blocks
+}
+
+func (p *AnthropicPassthrough) setCacheControl(id string, spec CacheControlSpec) {
+	if p.CacheControl == nil {
+		p.CacheControl = map[string]CacheControlSpec{}
+	}
+	p.CacheControl[id] = spec
+}
+
+func (p *AnthropicPassthrough) setToolResultError(id string, isError bool) {
+	if p.ToolResultErrors == nil {
+		p.ToolResultErrors = map[string]bool{}
+	}
+	p.ToolResultErrors[id] = isError
+}
+
+func (p *AnthropicPassthrough) setToolResultArrayContent(id string, blocks []ToolResultContentBlock) {
+	if p.ToolResultArrayContent == nil {
+		p.ToolResultArrayContent = map[string][]ToolResultContentBlock{}
+	}
+	p.ToolResultArrayContent[id] = blocks
+}
+
+func (p *AnthropicPassthrough) appendImageBlock(userMsgIndex int, img ImageBlock) {
+	if p.UserMessageImageBlocks == nil {
+		p.UserMessageImageBlocks = map[int][]ImageBlock{}
+	}
+	p.UserMessageImageBlocks[userMsgIndex] = append(p.UserMessageImageBlocks[userMsgIndex], img)
+}

--- a/src/semantic-router/pkg/anthropic/passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/passthrough_test.go
@@ -1,0 +1,275 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPassthrough_EmptyBodyReturnsNil(t *testing.T) {
+	pt, err := BuildPassthroughFromAnthropicBody(nil)
+	require.NoError(t, err)
+	assert.Nil(t, pt)
+
+	pt, err = BuildPassthroughFromAnthropicBody([]byte{})
+	require.NoError(t, err)
+	assert.Nil(t, pt)
+}
+
+func TestBuildPassthrough_OpenAIShapeBodyReturnsEmptyCarrier(t *testing.T) {
+	// An OpenAI-shape body has no top_k / metadata.user_id / system-array /
+	// image blocks / tool_result.is_error. The lenient parser should return
+	// an empty carrier without error.
+	raw := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.NotNil(t, pt)
+	assert.Nil(t, pt.TopK)
+	assert.Empty(t, pt.MetadataUserID)
+	assert.Empty(t, pt.SystemBlocks)
+	assert.Empty(t, pt.CacheControl)
+	assert.Empty(t, pt.ToolResultErrors)
+	assert.Empty(t, pt.ToolResultArrayContent)
+	assert.Empty(t, pt.UserMessageImageBlocks)
+}
+
+func TestBuildPassthrough_MalformedJSONIsLenient(t *testing.T) {
+	raw := []byte(`{"top_k":`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.NotNil(t, pt)
+	assert.Nil(t, pt.TopK)
+}
+
+func TestBuildPassthrough_TopK(t *testing.T) {
+	raw := []byte(`{"top_k":40}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.NotNil(t, pt.TopK)
+	assert.Equal(t, int64(40), *pt.TopK)
+}
+
+func TestBuildPassthrough_TopKMissing(t *testing.T) {
+	raw := []byte(`{}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	assert.Nil(t, pt.TopK)
+}
+
+func TestBuildPassthrough_MetadataUserID(t *testing.T) {
+	raw := []byte(`{"metadata":{"user_id":"alice"}}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", pt.MetadataUserID)
+}
+
+func TestBuildPassthrough_SystemArrayWithCacheControl(t *testing.T) {
+	raw := []byte(`{
+		"system": [
+			{"type":"text","text":"You are helpful.","cache_control":{"type":"ephemeral","ttl":"5m"}},
+			{"type":"text","text":"Be concise."}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Len(t, pt.SystemBlocks, 2)
+	assert.Equal(t, "You are helpful.", pt.SystemBlocks[0].Text)
+	require.NotNil(t, pt.SystemBlocks[0].CacheControl)
+	assert.Equal(t, "ephemeral", pt.SystemBlocks[0].CacheControl.Type)
+	assert.Equal(t, "5m", pt.SystemBlocks[0].CacheControl.TTL)
+	assert.Nil(t, pt.SystemBlocks[1].CacheControl)
+
+	require.Contains(t, pt.CacheControl, "system[0]")
+	assert.Equal(t, "5m", pt.CacheControl["system[0]"].TTL)
+	assert.NotContains(t, pt.CacheControl, "system[1]")
+}
+
+func TestBuildPassthrough_PerMessageCacheControl(t *testing.T) {
+	raw := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Contains(t, pt.CacheControl, "messages[0].content[0]")
+	assert.Equal(t, "ephemeral", pt.CacheControl["messages[0].content[0]"].Type)
+	assert.Empty(t, pt.CacheControl["messages[0].content[0]"].TTL)
+}
+
+func TestBuildPassthrough_ToolsCacheControl(t *testing.T) {
+	raw := []byte(`{
+		"tools": [
+			{"name":"get_weather","cache_control":{"type":"ephemeral","ttl":"1h"}},
+			{"name":"get_time"}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Contains(t, pt.CacheControl, "tools[0]")
+	assert.Equal(t, "1h", pt.CacheControl["tools[0]"].TTL)
+	assert.NotContains(t, pt.CacheControl, "tools[1]")
+}
+
+func TestBuildPassthrough_ImageBlocksBase64(t *testing.T) {
+	raw := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"text","text":"what is this"},
+				{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Contains(t, pt.UserMessageImageBlocks, 0)
+	images := pt.UserMessageImageBlocks[0]
+	require.Len(t, images, 1)
+	assert.Equal(t, "base64", images[0].Source.Type)
+	assert.Equal(t, "image/png", images[0].Source.MediaType)
+	assert.Equal(t, "AAAA", images[0].Source.Data)
+}
+
+func TestBuildPassthrough_ImageBlocksURL(t *testing.T) {
+	raw := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"image","source":{"type":"url","url":"https://example.com/cat.png"}}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Contains(t, pt.UserMessageImageBlocks, 0)
+	images := pt.UserMessageImageBlocks[0]
+	require.Len(t, images, 1)
+	assert.Equal(t, "url", images[0].Source.Type)
+	assert.Equal(t, "https://example.com/cat.png", images[0].Source.URL)
+}
+
+func TestBuildPassthrough_ImageBlockOnlyOnUserMessage(t *testing.T) {
+	// Image content blocks on assistant messages are not captured: the
+	// translation only re-attaches images to user messages in this PR.
+	raw := []byte(`{
+		"messages": [
+			{"role":"assistant","content":[
+				{"type":"image","source":{"type":"url","url":"https://example.com/cat.png"}}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	assert.Empty(t, pt.UserMessageImageBlocks)
+}
+
+func TestBuildPassthrough_UserMessageIndexCountsUserMessagesOnly(t *testing.T) {
+	// Index 0 is the first user message, even when assistant/system messages
+	// precede it.
+	raw := []byte(`{
+		"messages": [
+			{"role":"assistant","content":[{"type":"text","text":"hi"}]},
+			{"role":"user","content":[
+				{"type":"image","source":{"type":"url","url":"https://example.com/a.png"}}
+			]},
+			{"role":"assistant","content":[{"type":"text","text":"ok"}]},
+			{"role":"user","content":[
+				{"type":"image","source":{"type":"url","url":"https://example.com/b.png"}}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Contains(t, pt.UserMessageImageBlocks, 0)
+	require.Contains(t, pt.UserMessageImageBlocks, 1)
+	assert.Equal(t, "https://example.com/a.png", pt.UserMessageImageBlocks[0][0].Source.URL)
+	assert.Equal(t, "https://example.com/b.png", pt.UserMessageImageBlocks[1][0].Source.URL)
+}
+
+func TestBuildPassthrough_ToolResultIsError(t *testing.T) {
+	raw := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"call_abc","is_error":true,"content":"oops"}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Contains(t, pt.ToolResultErrors, "call_abc")
+	assert.True(t, pt.ToolResultErrors["call_abc"])
+}
+
+func TestBuildPassthrough_ToolResultIsErrorFalseNotCaptured(t *testing.T) {
+	// is_error: false is the SDK default; not capturing it keeps the carrier
+	// minimal and back-compat: replay only emits the flag when explicitly true.
+	raw := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"call_abc","is_error":false,"content":"ok"}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	assert.Empty(t, pt.ToolResultErrors)
+}
+
+func TestBuildPassthrough_ToolResultArrayContent(t *testing.T) {
+	raw := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"call_abc","content":[
+					{"type":"text","text":"see image"},
+					{"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":"BBBB"}}
+				]}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	require.Contains(t, pt.ToolResultArrayContent, "call_abc")
+	blocks := pt.ToolResultArrayContent["call_abc"]
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "text", blocks[0].Type)
+	assert.Equal(t, "see image", blocks[0].Text)
+	assert.Equal(t, "image", blocks[1].Type)
+	require.NotNil(t, blocks[1].Source)
+	assert.Equal(t, "image/jpeg", blocks[1].Source.MediaType)
+}
+
+func TestBuildPassthrough_ToolResultMissingToolUseIDSkipped(t *testing.T) {
+	raw := []byte(`{
+		"messages": [
+			{"role":"user","content":[
+				{"type":"tool_result","is_error":true,"content":"oops"}
+			]}
+		]
+	}`)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+	assert.Empty(t, pt.ToolResultErrors)
+	assert.Empty(t, pt.ToolResultArrayContent)
+}
+
+func TestSetHeadersFromIncoming_NilSafeAndCaseInsensitive(t *testing.T) {
+	var pt *AnthropicPassthrough
+	assert.NotPanics(t, func() { pt.SetHeadersFromIncoming(map[string]string{"x": "y"}) })
+
+	pt = &AnthropicPassthrough{}
+	pt.SetHeadersFromIncoming(map[string]string{
+		"Anthropic-Version": "2024-10-22",
+		"ANTHROPIC-BETA":    "prompt-caching-2024-07-31",
+		"unrelated":         "ignored",
+	})
+	assert.Equal(t, "2024-10-22", pt.AnthropicVersion)
+	assert.Equal(t, "prompt-caching-2024-07-31", pt.AnthropicBeta)
+}
+
+func TestSetHeadersFromIncoming_SkipsEmptyValues(t *testing.T) {
+	pt := &AnthropicPassthrough{AnthropicVersion: "existing"}
+	pt.SetHeadersFromIncoming(map[string]string{"anthropic-version": ""})
+	assert.Equal(t, "existing", pt.AnthropicVersion)
+}

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
@@ -58,7 +58,24 @@ func (r *OpenAIRouter) prepareAnthropicRoutingRequest(
 
 	openAIRequest.Model = targetModel
 	streaming := ctx.ExpectStreamingResponse
-	anthropicBody, err := anthropic.ToAnthropicRequestBody(openAIRequest)
+
+	// Capture Anthropic-only fields from the raw inbound body (cache_control,
+	// top_k, metadata.user_id, multi-block system, image blocks, tool_result
+	// is_error/array content) and from the incoming headers (anthropic-version,
+	// anthropic-beta). For OpenAI-shape inbound the carrier ends up empty and
+	// the rebuild is byte-identical to today. The carrier is also stashed on
+	// the request context so the header builder can consume the same values
+	// without re-parsing.
+	passthrough, ptErr := anthropic.BuildPassthroughFromAnthropicBody(ctx.OriginalRequestBody)
+	if ptErr != nil {
+		logging.Debugf("Anthropic passthrough capture skipped: %v", ptErr)
+	}
+	if passthrough != nil {
+		passthrough.SetHeadersFromIncoming(ctx.Headers)
+	}
+	ctx.AnthropicPassthrough = passthrough
+
+	anthropicBody, err := anthropic.ToAnthropicRequestBodyWithPassthrough(openAIRequest, passthrough)
 	if err != nil {
 		logging.Errorf("Failed to transform request to Anthropic format: %v", err)
 		return "", nil, r.createErrorResponse(500, fmt.Sprintf("Request transformation error: %v", err))
@@ -120,9 +137,9 @@ func (r *OpenAIRouter) buildAnthropicRoutingResponse(
 	bodyLength := len(anthropicBody)
 	var anthropicHeaders []anthropic.HeaderKeyValue
 	if ctx.ExpectStreamingResponse {
-		anthropicHeaders = anthropic.BuildStreamingRequestHeaders(accessKey, bodyLength, messagesPath)
+		anthropicHeaders = anthropic.BuildStreamingRequestHeadersWithPassthrough(accessKey, bodyLength, messagesPath, ctx.AnthropicPassthrough)
 	} else {
-		anthropicHeaders = anthropic.BuildRequestHeaders(accessKey, bodyLength, messagesPath)
+		anthropicHeaders = anthropic.BuildRequestHeadersWithPassthrough(accessKey, bodyLength, messagesPath, ctx.AnthropicPassthrough)
 	}
 	setHeaders := make([]*core.HeaderValueOption, 0, len(anthropicHeaders)+8)
 	for _, header := range anthropicHeaders {

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -62,6 +62,11 @@ type RequestContext struct {
 	IsStreamingResponse     bool                   // set from response Content-Type
 	AnthropicStream         *anthropic.StreamState // Anthropic SSE → OpenAI translation state
 
+	// AnthropicPassthrough carries Anthropic-only request fields captured from
+	// the raw inbound body and incoming headers, so the request-body writer
+	// and header builder can replay them on the outbound side.
+	AnthropicPassthrough *anthropic.AnthropicPassthrough
+
 	// Semi-streaming body handler (non-nil when Envoy sends STREAMED body chunks)
 	StreamedBody *StreamedBodyHandler
 


### PR DESCRIPTION
> **RFC**: #1946 — design rationale, alternatives considered, decisions invited from maintainers

Standalone PR (not stacked on anything). Fixes 10 distinct silent drops in
`pkg/anthropic/client.go::ToAnthropicRequestBody` and friends. End-to-end
verification against a real Anthropic backend (via an Anthropic-compatible
gateway proxy) confirmed these drops break observable behavior: prompt-cache
counters stay zero, images vanish, the wrong `stop_reason` gets reported,
custom `anthropic-version` headers get overwritten with the package default,
and so on.

## What's dropped today

`ToAnthropicRequestBody` only forwards a strict subset of OpenAI fields onto
the Anthropic backend body, and `BuildRequestHeaders` hardcodes
`anthropic-version: 2023-06-01`. As a result:

1. `cache_control` markers — dropped → `cache_creation_input_tokens` and
   `cache_read_input_tokens` always 0
2. `top_k` parameter — dropped
3. `metadata.user_id` — dropped (mirrored to OpenAI `User` but not surfaced
   back as `metadata` on the Anthropic backend body)
4. `anthropic-version` header — overwritten with the package default
5. `anthropic-beta` header — dropped
6. Image content blocks — flattened to text via `extractUserContent`
7. System content as array (with per-block `cache_control`) — collapsed to a
   single string
8. `tool_result.is_error: true` — dropped on translation
9. `tool_result` array content (image / nested blocks) — flattened to empty
   string
10. `stop_sequence` stop_reason mapping — handled correctly today on this
    branch (the response-side switch already covers it); included in the
    test matrix to prevent regression

Items 1-9 are real silent drops. Item 10 is a no-op fix on this branch
baseline but kept in the verification matrix.

## Approach

Introduce a package-local `AnthropicPassthrough` carrier — a sidecar struct
that holds the Anthropic-only fields captured at inbound parse time and
replayed at outbound emit time. New entrypoints `*WithPassthrough` accept a
nullable `*AnthropicPassthrough`; existing entrypoints stay byte-identical
(verified by a 5-fixture parity test) so unrelated callers see no behavior
change. Callers that want the fix opt in by calling the `*WithPassthrough`
variant.

No new external dependencies, no IR-package introduction — purely scoped to
`pkg/anthropic/`. Caller wiring is one ExtProc call site
(`processor_req_body_anthropic.go`).

## Commits

1. **`[Router] add AnthropicPassthrough carrier and inbound builder`** — new
   `passthrough.go` + tests. Pure additive, no behavior.
2. **`[Router] thread passthrough into ToAnthropicRequestBody`** — refactor
   to add the new entrypoints. Byte-identical to the legacy path when
   passthrough is nil. Parity locked by
   `TestToAnthropicRequestBodyWithPassthrough_NilIsByteIdenticalToLegacy`.
3. **`[Router] replay top_k, metadata, cache_control, system-array via passthrough`**
4. **`[Router] preserve image blocks across the Anthropic write path`** —
   covers both Anthropic-shape inbound AND OpenAI-shape `OfImageURL`/
   `OfImageBase64` parts in the existing OpenAI-client/Anthropic-backend
   cell. Closes the bug for both ingress paths.
5. **`[Router] forward anthropic-version and anthropic-beta from inbound`** —
   with precedence `profile pin > inbound passthrough > package default`
   (achieved via call ordering + Envoy's "last header wins" semantics).
   Streaming variant covered by `BuildStreamingRequestHeadersWithPassthrough`.
6. **`[Router] preserve tool_result.is_error and array content`**
7. **`[Router] wire ext-proc Anthropic ingress to build the passthrough carrier`** —
   the one ExtProc call site that builds the passthrough from the raw inbound
   body and threads it through.

## SDK note for reviewers

`anthropic-sdk-go`'s `NewToolResultBlock(id, content string, isError bool)`
takes a `string` for content. For `tool_result` array content (item 9) the
carrier assembles `ToolResultBlockParam` manually in a localized helper — the
only place this PR fights the SDK shape.

## Test plan

- [x] `make agent-lint CHANGED_FILES=...` clean
- [x] `go vet`, `go build`, `go test ./pkg/anthropic/...` clean (46 new tests)
- [x] DCO sign-off on all 7 commits, SSH-signed
- [x] Per-commit trajectory verified (each commit independently compiles +
      vets + passes agent-lint)
- [x] Byte-identical parity test for nil-passthrough (`TestToAnthropicRequestBodyWithPassthrough_NilIsByteIdenticalToLegacy`)
- [x] Per-field unit tests for every replay (cache_control across system/messages/tools,
      top_k, metadata.user_id, system-array, image blocks for both Anthropic and OpenAI
      shape, anthropic-version, anthropic-beta, tool_result.is_error,
      tool_result array content)
- [x] End-to-end verification against a real Anthropic backend: requests with
      `cache_control` on the system block now show non-zero
      `cache_creation_input_tokens` on first call and `cache_read_input_tokens`
      on second call; images survive; client `anthropic-version` is forwarded
- [x] E2E test added: `e2e/testcases/anthropic_passthrough_regression.go` (`anthropic-passthrough-openai-regression`) — guards OpenAI `/v1/chat/completions` against regressions from the passthrough carrier construction code; positive-path carrier behavior is covered by unit tests in `pkg/anthropic/` since the e2e backend is OpenAI-shaped and an Anthropic-native mock is out of scope
- [ ] Upstream CI — runs once this PR is marked ready

## Related

- Tracking issue: #1404 (dual-protocol entry points context)
- `pkg/anthropic/client.go` was introduced by #1922 (custom Anthropic upstream
  routing) — these drops have been live since then. Streaming variant in #1926.
- This fix benefits ANY caller of `ToAnthropicRequestBody`, including the
  existing OpenAI-client / Anthropic-backend cell.

