### PR TITLE
[Router] Support comma-separated auto model names

### DIFF
--- a/src/semantic-router/pkg/apiserver/route_models.go
+++ b/src/semantic-router/pkg/apiserver/route_models.go
@@ -21,9 +21,8 @@ func (s *ClassificationAPIServer) handleOpenAIModels(w http.ResponseWriter, _ *h
 
 	// Add the effective auto model name (configured or default "MoM")
 	if cfg != nil {
-		effectiveAutoModelName := cfg.GetEffectiveAutoModelName()
 		models = append(models, OpenAIModel{
-			ID:          effectiveAutoModelName,
+			ID:          cfg.GetEffectiveAutoModelName(),
 			Object:      "model",
 			Created:     now,
 			OwnedBy:     "vllm-semantic-router",
@@ -44,7 +43,7 @@ func (s *ClassificationAPIServer) handleOpenAIModels(w http.ResponseWriter, _ *h
 	if cfg != nil && cfg.IncludeConfigModelsInList {
 		for _, m := range cfg.GetAllModels() {
 			// Skip if already added as the configured auto model name (avoid duplicates)
-			if m == cfg.GetEffectiveAutoModelName() {
+			if cfg.IsAutoModelName(m) {
 				continue
 			}
 			models = append(models, OpenAIModel{

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -167,6 +167,8 @@ type LLMObservability struct {
 }
 
 type RouterOptions struct {
+	// AutoModelName supports comma-separated names to trigger automatic routing.
+	// The first name is the primary model ID returned by /v1/models.
 	AutoModelName             string               `yaml:"auto_model_name,omitempty"`
 	IncludeConfigModelsInList bool                 `yaml:"include_config_models_in_list,omitempty"`
 	ClearRouteCache           bool                 `yaml:"clear_route_cache"`

--- a/src/semantic-router/pkg/config/config_test.go
+++ b/src/semantic-router/pkg/config/config_test.go
@@ -2262,6 +2262,15 @@ api:
 				cfg := &RouterConfig{}
 				Expect(cfg.GetEffectiveAutoModelName()).To(Equal("MoM"))
 			})
+
+			It("should return the first comma-separated AutoModelName as primary", func() {
+				cfg := &RouterConfig{
+					RouterOptions: RouterOptions{
+						AutoModelName: "MoM, MoM[1M], router",
+					},
+				}
+				Expect(cfg.GetEffectiveAutoModelName()).To(Equal("MoM"))
+			})
 		})
 
 		Context("IsAutoModelName", func() {
@@ -2311,6 +2320,33 @@ api:
 				Expect(cfg.IsAutoModelName("auto")).To(BeTrue())
 				Expect(cfg.IsAutoModelName("MoM")).To(BeTrue())
 				Expect(cfg.IsAutoModelName("other")).To(BeFalse())
+			})
+
+			It("should recognize comma-separated AutoModelName values", func() {
+				cfg := &RouterConfig{
+					RouterOptions: RouterOptions{
+						AutoModelName: "MoM, MoM[1M], router",
+					},
+				}
+				Expect(cfg.GetEffectiveAutoModelNames()).To(Equal([]string{
+					"auto", "MoM", "MoM[1M]", "router",
+				}))
+				Expect(cfg.IsAutoModelName("auto")).To(BeTrue())
+				Expect(cfg.IsAutoModelName("MoM")).To(BeTrue())
+				Expect(cfg.IsAutoModelName("MoM[1M]")).To(BeTrue())
+				Expect(cfg.IsAutoModelName("router")).To(BeTrue())
+				Expect(cfg.IsAutoModelName("gpt-4")).To(BeFalse())
+			})
+
+			It("should trim whitespace and ignore empty AutoModelName entries", func() {
+				cfg := &RouterConfig{
+					RouterOptions: RouterOptions{
+						AutoModelName: "  MoM  , ,  MoM[1M]  ",
+					},
+				}
+				Expect(cfg.GetEffectiveAutoModelNames()).To(Equal([]string{
+					"auto", "MoM", "MoM[1M]",
+				}))
 			})
 		})
 

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -69,23 +69,52 @@ func (c *RouterConfig) resolveModelConfigKey(modelName string) (string, bool) {
 	return "", false
 }
 
-// GetEffectiveAutoModelName returns the effective auto model name for automatic model selection
-// Returns the configured AutoModelName if set, otherwise defaults to "MoM"
-// This is the primary model name that triggers automatic routing
+// GetEffectiveAutoModelName returns the primary auto model name for automatic model selection.
+// Returns the first configured AutoModelName if set, otherwise defaults to "MoM".
 func (c *RouterConfig) GetEffectiveAutoModelName() string {
-	if c.AutoModelName != "" {
-		return c.AutoModelName
+	names := c.GetEffectiveAutoModelNames()
+	if len(names) > 1 {
+		return names[1]
 	}
-	return "MoM" // Default value
+	return "MoM"
 }
 
-// IsAutoModelName checks if the given model name should trigger automatic model selection
-// Returns true if the model name is either the configured AutoModelName or "auto" (for backward compatibility)
-func (c *RouterConfig) IsAutoModelName(modelName string) bool {
-	if modelName == "auto" {
-		return true // Always support "auto" for backward compatibility
+// GetEffectiveAutoModelNames returns all effective auto model names for automatic model selection.
+// Supports comma-separated AutoModelName values, plus "auto" for backward compatibility.
+func (c *RouterConfig) GetEffectiveAutoModelNames() []string {
+	raw := c.AutoModelName
+	if raw == "" {
+		raw = "MoM"
 	}
-	return modelName == c.GetEffectiveAutoModelName()
+
+	names := []string{"auto"}
+	seen := map[string]struct{}{"auto": {}}
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+
+	if len(names) == 1 {
+		names = append(names, "MoM")
+	}
+	return names
+}
+
+// IsAutoModelName checks if the given model name should trigger automatic model selection.
+func (c *RouterConfig) IsAutoModelName(modelName string) bool {
+	for _, name := range c.GetEffectiveAutoModelNames() {
+		if modelName == name {
+			return true
+		}
+	}
+	return false
 }
 
 // GetCategoryDescriptions returns all category descriptions for similarity matching

--- a/src/semantic-router/pkg/extproc/req_filter_models.go
+++ b/src/semantic-router/pkg/extproc/req_filter_models.go
@@ -34,9 +34,8 @@ func (r *OpenAIRouter) handleModelsRequest(_ string) (*ext_proc.ProcessingRespon
 
 	// Add the effective auto model name (configured or default "MoM")
 	if r.Config != nil {
-		effectiveAutoModelName := r.Config.GetEffectiveAutoModelName()
 		models = append(models, OpenAIModel{
-			ID:          effectiveAutoModelName,
+			ID:          r.Config.GetEffectiveAutoModelName(),
 			Object:      "model",
 			Created:     now,
 			OwnedBy:     "vllm-semantic-router",
@@ -59,7 +58,7 @@ func (r *OpenAIRouter) handleModelsRequest(_ string) (*ext_proc.ProcessingRespon
 	if r.Config != nil && r.Config.IncludeConfigModelsInList {
 		for _, m := range r.Config.GetAllModels() {
 			// Skip if already added as the configured auto model name (avoid duplicates)
-			if m == r.Config.GetEffectiveAutoModelName() {
+			if r.Config.IsAutoModelName(m) {
 				continue
 			}
 			models = append(models, OpenAIModel{


### PR DESCRIPTION
## Summary

- support comma-separated `auto_model_name` values while keeping the YAML field as a string
- keep `auto` as a built-in alias and expose the first configured name as the primary `/v1/models` ID
- skip all configured auto-model aliases when appending config models to `/v1/models`

Closes #2116

## Testing

- `GOCACHE=/tmp/semantic-router-go-build go test ./pkg/config -run TestConfig -count=1`
- `git diff --check`

## Notes

I also attempted compile checks for `./pkg/apiserver ./pkg/extproc`, but this local environment is missing native binding artifacts such as `libcandle_semantic_router`, so those packages fail at link time before running tests.