### PR TITLE
[Docs] Remove unnecessary Threads renderer any cast

### DIFF
--- a/website/src/components/Threads/index.tsx
+++ b/website/src/components/Threads/index.tsx
@@ -150,7 +150,7 @@ const Threads: React.FC<ThreadsProps> = ({
     if (!containerRef.current) return
     const container = containerRef.current
 
-    const renderer = new Renderer({ alpha: true } as any)
+    const renderer = new Renderer({ alpha: true })
     const gl = renderer.gl
     gl.clearColor(0, 0, 0, 0)
     gl.enable(gl.BLEND)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes N/A

## Purpose

- Remove an unnecessary `as any` cast from the docs-site `Threads` component.
- This clears the existing `@typescript-eslint/no-explicit-any` lint warning while keeping the OGL renderer behavior unchanged.
- Affected module(s): `Docs`

## Test Plan

- Run `npm --prefix website run lint`.
- This is sufficient because the change is a type-only cleanup in a docs-site React component and the reported problem was an ESLint warning.

## Test Result

- `npm --prefix website run lint` passed with no warnings or errors.
- No follow-up risks or blockers identified.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.