### PR TITLE
[DSL] Stop dropping Hallucination and RAG plugin fields on decompile

### DIFF
--- a/src/semantic-router/pkg/dsl/decompiler_plugin_emit.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_emit.go
@@ -255,6 +255,9 @@ func emitRAGPluginConfig(sb *strings.Builder, p *config.DecisionPlugin) {
 	if cfg.InjectionMode != "" {
 		fmt.Fprintf(sb, "    injection_mode: %q\n", cfg.InjectionMode)
 	}
+	if cfg.OnFailure != "" {
+		fmt.Fprintf(sb, "    on_failure: %q\n", cfg.OnFailure)
+	}
 }
 
 func emitHeaderMutationPluginConfig(sb *strings.Builder, p *config.DecisionPlugin) {

--- a/src/semantic-router/pkg/dsl/decompiler_plugin_fields.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_fields.go
@@ -115,6 +115,12 @@ func pluginFieldsHallucination(p *config.DecisionPlugin) map[string]Value {
 	if cfg.Enabled {
 		fields["enabled"] = BoolValue{V: true}
 	}
+	if cfg.UseNLI {
+		fields["use_nli"] = BoolValue{V: true}
+	}
+	if cfg.HallucinationAction != "" {
+		fields["hallucination_action"] = StringValue{V: cfg.HallucinationAction}
+	}
 	return fields
 }
 
@@ -256,6 +262,9 @@ func pluginFieldsRAG(p *config.DecisionPlugin) map[string]Value {
 	}
 	if cfg.InjectionMode != "" {
 		fields["injection_mode"] = StringValue{V: cfg.InjectionMode}
+	}
+	if cfg.OnFailure != "" {
+		fields["on_failure"] = StringValue{V: cfg.OnFailure}
 	}
 	return fields
 }

--- a/src/semantic-router/pkg/dsl/decompiler_plugin_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_roundtrip_test.go
@@ -1,0 +1,143 @@
+package dsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestPluginFieldsHallucinationEmitsAllAuthorableFields locks in that the
+// AST emitter for the hallucination plugin surfaces every field the DSL
+// compiler can read (use_nli, hallucination_action). Without this guard
+// the AST converter silently drops those fields while the text decompiler
+// emits them, making any runtime config -> AST -> compile round trip
+// lossy on those knobs even though the runtime schema and the text DSL
+// fully support them.
+func TestPluginFieldsHallucinationEmitsAllAuthorableFields(t *testing.T) {
+	cfg := config.HallucinationPluginConfig{
+		Enabled:             true,
+		UseNLI:              true,
+		HallucinationAction: "block",
+	}
+	plugin := pluginFromConfig(t, config.DecisionPluginHallucination, cfg)
+
+	fields := pluginFieldsHallucination(plugin)
+
+	requirePluginBoolField(t, "hallucination", "enabled", fields, true)
+	requirePluginBoolField(t, "hallucination", "use_nli", fields, true)
+	requirePluginStringField(t, "hallucination", "hallucination_action", fields, "block")
+}
+
+// TestPluginFieldsHallucinationOmitsZeroValuedFields documents the
+// omit-when-default contract: when the runtime config carries zero / empty
+// values, the AST emitter must not introduce noisy default fields.
+func TestPluginFieldsHallucinationOmitsZeroValuedFields(t *testing.T) {
+	cfg := config.HallucinationPluginConfig{Enabled: true}
+	plugin := pluginFromConfig(t, config.DecisionPluginHallucination, cfg)
+
+	fields := pluginFieldsHallucination(plugin)
+
+	if _, ok := fields["use_nli"]; ok {
+		t.Errorf("expected use_nli to be omitted when false")
+	}
+	if _, ok := fields["hallucination_action"]; ok {
+		t.Errorf("expected hallucination_action to be omitted when empty")
+	}
+}
+
+// TestPluginFieldsRAGEmitsOnFailure locks in that the AST emitter for
+// the RAG plugin surfaces the on_failure knob. The DSL compiler reads it
+// in compileRAGPlugin (with documented "warn" / "error" semantics) but
+// pluginFieldsRAG used to drop it on the AST path.
+func TestPluginFieldsRAGEmitsOnFailure(t *testing.T) {
+	cfg := config.RAGPluginConfig{
+		Enabled:   true,
+		Backend:   "milvus",
+		OnFailure: "warn",
+	}
+	plugin := pluginFromConfig(t, config.DecisionPluginRAG, cfg)
+
+	fields := pluginFieldsRAG(plugin)
+
+	requirePluginStringField(t, "rag", "on_failure", fields, "warn")
+}
+
+// TestPluginFieldsRAGOmitsOnFailureWhenEmpty preserves the omit-default
+// contract for on_failure: an empty string in the runtime config must not
+// surface as a noisy field in the AST.
+func TestPluginFieldsRAGOmitsOnFailureWhenEmpty(t *testing.T) {
+	cfg := config.RAGPluginConfig{Enabled: true, Backend: "milvus"}
+	plugin := pluginFromConfig(t, config.DecisionPluginRAG, cfg)
+
+	fields := pluginFieldsRAG(plugin)
+
+	if _, ok := fields["on_failure"]; ok {
+		t.Errorf("expected on_failure to be omitted when empty")
+	}
+}
+
+// TestEmitRAGPluginConfigEmitsOnFailure covers the text-DSL path. Unlike
+// the keyword/context AST fix, the RAG on_failure leak affects BOTH the
+// AST emitter and the text emitter: emitRAGPluginConfig used to drop it
+// too, so Decompile()/Format() round trips through the runtime config
+// silently lost on_failure even when authored from DSL.
+func TestEmitRAGPluginConfigEmitsOnFailure(t *testing.T) {
+	cfg := config.RAGPluginConfig{
+		Enabled:   true,
+		Backend:   "milvus",
+		OnFailure: "error",
+	}
+	plugin := pluginFromConfig(t, config.DecisionPluginRAG, cfg)
+
+	var sb strings.Builder
+	emitRAGPluginConfig(&sb, plugin)
+
+	out := sb.String()
+	if !strings.Contains(out, `on_failure: "error"`) {
+		t.Errorf("expected emitRAGPluginConfig output to contain on_failure, got:\n%s", out)
+	}
+}
+
+func pluginFromConfig(t *testing.T, pluginType string, cfg interface{}) *config.DecisionPlugin {
+	t.Helper()
+	payload, err := config.NewStructuredPayload(cfg)
+	if err != nil {
+		t.Fatalf("NewStructuredPayload: %v", err)
+	}
+	return &config.DecisionPlugin{Type: pluginType, Configuration: payload}
+}
+
+func requirePluginStringField(t *testing.T, plugin, name string, fields map[string]Value, want string) {
+	t.Helper()
+	v, ok := fields[name]
+	if !ok {
+		t.Errorf("expected %s plugin AST to carry string field %q", plugin, name)
+		return
+	}
+	sv, ok := v.(StringValue)
+	if !ok {
+		t.Errorf("%s plugin field %q: expected StringValue, got %T", plugin, name, v)
+		return
+	}
+	if sv.V != want {
+		t.Errorf("%s plugin field %q: want %q, got %q", plugin, name, want, sv.V)
+	}
+}
+
+func requirePluginBoolField(t *testing.T, plugin, name string, fields map[string]Value, want bool) {
+	t.Helper()
+	v, ok := fields[name]
+	if !ok {
+		t.Errorf("expected %s plugin AST to carry bool field %q", plugin, name)
+		return
+	}
+	bv, ok := v.(BoolValue)
+	if !ok {
+		t.Errorf("%s plugin field %q: expected BoolValue, got %T", plugin, name, v)
+		return
+	}
+	if bv.V != want {
+		t.Errorf("%s plugin field %q: want %v, got %v", plugin, name, want, bv.V)
+	}
+}


### PR DESCRIPTION
## Summary

Three more silent field losses in the DSL plugin decompilers, all in the same class as #2086 and #2094 — the decompiler did not emit fields that the DSL compiler already reads back in. Found via a follow-up audit of compile-side `getXxxField(fields, "...")` reads against decompile-side `fields["..."] = ...` emits across every plugin decoder.

| Plugin | Field(s) silently dropped | AST path | Text DSL path |
|---|---|---|---|
| Hallucination | `use_nli`, `hallucination_action` | ❌ (this PR) | ✅ already emits |
| RAG | `on_failure` | ❌ (this PR) | ❌ (this PR) |

## Why this matters

### 1. Hallucination — same shape as #2094

`compileHallucinationPluginConfig` already reads three fields off the DSL:

```go
if v, ok := getBoolField(fields, "enabled"); ok       { cfg.Enabled = v }
if v, ok := getBoolField(fields, "use_nli"); ok       { cfg.UseNLI = v }
if v, ok := getStringField(fields, "hallucination_action"); ok { cfg.HallucinationAction = v }
```

`pluginFieldsHallucination` only emitted `enabled` when surfacing the runtime config back into the AST via `DecompileToAST`. Programmatic consumers (dashboard editor surfaces, projection-contract alignment per #1761, CLI validators) saw a hallucination plugin stripped of its NLI mode and action policy with **no error**. The text decompiler (`emitHallucinationPluginConfig`) already emits all three correctly, so this was a pure AST-path asymmetry — same class as #2094.

### 2. RAG `on_failure` — strictly worse than #2094

`compileRAGPlugin` reads `on_failure`, which has documented `"warn"` / `"error"` semantics validated by `config.validateRAGOnFailure`. **Neither the AST emitter nor the text emitter** surfaced it on decompile:

- [`pluginFieldsRAG`](https://github.com/vllm-project/semantic-router/blob/main/src/semantic-router/pkg/dsl/decompiler_plugin_fields.go#L236) — silent AST-path loss.
- [`emitRAGPluginConfig`](https://github.com/vllm-project/semantic-router/blob/main/src/semantic-router/pkg/dsl/decompiler_plugin_emit.go#L235) — silent **text-DSL** loss.

Concretely: a `Decompile()` → commit → `Compile()` cycle silently erases a validated routing-failure policy. A no-op YAML re-generation through the DSL contract drops the operator's on-failure intent. Unlike #2094 (AST-only leak), this is the strictly worse "even my text round-trip loses data" variant.

### 3. Aligns with the unification workstream

#1761 ("unify projection contract across Go, DSL, CLI, and dashboard surfaces") explicitly calls out cross-surface drift in DSL parse/compile/decompile as the main risk. This PR removes three concrete drift instances in the plugin decoder space.

## Changes

| File | Change |
|------|--------|
| `src/semantic-router/pkg/dsl/decompiler_plugin_fields.go` | `pluginFieldsHallucination` emits `use_nli` + `hallucination_action`; `pluginFieldsRAG` emits `on_failure`. |
| `src/semantic-router/pkg/dsl/decompiler_plugin_emit.go` | `emitRAGPluginConfig` emits `on_failure: %q`. |
| `src/semantic-router/pkg/dsl/decompiler_plugin_roundtrip_test.go` (new) | 5 focused regression tests + 2 small typed-field assertion helpers. |

Total diff: **3 files, +155 / -0**. Prod-only diff is **+12 lines**; remaining 143 lines are the new test file. All edits mirror the existing non-zero-guard idiom; behaviour for zero / empty fields is unchanged.

## Test Plan

- [x] `go build ./pkg/dsl/...` — clean
- [x] `go test ./pkg/dsl/... -count=1` — pass (`ok ... 0.707s`)
- [x] `make agent-lint CHANGED_FILES="<the three files>"` — Passed (go fmt, go lint, agent changed-files lint, golangci-lint, `TestReferenceConfig`, **structure checks fully clean** — no warn-only ratchet introduced).
- [x] Targeted: `TestPluginFieldsHallucination*`, `TestPluginFieldsRAG*`, `TestEmitRAGPluginConfigEmitsOnFailure` — all 5 pass.

Full `make test` from `cmd/` is skipped locally because the host is missing the CGO bindings (`candle-binding`, `nlp-binding`, `ml-binding`) — CI matrix will validate them.

## Notes

- Pure decompiler-side fix; no schema, grammar, compiler, or validator change.
- Default behaviour (fields zero / empty) is unchanged: the non-zero guards preserve the omit-default convention used everywhere else in this file.
- Third in a series of DSL round-trip symmetry fixes: #2086 (language threshold), #2094 (keyword + context fields), this PR (hallucination + RAG fields).

Follow-up to #2086 and #2094.
