### PR TITLE
[Router][E2E] Add MiniMax-M3 to provider model list and tests

### DIFF
--- a/e2e/config/config.multi-provider.yaml
+++ b/e2e/config/config.multi-provider.yaml
@@ -29,6 +29,12 @@ providers:
           extra_headers:
             anthropic-version: '2023-06-01'
           type: anthropic
+    - name: MiniMax-M3
+      backend_refs:
+        - name: minimax
+          base_url: https://api.minimax.io
+          provider: minimax
+          type: minimax
     - name: MiniMax-M2.7
       backend_refs:
         - name: minimax
@@ -98,6 +104,8 @@ routing:
       description: GPT-4o Mini — OpenAI only
     - name: claude-sonnet-4-20250514
       description: Claude Sonnet 4 — Anthropic
+    - name: MiniMax-M3
+      description: MiniMax M3 — MiniMax (OpenAI-compatible)
     - name: MiniMax-M2.7
       description: MiniMax M2.7 — MiniMax (OpenAI-compatible)
     - name: Qwen/Qwen2.5-14B-Instruct

--- a/src/semantic-router/pkg/authz/authz_test.go
+++ b/src/semantic-router/pkg/authz/authz_test.go
@@ -644,7 +644,7 @@ func TestMiniMaxProvider_CustomHeaderMap(t *testing.T) {
 		"x-custom-minimax-token": "custom-minimax-key",
 	}
 
-	got := p.GetKey(ProviderMiniMax, "MiniMax-M2.5", reqHeaders)
+	got := p.GetKey(ProviderMiniMax, "MiniMax-M3", reqHeaders)
 	if got != "custom-minimax-key" {
 		t.Errorf("GetKey(MiniMax, custom) = %q, want %q", got, "custom-minimax-key")
 	}


### PR DESCRIPTION
## Purpose

- Register the new `MiniMax-M3` model alongside the existing `MiniMax-M2.7` entry in `e2e/config/config.multi-provider.yaml` (both `providers.models` and `modelCards`), so the multi-provider e2e profile exposes the latest MiniMax flagship model.
- Update the `TestMiniMaxProvider_CustomHeaderMap` fixture in `src/semantic-router/pkg/authz/authz_test.go` to reference `MiniMax-M3` so the test tracks the supported model set.
- The Anthropic-compatible `MiniMax-M2.7` entry is intentionally retained as an alternative; older `M2.5/M2.1/M2/M1` IDs are not present anywhere in this repo, so no removal is required.
- Module(s): `Router` (authz unit test) / `E2E` (multi-provider config).

## Test Plan

```bash
# 1. Targeted unit tests for the MiniMax authz integration
cd src/semantic-router
go test ./pkg/authz/... -v -run TestMiniMaxProvider

# 2. Full authz package test suite
go test ./pkg/authz/...

# 3. Config package smoke test (validates ProviderProfile / ResolveAuthHeader for minimax)
go test ./pkg/config/... -run "TestConfig$"

# 4. go vet on touched packages
go vet ./pkg/authz/...

# 5. YAML syntax check on the updated e2e config
python3 -c "import yaml; yaml.safe_load(open('e2e/config/config.multi-provider.yaml'))"
```

Why sufficient: the touched files are scoped to one e2e config fixture and one authz unit-test parameter. The authz package owns the only behavior under test (`GetKey` / `KeyForProvider` for `ProviderMiniMax`), and the config-package smoke test exercises the same `minimax` provider profile that the YAML registers.

## Test Result

- `go test ./pkg/authz/... -v -run TestMiniMaxProvider` — all 5 MiniMax tests pass (`TestMiniMaxProvider_HeaderInjection`, `_CredentialResolver`, `_FailClosed_NoKey`, `_FailOpen_NoKey`, `_CustomHeaderMap`).
- `go test ./pkg/authz/...` — all 24 authz tests pass (0.602s).
- `go test ./pkg/config/... -run "TestConfig$"` — `ok` (3.801s).
- `go vet ./pkg/authz/...` — clean.
- YAML syntax check — `OK`.
- No follow-up risks identified; change is additive (one new model entry, one fixture rename) and does not alter routing decisions, default model selection (still `gpt-4o`), or any provider's auth/transport configuration.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>