### PR TITLE
[Router] Fix mmBERT embeddings unavailable when another model wins the OnceLock factory

### DIFF
--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -56,6 +56,73 @@ fn get_multimodal_refs() -> Option<(&'static MultiModalEmbeddingModel, &'static 
     None
 }
 
+use crate::model_architectures::embedding::MmBertEmbeddingModel;
+
+/// Standalone mmBERT model storage — allows initialization independent of the
+/// main ModelFactory (which uses OnceLock and can only be set once). Without this,
+/// whichever embedding init runs first wins the factory; if that init is not mmBERT
+/// (commonly the multimodal init), mmBERT can never be registered and every
+/// mmBERT embedding fails with "mmBERT model not available". Mirrors the
+/// STANDALONE_MULTIMODAL fallback so mmBERT is reachable regardless of init order.
+static STANDALONE_MMBERT: OnceLock<(MmBertEmbeddingModel, MmTokenizer)> = OnceLock::new();
+
+/// Load mmBERT into standalone storage from a model directory
+/// (`model.safetensors` + `tokenizer.json`). Idempotent: returns true if the
+/// standalone model is already present. Used when the ModelFactory OnceLock has
+/// already been set by another embedding init and therefore cannot take mmBERT.
+fn init_mmbert_standalone(model_path: &str, use_cpu: bool) -> bool {
+    use candle_core::Device;
+    if STANDALONE_MMBERT.get().is_some() {
+        return true;
+    }
+    let device = if use_cpu {
+        Device::Cpu
+    } else {
+        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
+    };
+    let model = match MmBertEmbeddingModel::load(model_path, &device) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("ERROR: Failed to load mmBERT model (standalone): {:?}", e);
+            return false;
+        }
+    };
+    let tokenizer_path = format!("{}/tokenizer.json", model_path);
+    let tokenizer = match MmTokenizer::from_file(&tokenizer_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!(
+                "ERROR: Failed to load mmBERT tokenizer from {} (standalone): {:?}",
+                tokenizer_path, e
+            );
+            return false;
+        }
+    };
+    match STANDALONE_MMBERT.set((model, tokenizer)) {
+        Ok(_) => {
+            println!("INFO: mmBERT embedding model registered in standalone storage");
+            true
+        }
+        Err(_) => true, // Another thread set it first — fine.
+    }
+}
+
+/// Get a reference to the mmBERT model + tokenizer, checking standalone storage
+/// first then falling back to the factory (mirrors `get_multimodal_refs`).
+fn get_mmbert_refs() -> Option<(&'static MmBertEmbeddingModel, &'static MmTokenizer)> {
+    if let Some((model, tokenizer)) = STANDALONE_MMBERT.get() {
+        return Some((model, tokenizer));
+    }
+    if let Some(factory) = GLOBAL_MODEL_FACTORY.get() {
+        if let (Some(model), Some(tokenizer)) =
+            (factory.get_mmbert_model(), factory.get_mmbert_tokenizer())
+        {
+            return Some((model, tokenizer));
+        }
+    }
+    None
+}
+
 /// Generic internal helper for single text embedding generation
 ///
 /// This function extracts common logic for both Qwen3 and Gemma models.
@@ -284,9 +351,10 @@ pub extern "C" fn init_mmbert_embedding_model(model_path: *const c_char, use_cpu
 
     // Create or get factory
     let factory = if let Some(_) = GLOBAL_MODEL_FACTORY.get() {
-        // Factory exists but mmbert not loaded - we can't modify OnceLock
-        eprintln!("Error: ModelFactory already initialized without mmBERT. Initialize mmBERT first or use init_embedding_models_with_mmbert.");
-        return false;
+        // Factory already set by another embedding init; OnceLock can't be mutated
+        // to add mmBERT. Load it into standalone storage so it stays reachable
+        // (mirrors the multimodal standalone fallback) instead of hard-failing.
+        return init_mmbert_standalone(&path, use_cpu);
     } else {
         let mut factory = ModelFactory::new(device);
         match factory.register_mmbert_embedding_model(&path) {
@@ -329,8 +397,21 @@ pub extern "C" fn init_embedding_models_with_mmbert(
     use candle_core::Device;
 
     if GLOBAL_MODEL_FACTORY.get().is_some() {
-        eprintln!("WARNING: ModelFactory already initialized");
-        return true;
+        // Factory already created by an earlier embedding init (commonly the
+        // multimodal init, which grabs the OnceLock first). OnceLock can't be
+        // mutated to add mmBERT, so load it into standalone storage instead of
+        // silently no-op'ing — otherwise mmBERT is permanently unavailable
+        // whenever another model wins the factory (order-dependent bug).
+        if mmbert_model_path.is_null() {
+            return true;
+        }
+        let path = unsafe {
+            match CStr::from_ptr(mmbert_model_path).to_str() {
+                Ok(s) if !s.is_empty() => s.to_string(),
+                _ => return true,
+            }
+        };
+        return init_mmbert_standalone(&path, use_cpu);
     }
 
     // Parse paths
@@ -704,20 +785,17 @@ fn generate_gemma_embedding(
 
 /// Internal helper to generate embedding for mmBERT with 2D Matryoshka
 fn generate_mmbert_embedding(
-    factory: &ModelFactory,
+    _factory: &ModelFactory,
     text: &str,
     target_layer: Option<usize>,
     target_dim: Option<usize>,
 ) -> Result<Vec<f32>, String> {
     use candle_core::Tensor;
 
-    let model = factory
-        .get_mmbert_model()
-        .ok_or_else(|| "mmBERT model not available".to_string())?;
-
-    let tokenizer = factory
-        .get_mmbert_tokenizer()
-        .ok_or_else(|| "mmBERT tokenizer not available".to_string())?;
+    // Resolve mmBERT via standalone-then-factory lookup so it works regardless of
+    // which embedding init created the factory first (see get_mmbert_refs).
+    let (model, tokenizer) =
+        get_mmbert_refs().ok_or_else(|| "mmBERT model not available".to_string())?;
 
     // Tokenize
     let encoding = tokenizer
@@ -759,18 +837,14 @@ fn generate_mmbert_embedding(
 
 /// Generate embeddings for multiple texts in a single batch (mmBERT)
 fn generate_mmbert_embeddings_batch(
-    factory: &ModelFactory,
+    _factory: &ModelFactory,
     texts: &[&str],
     target_layer: Option<usize>,
     target_dim: Option<usize>,
 ) -> Result<Vec<Vec<f32>>, String> {
-    let model = factory
-        .get_mmbert_model()
-        .ok_or_else(|| "mmBERT model not available".to_string())?;
-
-    let tokenizer = factory
-        .get_mmbert_tokenizer()
-        .ok_or_else(|| "mmBERT tokenizer not available".to_string())?;
+    // Resolve mmBERT via standalone-then-factory lookup (see get_mmbert_refs).
+    let (model, tokenizer) =
+        get_mmbert_refs().ok_or_else(|| "mmBERT model not available".to_string())?;
 
     // Batch encode
     let embeddings = model
@@ -952,7 +1026,7 @@ pub extern "C" fn get_embedding_with_dim(
         ModelType::Qwen3Embedding => {
             if factory.map_or(false, |f| f.get_qwen3_model().is_some()) {
                 "qwen3"
-            } else if factory.map_or(false, |f| f.get_mmbert_model().is_some()) {
+            } else if get_mmbert_refs().is_some() {
                 eprintln!("INFO: Qwen3 not available, falling back to mmbert");
                 "mmbert"
             } else if factory.map_or(false, |f| f.get_gemma_model().is_some()) {
@@ -971,7 +1045,7 @@ pub extern "C" fn get_embedding_with_dim(
         ModelType::GemmaEmbedding => {
             if factory.map_or(false, |f| f.get_gemma_model().is_some()) {
                 "gemma"
-            } else if factory.map_or(false, |f| f.get_mmbert_model().is_some()) {
+            } else if get_mmbert_refs().is_some() {
                 eprintln!("INFO: Gemma not available, falling back to mmbert");
                 "mmbert"
             } else if factory.map_or(false, |f| f.get_qwen3_model().is_some()) {
@@ -988,7 +1062,7 @@ pub extern "C" fn get_embedding_with_dim(
             }
         }
         ModelType::MmBertEmbedding => {
-            if factory.map_or(false, |f| f.get_mmbert_model().is_some()) {
+            if get_mmbert_refs().is_some() {
                 "mmbert"
             } else {
                 eprintln!("Error: MmBertEmbedding selected but not available");

--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -13,7 +13,7 @@ use std::ffi::{c_char, CStr};
 //Import embedding models and model factory
 use crate::model_architectures::config::{DualPathConfig, EmbeddingConfig};
 use crate::model_architectures::model_factory::ModelFactory;
-use std::sync::OnceLock;
+use std::sync::{MutexGuard, OnceLock};
 
 // ============================================================================
 // Refactoring: Shared embedding generation logic
@@ -30,6 +30,22 @@ enum PaddingSide {
 
 /// Global singleton for ModelFactory
 pub(crate) static GLOBAL_MODEL_FACTORY: OnceLock<ModelFactory> = OnceLock::new();
+
+/// Serialize every factory-owning initializer from availability check through
+/// publication. OnceLock protects publication, but not the preceding model load:
+/// without this guard a losing initializer can discard a fully loaded mmBERT.
+/// Embedding inference only reads OnceLocks and never takes this startup lock.
+static EMBEDDING_INIT_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_embedding_init() -> Option<MutexGuard<'static, ()>> {
+    match EMBEDDING_INIT_LOCK.lock() {
+        Ok(guard) => Some(guard),
+        Err(error) => {
+            eprintln!("ERROR: Embedding initialization lock poisoned: {}", error);
+            None
+        }
+    }
+}
 
 use crate::model_architectures::embedding::MultiModalEmbeddingModel;
 use tokenizers::Tokenizer as MmTokenizer;
@@ -91,6 +107,72 @@ fn get_multimodal_refs() -> Option<(&'static MultiModalEmbeddingModel, &'static 
         }
     }
     None
+}
+
+use crate::model_architectures::embedding::MmBertEmbeddingModel;
+
+/// mmBERT can be loaded after a different model has claimed the immutable factory.
+static STANDALONE_MMBERT: OnceLock<(MmBertEmbeddingModel, MmTokenizer)> = OnceLock::new();
+
+/// Prefer the already-registered factory model; never replace it on repeated init.
+fn get_mmbert_refs() -> Option<(&'static MmBertEmbeddingModel, &'static MmTokenizer)> {
+    if let Some(factory) = GLOBAL_MODEL_FACTORY.get() {
+        if let (Some(model), Some(tokenizer)) =
+            (factory.get_mmbert_model(), factory.get_mmbert_tokenizer())
+        {
+            return Some((model, tokenizer));
+        }
+    }
+    STANDALONE_MMBERT
+        .get()
+        .map(|(model, tokenizer)| (model, tokenizer))
+}
+
+/// The caller must hold the initialization guard across the check, load and set.
+/// A failed model/tokenizer load publishes nothing, so a later call can retry.
+fn init_mmbert_standalone(
+    model_path: &str,
+    use_cpu: bool,
+    _init_guard: &MutexGuard<'_, ()>,
+) -> bool {
+    use candle_core::Device;
+
+    if get_mmbert_refs().is_some() {
+        return true;
+    }
+    let device = if use_cpu {
+        Device::Cpu
+    } else {
+        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
+    };
+    let model = match MmBertEmbeddingModel::load(model_path, &device) {
+        Ok(model) => model,
+        Err(error) => {
+            eprintln!("ERROR: Failed to load standalone mmBERT model: {:?}", error);
+            return false;
+        }
+    };
+    let tokenizer_path = format!("{}/tokenizer.json", model_path);
+    let tokenizer = match MmTokenizer::from_file(&tokenizer_path) {
+        Ok(tokenizer) => tokenizer,
+        Err(error) => {
+            eprintln!(
+                "ERROR: Failed to load standalone mmBERT tokenizer: {:?}",
+                error
+            );
+            return false;
+        }
+    };
+    match STANDALONE_MMBERT.set((model, tokenizer)) {
+        Ok(()) => {
+            println!("INFO: mmBERT embedding model registered in standalone storage");
+            true
+        }
+        Err(_) => {
+            eprintln!("ERROR: Standalone mmBERT storage changed while initialization was locked");
+            false
+        }
+    }
 }
 
 /// Generic internal helper for single text embedding generation
@@ -265,6 +347,10 @@ where
 pub extern "C" fn init_mmbert_embedding_model(model_path: *const c_char, use_cpu: bool) -> bool {
     use candle_core::Device;
 
+    let Some(init_guard) = lock_embedding_init() else {
+        return false;
+    };
+
     if model_path.is_null() {
         eprintln!("Error: model_path is null");
         return false;
@@ -280,12 +366,9 @@ pub extern "C" fn init_mmbert_embedding_model(model_path: *const c_char, use_cpu
         }
     };
 
-    // Check if already initialized
-    if let Some(factory) = GLOBAL_MODEL_FACTORY.get() {
-        if factory.get_mmbert_model().is_some() {
-            eprintln!("WARNING: mmBERT model already initialized");
-            return true;
-        }
+    // Repeated initialization must not reload or switch model path/device.
+    if get_mmbert_refs().is_some() {
+        return true;
     }
 
     // Determine device
@@ -297,9 +380,9 @@ pub extern "C" fn init_mmbert_embedding_model(model_path: *const c_char, use_cpu
 
     // Create or get factory
     let factory = if GLOBAL_MODEL_FACTORY.get().is_some() {
-        // Factory exists but mmbert not loaded - we can't modify OnceLock
-        eprintln!("Error: ModelFactory already initialized without mmBERT. Initialize mmBERT first or use init_embedding_models_with_mmbert.");
-        return false;
+        // Another model owns the immutable factory. Keep mmBERT reachable
+        // through standalone storage without replacing that factory.
+        return init_mmbert_standalone(&path, use_cpu, &init_guard);
     } else {
         let mut factory = ModelFactory::new(device);
         match factory.register_mmbert_embedding_model(&path) {
@@ -342,9 +425,22 @@ pub extern "C" fn init_embedding_models_with_mmbert(
 ) -> bool {
     use candle_core::Device;
 
+    let Some(init_guard) = lock_embedding_init() else {
+        return false;
+    };
+
     if GLOBAL_MODEL_FACTORY.get().is_some() {
-        eprintln!("WARNING: ModelFactory already initialized");
-        return true;
+        // Preserve the loaded-model fast path before parsing any replacement path.
+        if get_mmbert_refs().is_some() || mmbert_model_path.is_null() {
+            return true;
+        }
+        let path = unsafe {
+            match CStr::from_ptr(mmbert_model_path).to_str() {
+                Ok(path) if !path.is_empty() => path,
+                _ => return true, // No optional mmBERT path, as on first init.
+            }
+        };
+        return init_mmbert_standalone(path, use_cpu, &init_guard);
     }
 
     // Parse paths
@@ -418,7 +514,10 @@ pub extern "C" fn init_embedding_models_with_mmbert(
 
     match GLOBAL_MODEL_FACTORY.set(factory) {
         Ok(_) => true,
-        Err(_) => true, // Already initialized
+        Err(_) => {
+            eprintln!("ERROR: ModelFactory changed while embedding initialization was locked");
+            false
+        }
     }
 }
 
@@ -440,6 +539,10 @@ pub extern "C" fn init_embedding_models(
     use_cpu: bool,
 ) -> bool {
     use candle_core::Device;
+
+    let Some(_init_guard) = lock_embedding_init() else {
+        return false;
+    };
 
     // Check if already initialized (OnceLock can only be set once)
     if GLOBAL_MODEL_FACTORY.get().is_some() {
@@ -521,8 +624,8 @@ pub extern "C" fn init_embedding_models(
     match GLOBAL_MODEL_FACTORY.set(factory) {
         Ok(_) => true,
         Err(_) => {
-            // Already initialized - idempotent behavior
-            true
+            eprintln!("ERROR: ModelFactory changed while embedding initialization was locked");
+            false
         }
     }
 }
@@ -719,20 +822,15 @@ fn generate_gemma_embedding(
 
 /// Internal helper to generate embedding for mmBERT with 2D Matryoshka
 fn generate_mmbert_embedding(
-    factory: &ModelFactory,
+    _factory: &ModelFactory,
     text: &str,
     target_layer: Option<usize>,
     target_dim: Option<usize>,
 ) -> Result<Vec<f32>, String> {
     use candle_core::Tensor;
 
-    let model = factory
-        .get_mmbert_model()
-        .ok_or_else(|| "mmBERT model not available".to_string())?;
-
-    let tokenizer = factory
-        .get_mmbert_tokenizer()
-        .ok_or_else(|| "mmBERT tokenizer not available".to_string())?;
+    let (model, tokenizer) =
+        get_mmbert_refs().ok_or_else(|| "mmBERT model not available".to_string())?;
 
     // Tokenize
     let encoding = tokenizer
@@ -770,18 +868,13 @@ fn generate_mmbert_embedding(
 
 /// Generate embeddings for multiple texts in a single batch (mmBERT)
 fn generate_mmbert_embeddings_batch(
-    factory: &ModelFactory,
+    _factory: &ModelFactory,
     texts: &[&str],
     target_layer: Option<usize>,
     target_dim: Option<usize>,
 ) -> Result<Vec<Vec<f32>>, String> {
-    let model = factory
-        .get_mmbert_model()
-        .ok_or_else(|| "mmBERT model not available".to_string())?;
-
-    let tokenizer = factory
-        .get_mmbert_tokenizer()
-        .ok_or_else(|| "mmBERT tokenizer not available".to_string())?;
+    let (model, tokenizer) =
+        get_mmbert_refs().ok_or_else(|| "mmBERT model not available".to_string())?;
 
     // Batch encode
     let embeddings = model
@@ -961,7 +1054,7 @@ pub extern "C" fn get_embedding_with_dim(
         ModelType::Qwen3Embedding => {
             if factory.is_some_and(|f| f.get_qwen3_model().is_some()) {
                 "qwen3"
-            } else if factory.is_some_and(|f| f.get_mmbert_model().is_some()) {
+            } else if get_mmbert_refs().is_some() {
                 eprintln!("INFO: Qwen3 not available, falling back to mmbert");
                 "mmbert"
             } else if factory.is_some_and(|f| f.get_gemma_model().is_some()) {
@@ -980,7 +1073,7 @@ pub extern "C" fn get_embedding_with_dim(
         ModelType::GemmaEmbedding => {
             if factory.is_some_and(|f| f.get_gemma_model().is_some()) {
                 "gemma"
-            } else if factory.is_some_and(|f| f.get_mmbert_model().is_some()) {
+            } else if get_mmbert_refs().is_some() {
                 eprintln!("INFO: Gemma not available, falling back to mmbert");
                 "mmbert"
             } else if factory.is_some_and(|f| f.get_qwen3_model().is_some()) {
@@ -997,7 +1090,7 @@ pub extern "C" fn get_embedding_with_dim(
             }
         }
         ModelType::MmBertEmbedding => {
-            if factory.is_some_and(|f| f.get_mmbert_model().is_some()) {
+            if get_mmbert_refs().is_some() {
                 "mmbert"
             } else {
                 eprintln!("Error: MmBertEmbedding selected but not available");
@@ -2201,6 +2294,10 @@ pub extern "C" fn init_multimodal_embedding_model(
 ) -> bool {
     use candle_core::Device;
 
+    let Some(_init_guard) = lock_embedding_init() else {
+        return false;
+    };
+
     if model_path.is_null() {
         eprintln!("Error: model_path is null");
         return false;
@@ -2957,3 +3054,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "embedding_init_test.rs"]
+mod init_order_tests;

--- a/candle-binding/src/ffi/embedding_init_test.rs
+++ b/candle-binding/src/ffi/embedding_init_test.rs
@@ -1,0 +1,385 @@
+//! No model downloads: each case loads a tiny local mmBERT checkpoint through
+//! the real FFI entrypoints. A fresh process per case isolates the OnceLocks.
+//! An empty ModelFactory represents ownership by an unrelated embedding model;
+//! its weights are irrelevant to the mmBERT registration decision. The separate
+//! gate case exercises all four real factory-owning FFI entrypoints, including
+//! multimodal, without downloading a production multimodal checkpoint.
+
+use super::*;
+use crate::model_architectures::embedding::mmbert_embedding::MmBertEmbeddingConfig;
+use candle_core::{DType, Device};
+use candle_nn::{VarBuilder, VarMap};
+use std::ffi::CString;
+use std::process::{Command, Stdio};
+use std::sync::{mpsc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const CHILD_CASE: &str = "SEMANTIC_ROUTER_EMBEDDING_INIT_TEST_CASE";
+
+fn fixture(hidden_size: usize) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let config_json = serde_json::json!({
+        "vocab_size": 4, "hidden_size": hidden_size, "num_hidden_layers": 1,
+        "num_attention_heads": 2, "intermediate_size": hidden_size * 2,
+        "max_position_embeddings": 16, "layer_norm_eps": 1e-5,
+        "pad_token_id": 0, "global_attn_every_n_layers": 3,
+        "global_rope_theta": 10000.0, "local_attention": 8,
+        "local_rope_theta": 10000.0
+    });
+    std::fs::write(dir.path().join("config.json"), config_json.to_string()).unwrap();
+    let config = MmBertEmbeddingConfig::from_pretrained(dir.path()).unwrap();
+    let vars = VarMap::new();
+    let model = MmBertEmbeddingModel::load_with_vb(
+        dir.path().to_str().unwrap(),
+        &config,
+        VarBuilder::from_varmap(&vars, DType::F32, &Device::Cpu),
+        &Device::Cpu,
+    )
+    .unwrap();
+    drop(model);
+    vars.save(dir.path().join("model.safetensors")).unwrap();
+    let wordlevel = tokenizers::models::wordlevel::WordLevel::builder()
+        .vocab(
+            [
+                ("[UNK]".into(), 0),
+                ("hello".into(), 1),
+                ("world".into(), 2),
+            ]
+            .into_iter()
+            .collect(),
+        )
+        .unk_token("[UNK]".into())
+        .build()
+        .unwrap();
+    MmTokenizer::new(wordlevel)
+        .save(dir.path().join("tokenizer.json"), false)
+        .unwrap();
+    dir
+}
+
+fn path(dir: &tempfile::TempDir) -> CString {
+    CString::new(dir.path().to_str().unwrap()).unwrap()
+}
+
+fn combined(path: &CString, use_cpu: bool) -> bool {
+    init_embedding_models_with_mmbert(std::ptr::null(), std::ptr::null(), path.as_ptr(), use_cpu)
+}
+
+fn install_other_factory() {
+    let _guard = lock_embedding_init().unwrap();
+    assert!(GLOBAL_MODEL_FACTORY
+        .set(ModelFactory::new(Device::Cpu))
+        .is_ok());
+}
+
+fn assert_embeddings(hidden_size: usize) {
+    let (model, _) = get_mmbert_refs().expect("mmBERT must remain reachable");
+    assert_eq!(model.config().hidden_size, hidden_size);
+    let factory = GLOBAL_MODEL_FACTORY.get().unwrap();
+    let one = generate_mmbert_embedding(factory, "hello", None, None).unwrap();
+    assert_eq!(one.len(), hidden_size);
+    assert!(one.iter().all(|v| v.is_finite()));
+    let batch = generate_mmbert_embeddings_batch(factory, &["hello", "world"], None, None).unwrap();
+    assert_eq!(batch.len(), 2);
+    assert!(batch
+        .iter()
+        .all(|row| row.len() == hidden_size && row.iter().all(|v| v.is_finite())));
+}
+
+fn assert_repeated_init_is_noop() {
+    let (model, tokenizer) = get_mmbert_refs().unwrap();
+    let model_ptr = model as *const _;
+    let tokenizer_ptr = tokenizer as *const _;
+    let second = fixture(16);
+    let second_path = path(&second);
+    assert!(combined(&second_path, false));
+    assert!(init_mmbert_embedding_model(second_path.as_ptr(), false));
+    // A missing path after successful initialization must not be opened at all.
+    let missing = CString::new(second.path().join("missing").to_str().unwrap()).unwrap();
+    assert!(combined(&missing, false));
+    assert!(init_mmbert_embedding_model(missing.as_ptr(), false));
+    let (same_model, same_tokenizer) = get_mmbert_refs().unwrap();
+    assert_eq!(model_ptr, same_model as *const _);
+    assert_eq!(tokenizer_ptr, same_tokenizer as *const _);
+    assert_embeddings(8);
+}
+
+fn assert_all_entrypoints_share_gate() {
+    let guard = lock_embedding_init().unwrap();
+    let (started_tx, started_rx) = mpsc::channel();
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::scope(|scope| {
+        let mut workers = Vec::new();
+        for entry in 0..4 {
+            let started = started_tx.clone();
+            let done = done_tx.clone();
+            workers.push(scope.spawn(move || {
+                started.send(()).unwrap();
+                let result = match entry {
+                    0 => init_mmbert_embedding_model(std::ptr::null(), true),
+                    1 => init_embedding_models_with_mmbert(
+                        std::ptr::null(),
+                        std::ptr::null(),
+                        std::ptr::null(),
+                        true,
+                    ),
+                    2 => init_embedding_models(std::ptr::null(), std::ptr::null(), true),
+                    _ => init_multimodal_embedding_model(std::ptr::null(), true),
+                };
+                done.send(result).unwrap();
+            }));
+        }
+        for _ in 0..4 {
+            started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        }
+        assert!(
+            matches!(
+                done_rx.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "an entrypoint bypassed the initialization gate"
+        );
+        drop(guard);
+        for _ in 0..4 {
+            assert!(!done_rx.recv_timeout(Duration::from_secs(5)).unwrap());
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+    });
+    assert!(GLOBAL_MODEL_FACTORY.get().is_none());
+}
+
+fn assert_factory_first(case: &str) {
+    let dir = fixture(8);
+    install_other_factory();
+    let model_path = path(&dir);
+    assert!(if case == "factory_first" {
+        combined(&model_path, true)
+    } else {
+        init_mmbert_embedding_model(model_path.as_ptr(), true)
+    });
+    assert!(GLOBAL_MODEL_FACTORY
+        .get()
+        .unwrap()
+        .get_mmbert_model()
+        .is_none());
+    assert!(STANDALONE_MMBERT.get().is_some());
+    assert_embeddings(8);
+    assert_repeated_init_is_noop();
+}
+
+fn assert_mmbert_first(case: &str) {
+    let dir = fixture(8);
+    let model_path = path(&dir);
+    assert!(if case == "mmbert_first" {
+        combined(&model_path, true)
+    } else {
+        init_mmbert_embedding_model(model_path.as_ptr(), true)
+    });
+    // A later non-mmBERT initializer must not replace the winning factory.
+    assert!(init_embedding_models(
+        std::ptr::null(),
+        std::ptr::null(),
+        true
+    ));
+    assert!(GLOBAL_MODEL_FACTORY
+        .get()
+        .unwrap()
+        .get_mmbert_model()
+        .is_some());
+    assert!(STANDALONE_MMBERT.get().is_none());
+    assert_repeated_init_is_noop();
+    assert!(
+        STANDALONE_MMBERT.get().is_none(),
+        "reinitialization must not load a duplicate"
+    );
+}
+
+fn assert_concurrent_mmbert() {
+    let dir = fixture(8);
+    let barrier = Barrier::new(2);
+    thread::scope(|scope| {
+        let a = scope.spawn(|| {
+            let model_path = path(&dir);
+            barrier.wait();
+            combined(&model_path, true)
+        });
+        let b = scope.spawn(|| {
+            let model_path = path(&dir);
+            barrier.wait();
+            init_mmbert_embedding_model(model_path.as_ptr(), true)
+        });
+        assert!(a.join().unwrap());
+        assert!(b.join().unwrap());
+    });
+    assert!(GLOBAL_MODEL_FACTORY
+        .get()
+        .unwrap()
+        .get_mmbert_model()
+        .is_some());
+    assert!(
+        STANDALONE_MMBERT.get().is_none(),
+        "concurrent init must not load a duplicate"
+    );
+    assert_repeated_init_is_noop();
+}
+
+fn assert_concurrent_other_factory() {
+    let dir = fixture(8);
+    let guard = lock_embedding_init().unwrap();
+    let (started_tx, started_rx) = mpsc::channel();
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::scope(|scope| {
+        let worker = scope.spawn(|| {
+            let model_path = path(&dir);
+            started_tx.send(()).unwrap();
+            done_tx.send(combined(&model_path, true)).unwrap();
+        });
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(matches!(
+            done_rx.recv_timeout(Duration::from_millis(100)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        assert!(
+            GLOBAL_MODEL_FACTORY.get().is_none(),
+            "the losing initializer must not load/publish early"
+        );
+        // Publish the competing factory while its initialization guard is
+        // still held. The waiting mmBERT initializer must recheck ownership
+        // after acquiring the guard and take the standalone path.
+        assert!(GLOBAL_MODEL_FACTORY
+            .set(ModelFactory::new(Device::Cpu))
+            .is_ok());
+        drop(guard);
+        assert!(done_rx.recv_timeout(Duration::from_secs(5)).unwrap());
+        worker.join().unwrap();
+    });
+    assert!(STANDALONE_MMBERT.get().is_some());
+    assert_embeddings(8);
+}
+
+fn assert_failed_load_retry(case: &str) {
+    let dir = fixture(8);
+    let model_path = path(&dir);
+    if case == "failed_standalone_retry" {
+        install_other_factory();
+    }
+    let tokenizer = dir.path().join("tokenizer.json");
+    let bytes = std::fs::read(&tokenizer).unwrap();
+    std::fs::remove_file(&tokenizer).unwrap();
+    assert!(!combined(&model_path, true));
+    assert!(
+        get_mmbert_refs().is_none(),
+        "failed init must not publish a partial model"
+    );
+    std::fs::write(tokenizer, bytes).unwrap();
+    assert!(
+        combined(&model_path, true),
+        "failed initialization must be retryable"
+    );
+    assert_embeddings(8);
+}
+
+fn assert_poisoned_gate() {
+    assert!(thread::spawn(|| {
+        let _guard = EMBEDDING_INIT_LOCK.lock().unwrap();
+        panic!("poison the initialization gate for this isolated case");
+    })
+    .join()
+    .is_err());
+    // Poison must be reported through the FFI bool, not an unwrap panic
+    // that aborts the process across an extern C boundary.
+    assert!(!init_mmbert_embedding_model(std::ptr::null(), true));
+    assert!(!init_embedding_models_with_mmbert(
+        std::ptr::null(),
+        std::ptr::null(),
+        std::ptr::null(),
+        true
+    ));
+    assert!(!init_embedding_models(
+        std::ptr::null(),
+        std::ptr::null(),
+        true
+    ));
+    assert!(!init_multimodal_embedding_model(std::ptr::null(), true));
+}
+
+fn run_case(case: &str) {
+    assert!(GLOBAL_MODEL_FACTORY.get().is_none());
+    assert!(STANDALONE_MMBERT.get().is_none());
+    match case {
+        "factory_first" | "factory_first_direct" => assert_factory_first(case),
+        "mmbert_first" | "mmbert_first_direct" => assert_mmbert_first(case),
+        "concurrent_mmbert" => assert_concurrent_mmbert(),
+        "concurrent_other_factory" => assert_concurrent_other_factory(),
+        "all_entrypoints_share_gate" => assert_all_entrypoints_share_gate(),
+        "failed_load_retry" | "failed_standalone_retry" => assert_failed_load_retry(case),
+        "poisoned_gate" => assert_poisoned_gate(),
+        other => panic!("unknown initialization case: {other}"),
+    }
+}
+
+#[test]
+fn embedding_init_order_regressions() {
+    if let Ok(case) = std::env::var(CHILD_CASE) {
+        run_case(&case);
+        return;
+    }
+    for case in [
+        "factory_first",
+        "factory_first_direct",
+        "mmbert_first",
+        "mmbert_first_direct",
+        "concurrent_mmbert",
+        "concurrent_other_factory",
+        "all_entrypoints_share_gate",
+        "failed_load_retry",
+        "failed_standalone_retry",
+        "poisoned_gate",
+    ] {
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                &format!(
+                    "{}::embedding_init_order_regressions",
+                    module_path!().split_once("::").unwrap().1
+                ),
+                "--nocapture",
+            ])
+            .env(CHILD_CASE, case)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if child.try_wait().unwrap().is_some() {
+                break;
+            }
+            if Instant::now() >= deadline {
+                child.kill().unwrap();
+                let output = child.wait_with_output().unwrap();
+                panic!(
+                    "initialization case {case} timed out (possible deadlock): {}\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "initialization case {case} failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("1 passed;"),
+            "child case {case} did not execute exactly one test"
+        );
+        println!("initialization case {case}: passed");
+    }
+}

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -13,6 +13,7 @@ TEST_GPU_DEVICE ?= 2
 # Keep this list explicit. Do not include tests whose fixtures initialize
 # models from ../models unless those tests have been converted to skip cleanly.
 RUST_CI_LIB_TESTS ?= \
+	ffi::embedding::init_order_tests::embedding_init_order_regressions \
 	core::tokenization_test::test_tokenization_config_default \
 	core::tokenization_test::test_tokenization_config_custom \
 	ffi::embedding_test::test_truncate_embedding_renormalizes_prefix \


### PR DESCRIPTION
Closes #3679

## Problem

The process-global `GLOBAL_MODEL_FACTORY` is a `OnceLock`. When another embedding initializer owns it first, mmBERT still needs a reachable model/tokenizer pair. The initial standalone fallback also needed to preserve repeated-init idempotency and handle concurrent factory ownership: protecting only `OnceLock::set` does not prevent a losing initializer from loading and then discarding mmBERT while reporting success.

This revision addresses the outstanding P1 concurrency and P2 duplicate-loading reviews and reapplies the fix to current `main`.

## Changes

- Serialize all four factory-owning FFI initializers from availability check through loading and publication: `init_mmbert_embedding_model`, `init_embedding_models_with_mmbert`, `init_embedding_models`, and `init_multimodal_embedding_model`. A waiting initializer rechecks ownership after acquiring the guard. Unexpected publication failures return false instead of reporting success after losing a loaded model.
- Resolve mmBERT from the already-ready factory model/tokenizer first, then standalone storage. Repeated direct/combined initialization returns before parsing replacement paths or loading weights. When another model owns the factory, publish a complete standalone mmBERT pair; failed loads publish nothing and remain retryable. Single/batch generation and automatic selection use the shared resolver.
- Add isolated-process CPU regressions and include them in the existing `RUST_CI_LIB_TESTS` allowlist. `make test` invokes `test-rust-ci` in CI, so this is not a one-off validation-only test.

The initialization mutex is not acquired by inference. The C/Go ABI, configuration, and deployment surfaces are unchanged. The upstream diff contains only:

1. `candle-binding/src/ffi/embedding.rs`
2. `candle-binding/src/ffi/embedding_init_test.rs`
3. `tools/make/rust.mk`

Fork-only preparation/workflow files are excluded from the PR.

## Regression coverage

Ten fresh-process scenarios isolate the global `OnceLock`s: other-factory-first and mmBERT-first through both entrypoints; simultaneous direct/combined mmBERT initialization; competing factory publication; the shared gate across all four real FFI entrypoints; failed-load retry in factory and standalone paths; and poisoned-lock error handling without an FFI panic.

Tiny local safetensors/tokenizer fixtures exercise real mmBERT loading and subsequent single/batch forward inference without GPU access or pretrained-model downloads. Repeated-init assertions pass a different valid checkpoint, a changed device argument, and a nonexistent path, then verify unchanged model/tokenizer identity, unchanged embedding dimensions, and no duplicate standalone model.

The unrelated factory is a lightweight ownership fixture. The multimodal entrypoint participates in the gate regression, but this is not a full pretrained multimodal-model E2E test.

## Exact-head validation — 2026-09-06

Head: `38fab906d617fb1b3fe3a6709abd578482642322`  
Base: `8c76b723c723fd79163a6cca98f62d5af03fb722`

[Validation run](https://github.com/scoobydont-666/semantic-router/actions/runs/34057670763) checks out the clean candidate before running gates. `pr2067-head.log` and `pr2067-candidate.sha` record the head above; the final check confirms no tracked changes after validation. Logs and the exact patch are in artifact `pr2067-binding-validation-eaba82a91a87accf2c000ad6840b221782612fce`.

| Check | Result |
| --- | --- |
| `git diff --check` and changed Rust formatting | Passed |
| `make agent-report` / `make agent-validate` | Passed; 35 workflow contracts, 131 CI tests, 29 harness tests |
| `make agent-lint` for the three changed files | Passed the repository's scoped lint and structure gates; architecture guard reported no configured scope changed |
| `make test-rust-ci` | Passed all 8 allowlisted top-level checks, including all 10 initialization scenarios |
| `make test-binding-minimal` | Passed with Go race detection; four model-dependent tests skipped |
| `make test-binding-lora` | Executed, **not passed**; model-backed validation remains incomplete |

Lint scope matters: the repository's changed-file runner filters Clippy findings outside the changed-file set. This is not a claim of a clean whole-crate Clippy run.

The minimal-suite skips were `TestModernBERTPIITokenClassification`, `TestMultiModalEmbeddingInit`, `TestMultiModalEncodeText`, and `TestMultiModalInputValidation`.

The asset-light LoRA run lacked the Qwen/Gemma/classifier model directories and recorded missing `config.json` files and HTTP 401 responses from attempted fallback downloads. Six top-level Go tests failed. The existing Make recipe masks Go failures in CI; the fork validation workflow deliberately detects those log failures and therefore reports the overall run red. No full LoRA/model-backed pass is claimed, and unrelated suite failures have not been reclassified as proven pre-existing regressions.

The normal [upstream PR workflow for this head](https://github.com/vllm-project/semantic-router/actions/runs/34058157532) is separate and includes broader core/model-backed and gateway integration checks. Maintainer re-review and the remaining upstream checks are still required. Historical manual standup observations from the original PR are not being presented as fresh validation of this revision.