### PR TITLE
[Router] Add multi_emit projection mapping method (#1759)

### DIFF
--- a/src/semantic-router/pkg/classification/classifier_projections.go
+++ b/src/semantic-router/pkg/classification/classifier_projections.go
@@ -60,12 +60,7 @@ func (c *Classifier) applyProjections(results *SignalResults) *SignalResults {
 
 		for _, mapping := range mappingBySource[score.Name] {
 			scoreValue := results.ProjectionScores[mapping.Source]
-			output, matched := matchProjectionOutput(mapping, scoreValue)
-			if !matched {
-				continue
-			}
-			results.MatchedProjectionRules = append(results.MatchedProjectionRules, output.Name)
-			results.SignalConfidences[signalConfidenceKey(config.SignalTypeProjection, output.Name)] = projectionOutputConfidence(mapping, output, scoreValue)
+			applyProjectionMapping(mapping, scoreValue, results)
 		}
 	}
 
@@ -237,6 +232,39 @@ func projectionMatchSet(results *SignalResults, signalType string) []string {
 		return nil
 	}
 	return accessor(results)
+}
+
+// applyProjectionMapping records the matched output band(s) for a mapping
+// according to its method. threshold_bands (and the empty default) emit only the
+// first matching band; multi_emit emits every matching band so orthogonal policy
+// tags can propagate simultaneously.
+func applyProjectionMapping(
+	mapping config.ProjectionMapping,
+	scoreValue float64,
+	results *SignalResults,
+) {
+	switch mapping.Method {
+	case config.ProjectionMappingMethodMultiEmit:
+		for _, output := range mapping.Outputs {
+			if projectionOutputMatches(output, scoreValue) {
+				recordProjectionMatch(mapping, output, scoreValue, results)
+			}
+		}
+	default: // "" and threshold_bands preserve first-hit behavior
+		if output, matched := matchProjectionOutput(mapping, scoreValue); matched {
+			recordProjectionMatch(mapping, output, scoreValue, results)
+		}
+	}
+}
+
+func recordProjectionMatch(
+	mapping config.ProjectionMapping,
+	output config.ProjectionMappingOutput,
+	scoreValue float64,
+	results *SignalResults,
+) {
+	results.MatchedProjectionRules = append(results.MatchedProjectionRules, output.Name)
+	results.SignalConfidences[signalConfidenceKey(config.SignalTypeProjection, output.Name)] = projectionOutputConfidence(mapping, output, scoreValue)
 }
 
 func matchProjectionOutput(

--- a/src/semantic-router/pkg/classification/classifier_projections_test.go
+++ b/src/semantic-router/pkg/classification/classifier_projections_test.go
@@ -644,3 +644,99 @@ func TestApplyProjectionsReverseDeclarationOrder(t *testing.T) {
 func float64Ptr(v float64) *float64 {
 	return &v
 }
+
+// newMultiEmitTestClassifier builds a classifier with one weighted_sum score and
+// one mapping using the given method plus three deliberately overlapping output
+// bands. For a score of 0.6: low_band (lt 0.3) does NOT match, while both
+// mid_band ([0.2,0.7)) and high_band ([0.5,inf)) match — letting first-hit and
+// multi_emit behavior be distinguished.
+func newMultiEmitTestClassifier(method string) *Classifier {
+	return &Classifier{
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				Projections: config.Projections{
+					Scores: []config.ProjectionScore{{
+						Name:   "multi_score",
+						Method: "weighted_sum",
+						Inputs: []config.ProjectionScoreInput{{
+							Type:        config.SignalTypeKeyword,
+							Name:        "test_signal",
+							Weight:      1.0,
+							ValueSource: "confidence",
+						}},
+					}},
+					Mappings: []config.ProjectionMapping{{
+						Name:   "multi_mapping",
+						Source: "multi_score",
+						Method: method,
+						Outputs: []config.ProjectionMappingOutput{
+							{Name: "low_band", LT: float64Ptr(0.3)},
+							{Name: "mid_band", GTE: float64Ptr(0.2), LT: float64Ptr(0.7)},
+							{Name: "high_band", GTE: float64Ptr(0.5)},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func multiEmitTestResults() *SignalResults {
+	return &SignalResults{
+		MatchedKeywordRules: []string{"test_signal"},
+		SignalConfidences:   map[string]float64{"keyword:test_signal": 0.6},
+	}
+}
+
+func assertMatchedProjectionRules(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("matched projection rules = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("matched projection rules = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestApplyProjectionsMultiEmitEmitsAllMatchingBands(t *testing.T) {
+	classifier := newMultiEmitTestClassifier("multi_emit")
+
+	got := classifier.applyProjections(multiEmitTestResults())
+	if got == nil {
+		t.Fatal("applyProjections returned nil")
+	}
+
+	// score = 1.0*0.6 = 0.6 -> mid_band and high_band match; low_band does not.
+	assertMatchedProjectionRules(t, got.MatchedProjectionRules, []string{"mid_band", "high_band"})
+	for _, name := range []string{"mid_band", "high_band"} {
+		if _, ok := got.SignalConfidences["projection:"+name]; !ok {
+			t.Fatalf("missing projection confidence for %q in %+v", name, got.SignalConfidences)
+		}
+	}
+}
+
+func TestApplyProjectionsThresholdBandsEmitsFirstMatchOnly(t *testing.T) {
+	classifier := newMultiEmitTestClassifier("threshold_bands")
+
+	got := classifier.applyProjections(multiEmitTestResults())
+	if got == nil {
+		t.Fatal("applyProjections returned nil")
+	}
+
+	// First-hit: only the first matching band (mid_band, in output order) is emitted.
+	assertMatchedProjectionRules(t, got.MatchedProjectionRules, []string{"mid_band"})
+}
+
+func TestApplyProjectionsEmptyMethodDefaultsToFirstHit(t *testing.T) {
+	classifier := newMultiEmitTestClassifier("")
+
+	got := classifier.applyProjections(multiEmitTestResults())
+	if got == nil {
+		t.Fatal("applyProjections returned nil")
+	}
+
+	// Unset method must preserve the legacy first-hit (threshold_bands) behavior.
+	assertMatchedProjectionRules(t, got.MatchedProjectionRules, []string{"mid_band"})
+}

--- a/src/semantic-router/pkg/config/projection_config.go
+++ b/src/semantic-router/pkg/config/projection_config.go
@@ -37,6 +37,17 @@ type ProjectionScoreInput struct {
 	Miss        float64 `yaml:"miss,omitempty"`
 }
 
+// Projection mapping methods control how matching output bands are selected
+// when a score is projected into named outputs.
+const (
+	// ProjectionMappingMethodThresholdBands emits the first matching output band
+	// (first-hit). It is the default behavior when method is unset.
+	ProjectionMappingMethodThresholdBands = "threshold_bands"
+	// ProjectionMappingMethodMultiEmit emits every matching output band, so
+	// orthogonal policy tags can propagate simultaneously from one mapping.
+	ProjectionMappingMethodMultiEmit = "multi_emit"
+)
+
 // ProjectionMapping projects a score into named routing outputs.
 type ProjectionMapping struct {
 	Name        string                        `yaml:"name"`

--- a/src/semantic-router/pkg/config/validator_projection.go
+++ b/src/semantic-router/pkg/config/validator_projection.go
@@ -474,11 +474,27 @@ func validateProjectionMapping(
 	if _, exists := scoreNames[mapping.Source]; !exists {
 		return fmt.Errorf("routing.projections.mappings[%q]: source %q is not a declared projection score", mapping.Name, mapping.Source)
 	}
-	if mapping.Method != "threshold_bands" {
-		return fmt.Errorf("routing.projections.mappings[%q]: unsupported method %q (supported: threshold_bands)", mapping.Name, mapping.Method)
+	switch mapping.Method {
+	case "", ProjectionMappingMethodThresholdBands, ProjectionMappingMethodMultiEmit:
+		// supported (empty defaults to threshold_bands)
+	default:
+		return fmt.Errorf(
+			"routing.projections.mappings[%q]: unsupported method %q (supported: %s, %s)",
+			mapping.Name,
+			mapping.Method,
+			ProjectionMappingMethodThresholdBands,
+			ProjectionMappingMethodMultiEmit,
+		)
 	}
 	if len(mapping.Outputs) == 0 {
 		return fmt.Errorf("routing.projections.mappings[%q]: outputs cannot be empty", mapping.Name)
+	}
+	if mapping.Method == ProjectionMappingMethodMultiEmit && len(mapping.Outputs) < 2 {
+		return fmt.Errorf(
+			"routing.projections.mappings[%q]: method %q requires at least 2 outputs (a single-output multi_emit is equivalent to threshold_bands)",
+			mapping.Name,
+			ProjectionMappingMethodMultiEmit,
+		)
 	}
 	if err := validateProjectionCalibration(mapping); err != nil {
 		return err

--- a/src/semantic-router/pkg/config/validator_projection_test.go
+++ b/src/semantic-router/pkg/config/validator_projection_test.go
@@ -529,3 +529,83 @@ func TestValidateProjectionScoreDependencyOrder_ConfidenceResolvesToSourceScore(
 }
 
 func float64Ptr(v float64) *float64 { return &v }
+
+func twoBandOutputs() []ProjectionMappingOutput {
+	return []ProjectionMappingOutput{
+		{Name: "low", LT: float64Ptr(0.5)},
+		{Name: "high", GTE: float64Ptr(0.5)},
+	}
+}
+
+func TestValidateProjectionMappingAcceptsSupportedMethods(t *testing.T) {
+	scoreNames := map[string]struct{}{"s": {}}
+	for _, method := range []string{"", ProjectionMappingMethodThresholdBands, ProjectionMappingMethodMultiEmit} {
+		t.Run(fmt.Sprintf("method=%q", method), func(t *testing.T) {
+			mapping := ProjectionMapping{
+				Name:    "m",
+				Source:  "s",
+				Method:  method,
+				Outputs: twoBandOutputs(),
+			}
+			if err := validateProjectionMapping(mapping, scoreNames, map[string]struct{}{}); err != nil {
+				t.Fatalf("expected method %q to be accepted, got: %v", method, err)
+			}
+		})
+	}
+}
+
+func TestValidateProjectionMappingRejectsUnknownMethod(t *testing.T) {
+	scoreNames := map[string]struct{}{"s": {}}
+	mapping := ProjectionMapping{
+		Name:    "m",
+		Source:  "s",
+		Method:  "bogus_method",
+		Outputs: twoBandOutputs(),
+	}
+	err := validateProjectionMapping(mapping, scoreNames, map[string]struct{}{})
+	if err == nil {
+		t.Fatal("expected error for unsupported mapping method")
+	}
+	if !strings.Contains(err.Error(), "unsupported method") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{ProjectionMappingMethodThresholdBands, ProjectionMappingMethodMultiEmit} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should list %q as supported: %v", want, err)
+		}
+	}
+}
+
+func TestValidateProjectionMappingMultiEmitRequiresAtLeastTwoOutputs(t *testing.T) {
+	scoreNames := map[string]struct{}{"s": {}}
+	mapping := ProjectionMapping{
+		Name:   "m",
+		Source: "s",
+		Method: ProjectionMappingMethodMultiEmit,
+		Outputs: []ProjectionMappingOutput{
+			{Name: "only", GTE: float64Ptr(0.5)},
+		},
+	}
+	err := validateProjectionMapping(mapping, scoreNames, map[string]struct{}{})
+	if err == nil {
+		t.Fatal("expected error for multi_emit with a single output")
+	}
+	if !strings.Contains(err.Error(), ProjectionMappingMethodMultiEmit) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateProjectionMappingThresholdBandsAllowsSingleOutput(t *testing.T) {
+	scoreNames := map[string]struct{}{"s": {}}
+	mapping := ProjectionMapping{
+		Name:   "m",
+		Source: "s",
+		Method: ProjectionMappingMethodThresholdBands,
+		Outputs: []ProjectionMappingOutput{
+			{Name: "only", GTE: float64Ptr(0.5)},
+		},
+	}
+	if err := validateProjectionMapping(mapping, scoreNames, map[string]struct{}{}); err != nil {
+		t.Fatalf("threshold_bands with a single output should be valid, got: %v", err)
+	}
+}

--- a/src/semantic-router/pkg/dsl/projection_multi_emit_test.go
+++ b/src/semantic-router/pkg/dsl/projection_multi_emit_test.go
@@ -1,0 +1,84 @@
+package dsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// multiEmitProjectionDSL declares a mapping with method: "multi_emit" and two
+// deliberately overlapping bands so the method carries meaning end-to-end.
+const multiEmitProjectionDSL = `
+SIGNAL keyword reasoning_request_markers {
+  operator: "OR"
+  keywords: ["reason carefully"]
+}
+
+PROJECTION score difficulty_score {
+  method: "weighted_sum"
+  inputs: [
+    { type: "keyword", name: "reasoning_request_markers", weight: 0.6 }
+  ]
+}
+
+PROJECTION mapping difficulty_band {
+  source: "difficulty_score"
+  method: "multi_emit"
+  outputs: [
+    { name: "balance_medium", lt: 0.7 },
+    { name: "balance_reasoning", gte: 0.5 }
+  ]
+}
+
+ROUTE reasoning_route {
+  PRIORITY 200
+  WHEN projection("balance_reasoning")
+  MODEL "m1"
+}
+
+ROUTE medium_route {
+  PRIORITY 100
+  WHEN projection("balance_medium")
+  MODEL "m2"
+}
+`
+
+func TestCompileAcceptsMultiEmitProjectionMapping(t *testing.T) {
+	cfg, errs := Compile(multiEmitProjectionDSL)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.Projections.Mappings) != 1 {
+		t.Fatalf("expected 1 projection mapping, got %d", len(cfg.Projections.Mappings))
+	}
+	if got := cfg.Projections.Mappings[0].Method; got != config.ProjectionMappingMethodMultiEmit {
+		t.Fatalf("mapping method = %q, want %q", got, config.ProjectionMappingMethodMultiEmit)
+	}
+}
+
+func TestMultiEmitProjectionMappingSurvivesRoundTrip(t *testing.T) {
+	cfg, errs := Compile(multiEmitProjectionDSL)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+
+	dslText, err := DecompileRouting(cfg)
+	if err != nil {
+		t.Fatalf("DecompileRouting error: %v", err)
+	}
+	if !strings.Contains(dslText, `method: "multi_emit"`) {
+		t.Fatalf("decompiled DSL missing multi_emit method:\n%s", dslText)
+	}
+
+	roundTripped, compileErrs := Compile(dslText)
+	if len(compileErrs) > 0 {
+		t.Fatalf("re-compile errors: %v", compileErrs)
+	}
+	if len(roundTripped.Projections.Mappings) != 1 {
+		t.Fatalf("expected 1 mapping after round-trip, got %d", len(roundTripped.Projections.Mappings))
+	}
+	if got := roundTripped.Projections.Mappings[0].Method; got != config.ProjectionMappingMethodMultiEmit {
+		t.Fatalf("round-tripped mapping method = %q, want %q", got, config.ProjectionMappingMethodMultiEmit)
+	}
+}

--- a/website/docs/tutorials/projection/mappings.md
+++ b/website/docs/tutorials/projection/mappings.md
@@ -36,7 +36,10 @@ This is also the point where a projection becomes decision-visible. In the curre
 
 ## How Mappings Behave at Runtime
 
-The current implementation supports `method: threshold_bands` only.
+The implementation supports two mapping methods:
+
+- `threshold_bands` (default, also used when `method` is unset) — emits the **first** matching output band.
+- `multi_emit` — emits **every** matching output band, so one mapping can set several orthogonal policy tags from the same score. Requires at least two outputs.
 
 Each output declares one or more bounds using:
 
@@ -47,10 +50,11 @@ Each output declares one or more bounds using:
 
 Important runtime details:
 
-- outputs are checked in order
-- the first matching output wins
+- outputs are checked in declared order
+- with `threshold_bands`, the first matching output wins
+- with `multi_emit`, every matching output is emitted (in declared order)
 - if no output matches, the mapping emits nothing
-- optional `calibration` computes a confidence for the matched projection output
+- optional `calibration` computes a confidence for each emitted projection output
 
 The supported calibration method today is `sigmoid_distance`, which derives confidence from how far the score sits from the nearest threshold boundary.
 
@@ -118,7 +122,7 @@ ROUTE reasoning_deep {
 |-------|---------|
 | `name` | mapping identifier |
 | `source` | score name to read from |
-| `method` | currently `threshold_bands` |
+| `method` | `threshold_bands` (default) or `multi_emit` |
 | `calibration` | optional confidence model for the matched output |
 | `outputs[].name` | decision-visible projection name |
 | `outputs[].lt/lte/gt/gte` | threshold bounds for that output |
@@ -130,7 +134,7 @@ ROUTE reasoning_deep {
 
 ## Configuration
 
-Mappings are configured under `routing.projections.mappings`. Each mapping requires a `name`, a `source` score, a `method` (currently `threshold_bands`), and a list of `outputs` with threshold bounds. See the [Canonical YAML](#canonical-yaml) and [Config Fields](#config-fields) sections above for full field reference.
+Mappings are configured under `routing.projections.mappings`. Each mapping requires a `name`, a `source` score, a `method` (`threshold_bands` by default, or `multi_emit`), and a list of `outputs` with threshold bounds. See the [Canonical YAML](#canonical-yaml) and [Config Fields](#config-fields) sections above for full field reference.
 
 ## When to Use
 
@@ -153,7 +157,7 @@ Do not use mappings when:
 - Keep output names policy-oriented so decisions read like routing intent, not threshold math.
 - Keep threshold bands monotonic, ordered, and easy to audit.
 - Let decisions consume named outputs with `type: projection` rather than repeating numeric thresholds in multiple places.
-- Avoid overlapping bands unless you intentionally want order-dependent behavior; the runtime returns the first matching output.
+- With `threshold_bands`, avoid overlapping bands unless you intentionally want order-dependent behavior; the runtime returns the first matching output. Use `multi_emit` when overlapping bands should all fire (e.g. orthogonal policy tags).
 
 ## Next Steps
 


### PR DESCRIPTION
Closes #1759

## Purpose

- **What does this PR change?** Adds a second projection-mapping method, `multi_emit`, to the routing projections layer. Today a mapping is first-hit only (`threshold_bands`): when a score falls in several overlapping output bands, only the first matching band is emitted. `multi_emit` emits **every** matching band, so one mapping can set several orthogonal policy tags from the same score.
- **Why is this change needed?** #1759 (parent meta #1711) asks to extend projection mappings beyond first-hit threshold bands. `multi_emit` is the minimal, stateless first step in that direction.
- **Which module(s) does this affect?** `Router` (Go: config + classification + DSL) and `Docs`.

### Design

- `threshold_bands` remains the default; an **unset** `method` continues to behave exactly as before (first-hit). 100% backward compatible.
- Output selection is dispatched on `mapping.Method` (`classifier_projections.go`); `threshold_bands` reuses the existing first-hit path, `multi_emit` appends every matching band with its calibrated confidence.
- The config validator accepts `{"", threshold_bands, multi_emit}` and rejects unknown methods. `multi_emit` requires ≥2 outputs (a single-output `multi_emit` is equivalent to `threshold_bands`).
- No new config struct fields — `multi_emit` only adds a `Method` value, keeping the blast radius small.

### Scope / deliberate follow-ups

- **`top_k` / hysteresis** mapping methods are intentionally out of scope (they need new fields and/or cross-request state) — separate follow-ups.
- **Projection trace** (`projectiontrace.MappingDecision.SelectedOutput`) still records the first matched output as the single "selected" summary; per-output `Matched` flags already reflect every band. Richer multi-output trace is tracked under #1760.
- **CLI/dashboard schema parity** (#1761): the Go config validator is the enforcement point for any authored config (CLI-generated configs are validated on router load), so this PR does not grow the `models.py`/`validator.py` config-contract hotspots. CLI/dashboard surfacing can follow under #1761.

## Test Plan

Run from the router module (multi-module repo; CGO + prebuilt Rust bindings on `LD_LIBRARY_PATH`):

- `go test -race ./pkg/config/ ./pkg/classification/ ./pkg/dsl/`
- New unit tests:
  - `pkg/classification`: `multi_emit` emits all matching bands; `threshold_bands` and empty-method stay first-hit.
  - `pkg/config`: validator accepts `""`/`threshold_bands`/`multi_emit`, rejects unknown method, requires ≥2 outputs for `multi_emit`, allows single output for `threshold_bands`.
  - `pkg/dsl`: a `method: "multi_emit"` mapping compiles and survives a decompile→recompile round-trip.
- `gofmt -l`, `go vet`, and `markdownlint -c tools/linter/markdown/markdownlint.yaml` on the changed doc.

## Test Result

- `go test -race` on all three packages: **PASS** (config 3.0s, classification 35.8s, dsl 6.7s), no regressions.
- `gofmt`/`go vet`: clean. markdownlint: clean.
- Backward compatibility: existing first-hit projection tests pass unchanged; unset/`threshold_bands` method behavior is byte-for-byte the same.
- Follow-up risks: the trace `SelectedOutput` and CLI/dashboard parity noted above (tracked by #1760/#1761). No routing wire-format change for existing configs, so no E2E update is required (the default path is unchanged).
