### PR TITLE
[auto-pareto/cheap] Add configurable score threshold to language signal API

### DIFF
--- a/src/semantic-router/pkg/classification/language_threshold_test.go
+++ b/src/semantic-router/pkg/classification/language_threshold_test.go
@@ -1,0 +1,27 @@
+package classification
+
+import "testing"
+
+func TestLanguageClassifier_ThresholdFiltering(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	text := "Hola, ¿cómo estás? Me llamo Juan y vivo en Madrid. ¿De dónde eres tú? Esta es una pregunta en español sobre mi ubicación."
+
+	// Low threshold should allow Spanish detection
+	resLow, err := classifier.ClassifyWithThreshold(text, 0.5)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if resLow.LanguageCode != "es" {
+		t.Fatalf("expected language 'es' for threshold 0.5, got %q", resLow.LanguageCode)
+	}
+
+	// Very high threshold should cause fallback to English
+	resHigh, err := classifier.ClassifyWithThreshold(text, 0.99)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if resHigh.LanguageCode == "es" {
+		t.Fatalf("expected fallback (not 'es') for threshold 0.99, got %q", resHigh.LanguageCode)
+	}
+}

--- a/src/semantic-router/pkg/dsl/compiler_signals.go
+++ b/src/semantic-router/pkg/dsl/compiler_signals.go
@@ -146,6 +146,9 @@ func (c *Compiler) compileLanguageSignal(s *SignalDecl) {
 	if v, ok := getStringField(s.Fields, "description"); ok {
 		rule.Description = v
 	}
+	if v, ok := getFloat32Field(s.Fields, "threshold"); ok {
+		rule.Threshold = v
+	}
 	c.config.LanguageRules = append(c.config.LanguageRules, rule)
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -104,6 +104,9 @@ func (d *decompiler) languageToSignal(lang *config.LanguageRule) *SignalDecl {
 	if lang.Description != "" {
 		fields["description"] = StringValue{V: lang.Description}
 	}
+	if lang.Threshold != 0 {
+		fields["threshold"] = FloatValue{V: float64(lang.Threshold)}
+	}
 	return &SignalDecl{SignalType: "language", Name: lang.Name, Fields: fields}
 }
 

--- a/src/semantic-router/pkg/dsl/language_threshold_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/language_threshold_roundtrip_test.go
@@ -1,0 +1,41 @@
+package dsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestDecompileLanguageThresholdRoundTrip(t *testing.T) {
+	cfg := &config.RouterConfig{
+		Categories: []config.Category{},
+		LanguageRules: []config.LanguageRule{
+			{Name: "es", Description: "Spanish", Threshold: 0.8},
+		},
+	}
+
+	dslText, err := DecompileRouting(cfg)
+	if err != nil {
+		t.Fatalf("DecompileRouting failed: %v", err)
+	}
+
+	if !strings.Contains(dslText, "SIGNAL language es") {
+		t.Fatalf("decompiled DSL missing language signal:\n%s", dslText)
+	}
+	if !strings.Contains(dslText, "threshold: 0.8") {
+		t.Fatalf("decompiled DSL missing threshold field:\n%s", dslText)
+	}
+
+	// Round-trip: compile back and verify threshold survives
+	rtCfg, errs := Compile(dslText)
+	if len(errs) > 0 {
+		t.Fatalf("round-trip compile errors: %v\n%s", errs, dslText)
+	}
+	if len(rtCfg.LanguageRules) != 1 {
+		t.Fatalf("round-trip: expected 1 language rule, got %d", len(rtCfg.LanguageRules))
+	}
+	if rtCfg.LanguageRules[0].Threshold != 0.8 {
+		t.Fatalf("round-trip: expected threshold 0.8, got %v", rtCfg.LanguageRules[0].Threshold)
+	}
+}


### PR DESCRIPTION
Auto-resolve for #1723 (verdict: lgtm)

Localizer brief:

Mode: fix

**Root cause**
Issue #1723 requires adding configurable threshold support to language signal API. The feature is ALREADY IMPLEMENTED in the codebase as of `classifier_signal_language.go:19-20` and `language_classifier.go:75-79`, but the DSL/YAML conversion layer does not serialize/deserialize the `Threshold` field in `LanguageRule`. The `languageToSignal()` decompiler at `decompiler_convert.go` only exports `description`, not `threshold`, preventing threshold configuration from persisting through DSL round-trips.

**Affected files** (workspace-relative, ranked by relevance)
1. `src/semantic-router/pkg/dsl/decompiler_convert.go` — Missing threshold serialization in `languageToSignal()` function
2. `src/semantic-router/pkg/dsl/compiler_signals.go` — Missing threshold deserialization in language signal compiler
3. `src/semantic-router/pkg/language_classifier_test.go` — Need test coverage for `ClassifyWithThreshold()` with custom thresholds
4. `src/semantic-router/pkg/config/signal_config.go` — Already has `LanguageRule.Threshold` field (lines 161–169); no changes needed

**Anchor symbols**
- `LanguageRule.Threshold` field: `src/semantic-router/pkg/config/signal_config.go:168`
- `lowestLanguageThreshold()`: `src/semantic-router/pkg/classification/classifier_signal_language.go:69–77` — computes minimum threshold across rules
- `evaluateLanguageSignal()`: `src/semantic-router/pkg/classification/classifier_signal_language.go:12–64` — evaluates and filters by per-rule threshold
- `ClassifyWithThreshold()`: `src/semantic-router/pkg/classification/language_classifier.go:75–124` — applies threshold to lingua-go detection
- `languageToSignal()`: `src/semantic-router/pkg/dsl/decompiler_convert.go` — MUST add `Threshold` field export

**Reference call-sites** (imitate these patterns for threshold handling)
- `src/semantic-router/pkg/config/signal_config.go:115–118` — `ReaskRule.WithDefaults()` shows how to handle optional threshold with defaults
- `src/semantic-router/pkg/dsl/decompiler_convert.go:~200+` (reask/preference) — show threshold export patterns (e.g., `fields["threshold"] = ...`)
- `src/semantic-router/pkg/dsl/compiler_signals.go` — language signal compilation must parse threshold from YAML (follow embedding/reask patterns)

**Runner/CI dependencies**
- Tests: `src/semantic-router/pkg/classification/language_classifier_test.go` (already runs; add `TestLanguageClassifier_ThresholdFiltering`)
- Config validation: `src/semantic-router/pkg/config/validator_*.go` (may need validator for threshold bounds, 0 ≤ threshold ≤ 1)
- DSL compilation: DSL tests in `src/semantic-router/pkg/dsl/dsl_test.go` must round-trip threshold through compile/decompile cycle

**Tests to update or add**
- `src/semantic-router/pkg/classification/language_classifier_test.go` — Add `TestLanguageClassifier_ThresholdFiltering()` testing `ClassifyWithThreshold()` with custom thresholds (0.5, 0.8)
- `src/semantic-router/pkg/dsl/dsl_test.go` — Add language rule with threshold to ensure DSL round-trip preserves the field
- Config tests: verify threshold bounds validation in `src/semantic-router/pkg/config/validator_*.go` (threshold must be in 0–1 range)

**Risks / unknowns**
- Unknown: Does DSL grammar already support `threshold` keyword for language signals, or must the grammar be extended? Check `src/semantic-router/pkg/dsl/compiler_signals.go` for existing language signal parsing.
- Unknown: Are there any CLI/API routes that construct `LanguageRule` directly (outside YAML)? If so, they may not populate `Threshold`.
- Assumption: Threshold validation (0 ≤ x ≤ 1) should follow the same pattern as `ReaskRule` and other signal thresholds; no new validation patterns required.

Verifier findings:

Verdict: lgtm — treated as a fix patch; the language threshold field is already implemented, wired into evaluation, and covered by tests.

## Findings
- (no issues found)

## Required follow-ups
- (none)