### PR TITLE
[Dashboard] reject closed-window bootstrap registration before bcrypt work

### DIFF
--- a/dashboard/backend/auth/bootstrap_gate_test.go
+++ b/dashboard/backend/auth/bootstrap_gate_test.go
@@ -149,3 +149,50 @@ func TestBootstrapRegister_ConcurrentCreatesExactlyOneAdmin(t *testing.T) {
 		t.Fatalf("got %d successful registrations; want exactly 1", ok)
 	}
 }
+
+// Once an admin exists, a register attempt must be rejected before any bcrypt
+// work happens: with the endpoint enabled (setup mode or open bootstrap), an
+// unauthenticated caller must not be able to burn a cost-12 bcrypt round per
+// request against an already-consumed bootstrap window.
+func TestBootstrapRegister_ClosedWindowRejectsBeforeHashing(t *testing.T) {
+	svc := newBootstrapService(t, false, true)
+	newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
+
+	hashCalls := 0
+	orig := hashBootstrapPassword
+	hashBootstrapPassword = func(svc *Service, password string) (string, error) {
+		hashCalls++
+		return orig(svc, password)
+	}
+	t.Cleanup(func() { hashBootstrapPassword = orig })
+
+	rec := postRegister(svc, "second@example.com")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 when an admin already exists", rec.Code)
+	}
+	if hashCalls != 0 {
+		t.Fatalf("bcrypt hash invoked %d times on a closed bootstrap window; want 0", hashCalls)
+	}
+}
+
+// The open window still hashes exactly once and creates the admin: the
+// fast-reject must not change the success path.
+func TestBootstrapRegister_OpenWindowStillHashesAndCreates(t *testing.T) {
+	svc := newBootstrapService(t, false, true)
+
+	hashCalls := 0
+	orig := hashBootstrapPassword
+	hashBootstrapPassword = func(svc *Service, password string) (string, error) {
+		hashCalls++
+		return orig(svc, password)
+	}
+	t.Cleanup(func() { hashBootstrapPassword = orig })
+
+	rec := postRegister(svc, "admin@example.com")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if hashCalls != 1 {
+		t.Fatalf("bcrypt hash invoked %d times on the open path; want 1", hashCalls)
+	}
+}

--- a/dashboard/backend/auth/bootstrap_gate_test.go
+++ b/dashboard/backend/auth/bootstrap_gate_test.go
@@ -42,6 +42,21 @@ func postRegister(svc *Service, email string) *httptest.ResponseRecorder {
 	return rec
 }
 
+// trackHashCalls swaps hashBootstrapPassword for a counting wrapper for the
+// duration of the test and returns a pointer to the live invocation count, so a
+// test can assert how many bcrypt rounds a register attempt actually performed.
+func trackHashCalls(t *testing.T) *int {
+	t.Helper()
+	calls := 0
+	orig := hashBootstrapPassword
+	hashBootstrapPassword = func(svc *Service, password string) (string, error) {
+		calls++
+		return orig(svc, password)
+	}
+	t.Cleanup(func() { hashBootstrapPassword = orig })
+	return &calls
+}
+
 // With open bootstrap disabled (the default), can-register must report false even
 // when no users exist - both to disable the path and to avoid leaking to an
 // unauthenticated caller that the instance is freshly deployed and claimable.
@@ -158,20 +173,14 @@ func TestBootstrapRegister_ClosedWindowRejectsBeforeHashing(t *testing.T) {
 	svc := newBootstrapService(t, false, true)
 	newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
 
-	hashCalls := 0
-	orig := hashBootstrapPassword
-	hashBootstrapPassword = func(svc *Service, password string) (string, error) {
-		hashCalls++
-		return orig(svc, password)
-	}
-	t.Cleanup(func() { hashBootstrapPassword = orig })
+	hashCalls := trackHashCalls(t)
 
 	rec := postRegister(svc, "second@example.com")
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409 when an admin already exists", rec.Code)
 	}
-	if hashCalls != 0 {
-		t.Fatalf("bcrypt hash invoked %d times on a closed bootstrap window; want 0", hashCalls)
+	if *hashCalls != 0 {
+		t.Fatalf("bcrypt hash invoked %d times on a closed bootstrap window; want 0", *hashCalls)
 	}
 }
 
@@ -180,19 +189,13 @@ func TestBootstrapRegister_ClosedWindowRejectsBeforeHashing(t *testing.T) {
 func TestBootstrapRegister_OpenWindowStillHashesAndCreates(t *testing.T) {
 	svc := newBootstrapService(t, false, true)
 
-	hashCalls := 0
-	orig := hashBootstrapPassword
-	hashBootstrapPassword = func(svc *Service, password string) (string, error) {
-		hashCalls++
-		return orig(svc, password)
-	}
-	t.Cleanup(func() { hashBootstrapPassword = orig })
+	hashCalls := trackHashCalls(t)
 
 	rec := postRegister(svc, "admin@example.com")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	if hashCalls != 1 {
-		t.Fatalf("bcrypt hash invoked %d times on the open path; want 1", hashCalls)
+	if *hashCalls != 1 {
+		t.Fatalf("bcrypt hash invoked %d times on the open path; want 1", *hashCalls)
 	}
 }

--- a/dashboard/backend/auth/public_handlers.go
+++ b/dashboard/backend/auth/public_handlers.go
@@ -32,6 +32,12 @@ func bootstrapCanRegisterHandler(svc *Service) http.HandlerFunc {
 	}
 }
 
+// hashBootstrapPassword is an indirection over Service.HashPassword so tests
+// can observe that no bcrypt work happens once the bootstrap window is closed.
+var hashBootstrapPassword = func(svc *Service, password string) (string, error) {
+	return svc.HashPassword(password)
+}
+
 func bootstrapRegisterHandler(svc *Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -54,7 +60,23 @@ func bootstrapRegisterHandler(svc *Service) http.HandlerFunc {
 			return
 		}
 
-		hash, err := svc.HashPassword(req.Password)
+		// Fast-reject before the expensive bcrypt hash: once an admin exists this
+		// request is certain to fail, and hashing first lets unauthenticated
+		// callers burn a full cost-12 bcrypt round per request for as long as the
+		// bootstrap endpoint stays enabled. This check is a cheap pre-filter
+		// only; BootstrapRegister re-checks under its lock, which remains the
+		// correctness gate for concurrent requests.
+		canBootstrap, err := svc.CanBootstrap(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !canBootstrap {
+			http.Error(w, "bootstrap is disabled", http.StatusConflict)
+			return
+		}
+
+		hash, err := hashBootstrapPassword(svc, req.Password)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION

## Purpose

`bootstrapRegisterHandler` runs the cost-12 bcrypt hash before `BootstrapRegister`'s closed-window check. Once the first admin exists, every further unauthenticated POST to `/api/auth/bootstrap/register` is certain to be rejected, but it still burns a full bcrypt round first. With setup mode keeping the endpoint enabled for the process lifetime per #2158 (setup-mode registration), an unauthenticated caller can spend dashboard CPU at no cost for as long as the process runs by replaying valid-shaped register requests against the consumed window.

This PR adds a cheap `CanBootstrap` fast-reject between body validation and hashing. The closed-window response is unchanged: the fast path returns the identical 409 `bootstrap is disabled` as the existing post-hash branch. One deliberate delta: a store failure in the pre-check now returns 500 instead of falling into the generic 400 branch, matching how `bootstrapCanRegisterHandler` already handles the same `CanBootstrap` error. It is a pre-filter only: `BootstrapRegister` still re-checks under its lock, which remains the correctness gate for concurrent requests (the existing concurrent-creates-exactly-one-admin test is untouched and still passes).

Hashing now goes through a package-level indirection (`hashBootstrapPassword`) so tests can observe that the closed window performs no bcrypt work. Two tests pin the behavior:

- closed window: 409 and zero hash invocations (fails against the previous handler order, which hashed once before the conflict)
- open window: exactly one hash invocation and a 200 with the admin created

## Test Plan

- [x] `go test ./auth/... -count=1` (dashboard/backend) passes, including the two new tests
- [x] New closed-window test verified red against the previous handler order (hash invoked 1 time; want 0)
- [x] Existing bootstrap gate tests unchanged and passing (disabled-by-default, setup-mode lifecycle, second-attempt conflict, concurrent race)
- [x] `make agent-lint CHANGED_FILES=...` passes

## Test Result

All CI checks green: Dashboard Lint and Type Check, pre-commit hooks, DCO, supply-chain AST scan, and the full `build_pr` image matrix. The `test-and-build` and `integration-test` jobs were path-filtered out by this dashboard-only diff, as expected.

Locally on the same commit, the full `dashboard/backend/auth` suite passes, and the new closed-window test was re-proven red against the previous handler order (fails with `bcrypt hash invoked 1 times on a closed bootstrap window; want 0`) before going green with the fix applied.

No known follow-up risks. The fast-reject is a pre-filter only; the lock-guarded re-check in `BootstrapRegister` remains the concurrency correctness gate.
