### PR TITLE
[Router] Require embedding model weights+tokenizer for download completeness

### DIFF
--- a/src/semantic-router/pkg/modeldownload/config_parser.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser.go
@@ -98,6 +98,7 @@ func BuildModelSpecs(cfg *config.RouterConfig) ([]ModelSpec, error) {
 	// Extract all model paths from config
 	paths := filterDisabledOptionalModelPaths(cfg, ExtractModelPaths(cfg))
 	requiredFilesByModel := ExtractRequiredFilesByModel(cfg)
+	addEmbeddingModelRequiredFiles(cfg, requiredFilesByModel)
 
 	// Allow empty paths for API-only configurations
 	if len(paths) == 0 {
@@ -134,6 +135,32 @@ func BuildModelSpecs(cfg *config.RouterConfig) ([]ModelSpec, error) {
 	}
 
 	return specs, nil
+}
+
+// embeddingModelWeightFiles are the files the candle embedding runtime loads to bring a
+// semantic embedding model up. They are deliberately stricter than the nested-weight
+// heuristic in IsModelComplete: a directory holding only config.json + onnx/ (the layout
+// shipped in the image) otherwise satisfies that heuristic via the nested *.onnx files and
+// the safetensors/tokenizer download is never triggered, leaving embedding_ready=false (#2172).
+var embeddingModelWeightFiles = []string{"model.safetensors", "tokenizer.json"}
+
+// addEmbeddingModelRequiredFiles marks the configured semantic embedding model as requiring
+// its safetensors weights and tokenizer so a partial (ONNX-only) directory is detected as
+// incomplete and the full snapshot is re-downloaded.
+func addEmbeddingModelRequiredFiles(cfg *config.RouterConfig, requiredFilesByModel map[string][]string) {
+	// MmBertModelPath holds the configured semantic embedding model directory.
+	path := cfg.MmBertModelPath
+	if path == "" || !strings.HasPrefix(path, "models/") {
+		return
+	}
+
+	existing := requiredFilesByModel[path]
+	for _, fileName := range embeddingModelWeightFiles {
+		if !slices.Contains(existing, fileName) {
+			existing = append(existing, fileName)
+		}
+	}
+	requiredFilesByModel[path] = existing
 }
 
 // ExtractRequiredFilesByModel derives per-model completeness requirements from

--- a/src/semantic-router/pkg/modeldownload/embedding_completeness_test.go
+++ b/src/semantic-router/pkg/modeldownload/embedding_completeness_test.go
@@ -1,0 +1,122 @@
+package modeldownload
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+const (
+	testEmbeddingModelPath = "models/mmbert-embed-32k-2d-matryoshka"
+	testEmbeddingRepoID    = "llm-semantic-router/mmbert-embed-32k-2d-matryoshka"
+)
+
+func newEmbeddingOnlyConfig() *config.RouterConfig {
+	return &config.RouterConfig{
+		MoMRegistry: map[string]string{
+			testEmbeddingModelPath: testEmbeddingRepoID,
+		},
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MmBertModelPath: testEmbeddingModelPath,
+			},
+		},
+	}
+}
+
+func findSpecByPath(specs []ModelSpec, localPath string) (ModelSpec, bool) {
+	for _, spec := range specs {
+		if spec.LocalPath == localPath {
+			return spec, true
+		}
+	}
+	return ModelSpec{}, false
+}
+
+// TestBuildModelSpecsRequiresEmbeddingModelWeightsAndTokenizer guards #2172:
+// the candle embedding runtime loads the model from model.safetensors + tokenizer.json,
+// so those must be part of the embedding model's completeness contract. Otherwise a dir
+// holding only config.json + onnx/ (the state shipped in the image) passes the
+// nested-onnx weight heuristic and the safetensors/tokenizer download is never triggered.
+func TestBuildModelSpecsRequiresEmbeddingModelWeightsAndTokenizer(t *testing.T) {
+	specs, err := BuildModelSpecs(newEmbeddingOnlyConfig())
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+
+	spec, ok := findSpecByPath(specs, testEmbeddingModelPath)
+	if !ok {
+		t.Fatalf("BuildModelSpecs() did not produce a spec for %q; got %#v", testEmbeddingModelPath, specs)
+	}
+
+	for _, want := range []string{"config.json", "model.safetensors", "tokenizer.json"} {
+		if !slices.Contains(spec.RequiredFiles, want) {
+			t.Fatalf("embedding spec RequiredFiles = %#v, missing %q", spec.RequiredFiles, want)
+		}
+	}
+}
+
+// TestOnnxOnlyEmbeddingDirReportedIncomplete reproduces the #2172 symptom end-to-end:
+// an ONNX-only embedding directory (config.json + nested onnx weights, no safetensors /
+// tokenizer.json) must be reported as missing so the full snapshot is re-downloaded.
+func TestOnnxOnlyEmbeddingDirReportedIncomplete(t *testing.T) {
+	specs, err := BuildModelSpecs(newEmbeddingOnlyConfig())
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	spec, ok := findSpecByPath(specs, testEmbeddingModelPath)
+	if !ok {
+		t.Fatalf("BuildModelSpecs() did not produce a spec for %q", testEmbeddingModelPath)
+	}
+
+	// Mirror the directory the image actually ships: config.json + onnx/layer-*/model.onnx,
+	// but no model.safetensors / tokenizer.json.
+	dir := t.TempDir()
+	writeModelFile(t, dir, "config.json", "{}")
+	writeModelFile(t, dir, "README.md", "# model")
+	writeModelFile(t, filepath.Join(dir, "onnx", "layer-6"), "model.onnx", "onnx-bytes")
+
+	complete, err := IsModelComplete(dir, spec.RequiredFiles)
+	if err != nil {
+		t.Fatalf("IsModelComplete() error = %v", err)
+	}
+	if complete {
+		t.Fatalf("ONNX-only embedding dir reported complete; expected incomplete so the full snapshot is re-downloaded")
+	}
+}
+
+// TestFullEmbeddingDirReportedComplete is the control: once the safetensors weights and
+// tokenizer are present, the embedding model is complete and is not re-downloaded.
+func TestFullEmbeddingDirReportedComplete(t *testing.T) {
+	specs, err := BuildModelSpecs(newEmbeddingOnlyConfig())
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	spec, _ := findSpecByPath(specs, testEmbeddingModelPath)
+
+	dir := t.TempDir()
+	writeModelFile(t, dir, "config.json", "{}")
+	writeModelFile(t, dir, "model.safetensors", "weights")
+	writeModelFile(t, dir, "tokenizer.json", "{}")
+
+	complete, err := IsModelComplete(dir, spec.RequiredFiles)
+	if err != nil {
+		t.Fatalf("IsModelComplete() error = %v", err)
+	}
+	if !complete {
+		t.Fatalf("complete embedding dir reported incomplete; RequiredFiles = %#v", spec.RequiredFiles)
+	}
+}
+
+func writeModelFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", filepath.Join(dir, name), err)
+	}
+}


### PR DESCRIPTION
## Problem

On the default (candle) image, the `mmbert-embed-32k-2d-matryoshka` embedding model can ship as an **ONNX-only** directory (`config.json` + `onnx/layer-*/model.onnx` + `README.md`, no `model.safetensors` / `tokenizer.json`). The candle embedding runtime loads from `model.safetensors` + `tokenizer.json`, so it fails:

```
ERROR: Failed to register mmBERT model: ... failed to load safetensors from
  models/mmbert-embed-32k-2d-matryoshka/model.safetensors ... No such file or directory
```

…and the router comes up with `embedding_ready=false`, RouterDC model-card embeddings all fail, semantic cache + tool DB are skipped. (#2172)

## Root cause

It is **not** a download-filter bug — `DownloadModelWithProgress` runs `hf download <repo>` with no `--include`, so a real download pulls the full snapshot (safetensors + tokenizer included). The problem is the **completeness check** that decides whether to download at all:

- `BuildModelSpecs` gives the embedding model only `DefaultRequiredFiles = ["config.json"]`.
- `IsModelComplete` then accepts the model as soon as `config.json` exists **and** `hasModelWeights` finds any weight file — and `hasModelWeights` walks recursively and matches `*.onnx`, so the nested `onnx/layer-*/model.onnx` shards satisfy it.

So a partial ONNX-only directory is treated as "ready", `EnsureModels` skips it, and the snapshot download that would back-fill `model.safetensors` / `tokenizer.json` never runs. (This is also why the manual `hf download model.safetensors tokenizer.json …` workaround fixes it.)

## Fix

Mark the configured semantic embedding model (`EmbeddingModels.MmBertModelPath`) as requiring `model.safetensors` + `tokenizer.json` for completeness. A partial ONNX-only directory is then detected as incomplete and the full snapshot is re-downloaded.

Scoped deliberately:
- Only the **embedding model** path is affected — classifier/LoRA-adapter dirs (which legitimately ship without a top-level `tokenizer.json` / safetensors) are untouched.
- The downloader already fetches the whole repo, so this only changes **which partial states count as complete**; it does not narrow what gets downloaded. ONNX/ROCm deployments still get a correct (full) snapshot.

The upstream repo `llm-semantic-router/mmbert-embed-32k-2d-matryoshka` contains both `model.safetensors` and `tokenizer.json`, so this is a zero-false-positive requirement for the default config.

## Test Plan

New `pkg/modeldownload/embedding_completeness_test.go` (model-free, pure Go):

- `TestBuildModelSpecsRequiresEmbeddingModelWeightsAndTokenizer` — the embedding spec's `RequiredFiles` now includes `model.safetensors` + `tokenizer.json`.
- `TestOnnxOnlyEmbeddingDirReportedIncomplete` — reproduces #2172: a dir with `config.json` + nested `onnx/layer-6/model.onnx` (no safetensors/tokenizer) is reported **incomplete** (RED before the fix — it was reported complete via the nested-onnx heuristic).
- `TestFullEmbeddingDirReportedComplete` — control: a dir with `config.json` + `model.safetensors` + `tokenizer.json` is complete.

Verified:
- `go test ./pkg/modeldownload/` (incl. `-race`) — green, no regressions.
- `gofmt`, `go vet`, `golangci-lint` — 0 issues.
- `make agent-lint CHANGED_FILES=...` — all gates Passed (structural lint, structure check, reference config contract, AST scan).

## Related

This is one half of getting `router_dc` + mmbert working out of the box. The other half — the selection path routing mmbert through the qwen3-only batched embedding API — is #2173, addressed by #2192.

Fixes #2172
