### PR TITLE
[E2E] add request-preservation tests for Anthropic /v1/messages

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -61,6 +61,16 @@ var DashboardContract = []string{
 var AnthropicShimContract = []string{
 	"anthropic-messages-cache-cycle",
 	"anthropic-messages-stop-sequence",
+	// Request-side field preservation tests (depend on the shim's
+	// /debug/last-request endpoint introduced in PR #1940).
+	"anthropic-messages-image-block-preserved",
+	"anthropic-messages-top-k-preserved",
+	"anthropic-messages-metadata-user-id-preserved",
+	"anthropic-messages-tool-result-is-error-preserved",
+	"anthropic-messages-tool-result-array-content-preserved",
+	"anthropic-messages-stop-sequences-preserved",
+	"anthropic-messages-temperature-preserved",
+	"anthropic-messages-top-p-preserved",
 }
 
 // Combine preserves order while removing duplicate testcase names.

--- a/e2e/testcases/anthropic_messages_request_preservation.go
+++ b/e2e/testcases/anthropic_messages_request_preservation.go
@@ -1,0 +1,661 @@
+package testcases
+
+// Request-side field preservation tests for the Anthropic /v1/messages translation path.
+//
+// These tests assert that specific fields sent by the client reach the upstream
+// backend (anthropic-shim) verbatim after the router's translation. Each test:
+//  1. Sends a POST /v1/messages to the router with a tagged x-vsr-test-session-id.
+//  2. Waits for a 200 OK.
+//  3. Opens a second port-forward to the shim's debug service and queries
+//     GET /debug/last-request to inspect what the shim received.
+//  4. Asserts the specific field of interest.
+//
+// All eight tests require the anthropic-shim profile and are registered in
+// AnthropicShimContract (e2e/pkg/testmatrix/testcases.go). Shared types and
+// helpers live in anthropic_messages_request_preservation_helpers.go.
+//
+// IMPORTANT: The shim's /debug/last-request endpoint returns the request body
+// AFTER the shim's own translations (join_system_array, join_tool_result_content).
+// For scenarios 5, 6, 7, and 9 this makes no difference. For scenario 10,
+// join_tool_result_content collapses the array to a newline-joined string before
+// forwarding to llama-server; the assertion verifies the collapsed form
+// (both parts present, in order) which is what actually reaches upstream.
+//
+// Header names are hardcoded as string literals here; the e2e module
+// (e2e/go.mod) is intentionally decoupled from the router module
+// (src/semantic-router/go.mod) and does not import pkg/headers.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-messages-image-block-preserved", pkgtestcases.TestCase{
+		Description: "Verify image content blocks survive router translation and reach the shim intact (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "image"},
+		Fn:          testAnthropicMessagesImageBlockPreserved,
+	})
+	pkgtestcases.Register("anthropic-messages-top-k-preserved", pkgtestcases.TestCase{
+		Description: "Verify top_k reaches upstream and no lossiness warning is emitted when backend is Anthropic-shaped (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "top_k"},
+		Fn:          testAnthropicMessagesTopKPreserved,
+	})
+	pkgtestcases.Register("anthropic-messages-metadata-user-id-preserved", pkgtestcases.TestCase{
+		Description: "Verify metadata.user_id reaches the shim verbatim through router translation (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "metadata"},
+		Fn:          testAnthropicMessagesMetadataUserIDPreserved,
+	})
+	pkgtestcases.Register("anthropic-messages-tool-result-is-error-preserved", pkgtestcases.TestCase{
+		Description: "Verify tool_result.is_error=true is preserved through router translation (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "tool_result"},
+		Fn:          testAnthropicMessagesToolResultIsErrorPreserved,
+	})
+	pkgtestcases.Register("anthropic-messages-tool-result-array-content-preserved", pkgtestcases.TestCase{
+		Description: "Verify multi-block tool_result.content array is forwarded to upstream with both parts present (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "tool_result", "array"},
+		Fn:          testAnthropicMessagesToolResultArrayContentPreserved,
+	})
+	pkgtestcases.Register("anthropic-messages-stop-sequences-preserved", pkgtestcases.TestCase{
+		Description: "Verify stop_sequences survives the Anthropic→IR→Anthropic round-trip and reaches the shim verbatim (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "stop_sequences"},
+		Fn:          testAnthropicMessagesStopSequencesPreserved,
+	})
+	pkgtestcases.Register("anthropic-messages-temperature-preserved", pkgtestcases.TestCase{
+		Description: "Verify temperature survives the Anthropic→IR→Anthropic round-trip and reaches the shim verbatim (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "sampling"},
+		Fn:          testAnthropicMessagesTemperaturePreserved,
+	})
+	pkgtestcases.Register("anthropic-messages-top-p-preserved", pkgtestcases.TestCase{
+		Description: "Verify top_p survives the Anthropic→IR→Anthropic round-trip and reaches the shim verbatim (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "preservation", "sampling"},
+		Fn:          testAnthropicMessagesTopPPreserved,
+	})
+}
+
+// ── Test: image block survival (scenario 5) ───────────────────────────────────
+
+// testAnthropicMessagesImageBlockPreserved verifies scenario 5:
+// a user message carrying a base64 image block is forwarded to the shim with
+// the image block intact (type, source.type, source.media_type, source.data
+// all present and matching the original values).
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesImageBlockPreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing image block preservation through /v1/messages translation")
+	}
+
+	routerPort, stopRouter, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopRouter()
+
+	shimPort, stopShim, err := openShimSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopShim()
+
+	sessionID := fmt.Sprintf("preservation-image-%d", time.Now().UnixNano())
+
+	body := preservationRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		Messages: []preservationMessage{
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{
+						Type: "image",
+						Source: imageSource{
+							Type:      "base64",
+							MediaType: "image/png",
+							Data:      tinyPNG1x1,
+						},
+					},
+					{
+						Type: "text",
+						Text: "What colour is this image?",
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := postPreservationRequest(ctx, body, sessionID, routerPort)
+	if err != nil {
+		return fmt.Errorf("router request: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected 200 from router, got %d: %s", resp.StatusCode, truncateString(string(rawBody), 200))
+	}
+
+	debug, err := fetchShimDebugBody(ctx, shimPort, sessionID)
+	if err != nil {
+		return fmt.Errorf("shim debug: %w", err)
+	}
+
+	// Navigate: body.messages[0].content[0] must be the image block.
+	imageBlock, err := extractFirstContentBlock(debug.Body)
+	if err != nil {
+		return fmt.Errorf("extract image block from shim body: %w", err)
+	}
+
+	got, err := readImageBlock(imageBlock)
+	if err != nil {
+		return err
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"block_type":        "image",
+			"source_type":       got.Type,
+			"source_media_type": got.MediaType,
+			"source_data_len":   len(got.Data),
+		})
+	}
+
+	want := imageSource{Type: "base64", MediaType: "image/png", Data: tinyPNG1x1}
+	return assertImageSourceEqual(want, got)
+}
+
+// ── Test: top_k reaching upstream (scenario 6) ───────────────────────────────
+
+// testAnthropicMessagesTopKPreserved verifies scenario 6:
+// top_k sent by the client reaches the shim with the correct value AND the
+// response does NOT carry x-vsr-lossiness-warnings, since the backend is
+// Anthropic-shaped and top_k should be forwarded without loss.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesTopKPreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing top_k preservation through /v1/messages translation")
+	}
+
+	routerPort, stopRouter, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopRouter()
+
+	shimPort, stopShim, err := openShimSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopShim()
+
+	sessionID := fmt.Sprintf("preservation-topk-%d", time.Now().UnixNano())
+
+	body := preservationRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		TopK:      40,
+		Messages: []preservationMessage{
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{Type: "text", Text: "Say one word."},
+				},
+			},
+		},
+	}
+
+	resp, err := postPreservationRequest(ctx, body, sessionID, routerPort)
+	if err != nil {
+		return fmt.Errorf("router request: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected 200 from router, got %d: %s", resp.StatusCode, truncateString(string(rawBody), 200))
+	}
+
+	// x-vsr-lossiness-warnings must be absent for Anthropic-shaped backends.
+	// When the backend is OpenAI-shaped, top_k cannot be forwarded and the router
+	// emits "top_k_drop_on_openai_backend". With the anthropic-shim the field
+	// should reach upstream without loss, so no warning is expected.
+	lossiness := resp.Header.Get("x-vsr-lossiness-warnings")
+
+	debug, err := fetchShimDebugBody(ctx, shimPort, sessionID)
+	if err != nil {
+		return fmt.Errorf("shim debug: %w", err)
+	}
+
+	// top_k is preserved in the body forwarded to upstream.
+	topKRaw, ok := debug.Body["top_k"]
+	if !ok {
+		return fmt.Errorf("expected top_k field in shim body, not present")
+	}
+	// JSON numbers unmarshal as float64 in interface{} maps.
+	topKVal, ok := topKRaw.(float64)
+	if !ok {
+		return fmt.Errorf("expected top_k to be a number, got %T", topKRaw)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"top_k_in_shim":    int(topKVal),
+			"lossiness_header": lossiness,
+		})
+	}
+
+	if int(topKVal) != 40 {
+		return fmt.Errorf("expected top_k=40 in shim body, got %d", int(topKVal))
+	}
+	if lossiness != "" {
+		return fmt.Errorf("expected no x-vsr-lossiness-warnings for Anthropic-shaped backend, got %q", lossiness)
+	}
+
+	return nil
+}
+
+// ── Test: metadata.user_id reaching upstream (scenario 7) ────────────────────
+
+// testAnthropicMessagesMetadataUserIDPreserved verifies scenario 7:
+// metadata.user_id sent by the client reaches the shim verbatim after router
+// translation.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesMetadataUserIDPreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing metadata.user_id preservation through /v1/messages translation")
+	}
+
+	routerPort, stopRouter, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopRouter()
+
+	shimPort, stopShim, err := openShimSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopShim()
+
+	sessionID := fmt.Sprintf("preservation-metadata-%d", time.Now().UnixNano())
+	const wantUserID = "test-user-12345"
+
+	body := preservationRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		Metadata:  map[string]interface{}{"user_id": wantUserID},
+		Messages: []preservationMessage{
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{Type: "text", Text: "Say one word."},
+				},
+			},
+		},
+	}
+
+	resp, err := postPreservationRequest(ctx, body, sessionID, routerPort)
+	if err != nil {
+		return fmt.Errorf("router request: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected 200 from router, got %d: %s", resp.StatusCode, truncateString(string(rawBody), 200))
+	}
+
+	debug, err := fetchShimDebugBody(ctx, shimPort, sessionID)
+	if err != nil {
+		return fmt.Errorf("shim debug: %w", err)
+	}
+
+	metaRaw, ok := debug.Body["metadata"]
+	if !ok {
+		return fmt.Errorf("expected metadata field in shim body, not present")
+	}
+	meta, ok := metaRaw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("expected metadata to be an object, got %T", metaRaw)
+	}
+	gotUserID, _ := meta["user_id"].(string)
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"metadata_user_id": gotUserID,
+		})
+	}
+
+	if gotUserID != wantUserID {
+		return fmt.Errorf("expected metadata.user_id=%q in shim body, got %q", wantUserID, gotUserID)
+	}
+
+	return nil
+}
+
+// ── Test: tool_result.is_error preservation (scenario 9) ─────────────────────
+
+// testAnthropicMessagesToolResultIsErrorPreserved verifies scenario 9:
+// is_error=true on a tool_result block reaches the shim after router translation.
+// The request has an assistant turn (to satisfy the alternating-turns contract)
+// followed by a user turn with a tool_result block carrying is_error=true.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesToolResultIsErrorPreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing tool_result.is_error=true preservation through /v1/messages translation")
+	}
+
+	routerPort, stopRouter, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopRouter()
+
+	shimPort, stopShim, err := openShimSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopShim()
+
+	sessionID := fmt.Sprintf("preservation-iserror-%d", time.Now().UnixNano())
+
+	body := preservationRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		Messages: []preservationMessage{
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{Type: "text", Text: "Call the tool."},
+				},
+			},
+			{
+				Role: "assistant",
+				Content: []preservationContentBlock{
+					{
+						Type:      "tool_use",
+						ToolUseID: "tu_x",
+						Text:      "do_something",
+					},
+				},
+			},
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{
+						Type:      "tool_result",
+						ToolUseID: "tu_x",
+						IsError:   true,
+						Content:   "Error!",
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := postPreservationRequest(ctx, body, sessionID, routerPort)
+	if err != nil {
+		return fmt.Errorf("router request: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected 200 from router, got %d: %s", resp.StatusCode, truncateString(string(rawBody), 200))
+	}
+
+	debug, err := fetchShimDebugBody(ctx, shimPort, sessionID)
+	if err != nil {
+		return fmt.Errorf("shim debug: %w", err)
+	}
+
+	// Navigate: body.messages[2].content[0] is the tool_result block.
+	isError, err := extractToolResultIsError(debug.Body)
+	if err != nil {
+		return fmt.Errorf("extract is_error from shim body: %w", err)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"tool_result_is_error": isError,
+		})
+	}
+
+	if !isError {
+		return fmt.Errorf("expected tool_result.is_error=true in shim body, got false")
+	}
+
+	return nil
+}
+
+// ── Test: tool_result array content preservation (scenario 10) ───────────────
+
+// testAnthropicMessagesToolResultArrayContentPreserved verifies scenario 10:
+// a tool_result block with multi-part array content (two text blocks) is
+// forwarded to upstream. The shim's join_tool_result_content collapses the
+// array into a newline-joined string before recording and forwarding, so the
+// assertion checks the joined string — "part 1\npart 2" — which is what
+// actually reaches llama-server. Both parts must be present, in order.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesToolResultArrayContentPreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing tool_result array content preservation through /v1/messages translation")
+	}
+
+	routerPort, stopRouter, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopRouter()
+
+	shimPort, stopShim, err := openShimSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopShim()
+
+	sessionID := fmt.Sprintf("preservation-trarr-%d", time.Now().UnixNano())
+
+	// The tool_result.content is a two-element array of text blocks.
+	// The shim collapses this to "part 1\npart 2" via join_tool_result_content
+	// before forwarding to llama-server. We assert on the collapsed form.
+	body := preservationRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		Messages: []preservationMessage{
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{Type: "text", Text: "Call the tool."},
+				},
+			},
+			{
+				Role: "assistant",
+				Content: []preservationContentBlock{
+					{
+						Type:      "tool_use",
+						ToolUseID: "tu_y",
+						Text:      "fetch_data",
+					},
+				},
+			},
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{
+						Type:      "tool_result",
+						ToolUseID: "tu_y",
+						Content: []map[string]string{
+							{"type": "text", "text": "part 1"},
+							{"type": "text", "text": "part 2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := postPreservationRequest(ctx, body, sessionID, routerPort)
+	if err != nil {
+		return fmt.Errorf("router request: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected 200 from router, got %d: %s", resp.StatusCode, truncateString(string(rawBody), 200))
+	}
+
+	debug, err := fetchShimDebugBody(ctx, shimPort, sessionID)
+	if err != nil {
+		return fmt.Errorf("shim debug: %w", err)
+	}
+
+	// The shim's join_tool_result_content collapses ["part 1", "part 2"] to
+	// "part 1\npart 2". Both original parts must appear in the forwarded content.
+	content, err := extractToolResultContent(debug.Body)
+	if err != nil {
+		return fmt.Errorf("extract tool_result.content from shim body: %w", err)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"tool_result_content": content,
+		})
+	}
+
+	const wantJoined = "part 1\npart 2"
+	if content != wantJoined {
+		return fmt.Errorf("expected tool_result.content=%q after shim join, got %q", wantJoined, content)
+	}
+
+	return nil
+}
+
+// ── Test: stop_sequences round-trip preservation ─────────────────────────────
+
+// testAnthropicMessagesStopSequencesPreserved verifies that stop_sequences
+// survives the full Anthropic→IR→Anthropic round-trip. Unlike top_k (which
+// rides the AnthropicPassthrough sidecar), stop_sequences is mapped into the
+// OpenAI IR's Stop field on inbound (applyStopSequences) and mapped back out to
+// the Anthropic StopSequences field on outbound (applySampling). A regression
+// in either re-mapping would drop or corrupt the field; the shim forwards it
+// verbatim, so /debug/last-request reflects exactly what reached upstream.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesStopSequencesPreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing stop_sequences preservation through /v1/messages translation")
+	}
+
+	routerPort, stopRouter, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopRouter()
+
+	shimPort, stopShim, err := openShimSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopShim()
+
+	sessionID := fmt.Sprintf("preservation-stopseq-%d", time.Now().UnixNano())
+	wantSequences := []string{"END", "STOP"}
+
+	body := preservationRequestBody{
+		Model:         "MoM",
+		MaxTokens:     32,
+		StopSequences: wantSequences,
+		Messages: []preservationMessage{
+			{
+				Role: "user",
+				Content: []preservationContentBlock{
+					{Type: "text", Text: "Say one word."},
+				},
+			},
+		},
+	}
+
+	resp, err := postPreservationRequest(ctx, body, sessionID, routerPort)
+	if err != nil {
+		return fmt.Errorf("router request: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected 200 from router, got %d: %s", resp.StatusCode, truncateString(string(rawBody), 200))
+	}
+
+	debug, err := fetchShimDebugBody(ctx, shimPort, sessionID)
+	if err != nil {
+		return fmt.Errorf("shim debug: %w", err)
+	}
+
+	got, err := extractStopSequences(debug.Body)
+	if err != nil {
+		return fmt.Errorf("extract stop_sequences from shim body: %w", err)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"stop_sequences": got,
+		})
+	}
+
+	if !equalStringSlices(got, wantSequences) {
+		return fmt.Errorf("expected stop_sequences=%v in shim body, got %v", wantSequences, got)
+	}
+
+	return nil
+}
+
+// ── Test: temperature round-trip preservation ────────────────────────────────
+
+// testAnthropicMessagesTemperaturePreserved verifies that temperature
+// survives the Anthropic→IR→Anthropic round-trip. It is mapped into the
+// OpenAI IR's Temperature field on inbound (applyNumericSampling) and back to
+// the Anthropic Temperature field on outbound (applySampling), with no scaling
+// in either direction. A regression in the Valid()-guarded re-mapping would
+// silently drop the field. 0.7 is valid in both the OpenAI (0-2) and Anthropic
+// (0-1) ranges, so the value reaching the shim must match exactly.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesTemperaturePreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	return runSamplingFieldPreservation(ctx, client, opts, samplingFieldCase{
+		label:     "temperature",
+		sessionID: "preservation-temp",
+		field:     "temperature",
+		want:      0.7,
+		apply:     func(b *preservationRequestBody, v float64) { b.Temperature = &v },
+	})
+}
+
+// ── Test: top_p round-trip preservation ──────────────────────────────────────
+
+// testAnthropicMessagesTopPPreserved verifies that top_p survives the
+// Anthropic→IR→Anthropic round-trip (applyNumericSampling inbound, applySampling
+// outbound, no scaling). A regression in the Valid()-guarded re-mapping would
+// silently drop the field.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicMessagesTopPPreserved(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	return runSamplingFieldPreservation(ctx, client, opts, samplingFieldCase{
+		label:     "top_p",
+		sessionID: "preservation-topp",
+		field:     "top_p",
+		want:      0.9,
+		apply:     func(b *preservationRequestBody, v float64) { b.TopP = &v },
+	})
+}

--- a/e2e/testcases/anthropic_messages_request_preservation_helpers.go
+++ b/e2e/testcases/anthropic_messages_request_preservation_helpers.go
@@ -1,0 +1,526 @@
+package testcases
+
+// Helpers for anthropic_messages_request_preservation.go.
+//
+// Split out to keep the main file under the 800-line cap. This file holds:
+//   - Constants for the shim service location.
+//   - Request body types (preservationContentBlock, imageSource, ...).
+//   - Shim debug response type.
+//   - Infrastructure helpers (port-forwarding, HTTP send/fetch).
+//   - Navigation helpers for the shim's recorded JSON body.
+//   - Image-block assertion helpers.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+// shimServiceNamespace is the Kubernetes namespace for the anthropic-shim
+// service (declared in e2e/profiles/anthropic-shim/gateway-resources/backend.yaml).
+const shimServiceNamespace = "anthropic-backend-system"
+
+// shimServiceName is the Kubernetes Service name for the shim. Its port is 9080
+// (the shim port; the llama-server port 8080 is cluster-internal only).
+const shimServiceName = "anthropic-backend-qwen"
+
+// shimServicePort is the Service port for the anthropic-shim container.
+const shimServicePort = "9080"
+
+// tinyPNG1x1 is a 1×1 transparent PNG image, base64-encoded.
+// Used as a minimal valid image payload for the image-block preservation test.
+const tinyPNG1x1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+// ── Request body types ────────────────────────────────────────────────────────
+
+// preservationContentBlock is a generic Anthropic content block that supports
+// type, text, source (for image blocks), tool_use_id, is_error, and content
+// (for tool_result blocks). Using interface{} for content and source lets a
+// single type cover all block shapes without requiring parallel type families.
+type preservationContentBlock struct {
+	Type      string      `json:"type"`
+	Text      string      `json:"text,omitempty"`
+	Source    interface{} `json:"source,omitempty"`
+	ToolUseID string      `json:"tool_use_id,omitempty"`
+	IsError   bool        `json:"is_error,omitempty"`
+	Content   interface{} `json:"content,omitempty"`
+}
+
+// imageSource is the Anthropic base64 image source shape.
+type imageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
+// preservationMessage is a rich Anthropic message that accepts content as
+// either a string (simple) or a slice of blocks (complex). We always use
+// the block form in this file.
+type preservationMessage struct {
+	Role    string                     `json:"role"`
+	Content []preservationContentBlock `json:"content"`
+}
+
+// preservationRequestBody is the POST /v1/messages payload for preservation
+// tests. It carries the fields the sibling anthropicMessagesRequestBody type
+// does not (top_k, metadata, rich content blocks), so it lives here and is
+// not shared with siblings to avoid expanding their scope.
+type preservationRequestBody struct {
+	Model         string                `json:"model"`
+	MaxTokens     int                   `json:"max_tokens"`
+	Messages      []preservationMessage `json:"messages"`
+	TopK          int                   `json:"top_k,omitempty"`
+	Temperature   *float64              `json:"temperature,omitempty"`
+	TopP          *float64              `json:"top_p,omitempty"`
+	Metadata      interface{}           `json:"metadata,omitempty"`
+	StopSequences []string              `json:"stop_sequences,omitempty"`
+}
+
+// ── Shim debug response type ──────────────────────────────────────────────────
+
+// shimDebugResponse mirrors the JSON shape returned by the shim's
+// GET /debug/last-request endpoint:
+//
+//	{"session_id": "...", "body": {...}, "headers": {...}}
+//
+// body is decoded as a raw map so individual field assertions can be
+// expressed at test level without coupling this file to every possible shape.
+type shimDebugResponse struct {
+	SessionID string                 `json:"session_id"`
+	Body      map[string]interface{} `json:"body"`
+	Headers   map[string]interface{} `json:"headers"`
+}
+
+// ── Infrastructure helpers ────────────────────────────────────────────────────
+
+// openShimSession opens a port-forward to the anthropic-shim service and
+// returns the local port string and a stop function. Callers must defer stop().
+func openShimSession(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) (string, func(), error) {
+	localPort, err := allocateLocalPort()
+	if err != nil {
+		return "", nil, fmt.Errorf("allocate local port for shim: %w", err)
+	}
+
+	stop, err := helpers.StartPortForward(
+		ctx,
+		client,
+		opts.RestConfig,
+		shimServiceNamespace,
+		shimServiceName,
+		fmt.Sprintf("%s:%s", localPort, shimServicePort),
+		opts.Verbose,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("port-forward to shim %s/%s: %w", shimServiceNamespace, shimServiceName, err)
+	}
+
+	// Give the port-forward a moment to stabilise before the first request.
+	time.Sleep(2 * time.Second)
+	return localPort, stop, nil
+}
+
+// allocateLocalPort finds a free TCP port on the local machine by briefly
+// listening on :0 and immediately closing the listener.
+//
+// TOCTOU note: between Close and the subsequent StartPortForward bind, another
+// process can claim the port. There is no fix available without passing a
+// listener socket into the port-forwarder, which the helpers API does not
+// expose. In practice the race window is microseconds on an idle test host;
+// accept it as a known limitation of the test harness.
+func allocateLocalPort() (string, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return "", fmt.Errorf("listen :0: %w", err)
+	}
+	defer func() { _ = l.Close() }()
+	addr := l.Addr().(*net.TCPAddr)
+	return fmt.Sprintf("%d", addr.Port), nil
+}
+
+// postPreservationRequest sends a POST /v1/messages to the router with the
+// given session ID header and body, and returns the response.
+//
+// The caller owns the returned response and MUST call resp.Body.Close() and
+// drain the body before discarding, even on the error path, to avoid leaking
+// the underlying HTTP connection back to the pool unconsumed.
+func postPreservationRequest(
+	ctx context.Context,
+	body preservationRequestBody,
+	sessionID string,
+	localPort string,
+) (*http.Response, error) {
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	url := fmt.Sprintf("http://localhost:%s/v1/messages", localPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// anthropic-version is required by real SDK clients; the router does not
+	// gate on it today but sending it matches the production client contract.
+	req.Header.Set("anthropic-version", "2023-06-01")
+	// x-vsr-test-session-id is the session tracking header used by the shim
+	// to key its per-session request store.
+	req.Header.Set("x-vsr-test-session-id", sessionID)
+
+	httpClient := &http.Client{Timeout: 120 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do: %w", err)
+	}
+	return resp, nil
+}
+
+// fetchShimDebugBody queries the shim's /debug/last-request endpoint for the
+// given session and returns the parsed response. Returns an error if the shim
+// responds with a non-200 status (e.g. 404 = session not seen yet).
+func fetchShimDebugBody(ctx context.Context, shimPort string, sessionID string) (shimDebugResponse, error) {
+	// Query param form: GET /debug/last-request?x-vsr-test-session-id=<id>
+	// Both header and query-param are supported; query param avoids the need
+	// to thread headers through a separate HTTP client setup.
+	url := fmt.Sprintf(
+		"http://localhost:%s/debug/last-request?x-vsr-test-session-id=%s",
+		shimPort,
+		sessionID,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return shimDebugResponse{}, fmt.Errorf("new request: %w", err)
+	}
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return shimDebugResponse{}, fmt.Errorf("do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return shimDebugResponse{}, fmt.Errorf("read: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return shimDebugResponse{}, fmt.Errorf(
+			"shim /debug/last-request returned %d for session %q: %s",
+			resp.StatusCode, sessionID, truncateString(string(raw), 200),
+		)
+	}
+
+	var parsed shimDebugResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return shimDebugResponse{}, fmt.Errorf(
+			"unmarshal shim debug response: %w (body=%s)", err, truncateString(string(raw), 200),
+		)
+	}
+	return parsed, nil
+}
+
+// ── Navigation helpers ────────────────────────────────────────────────────────
+
+// extractFirstContentBlock navigates body.messages[0].content[0] and returns
+// the block as a map. Returns an error if the path does not exist.
+func extractFirstContentBlock(body map[string]interface{}) (map[string]interface{}, error) {
+	messages, err := messagesSlice(body)
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages array is empty")
+	}
+	msg0, ok := messages[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("messages[0] is not an object")
+	}
+	content, err := contentSlice(msg0)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 {
+		return nil, fmt.Errorf("messages[0].content array is empty")
+	}
+	block, ok := content[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("messages[0].content[0] is not an object")
+	}
+	return block, nil
+}
+
+// extractToolResultIsError navigates body.messages[2].content[0].is_error
+// and returns the boolean value. The third message (index 2) is the user
+// turn containing the tool_result block in the is_error test scenario.
+//
+// Returns an error if the is_error field is missing entirely so a maintainer
+// can distinguish "router dropped the field" from "field is present and false".
+func extractToolResultIsError(body map[string]interface{}) (bool, error) {
+	messages, err := messagesSlice(body)
+	if err != nil {
+		return false, err
+	}
+	if len(messages) < 3 {
+		return false, fmt.Errorf("expected at least 3 messages, got %d", len(messages))
+	}
+	msg2, ok := messages[2].(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("messages[2] is not an object")
+	}
+	content, err := contentSlice(msg2)
+	if err != nil {
+		return false, err
+	}
+	if len(content) == 0 {
+		return false, fmt.Errorf("messages[2].content is empty")
+	}
+	block, ok := content[0].(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("messages[2].content[0] is not an object")
+	}
+	raw, present := block["is_error"]
+	if !present {
+		return false, fmt.Errorf("messages[2].content[0].is_error field missing (router may have stripped it)")
+	}
+	isError, ok := raw.(bool)
+	if !ok {
+		return false, fmt.Errorf("messages[2].content[0].is_error is not a bool (got %T)", raw)
+	}
+	return isError, nil
+}
+
+// extractToolResultContent navigates body.messages[2].content[0].content and
+// returns it as a string. After join_tool_result_content the shim stores the
+// collapsed string, so the return type is always string.
+func extractToolResultContent(body map[string]interface{}) (string, error) {
+	messages, err := messagesSlice(body)
+	if err != nil {
+		return "", err
+	}
+	if len(messages) < 3 {
+		return "", fmt.Errorf("expected at least 3 messages, got %d", len(messages))
+	}
+	msg2, ok := messages[2].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("messages[2] is not an object")
+	}
+	content, err := contentSlice(msg2)
+	if err != nil {
+		return "", err
+	}
+	if len(content) == 0 {
+		return "", fmt.Errorf("messages[2].content is empty")
+	}
+	block, ok := content[0].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("messages[2].content[0] is not an object")
+	}
+	raw, ok := block["content"]
+	if !ok {
+		return "", fmt.Errorf("messages[2].content[0].content field missing")
+	}
+	str, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("messages[2].content[0].content is not a string (got %T): shim may not have joined array", raw)
+	}
+	return str, nil
+}
+
+func messagesSlice(body map[string]interface{}) ([]interface{}, error) {
+	raw, ok := body["messages"]
+	if !ok {
+		return nil, fmt.Errorf("messages field missing from shim body")
+	}
+	msgs, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("messages is not an array (got %T)", raw)
+	}
+	return msgs, nil
+}
+
+func contentSlice(msg map[string]interface{}) ([]interface{}, error) {
+	raw, ok := msg["content"]
+	if !ok {
+		return nil, fmt.Errorf("content field missing from message")
+	}
+	content, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("content is not an array (got %T)", raw)
+	}
+	return content, nil
+}
+
+// extractStopSequences reads body.stop_sequences and returns it as a []string.
+// Returns an error if the field is missing (router may have dropped it in the
+// inbound→outbound re-mapping) or is not a JSON array of strings.
+func extractStopSequences(body map[string]interface{}) ([]string, error) {
+	raw, present := body["stop_sequences"]
+	if !present {
+		return nil, fmt.Errorf("stop_sequences field missing from shim body (router may have dropped it)")
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("stop_sequences is not an array (got %T)", raw)
+	}
+	out := make([]string, 0, len(arr))
+	for i, v := range arr {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("stop_sequences[%d] is not a string (got %T)", i, v)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// samplingFieldCase parameterises a numeric sampling-field preservation test
+// (temperature, top_p). The two cases differ only in the field name, the value
+// sent, and which request-body field to populate, so they share one runner.
+type samplingFieldCase struct {
+	label     string                                  // human label for log/error context
+	sessionID string                                  // session-id prefix (a timestamp is appended)
+	field     string                                  // JSON key to read back from the shim body
+	want      float64                                 // value to send and assert verbatim
+	apply     func(*preservationRequestBody, float64) // sets the field on the request body
+}
+
+// runSamplingFieldPreservation drives a numeric sampling-field round-trip: it
+// POSTs a /v1/messages request carrying the field, then asserts the shim
+// received the same numeric value (JSON numbers decode as float64).
+func runSamplingFieldPreservation(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	opts pkgtestcases.TestCaseOptions,
+	c samplingFieldCase,
+) error {
+	if opts.Verbose {
+		fmt.Printf("[Anthropic] Testing %s preservation through /v1/messages translation\n", c.label)
+	}
+
+	routerPort, stopRouter, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopRouter()
+
+	shimPort, stopShim, err := openShimSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopShim()
+
+	sessionID := fmt.Sprintf("%s-%d", c.sessionID, time.Now().UnixNano())
+
+	body := preservationRequestBody{
+		Model:     "MoM",
+		MaxTokens: 32,
+		Messages: []preservationMessage{
+			{Role: "user", Content: []preservationContentBlock{{Type: "text", Text: "Say one word."}}},
+		},
+	}
+	c.apply(&body, c.want)
+
+	resp, err := postPreservationRequest(ctx, body, sessionID, routerPort)
+	if err != nil {
+		return fmt.Errorf("router request: %w", err)
+	}
+	defer resp.Body.Close()
+	rawBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected 200 from router, got %d: %s", resp.StatusCode, truncateString(string(rawBody), 200))
+	}
+
+	debug, err := fetchShimDebugBody(ctx, shimPort, sessionID)
+	if err != nil {
+		return fmt.Errorf("shim debug: %w", err)
+	}
+
+	got, err := extractFloatField(debug.Body, c.field)
+	if err != nil {
+		return fmt.Errorf("extract %s from shim body: %w", c.field, err)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{c.field: got})
+	}
+
+	if got != c.want {
+		return fmt.Errorf("expected %s=%v in shim body, got %v", c.field, c.want, got)
+	}
+	return nil
+}
+
+// extractFloatField reads a top-level numeric field from the shim body.
+// Returns an error if the field is missing (router may have dropped it) or is
+// not a JSON number.
+func extractFloatField(body map[string]interface{}, field string) (float64, error) {
+	raw, present := body[field]
+	if !present {
+		return 0, fmt.Errorf("%s field missing from shim body (router may have dropped it)", field)
+	}
+	f, ok := raw.(float64)
+	if !ok {
+		return 0, fmt.Errorf("%s is not a number (got %T)", field, raw)
+	}
+	return f, nil
+}
+
+// equalStringSlices reports whether two string slices have identical length,
+// elements, and order.
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ── Image-block assertion helpers ─────────────────────────────────────────────
+
+// readImageBlock asserts that block is an Anthropic image content block and
+// returns its source fields. Returns an error if the block type is wrong or
+// the source object is missing/malformed.
+func readImageBlock(block map[string]interface{}) (imageSource, error) {
+	blockType, _ := block["type"].(string)
+	if blockType != "image" {
+		return imageSource{}, fmt.Errorf("expected content[0].type=image, got %q", blockType)
+	}
+	src, ok := block["source"].(map[string]interface{})
+	if !ok {
+		return imageSource{}, fmt.Errorf("expected content[0].source to be an object, got %T", block["source"])
+	}
+	srcType, _ := src["type"].(string)
+	mediaType, _ := src["media_type"].(string)
+	data, _ := src["data"].(string)
+	return imageSource{Type: srcType, MediaType: mediaType, Data: data}, nil
+}
+
+// assertImageSourceEqual compares the three fields of an Anthropic image
+// source struct and returns a descriptive error on the first mismatch.
+func assertImageSourceEqual(want, got imageSource) error {
+	if got.Type != want.Type {
+		return fmt.Errorf("expected source.type=%q, got %q", want.Type, got.Type)
+	}
+	if got.MediaType != want.MediaType {
+		return fmt.Errorf("expected source.media_type=%q, got %q", want.MediaType, got.MediaType)
+	}
+	if got.Data != want.Data {
+		return fmt.Errorf("expected source.data to match tinyPNG1x1, got %q", truncateString(got.Data, 80))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Eight strong-assertion e2e tests verifying that request-side fields survive the Anthropic→Anthropic translation path through the router and reach the `anthropic-shim` backend verbatim. Each test inspects what the shim received via its `/debug/last-request` endpoint (introduced in #1940).
- Registered in `AnthropicShimContract`; runs under the `anthropic-shim` profile.
- Why: complements the contract surface that #1940 deployed by exercising field preservation across the request-translation path.
- Risk: low — test-only addition; cannot affect production code paths.

## Scenarios covered
- **image block survival** — base64 PNG block reaches shim with `type`, `source.type`, `source.media_type`, `source.data` all intact.
- **top_k preservation** — `top_k=40` reaches upstream AND response carries no `x-vsr-lossiness-warnings` (Anthropic-shaped backend must not drop it).
- **metadata.user_id preservation** — survives translation verbatim.
- **tool_result.is_error preservation** — `is_error=true` not stripped during routing.
- **tool_result array content** — multi-block content array forwarded; assertion checks the newline-joined form the shim records.
- **stop_sequences round-trip** — mapped into the OpenAI IR `Stop` field inbound and back to Anthropic `StopSequences` outbound; asserted verbatim.
- **temperature / top_p round-trip** — both numeric sampling fields map through the OpenAI IR (`applyNumericSampling` inbound, `applySampling` outbound) with no scaling; each asserted verbatim at the shim.

## Test plan
- `make agent-lint CHANGED_FILES="<paths>"` (vet, fmt, golangci-lint, codespell): pass locally
- CI on push runs the `anthropic-shim` profile end-to-end against a real kind cluster
- Each test is self-contained (opens its own port-forwards, cleans up via `defer`)

## File layout
- `e2e/testcases/anthropic_messages_request_preservation.go` — eight test functions
- `e2e/testcases/anthropic_messages_request_preservation_helpers.go` — shared types, infra/navigation/assertion helpers, split out to keep the main test file under the project's 800-line cap
- `e2e/pkg/testmatrix/testcases.go` — adds eight test names to `AnthropicShimContract`

## Status
Kept in draft to avoid pulling reviewer attention from in-flight #1941 (streaming emitter). Will mark ready for review after #1941 is reviewed/merged.