### PR TITLE
[Dashboard] Gate the open bootstrap endpoint behind an opt-in and close the first-admin race

### DIFF
--- a/dashboard/backend/auth/bootstrap_gate_test.go
+++ b/dashboard/backend/auth/bootstrap_gate_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newBootstrapService(t *testing.T, allowOpen bool) *Service {
+	t.Helper()
+	svc := newTestAuthService(t)
+	svc.SetAllowOpenBootstrap(allowOpen)
+	return svc
+}
+
+func canRegister(t *testing.T, svc *Service) bool {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	bootstrapCanRegisterHandler(svc)(rec, httptest.NewRequest(http.MethodGet, "/api/auth/bootstrap/can-register", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("can-register status = %d, want 200", rec.Code)
+	}
+	var resp BootstrapStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode can-register: %v", err)
+	}
+	return resp.CanRegister
+}
+
+func postRegister(svc *Service, email string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	body := fmt.Sprintf(`{"email":%q,"password":"secret-password","name":"Admin"}`, email)
+	bootstrapRegisterHandler(svc)(rec, httptest.NewRequest(http.MethodPost, "/api/auth/bootstrap/register", strings.NewReader(body)))
+	return rec
+}
+
+// With open bootstrap disabled (the default), can-register must report false even
+// when no users exist - both to disable the path and to avoid leaking to an
+// unauthenticated caller that the instance is freshly deployed and claimable.
+func TestBootstrapCanRegister_DisabledByDefaultReportsFalse(t *testing.T) {
+	svc := newBootstrapService(t, false)
+	if canRegister(t, svc) {
+		t.Fatal("canRegister = true with open bootstrap disabled; want false")
+	}
+}
+
+func TestBootstrapCanRegister_EnabledTracksUserCount(t *testing.T) {
+	svc := newBootstrapService(t, true)
+	if !canRegister(t, svc) {
+		t.Fatal("canRegister = false with open bootstrap enabled and no users; want true")
+	}
+	newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
+	if canRegister(t, svc) {
+		t.Fatal("canRegister = true after an admin exists; want false")
+	}
+}
+
+// The open register endpoint must be closed by default and must not create a user.
+func TestBootstrapRegister_DisabledByDefaultForbidden(t *testing.T) {
+	svc := newBootstrapService(t, false)
+	rec := postRegister(svc, "admin@example.com")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 when open bootstrap disabled", rec.Code)
+	}
+	if n, _ := svc.store.CountUsers(context.Background()); n != 0 {
+		t.Fatalf("created %d users while disabled; want 0", n)
+	}
+}
+
+func TestBootstrapRegister_EnabledCreatesFirstAdmin(t *testing.T) {
+	svc := newBootstrapService(t, true)
+	rec := postRegister(svc, "admin@example.com")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if n, _ := svc.store.CountUsers(context.Background()); n != 1 {
+		t.Fatalf("user count = %d, want 1", n)
+	}
+}
+
+func TestBootstrapRegister_SecondAttemptConflict(t *testing.T) {
+	svc := newBootstrapService(t, true)
+	newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
+	rec := postRegister(svc, "second@example.com")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 when an admin already exists", rec.Code)
+	}
+}
+
+// The race fix: concurrent register requests must produce exactly one admin.
+func TestBootstrapRegister_ConcurrentCreatesExactlyOneAdmin(t *testing.T) {
+	svc := newBootstrapService(t, true)
+	const n = 16
+	var wg sync.WaitGroup
+	codes := make([]int, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			codes[i] = postRegister(svc, fmt.Sprintf("user%d@example.com", i)).Code
+		}(i)
+	}
+	wg.Wait()
+
+	if count, _ := svc.store.CountUsers(context.Background()); count != 1 {
+		t.Fatalf("concurrent bootstrap created %d users; want exactly 1 (race not closed)", count)
+	}
+	ok := 0
+	for _, c := range codes {
+		if c == http.StatusOK {
+			ok++
+		}
+	}
+	if ok != 1 {
+		t.Fatalf("got %d successful registrations; want exactly 1", ok)
+	}
+}

--- a/dashboard/backend/auth/public_handlers.go
+++ b/dashboard/backend/auth/public_handlers.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 )
@@ -10,6 +11,14 @@ func bootstrapCanRegisterHandler(svc *Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// When the open web-form bootstrap is disabled, always report false. This
+		// also avoids leaking to unauthenticated callers whether the instance is
+		// freshly deployed and claimable.
+		if !svc.OpenBootstrapEnabled() {
+			respondJSON(w, BootstrapStatusResponse{CanRegister: false})
 			return
 		}
 
@@ -30,6 +39,11 @@ func bootstrapRegisterHandler(svc *Service) http.HandlerFunc {
 			return
 		}
 
+		if !svc.OpenBootstrapEnabled() {
+			http.Error(w, "open bootstrap is disabled; provision an admin via DASHBOARD_ADMIN_* or set DASHBOARD_ALLOW_OPEN_BOOTSTRAP=true to enable web-form bootstrap", http.StatusForbidden)
+			return
+		}
+
 		var req BootstrapRegistrationRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid body", http.StatusBadRequest)
@@ -40,23 +54,19 @@ func bootstrapRegisterHandler(svc *Service) http.HandlerFunc {
 			return
 		}
 
-		allowed, err := svc.CanBootstrap(r.Context())
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if !allowed {
-			http.Error(w, "bootstrap is disabled", http.StatusConflict)
-			return
-		}
-
 		hash, err := svc.HashPassword(req.Password)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		user, err := svc.store.CreateUser(r.Context(), req.Email, req.Name, hash, RoleAdmin, "active")
+		// Atomic check-and-create: only one admin can be created via this path even
+		// under concurrent requests (see Service.BootstrapRegister).
+		user, err := svc.BootstrapRegister(r.Context(), req.Email, req.Name, hash)
+		if errors.Is(err, ErrBootstrapClosed) {
+			http.Error(w, "bootstrap is disabled", http.StatusConflict)
+			return
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/dashboard/backend/auth/service.go
+++ b/dashboard/backend/auth/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -19,7 +20,19 @@ type Service struct {
 	store       *Store
 	jwtSecret   []byte
 	ttlDuration time.Duration
+
+	// allowOpenBootstrap gates the public web-form bootstrap endpoint (off by default).
+	allowOpenBootstrap bool
+	// bootstrapMu serializes the check-then-create in BootstrapRegister so that two
+	// concurrent requests cannot both pass the "no users yet" check and each create an
+	// admin. The dashboard runs single-replica (enforced by the chart's replicaCount
+	// guard), so a process-level mutex is sufficient; a multi-writer deployment would
+	// need a transactional guard in the store instead.
+	bootstrapMu sync.Mutex
 }
+
+// ErrBootstrapClosed is returned by BootstrapRegister when an admin already exists.
+var ErrBootstrapClosed = errors.New("bootstrap is disabled")
 
 type TokenClaims struct {
 	UserID string `json:"userId"`
@@ -38,6 +51,29 @@ func NewService(store *Store, secret string, ttlHours int) *Service {
 		secret = base64.RawStdEncoding.EncodeToString(b)
 	}
 	return &Service{store: store, jwtSecret: []byte(secret), ttlDuration: time.Duration(ttlHours) * time.Hour}
+}
+
+// SetAllowOpenBootstrap toggles the public web-form bootstrap endpoint.
+func (s *Service) SetAllowOpenBootstrap(v bool) { s.allowOpenBootstrap = v }
+
+// OpenBootstrapEnabled reports whether the public web-form bootstrap endpoint is enabled.
+func (s *Service) OpenBootstrapEnabled() bool { return s.allowOpenBootstrap }
+
+// BootstrapRegister atomically creates the first admin. The "no users yet" check and
+// the create run under bootstrapMu, so two concurrent requests cannot each create an
+// admin (closing the time-of-check-to-time-of-use race in the public bootstrap path).
+// Returns ErrBootstrapClosed if any user already exists.
+func (s *Service) BootstrapRegister(ctx context.Context, email, name, hash string) (*User, error) {
+	s.bootstrapMu.Lock()
+	defer s.bootstrapMu.Unlock()
+	ok, err := s.CanBootstrap(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrBootstrapClosed
+	}
+	return s.store.CreateUser(ctx, email, defaultAdminName(name), hash, RoleAdmin, "active")
 }
 
 func (s *Service) HashPassword(password string) (string, error) {

--- a/dashboard/backend/config/config.go
+++ b/dashboard/backend/config/config.go
@@ -35,6 +35,11 @@ type Config struct {
 	ReadonlyMode bool
 	SetupMode    bool
 
+	// AllowOpenBootstrap enables first-admin creation via the public, unauthenticated
+	// web-form bootstrap endpoint. Off by default; production should provision the
+	// admin via DASHBOARD_ADMIN_* instead of exposing an open registration path.
+	AllowOpenBootstrap bool
+
 	// Platform branding (e.g., "amd" for AMD GPU deployments)
 	Platform string
 
@@ -127,6 +132,7 @@ type parsedFlags struct {
 	fleetSimURL          *string
 	readonlyMode         *bool
 	setupMode            *bool
+	allowOpenBootstrap   *bool
 	platform             *string
 	evaluationEnabled    *bool
 	evaluationDBPath     *string
@@ -155,6 +161,7 @@ func applyCoreConfig(cfg *Config, flags parsedFlags) {
 	cfg.FleetSimURL = *flags.fleetSimURL
 	cfg.ReadonlyMode = *flags.readonlyMode
 	cfg.SetupMode = *flags.setupMode
+	cfg.AllowOpenBootstrap = *flags.allowOpenBootstrap
 	cfg.Platform = *flags.platform
 }
 
@@ -224,6 +231,7 @@ func LoadConfig() (*Config, error) {
 	// Read-only mode for public beta deployments
 	readonlyMode := flag.Bool("readonly", env("DASHBOARD_READONLY", "false") == "true", "enable read-only mode (disable config editing)")
 	setupMode := flag.Bool("setup-mode", env("DASHBOARD_SETUP_MODE", "false") == "true", "enable dashboard setup mode")
+	allowOpenBootstrap := flag.Bool("allow-open-bootstrap", env("DASHBOARD_ALLOW_OPEN_BOOTSTRAP", "false") == "true", "allow first-admin creation via the public web-form bootstrap endpoint (off by default; production should provision the admin via DASHBOARD_ADMIN_*)")
 
 	// Platform branding
 	platform := flag.String("platform", env("DASHBOARD_PLATFORM", ""), "platform branding (e.g., 'amd' for AMD GPU deployments)")
@@ -263,6 +271,7 @@ func LoadConfig() (*Config, error) {
 		fleetSimURL:          fleetSimURL,
 		readonlyMode:         readonlyMode,
 		setupMode:            setupMode,
+		allowOpenBootstrap:   allowOpenBootstrap,
 		platform:             platform,
 		evaluationEnabled:    evaluationEnabled,
 		evaluationDBPath:     evaluationDBPath,

--- a/dashboard/backend/router/auth_routes.go
+++ b/dashboard/backend/router/auth_routes.go
@@ -33,6 +33,7 @@ func setupAuthRoutes(mux *http.ServeMux, cfg *config.Config) *auth.Service {
 	}
 
 	authSvc := auth.NewService(store, cfg.JWTSecret, cfg.JWTExpiryHours)
+	authSvc.SetAllowOpenBootstrap(cfg.AllowOpenBootstrap)
 	if err := authSvc.EnsureBootstrapAdmin(
 		context.Background(),
 		cfg.BootstrapAdminEmail,

--- a/deploy/helm/semantic-router/README.md
+++ b/deploy/helm/semantic-router/README.md
@@ -125,6 +125,7 @@ the locked chart dependencies.
 | config.global.stores.semantic_cache.max_entries | int | `1000` |  |
 | config.global.stores.semantic_cache.similarity_threshold | float | `0.8` |  |
 | config.global.stores.semantic_cache.ttl_seconds | int | `3600` |  |
+| dashboard.allowOpenBootstrap | bool | `false` | Allow first-admin creation via the public, unauthenticated web-form bootstrap endpoint. Off by default: a fresh, internet-reachable deployment should not be claimable by the first stranger who finds it. Production provisions the admin via the DASHBOARD_ADMIN_* env vars (which create it at startup and close the bootstrap path automatically). Set this to true only for demos where signing up the first admin through the UI is acceptable. |
 | dashboard.enabled | bool | `false` | Enable the vLLM-SR dashboard |
 | dashboard.image.pullPolicy | string | `"IfNotPresent"` | Dashboard image pull policy |
 | dashboard.image.repository | string | `"ghcr.io/vllm-project/semantic-router/dashboard"` | Dashboard image repository |

--- a/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
+++ b/deploy/helm/semantic-router/templates/dashboard-deployment.yaml
@@ -70,6 +70,10 @@ spec:
         - name: DASHBOARD_READONLY
           value: "true"
         {{- end }}
+        {{- if .Values.dashboard.allowOpenBootstrap }}
+        - name: DASHBOARD_ALLOW_OPEN_BOOTSTRAP
+          value: "true"
+        {{- end }}
         {{- if .Values.dashboard.persistence.enabled }}
         - name: DASHBOARD_AUTH_DB_PATH
           value: "{{ .Values.dashboard.persistence.mountPath }}/auth.db"

--- a/deploy/helm/semantic-router/values.schema.json
+++ b/deploy/helm/semantic-router/values.schema.json
@@ -101,6 +101,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "allowOpenBootstrap": {
+          "type": "boolean"
+        },
         "replicaCount": {
           "type": "integer",
           "minimum": 0,

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -527,6 +527,13 @@ dashboard:
     pullPolicy: IfNotPresent
   # -- Run dashboard in read-only mode
   readonly: false
+  # -- Allow first-admin creation via the public, unauthenticated web-form bootstrap
+  # endpoint. Off by default: a fresh, internet-reachable deployment should not be
+  # claimable by the first stranger who finds it. Production provisions the admin via
+  # the DASHBOARD_ADMIN_* env vars (which create it at startup and close the bootstrap
+  # path automatically). Set this to true only for demos where signing up the first
+  # admin through the UI is acceptable.
+  allowOpenBootstrap: false
   # -- JWT signing secret for dashboard auth sessions. Point this at a Secret you
   # manage (ideally an ExternalSecret) so the signing key is stable. If you leave
   # it unset, the dashboard binary falls back to generating a random secret on


### PR DESCRIPTION
## Purpose

- The dashboard's public, unauthenticated bootstrap path creates the first admin when no users exist: `POST /api/auth/bootstrap/register` creates the admin, and `GET /api/auth/bootstrap/can-register` reports whether that is possible. On an internet-reachable deployment this has two problems:
  - **Race (TOCTOU):** the register handler checked `CanBootstrap()` (users == 0) and then created the admin with nothing atomic in between, so two concurrent requests could both pass the check and each create an admin.
  - **Claimable-by-default + info leak:** a fresh deployment with no admin yet was claimable by the first unauthenticated caller to find it, and `can-register` advertised that claimable state to anyone.
- This change makes the open bootstrap **opt-in and secure-by-default**, and closes the race:
  - New `DASHBOARD_ALLOW_OPEN_BOOTSTRAP` (default `false`). When off, `register` returns 403 and `can-register` reports `false` without revealing the user count. Production provisions the admin via the existing `DASHBOARD_ADMIN_*` env path, which creates the admin at startup so the bootstrap window never opens. Demos set the flag to `true` to sign up the first admin through the UI.
  - When on, the check-and-create is serialized in `BootstrapRegister` so only one admin can be created even under concurrent requests. The dashboard runs single-replica (enforced by the chart's `replicaCount` guard), so a process-level mutex is sufficient; a multi-writer deployment would need a transactional guard in the store.
  - Helm: new `dashboard.allowOpenBootstrap` value (default `false`) wires `DASHBOARD_ALLOW_OPEN_BOOTSTRAP`, mirroring the existing `dashboard.readonly` pattern.
- Module: `Dashboard` (Go backend + Helm chart).
- Note: this changes the out-of-box first-run UX (the open web-form bootstrap is now opt-in rather than on). The env-admin path is unchanged and remains the production-blessed way to bootstrap, so no deployment is stranded. Flagging in case the team would prefer a different default.
- Two small behavior details worth calling out: (1) when the flag is off, `register` returns 403 (disabled) even if an admin already exists, rather than 409, because the gate is checked before the bootstrap-state check; this keeps "disabled" unambiguous. (2) `BootstrapRegister` now applies `defaultAdminName` (an empty name becomes "Admin"), aligning the web-form path with the existing env-admin path (`EnsureBootstrapAdmin` already did this); the previous handler stored an empty name as-is.

## Test Plan

- `go test ./dashboard/backend/auth/ -run TestBootstrap -race`, plus `go vet` and the full `go test ./auth/`.
- `helm template` with and without `dashboard.allowOpenBootstrap`, a non-bool value, and `helm lint`.

## Test Result

- Go (auth package, including `-race`): all bootstrap-gate tests pass:
  - disabled by default: `can-register` reports false, `register` returns 403, no user created
  - enabled, no users: `can-register` true, `register` 200, exactly one admin created
  - enabled, admin already exists: `register` returns 409
  - 16 concurrent enabled register requests: exactly one admin created and exactly one 200 response (the race is closed)
  - `go vet ./auth/... ./config/... ./router/...` clean; `go test ./auth/` ok
- Helm:
  - default render (`dashboard.enabled=true`): no `DASHBOARD_ALLOW_OPEN_BOOTSTRAP` env injected (secure default)
  - `--set dashboard.allowOpenBootstrap=true`: env present with value `"true"`
  - non-bool value: rejected by schema, `at '/dashboard/allowOpenBootstrap': got string, want boolean`
  - `helm lint`: 1 chart(s) linted, 0 failed; `values.schema.json` parses as valid JSON
