### PR TITLE
fix: price session cache pressure by input checkout cost

### DIFF
--- a/src/semantic-router/pkg/selection/session_aware_scoring.go
+++ b/src/semantic-router/pkg/selection/session_aware_scoring.go
@@ -1,6 +1,10 @@
 package selection
 
-import "math"
+import (
+	"math"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
 
 func (s *SessionAwareSelector) adjustScores(
 	selCtx *SelectionContext,
@@ -156,7 +160,7 @@ func (s *SessionAwareSelector) modelCostPressure(model string) float64 {
 	maxCost := 0.0
 	modelCost := 0.0
 	for name, params := range s.modelParams {
-		cost := params.Pricing.PromptPer1M + params.Pricing.CompletionPer1M
+		cost := prefixCacheCheckoutCost(params.Pricing)
 		if cost > maxCost {
 			maxCost = cost
 		}
@@ -171,6 +175,14 @@ func (s *SessionAwareSelector) modelCostPressure(model string) float64 {
 		return clamp01(params.QualityScore)
 	}
 	return 0.5
+}
+
+func prefixCacheCheckoutCost(pricing config.ModelPricing) float64 {
+	if pricing.PromptPer1M <= 0 {
+		return 0
+	}
+	cachedInputCost := clampF(pricing.CachedInputPer1M, 0, pricing.PromptPer1M)
+	return pricing.PromptPer1M - cachedInputCost
 }
 
 func (s *SessionAwareSelector) lookupQualityGap(selCtx *SelectionContext, current, candidate string) float64 {

--- a/src/semantic-router/pkg/selection/session_aware_test.go
+++ b/src/semantic-router/pkg/selection/session_aware_test.go
@@ -263,10 +263,10 @@ func TestSessionAwarePrefixPenaltyScalesWithModelCost(t *testing.T) {
 	})
 	selector.InitializeFromConfig(map[string]config.ModelParams{
 		"cheap": {
-			Pricing: config.ModelPricing{PromptPer1M: 0.05, CompletionPer1M: 0.10},
+			Pricing: config.ModelPricing{PromptPer1M: 0.05, CachedInputPer1M: 0.01, CompletionPer1M: 0.10},
 		},
 		"frontier": {
-			Pricing: config.ModelPricing{PromptPer1M: 10, CompletionPer1M: 30},
+			Pricing: config.ModelPricing{PromptPer1M: 10, CachedInputPer1M: 1, CompletionPer1M: 30},
 		},
 	})
 	session := &AgenticSessionContext{
@@ -281,6 +281,42 @@ func TestSessionAwarePrefixPenaltyScalesWithModelCost(t *testing.T) {
 	frontierPenalty := selector.prefixCachePenalty(session, "frontier", "cheap", false)
 	if frontierPenalty <= cheapPenalty {
 		t.Fatalf("expected frontier switch penalty %.4f > cheap penalty %.4f", frontierPenalty, cheapPenalty)
+	}
+}
+
+func TestSessionAwareCacheCostPressureUsesPrefixCheckoutDelta(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{MaxCacheCostMultiplier: 3})
+	selector.InitializeFromConfig(map[string]config.ModelParams{
+		"uncached-frontier": {
+			Pricing: config.ModelPricing{PromptPer1M: 10, CachedInputPer1M: 0, CompletionPer1M: 1},
+		},
+		"cached-frontier": {
+			Pricing: config.ModelPricing{PromptPer1M: 10, CachedInputPer1M: 9, CompletionPer1M: 1},
+		},
+	})
+
+	uncachedPressure := selector.modelCostPressure("uncached-frontier")
+	cachedPressure := selector.modelCostPressure("cached-frontier")
+	if cachedPressure >= uncachedPressure {
+		t.Fatalf("expected cached-input discount to reduce pressure, got cached %.4f >= uncached %.4f", cachedPressure, uncachedPressure)
+	}
+}
+
+func TestSessionAwareCacheCostPressureIgnoresCompletionOnlyCost(t *testing.T) {
+	selector := NewSessionAwareSelector(&SessionAwareConfig{MaxCacheCostMultiplier: 3})
+	selector.InitializeFromConfig(map[string]config.ModelParams{
+		"output-heavy": {
+			Pricing: config.ModelPricing{PromptPer1M: 0.1, CompletionPer1M: 100},
+		},
+		"input-heavy": {
+			Pricing: config.ModelPricing{PromptPer1M: 10, CachedInputPer1M: 1, CompletionPer1M: 0},
+		},
+	})
+
+	outputHeavyPressure := selector.modelCostPressure("output-heavy")
+	inputHeavyPressure := selector.modelCostPressure("input-heavy")
+	if outputHeavyPressure >= inputHeavyPressure {
+		t.Fatalf("expected prompt checkout cost to dominate pressure, got output %.4f >= input %.4f", outputHeavyPressure, inputHeavyPressure)
 	}
 }
 


### PR DESCRIPTION
## Summary
- price session-aware prefix-cache pressure from prompt checkout delta instead of prompt+completion total price
- clamp cached-input pricing into the valid prompt-cost range before computing pressure
- cover cached-input discount and completion-heavy pricing cases

## Validation
- `go test ./pkg/selection`
- `make agent-lint CHANGED_FILES="src/semantic-router/pkg/selection/session_aware_scoring.go src/semantic-router/pkg/selection/session_aware_test.go"`
- `make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/selection/session_aware_scoring.go src/semantic-router/pkg/selection/session_aware_test.go"`
- CPU smoke attempted; blocked before readiness because the generated runtime config was not mounted at the container path expected by the harness
