### PR TITLE
[Router] request_params strip_unknown: keep valid OpenAI fields and router-injected chat_template_kwargs

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_request_params.go
+++ b/src/semantic-router/pkg/extproc/req_filter_request_params.go
@@ -73,6 +73,9 @@ func (r *OpenAIRouter) buildRequestParamsMutations(
 
 	modified := applyBlockedParams(body, paramsConfig.BlockedParams, decision.Name)
 	modified = capIntField(body, "max_tokens", paramsConfig.MaxTokensLimit, decision.Name, metrics.RecordMaxTokensCapped) || modified
+	// max_completion_tokens is the current OpenAI name for the same knob; cap it
+	// with the same limit so clients cannot bypass max_tokens_limit by renaming.
+	modified = capIntField(body, "max_completion_tokens", paramsConfig.MaxTokensLimit, decision.Name, metrics.RecordMaxTokensCapped) || modified
 	modified = capIntField(body, "n", paramsConfig.MaxN, decision.Name, metrics.RecordMaxNCapped) || modified
 	modified = stripUnknownFields(body, paramsConfig.StripUnknown, decision.Name) || modified
 

--- a/src/semantic-router/pkg/extproc/req_filter_request_params.go
+++ b/src/semantic-router/pkg/extproc/req_filter_request_params.go
@@ -32,6 +32,22 @@ var allowedTopLevelFields = map[string]bool{
 	"tool_choice":       true,
 	"user":              true,
 	"reasoning_effort":  true,
+	// Current OpenAI Chat Completions fields that postdate the original list.
+	"max_completion_tokens": true,
+	"stream_options":        true,
+	"parallel_tool_calls":   true,
+	"metadata":              true,
+	"store":                 true,
+	"prediction":            true,
+	"service_tier":          true,
+	"modalities":            true,
+	"audio":                 true,
+	// Legacy function-calling fields still accepted by OpenAI-compatible backends.
+	"functions":     true,
+	"function_call": true,
+	// Injected by the router's own reasoning mutation; must not be stripped here,
+	// otherwise enabling reasoning together with strip_unknown silently removes it.
+	"chat_template_kwargs": true,
 }
 
 func (r *OpenAIRouter) buildRequestParamsMutations(

--- a/src/semantic-router/pkg/extproc/req_filter_request_params_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_request_params_test.go
@@ -62,3 +62,35 @@ func TestBuildRequestParamsMutationsBlockedAndCaps(t *testing.T) {
 		t.Fatalf("n cap: got %v", body["n"])
 	}
 }
+
+// max_tokens_limit must also cap max_completion_tokens (the current OpenAI
+// name for the same knob). Now that the strip_unknown allowlist passes
+// max_completion_tokens through, leaving it uncapped would let clients bypass
+// the governance limit by simply renaming the field.
+func TestBuildRequestParamsMutationsCapsMaxCompletionTokens(t *testing.T) {
+	r := &OpenAIRouter{}
+	payload, err := config.NewStructuredPayload(map[string]interface{}{
+		"max_tokens_limit": 500,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := &config.Decision{
+		Name: "tier_a",
+		Plugins: []config.DecisionPlugin{
+			{Type: "request_params", Configuration: payload},
+		},
+	}
+	raw := []byte(`{"model":"m","messages":[],"max_completion_tokens":9000}`)
+	out, err := r.buildRequestParamsMutations(decision, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(out, &body); err != nil {
+		t.Fatal(err)
+	}
+	if int(body["max_completion_tokens"].(float64)) != 500 {
+		t.Fatalf("max_completion_tokens cap: got %v", body["max_completion_tokens"])
+	}
+}

--- a/src/semantic-router/pkg/extproc/request_params_strip_allowlist_test.go
+++ b/src/semantic-router/pkg/extproc/request_params_strip_allowlist_test.go
@@ -1,0 +1,36 @@
+//go:build !windows && cgo
+
+package extproc
+
+import "testing"
+
+// strip_unknown must remove genuinely unknown fields but must NOT drop valid
+// OpenAI request parameters or the reasoning parameter (chat_template_kwargs)
+// that the router itself injects upstream.
+func TestStripUnknownKeepsValidParams(t *testing.T) {
+	keep := []string{
+		"max_completion_tokens", // current OpenAI standard (replaces max_tokens)
+		"stream_options",        // OpenAI streaming usage
+		"parallel_tool_calls",   // OpenAI tools
+		"chat_template_kwargs",  // injected by the router's reasoning mutation
+	}
+	body := map[string]interface{}{
+		"model":               "m",
+		"messages":            []interface{}{},
+		"bogus_unknown_field": 1,
+	}
+	for _, k := range keep {
+		body[k] = true
+	}
+
+	stripUnknownFields(body, true, "d1")
+
+	for _, k := range keep {
+		if _, ok := body[k]; !ok {
+			t.Errorf("strip_unknown wrongly removed valid field %q", k)
+		}
+	}
+	if _, ok := body["bogus_unknown_field"]; ok {
+		t.Error("strip_unknown should still remove genuinely unknown fields")
+	}
+}


### PR DESCRIPTION
## What

`request_params` `strip_unknown: true` removed any top-level field absent from a stale `allowedTopLevelFields`, silently dropping valid OpenAI request parameters — and the reasoning parameter the router itself injects.

Fixes #2128.

## Reproduction

Decision with `use_reasoning: true` + `request_params { strip_unknown: true }`. A request with `max_completion_tokens`, `stream_options`, `top_k`, `temperature` reached the backend as just `{messages, model, temperature}` — `max_completion_tokens`, `stream_options`, and the injected `chat_template_kwargs` were all stripped.

## Fix

Extend `allowedTopLevelFields` with current OpenAI fields (`max_completion_tokens`, `stream_options`, `parallel_tool_calls`, `metadata`, `store`, `prediction`, `service_tier`, `modalities`, `audio`), legacy function fields, and `chat_template_kwargs` (router-injected). Genuinely unknown fields are still stripped.

## Test plan

- [x] Added `pkg/extproc/request_params_strip_allowlist_test.go`: valid/injected fields survive strip_unknown; an unknown field is still removed. RED before fix → GREEN.
- [x] `go test ./pkg/extproc/` full suite green (no regression).
- [x] `go vet` + `gofmt` clean; `golangci-lint` (repo config) → 0 issues.
- [x] Reproduced/verified live via `SR_LOG_LEVEL=debug` body-mutation logs.

## Related (deferred, see #2128)

vLLM sampling params (`top_k`, `min_p`, `repetition_penalty`) are also stripped; allowlisting backend-specific params is a maintainer policy decision.

## Notes
- DCO signed-off.


## Follow-up commit: close the cap-bypass this allowlist change would open

Allowlisting `max_completion_tokens` exposed a governance gap: `max_tokens_limit` only capped `max_tokens`, so a client could bypass the limit by renaming the field. Second commit applies the same `max_tokens_limit` cap to `max_completion_tokens` (same metric), with a dedicated unit test (RED→GREEN).
