### PR TITLE
[Dashboard] Helm chart: support a stable DASHBOARD_JWT_SECRET via existingSecret

### DIFF
--- a/deploy/helm/semantic-router/README.md
+++ b/deploy/helm/semantic-router/README.md
@@ -129,6 +129,9 @@ the locked chart dependencies.
 | dashboard.image.pullPolicy | string | `"IfNotPresent"` | Dashboard image pull policy |
 | dashboard.image.repository | string | `"ghcr.io/vllm-project/semantic-router/dashboard"` | Dashboard image repository |
 | dashboard.image.tag | string | `"latest"` | Dashboard image tag |
+| dashboard.jwtSecret | object | `{"existingSecret":"","existingSecretKey":"jwt-secret"}` | JWT signing secret for dashboard auth sessions. Point this at a Secret you manage (ideally an ExternalSecret) so the signing key is stable. If you leave it unset, the dashboard binary falls back to generating a random secret on every pod start, which invalidates all login sessions on each restart (rolling update, chart bump, or node move forces a re-login). A zero-config install still works (the random fallback is a valid signing key, you can log in and use the dashboard); you just lose existing sessions whenever the pod restarts, so leaving it unset is fine for demos but set this for any deployment where sessions need to survive restarts. |
+| dashboard.jwtSecret.existingSecret | string | `""` | Name of an existing Secret holding the JWT signing key. When set, the dashboard reads DASHBOARD_JWT_SECRET from it via secretKeyRef. When empty, no env is injected and the binary uses its per-start random fallback. |
+| dashboard.jwtSecret.existingSecretKey | string | `"jwt-secret"` | Key within existingSecret holding the JWT signing secret. |
 | dashboard.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the dashboard-local state PVC |
 | dashboard.persistence.annotations | object | `{}` | Annotations for the dashboard-local state PVC |
 | dashboard.persistence.enabled | bool | `false` | Persist dashboard-local SQLite state for auth/session/workflow data. This is restart-safe for one dashboard replica, not a shared HA session store. |

--- a/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
+++ b/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
@@ -59,6 +59,13 @@ spec:
           value: "http://{{ include "semantic-router.fullname" . }}:{{ .Values.service.api.port }}"
         - name: TARGET_ROUTER_METRICS_URL
           value: "http://{{ include "semantic-router.fullname" . }}-metrics:{{ .Values.service.metrics.port }}/metrics"
+        {{- if .Values.dashboard.jwtSecret.existingSecret }}
+        - name: DASHBOARD_JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.dashboard.jwtSecret.existingSecret }}
+              key: {{ .Values.dashboard.jwtSecret.existingSecretKey }}
+        {{- end }}
         {{- if .Values.dashboard.readonly }}
         - name: DASHBOARD_READONLY
           value: "true"

--- a/deploy/helm/semantic-router/values.schema.json
+++ b/deploy/helm/semantic-router/values.schema.json
@@ -138,6 +138,18 @@
               "type": "integer"
             }
           }
+        },
+        "jwtSecret": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "existingSecret": {
+              "type": "string"
+            },
+            "existingSecretKey": {
+              "type": "string"
+            }
+          }
         }
       }
     }

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -527,6 +527,22 @@ dashboard:
     pullPolicy: IfNotPresent
   # -- Run dashboard in read-only mode
   readonly: false
+  # -- JWT signing secret for dashboard auth sessions. Point this at a Secret you
+  # manage (ideally an ExternalSecret) so the signing key is stable. If you leave
+  # it unset, the dashboard binary falls back to generating a random secret on
+  # every pod start, which invalidates all login sessions on each restart (rolling
+  # update, chart bump, or node move forces a re-login). A zero-config install
+  # still works (the random fallback is a valid signing key, you can log in and
+  # use the dashboard); you just lose existing sessions whenever the pod
+  # restarts, so leaving it unset is fine for demos but set this for any
+  # deployment where sessions need to survive restarts.
+  jwtSecret:
+    # -- Name of an existing Secret holding the JWT signing key. When set, the
+    # dashboard reads DASHBOARD_JWT_SECRET from it via secretKeyRef. When empty,
+    # no env is injected and the binary uses its per-start random fallback.
+    existingSecret: ""
+    # -- Key within existingSecret holding the JWT signing secret.
+    existingSecretKey: "jwt-secret"
   # -- Pod-level security context. The default fsGroup matches the non-root user
   # (UID/GID 65532) baked into the upstream dashboard image, ensuring the
   # persistence PVC mount at /app/data is writable by the binary. Without this,


### PR DESCRIPTION
## Purpose

- The dashboard auth service generates a random JWT signing secret on startup when `DASHBOARD_JWT_SECRET` is empty (`dashboard/backend/auth/service.go`), so every pod restart invalidates all login sessions. The chart had no way to set that env at all, so the binary always used the ephemeral fallback.
- Add `dashboard.jwtSecret.existingSecret` / `existingSecretKey`: when set, the dashboard reads `DASHBOARD_JWT_SECRET` from an operator-managed Secret (ideally an ExternalSecret) via `secretKeyRef`, giving a stable signing key across restarts and upgrades. When unset, no env is injected and the binary keeps its per-start random fallback, so a zero-config install still works (sessions just reset whenever the pod restarts).
- The chart creates no Secret of its own, keeping its reference-external-secret convention (no orphan-on-uninstall question). An auto-generating variant that mints and reuses a chart-managed Secret was kept out of this PR to stay right-sized and avoid introducing the chart's first generated Secret; it is available on request.
- Module: `Dashboard` (Helm chart). Documented in `values.yaml`, `values.schema.json`, and the README.

## Test Plan

- `helm template --set dashboard.enabled=true` - default render injects no `DASHBOARD_JWT_SECRET` env and creates no Secret.
- `helm template --set dashboard.jwtSecret.existingSecret=my-jwt --set dashboard.jwtSecret.existingSecretKey=k` - env wired via `secretKeyRef` to the operator Secret.
- `helm lint`.

## Test Result

- Default render (dashboard enabled, no `existingSecret`): 0 occurrences of `DASHBOARD_JWT_SECRET` and no chart-created Secret; the binary keeps its ephemeral fallback, so the install is unaffected.
- With `existingSecret=my-jwt, existingSecretKey=k`: the dashboard env `DASHBOARD_JWT_SECRET` resolves via `secretKeyRef` to `{name: my-jwt, key: k}`; no chart-created Secret.
- `helm lint`: `1 chart(s) linted, 0 chart(s) failed`.
- Validated on the branch rebased onto current `upstream/main` (post #2046 / #2047 merge), so the env block layers cleanly on the merged dashboard guards.
