### PR TITLE
[Router] Fix selection embeddings for non-qwen3 model_type

### DIFF
--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -66,22 +66,9 @@ func resolveSelectionEmbeddingFunc(cfg *config.RouterConfig) func(string) ([]flo
 	case "openvino":
 		return openvinoEmbeddingFunc(modelType)
 	default:
-		// The candle batched embedding path (GetEmbeddingBatched) is only
-		// implemented for the qwen3 continuous-batching model; it rejects any
-		// other model_type with "unsupported model type ... (only 'qwen3'
-		// supported)". The default embedding model_type is "mmbert", so
-		// unconditionally using the batched path makes every selection
-		// embedding fail for the default config — RouterDC/hybrid then fall
-		// back to flat scores. Route non-qwen3 model types through the
-		// single-text FFI (GetEmbeddingWithModelType), which supports mmbert,
-		// gemma, etc. and is what the rest of the router already uses.
-		//
-		// target_dim differs by path: the qwen3 batched model emits 1024-dim
-		// vectors, but mmbert is a 2D-Matryoshka model whose native dimension
-		// is 768 and cannot be truncated upward — passing 1024 fails the
-		// forward pass. Use 0 (native dimension) for the single-text path so
-		// each model returns its own dimension; the selector only needs the
-		// per-model embeddings to be mutually consistent, which they are.
+		// Batched FFI only supports qwen3 (1024-dim). Other types (default
+		// mmbert, gemma, ...) use the single-text FFI with target_dim 0 so
+		// each model returns its native dimension.
 		if candleEmbeddingSupportsBatched(modelType) {
 			return func(text string) ([]float32, error) {
 				output, err := candle_binding.GetEmbeddingBatched(text, modelType, 1024)
@@ -101,10 +88,8 @@ func resolveSelectionEmbeddingFunc(cfg *config.RouterConfig) func(string) ([]flo
 	}
 }
 
-// candleEmbeddingSupportsBatched reports whether the candle continuous-batching
-// embedding FFI (GetEmbeddingBatched) supports the given model type. Only qwen3
-// is implemented for batching; all other model types must use the single-text
-// FFI (GetEmbeddingWithModelType).
+// candleEmbeddingSupportsBatched reports whether the batched embedding FFI
+// supports the model type. Only qwen3 does; others use the single-text FFI.
 func candleEmbeddingSupportsBatched(modelType string) bool {
 	return modelType == "qwen3"
 }

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -66,14 +66,47 @@ func resolveSelectionEmbeddingFunc(cfg *config.RouterConfig) func(string) ([]flo
 	case "openvino":
 		return openvinoEmbeddingFunc(modelType)
 	default:
+		// The candle batched embedding path (GetEmbeddingBatched) is only
+		// implemented for the qwen3 continuous-batching model; it rejects any
+		// other model_type with "unsupported model type ... (only 'qwen3'
+		// supported)". The default embedding model_type is "mmbert", so
+		// unconditionally using the batched path makes every selection
+		// embedding fail for the default config — RouterDC/hybrid then fall
+		// back to flat scores. Route non-qwen3 model types through the
+		// single-text FFI (GetEmbeddingWithModelType), which supports mmbert,
+		// gemma, etc. and is what the rest of the router already uses.
+		//
+		// target_dim differs by path: the qwen3 batched model emits 1024-dim
+		// vectors, but mmbert is a 2D-Matryoshka model whose native dimension
+		// is 768 and cannot be truncated upward — passing 1024 fails the
+		// forward pass. Use 0 (native dimension) for the single-text path so
+		// each model returns its own dimension; the selector only needs the
+		// per-model embeddings to be mutually consistent, which they are.
+		if candleEmbeddingSupportsBatched(modelType) {
+			return func(text string) ([]float32, error) {
+				output, err := candle_binding.GetEmbeddingBatched(text, modelType, 1024)
+				if err != nil {
+					return nil, err
+				}
+				return output.Embedding, nil
+			}
+		}
 		return func(text string) ([]float32, error) {
-			output, err := candle_binding.GetEmbeddingBatched(text, modelType, 1024)
+			output, err := candle_binding.GetEmbeddingWithModelType(text, modelType, 0)
 			if err != nil {
 				return nil, err
 			}
 			return output.Embedding, nil
 		}
 	}
+}
+
+// candleEmbeddingSupportsBatched reports whether the candle continuous-batching
+// embedding FFI (GetEmbeddingBatched) supports the given model type. Only qwen3
+// is implemented for batching; all other model types must use the single-text
+// FFI (GetEmbeddingWithModelType).
+func candleEmbeddingSupportsBatched(modelType string) bool {
+	return modelType == "qwen3"
 }
 
 func collectConfiguredAlgorithmMethods(cfg *config.RouterConfig) []selection.SelectionMethod {

--- a/src/semantic-router/pkg/extproc/router_selection_dispatch_test.go
+++ b/src/semantic-router/pkg/extproc/router_selection_dispatch_test.go
@@ -2,12 +2,8 @@ package extproc
 
 import "testing"
 
-// TestCandleEmbeddingSupportsBatched guards the selection-embedding dispatch:
-// the candle batched FFI (GetEmbeddingBatched) is implemented only for qwen3,
-// so every other model type — including the default "mmbert" — must be routed
-// to the single-text FFI (GetEmbeddingWithModelType). Regressing this makes
-// selection embeddings fail for the default config and collapses RouterDC /
-// hybrid / session_aware base scores to a flat tie.
+// TestCandleEmbeddingSupportsBatched checks only qwen3 uses the batched FFI;
+// other types (incl. default mmbert) must use the single-text FFI.
 func TestCandleEmbeddingSupportsBatched(t *testing.T) {
 	cases := []struct {
 		modelType string

--- a/src/semantic-router/pkg/extproc/router_selection_dispatch_test.go
+++ b/src/semantic-router/pkg/extproc/router_selection_dispatch_test.go
@@ -1,0 +1,29 @@
+package extproc
+
+import "testing"
+
+// TestCandleEmbeddingSupportsBatched guards the selection-embedding dispatch:
+// the candle batched FFI (GetEmbeddingBatched) is implemented only for qwen3,
+// so every other model type — including the default "mmbert" — must be routed
+// to the single-text FFI (GetEmbeddingWithModelType). Regressing this makes
+// selection embeddings fail for the default config and collapses RouterDC /
+// hybrid / session_aware base scores to a flat tie.
+func TestCandleEmbeddingSupportsBatched(t *testing.T) {
+	cases := []struct {
+		modelType string
+		batched   bool
+	}{
+		{"qwen3", true},
+		{"mmbert", false},
+		{"gemma", false},
+		{"bert", false},
+		{"modernbert", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		if got := candleEmbeddingSupportsBatched(tc.modelType); got != tc.batched {
+			t.Errorf("candleEmbeddingSupportsBatched(%q) = %v, want %v", tc.modelType, got, tc.batched)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`resolveSelectionEmbeddingFunc` (introduced in #1907) routes every candle-backend
selection embedding through `GetEmbeddingBatched`, which the candle FFI implements
**only for the qwen3 continuous-batching model** — it rejects any other `model_type`
with `unsupported model type ... (only 'qwen3' supported)`.

The default embedding `model_type` is `mmbert` (`pkg/config/canonical_defaults.go`),
so with the default config **every model-description embedding fails**:

```
[RouterDC] Failed to embed model <m>: failed to generate batched embedding (status: -1)
router_dc_config_embeddings_initialized  models_with_descriptions=0
```

RouterDC — and hybrid's `router_dc` component, and `session_aware` when its base
selector uses them — are then left with no model embeddings and silently fall back
to undifferentiated scores.

## Root cause

Two issues in the candle (default) branch:

1. **Wrong FFI entrypoint.** `mmbert` / `gemma` are supported by the single-text FFI
   `GetEmbeddingWithModelType` (used everywhere else in the router), not by the
   qwen3-only `GetEmbeddingBatched`.
2. **Wrong target dimension.** The branch passed `target_dim=1024` (qwen3's native
   dimension). `mmbert` is a 768-dim 2D-Matryoshka model and cannot be truncated
   upward, so 1024 fails the forward pass even on the single-text path.

## Fix

Dispatch by batched-capability: only `qwen3` uses `GetEmbeddingBatched`; every other
`model_type` uses `GetEmbeddingWithModelType` with `target_dim=0` (native dimension,
model-agnostic). Adds a `candleEmbeddingSupportsBatched` helper and a unit test for
the dispatch decision.

## Test Plan

- New unit test `TestCandleEmbeddingSupportsBatched` covers qwen3 (batched) vs
  mmbert/gemma/bert/empty (single-text).
- Built the router image with the fix and ran against a config using the default
  `mmbert` embedding `model_type`:
  - **Before:** `[RouterDC] Failed to embed model ... (status: -1)` for every model,
    `router_dc_config_embeddings_initialized models_with_descriptions=0`.
  - **After:** `models_with_descriptions=4`, no embed errors, and with a `router_dc`
    selector `[RouterDC] Selected model ... (similarity=1.0000, confidence=0.95)` —
    embeddings are computed and consumed.

Fixes #2173
Refs #2172 — this fixes the selection-dispatch half (the `status: -1` on the
qwen3-only batched path). The packaging half (Docker mmbert dir missing
`model.safetensors` / `tokenizer.json`) is #2195.
