### PR TITLE
[Bench][CI/Build] Router Learning architecture eval: threshold profiles + pass/fail gate (#2244)

### DIFF
--- a/.github/workflows/router-learning-eval.yml
+++ b/.github/workflows/router-learning-eval.yml
@@ -1,0 +1,57 @@
+name: Router Learning Eval
+
+# Runs the deterministic Router Learning architecture eval and gates the summary
+# against the named PR profile. Pure stdlib Python — no router/model deployment needed.
+# See bench/profiles/router_learning/ for the threshold profiles and bench/README
+# "Router Learning architecture eval" for details.
+
+on:
+  pull_request:
+    paths:
+      - 'bench/agentic_routing_experiment.py'
+      - 'bench/profiles/router_learning/**'
+      - 'bench/test_agentic_routing_experiment.py'
+      - 'src/semantic-router/pkg/**'
+      - '.github/workflows/router-learning-eval.yml'
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'Profile to gate against (pr/release)'
+        default: 'pr'
+
+permissions:
+  contents: read
+
+jobs:
+  router-learning-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test deps
+        run: pip install pytest
+      - name: Run unit tests for the eval harness
+        run: python -m pytest bench/test_agentic_routing_experiment.py -q
+      - name: Gate Router Learning architecture eval
+        run: |
+          python bench/agentic_routing_experiment.py \
+            --learning-architecture \
+            --profile "${{ github.event.inputs.profile || 'pr' }}" \
+            --output-dir "$GITHUB_WORKSPACE/.rl-eval"
+      - name: Attach verdict + summary to job summary
+        if: always()
+        run: |
+          {
+            echo '## Router Learning Eval'
+            echo '```'
+            cat "$GITHUB_WORKSPACE/.rl-eval/learning_architecture_verdict.json" 2>/dev/null || echo 'no verdict produced'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload eval artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: router-learning-eval
+          path: .rl-eval/

--- a/bench/agentic_routing_experiment.py
+++ b/bench/agentic_routing_experiment.py
@@ -13,6 +13,7 @@ import csv
 import json
 import math
 import random
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -208,6 +209,15 @@ def parse_args() -> argparse.Namespace:
         "--learning-architecture",
         action="store_true",
         help="Run deterministic Router Learning architecture fixtures.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Gate the --learning-architecture summary against a named profile "
+            "(pr/release) or a profile JSON path. Writes a verdict and exits "
+            "non-zero on failure so CI/release pipelines can gate."
+        ),
     )
     parser.add_argument(
         "--agentic-policy",
@@ -1184,6 +1194,89 @@ def write_learning_architecture_outputs(out_dir: Path) -> dict[str, Any]:
     return summary
 
 
+PROFILE_DIR = Path(__file__).with_name("profiles") / "router_learning"
+
+
+def load_profile(name_or_path: str) -> dict[str, Any]:
+    """Load a Router Learning eval profile by short name (pr/release) or explicit path."""
+    candidate = Path(name_or_path)
+    if not candidate.exists():
+        candidate = PROFILE_DIR / f"{name_or_path}.json"
+    if not candidate.exists():
+        available = sorted(p.stem for p in PROFILE_DIR.glob("*.json"))
+        raise FileNotFoundError(
+            f"profile {name_or_path!r} not found; available: {', '.join(available) or '(none)'}"
+        )
+    profile = json.loads(candidate.read_text())
+    if "thresholds" not in profile or not isinstance(profile["thresholds"], dict):
+        raise ValueError(f"profile {candidate} missing a 'thresholds' object")
+    return profile
+
+
+def evaluate_against_profile(
+    summary: dict[str, Any], profile: dict[str, Any]
+) -> dict[str, Any]:
+    """Check a learning-architecture summary against a profile's min/max thresholds.
+
+    Returns a deterministic verdict dict: per-metric checks (with observed value,
+    bound, and pass flag) plus an overall ``passed`` boolean. A metric that is
+    absent from the summary, or ``None`` (e.g. bypass_correctness_pct when there
+    are no bypass cases), is reported as a failure so a profile can never be
+    silently satisfied by missing data.
+    """
+    checks: list[dict[str, Any]] = []
+    for metric, bounds in sorted(profile.get("thresholds", {}).items()):
+        observed = summary.get(metric)
+        failures: list[str] = []
+        if observed is None:
+            failures.append("missing-or-null")
+        else:
+            if "min" in bounds and observed < bounds["min"]:
+                failures.append(f"{observed} < min {bounds['min']}")
+            if "max" in bounds and observed > bounds["max"]:
+                failures.append(f"{observed} > max {bounds['max']}")
+        checks.append(
+            {
+                "metric": metric,
+                "observed": observed,
+                "min": bounds.get("min"),
+                "max": bounds.get("max"),
+                "passed": not failures,
+                "detail": "; ".join(failures) if failures else "ok",
+            }
+        )
+    failed = [c for c in checks if not c["passed"]]
+    return {
+        "profile": profile.get("profile", "unknown"),
+        "passed": not failed,
+        "n_checks": len(checks),
+        "n_failed": len(failed),
+        "checks": checks,
+        "failed_metrics": [c["metric"] for c in failed],
+    }
+
+
+def render_verdict(verdict: dict[str, Any]) -> str:
+    """Concise human-readable PASS/FAIL verdict for CI logs / PR comments."""
+    status = "PASS" if verdict["passed"] else "FAIL"
+    lines = [
+        f"Router Learning eval [{verdict['profile']}]: {status} "
+        f"({verdict['n_checks'] - verdict['n_failed']}/{verdict['n_checks']} checks passed)"
+    ]
+    for c in verdict["checks"]:
+        mark = "✓" if c["passed"] else "✗"
+        bound = []
+        if c["min"] is not None:
+            bound.append(f"min {c['min']}")
+        if c["max"] is not None:
+            bound.append(f"max {c['max']}")
+        lines.append(
+            f"  {mark} {c['metric']} = {c['observed']} [{', '.join(bound)}]"
+            + ("" if c["passed"] else f"  <-- {c['detail']}")
+        )
+    return "\n".join(lines)
+
+
 def render_learning_architecture_report(
     summary: dict[str, Any], rows: list[dict[str, Any]]
 ) -> str:
@@ -1361,8 +1454,34 @@ def render_ablation_svg(summary: dict[str, Any]) -> str:
 def main() -> None:
     args = parse_args()
     out_dir = args.output_dir or default_output_dir()
+    if args.profile and not args.learning_architecture:
+        print(
+            "error: --profile is only valid with --learning-architecture",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     if args.learning_architecture:
         summary = write_learning_architecture_outputs(out_dir)
+        if args.profile:
+            profile = load_profile(args.profile)
+            verdict = evaluate_against_profile(summary, profile)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "learning_architecture_verdict.json").write_text(
+                json.dumps(verdict, indent=2, sort_keys=True) + "\n"
+            )
+            print(render_verdict(verdict), file=sys.stderr)
+            print(
+                json.dumps(
+                    {
+                        "output_dir": str(out_dir),
+                        "summary": summary,
+                        "verdict": verdict,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            sys.exit(0 if verdict["passed"] else 1)
     elif args.ablation:
         summary = write_ablation_outputs(
             DEFAULT_SCENARIOS,

--- a/bench/profiles/router_learning/README.md
+++ b/bench/profiles/router_learning/README.md
@@ -1,0 +1,55 @@
+# Router Learning architecture eval — threshold profiles
+
+Pass/fail gate for the deterministic Router Learning architecture eval
+(`bench/agentic_routing_experiment.py --learning-architecture`). Implements the
+"named reusable profiles + pass/fail thresholds" slice of #2244.
+
+## What it does
+
+The `--learning-architecture` run produces a summary of routing-quality metrics
+over deterministic fixtures (session-aware / bandit / Elo / personalization
+adaptations). A **profile** declares min/max bounds per metric; the eval is
+gated against it and **exits non-zero on any breach**, so a PR or release
+pipeline fails when Router Learning routing quality, cost, cache behavior, or
+latency regresses.
+
+## Usage
+
+```bash
+# Run + gate against the per-PR profile (default)
+python bench/agentic_routing_experiment.py --learning-architecture --profile pr --output-dir OUT
+# or:
+make bench-router-learning              # PROFILE=pr
+make bench-router-learning PROFILE=release
+```
+
+Outputs in `OUT/`:
+- `learning_architecture_summary.json` — the metric summary (unchanged).
+- `learning_architecture_verdict.json` — per-metric checks + overall `passed`.
+- a human-readable PASS/FAIL verdict on stderr (for CI logs / PR comments).
+
+Exit codes: `0` pass · `1` threshold breach · `2` misuse (`--profile` without
+`--learning-architecture`).
+
+## Profiles
+
+| Profile | Intent | Notable bounds |
+|---------|--------|----------------|
+| `pr` | per-PR gate | correctness/explainability/bypass = 100%; switch-rate ≤ 20%; cost savings ≥ 0%; p95 overhead ≤ 50 ms (CI-host headroom) |
+| `release` | release sign-off | same correctness ceiling; switch-rate ≤ 15%; cost savings ≥ 5%; p95 overhead ≤ 25 ms |
+
+Profiles are JSON: `{"profile": NAME, "thresholds": {METRIC: {"min": x} | {"max": y}}}`.
+`--profile` also accepts an explicit path to a custom profile JSON.
+
+## Design notes
+
+- **Missing/null metrics fail closed.** A metric absent from the summary (or
+  `None`, e.g. `bypass_correctness_pct` when there are no bypass cases) is a
+  failure, so a profile can never be silently satisfied by missing data.
+- **Thresholds are calibrated to the deterministic fixtures**, which are
+  hand-built to route perfectly — hence the 100% correctness floors. The
+  operational bounds (switch-rate, cost, cache, latency) carry headroom tuned
+  to the current fixture values (see `git blame` for the baseline run).
+- **Scope (first slice of #2244):** thresholds + named profiles + CI gate on the
+  existing harness. Deferred follow-ups: live Router Replay mode, and the
+  session-scope / tool-loop / idle-reset / privacy fixture expansion.

--- a/bench/profiles/router_learning/pr.json
+++ b/bench/profiles/router_learning/pr.json
@@ -1,0 +1,13 @@
+{
+  "profile": "pr",
+  "description": "Per-PR gate for Router Learning architecture evals. Run against the deterministic fixtures; these are hand-constructed to route perfectly, so correctness/explainability must stay at ceiling. Latency bounds carry headroom for CI host noise.",
+  "thresholds": {
+    "route_correctness_pct":            {"min": 100.0},
+    "replay_explainability_coverage_pct": {"min": 100.0},
+    "bypass_correctness_pct":           {"min": 100.0},
+    "unnecessary_switch_rate_pct":      {"max": 20.0},
+    "cost_savings_pct":                 {"min": 0.0},
+    "cache_token_delta":                {"max": 100000},
+    "p95_overhead_ms":                  {"max": 50.0}
+  }
+}

--- a/bench/profiles/router_learning/release.json
+++ b/bench/profiles/router_learning/release.json
@@ -1,0 +1,13 @@
+{
+  "profile": "release",
+  "description": "Release sign-off gate for Router Learning architecture evals. Correctness/explainability at ceiling on the deterministic fixtures; tighter switch-rate, positive cost savings, and stricter latency than the PR gate.",
+  "thresholds": {
+    "route_correctness_pct":            {"min": 100.0},
+    "replay_explainability_coverage_pct": {"min": 100.0},
+    "bypass_correctness_pct":           {"min": 100.0},
+    "unnecessary_switch_rate_pct":      {"max": 15.0},
+    "cost_savings_pct":                 {"min": 5.0},
+    "cache_token_delta":                {"max": 50000},
+    "p95_overhead_ms":                  {"max": 25.0}
+  }
+}

--- a/bench/test_agentic_routing_experiment.py
+++ b/bench/test_agentic_routing_experiment.py
@@ -156,3 +156,87 @@ def test_learning_architecture_eval_reports_required_metrics(tmp_path):
     assert "Router Learning Architecture Eval" in report
     assert "conversation-cache-stay" in report
     assert "privacy-bypass-local" in report
+
+
+def test_pr_and_release_profiles_pass_on_deterministic_fixtures(tmp_path):
+    exp = load_experiment_module()
+    summary = exp.write_learning_architecture_outputs(tmp_path)
+    for profile_name in ("pr", "release"):
+        profile = exp.load_profile(profile_name)
+        verdict = exp.evaluate_against_profile(summary, profile)
+        assert verdict[
+            "passed"
+        ], f"{profile_name} profile should pass: {verdict['failed_metrics']}"
+        assert verdict["n_failed"] == 0
+        assert verdict["profile"] == profile_name
+
+
+def test_profile_gate_catches_regression():
+    exp = load_experiment_module()
+    profile = exp.load_profile("pr")
+    degraded = {
+        "route_correctness_pct": 82.0,
+        "replay_explainability_coverage_pct": 100.0,
+        "bypass_correctness_pct": 100.0,
+        "unnecessary_switch_rate_pct": 31.0,
+        "cost_savings_pct": -3.0,
+        "cache_token_delta": 5000,
+        "p95_overhead_ms": 120.0,
+    }
+    verdict = exp.evaluate_against_profile(degraded, profile)
+    assert verdict["passed"] is False
+    assert set(verdict["failed_metrics"]) == {
+        "route_correctness_pct",
+        "unnecessary_switch_rate_pct",
+        "cost_savings_pct",
+        "p95_overhead_ms",
+    }
+
+
+def test_profile_gate_fails_on_missing_metric():
+    exp = load_experiment_module()
+    profile = exp.load_profile("pr")
+    # Absent / None metrics must fail, never silently satisfy the gate.
+    verdict = exp.evaluate_against_profile({"route_correctness_pct": 100.0}, profile)
+    assert verdict["passed"] is False
+    assert verdict["n_failed"] == 6
+    none_check = exp.evaluate_against_profile(
+        {
+            **{
+                k: 100.0
+                for k in (
+                    "route_correctness_pct",
+                    "replay_explainability_coverage_pct",
+                )
+            },
+            "bypass_correctness_pct": None,
+            "unnecessary_switch_rate_pct": 0.0,
+            "cost_savings_pct": 10.0,
+            "cache_token_delta": 0,
+            "p95_overhead_ms": 1.0,
+        },
+        profile,
+    )
+    assert none_check["passed"] is False
+    assert "bypass_correctness_pct" in none_check["failed_metrics"]
+
+
+def test_load_profile_unknown_name_raises():
+    exp = load_experiment_module()
+    try:
+        exp.load_profile("does-not-exist")
+    except FileNotFoundError as e:
+        assert "available" in str(e)
+    else:
+        raise AssertionError("expected FileNotFoundError for unknown profile")
+
+
+def test_unknown_profile_via_explicit_path(tmp_path):
+    exp = load_experiment_module()
+    p = tmp_path / "custom.json"
+    p.write_text(
+        '{"profile":"custom","thresholds":{"route_correctness_pct":{"min":50.0}}}'
+    )
+    profile = exp.load_profile(str(p))
+    verdict = exp.evaluate_against_profile({"route_correctness_pct": 75.0}, profile)
+    assert verdict["passed"] is True

--- a/tools/make/build-run-test.mk
+++ b/tools/make/build-run-test.mk
@@ -189,6 +189,19 @@ test-e2e-vllm:
 	@echo "Note: Make sure LLM Katan servers are running with 'make start-llm-katan'"
 	@python3 e2e/testing/run_all_tests.py
 
+# Run the deterministic Router Learning architecture eval and gate it against a
+# named threshold profile (pr/release). Pure stdlib Python — no router/vLLM needed.
+# Exits non-zero on a threshold breach so CI/release pipelines can gate.
+# Usage: make bench-router-learning            (defaults to the pr profile)
+#        make bench-router-learning PROFILE=release
+bench-router-learning: ## Run + gate the Router Learning architecture eval (PROFILE=pr|release)
+bench-router-learning: PROFILE ?= pr
+bench-router-learning:
+	@echo "Running Router Learning architecture eval (profile: $(PROFILE))..."
+	@python3 bench/agentic_routing_experiment.py \
+		--learning-architecture --profile $(PROFILE) \
+		--output-dir .agent-harness/router-learning-eval
+
 # Run hallucination detection benchmark
 # Requires: router running with hallucination config, vLLM endpoint, envoy proxy
 bench-hallucination: ## Run hallucination detection benchmark (requires router + vLLM + envoy running)


### PR DESCRIPTION
Closes #2244

## Purpose

- **What this changes:** Adds a pass/fail **gate** on top of the existing deterministic Router Learning architecture eval (`bench/agentic_routing_experiment.py --learning-architecture`, added in #2258). The eval already computes the routing-quality metrics; this PR turns that summary into a CI/release gate via **named threshold profiles**.
  - `bench/profiles/router_learning/{pr,release}.json` — declarative `{min,max}` bounds per metric (route correctness, unnecessary switch rate, replay explainability coverage, cost savings, cache-token delta, p95 overhead).
  - `load_profile` / `evaluate_against_profile` / `render_verdict` in the harness, plus a new `--profile` flag that gates `--learning-architecture`: writes `learning_architecture_verdict.json`, prints a concise PASS/FAIL verdict, and **exits non-zero on a threshold breach** (exit `2` on misuse). Missing/`None` metrics **fail closed**, so a profile can never be silently satisfied by absent data.
  - `make bench-router-learning PROFILE=pr|release` for local == CI parity.
  - `.github/workflows/router-learning-eval.yml` — runs the harness unit tests, gates against the `pr` profile, and attaches the verdict to the job summary + uploads artifacts.

- **Why it's needed:** #2244 asks to turn the deterministic eval into reusable CI/release profiles with pass/fail thresholds. Without a gate, Router Learning routing quality / cost / cache / latency can regress silently. This is the smallest slice that makes the eval enforceable.

- **Module(s):** `E2E` / `CI/Build` (bench + workflow + Makefile). No `Router` runtime code is touched.

## Test Plan

```bash
# Unit tests for the harness + gate (pure stdlib + pytest)
python -m pytest bench/test_agentic_routing_experiment.py -q

# Run + gate the eval the same way CI does
make bench-router-learning              # pr profile (default)
make bench-router-learning PROFILE=release
```

Reviewers can also drive the CLI directly and check exit codes:
`--profile pr` → exit 0 on pass, exit 1 on a threshold breach, exit 2 if `--profile` is passed without `--learning-architecture`.

## Test Result

- **Unit tests:** 10/10 pass (5 pre-existing + 5 new: profiles pass on the deterministic fixtures; a degraded summary fails the *exact* breached metrics; missing metrics fail closed; unknown-profile and explicit-path loading).
- **Gate behavior (verified end-to-end):**
  - `pr` and `release` profiles → **PASS** on the deterministic fixtures (exit 0), verdict JSON written.
  - A degraded summary → **FAIL** (exit 1), flagging exactly the breached metrics.
  - Misuse (`--profile` without `--learning-architecture`) → exit 2.
- **Calibration check:** a threshold-boundary sweep confirms every gate flips PASS→FAIL **exactly at its bound** (e.g. `route_correctness_pct` 100.0 passes, 99.99 fails; `p95_overhead_ms` 50.0 passes, 50.01 fails) — i.e. the profiles are calibrated, not green-by-default.
- **Lint/format:** `black` and `ruff` clean on the changed Python.
- **Follow-up scope (deferred):** live Router Replay mode (gate against real replay records instead of synthetic fixtures) and the session-scope / tool-loop / idle-reset / privacy fixture expansion called out in #2244. Thresholds are currently calibrated to the deterministic fixtures (hand-built to route perfectly → 100% correctness floors); maintainer input welcome on the operational bounds (switch-rate, cost, latency).

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes (`[Bench]` / `[CI/Build]`)
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
