### PR TITLE
[Router] v0.4 headers: add x-vsr-schema-version + x-vsr-response-path keystone

### DIFF
--- a/dashboard/frontend/src/components/HeaderDisplay.tsx
+++ b/dashboard/frontend/src/components/HeaderDisplay.tsx
@@ -5,7 +5,19 @@ interface HeaderDisplayProps {
 }
 
 // Header metadata for display
-const HEADER_INFO: Record<string, { label: string; type: 'info' | 'success' | 'warning' | 'danger' }> = {
+const HEADER_INFO: Record<
+  string,
+  { label: string; type: 'info' | 'success' | 'warning' | 'danger' }
+> = {
+  // v0.4 keystone headers (#2203)
+  'x-vsr-schema-version': {
+    label: 'Schema Version',
+    type: 'info',
+  },
+  'x-vsr-response-path': {
+    label: 'Response Path',
+    type: 'info',
+  },
   'x-vsr-selected-model': {
     label: 'Model',
     type: 'info',
@@ -163,13 +175,15 @@ const HEADER_INFO: Record<string, { label: string; type: 'info' | 'success' | 'w
 }
 
 function shouldSummarizeHeaderValue(key: string, values: string[]): boolean {
-  return values.length > 1 && (key.startsWith('x-vsr-matched-') || key === 'x-vsr-looper-models-used')
+  return (
+    values.length > 1 && (key.startsWith('x-vsr-matched-') || key === 'x-vsr-looper-models-used')
+  )
 }
 
 function summarizeHeaderValue(key: string, rawValue: string): string {
   const values = rawValue
     .split(',')
-    .map(value => value.trim())
+    .map((value) => value.trim())
     .filter(Boolean)
 
   if (!shouldSummarizeHeaderValue(key, values)) {
@@ -194,7 +208,11 @@ const HeaderDisplay = ({ headers }: HeaderDisplayProps) => {
           const info = HEADER_INFO[key]
           const displayValue = summarizeHeaderValue(key, value)
           return (
-            <div key={key} className={`${styles.header} ${styles[info.type]}`} title={`${info.label}: ${value}`}>
+            <div
+              key={key}
+              className={`${styles.header} ${styles[info.type]}`}
+              title={`${info.label}: ${value}`}
+            >
               <span className={styles.label}>{info.label}</span>
               <span className={styles.value}>{displayValue}</span>
             </div>

--- a/dashboard/frontend/src/components/HeaderReveal.tsx
+++ b/dashboard/frontend/src/components/HeaderReveal.tsx
@@ -9,6 +9,15 @@ interface HeaderRevealProps {
 
 // Header metadata for display
 const HEADER_INFO: Record<string, { label: string; description: string }> = {
+  // Response contract (v0.4 keystone) headers (#2203)
+  'x-vsr-schema-version': {
+    label: 'Schema Version',
+    description: 'Response header contract revision',
+  },
+  'x-vsr-response-path': {
+    label: 'Response Path',
+    description: 'How the response was produced (upstream, cache, fast_response, looper, ...)',
+  },
   // Signal headers
   'x-vsr-matched-keywords': {
     label: 'Keywords',
@@ -189,6 +198,10 @@ const HeaderReveal = ({ headers, onComplete, displayDuration = 2000 }: HeaderRev
 
   // Group headers by category based on the comments in HEADER_INFO
   const groupedHeaders = {
+    // Response contract (keystone) headers: schema-version + response-path
+    response: displayHeaders.filter(
+      ([key]) => key === 'x-vsr-schema-version' || key === 'x-vsr-response-path',
+    ),
     // Signal headers: all x-vsr-matched-*
     signals: displayHeaders.filter(([key]) => key.startsWith('x-vsr-matched-')),
     // Decision headers: selected-decision
@@ -243,6 +256,7 @@ const HeaderReveal = ({ headers, onComplete, displayDuration = 2000 }: HeaderRev
       <div className={styles.container}>
         <div className={styles.title}>Signal Driven Decision</div>
         <div className={styles.sections}>
+          {renderSection('RESPONSE', groupedHeaders.response, true)}
           {renderSection('MODEL', groupedHeaders.model, true)}
           {renderSection('DECISION', groupedHeaders.decision, true)}
           {renderSection('SIGNALS', groupedHeaders.signals)}

--- a/dashboard/frontend/src/components/chatRequestSupport.ts
+++ b/dashboard/frontend/src/components/chatRequestSupport.ts
@@ -16,6 +16,9 @@ export interface OutboundChatMessage {
 }
 
 const RESPONSE_HEADER_KEYS = [
+  // v0.4 keystone headers (#2203)
+  'x-vsr-schema-version',
+  'x-vsr-response-path',
   'x-vsr-selected-model',
   'x-vsr-selected-decision',
   'x-vsr-selected-modality',
@@ -60,7 +63,7 @@ export const buildChatMessages = (
   messages: Message[],
   nextUserMessage: string,
   enableClawMode: boolean,
-  nextUserAttachments: PlaygroundAttachment[] = []
+  nextUserAttachments: PlaygroundAttachment[] = [],
 ): OutboundChatMessage[] => {
   const chatMessages: OutboundChatMessage[] = []
 
@@ -68,10 +71,7 @@ export const buildChatMessages = (
     if (message.role === 'user') {
       chatMessages.push({
         role: 'user',
-        content: buildPromptWithAttachments(
-          message.content,
-          message.playgroundAttachments ?? []
-        ),
+        content: buildPromptWithAttachments(message.content, message.playgroundAttachments ?? []),
       })
       continue
     }
@@ -95,7 +95,7 @@ export const buildChatMessages = (
 export const buildChatRequestBody = (
   model: string,
   messages: OutboundChatMessage[],
-  activeTools: unknown[]
+  activeTools: unknown[],
 ): Record<string, unknown> => {
   const requestBody: Record<string, unknown> = {
     model,

--- a/src/semantic-router/pkg/extproc/extproc_test.go
+++ b/src/semantic-router/pkg/extproc/extproc_test.go
@@ -2207,11 +2207,12 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 	assert.NotNil(t, headerMutation, "HeaderMutation should not be nil for successful non-cached response")
 
 	setHeaders := headerMutation.GetSetHeaders()
+	// 2 keystone headers (x-vsr-schema-version + x-vsr-response-path, #2203) +
 	// 4 standard decision headers + x-vsr-inbound-protocol +
 	// x-vsr-outbound-protocol (translation-cell markers added by the
 	// Anthropic ingress series; emitted on every non-cache-hit response
 	// so operators can identify the cell that handled the request).
-	assert.Len(t, setHeaders, 6, "Should have 6 VSR headers")
+	assert.Len(t, setHeaders, 8, "Should have 8 VSR headers (2 keystone + 4 decision + 2 protocol)")
 
 	// Verify each header
 	headerMap := make(map[string]string)
@@ -2219,6 +2220,8 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 		headerMap[header.Header.Key] = string(header.Header.RawValue)
 	}
 
+	assert.Equal(t, "2", headerMap["x-vsr-schema-version"])
+	assert.Equal(t, "upstream", headerMap["x-vsr-response-path"])
 	assert.Equal(t, "math", headerMap["x-vsr-selected-category"])
 	assert.Equal(t, "on", headerMap["x-vsr-selected-reasoning"])
 	assert.Equal(t, "deepseek-v31", headerMap["x-vsr-selected-model"])
@@ -2294,19 +2297,24 @@ func TestVSRHeadersNotAddedOnErrorResponse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 
-	// Decision/signal headers are NOT added on error responses, but the
-	// translation-cell protocol markers (x-vsr-inbound-protocol and
-	// x-vsr-outbound-protocol) ride on every non-cache-hit response —
-	// success or error — so operators can identify which translation
-	// cell handled a failed request. See processor_res_header_mutation.go.
+	// Decision/signal headers are NOT added on error responses, but the v0.4
+	// keystone headers (x-vsr-schema-version + x-vsr-response-path) and the
+	// translation-cell protocol markers (x-vsr-inbound-protocol,
+	// x-vsr-outbound-protocol) ride on every non-cache-hit response — success
+	// or error — so operators can identify the contract version, the response
+	// path, and which translation cell handled a failed request. The error
+	// here is an upstream-returned 500, so response-path is "upstream".
+	// See processor_res_header_mutation.go (issue #2203).
 	headerMutation := response.GetResponseHeaders().GetResponse().GetHeaderMutation()
-	require.NotNil(t, headerMutation, "HeaderMutation should carry protocol markers even on error")
+	require.NotNil(t, headerMutation, "HeaderMutation should carry keystone + protocol markers even on error")
 	setHeaders := headerMutation.GetSetHeaders()
-	assert.Len(t, setHeaders, 2, "Error response should have only the 2 protocol-marker headers")
+	assert.Len(t, setHeaders, 4, "Error response should have the 2 keystone + 2 protocol-marker headers")
 	headerMap := make(map[string]string)
 	for _, header := range setHeaders {
 		headerMap[header.Header.Key] = string(header.Header.RawValue)
 	}
+	assert.Equal(t, "2", headerMap["x-vsr-schema-version"])
+	assert.Equal(t, "upstream", headerMap["x-vsr-response-path"])
 	assert.Equal(t, "openai", headerMap["x-vsr-inbound-protocol"])
 	assert.Equal(t, "openai", headerMap["x-vsr-outbound-protocol"])
 	assert.NotContains(t, headerMap, "x-vsr-selected-category", "decision headers must not appear on error")
@@ -2350,10 +2358,11 @@ func TestVSRHeadersPartialInformation(t *testing.T) {
 	assert.NotNil(t, headerMutation)
 
 	setHeaders := headerMutation.GetSetHeaders()
+	// 2 keystone headers (x-vsr-schema-version + x-vsr-response-path, #2203) +
 	// 3 standard decision headers (excluding empty reasoning mode, but
 	// including injected-system-prompt) + 2 translation-cell protocol
 	// markers (x-vsr-inbound-protocol + x-vsr-outbound-protocol).
-	assert.Len(t, setHeaders, 5, "Should have 5 VSR headers")
+	assert.Len(t, setHeaders, 7, "Should have 7 VSR headers (2 keystone + 3 decision + 2 protocol)")
 
 	// Verify each header
 	headerMap := make(map[string]string)
@@ -2361,6 +2370,8 @@ func TestVSRHeadersPartialInformation(t *testing.T) {
 		headerMap[header.Header.Key] = string(header.Header.RawValue)
 	}
 
+	assert.Equal(t, "2", headerMap["x-vsr-schema-version"])
+	assert.Equal(t, "upstream", headerMap["x-vsr-response-path"])
 	assert.Equal(t, "math", headerMap["x-vsr-selected-category"])
 	assert.Equal(t, "deepseek-v31", headerMap["x-vsr-selected-model"])
 	assert.Equal(t, "false", headerMap["x-vsr-injected-system-prompt"])

--- a/src/semantic-router/pkg/extproc/processor_req_body_memory.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_memory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openai/openai-go"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
@@ -290,6 +291,9 @@ func (r *OpenAIRouter) createRateLimitResponse(decision *ratelimit.Decision) *ex
 			}})
 		}
 	}
+
+	// v0.4 keystone headers: this is the rate-limit path (#2203).
+	respHeaders = append(respHeaders, httputil.KeystoneHeaderOptions(headers.ResponsePathRateLimited)...)
 
 	return &ext_proc.ProcessingResponse{
 		Response: &ext_proc.ProcessingResponse_ImmediateResponse{

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -58,6 +58,21 @@ func (builder *responseHeaderMutationBuilder) addBool(key string, value bool) {
 	builder.addString(key, strconv.FormatBool(value))
 }
 
+// addKeystone emits the v0.4 keystone headers that ride on every
+// VSR-processed response: x-vsr-schema-version stamps the contract revision
+// and x-vsr-response-path names how the response was produced. The path
+// defaults to "upstream" when the caller has not classified a more specific
+// path (cache, fast_response, looper, rate_limited, error, image_generation).
+// See issue #2203.
+func (builder *responseHeaderMutationBuilder) addKeystone(ctx *RequestContext) {
+	path := ctx.ResponsePath
+	if path == "" {
+		path = headers.ResponsePathUpstream
+	}
+	builder.addString(headers.VSRSchemaVersion, headers.SchemaVersionValue)
+	builder.addString(headers.VSRResponsePath, path)
+}
+
 func (builder *responseHeaderMutationBuilder) addFloat(key string, value float64) {
 	if value <= 0 {
 		return
@@ -235,6 +250,11 @@ func buildResponseHeaderMutation(
 	// new headers entirely on cache hits and let the cached payload
 	// flow unchanged.
 	if !ctx.VSRCacheHit {
+		// Keystone headers ride on every non-cache-hit response (success or
+		// 4xx/5xx). Cache hits emit their own response-path: cache from the
+		// cache immediate-response builder. This function only handles upstream
+		// responses, so the path defaults to "upstream".
+		builder.addKeystone(ctx)
 		builder.addString(headers.VSRInboundProtocol, normalizeProtocol(ctx.ClientProtocol))
 		builder.addString(headers.VSROutboundProtocol, normalizeProtocol(ctx.APIFormat))
 		if ctx.IRExtensions != nil {

--- a/src/semantic-router/pkg/extproc/req_filter_looper_response.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_response.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
 )
 
 // createLooperResponse creates an ImmediateResponse from looper output.
@@ -37,6 +38,8 @@ func buildLooperResponseHeaders(
 	setHeaders := baseLooperResponseHeaders(resp)
 	appendLooperSignalHeaders(&setHeaders, reqCtx)
 	appendLooperRoutingHeaders(&setHeaders, resp, reqCtx)
+	// v0.4 keystone headers: this is the looper path (#2203).
+	setHeaders = append(setHeaders, httputil.KeystoneHeaderOptions(headers.ResponsePathLooper)...)
 	return setHeaders
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_modality.go
+++ b/src/semantic-router/pkg/extproc/req_filter_modality.go
@@ -661,7 +661,8 @@ func (r *OpenAIRouter) buildBothResponse(textResp map[string]interface{}, imgRes
 // buildImmediateResponseWithModality creates a JSON immediate response and adds
 // the x-vsr-selected-modality header.
 func (r *OpenAIRouter) buildImmediateResponseWithModality(statusCode int, body []byte, result ModalityClassificationResult) *ext_proc.ProcessingResponse {
-	procResp := r.createJSONResponseWithBody(statusCode, body)
+	// All callers are the diffusion/image-generation modality path (#2203).
+	procResp := r.createJSONResponseWithBody(statusCode, body, headers.ResponsePathImageGeneration)
 
 	modalityValue := result.Modality
 	if result.Method != "" {

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -120,6 +120,13 @@ type RequestContext struct {
 	VSRInjectedSystemPrompt       bool                   // Whether a system prompt was injected into the request
 	VSRSelectedDecision           *config.Decision       // The decision object selected by DecisionEngine (for plugins)
 
+	// ResponsePath records how the final response was produced, surfaced as the
+	// v0.4 keystone x-vsr-response-path header (one of the headers.ResponsePath*
+	// values). It defaults to "upstream"; immediate-response paths (cache,
+	// fast_response, looper, rate-limit, error, image generation) set it
+	// explicitly so the emitted path is accurate. See issue #2203.
+	ResponsePath string
+
 	// Modality routing classification result (AR/DIFFUSION/BOTH)
 	ModalityClassification *ModalityClassificationResult // Set by classifyModality()
 

--- a/src/semantic-router/pkg/extproc/router.go
+++ b/src/semantic-router/pkg/extproc/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ratelimit"
@@ -21,6 +22,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/selection/lookuptable"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/services"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
 )
 
 // OpenAIRouter is an Envoy ExtProc server that routes OpenAI API requests.
@@ -77,8 +79,24 @@ var _ ext_proc.ExternalProcessorServer = (*OpenAIRouter)(nil)
 
 const routerReplayAPIBasePath = "/v1/router_replay"
 
-// createJSONResponseWithBody creates a direct response with pre-marshaled JSON body.
-func (r *OpenAIRouter) createJSONResponseWithBody(statusCode int, jsonBody []byte) *ext_proc.ProcessingResponse {
+// createJSONResponseWithBody creates a direct response with pre-marshaled JSON
+// body. When responsePath is non-empty, the v0.4 keystone headers
+// (x-vsr-schema-version + x-vsr-response-path) are emitted for that path; pass
+// "" for router-management responses (e.g. /v1/models) that are not routed LLM
+// responses and therefore carry no response-path. See issue #2203.
+func (r *OpenAIRouter) createJSONResponseWithBody(statusCode int, jsonBody []byte, responsePath string) *ext_proc.ProcessingResponse {
+	setHeaders := []*core.HeaderValueOption{
+		{
+			Header: &core.HeaderValue{
+				Key:      "content-type",
+				RawValue: []byte("application/json"),
+			},
+		},
+	}
+	if responsePath != "" {
+		setHeaders = append(setHeaders, httputil.KeystoneHeaderOptions(responsePath)...)
+	}
+
 	return &ext_proc.ProcessingResponse{
 		Response: &ext_proc.ProcessingResponse_ImmediateResponse{
 			ImmediateResponse: &ext_proc.ImmediateResponse{
@@ -86,14 +104,7 @@ func (r *OpenAIRouter) createJSONResponseWithBody(statusCode int, jsonBody []byt
 					Code: statusCodeToImmediateResponseCode(statusCode),
 				},
 				Headers: &ext_proc.HeaderMutation{
-					SetHeaders: []*core.HeaderValueOption{
-						{
-							Header: &core.HeaderValue{
-								Key:      "content-type",
-								RawValue: []byte("application/json"),
-							},
-						},
-					},
+					SetHeaders: setHeaders,
 				},
 				Body: jsonBody,
 			},
@@ -109,7 +120,9 @@ func (r *OpenAIRouter) createJSONResponse(statusCode int, data interface{}) *ext
 		return r.createErrorResponse(500, "Internal server error")
 	}
 
-	return r.createJSONResponseWithBody(statusCode, jsonData)
+	// Router-management JSON responses (model lists, classify/route APIs, etc.)
+	// are not routed LLM responses, so they carry no response-path.
+	return r.createJSONResponseWithBody(statusCode, jsonData, "")
 }
 
 // createErrorResponse creates a direct error response.
@@ -129,7 +142,7 @@ func (r *OpenAIRouter) createErrorResponse(statusCode int, message string) *ext_
 		statusCode = 500
 	}
 
-	return r.createJSONResponseWithBody(statusCode, jsonData)
+	return r.createJSONResponseWithBody(statusCode, jsonData, headers.ResponsePathError)
 }
 
 // shouldClearRouteCache checks if route cache should be cleared.

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -86,6 +86,34 @@ const (
 	// Values: "true" or "false"
 	VSRInjectedSystemPrompt = "x-vsr-injected-system-prompt"
 
+	// --- v0.4 keystone response-contract headers (issue #2203) ---
+	// These two headers are emitted on every VSR-processed response and form
+	// the foundation of the v0.4 header contract: schema-version stamps the
+	// contract revision and response-path names how the response was produced.
+	// Everything else in the contract keys off response-path.
+
+	// VSRSchemaVersion stamps the response-header contract revision so clients
+	// know which contract they are parsing. Value: SchemaVersionValue.
+	VSRSchemaVersion = "x-vsr-schema-version"
+
+	// VSRResponsePath names the final path that produced the response.
+	// Value is one of the ResponsePath* constants below.
+	VSRResponsePath = "x-vsr-response-path"
+
+	// ResponsePath* are the valid values for VSRResponsePath.
+	ResponsePathUpstream        = "upstream"         // forwarded to and answered by the upstream model
+	ResponsePathCache           = "cache"            // served from semantic cache, no upstream call
+	ResponsePathFastResponse    = "fast_response"    // short-circuited by the fast_response plugin
+	ResponsePathLooper          = "looper"           // produced by the agent looper
+	ResponsePathImageGeneration = "image_generation" // produced by the image-generation path
+	ResponsePathBlocked         = "blocked"          // rejected by a guardrail (e.g. jailbreak/PII)
+	ResponsePathRateLimited     = "rate_limited"     // rejected by rate limiting
+	ResponsePathError           = "error"            // router-side error response
+
+	// SchemaVersionValue is the current response-header contract revision
+	// emitted in VSRSchemaVersion. v0.4 is contract revision "2".
+	SchemaVersionValue = "2"
+
 	// VSRCacheHit indicates that the response was served from cache.
 	// Value: "true"
 	VSRCacheHit = "x-vsr-cache-hit"

--- a/src/semantic-router/pkg/utils/http/keystone_test.go
+++ b/src/semantic-router/pkg/utils/http/keystone_test.go
@@ -1,0 +1,71 @@
+package http
+
+import (
+	"encoding/json"
+	"testing"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/openai/openai-go"
+)
+
+// headerValueByKey returns the value of the first SetHeader matching key, or "".
+func headerValueByKey(opts []*core.HeaderValueOption, key string) string {
+	for _, h := range opts {
+		if h.Header.Key == key {
+			return string(h.Header.RawValue)
+		}
+	}
+	return ""
+}
+
+// TestKeystoneHeaderOptions pins the wire contract of the shared keystone
+// builder: exactly two options, schema-version "2", and the given response path.
+func TestKeystoneHeaderOptions(t *testing.T) {
+	opts := KeystoneHeaderOptions("cache")
+	if len(opts) != 2 {
+		t.Fatalf("expected 2 keystone options, got %d", len(opts))
+	}
+	if v := headerValueByKey(opts, "x-vsr-schema-version"); v != "2" {
+		t.Errorf("schema-version: expected \"2\", got %q", v)
+	}
+	if v := headerValueByKey(opts, "x-vsr-response-path"); v != "cache" {
+		t.Errorf("response-path: expected \"cache\", got %q", v)
+	}
+}
+
+// TestCacheHitResponseEmitsKeystone verifies the cache immediate response
+// carries schema-version "2" and response-path "cache".
+func TestCacheHitResponseEmitsKeystone(t *testing.T) {
+	completion := openai.ChatCompletion{
+		ID:     "chatcmpl-keystone-cache",
+		Object: "chat.completion",
+		Model:  "test-model",
+		Choices: []openai.ChatCompletionChoice{
+			{Message: openai.ChatCompletionMessage{Role: "assistant", Content: "hi"}, FinishReason: "stop"},
+		},
+	}
+	body, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("Failed to marshal cached response: %v", err)
+	}
+
+	set := CreateCacheHitResponse(body, false, "math", "math_decision", nil).GetImmediateResponse().Headers.SetHeaders
+	if v := headerValueByKey(set, "x-vsr-schema-version"); v != "2" {
+		t.Errorf("cache schema-version: expected \"2\", got %q", v)
+	}
+	if v := headerValueByKey(set, "x-vsr-response-path"); v != "cache" {
+		t.Errorf("cache response-path: expected \"cache\", got %q", v)
+	}
+}
+
+// TestFastResponseEmitsKeystone verifies the fast_response immediate response
+// carries schema-version "2" and response-path "fast_response".
+func TestFastResponseEmitsKeystone(t *testing.T) {
+	set := CreateFastResponse("blocked message", false, "guard_decision").GetImmediateResponse().Headers.SetHeaders
+	if v := headerValueByKey(set, "x-vsr-schema-version"); v != "2" {
+		t.Errorf("fast schema-version: expected \"2\", got %q", v)
+	}
+	if v := headerValueByKey(set, "x-vsr-response-path"); v != "fast_response" {
+		t.Errorf("fast response-path: expected \"fast_response\", got %q", v)
+	}
+}

--- a/src/semantic-router/pkg/utils/http/response.go
+++ b/src/semantic-router/pkg/utils/http/response.go
@@ -203,10 +203,10 @@ func buildNonStreamingCacheBody(cachedResponse []byte) []byte {
 	return marshaledBody
 }
 
-// keystoneHeaderOptions returns the v0.4 keystone header options
+// KeystoneHeaderOptions returns the v0.4 keystone header options
 // (x-vsr-schema-version + x-vsr-response-path) for an immediate response on the
 // given response path. See issue #2203.
-func keystoneHeaderOptions(path string) []*core.HeaderValueOption {
+func KeystoneHeaderOptions(path string) []*core.HeaderValueOption {
 	return []*core.HeaderValueOption{
 		{Header: &core.HeaderValue{Key: headers.VSRSchemaVersion, RawValue: []byte(headers.SchemaVersionValue)}},
 		{Header: &core.HeaderValue{Key: headers.VSRResponsePath, RawValue: []byte(path)}},
@@ -279,7 +279,7 @@ func CreateCacheHitResponse(cachedResponse []byte, isStreaming bool, category st
 	}
 
 	// v0.4 keystone headers: this is the semantic-cache path (#2203).
-	setHeaders = append(setHeaders, keystoneHeaderOptions(headers.ResponsePathCache)...)
+	setHeaders = append(setHeaders, KeystoneHeaderOptions(headers.ResponsePathCache)...)
 
 	immediateResponse := &ext_proc.ImmediateResponse{
 		Status: &typev3.HttpStatus{
@@ -426,7 +426,7 @@ func CreateFastResponse(message string, isStreaming bool, decisionName string) *
 	}
 
 	// v0.4 keystone headers: this is the fast_response plugin path (#2203).
-	setHeaders = append(setHeaders, keystoneHeaderOptions(headers.ResponsePathFastResponse)...)
+	setHeaders = append(setHeaders, KeystoneHeaderOptions(headers.ResponsePathFastResponse)...)
 
 	immediateResponse := &ext_proc.ImmediateResponse{
 		Status: &typev3.HttpStatus{

--- a/src/semantic-router/pkg/utils/http/response.go
+++ b/src/semantic-router/pkg/utils/http/response.go
@@ -203,6 +203,16 @@ func buildNonStreamingCacheBody(cachedResponse []byte) []byte {
 	return marshaledBody
 }
 
+// keystoneHeaderOptions returns the v0.4 keystone header options
+// (x-vsr-schema-version + x-vsr-response-path) for an immediate response on the
+// given response path. See issue #2203.
+func keystoneHeaderOptions(path string) []*core.HeaderValueOption {
+	return []*core.HeaderValueOption{
+		{Header: &core.HeaderValue{Key: headers.VSRSchemaVersion, RawValue: []byte(headers.SchemaVersionValue)}},
+		{Header: &core.HeaderValue{Key: headers.VSRResponsePath, RawValue: []byte(path)}},
+	}
+}
+
 // CreateCacheHitResponse creates an immediate response from cache
 func CreateCacheHitResponse(cachedResponse []byte, isStreaming bool, category string, decisionName string, matchedKeywords []string, similarity ...float32) *ext_proc.ProcessingResponse {
 	var responseBody []byte
@@ -267,6 +277,9 @@ func CreateCacheHitResponse(cachedResponse []byte, isStreaming bool, category st
 			},
 		})
 	}
+
+	// v0.4 keystone headers: this is the semantic-cache path (#2203).
+	setHeaders = append(setHeaders, keystoneHeaderOptions(headers.ResponsePathCache)...)
 
 	immediateResponse := &ext_proc.ImmediateResponse{
 		Status: &typev3.HttpStatus{
@@ -411,6 +424,9 @@ func CreateFastResponse(message string, isStreaming bool, decisionName string) *
 			},
 		},
 	}
+
+	// v0.4 keystone headers: this is the fast_response plugin path (#2203).
+	setHeaders = append(setHeaders, keystoneHeaderOptions(headers.ResponsePathFastResponse)...)
 
 	immediateResponse := &ext_proc.ImmediateResponse{
 		Status: &typev3.HttpStatus{


### PR DESCRIPTION
## Summary

Closes #2203. Part of #2200 — v0.4 VSR response header contract redesign.

Adds the two **keystone** headers the rest of the v0.4 contract keys off, emitted on every VSR-processed response:

- `x-vsr-schema-version` — stamps the contract revision (value `2`)
- `x-vsr-response-path` — names how the response was produced: `upstream` / `cache` / `fast_response` / `looper` / `image_generation` / `blocked` / `rate_limited` / `error`

This slice is purely **additive** — it does not remove or rename any existing header. (Demotions/renames/merges land in #2205 / #2206 / #2204, which depend on this keystone existing.)

## What changed

- [x] Keystone constants (header names, schema value `2`, the 8 `ResponsePath*` values) — `pkg/headers/headers.go`
- [x] `RequestContext.ResponsePath` + `addKeystone` builder helper, wired the **upstream** path (`buildResponseHeaderMutation`); also rides on upstream 4xx/5xx
- [x] Exported `utils/http.KeystoneHeaderOptions` as the single shared `[]HeaderValueOption` builder, wired **cache** + **fast_response**
- [x] Wired **looper**, **rate_limited** (429), **error** (`createJSONResponseWithBody` gained a `responsePath` arg; management JSON e.g. `/v1/models` passes `""`), **image_generation** (`buildImmediateResponseWithModality`)
- [x] Unit tests: `KeystoneHeaderOptions` + cache/fast keystone (utils/http); updated the three existing extproc header-count tests to assert keystone
- [x] Dashboard allowlists: `chatRequestSupport`, `HeaderDisplay`, `HeaderReveal` (new primary `RESPONSE` group)

## Design notes

- Each response path sets its path **explicitly** (via the shared helper / `ResponsePath`), rather than inferring from HTTP status — status alone cannot distinguish `blocked` / `rate_limited` / `error`.
- One contract source of truth: the keystone constants live only in `pkg/headers`; emission goes through one builder per shape (`addKeystone` for the mutation builder, `KeystoneHeaderOptions` for `[]HeaderValueOption` sites).
- `blocked` has no dedicated producer today (jailbreak/PII rejections ride the `fast_response` path), so its value is reserved for a future distinct block path.

## Test plan

- [x] `go build` + `go vet` — `pkg/extproc`, `pkg/utils/http`
- [x] `go test ./pkg/utils/http/` (incl. new keystone tests) — pass
- [x] targeted `go test ./pkg/extproc/ -run 'VSRHeader|...'` — pass
- [x] `gofmt` clean; rebased on latest `main`
- [ ] CI full gate (Dashboard Lint + Type Check, test-and-build, e2e)
