### PR TITLE
[Docs] fix operator image path in deploy instructions

### DIFF
--- a/deploy/operator/README.md
+++ b/deploy/operator/README.md
@@ -31,7 +31,7 @@ make docker-build docker-push IMG=<your-registry>/semantic-router-operator:lates
 make install
 
 # Deploy operator
-make deploy IMG=ghcr.io/vllm-project/semantic-router-operator:latest
+make deploy IMG=ghcr.io/vllm-project/semantic-router/operator:latest
 ```
 
 #### Option 2: OpenShift OperatorHub

--- a/website/docs/installation/k8s/operator.md
+++ b/website/docs/installation/k8s/operator.md
@@ -36,7 +36,7 @@ cd semantic-router/deploy/operator
 make install
 
 # Deploy the operator
-make deploy IMG=ghcr.io/vllm-project/semantic-router-operator:latest
+make deploy IMG=ghcr.io/vllm-project/semantic-router/operator:latest
 ```
 
 Verify the operator is running:


### PR DESCRIPTION
The canonical image ghcr.io/vllm-project/semantic-router/operator is publicly pullable; ghcr.io/vllm-project/semantic-router-operator does not exist and returns denied

## Purpose

- Corrects the operator image path in deploy instructions from ghcr.io/vllm-project/semantic-router-operator:latest to
ghcr.io/vllm-project/semantic-router/operator:latest
- The old path does not exist on GHCR and returns denied; the correct path is publicly pullable
- Which module(s) does this affect?  `Docs` 

## Test Plan

- docker pull ghcr.io/vllm-project/semantic-router/operator:latest — confirm it pulls successfully
- docker pull ghcr.io/vllm-project/semantic-router-operator:latest — confirm it fails

## Test Result

Verified by pulling both images unauthenticated: correct path pulls successfully, old path returns denied

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
