### PR TITLE
[Dashboard] Helm chart: harden against multi-writer SQLite corruption

### DIFF
--- a/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
+++ b/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
@@ -1,6 +1,11 @@
 {{- if and .Values.dashboard.enabled (gt (int .Values.dashboard.replicaCount) 1) }}
 {{- fail "dashboard.replicaCount > 1 is not supported with the current SQLite auth/session store; use one dashboard replica until a shared auth/session store is configured" }}
 {{- end }}
+{{- if and .Values.dashboard.enabled .Values.dashboard.persistence.enabled }}
+{{- if not (has .Values.dashboard.persistence.accessMode (list "ReadWriteOnce" "ReadWriteOncePod")) }}
+{{- fail "dashboard.persistence.accessMode must be ReadWriteOnce or ReadWriteOncePod: the dashboard's SQLite auth/session store requires single-writer access. ReadWriteMany would allow concurrent writers and corrupt the database" }}
+{{- end }}
+{{- end }}
 {{- if .Values.dashboard.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -12,6 +17,11 @@ metadata:
     app.kubernetes.io/component: dashboard
 spec:
   replicas: {{ .Values.dashboard.replicaCount }}
+  # Recreate (not RollingUpdate): the SQLite auth/session store is single-writer,
+  # so the old pod must fully terminate and release the PVC before the new pod
+  # starts. RollingUpdate would briefly run two pods writing the same database.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "semantic-router.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/semantic-router/values.schema.json
+++ b/deploy/helm/semantic-router/values.schema.json
@@ -103,7 +103,8 @@
         },
         "replicaCount": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 1
         },
         "persistence": {
           "type": "object",


### PR DESCRIPTION
## Purpose

- The dashboard auth/session/workflow store is single-writer SQLite on a local PVC. Two concurrent writers (from `replicaCount > 1`, or from a rolling update briefly overlapping the old and new pod) corrupt the database silently.
- The chart already fails the render when `dashboard.replicaCount > 1`. This adds the rest of a layered guard:
  - `values.schema.json` caps `dashboard.replicaCount` at `maximum: 1` so Helm rejects an unsupported value at install/upgrade time (the existing template `fail` stays as a backstop for when values-schema validation is bypassed, e.g. `--skip-schema-validation`).
  - The dashboard Deployment sets `strategy.type: Recreate` so the old pod fully terminates and releases the PVC before the new pod starts, instead of RollingUpdate's transient two-pod overlap.
  - A template guard fails the render when persistence is enabled with an `accessMode` other than `ReadWriteOnce`/`ReadWriteOncePod`, since `ReadWriteMany` would permit concurrent attach and defeat the single-writer guarantee.
- `strategy.type: Recreate` introduces a brief dashboard restart gap on upgrade (the old pod must fully terminate and release the PVC before the new one starts). For a single-replica, non-HA dashboard this is the intended cost of guaranteeing single-writer PVC access.
- Module: `Dashboard` (Helm chart). The `maximum: 1` and `Recreate` follow the chart's documented split (schema validates types/bounds; templates emit cross-field safety errors).

## Test Plan

- `helm template --set dashboard.enabled=true` - default render gets `strategy.type: Recreate`, no fail.
- `helm template --set dashboard.replicaCount=2` - schema rejects.
- `helm template --set dashboard.persistence.enabled=true --set dashboard.persistence.accessMode=ReadWriteMany` - template fail fires.
- `helm template --set dashboard.persistence.enabled=true` (default RWO) - renders normally.
- `helm lint`.

## Test Result

- Default render: `strategy.type: Recreate` present on the dashboard Deployment; no error.
- `dashboard.replicaCount=2`: rejected at install time with `at '/dashboard/replicaCount': maximum: got 2, want 1`.
- `accessMode=ReadWriteMany` with persistence enabled: render fails with `dashboard.persistence.accessMode must be ReadWriteOnce or ReadWriteOncePod: ... ReadWriteMany would allow concurrent writers and corrupt the database`.
- `accessMode=ReadWriteOnce` (default) with persistence enabled: renders normally (router + dashboard Deployments).
- `helm lint`: `1 chart(s) linted, 0 chart(s) failed`.
- `replicaCount: 0` remains allowed (schema `minimum: 0`), so an operator can still scale the dashboard Deployment to zero without disabling it; only `> 1` is blocked.
- Note: `make helm-safety-validate` currently trips on this branch at an unrelated step (a stale Helm v3 grep that does not recognize Helm v4's reworded schema errors). That staleness is fixed independently and is not caused by this change; the dashboard behaviors above were validated via targeted `helm template` renders plus `helm lint`.
