### PR TITLE
[Router] Reassemble split SSE frames in double-Anthropic streaming (#2316)

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client.go
@@ -51,6 +51,19 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 		ctx.AnthropicStream = anthropic.NewStreamState()
 	}
 
+	// Envoy STREAMED mode delivers the response body split at arbitrary
+	// byte offsets, so an upstream SSE frame may straddle two chunks.
+	// Reassemble complete frames before translation and hold any trailing
+	// partial frame for the next chunk. Without this, a split frame fails
+	// to parse, the translated output is empty, and — because this handler
+	// suppresses the raw upstream bytes to keep ownership of the wire (see
+	// emptyAnthropicBodyMutation) — the frame vanishes entirely, hanging
+	// the client (issue #2316). The keepalive ping still flows below even
+	// when only a partial frame arrived, so a long split does not stall the
+	// connection.
+	frames, remainder := reassembleSSEFrames(ctx.PendingSSEBytes, responseBody)
+	ctx.PendingSSEBytes = remainder
+
 	// Inject a keepalive ping if the gap since the last chunk crossed
 	// the cadence threshold. Anthropic clients (including the SDK
 	// MessageStream accumulator) treat pings as no-ops; the value is
@@ -59,7 +72,7 @@ func (r *OpenAIRouter) handleAnthropicClientStreamingResponseBody(
 	// reaches the client before this chunk's content events.
 	pingBytes := maybeEmitPing(ctx.AnthropicStream)
 
-	openAIBytes, err := r.translateUpstreamToOpenAI(responseBody, ctx)
+	openAIBytes, err := r.translateUpstreamToOpenAI(frames, ctx)
 	if err != nil {
 		logging.Errorf("Failed to translate upstream streaming chunk to OpenAI: %v", err)
 		return emptyAnthropicBodyMutation()

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_split_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_client_split_test.go
@@ -1,0 +1,100 @@
+package extproc
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
+)
+
+// reasoningStreamFrames returns a realistic reasoning-model upstream
+// Anthropic SSE sequence (message_start → thinking block → text block →
+// message_delta → message_stop), one complete frame per element.
+func reasoningStreamFrames() []string {
+	frame := func(event, data string) string {
+		return "event: " + event + "\n" + "data: " + data + "\n\n"
+	}
+	return []string{
+		frame("message_start", `{"type":"message_start","message":{"id":"msg_2316","type":"message","role":"assistant","model":"test-model","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":1}}}`),
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think about the greeting."}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_abc"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"你好"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"！有什么可以帮你？"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":1}`),
+		frame("message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":8}}`),
+		frame("message_stop", `{"type":"message_stop"}`),
+	}
+}
+
+// feedDoubleAnthropicStream feeds the given wire chunks through the
+// double-Anthropic client streaming handler and returns the concatenated
+// bytes the client would observe on the wire.
+func feedDoubleAnthropicStream(t *testing.T, chunks []string) string {
+	t.Helper()
+	router := newTestRouter()
+	ctx := newAnthropicStreamCtx(anthropic.NewStreamState()) // APIFormat=Anthropic, ClientProtocol=Anthropic
+	var wire strings.Builder
+	for i, c := range chunks {
+		resp := router.handleAnthropicClientStreamingResponseBody([]byte(c), ctx)
+		if resp == nil {
+			t.Fatalf("chunk %d: handler returned nil", i)
+		}
+		wire.Write(resp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	}
+	return wire.String()
+}
+
+func assertUsableAnthropicStream(t *testing.T, wire string) {
+	t.Helper()
+	for _, want := range []string{
+		"event: message_start",
+		`"type":"thinking_delta"`,
+		`"type":"text_delta"`,
+		"你好",
+		"event: message_stop",
+	} {
+		assert.Contains(t, wire, want, "client stream must contain %q", want)
+	}
+}
+
+// TestDoubleAnthropicStream_FrameAlignedDelivery is the baseline: when Envoy
+// hands the handler one complete SSE frame per chunk, the double-Anthropic
+// cell translates the full reasoning stream correctly.
+func TestDoubleAnthropicStream_FrameAlignedDelivery(t *testing.T) {
+	wire := feedDoubleAnthropicStream(t, reasoningStreamFrames())
+	assertUsableAnthropicStream(t, wire)
+}
+
+// TestDoubleAnthropicStream_ByteSplitDelivery is the regression test for
+// issue #2316. Envoy STREAMED mode delivers the response body split at
+// arbitrary byte offsets that do NOT align to SSE frame boundaries. Before
+// the reassembly fix, split frames failed to parse and the handler
+// suppressed the raw upstream bytes, so the client received zero output and
+// hung. After the fix, the handler reassembles frames across chunks and the
+// client sees the complete stream regardless of where the splits fall.
+func TestDoubleAnthropicStream_ByteSplitDelivery(t *testing.T) {
+	whole := strings.Join(reasoningStreamFrames(), "")
+
+	// Try several unaligned span sizes so the test does not depend on a
+	// lucky boundary; small spans guarantee mid-frame splits.
+	for _, span := range []int{1, 7, 32, 64, 200} {
+		t.Run("span="+strconv.Itoa(span), func(t *testing.T) {
+			var chunks []string
+			for i := 0; i < len(whole); i += span {
+				end := i + span
+				if end > len(whole) {
+					end = len(whole)
+				}
+				chunks = append(chunks, whole[i:end])
+			}
+			wire := feedDoubleAnthropicStream(t, chunks)
+			assertUsableAnthropicStream(t, wire)
+		})
+	}
+}

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -63,6 +63,13 @@ type RequestContext struct {
 	IsStreamingResponse     bool                   // set from response Content-Type
 	AnthropicStream         *anthropic.StreamState // Anthropic SSE → OpenAI translation state
 
+	// PendingSSEBytes holds a trailing partial SSE frame carried over from a
+	// prior streaming response chunk. Envoy STREAMED mode delivers the
+	// response body split at arbitrary byte offsets, so an SSE frame can
+	// straddle two chunks; the streaming handlers stash the incomplete tail
+	// here and prepend it to the next chunk before parsing (issue #2316).
+	PendingSSEBytes []byte
+
 	// AnthropicPassthrough carries Anthropic-only request fields captured from
 	// the raw inbound body and incoming headers, so the request-body writer
 	// and header builder can replay them on the outbound side.

--- a/src/semantic-router/pkg/extproc/sse_frame_buffer.go
+++ b/src/semantic-router/pkg/extproc/sse_frame_buffer.go
@@ -1,0 +1,43 @@
+package extproc
+
+import "bytes"
+
+// sseFrameDelimiter separates two SSE events on the wire: a blank line.
+// Per the SSE spec an event is terminated by a blank line, which on the
+// Anthropic and OpenAI streaming surfaces is the byte sequence "\n\n".
+var sseFrameDelimiter = []byte("\n\n")
+
+// reassembleSSEFrames merges any partial SSE frame carried over from a
+// prior response-body chunk (pending) with the newly arrived bytes
+// (chunk), then splits the result into the leading run of COMPLETE SSE
+// frames and any trailing incomplete remainder.
+//
+// Envoy STREAMED mode delivers the upstream response body split at
+// arbitrary byte offsets, with no guarantee that a chunk boundary aligns
+// to an SSE frame boundary. A single event may therefore straddle two
+// chunks. Parsing a chunk that ends mid-frame drops the partial frame
+// silently (json.Unmarshal fails on the truncated payload), so callers
+// must hold the remainder and prepend it to the next chunk before parsing.
+//
+// The returned complete slice is safe for the caller to parse and forward;
+// the remainder must be stored and passed back as pending on the next call.
+// Both are subslices of a freshly allocated buffer, so retaining remainder
+// across calls does not alias Envoy's chunk buffer.
+//
+// This relies on the well-formed-SSE contract that every event ends with a
+// blank line; a stream that never emits the terminating "\n\n" for its
+// final event would leave that event in remainder. That is a malformed
+// upstream, out of scope here.
+func reassembleSSEFrames(pending, chunk []byte) (complete, remainder []byte) {
+	buf := make([]byte, 0, len(pending)+len(chunk))
+	buf = append(buf, pending...)
+	buf = append(buf, chunk...)
+
+	idx := bytes.LastIndex(buf, sseFrameDelimiter)
+	if idx < 0 {
+		// No frame boundary yet — hold everything until more bytes arrive.
+		return nil, buf
+	}
+	boundary := idx + len(sseFrameDelimiter)
+	return buf[:boundary], buf[boundary:]
+}

--- a/src/semantic-router/pkg/extproc/sse_frame_buffer_test.go
+++ b/src/semantic-router/pkg/extproc/sse_frame_buffer_test.go
@@ -1,0 +1,83 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReassembleSSEFrames covers the SSE frame reassembly used to survive
+// Envoy STREAMED-mode chunk boundaries that split events mid-frame (#2316).
+func TestReassembleSSEFrames(t *testing.T) {
+	cases := []struct {
+		name          string
+		pending       string
+		chunk         string
+		wantComplete  string
+		wantRemainder string
+	}{
+		{
+			name:          "single complete frame passes through",
+			pending:       "",
+			chunk:         "data: {\"a\":1}\n\n",
+			wantComplete:  "data: {\"a\":1}\n\n",
+			wantRemainder: "",
+		},
+		{
+			name:          "frame split mid-json is held as remainder",
+			pending:       "",
+			chunk:         "data: {\"a\":",
+			wantComplete:  "",
+			wantRemainder: "data: {\"a\":",
+		},
+		{
+			name:          "pending remainder completes on next chunk",
+			pending:       "data: {\"a\":",
+			chunk:         "1}\n\n",
+			wantComplete:  "data: {\"a\":1}\n\n",
+			wantRemainder: "",
+		},
+		{
+			name:          "trailing partial after a complete frame is held",
+			pending:       "",
+			chunk:         "data: {\"a\":1}\n\ndata: {\"b\":",
+			wantComplete:  "data: {\"a\":1}\n\n",
+			wantRemainder: "data: {\"b\":",
+		},
+		{
+			name:          "empty chunk with no pending yields nothing",
+			pending:       "",
+			chunk:         "",
+			wantComplete:  "",
+			wantRemainder: "",
+		},
+		{
+			name:          "boundary split exactly between the two newlines",
+			pending:       "data: {\"a\":1}\n",
+			chunk:         "\ndata: {\"b\":2}\n\n",
+			wantComplete:  "data: {\"a\":1}\n\ndata: {\"b\":2}\n\n",
+			wantRemainder: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			complete, remainder := reassembleSSEFrames([]byte(tc.pending), []byte(tc.chunk))
+			assert.Equal(t, tc.wantComplete, string(complete), "complete frames")
+			assert.Equal(t, tc.wantRemainder, string(remainder), "held remainder")
+		})
+	}
+}
+
+// TestReassembleSSEFrames_RemainderDoesNotAliasChunk asserts the returned
+// remainder is copied out of the caller's chunk buffer, so retaining it
+// across calls is safe even if Envoy reuses the underlying array.
+func TestReassembleSSEFrames_RemainderDoesNotAliasChunk(t *testing.T) {
+	chunk := []byte("data: {\"a\":")
+	_, remainder := reassembleSSEFrames(nil, chunk)
+	// Mutate the caller's buffer; the remainder must be unaffected.
+	for i := range chunk {
+		chunk[i] = 'X'
+	}
+	assert.Equal(t, "data: {\"a\":", string(remainder), "remainder must not alias the chunk buffer")
+}


### PR DESCRIPTION
## Summary

Fixes #2316 — double-Anthropic streaming (Anthropic client + Anthropic backend, e.g. a reasoning model routed with `api_format: anthropic` + `provider: anthropic`) produced **zero output** and the client hung waiting for events.

## Root cause

Envoy STREAMED mode delivers the upstream response body split at **arbitrary byte offsets**, with no guarantee that a chunk boundary aligns to an SSE frame boundary — a single event can straddle two body chunks.

`handleAnthropicClientStreamingResponseBody` parsed each chunk independently with **no cross-chunk buffering**, so any event split across two chunks failed `json.Unmarshal` in `extractSSEDataLines` and was silently dropped. Because this handler **suppresses the raw upstream bytes** to keep ownership of the wire (it synthesizes its own Anthropic SSE via `emptyAnthropicBodyMutation`), a dropped frame *vanishes entirely* rather than being forwarded. Reasoning models emit large, verbose streams whose frames split routinely, so the client received nothing and hung.

The sibling OpenAI-client handler (`handleAnthropicStreamingResponseBody`) masks the same underlying split because it returns a **nil** `BodyMutation` on empty translation, letting Envoy forward the raw bytes — which is exactly why only the double-Anthropic cell exhibited the failure while the OpenAI-client-to-Anthropic-backend cell appeared unaffected.

The translation logic itself is correct: happy-path delivery (per-event, batched, whole-response, reasoning round-trip) all translate fine. Only byte-split delivery breaks it.

## Fix

Reassemble complete SSE frames across response-body chunks:

- New `reassembleSSEFrames` helper (`sse_frame_buffer.go`) merges the trailing partial frame carried on `RequestContext.PendingSSEBytes` with the next chunk, splits off only complete frames (delimited by a blank line, `\n\n`) for translation, and holds the remainder for the following chunk.
- `handleAnthropicClientStreamingResponseBody` now reassembles before translating; the keepalive ping still flows when only a partial frame arrived, so a long split does not stall the connection.

Scope is intentionally limited to the reported client handler. The sibling handler has the same latent split behavior but is masked by its nil-mutation/forward-raw contract; fixing it changes that contract and is left as a follow-up.

## Test Plan

- [x] `TestReassembleSSEFrames` — unit tests for the helper: complete frame pass-through, mid-JSON split held as remainder, remainder completed on next chunk, trailing partial after a complete frame, empty chunk, split exactly between the two newlines.
- [x] `TestReassembleSSEFrames_RemainderDoesNotAliasChunk` — remainder is copied, not aliasing Envoy's buffer.
- [x] `TestDoubleAnthropicStream_FrameAlignedDelivery` — baseline: full reasoning stream (message_start → thinking → text → message_delta → message_stop) translates correctly one-frame-per-chunk.
- [x] `TestDoubleAnthropicStream_ByteSplitDelivery` — regression: same stream sliced at spans of 1, 7, 32, 64, 200 bytes (span=1 = one byte per chunk); client always receives message_start, thinking/text deltas, the content, and message_stop.
- [x] `go test ./pkg/extproc/ ./pkg/anthropic/` pass; `-race` clean on streaming tests.
- [x] `golangci-lint` with the repo's strict agent config → 0 issues; `gofmt`/`go vet` clean.

## Note for the reporter

I could reproduce the exact symptom (zero output + hang) deterministically via byte-split delivery, which matches every observed characteristic (reasoning model, only the double-Anthropic cell affected). If you can `git checkout` this branch and confirm against your upstream — or share an SSE wire capture — that would fully close the loop.
