### PR TITLE
fix: reject native Windows docker runtime

### DIFF
--- a/src/vllm-sr/README.md
+++ b/src/vllm-sr/README.md
@@ -19,6 +19,10 @@ pip install -e .
 
 ### Usage
 
+Local `vllm-sr serve` requires Docker on Linux, macOS, or WSL2 on Windows.
+Native Windows Python environments can install the CLI for configuration and
+validation tasks, but the local Docker runtime is not supported there.
+
 ```bash
 # Start the router (includes dashboard, simulator sidecar, and first-run setup)
 HF_TOKEN=hf_xxx vllm-sr serve

--- a/src/vllm-sr/cli/docker_runtime.py
+++ b/src/vllm-sr/cli/docker_runtime.py
@@ -38,6 +38,13 @@ def _detect_container_runtime():
     Raises:
         SystemExit: If Docker is unavailable or resolves to Podman
     """
+    if sys.platform.startswith("win"):
+        _exit_unsupported_runtime(
+            "native Windows",
+            "Native Windows is not supported for local `vllm-sr serve` workflows. "
+            "Run `vllm-sr serve` from WSL2 or another Linux environment with Docker.",
+        )
+
     env_runtime = (os.getenv("CONTAINER_RUNTIME") or "").strip()
     if env_runtime:
         normalized_runtime = env_runtime.lower()

--- a/src/vllm-sr/tests/test_docker_runtime.py
+++ b/src/vllm-sr/tests/test_docker_runtime.py
@@ -12,7 +12,8 @@ from cli import docker_runtime  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def clear_runtime_detection_cache():
+def clear_runtime_detection_cache(monkeypatch):
+    monkeypatch.setattr(docker_runtime.sys, "platform", "linux")
     docker_runtime._detect_container_runtime.cache_clear()
     yield
     docker_runtime._detect_container_runtime.cache_clear()
@@ -56,6 +57,13 @@ def test_detect_container_runtime_accepts_real_docker(monkeypatch):
 
 def test_detect_container_runtime_rejects_podman_env_override(monkeypatch):
     monkeypatch.setenv("CONTAINER_RUNTIME", "podman")
+
+    with pytest.raises(SystemExit):
+        docker_runtime.get_container_runtime()
+
+
+def test_detect_container_runtime_rejects_native_windows(monkeypatch):
+    monkeypatch.setattr(docker_runtime.sys, "platform", "win32")
 
     with pytest.raises(SystemExit):
         docker_runtime.get_container_runtime()

--- a/website/docs/installation/installation.md
+++ b/website/docs/installation/installation.md
@@ -17,6 +17,7 @@ No GPU required - the router runs efficiently on CPU using optimized BERT models
 
 - **Python**: 3.10 or higher
 - **Container Runtime**: Docker (required for running the router container)
+- **Local host OS**: Linux, macOS, or WSL2 on Windows for `vllm-sr serve`
 
 ## Quick Start
 
@@ -43,7 +44,10 @@ Need the latest stable release instead? Run:
 curl -fsSL https://vllm-semantic-router.com/install.sh | bash -s -- --channel stable
 ```
 
-Windows users should use the manual PyPI flow below.
+Windows users should run the local `vllm-sr serve` workflow from WSL2 or another
+Linux environment with Docker. A native Windows Python environment can install
+the CLI for configuration and validation tasks, but the v0.3 local Docker
+runtime is not supported there.
 
 ### 2. Manual PyPI install
 
@@ -66,6 +70,8 @@ vllm-sr --version
 ```
 
 ### 3. Restart `vllm-sr` later
+
+Run the local Docker runtime from Linux, macOS, or WSL2 on Windows:
 
 ```bash
 vllm-sr serve


### PR DESCRIPTION
## Summary
- fail fast when the Docker runtime path is invoked from native Windows and direct users to WSL2 or another Linux Docker environment
- clarify the Windows support boundary in the quickstart and CLI README
- add unit coverage for the native Windows runtime guard

Closes #1949

## Validation
- `PYTHONPATH=src/vllm-sr pytest -q src/vllm-sr/tests/test_docker_runtime.py src/vllm-sr/tests/test_install_script_surface.py src/vllm-sr/tests/test_cli_main.py`
- `make agent-lint CHANGED_FILES='src/vllm-sr/cli/docker_runtime.py src/vllm-sr/tests/test_docker_runtime.py website/docs/installation/installation.md src/vllm-sr/README.md'`
- `make vllm-sr-test`
- `make vllm-sr-test-integration`
- `make agent-dev ENV=cpu`
- `make agent-serve-local ENV=cpu`
- `make agent-smoke-local`
- `make agent-stop-local ENV=cpu`