### PR TITLE
[CI/Build] Pin tree-sitter versions to fix AST scanner segfault

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -101,13 +101,15 @@ jobs:
 
       - name: Install tree-sitter for security scan
         run: |
+          # Pin tree-sitter core + grammars to an ABI-compatible set (see
+          # security-scan.yml); unpinned installs segfault the scanner on ABI drift.
           pip install \
-            tree-sitter \
-            tree-sitter-python \
-            tree-sitter-javascript \
-            tree-sitter-typescript \
-            tree-sitter-go \
-            tree-sitter-rust
+            tree-sitter==0.25.2 \
+            tree-sitter-python==0.25.0 \
+            tree-sitter-javascript==0.25.0 \
+            tree-sitter-typescript==0.23.2 \
+            tree-sitter-go==0.25.0 \
+            tree-sitter-rust==0.24.0
 
       - name: Run AST supply chain security scan
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,13 +38,16 @@ jobs:
 
       - name: Install tree-sitter dependencies
         run: |
+          # Pin tree-sitter core + grammars to an ABI-compatible set. Unpinned
+          # installs let pip drift core and grammars onto mismatched ABIs, which
+          # crashes the scanner with a native segfault during parser.parse().
           pip install \
-            tree-sitter \
-            tree-sitter-python \
-            tree-sitter-javascript \
-            tree-sitter-typescript \
-            tree-sitter-go \
-            tree-sitter-rust
+            tree-sitter==0.25.2 \
+            tree-sitter-python==0.25.0 \
+            tree-sitter-javascript==0.25.0 \
+            tree-sitter-typescript==0.23.2 \
+            tree-sitter-go==0.25.0 \
+            tree-sitter-rust==0.24.0
 
       - name: Run AST codebase scan
         id: ast_scan


### PR DESCRIPTION
Pins tree-sitter core + grammars to an ABI-compatible set in both `security-scan.yml` and `pre-commit.yml`, fixing the native `Segmentation fault` (exit 139) that `tree-sitter` **0.26.0** (recently published, unpinned) causes on the ubuntu x64 CI runners.

Fixes https://github.com/vllm-project/semantic-router/issues/2306

## Fix

Pin the core + all five grammars to an ABI-compatible set (core `0.25.2` is backward-compatible with the pinned grammar ABIs):

```
tree-sitter==0.25.2
tree-sitter-python==0.25.0
tree-sitter-javascript==0.25.0
tree-sitter-typescript==0.23.2
tree-sitter-go==0.25.0
tree-sitter-rust==0.24.0
```

## Verification

- The `pre-commit` job (triggered by `pull_request`, so it runs this PR's workflow) already **passes** with the pin.
- Locally, a full-repo scan with the pinned set exits 0 (no segfault).

## Why `AST supply chain security scan` still shows red here

`security-scan.yml` is triggered by `pull_request_target`, so GitHub reads the workflow definition from the **base branch (`main`)**, not from this PR. That check therefore keeps running `main`'s still-unpinned workflow (installing `tree-sitter 0.26.0`) and will stay red until this PR is merged. Once merged, `main` carries the pin and the scan goes green. The pin's correctness is already confirmed by the passing `pre-commit` job and the local full-repo run above.
