### PR TITLE
[CI/Build] refresh precommit-local image before running

### DIFF
--- a/tools/make/pre-commit.mk
+++ b/tools/make/pre-commit.mk
@@ -40,12 +40,23 @@ precommit-local:
 		echo "Error: Neither docker nor podman is installed. Please install one of them."; \
 		exit 1; \
 	fi; \
-	if ! $$CONTAINER_CMD image inspect ${PRECOMMIT_CONTAINER} > /dev/null 2>&1; then \
-		echo "Image not found locally. Pulling..."; \
-		$$CONTAINER_CMD pull ${PRECOMMIT_CONTAINER}; \
+	IMAGE_SOURCE="freshly pulled image"; \
+	echo "Refreshing ${PRECOMMIT_CONTAINER}..."; \
+	if $$CONTAINER_CMD pull ${PRECOMMIT_CONTAINER}; then \
+		:; \
 	else \
-		echo "Image found locally. Skipping pull."; \
+		echo "Warning: failed to pull ${PRECOMMIT_CONTAINER}; checking for a cached image..." >&2; \
+		IMAGE_SOURCE="cached local image"; \
 	fi; \
+	if ! $$CONTAINER_CMD image inspect ${PRECOMMIT_CONTAINER} > /dev/null 2>&1; then \
+		echo "Error: ${PRECOMMIT_CONTAINER} is unavailable locally and could not be pulled."; \
+		exit 1; \
+	fi; \
+	IMAGE_REF=$$($$CONTAINER_CMD image inspect ${PRECOMMIT_CONTAINER} --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}' 2>/dev/null); \
+	if [ -z "$$IMAGE_REF" ]; then \
+		IMAGE_REF=${PRECOMMIT_CONTAINER}; \
+	fi; \
+	echo "Using $$IMAGE_SOURCE: $$IMAGE_REF"; \
 	$$CONTAINER_CMD run --rm \
 	    -e AGENT_BASE_REF="$(AGENT_BASE_REF)" \
 	    -v $(shell pwd):/app \


### PR DESCRIPTION
Closes #2167

## Purpose

- Update `make precommit-local` to always try pulling `ghcr.io/vllm-project/semantic-router/precommit:latest` before running.
- Fall back to the cached local image when the pull fails but a local copy already exists.
- Fail clearly when the pull fails and no local image is available.
- Print the exact image ref/digest used for the run so local results are easier to compare with CI.
- This change is needed because `precommit-local` previously skipped pulls whenever `:latest` already existed locally, which could silently run a stale tool image and drift from CI.
- Affected module(s): `CI/Build`

## Test Plan

- Inspect the updated `precommit-local` recipe in `tools/make/pre-commit.mk`.
- Run `make -n precommit-local` to confirm the command flow is:
  1. detect docker/podman
  2. try `pull`
  3. fall back to cached image only if needed
  4. print the image ref/digest
  5. run the containerized pre-commit gate
- Run `make precommit-local AGENT_BASE_REF=HEAD^` to verify the live Docker path uses the refreshed image and prints the resolved digest.
- Why this is sufficient: the change is isolated to the local pre-commit wrapper, and the main correctness criteria are the pull/fallback control flow and the emitted image identity.

## Test Result

- `make -n precommit-local` showed the expected control flow: detect docker/podman, pull first, fall back to a cached image if needed, print the resolved image ref/digest, then run the container.
- `make precommit-local AGENT_BASE_REF=HEAD^` successfully refreshed `ghcr.io/vllm-project/semantic-router/precommit:latest` and printed the exact image digest used:
  `ghcr.io/vllm-project/semantic-router/precommit@sha256:b67e7c209148b8b97f6942a2e326b5a6ba4156b206f33b9d7c9669a2c2398cea`
- `make agent-lint CHANGED_FILES="tools/make/pre-commit.mk"` passed for the changed file, including baseline pre-commit checks, agent changed-files lint, reference config contract lint, and structure checks.
- Follow-up risk/gap: I did not reproduce the offline fallback branch in a fully disconnected environment, so that path is validated by control-flow inspection rather than a full manual offline run.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>