### PR TITLE
[Dashboard] Helm chart: correct router URL env var name and add PVC fsGroup default

### DIFF
--- a/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
+++ b/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
@@ -22,6 +22,8 @@ spec:
         {{- include "semantic-router.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: dashboard
     spec:
+      securityContext:
+        {{- toYaml .Values.dashboard.podSecurityContext | nindent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -35,8 +37,10 @@ spec:
           name: http
           protocol: TCP
         env:
-        - name: ROUTER_API_URL
+        - name: TARGET_ROUTER_API_URL
           value: "http://{{ include "semantic-router.fullname" . }}:{{ .Values.service.api.port }}"
+        - name: TARGET_ROUTER_METRICS_URL
+          value: "http://{{ include "semantic-router.fullname" . }}-metrics:{{ .Values.service.metrics.port }}/metrics"
         {{- if .Values.dashboard.readonly }}
         - name: DASHBOARD_READONLY
           value: "true"

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -527,6 +527,15 @@ dashboard:
     pullPolicy: IfNotPresent
   # -- Run dashboard in read-only mode
   readonly: false
+  # -- Pod-level security context. The default fsGroup matches the non-root user
+  # (UID/GID 65532) baked into the upstream dashboard image, ensuring the
+  # persistence PVC mount at /app/data is writable by the binary. Without this,
+  # the dashboard crashloops with "unable to open database file" when
+  # persistence is enabled on storage classes that mount as root:root 0755
+  # (which is the default behavior for most cloud-provider CSI drivers).
+  # Override if you build a custom dashboard image with a different non-root UID.
+  podSecurityContext:
+    fsGroup: 65532
   service:
     # -- Dashboard service type
     type: ClusterIP


### PR DESCRIPTION
## Purpose

Two mechanical fixes to `deploy/helm/semantic-router/` that bite the first install of `--set dashboard.enabled=true` and (when persistence is on) prevent the pod from reaching Ready.

**1. Correct the env var names in the Dashboard Deployment template.**

The chart currently sets `ROUTER_API_URL`, but the dashboard binary reads `TARGET_ROUTER_API_URL` (per the `routerAPI` flag in `dashboard/backend/config/config.go`'s `LoadConfig`, default `http://localhost:8080`). With the wrong name set, the dashboard's reverse proxy silently falls back to localhost and the Config / Topology / Monitoring pages never reach the router.

Every other deploy manifest in the repo already uses the correct name. The Helm chart is the outlier:

- `deploy/openshift/dashboard/dashboard-deployment.yaml`
- `deploy/kubernetes/observability/dashboard/deployment.yaml`
- `deploy/kubernetes/observability/dashboard/configmap.yaml`
- `e2e/profiles/dashboard/dashboard-deployment.yaml`

Also adds `TARGET_ROUTER_METRICS_URL` (read by the `routerMetrics` flag in the same `LoadConfig`, default `http://localhost:9190/metrics`) pointing at the existing `-metrics` Service the chart already renders. Set unconditionally so that when `service.metrics.enabled=false` the URL still points at where the metrics Service would be rather than silently falling back to a localhost default.

**2. Add a `dashboard.podSecurityContext` block to values.yaml defaulting to `fsGroup: 65532`.**

The upstream dashboard image's entrypoint is `exec su-exec nonroot "$@"`, dropping to the `nonroot` user (UID/GID 65532 per `/etc/passwd` in the image). When `dashboard.persistence.enabled=true` (which the production values profile sets), the PVC mount at `/app/data` is owned by `root:root 0755` on standard CSI drivers (GKE `standard-rwo`, EKS `gp3`, AKS `managed-csi`, local-path), and the nonroot binary cannot create the SQLite auth/workflow DB files. Pod crashloops with `failed to init auth store: migrate schema: unable to open database file: no such file or directory`. `fsGroup` makes the kubelet chown the mount before the container starts.

The new value defaults to `{ fsGroup: 65532 }` (matches the upstream image) and uses the same `toYaml ... | nindent` rendering idiom as the main router Deployment's existing `podSecurityContext`, so the two pod templates stay structurally consistent. Override if you build a custom dashboard image with a different non-root UID.

**Which module(s) does this affect?** `Dashboard`

## Test Plan

- [ ] `make helm-lint` passes
- [ ] `make helm-ci-validate HELM_REPO_UPDATE=false` passes
- [ ] `agent changed-files lint` step in `make agent-ci-lint` passes for the two changed files
- [ ] Manual: deploy via Helm with `--set dashboard.enabled=true --set dashboard.persistence.enabled=true`, confirm pod reaches Ready and Config page reads live router config
- [ ] Confirm no impact when `dashboard.enabled=false` (the default)

## Test Result

Local validation against current `upstream/main` (commit `a0694610`):

- `make helm-lint`: PASS
- `make helm-ci-validate HELM_REPO_UPDATE=false`: PASS
- `make agent-ci-lint`: `agent changed-files lint` step PASS for the two changed files. The aggregate `yaml-lint` step has pre-existing errors on the rendered `dist/helm/default-template.yaml` and on `deploy/operator/config/samples/vllm.ai_v1alpha1_semanticrouter_openshift.yaml`. Verified identical errors at identical line numbers on clean `upstream/main` (commit `a0694610`, without this PR's changes applied), so not introduced by this PR.
- `make helm-safety-validate HELM_REPO_UPDATE=false`: pre-existing failure on clean `upstream/main` (commit `a0694610`), not introduced here. The script greps for `"safetyGuards.rejectMultiReplicaLocalSelectorState: Invalid type"`, but helm now emits `"at '/safetyGuards/rejectMultiReplicaLocalSelectorState': got string, want boolean"`. The schema rejection itself fires correctly; only the grep pattern is stale. Worth a separate `[CI/Build]` fix.

Live deploy validation against a real cluster: rendered the equivalent manifests into a GKE cluster with `standard-rwo` storage class and `persistence.enabled=true`. Without the fsGroup fix the pod crashlooped with the SQLite open-database error. With the fsGroup fix the pod reached Ready in 15s, admin bootstrap succeeded, and the Config page renders live router config via `TARGET_ROUTER_API_URL`.
