### PR TITLE
[Dashboard] Use dropdown for embedding aggregation method

### DIFF
--- a/dashboard/frontend/src/pages/ConfigPageSignalsSection.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageSignalsSection.tsx
@@ -771,8 +771,8 @@ export default function ConfigPageSignalsSection({
       {
         name: 'aggregation_method',
         label: 'Aggregation Method (embeddings only)',
-        type: 'text',
-        placeholder: 'mean',
+        type: 'select',
+        options: ['mean', 'max', 'any'],
         shouldHide: conditionallyHideFieldExceptType('Embeddings')
       },
       {


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes N/A

## Purpose

- Change the Dashboard config signal editor so the embedding signal `Aggregation Method` field uses a dropdown instead of a free-text input.
- This prevents users from entering unsupported aggregation values and makes the supported options discoverable in the UI.
- The dropdown uses the router-supported aggregation enum values: `mean`, `max`, and `any`.
- Affected module(s): `Dashboard`

## Test Plan

- Run `make dashboard-check`.
- This is sufficient for this scoped Dashboard config UI change because it covers frontend linting, TypeScript type-checking, frontend unit tests, dashboard backend linting, and dashboard backend module tidy checks.
- No router runtime behavior is changed; this PR only changes the schema-driven form control used by the Dashboard signal editor.

## Test Result

- `make dashboard-check` passed.
- The command completed:
  - dashboard frontend lint passed
  - dashboard frontend type-check passed
  - dashboard frontend unit tests passed
  - dashboard backend lint passed
  - dashboard backend go mod tidy check passed
- Existing npm audit and Sass/Svelte deprecation warnings were printed during dependency/build steps, but they are unrelated to this PR and did not fail the check.
- No follow-up blockers identified.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.