### PR TITLE
docs(vllm-sr): document model list command

### DIFF
--- a/src/vllm-sr/README.md
+++ b/src/vllm-sr/README.md
@@ -145,6 +145,25 @@ vllm-sr validate config.yaml
 
 `vllm-sr init` was removed in v0.3. Author `config.yaml` directly using the canonical `version/listeners/providers/routing/global` layout, migrate an older file with `vllm-sr config migrate --config old-config.yaml`, or import supported OpenClaw model providers with `vllm-sr config import --from openclaw`. Router-wide defaults come from the router itself and can be overridden under `global:`.
 
+### Inspect configured models
+
+Use `vllm-sr model list` to print the provider models and routing model cards from your active config without opening the dashboard.
+
+```bash
+# Uses config.yaml in the current directory
+vllm-sr model list
+
+# Inspect a specific config file
+vllm-sr model list --config my-config.yaml
+```
+
+The output is split into two sections:
+
+- **Provider models**: configured model names, the default model marker, provider model IDs, reasoning family, API format, and backend identity fields such as provider, redacted base URL, protocol, and weight.
+- **Model cards**: routing metadata such as modality, parameter size, context window, capabilities, tags, and LoRA names.
+
+Credential fields are intentionally not printed. API keys, API key environment variable names, embedded URL credentials, and sensitive query parameters are omitted or redacted so the command is safe to use in support logs.
+
 ## Features
 
 - **Router**: Intelligent request routing based on intent classification

--- a/src/vllm-sr/tests/test_model_command.py
+++ b/src/vllm-sr/tests/test_model_command.py
@@ -23,6 +23,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 main = importlib.import_module("cli.main").main
+README_PATH = PROJECT_ROOT / "README.md"
 
 
 _VALID_CONFIG = {
@@ -106,6 +107,15 @@ def test_model_list_help_describes_subcommand():
 
     assert result.exit_code == 0
     assert "list" in result.output
+
+
+def test_readme_documents_model_list_usage():
+    content = README_PATH.read_text(encoding="utf-8")
+
+    assert "vllm-sr model list" in content
+    assert "vllm-sr model list --config my-config.yaml" in content
+    assert "Provider models" in content
+    assert "Model cards" in content
 
 
 def test_model_list_prints_provider_models_and_model_cards(tmp_path: Path, caplog):


### PR DESCRIPTION
## Summary
- document `vllm-sr model list` usage in the vllm-sr README
- describe provider model and model card output sections
- call out credential redaction behavior for support-log-safe output
- add a README surface test for the documented command

Closes #2181

## Tests
- `uv run --project src/vllm-sr --extra dev pytest src/vllm-sr/tests/test_model_command.py -q`
- `uv run --project src/vllm-sr --extra dev pytest src/vllm-sr/tests -q`
- `make agent-report ENV=cpu AGENT_VENV="$PWD/.venv-agent-py312" AGENT_PYTHON="$PWD/.venv-agent-py312/bin/python" CHANGED_FILES="src/vllm-sr/README.md src/vllm-sr/tests/test_model_command.py"`
- `make vllm-sr-test AGENT_VENV="$PWD/.venv-agent-py312" AGENT_PYTHON="$PWD/.venv-agent-py312/bin/python"`
- `uv run --project src/vllm-sr --extra dev black --check src/vllm-sr/tests/test_model_command.py`
- `git diff --check`