### PR TITLE
[WIP][Router]feat: MCP config server foundation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1531,6 +1531,12 @@ global:
               unit: hour
     startup_status:
       store_backend: file
+    mcp_config:
+      enabled: false
+      loopback_only: false
+      allow_destructive: false
+      allowed_tools: []
+      rate_limit_per_minute: 60
     router_replay:
       enabled: true
       store_backend: postgres

--- a/src/semantic-router/pkg/apiserver/mcp_config_route.go
+++ b/src/semantic-router/pkg/apiserver/mcp_config_route.go
@@ -1,0 +1,57 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/mcpconfig"
+)
+
+const internalMCPConfigPath = mcpconfig.InternalHTTPPath
+
+func (s *ClassificationAPIServer) registerMCPConfigRoutes(mux *http.ServeMux) {
+	handler := s.buildMCPConfigHandler()
+	if handler == nil {
+		return
+	}
+	mux.Handle(internalMCPConfigPath, handler)
+}
+
+func (s *ClassificationAPIServer) buildMCPConfigHandler() http.Handler {
+	if s == nil || s.configPath == "" {
+		return nil
+	}
+
+	cfg := s.currentMCPConfig()
+	if !cfg.Enabled {
+		return nil
+	}
+
+	server, err := mcpconfig.NewServer(s.configPath, cfg)
+	if err != nil {
+		return nil
+	}
+
+	handler := server.HTTPHandler()
+	if cfg.LoopbackOnly {
+		return mcpconfig.LoopbackOnly(handler)
+	}
+	return handler
+}
+
+func (s *ClassificationAPIServer) currentMCPConfig() config.MCPConfigServerConfig {
+	if s == nil {
+		return config.MCPConfigServerConfig{}
+	}
+	if s.config != nil {
+		return s.config.MCPConfig.WithDefaults()
+	}
+	if s.runtimeConfig != nil {
+		if cfg := s.runtimeConfig.Current(); cfg != nil {
+			return cfg.MCPConfig.WithDefaults()
+		}
+	}
+	return config.MCPConfigServerConfig{}
+}

--- a/src/semantic-router/pkg/apiserver/mcp_config_route_test.go
+++ b/src/semantic-router/pkg/apiserver/mcp_config_route_test.go
@@ -1,0 +1,66 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/mcpconfig"
+)
+
+func TestMCPConfigRouteDisabledByDefault(t *testing.T) {
+	apiServer := &ClassificationAPIServer{
+		configPath: t.TempDir() + "/config.yaml",
+		config: &config.RouterConfig{
+			MCPConfig: config.MCPConfigServerConfig{Enabled: false},
+		},
+	}
+	if handler := apiServer.buildMCPConfigHandler(); handler != nil {
+		t.Fatal("expected nil handler when MCP config server is disabled")
+	}
+}
+
+func TestMCPConfigRouteLoopbackOnlyBlocksNonLoopback(t *testing.T) {
+	apiServer := &ClassificationAPIServer{
+		configPath: t.TempDir() + "/config.yaml",
+		config: &config.RouterConfig{
+			MCPConfig: config.MCPConfigServerConfig{
+				Enabled:      true,
+				LoopbackOnly: true,
+			},
+		},
+	}
+	handler := apiServer.buildMCPConfigHandler()
+	if handler == nil {
+		t.Fatal("expected handler when MCP config server is enabled")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, internalMCPConfigPath, nil)
+	req.RemoteAddr = "203.0.113.10:12345"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestMCPConfigRouteLoopbackOnlyAllowsLoopback(t *testing.T) {
+	// Do not hit the Streamable MCP handler with a plain GET; it waits for MCP protocol traffic.
+	handler := mcpconfig.LoopbackOnly(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, internalMCPConfigPath, nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code == http.StatusForbidden {
+		t.Fatalf("loopback request should not be forbidden, got %d", rr.Code)
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+}

--- a/src/semantic-router/pkg/apiserver/route_api_doc.go
+++ b/src/semantic-router/pkg/apiserver/route_api_doc.go
@@ -46,6 +46,7 @@ func (s *ClassificationAPIServer) handleAPIOverview(w http.ResponseWriter, _ *ht
 			"models_info":   "/info/models",
 			"health":        "/health",
 			"ready":         "/ready",
+			"mcp_config":    internalMCPConfigPath,
 		},
 	}
 

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -250,6 +250,7 @@ func (s *ClassificationAPIServer) setupRoutes() *http.ServeMux {
 	for _, route := range apiRoutes() {
 		mux.HandleFunc(route.pattern(), route.bind(s))
 	}
+	s.registerMCPConfigRoutes(mux)
 	return mux
 }
 

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -155,6 +155,7 @@ func CanonicalGlobalFromRouterConfig(cfg *RouterConfig) *CanonicalGlobal {
 			RateLimit:     cfg.RateLimit,
 			RouterReplay:  cfg.RouterReplay,
 			StartupStatus: cfg.StartupStatus,
+			MCPConfig:     cfg.MCPConfig,
 		},
 		Stores: CanonicalStoreGlobal{
 			SemanticCache: cfg.SemanticCache,

--- a/src/semantic-router/pkg/config/canonical_global.go
+++ b/src/semantic-router/pkg/config/canonical_global.go
@@ -38,13 +38,14 @@ type CanonicalStreamedBody struct {
 
 // CanonicalServiceGlobal groups shared runtime services exposed by the router.
 type CanonicalServiceGlobal struct {
-	API           APIConfig           `yaml:"api"`
-	ResponseAPI   ResponseAPIConfig   `yaml:"response_api"`
-	Observability ObservabilityConfig `yaml:"observability"`
-	Authz         AuthzConfig         `yaml:"authz"`
-	RateLimit     RateLimitConfig     `yaml:"ratelimit"`
-	RouterReplay  RouterReplayConfig  `yaml:"router_replay"`
-	StartupStatus StartupStatusConfig `yaml:"startup_status"`
+	API           APIConfig             `yaml:"api"`
+	ResponseAPI   ResponseAPIConfig     `yaml:"response_api"`
+	Observability ObservabilityConfig   `yaml:"observability"`
+	Authz         AuthzConfig           `yaml:"authz"`
+	RateLimit     RateLimitConfig       `yaml:"ratelimit"`
+	RouterReplay  RouterReplayConfig    `yaml:"router_replay"`
+	StartupStatus StartupStatusConfig   `yaml:"startup_status"`
+	MCPConfig     MCPConfigServerConfig `yaml:"mcp_config,omitempty"`
 }
 
 // CanonicalStoreGlobal groups storage-backed runtime facilities.
@@ -223,6 +224,7 @@ func applyCanonicalGlobal(cfg *RouterConfig, global *CanonicalGlobal) error {
 	cfg.RateLimit = global.Services.RateLimit
 	cfg.RouterReplay = global.Services.RouterReplay
 	cfg.StartupStatus = global.Services.StartupStatus
+	cfg.MCPConfig = global.Services.MCPConfig.WithDefaults()
 
 	cfg.SemanticCache = global.Stores.SemanticCache
 	cfg.Memory = global.Stores.Memory

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -65,12 +65,13 @@ type RouterConfig struct {
 	InlineModels     `yaml:",inline"`
 	ExternalModels   []ExternalModelConfig `yaml:"external_models,omitempty"`
 	SemanticCache    `yaml:"semantic_cache"`
-	Memory           MemoryConfig        `yaml:"memory"`
-	VectorStore      *VectorStoreConfig  `yaml:"vector_store,omitempty"`
-	ResponseAPI      ResponseAPIConfig   `yaml:"response_api"`
-	RouterReplay     RouterReplayConfig  `yaml:"router_replay"`
-	StartupStatus    StartupStatusConfig `yaml:"startup_status"`
-	Looper           LooperConfig        `yaml:"looper,omitempty"`
+	Memory           MemoryConfig          `yaml:"memory"`
+	VectorStore      *VectorStoreConfig    `yaml:"vector_store,omitempty"`
+	ResponseAPI      ResponseAPIConfig     `yaml:"response_api"`
+	RouterReplay     RouterReplayConfig    `yaml:"router_replay"`
+	StartupStatus    StartupStatusConfig   `yaml:"startup_status"`
+	MCPConfig        MCPConfigServerConfig `yaml:"mcp_config,omitempty"`
+	Looper           LooperConfig          `yaml:"looper,omitempty"`
 	LLMObservability `yaml:",inline"`
 	APIServer        `yaml:",inline"`
 	RouterOptions    `yaml:",inline"`

--- a/src/semantic-router/pkg/config/mcp_config_server.go
+++ b/src/semantic-router/pkg/config/mcp_config_server.go
@@ -1,0 +1,22 @@
+package config
+
+// MCPConfigServerConfig controls the in-router MCP config synthesis server.
+type MCPConfigServerConfig struct {
+	Enabled            bool     `yaml:"enabled,omitempty"`
+	LoopbackOnly       bool     `yaml:"loopback_only,omitempty"`
+	AllowDestructive   bool     `yaml:"allow_destructive,omitempty"`
+	AllowedTools       []string `yaml:"allowed_tools,omitempty"`
+	RateLimitPerMinute int      `yaml:"rate_limit_per_minute,omitempty"`
+}
+
+// WithDefaults returns cfg with router-owned defaults applied.
+func (c MCPConfigServerConfig) WithDefaults() MCPConfigServerConfig {
+	out := c
+	if !out.Enabled {
+		return out
+	}
+	if out.RateLimitPerMinute <= 0 {
+		out.RateLimitPerMinute = 60
+	}
+	return out
+}

--- a/src/semantic-router/pkg/config/reference_config_global_test.go
+++ b/src/semantic-router/pkg/config/reference_config_global_test.go
@@ -40,6 +40,11 @@ func assertReferenceConfigServiceGlobalCoverage(t testingT, services map[string]
 	assertReferenceConfigAuthzCoverage(t, mustMapAt(t, services, "authz"))
 	assertReferenceConfigRateLimitCoverage(t, mustMapAt(t, services, "ratelimit"))
 	assertReferenceConfigRouterReplayCoverage(t, mustMapAt(t, services, "router_replay"))
+	assertReferenceConfigMCPConfigCoverage(t, mustMapAt(t, services, "mcp_config"))
+}
+
+func assertReferenceConfigMCPConfigCoverage(t testingT, mcpConfig map[string]interface{}) {
+	assertMapCoversStructFields(t, mcpConfig, reflect.TypeOf(MCPConfigServerConfig{}), "global.services.mcp_config")
 }
 
 func assertReferenceConfigAPIServiceCoverage(t testingT, api map[string]interface{}) {

--- a/src/semantic-router/pkg/mcpconfig/audit.go
+++ b/src/semantic-router/pkg/mcpconfig/audit.go
@@ -1,0 +1,73 @@
+package mcpconfig
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// AuditEntry records one MCP config tool invocation.
+type AuditEntry struct {
+	Timestamp     string `json:"timestamp"`
+	Actor         string `json:"actor"`
+	Tool          string `json:"tool"`
+	ArgsHash      string `json:"args_hash"`
+	Success       bool   `json:"success"`
+	Error         string `json:"error,omitempty"`
+	ConfigVersion string `json:"config_version,omitempty"`
+}
+
+// AuditLog appends durable audit records for MCP config tool calls.
+type AuditLog struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewAuditLog(path string) (*AuditLog, error) {
+	if path == "" {
+		return &AuditLog{}, nil
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create audit log directory: %w", err)
+	}
+	return &AuditLog{path: path}, nil
+}
+
+func (a *AuditLog) Record(entry AuditEntry) error {
+	if a == nil || a.path == "" {
+		return nil
+	}
+	if entry.Timestamp == "" {
+		entry.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	payload, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	f, err := os.OpenFile(a.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.Write(append(payload, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func hashArgs(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:8])
+}

--- a/src/semantic-router/pkg/mcpconfig/loopback.go
+++ b/src/semantic-router/pkg/mcpconfig/loopback.go
@@ -1,0 +1,37 @@
+package mcpconfig
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// LoopbackOnly restricts requests to loopback clients.
+func LoopbackOnly(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isLoopbackRequest(r.RemoteAddr) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isLoopbackRequest(remoteAddr string) bool {
+	host := strings.TrimSpace(remoteAddr)
+	if host == "" {
+		return false
+	}
+
+	parsedHost, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		host = parsedHost
+	}
+
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/src/semantic-router/pkg/mcpconfig/loopback_test.go
+++ b/src/semantic-router/pkg/mcpconfig/loopback_test.go
@@ -1,0 +1,39 @@
+package mcpconfig
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoopbackOnly(t *testing.T) {
+	t.Parallel()
+
+	handler := LoopbackOnly(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	t.Run("allows loopback", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, InternalHTTPPath, nil)
+		req.RemoteAddr = "127.0.0.1:12345"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("blocks non-loopback", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, InternalHTTPPath, nil)
+		req.RemoteAddr = "203.0.113.10:12345"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+		}
+	})
+}

--- a/src/semantic-router/pkg/mcpconfig/mutator.go
+++ b/src/semantic-router/pkg/mcpconfig/mutator.go
@@ -1,0 +1,369 @@
+package mcpconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+const maxBackups = 10
+
+var configVersionPattern = regexp.MustCompile(`^[0-9]{8}-[0-9]{6}$`)
+
+var deployMu sync.Mutex
+
+// Mutator reads and writes router config through the same validation path as the apiserver.
+type Mutator struct {
+	configPath string
+}
+
+func NewMutator(configPath string) *Mutator {
+	return &Mutator{configPath: configPath}
+}
+
+func (m *Mutator) paths() persistencePaths {
+	return resolvePersistencePaths(m.configPath)
+}
+
+// GetDocument returns the current router config document.
+func (m *Mutator) GetDocument() (map[string]any, error) {
+	if m.configPath == "" {
+		return nil, fmt.Errorf("router config path is not set")
+	}
+	paths := m.paths()
+	data, err := os.ReadFile(paths.sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	return decodeYAMLDocument(data)
+}
+
+// ValidateDocument validates a config document without persisting it.
+func (m *Mutator) ValidateDocument(doc map[string]any, mode MutationMode) (map[string]any, error) {
+	if m.configPath == "" {
+		return nil, fmt.Errorf("router config path is not set")
+	}
+	paths := m.paths()
+	_, yamlBytes, err := m.prepareMutationPayload(doc, paths.sourcePath, mode)
+	if err != nil {
+		return nil, err
+	}
+	validated, err := decodeYAMLDocument(yamlBytes)
+	if err != nil {
+		return nil, err
+	}
+	return validated, nil
+}
+
+// DiffDocument merges patch into the current config and returns before/after views.
+func (m *Mutator) DiffDocument(patch map[string]any, mode MutationMode) (map[string]any, error) {
+	if m.configPath == "" {
+		return nil, fmt.Errorf("router config path is not set")
+	}
+	paths := m.paths()
+	existingDoc, _, err := readConfigDocument(paths.sourcePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read existing config: %w", err)
+	}
+
+	nextDoc := patch
+	if mode == MutationMerge {
+		nextDoc = mergeConfigDocuments(existingDoc, patch)
+	}
+
+	mergedYAML, err := normalizeRouterConfigDocument(nextDoc)
+	if err != nil {
+		return map[string]any{
+			"valid":            false,
+			"validation_error": err.Error(),
+			"base":             existingDoc,
+			"patch":            patch,
+			"merged":           nextDoc,
+		}, nil
+	}
+
+	mergedDoc, err := decodeYAMLDocument(mergedYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"valid":  true,
+		"base":   existingDoc,
+		"patch":  patch,
+		"merged": mergedDoc,
+	}, nil
+}
+
+// ApplyPatch persists a config mutation using merge or replace semantics.
+func (m *Mutator) ApplyPatch(patch map[string]any, mode MutationMode, dsl string) (*ApplyResult, error) {
+	if m.configPath == "" {
+		return nil, fmt.Errorf("router config path is not set")
+	}
+	if !deployMu.TryLock() {
+		return nil, fmt.Errorf("another config update operation is in progress")
+	}
+	defer deployMu.Unlock()
+
+	paths := m.paths()
+	yamlBytes, existingData, err := m.prepareMutationPayload(patch, paths.sourcePath, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	version, backupDir := recordConfigArtifacts(paths.sourcePath, existingData, dsl)
+	if err := writeConfigFiles(paths, yamlBytes); err != nil {
+		return nil, err
+	}
+	cleanupBackups(backupDir)
+
+	logging.Infof(
+		"Router config %s via MCP: version=%s, size=%d bytes, source=%s",
+		mode,
+		version,
+		len(yamlBytes),
+		paths.sourcePath,
+	)
+
+	return &ApplyResult{
+		Status:  "success",
+		Version: version,
+		Message: mutationMessage(mode),
+	}, nil
+}
+
+// ApplyResult is returned after a successful config write.
+type ApplyResult struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+	Message string `json:"message,omitempty"`
+}
+
+type MutationMode string
+
+const (
+	MutationMerge   MutationMode = "merge"
+	MutationReplace MutationMode = "replace"
+)
+
+func (m *Mutator) prepareMutationPayload(
+	patchDoc map[string]any,
+	sourceConfigPath string,
+	mode MutationMode,
+) ([]byte, []byte, error) {
+	existingDoc, existingData, err := readConfigDocument(sourceConfigPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, fmt.Errorf("read existing config: %w", err)
+	}
+
+	nextDoc := patchDoc
+	if mode == MutationMerge {
+		nextDoc = mergeConfigDocuments(existingDoc, patchDoc)
+	}
+
+	yamlBytes, err := normalizeRouterConfigDocument(nextDoc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return yamlBytes, existingData, nil
+}
+
+func normalizeRouterConfigDocument(doc map[string]any) ([]byte, error) {
+	rawYAML, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("encode router config: %w", err)
+	}
+
+	parsedCfg, err := config.ParseYAMLBytes(rawYAML)
+	if err != nil {
+		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	canonicalCfg := config.CanonicalConfigFromRouterConfig(parsedCfg)
+	yamlBytes, err := yaml.Marshal(canonicalCfg)
+	if err != nil {
+		return nil, fmt.Errorf("normalize router config: %w", err)
+	}
+	return yamlBytes, nil
+}
+
+func readConfigDocument(path string) (map[string]any, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil, err
+		}
+		return nil, nil, err
+	}
+	doc, err := decodeYAMLDocument(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return doc, data, nil
+}
+
+func decodeYAMLDocument(data []byte) (map[string]any, error) {
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("decode yaml: %w", err)
+	}
+	if doc == nil {
+		return map[string]any{}, nil
+	}
+	return doc, nil
+}
+
+func mergeConfigDocuments(base map[string]any, patch map[string]any) map[string]any {
+	merged, ok := mergeYAMLValue(base, patch).(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return merged
+}
+
+func mergeYAMLValue(base any, patch any) any {
+	if patch == nil {
+		return nil
+	}
+
+	patchMap, ok := patch.(map[string]any)
+	if !ok {
+		return cloneYAMLValue(patch)
+	}
+
+	merged := map[string]any{}
+	if baseMap, ok := base.(map[string]any); ok {
+		for key, value := range baseMap {
+			merged[key] = cloneYAMLValue(value)
+		}
+	}
+
+	for key, value := range patchMap {
+		if value == nil {
+			delete(merged, key)
+			continue
+		}
+		merged[key] = mergeYAMLValue(merged[key], value)
+	}
+	return merged
+}
+
+func cloneYAMLValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			cloned[key] = cloneYAMLValue(nested)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, nested := range typed {
+			cloned[i] = cloneYAMLValue(nested)
+		}
+		return cloned
+	default:
+		return typed
+	}
+}
+
+func recordConfigArtifacts(sourceConfigPath string, existingData []byte, dsl string) (string, string) {
+	configDir := filepath.Dir(sourceConfigPath)
+	backupDir := filepath.Join(configDir, ".vllm-sr", "config-backups")
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		logging.Warnf("Failed to create backup directory: %v", err)
+	}
+
+	version := time.Now().Format("20060102-150405")
+	if len(existingData) > 0 {
+		backupFile := filepath.Join(backupDir, fmt.Sprintf("config.%s.yaml", version))
+		if err := os.WriteFile(backupFile, existingData, 0o644); err != nil {
+			logging.Warnf("Failed to create backup: %v", err)
+		}
+	}
+
+	if strings.TrimSpace(dsl) != "" {
+		dslDir := filepath.Join(configDir, ".vllm-sr")
+		dslFile := filepath.Join(dslDir, "config.dsl")
+		if err := os.WriteFile(dslFile, []byte(dsl), 0o644); err != nil {
+			logging.Warnf("Failed to archive DSL source: %v", err)
+		}
+	}
+
+	return version, backupDir
+}
+
+func writeConfigFiles(paths persistencePaths, yamlBytes []byte) error {
+	if err := writeConfigAtomically(paths.sourcePath, yamlBytes); err != nil {
+		return fmt.Errorf("write source config: %w", err)
+	}
+	if !paths.usesRuntimeOverride() {
+		return nil
+	}
+	return fmt.Errorf("runtime config sync is not available from MCP config tools; write source config at %s", paths.sourcePath)
+}
+
+func writeConfigAtomically(configPath string, yamlBytes []byte) error {
+	tmpConfigFile := configPath + ".tmp"
+	if err := os.WriteFile(tmpConfigFile, yamlBytes, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpConfigFile, configPath); err != nil {
+		if writeErr := os.WriteFile(configPath, yamlBytes, 0o644); writeErr != nil {
+			return writeErr
+		}
+	}
+	return nil
+}
+
+func cleanupBackups(backupDir string) {
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return
+	}
+
+	var backups []os.DirEntry
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasPrefix(entry.Name(), "config.") && strings.HasSuffix(entry.Name(), ".yaml") {
+			backups = append(backups, entry)
+		}
+	}
+
+	if len(backups) <= maxBackups {
+		return
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Name() < backups[j].Name()
+	})
+
+	toRemove := len(backups) - maxBackups
+	for i := 0; i < toRemove; i++ {
+		path := filepath.Join(backupDir, backups[i].Name())
+		if err := os.Remove(path); err != nil {
+			logging.Warnf("Failed to remove old backup %s: %v", path, err)
+		}
+	}
+}
+
+func mutationMessage(mode MutationMode) string {
+	if mode == MutationMerge {
+		return "Router config merged successfully. Router will reload automatically via fsnotify."
+	}
+	return "Router config replaced successfully. Router will reload automatically via fsnotify."
+}
+
+// ConfigVersionPattern exposes the backup version format for tests.
+func ConfigVersionPattern() *regexp.Regexp {
+	return configVersionPattern
+}

--- a/src/semantic-router/pkg/mcpconfig/mutator_test.go
+++ b/src/semantic-router/pkg/mcpconfig/mutator_test.go
@@ -1,0 +1,109 @@
+package mcpconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestMutatorGetDocument(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	writeTestConfig(t, configPath, map[string]any{"version": "v0.3"})
+
+	mutator := NewMutator(configPath)
+	doc, err := mutator.GetDocument()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if doc["version"] != "v0.3" {
+		t.Fatalf("version = %#v", doc["version"])
+	}
+}
+
+func TestMutatorValidateRejectsInvalidDocument(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	writeTestConfig(t, configPath, map[string]any{"version": "v0.3"})
+
+	mutator := NewMutator(configPath)
+	_, err := mutator.ValidateDocument(map[string]any{"routing": "invalid"}, MutationMerge)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestMutatorApplyPatchCreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	initial := strings.TrimSpace(`
+version: v0.3
+listeners: []
+providers:
+  defaults: {}
+routing:
+  signals: {}
+global:
+  router:
+    config_source: file
+  services: {}
+  stores:
+    semantic_cache:
+      enabled: false
+  integrations:
+    tools:
+      enabled: false
+  model_catalog:
+    embeddings:
+      semantic:
+        use_cpu: true
+`)
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	mutator := NewMutator(configPath)
+	patch := map[string]any{
+		"global": map[string]any{
+			"router": map[string]any{
+				"auto_model_name": "router-mcp-test",
+			},
+		},
+	}
+
+	result, err := mutator.ApplyPatch(patch, MutationMerge, "")
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if result.Version == "" {
+		t.Fatal("expected version from backup")
+	}
+
+	backupPath := filepath.Join(dir, ".vllm-sr", "config-backups", "config."+result.Version+".yaml")
+	if _, statErr := os.Stat(backupPath); statErr != nil {
+		t.Fatalf("backup missing: %v", statErr)
+	}
+
+	updated, err := mutator.GetDocument()
+	if err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	router, ok := updated["global"].(map[string]any)["router"].(map[string]any)
+	if !ok || router["auto_model_name"] != "router-mcp-test" {
+		t.Fatalf("expected patched auto_model_name, got %#v", updated)
+	}
+}
+
+func writeTestConfig(t *testing.T, path string, doc map[string]any) {
+	t.Helper()
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/src/semantic-router/pkg/mcpconfig/paths.go
+++ b/src/semantic-router/pkg/mcpconfig/paths.go
@@ -1,0 +1,65 @@
+package mcpconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	sourceConfigPathEnv  = "VLLM_SR_SOURCE_CONFIG_PATH"
+	runtimeConfigPathEnv = "VLLM_SR_RUNTIME_CONFIG_PATH"
+)
+
+type persistencePaths struct {
+	activePath  string
+	sourcePath  string
+	runtimePath string
+}
+
+func resolvePersistencePaths(activeConfigPath string) persistencePaths {
+	activePath := filepath.Clean(activeConfigPath)
+	sourcePath := strings.TrimSpace(os.Getenv(sourceConfigPathEnv))
+	if sourcePath == "" {
+		sourcePath = deriveSourceConfigPath(activePath)
+	}
+	if sourcePath == "" {
+		sourcePath = activePath
+	}
+	sourcePath = filepath.Clean(sourcePath)
+
+	runtimePath := strings.TrimSpace(os.Getenv(runtimeConfigPathEnv))
+	if runtimePath == "" {
+		runtimePath = activePath
+	}
+	runtimePath = filepath.Clean(runtimePath)
+
+	return persistencePaths{
+		activePath:  activePath,
+		sourcePath:  sourcePath,
+		runtimePath: runtimePath,
+	}
+}
+
+func deriveSourceConfigPath(activeConfigPath string) string {
+	activePath := filepath.Clean(activeConfigPath)
+	if filepath.Base(activePath) == "config.yaml" {
+		return activePath
+	}
+
+	parent := filepath.Base(filepath.Dir(activePath))
+	base := filepath.Base(activePath)
+	if parent == ".vllm-sr" && strings.HasPrefix(base, "runtime-config") && strings.HasSuffix(base, ".yaml") {
+		return filepath.Join(filepath.Dir(filepath.Dir(activePath)), "config.yaml")
+	}
+
+	return ""
+}
+
+func (p persistencePaths) usesRuntimeOverride() bool {
+	return p.sourcePath != "" && p.runtimePath != "" && p.sourcePath != p.runtimePath
+}
+
+func defaultAuditLogPath(paths persistencePaths) string {
+	return filepath.Join(filepath.Dir(paths.sourcePath), ".vllm-sr", "mcp-config-audit.jsonl")
+}

--- a/src/semantic-router/pkg/mcpconfig/policy.go
+++ b/src/semantic-router/pkg/mcpconfig/policy.go
@@ -1,0 +1,129 @@
+package mcpconfig
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// Coarse tool names exposed in PR1.
+const (
+	ToolGetConfig        = "get_config"
+	ToolExportConfigJSON = "export_config_json"
+	ToolExportConfigYAML = "export_config_yaml"
+	ToolValidateConfig   = "validate_config"
+	ToolDiffConfig       = "diff_config"
+	ToolApplyPatch       = "apply_patch"
+)
+
+var coarseTools = []string{
+	ToolGetConfig,
+	ToolExportConfigJSON,
+	ToolExportConfigYAML,
+	ToolValidateConfig,
+	ToolDiffConfig,
+	ToolApplyPatch,
+}
+
+// Policy enforces MCP config server guardrails.
+type Policy struct {
+	cfg  config.MCPConfigServerConfig
+	rate *rateLimiter
+}
+
+func NewPolicy(cfg config.MCPConfigServerConfig) *Policy {
+	return &Policy{
+		cfg:  cfg.WithDefaults(),
+		rate: newRateLimiter(cfg.WithDefaults().RateLimitPerMinute),
+	}
+}
+
+// Check returns an error when the tool call must be denied.
+func (p *Policy) Check(toolName, actor string, destructive bool) error {
+	if !p.cfg.Enabled {
+		return fmt.Errorf("mcp config server is disabled")
+	}
+	if !isCoarseTool(toolName) {
+		return fmt.Errorf("tool %q is not registered", toolName)
+	}
+	if len(p.cfg.AllowedTools) > 0 && !containsString(p.cfg.AllowedTools, toolName) {
+		return fmt.Errorf("tool %q is not in the allowlist", toolName)
+	}
+	if destructive && !p.cfg.AllowDestructive {
+		return fmt.Errorf("destructive tool %q requires allow_destructive=true in global.services.mcp_config", toolName)
+	}
+	if !p.rate.allow(actorKey(actor)) {
+		return fmt.Errorf("rate limit exceeded for actor %q", actorKey(actor))
+	}
+	return nil
+}
+
+func isCoarseTool(name string) bool {
+	return containsString(coarseTools, name)
+}
+
+// CoarseTools returns the PR1 tool inventory.
+func CoarseTools() []string {
+	out := make([]string, len(coarseTools))
+	copy(out, coarseTools)
+	return out
+}
+
+func actorKey(actor string) string {
+	trimmed := strings.TrimSpace(actor)
+	if trimmed == "" {
+		return "anonymous"
+	}
+	return trimmed
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+type rateLimiter struct {
+	limit int
+	mu    sync.Mutex
+	usage map[string][]time.Time
+}
+
+func newRateLimiter(limitPerMinute int) *rateLimiter {
+	if limitPerMinute <= 0 {
+		limitPerMinute = 60
+	}
+	return &rateLimiter{
+		limit: limitPerMinute,
+		usage: make(map[string][]time.Time),
+	}
+}
+
+func (r *rateLimiter) allow(actor string) bool {
+	now := time.Now()
+	cutoff := now.Add(-time.Minute)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	timestamps := r.usage[actor]
+	filtered := timestamps[:0]
+	for _, ts := range timestamps {
+		if ts.After(cutoff) {
+			filtered = append(filtered, ts)
+		}
+	}
+	if len(filtered) >= r.limit {
+		r.usage[actor] = filtered
+		return false
+	}
+	filtered = append(filtered, now)
+	r.usage[actor] = filtered
+	return true
+}

--- a/src/semantic-router/pkg/mcpconfig/policy_test.go
+++ b/src/semantic-router/pkg/mcpconfig/policy_test.go
@@ -1,0 +1,52 @@
+package mcpconfig
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestPolicyDisabledByDefault(t *testing.T) {
+	policy := NewPolicy(config.MCPConfigServerConfig{Enabled: false})
+	if err := policy.Check(ToolGetConfig, "agent", false); err == nil {
+		t.Fatal("expected disabled policy to reject tool calls")
+	}
+}
+
+func TestPolicyAllowlist(t *testing.T) {
+	policy := NewPolicy(config.MCPConfigServerConfig{
+		Enabled:      true,
+		AllowedTools: []string{ToolGetConfig},
+	})
+
+	if err := policy.Check(ToolGetConfig, "agent", false); err != nil {
+		t.Fatalf("get_config should be allowed: %v", err)
+	}
+	if err := policy.Check(ToolApplyPatch, "agent", false); err == nil {
+		t.Fatal("expected apply_patch to be blocked by allowlist")
+	}
+}
+
+func TestPolicyDestructiveGate(t *testing.T) {
+	policy := NewPolicy(config.MCPConfigServerConfig{Enabled: true})
+	if err := policy.Check("delete_signal", "agent", true); err == nil {
+		t.Fatal("expected unknown/destructive tool to be rejected")
+	}
+}
+
+func TestPolicyRateLimit(t *testing.T) {
+	policy := NewPolicy(config.MCPConfigServerConfig{
+		Enabled:            true,
+		RateLimitPerMinute: 1,
+	})
+
+	if err := policy.Check(ToolGetConfig, "agent-a", false); err != nil {
+		t.Fatalf("first call should pass: %v", err)
+	}
+	if err := policy.Check(ToolGetConfig, "agent-a", false); err == nil {
+		t.Fatal("expected rate limit on second call")
+	}
+	if err := policy.Check(ToolGetConfig, "agent-b", false); err != nil {
+		t.Fatalf("different actor should not share limit: %v", err)
+	}
+}

--- a/src/semantic-router/pkg/mcpconfig/server.go
+++ b/src/semantic-router/pkg/mcpconfig/server.go
@@ -1,0 +1,299 @@
+package mcpconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// InternalHTTPPath is the loopback MCP endpoint mounted by the router apiserver.
+const InternalHTTPPath = "/_internal/mcp/config"
+
+// Server exposes router config MCP tools.
+type Server struct {
+	mutator *Mutator
+	policy  *Policy
+	audit   *AuditLog
+	httpMCP http.Handler
+}
+
+// NewServer builds an MCP config server when cfg.Enabled is true.
+func NewServer(configPath string, cfg config.MCPConfigServerConfig) (*Server, error) {
+	resolved := cfg.WithDefaults()
+	if !resolved.Enabled {
+		return nil, fmt.Errorf("mcp config server is disabled")
+	}
+
+	paths := resolvePersistencePaths(configPath)
+	audit, err := NewAuditLog(defaultAuditLogPath(paths))
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Server{
+		mutator: NewMutator(configPath),
+		policy:  NewPolicy(resolved),
+		audit:   audit,
+	}
+
+	mcpServer := mcpserver.NewMCPServer("router-config", "1.0.0")
+	s.registerTools(mcpServer)
+	s.httpMCP = mcpserver.NewStreamableHTTPServer(mcpServer)
+	return s, nil
+}
+
+func (s *Server) registerTools(mcpServer *mcpserver.MCPServer) {
+	mcpServer.AddTool(getConfigToolDefinition(), s.getConfigTool)
+	mcpServer.AddTool(exportConfigJSONToolDefinition(), s.exportConfigJSONTool)
+	mcpServer.AddTool(exportConfigYAMLToolDefinition(), s.exportConfigYAMLTool)
+	mcpServer.AddTool(validateConfigToolDefinition(), s.validateConfigTool)
+	mcpServer.AddTool(diffConfigToolDefinition(), s.diffConfigTool)
+	mcpServer.AddTool(applyPatchToolDefinition(), s.applyPatch)
+}
+
+func (s *Server) HTTPHandler() http.Handler {
+	return s.httpMCP
+}
+
+type toolInvocation struct {
+	Actor string
+	Args  map[string]any
+}
+
+func (s *Server) parseInvocation(request mcp.CallToolRequest) (toolInvocation, error) {
+	var args map[string]any
+	if err := request.BindArguments(&args); err != nil {
+		return toolInvocation{}, err
+	}
+	if args == nil {
+		args = map[string]any{}
+	}
+	actor, _ := args["actor"].(string)
+	return toolInvocation{Actor: actor, Args: args}, nil
+}
+
+func (s *Server) invoke(
+	toolName string,
+	invocation toolInvocation,
+	destructive bool,
+	run func() (any, string, error),
+) (*mcp.CallToolResult, error) {
+	rawArgs, _ := json.Marshal(invocation.Args)
+	argsHash := hashArgs(string(rawArgs))
+
+	if err := s.policy.Check(toolName, invocation.Actor, destructive); err != nil {
+		_ = s.audit.Record(AuditEntry{
+			Actor:    actorKey(invocation.Actor),
+			Tool:     toolName,
+			ArgsHash: argsHash,
+			Success:  false,
+			Error:    err.Error(),
+		})
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	result, version, err := run()
+	entry := AuditEntry{
+		Actor:         actorKey(invocation.Actor),
+		Tool:          toolName,
+		ArgsHash:      argsHash,
+		Success:       err == nil,
+		ConfigVersion: version,
+	}
+	if err != nil {
+		entry.Error = err.Error()
+		_ = s.audit.Record(entry)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	_ = s.audit.Record(entry)
+	return newJSONResult(result)
+}
+
+func (s *Server) getConfigTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	invocation, err := s.parseInvocation(request)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid arguments: %v", err)), nil
+	}
+	return s.invoke(ToolGetConfig, invocation, false, func() (any, string, error) {
+		doc, err := s.mutator.GetDocument()
+		if err != nil {
+			return nil, "", err
+		}
+		return doc, "", nil
+	})
+}
+
+func (s *Server) exportConfigJSONTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	invocation, err := s.parseInvocation(request)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid arguments: %v", err)), nil
+	}
+	return s.invoke(ToolExportConfigJSON, invocation, false, func() (any, string, error) {
+		doc, err := s.mutator.GetDocument()
+		if err != nil {
+			return nil, "", err
+		}
+		return doc, "", nil
+	})
+}
+
+func (s *Server) exportConfigYAMLTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	invocation, err := s.parseInvocation(request)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid arguments: %v", err)), nil
+	}
+	return s.invoke(ToolExportConfigYAML, invocation, false, func() (any, string, error) {
+		doc, err := s.mutator.GetDocument()
+		if err != nil {
+			return nil, "", err
+		}
+		yamlBytes, err := normalizeRouterConfigDocument(doc)
+		if err != nil {
+			return nil, "", err
+		}
+		return map[string]any{"yaml": string(yamlBytes)}, "", nil
+	})
+}
+
+func (s *Server) validateConfigTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	invocation, err := s.parseInvocation(request)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid arguments: %v", err)), nil
+	}
+	return s.invoke(ToolValidateConfig, invocation, false, func() (any, string, error) {
+		doc, mode, err := documentFromArgs(invocation.Args)
+		if err != nil {
+			return nil, "", err
+		}
+		validated, err := s.mutator.ValidateDocument(doc, mode)
+		if err != nil {
+			return map[string]any{"valid": false, "error": err.Error()}, "", nil
+		}
+		return map[string]any{"valid": true, "document": validated}, "", nil
+	})
+}
+
+func (s *Server) diffConfigTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	invocation, err := s.parseInvocation(request)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid arguments: %v", err)), nil
+	}
+	return s.invoke(ToolDiffConfig, invocation, false, func() (any, string, error) {
+		patch, mode, err := patchFromArgs(invocation.Args)
+		if err != nil {
+			return nil, "", err
+		}
+		diff, err := s.mutator.DiffDocument(patch, mode)
+		if err != nil {
+			return nil, "", err
+		}
+		return diff, "", nil
+	})
+}
+
+func (s *Server) applyPatch(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	_ = ctx
+	invocation, err := s.parseInvocation(request)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid arguments: %v", err)), nil
+	}
+	return s.invoke(ToolApplyPatch, invocation, false, func() (any, string, error) {
+		patch, mode, err := patchFromArgs(invocation.Args)
+		if err != nil {
+			return nil, "", err
+		}
+		dsl, _ := invocation.Args["dsl"].(string)
+		result, err := s.mutator.ApplyPatch(patch, mode, dsl)
+		if err != nil {
+			return nil, "", err
+		}
+		return result, result.Version, nil
+	})
+}
+
+func documentFromArgs(args map[string]any) (map[string]any, MutationMode, error) {
+	doc, err := objectArg(args, "document")
+	if err != nil {
+		return nil, "", err
+	}
+	return doc, mutationModeFromArgs(args), nil
+}
+
+func patchFromArgs(args map[string]any) (map[string]any, MutationMode, error) {
+	patch, err := objectArg(args, "patch")
+	if err != nil {
+		return nil, "", err
+	}
+	return patch, mutationModeFromArgs(args), nil
+}
+
+func objectArg(args map[string]any, key string) (map[string]any, error) {
+	raw, ok := args[key]
+	if !ok {
+		return nil, fmt.Errorf("%s is required", key)
+	}
+	doc, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an object", key)
+	}
+	return doc, nil
+}
+
+func mutationModeFromArgs(args map[string]any) MutationMode {
+	merge, ok := args["merge"].(bool)
+	if ok && !merge {
+		return MutationReplace
+	}
+	return MutationMerge
+}
+
+func newJSONResult(data any) (*mcp.CallToolResult, error) {
+	payload, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return mcp.NewToolResultText(string(payload)), nil
+}
+
+// ToolCatalog documents the PR1 MCP tool surface.
+func ToolCatalog() []map[string]string {
+	tools := CoarseTools()
+	out := make([]map[string]string, 0, len(tools))
+	for _, tool := range tools {
+		out = append(out, map[string]string{
+			"name":        tool,
+			"description": toolDescription(tool),
+		})
+	}
+	return out
+}
+
+func toolDescription(name string) string {
+	switch name {
+	case ToolGetConfig:
+		return "Return the current router config document as JSON."
+	case ToolExportConfigJSON:
+		return "Export the current router config document as JSON."
+	case ToolExportConfigYAML:
+		return "Export the current router config document as canonical YAML."
+	case ToolValidateConfig:
+		return "Validate a router config document."
+	case ToolDiffConfig:
+		return "Preview a config patch against the current router config."
+	case ToolApplyPatch:
+		return "Apply a validated config patch to the router config file."
+	default:
+		return ""
+	}
+}

--- a/src/semantic-router/pkg/mcpconfig/server_test.go
+++ b/src/semantic-router/pkg/mcpconfig/server_test.go
@@ -1,0 +1,73 @@
+package mcpconfig
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestServerRequiresEnabledConfig(t *testing.T) {
+	_, err := NewServer(filepath.Join(t.TempDir(), "config.yaml"), config.MCPConfigServerConfig{})
+	if err == nil {
+		t.Fatal("expected disabled config to fail server creation")
+	}
+}
+
+func TestServerGetConfigTool(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	writeTestConfig(t, configPath, map[string]any{
+		"version":   "v0.3",
+		"routing":   map[string]any{"signals": map[string]any{}, "decisions": []any{}},
+		"providers": map[string]any{},
+		"global":    map[string]any{},
+	})
+
+	server, err := NewServer(configPath, config.MCPConfigServerConfig{Enabled: true})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	result, err := server.getConfigTool(context.Background(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("tool call: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %#v", result)
+	}
+}
+
+func TestServerAuditLogWritten(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	auditPath := filepath.Join(dir, ".vllm-sr", "mcp-config-audit.jsonl")
+	writeTestConfig(t, configPath, map[string]any{
+		"version":   "v0.3",
+		"routing":   map[string]any{"signals": map[string]any{}, "decisions": []any{}},
+		"providers": map[string]any{},
+		"global":    map[string]any{},
+	})
+
+	server, err := NewServer(configPath, config.MCPConfigServerConfig{Enabled: true})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	_, err = server.getConfigTool(context.Background(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("tool call: %v", err)
+	}
+
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected audit log entry")
+	}
+}

--- a/src/semantic-router/pkg/mcpconfig/tools_schema.go
+++ b/src/semantic-router/pkg/mcpconfig/tools_schema.go
@@ -1,0 +1,122 @@
+package mcpconfig
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+func getConfigToolDefinition() mcp.Tool {
+	return mcp.Tool{
+		Name:        ToolGetConfig,
+		Description: "Return the current router config document as JSON.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"actor": actorProperty(),
+			},
+		},
+	}
+}
+
+func exportConfigJSONToolDefinition() mcp.Tool {
+	return mcp.Tool{
+		Name:        ToolExportConfigJSON,
+		Description: "Export the current router config document as JSON.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"actor": actorProperty(),
+			},
+		},
+	}
+}
+
+func exportConfigYAMLToolDefinition() mcp.Tool {
+	return mcp.Tool{
+		Name:        ToolExportConfigYAML,
+		Description: "Export the current router config document as canonical YAML.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"actor": actorProperty(),
+			},
+		},
+	}
+}
+
+func validateConfigToolDefinition() mcp.Tool {
+	return mcp.Tool{
+		Name:        ToolValidateConfig,
+		Description: "Validate a router config document using the same parser as /config/router.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"actor":    actorProperty(),
+				"document": documentProperty(),
+				"merge":    mergeProperty(),
+			},
+			Required: []string{"document"},
+		},
+	}
+}
+
+func diffConfigToolDefinition() mcp.Tool {
+	return mcp.Tool{
+		Name:        ToolDiffConfig,
+		Description: "Preview how a patch merges into the current router config.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"actor": actorProperty(),
+				"patch": patchProperty(),
+				"merge": mergeProperty(),
+			},
+			Required: []string{"patch"},
+		},
+	}
+}
+
+func applyPatchToolDefinition() mcp.Tool {
+	return mcp.Tool{
+		Name:        ToolApplyPatch,
+		Description: "Apply a router config patch with merge semantics by default, then validate, backup, and hot-reload.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"actor": actorProperty(),
+				"patch": patchProperty(),
+				"merge": mergeProperty(),
+				"dsl": map[string]any{
+					"type":        "string",
+					"description": "Optional DSL source archived with the config version.",
+				},
+			},
+			Required: []string{"patch"},
+		},
+	}
+}
+
+func actorProperty() map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": "Optional actor identifier recorded in the audit log.",
+	}
+}
+
+func documentProperty() map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": "Router config document object.",
+	}
+}
+
+func patchProperty() map[string]any {
+	return map[string]any{
+		"type":        "object",
+		"description": "Router config patch object.",
+	}
+}
+
+func mergeProperty() map[string]any {
+	return map[string]any{
+		"type":        "boolean",
+		"description": "When true (default), merge into the current config. When false, replace the document.",
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Part of https://github.com/vllm-project/semantic-router/issues/1220

## Purpose

- What does this PR change?


File | change
-- | --
config/config.yaml | Adds a disabled-by-default global.services.mcp_config block to the reference router config.
src/semantic-router/pkg/config/mcp_config_server.go | Defines MCPConfigServerConfig and defaulting for enablement, loopback, tool allowlist, and rate limits.
src/semantic-router/pkg/config/config.go | Wires MCPConfig into RouterConfig so the main config loader can parse it.
src/semantic-router/pkg/config/canonical_global.go | Adds mcp_config under canonical global.services and applies it when merging canonical global config.
src/semantic-router/pkg/config/canonical_export.go | Includes MCPConfig when exporting RouterConfig to the canonical global representation.
src/semantic-router/pkg/config/reference_config_global_test.go | Asserts the reference config.yaml documents every field on MCPConfigServerConfig.
src/semantic-router/pkg/mcpconfig/paths.go | Resolves active, source, and runtime config paths and audit-log location from env and config dir.
src/semantic-router/pkg/mcpconfig/policy.go | Enforces MCP tool allowlists, destructive-write rules, and per-actor rate limiting.
src/semantic-router/pkg/mcpconfig/policy_test.go | Unit-tests policy behavior for disabled server, allowlists, and destructive tools.
src/semantic-router/pkg/mcpconfig/audit.go | Appends JSONL audit records for each MCP config tool invocation under .vllm-sr/.
src/semantic-router/pkg/mcpconfig/mutator.go | Implements read/validate/diff/patch/deploy of router config with backups and apiserver-aligned validation.
src/semantic-router/pkg/mcpconfig/mutator_test.go | Unit-tests mutator get, validate, diff, patch, and versioned deploy behavior.
src/semantic-router/pkg/mcpconfig/loopback.go | HTTP middleware that returns 403 for non-loopback clients when loopback_only is set.
src/semantic-router/pkg/mcpconfig/loopback_test.go | Unit-tests loopback-only middleware for loopback vs remote addresses.
src/semantic-router/pkg/mcpconfig/tools_schema.go | Declares MCP tool input schemas for the six PR1 config tools.
src/semantic-router/pkg/mcpconfig/server.go | Builds the Streamable HTTP MCP server at /_internal/mcp/config and registers tool handlers.
src/semantic-router/pkg/mcpconfig/server_test.go | Unit-tests server creation, get_config, and related tool behavior.
src/semantic-router/pkg/apiserver/mcp_config_route.go | Mounts the MCP config HTTP handler on the apiserver when enabled, optionally behind loopback guard.
src/semantic-router/pkg/apiserver/mcp_config_route_test.go | Tests that the route is off by default and that loopback-only mode blocks or allows clients correctly.
src/semantic-router/pkg/apiserver/server.go | Calls registerMCPConfigRoutes during apiserver route setup.
src/semantic-router/pkg/apiserver/route_api_doc.go | Adds mcp_config to the /api/v1 overview links for endpoint discovery.



- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
