### PR TITLE
[Router] v0.4 protocol headers: rename + cross-protocol-only + x-vsr-debug trigger

### DIFF
--- a/e2e/testcases/anthropic_messages_headers.go
+++ b/e2e/testcases/anthropic_messages_headers.go
@@ -13,7 +13,7 @@ import (
 
 func init() {
 	pkgtestcases.Register("anthropic-messages-protocol-headers", pkgtestcases.TestCase{
-		Description: "Verify x-vsr-inbound-protocol/x-vsr-outbound-protocol markers and absence of lossiness warnings for clean /v1/messages requests",
+		Description: "Verify x-vsr-client-protocol/x-vsr-upstream-protocol markers and absence of lossiness warnings for clean /v1/messages requests",
 		Tags:        []string{"anthropic", "headers", "observability"},
 		Fn:          testAnthropicMessagesProtocolHeaders,
 	})
@@ -64,9 +64,9 @@ func testAnthropicMessagesProtocolHeaders(ctx context.Context, client *kubernete
 	// router module (src/semantic-router/go.mod) and does not import
 	// pkg/headers. If a header name changes upstream, this test must
 	// be updated explicitly.
-	inbound := resp.Header.Get("x-vsr-inbound-protocol")
-	outbound := resp.Header.Get("x-vsr-outbound-protocol")
-	lossiness := resp.Header.Get("x-vsr-lossiness-warnings")
+	inbound := resp.Header.Get("x-vsr-client-protocol")
+	outbound := resp.Header.Get("x-vsr-upstream-protocol")
+	lossiness := resp.Header.Get("x-vsr-protocol-warnings")
 
 	if opts.SetDetails != nil {
 		opts.SetDetails(map[string]interface{}{
@@ -78,7 +78,7 @@ func testAnthropicMessagesProtocolHeaders(ctx context.Context, client *kubernete
 	}
 
 	if inbound != "anthropic" {
-		return fmt.Errorf("expected x-vsr-inbound-protocol=anthropic, got %q", inbound)
+		return fmt.Errorf("expected x-vsr-client-protocol=anthropic, got %q", inbound)
 	}
 	// Outbound protocol depends on the backend the router selected. In
 	// the kubernetes e2e profile the backend is OpenAI-shaped, so
@@ -86,10 +86,10 @@ func testAnthropicMessagesProtocolHeaders(ctx context.Context, client *kubernete
 	// at an Anthropic-native endpoint this assertion would tighten
 	// there.
 	if outbound != "openai" {
-		return fmt.Errorf("expected x-vsr-outbound-protocol=openai for kubernetes profile, got %q", outbound)
+		return fmt.Errorf("expected x-vsr-upstream-protocol=openai for kubernetes profile, got %q", outbound)
 	}
 	if lossiness != "" {
-		return fmt.Errorf("expected no x-vsr-lossiness-warnings for clean request, got %q", lossiness)
+		return fmt.Errorf("expected no x-vsr-protocol-warnings for clean request, got %q", lossiness)
 	}
 
 	return nil

--- a/src/semantic-router/pkg/extproc/debug_mode.go
+++ b/src/semantic-router/pkg/extproc/debug_mode.go
@@ -1,0 +1,20 @@
+package extproc
+
+import (
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+)
+
+// debugHeadersRequested reports whether the request opted into verbose/debug
+// response headers via the x-vsr-debug request header (value "true",
+// case-insensitive).
+//
+// It is the shared trigger for the v0.4 "debug/replay mode" header surface
+// (issue #2216): when on, headers that the contract otherwise omits or demotes
+// to replay are emitted inline for that request — e.g. the same-protocol
+// client/upstream markers in #2206, and the demoted intermediate signal headers
+// in #2205, which both gate on this predicate.
+func debugHeadersRequested(ctx *RequestContext) bool {
+	return strings.EqualFold(strings.TrimSpace(headerValueCI(ctx, headers.VSRDebug)), "true")
+}

--- a/src/semantic-router/pkg/extproc/debug_mode_test.go
+++ b/src/semantic-router/pkg/extproc/debug_mode_test.go
@@ -1,0 +1,38 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+)
+
+func TestDebugHeadersRequested(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{"nil headers", nil, false},
+		{"absent", map[string]string{"x-other": "true"}, false},
+		{"true", map[string]string{headers.VSRDebug: "true"}, true},
+		{"mixed case value", map[string]string{headers.VSRDebug: "True"}, true},
+		{"surrounding whitespace", map[string]string{headers.VSRDebug: " true "}, true},
+		{"false", map[string]string{headers.VSRDebug: "false"}, false},
+		{"empty value", map[string]string{headers.VSRDebug: ""}, false},
+		{"case-insensitive key", map[string]string{"X-Vsr-Debug": "true"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &RequestContext{Headers: tt.headers}
+			if got := debugHeadersRequested(ctx); got != tt.want {
+				t.Errorf("debugHeadersRequested() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDebugHeadersRequested_NilContext(t *testing.T) {
+	if debugHeadersRequested(nil) {
+		t.Error("debugHeadersRequested(nil) = true, want false")
+	}
+}

--- a/src/semantic-router/pkg/extproc/extproc_test.go
+++ b/src/semantic-router/pkg/extproc/extproc_test.go
@@ -2208,8 +2208,8 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 
 	setHeaders := headerMutation.GetSetHeaders()
 	// 2 keystone headers (x-vsr-schema-version + x-vsr-response-path, #2203) +
-	// 4 standard decision headers + x-vsr-inbound-protocol +
-	// x-vsr-outbound-protocol (translation-cell markers added by the
+	// 4 standard decision headers + x-vsr-client-protocol +
+	// x-vsr-upstream-protocol (translation-cell markers added by the
 	// Anthropic ingress series; emitted on every non-cache-hit response
 	// so operators can identify the cell that handled the request).
 	assert.Len(t, setHeaders, 8, "Should have 8 VSR headers (2 keystone + 4 decision + 2 protocol)")
@@ -2226,8 +2226,8 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 	assert.Equal(t, "on", headerMap["x-vsr-selected-reasoning"])
 	assert.Equal(t, "deepseek-v31", headerMap["x-vsr-selected-model"])
 	assert.Equal(t, "true", headerMap["x-vsr-injected-system-prompt"])
-	assert.Equal(t, "openai", headerMap["x-vsr-inbound-protocol"])
-	assert.Equal(t, "openai", headerMap["x-vsr-outbound-protocol"])
+	assert.Equal(t, "openai", headerMap["x-vsr-client-protocol"])
+	assert.Equal(t, "openai", headerMap["x-vsr-upstream-protocol"])
 }
 
 func TestVSRHeadersNotAddedOnCacheHit(t *testing.T) {
@@ -2299,8 +2299,8 @@ func TestVSRHeadersNotAddedOnErrorResponse(t *testing.T) {
 
 	// Decision/signal headers are NOT added on error responses, but the v0.4
 	// keystone headers (x-vsr-schema-version + x-vsr-response-path) and the
-	// translation-cell protocol markers (x-vsr-inbound-protocol,
-	// x-vsr-outbound-protocol) ride on every non-cache-hit response — success
+	// translation-cell protocol markers (x-vsr-client-protocol,
+	// x-vsr-upstream-protocol) ride on every non-cache-hit response — success
 	// or error — so operators can identify the contract version, the response
 	// path, and which translation cell handled a failed request. The error
 	// here is an upstream-returned 500, so response-path is "upstream".
@@ -2315,8 +2315,8 @@ func TestVSRHeadersNotAddedOnErrorResponse(t *testing.T) {
 	}
 	assert.Equal(t, "2", headerMap["x-vsr-schema-version"])
 	assert.Equal(t, "upstream", headerMap["x-vsr-response-path"])
-	assert.Equal(t, "openai", headerMap["x-vsr-inbound-protocol"])
-	assert.Equal(t, "openai", headerMap["x-vsr-outbound-protocol"])
+	assert.Equal(t, "openai", headerMap["x-vsr-client-protocol"])
+	assert.Equal(t, "openai", headerMap["x-vsr-upstream-protocol"])
 	assert.NotContains(t, headerMap, "x-vsr-selected-category", "decision headers must not appear on error")
 	assert.NotContains(t, headerMap, "x-vsr-selected-model", "decision headers must not appear on error")
 }
@@ -2361,7 +2361,7 @@ func TestVSRHeadersPartialInformation(t *testing.T) {
 	// 2 keystone headers (x-vsr-schema-version + x-vsr-response-path, #2203) +
 	// 3 standard decision headers (excluding empty reasoning mode, but
 	// including injected-system-prompt) + 2 translation-cell protocol
-	// markers (x-vsr-inbound-protocol + x-vsr-outbound-protocol).
+	// markers (x-vsr-client-protocol + x-vsr-upstream-protocol).
 	assert.Len(t, setHeaders, 7, "Should have 7 VSR headers (2 keystone + 3 decision + 2 protocol)")
 
 	// Verify each header

--- a/src/semantic-router/pkg/extproc/extproc_test.go
+++ b/src/semantic-router/pkg/extproc/extproc_test.go
@@ -2208,11 +2208,9 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 
 	setHeaders := headerMutation.GetSetHeaders()
 	// 2 keystone headers (x-vsr-schema-version + x-vsr-response-path, #2203) +
-	// 4 standard decision headers + x-vsr-client-protocol +
-	// x-vsr-upstream-protocol (translation-cell markers added by the
-	// Anthropic ingress series; emitted on every non-cache-hit response
-	// so operators can identify the cell that handled the request).
-	assert.Len(t, setHeaders, 8, "Should have 8 VSR headers (2 keystone + 4 decision + 2 protocol)")
+	// 4 standard decision headers. The client/upstream protocol markers are
+	// omitted because this is a same-protocol response (#2206).
+	assert.Len(t, setHeaders, 6, "Should have 6 VSR headers (2 keystone + 4 decision)")
 
 	// Verify each header
 	headerMap := make(map[string]string)
@@ -2226,8 +2224,8 @@ func TestVSRHeadersAddedOnSuccessfulNonCachedResponse(t *testing.T) {
 	assert.Equal(t, "on", headerMap["x-vsr-selected-reasoning"])
 	assert.Equal(t, "deepseek-v31", headerMap["x-vsr-selected-model"])
 	assert.Equal(t, "true", headerMap["x-vsr-injected-system-prompt"])
-	assert.Equal(t, "openai", headerMap["x-vsr-client-protocol"])
-	assert.Equal(t, "openai", headerMap["x-vsr-upstream-protocol"])
+	assert.NotContains(t, headerMap, "x-vsr-client-protocol", "same-protocol response omits protocol markers")
+	assert.NotContains(t, headerMap, "x-vsr-upstream-protocol")
 }
 
 func TestVSRHeadersNotAddedOnCacheHit(t *testing.T) {
@@ -2298,25 +2296,24 @@ func TestVSRHeadersNotAddedOnErrorResponse(t *testing.T) {
 	assert.NotNil(t, response)
 
 	// Decision/signal headers are NOT added on error responses, but the v0.4
-	// keystone headers (x-vsr-schema-version + x-vsr-response-path) and the
-	// translation-cell protocol markers (x-vsr-client-protocol,
-	// x-vsr-upstream-protocol) ride on every non-cache-hit response — success
-	// or error — so operators can identify the contract version, the response
-	// path, and which translation cell handled a failed request. The error
-	// here is an upstream-returned 500, so response-path is "upstream".
-	// See processor_res_header_mutation.go (issue #2203).
+	// keystone headers (x-vsr-schema-version + x-vsr-response-path) ride on
+	// every non-cache-hit response — success or error — so operators can always
+	// see the contract version and response path. The error here is an
+	// upstream-returned 500, so response-path is "upstream". The client/upstream
+	// protocol markers are omitted because this is a same-protocol response
+	// (#2206). See processor_res_header_mutation.go (issues #2203, #2206).
 	headerMutation := response.GetResponseHeaders().GetResponse().GetHeaderMutation()
-	require.NotNil(t, headerMutation, "HeaderMutation should carry keystone + protocol markers even on error")
+	require.NotNil(t, headerMutation, "HeaderMutation should carry keystone headers even on error")
 	setHeaders := headerMutation.GetSetHeaders()
-	assert.Len(t, setHeaders, 4, "Error response should have the 2 keystone + 2 protocol-marker headers")
+	assert.Len(t, setHeaders, 2, "Error response should have only the 2 keystone headers")
 	headerMap := make(map[string]string)
 	for _, header := range setHeaders {
 		headerMap[header.Header.Key] = string(header.Header.RawValue)
 	}
 	assert.Equal(t, "2", headerMap["x-vsr-schema-version"])
 	assert.Equal(t, "upstream", headerMap["x-vsr-response-path"])
-	assert.Equal(t, "openai", headerMap["x-vsr-client-protocol"])
-	assert.Equal(t, "openai", headerMap["x-vsr-upstream-protocol"])
+	assert.NotContains(t, headerMap, "x-vsr-client-protocol", "same-protocol response omits protocol markers")
+	assert.NotContains(t, headerMap, "x-vsr-upstream-protocol")
 	assert.NotContains(t, headerMap, "x-vsr-selected-category", "decision headers must not appear on error")
 	assert.NotContains(t, headerMap, "x-vsr-selected-model", "decision headers must not appear on error")
 }
@@ -2360,9 +2357,9 @@ func TestVSRHeadersPartialInformation(t *testing.T) {
 	setHeaders := headerMutation.GetSetHeaders()
 	// 2 keystone headers (x-vsr-schema-version + x-vsr-response-path, #2203) +
 	// 3 standard decision headers (excluding empty reasoning mode, but
-	// including injected-system-prompt) + 2 translation-cell protocol
-	// markers (x-vsr-client-protocol + x-vsr-upstream-protocol).
-	assert.Len(t, setHeaders, 7, "Should have 7 VSR headers (2 keystone + 3 decision + 2 protocol)")
+	// including injected-system-prompt). Protocol markers are omitted because
+	// this is a same-protocol response (#2206).
+	assert.Len(t, setHeaders, 5, "Should have 5 VSR headers (2 keystone + 3 decision)")
 
 	// Verify each header
 	headerMap := make(map[string]string)

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -14,14 +14,14 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
 
-// lossinessHeaderSizeLimit caps the encoded x-vsr-lossiness-warnings
+// lossinessHeaderSizeLimit caps the encoded x-vsr-protocol-warnings
 // header at a conservative size well under any HTTP/2 frame limit.
 // >50 warnings already represent a deeper translation regression worth
 // investigating via the structured log rather than the header.
 const lossinessHeaderSizeLimit = 4096
 
 // protocolDefault is the wire-shape token emitted in x-vsr-inbound-
-// protocol / x-vsr-outbound-protocol when the request context did not
+// protocol / x-vsr-upstream-protocol when the request context did not
 // resolve an explicit protocol. The router's default contract is
 // OpenAI-compatible.
 const protocolDefault = "openai"
@@ -112,7 +112,7 @@ func (builder *responseHeaderMutationBuilder) addJoined(key string, values []str
 }
 
 // addLossinessWarnings encodes ctx.IRExtensions.Warnings into the
-// x-vsr-lossiness-warnings header, increments the per-warning Prometheus
+// x-vsr-protocol-warnings header, increments the per-warning Prometheus
 // counter, and emits a structured log event per warning. Returns
 // without emitting anything when warnings is empty.
 //
@@ -163,7 +163,7 @@ func (builder *responseHeaderMutationBuilder) addLossinessWarnings(
 		sb.WriteString(trailer)
 	}
 
-	builder.addString(headers.VSRLossinessWarnings, sb.String())
+	builder.addString(headers.VSRProtocolWarnings, sb.String())
 }
 
 func formatLossinessEntry(w ir.Warning) string {
@@ -255,8 +255,8 @@ func buildResponseHeaderMutation(
 		// cache immediate-response builder. This function only handles upstream
 		// responses, so the path defaults to "upstream".
 		builder.addKeystone(ctx)
-		builder.addString(headers.VSRInboundProtocol, normalizeProtocol(ctx.ClientProtocol))
-		builder.addString(headers.VSROutboundProtocol, normalizeProtocol(ctx.APIFormat))
+		builder.addString(headers.VSRClientProtocol, normalizeProtocol(ctx.ClientProtocol))
+		builder.addString(headers.VSRUpstreamProtocol, normalizeProtocol(ctx.APIFormat))
 		if ctx.IRExtensions != nil {
 			builder.addLossinessWarnings(ctx, ctx.IRExtensions.Warnings)
 		}

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -75,13 +75,14 @@ func (builder *responseHeaderMutationBuilder) addKeystone(ctx *RequestContext) {
 
 // addProtocolMarkers emits the client/upstream protocol markers
 // (x-vsr-client-protocol, x-vsr-upstream-protocol). Per the v0.4 contract
-// (#2206) they ride only on cross-protocol responses — when the inbound client
+// (#2206) they ride on cross-protocol responses — when the inbound client
 // protocol differs from the outbound upstream protocol, i.e. a translation
-// actually happened. Same-protocol calls omit them to keep the contract lean.
+// actually happened — or when the request opted into debug headers (#2216).
+// Same-protocol non-debug calls omit them to keep the contract lean.
 func (builder *responseHeaderMutationBuilder) addProtocolMarkers(ctx *RequestContext) {
 	client := normalizeProtocol(ctx.ClientProtocol)
 	upstream := normalizeProtocol(ctx.APIFormat)
-	if client == upstream {
+	if client == upstream && !debugHeadersRequested(ctx) {
 		return
 	}
 	builder.addString(headers.VSRClientProtocol, client)

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation.go
@@ -73,6 +73,21 @@ func (builder *responseHeaderMutationBuilder) addKeystone(ctx *RequestContext) {
 	builder.addString(headers.VSRResponsePath, path)
 }
 
+// addProtocolMarkers emits the client/upstream protocol markers
+// (x-vsr-client-protocol, x-vsr-upstream-protocol). Per the v0.4 contract
+// (#2206) they ride only on cross-protocol responses — when the inbound client
+// protocol differs from the outbound upstream protocol, i.e. a translation
+// actually happened. Same-protocol calls omit them to keep the contract lean.
+func (builder *responseHeaderMutationBuilder) addProtocolMarkers(ctx *RequestContext) {
+	client := normalizeProtocol(ctx.ClientProtocol)
+	upstream := normalizeProtocol(ctx.APIFormat)
+	if client == upstream {
+		return
+	}
+	builder.addString(headers.VSRClientProtocol, client)
+	builder.addString(headers.VSRUpstreamProtocol, upstream)
+}
+
 func (builder *responseHeaderMutationBuilder) addFloat(key string, value float64) {
 	if value <= 0 {
 		return
@@ -242,21 +257,20 @@ func buildResponseHeaderMutation(
 
 	builder := newResponseHeaderMutationBuilder()
 
-	// Protocol markers and lossiness warnings ride on every response
-	// (success or 4xx/5xx) so clients can always tell which translation
-	// cell handled the call. Cache-hit responses are an exception: the
-	// IRExtensions.Warnings slice is per-request, so a cached response
-	// would attribute warnings from a different request — we skip the
-	// new headers entirely on cache hits and let the cached payload
+	// The keystone headers, protocol markers, and protocol warnings ride on
+	// every non-cache-hit response (success or 4xx/5xx). Cache-hit responses
+	// are an exception: the IRExtensions.Warnings slice is per-request, so a
+	// cached response would attribute warnings from a different request — we
+	// skip these headers entirely on cache hits and let the cached payload
 	// flow unchanged.
 	if !ctx.VSRCacheHit {
-		// Keystone headers ride on every non-cache-hit response (success or
-		// 4xx/5xx). Cache hits emit their own response-path: cache from the
-		// cache immediate-response builder. This function only handles upstream
-		// responses, so the path defaults to "upstream".
+		// Keystone headers (schema-version + response-path) ride on every
+		// non-cache-hit response. This function only handles upstream responses,
+		// so the path defaults to "upstream".
 		builder.addKeystone(ctx)
-		builder.addString(headers.VSRClientProtocol, normalizeProtocol(ctx.ClientProtocol))
-		builder.addString(headers.VSRUpstreamProtocol, normalizeProtocol(ctx.APIFormat))
+		// Client/upstream protocol markers ride only on cross-protocol responses
+		// (#2206); same-protocol calls omit them.
+		builder.addProtocolMarkers(ctx)
 		if ctx.IRExtensions != nil {
 			builder.addLossinessWarnings(ctx, ctx.IRExtensions.Warnings)
 		}

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -67,18 +67,22 @@ func TestBuildResponseHeaderMutation_EmitsZeroDecisionConfidence(t *testing.T) {
 	assert.Equal(t, "42", headerMap[headers.VSRContextTokenCount])
 }
 
-func TestBuildResponseHeaderMutation_ProtocolMarkersDefaultToOpenAI(t *testing.T) {
+func TestBuildResponseHeaderMutation_SameProtocolOmitsMarkers(t *testing.T) {
+	// Default ctx: client and upstream both normalize to "openai" — no
+	// cross-protocol translation, so the protocol markers are omitted (#2206).
 	ctx := &RequestContext{}
 
 	mutation := buildResponseHeaderMutation(ctx, true)
 	require.NotNil(t, mutation)
 
 	headerMap := mutationToMap(mutation.SetHeaders)
-	assert.Equal(t, "openai", headerMap[headers.VSRClientProtocol])
-	assert.Equal(t, "openai", headerMap[headers.VSRUpstreamProtocol])
+	assert.NotContains(t, headerMap, headers.VSRClientProtocol)
+	assert.NotContains(t, headerMap, headers.VSRUpstreamProtocol)
 }
 
-func TestBuildResponseHeaderMutation_ProtocolMarkersReflectAnthropicIngress(t *testing.T) {
+func TestBuildResponseHeaderMutation_SameProtocolAnthropicOmitsMarkers(t *testing.T) {
+	// Anthropic in and anthropic out is still same-protocol (no translation),
+	// so the markers are omitted (#2206).
 	ctx := &RequestContext{
 		ClientProtocol: config.ClientProtocolAnthropic,
 		APIFormat:      config.APIFormatAnthropic,
@@ -88,8 +92,24 @@ func TestBuildResponseHeaderMutation_ProtocolMarkersReflectAnthropicIngress(t *t
 	require.NotNil(t, mutation)
 
 	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.NotContains(t, headerMap, headers.VSRClientProtocol)
+	assert.NotContains(t, headerMap, headers.VSRUpstreamProtocol)
+}
+
+func TestBuildResponseHeaderMutation_CrossProtocolEmitsMarkers(t *testing.T) {
+	// Anthropic client translated to an OpenAI upstream — cross-protocol, so
+	// both markers are emitted (#2206).
+	ctx := &RequestContext{
+		ClientProtocol: config.ClientProtocolAnthropic,
+		APIFormat:      "openai",
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
 	assert.Equal(t, "anthropic", headerMap[headers.VSRClientProtocol])
-	assert.Equal(t, "anthropic", headerMap[headers.VSRUpstreamProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSRUpstreamProtocol])
 }
 
 func TestBuildResponseHeaderMutation_ProtocolMarkersEmittedOnFailedResponse(t *testing.T) {

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -74,8 +74,8 @@ func TestBuildResponseHeaderMutation_ProtocolMarkersDefaultToOpenAI(t *testing.T
 	require.NotNil(t, mutation)
 
 	headerMap := mutationToMap(mutation.SetHeaders)
-	assert.Equal(t, "openai", headerMap[headers.VSRInboundProtocol])
-	assert.Equal(t, "openai", headerMap[headers.VSROutboundProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSRClientProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSRUpstreamProtocol])
 }
 
 func TestBuildResponseHeaderMutation_ProtocolMarkersReflectAnthropicIngress(t *testing.T) {
@@ -88,8 +88,8 @@ func TestBuildResponseHeaderMutation_ProtocolMarkersReflectAnthropicIngress(t *t
 	require.NotNil(t, mutation)
 
 	headerMap := mutationToMap(mutation.SetHeaders)
-	assert.Equal(t, "anthropic", headerMap[headers.VSRInboundProtocol])
-	assert.Equal(t, "anthropic", headerMap[headers.VSROutboundProtocol])
+	assert.Equal(t, "anthropic", headerMap[headers.VSRClientProtocol])
+	assert.Equal(t, "anthropic", headerMap[headers.VSRUpstreamProtocol])
 }
 
 func TestBuildResponseHeaderMutation_ProtocolMarkersEmittedOnFailedResponse(t *testing.T) {
@@ -101,8 +101,8 @@ func TestBuildResponseHeaderMutation_ProtocolMarkersEmittedOnFailedResponse(t *t
 	require.NotNil(t, mutation)
 
 	headerMap := mutationToMap(mutation.SetHeaders)
-	assert.Equal(t, "anthropic", headerMap[headers.VSRInboundProtocol])
-	assert.Equal(t, "openai", headerMap[headers.VSROutboundProtocol])
+	assert.Equal(t, "anthropic", headerMap[headers.VSRClientProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSRUpstreamProtocol])
 
 	// Existing pre-PR3 markers stay gated by isSuccessful.
 	assert.NotContains(t, headerMap, headers.VSRSelectedCategory)
@@ -238,7 +238,7 @@ func TestAddLossinessWarnings_SingleEntry(t *testing.T) {
 	headerMap := mutationToMap(builder.setHeaders)
 	assert.Equal(t,
 		"lossy;top_k_drop_on_openai_backend;top_k",
-		headerMap[headers.VSRLossinessWarnings],
+		headerMap[headers.VSRProtocolWarnings],
 	)
 }
 
@@ -257,7 +257,7 @@ func TestAddLossinessWarnings_MultipleEntriesCommaSeparated(t *testing.T) {
 		"lossy;unsupported_block_type;messages[0].content[2],"+
 			"lossy;dropped;top_k,"+
 			"info;coerced_string;tool_choice.disable_parallel_tool_use",
-		headerMap[headers.VSRLossinessWarnings],
+		headerMap[headers.VSRProtocolWarnings],
 	)
 }
 
@@ -278,7 +278,7 @@ func TestAddLossinessWarnings_TruncationAppendsTrailer(t *testing.T) {
 	builder.addLossinessWarnings(ctx, warnings)
 
 	headerMap := mutationToMap(builder.setHeaders)
-	got := headerMap[headers.VSRLossinessWarnings]
+	got := headerMap[headers.VSRProtocolWarnings]
 
 	assert.NotEmpty(t, got)
 	// The encoded list lives close to 4 KB; the trailer itself adds a
@@ -300,7 +300,7 @@ func TestAddLossinessWarnings_SanitizesSeparatorsInFieldPaths(t *testing.T) {
 	headerMap := mutationToMap(builder.setHeaders)
 	assert.Equal(t,
 		"lossy;dropped%3Bextra%2Cbits;weird%3Bfield%2Cname",
-		headerMap[headers.VSRLossinessWarnings],
+		headerMap[headers.VSRProtocolWarnings],
 	)
 }
 
@@ -315,7 +315,7 @@ func TestAddLossinessWarnings_SanitizesCRLFInFieldPaths(t *testing.T) {
 	}})
 
 	headerMap := mutationToMap(builder.setHeaders)
-	got := headerMap[headers.VSRLossinessWarnings]
+	got := headerMap[headers.VSRProtocolWarnings]
 	assert.NotContains(t, got, "\r")
 	assert.NotContains(t, got, "\n")
 	assert.Contains(t, got, "%0D%0A")
@@ -340,11 +340,11 @@ func TestBuildResponseHeaderMutation_EmitsWarningsAlongsideStandardHeaders(t *te
 	require.NotNil(t, mutation)
 
 	headerMap := mutationToMap(mutation.SetHeaders)
-	assert.Equal(t, "anthropic", headerMap[headers.VSRInboundProtocol])
-	assert.Equal(t, "openai", headerMap[headers.VSROutboundProtocol])
+	assert.Equal(t, "anthropic", headerMap[headers.VSRClientProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSRUpstreamProtocol])
 	assert.Equal(t,
 		"lossy;top_k_drop_on_openai_backend;top_k",
-		headerMap[headers.VSRLossinessWarnings],
+		headerMap[headers.VSRProtocolWarnings],
 	)
 	assert.Equal(t, "math", headerMap[headers.VSRSelectedCategory])
 }

--- a/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_mutation_test.go
@@ -112,6 +112,21 @@ func TestBuildResponseHeaderMutation_CrossProtocolEmitsMarkers(t *testing.T) {
 	assert.Equal(t, "openai", headerMap[headers.VSRUpstreamProtocol])
 }
 
+func TestBuildResponseHeaderMutation_DebugHeaderEmitsMarkersOnSameProtocol(t *testing.T) {
+	// Same-protocol (both openai), but the request opted into debug headers via
+	// x-vsr-debug, so the markers are emitted anyway (#2216).
+	ctx := &RequestContext{
+		Headers: map[string]string{headers.VSRDebug: "true"},
+	}
+
+	mutation := buildResponseHeaderMutation(ctx, true)
+	require.NotNil(t, mutation)
+
+	headerMap := mutationToMap(mutation.SetHeaders)
+	assert.Equal(t, "openai", headerMap[headers.VSRClientProtocol])
+	assert.Equal(t, "openai", headerMap[headers.VSRUpstreamProtocol])
+}
+
 func TestBuildResponseHeaderMutation_ProtocolMarkersEmittedOnFailedResponse(t *testing.T) {
 	ctx := &RequestContext{
 		ClientProtocol: config.ClientProtocolAnthropic,

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -45,6 +45,12 @@ const (
 	// global.router.skip_processing.enabled is true. Value: "true" (case-insensitive).
 	// See https://github.com/vllm-project/semantic-router/issues/1808.
 	VSRSkipProcessing = "x-vsr-skip-processing"
+
+	// VSRDebug opts a request into verbose/debug response headers. Value: "true"
+	// (case-insensitive). When set, headers that the v0.4 contract otherwise
+	// omits or demotes to replay are emitted inline for that request — the
+	// debug/replay-mode trigger for the v0.4 header surface. See issue #2216.
+	VSRDebug = "x-vsr-debug"
 )
 
 // VSR Decision Tracking Headers

--- a/src/semantic-router/pkg/headers/headers.go
+++ b/src/semantic-router/pkg/headers/headers.go
@@ -241,21 +241,21 @@ const (
 // and 5xx) so clients can always tell which translation cell handled the
 // call and what was lost during translation.
 const (
-	// VSRInboundProtocol describes the wire format of the inbound request
+	// VSRClientProtocol describes the wire format of the inbound request
 	// as seen by the router (e.g. "openai", "anthropic"). Defaults to
 	// "openai" when no other protocol was detected.
-	VSRInboundProtocol = "x-vsr-inbound-protocol"
+	VSRClientProtocol = "x-vsr-client-protocol"
 
-	// VSROutboundProtocol describes the wire format of the outbound
+	// VSRUpstreamProtocol describes the wire format of the outbound
 	// request sent to the upstream backend. Defaults to "openai" when no
 	// explicit APIFormat was resolved.
-	VSROutboundProtocol = "x-vsr-outbound-protocol"
+	VSRUpstreamProtocol = "x-vsr-upstream-protocol"
 
-	// VSRLossinessWarnings carries a structured, comma-separated list
+	// VSRProtocolWarnings carries a structured, comma-separated list
 	// of translation observations emitted by the inbound parser during
 	// a lossy translation. Each entry is "severity;reason;field".
 	// Absent when no warnings were produced.
-	VSRLossinessWarnings = "x-vsr-lossiness-warnings"
+	VSRProtocolWarnings = "x-vsr-protocol-warnings"
 )
 
 // Legacy Security Headers (kept for backward compatibility with replay recorder)

--- a/src/semantic-router/pkg/headers/headers_test.go
+++ b/src/semantic-router/pkg/headers/headers_test.go
@@ -101,6 +101,7 @@ func TestVSRRoutingHeadersAreDocumented(t *testing.T) {
 	headers := []string{
 		XSessionID,
 		VSRSkipProcessing,
+		VSRDebug,
 		VSRClientProtocol,
 		VSRUpstreamProtocol,
 		VSRProtocolWarnings,

--- a/src/semantic-router/pkg/headers/headers_test.go
+++ b/src/semantic-router/pkg/headers/headers_test.go
@@ -101,9 +101,9 @@ func TestVSRRoutingHeadersAreDocumented(t *testing.T) {
 	headers := []string{
 		XSessionID,
 		VSRSkipProcessing,
-		VSRInboundProtocol,
-		VSROutboundProtocol,
-		VSRLossinessWarnings,
+		VSRClientProtocol,
+		VSRUpstreamProtocol,
+		VSRProtocolWarnings,
 		RouterReplayID,
 		VSRSelectedCategory,
 		VSRSelectedDecision,

--- a/src/semantic-router/pkg/ir/warning_reasons.go
+++ b/src/semantic-router/pkg/ir/warning_reasons.go
@@ -1,7 +1,7 @@
 package ir
 
 // WarningReason is the stable machine token surfaced in the
-// x-vsr-lossiness-warnings response header and in the
+// x-vsr-protocol-warnings response header and in the
 // vsr_translation_lossy_total metric "reason" label.
 //
 // Stability contract: existing reason tokens are part of the wire/metric

--- a/website/docs/troubleshooting/vsr-headers.md
+++ b/website/docs/troubleshooting/vsr-headers.md
@@ -23,9 +23,9 @@ Cache-hit responses can emit cache headers, but they do not re-run routing and t
 
 | Header | Description |
 | ------ | ----------- |
-| `x-vsr-inbound-protocol` | Inbound protocol shape seen by the router, for example `openai` or `anthropic`. |
-| `x-vsr-outbound-protocol` | Protocol shape sent to the selected upstream backend. |
-| `x-vsr-lossiness-warnings` | Comma-separated protocol translation warnings encoded as `severity;reason;field`. |
+| `x-vsr-client-protocol` | Inbound protocol shape seen by the router, for example `openai` or `anthropic`. |
+| `x-vsr-upstream-protocol` | Protocol shape sent to the selected upstream backend. |
+| `x-vsr-protocol-warnings` | Comma-separated protocol translation warnings encoded as `severity;reason;field`. |
 | `x-vsr-replay-id` | Opaque router replay record identifier for correlating a response with replay/Insights data. |
 
 ## Decision Headers
@@ -91,8 +91,8 @@ Projection scores and full projection traces are stored in router replay records
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/json
-x-vsr-inbound-protocol: openai
-x-vsr-outbound-protocol: openai
+x-vsr-client-protocol: openai
+x-vsr-upstream-protocol: openai
 x-vsr-selected-decision: critical_event_tool_session_route
 x-vsr-selected-confidence: 1.0000
 x-vsr-selected-model: anthropic/claude-opus-4.6

--- a/website/docs/troubleshooting/vsr-headers.md
+++ b/website/docs/troubleshooting/vsr-headers.md
@@ -4,7 +4,7 @@ This page documents the public `x-vsr-*` headers emitted by vLLM Semantic Router
 
 ## Emission Rules
 
-The router emits protocol headers on every non-cache-hit response. It emits routing decision and matched-signal headers only when all of the following are true:
+The router emits the keystone headers (`x-vsr-schema-version`, `x-vsr-response-path`) on every non-cache-hit response. The client/upstream protocol markers ride only on cross-protocol handling or when `x-vsr-debug` is set, and `x-vsr-protocol-warnings` only when warnings exist. It emits routing decision and matched-signal headers only when all of the following are true:
 
 1. The upstream response is successful (`2xx`).
 2. The response was not served from semantic cache.

--- a/website/docs/troubleshooting/vsr-headers.md
+++ b/website/docs/troubleshooting/vsr-headers.md
@@ -18,14 +18,15 @@ Cache-hit responses can emit cache headers, but they do not re-run routing and t
 | ------ | --------- | ----------- |
 | `x-session-id` | request | Stable client-provided session identifier for Chat Completions. `session_aware` uses this to reason about stay-vs-switch decisions across turns. |
 | `x-vsr-skip-processing` | request | Opts a request out of router processing when `global.router.skip_processing.enabled` is enabled. Use value `true`. |
+| `x-vsr-debug` | request | Opts the request into verbose/debug response headers — headers the contract otherwise omits or demotes to replay are emitted inline for that request. Use value `true`. |
 
 ## Protocol And Replay Headers
 
 | Header | Description |
 | ------ | ----------- |
-| `x-vsr-client-protocol` | Inbound protocol shape seen by the router, for example `openai` or `anthropic`. |
-| `x-vsr-upstream-protocol` | Protocol shape sent to the selected upstream backend. |
-| `x-vsr-protocol-warnings` | Comma-separated protocol translation warnings encoded as `severity;reason;field`. |
+| `x-vsr-client-protocol` | Inbound protocol shape seen by the router, for example `openai` or `anthropic`. Emitted only on cross-protocol handling (client protocol differs from upstream), or when `x-vsr-debug` is set. |
+| `x-vsr-upstream-protocol` | Protocol shape sent to the selected upstream backend. Emitted only on cross-protocol handling, or when `x-vsr-debug` is set. |
+| `x-vsr-protocol-warnings` | Comma-separated protocol translation warnings encoded as `severity;reason;field`. Emitted only when warnings exist. |
 | `x-vsr-replay-id` | Opaque router replay record identifier for correlating a response with replay/Insights data. |
 
 ## Decision Headers
@@ -91,7 +92,7 @@ Projection scores and full projection traces are stored in router replay records
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/json
-x-vsr-client-protocol: openai
+x-vsr-client-protocol: anthropic
 x-vsr-upstream-protocol: openai
 x-vsr-selected-decision: critical_event_tool_session_route
 x-vsr-selected-confidence: 1.0000


### PR DESCRIPTION
## Summary

Closes #2206. Closes #2216. Part of #2200 — v0.4 VSR response header contract.

Reworks the three protocol-translation response headers for v0.4, and introduces the shared debug-mode trigger they (and #2205) key off.

## What changed

**Rename** (no behavior change on its own):
- `x-vsr-inbound-protocol` → `x-vsr-client-protocol`
- `x-vsr-outbound-protocol` → `x-vsr-upstream-protocol`
- `x-vsr-lossiness-warnings` → `x-vsr-protocol-warnings` (already emits only when warnings exist)

**Conditional emission** (#2206): `client` / `upstream` markers now ride only on **cross-protocol** responses (client protocol ≠ upstream) — same-protocol calls omit them to keep the contract lean. Centralised in an `addProtocolMarkers` builder helper.

**Debug trigger** (#2216): a new `x-vsr-debug: true` request header opts a request into verbose headers. The shared `debugHeadersRequested(ctx)` predicate gates it; when set, the protocol markers emit even on same-protocol responses. #2205 (demote) will reuse the same predicate to re-surface its demoted intermediates.

> Scope note: the contract's "debug/replay mode" clause had no usable trigger today (replay defaults on, so replay-id can't gate). #2216 settled on the per-request `x-vsr-debug` header — lightest, request-scoped, no config-schema change.

## Files

- `pkg/headers/headers.go` — rename the 3 constants, add `VSRDebug`.
- `pkg/extproc/processor_res_header_mutation.go` — `addProtocolMarkers` (cross-protocol + debug gate).
- `pkg/extproc/debug_mode.go` (new) — shared `debugHeadersRequested` predicate.
- `pkg/extproc/debug_mode_test.go` (new), `processor_res_header_mutation_test.go`, `extproc_test.go` — tests.
- `pkg/ir/warning_reasons.go` — comment.
- `e2e/testcases/anthropic_messages_headers.go` — renamed header reads (cross-protocol case, markers still present).
- `website/docs/troubleshooting/vsr-headers.md` — document `x-vsr-debug` + conditional emission.

## Test plan

- [x] `go build` + `go vet` — pkg/headers, pkg/extproc, pkg/ir, pkg/utils/http, e2e
- [x] `go test ./pkg/headers/` (incl. headers-are-documented) and targeted `pkg/extproc` protocol/debug/header tests — pass
- [x] `gofmt` clean; rebased on latest main (post-keystone #2203)
- [ ] CI full gate (Dashboard Lint, test-and-build, e2e)
