### PR TITLE
[Router] preserve thinking and tool_choice.disable_parallel_tool_use on Anthropic→Anthropic path

### DIFF
--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -123,6 +123,7 @@ func ToAnthropicRequestBodyWithPassthrough(openAIRequest *openai.ChatCompletionN
 	applyToolResultPassthrough(params.Messages, pt)
 	applySampling(&params, openAIRequest, pt)
 	applyMetadata(&params, openAIRequest, pt)
+	applyThinking(&params, pt)
 
 	return json.Marshal(params)
 }

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -224,6 +224,45 @@ func TestReplay_ThinkingRoundTripFromRawBody(t *testing.T) {
 	assert.Equal(t, int64(2048), gjson.GetBytes(body, "thinking.budget_tokens").Int())
 }
 
+// TestReplay_ToolChoiceDisableParallel verifies the
+// tool_choice.disable_parallel_tool_use flag survives the
+// Anthropic→IR→Anthropic round-trip. Inbound mirrors it onto the OpenAI
+// parallel_tool_calls field; without applyDisableParallelToolUse on the
+// outbound side it would be silently dropped and the backend would run tools
+// in parallel against the client's explicit request.
+func TestReplay_ToolChoiceDisableParallel(t *testing.T) {
+	tools := `"tools":[{"name":"w","description":"d","input_schema":{"type":"object"}}]`
+	cases := []struct {
+		name    string
+		choice  string
+		wantSet bool
+	}{
+		{"any_disabled", `{"type":"any","disable_parallel_tool_use":true}`, true},
+		{"tool_disabled", `{"type":"tool","name":"w","disable_parallel_tool_use":true}`, true},
+		{"any_default", `{"type":"any"}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := []byte(`{"model":"claude-sonnet-4-5","max_tokens":50,` + tools +
+				`,"tool_choice":` + tc.choice + `,"messages":[{"role":"user","content":"hi"}]}`)
+			params, _, err := ParseAnthropicRequest(raw)
+			require.NoError(t, err)
+			pt, err := BuildPassthroughFromAnthropicBody(raw)
+			require.NoError(t, err)
+
+			body, err := ToAnthropicRequestBodyWithPassthrough(params, pt)
+			require.NoError(t, err)
+
+			got := gjson.GetBytes(body, "tool_choice.disable_parallel_tool_use")
+			if tc.wantSet {
+				assert.True(t, got.Exists() && got.Bool(), "disable_parallel_tool_use must round-trip as true")
+			} else {
+				assert.False(t, got.Exists(), "disable_parallel_tool_use must stay omitted when not set")
+			}
+		})
+	}
+}
+
 func TestReplay_MetadataUserID(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		Model:    "claude-sonnet-4-5",

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -170,6 +170,60 @@ func TestReplay_TopK_OmittedWhenNil(t *testing.T) {
 	assert.False(t, gjson.GetBytes(body, "top_k").Exists())
 }
 
+func TestReplay_ThinkingEnabled(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	pt := &AnthropicPassthrough{Thinking: &ThinkingConfig{Type: "enabled", BudgetTokens: 2048}}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	assert.Equal(t, "enabled", gjson.GetBytes(body, "thinking.type").String())
+	assert.Equal(t, int64(2048), gjson.GetBytes(body, "thinking.budget_tokens").Int())
+}
+
+func TestReplay_ThinkingDisabled(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	pt := &AnthropicPassthrough{Thinking: &ThinkingConfig{Type: "disabled"}}
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, pt)
+	require.NoError(t, err)
+	assert.Equal(t, "disabled", gjson.GetBytes(body, "thinking.type").String())
+	// budget_tokens has no meaning for disabled and must not be emitted.
+	assert.False(t, gjson.GetBytes(body, "thinking.budget_tokens").Exists())
+}
+
+func TestReplay_ThinkingOmittedWhenNil(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:    "claude-sonnet-4-5",
+		Messages: []openai.ChatCompletionMessageParamUnion{userStringMessage("hi")},
+	}
+	body, err := ToAnthropicRequestBodyWithPassthrough(req, &AnthropicPassthrough{})
+	require.NoError(t, err)
+	assert.False(t, gjson.GetBytes(body, "thinking").Exists())
+}
+
+// TestReplay_ThinkingRoundTripFromRawBody is the end-to-end transparency
+// check: a raw Anthropic request carrying thinking, parsed and rebuilt through
+// the full passthrough pipeline, must preserve the field verbatim. This is the
+// path that was silently dropping thinking before the applyThinking fix.
+func TestReplay_ThinkingRoundTripFromRawBody(t *testing.T) {
+	raw := []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":2048},"messages":[{"role":"user","content":"hi"}]}`)
+	params, _, err := ParseAnthropicRequest(raw)
+	require.NoError(t, err)
+	pt, err := BuildPassthroughFromAnthropicBody(raw)
+	require.NoError(t, err)
+
+	body, err := ToAnthropicRequestBodyWithPassthrough(params, pt)
+	require.NoError(t, err)
+	assert.Equal(t, "enabled", gjson.GetBytes(body, "thinking.type").String())
+	assert.Equal(t, int64(2048), gjson.GetBytes(body, "thinking.budget_tokens").Int())
+}
+
 func TestReplay_MetadataUserID(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		Model:    "claude-sonnet-4-5",

--- a/src/semantic-router/pkg/anthropic/passthrough.go
+++ b/src/semantic-router/pkg/anthropic/passthrough.go
@@ -40,6 +40,13 @@ type AnthropicPassthrough struct {
 	// on inbound; do not emit".
 	TopK *int64
 
+	// Thinking preserves the Anthropic extended-thinking request parameter
+	// (type + budget_tokens). It has no OpenAI representation, so without this
+	// carrier it would be silently dropped on the Anthropic→Anthropic path and
+	// the backend would not enable extended thinking. nil means "not set on
+	// inbound; do not emit".
+	Thinking *ThinkingConfig
+
 	// MetadataUserID populates metadata.user_id on the outbound body. Empty
 	// means "do not emit".
 	MetadataUserID string
@@ -83,6 +90,14 @@ type SystemBlock struct {
 type CacheControlSpec struct {
 	Type string
 	TTL  string
+}
+
+// ThinkingConfig captures the Anthropic extended-thinking request parameter.
+// Type is "enabled" or "disabled"; BudgetTokens is only meaningful (and only
+// emitted) when Type is "enabled".
+type ThinkingConfig struct {
+	Type         string
+	BudgetTokens int64
 }
 
 // ToolResultContentBlock represents one block of a tool_result content array.
@@ -164,6 +179,15 @@ func captureSamplingAndMetadata(raw []byte, pt *AnthropicPassthrough) {
 	}
 	if v := gjson.GetBytes(raw, "metadata.user_id"); v.Exists() && v.Type == gjson.String {
 		pt.MetadataUserID = v.String()
+	}
+	if v := gjson.GetBytes(raw, "thinking"); v.Exists() {
+		if tType := v.Get("type").String(); tType != "" {
+			tc := &ThinkingConfig{Type: tType}
+			if b := v.Get("budget_tokens"); b.Exists() && b.Type == gjson.Number {
+				tc.BudgetTokens = b.Int()
+			}
+			pt.Thinking = tc
+		}
 	}
 }
 

--- a/src/semantic-router/pkg/anthropic/request_body.go
+++ b/src/semantic-router/pkg/anthropic/request_body.go
@@ -87,6 +87,25 @@ func applyMetadata(params *anthropic.MessageNewParams, req *openai.ChatCompletio
 	params.Metadata = anthropic.MetadataParam{UserID: anthropic.String(userID)}
 }
 
+// applyThinking restores the Anthropic extended-thinking request parameter from
+// the passthrough. The thinking config has no OpenAI representation, so without
+// this the same-protocol (Anthropic→Anthropic) path would silently drop it and
+// the backend would not enable extended thinking. nil passthrough or unset
+// Thinking is a no-op, leaving the field omitted.
+func applyThinking(params *anthropic.MessageNewParams, pt *AnthropicPassthrough) {
+	if pt == nil || pt.Thinking == nil {
+		return
+	}
+	switch pt.Thinking.Type {
+	case "enabled":
+		params.Thinking = anthropic.ThinkingConfigParamOfEnabled(pt.Thinking.BudgetTokens)
+	case "disabled":
+		params.Thinking = anthropic.ThinkingConfigParamUnion{
+			OfDisabled: &anthropic.ThinkingConfigDisabledParam{},
+		}
+	}
+}
+
 // applyToolsCacheControl attaches cache_control markers to tool definitions
 // based on the `tools[i]` keys in the passthrough.
 func applyToolsCacheControl(params *anthropic.MessageNewParams, pt *AnthropicPassthrough) {

--- a/src/semantic-router/pkg/anthropic/request_body.go
+++ b/src/semantic-router/pkg/anthropic/request_body.go
@@ -523,9 +523,31 @@ func applyOpenAIToolsToAnthropicParams(
 
 	toolChoice, hasChoice := openAIToolChoiceToAnthropic(openAIRequest.ToolChoice)
 	if hasChoice {
+		applyDisableParallelToolUse(&toolChoice, openAIRequest)
 		params.ToolChoice = toolChoice
 	}
 	return nil
+}
+
+// applyDisableParallelToolUse restores the Anthropic
+// tool_choice.disable_parallel_tool_use flag from the OpenAI
+// parallel_tool_calls field. Inbound maps Anthropic
+// disable_parallel_tool_use:true onto parallel_tool_calls:false; without this
+// the flag would be silently dropped on the Anthropic→Anthropic path, so a
+// client that asked the backend to serialize tool calls would not get it. Only
+// an explicit false triggers the flag (parallel is the Anthropic default).
+func applyDisableParallelToolUse(choice *anthropic.ToolChoiceUnionParam, req *openai.ChatCompletionNewParams) {
+	if req == nil || !req.ParallelToolCalls.Valid() || req.ParallelToolCalls.Value {
+		return
+	}
+	switch {
+	case choice.OfAuto != nil:
+		choice.OfAuto.DisableParallelToolUse = anthropic.Bool(true)
+	case choice.OfAny != nil:
+		choice.OfAny.DisableParallelToolUse = anthropic.Bool(true)
+	case choice.OfTool != nil:
+		choice.OfTool.DisableParallelToolUse = anthropic.Bool(true)
+	}
 }
 
 func openAIToolsToAnthropic(tools []openai.ChatCompletionToolParam) ([]anthropic.ToolUnionParam, error) {


### PR DESCRIPTION
## Summary
Fixes two same-protocol (Anthropic client → Anthropic backend) **transparency drops**: request parameters captured on inbound but never restored on the outbound request body, so they were silently lost with no signal to the client. On the same-protocol path every client-supplied field should reach the backend verbatim.

Both fields have no OpenAI representation, so neither can ride the OpenAI IR the way temperature/top_p do — they were falling through the translation.

### 1. `thinking` request parameter
- `convertThinking` writes `ext.Thinking` on inbound, but the outbound builder had no step reading it back → extended thinking never enabled on the backend.
- Fix: carry `thinking` on the `AnthropicPassthrough` sidecar (same mechanism as `top_k`/`metadata.user_id`); restore via a new `applyThinking` step mapping `enabled` (with `budget_tokens`) and `disabled` through the SDK's `ThinkingConfig` union.

### 2. `tool_choice.disable_parallel_tool_use`
- Inbound mirrors Anthropic `disable_parallel_tool_use:true` onto OpenAI `parallel_tool_calls:false`, but the outbound `openAIToolChoiceToAnthropic` never restored it → a client asking the backend to serialize tool calls got parallel execution.
- Fix: `applyDisableParallelToolUse` reads `parallel_tool_calls` and sets the flag on whichever ToolChoice variant (auto/any/tool) is active, only when explicitly false (parallel is the Anthropic default).

The `tool_choice` *type* mapping (auto/any/tool, named function) and per-tool `cache_control` already round-trip correctly — verified, no change needed.

## Risk
Low. Both fixes are no-ops when the field is unset (nil passthrough / omitted thinking / parallel default), so all existing callers are byte-identical.

## Verification
Each drop was reproduced before fixing (raw body → parse → rebuild produced no field), then confirmed restored. Unit tests cover:
- thinking: enabled / disabled / omitted / full raw-body round-trip
- disable_parallel: any+disabled / tool+disabled / default-omitted

## Test plan
- `make agent-lint CHANGED_FILES="<paths>"` (vet, fmt, golangci-lint, codespell): pass
- `go test ./pkg/anthropic/`: pass, no regressions

## Notes
Pairs with the e2e transparency suite in #2038 (shim-backed assertions for image/top_k/metadata/tool_result/stop_sequences/temperature/top_p). Shim-backed e2e assertions for `thinking` and `disable_parallel_tool_use` are a natural addition to that suite once both land.