### PR TITLE
[Dashboard] Improve post-login loading experience

### DIFF
--- a/dashboard/frontend/src/pages/AuthTransitionPage.module.css
+++ b/dashboard/frontend/src/pages/AuthTransitionPage.module.css
@@ -1,19 +1,29 @@
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400;1,600&family=Space+Mono:wght@400;700&display=swap');
-
 .page {
-  --loader-bg: #000000;
-  --loader-fg: #ffffff;
-  --loader-grid: rgba(255, 255, 255, 0.9);
-  --font-serif: 'Playfair Display', Georgia, serif;
-  --font-mono: 'Space Mono', 'SF Mono', 'Monaco', monospace;
+  --loader-bg: #050705;
+  --loader-fg: #f5f7f4;
+  --loader-muted: rgba(245, 247, 244, 0.56);
+  --loader-grid: rgba(255, 255, 255, 0.12);
+  --loader-primary: var(--color-primary, #76b900);
+  --loader-primary-light: var(--color-primary-light, #8fd400);
+  --loader-cyan: var(--color-accent-cyan, #00d4ff);
   position: relative;
   width: 100%;
   min-height: 100vh;
   overflow: hidden;
   background:
-    radial-gradient(circle at 50% 38%, rgba(255, 255, 255, 0.08), transparent 34%),
-    linear-gradient(180deg, #090909 0%, var(--loader-bg) 52%, #040404 100%);
+    radial-gradient(circle at 48% 42%, rgba(118, 185, 0, 0.16), transparent 32%),
+    radial-gradient(circle at 72% 28%, rgba(0, 212, 255, 0.1), transparent 28%),
+    linear-gradient(180deg, #080b08 0%, var(--loader-bg) 58%, #020302 100%);
   color: var(--loader-fg);
+}
+
+.page::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.22) 72%, rgba(0, 0, 0, 0.5) 100%);
+  z-index: 1;
 }
 
 .grid,
@@ -21,8 +31,8 @@
   position: absolute;
   inset: 0;
   display: grid;
-  grid-template-columns: 1fr 2fr 1fr;
-  grid-template-rows: 1fr 2fr 1fr;
+  grid-template-columns: 1fr minmax(22rem, 2fr) 1fr;
+  grid-template-rows: 1fr minmax(14rem, 2fr) 1fr;
 }
 
 .grid {
@@ -55,10 +65,13 @@
 }
 
 .metaText,
-.metaLabel {
+.metaLabel,
+.sequenceHeader,
+.sequenceYear,
+.centerEyebrow {
   font-family: var(--font-mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -66,7 +79,7 @@
 .topRight,
 .bottomLeft,
 .bottomRight {
-  padding: 2rem;
+  padding: clamp(1.2rem, 3vw, 2rem);
 }
 
 .topLeft {
@@ -77,6 +90,11 @@
   gap: 0.55rem;
   justify-content: flex-start;
   align-items: flex-start;
+  color: var(--loader-muted);
+}
+
+.topLeft .metaText:first-child {
+  color: rgba(255, 255, 255, 0.86);
 }
 
 .topRight {
@@ -85,13 +103,18 @@
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
+  gap: 0.65rem;
+  color: var(--loader-muted);
 }
 
-.asterisk {
-  font-family: var(--font-serif);
-  font-size: clamp(2.4rem, 4vw, 3rem);
-  line-height: 1;
-  color: rgba(255, 255, 255, 0.92);
+.statusBeacon {
+  width: 0.58rem;
+  height: 0.58rem;
+  margin-top: 0.18rem;
+  border-radius: 50%;
+  background: var(--loader-primary-light);
+  box-shadow: 0 0 20px rgba(143, 212, 0, 0.8);
+  animation: beaconPulse 1.6s ease-in-out infinite;
 }
 
 .center {
@@ -101,30 +124,36 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
 }
 
-.counterWrapper {
-  display: flex;
-  align-items: flex-start;
-  color: var(--loader-fg);
-  text-shadow: 0 0 28px rgba(255, 255, 255, 0.16);
+.centerCopy {
+  width: min(30rem, 86vw);
+  display: grid;
+  justify-items: center;
+  gap: 0.72rem;
+  padding-top: min(15vh, 8rem);
 }
 
-.counterNumber {
-  font-family: var(--font-serif);
-  font-size: clamp(8rem, 15vw, 15rem);
-  font-style: italic;
-  font-weight: 400;
-  line-height: 0.8;
-  letter-spacing: -0.03em;
-  font-variant-numeric: tabular-nums;
+.centerEyebrow {
+  color: var(--loader-primary-light);
+  font-weight: 750;
 }
 
-.counterSymbol {
-  font-family: var(--font-serif);
-  font-size: clamp(2rem, 4vw, 4rem);
-  margin-top: 1vw;
-  margin-left: 0.4vw;
+.centerTitle {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.96);
+  font-size: clamp(2.2rem, 6vw, 4.9rem);
+  font-weight: 760;
+  line-height: 0.98;
+  text-shadow: 0 22px 64px rgba(0, 0, 0, 0.45);
+}
+
+.centerText {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: clamp(0.95rem, 1.6vw, 1.08rem);
+  line-height: 1.55;
 }
 
 .bottomLeft {
@@ -135,72 +164,74 @@
 }
 
 .sequencePanel {
-  width: min(35rem, 100%);
-  padding: 1rem 1.1rem 1.05rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.04));
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(16px);
+  width: min(33rem, 100%);
+  padding: 1rem 1.05rem 1.05rem;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.032)),
+    rgba(7, 10, 7, 0.44);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(18px) saturate(130%);
+  -webkit-backdrop-filter: blur(18px) saturate(130%);
 }
 
 .sequenceHeader {
   display: inline-block;
-  margin-bottom: 0.8rem;
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.72);
+  margin-bottom: 0.78rem;
+  color: rgba(255, 255, 255, 0.62);
+  font-weight: 700;
 }
 
 .sequenceList {
   width: 100%;
   display: grid;
-  gap: 0.82rem;
+  gap: 0.7rem;
   list-style: none;
 }
 
 .sequenceItem {
   display: grid;
-  grid-template-columns: minmax(4.8rem, auto) 1fr;
-  gap: 0.9rem;
+  grid-template-columns: minmax(2.25rem, auto) 1fr;
+  gap: 0.78rem;
   align-items: start;
-  opacity: 0;
-  transform: translateY(12px);
+  opacity: 0.32;
+  transform: translateY(0);
   transition:
-    opacity 360ms ease,
-    transform 360ms ease;
+    opacity 300ms ease,
+    transform 300ms ease;
 }
 
 .sequenceItemVisible {
-  opacity: 0.62;
-  transform: translateY(0);
+  opacity: 0.7;
 }
 
 .sequenceItemActive {
   opacity: 1;
 }
 
-.sequenceYear,
-.sequenceCopy {
-  line-height: 1.55;
-}
-
 .sequenceYear {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  min-width: 4.8rem;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.72);
+  min-width: 2.25rem;
+  color: var(--loader-primary-light);
+  font-weight: 750;
+  line-height: 1.45;
+}
+
+.sequenceCopy,
+.sequenceDetail {
+  display: block;
+  line-height: 1.45;
 }
 
 .sequenceCopy {
-  max-width: 27rem;
-  font-family: var(--font-serif);
-  font-size: 0.94rem;
-  letter-spacing: 0.01em;
-  color: rgba(255, 255, 255, 0.96);
+  color: rgba(255, 255, 255, 0.94);
+  font-size: 0.92rem;
+  font-weight: 680;
+}
+
+.sequenceDetail {
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 0.82rem;
 }
 
 .bottomRight {
@@ -215,31 +246,53 @@
 .metaBlock {
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.12rem;
+}
+
+.metaLabel {
+  color: var(--loader-muted);
+  font-weight: 700;
 }
 
 .metaValue {
-  font-family: var(--font-serif);
-  font-size: clamp(1.8rem, 3vw, 2.5rem);
-  font-style: italic;
+  color: rgba(255, 255, 255, 0.94);
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  font-weight: 760;
   line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 
 .progressTrack {
   position: absolute;
   left: 50%;
   bottom: 2rem;
-  width: min(240px, 52vw);
-  height: 2px;
+  width: min(280px, 54vw);
+  height: 3px;
   transform: translateX(-50%);
-  background: rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
   overflow: hidden;
 }
 
 .progressBar {
   height: 100%;
-  background: var(--loader-fg);
-  transition: width 120ms linear;
+  transform-origin: left center;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--loader-primary), var(--loader-primary-light) 56%, var(--loader-cyan));
+  box-shadow: 0 0 18px rgba(118, 185, 0, 0.5);
+  transition: transform 120ms linear;
+}
+
+@keyframes beaconPulse {
+  0%,
+  100% {
+    opacity: 0.58;
+    transform: scale(0.9);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
 }
 
 @media (max-width: 860px) {
@@ -253,7 +306,7 @@
   .topRight,
   .bottomLeft,
   .bottomRight {
-    padding: 1.25rem;
+    padding: 1.15rem;
   }
 
   .topLeft {
@@ -271,6 +324,10 @@
     grid-row: 2;
   }
 
+  .centerCopy {
+    padding-top: 8rem;
+  }
+
   .bottomLeft {
     grid-column: 1;
     grid-row: 3;
@@ -281,41 +338,47 @@
     padding: 0.95rem;
   }
 
-  .sequenceCopy {
-    max-width: none;
-    font-size: 0.88rem;
-  }
-
   .bottomRight {
     grid-column: 1;
     grid-row: 4;
     justify-content: flex-start;
     text-align: left;
     padding-top: 0;
-    padding-bottom: 4.25rem;
-  }
-
-  .sequenceList,
-  .sequenceCopy {
-    max-width: none;
+    padding-bottom: 4.1rem;
   }
 
   .progressTrack {
-    bottom: 1.4rem;
+    bottom: 1.35rem;
   }
 }
 
 @media (max-width: 560px) {
-  .counterNumber {
-    font-size: min(32vw, 9rem);
+  .centerCopy {
+    width: min(21rem, 90vw);
+    padding-top: 7rem;
+  }
+
+  .centerTitle {
+    font-size: min(12vw, 3.7rem);
   }
 
   .sequenceItem {
     grid-template-columns: 1fr;
-    gap: 0.2rem;
+    gap: 0.12rem;
   }
 
   .sequenceYear {
     min-width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .statusBeacon {
+    animation: none;
+  }
+
+  .sequenceItem,
+  .progressBar {
+    transition: none;
   }
 }

--- a/dashboard/frontend/src/pages/AuthTransitionPage.tsx
+++ b/dashboard/frontend/src/pages/AuthTransitionPage.tsx
@@ -10,39 +10,43 @@ import {
 import styles from './AuthTransitionPage.module.css'
 
 type Milestone = {
-  year: string
-  text: string
+  key: string
+  label: string
+  detail: string
   revealAt: number
 }
 
 const PROGRESS_SEGMENTS = [
-  { duration: 700, from: 0, to: 14 },
-  { duration: 650, from: 14, to: 45 },
-  { duration: 850, from: 45, to: 45 },
-  { duration: 950, from: 45, to: 82 },
-  { duration: 650, from: 82, to: 100 },
+  { duration: 520, from: 0, to: 24 },
+  { duration: 620, from: 24, to: 54 },
+  { duration: 680, from: 54, to: 84 },
+  { duration: 480, from: 84, to: 100 },
 ]
 
 const MILESTONES: Milestone[] = [
   {
-    year: '1938',
-    text: 'Claude Shannon - A Symbolic Analysis of Relay and Switching Circuits',
+    key: 'session',
+    label: 'Session verified',
+    detail: 'Credentials accepted',
     revealAt: 8,
   },
   {
-    year: '1948',
-    text: 'Claude Shannon - A Mathematical Theory of Communication',
-    revealAt: 32,
+    key: 'workspace',
+    label: 'Workspace synced',
+    detail: 'Setup state loaded',
+    revealAt: 34,
   },
   {
-    year: '2025',
-    text: 'vLLM Semantic Router: Signal Decision Routing for Mixture-of-Modalities Models',
-    revealAt: 56,
+    key: 'policy',
+    label: 'Policy hydrated',
+    detail: 'Routes and signals prepared',
+    revealAt: 62,
   },
   {
-    year: 'Future',
-    text: 'Standing on the shoulders of giants, we honor that legacy and explore the future together.',
-    revealAt: 78,
+    key: 'dashboard',
+    label: 'Dashboard ready',
+    detail: 'Opening console',
+    revealAt: 86,
   },
 ]
 
@@ -66,6 +70,12 @@ function getTransitionProgress(elapsedMs: number): number {
   return 100
 }
 
+function getActiveMilestoneIndex(progress: number): number {
+  return MILESTONES.reduce((activeIndex, milestone, index) => {
+    return progress >= milestone.revealAt ? index : activeIndex
+  }, 0)
+}
+
 const TransitionScene: React.FC<{ progress: number }> = ({ progress }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const progressRef = useRef(progress)
@@ -81,160 +91,193 @@ const TransitionScene: React.FC<{ progress: number }> = ({ progress }) => {
     }
 
     const scene = new THREE.Scene()
-    const aspect = container.clientWidth / Math.max(container.clientHeight, 1)
-    const viewDistance = 5
-    const camera = new THREE.OrthographicCamera(
-      -viewDistance * aspect,
-      viewDistance * aspect,
-      viewDistance,
-      -viewDistance,
-      1,
-      1000,
-    )
-    camera.position.set(10, 10, 10)
-    camera.lookAt(scene.position)
+    const camera = new THREE.PerspectiveCamera(42, 1, 0.1, 100)
+    camera.position.set(0, 0.9, 8.8)
+    camera.lookAt(0, 0, 0)
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
     renderer.setClearColor(0x000000, 0)
+    renderer.domElement.style.display = 'block'
     container.appendChild(renderer.domElement)
-
-    const noiseVertexShader = `
-      varying vec2 vUv;
-
-      void main() {
-        vUv = uv;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-      }
-    `
-
-    const noiseFragmentShader = `
-      uniform float uTime;
-      uniform vec2 uResolution;
-      varying vec2 vUv;
-
-      float random(vec2 st) {
-        return fract(sin(dot(st.xy, vec2(12.9898, 78.233))) * 43758.5453123);
-      }
-
-      void main() {
-        vec2 center = vec2(0.45, 0.45);
-        float dist = distance(vUv, center);
-        float angle = atan(vUv.y - center.y, vUv.x - center.x);
-        float radius = 0.30 + 0.08 * sin(angle * 3.0 + uTime * 0.55);
-        float mask = smoothstep(radius, 0.0, dist);
-        vec2 noiseUv = vUv * min(uResolution.x, uResolution.y) * 0.5;
-        float noiseVal = random(noiseUv + uTime * 0.1);
-        float stipple = step(noiseVal, mask * 1.4);
-        gl_FragColor = vec4(vec3(1.0), stipple * 0.24);
-      }
-    `
-
-    const noiseGeometry = new THREE.PlaneGeometry(15, 15)
-    const noiseMaterial = new THREE.ShaderMaterial({
-      vertexShader: noiseVertexShader,
-      fragmentShader: noiseFragmentShader,
-      transparent: true,
-      uniforms: {
-        uTime: { value: 0 },
-        uResolution: { value: new THREE.Vector2(container.clientWidth, container.clientHeight) },
-      },
-    })
-    const noisePlane = new THREE.Mesh(noiseGeometry, noiseMaterial)
-    noisePlane.lookAt(camera.position)
-    noisePlane.position.set(-1, -1, -2)
-    scene.add(noisePlane)
 
     const group = new THREE.Group()
     scene.add(group)
 
-    const boxGeometry = new THREE.BoxGeometry(6, 6, 6)
-    const boxEdges = new THREE.EdgesGeometry(boxGeometry)
-    const wireframeMaterial = new THREE.LineBasicMaterial({
-      color: 0xffffff,
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.48)
+    scene.add(ambientLight)
+
+    const keyLight = new THREE.PointLight(0x8fd400, 18, 12)
+    keyLight.position.set(-2.6, 2.4, 4)
+    scene.add(keyLight)
+
+    const cyanLight = new THREE.PointLight(0x00d4ff, 10, 12)
+    cyanLight.position.set(2.8, -1.4, 3)
+    scene.add(cyanLight)
+
+    const nodePositions = [
+      new THREE.Vector3(-3.2, -0.65, 0),
+      new THREE.Vector3(-1.05, 0.72, 0),
+      new THREE.Vector3(1.14, -0.18, 0),
+      new THREE.Vector3(3.08, 0.58, 0),
+    ]
+
+    const curve = new THREE.CatmullRomCurve3(nodePositions)
+    const curvePoints = curve.getPoints(96)
+    const routeGeometry = new THREE.BufferGeometry().setFromPoints(curvePoints)
+    const routeMaterial = new THREE.LineBasicMaterial({
+      color: 0x8fd400,
       transparent: true,
-      opacity: 1,
+      opacity: 0.28,
     })
-    const wireframeBox = new THREE.LineSegments(boxEdges, wireframeMaterial)
-    group.add(wireframeBox)
+    const routeLine = new THREE.Line(routeGeometry, routeMaterial)
+    group.add(routeLine)
 
-    const cylinderGeometry = new THREE.CylinderGeometry(2.5, 2.5, 0.5, 32)
-    const fillVertexShader = `
-      varying vec3 vPosition;
-
-      void main() {
-        vPosition = position;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-      }
-    `
-
-    const fillFragmentShader = `
-      varying vec3 vPosition;
-      uniform float uProgress;
-
-      void main() {
-        float wipe = step(vPosition.y + 2.5, uProgress * 5.0);
-        if (wipe < 0.5) {
-          discard;
-        }
-        gl_FragColor = vec4(vec3(1.0), 1.0);
-      }
-    `
-
-    const fillMaterial = new THREE.ShaderMaterial({
-      vertexShader: fillVertexShader,
-      fragmentShader: fillFragmentShader,
-      side: THREE.DoubleSide,
-      uniforms: { uProgress: { value: 0 } },
+    const completedRouteGeometry = new THREE.BufferGeometry().setFromPoints([nodePositions[0], nodePositions[0]])
+    const completedRouteMaterial = new THREE.LineBasicMaterial({
+      color: 0xb7ff56,
+      transparent: true,
+      opacity: 0.86,
     })
-    const fillMesh = new THREE.Mesh(cylinderGeometry, fillMaterial)
-    fillMesh.rotation.x = Math.PI / 2
-    group.add(fillMesh)
+    const completedRouteLine = new THREE.Line(completedRouteGeometry, completedRouteMaterial)
+    group.add(completedRouteLine)
 
-    const cylinderEdges = new THREE.EdgesGeometry(cylinderGeometry)
-    const cylinderWireframe = new THREE.LineSegments(
-      cylinderEdges,
-      new THREE.LineBasicMaterial({
-        color: 0xffffff,
+    const nodeGeometry = new THREE.SphereGeometry(0.17, 32, 16)
+    const nodeMaterials = nodePositions.map(() =>
+      new THREE.MeshStandardMaterial({
+        color: 0x76b900,
+        emissive: 0x76b900,
+        emissiveIntensity: 0.15,
+        metalness: 0.18,
+        roughness: 0.48,
         transparent: true,
-        opacity: 0.54,
+        opacity: 0.5,
       }),
     )
-    fillMesh.add(cylinderWireframe)
+    const nodeMeshes = nodePositions.map((position, index) => {
+      const mesh = new THREE.Mesh(nodeGeometry, nodeMaterials[index])
+      mesh.position.copy(position)
+      group.add(mesh)
+      return mesh
+    })
 
-    const clock = new THREE.Clock()
+    const nodeRingGeometry = new THREE.RingGeometry(0.28, 0.31, 40)
+    const nodeRingMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.2,
+      side: THREE.DoubleSide,
+    })
+    const nodeRings = nodePositions.map((position) => {
+      const ring = new THREE.Mesh(nodeRingGeometry, nodeRingMaterial.clone())
+      ring.position.copy(position)
+      ring.lookAt(camera.position)
+      group.add(ring)
+      return ring
+    })
+
+    const particleCount = 22
+    const particleGeometry = new THREE.SphereGeometry(0.045, 16, 8)
+    const particleMaterial = new THREE.MeshBasicMaterial({
+      color: 0xd9ff8a,
+      transparent: true,
+      opacity: 0.78,
+    })
+    const particles = Array.from({ length: particleCount }, (_, index) => {
+      const particle = new THREE.Mesh(particleGeometry, particleMaterial.clone())
+      particle.userData.offset = index / particleCount
+      group.add(particle)
+      return particle
+    })
+
+    const arcGeometry = new THREE.TorusGeometry(1.65, 0.01, 8, 128, Math.PI * 1.42)
+    const arcMaterial = new THREE.MeshBasicMaterial({
+      color: 0x76b900,
+      transparent: true,
+      opacity: 0.42,
+    })
+    const progressArc = new THREE.Mesh(arcGeometry, arcMaterial)
+    progressArc.position.set(0, 0, -0.28)
+    progressArc.rotation.set(0, 0, -Math.PI * 0.18)
+    group.add(progressArc)
+
+    const haloGeometry = new THREE.RingGeometry(1.98, 2, 128)
+    const haloMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.08,
+      side: THREE.DoubleSide,
+    })
+    const halo = new THREE.Mesh(haloGeometry, haloMaterial)
+    halo.position.set(0, 0, -0.34)
+    halo.lookAt(camera.position)
+    group.add(halo)
+
+    const startTime = performance.now()
     let frameId = 0
     let currentProgress = 0
 
     const updateRendererSize = () => {
       const width = container.clientWidth || window.innerWidth
       const height = container.clientHeight || window.innerHeight
-      const nextAspect = width / Math.max(height, 1)
 
-      camera.left = -viewDistance * nextAspect
-      camera.right = viewDistance * nextAspect
-      camera.top = viewDistance
-      camera.bottom = -viewDistance
+      camera.aspect = width / Math.max(height, 1)
+      camera.fov = width < 640 ? 52 : 42
+      camera.position.z = width < 640 ? 9.8 : 8.8
       camera.updateProjectionMatrix()
 
-      renderer.setSize(width, height)
-      noiseMaterial.uniforms.uResolution.value.set(width, height)
+      renderer.setSize(width, height, false)
     }
 
     const renderFrame = () => {
       frameId = window.requestAnimationFrame(renderFrame)
-      const time = clock.getElapsedTime()
+      const time = (performance.now() - startTime) / 1000
 
-      currentProgress += (progressRef.current - currentProgress) * 0.06
-      noiseMaterial.uniforms.uTime.value = time
-      fillMaterial.uniforms.uProgress.value = currentProgress / 100
+      currentProgress += (progressRef.current - currentProgress) * 0.08
+      const normalizedProgress = Math.max(0, Math.min(currentProgress / 100, 1))
+      const visiblePointCount = Math.max(2, Math.floor(curvePoints.length * normalizedProgress))
+      completedRouteGeometry.setFromPoints(curvePoints.slice(0, visiblePointCount))
 
-      wireframeMaterial.opacity = 1 - currentProgress / 135
-      const boxScale = 1 + currentProgress / 200
-      wireframeBox.scale.set(boxScale, boxScale, boxScale)
-      group.rotation.y = time * (0.16 + currentProgress * 0.012)
-      group.rotation.x = Math.sin(time * 0.35) * 0.18
-      group.rotation.z = Math.cos(time * 0.25) * 0.08
+      keyLight.intensity = 15 + Math.sin(time * 1.4) * 2
+      cyanLight.intensity = 8 + Math.cos(time * 1.1) * 1.5
+      group.rotation.y = Math.sin(time * 0.28) * 0.12
+      group.rotation.x = Math.cos(time * 0.24) * 0.06
+
+      progressArc.scale.setScalar(0.92 + normalizedProgress * 0.24)
+      arcMaterial.opacity = 0.28 + normalizedProgress * 0.34
+      halo.rotation.z = time * 0.08
+      haloMaterial.opacity = 0.06 + Math.sin(time * 1.8) * 0.015
+
+      nodeMeshes.forEach((mesh, index) => {
+        const threshold = MILESTONES[index]?.revealAt ?? 100
+        const activeAmount = Math.max(0, Math.min((currentProgress - threshold + 16) / 22, 1))
+        const pulse = Math.sin(time * 2.2 + index * 0.8) * 0.035
+        const scale = 0.88 + activeAmount * 0.56 + pulse
+        mesh.scale.setScalar(scale)
+        nodeMaterials[index].opacity = 0.38 + activeAmount * 0.62
+        nodeMaterials[index].emissiveIntensity = 0.12 + activeAmount * 0.82
+      })
+
+      nodeRings.forEach((ring, index) => {
+        const threshold = MILESTONES[index]?.revealAt ?? 100
+        const activeAmount = Math.max(0, Math.min((currentProgress - threshold + 12) / 20, 1))
+        ring.lookAt(camera.position)
+        ring.rotation.z += 0.01 + activeAmount * 0.012
+        ring.scale.setScalar(0.8 + activeAmount * 0.8 + Math.sin(time * 1.7 + index) * 0.04)
+        ;(ring.material as THREE.MeshBasicMaterial).opacity = 0.1 + activeAmount * 0.38
+      })
+
+      particles.forEach((particle, index) => {
+        const baseOffset = particle.userData.offset as number
+        const travel = (baseOffset + time * 0.13) % 1
+        const gatedTravel = Math.min(travel, normalizedProgress)
+        const point = curve.getPointAt(gatedTravel)
+        const wobble = Math.sin(time * 2.2 + index) * 0.035
+        particle.position.set(point.x, point.y + wobble, point.z + Math.cos(time + index) * 0.025)
+        const particleActive = travel <= normalizedProgress || normalizedProgress > 0.96
+        ;(particle.material as THREE.MeshBasicMaterial).opacity = particleActive ? 0.28 + normalizedProgress * 0.62 : 0
+        particle.scale.setScalar(0.7 + Math.sin(time * 3 + index) * 0.16)
+      })
 
       renderer.render(scene, camera)
     }
@@ -248,15 +291,20 @@ const TransitionScene: React.FC<{ progress: number }> = ({ progress }) => {
       window.cancelAnimationFrame(frameId)
       window.removeEventListener('resize', updateRendererSize)
       renderer.dispose()
-      noiseGeometry.dispose()
-      noiseMaterial.dispose()
-      boxGeometry.dispose()
-      boxEdges.dispose()
-      wireframeMaterial.dispose()
-      cylinderGeometry.dispose()
-      cylinderEdges.dispose()
-      fillMaterial.dispose()
-      ;(cylinderWireframe.material as THREE.Material).dispose()
+      routeGeometry.dispose()
+      routeMaterial.dispose()
+      completedRouteGeometry.dispose()
+      completedRouteMaterial.dispose()
+      nodeGeometry.dispose()
+      nodeMaterials.forEach((material) => material.dispose())
+      nodeRingGeometry.dispose()
+      nodeRings.forEach((ring) => (ring.material as THREE.Material).dispose())
+      particleGeometry.dispose()
+      particles.forEach((particle) => (particle.material as THREE.Material).dispose())
+      arcGeometry.dispose()
+      arcMaterial.dispose()
+      haloGeometry.dispose()
+      haloMaterial.dispose()
       container.removeChild(renderer.domElement)
     }
   }, [])
@@ -274,7 +322,8 @@ const AuthTransitionPage: React.FC = () => {
 
   const fallbackTarget = setupState?.setupMode ? '/setup' : '/dashboard'
   const target = sanitizeAuthTransitionTarget(searchParams.get('to'), fallbackTarget)
-  const counterValue = Math.floor(progress)
+  const activeMilestoneIndex = getActiveMilestoneIndex(progress)
+  const activeMilestone = MILESTONES[activeMilestoneIndex]
 
   useEffect(() => {
     let frameId = 0
@@ -310,7 +359,7 @@ const AuthTransitionPage: React.FC = () => {
   }
 
   return (
-    <main className={styles.page}>
+    <main className={styles.page} aria-busy={!animationComplete} aria-live="polite" role="status">
       <div className={styles.grid} aria-hidden="true">
         {Array.from({ length: 9 }, (_, index) => (
           <div key={index} className={styles.gridCell} />
@@ -321,38 +370,41 @@ const AuthTransitionPage: React.FC = () => {
 
       <div className={styles.overlay}>
         <section className={styles.topLeft}>
-          <span className={styles.metaText}>SYS.ID: VSR-2025</span>
-          <span className={styles.metaText}>INITIATING SEQUENCE</span>
+          <span className={styles.metaText}>VSR Dashboard</span>
+          <span className={styles.metaText}>{activeMilestone.label}</span>
         </section>
 
         <section className={styles.topRight} aria-hidden="true">
-          <span className={styles.asterisk}>* * *</span>
+          <span className={styles.statusBeacon} />
+          <span className={styles.metaText}>Live route handoff</span>
         </section>
 
         <section className={styles.center}>
-          <div className={styles.counterWrapper}>
-            <span className={styles.counterNumber}>{counterValue}</span>
-            <span className={styles.counterSymbol}>%</span>
+          <div className={styles.centerCopy}>
+            <span className={styles.centerEyebrow}>Authenticated</span>
+            <h1 className={styles.centerTitle}>Opening dashboard</h1>
+            <p className={styles.centerText}>{activeMilestone.detail}</p>
           </div>
         </section>
 
         <section className={styles.bottomLeft}>
           <div className={styles.sequencePanel}>
-            <span className={styles.sequenceHeader}>Signal lineage</span>
+            <span className={styles.sequenceHeader}>Loading sequence</span>
             <ol className={styles.sequenceList} aria-live="polite">
               {MILESTONES.map((milestone, index) => {
                 const isVisible = progress >= milestone.revealAt
-                const isActive =
-                  isVisible &&
-                  (index === MILESTONES.length - 1 || progress < MILESTONES[index + 1].revealAt)
+                const isActive = index === activeMilestoneIndex
 
                 return (
                   <li
-                    key={milestone.year}
+                    key={milestone.key}
                     className={`${styles.sequenceItem} ${isVisible ? styles.sequenceItemVisible : ''} ${isActive ? styles.sequenceItemActive : ''}`}
                   >
-                    <span className={styles.sequenceYear}>{milestone.year}</span>
-                    <span className={styles.sequenceCopy}>{milestone.text}</span>
+                    <span className={styles.sequenceYear}>{String(index + 1).padStart(2, '0')}</span>
+                    <span>
+                      <span className={styles.sequenceCopy}>{milestone.label}</span>
+                      <span className={styles.sequenceDetail}>{milestone.detail}</span>
+                    </span>
                   </li>
                 )
               })}
@@ -362,13 +414,20 @@ const AuthTransitionPage: React.FC = () => {
 
         <section className={styles.bottomRight}>
           <div className={styles.metaBlock}>
-            <span className={styles.metaLabel}>VOL.</span>
-            <span className={styles.metaValue}>04</span>
+            <span className={styles.metaLabel}>Progress</span>
+            <span className={styles.metaValue}>{Math.round(progress)}%</span>
           </div>
         </section>
 
-        <div className={styles.progressTrack} aria-hidden="true">
-          <div className={styles.progressBar} style={{ width: `${progress}%` }} />
+        <div
+          className={styles.progressTrack}
+          role="progressbar"
+          aria-label="Opening dashboard"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(progress)}
+        >
+          <div className={styles.progressBar} style={{ transform: `scaleX(${progress / 100})` }} />
         </div>
       </div>
     </main>

--- a/dashboard/frontend/src/pages/authTransitionSupport.ts
+++ b/dashboard/frontend/src/pages/authTransitionSupport.ts
@@ -1,5 +1,5 @@
 export const AUTH_TRANSITION_PATH = '/auth/transition'
-export const AUTH_TRANSITION_MIN_DURATION_MS = 3800
+export const AUTH_TRANSITION_MIN_DURATION_MS = 2300
 
 const DASHBOARD_ORIGIN = 'http://vsr-dashboard.local'
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes N/A

## Purpose

- Improve the post-login dashboard transition loading experience.
- Keep the existing fullscreen transition shape and Three.js-based scene, but make the animation more purposeful and visually aligned with the dashboard.
- Replace the oversized center percentage and white rotating capsule-like object with a route handoff scene: session, workspace, policy, and dashboard nodes light up as progress advances.
- Shorten the minimum auth transition duration from `3800ms` to `2300ms` so the login flow feels more responsive without making the transition abrupt.
- Affected module(s): `Dashboard`

## Test Plan

- Run `make dashboard-check`.
- Run dashboard frontend TypeScript checking through the dashboard gate.
- Verify the auth transition manually in a local Vite dev server by mocking authenticated setup/auth responses and opening `/auth/transition?to=/dashboard`.
- Confirm the Three.js canvas renders, the loading sequence updates, and the layout remains a fullscreen transition rather than a new card-style flow.

## Test Result

- `make dashboard-check` passed.
- Dashboard frontend unit tests passed: `11` test files, `40` tests.
- Dashboard frontend type-check passed.
- Dashboard backend lint and `go mod tidy` checks passed through `dashboard-check`.
- Manual Playwright/Chrome validation confirmed the auth transition rendered with a non-empty fullscreen canvas, visible loading sequence, and progress state.
- Known follow-up: existing dashboard/wizmap Sass deprecation warnings and npm audit notices still appear during the dashboard checks, but they are pre-existing and not introduced by this PR.

Screenshot before change:

<img width="2956" height="1690" alt="screenshot-20260616-160623" src="https://github.com/user-attachments/assets/8c63d504-078e-45f6-a4f8-b15f23e68b04" />

After:

<img width="2970" height="1676" alt="screenshot-20260616-170507" src="https://github.com/user-attachments/assets/14ccb122-695f-4680-89ce-597e06b5ea0b" />

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.