### PR TITLE
[Bindings][Router] fix(embedding): derive mmBERT early-exit layers from model manifest

### DIFF
--- a/onnx-binding/src/model_architectures/embedding/mmbert_embedding.rs
+++ b/onnx-binding/src/model_architectures/embedding/mmbert_embedding.rs
@@ -134,6 +134,45 @@ impl Default for MatryoshkaConfig {
 }
 
 impl MatryoshkaConfig {
+    /// Build a config for a specific model directory, reading the early-exit
+    /// layer list from the model's own `onnx/model_config.json`
+    /// (`available_layers`) so the layers are a single source of truth rather
+    /// than a hardcoded list that can drift from the shipped model.
+    ///
+    /// Falls back to the built-in default layers when the manifest is absent
+    /// or does not declare `available_layers`.
+    pub fn from_model_dir<P: AsRef<Path>>(model_path: P) -> Self {
+        let model_dir = model_path.as_ref();
+        let manifest_candidates = [
+            model_dir.join("onnx").join("model_config.json"),
+            model_dir.join("model_config.json"),
+        ];
+
+        let layers = manifest_candidates
+            .iter()
+            .find(|p| p.exists())
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .and_then(|json| {
+                json.get("available_layers")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|l| l.as_u64().map(|n| n as usize))
+                            .collect::<Vec<usize>>()
+                    })
+            })
+            .filter(|layers| !layers.is_empty());
+
+        match layers {
+            Some(layers) => Self {
+                layers,
+                ..Self::default()
+            },
+            None => Self::default(),
+        }
+    }
+
     pub fn validate_dimension(&self, dim: usize) -> bool {
         self.dimensions.contains(&dim)
     }
@@ -263,6 +302,10 @@ impl MmBertEmbeddingModel {
         // Load configuration
         let config = MmBertEmbeddingConfig::from_pretrained(&model_path)?;
 
+        // Resolve the early-exit layer list from the model's own manifest
+        // (single source of truth) so it never drifts from what is shipped.
+        let matryoshka_config = MatryoshkaConfig::from_model_dir(&model_path);
+
         // Load tokenizer
         let tokenizer_candidates = [
             model_dir.join("tokenizer.json"),
@@ -283,7 +326,7 @@ impl MmBertEmbeddingModel {
             .map_err(|e| errors::tokenization_error(&e.to_string()))?;
 
         // Find ONNX model candidates (priority order)
-        let onnx_candidates = Self::find_onnx_models(&model_path)?;
+        let onnx_candidates = Self::find_onnx_models(&model_path, &matryoshka_config.layers)?;
 
         // Create ONNX Runtime session with fallback across candidates.
         // We intentionally prefer GPU-optimized model variants first.
@@ -321,13 +364,14 @@ impl MmBertEmbeddingModel {
         }
 
         // Check for layer-specific ONNX files (for early exit support)
-        let (supports_layer_exit, layer_sessions) = Self::load_layer_sessions(&model_path, use_cpu);
+        let (supports_layer_exit, layer_sessions) =
+            Self::load_layer_sessions(&model_path, use_cpu, &matryoshka_config.layers);
 
         Ok(Self {
             session,
             tokenizer: Arc::new(tokenizer),
             config,
-            matryoshka_config: MatryoshkaConfig::default(),
+            matryoshka_config,
             model_path: model_path_str,
             supports_layer_exit,
             layer_sessions,
@@ -338,7 +382,10 @@ impl MmBertEmbeddingModel {
     ///
     /// Searches: model_path/, model_path/onnx/, and HuggingFace-style
     /// model_path/onnx/layer-{N}/ subdirectories (highest layer first as primary).
-    fn find_onnx_models<P: AsRef<Path>>(model_path: P) -> UnifiedResult<Vec<std::path::PathBuf>> {
+    fn find_onnx_models<P: AsRef<Path>>(
+        model_path: P,
+        layers: &[usize],
+    ) -> UnifiedResult<Vec<std::path::PathBuf>> {
         let dir = model_path.as_ref();
         let onnx_subdir = dir.join("onnx");
 
@@ -369,8 +416,7 @@ impl MmBertEmbeddingModel {
         let mut search_dirs: Vec<std::path::PathBuf> = vec![dir.to_path_buf(), onnx_subdir.clone()];
 
         // HuggingFace-style layer subdirectories (highest layer first for primary model).
-        let matryoshka = MatryoshkaConfig::default();
-        let mut layers_desc: Vec<usize> = matryoshka.layers.clone();
+        let mut layers_desc: Vec<usize> = layers.to_vec();
         layers_desc.sort_unstable_by(|a, b| b.cmp(a));
         for layer in &layers_desc {
             let layer_dir = onnx_subdir.join(format!("layer-{}", layer));
@@ -498,7 +544,8 @@ impl MmBertEmbeddingModel {
                 // Bound the per-session CUDA arena and request-sized arena
                 // growth, mirroring the classifier path. The 2D-Matryoshka
                 // embedding model opens one primary session plus one session
-                // per early-exit layer (3, 6, 11, 22), so without a memory
+                // per early-exit layer declared in the model manifest, so
+                // without a memory
                 // limit each unbounded BFC arena tries to grab a large block
                 // up front and later sessions OOM (CUBLAS_STATUS_ALLOC_FAILED)
                 // on a shared/busy GPU, silently falling back to CPU.
@@ -541,8 +588,8 @@ impl MmBertEmbeddingModel {
     fn load_layer_sessions<P: AsRef<Path>>(
         model_path: P,
         use_cpu: bool,
+        layers: &[usize],
     ) -> (bool, Vec<Option<Session>>) {
-        let matryoshka = MatryoshkaConfig::default();
         let mut sessions = Vec::new();
         let mut any_loaded = false;
         let model_dir = model_path.as_ref();
@@ -553,7 +600,7 @@ impl MmBertEmbeddingModel {
             .filter(|s| !s.is_empty())
             .is_some();
 
-        for layer in &matryoshka.layers {
+        for layer in layers {
             let layer_filename = format!("model_layer_{}.onnx", layer);
             let hf_layer_dir = onnx_dir.join(format!("layer-{}", layer));
 
@@ -873,6 +920,34 @@ mod tests {
         let config = MatryoshkaConfig::default();
         assert_eq!(config.dimensions, vec![768, 512, 256, 128, 64]);
         assert_eq!(config.layers, vec![3, 6, 11, 22]);
+    }
+
+    #[test]
+    fn test_matryoshka_from_model_dir_reads_manifest() {
+        // SSoT: early-exit layers must come from the model's own
+        // onnx/model_config.json (available_layers), NOT a hardcoded list.
+        // The official mmbert-embed-32k-2d-matryoshka ships [6, 11, 16, 22].
+        let dir = tempfile::tempdir().unwrap();
+        let onnx_dir = dir.path().join("onnx");
+        std::fs::create_dir_all(&onnx_dir).unwrap();
+        std::fs::write(
+            onnx_dir.join("model_config.json"),
+            r#"{"total_layers": 22, "available_layers": [6, 11, 16, 22]}"#,
+        )
+        .unwrap();
+
+        let config = MatryoshkaConfig::from_model_dir(dir.path());
+
+        assert_eq!(config.layers, vec![6, 11, 16, 22]);
+    }
+
+    #[test]
+    fn test_matryoshka_from_model_dir_fallback_without_manifest() {
+        // No model_config.json present -> fall back to the built-in default
+        // rather than erroring, preserving backward compat.
+        let dir = tempfile::tempdir().unwrap();
+        let config = MatryoshkaConfig::from_model_dir(dir.path());
+        assert_eq!(config.layers, MatryoshkaConfig::default().layers);
     }
 
     #[test]

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -5,8 +5,11 @@ package apiserver
 import (
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
@@ -51,7 +54,12 @@ func (s *ClassificationAPIServer) parseEmbeddingRequest(w http.ResponseWriter, r
 	}
 
 	applyEmbeddingDefaults(&req)
-	if code, message, ok := validateEmbeddingRequest(req); !ok {
+	mmbertPath := ""
+	if s.config != nil {
+		mmbertPath = s.config.EmbeddingModels.MmBertModelPath
+	}
+	availableLayers := config.MmBertAvailableLayers(mmbertPath)
+	if code, message, ok := validateEmbeddingRequest(req, availableLayers); !ok {
 		s.writeErrorResponse(w, http.StatusBadRequest, code, message)
 		return EmbeddingRequest{}, false
 	}
@@ -72,7 +80,7 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 	}
 }
 
-func validateEmbeddingRequest(req EmbeddingRequest) (string, string, bool) {
+func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string, string, bool) {
 	if len(req.Texts) == 0 {
 		return "INVALID_INPUT", "texts array cannot be empty", false
 	}
@@ -82,8 +90,8 @@ func validateEmbeddingRequest(req EmbeddingRequest) (string, string, bool) {
 	if req.TargetLayer != 0 && req.Model != "mmbert" {
 		return "INVALID_PARAMETER", "target_layer is only supported for model='mmbert'", false
 	}
-	if req.Model == "mmbert" && req.TargetLayer != 0 && !isValidMmBertLayer(req.TargetLayer) {
-		return "INVALID_LAYER", fmt.Sprintf("target_layer must be one of: 3, 6, 11, 22 (got %d)", req.TargetLayer), false
+	if req.Model == "mmbert" && req.TargetLayer != 0 && !config.IsValidMmBertLayer(req.TargetLayer, mmbertLayers) {
+		return "INVALID_LAYER", fmt.Sprintf("target_layer must be one of: %s (got %d)", formatLayerList(mmbertLayers), req.TargetLayer), false
 	}
 	return "", "", true
 }
@@ -303,8 +311,12 @@ func isValidDimension(dim int) bool {
 	return validDimensions[dim]
 }
 
-// isValidMmBertLayer checks if the provided layer is valid for mmBERT early exit
-func isValidMmBertLayer(layer int) bool {
-	validLayers := map[int]bool{3: true, 6: true, 11: true, 22: true}
-	return validLayers[layer]
+// formatLayerList renders a layer set as a comma-separated string for error
+// messages, e.g. [6 11 16 22] -> "6, 11, 16, 22".
+func formatLayerList(layers []int) string {
+	parts := make([]string, len(layers))
+	for i, l := range layers {
+		parts[i] = strconv.Itoa(l)
+	}
+	return strings.Join(parts, ", ")
 }

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -3,6 +3,7 @@
 package apiserver
 
 import (
+	"strings"
 	"testing"
 
 	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
@@ -65,5 +66,68 @@ func TestValidateBatchSimilarityRequestRejectsNegativeTopK(t *testing.T) {
 	}
 	if code != "INVALID_INPUT" || message != "top_k cannot be negative" {
 		t.Fatalf("unexpected validation error %q: %q", code, message)
+	}
+}
+
+// target_layer must be validated against the layers the loaded model actually
+// advertises, not a hardcoded list. For the official
+// mmbert-embed-32k-2d-matryoshka (available_layers [6, 11, 16, 22]), layer 16
+// must be accepted (it ships and is loadable) and layer 3 must be rejected
+// (it is not on disk and previously fell back silently to the full model).
+func TestValidateEmbeddingRequestTargetLayerFollowsModelManifest(t *testing.T) {
+	available := []int{6, 11, 16, 22}
+
+	if _, _, ok := validateEmbeddingRequest(EmbeddingRequest{
+		Model:       "mmbert",
+		Texts:       []string{"hello"},
+		Dimension:   defaultEmbeddingDimension,
+		TargetLayer: 16,
+	}, available); !ok {
+		t.Fatalf("expected target_layer=16 to be valid for %v", available)
+	}
+
+	code, message, ok := validateEmbeddingRequest(EmbeddingRequest{
+		Model:       "mmbert",
+		Texts:       []string{"hello"},
+		Dimension:   defaultEmbeddingDimension,
+		TargetLayer: 3,
+	}, available)
+	if ok {
+		t.Fatalf("expected target_layer=3 to be rejected for %v", available)
+	}
+	if code != "INVALID_LAYER" {
+		t.Fatalf("expected INVALID_LAYER, got %q", code)
+	}
+	if !strings.Contains(message, "6, 11, 16, 22") {
+		t.Fatalf("error message should list the model's real layers, got %q", message)
+	}
+}
+
+// When a model ships without a manifest the validator falls back to the legacy
+// layer set, so target_layer=3 stays valid for that set.
+func TestValidateEmbeddingRequestTargetLayerLegacyFallback(t *testing.T) {
+	if _, _, ok := validateEmbeddingRequest(EmbeddingRequest{
+		Model:       "mmbert",
+		Texts:       []string{"hello"},
+		Dimension:   defaultEmbeddingDimension,
+		TargetLayer: 3,
+	}, []int{3, 6, 11, 22}); !ok {
+		t.Fatalf("expected target_layer=3 to be valid for the legacy fallback set")
+	}
+}
+
+// target_layer is only meaningful for mmbert; other models must reject it.
+func TestValidateEmbeddingRequestTargetLayerRejectedForNonMmbert(t *testing.T) {
+	code, _, ok := validateEmbeddingRequest(EmbeddingRequest{
+		Model:       "qwen3",
+		Texts:       []string{"hello"},
+		Dimension:   defaultEmbeddingDimension,
+		TargetLayer: 6,
+	}, []int{6, 11, 16, 22})
+	if ok {
+		t.Fatalf("expected target_layer on non-mmbert model to be rejected")
+	}
+	if code != "INVALID_PARAMETER" {
+		t.Fatalf("expected INVALID_PARAMETER, got %q", code)
 	}
 }

--- a/src/semantic-router/pkg/config/embedding_layers.go
+++ b/src/semantic-router/pkg/config/embedding_layers.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// legacyMmBertLayers is the historical hardcoded early-exit layer set. It is
+// used only as a fallback when a model ships without an onnx/model_config.json
+// manifest, so validation stays backward compatible instead of rejecting every
+// layer.
+var legacyMmBertLayers = []int{3, 6, 11, 22}
+
+// mmBertModelConfig is the subset of the model's onnx/model_config.json that
+// declares which early-exit layers the shipped model actually provides.
+type mmBertModelConfig struct {
+	AvailableLayers []int `json:"available_layers"`
+}
+
+// MmBertAvailableLayers returns the early-exit layers the mmBERT model at
+// modelPath supports, read from its own onnx/model_config.json
+// (available_layers). This manifest is the single source of truth: the layers
+// must match the ONNX sessions the model actually ships, not a hardcoded list
+// that can drift from the model.
+//
+// Falls back to the historical default layer set when the manifest is missing,
+// unreadable, or does not declare available_layers.
+func MmBertAvailableLayers(modelPath string) []int {
+	if modelPath == "" {
+		return legacyMmBertLayers
+	}
+
+	manifestPath := filepath.Join(modelPath, "onnx", "model_config.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return legacyMmBertLayers
+	}
+
+	var cfg mmBertModelConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return legacyMmBertLayers
+	}
+	if len(cfg.AvailableLayers) == 0 {
+		return legacyMmBertLayers
+	}
+	return cfg.AvailableLayers
+}
+
+// IsValidMmBertLayer reports whether layer is one of the model's advertised
+// early-exit layers.
+func IsValidMmBertLayer(layer int, available []int) bool {
+	for _, l := range available {
+		if l == layer {
+			return true
+		}
+	}
+	return false
+}

--- a/src/semantic-router/pkg/config/embedding_layers_test.go
+++ b/src/semantic-router/pkg/config/embedding_layers_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeManifest(t *testing.T, dir, body string) {
+	t.Helper()
+	onnxDir := filepath.Join(dir, "onnx")
+	if err := os.MkdirAll(onnxDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(onnxDir, "model_config.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+// The early-exit layers a request may target must come from the model's own
+// onnx/model_config.json (available_layers), the single source of truth, so
+// they never drift from what the shipped model actually provides. The official
+// mmbert-embed-32k-2d-matryoshka ships [6, 11, 16, 22].
+func TestMmBertAvailableLayers_ReadsManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{"total_layers": 22, "available_layers": [6, 11, 16, 22]}`)
+
+	got := MmBertAvailableLayers(dir)
+
+	want := []int{6, 11, 16, 22}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MmBertAvailableLayers = %v, want %v", got, want)
+	}
+}
+
+// When no manifest is present, fall back to the historical default layer set
+// rather than rejecting every layer, preserving backward compatibility with
+// models that ship without a model_config.json.
+func TestMmBertAvailableLayers_FallbackWithoutManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	got := MmBertAvailableLayers(dir)
+
+	want := []int{3, 6, 11, 22}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MmBertAvailableLayers fallback = %v, want %v", got, want)
+	}
+}
+
+func TestIsValidMmBertLayer(t *testing.T) {
+	available := []int{6, 11, 16, 22}
+	if !IsValidMmBertLayer(16, available) {
+		t.Errorf("layer 16 should be valid for %v", available)
+	}
+	if IsValidMmBertLayer(3, available) {
+		t.Errorf("layer 3 should be invalid for %v (phantom layer)", available)
+	}
+}


### PR DESCRIPTION
Closes #2385

## Purpose

- The supported mmBERT 2D-Matryoshka early-exit layers were hardcoded as `[3, 6, 11, 22]` in two independent places — the ONNX Rust binding's `MatryoshkaConfig` and the Go apiserver's `isValidMmBertLayer` — and both drifted from what the shipped model actually provides. The official `llm-semantic-router/mmbert-embed-32k-2d-matryoshka` declares `available_layers [6, 11, 16, 22]` in its `onnx/model_config.json`, which the code never read. Two concrete defects resulted:
  - **layer 3 is a phantom:** it is in the hardcoded list but not on disk, so `target_layer=3` passed validation, found no layer session, and silently fell back to the full L22 primary session — violating the speed/quality contract with no error or warning.
  - **layer 16 is unreachable:** it ships on disk (555 MB) and is officially recommended, but was absent from the hardcoded list, so it was never loaded and the API rejected `target_layer=16` outright.
- The fix makes the model's own `onnx/model_config.json` the single source of truth for early-exit layers, so the valid set can no longer drift from the shipped model and adapts automatically to a model with a different layer configuration.
- Modules affected: `Bindings` (ONNX Rust binding), `Router` (Go apiserver + config).

Changes:
- **onnx-binding:** add `MatryoshkaConfig::from_model_dir()` which parses `available_layers`, and thread the resolved layers through `find_onnx_models` and `load_layer_sessions` instead of each independently calling `::default()`. layer-16 is now loaded and `available_exit_layers()` reports `[6, 11, 16, 22]`. The built-in default is kept only as a fallback for models shipped without a manifest.
- **apiserver / config:** add `EmbeddingModels.MmBertAvailableLayers()` and a pure `IsValidMmBertLayer()`; validate `target_layer` against the manifest-derived set and build the error message from it, dropping the hardcoded list.
- The candle binding is intentionally untouched: it runs the full model and early-exits at any layer count, so the shared manifest-based validation gates both bindings consistently.

## Test Plan

- `cd onnx-binding && cargo test --lib --no-default-features` — Rust unit tests, including new `from_model_dir` manifest-read and fallback cases.
- `go test ./pkg/config/` — new `MmBertAvailableLayers` / `IsValidMmBertLayer` unit tests (manifest read, fallback, membership).
- `go test ./pkg/apiserver/ -run TestValidateEmbeddingRequestTargetLayer` (default/candle build) — new apiserver validation tests: layer 16 accepted, layer 3 rejected with a message listing the model's real layers, legacy fallback, non-mmbert rejection.
- Manual end-to-end on the ONNX path (`router-onnx`) with the real official model, before vs. after the change, to confirm the runtime behavior — not just the validation layer.

## Test Result

- All unit tests green: onnx-binding 47 passed (2 new); `pkg/config` 3 new passed; `pkg/apiserver` 3 new passed. `cargo fmt`/`gofmt` clean.
- **Pre-fix** (reverted sources, rebuilt binary, official model): `available_exits=[6, 11, 22]` (layer-16 never loaded); `target_layer=16` → `400 INVALID_LAYER`; `target_layer=3` → `200` with an embedding **byte-identical to `target_layer=22`** (the silent downgrade).
- **Post-fix** (same model): startup logs `Loading layer-16` and `available_exits=[6, 11, 16, 22]`; `target_layer=16` → `200`; `target_layer=3` → `400 INVALID_LAYER: target_layer must be one of: 6, 11, 16, 22`; `target_layer=6` / `11` → `200`.
- Follow-up / gaps: validation and the ONNX layer-loading path are covered by the unit tests above and verified manually end-to-end; there is no automated kind/E2E case exercising `/api/v1/embeddings target_layer` yet. Happy to add one under `e2e/` if reviewers prefer a CI-enforced check.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[Bindings]`, etc.
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

