### PR TITLE
[Router] fix: streaming responses never hit the Redis semantic cache

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_res_cache.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache.go
@@ -248,39 +248,10 @@ func (r *OpenAIRouter) cacheReconstructedStreamingResponse(
 		return nil
 	}
 
-	if cacheQueryForContext(ctx) == "" || ctx.RequestModel == "" {
-		return r.updateStreamingCacheEntry(ctx.RequestID, reconstructedJSON, ttlSeconds)
-	}
-
-	if err := r.addStreamingCacheEntry(ctx, reconstructedJSON, ttlSeconds); err != nil {
-		logging.Errorf("Error caching streaming response with AddEntry: %v", err)
-		return r.updateStreamingCacheEntry(ctx.RequestID, reconstructedJSON, ttlSeconds)
-	}
-
-	logging.Infof("Successfully cached streaming response (via AddEntry) for request ID: %s", ctx.RequestID)
-	return nil
-}
-
-func (r *OpenAIRouter) addStreamingCacheEntry(
-	ctx *RequestContext,
-	reconstructedJSON []byte,
-	ttlSeconds int,
-) error {
-	return r.Cache.AddEntry(
-		ctx.RequestID,
-		ctx.RequestModel,
-		cacheQueryForContext(ctx),
-		streamingCacheRequestBody(ctx),
-		reconstructedJSON,
-		ttlSeconds,
-	)
-}
-
-func streamingCacheRequestBody(ctx *RequestContext) []byte {
-	if ctx.OriginalRequestBody == nil {
-		return []byte("{}")
-	}
-	return ctx.OriginalRequestBody
+	// Must finalize in place (by request_id) like the non-streaming path.
+	// AddEntry would mint a new key and orphan the empty pending entry,
+	// which then shadows KNN lookups and causes cache misses (issue #2030).
+	return r.updateStreamingCacheEntry(ctx.RequestID, reconstructedJSON, ttlSeconds)
 }
 
 func (r *OpenAIRouter) updateStreamingCacheEntry(

--- a/src/semantic-router/pkg/extproc/processor_res_cache_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_test.go
@@ -1,7 +1,6 @@
 package extproc
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/openai/openai-go"
@@ -16,13 +15,14 @@ import (
 // =====================================================================
 
 type mockStreamingCache struct {
-	addEntryCalled      bool
-	addPendingCalled    bool
-	findSimilarCalled   bool
-	updateCalled        bool
-	addEntryRequestBody []byte
-	addEntryErr         error
-	updateErr           error
+	addEntryCalled     bool
+	addPendingCalled   bool
+	findSimilarCalled  bool
+	updateCalled       bool
+	updateRequestID    string
+	updateResponseBody []byte
+	addEntryErr        error
+	updateErr          error
 }
 
 func (m *mockStreamingCache) IsEnabled() bool { return true }
@@ -40,8 +40,10 @@ func (m *mockStreamingCache) AddPendingRequest(
 	return nil
 }
 
-func (m *mockStreamingCache) UpdateWithResponse(_ string, _ []byte, _ int) error {
+func (m *mockStreamingCache) UpdateWithResponse(requestID string, responseBody []byte, _ int) error {
 	m.updateCalled = true
+	m.updateRequestID = requestID
+	m.updateResponseBody = append([]byte(nil), responseBody...)
 	return m.updateErr
 }
 
@@ -49,12 +51,11 @@ func (m *mockStreamingCache) AddEntry(
 	_ string,
 	_ string,
 	_ string,
-	requestBody []byte,
+	_ []byte,
 	_ []byte,
 	_ int,
 ) error {
 	m.addEntryCalled = true
-	m.addEntryRequestBody = append([]byte(nil), requestBody...)
 	return m.addEntryErr
 }
 
@@ -204,7 +205,9 @@ func TestUpdateResponseCache_SkipsWhenNoDecisionSelectedButDecisionsConfigured(t
 // STREAMING: cacheReconstructedStreamingResponse
 // =====================================================================
 
-func TestCacheReconstructedStreamingResponseUsesAddEntry(t *testing.T) {
+// Regression for #2030: streaming finalize must update the pending entry in
+// place (by request_id), not mint a new key via AddEntry that orphans it.
+func TestCacheReconstructedStreamingResponseUpdatesInPlace(t *testing.T) {
 	mockCache := &mockStreamingCache{}
 	router := &OpenAIRouter{Cache: mockCache}
 	ctx := &RequestContext{
@@ -215,26 +218,28 @@ func TestCacheReconstructedStreamingResponseUsesAddEntry(t *testing.T) {
 
 	err := router.cacheReconstructedStreamingResponse(ctx, []byte(`{"ok":true}`))
 	assert.NoError(t, err)
-	assert.True(t, mockCache.addEntryCalled)
-	assert.False(t, mockCache.updateCalled)
-	assert.JSONEq(t, `{}`, string(mockCache.addEntryRequestBody))
+	assert.True(t, mockCache.updateCalled, "streaming finalize must update the pending entry in place")
+	assert.False(t, mockCache.addEntryCalled, "streaming finalize must not mint a new cache key via AddEntry")
+	assert.Equal(t, "req-1", mockCache.updateRequestID)
+	assert.JSONEq(t, `{"ok":true}`, string(mockCache.updateResponseBody))
 }
 
-func TestCacheReconstructedStreamingResponseFallsBackToUpdate(t *testing.T) {
-	mockCache := &mockStreamingCache{addEntryErr: errors.New("boom")}
+// Regression for #2030: ctx.RequestModel is overwritten from the client alias
+// to the resolved model by finalize time, so finalize must key off request_id.
+func TestCacheReconstructedStreamingResponseUpdatesAfterModelResolved(t *testing.T) {
+	mockCache := &mockStreamingCache{}
 	router := &OpenAIRouter{Cache: mockCache}
 	ctx := &RequestContext{
-		RequestID:           "req-1",
-		RequestModel:        "test-model",
-		RequestQuery:        "hello",
-		OriginalRequestBody: []byte(`{"messages":[]}`),
+		RequestID:    "req-1",
+		RequestModel: "doubao-1-5-lite-32k-250115",
+		RequestQuery: "who discovered gravity?",
 	}
 
 	err := router.cacheReconstructedStreamingResponse(ctx, []byte(`{"ok":true}`))
 	assert.NoError(t, err)
-	assert.True(t, mockCache.addEntryCalled)
 	assert.True(t, mockCache.updateCalled)
-	assert.JSONEq(t, `{"messages":[]}`, string(mockCache.addEntryRequestBody))
+	assert.False(t, mockCache.addEntryCalled)
+	assert.Equal(t, "req-1", mockCache.updateRequestID)
 }
 
 func TestCacheReconstructedStreamingResponseUpdatesWithoutQueryMetadata(t *testing.T) {
@@ -352,7 +357,8 @@ func TestCacheReconstructedStreamingResponse_StoresWhenDecisionCacheEnabled(t *t
 
 	err := router.cacheReconstructedStreamingResponse(ctx, []byte(`{"ok":true}`))
 	assert.NoError(t, err)
-	assert.True(t, mockCache.addEntryCalled, "should call AddEntry when decision has semantic-cache enabled")
+	assert.True(t, mockCache.updateCalled, "should finalize the pending entry when decision has semantic-cache enabled")
+	assert.False(t, mockCache.addEntryCalled, "should not mint a new cache key via AddEntry")
 }
 
 // =====================================================================
@@ -430,7 +436,7 @@ func TestCacheStreamingAllowedForGenericRequest(t *testing.T) {
 
 	err := router.cacheStreamingResponse(ctx)
 	assert.NoError(t, err)
-	assert.True(t, mockCache.addEntryCalled || mockCache.updateCalled,
+	assert.True(t, mockCache.updateCalled,
 		"cache write must proceed for generic requests without personalized context")
 }
 


### PR DESCRIPTION
Closes #2030

## Purpose

- **What does this PR change?** Streaming responses now finalize the semantic cache in place via `UpdateWithResponse` (keyed by `request_id`), instead of via `AddEntry`.
- **Why is this change needed?** On the Redis backend, streaming requests effectively never hit the cache (measured: non-streaming 10/10 hits, streaming 0/10). `AddEntry` mints a new key (`md5(model + query + timestamp)`), so the empty-`response_body` pending entry written at intake (under the client *alias* model) is never filled or deleted. That orphan then shadows KNN lookups: `extractSearchResult` treats an empty best match as a hard miss with **no fallthrough**, so repeat streaming queries miss even when a valid populated entry exists for the same query. The non-streaming path already finalizes in place via `UpdateWithResponse`, which is why it hits reliably — this change brings streaming to parity. KNN lookup does not filter by model, so storing under the alias model is harmless.
- **Which module(s) does this affect?** `Router`

## Test Plan

- `go test ./pkg/extproc/...` — full package, including the cache/streaming suites.
- Added two regression tests in `processor_res_cache_test.go`:
  - `TestCacheReconstructedStreamingResponseUpdatesInPlace` — asserts streaming finalize calls `UpdateWithResponse` (not `AddEntry`).
  - `TestCacheReconstructedStreamingResponseUpdatesAfterModelResolved` — covers the alias→resolved model overwrite (`ctx.RequestModel` is the resolved model by response phase), proving finalize must key off `request_id`.
- Updated the three existing tests that encoded the old `AddEntry` behavior.
- `make agent-lint` (go fmt, go lint, structural lint, supply-chain scan).

## Test Result

- Full `pkg/extproc` package tests pass; `pkg/cache` tests pass; `go vet` clean; `make agent-lint` green.
- **Follow-up / gap:** The literal Redis end-to-end repro from the issue (10/10 streaming hits against a live Redis + embedding models) was not run locally due to the cgo binding toolchain; the fix is pure Go logic fully covered by unit tests and CI builds the bindings. A reviewer can confirm with the issue's repro steps (flush `vsr:cache:*`, send the same prompt twice with `"stream": true`, expect `cache_hit`).

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>