### PR TITLE
[Dashboard] Add built-in routing modes with missing-model completion

### DIFF
--- a/dashboard/backend/handlers/presets.go
+++ b/dashboard/backend/handlers/presets.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type PresetModel struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+type PresetInfo struct {
+	ID       string        `json:"id"`
+	Label    string        `json:"label"`
+	Summary  string        `json:"summary"`
+	Models   []PresetModel `json:"required_models"`
+	RecipeURL string       `json:"recipe_url"`
+}
+
+type PresetDeltaRequest struct {
+	PresetID string   `json:"preset_id"`
+	Models   []string `json:"models"`
+}
+
+type PresetDeltaResponse struct {
+	PresetID         string        `json:"preset_id"`
+	ConfiguredModels []string      `json:"configured_models"`
+	MissingModels    []PresetModel `json:"missing_models"`
+	Ready            bool          `json:"ready"`
+	RecipeURL        string        `json:"recipe_url"`
+}
+
+var builtinPresets = []PresetInfo{
+	{
+		ID:      "balance",
+		Label:   "Balance",
+		Summary: "Default trade-off between cost, quality, and safety across five model tiers.",
+		Models: []PresetModel{
+			{Name: "qwen/qwen3.5-rocm", Role: "simple"},
+			{Name: "google/gemini-2.5-flash-lite", Role: "medium"},
+			{Name: "google/gemini-3.1-pro", Role: "complex"},
+			{Name: "openai/gpt5.4", Role: "reasoning"},
+			{Name: "anthropic/claude-opus-4.6", Role: "premium"},
+		},
+		RecipeURL: "https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/recipes/balance.yaml",
+	},
+	{
+		ID:      "security",
+		Label:   "Security",
+		Summary: "Privacy-first routing that keeps sensitive requests on local models and restricts cloud egress.",
+		Models: []PresetModel{
+			{Name: "local/private-qwen", Role: "local-private"},
+			{Name: "cloud/frontier-reasoning", Role: "cloud-reasoning"},
+		},
+		RecipeURL: "https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/recipes/privacy/privacy-router.yaml",
+	},
+}
+
+func PresetsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		data, err := json.Marshal(builtinPresets)
+		if err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(data); err != nil {
+			log.Printf("presets: write error: %v", err)
+		}
+	}
+}
+
+func PresetDeltaHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req PresetDeltaRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		preset := findPreset(req.PresetID)
+		if preset == nil {
+			http.Error(w, "Unknown preset ID", http.StatusNotFound)
+			return
+		}
+
+		configured, missing := computeModelDelta(preset.Models, req.Models)
+
+		data, err := json.Marshal(PresetDeltaResponse{
+			PresetID:         preset.ID,
+			ConfiguredModels: configured,
+			MissingModels:    missing,
+			Ready:            len(missing) == 0,
+			RecipeURL:        preset.RecipeURL,
+		})
+		if err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(data); err != nil {
+			log.Printf("presets/delta: write error: %v", err)
+		}
+	}
+}
+
+func findPreset(id string) *PresetInfo {
+	for i := range builtinPresets {
+		if builtinPresets[i].ID == id {
+			return &builtinPresets[i]
+		}
+	}
+	return nil
+}
+
+func computeModelDelta(required []PresetModel, userModels []string) (configured []string, missing []PresetModel) {
+	have := make(map[string]bool, len(userModels))
+	for _, m := range userModels {
+		have[strings.ToLower(strings.TrimSpace(m))] = true
+	}
+
+	for _, rm := range required {
+		if have[strings.ToLower(rm.Name)] {
+			configured = append(configured, rm.Name)
+		} else {
+			missing = append(missing, rm)
+		}
+	}
+
+	if configured == nil {
+		configured = []string{}
+	}
+	if missing == nil {
+		missing = []PresetModel{}
+	}
+
+	return configured, missing
+}

--- a/dashboard/backend/handlers/presets.go
+++ b/dashboard/backend/handlers/presets.go
@@ -13,11 +13,11 @@ type PresetModel struct {
 }
 
 type PresetInfo struct {
-	ID       string        `json:"id"`
-	Label    string        `json:"label"`
-	Summary  string        `json:"summary"`
-	Models   []PresetModel `json:"required_models"`
-	RecipeURL string       `json:"recipe_url"`
+	ID        string        `json:"id"`
+	Label     string        `json:"label"`
+	Summary   string        `json:"summary"`
+	Models    []PresetModel `json:"required_models"`
+	RecipeURL string        `json:"recipe_url"`
 }
 
 type PresetDeltaRequest struct {

--- a/dashboard/backend/handlers/presets_test.go
+++ b/dashboard/backend/handlers/presets_test.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPresetsHandler_ReturnsCatalog(t *testing.T) {
+	handler := PresetsHandler()
+	req := httptest.NewRequest(http.MethodGet, "/api/setup/presets", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var presets []PresetInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &presets); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(presets) < 2 {
+		t.Fatalf("expected at least 2 presets, got %d", len(presets))
+	}
+
+	ids := map[string]bool{}
+	for _, p := range presets {
+		ids[p.ID] = true
+		if p.Label == "" {
+			t.Errorf("preset %q has empty label", p.ID)
+		}
+		if p.Summary == "" {
+			t.Errorf("preset %q has empty summary", p.ID)
+		}
+		if len(p.Models) == 0 {
+			t.Errorf("preset %q has no required models", p.ID)
+		}
+		if p.RecipeURL == "" {
+			t.Errorf("preset %q has empty recipe URL", p.ID)
+		}
+	}
+
+	for _, expected := range []string{"balance", "security"} {
+		if !ids[expected] {
+			t.Errorf("missing expected preset %q", expected)
+		}
+	}
+}
+
+func TestPresetsHandler_RejectsNonGet(t *testing.T) {
+	handler := PresetsHandler()
+	req := httptest.NewRequest(http.MethodPost, "/api/setup/presets", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestPresetDeltaHandler_AllMissing(t *testing.T) {
+	handler := PresetDeltaHandler()
+	body, _ := json.Marshal(PresetDeltaRequest{
+		PresetID: "balance",
+		Models:   []string{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/setup/presets/delta", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp PresetDeltaResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Ready {
+		t.Error("expected ready=false when no models are configured")
+	}
+	if len(resp.ConfiguredModels) != 0 {
+		t.Errorf("expected 0 configured models, got %d", len(resp.ConfiguredModels))
+	}
+	if len(resp.MissingModels) != 5 {
+		t.Errorf("expected 5 missing models for balance preset, got %d", len(resp.MissingModels))
+	}
+}
+
+func TestPresetDeltaHandler_PartialOverlap(t *testing.T) {
+	handler := PresetDeltaHandler()
+	body, _ := json.Marshal(PresetDeltaRequest{
+		PresetID: "balance",
+		Models:   []string{"qwen/qwen3.5-rocm", "openai/gpt5.4"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/setup/presets/delta", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp PresetDeltaResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if resp.Ready {
+		t.Error("expected ready=false with partial overlap")
+	}
+	if len(resp.ConfiguredModels) != 2 {
+		t.Errorf("expected 2 configured, got %d", len(resp.ConfiguredModels))
+	}
+	if len(resp.MissingModels) != 3 {
+		t.Errorf("expected 3 missing, got %d", len(resp.MissingModels))
+	}
+}
+
+func TestPresetDeltaHandler_AllConfigured(t *testing.T) {
+	handler := PresetDeltaHandler()
+	body, _ := json.Marshal(PresetDeltaRequest{
+		PresetID: "security",
+		Models:   []string{"local/private-qwen", "cloud/frontier-reasoning"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/setup/presets/delta", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp PresetDeltaResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if !resp.Ready {
+		t.Error("expected ready=true when all models are configured")
+	}
+	if len(resp.MissingModels) != 0 {
+		t.Errorf("expected 0 missing, got %d", len(resp.MissingModels))
+	}
+	if len(resp.ConfiguredModels) != 2 {
+		t.Errorf("expected 2 configured, got %d", len(resp.ConfiguredModels))
+	}
+}
+
+func TestPresetDeltaHandler_CaseInsensitive(t *testing.T) {
+	handler := PresetDeltaHandler()
+	body, _ := json.Marshal(PresetDeltaRequest{
+		PresetID: "security",
+		Models:   []string{"LOCAL/PRIVATE-QWEN", "Cloud/Frontier-Reasoning"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/setup/presets/delta", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var resp PresetDeltaResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if !resp.Ready {
+		t.Error("expected case-insensitive matching to find all models")
+	}
+}
+
+func TestPresetDeltaHandler_UnknownPreset(t *testing.T) {
+	handler := PresetDeltaHandler()
+	body, _ := json.Marshal(PresetDeltaRequest{
+		PresetID: "nonexistent",
+		Models:   []string{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/setup/presets/delta", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown preset, got %d", rec.Code)
+	}
+}
+
+func TestPresetDeltaHandler_RejectsNonPost(t *testing.T) {
+	handler := PresetDeltaHandler()
+	req := httptest.NewRequest(http.MethodGet, "/api/setup/presets/delta", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestComputeModelDelta_EmptyInputs(t *testing.T) {
+	configured, missing := computeModelDelta([]PresetModel{}, []string{})
+	if len(configured) != 0 || len(missing) != 0 {
+		t.Errorf("expected empty results for empty inputs, got configured=%d missing=%d", len(configured), len(missing))
+	}
+}

--- a/dashboard/backend/router/core_routes.go
+++ b/dashboard/backend/router/core_routes.go
@@ -58,6 +58,8 @@ func registerHealthAndSetupRoutes(mux *http.ServeMux, cfg *config.Config) {
 	mux.HandleFunc("/api/setup/import-remote", handlers.SetupImportRemoteHandler(cfg.AbsConfigPath))
 	mux.HandleFunc("/api/setup/validate", handlers.SetupValidateHandler(cfg.AbsConfigPath))
 	mux.HandleFunc("/api/setup/activate", handlers.SetupActivateHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir))
+	mux.HandleFunc("/api/setup/presets", handlers.PresetsHandler())
+	mux.HandleFunc("/api/setup/presets/delta", handlers.PresetDeltaHandler())
 }
 
 func registerConfigRoutes(mux *http.ServeMux, cfg *config.Config) {

--- a/dashboard/frontend/src/pages/SetupWizardPage.tsx
+++ b/dashboard/frontend/src/pages/SetupWizardPage.tsx
@@ -21,11 +21,15 @@ import {
   createModelDraft,
   createSetupConfigCounts,
   DEFAULT_REMOTE_SETUP_CONFIG_URL,
+  fetchPresetDelta,
+  fetchPresets,
   getStepOneErrors,
   maskSecrets,
   PROVIDER_OPTIONS,
   type ImportedSetupConfig,
   type ModelDraft,
+  type PresetDelta,
+  type PresetInfo,
   type ProviderKind,
   type RemoteImportState,
   type SetupActivationState,
@@ -54,6 +58,12 @@ const SetupWizardPage: React.FC = () => {
   );
   const [importedRemoteConfig, setImportedRemoteConfig] =
     useState<ImportedSetupConfig | null>(null);
+  const [presets, setPresets] = useState<PresetInfo[]>([]);
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+  const [presetDelta, setPresetDelta] = useState<PresetDelta | null>(null);
+  const [presetImportedConfig, setPresetImportedConfig] =
+    useState<ImportedSetupConfig | null>(null);
+  const [presetError, setPresetError] = useState<string | null>(null);
   const [stepOneAttempted, setStepOneAttempted] = useState(false);
   const [validationState, setValidationState] =
     useState<SetupValidationState>("idle");
@@ -68,6 +78,12 @@ const SetupWizardPage: React.FC = () => {
   const [activationState, setActivationState] =
     useState<SetupActivationState>("idle");
   const [activationError, setActivationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchPresets()
+      .then(setPresets)
+      .catch(() => setPresets([]));
+  }, []);
 
   useEffect(() => {
     if (models.length === 0) {
@@ -94,6 +110,8 @@ const SetupWizardPage: React.FC = () => {
     setValidatedCounts(createSetupConfigCounts());
     setActivationState("idle");
     setActivationError(null);
+    setPresetDelta(null);
+    setPresetImportedConfig(null);
   };
 
   let scratchConfig: Record<string, unknown> | null = null;
@@ -119,16 +137,25 @@ const SetupWizardPage: React.FC = () => {
       scratchConfig.decisions.length > 0,
   });
 
+  const selectedPreset = presets.find((p) => p.id === selectedPresetId) ?? null;
   const currentRouteLabel =
-    routingMode === "remote" ? "From remote" : "From scratch";
+    routingMode === "preset" && selectedPreset
+      ? selectedPreset.label
+      : routingMode === "remote"
+        ? "From remote"
+        : "From scratch";
   const draftConfig =
-    routingMode === "remote"
-      ? (importedRemoteConfig?.config ?? null)
-      : scratchConfig;
+    routingMode === "preset"
+      ? (presetImportedConfig?.config ?? null)
+      : routingMode === "remote"
+        ? (importedRemoteConfig?.config ?? null)
+        : scratchConfig;
   const generatedCounts =
-    routingMode === "remote"
-      ? (importedRemoteConfig?.counts ?? createSetupConfigCounts())
-      : scratchCounts;
+    routingMode === "preset"
+      ? (presetImportedConfig?.counts ?? createSetupConfigCounts())
+      : routingMode === "remote"
+        ? (importedRemoteConfig?.counts ?? createSetupConfigCounts())
+        : scratchCounts;
 
   const previewSource = maskSecrets(validatedConfig ?? draftConfig);
   const validationSignature = draftConfig ? JSON.stringify(draftConfig) : "";
@@ -224,14 +251,25 @@ const SetupWizardPage: React.FC = () => {
     resetReviewState();
   };
 
+  const isStep2Blocked = () => {
+    if (routingMode === "remote" && !importedRemoteConfig) {
+      setRemoteImportError("Import a remote config before continuing.");
+      return true;
+    }
+    if (routingMode === "preset" && !presetImportedConfig) {
+      setPresetError("Select a mode and import its config before continuing.");
+      return true;
+    }
+    return false;
+  };
+
   const goToStep = (step: SetupStep) => {
     if (step > 0 && (hasStepOneIssues || scratchBuildError)) {
       setStepOneAttempted(true);
       return;
     }
 
-    if (step === 2 && routingMode === "remote" && !importedRemoteConfig) {
-      setRemoteImportError("Import a remote config before continuing.");
+    if (step === 2 && isStep2Blocked()) {
       return;
     }
 
@@ -249,12 +287,7 @@ const SetupWizardPage: React.FC = () => {
       return;
     }
 
-    if (
-      currentStep === 1 &&
-      routingMode === "remote" &&
-      !importedRemoteConfig
-    ) {
-      setRemoteImportError("Import a remote config before continuing.");
+    if (currentStep === 1 && isStep2Blocked()) {
       return;
     }
 
@@ -290,6 +323,59 @@ const SetupWizardPage: React.FC = () => {
       setValidationError(
         err instanceof Error ? err.message : "Setup validation failed.",
       );
+    }
+  };
+
+  const handleSelectPreset = async (presetId: string) => {
+    setSelectedPresetId(presetId);
+    setPresetDelta(null);
+    setPresetImportedConfig(null);
+    resetReviewState();
+
+    const userModelNames = models
+      .map((m) => m.name.trim())
+      .filter((n) => n.length > 0);
+    try {
+      const delta = await fetchPresetDelta(presetId, userModelNames);
+      setPresetDelta(delta);
+
+      if (delta.ready) {
+        const result = await importRemoteSetupConfig(delta.recipe_url);
+        setPresetImportedConfig({
+          config: result.config,
+          sourceUrl: result.sourceUrl,
+          counts: createSetupConfigCounts({
+            models: result.models,
+            decisions: result.decisions,
+            signals: result.signals,
+            canActivate: result.canActivate,
+          }),
+        });
+      }
+    } catch {
+      setPresetDelta(null);
+    }
+  };
+
+  const handleImportPresetConfig = async () => {
+    if (!presetDelta) {
+      return;
+    }
+    resetReviewState();
+    try {
+      const result = await importRemoteSetupConfig(presetDelta.recipe_url);
+      setPresetImportedConfig({
+        config: result.config,
+        sourceUrl: result.sourceUrl,
+        counts: createSetupConfigCounts({
+          models: result.models,
+          decisions: result.decisions,
+          signals: result.signals,
+          canActivate: result.canActivate,
+        }),
+      });
+    } catch {
+      setPresetImportedConfig(null);
     }
   };
 
@@ -413,9 +499,15 @@ const SetupWizardPage: React.FC = () => {
               remoteImportError={remoteImportError}
               importedConfig={importedRemoteConfig}
               counts={generatedCounts}
+              presets={presets}
+              selectedPresetId={selectedPresetId}
+              presetDelta={presetDelta}
+              presetImportedConfig={presetImportedConfig}
+              presetError={presetError}
               onSelectRoutingMode={(mode) => {
                 setRoutingMode(mode);
                 setRemoteImportError(null);
+                setPresetError(null);
                 resetReviewState();
               }}
               onChangeRemoteConfigUrl={(value) => {
@@ -435,6 +527,8 @@ const SetupWizardPage: React.FC = () => {
                 }
               }}
               onImportRemoteConfig={() => void handleImportRemote()}
+              onSelectPreset={(id) => void handleSelectPreset(id)}
+              onImportPresetConfig={() => void handleImportPresetConfig()}
             />
           )}
           {currentStep === 2 && (

--- a/dashboard/frontend/src/pages/SetupWizardPanels.tsx
+++ b/dashboard/frontend/src/pages/SetupWizardPanels.tsx
@@ -57,6 +57,163 @@ interface RoutingStarterPanelProps {
   onImportPresetConfig: () => void;
 }
 
+function PresetModelChecklist({
+  presetDelta,
+  presetImportedConfig,
+  counts,
+  presetError,
+  onImportPresetConfig,
+}: {
+  presetDelta: PresetDelta;
+  presetImportedConfig: ImportedSetupConfig | null;
+  counts: SetupConfigCounts;
+  presetError: string | null;
+  onImportPresetConfig: () => void;
+}) {
+  const total =
+    presetDelta.configured_models.length + presetDelta.missing_models.length;
+  const readyCount = presetDelta.configured_models.length;
+  const pct = total > 0 ? Math.round((readyCount / total) * 100) : 0;
+
+  return (
+    <div className={styles.remoteImportSummary}>
+      <div className={styles.remoteImportSummaryHeader}>
+        <h4 className={styles.presetCardTitle}>
+          {presetDelta.ready ? "Ready to activate" : "Model requirements"}
+        </h4>
+        <span className={styles.presetCardMeta}>
+          {readyCount}/{total} models ready
+        </span>
+      </div>
+
+      <div
+        style={{
+          height: 4,
+          borderRadius: 2,
+          background: "var(--color-border, #333)",
+          marginBottom: 12,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: "100%",
+            borderRadius: 2,
+            background: presetDelta.ready
+              ? "var(--color-success, #22c55e)"
+              : "var(--color-warning, #eab308)",
+            transition: "width 0.3s ease",
+          }}
+        />
+      </div>
+
+      <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+        {presetDelta.configured_models.map((name) => (
+          <li
+            key={name}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "4px 0",
+              color: "var(--color-success, #22c55e)",
+            }}
+          >
+            <span style={{ fontSize: 16, lineHeight: 1 }}>&#10003;</span>
+            <span style={{ color: "var(--color-text, #e5e5e5)" }}>
+              <strong>{name}</strong>
+            </span>
+            <span
+              style={{
+                fontSize: 12,
+                color: "var(--color-text-muted, #888)",
+              }}
+            >
+              configured
+            </span>
+          </li>
+        ))}
+        {presetDelta.missing_models.map((m) => (
+          <li
+            key={m.name}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "4px 0",
+              color: "var(--color-warning, #eab308)",
+            }}
+          >
+            <span style={{ fontSize: 16, lineHeight: 1 }}>&#9675;</span>
+            <span style={{ color: "var(--color-text, #e5e5e5)" }}>
+              <strong>{m.name}</strong>
+            </span>
+            <span
+              style={{
+                fontSize: 12,
+                color: "var(--color-text-muted, #888)",
+              }}
+            >
+              {m.role} &mdash; add in step 1
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {!presetDelta.ready && (
+        <p className={styles.fieldHint} style={{ marginTop: 12 }}>
+          Missing models will use placeholder endpoints. You can update them
+          after activation from the config page.
+        </p>
+      )}
+
+      {presetError && (
+        <p className={styles.fieldErrorText} style={{ marginTop: 8 }}>
+          {presetError}
+        </p>
+      )}
+
+      {!presetImportedConfig && (
+        <div className={styles.remoteImportActions}>
+          <button
+            className={styles.secondaryButton}
+            onClick={onImportPresetConfig}
+          >
+            {presetDelta.ready
+              ? "Import preset config"
+              : "Import with placeholders"}
+          </button>
+        </div>
+      )}
+
+      {presetImportedConfig && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: "8px 12px",
+            borderRadius: 6,
+            background: "var(--color-success-bg, rgba(34,197,94,0.1))",
+            border: "1px solid var(--color-success, #22c55e)",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <span style={{ color: "var(--color-success, #22c55e)", fontSize: 16 }}>
+            &#10003;
+          </span>
+          <span>
+            <strong>Preset config ready</strong> &mdash; {counts.models} models
+            &middot; {counts.decisions} decisions &middot; {counts.signals}{" "}
+            signals
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function SetupRouteSummary({ currentRouteLabel }: RouteSummaryProps) {
   return (
     <div className={styles.routeSummary}>
@@ -352,24 +509,31 @@ export function RoutingStarterPanel({
             </p>
           </button>
 
-          {presets.length > 0 && (
-            <button
-              className={`${styles.presetCard} ${isPresetMode ? styles.presetCardActive : ""}`}
-              onClick={() => onSelectRoutingMode("preset")}
-            >
-              <div className={styles.presetCardHeader}>
-                <h4 className={styles.presetCardTitle}>Choose a mode</h4>
-                <span className={styles.presetCardMeta}>
-                  {presets.length} built-in
-                  {presets.length === 1 ? " mode" : " modes"}
-                </span>
-              </div>
-              <p className={styles.presetCardDescription}>
-                Pick a goal-oriented preset like Balance or Security, then fill
-                in only the models that are missing from your setup.
-              </p>
-            </button>
-          )}
+          {presets.map((preset) => {
+            const isActive =
+              isPresetMode && selectedPresetId === preset.id;
+            return (
+              <button
+                key={preset.id}
+                className={`${styles.presetCard} ${isActive ? styles.presetCardActive : ""}`}
+                onClick={() => {
+                  onSelectRoutingMode("preset");
+                  onSelectPreset(preset.id);
+                }}
+              >
+                <div className={styles.presetCardHeader}>
+                  <h4 className={styles.presetCardTitle}>{preset.label}</h4>
+                  <span className={styles.presetCardMeta}>
+                    {preset.required_models.length} model
+                    {preset.required_models.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <p className={styles.presetCardDescription}>
+                  {preset.summary}
+                </p>
+              </button>
+            );
+          })}
 
           <button
             className={`${styles.presetCard} ${isRemoteMode ? styles.presetCardActive : ""}`}
@@ -390,101 +554,21 @@ export function RoutingStarterPanel({
           </button>
         </div>
 
-        {isPresetMode && (
+        {isPresetMode && presetDelta && (
           <div className={styles.remoteImportPanel}>
-            <div className={styles.presetGrid}>
-              {presets.map((preset) => (
-                <button
-                  key={preset.id}
-                  className={`${styles.presetCard} ${selectedPresetId === preset.id ? styles.presetCardActive : ""}`}
-                  onClick={() => onSelectPreset(preset.id)}
-                >
-                  <div className={styles.presetCardHeader}>
-                    <h4 className={styles.presetCardTitle}>{preset.label}</h4>
-                    <span className={styles.presetCardMeta}>
-                      {preset.required_models.length} model
-                      {preset.required_models.length === 1 ? "" : "s"}
-                    </span>
-                  </div>
-                  <p className={styles.presetCardDescription}>
-                    {preset.summary}
-                  </p>
-                </button>
-              ))}
-            </div>
+            <PresetModelChecklist
+              presetDelta={presetDelta}
+              presetImportedConfig={presetImportedConfig}
+              counts={counts}
+              presetError={presetError}
+              onImportPresetConfig={onImportPresetConfig}
+            />
+          </div>
+        )}
 
-            {presetError && (
-              <p className={styles.fieldErrorText}>{presetError}</p>
-            )}
-
-            {presetDelta && (
-              <div className={styles.remoteImportSummary}>
-                <div className={styles.remoteImportSummaryHeader}>
-                  <h4 className={styles.presetCardTitle}>
-                    {presetDelta.ready
-                      ? "All models configured"
-                      : "Missing models"}
-                  </h4>
-                  <span className={styles.presetCardMeta}>
-                    {presetDelta.configured_models.length} ready ·{" "}
-                    {presetDelta.missing_models.length} missing
-                  </span>
-                </div>
-
-                {presetDelta.configured_models.length > 0 && (
-                  <ul className={styles.errorList}>
-                    {presetDelta.configured_models.map((name) => (
-                      <li key={name}>
-                        <strong>{name}</strong> — configured
-                      </li>
-                    ))}
-                  </ul>
-                )}
-
-                {presetDelta.missing_models.length > 0 && (
-                  <ul className={styles.errorList}>
-                    {presetDelta.missing_models.map((m) => (
-                      <li key={m.name}>
-                        <strong>{m.name}</strong> — {m.role} (add this model in
-                        step 1)
-                      </li>
-                    ))}
-                  </ul>
-                )}
-
-                {!presetDelta.ready && (
-                  <p className={styles.fieldHint}>
-                    Go back to step 1 to add the missing models, then return
-                    here to continue.
-                  </p>
-                )}
-
-                {presetDelta.ready && !presetImportedConfig && (
-                  <div className={styles.remoteImportActions}>
-                    <button
-                      className={styles.secondaryButton}
-                      onClick={onImportPresetConfig}
-                    >
-                      Import preset config
-                    </button>
-                  </div>
-                )}
-
-                {presetImportedConfig && (
-                  <div className={styles.remoteImportSummary}>
-                    <div className={styles.remoteImportSummaryHeader}>
-                      <h4 className={styles.presetCardTitle}>
-                        Preset config ready
-                      </h4>
-                      <span className={styles.presetCardMeta}>
-                        {counts.models} models · {counts.decisions} decisions ·{" "}
-                        {counts.signals} signals
-                      </span>
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
+        {isPresetMode && !presetDelta && presetError && (
+          <div className={styles.remoteImportPanel}>
+            <p className={styles.fieldErrorText}>{presetError}</p>
           </div>
         )}
 

--- a/dashboard/frontend/src/pages/SetupWizardPanels.tsx
+++ b/dashboard/frontend/src/pages/SetupWizardPanels.tsx
@@ -6,6 +6,8 @@ import {
   SETUP_STEP_LABELS,
   type ImportedSetupConfig,
   type ModelDraft,
+  type PresetDelta,
+  type PresetInfo,
   type RemoteImportState,
   type SetupConfigCounts,
   type SetupRoutingMode,
@@ -43,9 +45,16 @@ interface RoutingStarterPanelProps {
   remoteImportError: string | null;
   importedConfig: ImportedSetupConfig | null;
   counts: SetupConfigCounts;
+  presets: PresetInfo[];
+  selectedPresetId: string | null;
+  presetDelta: PresetDelta | null;
+  presetImportedConfig: ImportedSetupConfig | null;
+  presetError: string | null;
   onSelectRoutingMode: (mode: SetupRoutingMode) => void;
   onChangeRemoteConfigUrl: (value: string) => void;
   onImportRemoteConfig: () => void;
+  onSelectPreset: (id: string) => void;
+  onImportPresetConfig: () => void;
 }
 
 export function SetupRouteSummary({ currentRouteLabel }: RouteSummaryProps) {
@@ -284,12 +293,20 @@ export function RoutingStarterPanel({
   remoteImportError,
   importedConfig,
   counts,
+  presets,
+  selectedPresetId,
+  presetDelta,
+  presetImportedConfig,
+  presetError,
   onSelectRoutingMode,
   onChangeRemoteConfigUrl,
   onImportRemoteConfig,
+  onSelectPreset,
+  onImportPresetConfig,
 }: RoutingStarterPanelProps) {
   const isScratchMode = routingMode === "scratch";
   const isRemoteMode = routingMode === "remote";
+  const isPresetMode = routingMode === "preset";
   const isImporting = remoteImportState === "importing";
 
   return (
@@ -300,9 +317,8 @@ export function RoutingStarterPanel({
             Choose how routing should begin
           </h2>
           <p className={styles.sectionDescription}>
-            Keep setup minimal with a default catch-all route, or import a
-            remote config and carry its models, decisions, and signals into
-            review.
+            Pick a goal-oriented mode, keep setup minimal with a default
+            catch-all route, or import a remote config.
           </p>
           <SetupRouteSummary currentRouteLabel={currentRouteLabel} />
         </div>
@@ -313,9 +329,9 @@ export function RoutingStarterPanel({
           <div>
             <h3 className={styles.presetSectionTitle}>Routing options</h3>
             <p className={styles.presetSectionDescription}>
-              `From scratch` keeps the setup on a default catch-all. `From
-              remote` imports a full config file from a URL and uses that
-              imported draft for review and activation.
+              Choose a built-in mode to get a curated routing config, start from
+              scratch with a default catch-all, or import a full config from a
+              URL.
             </p>
           </div>
           <span className={styles.presetSummaryBadge}>{currentRouteLabel}</span>
@@ -336,6 +352,25 @@ export function RoutingStarterPanel({
             </p>
           </button>
 
+          {presets.length > 0 && (
+            <button
+              className={`${styles.presetCard} ${isPresetMode ? styles.presetCardActive : ""}`}
+              onClick={() => onSelectRoutingMode("preset")}
+            >
+              <div className={styles.presetCardHeader}>
+                <h4 className={styles.presetCardTitle}>Choose a mode</h4>
+                <span className={styles.presetCardMeta}>
+                  {presets.length} built-in
+                  {presets.length === 1 ? " mode" : " modes"}
+                </span>
+              </div>
+              <p className={styles.presetCardDescription}>
+                Pick a goal-oriented preset like Balance or Security, then fill
+                in only the models that are missing from your setup.
+              </p>
+            </button>
+          )}
+
           <button
             className={`${styles.presetCard} ${isRemoteMode ? styles.presetCardActive : ""}`}
             onClick={() => onSelectRoutingMode("remote")}
@@ -354,6 +389,104 @@ export function RoutingStarterPanel({
             </p>
           </button>
         </div>
+
+        {isPresetMode && (
+          <div className={styles.remoteImportPanel}>
+            <div className={styles.presetGrid}>
+              {presets.map((preset) => (
+                <button
+                  key={preset.id}
+                  className={`${styles.presetCard} ${selectedPresetId === preset.id ? styles.presetCardActive : ""}`}
+                  onClick={() => onSelectPreset(preset.id)}
+                >
+                  <div className={styles.presetCardHeader}>
+                    <h4 className={styles.presetCardTitle}>{preset.label}</h4>
+                    <span className={styles.presetCardMeta}>
+                      {preset.required_models.length} model
+                      {preset.required_models.length === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  <p className={styles.presetCardDescription}>
+                    {preset.summary}
+                  </p>
+                </button>
+              ))}
+            </div>
+
+            {presetError && (
+              <p className={styles.fieldErrorText}>{presetError}</p>
+            )}
+
+            {presetDelta && (
+              <div className={styles.remoteImportSummary}>
+                <div className={styles.remoteImportSummaryHeader}>
+                  <h4 className={styles.presetCardTitle}>
+                    {presetDelta.ready
+                      ? "All models configured"
+                      : "Missing models"}
+                  </h4>
+                  <span className={styles.presetCardMeta}>
+                    {presetDelta.configured_models.length} ready ·{" "}
+                    {presetDelta.missing_models.length} missing
+                  </span>
+                </div>
+
+                {presetDelta.configured_models.length > 0 && (
+                  <ul className={styles.errorList}>
+                    {presetDelta.configured_models.map((name) => (
+                      <li key={name}>
+                        <strong>{name}</strong> — configured
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {presetDelta.missing_models.length > 0 && (
+                  <ul className={styles.errorList}>
+                    {presetDelta.missing_models.map((m) => (
+                      <li key={m.name}>
+                        <strong>{m.name}</strong> — {m.role} (add this model in
+                        step 1)
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {!presetDelta.ready && (
+                  <p className={styles.fieldHint}>
+                    Go back to step 1 to add the missing models, then return
+                    here to continue.
+                  </p>
+                )}
+
+                {presetDelta.ready && !presetImportedConfig && (
+                  <div className={styles.remoteImportActions}>
+                    <button
+                      className={styles.secondaryButton}
+                      onClick={onImportPresetConfig}
+                    >
+                      Import preset config
+                    </button>
+                  </div>
+                )}
+
+                {presetImportedConfig && (
+                  <div className={styles.remoteImportSummary}>
+                    <div className={styles.remoteImportSummaryHeader}>
+                      <h4 className={styles.presetCardTitle}>
+                        Preset config ready
+                      </h4>
+                      <span className={styles.presetCardMeta}>
+                        {counts.models} models · {counts.decisions} decisions ·{" "}
+                        {counts.signals} signals
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {isRemoteMode && (
           <div className={styles.remoteImportPanel}>

--- a/dashboard/frontend/src/pages/setupWizardSupport.ts
+++ b/dashboard/frontend/src/pages/setupWizardSupport.ts
@@ -2,7 +2,7 @@ export type SetupStep = 0 | 1 | 2;
 export type ProviderKind = "vllm" | "openai-compatible" | "anthropic";
 export type SetupValidationState = "idle" | "validating" | "valid" | "error";
 export type SetupActivationState = "idle" | "activating" | "error";
-export type SetupRoutingMode = "scratch" | "remote";
+export type SetupRoutingMode = "scratch" | "remote" | "preset";
 export type RemoteImportState = "idle" | "importing" | "imported" | "error";
 
 export interface ModelDraft {
@@ -330,6 +330,50 @@ export function buildSetupConfig(
   };
 
   return config;
+}
+
+export interface PresetModel {
+  name: string;
+  role: string;
+}
+
+export interface PresetInfo {
+  id: string;
+  label: string;
+  summary: string;
+  required_models: PresetModel[];
+  recipe_url: string;
+}
+
+export interface PresetDelta {
+  preset_id: string;
+  configured_models: string[];
+  missing_models: PresetModel[];
+  ready: boolean;
+  recipe_url: string;
+}
+
+export async function fetchPresets(): Promise<PresetInfo[]> {
+  const resp = await fetch("/api/setup/presets");
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch presets: ${resp.status}`);
+  }
+  return resp.json();
+}
+
+export async function fetchPresetDelta(
+  presetId: string,
+  models: string[],
+): Promise<PresetDelta> {
+  const resp = await fetch("/api/setup/presets/delta", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ preset_id: presetId, models }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch preset delta: ${resp.status}`);
+  }
+  return resp.json();
 }
 
 export function maskSecrets(config: Record<string, unknown> | null): string {


### PR DESCRIPTION
## Summary

- Add a built-in routing mode catalog (Balance, Security) to the dashboard setup wizard so new users can pick a goal-oriented preset instead of manually importing recipe YAML
- Each preset shows which models are already configured (green checkmark) vs missing (amber circle) with a progress bar
- Missing models can use placeholder endpoints — users don't need all models upfront to get started

Closes #1754

## Changes

### Backend
- **`dashboard/backend/handlers/presets.go`** — preset catalog (`GET /api/setup/presets`) and delta endpoint (`POST /api/setup/presets/delta`) that computes configured vs missing models
- **`dashboard/backend/handlers/presets_test.go`** — 8 unit tests covering catalog, delta computation, case-insensitive matching, unknown preset, and method validation
- **`dashboard/backend/router/core_routes.go`** — route registration

### Frontend
- **`setupWizardSupport.ts`** — `PresetInfo`, `PresetDelta` types + `fetchPresets()`, `fetchPresetDelta()` API helpers; extended `SetupRoutingMode` to include `"preset"`
- **`SetupWizardPanels.tsx`** — Balance and Security as first-class cards in the routing grid; `PresetModelChecklist` component with progress bar, green checkmarks for configured models, amber indicators for missing ones
- **`SetupWizardPage.tsx`** — preset state management, auto-import when all models ready, delta invalidation on model changes

## Test Plan

- [x] `go test ./handlers/ -run TestPreset` — 8/8 pass
- [x] `tsc --noEmit` — no type errors
- [x] `eslint` — no lint errors
- [x] Manual: setup wizard shows 4 cards (From scratch, Balance, Security, From remote)
- [x] Manual: selecting Balance shows model checklist with 1/5 configured
- [x] Manual: "Import with placeholders" imports the recipe and advances to review

Evidence

<img width="1391" height="798" alt="Screenshot 2026-05-31 at 2 55 33 PM" src="https://github.com/user-attachments/assets/a3772584-71af-4bd7-8632-a574f8003e93" />
<img width="1154" height="754" alt="Screenshot 2026-05-31 at 2 54 07 PM" src="https://github.com/user-attachments/assets/9dc6c887-30f1-478e-aed2-cc6e30066ee3" />
<img width="1256" height="748" alt="Screenshot 2026-05-31 at 2 53 58 PM" src="https://github.com/user-attachments/assets/39dd8afb-b2a0-4e11-a3f0-3eefbe248c63" />
