### PR TITLE
[Router] Normalize routing signal type usage checks

### DIFF
--- a/src/semantic-router/pkg/config/routing_signal_usage.go
+++ b/src/semantic-router/pkg/config/routing_signal_usage.go
@@ -5,7 +5,11 @@ import "strings"
 // HasSignalType returns true if the decision's rules tree references at least
 // one signal of the given type (e.g., "jailbreak", "pii").
 func (d *Decision) HasSignalType(signalType string) bool {
-	return len(collectSignalNames(&d.Rules, signalType)) > 0
+	normalizedType := strings.ToLower(strings.TrimSpace(signalType))
+	if normalizedType == "" {
+		return false
+	}
+	return len(collectSignalNames(&d.Rules, normalizedType)) > 0
 }
 
 // UsesSignalTypeInRouting returns true when any routing decision uses the given
@@ -123,7 +127,7 @@ func collectSignalNames(node *RuleNode, signalType string) []string {
 	if node == nil {
 		return nil
 	}
-	if node.Type == signalType && node.Name != "" {
+	if strings.ToLower(strings.TrimSpace(node.Type)) == signalType && node.Name != "" {
 		return []string{node.Name}
 	}
 	var names []string

--- a/src/semantic-router/pkg/config/routing_signal_usage_test.go
+++ b/src/semantic-router/pkg/config/routing_signal_usage_test.go
@@ -2,8 +2,8 @@ package config
 
 import "testing"
 
-func TestNeedsCoreMappingsForRouting(t *testing.T) {
-	cfg := &RouterConfig{
+func newRoutingSignalUsageTestConfig() *RouterConfig {
+	return &RouterConfig{
 		InlineModels: InlineModels{
 			Classifier: Classifier{
 				CategoryModel: CategoryModel{
@@ -44,6 +44,10 @@ func TestNeedsCoreMappingsForRouting(t *testing.T) {
 			},
 		},
 	}
+}
+
+func TestNeedsCoreMappingsForRouting(t *testing.T) {
+	cfg := newRoutingSignalUsageTestConfig()
 
 	tests := []struct {
 		name          string
@@ -80,6 +84,15 @@ func TestNeedsCoreMappingsForRouting(t *testing.T) {
 			decisions: []Decision{{
 				Name:  "safety-route",
 				Rules: RuleNode{Operator: "OR", Conditions: []RuleNode{{Type: SignalTypePII, Name: "contains_pii"}, {Type: SignalTypeJailbreak, Name: "detector"}}},
+			}},
+			wantPII:       true,
+			wantJailbreak: true,
+		},
+		{
+			name: "direct safety signals with mixed case and whitespace",
+			decisions: []Decision{{
+				Name:  "safety-route",
+				Rules: RuleNode{Operator: "OR", Conditions: []RuleNode{{Type: " PII ", Name: "contains_pii"}, {Type: "JailBreak", Name: "detector"}}},
 			}},
 			wantPII:       true,
 			wantJailbreak: true,


### PR DESCRIPTION
## What

Routing-signal usage detection now normalizes direct rule `type` values before comparing them with the requested signal type. This makes direct signal detection consistent with runtime rule evaluation and with the projection usage path, which already compares signal types case-insensitively.

## Why

`UsesSignalTypeInRouting` normalizes the requested signal type, but `collectSignalNames` compared `RuleNode.Type` byte-for-byte. A config using a valid signal type with different casing or surrounding whitespace, such as `type: PII`, could still be evaluated by runtime routing while the preload/usage check returned false. For safety signals, that can skip the PII or jailbreak mapping preload even though routing depends on those signals.

## Fix

- Normalize `Decision.HasSignalType` inputs with `strings.ToLower(strings.TrimSpace(...))`.
- Normalize direct rule node types inside `collectSignalNames`.
- Add a regression test covering mixed-case and whitespace-padded PII/jailbreak rule types.

## Test plan

- RED before fix: `GOCACHE=/tmp/semantic-router-go-build go test ./pkg/config -run TestNeedsCoreMappingsForRouting -count=1`
- GREEN after fix: `GOCACHE=/tmp/semantic-router-go-build go test ./pkg/config -run TestNeedsCoreMappingsForRouting -count=1`
- Package check: `GOCACHE=/tmp/semantic-router-go-build go test ./pkg/config -count=1`
