### PR TITLE
[DSL] Read max_context_length in compileRAGPlugin

### DIFF
--- a/src/semantic-router/pkg/dsl/compiler_plugins.go
+++ b/src/semantic-router/pkg/dsl/compiler_plugins.go
@@ -40,6 +40,9 @@ func (c *Compiler) compileRAGPlugin(fields map[string]Value) config.RAGPluginCon
 	if v, ok := getFloat32Field(fields, "similarity_threshold"); ok {
 		cfg.SimilarityThreshold = &v
 	}
+	if v, ok := getIntField(fields, "max_context_length"); ok {
+		cfg.MaxContextLength = &v
+	}
 	if v, ok := getStringField(fields, "injection_mode"); ok {
 		cfg.InjectionMode = v
 	}

--- a/src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go
+++ b/src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go
@@ -1,0 +1,97 @@
+package dsl
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestCompileRAGPluginReadsMaxContextLength locks in that the DSL compiler
+// surfaces max_context_length into the runtime RAG plugin config. The
+// runtime path (req_filter_rag.go) reads RAGPluginConfig.MaxContextLength
+// to truncate retrieved context, and the schema + validator already accept
+// the field, but compileRAGPlugin used to drop it entirely. Authoring
+// max_context_length in DSL was a silent no-op that left the runtime stuck
+// on its built-in default.
+func TestCompileRAGPluginReadsMaxContextLength(t *testing.T) {
+	input := `
+SIGNAL domain test { description: "test" }
+ROUTE rag_route (description = "RAG route") {
+  PRIORITY 100
+  WHEN domain("test")
+  MODEL "m:1b"
+  PLUGIN rag {
+    enabled: true
+    backend: "milvus"
+    max_context_length: 8000
+  }
+}
+`
+	cfg := mustCompile(t, input)
+	ragCfg := mustExtractRAGPluginConfig(t, cfg)
+
+	if ragCfg.MaxContextLength == nil {
+		t.Fatal("expected MaxContextLength to be set on compiled RAG plugin config, got nil")
+	}
+	if *ragCfg.MaxContextLength != 8000 {
+		t.Errorf("MaxContextLength: want 8000, got %d", *ragCfg.MaxContextLength)
+	}
+}
+
+// TestCompileRAGPluginOmitsMaxContextLengthWhenAbsent documents the
+// omit-default contract: when the DSL author does not specify
+// max_context_length, the compiled runtime config carries a nil pointer
+// so downstream consumers fall through to their default behaviour.
+func TestCompileRAGPluginOmitsMaxContextLengthWhenAbsent(t *testing.T) {
+	input := `
+SIGNAL domain test { description: "test" }
+ROUTE rag_route (description = "RAG route") {
+  PRIORITY 100
+  WHEN domain("test")
+  MODEL "m:1b"
+  PLUGIN rag {
+    enabled: true
+    backend: "milvus"
+  }
+}
+`
+	cfg := mustCompile(t, input)
+	ragCfg := mustExtractRAGPluginConfig(t, cfg)
+
+	if ragCfg.MaxContextLength != nil {
+		t.Errorf("expected MaxContextLength to remain nil when omitted, got *int = %d", *ragCfg.MaxContextLength)
+	}
+}
+
+func mustCompile(t *testing.T, input string) *config.RouterConfig {
+	t.Helper()
+	cfg, errs := Compile(input)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+	return cfg
+}
+
+// mustExtractRAGPluginConfig decodes the rag plugin configuration off the
+// first decision that carries it, using the same StructuredPayload contract
+// the runtime uses to read decision plugin configs.
+func mustExtractRAGPluginConfig(t *testing.T, cfg *config.RouterConfig) config.RAGPluginConfig {
+	t.Helper()
+	for _, dec := range cfg.Decisions {
+		for _, p := range dec.Plugins {
+			if p.Type != config.DecisionPluginRAG {
+				continue
+			}
+			if p.Configuration == nil {
+				t.Fatalf("rag plugin on decision %q has nil Configuration", dec.Name)
+			}
+			var out config.RAGPluginConfig
+			if err := p.Configuration.DecodeInto(&out); err != nil {
+				t.Fatalf("decode rag plugin configuration: %v", err)
+			}
+			return out
+		}
+	}
+	t.Fatal("no rag plugin found on any decision")
+	return config.RAGPluginConfig{}
+}


### PR DESCRIPTION
## Summary

The DSL compiler for the RAG plugin was missing one field — `max_context_length`. The runtime, schema, validator, and decompiler all treat the field as first-class, but `compileRAGPlugin` did not read it, so authoring this knob in DSL was a silent no-op.

Fourth in the audit series of [#2086](https://github.com/vllm-project/semantic-router/pull/2086), [#2094](https://github.com/vllm-project/semantic-router/pull/2094), [#2095](https://github.com/vllm-project/semantic-router/pull/2095) — this time the asymmetry is on the *compile* side, not the *decompile* side.

## Why this change

### 1. Every other layer already supports the field

`RAGPluginConfig.MaxContextLength` is a real, validated knob with a runtime consumer:

| Layer | Status |
|---|---|
| Schema (`config/rag_plugin.go`) | ✅ field defined, json+yaml tags |
| Validator | ✅ passes through validation pipeline |
| Runtime (`extproc/req_filter_rag.go:267-268`) | ✅ truncates retrieved context to this length |
| Hybrid backend (`extproc/req_filter_rag_hybrid.go`) | ✅ propagates to every backend call |
| Decompile (text + AST paths) | ✅ emits when set |
| **DSL compiler (`compileRAGPlugin`)** | ❌ **drops the field entirely** |

### 2. Silent no-op, not a hard error

Authoring `max_context_length: 8000` in DSL today compiles cleanly, decompiles back to the same DSL string, and looks correct end-to-end — but the runtime keeps using its built-in default because the compiled `RAGPluginConfig` has `MaxContextLength == nil`. There is no error, no warning, no log line.

This is the worst flavour of DSL bug: the operator believes they have configured something, the YAML round-trips perfectly, but the value never reaches the code that would have used it.

### 3. Tested but not actually verified

The pre-existing `TestDecompileRAGPlugin` even uses `max_context_length: 2000` in its fixture — but it only asserts decompile-side strings, never the compiled runtime config. That gap is exactly why this bug survived.

### 4. Fix is a one-line mirror of an existing pattern

`top_k` is a `*int` field two lines above. Same shape, same `getIntField` reader, same `&v` pointer assignment. The new code is byte-for-byte the `top_k` block with `max_context_length` substituted.

## Changes

| File | Change |
|------|--------|
| `src/semantic-router/pkg/dsl/compiler_plugins.go` | `compileRAGPlugin` reads `max_context_length` via `getIntField` into `cfg.MaxContextLength`. Mirror of the adjacent `top_k` block. |
| `src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go` (new) | 2 focused regression tests + 2 small helpers. |

Total diff: **2 files, +100 / -0**. Prod-only diff is **+3 lines**; the remaining 97 lines are the new test file with self-contained helpers.

## Reproduction (before vs after)

```dsl
PLUGIN rag {
    enabled: true
    backend: "milvus"
    max_context_length: 8000
}
```

**Before this PR**:
```
ragConfig.MaxContextLength == nil   ← silently dropped on compile
```

**After this PR**:
```
*ragConfig.MaxContextLength == 8000 ← reaches the runtime as intended
```

## Test Plan

- [x] `go build ./pkg/dsl/...` — clean
- [x] `go test ./pkg/dsl/... -count=1` — pass (`ok ... 0.252s`)
- [x] `make agent-lint CHANGED_FILES="<the two files>"` — Passed (go fmt, go lint, agent changed-files lint, golangci-lint, `TestReferenceConfig`, **structure checks fully clean** — no warn-only ratchet introduced).
- [x] Targeted: `TestCompileRAGPluginReadsMaxContextLength`, `TestCompileRAGPluginOmitsMaxContextLengthWhenAbsent` — both pass.
- [x] Pre-existing `TestDecompileRAGPlugin` still passes.
- [x] Manual end-to-end: DSL `max_context_length: 8000` now decompiles back unchanged AND lands as `*int = 8000` in the runtime config.

Full `make test` from `cmd/` is skipped locally because the host is missing CGO bindings (`candle-binding`, `nlp-binding`, `ml-binding`) — CI matrix will validate them.

## Notes

- Pure DSL-compiler-side fix; no schema, grammar, validator, or runtime change.
- Omit-default behaviour is preserved: when DSL does not author the field, the compiled config keeps `MaxContextLength == nil` and downstream consumers fall through to their default.
- Fourth and final fix in the DSL compile↔decompile symmetry audit series: #2086 (language threshold), #2094 (keyword + context fields), #2095 (hallucination + RAG `on_failure`), this PR (RAG `max_context_length`). After this, `compileRAGPlugin` reads exactly the same field set that `pluginFieldsRAG` / `emitRAGPluginConfig` emit.

Follow-up to #2086, #2094, and #2095.
