### PR TITLE
[Router] consume session retention directives (ttl_turns, keep_current_model, prefer_prefix_retention)

### DIFF
--- a/dashboard/frontend/src/components/HeaderDisplay.tsx
+++ b/dashboard/frontend/src/components/HeaderDisplay.tsx
@@ -143,6 +143,23 @@ const HEADER_INFO: Record<string, { label: string; type: 'info' | 'success' | 'w
     label: 'Algorithm',
     type: 'info',
   },
+  // Retention directive headers (issue #2009)
+  'x-vsr-retention-drop': {
+    label: 'Retention: Drop',
+    type: 'warning',
+  },
+  'x-vsr-retention-ttl-turns': {
+    label: 'Retention TTL (turns)',
+    type: 'info',
+  },
+  'x-vsr-retention-keep-current-model': {
+    label: 'Keep Current Model',
+    type: 'info',
+  },
+  'x-vsr-retention-prefer-prefix': {
+    label: 'Prefer Prefix',
+    type: 'info',
+  },
 }
 
 function shouldSummarizeHeaderValue(key: string, values: string[]): boolean {

--- a/dashboard/frontend/src/components/HeaderReveal.tsx
+++ b/dashboard/frontend/src/components/HeaderReveal.tsx
@@ -150,6 +150,23 @@ const HEADER_INFO: Record<string, { label: string; description: string }> = {
     label: 'Algorithm',
     description: 'The multi-model algorithm used (confidence, ratings)',
   },
+  // Retention directive headers (issue #2009)
+  'x-vsr-retention-drop': {
+    label: 'Retention: Drop',
+    description: 'Matched decision asked to skip the semantic-cache write',
+  },
+  'x-vsr-retention-ttl-turns': {
+    label: 'Retention TTL (turns)',
+    description: 'Per-entry semantic-cache lifetime override, in conversation turns',
+  },
+  'x-vsr-retention-keep-current-model': {
+    label: 'Keep Current Model',
+    description: 'Forces the model-switch gate to stay on the current model',
+  },
+  'x-vsr-retention-prefer-prefix': {
+    label: 'Prefer Prefix',
+    description: 'Hints the inference pool to keep the prompt prefix / KV cache warm',
+  },
 }
 
 const HeaderReveal = ({ headers, onComplete, displayDuration = 2000 }: HeaderRevealProps) => {
@@ -200,6 +217,10 @@ const HeaderReveal = ({ headers, onComplete, displayDuration = 2000 }: HeaderRev
     looper: displayHeaders.filter(([key]) =>
       key.startsWith('x-vsr-looper-')
     ),
+    // Retention directive headers: all x-vsr-retention-*
+    retention: displayHeaders.filter(([key]) =>
+      key.startsWith('x-vsr-retention-')
+    ),
   }
 
   const renderSection = (title: string, items: [string, string][], isPrimary = false) => {
@@ -232,6 +253,7 @@ const HeaderReveal = ({ headers, onComplete, displayDuration = 2000 }: HeaderRev
           {renderSection('SIGNALS', groupedHeaders.signals)}
           {renderSection('PLUGIN', groupedHeaders.plugin)}
           {renderSection('LOOPER', groupedHeaders.looper)}
+          {renderSection('RETENTION', groupedHeaders.retention)}
         </div>
         <div className={styles.hint}>
           Response will appear shortly...

--- a/dashboard/frontend/src/components/chatRequestSupport.ts
+++ b/dashboard/frontend/src/components/chatRequestSupport.ts
@@ -50,6 +50,10 @@ const RESPONSE_HEADER_KEYS = [
   'x-vsr-looper-models-used',
   'x-vsr-looper-iterations',
   'x-vsr-looper-algorithm',
+  'x-vsr-retention-drop',
+  'x-vsr-retention-ttl-turns',
+  'x-vsr-retention-keep-current-model',
+  'x-vsr-retention-prefer-prefix',
 ] as const
 
 export const buildChatMessages = (

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -26,6 +26,8 @@ var BaselineRouterContract = []string{
 	"plugin-config-variations",
 	"chat-completions-progressive-stress",
 	"anthropic-passthrough-openai-regression",
+	// Retention directive response-header contract (issue #2009)
+	"retention-directive",
 	// Session observability
 	"session-telemetry-metrics",
 	"session-pricing-chat-completions",

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -51,6 +51,24 @@ config:
           - type: fast_response
             configuration:
               message: Your request contains personal information. Please remove any sensitive data and try again.
+      - name: retention_probe_decision
+        description: Deterministic keyword-gated route used by the retention-directive E2E to assert x-vsr-retention-* response headers (issue #2009).
+        priority: 600
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: retention_probe_keywords
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        emits:
+          - kind: retention
+            retention:
+              ttl_turns: 0
+              keep_current_model: true
+              prefer_prefix_retention: true
       - name: tool_selection_add_weather_decision
         description: Contract route for tool_selection add mode (weather-aligned retrieval)
         priority: 500
@@ -558,6 +576,11 @@ config:
           operator: OR
           keywords:
             - __TOOL_SELECTION_WITH_SYSTEM_PROMPT__
+          case_sensitive: false
+        - name: retention_probe_keywords
+          operator: OR
+          keywords:
+            - __RETENTION_PROBE__
           case_sensitive: false
       domains:
         - name: business

--- a/e2e/testcases/retention_directive.go
+++ b/e2e/testcases/retention_directive.go
@@ -1,0 +1,106 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("retention-directive", pkgtestcases.TestCase{
+		Description: "Verify EMIT retention directives surface as x-vsr-retention-* response headers (issue #2009)",
+		Tags:        []string{"kubernetes", "routing", "retention", "headers"},
+		Fn:          testRetentionDirective,
+	})
+}
+
+// retentionProbeKeyword is the sentinel token wired into the kubernetes
+// profile's retention_probe_decision (see e2e/profiles/ai-gateway/values.yaml).
+// A prompt containing it deterministically routes to that decision, which emits
+//
+//	retention { ttl_turns: 0, keep_current_model: true, prefer_prefix_retention: true }
+//
+// so the router must mirror those fields onto the response as x-vsr-retention-*
+// headers.
+const retentionProbeKeyword = "__RETENTION_PROBE__"
+
+// testRetentionDirective asserts the response-header half of the EMIT retention
+// contract end-to-end: every explicitly-set field is emitted, an explicit
+// ttl_turns: 0 is preserved (tri-state regression guard), and an unset field
+// (drop) is omitted.
+func testRetentionDirective(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing retention directive response headers")
+	}
+
+	localPort, stopPortForward, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopPortForward()
+
+	query := "Diagnostics request " + retentionProbeKeyword + " please run."
+
+	response, err := sendLocalChatCompletion(ctx, localPort, "MoM", query, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("retention directive request failed: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		logUnexpectedChatCompletionStatus(opts.Verbose, response, "retention-directive", "Query: "+query)
+		return fmt.Errorf("retention directive request: %s", formatUnexpectedChatCompletionStatus(response))
+	}
+
+	// Guard: confirm the keyword rule actually matched the retention probe
+	// decision. Without this, a silently non-matching rule would make the
+	// header assertions vacuous (all absent, but for the wrong reason).
+	if decision := response.Headers.Get("x-vsr-selected-decision"); decision != "retention_probe_decision" {
+		logUnexpectedChatCompletionStatus(opts.Verbose, response, "retention-directive", "Query: "+query)
+		return fmt.Errorf("expected x-vsr-selected-decision=retention_probe_decision, got %q", decision)
+	}
+
+	// Every explicitly-set retention field must be emitted. ttl_turns is the
+	// tri-state regression guard (issue #2009): an explicit 0 must still be
+	// emitted, not dropped by a ">0" gate.
+	expected := []struct {
+		header string
+		want   string
+	}{
+		{"x-vsr-retention-ttl-turns", "0"},
+		{"x-vsr-retention-keep-current-model", "true"},
+		{"x-vsr-retention-prefer-prefix", "true"},
+	}
+	for _, e := range expected {
+		got := response.Headers.Get(e.header)
+		if got != e.want {
+			return fmt.Errorf("header %s: expected %q, got %q", e.header, e.want, got)
+		}
+		if opts.Verbose {
+			fmt.Printf("[Test]   %s = %q ✓\n", e.header, got)
+		}
+	}
+
+	// drop was not set on the probe decision; tri-state semantics require an
+	// unset field to be omitted rather than sent as a default.
+	if got := response.Headers.Get("x-vsr-retention-drop"); got != "" {
+		return fmt.Errorf("x-vsr-retention-drop must be absent for an unset field, got %q", got)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"decision":                           "retention_probe_decision",
+			"x-vsr-retention-ttl-turns":          "0",
+			"x-vsr-retention-keep-current-model": "true",
+			"x-vsr-retention-prefer-prefix":      "true",
+			"x-vsr-retention-drop-absent":        true,
+		})
+	}
+
+	if opts.Verbose {
+		fmt.Println("[Test] Retention directive response headers verified ✓")
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/config/decision_config.go
+++ b/src/semantic-router/pkg/config/decision_config.go
@@ -28,10 +28,12 @@ type EmitDirective struct {
 // response/cache surface. All fields are tri-state pointers so we can
 // distinguish "unset" from an explicit zero value.
 //
-// MVP runtime consumes only Drop. The remaining fields are contract-only and
-// observed via log + trace attributes; their runtime consumers will land in
-// follow-up PRs (#1742 turn telemetry, #1749 model_switch_gate, prefix cache
-// eviction hints).
+// Runtime consumes Drop (semantic-cache write skip), TTLTurns (per-entry
+// cache TTL override), and KeepCurrentModel (model-switch-gate forced stay).
+// PreferPrefixRetention is emitted to the pool as an x-vsr-retention-prefer-prefix
+// header; its session-aware scoring bias and KV-cache eviction integration are
+// follow-up work. All set fields are also observed via log + trace attributes
+// and emitted as x-vsr-retention-* response headers (issues #1747, #2009).
 type RetentionDirective struct {
 	Drop                  *bool `yaml:"drop,omitempty" json:"drop,omitempty"`
 	TTLTurns              *int  `yaml:"ttl_turns,omitempty" json:"ttl_turns,omitempty"`

--- a/src/semantic-router/pkg/extproc/model_switch_gate.go
+++ b/src/semantic-router/pkg/extproc/model_switch_gate.go
@@ -37,12 +37,13 @@ func (r *OpenAIRouter) applyModelSwitchGate(
 
 	gate := selection.NewModelSwitchGate(cfg, r.LookupTable)
 	decision := gate.Evaluate(selection.ModelSwitchGateInput{
-		SelectionContext: selCtx,
-		SelectionResult:  result,
-		CurrentModel:     currentModel,
-		CandidateModel:   selectedModelRef.Model,
-		CacheWarmth:      cacheWarmth,
-		CacheWarmthOK:    cacheWarmthOK,
+		SelectionContext:      selCtx,
+		SelectionResult:       result,
+		CurrentModel:          currentModel,
+		CandidateModel:        selectedModelRef.Model,
+		CacheWarmth:           cacheWarmth,
+		CacheWarmthOK:         cacheWarmthOK,
+		ForceKeepCurrentModel: retentionWantsKeepCurrentModel(ctx),
 	})
 
 	fields := decision.LogFields()

--- a/src/semantic-router/pkg/extproc/model_switch_gate_test.go
+++ b/src/semantic-router/pkg/extproc/model_switch_gate_test.go
@@ -81,6 +81,27 @@ func TestEstimateGateCacheWarmthEmptyModel(t *testing.T) {
 	}
 }
 
+func TestApplyModelSwitchGateHonorsRetentionKeepCurrentModel(t *testing.T) {
+	// Even in shadow mode, an explicit EMIT retention { keep_current_model: true }
+	// forces a stay on the previous model (the directive is not a heuristic).
+	router := routerWithModelSwitchGate(selection.ModelSwitchGateModeShadow)
+	selCtx, result := modelSwitchGateSelectionInput()
+	selected := &selCtx.CandidateModels[1] // "candidate"
+
+	got, applied := router.applyModelSwitchGate(selCtx, result, selected, &RequestContext{
+		RequestID:        "req-keep",
+		PreviousModel:    "current",
+		EmittedRetention: &config.RetentionDirective{KeepCurrentModel: boolPtr(true)},
+	})
+
+	if !applied {
+		t.Fatalf("keep_current_model must override the selected model even in shadow mode")
+	}
+	if got.Model != "current" {
+		t.Fatalf("expected current model, got %q", got.Model)
+	}
+}
+
 func routerWithModelSwitchGate(mode string) *OpenAIRouter {
 	lt := lookuptable.NewMemoryStorage()
 	_ = lt.Set(lookuptable.HandoffPenaltyKey("current", "candidate"), lookuptable.Entry{Value: 0.05})

--- a/src/semantic-router/pkg/extproc/processor_res_cache.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache.go
@@ -52,6 +52,9 @@ func (r *OpenAIRouter) updateResponseCache(ctx *RequestContext, responseBody []b
 	if r != nil && r.Config != nil {
 		ttlSeconds = r.Config.GetCacheTTLSecondsForDecision(decisionName)
 	}
+	// Retention ttl_turns (when set) overrides the decision/global default,
+	// scoping this entry to a turn-bounded lifetime (§2.8 order: ... -> TTL -> write).
+	ttlSeconds = applyRetentionTTLOverride(ttlSeconds, ctx)
 	if err := r.Cache.UpdateWithResponse(ctx.RequestID, responseBody, ttlSeconds); err != nil {
 		logging.Errorf("Error updating cache: %v", err)
 		return
@@ -242,6 +245,9 @@ func (r *OpenAIRouter) cacheReconstructedStreamingResponse(
 	if r != nil && r.Config != nil {
 		ttlSeconds = r.Config.GetCacheTTLSecondsForDecision(decisionName)
 	}
+	// Retention ttl_turns (when set) overrides the decision/global default for
+	// the reconstructed streaming entry, mirroring the non-streaming path.
+	ttlSeconds = applyRetentionTTLOverride(ttlSeconds, ctx)
 
 	if ctx.RequestID == "" {
 		logging.Warnf("No request ID available, cannot cache streaming response")

--- a/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
@@ -20,11 +20,13 @@ const retentionDropReason = "retention.drop"
 // The boolean indicates skip; the string is the canonical reason for
 // metrics/log/trace observability.
 //
-// Contract (issue #1747, MVP):
-//   - Only `retention.drop=true` triggers a skip.
-//   - `ttl_turns`, `keep_current_model`, `prefer_prefix_retention` are
-//     contract-only in this PR (observed but not consumed at the cache write
-//     surface).
+// Contract (issues #1747, #2009):
+//   - Only `retention.drop=true` triggers a write skip here.
+//   - `ttl_turns` is consumed separately as a per-entry TTL override
+//     (applyRetentionTTLOverride), not as a skip; `drop` and `ttl_turns` are
+//     mutually exclusive by validation.
+//   - `keep_current_model` is consumed by the model-switch gate;
+//     `prefer_prefix_retention` is emitted to the pool as a response header.
 //   - This gate does NOT affect cache reads; read-side gating lives in
 //     req_filter_cache.go.
 func ShouldSkipCacheWrite(ctx *RequestContext) (bool, string) {
@@ -88,10 +90,9 @@ func retentionWantsKeepCurrentModel(ctx *RequestContext) bool {
 // are nil are not recorded — preserving the tri-state (unset vs explicit zero)
 // semantics of the schema.
 //
-// This helper closes the contract loop for the three contract-only fields
-// (ttl_turns / keep_current_model / prefer_prefix_retention): even though
-// runtime does not consume them in this PR, they remain auditable end-to-end
-// (DSL → AST → config → ctx → log/trace) so operators can verify wiring.
+// This records every declared field for audit (DSL → AST → config → ctx →
+// log/trace) regardless of which fields the runtime consumes, complementing the
+// x-vsr-retention-* response headers so operators can verify wiring end-to-end.
 func observeRetentionDirective(ctx *RequestContext) {
 	if ctx == nil || ctx.EmittedRetention == nil {
 		return

--- a/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
@@ -37,6 +37,43 @@ func ShouldSkipCacheWrite(ctx *RequestContext) (bool, string) {
 	return false, ""
 }
 
+// retentionDefaultSecondsPerTurn converts a retention `ttl_turns` directive into
+// a per-entry cache TTL. The retention contract expresses lifetime in
+// conversation turns, but the semantic cache backends key expiry on wall-clock
+// seconds, so one turn is approximated as this many seconds. This is a
+// deliberate MVP simplification (issue #2009); promoting it to a configurable
+// knob (e.g. global.router.retention.seconds_per_turn) is a follow-up.
+const retentionDefaultSecondsPerTurn = 60
+
+// retentionTTLOverrideSeconds converts an emitted retention `ttl_turns`
+// directive into a per-entry cache TTL in seconds. Only a positive ttl_turns
+// produces an override; nil and zero fall through — config/DSL validation
+// already rejects negatives, forbids drop=true together with ttl_turns>0, and
+// treats ttl_turns=0 as a no-op (validator_decision_emit.go). Returns
+// (seconds, true) only when an override applies.
+func retentionTTLOverrideSeconds(ctx *RequestContext) (int, bool) {
+	if ctx == nil || ctx.EmittedRetention == nil || ctx.EmittedRetention.TTLTurns == nil {
+		return 0, false
+	}
+	turns := *ctx.EmittedRetention.TTLTurns
+	if turns <= 0 {
+		return 0, false
+	}
+	return turns * retentionDefaultSecondsPerTurn, true
+}
+
+// applyRetentionTTLOverride returns the cache-write TTL (seconds) to use,
+// preferring an emitted retention `ttl_turns` override over the decision/global
+// default. Callers compute the base TTL (GetCacheTTLSecondsForDecision) first
+// and pass it here. This runs only after the drop gate (ShouldSkipCacheWrite);
+// drop and ttl_turns are mutually exclusive by validation.
+func applyRetentionTTLOverride(base int, ctx *RequestContext) int {
+	if override, ok := retentionTTLOverrideSeconds(ctx); ok {
+		return override
+	}
+	return base
+}
+
 // observeRetentionDirective records every declared field of the emitted
 // retention directive to log + trace. It is invoked once per matched decision
 // (right after the deep clone in applyDecisionResultToContext). Fields that

--- a/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
@@ -39,20 +39,14 @@ func ShouldSkipCacheWrite(ctx *RequestContext) (bool, string) {
 	return false, ""
 }
 
-// retentionDefaultSecondsPerTurn converts a retention `ttl_turns` directive into
-// a per-entry cache TTL. The retention contract expresses lifetime in
-// conversation turns, but the semantic cache backends key expiry on wall-clock
-// seconds, so one turn is approximated as this many seconds. This is a
-// deliberate MVP simplification (issue #2009); promoting it to a configurable
-// knob (e.g. global.router.retention.seconds_per_turn) is a follow-up.
+// retentionDefaultSecondsPerTurn approximates one conversation turn as this many
+// wall-clock seconds, bridging the turn-based `ttl_turns` directive to the
+// seconds-based semantic-cache expiry. A configurable knob is follow-up work.
 const retentionDefaultSecondsPerTurn = 60
 
-// retentionTTLOverrideSeconds converts an emitted retention `ttl_turns`
-// directive into a per-entry cache TTL in seconds. Only a positive ttl_turns
-// produces an override; nil and zero fall through — config/DSL validation
-// already rejects negatives, forbids drop=true together with ttl_turns>0, and
-// treats ttl_turns=0 as a no-op (validator_decision_emit.go). Returns
-// (seconds, true) only when an override applies.
+// retentionTTLOverrideSeconds converts an emitted retention `ttl_turns` into a
+// per-entry cache TTL in seconds. Only a positive ttl_turns produces an override
+// (nil and zero fall through); returns (seconds, true) only when one applies.
 func retentionTTLOverrideSeconds(ctx *RequestContext) (int, bool) {
 	if ctx == nil || ctx.EmittedRetention == nil || ctx.EmittedRetention.TTLTurns == nil {
 		return 0, false

--- a/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_retention.go
@@ -74,6 +74,14 @@ func applyRetentionTTLOverride(base int, ctx *RequestContext) int {
 	return base
 }
 
+// retentionWantsKeepCurrentModel reports whether the emitted retention directive
+// explicitly set keep_current_model: true. The model-switch gate consumes this
+// as a forced-stay directive (honored regardless of shadow/enforce mode).
+func retentionWantsKeepCurrentModel(ctx *RequestContext) bool {
+	return ctx != nil && ctx.EmittedRetention != nil &&
+		ctx.EmittedRetention.KeepCurrentModel != nil && *ctx.EmittedRetention.KeepCurrentModel
+}
+
 // observeRetentionDirective records every declared field of the emitted
 // retention directive to log + trace. It is invoked once per matched decision
 // (right after the deep clone in applyDecisionResultToContext). Fields that

--- a/src/semantic-router/pkg/extproc/processor_res_cache_retention_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_retention_test.go
@@ -288,6 +288,103 @@ func TestCacheStreamingResponseChecksScopeBeforeRetentionDrop(t *testing.T) {
 	}
 }
 
+func TestRetentionTTLOverrideSeconds(t *testing.T) {
+	cases := []struct {
+		name    string
+		ctx     *RequestContext
+		wantSec int
+		wantOK  bool
+	}{
+		{name: "nil_ctx", ctx: nil, wantSec: 0, wantOK: false},
+		{name: "no_retention", ctx: &RequestContext{}, wantSec: 0, wantOK: false},
+		{
+			name:    "ttl_turns_unset",
+			ctx:     &RequestContext{EmittedRetention: &config.RetentionDirective{Drop: retBool(false)}},
+			wantSec: 0, wantOK: false,
+		},
+		{
+			name:    "ttl_turns_zero_is_noop",
+			ctx:     &RequestContext{EmittedRetention: &config.RetentionDirective{TTLTurns: intPtr(0)}},
+			wantSec: 0, wantOK: false,
+		},
+		{
+			name:    "ttl_turns_positive",
+			ctx:     &RequestContext{EmittedRetention: &config.RetentionDirective{TTLTurns: intPtr(3)}},
+			wantSec: 3 * retentionDefaultSecondsPerTurn, wantOK: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sec, ok := retentionTTLOverrideSeconds(tc.ctx)
+			if sec != tc.wantSec || ok != tc.wantOK {
+				t.Fatalf("got (%d,%v), want (%d,%v)", sec, ok, tc.wantSec, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestApplyRetentionTTLOverride(t *testing.T) {
+	const base = 42
+	if got := applyRetentionTTLOverride(base, &RequestContext{}); got != base {
+		t.Fatalf("no retention: got %d, want base %d", got, base)
+	}
+	ctx := &RequestContext{EmittedRetention: &config.RetentionDirective{TTLTurns: intPtr(2)}}
+	if got := applyRetentionTTLOverride(base, ctx); got != 2*retentionDefaultSecondsPerTurn {
+		t.Fatalf("ttl_turns override: got %d, want %d", got, 2*retentionDefaultSecondsPerTurn)
+	}
+}
+
+func TestUpdateResponseCacheAppliesRetentionTTL(t *testing.T) {
+	mockCache := &mockStreamingCache{}
+	router := &OpenAIRouter{
+		Cache: mockCache,
+		Config: &config.RouterConfig{
+			SemanticCache: config.SemanticCache{Enabled: true},
+			IntelligentRouting: config.IntelligentRouting{
+				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+			},
+		},
+	}
+	ctx := &RequestContext{
+		RequestID:               "req-retention-ttl",
+		VSRSelectedDecisionName: "cache-decision",
+		EmittedRetention:        &config.RetentionDirective{TTLTurns: intPtr(2)},
+	}
+
+	router.updateResponseCache(ctx, []byte(`{"choices":[]}`))
+	if !mockCache.updateCalled {
+		t.Fatalf("ttl_turns must still write the cache entry")
+	}
+	if mockCache.lastTTLSeconds != 2*retentionDefaultSecondsPerTurn {
+		t.Fatalf("non-streaming ttl_turns override: got %d, want %d", mockCache.lastTTLSeconds, 2*retentionDefaultSecondsPerTurn)
+	}
+}
+
+func TestCacheStreamingResponseAppliesRetentionTTL(t *testing.T) {
+	mockCache := &mockStreamingCache{}
+	router := &OpenAIRouter{
+		Cache: mockCache,
+		Config: &config.RouterConfig{
+			SemanticCache: config.SemanticCache{Enabled: true},
+			IntelligentRouting: config.IntelligentRouting{
+				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+			},
+		},
+	}
+	ctx := retentionStreamingContext("cache-decision")
+	ctx.EmittedRetention = &config.RetentionDirective{TTLTurns: intPtr(4)}
+
+	if err := router.cacheStreamingResponse(ctx); err != nil {
+		t.Fatalf("cacheStreamingResponse() error = %v", err)
+	}
+	if !mockCache.addEntryCalled && !mockCache.updateCalled {
+		t.Fatalf("ttl_turns streaming must still write the cache entry")
+	}
+	if mockCache.lastTTLSeconds != 4*retentionDefaultSecondsPerTurn {
+		t.Fatalf("streaming ttl_turns override: got %d, want %d", mockCache.lastTTLSeconds, 4*retentionDefaultSecondsPerTurn)
+	}
+}
+
 func retentionCacheDecision(name string, cacheEnabled bool) config.Decision {
 	decision := config.Decision{
 		Name:      name,

--- a/src/semantic-router/pkg/extproc/processor_res_cache_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_test.go
@@ -23,6 +23,7 @@ type mockStreamingCache struct {
 	updateResponseBody []byte
 	addEntryErr        error
 	updateErr          error
+	lastTTLSeconds     int
 }
 
 func (m *mockStreamingCache) IsEnabled() bool { return true }
@@ -40,10 +41,11 @@ func (m *mockStreamingCache) AddPendingRequest(
 	return nil
 }
 
-func (m *mockStreamingCache) UpdateWithResponse(requestID string, responseBody []byte, _ int) error {
+func (m *mockStreamingCache) UpdateWithResponse(requestID string, responseBody []byte, ttlSeconds int) error {
 	m.updateCalled = true
 	m.updateRequestID = requestID
 	m.updateResponseBody = append([]byte(nil), responseBody...)
+	m.lastTTLSeconds = ttlSeconds
 	return m.updateErr
 }
 
@@ -53,9 +55,10 @@ func (m *mockStreamingCache) AddEntry(
 	_ string,
 	_ []byte,
 	_ []byte,
-	_ int,
+	ttlSeconds int,
 ) error {
 	m.addEntryCalled = true
+	m.lastTTLSeconds = ttlSeconds
 	return m.addEntryErr
 }
 

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -238,7 +238,34 @@ func buildResponseHeaderMutation(
 
 	addStandardDecisionHeaders(builder, ctx)
 	addMatchedSignalHeaders(builder, ctx)
+	addRetentionDirectiveHeaders(builder, ctx)
 	return builder.mutation()
+}
+
+// addRetentionDirectiveHeaders emits the matched decision's EMIT retention
+// directive to the response as x-vsr-retention-* headers so the inference pool
+// and operators can observe the router's retention intent at the wire
+// (issue #2009). Only fields the directive explicitly set are emitted, mirroring
+// the tri-state semantics of config.RetentionDirective; an unset field is
+// omitted rather than sent as a default. Emitted only on successful,
+// non-cache-hit responses (same gate as the standard decision headers).
+func addRetentionDirectiveHeaders(builder *responseHeaderMutationBuilder, ctx *RequestContext) {
+	r := ctx.EmittedRetention
+	if r == nil {
+		return
+	}
+	if r.Drop != nil {
+		builder.addBool(headers.VSRRetentionDrop, *r.Drop)
+	}
+	if r.TTLTurns != nil && *r.TTLTurns > 0 {
+		builder.addInt(headers.VSRRetentionTTLTurns, *r.TTLTurns)
+	}
+	if r.KeepCurrentModel != nil {
+		builder.addBool(headers.VSRRetentionKeepCurrentModel, *r.KeepCurrentModel)
+	}
+	if r.PreferPrefixRetention != nil {
+		builder.addBool(headers.VSRRetentionPreferPrefix, *r.PreferPrefixRetention)
+	}
 }
 
 // addStandardDecisionHeaders adds the per-request decision headers

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -79,6 +79,16 @@ func (builder *responseHeaderMutationBuilder) addInt(key string, value int) {
 	builder.addString(key, strconv.Itoa(value))
 }
 
+// addNonNegativeInt emits the value when it is >= 0, so an explicit zero is
+// still written. Mirrors addNonNegativeFloat; used for tri-state retention
+// fields where 0 is a meaningful, explicitly-set value (not "unset").
+func (builder *responseHeaderMutationBuilder) addNonNegativeInt(key string, value int) {
+	if value < 0 {
+		return
+	}
+	builder.addString(key, strconv.Itoa(value))
+}
+
 func (builder *responseHeaderMutationBuilder) addJoined(key string, values []string) {
 	if len(values) == 0 {
 		return
@@ -257,8 +267,11 @@ func addRetentionDirectiveHeaders(builder *responseHeaderMutationBuilder, ctx *R
 	if r.Drop != nil {
 		builder.addBool(headers.VSRRetentionDrop, *r.Drop)
 	}
-	if r.TTLTurns != nil && *r.TTLTurns > 0 {
-		builder.addInt(headers.VSRRetentionTTLTurns, *r.TTLTurns)
+	if r.TTLTurns != nil {
+		// Tri-state: emit whenever explicitly set, including ttl_turns: 0
+		// (a valid no-op the validator permits). The runtime TTL override
+		// still applies only when > 0; the header reflects intent, not effect.
+		builder.addNonNegativeInt(headers.VSRRetentionTTLTurns, *r.TTLTurns)
 	}
 	if r.KeepCurrentModel != nil {
 		builder.addBool(headers.VSRRetentionKeepCurrentModel, *r.KeepCurrentModel)

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -163,6 +163,47 @@ func TestBuildResponseHeaderMutation_OmitsUnsetRetentionHeaders(t *testing.T) {
 	assert.NotContains(t, headerMap, headers.VSRRetentionDrop)
 }
 
+func TestBuildResponseHeaderMutation_EmitsExplicitZeroTTLTurns(t *testing.T) {
+	// Tri-state: an explicitly set ttl_turns: 0 is still an explicit field, so
+	// it must be emitted (the validator permits 0 as a no-op; only negatives
+	// are rejected). Regression guard against the old "*TTLTurns > 0" gate that
+	// silently dropped the header for an explicit zero.
+	ctx := &RequestContext{
+		VSRSelectedDecisionName: "agentic_routing",
+		VSRSelectedModel:        "qwen-small",
+		EmittedRetention:        &config.RetentionDirective{TTLTurns: intPtr(0)},
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "0", headerMap[headers.VSRRetentionTTLTurns])
+}
+
+func TestBuildResponseHeaderMutation_EmitsExplicitFalseRetentionBools(t *testing.T) {
+	// Tri-state companion to the explicit-zero ttl_turns guard: an explicitly
+	// set bool field of value false must still be emitted as "false" (not
+	// suppressed), so the wire contract is symmetric across every field.
+	ctx := &RequestContext{
+		VSRSelectedDecisionName: "agentic_routing",
+		VSRSelectedModel:        "qwen-small",
+		EmittedRetention: &config.RetentionDirective{
+			Drop:             boolPtr(false),
+			KeepCurrentModel: boolPtr(false),
+		},
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "false", headerMap[headers.VSRRetentionDrop])
+	assert.Equal(t, "false", headerMap[headers.VSRRetentionKeepCurrentModel])
+	// PreferPrefixRetention was left unset -> its header must be omitted.
+	assert.NotContains(t, headerMap, headers.VSRRetentionPreferPrefix)
+}
+
 func TestBuildResponseHeaderMutation_CacheHitSkipsRetentionHeaders(t *testing.T) {
 	ctx := &RequestContext{
 		VSRCacheHit:      true,

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -125,6 +125,54 @@ func TestBuildResponseHeaderMutation_NilContextReturnsNil(t *testing.T) {
 	assert.Nil(t, buildResponseHeaderMutation(nil, true))
 }
 
+func TestBuildResponseHeaderMutation_EmitsRetentionDirectiveHeaders(t *testing.T) {
+	ctx := &RequestContext{
+		VSRSelectedDecisionName: "agentic_routing",
+		VSRSelectedModel:        "qwen-small",
+		EmittedRetention: &config.RetentionDirective{
+			TTLTurns:              intPtr(3),
+			KeepCurrentModel:      boolPtr(true),
+			PreferPrefixRetention: boolPtr(true),
+		},
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "3", headerMap[headers.VSRRetentionTTLTurns])
+	assert.Equal(t, "true", headerMap[headers.VSRRetentionKeepCurrentModel])
+	assert.Equal(t, "true", headerMap[headers.VSRRetentionPreferPrefix])
+}
+
+func TestBuildResponseHeaderMutation_OmitsUnsetRetentionHeaders(t *testing.T) {
+	// Tri-state: only fields the directive explicitly set are emitted.
+	ctx := &RequestContext{
+		VSRSelectedDecisionName: "agentic_routing",
+		VSRSelectedModel:        "qwen-small",
+		EmittedRetention:        &config.RetentionDirective{PreferPrefixRetention: boolPtr(true)},
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "true", headerMap[headers.VSRRetentionPreferPrefix])
+	assert.NotContains(t, headerMap, headers.VSRRetentionTTLTurns)
+	assert.NotContains(t, headerMap, headers.VSRRetentionKeepCurrentModel)
+	assert.NotContains(t, headerMap, headers.VSRRetentionDrop)
+}
+
+func TestBuildResponseHeaderMutation_CacheHitSkipsRetentionHeaders(t *testing.T) {
+	ctx := &RequestContext{
+		VSRCacheHit:      true,
+		EmittedRetention: &config.RetentionDirective{PreferPrefixRetention: boolPtr(true)},
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	assert.Nil(t, mutation, "cache hit must not emit retention headers")
+}
+
 func TestAddLossinessWarnings_EmptyProducesNoHeader(t *testing.T) {
 	ctx := &RequestContext{ClientProtocol: config.ClientProtocolAnthropic}
 	builder := newResponseHeaderMutationBuilder()

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -90,6 +90,17 @@ const (
 	// Value: "true"
 	VSRCacheHit = "x-vsr-cache-hit"
 
+	// Retention directive headers expose the matched decision's EMIT retention
+	// block to the inference pool / operators (issue #2009). They are emitted
+	// only on successful, non-cache-hit responses, and only for the fields the
+	// directive explicitly set (tri-state). They let the pool observe the
+	// router's KV/cache retention intent at the wire; the router itself also
+	// consumes drop (cache-write skip) and ttl_turns (per-entry cache TTL).
+	VSRRetentionDrop             = "x-vsr-retention-drop"
+	VSRRetentionTTLTurns         = "x-vsr-retention-ttl-turns"
+	VSRRetentionKeepCurrentModel = "x-vsr-retention-keep-current-model"
+	VSRRetentionPreferPrefix     = "x-vsr-retention-prefer-prefix"
+
 	// RouterReplayID carries the identifier for a captured replay record.
 	// Value: opaque replay token
 	RouterReplayID = "x-vsr-replay-id"

--- a/src/semantic-router/pkg/selection/model_switch_gate.go
+++ b/src/semantic-router/pkg/selection/model_switch_gate.go
@@ -34,6 +34,14 @@ type ModelSwitchGateInput struct {
 	// When false the gate records cache_warmth as a missing signal but still
 	// evaluates evidence (cache warmth contributes zero penalty in that case).
 	CacheWarmthOK bool
+
+	// ForceKeepCurrentModel carries an explicit operator directive — EMIT
+	// retention { keep_current_model: true } — to stay on the current model.
+	// Unlike the heuristic evidence path, it forces a stay regardless of gate
+	// mode (shadow or enforce), provided the current model is known and is a
+	// valid candidate. It is a directive, not a signal, so it is not subject to
+	// the net-switch-advantage comparison.
+	ForceKeepCurrentModel bool
 }
 
 // ModelSwitchGateDecision is the auditable stay-vs-switch decision.
@@ -93,6 +101,19 @@ func (g *ModelSwitchGate) Evaluate(input ModelSwitchGateInput) ModelSwitchGateDe
 	}
 	if !candidateSetContains(input.SelectionContext.CandidateModels, input.CurrentModel) {
 		return decision.withMissingAuditOnly(append([]string{"previous_model_not_in_candidates"}, informational...))
+	}
+
+	// Explicit retention directive (keep_current_model) forces a stay on the
+	// known current model and skips the heuristic evidence path. It is honored
+	// regardless of gate mode because the operator asked for it directly; the
+	// reason field keeps the override auditable (e.g. mode=shadow + enforced_stay).
+	if input.ForceKeepCurrentModel {
+		decision.WouldSwitch = false
+		decision.EnforcedStay = true
+		decision.FinalModel = input.CurrentModel
+		decision.MissingSignals = append(decision.MissingSignals, informational...)
+		decision.Reason = "retention_keep_current_model"
+		return decision
 	}
 
 	evidence, evidenceMissing, ok := g.collectSwitchEvidence(input, candidateModel)

--- a/src/semantic-router/pkg/selection/model_switch_gate_test.go
+++ b/src/semantic-router/pkg/selection/model_switch_gate_test.go
@@ -201,6 +201,84 @@ func TestModelSwitchGateSwitchBenefitPrefersQualityGap(t *testing.T) {
 	}
 }
 
+func TestModelSwitchGateForceKeepCurrentModelEnforcesEvenInShadow(t *testing.T) {
+	// keep_current_model is an explicit operator directive, not a heuristic:
+	// it forces a stay on the known current model even in shadow mode and even
+	// when the heuristic would strongly prefer switching.
+	lt := lookuptable.NewMemoryStorage()
+	mustSetLookupEntry(t, lt, lookuptable.QualityGapKey("coding", "current", "candidate"), 0.9)
+
+	gate := NewModelSwitchGate(config.ModelSwitchGateConfig{
+		Enabled:            true,
+		Mode:               ModelSwitchGateModeShadow,
+		MinSwitchAdvantage: 0,
+	}, lt)
+
+	decision := gate.Evaluate(ModelSwitchGateInput{
+		SelectionContext: selectionContextForGate(),
+		SelectionResult: &SelectionResult{
+			SelectedModel: "candidate",
+			AllScores:     map[string]float64{"current": 0.1, "candidate": 0.99},
+		},
+		CurrentModel:          "current",
+		CandidateModel:        "candidate",
+		ForceKeepCurrentModel: true,
+	})
+
+	if decision.WouldSwitch {
+		t.Fatalf("keep_current_model must not switch, got %+v", decision)
+	}
+	if !decision.EnforcedStay {
+		t.Fatalf("keep_current_model must enforce stay even in shadow mode")
+	}
+	if decision.FinalModel != "current" {
+		t.Fatalf("expected final model current, got %q", decision.FinalModel)
+	}
+	if decision.Reason != "retention_keep_current_model" {
+		t.Fatalf("expected reason retention_keep_current_model, got %q", decision.Reason)
+	}
+}
+
+func TestModelSwitchGateForceKeepCurrentModelMissingPreviousModelStaysAuditOnly(t *testing.T) {
+	// keep_current_model cannot stay on a model we do not know: with no previous
+	// model the gate stays audit-only instead of fabricating an enforced stay.
+	gate := NewModelSwitchGate(config.ModelSwitchGateConfig{
+		Enabled: true,
+		Mode:    ModelSwitchGateModeEnforce,
+	}, nil)
+
+	decision := gate.Evaluate(ModelSwitchGateInput{
+		SelectionContext: &SelectionContext{
+			CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "candidate"}},
+		},
+		SelectionResult:       &SelectionResult{SelectedModel: "candidate"},
+		CurrentModel:          "",
+		CandidateModel:        "candidate",
+		ForceKeepCurrentModel: true,
+	})
+
+	if decision.EnforcedStay {
+		t.Fatalf("cannot force-keep an unknown previous model, got %+v", decision)
+	}
+	if decision.Reason != "missing_signal_audit_only" {
+		t.Fatalf("expected missing_signal_audit_only, got %q", decision.Reason)
+	}
+}
+
+func TestModelSwitchGateForceKeepCurrentModelDisabledIsNoOp(t *testing.T) {
+	gate := NewModelSwitchGate(config.ModelSwitchGateConfig{Enabled: false}, nil)
+	decision := gate.Evaluate(ModelSwitchGateInput{
+		SelectionContext:      selectionContextForGate(),
+		SelectionResult:       &SelectionResult{SelectedModel: "candidate"},
+		CurrentModel:          "current",
+		CandidateModel:        "candidate",
+		ForceKeepCurrentModel: true,
+	})
+	if decision.EnforcedStay {
+		t.Fatalf("disabled gate must not enforce even with keep_current_model")
+	}
+}
+
 func selectionContextForGate() *SelectionContext {
 	return &SelectionContext{
 		DecisionName:    "coding-route",

--- a/website/docs/tutorials/decision/retention.md
+++ b/website/docs/tutorials/decision/retention.md
@@ -30,15 +30,25 @@ structured and reviewable.
 
 ## Runtime Scope
 
-The current runtime consumer is intentionally narrow:
+The runtime now consumes every retention field, with one scoring bias deferred:
 
 - `drop: true` skips the response-side semantic-cache write for the matched
-  decision.
-- It does not block semantic-cache reads for the current request.
-- `ttl_turns`, `keep_current_model`, and `prefer_prefix_retention` are
-  contract-only in this release: they round-trip through DSL/config and are
-  emitted to logs/traces, but their business effects are reserved for follow-up
-  runtime consumers.
+  decision. It does not block semantic-cache reads for the current request.
+- `ttl_turns` (when `> 0`) overrides the decision/global semantic-cache TTL for
+  this entry, scoping it to roughly that many future turns (turns are mapped to
+  seconds at the cache-write seam; a configurable seconds-per-turn knob is
+  follow-up work).
+- `keep_current_model: true` forces the session-aware model-switch gate to stay
+  on the current model, regardless of gate mode (shadow or enforce), as long as
+  the current model is known and a valid candidate.
+- `prefer_prefix_retention: true` is emitted to the inference pool as an
+  `x-vsr-retention-prefer-prefix` response header; the session-aware scoring
+  bias and provider/KV-cache eviction integration remain follow-up work.
+
+Every explicitly set field is also emitted to the response as an
+`x-vsr-retention-*` header and recorded in logs/traces, so the pool and
+operators can audit the router's retention intent. `drop` and positive
+`ttl_turns` are mutually exclusive (validation rejects setting both).
 
 ## Retention Target Inventory
 
@@ -48,9 +58,9 @@ for these state signals or runtime hints:
 | Target | Why retention matters | Current status |
 |--------|-----------------------|----------------|
 | Semantic-cache response write | Prevents low-value, private, or unstable turns from becoming future cache hits. | Enforced by `drop: true`. |
-| Cache-write lifetime | Keeps a reusable response only for a bounded number of future turns instead of using a wall-clock-only TTL. | `ttl_turns` is typed and observed; runtime consumption needs a turn-to-TTL mapping. |
-| Current model affinity | Avoids bouncing a multi-turn session away from the model that owns the conversation context. | `keep_current_model` is typed and observed; the model-switch gate consumes this in a follow-up path. |
-| Prefix or KV cache warmth | Protects expensive prompt prefixes or warm worker state when a follow-up turn is likely. | `prefer_prefix_retention` is typed and observed; provider/cache-manager eviction integration is follow-up work. |
+| Cache-write lifetime | Keeps a reusable response only for a bounded number of future turns instead of using a wall-clock-only TTL. | `ttl_turns` overrides the per-entry semantic-cache TTL (turns mapped to seconds); a configurable seconds-per-turn knob is follow-up. |
+| Current model affinity | Avoids bouncing a multi-turn session away from the model that owns the conversation context. | `keep_current_model` forces a stay via the model-switch gate in any mode. |
+| Prefix or KV cache warmth | Protects expensive prompt prefixes or warm worker state when a follow-up turn is likely. | `prefer_prefix_retention` is emitted to the pool as a response header; scoring bias and provider/cache-manager eviction integration are follow-up work. |
 | Turn and transition telemetry | Records turn index, selected model, token/cost totals, retry/quality trends, and model transitions so stay-vs-switch policy can be audited. | Produced by session telemetry and transition logging surfaces, not by this directive alone. |
 | Conversation, tool, and replay history | Preserves the history needed for follow-up classification, tool retrieval, and offline lookup-table generation. | Owned by Response API, tool-history, and router-replay surfaces; retention directives should not duplicate those stores. |
 
@@ -122,9 +132,9 @@ routing:
 | Field | Type | Runtime behavior |
 |-------|------|------------------|
 | `drop` | boolean | When `true`, skips response-side semantic-cache writes for the matched decision. |
-| `ttl_turns` | integer >= 0 | Contract-only and observed in logs/traces until turn-aware TTL consumption lands. |
-| `keep_current_model` | boolean | Contract-only and observed until model-switch-gate consumption lands. |
-| `prefer_prefix_retention` | boolean | Contract-only and observed until prefix/KV-cache retention integration lands. |
+| `ttl_turns` | integer >= 0 | When `> 0`, overrides the matched decision's semantic-cache entry TTL (turns mapped to seconds). Also emitted as `x-vsr-retention-ttl-turns`. |
+| `keep_current_model` | boolean | When `true`, forces the model-switch gate to keep the current model regardless of gate mode. Also emitted as `x-vsr-retention-keep-current-model`. |
+| `prefer_prefix_retention` | boolean | Emitted to the pool as `x-vsr-retention-prefer-prefix`; session-aware scoring bias and KV-cache eviction integration are follow-up. |
 
 Validation rejects duplicate `EMIT retention` blocks on the same route, unknown
 fields, invalid field types, negative `ttl_turns`, and contradictory

--- a/website/docs/tutorials/decision/retention.md
+++ b/website/docs/tutorials/decision/retention.md
@@ -46,9 +46,10 @@ The runtime now consumes every retention field, with one scoring bias deferred:
   bias and provider/KV-cache eviction integration remain follow-up work.
 
 Every explicitly set field is also emitted to the response as an
-`x-vsr-retention-*` header and recorded in logs/traces, so the pool and
-operators can audit the router's retention intent. `drop` and positive
-`ttl_turns` are mutually exclusive (validation rejects setting both).
+`x-vsr-retention-*` header (including an explicit `ttl_turns: 0`) and recorded
+in logs/traces, so the pool and operators can audit the router's retention
+intent. `drop` and positive `ttl_turns` are mutually exclusive (validation
+rejects setting both).
 
 ## Retention Target Inventory
 
@@ -132,7 +133,7 @@ routing:
 | Field | Type | Runtime behavior |
 |-------|------|------------------|
 | `drop` | boolean | When `true`, skips response-side semantic-cache writes for the matched decision. |
-| `ttl_turns` | integer >= 0 | When `> 0`, overrides the matched decision's semantic-cache entry TTL (turns mapped to seconds). Also emitted as `x-vsr-retention-ttl-turns`. |
+| `ttl_turns` | integer >= 0 | When `> 0`, overrides the matched decision's semantic-cache entry TTL (turns mapped to seconds). Emitted as `x-vsr-retention-ttl-turns` whenever explicitly set, including an explicit `0`. |
 | `keep_current_model` | boolean | When `true`, forces the model-switch gate to keep the current model regardless of gate mode. Also emitted as `x-vsr-retention-keep-current-model`. |
 | `prefer_prefix_retention` | boolean | Emitted to the pool as `x-vsr-retention-prefer-prefix`; session-aware scoring bias and KV-cache eviction integration are follow-up. |
 


### PR DESCRIPTION
## Summary

Wires the three previously contract-only `EMIT retention` fields into runtime, continuing the MVP from #1747 / #1873 (which consumed only `drop`). Closes the consumption gap tracked in #2009. The now-shipped #1742 (per-turn telemetry) and #1749 (model-switch gate) unblocked these consumers.

| Field | New runtime behavior |
|-------|----------------------|
| `ttl_turns` (`> 0`) | Overrides the decision/global semantic-cache TTL for the entry, scoping it to ~N future turns (turns→seconds at the cache-write seam). |
| `keep_current_model: true` | Forces the session-aware `model_switch_gate` to stay on the current model, **regardless of gate mode** (shadow/enforce), when the previous model is known and a valid candidate. Auditable via `reason=retention_keep_current_model`. |
| `prefer_prefix_retention` | Emitted to the inference pool as an `x-vsr-retention-prefer-prefix` response header (the router-emitted-directive mechanism from the WRP vision paper, Opportunity 15). |

Every explicitly-set field is also emitted as an `x-vsr-retention-*` response header (success, non-cache-hit only) so the pool/operators can audit the router's retention intent over the wire.

## Commit trajectory

1. `[Router] consume retention ttl_turns as per-entry cache TTL` — `applyRetentionTTLOverride` on the retention seam; both streaming + non-streaming cache writes. `drop` still takes precedence (mutually exclusive by validation).
2. `[Router] honor retention keep_current_model in model_switch_gate` — `ForceKeepCurrentModel` on `ModelSwitchGateInput` + short-circuit forced stay.
3. `[Router] emit retention directive as x-vsr-retention-* response headers` — new header constants + tri-state-aware emission.
4. `[Router/Docs] document consumed retention fields` — `retention.md` + struct/contract comment updates.

## Out of scope (deferred follow-ups, noted in code + docs)

- **`prefer_prefix_retention` scoring-weight bias** in `session_aware_scoring`: deferred because it would inject a magic constant into calibrated hotspot weights and needs a separate tuning rationale. `keep_current_model` already provides the hard form of prefix retention.
- Promoting the `ttl_turns` seconds-per-turn factor (currently a `60` constant) to a `global.router` config knob.
- Honoring `keep_current_model` when the model-switch gate is disabled.
- Auto-deriving directives from semantic signals (`previous_response_id` / system-prompt fingerprint / tool type) and real vLLM/KV-cache backend eviction integration.

## Test Plan

- [x] TDD (RED→GREEN) for every field consumer:
  - `processor_res_cache_retention_test.go` — `retentionTTLOverrideSeconds` / `applyRetentionTTLOverride` + both cache-write seams apply the override; `drop` precedence preserved.
  - `selection/model_switch_gate_test.go` — forced stay in shadow mode; audit-only when previous model unknown / not a candidate; no-op when gate disabled.
  - `extproc/model_switch_gate_test.go` — wrapper threads `keep_current_model` and overrides even in shadow mode.
  - `processor_res_header_mutation_test.go` — headers emitted for set fields; unset fields omitted (tri-state); skipped on cache hit.
- [x] `go test -race ./pkg/{extproc,selection,config,headers}` — all pass.
- [x] `go build ./...`, `gofmt`, `go vet` clean on touched packages.
- [x] `make agent-ci-gate` — all checks pass (go fmt, go lint, AST security scan, changed-files lint). The local `md-fmt` hook errored only because the `markdownlint` binary isn't installed locally (exit 127); `retention.md` was verified clean via `npx markdownlint-cli` against the repo config (MD013 line-length is disabled).

Refs #2009. Builds on #1747 / #1873; consumers unblocked by #1742, #1749.
