### PR TITLE
[auto-pareto/cheap] Add configurable score threshold to language signal API

### DIFF
--- a/src/semantic-router/pkg/dsl/compiler_signals.go
+++ b/src/semantic-router/pkg/dsl/compiler_signals.go
@@ -146,6 +146,9 @@ func (c *Compiler) compileLanguageSignal(s *SignalDecl) {
 	if v, ok := getStringField(s.Fields, "description"); ok {
 		rule.Description = v
 	}
+	if v, ok := getFloat32Field(s.Fields, "threshold"); ok {
+		rule.Threshold = v
+	}
 	c.config.LanguageRules = append(c.config.LanguageRules, rule)
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -104,6 +104,9 @@ func (d *decompiler) languageToSignal(lang *config.LanguageRule) *SignalDecl {
 	if lang.Description != "" {
 		fields["description"] = StringValue{V: lang.Description}
 	}
+	if lang.Threshold != 0 {
+		fields["threshold"] = FloatValue{V: float64(lang.Threshold)}
+	}
 	return &SignalDecl{SignalType: "language", Name: lang.Name, Fields: fields}
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
+++ b/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
@@ -1,6 +1,10 @@
 package dsl
 
-import "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+import (
+	"strconv"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
 
 func (d *decompiler) decompileDomainSignals() {
 	for _, cat := range d.cfg.Categories {
@@ -98,7 +102,8 @@ func (d *decompiler) decompileReaskSignals() {
 			d.write("  description: %q\n", rule.Description)
 		}
 		if rule.Threshold != 0 {
-			d.write("  threshold: %g\n", rule.Threshold)
+			v := strconv.FormatFloat(float64(rule.Threshold), 'g', -1, 32)
+			d.write("  threshold: %s\n", v)
 		}
 		if rule.LookbackTurns != 0 {
 			d.write("  lookback_turns: %d\n", rule.LookbackTurns)
@@ -117,7 +122,8 @@ func (d *decompiler) decompilePreferenceSignals() {
 			d.write("  examples: %s\n", formatStringArray(pref.Examples))
 		}
 		if pref.Threshold != 0 {
-			d.write("  threshold: %g\n", pref.Threshold)
+			v := strconv.FormatFloat(float64(pref.Threshold), 'g', -1, 32)
+			d.write("  threshold: %s\n", v)
 		}
 		d.write("}\n\n")
 	}
@@ -130,7 +136,8 @@ func (d *decompiler) decompileLanguageSignals() {
 			d.write("  description: %q\n", lang.Description)
 		}
 		if lang.Threshold != 0 {
-			d.write("  threshold: %g\n", lang.Threshold)
+			v := strconv.FormatFloat(float64(lang.Threshold), 'g', -1, 32)
+			d.write("  threshold: %s\n", v)
 		}
 		d.write("}\n\n")
 	}

--- a/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
+++ b/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
@@ -129,6 +129,9 @@ func (d *decompiler) decompileLanguageSignals() {
 		if lang.Description != "" {
 			d.write("  description: %q\n", lang.Description)
 		}
+		if lang.Threshold != 0 {
+			d.write("  threshold: %g\n", lang.Threshold)
+		}
 		d.write("}\n\n")
 	}
 }

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -433,6 +433,24 @@ ROUTE math_route {
 	}
 }
 
+func TestCompileLanguageSignalThreshold(t *testing.T) {
+	input := `SIGNAL language myLang { description: "Test language" threshold: 0.6 }`
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.LanguageRules) != 1 {
+		t.Fatalf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	lr := cfg.LanguageRules[0]
+	if lr.Name != "myLang" {
+		t.Errorf("language name = %q, want %q", lr.Name, "myLang")
+	}
+	if lr.Threshold != 0.6 {
+		t.Errorf("language threshold = %v, want 0.6", lr.Threshold)
+	}
+}
+
 func TestCompilePluginTemplate(t *testing.T) {
 	input := `PLUGIN my_hallu hallucination {
   enabled: true
@@ -3537,6 +3555,37 @@ ROUTE test_route { PRIORITY 1 WHEN domain("dom") MODEL "m:1b" }
 		if !strings.Contains(dslText, want) {
 			t.Errorf("decompiled DSL missing %q:\n%s", want, dslText)
 		}
+	}
+}
+
+func TestLanguageSignalThresholdRoundTrip(t *testing.T) {
+	input := `SIGNAL language lang { description: "English" threshold: 0.6 }`
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	if len(cfg.LanguageRules) != 1 {
+		t.Fatalf("expected 1 language rule, got %d", len(cfg.LanguageRules))
+	}
+	expected := float32(0.6)
+	if cfg.LanguageRules[0].Threshold != expected {
+		t.Fatalf("unexpected language threshold: %v", cfg.LanguageRules[0].Threshold)
+	}
+
+	dslText, err := Decompile(cfg)
+	if err != nil {
+		t.Fatalf("decompile error: %v", err)
+	}
+
+	cfg2, errs := Compile(dslText)
+	if len(errs) > 0 {
+		t.Fatalf("recompile errors: %v\nDSL:\n%s", errs, dslText)
+	}
+	if len(cfg2.LanguageRules) != 1 {
+		t.Fatalf("expected 1 language rule after roundtrip, got %d", len(cfg2.LanguageRules))
+	}
+	if cfg2.LanguageRules[0].Threshold != expected {
+		t.Fatalf("roundtripped language threshold mismatch: %v", cfg2.LanguageRules[0].Threshold)
 	}
 }
 


### PR DESCRIPTION
Auto-resolve for #1723 (verdict: lgtm)

Localizer brief:

Mode: fix

## Root cause
The `LanguageRule` config struct already has a `Threshold` field (signal_config.go:168), and the classifier already implements threshold enforcement (classifier_signal_language.go:19–63, language_classifier.go:75–124). However, the DSL compiler and decompiler do not expose this field:
- `compileLanguageSignal()` at compiler_signals.go:144–150 only parses `name` and `description`, missing `threshold`
- `languageToSignal()` at decompiler_convert.go:102–108 only emits `description`, missing `threshold`
- `decompileLanguageSignals()` at decompiler_signals_rules.go:126–134 only emits `description`, missing `threshold`

## Affected files
1. **src/semantic-router/pkg/dsl/compiler_signals.go** — Add threshold parsing to `compileLanguageSignal()`, matching pattern from `compileReaskSignal()` (line 117–126)
2. **src/semantic-router/pkg/dsl/decompiler_signals_rules.go** — Add threshold emission to `decompileLanguageSignals()`, matching pattern from `decompileReaskSignals()` (line 95–105)
3. **src/semantic-router/pkg/dsl/decompiler_convert.go** — Add threshold emission to `languageToSignal()` (conditional on non-zero value)
4. **src/semantic-router/pkg/dsl/dsl_test.go** — Add DSL roundtrip test with threshold value (e.g., `SIGNAL language myLang { description: "..." threshold: 0.6 }`)

## Anchor symbols
- `LanguageRule.Threshold` → config/signal_config.go:168
- `compileLanguageSignal()` → dsl/compiler_signals.go:144
- `languageToSignal()` → dsl/decompiler_convert.go:102
- `decompileLanguageSignals()` → dsl/decompiler_signals_rules.go:126
- `lowestLanguageThreshold()` → classification/classifier_signal_language.go:69
- `evaluateLanguageSignal()` → classification/classifier_signal_language.go:12

## Reference call-sites
- `getFloat32Field()` usage in `compileReaskSignal()` (dsl/compiler_signals.go:121) — pattern to imitate for threshold parsing
- Threshold emission in `decompileReaskSignals()` (dsl/decompiler_signals_rules.go:101) — pattern to imitate for DSL emission
- `ClassifyWithThreshold(text, threshold)` call (classifier_signal_language.go:20) — threshold is already wired to runtime

## Runner/CI dependencies
- DSL tests: dsl_test.go roundtrip cases must validate `SIGNAL language ... { threshold: X }`
- Config validation: reference_config_public_surface_test.go may need update if public surface changed
- Language classifier tests: language_classifier_test.go can add cases for `ClassifyWithThreshold()` with custom thresholds

## Tests to update or add
- **dsl_test.go**: Add test case with `SIGNAL language myLang { threshold: 0.5 }` in compile/decompile roundtrip
- **language_classifier_test.go**: Add test for `ClassifyWithThreshold()` with non-default thresholds (e.g., 0.6, 0.8)
- **reference_config_public_surface_test.go**: Ensure `LanguageRule.Threshold` is in the public surface contract

## Risks / unknowns
- None; the runtime implementation is complete and tested. DSL work is mechanical (copy pattern from ReaskRule threshold handling).

Verifier findings:

Verdict: lgtm — treated as a fix patch that enables configuring per-language confidence thresholds via the DSL; changes are self-consistent and wire the field through parsing, decompilation, runtime use, and tests.

## Findings
- (no significant issues found)

## Required follow-ups
- Run the full Go test suite (e.g., `go test ./...`) and verify CI passes.
- Confirm the DSL round-trip tests and any language-classifier unit tests run in your CI environment (the patch adds DSL tests; CI should be run to ensure there are no unseen build/test interactions).