### PR TITLE
Update owner notifications for v0.3 committers

### DIFF
--- a/.github/workflows/owner-notification.yml
+++ b/.github/workflows/owner-notification.yml
@@ -126,16 +126,45 @@ jobs:
 
             // Assign owners to the PR
             if (allOwners.size > 0) {
-              try {
-                await github.rest.issues.addAssignees({
+              const requestedOwners = Array.from(allOwners);
+              const assigneeUsers = await github.paginate(
+                github.rest.issues.listAssignees,
+                {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  assignees: Array.from(allOwners)
-                });
+                  per_page: 100
+                }
+              );
+              const assignableLogins = new Set(
+                assigneeUsers.map(user => user.login.toLowerCase())
+              );
+              const assignableOwners = requestedOwners.filter(owner =>
+                assignableLogins.has(owner.toLowerCase())
+              );
+              const skippedOwners = requestedOwners.filter(owner =>
+                !assignableLogins.has(owner.toLowerCase())
+              );
+
+              if (skippedOwners.length > 0) {
                 console.log(
-                  `Assigned PR to: ${Array.from(allOwners).join(', ')}`
+                  `Skipping non-assignable owners: ${skippedOwners.join(', ')}`
                 );
+              }
+
+              try {
+                if (assignableOwners.length > 0) {
+                  await github.rest.issues.addAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    assignees: assignableOwners
+                  });
+                  console.log(
+                    `Assigned PR to: ${assignableOwners.join(', ')}`
+                  );
+                } else {
+                  console.log('No assignable owners found for changed files');
+                }
               } catch (error) {
                 console.log(`Failed to assign PR: ${error.message}`);
                 // Continue with comment creation even if assignment fails
@@ -146,7 +175,8 @@ jobs:
             let commentBody = '## 👥 vLLM Semantic Team Notification\n\n';
             commentBody +=
               'The following members have been identified for the changed ' +
-              'files in this PR and have been automatically assigned:\n\n';
+              'files in this PR and have been automatically assigned when ' +
+              'their GitHub accounts are assignable in this repository:\n\n';
 
             for (const [dirPath, info] of ownerMap) {
               commentBody +=

--- a/bench/OWNER
+++ b/bench/OWNER
@@ -1,6 +1,8 @@
 # Benchmark owners
-@Xunzhuo
-@yossiovadia
-@szedan-rh
-@henschwartz
-@mkoushni
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/candle-binding/OWNER
+++ b/candle-binding/OWNER
@@ -1,7 +1,8 @@
 # Candle binding owners
-@rootfs
-@Xunzhuo
-@haowu1234
-@szedan-rh
-@noalimoy
-@asaadbalum
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/config/OWNER
+++ b/config/OWNER
@@ -1,3 +1,8 @@
 # Configuration owners
-@rootfs
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/dashboard/OWNER
+++ b/dashboard/OWNER
@@ -1,7 +1,8 @@
 # Dashboard owners
-@Xunzhuo
-@JaredforReal
-@haowu1234
-@szedan-rh
-@yehuditkerido
-@henschwartz
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/deploy/OWNER
+++ b/deploy/OWNER
@@ -1,4 +1,8 @@
 # Deployment owners
-@rootfs
-@Xunzhuo
-@samzong
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/docs/OWNER
+++ b/docs/OWNER
@@ -1,2 +1,8 @@
 # Documentation owners
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/e2e/OWNER
+++ b/e2e/OWNER
@@ -1,6 +1,8 @@
 # Integration tests owners
-@Xunzhuo
-@yossiovadia
-@szedan-rh
-@henschwartz
-@mkoushni
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/ml-binding/OWNER
+++ b/ml-binding/OWNER
@@ -1,7 +1,8 @@
 # ML binding owners
-@rootfs
-@Xunzhuo
-@szedan-rh
-@abdallahsamabd
-@asaadbalum
-@noalimoy
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/nlp-binding/OWNER
+++ b/nlp-binding/OWNER
@@ -1,4 +1,8 @@
 # NLP binding owners
-@rootfs
-@Xunzhuo
-@haowu1234
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/onnx-binding/OWNER
+++ b/onnx-binding/OWNER
@@ -1,6 +1,8 @@
 # ONNX binding owners
-@rootfs
-@Xunzhuo
-@szedan-rh
-@abdallahsamabd
-@asaadbalum
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/paper/OWNER
+++ b/paper/OWNER
@@ -1,3 +1,8 @@
 # Research paper owners
-@rootfs
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/perf/OWNER
+++ b/perf/OWNER
@@ -1,6 +1,8 @@
 # Performance owners
-@rootfs
-@Xunzhuo
-@szedan-rh
-@liavweiss
-@mkoushni
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/scripts/OWNER
+++ b/scripts/OWNER
@@ -1,3 +1,8 @@
 # Script owners
-@rootfs
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/src/OWNER
+++ b/src/OWNER
@@ -1,3 +1,8 @@
 # Source code owners
-@rootfs
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/src/fleet-sim/OWNER
+++ b/src/fleet-sim/OWNER
@@ -1,3 +1,8 @@
 # Fleet simulator owners
-@rootfs
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/src/semantic-router/OWNER
+++ b/src/semantic-router/OWNER
@@ -1,9 +1,8 @@
 # Router runtime owners
-@rootfs
-@Xunzhuo
-@szedan-rh
-@yehuditkerido
-@abdallahsamabd
-@asaadbalum
-@liavweiss
-@noalimoy
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/src/training/OWNER
+++ b/src/training/OWNER
@@ -1,7 +1,8 @@
 # Training stack owners
-@rootfs
-@Xunzhuo
-@OneZero-Y
-@haowu1234
-@szedan-rh
-@abdallahsamabd
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/src/vllm-sr/OWNER
+++ b/src/vllm-sr/OWNER
@@ -1,9 +1,8 @@
 # Python CLI owners
-@Xunzhuo
-@szedan-rh
-@yehuditkerido
-@henschwartz
-@mkoushni
-@liavweiss
-@noalimoy
-@haowu1234
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/tools/OWNER
+++ b/tools/OWNER
@@ -1,4 +1,8 @@
 # Tooling owners
-@Xunzhuo
-@yuluo-yx
-@samzong
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/website/OWNER
+++ b/website/OWNER
@@ -1,4 +1,8 @@
 # Website owners
-@Xunzhuo
-@samzong
-@yuluo-yx
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.2/OWNER
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.2/OWNER
@@ -1,3 +1,8 @@
 # Documentation owners
-@rootfs
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu

--- a/website/versioned_docs/version-v0.2/OWNER
+++ b/website/versioned_docs/version-v0.2/OWNER
@@ -1,3 +1,8 @@
 # Documentation owners
-@rootfs
-@Xunzhuo
+@FAUST-BENCHOU
+@shraderdm
+@drivebyer
+@ramkrishs
+@WUKUNTAI-0211
+@AayushSaini101
+@siloteemu


### PR DESCRIPTION
## Summary

- switch all tracked non-root `OWNER` files to the v0.3 new committer pool
- keep the root `OWNER` fallback unchanged
- make `owner-notification.yml` filter non-assignable owners before calling `issues.addAssignees`, while still showing them in the notification comment

v0.3 new committer pool:

- `@FAUST-BENCHOU`
- `@shraderdm`
- `@drivebyer`
- `@ramkrishs`
- `@WUKUNTAI-0211`
- `@AayushSaini101`
- `@siloteemu`

## Validation

- `make agent-report ENV=cpu CHANGED_FILES="..."`
- `make agent-lint CHANGED_FILES="..."`
- YAML parse check for `.github/workflows/owner-notification.yml`
- local OWNER consistency check: 22 tracked non-root `OWNER` files contain exactly the v0.3 new committer pool; root `OWNER` has no v0.3 new committers
