### PR TITLE
[Dashboard] Fix duplicated health version prefix

### DIFF
--- a/dashboard/frontend/src/pages/DashboardPage.tsx
+++ b/dashboard/frontend/src/pages/DashboardPage.tsx
@@ -289,7 +289,7 @@ const DashboardPage: React.FC = () => {
                       {status.overall === 'not_running' ? 'Not Running' :
                        status.overall.charAt(0).toUpperCase() + status.overall.slice(1)}
                     </span>
-                    {status.version && <span className={styles.versionBadge}>v{status.version}</span>}
+                    {status.version && <span className={styles.versionBadge}>{status.version}</span>}
                     {status.deployment_type && status.deployment_type !== 'none' && (
                       <span className={styles.deployBadge}>{status.deployment_type}</span>
                     )}


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2220

## Purpose

- Fix the Dashboard System Health card showing a duplicated version prefix such as `vv0.1.0`.
- The backend `/api/status` response already returns a version string with the `v` prefix, for example `v0.1.0`.
- The Dashboard overview page was adding another hard-coded `v` before `status.version`, while the Status details page displayed the backend value directly.
- This change makes the Dashboard overview use the backend-provided version string as-is, keeping version display consistent across dashboard surfaces.
- Affected module(s): `Dashboard`

## Test Plan

- Run `npm run type-check` in `dashboard/frontend`.
- Run `make dashboard-check` from the repository root.
- Manually verify the Dashboard System Health card displays `v0.1.0` instead of `vv0.1.0` when the status API returns `v0.1.0`.
- Compare with the Status details page to confirm both surfaces display the same version value.

## Test Result

- `npm run type-check` passed.
- `make dashboard-check` passed.
- Dashboard frontend unit tests passed: `11` test files, `40` tests.
- Dashboard backend lint and `go mod tidy` checks passed through `dashboard-check`.
- Existing dashboard/wizmap Sass deprecation warnings and npm audit notices still appear during dashboard checks; they are pre-existing and not caused by this PR.
- No blockers identified.

Before:

<img width="1682" height="814" alt="image" src="https://github.com/user-attachments/assets/3e87ff34-756c-4a40-9e78-4b47dab2ba90" />

After:
<img width="1196" height="590" alt="screenshot-20260617-134728" src="https://github.com/user-attachments/assets/86087d63-6cff-4de1-ad06-3f16b1ddd3bd" />

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.