### PR TITLE
fix: request identity-encoded upstream responses

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -51,7 +52,7 @@ func (r *OpenAIRouter) handleRequestHeaders(v *ext_proc.ProcessingRequest_Reques
 	if validationResp := r.validateRequestHeaders(method, path); validationResp != nil {
 		return validationResp, nil
 	}
-	return newContinueRequestHeadersResponse(), nil
+	return newContinueRequestHeadersResponse(buildIdentityEncodingRequestMutation()), nil
 }
 
 func startRequestHeaderSpan(
@@ -166,12 +167,28 @@ func extractHeaderValue(header interface {
 	return headerValue
 }
 
-func newContinueRequestHeadersResponse() *ext_proc.ProcessingResponse {
+func buildIdentityEncodingRequestMutation() *ext_proc.HeaderMutation {
+	return &ext_proc.HeaderMutation{
+		SetHeaders: []*core.HeaderValueOption{{
+			Header: &core.HeaderValue{
+				Key:   "accept-encoding",
+				Value: "identity",
+			},
+		}},
+	}
+}
+
+func newContinueRequestHeadersResponse(headerMutation ...*ext_proc.HeaderMutation) *ext_proc.ProcessingResponse {
+	var mutation *ext_proc.HeaderMutation
+	if len(headerMutation) > 0 {
+		mutation = headerMutation[0]
+	}
 	return &ext_proc.ProcessingResponse{
 		Response: &ext_proc.ProcessingResponse_RequestHeaders{
 			RequestHeaders: &ext_proc.HeadersResponse{
 				Response: &ext_proc.CommonResponse{
-					Status: ext_proc.CommonResponse_CONTINUE,
+					Status:         ext_proc.CommonResponse_CONTINUE,
+					HeaderMutation: mutation,
 				},
 			},
 		},

--- a/src/semantic-router/pkg/extproc/processor_req_header_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_test.go
@@ -182,6 +182,35 @@ func TestHandleRequestHeadersSetsLooperAndStreamingFlags(t *testing.T) {
 	}
 }
 
+func TestHandleRequestHeadersForcesIdentityEncoding(t *testing.T) {
+	router := &OpenAIRouter{}
+	requestHeaders := &ext_proc.ProcessingRequest_RequestHeaders{
+		RequestHeaders: &ext_proc.HttpHeaders{
+			Headers: &core.HeaderMap{
+				Headers: []*core.HeaderValue{
+					{Key: ":method", Value: "POST"},
+					{Key: ":path", Value: "/v1/chat/completions"},
+					{Key: "accept-encoding", Value: "gzip, br"},
+				},
+			},
+		},
+	}
+
+	ctx := &RequestContext{Headers: make(map[string]string)}
+	response, err := router.handleRequestHeaders(requestHeaders, ctx)
+	if err != nil {
+		t.Fatalf("handleRequestHeaders failed: %v", err)
+	}
+
+	headerMutation := response.GetRequestHeaders().Response.GetHeaderMutation()
+	if headerMutation == nil {
+		t.Fatal("expected request header mutation")
+	}
+	if got := findSetHeader(headerMutation, "accept-encoding"); got != "identity" {
+		t.Fatalf("accept-encoding mutation = %q, want identity", got)
+	}
+}
+
 func TestHandleRequestHeadersReturnsMethodNotAllowedForChatCompletionsGet(t *testing.T) {
 	router := &OpenAIRouter{}
 	ctx := &RequestContext{Headers: make(map[string]string)}
@@ -245,6 +274,18 @@ func assertImmediateErrorResponse(
 	if decoded.Error.Message != wantMessage {
 		t.Fatalf("expected error message %q, got %q", wantMessage, decoded.Error.Message)
 	}
+}
+
+func findSetHeader(mutation *ext_proc.HeaderMutation, key string) string {
+	if mutation == nil {
+		return ""
+	}
+	for _, header := range mutation.SetHeaders {
+		if header.GetHeader().GetKey() == key {
+			return header.GetHeader().GetValue()
+		}
+	}
+	return ""
 }
 
 func TestValidateRequestHeaders_V1Messages(t *testing.T) {


### PR DESCRIPTION
## Summary

- Force normal routed upstream requests to use `accept-encoding: identity`.
- Keep the router response body path inspectable for usage parsing, cost accounting, replay, and dashboard insights when providers would otherwise return compressed JSON.
- Leave explicit skip-processing requests as a plain pass-through.

Fixes #1897.

## Validation

- `go test ./pkg/extproc -run 'TestHandleRequestHeadersForcesIdentityEncoding|TestParseResponseUsage|TestHandleRequestHeadersSetsLooperAndStreamingFlags'`
- `make agent-lint CHANGED_FILES='src/semantic-router/pkg/extproc/processor_req_header.go src/semantic-router/pkg/extproc/processor_req_header_test.go'`