### PR TITLE
fix(classification): scan prior user turns in history-aware PII/jailbreak signals

### DIFF
--- a/src/semantic-router/pkg/classification/classifier_signal_dispatch.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_dispatch.go
@@ -89,12 +89,14 @@ func (c *Classifier) buildSignalDispatchers(
 		{
 			config.SignalTypeJailbreak, "Jailbreak",
 			func() {
-				c.evaluateJailbreakSignal(results, mu, textForSignal(config.SignalTypeJailbreak), nonUserMessages)
+				c.evaluateJailbreakSignal(results, mu, textForSignal(config.SignalTypeJailbreak), historyForHistoryAwareSignals(priorUserMessages, nonUserMessages))
 			},
 		},
 		{
 			config.SignalTypePII, "PII",
-			func() { c.evaluatePIISignal(results, mu, textForSignal(config.SignalTypePII), nonUserMessages) },
+			func() {
+				c.evaluatePIISignal(results, mu, textForSignal(config.SignalTypePII), historyForHistoryAwareSignals(priorUserMessages, nonUserMessages))
+			},
 		},
 		{
 			config.SignalTypeKB, "KB",

--- a/src/semantic-router/pkg/classification/history_aware_pii_e2e_test.go
+++ b/src/semantic-router/pkg/classification/history_aware_pii_e2e_test.go
@@ -1,0 +1,46 @@
+package classification
+
+import (
+	"sync"
+	"testing"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// Security regression (issue #1961): include_history PII rules must detect a
+// secret placed in a prior USER turn, not just system/assistant history.
+func TestPIISignal_DetectsSecretInPriorUserTurn(t *testing.T) {
+	classifier, _, mockModel := newTestPIIClassifier()
+	classifier.Config.PIIRules = []config.PIIRule{
+		{
+			Name:            "restricted_pii",
+			Threshold:       0.7,
+			IncludeHistory:  true,
+			PIITypesAllowed: []string{},
+		},
+	}
+
+	secretTurn := "my contact is alice@corp.example"
+	currentTurn := "thanks, summarize that in one line"
+	priorUserMessages := []string{secretTurn}
+	nonUserMessages := []string{"Sure, here is how rotation works."}
+
+	mockModel.setMockResponse(secretTurn, []candle_binding.TokenEntity{
+		piiEntity("EMAIL", "alice@corp.example", 14, 32, 0.99),
+	}, nil)
+
+	results := &SignalResults{
+		Metrics:           &SignalMetricsCollection{},
+		SignalConfidences: make(map[string]float64),
+		SignalValues:      make(map[string]float64),
+	}
+	var mu sync.Mutex
+
+	history := historyForHistoryAwareSignals(priorUserMessages, nonUserMessages)
+	classifier.evaluatePIISignal(results, &mu, currentTurn, history)
+
+	if !results.PIIDetected {
+		t.Fatalf("SECURITY: PII in a prior user turn must be detected with include_history=true (issue #1961); got PIIDetected=false")
+	}
+}

--- a/src/semantic-router/pkg/classification/history_aware_signals.go
+++ b/src/semantic-router/pkg/classification/history_aware_signals.go
@@ -1,0 +1,21 @@
+package classification
+
+// Includes prior user turns (not just system/assistant) so include_history
+// detectors catch secrets from earlier turns. Security fix, issue #1961.
+func historyForHistoryAwareSignals(priorUserMessages, nonUserMessages []string) []string {
+	merged := make([]string, 0, len(priorUserMessages)+len(nonUserMessages))
+	seen := make(map[string]struct{}, len(priorUserMessages)+len(nonUserMessages))
+	for _, group := range [][]string{nonUserMessages, priorUserMessages} {
+		for _, msg := range group {
+			if msg == "" {
+				continue
+			}
+			if _, ok := seen[msg]; ok {
+				continue
+			}
+			seen[msg] = struct{}{}
+			merged = append(merged, msg)
+		}
+	}
+	return merged
+}

--- a/src/semantic-router/pkg/classification/history_aware_signals_test.go
+++ b/src/semantic-router/pkg/classification/history_aware_signals_test.go
@@ -1,0 +1,58 @@
+package classification
+
+import (
+	"testing"
+)
+
+// Security regression: prior USER turns must be scannable by history-aware
+// negative signals (PII/jailbreak), else secrets from an earlier turn leak to
+// external providers on a later benign turn. See issue #1961.
+func TestHistoryForHistoryAwareSignals_IncludesPriorUserTurns(t *testing.T) {
+	priorUserMessages := []string{"my prod key is sk-SECRET-123"}
+	nonUserMessages := []string{"You are a helpful assistant.", "Sure, here is how rotation works."}
+
+	got := historyForHistoryAwareSignals(priorUserMessages, nonUserMessages)
+
+	// Must contain every non-user message (existing behavior preserved).
+	for _, want := range nonUserMessages {
+		if !containsString(got, want) {
+			t.Errorf("expected history to preserve non-user message %q, got %v", want, got)
+		}
+	}
+
+	// Must ALSO contain the prior user message carrying the secret (the fix).
+	for _, want := range priorUserMessages {
+		if !containsString(got, want) {
+			t.Errorf("SECURITY: prior user message %q must be scanned by history-aware signals, got %v", want, got)
+		}
+	}
+}
+
+func TestHistoryForHistoryAwareSignals_NoDuplicatesAndDropsEmpty(t *testing.T) {
+	priorUserMessages := []string{"shared", "", "user-only"}
+	nonUserMessages := []string{"shared", "assistant-only", ""}
+
+	got := historyForHistoryAwareSignals(priorUserMessages, nonUserMessages)
+
+	if containsString(got, "") {
+		t.Errorf("expected empty strings to be dropped, got %v", got)
+	}
+	if countString(got, "shared") != 1 {
+		t.Errorf("expected %q to appear exactly once, got %v", "shared", got)
+	}
+	for _, want := range []string{"user-only", "assistant-only", "shared"} {
+		if !containsString(got, want) {
+			t.Errorf("expected merged history to contain %q, got %v", want, got)
+		}
+	}
+}
+
+func countString(s []string, target string) int {
+	n := 0
+	for _, v := range s {
+		if v == target {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
Fix multi-turn egress leak from #1961: `include_history: true` previously only scanned non-user (system + assistant) history, so secrets in earlier user turns were never inspected and could be exfiltrated on later benign turns.

Widens the history slice handed to PII/jailbreak evaluators to also include `priorUserMessages`, via a small dedup helper. Evaluator logic unchanged. `include_history: false` (default) path is bit-for-bit identical.

Adds unit + e2e regression tests covering the issue #1961 scenario.

Fixes #1961