### PR TITLE
docs: include anthropic shim in release contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
             ```bash
             docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/extproc:${{ needs.validate.outputs.tag }}
             docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/vllm-sr:${{ needs.validate.outputs.tag }}
+            docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/anthropic-shim:${{ needs.validate.outputs.tag }}
             docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/dashboard:${{ needs.validate.outputs.tag }}
             docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/operator:${{ needs.validate.outputs.tag }}
             docker pull ghcr.io/${{ steps.owner.outputs.lower }}/semantic-router/operator-bundle:${{ needs.validate.outputs.tag }}
@@ -120,6 +121,7 @@ jobs:
             |-------|-------------|
             | `extproc` | `${{ needs.validate.outputs.tag }}` · `latest` |
             | `vllm-sr` | `${{ needs.validate.outputs.tag }}` · `latest` |
+            | `anthropic-shim` | `${{ needs.validate.outputs.tag }}` · `latest` |
             | `extproc-rocm` | `${{ needs.validate.outputs.tag }}` · `latest` |
             | `vllm-sr-rocm` | `${{ needs.validate.outputs.tag }}` · `latest` |
             | `llm-katan` | `${{ needs.validate.outputs.tag }}` · `latest` |

--- a/website/docs/installation/upgrade-rollback.md
+++ b/website/docs/installation/upgrade-rollback.md
@@ -109,6 +109,7 @@ Find the latest version on the [GitHub Releases page](https://github.com/vllm-pr
 # Pull by version tag (substitute podman for docker if using podman)
 docker pull ghcr.io/vllm-project/semantic-router/extproc:v0.3.0
 docker pull ghcr.io/vllm-project/semantic-router/vllm-sr:v0.3.0
+docker pull ghcr.io/vllm-project/semantic-router/anthropic-shim:v0.3.0
 
 # Get the immutable digest for maximum pinning stability
 DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
@@ -130,6 +131,7 @@ Published versioned images for a full release:
 | `ghcr.io/vllm-project/semantic-router/extproc-rocm:v0.3.0` | ROCm router ExtProc runtime |
 | `ghcr.io/vllm-project/semantic-router/vllm-sr:v0.3.0` | Local/runtime CLI image |
 | `ghcr.io/vllm-project/semantic-router/vllm-sr-rocm:v0.3.0` | ROCm local/runtime CLI image |
+| `ghcr.io/vllm-project/semantic-router/anthropic-shim:v0.3.0` | Anthropic-compatible API shim image |
 | `ghcr.io/vllm-project/semantic-router/dashboard:v0.3.0` | Dashboard backend/frontend image |
 | `ghcr.io/vllm-project/semantic-router/llm-katan:v0.3.0` | Fleet simulation service image |
 | `ghcr.io/vllm-project/semantic-router/operator:v0.3.0` | Kubernetes operator image |


### PR DESCRIPTION
## Summary

- Add `anthropic-shim` to the generated GitHub Release container image notes.
- Add the `anthropic-shim:v0.3.0` image to the upgrade and rollback runbook.

Part of #1520 and PL0033 `V030002`.

## Validation

- `make release-check RELEASE_VERSION=0.3.0`
- `make agent-lint CHANGED_FILES='.github/workflows/release.yml website/docs/installation/upgrade-rollback.md'`