### PR TITLE
[Dashboard] Helm chart: add optional HTTPRoute for Gateway API ingress

### DIFF
--- a/deploy/helm/semantic-router/templates/dashboard-httproute.yaml
+++ b/deploy/helm/semantic-router/templates/dashboard-httproute.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "semantic-router.fullname" . }}-dashboard
+  namespace: {{ include "semantic-router.namespace" . }}
+  labels:
+    {{- include "semantic-router.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+  {{- with .Values.dashboard.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    - name: {{ .Values.dashboard.httpRoute.parentRef.name }}
+      namespace: {{ .Values.dashboard.httpRoute.parentRef.namespace }}
+      {{- if .Values.dashboard.httpRoute.parentRef.sectionName }}
+      sectionName: {{ .Values.dashboard.httpRoute.parentRef.sectionName }}
+      {{- end }}
+  hostnames:
+    - {{ .Values.dashboard.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "semantic-router.fullname" . }}-dashboard
+          port: {{ .Values.dashboard.service.port }}
+{{- end }}

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -566,6 +566,22 @@ dashboard:
     mountPath: /app/data
     # -- Annotations for the dashboard-local state PVC.
     annotations: {}
+  # Gateway API HTTPRoute for the dashboard
+  httpRoute:
+    # -- Enable HTTPRoute for the dashboard (requires Gateway API CRDs and a Gateway in the cluster)
+    enabled: false
+    # -- Annotations to add to the HTTPRoute
+    annotations: {}
+    # -- Hostname the HTTPRoute will accept traffic for
+    hostname: semantic-router-dashboard.local
+    # -- Reference to the parent Gateway
+    parentRef:
+      # -- Name of the Gateway resource
+      name: ""
+      # -- Namespace of the Gateway resource
+      namespace: ""
+      # -- Optional: listener section name on the Gateway (e.g. "https")
+      sectionName: ""
 
 dependencies:
   semanticCache:


### PR DESCRIPTION
Adds dashboard-httproute.yaml template and corresponding values to expose the dashboard via a Gateway API HTTPRoute. The existing Ingress only targets the router service

Disabled by default, opt-in via `dashboard.httpRoute.enabled: true`

Configurable fields: hostname, parentRef (name, namespace, sectionName), and annotations.


## Purpose

- Adds dashboard-httproute.yaml template and dashboard.httpRoute values block to expose the dashboard via a Gateway API
HTTPRoute
- The existing ingress.yaml only targets the router service — the dashboard had no resource to route traffic to it
- Affects: Dashboard, Helm

## Test Plan
```
helm install semantic-router ./deploy/helm/semantic-router \
  -n vllm-sr \
  --set dashboard.enabled=true \
  --set dashboard.httpRoute.enabled=true \
  --set dashboard.httpRoute.parentRef.name=<gateway-name> \
  --set dashboard.httpRoute.parentRef.namespace=<gateway-ns> \
  --set dashboard.httpRoute.hostname=semantic-router-dashboard.local

kubectl get httproute -n vllm-sr
curl -H "Host: semantic-router-dashboard.local" http://<gateway-ip>/
```
Disabled by default (dashboard.httpRoute.enabled: false) — no impact on existing installs.

## Test Result

- HTTPRoute accepted by Envoy Gateway, 200 returned through the route
- No regressions on default install

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
