### PR TITLE
[auto-pareto/strong] Add configurable score threshold to language signal API

### DIFF
--- a/src/semantic-router/pkg/classification/classifier_signal_language.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_language.go
@@ -63,14 +63,24 @@ func (c *Classifier) evaluateLanguageSignal(results *SignalResults, mu *sync.Mut
 	}
 }
 
-// lowestLanguageThreshold returns the smallest non-zero Threshold across all
-// configured LanguageRules, or 0 if none is set. This value is passed to
-// ClassifyWithThreshold so that a single lingua-go call covers all rules.
+// lowestLanguageThreshold returns the smallest effective threshold across all
+// configured LanguageRules, treating an unset Threshold as the built-in
+// defaultLanguageThreshold used by ClassifyWithThreshold. This value is passed
+// to ClassifyWithThreshold so that one lingua-go call can satisfy both custom
+// and default-threshold rules.
 func lowestLanguageThreshold(rules []config.LanguageRule) float32 {
+	if len(rules) == 0 {
+		return 0
+	}
+
 	var min float32
 	for _, r := range rules {
-		if r.Threshold > 0 && (min == 0 || r.Threshold < min) {
-			min = r.Threshold
+		threshold := r.Threshold
+		if threshold <= 0 {
+			threshold = float32(defaultLanguageThreshold)
+		}
+		if min == 0 || threshold < min {
+			min = threshold
 		}
 	}
 	return min

--- a/src/semantic-router/pkg/classification/classifier_signal_language.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_language.go
@@ -17,6 +17,8 @@ func (c *Classifier) evaluateLanguageSignal(results *SignalResults, mu *sync.Mut
 	// the built-in default. This preserves backward compatibility: when no rule
 	// sets a threshold the behaviour is identical to the previous Classify() call.
 	threshold := lowestLanguageThreshold(c.Config.LanguageRules)
+	logging.Infof("[Signal Computation] Language signal evaluation starting: text_len=%d rules=%d shared_threshold=%.2f",
+		len(text), len(c.Config.LanguageRules), threshold)
 	languageResult, err := c.languageClassifier.ClassifyWithThreshold(text, threshold)
 	elapsed := time.Since(start)
 	latencySeconds := elapsed.Seconds()
@@ -70,18 +72,24 @@ func (c *Classifier) evaluateLanguageSignal(results *SignalResults, mu *sync.Mut
 // and default-threshold rules.
 func lowestLanguageThreshold(rules []config.LanguageRule) float32 {
 	if len(rules) == 0 {
+		logging.Infof("[Signal Computation] Language threshold evaluation saw no rules; classifier default threshold handling will apply")
 		return 0
 	}
 
 	var min float32
 	for _, r := range rules {
-		threshold := r.Threshold
-		if threshold <= 0 {
-			threshold = float32(defaultLanguageThreshold)
+		rawThreshold := r.Threshold
+		effectiveThreshold := rawThreshold
+		if effectiveThreshold <= 0 {
+			effectiveThreshold = float32(defaultLanguageThreshold)
 		}
-		if min == 0 || threshold < min {
-			min = threshold
+		logging.Infof("[Signal Computation] Language threshold candidate: rule=%q raw_threshold=%.2f effective_threshold=%.2f",
+			r.Name, rawThreshold, effectiveThreshold)
+		if min == 0 || effectiveThreshold < min {
+			min = effectiveThreshold
 		}
 	}
+
+	logging.Infof("[Signal Computation] Language threshold evaluation selected effective minimum %.2f across %d rules", min, len(rules))
 	return min
 }

--- a/src/semantic-router/pkg/classification/classifier_signal_language_test.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_language_test.go
@@ -1,0 +1,97 @@
+package classification
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func newLanguageSignalClassifierForTest(t *testing.T, rules []config.LanguageRule) (*Classifier, *LanguageClassifier) {
+	t.Helper()
+
+	languageClassifier, err := NewLanguageClassifier(rules)
+	if err != nil {
+		t.Fatalf("failed to create language classifier: %v", err)
+	}
+
+	classifier := &Classifier{
+		Config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				Signals: config.Signals{LanguageRules: rules},
+			},
+		},
+		languageClassifier: languageClassifier,
+	}
+
+	return classifier, languageClassifier
+}
+
+func TestEvaluateLanguageSignal_UsesDefaultThresholdForUnsetRules(t *testing.T) {
+	rules := []config.LanguageRule{
+		{Name: "ru"},
+		{Name: "fr", Threshold: 0.5},
+	}
+	classifier, languageClassifier := newLanguageSignalClassifierForTest(t, rules)
+	text := "Привет, как дела?"
+
+	baseline, err := languageClassifier.Classify(text)
+	if err != nil {
+		t.Fatalf("baseline classification failed: %v", err)
+	}
+	if baseline.LanguageCode != "ru" {
+		t.Fatalf("expected baseline classification to detect Russian, got %q", baseline.LanguageCode)
+	}
+	if baseline.Confidence >= 0.5 {
+		t.Fatalf("expected probe text confidence below strict threshold, got %f", baseline.Confidence)
+	}
+	if got := lowestLanguageThreshold(rules); got != float32(defaultLanguageThreshold) {
+		t.Fatalf("expected lowest effective threshold %f, got %f", defaultLanguageThreshold, got)
+	}
+
+	results := newSignalResultsForTest()
+	var mu sync.Mutex
+	classifier.evaluateLanguageSignal(results, &mu, text)
+
+	if len(results.MatchedLanguageRules) != 1 || results.MatchedLanguageRules[0] != "ru" {
+		t.Fatalf("expected Russian rule to match, got %v", results.MatchedLanguageRules)
+	}
+	if math.Abs(results.Metrics.Language.Confidence-baseline.Confidence) > 1e-9 {
+		t.Fatalf("expected signal confidence %f, got %f", baseline.Confidence, results.Metrics.Language.Confidence)
+	}
+}
+
+func TestEvaluateLanguageSignal_EnforcesPerRuleThresholdAfterSharedClassification(t *testing.T) {
+	rules := []config.LanguageRule{
+		{Name: "ru", Threshold: 0.5},
+		{Name: "fr"},
+	}
+	classifier, languageClassifier := newLanguageSignalClassifierForTest(t, rules)
+	text := "Привет, как дела?"
+
+	baseline, err := languageClassifier.ClassifyWithThreshold(text, float32(defaultLanguageThreshold))
+	if err != nil {
+		t.Fatalf("baseline classification failed: %v", err)
+	}
+	if baseline.LanguageCode != "ru" {
+		t.Fatalf("expected baseline classification to detect Russian, got %q", baseline.LanguageCode)
+	}
+	if baseline.Confidence >= 0.5 {
+		t.Fatalf("expected probe text confidence below strict rule threshold, got %f", baseline.Confidence)
+	}
+	if got := lowestLanguageThreshold(rules); got != float32(defaultLanguageThreshold) {
+		t.Fatalf("expected lowest effective threshold %f, got %f", defaultLanguageThreshold, got)
+	}
+
+	results := newSignalResultsForTest()
+	var mu sync.Mutex
+	classifier.evaluateLanguageSignal(results, &mu, text)
+
+	if len(results.MatchedLanguageRules) != 0 {
+		t.Fatalf("expected strict Russian rule to be skipped, got %v", results.MatchedLanguageRules)
+	}
+	if math.Abs(results.Metrics.Language.Confidence-baseline.Confidence) > 1e-9 {
+		t.Fatalf("expected signal confidence %f, got %f", baseline.Confidence, results.Metrics.Language.Confidence)
+	}
+}

--- a/src/semantic-router/pkg/classification/language_classifier_test.go
+++ b/src/semantic-router/pkg/classification/language_classifier_test.go
@@ -164,6 +164,31 @@ func TestLanguageClassifier_HandlesMixedAndSpecialInputs(t *testing.T) {
 	}
 }
 
+func TestLanguageClassifier_ClassifyWithThresholdHonorsCallerThreshold(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+	text := "Bonjour, comment allez-vous?"
+
+	baseline, err := classifier.Classify(text)
+	if err != nil {
+		t.Fatalf("classification failed: %v", err)
+	}
+	if baseline.LanguageCode != "fr" {
+		t.Fatalf("expected baseline classification to detect French, got %q", baseline.LanguageCode)
+	}
+
+	strictThreshold := float32(baseline.Confidence + 0.05)
+	strictResult, err := classifier.ClassifyWithThreshold(text, strictThreshold)
+	if err != nil {
+		t.Fatalf("strict classification failed: %v", err)
+	}
+	if strictResult.LanguageCode != "en" {
+		t.Fatalf("expected strict threshold fallback to English, got %q", strictResult.LanguageCode)
+	}
+	if strictResult.Confidence != 0.5 {
+		t.Fatalf("expected fallback confidence 0.5, got %f", strictResult.Confidence)
+	}
+}
+
 func TestLanguageClassifier_CustomThreshold(t *testing.T) {
 	classifier := newLanguageClassifierForTest(t)
 	sample, defaultResult := findThresholdSensitiveLanguageSample(t, classifier)

--- a/src/semantic-router/pkg/classification/language_classifier_test.go
+++ b/src/semantic-router/pkg/classification/language_classifier_test.go
@@ -43,18 +43,28 @@ func findThresholdSensitiveLanguageSample(t *testing.T, classifier *LanguageClas
 		"Bonjour, comment allez-vous? Je m'appelle Marie et j'habite à Paris. Pouvez-vous me dire où se trouve la gare la plus proche ?",
 	}
 
+	var (
+		bestSample string
+		bestResult *LanguageResult
+	)
 	for _, sample := range samples {
 		result, err := classifier.Classify(sample)
 		if err != nil {
 			t.Fatalf("classification failed: %v", err)
 		}
-		if result.LanguageCode != "en" && result.Confidence > defaultLanguageThreshold+0.05 {
-			return sample, result
+		if result.LanguageCode == "en" || result.Confidence <= defaultLanguageThreshold {
+			continue
+		}
+		if bestResult == nil || result.Confidence > bestResult.Confidence {
+			bestSample = sample
+			bestResult = result
 		}
 	}
 
-	t.Fatal("failed to find a threshold-sensitive language sample")
-	return "", nil
+	if bestResult == nil {
+		t.Fatal("failed to find a threshold-sensitive language sample")
+	}
+	return bestSample, bestResult
 }
 
 func TestLanguageClassifier_DetectsCommonLanguages(t *testing.T) {
@@ -169,7 +179,7 @@ func TestLanguageClassifier_CustomThreshold(t *testing.T) {
 		t.Fatalf("expected explicit default threshold confidence %f, got %f", defaultResult.Confidence, explicitDefaultResult.Confidence)
 	}
 
-	customThreshold := float32(defaultResult.Confidence - 0.02)
+	customThreshold := float32((defaultLanguageThreshold + defaultResult.Confidence) / 2)
 	customResult, err := classifier.ClassifyWithThreshold(sample, customThreshold)
 	if err != nil {
 		t.Fatalf("classification with custom threshold failed: %v", err)
@@ -186,7 +196,7 @@ func TestLanguageClassifier_ThresholdEnforcement(t *testing.T) {
 	classifier := newLanguageClassifierForTest(t)
 	sample, baseResult := findThresholdSensitiveLanguageSample(t, classifier)
 
-	strictThreshold := float32(baseResult.Confidence + 0.01)
+	strictThreshold := float32(baseResult.Confidence) + 0.01
 	result, err := classifier.ClassifyWithThreshold(sample, strictThreshold)
 	if err != nil {
 		t.Fatalf("classification with strict threshold failed: %v", err)

--- a/src/semantic-router/pkg/classification/language_classifier_test.go
+++ b/src/semantic-router/pkg/classification/language_classifier_test.go
@@ -1,6 +1,7 @@
 package classification
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -31,6 +32,29 @@ func languageAllowed(result string, allowed ...string) bool {
 		}
 	}
 	return false
+}
+
+func findThresholdSensitiveLanguageSample(t *testing.T, classifier *LanguageClassifier) (string, *LanguageResult) {
+	t.Helper()
+
+	samples := []string{
+		"Hola, ¿cómo estás? Me llamo Juan y vivo en Madrid. ¿De dónde eres tú? Esta es una pregunta en español sobre mi ubicación.",
+		"Привет, как дела? Меня зовут Иван, и я живу в Москве. Откуда ты? Это вопрос на русском языке о моем местоположении.",
+		"Bonjour, comment allez-vous? Je m'appelle Marie et j'habite à Paris. Pouvez-vous me dire où se trouve la gare la plus proche ?",
+	}
+
+	for _, sample := range samples {
+		result, err := classifier.Classify(sample)
+		if err != nil {
+			t.Fatalf("classification failed: %v", err)
+		}
+		if result.LanguageCode != "en" && result.Confidence > defaultLanguageThreshold+0.05 {
+			return sample, result
+		}
+	}
+
+	t.Fatal("failed to find a threshold-sensitive language sample")
+	return "", nil
 }
 
 func TestLanguageClassifier_DetectsCommonLanguages(t *testing.T) {
@@ -128,4 +152,113 @@ func TestLanguageClassifier_HandlesMixedAndSpecialInputs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLanguageClassifier_CustomThreshold(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+	sample, defaultResult := findThresholdSensitiveLanguageSample(t, classifier)
+
+	explicitDefaultResult, err := classifier.ClassifyWithThreshold(sample, 0)
+	if err != nil {
+		t.Fatalf("classification with default threshold failed: %v", err)
+	}
+	if explicitDefaultResult.LanguageCode != defaultResult.LanguageCode {
+		t.Fatalf("expected explicit default threshold to keep %q, got %q", defaultResult.LanguageCode, explicitDefaultResult.LanguageCode)
+	}
+	if math.Abs(explicitDefaultResult.Confidence-defaultResult.Confidence) > 1e-9 {
+		t.Fatalf("expected explicit default threshold confidence %f, got %f", defaultResult.Confidence, explicitDefaultResult.Confidence)
+	}
+
+	customThreshold := float32(defaultResult.Confidence - 0.02)
+	customResult, err := classifier.ClassifyWithThreshold(sample, customThreshold)
+	if err != nil {
+		t.Fatalf("classification with custom threshold failed: %v", err)
+	}
+	if customResult.LanguageCode != defaultResult.LanguageCode {
+		t.Fatalf("expected custom threshold %.2f to keep %q, got %q", customThreshold, defaultResult.LanguageCode, customResult.LanguageCode)
+	}
+	if math.Abs(customResult.Confidence-defaultResult.Confidence) > 1e-9 {
+		t.Fatalf("expected custom threshold confidence %f, got %f", defaultResult.Confidence, customResult.Confidence)
+	}
+}
+
+func TestLanguageClassifier_ThresholdEnforcement(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+	sample, baseResult := findThresholdSensitiveLanguageSample(t, classifier)
+
+	strictThreshold := float32(baseResult.Confidence + 0.01)
+	result, err := classifier.ClassifyWithThreshold(sample, strictThreshold)
+	if err != nil {
+		t.Fatalf("classification with strict threshold failed: %v", err)
+	}
+	if result.LanguageCode != "en" {
+		t.Fatalf("expected strict threshold %.2f to fall back to English, got %q with confidence %f", strictThreshold, result.LanguageCode, result.Confidence)
+	}
+	if result.Confidence != 0.5 {
+		t.Fatalf("expected fallback confidence 0.5, got %f", result.Confidence)
+	}
+}
+
+func TestLanguageClassifier_ClassifyWithThreshold(t *testing.T) {
+	classifier := newLanguageClassifierForTest(t)
+
+	t.Run("ZeroThresholdUsesDefault", func(t *testing.T) {
+		// threshold=0 falls back to defaultLanguageThreshold (0.3); well-known
+		// English text must be detected reliably at that level.
+		result, err := classifier.ClassifyWithThreshold("Hello, how are you doing today?", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.LanguageCode != "en" {
+			t.Errorf("expected en, got %q", result.LanguageCode)
+		}
+	})
+
+	t.Run("LowThresholdAcceptsResult", func(t *testing.T) {
+		// A very low threshold (0.01) should never filter out a high-confidence result.
+		result, err := classifier.ClassifyWithThreshold(
+			strings.Repeat("This is a long English sentence. ", 50), 0.01)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.LanguageCode != "en" {
+			t.Errorf("expected en, got %q", result.LanguageCode)
+		}
+	})
+
+	t.Run("ImpossibleThresholdFallsBackToEnglish", func(t *testing.T) {
+		// A threshold of 1.0 can never be met; the classifier must fall back to "en".
+		result, err := classifier.ClassifyWithThreshold("Hola mundo", 1.0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.LanguageCode != "en" {
+			t.Errorf("expected en fallback, got %q", result.LanguageCode)
+		}
+		if result.Confidence != 0.5 {
+			t.Errorf("expected fallback confidence 0.5, got %f", result.Confidence)
+		}
+	})
+
+	t.Run("EmptyTextAlwaysReturnsEnglish", func(t *testing.T) {
+		// Empty text must return the "en" fallback regardless of threshold.
+		for _, th := range []float32{0, 0.5, 1.0} {
+			result, err := classifier.ClassifyWithThreshold("", th)
+			if err != nil {
+				t.Fatalf("threshold %.1f: unexpected error: %v", th, err)
+			}
+			if result.LanguageCode != "en" {
+				t.Errorf("threshold %.1f: expected en, got %q", th, result.LanguageCode)
+			}
+		}
+	})
 }

--- a/src/semantic-router/pkg/dsl/compiler_signals.go
+++ b/src/semantic-router/pkg/dsl/compiler_signals.go
@@ -146,6 +146,9 @@ func (c *Compiler) compileLanguageSignal(s *SignalDecl) {
 	if v, ok := getStringField(s.Fields, "description"); ok {
 		rule.Description = v
 	}
+	if v, ok := getFloat32Field(s.Fields, "threshold"); ok {
+		rule.Threshold = v
+	}
 	c.config.LanguageRules = append(c.config.LanguageRules, rule)
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -104,6 +104,9 @@ func (d *decompiler) languageToSignal(lang *config.LanguageRule) *SignalDecl {
 	if lang.Description != "" {
 		fields["description"] = StringValue{V: lang.Description}
 	}
+	if lang.Threshold != 0 {
+		fields["threshold"] = FloatValue{V: float64(lang.Threshold)}
+	}
 	return &SignalDecl{SignalType: "language", Name: lang.Name, Fields: fields}
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
+++ b/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
@@ -129,6 +129,9 @@ func (d *decompiler) decompileLanguageSignals() {
 		if lang.Description != "" {
 			d.write("  description: %q\n", lang.Description)
 		}
+		if lang.Threshold != 0 {
+			d.write("  threshold: %g\n", lang.Threshold)
+		}
 		d.write("}\n\n")
 	}
 }

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -597,7 +597,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard task"] } easy: { candidates: ["easy task"] } }
 SIGNAL modality mod { description: "image" }
@@ -640,6 +640,9 @@ SIGNAL authz auth { role: "admin" subjects: [{ kind: "User", name: "admin" }] }
 	}
 	if len(cfg.LanguageRules) != 1 {
 		t.Errorf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	if cfg.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language threshold: %v", cfg.LanguageRules[0].Threshold)
 	}
 	if len(cfg.ContextRules) != 1 {
 		t.Errorf("expected 1 context rule, got %d", len(cfg.ContextRules))
@@ -2507,7 +2510,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard"] } easy: { candidates: ["easy"] } }
 SIGNAL modality mod { description: "image" }
@@ -2561,6 +2564,9 @@ ROUTE test_route {
 	if len(rt.LanguageRules) != 1 {
 		t.Errorf("language rules: %d", len(rt.LanguageRules))
 	}
+	if rt.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language threshold round-trip: %v", rt.LanguageRules[0].Threshold)
+	}
 	if len(rt.ContextRules) != 1 {
 		t.Errorf("context rules: %d", len(rt.ContextRules))
 	}
@@ -2576,6 +2582,46 @@ ROUTE test_route {
 }
 
 // ---------- P2-5: Multiple Routes Same Priority ----------
+
+func TestLanguageSignalThresholdRoundTrip(t *testing.T) {
+	input := `
+SIGNAL language lang { description: "English" threshold: 0.6 }
+`
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.LanguageRules) != 1 {
+		t.Fatalf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	if cfg.LanguageRules[0].Threshold != 0.6 {
+		t.Fatalf("expected language threshold 0.6, got %v", cfg.LanguageRules[0].Threshold)
+	}
+
+	yamlBytes, err := EmitYAMLFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("emit YAML error: %v", err)
+	}
+
+	var rt config.RouterConfig
+	if err := yaml.Unmarshal(yamlBytes, &rt); err != nil {
+		t.Fatalf("unmarshal YAML error: %v\nYAML:\n%s", err, string(yamlBytes))
+	}
+	if len(rt.LanguageRules) != 1 {
+		t.Fatalf("expected 1 round-tripped language rule, got %d", len(rt.LanguageRules))
+	}
+	if rt.LanguageRules[0].Threshold != 0.6 {
+		t.Fatalf("expected round-tripped language threshold 0.6, got %v", rt.LanguageRules[0].Threshold)
+	}
+
+	dslText, err := Decompile(cfg)
+	if err != nil {
+		t.Fatalf("decompile error: %v", err)
+	}
+	if !strings.Contains(dslText, `threshold: 0.6`) {
+		t.Fatalf("decompiled DSL missing language threshold:\n%s", dslText)
+	}
+}
 
 func TestMultipleRoutesSamePriority(t *testing.T) {
 	input := `
@@ -3467,7 +3513,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL structure struct { feature: { type: "count", source: { type: "regex", pattern: "[?]" } } predicate: { gte: 1 } }
 SIGNAL conversation conv {
@@ -3519,6 +3565,9 @@ ROUTE test_route { PRIORITY 1 WHEN domain("dom") MODEL "m:1b" }
 	}
 	if !strings.Contains(dslText, `threshold: 0.7`) {
 		t.Error("decompiled DSL missing preference threshold")
+	}
+	if !strings.Contains(dslText, `threshold: 0.6`) {
+		t.Error("decompiled DSL missing language threshold")
 	}
 	if !strings.Contains(dslText, `examples: ["keep it concise", "bullet points only"]`) {
 		t.Error("decompiled DSL missing preference examples")


### PR DESCRIPTION
Auto-resolve for #1723 (verdict: lgtm)

Localizer brief:

Mode: fix

## Root cause
Issue #1723 is a completed feature request. The language signal threshold field has been **fully implemented** across all required layers:
- Config struct field added (LanguageRule.Threshold, signal_config.go:168)
- Signal evaluation wired (evaluateLanguageSignal, classifier_signal_language.go:12-64)
- Threshold helper function created (lowestLanguageThreshold, classifier_signal_language.go:66-77)
- Tests added (language_classifier_test.go, 60 lines of threshold test coverage added in commit cd6d433d)

## Affected files
| File | Status | Reason |
|------|--------|--------|
| `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/config/signal_config.go` | ✅ COMPLETE | LanguageRule.Threshold field defined at line 168 with YAML marshaling & docs |
| `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/classifier_signal_language.go` | ✅ COMPLETE | evaluateLanguageSignal (line 12) calls lowestLanguageThreshold (line 69) & enforces per-rule threshold (line 50) |
| `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier.go` | ✅ COMPLETE | ClassifyWithThreshold method (line 75) accepts caller-supplied threshold; defaultLanguageThreshold=0.3 (line 41) |
| `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/language_classifier_test.go` | ✅ COMPLETE | Tests for Classify/ClassifyWithThreshold; 60 lines in commit cd6d433d |

## Anchor symbols
- **LanguageRule** `signal_config.go:161-169` — config struct with Threshold field (float32, omitempty)
- **evaluateLanguageSignal()** `classifier_signal_language.go:12` — signal evaluation entry point
- **lowestLanguageThreshold()** `classifier_signal_language.go:69` — helper to extract lowest non-zero threshold
- **ClassifyWithThreshold()** `language_classifier.go:75` — classifier method accepting threshold parameter
- **defaultLanguageThreshold** `language_classifier.go:41` — constant = 0.3 (lingua-go confidence floor)

## Reference call-sites
- Similar threshold pattern in ReaskRule.Threshold `signal_config.go:116` with WithDefaults() helper `line 120`
- Similar pattern in JailbreakRule.Threshold `signal_config.go:139`; PIIRule.Threshold `line 148`
- Threshold enforcement in EmbeddingRule (SimilarityThreshold) `signal_config.go:83`

## Runner/CI dependencies
- Commit 9b22b305 merged issue #1723 into PR #1864 (feat(signals): configurable confidence threshold for language signal)
- Commit 24e7d1e3 extends feature: "[Router] wire language signal threshold through DSL compiler and decompiler"
- Commit 83a936b9 stabilizes tests: "[Router] stabilize language classifier threshold tests"
- Tests run via standard Go test suite (no special Make targets identified; grep shows no CI-specific references)

## Tests to update or add
**Already covered:**
- language_classifier_test.go lines 36–131 (TestLanguageClassifier_DetectsCommonLanguages, HandlesFallbackCases, HandlesMixedAndSpecialInputs)
- Commit cd6d433d adds 60 lines of threshold test coverage to language_classifier_test.go

**Gap / recommendation:**
- Add integration test for evaluateLanguageSignal with mixed rule thresholds (some rules with explicit threshold, some without) to verify lowestLanguageThreshold() logic and per-rule enforcement at line 50 (confidence < rule.Threshold check).
- Current language_classifier_test.go does not test ClassifyWithThreshold method's threshold parameter behavior directly — recommend adding test variant that calls ClassifyWithThreshold(text, 0.5) and verifies fallback behavior when confidence < 0.5.

## Risks / unknowns
- **Issue state:** marked open in issue tracker but feature is production-merged (commits cd6d433d, 24e7d1e3, 83a936b9 are in main history). Suggest closing issue or clarifying if additional scope exists.
- **DSL integration:** commit 24e7d1e3 references "DSL compiler and decompiler" which may require config-file examples or documentation updates not yet localized; verify YAML schema docs/examples include language_rules[].threshold field.
- **No failing CI signal provided:** verified implementation is complete via code inspection and git history; no runtime test failures cited.

Verifier findings:

Verdict: lgtm — Fix patch that correctly resolves a real evaluation bug where `lowestLanguageThreshold` could return a high custom threshold, causing the shared `ClassifyWithThreshold` call to silently drop languages that should have been detected under the default 0.3 threshold.

## Findings

- **`classifier_signal_language.go:71–90`** — The old `lowestLanguageThreshold` only tracked `r.Threshold > 0` values. When rules existed with mixed thresholds (e.g. `{Name:"ru"}` with no threshold alongside `{Name:"fr", Threshold:0.5}`), it returned 0.5. The single `ClassifyWithThreshold(text, 0.5)` call then dropped detections with confidence 0.3–0.5, silently missing the default-threshold rule. The patch substitutes unset thresholds with `defaultLanguageThreshold` before taking the minimum, fixing this correctly.

- **`language_classifier_test.go:167–191`** (new test) — `strictThreshold := float32(baseline.Confidence + 0.05)` relies on the same lingua-go singleton producing identical confidence on both calls. The detector is a `sync.Once` singleton; determinism holds. The `+0.05` gap is large enough that float32 rounding won't collapse it below the actual confidence, so the assertion is sound.

- Minor (no action needed): `float32(defaultLanguageThreshold)` (0.3 → float32 → back to float64) resolves to ~0.30000001192, fractionally above 0.3. In practice lingua-go confidence values are never exactly 0.3, but callers that depend on the exact 0.3 boundary should be aware the effective floor is infinitesimally higher than before. The existing tests cover this range and pass.

## Required follow-ups

(none)