### PR TITLE
Resolves #2010: bug: <Auth Related Integ Test Failing>

### DIFF
--- a/e2e/profiles/dashboard/dashboard-deployment.yaml
+++ b/e2e/profiles/dashboard/dashboard-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: semantic-router-dashboard
     spec:
+      securityContext:
+        fsGroup: 65532
       containers:
         - name: dashboard
           image: ghcr.io/vllm-project/semantic-router/dashboard:latest

--- a/e2e/profiles/dashboard/dashboard-deployment.yaml
+++ b/e2e/profiles/dashboard/dashboard-deployment.yaml
@@ -92,7 +92,11 @@ spec:
             - name: router-config
               mountPath: /app/config
               readOnly: true
+            - name: dashboard-data
+              mountPath: /tmp/vllm-sr-dashboard
       volumes:
         - name: router-config
           configMap:
             name: semantic-router-config
+        - name: dashboard-data
+          emptyDir: {}


### PR DESCRIPTION
Closes #2010

---

## Resolution Plan

### 1. Understanding

The E2E dashboard deployment sets all three database env vars (`DASHBOARD_AUTH_DB_PATH`, `DASHBOARD_WORKFLOW_DB_PATH`, `EVALUATION_DB_PATH`) to paths under `/tmp/vllm-sr-dashboard/`, but provides no `emptyDir` volume for that directory. The container runs as non-root user `nonroot:65532`; when `auth.NewStore()` calls `os.MkdirAll("/tmp/vllm-sr-dashboard", 0o755)` at `store.go:28`, it fails because the container's in-image `/tmp` is owned by root and not writable by the unprivileged user. `setupAuthRoutes()` catches the error, logs it, returns `nil`, and all authenticated E2E requests then get a `503 Authentication service is not configured`.

---

### 2. Affected Files

| File | Reason |
|------|--------|
| `e2e/profiles/dashboard/dashboard-deployment.yaml` | Only file to change — missing emptyDir volume + volumeMount |

No application code changes needed. `dashboard/backend/auth/store.go`, `dashboard/backend/router/auth_routes.go`, and all `e2e/testcases/dashboard_*.go` files are correct as-is.

---

### 3. Proposed Change

**`e2e/profiles/dashboard/dashboard-deployment.yaml`**

Two edits, matching the Helm pattern (`deploy/helm/semantic-router/templates/dashboard-deployment.yaml:104-106, 126-129`):

**a) Add volumeMount** under `spec.template.spec.containers[0].volumeMounts` (after the existing `router-config` mount, line 91–94):

```yaml
        - name: dashboard-data
          mountPath: /tmp/vllm-sr-dashboard
```

**b) Add volume** under `spec.template.spec.volumes` (after the existing `router-config` volume, line 95–98):

```yaml
      - name: dashboard-data
        emptyDir: {}
```
