### PR TITLE
[CI/Build] vllm-sr: bump huggingface_hub to fix broken CLI install

### DIFF
--- a/src/vllm-sr/Dockerfile
+++ b/src/vllm-sr/Dockerfile
@@ -264,7 +264,7 @@ RUN set -eux; \
 
 RUN python3 -m venv "${VIRTUAL_ENV}" && \
     "${VIRTUAL_ENV}/bin/pip" install --no-cache-dir --upgrade pip && \
-    "${VIRTUAL_ENV}/bin/pip" install --no-cache-dir 'huggingface_hub[cli]==1.5.0'
+    "${VIRTUAL_ENV}/bin/pip" install --no-cache-dir 'huggingface_hub==1.16.4'
 
 COPY --from=go-builder /build/router /usr/local/bin/router
 COPY --from=rust-builder /build/out/libcandle_semantic_router.so /usr/local/lib/


### PR DESCRIPTION
## Summary

The published image `ghcr.io/vllm-project/semantic-router/vllm-sr:latest` cannot start the router. `vllm-sr serve` fails fatally at the model-download gate with a misleading "huggingface-cli not found" message even though `hf` is present at `/opt/vllm-sr-venv/bin/hf`.

Root cause: `huggingface_hub==1.5.0` ships a `[cli]` extra that does not declare `click` as a dependency, but `huggingface_hub/cli/_cli_utils.py` imports `click` directly. Every `hf` invocation therefore fails with `ModuleNotFoundError: No module named 'click'`. `CheckHuggingFaceCLI` reads the non-zero exit as "not found" and falls through to the legacy `huggingface-cli --help` fallback — but that console script was dropped in `huggingface_hub` 1.x, so the fallback can never succeed. The user-visible error then blames the wrong binary.

## Fix

Bump the pin in `src/vllm-sr/Dockerfile` from `'huggingface_hub[cli]==1.5.0'` to `'huggingface_hub==1.16.4'`. 1.16.4 declares `click` as a core dependency and ships a working `hf`. The `[cli]` extra was removed in newer releases and is no longer needed.

## Reproduction (before and after)

Running the actual router binary inside the published image, with the canonical `config/config.yaml` mounted at `/app/config-mount/config.yaml`:

**Before — stock `vllm-sr:latest`** (same failure as #1951):
```
{"level":"fatal","msg":"startup_failed","message":"Failed to ensure models are downloaded: huggingface-cli check failed: huggingface-cli not found: exec: \"huggingface-cli\": executable file not found in $PATH\nPlease install it with: pip install huggingface_hub[cli]","stacktrace":"... pkg/observability/logging.ComponentFatalEvent ... main.failStartup ... cmd/runtime_bootstrap.go:152 main.ensureModelsDownloadedOrFatal cmd/runtime_bootstrap.go:159 main.main cmd/main.go:32 ..."}
```

**After — same image, venv patched in-place to `huggingface_hub==1.16.4`**:
```
{"level":"info","msg":"required_models_check_started","component":"router"}
{"level":"info","msg":"classification_service_autodiscovery_succeeded","component":"apiserver"}
{"level":"info","msg":"server_listening","component":"apiserver","port":8080}
```

The router passes the model-check gate and the API server listens on :8080. Remaining warnings (`memory_store_unavailable`) are unrelated config defaults, not the bug.

## Test plan

- Reproduced the failure in stock `ghcr.io/vllm-project/semantic-router/vllm-sr:latest` (commit `b41e297d`-parent image) against `config/config.yaml`.
- Confirmed the fix by patching the venv inside the running container and re-booting the router — startup succeeds, API server listens.
- Confirmed `pip show huggingface_hub` after the upgrade now reports `Requires: click, filelock, fsspec, hf-xet, httpx, packaging, pyyaml, tqdm, typer, typing-extensions` and `python -c "import click"` succeeds.

This change is a one-line pin bump and does not touch Go, Rust, or Python code. A full image rebuild on this PR exercises the fix end-to-end.

## Follow-up suggestion (not in this PR)

This regression slipped through green CI because CI does not currently boot the built image and verify the router reaches `server_listening`. A small smoke-test job — `docker run <built-image> /usr/local/bin/router -config=config/config.yaml &` then assert `server_listening` appears in logs within N seconds, or that the process does not exit non-zero — would have caught this before publication. Happy to send that as a separate PR if useful.

Fixes #1951
