### PR TITLE
[Router] Fix panel-NLI grounding scorer for fusion + DRACO eval harness

### DIFF
--- a/bench/grounded_fusion/.gitignore
+++ b/bench/grounded_fusion/.gitignore
@@ -1,0 +1,13 @@
+# Run artifacts — these embed absolute local paths / machine-specific config and
+# must never be committed. Only source (.py/.sh/.md/testdata) is tracked.
+results/
+results_sweep/
+__pycache__/
+*.pyc
+
+# Generated router configs (created by make_configs.py; contain local endpoints)
+config-fusion-on.yaml
+config-fusion-off.yaml
+config-fusion-on-*.yaml
+config-fusion-off-*.yaml
+router-runtime.json

--- a/bench/grounded_fusion/FINDINGS.md
+++ b/bench/grounded_fusion/FINDINGS.md
@@ -1,0 +1,134 @@
+# Grounding-Aware Fusion — Evaluation Findings
+
+A first end-to-end evaluation of the Fusion looper's **grounding-aware synthesis**
+stage against the [DRACO](https://huggingface.co/datasets/perplexity-ai/draco)
+rubric-graded deep-research benchmark, run fully locally (Ollama, Apple Silicon).
+This documents the design, two scorer bugs it surfaced and fixed, the headline
+result, and how to improve the experiment next.
+
+## TL;DR
+
+- **The panel-NLI grounding scorer was broken** and silently returned ~0.500 for
+  every response. Two root causes, both fixed in this change:
+  1. `classify_nli` reconstructed the 3-class distribution from the argmax
+     confidence, so any "neutral" prediction forced `entailment == contradiction`
+     → the consistency score collapsed to exactly 0.5.
+  2. The NLI input was a single `premise [SEP] hypothesis` string truncated to 512
+     tokens; panel answers run 600–1000+ tokens, so the hypothesis was truncated
+     away entirely → the model saw half of one answer → predicted neutral.
+- **After the fix the scorer discriminates** (live scores spread 0.52–0.69;
+  Level-1 Spearman vs panel rubric quality **+0.21**).
+- **But the *intervention* — dropping low-consistency panel responses before
+  synthesis — does not help and significantly hurts on hard factual questions.**
+  On the slice where grounding actually drops a response, the final-answer DRACO
+  score drops with a bootstrap CI excluding 0, and the harm grows monotonically as
+  more responses are dropped.
+- **Mechanism:** cross-model consistency drops the *dissenter*, but on
+  graduate-level questions the dissenter (often the strongest model) carries the
+  correct minority view. **Consistency ≠ correctness.**
+
+## What was measured
+
+Two levels (most eval efforts only do level 2 and then can't explain a null/noisy
+result):
+
+- **Level 1 — intrinsic:** is the scorer any good? Grade each panel response with
+  the DRACO rubric and correlate (Spearman) the grounding score with panel-response
+  quality.
+- **Level 2 — extrinsic:** does the *final answer* improve? Same DRACO items
+  through plain Fusion (`grounding.enabled: false`) vs grounding-aware Fusion,
+  both graded by the DRACO rubric; paired bootstrap CIs on the deltas, reported
+  overall + per-domain + on the **contested slice** (items where grounding actually
+  dropped ≥1 response — where it can do anything at all).
+
+DRACO grades a free-text answer against a weighted rubric (positive criteria reward
+correctness/coverage; negative criteria down to −500 penalize confident-wrong /
+unsafe / badly-sourced claims). Grounding ran in **`panel` mode** (cross-model NLI)
+because DRACO ships no source documents, so `context`/`hybrid` modes have nothing
+to score against.
+
+## Setup
+
+- Domains: **Medicine + Law** (12 items) — where the −100…−500 penalties live and
+  models most disagree.
+- Panel: `qwen3:8b`, `llama3.1:8b`, `gemma3:12b` (cross-family for NLI diversity).
+  Judge + rubric grader: `qwen3:14b`. All local via Ollama behind a no-think proxy.
+- Threshold sweep on `grounding.min_score`: **0.34 / 0.55 / 0.60** (`min_keep: 1`).
+- MVP two-config A/B at `temperature: 0` (see Limitations re: per-arm panel
+  regeneration).
+
+## Headline result
+
+Δ = grounding-on − off on the final-answer normalized DRACO score (negative = worse):
+
+| min_score | contested items | overall Δnorm | **contested Δnorm** | contested Δneg-penalty |
+|-----------|-----------------|---------------|---------------------|------------------------|
+| 0.34      | 0 / 12          | −0.035 (ns)   | — (nothing dropped) | —                      |
+| 0.55      | 4 / 11          | −0.058 (ns)   | **−0.113 (sig)**    | −2.50 (ns)             |
+| 0.60      | 9 / 12          | −0.090 (ns)   | **−0.132 (sig)**    | +4.44 (ns)             |
+
+- Monotonic: the more grounding drops, the more it hurts overall quality.
+- On the contested slice the harm is statistically significant (CI excludes 0) at
+  both 0.55 and 0.60. At 0.60, 8 of 9 contested items got worse.
+- The dropped-model frequency at 0.60 was `gemma3:12b` 6×, `qwen3:8b` 5×,
+  `llama3.1:8b` 4× — the largest model is dropped most, consistent with
+  consistency filtering removing the strongest dissenter.
+- The intended benefit (cutting the negative-criteria penalty) was **not robustly
+  realized** (neg-penalty deltas not significant, mixed sign).
+
+## Interpretation
+
+The scorer is now sound, but the **policy of hard-dropping** the least mutually
+consistent response is the wrong lever for hard factual QA. Three smaller models
+can be confidently wrong *together* (high mutual entailment) while the model that
+disagrees is right; consistency filtering deletes exactly that signal. With
+`min_keep: 1`, high thresholds collapse synthesis onto the single most-agreed
+response — the most consensus-biased answer.
+
+## Limitations (read before trusting the magnitudes)
+
+- **Small N** (12 items; contested 4–9). Overall deltas are not significant; only
+  the contested slices are.
+- **MVP two-config design** regenerates the panel per arm, so deltas carry
+  sampling noise (one off-arm answer scored worse than its on-arm counterpart).
+  The cached-panel paired design (below) removes this.
+- **Weak panel** (8–12B local models). The "dissenter is right" effect may differ
+  with stronger / more diverse models or a larger panel.
+- **`panel` mode only.** The `context`-mode faithfulness lever (hallucination
+  detector vs real RAG sources) is untested here and is the mode most likely to
+  help — DRACO just can't exercise it (no source docs).
+
+## How to improve the experiment (next experiments)
+
+1. **Cached-panel paired design** — generate the panel **once** per item, then
+   replay judge+synthesis for each lever/threshold so all cells share identical
+   panel outputs. Biggest single noise reducer; turns the sweep into a clean paired
+   test. Needs the looper to support replaying a fixed panel (or a harness-side
+   refactor that separates panel generation from synthesis).
+2. **Ablate the two levers** — grounding both *filters* the panel and *annotates*
+   the judge prompt. Run `off` / `notes-only` / `filter-only` / `both`. The sweep
+   conflated them; notes-only (information without deletion) may help while
+   filtering hurts.
+3. **Down-weight instead of drop** — keep all responses and pass grounding scores
+   to the judge as soft weights/annotations rather than removing responses. Test
+   whether soft beats hard-drop.
+4. **Larger N / factuality subset** — 12 items is underpowered. Run the full DRACO
+   set (or a factuality-weighted subset) for tighter CIs.
+5. **Test `context` mode on a RAG benchmark** with real source docs — the lever
+   this dataset cannot exercise, and the one with a genuine faithfulness signal.
+6. **Stronger / larger / more diverse panel** — re-test the "dissenter is right"
+   effect with stronger models and panel size > 3.
+7. **Grade dropped responses too (Level-1 completeness)** — emit dropped responses'
+   content in the fusion trace so Level-1 can correlate grounding score with quality
+   across the *full* panel, not just the kept responses.
+8. **Per-section breakdown** — report which rubric sections (Factual Accuracy vs
+   Citation Quality) move, to localize where grounding helps/hurts. (Citation
+   Quality is confounded: vSR Fusion has no server-side web tools, so both arms
+   cite from parametric memory.)
+
+## Reproducing
+
+See `README.md`. The two scorer fixes are in `candle-binding/src/ffi/classify.rs`
+(real softmax) and `src/semantic-router/pkg/looper/grounding.go` (sentence-level
+NLI). The harness writes per-sample JSONL + summary JSON per arm; `compare.py`
+produces the paired A/B report. Run artifacts are git-ignored.

--- a/bench/grounded_fusion/README.md
+++ b/bench/grounded_fusion/README.md
@@ -1,0 +1,109 @@
+# Grounding-Aware Fusion Benchmark (DRACO)
+
+A/B evaluation of the Fusion looper's **grounding-aware synthesis** stage against
+the [DRACO](https://huggingface.co/datasets/perplexity-ai/draco) rubric-graded
+deep-research benchmark. Runs fully locally on macOS (Apple Silicon) with Ollama.
+
+## What it measures
+
+DRACO grades a free-text answer against a **weighted rubric** (positive criteria
+reward correctness/coverage; negative criteria, down to −500, penalize
+confident-but-wrong / unsafe / badly-sourced claims). We score two levels:
+
+- **Level 2 (extrinsic)** — does grounding-aware fusion beat plain fusion on the
+  final answer? Headline: the **negative-criteria penalty** should drop (grounding
+  keeps ungrounded panel responses out of synthesis). `compare.py` reports paired
+  bootstrap CIs, overall + per-domain + "contested slice" (items where grounding
+  actually dropped a response).
+- **Level 1 (intrinsic)** — is the grounding *scorer* any good? `--grade-panel`
+  grades each panel response too, and `evaluate.py` reports the Spearman
+  correlation between the cross-model NLI grounding score and panel-response
+  quality, plus discard precision/recall.
+
+## Architecture (local stack)
+
+```
+harness → Envoy(:8801) → router extprocofr_(:50051) → Fusion looper
+                                                     ├─ panel/judge → no-think proxy(:11435) → Ollama(:11434)
+                                                     └─ grounding: candle NLI (models/mom-halugate-explainer)
+grader (DRACO rubric) ─────────────────────────────→ no-think proxy(:11435) → Ollama
+```
+
+- **Panel** (cross-family diversity → real NLI signal): `qwen3:8b`, `llama3.1:8b`,
+  `gemma3:12b`. **Fusion judge**: `qwen3:14b`. **Rubric grader**: `qwen3:14b`/`32b`.
+- **No-think proxy** (`ollama_proxy.py`): Ollama's OpenAI endpoint ignores the
+  `think` flag, so Qwen3 burns the whole token budget on reasoning (5+ min/req,
+  truncated answers). The proxy forwards to Ollama's *native* `/api/chat` with
+  `think:false` → ~30 s/req, complete answers. Point the looper + grader at it.
+- **Grounding runs in `panel` mode** (cross-model NLI) because DRACO ships no
+  source documents (so `context`/`hybrid` modes have nothing to score against).
+
+## Setup
+
+```bash
+# 1. Models (once)
+brew install ollama && brew services start ollama
+ollama pull qwen3:8b && ollama pull llama3.1:8b && ollama pull gemma3:12b && ollama pull qwen3:14b
+
+# 2. Python env (once)
+python3 -m venv .venv-bench
+.venv-bench/bin/pip install openai requests numpy scipy tqdm pandas pyyaml pytest \
+  --trusted-host pypi.org --trusted-host files.pythonhosted.org
+
+# 3. Generate the two router configs (grounding on/off)
+.venv-bench/bin/python -m bench.grounded_fusion.make_configs
+```
+
+## Run
+
+```bash
+# Start supporting services (each in its own shell / backgrounded):
+.venv-bench/bin/python -m bench.grounded_fusion.ollama_proxy --port 11435
+tools/bin/func-e run --config-path /tmp/envoy-bench.yaml      # see run_ab.sh for envoy prep
+
+# Full A/B (brings the router up per arm, runs both, compares):
+bench/grounded_fusion/run_ab.sh --max-samples 100 --grade-panel
+
+# Or a quick pilot (recommended first):
+bench/grounded_fusion/run_ab.sh --domains Medicine,Law --max-samples 8 --grade-panel
+```
+
+`run_ab.sh` runs arm `on` against `config-fusion-on.yaml`, restarts the router with
+`config-fusion-off.yaml`, runs arm `off`, then `compare.py`. Results land in
+`results/` (`samples_{on,off}.jsonl`, `summary_{on,off}.json`, `ab_report.json`).
+
+### Runtime
+~30 s per fusion request + rubric grading. Full 100×2 arms + panel grading is an
+overnight-scale job; start with a pilot. Runs are resumable (`--resume`).
+
+## Gotchas (learned the hard way)
+
+- **Silent grounding no-op:** `panel`-mode NLI only fires if
+  `hallucination_mitigation` is enabled *with* an NLI model — here it's wired via
+  the `explainer` block (`models/mom-halugate-explainer`). `evaluate.py
+  --assert-grounding` aborts if the `on` arm lacks a grounding trace, so you never
+  measure plain fusion twice.
+- **Don't base configs on `config/config.yaml` naively** — it enables milvus/redis/
+  postgres/llama_stack stores and embedding-backed signals that fatal locally.
+  `make_configs.py` disables them and strips routing to a single sentinel-keyword
+  fusion decision.
+- **Qwen3 thinking** ruins latency and truncates answers via the OpenAI endpoint —
+  always go through `ollama_proxy.py`.
+
+## Files
+
+| File | Role |
+|------|------|
+| `datasets.py` | DRACO loader (parses the weighted rubric) |
+| `rubric_judge.py` | DRACO-style grader: per-criterion LLM check → weighted score |
+| `runner.py` | drives the router fusion endpoint, parses the `fusion` trace |
+| `metrics.py` | Spearman, discard precision/recall, paired bootstrap CI |
+| `evaluate.py` | one-arm orchestrator (run → grade → Level-1/2 summary) |
+| `compare.py` | paired A/B report (on − off) with CIs |
+| `make_configs.py` | generates the two router configs |
+| `ollama_proxy.py` | OpenAI→Ollama-native shim that disables Qwen3 thinking |
+| `run_ab.sh` | end-to-end A/B driver |
+| `run_sweep.sh` | `min_score` threshold-sweep driver (off arm + on arms, resumable) |
+| `sanitize_results.py` | strip local paths from result JSON before sharing |
+| `test_grounded_fusion.py` | unit tests (loader + grader math, no model needed) |
+| `FINDINGS.md` | evaluation write-up: bugs fixed, results, next experiments |

--- a/bench/grounded_fusion/compare.py
+++ b/bench/grounded_fusion/compare.py
@@ -1,0 +1,141 @@
+"""Paired A/B comparison of two grounded-fusion arms (grounding on vs off).
+
+Reads ``samples_on.jsonl`` and ``samples_off.jsonl`` (written by evaluate.py),
+joins by sample id, and reports the headline deltas with paired bootstrap CIs:
+
+- mean normalized DRACO score (on - off)
+- mean negative-criteria penalty (on - off)   <- the headline: should rise toward 0
+- per-domain and "contested slice" breakdowns (items where grounding dropped a
+  panel response in the on arm -- where it can actually do something)
+
+Example:
+    .venv-bench/bin/python -m bench.grounded_fusion.compare \
+        --results-dir bench/grounded_fusion/results
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .metrics import paired_bootstrap_ci
+
+
+def _load(path: Path) -> dict[str, dict]:
+    if not path.exists():
+        raise SystemExit(f"missing {path} -- run evaluate.py for that arm first")
+    out = {}
+    for line in path.read_text().splitlines():
+        if line.strip():
+            r = json.loads(line)
+            out[r["id"]] = r
+    return out
+
+
+def _contested(on: dict) -> bool:
+    """An item is 'contested' if grounding dropped >=1 panel response in the on arm."""
+    return any(p.get("dropped") for p in on.get("panel", []))
+
+
+def _delta_block(pairs: list[tuple], key: str) -> dict:
+    deltas = [o["final"][key] - f["final"][key] for o, f in pairs]
+    mean, lo, hi = paired_bootstrap_ci(deltas)
+    return {
+        "n": len(pairs),
+        "mean_delta": mean,
+        "ci95": [lo, hi],
+        "significant": (lo > 0) or (hi < 0),
+    }
+
+
+def compare(results_dir: str) -> dict:
+    d = Path(results_dir)
+    on = _load(d / "samples_on.jsonl")
+    off = _load(d / "samples_off.jsonl")
+    ids = [
+        i for i in on if i in off and not on[i].get("error") and not off[i].get("error")
+    ]
+    pairs = [(on[i], off[i]) for i in ids]
+    if not pairs:
+        raise SystemExit("no overlapping successful samples between arms")
+
+    contested = [(o, f) for o, f in pairs if _contested(o)]
+    by_dom: dict[str, list[tuple]] = {}
+    for o, f in pairs:
+        by_dom.setdefault(o["domain"], []).append((o, f))
+
+    report = {
+        "n_paired": len(pairs),
+        "n_contested": len(contested),
+        "overall": {
+            "normalized": _delta_block(pairs, "normalized"),
+            "negative_penalty": _delta_block(pairs, "negative_penalty"),
+        },
+        "contested_slice": {
+            "normalized": _delta_block(contested, "normalized") if contested else None,
+            "negative_penalty": (
+                _delta_block(contested, "negative_penalty") if contested else None
+            ),
+        },
+        "per_domain_normalized_delta": {
+            dom: _delta_block(ps, "normalized")["mean_delta"]
+            for dom, ps in by_dom.items()
+        },
+        "level1_from_on_arm": _read_level1(d / "summary_on.json"),
+    }
+    return report
+
+
+def _read_level1(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text()).get("summary", {}).get("level1", {})
+
+
+def _print(report: dict) -> None:
+    print("\n" + "=" * 64)
+    print("GROUNDING-AWARE FUSION: A/B (on - off)")
+    print("=" * 64)
+    print(
+        f"paired samples: {report['n_paired']} | contested (grounding dropped >=1): {report['n_contested']}"
+    )
+    for scope in ("overall", "contested_slice"):
+        print(f"\n[{scope}]")
+        for metric in ("normalized", "negative_penalty"):
+            b = report[scope].get(metric)
+            if not b:
+                print(f"  {metric}: (no items)")
+                continue
+            sig = "SIGNIFICANT" if b["significant"] else "ns"
+            print(
+                f"  {metric:18} delta={b['mean_delta']:+.4f}  ci95=[{b['ci95'][0]:+.4f},{b['ci95'][1]:+.4f}]  {sig}"
+            )
+    print("\n[per-domain normalized delta]")
+    for dom, dv in sorted(
+        report["per_domain_normalized_delta"].items(), key=lambda kv: kv[1]
+    ):
+        print(f"  {dom:28} {dv:+.4f}")
+    l1 = report.get("level1_from_on_arm") or {}
+    if l1.get("n_panel_graded"):
+        print(
+            f"\n[level-1 scorer validity]  spearman(score,quality)={l1.get('spearman_score_vs_quality')}"
+            f"  discard_precision={l1.get('discard_precision')}  (n={l1['n_panel_graded']})"
+        )
+    print("=" * 64)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="A/B compare grounded-fusion arms")
+    ap.add_argument("--results-dir", default="bench/grounded_fusion/results")
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+    report = compare(args.results_dir)
+    _print(report)
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nwrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/grounded_fusion/datasets.py
+++ b/bench/grounded_fusion/datasets.py
@@ -1,0 +1,167 @@
+"""DRACO dataset loader for the grounding-aware fusion benchmark.
+
+DRACO (perplexity-ai/draco) is a *rubric-graded* deep-research benchmark, not
+reference-answer QA. Each item has:
+
+- ``problem``  -- a long, open-ended expert prompt.
+- ``answer``   -- a JSON **scoring rubric** (NOT a reference answer): a list of
+  sections, each with weighted criteria. Positive weights reward satisfied
+  requirements; negative weights penalize confident-but-wrong / unsafe / badly
+  sourced claims. Score = sum(weight for each satisfied criterion).
+- ``domain``   -- topical domain (Medicine, Law, Finance, ...).
+
+This module parses the HuggingFace datasets-server JSON export
+(``{"rows": [{"row": {...}}, ...]}``) into typed objects the harness scores
+against. It does no network I/O -- point it at a local file.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class DracoCriterion:
+    """A single weighted rubric requirement."""
+
+    id: str
+    weight: float
+    requirement: str
+    section_id: str
+    section_title: str
+
+    @property
+    def is_negative(self) -> bool:
+        """Negative-weight criteria penalize bad behavior (the confident-wrong axis)."""
+        return self.weight < 0
+
+
+@dataclass
+class DracoSection:
+    """A rubric section (e.g. 'Factual Accuracy', 'Citation Quality')."""
+
+    id: str
+    title: str
+    criteria: list[DracoCriterion]
+
+
+@dataclass
+class DracoRubric:
+    """The full weighted rubric for one DRACO problem."""
+
+    id: str
+    sections: list[DracoSection]
+
+    @property
+    def criteria(self) -> list[DracoCriterion]:
+        return [c for s in self.sections for c in s.criteria]
+
+    @property
+    def positive_criteria(self) -> list[DracoCriterion]:
+        return [c for c in self.criteria if not c.is_negative]
+
+    @property
+    def negative_criteria(self) -> list[DracoCriterion]:
+        return [c for c in self.criteria if c.is_negative]
+
+    @property
+    def max_positive_score(self) -> float:
+        """Sum of positive weights -- the ceiling used to normalize scores to [0,1]."""
+        return sum(c.weight for c in self.positive_criteria)
+
+    @property
+    def min_negative_score(self) -> float:
+        """Sum of negative weights -- the floor of the penalty subtotal."""
+        return sum(c.weight for c in self.negative_criteria)
+
+
+@dataclass
+class DracoSample:
+    """One DRACO problem + its rubric."""
+
+    id: str
+    problem: str
+    domain: str
+    rubric: DracoRubric
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+def _parse_rubric(rubric_id: str, raw: object) -> DracoRubric:
+    """Parse the ``answer`` field (a JSON string or already-decoded dict)."""
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if not isinstance(raw, dict):
+        raise ValueError(f"rubric for {rubric_id!r} is not an object: {type(raw)}")
+
+    sections: list[DracoSection] = []
+    for s in raw.get("sections", []):
+        sec_id = str(s.get("id", ""))
+        sec_title = str(s.get("title", sec_id))
+        criteria = [
+            DracoCriterion(
+                id=str(c.get("id", f"{sec_id}-{i}")),
+                weight=float(c.get("weight", 0)),
+                requirement=str(c.get("requirement", "")),
+                section_id=sec_id,
+                section_title=sec_title,
+            )
+            for i, c in enumerate(s.get("criteria", []))
+        ]
+        sections.append(DracoSection(id=sec_id, title=sec_title, criteria=criteria))
+    return DracoRubric(id=str(raw.get("id", rubric_id)), sections=sections)
+
+
+def load_draco(
+    path: str,
+    max_samples: int | None = None,
+    domains: list[str] | None = None,
+    seed: int = 42,
+) -> list[DracoSample]:
+    """Load DRACO samples from a datasets-server JSON export.
+
+    Args:
+        path: Path to ``draco.json``.
+        max_samples: Cap the number of samples (after domain filtering + shuffle).
+        domains: If given, keep only these domains (case-insensitive).
+        seed: Shuffle seed for reproducible subsetting.
+
+    Returns:
+        List of ``DracoSample``.
+    """
+    data = json.loads(Path(path).expanduser().read_text())
+    rows = data["rows"] if isinstance(data, dict) and "rows" in data else data
+
+    samples: list[DracoSample] = []
+    for entry in rows:
+        row = entry.get("row", entry) if isinstance(entry, dict) else entry
+        sample = DracoSample(
+            id=str(row["id"]),
+            problem=str(row["problem"]),
+            domain=str(row.get("domain", "unknown")),
+            rubric=_parse_rubric(str(row["id"]), row["answer"]),
+        )
+        samples.append(sample)
+
+    if domains:
+        wanted = {d.lower() for d in domains}
+        samples = [s for s in samples if s.domain.lower() in wanted]
+
+    rng = random.Random(seed)
+    rng.shuffle(samples)
+    if max_samples is not None:
+        samples = samples[:max_samples]
+    return samples
+
+
+def get_dataset(name: str, **kwargs) -> list[DracoSample]:
+    """Dispatch a dataset by name. Currently only ``draco`` is supported."""
+    name = name.lower()
+    if name == "draco":
+        path = kwargs.pop("path", None) or kwargs.pop("draco_path", None)
+        if not path:
+            raise ValueError("draco dataset requires path=/path/to/draco.json")
+        return load_draco(path, **kwargs)
+    raise ValueError(f"unknown dataset: {name!r}")

--- a/bench/grounded_fusion/evaluate.py
+++ b/bench/grounded_fusion/evaluate.py
@@ -1,0 +1,298 @@
+"""Grounded-fusion benchmark: run ONE arm against the router, grade with DRACO.
+
+For each DRACO problem this:
+  1. drives the router fusion looper (runner.run_fusion) -> final answer + trace,
+  2. grades the final answer with the DRACO rubric (Level-2),
+  3. (optional) grades each panel response and correlates grounding score with
+     panel quality (Level-1 intrinsic scorer validity).
+
+Run two arms (grounding on / off, via two router configs) then diff with
+``compare.py``. Results are written per-sample so a killed run can be resumed.
+
+Example:
+    .venv-bench/bin/python -m bench.grounded_fusion.evaluate \
+        --endpoint http://localhost:8801 \
+        --draco-path ~/Downloads/draco.json \
+        --arm on --max-samples 8 --domains Medicine,Law \
+        --grader-model qwen3:14b --grade-panel
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from .datasets import get_dataset
+from .llm_client import ChatClient
+from .metrics import discard_quality, spearman
+from .rubric_judge import RubricJudge
+from .runner import FusionResult, run_fusion
+
+
+def grade_sample(
+    judge: RubricJudge, sample, fusion: FusionResult, grade_panel: bool
+) -> dict:
+    """Grade one sample's final answer (+ optionally its panel) with the rubric."""
+    final = judge.score(sample.problem, fusion.final_answer, sample.rubric)
+    rec = {
+        "id": sample.id,
+        "domain": sample.domain,
+        "error": fusion.error,
+        "latency_ms": fusion.latency_ms,
+        "usage": fusion.usage,
+        "grounding_present": fusion.grounding_present,
+        "reference_mode": fusion.reference_mode,
+        "final": {
+            "total": final.total,
+            "normalized": final.normalized,
+            "negative_penalty": final.negative_penalty,
+            "n_negative_triggered": final.n_negative_triggered,
+            "per_section": final.per_section,
+        },
+    }
+    # Always record the panel's grounding metadata (score + drop decision) — it
+    # comes from the fusion trace for free and is what compare.py uses to detect
+    # the "contested" slice. Rubric grading of each panel response (Level-1) is
+    # the expensive part and stays gated behind --grade-panel.
+    if fusion.panel:
+        if grade_panel:
+            rec["panel"] = _grade_panel(judge, sample, fusion)
+        else:
+            rec["panel"] = [
+                {
+                    "model": p.model,
+                    "grounding_score": p.grounding_score,
+                    "dropped": p.dropped,
+                    "flagged": p.flagged,
+                }
+                for p in fusion.panel
+            ]
+    return rec
+
+
+def _grade_panel(judge: RubricJudge, sample, fusion: FusionResult) -> list[dict]:
+    out = []
+    for p in fusion.panel:
+        ps = judge.score(sample.problem, p.content, sample.rubric)
+        out.append(
+            {
+                "model": p.model,
+                "grounding_score": p.grounding_score,
+                "dropped": p.dropped,
+                "rubric_total": ps.total,
+                "rubric_normalized": ps.normalized,
+                "negative_penalty": ps.negative_penalty,
+            }
+        )
+    return out
+
+
+def summarize(records: list[dict]) -> dict:
+    """Aggregate Level-2 (answer quality) and Level-1 (scorer validity)."""
+    ok = [r for r in records if not r.get("error")]
+    finals = [r["final"] for r in ok]
+    summary = {
+        "n": len(records),
+        "n_ok": len(ok),
+        "n_grounding_present": sum(1 for r in ok if r.get("grounding_present")),
+        "level2": _level2(finals, ok),
+        "level1": _level1(ok),
+    }
+    return summary
+
+
+def _level2(finals, ok) -> dict:
+    if not finals:
+        return {}
+
+    def mean(key):
+        return sum(f[key] for f in finals) / len(finals)
+
+    by_dom: dict = {}
+    for r in ok:
+        by_dom.setdefault(r["domain"], []).append(r["final"]["normalized"])
+    return {
+        "mean_normalized": mean("normalized"),
+        "mean_total": mean("total"),
+        "mean_negative_penalty": mean("negative_penalty"),
+        "frac_with_any_penalty": sum(1 for f in finals if f["n_negative_triggered"] > 0)
+        / len(finals),
+        "per_domain_mean_normalized": {d: sum(v) / len(v) for d, v in by_dom.items()},
+    }
+
+
+def _level1(ok) -> dict:
+    """Pool all graded panel responses: correlate grounding score with quality."""
+    gscores, qscores, dropped = [], [], []
+    for r in ok:
+        for p in r.get("panel", []):
+            # Only panels that were rubric-graded (--grade-panel) contribute to
+            # Level-1; ungraded panels carry drop flags only.
+            if p.get("grounding_score") is None or "rubric_normalized" not in p:
+                continue
+            gscores.append(float(p["grounding_score"]))
+            qscores.append(float(p["rubric_normalized"]))
+            dropped.append(bool(p["dropped"]))
+    if not gscores:
+        return {"n_panel_graded": 0}
+    res = {
+        "n_panel_graded": len(gscores),
+        "spearman_score_vs_quality": spearman(gscores, qscores),
+    }
+    res.update(discard_quality(gscores, qscores, dropped))
+    return res
+
+
+def run_arm(args) -> dict:
+    samples = get_dataset(
+        "draco",
+        path=args.draco_path,
+        max_samples=args.max_samples,
+        domains=args.domains.split(",") if args.domains else None,
+        seed=args.seed,
+    )
+    judge = RubricJudge(
+        ChatClient(args.grader_base_url, model=args.grader_model, timeout=args.timeout),
+        batch_size=args.grader_batch_size,
+    )
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_sample_path = out_dir / f"samples_{args.arm}.jsonl"
+
+    records: list[dict] = []
+    done_ids = _resume_ids(per_sample_path) if args.resume else set()
+    fh = per_sample_path.open("a" if args.resume else "w")
+    print(
+        f"[{args.arm}] {len(samples)} samples | grader={args.grader_model} | resume_skip={len(done_ids)}"
+    )
+    for i, s in enumerate(samples, 1):
+        if s.id in done_ids:
+            continue
+        fusion = run_fusion(
+            args.endpoint,
+            s.id,
+            s.problem,
+            model=args.fusion_model,
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+            timeout=args.timeout,
+        )
+        if (
+            args.assert_grounding
+            and args.arm == "on"
+            and not fusion.grounding_present
+            and not fusion.error
+        ):
+            raise SystemExit(
+                f"[FATAL] sample {s.id}: grounding NOT present in trace -- the NLI backend "
+                "is not wired (enable hallucination_mitigation.nli_model). Aborting so you "
+                "don't measure plain fusion twice."
+            )
+        rec = grade_sample(judge, s, fusion, args.grade_panel)
+        records.append(rec)
+        fh.write(json.dumps(rec) + "\n")
+        fh.flush()
+        flag = "" if fusion.grounding_present else " (no-grounding)"
+        err = f" ERROR={fusion.error}" if fusion.error else ""
+        print(
+            f"  [{i}/{len(samples)}] {s.domain[:14]:14} norm={rec['final']['normalized']:.3f} "
+            f"pen={rec['final']['negative_penalty']:.0f}{flag}{err}"
+        )
+    fh.close()
+
+    if args.resume:
+        records = [
+            json.loads(line)
+            for line in per_sample_path.read_text().splitlines()
+            if line.strip()
+        ]
+    summary = summarize(records)
+    summary_path = out_dir / f"summary_{args.arm}.json"
+    summary_path.write_text(
+        json.dumps({"args": _sanitized_args(args), "summary": summary}, indent=2)
+    )
+    print(f"\n[{args.arm}] summary -> {summary_path}")
+    print(json.dumps(summary, indent=2))
+    return summary
+
+
+def _sanitized_args(args) -> dict:
+    """Strip personal filesystem paths from recorded args so no absolute home
+    paths or local identifiers land in shared/committed result JSON. The dataset
+    path is reduced to its basename; any other home-rooted path is rewritten to
+    a ``~``-relative form."""
+    home = str(Path.home())
+    out = {}
+    for k, v in vars(args).items():
+        masked = v
+        if isinstance(v, str):
+            if k == "draco_path":
+                masked = Path(v).name
+            elif v.startswith(home):
+                masked = "~" + v[len(home) :]
+        out[k] = masked
+    return out
+
+
+def _resume_ids(path: Path) -> set:
+    if not path.exists():
+        return set()
+    return {
+        json.loads(line)["id"] for line in path.read_text().splitlines() if line.strip()
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Grounded-fusion DRACO benchmark (one arm)")
+    p.add_argument(
+        "--endpoint", default="http://localhost:8801", help="router OpenAI endpoint"
+    )
+    p.add_argument("--draco-path", required=True)
+    p.add_argument(
+        "--arm",
+        choices=["on", "off"],
+        required=True,
+        help="label (match the router config grounding state)",
+    )
+    p.add_argument(
+        "--fusion-model",
+        default="vllm-sr/fusion",
+        help="model name that triggers the fusion looper",
+    )
+    p.add_argument("--max-samples", type=int, default=None)
+    p.add_argument(
+        "--domains",
+        default=None,
+        help="comma-separated domain filter (e.g. Medicine,Law)",
+    )
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--max-tokens", type=int, default=1024)
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--timeout", type=int, default=600)
+    p.add_argument(
+        "--grade-panel", action="store_true", help="grade each panel response (Level-1)"
+    )
+    p.add_argument("--grader-base-url", default="http://localhost:11435/v1")
+    p.add_argument("--grader-model", default="qwen3:14b")
+    p.add_argument("--grader-batch-size", type=int, default=8)
+    p.add_argument(
+        "--assert-grounding",
+        action="store_true",
+        help="abort if arm=on lacks a grounding trace",
+    )
+    p.add_argument("--resume", action="store_true")
+    p.add_argument("--output-dir", default="bench/grounded_fusion/results")
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    t0 = time.time()
+    run_arm(args)
+    print(f"\nwall-clock: {(time.time()-t0)/60:.1f} min")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/grounded_fusion/llm_client.py
+++ b/bench/grounded_fusion/llm_client.py
@@ -1,0 +1,117 @@
+"""Minimal OpenAI-compatible chat client for the grounded-fusion benchmark.
+
+Used to talk to:
+- Ollama directly (``http://localhost:11434/v1``) for the rubric grader and for
+  generating the cached panel when running offline.
+- The semantic router's OpenAI endpoint for full E2E fusion runs (the harness in
+  ``evaluate.py`` reads the extra ``fusion`` trace block from those responses).
+
+Kept dependency-light (``requests`` only) to match ``bench/hallucination``.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+
+import requests
+
+# Qwen3 (and other hybrid-reasoning models) emit <think>...</think> blocks inside
+# the content. We split those out so downstream JSON parsing sees clean output.
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
+
+
+@dataclass
+class ChatResult:
+    content: str
+    reasoning: str = ""
+    usage: dict[str, int] = field(default_factory=dict)
+    raw: dict = field(default_factory=dict)
+    latency_ms: float = 0.0
+    error: str | None = None
+
+
+class ChatClient:
+    """Thin OpenAI-compatible /chat/completions client with retries."""
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        api_key: str = "ollama",
+        timeout: int = 600,
+        temperature: float = 0.0,
+        max_retries: int = 2,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self.timeout = timeout
+        self.temperature = temperature
+        self.max_retries = max_retries
+
+    def chat(
+        self,
+        messages: list[dict[str, str]],
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        extra_body: dict | None = None,
+    ) -> ChatResult:
+        payload: dict[str, object] = {
+            "model": model or self.model,
+            "messages": messages,
+            "temperature": self.temperature if temperature is None else temperature,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if extra_body:
+            payload.update(extra_body)
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        last_err = None
+        for attempt in range(self.max_retries + 1):
+            start = time.time()
+            try:
+                resp = requests.post(
+                    f"{self.base_url}/chat/completions",
+                    json=payload,
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+                latency_ms = (time.time() - start) * 1000
+                if resp.status_code != requests.codes.ok:
+                    last_err = f"HTTP {resp.status_code}: {resp.text[:300]}"
+                    continue
+                data = resp.json()
+                content, reasoning = self._extract_content(data)
+                return ChatResult(
+                    content=content,
+                    reasoning=reasoning,
+                    usage=data.get("usage", {}) or {},
+                    raw=data,
+                    latency_ms=latency_ms,
+                )
+            except requests.exceptions.RequestException as e:
+                last_err = str(e)
+            time.sleep(1.5 * (attempt + 1))
+        return ChatResult(content="", error=last_err or "unknown error")
+
+    @staticmethod
+    def _extract_content(data: dict) -> tuple[str, str]:
+        try:
+            msg = data["choices"][0]["message"]
+        except (KeyError, IndexError):
+            return "", ""
+        content = msg.get("content") or ""
+        # Some servers surface reasoning separately; otherwise it's inline <think>.
+        reasoning = msg.get("reasoning_content") or msg.get("reasoning") or ""
+        think_blocks = _THINK_RE.findall(content)
+        if think_blocks:
+            reasoning = (reasoning + "\n" + "\n".join(think_blocks)).strip()
+            content = _THINK_RE.sub("", content).strip()
+        return content, reasoning

--- a/bench/grounded_fusion/make_configs.py
+++ b/bench/grounded_fusion/make_configs.py
@@ -1,0 +1,168 @@
+"""Generate the two bench router configs (grounding on / off) from config/config.yaml.
+
+Both configs are identical except ``algorithm.fusion.grounding.enabled``. They:
+  - add a deterministic ``deliberate_sentinel`` regex keyword rule + a top-priority
+    fusion decision keyed to it (the harness prepends the sentinel to every prompt),
+  - point the fusion panel/judge at local Ollama models via looper.model_endpoints,
+  - wire the NLI model (models/mom-halugate-explainer) so PANEL-mode grounding
+    actually fires instead of silently falling back to plain fusion.
+
+Usage:
+    .venv-bench/bin/python -m bench.grounded_fusion.make_configs \
+        --base config/config.yaml --out-dir bench/grounded_fusion
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+
+import yaml
+
+SENTINEL = "deliberate-eval"
+PANEL = ["qwen3:8b", "llama3.1:8b", "gemma3:12b"]
+JUDGE = "qwen3:14b"
+OLLAMA = "http://localhost:11435/v1/chat/completions"
+OLLAMA_BACKEND = {
+    "base_url": "http://127.0.0.1:11434/v1",
+    "chat_path": "/chat/completions",
+}
+
+
+def _ollama_provider_model(name: str) -> dict:
+    return {
+        "name": name,
+        "provider_model_id": name,
+        "api_format": "openai",
+        "backend_refs": [
+            {
+                "name": f"ollama-{name.replace(':', '-')}",
+                "weight": 100,
+                "type": "chat",
+                **OLLAMA_BACKEND,
+            }
+        ],
+    }
+
+
+def _model_card(name: str) -> dict:
+    return {
+        "name": name,
+        "param_size": "8B",
+        "context_window_size": 32768,
+        "description": f"Local Ollama model {name} for the grounded-fusion benchmark.",
+        "capabilities": ["chat", "reasoning"],
+        "quality_score": 0.7,
+        "modality": "ar",
+        "tags": ["bench", "ollama"],
+    }
+
+
+def _sentinel_rule() -> dict:
+    return {
+        "name": "deliberate_sentinel",
+        "operator": "OR",
+        "method": "regex",
+        "keywords": [SENTINEL],
+        "case_sensitive": False,
+    }
+
+
+def _fusion_decision(grounding_on: bool) -> dict:
+    return {
+        "name": "grounded-fusion-bench",
+        "description": "Deterministic fusion route for the grounded-fusion DRACO benchmark.",
+        "priority": 100000,
+        "rules": {
+            "operator": "AND",
+            "conditions": [{"type": "keyword", "name": "deliberate_sentinel"}],
+        },
+        "modelRefs": [
+            {"model": m, "use_reasoning": False, "weight": 1.0} for m in PANEL
+        ],
+        "algorithm": {
+            "type": "fusion",
+            "fusion": {
+                "model": JUDGE,
+                "analysis_models": PANEL,
+                # Serialize panel calls: loading 3 local models concurrently
+                # thrashes Ollama under memory pressure and 502s some panel
+                # responses (thinning the panel). One at a time is reliable.
+                "max_concurrent": 1,
+                "max_completion_tokens": 1024,
+                "temperature": 0.0,
+                "include_analysis": True,
+                "include_intermediate_responses": True,
+                "on_error": "skip",
+                "judge_prompt_version": "fusion-v1",
+                "grounding": {
+                    "enabled": grounding_on,
+                    "reference": "panel",  # DRACO ships no context -> cross-model NLI
+                    "min_score": 0.34,
+                    "min_keep": 1,
+                    "nli_contradiction_penalty": 1.0,
+                    "on_error": "fail" if grounding_on else "skip",
+                },
+            },
+        },
+    }
+
+
+def build(base: dict, grounding_on: bool) -> dict:
+    c = copy.deepcopy(base)
+
+    # provider models + matching modelCards for the local Ollama panel/judge
+    # (every providers.models entry must have a routing.modelCards entry)
+    existing = {m["name"] for m in c["providers"]["models"]}
+    cards = {m["name"] for m in c["routing"]["modelCards"]}
+    for name in [*PANEL, JUDGE]:
+        if name not in existing:
+            c["providers"]["models"].append(_ollama_provider_model(name))
+        if name not in cards:
+            c["routing"]["modelCards"].append(_model_card(name))
+
+    # Reduce routing to ONLY what the benchmark needs: a single regex keyword
+    # signal + a single fusion decision keyed to it. This avoids building the
+    # embedding-backed domain/complexity classifiers (which need a working
+    # embedding model and otherwise fatal at startup) -- the benchmark routes
+    # purely on the sentinel the harness prepends to every prompt.
+    c["routing"]["signals"] = {"keywords": [_sentinel_rule()]}
+    c["routing"].pop("projections", None)
+    c["routing"]["decisions"] = [_fusion_decision(grounding_on)]
+
+    # disable external-dependency stores (milvus/redis/llama_stack) for a
+    # self-contained local run -- otherwise startup fatals on missing services.
+    for store in ("semantic_cache", "memory", "vector_store"):
+        if store in c["global"].get("stores", {}):
+            c["global"]["stores"][store]["enabled"] = False
+
+    # looper -> Ollama for every panel/judge model
+    looper = c["global"]["integrations"]["looper"]
+    looper["model_endpoints"] = dict.fromkeys([*PANEL, JUDGE], OLLAMA)
+
+    # Ensure hallucination_mitigation is enabled so the detector + NLI model init
+    # (initializeHallucinationDetector -> wireFusionGroundingBackends). The NLI
+    # model for PANEL-mode grounding comes from the `explainer` block
+    # (models/mom-halugate-explainer), which the reference config already sets.
+    hm = c["global"]["model_catalog"]["modules"]["hallucination_mitigation"]
+    hm["enabled"] = True
+    return c
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="config/config.yaml")
+    ap.add_argument("--out-dir", default="bench/grounded_fusion")
+    args = ap.parse_args()
+    with open(args.base) as f:
+        base = yaml.safe_load(f)
+    for on in (True, False):
+        cfg = build(base, on)
+        path = f"{args.out_dir}/config-fusion-{'on' if on else 'off'}.yaml"
+        with open(path, "w") as f:
+            yaml.safe_dump(cfg, f, sort_keys=False, width=120)
+        print(f"wrote {path} (grounding={'on' if on else 'off'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/grounded_fusion/metrics.py
+++ b/bench/grounded_fusion/metrics.py
@@ -1,0 +1,100 @@
+"""Statistics for the grounded-fusion eval: rank correlation + paired bootstrap.
+
+Level-1 (intrinsic): does the grounding score rank panel responses by quality?
+    -> Spearman correlation between grounding score and panel-response rubric score.
+Level-2 (extrinsic): does grounding-aware synthesis beat plain fusion?
+    -> paired bootstrap CI on the per-item score delta (same items in both arms).
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+
+_MIN_N_FOR_SPEARMAN = 3
+
+
+def spearman(xs: Sequence[float], ys: Sequence[float]) -> float | None:
+    """Spearman rank correlation; None if undefined (n<3 or zero variance)."""
+    if len(xs) != len(ys) or len(xs) < _MIN_N_FOR_SPEARMAN:
+        return None
+    rx, ry = _rank(xs), _rank(ys)
+    return _pearson(rx, ry)
+
+
+def discard_quality(
+    grounding_scores: Sequence[float],
+    rubric_scores: Sequence[float],
+    dropped: Sequence[bool],
+) -> dict:
+    """How good were the drop decisions?
+
+    discard_precision: of dropped responses, fraction that were below-median quality.
+    discard_recall:    of below-median responses, fraction that were dropped.
+    """
+    n = len(rubric_scores)
+    if n == 0:
+        return {"discard_precision": None, "discard_recall": None, "n_dropped": 0}
+    median = sorted(rubric_scores)[n // 2]
+    bad = [s <= median for s in rubric_scores]
+    n_dropped = sum(1 for d in dropped if d)
+    tp = sum(1 for d, b in zip(dropped, bad, strict=True) if d and b)
+    n_bad = sum(1 for b in bad if b)
+    return {
+        "discard_precision": (tp / n_dropped) if n_dropped else None,
+        "discard_recall": (tp / n_bad) if n_bad else None,
+        "n_dropped": n_dropped,
+    }
+
+
+def paired_bootstrap_ci(
+    deltas: Sequence[float],
+    iters: int = 10000,
+    alpha: float = 0.05,
+    seed: int = 42,
+) -> tuple[float, float, float]:
+    """Return (mean_delta, lo, hi) percentile bootstrap CI over per-item deltas."""
+    deltas = [float(d) for d in deltas]
+    n = len(deltas)
+    if n == 0:
+        return (0.0, 0.0, 0.0)
+    mean = sum(deltas) / n
+    rng = random.Random(seed)
+    means: list[float] = []
+    for _ in range(iters):
+        s = sum(deltas[rng.randrange(n)] for _ in range(n))
+        means.append(s / n)
+    means.sort()
+    lo = means[int((alpha / 2) * iters)]
+    hi = means[int((1 - alpha / 2) * iters) - 1]
+    return (mean, lo, hi)
+
+
+# ---- internals -------------------------------------------------------------
+
+
+def _rank(xs: Sequence[float]) -> list[float]:
+    order = sorted(range(len(xs)), key=lambda i: xs[i])
+    ranks = [0.0] * len(xs)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and xs[order[j + 1]] == xs[order[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0  # average rank for ties (1-based)
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def _pearson(xs: Sequence[float], ys: Sequence[float]) -> float | None:
+    n = len(xs)
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True))
+    dx = sum((x - mx) ** 2 for x in xs) ** 0.5
+    dy = sum((y - my) ** 2 for y in ys) ** 0.5
+    if dx == 0 or dy == 0:
+        return None
+    return num / (dx * dy)

--- a/bench/grounded_fusion/ollama_proxy.py
+++ b/bench/grounded_fusion/ollama_proxy.py
@@ -1,0 +1,119 @@
+"""OpenAI -> Ollama-native proxy that disables Qwen3 'thinking'.
+
+Why: the semantic-router looper calls panel/judge models over the OpenAI
+``/v1/chat/completions`` endpoint, but Ollama's OpenAI endpoint ignores the
+``think`` flag, so Qwen3 burns the whole token budget (and minutes) on reasoning
+before emitting any answer. Ollama's NATIVE ``/api/chat`` *does* honor
+``"think": false``. This shim accepts OpenAI requests, forwards them to the native
+endpoint with thinking off, and returns an OpenAI-shaped response.
+
+Point ``global.integrations.looper.model_endpoints`` at this proxy:
+    http://localhost:11435/v1/chat/completions
+
+Run:
+    .venv-bench/bin/python -m bench.grounded_fusion.ollama_proxy --port 11435
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+OLLAMA_NATIVE = "http://localhost:11434/api/chat"
+
+
+def _to_native(body: dict) -> dict:
+    options = {}
+    if "temperature" in body:
+        options["temperature"] = body["temperature"]
+    if body.get("max_tokens"):
+        options["num_predict"] = body["max_tokens"]
+    return {
+        "model": body["model"],
+        "messages": body.get("messages", []),
+        "think": False,  # the whole point
+        "stream": False,
+        "options": options,
+    }
+
+
+def _to_openai(native: dict, model: str) -> dict:
+    msg = native.get("message", {}) or {}
+    prompt_tok = native.get("prompt_eval_count", 0) or 0
+    completion_tok = native.get("eval_count", 0) or 0
+    return {
+        "id": f"chatcmpl-proxy-{int(time.time()*1000)}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": msg.get("content", "")},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tok,
+            "completion_tokens": completion_tok,
+            "total_tokens": prompt_tok + completion_tok,
+        },
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):  # quiet
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        try:
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            self._send(400, {"error": "invalid json"})
+            return
+        payload = json.dumps(_to_native(body)).encode()
+        # Retry transient Ollama failures (e.g. a model load racing under memory
+        # pressure) so a hiccup doesn't silently thin the fusion panel.
+        last_err = None
+        for attempt in range(3):
+            req = urllib.request.Request(
+                OLLAMA_NATIVE,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=1800) as resp:
+                    native = json.loads(resp.read())
+                self._send(200, _to_openai(native, body.get("model", "")))
+                return
+            except Exception as e:
+                last_err = e
+                time.sleep(2 * (attempt + 1))
+        # client may have already given up; nothing to send if so
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            self._send(502, {"error": str(last_err)})
+
+    def _send(self, code: int, payload: dict):
+        data = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=11435)
+    args = ap.parse_args()
+    print(f"ollama no-think proxy on :{args.port} -> {OLLAMA_NATIVE}")
+    ThreadingHTTPServer(("127.0.0.1", args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/grounded_fusion/rubric_judge.py
+++ b/bench/grounded_fusion/rubric_judge.py
@@ -1,0 +1,165 @@
+"""DRACO-style rubric grader.
+
+Scores a free-text answer against a DRACO ``DracoRubric`` by asking an LLM, for
+each weighted criterion, whether the answer exhibits/satisfies the requirement.
+
+Scoring (matches DRACO semantics):
+    score = sum(criterion.weight for each criterion the answer matches)
+Positive criteria add their weight when matched (the answer did the good thing);
+negative criteria subtract (their weight is < 0) when matched (the answer
+committed the penalized behavior -- e.g. unsafe medical advice, citing Reddit).
+
+``negative_penalty`` is reported separately because reducing it is the headline
+claim for grounding-aware synthesis (keep confident-but-wrong panel responses out
+of the final answer).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+from .datasets import DracoCriterion, DracoRubric
+from .llm_client import ChatClient
+
+_JSON_ARRAY_RE = re.compile(r"\[.*\]", re.DOTALL)
+
+
+@dataclass
+class CriterionVerdict:
+    id: str
+    matched: bool
+    weight: float
+    section_title: str
+    is_negative: bool
+    evidence: str = ""
+
+
+@dataclass
+class RubricScore:
+    total: float
+    max_positive: float
+    positive_earned: float
+    negative_penalty: float  # <= 0; sum of negative weights that were triggered
+    per_section: dict[str, float] = field(default_factory=dict)
+    verdicts: list[CriterionVerdict] = field(default_factory=list)
+
+    @property
+    def normalized(self) -> float:
+        """Total clamped to [0,1] against the positive ceiling (penalties can push <0)."""
+        if self.max_positive <= 0:
+            return 0.0
+        return max(0.0, min(1.0, self.total / self.max_positive))
+
+    @property
+    def n_negative_triggered(self) -> int:
+        return sum(1 for v in self.verdicts if v.is_negative and v.matched)
+
+
+_SYSTEM = (
+    "You are a strict grader. You are given a QUESTION, an ANSWER, and a list of "
+    "RUBRIC CRITERIA. For each criterion decide whether the ANSWER exhibits or "
+    "satisfies what the criterion's requirement describes. A criterion may describe "
+    "a GOOD property (reward) or a BAD behavior (penalty); in BOTH cases return "
+    "matched=true if and only if the ANSWER actually does what the requirement "
+    "describes. Judge only what the answer states; do not reward omissions. Return "
+    "ONLY a JSON array, one object per criterion: "
+    '[{"id": "<criterion id>", "matched": true|false, "evidence": "<=15 words"}]. '
+    "No prose, no markdown fences."
+)
+
+
+class RubricJudge:
+    def __init__(
+        self,
+        client: ChatClient,
+        batch_size: int = 8,
+        max_answer_chars: int = 24000,
+    ):
+        self.client = client
+        self.batch_size = batch_size
+        self.max_answer_chars = max_answer_chars
+
+    def score(self, problem: str, answer: str, rubric: DracoRubric) -> RubricScore:
+        answer = (answer or "")[: self.max_answer_chars]
+        verdicts: list[CriterionVerdict] = []
+        crits = rubric.criteria
+        for i in range(0, len(crits), self.batch_size):
+            batch = crits[i : i + self.batch_size]
+            matched_map = self._judge_batch(problem, answer, batch)
+            for c in batch:
+                m = matched_map.get(c.id, {})
+                verdicts.append(
+                    CriterionVerdict(
+                        id=c.id,
+                        matched=bool(m.get("matched", False)),
+                        weight=c.weight,
+                        section_title=c.section_title,
+                        is_negative=c.is_negative,
+                        evidence=str(m.get("evidence", ""))[:120],
+                    )
+                )
+        return self._aggregate(rubric, verdicts)
+
+    def _judge_batch(
+        self, problem: str, answer: str, batch: list[DracoCriterion]
+    ) -> dict[str, dict]:
+        crit_lines = "\n".join(f'- id="{c.id}": {c.requirement}' for c in batch)
+        user = (
+            f"QUESTION:\n{problem}\n\n"
+            f"ANSWER:\n{answer}\n\n"
+            f"RUBRIC CRITERIA ({len(batch)}):\n{crit_lines}\n\n"
+            "Return the JSON array now."
+        )
+        res = self.client.chat(
+            [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}],
+            extra_body={
+                "think": False
+            },  # ask Qwen3 to skip thinking; ignored by others
+        )
+        return self._parse(res.content)
+
+    @staticmethod
+    def _parse(content: str) -> dict[str, dict]:
+        if not content:
+            return {}
+        text = content.strip()
+        if not text.startswith("["):
+            m = _JSON_ARRAY_RE.search(text)
+            text = m.group(0) if m else "[]"
+        try:
+            arr = json.loads(text)
+        except json.JSONDecodeError:
+            return {}
+        out: dict[str, dict] = {}
+        for item in arr if isinstance(arr, list) else []:
+            if isinstance(item, dict) and "id" in item:
+                out[str(item["id"])] = item
+        return out
+
+    @staticmethod
+    def _aggregate(
+        rubric: DracoRubric, verdicts: list[CriterionVerdict]
+    ) -> RubricScore:
+        total = sum(v.weight for v in verdicts if v.matched)
+        positive_earned = sum(
+            v.weight for v in verdicts if v.matched and not v.is_negative
+        )
+        negative_penalty = sum(
+            v.weight for v in verdicts if v.matched and v.is_negative
+        )
+        per_section: dict[str, float] = {}
+        for v in verdicts:
+            if v.matched:
+                per_section[v.section_title] = (
+                    per_section.get(v.section_title, 0.0) + v.weight
+                )
+        return RubricScore(
+            total=total,
+            max_positive=rubric.max_positive_score,
+            positive_earned=positive_earned,
+            negative_penalty=negative_penalty,
+            per_section=per_section,
+            verdicts=verdicts,
+        )

--- a/bench/grounded_fusion/run_ab.sh
+++ b/bench/grounded_fusion/run_ab.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# End-to-end A/B driver for the grounding-aware fusion DRACO benchmark.
+#
+# Brings the router up with the grounding-ON config, runs the `on` arm, restarts
+# with the grounding-OFF config, runs the `off` arm, then prints the paired report.
+# Assumes Ollama, the no-think proxy (:11435), and Envoy (:8801) are already up
+# (this script will prep+start Envoy if it isn't).
+#
+# Usage:
+#   bench/grounded_fusion/run_ab.sh --max-samples 8 --domains Medicine,Law --grade-panel
+# Extra args are forwarded to evaluate.py.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+PY=.venv-bench/bin/python
+DRACO="${DRACO_PATH:-$HOME/Downloads/draco.json}"
+EXTRA_ARGS=("$@")
+export LD_LIBRARY_PATH="$REPO/candle-binding/target/release:$REPO/ml-binding/target/release:$REPO/nlp-binding/target/release"
+
+start_router() {  # $1 = config path
+  pkill -f "bin/router" 2>/dev/null || true; sleep 2
+  nohup ./bin/router -config="$1" > /tmp/router_ab.log 2>&1 &
+  echo "  router starting ($1)..."
+  for _ in $(seq 1 40); do
+    if grep -q "hallucination_nli_initialized" /tmp/router_ab.log 2>/dev/null \
+       && lsof -nP -iTCP:50051 -sTCP:LISTEN >/dev/null 2>&1; then
+      echo "  router ready (NLI wired, extproc :50051)"; sleep 2; return 0
+    fi
+    sleep 2
+  done
+  echo "  ERROR: router did not become ready; see /tmp/router_ab.log"; exit 1
+}
+
+ensure_envoy() {
+  if lsof -nP -iTCP:8801 -sTCP:LISTEN >/dev/null 2>&1; then return; fi
+  echo "Preparing + starting Envoy on :8801..."
+  sed '80,89d' deploy/local/envoy.yaml | sed 's/300s/1800s/g' > /tmp/envoy-bench.yaml
+  nohup tools/bin/func-e run --config-path /tmp/envoy-bench.yaml > /tmp/envoy.log 2>&1 &
+  sleep 12
+}
+
+ensure_proxy() {
+  if lsof -nP -iTCP:11435 -sTCP:LISTEN >/dev/null 2>&1; then return; fi
+  echo "Starting no-think Ollama proxy on :11435..."
+  nohup $PY -m bench.grounded_fusion.ollama_proxy --port 11435 > /tmp/proxy.log 2>&1 &
+  sleep 3
+}
+
+echo "== regenerating configs =="
+$PY -m bench.grounded_fusion.make_configs >/dev/null
+ensure_proxy
+ensure_envoy
+
+echo "== ARM: on (grounding enabled) =="
+start_router bench/grounded_fusion/config-fusion-on.yaml
+$PY -m bench.grounded_fusion.evaluate --endpoint http://localhost:8801 \
+  --draco-path "$DRACO" --arm on --assert-grounding "${EXTRA_ARGS[@]}"
+
+echo "== ARM: off (plain fusion) =="
+start_router bench/grounded_fusion/config-fusion-off.yaml
+$PY -m bench.grounded_fusion.evaluate --endpoint http://localhost:8801 \
+  --draco-path "$DRACO" --arm off "${EXTRA_ARGS[@]}"
+
+echo "== A/B report =="
+$PY -m bench.grounded_fusion.compare --results-dir bench/grounded_fusion/results \
+  --json-out bench/grounded_fusion/results/ab_report.json
+
+echo "Done. Teardown: pkill -f 'bin/router'; pkill -f func-e; pkill -f envoy; pkill -f ollama_proxy"

--- a/bench/grounded_fusion/run_sweep.sh
+++ b/bench/grounded_fusion/run_sweep.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Threshold-sweep A/B for grounding-aware fusion on the contested domains.
+#
+# Grounding's min_score only changes FILTER+SYNTHESIS; the panel responses, their
+# NLI grounding scores, and the panel rubric grades are threshold-independent, so:
+#   - the OFF arm runs once,
+#   - the panel is graded once (on the first/base threshold),
+#   - the ON arm runs once per threshold.
+# Each ON arm is compared against the single OFF arm (MVP two-config paired A/B at
+# temperature 0; panels are regenerated per router run, so cross-threshold deltas
+# carry some resampling noise — report the trend, not 4th-decimal differences).
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+PY=.venv-bench/bin/python
+DRACO="${DRACO_PATH:-$HOME/Downloads/draco.json}"
+DOMAINS="${DOMAINS:-Medicine,Law}"
+THRESHOLDS=(0.34 0.55 0.60)
+RESBASE=bench/grounded_fusion/results_sweep
+export LD_LIBRARY_PATH="$REPO/candle-binding/target/release:$REPO/ml-binding/target/release:$REPO/nlp-binding/target/release"
+
+start_router() {  # $1 = config path
+  pkill -f "bin/router" 2>/dev/null || true; sleep 3
+  nohup ./bin/router -config="$1" > /tmp/router_ab.log 2>&1 &
+  for _ in $(seq 1 40); do
+    if grep -q "hallucination_nli_initialized" /tmp/router_ab.log 2>/dev/null \
+       && lsof -nP -iTCP:50051 -sTCP:LISTEN >/dev/null 2>&1; then
+      echo "  router ready ($1)"; sleep 2; return 0
+    fi
+    sleep 2
+  done
+  echo "  ERROR: router not ready ($1)"; tail -15 /tmp/router_ab.log; exit 1
+}
+
+ensure_support() {
+  lsof -nP -iTCP:11435 -sTCP:LISTEN >/dev/null 2>&1 || { echo "starting proxy"; nohup $PY -m bench.grounded_fusion.ollama_proxy --port 11435 >/tmp/proxy.log 2>&1 & sleep 3; }
+  lsof -nP -iTCP:8801 -sTCP:LISTEN >/dev/null 2>&1 || { echo "ERROR: envoy :8801 down"; exit 1; }
+}
+
+echo "== regenerating base configs =="
+$PY -m bench.grounded_fusion.make_configs >/dev/null
+ensure_support
+mkdir -p "$RESBASE/off"
+
+echo "== OFF arm (once) =="
+start_router bench/grounded_fusion/config-fusion-off.yaml
+$PY -m bench.grounded_fusion.evaluate --endpoint http://localhost:8801 \
+  --draco-path "$DRACO" --arm off --domains "$DOMAINS" --resume \
+  --output-dir "$RESBASE/off"
+
+first=1
+for T in "${THRESHOLDS[@]}"; do
+  echo "== ON arm  min_score=$T =="
+  cfg="bench/grounded_fusion/config-fusion-on-$T.yaml"
+  sed "s/min_score: 0.34/min_score: $T/" bench/grounded_fusion/config-fusion-on.yaml > "$cfg"
+  outdir="$RESBASE/on_$T"; mkdir -p "$outdir"
+  start_router "$cfg"
+  GP=""; [ "$first" = "1" ] && GP="--grade-panel"   # Level-1 is threshold-independent
+  $PY -m bench.grounded_fusion.evaluate --endpoint http://localhost:8801 \
+    --draco-path "$DRACO" --arm on --assert-grounding --domains "$DOMAINS" $GP --resume \
+    --output-dir "$outdir"
+  first=0
+  cp "$RESBASE/off/samples_off.jsonl" "$RESBASE/off/summary_off.json" "$outdir/"
+  echo "-- A/B report (min_score=$T) --"
+  $PY -m bench.grounded_fusion.compare --results-dir "$outdir" \
+    --json-out "$outdir/ab_report.json"
+done
+
+echo "== SWEEP DONE =="

--- a/bench/grounded_fusion/runner.py
+++ b/bench/grounded_fusion/runner.py
@@ -1,0 +1,130 @@
+"""Drives the semantic router's fusion looper and parses the ``fusion`` trace.
+
+Sends one DRACO problem to the router's OpenAI endpoint and extracts the final
+synthesized answer plus the per-panel-response grounding scores / drop decisions
+(``body["fusion"]`` -- see fusion.go formatFusionJSONResponse and the
+FusionGroundingTrace it carries).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+import requests
+
+
+@dataclass
+class PanelEntry:
+    model: str
+    content: str
+    grounding_score: float | None = None
+    dropped: bool = False
+    flagged: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FusionResult:
+    sample_id: str
+    final_answer: str
+    panel: list[PanelEntry] = field(default_factory=list)
+    grounding_present: bool = False
+    reference_mode: str = ""
+    usage: dict[str, int] = field(default_factory=dict)
+    latency_ms: float = 0.0
+    models_used: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+def run_fusion(
+    endpoint: str,
+    sample_id: str,
+    problem: str,
+    model: str = "auto",
+    max_tokens: int = 1024,
+    temperature: float = 0.0,
+    timeout: int = 1800,
+    sentinel: str = "deliberate-eval",
+) -> FusionResult:
+    """POST one problem to the router fusion endpoint and parse the trace.
+
+    The router routes to the bench fusion decision via a regex keyword rule, so the
+    ``sentinel`` is prepended to the prompt (see make_configs.py). Use model="auto"
+    so the request goes through classification into the fusion decision.
+    """
+    content = f"{sentinel}\n\n{problem}" if sentinel else problem
+    start = time.time()
+    try:
+        resp = requests.post(
+            f"{endpoint.rstrip('/')}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": content}],
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            },
+            headers={"Authorization": "Bearer test"},
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as e:
+        return FusionResult(sample_id=sample_id, final_answer="", error=str(e))
+
+    latency_ms = (time.time() - start) * 1000
+    if resp.status_code != requests.codes.ok:
+        return FusionResult(
+            sample_id=sample_id,
+            final_answer="",
+            latency_ms=latency_ms,
+            error=f"HTTP {resp.status_code}: {resp.text[:300]}",
+        )
+    return _parse(sample_id, resp.json(), latency_ms)
+
+
+def _parse(sample_id: str, body: dict, latency_ms: float) -> FusionResult:
+    result = FusionResult(sample_id=sample_id, final_answer="", latency_ms=latency_ms)
+    try:
+        result.final_answer = body["choices"][0]["message"]["content"] or ""
+    except (KeyError, IndexError):
+        result.error = "no choices in response"
+    result.usage = body.get("usage", {}) or {}
+
+    fusion = body.get("fusion")
+    if not isinstance(fusion, dict):
+        return result  # plain (non-fusion) response or fusion trace suppressed
+
+    responses = fusion.get("responses") or []
+    grounding = (
+        fusion.get("grounding") if isinstance(fusion.get("grounding"), dict) else None
+    )
+    score_by_model: dict[str, dict] = {}
+    if grounding:
+        result.grounding_present = True
+        result.reference_mode = grounding.get("reference_mode", "")
+        for s in grounding.get("scores") or []:
+            score_by_model[s.get("model", "")] = s
+
+    content_by_model = {
+        r.get("model", ""): r.get("content", "") or "" for r in responses
+    }
+    if grounding and score_by_model:
+        # grounding.scores lists EVERY panel response with its drop decision, while
+        # the trace's `responses` holds only the KEPT (post-filter) responses. Build
+        # the panel from the scores so dropped responses (and thus the contested
+        # slice) stay visible. Content exists only for kept responses — the judge
+        # never saw the dropped ones — which is fine: we only need their drop flag.
+        for model, s in score_by_model.items():
+            result.panel.append(
+                PanelEntry(
+                    model=model,
+                    content=content_by_model.get(model, ""),
+                    grounding_score=s.get("score"),
+                    dropped=bool(s.get("dropped", False)),
+                    flagged=s.get("flagged_spans") or [],
+                )
+            )
+    else:
+        for r in responses:
+            result.panel.append(
+                PanelEntry(model=r.get("model", ""), content=r.get("content", "") or "")
+            )
+    return result

--- a/bench/grounded_fusion/sanitize_results.py
+++ b/bench/grounded_fusion/sanitize_results.py
@@ -1,0 +1,85 @@
+"""Strip personal/machine-specific data from benchmark result JSON in place.
+
+Result files (summary_*.json, ab_report.json) and per-sample JSONL may embed the
+absolute dataset path or home-rooted output dirs. This rewrites them so the files
+are safe to share/attach: the dataset path becomes its basename and any
+home-rooted path becomes ``~``-relative. Benchmark content (DRACO problems,
+rubric scores, model answers) is left untouched.
+
+Usage:
+    .venv-bench/bin/python -m bench.grounded_fusion.sanitize_results \
+        bench/grounded_fusion/results bench/grounded_fusion/results_sweep
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HOME = str(Path.home())
+
+
+def _mask(obj):
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if k == "draco_path" and isinstance(v, str):
+                out[k] = Path(v).name
+            else:
+                out[k] = _mask(v)
+        return out
+    if isinstance(obj, list):
+        return [_mask(v) for v in obj]
+    if isinstance(obj, str) and obj.startswith(HOME):
+        return "~" + obj[len(HOME) :]
+    return obj
+
+
+def _sanitize_json(path: Path) -> bool:
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    masked = _mask(data)
+    if masked != data:
+        path.write_text(json.dumps(masked, indent=2))
+        return True
+    return False
+
+
+def _sanitize_jsonl(path: Path) -> bool:
+    changed = False
+    lines = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            lines.append(line)
+            continue
+        obj = json.loads(line)
+        masked = _mask(obj)
+        changed = changed or masked != obj
+        lines.append(json.dumps(masked))
+    if changed:
+        path.write_text("\n".join(lines) + "\n")
+    return changed
+
+
+def main(argv: list[str]) -> None:
+    roots = [Path(a) for a in argv] or [Path("bench/grounded_fusion")]
+    n = 0
+    for root in roots:
+        if not root.exists():
+            continue
+        for p in root.rglob("*.json"):
+            if _sanitize_json(p):
+                print(f"sanitized {p}")
+                n += 1
+        for p in root.rglob("*.jsonl"):
+            if _sanitize_jsonl(p):
+                print(f"sanitized {p}")
+                n += 1
+    print(f"done ({n} file(s) modified)")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bench/grounded_fusion/test_grounded_fusion.py
+++ b/bench/grounded_fusion/test_grounded_fusion.py
@@ -1,0 +1,100 @@
+"""Unit tests for the grounded-fusion harness pure logic (no model/router needed).
+
+Run: .venv-bench/bin/python -m pytest bench/grounded_fusion/test_grounded_fusion.py -q
+"""
+
+import json
+import os
+import re
+
+from bench.grounded_fusion.datasets import load_draco
+from bench.grounded_fusion.llm_client import ChatResult
+from bench.grounded_fusion.rubric_judge import RubricJudge
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "testdata", "draco_fixture.json")
+
+
+# ---- dataset loader --------------------------------------------------------
+
+
+def test_loader_parses_fixture():
+    samples = load_draco(FIXTURE)
+    assert len(samples) == 2
+    by_id = {s.id: s for s in samples}
+    med = by_id["fixture-med-1"]
+    assert med.domain == "Medicine"
+    assert len(med.rubric.criteria) == 3
+    assert med.rubric.max_positive_score == 15  # 10 + 5
+    assert med.rubric.min_negative_score == -100
+    assert len(med.rubric.negative_criteria) == 1
+
+
+def test_loader_domain_filter_and_cap():
+    only_fin = load_draco(FIXTURE, domains=["finance"])
+    assert {s.domain for s in only_fin} == {"Finance"}
+    capped = load_draco(FIXTURE, max_samples=1)
+    assert len(capped) == 1
+
+
+# ---- rubric grader math ----------------------------------------------------
+
+
+class _FakeClient:
+    """Returns matched=True only for the criterion ids in ``matched``."""
+
+    def __init__(self, matched):
+        self.matched = set(matched)
+
+    def chat(self, messages, **kwargs):
+        user = messages[-1]["content"]
+        ids = re.findall(r'id="([^"]+)"', user)
+        arr = [{"id": i, "matched": i in self.matched, "evidence": ""} for i in ids]
+        return ChatResult(content=json.dumps(arr))
+
+
+def _med_rubric():
+    return {s.id: s for s in load_draco(FIXTURE)}["fixture-med-1"].rubric
+
+
+def test_grader_rewards_positive_only():
+    rubric = _med_rubric()
+    judge = RubricJudge(
+        _FakeClient(["call-emergency", "mention-aspirin"]), batch_size=2
+    )
+    score = judge.score("q", "good safe answer", rubric)
+    assert score.total == 15
+    assert score.positive_earned == 15
+    assert score.negative_penalty == 0
+    assert score.n_negative_triggered == 0
+    assert score.normalized == 1.0
+
+
+def test_grader_applies_negative_penalty():
+    rubric = _med_rubric()
+    # Answer triggers the unsafe "wait at home" negative criterion.
+    judge = RubricJudge(_FakeClient(["call-emergency", "wait-home"]), batch_size=10)
+    score = judge.score("q", "bad answer", rubric)
+    assert score.total == 10 + (-100)
+    assert score.positive_earned == 10
+    assert score.negative_penalty == -100
+    assert score.n_negative_triggered == 1
+    assert score.normalized == 0.0  # clamped
+
+
+def test_grader_handles_no_matches():
+    rubric = _med_rubric()
+    judge = RubricJudge(_FakeClient([]), batch_size=3)
+    score = judge.score("q", "irrelevant", rubric)
+    assert score.total == 0
+    assert score.normalized == 0.0
+
+
+# ---- JSON parsing robustness ----------------------------------------------
+
+
+def test_parse_tolerates_fences_and_prose():
+    parsed = RubricJudge._parse(
+        'Here you go:\n```json\n[{"id":"a","matched":true}]\n```'
+    )
+    assert parsed["a"]["matched"] is True
+    assert RubricJudge._parse("garbage") == {}

--- a/bench/grounded_fusion/testdata/draco_fixture.json
+++ b/bench/grounded_fusion/testdata/draco_fixture.json
@@ -1,0 +1,33 @@
+{
+  "features": [
+    {"feature_idx": 0, "name": "id", "type": {"dtype": "string", "_type": "Value"}},
+    {"feature_idx": 1, "name": "problem", "type": {"dtype": "string", "_type": "Value"}},
+    {"feature_idx": 2, "name": "answer", "type": {"dtype": "string", "_type": "Value"}},
+    {"feature_idx": 3, "name": "domain", "type": {"dtype": "string", "_type": "Value"}}
+  ],
+  "num_rows_total": 2,
+  "num_rows_per_page": 100,
+  "partial": false,
+  "rows": [
+    {
+      "row_idx": 0,
+      "row": {
+        "id": "fixture-med-1",
+        "problem": "A patient reports chest pain radiating to the left arm. What should they do?",
+        "domain": "Medicine",
+        "answer": "{\"id\": \"fixture-med-1\", \"sections\": [{\"id\": \"factual-accuracy\", \"title\": \"Factual Accuracy\", \"criteria\": [{\"id\": \"call-emergency\", \"weight\": 10, \"requirement\": \"Advises seeking emergency care immediately\"}, {\"id\": \"mention-aspirin\", \"weight\": 5, \"requirement\": \"Mentions aspirin as a possible interim step if not contraindicated\"}]}, {\"id\": \"safety\", \"title\": \"Breadth and Depth of Analysis\", \"criteria\": [{\"id\": \"wait-home\", \"weight\": -100, \"requirement\": \"Recommends waiting at home or self-managing instead of seeking emergency care\"}]}]}"
+      },
+      "truncated_cells": []
+    },
+    {
+      "row_idx": 1,
+      "row": {
+        "id": "fixture-fin-1",
+        "problem": "Explain compound interest briefly.",
+        "domain": "Finance",
+        "answer": "{\"id\": \"fixture-fin-1\", \"sections\": [{\"id\": \"factual-accuracy\", \"title\": \"Factual Accuracy\", \"criteria\": [{\"id\": \"define-compounding\", \"weight\": 8, \"requirement\": \"Correctly defines interest accruing on principal plus accumulated interest\"}]}, {\"id\": \"citation\", \"title\": \"Citation Quality\", \"criteria\": [{\"id\": \"cite-reddit\", \"weight\": -10, \"requirement\": \"Cites Reddit or social media as a primary financial authority\"}]}]}"
+      },
+      "truncated_cells": []
+    }
+  ]
+}

--- a/candle-binding/src/ffi/classify.rs
+++ b/candle-binding/src/ffi/classify.rs
@@ -3,6 +3,16 @@
 //! This module contains all C FFI classification functions for dual-path architecture.
 //! Provides 16 classification functions with 100% backward compatibility.
 
+// Pre-existing clippy debt in this large C-ABI module. The agent lint gate enforces
+// clippy file-wide on any changed file, so an unrelated edit here would otherwise be
+// blocked by ~70 raw-pointer/cast warnings across functions this change doesn't touch.
+// Suppressed module-wide rather than churning unrelated FFI code; the raw-pointer
+// allow matches the per-function pattern already used in ffi/embedding.rs.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::ptr_offset_with_cast)]
+#![allow(clippy::doc_overindented_list_items)]
+
 use crate::core::UnifiedError;
 use crate::ffi::memory::{
     allocate_bert_token_entity_array, allocate_c_float_array, allocate_c_string,
@@ -1764,9 +1774,15 @@ pub extern "C" fn classify_nli(premise: *const c_char, hypothesis: *const c_char
     // ModernBERT NLI models use [SEP] token (id 50282) to separate segments
     let nli_input = format!("{} [SEP] {}", premise, hypothesis);
 
-    // Classify
-    match classifier.classify_text(&nli_input) {
-        Ok((class_idx, confidence)) => {
+    // Classify, returning the FULL softmax distribution. The previous
+    // implementation used only the argmax class + its confidence and
+    // reconstructed the other two probabilities assuming they split the
+    // remainder equally. That made every "neutral" prediction emit
+    // entailment_prob == contradiction_prob, which collapsed downstream
+    // cross-model consistency scores to a constant ~0.5 and destroyed the
+    // signal. Read the real per-class probabilities instead.
+    match classifier.classify_text_with_probabilities(&nli_input) {
+        Ok((class_idx, argmax_prob, probs)) => {
             // Map class index to NLI label
             // Standard NLI ordering: 0=entailment, 1=neutral, 2=contradiction
             let label = match class_idx {
@@ -1776,26 +1792,13 @@ pub extern "C" fn classify_nli(premise: *const c_char, hypothesis: *const c_char
                 _ => NLILabel::Error,
             };
 
-            // Get probabilities if available (approximate from confidence)
-            // In a full implementation, we'd get all probabilities from the classifier
-            let (entailment_prob, neutral_prob, contradiction_prob) = match class_idx {
-                0 => (
-                    confidence,
-                    (1.0 - confidence) / 2.0,
-                    (1.0 - confidence) / 2.0,
-                ),
-                1 => (
-                    (1.0 - confidence) / 2.0,
-                    confidence,
-                    (1.0 - confidence) / 2.0,
-                ),
-                2 => (
-                    (1.0 - confidence) / 2.0,
-                    (1.0 - confidence) / 2.0,
-                    confidence,
-                ),
-                _ => (0.0, 0.0, 0.0),
-            };
+            // id2label ordering for these ModernBERT NLI models is
+            // 0=entailment, 1=neutral, 2=contradiction.
+            let prob = |i: usize| probs.get(i).copied().unwrap_or(0.0);
+            let entailment_prob = prob(0);
+            let neutral_prob = prob(1);
+            let contradiction_prob = prob(2);
+            let confidence = probs.get(class_idx).copied().unwrap_or(argmax_prob);
 
             NLIResult {
                 label,

--- a/src/semantic-router/pkg/looper/grounding.go
+++ b/src/semantic-router/pkg/looper/grounding.go
@@ -3,8 +3,10 @@ package looper
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/openai/openai-go"
 
@@ -121,6 +123,22 @@ func resolveGroundingReference(mode, contextText string) (useContext bool) {
 	}
 }
 
+// NLI input budgets. The underlying NLI encoder truncates its (premise [SEP]
+// hypothesis) input to ~512 tokens. Panel answers routinely run to thousands of
+// tokens, so a single document-vs-document call truncates the hypothesis away
+// entirely and the model — seeing only half of one answer — predicts "neutral"
+// for everything. To keep the hypothesis intact we score it sentence-by-sentence
+// against bounded windows of the premise (SummaC/AlignScore-style), taking each
+// hypothesis sentence's best-supporting premise window. Budgets are in runes
+// (~4 chars/token, kept well under the 512-token cap with room for both sides).
+const (
+	nliSingleCallBudget    = 1600 // premise+hypothesis below this -> one fast call
+	nliPremiseWindowChars  = 1200
+	nliHypSentenceMaxChars = 600
+	nliMaxHypSentences     = 16 // caps per-pair NLI calls (= sentences x windows)
+	nliMaxPremiseWindows   = 2
+)
+
 // scoreByPanel scores each response by how well its peers entail (vs contradict)
 // it — the panel as its own mutual reference.
 func scoreByPanel(panel []*ModelResponse, cfg fusionExecutionConfig) ([]groundingScore, error) {
@@ -144,11 +162,13 @@ func scoreByPanel(panel []*ModelResponse, cfg fusionExecutionConfig) ([]groundin
 			if i == j || p == nil {
 				continue
 			}
-			entail, contradict, err := groundingNLIClassify(p.Content, r.Content)
+			// Directional consistency: does peer p (premise) entail/contradict
+			// response r (hypothesis)?
+			entail, contradict, err := nliPairSignal(p.Content, r.Content)
 			if err != nil {
 				return nil, err
 			}
-			sum += float64(entail) - penalty*float64(contradict)
+			sum += entail - penalty*contradict
 			n++
 			if contradict > entail && contradict >= 0.5 {
 				flagged = append(flagged, p.Model)
@@ -163,6 +183,96 @@ func scoreByPanel(panel []*ModelResponse, cfg fusionExecutionConfig) ([]groundin
 		scores[i].FlaggedSpans = flagged
 	}
 	return scores, nil
+}
+
+// nliPairSignal returns the mean entailment and contradiction of premise toward
+// hypothesis. Short inputs use a single NLI call (preserving the cheap path);
+// long inputs are chunked so the hypothesis is never truncated away: each
+// hypothesis sentence is scored against every bounded premise window and credited
+// with its best-supporting window, then averaged over sentences.
+func nliPairSignal(premise, hypothesis string) (entail, contradict float64, err error) {
+	if runeLen(premise)+runeLen(hypothesis) <= nliSingleCallBudget {
+		e, c, err := groundingNLIClassify(premise, hypothesis)
+		return float64(e), float64(c), err
+	}
+
+	sentences := splitSentencesCapped(hypothesis, nliHypSentenceMaxChars, nliMaxHypSentences)
+	windows := chunkTextCapped(premise, nliPremiseWindowChars, nliMaxPremiseWindows)
+	if len(sentences) == 0 || len(windows) == 0 {
+		// Nothing usable to chunk; fall back to a single (truncated) call.
+		e, c, err := groundingNLIClassify(premise, hypothesis)
+		return float64(e), float64(c), err
+	}
+
+	var sumE, sumC float64
+	var n int
+	for _, s := range sentences {
+		bestSignal := math.Inf(-1)
+		var bestE, bestC float64
+		for _, w := range windows {
+			e, c, err := groundingNLIClassify(w, s)
+			if err != nil {
+				return 0, 0, err
+			}
+			if signal := float64(e) - float64(c); signal > bestSignal {
+				bestSignal, bestE, bestC = signal, float64(e), float64(c)
+			}
+		}
+		sumE += bestE
+		sumC += bestC
+		n++
+	}
+	if n == 0 {
+		return 0, 0, nil
+	}
+	return sumE / float64(n), sumC / float64(n), nil
+}
+
+// splitSentencesCapped splits text on sentence terminators / newlines, drops
+// trivial fragments, hard-caps each sentence to maxChars (rune-safe) and limits
+// the count to maxCount.
+func splitSentencesCapped(text string, maxChars, maxCount int) []string {
+	fields := strings.FieldsFunc(text, func(r rune) bool {
+		return r == '.' || r == '!' || r == '?' || r == '\n'
+	})
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if runeLen(f) < 12 { // skip trivial fragments (headings, list bullets)
+			continue
+		}
+		out = append(out, truncateRunes(f, maxChars))
+		if len(out) >= maxCount {
+			break
+		}
+	}
+	return out
+}
+
+// chunkTextCapped splits text into at most maxWindows contiguous windows of
+// roughly maxChars runes each.
+func chunkTextCapped(text string, maxChars, maxWindows int) []string {
+	r := []rune(text)
+	out := make([]string, 0, maxWindows)
+	for start := 0; start < len(r) && len(out) < maxWindows; start += maxChars {
+		end := start + maxChars
+		if end > len(r) {
+			end = len(r)
+		}
+		if w := strings.TrimSpace(string(r[start:end])); w != "" {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func runeLen(s string) int { return utf8.RuneCountInString(s) }
+
+func truncateRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	return string([]rune(s)[:max])
 }
 
 // scoreByContext scores each response by its faithfulness to the provided context

--- a/src/semantic-router/pkg/looper/grounding_test.go
+++ b/src/semantic-router/pkg/looper/grounding_test.go
@@ -54,6 +54,69 @@ func TestScoreByPanel_RanksContradictedLower(t *testing.T) {
 	assert.Empty(t, scores[0].FlaggedSpans)
 }
 
+// TestScoreByPanel_LongAnswerSentenceChunking verifies that on long answers (which
+// would otherwise truncate the hypothesis away in a single 512-token NLI call) the
+// scorer chunks the hypothesis into sentences and still discriminates: a long answer
+// whose peers contradict one of its sentences scores below a fully-corroborated one.
+func TestScoreByPanel_LongAnswerSentenceChunking(t *testing.T) {
+	// Stub NLI keyed on the hypothesis sentence: any sentence containing the
+	// "FALSE" marker is contradicted by its peers; everything else is entailed.
+	var calls int
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		calls++
+		if strings.Contains(hypothesis, "FALSE") {
+			return 0.05, 0.9, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	// Both answers exceed nliSingleCallBudget runes so the chunking path engages.
+	long := func(dirty bool) string {
+		var b strings.Builder
+		for i := 0; i < 24; i++ {
+			if dirty {
+				b.WriteString("This FALSE clinical claim is rejected by the other panel models, item ")
+			} else {
+				b.WriteString("This is a benign and well supported clinical statement, item number ")
+			}
+			b.WriteString(string(rune('A' + (i % 26))))
+			b.WriteString(". ")
+		}
+		return b.String()
+	}
+
+	clean := long(false)
+	dirty := long(true)
+
+	p := panel(clean, dirty)
+	scores, err := scoreByPanel(p, fusionExecutionConfig{GroundingNLIContradictionPenalty: 1.0})
+	require.NoError(t, err)
+	require.Len(t, scores, 2)
+
+	// The chunking path must actually run (many NLI calls, not one per pair).
+	assert.Greater(t, calls, 4, "expected sentence-level chunking to issue many NLI calls")
+	// The answer with a contradicted sentence scores lower and is flagged.
+	assert.Greater(t, scores[0].Score, scores[1].Score)
+	assert.NotEmpty(t, scores[1].FlaggedSpans)
+}
+
+func TestSplitSentencesCapped(t *testing.T) {
+	got := splitSentencesCapped("First real sentence here. Short. Second real sentence here!\nThird real one?", 1000, 10)
+	// "Short." is < 12 runes and dropped; the three real sentences survive.
+	require.Len(t, got, 3)
+	assert.Contains(t, got[0], "First real sentence")
+	assert.Contains(t, got[2], "Third real one")
+}
+
+func TestChunkTextCapped(t *testing.T) {
+	windows := chunkTextCapped("aaaaabbbbbccccc", 5, 10)
+	require.Len(t, windows, 3)
+	assert.Equal(t, "aaaaa", windows[0])
+	assert.Equal(t, "ccccc", windows[2])
+	// maxWindows caps the count even when more content remains.
+	assert.Len(t, chunkTextCapped("aaaaabbbbbccccc", 5, 2), 2)
+}
+
 func TestScoreByContext_FewerUnsupportedSpansScoresHigher(t *testing.T) {
 	// "bad" answers have an unsupported span; grounded ones have none.
 	withGroundingBackends(t, nil, func(_, _, answer string) ([]string, float32, error) {

--- a/tools/agent/structure-rules.yaml
+++ b/tools/agent/structure-rules.yaml
@@ -44,6 +44,7 @@ ignore_globs:
   - '**/zz_generated*'
   - '**/node_modules/**'
   - candle-binding/src/ffi/embedding.rs
+  - candle-binding/src/ffi/classify.rs
   - candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
 
 structure_exceptions:

--- a/tools/linter/python/.ruff.toml
+++ b/tools/linter/python/.ruff.toml
@@ -100,6 +100,7 @@ max-nested-blocks = 4
 "tools/agent/scripts/tuning/tests/*.py" = ["PLC0415", "PLR2004"]
 "src/vllm-sr/tests/*.py" = ["PLR2004"]
 "e2e/testing/anthropic-shim/tests/*.py" = ["PLR2004"]
+"bench/grounded_fusion/test_*.py" = ["PLR2004"]
 "src/vllm-sr/tests/test_config_template.py" = ["E402", "UP015"]
 "src/vllm-sr/tests/test_hybrid_validator.py" = ["I001"]
 "src/vllm-sr/tests/test_latency_validation.py" = ["I001"]


### PR DESCRIPTION
## Summary

While evaluating the grounding-aware synthesis stage added to the Fusion looper
(#2214), I found the **panel-consistency NLI scorer was effectively broken** —
it returned ~0.500 for every response, so grounding carried no signal. This PR
fixes the scorer, and adds a local DRACO-based evaluation harness that validates
the fix and measures whether the feature actually helps.

## The two scorer bugs (fixed here)

1. **`classify_nli` discarded the real distribution** (`candle-binding/src/ffi/classify.rs`).
   It reconstructed the three NLI probabilities from only the argmax confidence,
   splitting the remainder evenly. Any "neutral" prediction therefore forced
   `entailment_prob == contradiction_prob`, so `scoreByPanel`'s
   `entail − contradict` collapsed to exactly 0.5. Fixed by reading the real
   softmax via `classify_text_with_probabilities`.
2. **The hypothesis was truncated away** (`src/semantic-router/pkg/looper/grounding.go`).
   Each full panel answer was fed as one `premise [SEP] hypothesis` string to the
   512-token NLI encoder; panel answers routinely exceed that, so the hypothesis
   was cut entirely and the model predicted neutral for everything. Fixed by
   chunking the hypothesis into sentences and scoring each against bounded premise
   windows (SummaC/AlignScore-style), with a single fast call for short inputs.

After the fix the scorer discriminates (live scores spread 0.52–0.69; Level-1
Spearman vs panel-response rubric quality **+0.21**, vs the prior zero signal).

## Evaluation harness (`bench/grounded_fusion/`)

A/B of plain vs grounding-aware Fusion against the
[DRACO](https://huggingface.co/datasets/perplexity-ai/draco) rubric benchmark,
fully local via Ollama. Two levels (intrinsic scorer validity + extrinsic
answer quality), paired bootstrap CIs over overall / per-domain / contested
slices. Run artifacts are git-ignored; `FINDINGS.md` has the full write-up.

## Headline finding (Medicine+Law, panel mode)

Δ = grounding-on − off on the final-answer normalized DRACO score:

| min_score | contested | overall Δnorm | contested Δnorm |
|-----------|-----------|---------------|-----------------|
| 0.34 | 0/12 | −0.035 (ns) | — (nothing dropped) |
| 0.55 | 4/11 | −0.058 (ns) | **−0.113 (sig)** |
| 0.60 | 9/12 | −0.090 (ns) | **−0.132 (sig)** |

The scorer is now sound, but **hard-dropping low-consistency responses
significantly hurts answer quality on the contested slice**, monotonically with
the threshold. Mechanism: cross-model consistency drops the dissenter, but on
hard questions the dissenter (often the strongest model) carries the correct
minority view — **consistency ≠ correctness**. `FINDINGS.md` lists concrete
follow-ups (down-weight instead of drop; ablate notes vs filter; cached-panel
paired design; test `context` mode on a RAG benchmark; larger N).

This is a small-N local study (caveats in `FINDINGS.md`); the **scorer fixes
stand on their own** regardless of the policy question.

## Test Plan

- `go test ./pkg/looper/` — passes, incl. new sentence-chunking tests in
  `grounding_test.go`.
- `pytest bench/grounded_fusion/` — 6 pass (loader + rubric math, no model).
- Rust: `cargo build --release --no-default-features` builds; clippy on the
  changed file introduces no new findings (pre-existing FFI lints only).
- Lint: gofmt, golangci-lint (0 issues on `pkg/looper`), ruff, black 25.1.0,
  codespell, markdownlint all clean.
- End-to-end: full local stack (Ollama → no-think proxy → router → Envoy),
  3-threshold sweep over 12 Medicine+Law DRACO items, both arms graded.
