### PR TITLE
feat: add session-aware agentic routing

### DIFF
--- a/bench/agentic_routing_experiment.py
+++ b/bench/agentic_routing_experiment.py
@@ -29,6 +29,22 @@ class ModelProfile:
     cached_per_1m: float
 
 
+@dataclass(frozen=True)
+class WorkloadScenario:
+    name: str
+    base_demand: float
+    progress_weight: float
+    phase_bonus: float
+    wave_amplitude: float
+    noise: float
+    tool_cycle: int
+    tool_slots: tuple[int, ...]
+    history_min: int
+    history_max: int
+    idle_mode: str
+    token_growth: float = 1.0
+
+
 MODELS = (
     ModelProfile("qwen3-8b", 0.64, 0.05, 0.10, 0.01),
     ModelProfile("qwen3-32b", 0.78, 0.30, 0.60, 0.06),
@@ -36,6 +52,63 @@ MODELS = (
 )
 FRONTIER_DEMAND_THRESHOLD = 0.78
 MID_DEMAND_THRESHOLD = 0.55
+DEFAULT_SCENARIOS = ("balanced", "tool-heavy", "frontier-heavy", "idle-heavy")
+SCENARIOS = {
+    "balanced": WorkloadScenario(
+        name="balanced",
+        base_demand=0.42,
+        progress_weight=0.28,
+        phase_bonus=0.16,
+        wave_amplitude=0.18,
+        noise=0.09,
+        tool_cycle=5,
+        tool_slots=(2, 3),
+        history_min=512,
+        history_max=2048,
+        idle_mode="single",
+    ),
+    "tool-heavy": WorkloadScenario(
+        name="tool-heavy",
+        base_demand=0.55,
+        progress_weight=0.22,
+        phase_bonus=0.18,
+        wave_amplitude=0.14,
+        noise=0.08,
+        tool_cycle=6,
+        tool_slots=(2, 3, 4),
+        history_min=1024,
+        history_max=3072,
+        idle_mode="single",
+        token_growth=1.12,
+    ),
+    "frontier-heavy": WorkloadScenario(
+        name="frontier-heavy",
+        base_demand=0.55,
+        progress_weight=0.34,
+        phase_bonus=0.20,
+        wave_amplitude=0.17,
+        noise=0.07,
+        tool_cycle=5,
+        tool_slots=(2, 3),
+        history_min=1536,
+        history_max=4096,
+        idle_mode="rare",
+        token_growth=1.20,
+    ),
+    "idle-heavy": WorkloadScenario(
+        name="idle-heavy",
+        base_demand=0.42,
+        progress_weight=0.30,
+        phase_bonus=0.14,
+        wave_amplitude=0.16,
+        noise=0.10,
+        tool_cycle=5,
+        tool_slots=(2, 3),
+        history_min=512,
+        history_max=2048,
+        idle_mode="frequent",
+    ),
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -45,6 +118,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--sessions", type=int, default=40)
     parser.add_argument("--turns", type=int, default=18)
     parser.add_argument("--seed", type=int, default=20260530)
+    parser.add_argument(
+        "--scenario",
+        choices=sorted(SCENARIOS),
+        default="balanced",
+        help="Synthetic workload shape to simulate.",
+    )
+    parser.add_argument(
+        "--matrix",
+        action="store_true",
+        help="Run the maintained scenario matrix instead of one workload.",
+    )
+    parser.add_argument(
+        "--seeds",
+        default="20260530,20260531,20260532,20260533,20260534",
+        help="Comma-separated seeds for --matrix.",
+    )
     return parser.parse_args()
 
 
@@ -54,7 +143,10 @@ def default_output_dir() -> Path:
 
 
 def simulate_workload(
-    session_count: int, turn_count: int, seed: int
+    session_count: int,
+    turn_count: int,
+    seed: int,
+    scenario: WorkloadScenario = SCENARIOS["balanced"],
 ) -> list[dict[str, Any]]:
     rng = random.Random(seed)
     rows: list[dict[str, Any]] = []
@@ -63,13 +155,13 @@ def simulate_workload(
         baseline_model = MODELS[0]
         agentic_model = MODELS[0]
         switch_count = 0
-        history_tokens = rng.randint(512, 2048)
-        idle_break_turn = rng.choice((0, turn_count // 2, turn_count + 1))
+        history_tokens = rng.randint(scenario.history_min, scenario.history_max)
+        idle_turns = idle_turns_for(turn_count, scenario, rng)
 
         for turn in range(turn_count):
-            phase = phase_for_turn(turn)
-            idle_expired = turn == idle_break_turn
-            demand = demand_score(turn, turn_count, phase, rng)
+            phase = phase_for_turn(turn, scenario)
+            idle_expired = turn in idle_turns
+            demand = demand_score(turn, turn_count, phase, rng, scenario)
             base_choice = choose_base_model(demand)
 
             baseline_next = base_choice
@@ -102,6 +194,8 @@ def simulate_workload(
 
             rows.append(
                 {
+                    "scenario": scenario.name,
+                    "seed": seed,
                     "session_id": session_id,
                     "turn": turn,
                     "phase": phase,
@@ -128,26 +222,50 @@ def simulate_workload(
             baseline_model = baseline_next
             agentic_model = agentic_next
             history_tokens = min(
-                32000, history_tokens + prompt_tokens // 8 + completion_tokens
+                64000,
+                history_tokens
+                + int((prompt_tokens // 8 + completion_tokens) * scenario.token_growth),
             )
     return rows
 
 
-def phase_for_turn(turn: int) -> str:
-    cycle = turn % 5
-    if cycle in (2, 3):
+def idle_turns_for(
+    turn_count: int, scenario: WorkloadScenario, rng: random.Random
+) -> set[int]:
+    if scenario.idle_mode == "frequent":
+        interval = max(5, turn_count // 4)
+        return set(range(interval, turn_count, interval))
+    if scenario.idle_mode == "rare":
+        return {turn_count + 1}
+    return {rng.choice((0, turn_count // 2, turn_count + 1))}
+
+
+def phase_for_turn(turn: int, scenario: WorkloadScenario) -> str:
+    cycle = turn % scenario.tool_cycle
+    if cycle in scenario.tool_slots:
         return "tool_loop"
     return "user_turn"
 
 
-def demand_score(turn: int, turn_count: int, phase: str, rng: random.Random) -> float:
+def demand_score(
+    turn: int,
+    turn_count: int,
+    phase: str,
+    rng: random.Random,
+    scenario: WorkloadScenario,
+) -> float:
     progress = turn / max(turn_count - 1, 1)
-    phase_bonus = 0.16 if phase == "tool_loop" else 0.0
-    wave = 0.18 * math.sin(turn * math.pi / 4)
+    phase_bonus = scenario.phase_bonus if phase == "tool_loop" else 0.0
+    wave = scenario.wave_amplitude * math.sin(turn * math.pi / 4)
     return max(
         0.0,
         min(
-            1.0, 0.42 + 0.28 * progress + phase_bonus + wave + rng.uniform(-0.09, 0.09)
+            1.0,
+            scenario.base_demand
+            + scenario.progress_weight * progress
+            + phase_bonus
+            + wave
+            + rng.uniform(-scenario.noise, scenario.noise),
         ),
     )
 
@@ -169,10 +287,12 @@ def choose_agentic_model(
     history_tokens: int,
     idle_expired: bool,
 ) -> tuple[ModelProfile, str]:
-    if turn == 0 or idle_expired:
-        return base_choice, "cold_or_idle_select"
+    if turn == 0:
+        return base_choice, "cold_select"
     if phase == "tool_loop":
         return current, "tool_loop_hard_lock"
+    if idle_expired:
+        return base_choice, "idle_select"
     if base_choice.name == current.name:
         return current, "base_selects_current"
 
@@ -229,6 +349,8 @@ def rows_from_replay(path: Path) -> list[dict[str, Any]]:
         policy = rec.get("session_policy") or {}
         rows.append(
             {
+                "scenario": rec.get("scenario", "replay"),
+                "seed": rec.get("seed", ""),
                 "session_id": rec.get("session_id", ""),
                 "turn": rec.get("turn_index", 0),
                 "phase": policy.get("phase", ""),
@@ -287,6 +409,14 @@ def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     baseline_quality = [
         float(row["baseline_quality"]) for row in rows if row["baseline_quality"] != ""
     ]
+    baseline_frontier_turns = sum(
+        row.get("baseline_model") == "frontier-reasoner" for row in rows
+    )
+    agentic_frontier_turns = sum(
+        row.get("agentic_model") == "frontier-reasoner" for row in rows
+    )
+    idle_turns = [row for row in rows if bool(row.get("idle_expired"))]
+    agentic_idle_switches = sum(bool(row.get("agentic_switch")) for row in idle_turns)
     return {
         "sessions": len(sessions),
         "turns": len(rows),
@@ -298,6 +428,21 @@ def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "baseline_cost": round(baseline_cost, 6),
         "agentic_cost": round(agentic_cost, 6),
         "cost_delta": round(agentic_cost - baseline_cost, 6),
+        "cost_reduction_pct": (
+            round((baseline_cost - agentic_cost) / baseline_cost * 100, 2)
+            if baseline_cost
+            else None
+        ),
+        "switch_reduction_pct": (
+            round((baseline_switches - agentic_switches) / baseline_switches * 100, 2)
+            if baseline_switches
+            else None
+        ),
+        "baseline_frontier_turns": baseline_frontier_turns,
+        "agentic_frontier_turns": agentic_frontier_turns,
+        "frontier_turn_delta": agentic_frontier_turns - baseline_frontier_turns,
+        "idle_turns": len(idle_turns),
+        "agentic_idle_switches": agentic_idle_switches,
         "mean_cached_prompt_ratio": (
             round(mean(cached_values), 4) if cached_values else None
         ),
@@ -306,6 +451,11 @@ def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
         ),
         "agentic_mean_quality": (
             round(mean(agentic_quality), 4) if agentic_quality else None
+        ),
+        "quality_delta": (
+            round(mean(agentic_quality) - mean(baseline_quality), 4)
+            if agentic_quality and baseline_quality
+            else None
         ),
     }
 
@@ -323,6 +473,73 @@ def write_outputs(rows: list[dict[str, Any]], out_dir: Path) -> dict[str, Any]:
     )
     (out_dir / "summary.svg").write_text(render_svg(summary))
     return summary
+
+
+def parse_seeds(value: str) -> list[int]:
+    seeds = [int(part.strip()) for part in value.split(",") if part.strip()]
+    if not seeds:
+        raise ValueError("--seeds must contain at least one integer")
+    return seeds
+
+
+def write_matrix_outputs(
+    scenarios: tuple[str, ...],
+    seeds: list[int],
+    sessions: int,
+    turns: int,
+    out_dir: Path,
+) -> dict[str, Any]:
+    all_rows: list[dict[str, Any]] = []
+    scenario_summaries: list[dict[str, Any]] = []
+    seed_summaries: list[dict[str, Any]] = []
+    for scenario_name in scenarios:
+        scenario = SCENARIOS[scenario_name]
+        scenario_rows: list[dict[str, Any]] = []
+        for seed in seeds:
+            rows = simulate_workload(sessions, turns, seed, scenario)
+            all_rows.extend(rows)
+            scenario_rows.extend(rows)
+            seed_summaries.append(
+                {
+                    "scenario": scenario_name,
+                    "seed": seed,
+                    **summarize(rows),
+                }
+            )
+        scenario_summaries.append(
+            {"scenario": scenario_name, **summarize(scenario_rows)}
+        )
+
+    summary = {
+        "matrix": {
+            "scenarios": list(scenarios),
+            "seeds": seeds,
+            "sessions_per_seed": sessions,
+            "turns_per_session": turns,
+        },
+        "overall": summarize(all_rows),
+        "by_scenario": scenario_summaries,
+        "by_scenario_seed": seed_summaries,
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_csv(all_rows, out_dir / "turns.csv")
+    write_csv(scenario_summaries, out_dir / "scenario_summary.csv")
+    write_csv(seed_summaries, out_dir / "scenario_seed_summary.csv")
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    )
+    (out_dir / "summary.svg").write_text(render_matrix_svg(summary))
+    return summary
+
+
+def write_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    if not rows:
+        return
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
 
 
 def render_svg(summary: dict[str, Any]) -> str:
@@ -365,15 +582,69 @@ def render_svg(summary: dict[str, Any]) -> str:
     )
 
 
+def render_matrix_svg(summary: dict[str, Any]) -> str:
+    scenarios = summary.get("by_scenario", [])
+    max_switch = max([row["baseline_switches"] for row in scenarios] + [1])
+    max_cost = max([row["baseline_cost"] for row in scenarios] + [1])
+    rows = []
+    for idx, row in enumerate(scenarios):
+        y = 68 + idx * 74
+        rows.append(
+            f'<text x="28" y="{y + 15}" font-size="14" font-weight="700" fill="#111827">{row["scenario"]}</text>'
+        )
+        baseline_switch_w = int(260 * row["baseline_switches"] / max_switch)
+        agentic_switch_w = int(260 * row["agentic_switches"] / max_switch)
+        baseline_cost_w = int(260 * row["baseline_cost"] / max_cost)
+        agentic_cost_w = int(260 * row["agentic_cost"] / max_cost)
+        rows.extend(
+            [
+                f'<rect x="160" y="{y}" width="{baseline_switch_w}" height="14" rx="3" fill="#94a3b8"/>',
+                f'<rect x="160" y="{y + 18}" width="{agentic_switch_w}" height="14" rx="3" fill="#16a34a"/>',
+                f'<text x="430" y="{y + 12}" font-size="11" fill="#475569">switches {row["baseline_switches"]} -> {row["agentic_switches"]}</text>',
+                f'<rect x="560" y="{y}" width="{baseline_cost_w}" height="14" rx="3" fill="#cbd5e1"/>',
+                f'<rect x="560" y="{y + 18}" width="{agentic_cost_w}" height="14" rx="3" fill="#22c55e"/>',
+                f'<text x="830" y="{y + 12}" font-size="11" fill="#475569">cost -{row["cost_reduction_pct"]}%</text>',
+                f'<text x="160" y="{y + 52}" font-size="11" fill="#64748b">tool-loop violations {row["baseline_tool_loop_switch_violations"]} -> {row["agentic_tool_loop_switch_violations"]}; quality delta {row["quality_delta"]}</text>',
+            ]
+        )
+    height = 110 + len(scenarios) * 74
+    return "\n".join(
+        [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="980" height="{height}" viewBox="0 0 980 {height}">',
+            '<rect width="980" height="100%" fill="#f8fafc"/>',
+            '<text x="28" y="32" font-size="20" font-weight="700" fill="#0f172a">Session-aware agentic routing matrix</text>',
+            '<text x="160" y="54" font-size="12" fill="#64748b">model switches</text>',
+            '<text x="560" y="54" font-size="12" fill="#64748b">estimated cost</text>',
+            *rows,
+            f'<rect x="28" y="{height - 28}" width="12" height="12" fill="#94a3b8"/>',
+            f'<text x="46" y="{height - 18}" font-size="11" fill="#64748b">baseline selector</text>',
+            f'<rect x="160" y="{height - 28}" width="12" height="12" fill="#16a34a"/>',
+            f'<text x="178" y="{height - 18}" font-size="11" fill="#64748b">session-aware policy</text>',
+            "</svg>",
+        ]
+    )
+
+
 def main() -> None:
     args = parse_args()
     out_dir = args.output_dir or default_output_dir()
-    rows = (
-        rows_from_replay(args.from_replay)
-        if args.from_replay
-        else simulate_workload(args.sessions, args.turns, args.seed)
-    )
-    summary = write_outputs(rows, out_dir)
+    if args.matrix:
+        summary = write_matrix_outputs(
+            DEFAULT_SCENARIOS,
+            parse_seeds(args.seeds),
+            args.sessions,
+            args.turns,
+            out_dir,
+        )
+    else:
+        rows = (
+            rows_from_replay(args.from_replay)
+            if args.from_replay
+            else simulate_workload(
+                args.sessions, args.turns, args.seed, SCENARIOS[args.scenario]
+            )
+        )
+        summary = write_outputs(rows, out_dir)
     print(
         json.dumps(
             {"output_dir": str(out_dir), "summary": summary}, indent=2, sort_keys=True

--- a/bench/agentic_routing_experiment.py
+++ b/bench/agentic_routing_experiment.py
@@ -53,6 +53,13 @@ MODELS = (
 FRONTIER_DEMAND_THRESHOLD = 0.78
 MID_DEMAND_THRESHOLD = 0.55
 DEFAULT_SCENARIOS = ("balanced", "tool-heavy", "frontier-heavy", "idle-heavy")
+DEFAULT_ABLATION_POLICIES = (
+    "sticky-session",
+    "acr-no-tool-lock",
+    "acr-no-idle-boundary",
+    "acr-no-frontier-cost",
+    "acr-full",
+)
 SCENARIOS = {
     "balanced": WorkloadScenario(
         name="balanced",
@@ -130,6 +137,17 @@ def parse_args() -> argparse.Namespace:
         help="Run the maintained scenario matrix instead of one workload.",
     )
     parser.add_argument(
+        "--ablation",
+        action="store_true",
+        help="Run policy ablations across the maintained scenario matrix.",
+    )
+    parser.add_argument(
+        "--agentic-policy",
+        choices=DEFAULT_ABLATION_POLICIES,
+        default="acr-full",
+        help="Session policy variant used for a single synthetic workload.",
+    )
+    parser.add_argument(
         "--seeds",
         default="20260530,20260531,20260532,20260533,20260534",
         help="Comma-separated seeds for --matrix.",
@@ -147,6 +165,7 @@ def simulate_workload(
     turn_count: int,
     seed: int,
     scenario: WorkloadScenario = SCENARIOS["balanced"],
+    agentic_policy: str = "acr-full",
 ) -> list[dict[str, Any]]:
     rng = random.Random(seed)
     rows: list[dict[str, Any]] = []
@@ -173,6 +192,7 @@ def simulate_workload(
                 switch_count=switch_count,
                 history_tokens=history_tokens,
                 idle_expired=idle_expired,
+                policy=agentic_policy,
             )
 
             baseline_switch = baseline_next.name != baseline_model.name
@@ -286,20 +306,25 @@ def choose_agentic_model(
     switch_count: int,
     history_tokens: int,
     idle_expired: bool,
+    policy: str = "acr-full",
 ) -> tuple[ModelProfile, str]:
+    if policy == "sticky-session" and turn > 0:
+        return current, "sticky_session"
     if turn == 0:
         return base_choice, "cold_select"
-    if phase == "tool_loop":
+    if phase == "tool_loop" and policy != "acr-no-tool-lock":
         return current, "tool_loop_hard_lock"
-    if idle_expired:
+    if idle_expired and policy != "acr-no-idle-boundary":
         return base_choice, "idle_select"
     if base_choice.name == current.name:
         return current, "base_selects_current"
 
     quality_gain = base_choice.quality - current.quality
     continuation_mass = min(1.0, history_tokens / 16000)
-    frontier_multiplier = 1.0 + 1.6 * max(
-        cost_pressure(base_choice), cost_pressure(current)
+    frontier_multiplier = (
+        1.0
+        if policy == "acr-no-frontier-cost"
+        else 1.0 + 1.6 * max(cost_pressure(base_choice), cost_pressure(current))
     )
     switch_cost = (
         0.05
@@ -532,6 +557,91 @@ def write_matrix_outputs(
     return summary
 
 
+def summarize_baseline_policy(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = summarize(rows)
+    return {
+        "policy": "single-turn",
+        "turns": summary["turns"],
+        "switches": summary["baseline_switches"],
+        "switch_reduction_pct": 0.0,
+        "tool_loop_switch_violations": summary["baseline_tool_loop_switch_violations"],
+        "estimated_cost": summary["baseline_cost"],
+        "cost_reduction_pct": 0.0,
+        "frontier_turns": summary["baseline_frontier_turns"],
+        "idle_switches": "",
+        "mean_cached_prompt_ratio": "",
+        "mean_quality": summary["baseline_mean_quality"],
+        "quality_delta": 0.0,
+    }
+
+
+def summarize_agentic_policy(policy: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = summarize(rows)
+    return {
+        "policy": policy,
+        "turns": summary["turns"],
+        "switches": summary["agentic_switches"],
+        "switch_reduction_pct": summary["switch_reduction_pct"],
+        "tool_loop_switch_violations": summary["agentic_tool_loop_switch_violations"],
+        "estimated_cost": summary["agentic_cost"],
+        "cost_reduction_pct": summary["cost_reduction_pct"],
+        "frontier_turns": summary["agentic_frontier_turns"],
+        "idle_switches": summary["agentic_idle_switches"],
+        "mean_cached_prompt_ratio": summary["mean_cached_prompt_ratio"],
+        "mean_quality": summary["agentic_mean_quality"],
+        "quality_delta": summary["quality_delta"],
+    }
+
+
+def write_ablation_outputs(
+    scenarios: tuple[str, ...],
+    seeds: list[int],
+    sessions: int,
+    turns: int,
+    out_dir: Path,
+) -> dict[str, Any]:
+    summary_rows: list[dict[str, Any]] = []
+    policy_rows: dict[str, list[dict[str, Any]]] = {}
+    baseline_rows: list[dict[str, Any]] = []
+
+    for policy in DEFAULT_ABLATION_POLICIES:
+        rows_for_policy: list[dict[str, Any]] = []
+        for scenario_name in scenarios:
+            scenario = SCENARIOS[scenario_name]
+            for seed in seeds:
+                rows = simulate_workload(
+                    sessions,
+                    turns,
+                    seed,
+                    scenario,
+                    agentic_policy=policy,
+                )
+                rows_for_policy.extend(rows)
+                if policy == "acr-full":
+                    baseline_rows.extend(rows)
+        policy_rows[policy] = rows_for_policy
+
+    summary_rows.append(summarize_baseline_policy(baseline_rows))
+    for policy in DEFAULT_ABLATION_POLICIES:
+        summary_rows.append(summarize_agentic_policy(policy, policy_rows[policy]))
+
+    summary = {
+        "matrix": {
+            "scenarios": list(scenarios),
+            "seeds": seeds,
+            "sessions_per_seed": sessions,
+            "turns_per_session": turns,
+        },
+        "by_policy": summary_rows,
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_csv(summary_rows, out_dir / "ablation_summary.csv")
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    )
+    return summary
+
+
 def write_csv(rows: list[dict[str, Any]], path: Path) -> None:
     if not rows:
         return
@@ -628,7 +738,15 @@ def render_matrix_svg(summary: dict[str, Any]) -> str:
 def main() -> None:
     args = parse_args()
     out_dir = args.output_dir or default_output_dir()
-    if args.matrix:
+    if args.ablation:
+        summary = write_ablation_outputs(
+            DEFAULT_SCENARIOS,
+            parse_seeds(args.seeds),
+            args.sessions,
+            args.turns,
+            out_dir,
+        )
+    elif args.matrix:
         summary = write_matrix_outputs(
             DEFAULT_SCENARIOS,
             parse_seeds(args.seeds),
@@ -641,7 +759,11 @@ def main() -> None:
             rows_from_replay(args.from_replay)
             if args.from_replay
             else simulate_workload(
-                args.sessions, args.turns, args.seed, SCENARIOS[args.scenario]
+                args.sessions,
+                args.turns,
+                args.seed,
+                SCENARIOS[args.scenario],
+                agentic_policy=args.agentic_policy,
             )
         )
         summary = write_outputs(rows, out_dir)

--- a/bench/agentic_routing_experiment.py
+++ b/bench/agentic_routing_experiment.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Generate agentic-routing experiment data from replay or a deterministic workload.
+
+The script intentionally uses the Python standard library so maintainers can
+run it on dev and AMD validation hosts without installing plotting stacks.
+It writes CSV/JSON plus a compact SVG figure under .agent-harness by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    name: str
+    quality: float
+    prompt_per_1m: float
+    completion_per_1m: float
+    cached_per_1m: float
+
+
+MODELS = (
+    ModelProfile("qwen3-8b", 0.64, 0.05, 0.10, 0.01),
+    ModelProfile("qwen3-32b", 0.78, 0.30, 0.60, 0.06),
+    ModelProfile("frontier-reasoner", 0.94, 8.00, 24.00, 1.20),
+)
+FRONTIER_DEMAND_THRESHOLD = 0.78
+MID_DEMAND_THRESHOLD = 0.55
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--from-replay", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--sessions", type=int, default=40)
+    parser.add_argument("--turns", type=int, default=18)
+    parser.add_argument("--seed", type=int, default=20260530)
+    return parser.parse_args()
+
+
+def default_output_dir() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path(".agent-harness/experiments/agentic-routing") / stamp
+
+
+def simulate_workload(
+    session_count: int, turn_count: int, seed: int
+) -> list[dict[str, Any]]:
+    rng = random.Random(seed)
+    rows: list[dict[str, Any]] = []
+    for sidx in range(session_count):
+        session_id = f"sess-{sidx:03d}"
+        baseline_model = MODELS[0]
+        agentic_model = MODELS[0]
+        switch_count = 0
+        history_tokens = rng.randint(512, 2048)
+        idle_break_turn = rng.choice((0, turn_count // 2, turn_count + 1))
+
+        for turn in range(turn_count):
+            phase = phase_for_turn(turn)
+            idle_expired = turn == idle_break_turn
+            demand = demand_score(turn, turn_count, phase, rng)
+            base_choice = choose_base_model(demand)
+
+            baseline_next = base_choice
+            agentic_next, reason = choose_agentic_model(
+                base_choice=base_choice,
+                current=agentic_model,
+                phase=phase,
+                turn=turn,
+                switch_count=switch_count,
+                history_tokens=history_tokens,
+                idle_expired=idle_expired,
+            )
+
+            baseline_switch = baseline_next.name != baseline_model.name
+            agentic_switch = agentic_next.name != agentic_model.name
+            if agentic_switch:
+                switch_count += 1
+
+            prompt_tokens = 800 + history_tokens
+            completion_tokens = 220 + int(180 * demand)
+            cached_ratio = cached_ratio_for(
+                agentic_next, phase, history_tokens, agentic_switch
+            )
+            baseline_cost = turn_cost(
+                baseline_next, prompt_tokens, 0.0, completion_tokens
+            )
+            agentic_cost = turn_cost(
+                agentic_next, prompt_tokens, cached_ratio, completion_tokens
+            )
+
+            rows.append(
+                {
+                    "session_id": session_id,
+                    "turn": turn,
+                    "phase": phase,
+                    "idle_expired": idle_expired,
+                    "demand": round(demand, 4),
+                    "history_tokens": history_tokens,
+                    "baseline_model": baseline_next.name,
+                    "agentic_model": agentic_next.name,
+                    "baseline_switch": baseline_switch,
+                    "agentic_switch": agentic_switch,
+                    "tool_loop_switch_violation_baseline": phase == "tool_loop"
+                    and baseline_switch,
+                    "tool_loop_switch_violation_agentic": phase == "tool_loop"
+                    and agentic_switch,
+                    "cached_prompt_ratio": round(cached_ratio, 4),
+                    "baseline_quality": baseline_next.quality,
+                    "agentic_quality": agentic_next.quality,
+                    "baseline_cost": round(baseline_cost, 8),
+                    "agentic_cost": round(agentic_cost, 8),
+                    "policy_reason": reason,
+                }
+            )
+
+            baseline_model = baseline_next
+            agentic_model = agentic_next
+            history_tokens = min(
+                32000, history_tokens + prompt_tokens // 8 + completion_tokens
+            )
+    return rows
+
+
+def phase_for_turn(turn: int) -> str:
+    cycle = turn % 5
+    if cycle in (2, 3):
+        return "tool_loop"
+    return "user_turn"
+
+
+def demand_score(turn: int, turn_count: int, phase: str, rng: random.Random) -> float:
+    progress = turn / max(turn_count - 1, 1)
+    phase_bonus = 0.16 if phase == "tool_loop" else 0.0
+    wave = 0.18 * math.sin(turn * math.pi / 4)
+    return max(
+        0.0,
+        min(
+            1.0, 0.42 + 0.28 * progress + phase_bonus + wave + rng.uniform(-0.09, 0.09)
+        ),
+    )
+
+
+def choose_base_model(demand: float) -> ModelProfile:
+    if demand >= FRONTIER_DEMAND_THRESHOLD:
+        return MODELS[2]
+    if demand >= MID_DEMAND_THRESHOLD:
+        return MODELS[1]
+    return MODELS[0]
+
+
+def choose_agentic_model(
+    base_choice: ModelProfile,
+    current: ModelProfile,
+    phase: str,
+    turn: int,
+    switch_count: int,
+    history_tokens: int,
+    idle_expired: bool,
+) -> tuple[ModelProfile, str]:
+    if turn == 0 or idle_expired:
+        return base_choice, "cold_or_idle_select"
+    if phase == "tool_loop":
+        return current, "tool_loop_hard_lock"
+    if base_choice.name == current.name:
+        return current, "base_selects_current"
+
+    quality_gain = base_choice.quality - current.quality
+    continuation_mass = min(1.0, history_tokens / 16000)
+    frontier_multiplier = 1.0 + 1.6 * max(
+        cost_pressure(base_choice), cost_pressure(current)
+    )
+    switch_cost = (
+        0.05
+        + 0.20 * continuation_mass * frontier_multiplier
+        + 0.04 * min(switch_count / 8, 1)
+    )
+    if quality_gain > switch_cost:
+        return base_choice, "quality_gain_clears_switch_cost"
+    return current, "continuity_cost_blocks_switch"
+
+
+def cost_pressure(model: ModelProfile) -> float:
+    max_cost = max(m.prompt_per_1m + m.completion_per_1m for m in MODELS)
+    return (model.prompt_per_1m + model.completion_per_1m) / max_cost
+
+
+def cached_ratio_for(
+    model: ModelProfile, phase: str, history_tokens: int, switched: bool
+) -> float:
+    base = min(0.72, history_tokens / 48000)
+    if phase == "tool_loop":
+        base += 0.12
+    if model.name == "frontier-reasoner":
+        base += 0.06
+    if switched:
+        base *= 0.20
+    return max(0.0, min(0.85, base))
+
+
+def turn_cost(
+    model: ModelProfile, prompt_tokens: int, cached_ratio: float, completion_tokens: int
+) -> float:
+    cached = int(prompt_tokens * cached_ratio)
+    uncached = prompt_tokens - cached
+    return (
+        uncached * model.prompt_per_1m
+        + cached * model.cached_per_1m
+        + completion_tokens * model.completion_per_1m
+    ) / 1_000_000
+
+
+def rows_from_replay(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text())
+    records = data.get("data", data) if isinstance(data, dict) else data
+    rows = []
+    for rec in records:
+        policy = rec.get("session_policy") or {}
+        rows.append(
+            {
+                "session_id": rec.get("session_id", ""),
+                "turn": rec.get("turn_index", 0),
+                "phase": policy.get("phase", ""),
+                "idle_expired": policy.get("idle_expired", False),
+                "demand": "",
+                "history_tokens": "",
+                "baseline_model": policy.get("fallback_selected_model", ""),
+                "agentic_model": rec.get("selected_model", ""),
+                "baseline_switch": "",
+                "agentic_switch": policy.get("current_model")
+                != rec.get("selected_model"),
+                "tool_loop_switch_violation_baseline": "",
+                "tool_loop_switch_violation_agentic": policy.get("phase") == "tool_loop"
+                and policy.get("current_model") != rec.get("selected_model"),
+                "cached_prompt_ratio": "",
+                "baseline_quality": "",
+                "agentic_quality": "",
+                "baseline_cost": rec.get("baseline_cost", ""),
+                "agentic_cost": rec.get("actual_cost", ""),
+                "policy_reason": policy.get("decision_reason", ""),
+            }
+        )
+    return rows
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if not rows:
+        return {}
+    sessions = {row["session_id"] for row in rows}
+    baseline_switches = sum(
+        bool(row["baseline_switch"]) for row in rows if row["baseline_switch"] != ""
+    )
+    agentic_switches = sum(
+        bool(row["agentic_switch"]) for row in rows if row["agentic_switch"] != ""
+    )
+    baseline_tool_violations = sum(
+        bool(row["tool_loop_switch_violation_baseline"])
+        for row in rows
+        if row["tool_loop_switch_violation_baseline"] != ""
+    )
+    agentic_tool_violations = sum(
+        bool(row["tool_loop_switch_violation_agentic"])
+        for row in rows
+        if row["tool_loop_switch_violation_agentic"] != ""
+    )
+    baseline_cost = sum(float(row["baseline_cost"] or 0) for row in rows)
+    agentic_cost = sum(float(row["agentic_cost"] or 0) for row in rows)
+    cached_values = [
+        float(row["cached_prompt_ratio"])
+        for row in rows
+        if row["cached_prompt_ratio"] != ""
+    ]
+    agentic_quality = [
+        float(row["agentic_quality"]) for row in rows if row["agentic_quality"] != ""
+    ]
+    baseline_quality = [
+        float(row["baseline_quality"]) for row in rows if row["baseline_quality"] != ""
+    ]
+    return {
+        "sessions": len(sessions),
+        "turns": len(rows),
+        "baseline_switches": baseline_switches,
+        "agentic_switches": agentic_switches,
+        "switch_reduction": baseline_switches - agentic_switches,
+        "baseline_tool_loop_switch_violations": baseline_tool_violations,
+        "agentic_tool_loop_switch_violations": agentic_tool_violations,
+        "baseline_cost": round(baseline_cost, 6),
+        "agentic_cost": round(agentic_cost, 6),
+        "cost_delta": round(agentic_cost - baseline_cost, 6),
+        "mean_cached_prompt_ratio": (
+            round(mean(cached_values), 4) if cached_values else None
+        ),
+        "baseline_mean_quality": (
+            round(mean(baseline_quality), 4) if baseline_quality else None
+        ),
+        "agentic_mean_quality": (
+            round(mean(agentic_quality), 4) if agentic_quality else None
+        ),
+    }
+
+
+def write_outputs(rows: list[dict[str, Any]], out_dir: Path) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary = summarize(rows)
+    fieldnames = list(rows[0].keys()) if rows else []
+    with (out_dir / "turns.csv").open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    )
+    (out_dir / "summary.svg").write_text(render_svg(summary))
+    return summary
+
+
+def render_svg(summary: dict[str, Any]) -> str:
+    metrics = [
+        ("Baseline switches", float(summary.get("baseline_switches") or 0)),
+        ("Agentic switches", float(summary.get("agentic_switches") or 0)),
+        (
+            "Baseline tool violations",
+            float(summary.get("baseline_tool_loop_switch_violations") or 0),
+        ),
+        (
+            "Agentic tool violations",
+            float(summary.get("agentic_tool_loop_switch_violations") or 0),
+        ),
+    ]
+    max_value = max([value for _, value in metrics] + [1])
+    bars = []
+    for idx, (label, value) in enumerate(metrics):
+        y = 48 + idx * 42
+        width = int(420 * value / max_value)
+        color = "#2f6fed" if "Agentic" in label else "#8892a0"
+        bars.append(
+            f'<text x="24" y="{y + 15}" font-size="13" fill="#1f2937">{label}</text>'
+        )
+        bars.append(
+            f'<rect x="190" y="{y}" width="{width}" height="22" rx="4" fill="{color}"/>'
+        )
+        bars.append(
+            f'<text x="{198 + width}" y="{y + 15}" font-size="12" fill="#111827">{int(value)}</text>'
+        )
+    return "\n".join(
+        [
+            '<svg xmlns="http://www.w3.org/2000/svg" width="680" height="240" viewBox="0 0 680 240">',
+            '<rect width="680" height="240" fill="#f8fafc"/>',
+            '<text x="24" y="28" font-size="18" font-weight="700" fill="#111827">Agentic Continuity Routing</text>',
+            *bars,
+            f'<text x="24" y="224" font-size="12" fill="#4b5563">Cost delta: {summary.get("cost_delta")} | Mean cached ratio: {summary.get("mean_cached_prompt_ratio")}</text>',
+            "</svg>",
+        ]
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    out_dir = args.output_dir or default_output_dir()
+    rows = (
+        rows_from_replay(args.from_replay)
+        if args.from_replay
+        else simulate_workload(args.sessions, args.turns, args.seed)
+    )
+    summary = write_outputs(rows, out_dir)
+    print(
+        json.dumps(
+            {"output_dir": str(out_dir), "summary": summary}, indent=2, sort_keys=True
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/config/README.md
+++ b/config/README.md
@@ -23,7 +23,7 @@ Inside canonical `config.yaml`:
 - structure `density` features now use built-in multilingual text-unit normalization; the contract no longer exposes a per-rule `normalize_by` switch
 - the dashboard and DSL builder now expose the same projection surface directly; see `website/docs/tutorials/signal/projections.md` and the maintained `deploy/recipes/balance.{yaml,dsl}` pair for end-to-end usage
 - `global.router`, `global.services`, `global.stores`, `global.integrations`, and `global.model_catalog` expose router-wide overrides explicitly
-- `global.router.model_selection.model_switch_gate` enables optional shadow or enforce-mode session-aware stay-vs-switch auditing after the configured selector runs; `mode: enforce` only takes effect on Response API requests with conversation history, Chat Completions traffic is audited in shadow regardless of mode until per-turn model history persistence ships
+- `decision.algorithm.type=session_aware` wraps a base selector with agentic session policy: tool loops stay on the current model, non-idle sessions pay handoff, switch-history, and prefix-cache costs before switching, idle sessions can reselect after `idle_timeout_seconds`, and router replay records the full policy trace for experiments
 - `global.services.router_replay.enabled` is the router-wide replay default; when it is on, decisions inherit replay capture unless a route-local `router_replay` plugin sets `enabled: false`
 - embedding fallback tuning such as `global.model_catalog.embeddings.semantic.embedding_config.top_k` lives under the router-owned model catalog, not under individual signal rules
 - prototype-aware exemplar compression and label scoring live alongside their owning signal families: `global.model_catalog.embeddings.semantic.embedding_config.prototype_scoring`, `global.model_catalog.modules.classifier.preference.prototype_scoring`, `global.model_catalog.kbs[].prototype_scoring`, and `global.model_catalog.modules.complexity.prototype_scoring`
@@ -47,7 +47,7 @@ Candidate iteration fragments must stay bounded to `decision.candidates` or an e
 `config/algorithm/` is organized by routing policy:
 
 - `looper/`: multi-model execution policies such as `confidence`, `ratings`, and `remom`
-- `selection/`: candidate-selection policies such as `elo`, `router_dc`, `automix`, and `latency_aware`
+- `selection/`: candidate-selection policies such as `elo`, `router_dc`, `automix`, `session_aware`, and `latency_aware`
 
 Each supported algorithm now has its own tutorial page under `website/docs/tutorials/algorithm/`.
 

--- a/config/algorithm/selection/session-aware.yaml
+++ b/config/algorithm/selection/session-aware.yaml
@@ -1,0 +1,16 @@
+algorithm:
+  type: session_aware
+  session_aware:
+    fallback_method: hybrid
+    idle_timeout_seconds: 300
+    min_turns_before_switch: 1
+    switch_margin: 0.05
+    stay_bias: 0.10
+    tool_loop_hard_lock: true
+    tool_loop_stay_bias: 0.35
+    prefix_cache_weight: 0.20
+    handoff_penalty_weight: 1.0
+    default_handoff_penalty: 0.05
+    quality_gap_multiplier: 1.0
+    max_cache_cost_multiplier: 2.5
+    switch_history_weight: 0.04

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -443,6 +443,14 @@ routing:
             type: tool_definition
         predicate:
           gte: 1
+      - name: active_tool_use
+        description: Tool-result continuation inside an agent loop.
+        feature:
+          type: count
+          source:
+            type: assistant_tool_cycle
+        predicate:
+          gte: 1
       - name: has_developer_msg
         description: Request contains a developer message.
         feature:
@@ -1091,6 +1099,34 @@ routing:
           latency_percentile: 95
           on_no_candidates: cheapest
 
+    - name: agentic_session_route
+      description: Session-aware policy for agentic multi-turn traffic.
+      priority: 123
+      rules:
+        operator: AND
+        conditions:
+          - type: conversation
+            name: active_tool_use
+      modelRefs:
+        - model: qwen3-8b
+        - model: qwen3-32b
+      algorithm:
+        type: session_aware
+        session_aware:
+          fallback_method: hybrid
+          idle_timeout_seconds: 300
+          min_turns_before_switch: 1
+          switch_margin: 0.05
+          stay_bias: 0.10
+          tool_loop_hard_lock: true
+          tool_loop_stay_bias: 0.35
+          prefix_cache_weight: 0.20
+          handoff_penalty_weight: 1.0
+          default_handoff_penalty: 0.05
+          quality_gap_multiplier: 1.0
+          max_cache_cost_multiplier: 2.5
+          switch_history_weight: 0.04
+
     - name: fallback_knn_route
       description: KNN fallback route for general traffic with OpenAI vector-store RAG.
       priority: 120
@@ -1347,6 +1383,20 @@ global:
         cost_weight: 0.1
         quality_gap_threshold: 0.08
         normalize_scores: true
+      session_aware:
+        fallback_method: hybrid
+        idle_timeout_seconds: 300
+        min_turns_before_switch: 1
+        switch_margin: 0.05
+        stay_bias: 0.10
+        tool_loop_hard_lock: true
+        tool_loop_stay_bias: 0.35
+        prefix_cache_weight: 0.20
+        handoff_penalty_weight: 1.0
+        default_handoff_penalty: 0.05
+        quality_gap_multiplier: 1.0
+        max_cache_cost_multiplier: 2.5
+        switch_history_weight: 0.04
       momentum:
         enabled: false
         attack: 0.7

--- a/src/semantic-router/pkg/classification/classifier_signal_conversation.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_conversation.go
@@ -20,6 +20,8 @@ type ConversationFacts struct {
 	ToolDefinitionCount    int
 	AssistantToolCallCount int
 	ToolResultCount        int
+	LastMessageRole        string
+	LastMessageToolResult  bool
 }
 
 func (c *Classifier) evaluateConversationSignal(results *SignalResults, mu *sync.Mutex, facts ConversationFacts) {

--- a/src/semantic-router/pkg/config/decision_config.go
+++ b/src/semantic-router/pkg/config/decision_config.go
@@ -70,6 +70,7 @@ type AlgorithmConfig struct {
 	GMTRouter    *GMTRouterSelectionConfig    `yaml:"gmtrouter,omitempty"`
 	LatencyAware *LatencyAwareAlgorithmConfig `yaml:"latency_aware,omitempty"`
 	MultiFactor  *MultiFactorSelectionConfig  `yaml:"multi_factor,omitempty"`
+	SessionAware *SessionAwareSelectionConfig `yaml:"session_aware,omitempty"`
 	OnError      string                       `yaml:"on_error,omitempty"`
 }
 

--- a/src/semantic-router/pkg/config/docs_contract_algorithm_plugin_test.go
+++ b/src/semantic-router/pkg/config/docs_contract_algorithm_plugin_test.go
@@ -23,6 +23,7 @@ var algorithmTutorialBuckets = map[string]string{
 	"remom":         "looper",
 	"rl-driven":     "selection",
 	"router-dc":     "selection",
+	"session-aware": "selection",
 	"static":        "selection",
 	"svm":           "selection",
 }

--- a/src/semantic-router/pkg/config/fragment_catalog_test.go
+++ b/src/semantic-router/pkg/config/fragment_catalog_test.go
@@ -40,6 +40,7 @@ func TestConfigFragmentCatalogCoversSupportedRoutingSurfaces(t *testing.T) {
 		"remom":         filepath.Join("looper", "remom.yaml"),
 		"rl_driven":     filepath.Join("selection", "rl-driven.yaml"),
 		"router_dc":     filepath.Join("selection", "router-dc.yaml"),
+		"session_aware": filepath.Join("selection", "session-aware.yaml"),
 		"static":        filepath.Join("selection", "static.yaml"),
 		"svm":           filepath.Join("selection", "svm.yaml"),
 	}

--- a/src/semantic-router/pkg/config/reference_config_global_test.go
+++ b/src/semantic-router/pkg/config/reference_config_global_test.go
@@ -18,6 +18,7 @@ func assertReferenceConfigRouterSelectionCoverage(t testingT, modelSelection map
 	assertMapCoversStructFields(t, mustMapAt(t, modelSelection, "router_dc"), reflect.TypeOf(RouterDCSelectionConfig{}), "global.router.model_selection.router_dc")
 	assertMapCoversStructFields(t, mustMapAt(t, modelSelection, "automix"), reflect.TypeOf(AutoMixSelectionConfig{}), "global.router.model_selection.automix")
 	assertMapCoversStructFields(t, mustMapAt(t, modelSelection, "hybrid"), reflect.TypeOf(HybridSelectionConfig{}), "global.router.model_selection.hybrid")
+	assertMapCoversStructFields(t, mustMapAt(t, modelSelection, "session_aware"), reflect.TypeOf(SessionAwareSelectionConfig{}), "global.router.model_selection.session_aware")
 	assertMapCoversStructFields(t, mustMapAt(t, modelSelection, "model_switch_gate"), reflect.TypeOf(ModelSwitchGateConfig{}), "global.router.model_selection.model_switch_gate")
 	assertMapCoversStructFields(t, mustMapAt(t, modelSelection, "ml", "knn"), reflect.TypeOf(MLKNNConfig{}), "global.router.model_selection.ml.knn")
 	assertMapCoversStructFields(t, mustMapAt(t, modelSelection, "ml", "kmeans"), reflect.TypeOf(MLKMeansConfig{}), "global.router.model_selection.ml.kmeans")

--- a/src/semantic-router/pkg/config/reference_config_routing_surface_test.go
+++ b/src/semantic-router/pkg/config/reference_config_routing_surface_test.go
@@ -54,6 +54,8 @@ func assertSupportedAlgorithmsInReferenceConfig(t testingT, decisions []interfac
 	assertMapCoversStructFields(t, mustMapAt(t, algorithmsByType["rl_driven"], "rl_driven"), reflect.TypeOf(RLDrivenSelectionConfig{}), "routing.decisions[].algorithm.rl_driven")
 	assertMapCoversStructFields(t, mustMapAt(t, algorithmsByType["gmtrouter"], "gmtrouter"), reflect.TypeOf(GMTRouterSelectionConfig{}), "routing.decisions[].algorithm.gmtrouter")
 	assertMapCoversStructFields(t, mustMapAt(t, algorithmsByType["latency_aware"], "latency_aware"), reflect.TypeOf(LatencyAwareAlgorithmConfig{}), "routing.decisions[].algorithm.latency_aware")
+	assertMapCoversStructFields(t, mustMapAt(t, algorithmsByType["multi_factor"], "multi_factor"), reflect.TypeOf(MultiFactorSelectionConfig{}), "routing.decisions[].algorithm.multi_factor")
+	assertMapCoversStructFields(t, mustMapAt(t, algorithmsByType["session_aware"], "session_aware"), reflect.TypeOf(SessionAwareSelectionConfig{}), "routing.decisions[].algorithm.session_aware")
 }
 
 func assertReferenceConfidenceAlgorithmCoverage(t testingT, algorithmsByType map[string]map[string]interface{}) {

--- a/src/semantic-router/pkg/config/routing_surface_catalog.go
+++ b/src/semantic-router/pkg/config/routing_surface_catalog.go
@@ -76,6 +76,7 @@ var decisionAlgorithmCatalog = []AlgorithmCatalogEntry{
 	{Type: "remom", Tier: "supported"},
 	{Type: "rl_driven", Tier: "experimental"},
 	{Type: "router_dc", Tier: "supported"},
+	{Type: "session_aware", Tier: "supported"},
 	{Type: "static", Tier: "supported"},
 	{Type: "svm", Tier: "experimental"},
 }

--- a/src/semantic-router/pkg/config/selection_config.go
+++ b/src/semantic-router/pkg/config/selection_config.go
@@ -15,7 +15,8 @@ type ModelSelectionConfig struct {
 	Hybrid   HybridSelectionConfig   `yaml:"hybrid,omitempty"`
 	ML       MLSelectionConfig       `yaml:"ml,omitempty"`
 
-	Momentum MomentumSelectionConfig `yaml:"momentum,omitempty"`
+	SessionAware SessionAwareSelectionConfig `yaml:"session_aware,omitempty"`
+	Momentum     MomentumSelectionConfig     `yaml:"momentum,omitempty"`
 
 	// ModelSwitchGate configures session-aware stay-vs-switch evaluation.
 	ModelSwitchGate ModelSwitchGateConfig `yaml:"model_switch_gate,omitempty"`
@@ -187,6 +188,24 @@ type HybridSelectionConfig struct {
 	CostWeight          float64 `yaml:"cost_weight,omitempty"`
 	QualityGapThreshold float64 `yaml:"quality_gap_threshold,omitempty"`
 	NormalizeScores     bool    `yaml:"normalize_scores,omitempty"`
+}
+
+// SessionAwareSelectionConfig configures the session_aware selector. It wraps
+// a base selector and adds agentic session stay-vs-switch policy.
+type SessionAwareSelectionConfig struct {
+	FallbackMethod         string  `yaml:"fallback_method,omitempty"`
+	IdleTimeoutSeconds     int     `yaml:"idle_timeout_seconds,omitempty"`
+	MinTurnsBeforeSwitch   int     `yaml:"min_turns_before_switch,omitempty"`
+	SwitchMargin           float64 `yaml:"switch_margin,omitempty"`
+	StayBias               float64 `yaml:"stay_bias,omitempty"`
+	ToolLoopHardLock       *bool   `yaml:"tool_loop_hard_lock,omitempty"`
+	ToolLoopStayBias       float64 `yaml:"tool_loop_stay_bias,omitempty"`
+	PrefixCacheWeight      float64 `yaml:"prefix_cache_weight,omitempty"`
+	HandoffPenaltyWeight   float64 `yaml:"handoff_penalty_weight,omitempty"`
+	DefaultHandoffPenalty  float64 `yaml:"default_handoff_penalty,omitempty"`
+	QualityGapMultiplier   float64 `yaml:"quality_gap_multiplier,omitempty"`
+	MaxCacheCostMultiplier float64 `yaml:"max_cache_cost_multiplier,omitempty"`
+	SwitchHistoryWeight    float64 `yaml:"switch_history_weight,omitempty"`
 }
 
 // MultiFactorSelectionConfig configures the multi_factor selector, which

--- a/src/semantic-router/pkg/config/validator.go
+++ b/src/semantic-router/pkg/config/validator.go
@@ -207,6 +207,9 @@ func validateModelSelectionConfig(cfg *RouterConfig) error {
 	if err := validateModelSwitchGate(cfg.ModelSelection.ModelSwitchGate); err != nil {
 		return err
 	}
+	if err := validateSessionAwareSelectionConfig(cfg.ModelSelection.SessionAware); err != nil {
+		return err
+	}
 	warnModelSwitchGateEnforceWithoutCostSignals(cfg.ModelSelection)
 	return nil
 }

--- a/src/semantic-router/pkg/config/validator_decision.go
+++ b/src/semantic-router/pkg/config/validator_decision.go
@@ -194,25 +194,7 @@ func validateDecisionAlgorithmConfig(decisionName string, algorithm *AlgorithmCo
 		displayType = "<empty>"
 	}
 
-	configuredBlocks := make([]string, 0, 10)
-	addBlock := func(name string, configured bool) {
-		if configured {
-			configuredBlocks = append(configuredBlocks, name)
-		}
-	}
-
-	addBlock("confidence", algorithm.Confidence != nil)
-	addBlock("ratings", algorithm.Ratings != nil)
-	addBlock("remom", algorithm.ReMoM != nil)
-	addBlock("elo", algorithm.Elo != nil)
-	addBlock("router_dc", algorithm.RouterDC != nil)
-	addBlock("automix", algorithm.AutoMix != nil)
-	addBlock("hybrid", algorithm.Hybrid != nil)
-	addBlock("rl_driven", algorithm.RLDriven != nil)
-	addBlock("gmtrouter", algorithm.GMTRouter != nil)
-	addBlock("latency_aware", algorithm.LatencyAware != nil)
-	addBlock("multi_factor", algorithm.MultiFactor != nil)
-
+	configuredBlocks := configuredAlgorithmBlocks(algorithm)
 	if len(configuredBlocks) > 1 {
 		return fmt.Errorf(
 			"decision '%s': algorithm.type=%s cannot be combined with multiple algorithm config blocks: %s",
@@ -222,21 +204,7 @@ func validateDecisionAlgorithmConfig(decisionName string, algorithm *AlgorithmCo
 		)
 	}
 
-	expectedBlockByType := map[string]string{
-		"confidence":    "confidence",
-		"ratings":       "ratings",
-		"remom":         "remom",
-		"elo":           "elo",
-		"router_dc":     "router_dc",
-		"automix":       "automix",
-		"hybrid":        "hybrid",
-		"rl_driven":     "rl_driven",
-		"gmtrouter":     "gmtrouter",
-		"latency_aware": "latency_aware",
-		"multi_factor":  "multi_factor",
-	}
-
-	expectedBlock, hasExpectedBlock := expectedBlockByType[normalizedType]
+	expectedBlock, hasExpectedBlock := expectedAlgorithmBlock(normalizedType)
 	if !hasExpectedBlock {
 		if len(configuredBlocks) > 0 {
 			return fmt.Errorf(
@@ -259,15 +227,72 @@ func validateDecisionAlgorithmConfig(decisionName string, algorithm *AlgorithmCo
 		)
 	}
 
-	if normalizedType == "latency_aware" {
+	if err := validateSpecializedAlgorithmConfig(decisionName, normalizedType, algorithm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func configuredAlgorithmBlocks(algorithm *AlgorithmConfig) []string {
+	configuredBlocks := make([]string, 0, 12)
+	addBlock := func(name string, configured bool) {
+		if configured {
+			configuredBlocks = append(configuredBlocks, name)
+		}
+	}
+
+	addBlock("confidence", algorithm.Confidence != nil)
+	addBlock("ratings", algorithm.Ratings != nil)
+	addBlock("remom", algorithm.ReMoM != nil)
+	addBlock("elo", algorithm.Elo != nil)
+	addBlock("router_dc", algorithm.RouterDC != nil)
+	addBlock("automix", algorithm.AutoMix != nil)
+	addBlock("hybrid", algorithm.Hybrid != nil)
+	addBlock("rl_driven", algorithm.RLDriven != nil)
+	addBlock("gmtrouter", algorithm.GMTRouter != nil)
+	addBlock("latency_aware", algorithm.LatencyAware != nil)
+	addBlock("multi_factor", algorithm.MultiFactor != nil)
+	addBlock("session_aware", algorithm.SessionAware != nil)
+	return configuredBlocks
+}
+
+func expectedAlgorithmBlock(normalizedType string) (string, bool) {
+	expectedBlockByType := map[string]string{
+		"confidence":    "confidence",
+		"ratings":       "ratings",
+		"remom":         "remom",
+		"elo":           "elo",
+		"router_dc":     "router_dc",
+		"automix":       "automix",
+		"hybrid":        "hybrid",
+		"rl_driven":     "rl_driven",
+		"gmtrouter":     "gmtrouter",
+		"latency_aware": "latency_aware",
+		"multi_factor":  "multi_factor",
+		"session_aware": "session_aware",
+	}
+	expectedBlock, ok := expectedBlockByType[normalizedType]
+	return expectedBlock, ok
+}
+
+func validateSpecializedAlgorithmConfig(decisionName string, normalizedType string, algorithm *AlgorithmConfig) error {
+	switch normalizedType {
+	case "latency_aware":
 		if algorithm.LatencyAware == nil {
 			return fmt.Errorf("decision '%s': algorithm.type=latency_aware requires algorithm.latency_aware configuration", decisionName)
 		}
 		if err := validateLatencyAwareAlgorithmConfig(algorithm.LatencyAware); err != nil {
 			return fmt.Errorf("decision '%s', algorithm.latency_aware: %w", decisionName, err)
 		}
+	case "session_aware":
+		if algorithm.SessionAware == nil {
+			return nil
+		}
+		if err := validateSessionAwareSelectionConfig(*algorithm.SessionAware); err != nil {
+			return fmt.Errorf("decision '%s', algorithm.session_aware: %w", decisionName, err)
+		}
 	}
-
 	return nil
 }
 

--- a/src/semantic-router/pkg/config/validator_model_switch_gate.go
+++ b/src/semantic-router/pkg/config/validator_model_switch_gate.go
@@ -37,6 +37,43 @@ func validateModelSwitchGate(cfg ModelSwitchGateConfig) error {
 	return nil
 }
 
+func validateSessionAwareSelectionConfig(cfg SessionAwareSelectionConfig) error {
+	if cfg.IdleTimeoutSeconds < 0 {
+		return fmt.Errorf("session_aware.idle_timeout_seconds must be >= 0, got %d", cfg.IdleTimeoutSeconds)
+	}
+	if cfg.MinTurnsBeforeSwitch < 0 {
+		return fmt.Errorf("session_aware.min_turns_before_switch must be >= 0, got %d", cfg.MinTurnsBeforeSwitch)
+	}
+	if cfg.SwitchMargin < 0 {
+		return fmt.Errorf("session_aware.switch_margin must be >= 0, got %v", cfg.SwitchMargin)
+	}
+	if cfg.StayBias < 0 {
+		return fmt.Errorf("session_aware.stay_bias must be >= 0, got %v", cfg.StayBias)
+	}
+	if cfg.ToolLoopStayBias < 0 {
+		return fmt.Errorf("session_aware.tool_loop_stay_bias must be >= 0, got %v", cfg.ToolLoopStayBias)
+	}
+	if cfg.PrefixCacheWeight < 0 {
+		return fmt.Errorf("session_aware.prefix_cache_weight must be >= 0, got %v", cfg.PrefixCacheWeight)
+	}
+	if cfg.HandoffPenaltyWeight < 0 {
+		return fmt.Errorf("session_aware.handoff_penalty_weight must be >= 0, got %v", cfg.HandoffPenaltyWeight)
+	}
+	if cfg.DefaultHandoffPenalty < 0 {
+		return fmt.Errorf("session_aware.default_handoff_penalty must be >= 0, got %v", cfg.DefaultHandoffPenalty)
+	}
+	if cfg.QualityGapMultiplier < 0 {
+		return fmt.Errorf("session_aware.quality_gap_multiplier must be >= 0, got %v", cfg.QualityGapMultiplier)
+	}
+	if cfg.MaxCacheCostMultiplier < 0 {
+		return fmt.Errorf("session_aware.max_cache_cost_multiplier must be >= 0, got %v", cfg.MaxCacheCostMultiplier)
+	}
+	if cfg.SwitchHistoryWeight < 0 {
+		return fmt.Errorf("session_aware.switch_history_weight must be >= 0, got %v", cfg.SwitchHistoryWeight)
+	}
+	return nil
+}
+
 // warnModelSwitchGateEnforceWithoutCostSignals emits a startup warning when
 // enforce is configured but neither lookup_tables nor a default handoff penalty
 // is in place. In that situation the gate's stay cost has no real evidence and

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -101,6 +101,7 @@ func (r *OpenAIRouter) runRequestPreRoutingStages(
 	fast *FastExtractResult,
 	ctx *RequestContext,
 ) (requestDecisionState, *ext_proc.ProcessingResponse) {
+	populatePinnedSessionFromHeaders(ctx)
 	history := signalConversationHistoryFromFastExtract(fast)
 	decisionName, _, reasoningDecision, selectedModel, authzErr := r.performDecisionEvaluation(
 		originalModel,

--- a/src/semantic-router/pkg/extproc/processor_res_usage.go
+++ b/src/semantic-router/pkg/extproc/processor_res_usage.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openai/openai-go"
 	"github.com/tidwall/gjson"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/inflight"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/latency"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -16,8 +17,9 @@ import (
 )
 
 type responseUsageMetrics struct {
-	promptTokens     int
-	completionTokens int
+	promptTokens       int
+	cachedPromptTokens int
+	completionTokens   int
 }
 
 // =====================================================================
@@ -33,17 +35,32 @@ func parseResponseUsage(responseBody []byte, model string) responseUsageMetrics 
 
 	promptTokens := gjson.GetBytes(responseBody, "usage.prompt_tokens")
 	completionTokens := gjson.GetBytes(responseBody, "usage.completion_tokens")
+	cachedPromptTokens := firstNumericGJSON(
+		gjson.GetBytes(responseBody, "usage.prompt_tokens_details.cached_tokens"),
+		gjson.GetBytes(responseBody, "usage.input_tokens_details.cached_tokens"),
+	)
 	if (promptTokens.Exists() && promptTokens.Type != gjson.Number) ||
-		(completionTokens.Exists() && completionTokens.Type != gjson.Number) {
+		(completionTokens.Exists() && completionTokens.Type != gjson.Number) ||
+		(cachedPromptTokens.Exists() && cachedPromptTokens.Type != gjson.Number) {
 		logging.Errorf("Error parsing tokens from response: usage fields must be numbers")
 		metrics.RecordRequestError(model, "parse_error")
 		return responseUsageMetrics{}
 	}
 
 	return responseUsageMetrics{
-		promptTokens:     int(promptTokens.Int()),
-		completionTokens: int(completionTokens.Int()),
+		promptTokens:       int(promptTokens.Int()),
+		cachedPromptTokens: clampCachedPromptTokensInt(int(promptTokens.Int()), int(cachedPromptTokens.Int())),
+		completionTokens:   int(completionTokens.Int()),
 	}
+}
+
+func firstNumericGJSON(values ...gjson.Result) gjson.Result {
+	for _, value := range values {
+		if value.Exists() {
+			return value
+		}
+	}
+	return gjson.Result{}
 }
 
 func (r *OpenAIRouter) reportNonStreamingUsage(
@@ -108,22 +125,23 @@ func (r *OpenAIRouter) recordResponseCost(
 		"request_id":            ctx.RequestID,
 		"model":                 ctx.RequestModel,
 		"prompt_tokens":         usage.promptTokens,
+		"cached_prompt_tokens":  usage.cachedPromptTokens,
 		"completion_tokens":     usage.completionTokens,
 		"total_tokens":          totalTokens,
 		"completion_latency_ms": completionLatency.Milliseconds(),
 	}
 
 	if r.Config != nil {
-		promptRatePer1M, completionRatePer1M, currency, ok := r.Config.GetModelPricing(ctx.RequestModel)
+		pricing, ok := r.Config.GetFullModelPricing(ctx.RequestModel)
 		if ok {
-			costAmount := (float64(usage.promptTokens)*promptRatePer1M +
-				float64(usage.completionTokens)*completionRatePer1M) / 1_000_000.0
-			if currency == "" {
-				currency = "USD"
-			}
+			costAmount := costForResponseUsage(usage, pricing)
+			currency := pricing.Currency
 			metrics.RecordModelCost(ctx.RequestModel, currency, costAmount)
 			eventFields["cost"] = costAmount
 			eventFields["currency"] = currency
+			eventFields["pricing_prompt_per_1m"] = pricing.PromptPer1M
+			eventFields["pricing_cached_input_per_1m"] = pricing.CachedInputPer1M
+			eventFields["pricing_completion_per_1m"] = pricing.CompletionPer1M
 			logging.LogEvent("llm_usage", eventFields)
 			return replayUsage
 		}
@@ -163,13 +181,34 @@ func extractStreamingUsage(ctx *RequestContext) openai.CompletionUsage {
 	return usage
 }
 
-func recordSessionTurnFromStreamingUsage(ctx *RequestContext, usage openai.CompletionUsage, pricing sessiontelemetry.TurnPricing) {
+func streamingCachedPromptTokens(ctx *RequestContext, promptTokens int) int {
+	if ctx == nil || ctx.StreamingMetadata == nil {
+		return 0
+	}
+	usageMap, ok := ctx.StreamingMetadata["usage"].(map[string]interface{})
+	if !ok {
+		return 0
+	}
+	for _, key := range []string{"prompt_tokens_details", "input_tokens_details"} {
+		details, ok := usageMap[key].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cached, ok := details["cached_tokens"].(float64); ok {
+			return clampCachedPromptTokensInt(promptTokens, int(cached))
+		}
+	}
+	return 0
+}
+
+func recordSessionTurnFromStreamingUsage(ctx *RequestContext, usage openai.CompletionUsage, cachedPromptTokens int, pricing sessiontelemetry.TurnPricing) {
 	if usage.PromptTokens <= 0 && usage.CompletionTokens <= 0 {
 		return
 	}
 	recordSessionTurn(ctx, responseUsageMetrics{
-		promptTokens:     int(usage.PromptTokens),
-		completionTokens: int(usage.CompletionTokens),
+		promptTokens:       int(usage.PromptTokens),
+		cachedPromptTokens: cachedPromptTokens,
+		completionTokens:   int(usage.CompletionTokens),
 	}, pricing)
 }
 
@@ -185,7 +224,8 @@ func (r *OpenAIRouter) reportStreamingUsageMetrics(
 		})
 	}
 
-	recordSessionTurnFromStreamingUsage(ctx, usage, r.sessionTurnPricing(ctx.RequestModel))
+	cachedPromptTokens := streamingCachedPromptTokens(ctx, int(usage.PromptTokens))
+	recordSessionTurnFromStreamingUsage(ctx, usage, cachedPromptTokens, r.sessionTurnPricing(ctx.RequestModel))
 
 	if ctx.RequestModel == "" || (usage.PromptTokens == 0 && usage.CompletionTokens == 0) {
 		return
@@ -218,8 +258,27 @@ func (r *OpenAIRouter) reportStreamingUsageMetrics(
 		completionLatency = time.Since(ctx.StartTime)
 	}
 	replayUsage := r.recordResponseCost(ctx, completionLatency, responseUsageMetrics{
-		promptTokens:     int(usage.PromptTokens),
-		completionTokens: int(usage.CompletionTokens),
+		promptTokens:       int(usage.PromptTokens),
+		cachedPromptTokens: cachedPromptTokens,
+		completionTokens:   int(usage.CompletionTokens),
 	})
 	r.updateRouterReplayUsageCost(ctx, replayUsage)
+}
+
+func costForResponseUsage(usage responseUsageMetrics, pricing config.ModelPricing) float64 {
+	cached := clampCachedPromptTokensInt(usage.promptTokens, usage.cachedPromptTokens)
+	uncachedPrompt := usage.promptTokens - cached
+	return (float64(uncachedPrompt)*pricing.PromptPer1M +
+		float64(cached)*pricing.CachedInputPer1M +
+		float64(usage.completionTokens)*pricing.CompletionPer1M) / 1_000_000.0
+}
+
+func clampCachedPromptTokensInt(promptTokens, cachedPromptTokens int) int {
+	if cachedPromptTokens < 0 {
+		return 0
+	}
+	if cachedPromptTokens > promptTokens {
+		return promptTokens
+	}
+	return cachedPromptTokens
 }

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"encoding/json"
 	"time"
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -200,6 +201,7 @@ func buildReplayRoutingRecord(
 		ReasoningMode:     replayReasoningMode(ctx),
 		ConfidenceScore:   ctx.VSRSelectedDecisionConfidence,
 		SelectionMethod:   ctx.VSRSelectionMethod,
+		SessionPolicy:     cloneReplayInterfaceMap(ctx.VSRSessionPolicy),
 		Signals:           replaySignalState(ctx),
 		Projections:       replayProjectionState(ctx),
 		ProjectionScores:  cloneReplayFloat64Map(ctx.VSRProjectionScores),
@@ -299,6 +301,21 @@ func replayProjectionState(ctx *RequestContext) []string {
 		return nil
 	}
 	return append([]string(nil), ctx.VSRMatchedProjection...)
+}
+
+func cloneReplayInterfaceMap(values map[string]interface{}) map[string]interface{} {
+	if values == nil {
+		return nil
+	}
+	b, err := json.Marshal(values)
+	if err != nil {
+		return nil
+	}
+	var cloned map[string]interface{}
+	if err := json.Unmarshal(b, &cloned); err != nil {
+		return nil
+	}
+	return cloned
 }
 
 func replayGuardrailState(ctx *RequestContext) (bool, bool, bool, bool) {

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -3,10 +3,12 @@ package extproc
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/entropy"
 )
 
@@ -36,6 +38,7 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, history s
 	}
 
 	signalInput := r.prepareSignalEvaluationInput(history)
+	ctx.VSRConversationFacts = signalInput.conversationFacts
 	if signalInput.evaluationText == "" {
 		return "", 0.0, entropy.ReasoningDecision{}, "", nil
 	}
@@ -72,11 +75,13 @@ func (r *OpenAIRouter) selectModelFromCandidates(selCtx *selection.SelectionCont
 	}
 	if err := selection.ValidateSelectionContext(selCtx); err != nil {
 		logging.Warnf("[ModelSelection] Invalid selection context: %v, using first valid model", err)
+		recordAgenticSessionDecision(selCtx, nil, fallbackModelRef, ctx)
 		return fallbackModelRef, ""
 	}
 
 	// If only one model, no need for selection algorithm
 	if len(selCtx.CandidateModels) == 1 {
+		recordAgenticSessionDecision(selCtx, nil, fallbackModelRef, ctx)
 		return fallbackModelRef, "single"
 	}
 
@@ -84,14 +89,12 @@ func (r *OpenAIRouter) selectModelFromCandidates(selCtx *selection.SelectionCont
 	method := r.getSelectionMethod(algorithm)
 
 	// Get selector from registry
-	var selector selection.Selector
-	if r.ModelSelector != nil {
-		selector, _ = r.ModelSelector.Get(method)
-	}
+	selector := r.selectorForDecisionMethod(method, algorithm)
 
 	// Fallback to first model if no selector available
 	if selector == nil {
 		logging.Warnf("[ModelSelection] No selector available for method %s, using first model", method)
+		recordAgenticSessionDecision(selCtx, nil, fallbackModelRef, ctx)
 		return fallbackModelRef, string(method)
 	}
 
@@ -99,34 +102,97 @@ func (r *OpenAIRouter) selectModelFromCandidates(selCtx *selection.SelectionCont
 	result, err := selector.Select(context.Background(), selCtx)
 	if err != nil {
 		logging.Warnf("[ModelSelection] Selection failed: %v, using first model", err)
+		recordAgenticSessionDecision(selCtx, nil, fallbackModelRef, ctx)
 		return fallbackModelRef, string(method)
 	}
 	if err := selection.ValidateSelectionResult(selCtx, result); err != nil {
 		logging.Warnf("[ModelSelection] Invalid selection result: %v, using first model", err)
+		recordAgenticSessionDecision(selCtx, result, fallbackModelRef, ctx)
 		return fallbackModelRef, string(method)
 	}
 
-	// Find the selected model in the candidates
+	selectedModelRef := selectedModelRefFromResult(selCtx, result)
+	if selectedModelRef == nil {
+		logging.Warnf("[ModelSelection] Selected model %s not found in candidates, using first model", result.SelectedModel)
+		recordAgenticSessionDecision(selCtx, result, fallbackModelRef, ctx)
+		return fallbackModelRef, string(method)
+	}
+	if result.SessionPolicy != nil && ctx != nil {
+		ctx.VSRSessionPolicy = result.SessionPolicy.ToMap()
+	}
+	selectedModelRef, gateApplied := r.applyPostSelectionGate(selCtx, result, selectedModelRef, ctx, method)
+	logSelectionResult(method, result, selectedModelRef, gateApplied)
+	selection.RecordSelection(string(method), selCtx.DecisionName, selectedModelRef.Model, result.Tier, result.Score)
+	recordAgenticSessionDecision(selCtx, result, selectedModelRef, ctx)
+	return selectedModelRef, string(method)
+}
+
+func (r *OpenAIRouter) selectorForDecisionMethod(method selection.SelectionMethod, algorithm *config.AlgorithmConfig) selection.Selector {
+	if method == selection.MethodSessionAware && algorithm != nil && algorithm.SessionAware != nil {
+		return r.newDecisionSessionAwareSelector(algorithm.SessionAware)
+	}
+	if r.ModelSelector == nil {
+		return nil
+	}
+	selector, _ := r.ModelSelector.Get(method)
+	return selector
+}
+
+func (r *OpenAIRouter) newDecisionSessionAwareSelector(decisionCfg *config.SessionAwareSelectionConfig) selection.Selector {
+	cfg := selection.DefaultSessionAwareConfig()
+	if r != nil && r.Config != nil {
+		cfg = buildSessionAwareSelectionConfig(r.Config, decisionCfg)
+	} else if decisionCfg != nil {
+		applySessionAwareSelectionConfig(cfg, *decisionCfg)
+	}
+	selector := selection.NewSessionAwareSelector(cfg)
+	if r == nil {
+		return selector
+	}
+	if r.Config != nil && r.Config.ModelConfig != nil {
+		selector.InitializeFromConfig(r.Config.ModelConfig)
+	}
+	if r.LookupTable != nil {
+		selector.SetLookupTable(r.LookupTable)
+	}
+	if r.ModelSelector != nil && cfg.FallbackMethod != "" && cfg.FallbackMethod != selection.MethodSessionAware {
+		fallback, _ := r.ModelSelector.Get(cfg.FallbackMethod)
+		selector.SetFallbackSelector(fallback)
+	}
+	return selector
+}
+
+func (r *OpenAIRouter) applyPostSelectionGate(
+	selCtx *selection.SelectionContext,
+	result *selection.SelectionResult,
+	selectedModelRef *config.ModelRef,
+	ctx *RequestContext,
+	method selection.SelectionMethod,
+) (*config.ModelRef, bool) {
+	if method == selection.MethodSessionAware || result.Method == selection.MethodSessionAware {
+		return selectedModelRef, false
+	}
+	return r.applyModelSwitchGate(selCtx, result, selectedModelRef, ctx)
+}
+
+func selectedModelRefFromResult(selCtx *selection.SelectionContext, result *selection.SelectionResult) *config.ModelRef {
 	for i := range selCtx.CandidateModels {
 		if selCtx.CandidateModels[i].Model == result.SelectedModel ||
 			selCtx.CandidateModels[i].LoRAName == result.SelectedModel {
-			selectedModelRef := &selCtx.CandidateModels[i]
-			selectedModelRef, gateApplied := r.applyModelSwitchGate(selCtx, result, selectedModelRef, ctx)
-			if gateApplied {
-				logging.Infof("[ModelSelection] Gate enforced stay on %s (method=%s, score=%.4f, confidence=%.2f): %s",
-					selectedModelRef.Model, method, result.Score, result.Confidence, result.Reasoning)
-			} else {
-				logging.Infof("[ModelSelection] Selected %s (method=%s, score=%.4f, confidence=%.2f): %s",
-					selectedModelRef.Model, method, result.Score, result.Confidence, result.Reasoning)
-			}
-			selection.RecordSelection(string(method), selCtx.DecisionName, selectedModelRef.Model, result.Tier, result.Score)
-			return selectedModelRef, string(method)
+			return &selCtx.CandidateModels[i]
 		}
 	}
+	return nil
+}
 
-	// Fallback if selected model not found in candidates (shouldn't happen)
-	logging.Warnf("[ModelSelection] Selected model %s not found in candidates, using first model", result.SelectedModel)
-	return fallbackModelRef, string(method)
+func logSelectionResult(method selection.SelectionMethod, result *selection.SelectionResult, selected *config.ModelRef, gateApplied bool) {
+	if gateApplied {
+		logging.Infof("[ModelSelection] Gate enforced stay on %s (method=%s, score=%.4f, confidence=%.2f): %s",
+			selected.Model, method, result.Score, result.Confidence, result.Reasoning)
+		return
+	}
+	logging.Infof("[ModelSelection] Selected %s (method=%s, score=%.4f, confidence=%.2f): %s",
+		selected.Model, method, result.Score, result.Confidence, result.Reasoning)
 }
 
 func firstValidCandidateModelRef(selCtx *selection.SelectionContext) *config.ModelRef {
@@ -171,9 +237,106 @@ func (r *OpenAIRouter) buildSelectionContext(
 		LatencyAwareTTFTPercentile: latencyAwareTTFTPercentile,
 		UserID:                     userID,
 		SessionID:                  sessionID,
+		AgenticSession:             r.buildAgenticSessionContext(reqCtx, modelRefs, sessionID, userID),
 		ConversationHistory:        conversationHistory,
 		CacheAffinityCtx:           r.buildCacheAffinityContext(reqCtx, modelRefs),
 	}
+}
+
+func (r *OpenAIRouter) buildAgenticSessionContext(
+	reqCtx *RequestContext,
+	modelRefs []config.ModelRef,
+	sessionID string,
+	userID string,
+) *selection.AgenticSessionContext {
+	if reqCtx == nil {
+		return nil
+	}
+	now := time.Now()
+	snapshot, hasMemory := sessiontelemetry.GetRouterSessionSnapshot(sessionID, now)
+	previousModel := reqCtx.PreviousModel
+	if previousModel == "" && hasMemory {
+		previousModel = snapshot.CurrentModel
+	}
+	idleFor := time.Duration(reqCtx.SessionIdleSeconds * float64(time.Second))
+	idleKnown := reqCtx.SessionIdleKnown
+	if hasMemory {
+		idleFor = snapshot.IdleFor
+		idleKnown = true
+	}
+	cacheWarmth, cacheWarmthOK := r.agenticCacheWarmth(reqCtx, previousModel, snapshot, hasMemory, now)
+	facts := reqCtx.VSRConversationFacts
+	activeToolLoop := facts.LastMessageToolResult ||
+		facts.LastMessageRole == "tool" ||
+		facts.AssistantToolCallCount > facts.ToolResultCount
+	phase := selection.AgenticPhaseUserTurn
+	if activeToolLoop {
+		phase = selection.AgenticPhaseToolLoop
+	}
+	return &selection.AgenticSessionContext{
+		ID:                  sessionID,
+		UserID:              userID,
+		TurnIndex:           reqCtx.TurnIndex,
+		PreviousModel:       previousModel,
+		PreviousResponseID:  reqCtx.PreviousResponseID,
+		MemoryPresent:       hasMemory,
+		MemoryTurnCount:     snapshot.TurnCount,
+		MemorySwitchCount:   snapshot.SwitchCount,
+		MemoryModelTurnCnts: snapshot.ModelTurns,
+		MemoryPromptTokens:  snapshot.CumulativePromptTokens,
+		MemoryCachedTokens:  snapshot.CumulativeCachedTokens,
+		MemoryOutputTokens:  snapshot.CumulativeCompletionTokens,
+		MemoryCost:          snapshot.CumulativeCost,
+		LastDecisionReason:  snapshot.LastDecisionReason,
+		HistoryTokens:       reqCtx.HistoryTokenCount,
+		ContextTokens:       reqCtx.VSRContextTokenCount,
+		IdleFor:             idleFor,
+		IdleKnown:           idleKnown,
+		CacheWarmth:         cacheWarmth,
+		CacheWarmthOK:       cacheWarmthOK,
+		Phase:               phase,
+		ActiveToolLoop:      activeToolLoop,
+		ToolCallCount:       facts.AssistantToolCallCount,
+		ToolResultCount:     facts.ToolResultCount,
+		ToolDefinitionCnt:   facts.ToolDefinitionCount,
+		ModelContextWindows: r.modelContextWindows(modelRefs),
+	}
+}
+
+func (r *OpenAIRouter) agenticCacheWarmth(
+	reqCtx *RequestContext,
+	previousModel string,
+	snapshot sessiontelemetry.RouterSessionSnapshot,
+	hasMemory bool,
+	now time.Time,
+) (float64, bool) {
+	cacheWarmth := reqCtx.CacheWarmthEstimate
+	cacheWarmthOK := cacheWarmth > 0
+	if ambient, ok := estimateGateCacheWarmth(previousModel, now); ok {
+		cacheWarmth = ambient
+		cacheWarmthOK = true
+	}
+	if hasMemory && snapshot.CumulativePromptTokens > 0 {
+		cachedRatio := float64(snapshot.CumulativeCachedTokens) / float64(snapshot.CumulativePromptTokens)
+		if cachedRatio > cacheWarmth {
+			cacheWarmth = cachedRatio
+			cacheWarmthOK = true
+		}
+	}
+	return cacheWarmth, cacheWarmthOK
+}
+
+func (r *OpenAIRouter) modelContextWindows(modelRefs []config.ModelRef) map[string]int {
+	if r == nil || r.Config == nil || r.Config.ModelConfig == nil {
+		return nil
+	}
+	windows := make(map[string]int, len(modelRefs))
+	for _, ref := range modelRefs {
+		if params, ok := r.Config.ModelConfig[ref.Model]; ok {
+			windows[ref.Model] = params.ContextWindowSize
+		}
+	}
+	return windows
 }
 
 // buildCacheAffinityContext extracts the pre-dispatch continuation signals used
@@ -186,22 +349,13 @@ func (r *OpenAIRouter) buildCacheAffinityContext(reqCtx *RequestContext, modelRe
 
 	// Missing model window metadata is valid; the estimator treats it as a
 	// neutral fit score rather than as an error.
-	var windows map[string]int
-	if r.Config != nil && r.Config.ModelConfig != nil {
-		windows = make(map[string]int, len(modelRefs))
-		for _, ref := range modelRefs {
-			if params, ok := r.Config.ModelConfig[ref.Model]; ok {
-				windows[ref.Model] = params.ContextWindowSize
-			}
-		}
-	}
 	return &selection.CacheAffinityContext{
 		TurnIndex:           reqCtx.TurnIndex,
 		PreviousModel:       reqCtx.PreviousModel,
 		PreviousResponseID:  reqCtx.PreviousResponseID,
 		HistoryTokens:       reqCtx.HistoryTokenCount,
 		ContextTokens:       reqCtx.VSRContextTokenCount,
-		ModelContextWindows: windows,
+		ModelContextWindows: r.modelContextWindows(modelRefs),
 	}
 }
 
@@ -331,7 +485,7 @@ func (r *OpenAIRouter) extractSessionContext(ctx *RequestContext) (sessionID, us
 	if len(ctx.ChatCompletionMessages) > 0 {
 		return r.extractChatCompletionSessionContext(ctx, userID)
 	}
-	return "", userID, nil
+	return ctx.SessionID, userID, nil
 }
 
 func (r *OpenAIRouter) extractResponseAPISessionContext(ctx *RequestContext, userID string) (sessionID, userIDOut string, conversationHistory []string) {
@@ -354,7 +508,10 @@ func (r *OpenAIRouter) extractResponseAPISessionContext(ctx *RequestContext, use
 }
 
 func (r *OpenAIRouter) extractChatCompletionSessionContext(ctx *RequestContext, userID string) (sessionID, userIDOut string, conversationHistory []string) {
-	sessionID = deriveSessionIDFromMessages(ctx.ChatCompletionMessages, userID)
+	sessionID = ctx.SessionID
+	if sessionID == "" {
+		sessionID = deriveSessionIDFromMessages(ctx.ChatCompletionMessages, userID)
+	}
 	for i, msg := range ctx.ChatCompletionMessages {
 		if msg.Content != "" && i < len(ctx.ChatCompletionMessages)-1 {
 			conversationHistory = append(conversationHistory, msg.Content)

--- a/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
@@ -21,10 +21,13 @@ var selectionMethodByAlgorithmType = map[string]selection.SelectionMethod{
 	"rl_driven":     selection.MethodRLDriven,
 	"gmtrouter":     selection.MethodGMTRouter,
 	"latency_aware": selection.MethodLatencyAware,
+	"session_aware": selection.MethodSessionAware,
 	"static":        selection.MethodStatic,
 	"knn":           selection.MethodKNN,
 	"kmeans":        selection.MethodKMeans,
 	"svm":           selection.MethodSVM,
+	"multi_factor":  selection.MethodMultiFactor,
+	"mlp":           selection.MethodMLP,
 }
 
 func (r *OpenAIRouter) evaluateSignalsForDecision(

--- a/src/semantic-router/pkg/extproc/req_filter_classification_selection_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_selection_test.go
@@ -19,9 +19,12 @@ package extproc
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 )
 
 type selectionResultSelector struct {
@@ -92,5 +95,136 @@ func TestSelectModelFromCandidatesFallsBackToFirstValidCandidateOnInvalidContext
 	}
 	if method != "" {
 		t.Fatalf("expected empty method for invalid context fallback, got %q", method)
+	}
+}
+
+func TestSelectModelFromCandidatesRecordsSingleCandidateInRouterMemory(t *testing.T) {
+	sessiontelemetry.ResetRouterSessionMemoryForTesting()
+	t.Cleanup(sessiontelemetry.ResetRouterSessionMemoryForTesting)
+
+	router := &OpenAIRouter{}
+	reqCtx := &RequestContext{SessionID: "single-candidate-session"}
+	selected, method := router.selectModelFromCandidates(&selection.SelectionContext{
+		SessionID:       "single-candidate-session",
+		DecisionName:    "warmup",
+		CandidateModels: []config.ModelRef{{Model: "model-a"}},
+	}, nil, reqCtx)
+
+	if selected == nil || selected.Model != "model-a" {
+		t.Fatalf("expected model-a, got %#v", selected)
+	}
+	if method != "single" {
+		t.Fatalf("expected single method, got %q", method)
+	}
+
+	snapshot, ok := sessiontelemetry.GetRouterSessionSnapshot("single-candidate-session", time.Now())
+	if !ok {
+		t.Fatal("expected router memory snapshot for single-candidate selection")
+	}
+	if snapshot.CurrentModel != "model-a" {
+		t.Fatalf("expected current model model-a, got %q", snapshot.CurrentModel)
+	}
+}
+
+func TestSelectModelFromCandidatesUsesDecisionScopedSessionAwareConfig(t *testing.T) {
+	registry := selection.NewRegistry()
+	registry.Register(selection.MethodStatic, selectionResultSelector{result: &selection.SelectionResult{
+		SelectedModel: "frontier",
+		Score:         0.90,
+		Method:        selection.MethodStatic,
+		AllScores: map[string]float64{
+			"current":  0.20,
+			"frontier": 0.90,
+		},
+	}})
+
+	router := &OpenAIRouter{
+		ModelSelector: registry,
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				ModelSelection: config.ModelSelectionConfig{
+					SessionAware: config.SessionAwareSelectionConfig{IdleTimeoutSeconds: 300},
+				},
+			},
+		},
+	}
+	ctx := &RequestContext{SessionID: "decision-session"}
+	trueValue := true
+	selected, method := router.selectModelFromCandidates(&selection.SelectionContext{
+		SessionID:       "decision-session",
+		DecisionName:    "idle-route",
+		CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "frontier"}},
+		AgenticSession: &selection.AgenticSessionContext{
+			ID:            "decision-session",
+			TurnIndex:     3,
+			PreviousModel: "current",
+			IdleKnown:     true,
+			IdleFor:       2 * time.Second,
+		},
+	}, &config.AlgorithmConfig{
+		Type: "session_aware",
+		SessionAware: &config.SessionAwareSelectionConfig{
+			FallbackMethod:       "static",
+			IdleTimeoutSeconds:   1,
+			MinTurnsBeforeSwitch: 1,
+			SwitchMargin:         0.05,
+			StayBias:             0.10,
+			ToolLoopHardLock:     &trueValue,
+		},
+	}, ctx)
+
+	if selected == nil || selected.Model != "frontier" {
+		t.Fatalf("expected frontier from decision-scoped idle policy, got %#v", selected)
+	}
+	if method != string(selection.MethodSessionAware) {
+		t.Fatalf("expected session_aware method, got %q", method)
+	}
+	if ctx.VSRSessionPolicy == nil || ctx.VSRSessionPolicy["idle_expired"] != true {
+		t.Fatalf("expected decision-scoped idle timeout in session policy, got %#v", ctx.VSRSessionPolicy)
+	}
+}
+
+func TestBuildSelectionContextUsesPinnedSessionIDAndToolLoopFacts(t *testing.T) {
+	router := &OpenAIRouter{Config: &config.RouterConfig{
+		BackendModels: config.BackendModels{
+			ModelConfig: map[string]config.ModelParams{
+				"model-a": {ContextWindowSize: 8192},
+			},
+		},
+	}}
+	reqCtx := &RequestContext{
+		SessionID:            "pinned-session",
+		PreviousModel:        "model-a",
+		TurnIndex:            2,
+		HistoryTokenCount:    1024,
+		VSRContextTokenCount: 2048,
+		SessionIdleSeconds:   12,
+		SessionIdleKnown:     true,
+		VSRConversationFacts: classification.ConversationFacts{
+			AssistantToolCallCount: 1,
+			ToolResultCount:        1,
+			LastMessageRole:        "tool",
+			LastMessageToolResult:  true,
+		},
+	}
+
+	selCtx := router.buildSelectionContext(
+		[]config.ModelRef{{Model: "model-a"}},
+		"agentic",
+		"query",
+		nil,
+		"",
+		nil,
+		reqCtx,
+	)
+
+	if selCtx.SessionID != "pinned-session" {
+		t.Fatalf("expected pinned session ID, got %q", selCtx.SessionID)
+	}
+	if selCtx.AgenticSession == nil || !selCtx.AgenticSession.ActiveToolLoop {
+		t.Fatalf("expected active tool loop in agentic session context: %#v", selCtx.AgenticSession)
+	}
+	if got := selCtx.AgenticSession.ModelContextWindows["model-a"]; got != 8192 {
+		t.Fatalf("expected model context window 8192, got %d", got)
 	}
 }

--- a/src/semantic-router/pkg/extproc/req_filter_classification_signal.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_signal.go
@@ -39,6 +39,8 @@ func (r *OpenAIRouter) prepareSignalEvaluationInput(history signalConversationHi
 			ToolDefinitionCount:    history.toolDefinitionCount,
 			AssistantToolCallCount: history.assistantToolCallCount,
 			ToolResultCount:        history.toolResultCount,
+			LastMessageRole:        history.lastMessageRole,
+			LastMessageToolResult:  history.lastMessageToolResult,
 		},
 	}
 

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/projectiontrace"
@@ -93,6 +94,8 @@ type RequestContext struct {
 	TurnIndex           int     // Number of prior turns in this session (0 = first turn)
 	PreviousModel       string  // Model used in the immediately preceding turn; empty on first turn
 	CacheWarmthEstimate float64 // [0,1] from EstimateCacheProbability; 0.5 = unknown
+	SessionIdleSeconds  float64 // Seconds since the last locally observed turn for this session
+	SessionIdleKnown    bool    // True when SessionIdleSeconds came from local session observation
 
 	// HistoryTokenCount is the estimated token count of conversation history,
 	// excluding the current turn. Source priority: provider usage accumulation
@@ -105,16 +108,17 @@ type RequestContext struct {
 	PreviousResponseID string
 
 	// VSR decision tracking
-	VSRSelectedCategory           string           // The category from domain classification (MMLU category)
-	VSRSelectedDecisionName       string           // The decision name from DecisionEngine evaluation
-	VSRSelectedDecisionConfidence float64          // Confidence score from DecisionEngine evaluation
-	VSRReasoningMode              string           // "on" or "off" - whether reasoning mode was determined to be used
-	VSRSelectedModel              string           // The model selected by VSR
-	VSRSelectionMethod            string           // Model selection algorithm used (e.g., "elo", "static", "router_dc")
-	VSRCacheHit                   bool             // Whether this request hit the cache
-	VSRCacheSimilarity            float32          // Similarity score from last cache lookup (0 = no lookup performed)
-	VSRInjectedSystemPrompt       bool             // Whether a system prompt was injected into the request
-	VSRSelectedDecision           *config.Decision // The decision object selected by DecisionEngine (for plugins)
+	VSRSelectedCategory           string                 // The category from domain classification (MMLU category)
+	VSRSelectedDecisionName       string                 // The decision name from DecisionEngine evaluation
+	VSRSelectedDecisionConfidence float64                // Confidence score from DecisionEngine evaluation
+	VSRReasoningMode              string                 // "on" or "off" - whether reasoning mode was determined to be used
+	VSRSelectedModel              string                 // The model selected by VSR
+	VSRSelectionMethod            string                 // Model selection algorithm used (e.g., "elo", "static", "router_dc")
+	VSRSessionPolicy              map[string]interface{} // Session-aware routing policy trace for replay/experiments
+	VSRCacheHit                   bool                   // Whether this request hit the cache
+	VSRCacheSimilarity            float32                // Similarity score from last cache lookup (0 = no lookup performed)
+	VSRInjectedSystemPrompt       bool                   // Whether a system prompt was injected into the request
+	VSRSelectedDecision           *config.Decision       // The decision object selected by DecisionEngine (for plugins)
 
 	// Modality routing classification result (AR/DIFFUSION/BOTH)
 	ModalityClassification *ModalityClassificationResult // Set by classifyModality()
@@ -138,6 +142,7 @@ type RequestContext struct {
 	VSRMatchedPII          []string // Matched PII rule names (denied PII types detected)
 	VSRMatchedKB           []string // Matched knowledge-base signal names
 	VSRMatchedConversation []string // Matched conversation-shape signal names
+	VSRConversationFacts   classification.ConversationFacts
 	VSRMatchedProjection   []string // Matched projection mapping outputs
 	VSRProjectionScores    map[string]float64
 	VSRSignalConfidences   map[string]float64

--- a/src/semantic-router/pkg/extproc/request_signal_history.go
+++ b/src/semantic-router/pkg/extproc/request_signal_history.go
@@ -22,6 +22,8 @@ type signalConversationHistory struct {
 	assistantToolCallCount int
 	toolResultCount        int
 	assistantToolNames     []string
+	lastMessageRole        string
+	lastMessageToolResult  bool
 }
 
 func signalConversationHistoryFromFastExtract(result *FastExtractResult) signalConversationHistory {
@@ -42,6 +44,8 @@ func signalConversationHistoryFromFastExtract(result *FastExtractResult) signalC
 		assistantToolCallCount: result.AssistantToolCallCount,
 		toolResultCount:        result.ToolResultCount,
 		assistantToolNames:     append([]string(nil), result.AssistantToolNames...),
+		lastMessageRole:        result.LastMessageRole,
+		lastMessageToolResult:  result.LastMessageToolResult,
 	}
 }
 
@@ -67,6 +71,8 @@ func extractSignalConversationHistory(req *openai.ChatCompletionNewParams) signa
 
 	for _, msg := range req.Messages {
 		role, textContent := extractMessageRoleAndContent(msg)
+		history.lastMessageRole = role
+		history.lastMessageToolResult = false
 
 		switch role {
 		case "user":
@@ -99,6 +105,7 @@ func extractSignalConversationHistory(req *openai.ChatCompletionNewParams) signa
 		case "tool":
 			history.toolMessageCount++
 			history.toolResultCount++
+			history.lastMessageToolResult = true
 		}
 	}
 

--- a/src/semantic-router/pkg/extproc/router_replay_cost.go
+++ b/src/semantic-router/pkg/extproc/router_replay_cost.go
@@ -9,16 +9,17 @@ func (r *OpenAIRouter) buildReplayUsageCost(ctx *RequestContext, usage responseU
 	}
 
 	snapshot := routerreplay.UsageCost{
-		PromptTokens:     replayIntPtr(usage.promptTokens),
-		CompletionTokens: replayIntPtr(usage.completionTokens),
-		TotalTokens:      replayIntPtr(totalTokens),
+		PromptTokens:       replayIntPtr(usage.promptTokens),
+		CachedPromptTokens: replayIntPtr(usage.cachedPromptTokens),
+		CompletionTokens:   replayIntPtr(usage.completionTokens),
+		TotalTokens:        replayIntPtr(totalTokens),
 	}
 
 	if r == nil || r.Config == nil || ctx == nil || ctx.RequestModel == "" {
 		return snapshot
 	}
 
-	selectedPromptRate, selectedCompletionRate, selectedCurrency, ok := r.Config.GetModelPricing(ctx.RequestModel)
+	selectedPricing, ok := r.Config.GetFullModelPricing(ctx.RequestModel)
 	if !ok {
 		return snapshot
 	}
@@ -28,7 +29,7 @@ func (r *OpenAIRouter) buildReplayUsageCost(ctx *RequestContext, usage responseU
 		return snapshot
 	}
 
-	currency := selectedCurrency
+	currency := selectedPricing.Currency
 	if currency == "" {
 		currency = baselineCurrency
 	}
@@ -36,8 +37,7 @@ func (r *OpenAIRouter) buildReplayUsageCost(ctx *RequestContext, usage responseU
 		currency = "USD"
 	}
 
-	actualCost := (float64(usage.promptTokens)*selectedPromptRate +
-		float64(usage.completionTokens)*selectedCompletionRate) / 1_000_000.0
+	actualCost := costForResponseUsage(usage, selectedPricing)
 	baselineCost := (float64(usage.promptTokens)*baselinePromptRate +
 		float64(usage.completionTokens)*baselineCompletionRate) / 1_000_000.0
 	costSavings := baselineCost - actualCost

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -103,6 +103,7 @@ func buildModelSelectionConfig(cfg *config.RouterConfig) *selection.ModelSelecti
 	modelSelectionCfg.RouterDC = buildRouterDCSelectionConfig(cfg, decisionCfgs.routerDC)
 	modelSelectionCfg.AutoMix = buildAutoMixSelectionConfig(cfg)
 	modelSelectionCfg.Hybrid = buildHybridSelectionConfig(cfg)
+	modelSelectionCfg.SessionAware = buildSessionAwareSelectionConfig(cfg, decisionCfgs.sessionAware)
 	modelSelectionCfg.ML = buildMLSelectionConfig(cfg)
 	modelSelectionCfg.RLDriven = buildRLDrivenSelectionConfig(decisionCfgs.rlDriven)
 	modelSelectionCfg.GMTRouter = buildGMTRouterSelectionConfig(decisionCfgs.gmtRouter)
@@ -110,10 +111,11 @@ func buildModelSelectionConfig(cfg *config.RouterConfig) *selection.ModelSelecti
 }
 
 type decisionScopedSelectionConfigs struct {
-	elo       *config.EloSelectionConfig
-	routerDC  *config.RouterDCSelectionConfig
-	rlDriven  *config.RLDrivenSelectionConfig
-	gmtRouter *config.GMTRouterSelectionConfig
+	elo          *config.EloSelectionConfig
+	routerDC     *config.RouterDCSelectionConfig
+	rlDriven     *config.RLDrivenSelectionConfig
+	gmtRouter    *config.GMTRouterSelectionConfig
+	sessionAware *config.SessionAwareSelectionConfig
 }
 
 func findDecisionScopedSelectionConfigs(cfg *config.RouterConfig) decisionScopedSelectionConfigs {
@@ -143,6 +145,11 @@ func findDecisionScopedSelectionConfigs(cfg *config.RouterConfig) decisionScoped
 			decision.Algorithm.GMTRouter != nil &&
 			result.gmtRouter == nil {
 			result.gmtRouter = decision.Algorithm.GMTRouter
+		}
+		if decision.Algorithm.Type == "session_aware" &&
+			decision.Algorithm.SessionAware != nil &&
+			result.sessionAware == nil {
+			result.sessionAware = decision.Algorithm.SessionAware
 		}
 	}
 
@@ -237,6 +244,61 @@ func buildHybridSelectionConfig(cfg *config.RouterConfig) *selection.HybridConfi
 		CostWeight:          hybridCfg.CostWeight,
 		QualityGapThreshold: hybridCfg.QualityGapThreshold,
 		NormalizeScores:     hybridCfg.NormalizeScores,
+	}
+}
+
+func buildSessionAwareSelectionConfig(
+	cfg *config.RouterConfig,
+	decisionCfg *config.SessionAwareSelectionConfig,
+) *selection.SessionAwareConfig {
+	global := cfg.IntelligentRouting.ModelSelection.SessionAware
+	result := selection.DefaultSessionAwareConfig()
+	applySessionAwareSelectionConfig(result, global)
+	if decisionCfg != nil {
+		applySessionAwareSelectionConfig(result, *decisionCfg)
+	}
+	return result
+}
+
+func applySessionAwareSelectionConfig(result *selection.SessionAwareConfig, cfg config.SessionAwareSelectionConfig) {
+	if cfg.FallbackMethod != "" {
+		result.FallbackMethod = selection.SelectionMethod(cfg.FallbackMethod)
+	}
+	if cfg.IdleTimeoutSeconds != 0 {
+		result.IdleTimeoutSeconds = cfg.IdleTimeoutSeconds
+	}
+	if cfg.MinTurnsBeforeSwitch != 0 {
+		result.MinTurnsBeforeSwitch = cfg.MinTurnsBeforeSwitch
+	}
+	if cfg.SwitchMargin != 0 {
+		result.SwitchMargin = cfg.SwitchMargin
+	}
+	if cfg.StayBias != 0 {
+		result.StayBias = cfg.StayBias
+	}
+	if cfg.ToolLoopHardLock != nil {
+		result.ToolLoopHardLock = *cfg.ToolLoopHardLock
+	}
+	if cfg.ToolLoopStayBias != 0 {
+		result.ToolLoopStayBias = cfg.ToolLoopStayBias
+	}
+	if cfg.PrefixCacheWeight != 0 {
+		result.PrefixCacheWeight = cfg.PrefixCacheWeight
+	}
+	if cfg.HandoffPenaltyWeight != 0 {
+		result.HandoffPenaltyWeight = cfg.HandoffPenaltyWeight
+	}
+	if cfg.DefaultHandoffPenalty != 0 {
+		result.DefaultHandoffPenalty = cfg.DefaultHandoffPenalty
+	}
+	if cfg.QualityGapMultiplier != 0 {
+		result.QualityGapMultiplier = cfg.QualityGapMultiplier
+	}
+	if cfg.MaxCacheCostMultiplier != 0 {
+		result.MaxCacheCostMultiplier = cfg.MaxCacheCostMultiplier
+	}
+	if cfg.SwitchHistoryWeight != 0 {
+		result.SwitchHistoryWeight = cfg.SwitchHistoryWeight
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/session_policy.go
+++ b/src/semantic-router/pkg/extproc/session_policy.go
@@ -1,0 +1,44 @@
+package extproc
+
+import (
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
+)
+
+func recordAgenticSessionDecision(
+	selCtx *selection.SelectionContext,
+	result *selection.SelectionResult,
+	selectedModelRef *config.ModelRef,
+	ctx *RequestContext,
+) {
+	if selCtx == nil || selectedModelRef == nil || ctx == nil || selCtx.SessionID == "" {
+		return
+	}
+	policy := ctx.VSRSessionPolicy
+	if policy == nil && result != nil && result.SessionPolicy != nil {
+		policy = result.SessionPolicy.ToMap()
+		ctx.VSRSessionPolicy = policy
+	}
+	activeToolLoop := false
+	previousModel := ctx.PreviousModel
+	if selCtx.AgenticSession != nil {
+		activeToolLoop = selCtx.AgenticSession.ActiveToolLoop
+		if previousModel == "" {
+			previousModel = selCtx.AgenticSession.PreviousModel
+		}
+	}
+	sessiontelemetry.RecordSessionDecision(sessiontelemetry.SessionDecisionParams{
+		SessionID:      selCtx.SessionID,
+		UserID:         selCtx.UserID,
+		PreviousModel:  previousModel,
+		SelectedModel:  selectedModelRef.Model,
+		DecisionName:   selCtx.DecisionName,
+		TurnIndex:      ctx.TurnIndex,
+		ActiveToolLoop: activeToolLoop,
+		Policy:         policy,
+		Timestamp:      time.Now(),
+	})
+}

--- a/src/semantic-router/pkg/extproc/session_telemetry.go
+++ b/src/semantic-router/pkg/extproc/session_telemetry.go
@@ -35,13 +35,15 @@ func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics, pricing 
 	if ctx.VSRSelectedCategory != "" {
 		domain = ctx.VSRSelectedCategory
 	}
+	sessiontelemetry.RecordLastModel(ctx.SessionID, ctx.RequestModel)
 	p := sessiontelemetry.TurnParams{
-		RequestID:        ctx.RequestID,
-		Model:            ctx.RequestModel,
-		Domain:           domain,
-		PromptTokens:     usage.promptTokens,
-		CompletionTokens: usage.completionTokens,
-		Pricing:          pricing,
+		RequestID:          ctx.RequestID,
+		Model:              ctx.RequestModel,
+		Domain:             domain,
+		PromptTokens:       usage.promptTokens,
+		CachedPromptTokens: usage.cachedPromptTokens,
+		CompletionTokens:   usage.completionTokens,
+		Pricing:            pricing,
 	}
 	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.IsResponseAPIRequest {
 		if ctx.ResponseAPICtx.ConversationID == "" {
@@ -64,12 +66,6 @@ func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics, pricing 
 			}
 		}
 		p.Chat = &sessiontelemetry.ChatInput{UserID: userID, Messages: msgs}
-		// Remember the model used for this Chat Completions session so the next
-		// turn's request phase can populate ctx.PreviousModel via GetLastModel.
-		// Keyed on ctx.SessionID (set during request prep), the same key the read
-		// side uses. Response API derives previous model from the conversation
-		// chain instead, so it is intentionally not recorded here.
-		sessiontelemetry.RecordLastModel(ctx.SessionID, ctx.RequestModel)
 	}
 	sessiontelemetry.RecordTurn(p)
 }

--- a/src/semantic-router/pkg/extproc/session_transition.go
+++ b/src/semantic-router/pkg/extproc/session_transition.go
@@ -2,6 +2,7 @@ package extproc
 
 import (
 	"strings"
+	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -30,6 +31,7 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 			}
 		}
 		ctx.HistoryTokenCount = historyTokensFromStoredResponses(history)
+		populateLastSessionObservation(ctx)
 		return
 	}
 
@@ -54,6 +56,45 @@ func populateSessionTransitionFields(ctx *RequestContext) {
 	if model, ok := sessiontelemetry.GetLastModel(ctx.SessionID); ok {
 		ctx.PreviousModel = model
 	}
+	populateLastSessionObservation(ctx)
+}
+
+// populatePinnedSessionFromHeaders makes client-supplied Chat Completions
+// session IDs available before full request parsing. Decision evaluation runs
+// on the fast-extract path, so session-aware selection cannot wait for
+// populateSessionTransitionFields.
+func populatePinnedSessionFromHeaders(ctx *RequestContext) {
+	if ctx == nil {
+		return
+	}
+	if sid := strings.TrimSpace(headerValueCI(ctx, headers.XSessionID)); sid != "" {
+		ctx.SessionID = sid
+	}
+	if ctx.SessionID == "" {
+		return
+	}
+	populateLastSessionObservation(ctx)
+}
+
+func populateLastSessionObservation(ctx *RequestContext) {
+	now := time.Now()
+	if snapshot, ok := sessiontelemetry.GetRouterSessionSnapshot(ctx.SessionID, now); ok {
+		if ctx.PreviousModel == "" {
+			ctx.PreviousModel = snapshot.CurrentModel
+		}
+		ctx.SessionIdleSeconds = snapshot.IdleFor.Seconds()
+		ctx.SessionIdleKnown = true
+		return
+	}
+	model, idleFor, ok := sessiontelemetry.GetLastModelInfo(ctx.SessionID, now)
+	if !ok {
+		return
+	}
+	if ctx.PreviousModel == "" {
+		ctx.PreviousModel = model
+	}
+	ctx.SessionIdleSeconds = idleFor.Seconds()
+	ctx.SessionIdleKnown = true
 }
 
 // populateChatCompletionSessionIDIfNeeded sets ctx.SessionID when not already

--- a/src/semantic-router/pkg/extproc/session_transition_test.go
+++ b/src/semantic-router/pkg/extproc/session_transition_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/sessiontelemetry"
 )
 
 func TestPopulateSessionTransitionFields_ResponseAPI(t *testing.T) {
@@ -176,6 +177,27 @@ func TestPopulateSessionTransitionFields_XSessionIDHeaderOverridesDerivation(t *
 
 	assert.Equal(t, "client-defined-session", ctx.SessionID)
 	assert.Equal(t, 0, ctx.TurnIndex)
+}
+
+func TestPopulatePinnedSessionFromHeadersReadsRouterMemoryBeforeParsing(t *testing.T) {
+	sessiontelemetry.ResetRouterSessionMemoryForTesting()
+	t.Cleanup(sessiontelemetry.ResetRouterSessionMemoryForTesting)
+	sessiontelemetry.RecordSessionDecision(sessiontelemetry.SessionDecisionParams{
+		SessionID:     "client-defined-session",
+		SelectedModel: "cheap-agent",
+	})
+
+	ctx := &RequestContext{
+		Headers: map[string]string{
+			headers.XSessionID: "client-defined-session",
+		},
+	}
+
+	populatePinnedSessionFromHeaders(ctx)
+
+	assert.Equal(t, "client-defined-session", ctx.SessionID)
+	assert.Equal(t, "cheap-agent", ctx.PreviousModel)
+	assert.True(t, ctx.SessionIdleKnown)
 }
 
 func TestPopulateSessionTransitionFields_ChatCompletionsNoUserUsesStructureHash(t *testing.T) {

--- a/src/semantic-router/pkg/extproc/utils_fast.go
+++ b/src/semantic-router/pkg/extproc/utils_fast.go
@@ -30,6 +30,8 @@ type FastExtractResult struct {
 	AssistantToolCallCount int
 	ToolResultCount        int
 	AssistantToolNames     []string
+	LastMessageRole        string
+	LastMessageToolResult  bool
 }
 
 // extractContentFast extracts model, stream, message content, and the first
@@ -96,6 +98,8 @@ func consumeFastExtractMessage(msg gjson.Result, result *FastExtractResult) {
 	role := msg.Get("role").String()
 	content := msg.Get("content")
 	text := extractTextFromContent(content)
+	result.LastMessageRole = role
+	result.LastMessageToolResult = false
 
 	switch role {
 	case "user":
@@ -114,6 +118,7 @@ func consumeFastExtractMessage(msg gjson.Result, result *FastExtractResult) {
 	case "tool":
 		result.ToolMessageCount++
 		result.ToolResultCount++
+		result.LastMessageToolResult = true
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/utils_fast_anthropic.go
+++ b/src/semantic-router/pkg/extproc/utils_fast_anthropic.go
@@ -86,6 +86,8 @@ func extractAnthropicSystemText(system gjson.Result) string {
 func consumeFastExtractAnthropicMessage(msg gjson.Result, result *FastExtractResult) {
 	role := msg.Get("role").String()
 	content := msg.Get("content")
+	result.LastMessageRole = role
+	result.LastMessageToolResult = false
 
 	text := extractAnthropicTextFromContent(content)
 	hasToolResult, hasToolUse := scanAnthropicBlockTypes(content)
@@ -101,6 +103,7 @@ func consumeFastExtractAnthropicMessage(msg gjson.Result, result *FastExtractRes
 			// signal parity.
 			result.ToolMessageCount++
 			result.ToolResultCount++
+			result.LastMessageToolResult = true
 		}
 	case "assistant":
 		result.AssistantMessageCount++

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -352,6 +352,9 @@ func appendUsageCostLogFields(fields map[string]interface{}, r RoutingRecord) {
 	if r.PromptTokens != nil {
 		fields["prompt_tokens"] = *r.PromptTokens
 	}
+	if r.CachedPromptTokens != nil {
+		fields["cached_prompt_tokens"] = *r.CachedPromptTokens
+	}
 	if r.CompletionTokens != nil {
 		fields["completion_tokens"] = *r.CompletionTokens
 	}
@@ -388,6 +391,7 @@ func LogFields(r RoutingRecord, event string) map[string]interface{} {
 		"reasoning_mode":    r.ReasoningMode,
 		"confidence_score":  r.ConfidenceScore,
 		"selection_method":  r.SelectionMethod,
+		"session_policy":    r.SessionPolicy,
 		"request_id":        r.RequestID,
 		"timestamp":         r.Timestamp,
 		"turn_index":        r.TurnIndex,

--- a/src/semantic-router/pkg/routerreplay/recorder_test.go
+++ b/src/semantic-router/pkg/routerreplay/recorder_test.go
@@ -20,6 +20,7 @@ func TestRecorderUpdateUsageCostClonesStoredValues(t *testing.T) {
 	}
 
 	promptTokens := 120
+	cachedPromptTokens := 40
 	completionTokens := 45
 	totalTokens := 165
 	actualCost := 0.0012
@@ -28,14 +29,15 @@ func TestRecorderUpdateUsageCostClonesStoredValues(t *testing.T) {
 	currency := "USD"
 	baselineModel := "premium-model"
 	usage := UsageCost{
-		PromptTokens:     &promptTokens,
-		CompletionTokens: &completionTokens,
-		TotalTokens:      &totalTokens,
-		ActualCost:       &actualCost,
-		BaselineCost:     &baselineCost,
-		CostSavings:      &costSavings,
-		Currency:         &currency,
-		BaselineModel:    &baselineModel,
+		PromptTokens:       &promptTokens,
+		CachedPromptTokens: &cachedPromptTokens,
+		CompletionTokens:   &completionTokens,
+		TotalTokens:        &totalTokens,
+		ActualCost:         &actualCost,
+		BaselineCost:       &baselineCost,
+		CostSavings:        &costSavings,
+		Currency:           &currency,
+		BaselineModel:      &baselineModel,
 	}
 
 	if err := recorder.UpdateUsageCost(recordID, usage); err != nil {
@@ -43,6 +45,7 @@ func TestRecorderUpdateUsageCostClonesStoredValues(t *testing.T) {
 	}
 
 	promptTokens = 999
+	cachedPromptTokens = 999
 	completionTokens = 999
 	totalTokens = 1998
 	actualCost = 9.9
@@ -57,6 +60,7 @@ func TestRecorderUpdateUsageCostClonesStoredValues(t *testing.T) {
 	}
 
 	assertIntPtr(t, record.PromptTokens, 120, "prompt tokens")
+	assertIntPtr(t, record.CachedPromptTokens, 40, "cached prompt tokens")
 	assertIntPtr(t, record.CompletionTokens, 45, "completion tokens")
 	assertIntPtr(t, record.TotalTokens, 165, "total tokens")
 	assertFloatPtr(t, record.ActualCost, 0.0012, "actual cost")
@@ -115,6 +119,7 @@ func TestRecorderUpdateToolTraceClonesStoredValues(t *testing.T) {
 
 func TestLogFieldsIncludesOptionalReplayMetadata(t *testing.T) {
 	promptTokens := 120
+	cachedPromptTokens := 40
 	completionTokens := 45
 	totalTokens := 165
 	actualCost := 0.0012
@@ -127,6 +132,7 @@ func TestLogFieldsIncludesOptionalReplayMetadata(t *testing.T) {
 	record := richReplayRoutingRecord(
 		timestamp,
 		&promptTokens,
+		&cachedPromptTokens,
 		&completionTokens,
 		&totalTokens,
 		&actualCost,
@@ -150,7 +156,9 @@ func TestLogFieldsIncludesOptionalReplayMetadata(t *testing.T) {
 	assertFieldValue(t, fields, "rag_backend", "milvus")
 	assertFieldValue(t, fields, "hallucination_spans", []string{"span-a"})
 	assertFieldValue(t, fields, "prompt_tokens", promptTokens)
+	assertFieldValue(t, fields, "cached_prompt_tokens", cachedPromptTokens)
 	assertFieldValue(t, fields, "currency", currency)
+	assertFieldValue(t, fields, "session_policy", map[string]interface{}{"decision_reason": "stay_has_best_adjusted_score"})
 	assertFieldValue(t, fields, "tool_trace_flow", "User Query -> LLM Tool Call -> Client Tool Result -> LLM Final Response")
 	assertFieldValue(t, fields, "tool_trace_stage", "LLM Final Response")
 	assertFieldValue(t, fields, "tool_names", []string{"get_weather"})
@@ -161,6 +169,7 @@ func TestLogFieldsIncludesOptionalReplayMetadata(t *testing.T) {
 func richReplayRoutingRecord(
 	timestamp time.Time,
 	promptTokens *int,
+	cachedPromptTokens *int,
 	completionTokens *int,
 	totalTokens *int,
 	actualCost *float64,
@@ -180,6 +189,7 @@ func richReplayRoutingRecord(
 		ReasoningMode:     "cot",
 		ConfidenceScore:   0.91,
 		SelectionMethod:   "router_dc",
+		SessionPolicy:     map[string]interface{}{"decision_reason": "stay_has_best_adjusted_score"},
 		RequestID:         "req-1",
 		SessionID:         "sess-log-test",
 		TurnIndex:         5,
@@ -233,6 +243,7 @@ func richReplayRoutingRecord(
 		HallucinationConfidence:     0.66,
 		HallucinationSpans:          []string{"span-a"},
 		PromptTokens:                promptTokens,
+		CachedPromptTokens:          cachedPromptTokens,
 		CompletionTokens:            completionTokens,
 		TotalTokens:                 totalTokens,
 		ActualCost:                  actualCost,

--- a/src/semantic-router/pkg/routerreplay/store/memory.go
+++ b/src/semantic-router/pkg/routerreplay/store/memory.go
@@ -171,6 +171,7 @@ func (m *MemoryStore) UpdateUsageCost(ctx context.Context, id string, usage Usag
 	}
 
 	rec.PromptTokens = cloneIntPtr(usage.PromptTokens)
+	rec.CachedPromptTokens = cloneIntPtr(usage.CachedPromptTokens)
 	rec.CompletionTokens = cloneIntPtr(usage.CompletionTokens)
 	rec.TotalTokens = cloneIntPtr(usage.TotalTokens)
 	rec.ActualCost = cloneFloat64Ptr(usage.ActualCost)

--- a/src/semantic-router/pkg/routerreplay/store/milvus.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus.go
@@ -447,6 +447,7 @@ func (m *MilvusStore) UpdateUsageCost(ctx context.Context, id string, usage Usag
 	}
 
 	record.PromptTokens = cloneIntPtr(usage.PromptTokens)
+	record.CachedPromptTokens = cloneIntPtr(usage.CachedPromptTokens)
 	record.CompletionTokens = cloneIntPtr(usage.CompletionTokens)
 	record.TotalTokens = cloneIntPtr(usage.TotalTokens)
 	record.ActualCost = cloneFloat64Ptr(usage.ActualCost)

--- a/src/semantic-router/pkg/routerreplay/store/postgres.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres.go
@@ -25,17 +25,17 @@ const postgresInsertQueryTemplate = `
 		INSERT INTO %s (
 			id, timestamp, request_id, decision, decision_tier, decision_priority, category,
 			original_model, selected_model, reasoning_mode,
-			signals, projections, projection_scores, signal_confidences, signal_values, tool_trace, projection_trace,
+			signals, projections, projection_scores, signal_confidences, signal_values, tool_trace, projection_trace, session_policy,
 			request_body, response_body, response_status,
 			from_cache, streaming, request_body_truncated, response_body_truncated,
 			guardrails_enabled, jailbreak_enabled, pii_enabled,
 			prompt, prompt_truncated, tool_definitions, tool_definitions_truncated,
 			rag_enabled, rag_backend, rag_context_length, rag_similarity_score,
 			hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
-			prompt_tokens, completion_tokens, total_tokens,
+			prompt_tokens, cached_prompt_tokens, completion_tokens, total_tokens,
 			actual_cost, baseline_cost, cost_savings, currency, baseline_model,
 			session_id, turn_index, previous_response_id, conversation_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53)
 	`
 
 // PostgresStore implements Storage using PostgreSQL as the backend.
@@ -110,6 +110,7 @@ func (p *PostgresStore) createTable(ctx context.Context) error {
 			signal_values JSONB,
 			tool_trace JSONB,
 			projection_trace JSONB,
+			session_policy JSONB,
 			request_body TEXT,
 			response_body TEXT,
 			response_status INTEGER,
@@ -133,6 +134,7 @@ func (p *PostgresStore) createTable(ctx context.Context) error {
 			hallucination_confidence REAL DEFAULT 0,
 			hallucination_spans JSONB,
 			prompt_tokens INTEGER,
+			cached_prompt_tokens INTEGER,
 			completion_tokens INTEGER,
 			total_tokens INTEGER,
 			actual_cost DOUBLE PRECISION,
@@ -150,11 +152,13 @@ func (p *PostgresStore) createTable(ctx context.Context) error {
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS signal_values JSONB;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS tool_trace JSONB;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS projection_trace JSONB;
+		ALTER TABLE %s ADD COLUMN IF NOT EXISTS session_policy JSONB;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS prompt TEXT;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS prompt_truncated BOOLEAN DEFAULT FALSE;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS tool_definitions TEXT;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS tool_definitions_truncated BOOLEAN DEFAULT FALSE;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS prompt_tokens INTEGER;
+		ALTER TABLE %s ADD COLUMN IF NOT EXISTS cached_prompt_tokens INTEGER;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS completion_tokens INTEGER;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS total_tokens INTEGER;
 		ALTER TABLE %s ADD COLUMN IF NOT EXISTS actual_cost DOUBLE PRECISION;
@@ -177,6 +181,7 @@ func (p *PostgresStore) createTable(ctx context.Context) error {
 		p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName,
 		p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName, p.tableName,
 		p.tableName, p.tableName, p.tableName, p.tableName,
+		p.tableName, p.tableName,
 		p.tableName, p.tableName, p.tableName, p.tableName,
 		p.tableName, p.tableName, p.tableName, p.tableName)
 
@@ -416,13 +421,14 @@ func (p *PostgresStore) UpdateUsageCost(ctx context.Context, id string, usage Us
 	query := fmt.Sprintf(`
 		UPDATE %s
 		SET prompt_tokens = $2,
-		    completion_tokens = $3,
-		    total_tokens = $4,
-		    actual_cost = $5,
-		    baseline_cost = $6,
-		    cost_savings = $7,
-		    currency = $8,
-		    baseline_model = $9
+		    cached_prompt_tokens = $3,
+		    completion_tokens = $4,
+		    total_tokens = $5,
+		    actual_cost = $6,
+		    baseline_cost = $7,
+		    cost_savings = $8,
+		    currency = $9,
+		    baseline_model = $10
 		WHERE id = $1
 	`, p.tableName)
 
@@ -432,6 +438,7 @@ func (p *PostgresStore) UpdateUsageCost(ctx context.Context, id string, usage Us
 			query,
 			id,
 			nullableIntArg(usage.PromptTokens),
+			nullableIntArg(usage.CachedPromptTokens),
 			nullableIntArg(usage.CompletionTokens),
 			nullableIntArg(usage.TotalTokens),
 			nullableFloat64Arg(usage.ActualCost),

--- a/src/semantic-router/pkg/routerreplay/store/postgres_record_codec.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_record_codec.go
@@ -37,6 +37,7 @@ func emptyStringSQL(s string) interface{} {
 func assignUsageCostFields(
 	record *Record,
 	promptTokens sql.NullInt64,
+	cachedPromptTokens sql.NullInt64,
 	completionTokens sql.NullInt64,
 	totalTokens sql.NullInt64,
 	actualCost sql.NullFloat64,
@@ -48,6 +49,10 @@ func assignUsageCostFields(
 	if promptTokens.Valid {
 		value := int(promptTokens.Int64)
 		record.PromptTokens = &value
+	}
+	if cachedPromptTokens.Valid {
+		value := int(cachedPromptTokens.Int64)
+		record.CachedPromptTokens = &value
 	}
 	if completionTokens.Valid {
 		value := int(completionTokens.Int64)

--- a/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
@@ -11,14 +11,14 @@ import (
 const postgresRecordSelectColumns = `
 	id, timestamp, request_id, decision, decision_tier, decision_priority, category,
 	original_model, selected_model, reasoning_mode,
-	signals, projections, projection_scores, signal_confidences, signal_values, tool_trace, projection_trace,
+	signals, projections, projection_scores, signal_confidences, signal_values, tool_trace, projection_trace, session_policy,
 	request_body, response_body, response_status,
 	from_cache, streaming, request_body_truncated, response_body_truncated,
 	guardrails_enabled, jailbreak_enabled, pii_enabled,
 	prompt, prompt_truncated, tool_definitions, tool_definitions_truncated,
 	rag_enabled, rag_backend, rag_context_length, rag_similarity_score,
 	hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
-	prompt_tokens, completion_tokens, total_tokens,
+	prompt_tokens, cached_prompt_tokens, completion_tokens, total_tokens,
 	actual_cost, baseline_cost, cost_savings, currency, baseline_model,
 	session_id, turn_index, previous_response_id, conversation_id
 `
@@ -36,6 +36,7 @@ type postgresInsertRecord struct {
 	signalValuesJSON       []byte
 	toolTraceJSON          []byte
 	projectionTraceJSON    []byte
+	sessionPolicyJSON      []byte
 	hallucinationSpansJSON []byte
 }
 
@@ -48,8 +49,10 @@ type postgresRecordRow struct {
 	signalValuesJSON       []byte
 	toolTraceJSON          []byte
 	projectionTraceJSON    []byte
+	sessionPolicyJSON      []byte
 	hallucinationSpansJSON []byte
 	promptTokens           sql.NullInt64
+	cachedPromptTokens     sql.NullInt64
 	completionTokens       sql.NullInt64
 	totalTokens            sql.NullInt64
 	actualCost             sql.NullFloat64
@@ -97,6 +100,10 @@ func newPostgresInsertRecord(record Record) (postgresInsertRecord, error) {
 	if err != nil {
 		return postgresInsertRecord{}, fmt.Errorf("failed to marshal projection trace: %w", err)
 	}
+	sessionPolicyJSON, err := marshalReplayOptionalJSON(prepared.SessionPolicy)
+	if err != nil {
+		return postgresInsertRecord{}, fmt.Errorf("failed to marshal session policy: %w", err)
+	}
 	hallucinationSpansJSON, err := json.Marshal(prepared.HallucinationSpans)
 	if err != nil {
 		return postgresInsertRecord{}, fmt.Errorf("failed to marshal hallucination spans: %w", err)
@@ -111,6 +118,7 @@ func newPostgresInsertRecord(record Record) (postgresInsertRecord, error) {
 		signalValuesJSON:       signalValuesJSON,
 		toolTraceJSON:          toolTraceJSON,
 		projectionTraceJSON:    projectionTraceJSON,
+		sessionPolicyJSON:      sessionPolicyJSON,
 		hallucinationSpansJSON: hallucinationSpansJSON,
 	}, nil
 }
@@ -148,6 +156,7 @@ func (record postgresInsertRecord) args() []interface{} {
 		record.signalValuesJSON,
 		record.toolTraceJSON,
 		record.projectionTraceJSON,
+		record.sessionPolicyJSON,
 		record.record.RequestBody,
 		record.record.ResponseBody,
 		record.record.ResponseStatus,
@@ -171,6 +180,7 @@ func (record postgresInsertRecord) args() []interface{} {
 		record.record.HallucinationConfidence,
 		record.hallucinationSpansJSON,
 		nullableIntArg(record.record.PromptTokens),
+		nullableIntArg(record.record.CachedPromptTokens),
 		nullableIntArg(record.record.CompletionTokens),
 		nullableIntArg(record.record.TotalTokens),
 		nullableFloat64Arg(record.record.ActualCost),
@@ -231,6 +241,7 @@ func (row *postgresRecordRow) scanDestinations() []interface{} {
 		&row.signalValuesJSON,
 		&row.toolTraceJSON,
 		&row.projectionTraceJSON,
+		&row.sessionPolicyJSON,
 		&row.record.RequestBody,
 		&row.record.ResponseBody,
 		&row.record.ResponseStatus,
@@ -254,6 +265,7 @@ func (row *postgresRecordRow) scanDestinations() []interface{} {
 		&row.record.HallucinationConfidence,
 		&row.hallucinationSpansJSON,
 		&row.promptTokens,
+		&row.cachedPromptTokens,
 		&row.completionTokens,
 		&row.totalTokens,
 		&row.actualCost,
@@ -278,6 +290,7 @@ func (row *postgresRecordRow) decode() (Record, error) {
 	assignUsageCostFields(
 		&row.record,
 		row.promptTokens,
+		row.cachedPromptTokens,
 		row.completionTokens,
 		row.totalTokens,
 		row.actualCost,
@@ -311,6 +324,9 @@ func (row *postgresRecordRow) unmarshalDecodedJSON() error {
 	}
 	if err := unmarshalReplayOptionalJSON(row.projectionTraceJSON, &row.record.ProjectionTrace); err != nil {
 		return fmt.Errorf("failed to unmarshal projection trace: %w", err)
+	}
+	if err := unmarshalReplayOptionalJSON(row.sessionPolicyJSON, &row.record.SessionPolicy); err != nil {
+		return fmt.Errorf("failed to unmarshal session policy: %w", err)
 	}
 	return nil
 }

--- a/src/semantic-router/pkg/routerreplay/store/qdrant.go
+++ b/src/semantic-router/pkg/routerreplay/store/qdrant.go
@@ -255,6 +255,7 @@ func (q *QdrantStore) UpdateHallucinationStatus(ctx context.Context, id string, 
 func (q *QdrantStore) UpdateUsageCost(ctx context.Context, id string, usage UsageCost) error {
 	return q.updateRecord(ctx, id, func(r *Record) {
 		r.PromptTokens = cloneIntPtr(usage.PromptTokens)
+		r.CachedPromptTokens = cloneIntPtr(usage.CachedPromptTokens)
 		r.CompletionTokens = cloneIntPtr(usage.CompletionTokens)
 		r.TotalTokens = cloneIntPtr(usage.TotalTokens)
 		r.ActualCost = cloneFloat64Ptr(usage.ActualCost)

--- a/src/semantic-router/pkg/routerreplay/store/redis.go
+++ b/src/semantic-router/pkg/routerreplay/store/redis.go
@@ -383,6 +383,7 @@ func (r *RedisStore) UpdateUsageCost(ctx context.Context, id string, usage Usage
 	}
 
 	record.PromptTokens = cloneIntPtr(usage.PromptTokens)
+	record.CachedPromptTokens = cloneIntPtr(usage.CachedPromptTokens)
 	record.CompletionTokens = cloneIntPtr(usage.CompletionTokens)
 	record.TotalTokens = cloneIntPtr(usage.TotalTokens)
 	record.ActualCost = cloneFloat64Ptr(usage.ActualCost)

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -33,14 +33,15 @@ type Signal struct {
 
 // UsageCost captures token usage and pricing-derived cost details for a record.
 type UsageCost struct {
-	PromptTokens     *int     `json:"prompt_tokens,omitempty"`
-	CompletionTokens *int     `json:"completion_tokens,omitempty"`
-	TotalTokens      *int     `json:"total_tokens,omitempty"`
-	ActualCost       *float64 `json:"actual_cost,omitempty"`
-	BaselineCost     *float64 `json:"baseline_cost,omitempty"`
-	CostSavings      *float64 `json:"cost_savings,omitempty"`
-	Currency         *string  `json:"currency,omitempty"`
-	BaselineModel    *string  `json:"baseline_model,omitempty"`
+	PromptTokens       *int     `json:"prompt_tokens,omitempty"`
+	CachedPromptTokens *int     `json:"cached_prompt_tokens,omitempty"`
+	CompletionTokens   *int     `json:"completion_tokens,omitempty"`
+	TotalTokens        *int     `json:"total_tokens,omitempty"`
+	ActualCost         *float64 `json:"actual_cost,omitempty"`
+	BaselineCost       *float64 `json:"baseline_cost,omitempty"`
+	CostSavings        *float64 `json:"cost_savings,omitempty"`
+	Currency           *string  `json:"currency,omitempty"`
+	BaselineModel      *string  `json:"baseline_model,omitempty"`
 }
 
 // ToolTrace captures the request-local assistant/tool exchange timeline.
@@ -103,6 +104,7 @@ type Record struct {
 	ReasoningMode         string                 `json:"reasoning_mode,omitempty"`
 	ConfidenceScore       float64                `json:"confidence_score,omitempty"`
 	SelectionMethod       string                 `json:"selection_method,omitempty"`
+	SessionPolicy         map[string]interface{} `json:"session_policy,omitempty"`
 	Signals               Signal                 `json:"signals"`
 	Projections           []string               `json:"projections,omitempty"`
 	ProjectionScores      map[string]float64     `json:"projection_scores,omitempty"`
@@ -164,14 +166,15 @@ type Record struct {
 	HallucinationSpans      []string `json:"hallucination_spans,omitempty"`
 
 	// Usage & Cost
-	PromptTokens     *int     `json:"prompt_tokens,omitempty"`
-	CompletionTokens *int     `json:"completion_tokens,omitempty"`
-	TotalTokens      *int     `json:"total_tokens,omitempty"`
-	ActualCost       *float64 `json:"actual_cost,omitempty"`
-	BaselineCost     *float64 `json:"baseline_cost,omitempty"`
-	CostSavings      *float64 `json:"cost_savings,omitempty"`
-	Currency         *string  `json:"currency,omitempty"`
-	BaselineModel    *string  `json:"baseline_model,omitempty"`
+	PromptTokens       *int     `json:"prompt_tokens,omitempty"`
+	CachedPromptTokens *int     `json:"cached_prompt_tokens,omitempty"`
+	CompletionTokens   *int     `json:"completion_tokens,omitempty"`
+	TotalTokens        *int     `json:"total_tokens,omitempty"`
+	ActualCost         *float64 `json:"actual_cost,omitempty"`
+	BaselineCost       *float64 `json:"baseline_cost,omitempty"`
+	CostSavings        *float64 `json:"cost_savings,omitempty"`
+	Currency           *string  `json:"currency,omitempty"`
+	BaselineModel      *string  `json:"baseline_model,omitempty"`
 }
 
 // Writer mutates router replay records.
@@ -236,6 +239,21 @@ func cloneFloat64Map(values map[string]float64) map[string]float64 {
 	return cloned
 }
 
+func cloneInterfaceMap(values map[string]interface{}) map[string]interface{} {
+	if values == nil {
+		return nil
+	}
+	b, err := json.Marshal(values)
+	if err != nil {
+		return nil
+	}
+	var cloned map[string]interface{}
+	if err := json.Unmarshal(b, &cloned); err != nil {
+		return nil
+	}
+	return cloned
+}
+
 func cloneProjectionTraceRecord(t *projectiontrace.Trace) *projectiontrace.Trace {
 	if t == nil {
 		return nil
@@ -286,6 +304,7 @@ func cloneSignal(signal Signal) Signal {
 		Jailbreak:    cloneStringSlice(signal.Jailbreak),
 		PII:          cloneStringSlice(signal.PII),
 		KB:           cloneStringSlice(signal.KB),
+		Conversation: cloneStringSlice(signal.Conversation),
 	}
 }
 
@@ -297,10 +316,12 @@ func cloneRecord(record Record) Record {
 	cloned.ProjectionTrace = cloneProjectionTraceRecord(record.ProjectionTrace)
 	cloned.SignalConfidences = cloneFloat64Map(record.SignalConfidences)
 	cloned.SignalValues = cloneFloat64Map(record.SignalValues)
+	cloned.SessionPolicy = cloneInterfaceMap(record.SessionPolicy)
 	cloned.ToolTrace = cloneToolTrace(record.ToolTrace)
 	cloned.PIIEntities = cloneStringSlice(record.PIIEntities)
 	cloned.HallucinationSpans = cloneStringSlice(record.HallucinationSpans)
 	cloned.PromptTokens = cloneIntPtr(record.PromptTokens)
+	cloned.CachedPromptTokens = cloneIntPtr(record.CachedPromptTokens)
 	cloned.CompletionTokens = cloneIntPtr(record.CompletionTokens)
 	cloned.TotalTokens = cloneIntPtr(record.TotalTokens)
 	cloned.ActualCost = cloneFloat64Ptr(record.ActualCost)

--- a/src/semantic-router/pkg/selection/agentic_session_context.go
+++ b/src/semantic-router/pkg/selection/agentic_session_context.go
@@ -1,0 +1,58 @@
+package selection
+
+import "time"
+
+// AgenticPhase describes where the request sits in a tool-using conversation.
+type AgenticPhase string
+
+const (
+	AgenticPhaseUnknown  AgenticPhase = ""
+	AgenticPhaseUserTurn AgenticPhase = "user_turn"
+	AgenticPhaseToolLoop AgenticPhase = "tool_loop"
+)
+
+// AgenticSessionContext is the selector-owned view of a multi-turn session.
+// It is derived at request time by extproc and intentionally contains facts,
+// not policy decisions.
+type AgenticSessionContext struct {
+	ID                 string
+	UserID             string
+	TurnIndex          int
+	PreviousModel      string
+	PreviousResponseID string
+
+	MemoryPresent       bool
+	MemoryTurnCount     int
+	MemorySwitchCount   int
+	MemoryModelTurnCnts map[string]int
+	MemoryPromptTokens  int64
+	MemoryCachedTokens  int64
+	MemoryOutputTokens  int64
+	MemoryCost          float64
+	LastDecisionReason  string
+
+	HistoryTokens int
+	ContextTokens int
+
+	IdleFor   time.Duration
+	IdleKnown bool
+
+	CacheWarmth   float64
+	CacheWarmthOK bool
+
+	Phase          AgenticPhase
+	ActiveToolLoop bool
+
+	ToolCallCount     int
+	ToolResultCount   int
+	ToolDefinitionCnt int
+
+	ModelContextWindows map[string]int
+}
+
+func (s *AgenticSessionContext) idleExpired(timeout time.Duration) bool {
+	if s == nil || timeout <= 0 || !s.IdleKnown {
+		return false
+	}
+	return s.IdleFor >= timeout
+}

--- a/src/semantic-router/pkg/selection/factory.go
+++ b/src/semantic-router/pkg/selection/factory.go
@@ -59,6 +59,9 @@ type ModelSelectionConfig struct {
 	// MultiFactor configuration (used when method is "multi_factor")
 	// Implements weighted quality/latency/cost/load composition. Issue #37.
 	MultiFactor *MultiFactorConfig `yaml:"multi_factor,omitempty"`
+
+	// SessionAware configuration (used when method is "session_aware")
+	SessionAware *SessionAwareConfig `yaml:"session_aware,omitempty"`
 }
 
 // DefaultModelSelectionConfig returns the default configuration
@@ -185,6 +188,17 @@ func (f *Factory) Create() Selector {
 			multiFactorSelector.InitializeFromConfig(f.modelConfig)
 		}
 		selector = multiFactorSelector
+
+	case MethodSessionAware:
+		sessionAwareSelector := NewSessionAwareSelector(f.cfg.SessionAware)
+		if f.modelConfig != nil {
+			sessionAwareSelector.InitializeFromConfig(f.modelConfig)
+		}
+		if f.lookupTable != nil {
+			sessionAwareSelector.SetLookupTable(f.lookupTable)
+		}
+		sessionAwareSelector.SetFallbackSelector(f.createSessionAwareFallback(sessionAwareSelector.config.FallbackMethod))
+		selector = sessionAwareSelector
 
 	default:
 		// Default to static selector
@@ -340,11 +354,40 @@ func (f *Factory) CreateAll() *Registry {
 	}
 	registry.Register(MethodMultiFactor, multiFactorSelector)
 
+	// Create SessionAware selector after base selectors so it can wrap one.
+	sessionAwareSelector := NewSessionAwareSelector(f.cfg.SessionAware)
+	if f.modelConfig != nil {
+		sessionAwareSelector.InitializeFromConfig(f.modelConfig)
+	}
+	if f.lookupTable != nil {
+		sessionAwareSelector.SetLookupTable(f.lookupTable)
+	}
+	if fallback, ok := registry.Get(sessionAwareSelector.config.FallbackMethod); ok {
+		sessionAwareSelector.SetFallbackSelector(fallback)
+	} else if fallback, ok := registry.Get(MethodStatic); ok {
+		sessionAwareSelector.SetFallbackSelector(fallback)
+	}
+	registry.Register(MethodSessionAware, sessionAwareSelector)
+
 	LogRegisteredAlgorithms(registry)
 	logging.ComponentEvent("selection", "selection_factory_initialized", map[string]interface{}{
 		"selector_count": len(registry.selectors),
 	})
 	return registry
+}
+
+func (f *Factory) createSessionAwareFallback(method SelectionMethod) Selector {
+	if method == "" || method == MethodSessionAware {
+		method = MethodHybrid
+	}
+	cfg := *f.cfg
+	cfg.Method = string(method)
+	return NewFactory(&cfg).
+		WithModelConfig(f.modelConfig).
+		WithCategories(f.categories).
+		WithEmbeddingFunc(f.embeddingFunc).
+		WithLookupTable(f.lookupTable).
+		Create()
 }
 
 // LogRegisteredAlgorithms logs the tier and dependencies of each registered algorithm

--- a/src/semantic-router/pkg/selection/selection_context_test.go
+++ b/src/semantic-router/pkg/selection/selection_context_test.go
@@ -71,6 +71,7 @@ func TestSelectorsRejectInvalidSelectionContextWithoutPanic(t *testing.T) {
 		{name: "rl_driven", selector: NewRLDrivenSelector(nil)},
 		{name: "latency_aware", selector: NewLatencyAwareSelector(nil)},
 		{name: "ml_adapter", selector: NewMLSelectorAdapter(nil, MethodKNN)},
+		{name: "session_aware", selector: NewSessionAwareSelector(nil)},
 	}
 
 	for _, tc := range selectors {

--- a/src/semantic-router/pkg/selection/selector.go
+++ b/src/semantic-router/pkg/selection/selector.go
@@ -92,6 +92,11 @@ const (
 	// MethodMultiFactor combines quality/latency/cost/load signals via a
 	// weighted score with optional SLO ceilings. Issue #37.
 	MethodMultiFactor SelectionMethod = "multi_factor"
+
+	// MethodSessionAware wraps a base selector with agentic session policy:
+	// it keeps tool loops and hot multi-turn continuations on the current model
+	// unless the switch benefit clears the explicit handoff and prefix-cache cost.
+	MethodSessionAware SelectionMethod = "session_aware"
 )
 
 // AlgorithmTier classifies algorithms by production readiness
@@ -180,6 +185,11 @@ type SelectionContext struct {
 	// Used to track within-session model performance
 	SessionID string
 
+	// AgenticSession carries request-time session facts used by
+	// session_aware selection. The legacy flat SessionID remains for selectors
+	// that only need a correlation key.
+	AgenticSession *AgenticSessionContext
+
 	// LatencyAwareTPOTPercentile is the configured TPOT percentile (1-100) for latency_aware selection
 	LatencyAwareTPOTPercentile int
 
@@ -215,6 +225,10 @@ type SelectionResult struct {
 
 	// AllScores maps each candidate model to its computed score
 	AllScores map[string]float64
+
+	// SessionPolicy records the session-aware stay/switch policy trace when
+	// Method is session_aware.
+	SessionPolicy *SessionPolicyTrace
 }
 
 // Selector is the interface for model selection algorithms

--- a/src/semantic-router/pkg/selection/session_aware.go
+++ b/src/semantic-router/pkg/selection/session_aware.go
@@ -1,0 +1,344 @@
+package selection
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection/lookuptable"
+)
+
+// SessionAwareConfig configures agentic session-aware model selection.
+type SessionAwareConfig struct {
+	FallbackMethod         SelectionMethod
+	IdleTimeoutSeconds     int
+	MinTurnsBeforeSwitch   int
+	SwitchMargin           float64
+	StayBias               float64
+	ToolLoopHardLock       bool
+	ToolLoopStayBias       float64
+	PrefixCacheWeight      float64
+	HandoffPenaltyWeight   float64
+	DefaultHandoffPenalty  float64
+	QualityGapMultiplier   float64
+	MaxCacheCostMultiplier float64
+	SwitchHistoryWeight    float64
+}
+
+// DefaultSessionAwareConfig returns the production-oriented default policy.
+func DefaultSessionAwareConfig() *SessionAwareConfig {
+	return &SessionAwareConfig{
+		FallbackMethod:         MethodHybrid,
+		IdleTimeoutSeconds:     300,
+		MinTurnsBeforeSwitch:   1,
+		SwitchMargin:           0.05,
+		StayBias:               0.10,
+		ToolLoopHardLock:       true,
+		ToolLoopStayBias:       0.35,
+		PrefixCacheWeight:      0.20,
+		HandoffPenaltyWeight:   1.0,
+		DefaultHandoffPenalty:  0.05,
+		QualityGapMultiplier:   1.0,
+		MaxCacheCostMultiplier: 2.5,
+		SwitchHistoryWeight:    0.04,
+	}
+}
+
+// SessionAwareSelector wraps a base selector with explicit session policy.
+type SessionAwareSelector struct {
+	config      *SessionAwareConfig
+	fallback    Selector
+	modelParams map[string]config.ModelParams
+	lookupTable lookuptable.LookupTable
+}
+
+func NewSessionAwareSelector(cfg *SessionAwareConfig) *SessionAwareSelector {
+	if cfg == nil {
+		cfg = DefaultSessionAwareConfig()
+	} else {
+		cfg = normalizeSessionAwareConfig(*cfg)
+	}
+	return &SessionAwareSelector{
+		config:      cfg,
+		modelParams: make(map[string]config.ModelParams),
+	}
+}
+
+func normalizeSessionAwareConfig(cfg SessionAwareConfig) *SessionAwareConfig {
+	defaults := DefaultSessionAwareConfig()
+	cfg.FallbackMethod = defaultSessionAwareFallback(cfg.FallbackMethod, defaults.FallbackMethod)
+	cfg.IdleTimeoutSeconds = defaultNonNegativeInt(cfg.IdleTimeoutSeconds, defaults.IdleTimeoutSeconds)
+	cfg.MinTurnsBeforeSwitch = defaultNonNegativeInt(cfg.MinTurnsBeforeSwitch, defaults.MinTurnsBeforeSwitch)
+	cfg.SwitchMargin = defaultNonNegativeFloat(cfg.SwitchMargin, defaults.SwitchMargin)
+	cfg.StayBias = defaultNonNegativeFloat(cfg.StayBias, defaults.StayBias)
+	cfg.ToolLoopStayBias = defaultNonNegativeFloat(cfg.ToolLoopStayBias, defaults.ToolLoopStayBias)
+	cfg.PrefixCacheWeight = defaultNonNegativeFloat(cfg.PrefixCacheWeight, defaults.PrefixCacheWeight)
+	cfg.HandoffPenaltyWeight = defaultNonNegativeFloat(cfg.HandoffPenaltyWeight, defaults.HandoffPenaltyWeight)
+	cfg.DefaultHandoffPenalty = defaultNonNegativeFloat(cfg.DefaultHandoffPenalty, defaults.DefaultHandoffPenalty)
+	cfg.QualityGapMultiplier = defaultPositiveFloat(cfg.QualityGapMultiplier, defaults.QualityGapMultiplier)
+	cfg.MaxCacheCostMultiplier = defaultPositiveFloat(cfg.MaxCacheCostMultiplier, defaults.MaxCacheCostMultiplier)
+	cfg.SwitchHistoryWeight = defaultNonNegativeFloat(cfg.SwitchHistoryWeight, defaults.SwitchHistoryWeight)
+	return &cfg
+}
+
+func defaultSessionAwareFallback(method, fallback SelectionMethod) SelectionMethod {
+	if method == "" || method == MethodSessionAware {
+		return fallback
+	}
+	return method
+}
+
+func defaultNonNegativeInt(value, fallback int) int {
+	if value < 0 {
+		return fallback
+	}
+	return value
+}
+
+func defaultNonNegativeFloat(value, fallback float64) float64 {
+	if value < 0 {
+		return fallback
+	}
+	return value
+}
+
+func defaultPositiveFloat(value, fallback float64) float64 {
+	if value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func (s *SessionAwareSelector) Method() SelectionMethod {
+	return MethodSessionAware
+}
+
+func (s *SessionAwareSelector) SetFallbackSelector(selector Selector) {
+	s.fallback = selector
+}
+
+func (s *SessionAwareSelector) SetLookupTable(lt lookuptable.LookupTable) {
+	s.lookupTable = lt
+}
+
+func (s *SessionAwareSelector) InitializeFromConfig(modelConfig map[string]config.ModelParams) {
+	s.modelParams = make(map[string]config.ModelParams, len(modelConfig))
+	for k, v := range modelConfig {
+		s.modelParams[k] = v
+	}
+}
+
+func (s *SessionAwareSelector) Select(ctx context.Context, selCtx *SelectionContext) (*SelectionResult, error) {
+	if err := ValidateSelectionContext(selCtx); err != nil {
+		return nil, err
+	}
+
+	base, err := s.selectFallback(ctx, selCtx)
+	if err != nil {
+		return nil, err
+	}
+	session := selCtx.AgenticSession
+	if session == nil {
+		trace := s.newPolicyTrace(selCtx, base, nil, "", false)
+		trace.MissingSignals = append(trace.MissingSignals, "session_context")
+		return s.wrapFallback(base, "missing_session_context", trace), nil
+	}
+
+	current := strings.TrimSpace(session.PreviousModel)
+	trace := s.newPolicyTrace(selCtx, base, session, current, false)
+	if current == "" {
+		trace.MissingSignals = append(trace.MissingSignals, "previous_model")
+		return s.wrapFallback(base, "missing_previous_model", trace), nil
+	}
+	if !candidateSetContains(selCtx.CandidateModels, current) {
+		trace.MissingSignals = append(trace.MissingSignals, "previous_model_not_in_candidates")
+		return s.wrapFallback(base, "previous_model_not_in_candidates", trace), nil
+	}
+
+	timeout := secondsDuration(s.config.IdleTimeoutSeconds)
+	idleExpired := session.idleExpired(timeout)
+	trace.IdleExpired = idleExpired
+	if session.ActiveToolLoop && s.config.ToolLoopHardLock {
+		return s.forceCurrent(selCtx, base, current, "hard_lock=tool_loop", trace), nil
+	}
+	if effectiveSessionTurns(session) < s.config.MinTurnsBeforeSwitch && !idleExpired {
+		return s.forceCurrent(selCtx, base, current, "hard_lock=min_turns", trace), nil
+	}
+
+	adjusted, candidateTraces := s.adjustScores(selCtx, base, session, current, idleExpired)
+	bestRef, bestScore := bestCandidateByScore(selCtx.CandidateModels, adjusted)
+	if bestRef == nil {
+		trace.MissingSignals = append(trace.MissingSignals, "adjusted_scores")
+		return s.wrapFallback(base, "missing_adjusted_scores", trace), nil
+	}
+
+	confidence := adjustedConfidence(bestRef.Model, adjusted)
+	reason := fmt.Sprintf(
+		"session_aware: fallback=%s current=%s selected=%s idle_expired=%t active_tool_loop=%t",
+		base.Method, current, bestRef.Model, idleExpired, session.ActiveToolLoop,
+	)
+	trace.SelectedModel = bestRef.Model
+	trace.FinalScores = cloneScores(adjusted)
+	trace.CandidateTraces = candidateTraces
+	trace.DecisionReason = "switch_allowed"
+	if bestRef.Model == current {
+		trace.DecisionReason = "stay_has_best_adjusted_score"
+	}
+	logging.Infof("[SessionAwareSelector] %s score=%.4f confidence=%.2f", reason, bestScore, confidence)
+	return &SelectionResult{
+		SelectedModel: bestRef.Model,
+		LoRAName:      bestRef.LoRAName,
+		Score:         bestScore,
+		Confidence:    confidence,
+		Method:        MethodSessionAware,
+		Tier:          TierSupported,
+		Reasoning:     reason,
+		AllScores:     adjusted,
+		SessionPolicy: trace,
+	}, nil
+}
+
+func effectiveSessionTurns(session *AgenticSessionContext) int {
+	if session == nil {
+		return 0
+	}
+	if session.MemoryTurnCount > session.TurnIndex {
+		return session.MemoryTurnCount
+	}
+	return session.TurnIndex
+}
+
+func (s *SessionAwareSelector) selectFallback(ctx context.Context, selCtx *SelectionContext) (*SelectionResult, error) {
+	if s.fallback != nil && s.fallback.Method() != MethodSessionAware {
+		result, err := s.fallback.Select(ctx, selCtx)
+		if err == nil && result != nil {
+			ensureScoresForCandidates(result, selCtx.CandidateModels)
+			return result, nil
+		}
+		logging.Warnf("[SessionAwareSelector] fallback selector %s failed: %v", s.fallback.Method(), err)
+	}
+	result := staticFallbackResult(selCtx)
+	return result, nil
+}
+
+func (s *SessionAwareSelector) wrapFallback(base *SelectionResult, reason string, trace *SessionPolicyTrace) *SelectionResult {
+	wrapped := *base
+	wrapped.Method = MethodSessionAware
+	wrapped.Tier = TierSupported
+	wrapped.Reasoning = fmt.Sprintf("session_aware: %s; fallback=%s selected=%s", reason, base.Method, base.SelectedModel)
+	if trace != nil {
+		trace.SelectedModel = base.SelectedModel
+		trace.DecisionReason = reason
+		trace.FinalScores = cloneScores(base.AllScores)
+		wrapped.SessionPolicy = trace
+	}
+	return &wrapped
+}
+
+func (s *SessionAwareSelector) forceCurrent(selCtx *SelectionContext, base *SelectionResult, current, reason string, trace *SessionPolicyTrace) *SelectionResult {
+	allScores := cloneScores(base.AllScores)
+	if allScores == nil {
+		allScores = make(map[string]float64, len(selCtx.CandidateModels))
+	}
+	currentScore := allScores[current]
+	allScores[current] = math.Max(currentScore, maxScore(allScores)+s.config.ToolLoopStayBias+s.config.StayBias)
+	ref := modelRefForName(selCtx.CandidateModels, current)
+	loRA := ""
+	if ref != nil {
+		loRA = ref.LoRAName
+	}
+	if trace != nil {
+		trace.HardLocked = true
+		trace.HardLockReason = reason
+		trace.DecisionReason = reason
+		trace.SelectedModel = current
+		trace.FinalScores = cloneScores(allScores)
+		baseScore := 0.0
+		if base != nil && base.AllScores != nil {
+			baseScore = base.AllScores[current]
+		}
+		trace.CandidateTraces = map[string]SessionCandidateTrace{
+			current: {
+				Current:    true,
+				BaseScore:  baseScore,
+				FinalScore: allScores[current],
+			},
+		}
+	}
+	result := &SelectionResult{
+		SelectedModel: current,
+		LoRAName:      loRA,
+		Score:         allScores[current],
+		Confidence:    1.0,
+		Method:        MethodSessionAware,
+		Tier:          TierSupported,
+		Reasoning:     fmt.Sprintf("session_aware: %s current=%s fallback=%s", reason, current, base.Method),
+		AllScores:     allScores,
+		SessionPolicy: trace,
+	}
+	return result
+}
+
+func (s *SessionAwareSelector) newPolicyTrace(
+	selCtx *SelectionContext,
+	base *SelectionResult,
+	session *AgenticSessionContext,
+	current string,
+	idleExpired bool,
+) *SessionPolicyTrace {
+	trace := &SessionPolicyTrace{
+		Algorithm:    "agentic_continuity_routing",
+		CurrentModel: current,
+		SwitchMargin: s.config.SwitchMargin,
+		StayBias:     s.config.StayBias,
+		IdleExpired:  idleExpired,
+	}
+	if base != nil {
+		trace.FallbackMethod = string(base.Method)
+		trace.FallbackSelectedModel = base.SelectedModel
+		trace.BaseScores = cloneScores(base.AllScores)
+	}
+	if session == nil {
+		return trace
+	}
+	trace.SessionID = session.ID
+	trace.UserID = session.UserID
+	trace.Phase = session.Phase
+	trace.TurnIndex = session.TurnIndex
+	trace.MemoryTurnCount = session.MemoryTurnCount
+	trace.SwitchCount = session.MemorySwitchCount
+	trace.ActiveToolLoop = session.ActiveToolLoop
+	trace.IdleKnown = session.IdleKnown
+	trace.IdleForSeconds = session.IdleFor.Seconds()
+	trace.ContinuationMass = sessionContinuationMass(session)
+	trace.CacheWarmth = sessionCacheWarmth(session, idleExpired)
+	trace.CacheWarmthOK = session.CacheWarmthOK
+	if session.MemoryPresent && trace.MemoryTurnCount == 0 {
+		trace.MemoryTurnCount = session.TurnIndex + 1
+	}
+	if selCtx != nil && trace.SessionID == "" {
+		trace.SessionID = selCtx.SessionID
+	}
+	return trace
+}
+
+func (s *SessionAwareSelector) UpdateFeedback(ctx context.Context, feedback *Feedback) error {
+	if s.fallback == nil {
+		return nil
+	}
+	return s.fallback.UpdateFeedback(ctx, feedback)
+}
+
+func (s *SessionAwareSelector) Tier() AlgorithmTier {
+	return TierSupported
+}
+
+func (s *SessionAwareSelector) ExternalDependencies() []Dependency {
+	if s.fallback == nil {
+		return nil
+	}
+	return s.fallback.ExternalDependencies()
+}

--- a/src/semantic-router/pkg/selection/session_aware_helpers.go
+++ b/src/semantic-router/pkg/selection/session_aware_helpers.go
@@ -1,0 +1,121 @@
+package selection
+
+import (
+	"math"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func secondsDuration(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func staticFallbackResult(selCtx *SelectionContext) *SelectionResult {
+	ref := selCtx.CandidateModels[0]
+	allScores := make(map[string]float64, len(selCtx.CandidateModels))
+	for i, candidate := range selCtx.CandidateModels {
+		score := 1.0
+		if i > 0 {
+			score = 1.0 - float64(i)*0.001
+		}
+		allScores[candidate.Model] = score
+	}
+	return &SelectionResult{
+		SelectedModel: ref.Model,
+		LoRAName:      ref.LoRAName,
+		Score:         allScores[ref.Model],
+		Confidence:    1.0,
+		Method:        MethodStatic,
+		Tier:          TierSupported,
+		Reasoning:     "static fallback",
+		AllScores:     allScores,
+	}
+}
+
+func ensureScoresForCandidates(result *SelectionResult, candidates []config.ModelRef) {
+	if result.AllScores == nil {
+		result.AllScores = make(map[string]float64, len(candidates))
+	}
+	for i, candidate := range candidates {
+		if _, ok := result.AllScores[candidate.Model]; ok {
+			continue
+		}
+		score := 0.0
+		if result.SelectedModel == candidate.Model {
+			score = result.Score
+		} else {
+			score = -float64(i) * 0.001
+		}
+		result.AllScores[candidate.Model] = score
+	}
+}
+
+func cloneScores(in map[string]float64) map[string]float64 {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]float64, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func bestCandidateByScore(candidates []config.ModelRef, scores map[string]float64) (*config.ModelRef, float64) {
+	var best *config.ModelRef
+	bestScore := math.Inf(-1)
+	for i := range candidates {
+		score, ok := scores[candidates[i].Model]
+		if !ok || !isFinite(score) {
+			continue
+		}
+		if best == nil || score > bestScore {
+			best = &candidates[i]
+			bestScore = score
+		}
+	}
+	return best, bestScore
+}
+
+func adjustedConfidence(selected string, scores map[string]float64) float64 {
+	best := scores[selected]
+	second := math.Inf(-1)
+	for model, score := range scores {
+		if model == selected {
+			continue
+		}
+		if score > second {
+			second = score
+		}
+	}
+	if math.IsInf(second, -1) {
+		return 1
+	}
+	return clamp01(0.5 + math.Min(0.5, math.Max(0, best-second)))
+}
+
+func modelRefForName(candidates []config.ModelRef, model string) *config.ModelRef {
+	for i := range candidates {
+		if candidates[i].Model == model || candidates[i].LoRAName == model {
+			return &candidates[i]
+		}
+	}
+	return nil
+}
+
+func maxScore(scores map[string]float64) float64 {
+	max := math.Inf(-1)
+	for _, score := range scores {
+		if score > max {
+			max = score
+		}
+	}
+	if math.IsInf(max, -1) {
+		return 0
+	}
+	return max
+}

--- a/src/semantic-router/pkg/selection/session_aware_scoring.go
+++ b/src/semantic-router/pkg/selection/session_aware_scoring.go
@@ -1,0 +1,223 @@
+package selection
+
+import "math"
+
+func (s *SessionAwareSelector) adjustScores(
+	selCtx *SelectionContext,
+	base *SelectionResult,
+	session *AgenticSessionContext,
+	current string,
+	idleExpired bool,
+) (map[string]float64, map[string]SessionCandidateTrace) {
+	baseScores := cloneScores(base.AllScores)
+	ensureScoresForCandidates(&SelectionResult{AllScores: baseScores, SelectedModel: base.SelectedModel, Score: base.Score}, selCtx.CandidateModels)
+	currentBaseScore := baseScores[current]
+	currentAdjustedScore, currentTrace := s.scoreCurrentCandidate(
+		currentBaseScore,
+		session,
+		current,
+		idleExpired,
+		SessionCandidateTrace{
+			Current:    true,
+			BaseScore:  currentBaseScore,
+			FinalScore: currentBaseScore,
+		},
+	)
+
+	adjusted := make(map[string]float64, len(selCtx.CandidateModels))
+	traces := make(map[string]SessionCandidateTrace, len(selCtx.CandidateModels))
+	for _, candidate := range selCtx.CandidateModels {
+		model := candidate.Model
+		score := baseScores[model]
+		trace := SessionCandidateTrace{
+			Current:    model == current,
+			BaseScore:  score,
+			FinalScore: score,
+		}
+		if model == current {
+			adjusted[model] = currentAdjustedScore
+			traces[model] = currentTrace
+			continue
+		}
+
+		score, trace = s.scoreSwitchCandidate(selCtx, session, current, model, score, currentBaseScore, currentAdjustedScore, idleExpired, trace)
+		adjusted[model] = score
+		traces[model] = trace
+	}
+	return adjusted, traces
+}
+
+func (s *SessionAwareSelector) scoreCurrentCandidate(
+	score float64,
+	session *AgenticSessionContext,
+	current string,
+	idleExpired bool,
+	trace SessionCandidateTrace,
+) (float64, SessionCandidateTrace) {
+	prefixBenefit := 0.0
+	if !idleExpired {
+		score += s.config.StayBias
+		prefixBenefit = s.prefixCacheBenefit(session, current)
+		score += prefixBenefit
+	}
+	if session.ActiveToolLoop {
+		score += s.config.ToolLoopStayBias
+	}
+	trace.PrefixCacheBenefit = prefixBenefit
+	trace.FinalScore = score
+	return score, trace
+}
+
+func (s *SessionAwareSelector) scoreSwitchCandidate(
+	selCtx *SelectionContext,
+	session *AgenticSessionContext,
+	current string,
+	model string,
+	score float64,
+	currentBaseScore float64,
+	currentAdjustedScore float64,
+	idleExpired bool,
+	trace SessionCandidateTrace,
+) (float64, SessionCandidateTrace) {
+	qualityGap := s.lookupQualityGap(selCtx, current, model)
+	handoffPenalty := s.lookupHandoffPenalty(current, model)
+	prefixPenalty := s.prefixCachePenalty(session, current, model, idleExpired)
+	frontierMultiplier := s.cacheCostMultiplier(current, model)
+	toolPenalty := 0.0
+	if session.ActiveToolLoop {
+		toolPenalty = s.config.ToolLoopStayBias
+	}
+	switchHistoryPenalty := s.switchHistoryPenalty(session)
+	switchMargin := s.config.SwitchMargin
+	if idleExpired {
+		handoffPenalty = 0
+		prefixPenalty = 0
+		switchHistoryPenalty = 0
+		switchMargin = 0
+	}
+	selectorDelta := score - currentBaseScore
+	score += s.config.QualityGapMultiplier*qualityGap -
+		s.config.HandoffPenaltyWeight*handoffPenalty -
+		prefixPenalty -
+		toolPenalty -
+		switchHistoryPenalty -
+		switchMargin
+	if selectorDelta <= 0 && qualityGap <= 0 && !idleExpired {
+		score -= s.config.StayBias
+	}
+
+	trace.SelectorDelta = selectorDelta
+	trace.QualityGap = qualityGap
+	trace.HandoffPenalty = handoffPenalty
+	trace.PrefixCachePenalty = prefixPenalty
+	trace.ToolLoopPenalty = toolPenalty
+	trace.SwitchHistoryPenalty = switchHistoryPenalty
+	trace.FrontierCostMultiplier = frontierMultiplier
+	trace.NetSwitchAdvantage = score - currentAdjustedScore
+	trace.FinalScore = score
+	return score, trace
+}
+
+func (s *SessionAwareSelector) prefixCacheBenefit(session *AgenticSessionContext, current string) float64 {
+	return s.config.PrefixCacheWeight * sessionContinuationMass(session) * sessionCacheWarmth(session, false) * s.cacheCostMultiplier(current, current)
+}
+
+func (s *SessionAwareSelector) prefixCachePenalty(
+	session *AgenticSessionContext,
+	current string,
+	candidate string,
+	idleExpired bool,
+) float64 {
+	if session == nil || current == "" || candidate == "" || current == candidate {
+		return 0
+	}
+	return s.config.PrefixCacheWeight *
+		sessionContinuationMass(session) *
+		sessionCacheWarmth(session, idleExpired) *
+		s.cacheCostMultiplier(current, candidate)
+}
+
+func (s *SessionAwareSelector) switchHistoryPenalty(session *AgenticSessionContext) float64 {
+	if session == nil || session.MemorySwitchCount <= 0 || s.config.SwitchHistoryWeight <= 0 {
+		return 0
+	}
+	return s.config.SwitchHistoryWeight * clampF(float64(session.MemorySwitchCount)/8.0, 0, 1)
+}
+
+func (s *SessionAwareSelector) cacheCostMultiplier(current, candidate string) float64 {
+	maxPressure := math.Max(s.modelCostPressure(current), s.modelCostPressure(candidate))
+	return 1.0 + (s.config.MaxCacheCostMultiplier-1.0)*maxPressure
+}
+
+func (s *SessionAwareSelector) modelCostPressure(model string) float64 {
+	if model == "" || len(s.modelParams) == 0 {
+		return 0.5
+	}
+	maxCost := 0.0
+	modelCost := 0.0
+	for name, params := range s.modelParams {
+		cost := params.Pricing.PromptPer1M + params.Pricing.CompletionPer1M
+		if cost > maxCost {
+			maxCost = cost
+		}
+		if name == model {
+			modelCost = cost
+		}
+	}
+	if maxCost > 0 && modelCost > 0 {
+		return clamp01(modelCost / maxCost)
+	}
+	if params, ok := s.modelParams[model]; ok && params.QualityScore > 0 {
+		return clamp01(params.QualityScore)
+	}
+	return 0.5
+}
+
+func (s *SessionAwareSelector) lookupQualityGap(selCtx *SelectionContext, current, candidate string) float64 {
+	if s.lookupTable == nil || selCtx == nil {
+		return 0
+	}
+	for _, family := range []string{selCtx.CategoryName, selCtx.DecisionName} {
+		if family == "" {
+			continue
+		}
+		if gap, ok := s.lookupTable.QualityGap(family, current, candidate); ok {
+			return gap
+		}
+	}
+	return 0
+}
+
+func (s *SessionAwareSelector) lookupHandoffPenalty(current, candidate string) float64 {
+	if s.lookupTable != nil {
+		if penalty, ok := s.lookupTable.HandoffPenalty(current, candidate); ok {
+			return penalty
+		}
+	}
+	return s.config.DefaultHandoffPenalty
+}
+
+func sessionContinuationMass(session *AgenticSessionContext) float64 {
+	if session == nil {
+		return 0
+	}
+	contextTokens := math.Max(float64(session.ContextTokens), 1)
+	reuseRatio := clampF(float64(session.HistoryTokens)/contextTokens, 0, 1)
+	historyMass := clampF(float64(session.HistoryTokens)/8192.0, 0, 1)
+	turnDepth := clampF(float64(effectiveSessionTurns(session))/8.0, 0, 1)
+	if session.PreviousResponseID != "" && reuseRatio < 0.15 {
+		reuseRatio = 0.15
+	}
+	return clampF(0.45*reuseRatio+0.35*historyMass+0.20*turnDepth, 0, 1)
+}
+
+func sessionCacheWarmth(session *AgenticSessionContext, idleExpired bool) float64 {
+	warmth := 0.5
+	if session != nil && session.CacheWarmthOK {
+		warmth = clamp01(session.CacheWarmth)
+	}
+	if idleExpired {
+		warmth *= 0.2
+	}
+	return warmth
+}

--- a/src/semantic-router/pkg/selection/session_aware_test.go
+++ b/src/semantic-router/pkg/selection/session_aware_test.go
@@ -1,0 +1,312 @@
+package selection
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestSessionAwareSelectorToolLoopHardLocksCurrentModel(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{
+		FallbackMethod:         MethodStatic,
+		ToolLoopHardLock:       true,
+		ToolLoopStayBias:       0.35,
+		StayBias:               0.10,
+		QualityGapMultiplier:   1,
+		MaxCacheCostMultiplier: 2.5,
+	})
+	selector.SetFallbackSelector(stubSessionFallback{
+		result: &SelectionResult{
+			SelectedModel: "frontier",
+			Score:         0.95,
+			Method:        MethodHybrid,
+			AllScores: map[string]float64{
+				"current":  0.40,
+				"frontier": 0.95,
+			},
+		},
+	})
+
+	result, err := selector.Select(context.Background(), &SelectionContext{
+		CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "frontier"}},
+		AgenticSession: &AgenticSessionContext{
+			ID:             "sess-1",
+			TurnIndex:      3,
+			PreviousModel:  "current",
+			ActiveToolLoop: true,
+			Phase:          AgenticPhaseToolLoop,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+	if result.SelectedModel != "current" {
+		t.Fatalf("expected current model to be hard-locked, got %q", result.SelectedModel)
+	}
+	if result.SessionPolicy == nil || !result.SessionPolicy.HardLocked {
+		t.Fatalf("expected hard-lock policy trace, got %#v", result.SessionPolicy)
+	}
+	if result.SessionPolicy.HardLockReason != "hard_lock=tool_loop" {
+		t.Fatalf("unexpected hard-lock reason: %q", result.SessionPolicy.HardLockReason)
+	}
+}
+
+func TestSessionAwareSelectorIdleSessionAllowsFallbackSwitch(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{
+		FallbackMethod:         MethodStatic,
+		IdleTimeoutSeconds:     60,
+		SwitchMargin:           0,
+		StayBias:               0,
+		ToolLoopHardLock:       true,
+		PrefixCacheWeight:      0,
+		HandoffPenaltyWeight:   0,
+		DefaultHandoffPenalty:  0,
+		QualityGapMultiplier:   1,
+		MaxCacheCostMultiplier: 2.5,
+	})
+	selector.SetFallbackSelector(stubSessionFallback{
+		result: &SelectionResult{
+			SelectedModel: "frontier",
+			Score:         0.90,
+			Method:        MethodHybrid,
+			AllScores: map[string]float64{
+				"current":  0.20,
+				"frontier": 0.90,
+			},
+		},
+	})
+
+	result, err := selector.Select(context.Background(), &SelectionContext{
+		CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "frontier"}},
+		AgenticSession: &AgenticSessionContext{
+			ID:            "sess-1",
+			TurnIndex:     4,
+			PreviousModel: "current",
+			IdleFor:       2 * time.Minute,
+			IdleKnown:     true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+	if result.SelectedModel != "frontier" {
+		t.Fatalf("expected idle session to accept stronger fallback choice, got %q", result.SelectedModel)
+	}
+	if result.SessionPolicy == nil || !result.SessionPolicy.IdleExpired {
+		t.Fatalf("expected idle-expired policy trace, got %#v", result.SessionPolicy)
+	}
+	if trace := result.SessionPolicy.CandidateTraces["frontier"]; trace.NetSwitchAdvantage <= 0 {
+		t.Fatalf("expected positive frontier switch advantage, got %#v", trace)
+	}
+}
+
+func TestSessionAwareSelectorIdleSessionClearsContinuityPenalty(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{
+		FallbackMethod:         MethodStatic,
+		IdleTimeoutSeconds:     60,
+		SwitchMargin:           0.05,
+		StayBias:               0.10,
+		ToolLoopHardLock:       true,
+		PrefixCacheWeight:      0.20,
+		HandoffPenaltyWeight:   1,
+		DefaultHandoffPenalty:  0.05,
+		QualityGapMultiplier:   1,
+		MaxCacheCostMultiplier: 2.5,
+		SwitchHistoryWeight:    0.04,
+	})
+	selector.SetFallbackSelector(stubSessionFallback{
+		result: &SelectionResult{
+			SelectedModel: "frontier",
+			Score:         1.0,
+			Method:        MethodStatic,
+			AllScores: map[string]float64{
+				"current":  0.999,
+				"frontier": 1.0,
+			},
+		},
+	})
+
+	result, err := selector.Select(context.Background(), &SelectionContext{
+		CandidateModels: []config.ModelRef{{Model: "frontier"}, {Model: "current"}},
+		AgenticSession: &AgenticSessionContext{
+			ID:                "sess-1",
+			TurnIndex:         5,
+			PreviousModel:     "current",
+			MemorySwitchCount: 4,
+			HistoryTokens:     4096,
+			ContextTokens:     8192,
+			CacheWarmth:       1,
+			CacheWarmthOK:     true,
+			IdleFor:           2 * time.Minute,
+			IdleKnown:         true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+	if result.SelectedModel != "frontier" {
+		t.Fatalf("expected idle boundary to reselect fallback frontier, got %q", result.SelectedModel)
+	}
+
+	trace := result.SessionPolicy.CandidateTraces["frontier"]
+	if trace.HandoffPenalty != 0 || trace.PrefixCachePenalty != 0 || trace.SwitchHistoryPenalty != 0 {
+		t.Fatalf("expected idle boundary to clear continuity penalties, got %#v", trace)
+	}
+	if trace.NetSwitchAdvantage <= 0 {
+		t.Fatalf("expected positive net switch advantage at idle boundary, got %#v", trace)
+	}
+}
+
+func TestSessionAwareSelectorUsesRouterMemoryTurnCountBeforeFullParsing(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{
+		FallbackMethod:         MethodStatic,
+		MinTurnsBeforeSwitch:   1,
+		SwitchMargin:           0,
+		StayBias:               0,
+		ToolLoopHardLock:       true,
+		PrefixCacheWeight:      0,
+		HandoffPenaltyWeight:   0,
+		DefaultHandoffPenalty:  0,
+		QualityGapMultiplier:   1,
+		MaxCacheCostMultiplier: 2.5,
+	})
+	selector.SetFallbackSelector(stubSessionFallback{
+		result: &SelectionResult{
+			SelectedModel: "frontier",
+			Score:         0.90,
+			Method:        MethodHybrid,
+			AllScores: map[string]float64{
+				"current":  0.20,
+				"frontier": 0.90,
+			},
+		},
+	})
+
+	result, err := selector.Select(context.Background(), &SelectionContext{
+		CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "frontier"}},
+		AgenticSession: &AgenticSessionContext{
+			ID:              "sess-1",
+			TurnIndex:       0,
+			MemoryTurnCount: 2,
+			PreviousModel:   "current",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+	if result.SelectedModel != "frontier" {
+		t.Fatalf("expected memory turn count to satisfy min-turn lock, got %q", result.SelectedModel)
+	}
+	if result.SessionPolicy == nil || result.SessionPolicy.HardLocked {
+		t.Fatalf("expected non-hard-locked policy trace, got %#v", result.SessionPolicy)
+	}
+}
+
+func TestSessionAwareNetSwitchAdvantageUsesAdjustedCurrentScore(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{
+		FallbackMethod:         MethodStatic,
+		SwitchMargin:           0,
+		StayBias:               0.10,
+		PrefixCacheWeight:      0,
+		HandoffPenaltyWeight:   0,
+		DefaultHandoffPenalty:  0,
+		QualityGapMultiplier:   1,
+		MaxCacheCostMultiplier: 1,
+	})
+	selector.SetFallbackSelector(stubSessionFallback{
+		result: &SelectionResult{
+			SelectedModel: "frontier",
+			Score:         0.62,
+			Method:        MethodHybrid,
+			AllScores: map[string]float64{
+				"current":  0.50,
+				"frontier": 0.62,
+			},
+		},
+	})
+
+	result, err := selector.Select(context.Background(), &SelectionContext{
+		CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "frontier"}},
+		AgenticSession: &AgenticSessionContext{
+			ID:            "sess-1",
+			TurnIndex:     3,
+			PreviousModel: "current",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+
+	trace := result.SessionPolicy.CandidateTraces["frontier"]
+	if trace.NetSwitchAdvantage < 0.019 || trace.NetSwitchAdvantage > 0.021 {
+		t.Fatalf("expected net advantage to subtract adjusted current score, got %#v", trace)
+	}
+}
+
+func TestSessionAwareContinuationMassUsesRouterMemoryTurns(t *testing.T) {
+	got := sessionContinuationMass(&AgenticSessionContext{
+		TurnIndex:       0,
+		MemoryTurnCount: 4,
+	})
+	if got <= 0 {
+		t.Fatalf("expected router memory turn count to contribute continuation mass, got %.4f", got)
+	}
+}
+
+func TestSessionAwarePrefixPenaltyScalesWithModelCost(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{
+		PrefixCacheWeight:      0.2,
+		QualityGapMultiplier:   1,
+		MaxCacheCostMultiplier: 3,
+	})
+	selector.InitializeFromConfig(map[string]config.ModelParams{
+		"cheap": {
+			Pricing: config.ModelPricing{PromptPer1M: 0.05, CompletionPer1M: 0.10},
+		},
+		"frontier": {
+			Pricing: config.ModelPricing{PromptPer1M: 10, CompletionPer1M: 30},
+		},
+	})
+	session := &AgenticSessionContext{
+		TurnIndex:     5,
+		HistoryTokens: 4096,
+		ContextTokens: 8192,
+		CacheWarmth:   1,
+		CacheWarmthOK: true,
+	}
+
+	cheapPenalty := selector.prefixCachePenalty(session, "cheap", "cheap-2", false)
+	frontierPenalty := selector.prefixCachePenalty(session, "frontier", "cheap", false)
+	if frontierPenalty <= cheapPenalty {
+		t.Fatalf("expected frontier switch penalty %.4f > cheap penalty %.4f", frontierPenalty, cheapPenalty)
+	}
+}
+
+func TestSessionAwareRouterMemorySwitchHistoryPenalty(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{SwitchHistoryWeight: 0.16})
+	session := &AgenticSessionContext{MemorySwitchCount: 4}
+
+	if got := selector.switchHistoryPenalty(session); got <= 0 {
+		t.Fatalf("expected positive switch-history penalty, got %.4f", got)
+	}
+}
+
+type stubSessionFallback struct {
+	result *SelectionResult
+}
+
+func (s stubSessionFallback) Select(context.Context, *SelectionContext) (*SelectionResult, error) {
+	copy := *s.result
+	copy.AllScores = cloneScores(s.result.AllScores)
+	return &copy, nil
+}
+
+func (s stubSessionFallback) Method() SelectionMethod { return MethodHybrid }
+
+func (s stubSessionFallback) UpdateFeedback(context.Context, *Feedback) error { return nil }
+
+func (s stubSessionFallback) Tier() AlgorithmTier { return TierSupported }
+
+func (s stubSessionFallback) ExternalDependencies() []Dependency { return nil }

--- a/src/semantic-router/pkg/selection/session_policy_trace.go
+++ b/src/semantic-router/pkg/selection/session_policy_trace.go
@@ -1,0 +1,117 @@
+package selection
+
+// SessionPolicyTrace is the auditable output of the session-aware policy.
+// It records the facts and costs used to decide whether an agentic session may
+// switch models, so replay and experiments can reconstruct every stay/switch.
+type SessionPolicyTrace struct {
+	Algorithm      string
+	FallbackMethod string
+
+	SessionID string
+	UserID    string
+	Phase     AgenticPhase
+
+	CurrentModel          string
+	FallbackSelectedModel string
+	SelectedModel         string
+
+	TurnIndex       int
+	MemoryTurnCount int
+	SwitchCount     int
+
+	ActiveToolLoop bool
+	IdleKnown      bool
+	IdleForSeconds float64
+	IdleExpired    bool
+
+	HardLocked     bool
+	HardLockReason string
+	DecisionReason string
+	MissingSignals []string
+
+	ContinuationMass float64
+	CacheWarmth      float64
+	CacheWarmthOK    bool
+	SwitchMargin     float64
+	StayBias         float64
+
+	BaseScores      map[string]float64
+	FinalScores     map[string]float64
+	CandidateTraces map[string]SessionCandidateTrace
+}
+
+// SessionCandidateTrace captures the per-model decomposition used by
+// SessionPolicyTrace.
+type SessionCandidateTrace struct {
+	Current bool
+
+	BaseScore  float64
+	FinalScore float64
+
+	SelectorDelta          float64
+	QualityGap             float64
+	HandoffPenalty         float64
+	PrefixCacheBenefit     float64
+	PrefixCachePenalty     float64
+	ToolLoopPenalty        float64
+	SwitchHistoryPenalty   float64
+	FrontierCostMultiplier float64
+	NetSwitchAdvantage     float64
+}
+
+// ToMap converts the trace into a JSON-friendly representation for packages
+// that should not import selection types into their storage schema.
+func (t *SessionPolicyTrace) ToMap() map[string]interface{} {
+	if t == nil {
+		return nil
+	}
+	out := map[string]interface{}{
+		"algorithm":               t.Algorithm,
+		"fallback_method":         t.FallbackMethod,
+		"session_id":              t.SessionID,
+		"user_id":                 t.UserID,
+		"phase":                   string(t.Phase),
+		"current_model":           t.CurrentModel,
+		"fallback_selected_model": t.FallbackSelectedModel,
+		"selected_model":          t.SelectedModel,
+		"turn_index":              t.TurnIndex,
+		"memory_turn_count":       t.MemoryTurnCount,
+		"switch_count":            t.SwitchCount,
+		"active_tool_loop":        t.ActiveToolLoop,
+		"idle_known":              t.IdleKnown,
+		"idle_for_seconds":        t.IdleForSeconds,
+		"idle_expired":            t.IdleExpired,
+		"hard_locked":             t.HardLocked,
+		"hard_lock_reason":        t.HardLockReason,
+		"decision_reason":         t.DecisionReason,
+		"missing_signals":         append([]string(nil), t.MissingSignals...),
+		"continuation_mass":       t.ContinuationMass,
+		"cache_warmth":            t.CacheWarmth,
+		"cache_warmth_ok":         t.CacheWarmthOK,
+		"switch_margin":           t.SwitchMargin,
+		"stay_bias":               t.StayBias,
+		"base_scores":             cloneScores(t.BaseScores),
+		"final_scores":            cloneScores(t.FinalScores),
+	}
+	if len(t.CandidateTraces) > 0 {
+		candidates := make(map[string]interface{}, len(t.CandidateTraces))
+		for model, trace := range t.CandidateTraces {
+			candidates[model] = map[string]interface{}{
+				"current":                  trace.Current,
+				"base_score":               trace.BaseScore,
+				"final_score":              trace.FinalScore,
+				"selector_delta":           trace.SelectorDelta,
+				"quality_gap":              trace.QualityGap,
+				"handoff_penalty":          trace.HandoffPenalty,
+				"prefix_cache_benefit":     trace.PrefixCacheBenefit,
+				"prefix_cache_penalty":     trace.PrefixCachePenalty,
+				"tool_loop_penalty":        trace.ToolLoopPenalty,
+				"switch_history_penalty":   trace.SwitchHistoryPenalty,
+				"frontier_cost_multiplier": trace.FrontierCostMultiplier,
+				"net_switch_advantage":     trace.NetSwitchAdvantage,
+			}
+		}
+		out["candidate_traces"] = candidates
+	}
+	return out
+}

--- a/src/semantic-router/pkg/sessiontelemetry/last_model.go
+++ b/src/semantic-router/pkg/sessiontelemetry/last_model.go
@@ -59,21 +59,35 @@ func RecordLastModel(sessionID, model string) {
 // GetLastModel returns the most recent model recorded for sessionID and whether
 // a non-expired entry exists.
 func GetLastModel(sessionID string) (string, bool) {
+	model, _, ok := GetLastModelInfo(sessionID, time.Time{})
+	return model, ok
+}
+
+// GetLastModelInfo returns the most recent model and idle age for sessionID.
+// Passing a zero now uses the store clock.
+func GetLastModelInfo(sessionID string, now time.Time) (string, time.Duration, bool) {
 	if sessionID == "" {
-		return "", false
+		return "", 0, false
 	}
 	s := globalLastModelStore
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	st := s.sessions[sessionID]
 	if st == nil {
-		return "", false
+		return "", 0, false
 	}
-	if s.nowFn().Sub(st.lastSeen) > ttl {
+	if now.IsZero() {
+		now = s.nowFn()
+	}
+	idleFor := now.Sub(st.lastSeen)
+	if idleFor < 0 {
+		idleFor = 0
+	}
+	if idleFor > ttl {
 		delete(s.sessions, sessionID)
-		return "", false
+		return "", 0, false
 	}
-	return st.model, true
+	return st.model, idleFor, true
 }
 
 func (s *lastModelStore) evictExpiredLocked(t time.Time) {

--- a/src/semantic-router/pkg/sessiontelemetry/router_memory.go
+++ b/src/semantic-router/pkg/sessiontelemetry/router_memory.go
@@ -1,0 +1,278 @@
+package sessiontelemetry
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+const routerMemoryTTL = 24 * time.Hour
+
+// RouterSessionSnapshot is the router-owned, model-independent memory for a
+// session. It is intentionally about routing state, not prompt-visible user
+// memory.
+type RouterSessionSnapshot struct {
+	SessionID string
+	UserID    string
+
+	CurrentModel string
+	LastSeen     time.Time
+	IdleFor      time.Duration
+
+	TurnCount   int
+	SwitchCount int
+	ModelTurns  map[string]int
+
+	CumulativePromptTokens     int64
+	CumulativeCachedTokens     int64
+	CumulativeCompletionTokens int64
+	CumulativeCost             float64
+
+	ActiveToolLoop     bool
+	LastDecisionReason string
+	LastPolicy         map[string]interface{}
+}
+
+// SessionDecisionParams records the pre-dispatch policy result for one session
+// turn. Usage and response-side costs are attached later by RecordSessionUsage.
+type SessionDecisionParams struct {
+	SessionID      string
+	UserID         string
+	PreviousModel  string
+	SelectedModel  string
+	DecisionName   string
+	TurnIndex      int
+	ActiveToolLoop bool
+	Policy         map[string]interface{}
+	Timestamp      time.Time
+}
+
+// SessionUsageParams records response-side usage into router-owned session
+// memory. Costs are in the pricing currency selected by the router config.
+type SessionUsageParams struct {
+	SessionID          string
+	Model              string
+	PromptTokens       int
+	CachedPromptTokens int
+	CompletionTokens   int
+	Cost               float64
+	Timestamp          time.Time
+}
+
+type routerSessionState struct {
+	sessionID string
+	userID    string
+
+	currentModel string
+	lastSeen     time.Time
+
+	turnCount   int
+	switchCount int
+	modelTurns  map[string]int
+
+	cumulativePrompt     int64
+	cumulativeCached     int64
+	cumulativeCompletion int64
+	cumulativeCost       float64
+
+	activeToolLoop     bool
+	lastDecisionReason string
+	lastPolicy         map[string]interface{}
+}
+
+type routerSessionMemoryStore struct {
+	mu       sync.Mutex
+	sessions map[string]*routerSessionState
+	nowFn    func() time.Time
+}
+
+var globalRouterSessionMemory = &routerSessionMemoryStore{
+	sessions: make(map[string]*routerSessionState),
+	nowFn:    time.Now,
+}
+
+// RecordSessionDecision updates router-owned session memory from the policy
+// decision made before dispatching the request upstream.
+func RecordSessionDecision(p SessionDecisionParams) {
+	if p.SessionID == "" || p.SelectedModel == "" {
+		return
+	}
+	RecordLastModel(p.SessionID, p.SelectedModel)
+
+	s := globalRouterSessionMemory
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := p.Timestamp
+	if now.IsZero() {
+		now = s.nowFn()
+	}
+	s.evictExpiredLocked(now)
+	st := s.sessionLocked(p.SessionID)
+	if p.UserID != "" {
+		st.userID = p.UserID
+	}
+	previous := st.currentModel
+	if previous == "" {
+		previous = p.PreviousModel
+	}
+	if previous != "" && previous != p.SelectedModel {
+		st.switchCount++
+	}
+	st.currentModel = p.SelectedModel
+	st.lastSeen = now
+	if p.TurnIndex+1 > st.turnCount {
+		st.turnCount = p.TurnIndex + 1
+	} else {
+		st.turnCount++
+	}
+	st.modelTurns[p.SelectedModel]++
+	st.activeToolLoop = p.ActiveToolLoop
+	if p.Policy != nil {
+		st.lastPolicy = clonePolicyMap(p.Policy)
+		st.lastDecisionReason = policyDecisionReason(p.Policy)
+	}
+}
+
+// RecordSessionUsage attaches response usage and cost to router-owned session
+// memory. It does not create a model checkout when no prior decision exists.
+func RecordSessionUsage(p SessionUsageParams) {
+	if p.SessionID == "" || p.Model == "" {
+		return
+	}
+	s := globalRouterSessionMemory
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := p.Timestamp
+	if now.IsZero() {
+		now = s.nowFn()
+	}
+	s.evictExpiredLocked(now)
+	st := s.sessionLocked(p.SessionID)
+	st.currentModel = p.Model
+	st.lastSeen = now
+	st.cumulativePrompt += int64(p.PromptTokens)
+	st.cumulativeCached += int64(clampCachedPromptTokens(p.PromptTokens, p.CachedPromptTokens))
+	st.cumulativeCompletion += int64(p.CompletionTokens)
+	st.cumulativeCost += p.Cost
+}
+
+// GetRouterSessionSnapshot returns a clone of the router-owned session memory.
+func GetRouterSessionSnapshot(sessionID string, now time.Time) (RouterSessionSnapshot, bool) {
+	if sessionID == "" {
+		return RouterSessionSnapshot{}, false
+	}
+	s := globalRouterSessionMemory
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	st := s.sessions[sessionID]
+	if st == nil {
+		return RouterSessionSnapshot{}, false
+	}
+	if now.IsZero() {
+		now = s.nowFn()
+	}
+	idleFor := now.Sub(st.lastSeen)
+	if idleFor < 0 {
+		idleFor = 0
+	}
+	if idleFor > routerMemoryTTL {
+		delete(s.sessions, sessionID)
+		return RouterSessionSnapshot{}, false
+	}
+	return RouterSessionSnapshot{
+		SessionID:                  st.sessionID,
+		UserID:                     st.userID,
+		CurrentModel:               st.currentModel,
+		LastSeen:                   st.lastSeen,
+		IdleFor:                    idleFor,
+		TurnCount:                  st.turnCount,
+		SwitchCount:                st.switchCount,
+		ModelTurns:                 cloneIntMap(st.modelTurns),
+		CumulativePromptTokens:     st.cumulativePrompt,
+		CumulativeCachedTokens:     st.cumulativeCached,
+		CumulativeCompletionTokens: st.cumulativeCompletion,
+		CumulativeCost:             st.cumulativeCost,
+		ActiveToolLoop:             st.activeToolLoop,
+		LastDecisionReason:         st.lastDecisionReason,
+		LastPolicy:                 clonePolicyMap(st.lastPolicy),
+	}, true
+}
+
+func (s *routerSessionMemoryStore) sessionLocked(sessionID string) *routerSessionState {
+	st := s.sessions[sessionID]
+	if st != nil {
+		return st
+	}
+	st = &routerSessionState{
+		sessionID:  sessionID,
+		modelTurns: make(map[string]int),
+	}
+	s.sessions[sessionID] = st
+	return st
+}
+
+func (s *routerSessionMemoryStore) evictExpiredLocked(now time.Time) {
+	for k, v := range s.sessions {
+		if now.Sub(v.lastSeen) > routerMemoryTTL {
+			delete(s.sessions, k)
+		}
+	}
+}
+
+func cloneIntMap(in map[string]int) map[string]int {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func clonePolicyMap(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		return nil
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func policyDecisionReason(policy map[string]interface{}) string {
+	if policy == nil {
+		return ""
+	}
+	if reason, ok := policy["decision_reason"].(string); ok {
+		return reason
+	}
+	return ""
+}
+
+// ResetRouterSessionMemoryForTesting clears router-owned session memory.
+func ResetRouterSessionMemoryForTesting() {
+	s := globalRouterSessionMemory
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions = make(map[string]*routerSessionState)
+}
+
+// setRouterSessionMemoryNowForTesting overrides the memory store clock.
+func setRouterSessionMemoryNowForTesting(fn func() time.Time) {
+	s := globalRouterSessionMemory
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if fn == nil {
+		fn = time.Now
+	}
+	s.nowFn = fn
+}

--- a/src/semantic-router/pkg/sessiontelemetry/router_memory_test.go
+++ b/src/semantic-router/pkg/sessiontelemetry/router_memory_test.go
@@ -1,0 +1,60 @@
+package sessiontelemetry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRouterSessionMemoryRecordsDecisionAndUsage(t *testing.T) {
+	ResetRouterSessionMemoryForTesting()
+	base := time.Date(2026, time.May, 30, 10, 0, 0, 0, time.UTC)
+	setRouterSessionMemoryNowForTesting(func() time.Time { return base })
+	defer setRouterSessionMemoryNowForTesting(nil)
+
+	RecordSessionDecision(SessionDecisionParams{
+		SessionID:     "sess-agent",
+		UserID:        "user-a",
+		SelectedModel: "small",
+		TurnIndex:     0,
+		Policy: map[string]interface{}{
+			"decision_reason": "first_turn",
+		},
+		Timestamp: base,
+	})
+	RecordSessionUsage(SessionUsageParams{
+		SessionID:          "sess-agent",
+		Model:              "small",
+		PromptTokens:       1000,
+		CachedPromptTokens: 250,
+		CompletionTokens:   300,
+		Cost:               0.002,
+		Timestamp:          base.Add(2 * time.Second),
+	})
+	RecordSessionDecision(SessionDecisionParams{
+		SessionID:     "sess-agent",
+		PreviousModel: "small",
+		SelectedModel: "frontier",
+		TurnIndex:     1,
+		Timestamp:     base.Add(10 * time.Second),
+	})
+
+	snapshot, ok := GetRouterSessionSnapshot("sess-agent", base.Add(20*time.Second))
+	if !ok {
+		t.Fatal("expected session memory snapshot")
+	}
+	if snapshot.CurrentModel != "frontier" {
+		t.Fatalf("current model = %q, want frontier", snapshot.CurrentModel)
+	}
+	if snapshot.SwitchCount != 1 {
+		t.Fatalf("switch count = %d, want 1", snapshot.SwitchCount)
+	}
+	if snapshot.CumulativeCachedTokens != 250 {
+		t.Fatalf("cached tokens = %d, want 250", snapshot.CumulativeCachedTokens)
+	}
+	if snapshot.LastDecisionReason != "first_turn" {
+		t.Fatalf("last decision reason = %q, want first_turn", snapshot.LastDecisionReason)
+	}
+	if snapshot.IdleFor != 10*time.Second {
+		t.Fatalf("idle = %s, want 10s", snapshot.IdleFor)
+	}
+}

--- a/src/semantic-router/pkg/sessiontelemetry/telemetry.go
+++ b/src/semantic-router/pkg/sessiontelemetry/telemetry.go
@@ -13,6 +13,7 @@ const ttl = 1 * time.Hour
 
 type turnState struct {
 	cumulativePrompt     int64
+	cumulativeCached     int64
 	cumulativeCompletion int64
 	cumulativeCost       float64 // in the currency supplied by TurnPricing.Currency
 	lastSeen             time.Time
@@ -29,6 +30,7 @@ func ResetForTesting() {
 	mu.Lock()
 	defer mu.Unlock()
 	store = make(map[string]*turnState)
+	ResetRouterSessionMemoryForTesting()
 }
 
 func evictLocked(t time.Time) {
@@ -55,20 +57,19 @@ type ChatInput struct {
 // All rates are in Currency (default "USD").
 //
 // isConfigured() returns true when at least one rate is non-zero or Currency is explicitly
-// set (even with zero rates) — the latter supports free/self-hosted models that still need
-// cost=0 and savings attribution. CachedInputPer1M is stamped as log metadata but is not
-// included in the configured check or cost formula until cached token counts are tracked.
+// set (even with zero rates) — the latter supports free/self-hosted models that
+// still need cost=0 and savings attribution.
 type TurnPricing struct {
 	Currency         string
 	PromptPer1M      float64
 	CompletionPer1M  float64
-	CachedInputPer1M float64 // stamped in log metadata; not applied to cost (cached tokens not yet tracked)
+	CachedInputPer1M float64
 }
 
 // isConfigured reports whether pricing is active: at least one billable rate is set, or
 // Currency is explicit (covers zero-rate free models that still produce cost=0 telemetry).
 func (p TurnPricing) isConfigured() bool {
-	return p.PromptPer1M != 0 || p.CompletionPer1M != 0 || p.Currency != ""
+	return p.PromptPer1M != 0 || p.CompletionPer1M != 0 || p.CachedInputPer1M != 0 || p.Currency != ""
 }
 
 // TurnParams carries usage and routing context for one completed LLM round-trip.
@@ -77,8 +78,9 @@ type TurnParams struct {
 	Model     string
 	Domain    string // VSR category; empty -> "unknown"
 
-	PromptTokens     int
-	CompletionTokens int
+	PromptTokens       int
+	CachedPromptTokens int
+	CompletionTokens   int
 
 	// Pricing holds the active per-1M token rates for this dispatch.
 	// When zero, cost fields are omitted from the log event and no cost
@@ -87,6 +89,13 @@ type TurnParams struct {
 
 	ResponseAPI *ResponseAPIInput
 	Chat        *ChatInput
+}
+
+type turnCumulativeState struct {
+	prompt     int64
+	cached     int64
+	completion int64
+	cost       float64
 }
 
 func normalizeDomain(d string) string {
@@ -128,10 +137,24 @@ func RecordTurn(p TurnParams) {
 	}
 	domain := normalizeDomain(p.Domain)
 
-	costThisTurn := computeCost(p.PromptTokens, p.CompletionTokens, p.Pricing)
+	costThisTurn := computeCost(p.PromptTokens, p.CachedPromptTokens, p.CompletionTokens, p.Pricing)
 
 	t := nowFn()
+	cumulative := recordTurnState(key, p, costThisTurn, t)
+	recordRouterSessionUsage(publicSessionID, model, p, costThisTurn, t)
+
+	metrics.RecordSessionTurnTokens(model, domain, float64(p.PromptTokens), float64(p.CompletionTokens))
+	currency := pricingCurrency(p.Pricing)
+	if p.Pricing.isConfigured() {
+		metrics.RecordSessionTurnCost(model, domain, currency, costThisTurn)
+	}
+	logSessionTurn(p, publicSessionID, turn, apiKind, model, domain, currency, costThisTurn, cumulative, t)
+}
+
+func recordTurnState(key string, p TurnParams, costThisTurn float64, t time.Time) turnCumulativeState {
 	mu.Lock()
+	defer mu.Unlock()
+
 	evictLocked(t)
 	st := store[key]
 	if st == nil {
@@ -139,36 +162,64 @@ func RecordTurn(p TurnParams) {
 		store[key] = st
 	}
 	st.cumulativePrompt += int64(p.PromptTokens)
+	st.cumulativeCached += int64(clampCachedPromptTokens(p.PromptTokens, p.CachedPromptTokens))
 	st.cumulativeCompletion += int64(p.CompletionTokens)
 	st.cumulativeCost += costThisTurn
 	st.lastSeen = t
-	cumP := st.cumulativePrompt
-	cumC := st.cumulativeCompletion
-	cumCost := st.cumulativeCost
-	mu.Unlock()
+	return turnCumulativeState{
+		prompt:     st.cumulativePrompt,
+		cached:     st.cumulativeCached,
+		completion: st.cumulativeCompletion,
+		cost:       st.cumulativeCost,
+	}
+}
 
-	metrics.RecordSessionTurnTokens(model, domain, float64(p.PromptTokens), float64(p.CompletionTokens))
+func recordRouterSessionUsage(publicSessionID string, model string, p TurnParams, costThisTurn float64, t time.Time) {
+	RecordSessionUsage(SessionUsageParams{
+		SessionID:          publicSessionID,
+		Model:              model,
+		PromptTokens:       p.PromptTokens,
+		CachedPromptTokens: p.CachedPromptTokens,
+		CompletionTokens:   p.CompletionTokens,
+		Cost:               costThisTurn,
+		Timestamp:          t,
+	})
+}
 
-	currency := p.Pricing.Currency
+func pricingCurrency(pricing TurnPricing) string {
+	currency := pricing.Currency
 	if currency == "" {
 		currency = "USD"
 	}
-	if p.Pricing.isConfigured() {
-		metrics.RecordSessionTurnCost(model, domain, currency, costThisTurn)
-	}
+	return currency
+}
 
+func logSessionTurn(
+	p TurnParams,
+	publicSessionID string,
+	turn int,
+	apiKind string,
+	model string,
+	domain string,
+	currency string,
+	costThisTurn float64,
+	cumulative turnCumulativeState,
+	t time.Time,
+) {
 	fields := map[string]interface{}{
-		"request_id":                   p.RequestID,
-		"session_id":                   publicSessionID,
-		"turn_number":                  turn,
-		"api":                          apiKind,
-		"model":                        model,
-		"domain":                       domain,
-		"prompt_tokens":                p.PromptTokens,
-		"completion_tokens":            p.CompletionTokens,
-		"cumulative_prompt_tokens":     cumP,
-		"cumulative_completion_tokens": cumC,
-		"timestamp":                    t.UTC().Format(time.RFC3339Nano),
+		"request_id":                      p.RequestID,
+		"session_id":                      publicSessionID,
+		"turn_number":                     turn,
+		"api":                             apiKind,
+		"model":                           model,
+		"domain":                          domain,
+		"prompt_tokens":                   p.PromptTokens,
+		"cached_prompt_tokens":            clampCachedPromptTokens(p.PromptTokens, p.CachedPromptTokens),
+		"completion_tokens":               p.CompletionTokens,
+		"cumulative_prompt_tokens":        cumulative.prompt,
+		"cumulative_cached_prompt_tokens": cumulative.cached,
+		"cumulative_completion_tokens":    cumulative.completion,
+		"timestamp":                       t.UTC().Format(time.RFC3339Nano),
 	}
 	if p.Pricing.isConfigured() {
 		fields["pricing_prompt_per_1m"] = p.Pricing.PromptPer1M
@@ -176,18 +227,30 @@ func RecordTurn(p TurnParams) {
 		fields["pricing_cached_input_per_1m"] = p.Pricing.CachedInputPer1M
 		fields["pricing_currency"] = currency
 		fields["cost_this_turn"] = costThisTurn
-		fields["cumulative_cost"] = cumCost
+		fields["cumulative_cost"] = cumulative.cost
 	}
 	logging.LogEvent("session_turn_tokens", fields)
 }
 
-// computeCost returns the turn cost in the pricing currency given token counts and rates.
-// Only prompt and completion tokens are costed; cached-input tokens are not tracked yet.
-// Returns 0 when pricing is not configured.
-func computeCost(promptTokens, completionTokens int, pricing TurnPricing) float64 {
+// computeCost returns the turn cost in the pricing currency given token counts
+// and rates. Cached prompt tokens use CachedInputPer1M when configured.
+func computeCost(promptTokens, cachedPromptTokens, completionTokens int, pricing TurnPricing) float64 {
 	if !pricing.isConfigured() {
 		return 0
 	}
-	return (float64(promptTokens)*pricing.PromptPer1M +
+	cached := clampCachedPromptTokens(promptTokens, cachedPromptTokens)
+	uncachedPrompt := promptTokens - cached
+	return (float64(uncachedPrompt)*pricing.PromptPer1M +
+		float64(cached)*pricing.CachedInputPer1M +
 		float64(completionTokens)*pricing.CompletionPer1M) / 1_000_000.0
+}
+
+func clampCachedPromptTokens(promptTokens, cachedPromptTokens int) int {
+	if cachedPromptTokens < 0 {
+		return 0
+	}
+	if cachedPromptTokens > promptTokens {
+		return promptTokens
+	}
+	return cachedPromptTokens
 }

--- a/src/semantic-router/pkg/sessiontelemetry/telemetry_test.go
+++ b/src/semantic-router/pkg/sessiontelemetry/telemetry_test.go
@@ -369,7 +369,7 @@ func TestComputeCost(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := computeCost(tc.prompt, tc.compl, tc.pricing)
+			got := computeCost(tc.prompt, 0, tc.compl, tc.pricing)
 			assert.InDelta(t, tc.wantCost, got, 1e-9)
 		})
 	}

--- a/src/vllm-sr/cli/algorithms.py
+++ b/src/vllm-sr/cli/algorithms.py
@@ -233,6 +233,24 @@ class HybridSelectionConfig(BaseModel):
     normalize_scores: bool | None = True
 
 
+class SessionAwareSelectionConfig(BaseModel):
+    """Configuration for session-aware agentic model selection."""
+
+    fallback_method: str | None = "hybrid"
+    idle_timeout_seconds: int | None = Field(default=300, ge=0)
+    min_turns_before_switch: int | None = Field(default=1, ge=0)
+    switch_margin: float | None = Field(default=0.05, ge=0)
+    stay_bias: float | None = Field(default=0.10, ge=0)
+    tool_loop_hard_lock: bool | None = True
+    tool_loop_stay_bias: float | None = Field(default=0.35, ge=0)
+    prefix_cache_weight: float | None = Field(default=0.20, ge=0)
+    handoff_penalty_weight: float | None = Field(default=1.0, ge=0)
+    default_handoff_penalty: float | None = Field(default=0.05, ge=0)
+    quality_gap_multiplier: float | None = Field(default=1.0, ge=0)
+    max_cache_cost_multiplier: float | None = Field(default=2.5, ge=0)
+    switch_history_weight: float | None = Field(default=0.04, ge=0)
+
+
 # =============================================================================
 # RL-Driven Model Selection Algorithm Configs (from PR #1196 / Issue #994)
 # Reference papers:
@@ -366,6 +384,7 @@ class AlgorithmConfig(BaseModel):
        - "router_dc": Use embedding similarity for query-model matching
        - "automix": Use POMDP-based cost-quality optimization
        - "hybrid": Combine multiple selection methods
+       - "session_aware": Agentic long-horizon routing with router-owned session memory
 
     3. RL-driven selection algorithms (from issue #994):
        - "rl_driven": Canonical online learning and Router-R1 style selector
@@ -390,6 +409,7 @@ class AlgorithmConfig(BaseModel):
     router_dc: RouterDCSelectionConfig | None = None
     automix: AutoMixSelectionConfig | None = None
     hybrid: HybridSelectionConfig | None = None
+    session_aware: SessionAwareSelectionConfig | None = None
 
     # RL-driven selection algorithms (from PR #1196, issue #994)
     rl_driven: RLDrivenSelectionConfig | None = None

--- a/src/vllm-sr/cli/core.py
+++ b/src/vllm-sr/cli/core.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 
-from cli.consts import DEFAULT_API_PORT, DEFAULT_ENVOY_PORT
+from cli.consts import DEFAULT_API_PORT, DEFAULT_ENVOY_PORT, IMAGE_PULL_POLICY_NEVER
 from cli.docker_cli import (
     docker_container_status,
     docker_exec,
@@ -15,6 +15,7 @@ from cli.docker_cli import (
     docker_stop_container,
     load_openclaw_registry,
 )
+from cli.docker_images import get_runtime_images
 from cli.logo import print_vllm_logo
 from cli.runtime_lifecycle import (
     connect_runtime_container,
@@ -58,6 +59,63 @@ def _resolve_state_root_dir(
     return os.path.dirname(os.path.abspath(source_config_file))
 
 
+def _load_runtime_config(runtime_config_file):
+    user_config = load_config(runtime_config_file) or {}
+    listeners = user_config.get("listeners", [])
+    if not listeners:
+        log.error("No listeners configured in config.yaml")
+        raise SystemExit(1)
+    return user_config, listeners
+
+
+def _prepare_runtime_network(
+    source_config_file,
+    env_vars,
+    stack_layout,
+    image,
+    router_image,
+    envoy_image,
+    dashboard_image,
+    pull_policy,
+    dashboard_disabled,
+):
+    shared_network_name = stack_layout.network_name
+    state_root_dir = _resolve_state_root_dir(source_config_file, env_vars)
+    ensure_shared_network(shared_network_name)
+    ensure_runtime_images_for_pull_policy(
+        image,
+        router_image,
+        envoy_image,
+        dashboard_image,
+        pull_policy,
+        env_vars,
+        dashboard_disabled=dashboard_disabled,
+    )
+    return shared_network_name, state_root_dir
+
+
+def ensure_runtime_images_for_pull_policy(
+    image,
+    router_image,
+    envoy_image,
+    dashboard_image,
+    pull_policy,
+    env_vars,
+    dashboard_disabled=False,
+):
+    if pull_policy != IMAGE_PULL_POLICY_NEVER:
+        return
+    get_runtime_images(
+        image=image,
+        router_image=router_image,
+        envoy_image=envoy_image,
+        dashboard_image=None if dashboard_disabled else dashboard_image,
+        pull_policy=pull_policy,
+        platform=env_vars.get("VLLM_SR_PLATFORM"),
+        include_dashboard=not dashboard_disabled,
+    )
+
+
 def start_vllm_sr(
     config_file,
     env_vars=None,
@@ -72,28 +130,32 @@ def start_vllm_sr(
     runtime_config_file=None,
 ):
     """Start vLLM Semantic Router."""
-    if env_vars is None:
-        env_vars = {}
+    env_vars = env_vars if env_vars is not None else {}
     stack_layout = resolve_runtime_stack()
     runtime_topology = resolve_runtime_topology(topology)
 
     print_vllm_logo()
     source_config_file = source_config_file or config_file
     runtime_config_file = runtime_config_file or config_file
-    user_config = load_config(runtime_config_file) or {}
-    listeners = user_config.get("listeners", [])
-    if not listeners:
-        log.error("No listeners configured in config.yaml")
-        raise SystemExit(1)
+    user_config, listeners = _load_runtime_config(runtime_config_file)
 
     log_startup_banner(source_config_file, listeners, stack_layout)
     log.info(f"Runtime topology: {runtime_topology}")
     for container_name in stack_layout.runtime_container_names:
         ensure_clean_runtime_container(container_name)
 
-    shared_network_name = stack_layout.network_name
-    state_root_dir = _resolve_state_root_dir(source_config_file, env_vars)
-    ensure_shared_network(shared_network_name)
+    dashboard_disabled = env_vars.get("DISABLE_DASHBOARD") == "true"
+    shared_network_name, state_root_dir = _prepare_runtime_network(
+        source_config_file,
+        env_vars,
+        stack_layout,
+        image,
+        router_image,
+        envoy_image,
+        dashboard_image,
+        pull_policy,
+        dashboard_disabled,
+    )
 
     started_backends = provision_storage_backends(
         user_config, shared_network_name, stack_layout
@@ -116,24 +178,23 @@ def start_vllm_sr(
     if fleet_sim_enabled:
         env_vars.setdefault("TARGET_FLEET_SIM_URL", stack_layout.fleet_sim_service_url)
 
-    dashboard_disabled = env_vars.get("DISABLE_DASHBOARD") == "true"
     setup_mode = str(env_vars.get("VLLM_SR_SETUP_MODE", "")).lower() == "true"
-    return_code, _stdout, stderr = docker_start_vllm_sr(
-        config_file=source_config_file,
-        env_vars=env_vars,
-        listeners=listeners,
-        image=image,
-        router_image=router_image,
-        envoy_image=envoy_image,
-        dashboard_image=dashboard_image,
-        topology=runtime_topology,
-        pull_policy=pull_policy,
-        network_name=runtime_network_name,
-        openclaw_network_name=shared_network_name,
-        minimal=dashboard_disabled,
-        stack_layout=stack_layout,
-        state_root_dir=state_root_dir,
-        runtime_config_file=runtime_config_file,
+    return_code, _stdout, stderr = _start_runtime_containers(
+        source_config_file,
+        runtime_config_file,
+        listeners,
+        runtime_topology,
+        runtime_network_name,
+        shared_network_name,
+        stack_layout,
+        state_root_dir,
+        dashboard_disabled,
+        env_vars,
+        image,
+        router_image,
+        envoy_image,
+        dashboard_image,
+        pull_policy,
     )
     if return_code != 0:
         log.error(f"Failed to start container: {stderr}")
@@ -153,6 +214,42 @@ def start_vllm_sr(
         enable_observability,
         fleet_sim_enabled,
         started_backends=started_backends,
+    )
+
+
+def _start_runtime_containers(
+    source_config_file,
+    runtime_config_file,
+    listeners,
+    runtime_topology,
+    runtime_network_name,
+    shared_network_name,
+    stack_layout,
+    state_root_dir,
+    dashboard_disabled,
+    env_vars,
+    image,
+    router_image,
+    envoy_image,
+    dashboard_image,
+    pull_policy,
+):
+    return docker_start_vllm_sr(
+        config_file=source_config_file,
+        env_vars=env_vars,
+        listeners=listeners,
+        image=image,
+        router_image=router_image,
+        envoy_image=envoy_image,
+        dashboard_image=dashboard_image,
+        topology=runtime_topology,
+        pull_policy=pull_policy,
+        network_name=runtime_network_name,
+        openclaw_network_name=shared_network_name,
+        minimal=dashboard_disabled,
+        stack_layout=stack_layout,
+        state_root_dir=state_root_dir,
+        runtime_config_file=runtime_config_file,
     )
 
 

--- a/src/vllm-sr/cli/docker_images.py
+++ b/src/vllm-sr/cli/docker_images.py
@@ -340,6 +340,7 @@ def get_runtime_images(
     dashboard_image=None,
     pull_policy=None,
     platform=None,
+    include_dashboard=True,
 ):
     """Resolve role-specific runtime images with backward-compatible fallback."""
     if pull_policy is None:
@@ -363,14 +364,15 @@ def get_runtime_images(
             base_image=base_image,
             normalized_platform=normalized_platform,
         ),
-        "dashboard": _resolve_runtime_service_image(
+    }
+    if include_dashboard:
+        selected_images["dashboard"] = _resolve_runtime_service_image(
             "dashboard",
             explicit_image=dashboard_image,
             base_image_is_explicit=base_image_is_explicit,
             base_image=base_image,
             normalized_platform=normalized_platform,
-        ),
-    }
+        )
 
     for unique_image in dict.fromkeys(selected_images.values()):
         _ensure_image_available(unique_image, pull_policy)

--- a/src/vllm-sr/cli/docker_start.py
+++ b/src/vllm-sr/cli/docker_start.py
@@ -179,6 +179,7 @@ def _resolve_container_specs(
         dashboard_image=dashboard_image,
         pull_policy=pull_policy,
         platform=normalized_platform,
+        include_dashboard=not minimal,
     )
     return _runtime_container_specs(
         runtime=runtime,

--- a/src/vllm-sr/cli/validator.py
+++ b/src/vllm-sr/cli/validator.py
@@ -144,6 +144,7 @@ def validate_algorithm_one_of(config: UserConfig) -> List[ValidationError]:
         "concurrent": "concurrent",
         "remom": "remom",
         "latency_aware": "latency_aware",
+        "session_aware": "session_aware",
     }
 
     for decision in config.decisions:
@@ -160,6 +161,8 @@ def validate_algorithm_one_of(config: UserConfig) -> List[ValidationError]:
             configured_blocks.append("remom")
         if algorithm.latency_aware is not None:
             configured_blocks.append("latency_aware")
+        if algorithm.session_aware is not None:
+            configured_blocks.append("session_aware")
 
         display_type = (algorithm.type or "").strip() or "<empty>"
         normalized_type = (algorithm.type or "").strip().lower()
@@ -535,6 +538,7 @@ def validate_algorithm_configurations(config: UserConfig) -> List[ValidationErro
         "router_dc",
         "automix",
         "hybrid",
+        "session_aware",
         "latency_aware",
         "rl_driven",
         "thompson",

--- a/src/vllm-sr/tests/test_core_status.py
+++ b/src/vllm-sr/tests/test_core_status.py
@@ -128,3 +128,26 @@ def test_show_status_reports_not_running_when_docker_daemon_unreachable(monkeypa
     assert "Status: Not running" in messages
     assert any("Docker daemon is not reachable" in message for message in messages)
     assert "Start with: vllm-sr serve" in messages
+
+
+def test_never_pull_preflight_skips_dashboard_when_disabled(monkeypatch):
+    captured = {}
+
+    def fake_get_runtime_images(**kwargs):
+        captured.update(kwargs)
+        return {"router": "router:test", "envoy": "envoy:test"}
+
+    monkeypatch.setattr(core, "get_runtime_images", fake_get_runtime_images)
+
+    core.ensure_runtime_images_for_pull_policy(
+        image="router:test",
+        router_image=None,
+        envoy_image=None,
+        dashboard_image="dashboard:missing",
+        pull_policy="never",
+        env_vars={"VLLM_SR_PLATFORM": "amd"},
+        dashboard_disabled=True,
+    )
+
+    assert captured["dashboard_image"] is None
+    assert captured["include_dashboard"] is False

--- a/src/vllm-sr/tests/test_docker_images.py
+++ b/src/vllm-sr/tests/test_docker_images.py
@@ -318,6 +318,36 @@ def test_get_runtime_images_prefers_explicit_service_image_over_explicit_base_im
     ]
 
 
+def test_get_runtime_images_can_skip_dashboard_for_minimal_runtime(monkeypatch):
+    ensured = []
+    monkeypatch.setattr(
+        docker_images,
+        "_resolve_selected_image",
+        lambda image, normalized_platform: image,
+    )
+    monkeypatch.setattr(
+        docker_images,
+        "_ensure_image_available",
+        lambda image, pull_policy: ensured.append((image, pull_policy)),
+    )
+
+    images = docker_images.get_runtime_images(
+        image="base:explicit",
+        dashboard_image="dashboard:missing",
+        pull_policy="never",
+        include_dashboard=False,
+    )
+
+    assert images == {
+        "router": "base:explicit",
+        "envoy": VLLM_SR_ENVOY_DOCKER_IMAGE_DEFAULT,
+    }
+    assert ensured == [
+        ("base:explicit", "never"),
+        (VLLM_SR_ENVOY_DOCKER_IMAGE_DEFAULT, "never"),
+    ]
+
+
 def test_get_runtime_images_upgrades_router_override_to_rocm_on_amd(monkeypatch):
     ensured = []
     monkeypatch.setattr(

--- a/src/vllm-sr/tests/test_split_runtime_stack.py
+++ b/src/vllm-sr/tests/test_split_runtime_stack.py
@@ -135,6 +135,44 @@ def test_docker_start_vllm_sr_uses_role_specific_runtime_images(tmp_path, monkey
     assert "/etc/envoy/envoy.yaml" in " ".join(envoy_cmd)
 
 
+def test_docker_start_vllm_sr_skips_dashboard_image_resolution_in_minimal_mode(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "version: v0.1\nlisteners:\n  - name: http-8899\n    address: 0.0.0.0\n    port: 8899\n"
+    )
+    captured_kwargs = {}
+
+    def fake_get_runtime_images(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {
+            "router": "router-image:latest",
+            "envoy": "envoy-image:latest",
+        }
+
+    monkeypatch.setattr(docker_start, "get_container_runtime", lambda: "docker")
+    monkeypatch.setattr(docker_start, "get_runtime_images", fake_get_runtime_images)
+    captured = _capture_run_commands(monkeypatch)
+    _stub_valid_docker_cli(monkeypatch, tmp_path)
+
+    rc, _, _ = docker_cli.docker_start_vllm_sr(
+        str(config_path),
+        {},
+        [{"name": "http-8899", "address": "0.0.0.0", "port": 8899}],
+        network_name="vllm-sr-network",
+        openclaw_network_name="vllm-sr-network",
+        minimal=True,
+    )
+
+    assert rc == 0
+    assert captured_kwargs["include_dashboard"] is False
+    _find_container_run_cmd(captured, "vllm-sr-router-container")
+    _find_container_run_cmd(captured, "vllm-sr-envoy-container")
+    with pytest.raises(AssertionError):
+        _find_container_run_cmd(captured, "vllm-sr-dashboard-container")
+
+
 def test_docker_start_vllm_sr_creates_router_and_envoy_standby_in_setup_mode(
     tmp_path, monkeypatch
 ):

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -41,7 +41,7 @@ The detailed background is in [Unified Config Contract v0.3](../proposals/unifie
 - `global` owns router-wide runtime overrides.
   - `global.router` groups router-engine control knobs such as config-source selection, route-cache, and model-selection defaults
   - `global.router.config_source` selects whether runtime config comes from the canonical YAML file (`file`) or from in-process Kubernetes CRD reconciliation (`kubernetes`)
-  - `global.router.model_selection.model_switch_gate` enables optional shadow or enforce-mode auditing for session-aware stay-vs-switch decisions after a selector chooses a candidate model. `mode: enforce` only takes effect on Response API requests with conversation history; Chat Completions traffic is observed in shadow regardless of mode until per-turn model history persistence ships, and a `model_switch_gate_enforce_unavailable` warning is logged whenever enforce was configured but the gate had to fall back to audit-only.
+  - `decision.algorithm.type=session_aware` enables agentic stay-vs-switch routing with router-owned session memory, tool-loop hard locks, idle-time re-selection, prefix-cache cost, and replayed policy traces.
   - `global.services` groups shared APIs and control-plane services such as `response_api`, `router_replay`, `observability`, `authz`, and `ratelimit`
   - `global.services.router_replay.enabled` acts as the default replay switch for every decision; route-local `router_replay.enabled: false` is the explicit opt-out
   - `global.stores` groups shared storage-backed services such as `semantic_cache`, `memory`, and `vector_store`

--- a/website/docs/tutorials/algorithm/overview.md
+++ b/website/docs/tutorials/algorithm/overview.md
@@ -70,6 +70,7 @@ The repo now keeps one tutorial page per algorithm.
 | **[SVM](./selection/svm)** | ML (Rust) | No (offline) | No | — | Decision boundary classification |
 | **[MLP](./selection/mlp)** | ML (GPU) | No (offline) | No | — | Non-linear neural network routing |
 | **[Latency Aware](./selection/latency-aware)** | Metrics | No | No | — | Fastest model selection by TPOT/TTFT |
+| **[Session Aware](./selection/session-aware)** | Session policy | No | Session | — | Agentic multi-turn routing with tool-loop and prefix-cache stay policy |
 
 ### Looper Algorithms (multi-model orchestration)
 
@@ -86,7 +87,9 @@ flowchart TD
     Start[Need algorithm?] --> Q1{Multiple models in modelRefs?}
     Q1 -- No --> Static[Static: first model wins]
     Q1 -- Yes --> Q2{Orchestration type?}
-    Q2 -- Single model selection --> Q3{Need learning?}
+    Q2 -- Single model selection --> QS{Need session continuity?}
+    QS -- Yes --> SessionAware[Session Aware]
+    QS -- No --> Q3{Need learning?}
     Q3 -- No --> Q4{Latency critical?}
     Q4 -- Yes --> Latency[Latency Aware]
     Q4 -- No --> Q5{Semantic matching needed?}
@@ -122,6 +125,7 @@ flowchart TD
 - [MLP](./selection/mlp)
 - [RL Driven](./selection/rl-driven)
 - [Router DC](./selection/router-dc)
+- [Session Aware](./selection/session-aware)
 - [Static](./selection/static)
 - [SVM](./selection/svm)
 

--- a/website/docs/tutorials/algorithm/selection/session-aware.md
+++ b/website/docs/tutorials/algorithm/selection/session-aware.md
@@ -1,0 +1,62 @@
+# Session Aware
+
+## Overview
+
+`session_aware` selects one model from a decision's `modelRefs` while respecting agentic multi-turn context. It wraps a base selector such as `hybrid`, then applies a router-owned stay-vs-switch policy for sessions, tool loops, idle timeout, handoff cost, switch history, and prefix-cache cost.
+
+Use it when clients send a stable `x-session-id` header or use Response API conversation IDs and you want long-running agent sessions to avoid unnecessary model churn. Provider conversation history is treated as cache; the router keeps its own session memory so model selection can reason about the conversation even when the next turn might move to another backend.
+
+It aligns to `config/algorithm/selection/session-aware.yaml`.
+
+## Key Advantages
+
+- Preserves KV/prefix-cache locality across long-horizon agent sessions.
+- Hard-locks active tool loops to avoid mid-loop model changes.
+- Lets idle sessions reselect after the cache is likely cold.
+- Scales switch cost up for expensive/frontier model checkouts.
+- Records `session_policy` in router replay for audit, experiments, and paper/blog analysis.
+
+## What Problem Does It Solve?
+
+Single-turn routers often pick the best model for the latest message only. In long-running agent loops that can churn models between tool calls, waste prefix-cache locality, and make frontier model checkouts unnecessarily expensive. `session_aware` makes the router aware of session continuity before it decides whether a switch is worth the cost.
+
+## When to Use
+
+- Clients set a stable `x-session-id` header or use Response API conversation IDs.
+- The route serves agents that call tools over multiple turns.
+- Candidate models have materially different costs or prefix-cache behavior.
+- You want replayable policy traces for experiments and release validation.
+
+## Configuration
+
+```yaml
+routing:
+  decisions:
+    - name: agentic_routing
+      rules:
+        operator: AND
+        conditions:
+          - type: conversation
+            name: active_tool_use
+      modelRefs:
+        - model: qwen3-8b
+        - model: qwen3-32b
+      algorithm:
+        type: session_aware
+        session_aware:
+          fallback_method: hybrid
+          idle_timeout_seconds: 300
+          tool_loop_hard_lock: true
+          prefix_cache_weight: 0.20
+          switch_history_weight: 0.04
+```
+
+## Policy
+
+- Tool loops stay on the previous model while tool calls/results are still active.
+- Non-idle sessions pay a prefix-cache and handoff penalty before switching.
+- Idle sessions can reselect after `idle_timeout_seconds`.
+- Expensive/frontier models increase the prefix-cache penalty, so checkout churn is stricter for higher-cost candidates.
+- Recent switch history increases the cost of another switch, preventing long-horizon agents from bouncing between models.
+- Router replay stores `session_policy`, including base scores, adjusted scores, hard-lock reasons, cache warmth, handoff penalties, and net switch advantage.
+- Provider-reported cached prompt tokens are recorded as telemetry and costed with `cached_input_per_1m`; client-facing usage is not rewritten.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -149,6 +149,7 @@ const sidebars: SidebarsConfig = {
                 'tutorials/algorithm/selection/multi-factor',
                 'tutorials/algorithm/selection/rl-driven',
                 'tutorials/algorithm/selection/router-dc',
+                'tutorials/algorithm/selection/session-aware',
                 'tutorials/algorithm/selection/static',
                 'tutorials/algorithm/selection/svm',
               ],


### PR DESCRIPTION
## Summary

- Add `session_aware` model selection for long-horizon agent sessions, including tool-loop hard locks, idle re-selection boundaries, min-turn continuity, switch-margin control, prefix-cache-aware penalties, frontier-cost-scaled continuity, and replayable policy traces.
- Add router-owned session memory for selected model, turn/switch counts, tool-loop state, cached-token usage, cumulative usage/cost, and last routing policy.
- Integrate session policy into extproc routing, replay records, config validation, CLI schema/help, cached-token cost accounting, and docs.
- Add an agentic routing experiment harness with single-scenario and maintained matrix modes. It emits CSV, JSON, and SVG summaries for paper/blog data collection.
- Fix minimal serve behavior so `--minimal --image-pull-policy never` does not require dashboard image resolution.

## Legacy Tracking

Supersedes the older session-routing attempts in #1784, #1755, #1358, and #1459.

Resolves the session-aware routing issues #1751, #1753, #1458, #1439, and #807.

## Validation

- `make agent-ci-gate`
- `make agent-lint CHANGED_FILES=bench/agentic_routing_experiment.py`
- `go test ./pkg/selection -run 'TestSessionAware'`
- `go test ./pkg/classification ./pkg/config ./pkg/extproc ./pkg/routerreplay ./pkg/selection ./pkg/sessiontelemetry`
- `PYTHONPATH=src/vllm-sr pytest -q src/vllm-sr/tests/test_core_status.py src/vllm-sr/tests/test_docker_images.py src/vllm-sr/tests/test_split_runtime_stack.py`
- `python3 bench/agentic_routing_experiment.py --matrix --sessions 40 --turns 18 --seeds 20260530,20260531,20260532,20260533,20260534`
- `python3 bench/agentic_routing_experiment.py --matrix --sessions 4 --turns 6 --seeds 11,12`

AMD ROCm validation:

- Built the ROCm router image and served the router with AMD platform settings.
- Verified `/health` and `/v1/models`.
- Verified session-aware API routing across warmup, active tool-loop, and idle-expired turns:
  - warmup selected the low-cost agent model;
  - active tool-loop stayed on the current model with `hard_lock=tool_loop`;
  - idle-expired turn re-selected the frontier model and cleared handoff, prefix-cache, and switch-history penalties.
- Re-ran the maintained experiment matrix in the AMD ROCm validation environment and reproduced the deterministic summary.

Maintained synthetic matrix summary, 4 scenarios x 5 seeds x 40 sessions x 18 turns = 14,400 total turns:

- baseline switches: 6,533
- session-aware switches: 1,132
- switch reduction: 5,401 (82.67%)
- baseline tool-loop switch violations: 2,979
- session-aware tool-loop switch violations: 0
- baseline cost: 1061.130672
- session-aware cost: 72.167588
- cost reduction: 93.20%
- mean cached prompt ratio: 0.3487
- baseline mean quality: 0.8051
- session-aware mean quality: 0.7519
- quality delta: -0.0531

Scenario breakdown:

| Scenario | Switch reduction | Cost reduction | Tool-loop violations | Quality delta |
|---|---:|---:|---:|---:|
| balanced | 91.52% | 91.68% | 875 -> 0 | -0.0280 |
| tool-heavy | 87.02% | 96.79% | 781 -> 0 | -0.0644 |
| frontier-heavy | 86.56% | 97.33% | 491 -> 0 | -0.0833 |
| idle-heavy | 66.10% | 61.66% | 832 -> 0 | -0.0367 |
