### PR TITLE
[Router] Populate Chat Completions previous-model to unblock ModelSwitchGate enforce (#1753)

### DIFF
--- a/docs/agent/plans/pl-0030-session-aware-model-switch-workstream.md
+++ b/docs/agent/plans/pl-0030-session-aware-model-switch-workstream.md
@@ -131,12 +131,14 @@ This ensures:
 - 2026-05-10: Chose Beta distribution accumulation (same as online `UpdateFeedback`) for offline replay rather than introducing a separate reward model. Keeps the weight format identical across online and offline paths, simplifying version promotion.
 - 2026-05-10: Added `MinRecordsPerModel` threshold so models with sparse offline evidence keep their parent-version priors unchanged, preventing noisy updates from small samples.
 - 2026-05-10: Policy versions are file-backed JSON rather than database-backed to keep the offline path zero-dependency and operator-friendly for inspection.
+- 2026-05-29: Unblocked enforce-mode for Chat Completions by recording the per-turn model in an in-memory, session-keyed last-model store (`pkg/sessiontelemetry/last_model.go`) at response time (`recordSessionTurn`) and reading it back as `ctx.PreviousModel` during request prep (`populateSessionTransitionFields`). Previously only Response API carried previous-model history via the conversation chain, so the ModelSwitchGate fell back to audit-only for all Chat Completions traffic regardless of mode (#1753). Keyed on the same `ctx.SessionID` the read side uses; mirrors the existing telemetry/transition store idioms (1h TTL + size cap).
 
 ## Follow-up Debt / ADR Links
 
 - `OfflineDatasetBuilder` implementation depends on RouterReplay store query capabilities (session-range queries). May need a store extension for windowed reads.
 - Shadow evaluator integration into the ExtProc hot path must respect latency budgets. Consider async recording or bounded channel.
 - No ADR required yet — this is additive infrastructure that does not change the runtime decision contract.
+- The Chat Completions last-model store (`pkg/sessiontelemetry/last_model.go`) is in-memory and per-replica (lost on restart, not shared across horizontally-scaled routers), matching the existing telemetry/transition stores. Durable/shared previous-model persistence is follow-up debt for enforce-mode continuity across replicas and restarts; until then enforce continuity is best-effort and the gate emits `model_switch_gate_enforce_unavailable` when the signal is absent.
 
 ## Validation
 

--- a/src/semantic-router/pkg/config/selection_config.go
+++ b/src/semantic-router/pkg/config/selection_config.go
@@ -90,11 +90,13 @@ type MomentumSelectionConfig struct {
 // ModelSwitchGateConfig configures auditable session-aware model switching.
 //
 // Note: enforce mode requires per-turn model history (the previous model the
-// session used). Today only Response API requests carry that signal via the
-// conversation chain. Chat Completions traffic is observed in shadow regardless
-// of mode until per-turn history persistence ships; when enforce is configured
-// but the signal is missing the router emits a model_switch_gate_enforce_unavailable
-// log event so operators can spot misconfiguration without an incident.
+// session used). Response API requests carry that signal via the conversation
+// chain; Chat Completions carry it from the first follow-up turn via an
+// in-memory, session-keyed last-model store (per-replica, lost on restart).
+// When enforce is configured but the signal is still missing — the first turn of
+// a session, an unresolvable session, or after a restart — the router emits a
+// model_switch_gate_enforce_unavailable log event so operators can spot
+// misconfiguration without an incident.
 type ModelSwitchGateConfig struct {
 	// Enabled activates stay-vs-switch evaluation after the configured selector runs.
 	Enabled bool `yaml:"enabled,omitempty"`
@@ -102,7 +104,8 @@ type ModelSwitchGateConfig struct {
 	// Mode controls whether the gate only audits decisions ("shadow") or applies
 	// them to keep the current model ("enforce"). Empty defaults to shadow.
 	// Enforce only takes effect when previous-model history is available
-	// (currently Response API only).
+	// (Response API via the conversation chain; Chat Completions from the first
+	// follow-up turn via the in-memory last-model store).
 	Mode string `yaml:"mode,omitempty"`
 
 	// MinSwitchAdvantage is the minimum net advantage required to allow switching.

--- a/src/semantic-router/pkg/extproc/model_switch_gate.go
+++ b/src/semantic-router/pkg/extproc/model_switch_gate.go
@@ -105,7 +105,8 @@ func estimateGateCacheWarmth(model string, now time.Time) (float64, bool) {
 
 // emitEnforceUnavailableLog warns once per request when enforce mode is
 // configured but the gate fell back to audit-only because previous_model was
-// missing — typically Chat Completions traffic without per-turn model history.
+// missing — e.g. the first turn of a session, an unresolvable session, or a
+// session whose recorded model expired/was lost on restart.
 func emitEnforceUnavailableLog(decision selection.ModelSwitchGateDecision, requestID, decisionName string) {
 	if decision.Mode != selection.ModelSwitchGateModeEnforce {
 		return
@@ -120,7 +121,7 @@ func emitEnforceUnavailableLog(decision selection.ModelSwitchGateDecision, reque
 		"request_id":      requestID,
 		"decision":        decisionName,
 		"missing_signals": decision.MissingSignals,
-		"hint":            "enforce mode currently requires per-turn model history; only Response API requests carry it. Chat Completions are observed in shadow until persistence ships.",
+		"hint":            "enforce mode requires a known previous model for the session; it is unavailable on the first turn, for unresolvable sessions, or after a restart (the Chat Completions last-model store is in-memory).",
 	})
 }
 

--- a/src/semantic-router/pkg/extproc/model_switch_gate_test.go
+++ b/src/semantic-router/pkg/extproc/model_switch_gate_test.go
@@ -46,16 +46,16 @@ func TestApplyModelSwitchGateShadowDoesNotOverride(t *testing.T) {
 }
 
 func TestApplyModelSwitchGateChatCompletionsAuditOnly(t *testing.T) {
-	// Chat Completions traffic has no per-turn model history yet; gate must
+	// A first-turn / unresolvable request still has no prior model; the gate must
 	// fall back to audit-only and never override the selector even in enforce.
 	router := routerWithModelSwitchGate(selection.ModelSwitchGateModeEnforce)
 	selCtx, result := modelSwitchGateSelectionInput()
-	selCtx.SessionID = "" // simulate Chat Completions: no session derived yet
+	selCtx.SessionID = "" // simulate a request with no session derived yet
 	selected := &selCtx.CandidateModels[1]
 
 	got, applied := router.applyModelSwitchGate(selCtx, result, selected, &RequestContext{
 		RequestID:     "req-cc",
-		PreviousModel: "", // unavailable for Chat Completions today
+		PreviousModel: "", // no prior model yet (first turn / unresolved session)
 	})
 	if applied {
 		t.Fatalf("enforce must not override when previous_model is missing")

--- a/src/semantic-router/pkg/extproc/session_telemetry.go
+++ b/src/semantic-router/pkg/extproc/session_telemetry.go
@@ -64,6 +64,12 @@ func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics, pricing 
 			}
 		}
 		p.Chat = &sessiontelemetry.ChatInput{UserID: userID, Messages: msgs}
+		// Remember the model used for this Chat Completions session so the next
+		// turn's request phase can populate ctx.PreviousModel via GetLastModel.
+		// Keyed on ctx.SessionID (set during request prep), the same key the read
+		// side uses. Response API derives previous model from the conversation
+		// chain instead, so it is intentionally not recorded here.
+		sessiontelemetry.RecordLastModel(ctx.SessionID, ctx.RequestModel)
 	}
 	sessiontelemetry.RecordTurn(p)
 }

--- a/src/semantic-router/pkg/extproc/session_transition.go
+++ b/src/semantic-router/pkg/extproc/session_transition.go
@@ -48,7 +48,12 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 
 	ctx.TurnIndex = sessiontelemetry.ChatTurnNumber(sessionTransitionChatMessages(ctx.ChatCompletionMessages)) - 1
 	ctx.HistoryTokenCount = historyTokensFromChatMessages(ctx.ChatCompletionMessages)
-	// TODO: populate PreviousModel for Chat Completions once per-turn model history is available.
+	// Populate PreviousModel for Chat Completions from the in-memory last-model
+	// store, recorded at response time of the previous turn in this session.
+	// (Response API derives PreviousModel from the conversation chain above.)
+	if model, ok := sessiontelemetry.GetLastModel(ctx.SessionID); ok {
+		ctx.PreviousModel = model
+	}
 }
 
 // populateChatCompletionSessionIDIfNeeded sets ctx.SessionID when not already

--- a/src/semantic-router/pkg/extproc/session_transition_last_model_test.go
+++ b/src/semantic-router/pkg/extproc/session_transition_last_model_test.go
@@ -1,0 +1,76 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
+)
+
+func TestPopulateSessionTransitionFields_ChatCompletionsPopulatesPreviousModelFromStore(t *testing.T) {
+	sessiontelemetry.ResetLastModelForTesting()
+	t.Cleanup(sessiontelemetry.ResetLastModelForTesting)
+
+	msgs := []ChatCompletionMessage{{Role: "user", Content: "remember me"}}
+	sid := deriveSessionIDFromMessages(msgs, "user-prev")
+	sessiontelemetry.RecordLastModel(sid, "model-a")
+
+	ctx := &RequestContext{
+		Headers:                map[string]string{"x-authz-user-id": "user-prev"},
+		ChatCompletionMessages: msgs,
+	}
+	populateSessionTransitionFields(ctx)
+
+	require.Equal(t, sid, ctx.SessionID)
+	assert.Equal(t, "model-a", ctx.PreviousModel)
+}
+
+func TestPopulateSessionTransitionFields_ChatCompletionsNoPriorModelLeavesEmpty(t *testing.T) {
+	sessiontelemetry.ResetLastModelForTesting()
+	t.Cleanup(sessiontelemetry.ResetLastModelForTesting)
+
+	ctx := &RequestContext{
+		Headers:                map[string]string{"x-authz-user-id": "user-fresh"},
+		ChatCompletionMessages: []ChatCompletionMessage{{Role: "user", Content: "first contact"}},
+	}
+	populateSessionTransitionFields(ctx)
+
+	require.NotEmpty(t, ctx.SessionID)
+	assert.Empty(t, ctx.PreviousModel)
+}
+
+// TestChatCompletionsModelContinuityAcrossTurns exercises the full write→read
+// path: turn 1 records its model at response time, and turn 2's request phase
+// recovers it as PreviousModel — the exact gap #1753's first deliverable closes.
+func TestChatCompletionsModelContinuityAcrossTurns(t *testing.T) {
+	sessiontelemetry.ResetLastModelForTesting()
+	t.Cleanup(sessiontelemetry.ResetLastModelForTesting)
+
+	turn1 := &RequestContext{
+		RequestID:              "req-1",
+		RequestModel:           "model-a",
+		Headers:                map[string]string{"x-authz-user-id": "user-7"},
+		ChatCompletionMessages: []ChatCompletionMessage{{Role: "user", Content: "hello there"}},
+	}
+	populateSessionTransitionFields(turn1)
+	require.Empty(t, turn1.PreviousModel, "first turn has no prior model")
+	recordSessionTurn(turn1, responseUsageMetrics{promptTokens: 10, completionTokens: 20}, sessiontelemetry.TurnPricing{})
+
+	// Same user + same first user message => same derived session.
+	turn2 := &RequestContext{
+		RequestID:    "req-2",
+		RequestModel: "model-b",
+		Headers:      map[string]string{"x-authz-user-id": "user-7"},
+		ChatCompletionMessages: []ChatCompletionMessage{
+			{Role: "user", Content: "hello there"},
+			{Role: "assistant", Content: "hi"},
+			{Role: "user", Content: "follow up"},
+		},
+	}
+	populateSessionTransitionFields(turn2)
+
+	require.Equal(t, turn1.SessionID, turn2.SessionID, "session must be stable across turns")
+	assert.Equal(t, "model-a", turn2.PreviousModel)
+}

--- a/src/semantic-router/pkg/sessiontelemetry/last_model.go
+++ b/src/semantic-router/pkg/sessiontelemetry/last_model.go
@@ -1,0 +1,131 @@
+package sessiontelemetry
+
+import (
+	"sync"
+	"time"
+)
+
+// maxLastModelSessions caps the number of sessions tracked by the last-model
+// store to bound memory. It is a var (not a const) so tests can exercise the
+// eviction path without inserting tens of thousands of entries.
+var maxLastModelSessions = 50_000
+
+type lastModelState struct {
+	model    string
+	lastSeen time.Time
+}
+
+// lastModelStore remembers the most recent model used per session so the next
+// turn can populate the previous-model signal that the model-switch gate needs.
+// It is in-memory and per-replica (lost on restart), matching the existing
+// telemetry and transition stores; durable cross-replica persistence is tracked
+// as follow-up debt.
+type lastModelStore struct {
+	mu       sync.Mutex
+	sessions map[string]*lastModelState
+	nowFn    func() time.Time
+}
+
+var globalLastModelStore = &lastModelStore{
+	sessions: make(map[string]*lastModelState),
+	nowFn:    time.Now,
+}
+
+// RecordLastModel stores model as the most recent model for sessionID. Empty
+// sessionID or model are ignored so the store never grows on unresolvable
+// sessions. Entries older than ttl are evicted, and a size cap bounds total
+// growth.
+func RecordLastModel(sessionID, model string) {
+	if sessionID == "" || model == "" {
+		return
+	}
+	s := globalLastModelStore
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.nowFn()
+	s.evictExpiredLocked(now)
+	st := s.sessions[sessionID]
+	if st == nil {
+		if len(s.sessions) >= maxLastModelSessions {
+			s.evictOldestLocked()
+		}
+		st = &lastModelState{}
+		s.sessions[sessionID] = st
+	}
+	st.model = model
+	st.lastSeen = now
+}
+
+// GetLastModel returns the most recent model recorded for sessionID and whether
+// a non-expired entry exists.
+func GetLastModel(sessionID string) (string, bool) {
+	if sessionID == "" {
+		return "", false
+	}
+	s := globalLastModelStore
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := s.sessions[sessionID]
+	if st == nil {
+		return "", false
+	}
+	if s.nowFn().Sub(st.lastSeen) > ttl {
+		delete(s.sessions, sessionID)
+		return "", false
+	}
+	return st.model, true
+}
+
+func (s *lastModelStore) evictExpiredLocked(t time.Time) {
+	for k, v := range s.sessions {
+		if t.Sub(v.lastSeen) > ttl {
+			delete(s.sessions, k)
+		}
+	}
+}
+
+// evictOldestLocked removes the single least-recently-seen entry. It is a
+// best-effort safety valve for the size cap when TTL eviction did not free room.
+func (s *lastModelStore) evictOldestLocked() {
+	var oldestKey string
+	var oldestSeen time.Time
+	first := true
+	for k, v := range s.sessions {
+		if first || v.lastSeen.Before(oldestSeen) {
+			oldestKey = k
+			oldestSeen = v.lastSeen
+			first = false
+		}
+	}
+	if oldestKey != "" {
+		delete(s.sessions, oldestKey)
+	}
+}
+
+// ResetLastModelForTesting clears the in-memory last-model store (tests only).
+func ResetLastModelForTesting() {
+	s := globalLastModelStore
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions = make(map[string]*lastModelState)
+}
+
+// setLastModelNowForTesting overrides the store clock for deterministic TTL
+// tests. Passing nil restores time.Now.
+func setLastModelNowForTesting(fn func() time.Time) {
+	s := globalLastModelStore
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if fn == nil {
+		fn = time.Now
+	}
+	s.nowFn = fn
+}
+
+// lastModelSessionCount returns the number of tracked sessions (tests only).
+func lastModelSessionCount() int {
+	s := globalLastModelStore
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.sessions)
+}

--- a/src/semantic-router/pkg/sessiontelemetry/last_model_test.go
+++ b/src/semantic-router/pkg/sessiontelemetry/last_model_test.go
@@ -1,0 +1,74 @@
+package sessiontelemetry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecordAndGetLastModel(t *testing.T) {
+	ResetLastModelForTesting()
+	RecordLastModel("sess-1", "model-a")
+	got, ok := GetLastModel("sess-1")
+	if !ok || got != "model-a" {
+		t.Fatalf("GetLastModel = (%q,%v), want (model-a,true)", got, ok)
+	}
+}
+
+func TestGetLastModelMissing(t *testing.T) {
+	ResetLastModelForTesting()
+	if got, ok := GetLastModel("nope"); ok || got != "" {
+		t.Fatalf(`GetLastModel(missing) = (%q,%v), want ("",false)`, got, ok)
+	}
+}
+
+func TestRecordLastModelOverwritesWithLatest(t *testing.T) {
+	ResetLastModelForTesting()
+	RecordLastModel("s", "a")
+	RecordLastModel("s", "b")
+	if got, _ := GetLastModel("s"); got != "b" {
+		t.Fatalf("expected latest model b, got %q", got)
+	}
+}
+
+func TestRecordLastModelIgnoresEmpty(t *testing.T) {
+	ResetLastModelForTesting()
+	RecordLastModel("", "a")
+	RecordLastModel("s", "")
+	if _, ok := GetLastModel(""); ok {
+		t.Fatal("empty session id must not be stored")
+	}
+	if _, ok := GetLastModel("s"); ok {
+		t.Fatal("empty model must not be stored")
+	}
+}
+
+func TestGetLastModelExpiresAfterTTL(t *testing.T) {
+	ResetLastModelForTesting()
+	base := time.Now()
+	setLastModelNowForTesting(func() time.Time { return base })
+	defer setLastModelNowForTesting(nil)
+
+	RecordLastModel("s", "a")
+	setLastModelNowForTesting(func() time.Time { return base.Add(ttl + time.Minute) })
+	if got, ok := GetLastModel("s"); ok || got != "" {
+		t.Fatalf("expired entry should be gone, got (%q,%v)", got, ok)
+	}
+}
+
+func TestRecordLastModelEnforcesSizeCap(t *testing.T) {
+	ResetLastModelForTesting()
+	base := time.Now()
+	setLastModelNowForTesting(func() time.Time { return base }) // freeze: nothing TTL-expires
+	defer setLastModelNowForTesting(nil)
+
+	orig := maxLastModelSessions
+	maxLastModelSessions = 3
+	defer func() { maxLastModelSessions = orig }()
+
+	for _, id := range []string{"s1", "s2", "s3", "s4", "s5"} {
+		RecordLastModel(id, "m")
+	}
+	if n := lastModelSessionCount(); n > maxLastModelSessions {
+		t.Fatalf("session count %d exceeds cap %d", n, maxLastModelSessions)
+	}
+}


### PR DESCRIPTION
Refs #1753

## Purpose

- **What does this PR change?** Makes the auditable `ModelSwitchGate` actually usable for **Chat Completions** traffic by giving it the previous-model signal it needs. It adds a small in-memory, session-keyed "last model used" store, records each turn's model at response time, and reads it back as `ctx.PreviousModel` during the next turn's request prep.
- **Why is this change needed?** #1753 (umbrella; under roadmap theme #1513) is blocked for the dominant API surface by a single gap: `pkg/extproc/session_transition.go` left `ctx.PreviousModel` empty for Chat Completions (`// TODO: populate PreviousModel ... once per-turn model history is available`). With it empty, the gate treats `previous_model` as a missing signal and **falls back to audit-only for every chat request** (even in enforce mode), emitting `model_switch_gate_enforce_unavailable`. Response API already worked because it derives the previous model from the conversation chain. This PR closes exactly that gap.
- **Which module(s) does this affect?** `Router` (Go).

### Design

- New `pkg/sessiontelemetry/last_model.go`: thread-safe `map[sessionID]{model,lastSeen}` with `RecordLastModel` / `GetLastModel`, a 1h TTL, and a size cap — mirroring the existing `telemetry.go` and `transition.go` store idioms.
- Write at response time in `recordSessionTurn` (Chat path only), keyed on `ctx.SessionID` — the **same** key the read side uses; the write→read race is impossible (write is turn N's response, read is turn N+1's request).
- Read in `populateSessionTransitionFields`, replacing the TODO. Response API behavior is untouched (it still derives previous model from the conversation chain).
- Additive and gated by the existing `model_switch_gate.enabled`; no decision-contract change.

### Scope / follow-ups (out of this PR)

- DSL primitives (#1744–#1748), CRM (#1752), offline weight updates (#1750) — separate workstreams.
- The store is **in-memory and per-replica** (lost on restart, not shared across horizontally-scaled routers), matching the existing telemetry/transition stores. Durable/shared previous-model persistence is recorded as follow-up debt in `pl-0030`; until then enforce-mode continuity is best-effort and the gate still logs `model_switch_gate_enforce_unavailable` when the signal is genuinely absent (first turn, unresolvable session, or after a restart).

## Test Plan

Run from the router module (multi-module repo; CGO + prebuilt Rust bindings on `LD_LIBRARY_PATH`):

- `go test -race ./pkg/sessiontelemetry/` — store: record/get, overwrite, ignore-empty, TTL expiry, size-cap eviction.
- `go test -race ./pkg/extproc/ -run 'SessionTransition|ChatCompletions|ModelSwitchGate|MaybeEmit'` — wiring:
  - `…PopulatesPreviousModelFromStore` and `…NoPriorModelLeavesEmpty`
  - `TestChatCompletionsModelContinuityAcrossTurns` — full write→read across two turns (turn 1 records `model-a`, turn 2 recovers it as `PreviousModel`).
  - existing gate/session tests still pass (audit-only fallback on empty previous-model preserved).
- `go vet ./pkg/sessiontelemetry/ ./pkg/extproc/ ./pkg/config/`, `gofmt -l`, markdownlint on the plan doc.

## Test Result

- All targeted tests **PASS** with `-race`; full `pkg/config` suite passes; no regressions in existing session/gate tests.
- `gofmt`/`go vet`/markdownlint: clean.
- Behavior change is config-gated and Chat-only; Response API path byte-for-byte unchanged. No wire-format change, so no E2E update is required for this slice.
- Follow-up risk: per-replica in-memory continuity (durable store tracked in `pl-0030`).
