### PR TITLE
Update community governance team page

### DIFF
--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -1475,61 +1475,28 @@
     "message": "加入特定的工作组"
   },
   "team.title": {
-    "message": "团队成员 👥"
+    "message": "团队成员"
   },
   "team.subtitle": {
-    "message": "构建智能 LLM 路由未来的热情成员们"
+    "message": "按治理职责和提交职责协作推进 vLLM Semantic Router"
   },
-  "team.coreTeam.title": {
-    "message": "核心团队"
+  "team.steering.title": {
+    "message": "指导委员会"
   },
-  "team.coreTeam.description": {
-    "message": "推动项目发展并做出关键决策的核心维护者。"
+  "team.steering.description": {
+    "message": "指导委员会负责 vLLM Semantic Router 的路线图方向、项目范围和跨社区协作。"
+  },
+  "team.committers.title": {
+    "message": "提交者"
+  },
+  "team.committers.description": {
+    "message": "提交者负责具体实现领域、代码评审、社区答疑，并维护项目在各个版本中的健康度。"
   },
   "team.joinTeam.title": {
     "message": "加入我们"
   },
   "team.joinTeam.description": {
     "message": "我们一直在寻找热情的贡献者加入我们的社区！"
-  },
-  "team.recognition.title": {
-    "message": "荣誉表彰"
-  },
-  "team.recognition.subtitle": {
-    "message": "贡献者表彰"
-  },
-  "team.recognition.description": {
-    "message": "我们相信认可社区成员的宝贵贡献。在特定领域展现持续奉献和高质量工作的贡献者可能会被邀请成为维护者，获得仓库的写入权限。"
-  },
-  "team.recognition.pathTitle": {
-    "message": "成为维护者之路："
-  },
-  "team.recognition.step1.title": {
-    "message": "定期贡献"
-  },
-  "team.recognition.step1.desc": {
-    "message": "在你感兴趣的领域做出持续、高质量的贡献"
-  },
-  "team.recognition.step2.title": {
-    "message": "加入工作组"
-  },
-  "team.recognition.step2.desc": {
-    "message": "积极参与我们的"
-  },
-  "team.recognition.step2.link": {
-    "message": "工作组"
-  },
-  "team.recognition.step3.title": {
-    "message": "社区投票"
-  },
-  "team.recognition.step3.desc": {
-    "message": "获得维护者团队的提名和批准"
-  },
-  "team.recognition.step4.title": {
-    "message": "维护者权限"
-  },
-  "team.recognition.step4.desc": {
-    "message": "获邀加入维护者团队并获得写入权限"
   },
   "team.getInvolved.title": {
     "message": "参与方式"
@@ -1562,10 +1529,79 @@
     "message": "GitHub 讨论区"
   },
   "team.members.HuaminChen.role": {
-    "message": "杰出工程师"
+    "message": "@Microsoft"
   },
   "team.members.HuaminChen.bio": {
-    "message": "Red Hat 杰出工程师，推动云原生和 AI/LLM 推理技术的创新。"
+    "message": "长期孵化前沿基础设施和 AI 系统，覆盖云原生平台、开源生态和模型服务栈。"
+  },
+  "team.members.HuaminChen.expertise.cloud": {
+    "message": "云原生平台"
+  },
+  "team.members.HuaminChen.expertise.serving": {
+    "message": "模型服务栈"
+  },
+  "team.members.HuaminChen.expertise.ecosystem": {
+    "message": "开源生态"
+  },
+  "team.members.BoweiHe.role": {
+    "message": "Postdoc @ MBZUAI / McGill"
+  },
+  "team.members.BoweiHe.bio": {
+    "message": "CityUHK 博士，曾参与青云人才计划下的 Hunyuan LLM。"
+  },
+  "team.members.BoweiHe.expertise.research": {
+    "message": "学术研究"
+  },
+  "team.members.BoweiHe.expertise.llm": {
+    "message": "LLM 系统"
+  },
+  "team.members.BoweiHe.expertise.hunyuan": {
+    "message": "腾讯混元 LLM"
+  },
+  "team.members.YankaiChen.role": {
+    "message": "Postdoctoral Associate @ McGill University / MBZUAI"
+  },
+  "team.members.YankaiChen.bio": {
+    "message": "研究方向覆盖 agentic AI、人本 AI 和知识挖掘。"
+  },
+  "team.members.YankaiChen.expertise.agentic": {
+    "message": "Agentic AI"
+  },
+  "team.members.YankaiChen.expertise.hcai": {
+    "message": "人本 AI"
+  },
+  "team.members.YankaiChen.expertise.mining": {
+    "message": "知识挖掘"
+  },
+  "team.members.FuyuanLyu.role": {
+    "message": "PhD Candidate @ McGill University / Mila"
+  },
+  "team.members.FuyuanLyu.bio": {
+    "message": "研究方向包括数据中心 AI、自动特征选择，以及面向深度学习和基础模型的自动标注。"
+  },
+  "team.members.FuyuanLyu.expertise.data": {
+    "message": "数据中心 AI"
+  },
+  "team.members.FuyuanLyu.expertise.features": {
+    "message": "自动特征选择"
+  },
+  "team.members.FuyuanLyu.expertise.labeling": {
+    "message": "自动标注"
+  },
+  "team.members.SteveLiu.role": {
+    "message": "@MBZUAI / McGill / Mila"
+  },
+  "team.members.SteveLiu.bio": {
+    "message": "CAE 与 IEEE Fellow；Associate VPR @ MBZUAI；Prof @ McGill；Mila；ex-VP R&D @ Samsung AI；Chair ACM SIGBED。"
+  },
+  "team.members.SteveLiu.expertise.aiml": {
+    "message": "AI 与机器学习"
+  },
+  "team.members.SteveLiu.expertise.systems": {
+    "message": "智能系统"
+  },
+  "team.members.SteveLiu.expertise.cps": {
+    "message": "信息物理系统"
   },
   "team.members.ChenWang.role": {
     "message": "高级研究科学家"
@@ -1580,10 +1616,67 @@
     "message": "IBM 研究科学家，专注于 AI 研究和 LLM 推理。"
   },
   "team.members.XunzhuoLiu.role": {
-    "message": "智能路由"
+    "message": "LLM Routing @ vLLM"
   },
   "team.members.XunzhuoLiu.bio": {
-    "message": "专注于将集体智能带入 LLM 系统。"
+    "message": "LLM routing builder at vLLM。"
+  },
+  "team.members.XunzhuoLiu.expertise.routing": {
+    "message": "LLM 路由"
+  },
+  "team.members.XunzhuoLiu.expertise.gateway": {
+    "message": "Kubernetes AI Gateway"
+  },
+  "team.members.XunzhuoLiu.expertise.opensource": {
+    "message": "开源基础设施"
+  },
+  "team.members.FAUST-BENCHOU.role": {
+    "message": "云原生开源贡献者"
+  },
+  "team.members.FAUST-BENCHOU.bio": {
+    "message": "参与 Karmada 与 Volcano 的云原生开源贡献者。"
+  },
+  "team.members.shraderdm.role": {
+    "message": "GTM Tech Lead"
+  },
+  "team.members.shraderdm.bio": {
+    "message": "Google GTM Tech Lead。"
+  },
+  "team.members.drivebyer.role": {
+    "message": "云原生工程师"
+  },
+  "team.members.drivebyer.bio": {
+    "message": "DaoCloud 工程师与开源贡献者，关注实用基础设施改进。"
+  },
+  "team.members.ramkrishs.role": {
+    "message": "计算机科学工程师"
+  },
+  "team.members.ramkrishs.bio": {
+    "message": "Intuit 计算机科学工程师，专注软件系统。"
+  },
+  "team.members.WUKUNTAI-0211.role": {
+    "message": "软件工程师"
+  },
+  "team.members.WUKUNTAI-0211.bio": {
+    "message": "来自台湾 Delta Electronics 的软件工程师。"
+  },
+  "team.members.AayushSaini101.role": {
+    "message": "SDE, Data and AI"
+  },
+  "team.members.AayushSaini101.bio": {
+    "message": "Red Hat Data and AI SDE，GSoC 2025 参与者，AsyncAPI Steering Committee member。"
+  },
+  "team.members.siloteemu.role": {
+    "message": "开源贡献者"
+  },
+  "team.members.siloteemu.bio": {
+    "message": "GitHub 开源贡献者。"
+  },
+  "team.members.topNewContributor.role": {
+    "message": "Release Window Committer"
+  },
+  "team.members.topNewContributor.bio": {
+    "message": "基于近期贡献者排行识别的新 committer。"
   },
   "team.members.SenanZedan.role": {
     "message": "研发经理"
@@ -1691,6 +1784,18 @@
     "message": "个人贡献者"
   },
   "team.members.aeft.bio": {
+    "message": "vLLM Semantic Router 的开源贡献者。"
+  },
+  "team.members.HaoWu.role": {
+    "message": "个人贡献者"
+  },
+  "team.members.HaoWu.bio": {
+    "message": "vLLM Semantic Router 的开源贡献者。"
+  },
+  "team.members.QipingPan.role": {
+    "message": "个人贡献者"
+  },
+  "team.members.QipingPan.bio": {
     "message": "vLLM Semantic Router 的开源贡献者。"
   },
   "workGroups.title": {
@@ -2359,6 +2464,9 @@
   },
   "team.badge.maintainer": {
     "message": "维护者"
+  },
+  "team.badge.steering": {
+    "message": "指导委员会"
   },
   "team.badge.committer": {
     "message": "提交者"

--- a/website/scripts/generate-contributor-rank.mjs
+++ b/website/scripts/generate-contributor-rank.mjs
@@ -270,8 +270,8 @@ const rangeDefinitions = [
 try {
   const generatedAt = formatLocalDate(new Date())
   const allRows = readContributorRows(null)
-  const release = readLatestRelease()
-  const newContributorsSinceRelease = buildNewContributorsSinceRelease(release, allRows)
+  const releaseWindow = readReleaseWindow()
+  const newContributorsSinceRelease = buildNewContributorsSinceRelease(releaseWindow, allRows)
   const newContributorKeys = new Set(newContributorsSinceRelease.entries.map(entry => entry.key))
   const snapshots = Object.fromEntries(
     rangeDefinitions.map(range => [range.id, buildSnapshot(range, generatedAt, allRows, newContributorKeys)]),
@@ -310,12 +310,15 @@ function buildSnapshot(range, generatedAt, allRows, newContributorKeys) {
   }
 }
 
-function buildNewContributorsSinceRelease(release, allRows) {
-  if (!release) {
+function buildNewContributorsSinceRelease(releaseWindow, allRows) {
+  if (!releaseWindow) {
     return {
       tagName: null,
       releaseName: null,
       releaseDate: null,
+      targetTagName: null,
+      targetReleaseName: null,
+      targetReleaseDate: null,
       comparisonMode: 'none',
       totalCommits: 0,
       totalContributors: 0,
@@ -323,15 +326,14 @@ function buildNewContributorsSinceRelease(release, allRows) {
     }
   }
 
-  const commitShasSinceTag = readCommitShasSinceTag(release.tagName)
-  const rowsSinceRelease = commitShasSinceTag
-    ? allRows.filter(row => row.sha && commitShasSinceTag.has(row.sha))
-    : allRows.filter(row => row.date >= release.publishedAt)
-  const rowsBeforeRelease = commitShasSinceTag
-    ? allRows.filter(row => !row.sha || !commitShasSinceTag.has(row.sha))
-    : allRows.filter(row => row.date < release.publishedAt)
-  const historicalContributorKeys = new Set(collectContributorStats(rowsBeforeRelease).keys())
-  const byContributor = collectContributorStats(rowsSinceRelease)
+  const { baseRelease, targetRelease } = releaseWindow
+  const commitShasInWindow = readCommitShasBetweenTags(baseRelease.tagName, targetRelease.tagName)
+  const rowsInWindow = commitShasInWindow
+    ? allRows.filter(row => row.sha && commitShasInWindow.has(row.sha))
+    : allRows.filter(row => row.date >= baseRelease.publishedAt && row.date <= targetRelease.publishedAt)
+  const rowsBeforeBaseRelease = allRows.filter(row => row.date < baseRelease.publishedAt)
+  const historicalContributorKeys = new Set(collectContributorStats(rowsBeforeBaseRelease).keys())
+  const byContributor = collectContributorStats(rowsInWindow)
 
   for (const key of historicalContributorKeys) {
     byContributor.delete(key)
@@ -341,10 +343,13 @@ function buildNewContributorsSinceRelease(release, allRows) {
   const entries = rankContributorEntries(byContributor, totalCommits, new Set(byContributor.keys()))
 
   return {
-    tagName: release.tagName,
-    releaseName: release.name,
-    releaseDate: release.publishedAt.slice(0, 10),
-    comparisonMode: commitShasSinceTag ? 'tag' : 'date',
+    tagName: baseRelease.tagName,
+    releaseName: baseRelease.name,
+    releaseDate: baseRelease.publishedAt.slice(0, 10),
+    targetTagName: targetRelease.tagName,
+    targetReleaseName: targetRelease.name,
+    targetReleaseDate: targetRelease.publishedAt.slice(0, 10),
+    comparisonMode: commitShasInWindow ? 'tag' : 'date',
     totalCommits,
     totalContributors: entries.length,
     entries,
@@ -418,7 +423,7 @@ function readContributorRows(startDate) {
   }
 }
 
-function readLatestRelease() {
+function readReleaseWindow() {
   try {
     const output = execFileSync('gh', ['api', `repos/${githubRepo}/releases`], {
       cwd: repoRoot,
@@ -427,15 +432,23 @@ function readLatestRelease() {
       stdio: ['ignore', 'pipe', 'pipe'],
     }).trim()
 
-    const release = JSON.parse(output)
+    const releases = uniqueReleasesByTag(JSON.parse(output)
       .filter(candidate => !candidate.draft)
-      .sort((left, right) => String(right.published_at).localeCompare(String(left.published_at)))[0]
+      .sort((left, right) => String(right.published_at).localeCompare(String(left.published_at))))
 
-    if (release?.tag_name && release?.published_at) {
+    const [targetRelease, baseRelease] = releases
+    if (baseRelease?.tag_name && baseRelease?.published_at && targetRelease?.tag_name && targetRelease?.published_at) {
       return {
-        tagName: release.tag_name,
-        name: release.name ?? release.tag_name,
-        publishedAt: release.published_at,
+        baseRelease: {
+          tagName: baseRelease.tag_name,
+          name: baseRelease.name ?? baseRelease.tag_name,
+          publishedAt: baseRelease.published_at,
+        },
+        targetRelease: {
+          tagName: targetRelease.tag_name,
+          name: targetRelease.name ?? targetRelease.tag_name,
+          publishedAt: targetRelease.published_at,
+        },
       }
     }
   }
@@ -443,31 +456,42 @@ function readLatestRelease() {
     console.warn(`Falling back to local git release tag data: ${error.message}`)
   }
 
-  return readLatestLocalTag()
+  return readLocalReleaseWindow()
 }
 
-function readLatestLocalTag() {
+function uniqueReleasesByTag(releases) {
+  const seen = new Set()
+  const unique = []
+
+  for (const release of releases) {
+    const tagName = release?.tag_name
+    if (!tagName || seen.has(tagName)) {
+      continue
+    }
+
+    seen.add(tagName)
+    unique.push(release)
+  }
+
+  return unique
+}
+
+function readLocalReleaseWindow() {
   try {
-    const tagName = execFileSync('git', ['tag', '--sort=-creatordate'], {
+    const tagNames = execFileSync('git', ['tag', '--sort=-creatordate'], {
       cwd: repoRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim().split('\n').find(Boolean)
+    }).trim().split('\n').filter(Boolean)
 
-    if (!tagName) {
+    const [targetTagName, baseTagName] = tagNames
+    if (!targetTagName || !baseTagName) {
       return null
     }
 
-    const publishedAt = execFileSync('git', ['log', '-1', '--format=%aI', tagName], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim()
-
     return {
-      tagName,
-      name: tagName,
-      publishedAt,
+      baseRelease: readLocalReleaseTag(baseTagName),
+      targetRelease: readLocalReleaseTag(targetTagName),
     }
   }
   catch (error) {
@@ -477,8 +501,22 @@ function readLatestLocalTag() {
   }
 }
 
-function readCommitShasSinceTag(tagName) {
-  if (!tagName) {
+function readLocalReleaseTag(tagName) {
+  const publishedAt = execFileSync('git', ['log', '-1', '--format=%aI', tagName], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+
+  return {
+    tagName,
+    name: tagName,
+    publishedAt,
+  }
+}
+
+function readCommitShasBetweenTags(baseTagName, targetTagName) {
+  if (!baseTagName || !targetTagName) {
     return null
   }
 
@@ -487,7 +525,7 @@ function readCommitShasSinceTag(tagName) {
       'api',
       '--paginate',
       '--slurp',
-      `repos/${githubRepo}/compare/${tagName}...main?per_page=100`,
+      `repos/${githubRepo}/compare/${baseTagName}...${targetTagName}?per_page=100`,
     ], {
       cwd: repoRoot,
       encoding: 'utf8',
@@ -506,13 +544,18 @@ function readCommitShasSinceTag(tagName) {
   }
 
   try {
-    execFileSync('git', ['rev-parse', '--verify', `${tagName}^{commit}`], {
+    execFileSync('git', ['rev-parse', '--verify', `${baseTagName}^{commit}`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    execFileSync('git', ['rev-parse', '--verify', `${targetTagName}^{commit}`], {
       cwd: repoRoot,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     })
 
-    const output = execFileSync('git', ['log', '--no-merges', '--format=%H', `${tagName}..HEAD`], {
+    const output = execFileSync('git', ['log', '--no-merges', '--format=%H', `${baseTagName}..${targetTagName}`], {
       cwd: repoRoot,
       encoding: 'utf8',
       maxBuffer: 1024 * 1024 * 8,
@@ -853,6 +896,9 @@ export interface NewContributorsSinceReleaseSnapshot {
   tagName: string | null
   releaseName: string | null
   releaseDate: string | null
+  targetTagName: string | null
+  targetReleaseName: string | null
+  targetReleaseDate: string | null
   comparisonMode: 'tag' | 'date' | 'none'
   totalCommits: number
   totalContributors: number

--- a/website/src/data/contributorRank.generated.ts
+++ b/website/src/data/contributorRank.generated.ts
@@ -36,18 +36,24 @@ export interface NewContributorsSinceReleaseSnapshot {
   tagName: string | null
   releaseName: string | null
   releaseDate: string | null
+  targetTagName: string | null
+  targetReleaseName: string | null
+  targetReleaseDate: string | null
   comparisonMode: 'tag' | 'date' | 'none'
   totalCommits: number
   totalContributors: number
   entries: ContributorRankEntry[]
 }
 
-export const contributorRankGeneratedAt = '2026-06-05'
+export const contributorRankGeneratedAt = '2026-06-09'
 
 export const newContributorsSinceRelease = {
   "tagName": "v0.2.0",
   "releaseName": "v0.2.0 - Athena",
   "releaseDate": "2026-03-10",
+  "targetTagName": "v0.3.0",
+  "targetReleaseName": "Release v0.3.0",
+  "targetReleaseDate": "2026-06-05",
   "comparisonMode": "tag",
   "totalCommits": 188,
   "totalContributors": 50,
@@ -756,11 +762,11 @@ export const contributorRankData = {
   "last3months": {
     "id": "last3months",
     "label": "Last 3 months",
-    "generatedAt": "2026-06-05",
-    "startDate": "2026-03-05",
-    "endDate": "2026-06-05",
+    "generatedAt": "2026-06-09",
+    "startDate": "2026-03-09",
+    "endDate": "2026-06-09",
     "description": "Recent non-merge commit activity.",
-    "totalCommits": 394,
+    "totalCommits": 386,
     "totalContributors": 69,
     "newContributors": 50,
     "entries": [
@@ -772,9 +778,9 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/48784001?v=4",
         "avatarSeed": "xunzhuo",
         "key": "github:xunzhuo",
-        "commits": 101,
-        "share": 0.2563,
-        "firstCommitDate": "2026-03-05",
+        "commits": 91,
+        "share": 0.2358,
+        "firstCommitDate": "2026-03-09",
         "latestCommitDate": "2026-06-05",
         "isNewContributorSinceRelease": false
       },
@@ -786,10 +792,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/126341483?v=4",
         "avatarSeed": "faust-benchou",
         "key": "github:faust-benchou",
-        "commits": 33,
-        "share": 0.0838,
+        "commits": 38,
+        "share": 0.0984,
         "firstCommitDate": "2026-03-26",
-        "latestCommitDate": "2026-06-05",
+        "latestCommitDate": "2026-06-08",
         "isNewContributorSinceRelease": true
       },
       {
@@ -800,10 +806,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/7062400?v=4",
         "avatarSeed": "rootfs",
         "key": "github:rootfs",
-        "commits": 33,
-        "share": 0.0838,
-        "firstCommitDate": "2026-03-05",
-        "latestCommitDate": "2026-05-05",
+        "commits": 28,
+        "share": 0.0725,
+        "firstCommitDate": "2026-03-16",
+        "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": false
       },
       {
@@ -814,10 +820,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/16212439?v=4",
         "avatarSeed": "shraderdm",
         "key": "github:shraderdm",
-        "commits": 17,
-        "share": 0.0431,
+        "commits": 20,
+        "share": 0.0518,
         "firstCommitDate": "2026-05-05",
-        "latestCommitDate": "2026-06-05",
+        "latestCommitDate": "2026-06-06",
         "isNewContributorSinceRelease": true
       },
       {
@@ -829,7 +835,7 @@ export const contributorRankData = {
         "avatarSeed": "drivebyer",
         "key": "github:drivebyer",
         "commits": 16,
-        "share": 0.0406,
+        "share": 0.0415,
         "firstCommitDate": "2026-03-13",
         "latestCommitDate": "2026-05-25",
         "isNewContributorSinceRelease": true
@@ -842,14 +848,28 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/129663775?v=4",
         "avatarSeed": "cryo-zd",
         "key": "github:cryo-zd",
-        "commits": 10,
-        "share": 0.0254,
+        "commits": 11,
+        "share": 0.0285,
         "firstCommitDate": "2026-03-09",
-        "latestCommitDate": "2026-06-01",
+        "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": false
       },
       {
         "rank": 7,
+        "name": "WUKUNTAI",
+        "login": "WUKUNTAI-0211",
+        "avatarLogin": "WUKUNTAI-0211",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/83541875?v=4",
+        "avatarSeed": "wukuntai-0211",
+        "key": "github:wukuntai-0211",
+        "commits": 11,
+        "share": 0.0285,
+        "firstCommitDate": "2026-05-05",
+        "latestCommitDate": "2026-06-08",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 8,
         "name": "Ramakrishnan Sathyavageeswaran",
         "login": "ramkrishs",
         "avatarLogin": "ramkrishs",
@@ -857,23 +877,9 @@ export const contributorRankData = {
         "avatarSeed": "ramkrishs",
         "key": "github:ramkrishs",
         "commits": 10,
-        "share": 0.0254,
+        "share": 0.0259,
         "firstCommitDate": "2026-04-28",
         "latestCommitDate": "2026-05-05",
-        "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 8,
-        "name": "WUKUNTAI",
-        "login": "WUKUNTAI-0211",
-        "avatarLogin": "WUKUNTAI-0211",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/83541875?v=4",
-        "avatarSeed": "wukuntai-0211",
-        "key": "github:wukuntai-0211",
-        "commits": 10,
-        "share": 0.0254,
-        "firstCommitDate": "2026-05-05",
-        "latestCommitDate": "2026-06-04",
         "isNewContributorSinceRelease": true
       },
       {
@@ -885,7 +891,7 @@ export const contributorRankData = {
         "avatarSeed": "asaadbalum",
         "key": "github:asaadbalum",
         "commits": 9,
-        "share": 0.0228,
+        "share": 0.0233,
         "firstCommitDate": "2026-03-24",
         "latestCommitDate": "2026-04-17",
         "isNewContributorSinceRelease": false
@@ -899,7 +905,7 @@ export const contributorRankData = {
         "avatarSeed": "aayushsaini101",
         "key": "github:aayushsaini101",
         "commits": 8,
-        "share": 0.0203,
+        "share": 0.0207,
         "firstCommitDate": "2026-04-17",
         "latestCommitDate": "2026-05-30",
         "isNewContributorSinceRelease": true
@@ -913,7 +919,7 @@ export const contributorRankData = {
         "avatarSeed": "siloteemu",
         "key": "github:siloteemu",
         "commits": 7,
-        "share": 0.0178,
+        "share": 0.0181,
         "firstCommitDate": "2026-05-27",
         "latestCommitDate": "2026-06-03",
         "isNewContributorSinceRelease": true
@@ -927,7 +933,7 @@ export const contributorRankData = {
         "avatarSeed": "yehuditkerido",
         "key": "github:yehuditkerido",
         "commits": 7,
-        "share": 0.0178,
+        "share": 0.0181,
         "firstCommitDate": "2026-03-12",
         "latestCommitDate": "2026-04-14",
         "isNewContributorSinceRelease": false
@@ -941,27 +947,13 @@ export const contributorRankData = {
         "avatarSeed": "liuqihao",
         "key": "github:brucelovedecimal",
         "commits": 7,
-        "share": 0.0178,
+        "share": 0.0181,
         "firstCommitDate": "2026-04-15",
         "latestCommitDate": "2026-04-29",
         "isNewContributorSinceRelease": true
       },
       {
         "rank": 14,
-        "name": "abdallahsamabd",
-        "login": "abdallahsamabd",
-        "avatarLogin": "abdallahsamabd",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/42250800?v=4",
-        "avatarSeed": "abdallahsamabd",
-        "key": "github:abdallahsamabd",
-        "commits": 6,
-        "share": 0.0152,
-        "firstCommitDate": "2026-03-05",
-        "latestCommitDate": "2026-04-21",
-        "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 15,
         "name": "Noa Limoy",
         "login": "noalimoy",
         "avatarLogin": "noalimoy",
@@ -969,13 +961,13 @@ export const contributorRankData = {
         "avatarSeed": "noalimoy",
         "key": "github:noalimoy",
         "commits": 6,
-        "share": 0.0152,
+        "share": 0.0155,
         "firstCommitDate": "2026-03-14",
         "latestCommitDate": "2026-04-19",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 16,
+        "rank": 15,
         "name": "Daria Korenieva",
         "login": "daric93",
         "avatarLogin": "daric93",
@@ -983,13 +975,13 @@ export const contributorRankData = {
         "avatarSeed": "daric93",
         "key": "github:daric93",
         "commits": 5,
-        "share": 0.0127,
+        "share": 0.013,
         "firstCommitDate": "2026-03-24",
         "latestCommitDate": "2026-04-16",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 17,
+        "rank": 16,
         "name": "Liav Weiss",
         "login": "liavweiss",
         "avatarLogin": "liavweiss",
@@ -997,10 +989,24 @@ export const contributorRankData = {
         "avatarSeed": "liavweiss",
         "key": "github:liavweiss",
         "commits": 5,
-        "share": 0.0127,
+        "share": 0.013,
         "firstCommitDate": "2026-03-19",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": false
+      },
+      {
+        "rank": 17,
+        "name": "Theo Hsiung",
+        "login": "theohsiung",
+        "avatarLogin": "theohsiung",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/90186852?v=4",
+        "avatarSeed": "theohsiung",
+        "key": "github:theohsiung",
+        "commits": 5,
+        "share": 0.013,
+        "firstCommitDate": "2026-05-29",
+        "latestCommitDate": "2026-06-05",
+        "isNewContributorSinceRelease": true
       },
       {
         "rank": 18,
@@ -1011,7 +1017,7 @@ export const contributorRankData = {
         "avatarSeed": "wilsonwu",
         "key": "github:wilsonwu",
         "commits": 5,
-        "share": 0.0127,
+        "share": 0.013,
         "firstCommitDate": "2026-04-15",
         "latestCommitDate": "2026-06-05",
         "isNewContributorSinceRelease": false
@@ -1025,7 +1031,7 @@ export const contributorRankData = {
         "avatarSeed": "xiaotian-yu",
         "key": "github:xiaotian-yu",
         "commits": 5,
-        "share": 0.0127,
+        "share": 0.013,
         "firstCommitDate": "2026-05-05",
         "latestCommitDate": "2026-05-28",
         "isNewContributorSinceRelease": true
@@ -1039,13 +1045,27 @@ export const contributorRankData = {
         "avatarSeed": "yossiovadia",
         "key": "github:yossiovadia",
         "commits": 5,
-        "share": 0.0127,
+        "share": 0.013,
         "firstCommitDate": "2026-03-10",
         "latestCommitDate": "2026-03-26",
         "isNewContributorSinceRelease": false
       },
       {
         "rank": 21,
+        "name": "abdallahsamabd",
+        "login": "abdallahsamabd",
+        "avatarLogin": "abdallahsamabd",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/42250800?v=4",
+        "avatarSeed": "abdallahsamabd",
+        "key": "github:abdallahsamabd",
+        "commits": 4,
+        "share": 0.0104,
+        "firstCommitDate": "2026-03-09",
+        "latestCommitDate": "2026-04-21",
+        "isNewContributorSinceRelease": false
+      },
+      {
+        "rank": 22,
         "name": "elijah",
         "login": "e1ijah1",
         "avatarLogin": "e1ijah1",
@@ -1053,24 +1073,10 @@ export const contributorRankData = {
         "avatarSeed": "e1ijah1",
         "key": "github:e1ijah1",
         "commits": 4,
-        "share": 0.0102,
+        "share": 0.0104,
         "firstCommitDate": "2026-04-14",
         "latestCommitDate": "2026-05-27",
         "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 22,
-        "name": "haowu1234",
-        "login": "haowu1234",
-        "avatarLogin": "haowu1234",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/126473953?v=4",
-        "avatarSeed": "haowu1234",
-        "key": "github:haowu1234",
-        "commits": 4,
-        "share": 0.0102,
-        "firstCommitDate": "2026-03-05",
-        "latestCommitDate": "2026-04-02",
-        "isNewContributorSinceRelease": false
       },
       {
         "rank": 23,
@@ -1081,27 +1087,13 @@ export const contributorRankData = {
         "avatarSeed": "njx-njx",
         "key": "github:njx-njx",
         "commits": 4,
-        "share": 0.0102,
+        "share": 0.0104,
         "firstCommitDate": "2026-03-15",
         "latestCommitDate": "2026-04-16",
         "isNewContributorSinceRelease": true
       },
       {
         "rank": 24,
-        "name": "TheoHsiung",
-        "login": "theohsiung",
-        "avatarLogin": "theohsiung",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/90186852?v=4",
-        "avatarSeed": "theohsiung",
-        "key": "github:theohsiung",
-        "commits": 4,
-        "share": 0.0102,
-        "firstCommitDate": "2026-05-29",
-        "latestCommitDate": "2026-06-03",
-        "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 25,
         "name": "Yincheng Ren",
         "login": "Peterren",
         "avatarLogin": "Peterren",
@@ -1109,13 +1101,13 @@ export const contributorRankData = {
         "avatarSeed": "peterren",
         "key": "github:peterren",
         "commits": 4,
-        "share": 0.0102,
+        "share": 0.0104,
         "firstCommitDate": "2026-05-31",
         "latestCommitDate": "2026-06-02",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 26,
+        "rank": 25,
         "name": "Akshay Viswanathan",
         "login": "akshayv",
         "avatarLogin": "akshayv",
@@ -1123,13 +1115,13 @@ export const contributorRankData = {
         "avatarSeed": "akshayv",
         "key": "github:akshayv",
         "commits": 3,
-        "share": 0.0076,
+        "share": 0.0078,
         "firstCommitDate": "2026-05-20",
         "latestCommitDate": "2026-05-21",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 27,
+        "rank": 26,
         "name": "Gagan Dhakrey",
         "login": "gagandhakrey",
         "avatarLogin": "gagandhakrey",
@@ -1137,10 +1129,24 @@ export const contributorRankData = {
         "avatarSeed": "gagandhakrey",
         "key": "github:gagandhakrey",
         "commits": 3,
-        "share": 0.0076,
+        "share": 0.0078,
         "firstCommitDate": "2026-06-04",
         "latestCommitDate": "2026-06-05",
         "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 27,
+        "name": "haowu1234",
+        "login": "haowu1234",
+        "avatarLogin": "haowu1234",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/126473953?v=4",
+        "avatarSeed": "haowu1234",
+        "key": "github:haowu1234",
+        "commits": 3,
+        "share": 0.0078,
+        "firstCommitDate": "2026-03-27",
+        "latestCommitDate": "2026-04-02",
+        "isNewContributorSinceRelease": false
       },
       {
         "rank": 28,
@@ -1151,7 +1157,7 @@ export const contributorRankData = {
         "avatarSeed": "henschwartz",
         "key": "github:henschwartz",
         "commits": 3,
-        "share": 0.0076,
+        "share": 0.0078,
         "firstCommitDate": "2026-03-30",
         "latestCommitDate": "2026-05-01",
         "isNewContributorSinceRelease": false
@@ -1165,27 +1171,13 @@ export const contributorRankData = {
         "avatarSeed": "mkoushni",
         "key": "github:mkoushni",
         "commits": 3,
-        "share": 0.0076,
+        "share": 0.0078,
         "firstCommitDate": "2026-03-14",
         "latestCommitDate": "2026-04-16",
         "isNewContributorSinceRelease": false
       },
       {
         "rank": 30,
-        "name": "Qiping Pan",
-        "login": "ppppqp",
-        "avatarLogin": "ppppqp",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/60682078?v=4",
-        "avatarSeed": "ppppqp",
-        "key": "github:ppppqp",
-        "commits": 3,
-        "share": 0.0076,
-        "firstCommitDate": "2026-03-07",
-        "latestCommitDate": "2026-03-21",
-        "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 31,
         "name": "Sai Asish Y",
         "login": "SAY-5",
         "avatarLogin": "SAY-5",
@@ -1193,13 +1185,13 @@ export const contributorRankData = {
         "avatarSeed": "say-5",
         "key": "github:say-5",
         "commits": 3,
-        "share": 0.0076,
+        "share": 0.0078,
         "firstCommitDate": "2026-04-28",
         "latestCommitDate": "2026-05-06",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 32,
+        "rank": 31,
         "name": "Alan Pope",
         "login": "popey",
         "avatarLogin": "popey",
@@ -1207,13 +1199,13 @@ export const contributorRankData = {
         "avatarSeed": "popey",
         "key": "github:popey",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-03-16",
         "latestCommitDate": "2026-03-30",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 33,
+        "rank": 32,
         "name": "CS458",
         "login": "csl458",
         "avatarLogin": "csl458",
@@ -1221,13 +1213,13 @@ export const contributorRankData = {
         "avatarSeed": "csl458",
         "key": "github:csl458",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-04-21",
         "latestCommitDate": "2026-04-25",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 34,
+        "rank": 33,
         "name": "Houston Zhang",
         "login": "Djanghao",
         "avatarLogin": "Djanghao",
@@ -1235,13 +1227,13 @@ export const contributorRankData = {
         "avatarSeed": "djanghao",
         "key": "github:djanghao",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-03-15",
         "latestCommitDate": "2026-03-20",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 35,
+        "rank": 34,
         "name": "José Maia",
         "login": "glitch-ux",
         "avatarLogin": "glitch-ux",
@@ -1249,13 +1241,13 @@ export const contributorRankData = {
         "avatarSeed": "glitch-ux",
         "key": "github:glitch-ux",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-05-30",
         "latestCommitDate": "2026-06-01",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 36,
+        "rank": 35,
         "name": "Keith Mattix II",
         "login": "keithmattix",
         "avatarLogin": "keithmattix",
@@ -1263,13 +1255,13 @@ export const contributorRankData = {
         "avatarSeed": "keithmattix",
         "key": "github:keithmattix",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-05-30",
         "latestCommitDate": "2026-06-01",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 37,
+        "rank": 36,
         "name": "lauri-amd",
         "login": "lauri-amd",
         "avatarLogin": "lauri-amd",
@@ -1277,13 +1269,13 @@ export const contributorRankData = {
         "avatarSeed": "lauri-amd",
         "key": "github:lauri-amd",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-06-03",
         "latestCommitDate": "2026-06-04",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 38,
+        "rank": 37,
         "name": "Louis Chu",
         "login": "noCharger",
         "avatarLogin": "noCharger",
@@ -1291,13 +1283,13 @@ export const contributorRankData = {
         "avatarSeed": "nocharger",
         "key": "github:nocharger",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-04-14",
         "latestCommitDate": "2026-04-19",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 39,
+        "rank": 38,
         "name": "Octopus",
         "login": "octo-patch",
         "avatarLogin": "octo-patch",
@@ -1305,13 +1297,13 @@ export const contributorRankData = {
         "avatarSeed": "octo-patch",
         "key": "github:octo-patch",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-03-26",
         "latestCommitDate": "2026-06-02",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 40,
+        "rank": 39,
         "name": "Peter Nguyen",
         "login": "petern48",
         "avatarLogin": "petern48",
@@ -1319,10 +1311,24 @@ export const contributorRankData = {
         "avatarSeed": "petern48",
         "key": "github:petern48",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-04-11",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 40,
+        "name": "Qiping Pan",
+        "login": "ppppqp",
+        "avatarLogin": "ppppqp",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/60682078?v=4",
+        "avatarSeed": "ppppqp",
+        "key": "github:ppppqp",
+        "commits": 2,
+        "share": 0.0052,
+        "firstCommitDate": "2026-03-17",
+        "latestCommitDate": "2026-03-21",
+        "isNewContributorSinceRelease": false
       },
       {
         "rank": 41,
@@ -1333,7 +1339,7 @@ export const contributorRankData = {
         "avatarSeed": "rpathade",
         "key": "github:rpathade",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-05-12",
         "latestCommitDate": "2026-05-15",
         "isNewContributorSinceRelease": true
@@ -1347,7 +1353,7 @@ export const contributorRankData = {
         "avatarSeed": "1fanwang",
         "key": "github:1fanwang",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-04-27",
         "latestCommitDate": "2026-05-04",
         "isNewContributorSinceRelease": true
@@ -1361,7 +1367,7 @@ export const contributorRankData = {
         "avatarSeed": "tristazero",
         "key": "github:tristazero",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-03-27",
         "latestCommitDate": "2026-04-09",
         "isNewContributorSinceRelease": true
@@ -1375,7 +1381,7 @@ export const contributorRankData = {
         "avatarSeed": "zhitongguo",
         "key": "github:zhitongguo",
         "commits": 2,
-        "share": 0.0051,
+        "share": 0.0052,
         "firstCommitDate": "2026-04-16",
         "latestCommitDate": "2026-04-20",
         "isNewContributorSinceRelease": true
@@ -1386,7 +1392,7 @@ export const contributorRankData = {
         "avatarSeed": "chenzw0521@gmail.com",
         "key": "email:chenzw0521@gmail.com",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-03-15",
         "latestCommitDate": "2026-03-15",
         "isNewContributorSinceRelease": true
@@ -1400,7 +1406,7 @@ export const contributorRankData = {
         "avatarSeed": "atao2004",
         "key": "github:atao2004",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-05-28",
         "latestCommitDate": "2026-05-28",
         "isNewContributorSinceRelease": true
@@ -1414,7 +1420,7 @@ export const contributorRankData = {
         "avatarSeed": "anush008",
         "key": "github:anush008",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-05-12",
         "latestCommitDate": "2026-05-12",
         "isNewContributorSinceRelease": true
@@ -1428,7 +1434,7 @@ export const contributorRankData = {
         "avatarSeed": "amytao",
         "key": "github:amytao",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-13",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": true
@@ -1442,7 +1448,7 @@ export const contributorRankData = {
         "avatarSeed": "deepak8858",
         "key": "github:deepak8858",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-15",
         "latestCommitDate": "2026-04-15",
         "isNewContributorSinceRelease": true
@@ -1456,7 +1462,7 @@ export const contributorRankData = {
         "avatarSeed": "emonlu",
         "key": "github:emonlu",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-05-28",
         "latestCommitDate": "2026-05-28",
         "isNewContributorSinceRelease": true
@@ -1470,7 +1476,7 @@ export const contributorRankData = {
         "avatarSeed": "erikjiang",
         "key": "github:erikjiang",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-05-07",
         "latestCommitDate": "2026-05-07",
         "isNewContributorSinceRelease": false
@@ -1484,7 +1490,7 @@ export const contributorRankData = {
         "avatarSeed": "fbalicchia",
         "key": "github:fbalicchia",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-03",
         "latestCommitDate": "2026-04-03",
         "isNewContributorSinceRelease": true
@@ -1498,7 +1504,7 @@ export const contributorRankData = {
         "avatarSeed": "pugafran",
         "key": "github:pugafran",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-03-12",
         "latestCommitDate": "2026-03-12",
         "isNewContributorSinceRelease": true
@@ -1512,7 +1518,7 @@ export const contributorRankData = {
         "avatarSeed": "hadar301",
         "key": "github:hadar301",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-06-01",
         "latestCommitDate": "2026-06-01",
         "isNewContributorSinceRelease": true
@@ -1526,7 +1532,7 @@ export const contributorRankData = {
         "avatarSeed": "altale",
         "key": "github:altale",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-07",
         "latestCommitDate": "2026-04-07",
         "isNewContributorSinceRelease": true
@@ -1540,7 +1546,7 @@ export const contributorRankData = {
         "avatarSeed": "immanuwell",
         "key": "github:immanuwell",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-05-21",
         "latestCommitDate": "2026-05-21",
         "isNewContributorSinceRelease": true
@@ -1554,7 +1560,7 @@ export const contributorRankData = {
         "avatarSeed": "brelance",
         "key": "github:brelance",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-05-30",
         "latestCommitDate": "2026-05-30",
         "isNewContributorSinceRelease": true
@@ -1568,7 +1574,7 @@ export const contributorRankData = {
         "avatarSeed": "kaveeshkhattar",
         "key": "github:kaveeshkhattar",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-28",
         "latestCommitDate": "2026-04-28",
         "isNewContributorSinceRelease": true
@@ -1582,7 +1588,7 @@ export const contributorRankData = {
         "avatarSeed": "kjyang-0114",
         "key": "github:kjyang-0114",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-03-19",
         "latestCommitDate": "2026-03-19",
         "isNewContributorSinceRelease": true
@@ -1596,27 +1602,13 @@ export const contributorRankData = {
         "avatarSeed": "iamagenius00",
         "key": "github:iamagenius00",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-21",
         "latestCommitDate": "2026-04-21",
         "isNewContributorSinceRelease": true
       },
       {
         "rank": 61,
-        "name": "Marc Navarro",
-        "login": "toffentoffen",
-        "avatarLogin": "toffentoffen",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/1538237?v=4",
-        "avatarSeed": "toffentoffen",
-        "key": "github:toffentoffen",
-        "commits": 1,
-        "share": 0.0025,
-        "firstCommitDate": "2026-03-06",
-        "latestCommitDate": "2026-03-06",
-        "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 62,
         "name": "mildred522",
         "login": "mildred522",
         "avatarLogin": "mildred522",
@@ -1624,13 +1616,13 @@ export const contributorRankData = {
         "avatarSeed": "mildred522",
         "key": "github:mildred522",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-03-18",
         "latestCommitDate": "2026-03-18",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 63,
+        "rank": 62,
         "name": "Mossaab Souaissa",
         "login": "Mossaab-s",
         "avatarLogin": "Mossaab-s",
@@ -1638,13 +1630,13 @@ export const contributorRankData = {
         "avatarSeed": "mossaab-s",
         "key": "github:mossaab-s",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-03-20",
         "latestCommitDate": "2026-03-20",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 64,
+        "rank": 63,
         "name": "Nilesh Agarwal",
         "login": "nickaggarwal",
         "avatarLogin": "nickaggarwal",
@@ -1652,13 +1644,13 @@ export const contributorRankData = {
         "avatarSeed": "nickaggarwal",
         "key": "github:nickaggarwal",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-19",
         "latestCommitDate": "2026-04-19",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 65,
+        "rank": 64,
         "name": "Sanjeev Rampal",
         "login": "srampal",
         "avatarLogin": "srampal",
@@ -1666,13 +1658,13 @@ export const contributorRankData = {
         "avatarSeed": "srampal",
         "key": "github:srampal",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-03-11",
         "latestCommitDate": "2026-03-11",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 66,
+        "rank": 65,
         "name": "Senan Zedan",
         "login": "szedan-rh",
         "avatarLogin": "szedan-rh",
@@ -1680,13 +1672,13 @@ export const contributorRankData = {
         "avatarSeed": "szedan-rh",
         "key": "github:szedan-rh",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-13",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 67,
+        "rank": 66,
         "name": "Shira Guskin",
         "login": "shira-g",
         "avatarLogin": "shira-g",
@@ -1694,13 +1686,13 @@ export const contributorRankData = {
         "avatarSeed": "shira-g",
         "key": "github:shira-g",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-06-04",
         "latestCommitDate": "2026-06-04",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 68,
+        "rank": 67,
         "name": "Siddharth Shah",
         "login": "siddharth1036",
         "avatarLogin": "siddharth1036",
@@ -1708,13 +1700,13 @@ export const contributorRankData = {
         "avatarSeed": "siddharth1036",
         "key": "github:siddharth1036",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-05-12",
         "latestCommitDate": "2026-05-12",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 69,
+        "rank": 68,
         "name": "Xiansen Chen",
         "login": "Cerdore",
         "avatarLogin": "Cerdore",
@@ -1722,22 +1714,36 @@ export const contributorRankData = {
         "avatarSeed": "cerdore",
         "key": "github:cerdore",
         "commits": 1,
-        "share": 0.0025,
+        "share": 0.0026,
         "firstCommitDate": "2026-04-26",
         "latestCommitDate": "2026-04-26",
         "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 69,
+        "name": "xiaoyu-xyz",
+        "login": "xiaoyu-xyz",
+        "avatarLogin": "xiaoyu-xyz",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/45517337?v=4",
+        "avatarSeed": "xiaoyu-xyz",
+        "key": "github:xiaoyu-xyz",
+        "commits": 1,
+        "share": 0.0026,
+        "firstCommitDate": "2026-06-05",
+        "latestCommitDate": "2026-06-05",
+        "isNewContributorSinceRelease": false
       }
     ]
   },
   "last365days": {
     "id": "last365days",
     "label": "Last 365 days",
-    "generatedAt": "2026-06-05",
-    "startDate": "2025-06-05",
-    "endDate": "2026-06-05",
+    "generatedAt": "2026-06-09",
+    "startDate": "2025-06-09",
+    "endDate": "2026-06-09",
     "description": "Trailing year non-merge commit activity.",
-    "totalCommits": 1318,
-    "totalContributors": 120,
+    "totalCommits": 1332,
+    "totalContributors": 121,
     "newContributors": 50,
     "entries": [
       {
@@ -1748,8 +1754,8 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/48784001?v=4",
         "avatarSeed": "xunzhuo",
         "key": "github:xunzhuo",
-        "commits": 351,
-        "share": 0.2663,
+        "commits": 352,
+        "share": 0.2643,
         "firstCommitDate": "2025-06-16",
         "latestCommitDate": "2026-06-05",
         "isNewContributorSinceRelease": false
@@ -1762,10 +1768,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/7062400?v=4",
         "avatarSeed": "rootfs",
         "key": "github:rootfs",
-        "commits": 170,
-        "share": 0.129,
+        "commits": 171,
+        "share": 0.1284,
         "firstCommitDate": "2025-06-12",
-        "latestCommitDate": "2026-05-05",
+        "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": false
       },
       {
@@ -1777,7 +1783,7 @@ export const contributorRankData = {
         "avatarSeed": "samzong",
         "key": "github:samzong",
         "commits": 58,
-        "share": 0.044,
+        "share": 0.0435,
         "firstCommitDate": "2025-09-16",
         "latestCommitDate": "2026-02-27",
         "isNewContributorSinceRelease": false
@@ -1791,7 +1797,7 @@ export const contributorRankData = {
         "avatarSeed": "yuluo-yx",
         "key": "github:yuluo-yx",
         "commits": 55,
-        "share": 0.0417,
+        "share": 0.0413,
         "firstCommitDate": "2025-09-06",
         "latestCommitDate": "2026-01-28",
         "isNewContributorSinceRelease": false
@@ -1805,7 +1811,7 @@ export const contributorRankData = {
         "avatarSeed": "yossiovadia",
         "key": "github:yossiovadia",
         "commits": 46,
-        "share": 0.0349,
+        "share": 0.0345,
         "firstCommitDate": "2025-09-26",
         "latestCommitDate": "2026-03-26",
         "isNewContributorSinceRelease": false
@@ -1818,10 +1824,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/129663775?v=4",
         "avatarSeed": "cryo-zd",
         "key": "github:cryo-zd",
-        "commits": 41,
-        "share": 0.0311,
+        "commits": 42,
+        "share": 0.0315,
         "firstCommitDate": "2025-09-01",
-        "latestCommitDate": "2026-06-01",
+        "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": false
       },
       {
@@ -1832,10 +1838,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/126341483?v=4",
         "avatarSeed": "faust-benchou",
         "key": "github:faust-benchou",
-        "commits": 33,
-        "share": 0.025,
+        "commits": 38,
+        "share": 0.0285,
         "firstCommitDate": "2026-03-26",
-        "latestCommitDate": "2026-06-05",
+        "latestCommitDate": "2026-06-08",
         "isNewContributorSinceRelease": true
       },
       {
@@ -1847,7 +1853,7 @@ export const contributorRankData = {
         "avatarSeed": "jaredforreal",
         "key": "github:jaredforreal",
         "commits": 31,
-        "share": 0.0235,
+        "share": 0.0233,
         "firstCommitDate": "2025-09-15",
         "latestCommitDate": "2025-12-16",
         "isNewContributorSinceRelease": false
@@ -1861,7 +1867,7 @@ export const contributorRankData = {
         "avatarSeed": "tao12345666333",
         "key": "github:tao12345666333",
         "commits": 28,
-        "share": 0.0212,
+        "share": 0.021,
         "firstCommitDate": "2025-09-01",
         "latestCommitDate": "2026-02-23",
         "isNewContributorSinceRelease": false
@@ -1875,7 +1881,7 @@ export const contributorRankData = {
         "avatarSeed": "yehuditkerido",
         "key": "github:yehuditkerido",
         "commits": 28,
-        "share": 0.0212,
+        "share": 0.021,
         "firstCommitDate": "2025-10-29",
         "latestCommitDate": "2026-04-14",
         "isNewContributorSinceRelease": false
@@ -1889,7 +1895,7 @@ export const contributorRankData = {
         "avatarSeed": "szedan-rh",
         "key": "github:szedan-rh",
         "commits": 27,
-        "share": 0.0205,
+        "share": 0.0203,
         "firstCommitDate": "2025-11-08",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": false
@@ -1903,7 +1909,7 @@ export const contributorRankData = {
         "avatarSeed": "liavweiss",
         "key": "github:liavweiss",
         "commits": 25,
-        "share": 0.019,
+        "share": 0.0188,
         "firstCommitDate": "2025-12-04",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": false
@@ -1917,7 +1923,7 @@ export const contributorRankData = {
         "avatarSeed": "asaadbalum",
         "key": "github:asaadbalum",
         "commits": 24,
-        "share": 0.0182,
+        "share": 0.018,
         "firstCommitDate": "2025-12-01",
         "latestCommitDate": "2026-04-17",
         "isNewContributorSinceRelease": false
@@ -1931,13 +1937,27 @@ export const contributorRankData = {
         "avatarSeed": "noalimoy",
         "key": "github:noalimoy",
         "commits": 23,
-        "share": 0.0175,
+        "share": 0.0173,
         "firstCommitDate": "2025-12-08",
         "latestCommitDate": "2026-04-19",
         "isNewContributorSinceRelease": false
       },
       {
         "rank": 15,
+        "name": "David Shrader",
+        "login": "shraderdm",
+        "avatarLogin": "shraderdm",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/16212439?v=4",
+        "avatarSeed": "shraderdm",
+        "key": "github:shraderdm",
+        "commits": 20,
+        "share": 0.015,
+        "firstCommitDate": "2026-05-05",
+        "latestCommitDate": "2026-06-06",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 16,
         "name": "abdallahsamabd",
         "login": "abdallahsamabd",
         "avatarLogin": "abdallahsamabd",
@@ -1945,24 +1965,10 @@ export const contributorRankData = {
         "avatarSeed": "abdallahsamabd",
         "key": "github:abdallahsamabd",
         "commits": 17,
-        "share": 0.0129,
+        "share": 0.0128,
         "firstCommitDate": "2025-12-11",
         "latestCommitDate": "2026-04-21",
         "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 16,
-        "name": "David Shrader",
-        "login": "shraderdm",
-        "avatarLogin": "shraderdm",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/16212439?v=4",
-        "avatarSeed": "shraderdm",
-        "key": "github:shraderdm",
-        "commits": 17,
-        "share": 0.0129,
-        "firstCommitDate": "2026-05-05",
-        "latestCommitDate": "2026-06-05",
-        "isNewContributorSinceRelease": true
       },
       {
         "rank": 17,
@@ -1973,7 +1979,7 @@ export const contributorRankData = {
         "avatarSeed": "onezero-y",
         "key": "github:onezero-y",
         "commits": 17,
-        "share": 0.0129,
+        "share": 0.0128,
         "firstCommitDate": "2025-09-02",
         "latestCommitDate": "2025-11-08",
         "isNewContributorSinceRelease": false
@@ -1987,7 +1993,7 @@ export const contributorRankData = {
         "avatarSeed": "drivebyer",
         "key": "github:drivebyer",
         "commits": 16,
-        "share": 0.0121,
+        "share": 0.012,
         "firstCommitDate": "2026-03-13",
         "latestCommitDate": "2026-05-25",
         "isNewContributorSinceRelease": true
@@ -2001,7 +2007,7 @@ export const contributorRankData = {
         "avatarSeed": "haowu1234",
         "key": "github:haowu1234",
         "commits": 13,
-        "share": 0.0099,
+        "share": 0.0098,
         "firstCommitDate": "2026-01-19",
         "latestCommitDate": "2026-04-02",
         "isNewContributorSinceRelease": false
@@ -2022,6 +2028,20 @@ export const contributorRankData = {
       },
       {
         "rank": 21,
+        "name": "WUKUNTAI",
+        "login": "WUKUNTAI-0211",
+        "avatarLogin": "WUKUNTAI-0211",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/83541875?v=4",
+        "avatarSeed": "wukuntai-0211",
+        "key": "github:wukuntai-0211",
+        "commits": 11,
+        "share": 0.0083,
+        "firstCommitDate": "2026-05-05",
+        "latestCommitDate": "2026-06-08",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 22,
         "name": "Yue Zhu",
         "login": "yuezhu1",
         "avatarLogin": "yuezhu1",
@@ -2035,7 +2055,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 22,
+        "rank": 23,
         "name": "杨朱 · Kiki",
         "login": "carlory",
         "avatarLogin": "carlory",
@@ -2049,7 +2069,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 23,
+        "rank": 24,
         "name": "Alex Wang",
         "login": "aeft",
         "avatarLogin": "aeft",
@@ -2057,13 +2077,13 @@ export const contributorRankData = {
         "avatarSeed": "aeft",
         "key": "github:aeft",
         "commits": 10,
-        "share": 0.0076,
+        "share": 0.0075,
         "firstCommitDate": "2025-09-05",
         "latestCommitDate": "2025-09-18",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 24,
+        "rank": 25,
         "name": "Ramakrishnan Sathyavageeswaran",
         "login": "ramkrishs",
         "avatarLogin": "ramkrishs",
@@ -2071,23 +2091,9 @@ export const contributorRankData = {
         "avatarSeed": "ramkrishs",
         "key": "github:ramkrishs",
         "commits": 10,
-        "share": 0.0076,
+        "share": 0.0075,
         "firstCommitDate": "2026-04-28",
         "latestCommitDate": "2026-05-05",
-        "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 25,
-        "name": "WUKUNTAI",
-        "login": "WUKUNTAI-0211",
-        "avatarLogin": "WUKUNTAI-0211",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/83541875?v=4",
-        "avatarSeed": "wukuntai-0211",
-        "key": "github:wukuntai-0211",
-        "commits": 10,
-        "share": 0.0076,
-        "firstCommitDate": "2026-05-05",
-        "latestCommitDate": "2026-06-04",
         "isNewContributorSinceRelease": true
       },
       {
@@ -2127,7 +2133,7 @@ export const contributorRankData = {
         "avatarSeed": "aayushsaini101",
         "key": "github:aayushsaini101",
         "commits": 8,
-        "share": 0.0061,
+        "share": 0.006,
         "firstCommitDate": "2026-04-17",
         "latestCommitDate": "2026-05-30",
         "isNewContributorSinceRelease": true
@@ -2141,7 +2147,7 @@ export const contributorRankData = {
         "avatarSeed": "ppppqp",
         "key": "github:ppppqp",
         "commits": 8,
-        "share": 0.0061,
+        "share": 0.006,
         "firstCommitDate": "2026-01-13",
         "latestCommitDate": "2026-03-21",
         "isNewContributorSinceRelease": false
@@ -2155,7 +2161,7 @@ export const contributorRankData = {
         "avatarSeed": "wilsonwu",
         "key": "github:wilsonwu",
         "commits": 8,
-        "share": 0.0061,
+        "share": 0.006,
         "firstCommitDate": "2025-12-09",
         "latestCommitDate": "2026-06-05",
         "isNewContributorSinceRelease": false
@@ -2211,7 +2217,7 @@ export const contributorRankData = {
         "avatarSeed": "wangchen615",
         "key": "github:wangchen615",
         "commits": 6,
-        "share": 0.0046,
+        "share": 0.0045,
         "firstCommitDate": "2025-08-16",
         "latestCommitDate": "2025-11-12",
         "isNewContributorSinceRelease": false
@@ -2225,7 +2231,7 @@ export const contributorRankData = {
         "avatarSeed": "djanghao",
         "key": "github:djanghao",
         "commits": 6,
-        "share": 0.0046,
+        "share": 0.0045,
         "firstCommitDate": "2026-02-15",
         "latestCommitDate": "2026-03-20",
         "isNewContributorSinceRelease": false
@@ -2239,7 +2245,7 @@ export const contributorRankData = {
         "avatarSeed": "cooktheryan",
         "key": "github:cooktheryan",
         "commits": 6,
-        "share": 0.0046,
+        "share": 0.0045,
         "firstCommitDate": "2025-11-05",
         "latestCommitDate": "2026-02-04",
         "isNewContributorSinceRelease": false
@@ -2253,7 +2259,7 @@ export const contributorRankData = {
         "avatarSeed": "srini-abhiram",
         "key": "github:srini-abhiram",
         "commits": 6,
-        "share": 0.0046,
+        "share": 0.0045,
         "firstCommitDate": "2025-10-07",
         "latestCommitDate": "2026-01-09",
         "isNewContributorSinceRelease": false
@@ -2288,6 +2294,20 @@ export const contributorRankData = {
       },
       {
         "rank": 40,
+        "name": "Theo Hsiung",
+        "login": "theohsiung",
+        "avatarLogin": "theohsiung",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/90186852?v=4",
+        "avatarSeed": "theohsiung",
+        "key": "github:theohsiung",
+        "commits": 5,
+        "share": 0.0038,
+        "firstCommitDate": "2026-05-29",
+        "latestCommitDate": "2026-06-05",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 41,
         "name": "Xiaotian Yu",
         "login": "xiaotian-yu",
         "avatarLogin": "xiaotian-yu",
@@ -2301,7 +2321,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 41,
+        "rank": 42,
         "name": "aias00",
         "login": "Aias00",
         "avatarLogin": "Aias00",
@@ -2315,7 +2335,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 42,
+        "rank": 43,
         "name": "elijah",
         "login": "e1ijah1",
         "avatarLogin": "e1ijah1",
@@ -2329,7 +2349,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 43,
+        "rank": 44,
         "name": "Nengxing Shen",
         "login": "uestcergs7",
         "avatarLogin": "uestcergs7",
@@ -2343,7 +2363,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 44,
+        "rank": 45,
         "name": "NJX",
         "login": "NJX-njx",
         "avatarLogin": "NJX-njx",
@@ -2357,7 +2377,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 45,
+        "rank": 46,
         "name": "Peng Lu",
         "login": "guluo2016",
         "avatarLogin": "guluo2016",
@@ -2371,7 +2391,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 46,
+        "rank": 47,
         "name": "R3hankhan",
         "login": "R3hankhan123",
         "avatarLogin": "R3hankhan123",
@@ -2383,20 +2403,6 @@ export const contributorRankData = {
         "firstCommitDate": "2026-01-14",
         "latestCommitDate": "2026-02-18",
         "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 47,
-        "name": "TheoHsiung",
-        "login": "theohsiung",
-        "avatarLogin": "theohsiung",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/90186852?v=4",
-        "avatarSeed": "theohsiung",
-        "key": "github:theohsiung",
-        "commits": 4,
-        "share": 0.003,
-        "firstCommitDate": "2026-05-29",
-        "latestCommitDate": "2026-06-03",
-        "isNewContributorSinceRelease": true
       },
       {
         "rank": 48,
@@ -3390,6 +3396,20 @@ export const contributorRankData = {
       },
       {
         "rank": 119,
+        "name": "xiaoyu-xyz",
+        "login": "xiaoyu-xyz",
+        "avatarLogin": "xiaoyu-xyz",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/45517337?v=4",
+        "avatarSeed": "xiaoyu-xyz",
+        "key": "github:xiaoyu-xyz",
+        "commits": 1,
+        "share": 0.0008,
+        "firstCommitDate": "2026-06-05",
+        "latestCommitDate": "2026-06-05",
+        "isNewContributorSinceRelease": false
+      },
+      {
+        "rank": 120,
         "name": "yafengio",
         "login": "yafengio",
         "avatarLogin": "yafengio",
@@ -3403,7 +3423,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 120,
+        "rank": 121,
         "name": "ZohaibHassan16",
         "login": "ZohaibHassan16",
         "avatarLogin": "ZohaibHassan16",
@@ -3421,12 +3441,12 @@ export const contributorRankData = {
   "all": {
     "id": "all",
     "label": "All time",
-    "generatedAt": "2026-06-05",
+    "generatedAt": "2026-06-09",
     "startDate": null,
-    "endDate": "2026-06-05",
+    "endDate": "2026-06-09",
     "description": "Full repository non-merge commit history.",
-    "totalCommits": 1358,
-    "totalContributors": 120,
+    "totalCommits": 1372,
+    "totalContributors": 121,
     "newContributors": 50,
     "entries": [
       {
@@ -3437,8 +3457,8 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/48784001?v=4",
         "avatarSeed": "xunzhuo",
         "key": "github:xunzhuo",
-        "commits": 351,
-        "share": 0.2585,
+        "commits": 352,
+        "share": 0.2566,
         "firstCommitDate": "2025-06-16",
         "latestCommitDate": "2026-06-05",
         "isNewContributorSinceRelease": false
@@ -3451,10 +3471,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/7062400?v=4",
         "avatarSeed": "rootfs",
         "key": "github:rootfs",
-        "commits": 205,
-        "share": 0.151,
+        "commits": 206,
+        "share": 0.1501,
         "firstCommitDate": "2025-04-15",
-        "latestCommitDate": "2026-05-05",
+        "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": false
       },
       {
@@ -3466,7 +3486,7 @@ export const contributorRankData = {
         "avatarSeed": "samzong",
         "key": "github:samzong",
         "commits": 58,
-        "share": 0.0427,
+        "share": 0.0423,
         "firstCommitDate": "2025-09-16",
         "latestCommitDate": "2026-02-27",
         "isNewContributorSinceRelease": false
@@ -3480,7 +3500,7 @@ export const contributorRankData = {
         "avatarSeed": "yuluo-yx",
         "key": "github:yuluo-yx",
         "commits": 55,
-        "share": 0.0405,
+        "share": 0.0401,
         "firstCommitDate": "2025-09-06",
         "latestCommitDate": "2026-01-28",
         "isNewContributorSinceRelease": false
@@ -3494,7 +3514,7 @@ export const contributorRankData = {
         "avatarSeed": "yossiovadia",
         "key": "github:yossiovadia",
         "commits": 51,
-        "share": 0.0376,
+        "share": 0.0372,
         "firstCommitDate": "2025-05-20",
         "latestCommitDate": "2026-03-26",
         "isNewContributorSinceRelease": false
@@ -3507,10 +3527,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/129663775?v=4",
         "avatarSeed": "cryo-zd",
         "key": "github:cryo-zd",
-        "commits": 41,
-        "share": 0.0302,
+        "commits": 42,
+        "share": 0.0306,
         "firstCommitDate": "2025-09-01",
-        "latestCommitDate": "2026-06-01",
+        "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": false
       },
       {
@@ -3521,10 +3541,10 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/126341483?v=4",
         "avatarSeed": "faust-benchou",
         "key": "github:faust-benchou",
-        "commits": 33,
-        "share": 0.0243,
+        "commits": 38,
+        "share": 0.0277,
         "firstCommitDate": "2026-03-26",
-        "latestCommitDate": "2026-06-05",
+        "latestCommitDate": "2026-06-08",
         "isNewContributorSinceRelease": true
       },
       {
@@ -3536,7 +3556,7 @@ export const contributorRankData = {
         "avatarSeed": "jaredforreal",
         "key": "github:jaredforreal",
         "commits": 31,
-        "share": 0.0228,
+        "share": 0.0226,
         "firstCommitDate": "2025-09-15",
         "latestCommitDate": "2025-12-16",
         "isNewContributorSinceRelease": false
@@ -3550,7 +3570,7 @@ export const contributorRankData = {
         "avatarSeed": "tao12345666333",
         "key": "github:tao12345666333",
         "commits": 28,
-        "share": 0.0206,
+        "share": 0.0204,
         "firstCommitDate": "2025-09-01",
         "latestCommitDate": "2026-02-23",
         "isNewContributorSinceRelease": false
@@ -3564,7 +3584,7 @@ export const contributorRankData = {
         "avatarSeed": "yehuditkerido",
         "key": "github:yehuditkerido",
         "commits": 28,
-        "share": 0.0206,
+        "share": 0.0204,
         "firstCommitDate": "2025-10-29",
         "latestCommitDate": "2026-04-14",
         "isNewContributorSinceRelease": false
@@ -3578,7 +3598,7 @@ export const contributorRankData = {
         "avatarSeed": "szedan-rh",
         "key": "github:szedan-rh",
         "commits": 27,
-        "share": 0.0199,
+        "share": 0.0197,
         "firstCommitDate": "2025-11-08",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": false
@@ -3592,7 +3612,7 @@ export const contributorRankData = {
         "avatarSeed": "liavweiss",
         "key": "github:liavweiss",
         "commits": 25,
-        "share": 0.0184,
+        "share": 0.0182,
         "firstCommitDate": "2025-12-04",
         "latestCommitDate": "2026-04-13",
         "isNewContributorSinceRelease": false
@@ -3606,7 +3626,7 @@ export const contributorRankData = {
         "avatarSeed": "asaadbalum",
         "key": "github:asaadbalum",
         "commits": 24,
-        "share": 0.0177,
+        "share": 0.0175,
         "firstCommitDate": "2025-12-01",
         "latestCommitDate": "2026-04-17",
         "isNewContributorSinceRelease": false
@@ -3620,13 +3640,27 @@ export const contributorRankData = {
         "avatarSeed": "noalimoy",
         "key": "github:noalimoy",
         "commits": 23,
-        "share": 0.0169,
+        "share": 0.0168,
         "firstCommitDate": "2025-12-08",
         "latestCommitDate": "2026-04-19",
         "isNewContributorSinceRelease": false
       },
       {
         "rank": 15,
+        "name": "David Shrader",
+        "login": "shraderdm",
+        "avatarLogin": "shraderdm",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/16212439?v=4",
+        "avatarSeed": "shraderdm",
+        "key": "github:shraderdm",
+        "commits": 20,
+        "share": 0.0146,
+        "firstCommitDate": "2026-05-05",
+        "latestCommitDate": "2026-06-06",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 16,
         "name": "abdallahsamabd",
         "login": "abdallahsamabd",
         "avatarLogin": "abdallahsamabd",
@@ -3634,24 +3668,10 @@ export const contributorRankData = {
         "avatarSeed": "abdallahsamabd",
         "key": "github:abdallahsamabd",
         "commits": 17,
-        "share": 0.0125,
+        "share": 0.0124,
         "firstCommitDate": "2025-12-11",
         "latestCommitDate": "2026-04-21",
         "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 16,
-        "name": "David Shrader",
-        "login": "shraderdm",
-        "avatarLogin": "shraderdm",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/16212439?v=4",
-        "avatarSeed": "shraderdm",
-        "key": "github:shraderdm",
-        "commits": 17,
-        "share": 0.0125,
-        "firstCommitDate": "2026-05-05",
-        "latestCommitDate": "2026-06-05",
-        "isNewContributorSinceRelease": true
       },
       {
         "rank": 17,
@@ -3662,7 +3682,7 @@ export const contributorRankData = {
         "avatarSeed": "onezero-y",
         "key": "github:onezero-y",
         "commits": 17,
-        "share": 0.0125,
+        "share": 0.0124,
         "firstCommitDate": "2025-09-02",
         "latestCommitDate": "2025-11-08",
         "isNewContributorSinceRelease": false
@@ -3676,7 +3696,7 @@ export const contributorRankData = {
         "avatarSeed": "drivebyer",
         "key": "github:drivebyer",
         "commits": 16,
-        "share": 0.0118,
+        "share": 0.0117,
         "firstCommitDate": "2026-03-13",
         "latestCommitDate": "2026-05-25",
         "isNewContributorSinceRelease": true
@@ -3690,7 +3710,7 @@ export const contributorRankData = {
         "avatarSeed": "haowu1234",
         "key": "github:haowu1234",
         "commits": 13,
-        "share": 0.0096,
+        "share": 0.0095,
         "firstCommitDate": "2026-01-19",
         "latestCommitDate": "2026-04-02",
         "isNewContributorSinceRelease": false
@@ -3704,13 +3724,27 @@ export const contributorRankData = {
         "avatarSeed": "henschwartz",
         "key": "github:henschwartz",
         "commits": 11,
-        "share": 0.0081,
+        "share": 0.008,
         "firstCommitDate": "2025-12-23",
         "latestCommitDate": "2026-05-01",
         "isNewContributorSinceRelease": false
       },
       {
         "rank": 21,
+        "name": "WUKUNTAI",
+        "login": "WUKUNTAI-0211",
+        "avatarLogin": "WUKUNTAI-0211",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/83541875?v=4",
+        "avatarSeed": "wukuntai-0211",
+        "key": "github:wukuntai-0211",
+        "commits": 11,
+        "share": 0.008,
+        "firstCommitDate": "2026-05-05",
+        "latestCommitDate": "2026-06-08",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 22,
         "name": "Yue Zhu",
         "login": "yuezhu1",
         "avatarLogin": "yuezhu1",
@@ -3718,13 +3752,13 @@ export const contributorRankData = {
         "avatarSeed": "yuezhu1",
         "key": "github:yuezhu1",
         "commits": 11,
-        "share": 0.0081,
+        "share": 0.008,
         "firstCommitDate": "2025-08-29",
         "latestCommitDate": "2025-12-10",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 22,
+        "rank": 23,
         "name": "杨朱 · Kiki",
         "login": "carlory",
         "avatarLogin": "carlory",
@@ -3732,13 +3766,13 @@ export const contributorRankData = {
         "avatarSeed": "carlory",
         "key": "github:carlory",
         "commits": 11,
-        "share": 0.0081,
+        "share": 0.008,
         "firstCommitDate": "2025-10-17",
         "latestCommitDate": "2026-01-13",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 23,
+        "rank": 24,
         "name": "Alex Wang",
         "login": "aeft",
         "avatarLogin": "aeft",
@@ -3746,13 +3780,13 @@ export const contributorRankData = {
         "avatarSeed": "aeft",
         "key": "github:aeft",
         "commits": 10,
-        "share": 0.0074,
+        "share": 0.0073,
         "firstCommitDate": "2025-09-05",
         "latestCommitDate": "2025-09-18",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 24,
+        "rank": 25,
         "name": "Ramakrishnan Sathyavageeswaran",
         "login": "ramkrishs",
         "avatarLogin": "ramkrishs",
@@ -3760,23 +3794,9 @@ export const contributorRankData = {
         "avatarSeed": "ramkrishs",
         "key": "github:ramkrishs",
         "commits": 10,
-        "share": 0.0074,
+        "share": 0.0073,
         "firstCommitDate": "2026-04-28",
         "latestCommitDate": "2026-05-05",
-        "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 25,
-        "name": "WUKUNTAI",
-        "login": "WUKUNTAI-0211",
-        "avatarLogin": "WUKUNTAI-0211",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/83541875?v=4",
-        "avatarSeed": "wukuntai-0211",
-        "key": "github:wukuntai-0211",
-        "commits": 10,
-        "share": 0.0074,
-        "firstCommitDate": "2026-05-05",
-        "latestCommitDate": "2026-06-04",
         "isNewContributorSinceRelease": true
       },
       {
@@ -3816,7 +3836,7 @@ export const contributorRankData = {
         "avatarSeed": "aayushsaini101",
         "key": "github:aayushsaini101",
         "commits": 8,
-        "share": 0.0059,
+        "share": 0.0058,
         "firstCommitDate": "2026-04-17",
         "latestCommitDate": "2026-05-30",
         "isNewContributorSinceRelease": true
@@ -3830,7 +3850,7 @@ export const contributorRankData = {
         "avatarSeed": "ppppqp",
         "key": "github:ppppqp",
         "commits": 8,
-        "share": 0.0059,
+        "share": 0.0058,
         "firstCommitDate": "2026-01-13",
         "latestCommitDate": "2026-03-21",
         "isNewContributorSinceRelease": false
@@ -3844,7 +3864,7 @@ export const contributorRankData = {
         "avatarSeed": "wilsonwu",
         "key": "github:wilsonwu",
         "commits": 8,
-        "share": 0.0059,
+        "share": 0.0058,
         "firstCommitDate": "2025-12-09",
         "latestCommitDate": "2026-06-05",
         "isNewContributorSinceRelease": false
@@ -3858,7 +3878,7 @@ export const contributorRankData = {
         "avatarSeed": "mkoushni",
         "key": "github:mkoushni",
         "commits": 7,
-        "share": 0.0052,
+        "share": 0.0051,
         "firstCommitDate": "2026-02-04",
         "latestCommitDate": "2026-04-16",
         "isNewContributorSinceRelease": false
@@ -3872,7 +3892,7 @@ export const contributorRankData = {
         "avatarSeed": "siloteemu",
         "key": "github:siloteemu",
         "commits": 7,
-        "share": 0.0052,
+        "share": 0.0051,
         "firstCommitDate": "2026-05-27",
         "latestCommitDate": "2026-06-03",
         "isNewContributorSinceRelease": true
@@ -3886,7 +3906,7 @@ export const contributorRankData = {
         "avatarSeed": "liuqihao",
         "key": "github:brucelovedecimal",
         "commits": 7,
-        "share": 0.0052,
+        "share": 0.0051,
         "firstCommitDate": "2026-04-15",
         "latestCommitDate": "2026-04-29",
         "isNewContributorSinceRelease": true
@@ -3956,7 +3976,7 @@ export const contributorRankData = {
         "avatarSeed": "daric93",
         "key": "github:daric93",
         "commits": 5,
-        "share": 0.0037,
+        "share": 0.0036,
         "firstCommitDate": "2026-03-24",
         "latestCommitDate": "2026-04-16",
         "isNewContributorSinceRelease": true
@@ -3970,13 +3990,27 @@ export const contributorRankData = {
         "avatarSeed": "windsonsea",
         "key": "github:windsonsea",
         "commits": 5,
-        "share": 0.0037,
+        "share": 0.0036,
         "firstCommitDate": "2025-09-29",
         "latestCommitDate": "2026-02-05",
         "isNewContributorSinceRelease": false
       },
       {
         "rank": 40,
+        "name": "Theo Hsiung",
+        "login": "theohsiung",
+        "avatarLogin": "theohsiung",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/90186852?v=4",
+        "avatarSeed": "theohsiung",
+        "key": "github:theohsiung",
+        "commits": 5,
+        "share": 0.0036,
+        "firstCommitDate": "2026-05-29",
+        "latestCommitDate": "2026-06-05",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 41,
         "name": "Xiaotian Yu",
         "login": "xiaotian-yu",
         "avatarLogin": "xiaotian-yu",
@@ -3984,13 +4018,13 @@ export const contributorRankData = {
         "avatarSeed": "xiaotian-yu",
         "key": "github:xiaotian-yu",
         "commits": 5,
-        "share": 0.0037,
+        "share": 0.0036,
         "firstCommitDate": "2026-05-05",
         "latestCommitDate": "2026-05-28",
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 41,
+        "rank": 42,
         "name": "aias00",
         "login": "Aias00",
         "avatarLogin": "Aias00",
@@ -4004,7 +4038,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 42,
+        "rank": 43,
         "name": "elijah",
         "login": "e1ijah1",
         "avatarLogin": "e1ijah1",
@@ -4018,7 +4052,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 43,
+        "rank": 44,
         "name": "Nengxing Shen",
         "login": "uestcergs7",
         "avatarLogin": "uestcergs7",
@@ -4032,7 +4066,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 44,
+        "rank": 45,
         "name": "NJX",
         "login": "NJX-njx",
         "avatarLogin": "NJX-njx",
@@ -4046,7 +4080,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 45,
+        "rank": 46,
         "name": "Peng Lu",
         "login": "guluo2016",
         "avatarLogin": "guluo2016",
@@ -4060,7 +4094,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 46,
+        "rank": 47,
         "name": "R3hankhan",
         "login": "R3hankhan123",
         "avatarLogin": "R3hankhan123",
@@ -4072,20 +4106,6 @@ export const contributorRankData = {
         "firstCommitDate": "2026-01-14",
         "latestCommitDate": "2026-02-18",
         "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 47,
-        "name": "TheoHsiung",
-        "login": "theohsiung",
-        "avatarLogin": "theohsiung",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/90186852?v=4",
-        "avatarSeed": "theohsiung",
-        "key": "github:theohsiung",
-        "commits": 4,
-        "share": 0.0029,
-        "firstCommitDate": "2026-05-29",
-        "latestCommitDate": "2026-06-03",
-        "isNewContributorSinceRelease": true
       },
       {
         "rank": 48,
@@ -5079,6 +5099,20 @@ export const contributorRankData = {
       },
       {
         "rank": 119,
+        "name": "xiaoyu-xyz",
+        "login": "xiaoyu-xyz",
+        "avatarLogin": "xiaoyu-xyz",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/45517337?v=4",
+        "avatarSeed": "xiaoyu-xyz",
+        "key": "github:xiaoyu-xyz",
+        "commits": 1,
+        "share": 0.0007,
+        "firstCommitDate": "2026-06-05",
+        "latestCommitDate": "2026-06-05",
+        "isNewContributorSinceRelease": false
+      },
+      {
+        "rank": 120,
         "name": "yafengio",
         "login": "yafengio",
         "avatarLogin": "yafengio",
@@ -5092,7 +5126,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 120,
+        "rank": 121,
         "name": "ZohaibHassan16",
         "login": "ZohaibHassan16",
         "avatarLogin": "ZohaibHassan16",

--- a/website/src/pages/community/team.module.css
+++ b/website/src/pages/community/team.module.css
@@ -13,10 +13,10 @@
 
 .header h1 {
   margin: 0;
-  font-size: clamp(2.8rem, 8vw, 5rem);
+  font-size: 4.2rem;
   line-height: 0.92;
   font-weight: 400;
-  letter-spacing: -0.05em;
+  letter-spacing: 0;
 }
 
 .subtitle,
@@ -39,7 +39,7 @@
 
 .section h2 {
   margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.7rem);
+  font-size: 2.4rem;
   line-height: 1;
 }
 
@@ -49,8 +49,13 @@
   gap: 1rem;
 }
 
+.steeringGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
 .memberCard,
-.recognitionCard,
 .involvementCard {
   padding: 1.3rem;
   border: 1px solid var(--site-border);
@@ -60,6 +65,7 @@
 .memberCard {
   display: grid;
   gap: 1rem;
+  align-content: start;
 }
 
 .memberHeader {
@@ -104,7 +110,11 @@
   letter-spacing: 0.08em;
 }
 
-.maintainer,
+.steering {
+  border-color: var(--site-text);
+  color: var(--site-text);
+}
+
 .committer,
 .contributor {
   border-color: var(--site-border-strong);
@@ -122,6 +132,24 @@
 
 .memberBio {
   margin: 0;
+}
+
+.expertiseList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: -0.2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.expertiseList li {
+  max-width: 100%;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--site-border);
+  color: var(--site-muted-bright);
+  font-size: 0.74rem;
+  line-height: 1.25;
 }
 
 .company {
@@ -168,45 +196,6 @@
   text-decoration: none;
 }
 
-.recognitionCard {
-  display: grid;
-  gap: 1rem;
-}
-
-.pathToMaintainer {
-  display: grid;
-  gap: 1rem;
-}
-
-.steps {
-  display: grid;
-  gap: 0.9rem;
-}
-
-.step {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.9rem;
-  padding: 1rem 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.step:first-child {
-  border-top: 0;
-  padding-top: 0;
-}
-
-.stepNumber {
-  display: grid;
-  place-items: center;
-  width: 2rem;
-  height: 2rem;
-  border: 1px solid var(--site-border-strong);
-  border-radius: 999px;
-  color: var(--site-text);
-  font-size: 0.78rem;
-}
-
 .involvementGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -220,6 +209,7 @@
 }
 
 @media (max-width: 996px) {
+  .steeringGrid,
   .teamGrid,
   .involvementGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -232,13 +222,21 @@
     padding-top: 1.5rem;
   }
 
+  .header h1 {
+    font-size: 2.7rem;
+  }
+
+  .section h2 {
+    font-size: 1.8rem;
+  }
+
+  .steeringGrid,
   .teamGrid,
   .involvementGrid {
     grid-template-columns: 1fr;
   }
 
   .memberCard,
-  .recognitionCard,
   .involvementCard {
     padding: 1.1rem;
   }

--- a/website/src/pages/community/team.tsx
+++ b/website/src/pages/community/team.tsx
@@ -3,7 +3,13 @@ import Layout from '@theme/Layout'
 import Translate from '@docusaurus/Translate'
 import Link from '@docusaurus/Link'
 import styles from './team.module.css'
-import { FaGithub, FaLinkedin } from 'react-icons/fa'
+import { FaExternalLinkAlt, FaGithub, FaLinkedin } from 'react-icons/fa'
+import { newContributorsSinceRelease } from '../../data/contributorRank.generated'
+
+interface MemberLink {
+  label: string
+  href: string
+}
 
 interface TeamMember {
   name: string
@@ -12,35 +18,185 @@ interface TeamMember {
   avatar: string
   github?: string
   linkedin?: string
+  externalLinks?: MemberLink[]
   bio: React.ReactNode
-  memberType: 'maintainer' | 'committer' | 'committer'
+  expertise?: React.ReactNode[]
+  memberType: 'steering' | 'committer'
 }
 
 interface TeamMemberProps {
   member: TeamMember
 }
 
-const allTeamMembers: TeamMember[] = [
+type NewContributorProfile = Pick<TeamMember, 'role' | 'bio'> & Pick<TeamMember, 'company' | 'externalLinks' | 'expertise' | 'linkedin'>
+
+const steeringCommitteeMembers: TeamMember[] = [
+  {
+    name: 'Xunzhuo Liu',
+    role: <Translate id="team.members.XunzhuoLiu.role">LLM Routing @ vLLM</Translate>,
+    avatar: '/img/team/xunzhuo.png',
+    github: 'https://github.com/Xunzhuo',
+    linkedin: 'http://linkedin.com/in/bitliu',
+    externalLinks: [
+      { label: 'Website', href: 'https://www.liuxunzhuo.com/' },
+    ],
+    bio: <Translate id="team.members.XunzhuoLiu.bio">LLM routing builder at vLLM.</Translate>,
+    expertise: [
+      <Translate id="team.members.XunzhuoLiu.expertise.routing">LLM routing</Translate>,
+      <Translate id="team.members.XunzhuoLiu.expertise.gateway">Kubernetes AI Gateway</Translate>,
+      <Translate id="team.members.XunzhuoLiu.expertise.opensource">Open-source infrastructure</Translate>,
+    ],
+    memberType: 'steering',
+  },
+  {
+    name: 'Bowei He',
+    role: <Translate id="team.members.BoweiHe.role">Postdoc @ MBZUAI / McGill</Translate>,
+    avatar: 'https://agentic-in.ai/people/bowei-he.jpeg',
+    linkedin: 'https://www.linkedin.com/in/bowei-he-8a9450199/',
+    externalLinks: [
+      { label: 'Google Scholar', href: 'https://scholar.google.com/citations?user=1cH0A9cAAAAJ&hl=zh-CN' },
+    ],
+    bio: <Translate id="team.members.BoweiHe.bio">PhD from CityUHK and former Hunyuan LLM under the Qingyun Talent program.</Translate>,
+    expertise: [
+      <Translate id="team.members.BoweiHe.expertise.research">Academic research</Translate>,
+      <Translate id="team.members.BoweiHe.expertise.llm">LLM systems</Translate>,
+      <Translate id="team.members.BoweiHe.expertise.hunyuan">Tencent Hunyuan LLM</Translate>,
+    ],
+    memberType: 'steering',
+  },
+  {
+    name: 'Yankai Chen',
+    role: <Translate id="team.members.YankaiChen.role">Postdoctoral Associate @ McGill University / MBZUAI</Translate>,
+    avatar: 'https://agentic-in.ai/people/yankai-chen.jpg',
+    linkedin: 'https://www.linkedin.com/in/yankai-chen-923001154/',
+    externalLinks: [
+      { label: 'Website', href: 'https://yankai-chen.github.io/' },
+      { label: 'Google Scholar', href: 'https://scholar.google.com/citations?user=5ZOi7UAAAAAJ&hl=zh-CN' },
+    ],
+    bio: <Translate id="team.members.YankaiChen.bio">Research spanning agentic AI, human-centered AI, and knowledge mining.</Translate>,
+    expertise: [
+      <Translate id="team.members.YankaiChen.expertise.agentic">Agentic AI</Translate>,
+      <Translate id="team.members.YankaiChen.expertise.hcai">Human-centered AI</Translate>,
+      <Translate id="team.members.YankaiChen.expertise.mining">Knowledge mining</Translate>,
+    ],
+    memberType: 'steering',
+  },
+  {
+    name: 'Fuyuan Lyu',
+    role: <Translate id="team.members.FuyuanLyu.role">PhD Candidate @ McGill University / Mila</Translate>,
+    avatar: 'https://agentic-in.ai/people/fuyuan-lv.jpeg',
+    linkedin: 'https://www.linkedin.com/in/fuyuan-lyu-560756167/',
+    externalLinks: [
+      { label: 'Website', href: 'https://fuyuanlyu.github.io/' },
+      { label: 'Google Scholar', href: 'https://scholar.google.com/citations?user=dOjmAVQAAAAJ&hl=en' },
+    ],
+    bio: <Translate id="team.members.FuyuanLyu.bio">Research in data-centric AI, automatic feature selection, and automatic labeling for deep learning and foundation models.</Translate>,
+    expertise: [
+      <Translate id="team.members.FuyuanLyu.expertise.data">Data-centric AI</Translate>,
+      <Translate id="team.members.FuyuanLyu.expertise.features">Automatic feature selection</Translate>,
+      <Translate id="team.members.FuyuanLyu.expertise.labeling">Automatic labeling</Translate>,
+    ],
+    memberType: 'steering',
+  },
   {
     name: 'Huamin Chen',
-    role: <Translate id="team.members.HuaminChen.role">Distinguished Engineer</Translate>,
-    company: 'Red Hat',
+    role: <Translate id="team.members.HuaminChen.role">@Microsoft</Translate>,
     avatar: '/img/team/huamin.png',
     github: 'https://github.com/rootfs',
     linkedin: 'https://www.linkedin.com/in/huaminchen',
-    bio: <Translate id="team.members.HuaminChen.bio">Distinguished Engineer at Red Hat, driving innovation in cloud-native and AI/LLM Inference technologies.</Translate>,
-    memberType: 'maintainer',
+    externalLinks: [
+      { label: 'Hugging Face', href: 'https://huggingface.co/HuaminChen' },
+    ],
+    bio: <Translate id="team.members.HuaminChen.bio">Long-term incubator of frontier infrastructure and AI systems across cloud-native platforms, open-source ecosystems, and model-serving stacks.</Translate>,
+    expertise: [
+      <Translate id="team.members.HuaminChen.expertise.cloud">Cloud-native platforms</Translate>,
+      <Translate id="team.members.HuaminChen.expertise.serving">Model-serving stacks</Translate>,
+      <Translate id="team.members.HuaminChen.expertise.ecosystem">Open-source ecosystems</Translate>,
+    ],
+    memberType: 'steering',
   },
   {
-    name: 'Xunzhuo Liu',
-    role: <Translate id="team.members.XunzhuoLiu.role">Intelligent Routing</Translate>,
-    company: 'vLLM',
-    avatar: '/img/team/xunzhuo.png',
-    github: 'https://github.com/Xunzhuo',
-    linkedin: 'https://www.linkedin.com/in/bitliu/',
-    bio: <Translate id="team.members.XunzhuoLiu.bio">Focus on bringing collective intelligence to the LLM systems.</Translate>,
-    memberType: 'maintainer',
+    name: 'Steve Liu',
+    role: <Translate id="team.members.SteveLiu.role">@MBZUAI / McGill / Mila</Translate>,
+    avatar: 'https://agentic-in.ai/people/steve-liu.jpeg',
+    linkedin: 'https://ca.linkedin.com/in/xueliu',
+    externalLinks: [
+      { label: 'MBZUAI', href: 'https://mbzuai.ac.ae/study/faculty/steve-liu/' },
+      { label: 'Google Scholar', href: 'https://scholar.google.com/citations?user=rfLIRakAAAAJ&hl=en' },
+    ],
+    bio: <Translate id="team.members.SteveLiu.bio">Fellow CAE & IEEE; Associate VPR @ MBZUAI; Prof @ McGill; Mila; ex-VP R&D @ Samsung AI; Chair ACM SIGBED.</Translate>,
+    expertise: [
+      <Translate id="team.members.SteveLiu.expertise.aiml">AI and machine learning</Translate>,
+      <Translate id="team.members.SteveLiu.expertise.systems">Intelligent systems</Translate>,
+      <Translate id="team.members.SteveLiu.expertise.cps">Cyber-physical systems</Translate>,
+    ],
+    memberType: 'steering',
   },
+]
+
+const topNewContributorProfiles: Record<string, NewContributorProfile> = {
+  'FAUST-BENCHOU': {
+    role: <Translate id="team.members.FAUST-BENCHOU.role">Cloud-native Open Source Contributor</Translate>,
+    company: 'Tongji University',
+    bio: <Translate id="team.members.FAUST-BENCHOU.bio">Cloud-native open source contributor across Karmada and Volcano.</Translate>,
+  },
+  'shraderdm': {
+    role: <Translate id="team.members.shraderdm.role">GTM Tech Lead</Translate>,
+    company: 'Google',
+    linkedin: 'https://www.linkedin.com/in/shraderdm/',
+    externalLinks: [
+      { label: 'Website', href: 'https://shrader.dev' },
+    ],
+    bio: <Translate id="team.members.shraderdm.bio">GTM Tech Lead at Google.</Translate>,
+  },
+  'drivebyer': {
+    role: <Translate id="team.members.drivebyer.role">Cloud-native Engineer</Translate>,
+    company: 'DaoCloud',
+    bio: <Translate id="team.members.drivebyer.bio">DaoCloud engineer and open-source contributor focused on practical infrastructure improvements.</Translate>,
+  },
+  'ramkrishs': {
+    role: <Translate id="team.members.ramkrishs.role">Computer Science Engineer</Translate>,
+    company: 'Intuit',
+    externalLinks: [
+      { label: 'Website', href: 'http://ramakrishnan.me' },
+    ],
+    bio: <Translate id="team.members.ramkrishs.bio">Computer science engineer at Intuit focused on software systems.</Translate>,
+  },
+  'WUKUNTAI-0211': {
+    role: <Translate id="team.members.WUKUNTAI-0211.role">Software Engineer</Translate>,
+    company: 'DELTA ELECTRONICS, INC.',
+    bio: <Translate id="team.members.WUKUNTAI-0211.bio">Software engineer at Delta Electronics in Taiwan.</Translate>,
+  },
+  'AayushSaini101': {
+    role: <Translate id="team.members.AayushSaini101.role">SDE, Data and AI</Translate>,
+    company: 'Red Hat',
+    bio: <Translate id="team.members.AayushSaini101.bio">SDE in Red Hat Data and AI, GSoC 2025 participant, and AsyncAPI Steering Committee member.</Translate>,
+  },
+  'siloteemu': {
+    role: <Translate id="team.members.siloteemu.role">Open Source Contributor</Translate>,
+    bio: <Translate id="team.members.siloteemu.bio">Open-source contributor on GitHub.</Translate>,
+  },
+}
+
+const topNewContributorMembers: TeamMember[] = newContributorsSinceRelease.entries.slice(0, 7).map((entry) => {
+  const profile = entry.login ? topNewContributorProfiles[entry.login] : undefined
+
+  return {
+    name: entry.name,
+    role: profile?.role ?? <Translate id="team.members.topNewContributor.role">Release Window Committer</Translate>,
+    company: profile?.company,
+    avatar: entry.avatarUrl ?? (entry.avatarLogin ? `https://github.com/${entry.avatarLogin}.png` : '/img/team/huamin.png'),
+    github: entry.login ? `https://github.com/${entry.login}` : undefined,
+    linkedin: profile?.linkedin,
+    externalLinks: profile?.externalLinks,
+    bio: profile?.bio ?? <Translate id="team.members.topNewContributor.bio">New committer recognized from recent contributor rankings.</Translate>,
+    expertise: profile?.expertise,
+    memberType: 'committer',
+  }
+})
+
+const committerMembers: TeamMember[] = [
+  ...topNewContributorMembers,
   {
     name: 'Chen Wang',
     role: <Translate id="team.members.ChenWang.role">Senior Staff Research Scientist</Translate>,
@@ -49,7 +205,7 @@ const allTeamMembers: TeamMember[] = [
     github: 'https://github.com/wangchen615',
     linkedin: 'https://www.linkedin.com/in/chenw615/',
     bio: <Translate id="team.members.ChenWang.bio">Senior Staff Research Scientist at IBM, focusing on advanced AI systems and research.</Translate>,
-    memberType: 'maintainer',
+    memberType: 'committer',
   },
   {
     name: 'Yue Zhu',
@@ -59,7 +215,7 @@ const allTeamMembers: TeamMember[] = [
     github: 'https://github.com/yuezhu1',
     linkedin: 'https://www.linkedin.com/in/yue-zhu-b26526a3/',
     bio: <Translate id="team.members.YueZhu.bio">Staff Research Scientist at IBM, specializing in AI research and LLM Inference.</Translate>,
-    memberType: 'maintainer',
+    memberType: 'committer',
   },
   {
     name: 'Senan Zedan',
@@ -262,11 +418,9 @@ const TeamMemberCard: React.FC<TeamMemberProps> = ({ member }) => {
           <div className={styles.nameWithBadge}>
             <h3 className={styles.memberName}>{member.name}</h3>
             <span className={`${styles.badge} ${styles[member.memberType]}`}>
-              {member.memberType === 'maintainer'
-                ? <Translate id="team.badge.maintainer">Maintainer</Translate>
-                : member.memberType === 'committer'
-                  ? <Translate id="team.badge.committer">Committer</Translate>
-                  : <Translate id="team.badge.contributor">Contributor</Translate>}
+              {member.memberType === 'steering'
+                ? <Translate id="team.badge.steering">Steering Committee</Translate>
+                : <Translate id="team.badge.committer">Committer</Translate>}
             </span>
           </div>
           <p className={styles.memberRole}>
@@ -282,6 +436,14 @@ const TeamMemberCard: React.FC<TeamMemberProps> = ({ member }) => {
       </div>
 
       <p className={styles.memberBio}>{member.bio}</p>
+
+      {member.expertise && (
+        <ul className={styles.expertiseList}>
+          {member.expertise.map((expertise, index) => (
+            <li key={index}>{expertise}</li>
+          ))}
+        </ul>
+      )}
 
       <div className={styles.memberActions}>
         {member.github && member.github !== '#' && (
@@ -307,6 +469,19 @@ const TeamMemberCard: React.FC<TeamMemberProps> = ({ member }) => {
             LinkedIn
           </a>
         )}
+
+        {member.externalLinks?.map(link => (
+          <a
+            key={link.href}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.actionLink}
+          >
+            <FaExternalLinkAlt />
+            {link.label}
+          </a>
+        ))}
       </div>
     </div>
   )
@@ -329,15 +504,15 @@ const Team: React.FC = () => {
         <main className={styles.main}>
           <section className={styles.section}>
             <h2>
-              <Translate id="team.coreTeam.title">Our Team</Translate>
+              <Translate id="team.steering.title">Steering Committee</Translate>
             </h2>
             <p className={styles.sectionDescription}>
-              <Translate id="team.coreTeam.description">
-                Meet the talented people who make vLLM Semantic Router possible.
+              <Translate id="team.steering.description">
+                The steering committee guides roadmap direction, project scope, and cross-community alignment for vLLM Semantic Router.
               </Translate>
             </p>
-            <div className={styles.teamGrid}>
-              {allTeamMembers.map((member, index) => (
+            <div className={styles.steeringGrid}>
+              {steeringCommitteeMembers.map((member, index) => (
                 <TeamMemberCard key={index} member={member} />
               ))}
             </div>
@@ -345,58 +520,17 @@ const Team: React.FC = () => {
 
           <section className={styles.section}>
             <h2>
-              <Translate id="team.recognition.title">Recognition</Translate>
+              <Translate id="team.committers.title">Committers</Translate>
             </h2>
-            <div className={styles.recognitionCard}>
-              <h3><Translate id="team.recognition.subtitle">Contributor Recognition</Translate></h3>
-              <p>
-                <Translate id="team.recognition.description">
-                  We believe in recognizing the valuable contributions of our community members.
-                  Contributors who show consistent dedication and quality work in specific areas
-                  may be invited to become maintainers with write access to the repository.
-                </Translate>
-              </p>
-
-              <div className={styles.pathToMaintainer}>
-                <h4><Translate id="team.recognition.pathTitle">Path to Maintainership:</Translate></h4>
-                <div className={styles.steps}>
-                  <div className={styles.step}>
-                    <span className={styles.stepNumber}>1</span>
-                    <div>
-                      <h5><Translate id="team.recognition.step1.title">Contribute Regularly</Translate></h5>
-                      <p><Translate id="team.recognition.step1.desc">Make consistent, quality contributions to your area of interest</Translate></p>
-                    </div>
-                  </div>
-
-                  <div className={styles.step}>
-                    <span className={styles.stepNumber}>2</span>
-                    <div>
-                      <h5><Translate id="team.recognition.step2.title">Join a Working Group</Translate></h5>
-                      <p>
-                        <Translate id="team.recognition.step2.desc">Participate actively in one of our</Translate>
-                        {' '}
-                        <Link to="/community/work-groups"><Translate id="team.recognition.step2.link">Working Groups</Translate></Link>
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className={styles.step}>
-                    <span className={styles.stepNumber}>3</span>
-                    <div>
-                      <h5><Translate id="team.recognition.step3.title">Community Vote</Translate></h5>
-                      <p><Translate id="team.recognition.step3.desc">Receive nomination and approval from the maintainer team</Translate></p>
-                    </div>
-                  </div>
-
-                  <div className={styles.step}>
-                    <span className={styles.stepNumber}>4</span>
-                    <div>
-                      <h5><Translate id="team.recognition.step4.title">Maintainer Access</Translate></h5>
-                      <p><Translate id="team.recognition.step4.desc">Get invited to the maintainer group with write access</Translate></p>
-                    </div>
-                  </div>
-                </div>
-              </div>
+            <p className={styles.sectionDescription}>
+              <Translate id="team.committers.description">
+                Committers own implementation areas, review changes, answer community questions, and keep the project healthy across releases.
+              </Translate>
+            </p>
+            <div className={styles.teamGrid}>
+              {committerMembers.map((member, index) => (
+                <TeamMemberCard key={index} member={member} />
+              ))}
             </div>
           </section>
 


### PR DESCRIPTION
## Summary

- Refactors the community team page into Steering Committee and Committers sections.
- Adds Agentic-IN leadership profiles for the steering group and updates requested titles/bios.
- Regenerates contributor rank data so `newContributorsSinceRelease` uses the `v0.2.0 -> v0.3.0` release window instead of starting from `v0.3.0`.
- Promotes the top 7 new contributors from that window into the Committers section with public GitHub/profile context.
- Removes the Recognition section from the team page.

## New Committers

Congrats to the new committers:

- @FAUST-BENCHOU — Cloud-native open source contributor, Tongji University.
- @shraderdm — GTM Tech Lead @ Google.
- @drivebyer — Cloud-native engineer @ DaoCloud.
- @ramkrishs — Computer science engineer @ Intuit.
- @WUKUNTAI-0211 — Software engineer @ DELTA ELECTRONICS, INC.
- @AayushSaini101 — SDE, Data and AI @ Red Hat; GSoC 2025; AsyncAPI Steering Committee member.
- @siloteemu — Open-source contributor on GitHub.

## Validation

- `make docs-contributors-rank`
- `make agent-report ENV=cpu CHANGED_FILES="website/src/pages/community/team.tsx website/src/pages/community/team.module.css website/i18n/zh-Hans/code.json website/scripts/generate-contributor-rank.mjs website/src/data/contributorRank.generated.ts"`
- `node --check website/scripts/generate-contributor-rank.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('website/i18n/zh-Hans/code.json','utf8')); console.log('json ok')"`
- `./node_modules/.bin/docusaurus build --locale en`
- commit hook: `js/ts lint`, supply chain scan, and agent changed-files lint