### PR TITLE
[Dashboard] Clarify account details trigger in header

### DIFF
--- a/dashboard/frontend/src/components/LayoutAccountControl.module.css
+++ b/dashboard/frontend/src/components/LayoutAccountControl.module.css
@@ -72,22 +72,6 @@
   font-weight: 400;
 }
 
-.triggerChevron {
-  flex-shrink: 0;
-  opacity: 0.62;
-  transition: transform var(--transition-fast), opacity var(--transition-fast);
-}
-
-.triggerActive .triggerChevron,
-.trigger:hover .triggerChevron,
-.trigger:focus-visible .triggerChevron {
-  opacity: 1;
-}
-
-.triggerChevronOpen {
-  transform: rotate(180deg);
-}
-
 .overlay {
   position: fixed;
   inset: 0;

--- a/dashboard/frontend/src/components/LayoutAccountControl.tsx
+++ b/dashboard/frontend/src/components/LayoutAccountControl.tsx
@@ -82,29 +82,15 @@ const LayoutAccountControl: React.FC<LayoutAccountControlProps> = ({
         aria-controls={isOpen ? dialogId : undefined}
         aria-expanded={isOpen}
         aria-haspopup="dialog"
-        aria-label={`Open account details for ${accountName}`}
+        aria-label={`View account details for ${accountName}`}
         data-testid={isRail ? 'playground-account-control' : undefined}
         onClick={onToggle}
-        title={isRail ? accountName : undefined}
+        title={isRail ? accountName : 'View account details'}
       >
         <span className={`${styles.triggerAvatar} ${isRail ? styles.triggerAvatarRail : ''}`} aria-hidden="true">
           {initials}
         </span>
         {isRail ? null : <span className={styles.triggerName}>{accountName}</span>}
-        {isRail ? null : (
-          <svg
-            className={`${styles.triggerChevron} ${isOpen ? styles.triggerChevronOpen : ''}`}
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            aria-hidden="true"
-          >
-            <path d="M3 4.5L6 7.5L9 4.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        )}
       </button>
 
       {isOpen && typeof document !== 'undefined'


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes N/A

## Purpose

- Remove the dropdown-style chevron from the Dashboard header account control.
- Update the account trigger accessibility text and tooltip so it communicates that clicking opens account details, not a dropdown menu.
- This avoids misleading users into expecting a menu when the actual interaction opens an account details popup/dialog.
- Affected module(s): `Dashboard`

## Test Plan

- Run focused Dashboard frontend checks:
  - `npm run lint`
  - `npm run type-check`
  - `npm run test:unit`
- Run the full Dashboard quick check:
  - `make dashboard-check`
- This validation is sufficient because the change is scoped to Dashboard header UI rendering and CSS cleanup. It does not change backend behavior, router runtime behavior, auth/session logic, or config schema.

## Test Result

- Focused frontend checks passed:
  - `npm run lint`
  - `npm run type-check`
  - `npm run test:unit`
- Frontend unit tests passed: 11 test files, 40 tests.
- `make dashboard-check` passed.
- Existing npm audit warnings and Sass/Svelte deprecation warnings were printed during dashboard checks, but they are unrelated to this PR and did not fail validation.
- No follow-up blockers identified.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.