### PR TITLE
[Docs] Add multi-step pipeline routing example

### DIFF
--- a/config/decision/composite/multi-step-pipeline.yaml
+++ b/config/decision/composite/multi-step-pipeline.yaml
@@ -13,7 +13,7 @@ routing:
               - type: keyword
                 name: pipeline_step_extract
       modelRefs:
-        - model: summarizer-model
+        - model: qwen3-8b
           use_reasoning: false
     - name: pipeline_extract_step
       description: Pin the extraction stage of a client-orchestrated pipeline.
@@ -28,5 +28,5 @@ routing:
               - type: keyword
                 name: pipeline_step_summarize
       modelRefs:
-        - model: insight-model
+        - model: qwen3-32b
           use_reasoning: true

--- a/config/decision/composite/multi-step-pipeline.yaml
+++ b/config/decision/composite/multi-step-pipeline.yaml
@@ -1,0 +1,32 @@
+routing:
+  decisions:
+    - name: pipeline_summarize_step
+      description: Pin the summarization stage of a client-orchestrated pipeline.
+      priority: 190
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: pipeline_step_summarize
+          - operator: NOT
+            conditions:
+              - type: keyword
+                name: pipeline_step_extract
+      modelRefs:
+        - model: summarizer-model
+          use_reasoning: false
+    - name: pipeline_extract_step
+      description: Pin the extraction stage of a client-orchestrated pipeline.
+      priority: 190
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: pipeline_step_extract
+          - operator: NOT
+            conditions:
+              - type: keyword
+                name: pipeline_step_summarize
+      modelRefs:
+        - model: insight-model
+          use_reasoning: true

--- a/config/signal/keyword/multi-step-pipeline.yaml
+++ b/config/signal/keyword/multi-step-pipeline.yaml
@@ -1,0 +1,11 @@
+routing:
+  signals:
+    keywords:
+      - name: pipeline_step_summarize
+        operator: OR
+        keywords: ["__pipeline_step:summarize__", "__step1__"]
+        case_sensitive: false
+      - name: pipeline_step_extract
+        operator: OR
+        keywords: ["__pipeline_step:extract__", "__step2__"]
+        case_sensitive: false

--- a/src/semantic-router/pkg/classification/multi_step_pipeline_fragment_test.go
+++ b/src/semantic-router/pkg/classification/multi_step_pipeline_fragment_test.go
@@ -1,0 +1,113 @@
+package classification
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestMultiStepPipelineKeywordFragmentDetectsStepMarkers(t *testing.T) {
+	rules := loadMultiStepPipelineKeywordRules(t)
+	classifier, err := NewKeywordClassifier(rules)
+	if err != nil {
+		t.Fatalf("NewKeywordClassifier() error = %v", err)
+	}
+	defer classifier.Free()
+
+	tests := []struct {
+		name        string
+		text        string
+		wantRule    string
+		wantKeyword string
+	}{
+		{
+			name:        "summarize marker",
+			text:        "<semantic-router-step>__pipeline_step:summarize__</semantic-router-step>",
+			wantRule:    "pipeline_step_summarize",
+			wantKeyword: "__pipeline_step:summarize__",
+		},
+		{
+			name:        "summarize alias",
+			text:        "<semantic-router-step>__step1__</semantic-router-step>",
+			wantRule:    "pipeline_step_summarize",
+			wantKeyword: "__step1__",
+		},
+		{
+			name:        "summarize marker is case insensitive",
+			text:        "<semantic-router-step>__PIPELINE_STEP:SUMMARIZE__</semantic-router-step>",
+			wantRule:    "pipeline_step_summarize",
+			wantKeyword: "__pipeline_step:summarize__",
+		},
+		{
+			name:        "extract marker",
+			text:        "<semantic-router-step>__pipeline_step:extract__</semantic-router-step>",
+			wantRule:    "pipeline_step_extract",
+			wantKeyword: "__pipeline_step:extract__",
+		},
+		{
+			name:        "extract alias",
+			text:        "<semantic-router-step>__step2__</semantic-router-step>",
+			wantRule:    "pipeline_step_extract",
+			wantKeyword: "__step2__",
+		},
+		{
+			name:        "extract marker is case insensitive",
+			text:        "<semantic-router-step>__PIPELINE_STEP:EXTRACT__</semantic-router-step>",
+			wantRule:    "pipeline_step_extract",
+			wantKeyword: "__pipeline_step:extract__",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRule, gotKeywords, err := classifier.ClassifyWithKeywords(tt.text)
+			if err != nil {
+				t.Fatalf("ClassifyWithKeywords() error = %v", err)
+			}
+			if gotRule != tt.wantRule {
+				t.Fatalf("ClassifyWithKeywords() rule = %q, want %q", gotRule, tt.wantRule)
+			}
+			if !containsString(gotKeywords, tt.wantKeyword) {
+				t.Fatalf("ClassifyWithKeywords() keywords = %v, want to include %q", gotKeywords, tt.wantKeyword)
+			}
+		})
+	}
+}
+
+func loadMultiStepPipelineKeywordRules(t *testing.T) []config.KeywordRule {
+	t.Helper()
+	path := filepath.Join(repoRootFromClassificationTest(t), "config", "signal", "keyword", "multi-step-pipeline.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read multi-step pipeline keyword fragment: %v", err)
+	}
+
+	var fragment struct {
+		Routing struct {
+			Signals struct {
+				Keywords []config.KeywordRule `yaml:"keywords"`
+			} `yaml:"signals"`
+		} `yaml:"routing"`
+	}
+	if err := yaml.Unmarshal(data, &fragment); err != nil {
+		t.Fatalf("parse multi-step pipeline keyword fragment: %v", err)
+	}
+	if len(fragment.Routing.Signals.Keywords) != 2 {
+		t.Fatalf("keyword fragment rules = %d, want 2", len(fragment.Routing.Signals.Keywords))
+	}
+	return fragment.Routing.Signals.Keywords
+}
+
+func repoRootFromClassificationTest(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
+}

--- a/src/semantic-router/pkg/decision/multi_step_pipeline_fragment_test.go
+++ b/src/semantic-router/pkg/decision/multi_step_pipeline_fragment_test.go
@@ -1,0 +1,118 @@
+package decision
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestMultiStepPipelineDecisionFragmentRoutesEachStep(t *testing.T) {
+	decisions := loadMultiStepPipelineDecisions(t)
+	decisions = append(decisions, config.Decision{
+		Name:     "generic_pipeline_step",
+		Priority: 10,
+		Rules: config.RuleCombination{
+			Operator: "OR",
+			Conditions: []config.RuleCondition{
+				{Type: "keyword", Name: "pipeline_step_summarize"},
+				{Type: "keyword", Name: "pipeline_step_extract"},
+			},
+		},
+		ModelRefs: []config.ModelRef{{Model: "qwen2.5:3b"}},
+	})
+
+	engine := NewDecisionEngine(nil, nil, nil, decisions, "priority")
+
+	tests := []struct {
+		name         string
+		matchedRules []string
+		wantDecision string
+		wantModel    string
+	}{
+		{
+			name:         "summarize step",
+			matchedRules: []string{"pipeline_step_summarize"},
+			wantDecision: "pipeline_summarize_step",
+			wantModel:    "qwen3-8b",
+		},
+		{
+			name:         "extract step",
+			matchedRules: []string{"pipeline_step_extract"},
+			wantDecision: "pipeline_extract_step",
+			wantModel:    "qwen3-32b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := engine.EvaluateDecisions(tt.matchedRules, nil, nil)
+			if err != nil {
+				t.Fatalf("EvaluateDecisions() error = %v", err)
+			}
+			if result == nil {
+				t.Fatal("EvaluateDecisions() result is nil")
+			}
+			if result.Decision.Name != tt.wantDecision {
+				t.Fatalf("decision = %q, want %q", result.Decision.Name, tt.wantDecision)
+			}
+			if len(result.Decision.ModelRefs) != 1 {
+				t.Fatalf("modelRefs = %d, want 1", len(result.Decision.ModelRefs))
+			}
+			if result.Decision.ModelRefs[0].Model != tt.wantModel {
+				t.Fatalf("model = %q, want %q", result.Decision.ModelRefs[0].Model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestMultiStepPipelineDecisionFragmentRejectsAmbiguousMarkers(t *testing.T) {
+	engine := NewDecisionEngine(nil, nil, nil, loadMultiStepPipelineDecisions(t), "priority")
+
+	result, err := engine.EvaluateDecisions(
+		[]string{"pipeline_step_summarize", "pipeline_step_extract"},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("EvaluateDecisions() error = %v", err)
+	}
+	if result != nil {
+		t.Fatalf("EvaluateDecisions() decision = %q, want no match", result.Decision.Name)
+	}
+}
+
+func loadMultiStepPipelineDecisions(t *testing.T) []config.Decision {
+	t.Helper()
+	path := filepath.Join(repoRootFromDecisionTest(t), "config", "decision", "composite", "multi-step-pipeline.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read multi-step pipeline decision fragment: %v", err)
+	}
+
+	var fragment struct {
+		Routing struct {
+			Decisions []config.Decision `yaml:"decisions"`
+		} `yaml:"routing"`
+	}
+	if err := yaml.Unmarshal(data, &fragment); err != nil {
+		t.Fatalf("parse multi-step pipeline decision fragment: %v", err)
+	}
+	if len(fragment.Routing.Decisions) != 2 {
+		t.Fatalf("decision fragment decisions = %d, want 2", len(fragment.Routing.Decisions))
+	}
+	return fragment.Routing.Decisions
+}
+
+func repoRootFromDecisionTest(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", ".."))
+}

--- a/website/docs/tutorials/decision/multi-step-pipeline.md
+++ b/website/docs/tutorials/decision/multi-step-pipeline.md
@@ -1,0 +1,98 @@
+# Multi-Step Pipeline Routing
+
+## Overview
+
+Use this pattern when a client already orchestrates a fixed multi-step workflow, but each step should be routed to a different model by Semantic Router.
+
+Semantic Router does not execute a full pipeline graph for the client. The client still sends one request per step. Each request carries a stable step marker, such as `__pipeline_step:summarize__` or `__pipeline_step:extract__`, and normal keyword signals map those markers to route decisions.
+
+## Key Advantages
+
+- Uses the existing signal and decision surfaces instead of adding a new pipeline runtime.
+- Keeps the step-to-model binding explicit and reviewable.
+- Lets operators pin each stage to a model while retaining normal routing observability.
+- Avoids hidden orchestration state inside the router; the client owns step order and request chaining.
+
+## What Problem Does It Solve?
+
+Some applications want predictable staged routing, such as summarizing a long document with one model and extracting structured insights with another model. That is not the same as asking Semantic Router to pick the best single model for a request.
+
+This pattern solves the routing part of that workflow. The client labels each request with the stage it is currently running, and Semantic Router picks the configured model for that stage.
+
+## When to Use
+
+Use multi-step pipeline routing when:
+
+- the application already knows the workflow order
+- each step is a separate request to the router
+- each step should be pinned to a known model or candidate set
+- stable lexical markers are acceptable for identifying the step
+
+Do not use this pattern when the router needs to decide the next step, run multiple steps automatically, or manage a dynamic DAG. Those remain application orchestration responsibilities.
+
+## Configuration
+
+Source fragments:
+
+- `config/signal/keyword/multi-step-pipeline.yaml`
+- `config/decision/composite/multi-step-pipeline.yaml`
+
+First, define keyword signals for the request markers:
+
+```yaml
+routing:
+  signals:
+    keywords:
+      - name: pipeline_step_summarize
+        operator: OR
+        keywords: ["__pipeline_step:summarize__", "__step1__"]
+        case_sensitive: false
+      - name: pipeline_step_extract
+        operator: OR
+        keywords: ["__pipeline_step:extract__", "__step2__"]
+        case_sensitive: false
+```
+
+Then bind each marker to a route. The `NOT` guard keeps the example unambiguous if a malformed request includes both markers:
+
+```yaml
+routing:
+  decisions:
+    - name: pipeline_summarize_step
+      description: Pin the summarization stage of a client-orchestrated pipeline.
+      priority: 190
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: pipeline_step_summarize
+          - operator: NOT
+            conditions:
+              - type: keyword
+                name: pipeline_step_extract
+      modelRefs:
+        - model: summarizer-model
+          use_reasoning: false
+    - name: pipeline_extract_step
+      description: Pin the extraction stage of a client-orchestrated pipeline.
+      priority: 190
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: pipeline_step_extract
+          - operator: NOT
+            conditions:
+              - type: keyword
+                name: pipeline_step_summarize
+      modelRefs:
+        - model: insight-model
+          use_reasoning: true
+```
+
+A client can then run the workflow as two normal requests:
+
+1. Send the original document with `__pipeline_step:summarize__` and store the summary.
+2. Send the summary with `__pipeline_step:extract__` and ask for structured insights.
+
+Only one step marker should be present in each request. Keyword signals inspect the model request, so these markers are model-visible in this pattern; put them in an application-controlled wrapper that the model can safely ignore if that matters.

--- a/website/docs/tutorials/decision/multi-step-pipeline.md
+++ b/website/docs/tutorials/decision/multi-step-pipeline.md
@@ -71,7 +71,7 @@ routing:
               - type: keyword
                 name: pipeline_step_extract
       modelRefs:
-        - model: summarizer-model
+        - model: qwen3-8b
           use_reasoning: false
     - name: pipeline_extract_step
       description: Pin the extraction stage of a client-orchestrated pipeline.
@@ -86,13 +86,37 @@ routing:
               - type: keyword
                 name: pipeline_step_summarize
       modelRefs:
-        - model: insight-model
+        - model: qwen3-32b
           use_reasoning: true
 ```
 
-A client can then run the workflow as two normal requests:
+The sample `modelRefs` use `qwen3-8b` and `qwen3-32b`, which are model names from the reference configuration. Replace them with model names registered in your deployment before shipping this fragment.
+
+## Client Request Pattern
+
+A client can run the workflow as two normal requests:
 
 1. Send the original document with `__pipeline_step:summarize__` and store the summary.
 2. Send the summary with `__pipeline_step:extract__` and ask for structured insights.
 
-Only one step marker should be present in each request. Keyword signals inspect the model request, so these markers are model-visible in this pattern; put them in an application-controlled wrapper that the model can safely ignore if that matters.
+For example, keep the marker in an application-controlled wrapper instead of free-form user text:
+
+```json
+{
+  "model": "auto",
+  "messages": [
+    {
+      "role": "system",
+      "content": "Ignore semantic-router-step markers. They are routing metadata, not task instructions."
+    },
+    {
+      "role": "user",
+      "content": "<semantic-router-step>__pipeline_step:summarize__</semantic-router-step>\nSummarize the following document:\n..."
+    }
+  ]
+}
+```
+
+Only one step marker should be present in each request. If both step markers are present, the `NOT` guards prevent both pipeline decisions from matching and normal fallback routing applies.
+
+Keyword signals inspect the model request, so these markers are model-visible in this pattern. Choose markers that are unlikely to collide with user content, add them from application code rather than accepting them from users, and instruct the target model to ignore the wrapper when needed.

--- a/website/docs/tutorials/decision/overview.md
+++ b/website/docs/tutorials/decision/overview.md
@@ -69,4 +69,6 @@ Use the case-shape catalog below in the same order as the fragment tree:
 | `composite` | `config/decision/composite/priority-safe-escalation.yaml` | nested real-world policies | [Composite Decisions](./composite) |
 | `retention` | `routing.decisions[].emits[]` | post-decision cache/session side effects | [Retention Directives](./retention) |
 
+For a reusable workflow pattern that combines keyword signals with composite decisions, see [Multi-Step Pipeline Routing](./multi-step-pipeline).
+
 Add [Algorithm](../algorithm/overview) when `modelRefs` contains more than one candidate, and add [Plugin](../plugin/overview) when the route needs post-selection behavior.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -126,6 +126,7 @@ const sidebars: SidebarsConfig = {
             'tutorials/decision/or',
             'tutorials/decision/not',
             'tutorials/decision/composite',
+            'tutorials/decision/multi-step-pipeline',
             'tutorials/decision/retention',
           ],
         },


### PR DESCRIPTION
## Summary
- add keyword signal and composite decision fragments for client-orchestrated multi-step routing
- document how step markers such as `__pipeline_step:summarize__` and `__pipeline_step:extract__` can pin each step to a model
- clarify that the client still orchestrates multiple requests while Semantic Router handles per-step model routing

## Validation
- `agent-ci-gate CHANGED_FILES="config/signal/keyword/multi-step-pipeline.yaml,config/decision/composite/multi-step-pipeline.yaml,website/docs/tutorials/decision/multi-step-pipeline.md,website/docs/tutorials/decision/overview.md,website/sidebars.ts"`

Refs #1815
