### PR TITLE
[Router][Docs] add multi_factor selector composing quality/latency/cost/load (closes #37)

### DIFF
--- a/config/algorithm/selection/multi-factor.yaml
+++ b/config/algorithm/selection/multi-factor.yaml
@@ -1,0 +1,15 @@
+algorithm:
+  type: multi_factor
+  multi_factor:
+    weights:
+      quality: 0.4
+      latency: 0.2
+      cost: 0.2
+      load: 0.2
+    slo:
+      max_tpot_ms: 200
+      max_ttft_ms: 800
+      max_cost_per_1m: 5.0
+      max_inflight: 50
+    latency_percentile: 95
+    on_no_candidates: cheapest

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1042,6 +1042,35 @@ routing:
                 top_k: ${top_k}
               timeout_seconds: 20
 
+    # multi_factor example: composes quality/latency/cost/load into one
+    # weighted score with optional SLO ceilings. Issue #37.
+    - name: multi_factor_route
+      description: Compose quality, latency, cost, and load signals into a single weighted score.
+      priority: 124
+      rules:
+        operator: AND
+        conditions:
+          - type: domain
+            name: other
+      modelRefs:
+        - model: qwen3-8b
+        - model: qwen3-32b
+      algorithm:
+        type: multi_factor
+        multi_factor:
+          weights:
+            quality: 0.4
+            latency: 0.2
+            cost: 0.2
+            load: 0.2
+          slo:
+            max_tpot_ms: 200
+            max_ttft_ms: 800
+            max_cost_per_1m: 5.0
+            max_inflight: 50
+          latency_percentile: 95
+          on_no_candidates: cheapest
+
     - name: fallback_knn_route
       description: KNN fallback route for general traffic with OpenAI vector-store RAG.
       priority: 120

--- a/src/semantic-router/pkg/config/decision_config.go
+++ b/src/semantic-router/pkg/config/decision_config.go
@@ -69,6 +69,7 @@ type AlgorithmConfig struct {
 	RLDriven     *RLDrivenSelectionConfig     `yaml:"rl_driven,omitempty"`
 	GMTRouter    *GMTRouterSelectionConfig    `yaml:"gmtrouter,omitempty"`
 	LatencyAware *LatencyAwareAlgorithmConfig `yaml:"latency_aware,omitempty"`
+	MultiFactor  *MultiFactorSelectionConfig  `yaml:"multi_factor,omitempty"`
 	OnError      string                       `yaml:"on_error,omitempty"`
 }
 

--- a/src/semantic-router/pkg/config/docs_contract_algorithm_plugin_test.go
+++ b/src/semantic-router/pkg/config/docs_contract_algorithm_plugin_test.go
@@ -18,6 +18,7 @@ var algorithmTutorialBuckets = map[string]string{
 	"knn":           "selection",
 	"latency-aware": "selection",
 	"mlp":           "selection",
+	"multi-factor":  "selection",
 	"ratings":       "looper",
 	"remom":         "looper",
 	"rl-driven":     "selection",

--- a/src/semantic-router/pkg/config/fragment_catalog_test.go
+++ b/src/semantic-router/pkg/config/fragment_catalog_test.go
@@ -35,6 +35,7 @@ func TestConfigFragmentCatalogCoversSupportedRoutingSurfaces(t *testing.T) {
 		"knn":           filepath.Join("selection", "knn.yaml"),
 		"latency_aware": filepath.Join("selection", "latency-aware.yaml"),
 		"mlp":           filepath.Join("selection", "mlp.yaml"),
+		"multi_factor":  filepath.Join("selection", "multi-factor.yaml"),
 		"ratings":       filepath.Join("looper", "ratings.yaml"),
 		"remom":         filepath.Join("looper", "remom.yaml"),
 		"rl_driven":     filepath.Join("selection", "rl-driven.yaml"),

--- a/src/semantic-router/pkg/config/routing_surface_catalog.go
+++ b/src/semantic-router/pkg/config/routing_surface_catalog.go
@@ -71,6 +71,7 @@ var decisionAlgorithmCatalog = []AlgorithmCatalogEntry{
 	{Type: "knn", Tier: "experimental"},
 	{Type: "latency_aware", Tier: "supported"},
 	{Type: "mlp", Tier: "experimental"},
+	{Type: "multi_factor", Tier: "supported"},
 	{Type: "ratings", Tier: "supported"},
 	{Type: "remom", Tier: "supported"},
 	{Type: "rl_driven", Tier: "experimental"},

--- a/src/semantic-router/pkg/config/selection_config.go
+++ b/src/semantic-router/pkg/config/selection_config.go
@@ -186,6 +186,41 @@ type HybridSelectionConfig struct {
 	NormalizeScores     bool    `yaml:"normalize_scores,omitempty"`
 }
 
+// MultiFactorSelectionConfig configures the multi_factor selector, which
+// composes raw quality/latency/cost/load signals into a weighted score per
+// candidate model. See issue #37.
+type MultiFactorSelectionConfig struct {
+	Weights *MultiFactorWeightsConfig `yaml:"weights,omitempty"`
+	SLO     *MultiFactorSLOConfig     `yaml:"slo,omitempty"`
+
+	// LatencyPercentile selects which percentile (e.g. 95) is read from
+	// pkg/latency when computing the latency signal. Defaults to 95.
+	LatencyPercentile int `yaml:"latency_percentile,omitempty"`
+
+	// OnNoCandidates controls behavior when SLO filtering removes every
+	// candidate. Valid values: "cheapest" (default), "first", "fail".
+	OnNoCandidates string `yaml:"on_no_candidates,omitempty"`
+}
+
+// MultiFactorWeightsConfig holds per-signal weights for the multi_factor
+// scoring formula score = w_q*quality + w_l*latency + w_c*cost + w_L*load.
+// Weights are normalized to sum to 1 if they do not. All four default to 0.25.
+type MultiFactorWeightsConfig struct {
+	Quality float64 `yaml:"quality,omitempty"`
+	Latency float64 `yaml:"latency,omitempty"`
+	Cost    float64 `yaml:"cost,omitempty"`
+	Load    float64 `yaml:"load,omitempty"`
+}
+
+// MultiFactorSLOConfig sets hard ceilings that prune candidates before
+// scoring. A zero value means "no ceiling" for that dimension.
+type MultiFactorSLOConfig struct {
+	MaxTPOTMs    float64 `yaml:"max_tpot_ms,omitempty"`
+	MaxTTFTMs    float64 `yaml:"max_ttft_ms,omitempty"`
+	MaxCostPer1M float64 `yaml:"max_cost_per_1m,omitempty"`
+	MaxInflight  int     `yaml:"max_inflight,omitempty"`
+}
+
 // RLDrivenSelectionConfig configures Router-R1 style reinforcement-learning-based routing.
 type RLDrivenSelectionConfig struct {
 	ExplorationRate       float64 `yaml:"exploration_rate,omitempty"`

--- a/src/semantic-router/pkg/config/validator_decision.go
+++ b/src/semantic-router/pkg/config/validator_decision.go
@@ -211,6 +211,7 @@ func validateDecisionAlgorithmConfig(decisionName string, algorithm *AlgorithmCo
 	addBlock("rl_driven", algorithm.RLDriven != nil)
 	addBlock("gmtrouter", algorithm.GMTRouter != nil)
 	addBlock("latency_aware", algorithm.LatencyAware != nil)
+	addBlock("multi_factor", algorithm.MultiFactor != nil)
 
 	if len(configuredBlocks) > 1 {
 		return fmt.Errorf(
@@ -232,6 +233,7 @@ func validateDecisionAlgorithmConfig(decisionName string, algorithm *AlgorithmCo
 		"rl_driven":     "rl_driven",
 		"gmtrouter":     "gmtrouter",
 		"latency_aware": "latency_aware",
+		"multi_factor":  "multi_factor",
 	}
 
 	expectedBlock, hasExpectedBlock := expectedBlockByType[normalizedType]

--- a/src/semantic-router/pkg/extproc/processor_core.go
+++ b/src/semantic-router/pkg/extproc/processor_core.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/inflight"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
@@ -87,6 +88,10 @@ func (r *OpenAIRouter) handleProcessReceiveError(ctx *RequestContext, err error)
 	if ctx.IsStreamingResponse && !ctx.StreamingComplete {
 		ctx.StreamingAborted = true
 		logging.Debugf("Streaming response aborted before completion, will not cache")
+	}
+	if ctx.InflightToken != 0 {
+		inflight.End(ctx.RequestModel, ctx.InflightToken)
+		ctx.InflightToken = 0
 	}
 
 	if errors.Is(err, io.EOF) {

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/inflight"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
@@ -112,15 +113,22 @@ func (r *OpenAIRouter) runRequestPreRoutingStages(
 	}
 
 	metrics.RecordModelRequest(selectedModel)
+	ctx.InflightToken = inflight.Begin(selectedModel)
 	if resp := r.handleFastResponse(ctx, decisionName); resp != nil {
+		inflight.End(selectedModel, ctx.InflightToken)
+		ctx.InflightToken = 0
 		r.startRouterReplay(ctx, originalModel, selectedModel, decisionName)
 		r.updateRouterReplayStatus(ctx, 200, false)
 		return requestDecisionState{}, resp
 	}
 	if resp := r.applyRateLimitAndCacheChecks(ctx, selectedModel, decisionName); resp != nil {
+		inflight.End(selectedModel, ctx.InflightToken)
+		ctx.InflightToken = 0
 		return requestDecisionState{}, resp
 	}
 	if ragErr := r.executeRAGPlugin(ctx, decisionName); ragErr != nil {
+		inflight.End(selectedModel, ctx.InflightToken)
+		ctx.InflightToken = 0
 		return requestDecisionState{}, r.createErrorResponse(503, fmt.Sprintf("RAG retrieval failed: %v", ragErr))
 	}
 

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
@@ -7,6 +7,7 @@ import (
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/inflight"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/latency"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
@@ -79,6 +80,9 @@ func (r *OpenAIRouter) finalizeStreamingResponse(ctx *RequestContext) {
 			"completion_latency_ms": time.Since(ctx.StartTime).Milliseconds(),
 		})
 	}
+
+	inflight.End(ctx.RequestModel, ctx.InflightToken)
+	ctx.InflightToken = 0
 
 	usage := extractStreamingUsage(ctx)
 	r.reportStreamingUsageMetrics(ctx, usage)

--- a/src/semantic-router/pkg/extproc/processor_res_usage.go
+++ b/src/semantic-router/pkg/extproc/processor_res_usage.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/tidwall/gjson"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/inflight"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/latency"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
@@ -74,6 +75,8 @@ func (r *OpenAIRouter) reportNonStreamingUsage(
 		float64(usage.completionTokens),
 	)
 	metrics.RecordModelCompletionLatency(ctx.RequestModel, completionLatency.Seconds())
+	inflight.End(ctx.RequestModel, ctx.InflightToken)
+	ctx.InflightToken = 0
 
 	if usage.completionTokens > 0 {
 		timePerToken := completionLatency.Seconds() / float64(usage.completionTokens)

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -77,6 +77,12 @@ type RequestContext struct {
 	TTFTRecorded bool
 	TTFTSeconds  float64
 
+	// InflightToken is the handle returned by inflight.Begin when this request
+	// was admitted to the in-flight tracker after model selection. Zero means
+	// the request was never admitted (rejected pre-selection, cache hit, etc.)
+	// and inflight.End on it is a no-op.
+	InflightToken uint64
+
 	// Session-aware transition metadata
 	SessionID           string  // Derived from ConversationID (Response API) or message hash (Chat Completions)
 	TurnIndex           int     // Number of prior turns in this session (0 = first turn)

--- a/src/semantic-router/pkg/inflight/tracker.go
+++ b/src/semantic-router/pkg/inflight/tracker.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package inflight tracks the number of concurrent in-flight chat completion
+// requests per model. It is the data source for load-aware selection (e.g.
+// the multi_factor selector). The tracker is self-healing: each Begin call
+// records a start timestamp, and any entries older than DefaultMaxAge are
+// considered abandoned and dropped from the count. This means a missed End
+// (panic, lost stream, etc.) self-corrects after at most DefaultMaxAge,
+// rather than leaking forever as a naive counter would.
+//
+// The package mirrors the pkg/latency global-state pattern intentionally so
+// selectors can call simple package-level read functions without threading a
+// tracker handle through SelectionContext.
+package inflight
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultMaxAge bounds how long an inflight entry is trusted before being
+// treated as abandoned. Chosen to comfortably exceed the longest reasonable
+// LLM streaming completion while still recovering from missed End calls in
+// minutes, not days. Configurable via SetMaxAge.
+const DefaultMaxAge = 10 * time.Minute
+
+type entry struct {
+	id    uint64
+	start time.Time
+}
+
+type modelState struct {
+	nextID  uint64
+	entries map[uint64]entry
+}
+
+var (
+	mu     sync.RWMutex
+	states = map[string]*modelState{}
+	maxAge = DefaultMaxAge
+)
+
+// SetMaxAge overrides DefaultMaxAge for the global tracker. Non-positive
+// values are ignored. Exposed primarily for tests; production callers should
+// rely on the default.
+func SetMaxAge(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	maxAge = d
+}
+
+// Begin records the start of an in-flight request for model and returns a
+// token that must be passed to End to clear the entry. An empty model name
+// is ignored and the returned token will be a no-op when passed to End.
+func Begin(model string) uint64 {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return 0
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	st, ok := states[model]
+	if !ok {
+		st = &modelState{entries: map[uint64]entry{}}
+		states[model] = st
+	}
+	st.nextID++
+	id := st.nextID
+	st.entries[id] = entry{id: id, start: time.Now()}
+	return id
+}
+
+// End clears the in-flight entry identified by (model, token). Calling End
+// with token == 0 or with a token that no longer exists (already evicted
+// by age or already ended) is a no-op.
+func End(model string, token uint64) {
+	model = strings.TrimSpace(model)
+	if model == "" || token == 0 {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	st, ok := states[model]
+	if !ok {
+		return
+	}
+	delete(st.entries, token)
+	if len(st.entries) == 0 {
+		delete(states, model)
+	}
+}
+
+// Get returns the current in-flight count for model, after evicting any
+// entries older than the configured max age.
+func Get(model string) int {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return 0
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	return evictAndCount(model, time.Now())
+}
+
+// Snapshot returns a copy of in-flight counts across all known models,
+// post-eviction. Useful for the Prometheus gauge mirror.
+func Snapshot() map[string]int {
+	mu.Lock()
+	defer mu.Unlock()
+	now := time.Now()
+	out := make(map[string]int, len(states))
+	for model := range states {
+		c := evictAndCount(model, now)
+		if c > 0 {
+			out[model] = c
+		}
+	}
+	return out
+}
+
+// Reset clears all in-flight state. For tests only.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	states = map[string]*modelState{}
+	maxAge = DefaultMaxAge
+}
+
+// evictAndCount drops abandoned entries for model and returns the remaining
+// count. Caller MUST hold mu (write lock) before calling. May delete the
+// model entry from states if it is empty after eviction.
+func evictAndCount(model string, now time.Time) int {
+	st, ok := states[model]
+	if !ok {
+		return 0
+	}
+	for id, e := range st.entries {
+		if now.Sub(e.start) > maxAge {
+			delete(st.entries, id)
+		}
+	}
+	if len(st.entries) == 0 {
+		delete(states, model)
+		return 0
+	}
+	return len(st.entries)
+}

--- a/src/semantic-router/pkg/inflight/tracker_test.go
+++ b/src/semantic-router/pkg/inflight/tracker_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package inflight
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBeginEndSymmetric(t *testing.T) {
+	Reset()
+	tok := Begin("m1")
+	if tok == 0 {
+		t.Fatal("Begin returned zero token for valid model")
+	}
+	if got := Get("m1"); got != 1 {
+		t.Errorf("after Begin: count = %d, want 1", got)
+	}
+	End("m1", tok)
+	if got := Get("m1"); got != 0 {
+		t.Errorf("after End: count = %d, want 0", got)
+	}
+}
+
+func TestMultipleInflightSameModel(t *testing.T) {
+	Reset()
+	tokens := []uint64{Begin("m1"), Begin("m1"), Begin("m1")}
+	if got := Get("m1"); got != 3 {
+		t.Errorf("3 begins: count = %d, want 3", got)
+	}
+	End("m1", tokens[1])
+	if got := Get("m1"); got != 2 {
+		t.Errorf("after one End: count = %d, want 2", got)
+	}
+	End("m1", tokens[0])
+	End("m1", tokens[2])
+	if got := Get("m1"); got != 0 {
+		t.Errorf("after all Ends: count = %d, want 0", got)
+	}
+}
+
+func TestEmptyModelIgnored(t *testing.T) {
+	Reset()
+	if tok := Begin(""); tok != 0 {
+		t.Errorf("Begin(\"\") = %d, want 0", tok)
+	}
+	if got := Get(""); got != 0 {
+		t.Errorf("Get(\"\") = %d, want 0", got)
+	}
+	End("", 1)
+}
+
+func TestZeroTokenEndIsNoop(t *testing.T) {
+	Reset()
+	tok := Begin("m1")
+	End("m1", 0)
+	if got := Get("m1"); got != 1 {
+		t.Errorf("End with token=0 should be no-op, count = %d, want 1", got)
+	}
+	End("m1", tok)
+	End("m1", tok)
+}
+
+func TestSelfHealingViaMaxAge(t *testing.T) {
+	Reset()
+	SetMaxAge(50 * time.Millisecond)
+	Begin("m1")
+	Begin("m1")
+	if got := Get("m1"); got != 2 {
+		t.Fatalf("initial count = %d, want 2", got)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := Get("m1"); got != 0 {
+		t.Errorf("after maxAge elapsed: count = %d, want 0 (abandoned entries evicted)", got)
+	}
+}
+
+func TestSnapshotPerModel(t *testing.T) {
+	Reset()
+	Begin("m1")
+	Begin("m1")
+	Begin("m2")
+	snap := Snapshot()
+	if snap["m1"] != 2 || snap["m2"] != 1 {
+		t.Errorf("snapshot = %v, want m1=2 m2=1", snap)
+	}
+	if _, ok := snap["m3"]; ok {
+		t.Errorf("snapshot should not contain m3")
+	}
+}
+
+func TestConcurrentBeginEnd(t *testing.T) {
+	Reset()
+	const goroutines = 50
+	const perGoroutine = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				tok := Begin("hot-model")
+				End("hot-model", tok)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := Get("hot-model"); got != 0 {
+		t.Errorf("after symmetric Begin/End from %d goroutines: count = %d, want 0", goroutines, got)
+	}
+}

--- a/src/semantic-router/pkg/observability/metrics/inflight_collector.go
+++ b/src/semantic-router/pkg/observability/metrics/inflight_collector.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/inflight"
+)
+
+// inflightCollector exposes pkg/inflight as the prometheus gauge
+// llm_model_inflight_requests at scrape time. Using a collector rather than a
+// GaugeVec mirrored from inc/dec calls keeps pkg/inflight the single source
+// of truth and avoids drift if a wire-in point panics or is missed.
+type inflightCollector struct {
+	desc *prometheus.Desc
+}
+
+func newInflightCollector() *inflightCollector {
+	return &inflightCollector{
+		desc: prometheus.NewDesc(
+			"llm_model_inflight_requests",
+			"Number of chat completion requests currently in flight per model, source: pkg/inflight",
+			[]string{"model"},
+			nil,
+		),
+	}
+}
+
+func (c *inflightCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *inflightCollector) Collect(ch chan<- prometheus.Metric) {
+	for model, count := range inflight.Snapshot() {
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(count), model)
+	}
+}
+
+func init() {
+	prometheus.MustRegister(newInflightCollector())
+}

--- a/src/semantic-router/pkg/selection/factory.go
+++ b/src/semantic-router/pkg/selection/factory.go
@@ -55,6 +55,10 @@ type ModelSelectionConfig struct {
 	// GMTRouter configuration (used when method is "gmtrouter")
 	// Implements heterogeneous graph learning for personalized routing
 	GMTRouter *GMTRouterConfig `yaml:"gmtrouter,omitempty"`
+
+	// MultiFactor configuration (used when method is "multi_factor")
+	// Implements weighted quality/latency/cost/load composition. Issue #37.
+	MultiFactor *MultiFactorConfig `yaml:"multi_factor,omitempty"`
 }
 
 // DefaultModelSelectionConfig returns the default configuration
@@ -174,6 +178,13 @@ func (f *Factory) Create() Selector {
 
 	case MethodLatencyAware:
 		selector = NewLatencyAwareSelector(nil)
+
+	case MethodMultiFactor:
+		multiFactorSelector := NewMultiFactorSelector(f.cfg.MultiFactor)
+		if f.modelConfig != nil {
+			multiFactorSelector.InitializeFromConfig(f.modelConfig)
+		}
+		selector = multiFactorSelector
 
 	default:
 		// Default to static selector
@@ -321,6 +332,13 @@ func (f *Factory) CreateAll() *Registry {
 	// Create LatencyAware selector
 	latencyAwareSelector := NewLatencyAwareSelector(nil)
 	registry.Register(MethodLatencyAware, latencyAwareSelector)
+
+	// Create MultiFactor selector
+	multiFactorSelector := NewMultiFactorSelector(f.cfg.MultiFactor)
+	if f.modelConfig != nil {
+		multiFactorSelector.InitializeFromConfig(f.modelConfig)
+	}
+	registry.Register(MethodMultiFactor, multiFactorSelector)
 
 	LogRegisteredAlgorithms(registry)
 	logging.ComponentEvent("selection", "selection_factory_initialized", map[string]interface{}{

--- a/src/semantic-router/pkg/selection/multi_factor.go
+++ b/src/semantic-router/pkg/selection/multi_factor.go
@@ -1,0 +1,441 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/inflight"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/latency"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// MultiFactorConfig configures the multi_factor selector that composes raw
+// quality / latency / cost / load signals into a single weighted score per
+// candidate, with optional SLO hard ceilings that prune candidates before
+// scoring. See issue #37.
+type MultiFactorConfig struct {
+	Weights           MultiFactorWeights
+	SLO               MultiFactorSLO
+	LatencyPercentile int
+	OnNoCandidates    string
+}
+
+// MultiFactorWeights are the per-signal weights in the scoring formula
+// score = wQ*quality + wL*latency + wC*cost + wLoad*load.
+// All values default to 0.25 (equal weighting). Negative values are clamped
+// to zero. Weights are normalized to sum to 1 at selector construction.
+type MultiFactorWeights struct {
+	Quality float64
+	Latency float64
+	Cost    float64
+	Load    float64
+}
+
+// MultiFactorSLO sets hard ceilings: any candidate exceeding a non-zero
+// ceiling is removed before scoring. A zero value means "no ceiling".
+type MultiFactorSLO struct {
+	MaxTPOTMs    float64
+	MaxTTFTMs    float64
+	MaxCostPer1M float64
+	MaxInflight  int
+}
+
+// Defaults captured for documentation + tests.
+const (
+	defaultMFLatencyPercentile = 95
+	defaultMFOnNoCandidates    = "cheapest"
+)
+
+// DefaultMultiFactorConfig returns the balanced default (equal weights, no
+// SLOs, p95 latency, "cheapest" fallback).
+func DefaultMultiFactorConfig() *MultiFactorConfig {
+	return &MultiFactorConfig{
+		Weights: MultiFactorWeights{
+			Quality: 0.25,
+			Latency: 0.25,
+			Cost:    0.25,
+			Load:    0.25,
+		},
+		LatencyPercentile: defaultMFLatencyPercentile,
+		OnNoCandidates:    defaultMFOnNoCandidates,
+	}
+}
+
+// MultiFactorSelector implements MethodMultiFactor.
+type MultiFactorSelector struct {
+	config *MultiFactorConfig
+
+	mu          sync.RWMutex
+	modelParams map[string]config.ModelParams
+
+	// Injectable for tests; production points at the real package globals.
+	getInflight func(model string) int
+	getTPOT     func(model string, percentile int) (float64, bool)
+	getTTFT     func(model string, percentile int) (float64, bool)
+}
+
+// NewMultiFactorSelector builds a selector with the given config and the
+// production signal sources. Weights are clamped non-negative and normalized
+// to sum to 1.
+func NewMultiFactorSelector(cfg *MultiFactorConfig) *MultiFactorSelector {
+	if cfg == nil {
+		cfg = DefaultMultiFactorConfig()
+	}
+	normalizeWeights(&cfg.Weights)
+	if cfg.LatencyPercentile <= 0 || cfg.LatencyPercentile > 100 {
+		cfg.LatencyPercentile = defaultMFLatencyPercentile
+	}
+	if cfg.OnNoCandidates == "" {
+		cfg.OnNoCandidates = defaultMFOnNoCandidates
+	}
+	return &MultiFactorSelector{
+		config:      cfg,
+		modelParams: make(map[string]config.ModelParams),
+		getInflight: inflight.Get,
+		getTPOT:     latency.GetTPOTPercentile,
+		getTTFT:     latency.GetTTFTPercentile,
+	}
+}
+
+// Method returns MethodMultiFactor.
+func (s *MultiFactorSelector) Method() SelectionMethod {
+	return MethodMultiFactor
+}
+
+// InitializeFromConfig captures per-model quality + pricing for use by Select.
+func (s *MultiFactorSelector) InitializeFromConfig(modelConfig map[string]config.ModelParams) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.modelParams = make(map[string]config.ModelParams, len(modelConfig))
+	for k, v := range modelConfig {
+		s.modelParams[k] = v
+	}
+}
+
+// UpdateFeedback is a no-op: multi_factor uses live signals only.
+func (s *MultiFactorSelector) UpdateFeedback(_ context.Context, _ *Feedback) error {
+	return nil
+}
+
+// Select runs the SLO filter, then the weighted multi-signal scoring.
+func (s *MultiFactorSelector) Select(_ context.Context, selCtx *SelectionContext) (*SelectionResult, error) {
+	if len(selCtx.CandidateModels) == 0 {
+		return nil, fmt.Errorf("no candidate models provided")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	kept, dropped := s.applySLOFilter(selCtx.CandidateModels)
+	if len(kept) == 0 {
+		return s.applyNoCandidateFallback(selCtx, dropped)
+	}
+
+	signals := s.gatherSignals(kept)
+	mins, maxs := signalExtrema(signals)
+	allScores := make(map[string]float64, len(kept))
+
+	var bestIdx int
+	bestScore := math.Inf(-1)
+	secondBest := math.Inf(-1)
+	for i, sig := range signals {
+		score := s.scoreCandidate(sig, mins, maxs)
+		allScores[sig.model] = score
+		if score > bestScore {
+			secondBest = bestScore
+			bestScore = score
+			bestIdx = i
+		} else if score > secondBest {
+			secondBest = score
+		}
+	}
+
+	chosen := kept[bestIdx]
+	confidence := 0.5
+	if !math.IsInf(secondBest, -1) && bestScore > 0 {
+		gap := bestScore - secondBest
+		if gap < 0 {
+			gap = 0
+		}
+		confidence = math.Min(1.0, gap/bestScore+0.5)
+	} else if len(kept) == 1 {
+		confidence = 1.0
+	}
+
+	reasoning := fmt.Sprintf(
+		"multi_factor: weights{q=%.2f l=%.2f c=%.2f L=%.2f} latency_p%d, kept=%d, dropped=%d",
+		s.config.Weights.Quality, s.config.Weights.Latency,
+		s.config.Weights.Cost, s.config.Weights.Load,
+		s.config.LatencyPercentile, len(kept), len(dropped),
+	)
+
+	logging.Infof("[MultiFactor] candidates=%d -> %s (score=%.4f confidence=%.2f, dropped_by_slo=%d)",
+		len(selCtx.CandidateModels), chosen.Model, bestScore, confidence, len(dropped))
+
+	return &SelectionResult{
+		SelectedModel: chosen.Model,
+		LoRAName:      chosen.LoRAName,
+		Score:         bestScore,
+		Confidence:    confidence,
+		Method:        MethodMultiFactor,
+		Tier:          TierSupported,
+		Reasoning:     reasoning,
+		AllScores:     allScores,
+	}, nil
+}
+
+type signalSet struct {
+	model   string
+	quality float64
+	hasQ    bool
+	latency float64
+	hasLat  bool
+	cost    float64
+	hasCost bool
+	load    float64
+}
+
+func (s *MultiFactorSelector) gatherSignals(candidates []config.ModelRef) []signalSet {
+	out := make([]signalSet, 0, len(candidates))
+	for _, c := range candidates {
+		sig := signalSet{model: c.Model}
+		if params, ok := s.modelParams[c.Model]; ok {
+			if params.QualityScore > 0 {
+				sig.quality = params.QualityScore
+				sig.hasQ = true
+			}
+			if params.Pricing.PromptPer1M > 0 {
+				sig.cost = params.Pricing.PromptPer1M
+				sig.hasCost = true
+			}
+		}
+		if v, ok := s.latencySignal(c.Model); ok {
+			sig.latency = v
+			sig.hasLat = true
+		}
+		sig.load = float64(s.getInflight(c.Model))
+		out = append(out, sig)
+	}
+	return out
+}
+
+// latencySignal returns a single representative latency (TPOT-prioritized) at
+// the configured percentile. Returns ok=false when no observations exist.
+func (s *MultiFactorSelector) latencySignal(model string) (float64, bool) {
+	if v, ok := s.getTPOT(model, s.config.LatencyPercentile); ok {
+		return v, true
+	}
+	if v, ok := s.getTTFT(model, s.config.LatencyPercentile); ok {
+		return v, true
+	}
+	return 0, false
+}
+
+func (s *MultiFactorSelector) applySLOFilter(candidates []config.ModelRef) (kept, dropped []config.ModelRef) {
+	for _, c := range candidates {
+		if reason, drop := s.exceedsSLO(c.Model); drop {
+			logging.Debugf("[MultiFactor] dropping %s by SLO: %s", c.Model, reason)
+			dropped = append(dropped, c)
+			continue
+		}
+		kept = append(kept, c)
+	}
+	return kept, dropped
+}
+
+func (s *MultiFactorSelector) exceedsSLO(model string) (string, bool) {
+	slo := s.config.SLO
+
+	if slo.MaxTPOTMs > 0 {
+		if v, ok := s.getTPOT(model, s.config.LatencyPercentile); ok && v*1000 > slo.MaxTPOTMs {
+			return fmt.Sprintf("tpot_p%d=%.1fms>%.1fms", s.config.LatencyPercentile, v*1000, slo.MaxTPOTMs), true
+		}
+	}
+	if slo.MaxTTFTMs > 0 {
+		if v, ok := s.getTTFT(model, s.config.LatencyPercentile); ok && v*1000 > slo.MaxTTFTMs {
+			return fmt.Sprintf("ttft_p%d=%.1fms>%.1fms", s.config.LatencyPercentile, v*1000, slo.MaxTTFTMs), true
+		}
+	}
+	if slo.MaxCostPer1M > 0 {
+		if params, ok := s.modelParams[model]; ok && params.Pricing.PromptPer1M > slo.MaxCostPer1M {
+			return fmt.Sprintf("cost=$%.2f>$%.2f per 1M", params.Pricing.PromptPer1M, slo.MaxCostPer1M), true
+		}
+	}
+	if slo.MaxInflight > 0 {
+		if got := s.getInflight(model); got > slo.MaxInflight {
+			return fmt.Sprintf("inflight=%d>%d", got, slo.MaxInflight), true
+		}
+	}
+	return "", false
+}
+
+func (s *MultiFactorSelector) applyNoCandidateFallback(selCtx *SelectionContext, dropped []config.ModelRef) (*SelectionResult, error) {
+	switch strings.ToLower(s.config.OnNoCandidates) {
+	case "fail":
+		return nil, fmt.Errorf("multi_factor: all %d candidates excluded by SLO", len(dropped))
+	case "first":
+		c := selCtx.CandidateModels[0]
+		return s.fallbackResult(c, "all_candidates_excluded_by_slo:first"), nil
+	default:
+		c := s.cheapestCandidate(selCtx.CandidateModels)
+		return s.fallbackResult(c, "all_candidates_excluded_by_slo:cheapest"), nil
+	}
+}
+
+func (s *MultiFactorSelector) cheapestCandidate(candidates []config.ModelRef) config.ModelRef {
+	best := candidates[0]
+	bestCost := math.Inf(1)
+	for _, c := range candidates {
+		cost := math.Inf(1)
+		if params, ok := s.modelParams[c.Model]; ok && params.Pricing.PromptPer1M > 0 {
+			cost = params.Pricing.PromptPer1M
+		}
+		if cost < bestCost {
+			bestCost = cost
+			best = c
+		}
+	}
+	return best
+}
+
+func (s *MultiFactorSelector) fallbackResult(c config.ModelRef, reason string) *SelectionResult {
+	return &SelectionResult{
+		SelectedModel: c.Model,
+		LoRAName:      c.LoRAName,
+		Score:         0,
+		Confidence:    0.0,
+		Method:        MethodMultiFactor,
+		Tier:          TierSupported,
+		Reasoning:     "multi_factor fallback: " + reason,
+	}
+}
+
+type extrema struct {
+	quality, latency, cost, load float64
+	hasQ, hasLat, hasCost        bool
+}
+
+func signalExtrema(signals []signalSet) (mins, maxs extrema) {
+	mins = extrema{quality: math.Inf(1), latency: math.Inf(1), cost: math.Inf(1), load: math.Inf(1)}
+	maxs = extrema{quality: math.Inf(-1), latency: math.Inf(-1), cost: math.Inf(-1), load: math.Inf(-1)}
+	for _, s := range signals {
+		updateOptionalExtrema(&mins.quality, &maxs.quality, &mins.hasQ, &maxs.hasQ, s.quality, s.hasQ)
+		updateOptionalExtrema(&mins.latency, &maxs.latency, &mins.hasLat, &maxs.hasLat, s.latency, s.hasLat)
+		updateOptionalExtrema(&mins.cost, &maxs.cost, &mins.hasCost, &maxs.hasCost, s.cost, s.hasCost)
+		updateExtrema(&mins.load, &maxs.load, s.load)
+	}
+	return mins, maxs
+}
+
+// updateExtrema folds value v into mandatory (min, max) accumulators.
+func updateExtrema(min, max *float64, v float64) {
+	if v < *min {
+		*min = v
+	}
+	if v > *max {
+		*max = v
+	}
+}
+
+// updateOptionalExtrema folds value v into (min, max) accumulators only when
+// the signal is present (ok == true), and marks the accumulators as having
+// observed at least one value via the corresponding hasMin / hasMax flags.
+func updateOptionalExtrema(min, max *float64, hasMin, hasMax *bool, v float64, ok bool) {
+	if !ok {
+		return
+	}
+	*hasMin, *hasMax = true, true
+	updateExtrema(min, max, v)
+}
+
+// scoreCandidate computes the weighted score. Each component is normalized to
+// [0, 1] across the surviving candidate set. Latency / cost / load are
+// inverted because lower-is-better; quality is direct.
+func (s *MultiFactorSelector) scoreCandidate(sig signalSet, mins, maxs extrema) float64 {
+	w := s.config.Weights
+	score := 0.0
+
+	if w.Quality > 0 && maxs.hasQ {
+		score += w.Quality * normalizeDirect(sig.quality, mins.quality, maxs.quality, sig.hasQ)
+	}
+	if w.Latency > 0 && maxs.hasLat {
+		score += w.Latency * normalizeInverted(sig.latency, mins.latency, maxs.latency, sig.hasLat)
+	}
+	if w.Cost > 0 && maxs.hasCost {
+		score += w.Cost * normalizeInverted(sig.cost, mins.cost, maxs.cost, sig.hasCost)
+	}
+	if w.Load > 0 {
+		score += w.Load * normalizeInverted(sig.load, mins.load, maxs.load, true)
+	}
+	return score
+}
+
+// normalizeDirect maps [min, max] -> [0, 1] linearly. Missing observation
+// yields 0 so signals without data don't dominate.
+func normalizeDirect(v, min, max float64, ok bool) float64 {
+	if !ok {
+		return 0
+	}
+	if max-min <= 0 {
+		return 0.5
+	}
+	return (v - min) / (max - min)
+}
+
+// normalizeInverted maps [min, max] -> [1, 0] linearly. Used for
+// lower-is-better signals (latency, cost, load).
+func normalizeInverted(v, min, max float64, ok bool) float64 {
+	if !ok {
+		return 0
+	}
+	if max-min <= 0 {
+		return 0.5
+	}
+	return 1.0 - (v-min)/(max-min)
+}
+
+// normalizeWeights clamps negative weights to zero and rescales so the sum is
+// 1. If all weights are zero, sets equal weights as a recoverable default.
+func normalizeWeights(w *MultiFactorWeights) {
+	if w.Quality < 0 {
+		w.Quality = 0
+	}
+	if w.Latency < 0 {
+		w.Latency = 0
+	}
+	if w.Cost < 0 {
+		w.Cost = 0
+	}
+	if w.Load < 0 {
+		w.Load = 0
+	}
+	sum := w.Quality + w.Latency + w.Cost + w.Load
+	if sum <= 0 {
+		w.Quality, w.Latency, w.Cost, w.Load = 0.25, 0.25, 0.25, 0.25
+		return
+	}
+	w.Quality /= sum
+	w.Latency /= sum
+	w.Cost /= sum
+	w.Load /= sum
+}

--- a/src/semantic-router/pkg/selection/multi_factor_test.go
+++ b/src/semantic-router/pkg/selection/multi_factor_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package selection
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func buildMFSelector(cfg *MultiFactorConfig, params map[string]config.ModelParams,
+	inflight func(string) int,
+	tpot func(string, int) (float64, bool),
+	ttft func(string, int) (float64, bool),
+) *MultiFactorSelector {
+	s := NewMultiFactorSelector(cfg)
+	if params != nil {
+		s.InitializeFromConfig(params)
+	}
+	if inflight != nil {
+		s.getInflight = inflight
+	}
+	if tpot != nil {
+		s.getTPOT = tpot
+	}
+	if ttft != nil {
+		s.getTTFT = ttft
+	}
+	return s
+}
+
+func candidates(names ...string) []config.ModelRef {
+	out := make([]config.ModelRef, 0, len(names))
+	for _, n := range names {
+		out = append(out, config.ModelRef{Model: n})
+	}
+	return out
+}
+
+func TestMultiFactor_PicksHighestQualityWhenQualityDominant(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.Weights = MultiFactorWeights{Quality: 1.0}
+	params := map[string]config.ModelParams{
+		"a": {QualityScore: 0.5},
+		"b": {QualityScore: 0.9},
+		"c": {QualityScore: 0.3},
+	}
+	s := buildMFSelector(cfg, params,
+		func(string) int { return 0 },
+		func(string, int) (float64, bool) { return 0, false },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	res, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("a", "b", "c")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SelectedModel != "b" {
+		t.Errorf("expected b (highest quality), got %s; scores=%v", res.SelectedModel, res.AllScores)
+	}
+}
+
+func TestMultiFactor_PicksCheapestWhenCostDominant(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.Weights = MultiFactorWeights{Cost: 1.0}
+	params := map[string]config.ModelParams{
+		"expensive": {Pricing: config.ModelPricing{PromptPer1M: 30.0}},
+		"cheap":     {Pricing: config.ModelPricing{PromptPer1M: 0.5}},
+		"mid":       {Pricing: config.ModelPricing{PromptPer1M: 5.0}},
+	}
+	s := buildMFSelector(cfg, params,
+		func(string) int { return 0 },
+		func(string, int) (float64, bool) { return 0, false },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	res, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("expensive", "cheap", "mid")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SelectedModel != "cheap" {
+		t.Errorf("expected cheap, got %s; scores=%v", res.SelectedModel, res.AllScores)
+	}
+}
+
+func TestMultiFactor_PicksLeastLoadedWhenLoadDominant(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.Weights = MultiFactorWeights{Load: 1.0}
+	loadMap := map[string]int{"a": 100, "b": 5, "c": 50}
+	s := buildMFSelector(cfg, nil,
+		func(m string) int { return loadMap[m] },
+		func(string, int) (float64, bool) { return 0, false },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	res, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("a", "b", "c")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SelectedModel != "b" {
+		t.Errorf("expected b (lowest load=5), got %s; scores=%v", res.SelectedModel, res.AllScores)
+	}
+}
+
+func TestMultiFactor_PicksFastestWhenLatencyDominant(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.Weights = MultiFactorWeights{Latency: 1.0}
+	tpotMap := map[string]float64{"slow": 0.5, "fast": 0.05, "mid": 0.2}
+	s := buildMFSelector(cfg, nil,
+		func(string) int { return 0 },
+		func(m string, _ int) (float64, bool) { v, ok := tpotMap[m]; return v, ok },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	res, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("slow", "fast", "mid")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SelectedModel != "fast" {
+		t.Errorf("expected fast (lowest TPOT), got %s; scores=%v", res.SelectedModel, res.AllScores)
+	}
+}
+
+func TestMultiFactor_SLOExcludesViolators(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.SLO.MaxTPOTMs = 100
+	cfg.Weights = MultiFactorWeights{Quality: 1.0}
+	params := map[string]config.ModelParams{
+		"slow_high_q": {QualityScore: 0.99},
+		"fast_low_q":  {QualityScore: 0.3},
+	}
+	tpot := map[string]float64{
+		"slow_high_q": 0.5,
+		"fast_low_q":  0.05,
+	}
+	s := buildMFSelector(cfg, params,
+		func(string) int { return 0 },
+		func(m string, _ int) (float64, bool) { v, ok := tpot[m]; return v, ok },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	res, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("slow_high_q", "fast_low_q")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SelectedModel != "fast_low_q" {
+		t.Errorf("SLO should exclude slow_high_q despite higher quality; got %s reasoning=%q",
+			res.SelectedModel, res.Reasoning)
+	}
+	if !strings.Contains(res.Reasoning, "dropped=1") {
+		t.Errorf("reasoning should report dropped=1, got %q", res.Reasoning)
+	}
+}
+
+func TestMultiFactor_FallbackCheapestWhenAllSLOExcluded(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.SLO.MaxTPOTMs = 1
+	cfg.OnNoCandidates = "cheapest"
+	params := map[string]config.ModelParams{
+		"a": {Pricing: config.ModelPricing{PromptPer1M: 5.0}},
+		"b": {Pricing: config.ModelPricing{PromptPer1M: 0.5}},
+	}
+	s := buildMFSelector(cfg, params,
+		func(string) int { return 0 },
+		func(string, int) (float64, bool) { return 0.5, true },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	res, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("a", "b")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SelectedModel != "b" {
+		t.Errorf("expected cheapest fallback to pick b, got %s", res.SelectedModel)
+	}
+	if !strings.Contains(res.Reasoning, "fallback") {
+		t.Errorf("expected fallback marker in reasoning, got %q", res.Reasoning)
+	}
+}
+
+func TestMultiFactor_FallbackFailWhenAllSLOExcluded(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.SLO.MaxTPOTMs = 1
+	cfg.OnNoCandidates = "fail"
+	s := buildMFSelector(cfg, nil,
+		func(string) int { return 0 },
+		func(string, int) (float64, bool) { return 0.5, true },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	_, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("a", "b")})
+	if err == nil {
+		t.Fatal("expected error when on_no_candidates=fail and all candidates excluded")
+	}
+}
+
+func TestMultiFactor_WeightsNormalized(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.Weights = MultiFactorWeights{Quality: 4, Latency: 2, Cost: 2, Load: 2}
+	s := NewMultiFactorSelector(cfg)
+	w := s.config.Weights
+	sum := w.Quality + w.Latency + w.Cost + w.Load
+	if math.Abs(sum-1.0) > 1e-9 {
+		t.Errorf("weights should sum to 1, got %.6f", sum)
+	}
+	if math.Abs(w.Quality-0.4) > 1e-9 {
+		t.Errorf("quality should be 4/10=0.4, got %.6f", w.Quality)
+	}
+}
+
+func TestMultiFactor_AllZeroWeightsResetToEqual(t *testing.T) {
+	cfg := &MultiFactorConfig{Weights: MultiFactorWeights{}}
+	s := NewMultiFactorSelector(cfg)
+	w := s.config.Weights
+	if w.Quality != 0.25 || w.Latency != 0.25 || w.Cost != 0.25 || w.Load != 0.25 {
+		t.Errorf("zero weights should reset to equal 0.25 each, got %+v", w)
+	}
+}
+
+func TestMultiFactor_NegativeWeightClamped(t *testing.T) {
+	cfg := DefaultMultiFactorConfig()
+	cfg.Weights = MultiFactorWeights{Quality: -1, Latency: 1, Cost: 1, Load: 1}
+	s := NewMultiFactorSelector(cfg)
+	if s.config.Weights.Quality != 0 {
+		t.Errorf("negative quality should clamp to 0, got %.4f", s.config.Weights.Quality)
+	}
+}
+
+func TestMultiFactor_NoCandidatesErrors(t *testing.T) {
+	s := NewMultiFactorSelector(DefaultMultiFactorConfig())
+	_, err := s.Select(context.Background(), &SelectionContext{})
+	if err == nil {
+		t.Fatal("expected error on empty candidate list")
+	}
+}
+
+func TestMultiFactor_SingleCandidateReturnedDirectly(t *testing.T) {
+	s := buildMFSelector(DefaultMultiFactorConfig(), nil,
+		func(string) int { return 0 },
+		func(string, int) (float64, bool) { return 0, false },
+		func(string, int) (float64, bool) { return 0, false },
+	)
+	res, err := s.Select(context.Background(), &SelectionContext{CandidateModels: candidates("only")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.SelectedModel != "only" {
+		t.Errorf("expected 'only', got %s", res.SelectedModel)
+	}
+}
+
+func TestMultiFactor_DefaultPercentileNormalized(t *testing.T) {
+	cfg := &MultiFactorConfig{LatencyPercentile: 0}
+	s := NewMultiFactorSelector(cfg)
+	if s.config.LatencyPercentile != defaultMFLatencyPercentile {
+		t.Errorf("zero LatencyPercentile should normalize to %d, got %d",
+			defaultMFLatencyPercentile, s.config.LatencyPercentile)
+	}
+	cfg2 := &MultiFactorConfig{LatencyPercentile: 150}
+	s2 := NewMultiFactorSelector(cfg2)
+	if s2.config.LatencyPercentile != defaultMFLatencyPercentile {
+		t.Errorf("invalid LatencyPercentile=150 should normalize to %d, got %d",
+			defaultMFLatencyPercentile, s2.config.LatencyPercentile)
+	}
+}
+
+func TestMultiFactor_MethodAndTier(t *testing.T) {
+	s := NewMultiFactorSelector(nil)
+	if s.Method() != MethodMultiFactor {
+		t.Errorf("Method() = %q, want %q", s.Method(), MethodMultiFactor)
+	}
+	if s.Tier() != TierSupported {
+		t.Errorf("Tier() = %q, want %q", s.Tier(), TierSupported)
+	}
+	if deps := s.ExternalDependencies(); len(deps) != 0 {
+		t.Errorf("ExternalDependencies() should be empty, got %v", deps)
+	}
+}
+
+func TestMultiFactor_NormalizeMinEqualsMax(t *testing.T) {
+	if got := normalizeDirect(5, 5, 5, true); got != 0.5 {
+		t.Errorf("when min==max, normalizeDirect should be 0.5, got %.4f", got)
+	}
+	if got := normalizeInverted(5, 5, 5, true); got != 0.5 {
+		t.Errorf("when min==max, normalizeInverted should be 0.5, got %.4f", got)
+	}
+}

--- a/src/semantic-router/pkg/selection/selector.go
+++ b/src/semantic-router/pkg/selection/selector.go
@@ -88,6 +88,10 @@ const (
 	// MethodLatencyAware uses TPOT/TTFT percentile data for latency-aware model selection
 	// Selects the fastest model from candidates based on configured latency percentiles
 	MethodLatencyAware SelectionMethod = "latency_aware"
+
+	// MethodMultiFactor combines quality/latency/cost/load signals via a
+	// weighted score with optional SLO ceilings. Issue #37.
+	MethodMultiFactor SelectionMethod = "multi_factor"
 )
 
 // AlgorithmTier classifies algorithms by production readiness

--- a/src/semantic-router/pkg/selection/tier_declarations.go
+++ b/src/semantic-router/pkg/selection/tier_declarations.go
@@ -49,6 +49,16 @@ func (l *LatencyAwareSelector) ExternalDependencies() []Dependency {
 }
 
 // Tier returns the production readiness tier
+func (m *MultiFactorSelector) Tier() AlgorithmTier {
+	return TierSupported
+}
+
+// ExternalDependencies returns external dependencies (none for multi_factor)
+func (m *MultiFactorSelector) ExternalDependencies() []Dependency {
+	return []Dependency{}
+}
+
+// Tier returns the production readiness tier
 func (h *HybridSelector) Tier() AlgorithmTier {
 	return TierSupported
 }

--- a/website/docs/tutorials/algorithm/selection/multi-factor.md
+++ b/website/docs/tutorials/algorithm/selection/multi-factor.md
@@ -1,0 +1,102 @@
+# Multi Factor
+
+## Overview
+
+`multi_factor` is a selection algorithm that composes four raw runtime signals — **quality**, **latency**, **cost**, and **load** — into a single weighted score per candidate, with optional SLO hard ceilings that prune candidates before scoring.
+
+It aligns to `config/algorithm/selection/multi-factor.yaml` and addresses issue [#37](https://github.com/vllm-project/semantic-router/issues/37).
+
+## Key Advantages
+
+- Single-decision SLO-aware routing without orchestrating multiple selectors.
+- Each signal is a live source: quality from `quality_score` config, latency from `pkg/latency` percentiles, cost from pricing, load from `pkg/inflight`.
+- Min-max normalization across the candidate set means weights have intuitive meaning regardless of absolute signal scales.
+- No model state to train. No external service required.
+- Hard SLO ceilings (TPOT, TTFT, cost, in-flight) prune unsafe candidates before scoring.
+
+## What Problem Does It Solve?
+
+Real routes care about more than one dimension at once: a faster cheaper model and a slower better model both exist in the same candidate pool, and the "right" answer depends on current load and SLO targets, not just the static config. Existing single-signal selectors (`latency_aware`, cost-only routing, quality-only routing) force a hard choice. `multi_factor` lets one decision rule express a smooth tradeoff across all four dimensions, with optional hard SLO ceilings to fence off unsafe candidates.
+
+## When to Use
+
+- A decision has 2+ candidate models that differ along multiple dimensions (e.g. a faster cheaper model and a slower better model) and you want a smooth tradeoff knob.
+- You want SLO enforcement (e.g. "never route to a model with p95 TPOT > 200ms") without writing a separate decision rule.
+- Quality, latency, cost, and load all matter and no single one dominates.
+
+## Sibling Algorithms
+
+- `latency_aware` is a special case of this — latency-only scoring. Use it when the other dimensions truly do not matter.
+- `hybrid` composes *other selectors* (Elo + RouterDC + AutoMix) into one. `multi_factor` composes *raw signals* directly. Both are useful and complementary.
+
+## Algorithm Principle
+
+For each candidate model $m$ in the candidate set, after SLO filtering:
+
+$$\text{score}(m) = w_Q \cdot \hat{Q}(m) + w_L \cdot (1 - \hat{T}(m)) + w_C \cdot (1 - \hat{C}(m)) + w_{\text{load}} \cdot (1 - \hat{N}(m))$$
+
+Where:
+
+- $\hat{Q}(m)$, $\hat{T}(m)$, $\hat{C}(m)$, $\hat{N}(m)$ are quality / latency / cost / load values **min-max normalized to [0, 1] across the surviving candidate set**.
+- Latency, cost, and load are inverted (`1 - ...`) because lower-is-better.
+- Quality is direct because higher-is-better.
+- Weights are normalized to sum to 1 (negative weights clamped to zero). Equal weights are the recoverable default.
+
+## SLO Filtering
+
+Before scoring, any candidate that exceeds a non-zero ceiling is removed:
+
+- `max_tpot_ms` — p95 (or configured) TPOT observed via `pkg/latency`
+- `max_ttft_ms` — p95 (or configured) TTFT observed via `pkg/latency`
+- `max_cost_per_1m` — configured prompt pricing
+- `max_inflight` — current in-flight request count from `pkg/inflight`
+
+If all candidates are filtered out, behavior is controlled by `on_no_candidates`:
+
+| Value | Behavior |
+|---|---|
+| `cheapest` (default) | Return the candidate with the lowest configured `prompt_per_1m` |
+| `first` | Return the first candidate as listed |
+| `fail` | Return an error to the caller |
+
+## Configuration
+
+```yaml
+algorithm:
+  type: multi_factor
+  multi_factor:
+    weights:
+      quality: 0.4
+      latency: 0.2
+      cost: 0.2
+      load: 0.2
+    slo:
+      max_tpot_ms: 200       # optional, omit for no ceiling
+      max_ttft_ms: 800       # optional
+      max_cost_per_1m: 5.0   # optional, USD per 1M prompt tokens
+      max_inflight: 50       # optional
+    latency_percentile: 95   # which percentile to read (default 95)
+    on_no_candidates: cheapest
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `weights.quality` | float | `0.25` | Weight for `quality_score` configured per model |
+| `weights.latency` | float | `0.25` | Weight for percentile latency (lower-is-better, inverted) |
+| `weights.cost` | float | `0.25` | Weight for prompt pricing (lower-is-better, inverted) |
+| `weights.load` | float | `0.25` | Weight for in-flight request count (lower-is-better, inverted) |
+| `slo.max_tpot_ms` | float | `0` (off) | Hard ceiling for p95 TPOT in milliseconds |
+| `slo.max_ttft_ms` | float | `0` (off) | Hard ceiling for p95 TTFT in milliseconds |
+| `slo.max_cost_per_1m` | float | `0` (off) | Hard ceiling for prompt cost per 1M tokens |
+| `slo.max_inflight` | int | `0` (off) | Hard ceiling for concurrent in-flight requests |
+| `latency_percentile` | int | `95` | Percentile read from `pkg/latency` (1-100) |
+| `on_no_candidates` | string | `cheapest` | Fallback policy when SLO filters everything: `cheapest`, `first`, `fail` |
+
+## Known Limitations
+
+- Quality scoring depends on `quality_score` being configured per model. Models without it contribute zero to the quality signal.
+- Min-max normalization is **per-request across the candidate set**, so absolute scale of any signal does not matter — but if all candidates have the same value on a dimension, that dimension contributes 0.5 (neutral).
+- Load uses an in-process tracker (`pkg/inflight`), so in multi-replica deployments each replica sees only its own load, not cluster-wide. Acceptable for the typical sidecar deployment; an external state store could be wired later for true cluster-wide load awareness.
+- The in-flight tracker self-heals via TTL eviction (default 10 minutes) to recover from missed `End` calls, but cannot detect actively-running long requests beyond that window — they will appear "free" to the selector. Tune via `pkg/inflight.SetMaxAge` if your workloads routinely exceed 10 minutes per request.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -144,6 +144,7 @@ const sidebars: SidebarsConfig = {
                 'tutorials/algorithm/selection/knn',
                 'tutorials/algorithm/selection/latency-aware',
                 'tutorials/algorithm/selection/mlp',
+                'tutorials/algorithm/selection/multi-factor',
                 'tutorials/algorithm/selection/rl-driven',
                 'tutorials/algorithm/selection/router-dc',
                 'tutorials/algorithm/selection/static',


### PR DESCRIPTION
Closes #37 (\"[v0.1] Multi-factor routing algorithm\", P1, area/research, 0 assignees, 8 months open).

The sibling issue #35 (load-and-latency-aware endpoint resilience) was closed via [PR #1328](https://github.com/vllm-project/semantic-router/pull/1328), whose author explicitly deferred multi-factor composition:

> *\"Per issue discussion, this PR intentionally introduces only \`latency_aware\` (no additional new selection strategies in this scope).\"*

This PR is that follow-up.

## Purpose

- **What:** A new per-decision selection algorithm \`multi_factor\` that composes four live runtime signals — **quality** (\`params.QualityScore\`), **latency** (\`pkg/latency\` percentiles), **cost** (\`params.Pricing.PromptPer1M\`), and **load** (new \`pkg/inflight\`) — into a single weighted score per candidate, after pruning candidates that exceed any non-zero SLO ceiling. Each signal is min-max normalized across the surviving candidate set so weight semantics are scale-invariant.
- **Why:** Real routes care about multiple dimensions simultaneously. Existing single-signal selectors (\`latency_aware\`, cost-only, quality-only) force a hard choice; \`hybrid\` composes *selectors*, not raw signals. \`multi_factor\` lets one decision express a smooth tradeoff across all four dimensions with optional hard SLO ceilings.
- **Module(s):** \`Router\` (pkg/selection, pkg/inflight, pkg/observability/metrics, pkg/extproc, pkg/config), \`Docs\`.

### In-flight tracking

The issue's acceptance criteria mention a \"ModelLoad counter\" that did not exist in the codebase. This PR adds:

- **\`pkg/inflight\`** — a self-healing in-process tracker (\`Begin\` returns a token, \`End\` clears it, \`Get\` reads). TTL eviction (\`DefaultMaxAge = 10m\`) recovers from missed \`End\` calls within minutes rather than leaking forever.
- **Prometheus collector** \`llm_model_inflight_requests\` that reads \`pkg/inflight.Snapshot()\` at scrape time. Using a collector rather than a GaugeVec mirrored from inc/dec calls keeps a single source of truth and avoids drift.

Inc is wired at \`processor_req_body_prepare.go\` right after successful model selection (mirroring \`metrics.RecordModelRequest\`). Dec is wired at every terminal path:

- \`processor_res_usage.go\` (non-streaming completion)
- \`processor_res_body_streaming.go\` (streaming finalize)
- \`processor_core.go handleProcessReceiveError\` (single funnel covering EOF, gRPC errors, timeout, context cancellation, streaming abort)
- Request-rejection paths in \`processor_req_body_prepare.go\` (\`handleFastResponse\` short-circuit, rate-limit reject, RAG error)

### Sibling relationship to existing selectors

| Selector | Composes |
|---|---|
| \`latency_aware\` | Latency only (strict subset of \`multi_factor\`) |
| \`hybrid\` | Other **selectors** (Elo + RouterDC + AutoMix) |
| \`multi_factor\` | Raw **signals** directly |

All three coexist. \`multi_factor\` opts in via explicit \`type: multi_factor\` — default behavior of every other decision is unchanged.

## Test Plan

1. \`go vet\` + \`gofmt\` on every changed file.
2. \`yamllint\` on \`config/config.yaml\` and the new fragment.
3. Full \`go test ./pkg/...\` with the same \`SKIP_*\` env vars as \`make test-semantic-router\` uses for offline runs.
4. 15 targeted unit tests in \`multi_factor_test.go\`:
   - Each-axis dominance: Quality / Cost / Load / Latency-only weighting selects the right candidate.
   - SLO filter excludes violators even when they would otherwise win on quality.
   - Fallback policies: \`cheapest\` returns cheapest, \`fail\` returns error.
   - Weight handling: normalized to sum=1, zero clamped, all-zero resets to equal.
   - Edge cases: no candidates errors, single candidate returned directly, percentile out-of-range normalized.
   - Method/Tier/ExternalDependencies contract.
5. 7 unit tests in \`pkg/inflight\` covering Begin/End symmetry, multiple inflight, empty-model no-op, zero-token no-op, **TTL self-healing**, snapshot, and **concurrent Begin/End** correctness (50 goroutines × 100 ops).
6. Structural reflection tests (\`TestReferenceConfigCoversCanonicalPublicSurface\`, \`TestConfigFragmentCatalogCoversSupportedRoutingSurfaces\`, \`TestLatestTutorialTaxonomyMatchesConfigHierarchy\`) all pass — meaning the new field surface is fully documented in the reference YAML, the algorithm appears in the tutorial taxonomy, and the doc sidebar is updated.

This validation is sufficient because (a) the selector is fully exercised through pure-function unit tests with injectable signal sources — no global state required, (b) the in-flight tracker is exercised under concurrent load to prove correctness, (c) all existing 45 router packages still pass with zero regressions, and (d) the structural reflection tests prove the public YAML surface, doc surface, and config catalog are all internally consistent.

## Test Result

\`\`\`
$ gofmt -l <every changed file>
(no output — clean)

$ go vet ./pkg/...
(no output — clean)

$ yamllint --config-file=tools/linter/yaml/.yamllint config/config.yaml config/algorithm/selection/multi-factor.yaml
(no output — clean)

$ go test ./pkg/selection/ -run TestMultiFactor -v
=== RUN   TestMultiFactor_PicksHighestQualityWhenQualityDominant — PASS
=== RUN   TestMultiFactor_PicksCheapestWhenCostDominant — PASS
=== RUN   TestMultiFactor_PicksLeastLoadedWhenLoadDominant — PASS
=== RUN   TestMultiFactor_PicksFastestWhenLatencyDominant — PASS
=== RUN   TestMultiFactor_SLOExcludesViolators — PASS
=== RUN   TestMultiFactor_FallbackCheapestWhenAllSLOExcluded — PASS
=== RUN   TestMultiFactor_FallbackFailWhenAllSLOExcluded — PASS
=== RUN   TestMultiFactor_WeightsNormalized — PASS
=== RUN   TestMultiFactor_AllZeroWeightsResetToEqual — PASS
=== RUN   TestMultiFactor_NegativeWeightClamped — PASS
=== RUN   TestMultiFactor_NoCandidatesErrors — PASS
=== RUN   TestMultiFactor_SingleCandidateReturnedDirectly — PASS
=== RUN   TestMultiFactor_DefaultPercentileNormalized — PASS
=== RUN   TestMultiFactor_MethodAndTier — PASS
=== RUN   TestMultiFactor_NormalizeMinEqualsMax — PASS
PASS  (15/15)

$ go test ./pkg/inflight/ -v
=== RUN   TestBeginEndSymmetric — PASS
=== RUN   TestMultipleInflightSameModel — PASS
=== RUN   TestEmptyModelIgnored — PASS
=== RUN   TestZeroTokenEndIsNoop — PASS
=== RUN   TestSelfHealingViaMaxAge — PASS
=== RUN   TestSnapshotPerModel — PASS
=== RUN   TestConcurrentBeginEnd — PASS  (50 goroutines × 100 ops, count returns to 0)
PASS  (7/7)

$ go test ./pkg/... -count=1
(45 packages ok, 0 FAIL)
\`\`\`

\`make agent-smoke-local\` was not run for this PR. Rationale: \`multi_factor\` is opt-in (off by default); the in-flight tracker's wire-in is purely additive (no behavior change for existing decisions); all existing tests pass; structural reflection tests confirm the YAML surface is well-formed. Happy to add a smoke run if reviewers request one.

**Follow-up risks / gaps:**

- Load tracking is in-process; in multi-replica deployments each replica sees only its own load, not cluster-wide. Documented in the tutorial. An external state store could be wired later for true cluster-wide awareness; out of scope for this PR.
- The TTL eviction default (10 minutes) bounds how long a missed \`End\` can leak; very-long-running requests (>10m) would self-expire and appear \"free\" to the selector. Tunable via \`pkg/inflight.SetMaxAge\`; documented in the tutorial's Known Limitations.
- Quality scoring depends on \`quality_score\` being configured per model. Models without it contribute zero to the quality signal (documented). This is consistent with how \`AutoMix\` and \`Hybrid\` already use \`QualityScore\`.