### PR TITLE
[Docs] Correct community meeting cadence wording (#1874)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,4 +31,4 @@ all current maintainers.
 ## Community Channels
 
 - **Slack:** `#semantic-router` in vLLM Slack
-- **Meetings:** Bi-weekly, listed in the [README](./README.md#community-meetings-)
+- **Meetings:** First and third Tuesday of each month, listed in the [README](./README.md#community-meetings-)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For questions, feedback, or to contribute, please join the `#semantic-router` ch
 
 ### Community Meetings
 
-We host bi-weekly community meetings to sync with contributors across different time zones:
+We host community meetings on the first and third Tuesday of each month to sync with contributors across different time zones:
 
 - **First Tuesday of the month**: 9:00-10:00 AM EST (accommodates US EST, EU, and Asia Pacific contributors)
   - [Zoom Link](https://us05web.zoom.us/j/84122485631?pwd=BB88v03mMNLVHn60YzVk4PihuqBV9d.1)


### PR DESCRIPTION
Closes #1874

## Purpose

- **What does this PR change?** Corrects the community-meeting cadence wording so the docs are internally consistent. `README.md` and `GOVERNANCE.md` both described the meetings as **"bi-weekly"**, but the schedule actually listed is the **first and third Tuesday of each month** — a twice-monthly cadence (the gap between the 3rd Tuesday and the next 1st Tuesday is ~3 weeks), not "every two weeks". Both files are updated to state the real cadence.
- **Why is this change needed?** #1874 reports the schedule wording is misleading/inconsistent. "Bi-weekly" contradicts the per-month entries, so a reader cannot tell the true cadence. (Verified `bi-weekly` appeared in exactly two places: `README.md:80` and `GOVERNANCE.md:34`.)
- **Which module(s) does this affect?** `Docs`

> [!NOTE]
> The reporter also suspected the **First Tuesday** meeting may no longer be held and asked whether to (1) drop it or (2) re-introduce an APAC-friendly slot. I intentionally **kept both meeting entries** because the README still lists the First-Tuesday slot with active Zoom/Calendar/ics links and I can't confirm from outside whether it's retired. If maintainers confirm it's discontinued, I'm happy to also remove that bullet (`README.md:82-85`) in this PR — just say the word.

## Test Plan

- `markdownlint -c tools/linter/markdown/markdownlint.yaml "README.md" "GOVERNANCE.md"` — the repo's canonical markdown gate.
- `grep -rni "bi-weekly\|biweekly" --include="*.md" .` — prove the inconsistent wording is gone everywhere.
- Manual read of the rendered `### Community Meetings` section.

## Test Result

- markdownlint: **no violations**.
- `grep` for `bi-weekly`/`biweekly`: **0 matches** across the repo.
- Docs-only change; no code paths touched, so no Go/Rust tests apply.
- Follow-up risk: only the open maintainer decision noted above (keep vs. retire the First-Tuesday meeting).
