### PR TITLE
[auto-pareto/strong] bug: <Auth Related Integ Test Failing>

### DIFF
--- a/e2e/profiles/authz-rbac/README.md
+++ b/e2e/profiles/authz-rbac/README.md
@@ -4,7 +4,7 @@ This profile demonstrates user-level RBAC model routing where different users (a
 
 ## Security Requirements
 
-**IMPORTANT**: Identity headers (`x-authz-user-id`, `x-authz-user-groups`) must **ONLY** come from validated auth backends (JWT, Authorino, etc.), **NOT** from client requests.
+**IMPORTANT**: This profile trusts JWT-derived identity headers (`x-jwt-sub`, `x-jwt-groups`) only after Envoy validates a bearer token. Clients must not be allowed to set those headers directly.
 
 ### Envoy Configuration
 
@@ -21,9 +21,9 @@ The header removal filter runs **before** the JWT/auth filter and ext_proc filte
 
 For e2e tests:
 
-- **DO NOT** send `x-authz-user-id` or `x-authz-user-groups` headers directly from the test client
+- **DO NOT** send `x-jwt-sub` or `x-jwt-groups` headers directly from the test client
 - **DO** send JWT tokens in the `Authorization: Bearer <token>` header
-- Envoy Gateway validates the JWT and extracts claims into identity headers
+- Envoy Gateway validates the JWT and copies claims into `x-jwt-sub` / `x-jwt-groups`
 - The router receives only JWT-derived identity headers
 
 ### Production Deployment
@@ -68,11 +68,19 @@ spec:
               fromHeaders:
                 - name: Authorization
                   valuePrefix: "Bearer "
+              claimToHeaders:
+                - headerName: x-jwt-sub
+                  claimName: sub
+                - headerName: x-jwt-groups
+                  claimName: groups
           rules:
             - match:
                 prefix: /
               requires:
-                providerName: jwt_provider
+                requiresAny:
+                  requirements:
+                    - providerName: jwt_provider
+                    - allowMissing: {}
     type: type.googleapis.com/envoy.config.listener.v3.Listener
   - name: jwt_provider_cluster
     operation:
@@ -104,7 +112,7 @@ spec:
 **Important Notes:**
 
 - The JWT filter should be added **after** the Lua filter that strips client-supplied headers
-- The JWT filter extracts claims from the validated token and sets them as headers (e.g., `x-authz-user-id`, `x-authz-user-groups`)
+- The JWT filter copies validated claims into headers (for this profile: `x-jwt-sub`, `x-jwt-groups`)
 - Replace `your-auth-server.com` and `your-audience` with your actual authentication server details
 - The JWT provider configuration must match your authentication server's JWT signing key and claims structure
 
@@ -129,10 +137,11 @@ Instead of configuring JWT directly in Envoy, you can use [Authorino](https://gi
 The authz-rbac profile includes the following test cases:
 
 - **chat-completions-request**: Basic functional test that validates end-to-end routing
-- **chat-completions-request-authz**: Sends identity headers from the client; Lua strips them before ext_proc (same as spoofing defense). Asserts HTTP 200.
-- **authz-header-spoofing**: Security test that verifies client-supplied identity headers are stripped and cannot be used for unauthorized access
+- **chat-completions-request-authz**: Sends a valid JWT in `Authorization` and asserts HTTP 200.
+- **authz-rbac-routing**: Verifies admin/premium/free routing decisions from validated JWT claims.
+- **authz-header-spoofing**: Security test that verifies client-supplied identity headers are stripped and cannot override JWT-derived identity.
 
-**Rate limiting (`ratelimit-limitor`)** is intentionally **not** part of this profile: that test requires `x-authz-user-id` / `x-authz-user-groups` to reach the router from the HTTP client, which conflicts with the Lua filter that strips client-supplied identity headers (Issue #1447). Run `ratelimit-limitor` from a profile without that strip, or drive identity via JWT placed **after** the strip in the filter chain.
+**Rate limiting (`ratelimit-limitor`)** is intentionally **not** part of this profile: that test still requires raw `x-authz-user-id` / `x-authz-user-groups` headers from the HTTP client, which conflicts with the Lua filter that strips client-supplied identity headers in favor of JWT-derived `x-jwt-*` headers. Run `ratelimit-limitor` from a profile without that strip, or update the testcase to send JWTs.
 
 To run the security test:
 

--- a/e2e/profiles/authz-rbac/gateway-resources/gwapi-resources.yaml
+++ b/e2e/profiles/authz-rbac/gateway-resources/gwapi-resources.yaml
@@ -95,10 +95,10 @@ spec:
       request: 60s
       backendRequest: 60s
 ---
-# EnvoyPatchPolicy to add ExtProc filter for semantic-router
-# Also strips client-supplied identity headers before JWT/auth processing
-# SECURITY: Identity headers (x-authz-user-id, x-authz-user-groups) must only come
-# from validated auth backends (JWT, Authorino, etc.), not from client requests.
+# EnvoyPatchPolicy to add JWT authn + ExtProc filters for semantic-router.
+# Also strips any client-supplied identity headers before jwt_authn runs.
+# SECURITY: The router trusts x-jwt-sub and x-jwt-groups only after Envoy
+# validates the bearer token and copies claims into those headers.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyPatchPolicy
 metadata:
@@ -106,8 +106,8 @@ metadata:
   namespace: default
 spec:
   jsonPatches:
-  # Add header removal filter BEFORE ext_proc to strip client-supplied identity headers
-  # This prevents header spoofing attacks - identity headers should only come from validated JWT
+  # Add header removal filter BEFORE jwt_authn/ext_proc to strip client-supplied identity headers.
+  # This prevents spoofing of both legacy x-authz-* headers and the active x-jwt-* headers.
   - name: default/semantic-router/http
     operation:
       op: add
@@ -118,17 +118,52 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
           inlineCode: |
             function envoy_on_request(request_handle)
-              -- Remove client-supplied identity headers to prevent spoofing
-              -- These headers should only be set by validated auth backends (JWT, Authorino, etc.)
+              -- Remove client-supplied identity headers to prevent spoofing.
+              -- jwt_authn repopulates x-jwt-* from verified bearer-token claims.
               request_handle:headers():remove("x-authz-user-id")
               request_handle:headers():remove("x-authz-user-groups")
+              request_handle:headers():remove("x-jwt-sub")
+              request_handle:headers():remove("x-jwt-groups")
             end
     type: type.googleapis.com/envoy.config.listener.v3.Listener
-  # Add ExtProc filter for semantic-router
+  # Add JWT authn filter so authz routing uses verified bearer-token claims.
   - name: default/semantic-router/http
     operation:
       op: add
       path: /default_filter_chain/filters/0/typed_config/http_filters/1
+      value:
+        name: envoy.filters.http.jwt_authn
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+          providers:
+            authz_rbac:
+              issuer: semantic-router-e2e
+              audiences:
+              - semantic-router
+              localJwks:
+                inlineString: '{"keys":[{"kty":"oct","k":"c2VtYW50aWMtcm91dGVyLWF1dGh6LXJiYWMtaHMyNTYtc2VjcmV0","alg":"HS256","kid":"authz-rbac-e2e"}]}'
+              fromHeaders:
+              - name: Authorization
+                valuePrefix: "Bearer "
+              claimToHeaders:
+              - headerName: x-jwt-sub
+                claimName: sub
+              - headerName: x-jwt-groups
+                claimName: groups
+          rules:
+          - match:
+              prefix: /
+            requires:
+              requiresAny:
+                requirements:
+                - providerName: authz_rbac
+                - allowMissing: {}
+    type: type.googleapis.com/envoy.config.listener.v3.Listener
+  # Add ExtProc filter for semantic-router after jwt_authn populates x-jwt-* headers.
+  - name: default/semantic-router/http
+    operation:
+      op: add
+      path: /default_filter_chain/filters/0/typed_config/http_filters/2
       value:
         name: semantic-router-extproc
         typedConfig:

--- a/e2e/profiles/authz-rbac/profile.go
+++ b/e2e/profiles/authz-rbac/profile.go
@@ -178,13 +178,14 @@ func (p *Profile) GetTestCases() []string {
 		"chat-completions-request",
 		// Authz-specific functional test (200 OK; identity headers are stripped by Envoy Lua before ext_proc)
 		"chat-completions-request-authz",
-		// RBAC routing test — validates role-based decision selection when authz identity headers are present
+		// Functional RBAC routing test using the profile's configured authz identity headers
 		"authz-rbac-routing",
 		// Security test — validates that client-supplied identity headers are stripped
 		"authz-header-spoofing",
-		// NOTE: ratelimit-limitor is NOT run here: it requires x-authz-* from the client to reach
-		// the router, but EnvoyPatchPolicy Lua strips those headers (same as production anti-spoofing).
-		// Run ratelimit-limitor from a profile without header stripping, or after JWT sets headers post-strip.
+		// NOTE: ratelimit-limitor is NOT run here because it requires x-authz-* headers from the
+		// client to reach the router, but EnvoyPatchPolicy Lua strips those headers before ext_proc
+		// (same as production anti-spoofing). Run it from a profile without header stripping, or
+		// after a JWT validation stage that re-injects identity headers post-strip.
 	}
 }
 

--- a/e2e/profiles/authz-rbac/profile.go
+++ b/e2e/profiles/authz-rbac/profile.go
@@ -68,10 +68,10 @@ const (
 // Profile implements the authz-rbac test profile.
 // It demonstrates user-level RBAC model routing where different users
 // (admin, premium, free) are routed to different models (14B vs 7B)
-// based on identity headers extracted from validated JWT tokens.
-// SECURITY: Identity headers (x-authz-user-id, x-authz-user-groups) must only
-// come from validated auth backends (JWT, Authorino, etc.), not from client requests.
-// The Envoy configuration strips any client-supplied identity headers before processing.
+// based on JWT claims copied into x-jwt-sub/x-jwt-groups after validation.
+// SECURITY: Those headers must only come from validated auth backends (JWT, Authorino, etc.),
+// not from client requests. The Envoy configuration strips any client-supplied identity
+// headers before jwt_authn/ext_proc processing.
 type Profile struct {
 	verbose bool
 }
@@ -88,7 +88,7 @@ func (p *Profile) Name() string {
 
 // Description returns the profile description
 func (p *Profile) Description() string {
-	return "Tests RBAC-based model routing with JWT-validated user identity headers (admin→14B, premium→14B/7B, free→7B)"
+	return "Tests RBAC-based model routing with JWT-validated x-jwt-* identity headers (admin→14B, premium→14B/7B, free→7B)"
 }
 
 // Setup deploys all required components for authz-rbac testing
@@ -176,16 +176,15 @@ func (p *Profile) GetTestCases() []string {
 	return []string{
 		// Standard functional test — validates end-to-end routing
 		"chat-completions-request",
-		// Authz-specific functional test (200 OK; identity headers are stripped by Envoy Lua before ext_proc)
+		// Authz-specific functional test using a validated JWT; jwt_authn copies claims into x-jwt-* headers.
 		"chat-completions-request-authz",
-		// Functional RBAC routing test using the profile's configured authz identity headers
+		// Functional RBAC routing test using validated JWT claims instead of client-supplied identity headers.
 		"authz-rbac-routing",
-		// Security test — validates that client-supplied identity headers are stripped
+		// Security test — validates that client-supplied identity headers are stripped before jwt_authn runs.
 		"authz-header-spoofing",
-		// NOTE: ratelimit-limitor is NOT run here because it requires x-authz-* headers from the
-		// client to reach the router, but EnvoyPatchPolicy Lua strips those headers before ext_proc
-		// (same as production anti-spoofing). Run it from a profile without header stripping, or
-		// after a JWT validation stage that re-injects identity headers post-strip.
+		// NOTE: ratelimit-limitor is NOT run here because it still sends raw x-authz-* headers from the
+		// client, while this profile now strips client-supplied identity headers and relies on JWT-derived
+		// x-jwt-* headers. Run it from a profile without header stripping, or after the testcase supports JWTs.
 	}
 }
 

--- a/e2e/profiles/authz-rbac/profile.go
+++ b/e2e/profiles/authz-rbac/profile.go
@@ -178,6 +178,8 @@ func (p *Profile) GetTestCases() []string {
 		"chat-completions-request",
 		// Authz-specific functional test (200 OK; identity headers are stripped by Envoy Lua before ext_proc)
 		"chat-completions-request-authz",
+		// RBAC routing test — validates role-based decision selection when authz identity headers are present
+		"authz-rbac-routing",
 		// Security test — validates that client-supplied identity headers are stripped
 		"authz-header-spoofing",
 		// NOTE: ratelimit-limitor is NOT run here: it requires x-authz-* from the client to reach

--- a/e2e/profiles/authz-rbac/values.yaml
+++ b/e2e/profiles/authz-rbac/values.yaml
@@ -191,6 +191,9 @@ config:
     services:
       authz:
         fail_open: true
+        identity:
+          user_id_header: x-authz-user-id
+          user_groups_header: x-authz-user-groups
       ratelimit:
         fail_open: false
         providers:

--- a/e2e/profiles/authz-rbac/values.yaml
+++ b/e2e/profiles/authz-rbac/values.yaml
@@ -12,11 +12,11 @@
 # Architecture:
 #   Client -> Envoy -> ext_proc (semantic router) -> vLLM endpoints
 #
-# Identity headers (x-authz-user-id, x-authz-user-groups) must come from
+# JWT-derived identity headers (x-jwt-sub, x-jwt-groups) must come from
 # validated auth backends (JWT, Authorino, etc.), not from client requests.
 # SECURITY: The Envoy configuration strips any client-supplied identity headers
-# to prevent spoofing attacks. For e2e tests, use JWT tokens in the Authorization
-# header; Envoy validates the JWT and extracts claims into identity headers.
+# before jwt_authn runs, then injects validated JWT claims into x-jwt-* headers.
+# For e2e tests, send JWT tokens in the Authorization header.
 #
 # Test Users:
 #   alice / platform-admins  → admin
@@ -192,8 +192,8 @@ config:
       authz:
         fail_open: true
         identity:
-          user_id_header: x-authz-user-id
-          user_groups_header: x-authz-user-groups
+          user_id_header: x-jwt-sub
+          user_groups_header: x-jwt-groups
       ratelimit:
         fail_open: false
         providers:

--- a/e2e/testcases/authz_header_spoofing.go
+++ b/e2e/testcases/authz_header_spoofing.go
@@ -16,11 +16,20 @@ import (
 
 func init() {
 	pkgtestcases.Register("authz-header-spoofing", pkgtestcases.TestCase{
-		Description: "Test that client-supplied identity headers are stripped and cannot be used for unauthorized access",
+		Description: "Test that client-supplied JWT-derived identity headers are stripped and cannot override validated JWT claims",
 		Tags:        []string{"authz-rbac", "security", "authz"},
 		Fn:          testAuthzHeaderSpoofing,
 	})
 }
+
+const (
+	authzJWTAdminToken    = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImF1dGh6LXJiYWMtZTJlIn0.eyJpc3MiOiJzZW1hbnRpYy1yb3V0ZXItZTJlIiwiYXVkIjoic2VtYW50aWMtcm91dGVyIiwiZXhwIjo0MTAyNDQ0ODAwLCJzdWIiOiJhbGljZSIsImdyb3VwcyI6WyJwbGF0Zm9ybS1hZG1pbnMiXX0.sH2fDyG6a4xBT_ZCIFiz5rt_moAJA0MP2oIioUeBWo4"
+	authzJWTPremiumToken  = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImF1dGh6LXJiYWMtZTJlIn0.eyJpc3MiOiJzZW1hbnRpYy1yb3V0ZXItZTJlIiwiYXVkIjoic2VtYW50aWMtcm91dGVyIiwiZXhwIjo0MTAyNDQ0ODAwLCJzdWIiOiJib2IiLCJncm91cHMiOlsicHJlbWl1bS10aWVyIl19.899EGXc0PK9zNfbKW4Esf8irr1zV2gOWQ6BAwqthqz4"
+	authzJWTFreeToken     = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImF1dGh6LXJiYWMtZTJlIn0.eyJpc3MiOiJzZW1hbnRpYy1yb3V0ZXItZTJlIiwiYXVkIjoic2VtYW50aWMtcm91dGVyIiwiZXhwIjo0MTAyNDQ0ODAwLCJzdWIiOiJjYXJvbCIsImdyb3VwcyI6WyJmcmVlLXRpZXIiXX0.pr0d9VRO1YaqmPvbNzINDssobi6Oiwm7M0yML-WWbUo"
+	authzJWTChatToken     = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImF1dGh6LXJiYWMtZTJlIn0.eyJpc3MiOiJzZW1hbnRpYy1yb3V0ZXItZTJlIiwiYXVkIjoic2VtYW50aWMtcm91dGVyIiwiZXhwIjo0MTAyNDQ0ODAwLCJzdWIiOiJlMmUtYXV0aHotZnJlZS11c2VyIiwiZ3JvdXBzIjpbImZyZWUtdGllciJdfQ.y4M5ph86xrChM9ll8WiFEG1s0KAh7cgzEK5H0ZOX1XI"
+	authzUserIDHeader     = "x-jwt-sub"
+	authzUserGroupsHeader = "x-jwt-groups"
+)
 
 // AuthzSpoofingTestCase represents a test case for identity header spoofing
 type AuthzSpoofingTestCase struct {
@@ -62,15 +71,15 @@ func testAuthzHeaderSpoofing(ctx context.Context, client *kubernetes.Clientset, 
 	// Define test cases
 	testCases := []AuthzSpoofingTestCase{
 		{
-			Description:     "Client sends x-authz-user-id header directly - should be stripped and route to default model",
-			UserID:          "admin",
+			Description:     "Client sends x-jwt-sub header directly - should be stripped and route to default model",
+			UserID:          "alice",
 			UserGroups:      "platform-admins",
 			ExpectedModel:   "Qwen/Qwen2.5-7B-Instruct", // Should route to default, not admin model
 			ExpectedBlocked: false,
 			ShouldUseJWT:    false,
 		},
 		{
-			Description:     "Client sends x-authz-user-groups header directly - should be stripped",
+			Description:     "Client sends x-jwt-groups header directly - should be stripped",
 			UserID:          "",
 			UserGroups:      "premium-tier",
 			ExpectedModel:   "Qwen/Qwen2.5-7B-Instruct", // Should route to default
@@ -78,12 +87,21 @@ func testAuthzHeaderSpoofing(ctx context.Context, client *kubernetes.Clientset, 
 			ShouldUseJWT:    false,
 		},
 		{
-			Description:     "Client sends both identity headers directly - should be stripped",
-			UserID:          "premium-user",
+			Description:     "Client sends both x-jwt-* headers directly - should be stripped",
+			UserID:          "bob",
 			UserGroups:      "premium-tier",
 			ExpectedModel:   "Qwen/Qwen2.5-7B-Instruct", // Should route to default
 			ExpectedBlocked: false,
 			ShouldUseJWT:    false,
+		},
+		{
+			Description:     "Valid free-tier JWT with spoofed admin x-jwt-* headers - JWT claims should win",
+			UserID:          "alice",
+			UserGroups:      "platform-admins",
+			ExpectedModel:   "Qwen/Qwen2.5-7B-Instruct",
+			ExpectedBlocked: false,
+			ShouldUseJWT:    true,
+			JWTToken:        authzJWTFreeToken,
 		},
 		{
 			Description:     "Request without identity headers - should route to default model",
@@ -203,10 +221,10 @@ func createAuthzSpoofingRequest(ctx context.Context, testCase AuthzSpoofingTestC
 	req.Header.Set("Content-Type", "application/json")
 
 	if testCase.UserID != "" {
-		req.Header.Set("x-authz-user-id", testCase.UserID)
+		req.Header.Set(authzUserIDHeader, testCase.UserID)
 	}
 	if testCase.UserGroups != "" {
-		req.Header.Set("x-authz-user-groups", testCase.UserGroups)
+		req.Header.Set(authzUserGroupsHeader, testCase.UserGroups)
 	}
 	if testCase.ShouldUseJWT && testCase.JWTToken != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testCase.JWTToken))

--- a/e2e/testcases/authz_header_spoofing.go
+++ b/e2e/testcases/authz_header_spoofing.go
@@ -130,16 +130,10 @@ func testAuthzHeaderSpoofing(ctx context.Context, client *kubernetes.Clientset, 
 			correctTests, totalTests, successRate)
 	}
 
-	// Return error if all tests failed
-	if correctTests == 0 {
-		return fmt.Errorf("authz header spoofing test failed: 0%% success rate (0/%d correct)", totalTests)
-	}
-
-	// Warn if success rate is low (but don't fail)
-	if successRate < 100 {
-		if opts.Verbose {
-			fmt.Printf("[Test] Warning: Some tests failed. Success rate: %.2f%%\n", successRate)
-		}
+	// Security tests must all pass — a partial pass means header stripping is broken for some cases.
+	if correctTests < totalTests {
+		return fmt.Errorf("authz header spoofing test failed: %d/%d cases passed (%.2f%% success rate) — identity headers not stripped for all requests",
+			correctTests, totalTests, successRate)
 	}
 
 	return nil

--- a/e2e/testcases/authz_rbac_routing.go
+++ b/e2e/testcases/authz_rbac_routing.go
@@ -23,6 +23,7 @@ type authzRoutingCase struct {
 	name         string
 	userID       string
 	groups       string
+	token        string
 	prompt       string
 	wantDecision string // expected x-vsr-selected-decision; empty = any 200 OK is sufficient
 }
@@ -46,6 +47,7 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 			name:         "admin_unrestricted",
 			userID:       "alice",
 			groups:       "platform-admins",
+			token:        authzJWTAdminToken,
 			prompt:       "Explain quantum entanglement",
 			wantDecision: "admin_unrestricted",
 		},
@@ -54,6 +56,7 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 			name:         "premium_complex",
 			userID:       "bob",
 			groups:       "premium-tier",
+			token:        authzJWTPremiumToken,
 			prompt:       "Please analyze and compare the trade-offs between microservices and monolithic architecture",
 			wantDecision: "premium_complex",
 		},
@@ -62,6 +65,7 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 			name:         "premium_code",
 			userID:       "bob",
 			groups:       "premium-tier",
+			token:        authzJWTPremiumToken,
 			prompt:       "Can you implement a binary search function and debug the edge cases?",
 			wantDecision: "premium_code",
 		},
@@ -70,6 +74,7 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 			name:         "premium_default",
 			userID:       "bob",
 			groups:       "premium-tier",
+			token:        authzJWTPremiumToken,
 			prompt:       "Hello, what time is it?",
 			wantDecision: "premium_default",
 		},
@@ -78,6 +83,7 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 			name:         "free_default",
 			userID:       "carol",
 			groups:       "free-tier",
+			token:        authzJWTFreeToken,
 			prompt:       "Hello, how are you today?",
 			wantDecision: "free_default",
 		},
@@ -121,11 +127,8 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 
 func checkAuthzRoutingCase(ctx context.Context, chatClient *fixtures.ChatCompletionsClient, tc authzRoutingCase, verbose bool) error {
 	headers := map[string]string{}
-	if tc.userID != "" {
-		headers["x-authz-user-id"] = tc.userID
-	}
-	if tc.groups != "" {
-		headers["x-authz-user-groups"] = tc.groups
+	if tc.token != "" {
+		headers["Authorization"] = "Bearer " + tc.token
 	}
 
 	resp, err := chatClient.Create(ctx, fixtures.ChatCompletionsRequest{
@@ -147,7 +150,7 @@ func checkAuthzRoutingCase(ctx context.Context, chatClient *fixtures.ChatComplet
 	gotDecision := resp.Headers.Get("x-vsr-selected-decision")
 	if gotDecision != tc.wantDecision {
 		if verbose {
-			fmt.Printf("[AuthzRBAC]   user=%q groups=%q: decision=%q, want=%q\n",
+			fmt.Printf("[AuthzRBAC]   jwt sub=%q groups=%q: decision=%q, want=%q\n",
 				tc.userID, tc.groups, gotDecision, tc.wantDecision)
 		}
 		return fmt.Errorf("x-vsr-selected-decision: got %q, want %q", gotDecision, tc.wantDecision)

--- a/e2e/testcases/authz_rbac_routing.go
+++ b/e2e/testcases/authz_rbac_routing.go
@@ -93,9 +93,11 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 	}
 
 	passed := 0
+	var failures []string
 	for _, tc := range cases {
 		if err := checkAuthzRoutingCase(ctx, chatClient, tc, opts.Verbose); err != nil {
 			fmt.Printf("[AuthzRBAC] FAIL %s: %v\n", tc.name, err)
+			failures = append(failures, tc.name)
 			continue
 		}
 		if opts.Verbose {
@@ -111,8 +113,8 @@ func testAuthzRBACRouting(ctx context.Context, client *kubernetes.Clientset, opt
 		})
 	}
 
-	if passed == 0 {
-		return fmt.Errorf("authz-rbac-routing: 0/%d cases passed", len(cases))
+	if len(failures) > 0 {
+		return fmt.Errorf("authz-rbac-routing: %d/%d cases failed: %v", len(failures), len(cases), failures)
 	}
 	return nil
 }

--- a/e2e/testcases/chat_completions_request_authz.go
+++ b/e2e/testcases/chat_completions_request_authz.go
@@ -8,13 +8,12 @@ import (
 )
 
 var authzChatRequestHeaders = map[string]string{
-	"x-authz-user-id":     "e2e-authz-free-user",
-	"x-authz-user-groups": "free-tier",
+	"Authorization": "Bearer " + authzJWTChatToken,
 }
 
 func init() {
 	pkgtestcases.Register("chat-completions-request-authz", pkgtestcases.TestCase{
-		Description: "Send a chat completions request with authz identity headers and verify 200 OK response",
+		Description: "Send a chat completions request with a valid authz JWT and verify 200 OK response",
 		Tags:        []string{"llm", "functional", "authz"},
 		Fn:          testChatCompletionsRequestAuthz,
 	})


### PR DESCRIPTION
Auto-resolve for #2010 (verdict: lgtm)

Localizer brief:

## Summary

**Mode: fix**

### Root cause
The `authz-rbac-routing` test case is **registered** (line 14 of `e2e/testcases/authz_rbac_routing.go`) but **NOT listed** in the e2e profile's `GetTestCases()` method (`e2e/profiles/authz-rbac/profile.go:175-186`). The test attempts to send authz headers directly (`x-authz-user-id`, `x-authz-user-groups`), which works with the default header names in the config, but:

1. The profile's `values.yaml` (line 192-193) configures `authz.fail_open: true` **without** defining an explicit `identity` section
2. The test assumes role bindings will match against headers like `x-authz-user-id: "alice"` + `x-authz-user-groups: "platform-admins"` → role `admin`
3. **Missing**: The `identity` configuration block is absent, so while defaults apply internally, the config sent to the router lacks explicit validation that headers are properly configured

### Affected files
- **`e2e/profiles/authz-rbac/profile.go`** (line 175-186) — Missing `authz-rbac-routing` from `GetTestCases()` list; only runs 3 tests instead of 4
- **`e2e/profiles/authz-rbac/values.yaml`** (line 192-193) — Missing explicit `identity` section under `authz`; relies on defaults silently
- **`e2e/testcases/authz_rbac_routing.go`** (line 14) — Registered but not scheduled by the profile

### Anchor symbols
- `Profile.GetTestCases()` at `/home/azureuser/ast/semantic-router/e2e/profiles/authz-rbac/profile.go:175`
- `authz-rbac-routing` test registration at `/home/azureuser/ast/semantic-router/e2e/testcases/authz_rbac_routing.go:14`
- `IdentityConfig.GetUserIDHeader()` at `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/config/config.go:104`
- `AuthzClassifier.Classify()` at `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/authz_classifier.go:118`

### Reference call-sites
- Default header usage: `/home/azureuser/ast/semantic-router/src/semantic-router/pkg/classification/classifier.go:171-172`
- Test fixture header passing: `/home/azureuser/ast/semantic-router/e2e/pkg/fixtures/chat.go:56-62`

### Runner/CI dependencies
- CI workflow: `/home/azureuser/ast/semantic-router/.github/workflows/integration-test-k8s.yml:64` (authz-rbac profile detection)

### Tests to update or add
1. **Add** `"authz-rbac-routing"` to `GetTestCases()` list in `/home/azureuser/ast/semantic-router/e2e/profiles/authz-rbac/profile.go:175`
2. **Add** explicit `identity` section to `/home/azureuser/ast/semantic-router/e2e/profiles/authz-rbac/values.yaml` under `global.services.authz` (below line 193):
   ```yaml
   identity:
     user_id_header: x-authz-user-id
     user_groups_header: x-authz-user-groups
   ```

### Risks / unknowns
- Whether the Envoy configuration in the profile actually strips/validates JWT before reaching ext_proc (affects whether direct headers work)
- Exact assertion error from the failing CI run (need GitHub Actions logs to confirm expected vs actual decision headers)

Verifier findings:

Verdict: lgtm — Fix patch that adds a missing test case registration and required config to the authz-rbac profile.

## Findings

- **`e2e/testcases/authz_rbac_routing.go:138` — Weak failure threshold.** The test only returns an error if `passed == 0`. Since the `no_identity_default` sub-case (empty headers, any 200 OK) will always pass when `fail_open: true`, the test as written cannot ever return an error even if all RBAC routing assertions fail. This means CI will show green for `authz-rbac-routing` even if none of the role-based decisions (admin_unrestricted, premium_complex, etc.) are working. This is a pre-existing issue in the test file, not introduced by this patch, but the patch adds this test to CI without calling attention to it.

- **`e2e/profiles/authz-rbac/values.yaml` — `identity` block is functionally redundant.** The router's `GetUserIDHeader()` / `GetUserGroupsHeader()` already default to `x-authz-user-id` / `x-authz-user-groups` when the config is absent (`config.go:106,113`). Adding them explicitly is harmless but provides no behavioral change. The patch is not wrong here.

## Required follow-ups

- The `authz-rbac-routing` test's pass criterion (`passed == 0` guard) should be tightened to require that all cases with a non-empty `wantDecision` pass — otherwise this test adds no CI signal for RBAC routing correctness.