### PR TITLE
[Router] Validate mmbert_model_path rejects classic BERT models at config-load time

### DIFF
--- a/src/semantic-router/pkg/config/validator_embedding.go
+++ b/src/semantic-router/pkg/config/validator_embedding.go
@@ -13,7 +13,35 @@ func validateEmbeddingContracts(cfg *RouterConfig) error {
 	if cfg == nil {
 		return nil
 	}
+	if err := validateMmBertModelPath(cfg.EmbeddingModels.MmBertModelPath); err != nil {
+		return err
+	}
 	return validateEmbeddingRuleModalities(cfg.EmbeddingRules, cfg.EmbeddingModels.EmbeddingConfig.ModelType)
+}
+
+// validateMmBertModelPath rejects classic BERT models in the mmbert_model_path
+// slot. Classic BERT (e.g. all-MiniLM-L12-v2) uses a different tensor layout
+// than ModernBERT/mmBERT and will crash the Rust loader with a cryptic tensor
+// name mismatch. Catching it here gives the user a clear message at config-load
+// time instead of a crash at model-init time.
+func validateMmBertModelPath(modelPath string) error {
+	if modelPath == "" {
+		return nil
+	}
+	model := GetModelByPath(modelPath)
+	if model == nil {
+		return nil
+	}
+	if model.Purpose == PurposeSemanticSimilarity {
+		return fmt.Errorf(
+			"mmbert_model_path is set to %q, which is a classic BERT model (%s, %s). "+
+				"Classic BERT models are not compatible with the mmBERT loader. "+
+				"Use 'bert_model_path' for this model instead, or set mmbert_model_path "+
+				"to a ModernBERT-based model such as 'models/mmbert-embed-32k-2d-matryoshka'",
+			modelPath, model.RepoID, model.ParameterSize,
+		)
+	}
+	return nil
 }
 
 // ValidateEmbeddingContracts is the exported counterpart of the private

--- a/src/semantic-router/pkg/config/validator_embedding_test.go
+++ b/src/semantic-router/pkg/config/validator_embedding_test.go
@@ -163,6 +163,55 @@ func TestValidateEmbeddingContracts_ExportedWrapperMatchesInternal(t *testing.T)
 	}
 }
 
+func TestValidateMmBertModelPath_RejectsClassicBERT(t *testing.T) {
+	err := validateMmBertModelPath("models/mom-embedding-light")
+	if err == nil {
+		t.Fatal("expected error when mmbert_model_path points to a classic BERT model, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"mom-embedding-light", "classic BERT", "bert_model_path", "all-MiniLM-L12-v2"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should contain %q, got: %s", want, msg)
+		}
+	}
+}
+
+func TestValidateMmBertModelPath_AcceptsModernBERT(t *testing.T) {
+	if err := validateMmBertModelPath("models/mmbert-embed-32k-2d-matryoshka"); err != nil {
+		t.Errorf("mmbert-embed-32k-2d-matryoshka should be accepted, got: %v", err)
+	}
+}
+
+func TestValidateMmBertModelPath_AcceptsEmpty(t *testing.T) {
+	if err := validateMmBertModelPath(""); err != nil {
+		t.Errorf("empty path should be accepted, got: %v", err)
+	}
+}
+
+func TestValidateMmBertModelPath_AcceptsUnknownPath(t *testing.T) {
+	if err := validateMmBertModelPath("models/some-custom-model"); err != nil {
+		t.Errorf("unknown model path should be accepted (not in registry), got: %v", err)
+	}
+}
+
+func TestValidateEmbeddingContracts_RejectsClassicBERTInMmBertSlot(t *testing.T) {
+	cfg := &RouterConfig{
+		InlineModels: InlineModels{
+			EmbeddingModels: EmbeddingModels{
+				MmBertModelPath: "models/mom-embedding-light",
+				EmbeddingConfig: HNSWConfig{ModelType: "mmbert"},
+			},
+		},
+	}
+	err := validateEmbeddingContracts(cfg)
+	if err == nil {
+		t.Fatal("expected validateEmbeddingContracts to reject classic BERT in mmbert slot, got nil")
+	}
+	if !strings.Contains(err.Error(), "classic BERT") {
+		t.Errorf("error should mention 'classic BERT', got: %s", err.Error())
+	}
+}
+
 func TestEmbeddingRule_EffectiveQueryModalityDefaultsToText(t *testing.T) {
 	cases := []struct {
 		input QueryModality


### PR DESCRIPTION
Closes #1769

## Purpose

- **What:** Add config-time validation that rejects classic BERT models (e.g. `all-MiniLM-L12-v2`) in the `mmbert_model_path` config slot.
- **Why:** When `mmbert_model_path` points to a classic BERT model, the Rust mmBERT loader crashes with a cryptic tensor name mismatch (`cannot find tensor _orig_mod.model.embeddings.tok_embeddings.weight`) because classic BERT uses a fundamentally different tensor layout (`word_embeddings`, separate Q/K/V) than ModernBERT/mmBERT (`tok_embeddings`, fused QKV). The user put the right model in the wrong config field and got no guidance from the error.
- **Module(s):** `Router`

### Root Cause

The model registry (`config/registry.go:220-221`) maps `models/mom-embedding-light` → `sentence-transformers/all-MiniLM-L12-v2` (classic BERT, `Purpose: semantic-similarity`), while `mmbert_model_path` expects a ModernBERT-compatible model like `models/mmbert-embed-32k-2d-matryoshka` (`Purpose: embedding`). The existing embedding validator pipeline (`validator_embedding.go`) had no check for this mismatch.

### Fix

Add `validateMmBertModelPath()` to the `validateEmbeddingContracts` pipeline. It looks up the model path in `DefaultModelRegistry` via `GetModelByPath()` and rejects models with `Purpose == PurposeSemanticSimilarity` with a clear, actionable error message directing the user to use `bert_model_path` instead.

## Test Plan

- `go test ./pkg/config/ -run 'TestValidateEmbedding|TestValidateMmBert' -v`
- 5 new tests covering: classic BERT rejected, ModernBERT accepted, empty path accepted, unknown path accepted, end-to-end via `RouterConfig`
- All 10 existing embedding validator tests verified for regressions

## Test Result

```
=== RUN   TestValidateMmBertModelPath_RejectsClassicBERT
--- PASS: TestValidateMmBertModelPath_RejectsClassicBERT (0.00s)
=== RUN   TestValidateMmBertModelPath_AcceptsModernBERT
--- PASS: TestValidateMmBertModelPath_AcceptsModernBERT (0.00s)
=== RUN   TestValidateMmBertModelPath_AcceptsEmpty
--- PASS: TestValidateMmBertModelPath_AcceptsEmpty (0.00s)
=== RUN   TestValidateMmBertModelPath_AcceptsUnknownPath
--- PASS: TestValidateMmBertModelPath_AcceptsUnknownPath (0.00s)
=== RUN   TestValidateEmbeddingContracts_RejectsClassicBERTInMmBertSlot
--- PASS: TestValidateEmbeddingContracts_RejectsClassicBERTInMmBertSlot (0.00s)
PASS — 15/15 tests pass (0.302s)
```

No follow-up risks. The check only applies to models found in `DefaultModelRegistry`; custom/unknown model paths are allowed through (validated by `TestValidateMmBertModelPath_AcceptsUnknownPath`).

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.