### PR TITLE
[Router] Accept image input on /api/v1/classify/intent, /api/v1/eval, and /api/v1/embeddings

### DIFF
--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -87,6 +87,7 @@ type ClassificationOptions struct {
 // EmbeddingRequest represents a request for embedding generation
 type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
+	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
 	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 768 (default), 512, 256, 128, 64
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert only): 3, 6, 11, 22 (0=full)
@@ -98,6 +99,7 @@ type EmbeddingRequest struct {
 // EmbeddingResult represents a single embedding result
 type EmbeddingResult struct {
 	Text             string    `json:"text"`
+	Modality         string    `json:"modality,omitempty"` // "image" for image inputs; empty for text (backward compatible)
 	Embedding        []float32 `json:"embedding"`
 	Dimension        int       `json:"dimension"`
 	ModelUsed        string    `json:"model_used"`

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -17,6 +17,9 @@ import (
 const (
 	defaultEmbeddingDimension = 768
 	defaultEmbeddingPriority  = 0.5
+	// maxImagesPerRequest bounds images per request; each is a full SigLIP
+	// forward pass and the body-size cap alone admits very many minimal images.
+	maxImagesPerRequest = 8
 )
 
 // handleEmbeddings handles embedding generation requests
@@ -93,10 +96,8 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 	if len(req.Texts) == 0 && len(req.Images) == 0 {
 		return "INVALID_INPUT", "at least one of texts or images must be provided", false
 	}
-	for i, image := range req.Images {
-		if !imageurl.IsSafeImageDataURL(image) {
-			return "INVALID_IMAGE", fmt.Sprintf("images[%d] must be an inline base64 image data URI (data:image/<type>;base64,...)", i), false
-		}
+	if code, message, ok := validateEmbeddingImages(req.Images); !ok {
+		return code, message, false
 	}
 	if !isValidDimension(req.Dimension) {
 		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 512, 768, 1024 (got %d)", req.Dimension), false
@@ -106,6 +107,23 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 	}
 	if req.Model == "mmbert" && req.TargetLayer != 0 && !config.IsValidMmBertLayer(req.TargetLayer, mmbertLayers) {
 		return "INVALID_LAYER", fmt.Sprintf("target_layer must be one of: %s (got %d)", formatLayerList(mmbertLayers), req.TargetLayer), false
+	}
+	return "", "", true
+}
+
+// validateEmbeddingImages enforces the image-input contract: a bounded count of
+// safe inline base64 image data URIs whose payloads decode.
+func validateEmbeddingImages(images []string) (string, string, bool) {
+	if len(images) > maxImagesPerRequest {
+		return "INVALID_INPUT", fmt.Sprintf("at most %d images may be provided per request (got %d)", maxImagesPerRequest, len(images)), false
+	}
+	for i, image := range images {
+		if !imageurl.IsSafeImageDataURL(image) {
+			return "INVALID_IMAGE", fmt.Sprintf("images[%d] must be an inline base64 image data URI (data:image/<type>;base64,...)", i), false
+		}
+		if _, ok := imageurl.DecodeBase64(image); !ok {
+			return "INVALID_IMAGE", fmt.Sprintf("images[%d] is not valid base64-encoded image data", i), false
+		}
 	}
 	return "", "", true
 }
@@ -133,7 +151,13 @@ func buildEmbeddingResults(req EmbeddingRequest) ([]EmbeddingResult, int64, erro
 	}
 
 	for _, image := range req.Images {
-		output, err := candle_binding.MultiModalEncodeImageFromBase64(image, req.Dimension)
+		// Canonicalize so the FFI's case-sensitive ";base64," scan finds the
+		// payload boundary (validation already guaranteed a safe data URI).
+		encodeInput := image
+		if canonical, ok := imageurl.CanonicalDataURL(image); ok {
+			encodeInput = canonical
+		}
+		output, err := candle_binding.MultiModalEncodeImageFromBase64(encodeInput, req.Dimension)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -11,6 +11,7 @@ import (
 	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/imageurl"
 )
 
 const (
@@ -32,7 +33,10 @@ func (s *ClassificationAPIServer) handleEmbeddings(w http.ResponseWriter, r *htt
 		return
 	}
 
-	avgProcessingTime := float64(totalProcessingTime) / float64(len(req.Texts))
+	avgProcessingTime := 0.0
+	if len(results) > 0 {
+		avgProcessingTime = float64(totalProcessingTime) / float64(len(results))
+	}
 	response := EmbeddingResponse{
 		Embeddings:            results,
 		TotalCount:            len(results),
@@ -81,8 +85,13 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 }
 
 func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string, string, bool) {
-	if len(req.Texts) == 0 {
-		return "INVALID_INPUT", "texts array cannot be empty", false
+	if len(req.Texts) == 0 && len(req.Images) == 0 {
+		return "INVALID_INPUT", "at least one of texts or images must be provided", false
+	}
+	for i, image := range req.Images {
+		if !imageurl.IsSafeImageDataURL(image) {
+			return "INVALID_IMAGE", fmt.Sprintf("images[%d] must be an inline base64 image data URI (data:image/<type>;base64,...)", i), false
+		}
 	}
 	if !isValidDimension(req.Dimension) {
 		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 512, 768, 1024 (got %d)", req.Dimension), false
@@ -97,7 +106,7 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 }
 
 func buildEmbeddingResults(req EmbeddingRequest) ([]EmbeddingResult, int64, error) {
-	results := make([]EmbeddingResult, 0, len(req.Texts))
+	results := make([]EmbeddingResult, 0, len(req.Texts)+len(req.Images))
 	var totalProcessingTime int64
 
 	for _, text := range req.Texts {
@@ -112,6 +121,24 @@ func buildEmbeddingResults(req EmbeddingRequest) ([]EmbeddingResult, int64, erro
 			Embedding:        output.Embedding,
 			Dimension:        len(output.Embedding),
 			ModelUsed:        output.ModelType,
+			ProcessingTimeMs: processingTime,
+		})
+
+		totalProcessingTime += processingTime
+	}
+
+	for _, image := range req.Images {
+		output, err := candle_binding.MultiModalEncodeImageFromBase64(image, req.Dimension)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		processingTime := int64(output.ProcessingTimeMs)
+		results = append(results, EmbeddingResult{
+			Modality:         output.Modality,
+			Embedding:        output.Embedding,
+			Dimension:        len(output.Embedding),
+			ModelUsed:        "multi-modal-embed",
 			ProcessingTimeMs: processingTime,
 		})
 

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -33,10 +33,7 @@ func (s *ClassificationAPIServer) handleEmbeddings(w http.ResponseWriter, r *htt
 		return
 	}
 
-	avgProcessingTime := 0.0
-	if len(results) > 0 {
-		avgProcessingTime = float64(totalProcessingTime) / float64(len(results))
-	}
+	avgProcessingTime := averageEmbeddingProcessingTime(totalProcessingTime, req)
 	response := EmbeddingResponse{
 		Embeddings:            results,
 		TotalCount:            len(results),
@@ -69,6 +66,14 @@ func (s *ClassificationAPIServer) parseEmbeddingRequest(w http.ResponseWriter, r
 	}
 
 	return req, true
+}
+
+func averageEmbeddingProcessingTime(totalProcessingTime int64, req EmbeddingRequest) float64 {
+	inputCount := len(req.Texts) + len(req.Images)
+	if inputCount == 0 {
+		return 0
+	}
+	return float64(totalProcessingTime) / float64(inputCount)
 }
 
 func applyEmbeddingDefaults(req *EmbeddingRequest) {

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -39,6 +39,44 @@ func TestBuildBatchSimilarityMatchesIncludesCandidateText(t *testing.T) {
 	}
 }
 
+func TestValidateEmbeddingRequestRequiresTextsOrImages(t *testing.T) {
+	req := EmbeddingRequest{Dimension: defaultEmbeddingDimension}
+
+	code, message, ok := validateEmbeddingRequest(req)
+	if ok {
+		t.Fatalf("expected empty texts and images to be invalid")
+	}
+	if code != "INVALID_INPUT" || message != "at least one of texts or images must be provided" {
+		t.Fatalf("unexpected validation error %q: %q", code, message)
+	}
+}
+
+func TestValidateEmbeddingRequestAcceptsImagesOnly(t *testing.T) {
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: defaultEmbeddingDimension,
+	}
+
+	if _, _, ok := validateEmbeddingRequest(req); !ok {
+		t.Fatalf("expected image-only request to be valid")
+	}
+}
+
+func TestValidateEmbeddingRequestRejectsUnsafeImage(t *testing.T) {
+	req := EmbeddingRequest{
+		Images:    []string{"https://example.com/cat.png"},
+		Dimension: defaultEmbeddingDimension,
+	}
+
+	code, message, ok := validateEmbeddingRequest(req)
+	if ok {
+		t.Fatalf("expected non-data-URI image to be rejected (SSRF guard)")
+	}
+	if code != "INVALID_IMAGE" {
+		t.Fatalf("unexpected validation error code %q: %q", code, message)
+	}
+}
+
 func TestNormalizeBatchSimilarityLimitCapsTopKAtCandidateCount(t *testing.T) {
 	req := BatchSimilarityRequest{
 		Candidates: []string{"a", "b"},

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -42,7 +42,7 @@ func TestBuildBatchSimilarityMatchesIncludesCandidateText(t *testing.T) {
 func TestValidateEmbeddingRequestRequiresTextsOrImages(t *testing.T) {
 	req := EmbeddingRequest{Dimension: defaultEmbeddingDimension}
 
-	code, message, ok := validateEmbeddingRequest(req)
+	code, message, ok := validateEmbeddingRequest(req, nil)
 	if ok {
 		t.Fatalf("expected empty texts and images to be invalid")
 	}
@@ -57,7 +57,7 @@ func TestValidateEmbeddingRequestAcceptsImagesOnly(t *testing.T) {
 		Dimension: defaultEmbeddingDimension,
 	}
 
-	if _, _, ok := validateEmbeddingRequest(req); !ok {
+	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
 		t.Fatalf("expected image-only request to be valid")
 	}
 }
@@ -68,12 +68,57 @@ func TestValidateEmbeddingRequestRejectsUnsafeImage(t *testing.T) {
 		Dimension: defaultEmbeddingDimension,
 	}
 
-	code, message, ok := validateEmbeddingRequest(req)
+	code, message, ok := validateEmbeddingRequest(req, nil)
 	if ok {
 		t.Fatalf("expected non-data-URI image to be rejected (SSRF guard)")
 	}
 	if code != "INVALID_IMAGE" {
 		t.Fatalf("unexpected validation error code %q: %q", code, message)
+	}
+}
+
+func TestValidateEmbeddingRequestRejectsMalformedBase64(t *testing.T) {
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,!!!!"},
+		Dimension: defaultEmbeddingDimension,
+	}
+
+	code, message, ok := validateEmbeddingRequest(req, nil)
+	if ok {
+		t.Fatalf("expected malformed base64 image to be rejected as a client error, not surface as a 500")
+	}
+	if code != "INVALID_IMAGE" {
+		t.Fatalf("unexpected validation error code %q: %q", code, message)
+	}
+}
+
+func TestValidateEmbeddingRequestAcceptsUppercaseDataURIScheme(t *testing.T) {
+	// "DATA:IMAGE/PNG;BASE64,..." passes the safety gate; it must also pass
+	// decode-validation so it is not accepted here only to 500 at the FFI, whose
+	// marker scan is case-sensitive (CanonicalDataURL normalizes it downstream).
+	req := EmbeddingRequest{
+		Images:    []string{"DATA:IMAGE/PNG;BASE64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: defaultEmbeddingDimension,
+	}
+
+	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
+		t.Fatalf("expected uppercase-scheme data URI to be accepted")
+	}
+}
+
+func TestValidateEmbeddingRequestRejectsTooManyImages(t *testing.T) {
+	images := make([]string, maxImagesPerRequest+1)
+	for i := range images {
+		images[i] = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+	}
+	req := EmbeddingRequest{Images: images, Dimension: defaultEmbeddingDimension}
+
+	code, _, ok := validateEmbeddingRequest(req, nil)
+	if ok {
+		t.Fatalf("expected more than %d images to be rejected", maxImagesPerRequest)
+	}
+	if code != "INVALID_INPUT" {
+		t.Fatalf("unexpected validation error code %q", code)
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -77,6 +77,19 @@ func TestValidateEmbeddingRequestRejectsUnsafeImage(t *testing.T) {
 	}
 }
 
+func TestAverageEmbeddingProcessingTimeUsesInputCount(t *testing.T) {
+	req := EmbeddingRequest{
+		Texts:  []string{"first", "second"},
+		Images: []string{"data:image/png;base64,iVBORw0KGgo="},
+	}
+
+	got := averageEmbeddingProcessingTime(90, req)
+
+	if got != 30 {
+		t.Fatalf("expected average processing time to use text plus image inputs, got %.2f", got)
+	}
+}
+
 func TestNormalizeBatchSimilarityLimitCapsTopKAtCandidateCount(t *testing.T) {
 	req := BatchSimilarityRequest{
 		Candidates: []string{"a", "b"},

--- a/src/semantic-router/pkg/classification/classifier_signal_authz.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_authz.go
@@ -2,7 +2,6 @@ package classification
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
@@ -27,11 +26,7 @@ import (
 //   - convFacts (ConversationFacts): optional conversation facts for conversation signals
 func (c *Classifier) EvaluateAllSignalsWithHeaders(text string, contextText string, currentUserText string, priorUserMessages []string, nonUserMessages []string, hasPriorAssistantReply bool, headers map[string]string, forceEvaluateAll bool, imageURL string, extra ...interface{}) (*SignalResults, error) {
 	opts := parseEvaluateSignalsExtra(extra)
-	var img []string
-	if strings.TrimSpace(imageURL) != "" {
-		img = []string{imageURL}
-	}
-	results := c.EvaluateAllSignalsWithContext(text, contextText, currentUserText, priorUserMessages, nonUserMessages, hasPriorAssistantReply, forceEvaluateAll, opts.uncompressedText, opts.skipCompressionSignals, opts.convFacts, img...)
+	results := c.EvaluateAllSignalsWithContext(text, contextText, currentUserText, priorUserMessages, nonUserMessages, hasPriorAssistantReply, forceEvaluateAll, opts.uncompressedText, opts.skipCompressionSignals, opts.convFacts, imageURL)
 	if err := c.appendAuthzFromHeaders(results, headers, forceEvaluateAll); err != nil {
 		return nil, err
 	}

--- a/src/semantic-router/pkg/classification/classifier_signal_context.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_context.go
@@ -50,8 +50,8 @@ func textForSignalFunc(text, uncompressedText string, skipCompressionSignals map
 // forceEvaluateAll: if true, evaluates all configured signals regardless of decision usage
 // uncompressedText: original text before prompt compression (empty = no compression happened)
 // skipCompressionSignals: signal types that must use uncompressedText instead of text
-// imageURL: optional image URL for multimodal signals
-func (c *Classifier) EvaluateAllSignalsWithContext(text string, contextText string, currentUserText string, priorUserMessages []string, nonUserMessages []string, hasPriorAssistantReply bool, forceEvaluateAll bool, uncompressedText string, skipCompressionSignals map[string]bool, convFacts ConversationFacts, imageURL ...string) *SignalResults {
+// imageURL: image URL for multimodal signals ("" when the request carries no image)
+func (c *Classifier) EvaluateAllSignalsWithContext(text string, contextText string, currentUserText string, priorUserMessages []string, nonUserMessages []string, hasPriorAssistantReply bool, forceEvaluateAll bool, uncompressedText string, skipCompressionSignals map[string]bool, convFacts ConversationFacts, imageURL string) *SignalResults {
 	defer c.enterSignalEvaluationLoadGate()()
 	// Determine which signals (type:name) should be evaluated
 	var usedSignals map[string]bool
@@ -73,10 +73,7 @@ func (c *Classifier) EvaluateAllSignalsWithContext(text string, contextText stri
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	imgArg := ""
-	if len(imageURL) > 0 {
-		imgArg = imageURL[0]
-	}
+	imgArg := imageURL
 
 	// Allocate a request-scoped image embedding cache only when an image is
 	// actually attached. Two signals - complexity (image rules) and embedding

--- a/src/semantic-router/pkg/classification/classifier_signal_eval.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_eval.go
@@ -3,11 +3,11 @@ package classification
 // EvaluateAllSignals evaluates all signal types and returns SignalResults
 // This is the new method that includes fact_check signals
 func (c *Classifier) EvaluateAllSignals(text string) *SignalResults {
-	return c.EvaluateAllSignalsWithContext(text, text, text, nil, nil, false, false, "", nil, ConversationFacts{})
+	return c.EvaluateAllSignalsWithContext(text, text, text, nil, nil, false, false, "", nil, ConversationFacts{}, "")
 }
 
 // EvaluateAllSignalsWithForceOption evaluates signals with option to force evaluate all
 // forceEvaluateAll: if true, evaluates all configured signals regardless of decision usage
 func (c *Classifier) EvaluateAllSignalsWithForceOption(text string, forceEvaluateAll bool) *SignalResults {
-	return c.EvaluateAllSignalsWithContext(text, text, text, nil, nil, false, forceEvaluateAll, "", nil, ConversationFacts{})
+	return c.EvaluateAllSignalsWithContext(text, text, text, nil, nil, false, forceEvaluateAll, "", nil, ConversationFacts{}, "")
 }

--- a/src/semantic-router/pkg/classification/reask_classifier_test.go
+++ b/src/semantic-router/pkg/classification/reask_classifier_test.go
@@ -238,6 +238,7 @@ func TestClassifierEvaluateAllSignalsWithContext_ReaskRecordsConfidenceAndStreak
 		"",
 		nil,
 		ConversationFacts{},
+		"",
 	)
 
 	if len(results.MatchedReaskRules) != 1 || results.MatchedReaskRules[0] != "persistently_dissatisfied" {
@@ -300,6 +301,7 @@ func TestClassifierEvaluateAllSignalsWithContext_ReaskRetainsOnlyPersistentTier(
 		"",
 		nil,
 		ConversationFacts{},
+		"",
 	)
 
 	if len(results.MatchedReaskRules) != 1 || results.MatchedReaskRules[0] != "persistently_dissatisfied" {
@@ -356,6 +358,7 @@ func TestClassifierEvaluateAllSignalsWithContext_ReaskIgnoresNonUserMessages(t *
 		"",
 		nil,
 		ConversationFacts{},
+		"",
 	)
 
 	if len(results.MatchedReaskRules) != 0 {

--- a/src/semantic-router/pkg/extproc/utils.go
+++ b/src/semantic-router/pkg/extproc/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openai/openai-go"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/imageurl"
 )
 
 // sendResponse sends a response with proper error handling and logging.
@@ -190,27 +191,11 @@ func statusCodeToEnum(statusCode int) typev3.StatusCode {
 // with an allowlisted MIME type (e.g. "data:image/png;base64,...").
 // HTTP(S) URLs, non-image data URIs, and file paths are rejected to prevent
 // SSRF, local file access, and decode errors on non-image payloads.
+//
+// The implementation lives in the shared imageurl package so the ExtProc path
+// and the HTTP classification API enforce an identical gate.
 func isSafeImageDataURL(url string) bool {
-	if url == "" {
-		return false
-	}
-	lower := strings.ToLower(url)
-	if !strings.HasPrefix(lower, "data:image/") {
-		return false
-	}
-	const base64Sep = ";base64,"
-	sepIdx := strings.Index(lower, base64Sep)
-	if sepIdx == -1 {
-		return false
-	}
-	mime := lower[len("data:"):sepIdx]
-	switch mime {
-	case "image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp":
-	default:
-		return false
-	}
-	payload := strings.TrimSpace(url[sepIdx+len(base64Sep):])
-	return payload != ""
+	return imageurl.IsSafeImageDataURL(url)
 }
 
 // rewriteRequestModel rewrites the model field in the request body JSON.

--- a/src/semantic-router/pkg/services/classification.go
+++ b/src/semantic-router/pkg/services/classification.go
@@ -148,6 +148,7 @@ func (s *ClassificationService) ClassifyIntent(req IntentRequest) (*IntentRespon
 		"",
 		nil,
 		classification.ConversationFacts{},
+		input.imageURL,
 	)
 
 	// Evaluate decision with engine (if decisions are configured)

--- a/src/semantic-router/pkg/services/classification_signal_contract.go
+++ b/src/semantic-router/pkg/services/classification_signal_contract.go
@@ -35,6 +35,7 @@ func (s *ClassificationService) ClassifyIntentForEval(req IntentRequest) (*EvalR
 		"",
 		nil,
 		classification.ConversationFacts{},
+		input.imageURL,
 	)
 
 	var decisionResult *decision.DecisionResult

--- a/src/semantic-router/pkg/services/intent_request_messages.go
+++ b/src/semantic-router/pkg/services/intent_request_messages.go
@@ -3,6 +3,8 @@ package services
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/imageurl"
 )
 
 type IntentMessage struct {
@@ -17,18 +19,25 @@ type intentSignalInput struct {
 	priorUserMessages []string
 	nonUserMessages   []string
 	hasAssistantReply bool
+	imageURL          string
 }
 
 type intentConversationHistory struct {
-	currentUserMessage string
-	priorUserMessages  []string
-	nonUserMessages    []string
-	hasAssistantReply  bool
+	currentUserMessage  string
+	currentUserImageURL string
+	priorUserMessages   []string
+	nonUserMessages     []string
+	hasAssistantReply   bool
+}
+
+type intentMessageImageURL struct {
+	URL string `json:"url"`
 }
 
 type intentMessageContentPart struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type     string                 `json:"type"`
+	Text     string                 `json:"text"`
+	ImageURL *intentMessageImageURL `json:"image_url,omitempty"`
 }
 
 func (req IntentRequest) resolveSignalInput() (intentSignalInput, error) {
@@ -61,6 +70,7 @@ func resolveIntentSignalInputFromMessages(messages []IntentMessage) (intentSigna
 		priorUserMessages: append([]string(nil), history.priorUserMessages...),
 		nonUserMessages:   append([]string(nil), history.nonUserMessages...),
 		hasAssistantReply: history.hasAssistantReply,
+		imageURL:          history.currentUserImageURL,
 	}
 
 	if input.evaluationText == "" && len(history.nonUserMessages) > 0 {
@@ -77,7 +87,10 @@ func resolveIntentSignalInputFromMessages(messages []IntentMessage) (intentSigna
 		input.contextText = history.currentUserMessage
 	}
 
-	return input, strings.TrimSpace(input.evaluationText) != ""
+	// An image-only user turn (no accompanying text) is still a valid input for
+	// image-modality signals, so accept the message path when an image is present
+	// even if there is no evaluation text to score.
+	return input, strings.TrimSpace(input.evaluationText) != "" || input.imageURL != ""
 }
 
 func extractIntentConversationHistory(messages []IntentMessage) intentConversationHistory {
@@ -85,25 +98,71 @@ func extractIntentConversationHistory(messages []IntentMessage) intentConversati
 
 	for _, msg := range messages {
 		text := extractIntentMessageText(msg.Content)
-		if text == "" {
-			continue
-		}
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
 
-		switch strings.ToLower(strings.TrimSpace(msg.Role)) {
-		case "user":
+		// A user turn may carry only an image (no text). Capture the image even
+		// when the text is empty so image-modality signals still receive it.
+		if role == "user" {
+			imageURL := extractIntentMessageImageURL(msg.Content)
+			if text == "" && imageURL == "" {
+				continue
+			}
 			if history.currentUserMessage != "" {
 				history.priorUserMessages = append(history.priorUserMessages, history.currentUserMessage)
 			}
 			history.currentUserMessage = text
+			history.currentUserImageURL = imageURL
+			continue
+		}
+
+		if text == "" {
+			continue
+		}
+
+		switch role {
 		case "system", "assistant":
 			history.nonUserMessages = append(history.nonUserMessages, text)
-			if strings.EqualFold(strings.TrimSpace(msg.Role), "assistant") {
+			if role == "assistant" {
 				history.hasAssistantReply = true
 			}
 		}
 	}
 
 	return history
+}
+
+// extractIntentMessageImageURL returns the first safe inline base64 image data
+// URI from a message's content parts, mirroring the ExtProc request path. Only
+// data URIs are accepted (HTTP(S) URLs are rejected to prevent SSRF).
+func extractIntentMessageImageURL(raw json.RawMessage) string {
+	raw = bytesTrimSpace(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	var parts []intentMessageContentPart
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		return firstSafeImageURL(parts)
+	}
+
+	var part intentMessageContentPart
+	if err := json.Unmarshal(raw, &part); err == nil {
+		return firstSafeImageURL([]intentMessageContentPart{part})
+	}
+
+	return ""
+}
+
+func firstSafeImageURL(parts []intentMessageContentPart) string {
+	for _, part := range parts {
+		if part.ImageURL == nil {
+			continue
+		}
+		if url := strings.TrimSpace(part.ImageURL.URL); imageurl.IsSafeImageDataURL(url) {
+			return url
+		}
+	}
+	return ""
 }
 
 func extractIntentMessageText(raw json.RawMessage) string {

--- a/src/semantic-router/pkg/services/intent_request_messages.go
+++ b/src/semantic-router/pkg/services/intent_request_messages.go
@@ -34,6 +34,25 @@ type intentMessageImageURL struct {
 	URL string `json:"url"`
 }
 
+// UnmarshalJSON accepts both the Chat Completions object form {"url": "..."} and
+// the Responses API bare-string form, so a string-valued image_url part cannot
+// fail the whole content-parts unmarshal (which would drop text extraction).
+func (u *intentMessageImageURL) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		u.URL = s
+		return nil
+	}
+	// Best-effort: an unknown shape (number/array/bool) yields no image rather
+	// than failing the whole content-parts unmarshal and dropping sibling text.
+	type plain intentMessageImageURL
+	var p plain
+	if err := json.Unmarshal(data, &p); err == nil {
+		*u = intentMessageImageURL(p)
+	}
+	return nil
+}
+
 type intentMessageContentPart struct {
 	Type     string                 `json:"type"`
 	Text     string                 `json:"text"`
@@ -41,11 +60,12 @@ type intentMessageContentPart struct {
 }
 
 func (req IntentRequest) resolveSignalInput() (intentSignalInput, error) {
+	text := strings.TrimSpace(req.Text)
+
 	if input, ok := resolveIntentSignalInputFromMessages(req.Messages); ok {
-		return input, nil
+		return applyTopLevelTextFallback(input, text), nil
 	}
 
-	text := strings.TrimSpace(req.Text)
 	if text == "" {
 		return intentSignalInput{}, ErrEmptyText
 	}
@@ -55,6 +75,23 @@ func (req IntentRequest) resolveSignalInput() (intentSignalInput, error) {
 		contextText:     text,
 		currentUserText: text,
 	}, nil
+}
+
+// applyTopLevelTextFallback fills empty text slots from req.Text when the
+// messages path was accepted solely because it carries an image, so image safety
+// cannot toggle whether the caller-supplied text is scored.
+func applyTopLevelTextFallback(input intentSignalInput, text string) intentSignalInput {
+	if text == "" || strings.TrimSpace(input.evaluationText) != "" {
+		return input
+	}
+	input.evaluationText = text
+	if strings.TrimSpace(input.contextText) == "" {
+		input.contextText = text
+	}
+	if strings.TrimSpace(input.currentUserText) == "" {
+		input.currentUserText = text
+	}
+	return input
 }
 
 func resolveIntentSignalInputFromMessages(messages []IntentMessage) (intentSignalInput, bool) {
@@ -73,7 +110,10 @@ func resolveIntentSignalInputFromMessages(messages []IntentMessage) (intentSigna
 		imageURL:          history.currentUserImageURL,
 	}
 
-	if input.evaluationText == "" && len(history.nonUserMessages) > 0 {
+	// Promote system/assistant text only with no user text AND no image; the
+	// image guard stops an image-only turn from promoting assistant text, leaving
+	// the slot empty for the caller's req.Text fallback.
+	if input.evaluationText == "" && input.imageURL == "" && len(history.nonUserMessages) > 0 {
 		input.evaluationText = strings.Join(history.nonUserMessages, " ")
 		input.contextText = input.evaluationText
 	}
@@ -100,11 +140,15 @@ func extractIntentConversationHistory(messages []IntentMessage) intentConversati
 		text := extractIntentMessageText(msg.Content)
 		role := strings.ToLower(strings.TrimSpace(msg.Role))
 
-		// A user turn may carry only an image (no text). Capture the image even
-		// when the text is empty so image-modality signals still receive it.
 		if role == "user" {
 			imageURL := extractIntentMessageImageURL(msg.Content)
 			if text == "" && imageURL == "" {
+				continue
+			}
+			// An image-only turn attaches its image without clobbering the most
+			// recent user text, which stays the best text to score.
+			if text == "" {
+				history.currentUserImageURL = imageURL
 				continue
 			}
 			if history.currentUserMessage != "" {

--- a/src/semantic-router/pkg/services/intent_request_messages_test.go
+++ b/src/semantic-router/pkg/services/intent_request_messages_test.go
@@ -110,6 +110,101 @@ func TestIntentRequestResolveSignalInput_AcceptsImageOnlyUserTurn(t *testing.T) 
 	assert.Equal(t, dataURI, input.imageURL)
 }
 
+func TestIntentRequestResolveSignalInput_StringImageURLDoesNotPoisonText(t *testing.T) {
+	// Responses API shape: image_url is a bare string, not a {"url": ...} object.
+	// A string-valued part must not fail the whole content-parts unmarshal, which
+	// would drop the text and regress a previously-classifiable request.
+	const dataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+	req := IntentRequest{
+		Messages: []IntentMessage{
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "input_text", "text": "hello world"},
+					{"type": "input_image", "image_url": dataURI},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello world", input.evaluationText)
+	assert.Equal(t, dataURI, input.imageURL)
+}
+
+func TestIntentRequestResolveSignalInput_MalformedImageURLDoesNotPoisonText(t *testing.T) {
+	// A non-string, non-object image_url (e.g. a JSON number) must not fail the
+	// whole content-parts unmarshal and drop the sibling text.
+	req := IntentRequest{
+		Messages: []IntentMessage{
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "input_text", "text": "keep this text"},
+					{"type": "input_image", "image_url": 123},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Equal(t, "keep this text", input.evaluationText)
+	assert.Empty(t, input.imageURL)
+}
+
+func TestIntentRequestResolveSignalInput_ImageOnlyTurnFallsBackToTopLevelText(t *testing.T) {
+	// A safe-image-only message plus top-level text must still score the supplied
+	// text; image safety (client-controlled) must not toggle whether it is scored.
+	const dataURI = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD"
+	req := IntentRequest{
+		Text: "summarize my quarterly report",
+		Messages: []IntentMessage{
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "image_url", "image_url": map[string]string{"url": dataURI}},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Equal(t, "summarize my quarterly report", input.evaluationText)
+	assert.Equal(t, dataURI, input.imageURL)
+}
+
+func TestIntentRequestResolveSignalInput_ImageOnlyFollowUpKeepsPriorUserText(t *testing.T) {
+	// An image-only follow-up turn must not rotate the real user question into
+	// history and let the assistant reply be promoted into the scored slot.
+	const dataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+	req := IntentRequest{
+		Messages: []IntentMessage{
+			{Role: "user", Content: mustMessageContent(t, "What is our refund policy?")},
+			{Role: "assistant", Content: mustMessageContent(t, "Refunds are processed within 30 days.")},
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "image_url", "image_url": map[string]string{"url": dataURI}},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Equal(t, "What is our refund policy?", input.evaluationText)
+	assert.Equal(t, dataURI, input.imageURL)
+	assert.NotEqual(t, "Refunds are processed within 30 days.", input.evaluationText,
+		"assistant reply must never be promoted into the scored evaluation text")
+}
+
 func TestIntentRequestResolveSignalInput_DropsUnsafeImageURL(t *testing.T) {
 	req := IntentRequest{
 		Messages: []IntentMessage{

--- a/src/semantic-router/pkg/services/intent_request_messages_test.go
+++ b/src/semantic-router/pkg/services/intent_request_messages_test.go
@@ -69,6 +69,67 @@ func TestIntentRequestResolveSignalInput_FallsBackToText(t *testing.T) {
 	assert.False(t, input.hasAssistantReply)
 }
 
+func TestIntentRequestResolveSignalInput_ExtractsImageFromCurrentUserTurn(t *testing.T) {
+	const dataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+	req := IntentRequest{
+		Messages: []IntentMessage{
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "text", "text": "What does this screenshot show?"},
+					{"type": "image_url", "image_url": map[string]string{"url": dataURI}},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Equal(t, "What does this screenshot show?", input.evaluationText)
+	assert.Equal(t, dataURI, input.imageURL)
+}
+
+func TestIntentRequestResolveSignalInput_AcceptsImageOnlyUserTurn(t *testing.T) {
+	const dataURI = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD"
+	req := IntentRequest{
+		Messages: []IntentMessage{
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "image_url", "image_url": map[string]string{"url": dataURI}},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Empty(t, input.evaluationText)
+	assert.Equal(t, dataURI, input.imageURL)
+}
+
+func TestIntentRequestResolveSignalInput_DropsUnsafeImageURL(t *testing.T) {
+	req := IntentRequest{
+		Messages: []IntentMessage{
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "text", "text": "Describe it."},
+					{"type": "image_url", "image_url": map[string]string{"url": "https://example.com/cat.png"}},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Equal(t, "Describe it.", input.evaluationText)
+	assert.Empty(t, input.imageURL, "non-data-URI image references must be rejected to prevent SSRF")
+}
+
 func TestClassificationServiceClassifyIntentForEval_AcceptsMessagesWithoutText(t *testing.T) {
 	service := &ClassificationService{classifier: nil}
 	req := IntentRequest{

--- a/src/semantic-router/pkg/utils/imageurl/imageurl.go
+++ b/src/semantic-router/pkg/utils/imageurl/imageurl.go
@@ -1,0 +1,34 @@
+// Package imageurl provides shared validation for inline image inputs accepted
+// across the router surfaces (ExtProc request path and the HTTP classification
+// API). Keeping the gate in one place avoids the security logic drifting
+// between callers.
+package imageurl
+
+import "strings"
+
+// IsSafeImageDataURL returns true only for inline base64-encoded image data URIs
+// with an allowlisted MIME type (e.g. "data:image/png;base64,...").
+// HTTP(S) URLs, non-image data URIs, and file paths are rejected to prevent
+// SSRF, local file access, and decode errors on non-image payloads.
+func IsSafeImageDataURL(url string) bool {
+	if url == "" {
+		return false
+	}
+	lower := strings.ToLower(url)
+	if !strings.HasPrefix(lower, "data:image/") {
+		return false
+	}
+	const base64Sep = ";base64,"
+	sepIdx := strings.Index(lower, base64Sep)
+	if sepIdx == -1 {
+		return false
+	}
+	mime := lower[len("data:"):sepIdx]
+	switch mime {
+	case "image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp":
+	default:
+		return false
+	}
+	payload := strings.TrimSpace(url[sepIdx+len(base64Sep):])
+	return payload != ""
+}

--- a/src/semantic-router/pkg/utils/imageurl/imageurl.go
+++ b/src/semantic-router/pkg/utils/imageurl/imageurl.go
@@ -4,31 +4,82 @@
 // between callers.
 package imageurl
 
-import "strings"
+import (
+	"encoding/base64"
+	"strings"
+)
 
-// IsSafeImageDataURL returns true only for inline base64-encoded image data URIs
-// with an allowlisted MIME type (e.g. "data:image/png;base64,...").
-// HTTP(S) URLs, non-image data URIs, and file paths are rejected to prevent
-// SSRF, local file access, and decode errors on non-image payloads.
-func IsSafeImageDataURL(url string) bool {
+const base64Marker = ";base64,"
+
+var allowedMIME = map[string]bool{
+	"image/png":  true,
+	"image/jpeg": true,
+	"image/jpg":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// parse is the single parser behind every exported helper. It returns the
+// lowercased MIME type and the exact-case base64 payload: the "data:" scheme and
+// ";base64," marker are matched case-insensitively (RFC 2397), but the payload is
+// preserved verbatim because the base64 alphabet is case-sensitive. ok is false
+// for anything that is not an allowlisted inline base64 image data URI.
+func parse(url string) (mime string, payload string, ok bool) {
 	if url == "" {
-		return false
+		return "", "", false
 	}
 	lower := strings.ToLower(url)
 	if !strings.HasPrefix(lower, "data:image/") {
-		return false
+		return "", "", false
 	}
-	const base64Sep = ";base64,"
-	sepIdx := strings.Index(lower, base64Sep)
+	sepIdx := strings.Index(lower, base64Marker)
 	if sepIdx == -1 {
-		return false
+		return "", "", false
 	}
-	mime := lower[len("data:"):sepIdx]
-	switch mime {
-	case "image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp":
-	default:
-		return false
+	mime = lower[len("data:"):sepIdx]
+	if !allowedMIME[mime] {
+		return "", "", false
 	}
-	payload := strings.TrimSpace(url[sepIdx+len(base64Sep):])
-	return payload != ""
+	payload = strings.TrimSpace(url[sepIdx+len(base64Marker):])
+	if payload == "" {
+		return "", "", false
+	}
+	return mime, payload, true
+}
+
+// IsSafeImageDataURL returns true only for inline base64-encoded image data URIs
+// with an allowlisted MIME type (e.g. "data:image/png;base64,..."). HTTP(S) URLs,
+// non-image data URIs, and file paths are rejected to prevent SSRF, local file
+// access, and decode errors. It checks shape only; use DecodeBase64 to validate
+// the payload.
+func IsSafeImageDataURL(url string) bool {
+	_, _, ok := parse(url)
+	return ok
+}
+
+// DecodeBase64 validates that url is a safe image data URI whose payload is
+// well-formed standard base64 and returns the decoded bytes. Request validation
+// uses it so malformed input is rejected as a 400 rather than failing later at
+// the FFI image decoder as a 500.
+func DecodeBase64(url string) ([]byte, bool) {
+	_, payload, ok := parse(url)
+	if !ok {
+		return nil, false
+	}
+	data, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil || len(data) == 0 {
+		return nil, false
+	}
+	return data, true
+}
+
+// CanonicalDataURL rebuilds the data URI with a lowercased scheme, MIME type, and
+// ";base64," marker while preserving the exact-case payload, for consumers that
+// scan for the marker case-sensitively (e.g. the candle FFI).
+func CanonicalDataURL(url string) (string, bool) {
+	mime, payload, ok := parse(url)
+	if !ok {
+		return "", false
+	}
+	return "data:" + mime + base64Marker + payload, true
 }

--- a/src/semantic-router/pkg/utils/imageurl/imageurl_test.go
+++ b/src/semantic-router/pkg/utils/imageurl/imageurl_test.go
@@ -1,6 +1,9 @@
 package imageurl
 
-import "testing"
+import (
+	"encoding/base64"
+	"testing"
+)
 
 func TestIsSafeImageDataURL(t *testing.T) {
 	cases := []struct {
@@ -25,5 +28,49 @@ func TestIsSafeImageDataURL(t *testing.T) {
 				t.Fatalf("IsSafeImageDataURL(%q) = %v, want %v", tc.url, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDecodeBase64(t *testing.T) {
+	valid := base64.StdEncoding.EncodeToString([]byte("hello image bytes"))
+
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"valid png payload", "data:image/png;base64," + valid, true},
+		{"uppercase scheme keeps case-sensitive payload", "DATA:IMAGE/PNG;BASE64," + valid, true},
+		{"malformed base64", "data:image/png;base64,!!!!", false},
+		{"non-decodable prefix bleed", "DATA:IMAGE/PNG;BASE64," + valid + "===", false},
+		{"not an image uri", "https://example.com/cat.png", false},
+		{"empty payload", "data:image/png;base64,", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := DecodeBase64(tc.url)
+			if ok != tc.want {
+				t.Fatalf("DecodeBase64(%q) ok = %v, want %v", tc.url, ok, tc.want)
+			}
+			if ok && len(got) == 0 {
+				t.Fatalf("DecodeBase64(%q) returned empty bytes on success", tc.url)
+			}
+		})
+	}
+}
+
+func TestCanonicalDataURL(t *testing.T) {
+	// Scheme/MIME/marker lowercased; mixed-case payload preserved verbatim.
+	got, ok := CanonicalDataURL("DATA:IMAGE/PNG;BASE64,AbCdEf")
+	if !ok {
+		t.Fatal("CanonicalDataURL returned ok=false for a safe upper-case data URI")
+	}
+	if want := "data:image/png;base64,AbCdEf"; got != want {
+		t.Fatalf("CanonicalDataURL = %q, want %q", got, want)
+	}
+
+	if _, ok := CanonicalDataURL("https://example.com/cat.png"); ok {
+		t.Fatal("CanonicalDataURL must reject non-data-URI inputs")
 	}
 }

--- a/src/semantic-router/pkg/utils/imageurl/imageurl_test.go
+++ b/src/semantic-router/pkg/utils/imageurl/imageurl_test.go
@@ -1,0 +1,29 @@
+package imageurl
+
+import "testing"
+
+func TestIsSafeImageDataURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"png data uri", "data:image/png;base64,iVBORw0KGgo=", true},
+		{"jpeg data uri", "data:image/jpeg;base64,/9j/4AAQ", true},
+		{"uppercase mime", "DATA:IMAGE/WEBP;BASE64,abc", true},
+		{"empty", "", false},
+		{"http url", "https://example.com/cat.png", false},
+		{"non-image data uri", "data:text/plain;base64,aGVsbG8=", false},
+		{"missing base64 marker", "data:image/png,rawbytes", false},
+		{"empty payload", "data:image/png;base64,", false},
+		{"disallowed mime", "data:image/svg+xml;base64,abc", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSafeImageDataURL(tc.url); got != tc.want {
+				t.Fatalf("IsSafeImageDataURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Closes #1911 (Phase 1 + embeddings).

The runtime already supports image-modality embeddings end-to-end (FFI `MultiModalEncodeImageFromBase64`, request-path image extractor, signal evaluator), but the HTTP API surface only accepted text. Image-modality embedding rules could therefore only fire from the gRPC ExtProc chat-completion path, never from the HTTP classification/embeddings endpoints. This PR extends the HTTP request schemas so they do.

Scope is intentionally limited to the issue's primary motivation (validating image-modality rules) plus direct image embedding. The batch-classify and similarity endpoints are deferred and tracked in #2317.

## Changes

**Shared image-input gate** (`pkg/utils/imageurl`)
- Extracts `isSafeImageDataURL` out of the ExtProc package into a reusable `IsSafeImageDataURL` helper, so the HTTP API and ExtProc enforce one identical gate (inline `data:image/...;base64,` only — HTTP(S) URLs and non-image data URIs rejected to prevent SSRF). ExtProc now delegates; behavior unchanged.
- Case-insensitive scheme/marker parsing with request-time base64 validation (`DecodeBase64`) and a canonical lowercase-marker rebuild (`CanonicalDataURL`) for the FFI's case-sensitive `;base64,` scan. Per-request image cap (`maxImagesPerRequest`).

**`/api/v1/classify/intent` and `/api/v1/eval`**
- Parse OpenAI-shaped `image_url` content parts from the current user turn and thread the inline data URI into `EvaluateAllSignalsWithContext` (now a **required** `imageURL` parameter — dropping it at a call site no longer compiles, so the request→classifier image wiring is type-defended).
- `intentMessageImageURL.UnmarshalJSON` accepts both the Chat Completions object form `{"url": "..."}` and the Responses API bare-string form; an unexpected shape (number/array/bool) degrades to no-image rather than poisoning the whole content-parts unmarshal.
- Image-only user turns no longer clobber or rotate out the most recent user text; evaluation/context/current-user text fall back to top-level `req.Text` when the messages path is accepted solely because of an image. Image safety can no longer toggle which text gets scored.
- `/api/v1/eval` reuses `IntentRequest`, so both endpoints are covered by one change.

**`/api/v1/embeddings`**
- Adds an optional `images` field (inline base64 data URIs) and computes their embeddings via the multi-modal model.
- Requests now require at least one of `texts` or `images`; malformed base64 / unsafe image references return `INVALID_IMAGE` (**400**) at request time instead of reaching the FFI as a 500; the average-processing-time calculation divides by request-input count (`len(texts)+len(images)`, zero-guarded) so image-only requests no longer skew it.
- Image results carry a `modality` field; text results are unchanged (backward compatible).

## Test Plan

- New unit tests:
  - `pkg/utils/imageurl`: data-URI gate (allowed MIME types, HTTP rejection, empty payload), `DecodeBase64`, `CanonicalDataURL`.
  - `pkg/services`: image extraction from current user turn, image-only turn accepted, unsafe URL dropped, plus the fix-commit repros — `TestIntentRequestResolveSignalInput_StringImageURLDoesNotPoisonText`, `..._MalformedImageURLDoesNotPoisonText`, `ImageOnlyTurnFallsBackToTopLevelText`, `ImageOnlyFollowUpKeepsPriorUserText`, `AcceptsImageOnlyUserTurn`.
  - `pkg/apiserver`: embeddings validation requires texts-or-images, accepts images-only, `RejectsMalformedBase64` (400), `AcceptsUppercaseDataURIScheme`, `RejectsTooManyImages`.

## Test Result

- `go test ./pkg/services/... ./pkg/apiserver/... ./pkg/utils/imageurl/... ./pkg/classification/... ./pkg/extproc/...` — all pass on the merged tree.
- `golangci-lint run` (agent config) on the changed packages — 0 issues.
- CI green; branch merges clean over current `main`.

> Note: the FFI image-encode path (`MultiModalEncodeImageFromBase64`) is env-gated behind `MULTIMODAL_MODEL_PATH` and was validated manually against a real SigLIP checkpoint (uppercase-URI repro encodes end-to-end on `/api/v1/embeddings`); it is not exercised by the unit suite. Building/testing the cgo packages required rebuilding the Candle Rust library (`make rust`) — the multi-modal image FFI symbol was missing from the previously cached `target/release` artifact.
