### PR TITLE
[Router] Don't treat a leading preview usage chunk as stream terminal

### DIFF
--- a/src/semantic-router/pkg/anthropic/sse_out.go
+++ b/src/semantic-router/pkg/anthropic/sse_out.go
@@ -151,14 +151,28 @@ func emitChunkEvents(
 	}
 
 	if len(chunk.Choices) == 0 {
-		// Usage-only chunk (no choices). If it carries usage and no prior
-		// chunk has already driven the terminal sequence, treat it as the
-		// terminal chunk so message_stop still fires — otherwise an Anthropic
-		// client would hang waiting for an end event. In the common path the
-		// finish_reason chunk already sent message_stop (caught by the
-		// MessageStopSent guard above), so this only fires when usage is the
-		// sole terminal signal. With no choices there is nothing else to emit.
-		if chunkHasUsage(chunk) {
+		// Usage-only chunk (no choices). Whether it is terminal depends on
+		// its position in the stream:
+		//
+		//   - AFTER content (state.contentStarted()): this is the stream's
+		//     final usage summary. Some OpenAI backends end the stream with
+		//     a usage-only chunk instead of a finish_reason chunk, so treat
+		//     it as terminal — otherwise an Anthropic client hangs waiting
+		//     for an end event. With no choices there is nothing else to emit.
+		//
+		//   - BEFORE any content (issue #2215): this is a gateway "preview"
+		//     usage chunk (e.g. {"choices":[],"usage":{"completion_tokens":4}})
+		//     sent at stream start. The real content and the real terminal
+		//     chunk (carrying the true usage, e.g. completion_tokens:252)
+		//     follow. Treating the preview as terminal would emit message_stop
+		//     after the first chunk, truncate the response, and record the
+		//     preview's token counts. Skip it and wait for the real terminal
+		//     signal.
+		//
+		// The common split-finish/usage path (finish_reason chunk first, then
+		// a trailing usage-only chunk) is handled by the MessageStopSent guard
+		// above, not here.
+		if chunkHasUsage(chunk) && state.contentStarted() {
 			out.Write(emitTerminalEvents(state, "", chunk.Usage, ext))
 			return out.Bytes(), true, nil
 		}
@@ -594,6 +608,17 @@ func formatAnthropicSSEEvent(eventName string, payload []byte) []byte {
 	buf.Write(payload)
 	buf.WriteString("\n\n")
 	return buf.Bytes()
+}
+
+// contentStarted reports whether the outbound emitter has opened at
+// least one Anthropic content block (text, thinking, or tool_use) for
+// this stream. NextBlockIndex is allocated monotonically as blocks open
+// and is never reset, so a non-zero value means real content has already
+// been emitted. Used to tell a stream-ending usage-only summary chunk
+// (after content) from a gateway "preview" usage chunk (before any
+// content; issue #2215).
+func (s *StreamState) contentStarted() bool {
+	return s.NextBlockIndex > 0
 }
 
 // chunkHasUsage returns true when an OpenAI chunk carries a non-zero

--- a/src/semantic-router/pkg/anthropic/sse_out_test.go
+++ b/src/semantic-router/pkg/anthropic/sse_out_test.go
@@ -408,6 +408,58 @@ func TestEmitAnthropicSSEChunk_UsageOnlyTerminalClosesThinkingAndToolBlocks(t *t
 	assert.Less(t, lastStop, msgStop, "all content_block_stop events must precede message_stop")
 }
 
+// TestEmitAnthropicSSEChunk_PreviewUsageChunkNotTerminal locks the fix for
+// issue #2215: a gateway may send a usage-only "preview" chunk (empty
+// choices, usage present, no finish_reason) as the FIRST chunk of a stream.
+// That preview usage is not the stream's final summary — real content and a
+// real terminal chunk (with the true usage) follow. The emitter must NOT
+// treat the preview chunk as terminal, or it fires message_stop after the
+// first chunk, truncates the response, and reports the preview's
+// completion_tokens (4) instead of the real total (252).
+//
+// This is the counterpart to UsageOnlyTerminal: there the usage-only chunk
+// trails content and IS terminal; here it precedes all content and is NOT.
+func TestEmitAnthropicSSEChunk_PreviewUsageChunkNotTerminal(t *testing.T) {
+	state := NewStreamState()
+
+	// Chunk 1: preview usage-only chunk at stream start — empty choices,
+	// usage present (small preview value), no finish_reason.
+	chunk1 := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":37494,"completion_tokens":4,"total_tokens":37498}}`,
+	)
+	out1, done1, err := EmitAnthropicSSEChunk(chunk1, state, nil, "claude-opus-4-6")
+	require.NoError(t, err)
+	assert.False(t, done1, "preview usage chunk must NOT end the stream")
+	assert.False(t, state.MessageStopSent, "preview usage chunk must not set MessageStopSent")
+	assert.Equal(t, 0, strings.Count(string(out1), "event: message_stop"), "preview usage chunk must not emit message_stop")
+
+	// Chunk 2: real content.
+	chunk2 := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hello world"}}]}`,
+	)
+	out2, done2, err := EmitAnthropicSSEChunk(chunk2, state, nil, "claude-opus-4-6")
+	require.NoError(t, err)
+	assert.False(t, done2, "content chunk must not end the stream")
+	assert.Contains(t, string(out2), `"text":"hello world"`, "content after the preview chunk must reach the client")
+
+	// Chunk 3: real terminal chunk — finish_reason plus the true usage.
+	chunk3 := buildOpenAISSE(
+		`{"id":"c","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":37494,"completion_tokens":252,"total_tokens":37746}}`,
+	)
+	out3, done3, err := EmitAnthropicSSEChunk(chunk3, state, nil, "claude-opus-4-6")
+	require.NoError(t, err)
+	assert.True(t, done3, "the real finish_reason chunk must end the stream")
+	body3 := string(out3)
+	assert.Equal(t, 1, strings.Count(body3, "event: message_stop"), "exactly one message_stop, on the real terminal chunk")
+	// The terminal usage must come from the real chunk (252), not the preview (4).
+	assert.Contains(t, body3, `"output_tokens":252`, "message_delta usage must reflect the real total, not the preview")
+	assert.NotContains(t, body3, `"output_tokens":4`, "preview completion_tokens must not be reported")
+
+	// Across the whole stream: exactly one message_stop, after content.
+	combined := string(out1) + string(out2) + body3
+	assert.Equal(t, 1, strings.Count(combined, "event: message_stop"), "exactly one message_stop total")
+}
+
 // TestEmitAnthropicSSEChunk_ErrorPath covers the IsError emitter branch:
 // an error event followed by terminal state flags and no second emission.
 func TestEmitAnthropicSSEChunk_ErrorPath(t *testing.T) {

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_test.go
@@ -159,6 +159,59 @@ func TestHandleAnthropicClientStreamingResponseBody_UnparsableChunk(t *testing.T
 	assert.Equal(t, []byte{}, mutation.GetBody(), "unparsable input must yield empty (not nil) mutation body")
 }
 
+// TestHandleAnthropicClientStreamingResponseBody_PreviewUsageChunk is the
+// end-to-end regression test for issue #2215. An upstream OpenAI gateway
+// sends a usage-only "preview" chunk first (completion_tokens:4, empty
+// choices), then content, then the real terminal chunk
+// (completion_tokens:252), then [DONE].
+//
+// Before the fix the emitter treated the preview chunk as terminal: it
+// fired message_stop after chunk 1, the handler called
+// finalizeStreamingResponse early, the StreamingComplete idempotency guard
+// then froze the recorded usage at the preview value (4), and all later
+// content was dropped from the cache/replay. After the fix finalization
+// happens only at [DONE], so the recorded usage is the real total (252) and
+// the content is preserved.
+func TestHandleAnthropicClientStreamingResponseBody_PreviewUsageChunk(t *testing.T) {
+	router := newTestRouter()
+	ctx := newAnthropicStreamCtx(anthropic.NewStreamState())
+	// Issue #2215 config: OpenAI upstream, Anthropic client. OpenAI bytes
+	// pass straight through translateUpstreamToOpenAI to the emitter.
+	ctx.APIFormat = config.APIFormatOpenAI
+	ctx.RequestModel = "claude-opus-4-6"
+
+	feed := func(chunk string) string {
+		resp := router.handleAnthropicClientStreamingResponseBody([]byte(chunk), ctx)
+		require.NotNil(t, resp)
+		return string(resp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	}
+
+	// Chunk 1: preview usage-only chunk (the trigger).
+	out1 := feed(`data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":37494,"completion_tokens":4,"total_tokens":37498}}` + "\n\n")
+	assert.NotContains(t, out1, "event: message_stop", "preview usage chunk must not emit a premature message_stop")
+	assert.False(t, ctx.StreamingComplete, "preview usage chunk must not finalize the stream")
+
+	// Chunk 2 + 3: real content.
+	feed(`data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hello "}}]}` + "\n\n")
+	feed(`data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"world"}}]}` + "\n\n")
+	assert.False(t, ctx.StreamingComplete, "stream must stay open while content flows")
+
+	// Chunk 4: real terminal chunk with finish_reason and the true usage.
+	out4 := feed(`data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":37494,"completion_tokens":252,"total_tokens":37746}}` + "\n\n")
+	assert.Contains(t, out4, "event: message_stop", "the real terminal chunk must emit message_stop")
+
+	// Chunk 5: [DONE] marker.
+	feed("data: [DONE]\n\n")
+
+	require.True(t, ctx.StreamingComplete, "stream must be finalized after [DONE]")
+	assert.Equal(t, "hello world", ctx.StreamingContent, "all content after the preview chunk must be preserved")
+
+	// The recorded usage must be the real total (252), not the preview (4).
+	usage := extractStreamingUsage(ctx)
+	assert.Equal(t, int64(252), usage.CompletionTokens, "recorded completion_tokens must be the real total, not the preview value")
+	assert.Equal(t, int64(37746), usage.TotalTokens, "recorded total_tokens must come from the real terminal chunk")
+}
+
 // TestHandleResponseBody_StreamingDispatchMatrix locks the four-cell
 // streaming dispatch in handleResponseBody:
 //


### PR DESCRIPTION
## Summary

Fixes #2215.

When an upstream OpenAI-format gateway sends a usage-only "preview" chunk
(`{"choices":[],"usage":{...}}`, no `finish_reason`) as the first chunk of a
stream, the Anthropic SSE emitter mistook it for the stream terminal. For an
Anthropic client (`/v1/messages` + `api_format: openai`) this caused:

- premature `message_stop` after the first chunk → truncated response;
- wrong `completion_tokens` recorded (the preview value, e.g. 4, instead of the
  real total, e.g. 252) — the early `finalizeStreamingResponse` froze the usage
  behind the `StreamingComplete` idempotency guard.

## Fix

`emitChunkEvents` now treats a usage-only chunk as terminal only once content
has started streaming (`StreamState.contentStarted()` → `NextBlockIndex > 0`):

- usage-only **after** content → final summary → terminal (unchanged; keeps the
  `UsageOnlyTerminal` and split-finish/usage paths working);
- usage-only **before** any content → preview → skipped; the real terminal chunk
  (`finish_reason` + true usage) drives `message_stop` and finalization.

Scope is limited to a *leading* preview chunk, matching the issue. The OpenAI
client path was never affected (it keys off `data: [DONE]`).

## Test Plan

- `go test ./pkg/anthropic/ ./pkg/extproc/` — green.
- New unit test (`TestEmitAnthropicSSEChunk_PreviewUsageChunkNotTerminal`):
  preview chunk does not end the stream; final `message_delta` reports 252, not 4.
- New e2e processor test (`TestHandleAnthropicClientStreamingResponseBody_PreviewUsageChunk`):
  through the real Anthropic-client streaming handler — `StreamingComplete` fires
  only after `[DONE]`, recorded `completion_tokens == 252`, content preserved.
- Existing `UsageOnlyTerminal` / `SplitFinishReasonAndUsage` paths unchanged.