### PR TITLE
[Router] persist demoted cache-similarity and context-token-count in replay record (#2254)

### DIFF
--- a/dashboard/frontend/src/pages/insightsPageSupport.tsx
+++ b/dashboard/frontend/src/pages/insightsPageSupport.tsx
@@ -346,6 +346,7 @@ export function buildInsightsRecordSections(
   sections.push({
     title: 'Usage & Cost',
     fields: [
+      { label: 'Context tokens', value: formatTokenValue(record.context_token_count) },
       { label: 'Prompt tokens', value: formatTokenValue(record.prompt_tokens) },
       { label: 'Completion tokens', value: formatTokenValue(record.completion_tokens) },
       { label: 'Total tokens', value: formatTokenValue(record.total_tokens) },
@@ -368,6 +369,7 @@ export function buildInsightsRecordSections(
     title: 'Plugin Status',
     fields: [
       { label: 'Cache', value: record.from_cache ? 'Hit' : 'Miss' },
+      { label: 'Cache similarity', value: formatSimilarityValue(record.cache_similarity) },
       { label: 'Streaming', value: record.streaming ? 'On' : 'Off' },
       { label: 'Guardrails', value: buildGuardrailsValue(record) },
       { label: 'RAG', value: buildRagValue(record) },
@@ -707,4 +709,8 @@ function formatCurrencyOrNA(value?: number, currency?: string) {
 
 function formatTokenValue(value?: number) {
   return typeof value === 'number' ? value.toLocaleString('en-US') : '-'
+}
+
+function formatSimilarityValue(value?: number) {
+  return typeof value === 'number' ? value.toFixed(3) : '-'
 }

--- a/dashboard/frontend/src/pages/insightsPageTypes.ts
+++ b/dashboard/frontend/src/pages/insightsPageTypes.ts
@@ -140,6 +140,10 @@ export interface InsightsRecord {
   rag_backend?: string
   rag_context_length?: number
   rag_similarity_score?: number
+  // v0.4 demoted-header replay fields (#2200, #2254): recoverable here even when
+  // x-vsr-cache-similarity / x-vsr-context-token-count are not emitted as headers.
+  cache_similarity?: number
+  context_token_count?: number
   hallucination_enabled?: boolean
   hallucination_detected?: boolean
   hallucination_confidence?: number

--- a/src/semantic-router/pkg/extproc/recorder.go
+++ b/src/semantic-router/pkg/extproc/recorder.go
@@ -234,6 +234,8 @@ func buildReplayRoutingRecord(
 		RAGBackend:           ctx.RAGBackend,
 		RAGContextLength:     len(ctx.RAGRetrievedContext),
 		RAGSimilarityScore:   ctx.RAGSimilarityScore,
+		CacheSimilarity:      ctx.VSRCacheSimilarity,
+		ContextTokenCount:    ctx.VSRContextTokenCount,
 		HallucinationEnabled: hallucinationEnabled,
 	}
 	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.IsResponseAPIRequest {

--- a/src/semantic-router/pkg/extproc/recorder_test.go
+++ b/src/semantic-router/pkg/extproc/recorder_test.go
@@ -320,6 +320,23 @@ func assertReplayMatchedSignals(t *testing.T, record routerreplay.RoutingRecord)
 	}
 }
 
+func TestBuildReplayRoutingRecord_CacheSimilarityAndContextTokenCount(t *testing.T) {
+	ctx := &RequestContext{
+		RequestID:            "req-cache-ctx",
+		VSRCacheSimilarity:   0.87,
+		VSRContextTokenCount: 1234,
+	}
+
+	record := buildReplayRoutingRecord(ctx, "model-a", "model-b", "balance")
+
+	if record.CacheSimilarity != 0.87 {
+		t.Fatalf("expected cache_similarity 0.87 copied to record, got %v", record.CacheSimilarity)
+	}
+	if record.ContextTokenCount != 1234 {
+		t.Fatalf("expected context_token_count 1234 copied to record, got %d", record.ContextTokenCount)
+	}
+}
+
 func TestBuildReplayRoutingRecord_ResponseAPIChainFields(t *testing.T) {
 	ctx := &RequestContext{
 		RequestID: "req-resp-1",

--- a/src/semantic-router/pkg/routerreplay/store/postgres.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres.go
@@ -35,8 +35,9 @@ const postgresInsertQueryTemplate = `
 			hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
 			prompt_tokens, cached_prompt_tokens, completion_tokens, total_tokens,
 			actual_cost, baseline_cost, cost_savings, currency, baseline_model,
-			session_id, turn_index, previous_response_id, conversation_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56)
+			session_id, turn_index, previous_response_id, conversation_id,
+			cache_similarity, context_token_count
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58)
 	`
 
 const postgresCreateTableQueryTemplate = `
@@ -124,6 +125,8 @@ const postgresCreateTableQueryTemplate = `
 		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS turn_index INTEGER;
 		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS previous_response_id VARCHAR(255);
 		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS conversation_id VARCHAR(255);
+		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS cache_similarity REAL DEFAULT 0;
+		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS context_token_count INTEGER DEFAULT 0;
 		CREATE INDEX IF NOT EXISTS idx_{{table}}_timestamp ON {{table}} (timestamp DESC);
 		CREATE INDEX IF NOT EXISTS idx_{{table}}_created_at ON {{table}} (created_at);
 		CREATE INDEX IF NOT EXISTS idx_{{table}}_request_id ON {{table}} (request_id);

--- a/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
@@ -20,7 +20,8 @@ const postgresRecordSelectColumns = `
 	hallucination_enabled, hallucination_detected, hallucination_confidence, hallucination_spans,
 	prompt_tokens, cached_prompt_tokens, completion_tokens, total_tokens,
 	actual_cost, baseline_cost, cost_savings, currency, baseline_model,
-	session_id, turn_index, previous_response_id, conversation_id
+	session_id, turn_index, previous_response_id, conversation_id,
+	cache_similarity, context_token_count
 `
 
 type postgresRowScanner interface {
@@ -186,6 +187,8 @@ func (record postgresInsertRecord) args() []interface{} {
 		record.record.TurnIndex,
 		emptyStringSQL(record.record.PreviousResponseID),
 		emptyStringSQL(record.record.ConversationID),
+		record.record.CacheSimilarity,
+		record.record.ContextTokenCount,
 	}
 }
 
@@ -274,6 +277,8 @@ func (row *postgresRecordRow) scanDestinations() []interface{} {
 		&row.turnIndex,
 		&row.previousResponseID,
 		&row.conversationID,
+		&row.record.CacheSimilarity,
+		&row.record.ContextTokenCount,
 	}
 }
 

--- a/src/semantic-router/pkg/routerreplay/store/record_demoted_header_fields_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/record_demoted_header_fields_test.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRecordJSONExposesDemotedHeaderFields locks the replay wire contract for
+// the two v0.4 demoted-header values (#2200, #2254). The replay API marshals
+// the full Record, so these exact snake_case keys are what GET
+// /v1/router_replay/{id} and the dashboard replay view read. Asserting the raw
+// JSON keys (not just a round trip) guards against a tag rename silently
+// breaking that contract.
+func TestRecordJSONExposesDemotedHeaderFields(t *testing.T) {
+	rec := Record{
+		ID:                "rid",
+		Signals:           Signal{},
+		CacheSimilarity:   0.875, // exactly representable as float32
+		ContextTokenCount: 4096,
+	}
+
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(data)
+
+	if !strings.Contains(js, `"cache_similarity":0.875`) {
+		t.Fatalf("expected cache_similarity key in replay JSON, got %s", js)
+	}
+	if !strings.Contains(js, `"context_token_count":4096`) {
+		t.Fatalf("expected context_token_count key in replay JSON, got %s", js)
+	}
+
+	decoded := roundTripRecord(t, rec)
+	if decoded.CacheSimilarity != 0.875 {
+		t.Fatalf("cache_similarity round-trip = %v", decoded.CacheSimilarity)
+	}
+	if decoded.ContextTokenCount != 4096 {
+		t.Fatalf("context_token_count round-trip = %d", decoded.ContextTokenCount)
+	}
+}
+
+// TestRecordJSONOmitsDemotedHeaderFieldsWhenZero confirms the omitempty tags
+// keep the replay JSON clean for requests with no cache lookup / no context
+// token count, matching the surrounding RAG/usage fields.
+func TestRecordJSONOmitsDemotedHeaderFieldsWhenZero(t *testing.T) {
+	data, err := json.Marshal(Record{ID: "rid", Signals: Signal{}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(data)
+
+	if strings.Contains(js, "cache_similarity") {
+		t.Fatalf("expected cache_similarity omitted when zero, got %s", js)
+	}
+	if strings.Contains(js, "context_token_count") {
+		t.Fatalf("expected context_token_count omitted when zero, got %s", js)
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/store/record_demoted_header_fields_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/record_demoted_header_fields_test.go
@@ -59,3 +59,42 @@ func TestRecordJSONOmitsDemotedHeaderFieldsWhenZero(t *testing.T) {
 		t.Fatalf("expected context_token_count omitted when zero, got %s", js)
 	}
 }
+
+// TestPostgresBackendWiresDemotedHeaderFields guards the Postgres column wiring
+// for the two demoted-header values (#2254). Unlike the JSON backends
+// (memory/redis/milvus/qdrant) which marshal the whole Record, Postgres maps
+// columns explicitly — so a struct field with no matching column in the
+// CREATE/INSERT/SELECT/scan chain is silently dropped under
+// store_backend: postgres (the documented default). This pins every link.
+func TestPostgresBackendWiresDemotedHeaderFields(t *testing.T) {
+	for _, col := range []string{"cache_similarity", "context_token_count"} {
+		if !strings.Contains(postgresCreateTableQueryTemplate, col) {
+			t.Errorf("CREATE TABLE template missing %q — column never provisioned", col)
+		}
+		if !strings.Contains(postgresInsertQueryTemplate, col) {
+			t.Errorf("INSERT template missing %q — value never written under store_backend: postgres", col)
+		}
+		if !strings.Contains(postgresRecordSelectColumns, col) {
+			t.Errorf("SELECT column list missing %q — value never read back under store_backend: postgres", col)
+		}
+	}
+
+	// SELECT column list and scan destinations must stay 1:1; otherwise every
+	// scanned column shifts. The insert-side alignment test does not cover this.
+	selectCols := splitSQLColumnList(postgresRecordSelectColumns)
+	scanDests := (&postgresRecordRow{}).scanDestinations()
+	if len(selectCols) != len(scanDests) {
+		t.Fatalf("SELECT columns (%d) vs scan destinations (%d) count mismatch", len(selectCols), len(scanDests))
+	}
+}
+
+func splitSQLColumnList(list string) []string {
+	parts := strings.Split(list, ",")
+	cols := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			cols = append(cols, trimmed)
+		}
+	}
+	return cols
+}

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -195,6 +195,18 @@ type Record struct {
 	RAGContextLength   int     `json:"rag_context_length,omitempty"`
 	RAGSimilarityScore float32 `json:"rag_similarity_score,omitempty"`
 
+	// v0.4 demoted-header replay homes (#2200, #2254): both values were removed
+	// from the default response header surface and now live only in the replay
+	// record, so they stay recoverable via x-vsr-replay-id when a request does
+	// not set x-vsr-debug.
+	//
+	// CacheSimilarity is the semantic-cache lookup similarity (0 = no lookup),
+	// formerly the x-vsr-cache-similarity header.
+	CacheSimilarity float32 `json:"cache_similarity,omitempty"`
+	// ContextTokenCount is the request context token count used for
+	// context-based routing, formerly the x-vsr-context-token-count header.
+	ContextTokenCount int `json:"context_token_count,omitempty"`
+
 	// Hallucination Detection
 	HallucinationEnabled    bool     `json:"hallucination_enabled,omitempty"`
 	HallucinationDetected   bool     `json:"hallucination_detected,omitempty"`


### PR DESCRIPTION
## Summary

Follow-up to #2229 (merged) — part of #2200 (v0.4 response header contract).

#2229 demoted the intermediate `x-vsr-cache-similarity` and `x-vsr-context-token-count` headers off the default response surface (behind `x-vsr-debug`). These two values had **no dedicated home in the replay record** (`store.Record`), so for any request that did *not* set `x-vsr-debug`, they were unrecoverable after the fact via `x-vsr-replay-id`. This closes that gap — the last two unchecked boxes from #2205's "every demoted header has a home in the replay record" acceptance checklist.

## Changes

- **`store.Record`**: add `CacheSimilarity float32` (`cache_similarity`) and `ContextTokenCount int` (`context_token_count`), both `omitempty`.
- **Recorder** (`pkg/extproc/recorder.go`): populate both in `buildReplayRoutingRecord` from `ctx.VSRCacheSimilarity` / `ctx.VSRContextTokenCount`, so every replay record carries them regardless of the `x-vsr-debug` trigger.
- **Dashboard replay view** (`insightsPageSupport.tsx` / `insightsPageTypes.ts`): surface the two fields in the replay/insights view.
- **Tests**: `record_demoted_header_fields_test.go` (store) + `recorder_test.go` additions.

The other two #2205 boxes need no new field (to be documented on #2205):
- `x-vsr-injected-system-prompt` — recoverable from `RequestBody`.
- `x-vsr-retention-*` — runtime effects applied internally; observability-only.

## Test Plan

- `go test ./pkg/routerreplay/... ./pkg/extproc/` — green (store record fields + recorder wiring).
- `tsc --noEmit` (dashboard/frontend) — clean.
- Rebased onto current `main` (includes #2229); no conflicts.

Purely additive to the replay record — does not change #2229's header logic.

Closes #2254
Part of #2200. Follows #2205, #2229.