### PR TITLE
[Bench] Cached-panel paired multi-arm fusion evaluator (stacked on #2259)

### DIFF
--- a/bench/grounded_fusion/README.md
+++ b/bench/grounded_fusion/README.md
@@ -98,6 +98,79 @@ bench/grounded_fusion/run_ab.sh --domains Medicine,Law --max-samples 8 --grade-p
 ~30 s per fusion request + rubric grading. Full 100×2 arms + panel grading is an
 overnight-scale job; start with a pilot. Runs are resumable (`--resume`).
 
+## Cached-panel, paired, multi-arm evaluation (the one that settles it)
+
+The `run_ab.sh` design above regenerates the panel **per arm**, so each delta mixes
+the intervention with fresh-sample noise — at small N the result is uninterpretable
+(see `FINDINGS.md`, and why `weight` shipped without efficacy evidence). The
+cached-panel evaluator fixes this: generate the panel **once** per item, then
+synthesize **every arm from the byte-identical panel**, so deltas isolate the
+intervention. It also adds the baselines the A/B lacked.
+
+Arms:
+
+| Arm | What | Answers |
+|-----|------|---------|
+| `A` | judge-solo (one model, no fusion) | does fusion beat one model at all? |
+| `B` | plain fusion (grounding off) | does grounding add anything over plain synthesis? |
+| `C` | `weight` (the shipped default) | the actual claim |
+| `D` | random-weight placebo (real synthesis, NLI replaced with seeded-random scores) | is it the *score* or just *any* weighting? |
+| `annotate`, `filter` | optional, via `--arms` | the other policies |
+
+Pre-registered decision rule (gated on the normalized DRACO score, paired bootstrap
+CI excluding 0): **KEEP_GROUNDING** if `C>B` and `C>D` and `B>=A`;
+**KILL_GROUNDING_ADDON** if `C≈B` or `C≈D`; **KILL_FUSION** if `A` beats `B`;
+else **INCONCLUSIVE**.
+
+This path drives the looper **in-process** (the `fusioneval` Go binary, via the
+`Request.CachedPanel` seam) with the **real candle NLI** — no Envoy/extproc — so it
+needs the candle lib + NLI model + an Ollama endpoint, not the router config dance.
+
+```bash
+# 0. Build the driver (needs the candle lib on the linker path).
+cd src/semantic-router && \
+  CGO_LDFLAGS="-L$PWD/../../candle-binding/target/release" go build -o ../../bin/fusioneval ./cmd/fusioneval
+cd ../..
+
+# 1. Dump items + start the no-think Ollama proxy.
+.venv-bench/bin/python -m bench.grounded_fusion.items \
+  --draco-path ~/Downloads/draco.json --domains Medicine,Law --max-samples 100 \
+  --out bench/grounded_fusion/results/items.jsonl
+.venv-bench/bin/python -m bench.grounded_fusion.ollama_proxy --port 11435 &
+
+# 2. Generate the panel ONCE, then run arms A–D from the identical cached panel.
+LD_LIBRARY_PATH=candle-binding/target/release bin/fusioneval \
+  --items bench/grounded_fusion/results/items.jsonl \
+  --nli-model models/mom-halugate-explainer \
+  --endpoint http://localhost:11435/v1/chat/completions \
+  --judge qwen3:14b --panel qwen3:8b,llama3.1:8b,gemma3:12b \
+  --arms A,B,C,D --out-dir bench/grounded_fusion/results --max-items 4   # drop --max-items for the full run
+
+# 3. Grade each arm with the SAME rubric grader (reuses evaluate.grade_sample).
+for arm in A B C D; do
+  .venv-bench/bin/python -m bench.grounded_fusion.grade_only \
+    --answers bench/grounded_fusion/results/answers_$arm.jsonl --arm $arm \
+    --draco-path ~/Downloads/draco.json --grader-model qwen3:14b --resume
+done
+
+# 4. Multi-arm verdict (writes verdict.json with the KEEP/KILL decision).
+.venv-bench/bin/python -m bench.grounded_fusion.compare_multiarm \
+  --results-dir bench/grounded_fusion/results --arms A,B,C,D \
+  --json-out bench/grounded_fusion/results/verdict.json
+```
+
+**Smoke first** (`--max-items 4`): re-run step 2 and confirm `panel_cache.jsonl` still
+has 4 rows (resume didn't regenerate); every `answers_*.jsonl` row shares the same
+`panel_sha256` per `id` (byte-identical panel across arms). The in-package Go tests
+(`fusion_cached_panel_test.go`) already assert B/C/D arm isolation without the stack.
+
+**Context mode (next step, sequenced after the DRACO smoke passes):** the dataset
+seam is in place — `get_dataset("jsonl", ...)` reads gold passages into
+`metadata["context"]`, `items.py` threads them, and the driver injects context as a
+system message. The remaining wiring is the **hallucination-detector** backend for
+`--grounding-reference context` (the driver currently wires panel-mode NLI only);
+DRACO ships no source docs, so context mode needs a context-grounded dataset.
+
 ## Gotchas (learned the hard way)
 
 - **Silent grounding no-op:** `panel`-mode NLI only fires if
@@ -116,7 +189,7 @@ overnight-scale job; start with a pilot. Runs are resumable (`--resume`).
 
 | File | Role |
 |------|------|
-| `datasets.py` | DRACO loader (parses the weighted rubric) |
+| `datasets.py` | DRACO loader + generic rubric-graded `jsonl` loader (context-mode seam) |
 | `rubric_judge.py` | DRACO-style grader: per-criterion LLM check → weighted score |
 | `runner.py` | drives the router fusion endpoint, parses the `fusion` trace |
 | `metrics.py` | Spearman, discard precision/recall, paired bootstrap CI |
@@ -129,3 +202,9 @@ overnight-scale job; start with a pilot. Runs are resumable (`--resume`).
 | `sanitize_results.py` | strip local paths from result JSON before sharing |
 | `test_grounded_fusion.py` | unit tests (loader + grader math, no model needed) |
 | `FINDINGS.md` | evaluation write-up: bugs fixed, results, next experiments |
+| **Cached-panel multi-arm** | (the paired evaluator that settles `weight` efficacy) |
+| `items.py` | dump DRACO items as JSONL for the `fusioneval` driver |
+| `../../src/semantic-router/cmd/fusioneval` | Go driver: cache panel once, run arms A–D from the identical panel via the real candle NLI |
+| `grade_only.py` | grade the driver's `answers_{arm}.jsonl` (reuses `evaluate.grade_sample`) |
+| `compare_multiarm.py` | N-arm paired comparison + pre-registered KEEP/KILL `verdict.json` |
+| `test_compare_multiarm.py` | unit tests for the verdict logic (no model needed) |

--- a/bench/grounded_fusion/compare_multiarm.py
+++ b/bench/grounded_fusion/compare_multiarm.py
@@ -1,0 +1,207 @@
+"""Paired, multi-arm comparison of cached-panel fusion arms + a KEEP/KILL verdict.
+
+The cached-panel evaluator runs every arm on the byte-identical panel, so deltas
+isolate the intervention. This joins ``samples_{arm}.jsonl`` across arms on a STRICT
+paired set (ids present and error-free in EVERY arm) and applies the pre-registered
+decision rule:
+
+    A judge-solo   B plain-fusion   C weight (default)   D random-weight placebo
+
+    KEEP_GROUNDING       if C > B and C > D and B >= A   (all paired, CI excludes 0)
+    KILL_GROUNDING_ADDON if C ~= B or C ~= D             (grounding adds nothing)
+    KILL_FUSION          if A significantly beats B      (fusion loses to one model)
+    INCONCLUSIVE         otherwise (e.g. fusion vs solo unproven)
+
+Gating is on the normalized DRACO score (higher = better); negative_penalty (toward
+0 = better) is reported as corroboration. "favorable" = bootstrap CI lower bound > 0.
+
+    python -m bench.grounded_fusion.compare_multiarm \
+        --results-dir results --arms A,B,C,D --json-out results/verdict.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .metrics import paired_bootstrap_ci
+
+METRICS = ("normalized", "negative_penalty")
+
+
+def _load_arm(results_dir: Path, arm: str) -> dict[str, dict]:
+    path = results_dir / f"samples_{arm}.jsonl"
+    if not path.exists():
+        raise SystemExit(f"missing {path} -- grade arm {arm} first (grade_only.py)")
+    out = {}
+    for line in path.read_text().splitlines():
+        if line.strip():
+            r = json.loads(line)
+            out[r["id"]] = r
+    return out
+
+
+def _paired_ids(byarm: dict[str, dict[str, dict]], arms: list[str]) -> list[str]:
+    """Ids present and error-free in EVERY arm (strict paired set)."""
+    common: set[str] | None = None
+    for arm in arms:
+        ok = {i for i, r in byarm[arm].items() if not r.get("error")}
+        common = ok if common is None else (common & ok)
+    return sorted(common or set())
+
+
+def _delta_block(
+    byarm: dict[str, dict[str, dict]], x: str, y: str, key: str, ids: list[str]
+) -> dict:
+    deltas = [byarm[x][i]["final"][key] - byarm[y][i]["final"][key] for i in ids]
+    mean, lo, hi = paired_bootstrap_ci(deltas)
+    return {
+        "n": len(ids),
+        "mean_delta": mean,
+        "ci95": [lo, hi],
+        "significant": (lo > 0) or (hi < 0),
+        # Higher is better for both metrics (normalized up; penalty toward 0), so a
+        # favorable X-vs-Y is a strictly positive lower CI bound.
+        "favorable": lo > 0,
+    }
+
+
+def _pair(byarm, x, y, ids) -> dict:
+    return {m: _delta_block(byarm, x, y, m, ids) for m in METRICS}
+
+
+def _contested(byarm: dict[str, dict[str, dict]], ids: list[str]) -> int:
+    """Items where arm C flagged or dropped a panel response (where grounding acts)."""
+    if "C" not in byarm:
+        return 0
+    n = 0
+    for i in ids:
+        panel = byarm["C"].get(i, {}).get("panel", [])
+        if any(p.get("dropped") or p.get("flagged") for p in panel):
+            n += 1
+    return n
+
+
+def _decide(pairs: dict[str, dict], have: set[str]) -> tuple[str, str]:
+    """Apply the pre-registered rule on the normalized-score pair blocks."""
+    norm = {k: v["normalized"] for k, v in pairs.items()}
+
+    # KILL_FUSION: arm A (one model) significantly beats arm B (plain fusion).
+    if {"A", "B"} <= have:
+        ba = norm["B_vs_A"]
+        if ba["ci95"][1] < 0:
+            return "KILL_FUSION", (
+                f"plain fusion loses to the judge model alone "
+                f"(B-A normalized {ba['mean_delta']:+.4f}, CI {ba['ci95']}); "
+                "fusion itself is not worth its cost."
+            )
+        if not ba["favorable"]:
+            return "INCONCLUSIVE", (
+                f"fusion is not shown to beat one model (B-A normalized {ba['mean_delta']:+.4f}, "
+                f"CI {ba['ci95']} includes 0); need more N before judging grounding."
+            )
+
+    if not ({"B", "C"} <= have):
+        return "INCONCLUSIVE", "arms B and C are both required to judge grounding."
+
+    cb = norm["C_vs_B"]
+    cd = norm.get("C_vs_D")
+    if not cb["favorable"]:
+        return "KILL_GROUNDING_ADDON", (
+            f"weight does not beat plain fusion (C-B normalized {cb['mean_delta']:+.4f}, "
+            f"CI {cb['ci95']}); the grounding stage adds nothing over plain synthesis."
+        )
+    if cd is not None and not cd["favorable"]:
+        return "KILL_GROUNDING_ADDON", (
+            f"weight does not beat the random-weight placebo (C-D normalized "
+            f"{cd['mean_delta']:+.4f}, CI {cd['ci95']}); the gain is from weighting, "
+            "not the groundedness score."
+        )
+    if cd is None:
+        return "INCONCLUSIVE", (
+            f"weight beats plain fusion (C-B {cb['mean_delta']:+.4f}, CI {cb['ci95']}) but the "
+            "placebo arm D is missing — cannot rule out that any weighting would do."
+        )
+    return "KEEP_GROUNDING", (
+        f"weight beats both plain fusion (C-B {cb['mean_delta']:+.4f}, CI {cb['ci95']}) and the "
+        f"random-weight placebo (C-D {cd['mean_delta']:+.4f}, CI {cd['ci95']}); the groundedness "
+        "score earns its place."
+    )
+
+
+def compare(results_dir: str, arms: list[str]) -> dict:
+    d = Path(results_dir)
+    byarm = {arm: _load_arm(d, arm) for arm in arms}
+    have = set(arms)
+    ids = _paired_ids(byarm, arms)
+    if not ids:
+        raise SystemExit("no overlapping error-free samples across all arms")
+
+    # Pairs needed for the decision rule (only those whose both arms are present).
+    wanted = [
+        ("C_vs_B", "C", "B"),
+        ("C_vs_D", "C", "D"),
+        ("B_vs_A", "B", "A"),
+        ("C_vs_A", "C", "A"),
+    ]
+    pairs = {name: _pair(byarm, x, y, ids) for name, x, y in wanted if {x, y} <= have}
+
+    decision, rationale = _decide(pairs, have)
+    per_arm_mean = {
+        arm: (sum(byarm[arm][i]["final"]["normalized"] for i in ids) / len(ids))
+        for arm in arms
+    }
+    return {
+        "arms": arms,
+        "n_paired": len(ids),
+        "n_contested": _contested(byarm, ids),
+        "per_arm_mean_normalized": per_arm_mean,
+        "pairs": pairs,
+        "decision": decision,
+        "rationale": rationale,
+    }
+
+
+def _print(report: dict) -> None:
+    print("\n" + "=" * 64)
+    print("CACHED-PANEL FUSION: multi-arm paired comparison")
+    print("=" * 64)
+    print(
+        f"paired samples (all arms, error-free): {report['n_paired']} | contested: {report['n_contested']}"
+    )
+    print("\n[per-arm mean normalized]")
+    for arm, m in report["per_arm_mean_normalized"].items():
+        print(f"  {arm:10} {m:.4f}")
+    for name, block in report["pairs"].items():
+        print(f"\n[{name}]")
+        for metric in METRICS:
+            b = block[metric]
+            sig = "SIGNIFICANT" if b["significant"] else "ns"
+            print(
+                f"  {metric:18} delta={b['mean_delta']:+.4f}  ci95=[{b['ci95'][0]:+.4f},{b['ci95'][1]:+.4f}]  {sig}"
+            )
+    print("\n" + "-" * 64)
+    print(f"DECISION: {report['decision']}")
+    print(f"  {report['rationale']}")
+    print("=" * 64)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Multi-arm paired compare + KEEP/KILL verdict"
+    )
+    ap.add_argument("--results-dir", default="bench/grounded_fusion/results")
+    ap.add_argument("--arms", default="A,B,C,D", help="comma-separated arms to compare")
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+    report = compare(args.results_dir, arms)
+    _print(report)
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\nwrote {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/grounded_fusion/datasets.py
+++ b/bench/grounded_fusion/datasets.py
@@ -156,12 +156,57 @@ def load_draco(
     return samples
 
 
+def load_jsonl(
+    path: str,
+    max_samples: int | None = None,
+    domains: list[str] | None = None,
+    seed: int = 42,
+) -> list[DracoSample]:
+    """Load a generic rubric-graded dataset from JSONL (one row per line).
+
+    Each line mirrors a DRACO row -- ``{id, problem, domain, answer}`` where
+    ``answer`` is the weighted rubric -- plus an optional ``context`` (gold passage)
+    surfaced in ``metadata["context"]``. This is the seam for context-mode grounding:
+    a context-grounded benchmark (RAGTruth / HotpotQA-with-gold-passages reshaped to
+    this row format) is scored against its real source rather than panel agreement.
+    """
+    samples: list[DracoSample] = []
+    for raw_line in Path(path).expanduser().read_text().splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        samples.append(
+            DracoSample(
+                id=str(row["id"]),
+                problem=str(row["problem"]),
+                domain=str(row.get("domain", "unknown")),
+                rubric=_parse_rubric(str(row["id"]), row["answer"]),
+                metadata={"context": str(row.get("context", "") or "")},
+            )
+        )
+
+    if domains:
+        wanted = {d.lower() for d in domains}
+        samples = [s for s in samples if s.domain.lower() in wanted]
+    rng = random.Random(seed)
+    rng.shuffle(samples)
+    if max_samples is not None:
+        samples = samples[:max_samples]
+    return samples
+
+
 def get_dataset(name: str, **kwargs) -> list[DracoSample]:
-    """Dispatch a dataset by name. Currently only ``draco`` is supported."""
+    """Dispatch a dataset by name (``draco`` or a generic rubric-graded ``jsonl``)."""
     name = name.lower()
     if name == "draco":
         path = kwargs.pop("path", None) or kwargs.pop("draco_path", None)
         if not path:
             raise ValueError("draco dataset requires path=/path/to/draco.json")
         return load_draco(path, **kwargs)
+    if name == "jsonl":
+        path = kwargs.pop("path", None) or kwargs.pop("draco_path", None)
+        if not path:
+            raise ValueError("jsonl dataset requires path=/path/to/dataset.jsonl")
+        return load_jsonl(path, **kwargs)
     raise ValueError(f"unknown dataset: {name!r}")

--- a/bench/grounded_fusion/grade_only.py
+++ b/bench/grounded_fusion/grade_only.py
@@ -1,0 +1,178 @@
+"""Grade pre-generated arm answers (from the fusioneval driver) with the DRACO rubric.
+
+The cached-panel paired evaluator (``cmd/fusioneval``) emits ``answers_{arm}.jsonl``:
+one final answer per item, already synthesized from the byte-identical cached panel.
+This grades those answers with the SAME ``RubricJudge`` + ``summarize`` the live
+harness uses (``evaluate.grade_sample`` / ``evaluate.summarize``) — only the answer
+SOURCE changes (disk, not a live router call). Output matches ``evaluate.py``:
+``samples_{arm}.jsonl`` + ``summary_{arm}.json``, so ``compare_multiarm.py`` consumes
+it unchanged.
+
+    python -m bench.grounded_fusion.grade_only --answers results/answers_C.jsonl \
+        --arm C --draco-path draco.json --grader-model qwen3:14b
+    # add --grade-panel --panel-cache results/panel_cache.jsonl for Level-1 scoring
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from .datasets import get_dataset
+from .evaluate import _resume_ids, grade_sample, summarize
+from .llm_client import ChatClient
+from .rubric_judge import RubricJudge
+from .runner import FusionResult, PanelEntry
+
+
+def _fusion_from_record(rec: dict, contents: dict[str, str]) -> FusionResult:
+    """Rebuild the FusionResult grade_sample expects from a fusioneval answer row.
+
+    Panel content is only needed for Level-1 (--grade-panel); it is sourced from the
+    panel cache (``contents``: model -> content). Without it, panel entries carry the
+    grounding metadata only (enough for Level-2 + the contested slice)."""
+    panel = []
+    for p in rec.get("panel", []):
+        model = p.get("model", "")
+        panel.append(
+            PanelEntry(
+                model=model,
+                content=contents.get(model, ""),
+                grounding_score=p.get("grounding_score"),
+                dropped=bool(p.get("dropped", False)),
+                flagged=p.get("flagged") or [],
+            )
+        )
+    return FusionResult(
+        sample_id=rec["id"],
+        final_answer=rec.get("final_answer", "") or "",
+        panel=panel,
+        grounding_present=bool(rec.get("grounding_present", False)),
+        reference_mode=rec.get("reference_mode", ""),
+        usage=rec.get("usage", {}) or {},
+        error=rec.get("error") or None,
+    )
+
+
+def _load_panel_contents(panel_cache: str | None) -> dict[str, dict[str, str]]:
+    """item_id -> {model -> content} from the fusioneval panel cache (for Level-1)."""
+    out: dict[str, dict[str, str]] = {}
+    if not panel_cache:
+        return out
+    for line in Path(panel_cache).read_text().splitlines():
+        if not line.strip():
+            continue
+        e = json.loads(line)
+        out[e["item_id"]] = {
+            p["model"]: p.get("content", "") for p in e.get("panel", [])
+        }
+    return out
+
+
+def grade_arm(args) -> dict:
+    if args.grade_panel and not args.panel_cache:
+        raise SystemExit(
+            "--grade-panel requires --panel-cache (panel content for Level-1)"
+        )
+
+    samples = {
+        s.id: s
+        for s in get_dataset(
+            "draco",
+            path=args.draco_path,
+            domains=args.domains.split(",") if args.domains else None,
+            seed=args.seed,
+        )
+    }
+    judge = RubricJudge(
+        ChatClient(args.grader_base_url, model=args.grader_model, timeout=args.timeout),
+        batch_size=args.grader_batch_size,
+    )
+    content_by_item = _load_panel_contents(args.panel_cache) if args.grade_panel else {}
+
+    answers = [
+        json.loads(line)
+        for line in Path(args.answers).read_text().splitlines()
+        if line.strip()
+    ]
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_sample_path = out_dir / f"samples_{args.arm}.jsonl"
+    done = _resume_ids(per_sample_path) if args.resume else set()
+    fh = per_sample_path.open("a" if args.resume else "w")
+    print(f"[{args.arm}] grading {len(answers)} answers | resume_skip={len(done)}")
+
+    records: list[dict] = []
+    for i, rec in enumerate(answers, 1):
+        if rec["id"] in done:
+            continue
+        s = samples.get(rec["id"])
+        if s is None:
+            print(f"  skip {rec['id']}: no DRACO rubric for this id")
+            continue
+        fusion = _fusion_from_record(rec, content_by_item.get(rec["id"], {}))
+        graded = grade_sample(judge, s, fusion, args.grade_panel)
+        records.append(graded)
+        fh.write(json.dumps(graded) + "\n")
+        fh.flush()
+        err = f" ERROR={graded['error']}" if graded.get("error") else ""
+        print(
+            f"  [{i}/{len(answers)}] {s.domain[:14]:14} norm={graded['final']['normalized']:.3f} "
+            f"pen={graded['final']['negative_penalty']:.0f}{err}"
+        )
+    fh.close()
+
+    if args.resume:
+        records = [
+            json.loads(line)
+            for line in per_sample_path.read_text().splitlines()
+            if line.strip()
+        ]
+    summary = summarize(records)
+    (out_dir / f"summary_{args.arm}.json").write_text(
+        json.dumps({"arm": args.arm, "summary": summary}, indent=2)
+    )
+    print(f"\n[{args.arm}] summary -> {out_dir / f'summary_{args.arm}.json'}")
+    print(json.dumps(summary, indent=2))
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Grade fusioneval arm answers with the DRACO rubric"
+    )
+    p.add_argument(
+        "--answers", required=True, help="answers_{arm}.jsonl from fusioneval"
+    )
+    p.add_argument("--arm", required=True, help="arm label (A/B/C/D/annotate/filter)")
+    p.add_argument("--draco-path", required=True)
+    p.add_argument("--domains", default=None, help="comma-separated domain filter")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--grade-panel", action="store_true", help="grade each panel response (Level-1)"
+    )
+    p.add_argument(
+        "--panel-cache",
+        default=None,
+        help="panel_cache.jsonl (panel content for --grade-panel)",
+    )
+    p.add_argument("--grader-base-url", default="http://localhost:11435/v1")
+    p.add_argument("--grader-model", default="qwen3:14b")
+    p.add_argument("--grader-batch-size", type=int, default=8)
+    p.add_argument("--timeout", type=int, default=600)
+    p.add_argument("--resume", action="store_true")
+    p.add_argument("--output-dir", default="bench/grounded_fusion/results")
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    t0 = time.time()
+    grade_arm(args)
+    print(f"\nwall-clock: {(time.time()-t0)/60:.1f} min")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/grounded_fusion/items.py
+++ b/bench/grounded_fusion/items.py
@@ -1,0 +1,79 @@
+"""Dump DRACO items as JSONL for the fusioneval Go driver.
+
+The cached-panel evaluator splits generation (Go: cmd/fusioneval, which needs the
+candle NLI + Ollama) from DRACO parsing (Python: datasets.py). This writes one
+item per line — ``{id, domain, question, context}`` — which the Go driver reads to
+generate the panel and synthesize the arms. ``context`` is populated for
+context-grounded datasets (gold passages); empty for DRACO panel-mode.
+
+    python -m bench.grounded_fusion.items --draco-path draco.json \
+        --domains Medicine,Law --max-samples 100 --out results/items.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .datasets import get_dataset
+
+
+def dump_items(
+    path: str,
+    out: str,
+    domains: str | None = None,
+    max_samples: int | None = None,
+    seed: int = 42,
+    dataset: str = "draco",
+) -> int:
+    samples = get_dataset(
+        dataset,
+        path=path,
+        max_samples=max_samples,
+        domains=domains.split(",") if domains else None,
+        seed=seed,
+    )
+    outp = Path(out)
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    with outp.open("w") as fh:
+        for s in samples:
+            context = ""
+            if isinstance(s.metadata, dict):
+                context = str(s.metadata.get("context", "") or "")
+            fh.write(
+                json.dumps(
+                    {
+                        "id": s.id,
+                        "domain": s.domain,
+                        "question": s.problem,
+                        "context": context,
+                    }
+                )
+                + "\n"
+            )
+    return len(samples)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Dump DRACO items JSONL for fusioneval")
+    ap.add_argument("--draco-path", required=True)
+    ap.add_argument("--out", default="bench/grounded_fusion/results/items.jsonl")
+    ap.add_argument("--dataset", default="draco")
+    ap.add_argument("--domains", default=None, help="comma-separated domain filter")
+    ap.add_argument("--max-samples", type=int, default=None)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+    n = dump_items(
+        args.draco_path,
+        args.out,
+        domains=args.domains,
+        max_samples=args.max_samples,
+        seed=args.seed,
+        dataset=args.dataset,
+    )
+    print(f"wrote {n} items -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/grounded_fusion/test_compare_multiarm.py
+++ b/bench/grounded_fusion/test_compare_multiarm.py
@@ -1,0 +1,114 @@
+"""Unit tests for the multi-arm verdict logic (no model/router needed).
+
+Run: .venv-bench/bin/python -m pytest bench/grounded_fusion/test_compare_multiarm.py -q
+"""
+
+import json
+
+from bench.grounded_fusion.compare_multiarm import compare
+
+
+def _write_arm(d, arm, finals, errors=None):
+    """Write a synthetic samples_{arm}.jsonl. finals: {id: normalized_score}."""
+    errors = errors or {}
+    path = d / f"samples_{arm}.jsonl"
+    with path.open("w") as fh:
+        for sid, norm in finals.items():
+            rec = {
+                "id": sid,
+                "domain": "Medicine",
+                "error": errors.get(sid),
+                "final": {
+                    "total": norm * 100,
+                    "normalized": norm,
+                    "negative_penalty": 0.0,
+                    "n_negative_triggered": 0,
+                    "per_section": {},
+                },
+                "panel": [],
+            }
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _ids(n):
+    return [f"q{i}" for i in range(n)]
+
+
+def test_keep_grounding(tmp_path):
+    # C beats B and D by a constant margin; B beats A. Constant deltas -> tight CI.
+    ids = _ids(12)
+    _write_arm(tmp_path, "A", dict.fromkeys(ids, 0.4))
+    _write_arm(tmp_path, "B", dict.fromkeys(ids, 0.55))
+    _write_arm(tmp_path, "C", dict.fromkeys(ids, 0.7))
+    _write_arm(tmp_path, "D", dict.fromkeys(ids, 0.58))
+    report = compare(str(tmp_path), ["A", "B", "C", "D"])
+    assert report["decision"] == "KEEP_GROUNDING"
+    assert report["pairs"]["C_vs_B"]["normalized"]["favorable"]
+    assert report["pairs"]["C_vs_D"]["normalized"]["favorable"]
+
+
+def test_kill_grounding_addon_when_c_equals_b(tmp_path):
+    # C ~= B (zero delta -> CI is [0,0], not favorable).
+    ids = _ids(12)
+    _write_arm(tmp_path, "A", dict.fromkeys(ids, 0.4))
+    _write_arm(tmp_path, "B", dict.fromkeys(ids, 0.6))
+    _write_arm(tmp_path, "C", dict.fromkeys(ids, 0.6))
+    _write_arm(tmp_path, "D", dict.fromkeys(ids, 0.55))
+    report = compare(str(tmp_path), ["A", "B", "C", "D"])
+    assert report["decision"] == "KILL_GROUNDING_ADDON"
+
+
+def test_kill_grounding_addon_when_c_equals_placebo(tmp_path):
+    # C beats B, but does NOT beat the random-weight placebo D.
+    ids = _ids(12)
+    _write_arm(tmp_path, "A", dict.fromkeys(ids, 0.4))
+    _write_arm(tmp_path, "B", dict.fromkeys(ids, 0.55))
+    _write_arm(tmp_path, "C", dict.fromkeys(ids, 0.7))
+    _write_arm(tmp_path, "D", dict.fromkeys(ids, 0.7))
+    report = compare(str(tmp_path), ["A", "B", "C", "D"])
+    assert report["decision"] == "KILL_GROUNDING_ADDON"
+    assert "placebo" in report["rationale"]
+
+
+def test_kill_fusion_when_solo_beats_fusion(tmp_path):
+    # A (one model) significantly beats B (plain fusion).
+    ids = _ids(12)
+    _write_arm(tmp_path, "A", dict.fromkeys(ids, 0.7))
+    _write_arm(tmp_path, "B", dict.fromkeys(ids, 0.5))
+    _write_arm(tmp_path, "C", dict.fromkeys(ids, 0.55))
+    _write_arm(tmp_path, "D", dict.fromkeys(ids, 0.52))
+    report = compare(str(tmp_path), ["A", "B", "C", "D"])
+    assert report["decision"] == "KILL_FUSION"
+
+
+def test_inconclusive_when_fusion_vs_solo_unproven(tmp_path):
+    # B-A straddles 0 (mixed signs) -> fusion vs solo unproven.
+    ids = _ids(12)
+    mixed = {i: (0.6 if int(i[1:]) % 2 == 0 else 0.4) for i in ids}
+    _write_arm(tmp_path, "A", dict.fromkeys(ids, 0.5))
+    _write_arm(tmp_path, "B", mixed)
+    _write_arm(tmp_path, "C", dict.fromkeys(ids, 0.7))
+    _write_arm(tmp_path, "D", dict.fromkeys(ids, 0.55))
+    report = compare(str(tmp_path), ["A", "B", "C", "D"])
+    assert report["decision"] == "INCONCLUSIVE"
+
+
+def test_strict_paired_set_excludes_errored_ids(tmp_path):
+    ids = _ids(12)
+    _write_arm(tmp_path, "A", dict.fromkeys(ids, 0.4))
+    _write_arm(tmp_path, "B", dict.fromkeys(ids, 0.55))
+    _write_arm(tmp_path, "C", dict.fromkeys(ids, 0.7), errors={"q0": "HTTP 500"})
+    _write_arm(tmp_path, "D", dict.fromkeys(ids, 0.58))
+    report = compare(str(tmp_path), ["A", "B", "C", "D"])
+    # q0 errored in arm C -> dropped from the paired set.
+    assert report["n_paired"] == 11
+
+
+def test_missing_placebo_is_inconclusive(tmp_path):
+    ids = _ids(12)
+    _write_arm(tmp_path, "A", dict.fromkeys(ids, 0.4))
+    _write_arm(tmp_path, "B", dict.fromkeys(ids, 0.55))
+    _write_arm(tmp_path, "C", dict.fromkeys(ids, 0.7))
+    report = compare(str(tmp_path), ["A", "B", "C"])
+    assert report["decision"] == "INCONCLUSIVE"
+    assert "placebo" in report["rationale"]

--- a/bench/grounded_fusion/test_grounded_fusion.py
+++ b/bench/grounded_fusion/test_grounded_fusion.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 
-from bench.grounded_fusion.datasets import load_draco
+from bench.grounded_fusion.datasets import get_dataset, load_draco, load_jsonl
 from bench.grounded_fusion.llm_client import ChatResult
 from bench.grounded_fusion.rubric_judge import RubricJudge
 
@@ -98,3 +98,36 @@ def test_parse_tolerates_fences_and_prose():
     )
     assert parsed["a"]["matched"] is True
     assert RubricJudge._parse("garbage") == {}
+
+
+# ---- generic JSONL loader (context-mode seam) ------------------------------
+
+
+def test_load_jsonl_carries_context(tmp_path):
+    rubric = {
+        "sections": [
+            {
+                "id": "acc",
+                "title": "Factual Accuracy",
+                "criteria": [{"id": "c1", "weight": 10, "requirement": "states X"}],
+            }
+        ]
+    }
+    row = {
+        "id": "ctx-1",
+        "problem": "summarize the passage",
+        "domain": "Medicine",
+        "context": "the gold source passage",
+        "answer": rubric,
+    }
+    path = tmp_path / "ds.jsonl"
+    path.write_text(json.dumps(row) + "\n")
+
+    samples = load_jsonl(str(path))
+    assert len(samples) == 1
+    s = samples[0]
+    assert s.id == "ctx-1"
+    assert s.metadata["context"] == "the gold source passage"
+    assert s.rubric.max_positive_score == 10
+    # get_dataset dispatches the same loader.
+    assert get_dataset("jsonl", path=str(path))[0].id == "ctx-1"

--- a/src/semantic-router/cmd/fusioneval/main.go
+++ b/src/semantic-router/cmd/fusioneval/main.go
@@ -1,0 +1,583 @@
+// Command fusioneval is the paired, multi-arm evaluation driver for
+// grounding-aware Fusion. It generates the panel ONCE per item and caches it,
+// then synthesizes every arm from the byte-identical cached panel so the deltas
+// isolate the intervention (no per-arm panel-regeneration noise — the flaw that
+// made the first DRACO A/B uninterpretable, see bench/grounded_fusion/FINDINGS.md).
+//
+// Arms:
+//
+//	A  judge-solo      one model, no fusion          — does fusion beat one model?
+//	B  plain-fusion    grounding disabled            — does grounding add anything?
+//	C  weight          shipped default               — the actual claim
+//	D  placebo         weight on seeded-random scores — score signal vs any weighting
+//	annotate / filter  optional, behind --arms
+//
+// It wires the REAL candle NLI (the same scorer the router uses) so arm C/D
+// reflect the shipped path. Grading + the KEEP/KILL verdict live in Python
+// (bench/grounded_fusion/grade_only.py + compare_multiarm.py), which read the
+// answers_{arm}.jsonl this driver emits.
+//
+// Build/run (needs the candle lib + NLI model + a running Ollama):
+//
+//	cd src/semantic-router && \
+//	  CGO_LDFLAGS="-L$PWD/../../candle-binding/target/release" go build -o ../../bin/fusioneval ./cmd/fusioneval
+//	LD_LIBRARY_PATH=$PWD/../../candle-binding/target/release ../../bin/fusioneval \
+//	  --items items.jsonl --nli-model models/mom-halugate-explainer \
+//	  --endpoint http://localhost:11435/v1/chat/completions \
+//	  --judge qwen3:14b --panel qwen3:8b,llama3.1:8b,gemma3:12b \
+//	  --arms A,B,C,D --out-dir results
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	openai "github.com/openai/openai-go"
+
+	candle "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
+)
+
+type options struct {
+	itemsPath   string
+	panelCache  string
+	outDir      string
+	arms        []string
+	judge       string
+	panelModels []string
+	endpoint    string
+	nliModel    string
+	useCPU      bool
+	seed        int64
+	placeboSeed uint64
+	reference   string
+	temperature float64
+	maxTokens   int
+	maxItems    int
+}
+
+// item is one evaluation question. The Python side (datasets.py) owns DRACO
+// parsing and dumps these via `python -m bench.grounded_fusion.items`.
+type item struct {
+	ID       string `json:"id"`
+	Domain   string `json:"domain"`
+	Question string `json:"question"`
+	Context  string `json:"context,omitempty"`
+}
+
+type usageRec struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+}
+
+type cachedResponse struct {
+	Model     string   `json:"model"`
+	Content   string   `json:"content"`
+	Reasoning string   `json:"reasoning,omitempty"`
+	Usage     usageRec `json:"usage"`
+}
+
+type cachedPanelItem struct {
+	ItemID      string           `json:"item_id"`
+	Question    string           `json:"question"`
+	Context     string           `json:"context,omitempty"`
+	PanelSeed   int64            `json:"panel_seed"`
+	Panel       []cachedResponse `json:"panel"`
+	PanelSHA256 string           `json:"panel_sha256"`
+}
+
+type panelRec struct {
+	Model          string   `json:"model"`
+	GroundingScore *float64 `json:"grounding_score"`
+	Dropped        bool     `json:"dropped"`
+	Flagged        []string `json:"flagged"`
+}
+
+// answerRecord is the pre-grading output consumed by grade_only.py.
+type answerRecord struct {
+	ID               string     `json:"id"`
+	Domain           string     `json:"domain"`
+	Arm              string     `json:"arm"`
+	FinalAnswer      string     `json:"final_answer"`
+	Usage            usageRec   `json:"usage"`
+	GroundingPresent bool       `json:"grounding_present"`
+	ReferenceMode    string     `json:"reference_mode,omitempty"`
+	Policy           string     `json:"policy,omitempty"`
+	Panel            []panelRec `json:"panel"`
+	PanelSHA256      string     `json:"panel_sha256"`
+	Error            string     `json:"error,omitempty"`
+}
+
+func main() {
+	opt := parseFlags()
+	if err := run(opt); err != nil {
+		fmt.Fprintln(os.Stderr, "fusioneval:", err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags() options {
+	var (
+		arms  = flag.String("arms", "A,B,C,D", "comma-separated arms to run: A(judge-solo) B(plain) C(weight) D(placebo) annotate filter")
+		panel = flag.String("panel", "qwen3:8b,llama3.1:8b,gemma3:12b", "comma-separated panel (analysis) models")
+	)
+	opt := options{}
+	flag.StringVar(&opt.itemsPath, "items", "", "path to items JSONL ({id,domain,question,context}) — dump via bench.grounded_fusion.items")
+	flag.StringVar(&opt.panelCache, "panel-cache", "", "panel cache JSONL path (default <out-dir>/panel_cache.jsonl)")
+	flag.StringVar(&opt.outDir, "out-dir", "results", "output directory for answers_{arm}.jsonl")
+	flag.StringVar(&opt.judge, "judge", "qwen3:14b", "judge / synthesis model")
+	flag.StringVar(&opt.endpoint, "endpoint", "http://localhost:11435/v1/chat/completions", "OpenAI-compatible chat endpoint (Ollama proxy)")
+	flag.StringVar(&opt.nliModel, "nli-model", "models/mom-halugate-explainer", "candle NLI model path for panel-mode grounding")
+	flag.BoolVar(&opt.useCPU, "use-cpu", true, "run the candle NLI model on CPU")
+	flag.Int64Var(&opt.seed, "seed", 42, "panel generation seed (recorded; determinism depends on the backend)")
+	flag.Uint64Var(&opt.placeboSeed, "placebo-seed", 7, "base seed for the random-weight placebo (arm D)")
+	flag.StringVar(&opt.reference, "grounding-reference", config.FusionGroundingReferencePanel, "grounding reference mode: panel|context|hybrid")
+	flag.Float64Var(&opt.temperature, "temperature", 0, "sampling temperature for all calls")
+	flag.IntVar(&opt.maxTokens, "max-tokens", 0, "max completion tokens (0 = backend default)")
+	flag.IntVar(&opt.maxItems, "max-items", 0, "cap items processed (0 = all); use for a smoke run")
+	flag.Parse()
+
+	opt.arms = splitCSV(*arms)
+	opt.panelModels = splitCSV(*panel)
+	if opt.panelCache == "" {
+		opt.panelCache = filepath.Join(opt.outDir, "panel_cache.jsonl")
+	}
+	return opt
+}
+
+func run(opt options) error {
+	if opt.itemsPath == "" {
+		return fmt.Errorf("--items is required")
+	}
+	if err := os.MkdirAll(opt.outDir, 0o755); err != nil {
+		return err
+	}
+
+	items, err := loadItems(opt.itemsPath)
+	if err != nil {
+		return fmt.Errorf("load items: %w", err)
+	}
+	if opt.maxItems > 0 && len(items) > opt.maxItems {
+		items = items[:opt.maxItems]
+	}
+
+	// Wire the REAL candle NLI for panel-mode grounding (arms C/D's reference).
+	// Context mode would additionally need the hallucination detector; deferred.
+	if err = candle.InitNLIModel(opt.nliModel, opt.useCPU); err != nil {
+		return fmt.Errorf("init candle NLI model %q: %w", opt.nliModel, err)
+	}
+	looper.SetGroundingBackends(realNLI(), nil)
+
+	looperCfg := &config.LooperConfig{Endpoint: opt.endpoint}
+	client := looper.NewClient(looperCfg)
+	fusion := looper.NewFusionLooper(looperCfg)
+
+	// Phase 1: build (or resume) the panel cache — generate each panel ONCE.
+	cache, err := buildPanelCache(client, opt, items)
+	if err != nil {
+		return fmt.Errorf("build panel cache: %w", err)
+	}
+	fmt.Printf("panel cache ready: %d items at %s\n", len(cache), opt.panelCache)
+
+	// Phase 2: per arm, synthesize every item from its cached panel.
+	for _, arm := range opt.arms {
+		if err := runArm(fusion, client, opt, looperCfg, items, cache, arm); err != nil {
+			return fmt.Errorf("arm %s: %w", arm, err)
+		}
+	}
+	fmt.Println("done. grade with: python -m bench.grounded_fusion.grade_only ...")
+	return nil
+}
+
+func realNLI() looper.NLIClassifyFunc {
+	return func(premise, hypothesis string) (float32, float32, error) {
+		r, err := candle.ClassifyNLI(premise, hypothesis)
+		if err != nil {
+			return 0, 0, err
+		}
+		return r.EntailmentProb, r.ContradictProb, nil
+	}
+}
+
+// placeboNLI returns deterministic seeded-random scores: reproducible for a given
+// (seed, premise, hypothesis) but carrying no real signal. Mirrors the in-package
+// test placebo so arm D weights on noise, isolating the score's signal.
+func placeboNLI(seed uint64) looper.NLIClassifyFunc {
+	return func(premise, hypothesis string) (float32, float32, error) {
+		h := fnv.New64a()
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], seed)
+		_, _ = h.Write(b[:])
+		_, _ = h.Write([]byte(premise))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(hypothesis))
+		// Deterministic seed for the placebo; the uint64->int64 wrap is harmless.
+		r := rand.New(rand.NewSource(int64(h.Sum64()))) //nolint:gosec // deterministic eval seed, overflow harmless
+		entail := float32(r.Float64())
+		contradict := float32(r.Float64() * (1 - float64(entail)))
+		return entail, contradict, nil
+	}
+}
+
+// buildPanelCache generates any panel not already cached, appending to the cache
+// file. Keyed on item ID; safe to re-run (resume).
+func buildPanelCache(client *looper.Client, opt options, items []item) (map[string]cachedPanelItem, error) {
+	cache, err := loadPanelCache(opt.panelCache)
+	if err != nil {
+		return nil, err
+	}
+	fh, err := os.OpenFile(opt.panelCache, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+
+	for _, it := range items {
+		if _, ok := cache[it.ID]; ok {
+			continue
+		}
+		panel, err := generatePanel(client, opt, it)
+		if err != nil {
+			return nil, fmt.Errorf("generate panel for %s: %w", it.ID, err)
+		}
+		entry := cachedPanelItem{
+			ItemID:      it.ID,
+			Question:    it.Question,
+			Context:     it.Context,
+			PanelSeed:   opt.seed,
+			Panel:       panel,
+			PanelSHA256: panelSHA256(panel),
+		}
+		if err := appendJSON(fh, entry); err != nil {
+			return nil, err
+		}
+		cache[it.ID] = entry
+		fmt.Printf("  panel cached: %s (%d responses)\n", it.ID, len(panel))
+	}
+	return cache, nil
+}
+
+func generatePanel(client *looper.Client, opt options, it item) ([]cachedResponse, error) {
+	out := make([]cachedResponse, 0, len(opt.panelModels))
+	for _, model := range opt.panelModels {
+		req := buildRequest(it.Question, it.Context, opt)
+		resp, err := client.CallModel(context.Background(), req, model, false, 1, nil, "")
+		if err != nil {
+			return nil, fmt.Errorf("model %q: %w", model, err)
+		}
+		out = append(out, cachedResponse{
+			Model:     model,
+			Content:   resp.Content,
+			Reasoning: resp.ReasoningContent,
+			Usage:     usageRec(resp.Usage),
+		})
+	}
+	return out, nil
+}
+
+func runArm(
+	fusion *looper.FusionLooper,
+	client *looper.Client,
+	opt options,
+	looperCfg *config.LooperConfig,
+	items []item,
+	cache map[string]cachedPanelItem,
+	arm string,
+) error {
+	outPath := filepath.Join(opt.outDir, fmt.Sprintf("answers_%s.jsonl", arm))
+	done, err := resumeIDs(outPath)
+	if err != nil {
+		return err
+	}
+	fh, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	for _, it := range items {
+		if done[it.ID] {
+			continue
+		}
+		entry, ok := cache[it.ID]
+		if !ok {
+			return fmt.Errorf("no cached panel for %s", it.ID)
+		}
+		rec := produceArm(fusion, client, opt, it, entry, arm)
+		if err := appendJSON(fh, rec); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("arm %s -> %s\n", arm, outPath)
+	return nil
+}
+
+// produceArm synthesizes a single item under one arm from its cached panel. A
+// failed call is recorded as an error row (never aborts the run) so grading sees
+// a strict paired set.
+func produceArm(
+	fusion *looper.FusionLooper,
+	client *looper.Client,
+	opt options,
+	it item,
+	entry cachedPanelItem,
+	arm string,
+) answerRecord {
+	rec := answerRecord{ID: it.ID, Domain: it.Domain, Arm: arm, PanelSHA256: entry.PanelSHA256, Panel: []panelRec{}}
+
+	if arm == "A" {
+		req := buildRequest(it.Question, it.Context, opt)
+		resp, err := client.CallModel(context.Background(), req, opt.judge, false, 1, nil, "")
+		if err != nil {
+			rec.Error = err.Error()
+			return rec
+		}
+		rec.FinalAnswer = resp.Content
+		rec.Usage = usageRec(resp.Usage)
+		return rec
+	}
+
+	grounding, placebo := armGrounding(arm, opt.reference)
+	if placebo {
+		looper.SetGroundingBackends(placeboNLI(itemSeed(opt.placeboSeed, it.ID)), nil)
+		defer looper.SetGroundingBackends(realNLI(), nil)
+	}
+
+	req := &looper.Request{
+		OriginalRequest: buildRequest(it.Question, it.Context, opt),
+		DecisionName:    "fusioneval",
+		CachedPanel:     toModelResponses(entry.Panel),
+		Algorithm: &config.AlgorithmConfig{
+			Type: "fusion",
+			Fusion: &config.FusionAlgorithmConfig{
+				Model:          opt.judge,
+				AnalysisModels: opt.panelModels,
+				Grounding:      grounding,
+			},
+		},
+	}
+	resp, err := fusion.Execute(context.Background(), req)
+	if err != nil {
+		rec.Error = err.Error()
+		return rec
+	}
+	rec.FinalAnswer = finalAnswer(resp.Body)
+	rec.Usage = usageRec(resp.Usage)
+	fillTrace(&rec, resp.IntermediateResponses)
+	return rec
+}
+
+// armGrounding maps an arm label to its grounding config and whether the placebo
+// NLI must be swapped in for this arm.
+func armGrounding(arm, reference string) (cfg *config.FusionGroundingConfig, placebo bool) {
+	switch arm {
+	case "B":
+		return nil, false // plain fusion
+	case "C":
+		return &config.FusionGroundingConfig{Enabled: true, Reference: reference}, false
+	case "D":
+		return &config.FusionGroundingConfig{Enabled: true, Reference: reference}, true
+	case "annotate":
+		return &config.FusionGroundingConfig{Enabled: true, Reference: reference, Policy: config.FusionGroundingPolicyAnnotate}, false
+	case "filter":
+		return &config.FusionGroundingConfig{Enabled: true, Reference: reference, Policy: config.FusionGroundingPolicyFilter, MinScore: 0.55, MinKeep: 1}, false
+	default:
+		// Treat unknown arms as plain fusion to avoid silent misconfiguration.
+		return nil, false
+	}
+}
+
+func fillTrace(rec *answerRecord, intermediate interface{}) {
+	trace, ok := intermediate.(*looper.FusionTrace)
+	if !ok || trace == nil || trace.Grounding == nil {
+		return
+	}
+	rec.GroundingPresent = true
+	rec.ReferenceMode = trace.Grounding.ReferenceMode
+	rec.Policy = trace.Grounding.Policy
+	rec.Panel = rec.Panel[:0]
+	for _, s := range trace.Grounding.Scores {
+		score := s.Score
+		flagged := s.FlaggedSpans
+		if flagged == nil {
+			flagged = []string{}
+		}
+		rec.Panel = append(rec.Panel, panelRec{
+			Model:          s.Model,
+			GroundingScore: &score,
+			Dropped:        s.Dropped,
+			Flagged:        flagged,
+		})
+	}
+}
+
+// ---- helpers ----
+
+func buildRequest(question, context string, opt options) *openai.ChatCompletionNewParams {
+	msgs := []openai.ChatCompletionMessageParamUnion{}
+	if strings.TrimSpace(context) != "" {
+		msgs = append(msgs, openai.SystemMessage(context))
+	}
+	msgs = append(msgs, openai.UserMessage(question))
+	req := &openai.ChatCompletionNewParams{Messages: msgs}
+	if opt.temperature > 0 {
+		req.Temperature = openai.Float(opt.temperature)
+	}
+	if opt.maxTokens > 0 {
+		req.MaxCompletionTokens = openai.Int(int64(opt.maxTokens))
+	}
+	return req
+}
+
+func toModelResponses(panel []cachedResponse) []*looper.ModelResponse {
+	out := make([]*looper.ModelResponse, 0, len(panel))
+	for _, p := range panel {
+		out = append(out, &looper.ModelResponse{
+			Model:            p.Model,
+			Content:          p.Content,
+			ReasoningContent: p.Reasoning,
+			Usage:            looper.TokenUsage(p.Usage),
+		})
+	}
+	return out
+}
+
+func finalAnswer(body []byte) string {
+	var completion struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &completion); err != nil || len(completion.Choices) == 0 {
+		return ""
+	}
+	return completion.Choices[0].Message.Content
+}
+
+func panelSHA256(panel []cachedResponse) string {
+	data, _ := json.Marshal(panel)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func itemSeed(base uint64, id string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(id))
+	return base ^ h.Sum64()
+}
+
+func loadItems(path string) ([]item, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var items []item
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var it item
+		if err := json.Unmarshal([]byte(line), &it); err != nil {
+			return nil, fmt.Errorf("bad item line: %w", err)
+		}
+		items = append(items, it)
+	}
+	return items, sc.Err()
+}
+
+func loadPanelCache(path string) (map[string]cachedPanelItem, error) {
+	cache := map[string]cachedPanelItem{}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cache, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e cachedPanelItem
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			return nil, err
+		}
+		cache[e.ItemID] = e
+	}
+	return cache, sc.Err()
+}
+
+func resumeIDs(path string) (map[string]bool, error) {
+	done := map[string]bool{}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return done, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var rec struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err == nil && rec.ID != "" {
+			done[rec.ID] = true
+		}
+	}
+	return done, sc.Err()
+}
+
+func appendJSON(fh *os.File, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if _, err := fh.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+var _ = time.Now // reserved for future per-arm timing

--- a/src/semantic-router/pkg/looper/fusion.go
+++ b/src/semantic-router/pkg/looper/fusion.go
@@ -325,6 +325,14 @@ func (l *FusionLooper) executeFusionPanel(
 	req *Request,
 	cfg fusionExecutionConfig,
 ) ([]*ModelResponse, []FusionFailedModel, error) {
+	// Paired multi-arm evaluation supplies the panel verbatim so every arm
+	// synthesizes from a byte-identical panel (see bench/grounded_fusion). Skip
+	// the live model calls and feed the cached panel straight into grounding +
+	// synthesis, which are source-agnostic over []*ModelResponse.
+	if len(req.CachedPanel) > 0 {
+		return req.CachedPanel, nil, nil
+	}
+
 	results := make(chan fusionPanelResult, len(cfg.AnalysisModels))
 	sem := make(chan struct{}, cfg.MaxConcurrent)
 	for i, model := range cfg.AnalysisModels {

--- a/src/semantic-router/pkg/looper/fusion_cached_panel_test.go
+++ b/src/semantic-router/pkg/looper/fusion_cached_panel_test.go
@@ -1,0 +1,226 @@
+package looper
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"hash/fnv"
+	"math/rand"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// These tests cover the CachedPanel seam used by the paired multi-arm fusion
+// evaluator (bench/grounded_fusion): generate the panel once, then synthesize
+// every arm from the byte-identical panel so deltas isolate the intervention.
+
+// cachedTestPanel builds panel responses with explicit model names + usage, as
+// the fusioneval driver loads them from the panel cache on disk.
+func cachedTestPanel() []*ModelResponse {
+	return []*ModelResponse{
+		{Model: "panel-a", Content: "good grounded answer", Usage: TokenUsage{PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12}},
+		{Model: "panel-b", Content: "bad contradicted answer", Usage: TokenUsage{PromptTokens: 20, CompletionTokens: 3, TotalTokens: 23}},
+	}
+}
+
+// placeboNLI is a deterministic seeded-random NLI: scores are reproducible for a
+// given (seed, premise, hypothesis) but carry no real signal. It mirrors the
+// random-weight placebo arm in the fusioneval driver, isolating "does the score
+// help" from "does any weighting help".
+func placeboNLI(seed uint64) NLIClassifyFunc {
+	return func(premise, hypothesis string) (float32, float32, error) {
+		h := fnv.New64a()
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], seed)
+		_, _ = h.Write(b[:])
+		_, _ = h.Write([]byte(premise))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(hypothesis))
+		r := rand.New(rand.NewSource(int64(h.Sum64()))) //nolint:gosec // deterministic test seed, overflow harmless
+		entail := float32(r.Float64())
+		contradict := float32(r.Float64() * (1 - float64(entail)))
+		return entail, contradict, nil
+	}
+}
+
+// runCachedPanelArm runs Execute against a fixed cached panel with the given
+// grounding config and NLI backend, capturing every prompt the judge saw. The
+// stub fails the test if any panel model is called live, proving the short-circuit.
+func runCachedPanelArm(
+	t *testing.T,
+	p []*ModelResponse,
+	grounding *config.FusionGroundingConfig,
+	nli NLIClassifyFunc,
+) (body map[string]interface{}, judgePrompts []string) {
+	t.Helper()
+	if nli != nil {
+		withGroundingBackends(t, nli, nil)
+	}
+	server := newFusionStubServer(t, func(model, prompt string) (string, int) {
+		if model != "judge" {
+			t.Errorf("cached panel must not call panel model %q live", model)
+			return "unexpected", http.StatusInternalServerError
+		}
+		judgePrompts = append(judgePrompts, prompt)
+		if strings.Contains(prompt, "return only valid JSON") {
+			return `{"consensus":[],"contradictions":[],"partial_coverage":[],"unique_insights":[],"blind_spots":[]}`, http.StatusOK
+		}
+		return "final answer", http.StatusOK
+	})
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.CachedPanel = p
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:          "judge",
+			AnalysisModels: []string{"panel-a", "panel-b"},
+			Grounding:      grounding,
+		},
+	}
+	resp, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	return body, judgePrompts
+}
+
+func groundingBlock(t *testing.T, body map[string]interface{}) (map[string]interface{}, bool) {
+	t.Helper()
+	fusion, ok := body["fusion"].(map[string]interface{})
+	require.True(t, ok, "response should carry a fusion trace")
+	g, ok := fusion["grounding"].(map[string]interface{})
+	return g, ok
+}
+
+func groundingScoresFromBody(t *testing.T, body map[string]interface{}) []float64 {
+	t.Helper()
+	g, ok := groundingBlock(t, body)
+	require.True(t, ok, "expected a grounding block")
+	raw := g["scores"].([]interface{})
+	out := make([]float64, 0, len(raw))
+	for _, s := range raw {
+		out = append(out, s.(map[string]interface{})["score"].(float64))
+	}
+	return out
+}
+
+func panelContentsFromBody(t *testing.T, body map[string]interface{}) []string {
+	t.Helper()
+	fusion := body["fusion"].(map[string]interface{})
+	raw, _ := fusion["responses"].([]interface{})
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, r.(map[string]interface{})["content"].(string))
+	}
+	return out
+}
+
+// TestFusionExecute_CachedPanelSkipsLiveCalls verifies a non-nil CachedPanel
+// short-circuits the live panel calls (the stub errors if any panel model is
+// called) and that usage still reflects the cached panel cost plus the judge.
+func TestFusionExecute_CachedPanelSkipsLiveCalls(t *testing.T) {
+	p := cachedTestPanel()
+	body, judgePrompts := runCachedPanelArm(t, p, nil, nil) // grounding off
+
+	// Exactly two judge calls: analysis + final synthesis.
+	require.Len(t, judgePrompts, 2)
+
+	choices := body["choices"].([]interface{})
+	msg := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+	assert.Equal(t, "final answer", msg["content"])
+
+	// Usage = cached panel (12+23) + two judge calls (34 each via fusionTestUsage).
+	usage := body["usage"].(map[string]interface{})
+	assert.Equal(t, float64(12+23+34+34), usage["total_tokens"])
+}
+
+// TestFusionExecute_CachedPanel_ArmIsolation_BvsC proves arms B (plain fusion)
+// and C (weight) synthesize from the identical cached panel and differ ONLY in
+// the grounding stage: B has no grounding block and no weighting directive; C
+// scores every response, reports policy=weight, and annotates synthesis.
+func TestFusionExecute_CachedPanel_ArmIsolation_BvsC(t *testing.T) {
+	p := cachedTestPanel()
+
+	// Arm B: plain fusion (grounding disabled).
+	bodyB, judgeB := runCachedPanelArm(t, p, nil, nil)
+
+	// Arm C: weight (grounding on, panel mode, policy defaults to weight).
+	highEntail := func(_, _ string) (float32, float32, error) { return 0.9, 0.05, nil }
+	bodyC, judgeC := runCachedPanelArm(t, p, &config.FusionGroundingConfig{
+		Enabled:   true,
+		Reference: config.FusionGroundingReferencePanel,
+	}, highEntail)
+
+	// Both arms feed the IDENTICAL panel content to the judge analysis stage.
+	for _, r := range p {
+		assert.Contains(t, judgeB[0], r.Content)
+		assert.Contains(t, judgeC[0], r.Content)
+	}
+
+	// Arm B: no grounding block, no weighting directive at synthesis.
+	_, hasGroundingB := groundingBlock(t, bodyB)
+	assert.False(t, hasGroundingB, "plain fusion must not emit a grounding block")
+	assert.NotContains(t, judgeB[1], "Weight each panel answer")
+
+	// Arm C: grounding block with a score per response, policy=weight, and the
+	// weighting directive on the final synthesis prompt.
+	gC, ok := groundingBlock(t, bodyC)
+	require.True(t, ok)
+	assert.Equal(t, config.FusionGroundingPolicyWeight, gC["policy"])
+	assert.Len(t, gC["scores"].([]interface{}), len(p))
+	assert.Contains(t, judgeC[1], "Weight each panel answer")
+}
+
+// TestFusionExecute_CachedPanel_PlaceboMechanism proves arm C (real NLI) and arm
+// D (seeded-random placebo NLI) synthesize from the identical panel but produce
+// different groundedness scores — so the A/B isolates the score's signal from the
+// mere act of weighting.
+func TestFusionExecute_CachedPanel_PlaceboMechanism(t *testing.T) {
+	p := cachedTestPanel()
+	grounding := &config.FusionGroundingConfig{
+		Enabled:   true,
+		Reference: config.FusionGroundingReferencePanel,
+	}
+
+	realNLI := func(_, hypothesis string) (float32, float32, error) {
+		if strings.Contains(hypothesis, "bad") {
+			return 0.1, 0.8, nil
+		}
+		return 0.9, 0.05, nil
+	}
+	bodyC, _ := runCachedPanelArm(t, p, grounding, realNLI)
+	bodyD, _ := runCachedPanelArm(t, p, grounding, placeboNLI(7))
+
+	scoresC := groundingScoresFromBody(t, bodyC)
+	scoresD := groundingScoresFromBody(t, bodyD)
+	require.Len(t, scoresC, len(p))
+	require.Len(t, scoresD, len(p))
+
+	// Same panel content reaches the judge in both arms.
+	assert.Equal(t, panelContentsFromBody(t, bodyC), panelContentsFromBody(t, bodyD))
+	// But the scores differ: the placebo weights on noise, not the real signal.
+	assert.NotEqual(t, scoresC, scoresD)
+}
+
+// TestPlaceboNLI_DeterministicAndSpread guards the placebo's two required
+// properties: reproducible for a fixed seed, and non-constant across inputs.
+func TestPlaceboNLI_DeterministicAndSpread(t *testing.T) {
+	nli := placeboNLI(42)
+	e1, c1, err := nli("premise one", "hypothesis one")
+	require.NoError(t, err)
+	e2, c2, err := nli("premise one", "hypothesis one")
+	require.NoError(t, err)
+	assert.Equal(t, e1, e2, "same inputs must yield identical scores")
+	assert.Equal(t, c1, c2)
+
+	e3, _, err := nli("premise one", "a different hypothesis")
+	require.NoError(t, err)
+	assert.NotEqual(t, e1, e3, "different inputs must yield different scores")
+}

--- a/src/semantic-router/pkg/looper/looper.go
+++ b/src/semantic-router/pkg/looper/looper.go
@@ -52,6 +52,12 @@ type Request struct {
 
 	// Fusion carries request-level plugins[].id=fusion overrides.
 	Fusion *config.FusionRequestConfig
+
+	// CachedPanel, when non-nil, is used verbatim as the fusion panel instead of
+	// calling the analysis models. It exists for paired multi-arm evaluation where
+	// every arm must synthesize from a byte-identical panel (see
+	// bench/grounded_fusion). Nil in production; only the fusioneval driver sets it.
+	CachedPanel []*ModelResponse
 }
 
 // Response contains the output from looper execution


### PR DESCRIPTION
## What & why

A **paired, cached-panel, multi-arm** evaluator that settles whether grounding-aware
Fusion's `weight` default actually helps. It generates the panel **once** per item and
synthesizes every arm from the **byte-identical** cached panel, removing the per-arm
panel-regeneration noise that made the first DRACO A/B uninterpretable
(`bench/grounded_fusion/FINDINGS.md`). It also adds the baselines the A/B lacked.

> **Stacked on #2259** (`router-cached-panel-seam`). Review that first; the three
> `[Router]` commits here belong to it. Only the `[Bench]` commits are new in this PR.

Arms: **A** judge-solo (does fusion beat one model?), **B** plain fusion (does grounding
add anything?), **C** `weight` (the shipped default), **D** random-weight placebo (is it
the *score* or just *any* weighting?), plus opt-in `annotate`/`filter`.

Pre-registered decision rule (paired bootstrap CI on the normalized DRACO score):
**KEEP_GROUNDING** if `C>B and C>D and B>=A`; **KILL_GROUNDING_ADDON** if `C≈B` or
`C≈D`; **KILL_FUSION** if `A>B`; else **INCONCLUSIVE**.

## Changes

- `cmd/fusioneval` (Go): wires the **real candle NLI** (`InitNLIModel`+`ClassifyNLI`
  → `SetGroundingBackends`), caches the panel once (resumable `panel_cache.jsonl`),
  runs arms A–D in-process from the identical panel.
- `items.py` → `grade_only.py` (reuses `evaluate.grade_sample`/`summarize`) →
  `compare_multiarm.py` (emits `verdict.json` with the KEEP/KILL decision).
- `datasets.get_dataset("jsonl")` — context-mode dataset seam (gold passages →
  `metadata["context"]`).
- Docs: run sequence, decision rule, context-mode as the sequenced next step.

## Test Plan

- `go test ./pkg/looper/...` — pass; `make go-lint` — 0 issues.
- `pytest bench/grounded_fusion/` — 14 pass (verdict logic: every decision branch,
  strict paired set, missing-placebo guard; + loader/grader).
- `go build ./cmd/fusioneval` (with candle `CGO_LDFLAGS`) — builds; flag/validation +
  real candle-NLI init paths exercised.
- Full local `make agent-ci-lint` — pass.
- **Pending (deliberately not run here):** the live ~100-item verdict run needs the
  candle NLI model + Ollama (overnight-scale). This PR is the infra; the verdict run
  is a follow-up.
