### PR TITLE
[Operator] fix updateStatus dropping reconcile-derived status fields

### DIFF
--- a/deploy/operator/controllers/semanticrouter_controller.go
+++ b/deploy/operator/controllers/semanticrouter_controller.go
@@ -81,11 +81,13 @@ func (r *SemanticRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	baseSR := semanticrouter.DeepCopy()
+
 	if err := r.reconcileOwnedResources(ctx, semanticrouter, logger); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := r.updateStatus(ctx, semanticrouter); err != nil {
+	if err := r.updateStatus(ctx, semanticrouter, baseSR); err != nil {
 		logger.Error(err, "Failed to update SemanticRouter status, will retry on next reconcile")
 	}
 

--- a/deploy/operator/controllers/semanticrouter_controller_test.go
+++ b/deploy/operator/controllers/semanticrouter_controller_test.go
@@ -344,7 +344,7 @@ func TestUpdateStatus(t *testing.T) {
 		Scheme: s,
 	}
 
-	err := r.updateStatus(context.Background(), sr)
+	err := r.updateStatus(context.Background(), sr, sr.DeepCopy())
 	if err != nil {
 		t.Fatalf("updateStatus() failed when deployment not found: %v", err)
 	}
@@ -378,7 +378,7 @@ func TestUpdateStatus(t *testing.T) {
 		Scheme: s,
 	}
 
-	err = r.updateStatus(context.Background(), sr)
+	err = r.updateStatus(context.Background(), sr, sr.DeepCopy())
 	if err != nil {
 		t.Fatalf("updateStatus() failed: %v", err)
 	}
@@ -396,6 +396,70 @@ func TestUpdateStatus(t *testing.T) {
 
 	if updatedSR2.Status.ReadyReplicas != 2 {
 		t.Errorf("expected 2 ready replicas, got %d", updatedSR2.Status.ReadyReplicas)
+	}
+}
+
+func TestUpdateStatusPreservesReconcileDerivedFields(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = scheme.AddToScheme(s)
+	_ = vllmv1alpha1.AddToScheme(s)
+
+	sr := &vllmv1alpha1.SemanticRouter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: vllmv1alpha1.SemanticRouterSpec{},
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      1,
+			ReadyReplicas: 1,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(sr, deployment).WithStatusSubresource(sr).Build()
+	r := &SemanticRouterReconciler{Client: cl, Scheme: s}
+
+	baseSR := sr.DeepCopy()
+
+	sr.Status.GatewayMode = "standalone"
+	sr.Status.OpenShiftFeatures = &vllmv1alpha1.OpenShiftFeaturesStatus{
+		RoutesEnabled: true,
+		RouteHostname: "sr.apps.example.com",
+	}
+
+	if err := r.updateStatus(context.Background(), sr, baseSR); err != nil {
+		t.Fatalf("updateStatus() failed: %v", err)
+	}
+
+	got := &vllmv1alpha1.SemanticRouter{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, got); err != nil {
+		t.Fatalf("failed to get updated SemanticRouter: %v", err)
+	}
+
+	if got.Status.GatewayMode != "standalone" {
+		t.Errorf("GatewayMode: want %q, got %q", "standalone", got.Status.GatewayMode)
+	}
+
+	if got.Status.OpenShiftFeatures == nil {
+		t.Fatal("OpenShiftFeatures: want non-nil, got nil")
+	}
+	if !got.Status.OpenShiftFeatures.RoutesEnabled {
+		t.Error("OpenShiftFeatures.RoutesEnabled: want true, got false")
+	}
+	if got.Status.OpenShiftFeatures.RouteHostname != "sr.apps.example.com" {
+		t.Errorf("OpenShiftFeatures.RouteHostname: want %q, got %q", "sr.apps.example.com", got.Status.OpenShiftFeatures.RouteHostname)
+	}
+
+	if got.Status.ObservedGeneration != 3 {
+		t.Errorf("ObservedGeneration: want 3, got %d", got.Status.ObservedGeneration)
 	}
 }
 

--- a/deploy/operator/controllers/semanticrouter_reconcile_resources.go
+++ b/deploy/operator/controllers/semanticrouter_reconcile_resources.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -236,64 +237,59 @@ func (r *SemanticRouterReconciler) reconcileIngress(ctx context.Context, sr *vll
 	return nil
 }
 
-func (r *SemanticRouterReconciler) updateStatus(ctx context.Context, sr *vllmv1alpha1.SemanticRouter) error {
+func (r *SemanticRouterReconciler) updateStatus(ctx context.Context, sr *vllmv1alpha1.SemanticRouter, baseSR *vllmv1alpha1.SemanticRouter) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		current := &vllmv1alpha1.SemanticRouter{}
-		if err := r.Get(ctx, types.NamespacedName{Name: sr.Name, Namespace: sr.Namespace}, current); err != nil {
-			return err
-		}
+		sr.Status.ObservedGeneration = sr.Generation
 
 		deployment := &appsv1.Deployment{}
 		err := r.Get(ctx, types.NamespacedName{Name: sr.Name, Namespace: sr.Namespace}, deployment)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				current.Status.Replicas = 0
-				current.Status.ReadyReplicas = 0
-				current.Status.ObservedGeneration = current.Generation
-				current.Status.Phase = "Pending"
-				meta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+				sr.Status.Replicas = 0
+				sr.Status.ReadyReplicas = 0
+				sr.Status.Phase = "Pending"
+				meta.SetStatusCondition(&sr.Status.Conditions, metav1.Condition{
 					Type:    typeAvailableSemanticRouter,
 					Status:  metav1.ConditionFalse,
 					Reason:  "DeploymentNotFound",
 					Message: "Deployment has not been created yet",
 				})
-				return r.Status().Update(ctx, current)
+				return r.Status().Patch(ctx, sr, client.MergeFrom(baseSR))
 			}
 			return err
 		}
 
-		current.Status.Replicas = deployment.Status.Replicas
-		current.Status.ReadyReplicas = deployment.Status.ReadyReplicas
-		current.Status.ObservedGeneration = current.Generation
+		sr.Status.Replicas = deployment.Status.Replicas
+		sr.Status.ReadyReplicas = deployment.Status.ReadyReplicas
 
 		if deployment.Status.ReadyReplicas == 0 {
-			current.Status.Phase = "Pending"
-			meta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+			sr.Status.Phase = "Pending"
+			meta.SetStatusCondition(&sr.Status.Conditions, metav1.Condition{
 				Type:    typeAvailableSemanticRouter,
 				Status:  metav1.ConditionFalse,
 				Reason:  "Pending",
 				Message: "No replicas are ready",
 			})
 		} else if deployment.Status.ReadyReplicas < deployment.Status.Replicas {
-			current.Status.Phase = "Progressing"
-			meta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+			sr.Status.Phase = "Progressing"
+			meta.SetStatusCondition(&sr.Status.Conditions, metav1.Condition{
 				Type:    typeProgressingSemanticRouter,
 				Status:  metav1.ConditionTrue,
 				Reason:  "Progressing",
 				Message: fmt.Sprintf("%d/%d replicas ready", deployment.Status.ReadyReplicas, deployment.Status.Replicas),
 			})
 		} else {
-			current.Status.Phase = "Running"
-			meta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+			sr.Status.Phase = "Running"
+			meta.SetStatusCondition(&sr.Status.Conditions, metav1.Condition{
 				Type:    typeAvailableSemanticRouter,
 				Status:  metav1.ConditionTrue,
 				Reason:  "AllReplicasReady",
 				Message: "All replicas are ready",
 			})
-			meta.RemoveStatusCondition(&current.Status.Conditions, typeProgressingSemanticRouter)
+			meta.RemoveStatusCondition(&sr.Status.Conditions, typeProgressingSemanticRouter)
 		}
 
-		return r.Status().Update(ctx, current)
+		return r.Status().Patch(ctx, sr, client.MergeFrom(baseSR))
 	})
 }
 


### PR DESCRIPTION
Fix `updateStatus` silently dropping `GatewayMode`, `OpenShiftFeatures`, and using wrong `ObservedGeneration`.

Switch from re-fetch + selective copy + `Status().Update()` to `Status().Patch()` with `client.MergeFrom`, preserving all status fields set during reconciliation.

Fixes https://github.com/vllm-project/semantic-router/issues/2271