### PR TITLE
[Docs] Fix the hover style for the GitHub Models link

### DIFF
--- a/website/src/css/shell.css
+++ b/website/src/css/shell.css
@@ -136,6 +136,15 @@
   box-shadow: none;
 }
 
+.navbar__item.navbar__link.nav-utility:hover,
+.navbar__item.navbar__link.nav-utility:focus-visible,
+.navbar__items--right > .navbar__item.navbar__link.nav-utility:hover,
+.navbar__items--right > .navbar__item.navbar__link.nav-utility:focus-visible {
+  background: var(--site-text);
+  color: var(--site-bg);
+  border-color: var(--site-text);
+}
+
 html[data-route-kind='home'] .nav-docs-only,
 html[data-route-kind='page'] .nav-docs-only,
 html[data-route-kind='blog'] .nav-docs-only {


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2054

## Test Plan

Works fine locally:

Before:

<img width="786" height="272" alt="image" src="https://github.com/user-attachments/assets/02d15d79-8a5d-4b3b-89de-9fcd41f644ab" />

After:

<img width="1062" height="332" alt="image" src="https://github.com/user-attachments/assets/fb7bf63d-1af1-4a70-8a12-8f43820ba5c2" />


## Test Result

All works fine.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
