### PR TITLE
[Docs] Clarify NVIDIA Step 5 uses the Envoy front-door port

### DIFF
--- a/deploy/nvidia/README.md
+++ b/deploy/nvidia/README.md
@@ -330,10 +330,13 @@ the active config.
 
 ## Step 5: Sanity-check a real query
 
-Send any prompt through the router and confirm it routes successfully:
+Send any prompt through the router and confirm it routes successfully. Chat
+completions enter through the **Envoy** front door of your existing `vllm-sr`
+deployment — not the router's own API port from Step 3c — so use that
+deployment's Envoy listener port, shown here as `${ENVOY_PORT}`:
 
 ```bash
-curl -sS -X POST http://localhost:8999/v1/chat/completions \
+curl -sS -X POST "http://localhost:${ENVOY_PORT}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d '{
       "model": "auto",


### PR DESCRIPTION
## What

Docs-only clarity fix for `deploy/nvidia/README.md`. The Step 5 sanity-check
curl used a bare `http://localhost:8999/...` port that is never defined anywhere
else in the playbook. Readers hit two questions with no answer:

- Where does `8999` come from? (It is not one of the host ports remapped in
  Step 3c: `50151` / `8180` / `9290`.)
- Why does it differ from the router API port used later in Troubleshooting
  (`localhost:8180/api/v1/classify/intent`)?

The answer is that chat completions enter through the **Envoy** front door of
the existing `vllm-sr` deployment, not the router's own API port — a distinction
the playbook already relies on but never states here.

## Change

- Replace the magic `8999` with an `${ENVOY_PORT}` placeholder.
- Add a one-line note that Step 5 targets the deployment's Envoy listener (not
  the Step 3c router API port), matching the env-var port convention already
  used in [`deploy/amd/README.md`](../amd/README.md).

No behavior change; documentation only.

## Test Plan

- `markdownlint -c tools/linter/markdown/markdownlint.yaml deploy/nvidia/README.md` — clean.
- Verified the `${ENVOY_PORT}` reference and the Step 3c cross-reference read
  correctly against the surrounding steps.
