### PR TITLE
[Router] drop deprecated legacy x-vsr jailbreak/pii response headers

### DIFF
--- a/dashboard/frontend/src/components/HeaderDisplay.tsx
+++ b/dashboard/frontend/src/components/HeaderDisplay.tsx
@@ -30,14 +30,6 @@ const HEADER_INFO: Record<string, { label: string; type: 'info' | 'success' | 'w
     label: 'Fast Response',
     type: 'success',
   },
-  'x-vsr-jailbreak-blocked': {
-    label: 'Jailbreak Blocked',
-    type: 'danger',
-  },
-  'x-vsr-pii-violation': {
-    label: 'PII Violation',
-    type: 'danger',
-  },
   'x-vsr-hallucination-detected': {
     label: 'Hallucination',
     type: 'warning',

--- a/dashboard/frontend/src/components/HeaderReveal.tsx
+++ b/dashboard/frontend/src/components/HeaderReveal.tsx
@@ -117,14 +117,6 @@ const HEADER_INFO: Record<string, { label: string; description: string }> = {
     label: 'Fast Response',
     description: 'Request short-circuited by fast_response plugin',
   },
-  'x-vsr-jailbreak-blocked': {
-    label: 'Jailbreak Blocked',
-    description: 'Request blocked by jailbreak protection',
-  },
-  'x-vsr-pii-violation': {
-    label: 'PII Violation',
-    description: 'Request blocked by PII protection',
-  },
   'x-vsr-hallucination-detected': {
     label: 'Quality: Hallucination',
     description: 'Potential hallucination detected',
@@ -204,8 +196,6 @@ const HeaderReveal = ({ headers, onComplete, displayDuration = 2000 }: HeaderRev
         key === 'x-vsr-selected-reasoning' ||
         key === 'x-vsr-fast-response' ||
         key === 'x-vsr-context-token-count' ||
-        key === 'x-vsr-jailbreak-blocked' ||
-        key === 'x-vsr-pii-violation' ||
         key === 'x-vsr-hallucination-detected' ||
         key === 'x-vsr-fact-check-needed',
     ),

--- a/dashboard/frontend/src/components/chatRequestSupport.ts
+++ b/dashboard/frontend/src/components/chatRequestSupport.ts
@@ -22,8 +22,6 @@ const RESPONSE_HEADER_KEYS = [
   'x-vsr-cache-hit',
   'x-vsr-selected-reasoning',
   'x-vsr-fast-response',
-  'x-vsr-jailbreak-blocked',
-  'x-vsr-pii-violation',
   'x-vsr-hallucination-detected',
   'x-vsr-fact-check-needed',
   'x-vsr-matched-keywords',

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -230,25 +230,6 @@ const (
 	VSRLossinessWarnings = "x-vsr-lossiness-warnings"
 )
 
-// Legacy Security Headers (kept for backward compatibility with replay recorder)
-// New signal-driven architecture uses x-vsr-matched-jailbreak and x-vsr-matched-pii instead.
-const (
-	// VSRPIIViolation indicates that the request was blocked due to PII policy violation.
-	VSRPIIViolation = "x-vsr-pii-violation"
-
-	// VSRPIITypes contains the comma-separated list of PII types that were detected and denied.
-	VSRPIITypes = "x-vsr-pii-types"
-
-	// VSRJailbreakBlocked indicates that a jailbreak attempt was detected and blocked.
-	VSRJailbreakBlocked = "x-vsr-jailbreak-blocked"
-
-	// VSRJailbreakType specifies the type of jailbreak attempt that was detected.
-	VSRJailbreakType = "x-vsr-jailbreak-type"
-
-	// VSRJailbreakConfidence indicates the confidence level of the jailbreak detection.
-	VSRJailbreakConfidence = "x-vsr-jailbreak-confidence"
-)
-
 // Hallucination Mitigation Headers
 // These headers are added to responses when hallucination detection is enabled
 // and potential hallucinations are detected in the LLM response.

--- a/src/semantic-router/pkg/headers/headers_test.go
+++ b/src/semantic-router/pkg/headers/headers_test.go
@@ -31,11 +31,6 @@ func TestHeaderConstants(t *testing.T) {
 		{"VSRMatchedReask", VSRMatchedReask, "x-vsr-matched-reask"},
 		{"VSRMatchedEvent", VSRMatchedEvent, "x-vsr-matched-event"},
 		{"VSRMatchedProjection", VSRMatchedProjection, "x-vsr-matched-projections"},
-		// Legacy security headers (kept for backward compatibility)
-		{"VSRPIIViolation", VSRPIIViolation, "x-vsr-pii-violation"},
-		{"VSRJailbreakBlocked", VSRJailbreakBlocked, "x-vsr-jailbreak-blocked"},
-		{"VSRJailbreakType", VSRJailbreakType, "x-vsr-jailbreak-type"},
-		{"VSRJailbreakConfidence", VSRJailbreakConfidence, "x-vsr-jailbreak-confidence"},
 		// Hallucination mitigation headers
 		{"HallucinationDetected", HallucinationDetected, "x-vsr-hallucination-detected"},
 		{"HallucinationSpans", HallucinationSpans, "x-vsr-hallucination-spans"},


### PR DESCRIPTION
## Summary

Closes #2207. Part of #2200 — v0.4 VSR response header contract redesign.

The legacy security response headers (`x-vsr-jailbreak-blocked`, `x-vsr-jailbreak-type`, `x-vsr-jailbreak-confidence`, `x-vsr-pii-violation`, `x-vsr-pii-types`) were already superseded by the signal-driven `x-vsr-matched-jailbreak` / `x-vsr-matched-pii` headers and are no longer emitted by the router. This removes the dead constants and their dashboard allowlist entries.

## What changed

- **Router** (`pkg/headers/headers.go`): remove the 5 legacy security header constants and their unit-test assertions. `grep` confirms no remaining symbol references in Go.
- **Dashboard**: remove `x-vsr-jailbreak-blocked` / `x-vsr-pii-violation` entries from the header display/reveal allowlists (`HeaderDisplay.tsx`, `HeaderReveal.tsx`, `chatRequestSupport.ts`).

Behavior is unchanged — the removed headers were never emitted.

## Test plan

- [x] `grep` confirms zero remaining references to the legacy header constants/strings in Go
- [x] Dashboard lint & type check — passes (CI)
- [ ] `make test-semantic-router` (router unit tests) — CI

## Notes

The dead legacy header reads in the e2e testcases are intentionally **out of scope** here: those `e2e/testcases/*.go` files are regular (non-`_test.go`) Go files carrying pre-existing complexity-linter debt (cyclop/gocognit/nestif) unrelated to the header contract, so cleaning them up requires its own refactor. That cleanup, and the `vsr-headers.md` rewrite, will land in focused follow-up PRs under #2200.
