### PR TITLE
[Router][Docs] wire AutoMix entailment verifier into confidence cascade (closes #1173 AutoMix half)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -668,6 +668,8 @@ routing:
           escalation_order: small_to_large
           cost_quality_tradeoff: 0.45
           token_filter: alpha_numeric
+          verifier_server_url: ""
+          verifier_timeout_seconds: 0
       plugins:
         - type: hallucination
           configuration:

--- a/src/semantic-router/pkg/config/decision_config.go
+++ b/src/semantic-router/pkg/config/decision_config.go
@@ -80,6 +80,19 @@ type ConfidenceAlgorithmConfig struct {
 	EscalationOrder     string               `yaml:"escalation_order,omitempty"`
 	CostQualityTradeoff float64              `yaml:"cost_quality_tradeoff,omitempty"`
 	TokenFilter         string               `yaml:"token_filter,omitempty"`
+
+	// VerifierServerURL points to the AutoMix self-verification server when
+	// confidence_method=automix_entailment. The server implements few-shot
+	// entailment verification per arXiv:2310.12963 §3.2 and is reached over
+	// HTTP via selection.AutoMixVerifierClient. A reference implementation
+	// lives at src/training/model_selection/rl_model_selection/automix_verifier.py.
+	// Required only when confidence_method=automix_entailment; ignored otherwise.
+	VerifierServerURL string `yaml:"verifier_server_url,omitempty"`
+
+	// VerifierTimeoutSeconds bounds each verifier HTTP call. Defaults to 60
+	// when zero, matching selection.NewAutoMixVerifierClient. Only consulted
+	// when confidence_method=automix_entailment.
+	VerifierTimeoutSeconds int `yaml:"verifier_timeout_seconds,omitempty"`
 }
 
 type HybridWeightsConfig struct {

--- a/src/semantic-router/pkg/looper/confidence.go
+++ b/src/semantic-router/pkg/looper/confidence.go
@@ -25,11 +25,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/openai/openai-go"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection"
 )
 
 // SelfVerificationPrompt is the prompt template for AutoMix self-verification
@@ -294,13 +297,27 @@ func getCostQualityTradeoff(cfg *config.ConfidenceAlgorithmConfig) float64 {
 	return cfg.CostQualityTradeoff
 }
 
+// MethodAutoMixEntailment is the confidence method name for paper-faithful
+// AutoMix self-verification (arXiv:2310.12963 §3.2). Unlike "self_verify",
+// which prompts the generation model to grade its own answer, this method
+// delegates verification to a separate entailment verifier reached over HTTP
+// via selection.AutoMixVerifierClient (reference server:
+// src/training/model_selection/rl_model_selection/automix_verifier.py).
+const MethodAutoMixEntailment = "automix_entailment"
+
 // ConfidenceEvaluator evaluates model response confidence based on configured method
 type ConfidenceEvaluator struct {
-	Method        string  // "avg_logprob", "margin", "hybrid", or "self_verify" (AutoMix)
+	Method        string  // "avg_logprob", "margin", "hybrid", "self_verify", or "automix_entailment"
 	Threshold     float64 // Threshold for the chosen method
 	LogprobWeight float64 // Weight for logprob in hybrid mode
 	MarginWeight  float64 // Weight for margin in hybrid mode
 	TokenFilter   string  // "all", "tool_call_args" — selects which tokens feed confidence
+
+	// VerifierServerURL and VerifierTimeoutSeconds carry the AutoMix
+	// entailment verifier configuration when Method == "automix_entailment".
+	// Empty/zero values when the method is anything else.
+	VerifierServerURL      string
+	VerifierTimeoutSeconds int
 }
 
 // NewConfidenceEvaluator creates a confidence evaluator from algorithm config
@@ -335,6 +352,8 @@ func NewConfidenceEvaluator(cfg *config.ConfidenceAlgorithmConfig) *ConfidenceEv
 			eval.Threshold = 0.5 // Normalized score
 		case "self_verify":
 			eval.Threshold = 0.7 // AutoMix paper default
+		case MethodAutoMixEntailment:
+			eval.Threshold = 0.7 // AutoMix paper default (k-sample entailment)
 		}
 	}
 
@@ -351,6 +370,9 @@ func NewConfidenceEvaluator(cfg *config.ConfidenceAlgorithmConfig) *ConfidenceEv
 	if cfg.TokenFilter != "" {
 		eval.TokenFilter = cfg.TokenFilter
 	}
+
+	eval.VerifierServerURL = cfg.VerifierServerURL
+	eval.VerifierTimeoutSeconds = cfg.VerifierTimeoutSeconds
 
 	return eval
 }
@@ -425,16 +447,24 @@ func (e *ConfidenceEvaluator) Evaluate(resp *ModelResponse) (float64, bool) {
 
 // NeedsLogprobs returns whether this evaluator needs logprobs enabled
 func (e *ConfidenceEvaluator) NeedsLogprobs() bool {
-	// self_verify uses model self-assessment, not logprobs
-	if e.Method == "self_verify" {
+	// self_verify and automix_entailment use external verification signals
+	// rather than logprobs from the generation call.
+	switch e.Method {
+	case "self_verify", MethodAutoMixEntailment:
 		return false
 	}
-	return true // All other methods need logprobs
+	return true
 }
 
 // IsSelfVerify returns true if using AutoMix self-verification method
 func (e *ConfidenceEvaluator) IsSelfVerify() bool {
 	return e.Method == "self_verify"
+}
+
+// IsAutoMixEntailment returns true when the evaluator delegates verification
+// to an external AutoMix entailment server (arXiv:2310.12963 §3.2).
+func (e *ConfidenceEvaluator) IsAutoMixEntailment() bool {
+	return e.Method == MethodAutoMixEntailment
 }
 
 // NeedsTopLogprobs returns the number of top_logprobs needed (0 if not needed)
@@ -607,7 +637,32 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		var meetsThreshold bool
 
 		// Evaluate confidence using configured method
-		if evaluator.IsSelfVerify() {
+		switch {
+		case evaluator.IsAutoMixEntailment():
+			// AutoMix entailment cascade (arXiv:2310.12963 §3.2): delegate
+			// verification to an external few-shot entailment server.
+			var verifyErr error
+			confidence, meetsThreshold, verifyErr = l.performAutoMixEntailment(ctx, req, evaluator, modelName, resp.Content)
+			if verifyErr != nil {
+				logging.ComponentWarnEvent("looper", "automix_entailment_failed", map[string]interface{}{
+					"looper":    "confidence",
+					"decision":  req.DecisionName,
+					"model_ref": modelName,
+					"error":     verifyErr.Error(),
+				})
+				if onError == "fail" {
+					return nil, fmt.Errorf("automix_entailment verification for %s failed: %w", modelName, verifyErr)
+				}
+			}
+			logging.ComponentDebugEvent("looper", "automix_entailment_completed", map[string]interface{}{
+				"looper":     "confidence",
+				"decision":   req.DecisionName,
+				"model_ref":  modelName,
+				"confidence": confidence,
+				"threshold":  evaluator.Threshold,
+				"accepted":   meetsThreshold,
+			})
+		case evaluator.IsSelfVerify():
 			// AutoMix self-verification: ask the model to evaluate its own answer
 			confidence, meetsThreshold = l.performSelfVerification(ctx, req, modelName, resp.Content, accessKey, evaluator.Threshold)
 			logging.ComponentDebugEvent("looper", "self_verification_completed", map[string]interface{}{
@@ -618,7 +673,7 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 				"threshold":  evaluator.Threshold,
 				"accepted":   meetsThreshold,
 			})
-		} else {
+		default:
 			confidence, meetsThreshold = evaluator.Evaluate(resp)
 			if evaluator.TokenFilter != "" && evaluator.TokenFilter != "all" && resp.FilteredAverageLogprob != 0 {
 				logging.ComponentDebugEvent("looper", "confidence_evaluated", map[string]interface{}{
@@ -830,6 +885,71 @@ func (l *ConfidenceLooper) buildSelfVerificationRequest(verificationPrompt strin
 	}
 
 	return &params
+}
+
+// automixVerifierCache memoises one selection.AutoMixVerifierClient per
+// (server_url, timeout_seconds) pair so repeated requests share a single
+// http.Client (and its underlying connection pool) instead of reconstructing
+// one per evaluation.
+var automixVerifierCache sync.Map
+
+type automixVerifierCacheKey struct {
+	url            string
+	timeoutSeconds int
+}
+
+func getAutoMixVerifierClient(serverURL string, timeoutSeconds int) *selection.AutoMixVerifierClient {
+	key := automixVerifierCacheKey{url: serverURL, timeoutSeconds: timeoutSeconds}
+	if existing, ok := automixVerifierCache.Load(key); ok {
+		return existing.(*selection.AutoMixVerifierClient)
+	}
+	client := selection.NewAutoMixVerifierClient(serverURL)
+	if timeoutSeconds > 0 {
+		client.SetTimeout(time.Duration(timeoutSeconds) * time.Second)
+	}
+	actual, _ := automixVerifierCache.LoadOrStore(key, client)
+	return actual.(*selection.AutoMixVerifierClient)
+}
+
+// performAutoMixEntailment runs the AutoMix paper-faithful self-verification
+// step (arXiv:2310.12963 §3.2) for one candidate model: it sends the original
+// question and the candidate's answer to an external entailment verifier and
+// returns (confidence, accepted, err). A non-nil err signals an unrecoverable
+// verifier failure; the caller decides how to react via the looper's on_error
+// policy. Missing or malformed configuration is reported as a hard error so it
+// fails loudly at the first request rather than silently degrading.
+func (l *ConfidenceLooper) performAutoMixEntailment(
+	ctx context.Context,
+	req *Request,
+	evaluator *ConfidenceEvaluator,
+	modelName string,
+	responseContent string,
+) (float64, bool, error) {
+	if evaluator.VerifierServerURL == "" {
+		return 0, false, fmt.Errorf("confidence_method=%s requires verifier_server_url", MethodAutoMixEntailment)
+	}
+
+	question := l.extractQuestionFromRequest(req.OriginalRequest)
+	if question == "" {
+		return 0, false, fmt.Errorf("could not extract user question from request")
+	}
+
+	client := getAutoMixVerifierClient(evaluator.VerifierServerURL, evaluator.VerifierTimeoutSeconds)
+
+	logging.ComponentDebugEvent("looper", "automix_entailment_started", map[string]interface{}{
+		"looper":     "confidence",
+		"decision":   req.DecisionName,
+		"model_ref":  modelName,
+		"server_url": evaluator.VerifierServerURL,
+	})
+
+	verifyResp, err := client.Verify(ctx, question, responseContent, "", evaluator.Threshold)
+	if err != nil {
+		return 0, false, fmt.Errorf("verifier call failed: %w", err)
+	}
+
+	accepted := verifyResp.Confidence >= evaluator.Threshold
+	return verifyResp.Confidence, accepted, nil
 }
 
 // formatConfidenceJSONResponse creates response with confidence algorithm type

--- a/src/semantic-router/pkg/looper/confidence_automix_entailment_test.go
+++ b/src/semantic-router/pkg/looper/confidence_automix_entailment_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func newTestLooper() *ConfidenceLooper {
+	return NewConfidenceLooper(&config.LooperConfig{})
+}
+
+func buildAutoMixEntailmentRequest(question string) *Request {
+	params := openai.ChatCompletionNewParams{
+		Model: "auto",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage(question),
+		},
+	}
+	return &Request{
+		OriginalRequest: &params,
+		DecisionName:    "test_decision",
+	}
+}
+
+func newStubVerifierServer(t *testing.T, confidence float64, shouldEscalate bool, verifiedCount, totalSamples int) (*httptest.Server, *int) {
+	t.Helper()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/verify" {
+			http.NotFound(w, r)
+			return
+		}
+		callCount++
+		body := map[string]interface{}{
+			"confidence":      confidence,
+			"should_escalate": shouldEscalate,
+			"verified_count":  verifiedCount,
+			"total_samples":   totalSamples,
+			"threshold":       0.7,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	return server, &callCount
+}
+
+func TestPerformAutoMixEntailment_AcceptedAtThreshold(t *testing.T) {
+	server, callCount := newStubVerifierServer(t, 0.85, false, 5, 5)
+	defer server.Close()
+	t.Cleanup(automixVerifierCacheReset)
+
+	looper := newTestLooper()
+	evaluator := &ConfidenceEvaluator{
+		Method:            MethodAutoMixEntailment,
+		Threshold:         0.7,
+		VerifierServerURL: server.URL,
+	}
+	req := buildAutoMixEntailmentRequest("What is 2+2?")
+
+	conf, accepted, err := looper.performAutoMixEntailment(context.Background(), req, evaluator, "small-model", "4")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !accepted {
+		t.Errorf("expected accepted=true (confidence=0.85 >= threshold=0.7), got false")
+	}
+	if conf < 0.84 || conf > 0.86 {
+		t.Errorf("expected confidence ~0.85, got %v", conf)
+	}
+	if *callCount != 1 {
+		t.Errorf("expected 1 verifier call, got %d", *callCount)
+	}
+}
+
+func TestPerformAutoMixEntailment_RejectedBelowThreshold(t *testing.T) {
+	server, _ := newStubVerifierServer(t, 0.4, true, 2, 5)
+	defer server.Close()
+	t.Cleanup(automixVerifierCacheReset)
+
+	looper := newTestLooper()
+	evaluator := &ConfidenceEvaluator{
+		Method:            MethodAutoMixEntailment,
+		Threshold:         0.7,
+		VerifierServerURL: server.URL,
+	}
+	req := buildAutoMixEntailmentRequest("What is the capital of France?")
+
+	conf, accepted, err := looper.performAutoMixEntailment(context.Background(), req, evaluator, "small-model", "Madrid")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if accepted {
+		t.Errorf("expected accepted=false (confidence=0.4 < threshold=0.7), got true")
+	}
+	if conf > 0.5 {
+		t.Errorf("expected low confidence, got %v", conf)
+	}
+}
+
+func TestPerformAutoMixEntailment_MissingVerifierURL(t *testing.T) {
+	t.Cleanup(automixVerifierCacheReset)
+	looper := newTestLooper()
+	evaluator := &ConfidenceEvaluator{
+		Method:    MethodAutoMixEntailment,
+		Threshold: 0.7,
+	}
+	req := buildAutoMixEntailmentRequest("anything")
+
+	_, _, err := looper.performAutoMixEntailment(context.Background(), req, evaluator, "small-model", "answer")
+	if err == nil {
+		t.Fatal("expected error when verifier_server_url is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "verifier_server_url") {
+		t.Errorf("expected error mentioning verifier_server_url, got: %v", err)
+	}
+}
+
+func TestPerformAutoMixEntailment_VerifierUnreachable(t *testing.T) {
+	t.Cleanup(automixVerifierCacheReset)
+	looper := newTestLooper()
+	evaluator := &ConfidenceEvaluator{
+		Method:                 MethodAutoMixEntailment,
+		Threshold:              0.7,
+		VerifierServerURL:      "http://127.0.0.1:1",
+		VerifierTimeoutSeconds: 1,
+	}
+	req := buildAutoMixEntailmentRequest("anything")
+
+	_, accepted, err := looper.performAutoMixEntailment(context.Background(), req, evaluator, "small-model", "answer")
+	if err == nil {
+		t.Fatal("expected error from unreachable verifier, got nil")
+	}
+	if accepted {
+		t.Error("expected accepted=false on verifier failure")
+	}
+}
+
+func TestPerformAutoMixEntailment_ClientCachedPerURL(t *testing.T) {
+	server, _ := newStubVerifierServer(t, 0.9, false, 5, 5)
+	defer server.Close()
+	t.Cleanup(automixVerifierCacheReset)
+
+	c1 := getAutoMixVerifierClient(server.URL, 0)
+	c2 := getAutoMixVerifierClient(server.URL, 0)
+	if c1 != c2 {
+		t.Error("expected getAutoMixVerifierClient to return the same client for repeated (url, timeout) tuples")
+	}
+
+	c3 := getAutoMixVerifierClient(server.URL, 30)
+	if c3 == c1 {
+		t.Error("expected a distinct client when timeout differs")
+	}
+}
+
+func automixVerifierCacheReset() {
+	automixVerifierCache.Range(func(k, _ interface{}) bool {
+		automixVerifierCache.Delete(k)
+		return true
+	})
+}

--- a/src/semantic-router/pkg/looper/confidence_test.go
+++ b/src/semantic-router/pkg/looper/confidence_test.go
@@ -74,11 +74,13 @@ func TestConfidenceEvaluator_Creation(t *testing.T) {
 		method       string
 		wantLogprobs bool
 		wantSelfVer  bool
+		wantAutoMix  bool
 	}{
-		{"avg_logprob", "avg_logprob", true, false},
-		{"margin", "margin", true, false},
-		{"hybrid", "hybrid", true, false},
-		{"self_verify", "self_verify", false, true},
+		{"avg_logprob", "avg_logprob", true, false, false},
+		{"margin", "margin", true, false, false},
+		{"hybrid", "hybrid", true, false, false},
+		{"self_verify", "self_verify", false, true, false},
+		{"automix_entailment", MethodAutoMixEntailment, false, false, true},
 	}
 
 	for _, tt := range tests {
@@ -94,6 +96,10 @@ func TestConfidenceEvaluator_Creation(t *testing.T) {
 
 			if eval.IsSelfVerify() != tt.wantSelfVer {
 				t.Errorf("IsSelfVerify() = %v, want %v", eval.IsSelfVerify(), tt.wantSelfVer)
+			}
+
+			if eval.IsAutoMixEntailment() != tt.wantAutoMix {
+				t.Errorf("IsAutoMixEntailment() = %v, want %v", eval.IsAutoMixEntailment(), tt.wantAutoMix)
 			}
 		})
 	}

--- a/src/semantic-router/pkg/selection/router_r1_client.go
+++ b/src/semantic-router/pkg/selection/router_r1_client.go
@@ -137,6 +137,16 @@ func NewAutoMixVerifierClient(serverURL string) *AutoMixVerifierClient {
 	}
 }
 
+// SetTimeout overrides the verifier HTTP client timeout. Useful for callers
+// that load timeout values from configuration after client construction.
+// Non-positive durations are ignored.
+func (c *AutoMixVerifierClient) SetTimeout(timeout time.Duration) {
+	if timeout <= 0 {
+		return
+	}
+	c.httpClient.Timeout = timeout
+}
+
 // Verify sends a question/answer pair for verification
 func (c *AutoMixVerifierClient) Verify(ctx context.Context, question, answer, optionalContext string, threshold float64) (*AutoMixVerifyResponse, error) {
 	reqBody := map[string]interface{}{

--- a/website/docs/tutorials/algorithm/looper/confidence.md
+++ b/website/docs/tutorials/algorithm/looper/confidence.md
@@ -10,18 +10,20 @@ It aligns to `config/algorithm/looper/confidence.yaml`.
 
 - Supports small-to-large escalation instead of a fixed winner.
 - Makes stopping conditions explicit and configurable.
-- Multiple confidence evaluation methods: `avg_logprob`, `margin`, `hybrid`.
+- Multiple confidence evaluation methods: `avg_logprob`, `margin`, `hybrid`, `self_verify`, `automix_entailment`.
 - Lets one route trade extra latency for higher confidence only when needed.
 
 ## Algorithm Principle
 
-The confidence algorithm evaluates model responses using token-level logprobs:
+The confidence algorithm evaluates model responses using either token-level logprobs or external verification:
 
 1. **Generate**: Call the current model (starting with the smallest).
 2. **Evaluate Confidence**:
    - `avg_logprob`: Average log probability across all output tokens. Higher (closer to 0) = more confident.
    - `margin`: Average margin between top-1 and top-2 logprobs per token. Higher = more confident.
    - `hybrid`: Weighted combination of both methods.
+   - `self_verify`: Prompt the same model to grade its own answer (returns a JSON `{confidence, reason}`).
+   - `automix_entailment`: Delegate verification to an external few-shot entailment server, per arXiv:2310.12963 §3.2. Confidence is `verified_samples / total_samples`.
 3. **Decide**:
    - Confidence >= threshold → return response.
    - Confidence < threshold → escalate to next model.
@@ -65,6 +67,7 @@ Some routes should try cheaper candidates first and only pay for escalation when
 - Confidence thresholds may need tuning per route type.
 - Logprob-based confidence may not always correlate with factual correctness.
 - `hybrid` method requires tuning `hybrid_weights` for optimal performance.
+- `automix_entailment` requires running a separate verification server (see [`automix_verifier.py`](https://github.com/vllm-project/semantic-router/blob/main/src/training/model_selection/rl_model_selection/automix_verifier.py)) and adds one HTTP round-trip per model call.
 
 ## Configuration
 
@@ -72,7 +75,7 @@ Some routes should try cheaper candidates first and only pay for escalation when
 algorithm:
   type: confidence
   confidence:
-    confidence_method: hybrid        # avg_logprob, margin, or hybrid
+    confidence_method: hybrid        # avg_logprob, margin, hybrid, self_verify, automix_entailment
     threshold: 0.72                  # Escalation threshold (method-dependent)
     escalation_order: small_to_large # Escalation direction
     cost_quality_tradeoff: 0.3       # Cost vs quality balance
@@ -81,17 +84,34 @@ algorithm:
     hybrid_weights:
       logprob_weight: 0.5            # Weight for avg_logprob in hybrid
       margin_weight: 0.5             # Weight for margin in hybrid
+    # Required when confidence_method = automix_entailment
+    verifier_server_url: ""          # AutoMix entailment verifier HTTP URL
+    verifier_timeout_seconds: 0      # 0 = default (60s)
 ```
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `confidence_method` | string | `avg_logprob` | Evaluation method: `avg_logprob`, `margin`, or `hybrid` |
-| `threshold` | float | method-dependent | Escalation threshold (negative for logprob, positive for margin) |
+| `confidence_method` | string | `avg_logprob` | Evaluation method: `avg_logprob`, `margin`, `hybrid`, `self_verify`, or `automix_entailment` |
+| `threshold` | float | method-dependent | Escalation threshold (negative for logprob, positive for margin/self_verify/automix_entailment) |
 | `escalation_order` | string | `small_to_large` | Escalation direction |
 | `cost_quality_tradeoff` | float | `0.3` | Cost vs. quality balance (0–1) |
 | `token_filter` | string | — | Token filtering strategy for confidence |
 | `on_error` | string | `skip` | Behavior on model call failure: `skip` or `fail` |
 | `hybrid_weights.logprob_weight` | float | `0.5` | Weight for avg_logprob in hybrid mode |
 | `hybrid_weights.margin_weight` | float | `0.5` | Weight for margin in hybrid mode |
+| `verifier_server_url` | string | — | Required when `confidence_method = automix_entailment`. URL of the AutoMix entailment verifier (see [`automix_verifier.py`](https://github.com/vllm-project/semantic-router/blob/main/src/training/model_selection/rl_model_selection/automix_verifier.py)). |
+| `verifier_timeout_seconds` | int | `60` | HTTP timeout for verifier calls when `confidence_method = automix_entailment`. |
+
+### `self_verify` vs `automix_entailment`
+
+Both implement the AutoMix paper's cascade idea but differ in how the verification signal is produced:
+
+| Aspect | `self_verify` | `automix_entailment` |
+|---|---|---|
+| Verifier | The same generation model | A separate few-shot entailment model on its own HTTP server |
+| Per-request cost | 1 extra prompt to the generation model | 1 HTTP round-trip; `k` sampled completions in the verifier |
+| Faithfulness to arXiv:2310.12963 | Loose (prompt-graded JSON) | Strict (paper §3.2 entailment) |
+| Extra infra | None | Requires running [`automix_verifier.py`](https://github.com/vllm-project/semantic-router/blob/main/src/training/model_selection/rl_model_selection/automix_verifier.py) |
+| When to pick | Single-deployment setups; no extra server | Production routes where verifier model can be smaller/specialized |


### PR DESCRIPTION
Addresses part of #1173 (the AutoMix half; RouterDC contrastive learning is left as a follow-up).

> **Relationship to #1104 (already merged):**
> #1104 landed a `self_verify` confidence method that prompts the **generation model itself** to grade its own answer and parse a `{"confidence": 0.x}` JSON. That is a useful single-deployment heuristic, but it is **not** the AutoMix paper's self-verification cascade — the paper (arXiv:2310.12963 §3.2) specifies a **separate few-shot entailment verifier on k samples**, not a same-model JSON self-grade.
>
> This PR is **complementary, not duplicative**: it adds a second, paper-faithful method (`automix_entailment`) alongside `self_verify`, and wires up the previously-dead `selection.AutoMixVerifierClient` + `src/training/model_selection/rl_model_selection/automix_verifier.py` reference server. `self_verify` is preserved untouched. Issue #1173 explicitly calls out the missing cascade and remains OPEN after #1104.
>
> | | `self_verify` (#1104) | `automix_entailment` (this PR) |
> |---|---|---|
> | Verifier | same generation model, prompted | external entailment server (HTTP) |
> | Paper-faithful to §3.2 | no (prompt grader) | yes (few-shot entailment, k samples) |
> | Config required | none (silent fallback to `0.5`) | `verifier_server_url` (fail-loud) |
> | Wires existing dead code | n/a | `AutoMixVerifierClient` + `automix_verifier.py` |
> | HTTP client reuse | n/a | `sync.Map`-cached per `(url, timeout)` |

## Purpose

- **What:** Adds a new `confidence_method: automix_entailment` to the confidence looper so an existing decision can opt into the AutoMix paper's self-verification cascade (arXiv:2310.12963 §3.2). When this method is selected the looper goes cheapest-model-first, calls an external few-shot entailment verifier (HTTP) for each candidate, accepts when `verified_count / k >= threshold`, and otherwise escalates.
- **Why:** Issue #1173 (P0, help-wanted) explicitly says *"For AutoMix, pre selection is done, but no self-verification cascade to large model."* That is still accurate even after #1104: `AutoMixSelector` does POMDP-driven pre-selection and is production-wired, but its paper-faithful cascade methods (`InitializeCascade`, `ContinueCascade`, `VerifyAnswer`) have no production caller. The `self_verify` method added by #1104 is a prompt-based same-model self-grader, not the paper's few-shot entailment method. The Python verifier server (`src/training/model_selection/rl_model_selection/automix_verifier.py`) and its Go client (`selection.AutoMixVerifierClient`) already existed but were dead code. This PR wires them into the production request path.
- **Module(s):** `Router` (pkg/looper, pkg/selection, pkg/config), `Docs`.

## Design notes

- Plumb verification through the **looper**, not the selector, because the looper already owns the per-candidate cascade loop. Doing it inside `AutoMixSelector` would require new cross-request state for extproc — much larger scope, and orthogonal to issue #1173 as worded.
- Keep `self_verify` (from #1104) untouched. It is a useful single-deployment fallback when no separate verifier service is available. The new method is opt-in.
- **Default behavior is unchanged.** Existing configs without `confidence_method: automix_entailment` are not affected; the new YAML fields (`verifier_server_url`, `verifier_timeout_seconds`) default to empty/zero and are only consulted when the method is selected.
- Fail-loud on misconfiguration: an empty `verifier_server_url` under `automix_entailment` returns an explicit error rather than silently degrading to a neutral score, so deployment mistakes surface on the first request.
- HTTP-client reuse via `sync.Map` keyed by `(url, timeout_seconds)` so repeated requests share one `*http.Client` (and its connection pool) instead of reconstructing one per evaluation.

## Test Plan

1. `go vet` and `gofmt` on changed packages (`pkg/config`, `pkg/looper`, `pkg/selection`).
2. `yamllint` on `config/config.yaml`.
3. `go test` on every `pkg/...` under `src/semantic-router` (the `test-semantic-router` target equivalent, minus `cmd/...` which requires a freshly built Rust binding chain).
4. Targeted unit tests for the new path (added in this PR):
   - `TestPerformAutoMixEntailment_AcceptedAtThreshold` — `httptest` stub returns `confidence=0.85`, threshold `0.7`, expect accepted.
   - `TestPerformAutoMixEntailment_RejectedBelowThreshold` — stub returns `0.4`, expect not accepted (escalation path).
   - `TestPerformAutoMixEntailment_MissingVerifierURL` — empty `verifier_server_url` must produce a loud error (not a silent fallback).
   - `TestPerformAutoMixEntailment_VerifierUnreachable` — unreachable URL produces an error; `accepted=false`.
   - `TestPerformAutoMixEntailment_ClientCachedPerURL` — confirms the `sync.Map` HTTP-client cache reuses one `*http.Client` per `(URL, timeout)` tuple.
5. Extended `TestConfidenceEvaluator_Creation` to cover the new method.

## Follow-ups (out of scope for this PR)

- RouterDC contrastive learning half of #1173.
- Optionally move the cascade into `AutoMixSelector` itself once extproc gains cross-request state.
