### PR TITLE
[auto-pareto/strong] Add configurable score threshold to language signal API

### DIFF
--- a/src/semantic-router/pkg/dsl/compiler_signals.go
+++ b/src/semantic-router/pkg/dsl/compiler_signals.go
@@ -146,6 +146,9 @@ func (c *Compiler) compileLanguageSignal(s *SignalDecl) {
 	if v, ok := getStringField(s.Fields, "description"); ok {
 		rule.Description = v
 	}
+	if v, ok := getFloat32Field(s.Fields, "threshold"); ok {
+		rule.Threshold = v
+	}
 	c.config.LanguageRules = append(c.config.LanguageRules, rule)
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
+++ b/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
@@ -129,6 +129,9 @@ func (d *decompiler) decompileLanguageSignals() {
 		if lang.Description != "" {
 			d.write("  description: %q\n", lang.Description)
 		}
+		if lang.Threshold != 0 {
+			d.write("  threshold: %g\n", lang.Threshold)
+		}
 		d.write("}\n\n")
 	}
 }

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -597,7 +597,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard task"] } easy: { candidates: ["easy task"] } }
 SIGNAL modality mod { description: "image" }
@@ -640,6 +640,9 @@ SIGNAL authz auth { role: "admin" subjects: [{ kind: "User", name: "admin" }] }
 	}
 	if len(cfg.LanguageRules) != 1 {
 		t.Errorf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	if cfg.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language threshold: %v", cfg.LanguageRules[0].Threshold)
 	}
 	if len(cfg.ContextRules) != 1 {
 		t.Errorf("expected 1 context rule, got %d", len(cfg.ContextRules))
@@ -2498,6 +2501,37 @@ func TestLargeScaleInput(t *testing.T) {
 
 // ---------- P2-4: All Signal Types YAML Round-Trip ----------
 
+func TestLanguageSignalThresholdRoundTrip(t *testing.T) {
+	input := `SIGNAL language my_lang { description: "English" threshold: 0.6 }`
+
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.LanguageRules) != 1 {
+		t.Fatalf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	if cfg.LanguageRules[0].Threshold != 0.6 {
+		t.Fatalf("unexpected language threshold after compile: %v", cfg.LanguageRules[0].Threshold)
+	}
+
+	dslText, err := Decompile(cfg)
+	if err != nil {
+		t.Fatalf("decompile error: %v", err)
+	}
+	if !strings.Contains(dslText, `threshold: 0.6`) {
+		t.Fatalf("decompiled DSL missing language threshold:\n%s", dslText)
+	}
+
+	rt, rtErrs := Compile(dslText)
+	if len(rtErrs) > 0 {
+		t.Fatalf("round-trip compile errors: %v", rtErrs)
+	}
+	if len(rt.LanguageRules) != 1 || rt.LanguageRules[0].Threshold != 0.6 {
+		t.Fatalf("unexpected language threshold after round-trip: %+v", rt.LanguageRules)
+	}
+}
+
 func TestAllSignalTypesRoundTrip(t *testing.T) {
 	input := `
 SIGNAL keyword kw { operator: "any" keywords: ["test"] case_sensitive: true method: "exact" }
@@ -2507,7 +2541,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard"] } easy: { candidates: ["easy"] } }
 SIGNAL modality mod { description: "image" }
@@ -2560,6 +2594,9 @@ ROUTE test_route {
 	}
 	if len(rt.LanguageRules) != 1 {
 		t.Errorf("language rules: %d", len(rt.LanguageRules))
+	}
+	if rt.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language round-trip: %+v", rt.LanguageRules[0])
 	}
 	if len(rt.ContextRules) != 1 {
 		t.Errorf("context rules: %d", len(rt.ContextRules))
@@ -3467,7 +3504,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL structure struct { feature: { type: "count", source: { type: "regex", pattern: "[?]" } } predicate: { gte: 1 } }
 SIGNAL conversation conv {
@@ -3519,6 +3556,9 @@ ROUTE test_route { PRIORITY 1 WHEN domain("dom") MODEL "m:1b" }
 	}
 	if !strings.Contains(dslText, `threshold: 0.7`) {
 		t.Error("decompiled DSL missing preference threshold")
+	}
+	if !strings.Contains(dslText, `threshold: 0.6`) {
+		t.Error("decompiled DSL missing language threshold")
 	}
 	if !strings.Contains(dslText, `examples: ["keep it concise", "bullet points only"]`) {
 		t.Error("decompiled DSL missing preference examples")

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -2506,8 +2506,9 @@ func TestLanguageSignalThresholdRoundTrip(t *testing.T) {
 
 	cfg, errs := Compile(input)
 	if len(errs) > 0 {
-		t.Fatalf("compile errors: %v", errs)
+		t.Fatalf("compile errors: %v\n--- source ---\n%s", errs, input)
 	}
+	t.Logf("compiled language rules: %+v", cfg.LanguageRules)
 	if len(cfg.LanguageRules) != 1 {
 		t.Fatalf("expected 1 language rule, got %d", len(cfg.LanguageRules))
 	}
@@ -2517,16 +2518,18 @@ func TestLanguageSignalThresholdRoundTrip(t *testing.T) {
 
 	dslText, err := Decompile(cfg)
 	if err != nil {
-		t.Fatalf("decompile error: %v", err)
+		t.Fatalf("decompile error: %v\ncompiled language rules: %+v", err, cfg.LanguageRules)
 	}
+	t.Logf("decompiled DSL:\n%s", dslText)
 	if !strings.Contains(dslText, `threshold: 0.6`) {
 		t.Fatalf("decompiled DSL missing language threshold:\n%s", dslText)
 	}
 
 	rt, rtErrs := Compile(dslText)
 	if len(rtErrs) > 0 {
-		t.Fatalf("round-trip compile errors: %v", rtErrs)
+		t.Fatalf("round-trip compile errors: %v\n--- decompiled DSL ---\n%s", rtErrs, dslText)
 	}
+	t.Logf("round-trip language rules: %+v", rt.LanguageRules)
 	if len(rt.LanguageRules) != 1 || rt.LanguageRules[0].Threshold != 0.6 {
 		t.Fatalf("unexpected language threshold after round-trip: %+v", rt.LanguageRules)
 	}
@@ -2562,11 +2565,13 @@ ROUTE test_route {
 	if err != nil {
 		t.Fatalf("emit error: %v", err)
 	}
+	t.Logf("round-trip YAML:\n%s", string(yamlBytes))
 
 	var rt config.RouterConfig
 	if err := yaml.Unmarshal(yamlBytes, &rt); err != nil {
 		t.Fatalf("unmarshal error: %v\nYAML:\n%s", err, string(yamlBytes))
 	}
+	t.Logf("language rules after YAML round-trip: %+v", rt.LanguageRules)
 
 	if len(rt.KeywordRules) != 1 {
 		t.Errorf("keyword rules: %d", len(rt.KeywordRules))


### PR DESCRIPTION
Auto-resolve for #1723 (verdict: risky)

Localizer brief:

Mode: fix

**Root cause**
The `LanguageRule.Threshold` field exists in config and is used by the classifier (language_classifier.go:75, classifier_signal_language.go:12), but is NOT exposed through the DSL signal API. Functions `compileLanguageSignal` (compiler_signals.go:144) and `decompileLanguageSignals` (decompiler_signals_rules.go:126) do not handle the threshold field.

**Affected files**
- `src/semantic-router/pkg/dsl/compiler_signals.go` — add threshold parsing to `compileLanguageSignal` (line 144-150)
- `src/semantic-router/pkg/dsl/decompiler_signals_rules.go` — add threshold output to `decompileLanguageSignals` (line 126-134)
- `src/semantic-router/pkg/dsl/dsl_test.go` — add tests for threshold field in language signals

**Anchor symbols**
- `func (c *Compiler) compileLanguageSignal(s *SignalDecl)` — compiler_signals.go:144
- `func (d *decompiler) decompileLanguageSignals()` — decompiler_signals_rules.go:126
- `type LanguageRule struct { Threshold float32 }` — config/signal_config.go:168
- `func (c *LanguageClassifier) ClassifyWithThreshold(text string, threshold float32)` — language_classifier.go:75

**Reference call-sites**
- `compileReaskSignal` (compiler_signals.go:121-122) — uses `getFloat32Field(s.Fields, "threshold")`
- `compilePreferenceSignal` (compiler_signals.go:138-140) — uses `getFloat32Field(s.Fields, "threshold")`
- `decompileReaskSignals` (decompiler_signals_rules.go:100-102) — writes threshold if non-zero with `%g` format
- `decompilePreferenceSignals` (decompiler_signals_rules.go:119-121) — writes threshold if non-zero with `%g` format

**Runner/CI dependencies**
Tests in `dsl_test.go` (line 600, 2510, 3470+) already use SIGNAL language syntax; extend to test threshold parsing.

**Tests to update or add**
- `dsl_test.go` — add test case for DSL: `SIGNAL language my_lang { description: "..." threshold: 0.6 }` to verify compile/decompile round-trip
- `language_classifier_test.go` — optionally add test for `ClassifyWithThreshold` with non-default thresholds

**Risks / unknowns**
None — config field and classifier code already exist; only DSL surface exposure is missing.

Verifier findings:

Verdict: risky — fix patch that misses one of two decompile paths for language signals, causing threshold to be silently dropped when decompiling to AST.

## Findings

- `src/semantic-router/pkg/dsl/decompiler_convert.go:102` — `languageToSignal()` builds a `SignalDecl` from a `LanguageRule` but never writes `lang.Threshold` into `fields["threshold"]`. All other signal converters in the same file (e.g. `preferenceToSignal` at line 80) do include their threshold. This function is called by `DecompileRoutingToAST` (`routing_contract.go:168`), which backs the public `DecompileToAST` entry point (`decompiler.go:17`). Any consumer of `DecompileToAST` that round-trips through compile will silently lose the configured threshold.

- The patch updates `decompiler_signals_rules.go`'s `decompileLanguageSignals()` (the text-emit path used by `Decompile`) but leaves `decompiler_convert.go`'s `languageToSignal()` (the AST path used by `DecompileToAST`) unchanged — two parallel decompile paths now behave differently for the same field.

## Required follow-ups

- Add `if lang.Threshold != 0 { fields["threshold"] = FloatValue{V: float64(lang.Threshold)} }` to `languageToSignal()` in `decompiler_convert.go:102–107`, matching the pattern used by every other signal converter in that file.
- Add a test exercising the `DecompileToAST` → `CompileAST` round-trip with a non-zero language threshold to cover this path.