### PR TITLE
[CI/Build] Match Helm v4 schema-rejection wording in helm-safety-validate

### DIFF
--- a/tools/make/helm.mk
+++ b/tools/make/helm.mk
@@ -175,7 +175,7 @@ helm-safety-validate: helm-ci-setup
 		cat "$$tmp_dir/invalid-guard.out"; \
 		exit 1; \
 	fi; \
-	grep -q "safetyGuards.rejectMultiReplicaLocalSelectorState: Invalid type" "$$tmp_dir/invalid-guard.out"; \
+	grep -Eq "rejectMultiReplicaLocalSelectorState.*(Invalid type|want boolean)" "$$tmp_dir/invalid-guard.out"; \
 	echo "Validating schema rejection for invalid replicaCount type..."; \
 	if helm template $(HELM_RELEASE_NAME) $(HELM_CHART_PATH) \
 		--set replicaCount=oops \
@@ -184,7 +184,7 @@ helm-safety-validate: helm-ci-setup
 		cat "$$tmp_dir/invalid-replica.out"; \
 		exit 1; \
 	fi; \
-	grep -q "replicaCount: Invalid type" "$$tmp_dir/invalid-replica.out"; \
+	grep -Eq "replicaCount.*(Invalid type|want integer)" "$$tmp_dir/invalid-replica.out"; \
 	echo "Validating RL-driven selector local-state multi-replica rejection..."; \
 	if helm template $(HELM_RELEASE_NAME) $(HELM_CHART_PATH) \
 		--set autoscaling.enabled=false \


### PR DESCRIPTION
## Purpose

- `make helm-safety-validate` asserts the chart's JSON schema rejects invalid `safetyGuards.rejectMultiReplicaLocalSelectorState` and `replicaCount` values. The two assertions grepped for Helm v3's error phrasing (`"<field>: Invalid type"`). Helm v4 reworded the schema error to `at '/<path>': got string, want <type>`, so both assertions fail when the target is run under a Helm v4 toolchain, even though the schema rejection itself still fires correctly.
- This is a local-developer target. CI pins `HELM_VERSION: v3.14.0` and runs `make helm-ci-validate` (which does not depend on `helm-safety-validate`), so CI is unaffected today. The fix makes the assertions tolerant of Helm v4's reworded errors so contributors who have moved to Helm v4 locally can run the target.
- Module: `CI/Build`.

## Test Plan

- Run `make helm-safety-validate` on Helm v4.
- Confirm the two invalid-type cases still make `helm template` exit non-zero and that the greps match the v4 error strings.

## Test Result

- Captured the actual Helm v4 error strings locally (Helm v4.1.4):
  - `at '/safetyGuards/rejectMultiReplicaLocalSelectorState': got string, want boolean`
  - `at '/replicaCount': got string, want integer`
- Before the fix, the two invalid-type assertions failed on these strings under Helm v4 (they matched only the v3 `Invalid type` wording).
- After: `make helm-safety-validate` completes with `[SUCCESS] Helm safety validation completed successfully` on Helm v4.1.4. Both greps now use `grep -Eq` with an alternation (`Invalid type|want boolean` and `Invalid type|want integer`), retaining the v3 wording by construction so the target stays compatible with the Helm v3.14.0 toolchain CI pins (v3 not separately executed in this pass).
