### PR TITLE
[Dashboard] Helm chart: document, schema-validate, and guard dashboard.podSecurityContext

### DIFF
--- a/deploy/helm/semantic-router/README.md
+++ b/deploy/helm/semantic-router/README.md
@@ -136,6 +136,7 @@ the locked chart dependencies.
 | dashboard.persistence.mountPath | string | `"/app/data"` | Container mount path for dashboard-local state |
 | dashboard.persistence.size | string | `"1Gi"` | Requested dashboard-local state size |
 | dashboard.persistence.storageClassName | string | `""` | Storage class name. Leave empty for the cluster default; use "-" to render storageClassName: "". |
+| dashboard.podSecurityContext | object | `{"fsGroup":65532}` | Pod-level security context. The default fsGroup matches the non-root user (UID/GID 65532) baked into the upstream dashboard image, ensuring the persistence PVC mount at /app/data is writable by the binary. Without this, the dashboard crashloops with "unable to open database file" when persistence is enabled on storage classes that mount as root:root 0755 (which is the default behavior for most cloud-provider CSI drivers). Override if you build a custom dashboard image with a different non-root UID. |
 | dashboard.readonly | bool | `false` | Run dashboard in read-only mode |
 | dashboard.replicaCount | int | `1` | Dashboard replica count. Must stay 1 until the dashboard auth/session store supports a shared multi-replica backend. |
 | dashboard.resources.limits | object | `{"cpu":"500m","memory":"512Mi"}` |  |

--- a/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
+++ b/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
@@ -7,6 +7,14 @@
 {{- end }}
 {{- end }}
 {{- if .Values.dashboard.enabled }}
+{{- $psc := .Values.dashboard.podSecurityContext | default dict }}
+{{- if kindIs "map" $psc }}
+{{- if or (dig "runAsNonRoot" false $psc | toString | eq "true") (and (hasKey $psc "runAsUser") (ne (int (dig "runAsUser" 0 $psc)) 0)) }}
+{{- fail "dashboard.podSecurityContext must let the container start as root (UID 0): the dashboard image entrypoint starts as root to fix ownership of the mounted config file and then drops to the nonroot user (UID 65532) via gosu. Setting runAsNonRoot: true or runAsUser to a non-zero value prevents the root start and the container will fail; this pod is therefore incompatible with the PodSecurity 'restricted' profile. Use a custom image with a true non-root entrypoint if you require non-root start" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.dashboard.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/semantic-router/values.schema.json
+++ b/deploy/helm/semantic-router/values.schema.json
@@ -129,6 +129,15 @@
               "type": "string"
             }
           }
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "fsGroup": {
+              "type": "integer"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Purpose

- `dashboard.podSecurityContext` already ships in `values.yaml` (`fsGroup: 65532`, matching the non-root UID baked into the dashboard image), but it was neither in `values.schema.json` nor documented in the chart README, and nothing guarded the one setting that breaks the image's startup. This PR documents, schema-validates, and guards the field.
- **Schema + docs:** adds `dashboard.podSecurityContext` to `values.schema.json` (object with an integer `fsGroup`, `additionalProperties: true` so operators can set the full PodSecurityContext surface) and adds the generated README row explaining why the `fsGroup` default matters for PVC ownership when persistence is enabled.
- **Guard:** adds a template guard that fails the render with an explanatory message when `podSecurityContext` would forbid the container's root start. The dashboard image entrypoint starts as root to fix ownership of the mounted config file, then drops to UID 65532 via `gosu`; setting `runAsNonRoot: true` or a non-zero `runAsUser` prevents that and the container fails to launch. Failing at render time turns a runtime crashloop into a clear message.
- The two commits pair intentionally: the schema admits the field, the guard rejects the values that break the `gosu` entrypoint.
- Module: `Dashboard` (Helm chart).

## Test Plan

- `helm template` with dashboard enabled (default) - renders, `fsGroup: 65532` present, no fail.
- `runAsNonRoot: true` and `runAsUser: 1000` - render fails with the explanatory message.
- `runAsUser: 0`, and `runAsNonRoot` set to the string `"false"` - render succeeds (no false positive).
- non-integer `fsGroup` - rejected by the schema.
- `helm lint`.

## Test Result

- Default render: `fsGroup: 65532` present, `strategy.type: Recreate` present (unchanged from the merged replicaCount guard), no error.
- `runAsNonRoot: true` and `runAsUser: 1000`: render fails with the root-start/`gosu` message.
- `runAsNonRoot` set to the string `"false"`: renders (the guard coerces to string and matches only `"true"`, so it does not false-positive). `runAsUser: 0`: renders.
- Non-integer `fsGroup`: rejected by schema validation as a non-integer type (exact wording is Helm-version dependent).
- `helm lint`: `1 chart(s) linted, 0 chart(s) failed`.
- Validated on the branch rebased onto current `upstream/main`, so the new guard layers cleanly on top of the already-merged `replicaCount` / accessMode guards (replicaCount=2 still rejected).
