### PR TITLE
[Docs] Add token-count route guard guidance

### DIFF
--- a/src/semantic-router/pkg/classification/context_classifier_test.go
+++ b/src/semantic-router/pkg/classification/context_classifier_test.go
@@ -50,6 +50,18 @@ func TestContextClassifier(t *testing.T) {
 		Expect(matched).To(BeEmpty())
 	})
 
+	t.Run("Classify inclusive boundary matches adjacent ranges", func(t *testing.T) {
+		boundaryRules := []config.ContextRule{
+			{Name: "low_token_count", MinTokens: "0", MaxTokens: "1K"},
+			{Name: "high_token_count", MinTokens: "1K", MaxTokens: "256K"},
+		}
+		classifier := NewContextClassifier(&mockTokenCounter{count: 1000}, boundaryRules)
+		matched, count, err := classifier.Classify("some text")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1000))
+		Expect(matched).To(ConsistOf("low_token_count", "high_token_count"))
+	})
+
 	t.Run("Token counter error", func(t *testing.T) {
 		classifier := NewContextClassifier(&mockTokenCounter{err: fmt.Errorf("error")}, rules)
 		_, _, err := classifier.Classify("some text")

--- a/src/semantic-router/pkg/decision/engine_context_test.go
+++ b/src/semantic-router/pkg/decision/engine_context_test.go
@@ -67,35 +67,79 @@ func TestDecisionEngine_EvaluateDecisionsWithContext(t *testing.T) {
 			)
 
 			result, err := engine.EvaluateDecisionsWithSignals(tt.signals)
-
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("Expected error but got none")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
-			}
-
-			if tt.expectedDecision == "" {
-				if result != nil {
-					t.Errorf("Expected nil result but got decision: %s", result.Decision.Name)
-				}
-				return
-			}
-
-			if result == nil {
-				t.Errorf("Expected result but got nil")
-				return
-			}
-
-			if result.Decision.Name != tt.expectedDecision {
-				t.Errorf("Expected decision %s, got %s", tt.expectedDecision, result.Decision.Name)
-			}
+			assertExpectedDecisionResult(t, result, err, tt.expectError, tt.expectedDecision)
 		})
+	}
+}
+
+func assertExpectedDecisionResult(
+	t *testing.T,
+	result *DecisionResult,
+	err error,
+	expectError bool,
+	expectedDecision string,
+) {
+	t.Helper()
+
+	if expectError {
+		if err == nil {
+			t.Errorf("Expected error but got none")
+		}
+		return
+	}
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	if expectedDecision == "" {
+		if result != nil {
+			t.Errorf("Expected nil result but got decision: %s", result.Decision.Name)
+		}
+		return
+	}
+
+	if result == nil {
+		t.Errorf("Expected result but got nil")
+		return
+	}
+
+	if result.Decision.Name != expectedDecision {
+		t.Errorf("Expected decision %s, got %s", expectedDecision, result.Decision.Name)
+	}
+}
+
+func evaluateDecisionsWithSignalsForTest(
+	t *testing.T,
+	decisions []config.Decision,
+	signals *SignalMatches,
+) *DecisionResult {
+	t.Helper()
+
+	engine := NewDecisionEngine(
+		[]config.KeywordRule{},
+		[]config.EmbeddingRule{},
+		[]config.Category{},
+		decisions,
+		"priority",
+	)
+
+	result, err := engine.EvaluateDecisionsWithSignals(signals)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatalf("Expected decision, got nil")
+	}
+	return result
+}
+
+func assertDecisionName(t *testing.T, result *DecisionResult, expectedDecision string) {
+	t.Helper()
+
+	if result.Decision.Name != expectedDecision {
+		t.Fatalf("Expected decision %s, got %s", expectedDecision, result.Decision.Name)
 	}
 }
 
@@ -171,24 +215,8 @@ func TestDecisionEngine_ContextGuardPreventsLowTokenRouteShadowing(t *testing.T)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			engine := NewDecisionEngine(
-				[]config.KeywordRule{},
-				[]config.EmbeddingRule{},
-				[]config.Category{},
-				tt.decisions,
-				"priority",
-			)
-
-			result, err := engine.EvaluateDecisionsWithSignals(tt.signals)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if result == nil {
-				t.Fatalf("Expected decision %s, got nil", tt.expectedDecision)
-			}
-			if result.Decision.Name != tt.expectedDecision {
-				t.Fatalf("Expected decision %s, got %s", tt.expectedDecision, result.Decision.Name)
-			}
+			result := evaluateDecisionsWithSignalsForTest(t, tt.decisions, tt.signals)
+			assertDecisionName(t, result, tt.expectedDecision)
 		})
 	}
 }

--- a/src/semantic-router/pkg/decision/engine_context_test.go
+++ b/src/semantic-router/pkg/decision/engine_context_test.go
@@ -98,3 +98,97 @@ func TestDecisionEngine_EvaluateDecisionsWithContext(t *testing.T) {
 		})
 	}
 }
+
+func TestDecisionEngine_ContextGuardPreventsLowTokenRouteShadowing(t *testing.T) {
+	tests := []struct {
+		name             string
+		decisions        []config.Decision
+		signals          *SignalMatches
+		expectedDecision string
+	}{
+		{
+			name: "domain-only code route shadows high-token route by priority",
+			decisions: []config.Decision{
+				{
+					Name:     "low-token-hard-code-route",
+					Priority: 180,
+					Rules: config.RuleCombination{
+						Operator: "AND",
+						Conditions: []config.RuleCondition{
+							{Type: "domain", Name: "code_generation"},
+						},
+					},
+				},
+				{
+					Name:     "high-token-route",
+					Priority: 170,
+					Rules: config.RuleCombination{
+						Operator: "AND",
+						Conditions: []config.RuleCondition{
+							{Type: "context", Name: "high_token_count"},
+						},
+					},
+				},
+			},
+			signals: &SignalMatches{
+				DomainRules:  []string{"code_generation"},
+				ContextRules: []string{"high_token_count"},
+			},
+			expectedDecision: "low-token-hard-code-route",
+		},
+		{
+			name: "explicit low-token guard lets long code route to high-token decision",
+			decisions: []config.Decision{
+				{
+					Name:     "low-token-hard-code-route",
+					Priority: 180,
+					Rules: config.RuleCombination{
+						Operator: "AND",
+						Conditions: []config.RuleCondition{
+							{Type: "domain", Name: "code_generation"},
+							{Type: "context", Name: "low_token_count"},
+						},
+					},
+				},
+				{
+					Name:     "high-token-route",
+					Priority: 170,
+					Rules: config.RuleCombination{
+						Operator: "AND",
+						Conditions: []config.RuleCondition{
+							{Type: "context", Name: "high_token_count"},
+						},
+					},
+				},
+			},
+			signals: &SignalMatches{
+				DomainRules:  []string{"code_generation"},
+				ContextRules: []string{"high_token_count"},
+			},
+			expectedDecision: "high-token-route",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := NewDecisionEngine(
+				[]config.KeywordRule{},
+				[]config.EmbeddingRule{},
+				[]config.Category{},
+				tt.decisions,
+				"priority",
+			)
+
+			result, err := engine.EvaluateDecisionsWithSignals(tt.signals)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatalf("Expected decision %s, got nil", tt.expectedDecision)
+			}
+			if result.Decision.Name != tt.expectedDecision {
+				t.Fatalf("Expected decision %s, got %s", tt.expectedDecision, result.Decision.Name)
+			}
+		})
+	}
+}

--- a/website/docs/tutorials/decision/and.md
+++ b/website/docs/tutorials/decision/and.md
@@ -50,3 +50,35 @@ routing:
 ```
 
 Use `AND` when a model should only activate for a narrow, high-confidence slice of traffic.
+
+For token-count routing, keep low-context and high-context routes mutually guarded. A route named for low-token traffic should include the matching context signal; otherwise a broad domain-only route with higher priority can still win for long prompts that also match the domain:
+
+```yaml
+routing:
+  decisions:
+    - name: low_token_code_route
+      description: Route short code prompts to the code model.
+      priority: 180
+      rules:
+        operator: AND
+        conditions:
+          - type: domain
+            name: code_generation
+          - type: context
+            name: low_token_count
+      modelRefs:
+        - model: code-lite
+          use_reasoning: false
+
+    - name: high_token_route
+      description: Route long prompts to the long-context model.
+      priority: 170
+      rules:
+        operator: AND
+        conditions:
+          - type: context
+            name: high_token_count
+      modelRefs:
+        - model: long-context
+          use_reasoning: false
+```


### PR DESCRIPTION
Refs #2020.

## Purpose

- Document how low-token and high-token routes should be guarded with explicit context conditions.
- Add regression coverage for inclusive context-token boundaries.
- Add decision-engine coverage showing how a higher-priority domain-only route can shadow a high-token route, and how adding a low-token context guard avoids it.

## Test Plan

- `env GOCACHE=/tmp/go-build-cache go test ./pkg/classification -run TestContextClassifier -count=1`
- `env GOCACHE=/tmp/go-build-cache go test ./pkg/decision -run 'TestDecisionEngine_EvaluateDecisionsWithContext|TestDecisionEngine_ContextGuardPreventsLowTokenRouteShadowing' -count=1`
- `git diff --check`
- `env GOCACHE=/tmp/go-build-cache make agent-lint CHANGED_FILES="src/semantic-router/pkg/classification/context_classifier_test.go,src/semantic-router/pkg/decision/engine_context_test.go,website/docs/tutorials/decision/and.md"`
- `env GOCACHE=/tmp/go-build-cache make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/classification/context_classifier_test.go,src/semantic-router/pkg/decision/engine_context_test.go,website/docs/tutorials/decision/and.md"`
- `env GOCACHE=/tmp/go-build-cache make test-semantic-router`

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
