### PR TITLE
[Router] Grounding-aware synthesis for Fusion (faithfulness-scored panel)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -806,6 +806,16 @@ routing:
           analysis_template: ""
           synthesis_template: ""
           judge_prompt_version: fusion-v1
+          # Grounding-aware synthesis: score panel responses for faithfulness
+          # (hallucination detector against context, else cross-model NLI) and
+          # rank/filter them before the judge. Disabled by default.
+          grounding:
+            enabled: false
+            reference: hybrid          # hybrid | context | panel
+            min_score: 0.0             # drop responses scoring below this (0-1)
+            min_keep: 1                # always keep at least this many
+            nli_contradiction_penalty: 1.0
+            on_error: skip             # skip (fall back to plain fusion) | fail
 
     - name: terse_elo_route
       description: Personalized terse-answer route using Elo selection.

--- a/src/semantic-router/pkg/classification/classifier_fact_hallucination_lifecycle.go
+++ b/src/semantic-router/pkg/classification/classifier_fact_hallucination_lifecycle.go
@@ -3,6 +3,8 @@ package classification
 import (
 	"fmt"
 
+	candle "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
@@ -52,7 +54,31 @@ func (c *Classifier) initializeHallucinationDetector() error {
 
 	c.initializeHallucinationNLI(detector)
 	c.hallucinationDetector = detector
+	wireFusionGroundingBackends(detector)
 	return nil
+}
+
+// wireFusionGroundingBackends injects the candle-backed NLI + hallucination
+// detection functions into the looper package so grounding-aware fusion can score
+// panel responses. This keeps the candle/CGO dependency out of the looper import
+// graph (the looper package stays hermetically testable).
+func wireFusionGroundingBackends(detector *HallucinationDetector) {
+	looper.SetGroundingBackends(
+		func(premise, hypothesis string) (float32, float32, error) {
+			r, err := candle.ClassifyNLI(premise, hypothesis)
+			if err != nil {
+				return 0, 0, err
+			}
+			return r.EntailmentProb, r.ContradictProb, nil
+		},
+		func(context, question, answer string) ([]string, float32, error) {
+			r, err := detector.Detect(context, question, answer)
+			if err != nil {
+				return nil, 0, err
+			}
+			return r.UnsupportedSpans, r.Confidence, nil
+		},
+	)
 }
 
 func (c *Classifier) initializeHallucinationNLI(detector *HallucinationDetector) {

--- a/src/semantic-router/pkg/config/fusion_config.go
+++ b/src/semantic-router/pkg/config/fusion_config.go
@@ -11,23 +11,42 @@ const (
 	DefaultFusionJudgePromptVersion = "fusion-v1"
 	FusionOnErrorSkip               = "skip"
 	FusionOnErrorFail               = "fail"
+
+	// Grounding reference modes select what panel responses are scored against.
+	FusionGroundingReferenceHybrid  = "hybrid"  // detector against context if present, else cross-model NLI
+	FusionGroundingReferenceContext = "context" // detector against provided RAG/tool context only
+	FusionGroundingReferencePanel   = "panel"   // cross-model NLI only (panel as its own reference)
 )
 
 // FusionAlgorithmConfig configures Fusion-style panel execution for
 // decision.algorithm.type=fusion. Model is the judge/calling model; analysis
 // models come from analysis_models when set, otherwise from decision.modelRefs.
 type FusionAlgorithmConfig struct {
-	Model                        string   `yaml:"model,omitempty" json:"model,omitempty"`
-	AnalysisModels               []string `yaml:"analysis_models,omitempty" json:"analysis_models,omitempty"`
-	MaxConcurrent                int      `yaml:"max_concurrent,omitempty" json:"max_concurrent,omitempty"`
-	MaxCompletionTokens          int      `yaml:"max_completion_tokens,omitempty" json:"max_completion_tokens,omitempty"`
-	Temperature                  *float64 `yaml:"temperature,omitempty" json:"temperature,omitempty"`
-	IncludeAnalysis              *bool    `yaml:"include_analysis,omitempty" json:"include_analysis,omitempty"`
-	OnError                      string   `yaml:"on_error,omitempty" json:"on_error,omitempty"`
-	AnalysisTemplate             string   `yaml:"analysis_template,omitempty" json:"analysis_template,omitempty"`
-	SynthesisTemplate            string   `yaml:"synthesis_template,omitempty" json:"synthesis_template,omitempty"`
-	JudgePromptVersion           string   `yaml:"judge_prompt_version,omitempty" json:"judge_prompt_version,omitempty"`
-	IncludeIntermediateResponses *bool    `yaml:"include_intermediate_responses,omitempty" json:"include_intermediate_responses,omitempty"`
+	Model                        string                 `yaml:"model,omitempty" json:"model,omitempty"`
+	AnalysisModels               []string               `yaml:"analysis_models,omitempty" json:"analysis_models,omitempty"`
+	MaxConcurrent                int                    `yaml:"max_concurrent,omitempty" json:"max_concurrent,omitempty"`
+	MaxCompletionTokens          int                    `yaml:"max_completion_tokens,omitempty" json:"max_completion_tokens,omitempty"`
+	Temperature                  *float64               `yaml:"temperature,omitempty" json:"temperature,omitempty"`
+	IncludeAnalysis              *bool                  `yaml:"include_analysis,omitempty" json:"include_analysis,omitempty"`
+	OnError                      string                 `yaml:"on_error,omitempty" json:"on_error,omitempty"`
+	AnalysisTemplate             string                 `yaml:"analysis_template,omitempty" json:"analysis_template,omitempty"`
+	SynthesisTemplate            string                 `yaml:"synthesis_template,omitempty" json:"synthesis_template,omitempty"`
+	JudgePromptVersion           string                 `yaml:"judge_prompt_version,omitempty" json:"judge_prompt_version,omitempty"`
+	IncludeIntermediateResponses *bool                  `yaml:"include_intermediate_responses,omitempty" json:"include_intermediate_responses,omitempty"`
+	Grounding                    *FusionGroundingConfig `yaml:"grounding,omitempty" json:"grounding,omitempty"`
+}
+
+// FusionGroundingConfig configures the optional grounding stage that scores each
+// panel response for faithfulness before the judge synthesizes. When nil or
+// disabled, Fusion behaves exactly as without grounding. Grounding makes no extra
+// LLM calls: it uses local encoder models (hallucination detector + NLI).
+type FusionGroundingConfig struct {
+	Enabled                 bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Reference               string  `yaml:"reference,omitempty" json:"reference,omitempty"`
+	MinScore                float64 `yaml:"min_score,omitempty" json:"min_score,omitempty"`
+	MinKeep                 int     `yaml:"min_keep,omitempty" json:"min_keep,omitempty"`
+	NLIContradictionPenalty float64 `yaml:"nli_contradiction_penalty,omitempty" json:"nli_contradiction_penalty,omitempty"`
+	OnError                 string  `yaml:"on_error,omitempty" json:"on_error,omitempty"`
 }
 
 // FusionRuntimeConfig registers direct Fusion model slugs. The panel and judge
@@ -107,7 +126,34 @@ func ValidateFusionAlgorithmConfig(cfg *FusionAlgorithmConfig) error {
 	if cfg.Temperature != nil && *cfg.Temperature < 0 {
 		return fmt.Errorf("temperature must be >= 0 when set")
 	}
+	if err := ValidateFusionGroundingConfig(cfg.Grounding); err != nil {
+		return err
+	}
 	return nil
+}
+
+// ValidateFusionGroundingConfig validates the grounding block. Bounds are kept
+// identical to the Python CLI mirror (see src/vllm-sr/cli/algorithms.py).
+func ValidateFusionGroundingConfig(cfg *FusionGroundingConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	switch strings.TrimSpace(cfg.Reference) {
+	case "", FusionGroundingReferenceHybrid, FusionGroundingReferenceContext, FusionGroundingReferencePanel:
+	default:
+		return fmt.Errorf("grounding.reference must be one of %q, %q or %q, got %q",
+			FusionGroundingReferenceHybrid, FusionGroundingReferenceContext, FusionGroundingReferencePanel, cfg.Reference)
+	}
+	if cfg.MinScore < 0 || cfg.MinScore > 1 {
+		return fmt.Errorf("grounding.min_score must be between 0 and 1")
+	}
+	if cfg.MinKeep < 0 {
+		return fmt.Errorf("grounding.min_keep must be >= 0")
+	}
+	if cfg.NLIContradictionPenalty < 0 {
+		return fmt.Errorf("grounding.nli_contradiction_penalty must be >= 0")
+	}
+	return validateFusionOnError(cfg.OnError)
 }
 
 func ValidateFusionRuntimeConfig(cfg FusionRuntimeConfig) error {

--- a/src/semantic-router/pkg/looper/fusion.go
+++ b/src/semantic-router/pkg/looper/fusion.go
@@ -35,6 +35,13 @@ type fusionExecutionConfig struct {
 	AnalysisTemplate             string
 	SynthesisTemplate            string
 	JudgePromptVersion           string
+
+	GroundingEnabled                 bool
+	GroundingReference               string
+	GroundingMinScore                float64
+	GroundingMinKeep                 int
+	GroundingNLIContradictionPenalty float64
+	GroundingOnError                 string
 }
 
 type FusionAnalysis struct {
@@ -65,6 +72,7 @@ type FusionTrace struct {
 	JudgeModel     string                `json:"judge_model,omitempty"`
 	AnalysisModels []string              `json:"analysis_models,omitempty"`
 	PromptVersion  string                `json:"prompt_version,omitempty"`
+	Grounding      *FusionGroundingTrace `json:"grounding,omitempty"`
 }
 
 type fusionPanelResult struct {
@@ -105,14 +113,21 @@ func (l *FusionLooper) Execute(ctx context.Context, req *Request) (*Response, er
 		return nil, err
 	}
 
-	analysis, analysisResp := l.runFusionAnalysis(ctx, req, cfg, panelResponses)
-	finalResp, err := l.runFusionFinal(ctx, req, cfg, panelResponses, analysis)
+	// Grounding (optional) ranks/filters the panel before the judge. It makes no
+	// model calls, so usage is summed from the full panel (the real cost paid).
+	groundedPanel, groundingScores, groundingMode, err := l.applyGrounding(req, cfg, panelResponses)
+	if err != nil {
+		return nil, err
+	}
+
+	analysis, analysisResp := l.runFusionAnalysis(ctx, req, cfg, groundedPanel, groundingScores)
+	finalResp, err := l.runFusionFinal(ctx, req, cfg, groundedPanel, analysis)
 	if err != nil {
 		return nil, err
 	}
 	usage := SumUsage(panelResponses...).Add(analysisResp, finalResp)
 
-	trace := buildFusionTrace(cfg, panelResponses, failedModels, analysis)
+	trace := buildFusionTrace(cfg, groundedPanel, failedModels, analysis, groundingMode, groundingScores)
 	modelsUsed := orderedFusionModelsUsed(cfg.AnalysisModels, cfg.Model)
 	iterations := len(cfg.AnalysisModels) + 2
 
@@ -153,7 +168,27 @@ func (l *FusionLooper) resolveFusionExecutionConfig(req *Request) fusionExecutio
 	if cfg.MaxConcurrent <= 0 || cfg.MaxConcurrent > len(cfg.AnalysisModels) {
 		cfg.MaxConcurrent = len(cfg.AnalysisModels)
 	}
+	applyGroundingDefaults(&cfg)
 	return cfg
+}
+
+// applyGroundingDefaults fills in grounding defaults when grounding is enabled.
+func applyGroundingDefaults(cfg *fusionExecutionConfig) {
+	if !cfg.GroundingEnabled {
+		return
+	}
+	if cfg.GroundingReference == "" {
+		cfg.GroundingReference = config.FusionGroundingReferenceHybrid
+	}
+	if cfg.GroundingMinKeep <= 0 {
+		cfg.GroundingMinKeep = 1
+	}
+	if cfg.GroundingNLIContradictionPenalty <= 0 {
+		cfg.GroundingNLIContradictionPenalty = 1.0
+	}
+	if strings.TrimSpace(cfg.GroundingOnError) == "" {
+		cfg.GroundingOnError = cfg.OnError
+	}
 }
 
 func validateFusionExecutionConfig(cfg fusionExecutionConfig) error {
@@ -199,6 +234,19 @@ func mergeFusionAlgorithmConfig(dst *fusionExecutionConfig, src *config.FusionAl
 	if src.JudgePromptVersion != "" {
 		dst.JudgePromptVersion = src.JudgePromptVersion
 	}
+	mergeFusionGroundingConfig(dst, src.Grounding)
+}
+
+func mergeFusionGroundingConfig(dst *fusionExecutionConfig, src *config.FusionGroundingConfig) {
+	if src == nil {
+		return
+	}
+	dst.GroundingEnabled = src.Enabled
+	dst.GroundingReference = src.Reference
+	dst.GroundingMinScore = src.MinScore
+	dst.GroundingMinKeep = src.MinKeep
+	dst.GroundingNLIContradictionPenalty = src.NLIContradictionPenalty
+	dst.GroundingOnError = src.OnError
 }
 
 func mergeFusionRequestConfig(dst *fusionExecutionConfig, src *config.FusionRequestConfig) {
@@ -353,8 +401,12 @@ func (l *FusionLooper) runFusionAnalysis(
 	req *Request,
 	cfg fusionExecutionConfig,
 	panelResponses []*ModelResponse,
+	groundingScores []groundingScore,
 ) (*FusionAnalysis, *ModelResponse) {
 	prompt := buildFusionAnalysisPrompt(cfg, extractOriginalContent(req.OriginalRequest), panelResponses)
+	if notes := formatGroundingNotes(groundingScores); notes != "" {
+		prompt = prompt + "\n\n" + notes
+	}
 	analysisReq := appendFusionStageMessage(req.OriginalRequest, prompt)
 	resp, err := l.callFusionModel(ctx, &Request{OriginalRequest: analysisReq, ModelParams: req.ModelParams}, cfg, cfg.Model, false, false, len(panelResponses)+1)
 	if err != nil {
@@ -494,12 +546,20 @@ func buildFusionTrace(
 	panelResponses []*ModelResponse,
 	failedModels []FusionFailedModel,
 	analysis *FusionAnalysis,
+	groundingMode string,
+	groundingScores []groundingScore,
 ) *FusionTrace {
 	trace := &FusionTrace{
 		JudgeModel:     cfg.Model,
 		AnalysisModels: append([]string(nil), cfg.AnalysisModels...),
 		FailedModels:   failedModels,
 		PromptVersion:  cfg.JudgePromptVersion,
+	}
+	if len(groundingScores) > 0 {
+		trace.Grounding = &FusionGroundingTrace{
+			ReferenceMode: groundingMode,
+			Scores:        groundingScores,
+		}
 	}
 	if cfg.IncludeAnalysis {
 		trace.Analysis = analysis
@@ -563,7 +623,7 @@ func (l *FusionLooper) formatFusionJSONResponse(
 		},
 		"usage": usage.Map(),
 	}
-	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 {
+	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 || trace.Grounding != nil {
 		completion["fusion"] = trace
 	}
 	body, err := json.Marshal(completion)
@@ -597,7 +657,7 @@ func (l *FusionLooper) formatFusionToolCallJSONResponse(
 	completion["id"] = fmt.Sprintf("chatcmpl-fusion-%d", time.Now().UnixNano())
 	completion["model"] = finalResp.Model
 	completion["usage"] = usage.Map()
-	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 {
+	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 || trace.Grounding != nil {
 		completion["fusion"] = trace
 	}
 	body, err := json.Marshal(completion)
@@ -659,7 +719,7 @@ func buildFusionStreamingSSE(
 		"finish_reason": nil,
 	}
 	var extra map[string]interface{}
-	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 {
+	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 || trace.Grounding != nil {
 		extra = map[string]interface{}{"fusion": trace}
 	}
 	body = appendSSEDataLine(body, chatCompletionChunkPayload(id, created, model, roleChoice, extra))

--- a/src/semantic-router/pkg/looper/fusion_tool_use.go
+++ b/src/semantic-router/pkg/looper/fusion_tool_use.go
@@ -87,7 +87,7 @@ func buildFusionStreamingToolCallSSE(
 		"finish_reason": nil,
 	}
 	var extra map[string]interface{}
-	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 {
+	if cfg.IncludeAnalysis || cfg.IncludeIntermediateResponses || len(trace.FailedModels) > 0 || trace.Grounding != nil {
 		extra = map[string]interface{}{"fusion": trace}
 	}
 	body = appendSSEDataLine(body, chatCompletionChunkPayload(id, created, model, roleChoice, extra))

--- a/src/semantic-router/pkg/looper/grounding.go
+++ b/src/semantic-router/pkg/looper/grounding.go
@@ -1,0 +1,295 @@
+package looper
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// Grounding-aware fusion scores each panel response for faithfulness before the
+// judge synthesizes, then ranks/filters the panel so the judge works from the
+// most-grounded responses. It makes NO extra LLM calls — it uses local encoder
+// models (a hallucination/groundedness detector and an NLI entailment model).
+//
+// Reference selection (config.FusionGroundingReference*):
+//   - context: score answers against provided RAG/tool context via the detector.
+//   - panel:   score answers against each other via cross-model NLI (the panel
+//     acts as its own mutual reference).
+//   - hybrid:  use context when the request carries it, otherwise the panel.
+//
+// Honest framing: grounding measures faithfulness/consistency, not truth. With no
+// authoritative source we can only down-weight the least-supported responses, not
+// certify correctness.
+
+// NLIClassifyFunc returns the entailment and contradiction probabilities for the
+// hypothesis given the premise.
+type NLIClassifyFunc func(premise, hypothesis string) (entailment, contradiction float32, err error)
+
+// HallucinationDetectFunc returns the unsupported spans of answer relative to
+// context, plus the detector's confidence.
+type HallucinationDetectFunc func(context, question, answer string) (unsupportedSpans []string, confidence float32, err error)
+
+// Backends are injected once at startup (see classification lifecycle) so the
+// candle/CGO dependency stays out of this package's import graph and the scoring
+// logic stays hermetically unit-testable.
+var (
+	groundingNLIClassify NLIClassifyFunc
+	groundingDetect      HallucinationDetectFunc
+)
+
+// SetGroundingBackends wires the NLI + hallucination detection backends used by
+// grounding-aware fusion. Safe to call again to replace them.
+func SetGroundingBackends(nli NLIClassifyFunc, detect HallucinationDetectFunc) {
+	groundingNLIClassify = nli
+	groundingDetect = detect
+}
+
+// groundingScore captures the per-response groundedness outcome (parallel to the
+// panel slice it was computed from, before ranking).
+type groundingScore struct {
+	Model        string   `json:"model"`
+	Score        float64  `json:"score"`
+	FlaggedSpans []string `json:"flagged_spans,omitempty"`
+	Dropped      bool     `json:"dropped,omitempty"`
+}
+
+// FusionGroundingTrace is attached to FusionTrace for observability.
+type FusionGroundingTrace struct {
+	ReferenceMode string           `json:"reference_mode,omitempty"`
+	Scores        []groundingScore `json:"scores,omitempty"`
+}
+
+// applyGrounding scores, ranks and filters the panel. It returns the (possibly
+// reordered/filtered) panel that the judge should use, the per-response scores,
+// the reference mode actually used, and an error only when on_error=fail.
+// When grounding is disabled or unavailable (and on_error=skip), it returns the
+// panel unchanged so Fusion behaves exactly as before.
+func (l *FusionLooper) applyGrounding(
+	req *Request,
+	cfg fusionExecutionConfig,
+	panel []*ModelResponse,
+) (kept []*ModelResponse, scores []groundingScore, referenceMode string, err error) {
+	if !cfg.GroundingEnabled || len(panel) == 0 {
+		return panel, nil, "", nil
+	}
+
+	question := extractOriginalContent(req.OriginalRequest)
+	contextText := extractGroundingContext(req.OriginalRequest)
+	useContext := resolveGroundingReference(cfg.GroundingReference, contextText)
+
+	if useContext {
+		scores, err = scoreByContext(contextText, question, panel, cfg)
+		referenceMode = config.FusionGroundingReferenceContext
+	} else {
+		scores, err = scoreByPanel(panel, cfg)
+		referenceMode = config.FusionGroundingReferencePanel
+	}
+	if err != nil {
+		if cfg.GroundingOnError == config.FusionOnErrorFail {
+			return nil, nil, "", fmt.Errorf("fusion grounding failed: %w", err)
+		}
+		logging.ComponentWarnEvent("looper", "fusion_grounding_skipped", map[string]interface{}{
+			"reference_mode": referenceMode,
+			"error":          err.Error(),
+		})
+		return panel, nil, "", nil
+	}
+
+	kept = filterPanelByScore(panel, scores, cfg)
+	logging.ComponentEvent("looper", "fusion_grounding_applied", map[string]interface{}{
+		"reference_mode": referenceMode,
+		"panel_in":       len(panel),
+		"panel_kept":     len(kept),
+	})
+	return kept, scores, referenceMode, nil
+}
+
+func resolveGroundingReference(mode, contextText string) (useContext bool) {
+	switch strings.TrimSpace(mode) {
+	case config.FusionGroundingReferenceContext:
+		return true
+	case config.FusionGroundingReferencePanel:
+		return false
+	default: // hybrid (and empty)
+		return strings.TrimSpace(contextText) != ""
+	}
+}
+
+// scoreByPanel scores each response by how well its peers entail (vs contradict)
+// it — the panel as its own mutual reference.
+func scoreByPanel(panel []*ModelResponse, cfg fusionExecutionConfig) ([]groundingScore, error) {
+	if groundingNLIClassify == nil {
+		return nil, fmt.Errorf("nli backend not configured")
+	}
+	penalty := cfg.GroundingNLIContradictionPenalty
+	if penalty <= 0 {
+		penalty = 1.0
+	}
+	scores := make([]groundingScore, len(panel))
+	for i, r := range panel {
+		scores[i].Model = modelName(r)
+		if r == nil {
+			continue
+		}
+		var sum float64
+		var n int
+		var flagged []string
+		for j, p := range panel {
+			if i == j || p == nil {
+				continue
+			}
+			entail, contradict, err := groundingNLIClassify(p.Content, r.Content)
+			if err != nil {
+				return nil, err
+			}
+			sum += float64(entail) - penalty*float64(contradict)
+			n++
+			if contradict > entail && contradict >= 0.5 {
+				flagged = append(flagged, p.Model)
+			}
+		}
+		raw := 0.0
+		if n > 0 {
+			raw = sum / float64(n)
+		}
+		// raw is in [-penalty, 1]; map to [0,1].
+		scores[i].Score = clamp01((raw + penalty) / (1.0 + penalty))
+		scores[i].FlaggedSpans = flagged
+	}
+	return scores, nil
+}
+
+// scoreByContext scores each response by its faithfulness to the provided context
+// (fewer unsupported spans => higher score).
+func scoreByContext(contextText, question string, panel []*ModelResponse, cfg fusionExecutionConfig) ([]groundingScore, error) {
+	if groundingDetect == nil {
+		return nil, fmt.Errorf("hallucination detector backend not configured")
+	}
+	scores := make([]groundingScore, len(panel))
+	for i, r := range panel {
+		scores[i].Model = modelName(r)
+		if r == nil {
+			continue
+		}
+		spans, _, err := groundingDetect(contextText, question, r.Content)
+		if err != nil {
+			return nil, err
+		}
+		// 0 unsupported spans => 1.0; degrades as unsupported spans accumulate.
+		scores[i].Score = 1.0 / (1.0 + float64(len(spans)))
+		scores[i].FlaggedSpans = spans
+	}
+	return scores, nil
+}
+
+// filterPanelByScore returns the panel ranked by score (desc), dropping responses
+// below min_score while always keeping at least min_keep of the highest-scoring
+// responses. It mutates scores[i].Dropped to record what was filtered out.
+func filterPanelByScore(panel []*ModelResponse, scores []groundingScore, cfg fusionExecutionConfig) []*ModelResponse {
+	minKeep := cfg.GroundingMinKeep
+	if minKeep <= 0 {
+		minKeep = 1
+	}
+	if minKeep > len(panel) {
+		minKeep = len(panel)
+	}
+
+	order := make([]int, len(panel))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return scores[order[a]].Score > scores[order[b]].Score
+	})
+
+	kept := make([]*ModelResponse, 0, len(panel))
+	for rank, idx := range order {
+		if rank < minKeep || scores[idx].Score >= cfg.GroundingMinScore {
+			kept = append(kept, panel[idx])
+		} else {
+			scores[idx].Dropped = true
+		}
+	}
+	return kept
+}
+
+// extractGroundingContext returns the authoritative context for the request:
+// the concatenation of system and tool message contents (where RAG/tool output
+// is conventionally injected). Empty when the request carries no such context.
+func extractGroundingContext(req *openai.ChatCompletionNewParams) string {
+	if req == nil {
+		return ""
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return ""
+	}
+	var reqMap map[string]interface{}
+	if err := json.Unmarshal(data, &reqMap); err != nil {
+		return ""
+	}
+	messages, ok := reqMap["messages"].([]interface{})
+	if !ok {
+		return ""
+	}
+	var b strings.Builder
+	for _, m := range messages {
+		msg, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != "system" && role != "tool" {
+			continue
+		}
+		if content, ok := msg["content"].(string); ok && strings.TrimSpace(content) != "" {
+			b.WriteString(content)
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// formatGroundingNotes renders a concise groundedness summary for the judge
+// prompt so synthesis is told which responses were corroborated vs flagged.
+func formatGroundingNotes(scores []groundingScore) string {
+	if len(scores) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Groundedness notes (higher score = better supported; flagged = contradicted/unsupported):\n")
+	for _, s := range scores {
+		fmt.Fprintf(&b, "- %s: score %.2f", s.Model, s.Score)
+		if s.Dropped {
+			b.WriteString(" [dropped]")
+		}
+		if len(s.FlaggedSpans) > 0 {
+			fmt.Fprintf(&b, " [flagged: %s]", strings.Join(s.FlaggedSpans, "; "))
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func modelName(r *ModelResponse) string {
+	if r == nil {
+		return ""
+	}
+	return r.Model
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/src/semantic-router/pkg/looper/grounding_test.go
+++ b/src/semantic-router/pkg/looper/grounding_test.go
@@ -1,0 +1,251 @@
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// withGroundingBackends swaps the package-level grounding backends for the
+// duration of a test and restores them afterwards.
+func withGroundingBackends(t *testing.T, nli NLIClassifyFunc, detect HallucinationDetectFunc) {
+	t.Helper()
+	prevNLI, prevDetect := groundingNLIClassify, groundingDetect
+	groundingNLIClassify, groundingDetect = nli, detect
+	t.Cleanup(func() {
+		groundingNLIClassify, groundingDetect = prevNLI, prevDetect
+	})
+}
+
+func panel(contents ...string) []*ModelResponse {
+	resps := make([]*ModelResponse, 0, len(contents))
+	for i, c := range contents {
+		resps = append(resps, &ModelResponse{Model: string(rune('a' + i)), Content: c})
+	}
+	return resps
+}
+
+func TestScoreByPanel_RanksContradictedLower(t *testing.T) {
+	// Peers entail "good" answers and contradict any answer containing "bad".
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(hypothesis, "bad") {
+			return 0.1, 0.8, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	p := panel("good one", "good two", "bad three")
+	scores, err := scoreByPanel(p, fusionExecutionConfig{GroundingNLIContradictionPenalty: 1.0})
+	require.NoError(t, err)
+	require.Len(t, scores, 3)
+
+	assert.Greater(t, scores[0].Score, scores[2].Score)
+	assert.Greater(t, scores[1].Score, scores[2].Score)
+	// The contradicted response is flagged by its peers.
+	assert.NotEmpty(t, scores[2].FlaggedSpans)
+	assert.Empty(t, scores[0].FlaggedSpans)
+}
+
+func TestScoreByContext_FewerUnsupportedSpansScoresHigher(t *testing.T) {
+	// "bad" answers have an unsupported span; grounded ones have none.
+	withGroundingBackends(t, nil, func(_, _, answer string) ([]string, float32, error) {
+		if strings.Contains(answer, "bad") {
+			return []string{"unsupported claim"}, 0.9, nil
+		}
+		return nil, 0.9, nil
+	})
+
+	p := panel("grounded answer", "bad answer")
+	scores, err := scoreByContext("the context", "the question", p, fusionExecutionConfig{})
+	require.NoError(t, err)
+	require.Len(t, scores, 2)
+	assert.Equal(t, 1.0, scores[0].Score)
+	assert.Less(t, scores[1].Score, scores[0].Score)
+	assert.NotEmpty(t, scores[1].FlaggedSpans)
+}
+
+func TestFilterPanelByScore_MinScoreAndMinKeep(t *testing.T) {
+	p := panel("a", "b", "c")
+	scores := []groundingScore{
+		{Model: "a", Score: 0.9},
+		{Model: "b", Score: 0.2},
+		{Model: "c", Score: 0.1},
+	}
+	kept := filterPanelByScore(p, scores, fusionExecutionConfig{GroundingMinScore: 0.5, GroundingMinKeep: 1})
+	// Only "a" clears the threshold; min_keep=1 is already satisfied by "a".
+	require.Len(t, kept, 1)
+	assert.Equal(t, "a", kept[0].Content)
+	assert.True(t, scores[1].Dropped)
+	assert.True(t, scores[2].Dropped)
+}
+
+func TestFilterPanelByScore_MinKeepGuaranteesSurvivors(t *testing.T) {
+	p := panel("a", "b", "c")
+	scores := []groundingScore{
+		{Model: "a", Score: 0.4},
+		{Model: "b", Score: 0.2},
+		{Model: "c", Score: 0.1},
+	}
+	// All below min_score, but min_keep=2 keeps the two highest.
+	kept := filterPanelByScore(p, scores, fusionExecutionConfig{GroundingMinScore: 0.9, GroundingMinKeep: 2})
+	require.Len(t, kept, 2)
+	assert.Equal(t, "a", kept[0].Content)
+	assert.Equal(t, "b", kept[1].Content)
+}
+
+func TestResolveGroundingReference(t *testing.T) {
+	assert.True(t, resolveGroundingReference(config.FusionGroundingReferenceContext, ""))
+	assert.False(t, resolveGroundingReference(config.FusionGroundingReferencePanel, "ctx"))
+	// hybrid: context only when present.
+	assert.True(t, resolveGroundingReference(config.FusionGroundingReferenceHybrid, "ctx"))
+	assert.False(t, resolveGroundingReference(config.FusionGroundingReferenceHybrid, ""))
+	assert.False(t, resolveGroundingReference("", ""))
+}
+
+func TestExtractGroundingContext(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage("retrieved passage"),
+			openai.UserMessage("the question"),
+		},
+	}
+	got := extractGroundingContext(req)
+	assert.Contains(t, got, "retrieved passage")
+	assert.NotContains(t, got, "the question")
+}
+
+func TestApplyGrounding_DisabledReturnsPanelUnchanged(t *testing.T) {
+	l := NewFusionLooper(&config.LooperConfig{})
+	p := panel("x", "y")
+	kept, scores, mode, err := l.applyGrounding(newFusionTestRequest(), fusionExecutionConfig{}, p)
+	require.NoError(t, err)
+	assert.Equal(t, p, kept)
+	assert.Nil(t, scores)
+	assert.Empty(t, mode)
+}
+
+func TestApplyGrounding_OnErrorSkipFallsBack(t *testing.T) {
+	withGroundingBackends(t, nil, nil) // panel mode needs NLI; nil => error
+	l := NewFusionLooper(&config.LooperConfig{})
+	p := panel("x", "y")
+	cfg := fusionExecutionConfig{
+		GroundingEnabled:   true,
+		GroundingReference: config.FusionGroundingReferencePanel,
+		GroundingOnError:   config.FusionOnErrorSkip,
+		GroundingMinKeep:   1,
+	}
+	kept, _, _, err := l.applyGrounding(newFusionTestRequest(), cfg, p)
+	require.NoError(t, err)
+	assert.Equal(t, p, kept) // unchanged on skip
+}
+
+func TestApplyGrounding_OnErrorFailReturnsError(t *testing.T) {
+	withGroundingBackends(t, nil, nil)
+	l := NewFusionLooper(&config.LooperConfig{})
+	cfg := fusionExecutionConfig{
+		GroundingEnabled:   true,
+		GroundingReference: config.FusionGroundingReferencePanel,
+		GroundingOnError:   config.FusionOnErrorFail,
+		GroundingMinKeep:   1,
+	}
+	_, _, _, err := l.applyGrounding(newFusionTestRequest(), cfg, panel("x", "y"))
+	require.Error(t, err)
+}
+
+func TestApplyGrounding_PanelModeFiltersContradicted(t *testing.T) {
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(hypothesis, "bad") {
+			return 0.1, 0.8, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	l := NewFusionLooper(&config.LooperConfig{})
+	cfg := fusionExecutionConfig{
+		GroundingEnabled:                 true,
+		GroundingReference:               config.FusionGroundingReferencePanel,
+		GroundingOnError:                 config.FusionOnErrorSkip,
+		GroundingMinScore:                0.5,
+		GroundingMinKeep:                 1,
+		GroundingNLIContradictionPenalty: 1.0,
+	}
+	kept, scores, mode, err := l.applyGrounding(newFusionTestRequest(), cfg, panel("good one", "good two", "bad three"))
+	require.NoError(t, err)
+	assert.Equal(t, config.FusionGroundingReferencePanel, mode)
+	require.Len(t, scores, 3)
+	// The contradicted "bad" response is dropped from the judge's panel.
+	for _, r := range kept {
+		assert.NotContains(t, r.Content, "bad")
+	}
+	assert.Len(t, kept, 2)
+}
+
+// TestFusionExecute_GroundingKeepsContradictedOutOfJudge runs the full Execute
+// path with grounding enabled and asserts the contradicted panel response never
+// reaches the judge, while usage still reflects the full panel cost.
+func TestFusionExecute_GroundingKeepsContradictedOutOfJudge(t *testing.T) {
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(hypothesis, "bad") {
+			return 0.1, 0.8, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	server := newFusionStubServer(t, func(model, prompt string) (string, int) {
+		switch model {
+		case "panel-a":
+			return "good grounded answer", http.StatusOK
+		case "panel-b":
+			return "bad contradicted answer", http.StatusOK
+		case "panel-c":
+			return "good supported answer", http.StatusOK
+		case "judge":
+			if strings.Contains(prompt, "return only valid JSON") {
+				// The dropped panel response must not reach the judge.
+				assert.NotContains(t, prompt, "bad contradicted answer")
+				return `{"consensus":["agree"],"contradictions":[],"partial_coverage":[],"unique_insights":[],"blind_spots":[]}`, http.StatusOK
+			}
+			return "final answer", http.StatusOK
+		default:
+			return "unexpected", http.StatusInternalServerError
+		}
+	})
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:          "judge",
+			AnalysisModels: []string{"panel-a", "panel-b", "panel-c"},
+			Grounding: &config.FusionGroundingConfig{
+				Enabled:   true,
+				Reference: config.FusionGroundingReferencePanel,
+				MinScore:  0.5,
+				MinKeep:   1,
+			},
+		},
+	}
+
+	resp, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	fusionTrace := body["fusion"].(map[string]interface{})
+	grounding, ok := fusionTrace["grounding"].(map[string]interface{})
+	require.True(t, ok, "fusion trace should carry grounding info")
+	assert.Equal(t, config.FusionGroundingReferencePanel, grounding["reference_mode"])
+	// Usage reflects the full panel (3 panel + judge analysis + judge final), not
+	// just the kept responses — grounding makes no extra calls but the panel cost
+	// was already paid.
+	assert.Positive(t, resp.Usage.TotalTokens)
+}

--- a/src/vllm-sr/cli/algorithms.py
+++ b/src/vllm-sr/cli/algorithms.py
@@ -104,6 +104,25 @@ class ReMoMAlgorithmConfig(BaseModel):
     max_responses_per_round: int | None = None
 
 
+class FusionGroundingConfig(BaseModel):
+    """Configuration for grounding-aware fusion.
+
+    Scores each panel response for faithfulness before the judge synthesizes,
+    then ranks/filters the panel. Uses local encoder models (hallucination
+    detector + NLI) and makes no extra LLM calls. Bounds here MUST match the Go
+    validator in pkg/config/fusion_config.go (ValidateFusionGroundingConfig).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool | None = False
+    reference: Literal["hybrid", "context", "panel"] | None = "hybrid"
+    min_score: float | None = Field(default=0.0, ge=0, le=1)
+    min_keep: int | None = Field(default=1, ge=0)
+    nli_contradiction_penalty: float | None = Field(default=1.0, ge=0)
+    on_error: Literal["skip", "fail"] | None = "skip"
+
+
 class FusionAlgorithmConfig(BaseModel):
     """Configuration for Fusion multi-model deliberation.
 
@@ -124,6 +143,7 @@ class FusionAlgorithmConfig(BaseModel):
     analysis_template: str | None = None
     synthesis_template: str | None = None
     judge_prompt_version: str | None = "fusion-v1"
+    grounding: FusionGroundingConfig | None = None
 
 
 class LatencyAwareAlgorithmConfig(BaseModel):

--- a/src/vllm-sr/tests/test_algorithm_config.py
+++ b/src/vllm-sr/tests/test_algorithm_config.py
@@ -356,6 +356,33 @@ class TestFusionAlgorithmConfig:
         with pytest.raises(PydanticValidationError):
             FusionAlgorithmConfig(on_error="ignore")
 
+    def test_grounding_defaults(self):
+        config = FusionAlgorithmConfig(grounding={"enabled": True})
+        assert config.grounding.enabled is True
+        assert config.grounding.reference == "hybrid"
+        assert config.grounding.min_score == 0.0
+        assert config.grounding.min_keep == 1
+        assert config.grounding.nli_contradiction_penalty == 1.0
+        assert config.grounding.on_error == "skip"
+
+    def test_grounding_bounds_match_go_validator(self):
+        # min_score in [0, 1]
+        with pytest.raises(PydanticValidationError):
+            FusionAlgorithmConfig(grounding={"min_score": 1.5})
+        with pytest.raises(PydanticValidationError):
+            FusionAlgorithmConfig(grounding={"min_score": -0.1})
+        # min_keep >= 0
+        with pytest.raises(PydanticValidationError):
+            FusionAlgorithmConfig(grounding={"min_keep": -1})
+        # penalty >= 0
+        with pytest.raises(PydanticValidationError):
+            FusionAlgorithmConfig(grounding={"nli_contradiction_penalty": -1})
+        # reference enum + on_error enum
+        with pytest.raises(PydanticValidationError):
+            FusionAlgorithmConfig(grounding={"reference": "elsewhere"})
+        with pytest.raises(PydanticValidationError):
+            FusionAlgorithmConfig(grounding={"on_error": "ignore"})
+
 
 class TestAlgorithmConfigIntegration:
     """Integration tests for AlgorithmConfig with nested configs."""

--- a/website/docs/proposals/deliberation-algorithms.md
+++ b/website/docs/proposals/deliberation-algorithms.md
@@ -1,0 +1,129 @@
+# Deliberation Algorithms for vLLM Semantic Router
+
+**Version:** 1.0
+**Authors:** vLLM Semantic Router Team
+**Status:** Proposal
+
+## Abstract
+
+The `fusion` looper (panel → judge → synthesis) gives vLLM Semantic Router an
+OpenRouter-equivalent multi-model deliberation mode. This proposal surveys the next
+generation of *original* deliberation algorithms in the spirit of ReMoM, identifies
+where vSR can structurally outperform OpenRouter's Fusion, and recommends building
+**grounding-aware synthesis** first — a factuality lever OpenRouter has no equivalent
+for, because vSR is a classifying gateway with a built-in groundedness detector.
+
+## 1. Problem
+
+Fusion deliberation works, but it has three structural limits:
+
+- **It always pays the full cost.** Every request fans out to the whole panel plus a
+  judge and a synthesis call (N+2), regardless of how easy the question is.
+- **Its judge has no grounding oracle.** The judge is a bare LLM reading raw panel
+  text. OpenRouter's own deep-research benchmark (DRACO) explicitly *penalizes
+  confident-but-wrong answers*, and judge choice alone swings scores 10–25 points.
+- **The spend/save decision is static.** Operators pick "single model" or "fusion"
+  per route; nothing decides per request whether deliberation is worth it.
+
+The underlying tension is two-fold: **save tokens** (route to a single cheap model)
+vs **spend tokens for accuracy** (deliberate). These are two ends of one adaptive
+spectrum, not two competing products.
+
+## 2. How OpenRouter Fusion works
+
+Fan a prompt to a panel of models in parallel (each with server-side web search /
+fetch), have a judge produce structured analysis (consensus, contradictions, partial
+coverage, unique insights, blind spots), then have the calling model write the final
+answer grounded in that analysis. Reported findings:
+
+- **Diversity + synthesis beats any single frontier model**, and a *budget* panel can
+  beat a frontier solo model at ~50% cost.
+- **Self-fusion** (a model paired with itself) still gains ~+6.7 points — a meaningful
+  share of the lift comes from the synthesis step, not just architecture diversity.
+
+vSR's Fusion matches the pipeline shape but lacks the server-side web tools and
+exclude-lists (an honest gap where OpenRouter leads).
+
+## 3. Candidate algorithms
+
+Each maps onto the existing `BaseLooper` substrate (`client.CallModel`, `SumUsage`,
+response formatting) and registers as a looper algorithm.
+
+| Algorithm | Lineage | Idea | Distinct from Fusion/ReMoM |
+|-----------|---------|------|----------------------------|
+| **Grounding-aware Fusion** (recommended) | Finch-Zk / SelfCheckGPT / NLI | Score panel responses for faithfulness, then rank/filter before the judge | Adds a groundedness oracle to the judge step |
+| Multi-Agent Debate | Du et al. 2024 | Iterative cross-critique + revision, convergence early-stop, then synthesis | Multi-round mutual revision vs Fusion's single round |
+| Cross-model self-consistency | SelfCheckGPT | Cluster semantically-equivalent answers, return the consensus | No judge; statistical consensus |
+| Confidence-gated / adaptive deliberation | AutoMix | Cheap model first; deliberate only when low-confidence | Resolves the spend/save tension at the gateway |
+
+## 4. Where vSR beats OpenRouter
+
+OpenRouter is a pass-through API, so its Fusion must be static and model-driven. vSR
+is a classifying gateway, so its Fusion can be adaptive and signal-driven.
+
+| OpenRouter approach | vSR structural advantage | Improvement |
+|---|---|---|
+| Model decides when to invoke Fusion, or always pays | Confidence + difficulty/domain signals at the gateway | Adaptive-gated deliberation |
+| Hand-picked / static panels | Per-model pricing, `param_size`, `CostQualityTradeoff`, selection pkg | Cost+diversity auto-panel |
+| Judge is a bare LLM | Built-in hallucination detector + NLI entailment model | **Grounding-aware synthesis** |
+| Always full panel + judge | Loop control (ReMoM breadth scheduling) | Adaptive compute / early-stop |
+| No per-deployment learning | Runs in your env; `rl_driven` + selection registry | Learned routing from Fusion traces |
+
+Honest gaps where OpenRouter leads: server-side web tools + exclude-lists, four
+polished entry modes, and the DRACO eval harness (worth borrowing to *prove* the
+grounding lift).
+
+## 5. The ground-truth reality
+
+The detector measures **groundedness against a provided reference**, not truth. So
+the design choice is *what serves as the reference*:
+
+- **Context** (RAG/tool output) — strongest, available only when the request carries it.
+- **Panel** (cross-model NLI) — the panel as its own mutual reference; no external
+  dependency; works on any query.
+- **External verifier** — strong but an operational dependency.
+
+Reliability hierarchy of signals: grounded > peer-supported > confident >
+self-consistent > relevant. None is truth, but stacked they give a robust *relative*
+score — enough to down-weight the least-supported responses before synthesis.
+
+## 6. Recommendation — Grounding-Aware Fusion (hybrid reference)
+
+Extend the existing `FusionLooper` with an optional grounding stage (off by default):
+after the panel returns and before the judge runs, score each response for
+groundedness, then rank and filter. Hybrid reference: detector against context when
+present, otherwise cross-model NLI.
+
+This is the highest-leverage first build because:
+
+- It reuses two already-built subsystems — the hallucination detector
+  (`pkg/classification`) and the NLI binding (`candle-binding`) — plus the merged
+  usage substrate.
+- It is the differentiator OpenRouter structurally cannot match (its judge has no
+  grounding oracle).
+- It directly attacks DRACO's factual-accuracy / negative-criteria axis.
+
+See the implementation in `tutorials/algorithm/looper/fusion.md` (Grounding-Aware
+Synthesis). It makes no extra LLM calls and degrades gracefully (`on_error: skip`
+falls back to plain Fusion when the detectors are unavailable).
+
+## 7. Evaluation
+
+Borrow DRACO-style scoring (with negative criteria) to prove the lift: A/B plain
+Fusion vs grounding-aware Fusion on a factuality slice, measuring resolve quality and
+the rate at which contradicted/ungrounded panel responses are kept out of synthesis.
+
+## 8. Follow-ups
+
+- Multi-Agent Debate as a high-accuracy escalation engine.
+- Adaptive gating (cheap-first, deliberate-on-low-confidence) to fix Fusion's
+  always-N+2 cost profile.
+- Cost+diversity auto-panel composition.
+
+## References
+
+1. OpenRouter, *Surpassing Frontier Performance with Fusion* (2026).
+2. Goel et al., *Finch-Zk: cross-model consistency for hallucination detection* (arXiv:2508.14314).
+3. Manakul et al., *SelfCheckGPT* (arXiv:2303.08896).
+4. Du et al., *Improving Factuality and Reasoning via Multiagent Debate* (2024).
+5. See also `proposals/hallucination-mitigation-milestone.md` (TruthLens).

--- a/website/docs/tutorials/algorithm/looper/fusion.md
+++ b/website/docs/tutorials/algorithm/looper/fusion.md
@@ -162,3 +162,46 @@ Request-level override:
 | `analysis_template` | string | built-in | Custom judge analysis prompt with `{{original}}` and `{{responses}}` |
 | `synthesis_template` | string | built-in | Custom final prompt with `{{original}}`, `{{responses}}`, and `{{analysis}}` |
 | `judge_prompt_version` | string | `fusion-v1` | Version marker included in Fusion response trace |
+| `grounding` | object | disabled | Optional grounding-aware synthesis (see below) |
+
+## Grounding-Aware Synthesis
+
+By default the judge reads raw panel text with no grounding oracle. Grounding-aware synthesis scores each panel response for **faithfulness** *before* the judge runs, then ranks and filters the panel so the judge synthesizes from the most-grounded responses. It makes **no extra LLM calls** — it uses local encoder models (the hallucination/groundedness detector and an NLI entailment model).
+
+Reference selection (what each answer is scored against):
+
+- `context` — score answers against provided RAG/tool context via the detector (strongest, but only when the request carries context such as system/tool messages).
+- `panel` — score answers against each other via cross-model NLI; the panel acts as its own mutual reference (no external dependency, works on any query).
+- `hybrid` (default) — use `context` when the request carries it, otherwise `panel`.
+
+> Grounding measures faithfulness/consistency, not truth. With no authoritative source it can down-weight the least-supported responses, not certify correctness.
+
+Requires the hallucination detector (and, for the `panel`/cross-model path, the NLI model) to be configured under `global` hallucination mitigation. If the backends are unavailable, `on_error: skip` falls back to plain Fusion.
+
+```yaml
+algorithm:
+  type: fusion
+  fusion:
+    model: qwen3-32b
+    analysis_models: [qwen3-8b, qwen3-32b]
+    grounding:
+      enabled: true
+      reference: hybrid          # hybrid | context | panel
+      min_score: 0.0             # drop responses scoring below this (0-1)
+      min_keep: 1                # always keep at least this many
+      nli_contradiction_penalty: 1.0
+      on_error: skip             # skip (fall back to plain fusion) | fail
+```
+
+When enabled, the Fusion response `trace.grounding` records the reference mode and per-response `score`, `flagged_spans`, and whether each was `dropped`.
+
+### Grounding parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable grounding-aware synthesis |
+| `reference` | string | `hybrid` | `hybrid`, `context`, or `panel` |
+| `min_score` | float | `0.0` | Drop responses scoring below this (0–1) |
+| `min_keep` | int | `1` | Always keep at least this many top-scoring responses |
+| `nli_contradiction_penalty` | float | `1.0` | Weight of a peer contradiction in the `panel` reference |
+| `on_error` | string | `skip` | `skip` (fall back to plain Fusion) or `fail` |


### PR DESCRIPTION
## What

Add **grounding-aware synthesis** to the Fusion looper: an optional stage that scores each panel response for *faithfulness* before the judge runs, then ranks/filters the panel so synthesis works from the most-grounded responses. Off by default — when disabled, Fusion behaves exactly as today.

This is the first of the "new deliberation algorithms" direction (see the proposal doc added here), and it's a differentiator OpenRouter's Fusion structurally can't match: its judge is a bare LLM with no grounding oracle, whereas vSR is a classifying gateway with a built-in hallucination/groundedness detector and an NLI entailment model.

## Why

OpenRouter's Fusion benchmark (DRACO) explicitly penalizes confident-but-wrong answers, and judge choice alone swings scores 10–25 points. vSR can score panel faithfulness with local encoder models (no extra LLM calls) and keep ungrounded/contradicted responses out of synthesis.

> Honest framing: grounding measures faithfulness/consistency, not truth. With no authoritative source we down-weight the least-supported responses, not certify correctness.

## Changes

- **`config/fusion_config.go`** — new `FusionGroundingConfig` (`enabled`, `reference`, `min_score`, `min_keep`, `nli_contradiction_penalty`, `on_error`) + `ValidateFusionGroundingConfig`. Python CLI mirror (`cli/algorithms.py`) with **identical bounds** (avoids the Go-allows-0 vs Python-ge=1 drift). Reference config + Go contract test + Python tests.
- **`looper/grounding.go` (new)** — hybrid reference scoring: hallucination **detector** against provided context when present, else cross-model **NLI** (the panel as its own mutual reference); rank + filter; `FusionGroundingTrace`. Kept hermetic — candle/CGO backends are injected via `SetGroundingBackends`, so the looper package stays unit-testable without the Rust lib.
- **`looper/fusion.go`** — run grounding between panel and judge; usage still summed from the **full** panel (real cost paid); grounding notes added to the judge prompt; grounding recorded in `FusionTrace` and surfaced in responses.
- **`classification`** — wire the candle `ClassifyNLI` + detector into the looper at hallucination-detector init (the single deterministic init point; no extproc changes).
- **Docs** — Fusion tutorial grounding section + `proposals/deliberation-algorithms.md`.

Substrate reuse: the hallucination detector (`pkg/classification`), the NLI binding (`candle-binding`), and the `SumUsage` seam from #2198 — all already present.

## Test plan

**Unit + integration (Go, hermetic — stubbed backends, no CGO):** `pkg/looper/grounding_test.go` covers panel/context scoring, `min_score`/`min_keep` filtering, reference resolution, context extraction, `on_error` fallback, and an `Execute`-level test asserting a contradicted panel response never reaches the judge while usage reflects the full panel. **Python:** `test_algorithm_config.py` covers grounding defaults + bounds (mirrors the Go validator).

```
go test ./pkg/looper/... ./pkg/config/... ./pkg/classification/...   # green
make agent-ci-lint                                                   # exit 0
```

**Full-stack e2e (manual, macOS dockerless):** ran curl → envoy → router extproc → fusion looper → real `models/mom-halugate-detector` over two `llm-katan` echo backends, with a `reference: context` grounding config:

- Startup: `hallucination_detector_initialized` (confirms the grounding backends wire at init).
- Per request: `fusion_execution_started` → `fusion_grounding_applied reference_mode: context panel_in:2 panel_kept:2`; response `fusion.grounding.scores[]` carried real per-model scores and `flagged_spans` (the detector correctly flagged content unsupported by the provided context).
- Drop path (`min_score: 0.6`): `panel_in:2 panel_kept:1`, trace showed the lower-scoring response `dropped: true` and the judge synthesized from the survivor.

(The cross-model NLI `panel`/`hybrid` path needs an NLI model that isn't bundled in the dev checkout; the `context` path was used for the live e2e. Unit tests cover the panel path with stubs.)

## Related

- Builds on #2197 (Fusion API, merged) and #2198 (looper usage accounting, merged).
- Part of the response to #2193 (Fusion API for multi-model deliberation).
