### PR TITLE
[Dashboard] Remove avoidable frontend any casts

### DIFF
--- a/dashboard/frontend/src/components/DataTable.tsx
+++ b/dashboard/frontend/src/components/DataTable.tsx
@@ -26,6 +26,36 @@ export interface DataTableProps<T> {
   readonly?: boolean
 }
 
+function getColumnValue<T>(row: T, key: string): unknown {
+  if (row !== null && typeof row === 'object') {
+    return (row as Record<string, unknown>)[key]
+  }
+
+  return undefined
+}
+
+function compareColumnValues(aValue: unknown, bValue: unknown): number {
+  if (aValue === bValue) return 0
+  if (aValue === null || typeof aValue === 'undefined') return -1
+  if (bValue === null || typeof bValue === 'undefined') return 1
+
+  if (typeof aValue === 'number' && typeof bValue === 'number') {
+    return aValue > bValue ? 1 : -1
+  }
+
+  const aText = String(aValue)
+  const bText = String(bValue)
+  if (aText === bText) return 0
+  return aText > bText ? 1 : -1
+}
+
+function renderColumnValue(value: unknown): React.ReactNode {
+  if (value === null || typeof value === 'undefined') return ''
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+  if (React.isValidElement(value)) return value
+  return String(value)
+}
+
 export function DataTable<T>({
   columns,
   data,
@@ -61,14 +91,10 @@ export function DataTable<T>({
     if (!sortColumn) return data
 
     return [...data].sort((a, b) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const aValue = (a as any)[sortColumn]
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const bValue = (b as any)[sortColumn]
+      const aValue = getColumnValue(a, sortColumn)
+      const bValue = getColumnValue(b, sortColumn)
 
-      if (aValue === bValue) return 0
-      
-      const comparison = aValue > bValue ? 1 : -1
+      const comparison = compareColumnValues(aValue, bValue)
       return sortDirection === 'asc' ? comparison : -comparison
     })
   }, [data, sortColumn, sortDirection])
@@ -138,8 +164,7 @@ export function DataTable<T>({
                         className={styles.td}
                         style={{ textAlign: column.align || 'left' }}
                       >
-                        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                        {column.render ? column.render(row) : (row as any)[column.key]}
+                        {column.render ? column.render(row) : renderColumnValue(getColumnValue(row, column.key))}
                       </td>
                     ))}
                     {(onView || onEdit || onDelete) && (

--- a/dashboard/frontend/src/pages/builderPageDeployOverlays.tsx
+++ b/dashboard/frontend/src/pages/builderPageDeployOverlays.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { DiffEditor } from "@monaco-editor/react";
+import type { MonacoDiffEditor } from "@monaco-editor/react";
 
 import type { DeployResult, DeployStep } from "@/types/dsl";
 
@@ -87,8 +88,7 @@ const BuilderDeployConfirmModal: React.FC<BuilderDeployConfirmModalProps> = ({
   onClose,
   onConfirm,
 }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const diffEditorRef = useRef<any>(null);
+  const diffEditorRef = useRef<MonacoDiffEditor | null>(null);
   const [diffChangeCount, setDiffChangeCount] = useState(0);
 
   if (!open) return null;


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes N/A

## Purpose

- Remove avoidable `any` usage from two dashboard frontend components.
- Type the Monaco diff editor ref with `MonacoDiffEditor | null` and replace generic table dynamic field access with `unknown`-based helper functions.
- This keeps the dashboard frontend lint/type surface cleaner without changing the user-facing deploy diff or table behavior.
- Affected module(s): `Dashboard`

## Test Plan

- Run `npm --prefix dashboard/frontend run lint`.
- Run `npm --prefix dashboard/frontend run type-check`.
- Run `make dashboard-check`.
- These checks cover the touched dashboard frontend TypeScript/lint paths and the repository dashboard validation gate.

## Test Result

- `npm --prefix dashboard/frontend run lint` passed.
- `npm --prefix dashboard/frontend run type-check` passed.
- `make dashboard-check` passed, including dashboard frontend lint/type-check/unit tests, dashboard backend lint, and dashboard backend go mod tidy check.
- Existing npm audit and Sass/Svelte warnings appeared during dependency/build steps, but they did not fail the dashboard gate and are unrelated to this change.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.