### PR TITLE
[CI/Build] Run CI-safe Rust lib tests

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -78,6 +78,9 @@ jobs:
           exit 1
         fi
 
+    - name: Run Rust lib unit tests (CPU-only, no model assets)
+      run: make test-rust-ci
+
     - name: Run API smoke tests (CPU-only, no CUDA)
       working-directory: candle-binding
       run: |

--- a/tools/make/build-run-test.mk
+++ b/tools/make/build-run-test.mk
@@ -94,7 +94,7 @@ test-semantic-router: build-router
 #   4. Run test-binding-lora
 # In local dev, run all tests together
 ifeq ($(CI),true)
-test: vet check-go-mod-tidy download-models test-binding-minimal test-semantic-router clean-minimal-models download-models-lora test-binding-lora
+test: vet check-go-mod-tidy test-rust-ci download-models test-binding-minimal test-semantic-router clean-minimal-models download-models-lora test-binding-lora
 else
 test: vet check-go-mod-tidy download-models $(if $(CI),,test-rust) test-binding test-semantic-router
 endif

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -5,6 +5,31 @@
 # Default GPU device for testing (can be overridden: TEST_GPU_DEVICE=3 make test-rust)
 TEST_GPU_DEVICE ?= 2
 
+# Rust lib unit tests that are safe for PR CI:
+# - no downloaded model assets
+# - no GPU/CUDA requirement
+# - deterministic pure Rust/FFI helper logic
+#
+# Keep this list explicit. Do not include tests whose fixtures initialize
+# models from ../models unless those tests have been converted to skip cleanly.
+RUST_CI_LIB_TESTS ?= \
+	core::tokenization_test::test_tokenization_config_default \
+	core::tokenization_test::test_tokenization_config_custom
+
+test-rust-ci:
+	@$(LOG_TARGET)
+	@echo "Running CI-safe Rust lib unit tests (CPU-only, no model assets)"
+	@cd candle-binding && \
+	test_list="$$(cargo test --release --no-default-features --lib -- --list)" && \
+	for test_filter in $(RUST_CI_LIB_TESTS); do \
+		echo "$$test_list" | grep -F "$${test_filter}:" >/dev/null || { \
+			echo "Configured Rust CI test not found: $$test_filter"; \
+			exit 1; \
+		}; \
+		echo "Running $$test_filter"; \
+		cargo test --release --no-default-features --lib "$$test_filter" -- --exact --test-threads=1 --nocapture; \
+	done
+
 # Test Rust unit tests (with release optimization for performance)
 # Note: Uses TEST_GPU_DEVICE env var (default: 2) to avoid GPU 0/1 which may be busy
 # Override with: TEST_GPU_DEVICE=3 make test-rust

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -27,7 +27,7 @@ test-rust-ci:
 			exit 1; \
 		}; \
 		echo "Running $$test_filter"; \
-		cargo test --release --no-default-features --lib "$$test_filter" -- --exact --test-threads=1 --nocapture; \
+		cargo test --release --no-default-features --lib "$$test_filter" -- --exact --test-threads=1 --nocapture || exit 1; \
 	done
 
 # Test Rust unit tests (with release optimization for performance)

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -14,7 +14,8 @@ TEST_GPU_DEVICE ?= 2
 # models from ../models unless those tests have been converted to skip cleanly.
 RUST_CI_LIB_TESTS ?= \
 	core::tokenization_test::test_tokenization_config_default \
-	core::tokenization_test::test_tokenization_config_custom
+	core::tokenization_test::test_tokenization_config_custom \
+	ffi::embedding_test::test_truncate_embedding_renormalizes_prefix
 
 test-rust-ci:
 	@$(LOG_TARGET)


### PR DESCRIPTION
Closes #2182

## Purpose

- Add a CI-safe Rust `--lib` unit test target for `candle-binding` that runs without downloaded model assets or GPU/CUDA requirements.
- Wire that target into the `CI=true` `make test` path so PR CI covers the curated Rust unit-test subset before model-dependent binding tests.
- Run the same CI-safe Rust unit tests in `publish-crate.yml` before the crate release workflow moves on to API smoke tests.
- Affected module(s): `Bindings`, `CI/Build`