### PR TITLE
[Router] [Dashboard] Add showDetails for replay list summaries

### DIFF
--- a/dashboard/frontend/src/pages/InsightsPage.tsx
+++ b/dashboard/frontend/src/pages/InsightsPage.tsx
@@ -38,6 +38,7 @@ function buildReplayQueryString(filters: ReplayQueryFilters, pagination?: { limi
   if (pagination) {
     params.set('limit', String(pagination.limit))
     params.set('offset', String(pagination.offset))
+    params.set('showDetails', 'false')
   }
 
   const search = filters.searchTerm.trim()

--- a/src/semantic-router/pkg/extproc/router_replay_api.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api.go
@@ -29,9 +29,10 @@ type routerReplayFilters struct {
 }
 
 type routerReplayListQuery struct {
-	filters routerReplayFilters
-	limit   int
-	offset  int
+	filters     routerReplayFilters
+	limit       int
+	offset      int
+	showDetails bool
 }
 
 type routerReplayListResponse struct {
@@ -167,7 +168,8 @@ func (r *OpenAIRouter) findRouterReplayRecord(replayID string) (routerreplay.Rou
 
 func parseRouterReplayListQuery(rawQuery string) (routerReplayListQuery, error) {
 	query := routerReplayListQuery{
-		limit: routerReplayDefaultListLimit,
+		limit:       routerReplayDefaultListLimit,
+		showDetails: true,
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
@@ -196,6 +198,15 @@ func parseRouterReplayListQuery(rawQuery string) (routerReplayListQuery, error) 
 			return query, err
 		}
 		query.offset = offset
+	}
+
+	if values.Has("showDetails") {
+		raw := strings.TrimSpace(values.Get("showDetails"))
+		parsed, err := strconv.ParseBool(raw)
+		if err != nil {
+			return query, fmt.Errorf("showDetails must be a boolean")
+		}
+		query.showDetails = parsed
 	}
 
 	return query, nil
@@ -309,6 +320,13 @@ func buildRouterReplayListPayload(
 	}
 
 	page := records[offset:end]
+	if !query.showDetails {
+		summarized := make([]routerreplay.RoutingRecord, len(page))
+		for i := range page {
+			summarized[i] = routerreplay.ListSummaryRecord(page[i])
+		}
+		page = summarized
+	}
 	payload := routerReplayListResponse{
 		Object:  "router_replay.list",
 		Count:   len(page),

--- a/src/semantic-router/pkg/extproc/router_replay_api_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api_test.go
@@ -181,6 +181,45 @@ func TestHandleRouterReplayAPIListRejectsInvalidQuery(t *testing.T) {
 	}
 }
 
+func TestHandleRouterReplayAPIListSummarySkipsLargeBodies(t *testing.T) {
+	oversizedBody := strings.Repeat("x", 5*1024*1024)
+	router := newReplayAPITestRouterWithRecords(t, 1, oversizedBody)
+
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay?limit=1&showDetails=false")
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate replay list response")
+	}
+	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_OK {
+		t.Fatalf("expected OK status, got %v", got)
+	}
+
+	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
+	record := mustSingleReplayRecord(t, body)
+	if got := record["request_body"]; got != nil && got != "" {
+		t.Fatalf("expected empty request_body in summary list, got %#v", got)
+	}
+}
+
+func TestHandleRouterReplayAPIListRejectsInvalidShowDetails(t *testing.T) {
+	router, _ := newReplayAPITestRouter(t)
+
+	response := router.handleRouterReplayAPI("GET", "/v1/router_replay?limit=10&showDetails=maybe")
+	if response == nil || response.GetImmediateResponse() == nil {
+		t.Fatal("expected immediate error response")
+	}
+	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_BadRequest {
+		t.Fatalf("expected bad request status, got %v", got)
+	}
+	body := decodeJSONBody(t, response.GetImmediateResponse().Body)
+	errorBody, ok := body["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error payload, got %#v", body)
+	}
+	if got := errorBody["message"]; got != "showDetails must be a boolean" {
+		t.Fatalf("expected invalid showDetails message, got %#v", got)
+	}
+}
+
 func TestHandleRouterReplayAPIListReturnsPayloadTooLargeForOversizedPage(t *testing.T) {
 	oversizedBody := strings.Repeat("x", 5*1024*1024)
 	router := newReplayAPITestRouterWithRecords(t, 1, oversizedBody)

--- a/src/semantic-router/pkg/routerreplay/list_summary_record.go
+++ b/src/semantic-router/pkg/routerreplay/list_summary_record.go
@@ -1,0 +1,46 @@
+package routerreplay
+
+import "sort"
+
+// ListSummaryRecord returns a copy of rec with large captured fields cleared so
+// replay list responses are restricted in size.
+// Full payloads remain available via GET /v1/router_replay/{id}.
+func ListSummaryRecord(rec RoutingRecord) RoutingRecord {
+	out := rec
+	out.RequestBody = ""
+	out.ResponseBody = ""
+	out.Prompt = ""
+	out.ToolDefinitions = ""
+	out.ProjectionTrace = nil
+	out.ToolTrace = toolTraceNamesOnly(out.ToolTrace)
+	return out
+}
+
+func toolTraceNamesOnly(tt *ToolTrace) *ToolTrace {
+	if tt == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for _, n := range tt.ToolNames {
+		if n == "" {
+			continue
+		}
+		seen[n] = struct{}{}
+	}
+	for _, step := range tt.Steps {
+		if step.ToolName == "" {
+			continue
+		}
+		seen[step.ToolName] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return &ToolTrace{
+		Flow:      tt.Flow,
+		Stage:     tt.Stage,
+		ToolNames: names,
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/list_summary_record_test.go
+++ b/src/semantic-router/pkg/routerreplay/list_summary_record_test.go
@@ -1,0 +1,41 @@
+package routerreplay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/projectiontrace"
+)
+
+func TestListSummaryRecordStripsLargeFields(t *testing.T) {
+	huge := strings.Repeat("z", 1000)
+	rec := RoutingRecord{
+		ID:               "r1",
+		RequestBody:      huge,
+		ResponseBody:     huge,
+		Prompt:           huge,
+		ToolDefinitions:  huge,
+		ProjectionTrace:  &projectiontrace.Trace{SchemaVersion: projectiontrace.SchemaVersion},
+		ToolTrace:        &ToolTrace{Flow: "f", Steps: []ToolTraceStep{{ToolName: "t1", RawOutput: huge}}},
+		Decision:         "d1",
+		OriginalModel:    "m1",
+		SelectedModel:    "m2",
+		SignalConfidences: map[string]float64{"a": 0.5},
+	}
+	out := ListSummaryRecord(rec)
+	if out.RequestBody != "" || out.ResponseBody != "" || out.Prompt != "" || out.ToolDefinitions != "" {
+		t.Fatalf("expected large string fields cleared, got req=%d resp=%d", len(out.RequestBody), len(out.ResponseBody))
+	}
+	if out.ProjectionTrace != nil {
+		t.Fatalf("expected projection trace cleared")
+	}
+	if out.ToolTrace == nil || len(out.ToolTrace.Steps) != 0 {
+		t.Fatalf("expected tool trace steps stripped, got %#v", out.ToolTrace)
+	}
+	if len(out.ToolTrace.ToolNames) != 1 || out.ToolTrace.ToolNames[0] != "t1" {
+		t.Fatalf("expected tool name preserved, got %#v", out.ToolTrace.ToolNames)
+	}
+	if out.Decision != "d1" || out.OriginalModel != "m1" {
+		t.Fatalf("expected metadata preserved")
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/list_summary_record_test.go
+++ b/src/semantic-router/pkg/routerreplay/list_summary_record_test.go
@@ -10,16 +10,16 @@ import (
 func TestListSummaryRecordStripsLargeFields(t *testing.T) {
 	huge := strings.Repeat("z", 1000)
 	rec := RoutingRecord{
-		ID:               "r1",
-		RequestBody:      huge,
-		ResponseBody:     huge,
-		Prompt:           huge,
-		ToolDefinitions:  huge,
-		ProjectionTrace:  &projectiontrace.Trace{SchemaVersion: projectiontrace.SchemaVersion},
-		ToolTrace:        &ToolTrace{Flow: "f", Steps: []ToolTraceStep{{ToolName: "t1", RawOutput: huge}}},
-		Decision:         "d1",
-		OriginalModel:    "m1",
-		SelectedModel:    "m2",
+		ID:                "r1",
+		RequestBody:       huge,
+		ResponseBody:      huge,
+		Prompt:            huge,
+		ToolDefinitions:   huge,
+		ProjectionTrace:   &projectiontrace.Trace{SchemaVersion: projectiontrace.SchemaVersion},
+		ToolTrace:         &ToolTrace{Flow: "f", Steps: []ToolTraceStep{{ToolName: "t1", RawOutput: huge}}},
+		Decision:          "d1",
+		OriginalModel:     "m1",
+		SelectedModel:     "m2",
 		SignalConfidences: map[string]float64{"a": 0.5},
 	}
 	out := ListSummaryRecord(rec)

--- a/src/vllm-sr/README.md
+++ b/src/vllm-sr/README.md
@@ -404,11 +404,11 @@ routing:
 
 Router replay records are exposed through:
 
-- `GET /v1/router_replay?limit=20&offset=0&search=req-123&decision=foo&model=bar&cache_status=cached` - List recent records with pagination metadata. Default page size is `20`; larger `limit` values are capped at `100`.
+- `GET /v1/router_replay?limit=20&offset=0&search=req-123&decision=foo&model=bar&cache_status=cached&showDetails=false` - List recent records with pagination metadata. Default page size is `20`; larger `limit` values are capped at `100`. Use `showDetails=false` (default `true`) to omit large captured bodies and traces from each row so the list stays under the ext-proc response limit; fetch `GET /v1/router_replay/{id}` for full payloads.
 - `GET /v1/router_replay/aggregate?search=req-123&decision=foo&model=bar&cache_status=cached` - Return summary and chart aggregates for the filtered replay set.
 - `GET /v1/router_replay/{id}` - Fetch a single replay record.
 
-If a replay page would exceed the ext-proc gRPC message budget, the router returns `413 Payload Too Large` instead of failing the stream.
+If a replay page would exceed the ext-proc gRPC message budget, the router returns `413 Payload Too Large` instead of failing the stream. Prefer `showDetails=false` on list calls when rows may contain large request or response bodies.
 
 **Validation Rules:**
 


### PR DESCRIPTION
## Purpose

- Adds optional `showDetails` query parameter on `GET /v1/router_replay` (default `true`). When `showDetails=false`, list rows omit large captured fields via `routerreplay.ListSummaryRecord`, keeping list responses within the ext-proc gRPC size budget while full payloads remain on `GET /v1/router_replay/{id}`.
- Updates the Insights dashboard to request summary list rows (`showDetails=false`) for paginated list loads.
- Documents the list API in `src/vllm-sr/README.md`.

**Modules:** `Router`, `Dashboard`, `CLI` (docs only under `src/vllm-sr/README.md`).

Related to https://github.com/vllm-project/semantic-router/issues/2189 and https://github.com/vllm-project/semantic-router/issues/2157.

## Test Plan

- [x] `cd src/semantic-router && go test ./pkg/routerreplay/ -run ListSummary -count=1 -v`

## Test Result

- `TestListSummaryRecordStripsLargeFields` passed locally.
- `pkg/extproc` tests were not re-run here (linker/CGO environment); CI should cover extproc tests.


Made with [Cursor](https://cursor.com)