### PR TITLE
[Docs] Add multi-arch :latest digest-pinning troubleshooting note

### DIFF
--- a/website/docs/troubleshooting/common-errors.md
+++ b/website/docs/troubleshooting/common-errors.md
@@ -335,6 +335,58 @@ global:
 
 ---
 
+## Image Pull Errors
+
+### No matching manifest for linux/amd64 (after pinning a digest built on Apple Silicon)
+
+**Symptoms:** Pods on `amd64` nodes stay in `ImagePullBackOff` with an event like
+`no matching manifest for linux/amd64 in the manifest list entries`, while the
+same image reference runs fine on `arm64` nodes or on an Apple Silicon laptop.
+The exact wording varies by container runtime (Docker vs containerd), but it
+always reports that no image matches the node's `linux/amd64` platform.
+
+**Cause:** The published images (`ghcr.io/vllm-project/semantic-router/extproc`
+and `.../dashboard`) are multi-arch manifest lists covering `linux/amd64` and
+`linux/arm64`. You are most likely to hit this if you pin images by digest (a
+common supply-chain or GitOps practice) and resolved that digest on an arm64
+build host such as an Apple Silicon laptop or an arm64 CI runner; a default
+tag-based install is not affected. Resolving a floating tag such as `:latest` to
+a digest on an Apple Silicon machine (for example `docker pull` followed by
+`docker inspect` of `RepoDigests`) returns the **arm64-specific** image digest,
+not the
+manifest-list (index) digest. Pinning a deployment to that single-arch digest
+(in a raw manifest, via `kubectl set image`, or any tooling that consumes a
+`name@sha256:...` reference) leaves `amd64` nodes without a matching manifest.
+
+**Fixes:**
+
+- Reference images by tag (for example `:latest` or a release tag like
+  `:v0.3.0`) so the kubelet selects the correct architecture per node from the
+  manifest list. The bundled Helm chart references images this way, through
+  `image.tag` and `dashboard.image.tag`.
+- If you pin by digest for immutability, pin the **manifest-list (index)
+  digest** in the `name@sha256:...` form, not a platform-specific one. Read the
+  index digest without pulling a single architecture:
+
+```bash
+# Index (manifest-list) digest, safe to pin; resolves correctly on amd64 and arm64.
+docker buildx imagetools inspect \
+  ghcr.io/vllm-project/semantic-router/extproc:latest \
+  --format '{{.Manifest.Digest}}'
+```
+
+- Avoid deriving the digest from a plain `docker pull` + `docker inspect` on
+  Apple Silicon; that yields the per-architecture digest for the host platform
+  (arm64), which is the root cause above.
+
+> Note: the bundled Helm chart builds image references as `repository:tag` (from
+> `image.tag` and `dashboard.image.tag` in
+> [the chart values](https://github.com/vllm-project/semantic-router/blob/main/deploy/helm/semantic-router/values.yaml)),
+> so it does not construct `name@sha256:...` digest references. Digest pinning is
+> done in your own deployment manifest, not through these values.
+
+---
+
 ## Performance Issues
 
 ### Low cache hit ratio


### PR DESCRIPTION
## Purpose

- Adds a troubleshooting entry for a real image-pull failure class: pinning a digest you resolved on Apple Silicon (arm64) for a multi-arch `:latest` manifest list breaks amd64 nodes, because that digest is the arm64 child manifest, not the multi-arch index. amd64 nodes then fail to pull.
- Documents the fix: reference the image by tag, or pin the multi-arch INDEX digest (in the `name@sha256:...` form) via `docker buildx imagetools inspect <image> --format '{{.Manifest.Digest}}'`.
- Notes the chart limitation explicitly: the bundled Helm chart builds image references as `repository:tag`, so digest pinning is done in your own deployment manifest, not through `image.tag` / `dashboard.image.tag`.
- Module: `Docs`.

## Test Plan

- `markdownlint -c tools/linter/markdown/markdownlint.yaml` on the changed page.
- The Docusaurus build runs in the PR's Netlify deploy preview.

## Test Result

- `markdownlint`: clean.
- Multi-arch behavior verified against the live `ghcr.io/vllm-project/semantic-router/extproc:latest` image: the index, amd64-child, and arm64-child digests are all distinct, and `--format '{{.Manifest.Digest}}'` returns the index (manifest-list) digest, confirming the documented command:
  - index: `sha256:46b57f20...` (`application/vnd.docker.distribution.manifest.list.v2+json`)
  - amd64 child: `sha256:ec0c1efb...`
  - arm64 child: `sha256:9b75395c...`
- No digests are hardcoded in the doc (they are ephemeral); the guidance is digest-agnostic.
