### PR TITLE
Resolves #2010: bug: <Auth Related Integ Test Failing>

### DIFF
--- a/dashboard/backend/router/auth_routes.go
+++ b/dashboard/backend/router/auth_routes.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
@@ -24,7 +26,21 @@ var dashboardAuthRouteSpecs = []authRouteSpec{
 
 const authUnavailableResponse = `{"error":"Service not available","message":"Authentication service is not configured"}`
 
+func ensureAuthDBDir(dbPath string) error {
+	dir := filepath.Dir(dbPath)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o755)
+}
+
 func setupAuthRoutes(mux *http.ServeMux, cfg *config.Config) *auth.Service {
+	if err := ensureAuthDBDir(cfg.AuthDBPath); err != nil {
+		log.Printf("failed to prepare auth DB directory for %q: %v", cfg.AuthDBPath, err)
+		registerAuthUnavailableRoutes(mux)
+		return nil
+	}
+
 	store, err := auth.NewStore(cfg.AuthDBPath)
 	if err != nil {
 		log.Printf("failed to init auth store: %v", err)

--- a/e2e/profiles/dashboard/dashboard-deployment.yaml
+++ b/e2e/profiles/dashboard/dashboard-deployment.yaml
@@ -72,11 +72,11 @@ spec:
             # store cannot be initialized, so the tests use this bootstrap admin
             # and a writable temporary SQLite store.
             - name: DASHBOARD_AUTH_DB_PATH
-              value: /tmp/vllm-sr-dashboard/auth.db
+              value: /tmp/dashboard-auth.db
             - name: DASHBOARD_WORKFLOW_DB_PATH
-              value: /tmp/vllm-sr-dashboard/workflow.sqlite
+              value: /tmp/dashboard-workflow.sqlite
             - name: EVALUATION_DB_PATH
-              value: /tmp/vllm-sr-dashboard/evaluations.db
+              value: /tmp/dashboard-evaluations.db
             - name: DASHBOARD_JWT_SECRET
               value: dashboard-e2e-jwt-secret
             - name: DASHBOARD_ADMIN_EMAIL


### PR DESCRIPTION
Closes #2010

I can draft the plan, but I’m currently **blocked from repository reads** in this session (`No interactive UI is attached to handle permission requests` on every file-read/tool call), so the anchors below are based on the provided localizer context rather than fresh in-session verification.

### 1. **Understanding**
The failing CI integration tests are hitting dashboard endpoints that expect `200 OK`, but the dashboard is returning `503 Authentication service is not configured`. The failure pattern points to auth service/store initialization failing during dashboard startup, after which middleware intentionally fail-closes protected routes. The fix should ensure auth initialization is reliable in the E2E dashboard profile (DB path/env/runtime wiring), and add coverage for the auth-init-failure branch so regressions are caught earlier.

### 2. **Affected files**
- `dashboard/backend/router/auth_routes.go`
- `dashboard/backend/config/config.go`
- `dashboard/backend/auth/middleware.go`
- `e2e/profiles/dashboard/dashboard-deployment.yaml`
- `e2e/testcases/dashboard_auth.go`
- `e2e/testcases/dashboard_status.go`
- `e2e/testcases/dashboard_config_read.go`
- `e2e/testcases/security_policy_apply.go`
- `e2e/pkg/testmatrix/testcases.go`

### 3. **Proposed change**
1. Confirm and harden dashboard auth DB/runtime wiring in E2E profile:
   - Ensure writable DB envs and backing directory are always present in `e2e/profiles/dashboard/dashboard-deployment.yaml` (existing pattern references include `DASHBOARD_AUTH_DB_PATH` / `DASHBOARD_WORKFLOW_DB_PATH` around `:72-85`).
2. Make auth init failure diagnosable and deterministic at router bootstrap:
   - Review `setupAuthRoutes` and fallback registration in `dashboard/backend/router/auth_routes.go:27,50,90` to ensure startup behavior is explicit and consistent with middleware expectations.
3. Verify config/env binding consistency end-to-end:
   - Validate `bindAuthFlags` / `applyAuthConfig` in `dashboard/backend/config/config.go:78,170` against the E2E deployment env names and defaults.
4. Keep protected-route behavior strict but scoped:
   - Re-check `ServiceUnavailableGuard` and `requiresAuthentication` in `dashboard/backend/auth/middleware.go:78,349` so only intended routes fail with 503 when auth is unavailable.
5. Add missing unit coverage for router auth-init-failure branch:
   - Add tests around `setupAuthRoutes`/`wrapWithAuth` fail path (currently identified gap), and keep existing E2E expectations aligned:
     - `e2e/testcases/dashboard_status.go:54`
     - `e2e/testcases/dashboard_config_read.go:76-78`
     - `e2e/testcases/security_policy_apply.go:124-126`

### 4. **Risks**
- Tightening startup/auth wiring could change startup failure mode (e.g., fail-open vs fail-closed expectations) if not kept consistent across router + middleware.
- Deployment/env changes may pass local tests but still fail in CI if image/tag provenance is stale or not rebuilt in the same workflow.
- Tests that must pass:
  - Dashboard contract/E2E cases (`dashboard-status`, `dashboard-config-read`, `security-policy-apply`)
  - Dashboard auth/middleware unit tests (including new auth-init-failure router test coverage)
  - Relevant harness gates for touched files (`agent-lint`, `agent-ci-gate`, plus affected E2E selection)

### 5. **Next steps**