### PR TITLE
[Bench] Fix cache benchmarks failing to resolve embedding model path under go test

### DIFF
--- a/perf/benchmarks/cache_bench_test.go
+++ b/perf/benchmarks/cache_bench_test.go
@@ -4,17 +4,49 @@ package benchmarks
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
 )
 
-// BenchmarkCacheSearch_1000Entries benchmarks cache search with 1000 entries
-func BenchmarkCacheSearch_1000Entries(b *testing.B) {
-	// Initialize embedding models once
+const embeddingModelPathEnv = "QWEN3_MODEL_PATH"
+
+var embeddingModelPathOnce sync.Once
+
+// initCacheEmbeddingModels initializes the cache embedding models for benchmarks.
+// The fallback paths inside cache.InitEmbeddingModels are relative to the process
+// working directory, which for `go test` is this package directory
+// (perf/benchmarks), so none of them reach the repo-root models/ directory.
+// Point QWEN3_MODEL_PATH at the repo root explicitly (same repo-root resolution
+// as initIntentClassifier in classification_accuracy_bench_test.go) unless the
+// caller already set it.
+func initCacheEmbeddingModels(b *testing.B) {
+	b.Helper()
+	embeddingModelPathOnce.Do(func() {
+		if os.Getenv(embeddingModelPathEnv) != "" {
+			return
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			return
+		}
+		modelDir := filepath.Join(wd, "..", "..", "models", "mom-embedding-pro")
+		if _, err := os.Stat(modelDir); err == nil {
+			os.Setenv(embeddingModelPathEnv, modelDir)
+		}
+	})
 	if err := cache.InitEmbeddingModels(); err != nil {
 		b.Fatalf("Failed to initialize embedding models: %v", err)
 	}
+}
+
+// BenchmarkCacheSearch_1000Entries benchmarks cache search with 1000 entries
+func BenchmarkCacheSearch_1000Entries(b *testing.B) {
+	// Initialize embedding models once
+	initCacheEmbeddingModels(b)
 
 	config := cache.BenchmarkConfig{
 		CacheSize:         1000,
@@ -42,9 +74,7 @@ func BenchmarkCacheSearch_1000Entries(b *testing.B) {
 
 // BenchmarkCacheSearch_10000Entries benchmarks cache search with 10,000 entries
 func BenchmarkCacheSearch_10000Entries(b *testing.B) {
-	if err := cache.InitEmbeddingModels(); err != nil {
-		b.Fatalf("Failed to initialize embedding models: %v", err)
-	}
+	initCacheEmbeddingModels(b)
 
 	config := cache.BenchmarkConfig{
 		CacheSize:         10000,
@@ -72,9 +102,7 @@ func BenchmarkCacheSearch_10000Entries(b *testing.B) {
 
 // BenchmarkCacheSearch_HNSW benchmarks HNSW index search
 func BenchmarkCacheSearch_HNSW(b *testing.B) {
-	if err := cache.InitEmbeddingModels(); err != nil {
-		b.Fatalf("Failed to initialize embedding models: %v", err)
-	}
+	initCacheEmbeddingModels(b)
 
 	config := cache.BenchmarkConfig{
 		CacheSize:         5000,
@@ -100,9 +128,7 @@ func BenchmarkCacheSearch_HNSW(b *testing.B) {
 
 // BenchmarkCacheSearch_Linear benchmarks linear search (no HNSW)
 func BenchmarkCacheSearch_Linear(b *testing.B) {
-	if err := cache.InitEmbeddingModels(); err != nil {
-		b.Fatalf("Failed to initialize embedding models: %v", err)
-	}
+	initCacheEmbeddingModels(b)
 
 	config := cache.BenchmarkConfig{
 		CacheSize:         1000, // Smaller for linear search
@@ -128,9 +154,7 @@ func BenchmarkCacheSearch_Linear(b *testing.B) {
 
 // BenchmarkCacheConcurrency_1 benchmarks cache with concurrency level 1
 func BenchmarkCacheConcurrency_1(b *testing.B) {
-	if err := cache.InitEmbeddingModels(); err != nil {
-		b.Fatalf("Failed to initialize embedding models: %v", err)
-	}
+	initCacheEmbeddingModels(b)
 
 	config := cache.BenchmarkConfig{
 		CacheSize:         5000,
@@ -155,9 +179,7 @@ func BenchmarkCacheConcurrency_1(b *testing.B) {
 
 // BenchmarkCacheConcurrency_10 benchmarks cache with concurrency level 10
 func BenchmarkCacheConcurrency_10(b *testing.B) {
-	if err := cache.InitEmbeddingModels(); err != nil {
-		b.Fatalf("Failed to initialize embedding models: %v", err)
-	}
+	initCacheEmbeddingModels(b)
 
 	config := cache.BenchmarkConfig{
 		CacheSize:         5000,
@@ -182,9 +204,7 @@ func BenchmarkCacheConcurrency_10(b *testing.B) {
 
 // BenchmarkCacheConcurrency_50 benchmarks cache with concurrency level 50
 func BenchmarkCacheConcurrency_50(b *testing.B) {
-	if err := cache.InitEmbeddingModels(); err != nil {
-		b.Fatalf("Failed to initialize embedding models: %v", err)
-	}
+	initCacheEmbeddingModels(b)
 
 	config := cache.BenchmarkConfig{
 		CacheSize:         5000,
@@ -210,9 +230,7 @@ func BenchmarkCacheConcurrency_50(b *testing.B) {
 
 // BenchmarkCacheHitRate benchmarks cache hit rate effectiveness
 func BenchmarkCacheHitRate(b *testing.B) {
-	if err := cache.InitEmbeddingModels(); err != nil {
-		b.Fatalf("Failed to initialize embedding models: %v", err)
-	}
+	initCacheEmbeddingModels(b)
 
 	// High hit ratio scenario
 	config := cache.BenchmarkConfig{


### PR DESCRIPTION
Fixes #2388

## What

All 8 cache benchmarks (`BenchmarkCacheSearch_*`, `BenchmarkCacheConcurrency_*`, `BenchmarkCacheHitRate`) failed out of the box, even with `models/mom-embedding-pro` downloaded at the repo root. The fallback paths inside `cache.InitEmbeddingModels` (`src/semantic-router/pkg/cache/benchmark.go:517-522`) resolve against the process working directory, and `go test` runs the test binary with CWD set to the package directory (`perf/benchmarks/`), so none of the four fallbacks reach the repo-root `models/` directory. No Make target sets the `QWEN3_MODEL_PATH` escape hatch either, so `make perf-bench-cache` inherits the same failure.

## Before the fix

```
$ cd perf && go test -bench='BenchmarkCacheSearch_1000Entries' -run='^$' -benchtime=1x ./benchmarks/
Initializing Qwen3 embedding model with FIXED continuous batching on CPU...
QWEN3_MODEL_PATH not set, trying default paths...
  Attempt 1/4: Trying ./models/mom-embedding-pro (device: CPU)
ERROR: Failed to load tokenizer from ./models/mom-embedding-pro/tokenizer.json: Os { code: 2, kind: NotFound, message: "No such file or directory" }
  Attempt 2/4: Trying ./candle-binding/models/mom-embedding-pro (device: CPU)
ERROR: ... NotFound ...
  Attempt 3/4: Trying ../models/mom-embedding-pro (device: CPU)
ERROR: ... NotFound ...
  Attempt 4/4: Trying models/mom-embedding-pro (device: CPU)
ERROR: ... NotFound ...
--- FAIL: BenchmarkCacheSearch_1000Entries
    cache_bench_test.go:16: Failed to initialize embedding models: failed to initialize Qwen3 model on CPU with continuous batching (tried 4 paths)
FAIL
exit status 1
FAIL    github.com/vllm-project/semantic-router/perf/benchmarks    2.202s
```

## After the fix

Same command, same machine (macOS arm64, CPU):

```
Initializing Qwen3 embedding model with FIXED continuous batching on CPU...
Qwen3 embedding model initialized from: <repo-root>/models/mom-embedding-pro
BenchmarkCacheSearch_1000Entries-10   1   16750142208 ns/op   100.0 hit_rate_%   0.1670 p95_ms   0.1670 p99_ms   3146 qps
PASS
ok      github.com/vllm-project/semantic-router/perf/benchmarks    1162.150s
```

## How

One test-only change in `perf/benchmarks/cache_bench_test.go`: a shared `initCacheEmbeddingModels` helper resolves the repo root the same way `classification_accuracy_bench_test.go` already does (`filepath.Join(wd, "..", "..")`) and points `QWEN3_MODEL_PATH` at `<repo-root>/models/mom-embedding-pro` **only when the variable is unset** — a caller-provided value always wins. The 8 duplicated init blocks now call the helper. Library code and Makefiles are untouched.

## Test Plan

- Repro command above: fails on `main`, passes with this branch (output above).
- `QWEN3_MODEL_PATH=/custom/path` is respected (helper returns early when the env var is set).
- `gofmt`, `go vet`, and `pre-commit run --files perf/benchmarks/cache_bench_test.go` (incl. go lint) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)