### PR TITLE
[Router] Fix path traversal in config rollback version handling

### DIFF
--- a/src/semantic-router/pkg/apiserver/route_config_deploy.go
+++ b/src/semantic-router/pkg/apiserver/route_config_deploy.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -25,6 +26,14 @@ var deployMu sync.Mutex
 
 // maxBackups is the maximum number of config backups to keep
 const maxBackups = 10
+
+// configVersionPattern matches the backup version identifier produced by
+// recordRouterConfigArtifacts, i.e. time.Now().Format("20060102-150405")
+// (YYYYMMDD-HHMMSS). The rollback endpoint accepts a caller-supplied version
+// and uses it to build a filesystem path, so the value is restricted to this
+// exact shape to prevent path traversal (e.g. "../../../etc/passwd") out of the
+// backup directory.
+var configVersionPattern = regexp.MustCompile(`^[0-9]{8}-[0-9]{6}$`)
 
 // RouterConfigUpdateRequest is the JSON body for a router config update request.
 type RouterConfigUpdateRequest struct {
@@ -73,6 +82,15 @@ func (s *ClassificationAPIServer) handleConfigRollback(w http.ResponseWriter, r 
 	}
 	if req.Version == "" {
 		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_INPUT", "version is required")
+		return
+	}
+	// Reject anything that is not a canonical backup version. req.Version is
+	// interpolated into a filesystem path below, so an unvalidated value such as
+	// "../../../etc/passwd" would escape the backup directory (filepath.Join
+	// resolves the "..") and read/restore an arbitrary file as the live config.
+	if !configVersionPattern.MatchString(req.Version) {
+		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_INPUT",
+			"version must match the backup timestamp format YYYYMMDD-HHMMSS")
 		return
 	}
 

--- a/src/semantic-router/pkg/apiserver/route_config_deploy_test.go
+++ b/src/semantic-router/pkg/apiserver/route_config_deploy_test.go
@@ -212,6 +212,103 @@ func mustMarshalCanonicalConfigYAML(t *testing.T, cfg *config.RouterConfig) []by
 	return data
 }
 
+func rollbackErrorCode(t *testing.T, body []byte) string {
+	t.Helper()
+
+	var resp struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal error response %q: %v", string(body), err)
+	}
+	return resp.Error.Code
+}
+
+func postRollback(t *testing.T, configPath, version string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"version": version})
+	if err != nil {
+		t.Fatalf("marshal rollback body: %v", err)
+	}
+	apiServer := &ClassificationAPIServer{configPath: configPath}
+	req := httptest.NewRequest(http.MethodPost, "/config/router/rollback", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	apiServer.handleConfigRollback(rr, req)
+	return rr
+}
+
+// TestHandleConfigRollbackRejectsMaliciousVersion ensures the rollback endpoint
+// rejects any version that is not a canonical backup timestamp before it is used
+// to build a filesystem path, closing the path-traversal vector.
+func TestHandleConfigRollbackRejectsMaliciousVersion(t *testing.T) {
+	configPath := writeDeployTestBaseConfig(t)
+	originalConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read base config: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		version string
+	}{
+		{"parent traversal", "../../../../etc/passwd"},
+		{"deep traversal", "../../../../../../../../etc/hostname"},
+		{"url encoded traversal", "..%2f..%2fetc%2fpasswd"},
+		{"embedded traversal", "foo/../../bar"},
+		{"absolute path", "/etc/passwd"},
+		{"bare word", "config"},
+		{"valid prefix yaml suffix", "20240101-000000.yaml"},
+		{"valid prefix then traversal", "20240101-000000/../../secret"},
+		{"wrong separator", "20240101_000000"},
+		{"too short date", "2024010-000000"},
+		{"non numeric", "abcdefgh-ijklmn"},
+		{"shell metachars", "; rm -rf /"},
+		{"dot dot", ".."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := postRollback(t, configPath, tc.version)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("version %q: expected 400, got %d: %s", tc.version, rr.Code, rr.Body.String())
+			}
+			if code := rollbackErrorCode(t, rr.Body.Bytes()); code != "INVALID_INPUT" {
+				t.Fatalf("version %q: expected error code INVALID_INPUT, got %q", tc.version, code)
+			}
+		})
+	}
+
+	// A rejected rollback must never mutate the active config.
+	afterConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("re-read base config: %v", err)
+	}
+	if !bytes.Equal(originalConfig, afterConfig) {
+		t.Fatal("rejected rollback mutated the active config")
+	}
+}
+
+// TestHandleConfigRollbackAcceptsWellFormedVersion proves the allowlist does not
+// over-reject the canonical YYYYMMDD-HHMMSS format: a correctly-formatted version
+// with no backup file passes validation and fails later at the lookup (404).
+func TestHandleConfigRollbackAcceptsWellFormedVersion(t *testing.T) {
+	configPath := writeDeployTestBaseConfig(t)
+
+	rr := postRollback(t, configPath, "20240101-000000")
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for well-formed missing version, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if code := rollbackErrorCode(t, rr.Body.Bytes()); code != "VERSION_NOT_FOUND" {
+		t.Fatalf("expected error code VERSION_NOT_FOUND, got %q", code)
+	}
+}
+
 func TestHandleConfigHashReturnsHashAndNoPath(t *testing.T) {
 	configPath := writeDeployTestBaseConfig(t)
 	apiServer := &ClassificationAPIServer{configPath: configPath}


### PR DESCRIPTION
### Purpose

Closes #1967.

Fixes a path-traversal vector in `POST /config/router/rollback` (`pkg/apiserver`). The caller-supplied `version` was interpolated into a backup file path with only an emptiness check, so a `../`-laden value escaped the backup directory — an arbitrary-file read whose contents are then restored as the **live router config**. This endpoint is served without authentication, so the input is fully untrusted.

**Change:** validate `version` against a package-level allowlist `^[0-9]{8}-[0-9]{6}$` — the exact `time.Format("20060102-150405")` shape that `recordRouterConfigArtifacts` produces — and reject non-conforming input with `400 INVALID_INPUT` before it touches the filesystem. This follows the package's existing validation idiom (`knowledgeBaseNamePattern`, `safeIDPattern`). The other backup-path constructions use server-generated timestamps and are unaffected.

### Test Plan

```bash
make test-semantic-router
# focused:
cd src/semantic-router && go test ./pkg/apiserver/ -run TestHandleConfigRollback -v
```

New tests in `route_config_deploy_test.go`:
- `TestHandleConfigRollbackRejectsMaliciousVersion` — 13 traversal/format-attack inputs (`../`, URL-encoded, absolute, embedded `..`, wrong separator, shell metachars) → all `400 INVALID_INPUT`; asserts the active config is byte-for-byte unchanged.
- `TestHandleConfigRollbackAcceptsWellFormedVersion` — a well-formed but nonexistent version → `404 VERSION_NOT_FOUND`, proving the allowlist does not over-reject the canonical format.

### Test Result

- `gofmt -l route_config_deploy.go route_config_deploy_test.go` → clean (no diffs; both files parse and satisfy the format gate).
- Validation-logic verification against the full test-vector set → all 14 attack vectors rejected, both canonical versions accepted (`20240101-000000` and a live `time.Format` timestamp).
- Full package suite (`make test-semantic-router`) links the Rust candle FFI binding and is exercised in CI.
