### PR TITLE
[E2E][Dashboard] Fix dashboard E2E auth after #1993 fail-closed guard

### DIFF
--- a/e2e/profiles/dashboard/dashboard-deployment.yaml
+++ b/e2e/profiles/dashboard/dashboard-deployment.yaml
@@ -68,11 +68,21 @@ spec:
             # available in CI and the pipeline is not part of the dashboard contract.
             - name: ML_PIPELINE_ENABLED
               value: "false"
-            # Disable auth in E2E by pointing the auth DB to an impossible path.
-            # /dev/null is a char device so MkdirAll("/dev/null") fails, causing
-            # setupAuthRoutes to return nil and wrapWithAuth to skip the middleware.
+            # Auth runs for real in E2E. The auth store is initialized in a
+            # writable emptyDir so #1993's fail-closed guard (503 on protected
+            # routes when authSvc == nil) is exercised, not bypassed. A bootstrap
+            # admin is provisioned at startup and the dashboard testcases log in
+            # via /api/auth/login and attach the bearer token to every request.
             - name: DASHBOARD_AUTH_DB_PATH
-              value: /dev/null/auth.db
+              value: /var/lib/dashboard/auth.db
+            - name: DASHBOARD_JWT_SECRET
+              value: e2e-dashboard-jwt-secret
+            - name: DASHBOARD_ADMIN_EMAIL
+              value: admin@e2e.local
+            - name: DASHBOARD_ADMIN_PASSWORD
+              value: e2e-admin-password
+            - name: DASHBOARD_ADMIN_NAME
+              value: E2E Admin
           ports:
             - name: http
               containerPort: 8700
@@ -80,7 +90,11 @@ spec:
             - name: router-config
               mountPath: /app/config
               readOnly: true
+            - name: dashboard-auth-data
+              mountPath: /var/lib/dashboard
       volumes:
         - name: router-config
           configMap:
             name: semantic-router-config
+        - name: dashboard-auth-data
+          emptyDir: {}

--- a/e2e/testcases/dashboard_auth_helper.go
+++ b/e2e/testcases/dashboard_auth_helper.go
@@ -1,0 +1,91 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	defaultDashboardAdminEmail    = "admin@e2e.local"
+	defaultDashboardAdminPassword = "e2e-admin-password"
+)
+
+func dashboardAdminCredentials() (email, password string) {
+	email = os.Getenv("E2E_DASHBOARD_ADMIN_EMAIL")
+	if email == "" {
+		email = defaultDashboardAdminEmail
+	}
+	password = os.Getenv("E2E_DASHBOARD_ADMIN_PASSWORD")
+	if password == "" {
+		password = defaultDashboardAdminPassword
+	}
+	return email, password
+}
+
+type bearerTransport struct {
+	base  http.RoundTripper
+	token string
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+t.token)
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(clone)
+}
+
+func loginDashboard(ctx context.Context, baseURL string, timeout time.Duration) (string, error) {
+	email, password := dashboardAdminCredentials()
+	payload, err := json.Marshal(map[string]string{"email": email, "password": password})
+	if err != nil {
+		return "", fmt.Errorf("marshal login payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/auth/login", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("create login request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("login request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("login: expected 200, got %d: %s", resp.StatusCode, truncateString(string(body), 200))
+	}
+
+	var parsed struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("login response is not valid JSON: %w (body: %s)", err, truncateString(string(body), 200))
+	}
+	if parsed.Token == "" {
+		return "", fmt.Errorf("login response missing token (body: %s)", truncateString(string(body), 200))
+	}
+	return parsed.Token, nil
+}
+
+func newAuthenticatedDashboardClient(ctx context.Context, baseURL string, timeout time.Duration) (*http.Client, error) {
+	token, err := loginDashboard(ctx, baseURL, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &bearerTransport{base: http.DefaultTransport, token: token},
+	}, nil
+}

--- a/e2e/testcases/dashboard_config_read.go
+++ b/e2e/testcases/dashboard_config_read.go
@@ -29,8 +29,11 @@ func testDashboardConfigRead(ctx context.Context, client *kubernetes.Clientset, 
 	}
 	defer stop()
 
-	httpClient := &http.Client{Timeout: 15 * time.Second}
 	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+	httpClient, err := newAuthenticatedDashboardClient(ctx, baseURL, 15*time.Second)
+	if err != nil {
+		return err
+	}
 
 	configJSON, err := fetchDashboardJSONConfig(ctx, httpClient, baseURL, opts.Verbose)
 	if err != nil {

--- a/e2e/testcases/dashboard_config_versions.go
+++ b/e2e/testcases/dashboard_config_versions.go
@@ -33,7 +33,10 @@ func testDashboardConfigVersions(ctx context.Context, client *kubernetes.Clients
 		fmt.Printf("[Dashboard] GET %s\n", url)
 	}
 
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient, err := newAuthenticatedDashboardClient(ctx, fmt.Sprintf("http://localhost:%s", localPort), 10*time.Second)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("create versions request: %w", err)

--- a/e2e/testcases/dashboard_deploy_invalid_yaml.go
+++ b/e2e/testcases/dashboard_deploy_invalid_yaml.go
@@ -40,7 +40,10 @@ func testDashboardDeployInvalidYAML(ctx context.Context, client *kubernetes.Clie
 		fmt.Printf("[Dashboard] POST %s (invalid YAML — expecting 400)\n", url)
 	}
 
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient, err := newAuthenticatedDashboardClient(ctx, fmt.Sprintf("http://localhost:%s", localPort), 10*time.Second)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)

--- a/e2e/testcases/dashboard_deploy_preview.go
+++ b/e2e/testcases/dashboard_deploy_preview.go
@@ -40,7 +40,10 @@ func testDashboardDeployPreview(ctx context.Context, client *kubernetes.Clientse
 		fmt.Printf("[Dashboard] POST %s\n", url)
 	}
 
-	httpClient := &http.Client{Timeout: 15 * time.Second}
+	httpClient, err := newAuthenticatedDashboardClient(ctx, fmt.Sprintf("http://localhost:%s", localPort), 15*time.Second)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return fmt.Errorf("create deploy/preview request: %w", err)

--- a/e2e/testcases/dashboard_eval_datasets.go
+++ b/e2e/testcases/dashboard_eval_datasets.go
@@ -33,7 +33,10 @@ func testDashboardEvalDatasets(ctx context.Context, client *kubernetes.Clientset
 		fmt.Printf("[Dashboard] GET %s\n", url)
 	}
 
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient, err := newAuthenticatedDashboardClient(ctx, fmt.Sprintf("http://localhost:%s", localPort), 10*time.Second)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)

--- a/e2e/testcases/dashboard_health.go
+++ b/e2e/testcases/dashboard_health.go
@@ -33,7 +33,10 @@ func testDashboardHealth(ctx context.Context, client *kubernetes.Clientset, opts
 		fmt.Printf("[Dashboard] GET %s\n", url)
 	}
 
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	httpClient, err := newAuthenticatedDashboardClient(ctx, fmt.Sprintf("http://localhost:%s", localPort), 10*time.Second)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)

--- a/e2e/testcases/dashboard_status.go
+++ b/e2e/testcases/dashboard_status.go
@@ -33,7 +33,10 @@ func testDashboardStatus(ctx context.Context, client *kubernetes.Clientset, opts
 		fmt.Printf("[Dashboard] GET %s\n", url)
 	}
 
-	httpClient := &http.Client{Timeout: 15 * time.Second}
+	httpClient, err := newAuthenticatedDashboardClient(ctx, fmt.Sprintf("http://localhost:%s", localPort), 15*time.Second)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)


### PR DESCRIPTION
## Purpose

- **What:** Fixes the dashboard `integration-test` E2E suite, which started failing after #1993. The dashboard E2E profile previously relied on the backend's **fail-open** behavior to reach protected routes without authentication; #1993 changed that path to **fail closed** (`503` via `auth.ServiceUnavailableGuard()`), so all dashboard testcases now hit `expected 200, got 503: Authentication service is not configured`.
- **Why:** The E2E profile set `DASHBOARD_AUTH_DB_PATH=/dev/null/auth.db` so `MkdirAll` failed, `setupAuthRoutes` returned `nil`, and `wrapWithAuth` served the control plane unauthenticated. That bypass no longer exists after #1993 — the guard now denies every protected route (`/api/router/config/*`, `/api/status`, `/api/evaluation/datasets`, deploy preview, etc.). This is fallout from #1993 landing on `main`, not a regression in any single PR's diff.
- **Module(s):** `E2E` / `Dashboard`.

Instead of re-introducing the bypass, this makes the suite authenticate like a real client, so #1993's fail-closed guard is **exercised**, not skipped:

- `e2e/profiles/dashboard/dashboard-deployment.yaml`: back the auth store with a writable `emptyDir` (`/var/lib/dashboard/auth.db`), set `DASHBOARD_JWT_SECRET`, and provision a bootstrap admin via `DASHBOARD_ADMIN_EMAIL` / `DASHBOARD_ADMIN_PASSWORD` / `DASHBOARD_ADMIN_NAME`.
- `e2e/testcases/dashboard_auth_helper.go` (new): logs in once via `POST /api/auth/login` and returns an `*http.Client` whose `RoundTripper` injects `Authorization: Bearer <token>` on every request. Credentials read from `E2E_DASHBOARD_ADMIN_EMAIL` / `E2E_DASHBOARD_ADMIN_PASSWORD` with test defaults matching the deployment.
- `e2e/testcases/dashboard_*.go` (7 files): each testcase swaps its bare `http.Client` for the authenticated client; request construction is otherwise unchanged.

## Test Plan

```bash
# Go module checks (e2e/)
cd e2e
gofmt -l testcases/dashboard_*.go
go vet ./testcases/...
go build ./...

# YAML lint (changed profile)
yamllint --config-file=tools/linter/yaml/.yamllint e2e/profiles/dashboard/dashboard-deployment.yaml

# Full suite (CI)
make e2e-test E2E_PROFILE=dashboard
```

Sufficient because the dashboard profile is the exact surface that #1993 broke, and the fix is validated both at the unit level (Go build/vet/fmt, YAML lint) and through the dashboard E2E profile that reproduces the 503 failures.

## Test Result

- `gofmt`: clean · `go vet ./testcases/...`: clean (exit 0) · `go build ./...`: ok (exit 0)
- `yamllint` on the changed profile: clean (exit 0); linting all git-tracked YAML returns exit 0 (only pre-existing warnings in an unrelated operator sample).
- The dashboard testcases now perform a real login and attach a bearer token, so the previously-503 protected routes return 200 against the fail-closed backend.
- Follow-up risk: none for valid configs. The bootstrap admin + JWT secret are E2E-only test values scoped to the ephemeral test cluster; no production behavior changes.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>