### PR TITLE
[Docs] Add Agentgateway installation guide

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -27,6 +27,8 @@ on:
       # Per-profile e2e change detection
       e2e_istio:
         value: ${{ jobs.filter.outputs.e2e_istio }}
+      e2e_agentgateway:
+        value: ${{ jobs.filter.outputs.e2e_agentgateway }}
       e2e_kubernetes:
         value: ${{ jobs.filter.outputs.e2e_kubernetes }}
       e2e_aibrix:
@@ -77,6 +79,7 @@ jobs:
       agent_exec: ${{ steps.changes.outputs.agent_exec }}
       # Per-profile e2e outputs
       e2e_istio: ${{ steps.changes.outputs.e2e_istio }}
+      e2e_agentgateway: ${{ steps.changes.outputs.e2e_agentgateway }}
       e2e_kubernetes: ${{ steps.changes.outputs.e2e_kubernetes }}
       e2e_aibrix: ${{ steps.changes.outputs.e2e_aibrix }}
       e2e_dashboard: ${{ steps.changes.outputs.e2e_dashboard }}
@@ -178,6 +181,9 @@ jobs:
             e2e_istio:
               - 'e2e/profiles/istio/**'
               - 'deploy/kubernetes/istio/**'
+            e2e_agentgateway:
+              - 'e2e/profiles/agentgateway/**'
+              - 'deploy/kubernetes/agentgateway/**'
             e2e_kubernetes:
               - 'e2e/profiles/ai-gateway/**'
               - 'deploy/kubernetes/ai-gateway/**'

--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -51,6 +51,7 @@ jobs:
           # Only run affected profiles for PRs
           profiles=()
           [[ "${{ needs.changes.outputs.e2e_istio }}" == "true" ]] && profiles+=("istio")
+          [[ "${{ needs.changes.outputs.e2e_agentgateway }}" == "true" ]] && profiles+=("agentgateway")
           [[ "${{ needs.changes.outputs.e2e_kubernetes }}" == "true" ]] && profiles+=("kubernetes")
           [[ "${{ needs.changes.outputs.e2e_aibrix }}" == "true" ]] && profiles+=("aibrix")
           [[ "${{ needs.changes.outputs.e2e_dashboard }}" == "true" ]] && profiles+=("dashboard")

--- a/deploy/kubernetes/agentgateway/demo-llm.yaml
+++ b/deploy/kubernetes/agentgateway/demo-llm.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-llama3-8b-instruct
+  template:
+    metadata:
+      labels:
+        app: vllm-llama3-8b-instruct
+    spec:
+      containers:
+      - name: vllm-sim
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.5.0
+        imagePullPolicy: IfNotPresent
+        args:
+        - --model
+        - base-model
+        - --port
+        - "8000"
+        - --max-loras
+        - "6"
+        - --lora-modules
+        - '{"name": "math-expert"}'
+        - '{"name": "science-expert"}'
+        - '{"name": "social-expert"}'
+        - '{"name": "humanities-expert"}'
+        - '{"name": "law-expert"}'
+        - '{"name": "general-expert"}'
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: default
+  labels:
+    app: vllm-llama3-8b-instruct
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    targetPort: 8000
+    protocol: TCP
+  selector:
+    app: vllm-llama3-8b-instruct

--- a/deploy/kubernetes/agentgateway/extproc-policy.yaml
+++ b/deploy/kubernetes/agentgateway/extproc-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: semantic-router-extproc
+  namespace: agentgateway-system
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: agentgateway-proxy
+  traffic:
+    extProc:
+      backendRef:
+        name: semantic-router
+        namespace: agentgateway-system
+        port: 50051
+      processingOptions:
+        requestHeaderMode: Send
+        requestBodyMode: Buffered
+        responseHeaderMode: Send
+        responseBodyMode: Buffered
+        allowModeOverride: true

--- a/deploy/kubernetes/agentgateway/gateway.yaml
+++ b/deploy/kubernetes/agentgateway/gateway.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway-proxy
+  namespace: agentgateway-system
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/deploy/kubernetes/agentgateway/routing-resources.yaml
+++ b/deploy/kubernetes/agentgateway/routing-resources.yaml
@@ -1,0 +1,27 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: semantic-router-vllm
+  namespace: agentgateway-system
+spec:
+  ai:
+    provider:
+      openai: {}
+      host: vllm-llama3-8b-instruct.default.svc.cluster.local
+      port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: semantic-router-vllm
+  namespace: agentgateway-system
+spec:
+  parentRefs:
+  - name: agentgateway-proxy
+    namespace: agentgateway-system
+  rules:
+  - backendRefs:
+    - name: semantic-router-vllm
+      namespace: agentgateway-system
+      group: agentgateway.dev
+      kind: AgentgatewayBackend

--- a/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
@@ -1,0 +1,433 @@
+config:
+  version: v0.3
+  listeners: []
+  providers:
+    defaults:
+      default_model: general-expert
+      reasoning_families:
+        deepseek:
+          type: chat_template_kwargs
+          parameter: thinking
+        qwen3:
+          type: chat_template_kwargs
+          parameter: enable_thinking
+        gpt-oss:
+          type: reasoning_effort
+          parameter: reasoning_effort
+        gpt:
+          type: reasoning_effort
+          parameter: reasoning_effort
+      default_reasoning_effort: high
+    models:
+      - name: base-model
+        reasoning_family: qwen3
+        backend_refs:
+          - name: local-vllm
+            endpoint: vllm-llama3-8b-instruct.default.svc.cluster.local:8000
+            weight: 1
+  routing:
+    decisions:
+      - name: business_decision
+        description: Business and management related queries
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: business
+        modelRefs:
+          - model: base-model
+            lora_name: social-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a senior business consultant and strategic advisor with expertise in corporate strategy, operations management, financial analysis, marketing, and organizational development. Provide practical, actionable business advice backed by proven methodologies and industry best practices. Consider market dynamics, competitive landscape, and stakeholder interests in your recommendations.
+              mode: replace
+      - name: law_decision
+        description: Legal questions and law-related topics
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: law
+        modelRefs:
+          - model: base-model
+            lora_name: law-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a knowledgeable legal expert with comprehensive understanding of legal principles, case law, statutory interpretation, and legal procedures across multiple jurisdictions. Provide accurate legal information and analysis while clearly stating that your responses are for informational purposes only and do not constitute legal advice. Always recommend consulting with qualified legal professionals for specific legal matters.
+              mode: replace
+      - name: psychology_decision
+        description: Psychology and mental health topics
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: psychology
+        modelRefs:
+          - model: base-model
+            lora_name: humanities-expert
+            use_reasoning: false
+        plugins:
+          - type: semantic-cache
+            configuration:
+              enabled: true
+              similarity_threshold: 0.8
+      - name: biology_decision
+        description: Biology and life sciences questions
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: biology
+        modelRefs:
+          - model: base-model
+            lora_name: science-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a biology expert with comprehensive knowledge spanning molecular biology, genetics, cell biology, ecology, evolution, anatomy, physiology, and biotechnology. Explain biological concepts with scientific accuracy, use appropriate terminology, and provide examples from current research. Connect biological principles to real-world applications and emphasize the interconnectedness of biological systems.
+              mode: replace
+      - name: chemistry_decision
+        description: Chemistry and chemical sciences questions
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: chemistry
+        modelRefs:
+          - model: base-model
+            lora_name: science-expert
+            use_reasoning: true
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a chemistry expert specializing in chemical reactions, molecular structures, and laboratory techniques. Provide detailed, step-by-step explanations.
+              mode: replace
+      - name: history_decision
+        description: Historical questions and cultural topics
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: history
+        modelRefs:
+          - model: base-model
+            lora_name: humanities-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a historian with expertise across different time periods and cultures. Provide accurate historical context and analysis.
+              mode: replace
+      - name: health_decision
+        description: Health and medical information queries
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: health
+        modelRefs:
+          - model: base-model
+            lora_name: science-expert
+            use_reasoning: false
+        plugins:
+          - type: semantic-cache
+            configuration:
+              enabled: true
+              similarity_threshold: 0.8
+      - name: economics_decision
+        description: Economics and financial topics
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: economics
+        modelRefs:
+          - model: base-model
+            lora_name: social-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are an economics expert with deep understanding of microeconomics, macroeconomics, econometrics, financial markets, monetary policy, fiscal policy, international trade, and economic theory. Analyze economic phenomena using established economic principles, provide data-driven insights, and explain complex economic concepts in accessible terms. Consider both theoretical frameworks and real-world applications in your responses.
+              mode: replace
+      - name: math_decision
+        description: Mathematics and quantitative reasoning
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: math
+        modelRefs:
+          - model: base-model
+            lora_name: math-expert
+            use_reasoning: true
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a mathematics expert. Provide step-by-step solutions, show your work clearly, and explain mathematical concepts in an understandable way.
+              mode: replace
+      - name: physics_decision
+        description: Physics and physical sciences
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: physics
+        modelRefs:
+          - model: base-model
+            lora_name: science-expert
+            use_reasoning: true
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a physics expert with deep understanding of physical laws and phenomena. Provide clear explanations with mathematical derivations when appropriate.
+              mode: replace
+      - name: computer_science_decision
+        description: Computer science and programming
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: computer science
+        modelRefs:
+          - model: base-model
+            lora_name: science-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a computer science expert with knowledge of algorithms, data structures, programming languages, and software engineering. Provide clear, practical solutions with code examples when helpful.
+              mode: replace
+      - name: philosophy_decision
+        description: Philosophy and ethical questions
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: philosophy
+        modelRefs:
+          - model: base-model
+            lora_name: humanities-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a philosophy expert with comprehensive knowledge of philosophical traditions, ethical theories, logic, metaphysics, epistemology, political philosophy, and the history of philosophical thought. Engage with complex philosophical questions by presenting multiple perspectives, analyzing arguments rigorously, and encouraging critical thinking. Draw connections between philosophical concepts and contemporary issues while maintaining intellectual honesty about the complexity and ongoing nature of philosophical debates.
+              mode: replace
+      - name: engineering_decision
+        description: Engineering and technical problem-solving
+        priority: 10
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: engineering
+        modelRefs:
+          - model: base-model
+            lora_name: science-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are an engineering expert with knowledge across multiple engineering disciplines including mechanical, electrical, civil, chemical, software, and systems engineering. Apply engineering principles, design methodologies, and problem-solving approaches to provide practical solutions. Consider safety, efficiency, sustainability, and cost-effectiveness in your recommendations. Use technical precision while explaining concepts clearly, and emphasize the importance of proper engineering practices and standards.
+              mode: replace
+      - name: thinking_decision
+        description: Complex reasoning and multi-step thinking
+        priority: 20
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              rule_name: thinking
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: true
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are a thinking expert, should think multiple steps before answering. Please answer the question step by step.
+              mode: replace
+      - name: general_decision
+        description: General knowledge and miscellaneous topics
+        priority: 1
+        rules:
+          operator: OR
+          conditions:
+            - type: domain
+              name: other
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: semantic-cache
+            configuration:
+              enabled: true
+              similarity_threshold: 0.75
+    signals:
+      keywords:
+        - category: thinking
+          operator: OR
+          keywords:
+            - urgent
+            - immediate
+            - asap
+            - think
+            - careful
+          case_sensitive: false
+      domains:
+        - name: business
+          description: Business, corporate strategy, management, finance, marketing
+        - name: law
+          description: Legal principles, case law, statutory interpretation, legal procedures
+        - name: psychology
+          description: Cognitive processes, behavioral patterns, mental health, developmental psychology
+        - name: biology
+          description: Molecular biology, genetics, cell biology, ecology, evolution, anatomy
+        - name: chemistry
+          description: Chemical reactions, molecular structures, laboratory techniques
+        - name: history
+          description: Historical events, time periods, cultures, civilizations
+        - name: health
+          description: Anatomy, physiology, diseases, treatments, preventive care, nutrition
+        - name: economics
+          description: Microeconomics, macroeconomics, financial markets, monetary policy, trade
+        - name: math
+          description: Mathematics, algebra, calculus, geometry, statistics
+        - name: physics
+          description: Physical laws, mechanics, thermodynamics, electromagnetism, quantum physics
+        - name: computer science
+          description: Algorithms, data structures, programming, software engineering
+        - name: philosophy
+          description: Philosophical traditions, ethics, logic, metaphysics, epistemology
+        - name: engineering
+          description: Engineering disciplines, design, problem-solving, systems
+        - name: other
+          description: General knowledge and miscellaneous topics
+    modelCards:
+      - name: base-model
+        loras:
+          - name: science-expert
+            description: 'Specialized for science domains: biology, chemistry, physics, health, engineering'
+          - name: social-expert
+            description: 'Optimized for social sciences: business, economics'
+          - name: math-expert
+            description: Fine-tuned for mathematics and quantitative reasoning
+          - name: law-expert
+            description: Specialized for legal questions and law-related topics
+          - name: humanities-expert
+            description: 'Optimized for humanities: psychology, history, philosophy'
+          - name: general-expert
+            description: General-purpose adapter for diverse topics
+      - name: general-expert
+  global:
+    router:
+      strategy: priority
+    services:
+      response_api:
+        enabled: true
+        store_backend: memory
+        ttl_seconds: 86400
+        max_responses: 1000
+      router_replay:
+        store_backend: memory
+        ttl_seconds: 2592000
+        async_writes: false
+      api:
+        batch_classification:
+          max_batch_size: 100
+          concurrency_threshold: 5
+          max_concurrency: 8
+          metrics:
+            enabled: true
+            detailed_goroutine_tracking: true
+            high_resolution_timing: false
+            sample_rate: 1.0
+            duration_buckets:
+              - 0.001
+              - 0.005
+              - 0.01
+              - 0.025
+              - 0.05
+              - 0.1
+              - 0.25
+              - 0.5
+              - 1
+              - 2.5
+              - 5
+              - 10
+              - 30
+            size_buckets:
+              - 1
+              - 2
+              - 5
+              - 10
+              - 20
+              - 50
+              - 100
+              - 200
+      observability:
+        tracing:
+          enabled: false
+          provider: opentelemetry
+          exporter:
+            type: otlp
+            endpoint: jaeger:4317
+            insecure: true
+          sampling:
+            type: always_on
+            rate: 1.0
+          resource:
+            service_name: vllm-semantic-router
+            service_version: v0.1.0
+            deployment_environment: development
+    stores:
+      semantic_cache:
+        enabled: true
+        backend_type: memory
+        similarity_threshold: 0.8
+        max_entries: 1000
+        ttl_seconds: 3600
+        eviction_policy: fifo
+        embedding_model: mmbert
+      memory:
+        embedding_model: mmbert
+      vector_store:
+        embedding_model: mmbert
+    integrations:
+      tools:
+        enabled: true
+        top_k: 3
+        similarity_threshold: 0.2
+        tools_db_path: config/tools_db.json
+        fallback_to_empty: true

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,6 +23,7 @@ Standard CI-backed profiles:
 - **multimodal-routing**: Image-modality EmbeddingSignal routing via the multi-modal-embed-small model
 - **llm-d**: LLM-D inference-gateway health plus a minimal router smoke path
 - **istio**: Istio service mesh sidecar, traffic, mTLS, and tracing behavior
+- **agentgateway**: Agentgateway gateway controller routing and extproc policy enforcement behavior
 - **production-stack**: HA, load-balancing, failover, and throughput behavior
 - **response-api**: Responses API coverage across memory, Redis, and Redis Cluster backends under one CI check
 - **ml-model-selection**: ML-based model-selection behavior
@@ -51,6 +52,7 @@ Manual-only profiles:
 | `multimodal-routing` | `chat-completions-request` | Image-modality embedding-signal routing |
 | `llm-d` | `chat-completions-request` | llm-d inference-gateway health |
 | `istio` | `chat-completions-request` | Sidecar, traffic, mTLS, and tracing |
+| `agentgateway` | `chat-completions-request` | Agentgateway gateway controller and extproc behavior |
 | `production-stack` | `chat-completions-request` | HA, failover, load-balancing, throughput |
 | `response-api` | none | Responses API behavior across memory, Redis, and Redis Cluster backends |
 | `ml-model-selection` | `chat-completions-request`, `domain-classify` | ML selector behavior |

--- a/e2e/profiles/agentgateway/profile.go
+++ b/e2e/profiles/agentgateway/profile.go
@@ -1,0 +1,155 @@
+package agentgateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helm"
+	"github.com/vllm-project/semantic-router/e2e/pkg/testmatrix"
+
+	// Import testcases package to register all test cases via their init() functions
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
+)
+
+const (
+	agentGatewayVersion      = "v1.3.0-alpha.1"
+	agentGatewayNamespace    = "agentgateway-system"
+	agentGatewayProxyService = "agentgateway-proxy"
+	semanticRouterDeployment = "semantic-router"
+	semanticRouterValuesFile = "deploy/kubernetes/agentgateway/semantic-router-values/values.yaml"
+)
+
+// Profile implements the AgentGateway test profile.
+type Profile struct {
+	verbose bool
+}
+
+type setupState struct {
+	gatewayAPICRDsInstalled bool
+	agentGatewayInstalled   bool
+	gatewayProxyCreated     bool
+	demoLLMDeployed         bool
+	semanticRouterDeployed  bool
+	routingResourcesApplied bool
+	extProcPolicyApplied    bool
+}
+
+// NewProfile creates a new AgentGateway profile.
+func NewProfile() *Profile {
+	return &Profile{}
+}
+
+// Name returns the profile name.
+func (p *Profile) Name() string {
+	return "agentgateway"
+}
+
+// Description returns the profile description.
+func (p *Profile) Description() string {
+	return fmt.Sprintf("Tests Semantic Router through AgentGateway (version: %s)", agentGatewayVersion)
+}
+
+// Setup deploys all required components for AgentGateway testing.
+func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error {
+	p.verbose = opts.Verbose
+	p.log("Setting up AgentGateway test environment")
+
+	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+	state := &setupState{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			p.log("Panic during setup, cleaning up...")
+			p.cleanupPartialDeployment(ctx, opts, state)
+			panic(r)
+		}
+	}()
+
+	p.log("Step 1/7: Installing Kubernetes Gateway API CRDs")
+	if err := p.installGatewayAPICRDs(ctx, opts); err != nil {
+		return p.failSetup(ctx, opts, state, fmt.Errorf("install Gateway API CRDs: %w", err))
+	}
+	state.gatewayAPICRDsInstalled = true
+
+	p.log("Step 2/7: Installing AgentGateway CRDs and controller")
+	if err := p.installAgentGateway(ctx, deployer, opts); err != nil {
+		return p.failSetup(ctx, opts, state, fmt.Errorf("install AgentGateway: %w", err))
+	}
+	state.agentGatewayInstalled = true
+
+	p.log("Step 3/7: Creating AgentGateway proxy")
+	if err := p.applyManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/gateway.yaml"); err != nil {
+		return p.failSetup(ctx, opts, state, fmt.Errorf("create Gateway proxy: %w", err))
+	}
+	state.gatewayProxyCreated = true
+
+	p.log("Step 4/7: Deploying Demo LLM backend")
+	if err := p.deployDemoLLM(ctx, deployer, opts); err != nil {
+		return p.failSetup(ctx, opts, state, fmt.Errorf("deploy demo LLM: %w", err))
+	}
+	state.demoLLMDeployed = true
+
+	p.log("Step 5/7: Deploying Semantic Router")
+	if err := p.deploySemanticRouter(ctx, deployer, opts); err != nil {
+		return p.failSetup(ctx, opts, state, fmt.Errorf("deploy Semantic Router: %w", err))
+	}
+	state.semanticRouterDeployed = true
+
+	p.log("Step 6/7: Applying AgentGateway routing resources")
+	if err := p.applyManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/routing-resources.yaml"); err != nil {
+		return p.failSetup(ctx, opts, state, fmt.Errorf("apply routing resources: %w", err))
+	}
+	state.routingResourcesApplied = true
+
+	p.log("Step 7/7: Attaching Semantic Router as ExtProc")
+	if err := p.applyManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/extproc-policy.yaml"); err != nil {
+		return p.failSetup(ctx, opts, state, fmt.Errorf("apply ExtProc policy: %w", err))
+	}
+	state.extProcPolicyApplied = true
+
+	p.log("AgentGateway test environment setup complete")
+	return nil
+}
+
+// Teardown cleans up all deployed resources.
+func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions) error {
+	p.verbose = opts.Verbose
+	p.log("Tearing down AgentGateway test environment")
+
+	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+
+	_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/extproc-policy.yaml")
+	_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/routing-resources.yaml")
+	_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/gateway.yaml")
+	_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/demo-llm.yaml")
+	_ = deployer.Uninstall(ctx, semanticRouterDeployment, agentGatewayNamespace)
+	_ = deployer.Uninstall(ctx, "agentgateway", agentGatewayNamespace)
+	_ = deployer.Uninstall(ctx, "agentgateway-crds", agentGatewayNamespace)
+
+	p.log("AgentGateway test environment teardown complete")
+	return nil
+}
+
+// GetTestCases returns the list of test cases for this profile.
+func (p *Profile) GetTestCases() []string {
+	return testmatrix.Combine(
+		testmatrix.RouterSmoke,
+		[]string{"agentgateway-traffic-routing"},
+	)
+}
+
+// GetServiceConfig returns the service configuration for accessing the AgentGateway proxy.
+func (p *Profile) GetServiceConfig() framework.ServiceConfig {
+	return framework.ServiceConfig{
+		Name:        agentGatewayProxyService,
+		Namespace:   agentGatewayNamespace,
+		ServicePort: "80",
+	}
+}
+
+func (p *Profile) log(format string, args ...interface{}) {
+	if p.verbose {
+		fmt.Printf("[agentgateway] "+format+"\n", args...)
+	}
+}

--- a/e2e/profiles/agentgateway/runtime.go
+++ b/e2e/profiles/agentgateway/runtime.go
@@ -1,0 +1,120 @@
+package agentgateway
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helm"
+)
+
+const (
+	gatewayAPICRDsURL           = "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml"
+	timeoutAgentGatewayInstall  = 10 * time.Minute
+	timeoutSemanticRouterDeploy = 20 * time.Minute
+	timeoutDemoLLMDeploy        = 10 * time.Minute
+)
+
+func (p *Profile) installGatewayAPICRDs(ctx context.Context, opts *framework.SetupOptions) error {
+	return p.runKubectl(ctx, opts.KubeConfig,
+		"apply", "--server-side", "--force-conflicts", "-f", gatewayAPICRDsURL,
+	)
+}
+
+func (p *Profile) installAgentGateway(ctx context.Context, deployer *helm.Deployer, opts *framework.SetupOptions) error {
+	crdsRelease := helm.InstallOptions{
+		ReleaseName: "agentgateway-crds",
+		Chart:       "oci://cr.agentgateway.dev/charts/agentgateway-crds",
+		Namespace:   agentGatewayNamespace,
+		Version:     agentGatewayVersion,
+		Set: map[string]string{
+			"controller.image.pullPolicy": "Always",
+		},
+		Wait:    true,
+		Timeout: "10m",
+	}
+	if err := deployer.Install(ctx, crdsRelease); err != nil {
+		return fmt.Errorf("install agentgateway-crds: %w", err)
+	}
+
+	controllerRelease := helm.InstallOptions{
+		ReleaseName: "agentgateway",
+		Chart:       "oci://cr.agentgateway.dev/charts/agentgateway",
+		Namespace:   agentGatewayNamespace,
+		Version:     agentGatewayVersion,
+		Set: map[string]string{
+			"controller.image.pullPolicy":                                      "Always",
+			"controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES": "true",
+		},
+		Wait:    true,
+		Timeout: "10m",
+	}
+	return deployer.Install(ctx, controllerRelease)
+}
+
+func (p *Profile) deployDemoLLM(ctx context.Context, deployer *helm.Deployer, opts *framework.SetupOptions) error {
+	if err := p.applyManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/demo-llm.yaml"); err != nil {
+		return err
+	}
+	return deployer.WaitForDeployment(ctx, "default", "vllm-llama3-8b-instruct", timeoutDemoLLMDeploy)
+}
+
+func (p *Profile) deploySemanticRouter(ctx context.Context, deployer *helm.Deployer, opts *framework.SetupOptions) error {
+	release := helm.SemanticRouterRelease.Clone()
+	release.Namespace = agentGatewayNamespace
+	release.ValuesFiles = []string{semanticRouterValuesFile}
+	release.Set = map[string]string{
+		"image.repository": "ghcr.io/vllm-project/semantic-router/extproc",
+		"image.tag":        opts.ImageTag,
+		"image.pullPolicy": "Never",
+	}
+	if err := deployer.Install(ctx, release); err != nil {
+		return fmt.Errorf("install semantic-router: %w", err)
+	}
+	return deployer.WaitForDeployment(ctx, agentGatewayNamespace, semanticRouterDeployment, timeoutSemanticRouterDeploy)
+}
+
+func (p *Profile) failSetup(ctx context.Context, opts *framework.SetupOptions, state *setupState, err error) error {
+	p.log("ERROR: %v", err)
+	p.cleanupPartialDeployment(ctx, opts, state)
+	return err
+}
+
+func (p *Profile) cleanupPartialDeployment(ctx context.Context, opts *framework.SetupOptions, state *setupState) {
+	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
+	if state.extProcPolicyApplied {
+		_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/extproc-policy.yaml")
+	}
+	if state.routingResourcesApplied {
+		_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/routing-resources.yaml")
+	}
+	if state.semanticRouterDeployed {
+		_ = deployer.Uninstall(ctx, semanticRouterDeployment, agentGatewayNamespace)
+	}
+	if state.demoLLMDeployed {
+		_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/demo-llm.yaml")
+	}
+	if state.gatewayProxyCreated {
+		_ = p.deleteManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/gateway.yaml")
+	}
+	if state.agentGatewayInstalled {
+		_ = deployer.Uninstall(ctx, "agentgateway", agentGatewayNamespace)
+		_ = deployer.Uninstall(ctx, "agentgateway-crds", agentGatewayNamespace)
+	}
+}
+
+func (p *Profile) applyManifest(ctx context.Context, kubeConfig, manifest string) error {
+	return p.runKubectl(ctx, kubeConfig, "apply", "-f", manifest)
+}
+
+func (p *Profile) deleteManifest(ctx context.Context, kubeConfig, manifest string) error {
+	return p.runKubectl(ctx, kubeConfig, "delete", "-f", manifest, "--ignore-not-found=true")
+}
+
+func (p *Profile) runKubectl(ctx context.Context, kubeConfig string, args ...string) error {
+	args = append(args, "--kubeconfig", kubeConfig)
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	return cmd.Run()
+}

--- a/e2e/profiles/all/imports.go
+++ b/e2e/profiles/all/imports.go
@@ -2,6 +2,7 @@ package all
 
 import (
 	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	agentgateway "github.com/vllm-project/semantic-router/e2e/profiles/agentgateway"
 	aigateway "github.com/vllm-project/semantic-router/e2e/profiles/ai-gateway"
 	aibrix "github.com/vllm-project/semantic-router/e2e/profiles/aibrix"
 	authzrbac "github.com/vllm-project/semantic-router/e2e/profiles/authz-rbac"
@@ -33,6 +34,7 @@ var mockVLLMLocalImages = []framework.LocalImageBuild{
 }
 
 func init() {
+	register("agentgateway", func() framework.Profile { return agentgateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("kubernetes", func() framework.Profile { return aigateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("aibrix", func() framework.Profile { return aibrix.NewProfile() }, framework.ProfileCapabilities{})
 	register("authz-rbac", func() framework.Profile { return authzrbac.NewProfile() }, framework.ProfileCapabilities{})

--- a/e2e/testcases/agentgateway_traffic_routing.go
+++ b/e2e/testcases/agentgateway_traffic_routing.go
@@ -1,0 +1,88 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("agentgateway-traffic-routing", pkgtestcases.TestCase{
+		Description: "Test request routing through AgentGateway proxy to Semantic Router",
+		Tags:        []string{"agentgateway", "gateway", "routing"},
+		Fn:          testAgentGatewayTrafficRouting,
+	})
+}
+
+func testAgentGatewayTrafficRouting(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	const (
+		namespace = "agentgateway-system"
+		svcName   = "agentgateway-proxy"
+		localPort = "8080"
+	)
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Setting up port-forward to %s/%s\n", namespace, svcName)
+	}
+
+	stopFunc, err := helpers.StartPortForward(ctx, client, opts.RestConfig, namespace, svcName, localPort+":80", opts.Verbose)
+	if err != nil {
+		return fmt.Errorf("failed to start port-forward to AgentGateway proxy: %w", err)
+	}
+	defer stopFunc()
+
+	time.Sleep(2 * time.Second)
+
+	url := fmt.Sprintf("http://localhost:%s/v1/chat/completions", localPort)
+	payload := `{"model":"auto","messages":[{"role":"user","content":"What is the derivative of f(x) = x^3?"}],"max_tokens":64,"temperature":0}`
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Sending POST to %s\n", url)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request through AgentGateway: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Response status: %d, body length: %d\n", resp.StatusCode, len(body))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected HTTP 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code":     resp.StatusCode,
+			"response_length": len(body),
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Println("[Test] ✅ Traffic routing through AgentGateway successful")
+	}
+
+	return nil
+}

--- a/tools/agent/e2e-profile-map.yaml
+++ b/tools/agent/e2e-profile-map.yaml
@@ -91,6 +91,14 @@ profile_rules:
     paths:
       - e2e/profiles/istio/**
       - deploy/kubernetes/istio/**
+  agentgateway:
+    owner: e2e
+    coverage_role: agentgateway-integration
+    selection_mode: full-ci
+    summary: Integration coverage with Agentgateway's gateway controller, including backend routing and extproc policy enforcement.
+    paths:
+      - e2e/profiles/agentgateway/**
+      - deploy/kubernetes/agentgateway/**
   production-stack:
     owner: e2e
     coverage_role: production-ha-load-observability

--- a/tools/make/e2e.mk
+++ b/tools/make/e2e.mk
@@ -127,7 +127,8 @@ e2e-help: ## Show help for E2E testing
 	@echo ""
 	@echo "Available Profiles:"
 	@echo "  kubernetes       - Test Semantic Router with the default Kubernetes baseline"
-	@echo "  aibrix           - Test Semantic Router with vLLM AIBrix"
+	@echo "  agentgateway			 - Test Semantic Router with Agentgateway gateway controller"
+	@echo "  aibrix           - Test Semantic Router with vLLM AIBrix"F
 	@echo "  dynamo           - Test Semantic Router with Nvidia Dynamo (requires 3+ GPUs)"
 	@echo "  istio            - Test Semantic Router with Istio service mesh"
 	@echo "  llm-d            - Test Semantic Router with LLM-D"

--- a/website/docs/installation/k8s/agentgateway.md
+++ b/website/docs/installation/k8s/agentgateway.md
@@ -1,0 +1,323 @@
+# Install with AgentGateway
+
+This guide provides step-by-step instructions for integrating the vLLM Semantic Router with [AgentGateway](https://agentgateway.dev/) on Kubernetes. AgentGateway acts as the Gateway API data plane for OpenAI-compatible traffic, and vLLM Semantic Router runs as an Envoy ExtProc server that classifies each request and mutates the request body before AgentGateway forwards it to vLLM.
+
+## Architecture Overview
+
+The deployment consists of:
+
+- **vLLM Semantic Router**: Provides prompt classification, model selection, request mutation, and response processing through ExtProc
+- **AgentGateway**: Provides the Kubernetes Gateway API proxy, `AgentgatewayBackend`, `HTTPRoute`, and `AgentgatewayPolicy` resources
+- **Demo vLLM-compatible backend**: Serves a base model and LoRA adapters through an OpenAI-compatible API
+
+## Prerequisites
+
+Before starting, ensure you have the following tools installed:
+
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) - Kubernetes in Docker (Optional)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) - Kubernetes CLI
+- [Helm](https://helm.sh/docs/intro/install/) - Package manager for Kubernetes
+
+This guide requires AgentGateway `v1.3.0-alpha.1` or newer because it uses the ExtProc `processingOptions` and `allowModeOverride` fields that were added after `v1.2.1`.
+
+## Step 1: Create Kind Cluster (Optional)
+
+Create a local Kubernetes cluster for testing:
+
+```bash
+kind create cluster --name semantic-router-agentgateway
+
+# Verify cluster is ready
+kubectl wait --for=condition=Ready nodes --all --timeout=300s
+```
+
+## Step 2: Install AgentGateway
+
+Install the Kubernetes Gateway API CRDs and the AgentGateway control plane:
+
+```bash
+export AGENTGATEWAY_VERSION=v1.3.0-alpha.1
+
+kubectl apply --server-side --force-conflicts \
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+
+helm upgrade -i agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds \
+  --create-namespace \
+  --namespace agentgateway-system \
+  --version "${AGENTGATEWAY_VERSION}" \
+  --set controller.image.pullPolicy=Always
+
+helm upgrade -i agentgateway oci://cr.agentgateway.dev/charts/agentgateway \
+  --namespace agentgateway-system \
+  --version "${AGENTGATEWAY_VERSION}" \
+  --set controller.image.pullPolicy=Always \
+  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true \
+  --wait
+
+kubectl get pods -n agentgateway-system
+```
+
+## Step 3: Create an AgentGateway Proxy
+
+Create a Gateway that uses the AgentGateway GatewayClass:
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway-proxy
+  namespace: agentgateway-system
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+EOF
+
+kubectl wait --for=condition=Available deployment/agentgateway-proxy \
+  -n agentgateway-system \
+  --timeout=300s
+```
+
+## Step 4: Deploy Demo LLM
+
+Deploy a lightweight OpenAI-compatible simulator that serves `base-model` plus the LoRA adapter names selected by the Semantic Router demo configuration:
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-llama3-8b-instruct
+  template:
+    metadata:
+      labels:
+        app: vllm-llama3-8b-instruct
+    spec:
+      containers:
+      - name: vllm-sim
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.5.0
+        imagePullPolicy: IfNotPresent
+        args:
+        - --model
+        - base-model
+        - --port
+        - "8000"
+        - --max-loras
+        - "6"
+        - --lora-modules
+        - '{"name": "math-expert"}'
+        - '{"name": "science-expert"}'
+        - '{"name": "social-expert"}'
+        - '{"name": "humanities-expert"}'
+        - '{"name": "law-expert"}'
+        - '{"name": "general-expert"}'
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: default
+  labels:
+    app: vllm-llama3-8b-instruct
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    targetPort: 8000
+    protocol: TCP
+  selector:
+    app: vllm-llama3-8b-instruct
+EOF
+
+kubectl wait --for=condition=Available deployment/vllm-llama3-8b-instruct \
+  -n default \
+  --timeout=300s
+```
+
+## Step 5: Deploy vLLM Semantic Router
+
+Install the Semantic Router in the `agentgateway-system` namespace so the AgentGateway ExtProc policy can reference the `semantic-router` service directly:
+
+```bash
+helm install semantic-router oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version v0.0.0-latest \
+  --namespace agentgateway-system \
+  -f https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
+
+kubectl wait --for=condition=Available deployment/semantic-router \
+  -n agentgateway-system \
+  --timeout=600s
+```
+
+The values file configures Semantic Router to send traffic to `vllm-llama3-8b-instruct.default.svc.cluster.local:8000` and to select adapter names such as `math-expert`, `science-expert`, and `general-expert`.
+
+## Step 6: Create AgentGateway Routing Resources
+
+Create an `AgentgatewayBackend` for the vLLM-compatible backend and route OpenAI-compatible requests to it:
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: semantic-router-vllm
+  namespace: agentgateway-system
+spec:
+  ai:
+    provider:
+      openai: {}
+      host: vllm-llama3-8b-instruct.default.svc.cluster.local
+      port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: semantic-router-vllm
+  namespace: agentgateway-system
+spec:
+  parentRefs:
+  - name: agentgateway-proxy
+    namespace: agentgateway-system
+  rules:
+  - backendRefs:
+    - name: semantic-router-vllm
+      namespace: agentgateway-system
+      group: agentgateway.dev
+      kind: AgentgatewayBackend
+EOF
+```
+
+The `openai.model` field is intentionally omitted so AgentGateway uses the model name from the request body after Semantic Router selects the target model or LoRA adapter.
+
+## Step 7: Attach Semantic Router as ExtProc
+
+Create an `AgentgatewayPolicy` that sends request and response processing phases to the Semantic Router ExtProc service:
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: semantic-router-extproc
+  namespace: agentgateway-system
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: agentgateway-proxy
+  traffic:
+    extProc:
+      backendRef:
+        name: semantic-router
+        namespace: agentgateway-system
+        port: 50051
+      processingOptions:
+        requestHeaderMode: Send
+        requestBodyMode: Buffered
+        responseHeaderMode: Send
+        responseBodyMode: Buffered
+        allowModeOverride: true
+EOF
+```
+
+The demo uses buffered request bodies to match the existing Envoy AI Gateway and Istio examples. For large prompts, use `requestBodyMode: FullDuplexStreamed` together with a Semantic Router configuration that enables streamed body handling. AgentGateway does not support `Streamed` mode; `FullDuplexStreamed` is the only streaming option.
+
+## Testing the Deployment
+
+Start a port-forward to the AgentGateway proxy:
+
+```bash
+kubectl port-forward -n agentgateway-system svc/agentgateway-proxy 8080:80
+```
+
+In another terminal, send an OpenAI-compatible request with `"model": "auto"`:
+
+```bash
+curl -i -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "auto",
+    "messages": [
+      {"role": "user", "content": "What is the derivative of f(x) = x^3?"}
+    ],
+    "max_tokens": 64,
+    "temperature": 0
+  }'
+```
+
+Semantic Router should classify the math prompt, select the configured math route, and mutate the request model before AgentGateway forwards the request to the vLLM-compatible backend. Use `-i` to inspect Semantic Router response headers such as the selected model metadata.
+
+## Troubleshooting
+
+**AgentGateway proxy not ready:**
+
+```bash
+kubectl get gateway agentgateway-proxy -n agentgateway-system
+kubectl get deployment agentgateway-proxy -n agentgateway-system
+kubectl logs -n agentgateway-system deployment/agentgateway
+```
+
+**HTTPRoute or AgentGateway backend not accepted:**
+
+```bash
+kubectl describe httproute semantic-router-vllm -n agentgateway-system
+kubectl describe agentgatewaybackend semantic-router-vllm -n agentgateway-system
+```
+
+**Semantic Router not responding to ExtProc:**
+
+```bash
+kubectl get pods -n agentgateway-system
+kubectl get svc semantic-router -n agentgateway-system
+kubectl logs -n agentgateway-system deployment/semantic-router
+kubectl describe agentgatewaypolicy semantic-router-extproc -n agentgateway-system
+```
+
+**Demo LLM not responding:**
+
+```bash
+kubectl get pods -n default -l app=vllm-llama3-8b-instruct
+kubectl logs -n default deployment/vllm-llama3-8b-instruct
+```
+
+## Cleanup
+
+To remove the entire deployment:
+
+```bash
+kubectl delete agentgatewaypolicy semantic-router-extproc -n agentgateway-system
+kubectl delete httproute semantic-router-vllm -n agentgateway-system
+kubectl delete agentgatewaybackend semantic-router-vllm -n agentgateway-system
+kubectl delete gateway agentgateway-proxy -n agentgateway-system
+kubectl delete deployment vllm-llama3-8b-instruct -n default
+kubectl delete service vllm-llama3-8b-instruct -n default
+
+helm uninstall semantic-router -n agentgateway-system
+helm uninstall agentgateway -n agentgateway-system
+helm uninstall agentgateway-crds -n agentgateway-system
+
+kind delete cluster --name semantic-router-agentgateway
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -39,6 +39,7 @@ const sidebars: SidebarsConfig = {
           label: 'Install with Gateways',
           items: [
             'installation/k8s/ai-gateway',
+            'installation/k8s/agentgateway',
             'installation/k8s/istio',
             'installation/k8s/gateway-api-inference-extension',
           ],


### PR DESCRIPTION
## Purpose

- What does this PR change?  Add an installation guide for integrating with the [agentgateway](https://agentgateway.dev/) project. Replaces #1420 since agentgateway now supports semantic router out of the box
- Why is this change needed? Like Istio and Envoy AI Gateway, Agentgateway now supports semantic routing
- Which module(s) does this affect? `Docs`
## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results? Tested manually; for some reason, `make test-e2e` fails for me with any profile: 
```
Error: failed to create typed patch object (vllm-semantic-router-system/semantic-router; apps/v1, Kind=Deployment): .spec.template.spec.containers[name="semantic-router"].resources.observability: field not declared in schema
```
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [X] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [X] If the PR spans multiple modules, the title includes all relevant prefixes
- [X] Commits in this PR are signed off with `git commit -s`
- [X] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
