### PR TITLE
[Bindings] free boxed-slice FFI arrays with their full allocation layout

### DIFF
--- a/candle-binding/src/ffi/dealloc_layout_test.rs
+++ b/candle-binding/src/ffi/dealloc_layout_test.rs
@@ -1,0 +1,238 @@
+//! Dealloc-layout regression tests for the FFI free functions
+//!
+//! `Box::from_raw` must reconstruct the exact type that was leaked with
+//! `Box::into_raw`. The arrays handed across the FFI boundary are allocated
+//! as `Box<[T]>` via `into_boxed_slice()`, so reclaiming them through the
+//! element pointer (`Box::from_raw(slice.as_mut_ptr())`) deallocates with a
+//! single-element layout. That is undefined behavior whenever the slice holds
+//! more than one element, but the default system allocator absorbs the size
+//! mismatch silently (`free()` takes no size), so an ordinary round-trip test
+//! passes against the broken form.
+//!
+//! These tests install a layout-tracking allocator for the test binary that
+//! records the layout of every allocation made while a tracking window is
+//! armed and compares it with the layout supplied at deallocation. A free
+//! through the element pointer is reported as a layout mismatch and fails the
+//! test; the full-length `slice_from_raw_parts_mut` form passes.
+
+use super::embedding::{free_batch_similarity_result, free_embedding_models_info};
+use super::types::{
+    BatchSimilarityResult, EmbeddingModelInfo, EmbeddingModelsInfoResult, SimilarityMatch,
+};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::ffi::CString;
+use std::sync::Mutex;
+
+/// One allocation observed while the tracking window is armed.
+#[derive(Debug, Clone, Copy)]
+struct AllocRecord {
+    ptr: usize,
+    size: usize,
+    align: usize,
+}
+
+/// A tracked pointer freed with a layout differing from its allocation layout.
+#[derive(Debug, Clone, Copy)]
+struct LayoutMismatch {
+    ptr: usize,
+    alloc_size: usize,
+    alloc_align: usize,
+    dealloc_size: usize,
+    dealloc_align: usize,
+}
+
+static TRACKED: Mutex<Vec<AllocRecord>> = Mutex::new(Vec::new());
+static MISMATCHED: Mutex<Vec<LayoutMismatch>> = Mutex::new(Vec::new());
+/// (ptr, size) for every tracked pointer freed with its exact allocation layout.
+static FREED_OK: Mutex<Vec<(usize, usize)>> = Mutex::new(Vec::new());
+/// Serializes the tests in this module so their tracking windows don't overlap.
+static WINDOW_GUARD: Mutex<()> = Mutex::new(());
+
+thread_local! {
+    /// True only on the thread that armed the current tracking window, so the
+    /// hooks never race with allocations made by other test threads or the
+    /// libtest harness.
+    static WINDOW_OWNER: Cell<bool> = const { Cell::new(false) };
+    /// Reentrancy guard: the bookkeeping Vecs may themselves allocate while
+    /// the hook holds the lock; those inner allocations must not be recorded.
+    static IN_HOOK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Only the window-owner thread records, and never reentrantly. `try_with`
+/// keeps the hook safe during thread teardown after TLS destruction.
+fn should_record() -> bool {
+    WINDOW_OWNER.try_with(|w| w.get()).unwrap_or(false)
+        && !IN_HOOK.try_with(|g| g.get()).unwrap_or(true)
+}
+
+fn locked<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+struct LayoutTrackingAllocator;
+
+unsafe impl GlobalAlloc for LayoutTrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() && should_record() {
+            IN_HOOK.with(|g| g.set(true));
+            locked(&TRACKED).push(AllocRecord {
+                ptr: ptr as usize,
+                size: layout.size(),
+                align: layout.align(),
+            });
+            IN_HOOK.with(|g| g.set(false));
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if should_record() {
+            IN_HOOK.with(|g| g.set(true));
+            let entry = {
+                let mut tracked = locked(&TRACKED);
+                tracked
+                    .iter()
+                    .rposition(|r| r.ptr == ptr as usize)
+                    .map(|pos| tracked.remove(pos))
+            };
+            if let Some(record) = entry {
+                if record.size == layout.size() && record.align == layout.align() {
+                    locked(&FREED_OK).push((record.ptr, record.size));
+                } else {
+                    locked(&MISMATCHED).push(LayoutMismatch {
+                        ptr: record.ptr,
+                        alloc_size: record.size,
+                        alloc_align: record.align,
+                        dealloc_size: layout.size(),
+                        dealloc_align: layout.align(),
+                    });
+                }
+            }
+            IN_HOOK.with(|g| g.set(false));
+        }
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: LayoutTrackingAllocator = LayoutTrackingAllocator;
+
+fn arm() {
+    locked(&TRACKED).clear();
+    locked(&MISMATCHED).clear();
+    locked(&FREED_OK).clear();
+    WINDOW_OWNER.with(|w| w.set(true));
+}
+
+struct WindowReport {
+    mismatched: Vec<LayoutMismatch>,
+    freed_ok: Vec<(usize, usize)>,
+}
+
+fn disarm() -> WindowReport {
+    WINDOW_OWNER.with(|w| w.set(false));
+    WindowReport {
+        mismatched: std::mem::take(&mut *locked(&MISMATCHED)),
+        freed_ok: std::mem::take(&mut *locked(&FREED_OK)),
+    }
+}
+
+fn assert_full_layout_free(report: &WindowReport, ptr: usize, expected_size: usize, what: &str) {
+    assert!(
+        report.mismatched.is_empty(),
+        "{} freed with wrong layout (UB): {:?}",
+        what,
+        report.mismatched
+    );
+    assert!(
+        report
+            .freed_ok
+            .iter()
+            .any(|&(p, size)| p == ptr && size == expected_size),
+        "{} (ptr {:#x}, {} bytes) was not freed with its full allocation layout; \
+         freed_ok = {:?}",
+        what,
+        ptr,
+        expected_size,
+        report.freed_ok
+    );
+}
+
+/// Mirrors the producer in `find_most_similar_batch`: the matches array is
+/// allocated as `Vec<SimilarityMatch>` -> `into_boxed_slice()` -> `Box::into_raw`.
+#[test]
+fn test_free_batch_similarity_result_uses_full_slice_layout() {
+    let _guard = WINDOW_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    const NUM_MATCHES: usize = 4;
+
+    arm();
+    let top_matches: Vec<SimilarityMatch> = (0..NUM_MATCHES)
+        .map(|i| SimilarityMatch {
+            index: i as i32,
+            similarity: 1.0 - 0.1 * i as f32,
+        })
+        .collect();
+    let matches_ptr = Box::into_raw(top_matches.into_boxed_slice()) as *mut SimilarityMatch;
+
+    let mut result = BatchSimilarityResult {
+        matches: matches_ptr,
+        num_matches: NUM_MATCHES as i32,
+        model_type: 0,
+        processing_time_ms: 0.0,
+        error: false,
+    };
+    free_batch_similarity_result(&mut result);
+    let report = disarm();
+
+    assert_full_layout_free(
+        &report,
+        matches_ptr as usize,
+        NUM_MATCHES * std::mem::size_of::<SimilarityMatch>(),
+        "BatchSimilarityResult.matches array",
+    );
+    assert!(result.matches.is_null());
+    assert_eq!(result.num_matches, 0);
+}
+
+/// Mirrors the producer in `get_embedding_models_info`: the models array is
+/// allocated as `Vec<EmbeddingModelInfo>` -> `into_boxed_slice()` ->
+/// `Box::into_raw`, with `CString::into_raw` name/path fields.
+#[test]
+fn test_free_embedding_models_info_uses_full_slice_layout() {
+    let _guard = WINDOW_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    const NUM_MODELS: usize = 2;
+
+    arm();
+    let models_vec: Vec<EmbeddingModelInfo> = ["qwen3", "gemma"]
+        .iter()
+        .map(|name| EmbeddingModelInfo {
+            model_name: CString::new(*name).unwrap().into_raw(),
+            is_loaded: true,
+            max_sequence_length: 8192,
+            default_dimension: 768,
+            model_path: CString::new(format!("/models/{}", name))
+                .unwrap()
+                .into_raw(),
+        })
+        .collect();
+    let models_ptr = Box::into_raw(models_vec.into_boxed_slice()) as *mut EmbeddingModelInfo;
+
+    let mut result = EmbeddingModelsInfoResult {
+        models: models_ptr,
+        num_models: NUM_MODELS as i32,
+        error: false,
+    };
+    free_embedding_models_info(&mut result);
+    let report = disarm();
+
+    assert_full_layout_free(
+        &report,
+        models_ptr as usize,
+        NUM_MODELS * std::mem::size_of::<EmbeddingModelInfo>(),
+        "EmbeddingModelsInfoResult.models array",
+    );
+    assert!(result.models.is_null());
+    assert_eq!(result.num_models, 0);
+}

--- a/candle-binding/src/ffi/dealloc_layout_test.rs
+++ b/candle-binding/src/ffi/dealloc_layout_test.rs
@@ -33,6 +33,10 @@ struct AllocRecord {
 }
 
 /// A tracked pointer freed with a layout differing from its allocation layout.
+// The fields are read only through the Debug-formatted assertion message, which
+// dead-code analysis does not count as a use; allow rather than drop them, since
+// the byte counts are the whole diagnostic value when this fires.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct LayoutMismatch {
     ptr: usize,

--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -1723,13 +1723,16 @@ pub extern "C" fn free_batch_similarity_result(result: *mut BatchSimilarityResul
     unsafe {
         let batch_result = &mut *result;
 
-        // Free the matches array if it's not null
+        // Free the matches array if it's not null. The array was allocated with
+        // `into_boxed_slice()`, so it must be reclaimed as a `Box<[SimilarityMatch]>`
+        // over the full length. Reconstructing a `Box<SimilarityMatch>` from the
+        // element pointer frees with the layout of a single element and is undefined
+        // behavior whenever num_matches > 1.
         if !batch_result.matches.is_null() && batch_result.num_matches > 0 {
-            let matches_slice = std::slice::from_raw_parts_mut(
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                 batch_result.matches,
                 batch_result.num_matches as usize,
-            );
-            let _ = Box::from_raw(matches_slice.as_mut_ptr());
+            ));
         }
 
         // Reset the result
@@ -1870,8 +1873,13 @@ pub extern "C" fn free_embedding_models_info(
                 }
             }
 
-            // Free the models array
-            let _ = Box::from_raw(models_slice.as_mut_ptr());
+            // Free the models array as the boxed slice it was allocated as. The
+            // element-pointer form would free with single-element layout while
+            // num_models is always 2, so reclaim the full-length slice.
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                info_result.models,
+                info_result.num_models as usize,
+            ));
         }
 
         // Reset the result

--- a/candle-binding/src/ffi/mod.rs
+++ b/candle-binding/src/ffi/mod.rs
@@ -38,6 +38,8 @@ pub use state_manager::*;
 #[cfg(test)]
 pub mod classify_test;
 #[cfg(test)]
+pub mod dealloc_layout_test;
+#[cfg(test)]
 pub mod embedding_test;
 #[cfg(test)]
 pub mod init_test;

--- a/onnx-binding/src/ffi/memory.rs
+++ b/onnx-binding/src/ffi/memory.rs
@@ -7,6 +7,7 @@ use std::ffi::{c_char, CString};
 /// # Safety
 /// - `data` must be a valid pointer allocated by Rust
 /// - `length` must match the original allocation length
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn free_embedding(data: *mut f32, length: i32) {
     if data.is_null() || length <= 0 {
@@ -14,7 +15,7 @@ pub extern "C" fn free_embedding(data: *mut f32, length: i32) {
     }
 
     unsafe {
-        let _ = Box::from_raw(std::slice::from_raw_parts_mut(data, length as usize));
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(data, length as usize));
     }
 }
 
@@ -22,6 +23,7 @@ pub extern "C" fn free_embedding(data: *mut f32, length: i32) {
 ///
 /// # Safety
 /// - `s` must be a valid CString pointer allocated by Rust
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn free_cstring(s: *mut c_char) {
     if s.is_null() {
@@ -37,6 +39,7 @@ pub extern "C" fn free_cstring(s: *mut c_char) {
 ///
 /// # Safety
 /// - `result` must be a valid pointer to BatchSimilarityResult
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn free_batch_similarity_result(result: *mut super::types::BatchSimilarityResult) {
     if result.is_null() {
@@ -65,6 +68,7 @@ pub extern "C" fn free_batch_similarity_result(result: *mut super::types::BatchS
 ///
 /// # Safety
 /// - `result` must be a valid pointer to EmbeddingModelsInfoResult
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn free_embedding_models_info(result: *mut super::types::EmbeddingModelsInfoResult) {
     if result.is_null() {

--- a/onnx-binding/src/ffi/memory.rs
+++ b/onnx-binding/src/ffi/memory.rs
@@ -46,12 +46,14 @@ pub extern "C" fn free_batch_similarity_result(result: *mut super::types::BatchS
     unsafe {
         let batch_result = &mut *result;
 
+        // The array was allocated with `into_boxed_slice()` and must be reclaimed as
+        // a full-length `Box<[SimilarityMatch]>`. The element-pointer form frees with
+        // single-element layout, which is undefined behavior when num_matches > 1.
         if !batch_result.matches.is_null() && batch_result.num_matches > 0 {
-            let matches_slice = std::slice::from_raw_parts_mut(
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                 batch_result.matches,
                 batch_result.num_matches as usize,
-            );
-            let _ = Box::from_raw(matches_slice.as_mut_ptr());
+            ));
         }
 
         batch_result.matches = std::ptr::null_mut();
@@ -88,7 +90,12 @@ pub extern "C" fn free_embedding_models_info(result: *mut super::types::Embeddin
                 }
             }
 
-            let _ = Box::from_raw(models_slice.as_mut_ptr());
+            // Reclaim the models array as the full-length boxed slice it was
+            // allocated as, not as a single-element box.
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                info_result.models,
+                info_result.num_models as usize,
+            ));
         }
 
         info_result.models = std::ptr::null_mut();

--- a/onnx-binding/src/ffi/memory_test.rs
+++ b/onnx-binding/src/ffi/memory_test.rs
@@ -196,9 +196,12 @@ fn test_free_batch_similarity_result_uses_full_slice_layout() {
     assert_eq!(result.num_matches, 0);
 }
 
-/// Mirrors the producer of model info results: the models array is allocated
-/// as `Vec<EmbeddingModelInfo>` -> `into_boxed_slice()` -> `Box::into_raw`,
-/// with `CString::into_raw` string fields.
+/// Mirrors the producer's allocation pattern (`Vec<EmbeddingModelInfo>` ->
+/// `into_boxed_slice()` -> `Box::into_raw`, `CString::into_raw` string
+/// fields) but deliberately uses a 2-entry array: the production array
+/// currently holds a single entry, for which the element-pointer free
+/// happens to use the right layout; more than one element is what exposes
+/// the mismatch this test exists to catch.
 #[test]
 fn test_free_embedding_models_info_uses_full_slice_layout() {
     let _guard = WINDOW_GUARD.lock().unwrap_or_else(|e| e.into_inner());

--- a/onnx-binding/src/ffi/memory_test.rs
+++ b/onnx-binding/src/ffi/memory_test.rs
@@ -1,0 +1,240 @@
+//! Dealloc-layout regression tests for the FFI free functions
+//!
+//! `Box::from_raw` must reconstruct the exact type that was leaked with
+//! `Box::into_raw`. The arrays handed across the FFI boundary are allocated
+//! as `Box<[T]>` via `into_boxed_slice()`, so reclaiming them through the
+//! element pointer (`Box::from_raw(slice.as_mut_ptr())`) deallocates with a
+//! single-element layout. That is undefined behavior whenever the slice holds
+//! more than one element, but the default system allocator absorbs the size
+//! mismatch silently (`free()` takes no size), so an ordinary round-trip test
+//! passes against the broken form.
+//!
+//! These tests install a layout-tracking allocator for the test binary that
+//! records the layout of every allocation made while a tracking window is
+//! armed and compares it with the layout supplied at deallocation. A free
+//! through the element pointer is reported as a layout mismatch and fails the
+//! test; the full-length `slice_from_raw_parts_mut` form passes.
+
+use super::memory::{free_batch_similarity_result, free_embedding_models_info};
+use super::types::{
+    BatchSimilarityResult, EmbeddingModelInfo, EmbeddingModelsInfoResult, SimilarityMatch,
+};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::ffi::CString;
+use std::sync::Mutex;
+
+/// One allocation observed while the tracking window is armed.
+#[derive(Debug, Clone, Copy)]
+struct AllocRecord {
+    ptr: usize,
+    size: usize,
+    align: usize,
+}
+
+/// A tracked pointer freed with a layout differing from its allocation layout.
+#[derive(Debug, Clone, Copy)]
+struct LayoutMismatch {
+    ptr: usize,
+    alloc_size: usize,
+    alloc_align: usize,
+    dealloc_size: usize,
+    dealloc_align: usize,
+}
+
+static TRACKED: Mutex<Vec<AllocRecord>> = Mutex::new(Vec::new());
+static MISMATCHED: Mutex<Vec<LayoutMismatch>> = Mutex::new(Vec::new());
+/// (ptr, size) for every tracked pointer freed with its exact allocation layout.
+static FREED_OK: Mutex<Vec<(usize, usize)>> = Mutex::new(Vec::new());
+/// Serializes the tests in this module so their tracking windows don't overlap.
+static WINDOW_GUARD: Mutex<()> = Mutex::new(());
+
+thread_local! {
+    /// True only on the thread that armed the current tracking window, so the
+    /// hooks never race with allocations made by other test threads or the
+    /// libtest harness.
+    static WINDOW_OWNER: Cell<bool> = const { Cell::new(false) };
+    /// Reentrancy guard: the bookkeeping Vecs may themselves allocate while
+    /// the hook holds the lock; those inner allocations must not be recorded.
+    static IN_HOOK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Only the window-owner thread records, and never reentrantly. `try_with`
+/// keeps the hook safe during thread teardown after TLS destruction.
+fn should_record() -> bool {
+    WINDOW_OWNER.try_with(|w| w.get()).unwrap_or(false)
+        && !IN_HOOK.try_with(|g| g.get()).unwrap_or(true)
+}
+
+fn locked<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+struct LayoutTrackingAllocator;
+
+unsafe impl GlobalAlloc for LayoutTrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() && should_record() {
+            IN_HOOK.with(|g| g.set(true));
+            locked(&TRACKED).push(AllocRecord {
+                ptr: ptr as usize,
+                size: layout.size(),
+                align: layout.align(),
+            });
+            IN_HOOK.with(|g| g.set(false));
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if should_record() {
+            IN_HOOK.with(|g| g.set(true));
+            let entry = {
+                let mut tracked = locked(&TRACKED);
+                tracked
+                    .iter()
+                    .rposition(|r| r.ptr == ptr as usize)
+                    .map(|pos| tracked.remove(pos))
+            };
+            if let Some(record) = entry {
+                if record.size == layout.size() && record.align == layout.align() {
+                    locked(&FREED_OK).push((record.ptr, record.size));
+                } else {
+                    locked(&MISMATCHED).push(LayoutMismatch {
+                        ptr: record.ptr,
+                        alloc_size: record.size,
+                        alloc_align: record.align,
+                        dealloc_size: layout.size(),
+                        dealloc_align: layout.align(),
+                    });
+                }
+            }
+            IN_HOOK.with(|g| g.set(false));
+        }
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: LayoutTrackingAllocator = LayoutTrackingAllocator;
+
+fn arm() {
+    locked(&TRACKED).clear();
+    locked(&MISMATCHED).clear();
+    locked(&FREED_OK).clear();
+    WINDOW_OWNER.with(|w| w.set(true));
+}
+
+struct WindowReport {
+    mismatched: Vec<LayoutMismatch>,
+    freed_ok: Vec<(usize, usize)>,
+}
+
+fn disarm() -> WindowReport {
+    WINDOW_OWNER.with(|w| w.set(false));
+    WindowReport {
+        mismatched: std::mem::take(&mut *locked(&MISMATCHED)),
+        freed_ok: std::mem::take(&mut *locked(&FREED_OK)),
+    }
+}
+
+fn assert_full_layout_free(report: &WindowReport, ptr: usize, expected_size: usize, what: &str) {
+    assert!(
+        report.mismatched.is_empty(),
+        "{} freed with wrong layout (UB): {:?}",
+        what,
+        report.mismatched
+    );
+    assert!(
+        report
+            .freed_ok
+            .iter()
+            .any(|&(p, size)| p == ptr && size == expected_size),
+        "{} (ptr {:#x}, {} bytes) was not freed with its full allocation layout; \
+         freed_ok = {:?}",
+        what,
+        ptr,
+        expected_size,
+        report.freed_ok
+    );
+}
+
+/// Mirrors the producer of batch similarity results: the matches array is
+/// allocated as `Vec<SimilarityMatch>` -> `into_boxed_slice()` -> `Box::into_raw`.
+#[test]
+fn test_free_batch_similarity_result_uses_full_slice_layout() {
+    let _guard = WINDOW_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    const NUM_MATCHES: usize = 4;
+
+    arm();
+    let top_matches: Vec<SimilarityMatch> = (0..NUM_MATCHES)
+        .map(|i| SimilarityMatch {
+            index: i as i32,
+            similarity: 1.0 - 0.1 * i as f32,
+        })
+        .collect();
+    let matches_ptr = Box::into_raw(top_matches.into_boxed_slice()) as *mut SimilarityMatch;
+
+    let mut result = BatchSimilarityResult {
+        matches: matches_ptr,
+        num_matches: NUM_MATCHES as i32,
+        model_type: 0,
+        processing_time_ms: 0.0,
+        error: false,
+    };
+    free_batch_similarity_result(&mut result);
+    let report = disarm();
+
+    assert_full_layout_free(
+        &report,
+        matches_ptr as usize,
+        NUM_MATCHES * std::mem::size_of::<SimilarityMatch>(),
+        "BatchSimilarityResult.matches array",
+    );
+    assert!(result.matches.is_null());
+    assert_eq!(result.num_matches, 0);
+}
+
+/// Mirrors the producer of model info results: the models array is allocated
+/// as `Vec<EmbeddingModelInfo>` -> `into_boxed_slice()` -> `Box::into_raw`,
+/// with `CString::into_raw` string fields.
+#[test]
+fn test_free_embedding_models_info_uses_full_slice_layout() {
+    let _guard = WINDOW_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    const NUM_MODELS: usize = 2;
+
+    arm();
+    let models_vec: Vec<EmbeddingModelInfo> = ["mmbert", "mmbert-32k"]
+        .iter()
+        .map(|name| EmbeddingModelInfo {
+            model_name: CString::new(*name).unwrap().into_raw(),
+            is_loaded: true,
+            max_sequence_length: 8192,
+            default_dimension: 768,
+            model_path: CString::new(format!("/models/{}", name))
+                .unwrap()
+                .into_raw(),
+            supports_layer_exit: true,
+            available_layers: CString::new("3,6,11,22").unwrap().into_raw(),
+        })
+        .collect();
+    let models_ptr = Box::into_raw(models_vec.into_boxed_slice()) as *mut EmbeddingModelInfo;
+
+    let mut result = EmbeddingModelsInfoResult {
+        models: models_ptr,
+        num_models: NUM_MODELS as i32,
+        error: false,
+    };
+    free_embedding_models_info(&mut result);
+    let report = disarm();
+
+    assert_full_layout_free(
+        &report,
+        models_ptr as usize,
+        NUM_MODELS * std::mem::size_of::<EmbeddingModelInfo>(),
+        "EmbeddingModelsInfoResult.models array",
+    );
+    assert!(result.models.is_null());
+    assert_eq!(result.num_models, 0);
+}

--- a/onnx-binding/src/ffi/memory_test.rs
+++ b/onnx-binding/src/ffi/memory_test.rs
@@ -33,6 +33,10 @@ struct AllocRecord {
 }
 
 /// A tracked pointer freed with a layout differing from its allocation layout.
+// The fields are read only through the Debug-formatted assertion message, which
+// dead-code analysis does not count as a use; allow rather than drop them, since
+// the byte counts are the whole diagnostic value when this fires.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct LayoutMismatch {
     ptr: usize,

--- a/onnx-binding/src/ffi/mod.rs
+++ b/onnx-binding/src/ffi/mod.rs
@@ -3,6 +3,8 @@
 pub mod classification;
 pub mod embedding;
 pub mod memory;
+#[cfg(test)]
+mod memory_test;
 pub mod multimodal;
 pub mod types;
 pub mod unified;


### PR DESCRIPTION

## Purpose

`free_batch_similarity_result` and `free_embedding_models_info` (both candle-binding and onnx-binding, 4 sites total) reclaim the result arrays with `Box::from_raw(slice.as_mut_ptr())`. The arrays are allocated as `Box<[T]>` via `into_boxed_slice()`, so that form reconstructs a `Box<T>` from the first element and drops it with the single-element layout. Deallocating with a layout other than the allocation layout is undefined behavior whenever the array holds more than one element.

How live each site is differs by producer: the `matches` arrays are top-k results and routinely hold more than one entry in both crates, and candle's `get_embedding_models_info` always pushes 2 entries (qwen3 + gemma), so those three sites hit the mismatched layout in normal operation. onnx's models producer currently pushes exactly 1 entry (mmbert), for which the two layouts coincide, so that fourth site is latent rather than firing today; it is fixed for correctness and so the next added model does not arm it.

Concretely, with the layouts observed under a tracking allocator (test fixtures sized to expose the mismatch; the onnx models fixture uses 2 entries where production currently has 1):

- candle: a 4-match `matches` array allocates 32 bytes and frees 8; the 2-entry `models` array allocates 64 bytes and frees 32.
- onnx: same 32 vs 8 for `matches`; a 2-entry `models` array allocates 96 bytes and frees 48.

This has never crashed in practice because the default system allocator routes through `free()`, which takes no size, so the mismatch is silently absorbed. It is still UB at the Rust language level and breaks immediately under any size-aware allocator (jemalloc/mimalloc with sized deallocation, sanitizers, Miri).

The fix reclaims the arrays with `Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len))`, the same pattern `free_multimodal_embedding` already uses. The pattern dates back to the modular candle-binding refactor in #266 (candle modular refactor) and was inherited by onnx-binding in #1218 (onnx binding introduction); #1997 (embedding.rs clippy retirement) reorganized lint debt around these functions without changing the free semantics.

Because the system allocator masks the bug, a plain alloc/free round-trip test passes against the broken form. The second commit adds dealloc-layout regression tests that install a layout-tracking `#[global_allocator]` in the test binary (test-only code, recording restricted to the window-owner thread with a reentrancy guard). The tests fail against the previous free implementations with the exact byte counts above and pass with the fix.

A third commit cleans the onnx memory.rs lint surface the diff promotes: it mirrors the `#[allow(clippy::not_unsafe_ptr_arg_deref)]` candle uses on its boxed-slice free functions onto the four onnx free functions, and moves `free_embedding` (whose layout was already correct) to the same explicit `slice_from_raw_parts_mut` form, which also clears the newer `from_raw_parts_mut` cast lint.

One note on test lanes, stated plainly: the CI `make test` path exercises the bindings through `go test` (cgo), where the system allocator masks this class of bug by construction. The new candle tests run in the local Rust development lane (`make test-rust`, which CI skips); the crate-publish workflow runs only two named integration-test targets, not `--lib`, so they do not execute there either. The onnx-binding tests currently have no automated lane at all and run via `cd onnx-binding && cargo test --lib`. If a `cargo test --lib` CI lane for the bindings is welcome, happy to add one as a follow-up; it is what makes this defect class machine-checkable.

## Test Plan

- [ ] `cd candle-binding && cargo test --no-default-features --lib dealloc_layout` passes with the fix
- [ ] `cd onnx-binding && cargo test --lib memory_test` passes with the fix
- [ ] Both test modules verified red against the previous free implementations (fix commit stashed): layout mismatches reported as alloc 32/free 8 and alloc 64/free 32 (candle), alloc 32/free 8 and alloc 96/free 48 (onnx)
- [ ] Repeated parallel-thread runs stable (8 consecutive green runs, onnx; 3 consecutive, candle)
- [ ] `make agent-lint CHANGED_FILES=...` passes (cargo fmt, cargo check, changed-file clippy, structure checks)

## Test Result

(local lane results; no per-PR CI lane runs cargo --lib tests in either crate - see the test-lane note above)

