### PR TITLE
[Dashboard] wire ClawRoom clients to room collaboration event bus

### DIFF
--- a/dashboard/frontend/e2e/claw-room-collaboration.spec.ts
+++ b/dashboard/frontend/e2e/claw-room-collaboration.spec.ts
@@ -1,0 +1,369 @@
+import { expect, test, type Page } from '@playwright/test'
+import { mockAuthenticatedSession } from './support/auth'
+
+const openClawTeam = {
+  id: 'team-alpha',
+  name: 'Team Alpha',
+  vibe: 'Calm',
+  role: 'Operations',
+  principal: 'Safety first',
+  leaderId: 'leader-1',
+}
+
+const openClawWorkers = [
+  {
+    name: 'leader-1',
+    teamId: 'team-alpha',
+    agentName: 'Leader One',
+    agentRole: 'Lead',
+    roleKind: 'leader',
+  },
+  {
+    name: 'worker-a',
+    teamId: 'team-alpha',
+    agentName: 'Worker A',
+    agentRole: 'Operator',
+    roleKind: 'worker',
+  },
+]
+
+const openClawRoom = {
+  id: 'room-alpha',
+  teamId: 'team-alpha',
+  name: 'Planning',
+}
+
+const initialMessages = [
+  {
+    id: 'room-msg-user-1',
+    roomId: 'room-alpha',
+    teamId: 'team-alpha',
+    senderType: 'user',
+    senderId: 'playground-user',
+    senderName: 'You',
+    content: 'hello team',
+    createdAt: '2026-05-31T00:00:00Z',
+  },
+]
+
+async function mockCollaborationBootstrap(page: Page) {
+  await mockAuthenticatedSession(page)
+
+  await page.route('**/api/setup/state', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        setupMode: false,
+        listenerPort: 8700,
+        models: 1,
+        decisions: 1,
+        hasModels: true,
+        hasDecisions: true,
+        canActivate: true,
+      }),
+    })
+  })
+
+  await page.route('**/api/settings', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ readonlyMode: false, setupMode: false }),
+    })
+  })
+
+  await page.route('**/api/openclaw/teams', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([openClawTeam]) })
+  })
+
+  await page.route('**/api/openclaw/workers', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(openClawWorkers) })
+  })
+
+  await page.route('**/api/openclaw/rooms?*', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([openClawRoom]) })
+  })
+
+  await page.route('**/api/openclaw/rooms/room-alpha/messages?*', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(initialMessages) })
+  })
+}
+
+async function enableClawRoom(page: Page) {
+  await page.goto('/playground')
+  await page.getByRole('button', { name: 'Enable HireClaw' }).click()
+  await page.getByRole('button', { name: 'Open ClawRoom view' }).click()
+  await expect(page.getByTestId('claw-room-transcript')).toBeVisible()
+}
+
+test.describe('Claw room collaboration', () => {
+  test('renders streaming worker chunks in the transcript', async ({ page }) => {
+    await mockCollaborationBootstrap(page)
+
+    await page.addInitScript(() => {
+      class MockWebSocket {
+        static instances: MockWebSocket[] = []
+        url: string
+        readyState = 1
+        onopen: ((event: Event) => void) | null = null
+        onmessage: ((event: MessageEvent) => void) | null = null
+        onerror: ((event: Event) => void) | null = null
+        onclose: ((event: CloseEvent) => void) | null = null
+
+        constructor(url: string) {
+          this.url = url
+          MockWebSocket.instances.push(this)
+          window.setTimeout(() => this.onopen?.(new Event('open')), 0)
+        }
+
+        send() {}
+
+        close() {
+          this.readyState = 3
+        }
+
+        emit(payload: Record<string, unknown>) {
+          this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+        }
+      }
+
+      ;(window as typeof window & { __mockRoomSockets?: MockWebSocket[] }).__mockRoomSockets = MockWebSocket.instances
+      window.WebSocket = MockWebSocket as unknown as typeof WebSocket
+    })
+
+    await enableClawRoom(page)
+
+    await page.evaluate(() => {
+      const sockets = (window as typeof window & {
+        __mockRoomSockets?: Array<{ emit: (payload: Record<string, unknown>) => void }>
+      }).__mockRoomSockets
+      const socket = sockets?.[sockets.length - 1]
+      socket?.emit({
+        type: 'message_chunk',
+        messageId: 'stream-worker-1',
+        chunk: 'Typing ',
+        participantType: 'worker',
+        participantId: 'worker-a',
+      })
+      socket?.emit({
+        type: 'message_chunk',
+        messageId: 'stream-worker-1',
+        chunk: 'now',
+        participantType: 'worker',
+        participantId: 'worker-a',
+      })
+    })
+
+    await expect(page.locator('[data-room-message-streaming="true"]')).toContainText('Typing now')
+  })
+
+  test('falls back to SSE when websocket disconnects', async ({ page }) => {
+    await mockCollaborationBootstrap(page)
+
+    await page.addInitScript(() => {
+      class FailingWebSocket {
+        readyState = 3
+        onopen: ((event: Event) => void) | null = null
+        onmessage: ((event: MessageEvent) => void) | null = null
+        onerror: ((event: Event) => void) | null = null
+        onclose: ((event: CloseEvent) => void) | null = null
+
+        constructor() {
+          window.setTimeout(() => this.onclose?.({ code: 1006 } as CloseEvent), 0)
+        }
+
+        send() {}
+        close() {}
+      }
+
+      class MockEventSource {
+        static latest: MockEventSource | null = null
+        url: string
+        onopen: ((event: Event) => void) | null = null
+        onerror: ((event: Event) => void) | null = null
+        messageListener: EventListener | null = null
+
+        constructor(url: string) {
+          this.url = url
+          MockEventSource.latest = this
+          window.setTimeout(() => this.onopen?.(new Event('open')), 0)
+        }
+
+        addEventListener(type: string, listener: EventListener) {
+          if (type !== 'message') {
+            return
+          }
+          this.messageListener = listener
+        }
+
+        close() {}
+
+        emitMessage(payload: Record<string, unknown>) {
+          this.messageListener?.({ data: JSON.stringify(payload) } as MessageEvent)
+        }
+      }
+
+      window.WebSocket = FailingWebSocket as unknown as typeof WebSocket
+      window.EventSource = MockEventSource as unknown as typeof EventSource
+      ;(window as typeof window & { __mockEventSource?: typeof MockEventSource }).__mockEventSource = MockEventSource
+    })
+
+    await enableClawRoom(page)
+    await expect(page.getByTestId('claw-room-transport-status')).toContainText('SSE')
+
+    await page.evaluate(() => {
+      const MockEventSource = (window as typeof window & {
+        __mockEventSource?: { latest?: { emitMessage: (payload: Record<string, unknown>) => void } }
+      }).__mockEventSource
+      MockEventSource?.latest?.emitMessage({
+        type: 'message',
+        roomId: 'room-alpha',
+        message: {
+          id: 'room-msg-sse-1',
+          roomId: 'room-alpha',
+          teamId: 'team-alpha',
+          senderType: 'worker',
+          senderId: 'worker-a',
+          senderName: 'worker-a',
+          content: 'SSE fallback delivery',
+          createdAt: '2026-05-31T00:01:00Z',
+        },
+      })
+    })
+
+    await expect(page.getByText('SSE fallback delivery')).toBeVisible()
+  })
+
+  test('forwards room events to embedded iframe via bridge', async ({ page }) => {
+    await mockCollaborationBootstrap(page)
+
+    await page.addInitScript(() => {
+      class MockWebSocket {
+        static instances: MockWebSocket[] = []
+        readyState = 1
+        onopen: ((event: Event) => void) | null = null
+        onmessage: ((event: MessageEvent) => void) | null = null
+        onerror: ((event: Event) => void) | null = null
+        onclose: ((event: CloseEvent) => void) | null = null
+
+        constructor(_url: string) {
+          MockWebSocket.instances.push(this)
+          window.setTimeout(() => this.onopen?.(new Event('open')), 0)
+        }
+
+        send() {}
+        close() {}
+
+        emit(payload: Record<string, unknown>) {
+          this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+        }
+      }
+
+      ;(window as typeof window & { __mockRoomSockets?: MockWebSocket[] }).__mockRoomSockets = MockWebSocket.instances
+      window.WebSocket = MockWebSocket as unknown as typeof WebSocket
+    })
+
+    await page.route('**/api/openclaw/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            running: true,
+            containerName: 'worker-a',
+            gatewayUrl: 'http://127.0.0.1:18788',
+            port: 18788,
+            healthy: true,
+            error: '',
+            teamId: 'team-alpha',
+            teamName: 'Team Alpha',
+            agentName: 'Worker A',
+          },
+        ]),
+      })
+    })
+
+    await page.route('**/api/openclaw/token?name=*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ token: 'gateway-token' }),
+      })
+    })
+
+    await page.route('**/embedded/openclaw/**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: `<!doctype html><html><body>
+          <script>
+            window.__bridgeEvents = [];
+            window.addEventListener('message', (event) => {
+              if (event.data && event.data.source === 'clawos-room-bridge') {
+                window.__bridgeEvents.push(event.data);
+              }
+            });
+          </script>
+        </body></html>`,
+      })
+    })
+
+    await page.goto('/clawos')
+    await page.getByRole('button', { name: /Claw Dashboard/ }).click()
+    await page.getByRole('button', { name: 'Dashboard', exact: true }).click()
+
+    await expect(page.getByTestId('claw-room-bridge-activity')).toBeVisible()
+
+    await page.evaluate(() => {
+      const sockets = (window as typeof window & {
+        __mockRoomSockets?: Array<{ emit: (payload: Record<string, unknown>) => void }>
+      }).__mockRoomSockets
+      const socket = sockets?.[sockets.length - 1]
+      socket?.emit({
+        type: 'new_message',
+        message: {
+          id: 'room-msg-bridge-1',
+          roomId: 'room-alpha',
+          teamId: 'team-alpha',
+          senderType: 'worker',
+          senderId: 'worker-a',
+          senderName: 'worker-a',
+          content: 'bridge hello',
+          createdAt: '2026-05-31T00:02:00Z',
+        },
+      })
+    })
+
+    const iframeEvents = await page.evaluate(async () => {
+      const iframe = document.querySelector('iframe[title*="OpenClaw Control UI"]') as HTMLIFrameElement | null
+      if (!iframe?.contentWindow) {
+        return [] as unknown[]
+      }
+
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const events = (iframe.contentWindow as Window & { __bridgeEvents?: unknown[] }).__bridgeEvents
+        if (Array.isArray(events) && events.length > 0) {
+          return events
+        }
+        await new Promise(resolve => window.setTimeout(resolve, 100))
+      }
+      return [] as unknown[]
+    })
+
+    expect(iframeEvents.length).toBeGreaterThan(0)
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          source: 'clawos-room-bridge',
+          type: 'surface_event',
+          roomId: 'room-alpha',
+          payload: { kind: 'tool_call', name: 'search' },
+        },
+      }))
+    })
+
+    await expect(page.getByTestId('claw-room-bridge-activity')).toContainText('Surface')
+  })
+})

--- a/dashboard/frontend/src/components/ClawRoomChat.module.css
+++ b/dashboard/frontend/src/components/ClawRoomChat.module.css
@@ -446,6 +446,14 @@
   line-height: 1;
 }
 
+.wsFallback {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+  color: #fbbf24;
+  line-height: 1;
+}
+
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.6; }
@@ -1185,6 +1193,31 @@
   background: rgba(255, 255, 255, 0.05);
   border-radius: 1.1rem;
   padding: 0.72rem 0.9rem;
+}
+
+.messageBubbleStreaming {
+  opacity: 0.94;
+}
+
+.streamingCursor {
+  display: inline-block;
+  width: 0.45rem;
+  height: 1rem;
+  margin-left: 0.15rem;
+  vertical-align: text-bottom;
+  background: rgba(255, 255, 255, 0.72);
+  animation: clawRoomStreamingBlink 1s step-end infinite;
+}
+
+@keyframes clawRoomStreamingBlink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
 }
 
 .messageMarkdown {

--- a/dashboard/frontend/src/components/ClawRoomChat.tsx
+++ b/dashboard/frontend/src/components/ClawRoomChat.tsx
@@ -9,16 +9,16 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from 'react'
-import MarkdownRenderer from './MarkdownRenderer'
 import styles from './ClawRoomChat.module.css'
 import { useReadonly } from '../contexts/ReadonlyContext'
 import ClawRoomSidebar from './ClawRoomSidebar'
-import ClawRoomMessageMeta from './ClawRoomMessageMeta'
+import ClawRoomTranscript from './ClawRoomTranscript'
+import ClawRoomTransportStatus from './ClawRoomTransportStatus'
+import { buildStreamingEntries } from './clawRoomStreamingUi'
 import {
   compareByCreatedAt,
   compareByName,
   findMentionRange,
-  formatMessageTime,
   type MentionAutocompleteState,
   type MentionOption,
   parseJSON,
@@ -299,6 +299,8 @@ const ClawRoomChat = ({
 
   const {
     streamingMessages,
+    streamingParticipants,
+    transportMode,
     wsConnected,
     wsRef,
   } = useClawRoomTransport({
@@ -308,7 +310,11 @@ const ClawRoomChat = ({
     setError,
     upsertMessage,
   })
-  void streamingMessages
+
+  const streamingEntries = useMemo(
+    () => buildStreamingEntries(messages, streamingMessages),
+    [messages, streamingMessages]
+  )
 
   useEffect(() => {
     let mounted = true
@@ -369,7 +375,7 @@ const ClawRoomChat = ({
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+  }, [messages, streamingEntries])
 
   useEffect(() => {
     if (!selectedRoomId) {
@@ -707,57 +713,20 @@ const ClawRoomChat = ({
             <div className={styles.chatTitleWrap}>
               <h3 className={styles.chatTitle}>{selectedRoom?.name || selectedTeam?.name || 'No room selected'}</h3>
               {selectedRoomId && (
-                <span
-                  className={`${styles.chatTitleStatus} ${wsConnected ? styles.wsConnected : styles.wsDisconnected}`}
-                  title={wsConnected ? 'WebSocket connected' : 'WebSocket disconnected (using fallback)'}
-                >
-                  {wsConnected ? '● Live' : '○ Reconnecting...'}
-                </span>
+                <ClawRoomTransportStatus transportMode={transportMode} wsConnected={wsConnected} />
               )}
             </div>
           </header>
 
           <div className={styles.messages} data-testid="claw-room-transcript">
-            {!selectedRoomId ? (
-              <div className={styles.stateHint}>Select a room from the left panel.</div>
-            ) : messages.length === 0 ? (
-              <div className={styles.stateHint}>No messages yet. Start the conversation.</div>
-            ) : (
-              messages.map(message => {
-                const isUser = message.senderType === 'user'
-                const isSystem = message.senderType === 'system'
-                const isLeader = message.senderType === 'leader'
-                const isWorker = message.senderType === 'worker'
-                const senderVisual = resolveSenderVisual(message)
-                return (
-                  <div
-                    key={message.id}
-                    className={`${styles.messageRow} ${isUser ? styles.messageRowUser : styles.messageRowAgent}`}
-                    data-room-message-id={message.id}
-                    data-room-message-role={message.senderType}
-                  >
-                    <div className={styles.messageMain}>
-                      <ClawRoomMessageMeta
-                        displayName={senderVisual.displayName}
-                        isLeader={isLeader}
-                        isUser={isUser}
-                        isWorker={isWorker}
-                        roleLabel={senderVisual.roleLabel}
-                        timestamp={formatMessageTime(message.createdAt)}
-                      />
-                      <div
-                        className={`${styles.messageBubble} ${isUser ? styles.messageBubbleUser : styles.messageBubbleAgent} ${isSystem ? styles.messageBubbleSystem : ''}`}
-                        data-room-message-content
-                      >
-                        <div className={styles.messageMarkdown}>
-                          <MarkdownRenderer content={message.content} />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )
-              })
-            )}
+            <ClawRoomTranscript
+              messages={messages}
+              resolveSenderVisual={resolveSenderVisual}
+              selectedRoomId={selectedRoomId}
+              streamingEntries={streamingEntries}
+              streamingMessages={streamingMessages}
+              streamingParticipants={streamingParticipants}
+            />
             <div ref={endRef} />
           </div>
 

--- a/dashboard/frontend/src/components/ClawRoomTranscript.tsx
+++ b/dashboard/frontend/src/components/ClawRoomTranscript.tsx
@@ -1,0 +1,123 @@
+import MarkdownRenderer from './MarkdownRenderer'
+import ClawRoomMessageMeta from './ClawRoomMessageMeta'
+import styles from './ClawRoomChat.module.css'
+import {
+  formatMessageTime,
+  type RoomMessage,
+  type StreamingParticipant,
+} from './clawRoomChatSupport'
+import { resolveStreamingParticipantDisplay } from './clawRoomStreamingUi'
+
+interface SenderVisual {
+  displayName: string
+  roleLabel: string
+}
+
+interface ClawRoomTranscriptProps {
+  selectedRoomId: string
+  messages: RoomMessage[]
+  streamingMessages: Map<string, string>
+  streamingParticipants: Map<string, StreamingParticipant>
+  streamingEntries: Array<[string, string]>
+  resolveSenderVisual: (message: RoomMessage) => SenderVisual
+}
+
+const ClawRoomTranscript = ({
+  selectedRoomId,
+  messages,
+  streamingMessages,
+  streamingParticipants,
+  streamingEntries,
+  resolveSenderVisual,
+}: ClawRoomTranscriptProps) => {
+  if (!selectedRoomId) {
+    return <div className={styles.stateHint}>Select a room from the left panel.</div>
+  }
+
+  if (messages.length === 0 && streamingEntries.length === 0) {
+    return <div className={styles.stateHint}>No messages yet. Start the conversation.</div>
+  }
+
+  return (
+    <>
+      {messages.map(message => {
+        const isUser = message.senderType === 'user'
+        const isSystem = message.senderType === 'system'
+        const isLeader = message.senderType === 'leader'
+        const isWorker = message.senderType === 'worker'
+        const senderVisual = resolveSenderVisual(message)
+        const streamingContent = streamingMessages.get(message.id)
+        const displayContent = streamingContent && streamingContent !== message.content
+          ? streamingContent
+          : message.content
+        const isStreaming = Boolean(streamingContent && streamingContent !== message.content)
+        return (
+          <div
+            key={message.id}
+            className={`${styles.messageRow} ${isUser ? styles.messageRowUser : styles.messageRowAgent}`}
+            data-room-message-id={message.id}
+            data-room-message-role={message.senderType}
+            data-room-message-streaming={isStreaming ? 'true' : 'false'}
+          >
+            <div className={styles.messageMain}>
+              <ClawRoomMessageMeta
+                displayName={senderVisual.displayName}
+                isLeader={isLeader}
+                isUser={isUser}
+                isWorker={isWorker}
+                roleLabel={senderVisual.roleLabel}
+                timestamp={formatMessageTime(message.createdAt)}
+              />
+              <div
+                className={`${styles.messageBubble} ${isUser ? styles.messageBubbleUser : styles.messageBubbleAgent} ${isSystem ? styles.messageBubbleSystem : ''} ${isStreaming ? styles.messageBubbleStreaming : ''}`}
+                data-room-message-content
+              >
+                <div className={styles.messageMarkdown}>
+                  <MarkdownRenderer content={displayContent} />
+                  {isStreaming && <span className={styles.streamingCursor} aria-hidden="true" />}
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+      {streamingEntries.map(([messageId, content]) => {
+        const { participantType, displayName, isLeader, isWorker } = resolveStreamingParticipantDisplay(
+          messageId,
+          streamingParticipants
+        )
+        return (
+          <div
+            key={`streaming-${messageId}`}
+            className={`${styles.messageRow} ${styles.messageRowAgent}`}
+            data-room-message-id={messageId}
+            data-room-message-role={participantType}
+            data-room-message-streaming="true"
+          >
+            <div className={styles.messageMain}>
+              <ClawRoomMessageMeta
+                displayName={displayName}
+                isLeader={isLeader}
+                isUser={false}
+                isWorker={isWorker}
+                roleLabel={isLeader ? 'LEADER' : 'WORKER'}
+                timestamp="..."
+              />
+              <div
+                className={`${styles.messageBubble} ${styles.messageBubbleAgent} ${styles.messageBubbleStreaming}`}
+                data-room-message-content
+              >
+                <div className={styles.messageMarkdown}>
+                  <MarkdownRenderer content={content} />
+                  <span className={styles.streamingCursor} aria-hidden="true" />
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export default ClawRoomTranscript

--- a/dashboard/frontend/src/components/ClawRoomTransportStatus.tsx
+++ b/dashboard/frontend/src/components/ClawRoomTransportStatus.tsx
@@ -1,0 +1,35 @@
+import styles from './ClawRoomChat.module.css'
+import type { RoomTransportMode } from './clawRoomChatSupport'
+import {
+  resolveTransportStatusClassName,
+  resolveTransportStatusLabel,
+  resolveTransportStatusTitle,
+} from './clawRoomStreamingUi'
+
+interface ClawRoomTransportStatusProps {
+  transportMode: RoomTransportMode
+  wsConnected: boolean
+}
+
+const ClawRoomTransportStatus = ({ transportMode, wsConnected }: ClawRoomTransportStatusProps) => {
+  const label = resolveTransportStatusLabel(transportMode, wsConnected)
+  const className = resolveTransportStatusClassName(transportMode, wsConnected, {
+    wsConnected: styles.wsConnected,
+    wsFallback: styles.wsFallback,
+    wsDisconnected: styles.wsDisconnected,
+  })
+  const title = resolveTransportStatusTitle(transportMode, wsConnected)
+  const icon = transportMode === 'websocket' && wsConnected ? '●' : transportMode === 'sse' ? '◐' : '○'
+
+  return (
+    <span
+      className={`${styles.chatTitleStatus} ${className}`}
+      title={title}
+      data-testid="claw-room-transport-status"
+    >
+      {icon} {label}
+    </span>
+  )
+}
+
+export default ClawRoomTransportStatus

--- a/dashboard/frontend/src/components/clawRoomChatSupport.collaboration.test.ts
+++ b/dashboard/frontend/src/components/clawRoomChatSupport.collaboration.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyCollaborationOutboundEvent,
+  applyRoomStreamEvent,
+  type RoomMessage,
+} from './clawRoomChatSupport'
+
+const baseMessage: RoomMessage = {
+  id: 'msg-1',
+  roomId: 'room-alpha',
+  teamId: 'team-alpha',
+  senderType: 'worker',
+  senderName: 'worker-a',
+  content: 'final',
+  createdAt: '2026-05-31T00:00:00Z',
+}
+
+describe('clawRoomChatSupport collaboration events', () => {
+  it('accumulates message chunks and clears on message_updated', () => {
+    let streaming = new Map<string, string>()
+    const state: { persisted: RoomMessage | null } = { persisted: null }
+
+    const handlers = {
+      upsertMessage: (message: RoomMessage) => {
+        state.persisted = message
+      },
+      setStreamingMessages: (update: (previous: Map<string, string>) => Map<string, string>) => {
+        streaming = update(streaming)
+      },
+    }
+
+    applyCollaborationOutboundEvent(
+      { type: 'message_chunk', messageId: 'stream-1', chunk: 'hel' },
+      handlers
+    )
+    applyCollaborationOutboundEvent(
+      { type: 'message_chunk', messageId: 'stream-1', chunk: 'lo' },
+      handlers
+    )
+
+    expect(streaming.get('stream-1')).toBe('hello')
+
+    applyCollaborationOutboundEvent(
+      { type: 'message_updated', message: { ...baseMessage, id: 'stream-1', content: 'hello' } },
+      handlers
+    )
+
+    expect(state.persisted?.content).toBe('hello')
+    expect(streaming.has('stream-1')).toBe(false)
+  })
+
+  it('maps SSE message events to new_message semantics', () => {
+    const state: { persisted: RoomMessage | null } = { persisted: null }
+
+    applyRoomStreamEvent(
+      {
+        type: 'message',
+        roomId: 'room-alpha',
+        message: baseMessage,
+      },
+      {
+        upsertMessage: (message: RoomMessage) => {
+          state.persisted = message
+        },
+        setStreamingMessages: update => update(new Map()),
+      }
+    )
+
+    expect(state.persisted?.id).toBe('msg-1')
+  })
+})

--- a/dashboard/frontend/src/components/clawRoomChatSupport.ts
+++ b/dashboard/frontend/src/components/clawRoomChatSupport.ts
@@ -44,7 +44,24 @@ export interface RoomStreamEvent {
   type: string
   roomId: string
   message?: RoomMessage
+  messageId?: string
+  chunk?: string
 }
+
+export interface StreamingParticipant {
+  participantType?: string
+  participantId?: string
+}
+
+export const ROOM_COLLABORATION_OUTBOUND_TYPES = {
+  connected: 'connected',
+  newMessage: 'new_message',
+  messageChunk: 'message_chunk',
+  messageUpdated: 'message_updated',
+  error: 'error',
+} as const
+
+export type RoomTransportMode = 'connecting' | 'websocket' | 'sse'
 
 export interface WSInboundMessage {
   type: 'send_message' | 'ping'
@@ -63,6 +80,106 @@ export interface WSOutboundMessage {
   status?: string
   error?: string
   timestamp?: string
+  participantType?: string
+  participantId?: string
+  sessionUser?: string
+}
+
+export interface CollaborationEventHandlers {
+  upsertMessage: (message: RoomMessage) => void
+  setStreamingMessages: (update: (previous: Map<string, string>) => Map<string, string>) => void
+  setStreamingParticipants?: (
+    update: (previous: Map<string, StreamingParticipant>) => Map<string, StreamingParticipant>
+  ) => void
+  setError?: (error: string) => void
+}
+
+export const applyCollaborationOutboundEvent = (
+  payload: WSOutboundMessage,
+  handlers: CollaborationEventHandlers
+): void => {
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.newMessage && payload.message) {
+    handlers.upsertMessage(payload.message)
+    if (payload.message.id) {
+      handlers.setStreamingMessages(previous => {
+        const next = new Map(previous)
+        next.delete(payload.message!.id)
+        return next
+      })
+      handlers.setStreamingParticipants?.(previous => {
+        const next = new Map(previous)
+        next.delete(payload.message!.id)
+        return next
+      })
+    }
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.messageUpdated && payload.message) {
+    handlers.upsertMessage(payload.message)
+    handlers.setStreamingMessages(previous => {
+      const next = new Map(previous)
+      next.delete(payload.message!.id)
+      return next
+    })
+    handlers.setStreamingParticipants?.(previous => {
+      const next = new Map(previous)
+      next.delete(payload.message!.id)
+      return next
+    })
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.messageChunk && payload.messageId) {
+    if (payload.chunk) {
+      handlers.setStreamingMessages(previous => {
+        const next = new Map(previous)
+        const existing = next.get(payload.messageId!) || ''
+        next.set(payload.messageId!, existing + payload.chunk)
+        return next
+      })
+    }
+    if (payload.participantType || payload.participantId) {
+      handlers.setStreamingParticipants?.(previous => {
+        const next = new Map(previous)
+        next.set(payload.messageId!, {
+          participantType: payload.participantType,
+          participantId: payload.participantId,
+        })
+        return next
+      })
+    }
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.error && payload.error) {
+    handlers.setError?.(payload.error)
+  }
+}
+
+export const applyRoomStreamEvent = (
+  payload: RoomStreamEvent,
+  handlers: CollaborationEventHandlers
+): void => {
+  if (payload.type === 'message' && payload.message) {
+    applyCollaborationOutboundEvent(
+      { type: ROOM_COLLABORATION_OUTBOUND_TYPES.newMessage, message: payload.message },
+      handlers
+    )
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.messageUpdated && payload.message) {
+    applyCollaborationOutboundEvent(
+      { type: ROOM_COLLABORATION_OUTBOUND_TYPES.messageUpdated, message: payload.message },
+      handlers
+    )
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.newMessage && payload.message) {
+    applyCollaborationOutboundEvent(payload, handlers)
+  }
 }
 
 export interface MentionOption {

--- a/dashboard/frontend/src/components/clawRoomStreamingUi.ts
+++ b/dashboard/frontend/src/components/clawRoomStreamingUi.ts
@@ -1,0 +1,70 @@
+import type { RoomMessage, RoomTransportMode, StreamingParticipant } from './clawRoomChatSupport'
+
+export const buildStreamingEntries = (
+  messages: RoomMessage[],
+  streamingMessages: Map<string, string>
+): Array<[string, string]> => {
+  return Array.from(streamingMessages.entries()).filter(([messageId, content]) => {
+    if (!content.trim()) {
+      return false
+    }
+    const persisted = messages.find(message => message.id === messageId)
+    return !persisted || persisted.content !== content
+  })
+}
+
+export const resolveTransportStatusLabel = (
+  transportMode: RoomTransportMode,
+  wsConnected: boolean
+): string => {
+  if (transportMode === 'websocket' && wsConnected) {
+    return 'Live'
+  }
+  if (transportMode === 'sse') {
+    return 'SSE'
+  }
+  return 'Reconnecting...'
+}
+
+export const resolveTransportStatusClassName = (
+  transportMode: RoomTransportMode,
+  wsConnected: boolean,
+  styles: {
+    wsConnected: string
+    wsFallback: string
+    wsDisconnected: string
+  }
+): string => {
+  if (transportMode === 'websocket' && wsConnected) {
+    return styles.wsConnected
+  }
+  if (transportMode === 'sse') {
+    return styles.wsFallback
+  }
+  return styles.wsDisconnected
+}
+
+export const resolveTransportStatusTitle = (
+  transportMode: RoomTransportMode,
+  wsConnected: boolean
+): string => {
+  if (transportMode === 'websocket' && wsConnected) {
+    return 'WebSocket connected'
+  }
+  if (transportMode === 'sse') {
+    return 'WebSocket disconnected (SSE fallback active)'
+  }
+  return 'Reconnecting transport'
+}
+
+export const resolveStreamingParticipantDisplay = (
+  messageId: string,
+  streamingParticipants: Map<string, StreamingParticipant>
+): { participantType: string; displayName: string; isLeader: boolean; isWorker: boolean } => {
+  const participant = streamingParticipants.get(messageId)
+  const participantType = participant?.participantType || 'worker'
+  const isLeader = participantType === 'leader'
+  const isWorker = participantType === 'worker'
+  const displayName = participant?.participantId || (isLeader ? 'Leader' : 'Worker')
+  return { participantType, displayName, isLeader, isWorker }
+}

--- a/dashboard/frontend/src/components/openclawRoomBridge.test.ts
+++ b/dashboard/frontend/src/components/openclawRoomBridge.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildRoomBridgeEnvelope,
+  CLAWOS_ROOM_BRIDGE_SOURCE,
+  isRoomBridgeEnvelope,
+  postRoomEventToFrame,
+} from './openclawRoomBridge'
+
+describe('openclawRoomBridge', () => {
+  it('recognizes valid bridge envelopes', () => {
+    const envelope = buildRoomBridgeEnvelope('room_event', 'room-alpha', {
+      event: { type: 'new_message', message: { id: 'm1' } as never },
+    })
+    expect(isRoomBridgeEnvelope(envelope)).toBe(true)
+    expect(isRoomBridgeEnvelope({ source: 'other', type: 'room_event', roomId: 'room-alpha' })).toBe(false)
+  })
+
+  it('builds parent to iframe room_event payloads', () => {
+    const envelope = buildRoomBridgeEnvelope('room_event', 'room-alpha', {
+      event: {
+        type: 'message_chunk',
+        messageId: 'stream-1',
+        chunk: 'hello',
+      },
+    })
+
+    expect(envelope).toEqual({
+      source: CLAWOS_ROOM_BRIDGE_SOURCE,
+      type: 'room_event',
+      roomId: 'room-alpha',
+      event: {
+        type: 'message_chunk',
+        messageId: 'stream-1',
+        chunk: 'hello',
+      },
+    })
+  })
+
+  it('posts room events to iframe contentWindow', () => {
+    const postMessage = vi.fn()
+    const iframe = {
+      contentWindow: { postMessage },
+    } as unknown as HTMLIFrameElement
+
+    postRoomEventToFrame(iframe, 'room-alpha', {
+      type: 'new_message',
+      message: {
+        id: 'msg-1',
+        roomId: 'room-alpha',
+        teamId: 'team-alpha',
+        senderType: 'worker',
+        senderName: 'worker-a',
+        content: 'done',
+        createdAt: '2026-05-31T00:00:00Z',
+      },
+    })
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: CLAWOS_ROOM_BRIDGE_SOURCE,
+        type: 'room_event',
+        roomId: 'room-alpha',
+      }),
+      '*'
+    )
+  })
+
+  it('builds iframe to parent surface_event payloads', () => {
+    const envelope = buildRoomBridgeEnvelope('surface_event', 'room-alpha', {
+      payload: { kind: 'status', value: 'running' },
+    })
+
+    expect(envelope).toEqual({
+      source: CLAWOS_ROOM_BRIDGE_SOURCE,
+      type: 'surface_event',
+      roomId: 'room-alpha',
+      payload: { kind: 'status', value: 'running' },
+    })
+  })
+})

--- a/dashboard/frontend/src/components/openclawRoomBridge.ts
+++ b/dashboard/frontend/src/components/openclawRoomBridge.ts
@@ -1,0 +1,100 @@
+import type { WSOutboundMessage } from './clawRoomChatSupport'
+
+export const CLAWOS_ROOM_BRIDGE_SOURCE = 'clawos-room-bridge'
+
+export type RoomBridgeMessageType = 'room_event' | 'surface_event' | 'room_context'
+
+export interface RoomBridgeEnvelope {
+  source: typeof CLAWOS_ROOM_BRIDGE_SOURCE
+  type: RoomBridgeMessageType
+  roomId: string
+  event?: WSOutboundMessage
+  payload?: Record<string, unknown>
+}
+
+export type RoomEventListener = (event: WSOutboundMessage) => void
+export type SurfaceEventListener = (roomId: string, payload: Record<string, unknown>) => void
+
+export const isRoomBridgeEnvelope = (data: unknown): data is RoomBridgeEnvelope => {
+  if (!data || typeof data !== 'object') {
+    return false
+  }
+  const candidate = data as Partial<RoomBridgeEnvelope>
+  return candidate.source === CLAWOS_ROOM_BRIDGE_SOURCE
+    && typeof candidate.type === 'string'
+    && typeof candidate.roomId === 'string'
+}
+
+export const buildRoomBridgeEnvelope = (
+  type: RoomBridgeMessageType,
+  roomId: string,
+  details: Pick<RoomBridgeEnvelope, 'event' | 'payload'> = {}
+): RoomBridgeEnvelope => ({
+  source: CLAWOS_ROOM_BRIDGE_SOURCE,
+  type,
+  roomId,
+  ...details,
+})
+
+export const postRoomEventToFrame = (
+  iframe: HTMLIFrameElement,
+  roomId: string,
+  event: WSOutboundMessage
+): void => {
+  const target = iframe.contentWindow
+  if (!target) {
+    return
+  }
+  target.postMessage(buildRoomBridgeEnvelope('room_event', roomId, { event }), '*')
+}
+
+export const postRoomContextToFrame = (iframe: HTMLIFrameElement, roomId: string): void => {
+  const target = iframe.contentWindow
+  if (!target) {
+    return
+  }
+  target.postMessage(buildRoomBridgeEnvelope('room_context', roomId), '*')
+}
+
+export const publishSurfaceEvent = (roomId: string, payload: Record<string, unknown>): void => {
+  window.parent.postMessage(buildRoomBridgeEnvelope('surface_event', roomId, { payload }), '*')
+}
+
+export const subscribeRoomEvents = (roomId: string, onEvent: RoomEventListener): (() => void) => {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const wsUrl = `${protocol}//${window.location.host}/api/openclaw/rooms/${encodeURIComponent(roomId)}/ws`
+  const ws = new WebSocket(wsUrl)
+
+  ws.onmessage = event => {
+    try {
+      const payload = JSON.parse(event.data) as WSOutboundMessage
+      onEvent(payload)
+    } catch {
+      // ignore malformed messages
+    }
+  }
+
+  return () => {
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+      ws.close()
+    }
+  }
+}
+
+export const listenForSurfaceEvents = (
+  roomId: string,
+  onSurfaceEvent: SurfaceEventListener
+): (() => void) => {
+  const handleMessage = (event: MessageEvent) => {
+    if (!isRoomBridgeEnvelope(event.data) || event.data.type !== 'surface_event') {
+      return
+    }
+    if (event.data.roomId !== roomId) {
+      return
+    }
+    onSurfaceEvent(roomId, event.data.payload || {})
+  }
+
+  window.addEventListener('message', handleMessage)
+  return () => window.removeEventListener('message', handleMessage)
+}

--- a/dashboard/frontend/src/components/useClawRoomTransport.ts
+++ b/dashboard/frontend/src/components/useClawRoomTransport.ts
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import {
+  applyCollaborationOutboundEvent,
+  applyRoomStreamEvent,
   type RoomMessage,
   type RoomStreamEvent,
+  type RoomTransportMode,
+  type StreamingParticipant,
   type WSOutboundMessage,
 } from './clawRoomChatSupport'
 
@@ -11,6 +15,7 @@ interface UseClawRoomTransportParams {
   setMessages: Dispatch<SetStateAction<RoomMessage[]>>
   setError: Dispatch<SetStateAction<string | null>>
   upsertMessage: (message: RoomMessage) => void
+  onRoomEvent?: (event: WSOutboundMessage) => void
 }
 
 export const useClawRoomTransport = ({
@@ -19,20 +24,32 @@ export const useClawRoomTransport = ({
   setMessages,
   setError,
   upsertMessage,
+  onRoomEvent,
 }: UseClawRoomTransportParams) => {
   const wsRef = useRef<WebSocket | null>(null)
   const sourceRef = useRef<EventSource | null>(null)
   const reconnectTimerRef = useRef<number | null>(null)
   const reconnectAttemptsRef = useRef(0)
   const heartbeatTimerRef = useRef<number | null>(null)
+  const onRoomEventRef = useRef(onRoomEvent)
   const [wsConnected, setWsConnected] = useState(false)
+  const [transportMode, setTransportMode] = useState<RoomTransportMode>('connecting')
   const [streamingMessages, setStreamingMessages] = useState<Map<string, string>>(new Map())
+  const [streamingParticipants, setStreamingParticipants] = useState<Map<string, StreamingParticipant>>(
+    new Map()
+  )
+
+  useEffect(() => {
+    onRoomEventRef.current = onRoomEvent
+  }, [onRoomEvent])
 
   useEffect(() => {
     if (!selectedRoomId) {
       setMessages([])
       setWsConnected(false)
+      setTransportMode('connecting')
       setStreamingMessages(new Map())
+      setStreamingParticipants(new Map())
       if (wsRef.current) {
         wsRef.current.close()
         wsRef.current = null
@@ -55,6 +72,25 @@ export const useClawRoomTransport = ({
 
     let mounted = true
 
+    const collaborationHandlers = {
+      upsertMessage,
+      setStreamingMessages,
+      setStreamingParticipants,
+      setError: (message: string) => setError(message),
+    }
+
+    const handleOutboundEvent = (payload: WSOutboundMessage) => {
+      applyCollaborationOutboundEvent(payload, collaborationHandlers)
+      onRoomEventRef.current?.(payload)
+    }
+
+    const closeSSE = () => {
+      if (sourceRef.current) {
+        sourceRef.current.close()
+        sourceRef.current = null
+      }
+    }
+
     const loadMessages = async () => {
       try {
         await fetchMessages(selectedRoomId)
@@ -68,100 +104,10 @@ export const useClawRoomTransport = ({
       }
     }
 
-    const connectWebSocket = () => {
-      if (!mounted) return
-
-      if (wsRef.current) {
-        wsRef.current.close()
-      }
-      if (sourceRef.current) {
-        sourceRef.current.close()
-        sourceRef.current = null
-      }
-      if (heartbeatTimerRef.current !== null) {
-        window.clearInterval(heartbeatTimerRef.current)
-        heartbeatTimerRef.current = null
-      }
-
-      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-      const wsUrl = `${protocol}//${window.location.host}/api/openclaw/rooms/${encodeURIComponent(selectedRoomId)}/ws`
-      const ws = new WebSocket(wsUrl)
-      wsRef.current = ws
-
-      ws.onopen = () => {
-        if (!mounted) return
-        console.log('WebSocket connected to room:', selectedRoomId)
-        setWsConnected(true)
-        reconnectAttemptsRef.current = 0
-        heartbeatTimerRef.current = window.setInterval(() => {
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.send(JSON.stringify({ type: 'ping' }))
-          }
-        }, 30000)
-      }
-
-      ws.onmessage = event => {
-        try {
-          const payload = JSON.parse(event.data) as WSOutboundMessage
-          if (payload.type === 'new_message' && payload.message) {
-            upsertMessage(payload.message)
-            if (payload.message.id) {
-              setStreamingMessages(previous => {
-                const next = new Map(previous)
-                next.delete(payload.message!.id)
-                return next
-              })
-            }
-          } else if (payload.type === 'message_chunk' && payload.messageId) {
-            if (payload.chunk) {
-              setStreamingMessages(previous => {
-                const next = new Map(previous)
-                const existing = next.get(payload.messageId!) || ''
-                next.set(payload.messageId!, existing + payload.chunk)
-                return next
-              })
-            }
-          } else if (payload.type === 'error' && payload.error) {
-            console.error('WebSocket error from server:', payload.error)
-            setError(payload.error)
-          }
-        } catch {
-          // ignore malformed messages
-        }
-      }
-
-      ws.onerror = event => {
-        console.error('WebSocket error:', event)
-        setWsConnected(false)
-      }
-
-      ws.onclose = event => {
-        if (!mounted) return
-        console.log('WebSocket closed:', event.code, event.reason)
-        setWsConnected(false)
-        if (heartbeatTimerRef.current !== null) {
-          window.clearInterval(heartbeatTimerRef.current)
-          heartbeatTimerRef.current = null
-        }
-        if (reconnectTimerRef.current !== null) {
-          window.clearTimeout(reconnectTimerRef.current)
-        }
-        const baseDelay = 1000
-        const maxDelay = 30000
-        const delay = Math.min(baseDelay * Math.pow(2, reconnectAttemptsRef.current), maxDelay)
-        reconnectAttemptsRef.current += 1
-        console.log(`WebSocket reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current})`)
-        reconnectTimerRef.current = window.setTimeout(() => {
-          if (mounted) {
-            connectWebSocket()
-          }
-        }, delay)
-      }
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const connectSSE = () => {
-      if (!mounted || wsRef.current?.readyState === WebSocket.OPEN) return
+      if (!mounted || wsRef.current?.readyState === WebSocket.OPEN) {
+        return
+      }
 
       if (sourceRef.current) {
         sourceRef.current.close()
@@ -173,21 +119,124 @@ export const useClawRoomTransport = ({
       source.addEventListener('message', ((event: MessageEvent<string>) => {
         try {
           const payload = JSON.parse(event.data) as RoomStreamEvent
+          applyRoomStreamEvent(payload, collaborationHandlers)
           if (payload.message) {
-            upsertMessage(payload.message)
+            onRoomEventRef.current?.({
+              type: payload.type === 'message' ? 'new_message' : payload.type,
+              roomId: payload.roomId,
+              message: payload.message,
+            })
           }
         } catch {
           // ignore malformed stream events
         }
       }) as EventListener)
 
+      source.addEventListener('message_updated', ((event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as RoomStreamEvent
+          applyRoomStreamEvent(payload, collaborationHandlers)
+          if (payload.message) {
+            onRoomEventRef.current?.({
+              type: 'message_updated',
+              roomId: payload.roomId,
+              message: payload.message,
+            })
+          }
+        } catch {
+          // ignore malformed stream events
+        }
+      }) as EventListener)
+
+      source.onopen = () => {
+        if (!mounted) return
+        if (wsRef.current?.readyState !== WebSocket.OPEN) {
+          setTransportMode('sse')
+          setWsConnected(false)
+        }
+      }
+
       source.onerror = () => {
         source.close()
         if (!mounted) return
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          return
+        }
+        setTransportMode('connecting')
         if (reconnectTimerRef.current !== null) {
           window.clearTimeout(reconnectTimerRef.current)
         }
         reconnectTimerRef.current = window.setTimeout(connectSSE, 1500)
+      }
+    }
+
+    const connectWebSocket = () => {
+      if (!mounted) return
+
+      if (wsRef.current) {
+        wsRef.current.close()
+      }
+      closeSSE()
+      if (heartbeatTimerRef.current !== null) {
+        window.clearInterval(heartbeatTimerRef.current)
+        heartbeatTimerRef.current = null
+      }
+
+      setTransportMode('connecting')
+
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const wsUrl = `${protocol}//${window.location.host}/api/openclaw/rooms/${encodeURIComponent(selectedRoomId)}/ws`
+      const ws = new WebSocket(wsUrl)
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        if (!mounted) return
+        setWsConnected(true)
+        setTransportMode('websocket')
+        reconnectAttemptsRef.current = 0
+        closeSSE()
+        heartbeatTimerRef.current = window.setInterval(() => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'ping' }))
+          }
+        }, 30000)
+      }
+
+      ws.onmessage = event => {
+        try {
+          const payload = JSON.parse(event.data) as WSOutboundMessage
+          handleOutboundEvent(payload)
+        } catch {
+          // ignore malformed messages
+        }
+      }
+
+      ws.onerror = () => {
+        setWsConnected(false)
+      }
+
+      ws.onclose = () => {
+        if (!mounted) return
+        setWsConnected(false)
+        if (heartbeatTimerRef.current !== null) {
+          window.clearInterval(heartbeatTimerRef.current)
+          heartbeatTimerRef.current = null
+        }
+        if (reconnectTimerRef.current !== null) {
+          window.clearTimeout(reconnectTimerRef.current)
+        }
+
+        connectSSE()
+
+        const baseDelay = 1000
+        const maxDelay = 30000
+        const delay = Math.min(baseDelay * Math.pow(2, reconnectAttemptsRef.current), maxDelay)
+        reconnectAttemptsRef.current += 1
+        reconnectTimerRef.current = window.setTimeout(() => {
+          if (mounted) {
+            connectWebSocket()
+          }
+        }, delay)
       }
     }
 
@@ -197,15 +246,13 @@ export const useClawRoomTransport = ({
     return () => {
       mounted = false
       setWsConnected(false)
+      setTransportMode('connecting')
       reconnectAttemptsRef.current = 0
       if (wsRef.current) {
         wsRef.current.close()
         wsRef.current = null
       }
-      if (sourceRef.current) {
-        sourceRef.current.close()
-        sourceRef.current = null
-      }
+      closeSSE()
       if (reconnectTimerRef.current !== null) {
         window.clearTimeout(reconnectTimerRef.current)
         reconnectTimerRef.current = null
@@ -219,6 +266,8 @@ export const useClawRoomTransport = ({
 
   return {
     streamingMessages,
+    streamingParticipants,
+    transportMode,
     wsConnected,
     wsRef,
   }

--- a/dashboard/frontend/src/pages/OpenClawPage.module.css
+++ b/dashboard/frontend/src/pages/OpenClawPage.module.css
@@ -239,11 +239,33 @@
   border-radius: var(--radius-lg);
   overflow: hidden;
   background: var(--color-bg-secondary);
+  display: flex;
+  flex-direction: column;
+}
+
+.roomBridgePanel {
+  flex-shrink: 0;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  background: rgba(118, 185, 1, 0.08);
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+}
+
+.roomBridgePanelHeader {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 0.2rem;
+}
+
+.roomBridgeMeta,
+.roomBridgeEvent {
+  line-height: 1.35;
 }
 
 .iframe {
   width: 100%;
-  height: 100%;
+  flex: 1;
   min-height: 0;
   border: none;
 }

--- a/dashboard/frontend/src/pages/OpenClawPageTabs.tsx
+++ b/dashboard/frontend/src/pages/OpenClawPageTabs.tsx
@@ -5,6 +5,14 @@ import {
   type OpenClawStatus,
   type TeamProfile,
 } from './OpenClawPageSupport'
+import {
+  listenForSurfaceEvents,
+  postRoomContextToFrame,
+  postRoomEventToFrame,
+  subscribeRoomEvents,
+  type RoomBridgeEnvelope,
+} from '../components/openclawRoomBridge'
+import type { WSOutboundMessage } from '../components/clawRoomChatSupport'
 
 export { ArchitectureTab } from './OpenClawArchitectureTab'
 export { TeamTab } from './OpenClawTeamTab'
@@ -325,7 +333,11 @@ export const StatusTab: React.FC<{
   const [selectedContainer, setSelectedContainer] = useState<string | null>(null)
   const [gatewayToken, setGatewayToken] = useState('')
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const [linkedRoomId, setLinkedRoomId] = useState('')
+  const [roomBridgeEvents, setRoomBridgeEvents] = useState<WSOutboundMessage[]>([])
+  const [surfaceEvents, setSurfaceEvents] = useState<RoomBridgeEnvelope[]>([])
   const iframeContainerRef = useRef<HTMLDivElement | null>(null)
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
   const selected = containers.find(c => c.containerName === selectedContainer)
 
@@ -352,6 +364,86 @@ export const StatusTab: React.FC<{
       setSelectedContainer(null)
     }
   }, [readOnly, selectedContainer])
+
+  useEffect(() => {
+    if (!selected?.teamId) {
+      setLinkedRoomId('')
+      return
+    }
+
+    let cancelled = false
+    const loadRoom = async () => {
+      try {
+        const resp = await fetch(`/api/openclaw/rooms?teamId=${encodeURIComponent(selected.teamId || '')}`)
+        if (!resp.ok) {
+          throw new Error(`Failed to load rooms (${resp.status})`)
+        }
+        const rooms = await resp.json() as Array<{ id?: string }>
+        if (cancelled) {
+          return
+        }
+        setLinkedRoomId(Array.isArray(rooms) && rooms[0]?.id ? rooms[0].id : '')
+      } catch {
+        if (!cancelled) {
+          setLinkedRoomId('')
+        }
+      }
+    }
+
+    void loadRoom()
+    return () => {
+      cancelled = true
+    }
+  }, [selected?.teamId])
+
+  useEffect(() => {
+    if (!linkedRoomId || !selectedContainer || !selected?.healthy) {
+      setRoomBridgeEvents([])
+      return
+    }
+
+    const unsubscribe = subscribeRoomEvents(linkedRoomId, event => {
+      setRoomBridgeEvents(previous => [...previous.slice(-19), event])
+      if (iframeRef.current) {
+        postRoomEventToFrame(iframeRef.current, linkedRoomId, event)
+      }
+    })
+
+    return unsubscribe
+  }, [linkedRoomId, selected?.healthy, selectedContainer])
+
+  useEffect(() => {
+    if (!linkedRoomId || !selectedContainer || !selected?.healthy) {
+      setSurfaceEvents([])
+      return
+    }
+
+    return listenForSurfaceEvents(linkedRoomId, (_roomId, payload) => {
+      setSurfaceEvents(previous => [
+        ...previous.slice(-9),
+        {
+          source: 'clawos-room-bridge',
+          type: 'surface_event',
+          roomId: linkedRoomId,
+          payload,
+        },
+      ])
+    })
+  }, [linkedRoomId, selected?.healthy, selectedContainer])
+
+  const latestRoomBridgeEvent = useMemo(() => {
+    const last = roomBridgeEvents[roomBridgeEvents.length - 1]
+    if (!last) {
+      return ''
+    }
+    if (last.message?.content) {
+      return last.message.content
+    }
+    if (last.chunk) {
+      return last.chunk
+    }
+    return last.type
+  }, [roomBridgeEvents])
 
   const handleAction = async (action: 'start' | 'stop', name: string) => {
     if (readOnly) return
@@ -415,7 +507,8 @@ export const StatusTab: React.FC<{
     }
     const proxyBase = `/embedded/openclaw/${encodeURIComponent(selectedContainer)}/`
     const gatewayUrl = `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}${proxyBase}`
-    const iframeSrc = `${proxyBase}#gatewayUrl=${encodeURIComponent(gatewayUrl)}&token=${encodeURIComponent(gatewayToken)}`
+    const roomContext = linkedRoomId ? `&roomId=${encodeURIComponent(linkedRoomId)}` : ''
+    const iframeSrc = `${proxyBase}#gatewayUrl=${encodeURIComponent(gatewayUrl)}&token=${encodeURIComponent(gatewayToken)}${roomContext}`
     const openInNewTab = () => {
       window.open(iframeSrc, '_blank', 'noopener,noreferrer')
     }
@@ -462,12 +555,34 @@ export const StatusTab: React.FC<{
           </button>
         </div>
         <div ref={iframeContainerRef} className={styles.iframeContainer}>
+          {(linkedRoomId || latestRoomBridgeEvent || surfaceEvents.length > 0) && (
+            <div className={styles.roomBridgePanel} data-testid="claw-room-bridge-activity">
+              <div className={styles.roomBridgePanelHeader}>Room collaboration</div>
+              {linkedRoomId && (
+                <div className={styles.roomBridgeMeta}>Room: {linkedRoomId}</div>
+              )}
+              {latestRoomBridgeEvent && (
+                <div className={styles.roomBridgeEvent}>Latest: {truncateText(latestRoomBridgeEvent, 120)}</div>
+              )}
+              {surfaceEvents.length > 0 && (
+                <div className={styles.roomBridgeEvent}>
+                  Surface: {truncateText(JSON.stringify(surfaceEvents[surfaceEvents.length - 1].payload || {}), 120)}
+                </div>
+              )}
+            </div>
+          )}
           <iframe
-            key={gatewayToken}
+            ref={iframeRef}
+            key={`${gatewayToken}:${linkedRoomId}`}
             className={styles.iframe}
             src={iframeSrc}
             title={`OpenClaw Control UI — ${selectedContainer}`}
             sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+            onLoad={() => {
+              if (iframeRef.current && linkedRoomId) {
+                postRoomContextToFrame(iframeRef.current, linkedRoomId)
+              }
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Part of https://github.com/vllm-project/semantic-router/issues/1521

**PR2.Wire clients to the bus: streaming chat, offline fallback, embedded page sync**
The ClawRoom chat UI handles WebSocket streaming chunks, shows a typing effect as data arrives, and upserts the final message when message_updated arrives. If the WebSocket drops, the client falls back to SSE with the same event semantics so users still receive new messages. The embedded OpenClaw page in the ClawOS Dashboard uses a postMessage bridge: the parent page subscribes to the same room events and forwards them to the iframe; iframe activity can flow back into the room. New frontend unit tests and E2E cover streaming UI, SSE fallback when WS is blocked, and the embedded page receiving room events.
## Purpose

- What does this PR change?


`useClawRoomTransport.ts `
Handles collaboration WS events, falls back to SSE on disconnect, and exposes streaming plus transport mode state.

`clawRoomChatSupport.ts `
Adds shared collaboration event types and helpers to apply WS/SSE payloads consistently.

`ClawRoomChat.tsx`
 Wires in transport/streaming state and delegates transcript and status rendering to smaller components.

`ClawRoomTranscript.tsx`
Renders persisted messages and in-flight worker stream bubbles in the room transcript.
`ClawRoomTransportStatus.tsx`
 Shows Live, SSE, or Reconnecting status in the room header.

`clawRoomStreamingUi.ts`
Holds helpers for streaming entry filtering and transport or participant display labels.

`ClawRoomChat.module.css`
 Styles streaming bubbles, the typing cursor, and SSE fallback status.

`openclawRoomBridge.ts`
 Implements postMessage bridge protocol and a standalone room WebSocket subscription for embedded UI.

`OpenClawPageTabs.tsx`
Links embedded OpenClaw dashboard to a team room and forwards room events into the iframe.

`OpenClawPage.module.css`
 Styles the room collaboration activity panel above the embedded iframe.

`openclawRoomBridge.test.ts`
 Unit-tests bridge envelope encoding and iframe postMessage forwarding.

`clawRoomChatSupport.collaboration.test.ts`
 Unit-tests chunk accumulation and SSE-to-new_message event mapping.

`claw-room-collaboration.spec.ts`
E2E tests streaming UI, SSE fallback, and parent-to-iframe room event delivery.



- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
