### PR TITLE
[auto-pareto/strong] Add configurable score threshold to language signal API

### DIFF
--- a/src/semantic-router/pkg/classification/language_classifier_test.go
+++ b/src/semantic-router/pkg/classification/language_classifier_test.go
@@ -43,18 +43,28 @@ func findThresholdSensitiveLanguageSample(t *testing.T, classifier *LanguageClas
 		"Bonjour, comment allez-vous? Je m'appelle Marie et j'habite à Paris. Pouvez-vous me dire où se trouve la gare la plus proche ?",
 	}
 
+	var (
+		bestSample string
+		bestResult *LanguageResult
+	)
 	for _, sample := range samples {
 		result, err := classifier.Classify(sample)
 		if err != nil {
 			t.Fatalf("classification failed: %v", err)
 		}
-		if result.LanguageCode != "en" && result.Confidence > defaultLanguageThreshold+0.05 {
-			return sample, result
+		if result.LanguageCode == "en" || result.Confidence <= defaultLanguageThreshold {
+			continue
+		}
+		if bestResult == nil || result.Confidence > bestResult.Confidence {
+			bestSample = sample
+			bestResult = result
 		}
 	}
 
-	t.Fatal("failed to find a threshold-sensitive language sample")
-	return "", nil
+	if bestResult == nil {
+		t.Fatal("failed to find a threshold-sensitive language sample")
+	}
+	return bestSample, bestResult
 }
 
 func TestLanguageClassifier_DetectsCommonLanguages(t *testing.T) {
@@ -169,7 +179,7 @@ func TestLanguageClassifier_CustomThreshold(t *testing.T) {
 		t.Fatalf("expected explicit default threshold confidence %f, got %f", defaultResult.Confidence, explicitDefaultResult.Confidence)
 	}
 
-	customThreshold := float32(defaultResult.Confidence - 0.02)
+	customThreshold := float32((defaultLanguageThreshold + defaultResult.Confidence) / 2)
 	customResult, err := classifier.ClassifyWithThreshold(sample, customThreshold)
 	if err != nil {
 		t.Fatalf("classification with custom threshold failed: %v", err)
@@ -186,7 +196,7 @@ func TestLanguageClassifier_ThresholdEnforcement(t *testing.T) {
 	classifier := newLanguageClassifierForTest(t)
 	sample, baseResult := findThresholdSensitiveLanguageSample(t, classifier)
 
-	strictThreshold := float32(baseResult.Confidence + 0.01)
+	strictThreshold := float32(baseResult.Confidence) + 0.01
 	result, err := classifier.ClassifyWithThreshold(sample, strictThreshold)
 	if err != nil {
 		t.Fatalf("classification with strict threshold failed: %v", err)

--- a/src/semantic-router/pkg/classification/language_classifier_test.go
+++ b/src/semantic-router/pkg/classification/language_classifier_test.go
@@ -1,6 +1,7 @@
 package classification
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -31,6 +32,29 @@ func languageAllowed(result string, allowed ...string) bool {
 		}
 	}
 	return false
+}
+
+func findThresholdSensitiveLanguageSample(t *testing.T, classifier *LanguageClassifier) (string, *LanguageResult) {
+	t.Helper()
+
+	samples := []string{
+		"Hola, ¿cómo estás? Me llamo Juan y vivo en Madrid. ¿De dónde eres tú? Esta es una pregunta en español sobre mi ubicación.",
+		"Привет, как дела? Меня зовут Иван, и я живу в Москве. Откуда ты? Это вопрос на русском языке о моем местоположении.",
+		"Bonjour, comment allez-vous? Je m'appelle Marie et j'habite à Paris. Pouvez-vous me dire où se trouve la gare la plus proche ?",
+	}
+
+	for _, sample := range samples {
+		result, err := classifier.Classify(sample)
+		if err != nil {
+			t.Fatalf("classification failed: %v", err)
+		}
+		if result.LanguageCode != "en" && result.Confidence > defaultLanguageThreshold+0.05 {
+			return sample, result
+		}
+	}
+
+	t.Fatal("failed to find a threshold-sensitive language sample")
+	return "", nil
 }
 
 func TestLanguageClassifier_DetectsCommonLanguages(t *testing.T) {
@@ -128,4 +152,113 @@ func TestLanguageClassifier_HandlesMixedAndSpecialInputs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLanguageClassifier_CustomThreshold(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+	sample, defaultResult := findThresholdSensitiveLanguageSample(t, classifier)
+
+	explicitDefaultResult, err := classifier.ClassifyWithThreshold(sample, 0)
+	if err != nil {
+		t.Fatalf("classification with default threshold failed: %v", err)
+	}
+	if explicitDefaultResult.LanguageCode != defaultResult.LanguageCode {
+		t.Fatalf("expected explicit default threshold to keep %q, got %q", defaultResult.LanguageCode, explicitDefaultResult.LanguageCode)
+	}
+	if math.Abs(explicitDefaultResult.Confidence-defaultResult.Confidence) > 1e-9 {
+		t.Fatalf("expected explicit default threshold confidence %f, got %f", defaultResult.Confidence, explicitDefaultResult.Confidence)
+	}
+
+	customThreshold := float32(defaultResult.Confidence - 0.02)
+	customResult, err := classifier.ClassifyWithThreshold(sample, customThreshold)
+	if err != nil {
+		t.Fatalf("classification with custom threshold failed: %v", err)
+	}
+	if customResult.LanguageCode != defaultResult.LanguageCode {
+		t.Fatalf("expected custom threshold %.2f to keep %q, got %q", customThreshold, defaultResult.LanguageCode, customResult.LanguageCode)
+	}
+	if math.Abs(customResult.Confidence-defaultResult.Confidence) > 1e-9 {
+		t.Fatalf("expected custom threshold confidence %f, got %f", defaultResult.Confidence, customResult.Confidence)
+	}
+}
+
+func TestLanguageClassifier_ThresholdEnforcement(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+	sample, baseResult := findThresholdSensitiveLanguageSample(t, classifier)
+
+	strictThreshold := float32(baseResult.Confidence + 0.01)
+	result, err := classifier.ClassifyWithThreshold(sample, strictThreshold)
+	if err != nil {
+		t.Fatalf("classification with strict threshold failed: %v", err)
+	}
+	if result.LanguageCode != "en" {
+		t.Fatalf("expected strict threshold %.2f to fall back to English, got %q with confidence %f", strictThreshold, result.LanguageCode, result.Confidence)
+	}
+	if result.Confidence != 0.5 {
+		t.Fatalf("expected fallback confidence 0.5, got %f", result.Confidence)
+	}
+}
+
+func TestLanguageClassifier_ClassifyWithThreshold(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	t.Run("ZeroThresholdUsesDefault", func(t *testing.T) {
+		// threshold=0 falls back to defaultLanguageThreshold (0.3); well-known
+		// English text must be detected reliably at that level.
+		result, err := classifier.ClassifyWithThreshold("Hello, how are you doing today?", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.LanguageCode != "en" {
+			t.Errorf("expected en, got %q", result.LanguageCode)
+		}
+	})
+
+	t.Run("LowThresholdAcceptsResult", func(t *testing.T) {
+		// A very low threshold (0.01) should never filter out a high-confidence result.
+		result, err := classifier.ClassifyWithThreshold(
+			strings.Repeat("This is a long English sentence. ", 50), 0.01)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.LanguageCode != "en" {
+			t.Errorf("expected en, got %q", result.LanguageCode)
+		}
+	})
+
+	t.Run("ImpossibleThresholdFallsBackToEnglish", func(t *testing.T) {
+		// A threshold of 1.0 can never be met; the classifier must fall back to "en".
+		result, err := classifier.ClassifyWithThreshold("Hola mundo", 1.0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.LanguageCode != "en" {
+			t.Errorf("expected en fallback, got %q", result.LanguageCode)
+		}
+		if result.Confidence != 0.5 {
+			t.Errorf("expected fallback confidence 0.5, got %f", result.Confidence)
+		}
+	})
+
+	t.Run("EmptyTextAlwaysReturnsEnglish", func(t *testing.T) {
+		// Empty text must return the "en" fallback regardless of threshold.
+		for _, th := range []float32{0, 0.5, 1.0} {
+			result, err := classifier.ClassifyWithThreshold("", th)
+			if err != nil {
+				t.Fatalf("threshold %.1f: unexpected error: %v", th, err)
+			}
+			if result.LanguageCode != "en" {
+				t.Errorf("threshold %.1f: expected en, got %q", th, result.LanguageCode)
+			}
+		}
+	})
 }

--- a/src/semantic-router/pkg/dsl/compiler_signals.go
+++ b/src/semantic-router/pkg/dsl/compiler_signals.go
@@ -146,6 +146,9 @@ func (c *Compiler) compileLanguageSignal(s *SignalDecl) {
 	if v, ok := getStringField(s.Fields, "description"); ok {
 		rule.Description = v
 	}
+	if v, ok := getFloat32Field(s.Fields, "threshold"); ok {
+		rule.Threshold = v
+	}
 	c.config.LanguageRules = append(c.config.LanguageRules, rule)
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -104,6 +104,9 @@ func (d *decompiler) languageToSignal(lang *config.LanguageRule) *SignalDecl {
 	if lang.Description != "" {
 		fields["description"] = StringValue{V: lang.Description}
 	}
+	if lang.Threshold != 0 {
+		fields["threshold"] = FloatValue{V: float64(lang.Threshold)}
+	}
 	return &SignalDecl{SignalType: "language", Name: lang.Name, Fields: fields}
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
+++ b/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
@@ -129,6 +129,9 @@ func (d *decompiler) decompileLanguageSignals() {
 		if lang.Description != "" {
 			d.write("  description: %q\n", lang.Description)
 		}
+		if lang.Threshold != 0 {
+			d.write("  threshold: %g\n", lang.Threshold)
+		}
 		d.write("}\n\n")
 	}
 }

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -597,7 +597,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard task"] } easy: { candidates: ["easy task"] } }
 SIGNAL modality mod { description: "image" }
@@ -640,6 +640,9 @@ SIGNAL authz auth { role: "admin" subjects: [{ kind: "User", name: "admin" }] }
 	}
 	if len(cfg.LanguageRules) != 1 {
 		t.Errorf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	if cfg.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language threshold: %v", cfg.LanguageRules[0].Threshold)
 	}
 	if len(cfg.ContextRules) != 1 {
 		t.Errorf("expected 1 context rule, got %d", len(cfg.ContextRules))
@@ -2507,7 +2510,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard"] } easy: { candidates: ["easy"] } }
 SIGNAL modality mod { description: "image" }
@@ -2561,6 +2564,9 @@ ROUTE test_route {
 	if len(rt.LanguageRules) != 1 {
 		t.Errorf("language rules: %d", len(rt.LanguageRules))
 	}
+	if rt.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language threshold round-trip: %v", rt.LanguageRules[0].Threshold)
+	}
 	if len(rt.ContextRules) != 1 {
 		t.Errorf("context rules: %d", len(rt.ContextRules))
 	}
@@ -2576,6 +2582,46 @@ ROUTE test_route {
 }
 
 // ---------- P2-5: Multiple Routes Same Priority ----------
+
+func TestLanguageSignalThresholdRoundTrip(t *testing.T) {
+	input := `
+SIGNAL language lang { description: "English" threshold: 0.6 }
+`
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.LanguageRules) != 1 {
+		t.Fatalf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	if cfg.LanguageRules[0].Threshold != 0.6 {
+		t.Fatalf("expected language threshold 0.6, got %v", cfg.LanguageRules[0].Threshold)
+	}
+
+	yamlBytes, err := EmitYAMLFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("emit YAML error: %v", err)
+	}
+
+	var rt config.RouterConfig
+	if err := yaml.Unmarshal(yamlBytes, &rt); err != nil {
+		t.Fatalf("unmarshal YAML error: %v\nYAML:\n%s", err, string(yamlBytes))
+	}
+	if len(rt.LanguageRules) != 1 {
+		t.Fatalf("expected 1 round-tripped language rule, got %d", len(rt.LanguageRules))
+	}
+	if rt.LanguageRules[0].Threshold != 0.6 {
+		t.Fatalf("expected round-tripped language threshold 0.6, got %v", rt.LanguageRules[0].Threshold)
+	}
+
+	dslText, err := Decompile(cfg)
+	if err != nil {
+		t.Fatalf("decompile error: %v", err)
+	}
+	if !strings.Contains(dslText, `threshold: 0.6`) {
+		t.Fatalf("decompiled DSL missing language threshold:\n%s", dslText)
+	}
+}
 
 func TestMultipleRoutesSamePriority(t *testing.T) {
 	input := `
@@ -3467,7 +3513,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL structure struct { feature: { type: "count", source: { type: "regex", pattern: "[?]" } } predicate: { gte: 1 } }
 SIGNAL conversation conv {
@@ -3519,6 +3565,9 @@ ROUTE test_route { PRIORITY 1 WHEN domain("dom") MODEL "m:1b" }
 	}
 	if !strings.Contains(dslText, `threshold: 0.7`) {
 		t.Error("decompiled DSL missing preference threshold")
+	}
+	if !strings.Contains(dslText, `threshold: 0.6`) {
+		t.Error("decompiled DSL missing language threshold")
 	}
 	if !strings.Contains(dslText, `examples: ["keep it concise", "bullet points only"]`) {
 		t.Error("decompiled DSL missing preference examples")


### PR DESCRIPTION
Auto-resolve for #1723 (verdict: lgtm)

Localizer brief:

Mode: fix

## Root cause
Issue #1723 is a feature request to add configurable score threshold to language signal API. The config struct and runtime code are mostly complete, but the DSL parser/emitter and comprehensive tests are missing.

The code at `classifier_signal_language.go:19` already calls `lowestLanguageThreshold()` and `ClassifyWithThreshold()`, showing the runtime hooks are in place. However, the DSL compiler at `compiler_signals.go:144` does not parse the threshold field from DSL input, and the decompiler does not emit it back to YAML.

## Affected files
Ranked by relevance:

1. **`src/semantic-router/pkg/dsl/compiler_signals.go`** (line 144) — DSL compiler missing threshold field parsing in `compileLanguageSignal()`
2. **`src/semantic-router/pkg/dsl/decompiler_convert.go`** — DSL decompiler missing threshold field emission in `languageToSignal()`
3. **`src/semantic-router/pkg/classification/language_classifier_test.go`** (line 1) — Missing unit tests for threshold behavior
4. **`src/semantic-router/pkg/classification/classifier_signal_language.go`** (line 12) — Integration point; already wired but needs test coverage

## Anchor symbols
For each file:

1. **compiler_signals.go** — `func (c *Compiler) compileLanguageSignal(s *SignalDecl)` at line 144
   - Currently only extracts `description` field
   - Needs: `getFloat32Field(s.Fields, "threshold")` call (pattern at line 56 in same file for embedding threshold)

2. **decompiler_convert.go** — `func (d *decompiler) languageToSignal(lang *config.LanguageRule) *SignalDecl`
   - Currently only emits `description` field
   - Needs: emit `Threshold` field conditionally (pattern: contextToSignal emits min_tokens/max_tokens)

3. **language_classifier_test.go** — Test suite at line 1
   - Needs tests for: `ClassifyWithThreshold()` method, custom vs. default thresholds
   - Reference: see `TestLanguageClassifier_DetectsCommonLanguages` (line 36) for test structure

4. **language_classifier.go** — `func (c *LanguageClassifier) ClassifyWithThreshold(...)` at line 75
   - Already correct; just needs test coverage

## Reference call-sites
1. **Threshold parsing pattern** — `compileEmbeddingSignal()` at `compiler_signals.go:56` shows `getFloat32Field()` usage
2. **Threshold emission pattern** — `contextToSignal()` in `decompiler_convert.go` shows conditional field emission
3. **Threshold usage pattern** — `evaluateLanguageSignal()` at `classifier_signal_language.go:50` shows per-rule enforcement logic

## Runner/CI dependencies
- Makefile: standard `go test ./...` targets run language classifier tests
- No special CI/Make dependencies identified

## Tests to update or add
1. **Add to `language_classifier_test.go`:**
   - `TestLanguageClassifier_CustomThreshold()` — test ClassifyWithThreshold with explicit threshold vs. default
   - `TestLanguageClassifier_ThresholdEnforcement()` — test that low-confidence results fall back to "en" when threshold is high

2. **Validate DSL roundtrip:** Extend dsl_test.go to verify `SIGNAL language x { threshold: 0.6 }` parses and emits correctly

3. **Existing tests to verify:**
   - `language_classifier_test.go:36–131` — run as-is (should still pass; tests default behavior)

## Risks / unknowns
- None identified from repo inspection; feature is structurally complete, just wiring gaps in DSL layer.

Verifier findings:

Verdict: lgtm — Fix patch that tightens test robustness without introducing correctness issues.

## Findings

- No bugs found. Three independent changes, all correct:

1. `findThresholdSensitiveLanguageSample` (lines 46-67): New implementation walks all samples to find the *highest*-confidence non-English result above `defaultLanguageThreshold`, rather than returning the first hit at `> threshold+0.05`. This is strictly more robust: the old code could fail non-deterministically if the first qualifying sample happened to shift below 0.35 on some build; the new code guarantees the best available sample is returned, and `t.Fatal` is only reached when *all* samples fail, which is the correct condition.

2. `TestLanguageClassifier_CustomThreshold` (line 182): `customThreshold := float32(defaultResult.Confidence - 0.02)` was fragile when `defaultResult.Confidence` was close to `defaultLanguageThreshold` (0.3) — subtracting 0.02 from a value barely above 0.3 could yield a threshold at or below the default, making the test vacuous. The midpoint formula `(defaultLanguageThreshold + defaultResult.Confidence) / 2` is always strictly between 0.3 and the result confidence, which is exactly what the test needs to verify.

3. `TestLanguageClassifier_ThresholdEnforcement` (line 199): `float32(baseResult.Confidence + 0.01)` versus `float32(baseResult.Confidence) + 0.01` — both produce a float32 approximately 0.01 above `baseResult.Confidence`. The new form is marginally more precise because float32 truncation of the larger sum `(x + 0.01)` could clip the increment, whereas adding 0.01 *after* truncation preserves it. Either way `float64(strictThreshold) > baseResult.Confidence` holds, but the new form is the safer expression.

## Required follow-ups

(none)