### PR TITLE
fix/streaming-chunks-memory-accumulation

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
@@ -21,7 +21,7 @@ func (r *OpenAIRouter) handleStreamingResponseBody(
 	ensureStreamingState(ctx)
 
 	chunk := string(responseBody)
-	ctx.StreamingChunks = append(ctx.StreamingChunks, chunk)
+	ctx.HasStreamingChunks = true
 	r.parseStreamingChunk(chunk, ctx)
 
 	if strings.Contains(chunk, "data: [DONE]") {
@@ -54,9 +54,6 @@ func recordStreamingTTFT(ctx *RequestContext) {
 }
 
 func ensureStreamingState(ctx *RequestContext) {
-	if ctx.StreamingChunks == nil {
-		ctx.StreamingChunks = make([]string, 0)
-	}
 	if ctx.StreamingMetadata == nil {
 		ctx.StreamingMetadata = make(map[string]interface{})
 	}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -39,7 +39,7 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 	}
 
 	chunkStr := string(transformed)
-	ctx.StreamingChunks = append(ctx.StreamingChunks, chunkStr)
+	ctx.HasStreamingChunks = true
 	r.parseStreamingChunk(chunkStr, ctx)
 
 	if strings.Contains(chunkStr, "data: [DONE]") || streamDone {

--- a/src/semantic-router/pkg/extproc/replay_tool_trace.go
+++ b/src/semantic-router/pkg/extproc/replay_tool_trace.go
@@ -297,7 +297,7 @@ func buildReplayResponseToolTrace(
 	if ctx == nil {
 		return nil
 	}
-	if len(ctx.StreamingChunks) > 0 || len(ctx.StreamingToolCalls) > 0 {
+	if ctx.HasStreamingChunks || len(ctx.StreamingToolCalls) > 0 {
 		return buildReplayStreamingToolTrace(ctx)
 	}
 	if isResponseAPIRequest(ctx) {

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -72,7 +72,7 @@ type RequestContext struct {
 	StreamedBody *StreamedBodyHandler
 
 	// Streaming accumulation for caching
-	StreamingChunks    []string                        // Accumulated SSE chunks
+	HasStreamingChunks bool                            // True when at least one SSE chunk has been received
 	StreamingContent   string                          // Accumulated content from delta.content
 	StreamingMetadata  map[string]interface{}          // id, model, created from first chunk
 	StreamingToolCalls map[int]*StreamingToolCallState // Accumulated delta.tool_calls keyed by tool index


### PR DESCRIPTION
## Problem

The request context maintained a `StreamingChunks []string` field that stored every raw SSE chunk received during a streaming response. This occurred on both the OpenAI and Anthropic streaming paths.

Each entry contained the full `data: {...}` JSON payload, and the slice continued growing for the entire lifetime of the request. However, the accumulated chunk data was never actually consumed during finalization.

The only usage of `StreamingChunks` was a presence check in `replay_tool_trace.go`:

```go
if len(ctx.StreamingChunks) > 0 || len(ctx.StreamingToolCalls) > 0 {
```

All downstream consumers already rely on data captured incrementally during streaming via:

- `StreamingContent`
- `StreamingMetadata`
- `StreamingToolCalls`

As a result, `StreamingChunks` served only as a signal that streaming data had been observed, while retaining all raw SSE payloads in memory until the stream completed.

## Impact

Because the slice retained every chunk for the duration of the request, memory usage scaled linearly with response size.

Impact:

Under concurrent streaming workloads, this can translate to tens of megabytes of unnecessary memory retention. The continuously growing slice also introduces additional allocations and GC overhead throughout the stream.

## Solution

Replace the `StreamingChunks []string` field with a lightweight boolean flag:

```go
HasStreamingChunks bool
```

Since the only consumer checked whether any chunks had been received, a boolean preserves the exact behavior without retaining the raw chunk data.

### Changes

- Replaced `StreamingChunks []string` with `HasStreamingChunks bool` in `RequestContext`
- Replaced all chunk append operations with:

```go
ctx.HasStreamingChunks = true
```

- Removed unnecessary `StreamingChunks` initialization in `ensureStreamingState`
- Updated finalization logic to use the boolean flag instead of checking slice length

## Result

- Eliminates accumulation of unused SSE chunk data
- Reduces memory retained for long-running streams
- Avoids slice growth and associated allocations
- Lowers GC pressure under high concurrency
- Preserves existing behavior with no functional changes