### PR TITLE
[Dashboard] complete room collaboration participants for ClawOS

### DIFF
--- a/dashboard/backend/handlers/openclaw_room_automation.go
+++ b/dashboard/backend/handlers/openclaw_room_automation.go
@@ -306,7 +306,7 @@ func (h *OpenClawHandler) collectRoomAutomationReplies(
 			continue
 		}
 		replyCopy := result.reply
-		h.publishRoomCollaborationEvent(roomID, messageUpdatedCollaborationEvent(replyCopy))
+		h.publishRoomCollaborationEvent(roomID, messageUpdatedCollaborationEvent(room, replyCopy))
 		if len(result.reply.Mentions) > 0 {
 			next = append(next, result.reply.ID)
 		}

--- a/dashboard/backend/handlers/openclaw_room_collaboration.go
+++ b/dashboard/backend/handlers/openclaw_room_collaboration.go
@@ -18,6 +18,7 @@ type ClawRoomCollaborationEvent struct {
 	ParticipantType string           `json:"participantType,omitempty"`
 	ParticipantID   string           `json:"participantId,omitempty"`
 	SessionUser     string           `json:"sessionUser,omitempty"`
+	Payload         map[string]any   `json:"payload,omitempty"`
 	Timestamp       string           `json:"timestamp,omitempty"`
 }
 
@@ -41,15 +42,32 @@ func newMessageCollaborationEvent(message ClawRoomMessage) ClawRoomCollaboration
 	}
 }
 
-func messageUpdatedCollaborationEvent(message ClawRoomMessage) ClawRoomCollaborationEvent {
+func messageUpdatedCollaborationEvent(room ClawRoomEntry, message ClawRoomMessage) ClawRoomCollaborationEvent {
 	copyMsg := message
 	participantType := normalizeRoomSenderType(message.SenderType)
-	return ClawRoomCollaborationEvent{
+	event := ClawRoomCollaborationEvent{
 		Type:            WSTypeMessageUpdated,
 		Message:         &copyMsg,
 		MessageID:       message.ID,
 		ParticipantType: participantType,
 		ParticipantID:   message.SenderID,
+	}
+	if participantType == "worker" && message.SenderID != "" {
+		event.SessionUser = roomScopedSessionUser(room, ContainerEntry{Name: message.SenderID})
+	}
+	return event
+}
+
+func surfaceEventCollaborationEvent(participantType, participantID string, payload map[string]any) ClawRoomCollaborationEvent {
+	payloadCopy := make(map[string]any, len(payload))
+	for key, value := range payload {
+		payloadCopy[key] = value
+	}
+	return ClawRoomCollaborationEvent{
+		Type:            WSTypeSurfaceEvent,
+		ParticipantType: participantType,
+		ParticipantID:   participantID,
+		Payload:         payloadCopy,
 	}
 }
 
@@ -87,6 +105,7 @@ func collaborationEventToWSOutbound(event ClawRoomCollaborationEvent) WSOutbound
 		ParticipantType: event.ParticipantType,
 		ParticipantID:   event.ParticipantID,
 		SessionUser:     event.SessionUser,
+		Payload:         event.Payload,
 	}
 	if event.Message != nil {
 		copyMsg := *event.Message
@@ -101,8 +120,15 @@ func collaborationEventToSSE(event ClawRoomCollaborationEvent) clawRoomStreamEve
 		sseType = "message"
 	}
 	sseEvent := clawRoomStreamEvent{
-		Type:   sseType,
-		RoomID: event.RoomID,
+		Type:            sseType,
+		RoomID:          event.RoomID,
+		MessageID:       event.MessageID,
+		Chunk:           event.Chunk,
+		Status:          event.Status,
+		ParticipantType: event.ParticipantType,
+		ParticipantID:   event.ParticipantID,
+		SessionUser:     event.SessionUser,
+		Payload:         event.Payload,
 	}
 	if event.Message != nil {
 		copyMsg := *event.Message

--- a/dashboard/backend/handlers/openclaw_room_collaboration_test.go
+++ b/dashboard/backend/handlers/openclaw_room_collaboration_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestRoomCollaborationBus_WSAndSSEReceiveSameEvent(t *testing.T) {
@@ -205,6 +207,135 @@ func TestRoomCollaborationBus_HTTPPostAndWSSendEquivalent(t *testing.T) {
 	}
 	if len(messages) != 2 {
 		t.Fatalf("expected two persisted room messages, got %d", len(messages))
+	}
+}
+
+func TestRoomCollaboration_WorkerMessageUpdatedCarriesSessionIdentity(t *testing.T) {
+	room := ClawRoomEntry{ID: "room-1", TeamID: "team-1"}
+	reply := ClawRoomMessage{
+		ID:         "msg-worker-final",
+		RoomID:     room.ID,
+		TeamID:     room.TeamID,
+		SenderType: "worker",
+		SenderID:   "worker-a",
+		SenderName: "Worker A",
+		Content:    "done",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	event := messageUpdatedCollaborationEvent(room, reply)
+	if event.SessionUser != "room-1:worker-a" {
+		t.Fatalf("expected room-scoped session user on message_updated, got %q", event.SessionUser)
+	}
+	if event.ParticipantType != "worker" || event.ParticipantID != "worker-a" {
+		t.Fatalf("unexpected participant identity: %+v", event)
+	}
+}
+
+func TestRoomCollaboration_SurfaceEventReachAllWSClients(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := seedCollaborationTestRoom(t, h)
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	connA := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, connA)
+	connB := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, connB)
+
+	if writeErr := connA.WriteJSON(WSInboundMessage{
+		Type:       WSTypeSurfaceEvent,
+		SenderType: "worker",
+		SenderID:   "worker-a",
+		Payload:    map[string]any{"kind": "tool_call", "name": "search"},
+	}); writeErr != nil {
+		t.Fatalf("failed to send surface_event: %v", writeErr)
+	}
+
+	matchSurface := func(outbound WSOutboundMessage) bool {
+		return outbound.Type == WSTypeSurfaceEvent &&
+			outbound.ParticipantID == "worker-a" &&
+			outbound.Payload != nil &&
+			outbound.Payload["kind"] == "tool_call"
+	}
+	outA := waitForWSOutboundMessage(t, connA, "client A surface event", matchSurface)
+	outB := waitForWSOutboundMessage(t, connB, "client B surface event", matchSurface)
+	if outA.Payload == nil || outB.Payload == nil {
+		t.Fatalf("expected surface payload on both clients")
+	}
+}
+
+func TestRoomCollaboration_FullFlowUserWorkerSurface(t *testing.T) {
+	tempDir := t.TempDir()
+	h := newTestOpenClawHandler(t, tempDir, false)
+	room := seedCollaborationTestRoom(t, h)
+	worker := ContainerEntry{Name: "worker-a", RoleKind: "worker"}
+
+	server := httptest.NewServer(h.RoomByIDHandler())
+	defer server.Close()
+
+	userConn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, userConn)
+	embeddedConn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, embeddedConn)
+	observerConn := dialRoomWebSocket(t, server.URL, room.ID)
+	readWSConnected(t, observerConn)
+
+	messageID := "room-msg-flow"
+	h.publishRoomCollaborationEvent(
+		room.ID,
+		workerStreamChunkCollaborationEvent(room, worker, messageID, "Hello", false),
+	)
+
+	for _, conn := range []*websocket.Conn{userConn, embeddedConn, observerConn} {
+		outbound := waitForWSOutboundMessage(t, conn, "worker chunk", func(message WSOutboundMessage) bool {
+			return message.Type == WSTypeMessageChunk &&
+				message.Chunk == "Hello" &&
+				message.SessionUser == "room-collab:worker-a"
+		})
+		if outbound.ParticipantID != "worker-a" {
+			t.Fatalf("unexpected chunk participant: %+v", outbound)
+		}
+	}
+
+	if writeErr := embeddedConn.WriteJSON(WSInboundMessage{
+		Type:       WSTypeSurfaceEvent,
+		SenderType: "worker",
+		SenderID:   "worker-a",
+		Payload:    map[string]any{"kind": "status", "value": "thinking"},
+	}); writeErr != nil {
+		t.Fatalf("failed to send embedded surface_event: %v", writeErr)
+	}
+
+	for _, conn := range []*websocket.Conn{userConn, observerConn} {
+		waitForWSOutboundMessage(t, conn, "surface fanout", func(message WSOutboundMessage) bool {
+			return message.Type == WSTypeSurfaceEvent && message.Payload != nil && message.Payload["value"] == "thinking"
+		})
+	}
+
+	reply := ClawRoomMessage{
+		ID:         messageID,
+		RoomID:     room.ID,
+		TeamID:     room.TeamID,
+		SenderType: "worker",
+		SenderID:   "worker-a",
+		SenderName: "Worker A",
+		Content:    "Hello",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	h.publishRoomCollaborationEvent(room.ID, messageUpdatedCollaborationEvent(room, reply))
+
+	for _, conn := range []*websocket.Conn{userConn, embeddedConn, observerConn} {
+		updated := waitForWSOutboundMessage(t, conn, "message_updated", func(message WSOutboundMessage) bool {
+			return message.Type == WSTypeMessageUpdated &&
+				message.Message != nil &&
+				message.Message.Content == "Hello" &&
+				message.SessionUser == "room-collab:worker-a"
+		})
+		if updated.ParticipantID != "worker-a" {
+			t.Fatalf("unexpected updated participant: %+v", updated)
+		}
 	}
 }
 

--- a/dashboard/backend/handlers/openclaw_rooms.go
+++ b/dashboard/backend/handlers/openclaw_rooms.go
@@ -48,9 +48,16 @@ type clawRoomMessagePayload struct {
 }
 
 type clawRoomStreamEvent struct {
-	Type    string           `json:"type"`
-	RoomID  string           `json:"roomId"`
-	Message *ClawRoomMessage `json:"message,omitempty"`
+	Type            string           `json:"type"`
+	RoomID          string           `json:"roomId"`
+	Message         *ClawRoomMessage `json:"message,omitempty"`
+	MessageID       string           `json:"messageId,omitempty"`
+	Chunk           string           `json:"chunk,omitempty"`
+	Status          string           `json:"status,omitempty"`
+	ParticipantType string           `json:"participantType,omitempty"`
+	ParticipantID   string           `json:"participantId,omitempty"`
+	SessionUser     string           `json:"sessionUser,omitempty"`
+	Payload         map[string]any   `json:"payload,omitempty"`
 }
 
 var roomMentionPattern = regexp.MustCompile(`@([a-zA-Z0-9_.-]+)`)
@@ -685,6 +692,8 @@ func defaultSenderID(senderType, senderName string) string {
 	}
 }
 
+// handleRoomStream serves legacy SSE clients when WebSocket is unavailable.
+// Primary room collaboration transport is WebSocket (/rooms/{id}/ws).
 func (h *OpenClawHandler) handleRoomStream(w http.ResponseWriter, r *http.Request, roomID string) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/dashboard/backend/handlers/openclaw_websocket.go
+++ b/dashboard/backend/handlers/openclaw_websocket.go
@@ -10,9 +10,11 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// WebSocket message types for ClawRoom
+// WebSocket message types for ClawRoom.
+// WebSocket is the primary room collaboration transport; SSE (/stream) is a legacy fallback.
 const (
 	WSTypeSendMessage    = "send_message"
+	WSTypeSurfaceEvent   = "surface_event"
 	WSTypePing           = "ping"
 	WSTypePong           = "pong"
 	WSTypeNewMessage     = "new_message"
@@ -28,12 +30,13 @@ const (
 
 // WSInboundMessage represents a message from client to server
 type WSInboundMessage struct {
-	Type       string   `json:"type"`
-	Content    string   `json:"content,omitempty"`
-	SenderType string   `json:"senderType,omitempty"`
-	SenderID   string   `json:"senderId,omitempty"`
-	SenderName string   `json:"senderName,omitempty"`
-	Mentions   []string `json:"mentions,omitempty"`
+	Type       string         `json:"type"`
+	Content    string         `json:"content,omitempty"`
+	SenderType string         `json:"senderType,omitempty"`
+	SenderID   string         `json:"senderId,omitempty"`
+	SenderName string         `json:"senderName,omitempty"`
+	Mentions   []string       `json:"mentions,omitempty"`
+	Payload    map[string]any `json:"payload,omitempty"`
 }
 
 // WSOutboundMessage represents a message from server to client
@@ -48,6 +51,7 @@ type WSOutboundMessage struct {
 	ParticipantType string           `json:"participantType,omitempty"`
 	ParticipantID   string           `json:"participantId,omitempty"`
 	SessionUser     string           `json:"sessionUser,omitempty"`
+	Payload         map[string]any   `json:"payload,omitempty"`
 	Timestamp       string           `json:"timestamp,omitempty"`
 }
 
@@ -225,9 +229,42 @@ func (c *WSClient) handleMessage(msg WSInboundMessage) {
 	case WSTypeSendMessage:
 		c.handleSendMessage(msg)
 
+	case WSTypeSurfaceEvent:
+		c.handleSurfaceEvent(msg)
+
 	default:
 		c.sendError("unknown message type: " + msg.Type)
 	}
+}
+
+// handleSurfaceEvent publishes embedded OpenClaw surface activity to the room bus.
+func (c *WSClient) handleSurfaceEvent(msg WSInboundMessage) {
+	if msg.Payload == nil {
+		c.sendError("payload is required")
+		return
+	}
+
+	participantType := normalizeRoomSenderType(msg.SenderType)
+	if participantType != "user" && participantType != "leader" && participantType != "worker" && participantType != "system" {
+		participantType = "user"
+	}
+
+	participantID := msg.SenderID
+	if participantID == "" {
+		switch participantType {
+		case "user":
+			participantID = "playground-user"
+		case "leader", "worker":
+			participantID = sanitizeContainerName(msg.SenderName)
+		case "system":
+			participantID = "clawos-system"
+		}
+	}
+
+	c.handler.publishRoomCollaborationEvent(
+		c.roomID,
+		surfaceEventCollaborationEvent(participantType, participantID, msg.Payload),
+	)
 }
 
 // handleSendMessage handles sending a new message to the room

--- a/dashboard/backend/handlers/openclaw_websocket_test.go
+++ b/dashboard/backend/handlers/openclaw_websocket_test.go
@@ -214,7 +214,7 @@ func TestPublishRoomCollaborationEvent_StreamingChunkSequence(t *testing.T) {
 		Content:    "Hello world",
 		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
 	}
-	h.publishRoomCollaborationEvent(room.ID, messageUpdatedCollaborationEvent(reply))
+	h.publishRoomCollaborationEvent(room.ID, messageUpdatedCollaborationEvent(room, reply))
 
 	events := collectWSOutboundUntil(t, conn, 2*time.Second, func(outbound WSOutboundMessage) bool {
 		return outbound.Type == WSTypeMessageUpdated

--- a/dashboard/backend/router/openclaw_routes.go
+++ b/dashboard/backend/router/openclaw_routes.go
@@ -99,6 +99,14 @@ func registerOpenClawProxyRoute(mux *http.ServeMux, openClawHandler *handlers.Op
 			handler, _ = proxyCache.LoadOrStore(cacheKey, h)
 		}
 
+		roomID := strings.TrimSpace(r.Header.Get("X-ClawOS-Room-Id"))
+		if roomID == "" {
+			roomID = strings.TrimSpace(r.URL.Query().Get("roomId"))
+		}
+		if roomID != "" {
+			r.Header.Set("X-ClawOS-Room-Id", roomID)
+		}
+
 		handler.(http.Handler).ServeHTTP(w, r)
 	})
 }

--- a/dashboard/frontend/e2e/claw-room-collaboration.spec.ts
+++ b/dashboard/frontend/e2e/claw-room-collaboration.spec.ts
@@ -241,6 +241,7 @@ test.describe('Claw room collaboration', () => {
     await page.addInitScript(() => {
       class MockWebSocket {
         static instances: MockWebSocket[] = []
+        sent: string[] = []
         readyState = 1
         onopen: ((event: Event) => void) | null = null
         onmessage: ((event: MessageEvent) => void) | null = null
@@ -252,7 +253,10 @@ test.describe('Claw room collaboration', () => {
           window.setTimeout(() => this.onopen?.(new Event('open')), 0)
         }
 
-        send() {}
+        send(data: string) {
+          this.sent.push(data)
+        }
+
         close() {}
 
         emit(payload: Record<string, unknown>) {
@@ -365,5 +369,13 @@ test.describe('Claw room collaboration', () => {
     })
 
     await expect(page.getByTestId('claw-room-bridge-activity')).toContainText('Surface')
+
+    const surfaceWrites = await page.evaluate(() => {
+      const sockets = (window as typeof window & {
+        __mockRoomSockets?: Array<{ sent: string[] }>
+      }).__mockRoomSockets
+      return sockets?.flatMap(socket => socket.sent) || []
+    })
+    expect(surfaceWrites.some(entry => entry.includes('surface_event') && entry.includes('tool_call'))).toBeTruthy()
   })
 })

--- a/dashboard/frontend/src/components/clawRoomChatSupport.ts
+++ b/dashboard/frontend/src/components/clawRoomChatSupport.ts
@@ -46,6 +46,11 @@ export interface RoomStreamEvent {
   message?: RoomMessage
   messageId?: string
   chunk?: string
+  status?: string
+  participantType?: string
+  participantId?: string
+  sessionUser?: string
+  payload?: Record<string, unknown>
 }
 
 export interface StreamingParticipant {
@@ -58,17 +63,19 @@ export const ROOM_COLLABORATION_OUTBOUND_TYPES = {
   newMessage: 'new_message',
   messageChunk: 'message_chunk',
   messageUpdated: 'message_updated',
+  surfaceEvent: 'surface_event',
   error: 'error',
 } as const
 
 export type RoomTransportMode = 'connecting' | 'websocket' | 'sse'
 
 export interface WSInboundMessage {
-  type: 'send_message' | 'ping'
+  type: 'send_message' | 'surface_event' | 'ping'
   content?: string
   senderType?: string
   senderId?: string
   senderName?: string
+  payload?: Record<string, unknown>
 }
 
 export interface WSOutboundMessage {
@@ -83,6 +90,7 @@ export interface WSOutboundMessage {
   participantType?: string
   participantId?: string
   sessionUser?: string
+  payload?: Record<string, unknown>
 }
 
 export interface CollaborationEventHandlers {
@@ -152,6 +160,10 @@ export const applyCollaborationOutboundEvent = (
     return
   }
 
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.surfaceEvent) {
+    return
+  }
+
   if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.error && payload.error) {
     handlers.setError?.(payload.error)
   }
@@ -179,6 +191,14 @@ export const applyRoomStreamEvent = (
 
   if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.newMessage && payload.message) {
     applyCollaborationOutboundEvent(payload, handlers)
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.surfaceEvent) {
+    applyCollaborationOutboundEvent(
+      { type: ROOM_COLLABORATION_OUTBOUND_TYPES.surfaceEvent, payload: payload.payload },
+      handlers
+    )
   }
 }
 

--- a/dashboard/frontend/src/components/openclawRoomBridge.test.ts
+++ b/dashboard/frontend/src/components/openclawRoomBridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   buildRoomBridgeEnvelope,
+  buildRoomSurfaceWSMessage,
   CLAWOS_ROOM_BRIDGE_SOURCE,
   isRoomBridgeEnvelope,
   postRoomEventToFrame,
@@ -63,6 +64,19 @@ describe('openclawRoomBridge', () => {
       }),
       '*'
     )
+  })
+
+  it('builds websocket surface_event payloads with worker identity', () => {
+    expect(buildRoomSurfaceWSMessage(
+      { kind: 'tool_call', name: 'search' },
+      { senderType: 'worker', senderId: 'worker-a', senderName: 'worker-a' }
+    )).toEqual({
+      type: 'surface_event',
+      payload: { kind: 'tool_call', name: 'search' },
+      senderType: 'worker',
+      senderId: 'worker-a',
+      senderName: 'worker-a',
+    })
   })
 
   it('builds iframe to parent surface_event payloads', () => {

--- a/dashboard/frontend/src/components/openclawRoomBridge.ts
+++ b/dashboard/frontend/src/components/openclawRoomBridge.ts
@@ -1,4 +1,4 @@
-import type { WSOutboundMessage } from './clawRoomChatSupport'
+import type { WSInboundMessage, WSOutboundMessage } from './clawRoomChatSupport'
 
 export const CLAWOS_ROOM_BRIDGE_SOURCE = 'clawos-room-bridge'
 
@@ -14,6 +14,17 @@ export interface RoomBridgeEnvelope {
 
 export type RoomEventListener = (event: WSOutboundMessage) => void
 export type SurfaceEventListener = (roomId: string, payload: Record<string, unknown>) => void
+
+export interface RoomSurfaceEventSender {
+  senderType?: string
+  senderId?: string
+  senderName?: string
+}
+
+export interface RoomWebSocketSubscription {
+  close: () => void
+  sendSurfaceEvent: (payload: Record<string, unknown>, sender?: RoomSurfaceEventSender) => void
+}
 
 export const isRoomBridgeEnvelope = (data: unknown): data is RoomBridgeEnvelope => {
   if (!data || typeof data !== 'object') {
@@ -60,7 +71,21 @@ export const publishSurfaceEvent = (roomId: string, payload: Record<string, unkn
   window.parent.postMessage(buildRoomBridgeEnvelope('surface_event', roomId, { payload }), '*')
 }
 
-export const subscribeRoomEvents = (roomId: string, onEvent: RoomEventListener): (() => void) => {
+export const buildRoomSurfaceWSMessage = (
+  payload: Record<string, unknown>,
+  sender: RoomSurfaceEventSender = {}
+): WSInboundMessage => ({
+  type: 'surface_event',
+  payload,
+  senderType: sender.senderType || 'user',
+  senderId: sender.senderId || 'playground-user',
+  senderName: sender.senderName,
+})
+
+export const subscribeRoomEvents = (
+  roomId: string,
+  onEvent: RoomEventListener
+): RoomWebSocketSubscription => {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
   const wsUrl = `${protocol}//${window.location.host}/api/openclaw/rooms/${encodeURIComponent(roomId)}/ws`
   const ws = new WebSocket(wsUrl)
@@ -74,10 +99,20 @@ export const subscribeRoomEvents = (roomId: string, onEvent: RoomEventListener):
     }
   }
 
-  return () => {
-    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-      ws.close()
+  const sendSurfaceEvent = (payload: Record<string, unknown>, sender: RoomSurfaceEventSender = {}) => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      return
     }
+    ws.send(JSON.stringify(buildRoomSurfaceWSMessage(payload, sender)))
+  }
+
+  return {
+    close: () => {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close()
+      }
+    },
+    sendSurfaceEvent,
   }
 }
 

--- a/dashboard/frontend/src/components/useClawRoomTransport.ts
+++ b/dashboard/frontend/src/components/useClawRoomTransport.ts
@@ -132,6 +132,22 @@ export const useClawRoomTransport = ({
         }
       }) as EventListener)
 
+      source.addEventListener('surface_event', ((event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as RoomStreamEvent
+          onRoomEventRef.current?.({
+            type: 'surface_event',
+            roomId: payload.roomId,
+            payload: payload.payload,
+            participantType: payload.participantType,
+            participantId: payload.participantId,
+            sessionUser: payload.sessionUser,
+          })
+        } catch {
+          // ignore malformed stream events
+        }
+      }) as EventListener)
+
       source.addEventListener('message_updated', ((event: MessageEvent<string>) => {
         try {
           const payload = JSON.parse(event.data) as RoomStreamEvent

--- a/dashboard/frontend/src/pages/OpenClawPageTabs.tsx
+++ b/dashboard/frontend/src/pages/OpenClawPageTabs.tsx
@@ -399,26 +399,23 @@ export const StatusTab: React.FC<{
   useEffect(() => {
     if (!linkedRoomId || !selectedContainer || !selected?.healthy) {
       setRoomBridgeEvents([])
+      setSurfaceEvents([])
       return
     }
 
-    const unsubscribe = subscribeRoomEvents(linkedRoomId, event => {
+    const subscription = subscribeRoomEvents(linkedRoomId, event => {
       setRoomBridgeEvents(previous => [...previous.slice(-19), event])
       if (iframeRef.current) {
         postRoomEventToFrame(iframeRef.current, linkedRoomId, event)
       }
     })
 
-    return unsubscribe
-  }, [linkedRoomId, selected?.healthy, selectedContainer])
-
-  useEffect(() => {
-    if (!linkedRoomId || !selectedContainer || !selected?.healthy) {
-      setSurfaceEvents([])
-      return
-    }
-
-    return listenForSurfaceEvents(linkedRoomId, (_roomId, payload) => {
+    const unsubscribeSurface = listenForSurfaceEvents(linkedRoomId, (_roomId, payload) => {
+      subscription.sendSurfaceEvent(payload, {
+        senderType: 'worker',
+        senderId: selectedContainer,
+        senderName: selectedContainer,
+      })
       setSurfaceEvents(previous => [
         ...previous.slice(-9),
         {
@@ -429,6 +426,11 @@ export const StatusTab: React.FC<{
         },
       ])
     })
+
+    return () => {
+      unsubscribeSurface()
+      subscription.close()
+    }
   }, [linkedRoomId, selected?.healthy, selectedContainer])
 
   const latestRoomBridgeEvent = useMemo(() => {


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes https://github.com/vllm-project/semantic-router/issues/1521

**PR3:Complete participant identity and multi-client sync; close the issue after legacy cleanup**

Worker replies are no longer anonymous streaming text; events carry room-scoped session and participant identity so it is clear who is speaking. The embedded OpenClaw surface sends surface_event over WebSocket so tool calls, status changes, and similar activity are written back to the room and broadcast to all connected clients. Multi-tab sync is hardened, and ClawRoom and the Dashboard embedded page stay in sync in the same room. Remaining direct-broadcast legacy paths are removed; SSE is explicitly documented as fallback only. Go and E2E tests cover the full path: user sends @ worker → worker streams a reply → a third client (simulating the embedded page) receives the same events

## Purpose

- What does this PR change?

Backend

`openclaw_room_automation.go` — Passes the room into message_updated events so worker replies include room-scoped session identity.
`openclaw_room_collaboration.go` — Adds surface_event collaboration events, richer SSE mapping, and sessionUser on worker message_updated payloads.
`openclaw_room_collaboration_test.go` — Adds Go tests for worker identity, surface fan-out, and full user/worker/surface collaboration flows.
`openclaw_rooms.go` — Extends SSE stream events with collaboration fields and documents SSE as a WebSocket fallback.
`openclaw_websocket.go` — Handles inbound surface_event over room WebSocket and forwards participant payloads on outbound messages.
`openclaw_websocket_test.go` — Updates a streaming test to use the room-aware message_updated helper.
`openclaw_routes.go` — Propagates optional roomId / X-ClawOS-Room-Id on the embedded OpenClaw proxy for room context.

Frontend

`clawRoomChatSupport.ts `— Types and handlers for surface_event on WebSocket/SSE (consume-only; no UI rendering yet).
`openclawRoomBridge.ts` — Exposes room WebSocket subscription with sendSurfaceEvent to publish surface activity back to the room bus.
`openclawRoomBridge.test.ts` — Unit tests for surface WebSocket message shape and bridge envelope encoding.
`useClawRoomTransport.ts` — Listens for surface_event on SSE and forwards it through the room transport callback.
`OpenClawPageTabs.tsx` — Forwards iframe surface events to the room WebSocket while keeping local bridge activity state.
`claw-room-collaboration.spec.ts` — E2E checks that simulated surface events are sent over the room WebSocket from the dashboard flow.

- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
