### PR TITLE
[DSL] Expose language signal threshold in compiler/decompiler (#1723)

### DIFF
--- a/src/semantic-router/pkg/dsl/compiler_signals.go
+++ b/src/semantic-router/pkg/dsl/compiler_signals.go
@@ -146,6 +146,9 @@ func (c *Compiler) compileLanguageSignal(s *SignalDecl) {
 	if v, ok := getStringField(s.Fields, "description"); ok {
 		rule.Description = v
 	}
+	if v, ok := getFloat32Field(s.Fields, "threshold"); ok {
+		rule.Threshold = v
+	}
 	c.config.LanguageRules = append(c.config.LanguageRules, rule)
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -104,6 +104,9 @@ func (d *decompiler) languageToSignal(lang *config.LanguageRule) *SignalDecl {
 	if lang.Description != "" {
 		fields["description"] = StringValue{V: lang.Description}
 	}
+	if lang.Threshold != 0 {
+		fields["threshold"] = FloatValue{V: float64(lang.Threshold)}
+	}
 	return &SignalDecl{SignalType: "language", Name: lang.Name, Fields: fields}
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
+++ b/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
@@ -129,6 +129,9 @@ func (d *decompiler) decompileLanguageSignals() {
 		if lang.Description != "" {
 			d.write("  description: %q\n", lang.Description)
 		}
+		if lang.Threshold != 0 {
+			d.write("  threshold: %g\n", lang.Threshold)
+		}
 		d.write("}\n\n")
 	}
 }

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -597,7 +597,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard task"] } easy: { candidates: ["easy task"] } }
 SIGNAL modality mod { description: "image" }
@@ -640,6 +640,9 @@ SIGNAL authz auth { role: "admin" subjects: [{ kind: "User", name: "admin" }] }
 	}
 	if len(cfg.LanguageRules) != 1 {
 		t.Errorf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	if cfg.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language threshold: %v", cfg.LanguageRules[0].Threshold)
 	}
 	if len(cfg.ContextRules) != 1 {
 		t.Errorf("expected 1 context rule, got %d", len(cfg.ContextRules))
@@ -2507,7 +2510,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL complexity comp { threshold: 0.1 hard: { candidates: ["hard"] } easy: { candidates: ["easy"] } }
 SIGNAL modality mod { description: "image" }
@@ -2560,6 +2563,9 @@ ROUTE test_route {
 	}
 	if len(rt.LanguageRules) != 1 {
 		t.Errorf("language rules: %d", len(rt.LanguageRules))
+	}
+	if rt.LanguageRules[0].Threshold != 0.6 {
+		t.Errorf("unexpected language round-trip threshold: %v", rt.LanguageRules[0].Threshold)
 	}
 	if len(rt.ContextRules) != 1 {
 		t.Errorf("context rules: %d", len(rt.ContextRules))
@@ -3467,7 +3473,7 @@ SIGNAL fact_check fc { description: "fact check" }
 SIGNAL user_feedback uf { description: "feedback" }
 SIGNAL reask ra { description: "repeat question" threshold: 0.8 lookback_turns: 2 }
 SIGNAL preference pref { description: "preference" threshold: 0.7 examples: ["keep it concise", "bullet points only"] }
-SIGNAL language lang { description: "English" }
+SIGNAL language lang { description: "English" threshold: 0.6 }
 SIGNAL context ctx { min_tokens: "1K" max_tokens: "32K" }
 SIGNAL structure struct { feature: { type: "count", source: { type: "regex", pattern: "[?]" } } predicate: { gte: 1 } }
 SIGNAL conversation conv {
@@ -3525,6 +3531,9 @@ ROUTE test_route { PRIORITY 1 WHEN domain("dom") MODEL "m:1b" }
 	}
 	if !strings.Contains(dslText, `lookback_turns: 2`) {
 		t.Error("decompiled DSL missing reask lookback_turns")
+	}
+	if !strings.Contains(dslText, `threshold: 0.6`) {
+		t.Error("decompiled DSL missing language threshold")
 	}
 	for _, want := range []string{
 		`query_modality: "image"`,


### PR DESCRIPTION
## Summary

Wire `threshold` through the DSL surface for the language signal so the
runtime field added in #1864 can actually be authored from DSL and round-
tripped via the decompiler. Closes the gap left by #1723.

## Background

- #1723 asked for a configurable score threshold on the language signal.
- #1864 (merged) added `Threshold float32` to `config.LanguageRule` and
  wired it into the language classifier. Default `0` preserves the
  built-in `0.3` floor; any non-zero value overrides it.
- The DSL compiler/decompiler was not updated in #1864, so authoring a
  language threshold via DSL silently drops it, and a router config that
  has one decompiles to DSL without the field.

This PR fixes that asymmetry by mirroring the existing
`PreferenceRule.Threshold` pattern in the three relevant DSL files.

## Changes

| File | Change |
|------|--------|
| `src/semantic-router/pkg/dsl/compiler_signals.go` | `compileLanguageSignal` reads optional `threshold` field via `getFloat32Field` into `LanguageRule.Threshold` |
| `src/semantic-router/pkg/dsl/decompiler_convert.go` | `languageToSignal` emits `threshold` only when non-zero (preserves zero-default contract) |
| `src/semantic-router/pkg/dsl/decompiler_signals_rules.go` | `decompileLanguageSignals` writes `threshold: %g` only when non-zero |
| `src/semantic-router/pkg/dsl/dsl_test.go` | Three existing `SIGNAL language lang` fixtures gain `threshold: 0.6`; added compile-time, YAML round-trip, and decompile assertions |

Total diff: **4 files, +21 / -3**.

### Example

```dsl
SIGNAL language zh {
  description: "Chinese-language requests."
  threshold: 0.6
}
```

Decompiles back to the same DSL; YAML round-trips through `config.RouterConfig`
preserving `Threshold: 0.6`. Omitting `threshold` keeps the prior behaviour
(classifier uses its built-in `0.3` default).

## Test Plan

- [x] `go build ./pkg/dsl/...` — clean
- [x] `go test ./pkg/dsl/... -count=1` — pass (`ok ... 1.395s`)
- [x] `make agent-lint CHANGED_FILES="<the four files>"` — Passed (`go fmt`, `go lint`, `agent changed-files lint`, `golangci-lint`, `TestReferenceConfig`, structure checks; all warnings are pre-existing baselines)
- [x] Targeted runs: `TestAllSignalTypes`, `TestAllSignalTypesRoundTrip`, `TestDecompileAllSignals*` pass with the new assertions

Full `make test` from `cmd/` is skipped locally because the host is missing
the CGO bindings (`candle-binding`, `nlp-binding`, `ml-binding`, etc.) —
CI matrix will validate them.

## Notes

- Default (`threshold` omitted, zero value) keeps the existing 0.3 floor
  behaviour, so this is a backwards-compatible extension.
- Touches `pkg/dsl/**` only; no `config.go` or schema changes (the schema
  side was already done in #1864).
- Supersedes the auto-generated PR #2082, which is failing
  `pre-commit lint`, `build_pr (dashboard)`, and `test-and-build`. Happy
  to close #2082 in favour of this once a maintainer signs off.

Resolves #1723.
