### PR TITLE
[DSL] Preserve compile/decompile fields across Keyword, Context, RAG, and Authz

### DIFF
--- a/src/semantic-router/pkg/dsl/compiler_plugins.go
+++ b/src/semantic-router/pkg/dsl/compiler_plugins.go
@@ -49,6 +49,15 @@ func (c *Compiler) compileRAGPlugin(fields map[string]Value) config.RAGPluginCon
 	if v, ok := getStringField(fields, "on_failure"); ok {
 		cfg.OnFailure = v
 	}
+	if v, ok := getBoolField(fields, "cache_results"); ok {
+		cfg.CacheResults = v
+	}
+	if v, ok := getIntField(fields, "cache_ttl_seconds"); ok {
+		cfg.CacheTTLSeconds = &v
+	}
+	if v, ok := getFloat32Field(fields, "min_confidence_threshold"); ok {
+		cfg.MinConfidenceThreshold = &v
+	}
 	cfg.BackendConfig = c.compileRAGBackendConfig(fields)
 	return cfg
 }

--- a/src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go
+++ b/src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go
@@ -38,6 +38,42 @@ ROUTE rag_route (description = "RAG route") {
 	}
 }
 
+func TestCompileRAGPluginReadsCacheAndConfidenceFields(t *testing.T) {
+	input := `
+SIGNAL domain test { description: "test" }
+ROUTE rag_route (description = "RAG route") {
+  PRIORITY 100
+  WHEN domain("test")
+  MODEL "m:1b"
+  PLUGIN rag {
+    enabled: true
+    backend: "milvus"
+    cache_results: true
+    cache_ttl_seconds: 60
+    min_confidence_threshold: 0.4
+  }
+}
+`
+	cfg := mustCompile(t, input)
+	ragCfg := mustExtractRAGPluginConfig(t, cfg)
+
+	if !ragCfg.CacheResults {
+		t.Fatal("expected CacheResults to be true")
+	}
+	if ragCfg.CacheTTLSeconds == nil {
+		t.Fatal("expected CacheTTLSeconds to be set, got nil")
+	}
+	if *ragCfg.CacheTTLSeconds != 60 {
+		t.Errorf("CacheTTLSeconds: want 60, got %d", *ragCfg.CacheTTLSeconds)
+	}
+	if ragCfg.MinConfidenceThreshold == nil {
+		t.Fatal("expected MinConfidenceThreshold to be set, got nil")
+	}
+	if *ragCfg.MinConfidenceThreshold != 0.4 {
+		t.Errorf("MinConfidenceThreshold: want 0.4, got %v", *ragCfg.MinConfidenceThreshold)
+	}
+}
+
 // TestCompileRAGPluginOmitsMaxContextLengthWhenAbsent documents the
 // omit-default contract: when the DSL author does not specify
 // max_context_length, the compiled runtime config carries a nil pointer

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -35,6 +35,21 @@ func (d *decompiler) keywordToSignal(kw *config.KeywordRule) *SignalDecl {
 	if kw.Method != "" {
 		fields["method"] = StringValue{V: kw.Method}
 	}
+	if kw.FuzzyMatch {
+		fields["fuzzy_match"] = BoolValue{V: true}
+	}
+	if kw.FuzzyThreshold != 0 {
+		fields["fuzzy_threshold"] = IntValue{V: kw.FuzzyThreshold}
+	}
+	if kw.BM25Threshold != 0 {
+		fields["bm25_threshold"] = FloatValue{V: float64(kw.BM25Threshold)}
+	}
+	if kw.NgramThreshold != 0 {
+		fields["ngram_threshold"] = FloatValue{V: float64(kw.NgramThreshold)}
+	}
+	if kw.NgramArity != 0 {
+		fields["ngram_arity"] = IntValue{V: kw.NgramArity}
+	}
 	return &SignalDecl{SignalType: "keyword", Name: kw.Name, Fields: fields}
 }
 
@@ -117,6 +132,9 @@ func (d *decompiler) contextToSignal(ctx *config.ContextRule) *SignalDecl {
 	}
 	if ctx.MaxTokens != "" {
 		fields["max_tokens"] = StringValue{V: string(ctx.MaxTokens)}
+	}
+	if ctx.Description != "" {
+		fields["description"] = StringValue{V: ctx.Description}
 	}
 	return &SignalDecl{SignalType: "context", Name: ctx.Name, Fields: fields}
 }

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -196,6 +196,9 @@ func (d *decompiler) roleBindingToSignal(rb *config.RoleBinding) *SignalDecl {
 	if rb.Role != "" {
 		fields["role"] = StringValue{V: rb.Role}
 	}
+	if rb.Description != "" {
+		fields["description"] = StringValue{V: rb.Description}
+	}
 	if len(rb.Subjects) > 0 {
 		var items []Value
 		for _, subj := range rb.Subjects {

--- a/src/semantic-router/pkg/dsl/decompiler_convert_ast_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert_ast_roundtrip_test.go
@@ -1,0 +1,192 @@
+package dsl
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestDecompileToASTPreservesKeywordRuleFields locks in the AST emit contract
+// for KeywordRule. The runtime KeywordRule schema carries 9 configurable
+// fields; DecompileToAST must surface every non-zero field so that
+// programmatic consumers of the AST (dashboard editors, projection contract
+// alignment, CLI validators) do not silently observe a truncated rule.
+//
+// Regression coverage for the gap where fuzzy_match, fuzzy_threshold,
+// bm25_threshold, ngram_threshold, and ngram_arity were dropped on the
+// AST path even though they round-trip correctly through DSL text.
+func TestDecompileToASTPreservesKeywordRuleFields(t *testing.T) {
+	cfg := &config.RouterConfig{
+		IntelligentRouting: config.IntelligentRouting{
+			Signals: config.Signals{
+				KeywordRules: []config.KeywordRule{{
+					Name:           "fuzzy_kw",
+					Operator:       "any",
+					Keywords:       []string{"alpha", "beta"},
+					CaseSensitive:  true,
+					Method:         "fuzzy",
+					FuzzyMatch:     true,
+					FuzzyThreshold: 80,
+					BM25Threshold:  0.5,
+					NgramThreshold: 0.25,
+					NgramArity:     3,
+				}},
+			},
+		},
+	}
+
+	prog := DecompileToAST(cfg)
+
+	sig := findSignal(t, prog, "keyword", "fuzzy_kw")
+	requireStringField(t, sig, "operator", "any")
+	requireFieldExists(t, sig, "keywords")
+	requireBoolField(t, sig, "case_sensitive", true)
+	requireStringField(t, sig, "method", "fuzzy")
+	requireBoolField(t, sig, "fuzzy_match", true)
+	requireIntField(t, sig, "fuzzy_threshold", 80)
+	requireFloatField(t, sig, "bm25_threshold", 0.5)
+	requireFloatField(t, sig, "ngram_threshold", 0.25)
+	requireIntField(t, sig, "ngram_arity", 3)
+}
+
+// TestDecompileToASTPreservesContextRuleFields locks in the AST emit
+// contract for ContextRule.Description. Without this, a runtime ContextRule
+// authored with a human-readable description is silently stripped of that
+// description when surfaced through DecompileToAST.
+func TestDecompileToASTPreservesContextRuleFields(t *testing.T) {
+	cfg := &config.RouterConfig{
+		IntelligentRouting: config.IntelligentRouting{
+			Signals: config.Signals{
+				ContextRules: []config.ContextRule{{
+					Name:        "long_ctx",
+					MinTokens:   "1K",
+					MaxTokens:   "32K",
+					Description: "Long requests requiring large context window",
+				}},
+			},
+		},
+	}
+
+	prog := DecompileToAST(cfg)
+
+	sig := findSignal(t, prog, "context", "long_ctx")
+	requireStringField(t, sig, "min_tokens", "1K")
+	requireStringField(t, sig, "max_tokens", "32K")
+	requireStringField(t, sig, "description", "Long requests requiring large context window")
+}
+
+// TestDecompileToASTOmitsZeroValuedKeywordRuleFields documents the
+// zero-value omission contract: only non-zero / non-empty fields should
+// appear in the AST, preserving the existing behaviour for the original
+// four fields and matching the convention used by the text decompiler.
+func TestDecompileToASTOmitsZeroValuedKeywordRuleFields(t *testing.T) {
+	cfg := &config.RouterConfig{
+		IntelligentRouting: config.IntelligentRouting{
+			Signals: config.Signals{
+				KeywordRules: []config.KeywordRule{{
+					Name:     "minimal_kw",
+					Operator: "any",
+					Keywords: []string{"foo"},
+				}},
+			},
+		},
+	}
+
+	prog := DecompileToAST(cfg)
+	sig := findSignal(t, prog, "keyword", "minimal_kw")
+
+	for _, omitted := range []string{
+		"case_sensitive", "method", "fuzzy_match", "fuzzy_threshold",
+		"bm25_threshold", "ngram_threshold", "ngram_arity",
+	} {
+		if _, ok := sig.Fields[omitted]; ok {
+			t.Errorf("expected %q to be omitted from AST when zero-valued, but it was present", omitted)
+		}
+	}
+}
+
+func findSignal(t *testing.T, prog *Program, signalType, name string) *SignalDecl {
+	t.Helper()
+	for _, sig := range prog.Signals {
+		if sig.SignalType == signalType && sig.Name == name {
+			return sig
+		}
+	}
+	t.Fatalf("expected SIGNAL %s %s in AST, not found", signalType, name)
+	return nil
+}
+
+func requireFieldExists(t *testing.T, sig *SignalDecl, name string) {
+	t.Helper()
+	if _, ok := sig.Fields[name]; !ok {
+		t.Errorf("expected SIGNAL %s %s to carry field %q", sig.SignalType, sig.Name, name)
+	}
+}
+
+func requireStringField(t *testing.T, sig *SignalDecl, name, want string) {
+	t.Helper()
+	v, ok := sig.Fields[name]
+	if !ok {
+		t.Errorf("expected SIGNAL %s %s to carry string field %q", sig.SignalType, sig.Name, name)
+		return
+	}
+	sv, ok := v.(StringValue)
+	if !ok {
+		t.Errorf("field %q: expected StringValue, got %T", name, v)
+		return
+	}
+	if sv.V != want {
+		t.Errorf("field %q: want %q, got %q", name, want, sv.V)
+	}
+}
+
+func requireBoolField(t *testing.T, sig *SignalDecl, name string, want bool) {
+	t.Helper()
+	v, ok := sig.Fields[name]
+	if !ok {
+		t.Errorf("expected SIGNAL %s %s to carry bool field %q", sig.SignalType, sig.Name, name)
+		return
+	}
+	bv, ok := v.(BoolValue)
+	if !ok {
+		t.Errorf("field %q: expected BoolValue, got %T", name, v)
+		return
+	}
+	if bv.V != want {
+		t.Errorf("field %q: want %v, got %v", name, want, bv.V)
+	}
+}
+
+func requireIntField(t *testing.T, sig *SignalDecl, name string, want int) {
+	t.Helper()
+	v, ok := sig.Fields[name]
+	if !ok {
+		t.Errorf("expected SIGNAL %s %s to carry int field %q", sig.SignalType, sig.Name, name)
+		return
+	}
+	iv, ok := v.(IntValue)
+	if !ok {
+		t.Errorf("field %q: expected IntValue, got %T", name, v)
+		return
+	}
+	if iv.V != want {
+		t.Errorf("field %q: want %d, got %d", name, want, iv.V)
+	}
+}
+
+func requireFloatField(t *testing.T, sig *SignalDecl, name string, want float64) {
+	t.Helper()
+	v, ok := sig.Fields[name]
+	if !ok {
+		t.Errorf("expected SIGNAL %s %s to carry float field %q", sig.SignalType, sig.Name, name)
+		return
+	}
+	fv, ok := v.(FloatValue)
+	if !ok {
+		t.Errorf("field %q: expected FloatValue, got %T", name, v)
+		return
+	}
+	if fv.V != want {
+		t.Errorf("field %q: want %v, got %v", name, want, fv.V)
+	}
+}

--- a/src/semantic-router/pkg/dsl/decompiler_convert_ast_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert_ast_roundtrip_test.go
@@ -1,6 +1,8 @@
 package dsl
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
@@ -73,6 +75,57 @@ func TestDecompileToASTPreservesContextRuleFields(t *testing.T) {
 	requireStringField(t, sig, "min_tokens", "1K")
 	requireStringField(t, sig, "max_tokens", "32K")
 	requireStringField(t, sig, "description", "Long requests requiring large context window")
+}
+
+// TestDecompileToASTPreservesAuthzDescription locks in the AST emit contract
+// for RoleBinding.Description. compileAuthzSignal reads this field, so the
+// decompiler must emit it to avoid a lossy runtime config -> AST round trip.
+func TestDecompileToASTPreservesAuthzDescription(t *testing.T) {
+	cfg := &config.RouterConfig{
+		IntelligentRouting: config.IntelligentRouting{
+			Signals: config.Signals{
+				RoleBindings: []config.RoleBinding{{
+					Name:        "admins",
+					Role:        "admin",
+					Description: "Admin callers",
+					Subjects: []config.Subject{{
+						Kind: "User",
+						Name: "alice",
+					}},
+				}},
+			},
+		},
+	}
+
+	prog := DecompileToAST(cfg)
+
+	sig := findSignal(t, prog, "authz", "admins")
+	requireStringField(t, sig, "role", "admin")
+	requireStringField(t, sig, "description", "Admin callers")
+	requireFieldExists(t, sig, "subjects")
+}
+
+func TestDecompilePreservesAuthzDescription(t *testing.T) {
+	cfg := &config.RouterConfig{
+		IntelligentRouting: config.IntelligentRouting{
+			Signals: config.Signals{
+				RoleBindings: []config.RoleBinding{{
+					Name:        "admins",
+					Role:        "admin",
+					Description: "Admin callers",
+				}},
+			},
+		},
+	}
+
+	out, err := Decompile(cfg)
+	if err != nil {
+		t.Fatalf("Decompile: %v", err)
+	}
+
+	if !strings.Contains(out, `description: "Admin callers"`) {
+		t.Fatalf("expected authz description in decompiled DSL, got:\n%s", out)
+	}
 }
 
 // TestDecompileToASTOmitsZeroValuedKeywordRuleFields documents the
@@ -186,7 +239,7 @@ func requireFloatField(t *testing.T, sig *SignalDecl, name string, want float64)
 		t.Errorf("field %q: expected FloatValue, got %T", name, v)
 		return
 	}
-	if fv.V != want {
+	if math.Abs(fv.V-want) > 0.000001 {
 		t.Errorf("field %q: want %v, got %v", name, want, fv.V)
 	}
 }

--- a/src/semantic-router/pkg/dsl/decompiler_plugin_emit.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_emit.go
@@ -237,6 +237,12 @@ func emitRAGPluginConfig(sb *strings.Builder, p *config.DecisionPlugin) {
 	if !ok {
 		return
 	}
+	emitRAGCorePluginConfig(sb, cfg)
+	emitRAGBackendAndFailureConfig(sb, cfg)
+	emitRAGCacheConfig(sb, cfg)
+}
+
+func emitRAGCorePluginConfig(sb *strings.Builder, cfg *config.RAGPluginConfig) {
 	if cfg.Enabled {
 		fmt.Fprintf(sb, "    enabled: true\n")
 	}
@@ -255,8 +261,26 @@ func emitRAGPluginConfig(sb *strings.Builder, p *config.DecisionPlugin) {
 	if cfg.InjectionMode != "" {
 		fmt.Fprintf(sb, "    injection_mode: %q\n", cfg.InjectionMode)
 	}
+}
+
+func emitRAGBackendAndFailureConfig(sb *strings.Builder, cfg *config.RAGPluginConfig) {
+	if backendConfig, ok := normalizePluginConfigMap(cfg.BackendConfig); ok && len(backendConfig) > 0 {
+		fmt.Fprintf(sb, "    backend_config: %s\n", formatPluginConfigValue(backendConfig))
+	}
 	if cfg.OnFailure != "" {
 		fmt.Fprintf(sb, "    on_failure: %q\n", cfg.OnFailure)
+	}
+}
+
+func emitRAGCacheConfig(sb *strings.Builder, cfg *config.RAGPluginConfig) {
+	if cfg.CacheResults {
+		fmt.Fprintf(sb, "    cache_results: true\n")
+	}
+	if cfg.CacheTTLSeconds != nil {
+		fmt.Fprintf(sb, "    cache_ttl_seconds: %d\n", *cfg.CacheTTLSeconds)
+	}
+	if cfg.MinConfidenceThreshold != nil {
+		fmt.Fprintf(sb, "    min_confidence_threshold: %v\n", *cfg.MinConfidenceThreshold)
 	}
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler_plugin_fields.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_fields.go
@@ -1,6 +1,8 @@
 package dsl
 
 import (
+	"fmt"
+
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
@@ -245,6 +247,13 @@ func pluginFieldsRAG(p *config.DecisionPlugin) map[string]Value {
 	if !ok {
 		return fields
 	}
+	addRAGCoreFields(fields, cfg)
+	addRAGBackendAndFailureFields(fields, cfg)
+	addRAGCacheFields(fields, cfg)
+	return fields
+}
+
+func addRAGCoreFields(fields map[string]Value, cfg *config.RAGPluginConfig) {
 	if cfg.Enabled {
 		fields["enabled"] = BoolValue{V: true}
 	}
@@ -263,10 +272,27 @@ func pluginFieldsRAG(p *config.DecisionPlugin) map[string]Value {
 	if cfg.InjectionMode != "" {
 		fields["injection_mode"] = StringValue{V: cfg.InjectionMode}
 	}
+}
+
+func addRAGBackendAndFailureFields(fields map[string]Value, cfg *config.RAGPluginConfig) {
+	if backendConfig, ok := structuredPayloadObjectValue(cfg.BackendConfig); ok {
+		fields["backend_config"] = backendConfig
+	}
 	if cfg.OnFailure != "" {
 		fields["on_failure"] = StringValue{V: cfg.OnFailure}
 	}
-	return fields
+}
+
+func addRAGCacheFields(fields map[string]Value, cfg *config.RAGPluginConfig) {
+	if cfg.CacheResults {
+		fields["cache_results"] = BoolValue{V: true}
+	}
+	if cfg.CacheTTLSeconds != nil {
+		fields["cache_ttl_seconds"] = IntValue{V: *cfg.CacheTTLSeconds}
+	}
+	if cfg.MinConfidenceThreshold != nil {
+		fields["min_confidence_threshold"] = FloatValue{V: float64(*cfg.MinConfidenceThreshold)}
+	}
 }
 
 func pluginFieldsHeaderMutation(p *config.DecisionPlugin) map[string]Value {
@@ -299,4 +325,47 @@ func pluginFieldsHeaderMutation(p *config.DecisionPlugin) map[string]Value {
 		fields["delete"] = stringsToArray(cfg.Delete)
 	}
 	return fields
+}
+
+func structuredPayloadObjectValue(payload *config.StructuredPayload) (ObjectValue, bool) {
+	raw, err := payload.AsStringMap()
+	if err != nil || len(raw) == 0 {
+		return ObjectValue{}, false
+	}
+	return interfaceMapObjectValue(raw), true
+}
+
+func interfaceMapObjectValue(raw map[string]interface{}) ObjectValue {
+	fields := make(map[string]Value, len(raw))
+	for key, value := range raw {
+		fields[key] = interfaceValueToDSLValue(value)
+	}
+	return ObjectValue{Fields: fields}
+}
+
+func interfaceValueToDSLValue(raw interface{}) Value {
+	switch typed := normalizePluginConfigValue(raw).(type) {
+	case string:
+		return StringValue{V: typed}
+	case bool:
+		return BoolValue{V: typed}
+	case int:
+		return IntValue{V: typed}
+	case int64:
+		return IntValue{V: int(typed)}
+	case float32:
+		return FloatValue{V: float64(typed)}
+	case float64:
+		return FloatValue{V: typed}
+	case []interface{}:
+		items := make([]Value, 0, len(typed))
+		for _, item := range typed {
+			items = append(items, interfaceValueToDSLValue(item))
+		}
+		return ArrayValue{Items: items}
+	case map[string]interface{}:
+		return interfaceMapObjectValue(typed)
+	default:
+		return StringValue{V: fmt.Sprintf("%v", typed)}
+	}
 }

--- a/src/semantic-router/pkg/dsl/decompiler_plugin_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_roundtrip_test.go
@@ -1,6 +1,7 @@
 package dsl
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -51,16 +52,39 @@ func TestPluginFieldsHallucinationOmitsZeroValuedFields(t *testing.T) {
 // in compileRAGPlugin (with documented "warn" / "error" semantics) but
 // pluginFieldsRAG used to drop it on the AST path.
 func TestPluginFieldsRAGEmitsOnFailure(t *testing.T) {
+	topK := 5
+	maxContextLength := 2048
+	cacheTTL := 60
+	similarityThreshold := float32(0.7)
+	minConfidenceThreshold := float32(0.4)
 	cfg := config.RAGPluginConfig{
-		Enabled:   true,
-		Backend:   "milvus",
-		OnFailure: "warn",
+		Enabled:                true,
+		Backend:                "milvus",
+		TopK:                   &topK,
+		SimilarityThreshold:    &similarityThreshold,
+		MaxContextLength:       &maxContextLength,
+		InjectionMode:          "tool_role",
+		BackendConfig:          config.MustStructuredPayload(map[string]interface{}{"collection_name": "docs"}),
+		OnFailure:              "warn",
+		CacheResults:           true,
+		CacheTTLSeconds:        &cacheTTL,
+		MinConfidenceThreshold: &minConfidenceThreshold,
 	}
 	plugin := pluginFromConfig(t, config.DecisionPluginRAG, cfg)
 
 	fields := pluginFieldsRAG(plugin)
 
+	requirePluginBoolField(t, "rag", "enabled", fields, true)
+	requirePluginStringField(t, "rag", "backend", fields, "milvus")
+	requirePluginIntField(t, "rag", "top_k", fields, 5)
+	requirePluginFloatField(t, "rag", "similarity_threshold", fields, 0.7)
+	requirePluginIntField(t, "rag", "max_context_length", fields, 2048)
+	requirePluginStringField(t, "rag", "injection_mode", fields, "tool_role")
+	requirePluginObjectField(t, "rag", "backend_config", fields)
 	requirePluginStringField(t, "rag", "on_failure", fields, "warn")
+	requirePluginBoolField(t, "rag", "cache_results", fields, true)
+	requirePluginIntField(t, "rag", "cache_ttl_seconds", fields, 60)
+	requirePluginFloatField(t, "rag", "min_confidence_threshold", fields, 0.4)
 }
 
 // TestPluginFieldsRAGOmitsOnFailureWhenEmpty preserves the omit-default
@@ -83,10 +107,16 @@ func TestPluginFieldsRAGOmitsOnFailureWhenEmpty(t *testing.T) {
 // too, so Decompile()/Format() round trips through the runtime config
 // silently lost on_failure even when authored from DSL.
 func TestEmitRAGPluginConfigEmitsOnFailure(t *testing.T) {
+	cacheTTL := 60
+	minConfidenceThreshold := float32(0.4)
 	cfg := config.RAGPluginConfig{
-		Enabled:   true,
-		Backend:   "milvus",
-		OnFailure: "error",
+		Enabled:                true,
+		Backend:                "milvus",
+		BackendConfig:          config.MustStructuredPayload(map[string]interface{}{"collection_name": "docs"}),
+		OnFailure:              "error",
+		CacheResults:           true,
+		CacheTTLSeconds:        &cacheTTL,
+		MinConfidenceThreshold: &minConfidenceThreshold,
 	}
 	plugin := pluginFromConfig(t, config.DecisionPluginRAG, cfg)
 
@@ -96,6 +126,16 @@ func TestEmitRAGPluginConfigEmitsOnFailure(t *testing.T) {
 	out := sb.String()
 	if !strings.Contains(out, `on_failure: "error"`) {
 		t.Errorf("expected emitRAGPluginConfig output to contain on_failure, got:\n%s", out)
+	}
+	for _, want := range []string{
+		`backend_config: { collection_name: "docs" }`,
+		`cache_results: true`,
+		`cache_ttl_seconds: 60`,
+		`min_confidence_threshold: 0.4`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected emitRAGPluginConfig output to contain %q, got:\n%s", want, out)
+		}
 	}
 }
 
@@ -140,4 +180,53 @@ func requirePluginBoolField(t *testing.T, plugin, name string, fields map[string
 	if bv.V != want {
 		t.Errorf("%s plugin field %q: want %v, got %v", plugin, name, want, bv.V)
 	}
+}
+
+func requirePluginIntField(t *testing.T, plugin, name string, fields map[string]Value, want int) {
+	t.Helper()
+	v, ok := fields[name]
+	if !ok {
+		t.Errorf("expected %s plugin AST to carry int field %q", plugin, name)
+		return
+	}
+	iv, ok := v.(IntValue)
+	if !ok {
+		t.Errorf("%s plugin field %q: expected IntValue, got %T", plugin, name, v)
+		return
+	}
+	if iv.V != want {
+		t.Errorf("%s plugin field %q: want %d, got %d", plugin, name, want, iv.V)
+	}
+}
+
+func requirePluginFloatField(t *testing.T, plugin, name string, fields map[string]Value, want float64) {
+	t.Helper()
+	v, ok := fields[name]
+	if !ok {
+		t.Errorf("expected %s plugin AST to carry float field %q", plugin, name)
+		return
+	}
+	fv, ok := v.(FloatValue)
+	if !ok {
+		t.Errorf("%s plugin field %q: expected FloatValue, got %T", plugin, name, v)
+		return
+	}
+	if math.Abs(fv.V-want) > 0.000001 {
+		t.Errorf("%s plugin field %q: want %v, got %v", plugin, name, want, fv.V)
+	}
+}
+
+func requirePluginObjectField(t *testing.T, plugin, name string, fields map[string]Value) ObjectValue {
+	t.Helper()
+	v, ok := fields[name]
+	if !ok {
+		t.Errorf("expected %s plugin AST to carry object field %q", plugin, name)
+		return ObjectValue{}
+	}
+	ov, ok := v.(ObjectValue)
+	if !ok {
+		t.Errorf("%s plugin field %q: expected ObjectValue, got %T", plugin, name, v)
+		return ObjectValue{}
+	}
+	return ov
 }

--- a/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
+++ b/src/semantic-router/pkg/dsl/decompiler_signals_rules.go
@@ -215,6 +215,9 @@ func (d *decompiler) decompileAuthzSignals() {
 		if rb.Role != "" {
 			d.write("  role: %q\n", rb.Role)
 		}
+		if rb.Description != "" {
+			d.write("  description: %q\n", rb.Description)
+		}
 		if len(rb.Subjects) > 0 {
 			d.write("  subjects: [")
 			for i, subj := range rb.Subjects {


### PR DESCRIPTION
## Summary

This PR fixes several silent DSL compile/decompile parity gaps where runtime config fields were accepted by one surface but dropped by another. The original scope covered `KeywordRule` and `ContextRule` AST decompile loss; follow-up review also identified RAG and authz field drift, which is now included in this PR.

## Changes

- `KeywordRule`: `DecompileToAST` now preserves `fuzzy_match`, `fuzzy_threshold`, `bm25_threshold`, `ngram_threshold`, and `ngram_arity`.
- `ContextRule`: `DecompileToAST` now preserves `description`.
- RAG plugin: compiler/decompiler paths now preserve `backend_config`, `cache_results`, `cache_ttl_seconds`, and `min_confidence_threshold` where applicable.
- Authz signal: text and AST decompiler paths now preserve `description`.
- Adds focused AST and text round-trip regression tests for the fixed surfaces.

## Test Plan

- `go build ./pkg/dsl/...`
- `go test ./pkg/dsl/... -count=1`
- `make agent-lint CHANGED_FILES="src/semantic-router/pkg/dsl/compiler_plugins.go,src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go,src/semantic-router/pkg/dsl/decompiler_convert.go,src/semantic-router/pkg/dsl/decompiler_convert_ast_roundtrip_test.go,src/semantic-router/pkg/dsl/decompiler_plugin_emit.go,src/semantic-router/pkg/dsl/decompiler_plugin_fields.go,src/semantic-router/pkg/dsl/decompiler_plugin_roundtrip_test.go,src/semantic-router/pkg/dsl/decompiler_signals_rules.go"`

CI is rerunning after rebasing this branch onto latest `main`.

## Notes

No schema, grammar, validator, or runtime behavior change. Fields are emitted only when non-zero or non-empty, preserving the existing omit-default convention.

Follow-up to #2086, #2095, and #2101.