### PR TITLE
[Operator] fix test build broken by EloWeight rename + harden CI trigger

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -9,6 +9,7 @@ on:
       - 'v*'
     paths:
       - 'deploy/operator/**'
+      - 'src/semantic-router/pkg/config/**'
       - '.github/workflows/operator-ci.yml'
   pull_request:
     branches:
@@ -16,6 +17,7 @@ on:
       - develop
     paths:
       - 'deploy/operator/**'
+      - 'src/semantic-router/pkg/config/**'
       - '.github/workflows/operator-ci.yml'
 
 env:

--- a/deploy/operator/controllers/canonical_config_spec_test.go
+++ b/deploy/operator/controllers/canonical_config_spec_test.go
@@ -134,7 +134,7 @@ func TestBuildCanonicalConfigAppliesCanonicalRoutingOverride(t *testing.T) {
 							"algorithm": {
 								"type": "hybrid",
 								"hybrid": {
-									"elo_weight": 0.4,
+									"experience_weight": 0.4,
 									"router_dc_weight": 0.4,
 									"automix_weight": 0.2,
 									"normalize_scores": true
@@ -176,7 +176,7 @@ func TestBuildCanonicalConfigPreservesDecisionAlgorithm(t *testing.T) {
 						Algorithm: rawCanonicalRoutingJSON(t, `{
 							"type": "hybrid",
 							"hybrid": {
-								"elo_weight": 0.4,
+								"experience_weight": 0.4,
 								"router_dc_weight": 0.4,
 								"automix_weight": 0.2,
 								"normalize_scores": true
@@ -200,7 +200,7 @@ func TestBuildCanonicalConfigPreservesDecisionAlgorithm(t *testing.T) {
 	if algorithm == nil || algorithm.Type != "hybrid" || algorithm.Hybrid == nil {
 		t.Fatalf("expected hybrid algorithm to survive typed decision conversion, got %#v", algorithm)
 	}
-	if algorithm.Hybrid.EloWeight != 0.4 || !algorithm.Hybrid.NormalizeScores {
+	if algorithm.Hybrid.ExperienceWeight != 0.4 || !algorithm.Hybrid.NormalizeScores {
 		t.Fatalf("expected hybrid fields to survive typed decision conversion, got %#v", algorithm.Hybrid)
 	}
 	if canonical.Routing.Decisions[0].Rules.Conditions[0].Type != "event" {
@@ -294,7 +294,7 @@ func assertCanonicalAgenticWorkflowDecision(t *testing.T, decisions []routerconf
 	if decision.Algorithm == nil || decision.Algorithm.Type != "hybrid" || decision.Algorithm.Hybrid == nil {
 		t.Fatalf("expected hybrid algorithm, got %#v", decision.Algorithm)
 	}
-	if decision.Algorithm.Hybrid.EloWeight != 0.4 || !decision.Algorithm.Hybrid.NormalizeScores {
+	if decision.Algorithm.Hybrid.ExperienceWeight != 0.4 || !decision.Algorithm.Hybrid.NormalizeScores {
 		t.Fatalf("expected hybrid fields, got %#v", decision.Algorithm.Hybrid)
 	}
 }


### PR DESCRIPTION
Fixes #2268

## Summary

- **Fix operator test compilation failure**: PR #2258 renamed `HybridSelectionConfig.EloWeight` → `ExperienceWeight` (yaml `elo_weight` → `experience_weight`), but the operator test `canonical_config_spec_test.go` still referenced the old field — `go vet ./...` and `go test -race ./...` fail on current main.
- **Prevent recurrence**: Add `src/semantic-router/pkg/config/**` to operator-ci.yml path filters. The operator `go.mod` uses `replace => ../../src/semantic-router`, so changes to the config package can break operator builds. The existing `deploy/operator/**`-only filter missed the #2258 rename.

## Test Plan

- [x] `cd deploy/operator && go vet ./...` — passes (was failing before fix)
- [x] `cd deploy/operator && go test -race ./...` — all tests pass
- [x] No production code changes — only test fixtures/assertions and CI workflow