### PR TITLE
fix: lift observability out of helm resources

### DIFF
--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -3912,21 +3912,21 @@ resources:
   requests:
     memory: 6Gi
     cpu: '1'
-  observability:
-    tracing:
-      enabled: false
-      provider: opentelemetry
-      exporter:
-        type: otlp
-        endpoint: jaeger:4317
-        insecure: true
-      sampling:
-        type: always_on
-        rate: 1.0
-      resource:
-        service_name: vllm-semantic-router
-        service_version: v0.1.0
-        deployment_environment: development
+observability:
+  tracing:
+    enabled: false
+    provider: opentelemetry
+    exporter:
+      type: otlp
+      endpoint: jaeger:4317
+      insecure: true
+    sampling:
+      type: always_on
+      rate: 1.0
+    resource:
+      service_name: vllm-semantic-router
+      service_version: v0.1.0
+      deployment_environment: development
 ---
 # Profile revision 2025-11-21: math -> phi4-mini; cs/default -> llama3-8b; removed global HTTPRoute catch-all.
 config:
@@ -9330,21 +9330,21 @@ resources:
   requests:
     memory: 6Gi
     cpu: '1'
-  observability:
-    tracing:
-      enabled: false
-      provider: opentelemetry
-      exporter:
-        type: otlp
-        endpoint: jaeger:4317
-        insecure: true
-      sampling:
-        type: always_on
-        rate: 1.0
-      resource:
-        service_name: vllm-semantic-router
-        service_version: v0.1.0
-        deployment_environment: development
+observability:
+  tracing:
+    enabled: false
+    provider: opentelemetry
+    exporter:
+      type: otlp
+      endpoint: jaeger:4317
+      insecure: true
+    sampling:
+      type: always_on
+      rate: 1.0
+    resource:
+      service_name: vllm-semantic-router
+      service_version: v0.1.0
+      deployment_environment: development
 ---
 # Profile revision 2025-11-21: math -> phi4-mini; cs/default -> llama3-8b; removed global HTTPRoute catch-all.
 config:


### PR DESCRIPTION
## Summary

- Move the two misindented `observability` blocks in `deploy/helm/semantic-router/values.yaml` out from under `resources`.
- Keep container resources limited to `limits` and `requests` so rendered Deployments pass the apps/v1 schema.

Fixes #1910.

## Validation

- `helm dependency build deploy/helm/semantic-router/`
- `helm template vsr deploy/helm/semantic-router/ -n vllm-semantic-router-system | yq 'select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "semantic-router") | .resources'`
- `helm lint deploy/helm/semantic-router/`
- `make agent-lint CHANGED_FILES=deploy/helm/semantic-router/values.yaml`