### PR TITLE
[auto-pareto/strong] Add configurable score threshold to language signal API

### DIFF
--- a/src/semantic-router/pkg/classification/language_classifier_test.go
+++ b/src/semantic-router/pkg/classification/language_classifier_test.go
@@ -1,6 +1,7 @@
 package classification
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -127,5 +128,104 @@ func TestLanguageClassifier_HandlesMixedAndSpecialInputs(t *testing.T) {
 				t.Fatalf("expected confidence >= %f, got %f", tt.minScore, result.Confidence)
 			}
 		})
+	}
+}
+
+func TestClassifyWithThreshold_DefaultThreshold(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+	text := "Hello, how are you?"
+
+	result, err := classifier.ClassifyWithThreshold(text, 0)
+	if err != nil {
+		t.Fatalf("classification with implicit default threshold failed: %v", err)
+	}
+
+	expected, err := classifier.ClassifyWithThreshold(text, defaultLanguageThreshold)
+	if err != nil {
+		t.Fatalf("classification with explicit default threshold failed: %v", err)
+	}
+
+	if result.LanguageCode != expected.LanguageCode {
+		t.Fatalf("expected language %q, got %q", expected.LanguageCode, result.LanguageCode)
+	}
+	if math.Abs(result.Confidence-expected.Confidence) > 1e-9 {
+		t.Fatalf("expected confidence %f, got %f", expected.Confidence, result.Confidence)
+	}
+}
+
+func TestClassifyWithThreshold_HighThresholdFallsBackToEnglish(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	result, err := classifier.ClassifyWithThreshold("Hello, bonjour, hola", 0.999)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if result.LanguageCode != "en" {
+		t.Fatalf("expected fallback language %q, got %q", "en", result.LanguageCode)
+	}
+	if result.Confidence != 0.5 {
+		t.Fatalf("expected fallback confidence %f, got %f", 0.5, result.Confidence)
+	}
+}
+
+func TestClassifyWithThreshold_LowThresholdAllowsDetection(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	result, err := classifier.ClassifyWithThreshold("你好，世界，这是一个中文句子，用来测试语言检测。", 0.01)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if result.LanguageCode != "zh" {
+		t.Fatalf("expected language %q, got %q", "zh", result.LanguageCode)
+	}
+	if result.Confidence < 0.01 {
+		t.Fatalf("expected confidence >= %f, got %f", 0.01, result.Confidence)
+	}
+}
+
+func TestLowestLanguageThreshold_NoRules(t *testing.T) {
+	if got := lowestLanguageThreshold(nil); got != 0 {
+		t.Fatalf("expected threshold %f, got %f", 0.0, got)
+	}
+}
+
+func TestLowestLanguageThreshold_AllZeroThresholds(t *testing.T) {
+	rules := []config.LanguageRule{{Name: "en"}, {Name: "es", Threshold: 0}, {Name: "fr"}}
+
+	if got := lowestLanguageThreshold(rules); got != 0 {
+		t.Fatalf("expected threshold %f, got %f", 0.0, got)
+	}
+}
+
+func TestLowestLanguageThreshold_SingleRule(t *testing.T) {
+	rules := []config.LanguageRule{{Name: "zh", Threshold: 0.65}}
+
+	if got := lowestLanguageThreshold(rules); got != 0.65 {
+		t.Fatalf("expected threshold %f, got %f", 0.65, got)
+	}
+}
+
+func TestLowestLanguageThreshold_MultipleRulesReturnsMinimum(t *testing.T) {
+	rules := []config.LanguageRule{
+		{Name: "en", Threshold: 0.7},
+		{Name: "es", Threshold: 0.2},
+		{Name: "fr", Threshold: 0.5},
+	}
+
+	if got := lowestLanguageThreshold(rules); got != 0.2 {
+		t.Fatalf("expected threshold %f, got %f", 0.2, got)
+	}
+}
+
+func TestLowestLanguageThreshold_MixedZeroAndNonZero(t *testing.T) {
+	rules := []config.LanguageRule{
+		{Name: "en"},
+		{Name: "es", Threshold: 0.45},
+		{Name: "fr", Threshold: 0},
+		{Name: "zh", Threshold: 0.15},
+	}
+
+	if got := lowestLanguageThreshold(rules); got != 0.15 {
+		t.Fatalf("expected threshold %f, got %f", 0.15, got)
 	}
 }


### PR DESCRIPTION
Auto-resolve for #1723 (verdict: lgtm)

Localizer brief:

Mode: fix

## Root cause
Issue #1723 tracks a feature request to add configurable score threshold to the language signal API. The feature implementation is COMPLETE in the current codebase (commit 9b22b305: "feat(signals): configurable confidence threshold for language signal (#1723) (#1864)"), but the tests to validate threshold behavior are MISSING.

The core code additions:
- `LanguageRule.Threshold` field (line 168 in `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/config/signal_config.go`)
- `LanguageClassifier.ClassifyWithThreshold()` method (line 75 in `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier.go`)
- `evaluateLanguageSignal()` function with per-rule threshold enforcement (in `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/classifier_signal_language.go`)
- `lowestLanguageThreshold()` helper (line 69 in `classifier_signal_language.go`)

BUT: `language_classifier_test.go` (currently 131 lines) lacks coverage for ClassifyWithThreshold() and lowestLanguageThreshold() functions.

## Affected files
- `src/semantic-router/pkg/classification/language_classifier_test.go` — Add 8 test functions (~100 lines) to cover threshold behavior

## Anchor symbols
1. **LanguageClassifier.ClassifyWithThreshold()** — `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier.go:75`
2. **lowestLanguageThreshold()** — `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/classifier_signal_language.go:69`
3. **defaultLanguageThreshold constant** — `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier.go:41`
4. **LanguageRule.Threshold field** — `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/config/signal_config.go:168`

## Reference call-sites
- `evaluateLanguageSignal()` calls `lowestLanguageThreshold()` at line 19 then `ClassifyWithThreshold()` at line 20 in `classifier_signal_language.go`
- Per-rule threshold enforcement at line 50 in `classifier_signal_language.go`: `if rule.Threshold > 0 && float32(languageResult.Confidence) < rule.Threshold`
- Existing high-level integration tests in `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier_test.go` (see TestLanguageClassifier_DetectsCommonLanguages at line 36)

## Runner/CI dependencies
- Make target / test runner: `go test ./src/semantic-router/pkg/classification/... -v` covers language_classifier_test.go
- GitHub CI workflow likely runs this test suite on every PR

## Tests to update or add
Add 8 new test functions to `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier_test.go` (after line 98):
1. **TestClassifyWithThreshold_DefaultThreshold** — verify threshold=0 falls back to defaultLanguageThreshold (0.3)
2. **TestClassifyWithThreshold_HighThresholdFallsBackToEnglish** — threshold=0.999 on ambiguous text returns fallback sentinel (confidence=0.5, lang="en")
3. **TestClassifyWithThreshold_LowThresholdAllowsDetection** — threshold=0.01 accepts high-confidence Chinese detection
4. **TestLowestLanguageThreshold_NoRules** — nil rules return 0
5. **TestLowestLanguageThreshold_AllZeroThresholds** — all-zero LanguageRule thresholds return 0
6. **TestLowestLanguageThreshold_SingleRule** — single non-zero threshold returned unchanged
7. **TestLowestLanguageThreshold_MultipleRulesReturnsMinimum** — minimum of multiple non-zero thresholds is selected
8. **TestLowestLanguageThreshold_MixedZeroAndNonZero** — zero entries skipped when computing minimum

## Reference test patterns
See commit 838403e5 "Add unit tests for language threshold feature" (branch: fork/auto-pareto/strong-1723) for the exact test implementations; they follow the existing pattern in language_classifier_test.go (simple for-loop with t.Run subtests, clear error messages with expected vs. actual values).

## Risks / unknowns
- None; the feature code is stable and the test patterns are clear. This is a straightforward test-coverage gap.

Verifier findings:

Verdict: lgtm — fix patch (test-only) that correctly exercises already-landed production code for the configurable language threshold feature.

## Findings
- No issues found. All referenced symbols (`ClassifyWithThreshold`, `defaultLanguageThreshold`, `lowestLanguageThreshold`, `config.LanguageRule.Threshold`) are present in the production code. Logic in each test case was verified against the implementation:
  - `TestClassifyWithThreshold_DefaultThreshold`: `threshold=0` branches to `defaultLanguageThreshold` (0.3) inside the implementation, so both calls are equivalent. ✓
  - `TestClassifyWithThreshold_HighThresholdFallsBackToEnglish`: threshold 0.999 will exceed any real confidence score; the fallback path returns `{LanguageCode:"en", Confidence:0.5}`. ✓
  - `TestLowestLanguageThreshold_*`: the min-of-nonzero scan in `lowestLanguageThreshold` matches every expected output in the table. ✓

## Required follow-ups
(none)