### PR TITLE
[Router] Reject complexity decision conditions without a difficulty suffix (#2324)

### DIFF
--- a/config/decision/composite/priority-safe-escalation.yaml
+++ b/config/decision/composite/priority-safe-escalation.yaml
@@ -13,7 +13,7 @@ routing:
               - type: keyword
                 name: urgent_keywords
               - type: complexity
-                name: needs_reasoning
+                name: needs_reasoning:hard
           - operator: NOT
             conditions:
               - type: jailbreak

--- a/src/semantic-router/pkg/config/validator.go
+++ b/src/semantic-router/pkg/config/validator.go
@@ -91,6 +91,11 @@ var (
 			scopes:   configValidationScopeFile | configValidationScopeKubernetes,
 		},
 		{
+			name:     "complexity",
+			validate: validateComplexityContracts,
+			scopes:   configValidationScopeFile | configValidationScopeKubernetes,
+		},
+		{
 			name:     "model_selection",
 			validate: validateModelSelectionConfig,
 			scopes:   configValidationScopeFile | configValidationScopeKubernetes,

--- a/src/semantic-router/pkg/config/validator_complexity.go
+++ b/src/semantic-router/pkg/config/validator_complexity.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// complexityDifficultyLevels enumerates the difficulty levels a complexity
+// rule can emit at runtime. It mirrors classifyComplexityDifficulty in
+// pkg/classification/complexity_rule_scoring.go, which always tags a rule
+// result as "<rule>:<level>" (e.g. "needs_reasoning:hard"). The config
+// package cannot import the classification package (import cycle), so the set
+// is duplicated here; keep the two in sync.
+var complexityDifficultyLevels = map[string]struct{}{
+	"hard":   {},
+	"easy":   {},
+	"medium": {},
+}
+
+// validateComplexityContracts checks that every decision condition of type
+// "complexity" references a declared complexity rule using the required
+// "<rule>:<difficulty>" form.
+//
+// The decision engine matches complexity conditions by literal membership
+// against the classifier's emitted "<rule>:<difficulty>" strings
+// (pkg/decision/engine.go uses slices.Contains), so a bare rule name — or one
+// with an unknown difficulty — never matches at runtime and becomes a
+// silently inert route. Config validation previously accepted the bare form
+// because the projection-input validator strips the ":" suffix before
+// checking the base name, leaving the mismatch undetected. Enforcing the
+// suffix here turns that latent misconfiguration into a clear load-time error
+// (issue #2324).
+func validateComplexityContracts(cfg *RouterConfig) error {
+	declared := collectComplexityRuleNames(cfg.ComplexityRules)
+	for _, decision := range cfg.Decisions {
+		if err := validateDecisionComplexityReferences(decision.Name, &decision.Rules, declared); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDecisionComplexityReferences(decisionName string, node *RuleNode, declared map[string]struct{}) error {
+	if node == nil {
+		return nil
+	}
+
+	if node.Type == SignalTypeComplexity {
+		if err := validateComplexityConditionName(decisionName, node.Name, declared); err != nil {
+			return err
+		}
+	}
+
+	for i := range node.Conditions {
+		if err := validateDecisionComplexityReferences(decisionName, &node.Conditions[i], declared); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateComplexityConditionName(decisionName, name string, declared map[string]struct{}) error {
+	// Split on the last ":" so complexity rule names that themselves contain a
+	// colon still resolve to the trailing difficulty token.
+	idx := strings.LastIndex(name, ":")
+	if idx <= 0 || idx == len(name)-1 {
+		return fmt.Errorf(
+			"decision %q references complexity %q, but a complexity condition must name a difficulty level as "+
+				"\"<rule>:<%s>\"; a bare rule name never matches at runtime because the classifier always emits "+
+				"\"<rule>:<difficulty>\"",
+			decisionName, name, strings.Join(sortedComplexityDifficultyLevels(), "|"),
+		)
+	}
+
+	rule, difficulty := name[:idx], name[idx+1:]
+	if _, ok := declared[rule]; !ok {
+		return fmt.Errorf(
+			"decision %q references complexity rule %q, but no routing.signals.complexity entry declares that name",
+			decisionName, rule,
+		)
+	}
+	if _, ok := complexityDifficultyLevels[difficulty]; !ok {
+		return fmt.Errorf(
+			"decision %q references complexity %q with unsupported difficulty %q; valid levels: %s",
+			decisionName, name, difficulty, strings.Join(sortedComplexityDifficultyLevels(), ", "),
+		)
+	}
+
+	return nil
+}
+
+func sortedComplexityDifficultyLevels() []string {
+	levels := make([]string, 0, len(complexityDifficultyLevels))
+	for level := range complexityDifficultyLevels {
+		levels = append(levels, level)
+	}
+	sort.Strings(levels)
+	return levels
+}

--- a/src/semantic-router/pkg/config/validator_complexity_test.go
+++ b/src/semantic-router/pkg/config/validator_complexity_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// complexityDecisionConfig builds a RouterConfig that declares the given
+// complexity rules and a single decision whose (possibly nested) rule tree
+// contains one complexity condition with the given name.
+func complexityDecisionConfig(declaredRules []string, conditionName string, nested bool) *RouterConfig {
+	rules := make([]ComplexityRule, 0, len(declaredRules))
+	for _, name := range declaredRules {
+		rules = append(rules, ComplexityRule{Name: name})
+	}
+
+	cond := RuleNode{Type: SignalTypeComplexity, Name: conditionName}
+	root := RuleNode{Operator: "AND", Conditions: []RuleNode{cond}}
+	if nested {
+		// Bury the complexity condition under OR -> NOT to exercise recursion.
+		root = RuleNode{
+			Operator: "AND",
+			Conditions: []RuleNode{
+				{Operator: "OR", Conditions: []RuleNode{
+					{Type: SignalTypeKeyword, Name: "kw"},
+					{Operator: "NOT", Conditions: []RuleNode{cond}},
+				}},
+			},
+		}
+	}
+
+	return &RouterConfig{
+		IntelligentRouting: IntelligentRouting{
+			Signals:   Signals{ComplexityRules: rules},
+			Decisions: []Decision{{Name: "route", Rules: root}},
+		},
+	}
+}
+
+func TestValidateComplexityContracts(t *testing.T) {
+	cases := []struct {
+		name       string
+		declared   []string
+		condition  string
+		nested     bool
+		wantErr    bool
+		errSubstrs []string
+	}{
+		{
+			name:      "valid hard",
+			declared:  []string{"needs_reasoning"},
+			condition: "needs_reasoning:hard",
+		},
+		{
+			name:      "valid easy",
+			declared:  []string{"needs_reasoning"},
+			condition: "needs_reasoning:easy",
+		},
+		{
+			name:      "valid medium",
+			declared:  []string{"needs_reasoning"},
+			condition: "needs_reasoning:medium",
+		},
+		{
+			name:      "valid nested under OR/NOT",
+			declared:  []string{"needs_reasoning"},
+			condition: "needs_reasoning:hard",
+			nested:    true,
+		},
+		{
+			name:       "bare rule name rejected",
+			declared:   []string{"needs_reasoning"},
+			condition:  "needs_reasoning",
+			wantErr:    true,
+			errSubstrs: []string{"needs_reasoning", "difficulty", "easy|hard|medium"},
+		},
+		{
+			name:       "bare rule name rejected even when nested",
+			declared:   []string{"needs_reasoning"},
+			condition:  "needs_reasoning",
+			nested:     true,
+			wantErr:    true,
+			errSubstrs: []string{"difficulty"},
+		},
+		{
+			name:       "unknown difficulty rejected",
+			declared:   []string{"needs_reasoning"},
+			condition:  "needs_reasoning:hardd",
+			wantErr:    true,
+			errSubstrs: []string{"unsupported difficulty", "hardd"},
+		},
+		{
+			name:       "undeclared rule rejected",
+			declared:   []string{"needs_reasoning"},
+			condition:  "bogus_rule:hard",
+			wantErr:    true,
+			errSubstrs: []string{"bogus_rule", "no routing.signals.complexity"},
+		},
+		{
+			name:       "trailing colon rejected",
+			declared:   []string{"needs_reasoning"},
+			condition:  "needs_reasoning:",
+			wantErr:    true,
+			errSubstrs: []string{"difficulty"},
+		},
+		{
+			name:       "leading colon rejected",
+			declared:   []string{"needs_reasoning"},
+			condition:  ":hard",
+			wantErr:    true,
+			errSubstrs: []string{"difficulty"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := complexityDecisionConfig(tc.declared, tc.condition, tc.nested)
+			err := validateComplexityContracts(cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for condition %q, got nil", tc.condition)
+				}
+				for _, sub := range tc.errSubstrs {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q missing expected substring %q", err.Error(), sub)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for condition %q: %v", tc.condition, err)
+			}
+		})
+	}
+}
+
+// TestValidateComplexityContracts_NoComplexityConditions ensures decisions
+// without any complexity conditions are unaffected.
+func TestValidateComplexityContracts_NoComplexityConditions(t *testing.T) {
+	cfg := &RouterConfig{
+		IntelligentRouting: IntelligentRouting{
+			Decisions: []Decision{{
+				Name: "route",
+				Rules: RuleNode{Operator: "AND", Conditions: []RuleNode{
+					{Type: SignalTypeDomain, Name: "business"},
+				}},
+			}},
+		},
+	}
+	if err := validateComplexityContracts(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/website/docs/tutorials/decision/composite.md
+++ b/website/docs/tutorials/decision/composite.md
@@ -47,7 +47,7 @@ routing:
               - type: keyword
                 name: urgent_keywords
               - type: complexity
-                name: needs_reasoning
+                name: needs_reasoning:hard
           - operator: NOT
             conditions:
               - type: jailbreak

--- a/website/docs/tutorials/signal/learned/complexity.md
+++ b/website/docs/tutorials/signal/learned/complexity.md
@@ -63,3 +63,24 @@ routing:
 ```
 
 Use `complexity` with representative hard and easy examples so the learned boundary matches your real routing cost profile. `prototype_scoring` is a family-level config under `global.model_catalog.modules.complexity`, so every complexity rule shares the same prototype-bank construction and label-scoring policy. Each rule still builds separate hard and easy prototype banks before computing the hard-vs-easy margin.
+
+## Routing on a complexity rule
+
+A complexity rule classifies each request into one of three difficulty levels — `hard`, `easy`, or `medium` — and emits the match as `<rule>:<level>`. Decision conditions must therefore reference the rule **with the difficulty suffix**, not by the bare rule name:
+
+```yaml
+routing:
+  decisions:
+    - name: escalate_hard_prompts
+      priority: 160
+      rules:
+        operator: OR
+        conditions:
+          - type: complexity
+            name: needs_reasoning:hard # required form: <rule>:<hard|easy|medium>
+      modelRefs:
+        - model: qwen3-30b
+          use_reasoning: true
+```
+
+A bare `name: needs_reasoning` never matches at runtime — the classifier only ever emits `needs_reasoning:hard|easy|medium` — so config validation rejects the suffix-less form with a clear error.


### PR DESCRIPTION
## Summary

Fixes #2324 — a `decision` condition of `type: complexity` that references a complexity rule by its **bare name** (e.g. `name: needs_reasoning`) passed config validation but **never matched at runtime**, silently disabling that route.

## Root cause

The decision engine matches complexity conditions by literal membership against the classifier's emitted `"<rule>:<difficulty>"` strings:

- **Emit**: `classifier_signal_complexity.go` → `matchName := fmt.Sprintf("%s:%s", RuleName, Difficulty)` (difficulty ∈ `hard|easy|medium`).
- **Runtime match**: `pkg/decision/engine.go` → `slices.Contains(signals.ComplexityRules, name)`.
- **Validation**: `validator_projection.go` `complexityNameDeclared` strips the `:` suffix before checking the base name, so the bare form passed validation.

So `slices.Contains(["needs_reasoning:hard"], "needs_reasoning")` → `false`. A complexity rule always classifies into one of `hard`/`easy`/`medium`, so a bare name can never be a discriminating match — the route is silently inert.

## Fix (fail-fast validation)

Add a dedicated `validateComplexityContracts` validator (sibling file per `pkg/config/AGENTS.md`, registered in the validator table) that walks each decision's rule tree and requires every `type: complexity` condition to name a **declared** rule in the `"<rule>:<hard|easy|medium>"` form. Bare names, unknown/missing difficulties, and undeclared rules now fail at config load with a clear error, mirroring the existing domain reference validator.

Also fixes the one shipped example that used the bare form and documents the required form.

## Why this contract (vs. making runtime lenient)

A complexity rule emits a difficulty for **every** request, so treating a bare name as "match any difficulty" would make it always-true (useless). Every maintained config (`config/config.yaml`, all `deploy/recipes/*`, kserve) already uses the explicit `:difficulty` form and declares its rules — so this enforces the de-facto contract with **zero breakage**; only the one broken example is corrected.

## Changes

- `pkg/config/validator_complexity.go` (new) + registration in `pkg/config/validator.go`
- `pkg/config/validator_complexity_test.go` (new)
- `config/decision/composite/priority-safe-escalation.yaml`: `needs_reasoning` → `needs_reasoning:hard`
- `website/docs/tutorials/decision/composite.md`: same fix
- `website/docs/tutorials/signal/learned/complexity.md`: document the `<rule>:<hard|easy|medium>` routing form

## Test Plan

- [x] `TestValidateComplexityContracts` (table-driven): valid `hard`/`easy`/`medium`, nested under OR/NOT, bare name rejected (incl. nested), unknown difficulty rejected, undeclared rule rejected, leading/trailing colon rejected.
- [x] `TestValidateComplexityContracts_NoComplexityConditions`: decisions without complexity conditions unaffected.
- [x] `go test ./pkg/config/` passes — including `maintained_asset_contract_test` (validates all `deploy/` recipes through the new validator) and the reference-config enforcement.
- [x] `gofmt`/`go vet` clean; `golangci-lint` (strict agent config) → 0 issues; `go build ./pkg/...` clean.
