### PR TITLE
fix: record session header usage telemetry

### DIFF
--- a/src/semantic-router/pkg/extproc/session_telemetry.go
+++ b/src/semantic-router/pkg/extproc/session_telemetry.go
@@ -31,11 +31,12 @@ func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics, pricing 
 	if ctx == nil || usage.promptTokens+usage.completionTokens <= 0 {
 		return
 	}
+	sessiontelemetry.RecordLastModel(ctx.SessionID, ctx.RequestModel)
+
 	domain := consts.UnknownLabel
 	if ctx.VSRSelectedCategory != "" {
 		domain = ctx.VSRSelectedCategory
 	}
-	sessiontelemetry.RecordLastModel(ctx.SessionID, ctx.RequestModel)
 	p := sessiontelemetry.TurnParams{
 		RequestID:          ctx.RequestID,
 		Model:              ctx.RequestModel,
@@ -56,6 +57,7 @@ func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics, pricing 
 	} else {
 		userID := extractUserID(ctx)
 		if userID == "" || len(ctx.ChatCompletionMessages) == 0 {
+			recordRouterSessionUsageFromContext(ctx, usage, pricing)
 			return
 		}
 		msgs := make([]sessiontelemetry.ChatMessage, len(ctx.ChatCompletionMessages))
@@ -68,6 +70,39 @@ func recordSessionTurn(ctx *RequestContext, usage responseUsageMetrics, pricing 
 		p.Chat = &sessiontelemetry.ChatInput{UserID: userID, Messages: msgs}
 	}
 	sessiontelemetry.RecordTurn(p)
+}
+
+func recordRouterSessionUsageFromContext(
+	ctx *RequestContext,
+	usage responseUsageMetrics,
+	pricing sessiontelemetry.TurnPricing,
+) {
+	if ctx == nil || ctx.SessionID == "" || ctx.RequestModel == "" {
+		return
+	}
+	sessiontelemetry.RecordSessionUsage(sessiontelemetry.SessionUsageParams{
+		SessionID:          ctx.SessionID,
+		Model:              ctx.RequestModel,
+		PromptTokens:       usage.promptTokens,
+		CachedPromptTokens: usage.cachedPromptTokens,
+		CompletionTokens:   usage.completionTokens,
+		Cost:               sessionTurnCost(usage, pricing),
+		Timestamp:          time.Now(),
+	})
+}
+
+func sessionTurnCost(usage responseUsageMetrics, pricing sessiontelemetry.TurnPricing) float64 {
+	if pricing.PromptPer1M == 0 &&
+		pricing.CompletionPer1M == 0 &&
+		pricing.CachedInputPer1M == 0 &&
+		pricing.Currency == "" {
+		return 0
+	}
+	cached := clampCachedPromptTokensInt(usage.promptTokens, usage.cachedPromptTokens)
+	uncachedPrompt := usage.promptTokens - cached
+	return (float64(uncachedPrompt)*pricing.PromptPer1M +
+		float64(cached)*pricing.CachedInputPer1M +
+		float64(usage.completionTokens)*pricing.CompletionPer1M) / 1_000_000.0
 }
 
 // maybeEmitTransitionEvent records a ModelTransitionEvent on model change.

--- a/src/semantic-router/pkg/extproc/session_transition_last_model_test.go
+++ b/src/semantic-router/pkg/extproc/session_transition_last_model_test.go
@@ -2,6 +2,7 @@ package extproc
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,4 +74,66 @@ func TestChatCompletionsModelContinuityAcrossTurns(t *testing.T) {
 
 	require.Equal(t, turn1.SessionID, turn2.SessionID, "session must be stable across turns")
 	assert.Equal(t, "model-a", turn2.PreviousModel)
+}
+
+func TestRecordSessionTurn_PinnedSessionWithoutUserRecordsRouterUsage(t *testing.T) {
+	sessiontelemetry.ResetForTesting()
+	sessiontelemetry.ResetLastModelForTesting()
+	t.Cleanup(sessiontelemetry.ResetForTesting)
+	t.Cleanup(sessiontelemetry.ResetLastModelForTesting)
+
+	ctx := &RequestContext{
+		RequestID:              "req-pinned-usage",
+		RequestModel:           "frontier-model",
+		SessionID:              "pinned-agent-session",
+		Headers:                map[string]string{"x-session-id": "pinned-agent-session"},
+		ChatCompletionMessages: []ChatCompletionMessage{{Role: "user", Content: "continue the task"}},
+	}
+	recordSessionTurn(
+		ctx,
+		responseUsageMetrics{promptTokens: 1000, cachedPromptTokens: 400, completionTokens: 100},
+		sessiontelemetry.TurnPricing{
+			Currency:         "USD",
+			PromptPer1M:      10,
+			CachedInputPer1M: 1,
+			CompletionPer1M:  20,
+		},
+	)
+
+	snapshot, ok := sessiontelemetry.GetRouterSessionSnapshot("pinned-agent-session", time.Now())
+	require.True(t, ok, "expected router-owned session memory for pinned session")
+	assert.Equal(t, "frontier-model", snapshot.CurrentModel)
+	assert.Equal(t, int64(1000), snapshot.CumulativePromptTokens)
+	assert.Equal(t, int64(400), snapshot.CumulativeCachedTokens)
+	assert.Equal(t, int64(100), snapshot.CumulativeCompletionTokens)
+	assert.InDelta(t, 0.0084, snapshot.CumulativeCost, 0.0000001)
+
+	lastModel, ok := sessiontelemetry.GetLastModel("pinned-agent-session")
+	require.True(t, ok, "expected last-model continuity for pinned session")
+	assert.Equal(t, "frontier-model", lastModel)
+}
+
+func TestRecordSessionTurn_UserDerivedChatDoesNotDoubleCountRouterUsage(t *testing.T) {
+	sessiontelemetry.ResetForTesting()
+	t.Cleanup(sessiontelemetry.ResetForTesting)
+
+	messages := []ChatCompletionMessage{{Role: "user", Content: "hello there"}}
+	ctx := &RequestContext{
+		RequestID:              "req-user-derived",
+		RequestModel:           "small-model",
+		Headers:                map[string]string{"x-authz-user-id": "user-7"},
+		ChatCompletionMessages: messages,
+	}
+	populateSessionTransitionFields(ctx)
+	recordSessionTurn(
+		ctx,
+		responseUsageMetrics{promptTokens: 200, cachedPromptTokens: 50, completionTokens: 30},
+		sessiontelemetry.TurnPricing{},
+	)
+
+	snapshot, ok := sessiontelemetry.GetRouterSessionSnapshot(ctx.SessionID, time.Now())
+	require.True(t, ok, "expected router-owned session memory for user-derived chat")
+	assert.Equal(t, int64(200), snapshot.CumulativePromptTokens)
+	assert.Equal(t, int64(50), snapshot.CumulativeCachedTokens)
+	assert.Equal(t, int64(30), snapshot.CumulativeCompletionTokens)
 }


### PR DESCRIPTION
## Summary
- record router-owned session usage for Chat Completions calls that provide `x-session-id` without a user identity
- preserve cached prompt tokens and estimated turn cost in the session snapshot so session-aware routing can reason about cache warmth/cost for pinned agent sessions
- keep user-derived Chat Completions on the existing `RecordTurn` path and add coverage to prevent double counting

## Validation
- `go test ./pkg/extproc -run 'TestRecordSessionTurn|TestChatCompletionsModelContinuityAcrossTurns|TestPopulateSessionTransitionFields_ChatCompletions'`\n- `make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/extproc/session_telemetry.go src/semantic-router/pkg/extproc/session_transition_last_model_test.go"`\n- `make agent-feature-gate ENV=cpu CHANGED_FILES="src/semantic-router/pkg/extproc/session_telemetry.go src/semantic-router/pkg/extproc/session_transition_last_model_test.go"`