### PR TITLE
[Router] fix router_replay history 413 on large requests (bound list response + safer default)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -702,11 +702,13 @@ routing:
             capture_request_body: true
             capture_response_body: true
             max_body_bytes: 4096
-            # 0 = no truncation (the documented default). Set to a positive
-            # byte cap to independently limit structured tool-trace fields
-            # (prompt, tool_definitions, and each tool-call's arguments/output)
-            # without having to shrink max_body_bytes.
-            max_tool_trace_bytes: 0
+            # Caps structured tool-trace fields (prompt, tool_definitions, and
+            # each tool-call's arguments/output) independently of max_body_bytes.
+            # Defaults to 4096; a large request would otherwise produce a
+            # multi-MB prompt that breaks the /v1/router_replay history list with
+            # a 413. Set to 0 for no truncation (full structured fields, at the
+            # risk of oversized history responses).
+            max_tool_trace_bytes: 4096
             # Cap the number of tool-trace steps retained per record. Long
             # agent sessions (many sequential tool calls) can otherwise grow
             # the trace unbounded and OOM the router (#1835). 0 = no cap.

--- a/e2e/profiles/router-replay/profile.go
+++ b/e2e/profiles/router-replay/profile.go
@@ -62,6 +62,7 @@ func (p *Profile) GetTestCases() []string {
 		"router-replay-restart-recovery",
 		"router-replay-session-list-filter",
 		"router-replay-session-turn-progression",
+		"router-replay-large-request-list-ok",
 	}
 }
 

--- a/e2e/testcases/router_replay_large_request.go
+++ b/e2e/testcases/router_replay_large_request.go
@@ -1,0 +1,91 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("router-replay-large-request-list-ok", pkgtestcases.TestCase{
+		Description: "GET /v1/router_replay returns 200 (not 413) after a large request is recorded",
+		Tags:        []string{"router-replay", "functional", "router-replay-api"},
+		Fn:          testRouterReplayLargeRequestListOK,
+	})
+}
+
+// testRouterReplayLargeRequestListOK is the end-to-end regression for the
+// history-list 413: a large chat request is recorded, then the replay list
+// endpoint is queried. Before the fix a single multi-MB request produced a
+// replay record whose structured fields pushed the serialized page past the
+// ext-proc message-size cap, so GET /v1/router_replay returned 413 and the
+// whole history view broke. The list endpoint must now stay 200 and remain
+// listable regardless of how large the recorded request was.
+func testRouterReplayLargeRequestListOK(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Router replay: large request must not 413 the history list")
+	}
+	session, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return fmt.Errorf("open session: %w", err)
+	}
+	defer session.Close()
+
+	sess := fmt.Sprintf("e2e_large_%d", time.Now().UnixNano())
+	user := "e2e-replay-large-user"
+
+	// ~5 MB of user content — the size class that triggered the reported 413.
+	largeContent := "router replay large-request regression " + sess + " " +
+		strings.Repeat("x", 5*1024*1024)
+
+	if err := postChatCompletionsWithReplayHeaders(ctx, session, postChatOpts{
+		sessionID: sess,
+		userID:    user,
+		content:   largeContent,
+	}); err != nil {
+		return fmt.Errorf("post large chat completion: %w", err)
+	}
+	time.Sleep(2 * time.Second)
+
+	// The list endpoint must return 200, not 413, and the page must decode.
+	q := "limit=25&offset=0"
+	httpClient := session.HTTPClient(30 * time.Second)
+	raw, err := fixtures.DoGETRequest(ctx, httpClient, session.BaseURL()+"/v1/router_replay?"+q)
+	if err != nil {
+		return fmt.Errorf("GET router_replay list: %w", err)
+	}
+	if raw.StatusCode == http.StatusRequestEntityTooLarge {
+		return fmt.Errorf("router_replay list returned 413 after a large request was recorded (the bug this guards against)")
+	}
+	if raw.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET router_replay list status %d: %s", raw.StatusCode, truncateE2EBody(raw.Body))
+	}
+
+	var listResp replayListResponse
+	if err := raw.DecodeJSON(&listResp); err != nil {
+		return fmt.Errorf("decode list after large request: %w", err)
+	}
+	if listResp.Count == 0 {
+		return fmt.Errorf("expected at least one replay row after recording a large request, got 0")
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] large-request replay list ok: status=200 count=%d\n", listResp.Count)
+	}
+	return nil
+}
+
+// truncateE2EBody keeps error output readable when the body is large.
+func truncateE2EBody(body []byte) string {
+	const max = 200
+	if len(body) <= max {
+		return string(body)
+	}
+	return string(body[:max]) + "...(truncated)"
+}

--- a/src/semantic-router/pkg/config/plugin_config_test.go
+++ b/src/semantic-router/pkg/config/plugin_config_test.go
@@ -220,6 +220,13 @@ func registerEffectiveRouterReplayConfigForDecisionSpecs() {
 		Expect(replayCfg.CaptureRequestBody).To(BeTrue())
 		Expect(replayCfg.CaptureResponseBody).To(BeTrue())
 		Expect(replayCfg.MaxBodyBytes).To(Equal(4096))
+		// MaxToolTraceBytes must default to a positive cap: the structured
+		// fields (prompt, tool_definitions) are extracted from the full request
+		// before MaxBodyBytes truncation, so leaving this unbounded lets a large
+		// request produce a multi-MB prompt that breaks the /v1/router_replay
+		// history list with a 413. Mirrors MaxBodyBytes.
+		Expect(replayCfg.MaxToolTraceBytes).To(Equal(4096))
+		Expect(replayCfg.MaxToolTraceSteps).To(Equal(100))
 	})
 
 	Describe("decision plugin overrides", registerRouterReplayPluginOverrideSpecs)

--- a/src/semantic-router/pkg/config/plugin_router_replay_support.go
+++ b/src/semantic-router/pkg/config/plugin_router_replay_support.go
@@ -5,6 +5,19 @@ import "github.com/vllm-project/semantic-router/src/semantic-router/pkg/observab
 const (
 	defaultRouterReplayMaxRecords   = 10000
 	defaultRouterReplayMaxBodyBytes = 4096
+	// defaultRouterReplayMaxToolTraceBytes caps each structured text field
+	// (Prompt, ToolDefinitions, and per-step tool-trace Arguments/Output) by
+	// default. Without a default these fields are unbounded (0 = no limit):
+	// they are extracted from the *full* request before MaxBodyBytes truncation,
+	// so a single large request (e.g. a 10 MB input) produces a multi-MB Prompt
+	// that survives in the record. A page of such records then exceeds the
+	// ext-proc message-size cap, and the /v1/router_replay list endpoint returns
+	// 413 — breaking the history view for everyone (reported by internal users).
+	// Mirroring the raw-body budget (4096) keeps prompts useful for debugging
+	// while bounding growth, consistent with the MaxBodyBytes and
+	// MaxToolTraceSteps defaults. Operators who need fuller structured fields
+	// can raise or zero (unlimited) this explicitly.
+	defaultRouterReplayMaxToolTraceBytes = 4096
 	// defaultRouterReplayMaxToolTraceSteps caps the per-record tool-trace
 	// step count by default so an agentic session that loops forever can't
 	// drive the router to OOM (see #1835). 100 covers normal multi-tool
@@ -20,6 +33,7 @@ func DefaultRouterReplayPluginConfig() RouterReplayPluginConfig {
 		CaptureRequestBody:  true,
 		CaptureResponseBody: true,
 		MaxBodyBytes:        defaultRouterReplayMaxBodyBytes,
+		MaxToolTraceBytes:   defaultRouterReplayMaxToolTraceBytes,
 		MaxToolTraceSteps:   defaultRouterReplayMaxToolTraceSteps,
 	}
 }

--- a/src/semantic-router/pkg/extproc/router_replay_api.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
@@ -105,7 +106,106 @@ func (r *OpenAIRouter) handleRouterReplayListAPI(method string, rawQuery string)
 
 	records := filterRouterReplayRecords(r.collectRouterReplayRecords(), query.filters)
 	payload := buildRouterReplayListPayload(records, query)
+	boundRouterReplayListPayloadSize(&payload)
 	return r.createRouterReplayJSONResponse(200, payload)
+}
+
+// boundRouterReplayListPayloadSize guarantees the list page serializes under
+// the ext-proc message-size cap regardless of per-record capture config.
+//
+// The list response embeds whole records, and the heavy text fields
+// (tool-trace step Arguments/Output, request/response bodies, prompt,
+// tool_definitions) are individually capped only by the replay capture policy
+// — which an operator may raise or disable (max_tool_trace_bytes: 0). A single
+// large request, or a long agent tool-trace under the default config, can
+// therefore push a normal page past the cap. Hard-failing the whole history
+// list with a 413 in that case is the wrong behavior for a read endpoint, so
+// this trims the heaviest fields on the page records (which are clones from the
+// store, never the stored originals) until the page fits, setting the existing
+// *_truncated flags so callers can see fidelity was reduced for transport. Full
+// fidelity remains available via the single-record GET /v1/router_replay/{id}.
+//
+// Trimming order is heaviest-first so the cheapest loss of fidelity is taken
+// first: per-step tool-trace text, then response/request bodies, then the
+// structured prompt and tool definitions.
+func boundRouterReplayListPayloadSize(payload *routerReplayListResponse) {
+	if listPayloadSizeWithinLimit(*payload) {
+		return
+	}
+	// Budget per heavy field per record, shrunk on each pass until the page
+	// fits or we reach a hard floor. A floor keeps each record minimally useful
+	// (id, decision, metadata, a snippet of each text field) rather than
+	// blanking them entirely.
+	for _, budget := range []int{4096, 1024, 256, 0} {
+		for i := range payload.Data {
+			trimRoutingRecordForList(&payload.Data[i], budget)
+		}
+		if listPayloadSizeWithinLimit(*payload) {
+			return
+		}
+	}
+	// Even fully trimmed the page is too large (pathological: a huge page of
+	// records whose non-text metadata alone exceeds the cap). Fall back to
+	// halving the page until it fits, recording the reduced count.
+	for len(payload.Data) > 1 && !listPayloadSizeWithinLimit(*payload) {
+		keep := len(payload.Data) / 2
+		payload.Data = payload.Data[:keep]
+		payload.Count = keep
+		payload.HasMore = true
+		nextOffset := payload.Offset + keep
+		payload.NextOffset = &nextOffset
+	}
+}
+
+// listPayloadSizeWithinLimit reports whether the payload serializes (as the
+// ext-proc immediate response) within the size cap. It measures the same
+// proto envelope createRouterReplayJSONResponse will emit.
+func listPayloadSizeWithinLimit(payload routerReplayListResponse) bool {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return false
+	}
+	// The immediate-response envelope adds fixed framing around the JSON body;
+	// measuring the JSON length against the cap is a safe lower bound, and the
+	// final proto.Size check in createRouterReplayJSONResponse remains the
+	// authoritative gate.
+	return len(body) <= routerReplayMaxImmediateResponseMB
+}
+
+// trimRoutingRecordForList shrinks the heavy text fields of a single list
+// record to at most budget bytes each, setting the matching *_truncated flag
+// when it cuts. budget == 0 trims the fields to empty (flag still set). The
+// record is a per-request clone, so this never mutates the stored original.
+func trimRoutingRecordForList(record *routerreplay.RoutingRecord, budget int) {
+	if record.ToolTrace != nil {
+		for i := range record.ToolTrace.Steps {
+			trimToolTraceStepForList(&record.ToolTrace.Steps[i], budget)
+		}
+	}
+	truncateListField(&record.ResponseBody, &record.ResponseBodyTruncated, budget)
+	truncateListField(&record.RequestBody, &record.RequestBodyTruncated, budget)
+	truncateListField(&record.Prompt, &record.PromptTruncated, budget)
+	truncateListField(&record.ToolDefinitions, &record.ToolDefinitionsTruncated, budget)
+}
+
+// trimToolTraceStepForList trims every free-text field a tool-trace step can
+// carry (each can hold a full message or tool payload) to budget bytes,
+// flagging Truncated if any field is cut.
+func trimToolTraceStepForList(step *routerreplay.ToolTraceStep, budget int) {
+	truncateListField(&step.Arguments, &step.Truncated, budget)
+	truncateListField(&step.RawArguments, &step.Truncated, budget)
+	truncateListField(&step.Output, &step.Truncated, budget)
+	truncateListField(&step.RawOutput, &step.Truncated, budget)
+	truncateListField(&step.Text, &step.Truncated, budget)
+}
+
+// truncateListField cuts *field to at most budget bytes, setting *flag true
+// when it removes anything. A no-op when the field already fits.
+func truncateListField(field *string, flag *bool, budget int) {
+	if len(*field) > budget {
+		*field = (*field)[:budget]
+		*flag = true
+	}
 }
 
 func (r *OpenAIRouter) collectRouterReplayRecords() []routerreplay.RoutingRecord {

--- a/src/semantic-router/pkg/extproc/router_replay_api_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api_test.go
@@ -10,6 +10,7 @@ import (
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
 )
@@ -203,6 +204,63 @@ func TestHandleRouterReplayAPIListReturnsPayloadTooLargeForOversizedPage(t *test
 	}
 	if got := errorBody["message"]; got == nil || !strings.Contains(got.(string), "ext-proc message size limit") {
 		t.Fatalf("expected oversized response guidance, got %#v", got)
+	}
+}
+
+// TestHandleRouterReplayAPIListBoundedByDefaultConfigForLargeInput is the
+// regression test for the reported 413 on the history list when a large request
+// is recorded. The structured Prompt/ToolDefinitions fields are extracted from
+// the full request before MaxBodyBytes truncation; before the fix the default
+// config left MaxToolTraceBytes=0 (unbounded), so a single multi-MB input
+// produced a multi-MB Prompt that pushed a normal page past the ext-proc size
+// cap and returned 413. With the default config wired through the real
+// configureReplayRecorder path, the list endpoint must return 200.
+func TestHandleRouterReplayAPIListBoundedByDefaultConfigForLargeInput(t *testing.T) {
+	bigInput := strings.Repeat("x", 5*1024*1024) // 5 MB user input
+
+	cfg := config.DefaultRouterReplayPluginConfig()
+	recorder := routerreplay.NewRecorder(store.NewMemoryStore(100, 0))
+	// Use the production wiring so the test exercises the actual default policy,
+	// not a hand-set recorder limit.
+	configureReplayRecorder(recorder, &cfg)
+
+	// Build records the way buildReplayRoutingRecord does: Prompt and
+	// ToolDefinitions come from the full request body, RequestBody is the raw body.
+	for i := 0; i < 25; i++ {
+		if _, err := recorder.AddRecord(routerreplay.RoutingRecord{
+			ID:              fmt.Sprintf("replay-%03d", i),
+			Decision:        "decision-a",
+			RequestID:       fmt.Sprintf("req-%03d", i),
+			RequestBody:     bigInput,
+			Prompt:          bigInput,
+			ToolDefinitions: bigInput,
+			Timestamp:       time.Unix(int64(i+1), 0).UTC(),
+		}); err != nil {
+			t.Fatalf("failed to add replay record %d: %v", i, err)
+		}
+	}
+
+	// Each heavy field must have been truncated to the default cap.
+	stored, ok := recorder.GetRecord("replay-000")
+	if !ok {
+		t.Fatal("expected stored record")
+	}
+	if len(stored.Prompt) != 4096 || !stored.PromptTruncated {
+		t.Fatalf("prompt should be truncated to 4096, got len=%d truncated=%v", len(stored.Prompt), stored.PromptTruncated)
+	}
+	if len(stored.ToolDefinitions) != 4096 || !stored.ToolDefinitionsTruncated {
+		t.Fatalf("tool_definitions should be truncated to 4096, got len=%d truncated=%v", len(stored.ToolDefinitions), stored.ToolDefinitionsTruncated)
+	}
+
+	router := &OpenAIRouter{
+		ReplayRecorders: map[string]*routerreplay.Recorder{"decision-a": recorder},
+	}
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay?limit=25&offset=0")
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate response")
+	}
+	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_OK {
+		t.Fatalf("expected 200 OK for a full page of large-input records under the default config, got %v", got)
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/router_replay_api_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api_test.go
@@ -182,28 +182,40 @@ func TestHandleRouterReplayAPIListRejectsInvalidQuery(t *testing.T) {
 	}
 }
 
-func TestHandleRouterReplayAPIListReturnsPayloadTooLargeForOversizedPage(t *testing.T) {
+// TestHandleRouterReplayAPIListBoundsOversizedPageInsteadOf413 verifies the
+// list endpoint degrades gracefully rather than hard-failing: an oversized
+// record (here a 5 MB body stored untruncated, e.g. via an explicit
+// max_tool_trace_bytes:0 / raised-limit capture config) must still yield a
+// 200 list response, with the heavy field trimmed for transport and its
+// *_truncated flag set. Full fidelity remains available via the per-record
+// GET endpoint. This replaces the previous behavior that returned 413 and
+// broke the whole history view for everyone.
+func TestHandleRouterReplayAPIListBoundsOversizedPageInsteadOf413(t *testing.T) {
 	oversizedBody := strings.Repeat("x", 5*1024*1024)
 	router := newReplayAPITestRouterWithRecords(t, 1, oversizedBody)
 
 	response := router.handleRouterReplayAPI("GET", "/v1/router_replay?limit=1")
 	if response == nil || response.GetImmediateResponse() == nil {
-		t.Fatal("expected immediate error response")
+		t.Fatal("expected immediate response")
 	}
-	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_PayloadTooLarge {
-		t.Fatalf("expected payload too large status, got %v", got)
+	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_OK {
+		t.Fatalf("expected 200 OK (bounded), got %v", got)
 	}
 
 	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
-	errorBody, ok := body["error"].(map[string]interface{})
+	data, ok := body["data"].([]interface{})
+	if !ok || len(data) != 1 {
+		t.Fatalf("expected one record in data, got %#v", body["data"])
+	}
+	record, ok := data[0].(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected error payload, got %#v", body)
+		t.Fatalf("expected record object, got %#v", data[0])
 	}
-	if got := int(errorBody["code"].(float64)); got != 413 {
-		t.Fatalf("expected error code 413, got %d", got)
+	if trimmed, _ := record["request_body"].(string); len(trimmed) >= len(oversizedBody) {
+		t.Fatalf("expected request_body to be trimmed for transport, got len=%d", len(trimmed))
 	}
-	if got := errorBody["message"]; got == nil || !strings.Contains(got.(string), "ext-proc message size limit") {
-		t.Fatalf("expected oversized response guidance, got %#v", got)
+	if truncated, _ := record["request_body_truncated"].(bool); !truncated {
+		t.Fatal("expected request_body_truncated flag to be set after transport trimming")
 	}
 }
 
@@ -262,6 +274,59 @@ func TestHandleRouterReplayAPIListBoundedByDefaultConfigForLargeInput(t *testing
 	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_OK {
 		t.Fatalf("expected 200 OK for a full page of large-input records under the default config, got %v", got)
 	}
+}
+
+// TestHandleRouterReplayAPIListBoundsPageRegardlessOfCaptureConfig locks the
+// transport-layer fix for the two cases the capture-default change alone does
+// NOT cover: (1) an operator who explicitly disables structured-field
+// truncation (max_tool_trace_bytes:0), and (2) a long agent tool-trace under
+// the default config (many steps, each at the per-step byte cap). In both, a
+// normal page would otherwise exceed the ext-proc cap; the list endpoint must
+// still return 200 by trimming heavy fields for transport.
+func TestHandleRouterReplayAPIListBoundsPageRegardlessOfCaptureConfig(t *testing.T) {
+	big := strings.Repeat("x", 5*1024*1024)
+
+	t.Run("explicit unlimited opt-out", func(t *testing.T) {
+		recorder := routerreplay.NewRecorder(store.NewMemoryStore(100, 0))
+		recorder.SetCapturePolicy(true, true, 4096)
+		recorder.SetMaxToolTraceBytes(0) // operator opts out of structured-field truncation
+		for i := 0; i < 25; i++ {
+			if _, err := recorder.AddRecord(routerreplay.RoutingRecord{
+				ID: fmt.Sprintf("u%02d", i), Decision: "d", RequestID: fmt.Sprintf("q%02d", i),
+				Prompt: big, Timestamp: time.Unix(int64(i+1), 0).UTC(),
+			}); err != nil {
+				t.Fatalf("add record: %v", err)
+			}
+		}
+		router := &OpenAIRouter{ReplayRecorders: map[string]*routerreplay.Recorder{"d": recorder}}
+		resp := router.handleRouterReplayAPI("GET", "/v1/router_replay?limit=25&offset=0")
+		if got := resp.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_OK {
+			t.Fatalf("expected 200 OK with unlimited capture config, got %v", got)
+		}
+	})
+
+	t.Run("default config with long agent tool-trace", func(t *testing.T) {
+		cfg := config.DefaultRouterReplayPluginConfig()
+		recorder := routerreplay.NewRecorder(store.NewMemoryStore(100, 0))
+		configureReplayRecorder(recorder, &cfg)
+		for i := 0; i < 25; i++ {
+			steps := make([]routerreplay.ToolTraceStep, 100)
+			for s := range steps {
+				steps[s] = routerreplay.ToolTraceStep{Arguments: big, Output: big}
+			}
+			if _, err := recorder.AddRecord(routerreplay.RoutingRecord{
+				ID: fmt.Sprintf("a%02d", i), Decision: "d", RequestID: fmt.Sprintf("q%02d", i),
+				ToolTrace: &routerreplay.ToolTrace{Steps: steps}, Timestamp: time.Unix(int64(i+1), 0).UTC(),
+			}); err != nil {
+				t.Fatalf("add record: %v", err)
+			}
+		}
+		router := &OpenAIRouter{ReplayRecorders: map[string]*routerreplay.Recorder{"d": recorder}}
+		resp := router.handleRouterReplayAPI("GET", "/v1/router_replay?limit=25&offset=0")
+		if got := resp.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_OK {
+			t.Fatalf("expected 200 OK with a long agent tool-trace under default config, got %v", got)
+		}
+	})
 }
 
 func TestHandleRouterReplayAPIReturnsErrorsForInvalidRequests(t *testing.T) {


### PR DESCRIPTION
## Problem
`GET /v1/router_replay` (the replay **history list**) returns **413 Payload Too Large** once a large request has been recorded — reproduced by sending a ~5–10 MB input and then opening the history view. One big record breaks the whole list for everyone.

## Root cause
The list response embeds whole records, and several fields hold free text from the **full** request/response (`prompt`, `tool_definitions`, tool-trace step text, `request_body`/`response_body`). A page of records is serialized into one ext-proc message; past the 4 MB cap it hard-fails with 413. Raw bodies were capped (`max_body_bytes`), but the structured fields were bounded only by `max_tool_trace_bytes`, which **defaulted to 0 (unlimited)** — so one large input, or a long agent tool-trace, produced a multi-MB page.

## Fix
**1. List endpoint never 413s a page (the actual fix).** When a page would exceed the cap, it progressively trims the heaviest text fields on the page records — tool-trace text → bodies → prompt/tool_definitions — and sets the existing `*_truncated` flags so reduced fidelity is visible. Page records are per-request **clones**, so the stored originals are untouched and full fidelity stays available via `GET /v1/router_replay/{id}`. This is what makes the endpoint correct under **any** capture config — including the two cases a storage cap alone can't fix: an operator setting `max_tool_trace_bytes: 0`, and a long agent tool-trace under default config.

**2. Safer default (defense-in-depth).** `max_tool_trace_bytes` now defaults to 4096 — the missing sibling of the existing bounded defaults (`max_body_bytes=4096`, `max_tool_trace_steps=100`, the latter added for OOM-prevention in #1835). It bounds what is *stored* per record (a memory safeguard); `0 = unlimited` stays as an explicit opt-out. Not sufficient alone, which is why layer 1 exists.

## Verification
Reproduced the 413 with a 5 MB input through the real recorder config path, then confirmed a **200** with trimmed + `*_truncated` fields for all three cases: large body, explicit `max_tool_trace_bytes:0`, and a 100-step agent tool-trace under default config.

## Tests
- `pkg/extproc`: oversized page now returns 200 (replaces the old 413-asserting test); plus opt-out-unlimited, long-agent-tool-trace, and default-config large-input cases.
- `pkg/config`: pins the `max_tool_trace_bytes=4096` default.

## Risk
Low. Under extreme sizes the list may return truncated heavy fields (flagged via `*_truncated`; full record via the per-record endpoint). Explicit configs are unaffected; the `0` opt-out is preserved.

## Follow-up
This PR is the immediate, non-breaking fix (bound the list response so it never 413s; full fidelity stays on `GET /v1/router_replay/{id}`). The deeper design issue — the list endpoint embedding full record bodies at all — is tracked in #2157 for maintainers to decide whether to advance (summaries-only list, or a projection param). Happy to own that follow-up if wanted.

---

Closes #2189 (same `413` on the replay history list from a large recorded request; same code path).