### PR TITLE
[Router] Reclaim TTL-expired entries from the hybrid semantic cache

### DIFF
--- a/src/semantic-router/pkg/cache/hybrid_cache.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache.go
@@ -94,6 +94,7 @@ type HybridCache struct {
 	// all-time high-water mark. See issue #2288.
 	reclaimTicker *time.Ticker
 	stopReclaim   chan struct{}
+	reclaimDone   chan struct{} // closed by the reclaim goroutine on exit; lets stop block until it has returned
 	closeOnce     sync.Once
 	reclaimFn     func(context.Context) error // defaults to RebuildFromMilvus; overridable in tests
 }
@@ -567,8 +568,12 @@ func (h *HybridCache) Close() error {
 		return nil
 	}
 
-	// Stop the background reclaim goroutine before taking the write lock so a
-	// reclaim pass in flight can finish and release the lock (avoids deadlock).
+	// Stop the background reclaim goroutine before taking the write lock. This
+	// is ordered (not locked) on purpose: stopBackgroundReclaim blocks until the
+	// goroutine has exited, and an in-flight reclaim pass needs h.mu to finish,
+	// so we must release the lock to it first. By the time we acquire the write
+	// lock below, no reclaim pass can still be running — which is what makes the
+	// subsequent nil-out of embeddings/idMap/hnswIndex safe (no use-after-close).
 	h.stopBackgroundReclaim()
 
 	h.mu.Lock()

--- a/src/semantic-router/pkg/cache/hybrid_cache.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache.go
@@ -88,6 +88,14 @@ type HybridCache struct {
 
 	// Concurrency control
 	mu sync.RWMutex
+
+	// Background TTL reclamation: drops in-memory entries that Milvus has
+	// already expired so the index tracks the live working set rather than the
+	// all-time high-water mark. See issue #2288.
+	reclaimTicker *time.Ticker
+	stopReclaim   chan struct{}
+	closeOnce     sync.Once
+	reclaimFn     func(context.Context) error // defaults to RebuildFromMilvus; overridable in tests
 }
 
 // HybridCacheOptions contains configuration for the hybrid cache
@@ -190,6 +198,11 @@ func NewHybridCache(options HybridCacheOptions) (*HybridCache, error) {
 			})
 			// Don't fail initialization, just log warning and continue with empty index
 		}
+
+		// Start periodic TTL reclamation (reuses the same rebuild path). Gated
+		// on the rebuild mechanism being enabled so the DisableRebuildOnStartup
+		// opt-out also suppresses the recurring Milvus re-query.
+		cache.startBackgroundReclaim()
 	} else {
 		logging.ComponentWarnEvent("cache", "hybrid_cache_rebuild_skipped", map[string]interface{}{
 			"source":      "startup",
@@ -553,6 +566,10 @@ func (h *HybridCache) Close() error {
 	if !h.enabled {
 		return nil
 	}
+
+	// Stop the background reclaim goroutine before taking the write lock so a
+	// reclaim pass in flight can finish and release the lock (avoids deadlock).
+	h.stopBackgroundReclaim()
 
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/src/semantic-router/pkg/cache/hybrid_cache_reclaim.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_reclaim.go
@@ -1,0 +1,98 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+const (
+	// minReclaimInterval is the floor for the background TTL-reclaim cadence.
+	// A reclaim pass performs a full RebuildFromMilvus, so we never run it more
+	// often than this regardless of how short the configured TTL is.
+	minReclaimInterval = 60 * time.Second
+
+	// reclaimTimeout bounds a single background reclaim pass.
+	reclaimTimeout = 5 * time.Minute
+)
+
+// reclaimIntervalForTTL derives the background reclaim cadence from the TTL.
+// We re-sync roughly once per TTL window (so an expired entry is dropped within
+// about one extra TTL period), floored at minReclaimInterval to avoid hammering
+// Milvus with full rebuilds when the TTL is very short.
+func reclaimIntervalForTTL(ttlSeconds int) time.Duration {
+	d := time.Duration(ttlSeconds) * time.Second
+	if d < minReclaimInterval {
+		return minReclaimInterval
+	}
+	return d
+}
+
+// startBackgroundReclaim launches the periodic TTL-reclamation goroutine.
+//
+// The hybrid backend keeps an in-process HNSW index alongside Milvus. Milvus
+// expires entries via its own TTL and silently deletes them, but the in-memory
+// index is otherwise only trimmed when it reaches maxMemoryEntries. Without this
+// goroutine, entries that Milvus has already expired keep occupying in-process
+// memory (and HNSW search slots) until the capacity cap forces FIFO eviction
+// (see https://github.com/vllm-project/semantic-router/issues/2288).
+//
+// Reclamation reuses RebuildFromMilvus: re-querying Milvus returns only the live
+// (non-expired) entries, so the rebuilt index naturally drops the expired ones.
+// It is a no-op when TTL is disabled (ttlSeconds <= 0), since nothing expires.
+func (h *HybridCache) startBackgroundReclaim() {
+	if !h.enabled || h.ttlSeconds <= 0 {
+		return
+	}
+
+	if h.reclaimFn == nil {
+		h.reclaimFn = h.RebuildFromMilvus
+	}
+
+	interval := reclaimIntervalForTTL(h.ttlSeconds)
+	h.stopReclaim = make(chan struct{})
+	h.reclaimTicker = time.NewTicker(interval)
+
+	logging.ComponentEvent("cache", "hybrid_cache_reclaim_started", map[string]interface{}{
+		"interval_seconds": interval.Seconds(),
+		"ttl_seconds":      h.ttlSeconds,
+	})
+
+	go h.backgroundReclaim()
+}
+
+// backgroundReclaim reclaims entries that Milvus has expired on each tick until
+// the cache is closed. A single pass is best-effort: failures are logged and the
+// loop continues.
+func (h *HybridCache) backgroundReclaim() {
+	for {
+		select {
+		case <-h.reclaimTicker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), reclaimTimeout)
+			if err := h.reclaimFn(ctx); err != nil {
+				logging.ComponentWarnEvent("cache", "hybrid_cache_reclaim_failed", map[string]interface{}{
+					"error": err.Error(),
+				})
+			}
+			cancel()
+		case <-h.stopReclaim:
+			return
+		}
+	}
+}
+
+// stopBackgroundReclaim signals the reclaim goroutine to exit and stops its
+// ticker. Safe to call multiple times and when reclaim was never started.
+func (h *HybridCache) stopBackgroundReclaim() {
+	h.closeOnce.Do(func() {
+		if h.stopReclaim != nil {
+			close(h.stopReclaim)
+		}
+		if h.reclaimTicker != nil {
+			h.reclaimTicker.Stop()
+		}
+	})
+}

--- a/src/semantic-router/pkg/cache/hybrid_cache_reclaim.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_reclaim.go
@@ -15,7 +15,10 @@ const (
 	// often than this regardless of how short the configured TTL is.
 	minReclaimInterval = 60 * time.Second
 
-	// reclaimTimeout bounds a single background reclaim pass.
+	// reclaimTimeout bounds a single background reclaim pass. A pass runs a full
+	// RebuildFromMilvus, which holds the cache write lock for its whole body, so
+	// this is also the worst-case window during which lookups/writes are blocked
+	// by reclamation. It matches the startup-rebuild timeout for consistency.
 	reclaimTimeout = 5 * time.Minute
 )
 
@@ -54,6 +57,7 @@ func (h *HybridCache) startBackgroundReclaim() {
 
 	interval := reclaimIntervalForTTL(h.ttlSeconds)
 	h.stopReclaim = make(chan struct{})
+	h.reclaimDone = make(chan struct{})
 	h.reclaimTicker = time.NewTicker(interval)
 
 	logging.ComponentEvent("cache", "hybrid_cache_reclaim_started", map[string]interface{}{
@@ -61,7 +65,10 @@ func (h *HybridCache) startBackgroundReclaim() {
 		"ttl_seconds":      h.ttlSeconds,
 	})
 
-	go h.backgroundReclaim()
+	go func() {
+		defer close(h.reclaimDone)
+		h.backgroundReclaim()
+	}()
 }
 
 // backgroundReclaim reclaims entries that Milvus has expired on each tick until
@@ -84,8 +91,13 @@ func (h *HybridCache) backgroundReclaim() {
 	}
 }
 
-// stopBackgroundReclaim signals the reclaim goroutine to exit and stops its
-// ticker. Safe to call multiple times and when reclaim was never started.
+// stopBackgroundReclaim signals the reclaim goroutine to exit, stops its ticker,
+// and blocks until the goroutine has actually returned. Blocking matters: it is
+// called from Close() before the write lock is taken, so a reclaim pass already
+// in flight can still acquire h.mu, finish, and exit — guaranteeing no pass is
+// running by the time Close() nils out the in-memory structures (no
+// use-after-close). Safe to call multiple times and when reclaim was never
+// started.
 func (h *HybridCache) stopBackgroundReclaim() {
 	h.closeOnce.Do(func() {
 		if h.stopReclaim != nil {
@@ -93,6 +105,12 @@ func (h *HybridCache) stopBackgroundReclaim() {
 		}
 		if h.reclaimTicker != nil {
 			h.reclaimTicker.Stop()
+		}
+		if h.reclaimDone != nil {
+			<-h.reclaimDone
+			logging.ComponentEvent("cache", "hybrid_cache_reclaim_stopped", map[string]interface{}{
+				"ttl_seconds": h.ttlSeconds,
+			})
 		}
 	})
 }

--- a/src/semantic-router/pkg/cache/hybrid_cache_reclaim_test.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_reclaim_test.go
@@ -1,0 +1,149 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestReclaimIntervalForTTL(t *testing.T) {
+	tests := []struct {
+		name       string
+		ttlSeconds int
+		want       time.Duration
+	}{
+		{"one second floored", 1, minReclaimInterval},
+		{"short ttl floored", 10, minReclaimInterval},
+		{"exactly floor", 60, 60 * time.Second},
+		{"above floor", 120, 120 * time.Second},
+		{"long ttl", 3600, 3600 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reclaimIntervalForTTL(tt.ttlSeconds); got != tt.want {
+				t.Fatalf("reclaimIntervalForTTL(%d) = %v, want %v", tt.ttlSeconds, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStartBackgroundReclaimNoopWhenTTLDisabled(t *testing.T) {
+	// ttlSeconds <= 0: nothing ever expires, so no goroutine/ticker should start.
+	h := &HybridCache{enabled: true, ttlSeconds: 0}
+	h.startBackgroundReclaim()
+	if h.stopReclaim != nil || h.reclaimTicker != nil {
+		t.Fatalf("expected no reclaim goroutine when TTL disabled; stopReclaim=%v ticker=%v",
+			h.stopReclaim, h.reclaimTicker)
+	}
+	// stop must be safe even though nothing started.
+	h.stopBackgroundReclaim()
+}
+
+func TestStartBackgroundReclaimNoopWhenDisabled(t *testing.T) {
+	h := &HybridCache{enabled: false, ttlSeconds: 600}
+	h.startBackgroundReclaim()
+	if h.stopReclaim != nil || h.reclaimTicker != nil {
+		t.Fatalf("expected no reclaim goroutine when cache disabled; stopReclaim=%v ticker=%v",
+			h.stopReclaim, h.reclaimTicker)
+	}
+}
+
+func TestStartBackgroundReclaimDefaultsReclaimFn(t *testing.T) {
+	// A long TTL means the real ticker never fires during the test, so the
+	// nil milvusCache behind the default RebuildFromMilvus is never invoked.
+	h := &HybridCache{enabled: true, ttlSeconds: 3600}
+	h.startBackgroundReclaim()
+	defer h.stopBackgroundReclaim()
+
+	if h.reclaimFn == nil {
+		t.Fatal("expected reclaimFn to default to RebuildFromMilvus")
+	}
+	if h.stopReclaim == nil || h.reclaimTicker == nil {
+		t.Fatal("expected reclaim goroutine to be started for enabled cache with TTL")
+	}
+}
+
+func TestBackgroundReclaimTicksThenStops(t *testing.T) {
+	var calls int64
+	h := &HybridCache{
+		enabled:    true,
+		ttlSeconds: 600,
+		reclaimFn: func(context.Context) error {
+			atomic.AddInt64(&calls, 1)
+			return nil
+		},
+	}
+	// Drive a fast ticker directly (bypassing the 60s floor) to exercise the loop.
+	h.stopReclaim = make(chan struct{})
+	h.reclaimTicker = time.NewTicker(5 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		h.backgroundReclaim()
+		close(done)
+	}()
+
+	time.Sleep(60 * time.Millisecond) // allow several ticks
+	h.stopBackgroundReclaim()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("backgroundReclaim did not exit after stop")
+	}
+
+	if atomic.LoadInt64(&calls) == 0 {
+		t.Fatal("expected reclaimFn to be called at least once")
+	}
+
+	// After stop, no further calls.
+	settled := atomic.LoadInt64(&calls)
+	time.Sleep(30 * time.Millisecond)
+	if got := atomic.LoadInt64(&calls); got != settled {
+		t.Fatalf("reclaimFn called after stop: settled=%d got=%d", settled, got)
+	}
+}
+
+func TestBackgroundReclaimSurvivesReclaimError(t *testing.T) {
+	var calls int64
+	h := &HybridCache{
+		enabled:    true,
+		ttlSeconds: 600,
+		reclaimFn: func(context.Context) error {
+			atomic.AddInt64(&calls, 1)
+			return context.DeadlineExceeded // a failing pass must not kill the loop
+		},
+	}
+	h.stopReclaim = make(chan struct{})
+	h.reclaimTicker = time.NewTicker(5 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		h.backgroundReclaim()
+		close(done)
+	}()
+
+	time.Sleep(60 * time.Millisecond)
+	h.stopBackgroundReclaim()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("backgroundReclaim did not exit after stop")
+	}
+
+	if atomic.LoadInt64(&calls) < 2 {
+		t.Fatalf("expected the loop to keep ticking after errors, got %d calls", atomic.LoadInt64(&calls))
+	}
+}
+
+func TestStopBackgroundReclaimIdempotent(t *testing.T) {
+	h := &HybridCache{enabled: true, ttlSeconds: 600}
+	h.startBackgroundReclaim()
+	// Multiple stops must not panic on a double channel close.
+	h.stopBackgroundReclaim()
+	h.stopBackgroundReclaim()
+}

--- a/src/semantic-router/pkg/cache/hybrid_cache_reclaim_test.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_reclaim_test.go
@@ -147,3 +147,59 @@ func TestStopBackgroundReclaimIdempotent(t *testing.T) {
 	h.stopBackgroundReclaim()
 	h.stopBackgroundReclaim()
 }
+
+// TestStopBackgroundReclaimWaitsForInFlightReclaim locks in the property that
+// stopBackgroundReclaim blocks until the goroutine has fully exited, including a
+// reclaim pass that is already in flight. This is what makes Close()'s nil-out of
+// the in-memory structures safe: by the time stop returns, no pass can still be
+// about to take the write lock and touch them.
+func TestStopBackgroundReclaimWaitsForInFlightReclaim(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var finished atomic.Bool
+
+	h := &HybridCache{
+		enabled:    true,
+		ttlSeconds: 600,
+		reclaimFn: func(context.Context) error {
+			close(started) // a pass is now in flight (only the first tick gets here)
+			<-release      // simulate a slow RebuildFromMilvus still running
+			finished.Store(true)
+			return nil
+		},
+	}
+	// Drive a fast ticker and wire reclaimDone the way startBackgroundReclaim does.
+	h.stopReclaim = make(chan struct{})
+	h.reclaimDone = make(chan struct{})
+	h.reclaimTicker = time.NewTicker(5 * time.Millisecond)
+	go func() {
+		defer close(h.reclaimDone)
+		h.backgroundReclaim()
+	}()
+
+	<-started // ensure a reclaim pass is in flight before we stop
+
+	stopReturned := make(chan struct{})
+	go func() {
+		h.stopBackgroundReclaim()
+		close(stopReturned)
+	}()
+
+	// stop must NOT return while a reclaim pass is still running.
+	select {
+	case <-stopReturned:
+		t.Fatal("stopBackgroundReclaim returned before the in-flight reclaim pass finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Let the in-flight pass complete; stop must now return promptly.
+	close(release)
+	select {
+	case <-stopReturned:
+	case <-time.After(time.Second):
+		t.Fatal("stopBackgroundReclaim did not return after the in-flight reclaim pass finished")
+	}
+	if !finished.Load() {
+		t.Fatal("expected the in-flight reclaim pass to complete before stop returned")
+	}
+}


### PR DESCRIPTION
Closes #2288

## Purpose

- **What:** Add a `Close()`-managed background goroutine to the **hybrid** semantic cache that periodically reclaims entries Milvus has already expired from the in-process HNSW index.
- **Why:** The hybrid backend keeps an in-memory HNSW index (`embeddings` / `idMap` / HNSW nodes) alongside the persistent Milvus store. Milvus expires entries via its own TTL and silently deletes them, but the in-memory side was only ever trimmed when it hit `maxMemoryEntries` (default 100,000) via FIFO — there was **no TTL-aware reclamation**. As a result, entries Milvus had already expired kept occupying in-process memory and HNSW search slots until the capacity cap forced eviction, so memory tracked the all-time high-water mark instead of the live working set (and FIFO could drop a *live* entry while keeping expired ones). Surfaced during the per-backend cache lifecycle audit requested in #2162's review.
- **Module:** `Router` (semantic cache, hybrid backend only).

### Approach

Reclamation reuses the existing `RebuildFromMilvus`: re-querying Milvus returns only the live (non-expired) entries, so the rebuilt index naturally drops the expired ones. The cadence is derived from the TTL (`reclaimIntervalForTTL`, floored at 60s so a short TTL can't trigger constant full rebuilds). The goroutine starts only when the cache is enabled, `ttl > 0`, and the startup rebuild mechanism is not disabled (so the existing `DisableRebuildOnStartup` opt-out also suppresses the recurring Milvus re-query). It is stopped before `Close()` takes the write lock, so an in-flight reclaim pass can finish and release the lock (no deadlock).

A `reclaimFn` seam (defaulting to `RebuildFromMilvus`) lets the white-box tests drive the loop without a live Milvus. Scope is intentionally narrow: in-process structures and the non-cgo stub are unchanged; the other five backends were audited as clean (no leak).

This is not an unbounded leak (it was already capped at `maxMemoryEntries`) and not a correctness bug (a stale HNSW node resolves to a Milvus `GetByID` miss, never a stale answer) — it is a memory-retention / efficiency fix. A lighter, fully-incremental local reclamation is possible future work.

## Test Plan

New white-box tests in `hybrid_cache_reclaim_test.go`, run under `-race`:

- `reclaimIntervalForTTL` floor/passthrough table.
- start/stop gating: no goroutine when the cache is disabled or `ttl <= 0`; `reclaimFn` defaults to `RebuildFromMilvus`.
- background loop lifecycle: ticks invoke `reclaimFn`, the loop survives a failing pass, exits cleanly on stop, and stop is idempotent (no double-close panic).

Commands (cgo + milvus tag, candle lib on `LD_LIBRARY_PATH`):

```
go vet -tags=milvus ./pkg/cache/
go test -tags=milvus -race -run 'Reclaim|BackgroundReclaim' ./pkg/cache/
go test -tags=milvus -race -count=1 ./pkg/cache/   # full suite, integration backends skipped
golangci-lint run --config tools/linter/go/.golangci.yml --build-tags=milvus ./pkg/cache/...
```

## Test Result

- New reclaim tests: 7/7 pass under `-race`.
- Full `pkg/cache` suite (integration backends skipped): green under `-race` (~34s), no regression.
- `gofmt`/`go vet` clean; `golangci-lint` (repo config) → 0 issues.
- Pure in-process change; no behavior change to routing/startup/config/API, so no E2E update required. Follow-up to the lifecycle question in #2162.
