### PR TITLE
[auto-pareto/cheap] Add configurable score threshold to language signal API

### DIFF
--- a/src/semantic-router/pkg/classification/language_classifier_test.go
+++ b/src/semantic-router/pkg/classification/language_classifier_test.go
@@ -129,3 +129,63 @@ func TestLanguageClassifier_HandlesMixedAndSpecialInputs(t *testing.T) {
 		})
 	}
 }
+
+func TestLanguageClassifier_RespectPerRuleThreshold(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	// Use a reasonably long Spanish text to get a decent confidence score.
+	text := "Hola, ¿cómo estás? Me llamo Juan y vivo en Madrid. ¿De dónde eres tú? Esta es una pregunta en español sobre mi ubicación."
+
+	// Very high threshold should force a fallback to English (confidence 0.5).
+	high, err := classifier.ClassifyWithThreshold(text, 0.99)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if high.LanguageCode != "en" || high.Confidence != 0.5 {
+		t.Fatalf("expected fallback to english with confidence 0.5 for high threshold, got: %v", high)
+	}
+
+	// Low threshold should allow a real language detection (not the fallback).
+	low, err := classifier.ClassifyWithThreshold(text, 0.1)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if low.LanguageCode == "en" && low.Confidence == 0.5 {
+		t.Fatalf("expected non-fallback result for low threshold, got fallback: %v", low)
+	}
+}
+
+func TestLanguageClassifier_DefaultThresholdWhenUnset(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	text := "Bonjour, comment allez-vous?"
+
+	// threshold == 0 should use defaultLanguageThreshold internally and thus
+	// behave the same as Classify().
+	withZero, err := classifier.ClassifyWithThreshold(text, 0)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	without, err := classifier.Classify(text)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if withZero.LanguageCode != without.LanguageCode || withZero.Confidence != without.Confidence {
+		t.Fatalf("expected ClassifyWithThreshold(...,0) to match Classify(): got %v vs %v", withZero, without)
+	}
+}
+
+func TestLanguageClassifier_CustomThresholdRejects(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	// Very short text which may have low confidence; a very high threshold should reject it.
+	text := "Hi"
+
+	res, err := classifier.ClassifyWithThreshold(text, 0.9)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if res.LanguageCode != "en" || res.Confidence != 0.5 {
+		t.Fatalf("expected fallback to english with confidence 0.5 for high threshold on short text, got: %v", res)
+	}
+}


### PR DESCRIPTION
Auto-resolve for #1723 (verdict: lgtm)

Localizer brief:

Mode: fix

## Root cause
The threshold field **ALREADY EXISTS** in `LanguageRule` struct (`signal_config.go:168`), and the implementation is **ALREADY COMPLETE** and WIRED:
- Threshold field defined at `signal_config.go:168` with comment explaining behavior
- Evaluated in `classifier_signal_language.go:50` with per-rule enforcement
- Passed to lingua-go classifier via `ClassifyWithThreshold` at `classifier_signal_language.go:20`
- Default fallback behavior preserved via `lowestLanguageThreshold()` at `classifier_signal_language.go:69-77`

## Affected files
1. **src/semantic-router/pkg/config/signal_config.go** — `LanguageRule` struct already has `Threshold float32` field (line 168)
2. **src/semantic-router/pkg/classification/classifier_signal_language.go** — Already wired: calls `lowestLanguageThreshold()` and `ClassifyWithThreshold()` 
3. **src/semantic-router/pkg/classification/language_classifier.go** — Already implements `ClassifyWithThreshold()` with default fallback (lines 71-124)
4. **src/semantic-router/pkg/classification/language_classifier_test.go** — Tests exist but **lack threshold-specific tests**

## Anchor symbols
- `LanguageRule.Threshold`: `signal_config.go:168` (float32, omitempty)
- `lowestLanguageThreshold()`: `classifier_signal_language.go:69`
- `LanguageClassifier.ClassifyWithThreshold()`: `language_classifier.go:75`
- `evaluateLanguageSignal()`: `classifier_signal_language.go:12`
- `defaultLanguageThreshold`: `language_classifier.go:41`

## Reference call-sites (existing threshold patterns)
- `JailbreakRule.Threshold` + `PIIRule.Threshold`: `signal_config.go:139,148` — similar float32 threshold fields
- `ReaskRule.WithDefaults()`: `signal_config.go:120-129` — pattern for threshold default handling
- `EmbeddingRule.SimilarityThreshold`: `signal_config.go:83` — used in embedding matching (`classifier_signal_eval.go`)

## Runner/CI dependencies
Search for test files running language signal tests:
- `language_classifier_test.go` — unit tests for classifier
- Look for integration tests in `e2e/testcases/` or `pkg/classification/*_test.go` referencing language rules

## Tests to update or add
**MUST ADD** tests in `language_classifier_test.go` for:
- `TestLanguageClassifier_RespectPerRuleThreshold()` — verify rule.Threshold > 0 overrides default
- `TestLanguageClassifier_DefaultThresholdWhenUnset()` — verify 0 threshold uses `defaultLanguageThreshold` (0.3)
- `TestLanguageClassifier_CustomThresholdRejects()` — verify high threshold (e.g. 0.9) rejects borderline text

Example to add to `language_classifier_test.go`:

Verifier findings:

Verdict: lgtm — treated as a fix patch (adds tests exercising the existing threshold behavior); implementation and config support are already present.

## Findings
- (none)

## Required follow-ups
- Run the full Go test suite in CI (or locally) on a build agent that has the native/shared libraries available (candle_semantic_router, nlp_binding, etc.). Local test runs in this sandbox failed at link time due to missing native libs; the patch itself only adds tests and does not introduce compile-time changes.
- Ensure CI exercises the new tests (they live at /home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier_test.go) so the behavior is validated in an environment with the required CGO/native dependencies.