### PR TITLE
[Dashboard]feat: surface OpenClaw worker tool calls in ClawRoom from session jsonl

### DIFF
--- a/dashboard/backend/handlers/openclaw_room_automation.go
+++ b/dashboard/backend/handlers/openclaw_room_automation.go
@@ -257,6 +257,16 @@ func (h *OpenClawHandler) startRoomAutomationReply(
 
 	placeholderID := generateRoomEntityID("room-msg")
 	go func() {
+		sessionFile, baselineOffset := h.captureOpenClawSessionToolTraceBaseline(room, target)
+		traceDone, _ := h.bindOpenClawSessionToolTraceWatcher(
+			roomID,
+			room,
+			target,
+			placeholderID,
+			sessionFile,
+			baselineOffset,
+		)
+
 		onChunk := func(chunk string, done bool) {
 			if done || chunk != "" {
 				h.publishRoomCollaborationEvent(
@@ -278,6 +288,17 @@ func (h *OpenClawHandler) startRoomAutomationReply(
 		)
 		if err == nil {
 			reply.ID = placeholderID
+			h.attachOpenClawSessionToolTraceToReply(
+				placeholderID,
+				traceDone,
+				room,
+				target,
+				sessionFile,
+				baselineOffset,
+				&reply,
+			)
+		} else {
+			finishOpenClawSessionToolTraceWatcher(placeholderID, traceDone)
 		}
 		results <- targetReplyResult{
 			target: target,

--- a/dashboard/backend/handlers/openclaw_session_tool_trace.go
+++ b/dashboard/backend/handlers/openclaw_session_tool_trace.go
@@ -1,0 +1,511 @@
+package handlers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	openClawSessionStateRoot             = "/state/agents"
+	openClawSessionPollInterval          = 400 * time.Millisecond
+	openClawSessionPollTimeout           = 45 * time.Second
+	openClawSessionToolTraceMaxLineBytes = 1024 * 1024
+	roomMessageToolTraceMetadataKey      = "toolTrace"
+)
+
+type openClawSessionToolStep struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments,omitempty"`
+	Status    string `json:"status"`
+	Result    string `json:"result,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+type openClawSessionToolTracePayload struct {
+	Revision int                       `json:"revision"`
+	Steps    []openClawSessionToolStep `json:"steps"`
+}
+
+type openClawSessionIndexEntry struct {
+	SessionFile string `json:"sessionFile"`
+	SessionID   string `json:"sessionId"`
+}
+
+func openClawChatCompletionsSessionKeys(sessionUser string) []string {
+	trimmedUser := strings.TrimSpace(sessionUser)
+	keys := make([]string, 0, 2)
+	if trimmedUser != "" {
+		keys = append(keys,
+			fmt.Sprintf("agent:%s:openai-user:%s", openClawPrimaryAgentID, trimmedUser),
+			fmt.Sprintf("agent:%s:openresponses-user:%s", openClawPrimaryAgentID, trimmedUser),
+		)
+	}
+	return keys
+}
+
+func openClawSessionsIndexPath() string {
+	return fmt.Sprintf("%s/%s/sessions/sessions.json", openClawSessionStateRoot, openClawPrimaryAgentID)
+}
+
+func (h *OpenClawHandler) readOpenClawContainerFile(containerName, filePath string) ([]byte, error) {
+	normalizedContainer := sanitizeContainerName(containerName)
+	if normalizedContainer == "" {
+		return nil, fmt.Errorf("container name is required")
+	}
+	trimmedPath := strings.TrimSpace(filePath)
+	if trimmedPath == "" || strings.Contains(trimmedPath, "..") {
+		return nil, fmt.Errorf("invalid container file path")
+	}
+
+	output, err := h.containerCombinedOutput(
+		"exec",
+		normalizedContainer,
+		"sh",
+		"-c",
+		fmt.Sprintf("cat %s 2>/dev/null", shellQuote(trimmedPath)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func resolveOpenClawSessionFileFromIndex(indexData []byte, sessionKeys []string) (string, bool) {
+	var index map[string]openClawSessionIndexEntry
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return "", false
+	}
+	for _, key := range sessionKeys {
+		entry, ok := index[key]
+		if !ok {
+			continue
+		}
+		sessionFile := strings.TrimSpace(entry.SessionFile)
+		if sessionFile != "" {
+			return sessionFile, true
+		}
+	}
+	return "", false
+}
+
+func openClawSessionToolTraceInitialOffset(baselineOffset, fileSize int64) int64 {
+	if baselineOffset <= 0 {
+		return 0
+	}
+	if baselineOffset > fileSize {
+		return 0
+	}
+	return baselineOffset
+}
+
+func encodeRoomMessageToolTraceMetadata(steps []openClawSessionToolStep) (string, error) {
+	if len(steps) == 0 {
+		return "", nil
+	}
+	encoded, err := json.Marshal(steps)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func attachRoomMessageToolTraceMetadata(message *ClawRoomMessage, steps []openClawSessionToolStep) {
+	if message == nil || len(steps) == 0 {
+		return
+	}
+	encoded, err := encodeRoomMessageToolTraceMetadata(steps)
+	if err != nil {
+		log.Printf("openclaw: failed to encode tool trace metadata for message %s: %v", message.ID, err)
+		return
+	}
+	if encoded == "" {
+		return
+	}
+	if message.Metadata == nil {
+		message.Metadata = map[string]string{}
+	}
+	message.Metadata[roomMessageToolTraceMetadataKey] = encoded
+}
+
+func splitOpenClawSessionToolTraceLines(data []byte) ([]string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), openClawSessionToolTraceMaxLineBytes)
+	lines := make([]string, 0)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return lines, err
+	}
+	return lines, nil
+}
+
+func (h *OpenClawHandler) readOpenClawSessionToolTraceSteps(
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	sessionFile string,
+	baselineOffset int64,
+) []openClawSessionToolStep {
+	sessionFile = strings.TrimSpace(sessionFile)
+	if sessionFile == "" {
+		sessionUser := roomScopedSessionUser(room, worker)
+		sessionKeys := openClawChatCompletionsSessionKeys(sessionUser)
+		resolved, err := h.resolveOpenClawSessionFile(worker.Name, sessionKeys)
+		if err != nil {
+			return nil
+		}
+		sessionFile = resolved
+	}
+
+	data, err := h.readOpenClawContainerFile(worker.Name, sessionFile)
+	if err != nil {
+		return nil
+	}
+
+	offset := openClawSessionToolTraceInitialOffset(baselineOffset, int64(len(data)))
+	if offset >= int64(len(data)) {
+		return nil
+	}
+
+	lines, err := splitOpenClawSessionToolTraceLines(data[offset:])
+	if err != nil {
+		log.Printf("openclaw: failed to parse session tool trace lines in %s: %v", sessionFile, err)
+	}
+
+	steps := make(map[string]openClawSessionToolStep)
+	stepOrder := make([]string, 0)
+	stepOrder, _ = parseOpenClawSessionToolTraceLines(lines, steps, stepOrder)
+	return orderedOpenClawSessionToolSteps(steps, stepOrder)
+}
+
+func (h *OpenClawHandler) captureOpenClawSessionToolTraceBaseline(
+	room ClawRoomEntry,
+	worker ContainerEntry,
+) (sessionFile string, offset int64) {
+	if !h.canWatchOpenClawSessionToolTrace(worker) {
+		return "", 0
+	}
+	sessionUser := roomScopedSessionUser(room, worker)
+	sessionKeys := openClawChatCompletionsSessionKeys(sessionUser)
+	resolved, err := h.resolveOpenClawSessionFile(worker.Name, sessionKeys)
+	if err != nil {
+		return "", 0
+	}
+	data, err := h.readOpenClawContainerFile(worker.Name, resolved)
+	if err != nil {
+		return resolved, 0
+	}
+	return resolved, int64(len(data))
+}
+
+func (h *OpenClawHandler) resolveOpenClawSessionFile(containerName string, sessionKeys []string) (string, error) {
+	indexData, err := h.readOpenClawContainerFile(containerName, openClawSessionsIndexPath())
+	if err != nil {
+		return "", err
+	}
+	sessionFile, ok := resolveOpenClawSessionFileFromIndex(indexData, sessionKeys)
+	if !ok {
+		return "", fmt.Errorf("session file not found for keys %v", sessionKeys)
+	}
+	return sessionFile, nil
+}
+
+func parseOpenClawSessionToolTraceLines(
+	lines []string,
+	steps map[string]openClawSessionToolStep,
+	order []string,
+) ([]string, bool) {
+	changed := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		nextOrder, lineChanged := parseOpenClawSessionToolTraceLine(line, steps, order)
+		if lineChanged {
+			changed = true
+			order = nextOrder
+		}
+	}
+	return order, changed
+}
+
+func parseOpenClawSessionToolTraceLine(
+	line string,
+	steps map[string]openClawSessionToolStep,
+	order []string,
+) ([]string, bool) {
+	var record struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role       string            `json:"role"`
+			Content    []json.RawMessage `json:"content"`
+			ToolCallID string            `json:"toolCallId"`
+			ToolName   string            `json:"toolName"`
+			IsError    bool              `json:"isError"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(line), &record); err != nil || record.Type != "message" {
+		return order, false
+	}
+
+	changed := false
+	if record.Message.Role == "assistant" {
+		for _, raw := range record.Message.Content {
+			var part struct {
+				Type      string          `json:"type"`
+				ID        string          `json:"id"`
+				Name      string          `json:"name"`
+				Arguments json.RawMessage `json:"arguments"`
+			}
+			if err := json.Unmarshal(raw, &part); err != nil || part.Type != "toolCall" {
+				continue
+			}
+			callID := strings.TrimSpace(part.ID)
+			if callID == "" {
+				continue
+			}
+			next := openClawSessionToolStep{
+				ID:        callID,
+				Name:      strings.TrimSpace(part.Name),
+				Arguments: stringifyToolTraceJSON(part.Arguments),
+				Status:    "running",
+			}
+			if existing, ok := steps[callID]; ok {
+				if existing.Status == "completed" || existing.Status == "failed" {
+					continue
+				}
+				if existing.Result != "" {
+					next.Result = existing.Result
+				}
+				if existing.Error != "" {
+					next.Error = existing.Error
+				}
+			}
+			steps[callID] = next
+			order = appendToolTraceOrder(order, callID)
+			changed = true
+		}
+	}
+
+	if record.Message.Role == "toolResult" {
+		callID := strings.TrimSpace(record.Message.ToolCallID)
+		if callID == "" {
+			return order, changed
+		}
+		existing := steps[callID]
+		existing.ID = callID
+		if existing.Name == "" {
+			existing.Name = strings.TrimSpace(record.Message.ToolName)
+		}
+		existing.Result = extractOpenClawToolResultText(record.Message.Content)
+		if record.Message.IsError {
+			existing.Status = "failed"
+			if existing.Result == "" {
+				existing.Error = "tool returned an error"
+			} else {
+				existing.Error = existing.Result
+			}
+		} else {
+			existing.Status = "completed"
+		}
+		steps[callID] = existing
+		order = appendToolTraceOrder(order, callID)
+		changed = true
+	}
+
+	return order, changed
+}
+
+func appendToolTraceOrder(order []string, callID string) []string {
+	for _, existing := range order {
+		if existing == callID {
+			return order
+		}
+	}
+	return append(order, callID)
+}
+
+func stringifyToolTraceJSON(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		return trimmed
+	}
+	return compact.String()
+}
+
+func extractOpenClawToolResultText(raw []json.RawMessage) string {
+	parts := make([]string, 0, len(raw))
+	for _, item := range raw {
+		var part struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(item, &part); err != nil {
+			continue
+		}
+		if strings.TrimSpace(part.Text) != "" {
+			parts = append(parts, part.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func orderedOpenClawSessionToolSteps(
+	steps map[string]openClawSessionToolStep,
+	order []string,
+) []openClawSessionToolStep {
+	ordered := make([]openClawSessionToolStep, 0, len(order))
+	for _, callID := range order {
+		step, ok := steps[callID]
+		if !ok {
+			continue
+		}
+		ordered = append(ordered, step)
+	}
+	return ordered
+}
+
+func toolTraceUpdateCollaborationEvent(
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	messageID string,
+	payload openClawSessionToolTracePayload,
+) ClawRoomCollaborationEvent {
+	steps := payload.Steps
+	payloadMap := map[string]any{
+		"revision": payload.Revision,
+		"steps":    steps,
+	}
+	return ClawRoomCollaborationEvent{
+		Type:            WSTypeToolTraceUpdate,
+		MessageID:       messageID,
+		ParticipantType: "worker",
+		ParticipantID:   worker.Name,
+		SessionUser:     roomScopedSessionUser(room, worker),
+		Payload:         payloadMap,
+	}
+}
+
+func takeOpenClawSessionToolTraceSteps(messageID string) []openClawSessionToolStep {
+	raw, ok := openClawSessionToolTraceStepRegistry.LoadAndDelete(messageID)
+	if !ok {
+		return nil
+	}
+	steps, ok := raw.([]openClawSessionToolStep)
+	if !ok || len(steps) == 0 {
+		return nil
+	}
+	return append([]openClawSessionToolStep(nil), steps...)
+}
+
+func (h *OpenClawHandler) attachOpenClawSessionToolTraceToReply(
+	messageID string,
+	done chan struct{},
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	sessionFile string,
+	baselineOffset int64,
+	reply *ClawRoomMessage,
+) {
+	finishOpenClawSessionToolTraceWatcher(messageID, done)
+	steps := h.readOpenClawSessionToolTraceSteps(room, worker, sessionFile, baselineOffset)
+	if len(steps) == 0 {
+		steps = takeOpenClawSessionToolTraceSteps(messageID)
+	} else {
+		openClawSessionToolTraceStepRegistry.Delete(messageID)
+	}
+	if reply != nil {
+		attachRoomMessageToolTraceMetadata(reply, steps)
+	}
+}
+
+func (h *OpenClawHandler) startOpenClawSessionToolTraceWatcher(
+	roomID string,
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	messageID string,
+	done <-chan struct{},
+	sessionFile string,
+	baselineOffset int64,
+) context.CancelFunc {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer cancel()
+		<-done
+	}()
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				log.Printf("openclaw: session tool trace watcher panic for %s: %v", messageID, recovered)
+			}
+		}()
+		h.streamOpenClawSessionToolTrace(ctx, roomID, room, worker, messageID, sessionFile, baselineOffset)
+	}()
+	return cancel
+}
+
+var (
+	openClawSessionToolTraceWatcherRegistry sync.Map
+	openClawSessionToolTraceStepRegistry    sync.Map
+)
+
+func (h *OpenClawHandler) canWatchOpenClawSessionToolTrace(worker ContainerEntry) bool {
+	containerName := sanitizeContainerName(worker.Name)
+	if containerName == "" {
+		return false
+	}
+	return h.containerRunning(containerName)
+}
+
+func (h *OpenClawHandler) bindOpenClawSessionToolTraceWatcher(
+	roomID string,
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	messageID string,
+	sessionFile string,
+	baselineOffset int64,
+) (done chan struct{}, cancel context.CancelFunc) {
+	done = make(chan struct{})
+	if !h.canWatchOpenClawSessionToolTrace(worker) {
+		return done, func() {}
+	}
+	cancel = h.startOpenClawSessionToolTraceWatcher(
+		roomID,
+		room,
+		worker,
+		messageID,
+		done,
+		sessionFile,
+		baselineOffset,
+	)
+	openClawSessionToolTraceWatcherRegistry.Store(messageID, cancel)
+	return done, cancel
+}
+
+func finishOpenClawSessionToolTraceWatcher(messageID string, done chan struct{}) {
+	if done != nil {
+		close(done)
+	}
+	if raw, ok := openClawSessionToolTraceWatcherRegistry.LoadAndDelete(messageID); ok {
+		if cancel, ok := raw.(context.CancelFunc); ok {
+			cancel()
+		}
+	}
+}

--- a/dashboard/backend/handlers/openclaw_session_tool_trace_stream.go
+++ b/dashboard/backend/handlers/openclaw_session_tool_trace_stream.go
@@ -1,0 +1,168 @@
+package handlers
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+)
+
+func (h *OpenClawHandler) resolveOpenClawSessionToolTraceFile(
+	ctx context.Context,
+	worker ContainerEntry,
+	sessionKeys []string,
+	knownSessionFile string,
+) string {
+	sessionFile := strings.TrimSpace(knownSessionFile)
+	if sessionFile != "" {
+		return sessionFile
+	}
+
+	deadline := time.Now().Add(openClawSessionPollTimeout)
+	for sessionFile == "" && time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ""
+		default:
+		}
+		resolved, err := h.resolveOpenClawSessionFile(worker.Name, sessionKeys)
+		if err == nil {
+			return resolved
+		}
+		time.Sleep(openClawSessionPollInterval)
+	}
+	return ""
+}
+
+func (h *OpenClawHandler) readOpenClawSessionToolTraceStartOffset(
+	worker ContainerEntry,
+	sessionFile string,
+	baselineOffset int64,
+) int64 {
+	offset := baselineOffset
+	if data, err := h.readOpenClawContainerFile(worker.Name, sessionFile); err == nil {
+		return openClawSessionToolTraceInitialOffset(baselineOffset, int64(len(data)))
+	}
+	if offset < 0 {
+		return 0
+	}
+	return offset
+}
+
+func (h *OpenClawHandler) publishOpenClawSessionToolTraceUpdate(
+	roomID string,
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	messageID string,
+	steps map[string]openClawSessionToolStep,
+	stepOrder []string,
+	revision int,
+) int {
+	revision++
+	orderedSteps := orderedOpenClawSessionToolSteps(steps, stepOrder)
+	payload := openClawSessionToolTracePayload{
+		Revision: revision,
+		Steps:    orderedSteps,
+	}
+	openClawSessionToolTraceStepRegistry.Store(messageID, append([]openClawSessionToolStep(nil), orderedSteps...))
+	h.publishRoomCollaborationEvent(
+		roomID,
+		toolTraceUpdateCollaborationEvent(room, worker, messageID, payload),
+	)
+	return revision
+}
+
+func (h *OpenClawHandler) pollOpenClawSessionToolTraceOnce(
+	roomID string,
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	messageID string,
+	sessionFile string,
+	steps map[string]openClawSessionToolStep,
+	stepOrder *[]string,
+	offset *int64,
+	revision *int,
+) {
+	data, err := h.readOpenClawContainerFile(worker.Name, sessionFile)
+	if err != nil {
+		return
+	}
+
+	if int64(len(data)) < *offset {
+		*offset = 0
+		for key := range steps {
+			delete(steps, key)
+		}
+		*stepOrder = (*stepOrder)[:0]
+	}
+	if int64(len(data)) == *offset {
+		return
+	}
+
+	newData := data[*offset:]
+	*offset = int64(len(data))
+
+	lines, err := splitOpenClawSessionToolTraceLines(newData)
+	if err != nil {
+		log.Printf("openclaw: failed to tail session tool trace lines in %s: %v", sessionFile, err)
+	}
+
+	var changed bool
+	*stepOrder, changed = parseOpenClawSessionToolTraceLines(lines, steps, *stepOrder)
+	if !changed {
+		return
+	}
+
+	*revision = h.publishOpenClawSessionToolTraceUpdate(
+		roomID,
+		room,
+		worker,
+		messageID,
+		steps,
+		*stepOrder,
+		*revision,
+	)
+}
+
+func (h *OpenClawHandler) streamOpenClawSessionToolTrace(
+	ctx context.Context,
+	roomID string,
+	room ClawRoomEntry,
+	worker ContainerEntry,
+	messageID string,
+	knownSessionFile string,
+	baselineOffset int64,
+) {
+	sessionUser := roomScopedSessionUser(room, worker)
+	sessionKeys := openClawChatCompletionsSessionKeys(sessionUser)
+	sessionFile := h.resolveOpenClawSessionToolTraceFile(ctx, worker, sessionKeys, knownSessionFile)
+	if sessionFile == "" {
+		return
+	}
+
+	steps := make(map[string]openClawSessionToolStep)
+	stepOrder := make([]string, 0)
+	offset := h.readOpenClawSessionToolTraceStartOffset(worker, sessionFile, baselineOffset)
+	var revision int
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		h.pollOpenClawSessionToolTraceOnce(
+			roomID,
+			room,
+			worker,
+			messageID,
+			sessionFile,
+			steps,
+			&stepOrder,
+			&offset,
+			&revision,
+		)
+		time.Sleep(openClawSessionPollInterval)
+	}
+}

--- a/dashboard/backend/handlers/openclaw_session_tool_trace_test.go
+++ b/dashboard/backend/handlers/openclaw_session_tool_trace_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestResolveOpenClawSessionFileFromIndex(t *testing.T) {
+	indexData := []byte(`{
+	  "agent:vllm-sr:openai-user:room-a:worker-a": {
+	    "sessionFile": "/state/agents/vllm-sr/sessions/abc.jsonl"
+	  }
+	}`)
+
+	sessionFile, ok := resolveOpenClawSessionFileFromIndex(indexData, []string{
+		"agent:vllm-sr:openresponses-user:room-a:worker-a",
+		"agent:vllm-sr:openai-user:room-a:worker-a",
+	})
+	if !ok {
+		t.Fatal("expected session file to resolve")
+	}
+	if sessionFile != "/state/agents/vllm-sr/sessions/abc.jsonl" {
+		t.Fatalf("sessionFile = %q", sessionFile)
+	}
+}
+
+func TestParseOpenClawSessionToolTraceLine(t *testing.T) {
+	toolCallLine := `{"type":"message","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_1","name":"exec","arguments":{"command":"pwd"}}]}}`
+	toolResultLine := `{"type":"message","message":{"role":"toolResult","toolCallId":"call_1","toolName":"exec","content":[{"type":"text","text":"/workspace"}],"isError":false}}`
+
+	steps := make(map[string]openClawSessionToolStep)
+	order := make([]string, 0)
+
+	order, changed := parseOpenClawSessionToolTraceLine(toolCallLine, steps, order)
+	if !changed {
+		t.Fatal("expected tool call line to change state")
+	}
+	if steps["call_1"].Status != "running" {
+		t.Fatalf("tool call status = %q, want running", steps["call_1"].Status)
+	}
+
+	order, changed = parseOpenClawSessionToolTraceLine(toolResultLine, steps, order)
+	if !changed {
+		t.Fatal("expected tool result line to change state")
+	}
+	if steps["call_1"].Status != "completed" {
+		t.Fatalf("tool result status = %q, want completed", steps["call_1"].Status)
+	}
+	if steps["call_1"].Result != "/workspace" {
+		t.Fatalf("tool result = %q", steps["call_1"].Result)
+	}
+	if len(order) != 1 || order[0] != "call_1" {
+		t.Fatalf("order = %#v", order)
+	}
+}
+
+func TestOpenClawSessionToolTraceInitialOffset(t *testing.T) {
+	if got := openClawSessionToolTraceInitialOffset(128, 128); got != 128 {
+		t.Fatalf("offset = %d, want 128", got)
+	}
+	if got := openClawSessionToolTraceInitialOffset(128, 64); got != 0 {
+		t.Fatalf("offset = %d, want 0 for truncated baseline", got)
+	}
+	if got := openClawSessionToolTraceInitialOffset(0, 64); got != 0 {
+		t.Fatalf("offset = %d, want 0 for missing baseline", got)
+	}
+}
+
+func TestEncodeRoomMessageToolTraceMetadata(t *testing.T) {
+	steps := []openClawSessionToolStep{
+		{ID: "call_1", Name: "exec", Status: "completed", Result: "/workspace"},
+		{ID: "call_2", Name: "read", Status: "running"},
+	}
+	encoded, err := encodeRoomMessageToolTraceMetadata(steps)
+	if err != nil {
+		t.Fatalf("encodeRoomMessageToolTraceMetadata() error = %v", err)
+	}
+
+	message := &ClawRoomMessage{ID: "msg-1"}
+	attachRoomMessageToolTraceMetadata(message, steps)
+	if message.Metadata[roomMessageToolTraceMetadataKey] != encoded {
+		t.Fatalf("metadata = %q, want %q", message.Metadata[roomMessageToolTraceMetadataKey], encoded)
+	}
+
+	var decoded []openClawSessionToolStep
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if len(decoded) != 2 || decoded[0].ID != "call_1" || decoded[1].ID != "call_2" {
+		t.Fatalf("decoded order = %#v", decoded)
+	}
+}
+
+func TestSplitOpenClawSessionToolTraceLines(t *testing.T) {
+	toolCallLine := `{"type":"message","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_1","name":"exec","arguments":{"command":"pwd"}}]}}`
+	largeLine := strings.Repeat("x", openClawSessionToolTraceMaxLineBytes/2) + toolCallLine
+
+	lines, err := splitOpenClawSessionToolTraceLines([]byte(largeLine + "\n" + toolCallLine))
+	if err != nil {
+		t.Fatalf("splitOpenClawSessionToolTraceLines() error = %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2", len(lines))
+	}
+}
+
+func TestOpenClawChatCompletionsSessionKeys(t *testing.T) {
+	keys := openClawChatCompletionsSessionKeys("room-a:worker-a")
+	if len(keys) != 2 {
+		t.Fatalf("keys = %#v", keys)
+	}
+	if keys[0] != "agent:vllm-sr:openai-user:room-a:worker-a" {
+		t.Fatalf("first key = %q", keys[0])
+	}
+}

--- a/dashboard/backend/handlers/openclaw_websocket.go
+++ b/dashboard/backend/handlers/openclaw_websocket.go
@@ -13,15 +13,16 @@ import (
 // WebSocket message types for ClawRoom.
 // WebSocket is the primary room collaboration transport; SSE (/stream) is a legacy fallback.
 const (
-	WSTypeSendMessage    = "send_message"
-	WSTypeSurfaceEvent   = "surface_event"
-	WSTypePing           = "ping"
-	WSTypePong           = "pong"
-	WSTypeNewMessage     = "new_message"
-	WSTypeMessageUpdated = "message_updated"
-	WSTypeMessageChunk   = "message_chunk"
-	WSTypeConnected      = "connected"
-	WSTypeError          = "error"
+	WSTypeSendMessage     = "send_message"
+	WSTypeSurfaceEvent    = "surface_event"
+	WSTypePing            = "ping"
+	WSTypePong            = "pong"
+	WSTypeNewMessage      = "new_message"
+	WSTypeMessageUpdated  = "message_updated"
+	WSTypeMessageChunk    = "message_chunk"
+	WSTypeToolTraceUpdate = "tool_trace_update"
+	WSTypeConnected       = "connected"
+	WSTypeError           = "error"
 
 	roomWSPingInterval = 5 * time.Minute
 	roomWSWriteTimeout = 5 * time.Minute

--- a/dashboard/frontend/e2e/claw-room-collaboration.spec.ts
+++ b/dashboard/frontend/e2e/claw-room-collaboration.spec.ts
@@ -158,6 +158,80 @@ test.describe('Claw room collaboration', () => {
     await expect(page.locator('[data-room-message-streaming="true"]')).toContainText('Typing now')
   })
 
+  test('renders streaming tool trace cards from websocket events', async ({ page }) => {
+    await mockCollaborationBootstrap(page)
+    await enableClawRoom(page)
+
+    await page.evaluate(() => {
+      const sockets = (window as typeof window & {
+        __mockRoomSockets?: Array<{ emit: (payload: Record<string, unknown>) => void }>
+      }).__mockRoomSockets
+      const socket = sockets?.[sockets.length - 1]
+      socket?.emit({
+        type: 'message_chunk',
+        messageId: 'stream-worker-tools',
+        chunk: 'Done.',
+        participantType: 'worker',
+        participantId: 'worker-a',
+      })
+      socket?.emit({
+        type: 'tool_trace_update',
+        messageId: 'stream-worker-tools',
+        payload: {
+          revision: 1,
+          steps: [
+            { id: 'call_1', name: 'exec', arguments: '{"command":"pwd"}', status: 'running' },
+          ],
+        },
+      })
+      socket?.emit({
+        type: 'tool_trace_update',
+        messageId: 'stream-worker-tools',
+        payload: {
+          revision: 2,
+          steps: [
+            {
+              id: 'call_1',
+              name: 'exec',
+              arguments: '{"command":"pwd"}',
+              status: 'completed',
+              result: '/workspace',
+            },
+          ],
+        },
+      })
+      socket?.emit({
+        type: 'message_updated',
+        message: {
+          id: 'stream-worker-tools',
+          roomId: 'room-alpha',
+          teamId: 'team-alpha',
+          senderType: 'worker',
+          senderName: 'worker-a',
+          content: 'Done.',
+          createdAt: '2026-05-31T00:00:00Z',
+          metadata: {
+            toolTrace: JSON.stringify([
+              {
+                id: 'call_1',
+                name: 'exec',
+                arguments: '{"command":"pwd"}',
+                status: 'completed',
+                result: '/workspace',
+              },
+            ]),
+          },
+        },
+      })
+    })
+
+    await expect(page.getByTestId('claw-room-tool-trace')).toBeVisible()
+    await expect(page.getByTestId('claw-room-tool-trace')).toContainText('exec')
+    await expect(page.getByTestId('claw-room-tool-trace')).toContainText('/workspace')
+    await expect(page.locator('[data-room-message-streaming="true"]')).toHaveCount(0)
+    await expect(page.locator('[data-room-message-id="stream-worker-tools"]')).toContainText('Done.')
+  })
+
   test('falls back to SSE when websocket disconnects', async ({ page }) => {
     await mockCollaborationBootstrap(page)
 

--- a/dashboard/frontend/src/components/ClawRoomChat.module.css
+++ b/dashboard/frontend/src/components/ClawRoomChat.module.css
@@ -1108,6 +1108,14 @@
   align-items: flex-end;
 }
 
+.toolTraceList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 100%;
+  max-width: min(72%, 560px);
+}
+
 .messageMeta {
   display: flex;
   align-items: center;

--- a/dashboard/frontend/src/components/ClawRoomChat.tsx
+++ b/dashboard/frontend/src/components/ClawRoomChat.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import styles from './ClawRoomChat.module.css'
 import { useReadonly } from '../contexts/ReadonlyContext'
+import ClawRoomMentionMenu from './ClawRoomMentionMenu'
 import ClawRoomSidebar from './ClawRoomSidebar'
 import ClawRoomTranscript from './ClawRoomTranscript'
 import ClawRoomTransportStatus from './ClawRoomTransportStatus'
@@ -299,6 +300,7 @@ const ClawRoomChat = ({
 
   const {
     streamingMessages,
+    streamingToolTraces,
     streamingParticipants,
     transportMode,
     wsConnected,
@@ -312,8 +314,8 @@ const ClawRoomChat = ({
   })
 
   const streamingEntries = useMemo(
-    () => buildStreamingEntries(messages, streamingMessages),
-    [messages, streamingMessages]
+    () => buildStreamingEntries(messages, streamingMessages, streamingToolTraces),
+    [messages, streamingMessages, streamingToolTraces]
   )
 
   useEffect(() => {
@@ -725,6 +727,7 @@ const ClawRoomChat = ({
               selectedRoomId={selectedRoomId}
               streamingEntries={streamingEntries}
               streamingMessages={streamingMessages}
+              streamingToolTraces={streamingToolTraces}
               streamingParticipants={streamingParticipants}
             />
             <div ref={endRef} />
@@ -766,32 +769,17 @@ const ClawRoomChat = ({
                 </div>
               </div>
 
-              {mentionAutocomplete && mentionAutocomplete.options.length > 0 && (
-                <div className={styles.mentionMenu} role="listbox" aria-label="Mention suggestions">
-                  {mentionAutocomplete.options.map((option, index) => {
-                    const isActive = mentionAutocomplete.activeIndex === index
-                    return (
-                      <button
-                        key={option.token}
-                        type="button"
-                        className={`${styles.mentionItem} ${isActive ? styles.mentionItemActive : ''}`}
-                        onMouseDown={event => {
-                          event.preventDefault()
-                          selectMentionOption(option)
-                        }}
-                        onMouseEnter={() => {
-                          setMentionAutocomplete(previous => {
-                            if (!previous) return previous
-                            return { ...previous, activeIndex: index }
-                          })
-                        }}
-                      >
-                        <span className={styles.mentionToken}>{option.token}</span>
-                        <span className={styles.mentionDescription}>{option.description}</span>
-                      </button>
-                    )
-                  })}
-                </div>
+              {mentionAutocomplete && (
+                <ClawRoomMentionMenu
+                  mentionAutocomplete={mentionAutocomplete}
+                  onSelect={selectMentionOption}
+                  onActiveIndexChange={index => {
+                    setMentionAutocomplete(previous => {
+                      if (!previous) return previous
+                      return { ...previous, activeIndex: index }
+                    })
+                  }}
+                />
               )}
             </div>
           </div>

--- a/dashboard/frontend/src/components/ClawRoomMentionMenu.tsx
+++ b/dashboard/frontend/src/components/ClawRoomMentionMenu.tsx
@@ -1,0 +1,43 @@
+import styles from './ClawRoomChat.module.css'
+import type { MentionAutocompleteState, MentionOption } from './clawRoomChatSupport'
+
+interface ClawRoomMentionMenuProps {
+  mentionAutocomplete: MentionAutocompleteState
+  onSelect: (option: MentionOption) => void
+  onActiveIndexChange: (index: number) => void
+}
+
+const ClawRoomMentionMenu = ({
+  mentionAutocomplete,
+  onSelect,
+  onActiveIndexChange,
+}: ClawRoomMentionMenuProps) => {
+  if (mentionAutocomplete.options.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={styles.mentionMenu} role="listbox" aria-label="Mention suggestions">
+      {mentionAutocomplete.options.map((option, index) => {
+        const isActive = mentionAutocomplete.activeIndex === index
+        return (
+          <button
+            key={option.token}
+            type="button"
+            className={`${styles.mentionItem} ${isActive ? styles.mentionItemActive : ''}`}
+            onMouseDown={event => {
+              event.preventDefault()
+              onSelect(option)
+            }}
+            onMouseEnter={() => onActiveIndexChange(index)}
+          >
+            <span className={styles.mentionToken}>{option.token}</span>
+            <span className={styles.mentionDescription}>{option.description}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ClawRoomMentionMenu

--- a/dashboard/frontend/src/components/ClawRoomStreamingToolCards.tsx
+++ b/dashboard/frontend/src/components/ClawRoomStreamingToolCards.tsx
@@ -1,0 +1,56 @@
+import { useMemo, useState } from 'react'
+
+import { ToolCard } from './ChatComponentToolCards'
+import styles from './ClawRoomChat.module.css'
+import {
+  toPlaygroundToolCall,
+  toPlaygroundToolResult,
+  type ClawRoomToolTraceStep,
+} from './clawRoomToolTrace'
+
+interface ClawRoomStreamingToolCardsProps {
+  steps: ClawRoomToolTraceStep[]
+}
+
+const ClawRoomStreamingToolCards = ({ steps }: ClawRoomStreamingToolCardsProps) => {
+  const [expandedToolCards, setExpandedToolCards] = useState<Set<string>>(new Set())
+
+  const toolModels = useMemo(
+    () => steps.map(step => ({
+      step,
+      toolCall: toPlaygroundToolCall(step),
+      toolResult: toPlaygroundToolResult(step),
+    })),
+    [steps]
+  )
+
+  if (toolModels.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={styles.toolTraceList} data-testid="claw-room-tool-trace">
+      {toolModels.map(({ step, toolCall, toolResult }) => (
+        <ToolCard
+          key={step.id}
+          toolCall={toolCall}
+          toolResult={toolResult}
+          isExpanded={expandedToolCards.has(step.id)}
+          onToggle={() => {
+            setExpandedToolCards(previous => {
+              const next = new Set(previous)
+              if (next.has(step.id)) {
+                next.delete(step.id)
+              } else {
+                next.add(step.id)
+              }
+              return next
+            })
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default ClawRoomStreamingToolCards

--- a/dashboard/frontend/src/components/ClawRoomTranscript.tsx
+++ b/dashboard/frontend/src/components/ClawRoomTranscript.tsx
@@ -1,6 +1,11 @@
 import MarkdownRenderer from './MarkdownRenderer'
 import ClawRoomMessageMeta from './ClawRoomMessageMeta'
+import ClawRoomStreamingToolCards from './ClawRoomStreamingToolCards'
 import styles from './ClawRoomChat.module.css'
+import {
+  parseClawRoomToolTraceFromMessageMetadata,
+  type ClawRoomStreamingToolTraceEntry,
+} from './clawRoomToolTrace'
 import {
   formatMessageTime,
   type RoomMessage,
@@ -19,6 +24,7 @@ interface ClawRoomTranscriptProps {
   streamingMessages: Map<string, string>
   streamingParticipants: Map<string, StreamingParticipant>
   streamingEntries: Array<[string, string]>
+  streamingToolTraces: Map<string, ClawRoomStreamingToolTraceEntry>
   resolveSenderVisual: (message: RoomMessage) => SenderVisual
 }
 
@@ -28,6 +34,7 @@ const ClawRoomTranscript = ({
   streamingMessages,
   streamingParticipants,
   streamingEntries,
+  streamingToolTraces,
   resolveSenderVisual,
 }: ClawRoomTranscriptProps) => {
   if (!selectedRoomId) {
@@ -51,6 +58,9 @@ const ClawRoomTranscript = ({
           ? streamingContent
           : message.content
         const isStreaming = Boolean(streamingContent && streamingContent !== message.content)
+        const liveToolSteps = streamingToolTraces.get(message.id)?.steps || []
+        const metadataToolSteps = parseClawRoomToolTraceFromMessageMetadata(message.metadata)
+        const toolSteps = liveToolSteps.length > 0 ? liveToolSteps : metadataToolSteps
         return (
           <div
             key={message.id}
@@ -68,6 +78,7 @@ const ClawRoomTranscript = ({
                 roleLabel={senderVisual.roleLabel}
                 timestamp={formatMessageTime(message.createdAt)}
               />
+              {!isUser && toolSteps.length > 0 && <ClawRoomStreamingToolCards steps={toolSteps} />}
               <div
                 className={`${styles.messageBubble} ${isUser ? styles.messageBubbleUser : styles.messageBubbleAgent} ${isSystem ? styles.messageBubbleSystem : ''} ${isStreaming ? styles.messageBubbleStreaming : ''}`}
                 data-room-message-content
@@ -86,6 +97,7 @@ const ClawRoomTranscript = ({
           messageId,
           streamingParticipants
         )
+        const toolSteps = streamingToolTraces.get(messageId)?.steps || []
         return (
           <div
             key={`streaming-${messageId}`}
@@ -103,15 +115,18 @@ const ClawRoomTranscript = ({
                 roleLabel={isLeader ? 'LEADER' : 'WORKER'}
                 timestamp="..."
               />
-              <div
-                className={`${styles.messageBubble} ${styles.messageBubbleAgent} ${styles.messageBubbleStreaming}`}
-                data-room-message-content
-              >
-                <div className={styles.messageMarkdown}>
-                  <MarkdownRenderer content={content} />
-                  <span className={styles.streamingCursor} aria-hidden="true" />
+              <ClawRoomStreamingToolCards steps={toolSteps} />
+              {content.trim() ? (
+                <div
+                  className={`${styles.messageBubble} ${styles.messageBubbleAgent} ${styles.messageBubbleStreaming}`}
+                  data-room-message-content
+                >
+                  <div className={styles.messageMarkdown}>
+                    <MarkdownRenderer content={content} />
+                    <span className={styles.streamingCursor} aria-hidden="true" />
+                  </div>
                 </div>
-              </div>
+              ) : null}
             </div>
           </div>
         )

--- a/dashboard/frontend/src/components/clawRoomChatSupport.collaboration.test.ts
+++ b/dashboard/frontend/src/components/clawRoomChatSupport.collaboration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { ClawRoomStreamingToolTraceEntry } from './clawRoomToolTrace'
 import {
   applyCollaborationOutboundEvent,
   applyRoomStreamEvent,
@@ -67,5 +68,85 @@ describe('clawRoomChatSupport collaboration events', () => {
     )
 
     expect(state.persisted?.id).toBe('msg-1')
+  })
+
+  it('accumulates tool trace updates and clears streaming on message_updated', () => {
+    let toolTraces = new Map<string, ClawRoomStreamingToolTraceEntry>()
+    const state: { persisted: RoomMessage | null } = { persisted: null }
+
+    const handlers = {
+      upsertMessage: (message: RoomMessage) => {
+        state.persisted = message
+      },
+      setStreamingMessages: (update: (previous: Map<string, string>) => Map<string, string>) => update(new Map()),
+      setStreamingToolTraces: (
+        update: (
+          previous: Map<string, ClawRoomStreamingToolTraceEntry>
+        ) => Map<string, ClawRoomStreamingToolTraceEntry>
+      ) => {
+        toolTraces = update(toolTraces)
+      },
+    }
+
+    applyCollaborationOutboundEvent(
+      {
+        type: 'tool_trace_update',
+        messageId: 'stream-1',
+        payload: {
+          revision: 1,
+          steps: [{ id: 'call_1', name: 'exec', status: 'running' }],
+        },
+      },
+      handlers
+    )
+    applyCollaborationOutboundEvent(
+      {
+        type: 'tool_trace_update',
+        messageId: 'stream-1',
+        payload: {
+          revision: 2,
+          steps: [{ id: 'call_1', name: 'exec', status: 'completed', result: '/workspace' }],
+        },
+      },
+      handlers
+    )
+
+    expect(toolTraces.get('stream-1')?.steps).toHaveLength(1)
+    expect(toolTraces.get('stream-1')?.steps?.[0]?.status).toBe('completed')
+    expect(toolTraces.get('stream-1')?.revision).toBe(2)
+
+    applyCollaborationOutboundEvent(
+      {
+        type: 'tool_trace_update',
+        messageId: 'stream-1',
+        payload: {
+          revision: 1,
+          steps: [{ id: 'call_1', name: 'exec', status: 'running' }],
+        },
+      },
+      handlers
+    )
+
+    expect(toolTraces.get('stream-1')?.revision).toBe(2)
+    expect(toolTraces.get('stream-1')?.steps?.[0]?.status).toBe('completed')
+
+    applyCollaborationOutboundEvent(
+      {
+        type: 'message_updated',
+        message: {
+          ...baseMessage,
+          id: 'stream-1',
+          metadata: {
+            toolTrace: JSON.stringify([
+              { id: 'call_1', name: 'exec', status: 'completed', result: '/workspace' },
+            ]),
+          },
+        },
+      },
+      handlers
+    )
+
+    expect(toolTraces.has('stream-1')).toBe(false)
+    expect(state.persisted?.metadata?.toolTrace).toContain('call_1')
   })
 })

--- a/dashboard/frontend/src/components/clawRoomChatSupport.ts
+++ b/dashboard/frontend/src/components/clawRoomChatSupport.ts
@@ -1,3 +1,9 @@
+import {
+  applyClawRoomToolTraceRevision,
+  parseClawRoomToolTracePayload,
+  type ClawRoomStreamingToolTraceEntry,
+} from './clawRoomToolTrace'
+
 export interface TeamProfile {
   id: string
   name: string
@@ -63,6 +69,7 @@ export const ROOM_COLLABORATION_OUTBOUND_TYPES = {
   newMessage: 'new_message',
   messageChunk: 'message_chunk',
   messageUpdated: 'message_updated',
+  toolTraceUpdate: 'tool_trace_update',
   surfaceEvent: 'surface_event',
   error: 'error',
 } as const
@@ -96,6 +103,11 @@ export interface WSOutboundMessage {
 export interface CollaborationEventHandlers {
   upsertMessage: (message: RoomMessage) => void
   setStreamingMessages: (update: (previous: Map<string, string>) => Map<string, string>) => void
+  setStreamingToolTraces?: (
+    update: (
+      previous: Map<string, ClawRoomStreamingToolTraceEntry>
+    ) => Map<string, ClawRoomStreamingToolTraceEntry>
+  ) => void
   setStreamingParticipants?: (
     update: (previous: Map<string, StreamingParticipant>) => Map<string, StreamingParticipant>
   ) => void
@@ -106,35 +118,42 @@ export const applyCollaborationOutboundEvent = (
   payload: WSOutboundMessage,
   handlers: CollaborationEventHandlers
 ): void => {
+  const clearStreamingTextState = (messageId: string) => {
+    handlers.setStreamingMessages(previous => {
+      const next = new Map(previous)
+      next.delete(messageId)
+      return next
+    })
+    handlers.setStreamingParticipants?.(previous => {
+      const next = new Map(previous)
+      next.delete(messageId)
+      return next
+    })
+  }
+
+  const clearStreamingToolTrace = (messageId: string) => {
+    handlers.setStreamingToolTraces?.(previous => {
+      const next = new Map(previous)
+      next.delete(messageId)
+      return next
+    })
+  }
+
   if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.newMessage && payload.message) {
     handlers.upsertMessage(payload.message)
     if (payload.message.id) {
-      handlers.setStreamingMessages(previous => {
-        const next = new Map(previous)
-        next.delete(payload.message!.id)
-        return next
-      })
-      handlers.setStreamingParticipants?.(previous => {
-        const next = new Map(previous)
-        next.delete(payload.message!.id)
-        return next
-      })
+      clearStreamingToolTrace(payload.message.id)
+      clearStreamingTextState(payload.message.id)
     }
     return
   }
 
   if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.messageUpdated && payload.message) {
     handlers.upsertMessage(payload.message)
-    handlers.setStreamingMessages(previous => {
-      const next = new Map(previous)
-      next.delete(payload.message!.id)
-      return next
-    })
-    handlers.setStreamingParticipants?.(previous => {
-      const next = new Map(previous)
-      next.delete(payload.message!.id)
-      return next
-    })
+    if (payload.message.id) {
+      clearStreamingToolTrace(payload.message.id)
+      clearStreamingTextState(payload.message.id)
+    }
     return
   }
 
@@ -157,6 +176,23 @@ export const applyCollaborationOutboundEvent = (
         return next
       })
     }
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.toolTraceUpdate && payload.messageId) {
+    const parsed = parseClawRoomToolTracePayload(payload.payload)
+    if (!parsed?.steps?.length) {
+      return
+    }
+    handlers.setStreamingToolTraces?.(previous => {
+      const applied = applyClawRoomToolTraceRevision(previous.get(payload.messageId!), parsed)
+      if (!applied) {
+        return previous
+      }
+      const next = new Map(previous)
+      next.set(payload.messageId!, applied)
+      return next
+    })
     return
   }
 
@@ -191,6 +227,21 @@ export const applyRoomStreamEvent = (
 
   if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.newMessage && payload.message) {
     applyCollaborationOutboundEvent(payload, handlers)
+    return
+  }
+
+  if (payload.type === ROOM_COLLABORATION_OUTBOUND_TYPES.toolTraceUpdate) {
+    applyCollaborationOutboundEvent(
+      {
+        type: ROOM_COLLABORATION_OUTBOUND_TYPES.toolTraceUpdate,
+        messageId: payload.messageId,
+        payload: payload.payload,
+        participantType: payload.participantType,
+        participantId: payload.participantId,
+        sessionUser: payload.sessionUser,
+      },
+      handlers
+    )
     return
   }
 

--- a/dashboard/frontend/src/components/clawRoomStreamingUi.ts
+++ b/dashboard/frontend/src/components/clawRoomStreamingUi.ts
@@ -1,16 +1,41 @@
+import type { ClawRoomStreamingToolTraceEntry } from './clawRoomToolTrace'
 import type { RoomMessage, RoomTransportMode, StreamingParticipant } from './clawRoomChatSupport'
+
+const hasActiveStreamingText = (
+  messageId: string,
+  content: string,
+  messages: RoomMessage[]
+): boolean => {
+  if (!content.trim()) {
+    return false
+  }
+  const persisted = messages.find(message => message.id === messageId)
+  return !persisted || persisted.content !== content
+}
 
 export const buildStreamingEntries = (
   messages: RoomMessage[],
-  streamingMessages: Map<string, string>
+  streamingMessages: Map<string, string>,
+  streamingToolTraces: Map<string, ClawRoomStreamingToolTraceEntry> = new Map()
 ): Array<[string, string]> => {
-  return Array.from(streamingMessages.entries()).filter(([messageId, content]) => {
-    if (!content.trim()) {
-      return false
+  const messageIds = new Set<string>()
+
+  for (const [messageId, content] of streamingMessages.entries()) {
+    if (hasActiveStreamingText(messageId, content, messages)) {
+      messageIds.add(messageId)
     }
-    const persisted = messages.find(message => message.id === messageId)
-    return !persisted || persisted.content !== content
-  })
+  }
+
+  for (const [messageId, entry] of streamingToolTraces.entries()) {
+    if (entry.steps.length > 0 && !messages.some(message => message.id === messageId)) {
+      messageIds.add(messageId)
+    }
+  }
+
+  return Array.from(messageIds).map(messageId => [
+    messageId,
+    streamingMessages.get(messageId) || '',
+  ] as [string, string])
 }
 
 export const resolveTransportStatusLabel = (

--- a/dashboard/frontend/src/components/clawRoomToolTrace.test.ts
+++ b/dashboard/frontend/src/components/clawRoomToolTrace.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyClawRoomToolTraceRevision,
+  parseClawRoomToolTraceFromMessageMetadata,
+  parseClawRoomToolTracePayload,
+  toPlaygroundToolCall,
+} from './clawRoomToolTrace'
+
+describe('clawRoomToolTrace', () => {
+  it('parses tool trace payload steps', () => {
+    const parsed = parseClawRoomToolTracePayload({
+      revision: 2,
+      steps: [
+        { id: 'call_1', name: 'exec', arguments: '{"command":"pwd"}', status: 'running' },
+      ],
+    })
+
+    expect(parsed?.revision).toBe(2)
+    expect(parsed?.steps).toHaveLength(1)
+    expect(parsed?.steps?.[0]?.name).toBe('exec')
+  })
+
+  it('rejects stale tool trace revisions', () => {
+    const current = applyClawRoomToolTraceRevision(undefined, {
+      revision: +2,
+      steps: [{ id: 'call_1', name: 'exec', status: 'completed', result: '/workspace' }],
+    })
+    const stale = applyClawRoomToolTraceRevision(current ?? undefined, {
+      revision: 1,
+      steps: [{ id: 'call_1', name: 'exec', status: 'running' }],
+    })
+
+    expect(stale).toBeNull()
+    expect(current?.revision).toBe(2)
+    expect(current?.steps?.[0]?.status).toBe('completed')
+  })
+
+  it('maps trace step to playground tool call', () => {
+    const toolCall = toPlaygroundToolCall({
+      id: 'call_1',
+      name: 'exec',
+      arguments: '{"command":"pwd"}',
+      status: 'running',
+    })
+
+    expect(toolCall.function.name).toBe('exec')
+    expect(toolCall.status).toBe('running')
+  })
+
+  it('parses persisted tool trace metadata in call order', () => {
+    const steps = parseClawRoomToolTraceFromMessageMetadata({
+      toolTrace: JSON.stringify([
+        { id: 'call_1', name: 'exec', status: 'completed', result: '/workspace' },
+        { id: 'call_2', name: 'read', status: 'running' },
+      ]),
+    })
+
+    expect(steps).toHaveLength(2)
+    expect(steps[0]?.id).toBe('call_1')
+    expect(steps[1]?.id).toBe('call_2')
+  })
+})

--- a/dashboard/frontend/src/components/clawRoomToolTrace.ts
+++ b/dashboard/frontend/src/components/clawRoomToolTrace.ts
@@ -1,0 +1,140 @@
+import type { ToolCall, ToolResult } from '../tools'
+
+export interface ClawRoomToolTraceStep {
+  id: string
+  name: string
+  arguments?: string
+  status: 'pending' | 'running' | 'completed' | 'failed'
+  result?: string
+  error?: string
+}
+
+export interface ClawRoomToolTracePayload {
+  revision?: number
+  steps?: ClawRoomToolTraceStep[]
+}
+
+export type ClawRoomStreamingToolTraceEntry = {
+  revision?: number
+  steps: ClawRoomToolTraceStep[]
+}
+
+export const CLAW_ROOM_TOOL_TRACE_METADATA_KEY = 'toolTrace'
+
+const normalizeToolTraceStatus = (
+  status: string | undefined
+): ClawRoomToolTraceStep['status'] => {
+  if (status === 'completed' || status === 'failed' || status === 'pending') {
+    return status
+  }
+  return 'running'
+}
+
+const normalizeClawRoomToolTraceStep = (
+  value: unknown
+): ClawRoomToolTraceStep | null => {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const step = value as Record<string, unknown>
+  const id = typeof step.id === 'string' ? step.id : ''
+  if (!id) {
+    return null
+  }
+  return {
+    id,
+    name: typeof step.name === 'string' ? step.name : 'tool',
+    arguments: typeof step.arguments === 'string' ? step.arguments : undefined,
+    status: normalizeToolTraceStatus(typeof step.status === 'string' ? step.status : undefined),
+    result: typeof step.result === 'string' ? step.result : undefined,
+    error: typeof step.error === 'string' ? step.error : undefined,
+  }
+}
+
+const normalizeClawRoomToolTraceSteps = (values: unknown[]): ClawRoomToolTraceStep[] => {
+  return values.flatMap(value => {
+    const step = normalizeClawRoomToolTraceStep(value)
+    return step ? [step] : []
+  })
+}
+
+export const parseClawRoomToolTracePayload = (
+  payload: Record<string, unknown> | undefined
+): ClawRoomToolTracePayload | null => {
+  if (!payload || !Array.isArray(payload.steps)) {
+    return null
+  }
+
+  return {
+    revision: typeof payload.revision === 'number' ? payload.revision : undefined,
+    steps: normalizeClawRoomToolTraceSteps(payload.steps),
+  }
+}
+
+export const parseClawRoomToolTraceFromMessageMetadata = (
+  metadata?: Record<string, string>
+): ClawRoomToolTraceStep[] => {
+  const raw = metadata?.[CLAW_ROOM_TOOL_TRACE_METADATA_KEY]
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+    return normalizeClawRoomToolTraceSteps(parsed)
+  } catch {
+    return []
+  }
+}
+
+export const applyClawRoomToolTraceRevision = (
+  current: ClawRoomStreamingToolTraceEntry | undefined,
+  incoming: ClawRoomToolTracePayload
+): ClawRoomStreamingToolTraceEntry | null => {
+  if (!incoming.steps?.length) {
+    return null
+  }
+  if (
+    current?.revision != null &&
+    incoming.revision != null &&
+    incoming.revision < current.revision
+  ) {
+    return null
+  }
+  return {
+    revision: incoming.revision ?? current?.revision,
+    steps: incoming.steps,
+  }
+}
+
+export const toPlaygroundToolCall = (step: ClawRoomToolTraceStep): ToolCall => ({
+  id: step.id,
+  type: 'function',
+  function: {
+    name: step.name,
+    arguments: step.arguments || '{}',
+  },
+  status: step.status,
+})
+
+export const toPlaygroundToolResult = (step: ClawRoomToolTraceStep): ToolResult | undefined => {
+  if (step.status !== 'completed' && step.status !== 'failed') {
+    return undefined
+  }
+  if (step.status === 'failed') {
+    return {
+      callId: step.id,
+      name: step.name,
+      content: step.error || step.result || 'Tool failed',
+      error: step.error || 'Tool failed',
+    }
+  }
+  return {
+    callId: step.id,
+    name: step.name,
+    content: step.result ?? '',
+  }
+}

--- a/dashboard/frontend/src/components/useClawRoomTransport.ts
+++ b/dashboard/frontend/src/components/useClawRoomTransport.ts
@@ -2,12 +2,14 @@ import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 
 import {
   applyCollaborationOutboundEvent,
   applyRoomStreamEvent,
+  ROOM_COLLABORATION_OUTBOUND_TYPES,
   type RoomMessage,
   type RoomStreamEvent,
   type RoomTransportMode,
   type StreamingParticipant,
   type WSOutboundMessage,
 } from './clawRoomChatSupport'
+import type { ClawRoomStreamingToolTraceEntry } from './clawRoomToolTrace'
 
 interface UseClawRoomTransportParams {
   selectedRoomId: string
@@ -35,6 +37,9 @@ export const useClawRoomTransport = ({
   const [wsConnected, setWsConnected] = useState(false)
   const [transportMode, setTransportMode] = useState<RoomTransportMode>('connecting')
   const [streamingMessages, setStreamingMessages] = useState<Map<string, string>>(new Map())
+  const [streamingToolTraces, setStreamingToolTraces] = useState<
+    Map<string, ClawRoomStreamingToolTraceEntry>
+  >(new Map())
   const [streamingParticipants, setStreamingParticipants] = useState<Map<string, StreamingParticipant>>(
     new Map()
   )
@@ -49,6 +54,7 @@ export const useClawRoomTransport = ({
       setWsConnected(false)
       setTransportMode('connecting')
       setStreamingMessages(new Map())
+      setStreamingToolTraces(new Map())
       setStreamingParticipants(new Map())
       if (wsRef.current) {
         wsRef.current.close()
@@ -75,6 +81,7 @@ export const useClawRoomTransport = ({
     const collaborationHandlers = {
       upsertMessage,
       setStreamingMessages,
+      setStreamingToolTraces,
       setStreamingParticipants,
       setError: (message: string) => setError(message),
     }
@@ -143,6 +150,15 @@ export const useClawRoomTransport = ({
             participantId: payload.participantId,
             sessionUser: payload.sessionUser,
           })
+        } catch {
+          // ignore malformed stream events
+        }
+      }) as EventListener)
+
+      source.addEventListener(ROOM_COLLABORATION_OUTBOUND_TYPES.toolTraceUpdate, ((event: MessageEvent<string>) => {
+        try {
+          const payload = JSON.parse(event.data) as RoomStreamEvent
+          applyRoomStreamEvent(payload, collaborationHandlers)
         } catch {
           // ignore malformed stream events
         }
@@ -282,6 +298,7 @@ export const useClawRoomTransport = ({
 
   return {
     streamingMessages,
+    streamingToolTraces,
     streamingParticipants,
     transportMode,
     wsConnected,


### PR DESCRIPTION


<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes https://github.com/vllm-project/semantic-router/issues/2029

## Purpose

- What does this PR change?

Backend

`openclaw_session_tool_trace.go` — Tails the OpenClaw session jsonl via docker exec, collects tool calls for the current reply only, pushes them over WS/SSE, and persists ordered steps in metadata.toolTrace.
`openclaw_session_tool_trace_test.go` — Unit tests for session index resolution, tool-line parsing, baseline offset, and metadata encoding order.
`openclaw_room_automation.go` — Captures a baseline offset and starts the tool-trace watcher when a worker auto-reply begins, then attaches the trace to the message when the reply finishes.
`openclaw_websocket.go` — Defines the tool_trace_update collaboration event type for room WebSocket delivery.

Frontend components / logic

`clawRoomToolTrace.ts` — Defines tool-step types and parses WS payloads and message metadata into Playground ToolCall/ToolResult models.
`clawRoomToolTrace.test.ts` — Unit tests for payload/metadata parsing and Playground mapping.
`ClawRoomStreamingToolCards.tsx` — Reuses Playground ToolCard to render streaming and persisted tool cards in ClawRoom.
`clawRoomChatSupport.ts` — Handles tool_trace_update and message_updated, maintains streaming tool traces, and clears streaming state when a message completes.
`clawRoomChatSupport.collaboration.test.ts` — Unit tests for chunk accumulation, tool-trace updates, and streaming cleanup on message_updated.
`clawRoomStreamingUi.ts` — Extends buildStreamingEntries so a streaming row appears even when only tool traces exist and no text has arrived yet.
`useClawRoomTransport.ts` — Subscribes to tool_trace_update over WS/SSE and holds streamingToolTraces state.
`ClawRoomTranscript.tsx` — Renders tool cards on worker messages from streamingToolTraces while streaming and from metadata after completion.
`ClawRoomChat.tsx` — Wires transport tool-trace state into the transcript and buildStreamingEntries.
ClawRoomChat.module.css — Styles the .toolTraceList layout and spacing for tool cards.

E2E

`claw-room-collaboration.spec.ts` — Mocks WS tool_trace_update and message_updated events and asserts tool cards stay visible after the reply completes.

- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
