### PR TITLE
[Docs] Fix agentgateway casing

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,7 +23,7 @@ Standard CI-backed profiles:
 - **multimodal-routing**: Image-modality EmbeddingSignal routing via the multi-modal-embed-small model
 - **llm-d**: LLM-D inference-gateway health plus a minimal router smoke path
 - **istio**: Istio service mesh sidecar, traffic, mTLS, and tracing behavior
-- **agentgateway**: Agentgateway gateway controller routing and extproc policy enforcement behavior
+- **agentgateway**: agentgateway gateway controller routing and extproc policy enforcement behavior
 - **production-stack**: HA, load-balancing, failover, and throughput behavior
 - **response-api**: Responses API coverage across memory, Redis, and Redis Cluster backends under one CI check
 - **ml-model-selection**: ML-based model-selection behavior
@@ -52,7 +52,7 @@ Manual-only profiles:
 | `multimodal-routing` | `chat-completions-request` | Image-modality embedding-signal routing |
 | `llm-d` | `chat-completions-request` | llm-d inference-gateway health |
 | `istio` | `chat-completions-request` | Sidecar, traffic, mTLS, and tracing |
-| `agentgateway` | `chat-completions-request` | Agentgateway gateway controller and extproc behavior |
+| `agentgateway` | `chat-completions-request` | agentgateway gateway controller and extproc behavior |
 | `production-stack` | `chat-completions-request` | HA, failover, load-balancing, throughput |
 | `response-api` | none | Responses API behavior across memory, Redis, and Redis Cluster backends |
 | `ml-model-selection` | `chat-completions-request`, `domain-classify` | ML selector behavior |

--- a/e2e/profiles/agentgateway/profile.go
+++ b/e2e/profiles/agentgateway/profile.go
@@ -20,7 +20,7 @@ const (
 	semanticRouterValuesFile = "deploy/kubernetes/agentgateway/semantic-router-values/values.yaml"
 )
 
-// Profile implements the AgentGateway test profile.
+// Profile implements the agentgateway test profile.
 type Profile struct {
 	verbose bool
 }
@@ -35,7 +35,7 @@ type setupState struct {
 	extProcPolicyApplied    bool
 }
 
-// NewProfile creates a new AgentGateway profile.
+// NewProfile creates a new agentgateway profile.
 func NewProfile() *Profile {
 	return &Profile{}
 }
@@ -47,13 +47,13 @@ func (p *Profile) Name() string {
 
 // Description returns the profile description.
 func (p *Profile) Description() string {
-	return fmt.Sprintf("Tests Semantic Router through AgentGateway (version: %s)", agentGatewayVersion)
+	return fmt.Sprintf("Tests Semantic Router through agentgateway (version: %s)", agentGatewayVersion)
 }
 
-// Setup deploys all required components for AgentGateway testing.
+// Setup deploys all required components for agentgateway testing.
 func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error {
 	p.verbose = opts.Verbose
-	p.log("Setting up AgentGateway test environment")
+	p.log("Setting up agentgateway test environment")
 
 	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
 	state := &setupState{}
@@ -72,13 +72,13 @@ func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error
 	}
 	state.gatewayAPICRDsInstalled = true
 
-	p.log("Step 2/7: Installing AgentGateway CRDs and controller")
+	p.log("Step 2/7: Installing agentgateway CRDs and controller")
 	if err := p.installAgentGateway(ctx, deployer, opts); err != nil {
-		return p.failSetup(ctx, opts, state, fmt.Errorf("install AgentGateway: %w", err))
+		return p.failSetup(ctx, opts, state, fmt.Errorf("install agentgateway: %w", err))
 	}
 	state.agentGatewayInstalled = true
 
-	p.log("Step 3/7: Creating AgentGateway proxy")
+	p.log("Step 3/7: Creating agentgateway proxy")
 	if err := p.applyManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/gateway.yaml"); err != nil {
 		return p.failSetup(ctx, opts, state, fmt.Errorf("create Gateway proxy: %w", err))
 	}
@@ -96,7 +96,7 @@ func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error
 	}
 	state.semanticRouterDeployed = true
 
-	p.log("Step 6/7: Applying AgentGateway routing resources")
+	p.log("Step 6/7: Applying agentgateway routing resources")
 	if err := p.applyManifest(ctx, opts.KubeConfig, "deploy/kubernetes/agentgateway/routing-resources.yaml"); err != nil {
 		return p.failSetup(ctx, opts, state, fmt.Errorf("apply routing resources: %w", err))
 	}
@@ -108,14 +108,14 @@ func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error
 	}
 	state.extProcPolicyApplied = true
 
-	p.log("AgentGateway test environment setup complete")
+	p.log("agentgateway test environment setup complete")
 	return nil
 }
 
 // Teardown cleans up all deployed resources.
 func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions) error {
 	p.verbose = opts.Verbose
-	p.log("Tearing down AgentGateway test environment")
+	p.log("Tearing down agentgateway test environment")
 
 	deployer := helm.NewDeployer(opts.KubeConfig, opts.Verbose)
 
@@ -127,7 +127,7 @@ func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions)
 	_ = deployer.Uninstall(ctx, "agentgateway", agentGatewayNamespace)
 	_ = deployer.Uninstall(ctx, "agentgateway-crds", agentGatewayNamespace)
 
-	p.log("AgentGateway test environment teardown complete")
+	p.log("agentgateway test environment teardown complete")
 	return nil
 }
 
@@ -139,7 +139,7 @@ func (p *Profile) GetTestCases() []string {
 	)
 }
 
-// GetServiceConfig returns the service configuration for accessing the AgentGateway proxy.
+// GetServiceConfig returns the service configuration for accessing the agentgateway proxy.
 func (p *Profile) GetServiceConfig() framework.ServiceConfig {
 	return framework.ServiceConfig{
 		Name:        agentGatewayProxyService,

--- a/e2e/testcases/agentgateway_traffic_routing.go
+++ b/e2e/testcases/agentgateway_traffic_routing.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	pkgtestcases.Register("agentgateway-traffic-routing", pkgtestcases.TestCase{
-		Description: "Test request routing through AgentGateway proxy to Semantic Router",
+		Description: "Test request routing through agentgateway proxy to Semantic Router",
 		Tags:        []string{"agentgateway", "gateway", "routing"},
 		Fn:          testAgentGatewayTrafficRouting,
 	})
@@ -34,7 +34,7 @@ func testAgentGatewayTrafficRouting(ctx context.Context, client *kubernetes.Clie
 
 	stopFunc, err := helpers.StartPortForward(ctx, client, opts.RestConfig, namespace, svcName, localPort+":80", opts.Verbose)
 	if err != nil {
-		return fmt.Errorf("failed to start port-forward to AgentGateway proxy: %w", err)
+		return fmt.Errorf("failed to start port-forward to agentgateway proxy: %w", err)
 	}
 	defer stopFunc()
 
@@ -56,7 +56,7 @@ func testAgentGatewayTrafficRouting(ctx context.Context, client *kubernetes.Clie
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to send request through AgentGateway: %w", err)
+		return fmt.Errorf("failed to send request through agentgateway: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -81,7 +81,7 @@ func testAgentGatewayTrafficRouting(ctx context.Context, client *kubernetes.Clie
 	}
 
 	if opts.Verbose {
-		fmt.Println("[Test] ✅ Traffic routing through AgentGateway successful")
+		fmt.Println("[Test] ✅ Traffic routing through agentgateway successful")
 	}
 
 	return nil

--- a/tools/agent/e2e-profile-map.yaml
+++ b/tools/agent/e2e-profile-map.yaml
@@ -95,7 +95,7 @@ profile_rules:
     owner: e2e
     coverage_role: agentgateway-integration
     selection_mode: full-ci
-    summary: Integration coverage with Agentgateway's gateway controller, including backend routing and extproc policy enforcement.
+    summary: Integration coverage with agentgateway's gateway controller, including backend routing and extproc policy enforcement.
     paths:
       - e2e/profiles/agentgateway/**
       - deploy/kubernetes/agentgateway/**

--- a/tools/make/e2e.mk
+++ b/tools/make/e2e.mk
@@ -127,7 +127,7 @@ e2e-help: ## Show help for E2E testing
 	@echo ""
 	@echo "Available Profiles:"
 	@echo "  kubernetes       - Test Semantic Router with the default Kubernetes baseline"
-	@echo "  agentgateway			 - Test Semantic Router with Agentgateway gateway controller"
+	@echo "  agentgateway			 - Test Semantic Router with agentgateway gateway controller"
 	@echo "  aibrix           - Test Semantic Router with vLLM AIBrix"F
 	@echo "  dynamo           - Test Semantic Router with Nvidia Dynamo (requires 3+ GPUs)"
 	@echo "  istio            - Test Semantic Router with Istio service mesh"

--- a/website/docs/installation/k8s/agentgateway.md
+++ b/website/docs/installation/k8s/agentgateway.md
@@ -1,13 +1,13 @@
-# Install with AgentGateway
+# Install with agentgateway
 
-This guide provides step-by-step instructions for integrating the vLLM Semantic Router with [AgentGateway](https://agentgateway.dev/) on Kubernetes. AgentGateway acts as the Gateway API data plane for OpenAI-compatible traffic, and vLLM Semantic Router runs as an Envoy ExtProc server that classifies each request and mutates the request body before AgentGateway forwards it to vLLM.
+This guide provides step-by-step instructions for integrating the vLLM Semantic Router with [agentgateway](https://agentgateway.dev/) on Kubernetes. agentgateway acts as the Gateway API data plane for OpenAI-compatible traffic, and vLLM Semantic Router runs as an Envoy ExtProc server that classifies each request and mutates the request body before agentgateway forwards it to vLLM.
 
 ## Architecture Overview
 
 The deployment consists of:
 
 - **vLLM Semantic Router**: Provides prompt classification, model selection, request mutation, and response processing through ExtProc
-- **AgentGateway**: Provides the Kubernetes Gateway API proxy, `AgentgatewayBackend`, `HTTPRoute`, and `AgentgatewayPolicy` resources
+- **agentgateway**: Provides the Kubernetes Gateway API proxy, `AgentgatewayBackend`, `HTTPRoute`, and `AgentgatewayPolicy` resources
 - **Demo vLLM-compatible backend**: Serves a base model and LoRA adapters through an OpenAI-compatible API
 
 ## Prerequisites
@@ -18,7 +18,7 @@ Before starting, ensure you have the following tools installed:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) - Kubernetes CLI
 - [Helm](https://helm.sh/docs/intro/install/) - Package manager for Kubernetes
 
-This guide requires AgentGateway `v1.3.0-alpha.1` or newer because it uses the ExtProc `processingOptions` and `allowModeOverride` fields that were added after `v1.2.1`.
+This guide requires agentgateway `v1.3.0-alpha.1` or newer because it uses the ExtProc `processingOptions` and `allowModeOverride` fields that were added after `v1.2.1`.
 
 ## Step 1: Create Kind Cluster (Optional)
 
@@ -31,9 +31,9 @@ kind create cluster --name semantic-router-agentgateway
 kubectl wait --for=condition=Ready nodes --all --timeout=300s
 ```
 
-## Step 2: Install AgentGateway
+## Step 2: Install agentgateway
 
-Install the Kubernetes Gateway API CRDs and the AgentGateway control plane:
+Install the Kubernetes Gateway API CRDs and the agentgateway control plane:
 
 ```bash
 export AGENTGATEWAY_VERSION=v1.3.0-alpha.1
@@ -57,9 +57,9 @@ helm upgrade -i agentgateway oci://cr.agentgateway.dev/charts/agentgateway \
 kubectl get pods -n agentgateway-system
 ```
 
-## Step 3: Create an AgentGateway Proxy
+## Step 3: Create an agentgateway proxy
 
-Create a Gateway that uses the AgentGateway GatewayClass:
+Create a Gateway that uses the agentgateway GatewayClass:
 
 ```bash
 kubectl apply -f- <<'EOF'
@@ -159,7 +159,7 @@ kubectl wait --for=condition=Available deployment/vllm-llama3-8b-instruct \
 
 ## Step 5: Deploy vLLM Semantic Router
 
-Install the Semantic Router in the `agentgateway-system` namespace so the AgentGateway ExtProc policy can reference the `semantic-router` service directly:
+Install the Semantic Router in the `agentgateway-system` namespace so the agentgateway ExtProc policy can reference the `semantic-router` service directly:
 
 ```bash
 helm install semantic-router oci://ghcr.io/vllm-project/charts/semantic-router \
@@ -174,7 +174,7 @@ kubectl wait --for=condition=Available deployment/semantic-router \
 
 The values file configures Semantic Router to send traffic to `vllm-llama3-8b-instruct.default.svc.cluster.local:8000` and to select adapter names such as `math-expert`, `science-expert`, and `general-expert`.
 
-## Step 6: Create AgentGateway Routing Resources
+## Step 6: Create agentgateway routing resources
 
 Create an `AgentgatewayBackend` for the vLLM-compatible backend and route OpenAI-compatible requests to it:
 
@@ -210,7 +210,7 @@ spec:
 EOF
 ```
 
-The `openai.model` field is intentionally omitted so AgentGateway uses the model name from the request body after Semantic Router selects the target model or LoRA adapter.
+The `openai.model` field is intentionally omitted so agentgateway uses the model name from the request body after Semantic Router selects the target model or LoRA adapter.
 
 ## Step 7: Attach Semantic Router as ExtProc
 
@@ -243,11 +243,11 @@ spec:
 EOF
 ```
 
-The demo uses buffered request bodies to match the existing Envoy AI Gateway and Istio examples. For large prompts, use `requestBodyMode: FullDuplexStreamed` together with a Semantic Router configuration that enables streamed body handling. AgentGateway does not support `Streamed` mode; `FullDuplexStreamed` is the only streaming option.
+The demo uses buffered request bodies to match the existing Envoy AI Gateway and Istio examples. For large prompts, use `requestBodyMode: FullDuplexStreamed` together with a Semantic Router configuration that enables streamed body handling. agentgateway does not support `Streamed` mode; `FullDuplexStreamed` is the only streaming option.
 
 ## Testing the Deployment
 
-Start a port-forward to the AgentGateway proxy:
+Start a port-forward to the agentgateway proxy:
 
 ```bash
 kubectl port-forward -n agentgateway-system svc/agentgateway-proxy 8080:80
@@ -268,11 +268,11 @@ curl -i -X POST http://localhost:8080/v1/chat/completions \
   }'
 ```
 
-Semantic Router should classify the math prompt, select the configured math route, and mutate the request model before AgentGateway forwards the request to the vLLM-compatible backend. Use `-i` to inspect Semantic Router response headers such as the selected model metadata.
+Semantic Router should classify the math prompt, select the configured math route, and mutate the request model before agentgateway forwards the request to the vLLM-compatible backend. Use `-i` to inspect Semantic Router response headers such as the selected model metadata.
 
 ## Troubleshooting
 
-**AgentGateway proxy not ready:**
+**agentgateway proxy not ready:**
 
 ```bash
 kubectl get gateway agentgateway-proxy -n agentgateway-system
@@ -280,7 +280,7 @@ kubectl get deployment agentgateway-proxy -n agentgateway-system
 kubectl logs -n agentgateway-system deployment/agentgateway
 ```
 
-**HTTPRoute or AgentGateway backend not accepted:**
+**HTTPRoute or agentgateway backend not accepted:**
 
 ```bash
 kubectl describe httproute semantic-router-vllm -n agentgateway-system


### PR DESCRIPTION
Agentgateway shouldn't be camelcase ever and should be lowercase most of the time

## Purpose

- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Docs`

## Test Plan
N/A

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [X] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [X] If the PR spans multiple modules, the title includes all relevant prefixes
- [X] Commits in this PR are signed off with `git commit -s`
- [X] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
