### PR TITLE
[E2E] add dashboard restart SQLite recovery test with PVC-backed workflow store

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -46,6 +46,8 @@ var DashboardContract = []string{
 	"dashboard-deploy-invalid-yaml",
 	// Evaluation endpoints (tasks/CRUD require CGO — only datasets works without it)
 	"dashboard-eval-datasets",
+	// Workflow persistence survives dashboard pod restart (requires dashboard PVC)
+	"dashboard-restart-recovery",
 	// Security Policy RBAC + ratelimit apply
 	"security-policy-apply",
 }

--- a/e2e/profiles/dashboard/dashboard-deployment.yaml
+++ b/e2e/profiles/dashboard/dashboard-deployment.yaml
@@ -92,7 +92,12 @@ spec:
             - name: router-config
               mountPath: /app/config
               readOnly: true
+            - name: dashboard-data
+              mountPath: /tmp/vllm-sr-dashboard
       volumes:
         - name: router-config
           configMap:
             name: semantic-router-config
+        - name: dashboard-data
+          persistentVolumeClaim:
+            claimName: semantic-router-dashboard-data

--- a/e2e/profiles/dashboard/dashboard-deployment.yaml
+++ b/e2e/profiles/dashboard/dashboard-deployment.yaml
@@ -100,4 +100,4 @@ spec:
             name: semantic-router-config
         - name: dashboard-data
           persistentVolumeClaim:
-            claimName: semantic-router-dashboard-data
+            claimName: semantic-router-dashboard-e2e-data

--- a/e2e/profiles/dashboard/dashboard-pvc.yaml
+++ b/e2e/profiles/dashboard/dashboard-pvc.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: semantic-router-dashboard-data
+  name: semantic-router-dashboard-e2e-data
+  namespace: vllm-semantic-router-system
+  labels:
+    app.kubernetes.io/name: semantic-router-dashboard
+    app.kubernetes.io/component: e2e-data
+    vllm.ai/e2e-managed: "true"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/e2e/profiles/dashboard/dashboard-pvc.yaml
+++ b/e2e/profiles/dashboard/dashboard-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: semantic-router-dashboard-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 128Mi

--- a/e2e/profiles/dashboard/dashboard-pvc.yaml
+++ b/e2e/profiles/dashboard/dashboard-pvc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/component: e2e-data
     vllm.ai/e2e-managed: "true"
 spec:
+  storageClassName: standard
   accessModes:
     - ReadWriteOnce
   resources:

--- a/e2e/profiles/dashboard/profile.go
+++ b/e2e/profiles/dashboard/profile.go
@@ -33,9 +33,7 @@ const (
 	dashboardE2EDeploymentManifest = "e2e/profiles/dashboard/dashboard-deployment.yaml"
 	dashboardE2EPVCManifest        = "e2e/profiles/dashboard/dashboard-pvc.yaml"
 
-	dashboardE2EPVCName       = "semantic-router-dashboard-e2e-data"
-	dashboardE2EManagedLabel  = "vllm.ai/e2e-managed=true"
-	dashboardE2EPVCWaitPeriod = 2 * time.Minute
+	dashboardE2EManagedLabel = "vllm.ai/e2e-managed=true"
 
 	deploymentDashboard = "semantic-router-dashboard"
 	serviceDashboard    = "semantic-router-dashboard"
@@ -143,10 +141,6 @@ func (p *Profile) deployDashboard(ctx context.Context, opts *framework.SetupOpti
 		return fmt.Errorf("failed to apply dashboard PVC: %w", err)
 	}
 
-	if err := p.waitForDashboardPVC(ctx, opts.KubeConfig); err != nil {
-		return fmt.Errorf("dashboard PVC not ready (check storage class and PVC quotas): %w", err)
-	}
-
 	if err := p.kubectlApplyWithNamespace(ctx, opts.KubeConfig, namespaceRouter, dashboardE2EDeploymentManifest); err != nil {
 		return fmt.Errorf("failed to apply dashboard deployment: %w", err)
 	}
@@ -196,22 +190,6 @@ func (p *Profile) cleanupDashboard(ctx context.Context, opts *framework.Teardown
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "pvc", "-l", dashboardE2EManagedLabel, "-n", namespaceRouter, "--ignore-not-found=true")
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardManifestDir+"/configmap.yaml", "-n", namespaceRouter, "--ignore-not-found=true")
 	return nil
-}
-
-func (p *Profile) waitForDashboardPVC(ctx context.Context, kubeConfig string) error {
-	p.log("Waiting for dashboard PVC %s to bind", dashboardE2EPVCName)
-	waitCtx, cancel := context.WithTimeout(ctx, dashboardE2EPVCWaitPeriod)
-	defer cancel()
-
-	return p.runKubectl(
-		waitCtx,
-		kubeConfig,
-		"wait",
-		"--for=jsonpath={.status.phase}=Bound",
-		"pvc/"+dashboardE2EPVCName,
-		"-n", namespaceRouter,
-		"--timeout="+dashboardE2EPVCWaitPeriod.String(),
-	)
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e/profiles/dashboard/profile.go
+++ b/e2e/profiles/dashboard/profile.go
@@ -33,6 +33,10 @@ const (
 	dashboardE2EDeploymentManifest = "e2e/profiles/dashboard/dashboard-deployment.yaml"
 	dashboardE2EPVCManifest        = "e2e/profiles/dashboard/dashboard-pvc.yaml"
 
+	dashboardE2EPVCName       = "semantic-router-dashboard-e2e-data"
+	dashboardE2EManagedLabel  = "vllm.ai/e2e-managed=true"
+	dashboardE2EPVCWaitPeriod = 2 * time.Minute
+
 	deploymentDashboard = "semantic-router-dashboard"
 	serviceDashboard    = "semantic-router-dashboard"
 
@@ -139,6 +143,10 @@ func (p *Profile) deployDashboard(ctx context.Context, opts *framework.SetupOpti
 		return fmt.Errorf("failed to apply dashboard PVC: %w", err)
 	}
 
+	if err := p.waitForDashboardPVC(ctx, opts.KubeConfig); err != nil {
+		return fmt.Errorf("dashboard PVC not ready (check storage class and PVC quotas): %w", err)
+	}
+
 	if err := p.kubectlApplyWithNamespace(ctx, opts.KubeConfig, namespaceRouter, dashboardE2EDeploymentManifest); err != nil {
 		return fmt.Errorf("failed to apply dashboard deployment: %w", err)
 	}
@@ -184,9 +192,26 @@ func (p *Profile) deployDashboard(ctx context.Context, opts *framework.SetupOpti
 func (p *Profile) cleanupDashboard(ctx context.Context, opts *framework.TeardownOptions) error {
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardManifestDir+"/service.yaml", "-n", namespaceRouter, "--ignore-not-found=true")
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardE2EDeploymentManifest, "-n", namespaceRouter, "--ignore-not-found=true")
-	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardE2EPVCManifest, "-n", namespaceRouter, "--ignore-not-found=true")
+	// Delete only PVCs created by this E2E profile (label vllm.ai/e2e-managed=true).
+	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "pvc", "-l", dashboardE2EManagedLabel, "-n", namespaceRouter, "--ignore-not-found=true")
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardManifestDir+"/configmap.yaml", "-n", namespaceRouter, "--ignore-not-found=true")
 	return nil
+}
+
+func (p *Profile) waitForDashboardPVC(ctx context.Context, kubeConfig string) error {
+	p.log("Waiting for dashboard PVC %s to bind", dashboardE2EPVCName)
+	waitCtx, cancel := context.WithTimeout(ctx, dashboardE2EPVCWaitPeriod)
+	defer cancel()
+
+	return p.runKubectl(
+		waitCtx,
+		kubeConfig,
+		"wait",
+		"--for=jsonpath={.status.phase}=Bound",
+		"pvc/"+dashboardE2EPVCName,
+		"-n", namespaceRouter,
+		"--timeout="+dashboardE2EPVCWaitPeriod.String(),
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e/profiles/dashboard/profile.go
+++ b/e2e/profiles/dashboard/profile.go
@@ -31,6 +31,7 @@ const (
 	// and sets ML_PIPELINE_ENABLED=false. All other spec comes from the same image
 	// and configmap as the production deployment.
 	dashboardE2EDeploymentManifest = "e2e/profiles/dashboard/dashboard-deployment.yaml"
+	dashboardE2EPVCManifest        = "e2e/profiles/dashboard/dashboard-pvc.yaml"
 
 	deploymentDashboard = "semantic-router-dashboard"
 	serviceDashboard    = "semantic-router-dashboard"
@@ -72,7 +73,7 @@ func (p *Profile) Name() string { return profileName }
 
 // Description returns the profile description.
 func (p *Profile) Description() string {
-	return "Tests the dashboard API surface: health, status, config read, deploy preview, config versions, and input validation"
+	return "Tests the dashboard API surface: health, status, config read, deploy preview, config versions, restart recovery, and input validation"
 }
 
 // Setup deploys the shared gateway stack then the standalone dashboard.
@@ -134,6 +135,10 @@ func (p *Profile) deployDashboard(ctx context.Context, opts *framework.SetupOpti
 		return fmt.Errorf("failed to apply dashboard configmap: %w", err)
 	}
 
+	if err := p.kubectlApplyWithNamespace(ctx, opts.KubeConfig, namespaceRouter, dashboardE2EPVCManifest); err != nil {
+		return fmt.Errorf("failed to apply dashboard PVC: %w", err)
+	}
+
 	if err := p.kubectlApplyWithNamespace(ctx, opts.KubeConfig, namespaceRouter, dashboardE2EDeploymentManifest); err != nil {
 		return fmt.Errorf("failed to apply dashboard deployment: %w", err)
 	}
@@ -179,6 +184,7 @@ func (p *Profile) deployDashboard(ctx context.Context, opts *framework.SetupOpti
 func (p *Profile) cleanupDashboard(ctx context.Context, opts *framework.TeardownOptions) error {
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardManifestDir+"/service.yaml", "-n", namespaceRouter, "--ignore-not-found=true")
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardE2EDeploymentManifest, "-n", namespaceRouter, "--ignore-not-found=true")
+	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardE2EPVCManifest, "-n", namespaceRouter, "--ignore-not-found=true")
 	_ = p.kubectl(ctx, opts.KubeConfig, "delete", "-f", dashboardManifestDir+"/configmap.yaml", "-n", namespaceRouter, "--ignore-not-found=true")
 	return nil
 }

--- a/e2e/testcases/dashboard_restart_recovery.go
+++ b/e2e/testcases/dashboard_restart_recovery.go
@@ -1,0 +1,315 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	dashboardRestartNamespace  = "vllm-semantic-router-system"
+	dashboardRestartDeployment = "semantic-router-dashboard"
+	dashboardRestartPodLabel   = "app=semantic-router-dashboard"
+
+	dashboardRestartRecoveryTimeout  = 5 * time.Minute
+	dashboardRestartRecoveryInterval = 5 * time.Second
+
+	dashboardRestartMCPServerID   = "e2e00001-0000-4000-8000-000000000001"
+	dashboardRestartMCPServerName = "E2E Restart Recovery MCP"
+)
+
+func init() {
+	pkgtestcases.Register("dashboard-restart-recovery", pkgtestcases.TestCase{
+		Description: "Dashboard workflow SQLite state survives a dashboard pod restart",
+		Tags:        []string{"dashboard", "functional", "restart"},
+		Fn:          testDashboardRestartRecovery,
+	})
+}
+
+func testDashboardRestartRecovery(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Dashboard: restart recovery (workflow SQLite persistence)")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	baseURL := fmt.Sprintf("http://localhost:%s", localPort)
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	if err := seedDashboardWorkflowState(ctx, httpClient, baseURL, opts.Verbose); err != nil {
+		stop()
+		return err
+	}
+	stop()
+
+	if err := deleteDashboardPod(ctx, client, opts); err != nil {
+		return err
+	}
+
+	if err := waitForDashboardReady(ctx, client, opts); err != nil {
+		return err
+	}
+
+	localPort, stop, err = setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	return verifyDashboardWorkflowStateAfterRestart(
+		ctx,
+		&http.Client{Timeout: 30 * time.Second},
+		fmt.Sprintf("http://localhost:%s", localPort),
+		opts,
+	)
+}
+
+func seedDashboardWorkflowState(ctx context.Context, client *http.Client, baseURL string, verbose bool) error {
+	token, err := dashboardAuthToken(ctx, client, baseURL, verbose)
+	if err != nil {
+		return fmt.Errorf("pre-restart login: %w", err)
+	}
+
+	if err := createRestartTestMCPServer(ctx, client, baseURL, token, verbose); err != nil {
+		return err
+	}
+
+	return assertMCPServerPresent(ctx, client, baseURL, token, verbose, "before restart")
+}
+
+func createRestartTestMCPServer(ctx context.Context, client *http.Client, baseURL, token string, verbose bool) error {
+	payload := map[string]interface{}{
+		"id":          dashboardRestartMCPServerID,
+		"name":        dashboardRestartMCPServerName,
+		"description": "Created by dashboard-restart-recovery E2E",
+		"transport":   "stdio",
+		"connection": map[string]string{
+			"command": "echo",
+		},
+		"enabled": false,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal MCP server payload: %w", err)
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/api/mcp/servers"
+	if verbose {
+		fmt.Printf("[Dashboard] POST %s (seed MCP server)\n", url)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create MCP server request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	setDashboardAuth(req, token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("create MCP server request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("create MCP server: expected 201, got %d: %s", resp.StatusCode, truncateString(string(respBody), 200))
+	}
+
+	if verbose {
+		fmt.Printf("[Dashboard] MCP server %s seeded\n", dashboardRestartMCPServerID)
+	}
+	return nil
+}
+
+func verifyDashboardWorkflowStateAfterRestart(
+	ctx context.Context,
+	client *http.Client,
+	baseURL string,
+	opts pkgtestcases.TestCaseOptions,
+) error {
+	const verifyTimeout = 90 * time.Second
+	deadline := time.Now().Add(verifyTimeout)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		token, err := dashboardAuthToken(ctx, client, baseURL, opts.Verbose)
+		if err != nil {
+			lastErr = err
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		if err := assertMCPServerPresent(ctx, client, baseURL, token, opts.Verbose, "after restart"); err != nil {
+			lastErr = err
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		if err := assertWorkflowHealthOK(ctx, client, baseURL, token, opts.Verbose); err != nil {
+			lastErr = err
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		if opts.Verbose {
+			fmt.Printf("[Test] Dashboard workflow state survived restart (mcp_server_id=%s)\n", dashboardRestartMCPServerID)
+		}
+		if opts.SetDetails != nil {
+			opts.SetDetails(map[string]interface{}{
+				"mcp_server_id":   dashboardRestartMCPServerID,
+				"mcp_server_name": dashboardRestartMCPServerName,
+				"survived":        true,
+			})
+		}
+		return nil
+	}
+
+	return fmt.Errorf("dashboard workflow state not recoverable after %s: %w", verifyTimeout, lastErr)
+}
+
+func assertMCPServerPresent(ctx context.Context, client *http.Client, baseURL, token string, verbose bool, phase string) error {
+	url := strings.TrimRight(baseURL, "/") + "/api/mcp/servers"
+	if verbose {
+		fmt.Printf("[Dashboard] GET %s (%s)\n", url, phase)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create MCP list request: %w", err)
+	}
+	setDashboardAuth(req, token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("list MCP servers failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("list MCP servers: expected 200, got %d: %s", resp.StatusCode, truncateString(string(body), 200))
+	}
+
+	var result struct {
+		Servers []struct {
+			Config struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"config"`
+		} `json:"servers"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("MCP servers response is not valid JSON: %w", err)
+	}
+
+	for _, server := range result.Servers {
+		if server.Config.ID == dashboardRestartMCPServerID {
+			if server.Config.Name != dashboardRestartMCPServerName {
+				return fmt.Errorf("MCP server name mismatch: got %q, expected %q", server.Config.Name, dashboardRestartMCPServerName)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("MCP server %s not found in list (%s)", dashboardRestartMCPServerID, phase)
+}
+
+func assertWorkflowHealthOK(ctx context.Context, client *http.Client, baseURL, token string, verbose bool) error {
+	url := strings.TrimRight(baseURL, "/") + "/api/workflows/health"
+	if verbose {
+		fmt.Printf("[Dashboard] GET %s (workflow health)\n", url)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create workflow health request: %w", err)
+	}
+	setDashboardAuth(req, token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("workflow health request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("workflow health: expected 200, got %d: %s", resp.StatusCode, truncateString(string(body), 200))
+	}
+
+	var health struct {
+		Store string `json:"store"`
+	}
+	if err := json.Unmarshal(body, &health); err != nil {
+		return fmt.Errorf("workflow health response is not valid JSON: %w", err)
+	}
+	if strings.TrimSpace(health.Store) != "ok" {
+		return fmt.Errorf("workflow health store: got %q, expected ok", health.Store)
+	}
+	return nil
+}
+
+func deleteDashboardPod(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	pods, err := client.CoreV1().Pods(dashboardRestartNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: dashboardRestartPodLabel,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list dashboard pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no dashboard pods found in %s", dashboardRestartNamespace)
+	}
+
+	podName := pods.Items[0].Name
+	if opts.Verbose {
+		fmt.Printf("[Test] Deleting dashboard pod %s to simulate restart\n", podName)
+	}
+
+	if err := client.CoreV1().Pods(dashboardRestartNamespace).Delete(ctx, podName, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete dashboard pod %s: %w", podName, err)
+	}
+
+	return waitForOldDashboardPodTerminated(ctx, client, podName, opts)
+}
+
+func waitForOldDashboardPodTerminated(ctx context.Context, client *kubernetes.Clientset, podName string, opts pkgtestcases.TestCaseOptions) error {
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		_, err := client.CoreV1().Pods(dashboardRestartNamespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			if opts.Verbose {
+				fmt.Printf("[Test] Old dashboard pod %s terminated\n", podName)
+			}
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("old dashboard pod %s still exists after 2m", podName)
+}
+
+func waitForDashboardReady(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Printf("[Test] Waiting for dashboard deployment to recover (timeout=%s)\n", dashboardRestartRecoveryTimeout)
+	}
+
+	return helpers.WaitForDeploymentReady(
+		ctx, client,
+		dashboardRestartNamespace, dashboardRestartDeployment,
+		dashboardRestartRecoveryTimeout, dashboardRestartRecoveryInterval,
+		opts.Verbose,
+	)
+}


### PR DESCRIPTION


<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Add e2e test for https://github.com/vllm-project/semantic-router/pull/2064
part of https://github.com/vllm-project/semantic-router/issues/1509
## Purpose

- What does this PR change?


File | Modification
-- | --
e2e/testcases/dashboard_restart_recovery.go | Adds the dashboard-restart-recovery E2E test that seeds MCP workflow state, deletes the dashboard pod, and verifies SQLite-backed data survives the restart.
e2e/profiles/dashboard/dashboard-pvc.yaml | Introduces a 128Mi ReadWriteOnce PVC so dashboard SQLite files persist across pod restarts in the E2E cluster.
e2e/profiles/dashboard/dashboard-deployment.yaml | Mounts the new PVC at /tmp/vllm-sr-dashboard so auth, workflow, and evaluation databases are no longer stored on ephemeral container storage.
e2e/profiles/dashboard/profile.go | Applies and tears down the dashboard PVC during profile setup/cleanup and updates the profile description to mention restart recovery coverage.
e2e/pkg/testmatrix/testcases.go | Registers dashboard-restart-recovery in DashboardContract so CI runs it with the dashboard E2E profile.



- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
