### PR TITLE
[Dashboard] Refine topology focus toggle

### DIFF
--- a/dashboard/frontend/src/pages/topology/TopologyPageEnhanced.module.css
+++ b/dashboard/frontend/src/pages/topology/TopologyPageEnhanced.module.css
@@ -198,6 +198,86 @@
   color: #f4f8ee;
 }
 
+.focusSwitch {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 28px;
+  padding: 3px 8px 3px 4px;
+  border: 1px solid rgba(118, 185, 0, 0.32);
+  border-radius: 999px;
+  background: rgba(26, 30, 25, 0.84);
+  color: rgba(219, 226, 211, 0.82);
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.focusSwitch:hover {
+  border-color: rgba(118, 185, 0, 0.72);
+  color: #f4f8ee;
+}
+
+.focusSwitch:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(118, 185, 0, 0.2);
+}
+
+.focusSwitchOn {
+  background: rgba(118, 185, 0, 0.18);
+  border-color: rgba(118, 185, 0, 0.82);
+  color: #f4f8ee;
+}
+
+.focusSwitchTrack {
+  position: relative;
+  width: 34px;
+  height: 18px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: rgba(6, 8, 6, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.focusSwitchThumb {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(219, 226, 211, 0.84);
+  transform: translateY(-50%);
+  transition:
+    transform 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.focusSwitchOn .focusSwitchTrack {
+  background: rgba(118, 185, 0, 0.28);
+  border-color: rgba(118, 185, 0, 0.54);
+}
+
+.focusSwitchOn .focusSwitchThumb {
+  background: #f4f8ee;
+  transform: translate(16px, -50%);
+  box-shadow: 0 0 10px rgba(118, 185, 0, 0.5);
+}
+
+.focusSwitchText {
+  min-width: 18px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 /* ReactFlow Custom Styling */
 .flowContainer :global(.react-flow) {
   background: transparent;

--- a/dashboard/frontend/src/pages/topology/TopologyPageEnhanced.tsx
+++ b/dashboard/frontend/src/pages/topology/TopologyPageEnhanced.tsx
@@ -225,7 +225,10 @@ const TopologyFlow: React.FC = () => {
               <div className={styles.toolbarRow}>
                 <button
                   type="button"
-                  className={`${styles.toolBtn} ${focusMode ? styles.toolBtnActive : ''}`}
+                  role="switch"
+                  aria-checked={focusMode}
+                  aria-label="Toggle focus mode"
+                  className={`${styles.focusSwitch} ${focusMode ? styles.focusSwitchOn : ''}`}
                   onClick={() => {
                     setFocusMode(prev => {
                       const next = !prev
@@ -234,7 +237,10 @@ const TopologyFlow: React.FC = () => {
                     })
                   }}
                 >
-                  {focusMode ? 'On' : 'Off'}
+                  <span className={styles.focusSwitchTrack} aria-hidden="true">
+                    <span className={styles.focusSwitchThumb} />
+                  </span>
+                  <span className={styles.focusSwitchText}>{focusMode ? 'On' : 'Off'}</span>
                 </button>
                 {focusedDecisionName && (
                   <button

--- a/dashboard/frontend/src/pages/topology/TopologyPageEnhanced.tsx
+++ b/dashboard/frontend/src/pages/topology/TopologyPageEnhanced.tsx
@@ -270,15 +270,15 @@ const TopologyFlow: React.FC = () => {
             fitViewOptions={{ padding: 0.16, minZoom: 0.15, maxZoom: 1.0 }}
             defaultViewport={{ x: 0, y: 0, zoom: 0.32 }}
           >
-            <Background 
+            <Background
               variant={BackgroundVariant.Dots}
               gap={20}
               size={1}
               color={isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.08)'}
             />
             <Controls />
-            <MiniMap 
-              nodeColor={getNodeColor} 
+            <MiniMap
+              nodeColor={getNodeColor}
               maskColor={isDark ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255, 255, 255, 0.3)'}
               style={{
                 backgroundColor: isDark ? '#141414' : '#ffffff',


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes N/A

## Purpose

- Improve the Brain topology configuration panel by replacing the Focus On/Off text-style button with a proper switch button.
- Make the Focus control visually match its binary behavior, so users can more clearly understand whether focus mode is enabled or disabled.
- Preserve the existing focus-mode behavior: turning Focus off clears the selected focused decision, and the existing Clear action remains available when a decision is focused.
- Improve accessibility by using `role="switch"` and `aria-checked` for the Focus control.
- Affected module(s): `Dashboard`

## Test Plan

- Run `npm run type-check` in `dashboard/frontend`.
- Run `make dashboard-check` from the repository root.
- Manually open the dashboard topology/Brain page and verify the Focus control in the upper-right toolbar renders as a switch button.
- Toggle Focus on and off, then verify the selected focused decision is cleared when Focus is turned off and the Clear button still works when a decision is focused.

## Test Result

- `npm run type-check` passed.
- `make dashboard-check` passed.
- Dashboard frontend unit tests passed: `11` test files, `40` tests.
- Dashboard backend lint and `go mod tidy` checks passed through `dashboard-check`.
- Existing dashboard/wizmap Sass deprecation warnings and npm audit notices still appear during dashboard checks; they are pre-existing and not caused by this PR.
- No blockers identified.

Screenshot before change:

<img width="1738" height="468" alt="screenshot-20260617-105333" src="https://github.com/user-attachments/assets/22f69b2e-9219-4db6-a5eb-2b568da4f2d9" />

After change:

<img width="1550" height="418" alt="screenshot-20260617-105351" src="https://github.com/user-attachments/assets/0331cc7d-c450-4bbb-b033-fb17385e809b" />

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.