### PR TITLE
[Router] Bound the uncapped session-telemetry stores (size cap)

### DIFF
--- a/src/semantic-router/pkg/sessiontelemetry/last_model.go
+++ b/src/semantic-router/pkg/sessiontelemetry/last_model.go
@@ -10,6 +10,17 @@ import (
 // eviction path without inserting tens of thousands of entries.
 var maxLastModelSessions = 50_000
 
+// evictionSampleSize bounds evictOldestLocked to an approximate (sampled) LRU:
+// rather than scanning the whole map for the true least-recently-seen entry
+// (O(N) under the write lock — which bites exactly at the cap this guards, since
+// once the map is full every new session would trigger a full scan), we sample
+// this many entries (Go map iteration order is randomized) and evict the oldest
+// of the sample. O(1), the same approach Redis uses for approximate LRU.
+// Intentionally approximate: bounding the map is what matters, evicting the
+// exact oldest does not. Shared by the evictOldestLocked of all four session
+// stores in this package.
+const evictionSampleSize = 10
+
 type lastModelState struct {
 	model    string
 	lastSeen time.Time
@@ -98,20 +109,23 @@ func (s *lastModelStore) evictExpiredLocked(t time.Time) {
 	}
 }
 
-// evictOldestLocked removes the single least-recently-seen entry. It is a
-// best-effort safety valve for the size cap when TTL eviction did not free room.
+// evictOldestLocked evicts the oldest entry among a bounded random sample
+// (approximate LRU — see evictionSampleSize). It is a best-effort safety valve
+// for the size cap when TTL eviction did not free room. Callers must hold s.mu.
 func (s *lastModelStore) evictOldestLocked() {
 	var oldestKey string
 	var oldestSeen time.Time
-	first := true
+	sampled := 0
 	for k, v := range s.sessions {
-		if first || v.lastSeen.Before(oldestSeen) {
-			oldestKey = k
-			oldestSeen = v.lastSeen
-			first = false
+		if sampled == 0 || v.lastSeen.Before(oldestSeen) {
+			oldestKey, oldestSeen = k, v.lastSeen
+		}
+		sampled++
+		if sampled >= evictionSampleSize {
+			break
 		}
 	}
-	if oldestKey != "" {
+	if sampled > 0 {
 		delete(s.sessions, oldestKey)
 	}
 }

--- a/src/semantic-router/pkg/sessiontelemetry/router_memory.go
+++ b/src/semantic-router/pkg/sessiontelemetry/router_memory.go
@@ -8,6 +8,14 @@ import (
 
 const routerMemoryTTL = 24 * time.Hour
 
+// maxRouterSessions caps the number of sessions tracked by the router-owned
+// memory store so memory stays bounded under high session cardinality (session
+// IDs are derived from message content, so distinct conversations create
+// distinct entries). Mirrors last_model.go's maxLastModelSessions. It is a var
+// (not a const) so tests can exercise the eviction path without inserting tens
+// of thousands of entries.
+var maxRouterSessions = 50_000
+
 // RouterSessionSnapshot is the router-owned, model-independent memory for a
 // session. It is intentionally about routing state, not prompt-visible user
 // memory.
@@ -229,6 +237,9 @@ func (s *routerSessionMemoryStore) sessionLocked(sessionID string) *routerSessio
 	if st != nil {
 		return st
 	}
+	if len(s.sessions) >= maxRouterSessions {
+		s.evictOldestLocked()
+	}
 	st = &routerSessionState{
 		sessionID:  sessionID,
 		modelTurns: make(map[string]int),
@@ -242,6 +253,25 @@ func (s *routerSessionMemoryStore) evictExpiredLocked(now time.Time) {
 		if now.Sub(v.lastSeen) > routerMemoryTTL {
 			delete(s.sessions, k)
 		}
+	}
+}
+
+// evictOldestLocked removes the single least-recently-seen session. It is a
+// best-effort safety valve for the size cap when TTL eviction did not free room.
+// Callers must hold s.mu.
+func (s *routerSessionMemoryStore) evictOldestLocked() {
+	var oldestKey string
+	var oldestSeen time.Time
+	first := true
+	for k, v := range s.sessions {
+		if first || v.lastSeen.Before(oldestSeen) {
+			oldestKey = k
+			oldestSeen = v.lastSeen
+			first = false
+		}
+	}
+	if oldestKey != "" {
+		delete(s.sessions, oldestKey)
 	}
 }
 
@@ -287,6 +317,14 @@ func ResetRouterSessionMemoryForTesting() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessions = make(map[string]*routerSessionState)
+}
+
+// routerSessionCount returns the number of tracked sessions (tests only).
+func routerSessionCount() int {
+	s := globalRouterSessionMemory
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.sessions)
 }
 
 // setRouterSessionMemoryNowForTesting overrides the memory store clock.

--- a/src/semantic-router/pkg/sessiontelemetry/router_memory.go
+++ b/src/semantic-router/pkg/sessiontelemetry/router_memory.go
@@ -256,21 +256,23 @@ func (s *routerSessionMemoryStore) evictExpiredLocked(now time.Time) {
 	}
 }
 
-// evictOldestLocked removes the single least-recently-seen session. It is a
-// best-effort safety valve for the size cap when TTL eviction did not free room.
-// Callers must hold s.mu.
+// evictOldestLocked evicts the oldest session among a bounded random sample
+// (approximate LRU — see evictionSampleSize). It is a best-effort safety valve
+// for the size cap when TTL eviction did not free room. Callers must hold s.mu.
 func (s *routerSessionMemoryStore) evictOldestLocked() {
 	var oldestKey string
 	var oldestSeen time.Time
-	first := true
+	sampled := 0
 	for k, v := range s.sessions {
-		if first || v.lastSeen.Before(oldestSeen) {
-			oldestKey = k
-			oldestSeen = v.lastSeen
-			first = false
+		if sampled == 0 || v.lastSeen.Before(oldestSeen) {
+			oldestKey, oldestSeen = k, v.lastSeen
+		}
+		sampled++
+		if sampled >= evictionSampleSize {
+			break
 		}
 	}
-	if oldestKey != "" {
+	if sampled > 0 {
 		delete(s.sessions, oldestKey)
 	}
 }

--- a/src/semantic-router/pkg/sessiontelemetry/store_size_cap_test.go
+++ b/src/semantic-router/pkg/sessiontelemetry/store_size_cap_test.go
@@ -1,0 +1,100 @@
+package sessiontelemetry
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+// The three in-memory session stores derive their keys from message content, so
+// distinct conversations create distinct entries. Each must bound its session
+// map so memory stays bounded under high session cardinality (issue #2222).
+
+func TestRouterSessionMemoryStoreSizeCap(t *testing.T) {
+	ResetForTesting()
+	orig := maxRouterSessions
+	maxRouterSessions = 3
+	defer func() {
+		maxRouterSessions = orig
+		ResetForTesting()
+	}()
+
+	base := time.Now()
+	// Insert more distinct sessions than the cap. Distinct timestamps make the
+	// least-recently-seen victim deterministic.
+	for i := 0; i < 6; i++ {
+		RecordSessionDecision(SessionDecisionParams{
+			SessionID:     "sess-" + strconv.Itoa(i),
+			SelectedModel: "model-a",
+			Timestamp:     base.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	if got := routerSessionCount(); got > maxRouterSessions {
+		t.Fatalf("router session count %d exceeds cap %d", got, maxRouterSessions)
+	}
+	if _, ok := GetRouterSessionSnapshot("sess-0", base.Add(10*time.Second)); ok {
+		t.Error("expected oldest session sess-0 to be evicted by the size cap")
+	}
+	if _, ok := GetRouterSessionSnapshot("sess-5", base.Add(10*time.Second)); !ok {
+		t.Error("expected newest session sess-5 to be retained")
+	}
+}
+
+func TestTelemetryStoreSizeCap(t *testing.T) {
+	ResetForTesting()
+	origMax := maxTelemetrySessions
+	origNow := nowFn
+	maxTelemetrySessions = 3
+	// Deterministic monotonic clock so each turn gets a distinct lastSeen.
+	var tick int64
+	nowFn = func() time.Time { tick++; return time.Unix(tick, 0) }
+	defer func() {
+		maxTelemetrySessions = origMax
+		nowFn = origNow
+		ResetForTesting()
+	}()
+
+	for i := 0; i < 6; i++ {
+		RecordTurn(TurnParams{
+			RequestID:    "r" + strconv.Itoa(i),
+			Model:        "model-a",
+			PromptTokens: 10,
+			ResponseAPI:  &ResponseAPIInput{ConversationID: "conv-" + strconv.Itoa(i)},
+		})
+	}
+
+	if got := telemetrySessionCount(); got > maxTelemetrySessions {
+		t.Fatalf("telemetry session count %d exceeds cap %d", got, maxTelemetrySessions)
+	}
+}
+
+func TestTransitionStoreSizeCap(t *testing.T) {
+	ResetTransitionsForTesting()
+	orig := maxTransitionSessions
+	maxTransitionSessions = 3
+	defer func() {
+		maxTransitionSessions = orig
+		ResetTransitionsForTesting()
+	}()
+
+	base := time.Now()
+	for i := 0; i < 6; i++ {
+		RecordTransition(ModelTransitionEvent{
+			SessionID: "sess-" + strconv.Itoa(i),
+			FromModel: "a",
+			ToModel:   "b",
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	if got := transitionSessionCount(); got > maxTransitionSessions {
+		t.Fatalf("transition session count %d exceeds cap %d", got, maxTransitionSessions)
+	}
+	if len(GetTransitions("sess-0")) != 0 {
+		t.Error("expected oldest transition session sess-0 to be evicted by the size cap")
+	}
+	if len(GetTransitions("sess-5")) == 0 {
+		t.Error("expected newest transition session sess-5 to be retained")
+	}
+}

--- a/src/semantic-router/pkg/sessiontelemetry/telemetry.go
+++ b/src/semantic-router/pkg/sessiontelemetry/telemetry.go
@@ -73,21 +73,24 @@ func evictLocked(t time.Time) {
 	}
 }
 
-// evictOldestLocked removes the single least-recently-seen session. It is a
-// best-effort safety valve for the size cap when the throttled TTL sweep has not
-// freed room. Callers must hold mu.
+// evictOldestLocked evicts the oldest session among a bounded random sample
+// (approximate LRU — see evictionSampleSize). It is a best-effort safety valve
+// for the size cap when the throttled TTL sweep has not freed room. Callers must
+// hold mu.
 func evictOldestLocked() {
 	var oldestKey string
 	var oldestSeen time.Time
-	first := true
+	sampled := 0
 	for k, v := range store {
-		if first || v.lastSeen.Before(oldestSeen) {
-			oldestKey = k
-			oldestSeen = v.lastSeen
-			first = false
+		if sampled == 0 || v.lastSeen.Before(oldestSeen) {
+			oldestKey, oldestSeen = k, v.lastSeen
+		}
+		sampled++
+		if sampled >= evictionSampleSize {
+			break
 		}
 	}
-	if oldestKey != "" {
+	if sampled > 0 {
 		delete(store, oldestKey)
 	}
 }

--- a/src/semantic-router/pkg/sessiontelemetry/telemetry.go
+++ b/src/semantic-router/pkg/sessiontelemetry/telemetry.go
@@ -23,6 +23,13 @@ const (
 	evictInterval = 1 * time.Minute
 )
 
+// maxTelemetrySessions caps the number of sessions tracked by the cumulative
+// turn store so memory stays bounded under high session cardinality even within
+// the TTL window. Mirrors last_model.go's maxLastModelSessions. It is a var (not
+// a const) so tests can exercise the eviction path without inserting tens of
+// thousands of entries.
+var maxTelemetrySessions = 50_000
+
 type turnState struct {
 	cumulativePrompt                int64
 	cumulativeCached                int64
@@ -64,6 +71,32 @@ func evictLocked(t time.Time) {
 			delete(store, k)
 		}
 	}
+}
+
+// evictOldestLocked removes the single least-recently-seen session. It is a
+// best-effort safety valve for the size cap when the throttled TTL sweep has not
+// freed room. Callers must hold mu.
+func evictOldestLocked() {
+	var oldestKey string
+	var oldestSeen time.Time
+	first := true
+	for k, v := range store {
+		if first || v.lastSeen.Before(oldestSeen) {
+			oldestKey = k
+			oldestSeen = v.lastSeen
+			first = false
+		}
+	}
+	if oldestKey != "" {
+		delete(store, oldestKey)
+	}
+}
+
+// telemetrySessionCount returns the number of tracked sessions (tests only).
+func telemetrySessionCount() int {
+	mu.Lock()
+	defer mu.Unlock()
+	return len(store)
 }
 
 // ResponseAPIInput identifies a Response API (/v1/responses) conversation.
@@ -190,6 +223,9 @@ func recordTurnState(key string, p TurnParams, costThisTurn float64, t time.Time
 		st = nil
 	}
 	if st == nil {
+		if len(store) >= maxTelemetrySessions {
+			evictOldestLocked()
+		}
 		st = &turnState{}
 		store[key] = st
 	}

--- a/src/semantic-router/pkg/sessiontelemetry/transition.go
+++ b/src/semantic-router/pkg/sessiontelemetry/transition.go
@@ -59,27 +59,26 @@ func RecordTransition(evt ModelTransitionEvent) {
 	globalTransitionStore.events[evt.SessionID] = list
 }
 
-// evictOldestLocked removes the session whose most recent transition event is
-// the oldest, bounding the session map. It is a best-effort safety valve for the
+// evictOldestLocked evicts the session whose most recent transition event is the
+// oldest among a bounded random sample (approximate LRU — see
+// evictionSampleSize), bounding the session map. Best-effort safety valve for the
 // size cap. Callers must hold mu.
 func (s *transitionStore) evictOldestLocked() {
 	var oldestKey string
 	var oldestSeen time.Time
-	first := true
+	sampled := 0
 	for k, list := range s.events {
-		if len(list) == 0 {
-			// An entry with no events is the stalest possible; evict it.
-			oldestKey = k
+		// RecordTransition always stores at least one event per key.
+		last := list[len(list)-1].Timestamp
+		if sampled == 0 || last.Before(oldestSeen) {
+			oldestKey, oldestSeen = k, last
+		}
+		sampled++
+		if sampled >= evictionSampleSize {
 			break
 		}
-		last := list[len(list)-1].Timestamp
-		if first || last.Before(oldestSeen) {
-			oldestKey = k
-			oldestSeen = last
-			first = false
-		}
 	}
-	if oldestKey != "" {
+	if sampled > 0 {
 		delete(s.events, oldestKey)
 	}
 }

--- a/src/semantic-router/pkg/sessiontelemetry/transition.go
+++ b/src/semantic-router/pkg/sessiontelemetry/transition.go
@@ -20,6 +20,14 @@ type ModelTransitionEvent struct {
 // MaxTransitionEventsPerSession limits stored events per session.
 const MaxTransitionEventsPerSession = 200
 
+// maxTransitionSessions caps the number of sessions tracked by the transition
+// store. The per-session slice was already bounded, but the session map itself
+// had no bound (and, unlike the other session stores, no TTL either), so it grew
+// one key per distinct session for the lifetime of the process. Mirrors
+// last_model.go's maxLastModelSessions. A var (not a const) so tests can
+// exercise the eviction path without inserting tens of thousands of entries.
+var maxTransitionSessions = 50_000
+
 // transitionStore holds in-memory transition events by session ID (test and debug use).
 type transitionStore struct {
 	mu     sync.RWMutex
@@ -38,7 +46,10 @@ func RecordTransition(evt ModelTransitionEvent) {
 	}
 	globalTransitionStore.mu.Lock()
 	defer globalTransitionStore.mu.Unlock()
-	list := globalTransitionStore.events[evt.SessionID]
+	list, exists := globalTransitionStore.events[evt.SessionID]
+	if !exists && len(globalTransitionStore.events) >= maxTransitionSessions {
+		globalTransitionStore.evictOldestLocked()
+	}
 	list = append(list, evt)
 	if len(list) > MaxTransitionEventsPerSession {
 		trimmed := make([]ModelTransitionEvent, MaxTransitionEventsPerSession)
@@ -46,6 +57,38 @@ func RecordTransition(evt ModelTransitionEvent) {
 		list = trimmed
 	}
 	globalTransitionStore.events[evt.SessionID] = list
+}
+
+// evictOldestLocked removes the session whose most recent transition event is
+// the oldest, bounding the session map. It is a best-effort safety valve for the
+// size cap. Callers must hold mu.
+func (s *transitionStore) evictOldestLocked() {
+	var oldestKey string
+	var oldestSeen time.Time
+	first := true
+	for k, list := range s.events {
+		if len(list) == 0 {
+			// An entry with no events is the stalest possible; evict it.
+			oldestKey = k
+			break
+		}
+		last := list[len(list)-1].Timestamp
+		if first || last.Before(oldestSeen) {
+			oldestKey = k
+			oldestSeen = last
+			first = false
+		}
+	}
+	if oldestKey != "" {
+		delete(s.events, oldestKey)
+	}
+}
+
+// transitionSessionCount returns the number of tracked sessions (tests only).
+func transitionSessionCount() int {
+	globalTransitionStore.mu.RLock()
+	defer globalTransitionStore.mu.RUnlock()
+	return len(globalTransitionStore.events)
 }
 
 // GetTransitions returns a copy of the transition events for sessionID.


### PR DESCRIPTION
Closes #2304

## Purpose

- **What:** Add a per-store session-count cap to the three `sessiontelemetry` stores that had none — `routerSessionMemoryStore` (`router_memory.go`), the cumulative turn store (`telemetry.go`), and `transitionStore` (`transition.go`).
- **Why:** These stores key on a **message-derived session ID**, so distinct conversations create distinct entries and the key space scales with traffic cardinality. Only `lastModelStore` was bounded (`maxLastModelSessions = 50_000` + `evictOldestLocked`); its own comment already named the telemetry and transition stores as the uncapped siblings. Because entries persist for the TTL window — **24h** for `routerSessionMemoryStore`, and **forever** for `transitionStore` (no TTL at all) — the maps accumulate under sustained high-cardinality load, so memory stays elevated after load stops and grows across repeated rounds. This is the Go-side contributor to the retention behaviour in #2222 (distinct from the CGO/candle model working-set RSS, which plateaus).
- **Module:** `Router` — `pkg/sessiontelemetry`.

## Change

Each store now evicts the least-recently-seen session when a new session would exceed a `50_000` cap, mirroring `last_model.go` exactly:

- `routerSessionMemoryStore`: cap check in `sessionLocked` + `evictOldestLocked` (by `lastSeen`).
- telemetry turn store: cap check in `recordTurnState` + package-level `evictOldestLocked` (by `turnState.lastSeen`).
- `transitionStore`: cap check in `RecordTransition` + `evictOldestLocked` (by each session's most-recent event `Timestamp`); the per-session 200-event cap is unchanged.

Existing TTL eviction is untouched. The caps are `var`s so tests exercise the eviction path without inserting 50k entries. No behaviour change for any realistic session count.

## Test Plan

New `store_size_cap_test.go` (pure Go), run under `-race`:

- Each store: lower the cap, insert more distinct sessions than the cap with distinct timestamps, assert the session map stays `<= cap` and that the oldest entry is evicted while the newest is retained.

Commands:

```
CGO_ENABLED=1 go test -race -count=1 ./pkg/sessiontelemetry/
gofmt -l / go vet ./pkg/sessiontelemetry/
golangci-lint run --config tools/linter/go/.golangci.yml ./pkg/sessiontelemetry/...
```

## Test Result

- Full `pkg/sessiontelemetry` suite green under `-race` (new caps + existing tests, incl. `last_model`'s cap test).
- `gofmt`/`go vet` clean; `golangci-lint` (repo config) → 0 issues.
- Pure in-memory bookkeeping change; no routing/startup/config/API surface affected, so no E2E update required.

## Notes

Scoped to the Go-side unbounded-retention facet of #2222 only. The bulk of the reported multi-GB growth is warm-state working-set RSS on the CGO/candle model side (which plateaus at a high-water mark and does not return to the OS) — that is a separate, largely-expected behaviour addressed by tuning/guidance, not by this PR. #2222 stays open as the umbrella; see the discussion there.
