### PR TITLE
fix: reconcile each IntelligentRoute/Pool when multiple coexist

### DIFF
--- a/src/semantic-router/pkg/k8s/reconciler.go
+++ b/src/semantic-router/pkg/k8s/reconciler.go
@@ -18,7 +18,9 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -164,17 +166,32 @@ func (r *Reconciler) watchLoop(ctx context.Context) {
 
 // reconcile performs the reconciliation logic
 func (r *Reconciler) reconcile(ctx context.Context) error {
-	// Get IntelligentPool
-	pool, err := r.getIntelligentPool(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get IntelligentPool: %w", err)
+	// The reconciler emits a single canonical config and so expects exactly
+	// one pool and one route. When several coexist, short-circuiting would
+	// leave every CR with an empty status indefinitely (#1908); instead mark
+	// each conflicting CR Ready=False so the conflict is observable.
+	poolList := &v1alpha1.IntelligentPoolList{}
+	if err := r.client.List(ctx, poolList, client.InNamespace(r.namespace)); err != nil {
+		return fmt.Errorf("failed to list IntelligentPools: %w", err)
+	}
+	routeList := &v1alpha1.IntelligentRouteList{}
+	if err := r.client.List(ctx, routeList, client.InNamespace(r.namespace)); err != nil {
+		return fmt.Errorf("failed to list IntelligentRoutes: %w", err)
 	}
 
-	// Get IntelligentRoute
-	route, err := r.getIntelligentRoute(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get IntelligentRoute: %w", err)
+	if len(poolList.Items) == 0 {
+		return fmt.Errorf("no IntelligentPool found in namespace %s", r.namespace)
 	}
+	if len(routeList.Items) == 0 {
+		return fmt.Errorf("no IntelligentRoute found in namespace %s", r.namespace)
+	}
+
+	if len(poolList.Items) > 1 || len(routeList.Items) > 1 {
+		return r.reportConflict(ctx, poolList.Items, routeList.Items)
+	}
+
+	pool := &poolList.Items[0]
+	route := &routeList.Items[0]
 
 	// Check if anything changed
 	r.mu.RLock()
@@ -202,38 +219,29 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	return nil
 }
 
-// getIntelligentPool retrieves the IntelligentPool from the namespace
-func (r *Reconciler) getIntelligentPool(ctx context.Context) (*v1alpha1.IntelligentPool, error) {
-	poolList := &v1alpha1.IntelligentPoolList{}
-	if err := r.client.List(ctx, poolList, client.InNamespace(r.namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list IntelligentPools: %w", err)
+// reportConflict marks every IntelligentPool and IntelligentRoute in the
+// namespace Ready=False/Reason=Conflict and returns an error so the watch
+// loop logs the condition without silently dropping all CRs' status.
+func (r *Reconciler) reportConflict(ctx context.Context, pools []v1alpha1.IntelligentPool, routes []v1alpha1.IntelligentRoute) error {
+	var msgs []string
+
+	if len(pools) > 1 {
+		msg := fmt.Sprintf("found %d IntelligentPools in namespace %s, expected exactly 1; resolve the conflict so a single configuration can be applied", len(pools), r.namespace)
+		msgs = append(msgs, msg)
+		for i := range pools {
+			r.updatePoolStatus(ctx, &pools[i], metav1.ConditionFalse, "Conflict", msg)
+		}
 	}
 
-	if len(poolList.Items) == 0 {
-		return nil, fmt.Errorf("no IntelligentPool found in namespace %s", r.namespace)
-	}
-	if len(poolList.Items) > 1 {
-		return nil, fmt.Errorf("multiple IntelligentPools found in namespace %s, expected exactly 1", r.namespace)
-	}
-
-	return &poolList.Items[0], nil
-}
-
-// getIntelligentRoute retrieves the IntelligentRoute from the namespace
-func (r *Reconciler) getIntelligentRoute(ctx context.Context) (*v1alpha1.IntelligentRoute, error) {
-	routeList := &v1alpha1.IntelligentRouteList{}
-	if err := r.client.List(ctx, routeList, client.InNamespace(r.namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list IntelligentRoutes: %w", err)
+	if len(routes) > 1 {
+		msg := fmt.Sprintf("found %d IntelligentRoutes in namespace %s, expected exactly 1; resolve the conflict so a single configuration can be applied", len(routes), r.namespace)
+		msgs = append(msgs, msg)
+		for i := range routes {
+			r.updateRouteStatus(ctx, &routes[i], metav1.ConditionFalse, "Conflict", msg)
+		}
 	}
 
-	if len(routeList.Items) == 0 {
-		return nil, fmt.Errorf("no IntelligentRoute found in namespace %s", r.namespace)
-	}
-	if len(routeList.Items) > 1 {
-		return nil, fmt.Errorf("multiple IntelligentRoutes found in namespace %s, expected exactly 1", r.namespace)
-	}
-
-	return &routeList.Items[0], nil
+	return errors.New(strings.Join(msgs, "; "))
 }
 
 // validateAndUpdate validates CRDs and updates configuration

--- a/src/semantic-router/pkg/k8s/reconciler_conflict_test.go
+++ b/src/semantic-router/pkg/k8s/reconciler_conflict_test.go
@@ -1,0 +1,209 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/apis/vllm.ai/v1alpha1"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestReconcileMultipleCRsReportsConflict is the regression artifact for
+// #1908: before the fix, a second IntelligentRoute (or IntelligentPool) made
+// reconcile return early without ever writing status, so every CR sat with an
+// empty status indefinitely. The reconcile loop must instead mark each
+// conflicting CR Ready=False/Reason=Conflict.
+func TestReconcileMultipleCRsReportsConflict(t *testing.T) {
+	const namespace = "default"
+
+	t.Run("MultipleRoutes", func(t *testing.T) {
+		pool := buildConflictPool(namespace, "pool-a")
+		routeA := buildConflictRoute(namespace, "route-a")
+		routeB := buildConflictRoute(namespace, "route-b")
+
+		reconciler := buildConflictReconciler(t, namespace, pool, routeA, routeB)
+
+		err := reconciler.reconcile(context.Background())
+		if err == nil {
+			t.Fatal("reconcile: expected a conflict error with multiple routes, got nil")
+		}
+		if !strings.Contains(err.Error(), "IntelligentRoutes") {
+			t.Errorf("conflict error should name the conflicting kind, got: %v", err)
+		}
+
+		assertConflictRouteStatus(t, reconciler, namespace, "route-a")
+		assertConflictRouteStatus(t, reconciler, namespace, "route-b")
+	})
+
+	t.Run("MultiplePools", func(t *testing.T) {
+		poolA := buildConflictPool(namespace, "pool-a")
+		poolB := buildConflictPool(namespace, "pool-b")
+		route := buildConflictRoute(namespace, "route-a")
+
+		reconciler := buildConflictReconciler(t, namespace, poolA, poolB, route)
+
+		err := reconciler.reconcile(context.Background())
+		if err == nil {
+			t.Fatal("reconcile: expected a conflict error with multiple pools, got nil")
+		}
+		if !strings.Contains(err.Error(), "IntelligentPools") {
+			t.Errorf("conflict error should name the conflicting kind, got: %v", err)
+		}
+
+		assertConflictPoolStatus(t, reconciler, namespace, "pool-a")
+		assertConflictPoolStatus(t, reconciler, namespace, "pool-b")
+	})
+}
+
+// TestReconcileSingleCRUnchanged guards the happy path: exactly one pool and
+// one route must still reconcile to Ready=True. This is the regression canary
+// ensuring the #1908 fix did not alter single-CR behavior.
+func TestReconcileSingleCRUnchanged(t *testing.T) {
+	const namespace = "default"
+
+	pool := buildConflictPool(namespace, "pool-a")
+	route := buildConflictRoute(namespace, "route-a")
+
+	reconciler := buildConflictReconciler(t, namespace, pool, route)
+
+	if err := reconciler.reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile: expected success with a single pool and route, got: %v", err)
+	}
+
+	assertReadyConditionByName(t, reconciler, namespace, "pool", "pool-a", metav1.ConditionTrue, "Ready")
+	assertReadyConditionByName(t, reconciler, namespace, "route", "route-a", metav1.ConditionTrue, "Ready")
+}
+
+func buildConflictPool(namespace, name string) *v1alpha1.IntelligentPool {
+	return &v1alpha1.IntelligentPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.IntelligentPoolSpec{
+			DefaultModel: "deepseek-v3",
+			Models: []v1alpha1.ModelConfig{
+				{Name: "deepseek-v3"},
+			},
+		},
+	}
+}
+
+func buildConflictRoute(namespace, name string) *v1alpha1.IntelligentRoute {
+	return &v1alpha1.IntelligentRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.IntelligentRouteSpec{
+			Signals: v1alpha1.Signals{
+				Embeddings: []v1alpha1.EmbeddingSignal{
+					{
+						Name:              "rule_" + name,
+						Threshold:         0.7,
+						Candidates:        []string{"anchor phrase"},
+						AggregationMethod: "max",
+						QueryModality:     "text",
+					},
+				},
+			},
+			Decisions: []v1alpha1.Decision{
+				{
+					Name:     "decision_" + name,
+					Priority: 100,
+					Signals: v1alpha1.SignalCombination{
+						Operator: "AND",
+						Conditions: []v1alpha1.SignalCondition{
+							{Type: "embedding", Name: "rule_" + name},
+						},
+					},
+					ModelRefs: []v1alpha1.ModelRef{
+						{Model: "deepseek-v3"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildConflictReconciler(t *testing.T, namespace string, objs ...client.Object) *Reconciler {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.IntelligentPool{}, &v1alpha1.IntelligentRoute{}).
+		WithObjects(objs...).
+		Build()
+
+	return &Reconciler{
+		client:    fakeClient,
+		scheme:    scheme,
+		namespace: namespace,
+		converter: NewCRDConverter(),
+		staticConfig: &config.RouterConfig{
+			ConfigSource: config.ConfigSourceKubernetes,
+			InlineModels: config.InlineModels{
+				EmbeddingModels: config.EmbeddingModels{
+					EmbeddingConfig: config.HNSWConfig{
+						ModelType: "qwen3",
+					},
+				},
+			},
+		},
+		onConfigUpdate: func(*config.RouterConfig) error { return nil },
+	}
+}
+
+func assertConflictRouteStatus(t *testing.T, reconciler *Reconciler, namespace, name string) {
+	t.Helper()
+	assertReadyConditionByName(t, reconciler, namespace, "route", name, metav1.ConditionFalse, "Conflict")
+}
+
+func assertConflictPoolStatus(t *testing.T, reconciler *Reconciler, namespace, name string) {
+	t.Helper()
+	assertReadyConditionByName(t, reconciler, namespace, "pool", name, metav1.ConditionFalse, "Conflict")
+}
+
+func assertReadyConditionByName(
+	t *testing.T,
+	reconciler *Reconciler,
+	namespace, kind, name string,
+	wantStatus metav1.ConditionStatus,
+	wantReason string,
+) {
+	t.Helper()
+
+	var conditions []metav1.Condition
+	ctx := context.Background()
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+
+	switch kind {
+	case "pool":
+		var pool v1alpha1.IntelligentPool
+		if err := reconciler.client.Get(ctx, key, &pool); err != nil {
+			t.Fatalf("Get pool %s: %v", name, err)
+		}
+		conditions = pool.Status.Conditions
+	case "route":
+		var route v1alpha1.IntelligentRoute
+		if err := reconciler.client.Get(ctx, key, &route); err != nil {
+			t.Fatalf("Get route %s: %v", name, err)
+		}
+		conditions = route.Status.Conditions
+	default:
+		t.Fatalf("unknown kind %q", kind)
+	}
+
+	assertReadyCondition(t, kind+"/"+name, conditions, wantStatus, wantReason)
+}


### PR DESCRIPTION
## Summary

Fixes #1908.

`Reconciler.reconcile` retrieved the namespace's `IntelligentPool` and `IntelligentRoute` through helpers that returned an error whenever **more than one** CR of either kind existed. `reconcile()` short-circuited on that error before reaching `validateAndUpdate`, so when a second `IntelligentRoute` was applied alongside a valid one, **neither** CR ever received a status update — both sat with empty `status: {}` indefinitely, and the watch loop logged the same `multiple IntelligentRoutes found ...` error every tick.

This blocked, among other things, the embedding-modality e2e test from #1908's description: the bad CR's status stayed empty for the full polling window because the reconciler never reached the validator while a second CR was present.

## Change

- `reconcile()` now lists pools and routes directly instead of delegating to the now-removed `getIntelligentPool`/`getIntelligentRoute` single-CR helpers.
- When more than one pool or route is present, the new `reportConflict` marks **every** conflicting CR `Ready=False` / `Reason=Conflict` with an actionable message, then returns an error so the watch loop still surfaces the condition.
- The single-pool / single-route happy path is **unchanged** — exactly-one still flows through `validateAndUpdate` as before.

This is the minimal, deny-on-conflict fix: it makes the conflict observable per-CR without changing the existing single-canonical-config contract. Full multi-CR coexistence (merge / last-wins / explicit selector) remains a separate design decision, as noted in the issue.

## Tests

New `reconciler_conflict_test.go`:
- `MultipleRoutes` — two routes both end up `Ready=False`/`Conflict`.
- `MultiplePools` — two pools both end up `Ready=False`/`Conflict`.
- `TestReconcileSingleCRUnchanged` — regression canary that a single pool+route still reconciles to `Ready=True`.

```
go build ./pkg/k8s/...   # ok
go vet ./pkg/k8s/...      # ok
go test ./pkg/k8s/...     # ok (incl. existing reconciler/validation tests)
```

Signed-off-by per DCO.