### PR TITLE
[Router] Fix episodic memory extraction count metric

### DIFF
--- a/src/semantic-router/pkg/memory/extractor.go
+++ b/src/semantic-router/pkg/memory/extractor.go
@@ -267,7 +267,7 @@ func (e *MemoryExtractor) storeTurnChunk(ctx context.Context, userMessage, assis
 	chunk := formatTurnChunk(userMessage, assistantResponse)
 	sanitized, err := sanitizeMemoryContent(chunk)
 	if err != nil {
-		logging.Debugf("Memory chunk store: REJECTED - %v (user=%s)", err, userID)
+		logging.Debugf("Memory chunk store: sanitization rejected: not stored - %v (user=%s)", err, userID)
 		return false, nil
 	}
 	mem := &Memory{

--- a/src/semantic-router/pkg/memory/extractor.go
+++ b/src/semantic-router/pkg/memory/extractor.go
@@ -235,39 +235,40 @@ func (e *MemoryExtractor) ProcessResponseWithHistory(
 	}
 
 	startTime := time.Now()
-	turnStored := false
+	factsCount := 0
 	status := "success"
 	defer func() {
 		duration := time.Since(startTime).Seconds()
-		count := 1
-		if turnStored {
-			count = 1
-		}
-		RecordMemoryExtraction(status, duration, count, "episodic")
+		RecordMemoryExtraction(status, duration, factsCount, "episodic")
 	}()
 
 	// --- Per-turn chunk ---
 	if isLowEntropy(userMessage, assistantResponse) {
 		logging.Debugf("Memory chunk store: SKIPPED low-entropy turn for user=%s", userID)
-	} else if err := e.storeTurnChunk(ctx, userMessage, assistantResponse, userID); err != nil {
+	} else if stored, err := e.storeTurnChunk(ctx, userMessage, assistantResponse, userID); err != nil {
 		status = "error"
+		// Negative count skips the facts-count histogram for failed extraction attempts.
+		factsCount = -1
 		return err
-	} else {
-		turnStored = true
+	} else if stored {
+		factsCount++
 	}
 
 	// --- Session-level rolling window chunk ---
-	e.maybeStoreSessionChunk(ctx, userID, userMessage, assistantResponse, history)
+	if e.maybeStoreSessionChunk(ctx, userID, userMessage, assistantResponse, history) {
+		// The session window is stored as a separate episodic memory chunk.
+		factsCount++
+	}
 
 	return nil
 }
 
-func (e *MemoryExtractor) storeTurnChunk(ctx context.Context, userMessage, assistantResponse, userID string) error {
+func (e *MemoryExtractor) storeTurnChunk(ctx context.Context, userMessage, assistantResponse, userID string) (bool, error) {
 	chunk := formatTurnChunk(userMessage, assistantResponse)
 	sanitized, err := sanitizeMemoryContent(chunk)
 	if err != nil {
 		logging.Debugf("Memory chunk store: REJECTED - %v (user=%s)", err, userID)
-		return nil
+		return false, nil
 	}
 	mem := &Memory{
 		ID:         generateMemoryID(),
@@ -279,25 +280,26 @@ func (e *MemoryExtractor) storeTurnChunk(ctx context.Context, userMessage, assis
 		Importance: 0.5,
 	}
 	if err := e.store.Store(ctx, mem); err != nil {
-		return fmt.Errorf("failed to store conversation chunk: %w", err)
+		return false, fmt.Errorf("failed to store conversation chunk: %w", err)
 	}
 	logging.Infof("Memory chunk store: stored turn for user=%s (len=%d)", userID, len(sanitized))
-	return nil
+	return true, nil
 }
 
 // maybeStoreSessionChunk stores a session-level chunk every `stride` turns.
 // Each chunk covers the last `windowSize` turns, creating overlapping windows
 // (stride < windowSize) so facts near window boundaries still co-occur in at
-// least one chunk -- critical for multi-hop retrieval.
+// least one chunk -- critical for multi-hop retrieval. It returns true when a
+// session chunk was actually stored.
 func (e *MemoryExtractor) maybeStoreSessionChunk(
 	ctx context.Context,
 	userID string,
 	userMessage string,
 	assistantResponse string,
 	history []openai.ChatCompletionMessageParamUnion,
-) {
+) bool {
 	if len(history) == 0 {
-		return
+		return false
 	}
 
 	windowSize := e.sessionWindowSize
@@ -312,23 +314,23 @@ func (e *MemoryExtractor) maybeStoreSessionChunk(
 	// history contains prior turns; +1 for the current turn
 	totalTurns := countTurns(history) + 1
 	if totalTurns < stride {
-		return
+		return false
 	}
 	// Fire on every stride-th turn (once we have enough turns for a window)
 	if totalTurns%stride != 0 {
-		return
+		return false
 	}
 
 	// Build session chunk from the last windowSize turns of history + current
 	sessionChunk := buildSessionChunk(history, userMessage, assistantResponse, windowSize)
 	if sessionChunk == "" {
-		return
+		return false
 	}
 
 	sanitized, err := sanitizeMemoryContent(sessionChunk)
 	if err != nil {
 		logging.Debugf("Memory session chunk: REJECTED - %v (user=%s)", err, userID)
-		return
+		return false
 	}
 
 	mem := &Memory{
@@ -343,11 +345,12 @@ func (e *MemoryExtractor) maybeStoreSessionChunk(
 
 	if err := e.store.Store(ctx, mem); err != nil {
 		logging.Warnf("Memory session chunk: failed to store for user=%s: %v", userID, err)
-		return
+		return false
 	}
 
 	logging.Infof("Memory session chunk: stored %d-turn window (stride=%d) for user=%s (len=%d)",
 		windowSize, stride, userID, len(sanitized))
+	return true
 }
 
 // countTurns counts user turns in a message history. Each user message is one turn.

--- a/src/semantic-router/pkg/memory/extractor_test.go
+++ b/src/semantic-router/pkg/memory/extractor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/openai/openai-go"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -407,6 +409,74 @@ func TestProcessResponseWithHistory_NilHistory(t *testing.T) {
 	results, err := store.List(ctx, ListOptions{UserID: "user1", Limit: 100})
 	require.NoError(t, err)
 	assert.Len(t, results.Memories, 1, "nil history should still store per-turn chunk")
+}
+
+func TestProcessResponseWithHistory_RecordsStoredChunkCountMetric(t *testing.T) {
+	snapshot := func(t *testing.T) (uint64, float64) {
+		metric := &dto.Metric{}
+		writable, ok := MemoryExtractionFactsCount.WithLabelValues("episodic").(prometheus.Metric)
+		require.True(t, ok)
+		require.NoError(t, writable.Write(metric))
+		histogram := metric.GetHistogram()
+		require.NotNil(t, histogram)
+		return histogram.GetSampleCount(), histogram.GetSampleSum()
+	}
+
+	tests := []struct {
+		name       string
+		user       string
+		assistant  string
+		history    []openai.ChatCompletionMessageParamUnion
+		wantStored int
+	}{
+		{
+			name:       "per turn only",
+			user:       "What is Go and why is it useful for backend services?",
+			assistant:  "Go is a compiled language with concurrency features and simple deployment.",
+			wantStored: 1,
+		},
+		{
+			name:      "per turn plus session window",
+			user:      "Tell me about Go concurrency.",
+			assistant: "Go uses goroutines and channels for concurrency.",
+			history: []openai.ChatCompletionMessageParamUnion{
+				sdkUserMessage("What is your name?"),
+				sdkAssistantMessage("I am an AI assistant."),
+				sdkUserMessage("What languages do you know?"),
+				sdkAssistantMessage("I can help with Go, Python, and more."),
+			},
+			wantStored: 2,
+		},
+		{
+			name:       "sanitize rejected",
+			user:       "This message includes invalid UTF-8: " + string([]byte{0xff}),
+			assistant:  "This response is long enough to avoid the low entropy filter.",
+			wantStored: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewInMemoryStore()
+			extractor := NewMemoryChunkStore(store)
+			ctx := context.Background()
+
+			beforeCount, beforeSum := snapshot(t)
+			err := extractor.ProcessResponseWithHistory(
+				ctx, "session1", "user1",
+				tt.user, tt.assistant, tt.history,
+			)
+			require.NoError(t, err)
+
+			results, err := store.List(ctx, ListOptions{UserID: "user1", Limit: 100})
+			require.NoError(t, err)
+			assert.Len(t, results.Memories, tt.wantStored)
+
+			afterCount, afterSum := snapshot(t)
+			assert.Equal(t, beforeCount+1, afterCount)
+			assert.InDelta(t, beforeSum+float64(tt.wantStored), afterSum, 0.000001)
+		})
+	}
 }
 
 // =============================================================================

--- a/src/semantic-router/pkg/memory/extractor_test.go
+++ b/src/semantic-router/pkg/memory/extractor_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -11,6 +12,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingMemoryStore struct {
+	*InMemoryStore
+}
+
+func (s *failingMemoryStore) Store(ctx context.Context, memory *Memory) error {
+	return errors.New("store failed")
+}
 
 // =============================================================================
 // NewMemoryChunkStore Tests
@@ -412,6 +421,7 @@ func TestProcessResponseWithHistory_NilHistory(t *testing.T) {
 }
 
 func TestProcessResponseWithHistory_RecordsStoredChunkCountMetric(t *testing.T) {
+	defer MemoryExtractionFactsCount.Reset()
 	snapshot := func(t *testing.T) (uint64, float64) {
 		metric := &dto.Metric{}
 		writable, ok := MemoryExtractionFactsCount.WithLabelValues("episodic").(prometheus.Metric)
@@ -427,7 +437,9 @@ func TestProcessResponseWithHistory_RecordsStoredChunkCountMetric(t *testing.T) 
 		user       string
 		assistant  string
 		history    []openai.ChatCompletionMessageParamUnion
+		store      Store
 		wantStored int
+		wantErr    bool
 	}{
 		{
 			name:       "per turn only",
@@ -453,11 +465,23 @@ func TestProcessResponseWithHistory_RecordsStoredChunkCountMetric(t *testing.T) 
 			assistant:  "This response is long enough to avoid the low entropy filter.",
 			wantStored: 0,
 		},
+		{
+			name:       "store error",
+			store:      &failingMemoryStore{InMemoryStore: NewInMemoryStore()},
+			user:       "What should be remembered from this detailed request?",
+			assistant:  "This detailed response should attempt to store a conversation memory.",
+			wantStored: 0,
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store := NewInMemoryStore()
+			MemoryExtractionFactsCount.Reset()
+			store := tt.store
+			if store == nil {
+				store = NewInMemoryStore()
+			}
 			extractor := NewMemoryChunkStore(store)
 			ctx := context.Background()
 
@@ -466,15 +490,24 @@ func TestProcessResponseWithHistory_RecordsStoredChunkCountMetric(t *testing.T) 
 				ctx, "session1", "user1",
 				tt.user, tt.assistant, tt.history,
 			)
-			require.NoError(t, err)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 
 			results, err := store.List(ctx, ListOptions{UserID: "user1", Limit: 100})
 			require.NoError(t, err)
 			assert.Len(t, results.Memories, tt.wantStored)
 
 			afterCount, afterSum := snapshot(t)
-			assert.Equal(t, beforeCount+1, afterCount)
-			assert.InDelta(t, beforeSum+float64(tt.wantStored), afterSum, 0.000001)
+			if tt.wantErr {
+				assert.Equal(t, beforeCount, afterCount)
+				assert.Equal(t, beforeSum, afterSum)
+			} else {
+				assert.Equal(t, beforeCount+1, afterCount)
+				assert.InDelta(t, beforeSum+float64(tt.wantStored), afterSum, 0.000001)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

- What does this PR change?
  - Fix episodic memory extraction metrics to report the actual number of stored memory chunks by replacing the previous fixed `count=1` with explicit counting for per-turn and session-window chunks
- Why is this change needed?
  - Try to avoid recording facts-count histogram samples for failed store attempts
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`
  - Router

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
