### PR TITLE
[Router] Validate semantic_cache similarity_threshold range

### DIFF
--- a/src/semantic-router/pkg/config/validator.go
+++ b/src/semantic-router/pkg/config/validator.go
@@ -71,6 +71,11 @@ var (
 			scopes:   configValidationScopeFile | configValidationScopeKubernetes,
 		},
 		{
+			name:     "semantic_cache",
+			validate: validateSemanticCacheContracts,
+			scopes:   configValidationScopeFile | configValidationScopeKubernetes,
+		},
+		{
 			name:     "embedding",
 			validate: validateEmbeddingContracts,
 			scopes:   configValidationScopeFile | configValidationScopeKubernetes,

--- a/src/semantic-router/pkg/config/validator_semantic_cache.go
+++ b/src/semantic-router/pkg/config/validator_semantic_cache.go
@@ -1,0 +1,50 @@
+package config
+
+import "fmt"
+
+// validateSemanticCacheContracts validates the semantic-cache similarity
+// threshold wherever it can be configured: the global semantic_cache block and
+// each decision's semantic-cache plugin.
+//
+// The threshold is a cosine similarity, which is bounded by [0.0, 1.0]. A value
+// outside that range is silently accepted today and reaches the runtime
+// unchanged (GetCacheSimilarityThreshold / GetCacheSimilarityThresholdForDecision
+// do not clamp it). A threshold > 1.0 can never be reached by any similarity, so
+// the cache never hits despite enabled: true — caching is silently disabled.
+// This mirrors the bound the RAG plugin already enforces
+// (validateRAGSimilarityThreshold).
+func validateSemanticCacheContracts(cfg *RouterConfig) error {
+	if cfg == nil {
+		return nil
+	}
+
+	if err := validateCacheThreshold(cfg.SemanticCache.SimilarityThreshold, "global semantic_cache"); err != nil {
+		return err
+	}
+
+	for i := range cfg.Decisions {
+		decision := &cfg.Decisions[i]
+		pluginCfg := decision.GetSemanticCacheConfig()
+		if pluginCfg == nil {
+			continue
+		}
+		scope := fmt.Sprintf("decision %q semantic-cache plugin", decision.Name)
+		if err := validateCacheThreshold(pluginCfg.SimilarityThreshold, scope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateCacheThreshold enforces that a configured cache similarity threshold
+// is a valid cosine similarity in [0.0, 1.0]. A nil pointer means "unset" and is
+// valid (the runtime falls back to a default).
+func validateCacheThreshold(threshold *float32, scope string) error {
+	if threshold == nil {
+		return nil
+	}
+	if *threshold < 0.0 || *threshold > 1.0 {
+		return fmt.Errorf("%s similarity_threshold must be between 0.0 and 1.0, got %.2f", scope, *threshold)
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/config/validator_semantic_cache_test.go
+++ b/src/semantic-router/pkg/config/validator_semantic_cache_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func f32(v float32) *float32 { return &v }
+
+func TestValidateSemanticCacheThresholdRange(t *testing.T) {
+	cases := []struct {
+		name      string
+		threshold *float32
+		wantErr   bool
+	}{
+		{"unset_ok", nil, false},
+		{"zero_ok", f32(0), false},
+		{"mid_ok", f32(0.8), false},
+		{"one_ok", f32(1.0), false},
+		{"above_one_rejected", f32(1.5), true},
+		{"negative_rejected", f32(-0.1), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &RouterConfig{}
+			cfg.SemanticCache.SimilarityThreshold = tc.threshold
+			err := validateSemanticCacheContracts(cfg)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("threshold=%v: wantErr=%v, got err=%v", tc.threshold, tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateSemanticCachePerDecisionThreshold(t *testing.T) {
+	mkDecision := func(name string, threshold float32) Decision {
+		return Decision{
+			Name: name,
+			Plugins: []DecisionPlugin{{
+				Type: "semantic-cache",
+				Configuration: MustStructuredPayload(map[string]interface{}{
+					"enabled":              true,
+					"similarity_threshold": threshold,
+				}),
+			}},
+		}
+	}
+
+	// Valid per-decision threshold passes.
+	okCfg := &RouterConfig{}
+	okCfg.Decisions = []Decision{mkDecision("route_ok", 0.7)}
+	if err := validateSemanticCacheContracts(okCfg); err != nil {
+		t.Fatalf("valid per-decision threshold rejected: %v", err)
+	}
+
+	// Out-of-range per-decision threshold is rejected and names the decision.
+	badCfg := &RouterConfig{}
+	badCfg.Decisions = []Decision{mkDecision("route_bad", 2.0)}
+	err := validateSemanticCacheContracts(badCfg)
+	if err == nil {
+		t.Fatal("out-of-range per-decision threshold must be rejected")
+	}
+	if !strings.Contains(err.Error(), "route_bad") {
+		t.Fatalf("error should name the offending decision, got: %v", err)
+	}
+}
+
+func TestValidateSemanticCacheNilConfig(t *testing.T) {
+	if err := validateSemanticCacheContracts(nil); err != nil {
+		t.Fatalf("nil config must be valid, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

The semantic-cache `similarity_threshold` (cosine, must be in [0,1]) was never validated. A value > 1.0 is accepted at load and returned verbatim at runtime (no clamp), so the cache never hits — caching is silently disabled despite `enabled: true`.

Fixes #2142.

## Fix

Add a `semantic_cache` contract validator (wired into `sharedConfigContractValidators`) that rejects an out-of-range `similarity_threshold` on:
- the global `semantic_cache` block (`cfg.SemanticCache.SimilarityThreshold`), and
- each decision's `semantic-cache` plugin (`decision.GetSemanticCacheConfig().SimilarityThreshold`).

Mirrors the bound the RAG plugin already enforces (`validateRAGSimilarityThreshold`). An unset threshold stays valid (runtime falls back to a default).

`ttl_seconds`/`max_entries` are intentionally **not** range-checked — `0`/negative carry meaning (no-expiry / unlimited) in the backends, so rejecting them would be a false positive.

## Test plan

- [x] `validator_semantic_cache_test.go`: global threshold range table (unset/0/0.8/1.0 ok; 1.5/-0.1 rejected); per-decision out-of-range rejected and error names the decision; nil config ok. RED before fix → GREEN.
- [x] Full `pkg/config` suite green — no shipped config trips the new check (verified all repo `similarity_threshold` values are within [0,1]).
- [x] `gofmt`/`go vet` clean; `golangci-lint` (repo config) → 0 issues.

## Notes
- DCO signed-off. Same validator-hardening family as #2115 / #2123.
