### PR TITLE
[Dashboard] refactor: add room collaboration event bus with unified WS/SSE fan-out

### DIFF
--- a/dashboard/backend/handlers/openclaw.go
+++ b/dashboard/backend/handlers/openclaw.go
@@ -58,6 +58,7 @@ type OpenClawHandler struct {
 	routerConfigPath string
 	wf               *workflowstore.Store
 	mu               sync.RWMutex
+	roomWSClients    sync.Map
 	roomSSEClients   sync.Map
 	roomSSELastEvent sync.Map
 	roomAutomationMu sync.Map

--- a/dashboard/backend/handlers/openclaw_room_automation.go
+++ b/dashboard/backend/handlers/openclaw_room_automation.go
@@ -258,11 +258,12 @@ func (h *OpenClawHandler) startRoomAutomationReply(
 	placeholderID := generateRoomEntityID("room-msg")
 	go func() {
 		onChunk := func(chunk string, done bool) {
-			h.publishRoomWSEvent(roomID, WSOutboundMessage{
-				Type:      "message_chunk",
-				MessageID: placeholderID,
-				Status:    "streaming",
-			})
+			if done || chunk != "" {
+				h.publishRoomCollaborationEvent(
+					roomID,
+					workerStreamChunkCollaborationEvent(room, target, placeholderID, chunk, done),
+				)
+			}
 		}
 
 		reply, err := h.runWorkerReplyStream(
@@ -304,6 +305,8 @@ func (h *OpenClawHandler) collectRoomAutomationReplies(
 			log.Printf("openclaw: failed to append room reply: %v", err)
 			continue
 		}
+		replyCopy := result.reply
+		h.publishRoomCollaborationEvent(roomID, messageUpdatedCollaborationEvent(replyCopy))
 		if len(result.reply.Mentions) > 0 {
 			next = append(next, result.reply.ID)
 		}

--- a/dashboard/backend/handlers/openclaw_room_collaboration.go
+++ b/dashboard/backend/handlers/openclaw_room_collaboration.go
@@ -1,0 +1,191 @@
+package handlers
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// ClawRoomCollaborationEvent is the canonical room-scoped live event envelope.
+type ClawRoomCollaborationEvent struct {
+	Type            string           `json:"type"`
+	RoomID          string           `json:"roomId,omitempty"`
+	Message         *ClawRoomMessage `json:"message,omitempty"`
+	MessageID       string           `json:"messageId,omitempty"`
+	Chunk           string           `json:"chunk,omitempty"`
+	Status          string           `json:"status,omitempty"`
+	Error           string           `json:"error,omitempty"`
+	ParticipantType string           `json:"participantType,omitempty"`
+	ParticipantID   string           `json:"participantId,omitempty"`
+	SessionUser     string           `json:"sessionUser,omitempty"`
+	Timestamp       string           `json:"timestamp,omitempty"`
+}
+
+func cloneCollaborationEvent(event ClawRoomCollaborationEvent) ClawRoomCollaborationEvent {
+	if event.Message == nil {
+		return event
+	}
+	copyMsg := *event.Message
+	event.Message = &copyMsg
+	return event
+}
+
+func newMessageCollaborationEvent(message ClawRoomMessage) ClawRoomCollaborationEvent {
+	copyMsg := message
+	participantType := normalizeRoomSenderType(message.SenderType)
+	return ClawRoomCollaborationEvent{
+		Type:            WSTypeNewMessage,
+		Message:         &copyMsg,
+		ParticipantType: participantType,
+		ParticipantID:   message.SenderID,
+	}
+}
+
+func messageUpdatedCollaborationEvent(message ClawRoomMessage) ClawRoomCollaborationEvent {
+	copyMsg := message
+	participantType := normalizeRoomSenderType(message.SenderType)
+	return ClawRoomCollaborationEvent{
+		Type:            WSTypeMessageUpdated,
+		Message:         &copyMsg,
+		MessageID:       message.ID,
+		ParticipantType: participantType,
+		ParticipantID:   message.SenderID,
+	}
+}
+
+func workerStreamChunkCollaborationEvent(
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	messageID, chunk string,
+	done bool,
+) ClawRoomCollaborationEvent {
+	event := ClawRoomCollaborationEvent{
+		Type:            WSTypeMessageChunk,
+		MessageID:       messageID,
+		Chunk:           chunk,
+		ParticipantType: "worker",
+		ParticipantID:   worker.Name,
+		SessionUser:     roomScopedSessionUser(room, worker),
+	}
+	if done {
+		event.Status = "complete"
+	} else {
+		event.Status = "streaming"
+	}
+	return event
+}
+
+func collaborationEventToWSOutbound(event ClawRoomCollaborationEvent) WSOutboundMessage {
+	outbound := WSOutboundMessage{
+		Type:            event.Type,
+		RoomID:          event.RoomID,
+		MessageID:       event.MessageID,
+		Chunk:           event.Chunk,
+		Status:          event.Status,
+		Error:           event.Error,
+		Timestamp:       event.Timestamp,
+		ParticipantType: event.ParticipantType,
+		ParticipantID:   event.ParticipantID,
+		SessionUser:     event.SessionUser,
+	}
+	if event.Message != nil {
+		copyMsg := *event.Message
+		outbound.Message = &copyMsg
+	}
+	return outbound
+}
+
+func collaborationEventToSSE(event ClawRoomCollaborationEvent) clawRoomStreamEvent {
+	sseType := event.Type
+	if sseType == WSTypeNewMessage {
+		sseType = "message"
+	}
+	sseEvent := clawRoomStreamEvent{
+		Type:   sseType,
+		RoomID: event.RoomID,
+	}
+	if event.Message != nil {
+		copyMsg := *event.Message
+		sseEvent.Message = &copyMsg
+	}
+	return sseEvent
+}
+
+func shouldCacheCollaborationEvent(event ClawRoomCollaborationEvent) bool {
+	return event.Message != nil && event.Type == WSTypeNewMessage
+}
+
+func (h *OpenClawHandler) roomWSClientMap(roomID string) *sync.Map {
+	if existing, ok := h.roomWSClients.Load(roomID); ok {
+		return existing.(*sync.Map)
+	}
+	clients := &sync.Map{}
+	actual, _ := h.roomWSClients.LoadOrStore(roomID, clients)
+	return actual.(*sync.Map)
+}
+
+func (h *OpenClawHandler) roomSSEClientMap(roomID string) *sync.Map {
+	if existing, ok := h.roomSSEClients.Load(roomID); ok {
+		return existing.(*sync.Map)
+	}
+	clients := &sync.Map{}
+	actual, _ := h.roomSSEClients.LoadOrStore(roomID, clients)
+	return actual.(*sync.Map)
+}
+
+// publishRoomCollaborationEvent is the single fan-out entry for room live events.
+func (h *OpenClawHandler) publishRoomCollaborationEvent(roomID string, event ClawRoomCollaborationEvent) {
+	event.RoomID = roomID
+	if event.Timestamp == "" {
+		event.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	event = cloneCollaborationEvent(event)
+
+	if shouldCacheCollaborationEvent(event) {
+		h.roomSSELastEvent.Store(roomID, collaborationEventToSSE(event))
+	}
+
+	h.fanOutCollaborationToWebSocket(roomID, event)
+	h.fanOutCollaborationToSSE(roomID, event)
+}
+
+func (h *OpenClawHandler) fanOutCollaborationToWebSocket(roomID string, event ClawRoomCollaborationEvent) {
+	outbound := collaborationEventToWSOutbound(event)
+	clients := h.roomWSClientMap(roomID)
+	clients.Range(func(_, value any) bool {
+		client, ok := value.(*WSClient)
+		if !ok {
+			return true
+		}
+
+		client.closeMu.Lock()
+		if client.closed {
+			client.closeMu.Unlock()
+			return true
+		}
+		client.closeMu.Unlock()
+
+		select {
+		case client.send <- outbound:
+		default:
+			log.Printf("openclaw: WS client %s buffer full, skipping event", client.clientID)
+		}
+		return true
+	})
+}
+
+func (h *OpenClawHandler) fanOutCollaborationToSSE(roomID string, event ClawRoomCollaborationEvent) {
+	sseEvent := collaborationEventToSSE(event)
+	clients := h.roomSSEClientMap(roomID)
+	clients.Range(func(_, value any) bool {
+		ch, ok := value.(chan clawRoomStreamEvent)
+		if !ok {
+			return true
+		}
+		select {
+		case ch <- cloneRoomEventWithMessage(sseEvent):
+		default:
+		}
+		return true
+	})
+}

--- a/dashboard/backend/handlers/openclaw_room_collaboration_test.go
+++ b/dashboard/backend/handlers/openclaw_room_collaboration_test.go
@@ -1,0 +1,244 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRoomCollaborationBus_WSAndSSEReceiveSameEvent(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := seedCollaborationTestRoom(t, h)
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	wsConn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, wsConn)
+
+	sseEvents := make(chan clawRoomStreamEvent, 4)
+	sseClientID := "sse-test-client"
+	h.roomSSEClientMap(room.ID).Store(sseClientID, sseEvents)
+	t.Cleanup(func() {
+		h.roomSSEClientMap(room.ID).Delete(sseClientID)
+	})
+
+	message := ClawRoomMessage{
+		ID:         "msg-bus-1",
+		RoomID:     room.ID,
+		TeamID:     room.TeamID,
+		SenderType: "user",
+		SenderID:   "playground-user",
+		SenderName: "You",
+		Content:    "bus fanout",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	h.publishRoomCollaborationEvent(room.ID, newMessageCollaborationEvent(message))
+
+	wsOutbound := waitForWSOutboundMessage(t, wsConn, "websocket collaboration event", func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeNewMessage && outbound.Message != nil && outbound.Message.Content == "bus fanout"
+	})
+	if wsOutbound.Message == nil {
+		t.Fatalf("expected websocket message payload")
+	}
+
+	select {
+	case sseEvent := <-sseEvents:
+		if sseEvent.Type != "message" || sseEvent.Message == nil || sseEvent.Message.Content != "bus fanout" {
+			t.Fatalf("unexpected sse event: %+v", sseEvent)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sse collaboration event")
+	}
+}
+
+func TestRoomCollaborationBus_EventsDoNotLeakAcrossRooms(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	roomA := seedCollaborationTestRoomWithID(t, h, "room-a", "team-a")
+	roomB := seedCollaborationTestRoomWithID(t, h, "room-b", "team-b")
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	connB := dialRoomWebSocket(t, server.URL, roomB.ID)
+	readWSConnected(t, connB)
+
+	h.publishRoomCollaborationEvent(roomA.ID, newMessageCollaborationEvent(ClawRoomMessage{
+		ID:         "msg-room-a",
+		RoomID:     roomA.ID,
+		TeamID:     roomA.TeamID,
+		SenderType: "user",
+		SenderID:   "playground-user",
+		SenderName: "You",
+		Content:    "room a only",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}))
+
+	_ = connB.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	var leaked WSOutboundMessage
+	err := connB.ReadJSON(&leaked)
+	if err == nil && leaked.Type == WSTypeNewMessage {
+		t.Fatalf("room A event leaked to room B websocket: %+v", leaked)
+	}
+}
+
+func TestRoomCollaborationBus_WSDisconnectDoesNotBreakSSE(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := seedCollaborationTestRoom(t, h)
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	wsConn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, wsConn)
+	_ = wsConn.Close()
+
+	sseEvents := make(chan clawRoomStreamEvent, 4)
+	sseClientID := "sse-after-ws-close"
+	h.roomSSEClientMap(room.ID).Store(sseClientID, sseEvents)
+	t.Cleanup(func() {
+		h.roomSSEClientMap(room.ID).Delete(sseClientID)
+	})
+
+	h.publishRoomCollaborationEvent(room.ID, newMessageCollaborationEvent(ClawRoomMessage{
+		ID:         "msg-sse-only",
+		RoomID:     room.ID,
+		TeamID:     room.TeamID,
+		SenderType: "system",
+		SenderID:   "clawos-system",
+		SenderName: "ClawOS",
+		Content:    "sse still works",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}))
+
+	select {
+	case sseEvent := <-sseEvents:
+		if sseEvent.Message == nil || sseEvent.Message.Content != "sse still works" {
+			t.Fatalf("unexpected sse event after ws disconnect: %+v", sseEvent)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected sse client to receive event after websocket disconnect")
+	}
+}
+
+func TestRoomWebSocket_MultipleClientsReceiveSameEvent(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := seedCollaborationTestRoom(t, h)
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	connA := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, connA)
+	connB := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, connB)
+
+	h.publishRoomCollaborationEvent(room.ID, newMessageCollaborationEvent(ClawRoomMessage{
+		ID:         "msg-multi",
+		RoomID:     room.ID,
+		TeamID:     room.TeamID,
+		SenderType: "user",
+		SenderID:   "playground-user",
+		SenderName: "You",
+		Content:    "multi client",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}))
+
+	outA := waitForWSOutboundMessage(t, connA, "client A event", func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeNewMessage && outbound.Message != nil && outbound.Message.Content == "multi client"
+	})
+	outB := waitForWSOutboundMessage(t, connB, "client B event", func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeNewMessage && outbound.Message != nil && outbound.Message.Content == "multi client"
+	})
+	if outA.Message == nil || outB.Message == nil {
+		t.Fatalf("expected both websocket clients to receive the event")
+	}
+}
+
+func TestRoomCollaborationBus_HTTPPostAndWSSendEquivalent(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := seedCollaborationTestRoom(t, h)
+
+	httpCreated := postRoomMessage(t, h, room.ID, `{
+		"senderType":"user",
+		"senderId":"playground-user",
+		"senderName":"You",
+		"content":"http path"
+	}`)
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	conn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, conn)
+
+	if writeErr := conn.WriteJSON(WSInboundMessage{
+		Type:       WSTypeSendMessage,
+		Content:    "ws path",
+		SenderType: "user",
+		SenderName: "You",
+		SenderID:   "playground-user",
+	}); writeErr != nil {
+		t.Fatalf("failed to send websocket message: %v", writeErr)
+	}
+
+	wsOutbound := waitForWSOutboundMessage(t, conn, "websocket send event", func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeNewMessage && outbound.Message != nil && outbound.Message.Content == "ws path"
+	})
+
+	if httpCreated.Content != "http path" {
+		t.Fatalf("unexpected http-created message: %+v", httpCreated)
+	}
+	if wsOutbound.Message == nil || wsOutbound.Message.Content != "ws path" {
+		t.Fatalf("unexpected websocket-created message: %+v", wsOutbound)
+	}
+
+	messages, err := h.loadRoomMessages(room.ID)
+	if err != nil {
+		t.Fatalf("failed to load room messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected two persisted room messages, got %d", len(messages))
+	}
+}
+
+func TestWorkerStreamChunkCollaborationEvent_IncludesParticipantIdentity(t *testing.T) {
+	room := ClawRoomEntry{ID: "room-1", TeamID: "team-1"}
+	worker := ContainerEntry{Name: "worker-a", RoleKind: "worker"}
+	event := workerStreamChunkCollaborationEvent(room, worker, "msg-1", "He", false)
+	if event.ParticipantType != "worker" || event.ParticipantID != "worker-a" {
+		t.Fatalf("unexpected participant identity: %+v", event)
+	}
+	if event.SessionUser != "room-1:worker-a" {
+		t.Fatalf("expected room-scoped session user, got %q", event.SessionUser)
+	}
+	if event.Chunk != "He" || event.Status != "streaming" {
+		t.Fatalf("unexpected chunk payload: %+v", event)
+	}
+}
+
+func seedCollaborationTestRoom(t *testing.T, h *OpenClawHandler) ClawRoomEntry {
+	t.Helper()
+	return seedCollaborationTestRoomWithID(t, h, "room-collab", "team-collab")
+}
+
+func seedCollaborationTestRoomWithID(t *testing.T, h *OpenClawHandler, roomID, teamID string) ClawRoomEntry {
+	t.Helper()
+	room := ClawRoomEntry{
+		ID:        roomID,
+		TeamID:    teamID,
+		Name:      strings.ToUpper(roomID),
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := h.saveRooms([]ClawRoomEntry{room}); err != nil {
+		t.Fatalf("failed to seed room: %v", err)
+	}
+	return room
+}

--- a/dashboard/backend/handlers/openclaw_rooms.go
+++ b/dashboard/backend/handlers/openclaw_rooms.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -296,33 +295,6 @@ func cloneRoomEventWithMessage(event clawRoomStreamEvent) clawRoomStreamEvent {
 	return event
 }
 
-func (h *OpenClawHandler) roomClientMap(roomID string) *sync.Map {
-	if existing, ok := h.roomSSEClients.Load(roomID); ok {
-		return existing.(*sync.Map)
-	}
-	clients := &sync.Map{}
-	actual, _ := h.roomSSEClients.LoadOrStore(roomID, clients)
-	return actual.(*sync.Map)
-}
-
-func (h *OpenClawHandler) publishRoomEvent(roomID string, event clawRoomStreamEvent) {
-	event.RoomID = roomID
-	h.roomSSELastEvent.Store(roomID, cloneRoomEventWithMessage(event))
-
-	clients := h.roomClientMap(roomID)
-	clients.Range(func(_, value any) bool {
-		ch, ok := value.(chan clawRoomStreamEvent)
-		if !ok {
-			return true
-		}
-		select {
-		case ch <- cloneRoomEventWithMessage(event):
-		default:
-		}
-		return true
-	})
-}
-
 func writeSSE(w http.ResponseWriter, flusher http.Flusher, eventName string, payload any) {
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -345,14 +317,7 @@ func (h *OpenClawHandler) appendRoomMessage(roomID string, message ClawRoomMessa
 		return err
 	}
 
-	// Broadcast to WebSocket clients (also handles SSE backward compatibility)
-	h.publishRoomWSEvent(roomID, WSOutboundMessage{
-		Type:    WSTypeNewMessage,
-		Message: &message,
-	})
-
-	// Keep SSE event for backward compatibility
-	h.publishRoomEvent(roomID, clawRoomStreamEvent{Type: "message", Message: &message})
+	h.publishRoomCollaborationEvent(roomID, newMessageCollaborationEvent(message))
 	return nil
 }
 
@@ -751,7 +716,7 @@ func (h *OpenClawHandler) handleRoomStream(w http.ResponseWriter, r *http.Reques
 
 	clientID := generateRoomEntityID("room-client")
 	clientChan := make(chan clawRoomStreamEvent, 16)
-	clients := h.roomClientMap(roomID)
+	clients := h.roomSSEClientMap(roomID)
 	clients.Store(clientID, clientChan)
 	defer func() {
 		clients.Delete(clientID)

--- a/dashboard/backend/handlers/openclaw_websocket.go
+++ b/dashboard/backend/handlers/openclaw_websocket.go
@@ -38,14 +38,17 @@ type WSInboundMessage struct {
 
 // WSOutboundMessage represents a message from server to client
 type WSOutboundMessage struct {
-	Type      string           `json:"type"`
-	RoomID    string           `json:"roomId,omitempty"`
-	Message   *ClawRoomMessage `json:"message,omitempty"`
-	MessageID string           `json:"messageId,omitempty"`
-	Chunk     string           `json:"chunk,omitempty"`
-	Status    string           `json:"status,omitempty"`
-	Error     string           `json:"error,omitempty"`
-	Timestamp string           `json:"timestamp,omitempty"`
+	Type            string           `json:"type"`
+	RoomID          string           `json:"roomId,omitempty"`
+	Message         *ClawRoomMessage `json:"message,omitempty"`
+	MessageID       string           `json:"messageId,omitempty"`
+	Chunk           string           `json:"chunk,omitempty"`
+	Status          string           `json:"status,omitempty"`
+	Error           string           `json:"error,omitempty"`
+	ParticipantType string           `json:"participantType,omitempty"`
+	ParticipantID   string           `json:"participantId,omitempty"`
+	SessionUser     string           `json:"sessionUser,omitempty"`
+	Timestamp       string           `json:"timestamp,omitempty"`
 }
 
 // WSClient represents a WebSocket client connection
@@ -67,59 +70,36 @@ var wsUpgrader = websocket.Upgrader{
 	},
 }
 
-// roomWSClients stores WebSocket clients per room
-// Key: roomID, Value: *sync.Map (clientID -> *WSClient)
-func (h *OpenClawHandler) roomWSClientMap(roomID string) *sync.Map {
-	if existing, ok := h.roomSSEClients.Load(roomID); ok {
-		return existing.(*sync.Map)
+func wsOutboundFromLastRoomEvent(roomID string, event clawRoomStreamEvent) (WSOutboundMessage, bool) {
+	if event.Message == nil {
+		return WSOutboundMessage{}, false
 	}
-	clients := &sync.Map{}
-	actual, _ := h.roomSSEClients.LoadOrStore(roomID, clients)
-	return actual.(*sync.Map)
+	copyMsg := *event.Message
+	return WSOutboundMessage{
+		Type:    WSTypeNewMessage,
+		RoomID:  roomID,
+		Message: &copyMsg,
+	}, true
 }
 
-// publishRoomWSEvent broadcasts an event to all WebSocket clients in a room
-func (h *OpenClawHandler) publishRoomWSEvent(roomID string, event WSOutboundMessage) {
-	event.RoomID = roomID
-	event.Timestamp = time.Now().UTC().Format(time.RFC3339)
-
-	clients := h.roomWSClientMap(roomID)
-	clients.Range(func(_, value any) bool {
-		client, ok := value.(*WSClient)
-		if !ok {
-			// Backward compatibility: might be SSE channel
-			if ch, ok := value.(chan clawRoomStreamEvent); ok {
-				// Convert to SSE event
-				sseEvent := clawRoomStreamEvent{
-					Type:   event.Type,
-					RoomID: roomID,
-				}
-				if event.Message != nil {
-					sseEvent.Message = event.Message
-				}
-				select {
-				case ch <- sseEvent:
-				default:
-				}
-			}
-			return true
-		}
-
-		client.closeMu.Lock()
-		if client.closed {
-			client.closeMu.Unlock()
-			return true
-		}
-		client.closeMu.Unlock()
-
-		select {
-		case client.send <- event:
-		default:
-			// Client buffer full, skip
-			log.Printf("openclaw: WS client %s buffer full, skipping event", client.clientID)
-		}
-		return true
-	})
+func (h *OpenClawHandler) replayLastRoomEventToClient(client *WSClient, roomID string) {
+	lastAny, ok := h.roomSSELastEvent.Load(roomID)
+	if !ok {
+		return
+	}
+	lastEvent, ok := lastAny.(clawRoomStreamEvent)
+	if !ok {
+		return
+	}
+	replay, ok := wsOutboundFromLastRoomEvent(roomID, lastEvent)
+	if !ok {
+		return
+	}
+	select {
+	case client.send <- replay:
+	default:
+		log.Printf("openclaw: WS client %s buffer full, skipping room replay", client.clientID)
+	}
 }
 
 // handleRoomWebSocket handles WebSocket connections for a room
@@ -147,7 +127,7 @@ func (h *OpenClawHandler) handleRoomWebSocket(w http.ResponseWriter, r *http.Req
 	clientID := generateRoomEntityID("ws-client")
 	client := &WSClient{
 		conn:     conn,
-		send:     make(chan WSOutboundMessage, 32),
+		send:     make(chan WSOutboundMessage, 128),
 		roomID:   roomID,
 		clientID: clientID,
 		handler:  h,
@@ -164,6 +144,7 @@ func (h *OpenClawHandler) handleRoomWebSocket(w http.ResponseWriter, r *http.Req
 		Type:   WSTypeConnected,
 		RoomID: roomID,
 	}
+	h.replayLastRoomEventToClient(client, roomID)
 
 	// Start read/write goroutines
 	go client.writePump()
@@ -336,19 +317,7 @@ func (h *OpenClawHandler) appendRoomMessageWS(roomID string, message ClawRoomMes
 	}
 	h.mu.Unlock()
 
-	// Broadcast via WebSocket
-	h.publishRoomWSEvent(roomID, WSOutboundMessage{
-		Type:    WSTypeNewMessage,
-		Message: &message,
-	})
-
-	// Also publish to SSE for backward compatibility
-	h.roomSSELastEvent.Store(roomID, clawRoomStreamEvent{
-		Type:    "message",
-		RoomID:  roomID,
-		Message: &message,
-	})
-
+	h.publishRoomCollaborationEvent(roomID, newMessageCollaborationEvent(message))
 	return nil
 }
 

--- a/dashboard/backend/handlers/openclaw_websocket_test.go
+++ b/dashboard/backend/handlers/openclaw_websocket_test.go
@@ -1,0 +1,264 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func dialRoomWebSocket(t *testing.T, serverURL, roomID string) *websocket.Conn {
+	t.Helper()
+
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + "/api/openclaw/rooms/" + roomID + "/ws"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to connect websocket: %v", err)
+	}
+	if resp != nil && resp.Body != nil {
+		t.Cleanup(func() { _ = resp.Body.Close() })
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func readWSConnected(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	waitForWSOutboundMessage(t, conn, "connected message", func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeConnected
+	})
+	_ = conn.SetReadDeadline(time.Time{})
+}
+
+func collectWSOutboundUntil(
+	t *testing.T,
+	conn *websocket.Conn,
+	timeout time.Duration,
+	stop func(WSOutboundMessage) bool,
+) []WSOutboundMessage {
+	t.Helper()
+
+	events := make(chan WSOutboundMessage, 64)
+	errs := make(chan error, 1)
+	go func() {
+		for {
+			var outbound WSOutboundMessage
+			if err := conn.ReadJSON(&outbound); err != nil {
+				errs <- err
+				return
+			}
+			events <- outbound
+		}
+	}()
+
+	collected := make([]WSOutboundMessage, 0)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case outbound := <-events:
+			collected = append(collected, outbound)
+			if stop(outbound) {
+				return collected
+			}
+		case err := <-errs:
+			t.Fatalf("websocket read failed: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return collected
+}
+
+func TestWorkerStreamChunkCollaborationEvent_WSOutboundShape(t *testing.T) {
+	room := ClawRoomEntry{ID: "room-1", TeamID: "team-1"}
+	worker := ContainerEntry{Name: "worker-a", RoleKind: "worker"}
+
+	streaming := collaborationEventToWSOutbound(
+		workerStreamChunkCollaborationEvent(room, worker, "room-msg-1", "He", false),
+	)
+	if streaming.Type != WSTypeMessageChunk {
+		t.Fatalf("expected message_chunk, got %q", streaming.Type)
+	}
+	if streaming.Chunk != "He" {
+		t.Fatalf("expected chunk payload, got %q", streaming.Chunk)
+	}
+	if streaming.Status != "streaming" {
+		t.Fatalf("expected streaming status, got %q", streaming.Status)
+	}
+
+	complete := collaborationEventToWSOutbound(
+		workerStreamChunkCollaborationEvent(room, worker, "room-msg-1", "llo", true),
+	)
+	if complete.Chunk != "llo" {
+		t.Fatalf("expected final chunk payload, got %q", complete.Chunk)
+	}
+	if complete.Status != "complete" {
+		t.Fatalf("expected complete status, got %q", complete.Status)
+	}
+}
+
+func TestRoomWebSocket_ConnectReplayLastEvent(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+
+	workerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertChatCompletionPath(t, r)
+		encodeOpenAIResponse(w, "unused")
+	}))
+	defer workerSrv.Close()
+
+	room := seedRoomTeamWithLeaderAndWorker(t, h, tempDir, "team-ws-replay", "WS Replay Team", workerSrv.URL)
+	created := postRoomMessage(t, h, room.ID, `{
+		"senderType":"user",
+		"senderId":"playground-user",
+		"senderName":"You",
+		"content":"seed message for replay"
+	}`)
+	if created.Content != "seed message for replay" {
+		t.Fatalf("unexpected seeded message: %+v", created)
+	}
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	conn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, conn)
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	replay := waitForWSOutboundMessage(t, conn, "replay message", func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeNewMessage && outbound.Message != nil
+	})
+	if replay.Message == nil || replay.Message.Content != "seed message for replay" {
+		t.Fatalf("unexpected replay message: %+v", replay)
+	}
+}
+
+func TestPublishRoomCollaborationEvent_ChunkReachConnectedClient(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := ClawRoomEntry{
+		ID:        "room-ws-chunk",
+		TeamID:    "team-a",
+		Name:      "Chunk Room",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := h.saveRooms([]ClawRoomEntry{room}); err != nil {
+		t.Fatalf("failed to seed room: %v", err)
+	}
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	conn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, conn)
+
+	worker := ContainerEntry{Name: "worker-a", RoleKind: "worker"}
+	h.publishRoomCollaborationEvent(
+		room.ID,
+		workerStreamChunkCollaborationEvent(room, worker, "room-msg-test", "partial", false),
+	)
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	outbound := waitForWSOutboundMessage(t, conn, "chunk event", func(message WSOutboundMessage) bool {
+		return message.Type == WSTypeMessageChunk && message.Chunk == "partial"
+	})
+	if outbound.MessageID != "room-msg-test" {
+		t.Fatalf("unexpected chunk event: %+v", outbound)
+	}
+}
+
+func TestPublishRoomCollaborationEvent_StreamingChunkSequence(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := ClawRoomEntry{
+		ID:        "room-ws-stream-seq",
+		TeamID:    "team-a",
+		Name:      "Stream Sequence Room",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := h.saveRooms([]ClawRoomEntry{room}); err != nil {
+		t.Fatalf("failed to seed room: %v", err)
+	}
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	conn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, conn)
+
+	worker := ContainerEntry{Name: "worker-a", RoleKind: "worker"}
+	messageID := "room-msg-stream"
+	for _, chunk := range []string{"He", "llo", " world"} {
+		h.publishRoomCollaborationEvent(
+			room.ID,
+			workerStreamChunkCollaborationEvent(room, worker, messageID, chunk, false),
+		)
+	}
+	h.publishRoomCollaborationEvent(
+		room.ID,
+		workerStreamChunkCollaborationEvent(room, worker, messageID, "", true),
+	)
+	reply := ClawRoomMessage{
+		ID:         messageID,
+		RoomID:     room.ID,
+		TeamID:     room.TeamID,
+		SenderType: "worker",
+		SenderID:   "worker-a",
+		SenderName: "Worker A",
+		Content:    "Hello world",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	h.publishRoomCollaborationEvent(room.ID, messageUpdatedCollaborationEvent(reply))
+
+	events := collectWSOutboundUntil(t, conn, 2*time.Second, func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeMessageUpdated
+	})
+
+	var chunks []string
+	var updated *ClawRoomMessage
+	for _, outbound := range events {
+		switch outbound.Type {
+		case WSTypeMessageChunk:
+			if outbound.Chunk != "" {
+				chunks = append(chunks, outbound.Chunk)
+			}
+		case WSTypeMessageUpdated:
+			if outbound.Message != nil {
+				copyMsg := *outbound.Message
+				updated = &copyMsg
+			}
+		}
+	}
+
+	if strings.Join(chunks, "") != "Hello world" {
+		t.Fatalf("expected streamed chunks %q, got %q (%v)", "Hello world", strings.Join(chunks, ""), chunks)
+	}
+	if updated == nil || updated.Content != "Hello world" {
+		t.Fatalf("expected message_updated payload, got %+v", updated)
+	}
+}
+
+func TestWSOutboundFromLastRoomEvent(t *testing.T) {
+	msg := ClawRoomMessage{ID: "m1", Content: "hello"}
+	event := clawRoomStreamEvent{Type: "message", Message: &msg}
+
+	outbound, ok := wsOutboundFromLastRoomEvent("room-a", event)
+	if !ok {
+		t.Fatalf("expected replay conversion to succeed")
+	}
+	if outbound.Type != WSTypeNewMessage {
+		t.Fatalf("expected new_message replay type, got %q", outbound.Type)
+	}
+	if outbound.Message == nil || outbound.Message.Content != "hello" {
+		t.Fatalf("unexpected replay payload: %+v", outbound)
+	}
+	if outbound.Message == event.Message {
+		t.Fatalf("expected replay message to be copied")
+	}
+}


### PR DESCRIPTION


<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.
part of https://github.com/vllm-project/semantic-router/issues/1521

**PR1.Room collaboration event bus (unified backend broadcasting)**

This PR is backend-only. It routes all live ClawRoom events—new messages, streaming chunks, updates, connection status, and so on—through a single entry point, publishRoomCollaborationEvent, which then fans out to WebSocket and SSE clients. Previously, HTTP posts, WebSocket sends, and automated worker replies each had their own broadcast path, which could duplicate or miss events. Everything now goes through the bus. WS and SSE client registries are kept separate so one transport does not interfere with the other. Work already done for streaming chunks, message_updated, and reconnect replay is folded into this model. Go tests verify that the same event reaches both WS and SSE, events do not leak across rooms, and an WS disconnect does not break SSE. The frontend stays largely unchanged; this PR lays the foundation for the next ones.
## Purpose

- What does this PR change?

`openclaw.go`
Adds a dedicated roomWSClients field on the handler so WebSocket clients no longer share the same registry as SSE clients.

`openclaw_room_collaboration.go (new)`
Introduces the canonical room collaboration event model and a single fan-out entry point, publishRoomCollaborationEvent, which pushes the same event to both WS and SSE and carries metadata such as worker identity.

`openclaw_rooms.go`
Removes the legacy publishRoomEvent / roomClientMap paths so persisted HTTP messages go only through the bus, and SSE subscriptions use the separate roomSSEClientMap.

`openclaw_websocket.go`
Routes WS through the bus instead of ad hoc broadcasts, splits WS/SSE registries, adds participant fields on outbound messages, replays the latest message on connect, and removes the old mixed WS+SSE fan-out logic.

`openclaw_room_automation.go`
Publishes worker streaming chunks and final message_updated events through the bus with worker participant identity, instead of calling the old WS broadcast directly.

`openclaw_room_collaboration_test.go (new)`
Covers bus behavior: WS and SSE receive the same event, HTTP and WS sends are equivalent, events do not leak across rooms, WS disconnect does not break SSE, multi-client sync works, and worker identity fields are correct.

`openclaw_websocket_test.go (new)`
Covers WS-layer details: chunk outbound shape, reconnect replay, streaming chunk sequence, and the full path through message_updated.

- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
