### PR TITLE
feat: add CLIENT SETNAME for connection identification

### DIFF
--- a/src/semantic-router/pkg/cache/valkey_cache.go
+++ b/src/semantic-router/pkg/cache/valkey_cache.go
@@ -72,7 +72,8 @@ func NewValkeyCache(options ValkeyCacheOptions) (*ValkeyCache, error) {
 		WithAddress(&config.NodeAddress{
 			Host: resolvedHost,
 			Port: valkeyConfig.Connection.Port,
-		})
+		}).
+		WithClientName("vllm_cache_client")
 
 	if valkeyConfig.Connection.Password != "" {
 		clientConfig = clientConfig.WithCredentials(

--- a/src/semantic-router/pkg/extproc/router_memory.go
+++ b/src/semantic-router/pkg/extproc/router_memory.go
@@ -246,7 +246,8 @@ func buildValkeyClientConfig(vc *config.MemoryValkeyConfig, host string, port in
 		WithAddress(&glideconfig.NodeAddress{
 			Host: host,
 			Port: port,
-		})
+		}).
+		WithClientName("vllm_agentic_memory_client")
 
 	if vc.Password != "" {
 		clientConfig = clientConfig.WithCredentials(

--- a/src/semantic-router/pkg/vectorstore/valkey_backend.go
+++ b/src/semantic-router/pkg/vectorstore/valkey_backend.go
@@ -115,6 +115,7 @@ func NewValkeyBackend(cfg ValkeyBackendConfig) (*ValkeyBackend, error) {
 
 	clientConfig := glideconfig.NewClientConfiguration().
 		WithAddress(&glideconfig.NodeAddress{Host: host, Port: port}).
+		WithClientName("vllm_vector_store_client").
 		WithRequestTimeout(time.Duration(timeout) * time.Second)
 
 	if cfg.Password != "" {


### PR DESCRIPTION
## Summary

Adds `WithClientName()` to all three Valkey client configurations so connections are identifiable via `CLIENT LIST` on the server.

- `pkg/cache/valkey_cache.go`: `"vllm_cache_client"`
- `pkg/vectorstore/valkey_backend.go`: `"vllm_vector_store_client"`
- `pkg/extproc/router_memory.go` (shared client for agentic memory): `"vllm_agentic_memory_client"`

Fixes #1947

## Changes

Three one-line additions — each adds `.WithClientName(...)` to the existing `NewClientConfiguration()` chain.

## Motivation

As described in #1947, connections without a name appear anonymous in `CLIENT LIST`, making it impossible to attribute them to specific services. Setting `ClientName` sends a `CLIENT SETNAME` command on connection, making connections identifiable in:
- `CLIENT LIST` output
- Monitoring dashboards (e.g., Valkey Admin)
- CloudWatch metrics (ElastiCache)

## Risk

Zero-risk — `WithClientName` is a metadata-only option. No behavioral changes.
