### PR TITLE
[CI/Build] add Anthropic-shape e2e test backend (llama.cpp + shim)

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -116,6 +116,7 @@ jobs:
               - 'Cargo.lock'
               - 'pyproject.toml'
               - 'e2e/testing/llm-katan/**'
+              - 'e2e/testing/anthropic-shim/**'
             dashboard:
               - 'dashboard/**'
             website:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,7 @@ on:
       - "onnx-binding/**"
       - "src/**"
       - "e2e/testing/llm-katan/**"
+      - "e2e/testing/anthropic-shim/**"
       - "dashboard/**"
       - "src/vllm-sr/**"
   pull_request:
@@ -38,6 +39,7 @@ on:
       - "onnx-binding/**"
       - "src/**"
       - "e2e/testing/llm-katan/**"
+      - "e2e/testing/anthropic-shim/**"
       - "dashboard/**"
       - "src/vllm-sr/**"
 
@@ -61,7 +63,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [dashboard, extproc, extproc-rocm, llm-katan, vllm-sr, vllm-sr-rocm, vllm-sr-sim]
+        image: [anthropic-shim, dashboard, extproc, extproc-rocm, llm-katan, vllm-sr, vllm-sr-rocm, vllm-sr-sim]
       fail-fast: false
 
     steps:
@@ -107,6 +109,9 @@ jobs:
           elif [ "${{ matrix.image }}" = "llm-katan" ]; then
             echo "context=./e2e/testing/llm-katan" >> $GITHUB_OUTPUT
             echo "dockerfile=./e2e/testing/llm-katan/Dockerfile" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.image }}" = "anthropic-shim" ]; then
+            echo "context=./e2e/testing/anthropic-shim" >> $GITHUB_OUTPUT
+            echo "dockerfile=./e2e/testing/anthropic-shim/Dockerfile" >> $GITHUB_OUTPUT
           elif [ "${{ matrix.image }}" = "dashboard" ]; then
             echo "context=." >> $GITHUB_OUTPUT
             echo "dockerfile=./dashboard/backend/Dockerfile" >> $GITHUB_OUTPUT
@@ -188,7 +193,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [dashboard, extproc, llm-katan, vllm-sr, vllm-sr-sim]
+        image: [anthropic-shim, dashboard, extproc, llm-katan, vllm-sr, vllm-sr-sim]
         platform: [linux/amd64, linux/arm64]
       fail-fast: false
 
@@ -248,6 +253,9 @@ jobs:
           elif [ "${{ matrix.image }}" = "llm-katan" ]; then
             echo "context=./e2e/testing/llm-katan" >> $GITHUB_OUTPUT
             echo "dockerfile=./e2e/testing/llm-katan/Dockerfile" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.image }}" = "anthropic-shim" ]; then
+            echo "context=./e2e/testing/anthropic-shim" >> $GITHUB_OUTPUT
+            echo "dockerfile=./e2e/testing/anthropic-shim/Dockerfile" >> $GITHUB_OUTPUT
           elif [ "${{ matrix.image }}" = "dashboard" ]; then
             echo "context=." >> $GITHUB_OUTPUT
             echo "dockerfile=./dashboard/backend/Dockerfile" >> $GITHUB_OUTPUT
@@ -557,7 +565,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [dashboard, extproc, llm-katan, vllm-sr, vllm-sr-sim]
+        image: [anthropic-shim, dashboard, extproc, llm-katan, vllm-sr, vllm-sr-sim]
       fail-fast: false
 
     steps:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -233,6 +233,55 @@ jobs:
           ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/llm-katan:v${{ steps.version.outputs.version }}
           ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/llm-katan:latest
 
+  build_and_push_anthropic_shim:
+    if: github.repository == 'vllm-project/semantic-router'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Extract tag name
+      id: extract_tag
+      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+    - name: Set lowercase repository owner
+      run: echo "REPOSITORY_OWNER_LOWER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract version from pyproject.toml
+      id: version
+      run: |
+        VERSION=$(grep '^version = ' e2e/testing/anthropic-shim/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Build and push anthropic-shim Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./e2e/testing/anthropic-shim
+        file: ./e2e/testing/anthropic-shim/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/anthropic-shim:${{ steps.extract_tag.outputs.tag }}
+          ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/anthropic-shim:v${{ steps.version.outputs.version }}
+          ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/anthropic-shim:latest
+
   build_and_push_dashboard:
     if: github.repository == 'vllm-project/semantic-router'
     runs-on: ubuntu-latest

--- a/deploy/kubernetes/anthropic-backend/base/deployment.yaml
+++ b/deploy/kubernetes/anthropic-backend/base/deployment.yaml
@@ -1,0 +1,174 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anthropic-backend
+spec:
+  selector:
+    matchLabels:
+      app: anthropic-backend
+      app.kubernetes.io/name: anthropic-backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: anthropic-backend
+        app.kubernetes.io/name: anthropic-backend
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+
+      initContainers:
+        - name: model-downloader
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0  # root needed to install hf CLI into image-local site-packages
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -e
+
+              MODEL_REPO="${MODEL_REPO:-bartowski/Qwen2.5-0.5B-Instruct-GGUF}"
+              MODEL_FILE="${MODEL_FILE:-Qwen2.5-0.5B-Instruct-Q4_K_M.gguf}"
+              TARGET="/cache/models/${MODEL_FILE}"
+
+              mkdir -p /cache/models
+              if [ -f "$TARGET" ]; then
+                echo "Model $MODEL_FILE already cached. Skipping download."
+                exit 0
+              fi
+
+              echo "Downloading ${MODEL_REPO}/${MODEL_FILE}..."
+              pip install --no-cache-dir "huggingface_hub[cli]"
+              hf download "$MODEL_REPO" "$MODEL_FILE" --local-dir /cache/models
+          env:
+            - name: MODEL_REPO
+              value: "bartowski/Qwen2.5-0.5B-Instruct-GGUF"
+            - name: MODEL_FILE
+              value: "Qwen2.5-0.5B-Instruct-Q4_K_M.gguf"
+          volumeMounts:
+            - name: models-volume
+              mountPath: /cache/models
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+
+      containers:
+        - name: llama-server
+          image: ghcr.io/ggml-org/llama.cpp:server
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--model"
+            - "/cache/models/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf"
+            - "--jinja"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "-c"
+            - "4096"
+          ports:
+            - name: llama
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: models-volume
+              mountPath: /cache/models
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: llama
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: llama
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: llama
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 18  # 3 min total
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+
+        - name: anthropic-shim
+          image: anthropic-shim:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: shim
+              containerPort: 9080
+              protocol: TCP
+          env:
+            - name: ANTHROPIC_SHIM_UPSTREAM_URL
+              value: "http://127.0.0.1:8080"
+            - name: ANTHROPIC_SHIM_HOST
+              value: "0.0.0.0"
+            - name: ANTHROPIC_SHIM_PORT
+              value: "9080"
+            - name: ANTHROPIC_SHIM_SESSION_HEADER
+              value: "x-vsr-test-session-id"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: shim
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: shim
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+
+      volumes:
+        - name: models-volume
+          persistentVolumeClaim:
+            claimName: anthropic-backend-models

--- a/deploy/kubernetes/anthropic-backend/base/kustomization.yaml
+++ b/deploy/kubernetes/anthropic-backend/base/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: anthropic-backend-base
+
+namespace: anthropic-backend-system
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+
+images:
+  - name: anthropic-shim
+    newName: ghcr.io/vllm-project/semantic-router/anthropic-shim
+    newTag: latest

--- a/deploy/kubernetes/anthropic-backend/base/namespace.yaml
+++ b/deploy/kubernetes/anthropic-backend/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: anthropic-backend-system

--- a/deploy/kubernetes/anthropic-backend/base/pvc.yaml
+++ b/deploy/kubernetes/anthropic-backend/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: anthropic-backend-models
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi  # GGUF model (~400 MB) plus headroom

--- a/deploy/kubernetes/anthropic-backend/base/service.yaml
+++ b/deploy/kubernetes/anthropic-backend/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: anthropic-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: anthropic-backend
+    app.kubernetes.io/name: anthropic-backend
+  ports:
+    - name: http
+      port: 9080
+      targetPort: shim
+      protocol: TCP

--- a/deploy/kubernetes/anthropic-backend/components/common/kustomization.yaml
+++ b/deploy/kubernetes/anthropic-backend/components/common/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Common labels applied to every resource that uses this component.
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: anthropic-backend
+      app.kubernetes.io/part-of: semantic-router-workspaces
+      app.kubernetes.io/managed-by: kustomize

--- a/deploy/kubernetes/anthropic-backend/overlays/qwen/kustomization.yaml
+++ b/deploy/kubernetes/anthropic-backend/overlays/qwen/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: anthropic-backend-qwen
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/common
+
+nameSuffix: -qwen
+
+patches:
+  - target:
+      kind: Deployment
+      name: anthropic-backend
+    patch: |-
+      - op: add
+        path: /spec/selector/matchLabels/app
+        value: "anthropic-backend-qwen"
+      - op: add
+        path: /spec/template/metadata/labels/app
+        value: "anthropic-backend-qwen"
+      - op: add
+        path: /spec/template/metadata/labels/model-alias
+        value: "qwen2.5-0.5b-instruct"
+  - target:
+      kind: Service
+      name: anthropic-backend
+    patch: |-
+      - op: add
+        path: /spec/selector/app
+        value: "anthropic-backend-qwen"
+      - op: add
+        path: /metadata/labels/model-alias
+        value: "qwen2.5-0.5b-instruct"
+  - target:
+      kind: Deployment
+      name: anthropic-backend
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/0/persistentVolumeClaim/claimName
+        value: anthropic-backend-models-qwen

--- a/e2e/testing/anthropic-shim/.gitignore
+++ b/e2e/testing/anthropic-shim/.gitignore
@@ -1,0 +1,17 @@
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# IDE files
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/e2e/testing/anthropic-shim/Dockerfile
+++ b/e2e/testing/anthropic-shim/Dockerfile
@@ -1,0 +1,31 @@
+# Anthropic-shape shim in front of llama.cpp's llama-server.
+# Tiny FastAPI service used by the e2e suite.
+FROM python:3.11-slim
+
+LABEL maintainer="vLLM Semantic Router Team"
+LABEL description="Anthropic Messages API shim that fronts llama.cpp's llama-server for vLLM SR e2e tests"
+LABEL version="0.1.0"
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY anthropic_shim/ ./anthropic_shim/
+COPY pyproject.toml ./
+COPY README.md ./
+
+RUN pip install --no-cache-dir -e .
+
+RUN useradd --create-home --shell /bin/bash shim
+USER shim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    ANTHROPIC_SHIM_HOST=0.0.0.0 \
+    ANTHROPIC_SHIM_PORT=9080 \
+    ANTHROPIC_SHIM_UPSTREAM_URL=http://127.0.0.1:8080
+
+EXPOSE 9080
+
+CMD ["python", "-m", "anthropic_shim"]

--- a/e2e/testing/anthropic-shim/README.md
+++ b/e2e/testing/anthropic-shim/README.md
@@ -1,0 +1,95 @@
+# anthropic-shim
+
+A small FastAPI service that fronts [`llama.cpp`'s `llama-server`][llama-server]
+and patches three gaps in its Anthropic Messages API support so the
+vLLM Semantic Router e2e suite can exercise realistic upstream
+Anthropic behaviour without forking llama.cpp.
+
+## What it fixes
+
+| Gap | llama-server behaviour | Shim behaviour |
+| --- | --- | --- |
+| `system` as `TextBlockParam[]` | Concatenates text fields with no separator (`"You are helpful.Be concise."`) | Joins text fields with `\n` before forwarding |
+| `tool_result.content` as `TextBlockParam[]` | Same flattening issue inside tool results | Joins text fields with `\n` before forwarding |
+| Prompt-cache token counters | `cache_creation_input_tokens` and `cache_read_input_tokens` are never populated | Tracks per-session request-prefix hashes; sets `cache_creation_input_tokens` on first request and `cache_read_input_tokens` on subsequent repeats |
+
+Everything else (image blocks, `top_k`, `metadata.user_id`,
+`tool_result.is_error`, headers like `anthropic-version` and
+`anthropic-beta`, streaming SSE) is forwarded verbatim.
+
+## Layout
+
+```
+e2e/testing/anthropic-shim/
+├── anthropic_shim/
+│   ├── __init__.py
+│   ├── __main__.py     # python -m anthropic_shim entry point
+│   ├── app.py          # FastAPI proxy
+│   └── translate.py    # pure translation helpers
+├── tests/
+│   ├── test_app.py
+│   └── test_translate.py
+├── Dockerfile
+├── pyproject.toml
+├── requirements.txt
+└── README.md
+```
+
+## Running locally
+
+```bash
+# Start llama-server with a tiny GGUF model on port 8080
+docker run --rm -p 8080:8080 \
+  -v /path/to/models:/models:ro \
+  ghcr.io/ggml-org/llama.cpp:server \
+  -m /models/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf \
+  --jinja --host 0.0.0.0 --port 8080 -c 4096
+
+# In another terminal, start the shim on port 9080
+pip install -e .
+ANTHROPIC_SHIM_UPSTREAM_URL=http://127.0.0.1:8080 \
+  python -m anthropic_shim
+
+# Hit the shim with an Anthropic Messages request
+curl -s http://127.0.0.1:9080/v1/messages \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "qwen-test",
+    "system": [
+      {"type": "text", "text": "You are a helpful assistant."},
+      {"type": "text", "text": "Be very concise.", "cache_control": {"type": "ephemeral"}}
+    ],
+    "messages": [{"role": "user", "content": "Hi"}],
+    "max_tokens": 16
+  }'
+```
+
+## Configuration
+
+All configuration is environment-driven so the same image can be
+reused across overlays:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ANTHROPIC_SHIM_UPSTREAM_URL` | `http://127.0.0.1:8080` | llama-server base URL |
+| `ANTHROPIC_SHIM_HOST` | `0.0.0.0` | bind address |
+| `ANTHROPIC_SHIM_PORT` | `9080` | bind port |
+| `ANTHROPIC_SHIM_SESSION_HEADER` | `x-vsr-test-session-id` | request header used to scope prompt-cache state |
+| `ANTHROPIC_SHIM_REQUEST_TIMEOUT` | `300` | upstream request timeout (seconds) |
+
+Requests without the session header share a single global session,
+which is fine for single-tenant test runs.
+
+## Tests
+
+```bash
+pip install -e .[dev]
+pytest
+```
+
+The unit tests cover every translation rule plus edge cases
+(nil-safety, mixed content blocks, malformed payloads). The
+end-to-end translation behaviour is also exercised against a stub
+upstream that records every forwarded request.
+
+[llama-server]: https://github.com/ggml-org/llama.cpp/tree/master/tools/server

--- a/e2e/testing/anthropic-shim/anthropic_shim/__init__.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/__init__.py
@@ -1,0 +1,8 @@
+"""Anthropic-shape shim in front of llama.cpp's llama-server.
+
+Bridges three gaps in llama-server's Messages API support so the e2e
+suite can drive realistic Anthropic-shape upstream behaviour without
+forking llama.cpp.
+"""
+
+__version__ = "0.1.0"

--- a/e2e/testing/anthropic-shim/anthropic_shim/__main__.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/__main__.py
@@ -1,0 +1,17 @@
+"""Run the shim with ``python -m anthropic_shim``."""
+
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+def main() -> None:
+    host = os.environ.get("ANTHROPIC_SHIM_HOST", "0.0.0.0")
+    port = int(os.environ.get("ANTHROPIC_SHIM_PORT", "9080"))
+    uvicorn.run("anthropic_shim.app:app", host=host, port=port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/testing/anthropic-shim/anthropic_shim/app.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/app.py
@@ -1,0 +1,227 @@
+"""FastAPI proxy that fronts a llama-server with Anthropic-shape fixes.
+
+Forwards every request as-is to the configured upstream after applying
+the inbound translations from :mod:`anthropic_shim.translate`, then
+post-processes the response to synthesise prompt-cache usage counters.
+
+The proxy is intentionally minimal: it covers ``/v1/messages`` and the
+streaming sibling, and passes everything else (``/health``, ``/v1/models``,
+arbitrary debug routes) straight through.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from .translate import (
+    apply_cache_usage,
+    cache_prefix_hash,
+    has_cache_control,
+    join_system_array,
+    join_tool_result_content,
+)
+
+LOGGER = logging.getLogger("anthropic_shim")
+
+# Headers that httpx / Starlette manage themselves; forwarding them
+# verbatim either confuses the upstream or breaks chunked transfer.
+_HOP_BY_HOP = {
+    "connection",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def _filtered_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP}
+
+
+class SessionCacheTracker:
+    """Tracks per-session request-prefix hashes for cache synthesis.
+
+    A session is identified by the header named in
+    ``ANTHROPIC_SHIM_SESSION_HEADER`` (default
+    ``x-vsr-test-session-id``). Requests without that header share a
+    global session — fine for single-tenant test runs.
+    """
+
+    def __init__(self) -> None:
+        self._seen: dict[str, set[str]] = {}
+
+    def mark(self, session_id: str, prefix: str) -> bool:
+        """Record ``prefix`` for ``session_id`` and return prior-seen status."""
+        bucket = self._seen.setdefault(session_id, set())
+        already_seen = prefix in bucket
+        bucket.add(prefix)
+        return already_seen
+
+
+def create_app(
+    upstream_url: str | None = None,
+    session_header: str | None = None,
+    request_timeout: float | None = None,
+) -> FastAPI:
+    upstream = (
+        upstream_url
+        or os.environ.get("ANTHROPIC_SHIM_UPSTREAM_URL")
+        or "http://127.0.0.1:8080"
+    ).rstrip("/")
+    session_header_name = (
+        session_header
+        or os.environ.get("ANTHROPIC_SHIM_SESSION_HEADER")
+        or "x-vsr-test-session-id"
+    ).lower()
+    timeout = float(
+        request_timeout
+        if request_timeout is not None
+        else os.environ.get("ANTHROPIC_SHIM_REQUEST_TIMEOUT", "300")
+    )
+
+    client = httpx.AsyncClient(base_url=upstream, timeout=timeout)
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        try:
+            yield
+        finally:
+            await _app.state.client.aclose()
+
+    app = FastAPI(title="anthropic-shim", version="0.1.0", lifespan=lifespan)
+    app.state.upstream = upstream
+    app.state.tracker = SessionCacheTracker()
+    app.state.session_header = session_header_name
+    app.state.client = client
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok", "upstream": upstream}
+
+    @app.post("/v1/messages")
+    async def messages(request: Request) -> Response:
+        return await _handle_messages(request, app)
+
+    @app.api_route(
+        "/{path:path}",
+        methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+    )
+    async def passthrough(path: str, request: Request) -> Response:
+        return await _proxy_raw(request, path, app)
+
+    return app
+
+
+async def _handle_messages(request: Request, app: FastAPI) -> Response:
+    raw_body = await request.body()
+    try:
+        body: dict[str, Any] = (
+            httpx.Response(200, content=raw_body).json() if raw_body else {}
+        )
+    except ValueError:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_json", "detail": "body is not JSON"},
+        )
+
+    request_had_cache_control = has_cache_control(body)
+    prefix_hash = cache_prefix_hash(body) if request_had_cache_control else ""
+
+    body = join_system_array(body)
+    body = join_tool_result_content(body)
+
+    session_id = request.headers.get(app.state.session_header) or "__global__"
+    headers = _filtered_headers(dict(request.headers))
+    headers.pop("content-length", None)
+
+    is_streaming = bool(body.get("stream"))
+    if is_streaming:
+        return await _proxy_stream(app, "/v1/messages", body, headers)
+
+    upstream_response = await app.state.client.post(
+        "/v1/messages",
+        json=body,
+        headers=headers,
+    )
+
+    response_headers = _filtered_headers(dict(upstream_response.headers))
+    try:
+        response_payload = upstream_response.json()
+    except ValueError:
+        return Response(
+            content=upstream_response.content,
+            status_code=upstream_response.status_code,
+            headers=response_headers,
+            media_type=upstream_response.headers.get("content-type"),
+        )
+
+    if request_had_cache_control and isinstance(response_payload, dict):
+        prefix_seen = app.state.tracker.mark(session_id, prefix_hash)
+        apply_cache_usage(
+            response_payload,
+            request_had_cache_control=True,
+            prefix_seen=prefix_seen,
+        )
+
+    return JSONResponse(
+        content=response_payload,
+        status_code=upstream_response.status_code,
+        headers=response_headers,
+    )
+
+
+async def _proxy_stream(
+    app: FastAPI,
+    path: str,
+    body: dict[str, Any],
+    headers: dict[str, str],
+) -> StreamingResponse:
+    """Stream upstream SSE bytes verbatim.
+
+    Cache usage post-processing is not applied to streamed responses
+    because the bytes-on-the-wire format would need to be parsed and
+    re-emitted; the e2e cache-cycle tests use non-streaming requests.
+    """
+
+    async def iterate() -> AsyncIterator[bytes]:
+        async with app.state.client.stream(
+            "POST", path, json=body, headers=headers
+        ) as upstream:
+            async for chunk in upstream.aiter_raw():
+                yield chunk
+
+    return StreamingResponse(iterate(), media_type="text/event-stream")
+
+
+async def _proxy_raw(request: Request, path: str, app: FastAPI) -> Response:
+    body = await request.body()
+    headers = _filtered_headers(dict(request.headers))
+    upstream_response = await app.state.client.request(
+        request.method,
+        "/" + path,
+        params=dict(request.query_params),
+        content=body,
+        headers=headers,
+    )
+    return Response(
+        content=upstream_response.content,
+        status_code=upstream_response.status_code,
+        headers=_filtered_headers(dict(upstream_response.headers)),
+        media_type=upstream_response.headers.get("content-type"),
+    )
+
+
+app = create_app()

--- a/e2e/testing/anthropic-shim/anthropic_shim/translate.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/translate.py
@@ -1,0 +1,219 @@
+"""Pure translation helpers used by the proxy.
+
+The functions here are deliberately framework-free so they can be
+exercised by unit tests without spinning up a server or a model.
+
+Three concerns are handled:
+
+1. ``join_system_array`` flattens a Messages-API ``system`` array of
+   ``TextBlockParam`` entries into a single newline-separated string.
+   llama-server otherwise concatenates the text fields with no
+   separator, which destroys word boundaries.
+2. ``join_tool_result_content`` does the same for the ``content`` array
+   of a ``tool_result`` block.
+3. ``apply_cache_usage`` post-processes a Messages response and
+   synthesises ``cache_creation_input_tokens`` /
+   ``cache_read_input_tokens`` based on whether the inbound request
+   carried ``cache_control`` markers and whether this session has seen
+   the same request-body prefix before.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def _is_text_block(block: Any) -> bool:
+    return (
+        isinstance(block, dict)
+        and block.get("type") == "text"
+        and isinstance(block.get("text"), str)
+    )
+
+
+def join_system_array(body: dict[str, Any]) -> dict[str, Any]:
+    """Collapse ``system`` array into a single newline-joined string.
+
+    Mutates and returns ``body``. No-op when ``system`` is missing or
+    already a string. Non-text blocks are silently dropped (the
+    Messages API permits only text blocks in ``system`` today).
+    """
+    system = body.get("system")
+    if not isinstance(system, list):
+        return body
+    texts = [block["text"] for block in system if _is_text_block(block)]
+    body["system"] = "\n".join(texts)
+    return body
+
+
+def join_tool_result_content(body: dict[str, Any]) -> dict[str, Any]:
+    """Collapse every ``tool_result.content`` array into a single string.
+
+    Walks all message blocks and rewrites ``tool_result`` entries whose
+    ``content`` is an array of text blocks. Non-array contents
+    (already a string, or absent) are left untouched. Non-text array
+    entries are skipped, matching llama-server's expectation that
+    ``tool_result.content`` carries only text.
+    """
+    messages = body.get("messages")
+    if not isinstance(messages, list):
+        return body
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            tr_content = block.get("content")
+            if not isinstance(tr_content, list):
+                continue
+            texts = [item["text"] for item in tr_content if _is_text_block(item)]
+            block["content"] = "\n".join(texts)
+    return body
+
+
+def has_cache_control(body: dict[str, Any]) -> bool:
+    """Return True when any block in the request carries a ``cache_control`` marker."""
+    system = body.get("system")
+    if isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and "cache_control" in block:
+                return True
+    for message in body.get("messages", []) or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and "cache_control" in block:
+                    return True
+    for tool in body.get("tools", []) or []:
+        if isinstance(tool, dict) and "cache_control" in tool:
+            return True
+    return False
+
+
+def cache_prefix_hash(body: dict[str, Any]) -> str:
+    """Hash the cacheable prefix of a request.
+
+    Anthropic's prompt-cache contract keys on the request prefix up to
+    and including the last block bearing ``cache_control``. The shim
+    walks ``tools``, ``system``, then each message's ``content``
+    blocks in order, and stops at the last marker. Everything past
+    that marker (subsequent turns, the final user query) is treated as
+    cache-irrelevant. The hash is opaque; only equality matters.
+    """
+    prefix_parts: list[Any] = []
+
+    tool_prefix = _tools_prefix(body.get("tools") or [])
+    if tool_prefix is not None:
+        prefix_parts.append({"tools": tool_prefix})
+
+    system = body.get("system")
+    if _should_include_system(body, system, tool_prefix is not None):
+        prefix_parts.append({"system": system})
+
+    message_prefix = _messages_prefix(body.get("messages") or [])
+    if message_prefix is not None:
+        prefix_parts.append({"messages": message_prefix})
+
+    digest = hashlib.sha256(
+        json.dumps(prefix_parts, sort_keys=True, default=str).encode("utf-8")
+    )
+    return digest.hexdigest()
+
+
+def _tools_prefix(tools: list[Any]) -> list[Any] | None:
+    """Return tools up to and including the last cache_control marker, or None."""
+    last_marker = -1
+    for idx, tool in enumerate(tools):
+        if isinstance(tool, dict) and "cache_control" in tool:
+            last_marker = idx
+    return tools[: last_marker + 1] if last_marker >= 0 else None
+
+
+def _should_include_system(
+    body: dict[str, Any], system: Any, tools_have_marker: bool
+) -> bool:
+    """The system block joins the prefix if any later cached block exists."""
+    if system is None:
+        return False
+    if tools_have_marker:
+        return True
+    if isinstance(system, list) and any(
+        isinstance(block, dict) and "cache_control" in block for block in system
+    ):
+        return True
+    return _messages_have_marker(body)
+
+
+def _messages_prefix(messages: list[Any]) -> list[Any] | None:
+    """Return messages truncated to the last cache_control marker, or None."""
+    cutoff_message = -1
+    cutoff_block = -1
+    for m_idx, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for b_idx, block in enumerate(content):
+            if isinstance(block, dict) and "cache_control" in block:
+                cutoff_message = m_idx
+                cutoff_block = b_idx
+    if cutoff_message < 0:
+        return None
+    truncated: list[Any] = list(messages[:cutoff_message])
+    last = messages[cutoff_message]
+    if isinstance(last, dict) and isinstance(last.get("content"), list):
+        partial = dict(last)
+        partial["content"] = last["content"][: cutoff_block + 1]
+        truncated.append(partial)
+    else:
+        truncated.append(last)
+    return truncated
+
+
+def _messages_have_marker(body: dict[str, Any]) -> bool:
+    for message in body.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and "cache_control" in block:
+                    return True
+    return False
+
+
+def apply_cache_usage(
+    response: dict[str, Any],
+    request_had_cache_control: bool,
+    prefix_seen: bool,
+) -> dict[str, Any]:
+    """Populate ``cache_creation_input_tokens`` and ``cache_read_input_tokens``.
+
+    Mutates and returns ``response``. The Anthropic contract says:
+    on the first request with a given cache prefix, the whole input
+    counts as a creation; on subsequent requests, the same input
+    counts as a read. llama-server reports neither field today, so the
+    shim fills them in from ``input_tokens``.
+    """
+    if not request_had_cache_control:
+        return response
+    usage = response.get("usage")
+    if not isinstance(usage, dict):
+        return response
+    input_tokens = usage.get("input_tokens", 0)
+    if prefix_seen:
+        usage.setdefault("cache_creation_input_tokens", 0)
+        usage["cache_read_input_tokens"] = input_tokens
+    else:
+        usage["cache_creation_input_tokens"] = input_tokens
+        usage.setdefault("cache_read_input_tokens", 0)
+    return response

--- a/e2e/testing/anthropic-shim/pyproject.toml
+++ b/e2e/testing/anthropic-shim/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "anthropic-shim"
+version = "0.1.0"
+description = "Anthropic Messages API shim in front of llama.cpp's llama-server for vLLM Semantic Router e2e tests"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+requires-python = ">=3.10"
+keywords = ["llm", "anthropic", "llama.cpp", "testing", "semantic-router"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Testing",
+]
+
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+    "httpx>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.23.0",
+    "asgi-lifespan>=2.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/vllm-project/semantic-router"
+Documentation = "https://github.com/vllm-project/semantic-router/tree/main/e2e/testing/anthropic-shim"
+Repository = "https://github.com/vllm-project/semantic-router.git"
+Issues = "https://github.com/vllm-project/semantic-router/issues"
+
+[project.scripts]
+anthropic-shim = "anthropic_shim.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["anthropic_shim*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/e2e/testing/anthropic-shim/requirements.txt
+++ b/e2e/testing/anthropic-shim/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0
+httpx>=0.27.0

--- a/e2e/testing/anthropic-shim/tests/test_app.py
+++ b/e2e/testing/anthropic-shim/tests/test_app.py
@@ -1,0 +1,197 @@
+"""Integration tests for the FastAPI proxy using a stub upstream.
+
+These avoid spinning up llama-server by mounting a tiny in-process
+ASGI app as the proxy target. They verify that the shim:
+- forwards the joined ``system`` string to the upstream
+- joins ``tool_result.content`` arrays before forwarding
+- post-processes responses to synthesise prompt-cache token counters
+- tracks repeat-prefix state per session header
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from anthropic_shim.app import create_app
+
+
+class _UpstreamRecorder:
+    """In-process stand-in for llama-server.
+
+    Records every request body it receives, and emits a canned response
+    so the test can assert on the shim's pre- and post-processing
+    without involving a real model.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.input_tokens = 42
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8")) if request.content else {}
+        self.requests.append(body)
+        payload = {
+            "id": f"msg_{len(self.requests)}",
+            "type": "message",
+            "role": "assistant",
+            "model": body.get("model", "qwen-test"),
+            "content": [{"type": "text", "text": "ok"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": self.input_tokens, "output_tokens": 1},
+        }
+        return httpx.Response(200, json=payload)
+
+
+@pytest.fixture()
+def client_with_upstream() -> tuple[httpx.AsyncClient, _UpstreamRecorder]:
+    upstream = _UpstreamRecorder()
+    app = create_app(upstream_url="http://upstream.invalid")
+    app.state.client = httpx.AsyncClient(
+        transport=httpx.MockTransport(upstream.handler),
+        base_url="http://upstream.invalid",
+    )
+    return (
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://shim"
+        ),
+        upstream,
+    )
+
+
+@pytest.mark.asyncio
+async def test_messages_joins_system_array_before_forwarding(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, upstream = client_with_upstream
+    payload = {
+        "model": "qwen-test",
+        "system": [
+            {"type": "text", "text": "You are a helpful assistant."},
+            {"type": "text", "text": "Be very concise."},
+        ],
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16,
+    }
+    await client.post("/v1/messages", json=payload)
+    assert upstream.requests
+    forwarded = upstream.requests[-1]
+    assert forwarded["system"] == "You are a helpful assistant.\nBe very concise."
+
+
+@pytest.mark.asyncio
+async def test_messages_joins_tool_result_array_before_forwarding(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, upstream = client_with_upstream
+    payload = {
+        "model": "qwen-test",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "abc",
+                        "content": [
+                            {"type": "text", "text": "first"},
+                            {"type": "text", "text": "second"},
+                        ],
+                    }
+                ],
+            }
+        ],
+        "max_tokens": 16,
+    }
+    await client.post("/v1/messages", json=payload)
+    forwarded = upstream.requests[-1]
+    assert forwarded["messages"][0]["content"][0]["content"] == "first\nsecond"
+
+
+@pytest.mark.asyncio
+async def test_cache_usage_synthesised_on_first_then_repeat_request(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    payload = {
+        "model": "qwen-test",
+        "system": [
+            {
+                "type": "text",
+                "text": "long prefix",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16,
+    }
+    headers = {"x-vsr-test-session-id": "session-a"}
+
+    first = await client.post("/v1/messages", json=payload, headers=headers)
+    second = await client.post("/v1/messages", json=payload, headers=headers)
+
+    first_usage = first.json()["usage"]
+    second_usage = second.json()["usage"]
+    assert first_usage["cache_creation_input_tokens"] == 42
+    assert first_usage["cache_read_input_tokens"] == 0
+    assert second_usage["cache_creation_input_tokens"] == 0
+    assert second_usage["cache_read_input_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_cache_usage_untouched_when_request_has_no_cache_control(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    payload = {
+        "model": "qwen-test",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16,
+    }
+    response = await client.post("/v1/messages", json=payload)
+    usage = response.json()["usage"]
+    assert "cache_creation_input_tokens" not in usage
+    assert "cache_read_input_tokens" not in usage
+
+
+@pytest.mark.asyncio
+async def test_session_isolation_with_distinct_session_headers(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    payload = {
+        "model": "qwen-test",
+        "system": [
+            {
+                "type": "text",
+                "text": "long prefix",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16,
+    }
+    first = await client.post(
+        "/v1/messages", json=payload, headers={"x-vsr-test-session-id": "alpha"}
+    )
+    second_other_session = await client.post(
+        "/v1/messages", json=payload, headers={"x-vsr-test-session-id": "beta"}
+    )
+    assert first.json()["usage"]["cache_creation_input_tokens"] == 42
+    # different session: counts as first request again
+    assert second_other_session.json()["usage"]["cache_creation_input_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_returns_400(
+    client_with_upstream: tuple[httpx.AsyncClient, _UpstreamRecorder],
+) -> None:
+    client, _ = client_with_upstream
+    response = await client.post(
+        "/v1/messages",
+        content=b"not valid json",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 400

--- a/e2e/testing/anthropic-shim/tests/test_translate.py
+++ b/e2e/testing/anthropic-shim/tests/test_translate.py
@@ -1,0 +1,239 @@
+"""Unit tests for the translation helpers.
+
+Three gap-translation cases (system-array join, tool_result array join,
+cache token synthesis) plus edge cases (nil-safety, mixed content,
+malformed payloads).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from anthropic_shim.translate import (
+    apply_cache_usage,
+    cache_prefix_hash,
+    has_cache_control,
+    join_system_array,
+    join_tool_result_content,
+)
+
+
+def test_join_system_array_collapses_text_blocks_with_newline() -> None:
+    body = {
+        "system": [
+            {"type": "text", "text": "You are a helpful assistant."},
+            {"type": "text", "text": "Be very concise."},
+        ]
+    }
+    join_system_array(body)
+    assert body["system"] == "You are a helpful assistant.\nBe very concise."
+
+
+def test_join_system_array_passes_through_string() -> None:
+    body = {"system": "already a string"}
+    join_system_array(body)
+    assert body["system"] == "already a string"
+
+
+def test_join_system_array_missing_is_noop() -> None:
+    body: dict = {"messages": []}
+    join_system_array(body)
+    assert "system" not in body
+
+
+def test_join_system_array_drops_non_text_blocks() -> None:
+    body = {
+        "system": [
+            {"type": "text", "text": "Hello"},
+            {"type": "image", "source": {"type": "base64"}},
+            {"type": "text", "text": "World"},
+        ]
+    }
+    join_system_array(body)
+    assert body["system"] == "Hello\nWorld"
+
+
+def test_join_tool_result_content_collapses_text_blocks() -> None:
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "abc",
+                        "content": [
+                            {"type": "text", "text": "first line"},
+                            {"type": "text", "text": "second line"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    join_tool_result_content(body)
+    block = body["messages"][0]["content"][0]
+    assert block["content"] == "first line\nsecond line"
+
+
+def test_join_tool_result_content_preserves_string_form() -> None:
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "abc",
+                        "content": "already a string",
+                    }
+                ],
+            }
+        ]
+    }
+    original = copy.deepcopy(body)
+    join_tool_result_content(body)
+    assert body == original
+
+
+def test_join_tool_result_content_handles_mixed_blocks() -> None:
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "irrelevant"},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "abc",
+                        "content": [{"type": "text", "text": "one"}],
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "def",
+                        "content": [
+                            {"type": "text", "text": "two"},
+                            {"type": "text", "text": "three"},
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+    join_tool_result_content(body)
+    blocks = body["messages"][0]["content"]
+    assert blocks[1]["content"] == "one"
+    assert blocks[2]["content"] == "two\nthree"
+
+
+def test_join_tool_result_content_missing_messages_is_noop() -> None:
+    body: dict = {}
+    join_tool_result_content(body)
+    assert body == {}
+
+
+def test_has_cache_control_detects_system_block_marker() -> None:
+    body = {
+        "system": [
+            {"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral"}},
+        ]
+    }
+    assert has_cache_control(body) is True
+
+
+def test_has_cache_control_detects_message_block_marker() -> None:
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+            }
+        ]
+    }
+    assert has_cache_control(body) is True
+
+
+def test_has_cache_control_detects_tool_marker() -> None:
+    body = {
+        "tools": [
+            {"name": "calc", "input_schema": {}, "cache_control": {"type": "ephemeral"}}
+        ]
+    }
+    assert has_cache_control(body) is True
+
+
+def test_has_cache_control_negative_when_absent() -> None:
+    body = {"system": "plain", "messages": [{"role": "user", "content": "hi"}]}
+    assert has_cache_control(body) is False
+
+
+def test_apply_cache_usage_creation_on_first_request() -> None:
+    response = {"usage": {"input_tokens": 42, "output_tokens": 7}}
+    apply_cache_usage(response, request_had_cache_control=True, prefix_seen=False)
+    assert response["usage"]["cache_creation_input_tokens"] == 42
+    assert response["usage"]["cache_read_input_tokens"] == 0
+
+
+def test_apply_cache_usage_read_on_repeat_request() -> None:
+    response = {"usage": {"input_tokens": 42, "output_tokens": 7}}
+    apply_cache_usage(response, request_had_cache_control=True, prefix_seen=True)
+    assert response["usage"]["cache_creation_input_tokens"] == 0
+    assert response["usage"]["cache_read_input_tokens"] == 42
+
+
+def test_apply_cache_usage_noop_without_cache_control() -> None:
+    response = {"usage": {"input_tokens": 42, "output_tokens": 7}}
+    apply_cache_usage(response, request_had_cache_control=False, prefix_seen=True)
+    assert "cache_creation_input_tokens" not in response["usage"]
+    assert "cache_read_input_tokens" not in response["usage"]
+
+
+def test_apply_cache_usage_handles_missing_usage() -> None:
+    response: dict = {"id": "msg_1"}
+    apply_cache_usage(response, request_had_cache_control=True, prefix_seen=False)
+    assert response == {"id": "msg_1"}
+
+
+def test_cache_prefix_hash_stable_across_repeat_requests() -> None:
+    body_a = {
+        "system": [
+            {"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral"}}
+        ],
+        "messages": [{"role": "user", "content": "first turn"}],
+    }
+    body_b = {
+        "system": [
+            {"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral"}}
+        ],
+        "messages": [
+            {"role": "user", "content": "first turn"},
+            {"role": "assistant", "content": "ack"},
+            {"role": "user", "content": "second turn"},
+        ],
+    }
+    # body_b appends new turns after the cached prefix; hashes should match
+    # because the cache_control marker is in `system`, so the prefix is just
+    # the system block.
+    assert cache_prefix_hash(body_a) == cache_prefix_hash(body_b)
+
+
+def test_cache_prefix_hash_differs_when_prefix_changes() -> None:
+    body_a = {
+        "system": [
+            {"type": "text", "text": "Hello A", "cache_control": {"type": "ephemeral"}}
+        ],
+        "messages": [],
+    }
+    body_b = {
+        "system": [
+            {"type": "text", "text": "Hello B", "cache_control": {"type": "ephemeral"}}
+        ],
+        "messages": [],
+    }
+    assert cache_prefix_hash(body_a) != cache_prefix_hash(body_b)

--- a/tools/linter/python/.ruff.toml
+++ b/tools/linter/python/.ruff.toml
@@ -99,6 +99,7 @@ max-nested-blocks = 4
 "tools/agent/scripts/tuning/scenarios/*.py" = ["PLR2004"]
 "tools/agent/scripts/tuning/tests/*.py" = ["PLC0415", "PLR2004"]
 "src/vllm-sr/tests/*.py" = ["PLR2004"]
+"e2e/testing/anthropic-shim/tests/*.py" = ["PLR2004"]
 "src/vllm-sr/tests/test_config_template.py" = ["E402", "UP015"]
 "src/vllm-sr/tests/test_latency_validation.py" = ["I001"]
 "src/vllm-sr/tests/test_plugin_parsing.py" = ["I001", "RUF043"]


### PR DESCRIPTION
# Add Anthropic-shape e2e backend for `/v1/messages` translation cells

Opening this as a PR rather than a design issue because the gap is clearly defined and the proposed approach is small, targeted, and additive (no changes to existing code paths). Happy to pivot to an issue-first discussion or take a different approach if you'd prefer that before reviewing the code.

## Problem

The e2e suite cannot exercise the upstream side of vsr's Anthropic translation cells, because `llm-katan` only serves OpenAI shape. When the router translates `OpenAI → Anthropic` on outbound — either for the existing OpenAI-client / Anthropic-backend cell (the `ToAnthropicRequestBody` write path introduced by #1922) or for the in-flight native `/v1/messages` ingress work (#1937 merged, #1938–#1941 + #1944 in review, design at #1946) — no automated test verifies that the translation reached and was understood by the backend.

Concretely, 11 behavioral test cases that protect real bugs we've found and fixed are not writable today: prompt cache cycle (`cache_creation_input_tokens` on first request, `cache_read_input_tokens` on second), `anthropic-version` and `anthropic-beta` header forwarding to upstream verbatim, image block survival across translation, `top_k` and `metadata.user_id` and system-as-array (with per-block `cache_control`) reaching upstream, `tool_result.is_error` preservation, `tool_result` with array content preserved, `stop_reason: stop_sequence` reported correctly on responses, and exactly one `message_stop` on the double-Anthropic streaming cell.

## Proposed solution

Adopt the upstream `ghcr.io/ggml-org/llama.cpp:server` image as an additional e2e backend deployed alongside `llm-katan` in the kubernetes profile, fronted by a small shim (~150 LOC) that covers three minor gaps we verified empirically. The shim joins llama-server's flattened system-array and `tool_result` array content with newline separators (otherwise text blocks lose word boundaries), and synthesizes Anthropic `cache_creation_input_tokens` / `cache_read_input_tokens` values in the response `usage` based on whether the request has `cache_control` markers and whether the prefix has been seen before in the test session.

Estimated impact: ~230 LOC added to vsr (shim + kustomize manifests + CI workflow update), ~8–10 new files under `e2e/testing/anthropic-shim/` and `deploy/kubernetes/anthropic-backend/`, no changes to llama.cpp upstream. Test-machine load per kubernetes integration-test run: ~1.5 GB memory, ~1 CPU core, ~30s startup, ~1–3 min added to total runtime (currently ~21 min for `integration-test (kubernetes)`).

## Why this rather than a hand-rolled mock

Drift resistance. The llama.cpp project's maintainers track the Anthropic Messages API and ship updates as the spec evolves; the e2e suite consumes those without our maintenance. The shim only needs updating if Anthropic changes the `usage` schema or adds a new `tool_result` content variant — both rare and scoped. Compared to a hand-rolled deterministic mock, drift maintenance drops from "every Anthropic API addition" to "a 5–10 LOC update on rare spec changes."

## Alternatives considered

Extending `llm-katan` in-place with `/v1/messages` support was attractive (single backend image to maintain) but injects protocol-specific logic into what is currently a clean OpenAI server, and re-introduces the drift exposure llama.cpp avoids. `LiteLLM` proxy as the translator has open bugs in its Anthropic pass-through (including filtered beta headers and broken `tool_result` routing) that would make our header-forwarding tests test the wrong thing. `vllm` with its merged `/v1/messages` support is the production reference implementation, but the CPU image is 6–11 GB compressed and takes 30–90s to start — impractical for kind cluster e2e.

## Test plan

- [x] Shim unit tests cover each translation case (system-array join, tool_result array join, cache_creation/cache_read synthesis on first vs repeat request)
- [x] Shim + llama-server integration verified locally outside the kind cluster (curl-driven, real model inference, all 11 target test cases produce expected response shapes)
- [x] Kubernetes manifests validated via `kustomize build` (cannot test actual deployment locally without a kind cluster — will run in CI on this PR)
- [x] `make agent-lint` clean on all new files
- [x] New e2e test cases in subsequent PRs (the fix PRs in the ingress series and the OpenAI-client/Anthropic-backend sibling) will reference this backend; not in this PR's scope

## Notes for reviewers

The two design questions worth flagging early:
1. **Separate backend vs extending `llm-katan` in-place**: chose separate to preserve `llm-katan` as a clean OpenAI server and to keep llama.cpp as the upstream source-of-truth for drift resistance. Open to pivoting to in-place if you prefer one image to maintain.
2. **Packaging**: `[CI/Build]` PR off main, deliberately not bundled into any of the in-flight ingress series PRs so it can be reviewed for the testing concern independently. Open to bundling if you'd rather.
