### PR TITLE
[Dashboard] allow first-admin registration during setup mode

### DIFF
--- a/dashboard/backend/auth/bootstrap_gate_test.go
+++ b/dashboard/backend/auth/bootstrap_gate_test.go
@@ -11,10 +11,13 @@ import (
 	"testing"
 )
 
-func newBootstrapService(t *testing.T, allowOpen bool) *Service {
+func newBootstrapService(t *testing.T, allowOpen bool, setupMode ...bool) *Service {
 	t.Helper()
 	svc := newTestAuthService(t)
 	svc.SetAllowOpenBootstrap(allowOpen)
+	if len(setupMode) > 0 {
+		svc.SetSetupMode(setupMode[0])
+	}
 	return svc
 }
 
@@ -46,6 +49,32 @@ func TestBootstrapCanRegister_DisabledByDefaultReportsFalse(t *testing.T) {
 	svc := newBootstrapService(t, false)
 	if canRegister(t, svc) {
 		t.Fatal("canRegister = true with open bootstrap disabled; want false")
+	}
+}
+
+func TestBootstrapCanRegister_SetupModeAllowsWhenNoUsers(t *testing.T) {
+	svc := newBootstrapService(t, false, true)
+	if !canRegister(t, svc) {
+		t.Fatal("canRegister = false with setup mode and no users; want true")
+	}
+}
+
+func TestBootstrapCanRegister_SetupModeClosedAfterAdminExists(t *testing.T) {
+	svc := newBootstrapService(t, false, true)
+	newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
+	if canRegister(t, svc) {
+		t.Fatal("canRegister = true with setup mode after an admin exists; want false")
+	}
+}
+
+func TestBootstrapRegister_SetupModeCreatesFirstAdmin(t *testing.T) {
+	svc := newBootstrapService(t, false, true)
+	rec := postRegister(svc, "admin@example.com")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if n, _ := svc.store.CountUsers(context.Background()); n != 1 {
+		t.Fatalf("user count = %d, want 1", n)
 	}
 }
 

--- a/dashboard/backend/auth/public_handlers.go
+++ b/dashboard/backend/auth/public_handlers.go
@@ -14,9 +14,9 @@ func bootstrapCanRegisterHandler(svc *Service) http.HandlerFunc {
 			return
 		}
 
-		// When the open web-form bootstrap is disabled, always report false. This
-		// also avoids leaking to unauthenticated callers whether the instance is
-		// freshly deployed and claimable.
+		// When neither explicit open bootstrap nor dashboard setup mode is active,
+		// always report false. This avoids leaking to unauthenticated callers
+		// whether a non-bootstrap instance is freshly deployed and claimable.
 		if !svc.OpenBootstrapEnabled() {
 			respondJSON(w, BootstrapStatusResponse{CanRegister: false})
 			return

--- a/dashboard/backend/auth/service.go
+++ b/dashboard/backend/auth/service.go
@@ -23,6 +23,8 @@ type Service struct {
 
 	// allowOpenBootstrap gates the public web-form bootstrap endpoint (off by default).
 	allowOpenBootstrap bool
+	// setupMode enables bootstrap during dashboard-first local install (trusted phase).
+	setupMode bool
 	// bootstrapMu serializes the check-then-create in BootstrapRegister so that two
 	// concurrent requests cannot both pass the "no users yet" check and each create an
 	// admin. The dashboard runs single-replica (enforced by the chart's replicaCount
@@ -56,8 +58,11 @@ func NewService(store *Store, secret string, ttlHours int) *Service {
 // SetAllowOpenBootstrap toggles the public web-form bootstrap endpoint.
 func (s *Service) SetAllowOpenBootstrap(v bool) { s.allowOpenBootstrap = v }
 
+// SetSetupMode toggles dashboard-first setup mode for trusted first-run bootstrap.
+func (s *Service) SetSetupMode(v bool) { s.setupMode = v }
+
 // OpenBootstrapEnabled reports whether the public web-form bootstrap endpoint is enabled.
-func (s *Service) OpenBootstrapEnabled() bool { return s.allowOpenBootstrap }
+func (s *Service) OpenBootstrapEnabled() bool { return s.allowOpenBootstrap || s.setupMode }
 
 // BootstrapRegister atomically creates the first admin. The "no users yet" check and
 // the create run under bootstrapMu, so two concurrent requests cannot each create an

--- a/dashboard/backend/config/config.go
+++ b/dashboard/backend/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	// AllowOpenBootstrap enables first-admin creation via the public, unauthenticated
 	// web-form bootstrap endpoint. Off by default; production should provision the
 	// admin via DASHBOARD_ADMIN_* instead of exposing an open registration path.
+	// SetupMode is a separate trusted bootstrap path for dashboard-first local install.
 	AllowOpenBootstrap bool
 
 	// Platform branding (e.g., "amd" for AMD GPU deployments)

--- a/dashboard/backend/router/auth_routes.go
+++ b/dashboard/backend/router/auth_routes.go
@@ -34,6 +34,7 @@ func setupAuthRoutes(mux *http.ServeMux, cfg *config.Config) *auth.Service {
 
 	authSvc := auth.NewService(store, cfg.JWTSecret, cfg.JWTExpiryHours)
 	authSvc.SetAllowOpenBootstrap(cfg.AllowOpenBootstrap)
+	authSvc.SetSetupMode(cfg.SetupMode)
 	if err := authSvc.EnsureBootstrapAdmin(
 		context.Background(),
 		cfg.BootstrapAdminEmail,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #xxxx

## Purpose

- What does this PR change?
- Why is this change needed?
- Which module(s) does this affect? `Router` / `CLI` / `Dashboard` / `Operator` / `Fleet-Sim` / `Bindings` / `Training` / `E2E` / `Docs` / `CI/Build`

## Test Plan

- What commands, checks, or manual steps should reviewers use?
- Why is this validation sufficient for the affected module(s)?

## Test Result

- What were the actual results?
- Any follow-up risks, gaps, or blockers?

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [ ] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [ ] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
