### PR TITLE
[Router] wire decision-scoped hybrid selector with canonical defaults

### DIFF
--- a/src/semantic-router/pkg/config/canonical_defaults.go
+++ b/src/semantic-router/pkg/config/canonical_defaults.go
@@ -22,6 +22,22 @@ func defaultCanonicalRouterGlobal() CanonicalRouterGlobal {
 		ModelSelection: ModelSelectionConfig{
 			Enabled: true,
 			Method:  "knn",
+			RouterDC: RouterDCSelectionConfig{
+				Temperature:         0.07,
+				DimensionSize:       768,
+				MinSimilarity:       0.3,
+				UseQueryContrastive: true,
+				UseModelContrastive: true,
+				UseCapabilities:     true,
+			},
+			Hybrid: HybridSelectionConfig{
+				EloWeight:           0.3,
+				RouterDCWeight:      0.3,
+				AutoMixWeight:       0.2,
+				CostWeight:          0.2,
+				QualityGapThreshold: 0.1,
+				NormalizeScores:     true,
+			},
 		},
 	}
 }

--- a/src/semantic-router/pkg/config/selection_config.go
+++ b/src/semantic-router/pkg/config/selection_config.go
@@ -166,10 +166,10 @@ type RouterDCSelectionConfig struct {
 	Temperature         float64 `yaml:"temperature,omitempty"`
 	DimensionSize       int     `yaml:"dimension_size,omitempty"`
 	MinSimilarity       float64 `yaml:"min_similarity,omitempty"`
-	UseQueryContrastive bool    `yaml:"use_query_contrastive,omitempty"`
-	UseModelContrastive bool    `yaml:"use_model_contrastive,omitempty"`
-	RequireDescriptions bool    `yaml:"require_descriptions,omitempty"`
-	UseCapabilities     bool    `yaml:"use_capabilities,omitempty"`
+	UseQueryContrastive bool    `yaml:"use_query_contrastive"`
+	UseModelContrastive bool    `yaml:"use_model_contrastive"`
+	RequireDescriptions bool    `yaml:"require_descriptions"`
+	UseCapabilities     bool    `yaml:"use_capabilities"`
 }
 
 type AutoMixSelectionConfig struct {
@@ -187,7 +187,7 @@ type HybridSelectionConfig struct {
 	AutoMixWeight       float64 `yaml:"automix_weight,omitempty"`
 	CostWeight          float64 `yaml:"cost_weight,omitempty"`
 	QualityGapThreshold float64 `yaml:"quality_gap_threshold,omitempty"`
-	NormalizeScores     bool    `yaml:"normalize_scores,omitempty"`
+	NormalizeScores     bool    `yaml:"normalize_scores"`
 }
 
 // SessionAwareSelectionConfig configures the session_aware selector. It wraps

--- a/src/semantic-router/pkg/config/skip_processing_test.go
+++ b/src/semantic-router/pkg/config/skip_processing_test.go
@@ -83,3 +83,40 @@ model_catalog:
 		t.Fatal("CanonicalGlobalFromRouterConfig should round-trip skip_processing.enabled=true")
 	}
 }
+
+func TestCanonicalGlobalModelSelectionFalseOverridesRoundTrip(t *testing.T) {
+	cfg := DefaultGlobalConfig()
+	cfg.ModelSelection.RouterDC.UseQueryContrastive = false
+	cfg.ModelSelection.RouterDC.UseModelContrastive = false
+	cfg.ModelSelection.RouterDC.UseCapabilities = false
+	cfg.ModelSelection.Hybrid.NormalizeScores = false
+
+	exported := CanonicalGlobalFromRouterConfig(&cfg)
+	if exported == nil {
+		t.Fatal("expected canonical global export")
+	}
+
+	doc := CanonicalConfig{Global: exported}
+	encoded, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("failed to marshal canonical config: %v", err)
+	}
+
+	parsed, err := ParseYAMLBytes(encoded)
+	if err != nil {
+		t.Fatalf("ParseYAMLBytes returned error: %v", err)
+	}
+
+	if parsed.ModelSelection.RouterDC.UseQueryContrastive {
+		t.Fatalf("expected router_dc.use_query_contrastive=false after round-trip, got %+v", parsed.ModelSelection.RouterDC)
+	}
+	if parsed.ModelSelection.RouterDC.UseModelContrastive {
+		t.Fatalf("expected router_dc.use_model_contrastive=false after round-trip, got %+v", parsed.ModelSelection.RouterDC)
+	}
+	if parsed.ModelSelection.RouterDC.UseCapabilities {
+		t.Fatalf("expected router_dc.use_capabilities=false after round-trip, got %+v", parsed.ModelSelection.RouterDC)
+	}
+	if parsed.ModelSelection.Hybrid.NormalizeScores {
+		t.Fatalf("expected hybrid.normalize_scores=false after round-trip, got %+v", parsed.ModelSelection.Hybrid)
+	}
+}

--- a/src/semantic-router/pkg/dsl/algorithm_defaults_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/algorithm_defaults_roundtrip_test.go
@@ -1,0 +1,21 @@
+package dsl
+
+import "testing"
+
+func TestCompileASTSeedsModelSelectionDefaults(t *testing.T) {
+	cfg, errs := CompileAST(&Program{})
+	if len(errs) > 0 {
+		t.Fatalf("CompileAST errors: %v", errs)
+	}
+	if cfg == nil {
+		t.Fatal("expected router config from CompileAST")
+	}
+	if !cfg.ModelSelection.RouterDC.UseQueryContrastive ||
+		!cfg.ModelSelection.RouterDC.UseModelContrastive ||
+		!cfg.ModelSelection.RouterDC.UseCapabilities {
+		t.Fatalf("expected CompileAST to seed RouterDC defaults, got %+v", cfg.ModelSelection.RouterDC)
+	}
+	if !cfg.ModelSelection.Hybrid.NormalizeScores {
+		t.Fatalf("expected CompileAST to seed Hybrid defaults, got %+v", cfg.ModelSelection.Hybrid)
+	}
+}

--- a/src/semantic-router/pkg/dsl/compiler.go
+++ b/src/semantic-router/pkg/dsl/compiler.go
@@ -25,9 +25,14 @@ func Compile(input string) (*config.RouterConfig, []error) {
 }
 
 func CompileAST(prog *Program) (*config.RouterConfig, []error) {
+	defaults := config.DefaultGlobalConfig()
 	c := &Compiler{
-		prog:            prog,
-		config:          &config.RouterConfig{},
+		prog: prog,
+		config: &config.RouterConfig{
+			IntelligentRouting: config.IntelligentRouting{
+				ModelSelection: defaults.ModelSelection,
+			},
+		},
 		pluginTemplates: make(map[string]*PluginDecl),
 	}
 	c.compile()

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -153,33 +153,47 @@ func (r *OpenAIRouter) newDecisionHybridSelector(decisionCfg *config.HybridSelec
 		cfg = selection.DefaultHybridConfig()
 	}
 
-	var eloSelector *selection.EloSelector
-	var routerDCSelector *selection.RouterDCSelector
-	var autoMixSelector *selection.AutoMixSelector
-	if r != nil && r.ModelSelector != nil {
-		if selector, ok := r.ModelSelector.Get(selection.MethodElo); ok {
-			eloSelector, _ = selector.(*selection.EloSelector)
-		}
-		if selector, ok := r.ModelSelector.Get(selection.MethodRouterDC); ok {
-			routerDCSelector, _ = selector.(*selection.RouterDCSelector)
-		}
-		if selector, ok := r.ModelSelector.Get(selection.MethodAutoMix); ok {
-			autoMixSelector, _ = selector.(*selection.AutoMixSelector)
-		}
-	}
+	eloSelector, routerDCSelector, autoMixSelector := r.hybridComponentSelectors()
 
 	selector := selection.NewHybridSelectorWithComponents(cfg, eloSelector, routerDCSelector, autoMixSelector)
-	if r != nil && r.Config != nil && r.Config.ModelConfig != nil {
-		for model, params := range r.Config.ModelConfig {
-			if params.Pricing.PromptPer1M > 0 {
-				selector.SetModelCost(model, params.Pricing.PromptPer1M)
-			}
-		}
-	}
+	r.applyHybridModelCosts(selector)
 	if r != nil && r.LookupTable != nil {
 		selector.SetLookupTable(r.LookupTable)
 	}
 	return selector
+}
+
+// hybridComponentSelectors resolves the underlying elo/routerDC/autoMix selectors
+// that the hybrid selector composes, when they are registered on the router.
+func (r *OpenAIRouter) hybridComponentSelectors() (*selection.EloSelector, *selection.RouterDCSelector, *selection.AutoMixSelector) {
+	if r == nil || r.ModelSelector == nil {
+		return nil, nil, nil
+	}
+	var eloSelector *selection.EloSelector
+	var routerDCSelector *selection.RouterDCSelector
+	var autoMixSelector *selection.AutoMixSelector
+	if selector, ok := r.ModelSelector.Get(selection.MethodElo); ok {
+		eloSelector, _ = selector.(*selection.EloSelector)
+	}
+	if selector, ok := r.ModelSelector.Get(selection.MethodRouterDC); ok {
+		routerDCSelector, _ = selector.(*selection.RouterDCSelector)
+	}
+	if selector, ok := r.ModelSelector.Get(selection.MethodAutoMix); ok {
+		autoMixSelector, _ = selector.(*selection.AutoMixSelector)
+	}
+	return eloSelector, routerDCSelector, autoMixSelector
+}
+
+// applyHybridModelCosts seeds per-model prompt pricing into the hybrid selector.
+func (r *OpenAIRouter) applyHybridModelCosts(selector *selection.HybridSelector) {
+	if r == nil || r.Config == nil || r.Config.ModelConfig == nil {
+		return
+	}
+	for model, params := range r.Config.ModelConfig {
+		if params.Pricing.PromptPer1M > 0 {
+			selector.SetModelCost(model, params.Pricing.PromptPer1M)
+		}
+	}
 }
 
 func (r *OpenAIRouter) newDecisionSessionAwareSelector(decisionCfg *config.SessionAwareSelectionConfig) selection.Selector {

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -132,6 +132,9 @@ func (r *OpenAIRouter) selectModelFromCandidates(selCtx *selection.SelectionCont
 }
 
 func (r *OpenAIRouter) selectorForDecisionMethod(method selection.SelectionMethod, algorithm *config.AlgorithmConfig) selection.Selector {
+	if method == selection.MethodHybrid && algorithm != nil && algorithm.Hybrid != nil {
+		return r.newDecisionHybridSelector(algorithm.Hybrid)
+	}
 	if method == selection.MethodSessionAware && algorithm != nil && algorithm.SessionAware != nil {
 		return r.newDecisionSessionAwareSelector(algorithm.SessionAware)
 	}
@@ -139,6 +142,43 @@ func (r *OpenAIRouter) selectorForDecisionMethod(method selection.SelectionMetho
 		return nil
 	}
 	selector, _ := r.ModelSelector.Get(method)
+	return selector
+}
+
+func (r *OpenAIRouter) newDecisionHybridSelector(decisionCfg *config.HybridSelectionConfig) selection.Selector {
+	var cfg *selection.HybridConfig
+	if r != nil && r.Config != nil {
+		cfg = buildHybridSelectionConfig(r.Config, decisionCfg)
+	} else {
+		cfg = selection.DefaultHybridConfig()
+	}
+
+	var eloSelector *selection.EloSelector
+	var routerDCSelector *selection.RouterDCSelector
+	var autoMixSelector *selection.AutoMixSelector
+	if r != nil && r.ModelSelector != nil {
+		if selector, ok := r.ModelSelector.Get(selection.MethodElo); ok {
+			eloSelector, _ = selector.(*selection.EloSelector)
+		}
+		if selector, ok := r.ModelSelector.Get(selection.MethodRouterDC); ok {
+			routerDCSelector, _ = selector.(*selection.RouterDCSelector)
+		}
+		if selector, ok := r.ModelSelector.Get(selection.MethodAutoMix); ok {
+			autoMixSelector, _ = selector.(*selection.AutoMixSelector)
+		}
+	}
+
+	selector := selection.NewHybridSelectorWithComponents(cfg, eloSelector, routerDCSelector, autoMixSelector)
+	if r != nil && r.Config != nil && r.Config.ModelConfig != nil {
+		for model, params := range r.Config.ModelConfig {
+			if params.Pricing.PromptPer1M > 0 {
+				selector.SetModelCost(model, params.Pricing.PromptPer1M)
+			}
+		}
+	}
+	if r != nil && r.LookupTable != nil {
+		selector.SetLookupTable(r.LookupTable)
+	}
 	return selector
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_classification_selection_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_selection_test.go
@@ -18,6 +18,9 @@ package extproc
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -183,6 +186,119 @@ func TestSelectModelFromCandidatesUsesDecisionScopedSessionAwareConfig(t *testin
 	}
 	if ctx.VSRSessionPolicy == nil || ctx.VSRSessionPolicy["idle_expired"] != true {
 		t.Fatalf("expected decision-scoped idle timeout in session policy, got %#v", ctx.VSRSessionPolicy)
+	}
+}
+
+func TestNewDecisionSessionAwareSelectorWithRouterDCBaseProducesFiniteScore(t *testing.T) {
+	cfg := config.DefaultGlobalConfig()
+	cfg.BackendModels.ModelConfig = map[string]config.ModelParams{
+		"current":  {Description: "general chat"},
+		"frontier": {Description: "coding specialist"},
+	}
+
+	modelSelectionCfg := buildModelSelectionConfig(&cfg)
+	registry := selection.NewFactory(modelSelectionCfg).
+		WithModelConfig(cfg.BackendModels.ModelConfig).
+		WithEmbeddingFunc(func(text string) ([]float32, error) {
+			lower := strings.ToLower(text)
+			switch {
+			case strings.Contains(lower, "coding"):
+				return []float32{1, 0}, nil
+			case strings.Contains(lower, "general"):
+				return []float32{0, 1}, nil
+			default:
+				return []float32{0.5, 0.5}, nil
+			}
+		}).
+		CreateAll()
+
+	router := &OpenAIRouter{
+		Config:        &cfg,
+		ModelSelector: registry,
+	}
+
+	selector := router.newDecisionSessionAwareSelector(&config.SessionAwareSelectionConfig{
+		BaseMethod:           "router_dc",
+		IdleTimeoutSeconds:   extprocIntPtr(1),
+		MinTurnsBeforeSwitch: extprocIntPtr(1),
+	})
+
+	result, err := selector.Select(context.Background(), &selection.SelectionContext{
+		Query:           "need help with coding",
+		DecisionName:    "agentic_session_routing",
+		CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "frontier"}},
+		AgenticSession: &selection.AgenticSessionContext{
+			ID:            "session-router-dc",
+			TurnIndex:     3,
+			PreviousModel: "current",
+			IdleKnown:     true,
+			IdleFor:       2 * time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+	if result.Method != selection.MethodSessionAware {
+		t.Fatalf("expected session_aware method, got %q", result.Method)
+	}
+	if math.IsNaN(result.Score) || math.IsInf(result.Score, 0) {
+		t.Fatalf("expected finite session-aware score, got %v", result.Score)
+	}
+	if result.SessionPolicy == nil {
+		t.Fatal("expected session policy trace from session_aware selector")
+	}
+	if result.SelectedModel != "frontier" {
+		t.Fatalf("expected router_dc base selection to surface frontier, got %q", result.SelectedModel)
+	}
+}
+
+func TestSelectorForDecisionMethodBuildsDecisionScopedHybridSelector(t *testing.T) {
+	cfg := config.DefaultGlobalConfig()
+	cfg.BackendModels.ModelConfig = map[string]config.ModelParams{
+		"current":  {Description: "general chat"},
+		"frontier": {Description: "coding specialist"},
+	}
+
+	modelSelectionCfg := buildModelSelectionConfig(&cfg)
+	registry := selection.NewFactory(modelSelectionCfg).
+		WithModelConfig(cfg.BackendModels.ModelConfig).
+		WithEmbeddingFunc(func(text string) ([]float32, error) {
+			lower := strings.ToLower(text)
+			switch {
+			case strings.Contains(lower, "coding"):
+				return []float32{1, 0}, nil
+			case strings.Contains(lower, "general"):
+				return []float32{0, 1}, nil
+			default:
+				return []float32{0.5, 0.5}, nil
+			}
+		}).
+		CreateAll()
+
+	router := &OpenAIRouter{
+		Config:        &cfg,
+		ModelSelector: registry,
+	}
+
+	selector := router.selectorForDecisionMethod(selection.MethodHybrid, &config.AlgorithmConfig{
+		Type: "hybrid",
+		Hybrid: &config.HybridSelectionConfig{
+			EloWeight:      0.6,
+			RouterDCWeight: 0.4,
+		},
+	})
+
+	result, err := selector.Select(context.Background(), &selection.SelectionContext{
+		Query:           "need help with coding",
+		DecisionName:    "hybrid_route",
+		CandidateModels: []config.ModelRef{{Model: "current"}, {Model: "frontier"}},
+	})
+	if err != nil {
+		t.Fatalf("Select returned error: %v", err)
+	}
+	wantWeights := fmt.Sprintf("weights=[elo:%.2f, dc:%.2f, am:%.2f, cost:%.2f]", 0.6, 0.4, 0.2, 0.2)
+	if !strings.Contains(result.Reasoning, wantWeights) {
+		t.Fatalf("expected decision-scoped hybrid weights in reasoning, got %q", result.Reasoning)
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -102,7 +102,7 @@ func buildModelSelectionConfig(cfg *config.RouterConfig) *selection.ModelSelecti
 	modelSelectionCfg.Elo = buildEloSelectionConfig(cfg, decisionCfgs.elo)
 	modelSelectionCfg.RouterDC = buildRouterDCSelectionConfig(cfg, decisionCfgs.routerDC)
 	modelSelectionCfg.AutoMix = buildAutoMixSelectionConfig(cfg)
-	modelSelectionCfg.Hybrid = buildHybridSelectionConfig(cfg)
+	modelSelectionCfg.Hybrid = buildHybridSelectionConfig(cfg, nil)
 	modelSelectionCfg.SessionAware = buildSessionAwareSelectionConfig(cfg, decisionCfgs.sessionAware)
 	modelSelectionCfg.ML = buildMLSelectionConfig(cfg)
 	modelSelectionCfg.MultiFactor = buildMultiFactorSelectionConfig(decisionCfgs.multiFactor)
@@ -241,10 +241,13 @@ func buildAutoMixSelectionConfig(cfg *config.RouterConfig) *selection.AutoMixCon
 	}
 }
 
-func buildHybridSelectionConfig(cfg *config.RouterConfig) *selection.HybridConfig {
+func buildHybridSelectionConfig(
+	cfg *config.RouterConfig,
+	decisionCfg *config.HybridSelectionConfig,
+) *selection.HybridConfig {
 	intelligentRouting := cfg.IntelligentRouting
 	hybridCfg := intelligentRouting.ModelSelection.Hybrid
-	return &selection.HybridConfig{
+	result := &selection.HybridConfig{
 		EloWeight:           hybridCfg.EloWeight,
 		RouterDCWeight:      hybridCfg.RouterDCWeight,
 		AutoMixWeight:       hybridCfg.AutoMixWeight,
@@ -252,6 +255,29 @@ func buildHybridSelectionConfig(cfg *config.RouterConfig) *selection.HybridConfi
 		QualityGapThreshold: hybridCfg.QualityGapThreshold,
 		NormalizeScores:     hybridCfg.NormalizeScores,
 	}
+
+	if decisionCfg == nil {
+		return result
+	}
+	if decisionCfg.EloWeight != 0 {
+		result.EloWeight = decisionCfg.EloWeight
+	}
+	if decisionCfg.RouterDCWeight != 0 {
+		result.RouterDCWeight = decisionCfg.RouterDCWeight
+	}
+	if decisionCfg.AutoMixWeight != 0 {
+		result.AutoMixWeight = decisionCfg.AutoMixWeight
+	}
+	if decisionCfg.CostWeight != 0 {
+		result.CostWeight = decisionCfg.CostWeight
+	}
+	if decisionCfg.QualityGapThreshold != 0 {
+		result.QualityGapThreshold = decisionCfg.QualityGapThreshold
+	}
+	if decisionCfg.NormalizeScores {
+		result.NormalizeScores = true
+	}
+	return result
 }
 
 func buildSessionAwareSelectionConfig(

--- a/src/semantic-router/pkg/extproc/router_selection_config_test.go
+++ b/src/semantic-router/pkg/extproc/router_selection_config_test.go
@@ -80,7 +80,18 @@ func gmtRouterLearningDecision() config.Decision {
 }
 
 func TestBuildModelSelectionConfigPreservesLearningDefaultsWhenUnset(t *testing.T) {
-	got := buildModelSelectionConfig(&config.RouterConfig{})
+	defaults := config.DefaultGlobalConfig()
+	got := buildModelSelectionConfig(&defaults)
+
+	defaultRouterDC := selection.DefaultRouterDCConfig()
+	if !reflect.DeepEqual(got.RouterDC, defaultRouterDC) {
+		t.Fatalf("RouterDC default drift:\n got: %+v\nwant: %+v", got.RouterDC, defaultRouterDC)
+	}
+
+	defaultHybrid := selection.DefaultHybridConfig()
+	if !reflect.DeepEqual(got.Hybrid, defaultHybrid) {
+		t.Fatalf("Hybrid default drift:\n got: %+v\nwant: %+v", got.Hybrid, defaultHybrid)
+	}
 
 	defaultRL := selection.DefaultRLDrivenConfig()
 	if !reflect.DeepEqual(got.RLDriven, defaultRL) {
@@ -90,6 +101,53 @@ func TestBuildModelSelectionConfigPreservesLearningDefaultsWhenUnset(t *testing.
 	defaultGMT := selection.DefaultGMTRouterConfig()
 	if !reflect.DeepEqual(got.GMTRouter, defaultGMT) {
 		t.Fatalf("GMTRouter default drift:\n got: %+v\nwant: %+v", got.GMTRouter, defaultGMT)
+	}
+}
+
+func TestBuildModelSelectionConfigPreservesExplicitFalseOverrides(t *testing.T) {
+	cfg := config.DefaultGlobalConfig()
+	cfg.IntelligentRouting.ModelSelection.RouterDC.UseCapabilities = false
+	cfg.IntelligentRouting.ModelSelection.Hybrid.NormalizeScores = false
+
+	got := buildModelSelectionConfig(&cfg)
+
+	if got.RouterDC == nil {
+		t.Fatal("expected RouterDC config to be built")
+	}
+	if got.RouterDC.UseCapabilities {
+		t.Fatalf("expected explicit router_dc.use_capabilities=false to be preserved, got %+v", got.RouterDC)
+	}
+	if got.RouterDC.Temperature != selection.DefaultRouterDCConfig().Temperature {
+		t.Fatalf("expected router_dc defaults to survive explicit false override, got %+v", got.RouterDC)
+	}
+
+	if got.Hybrid == nil {
+		t.Fatal("expected Hybrid config to be built")
+	}
+	if got.Hybrid.NormalizeScores {
+		t.Fatalf("expected explicit hybrid.normalize_scores=false to be preserved, got %+v", got.Hybrid)
+	}
+	if got.Hybrid.RouterDCWeight != selection.DefaultHybridConfig().RouterDCWeight {
+		t.Fatalf("expected hybrid defaults to survive explicit false override, got %+v", got.Hybrid)
+	}
+}
+
+func TestBuildHybridSelectionConfigMergesDecisionOverrides(t *testing.T) {
+	cfg := config.DefaultGlobalConfig()
+
+	got := buildHybridSelectionConfig(&cfg, &config.HybridSelectionConfig{
+		EloWeight:      0.6,
+		RouterDCWeight: 0.4,
+	})
+
+	if got == nil {
+		t.Fatal("expected Hybrid config to be built")
+	}
+	if got.EloWeight != 0.6 || got.RouterDCWeight != 0.4 {
+		t.Fatalf("expected decision-scoped hybrid weights, got %+v", got)
+	}
+	if got.AutoMixWeight != selection.DefaultHybridConfig().AutoMixWeight || !got.NormalizeScores {
+		t.Fatalf("expected decision-scoped hybrid config to preserve remaining defaults, got %+v", got)
 	}
 }
 

--- a/src/vllm-sr/cli/algorithms.py
+++ b/src/vllm-sr/cli/algorithms.py
@@ -191,16 +191,16 @@ class RouterDCSelectionConfig(BaseModel):
     min_similarity: float | None = Field(default=0.3, ge=0, le=1)
 
     # Enable query-side contrastive learning
-    use_query_contrastive: bool | None = False
+    use_query_contrastive: bool | None = True
 
     # Enable model-side contrastive learning
-    use_model_contrastive: bool | None = False
+    use_model_contrastive: bool | None = True
 
     # Require all models to have descriptions
     require_descriptions: bool | None = False
 
     # Include capability tags in embeddings
-    use_capabilities: bool | None = False
+    use_capabilities: bool | None = True
 
 
 class AutoMixSelectionConfig(BaseModel):

--- a/src/vllm-sr/cli/validator.py
+++ b/src/vllm-sr/cli/validator.py
@@ -520,19 +520,22 @@ def _maybe_hybrid_weight_error(
     if algo_type != "hybrid" or not algo.hybrid:
         return None
     h = algo.hybrid
+    # Per-weight non-negativity is enforced by the pydantic model (ge=0).
+    # Weights are normalized at runtime, so they need not sum to 1.0 — but an
+    # all-zero set leaves the selector with nothing to normalize, so reject it.
     total = (
         (0.3 if h.elo_weight is None else h.elo_weight)
         + (0.3 if h.router_dc_weight is None else h.router_dc_weight)
         + (0.2 if h.automix_weight is None else h.automix_weight)
         + (0.2 if h.cost_weight is None else h.cost_weight)
     )
-    if abs(total - 1.0) <= 0.01:
-        return None
-    return ValidationError(
-        f"Decision '{decision_name}' hybrid weights sum to {total:.2f}, "
-        "should sum to 1.0",
-        field=f"decisions.{decision_name}.algorithm.hybrid",
-    )
+    if total <= 0:
+        return ValidationError(
+            f"Decision '{decision_name}' hybrid weights are all zero; "
+            "at least one weight must be positive",
+            field=f"decisions.{decision_name}.algorithm.hybrid",
+        )
+    return None
 
 
 def validate_algorithm_configurations(config: UserConfig) -> List[ValidationError]:

--- a/src/vllm-sr/tests/test_algorithm_config.py
+++ b/src/vllm-sr/tests/test_algorithm_config.py
@@ -107,6 +107,9 @@ class TestRouterDCSelectionConfig:
         assert config.temperature == 0.07
         assert config.dimension_size == 768
         assert config.min_similarity == 0.3
+        assert config.use_query_contrastive is True
+        assert config.use_model_contrastive is True
+        assert config.use_capabilities is True
 
     def test_temperature_validation(self):
         """Test that temperature must be positive."""

--- a/src/vllm-sr/tests/test_hybrid_validator.py
+++ b/src/vllm-sr/tests/test_hybrid_validator.py
@@ -1,0 +1,121 @@
+import os
+import tempfile
+
+import yaml
+
+from cli.config_migration import migrate_config_data
+from cli.parser import parse_user_config
+from cli.validator import validate_user_config
+
+
+def _parse_config(config_yaml: str):
+    data = yaml.safe_load(config_yaml)
+    providers = data.get("providers") if isinstance(data, dict) else None
+    models = providers.get("models", []) if isinstance(providers, dict) else []
+    if isinstance(data, dict) and (
+        "signals" in data
+        or "decisions" in data
+        or any(isinstance(model, dict) and "endpoints" in model for model in models)
+    ):
+        data = migrate_config_data(data)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as handle:
+        yaml.safe_dump(data, handle, sort_keys=False)
+        temp_path = handle.name
+
+    try:
+        return parse_user_config(temp_path)
+    finally:
+        os.unlink(temp_path)
+
+
+def _hybrid_config_yaml(hybrid_block: str) -> str:
+    return f"""
+version: v0.1
+listeners:
+  - name: "http-8888"
+    address: "0.0.0.0"
+    port: 8888
+signals:
+  domains:
+    - name: "general"
+      description: "General domain"
+decisions:
+  - name: "hybrid_route"
+    description: "Hybrid route"
+    priority: 100
+    rules:
+      operator: "AND"
+      conditions:
+        - type: "domain"
+          name: "general"
+    modelRefs:
+      - model: "test_model"
+    algorithm:
+      type: "hybrid"
+      hybrid:
+{hybrid_block}
+providers:
+  models:
+    - name: "test_model"
+      endpoints:
+        - name: "ep1"
+          weight: 1
+          endpoint: "localhost:8000"
+  default_model: "test_model"
+"""
+
+
+def test_validate_user_config_rejects_all_zero_hybrid_weights():
+    config = _parse_config(
+        _hybrid_config_yaml(
+            "        elo_weight: 0\n        router_dc_weight: 0\n"
+            "        automix_weight: 0\n        cost_weight: 0"
+        )
+    )
+    errors = validate_user_config(config)
+
+    assert any("all zero" in e.message for e in errors)
+
+
+def test_validate_user_config_accepts_partial_hybrid_weights():
+    config_yaml = """
+version: v0.1
+listeners:
+  - name: "http-8888"
+    address: "0.0.0.0"
+    port: 8888
+signals:
+  domains:
+    - name: "general"
+      description: "General domain"
+decisions:
+  - name: "hybrid_route"
+    description: "Hybrid route"
+    priority: 100
+    rules:
+      operator: "AND"
+      conditions:
+        - type: "domain"
+          name: "general"
+    modelRefs:
+      - model: "test_model"
+    algorithm:
+      type: "hybrid"
+      hybrid:
+        elo_weight: 0.6
+        router_dc_weight: 0.4
+providers:
+  models:
+    - name: "test_model"
+      endpoints:
+        - name: "ep1"
+          weight: 1
+          endpoint: "localhost:8000"
+  default_model: "test_model"
+"""
+
+    config = _parse_config(config_yaml)
+    errors = validate_user_config(config)
+
+    assert errors == []

--- a/tools/linter/python/.ruff.toml
+++ b/tools/linter/python/.ruff.toml
@@ -101,6 +101,7 @@ max-nested-blocks = 4
 "src/vllm-sr/tests/*.py" = ["PLR2004"]
 "e2e/testing/anthropic-shim/tests/*.py" = ["PLR2004"]
 "src/vllm-sr/tests/test_config_template.py" = ["E402", "UP015"]
+"src/vllm-sr/tests/test_hybrid_validator.py" = ["I001"]
 "src/vllm-sr/tests/test_latency_validation.py" = ["I001"]
 "src/vllm-sr/tests/test_plugin_parsing.py" = ["I001", "RUF043"]
 "src/vllm-sr/tests/test_setup_bootstrap.py" = ["I001", "UP015"]


### PR DESCRIPTION
## Why
On `main` the `hybrid` model-selection method exists but is effectively
unreachable and misconfigured:

1. **Not reachable per decision** — `selectorForDecisionMethod` has no `hybrid`
   branch, so decision-level weights are silently ignored (only `session_aware`
   had its decision-scoped path).
2. **No canonical defaults** — `ModelSelection` has no defaults for
   `router_dc`/`hybrid`, so an out-of-the-box hybrid route runs with all-zero
   weights.
3. **Explicit `false` cannot round-trip** — selection bool flags use
   `,omitempty`, so an explicit `false` is indistinguishable from unset and is
   dropped on canonical export.
4. **CLI false positive** — the CLI rejects hybrid weights that don't sum to
   1.0, but the router normalizes them at runtime, so valid configs were
   rejected.

## Changes
- [Router] add `newDecisionHybridSelector`, mirroring the existing
  `session_aware` decision-scoped path; `buildHybridSelectionConfig` merges
  decision overrides onto the global config.
- [Router] seed `defaultCanonicalRouterGlobal` and the DSL compiler with
  documented `router_dc`/`hybrid` defaults.
- [Router] drop `,omitempty` on the affected selection bool flags so explicit
  `false` round-trips.
- [CLI] default `router_dc` contrastive/capability flags to `true`, matching
  the Go canonical defaults.
- [CLI] replace the hybrid weight-sum check with an all-zero guard (per-weight
  non-negativity is already enforced by pydantic `ge=0`).

Refs #1514

## Test Plan
- `make go-lint` → 0 issues
- `go test ./pkg/config/... ./pkg/dsl/... ./pkg/extproc/...` → pass
- vllm-sr `pytest tests/` → 330 passed
- New tests: explicit-false round-trip, default drift, decision-override merge,
  finite decision-scoped hybrid score, hybrid validator (partial accepted /
  all-zero rejected)