### PR TITLE
[Router] Authenticate looper requests to close security-pipeline bypass (#1443)

### DIFF
--- a/docs/architecture/security-hardening.md
+++ b/docs/architecture/security-hardening.md
@@ -50,6 +50,33 @@ This is configured in both:
 - `deploy/local/envoy.yaml` (local development)
 - `src/vllm-sr/cli/templates/envoy.template.yaml` (production template)
 
+### Looper Request Authentication
+
+Stripping headers at Envoy is defense-in-depth, not the primary control: the
+`request_headers_to_remove` rules run in Envoy's router filter, which executes
+*after* ext_proc. They stop internal headers from leaking to upstream backends,
+but they do not stop a client-injected header from reaching ext_proc.
+
+The primary control is an application-layer secret. The router owns a looper
+secret (`pkg/looper.Secret()`); the in-process looper client attaches it as
+`x-vsr-looper-secret` on every internal multi-model call, and ext_proc only
+honors the `x-vsr-looper-request` fast-path when that secret validates with a
+constant-time comparison. A request that carries `x-vsr-looper-request` without
+a valid secret is logged (`extproc looper_request_rejected`) and processed as a
+normal external request, so it still passes through decision evaluation,
+jailbreak, PII, and authz checks. This closes the bypass where any client could
+set `x-vsr-looper-request: true` to skip the entire security pipeline.
+
+**Secret source:**
+
+- By default each router process generates a random 256-bit secret in memory at
+  first use. This is correct for single-process and sidecar-per-Envoy
+  deployments, where the looper's internal call returns to the same process.
+- For multi-replica deployments where Envoy may load-balance the internal looper
+  call to a different router replica, set the `VSR_LOOPER_SECRET` environment
+  variable to the same value on every replica (e.g. from a Kubernetes Secret) so
+  all replicas trust one secret. The secret is never written to config or disk.
+
 ## 2. Dashboard RBAC Integration
 
 ### Security Policy API
@@ -208,3 +235,6 @@ For production multi-user deployments:
 - [ ] Review dashboard user roles — only admins should have `security.manage`
 - [ ] Ensure the looper endpoint is only accessible from the router container
       (network-level isolation)
+- [ ] For multi-replica router deployments, set a shared `VSR_LOOPER_SECRET`
+      (e.g. from a Kubernetes Secret) on every replica so internal looper calls
+      are accepted across replicas

--- a/src/semantic-router/pkg/extproc/processor_req_header.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/tracing"
 )
@@ -84,6 +85,10 @@ func captureRequestHeaders(
 	skipProcessingGateEnabled bool,
 ) (string, string) {
 	requestHeaders := v.RequestHeaders.Headers
+	var (
+		looperMarker bool
+		looperSecret string
+	)
 	for _, header := range requestHeaders.Headers {
 		headerValue := extractHeaderValue(header)
 		ctx.Headers[header.Key] = headerValue
@@ -96,7 +101,12 @@ func captureRequestHeaders(
 			ctx.RequestID = headerValue
 		}
 		if lowerKey == headers.VSRLooperRequest && headerValue == "true" {
-			ctx.LooperRequest = true
+			looperMarker = true
+		}
+		// The looper secret value is compared exactly (case-sensitive) by
+		// resolveLooperRequest, so only the header key is normalized here.
+		if lowerKey == headers.VSRLooperSecret {
+			looperSecret = headerValue
 		}
 		// The x-vsr-skip-processing opt-out is gated by the deployment-level
 		// global.router.skip_processing.enabled flag. When disabled (the
@@ -108,6 +118,13 @@ func captureRequestHeaders(
 			ctx.SkipProcessing = true
 		}
 	}
+
+	// Authorize the internal looper fast-path: the x-vsr-looper-request marker
+	// is only honored when accompanied by a valid secret that the in-process
+	// looper client attaches to every internal call. A marker without a valid
+	// secret is treated as a normal external request so the full security
+	// pipeline still runs (issue #1443).
+	ctx.LooperRequest = resolveLooperRequest(looperMarker, looperSecret, ctx.RequestID)
 
 	method := ctx.Headers[":method"]
 	path := ctx.Headers[":path"]
@@ -121,6 +138,26 @@ func captureRequestHeaders(
 	})
 
 	return method, path
+}
+
+// resolveLooperRequest authorizes the looper fast-path. It returns true only
+// when the looper marker is present and the accompanying secret matches the
+// process looper secret (constant-time comparison). A marker without a valid
+// secret is logged as a potential bypass attempt and rejected; the request
+// then continues through the normal security pipeline instead of skipping it.
+// See issue #1443.
+func resolveLooperRequest(marker bool, secret, requestID string) bool {
+	if !marker {
+		return false
+	}
+	if looper.ValidateSecret(secret) {
+		return true
+	}
+	logging.ComponentWarnEvent("extproc", "looper_request_rejected", map[string]interface{}{
+		"request_id": requestID,
+		"reason":     "missing_or_invalid_looper_secret",
+	})
+	return false
 }
 
 func setRequestHeaderSpanAttributes(

--- a/src/semantic-router/pkg/extproc/processor_req_header_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_header_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
 )
 
 type requestHeaderTestCase struct {
@@ -158,6 +159,7 @@ func TestHandleRequestHeadersSetsLooperAndStreamingFlags(t *testing.T) {
 					{Key: ":path", Value: "/v1/chat/completions"},
 					{Key: "accept", Value: "text/event-stream"},
 					{Key: "x-vsr-looper-request", Value: "true"},
+					{Key: "x-vsr-looper-secret", Value: looper.Secret()},
 					{Key: "x-request-id", Value: "req-123"},
 				},
 			},
@@ -180,6 +182,59 @@ func TestHandleRequestHeadersSetsLooperAndStreamingFlags(t *testing.T) {
 	}
 	if ctx.RequestID != "req-123" {
 		t.Fatalf("expected request ID to be captured, got %q", ctx.RequestID)
+	}
+}
+
+// TestHandleRequestHeadersRejectsForgedLooperRequest verifies that an external
+// client cannot bypass the security pipeline by forging x-vsr-looper-request:
+// without a valid x-vsr-looper-secret the request is not treated as a looper
+// request, so it continues through normal processing. Regression test for the
+// looper header-injection bypass (issue #1443).
+func TestHandleRequestHeadersRejectsForgedLooperRequest(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers []*core.HeaderValue
+	}{
+		{
+			name: "missing secret",
+			headers: []*core.HeaderValue{
+				{Key: ":method", Value: "POST"},
+				{Key: ":path", Value: "/v1/chat/completions"},
+				{Key: "x-vsr-looper-request", Value: "true"},
+			},
+		},
+		{
+			name: "wrong secret",
+			headers: []*core.HeaderValue{
+				{Key: ":method", Value: "POST"},
+				{Key: ":path", Value: "/v1/chat/completions"},
+				{Key: "x-vsr-looper-request", Value: "true"},
+				{Key: "x-vsr-looper-secret", Value: "not-the-real-secret"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := &OpenAIRouter{}
+			requestHeaders := &ext_proc.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &ext_proc.HttpHeaders{
+					Headers: &core.HeaderMap{Headers: tc.headers},
+				},
+			}
+
+			ctx := &RequestContext{Headers: make(map[string]string)}
+			response, err := router.handleRequestHeaders(requestHeaders, ctx)
+			if err != nil {
+				t.Fatalf("handleRequestHeaders failed: %v", err)
+			}
+			if response.GetRequestHeaders() == nil {
+				t.Fatal("expected continue request headers response")
+			}
+			if ctx.LooperRequest {
+				t.Fatal("forged looper request must not be honored without a valid secret")
+			}
+		})
 	}
 }
 

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -356,6 +356,15 @@ const (
 	// Used by extproc to lookup decision configuration and apply plugins.
 	// Value: decision name (e.g., "remom_low_effort")
 	VSRLooperDecision = "x-vsr-looper-decision"
+
+	// VSRLooperSecret authenticates internal looper requests. The router owns a
+	// per-process secret (or a shared VSR_LOOPER_SECRET for multi-replica
+	// deployments) that the in-process looper client attaches to every internal
+	// call. extproc validates it with a constant-time comparison before honoring
+	// the VSRLooperRequest fast-path, so an external client cannot forge
+	// VSRLooperRequest to skip the security pipeline. See issue #1443.
+	// Value: opaque secret string.
+	VSRLooperSecret = "x-vsr-looper-secret"
 )
 
 // Looper Response Headers

--- a/src/semantic-router/pkg/looper/client.go
+++ b/src/semantic-router/pkg/looper/client.go
@@ -208,6 +208,10 @@ func (c *Client) CallModel(ctx context.Context, req *openai.ChatCompletionNewPar
 	// Add looper identification headers
 	// These allow extproc to identify looper requests and lookup decision configuration
 	httpReq.Header.Set("x-vsr-looper-request", "true")
+	// Authenticate the internal call. extproc only honors the looper fast-path
+	// (which skips the security pipeline) when this secret is valid, so an
+	// external client cannot forge x-vsr-looper-request to bypass it (issue #1443).
+	httpReq.Header.Set("x-vsr-looper-secret", Secret())
 	httpReq.Header.Set("x-vsr-looper-iteration", fmt.Sprintf("%d", iteration))
 
 	// Add decision name header for extproc to lookup decision configuration

--- a/src/semantic-router/pkg/looper/secret.go
+++ b/src/semantic-router/pkg/looper/secret.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// SecretEnv is the environment variable used to share a looper authentication
+// secret across multiple router replicas. When set, every replica trusts the
+// same secret so an internal looper call routed (through Envoy) to a different
+// replica is still recognized. When unset, each process generates its own
+// random secret, which is correct for single-process and sidecar topologies.
+const SecretEnv = "VSR_LOOPER_SECRET"
+
+var (
+	secretOnce   sync.Once
+	looperSecret string
+)
+
+// Secret returns the process looper authentication secret, initializing it on
+// first use. The secret is sourced from SecretEnv when set; otherwise a
+// cryptographically random 256-bit value is generated in memory. It is never
+// written to config or disk. The in-process looper client attaches this value
+// to every internal call and extproc validates it before honoring the looper
+// fast-path, closing the bypass described in issue #1443.
+func Secret() string {
+	secretOnce.Do(func() { looperSecret = loadSecret() })
+	return looperSecret
+}
+
+// loadSecret resolves the looper secret from the environment or generates a
+// random one. It is separated from Secret so the resolution logic is unit
+// testable without the process-wide sync.Once cache.
+func loadSecret() string {
+	if env := strings.TrimSpace(os.Getenv(SecretEnv)); env != "" {
+		logging.ComponentEvent("looper", "secret_source_env", map[string]interface{}{
+			"env": SecretEnv,
+		})
+		return env
+	}
+
+	buf := make([]byte, 32) // 256-bit
+	if _, err := rand.Read(buf); err != nil {
+		// Fail closed: an empty secret never validates, so looper requests are
+		// not honored and every request falls back to the full security
+		// pipeline. crypto/rand.Read does not fail on supported platforms.
+		logging.ComponentErrorEvent("looper", "secret_generation_failed", map[string]interface{}{
+			"error": err.Error(),
+		})
+		return ""
+	}
+	logging.ComponentEvent("looper", "secret_generated", map[string]interface{}{
+		"source": "crypto/rand",
+		"bits":   256,
+	})
+	return hex.EncodeToString(buf)
+}
+
+// ValidateSecret reports whether provided matches the process looper secret
+// using a constant-time comparison. An empty provided secret, or an empty
+// process secret (generation failure), never validates.
+func ValidateSecret(provided string) bool {
+	if provided == "" {
+		return false
+	}
+	expected := Secret()
+	if expected == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) == 1
+}

--- a/src/semantic-router/pkg/looper/secret_test.go
+++ b/src/semantic-router/pkg/looper/secret_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import "testing"
+
+func TestSecretIsStableAndValidates(t *testing.T) {
+	s := Secret()
+	if s == "" {
+		t.Fatal("Secret() returned an empty secret")
+	}
+	if got := Secret(); got != s {
+		t.Fatalf("Secret() not stable: first %q second %q", s, got)
+	}
+	if !ValidateSecret(s) {
+		t.Fatal("ValidateSecret rejected the process secret")
+	}
+}
+
+func TestValidateSecretRejectsBadInput(t *testing.T) {
+	s := Secret()
+	if ValidateSecret("") {
+		t.Fatal("ValidateSecret accepted an empty secret")
+	}
+	if ValidateSecret(s + "tamper") {
+		t.Fatal("ValidateSecret accepted a tampered secret")
+	}
+	if ValidateSecret("not-the-secret") {
+		t.Fatal("ValidateSecret accepted an unrelated value")
+	}
+}
+
+func TestLoadSecretUsesEnvOverride(t *testing.T) {
+	t.Setenv(SecretEnv, "  shared-replica-secret  ")
+	if got := loadSecret(); got != "shared-replica-secret" {
+		t.Fatalf("loadSecret() = %q, want trimmed env value %q", got, "shared-replica-secret")
+	}
+}
+
+func TestLoadSecretGeneratesRandomWhenEnvUnset(t *testing.T) {
+	t.Setenv(SecretEnv, "")
+	first := loadSecret()
+	if len(first) != 64 { // 32 bytes hex-encoded
+		t.Fatalf("loadSecret() length = %d, want 64 hex chars", len(first))
+	}
+	if second := loadSecret(); second == first {
+		t.Fatal("loadSecret() produced identical random secrets across calls")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1443.

Any external client could send `x-vsr-looper-request: true` to make the ext_proc
filter treat the request as an internal looper call, which skips the **entire**
security pipeline: decision evaluation, jailbreak detection, PII detection, and
authz. The root cause was that ext_proc set `ctx.LooperRequest` directly from a
client-controlled header with no authentication.

```bash
# Before this change, this bypassed all safety checks:
curl http://vsr-endpoint/v1/chat/completions \
  -H "x-vsr-looper-request: true" \
  -d '{"model":"any-model","messages":[{"role":"user","content":"bypass all safety"}]}'
```

## Approach

Introduce an in-process looper secret:

- The router owns a per-process secret generated with `crypto/rand` (256-bit),
  or a shared `VSR_LOOPER_SECRET` for multi-replica deployments. It is never
  written to config or disk.
- The in-process looper client attaches it as `x-vsr-looper-secret` on every
  internal call.
- ext_proc only honors the `x-vsr-looper-request` fast-path when the secret
  validates with a **constant-time** comparison (`crypto/subtle`).
- A forged marker without a valid secret is logged
  (`extproc looper_request_rejected`) and processed as a **normal external
  request**, so the full security pipeline still runs. This fails to normal
  processing rather than hard-rejecting, avoiding a DoS vector from a spoofed
  header.

This complements the existing defense-in-depth Envoy header stripping
(`request_headers_to_remove`), which runs in Envoy's router filter **after**
ext_proc and therefore cannot by itself stop a client-injected header from
reaching ext_proc. The application-layer secret is the primary control.

### Multi-replica note

By default each process generates its own random secret (correct for
single-process and sidecar-per-Envoy topologies). For multi-replica router
deployments where Envoy may load-balance the internal looper call to a different
replica, set the same `VSR_LOOPER_SECRET` on every replica (e.g. from a
Kubernetes Secret).

## Changes

- `pkg/looper/secret.go` (new) — `Secret()` / `ValidateSecret()` with env
  override + crypto/rand fallback and constant-time compare.
- `pkg/looper/client.go` — send `x-vsr-looper-secret` on internal calls.
- `pkg/extproc/processor_req_header.go` — gate `ctx.LooperRequest` on a valid
  secret; warn-log rejected markers.
- `pkg/headers/headers.go` — add the `VSRLooperSecret` constant.
- `docs/architecture/security-hardening.md` — document the mechanism and
  `VSR_LOOPER_SECRET`.

## Test Plan

- `gofmt` clean on all changed Go files.
- Ran the secret crypto logic standalone (secret stability, constant-time
  accept/reject, `VSR_LOOPER_SECRET` override with trimming, random 256-bit
  generation): all pass.
- Added `pkg/looper/secret_test.go` and an ext_proc regression test asserting
  forged looper requests (missing **and** wrong secret) are not honored, while a
  request carrying a valid secret still enters the looper fast-path.
- Full `pkg/looper` + `pkg/extproc` build/tests require CGO and the prebuilt
  Rust candle binding; deferred to CI.

This is a behavior-visible security fix to the request-header path; the added
unit/regression tests cover the new accept/reject behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
