### PR TITLE
[Router] Soft-weight grounding-aware Fusion instead of hard-dropping panel responses

### DIFF
--- a/bench/grounded_fusion/FINDINGS.md
+++ b/bench/grounded_fusion/FINDINGS.md
@@ -27,6 +27,29 @@ result, and how to improve the experiment next.
   graduate-level questions the dissenter (often the strongest model) carries the
   correct minority view. **Consistency ≠ correctness.**
 
+## Status / production decision (2026-06)
+
+Acting on the headline result, the grounding stage now exposes a `grounding.policy`
+lever and **defaults to `weight` (soft down-weighting, no hard-drop)**:
+
+- `weight` (default) — keep every panel response; the judge is told to weight each
+  answer by its groundedness score and to protect a correct lone dissenter.
+- `annotate` — keep every response; pass the scores to the judge as notes only.
+- `filter` — the prior hard-drop (below `min_score`); now opt-in.
+
+**Decided:** we do **not** hard-drop facts by default — `filter` is known to regress
+quality on contested factual items (this document).
+
+**Still open (to validate in follow-up CRs, not in this change):**
+
+1. Does `weight`/`annotate` actually *beat* plain fusion, or is it merely
+   non-harmful? Run `make_configs.py --policy weight` / `--policy annotate` arms
+   against the `off` baseline.
+2. Is the scorer (Level-1 Spearman +0.21) strong enough that soft-weighting on it
+   improves synthesis? Discrimination ≠ usefulness-as-a-weight.
+
+This change ships the policy + default; the efficacy A/B above is deferred.
+
 ## What was measured
 
 Two levels (most eval efforts only do level 2 and then can't explain a null/noisy

--- a/bench/grounded_fusion/README.md
+++ b/bench/grounded_fusion/README.md
@@ -11,14 +11,34 @@ reward correctness/coverage; negative criteria, down to −500, penalize
 confident-but-wrong / unsafe / badly-sourced claims). We score two levels:
 
 - **Level 2 (extrinsic)** — does grounding-aware fusion beat plain fusion on the
-  final answer? Headline: the **negative-criteria penalty** should drop (grounding
-  keeps ungrounded panel responses out of synthesis). `compare.py` reports paired
-  bootstrap CIs, overall + per-domain + "contested slice" (items where grounding
-  actually dropped a response).
+  final answer? Headline: the **negative-criteria penalty** should drop. `compare.py`
+  reports paired bootstrap CIs, overall + per-domain + "contested slice" (items where
+  the `filter` policy actually dropped a response — meaningful only under `filter`).
 - **Level 1 (intrinsic)** — is the grounding *scorer* any good? `--grade-panel`
   grades each panel response too, and `evaluate.py` reports the Spearman
   correlation between the cross-model NLI grounding score and panel-response
   quality, plus discard precision/recall.
+
+## Grounding policy (what we use the score for)
+
+The grounding stage now defaults to **`policy: weight`** — keep every panel response
+and let the judge soft-weight by groundedness score (protecting a correct lone
+dissenter) — instead of hard-dropping. `make_configs.py --policy {weight,annotate,filter}`
+selects the lever for the `on` arm so follow-up CRs can A/B them.
+
+**Status / open questions (tracked, not yet answered here):**
+
+- ✅ **Hard-drop (`filter`) hurts.** The first DRACO A/B showed dropping the least
+  mutually-consistent response significantly *lowers* answer quality on contested
+  factual items (the dissenter is often the right minority view). So the production
+  default no longer drops facts — see `FINDINGS.md`. This is why `weight` is default.
+- ❓ **Does `annotate`/`weight` actually *help*?** Unknown. Keeping all responses and
+  passing scores to the judge as weights/notes may help, hurt, or be neutral vs plain
+  fusion. To be measured in a follow-up CR (`--policy weight` and `--policy annotate`
+  arms vs the `off` baseline).
+- ❓ **Is the *scorer* trustworthy enough to weight on?** Level-1 Spearman was +0.21
+  (it discriminates), but whether that signal is strong enough to improve synthesis
+  when used as a soft weight is not yet established. Follow-up experiment.
 
 ## Architecture (local stack)
 
@@ -50,8 +70,10 @@ python3 -m venv .venv-bench
 .venv-bench/bin/pip install openai requests numpy scipy tqdm pandas pyyaml pytest \
   --trusted-host pypi.org --trusted-host files.pythonhosted.org
 
-# 3. Generate the two router configs (grounding on/off)
-.venv-bench/bin/python -m bench.grounded_fusion.make_configs
+# 3. Generate the two router configs (grounding on/off).
+#    --policy {weight,annotate,filter} picks the lever for the 'on' arm
+#    (default weight = no hard-drop).
+.venv-bench/bin/python -m bench.grounded_fusion.make_configs --policy weight
 ```
 
 ## Run
@@ -103,7 +125,7 @@ overnight-scale job; start with a pilot. Runs are resumable (`--resume`).
 | `make_configs.py` | generates the two router configs |
 | `ollama_proxy.py` | OpenAI→Ollama-native shim that disables Qwen3 thinking |
 | `run_ab.sh` | end-to-end A/B driver |
-| `run_sweep.sh` | `min_score` threshold-sweep driver (off arm + on arms, resumable) |
+| `run_sweep.sh` | `min_score` threshold-sweep driver (`filter` policy only; off arm + on arms, resumable) |
 | `sanitize_results.py` | strip local paths from result JSON before sharing |
 | `test_grounded_fusion.py` | unit tests (loader + grader math, no model needed) |
 | `FINDINGS.md` | evaluation write-up: bugs fixed, results, next experiments |

--- a/bench/grounded_fusion/make_configs.py
+++ b/bench/grounded_fusion/make_configs.py
@@ -68,7 +68,7 @@ def _sentinel_rule() -> dict:
     }
 
 
-def _fusion_decision(grounding_on: bool) -> dict:
+def _fusion_decision(grounding_on: bool, policy: str = "weight") -> dict:
     return {
         "name": "grounded-fusion-bench",
         "description": "Deterministic fusion route for the grounded-fusion DRACO benchmark.",
@@ -98,6 +98,12 @@ def _fusion_decision(grounding_on: bool) -> dict:
                 "grounding": {
                     "enabled": grounding_on,
                     "reference": "panel",  # DRACO ships no context -> cross-model NLI
+                    # policy controls how the score is used. weight (default, no
+                    # drop) is the production default; filter (hard-drop below
+                    # min_score) is known to hurt on contested factual items and is
+                    # kept only so later CRs can A/B annotate vs weight vs filter.
+                    # min_score/min_keep apply to the filter policy only.
+                    "policy": policy,
                     "min_score": 0.34,
                     "min_keep": 1,
                     "nli_contradiction_penalty": 1.0,
@@ -108,7 +114,7 @@ def _fusion_decision(grounding_on: bool) -> dict:
     }
 
 
-def build(base: dict, grounding_on: bool) -> dict:
+def build(base: dict, grounding_on: bool, policy: str = "weight") -> dict:
     c = copy.deepcopy(base)
 
     # provider models + matching modelCards for the local Ollama panel/judge
@@ -128,7 +134,7 @@ def build(base: dict, grounding_on: bool) -> dict:
     # purely on the sentinel the harness prepends to every prompt.
     c["routing"]["signals"] = {"keywords": [_sentinel_rule()]}
     c["routing"].pop("projections", None)
-    c["routing"]["decisions"] = [_fusion_decision(grounding_on)]
+    c["routing"]["decisions"] = [_fusion_decision(grounding_on, policy)]
 
     # disable external-dependency stores (milvus/redis/llama_stack) for a
     # self-contained local run -- otherwise startup fatals on missing services.
@@ -153,11 +159,19 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="config/config.yaml")
     ap.add_argument("--out-dir", default="bench/grounded_fusion")
+    ap.add_argument(
+        "--policy",
+        default="weight",
+        choices=["weight", "annotate", "filter"],
+        help="grounding policy for the 'on' arm: weight/annotate keep all panel "
+        "responses; filter hard-drops below min_score (known to hurt). Use this to "
+        "A/B the policies in follow-up experiments.",
+    )
     args = ap.parse_args()
     with open(args.base) as f:
         base = yaml.safe_load(f)
     for on in (True, False):
-        cfg = build(base, on)
+        cfg = build(base, on, args.policy)
         path = f"{args.out_dir}/config-fusion-{'on' if on else 'off'}.yaml"
         with open(path, "w") as f:
             yaml.safe_dump(cfg, f, sort_keys=False, width=120)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -809,14 +809,22 @@ routing:
           judge_prompt_version: fusion-v1
           # Grounding-aware synthesis: score panel responses for faithfulness
           # (hallucination detector against context, else cross-model NLI) and
-          # rank/filter them before the judge. Disabled by default.
+          # use the scores to guide the judge. Disabled by default.
           grounding:
             enabled: false
             reference: hybrid          # hybrid | context | panel
-            min_score: 0.0             # drop responses scoring below this (0-1)
-            min_keep: 1                # always keep at least this many
+            policy: weight             # weight | annotate | filter (see below)
+            min_score: 0.0             # filter policy only: drop below this (0-1)
+            min_keep: 1                # filter policy only: keep at least this many
             nli_contradiction_penalty: 1.0
             on_error: skip             # skip (fall back to plain fusion) | fail
+            # policy controls how the scores are used:
+            #   weight   (default) keep every response; tell the judge to weight
+            #            each answer by its score (a correct lone dissenter is kept).
+            #   annotate keep every response; pass the scores to the judge as notes.
+            #   filter   hard-drop responses below min_score (keep min_keep).
+            # filter regresses quality on contested factual questions because it
+            # deletes the correct dissenter; see bench/grounded_fusion/FINDINGS.md.
 
     - name: terse_elo_route
       description: Personalized terse-answer route using Elo selection.

--- a/src/semantic-router/pkg/config/fusion_config.go
+++ b/src/semantic-router/pkg/config/fusion_config.go
@@ -16,6 +16,19 @@ const (
 	FusionGroundingReferenceHybrid  = "hybrid"  // detector against context if present, else cross-model NLI
 	FusionGroundingReferenceContext = "context" // detector against provided RAG/tool context only
 	FusionGroundingReferencePanel   = "panel"   // cross-model NLI only (panel as its own reference)
+
+	// Grounding policy modes select how the groundedness scores are used.
+	//   - weight:   keep every response, tell the judge to weight each panel
+	//               answer by its groundedness score (soft down-weighting).
+	//   - annotate: keep every response, surface groundedness notes to the judge
+	//               without a weighting instruction.
+	//   - filter:   hard-drop responses below min_score (keep min_keep).
+	// The default is weight. Hard-dropping the least mutually-consistent response
+	// regresses quality on contested factual items (it deletes the correct
+	// dissenter); see bench/grounded_fusion/FINDINGS.md.
+	FusionGroundingPolicyWeight   = "weight"
+	FusionGroundingPolicyAnnotate = "annotate"
+	FusionGroundingPolicyFilter   = "filter"
 )
 
 // FusionAlgorithmConfig configures Fusion-style panel execution for
@@ -43,6 +56,7 @@ type FusionAlgorithmConfig struct {
 type FusionGroundingConfig struct {
 	Enabled                 bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	Reference               string  `yaml:"reference,omitempty" json:"reference,omitempty"`
+	Policy                  string  `yaml:"policy,omitempty" json:"policy,omitempty"`
 	MinScore                float64 `yaml:"min_score,omitempty" json:"min_score,omitempty"`
 	MinKeep                 int     `yaml:"min_keep,omitempty" json:"min_keep,omitempty"`
 	NLIContradictionPenalty float64 `yaml:"nli_contradiction_penalty,omitempty" json:"nli_contradiction_penalty,omitempty"`
@@ -143,6 +157,12 @@ func ValidateFusionGroundingConfig(cfg *FusionGroundingConfig) error {
 	default:
 		return fmt.Errorf("grounding.reference must be one of %q, %q or %q, got %q",
 			FusionGroundingReferenceHybrid, FusionGroundingReferenceContext, FusionGroundingReferencePanel, cfg.Reference)
+	}
+	switch strings.TrimSpace(cfg.Policy) {
+	case "", FusionGroundingPolicyWeight, FusionGroundingPolicyAnnotate, FusionGroundingPolicyFilter:
+	default:
+		return fmt.Errorf("grounding.policy must be one of %q, %q or %q, got %q",
+			FusionGroundingPolicyWeight, FusionGroundingPolicyAnnotate, FusionGroundingPolicyFilter, cfg.Policy)
 	}
 	if cfg.MinScore < 0 || cfg.MinScore > 1 {
 		return fmt.Errorf("grounding.min_score must be between 0 and 1")

--- a/src/semantic-router/pkg/looper/fusion.go
+++ b/src/semantic-router/pkg/looper/fusion.go
@@ -38,6 +38,7 @@ type fusionExecutionConfig struct {
 
 	GroundingEnabled                 bool
 	GroundingReference               string
+	GroundingPolicy                  string
 	GroundingMinScore                float64
 	GroundingMinKeep                 int
 	GroundingNLIContradictionPenalty float64
@@ -121,7 +122,7 @@ func (l *FusionLooper) Execute(ctx context.Context, req *Request) (*Response, er
 	}
 
 	analysis, analysisResp := l.runFusionAnalysis(ctx, req, cfg, groundedPanel, groundingScores)
-	finalResp, err := l.runFusionFinal(ctx, req, cfg, groundedPanel, analysis)
+	finalResp, err := l.runFusionFinal(ctx, req, cfg, groundedPanel, analysis, groundingScores)
 	if err != nil {
 		return nil, err
 	}
@@ -179,6 +180,13 @@ func applyGroundingDefaults(cfg *fusionExecutionConfig) {
 	}
 	if cfg.GroundingReference == "" {
 		cfg.GroundingReference = config.FusionGroundingReferenceHybrid
+	}
+	if cfg.GroundingPolicy == "" {
+		// Default to soft down-weighting: hard-dropping the least mutually
+		// consistent response regresses quality on contested factual items
+		// (see bench/grounded_fusion/FINDINGS.md). Set policy=filter for the
+		// prior drop behavior.
+		cfg.GroundingPolicy = config.FusionGroundingPolicyWeight
 	}
 	if cfg.GroundingMinKeep <= 0 {
 		cfg.GroundingMinKeep = 1
@@ -243,6 +251,7 @@ func mergeFusionGroundingConfig(dst *fusionExecutionConfig, src *config.FusionGr
 	}
 	dst.GroundingEnabled = src.Enabled
 	dst.GroundingReference = src.Reference
+	dst.GroundingPolicy = src.Policy
 	dst.GroundingMinScore = src.MinScore
 	dst.GroundingMinKeep = src.MinKeep
 	dst.GroundingNLIContradictionPenalty = src.NLIContradictionPenalty
@@ -433,8 +442,14 @@ func (l *FusionLooper) runFusionFinal(
 	cfg fusionExecutionConfig,
 	panelResponses []*ModelResponse,
 	analysis *FusionAnalysis,
+	groundingScores []groundingScore,
 ) (*ModelResponse, error) {
 	prompt := buildFusionFinalPrompt(cfg, extractOriginalContent(req.OriginalRequest), panelResponses, analysis)
+	// Under weight/annotate policies the panel was not pruned, so the judge needs
+	// the per-response groundedness signal at synthesis time to soft-weight.
+	if notes := groundingSynthesisNotes(groundingScores, cfg.GroundingPolicy); notes != "" {
+		prompt = prompt + "\n\n" + notes
+	}
 	finalReq := appendFusionStageMessage(req.OriginalRequest, prompt)
 	resp, err := l.callFusionModel(ctx, &Request{OriginalRequest: finalReq, ModelParams: req.ModelParams}, cfg, cfg.Model, true, false, len(panelResponses)+2)
 	if err != nil {
@@ -558,6 +573,7 @@ func buildFusionTrace(
 	if len(groundingScores) > 0 {
 		trace.Grounding = &FusionGroundingTrace{
 			ReferenceMode: groundingMode,
+			Policy:        cfg.GroundingPolicy,
 			Scores:        groundingScores,
 		}
 	}

--- a/src/semantic-router/pkg/looper/grounding.go
+++ b/src/semantic-router/pkg/looper/grounding.go
@@ -64,6 +64,7 @@ type groundingScore struct {
 // FusionGroundingTrace is attached to FusionTrace for observability.
 type FusionGroundingTrace struct {
 	ReferenceMode string           `json:"reference_mode,omitempty"`
+	Policy        string           `json:"policy,omitempty"`
 	Scores        []groundingScore `json:"scores,omitempty"`
 }
 
@@ -103,9 +104,20 @@ func (l *FusionLooper) applyGrounding(
 		return panel, nil, "", nil
 	}
 
-	kept = filterPanelByScore(panel, scores, cfg)
+	// Policy decides what we do with the scores. Only `filter` drops responses;
+	// `weight`/`annotate` keep the full panel and let the judge soft-weight from
+	// the groundedness notes (the synthesis prompt is annotated in runFusionFinal).
+	// Hard-dropping the least mutually-consistent response regresses quality on
+	// contested factual items (see bench/grounded_fusion/FINDINGS.md), so it is no
+	// longer the default.
+	if cfg.GroundingPolicy == config.FusionGroundingPolicyFilter {
+		kept = filterPanelByScore(panel, scores, cfg)
+	} else {
+		kept = panel
+	}
 	logging.ComponentEvent("looper", "fusion_grounding_applied", map[string]interface{}{
 		"reference_mode": referenceMode,
+		"policy":         cfg.GroundingPolicy,
 		"panel_in":       len(panel),
 		"panel_kept":     len(kept),
 	})
@@ -385,6 +397,25 @@ func formatGroundingNotes(scores []groundingScore) string {
 		b.WriteString("\n")
 	}
 	return strings.TrimSpace(b.String())
+}
+
+// groundingSynthesisNotes renders the groundedness notes for the final synthesis
+// prompt. For the `weight` policy it prepends an explicit instruction to weight
+// each panel answer by its score (while protecting a correct lone dissenter);
+// `annotate` emits the notes without that instruction. `filter` returns empty —
+// the panel was already pruned, so the judge needs no per-response weighting.
+func groundingSynthesisNotes(scores []groundingScore, policy string) string {
+	if policy == config.FusionGroundingPolicyFilter {
+		return ""
+	}
+	notes := formatGroundingNotes(scores)
+	if notes == "" {
+		return ""
+	}
+	if policy == config.FusionGroundingPolicyWeight {
+		return "Weight each panel answer by its groundedness score below: prefer better-supported answers and treat flagged/contradicted claims with extra skepticism. Do not discard a lower-scoring answer if it is the only one that is correct — consistency is not the same as correctness.\n\n" + notes
+	}
+	return notes
 }
 
 func modelName(r *ModelResponse) string {

--- a/src/semantic-router/pkg/looper/grounding_live_test.go
+++ b/src/semantic-router/pkg/looper/grounding_live_test.go
@@ -1,0 +1,94 @@
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestFusionWeightPolicy_LiveOllama exercises the full Fusion path with the default
+// weight grounding policy against locally-running Ollama models via the
+// OpenAI-compatible endpoint. The cross-model NLI scorer is stubbed (the candle NLI
+// model is not needed for this check), so this validates the orchestration + the
+// new soft-weight policy against REAL panel/judge/synthesis LLM calls: the panel is
+// scored, nothing is dropped, the groundedness notes reach synthesis, and a real
+// answer comes back.
+//
+// Skipped unless OLLAMA_LIVE=1. Models default to llama3.1:8b + gemma3:12b (no
+// "thinking" latency); override with OLLAMA_ENDPOINT / OLLAMA_PANEL / OLLAMA_JUDGE.
+//
+//	OLLAMA_LIVE=1 go test ./pkg/looper/ -run TestFusionWeightPolicy_LiveOllama -v
+func TestFusionWeightPolicy_LiveOllama(t *testing.T) {
+	if os.Getenv("OLLAMA_LIVE") != "1" {
+		t.Skip("set OLLAMA_LIVE=1 to run against a local Ollama instance")
+	}
+	endpoint := envOr("OLLAMA_ENDPOINT", "http://localhost:11434/v1/chat/completions")
+	judge := envOr("OLLAMA_JUDGE", "llama3.1:8b")
+	panelEnv := envOr("OLLAMA_PANEL", "llama3.1:8b,gemma3:12b")
+	panelModels := strings.Split(panelEnv, ",")
+
+	// Deterministic NLI stub: flag any answer mentioning "teleport" as contradicted
+	// by its peers, everything else entailed. Produces a real score spread so the
+	// weight policy has something to surface to the judge — without the candle model.
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(strings.ToLower(hypothesis), "teleport") {
+			return 0.05, 0.9, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:          judge,
+			AnalysisModels: panelModels,
+			MaxConcurrent:  1, // serialize local model loads to avoid Ollama thrash
+			Grounding: &config.FusionGroundingConfig{
+				Enabled:   true,
+				Reference: config.FusionGroundingReferencePanel,
+				// policy unset -> defaults to weight (no hard-drop)
+			},
+		},
+	}
+
+	resp, err := NewFusionLooper(&config.LooperConfig{Endpoint: endpoint}).
+		Execute(context.Background(), req)
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+	// A real synthesized answer came back from the judge model.
+	choices := body["choices"].([]interface{})
+	require.NotEmpty(t, choices)
+	msg := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+	content, _ := msg["content"].(string)
+	assert.NotEmpty(t, content, "expected a synthesized final answer from Ollama")
+	t.Logf("final answer (truncated): %.300s", content)
+
+	// Grounding ran under the weight policy and kept the WHOLE panel (no drops).
+	grounding := body["fusion"].(map[string]interface{})["grounding"].(map[string]interface{})
+	assert.Equal(t, config.FusionGroundingPolicyWeight, grounding["policy"])
+	scores := grounding["scores"].([]interface{})
+	assert.Len(t, scores, len(panelModels), "weight policy must keep every panel response")
+	for _, s := range scores {
+		dropped, _ := s.(map[string]interface{})["dropped"].(bool)
+		assert.False(t, dropped, "weight policy must not drop responses")
+	}
+	assert.Positive(t, resp.Usage.TotalTokens)
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/src/semantic-router/pkg/looper/grounding_test.go
+++ b/src/semantic-router/pkg/looper/grounding_test.go
@@ -235,6 +235,7 @@ func TestApplyGrounding_PanelModeFiltersContradicted(t *testing.T) {
 	cfg := fusionExecutionConfig{
 		GroundingEnabled:                 true,
 		GroundingReference:               config.FusionGroundingReferencePanel,
+		GroundingPolicy:                  config.FusionGroundingPolicyFilter,
 		GroundingOnError:                 config.FusionOnErrorSkip,
 		GroundingMinScore:                0.5,
 		GroundingMinKeep:                 1,
@@ -249,6 +250,103 @@ func TestApplyGrounding_PanelModeFiltersContradicted(t *testing.T) {
 		assert.NotContains(t, r.Content, "bad")
 	}
 	assert.Len(t, kept, 2)
+}
+
+// TestApplyGrounding_WeightPolicyKeepsAll verifies the default soft-weight policy
+// scores the panel but drops nothing, even a peer-contradicted response.
+func TestApplyGrounding_WeightPolicyKeepsAll(t *testing.T) {
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(hypothesis, "bad") {
+			return 0.1, 0.8, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	l := NewFusionLooper(&config.LooperConfig{})
+	cfg := fusionExecutionConfig{
+		GroundingEnabled:                 true,
+		GroundingReference:               config.FusionGroundingReferencePanel,
+		GroundingPolicy:                  config.FusionGroundingPolicyWeight,
+		GroundingOnError:                 config.FusionOnErrorSkip,
+		GroundingMinScore:                0.5, // high threshold is ignored under weight
+		GroundingMinKeep:                 1,
+		GroundingNLIContradictionPenalty: 1.0,
+	}
+	in := panel("good one", "good two", "bad three")
+	kept, scores, _, err := l.applyGrounding(newFusionTestRequest(), cfg, in)
+	require.NoError(t, err)
+	// Nothing dropped: the contradicted response is still present.
+	assert.Len(t, kept, 3)
+	require.Len(t, scores, 3)
+	for _, s := range scores {
+		assert.False(t, s.Dropped, "weight policy must not drop responses")
+	}
+}
+
+// TestApplyGrounding_AnnotatePolicyKeepsAll mirrors the weight test for annotate.
+func TestApplyGrounding_AnnotatePolicyKeepsAll(t *testing.T) {
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(hypothesis, "bad") {
+			return 0.1, 0.8, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	l := NewFusionLooper(&config.LooperConfig{})
+	cfg := fusionExecutionConfig{
+		GroundingEnabled:                 true,
+		GroundingReference:               config.FusionGroundingReferencePanel,
+		GroundingPolicy:                  config.FusionGroundingPolicyAnnotate,
+		GroundingOnError:                 config.FusionOnErrorSkip,
+		GroundingMinScore:                0.9,
+		GroundingMinKeep:                 1,
+		GroundingNLIContradictionPenalty: 1.0,
+	}
+	kept, scores, _, err := l.applyGrounding(newFusionTestRequest(), cfg, panel("good one", "bad two"))
+	require.NoError(t, err)
+	assert.Len(t, kept, 2)
+	require.Len(t, scores, 2)
+	for _, s := range scores {
+		assert.False(t, s.Dropped)
+	}
+}
+
+func TestGroundingSynthesisNotes(t *testing.T) {
+	scores := []groundingScore{
+		{Model: "a", Score: 0.8},
+		{Model: "b", Score: 0.2, FlaggedSpans: []string{"a"}},
+	}
+	// weight: includes the weighting directive plus the per-model notes.
+	weight := groundingSynthesisNotes(scores, config.FusionGroundingPolicyWeight)
+	assert.Contains(t, weight, "Weight each panel answer")
+	assert.Contains(t, weight, "consistency is not the same as correctness")
+	assert.Contains(t, weight, "score 0.80")
+	// annotate: notes without the weighting directive.
+	annotate := groundingSynthesisNotes(scores, config.FusionGroundingPolicyAnnotate)
+	assert.NotContains(t, annotate, "Weight each panel answer")
+	assert.Contains(t, annotate, "Groundedness notes")
+	// filter: nothing (the panel was already pruned).
+	assert.Empty(t, groundingSynthesisNotes(scores, config.FusionGroundingPolicyFilter))
+	// no scores: empty regardless of policy.
+	assert.Empty(t, groundingSynthesisNotes(nil, config.FusionGroundingPolicyWeight))
+}
+
+// TestApplyGroundingDefaults_PolicyDefaultsToWeight verifies the resolved config
+// defaults the policy to weight when grounding is enabled and policy is unset.
+func TestApplyGroundingDefaults_PolicyDefaultsToWeight(t *testing.T) {
+	cfg := fusionExecutionConfig{GroundingEnabled: true}
+	applyGroundingDefaults(&cfg)
+	assert.Equal(t, config.FusionGroundingPolicyWeight, cfg.GroundingPolicy)
+
+	// An explicit policy is preserved.
+	cfg = fusionExecutionConfig{GroundingEnabled: true, GroundingPolicy: config.FusionGroundingPolicyFilter}
+	applyGroundingDefaults(&cfg)
+	assert.Equal(t, config.FusionGroundingPolicyFilter, cfg.GroundingPolicy)
+
+	// Disabled grounding leaves the policy untouched.
+	cfg = fusionExecutionConfig{}
+	applyGroundingDefaults(&cfg)
+	assert.Empty(t, cfg.GroundingPolicy)
 }
 
 // TestFusionExecute_GroundingKeepsContradictedOutOfJudge runs the full Execute
@@ -292,6 +390,7 @@ func TestFusionExecute_GroundingKeepsContradictedOutOfJudge(t *testing.T) {
 			Grounding: &config.FusionGroundingConfig{
 				Enabled:   true,
 				Reference: config.FusionGroundingReferencePanel,
+				Policy:    config.FusionGroundingPolicyFilter,
 				MinScore:  0.5,
 				MinKeep:   1,
 			},
@@ -311,4 +410,67 @@ func TestFusionExecute_GroundingKeepsContradictedOutOfJudge(t *testing.T) {
 	// just the kept responses — grounding makes no extra calls but the panel cost
 	// was already paid.
 	assert.Positive(t, resp.Usage.TotalTokens)
+}
+
+// TestFusionExecute_WeightPolicyKeepsPanelAndAnnotatesSynthesis runs the full
+// Execute path under the default weight policy: the contradicted response is NOT
+// dropped (it still reaches the judge) and the final synthesis prompt carries the
+// groundedness weighting notes.
+func TestFusionExecute_WeightPolicyKeepsPanelAndAnnotatesSynthesis(t *testing.T) {
+	withGroundingBackends(t, func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(hypothesis, "bad") {
+			return 0.1, 0.8, nil
+		}
+		return 0.9, 0.05, nil
+	}, nil)
+
+	var sawDissenterAtJudge, sawNotesAtSynthesis bool
+	server := newFusionStubServer(t, func(model, prompt string) (string, int) {
+		switch model {
+		case "panel-a":
+			return "good grounded answer", http.StatusOK
+		case "panel-b":
+			return "bad contradicted answer", http.StatusOK
+		case "judge":
+			if strings.Contains(prompt, "return only valid JSON") {
+				// Weight policy keeps the dissenter in the judge's panel.
+				if strings.Contains(prompt, "bad contradicted answer") {
+					sawDissenterAtJudge = true
+				}
+				return `{"consensus":[],"contradictions":["x"],"partial_coverage":[],"unique_insights":[],"blind_spots":[]}`, http.StatusOK
+			}
+			// Final synthesis prompt carries the weighting notes.
+			if strings.Contains(prompt, "Weight each panel answer") {
+				sawNotesAtSynthesis = true
+			}
+			return "final answer", http.StatusOK
+		default:
+			return "unexpected", http.StatusInternalServerError
+		}
+	})
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:          "judge",
+			AnalysisModels: []string{"panel-a", "panel-b"},
+			Grounding: &config.FusionGroundingConfig{
+				Enabled:   true,
+				Reference: config.FusionGroundingReferencePanel,
+				// Policy unset -> defaults to weight.
+			},
+		},
+	}
+
+	resp, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, sawDissenterAtJudge, "weight policy should keep the contradicted response in the judge panel")
+	assert.True(t, sawNotesAtSynthesis, "weight policy should annotate the final synthesis prompt")
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	grounding := body["fusion"].(map[string]interface{})["grounding"].(map[string]interface{})
+	assert.Equal(t, config.FusionGroundingPolicyWeight, grounding["policy"])
 }

--- a/src/vllm-sr/cli/algorithms.py
+++ b/src/vllm-sr/cli/algorithms.py
@@ -117,6 +117,11 @@ class FusionGroundingConfig(BaseModel):
 
     enabled: bool | None = False
     reference: Literal["hybrid", "context", "panel"] | None = "hybrid"
+    # How the groundedness scores are used. weight/annotate keep every response and
+    # let the judge soft-weight; filter hard-drops below min_score. Default weight:
+    # hard-dropping the least consistent response regresses quality on contested
+    # factual items (see bench/grounded_fusion/FINDINGS.md).
+    policy: Literal["weight", "annotate", "filter"] | None = "weight"
     min_score: float | None = Field(default=0.0, ge=0, le=1)
     min_keep: int | None = Field(default=1, ge=0)
     nli_contradiction_penalty: float | None = Field(default=1.0, ge=0)

--- a/src/vllm-sr/tests/test_algorithm_config.py
+++ b/src/vllm-sr/tests/test_algorithm_config.py
@@ -362,6 +362,7 @@ class TestFusionAlgorithmConfig:
         config = FusionAlgorithmConfig(grounding={"enabled": True})
         assert config.grounding.enabled is True
         assert config.grounding.reference == "hybrid"
+        assert config.grounding.policy == "weight"
         assert config.grounding.min_score == 0.0
         assert config.grounding.min_keep == 1
         assert config.grounding.nli_contradiction_penalty == 1.0
@@ -384,6 +385,9 @@ class TestFusionAlgorithmConfig:
             FusionAlgorithmConfig(grounding={"reference": "elsewhere"})
         with pytest.raises(PydanticValidationError):
             FusionAlgorithmConfig(grounding={"on_error": "ignore"})
+        # policy enum
+        with pytest.raises(PydanticValidationError):
+            FusionAlgorithmConfig(grounding={"policy": "drop"})
 
 
 class TestAlgorithmConfigIntegration:

--- a/website/docs/proposals/deliberation-algorithms.md
+++ b/website/docs/proposals/deliberation-algorithms.md
@@ -87,12 +87,22 @@ Reliability hierarchy of signals: grounded > peer-supported > confident >
 self-consistent > relevant. None is truth, but stacked they give a robust *relative*
 score — enough to down-weight the least-supported responses before synthesis.
 
+**Use the score as a soft weight, not a hard filter.** The first evaluation
+(`bench/grounded_fusion/FINDINGS.md`) found that *hard-dropping* the least
+mutually-consistent panel response regresses quality on contested factual questions:
+three weaker models can be confidently wrong together (high mutual entailment) while
+the lone dissenter — often the strongest model — is right, and consistency filtering
+deletes exactly that signal. The grounding stage therefore defaults to the `weight`
+policy (keep every response, let the judge weight by score and protect a correct
+dissenter); `filter` remains available but is opt-in.
+
 ## 6. Recommendation — Grounding-Aware Fusion (hybrid reference)
 
 Extend the existing `FusionLooper` with an optional grounding stage (off by default):
 after the panel returns and before the judge runs, score each response for
-groundedness, then rank and filter. Hybrid reference: detector against context when
-present, otherwise cross-model NLI.
+groundedness, then guide synthesis with the scores (soft-weight by default; hard
+filter is opt-in). Hybrid reference: detector against context when present, otherwise
+cross-model NLI.
 
 This is the highest-leverage first build because:
 

--- a/website/docs/proposals/deliberation-algorithms.md
+++ b/website/docs/proposals/deliberation-algorithms.md
@@ -44,7 +44,70 @@ answer grounded in that analysis. Reported findings:
 vSR's Fusion matches the pipeline shape but lacks the server-side web tools and
 exclude-lists (an honest gap where OpenRouter leads).
 
-## 3. Candidate algorithms
+## 3. Why fusion works — and what the consistency score is *not*
+
+It is easy to misread fusion as "average several models and trust where they agree."
+That is the wrong mental model, and it leads directly to the regression that motivated
+the `weight` default. Spelling out the actual mechanism keeps the design honest.
+
+### 3.1 The three mechanisms — only one carries the lift
+
+- **Coverage (raises the ceiling).** Models have different blind spots, so the *union*
+  of what a panel knows is larger than any single member. On a hard question the correct
+  fact, framing, or citation often appears *somewhere* in the panel even if no member
+  got the whole answer right. This raises the best *achievable* answer; it does not, by
+  itself, produce it.
+- **Self-consistency / marginalization.** Sampling many answers and taking the consensus
+  cancels reasoning-path noise — but only for tasks with a checkable answer (e.g. math).
+  It does little for the open-ended factual questions that dominate real traffic.
+- **Verification is easier than generation — this is where the lift comes from.** A judge
+  reading several candidate answers *with the question in front of it* operates in
+  verify-mode: cross-check this claim against that one, notice the contradiction, keep the
+  supported piece. That is cheaper and more reliable than generating from a blank page.
+
+The decisive evidence for the third mechanism is **self-fusion**: pairing a model with
+*itself* (zero panel diversity) still gains ~+6.7 points (§2). There is no ensemble magic
+there — the gain is the synthesis pass reconsidering candidates. **The intelligence in
+fusion lives in the judge, not in the panel and not in the consistency score.**
+
+### 3.2 What the consistency score is — and is not
+
+The cross-model NLI / groundedness score measures *agreement and faithfulness*, not
+truth. On factual questions agreement can be actively misleading: several mediocre models
+can be confidently, consistently wrong together while the strongest model is the lone
+dissenter *because* it knows something they do not. Empirically the score discriminates
+weakly (DRACO Level-1 Spearman ≈ +0.21) — useful as a hint, useless as an oracle. Treated
+as a hard filter it deletes exactly the correct-minority signal, which is the regression
+documented in `bench/grounded_fusion/FINDINGS.md`. So the score is a **soft attention hint
+handed to the judge**, never a gate (this is the `weight` policy; see §6).
+
+### 3.3 Does fusing a frontier model with weaker ones beat the frontier model solo?
+
+Often it does **not**, and the design should not assume it does:
+
+- On questions the frontier model already nails, weaker panelists are noise and cost. A
+  confidently wrong panelist can even *anchor* the judge and make a frontier answer worse.
+- When it *does* help, the win is the strongest model doing verify-mode synthesis over a
+  *superset* of content — a weaker model occasionally surfaces a fact or angle the frontier
+  model omitted, and the judge folds it in. You are not averaging models; you are widening
+  the candidate pool the verifier reads.
+- The gate that decides the outcome is **judge competence**. A weak judge regresses to the
+  consistent-but-wrong majority. The judge should be the strongest available model.
+
+### 3.4 Consequences for the design
+
+1. **Synthesize with a strong judge** — that is where the value is; do not synthesize with
+   a weak calling model.
+2. **Treat panel answers as evidence to verify, not authorities to average**, with the
+   grounding score as a soft annotation (the `weight` policy).
+3. **Gate the spend** — pay the N+2 calls only when the question is hard/contested or the
+   lead model is low-confidence (the adaptive-gating follow-up in §8).
+4. **Prefer ground truth over mutual agreement** — retrieval/tool context lets the panel
+   anchor on *sources* and the judge synthesize against citations. `context`-mode grounding
+   beats panel-mode consistency because it scores against truth-ish references rather than
+   agreement; this is also the real capability gap vs OpenRouter (§4).
+
+## 4. Candidate algorithms
 
 Each maps onto the existing `BaseLooper` substrate (`client.CallModel`, `SumUsage`,
 response formatting) and registers as a looper algorithm.
@@ -56,7 +119,7 @@ response formatting) and registers as a looper algorithm.
 | Cross-model self-consistency | SelfCheckGPT | Cluster semantically-equivalent answers, return the consensus | No judge; statistical consensus |
 | Confidence-gated / adaptive deliberation | AutoMix | Cheap model first; deliberate only when low-confidence | Resolves the spend/save tension at the gateway |
 
-## 4. Where vSR beats OpenRouter
+## 5. Where vSR beats OpenRouter
 
 OpenRouter is a pass-through API, so its Fusion must be static and model-driven. vSR
 is a classifying gateway, so its Fusion can be adaptive and signal-driven.
@@ -73,7 +136,7 @@ Honest gaps where OpenRouter leads: server-side web tools + exclude-lists, four
 polished entry modes, and the DRACO eval harness (worth borrowing to *prove* the
 grounding lift).
 
-## 5. The ground-truth reality
+## 6. The ground-truth reality
 
 The detector measures **groundedness against a provided reference**, not truth. So
 the design choice is *what serves as the reference*:
@@ -96,7 +159,7 @@ deletes exactly that signal. The grounding stage therefore defaults to the `weig
 policy (keep every response, let the judge weight by score and protect a correct
 dissenter); `filter` remains available but is opt-in.
 
-## 6. Recommendation — Grounding-Aware Fusion (hybrid reference)
+## 7. Recommendation — Grounding-Aware Fusion (hybrid reference)
 
 Extend the existing `FusionLooper` with an optional grounding stage (off by default):
 after the panel returns and before the judge runs, score each response for
@@ -117,13 +180,13 @@ See the implementation in `tutorials/algorithm/looper/fusion.md` (Grounding-Awar
 Synthesis). It makes no extra LLM calls and degrades gracefully (`on_error: skip`
 falls back to plain Fusion when the detectors are unavailable).
 
-## 7. Evaluation
+## 8. Evaluation
 
 Borrow DRACO-style scoring (with negative criteria) to prove the lift: A/B plain
 Fusion vs grounding-aware Fusion on a factuality slice, measuring resolve quality and
 the rate at which contradicted/ungrounded panel responses are kept out of synthesis.
 
-## 8. Follow-ups
+## 9. Follow-ups
 
 - Multi-Agent Debate as a high-accuracy escalation engine.
 - Adaptive gating (cheap-first, deliberate-on-low-confidence) to fix Fusion's

--- a/website/docs/tutorials/algorithm/looper/fusion.md
+++ b/website/docs/tutorials/algorithm/looper/fusion.md
@@ -166,7 +166,7 @@ Request-level override:
 
 ## Grounding-Aware Synthesis
 
-By default the judge reads raw panel text with no grounding oracle. Grounding-aware synthesis scores each panel response for **faithfulness** *before* the judge runs, then ranks and filters the panel so the judge synthesizes from the most-grounded responses. It makes **no extra LLM calls** — it uses local encoder models (the hallucination/groundedness detector and an NLI entailment model).
+By default the judge reads raw panel text with no grounding oracle. Grounding-aware synthesis scores each panel response for **faithfulness** *before* the judge runs, then uses those scores to guide synthesis toward the better-grounded responses. It makes **no extra LLM calls** — it uses local encoder models (the hallucination/groundedness detector and an NLI entailment model).
 
 Reference selection (what each answer is scored against):
 
@@ -174,7 +174,13 @@ Reference selection (what each answer is scored against):
 - `panel` — score answers against each other via cross-model NLI; the panel acts as its own mutual reference (no external dependency, works on any query).
 - `hybrid` (default) — use `context` when the request carries it, otherwise `panel`.
 
-> Grounding measures faithfulness/consistency, not truth. With no authoritative source it can down-weight the least-supported responses, not certify correctness.
+Policy (how the scores are used):
+
+- `weight` (default) — keep every response and instruct the judge to weight each panel answer by its score, while explicitly protecting a correct lone dissenter.
+- `annotate` — keep every response and pass the scores to the judge as notes, without a weighting instruction.
+- `filter` — hard-drop responses scoring below `min_score` (always keeping `min_keep`); only this policy uses `min_score`/`min_keep`.
+
+> Grounding measures faithfulness/consistency, not truth. With no authoritative source it can down-weight the least-supported responses, not certify correctness. **Hard-dropping** the least mutually-consistent response (the `filter` policy) measurably *hurts* on contested factual questions — three models can be confidently wrong together while the lone dissenter is right — so the default is `weight`. See `bench/grounded_fusion/FINDINGS.md` for the evaluation behind this default.
 
 Requires the hallucination detector (and, for the `panel`/cross-model path, the NLI model) to be configured under `global` hallucination mitigation. If the backends are unavailable, `on_error: skip` falls back to plain Fusion.
 
@@ -187,13 +193,14 @@ algorithm:
     grounding:
       enabled: true
       reference: hybrid          # hybrid | context | panel
-      min_score: 0.0             # drop responses scoring below this (0-1)
-      min_keep: 1                # always keep at least this many
+      policy: weight             # weight | annotate | filter
+      min_score: 0.0             # filter policy only: drop below this (0-1)
+      min_keep: 1                # filter policy only: keep at least this many
       nli_contradiction_penalty: 1.0
       on_error: skip             # skip (fall back to plain fusion) | fail
 ```
 
-When enabled, the Fusion response `trace.grounding` records the reference mode and per-response `score`, `flagged_spans`, and whether each was `dropped`.
+When enabled, the Fusion response `trace.grounding` records the reference mode, the `policy`, and per-response `score`, `flagged_spans`, and whether each was `dropped` (only under the `filter` policy).
 
 ### Grounding parameters
 
@@ -201,7 +208,8 @@ When enabled, the Fusion response `trace.grounding` records the reference mode a
 |-----------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable grounding-aware synthesis |
 | `reference` | string | `hybrid` | `hybrid`, `context`, or `panel` |
-| `min_score` | float | `0.0` | Drop responses scoring below this (0–1) |
-| `min_keep` | int | `1` | Always keep at least this many top-scoring responses |
+| `policy` | string | `weight` | `weight` (soft-weight, keep all), `annotate` (notes, keep all), or `filter` (hard-drop) |
+| `min_score` | float | `0.0` | `filter` policy only: drop responses scoring below this (0–1) |
+| `min_keep` | int | `1` | `filter` policy only: keep at least this many top-scoring responses |
 | `nli_contradiction_penalty` | float | `1.0` | Weight of a peer contradiction in the `panel` reference |
 | `on_error` | string | `skip` | `skip` (fall back to plain Fusion) or `fail` |


### PR DESCRIPTION
## What & why

The grounding-aware Fusion stage (PR #2214 / #2233) scores each panel response for
faithfulness and then **hard-drops** the least-grounded ones before the judge
synthesizes. The DRACO evaluation in `bench/grounded_fusion/FINDINGS.md` showed that
hard-dropping **regresses** answer quality on contested factual questions: the dropped
response is often the strongest model carrying the correct minority view — consistency
is not the same as correctness.

This PR replaces the drop-by-default behavior with **soft down-weighting** via a new
`grounding.policy` lever:

- **`weight`** (new default) — keep every panel response; the judge is told to weight
  each answer by its groundedness score, while explicitly protecting a correct lone
  dissenter. Groundedness notes now reach the **final synthesis** prompt (previously
  only the analysis prompt).
- **`annotate`** — keep every response; pass scores to the judge as notes only.
- **`filter`** — the prior hard-drop (below `min_score`, keeping `min_keep`); now
  opt-in. `min_score`/`min_keep` apply to this policy only.

The trace records the active policy. Grounding is still disabled by default, so this
only changes behavior for routes that opt into grounding.

### Still open (deferred to follow-up CRs)

- Does `weight`/`annotate` actually *beat* plain fusion, or just avoid the regression?
- Is the scorer (Level-1 Spearman +0.21) strong enough that soft-weighting on it
  improves synthesis?

`make_configs.py` now takes `--policy {weight,annotate,filter}` so these can be A/B'd
in a later experiment; the decision + open questions are recorded in
`bench/grounded_fusion/FINDINGS.md` and `README.md`.

## Changes

- **Router**: `grounding.policy` config + validation; soft-weight/annotate apply paths
  (no drop); groundedness notes surfaced to synthesis; policy in the trace.
- **CLI**: pydantic validator mirror kept in lockstep.
- **Bench**: harness parameterized by policy; findings/decision recorded.
- **Docs**: reference config, fusion tutorial, deliberation proposal.

## Test Plan

- `go test ./pkg/looper/... ./pkg/config/...` — pass. New unit tests cover the
  weight/annotate no-drop modes, synthesis-notes formatting, the default policy, and
  a regression guard that `filter` is unchanged.
- `pytest src/vllm-sr/tests/test_algorithm_config.py` — 42 pass (policy default + enum).
- **Live end-to-end against local Ollama** (`OLLAMA_LIVE=1 go test ./pkg/looper/ -run
  TestFusionWeightPolicy_LiveOllama`): full panel → grounding(weight) → judge →
  synthesis with a real panel (`llama3.1:8b`, `gemma3:12b`) and judge (`llama3.1:8b`);
  asserts a real synthesized answer, `policy=weight` in the trace, no panel response
  dropped. Passed (~23s).
- Full local gate `make agent-ci-lint` — pass (pre-commit hooks, Python lint, Go lint,
  structure checks, Rust build, router build, Go test suite).
