### PR TITLE
Resolves #1500: bug: cache hits bypass the RAG and memory injection pipeline

### DIFF
--- a/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
+++ b/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
@@ -277,6 +277,39 @@ func TestNoCacheBypassWhenMemoryExplicitlyDisabledPerDecision(t *testing.T) {
 	assert.True(t, hit, "should report a cache hit")
 }
 
+func TestCacheBypassWhenDecisionProvidedByCategoryName(t *testing.T) {
+	spy := &spyCache{shouldHit: true, hitResponse: []byte(`{"choices":[]}`)}
+
+	decision := config.Decision{
+		Name:      "rag-by-name",
+		ModelRefs: []config.ModelRef{{Model: "m"}},
+		Plugins: []config.DecisionPlugin{
+			{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+				"enabled": true,
+				"backend": "external_api",
+			})},
+		},
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.Enabled = true
+	cfg.Decisions = []config.Decision{decision}
+
+	router := &OpenAIRouter{Config: cfg, Cache: spy}
+	ctx := &RequestContext{
+		Headers:             make(map[string]string),
+		RequestID:           "category-name-bypass-1",
+		StartTime:           time.Now(),
+		OriginalRequestBody: makeOpenAIRequestBody("m", "What are my recent orders?"),
+	}
+
+	resp, hit := router.handleCaching(ctx, "rag-by-name")
+
+	assert.False(t, spy.findCalled, "cache read must be skipped when decision is resolved by category name")
+	assert.Nil(t, resp)
+	assert.False(t, hit)
+}
+
 // --- decisionWillPersonalize predicate tests ---
 
 func TestDecisionWillPersonalize_RAGEnabled(t *testing.T) {

--- a/src/semantic-router/pkg/extproc/req_filter_cache.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache.go
@@ -22,21 +22,38 @@ import (
 //
 // This avoids orphaned pending cache entries and unnecessary embedding work.
 func decisionWillPersonalize(ctx *RequestContext, cfg *config.RouterConfig) bool {
-	d := ctx.VSRSelectedDecision
-	if d == nil {
+	return decisionWillPersonalizeForDecision(ctx, cfg, "")
+}
+
+func decisionWillPersonalizeForDecision(ctx *RequestContext, cfg *config.RouterConfig, decisionName string) bool {
+	if ctx == nil {
 		return false
 	}
-	if ragCfg := d.GetRAGConfig(); ragCfg != nil && ragCfg.Enabled {
+
+	if d := ctx.VSRSelectedDecision; d != nil {
+		if ragCfg := d.GetRAGConfig(); ragCfg != nil && ragCfg.Enabled {
+			return true
+		}
+		// Per-decision memory plugin takes priority over global setting.
+		if memCfg := d.GetMemoryConfig(); memCfg != nil {
+			return memCfg.Enabled
+		}
+	}
+
+	if cfg == nil {
+		return false
+	}
+
+	if decisionName == "" {
+		decisionName = ctx.VSRSelectedDecisionName
+	}
+	if decisionName == "" && ctx.VSRSelectedDecision != nil {
+		decisionName = ctx.VSRSelectedDecision.Name
+	}
+	if decisionName != "" && cfg.HasPersonalizationPlugins(decisionName) {
 		return true
 	}
-	// Per-decision memory plugin takes priority over global setting.
-	if memCfg := d.GetMemoryConfig(); memCfg != nil {
-		return memCfg.Enabled
-	}
-	if cfg != nil && cfg.Memory.Enabled {
-		return true
-	}
-	return false
+	return cfg.Memory.Enabled
 }
 
 // handleCaching handles cache lookup and storage with category-specific settings
@@ -44,7 +61,7 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext, categoryName string) (
 	// Skip entire cache path for decisions that will inject user-specific context.
 	// Both reads (would serve stale generic answers) and writes (would leak
 	// personalized data) are wrong when RAG or memory is enabled.
-	if decisionWillPersonalize(ctx, r.Config) {
+	if decisionWillPersonalizeForDecision(ctx, r.Config, categoryName) {
 		logging.Debugf("[Cache] Skipping cache for decision '%s': RAG or memory enabled", categoryName)
 		return nil, false
 	}

--- a/src/semantic-router/pkg/extproc/req_filter_cache_personalized_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache_personalized_test.go
@@ -78,6 +78,29 @@ func TestDecisionWillPersonalize(t *testing.T) {
 			cfg:  &config.RouterConfig{},
 			want: false,
 		},
+		{
+			name: "decision name lookup without decision object",
+			ctx: &RequestContext{
+				VSRSelectedDecisionName: "rag-only",
+			},
+			cfg: func() *config.RouterConfig {
+				cfg := &config.RouterConfig{}
+				cfg.Decisions = []config.Decision{
+					{
+						Name:      "rag-only",
+						ModelRefs: []config.ModelRef{{Model: "m"}},
+						Plugins: []config.DecisionPlugin{
+							{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+								"enabled": true,
+								"backend": "milvus",
+							})},
+						},
+					},
+				}
+				return cfg
+			}(),
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -85,6 +108,25 @@ func TestDecisionWillPersonalize(t *testing.T) {
 			assert.Equal(t, tt.want, decisionWillPersonalize(tt.ctx, tt.cfg))
 		})
 	}
+}
+
+func TestDecisionWillPersonalizeForDecision_UsesCategoryFallback(t *testing.T) {
+	ctx := &RequestContext{}
+	cfg := &config.RouterConfig{}
+	cfg.Decisions = []config.Decision{
+		{
+			Name:      "rag-from-category",
+			ModelRefs: []config.ModelRef{{Model: "m"}},
+			Plugins: []config.DecisionPlugin{
+				{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
+					"enabled": true,
+					"backend": "milvus",
+				})},
+			},
+		},
+	}
+
+	assert.True(t, decisionWillPersonalizeForDecision(ctx, cfg, "rag-from-category"))
 }
 
 func TestUpdateResponseCacheSkipsPersonalizedContext(t *testing.T) {


### PR DESCRIPTION
Closes #1500

1. **Understanding** — The bug is that cache lookup can short-circuit request processing before personalization (RAG and/or memory retrieval), so users may receive a valid but non-personalized cached answer. In this workspace, the fix pattern for **Option 2** (skip cache path when decision implies personalization) is already present via `decisionWillPersonalize` and early cache bypass, but the resolution work should confirm whether any remaining path (especially looper or decision-timing edge cases) still allows a cache hit before personalization.

2. **Affected files** — verified workspace-relative paths:
- `src/semantic-router/pkg/extproc/processor_req_body_prepare.go`
- `src/semantic-router/pkg/extproc/req_filter_cache.go`
- `src/semantic-router/pkg/extproc/req_filter_looper_internal.go`
- `src/semantic-router/pkg/extproc/processor_req_body_memory.go`
- `src/semantic-router/pkg/extproc/req_filter_rag.go`
- `src/semantic-router/pkg/extproc/request_context.go`
- `src/semantic-router/pkg/extproc/processor_req_body.go`
- `src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go`
- `src/semantic-router/pkg/extproc/req_filter_cache_personalized_test.go`
- `src/semantic-router/pkg/extproc/processor_res_cache_test.go`

3. **Proposed change**
- Confirm the request-phase ordering and short-circuit points are correct and complete:
  - `runRequestPreRoutingStages` currently does cache checks before RAG (`src/semantic-router/pkg/extproc/processor_req_body_prepare.go:99-140`, cache at `:125`, RAG at `:130`).
  - Memory runs later in `prepareRequestForModelRouting` (`src/semantic-router/pkg/extproc/processor_req_body_prepare.go:182-228`, memory at `:214`).
  - Main sequencing call-site is `runRequestPreRoutingStages` then `prepareRequestForModelRouting` (`src/semantic-router/pkg/extproc/processor_req_body.go:73-79`).
- Keep Option 2 as the enforced behavior by centralizing/retaining the bypass predicate:
  - `decisionWillPersonalize` in `src/semantic-router/pkg/extproc/req_filter_cache.go:24-40`.
  - Ensure every request-side cache-read entrypoint uses it before lookup (`handleCaching` at `req_filter_cache.go:43-75`; call sites in `processor_req_body_prepare.go:172` and `req_filter_looper_internal.go:345`).
- Verify response-side cache-write protections remain aligned with request-side bypass:
  - `updateResponseCache` personalization skip (`src/semantic-router/pkg/extproc/processor_res_cache.go:21-49`).
  - `cacheStreamingResponse` personalization skip (`src/semantic-router/pkg/extproc/processor_res_cache.go:67-96`).
  - Canonical personalized-context check remains `HasPersonalizedContext` (`src/semantic-router/pkg/extproc/request_context.go:257`).
- If any uncovered path exists (e.g., decision unset at cache-check time), add a narrow guard/test rather than reordering the full pipeline.

4. **Risks**
- **Behavioral risk:** over-bypassing cache when personalization is actually disabled (especially per-decision memory override).
- **Edge risk:** decision availability timing (`ctx.VSRSelectedDecision` nil) could permit accidental cache reads.
- **Consistency risk:** request-side bypass and response-side skip could diverge if predicate semantics drift.
- **Tests that must pass:**  
  - `cache_personalization_pipeline_test.go` (bypass + pipeline behavior)  
  - `req_filter_cache_personalized_test.go` (predicate + cache write skip expectations)  
  - `processor_res_cache_test.go` (streaming/non-streaming personalized skip paths)

5. **Next steps**
1. Reproduce/confirm current behavior for Issue #1500 scenario with focused extproc tests.
2. Add/adjust only the missing guard(s) for any remaining cache-before-personalization edge path.