### PR TITLE
[Bindings] Fix CUDA execution provider on Auto path + bound embedding arenas

### DIFF
--- a/onnx-binding/src/model_architectures/classification/mmbert_classifier.rs
+++ b/onnx-binding/src/model_architectures/classification/mmbert_classifier.rs
@@ -167,7 +167,7 @@ impl MmBertClassifierConfig {
 /// Execution provider preference
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ClassifierExecutionProvider {
-    /// Automatic selection (ROCm > CUDA > OpenVINO > CPU)
+    /// Automatic selection (ROCm > CUDA > CPU; OpenVINO requires an explicit `OpenVino` request)
     Auto,
     /// Force CPU
     Cpu,
@@ -432,9 +432,11 @@ impl MmBertSequenceClassifier {
                     }
                 }
 
-                // Auto selection priority is ROCm > CUDA > OpenVINO > CPU. On a
-                // CUDA build the ROCm block above is compiled out, so Auto must
-                // also try CUDA here before falling back to CPU. Without this,
+                // Auto selection priority is ROCm > CUDA > CPU. OpenVINO is not
+                // part of the Auto chain; it is only used for an explicit
+                // `OpenVino` request. On a CUDA build the ROCm block above is
+                // compiled out, so Auto must also try CUDA here before falling
+                // back to CPU. Without this,
                 // Auto silently ran every classifier (PII, jailbreak, intent,
                 // factcheck) on CPU even on NVIDIA GPUs, because the dedicated
                 // CUDA arm below is only reached for an explicit `Cuda` request.

--- a/onnx-binding/src/model_architectures/classification/mmbert_classifier.rs
+++ b/onnx-binding/src/model_architectures/classification/mmbert_classifier.rs
@@ -432,6 +432,47 @@ impl MmBertSequenceClassifier {
                     }
                 }
 
+                // Auto selection priority is ROCm > CUDA > OpenVINO > CPU. On a
+                // CUDA build the ROCm block above is compiled out, so Auto must
+                // also try CUDA here before falling back to CPU. Without this,
+                // Auto silently ran every classifier (PII, jailbreak, intent,
+                // factcheck) on CPU even on NVIDIA GPUs, because the dedicated
+                // CUDA arm below is only reached for an explicit `Cuda` request.
+                // Gated to `Auto` so an explicit `Rocm` request on a CUDA build
+                // still falls through to CPU rather than silently using NVIDIA.
+                #[cfg(feature = "cuda")]
+                {
+                    if matches!(provider, ClassifierExecutionProvider::Auto) {
+                        use crate::core::gpu_memory;
+                        use ort::execution_providers::{
+                            ArenaExtendStrategy as CudaArenaStrategy, CUDAExecutionProvider,
+                        };
+                        let mem_limit = gpu_memory::get_gpu_mem_limit();
+                        match Session::builder()
+                            .map_err(|e: ort::Error| errors::ort_error(&e.to_string()))?
+                            .with_execution_providers([CUDAExecutionProvider::default()
+                                .with_memory_limit(mem_limit)
+                                .with_arena_extend_strategy(CudaArenaStrategy::SameAsRequested)
+                                .build()
+                                .error_on_failure()])
+                            .and_then(|b| b.commit_from_file(onnx_path.as_ref()))
+                        {
+                            Ok(session) => {
+                                println!(
+                                    "INFO: Using CUDA execution provider (NVIDIA GPU) — verified"
+                                );
+                                return Ok(session);
+                            }
+                            Err(e) => {
+                                println!(
+                                    "WARNING: CUDA EP failed: {}, falling back to CPU",
+                                    e
+                                );
+                            }
+                        }
+                    }
+                }
+
                 println!("INFO: Using CPU execution provider");
                 Session::builder()
                     .map_err(|e: ort::Error| errors::ort_error(&e.to_string()))?

--- a/onnx-binding/src/model_architectures/embedding/mmbert_embedding.rs
+++ b/onnx-binding/src/model_architectures/embedding/mmbert_embedding.rs
@@ -491,10 +491,23 @@ impl MmBertEmbeddingModel {
 
             #[cfg(feature = "cuda")]
             {
-                use ort::execution_providers::CUDAExecutionProvider;
+                use crate::core::gpu_memory;
+                use ort::execution_providers::{
+                    ArenaExtendStrategy as CudaArenaStrategy, CUDAExecutionProvider,
+                };
+                // Bound the per-session CUDA arena and request-sized arena
+                // growth, mirroring the classifier path. The 2D-Matryoshka
+                // embedding model opens one primary session plus one session
+                // per early-exit layer (3, 6, 11, 22), so without a memory
+                // limit each unbounded BFC arena tries to grab a large block
+                // up front and later sessions OOM (CUBLAS_STATUS_ALLOC_FAILED)
+                // on a shared/busy GPU, silently falling back to CPU.
+                let mem_limit = gpu_memory::get_gpu_mem_limit();
                 match Session::builder()
                     .map_err(|e: ort::Error| errors::ort_error(&e.to_string()))?
                     .with_execution_providers([CUDAExecutionProvider::default()
+                        .with_memory_limit(mem_limit)
+                        .with_arena_extend_strategy(CudaArenaStrategy::SameAsRequested)
                         .build()
                         .error_on_failure()])
                     .and_then(|b| b.commit_from_file(onnx_path.as_ref()))


### PR DESCRIPTION
## Purpose

- **What does this PR change?**
  Two related fixes in `onnx-binding` so that the existing `--platform nvidia` / CUDA build actually runs classification and embedding models on the GPU, instead of silently falling back to CPU.

  1. `mmbert_classifier.rs`: the `Rocm | Auto` provider arm only had a `#[cfg(feature = "rocm")]` GPU attempt. On a CUDA build the ROCm block is compiled out, so `Auto` fell straight through to the CPU fallback. The Go FFI maps `use_gpu=true` to `Auto` (see `src/ffi/classification.rs:168`), so every sequence/token classifier (PII, jailbreak, intent, factcheck) was running on CPU even when the operator explicitly requested GPU. Add a `#[cfg(feature = "cuda")]` CUDA attempt inside the `Auto` arm, gated so an explicit `Rocm` request on a CUDA build still falls through to CPU rather than silently using NVIDIA.

  2. `mmbert_embedding.rs`: `create_session`'s CUDA branch used a bare `CUDAExecutionProvider::default()` with no memory limit and no arena strategy, unlike the explicit-CUDA path in the classifier (`mmbert_classifier.rs:487-494`). The 2D-Matryoshka embedding model opens one primary session plus one per early-exit layer (3 / 6 / 11 / 22). With unbounded BFC arenas, later sessions OOM (`CUBLAS_STATUS_ALLOC_FAILED`) on a shared / busy GPU and silently fall back to CPU. Apply `with_memory_limit(get_gpu_mem_limit())` + `with_arena_extend_strategy(SameAsRequested)` to mirror the classifier path.

- **Why is this change needed?**
  The repository already supports `--platform nvidia` for GPU passthrough at the container level, but the router-side signal models (classifiers + embeddings) were silently running on CPU on NVIDIA GPUs because of these two `onnx-binding` defects. Without this fix, `--platform nvidia` provides container access to the GPU but no model actually uses it.

- **Which module(s) does this affect?** `Bindings`

## Test Plan

- Build verification (CPU-only and CUDA feature):

  ```bash
  cd onnx-binding
  cargo build --no-default-features
  cargo build --features cuda
  ```

- Unit tests on both feature configurations:

  ```bash
  cargo test --no-default-features --lib
  cargo test --features cuda --lib
  ```

- Repo agent gates on the changed files:

  ```bash
  make agent-lint    CHANGED_FILES="onnx-binding/src/model_architectures/classification/mmbert_classifier.rs onnx-binding/src/model_architectures/embedding/mmbert_embedding.rs"
  make agent-ci-gate CHANGED_FILES="onnx-binding/src/model_architectures/classification/mmbert_classifier.rs onnx-binding/src/model_architectures/embedding/mmbert_embedding.rs"
  ```

- Live GPU validation on RTX 4090 with `onnxruntime-gpu 1.22.0` and the `cuda` feature, checking router logs for the EP selection line emitted by `mmbert_classifier.rs` (`"Using CUDA execution provider (NVIDIA GPU) — verified"`).

- **Why is this validation sufficient for the affected module(s)?**
  - The change is gated by `#[cfg(feature = "cuda")]`, so the existing CPU / ROCm code paths are not affected — verified by running the full `--no-default-features` test suite.
  - The new CUDA arm matches the structure of the existing explicit-`Cuda` arm in the same file, so the same bounded-arena guarantees apply.
  - The behavioral claim ("`Auto` was falling back to CPU on CUDA builds") is verifiable by inspection: the existing `Rocm | Auto` block is gated only by `feature = "rocm"`, so on a CUDA-only build it compiles out and the `Auto` path drops to the CPU fallback.

## Test Result

- `cargo build --no-default-features`: **PASS**
- `cargo build --features cuda`: **PASS**
- `cargo test --no-default-features --lib`: **45 passed, 0 failed**
- `cargo test --features cuda --lib`: **45 passed, 0 failed**
- `cargo clippy` on the two changed files: **0 warnings** (pre-existing crate-wide clippy debt is unchanged)
- `make agent-lint  CHANGED_FILES=...`: **exit 0**
- `make agent-ci-gate CHANGED_FILES=...`: **exit 0**
- Live NVIDIA validation (RTX 4090, `onnxruntime-gpu 1.22.0`):
  - Before this PR: jailbreak / PII / intent classifiers and embedding layer-22 ran on CPU
  - After this PR: all classifiers and all four embedding layers (3 / 6 / 11 / 22) select the CUDA EP and log `"Using CUDA execution provider (NVIDIA GPU) — verified"`
  - Any residual CPU fallback now happens only under genuine VRAM exhaustion (e.g. shared GPU with < 1 GB free), and the bounded arena degrades gracefully instead of failing hard. `ORT_GPU_MEM_LIMIT` can be used to tune the per-session arena size on contended GPUs.

- **Any follow-up risks, gaps, or blockers?**
  - No behavior change for CPU-only builds (the new code compiles out without `feature = "cuda"`).
  - No behavior change for ROCm builds (the new arm is gated to `Auto`, so explicit `Rocm` still falls through to CPU on CUDA builds as before).
  - Follow-up PRs (separate, not part of this one) will add a CUDA Dockerfile mirroring the ROCm variant, and a deployment doc for the NVIDIA local flow.

cc @Xunzhuo — first of the NVIDIA upstream-compatible PR stack.

