### PR TITLE
[Dashboard] Fail closed when the auth service cannot initialize

### DIFF
--- a/dashboard/backend/auth/middleware.go
+++ b/dashboard/backend/auth/middleware.go
@@ -69,6 +69,28 @@ func AuthenticateRequest(service *Service) func(http.Handler) http.Handler {
 	}
 }
 
+// ServiceUnavailableGuard returns middleware that fails closed when the auth
+// service could not be initialized. It rejects every request to a route that
+// normally requires authentication with 503 Service Unavailable, while still
+// allowing public routes (login/bootstrap endpoints, setup state, embedded
+// assets, and the static frontend) through so the dashboard can render and
+// surface the "authentication service is not configured" state.
+//
+// This is the deny-by-default counterpart to AuthenticateRequest: it shares
+// the same requiresAuthentication policy so the set of protected routes cannot
+// drift between the two paths.
+func ServiceUnavailableGuard() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if requiresAuthentication(r.URL.Path) {
+				http.Error(w, "Authentication service is not configured", http.StatusServiceUnavailable)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func RequiredPermission(method, path string) string {
 	path = strings.TrimSpace(strings.ToLower(path))
 	for _, resolver := range []func(string, string) (string, bool){

--- a/dashboard/backend/auth/middleware_test.go
+++ b/dashboard/backend/auth/middleware_test.go
@@ -38,6 +38,48 @@ func TestRequiresAuthentication(t *testing.T) {
 	}
 }
 
+func TestServiceUnavailableGuard(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		path     string
+		wantCode int
+		wantNext bool
+	}{
+		{name: "protected api denied", path: "/api/router/config", wantCode: http.StatusServiceUnavailable, wantNext: false},
+		{name: "admin denied", path: "/api/admin/users", wantCode: http.StatusServiceUnavailable, wantNext: false},
+		{name: "embedded denied", path: "/embedded/grafana/", wantCode: http.StatusServiceUnavailable, wantNext: false},
+		{name: "login public", path: "/api/auth/login", wantCode: http.StatusOK, wantNext: true},
+		{name: "setup state public", path: "/api/setup/state", wantCode: http.StatusOK, wantNext: true},
+		{name: "static frontend public", path: "/dashboard", wantCode: http.StatusOK, wantNext: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			handler := ServiceUnavailableGuard()(next)
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+			if nextCalled != tc.wantNext {
+				t.Fatalf("next handler called = %v, want %v", nextCalled, tc.wantNext)
+			}
+		})
+	}
+}
+
 func TestExtractAccessToken(t *testing.T) {
 	t.Parallel()
 

--- a/dashboard/backend/router/auth_routes.go
+++ b/dashboard/backend/router/auth_routes.go
@@ -92,6 +92,13 @@ func wrapWithAuth(mux *http.ServeMux, authSvc *auth.Service) *http.ServeMux {
 		wrappedMux.Handle("/", auth.AuthenticateRequest(authSvc)(mux))
 		return wrappedMux
 	}
-	wrappedMux.Handle("/", mux)
+	// authSvc is nil only when the auth store failed to initialize. Fail
+	// closed: deny every route that requires authentication rather than
+	// serving the entire control plane (config deploy/rollback, admin user
+	// management, MCP tooling, proxy) unauthenticated. Public routes and the
+	// static frontend remain reachable so the dashboard can surface the
+	// misconfiguration.
+	log.Printf("WARNING: auth service unavailable; authenticated routes are failing closed (503). Check AuthDBPath/JWT configuration.")
+	wrappedMux.Handle("/", auth.ServiceUnavailableGuard()(mux))
 	return wrappedMux
 }

--- a/dashboard/backend/router/auth_routes_test.go
+++ b/dashboard/backend/router/auth_routes_test.go
@@ -1,0 +1,72 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// When the auth service fails to initialize (authSvc == nil), wrapWithAuth must
+// fail CLOSED: routes that require authentication must be denied with 503 and
+// their backend handlers must never run, while public/static routes stay
+// reachable so the dashboard can surface the misconfiguration. This guards
+// against the fail-open regression where the entire control plane was served
+// unauthenticated whenever the auth store could not be opened.
+func TestWrapWithAuthFailsClosedWhenAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	protectedHit := false
+	publicHit := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/router/config", func(w http.ResponseWriter, _ *http.Request) {
+		protectedHit = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		publicHit = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := wrapWithAuth(mux, nil) // nil => auth store failed to initialize
+
+	t.Run("protected route denied without executing handler", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/router/config", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("protected route status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+		}
+		if protectedHit {
+			t.Fatal("protected handler executed while auth was unavailable (fail-open regression)")
+		}
+	})
+
+	t.Run("public/static route still served", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("public route status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		if !publicHit {
+			t.Fatal("public handler did not run; fail-closed guard over-blocked")
+		}
+	})
+
+	t.Run("protected admin route denied", func(t *testing.T) {
+		mux.HandleFunc("/api/admin/users", func(w http.ResponseWriter, _ *http.Request) {
+			t.Error("admin handler executed while auth was unavailable")
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("admin route status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+		}
+	})
+}


### PR DESCRIPTION
Closes #1992

## Purpose

- **What:** When the dashboard auth store fails to initialize, the backend no longer serves the control plane unauthenticated — it now **fails closed**.
- **Why:** `wrapWithAuth` previously fell back to `wrappedMux.Handle("/", mux)` with no `AuthenticateRequest` wrapper whenever `authSvc == nil`, exposing config deploy/rollback, admin user management, MCP tooling, and the proxy without authentication. `authSvc` is nil whenever `auth.NewStore(cfg.AuthDBPath)` errors (e.g. an unwritable/misconfigured `AuthDBPath`).
- **Module(s):** `Dashboard`.

Changes:

- Add `auth.ServiceUnavailableGuard()` — a deny-by-default counterpart to `AuthenticateRequest` that **reuses the same `requiresAuthentication` policy**, so the protected-route set cannot drift between the two paths. Routes that require auth return `503 Service Unavailable`; public routes (login/bootstrap, `/api/setup/state`, embedded assets, the static frontend) pass through so the UI can still render and surface the misconfiguration.
- `wrapWithAuth` uses the guard on the nil-service path and logs a warning.
- No supported configuration relies on the old behavior — `authSvc` is nil *only* on a real init failure (there is no intentional no-auth mode), so this is not a behavior regression for any valid deployment.

Design note: I chose **fail-closed** over **hard-fail-at-startup** so the static UI and the existing `/api/auth/*` 503 endpoints can still render a clear "authentication service is not configured" message. Happy to switch to `log.Fatal` at startup instead if maintainers prefer.

## Test Plan

```bash
cd dashboard/backend
gofmt -l auth/middleware.go router/auth_routes.go router/auth_routes_test.go auth/middleware_test.go
go vet ./auth/... ./router/...
go test ./auth/... ./router/...
```

New tests:
- `auth.TestServiceUnavailableGuard` — protected/admin/embedded paths → 503 with `next` not called; login/setup-state/static → pass through.
- `router.TestWrapWithAuthFailsClosedWhenAuthUnavailable` — with `authSvc == nil`, protected and admin routes return 503 **without running their handlers**, while public/static routes are still served.

## Test Result

- `gofmt`: clean · `go vet`: clean · `go build ./...`: ok
- `go test ./auth/... ./router/...` → both packages **PASS** (new guard test + regression test pass; existing `TestRequiresAuthentication` / `TestRequiredPermission` / `TestExtractAccessToken` unaffected).
- Follow-up risk: none for valid configs. The guard centralizes policy in `requiresAuthentication`, so any future public-route change applies to both the authenticated and the fail-closed paths automatically.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefix `[Dashboard]`
- [x] Commits in this PR are signed off with `git commit -s` (DCO)
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and results for this change

</details>
