### PR TITLE
[Router] Require candle embedding runtime files for model completeness

### DIFF
--- a/src/semantic-router/pkg/classification/embedding_classifier_backend.go
+++ b/src/semantic-router/pkg/classification/embedding_classifier_backend.go
@@ -70,6 +70,9 @@ func (c *ExternalModelBasedEmbeddingInitializer) Init(qwen3ModelPath string, gem
 	gemmaModelPath = config.ResolveModelPath(gemmaModelPath)
 	mmBertModelPath = config.ResolveModelPath(mmBertModelPath)
 
+	// NOTE: pkg/modeldownload's collectCandleEmbeddingRequiredFiles mirrors
+	// this backend resolution to derive download-completeness requirements.
+	// Keep the two in sync if the resolution changes.
 	backend = strings.ToLower(strings.TrimSpace(backend))
 	if backend == "" {
 		backend = "candle"
@@ -129,6 +132,10 @@ func (c *Classifier) initializeKeywordEmbeddingClassifier() error {
 		return fmt.Errorf("keyword embedding similarity match is not properly configured")
 	}
 
+	// NOTE: pkg/modeldownload's collectCandleEmbeddingRequiredFiles mirrors
+	// this model_type resolution (and the image_candidates trigger in
+	// classifier_option_rules.go) to derive download-completeness
+	// requirements. Keep them in sync if the triggers change.
 	modelType := strings.ToLower(strings.TrimSpace(c.Config.EmbeddingConfig.ModelType))
 	if modelType == "multimodal" {
 		mmPath := config.ResolveModelPath(c.Config.MultiModalModelPath)

--- a/src/semantic-router/pkg/modeldownload/config_parser.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser.go
@@ -168,11 +168,86 @@ func addEmbeddingModelRequiredFiles(cfg *config.RouterConfig, requiredFilesByMod
 }
 
 // ExtractRequiredFilesByModel derives per-model completeness requirements from
-// config-owned companion files such as category/jailbreak/PII mappings.
+// config-owned companion files such as category/jailbreak/PII mappings, plus
+// the files the configured embedding runtime hard-loads at startup.
 func ExtractRequiredFilesByModel(cfg *config.RouterConfig) map[string][]string {
 	requiredFilesByModel := make(map[string][]string)
 	collectRequiredFilesByModel(reflect.ValueOf(cfg), requiredFilesByModel)
+	collectCandleEmbeddingRequiredFiles(cfg, requiredFilesByModel)
 	return requiredFilesByModel
+}
+
+// candleEmbeddingRequiredFiles are the files the candle embedding runtime
+// hard-loads from each configured embedding model directory at startup:
+// candle-binding builds its VarBuilder from <model>/model.safetensors and the
+// tokenizer from <model>/tokenizer.json, with no fallback formats.
+var candleEmbeddingRequiredFiles = []string{"model.safetensors", "tokenizer.json"}
+
+// gemmaEmbeddingRequiredFiles extends the common candle set with the dense
+// bottleneck weights GemmaEmbeddingModel additionally hard-loads from the
+// 2_Dense/ and 3_Dense/ subdirectories (BottleneckDenseNet::load_from_path).
+var gemmaEmbeddingRequiredFiles = []string{
+	"model.safetensors",
+	"tokenizer.json",
+	"2_Dense/model.safetensors",
+	"3_Dense/model.safetensors",
+}
+
+// collectCandleEmbeddingRequiredFiles records the candle runtime's startup
+// files as per-model completeness requirements for a superset of the embedding
+// models the candle runtime may load: the qwen3/gemma/mmbert paths under the
+// candle backend, and the multimodal path whenever model_type selects it or
+// complexity rules declare image_candidates (which loads the multimodal model
+// regardless of model_type).
+//
+// Without this, an interrupted download that fetched only companion artifacts
+// (config.json, nested onnx/ exports) satisfies the generic weight heuristic
+// in IsModelComplete: the model is treated as complete, is never re-downloaded
+// on restart, and the router crash-loops at classifier init with
+// "failed to load safetensors from <model>/model.safetensors". Recording the
+// runtime-required files makes such partial downloads read as incomplete so
+// the next startup resumes the download instead of crash-looping.
+//
+// The embedding path fields are enumerated explicitly (unlike the reflective
+// ExtractModelPaths walk) because the requirement is loader-specific: only the
+// paths whose loaders hard-code these files are covered. A new embedding path
+// field needs a matching entry here to gain partial-download protection.
+func collectCandleEmbeddingRequiredFiles(cfg *config.RouterConfig, requiredFilesByModel map[string][]string) {
+	// Mirror the backend resolution in classification's
+	// ExternalModelBasedEmbeddingInitializer: empty backend defaults to
+	// candle, case- and space-insensitively. Keep the two in sync.
+	backend := strings.ToLower(strings.TrimSpace(cfg.EmbeddingModels.EmbeddingConfig.Backend))
+	if backend == "" || backend == "candle" {
+		appendRequiredFiles(requiredFilesByModel, cfg.EmbeddingModels.Qwen3ModelPath, candleEmbeddingRequiredFiles)
+		appendRequiredFiles(requiredFilesByModel, cfg.EmbeddingModels.GemmaModelPath, gemmaEmbeddingRequiredFiles)
+		appendRequiredFiles(requiredFilesByModel, cfg.EmbeddingModels.MmBertModelPath, candleEmbeddingRequiredFiles)
+	}
+
+	// The multimodal model is loaded independently of the backend value:
+	// classification's initializer branches run it whenever model_type
+	// resolves to "multimodal", and the complexity classifier additionally
+	// loads it whenever any complexity rule declares image_candidates,
+	// without any model_type gate. Keep these triggers in sync with
+	// classifier_option_rules.go.
+	modelType := strings.ToLower(strings.TrimSpace(cfg.EmbeddingModels.EmbeddingConfig.ModelType))
+	if modelType == "multimodal" || config.HasImageCandidatesInRules(cfg.ComplexityRules) {
+		appendRequiredFiles(requiredFilesByModel, cfg.EmbeddingModels.MultiModalModelPath, candleEmbeddingRequiredFiles)
+	}
+}
+
+// appendRequiredFiles records files as completeness requirements for a local
+// model path, deduplicating against already-recorded requirements.
+func appendRequiredFiles(requiredFilesByModel map[string][]string, modelPath string, files []string) {
+	if !strings.HasPrefix(modelPath, "models/") || modelPath == "models/" {
+		return
+	}
+	requiredFiles := requiredFilesByModel[modelPath]
+	for _, file := range files {
+		if !slices.Contains(requiredFiles, file) {
+			requiredFiles = append(requiredFiles, file)
+		}
+	}
+	requiredFilesByModel[modelPath] = requiredFiles
 }
 
 func collectRequiredFilesByModel(v reflect.Value, requiredFilesByModel map[string][]string) {

--- a/src/semantic-router/pkg/modeldownload/config_parser.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser.go
@@ -213,11 +213,12 @@ var gemmaEmbeddingRequiredFiles = []string{
 // paths whose loaders hard-code these files are covered. A new embedding path
 // field needs a matching entry here to gain partial-download protection.
 func collectCandleEmbeddingRequiredFiles(cfg *config.RouterConfig, requiredFilesByModel map[string][]string) {
-	// Mirror the backend resolution in classification's
-	// ExternalModelBasedEmbeddingInitializer: empty backend defaults to
-	// candle, case- and space-insensitively. Keep the two in sync.
-	backend := strings.ToLower(strings.TrimSpace(cfg.EmbeddingModels.EmbeddingConfig.Backend))
-	if backend == "" || backend == "candle" {
+	// Use the canonical backend resolution (EmbeddingModels.EmbeddingBackend):
+	// only the candle backend hard-loads these local files at startup. The
+	// remote backend (openai_compatible, including model_type=remote with no
+	// backend set) and openvino load nothing from these paths, so requiring
+	// the files there would force downloads of models that never load.
+	if cfg.EmbeddingModels.EmbeddingBackend() == config.EmbeddingBackendCandle {
 		appendRequiredFiles(requiredFilesByModel, cfg.EmbeddingModels.Qwen3ModelPath, candleEmbeddingRequiredFiles)
 		appendRequiredFiles(requiredFilesByModel, cfg.EmbeddingModels.GemmaModelPath, gemmaEmbeddingRequiredFiles)
 		appendRequiredFiles(requiredFilesByModel, cfg.EmbeddingModels.MmBertModelPath, candleEmbeddingRequiredFiles)

--- a/src/semantic-router/pkg/modeldownload/config_parser_embedding_requirements_test.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser_embedding_requirements_test.go
@@ -15,14 +15,17 @@ import (
 
 func TestExtractRequiredFilesByModelIncludesCandleEmbeddingRuntimeFiles(t *testing.T) {
 	tests := []struct {
-		name    string
-		backend string
-		want    bool
+		name      string
+		backend   string
+		modelType string
+		want      bool
 	}{
 		{name: "empty backend defaults to candle", backend: "", want: true},
 		{name: "explicit candle backend", backend: "candle", want: true},
 		{name: "candle backend is case and space insensitive", backend: "  Candle ", want: true},
 		{name: "openvino backend adds no candle requirements", backend: "openvino", want: false},
+		{name: "openai_compatible backend adds no candle requirements", backend: "openai_compatible", want: false},
+		{name: "remote model_type with empty backend resolves remote, no candle requirements", backend: "", modelType: "remote", want: false},
 	}
 
 	for _, tt := range tests {
@@ -32,7 +35,7 @@ func TestExtractRequiredFilesByModelIncludesCandleEmbeddingRuntimeFiles(t *testi
 					EmbeddingModels: config.EmbeddingModels{
 						Qwen3ModelPath:  "models/mom-embedding-pro",
 						MmBertModelPath: "models/mmbert-embed-32k-2d-matryoshka",
-						EmbeddingConfig: config.HNSWConfig{Backend: tt.backend},
+						EmbeddingConfig: config.HNSWConfig{Backend: tt.backend, ModelType: tt.modelType},
 					},
 				},
 			}

--- a/src/semantic-router/pkg/modeldownload/config_parser_embedding_requirements_test.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser_embedding_requirements_test.go
@@ -1,0 +1,252 @@
+package modeldownload
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// Tests for the candle-embedding-runtime completeness requirements
+// (collectCandleEmbeddingRequiredFiles and its wiring through
+// ExtractRequiredFilesByModel / BuildModelSpecs).
+
+func TestExtractRequiredFilesByModelIncludesCandleEmbeddingRuntimeFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend string
+		want    bool
+	}{
+		{name: "empty backend defaults to candle", backend: "", want: true},
+		{name: "explicit candle backend", backend: "candle", want: true},
+		{name: "candle backend is case and space insensitive", backend: "  Candle ", want: true},
+		{name: "openvino backend adds no candle requirements", backend: "openvino", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.RouterConfig{
+				InlineModels: config.InlineModels{
+					EmbeddingModels: config.EmbeddingModels{
+						Qwen3ModelPath:  "models/mom-embedding-pro",
+						MmBertModelPath: "models/mmbert-embed-32k-2d-matryoshka",
+						EmbeddingConfig: config.HNSWConfig{Backend: tt.backend},
+					},
+				},
+			}
+
+			got := ExtractRequiredFilesByModel(cfg)
+			for _, modelPath := range []string{
+				"models/mom-embedding-pro",
+				"models/mmbert-embed-32k-2d-matryoshka",
+			} {
+				for _, file := range []string{"model.safetensors", "tokenizer.json"} {
+					if slices.Contains(got[modelPath], file) != tt.want {
+						t.Errorf("ExtractRequiredFilesByModel()[%q] contains %q = %v, want %v (map: %#v)",
+							modelPath, file, !tt.want, tt.want, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExtractRequiredFilesByModelSkipsNonLocalEmbeddingPaths(t *testing.T) {
+	cfg := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MmBertModelPath: "/opt/external/mmbert",
+			},
+		},
+	}
+
+	got := ExtractRequiredFilesByModel(cfg)
+	if _, ok := got["/opt/external/mmbert"]; ok {
+		t.Fatalf("ExtractRequiredFilesByModel() recorded requirements for non-models/ path: %#v", got)
+	}
+}
+
+func TestExtractRequiredFilesByModelCoversMultiModalIndependentOfBackend(t *testing.T) {
+	// The multimodal initializer branch runs before the backend switch
+	// whenever model_type resolves to "multimodal", so its loader files are
+	// required regardless of the configured backend.
+	cfg := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MmBertModelPath:     "models/mmbert-embed-32k-2d-matryoshka",
+				MultiModalModelPath: "models/mom-embedding-multimodal",
+				EmbeddingConfig: config.HNSWConfig{
+					Backend:   "openvino",
+					ModelType: "multimodal",
+				},
+			},
+		},
+	}
+
+	got := ExtractRequiredFilesByModel(cfg)
+	for _, file := range []string{"model.safetensors", "tokenizer.json"} {
+		if !slices.Contains(got["models/mom-embedding-multimodal"], file) {
+			t.Errorf("multimodal path missing required file %q under openvino backend (map: %#v)", file, got)
+		}
+		if slices.Contains(got["models/mmbert-embed-32k-2d-matryoshka"], file) {
+			t.Errorf("mmbert path gained candle requirement %q under openvino backend (map: %#v)", file, got)
+		}
+	}
+
+	// Without model_type=multimodal the multimodal path gains no requirement.
+	cfg.EmbeddingModels.EmbeddingConfig.ModelType = ""
+	got = ExtractRequiredFilesByModel(cfg)
+	if _, ok := got["models/mom-embedding-multimodal"]; ok {
+		t.Errorf("multimodal path recorded requirements without model_type=multimodal: %#v", got)
+	}
+}
+
+// Regression test for the partial-download poisoning scenario: an interrupted
+// hf download leaves companion artifacts (config.json, nested onnx/ exports)
+// without the root weight files the candle embedding runtime hard-loads.
+// The nested onnx file satisfies the generic weight heuristic, so without the
+// candle-derived RequiredFiles the model reads as complete, is never
+// re-downloaded, and the router crash-loops at classifier init on every
+// restart ("failed to load safetensors from .../model.safetensors").
+func TestPartiallyDownloadedCandleEmbeddingModelIsIncomplete(t *testing.T) {
+	tmpDir := t.TempDir()
+	modelDir := writeModelDir(t, tmpDir, "mmbert-partial", map[string]string{
+		"config.json":                     "{}",
+		"onnx/layer-6/model_fa_fp16.onnx": "",
+	})
+
+	cfg := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MmBertModelPath: "models/mmbert-embed-32k-2d-matryoshka",
+			},
+		},
+	}
+	requiredFiles := append([]string{}, DefaultRequiredFiles...)
+	requiredFiles = append(requiredFiles,
+		ExtractRequiredFilesByModel(cfg)["models/mmbert-embed-32k-2d-matryoshka"]...)
+
+	complete, err := IsModelComplete(modelDir, requiredFiles)
+	if err != nil {
+		t.Fatalf("IsModelComplete() error = %v", err)
+	}
+	if complete {
+		t.Fatal("IsModelComplete() = true for a partial download missing model.safetensors and tokenizer.json, want false")
+	}
+
+	// Once the runtime-required files land, the same model reads as complete.
+	for _, file := range []string{"model.safetensors", "tokenizer.json"} {
+		if writeErr := os.WriteFile(filepath.Join(modelDir, file), []byte(""), 0o644); writeErr != nil {
+			t.Fatalf("WriteFile(%q) failed: %v", file, writeErr)
+		}
+	}
+	complete, err = IsModelComplete(modelDir, requiredFiles)
+	if err != nil {
+		t.Fatalf("IsModelComplete() error = %v", err)
+	}
+	if !complete {
+		t.Fatal("IsModelComplete() = false after weights and tokenizer are present, want true")
+	}
+}
+
+func TestExtractRequiredFilesByModelGemmaIncludesDenseBottleneckWeights(t *testing.T) {
+	cfg := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				GemmaModelPath:  "models/mom-embedding-flash",
+				MmBertModelPath: "models/mmbert-embed-32k-2d-matryoshka",
+			},
+		},
+	}
+
+	got := ExtractRequiredFilesByModel(cfg)
+	for _, file := range []string{"model.safetensors", "tokenizer.json", "2_Dense/model.safetensors", "3_Dense/model.safetensors"} {
+		if !slices.Contains(got["models/mom-embedding-flash"], file) {
+			t.Errorf("gemma path missing required file %q (map: %#v)", file, got)
+		}
+	}
+	for _, file := range []string{"2_Dense/model.safetensors", "3_Dense/model.safetensors"} {
+		if slices.Contains(got["models/mmbert-embed-32k-2d-matryoshka"], file) {
+			t.Errorf("mmbert path gained gemma-only dense requirement %q (map: %#v)", file, got)
+		}
+	}
+}
+
+func TestExtractRequiredFilesByModelCoversMultiModalForImageCandidates(t *testing.T) {
+	// Complexity rules with image_candidates load the multimodal model with
+	// no model_type gate, so the requirement must follow without it.
+	cfg := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MultiModalModelPath: "models/mom-embedding-multimodal",
+			},
+		},
+		IntelligentRouting: config.IntelligentRouting{
+			Signals: config.Signals{
+				ComplexityRules: []config.ComplexityRule{
+					{Hard: config.ComplexityCandidates{ImageCandidates: []string{"a screenshot of code"}}},
+				},
+			},
+		},
+	}
+
+	got := ExtractRequiredFilesByModel(cfg)
+	for _, file := range []string{"model.safetensors", "tokenizer.json"} {
+		if !slices.Contains(got["models/mom-embedding-multimodal"], file) {
+			t.Errorf("multimodal path missing %q under image_candidates trigger (map: %#v)", file, got)
+		}
+	}
+}
+
+func TestExtractRequiredFilesByModelMultiModalEdgeCases(t *testing.T) {
+	// model_type matching is case- and space-insensitive, mirroring the
+	// classification initializer; an empty multimodal path records nothing.
+	cfg := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MultiModalModelPath: "models/mom-embedding-multimodal",
+				EmbeddingConfig:     config.HNSWConfig{ModelType: "  MultiModal "},
+			},
+		},
+	}
+	got := ExtractRequiredFilesByModel(cfg)
+	if !slices.Contains(got["models/mom-embedding-multimodal"], "model.safetensors") {
+		t.Errorf("case/space-insensitive model_type did not trigger multimodal requirement (map: %#v)", got)
+	}
+
+	cfg.EmbeddingModels.MultiModalModelPath = ""
+	got = ExtractRequiredFilesByModel(cfg)
+	if len(got) != 0 {
+		t.Errorf("empty multimodal path recorded requirements: %#v", got)
+	}
+}
+
+func TestBuildModelSpecsIncludesCandleEmbeddingRequiredFiles(t *testing.T) {
+	// End-to-end through BuildModelSpecs: the production path must carry the
+	// candle runtime files into the spec used by GetMissingModels.
+	cfg := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MmBertModelPath: "models/mmbert-embed-32k-2d-matryoshka",
+			},
+		},
+		MoMRegistry: map[string]string{
+			"models/mmbert-embed-32k-2d-matryoshka": "llm-semantic-router/mmbert-embed-32k-2d-matryoshka",
+		},
+	}
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("BuildModelSpecs() returned %d specs, want 1 (%#v)", len(specs), specs)
+	}
+	for _, file := range []string{"config.json", "model.safetensors", "tokenizer.json"} {
+		if !slices.Contains(specs[0].RequiredFiles, file) {
+			t.Errorf("spec.RequiredFiles missing %q (got %#v)", file, specs[0].RequiredFiles)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2531

## Purpose
- Extend the model downloader's completeness contract to everything the candle embedding runtime hard-loads at startup. #2195 (embedding weights+tokenizer completeness) fixed the headline case for the configured semantic embedding model (`mmbert`): a partial download holding only companion artifacts (`config.json`, nested `onnx/` exports) satisfied the generic weight heuristic in `IsModelComplete` (`*.onnx` matches via the recursive walk), was treated as complete, was never re-downloaded, and the router crash-looped at classifier init on every restart.
- This PR covers the rest of the candle runtime's load surface, which has the same non-healing failure shape and is not covered by #2195 (embedding weights+tokenizer completeness):
  - the qwen3 and gemma embedding paths (`model.safetensors` + `tokenizer.json`), with gemma additionally requiring `2_Dense/model.safetensors` and `3_Dense/model.safetensors`, which `BottleneckDenseNet::load_from_path` hard-loads;
  - the multimodal path, required whenever `model_type` resolves to `multimodal` or any complexity rule declares `image_candidates` (both load the multimodal model; the latter has no model_type gate).
- Gating follows the canonical backend resolution (`EmbeddingModels.EmbeddingBackend()`), so the qwen3/gemma/mmbert requirements apply only when the backend resolves to candle. Remote deployments (`openai_compatible`, including `model_type: remote` with no backend set, per #2276 (external embedding providers)) and openvino deployments load none of these files and gain no requirements from this change. (Separately and pre-existing: #2195's mmbert requirement is guarded only against the remote backend, so it still applies under openvino; that interaction predates this PR and is out of scope here.)
- `IsModelComplete` checks `RequiredFiles` before the weight heuristic, so partial downloads read as incomplete and the next startup resumes the download instead of crash-looping.
- Module: `Router` (`pkg/modeldownload`, plus a keep-in-sync comment in `pkg/classification`).
- Scope notes:
  - The generic nested-weight heuristic is intentionally unchanged (it serves nested-onnx layouts and is test-pinned), and #2195's mmbert requirement is left in place; the two mechanisms deduplicate.
  - `bert_model_path` is excluded because its loader has a weight-format fallback chain (`similarity.rs`); the covered loaders hard-code their files with no fallback.
  - All four registry repos for the covered paths ship the required files (verified via the HF tree API, including gemma's `2_Dense/` and `3_Dense/` weights), so the added requirements cannot produce false-incomplete for registry models. The requirements are a deliberate superset: they are recorded for configured paths even when no rule ends up loading the model, so a custom non-registry path that lacks `tokenizer.json` would re-attempt its download on each boot.
  - Two adjacent items remain deliberately out of scope: (1) whatever interrupts the first download (with this fix the state converges across restarts instead of poisoning permanently); (2) `IsGatedModelError` treating token-less download failures as gated-model soft-skips even for public repos, filed as #2107 (gated-model soft-skip). Healing is therefore eventual (next successful retry), not guaranteed-on-first-restart.
  - Residual: completeness checks file existence, not integrity; a truncated root weight file from a non-atomic copy onto a pre-mounted volume would still read complete.

## Test Plan
- `go test ./pkg/modeldownload/` covering: the candle-derived requirements under the canonical backend resolution (empty/candle/case-insensitive add them; openvino, `openai_compatible`, and `model_type: remote` with empty backend do not), gemma's dense-bottleneck files, multimodal coverage independent of backend plus the `image_candidates` trigger and model_type edge cases, a `BuildModelSpecs`-level assertion that specs carry the new requirements, non-`models/` paths skipped, and a regression test reproducing the poisoning scenario at the unit level (partial dir reads incomplete, then complete once the runtime files land).
- No e2e testcase update: there is no existing e2e surface for the model downloader, and the failing precondition (a poisoned volume that predates pod start) does not fit the request-level e2e harness; the cluster A/B below covers the behavior-visible path end to end.
- Cluster A/B on GKE with the `semantic-router` 0.3.0 chart and a pre-seeded poisoned models PVC (`config.json` + `onnx/layer-6/*.onnx` + `.cache/huggingface` metadata, no root weights). Note this A/B predates #2195 (embedding weights+tokenizer completeness) landing on main and demonstrates the shared failure shape on the mmbert path; on current main that specific path heals via #2195, and this PR extends the same healing to the qwen3/gemma/multimodal paths.

## Test Result
- Unit: all `pkg/modeldownload` tests pass, including the pre-existing nested-onnx heuristic cases (intentional behavior preserved) and #2195's completeness tests. `gofmt`, `go vet`, codespell clean. Red-green on the backend-resolution gate: the `model_type: remote` case fails against a hand-rolled empty-means-candle check and passes with the canonical resolution.
- Cluster A/B (GKE, chart 0.3.0, models PVC pre-seeded with `config.json` + `onnx/layer-6/model_fa_fp16.onnx` + `.cache/huggingface` metadata, no root weights; historical run - v0.3.0 predates #2195 (embedding weights+tokenizer completeness) and demonstrates the shared failure shape on the mmbert path):
  - Control (stock `extproc:v0.3.0`): logs `required_models_already_present total_models=4` with no download attempt, then `failed to load safetensors from models/mmbert-embed-32k-2d-matryoshka/model.safetensors: No such file or directory` and `startup_failed`; crash-looped past 7 restarts without ever healing.
  - Treatment (patched image, same volume): logs `Downloading model: models/mmbert-embed-32k-2d-matryoshka`, fetches the repo (with `HF_TOKEN` wired; anonymous downloads rate-limit and the failure is masked by the gated-model soft-skip, #2107 (gated-model soft-skip)), then `keyword_embedding_backend_initialized backend=candle mmbert_2d_enabled=true` and the pod reaches Ready. The previously missing files land on the volume (`model.safetensors` 613892480 bytes, `tokenizer.json` 34363443 bytes).
  - Negative control (restart on the healed volume): `required_models_already_present total_models=4`, zero `Downloading model` lines, Ready with 0 restarts. No false-incomplete loop.
  - Incidental repro of the interruption class: an early treatment run with a low memory limit was OOMKilled mid-fetch, leaving exactly the partial layout this PR detects; with the fix the next boot resumed instead of poisoning.

