### PR TITLE
[Router] Report real token usage across looper algorithms

### DIFF
--- a/src/semantic-router/pkg/looper/base.go
+++ b/src/semantic-router/pkg/looper/base.go
@@ -176,6 +176,8 @@ type AggregatedResponse struct {
 // When the final response contains tool_calls, the original raw response
 // is preserved (with metadata patched) to avoid dropping tool_calls.
 func (l *BaseLooper) formatJSONResponse(agg *AggregatedResponse, modelsUsed []string, iterations int) (*Response, error) {
+	usage := SumUsage(agg.Responses...)
+
 	// If the final response has tool_calls, use the original raw response
 	// but patch the model name and id to reflect the looper wrapper.
 	if agg.HasToolCalls && len(agg.Responses) > 0 {
@@ -194,6 +196,7 @@ func (l *BaseLooper) formatJSONResponse(agg *AggregatedResponse, modelsUsed []st
 						ModelsUsed:    modelsUsed,
 						Iterations:    iterations,
 						AlgorithmType: "simple",
+						Usage:         usage,
 					}, nil
 				}
 			}
@@ -214,6 +217,7 @@ func (l *BaseLooper) formatJSONResponse(agg *AggregatedResponse, modelsUsed []st
 				ModelsUsed:    modelsUsed,
 				Iterations:    iterations,
 				AlgorithmType: "simple",
+				Usage:         usage,
 			}, nil
 		}
 	}
@@ -233,11 +237,7 @@ func (l *BaseLooper) formatJSONResponse(agg *AggregatedResponse, modelsUsed []st
 				"finish_reason": "stop",
 			},
 		},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     0,
-			"completion_tokens": 0,
-			"total_tokens":      0,
-		},
+		"usage": usage.Map(),
 	}
 
 	body, err := json.Marshal(completion)
@@ -252,6 +252,7 @@ func (l *BaseLooper) formatJSONResponse(agg *AggregatedResponse, modelsUsed []st
 		ModelsUsed:    modelsUsed,
 		Iterations:    iterations,
 		AlgorithmType: "simple",
+		Usage:         usage,
 	}, nil
 }
 
@@ -348,9 +349,12 @@ func (l *BaseLooper) formatStreamingResponse(agg *AggregatedResponse, modelsUsed
 	// If we have real SSE streams from the underlying model(s), preserve the SSE
 	// framing instead of simulating it. This still returns a single response body,
 	// but avoids the "fake streaming" behavior where we pre-split text.
+	usage := SumUsage(agg.Responses...)
 	if len(agg.Responses) > 0 && agg.Responses[0].IsStreaming {
 		body := concatModelSSEStreams(agg.Responses)
-		return streamingLooperResponse(body, agg.FinalModel, modelsUsed, iterations, "simple"), nil
+		resp := streamingLooperResponse(body, agg.FinalModel, modelsUsed, iterations, "simple")
+		resp.Usage = usage
+		return resp, nil
 	}
 
 	timestamp := time.Now().Unix()
@@ -360,7 +364,9 @@ func (l *BaseLooper) formatStreamingResponse(agg *AggregatedResponse, modelsUsed
 	sseBody := buildSimulatedChatCompletionSSE(
 		id, timestamp, agg.FinalModel, chunks, toolName, toolArgs, toolCallID, hasToolCall,
 	)
-	return streamingLooperResponse(sseBody, agg.FinalModel, modelsUsed, iterations, "simple"), nil
+	resp := streamingLooperResponse(sseBody, agg.FinalModel, modelsUsed, iterations, "simple")
+	resp.Usage = usage
+	return resp, nil
 }
 
 func concatModelSSEStreams(responses []*ModelResponse) []byte {

--- a/src/semantic-router/pkg/looper/client.go
+++ b/src/semantic-router/pkg/looper/client.go
@@ -134,6 +134,11 @@ type ModelResponse struct {
 
 	// StreamingChunks contains the raw SSE chunks for streaming responses
 	StreamingChunks []string
+
+	// Usage holds the token counts reported by the backend for this single
+	// call. It is zero when the backend omits usage (e.g. streaming responses
+	// without stream_options.include_usage).
+	Usage TokenUsage
 }
 
 // LogprobsConfig controls logprobs behavior for model calls
@@ -251,6 +256,11 @@ func (c *Client) parseNonStreamingResponse(body []byte, modelName string) (*Mode
 		Parsed:      &completion,
 		Model:       modelName, // Use the requested model name, not the backend's response
 		IsStreaming: false,
+		Usage: TokenUsage{
+			PromptTokens:     completion.Usage.PromptTokens,
+			CompletionTokens: completion.Usage.CompletionTokens,
+			TotalTokens:      completion.Usage.TotalTokens,
+		},
 	}
 
 	// Extract content, tool_calls, and logprobs

--- a/src/semantic-router/pkg/looper/confidence.go
+++ b/src/semantic-router/pkg/looper/confidence.go
@@ -587,6 +587,7 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 	}
 
 	var lastResponse *ModelResponse
+	var allResponses []*ModelResponse
 	var modelsUsed []string
 	iteration := 0
 
@@ -631,6 +632,7 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		ApplyTokenFilter(resp, evaluator.TokenFilter)
 
 		lastResponse = resp
+		allResponses = append(allResponses, resp)
 		modelsUsed = append(modelsUsed, modelName)
 
 		var confidence float64
@@ -725,10 +727,13 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		return nil, fmt.Errorf("all models failed")
 	}
 
-	// Format the final response (only include the last response, not aggregated)
+	// Format the final response. Content/model come from the chosen (last)
+	// response, but every attempted call is included so token usage reflects the
+	// full cost of the confidence cascade, not just the accepted answer.
+	// allResponses is ordered, so its final element is always lastResponse.
 	agg := &AggregatedResponse{
 		Models:          modelsUsed,
-		Responses:       []*ModelResponse{lastResponse},
+		Responses:       allResponses,
 		CombinedContent: lastResponse.Content,
 		FinalModel:      lastResponse.Model,
 		AverageLogprob:  lastResponse.AverageLogprob,

--- a/src/semantic-router/pkg/looper/looper.go
+++ b/src/semantic-router/pkg/looper/looper.go
@@ -77,6 +77,11 @@ type Response struct {
 	// IntermediateResponses contains intermediate responses from multi-round algorithms (e.g., ReMoM)
 	// This is used for visualization in the dashboard
 	IntermediateResponses interface{} `json:"intermediate_responses,omitempty"`
+
+	// Usage is the aggregated token usage across all model calls made during
+	// this execution. It mirrors the usage block embedded in Body so callers
+	// (extproc, dashboard, metrics) can read totals without re-parsing the body.
+	Usage TokenUsage `json:"usage,omitempty"`
 }
 
 // Looper defines the interface for multi-model execution strategies

--- a/src/semantic-router/pkg/looper/ratings.go
+++ b/src/semantic-router/pkg/looper/ratings.go
@@ -190,17 +190,14 @@ func (l *RatingsLooper) formatRatingsJSONResponse(responses []*ModelResponse, mo
 		}
 	}
 
+	usage := SumUsage(responses...)
 	completion := map[string]interface{}{
 		"id":      fmt.Sprintf("chatcmpl-looper-%d", time.Now().UnixNano()),
 		"object":  "chat.completion",
 		"created": time.Now().Unix(),
 		"model":   strings.Join(modelsUsed, ","), // Combined model names
 		"choices": choices,
-		"usage": map[string]interface{}{
-			"prompt_tokens":     0,
-			"completion_tokens": 0,
-			"total_tokens":      0,
-		},
+		"usage":   usage.Map(),
 	}
 
 	body, err := json.Marshal(completion)
@@ -215,6 +212,7 @@ func (l *RatingsLooper) formatRatingsJSONResponse(responses []*ModelResponse, mo
 		ModelsUsed:    modelsUsed,
 		Iterations:    iterations,
 		AlgorithmType: "ratings",
+		Usage:         usage,
 	}, nil
 }
 
@@ -319,5 +317,6 @@ func (l *RatingsLooper) formatRatingsStreamingResponse(responses []*ModelRespons
 		ModelsUsed:    modelsUsed,
 		Iterations:    iterations,
 		AlgorithmType: "ratings",
+		Usage:         SumUsage(responses...),
 	}, nil
 }

--- a/src/semantic-router/pkg/looper/remom.go
+++ b/src/semantic-router/pkg/looper/remom.go
@@ -210,6 +210,7 @@ type remomScheduleResult struct {
 	allRoundResponses []RoundResponse
 	modelsUsed        map[string]bool
 	totalIterations   int
+	usage             TokenUsage
 }
 
 // Execute implements the Looper interface for ReMoM
@@ -248,9 +249,9 @@ func (l *ReMoMLooper) Execute(ctx context.Context, req *Request) (*Response, err
 	}
 
 	if req.IsStreaming {
-		return l.formatReMoMStreamingResponse(finalResponse, result.allRoundResponses, modelsUsedSlice, result.totalIterations, cfg)
+		return l.formatReMoMStreamingResponse(finalResponse, result.allRoundResponses, modelsUsedSlice, result.totalIterations, result.usage, cfg)
 	}
-	return l.formatReMoMJSONResponse(finalResponse, result.allRoundResponses, modelsUsedSlice, result.totalIterations, cfg)
+	return l.formatReMoMJSONResponse(finalResponse, result.allRoundResponses, modelsUsedSlice, result.totalIterations, result.usage, cfg)
 }
 
 func (l *ReMoMLooper) runReMoMSchedule(
@@ -263,6 +264,7 @@ func (l *ReMoMLooper) runReMoMSchedule(
 	var allRoundResponses []RoundResponse
 	modelsUsed := make(map[string]bool)
 	totalIterations := 0
+	var usage TokenUsage
 	currentMessages := cloneMessages(req.OriginalRequest)
 
 	for roundIdx, numCalls := range schedule {
@@ -281,6 +283,7 @@ func (l *ReMoMLooper) runReMoMSchedule(
 
 		allRoundResponses = append(allRoundResponses, roundResp)
 		trackReMoMModelsUsed(modelsUsed, responses)
+		usage = usage.Add(responses...)
 		totalIterations += len(responses)
 		logging.Infof("[ReMoM] Round %d completed: %d responses", roundIdx+1, len(responses))
 	}
@@ -289,6 +292,7 @@ func (l *ReMoMLooper) runReMoMSchedule(
 		allRoundResponses: allRoundResponses,
 		modelsUsed:        modelsUsed,
 		totalIterations:   totalIterations,
+		usage:             usage,
 	}, nil
 }
 
@@ -382,6 +386,7 @@ func (l *ReMoMLooper) formatReMoMJSONResponse(
 	allRoundResponses []RoundResponse,
 	modelsUsed []string,
 	iterations int,
+	usage TokenUsage,
 	cfg *config.ReMoMAlgorithmConfig,
 ) (*Response, error) {
 	completion := map[string]interface{}{
@@ -399,11 +404,7 @@ func (l *ReMoMLooper) formatReMoMJSONResponse(
 				"finish_reason": "stop",
 			},
 		},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     0,
-			"completion_tokens": 0,
-			"total_tokens":      0,
-		},
+		"usage": usage.Map(),
 	}
 
 	// Add intermediate responses if enabled
@@ -424,6 +425,7 @@ func (l *ReMoMLooper) formatReMoMJSONResponse(
 		Iterations:            iterations,
 		AlgorithmType:         "remom",
 		IntermediateResponses: allRoundResponses,
+		Usage:                 usage,
 	}, nil
 }
 
@@ -433,6 +435,7 @@ func (l *ReMoMLooper) formatReMoMStreamingResponse(
 	allRoundResponses []RoundResponse,
 	modelsUsed []string,
 	iterations int,
+	usage TokenUsage,
 	cfg *config.ReMoMAlgorithmConfig,
 ) (*Response, error) {
 	timestamp := time.Now().Unix()
@@ -441,6 +444,7 @@ func (l *ReMoMLooper) formatReMoMStreamingResponse(
 
 	resp := streamingLooperResponse(sseBody, finalResponse.Model, modelsUsed, iterations, "remom")
 	resp.IntermediateResponses = allRoundResponses
+	resp.Usage = usage
 	return resp, nil
 }
 

--- a/src/semantic-router/pkg/looper/rl_driven.go
+++ b/src/semantic-router/pkg/looper/rl_driven.go
@@ -131,6 +131,7 @@ func (l *RLDrivenLooper) Execute(ctx context.Context, req *Request) (*Response, 
 	responses := make(map[string]string)
 	scores := make(map[string]float64)
 	var modelsUsed []string
+	var usage TokenUsage
 	iteration := 0
 
 	for _, modelName := range multiRoundResult.SelectedModels {
@@ -197,6 +198,7 @@ func (l *RLDrivenLooper) Execute(ctx context.Context, req *Request) (*Response, 
 
 		responses[modelName] = resp.Content
 		scores[modelName] = score
+		usage = usage.Add(resp)
 		modelsUsed = append(modelsUsed, displayName)
 	}
 
@@ -233,9 +235,9 @@ func (l *RLDrivenLooper) Execute(ctx context.Context, req *Request) (*Response, 
 
 	// Format output
 	if req.IsStreaming {
-		return l.formatStreamingResponse(aggregatedContent, bestModel, modelsUsed, iteration)
+		return l.formatStreamingResponse(aggregatedContent, bestModel, modelsUsed, iteration, usage)
 	}
-	return l.formatJSONResponse(aggregatedContent, bestModel, modelsUsed, iteration)
+	return l.formatJSONResponse(aggregatedContent, bestModel, modelsUsed, iteration, usage)
 }
 
 // buildSelectionContext creates a SelectionContext from the looper Request
@@ -309,14 +311,15 @@ func (l *RLDrivenLooper) executeAllModels(ctx context.Context, req *Request) (*R
 		content += fmt.Sprintf("**[%s]:**\n%s", modelsUsed[i], resp.Content)
 	}
 
+	usage := SumUsage(responses...)
 	if req.IsStreaming {
-		return l.formatStreamingResponse(content, modelsUsed[len(modelsUsed)-1], modelsUsed, iteration)
+		return l.formatStreamingResponse(content, modelsUsed[len(modelsUsed)-1], modelsUsed, iteration, usage)
 	}
-	return l.formatJSONResponse(content, modelsUsed[len(modelsUsed)-1], modelsUsed, iteration)
+	return l.formatJSONResponse(content, modelsUsed[len(modelsUsed)-1], modelsUsed, iteration, usage)
 }
 
 // formatJSONResponse creates a JSON ChatCompletion response
-func (l *RLDrivenLooper) formatJSONResponse(content, model string, modelsUsed []string, iterations int) (*Response, error) {
+func (l *RLDrivenLooper) formatJSONResponse(content, model string, modelsUsed []string, iterations int, usage TokenUsage) (*Response, error) {
 	completion := map[string]interface{}{
 		"id":      fmt.Sprintf("chatcmpl-rl-%d", time.Now().UnixNano()),
 		"object":  "chat.completion",
@@ -332,11 +335,7 @@ func (l *RLDrivenLooper) formatJSONResponse(content, model string, modelsUsed []
 				"finish_reason": "stop",
 			},
 		},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     0,
-			"completion_tokens": 0,
-			"total_tokens":      0,
-		},
+		"usage": usage.Map(),
 	}
 
 	body, err := json.Marshal(completion)
@@ -351,11 +350,12 @@ func (l *RLDrivenLooper) formatJSONResponse(content, model string, modelsUsed []
 		ModelsUsed:    modelsUsed,
 		Iterations:    iterations,
 		AlgorithmType: "rl_driven",
+		Usage:         usage,
 	}, nil
 }
 
 // formatStreamingResponse creates an SSE streaming response
-func (l *RLDrivenLooper) formatStreamingResponse(content, model string, modelsUsed []string, iterations int) (*Response, error) {
+func (l *RLDrivenLooper) formatStreamingResponse(content, model string, modelsUsed []string, iterations int, usage TokenUsage) (*Response, error) {
 	timestamp := time.Now().Unix()
 	id := fmt.Sprintf("chatcmpl-rl-%d", timestamp)
 
@@ -427,5 +427,6 @@ func (l *RLDrivenLooper) formatStreamingResponse(content, model string, modelsUs
 		ModelsUsed:    modelsUsed,
 		Iterations:    iterations,
 		AlgorithmType: "rl_driven",
+		Usage:         usage,
 	}, nil
 }

--- a/src/semantic-router/pkg/looper/rl_driven_test.go
+++ b/src/semantic-router/pkg/looper/rl_driven_test.go
@@ -103,9 +103,14 @@ func TestRLDrivenLooper_FormatJSONResponse(t *testing.T) {
 	modelsUsed := []string{"gpt-4", "claude-3"}
 	iterations := 2
 
-	resp, err := looper.formatJSONResponse(content, model, modelsUsed, iterations)
+	usage := TokenUsage{PromptTokens: 30, CompletionTokens: 12, TotalTokens: 42}
+	resp, err := looper.formatJSONResponse(content, model, modelsUsed, iterations, usage)
 	if err != nil {
 		t.Fatalf("formatJSONResponse failed: %v", err)
+	}
+
+	if resp.Usage != usage {
+		t.Errorf("Expected response usage %+v, got %+v", usage, resp.Usage)
 	}
 
 	if resp == nil {
@@ -151,7 +156,7 @@ func TestRLDrivenLooper_FormatStreamingResponse(t *testing.T) {
 	modelsUsed := []string{"claude-3"}
 	iterations := 1
 
-	resp, err := looper.formatStreamingResponse(content, model, modelsUsed, iterations)
+	resp, err := looper.formatStreamingResponse(content, model, modelsUsed, iterations, TokenUsage{})
 	if err != nil {
 		t.Fatalf("formatStreamingResponse failed: %v", err)
 	}

--- a/src/semantic-router/pkg/looper/usage.go
+++ b/src/semantic-router/pkg/looper/usage.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+// TokenUsage holds OpenAI-compatible token counts. For multi-model looper
+// algorithms it represents the aggregate across every model call made during a
+// single execution (panel + judge + synthesis, rounds, candidates, etc.).
+type TokenUsage struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+}
+
+// Add returns u with the usage of the given responses added to it. It is
+// nil-safe: nil responses contribute nothing, so callers can accumulate across
+// rounds or skip failed calls without guarding. The receiver is not mutated.
+func (u TokenUsage) Add(resps ...*ModelResponse) TokenUsage {
+	for _, resp := range resps {
+		if resp == nil {
+			continue
+		}
+		u.PromptTokens += resp.Usage.PromptTokens
+		u.CompletionTokens += resp.Usage.CompletionTokens
+		u.TotalTokens += resp.Usage.TotalTokens
+	}
+	return u
+}
+
+// SumUsage sums the per-call usage of the given responses. nil responses are
+// skipped. The total is computed from each response's reported prompt and
+// completion tokens; TotalTokens is taken from the backend rather than
+// recomputed so it matches the upstream accounting.
+func SumUsage(resps ...*ModelResponse) TokenUsage {
+	return TokenUsage{}.Add(resps...)
+}
+
+// Map renders the usage as the OpenAI-compatible block embedded in a
+// chat.completion response body. This is the single seam every looper uses in
+// place of the legacy hardcoded {0,0,0} literal.
+func (u TokenUsage) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"prompt_tokens":     u.PromptTokens,
+		"completion_tokens": u.CompletionTokens,
+		"total_tokens":      u.TotalTokens,
+	}
+}

--- a/src/semantic-router/pkg/looper/usage_integration_test.go
+++ b/src/semantic-router/pkg/looper/usage_integration_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// newUsageBackend returns an httptest server that mimics an OpenAI-compatible
+// backend reporting a fixed usage block per call (like mock-vllm-simple.py and
+// llm-katan do in the e2e suite). It counts how many calls it received.
+func newUsageBackend(t *testing.T, prompt, completion, total int64) (*httptest.Server, *int64) {
+	t.Helper()
+	var calls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		body := map[string]interface{}{
+			"id":      "chatcmpl-stub",
+			"object":  "chat.completion",
+			"created": 0,
+			"model":   "stub-backend",
+			"choices": []map[string]interface{}{
+				{
+					"index":         0,
+					"message":       map[string]interface{}{"role": "assistant", "content": "stub answer"},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]interface{}{
+				"prompt_tokens":     prompt,
+				"completion_tokens": completion,
+				"total_tokens":      total,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	return server, &calls
+}
+
+func usageBackendRequest(models ...config.ModelRef) *Request {
+	params := openai.ChatCompletionNewParams{
+		Model:    "auto",
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("hello")},
+	}
+	return &Request{
+		OriginalRequest: &params,
+		ModelRefs:       models,
+		DecisionName:    "usage_decision",
+	}
+}
+
+// TestBaseLooper_Execute_AggregatesUsageOverHTTP is a full-path integration test:
+// the base looper fans out to two models over real HTTP, each backend call
+// reports usage, and the wrapped completion must report the SUM (not {0,0,0}).
+func TestBaseLooper_Execute_AggregatesUsageOverHTTP(t *testing.T) {
+	server, calls := newUsageBackend(t, 10, 20, 30)
+	defer server.Close()
+
+	l := NewBaseLooper(&config.LooperConfig{Endpoint: server.URL})
+	req := usageBackendRequest(
+		config.ModelRef{Model: "model-a"},
+		config.ModelRef{Model: "model-b"},
+	)
+
+	out, err := l.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if *calls != 2 {
+		t.Fatalf("expected 2 backend calls, got %d", *calls)
+	}
+
+	// Two calls of 10/20/30 each → 20/40/60 aggregated.
+	want := TokenUsage{PromptTokens: 20, CompletionTokens: 40, TotalTokens: 60}
+	if out.Usage != want {
+		t.Errorf("Response.Usage = %+v, want %+v", out.Usage, want)
+	}
+
+	var parsed struct {
+		Usage TokenUsage `json:"usage"`
+	}
+	if err := json.Unmarshal(out.Body, &parsed); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if parsed.Usage != want {
+		t.Errorf("body usage = %+v, want %+v (must not be the legacy {0,0,0})", parsed.Usage, want)
+	}
+}

--- a/src/semantic-router/pkg/looper/usage_test.go
+++ b/src/semantic-router/pkg/looper/usage_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func resp(prompt, completion, total int64) *ModelResponse {
+	return &ModelResponse{Usage: TokenUsage{PromptTokens: prompt, CompletionTokens: completion, TotalTokens: total}}
+}
+
+func TestSumUsage(t *testing.T) {
+	tests := []struct {
+		name  string
+		resps []*ModelResponse
+		want  TokenUsage
+	}{
+		{
+			name:  "no responses",
+			resps: nil,
+			want:  TokenUsage{},
+		},
+		{
+			name:  "single response",
+			resps: []*ModelResponse{resp(10, 5, 15)},
+			want:  TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+		{
+			name:  "multiple responses summed",
+			resps: []*ModelResponse{resp(10, 5, 15), resp(20, 8, 28), resp(1, 1, 2)},
+			want:  TokenUsage{PromptTokens: 31, CompletionTokens: 14, TotalTokens: 45},
+		},
+		{
+			name:  "nil entries skipped",
+			resps: []*ModelResponse{nil, resp(10, 5, 15), nil},
+			want:  TokenUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SumUsage(tt.resps...); got != tt.want {
+				t.Errorf("SumUsage() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenUsageAdd_Accumulates(t *testing.T) {
+	// Simulates a multi-round looper accumulating across rounds.
+	var total TokenUsage
+	total = total.Add(resp(10, 5, 15), resp(20, 5, 25))
+	total = total.Add(resp(4, 1, 5))
+
+	want := TokenUsage{PromptTokens: 34, CompletionTokens: 11, TotalTokens: 45}
+	if total != want {
+		t.Errorf("accumulated usage = %+v, want %+v", total, want)
+	}
+}
+
+func TestTokenUsageAdd_DoesNotMutateReceiver(t *testing.T) {
+	base := TokenUsage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3}
+	_ = base.Add(resp(10, 10, 20))
+	if (base != TokenUsage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3}) {
+		t.Errorf("Add mutated the receiver: %+v", base)
+	}
+}
+
+func TestTokenUsageMap(t *testing.T) {
+	u := TokenUsage{PromptTokens: 7, CompletionTokens: 3, TotalTokens: 10}
+	m := u.Map()
+
+	// Round-trip through JSON to confirm the OpenAI-compatible shape.
+	body, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal usage map: %v", err)
+	}
+	var decoded TokenUsage
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal usage map: %v", err)
+	}
+	if decoded != u {
+		t.Errorf("usage map round-trip = %+v, want %+v", decoded, u)
+	}
+}
+
+// TestParseNonStreamingResponse_PopulatesUsage verifies that usage is lifted
+// from the backend completion into ModelResponse.Usage, which every looper then
+// aggregates instead of emitting the legacy {0,0,0} block.
+func TestParseNonStreamingResponse_PopulatesUsage(t *testing.T) {
+	c := &Client{}
+	body := []byte(`{
+		"id": "chatcmpl-1",
+		"object": "chat.completion",
+		"model": "backend-model",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 42, "completion_tokens": 8, "total_tokens": 50}
+	}`)
+
+	resp, err := c.parseNonStreamingResponse(body, "logical-model")
+	if err != nil {
+		t.Fatalf("parseNonStreamingResponse failed: %v", err)
+	}
+
+	want := TokenUsage{PromptTokens: 42, CompletionTokens: 8, TotalTokens: 50}
+	if resp.Usage != want {
+		t.Errorf("ModelResponse.Usage = %+v, want %+v", resp.Usage, want)
+	}
+}
+
+// TestBaseLooper_FormatJSONResponse_AggregatesUsage verifies the wired path:
+// per-call usages are summed and reported in both the response body and the
+// Response.Usage field (no more hardcoded zeros).
+func TestBaseLooper_FormatJSONResponse_AggregatesUsage(t *testing.T) {
+	l := NewBaseLooper(&config.LooperConfig{Endpoint: "http://localhost:8000"})
+
+	agg := &AggregatedResponse{
+		Models:          []string{"a", "b"},
+		Responses:       []*ModelResponse{resp(100, 20, 120), resp(50, 10, 60)},
+		CombinedContent: "combined",
+		FinalModel:      "b",
+	}
+
+	out, err := l.formatJSONResponse(agg, agg.Models, 2)
+	if err != nil {
+		t.Fatalf("formatJSONResponse failed: %v", err)
+	}
+
+	wantUsage := TokenUsage{PromptTokens: 150, CompletionTokens: 30, TotalTokens: 180}
+	if out.Usage != wantUsage {
+		t.Errorf("Response.Usage = %+v, want %+v", out.Usage, wantUsage)
+	}
+
+	var parsed struct {
+		Usage TokenUsage `json:"usage"`
+	}
+	if err := json.Unmarshal(out.Body, &parsed); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if parsed.Usage != wantUsage {
+		t.Errorf("body usage = %+v, want %+v", parsed.Usage, wantUsage)
+	}
+}


### PR DESCRIPTION
## What

Make every looper algorithm report **real aggregated token usage** instead of the hardcoded `usage: {0, 0, 0}` block.

Today the looper substrate parses each backend completion into `ModelResponse` but discards the OpenAI `usage` block, so `confidence`, `ratings`, `remom`, `rl_driven`, and the base looper all emit zeros. This change captures per-call usage and sums it across every model call an execution makes.

## Why

Multi-model loopers are exactly where token accounting matters most (they make N calls per request), yet they were the only paths reporting zero usage — breaking cost/usage visibility for callers, dashboards, and metrics. This is also a prerequisite for the Fusion API (#2193): a Fusion looper fans out to a panel + judge + synthesis and needs to report the summed cost. This PR lands the reusable substrate so Fusion (and every other looper) gets correct usage for free.

## Changes

- **`looper/usage.go` (new):** `TokenUsage{Prompt,Completion,Total}` with nil-safe `SumUsage(...)` / `Add(...)` (non-mutating) and a `Map()` helper that renders the OpenAI-compatible usage block — the single seam loopers use in place of the `{0,0,0}` literal.
- **`looper/client.go`:** add `ModelResponse.Usage`, populated from `completion.Usage` in `parseNonStreamingResponse` (was parsed, then dropped).
- **`looper/looper.go`:** add `Response.Usage` so extproc/dashboard/metrics can read totals without re-parsing the body.
- **Wire all algorithms:** `base` and `ratings` sum the responses they hold; `remom` accumulates across rounds; `rl_driven` accumulates over both the selector and fallback paths; `confidence` includes **every cascade attempt** (not just the accepted answer) so usage reflects the full cost. Both JSON and streaming return paths set `Response.Usage`.

Substrate-only — no API/config/behavior change beyond `usage` going from zeros to real numbers. Streaming sub-calls (no `stream_options.include_usage`) still report zero for that call; non-streaming sub-calls (which all looper internal calls are) report real counts.

## Test plan

**Unit + integration (`pkg/looper/usage_test.go`, `usage_integration_test.go`):**
- `SumUsage`/`Add` summation, nil-safety, no-receiver-mutation; `Map()` JSON shape.
- `parseNonStreamingResponse` lifts `usage` into `ModelResponse.Usage`.
- Base-looper body + `Response.Usage` aggregation.
- **Integration:** `BaseLooper.Execute` against a real in-process `httptest` backend that returns a `usage` block → asserts the wrapped completion sums per-call usage (20/40/60 from two 10/20/30 calls). Self-contained — no external services, config, or auth.

```
make test-semantic-router      # all looper tests green
make agent-ci-lint             # full gate (pre-commit, ruff, go-lint, structure_check) → exit 0
```

**Full-stack e2e (manual, macOS dockerless):** ran curl → envoy → router extproc → `ratings` looper → two `llm-katan` echo backends (:8000/:8001) → aggregated response. A decision configured with `algorithm.type: ratings` over two models returned:

```json
"model": "Model-A,Model-B",
"choices": [ /* Model-A */, /* Model-B */ ],
"usage": { "prompt_tokens": 18, "completion_tokens": 34, "total_tokens": 52 }
```

Each backend reported `{9, 17, 26}`, so **18/34/52 = exactly 2× a single call** — confirming real cross-call aggregation through the live stack (previously this block was `{0,0,0}`). Router logs confirmed `looper_execution_started algorithm: ratings` → `execution_completed successful_models: 2`.

## Related

Substrate for #2193 (Fusion API): when the Fusion looper lands, it reports usage by summing panel + judge + synthesis `ModelResponse.Usage` via the same `SumUsage(...).Map()` seam.
