### PR TITLE
[Inference] Add backend telemetry contract

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -11,7 +11,7 @@
 Inside canonical `config.yaml`:
 
 - `providers.defaults` holds provider-wide defaults such as `default_model` and reasoning families
-- `providers.models[]` holds concrete backend access details directly, including optional `backend_id` and `engine_kind` identity hints on each `backend_refs[]` entry
+- `providers.models[]` holds concrete backend access details directly. Each `backend_refs[]` entry names one runtime backend pool with `runtime` plus either legacy singleton `endpoint`, static `endpoints[]`, dynamic `discovery`, or hosted-provider metadata such as `base_url`
 - `providers.models[].pricing` supports separate prompt, cached-input, cache-write, and completion rates; omitted `cache_write_per_1m` falls back to `prompt_per_1m`
 - `routing.modelCards[]` holds semantic model metadata, including optional `loras[]` catalogs for decision-level `lora_name` references
 - `routing.projections` carries cross-signal coordination and derived routing outputs

--- a/config/README.md
+++ b/config/README.md
@@ -11,7 +11,7 @@
 Inside canonical `config.yaml`:
 
 - `providers.defaults` holds provider-wide defaults such as `default_model` and reasoning families
-- `providers.models[]` holds concrete backend access details directly
+- `providers.models[]` holds concrete backend access details directly, including optional `backend_id` and `engine_kind` identity hints on each `backend_refs[]` entry
 - `providers.models[].pricing` supports separate prompt, cached-input, cache-write, and completion rates; omitted `cache_write_per_1m` falls back to `prompt_per_1m`
 - `routing.modelCards[]` holds semantic model metadata, including optional `loras[]` catalogs for decision-level `lora_name` references
 - `routing.projections` carries cross-signal coordination and derived routing outputs

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,6 +33,8 @@ providers:
         analytics: qwen3-routing
       backend_refs:
         - name: local-primary
+          backend_id: qwen3-8b-local-primary
+          engine_kind: vllm
           endpoint: 127.0.0.1:8000
           protocol: http
           weight: 80

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,14 +32,30 @@ providers:
         openai: qwen3-8b
         analytics: qwen3-routing
       backend_refs:
-        - name: local-primary
-          backend_id: qwen3-8b-local-primary
-          engine_kind: vllm
-          endpoint: 127.0.0.1:8000
+        - name: local-vllm
+          runtime: vllm
           protocol: http
-          weight: 80
           type: chat
           api_key_env: VLLM_SR_PRIMARY_API_KEY
+          endpoints:
+            - name: primary-a
+              endpoint: 127.0.0.1:8000
+              metrics_endpoint: 127.0.0.1:9000
+              weight: 80
+            - name: primary-b
+              endpoint: 127.0.0.1:8001
+              metrics_endpoint: 127.0.0.1:9001
+              weight: 20
+        - name: k8s-vllm
+          runtime: vllm
+          protocol: http
+          discovery:
+            type: kubernetes
+            kubernetes:
+              service: qwen3-vllm
+              namespace: inference
+              endpoint_port: http
+              metrics_port: metrics
         - name: remote-secondary
           base_url: https://api.example.com/v1
           provider: openai
@@ -51,6 +67,10 @@ providers:
           chat_path: /chat/completions
           api_key: static-demo-key
           weight: 20
+        - name: compat-singleton
+          endpoint: 127.0.0.1:8010
+          protocol: http
+          weight: 1
     - name: qwen3-32b
       reasoning_family: gpt
       provider_model_id: qwen3-32b-instruct
@@ -64,9 +84,12 @@ providers:
         internal: qwen3-32b
       backend_refs:
         - name: large-primary
-          endpoint: 127.0.0.1:8001
+          runtime: vllm
           protocol: http
-          weight: 100
+          endpoints:
+            - name: primary-a
+              endpoint: 127.0.0.1:8001
+              weight: 100
     - name: llava-omni
       provider_model_id: llava-omni-preview
       api_format: openai
@@ -79,9 +102,12 @@ providers:
         openai: llava-omni-preview
       backend_refs:
         - name: omni-primary
-          endpoint: 127.0.0.1:8002
+          runtime: vllm
           protocol: http
-          weight: 100
+          endpoints:
+            - name: primary-a
+              endpoint: 127.0.0.1:8002
+              weight: 100
     - name: sdxl-image
       provider_model_id: sdxl-image
       api_format: openai
@@ -93,9 +119,12 @@ providers:
         openai: gpt-image-1
       backend_refs:
         - name: image-primary
-          endpoint: 127.0.0.1:8003
+          runtime: vllm
           protocol: http
-          weight: 100
+          endpoints:
+            - name: primary-a
+              endpoint: 127.0.0.1:8003
+              weight: 100
 
 routing:
   modelCards:

--- a/dashboard/frontend/src/pages/configPageCanonicalization.ts
+++ b/dashboard/frontend/src/pages/configPageCanonicalization.ts
@@ -169,7 +169,7 @@ const buildLegacyBackendCatalog = (cfg: ConfigData): Record<string, BackendRefEn
       continue
     }
 
-    const backendRef: BackendRefEntry = { name }
+    const backendRef: BackendRefEntry = { name: endpoint.backend_ref?.trim() || name }
     const profileName =
       typeof endpoint.provider_profile === 'string' ? endpoint.provider_profile.trim() : ''
     const profile = profileName ? asRecord(providerProfiles[profileName]) : undefined
@@ -186,16 +186,22 @@ const buildLegacyBackendCatalog = (cfg: ConfigData): Record<string, BackendRefEn
 
     const address = endpoint.address?.trim()
     if (address) {
-      backendRef.endpoint = endpoint.port > 0 ? `${address}:${endpoint.port}` : address
+      backendRef.endpoints = [{
+        name,
+        endpoint: endpoint.port > 0 ? `${address}:${endpoint.port}` : address,
+        metrics_endpoint: endpoint.metrics_endpoint,
+        protocol: endpoint.protocol,
+        weight: endpoint.weight,
+      }]
     }
     if (endpoint.protocol) {
       backendRef.protocol = endpoint.protocol
     }
-    if (endpoint.backend_id) {
-      backendRef.backend_id = endpoint.backend_id
-    }
-    if (endpoint.engine_kind) {
-      backendRef.engine_kind = endpoint.engine_kind
+    const runtime = endpoint.runtime
+    if (runtime) {
+      backendRef.runtime = runtime
+    } else if (backendRef.endpoints?.length) {
+      backendRef.runtime = 'vllm'
     }
     if (typeof endpoint.weight === 'number') {
       backendRef.weight = endpoint.weight

--- a/dashboard/frontend/src/pages/configPageCanonicalization.ts
+++ b/dashboard/frontend/src/pages/configPageCanonicalization.ts
@@ -191,6 +191,12 @@ const buildLegacyBackendCatalog = (cfg: ConfigData): Record<string, BackendRefEn
     if (endpoint.protocol) {
       backendRef.protocol = endpoint.protocol
     }
+    if (endpoint.backend_id) {
+      backendRef.backend_id = endpoint.backend_id
+    }
+    if (endpoint.engine_kind) {
+      backendRef.engine_kind = endpoint.engine_kind
+    }
     if (typeof endpoint.weight === 'number') {
       backendRef.weight = endpoint.weight
     }

--- a/dashboard/frontend/src/pages/configPageModelFormSupport.ts
+++ b/dashboard/frontend/src/pages/configPageModelFormSupport.ts
@@ -1,4 +1,6 @@
 import type {
+  BackendDiscoveryEntry,
+  BackendEndpointEntry,
   BackendRefEntry,
   ConfigData,
   LoRAAdapter,
@@ -27,9 +29,12 @@ export function normalizeModelBackendRefs(value: unknown): BackendRefEntry[] {
     .map((entry) => {
       const normalized: BackendRefEntry = {}
       if (typeof entry.name === 'string' && entry.name.trim()) normalized.name = entry.name.trim()
-      if (typeof entry.backend_id === 'string' && entry.backend_id.trim()) normalized.backend_id = entry.backend_id.trim()
-      if (typeof entry.engine_kind === 'string' && entry.engine_kind.trim()) normalized.engine_kind = entry.engine_kind.trim()
+      if (typeof entry.runtime === 'string' && entry.runtime.trim()) normalized.runtime = entry.runtime.trim()
       if (typeof entry.endpoint === 'string' && entry.endpoint.trim()) normalized.endpoint = entry.endpoint.trim()
+      const endpoints = normalizeBackendEndpointEntries(entry.endpoints)
+      if (endpoints.length > 0) normalized.endpoints = endpoints
+      const discovery = normalizeBackendDiscovery(entry.discovery)
+      if (discovery) normalized.discovery = discovery
       if (entry.protocol === 'https') normalized.protocol = 'https'
       else if (entry.protocol === 'http') normalized.protocol = 'http'
       if (typeof entry.weight === 'number' && Number.isFinite(entry.weight)) normalized.weight = entry.weight
@@ -51,6 +56,43 @@ export function normalizeModelBackendRefs(value: unknown): BackendRefEntry[] {
       if (typeof entry.api_key_env === 'string' && entry.api_key_env.trim()) normalized.api_key_env = entry.api_key_env.trim()
       return normalized
     })
+}
+
+function normalizeBackendEndpointEntries(value: unknown): BackendEndpointEntry[] {
+  if (!Array.isArray(value)) return []
+
+  return value
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === 'object' && !Array.isArray(entry))
+    .map((entry) => {
+      const normalized: BackendEndpointEntry = {}
+      if (typeof entry.name === 'string' && entry.name.trim()) normalized.name = entry.name.trim()
+      if (typeof entry.endpoint === 'string' && entry.endpoint.trim()) normalized.endpoint = entry.endpoint.trim()
+      if (typeof entry.metrics_endpoint === 'string' && entry.metrics_endpoint.trim()) normalized.metrics_endpoint = entry.metrics_endpoint.trim()
+      if (entry.protocol === 'https') normalized.protocol = 'https'
+      else if (entry.protocol === 'http') normalized.protocol = 'http'
+      if (typeof entry.weight === 'number' && Number.isFinite(entry.weight)) normalized.weight = entry.weight
+      const labels = normalizeModelStringMap(entry.labels)
+      if (labels) normalized.labels = labels
+      return normalized
+    })
+}
+
+function normalizeBackendDiscovery(value: unknown): BackendDiscoveryEntry | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+
+  const raw = value as Record<string, unknown>
+  const discovery: BackendDiscoveryEntry = {}
+  if (typeof raw.type === 'string' && raw.type.trim()) discovery.type = raw.type.trim()
+  if (raw.kubernetes && typeof raw.kubernetes === 'object' && !Array.isArray(raw.kubernetes)) {
+    const kubernetes = raw.kubernetes as Record<string, unknown>
+    const normalizedKubernetes: NonNullable<BackendDiscoveryEntry['kubernetes']> = {}
+    if (typeof kubernetes.service === 'string' && kubernetes.service.trim()) normalizedKubernetes.service = kubernetes.service.trim()
+    if (typeof kubernetes.namespace === 'string' && kubernetes.namespace.trim()) normalizedKubernetes.namespace = kubernetes.namespace.trim()
+    if (typeof kubernetes.endpoint_port === 'string' && kubernetes.endpoint_port.trim()) normalizedKubernetes.endpoint_port = kubernetes.endpoint_port.trim()
+    if (typeof kubernetes.metrics_port === 'string' && kubernetes.metrics_port.trim()) normalizedKubernetes.metrics_port = kubernetes.metrics_port.trim()
+    if (Object.keys(normalizedKubernetes).length > 0) discovery.kubernetes = normalizedKubernetes
+  }
+  return Object.keys(discovery).length > 0 ? discovery : undefined
 }
 
 export function normalizeModelStringMap(value: unknown): Record<string, string> | undefined {

--- a/dashboard/frontend/src/pages/configPageModelFormSupport.ts
+++ b/dashboard/frontend/src/pages/configPageModelFormSupport.ts
@@ -27,6 +27,8 @@ export function normalizeModelBackendRefs(value: unknown): BackendRefEntry[] {
     .map((entry) => {
       const normalized: BackendRefEntry = {}
       if (typeof entry.name === 'string' && entry.name.trim()) normalized.name = entry.name.trim()
+      if (typeof entry.backend_id === 'string' && entry.backend_id.trim()) normalized.backend_id = entry.backend_id.trim()
+      if (typeof entry.engine_kind === 'string' && entry.engine_kind.trim()) normalized.engine_kind = entry.engine_kind.trim()
       if (typeof entry.endpoint === 'string' && entry.endpoint.trim()) normalized.endpoint = entry.endpoint.trim()
       if (entry.protocol === 'https') normalized.protocol = 'https'
       else if (entry.protocol === 'http') normalized.protocol = 'http'

--- a/dashboard/frontend/src/pages/configPageModelInventory.test.ts
+++ b/dashboard/frontend/src/pages/configPageModelInventory.test.ts
@@ -109,9 +109,11 @@ describe('model inventory filtering', () => {
     expect(() => validateNewModelName('  local/model-001  ', models)).toThrow(/already exists/i)
     expect(validateNewModelName('  local/new-model  ', models)).toBe('local/new-model')
     expect(() => validateModelStructuredFields({ backend_refs: '{broken json' })).toThrow(/json array/i)
-    expect(() => validateModelStructuredFields({ backend_refs: [{}] })).toThrow(/endpoint or base url/i)
+    expect(() => validateModelStructuredFields({ backend_refs: [{}] })).toThrow(/endpoint, endpoints, discovery, or base url/i)
     expect(() => validateModelStructuredFields({ backend_refs: [{ endpoint: 'localhost:8000', protocol: 'grpc' }] })).toThrow(/http or https/i)
     expect(() => validateModelStructuredFields({ backend_refs: [{ endpoint: 'localhost:8000', extra_headers: { valid: 1 } }] })).toThrow(/text key\/value pairs/i)
+    expect(() => validateModelStructuredFields({ backend_refs: [{ runtime: 'vllm', endpoint: 'localhost:8000', endpoints: [{ endpoint: 'localhost:8001' }] }] })).toThrow(/cannot mix legacy endpoint/i)
+    expect(() => validateModelStructuredFields({ backend_refs: [{ endpoints: [{ endpoint: 'localhost:8001' }] }] })).toThrow(/requires runtime/i)
     expect(() => validateModelStructuredFields({ tags: 'premium,fast' })).toThrow(/list of text values/i)
     expect(() => validateModelStructuredFields({ capabilities: 'tools,vision' })).toThrow(/list of text values/i)
     expect(() => validateModelStructuredFields({ loras: [{ description: 'missing name' }] })).toThrow(/requires a name/i)
@@ -125,6 +127,23 @@ describe('model inventory filtering', () => {
       external_model_ids: { openai: 'gpt-4.1' },
       tags: ['premium', 'fast'],
       pricing: { currency: 'USD', prompt_per_1m: 0.5 },
+    })).not.toThrow()
+    expect(() => validateModelStructuredFields({
+      backend_refs: [{
+        name: 'local-vllm',
+        runtime: 'vllm',
+        endpoints: [{ name: 'primary-a', endpoint: 'localhost:8000', weight: 80 }],
+      }],
+    })).not.toThrow()
+    expect(() => validateModelStructuredFields({
+      backend_refs: [{
+        name: 'k8s-vllm',
+        runtime: 'vllm',
+        discovery: {
+          type: 'kubernetes',
+          kubernetes: { service: 'qwen3-vllm', namespace: 'inference', endpoint_port: 'http' },
+        },
+      }],
     })).not.toThrow()
   })
 })

--- a/dashboard/frontend/src/pages/configPageModelInventory.ts
+++ b/dashboard/frontend/src/pages/configPageModelInventory.ts
@@ -23,7 +23,7 @@ function searchableModelValues(model: NormalizedModel): string[] {
     ...(model.tags ?? []),
     ...(model.capabilities ?? []),
     ...(model.endpoints ?? []).flatMap((endpoint) => [endpoint.name, endpoint.protocol]),
-    ...(model.backend_refs ?? []).flatMap((backend) => [backend.name, backend.provider, backend.type]),
+    ...(model.backend_refs ?? []).flatMap((backend) => [backend.name, backend.runtime, backend.provider, backend.type, backend.discovery?.type]),
   ].filter((value): value is string => typeof value === 'string' && value.length > 0)
 }
 
@@ -195,11 +195,69 @@ export function validateModelStructuredFields(data: Record<string, unknown>): vo
       const backend = value as Record<string, unknown>
       const endpoint = typeof backend.endpoint === 'string' ? backend.endpoint.trim() : ''
       const baseUrl = typeof backend.base_url === 'string' ? backend.base_url.trim() : ''
-      if (!endpoint && !baseUrl) {
-        throw new Error(`Provider backend ${index + 1} requires an endpoint or base URL.`)
+      const staticEndpoints = Array.isArray(backend.endpoints) ? backend.endpoints : []
+      const discovery = backend.discovery && typeof backend.discovery === 'object' && !Array.isArray(backend.discovery)
+        ? backend.discovery as Record<string, unknown>
+        : undefined
+      if (endpoint && (staticEndpoints.length > 0 || discovery)) {
+        throw new Error(`Provider backend ${index + 1} cannot mix legacy endpoint with endpoints or discovery.`)
+      }
+      if (staticEndpoints.length > 0 && discovery) {
+        throw new Error(`Provider backend ${index + 1} cannot define both endpoints and discovery.`)
+      }
+      if ((staticEndpoints.length > 0 || discovery) && (typeof backend.runtime !== 'string' || !backend.runtime.trim())) {
+        throw new Error(`Provider backend ${index + 1} requires runtime when endpoints or discovery are configured.`)
+      }
+      if (!endpoint && !baseUrl && staticEndpoints.length === 0 && !discovery) {
+        throw new Error(`Provider backend ${index + 1} requires an endpoint, endpoints, discovery, or base URL.`)
       }
       if (backend.protocol !== undefined && backend.protocol !== 'http' && backend.protocol !== 'https') {
         throw new Error(`Provider backend ${index + 1} protocol must be HTTP or HTTPS.`)
+      }
+      staticEndpoints.forEach((member, memberIndex) => {
+        if (!member || typeof member !== 'object' || Array.isArray(member)) {
+          throw new Error(`Provider backend ${index + 1} endpoint ${memberIndex + 1} must be a structured object.`)
+        }
+        const staticEndpoint = member as Record<string, unknown>
+        if (typeof staticEndpoint.endpoint !== 'string' || !staticEndpoint.endpoint.trim()) {
+          throw new Error(`Provider backend ${index + 1} endpoint ${memberIndex + 1} requires an endpoint.`)
+        }
+        if (staticEndpoint.protocol !== undefined && staticEndpoint.protocol !== 'http' && staticEndpoint.protocol !== 'https') {
+          throw new Error(`Provider backend ${index + 1} endpoint ${memberIndex + 1} protocol must be HTTP or HTTPS.`)
+        }
+        if (staticEndpoint.weight !== undefined && (
+          typeof staticEndpoint.weight !== 'number'
+          || !Number.isFinite(staticEndpoint.weight)
+          || staticEndpoint.weight < 0
+        )) {
+          throw new Error(`Provider backend ${index + 1} endpoint ${memberIndex + 1} weight must be zero or greater.`)
+        }
+        if (staticEndpoint.labels !== undefined && (
+          !staticEndpoint.labels
+          || typeof staticEndpoint.labels !== 'object'
+          || Array.isArray(staticEndpoint.labels)
+          || Object.values(staticEndpoint.labels).some((labelValue) => typeof labelValue !== 'string')
+        )) {
+          throw new Error(`Provider backend ${index + 1} endpoint ${memberIndex + 1} labels must contain text key/value pairs.`)
+        }
+      })
+      if (discovery) {
+        if (typeof discovery.type !== 'string' || !discovery.type.trim()) {
+          throw new Error(`Provider backend ${index + 1} discovery requires a type.`)
+        }
+        if (discovery.type === 'kubernetes') {
+          const kubernetes = discovery.kubernetes && typeof discovery.kubernetes === 'object' && !Array.isArray(discovery.kubernetes)
+            ? discovery.kubernetes as Record<string, unknown>
+            : undefined
+          if (!kubernetes) {
+            throw new Error(`Provider backend ${index + 1} Kubernetes discovery requires kubernetes settings.`)
+          }
+          for (const field of ['service', 'namespace', 'endpoint_port']) {
+            if (typeof kubernetes[field] !== 'string' || !(kubernetes[field] as string).trim()) {
+              throw new Error(`Provider backend ${index + 1} Kubernetes discovery requires ${field}.`)
+            }
+          }
+        }
       }
       if (backend.weight !== undefined && (
         typeof backend.weight !== 'number'

--- a/dashboard/frontend/src/pages/configPageModelStructuredEditors.tsx
+++ b/dashboard/frontend/src/pages/configPageModelStructuredEditors.tsx
@@ -15,6 +15,8 @@ interface StructuredModelFieldProps {
 
 const backendRefFields: ObjectEditorField<BackendRefEntry>[] = [
   { key: 'name', label: 'Reference name', placeholder: 'local-primary' },
+  { key: 'backend_id', label: 'Backend ID', placeholder: 'pod-a-0' },
+  { key: 'engine_kind', label: 'Engine kind', placeholder: 'vllm' },
   { key: 'type', label: 'Backend type', placeholder: 'chat' },
   { key: 'endpoint', label: 'Endpoint', placeholder: '127.0.0.1:8000', fullWidth: true },
   {

--- a/dashboard/frontend/src/pages/configPageModelStructuredEditors.tsx
+++ b/dashboard/frontend/src/pages/configPageModelStructuredEditors.tsx
@@ -15,8 +15,7 @@ interface StructuredModelFieldProps {
 
 const backendRefFields: ObjectEditorField<BackendRefEntry>[] = [
   { key: 'name', label: 'Reference name', placeholder: 'local-primary' },
-  { key: 'backend_id', label: 'Backend ID', placeholder: 'pod-a-0' },
-  { key: 'engine_kind', label: 'Engine kind', placeholder: 'vllm' },
+  { key: 'runtime', label: 'Runtime', placeholder: 'vllm' },
   { key: 'type', label: 'Backend type', placeholder: 'chat' },
   { key: 'endpoint', label: 'Endpoint', placeholder: '127.0.0.1:8000', fullWidth: true },
   {
@@ -105,17 +104,45 @@ function backendRefLabel(item: BackendRefEntry, index: number): string {
 }
 
 function backendRefDescription(item: BackendRefEntry): string | undefined {
+  if (Array.isArray(item.endpoints) && item.endpoints.length > 0) {
+    return `${item.endpoints.length} static endpoint${item.endpoints.length === 1 ? '' : 's'}`
+  }
+  if (item.discovery?.type) {
+    return `${item.discovery.type} discovery`
+  }
   return item.endpoint?.trim() || item.base_url?.trim() || 'Target required'
 }
 
 function validateBackendRef(item: BackendRefEntry): string[] {
   const errors: string[] = []
-  if (!item.endpoint?.trim() && !item.base_url?.trim()) {
-    errors.push('Provide an endpoint or base URL.')
+  const hasStaticEndpoints = Array.isArray(item.endpoints) && item.endpoints.length > 0
+  const hasDiscovery = Boolean(item.discovery?.type)
+  if (hasStaticEndpoints && hasDiscovery) {
+    errors.push('Use static endpoints or discovery, not both.')
+  }
+  if (item.endpoint?.trim() && (hasStaticEndpoints || hasDiscovery)) {
+    errors.push('Do not mix the legacy endpoint field with endpoints or discovery.')
+  }
+  if ((hasStaticEndpoints || hasDiscovery) && !item.runtime?.trim()) {
+    errors.push('Runtime is required for endpoints or discovery.')
+  }
+  if (!item.endpoint?.trim() && !item.base_url?.trim() && !hasStaticEndpoints && !hasDiscovery) {
+    errors.push('Provide an endpoint, static endpoints, discovery, or base URL.')
   }
   if (item.protocol && item.protocol !== 'http' && item.protocol !== 'https') {
     errors.push('Protocol must be HTTP or HTTPS.')
   }
+  item.endpoints?.forEach((endpoint, index) => {
+    if (!endpoint.endpoint?.trim()) {
+      errors.push(`Static endpoint ${index + 1} requires an endpoint.`)
+    }
+    if (endpoint.protocol && endpoint.protocol !== 'http' && endpoint.protocol !== 'https') {
+      errors.push(`Static endpoint ${index + 1} protocol must be HTTP or HTTPS.`)
+    }
+    if (endpoint.weight !== undefined && (!Number.isFinite(endpoint.weight) || endpoint.weight < 0)) {
+      errors.push(`Static endpoint ${index + 1} weight must be zero or greater.`)
+    }
+  })
   if (item.weight !== undefined && (!Number.isFinite(item.weight) || item.weight < 0)) {
     errors.push('Traffic weight must be zero or greater.')
   }

--- a/dashboard/frontend/src/pages/configPageSupport.ts
+++ b/dashboard/frontend/src/pages/configPageSupport.ts
@@ -10,6 +10,8 @@ export interface ListenerConfig {
 
 export interface VLLMEndpoint {
   name: string
+  backend_id?: string
+  engine_kind?: string
   address: string
   port: number
   weight: number
@@ -134,6 +136,8 @@ export interface ModelConfigEntry {
 
 export interface BackendRefEntry {
   name?: string
+  backend_id?: string
+  engine_kind?: string
   endpoint?: string
   protocol?: 'http' | 'https'
   weight?: number

--- a/dashboard/frontend/src/pages/configPageSupport.ts
+++ b/dashboard/frontend/src/pages/configPageSupport.ts
@@ -10,10 +10,11 @@ export interface ListenerConfig {
 
 export interface VLLMEndpoint {
   name: string
-  backend_id?: string
-  engine_kind?: string
+  backend_ref?: string
+  runtime?: string
   address: string
   port: number
+  metrics_endpoint?: string
   weight: number
   health_check_path: string
   protocol?: 'http' | 'https'
@@ -120,6 +121,7 @@ export interface ModelConfigEntry {
   model_id?: string
   reasoning_family?: string
   preferred_endpoints?: string[]
+  backend_refs?: BackendRefEntry[]
   access_key?: string
   pricing?: ModelPricing
   api_format?: string
@@ -134,11 +136,31 @@ export interface ModelConfigEntry {
   modality?: string
 }
 
+export interface BackendEndpointEntry {
+  name?: string
+  endpoint?: string
+  metrics_endpoint?: string
+  protocol?: 'http' | 'https'
+  weight?: number
+  labels?: Record<string, string>
+}
+
+export interface BackendDiscoveryEntry {
+  type?: string
+  kubernetes?: {
+    service?: string
+    namespace?: string
+    endpoint_port?: string
+    metrics_port?: string
+  }
+}
+
 export interface BackendRefEntry {
   name?: string
-  backend_id?: string
-  engine_kind?: string
+  runtime?: string
   endpoint?: string
+  endpoints?: BackendEndpointEntry[]
+  discovery?: BackendDiscoveryEntry
   protocol?: 'http' | 'https'
   weight?: number
   type?: string
@@ -1287,12 +1309,31 @@ export const normalizeProviderModelEndpoints = (
   }
 ): Endpoint[] => {
   if (Array.isArray(model.backend_refs) && model.backend_refs.length > 0) {
-    return model.backend_refs.map((backend, index) => {
+    return model.backend_refs.flatMap((backend, index) => {
+      if (Array.isArray(backend.endpoints) && backend.endpoints.length > 0) {
+        return backend.endpoints.map((member, memberIndex) => normalizeEndpoint({
+          name: member.name || backend.name,
+          endpoint: member.endpoint || '',
+          protocol: member.protocol || backend.protocol,
+          weight: member.weight ?? backend.weight,
+        }, memberIndex))
+      }
+      if (backend.discovery?.type) {
+        return [normalizeEndpoint({
+          name: backend.name,
+          endpoint: `${backend.discovery.type} discovery`,
+          protocol: backend.protocol,
+          weight: backend.weight,
+        }, index)]
+      }
       const baseURL = typeof backend.base_url === 'string' ? backend.base_url.trim() : ''
       const endpoint =
         typeof backend.endpoint === 'string' && backend.endpoint.trim()
           ? backend.endpoint.trim()
           : baseURL
+      if (!endpoint) {
+        return []
+      }
       const protocol =
         backend.protocol ||
         (baseURL.startsWith('https://') ? 'https' : 'http')

--- a/dashboard/frontend/src/pages/setupWizardSupport.ts
+++ b/dashboard/frontend/src/pages/setupWizardSupport.ts
@@ -53,7 +53,14 @@ interface BuiltModel {
   backend_refs: Array<{
     name: string;
     weight: number;
+    runtime?: string;
     endpoint?: string;
+    endpoints?: Array<{
+      name?: string;
+      endpoint: string;
+      protocol?: "http" | "https";
+      weight?: number;
+    }>;
     protocol: "http" | "https";
     base_url?: string;
     provider?: "openai" | "anthropic";
@@ -561,9 +568,16 @@ export function buildSetupConfig(
       model.providerKind === "vllm"
         ? {
             name: endpointName,
+            runtime: "vllm",
             weight: 100,
-            endpoint,
             protocol,
+            endpoints: [
+              {
+                name: "primary-a",
+                endpoint,
+                weight: 100,
+              },
+            ],
             api_key: apiKey,
           }
         : {

--- a/dashboard/frontend/src/types/config.ts
+++ b/dashboard/frontend/src/types/config.ts
@@ -14,15 +14,35 @@
 
 export interface ProviderEndpoint {
   name: string
-  backend_id?: string
-  engine_kind?: string
+  runtime?: string
   weight: number
-  endpoint: string  // e.g., "host.docker.internal:8000" or "api.openai.com"
+  endpoint?: string  // legacy singleton, e.g. "host.docker.internal:8000"
+  endpoints?: ProviderBackendEndpoint[]
+  discovery?: ProviderBackendDiscovery
   protocol: 'http' | 'https'
   base_url?: string
   provider?: 'openai' | 'anthropic'
   api_key?: string
   api_key_env?: string
+}
+
+export interface ProviderBackendEndpoint {
+  name?: string
+  endpoint?: string
+  metrics_endpoint?: string
+  protocol?: 'http' | 'https'
+  weight?: number
+  labels?: Record<string, string>
+}
+
+export interface ProviderBackendDiscovery {
+  type: string
+  kubernetes?: {
+    service: string
+    namespace: string
+    endpoint_port: string
+    metrics_port?: string
+  }
 }
 
 export interface ProviderModel {
@@ -300,8 +320,8 @@ export interface PythonCLIConfig {
 
 export interface LegacyVLLMEndpoint {
   name: string
-  backend_id?: string
-  engine_kind?: string
+  backend_ref?: string
+  runtime?: string
   address: string
   port: number
   weight: number

--- a/dashboard/frontend/src/types/config.ts
+++ b/dashboard/frontend/src/types/config.ts
@@ -14,6 +14,8 @@
 
 export interface ProviderEndpoint {
   name: string
+  backend_id?: string
+  engine_kind?: string
   weight: number
   endpoint: string  // e.g., "host.docker.internal:8000" or "api.openai.com"
   protocol: 'http' | 'https'
@@ -298,6 +300,8 @@ export interface PythonCLIConfig {
 
 export interface LegacyVLLMEndpoint {
   name: string
+  backend_id?: string
+  engine_kind?: string
   address: string
   port: number
   weight: number

--- a/src/semantic-router/pkg/backend/policy.go
+++ b/src/semantic-router/pkg/backend/policy.go
@@ -1,0 +1,275 @@
+package backend
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+const (
+	PolicyReasonSelectedFreshTelemetry = "fresh_selectable_telemetry"
+
+	FallbackReasonMissingTelemetry    = "missing_telemetry"
+	FallbackReasonStaleTelemetry      = "stale_telemetry"
+	FallbackReasonAllUnhealthy        = "all_unhealthy"
+	FallbackReasonNoBackendCandidates = "no_backend_candidates"
+)
+
+type policyOption struct {
+	candidate BackendCandidate
+	telemetry BackendTelemetry
+}
+
+type candidateEvaluation struct {
+	option         policyOption
+	selectable     bool
+	missing        bool
+	stale          bool
+	fresh          bool
+	telemetryAgeMS int64
+	unhealthyCount int
+}
+
+// SelectBackendCandidate applies a minimal second-stage backend policy. It only
+// selects when at least one candidate has fresh, selectable telemetry; otherwise
+// it fails open so existing model/backend routing can continue unchanged.
+func SelectBackendCandidate(modelName string, candidates []BackendCandidate, store *Store) BackendPolicyResult {
+	if store == nil {
+		store = defaultStore
+	}
+
+	diag := BackendPolicyDiagnostics{
+		SelectedModel:  modelName,
+		CandidateCount: len(candidates),
+	}
+	if len(candidates) == 0 {
+		return failOpenResult(diag, FallbackReasonNoBackendCandidates)
+	}
+
+	options := []policyOption{}
+	missingCount := 0
+	staleCount := 0
+	unhealthyCount := 0
+
+	for _, candidate := range candidates {
+		evaluation := evaluateCandidate(modelName, candidate, store)
+		if evaluation.missing {
+			missingCount++
+			continue
+		}
+		if evaluation.stale {
+			staleCount++
+			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
+			continue
+		}
+		if evaluation.fresh {
+			diag.FreshCandidateCount++
+			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
+		}
+		unhealthyCount += evaluation.unhealthyCount
+		if !evaluation.selectable {
+			continue
+		}
+		options = append(options, evaluation.option)
+	}
+
+	diag.UnhealthyCount = unhealthyCount
+	diag.TelemetryFresh = diag.FreshCandidateCount > 0
+	if len(options) == 0 {
+		return failOpenResult(diag, fallbackReasonForEmptyPolicy(candidates, missingCount, staleCount, unhealthyCount))
+	}
+
+	sort.Slice(options, func(i, j int) bool {
+		return policyOptionLess(options[i], options[j])
+	})
+	selected := options[0]
+	age := store.Age(selected.telemetry)
+	diag.SelectedBackendID = selected.candidate.BackendID
+	diag.SelectedReplicaID = selected.telemetry.Identity.ReplicaID
+	diag.TelemetryFresh = true
+	diag.TelemetryAgeMS = age.Milliseconds()
+	diag.PolicyReason = PolicyReasonSelectedFreshTelemetry
+
+	return BackendPolicyResult{
+		SelectedBackendID: selected.candidate.BackendID,
+		SelectedReplicaID: selected.telemetry.Identity.ReplicaID,
+		FailOpen:          false,
+		Reason:            PolicyReasonSelectedFreshTelemetry,
+		Diagnostics:       diag,
+	}
+}
+
+func evaluateCandidate(modelName string, candidate BackendCandidate, store *Store) candidateEvaluation {
+	candidate = normalizeCandidate(modelName, candidate)
+	if candidate.BackendID == "" || candidate.ModelName == "" {
+		return candidateEvaluation{missing: true}
+	}
+
+	rawTelemetry := store.ListByBackend(candidate.ModelName, candidate.BackendID)
+	if candidate.ReplicaID != "" {
+		rawTelemetry = filterTelemetryByReplica(rawTelemetry, candidate.ReplicaID)
+	}
+	if len(rawTelemetry) == 0 {
+		return candidateEvaluation{missing: true}
+	}
+
+	freshTelemetry := filterFreshTelemetry(rawTelemetry, store)
+	if len(freshTelemetry) == 0 {
+		return candidateEvaluation{stale: true, telemetryAgeMS: telemetryAgeMS(rawTelemetry, store)}
+	}
+
+	selectableTelemetry, unhealthyCount := filterSelectableTelemetry(freshTelemetry)
+	if len(selectableTelemetry) == 0 {
+		return candidateEvaluation{fresh: true, telemetryAgeMS: telemetryAgeMS(freshTelemetry, store), unhealthyCount: unhealthyCount}
+	}
+
+	sort.Slice(selectableTelemetry, func(i, j int) bool {
+		return telemetryLess(selectableTelemetry[i], selectableTelemetry[j])
+	})
+	return candidateEvaluation{
+		option:         policyOption{candidate: candidate, telemetry: selectableTelemetry[0]},
+		selectable:     true,
+		fresh:          true,
+		telemetryAgeMS: telemetryAgeMS(selectableTelemetry, store),
+		unhealthyCount: unhealthyCount,
+	}
+}
+
+func filterFreshTelemetry(items []BackendTelemetry, store *Store) []BackendTelemetry {
+	fresh := make([]BackendTelemetry, 0, len(items))
+	for _, telemetry := range items {
+		if store.IsFresh(telemetry) {
+			fresh = append(fresh, telemetry)
+		}
+	}
+	return fresh
+}
+
+func filterSelectableTelemetry(items []BackendTelemetry) ([]BackendTelemetry, int) {
+	selectable := make([]BackendTelemetry, 0, len(items))
+	unhealthyCount := 0
+	for _, telemetry := range items {
+		if isSelectableHealth(telemetry.Health) {
+			selectable = append(selectable, telemetry)
+		} else {
+			unhealthyCount++
+		}
+	}
+	return selectable, unhealthyCount
+}
+
+func failOpenResult(diag BackendPolicyDiagnostics, reason string) BackendPolicyResult {
+	diag.PolicyReason = reason
+	diag.FallbackReason = reason
+	return BackendPolicyResult{
+		FailOpen:    true,
+		Reason:      reason,
+		Diagnostics: diag,
+	}
+}
+
+func normalizeCandidate(modelName string, candidate BackendCandidate) BackendCandidate {
+	candidate.BackendID = strings.TrimSpace(candidate.BackendID)
+	candidate.ReplicaID = strings.TrimSpace(candidate.ReplicaID)
+	candidate.ModelName = strings.TrimSpace(candidate.ModelName)
+	candidate.EndpointName = strings.TrimSpace(candidate.EndpointName)
+	if candidate.ModelName == "" {
+		candidate.ModelName = strings.TrimSpace(modelName)
+	}
+	if candidate.BackendID == "" {
+		candidate.BackendID = candidate.EndpointName
+	}
+	return candidate
+}
+
+func filterTelemetryByReplica(items []BackendTelemetry, replicaID string) []BackendTelemetry {
+	filtered := make([]BackendTelemetry, 0, len(items))
+	for _, telemetry := range items {
+		if telemetry.Identity.ReplicaID == replicaID {
+			filtered = append(filtered, telemetry)
+		}
+	}
+	return filtered
+}
+
+func fallbackReasonForEmptyPolicy(candidates []BackendCandidate, missingCount, staleCount, unhealthyCount int) string {
+	if unhealthyCount > 0 && unhealthyCount == len(candidates) {
+		return FallbackReasonAllUnhealthy
+	}
+	if staleCount > 0 {
+		return FallbackReasonStaleTelemetry
+	}
+	if missingCount > 0 {
+		return FallbackReasonMissingTelemetry
+	}
+	if unhealthyCount > 0 {
+		return FallbackReasonAllUnhealthy
+	}
+	return FallbackReasonMissingTelemetry
+}
+
+func policyOptionLess(a, b policyOption) bool {
+	aQueue := intValue(a.telemetry.QueueDepth)
+	bQueue := intValue(b.telemetry.QueueDepth)
+	if aQueue != bQueue {
+		return aQueue < bQueue
+	}
+	aActive := intValue(a.telemetry.ActiveRequests)
+	bActive := intValue(b.telemetry.ActiveRequests)
+	if aActive != bActive {
+		return aActive < bActive
+	}
+	if a.candidate.Weight != b.candidate.Weight {
+		return a.candidate.Weight > b.candidate.Weight
+	}
+	if a.candidate.BackendID != b.candidate.BackendID {
+		return a.candidate.BackendID < b.candidate.BackendID
+	}
+	return a.telemetry.Identity.ReplicaID < b.telemetry.Identity.ReplicaID
+}
+
+func telemetryLess(a, b BackendTelemetry) bool {
+	aQueue := intValue(a.QueueDepth)
+	bQueue := intValue(b.QueueDepth)
+	if aQueue != bQueue {
+		return aQueue < bQueue
+	}
+	aActive := intValue(a.ActiveRequests)
+	bActive := intValue(b.ActiveRequests)
+	if aActive != bActive {
+		return aActive < bActive
+	}
+	if a.Identity.BackendID != b.Identity.BackendID {
+		return a.Identity.BackendID < b.Identity.BackendID
+	}
+	return a.Identity.ReplicaID < b.Identity.ReplicaID
+}
+
+func intValue(value *int) int {
+	if value == nil {
+		return math.MaxInt
+	}
+	return *value
+}
+
+func telemetryAgeMS(items []BackendTelemetry, store *Store) int64 {
+	var maxAge int64
+	for _, telemetry := range items {
+		maxAge = maxInt64(maxAge, store.Age(telemetry).Milliseconds())
+	}
+	return maxAge
+}
+
+func maxInt64(a, b int64) int64 {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+func isSelectableHealth(health HealthState) bool {
+	// The contract layer only rejects explicit unhealthy telemetry. Missing,
+	// unknown, or degraded health remains selectable so new adapters can fail
+	// open while they converge on richer engine-specific health mapping.
+	return health == "" || health == HealthStateUnknown || health == HealthStateHealthy || health == HealthStateDegraded
+}

--- a/src/semantic-router/pkg/backend/policy.go
+++ b/src/semantic-router/pkg/backend/policy.go
@@ -20,14 +20,19 @@ type policyOption struct {
 	telemetry BackendTelemetry
 }
 
+type candidateStatus int
+
+const (
+	candidateMissing candidateStatus = iota
+	candidateStale
+	candidateUnhealthy
+	candidateSelectable
+)
+
 type candidateEvaluation struct {
 	option         policyOption
-	selectable     bool
-	missing        bool
-	stale          bool
-	fresh          bool
+	status         candidateStatus
 	telemetryAgeMS int64
-	unhealthyCount int
 }
 
 // SelectBackendCandidate applies a minimal second-stage backend policy. It only
@@ -49,34 +54,34 @@ func SelectBackendCandidate(modelName string, candidates []BackendCandidate, sto
 	options := []policyOption{}
 	missingCount := 0
 	staleCount := 0
-	unhealthyCount := 0
+	unhealthyCandidateCount := 0
 
 	for _, candidate := range candidates {
 		evaluation := evaluateCandidate(modelName, candidate, store)
-		if evaluation.missing {
+		switch evaluation.status {
+		case candidateMissing:
 			missingCount++
 			continue
-		}
-		if evaluation.stale {
+		case candidateStale:
 			staleCount++
 			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
 			continue
-		}
-		if evaluation.fresh {
+		case candidateUnhealthy:
 			diag.FreshCandidateCount++
 			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
-		}
-		unhealthyCount += evaluation.unhealthyCount
-		if !evaluation.selectable {
+			unhealthyCandidateCount++
 			continue
+		case candidateSelectable:
+			diag.FreshCandidateCount++
+			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
+			options = append(options, evaluation.option)
 		}
-		options = append(options, evaluation.option)
 	}
 
-	diag.UnhealthyCount = unhealthyCount
+	diag.UnhealthyCount = unhealthyCandidateCount
 	diag.TelemetryFresh = diag.FreshCandidateCount > 0
 	if len(options) == 0 {
-		return failOpenResult(diag, fallbackReasonForEmptyPolicy(candidates, missingCount, staleCount, unhealthyCount))
+		return failOpenResult(diag, fallbackReasonForEmptyPolicy(len(candidates), missingCount, staleCount, unhealthyCandidateCount))
 	}
 
 	sort.Slice(options, func(i, j int) bool {
@@ -102,7 +107,7 @@ func SelectBackendCandidate(modelName string, candidates []BackendCandidate, sto
 func evaluateCandidate(modelName string, candidate BackendCandidate, store *Store) candidateEvaluation {
 	candidate = normalizeCandidate(modelName, candidate)
 	if candidate.BackendID == "" || candidate.ModelName == "" {
-		return candidateEvaluation{missing: true}
+		return candidateEvaluation{status: candidateMissing}
 	}
 
 	rawTelemetry := store.ListByBackend(candidate.ModelName, candidate.BackendID)
@@ -110,17 +115,17 @@ func evaluateCandidate(modelName string, candidate BackendCandidate, store *Stor
 		rawTelemetry = filterTelemetryByReplica(rawTelemetry, candidate.ReplicaID)
 	}
 	if len(rawTelemetry) == 0 {
-		return candidateEvaluation{missing: true}
+		return candidateEvaluation{status: candidateMissing}
 	}
 
 	freshTelemetry := filterFreshTelemetry(rawTelemetry, store)
 	if len(freshTelemetry) == 0 {
-		return candidateEvaluation{stale: true, telemetryAgeMS: telemetryAgeMS(rawTelemetry, store)}
+		return candidateEvaluation{status: candidateStale, telemetryAgeMS: telemetryAgeMS(rawTelemetry, store)}
 	}
 
-	selectableTelemetry, unhealthyCount := filterSelectableTelemetry(freshTelemetry)
+	selectableTelemetry := filterSelectableTelemetry(freshTelemetry)
 	if len(selectableTelemetry) == 0 {
-		return candidateEvaluation{fresh: true, telemetryAgeMS: telemetryAgeMS(freshTelemetry, store), unhealthyCount: unhealthyCount}
+		return candidateEvaluation{status: candidateUnhealthy, telemetryAgeMS: telemetryAgeMS(freshTelemetry, store)}
 	}
 
 	sort.Slice(selectableTelemetry, func(i, j int) bool {
@@ -128,10 +133,8 @@ func evaluateCandidate(modelName string, candidate BackendCandidate, store *Stor
 	})
 	return candidateEvaluation{
 		option:         policyOption{candidate: candidate, telemetry: selectableTelemetry[0]},
-		selectable:     true,
-		fresh:          true,
+		status:         candidateSelectable,
 		telemetryAgeMS: telemetryAgeMS(selectableTelemetry, store),
-		unhealthyCount: unhealthyCount,
 	}
 }
 
@@ -145,17 +148,14 @@ func filterFreshTelemetry(items []BackendTelemetry, store *Store) []BackendTelem
 	return fresh
 }
 
-func filterSelectableTelemetry(items []BackendTelemetry) ([]BackendTelemetry, int) {
+func filterSelectableTelemetry(items []BackendTelemetry) []BackendTelemetry {
 	selectable := make([]BackendTelemetry, 0, len(items))
-	unhealthyCount := 0
 	for _, telemetry := range items {
 		if isSelectableHealth(telemetry.Health) {
 			selectable = append(selectable, telemetry)
-		} else {
-			unhealthyCount++
 		}
 	}
-	return selectable, unhealthyCount
+	return selectable
 }
 
 func failOpenResult(diag BackendPolicyDiagnostics, reason string) BackendPolicyResult {
@@ -192,8 +192,8 @@ func filterTelemetryByReplica(items []BackendTelemetry, replicaID string) []Back
 	return filtered
 }
 
-func fallbackReasonForEmptyPolicy(candidates []BackendCandidate, missingCount, staleCount, unhealthyCount int) string {
-	if unhealthyCount > 0 && unhealthyCount == len(candidates) {
+func fallbackReasonForEmptyPolicy(candidateCount, missingCount, staleCount, unhealthyCandidateCount int) string {
+	if unhealthyCandidateCount > 0 && unhealthyCandidateCount == candidateCount {
 		return FallbackReasonAllUnhealthy
 	}
 	if staleCount > 0 {
@@ -202,7 +202,7 @@ func fallbackReasonForEmptyPolicy(candidates []BackendCandidate, missingCount, s
 	if missingCount > 0 {
 		return FallbackReasonMissingTelemetry
 	}
-	if unhealthyCount > 0 {
+	if unhealthyCandidateCount > 0 {
 		return FallbackReasonAllUnhealthy
 	}
 	return FallbackReasonMissingTelemetry

--- a/src/semantic-router/pkg/backend/policy.go
+++ b/src/semantic-router/pkg/backend/policy.go
@@ -76,18 +76,18 @@ func SelectBackendCandidate(modelName string, candidates []BackendCandidate, sto
 	})
 	selected := summary.options[0]
 	age := store.Age(selected.telemetry)
-	diag.SelectedBackendID = selected.candidate.BackendID
+	diag.SelectedBackendRefName = selected.candidate.BackendRefName
 	diag.SelectedReplicaID = selected.telemetry.Identity.ReplicaID
 	diag.TelemetryFresh = true
 	diag.TelemetryAgeMS = age.Milliseconds()
 	diag.PolicyReason = PolicyReasonSelectedFreshTelemetry
 
 	return BackendPolicyResult{
-		SelectedBackendID: selected.candidate.BackendID,
-		SelectedReplicaID: selected.telemetry.Identity.ReplicaID,
-		FailOpen:          false,
-		Reason:            PolicyReasonSelectedFreshTelemetry,
-		Diagnostics:       diag,
+		SelectedBackendRefName: selected.candidate.BackendRefName,
+		SelectedReplicaID:      selected.telemetry.Identity.ReplicaID,
+		FailOpen:               false,
+		Reason:                 PolicyReasonSelectedFreshTelemetry,
+		Diagnostics:            diag,
 	}
 }
 
@@ -122,11 +122,11 @@ func collectPolicyCandidates(modelName string, candidates []BackendCandidate, st
 
 func evaluateCandidate(modelName string, candidate BackendCandidate, store *Store) candidateEvaluation {
 	candidate = normalizeCandidate(modelName, candidate)
-	if candidate.BackendID == "" || candidate.ModelName == "" {
+	if candidate.BackendRefName == "" || candidate.ModelName == "" {
 		return candidateEvaluation{status: candidateMissing}
 	}
 
-	rawTelemetry := store.ListByBackend(candidate.ModelName, candidate.BackendID)
+	rawTelemetry := store.ListByBackend(candidate.ModelName, candidate.BackendRefName)
 	if candidate.ReplicaID != "" {
 		rawTelemetry = filterTelemetryByReplica(rawTelemetry, candidate.ReplicaID)
 	}
@@ -185,15 +185,15 @@ func failOpenResult(diag BackendPolicyDiagnostics, reason string) BackendPolicyR
 }
 
 func normalizeCandidate(modelName string, candidate BackendCandidate) BackendCandidate {
-	candidate.BackendID = strings.TrimSpace(candidate.BackendID)
+	candidate.BackendRefName = strings.TrimSpace(candidate.BackendRefName)
 	candidate.ReplicaID = strings.TrimSpace(candidate.ReplicaID)
 	candidate.ModelName = strings.TrimSpace(candidate.ModelName)
 	candidate.EndpointName = strings.TrimSpace(candidate.EndpointName)
 	if candidate.ModelName == "" {
 		candidate.ModelName = strings.TrimSpace(modelName)
 	}
-	if candidate.BackendID == "" {
-		candidate.BackendID = candidate.EndpointName
+	if candidate.BackendRefName == "" {
+		candidate.BackendRefName = candidate.EndpointName
 	}
 	return candidate
 }
@@ -238,8 +238,8 @@ func policyOptionLess(a, b policyOption) bool {
 	if a.candidate.Weight != b.candidate.Weight {
 		return a.candidate.Weight > b.candidate.Weight
 	}
-	if a.candidate.BackendID != b.candidate.BackendID {
-		return a.candidate.BackendID < b.candidate.BackendID
+	if a.candidate.BackendRefName != b.candidate.BackendRefName {
+		return a.candidate.BackendRefName < b.candidate.BackendRefName
 	}
 	return a.telemetry.Identity.ReplicaID < b.telemetry.Identity.ReplicaID
 }
@@ -255,8 +255,8 @@ func telemetryLess(a, b BackendTelemetry) bool {
 	if aActive != bActive {
 		return aActive < bActive
 	}
-	if a.Identity.BackendID != b.Identity.BackendID {
-		return a.Identity.BackendID < b.Identity.BackendID
+	if a.Identity.BackendRefName != b.Identity.BackendRefName {
+		return a.Identity.BackendRefName < b.Identity.BackendRefName
 	}
 	return a.Identity.ReplicaID < b.Identity.ReplicaID
 }

--- a/src/semantic-router/pkg/backend/policy.go
+++ b/src/semantic-router/pkg/backend/policy.go
@@ -35,6 +35,13 @@ type candidateEvaluation struct {
 	telemetryAgeMS int64
 }
 
+type policyCandidateSummary struct {
+	options                 []policyOption
+	missingCount            int
+	staleCount              int
+	unhealthyCandidateCount int
+}
+
 // SelectBackendCandidate applies a minimal second-stage backend policy. It only
 // selects when at least one candidate has fresh, selectable telemetry; otherwise
 // it fails open so existing model/backend routing can continue unchanged.
@@ -51,43 +58,23 @@ func SelectBackendCandidate(modelName string, candidates []BackendCandidate, sto
 		return failOpenResult(diag, FallbackReasonNoBackendCandidates)
 	}
 
-	options := []policyOption{}
-	missingCount := 0
-	staleCount := 0
-	unhealthyCandidateCount := 0
+	summary := collectPolicyCandidates(modelName, candidates, store, &diag)
 
-	for _, candidate := range candidates {
-		evaluation := evaluateCandidate(modelName, candidate, store)
-		switch evaluation.status {
-		case candidateMissing:
-			missingCount++
-			continue
-		case candidateStale:
-			staleCount++
-			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
-			continue
-		case candidateUnhealthy:
-			diag.FreshCandidateCount++
-			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
-			unhealthyCandidateCount++
-			continue
-		case candidateSelectable:
-			diag.FreshCandidateCount++
-			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
-			options = append(options, evaluation.option)
-		}
-	}
-
-	diag.UnhealthyCount = unhealthyCandidateCount
+	diag.UnhealthyCount = summary.unhealthyCandidateCount
 	diag.TelemetryFresh = diag.FreshCandidateCount > 0
-	if len(options) == 0 {
-		return failOpenResult(diag, fallbackReasonForEmptyPolicy(len(candidates), missingCount, staleCount, unhealthyCandidateCount))
+	if len(summary.options) == 0 {
+		return failOpenResult(diag, fallbackReasonForEmptyPolicy(
+			len(candidates),
+			summary.missingCount,
+			summary.staleCount,
+			summary.unhealthyCandidateCount,
+		))
 	}
 
-	sort.Slice(options, func(i, j int) bool {
-		return policyOptionLess(options[i], options[j])
+	sort.Slice(summary.options, func(i, j int) bool {
+		return policyOptionLess(summary.options[i], summary.options[j])
 	})
-	selected := options[0]
+	selected := summary.options[0]
 	age := store.Age(selected.telemetry)
 	diag.SelectedBackendID = selected.candidate.BackendID
 	diag.SelectedReplicaID = selected.telemetry.Identity.ReplicaID
@@ -102,6 +89,35 @@ func SelectBackendCandidate(modelName string, candidates []BackendCandidate, sto
 		Reason:            PolicyReasonSelectedFreshTelemetry,
 		Diagnostics:       diag,
 	}
+}
+
+func collectPolicyCandidates(modelName string, candidates []BackendCandidate, store *Store, diag *BackendPolicyDiagnostics) policyCandidateSummary {
+	summary := policyCandidateSummary{
+		options: make([]policyOption, 0, len(candidates)),
+	}
+	for _, candidate := range candidates {
+		evaluation := evaluateCandidate(modelName, candidate, store)
+		switch evaluation.status {
+		case candidateMissing:
+			summary.missingCount++
+			continue
+		case candidateStale:
+			summary.staleCount++
+			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
+			continue
+		case candidateUnhealthy:
+			diag.FreshCandidateCount++
+			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
+			summary.unhealthyCandidateCount++
+			continue
+		case candidateSelectable:
+			diag.FreshCandidateCount++
+			diag.TelemetryAgeMS = maxInt64(diag.TelemetryAgeMS, evaluation.telemetryAgeMS)
+			summary.options = append(summary.options, evaluation.option)
+		}
+	}
+
+	return summary
 }
 
 func evaluateCandidate(modelName string, candidate BackendCandidate, store *Store) candidateEvaluation {

--- a/src/semantic-router/pkg/backend/policy_test.go
+++ b/src/semantic-router/pkg/backend/policy_test.go
@@ -14,14 +14,14 @@ func TestSelectBackendCandidatePrefersFreshLowestQueue(t *testing.T) {
 	activeHigh := 7
 	for _, telemetry := range []BackendTelemetry{
 		{
-			Identity:       BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+			Identity:       BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
 			QueueDepth:     &queueHigh,
 			ActiveRequests: &activeLow,
 			Health:         HealthStateHealthy,
 			CollectedAt:    base,
 		},
 		{
-			Identity:       BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
+			Identity:       BackendIdentity{BackendRefName: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
 			QueueDepth:     &queueLow,
 			ActiveRequests: &activeHigh,
 			Health:         HealthStateHealthy,
@@ -34,13 +34,13 @@ func TestSelectBackendCandidatePrefersFreshLowestQueue(t *testing.T) {
 	}
 
 	result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
-		{BackendID: "backend-a", Weight: 100},
-		{BackendID: "backend-b", Weight: 1},
+		{BackendRefName: "backend-a", Weight: 100},
+		{BackendRefName: "backend-b", Weight: 1},
 	}, store)
 	if result.FailOpen {
 		t.Fatalf("expected backend selection, got fail-open result %#v", result)
 	}
-	if result.SelectedBackendID != "backend-b" || result.SelectedReplicaID != "b-0" {
+	if result.SelectedBackendRefName != "backend-b" || result.SelectedReplicaID != "b-0" {
 		t.Fatalf("expected backend-b/b-0, got %#v", result)
 	}
 	if result.Reason != PolicyReasonSelectedFreshTelemetry {
@@ -51,7 +51,7 @@ func TestSelectBackendCandidatePrefersFreshLowestQueue(t *testing.T) {
 	}
 }
 
-func TestSelectBackendCandidateTieBreaksWithActiveRequestsWeightThenBackendID(t *testing.T) {
+func TestSelectBackendCandidateTieBreaksWithActiveRequestsWeightThenBackendRefName(t *testing.T) {
 	base := time.Unix(400, 0)
 	store := newStoreWithClock(5*time.Second, func() time.Time { return base })
 	queue := 1
@@ -60,21 +60,21 @@ func TestSelectBackendCandidateTieBreaksWithActiveRequestsWeightThenBackendID(t 
 
 	samples := []BackendTelemetry{
 		{
-			Identity:       BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b"},
+			Identity:       BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b"},
 			QueueDepth:     &queue,
 			ActiveRequests: &activeBusy,
 			Health:         HealthStateHealthy,
 			CollectedAt:    base,
 		},
 		{
-			Identity:       BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b"},
+			Identity:       BackendIdentity{BackendRefName: "backend-b", ModelName: "qwen3-8b"},
 			QueueDepth:     &queue,
 			ActiveRequests: &activeIdle,
 			Health:         HealthStateHealthy,
 			CollectedAt:    base,
 		},
 		{
-			Identity:       BackendIdentity{BackendID: "backend-c", ModelName: "qwen3-8b"},
+			Identity:       BackendIdentity{BackendRefName: "backend-c", ModelName: "qwen3-8b"},
 			QueueDepth:     &queue,
 			ActiveRequests: &activeIdle,
 			Health:         HealthStateHealthy,
@@ -88,20 +88,20 @@ func TestSelectBackendCandidateTieBreaksWithActiveRequestsWeightThenBackendID(t 
 	}
 
 	result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
-		{BackendID: "backend-a", Weight: 100},
-		{BackendID: "backend-b", Weight: 10},
-		{BackendID: "backend-c", Weight: 20},
+		{BackendRefName: "backend-a", Weight: 100},
+		{BackendRefName: "backend-b", Weight: 10},
+		{BackendRefName: "backend-c", Weight: 20},
 	}, store)
-	if result.SelectedBackendID != "backend-c" {
+	if result.SelectedBackendRefName != "backend-c" {
 		t.Fatalf("expected higher-weight idle backend-c, got %#v", result)
 	}
 
 	result = SelectBackendCandidate("qwen3-8b", []BackendCandidate{
-		{BackendID: "backend-b", Weight: 20},
-		{BackendID: "backend-c", Weight: 20},
+		{BackendRefName: "backend-b", Weight: 20},
+		{BackendRefName: "backend-c", Weight: 20},
 	}, store)
-	if result.SelectedBackendID != "backend-b" {
-		t.Fatalf("expected stable backend ID tie-break to choose backend-b, got %#v", result)
+	if result.SelectedBackendRefName != "backend-b" {
+		t.Fatalf("expected stable backend ref name tie-break to choose backend-b, got %#v", result)
 	}
 }
 
@@ -114,20 +114,20 @@ func TestSelectBackendCandidateFailOpenReasons(t *testing.T) {
 	})
 
 	t.Run("missing telemetry", func(t *testing.T) {
-		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendID: "missing"}}, NewStore(DefaultTelemetryTTL))
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendRefName: "missing"}}, NewStore(DefaultTelemetryTTL))
 		assertFailOpenReason(t, result, FallbackReasonMissingTelemetry)
 	})
 
 	t.Run("stale telemetry", func(t *testing.T) {
 		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
 		if err := store.Upsert(BackendTelemetry{
-			Identity:    BackendIdentity{BackendID: "stale", ModelName: "qwen3-8b"},
+			Identity:    BackendIdentity{BackendRefName: "stale", ModelName: "qwen3-8b"},
 			Health:      HealthStateHealthy,
 			CollectedAt: base.Add(-6 * time.Second),
 		}); err != nil {
 			t.Fatalf("Upsert returned error: %v", err)
 		}
-		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendID: "stale"}}, store)
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendRefName: "stale"}}, store)
 		assertFailOpenReason(t, result, FallbackReasonStaleTelemetry)
 		if result.Diagnostics.TelemetryFresh {
 			t.Fatal("expected stale telemetry to report TelemetryFresh=false")
@@ -140,13 +140,13 @@ func TestSelectBackendCandidateFailOpenReasons(t *testing.T) {
 	t.Run("all unhealthy", func(t *testing.T) {
 		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
 		if err := store.Upsert(BackendTelemetry{
-			Identity:    BackendIdentity{BackendID: "unhealthy", ModelName: "qwen3-8b"},
+			Identity:    BackendIdentity{BackendRefName: "unhealthy", ModelName: "qwen3-8b"},
 			Health:      HealthStateUnhealthy,
 			CollectedAt: base,
 		}); err != nil {
 			t.Fatalf("Upsert returned error: %v", err)
 		}
-		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendID: "unhealthy"}}, store)
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendRefName: "unhealthy"}}, store)
 		assertFailOpenReason(t, result, FallbackReasonAllUnhealthy)
 		if !result.Diagnostics.TelemetryFresh {
 			t.Fatal("expected fresh unhealthy telemetry to report TelemetryFresh=true")
@@ -164,12 +164,12 @@ func TestSelectBackendCandidateCountsUnhealthyByCandidate(t *testing.T) {
 		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
 		for _, telemetry := range []BackendTelemetry{
 			{
-				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+				Identity:    BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
 				Health:      HealthStateUnhealthy,
 				CollectedAt: base,
 			},
 			{
-				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
+				Identity:    BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
 				Health:      HealthStateUnhealthy,
 				CollectedAt: base,
 			},
@@ -180,8 +180,8 @@ func TestSelectBackendCandidateCountsUnhealthyByCandidate(t *testing.T) {
 		}
 
 		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
-			{BackendID: "backend-a"},
-			{BackendID: "backend-b"},
+			{BackendRefName: "backend-a"},
+			{BackendRefName: "backend-b"},
 		}, store)
 		assertFailOpenReason(t, result, FallbackReasonMissingTelemetry)
 		if result.Diagnostics.UnhealthyCount != 1 {
@@ -196,17 +196,17 @@ func TestSelectBackendCandidateCountsUnhealthyByCandidate(t *testing.T) {
 		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
 		for _, telemetry := range []BackendTelemetry{
 			{
-				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+				Identity:    BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
 				Health:      HealthStateUnhealthy,
 				CollectedAt: base,
 			},
 			{
-				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
+				Identity:    BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
 				Health:      HealthStateUnhealthy,
 				CollectedAt: base,
 			},
 			{
-				Identity:    BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
+				Identity:    BackendIdentity{BackendRefName: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
 				Health:      HealthStateUnhealthy,
 				CollectedAt: base,
 			},
@@ -217,8 +217,8 @@ func TestSelectBackendCandidateCountsUnhealthyByCandidate(t *testing.T) {
 		}
 
 		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
-			{BackendID: "backend-a"},
-			{BackendID: "backend-b"},
+			{BackendRefName: "backend-a"},
+			{BackendRefName: "backend-b"},
 		}, store)
 		assertFailOpenReason(t, result, FallbackReasonAllUnhealthy)
 		if result.Diagnostics.UnhealthyCount != 2 {
@@ -238,19 +238,19 @@ func TestSelectBackendCandidateSelectsBackendWithAnyHealthyReplica(t *testing.T)
 	queueOther := 1
 	for _, telemetry := range []BackendTelemetry{
 		{
-			Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+			Identity:    BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
 			QueueDepth:  &queueUnhealthy,
 			Health:      HealthStateUnhealthy,
 			CollectedAt: base,
 		},
 		{
-			Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
+			Identity:    BackendIdentity{BackendRefName: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
 			QueueDepth:  &queueHealthy,
 			Health:      HealthStateHealthy,
 			CollectedAt: base,
 		},
 		{
-			Identity:    BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
+			Identity:    BackendIdentity{BackendRefName: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
 			QueueDepth:  &queueOther,
 			Health:      HealthStateUnhealthy,
 			CollectedAt: base,
@@ -262,13 +262,13 @@ func TestSelectBackendCandidateSelectsBackendWithAnyHealthyReplica(t *testing.T)
 	}
 
 	result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
-		{BackendID: "backend-a"},
-		{BackendID: "backend-b"},
+		{BackendRefName: "backend-a"},
+		{BackendRefName: "backend-b"},
 	}, store)
 	if result.FailOpen {
 		t.Fatalf("expected selectable healthy replica, got fail-open result %#v", result)
 	}
-	if result.SelectedBackendID != "backend-a" || result.SelectedReplicaID != "a-1" {
+	if result.SelectedBackendRefName != "backend-a" || result.SelectedReplicaID != "a-1" {
 		t.Fatalf("expected backend-a/a-1, got %#v", result)
 	}
 	if result.Diagnostics.UnhealthyCount != 1 {
@@ -287,7 +287,7 @@ func assertFailOpenReason(t *testing.T, result BackendPolicyResult, reason strin
 	if result.Reason != reason || result.Diagnostics.FallbackReason != reason {
 		t.Fatalf("expected reason %q, got %#v", reason, result)
 	}
-	if result.SelectedBackendID != "" || result.SelectedReplicaID != "" {
+	if result.SelectedBackendRefName != "" || result.SelectedReplicaID != "" {
 		t.Fatalf("expected no selected backend on fail-open, got %#v", result)
 	}
 }

--- a/src/semantic-router/pkg/backend/policy_test.go
+++ b/src/semantic-router/pkg/backend/policy_test.go
@@ -157,6 +157,128 @@ func TestSelectBackendCandidateFailOpenReasons(t *testing.T) {
 	})
 }
 
+func TestSelectBackendCandidateCountsUnhealthyByCandidate(t *testing.T) {
+	base := time.Unix(600, 0)
+
+	t.Run("mixed unhealthy replicas and missing telemetry reports missing", func(t *testing.T) {
+		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+		for _, telemetry := range []BackendTelemetry{
+			{
+				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+				Health:      HealthStateUnhealthy,
+				CollectedAt: base,
+			},
+			{
+				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
+				Health:      HealthStateUnhealthy,
+				CollectedAt: base,
+			},
+		} {
+			if err := store.Upsert(telemetry); err != nil {
+				t.Fatalf("Upsert returned error: %v", err)
+			}
+		}
+
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
+			{BackendID: "backend-a"},
+			{BackendID: "backend-b"},
+		}, store)
+		assertFailOpenReason(t, result, FallbackReasonMissingTelemetry)
+		if result.Diagnostics.UnhealthyCount != 1 {
+			t.Fatalf("UnhealthyCount = %d, want 1 unhealthy candidate", result.Diagnostics.UnhealthyCount)
+		}
+		if result.Diagnostics.FreshCandidateCount != 1 {
+			t.Fatalf("FreshCandidateCount = %d, want 1", result.Diagnostics.FreshCandidateCount)
+		}
+	})
+
+	t.Run("all unhealthy counts candidates not replicas", func(t *testing.T) {
+		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+		for _, telemetry := range []BackendTelemetry{
+			{
+				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+				Health:      HealthStateUnhealthy,
+				CollectedAt: base,
+			},
+			{
+				Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
+				Health:      HealthStateUnhealthy,
+				CollectedAt: base,
+			},
+			{
+				Identity:    BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
+				Health:      HealthStateUnhealthy,
+				CollectedAt: base,
+			},
+		} {
+			if err := store.Upsert(telemetry); err != nil {
+				t.Fatalf("Upsert returned error: %v", err)
+			}
+		}
+
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
+			{BackendID: "backend-a"},
+			{BackendID: "backend-b"},
+		}, store)
+		assertFailOpenReason(t, result, FallbackReasonAllUnhealthy)
+		if result.Diagnostics.UnhealthyCount != 2 {
+			t.Fatalf("UnhealthyCount = %d, want 2 unhealthy candidates", result.Diagnostics.UnhealthyCount)
+		}
+		if result.Diagnostics.FreshCandidateCount != 2 {
+			t.Fatalf("FreshCandidateCount = %d, want 2", result.Diagnostics.FreshCandidateCount)
+		}
+	})
+}
+
+func TestSelectBackendCandidateSelectsBackendWithAnyHealthyReplica(t *testing.T) {
+	base := time.Unix(700, 0)
+	store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+	queueUnhealthy := 0
+	queueHealthy := 5
+	queueOther := 1
+	for _, telemetry := range []BackendTelemetry{
+		{
+			Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+			QueueDepth:  &queueUnhealthy,
+			Health:      HealthStateUnhealthy,
+			CollectedAt: base,
+		},
+		{
+			Identity:    BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-1"},
+			QueueDepth:  &queueHealthy,
+			Health:      HealthStateHealthy,
+			CollectedAt: base,
+		},
+		{
+			Identity:    BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
+			QueueDepth:  &queueOther,
+			Health:      HealthStateUnhealthy,
+			CollectedAt: base,
+		},
+	} {
+		if err := store.Upsert(telemetry); err != nil {
+			t.Fatalf("Upsert returned error: %v", err)
+		}
+	}
+
+	result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
+		{BackendID: "backend-a"},
+		{BackendID: "backend-b"},
+	}, store)
+	if result.FailOpen {
+		t.Fatalf("expected selectable healthy replica, got fail-open result %#v", result)
+	}
+	if result.SelectedBackendID != "backend-a" || result.SelectedReplicaID != "a-1" {
+		t.Fatalf("expected backend-a/a-1, got %#v", result)
+	}
+	if result.Diagnostics.UnhealthyCount != 1 {
+		t.Fatalf("UnhealthyCount = %d, want 1 unhealthy candidate", result.Diagnostics.UnhealthyCount)
+	}
+	if result.Diagnostics.FreshCandidateCount != 2 {
+		t.Fatalf("FreshCandidateCount = %d, want 2", result.Diagnostics.FreshCandidateCount)
+	}
+}
+
 func assertFailOpenReason(t *testing.T, result BackendPolicyResult, reason string) {
 	t.Helper()
 	if !result.FailOpen {

--- a/src/semantic-router/pkg/backend/policy_test.go
+++ b/src/semantic-router/pkg/backend/policy_test.go
@@ -1,0 +1,171 @@
+package backend
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSelectBackendCandidatePrefersFreshLowestQueue(t *testing.T) {
+	base := time.Unix(300, 0)
+	store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+	queueHigh := 8
+	queueLow := 2
+	activeLow := 1
+	activeHigh := 7
+	for _, telemetry := range []BackendTelemetry{
+		{
+			Identity:       BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b", ReplicaID: "a-0"},
+			QueueDepth:     &queueHigh,
+			ActiveRequests: &activeLow,
+			Health:         HealthStateHealthy,
+			CollectedAt:    base,
+		},
+		{
+			Identity:       BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b", ReplicaID: "b-0"},
+			QueueDepth:     &queueLow,
+			ActiveRequests: &activeHigh,
+			Health:         HealthStateHealthy,
+			CollectedAt:    base,
+		},
+	} {
+		if err := store.Upsert(telemetry); err != nil {
+			t.Fatalf("Upsert returned error: %v", err)
+		}
+	}
+
+	result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
+		{BackendID: "backend-a", Weight: 100},
+		{BackendID: "backend-b", Weight: 1},
+	}, store)
+	if result.FailOpen {
+		t.Fatalf("expected backend selection, got fail-open result %#v", result)
+	}
+	if result.SelectedBackendID != "backend-b" || result.SelectedReplicaID != "b-0" {
+		t.Fatalf("expected backend-b/b-0, got %#v", result)
+	}
+	if result.Reason != PolicyReasonSelectedFreshTelemetry {
+		t.Fatalf("Reason = %q, want %q", result.Reason, PolicyReasonSelectedFreshTelemetry)
+	}
+	if result.Diagnostics.CandidateCount != 2 || result.Diagnostics.FreshCandidateCount != 2 {
+		t.Fatalf("unexpected diagnostics counts: %#v", result.Diagnostics)
+	}
+}
+
+func TestSelectBackendCandidateTieBreaksWithActiveRequestsWeightThenBackendID(t *testing.T) {
+	base := time.Unix(400, 0)
+	store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+	queue := 1
+	activeBusy := 5
+	activeIdle := 1
+
+	samples := []BackendTelemetry{
+		{
+			Identity:       BackendIdentity{BackendID: "backend-a", ModelName: "qwen3-8b"},
+			QueueDepth:     &queue,
+			ActiveRequests: &activeBusy,
+			Health:         HealthStateHealthy,
+			CollectedAt:    base,
+		},
+		{
+			Identity:       BackendIdentity{BackendID: "backend-b", ModelName: "qwen3-8b"},
+			QueueDepth:     &queue,
+			ActiveRequests: &activeIdle,
+			Health:         HealthStateHealthy,
+			CollectedAt:    base,
+		},
+		{
+			Identity:       BackendIdentity{BackendID: "backend-c", ModelName: "qwen3-8b"},
+			QueueDepth:     &queue,
+			ActiveRequests: &activeIdle,
+			Health:         HealthStateHealthy,
+			CollectedAt:    base,
+		},
+	}
+	for _, sample := range samples {
+		if err := store.Upsert(sample); err != nil {
+			t.Fatalf("Upsert returned error: %v", err)
+		}
+	}
+
+	result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{
+		{BackendID: "backend-a", Weight: 100},
+		{BackendID: "backend-b", Weight: 10},
+		{BackendID: "backend-c", Weight: 20},
+	}, store)
+	if result.SelectedBackendID != "backend-c" {
+		t.Fatalf("expected higher-weight idle backend-c, got %#v", result)
+	}
+
+	result = SelectBackendCandidate("qwen3-8b", []BackendCandidate{
+		{BackendID: "backend-b", Weight: 20},
+		{BackendID: "backend-c", Weight: 20},
+	}, store)
+	if result.SelectedBackendID != "backend-b" {
+		t.Fatalf("expected stable backend ID tie-break to choose backend-b, got %#v", result)
+	}
+}
+
+func TestSelectBackendCandidateFailOpenReasons(t *testing.T) {
+	base := time.Unix(500, 0)
+
+	t.Run("no candidates", func(t *testing.T) {
+		result := SelectBackendCandidate("qwen3-8b", nil, NewStore(DefaultTelemetryTTL))
+		assertFailOpenReason(t, result, FallbackReasonNoBackendCandidates)
+	})
+
+	t.Run("missing telemetry", func(t *testing.T) {
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendID: "missing"}}, NewStore(DefaultTelemetryTTL))
+		assertFailOpenReason(t, result, FallbackReasonMissingTelemetry)
+	})
+
+	t.Run("stale telemetry", func(t *testing.T) {
+		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+		if err := store.Upsert(BackendTelemetry{
+			Identity:    BackendIdentity{BackendID: "stale", ModelName: "qwen3-8b"},
+			Health:      HealthStateHealthy,
+			CollectedAt: base.Add(-6 * time.Second),
+		}); err != nil {
+			t.Fatalf("Upsert returned error: %v", err)
+		}
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendID: "stale"}}, store)
+		assertFailOpenReason(t, result, FallbackReasonStaleTelemetry)
+		if result.Diagnostics.TelemetryFresh {
+			t.Fatal("expected stale telemetry to report TelemetryFresh=false")
+		}
+		if result.Diagnostics.TelemetryAgeMS != (6 * time.Second).Milliseconds() {
+			t.Fatalf("TelemetryAgeMS = %d, want 6000", result.Diagnostics.TelemetryAgeMS)
+		}
+	})
+
+	t.Run("all unhealthy", func(t *testing.T) {
+		store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+		if err := store.Upsert(BackendTelemetry{
+			Identity:    BackendIdentity{BackendID: "unhealthy", ModelName: "qwen3-8b"},
+			Health:      HealthStateUnhealthy,
+			CollectedAt: base,
+		}); err != nil {
+			t.Fatalf("Upsert returned error: %v", err)
+		}
+		result := SelectBackendCandidate("qwen3-8b", []BackendCandidate{{BackendID: "unhealthy"}}, store)
+		assertFailOpenReason(t, result, FallbackReasonAllUnhealthy)
+		if !result.Diagnostics.TelemetryFresh {
+			t.Fatal("expected fresh unhealthy telemetry to report TelemetryFresh=true")
+		}
+		if result.Diagnostics.UnhealthyCount != 1 {
+			t.Fatalf("UnhealthyCount = %d, want 1", result.Diagnostics.UnhealthyCount)
+		}
+	})
+}
+
+func assertFailOpenReason(t *testing.T, result BackendPolicyResult, reason string) {
+	t.Helper()
+	if !result.FailOpen {
+		t.Fatalf("expected fail-open result for %s, got %#v", reason, result)
+	}
+	if result.Reason != reason || result.Diagnostics.FallbackReason != reason {
+		t.Fatalf("expected reason %q, got %#v", reason, result)
+	}
+	if result.SelectedBackendID != "" || result.SelectedReplicaID != "" {
+		t.Fatalf("expected no selected backend on fail-open, got %#v", result)
+	}
+}

--- a/src/semantic-router/pkg/backend/registry.go
+++ b/src/semantic-router/pkg/backend/registry.go
@@ -25,48 +25,48 @@ type AdapterConfig struct {
 
 // TelemetryAdapter normalizes engine-specific metrics into BackendTelemetry.
 type TelemetryAdapter interface {
-	EngineKind() EngineKind
+	Runtime() Runtime
 	Collect(ctx context.Context) ([]BackendTelemetry, error)
 }
 
 // AdapterConstructor creates a telemetry adapter.
 type AdapterConstructor func(AdapterConfig) (TelemetryAdapter, error)
 
-// Registry stores telemetry adapter constructors by engine kind.
+// Registry stores telemetry adapter constructors by runtime.
 type Registry struct {
 	mu           sync.RWMutex
-	constructors map[EngineKind]AdapterConstructor
+	constructors map[Runtime]AdapterConstructor
 }
 
 var defaultRegistry = NewRegistry()
 
 // NewRegistry creates an empty adapter registry.
 func NewRegistry() *Registry {
-	return &Registry{constructors: map[EngineKind]AdapterConstructor{}}
+	return &Registry{constructors: map[Runtime]AdapterConstructor{}}
 }
 
 // RegisterAdapter registers an adapter constructor on the package-level registry.
-func RegisterAdapter(kind EngineKind, constructor AdapterConstructor) error {
+func RegisterAdapter(kind Runtime, constructor AdapterConstructor) error {
 	return defaultRegistry.Register(kind, constructor)
 }
 
 // NewAdapter constructs an adapter from the package-level registry.
-func NewAdapter(kind EngineKind, cfg AdapterConfig) (TelemetryAdapter, error) {
+func NewAdapter(kind Runtime, cfg AdapterConfig) (TelemetryAdapter, error) {
 	return defaultRegistry.Create(kind, cfg)
 }
 
-// AdapterRegistered reports whether an engine kind has a package-level constructor.
-func AdapterRegistered(kind EngineKind) bool {
+// AdapterRegistered reports whether a runtime has a package-level constructor.
+func AdapterRegistered(kind Runtime) bool {
 	return defaultRegistry.Has(kind)
 }
 
-// Register associates an engine kind with an adapter constructor.
-func (r *Registry) Register(kind EngineKind, constructor AdapterConstructor) error {
+// Register associates a runtime with an adapter constructor.
+func (r *Registry) Register(kind Runtime, constructor AdapterConstructor) error {
 	if r == nil {
 		return fmt.Errorf("backend telemetry adapter registry is nil")
 	}
 	if kind == "" {
-		return fmt.Errorf("backend telemetry adapter engine kind is required")
+		return fmt.Errorf("backend telemetry adapter runtime is required")
 	}
 	if constructor == nil {
 		return fmt.Errorf("backend telemetry adapter constructor is required")
@@ -78,8 +78,8 @@ func (r *Registry) Register(kind EngineKind, constructor AdapterConstructor) err
 	return nil
 }
 
-// Create builds an adapter for an engine kind.
-func (r *Registry) Create(kind EngineKind, cfg AdapterConfig) (TelemetryAdapter, error) {
+// Create builds an adapter for a runtime.
+func (r *Registry) Create(kind Runtime, cfg AdapterConfig) (TelemetryAdapter, error) {
 	if r == nil {
 		return nil, fmt.Errorf("backend telemetry adapter registry is nil")
 	}
@@ -93,8 +93,8 @@ func (r *Registry) Create(kind EngineKind, cfg AdapterConfig) (TelemetryAdapter,
 	return constructor(cfg)
 }
 
-// Has reports whether an engine kind is registered.
-func (r *Registry) Has(kind EngineKind) bool {
+// Has reports whether a runtime is registered.
+func (r *Registry) Has(kind Runtime) bool {
 	if r == nil {
 		return false
 	}

--- a/src/semantic-router/pkg/backend/registry.go
+++ b/src/semantic-router/pkg/backend/registry.go
@@ -1,0 +1,105 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// AdapterTarget describes one metrics collection target for an adapter.
+type AdapterTarget struct {
+	Identity        BackendIdentity
+	MetricsEndpoint string
+	Headers         map[string]string
+	Labels          map[string]string
+}
+
+// AdapterConfig carries engine-neutral adapter construction settings.
+type AdapterConfig struct {
+	Targets  []AdapterTarget
+	Store    *Store
+	Interval time.Duration
+	Labels   map[string]string
+}
+
+// TelemetryAdapter normalizes engine-specific metrics into BackendTelemetry.
+type TelemetryAdapter interface {
+	EngineKind() EngineKind
+	Collect(ctx context.Context) ([]BackendTelemetry, error)
+}
+
+// AdapterConstructor creates a telemetry adapter.
+type AdapterConstructor func(AdapterConfig) (TelemetryAdapter, error)
+
+// Registry stores telemetry adapter constructors by engine kind.
+type Registry struct {
+	mu           sync.RWMutex
+	constructors map[EngineKind]AdapterConstructor
+}
+
+var defaultRegistry = NewRegistry()
+
+// NewRegistry creates an empty adapter registry.
+func NewRegistry() *Registry {
+	return &Registry{constructors: map[EngineKind]AdapterConstructor{}}
+}
+
+// RegisterAdapter registers an adapter constructor on the package-level registry.
+func RegisterAdapter(kind EngineKind, constructor AdapterConstructor) error {
+	return defaultRegistry.Register(kind, constructor)
+}
+
+// NewAdapter constructs an adapter from the package-level registry.
+func NewAdapter(kind EngineKind, cfg AdapterConfig) (TelemetryAdapter, error) {
+	return defaultRegistry.Create(kind, cfg)
+}
+
+// AdapterRegistered reports whether an engine kind has a package-level constructor.
+func AdapterRegistered(kind EngineKind) bool {
+	return defaultRegistry.Has(kind)
+}
+
+// Register associates an engine kind with an adapter constructor.
+func (r *Registry) Register(kind EngineKind, constructor AdapterConstructor) error {
+	if r == nil {
+		return fmt.Errorf("backend telemetry adapter registry is nil")
+	}
+	if kind == "" {
+		return fmt.Errorf("backend telemetry adapter engine kind is required")
+	}
+	if constructor == nil {
+		return fmt.Errorf("backend telemetry adapter constructor is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.constructors[kind] = constructor
+	return nil
+}
+
+// Create builds an adapter for an engine kind.
+func (r *Registry) Create(kind EngineKind, cfg AdapterConfig) (TelemetryAdapter, error) {
+	if r == nil {
+		return nil, fmt.Errorf("backend telemetry adapter registry is nil")
+	}
+
+	r.mu.RLock()
+	constructor, ok := r.constructors[kind]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("backend telemetry adapter %q is not registered", kind)
+	}
+	return constructor(cfg)
+}
+
+// Has reports whether an engine kind is registered.
+func (r *Registry) Has(kind EngineKind) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.constructors[kind]
+	return ok
+}

--- a/src/semantic-router/pkg/backend/registry_test.go
+++ b/src/semantic-router/pkg/backend/registry_test.go
@@ -1,0 +1,53 @@
+package backend
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeAdapter struct {
+	kind EngineKind
+}
+
+func (a fakeAdapter) EngineKind() EngineKind {
+	return a.kind
+}
+
+func (a fakeAdapter) Collect(context.Context) ([]BackendTelemetry, error) {
+	return []BackendTelemetry{{Identity: BackendIdentity{BackendID: "backend", ModelName: "model"}}}, nil
+}
+
+func TestRegistryCreatesRegisteredAdapter(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(EngineKindVLLM, func(AdapterConfig) (TelemetryAdapter, error) {
+		return fakeAdapter{kind: EngineKindVLLM}, nil
+	}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if !registry.Has(EngineKindVLLM) {
+		t.Fatal("expected registry to report vLLM adapter as registered")
+	}
+
+	adapter, err := registry.Create(EngineKindVLLM, AdapterConfig{})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if adapter.EngineKind() != EngineKindVLLM {
+		t.Fatalf("EngineKind = %q, want %q", adapter.EngineKind(), EngineKindVLLM)
+	}
+}
+
+func TestRegistryRejectsInvalidRegistrations(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register("", func(AdapterConfig) (TelemetryAdapter, error) {
+		return fakeAdapter{}, nil
+	}); err == nil {
+		t.Fatal("expected empty engine kind to be rejected")
+	}
+	if err := registry.Register(EngineKindATOM, nil); err == nil {
+		t.Fatal("expected nil constructor to be rejected")
+	}
+	if _, err := registry.Create(EngineKindSGLang, AdapterConfig{}); err == nil {
+		t.Fatal("expected unregistered adapter create to fail")
+	}
+}

--- a/src/semantic-router/pkg/backend/registry_test.go
+++ b/src/semantic-router/pkg/backend/registry_test.go
@@ -6,34 +6,34 @@ import (
 )
 
 type fakeAdapter struct {
-	kind EngineKind
+	kind Runtime
 }
 
-func (a fakeAdapter) EngineKind() EngineKind {
+func (a fakeAdapter) Runtime() Runtime {
 	return a.kind
 }
 
 func (a fakeAdapter) Collect(context.Context) ([]BackendTelemetry, error) {
-	return []BackendTelemetry{{Identity: BackendIdentity{BackendID: "backend", ModelName: "model"}}}, nil
+	return []BackendTelemetry{{Identity: BackendIdentity{BackendRefName: "backend", ModelName: "model"}}}, nil
 }
 
 func TestRegistryCreatesRegisteredAdapter(t *testing.T) {
 	registry := NewRegistry()
-	if err := registry.Register(EngineKindVLLM, func(AdapterConfig) (TelemetryAdapter, error) {
-		return fakeAdapter{kind: EngineKindVLLM}, nil
+	if err := registry.Register(RuntimeVLLM, func(AdapterConfig) (TelemetryAdapter, error) {
+		return fakeAdapter{kind: RuntimeVLLM}, nil
 	}); err != nil {
 		t.Fatalf("Register returned error: %v", err)
 	}
-	if !registry.Has(EngineKindVLLM) {
+	if !registry.Has(RuntimeVLLM) {
 		t.Fatal("expected registry to report vLLM adapter as registered")
 	}
 
-	adapter, err := registry.Create(EngineKindVLLM, AdapterConfig{})
+	adapter, err := registry.Create(RuntimeVLLM, AdapterConfig{})
 	if err != nil {
 		t.Fatalf("Create returned error: %v", err)
 	}
-	if adapter.EngineKind() != EngineKindVLLM {
-		t.Fatalf("EngineKind = %q, want %q", adapter.EngineKind(), EngineKindVLLM)
+	if adapter.Runtime() != RuntimeVLLM {
+		t.Fatalf("Runtime = %q, want %q", adapter.Runtime(), RuntimeVLLM)
 	}
 }
 
@@ -42,12 +42,12 @@ func TestRegistryRejectsInvalidRegistrations(t *testing.T) {
 	if err := registry.Register("", func(AdapterConfig) (TelemetryAdapter, error) {
 		return fakeAdapter{}, nil
 	}); err == nil {
-		t.Fatal("expected empty engine kind to be rejected")
+		t.Fatal("expected empty runtime to be rejected")
 	}
-	if err := registry.Register(EngineKindATOM, nil); err == nil {
+	if err := registry.Register(RuntimeATOM, nil); err == nil {
 		t.Fatal("expected nil constructor to be rejected")
 	}
-	if _, err := registry.Create(EngineKindSGLang, AdapterConfig{}); err == nil {
+	if _, err := registry.Create(RuntimeSGLang, AdapterConfig{}); err == nil {
 		t.Fatal("expected unregistered adapter create to fail")
 	}
 }

--- a/src/semantic-router/pkg/backend/store.go
+++ b/src/semantic-router/pkg/backend/store.go
@@ -1,0 +1,207 @@
+package backend
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const DefaultTelemetryTTL = 5 * time.Second
+
+// Store keeps the latest telemetry sample per model/backend/replica tuple.
+type Store struct {
+	mu         sync.RWMutex
+	items      map[string]BackendTelemetry
+	defaultTTL time.Duration
+	now        func() time.Time
+}
+
+var defaultStore = NewStore(DefaultTelemetryTTL)
+
+// NewStore creates a telemetry store with the provided default TTL.
+func NewStore(defaultTTL time.Duration) *Store {
+	if defaultTTL <= 0 {
+		defaultTTL = DefaultTelemetryTTL
+	}
+	return newStoreWithClock(defaultTTL, time.Now)
+}
+
+func newStoreWithClock(defaultTTL time.Duration, now func() time.Time) *Store {
+	if defaultTTL <= 0 {
+		defaultTTL = DefaultTelemetryTTL
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{
+		items:      map[string]BackendTelemetry{},
+		defaultTTL: defaultTTL,
+		now:        now,
+	}
+}
+
+// DefaultStore returns the package-level telemetry store.
+func DefaultStore() *Store {
+	return defaultStore
+}
+
+// Upsert writes telemetry into the package-level store.
+func Upsert(telemetry BackendTelemetry) error {
+	return defaultStore.Upsert(telemetry)
+}
+
+// Get returns raw telemetry from the package-level store.
+func Get(identity BackendIdentity) (BackendTelemetry, bool) {
+	return defaultStore.Get(identity)
+}
+
+// GetFresh returns non-stale telemetry from the package-level store.
+func GetFresh(identity BackendIdentity) (BackendTelemetry, bool) {
+	return defaultStore.GetFresh(identity)
+}
+
+// ListByModel returns raw model telemetry from the package-level store.
+func ListByModel(modelName string) []BackendTelemetry {
+	return defaultStore.ListByModel(modelName)
+}
+
+// Upsert writes telemetry into the store. CollectedAt defaults to now when
+// omitted; TTL defaults are applied during freshness checks.
+func (s *Store) Upsert(telemetry BackendTelemetry) error {
+	if s == nil {
+		return fmt.Errorf("backend telemetry store is nil")
+	}
+	telemetry.Identity = telemetry.Identity.Normalize()
+	if telemetry.Identity.BackendID == "" {
+		return fmt.Errorf("backend telemetry requires backend identity")
+	}
+	if telemetry.Identity.ModelName == "" {
+		return fmt.Errorf("backend telemetry requires model name")
+	}
+	if telemetry.CollectedAt.IsZero() {
+		telemetry.CollectedAt = s.now()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[telemetry.Identity.Key()] = telemetry
+	return nil
+}
+
+// Get returns raw telemetry without freshness filtering.
+func (s *Store) Get(identity BackendIdentity) (BackendTelemetry, bool) {
+	if s == nil {
+		return BackendTelemetry{}, false
+	}
+	identity = identity.Normalize()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	telemetry, ok := s.items[identity.Key()]
+	return telemetry, ok
+}
+
+// GetFresh returns telemetry only when it is still within its TTL window.
+func (s *Store) GetFresh(identity BackendIdentity) (BackendTelemetry, bool) {
+	telemetry, ok := s.Get(identity)
+	if !ok || !s.IsFresh(telemetry) {
+		return BackendTelemetry{}, false
+	}
+	return telemetry, true
+}
+
+// ListByModel returns raw telemetry for a model.
+func (s *Store) ListByModel(modelName string) []BackendTelemetry {
+	if s == nil {
+		return nil
+	}
+	modelName = strings.TrimSpace(modelName)
+	results := []BackendTelemetry{}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, telemetry := range s.items {
+		if telemetry.Identity.ModelName == modelName {
+			results = append(results, telemetry)
+		}
+	}
+	return results
+}
+
+// ListFreshByModel returns non-stale telemetry for a model.
+func (s *Store) ListFreshByModel(modelName string) []BackendTelemetry {
+	raw := s.ListByModel(modelName)
+	results := make([]BackendTelemetry, 0, len(raw))
+	for _, telemetry := range raw {
+		if s.IsFresh(telemetry) {
+			results = append(results, telemetry)
+		}
+	}
+	return results
+}
+
+// ListByBackend returns raw telemetry for a model/backend pair.
+func (s *Store) ListByBackend(modelName string, backendID string) []BackendTelemetry {
+	if s == nil {
+		return nil
+	}
+	modelName = strings.TrimSpace(modelName)
+	backendID = strings.TrimSpace(backendID)
+	results := []BackendTelemetry{}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, telemetry := range s.items {
+		if telemetry.Identity.ModelName == modelName && telemetry.Identity.BackendID == backendID {
+			results = append(results, telemetry)
+		}
+	}
+	return results
+}
+
+// IsFresh reports whether telemetry is within its own TTL or the store default.
+func (s *Store) IsFresh(telemetry BackendTelemetry) bool {
+	if s == nil || telemetry.CollectedAt.IsZero() {
+		return false
+	}
+	age := s.Age(telemetry)
+	return age >= 0 && age <= s.ttlFor(telemetry)
+}
+
+// Age reports telemetry age using the store clock.
+func (s *Store) Age(telemetry BackendTelemetry) time.Duration {
+	if s == nil || telemetry.CollectedAt.IsZero() {
+		return 0
+	}
+	return s.now().Sub(telemetry.CollectedAt)
+}
+
+// Remove deletes telemetry for an identity.
+func (s *Store) Remove(identity BackendIdentity) {
+	if s == nil {
+		return
+	}
+	identity = identity.Normalize()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.items, identity.Key())
+}
+
+// Reset clears the store.
+func (s *Store) Reset() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = map[string]BackendTelemetry{}
+}
+
+func (s *Store) ttlFor(telemetry BackendTelemetry) time.Duration {
+	if telemetry.TTL > 0 {
+		return telemetry.TTL
+	}
+	return s.defaultTTL
+}

--- a/src/semantic-router/pkg/backend/store.go
+++ b/src/semantic-router/pkg/backend/store.go
@@ -9,7 +9,7 @@ import (
 
 const DefaultTelemetryTTL = 5 * time.Second
 
-// Store keeps the latest telemetry sample per model/backend/replica tuple.
+// Store keeps the latest telemetry sample per model/backend-ref/replica tuple.
 type Store struct {
 	mu         sync.RWMutex
 	items      map[string]BackendTelemetry
@@ -73,8 +73,8 @@ func (s *Store) Upsert(telemetry BackendTelemetry) error {
 		return fmt.Errorf("backend telemetry store is nil")
 	}
 	telemetry.Identity = telemetry.Identity.Normalize()
-	if telemetry.Identity.BackendID == "" {
-		return fmt.Errorf("backend telemetry requires backend identity")
+	if telemetry.Identity.BackendRefName == "" {
+		return fmt.Errorf("backend telemetry requires backend ref name")
 	}
 	if telemetry.Identity.ModelName == "" {
 		return fmt.Errorf("backend telemetry requires model name")
@@ -141,19 +141,19 @@ func (s *Store) ListFreshByModel(modelName string) []BackendTelemetry {
 	return results
 }
 
-// ListByBackend returns raw telemetry for a model/backend pair.
-func (s *Store) ListByBackend(modelName string, backendID string) []BackendTelemetry {
+// ListByBackend returns raw telemetry for a model/backend-ref pair.
+func (s *Store) ListByBackend(modelName string, backendRefName string) []BackendTelemetry {
 	if s == nil {
 		return nil
 	}
 	modelName = strings.TrimSpace(modelName)
-	backendID = strings.TrimSpace(backendID)
+	backendRefName = strings.TrimSpace(backendRefName)
 	results := []BackendTelemetry{}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, telemetry := range s.items {
-		if telemetry.Identity.ModelName == modelName && telemetry.Identity.BackendID == backendID {
+		if telemetry.Identity.ModelName == modelName && telemetry.Identity.BackendRefName == backendRefName {
 			results = append(results, telemetry)
 		}
 	}

--- a/src/semantic-router/pkg/backend/store_test.go
+++ b/src/semantic-router/pkg/backend/store_test.go
@@ -10,9 +10,9 @@ func TestStoreGetFreshHonorsDefaultTTL(t *testing.T) {
 	now := base
 	store := newStoreWithClock(5*time.Second, func() time.Time { return now })
 	identity := BackendIdentity{
-		BackendID: "qwen-primary",
-		ModelName: "qwen3-8b",
-		ReplicaID: "replica-a",
+		BackendRefName: "qwen-primary",
+		ModelName:      "qwen3-8b",
+		ReplicaID:      "replica-a",
 	}
 
 	if err := store.Upsert(BackendTelemetry{Identity: identity}); err != nil {
@@ -26,7 +26,7 @@ func TestStoreGetFreshHonorsDefaultTTL(t *testing.T) {
 	if _, ok := store.GetFresh(identity); ok {
 		t.Fatal("expected telemetry to be stale after default TTL")
 	}
-	if telemetry, ok := store.Get(identity); !ok || telemetry.Identity.BackendID != identity.BackendID {
+	if telemetry, ok := store.Get(identity); !ok || telemetry.Identity.BackendRefName != identity.BackendRefName {
 		t.Fatalf("expected raw stale telemetry to remain available, got %#v ok=%v", telemetry, ok)
 	}
 }
@@ -35,7 +35,7 @@ func TestStoreTelemetryTTLOverridesDefault(t *testing.T) {
 	base := time.Unix(200, 0)
 	now := base
 	store := newStoreWithClock(5*time.Second, func() time.Time { return now })
-	identity := BackendIdentity{BackendID: "slow-ttl", ModelName: "qwen3-8b"}
+	identity := BackendIdentity{BackendRefName: "slow-ttl", ModelName: "qwen3-8b"}
 
 	if err := store.Upsert(BackendTelemetry{
 		Identity:    identity,
@@ -54,7 +54,7 @@ func TestStoreTelemetryTTLOverridesDefault(t *testing.T) {
 func TestStoreGetFreshRejectsFutureCollectedAt(t *testing.T) {
 	base := time.Unix(300, 0)
 	store := newStoreWithClock(5*time.Second, func() time.Time { return base })
-	identity := BackendIdentity{BackendID: "future-sample", ModelName: "qwen3-8b"}
+	identity := BackendIdentity{BackendRefName: "future-sample", ModelName: "qwen3-8b"}
 
 	if err := store.Upsert(BackendTelemetry{
 		Identity:    identity,
@@ -71,9 +71,9 @@ func TestStoreGetFreshRejectsFutureCollectedAt(t *testing.T) {
 func TestStoreRejectsIncompleteIdentity(t *testing.T) {
 	store := NewStore(DefaultTelemetryTTL)
 	if err := store.Upsert(BackendTelemetry{Identity: BackendIdentity{ModelName: "qwen3-8b"}}); err == nil {
-		t.Fatal("expected missing backend id to be rejected")
+		t.Fatal("expected missing backend ref name to be rejected")
 	}
-	if err := store.Upsert(BackendTelemetry{Identity: BackendIdentity{BackendID: "backend"}}); err == nil {
+	if err := store.Upsert(BackendTelemetry{Identity: BackendIdentity{BackendRefName: "backend"}}); err == nil {
 		t.Fatal("expected missing model name to be rejected")
 	}
 }

--- a/src/semantic-router/pkg/backend/store_test.go
+++ b/src/semantic-router/pkg/backend/store_test.go
@@ -1,0 +1,79 @@
+package backend
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStoreGetFreshHonorsDefaultTTL(t *testing.T) {
+	base := time.Unix(100, 0)
+	now := base
+	store := newStoreWithClock(5*time.Second, func() time.Time { return now })
+	identity := BackendIdentity{
+		BackendID: "qwen-primary",
+		ModelName: "qwen3-8b",
+		ReplicaID: "replica-a",
+	}
+
+	if err := store.Upsert(BackendTelemetry{Identity: identity}); err != nil {
+		t.Fatalf("Upsert returned error: %v", err)
+	}
+	if _, ok := store.GetFresh(identity); !ok {
+		t.Fatal("expected telemetry to be fresh immediately after upsert")
+	}
+
+	now = base.Add(6 * time.Second)
+	if _, ok := store.GetFresh(identity); ok {
+		t.Fatal("expected telemetry to be stale after default TTL")
+	}
+	if telemetry, ok := store.Get(identity); !ok || telemetry.Identity.BackendID != identity.BackendID {
+		t.Fatalf("expected raw stale telemetry to remain available, got %#v ok=%v", telemetry, ok)
+	}
+}
+
+func TestStoreTelemetryTTLOverridesDefault(t *testing.T) {
+	base := time.Unix(200, 0)
+	now := base
+	store := newStoreWithClock(5*time.Second, func() time.Time { return now })
+	identity := BackendIdentity{BackendID: "slow-ttl", ModelName: "qwen3-8b"}
+
+	if err := store.Upsert(BackendTelemetry{
+		Identity:    identity,
+		CollectedAt: base,
+		TTL:         30 * time.Second,
+	}); err != nil {
+		t.Fatalf("Upsert returned error: %v", err)
+	}
+
+	now = base.Add(20 * time.Second)
+	if _, ok := store.GetFresh(identity); !ok {
+		t.Fatal("expected telemetry-specific TTL to keep sample fresh")
+	}
+}
+
+func TestStoreGetFreshRejectsFutureCollectedAt(t *testing.T) {
+	base := time.Unix(300, 0)
+	store := newStoreWithClock(5*time.Second, func() time.Time { return base })
+	identity := BackendIdentity{BackendID: "future-sample", ModelName: "qwen3-8b"}
+
+	if err := store.Upsert(BackendTelemetry{
+		Identity:    identity,
+		CollectedAt: base.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("Upsert returned error: %v", err)
+	}
+
+	if _, ok := store.GetFresh(identity); ok {
+		t.Fatal("expected future-dated telemetry to be treated as not fresh")
+	}
+}
+
+func TestStoreRejectsIncompleteIdentity(t *testing.T) {
+	store := NewStore(DefaultTelemetryTTL)
+	if err := store.Upsert(BackendTelemetry{Identity: BackendIdentity{ModelName: "qwen3-8b"}}); err == nil {
+		t.Fatal("expected missing backend id to be rejected")
+	}
+	if err := store.Upsert(BackendTelemetry{Identity: BackendIdentity{BackendID: "backend"}}); err == nil {
+		t.Fatal("expected missing model name to be rejected")
+	}
+}

--- a/src/semantic-router/pkg/backend/types.go
+++ b/src/semantic-router/pkg/backend/types.go
@@ -5,14 +5,14 @@ import (
 	"time"
 )
 
-// EngineKind identifies the serving engine that produced backend telemetry.
-type EngineKind string
+// Runtime identifies the serving runtime that produced backend telemetry.
+type Runtime string
 
 const (
-	EngineKindVLLM        EngineKind = "vllm"
-	EngineKindSGLang      EngineKind = "sglang"
-	EngineKindATOM        EngineKind = "atom"
-	EngineKindTensorRTLLM EngineKind = "tensorrt-llm"
+	RuntimeVLLM        Runtime = "vllm"
+	RuntimeSGLang      Runtime = "sglang"
+	RuntimeATOM        Runtime = "atom"
+	RuntimeTensorRTLLM Runtime = "tensorrt-llm"
 )
 
 // HealthState reports the adapter's normalized view of backend health.
@@ -25,33 +25,33 @@ const (
 	HealthStateUnhealthy HealthState = "unhealthy"
 )
 
-// BackendIdentity names one logical backend and optional serving replica.
+// BackendIdentity names one backend pool and optional serving replica.
 type BackendIdentity struct {
-	BackendID     string
-	ModelName     string
-	ReplicaID     string
-	Endpoint      string
-	EngineKind    EngineKind
-	EngineVersion string
+	BackendRefName string
+	ModelName      string
+	ReplicaID      string
+	Endpoint       string
+	Runtime        Runtime
+	RuntimeVersion string
 }
 
 // Normalize trims string identity fields while preserving engine metadata.
 func (id BackendIdentity) Normalize() BackendIdentity {
-	id.BackendID = strings.TrimSpace(id.BackendID)
+	id.BackendRefName = strings.TrimSpace(id.BackendRefName)
 	id.ModelName = strings.TrimSpace(id.ModelName)
 	id.ReplicaID = strings.TrimSpace(id.ReplicaID)
 	id.Endpoint = strings.TrimSpace(id.Endpoint)
-	id.EngineVersion = strings.TrimSpace(id.EngineVersion)
+	id.RuntimeVersion = strings.TrimSpace(id.RuntimeVersion)
 	return id
 }
 
-// Key returns the stable store key for a model/backend/replica tuple.
+// Key returns the stable store key for a model/backend-ref/replica tuple.
 func (id BackendIdentity) Key() string {
 	id = id.Normalize()
 	if id.ReplicaID == "" {
-		return id.ModelName + "|" + id.BackendID
+		return id.ModelName + "|" + id.BackendRefName
 	}
-	return id.ModelName + "|" + id.BackendID + "|" + id.ReplicaID
+	return id.ModelName + "|" + id.BackendRefName + "|" + id.ReplicaID
 }
 
 // BackendTelemetry is the engine-neutral telemetry contract consumed by
@@ -102,33 +102,33 @@ type BackendAffinity struct {
 
 // BackendCandidate is the minimal input shape for second-stage backend policy.
 type BackendCandidate struct {
-	BackendID    string
-	ReplicaID    string
-	ModelName    string
-	EndpointName string
-	Weight       int
+	BackendRefName string
+	ReplicaID      string
+	ModelName      string
+	EndpointName   string
+	Weight         int
 }
 
 // BackendPolicyResult explains the selected backend or why policy failed open.
 type BackendPolicyResult struct {
-	SelectedBackendID string                   `json:"selected_backend_id,omitempty"`
-	SelectedReplicaID string                   `json:"selected_replica_id,omitempty"`
-	FailOpen          bool                     `json:"fail_open"`
-	Reason            string                   `json:"reason,omitempty"`
-	Diagnostics       BackendPolicyDiagnostics `json:"diagnostics"`
+	SelectedBackendRefName string                   `json:"selected_backend_ref_name,omitempty"`
+	SelectedReplicaID      string                   `json:"selected_replica_id,omitempty"`
+	FailOpen               bool                     `json:"fail_open"`
+	Reason                 string                   `json:"reason,omitempty"`
+	Diagnostics            BackendPolicyDiagnostics `json:"diagnostics"`
 }
 
 // BackendPolicyDiagnostics is safe to persist in replay/debug records.
 type BackendPolicyDiagnostics struct {
-	SelectedModel       string `json:"selected_model,omitempty"`
-	SelectedBackendID   string `json:"selected_backend_id,omitempty"`
-	SelectedReplicaID   string `json:"selected_replica_id,omitempty"`
-	TelemetryFresh      bool   `json:"telemetry_fresh"`
-	TelemetryAgeMS      int64  `json:"telemetry_age_ms,omitempty"`
-	PolicyReason        string `json:"policy_reason,omitempty"`
-	FallbackReason      string `json:"fallback_reason,omitempty"`
-	CandidateCount      int    `json:"candidate_count"`
-	FreshCandidateCount int    `json:"fresh_candidate_count"`
+	SelectedModel          string `json:"selected_model,omitempty"`
+	SelectedBackendRefName string `json:"selected_backend_ref_name,omitempty"`
+	SelectedReplicaID      string `json:"selected_replica_id,omitempty"`
+	TelemetryFresh         bool   `json:"telemetry_fresh"`
+	TelemetryAgeMS         int64  `json:"telemetry_age_ms,omitempty"`
+	PolicyReason           string `json:"policy_reason,omitempty"`
+	FallbackReason         string `json:"fallback_reason,omitempty"`
+	CandidateCount         int    `json:"candidate_count"`
+	FreshCandidateCount    int    `json:"fresh_candidate_count"`
 	// UnhealthyCount counts candidates with fresh telemetry but no selectable replica.
 	UnhealthyCount int `json:"unhealthy_count"`
 }

--- a/src/semantic-router/pkg/backend/types.go
+++ b/src/semantic-router/pkg/backend/types.go
@@ -129,5 +129,6 @@ type BackendPolicyDiagnostics struct {
 	FallbackReason      string `json:"fallback_reason,omitempty"`
 	CandidateCount      int    `json:"candidate_count"`
 	FreshCandidateCount int    `json:"fresh_candidate_count"`
-	UnhealthyCount      int    `json:"unhealthy_count"`
+	// UnhealthyCount counts candidates with fresh telemetry but no selectable replica.
+	UnhealthyCount int `json:"unhealthy_count"`
 }

--- a/src/semantic-router/pkg/backend/types.go
+++ b/src/semantic-router/pkg/backend/types.go
@@ -1,0 +1,133 @@
+package backend
+
+import (
+	"strings"
+	"time"
+)
+
+// EngineKind identifies the serving engine that produced backend telemetry.
+type EngineKind string
+
+const (
+	EngineKindVLLM        EngineKind = "vllm"
+	EngineKindSGLang      EngineKind = "sglang"
+	EngineKindATOM        EngineKind = "atom"
+	EngineKindTensorRTLLM EngineKind = "tensorrt-llm"
+)
+
+// HealthState reports the adapter's normalized view of backend health.
+type HealthState string
+
+const (
+	HealthStateUnknown   HealthState = "unknown"
+	HealthStateHealthy   HealthState = "healthy"
+	HealthStateDegraded  HealthState = "degraded"
+	HealthStateUnhealthy HealthState = "unhealthy"
+)
+
+// BackendIdentity names one logical backend and optional serving replica.
+type BackendIdentity struct {
+	BackendID     string
+	ModelName     string
+	ReplicaID     string
+	Endpoint      string
+	EngineKind    EngineKind
+	EngineVersion string
+}
+
+// Normalize trims string identity fields while preserving engine metadata.
+func (id BackendIdentity) Normalize() BackendIdentity {
+	id.BackendID = strings.TrimSpace(id.BackendID)
+	id.ModelName = strings.TrimSpace(id.ModelName)
+	id.ReplicaID = strings.TrimSpace(id.ReplicaID)
+	id.Endpoint = strings.TrimSpace(id.Endpoint)
+	id.EngineVersion = strings.TrimSpace(id.EngineVersion)
+	return id
+}
+
+// Key returns the stable store key for a model/backend/replica tuple.
+func (id BackendIdentity) Key() string {
+	id = id.Normalize()
+	if id.ReplicaID == "" {
+		return id.ModelName + "|" + id.BackendID
+	}
+	return id.ModelName + "|" + id.BackendID + "|" + id.ReplicaID
+}
+
+// BackendTelemetry is the engine-neutral telemetry contract consumed by
+// backend-aware policy helpers.
+type BackendTelemetry struct {
+	Identity BackendIdentity
+
+	QueueDepth     *int
+	ActiveRequests *int
+
+	GPUUtilization  *float64
+	MemoryPressure  *float64
+	KVCachePressure *float64
+
+	Latency  BackendLatency
+	Affinity BackendAffinity
+
+	Health      HealthState
+	Confidence  float64
+	CollectedAt time.Time
+	TTL         time.Duration
+}
+
+// BackendLatency holds normalized latency snapshots in seconds.
+type BackendLatency struct {
+	TTFTSeconds  LatencySnapshot
+	TPOTSeconds  LatencySnapshot
+	E2ESeconds   LatencySnapshot
+	QueueSeconds LatencySnapshot
+}
+
+// LatencySnapshot reports latency distribution samples in seconds.
+type LatencySnapshot struct {
+	P50Seconds *float64
+	P90Seconds *float64
+	P95Seconds *float64
+	P99Seconds *float64
+}
+
+// BackendAffinity carries optional cache/session hints without engine-specific
+// policy logic.
+type BackendAffinity struct {
+	PrefixCacheHitRate *float64
+	KVCacheReuseScore  *float64
+	SessionAffinity    map[string]float64
+	ExtraHints         map[string]float64
+}
+
+// BackendCandidate is the minimal input shape for second-stage backend policy.
+type BackendCandidate struct {
+	BackendID    string
+	ReplicaID    string
+	ModelName    string
+	EndpointName string
+	Weight       int
+}
+
+// BackendPolicyResult explains the selected backend or why policy failed open.
+type BackendPolicyResult struct {
+	SelectedBackendID string                   `json:"selected_backend_id,omitempty"`
+	SelectedReplicaID string                   `json:"selected_replica_id,omitempty"`
+	FailOpen          bool                     `json:"fail_open"`
+	Reason            string                   `json:"reason,omitempty"`
+	Diagnostics       BackendPolicyDiagnostics `json:"diagnostics"`
+}
+
+// BackendPolicyDiagnostics is safe to persist in replay/debug records.
+type BackendPolicyDiagnostics struct {
+	SelectedModel       string `json:"selected_model,omitempty"`
+	SelectedBackendID   string `json:"selected_backend_id,omitempty"`
+	SelectedReplicaID   string `json:"selected_replica_id,omitempty"`
+	TelemetryFresh      bool   `json:"telemetry_fresh"`
+	TelemetryAgeMS      int64  `json:"telemetry_age_ms,omitempty"`
+	PolicyReason        string `json:"policy_reason,omitempty"`
+	FallbackReason      string `json:"fallback_reason,omitempty"`
+	CandidateCount      int    `json:"candidate_count"`
+	FreshCandidateCount int    `json:"fresh_candidate_count"`
+	UnhealthyCount      int    `json:"unhealthy_count"`
+}

--- a/src/semantic-router/pkg/config/canonical_config.go
+++ b/src/semantic-router/pkg/config/canonical_config.go
@@ -343,12 +343,14 @@ func normalizeCanonicalProviderModels(models []CanonicalProviderModel) (map[stri
 			endpointName := canonicalEndpointName(model.Name, backendRef, index)
 			backendType := canonicalBackendType(backendRef)
 			endpoint := VLLMEndpoint{
-				Name:     endpointName,
-				Weight:   backendRef.Weight,
-				Type:     backendType,
-				Protocol: defaultProtocol(backendRef.Protocol),
-				Model:    model.Name,
-				APIKey:   resolveBackendAPIKey(backendRef),
+				Name:       endpointName,
+				BackendID:  backendRef.BackendID,
+				EngineKind: backendRef.EngineKind,
+				Weight:     backendRef.Weight,
+				Type:       backendType,
+				Protocol:   defaultProtocol(backendRef.Protocol),
+				Model:      model.Name,
+				APIKey:     resolveBackendAPIKey(backendRef),
 			}
 			if endpoint.Weight == 0 {
 				endpoint.Weight = 1

--- a/src/semantic-router/pkg/config/canonical_config.go
+++ b/src/semantic-router/pkg/config/canonical_config.go
@@ -426,56 +426,21 @@ func normalizeCanonicalProviderModels(models []CanonicalProviderModel) (map[stri
 				backendEndpoints = []CanonicalBackendEndpoint{{Name: backendRefName}}
 			}
 
-			for endpointIndex, backendEndpoint := range backendEndpoints {
-				endpointName := canonicalEndpointName(model.Name, backendRef, refIndex, backendEndpoint, endpointIndex)
-				endpoint := VLLMEndpoint{
-					Name:            endpointName,
-					BackendRefName:  backendRefName,
-					Runtime:         backendRef.Runtime,
-					Weight:          canonicalEndpointWeight(backendRef, backendEndpoint),
-					Type:            backendType,
-					Protocol:        defaultProtocol(firstNonEmpty(backendEndpoint.Protocol, backendRef.Protocol)),
-					Model:           model.Name,
-					APIKey:          resolveBackendAPIKey(backendRef),
-					MetricsEndpoint: backendEndpoint.MetricsEndpoint,
-				}
-				if endpoint.Weight == 0 {
-					endpoint.Weight = 1
-				}
-
-				if backendEndpoint.Endpoint != "" {
-					address, port, err := splitEndpointAddress(endpointForParse(backendEndpoint.Endpoint), endpoint.Protocol)
-					if err != nil {
-						return nil, nil, nil, fmt.Errorf("providers.models[%s].backend_refs[%d].endpoints[%d]: %w", model.Name, refIndex, endpointIndex, err)
-					}
-					endpoint.Address = address
-					endpoint.Port = port
-				}
-
-				params.PreferredEndpoints = append(params.PreferredEndpoints, endpointName)
-				if params.AccessKey == "" {
-					params.AccessKey = endpoint.APIKey
-				}
-				endpoints = append(endpoints, endpoint)
+			var err error
+			endpoints, err = appendCanonicalBackendRefEndpoints(
+				endpoints,
+				&params,
+				model.Name,
+				backendRef,
+				refIndex,
+				backendType,
+				backendRefName,
+				backendEndpoints,
+			)
+			if err != nil {
+				return nil, nil, nil, err
 			}
-
-			if len(backendEndpoints) > 0 && (backendRef.BaseURL != "" || backendRef.Provider != "" || backendRef.AuthHeader != "" || backendRef.AuthPrefix != "" || backendRef.ChatPath != "" || len(backendRef.ExtraHeaders) > 0 || backendRef.APIVersion != "") {
-				profileName := canonicalEndpointName(model.Name, backendRef, refIndex, backendEndpoints[0], 0)
-				profiles[profileName] = ProviderProfile{
-					Type:         backendRef.Provider,
-					BaseURL:      backendRef.BaseURL,
-					AuthHeader:   backendRef.AuthHeader,
-					AuthPrefix:   backendRef.AuthPrefix,
-					ExtraHeaders: copyStringMap(backendRef.ExtraHeaders),
-					APIVersion:   backendRef.APIVersion,
-					ChatPath:     backendRef.ChatPath,
-				}
-				for i := len(endpoints) - len(backendEndpoints); i < len(endpoints); i++ {
-					if endpoints[i].BackendRefName == backendRefName && endpoints[i].Model == model.Name {
-						endpoints[i].ProviderProfileName = profileName
-					}
-				}
-			}
+			applyCanonicalProviderProfile(profiles, endpoints, model.Name, backendRef, refIndex, backendRefName, backendEndpoints)
 		}
 
 		modelParams[model.Name] = params
@@ -485,6 +450,86 @@ func normalizeCanonicalProviderModels(models []CanonicalProviderModel) (map[stri
 		profiles = nil
 	}
 	return profiles, endpoints, modelParams, nil
+}
+
+func appendCanonicalBackendRefEndpoints(
+	endpoints []VLLMEndpoint,
+	params *ModelParams,
+	modelName string,
+	backendRef CanonicalBackendRef,
+	refIndex int,
+	backendType string,
+	backendRefName string,
+	backendEndpoints []CanonicalBackendEndpoint,
+) ([]VLLMEndpoint, error) {
+	for endpointIndex, backendEndpoint := range backendEndpoints {
+		endpointName := canonicalEndpointName(modelName, backendRef, refIndex, backendEndpoint, endpointIndex)
+		endpoint := VLLMEndpoint{
+			Name:            endpointName,
+			BackendRefName:  backendRefName,
+			Runtime:         backendRef.Runtime,
+			Weight:          canonicalEndpointWeight(backendRef, backendEndpoint),
+			Type:            backendType,
+			Protocol:        defaultProtocol(firstNonEmpty(backendEndpoint.Protocol, backendRef.Protocol)),
+			Model:           modelName,
+			APIKey:          resolveBackendAPIKey(backendRef),
+			MetricsEndpoint: backendEndpoint.MetricsEndpoint,
+		}
+		if endpoint.Weight == 0 {
+			endpoint.Weight = 1
+		}
+
+		if backendEndpoint.Endpoint != "" {
+			address, port, err := splitEndpointAddress(endpointForParse(backendEndpoint.Endpoint), endpoint.Protocol)
+			if err != nil {
+				return nil, fmt.Errorf("providers.models[%s].backend_refs[%d].endpoints[%d]: %w", modelName, refIndex, endpointIndex, err)
+			}
+			endpoint.Address = address
+			endpoint.Port = port
+		}
+
+		params.PreferredEndpoints = append(params.PreferredEndpoints, endpointName)
+		if params.AccessKey == "" {
+			params.AccessKey = endpoint.APIKey
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+	return endpoints, nil
+}
+
+func applyCanonicalProviderProfile(
+	profiles map[string]ProviderProfile,
+	endpoints []VLLMEndpoint,
+	modelName string,
+	backendRef CanonicalBackendRef,
+	refIndex int,
+	backendRefName string,
+	backendEndpoints []CanonicalBackendEndpoint,
+) {
+	if len(backendEndpoints) == 0 || !canonicalBackendRefHasProfile(backendRef) {
+		return
+	}
+
+	profileName := canonicalEndpointName(modelName, backendRef, refIndex, backendEndpoints[0], 0)
+	profiles[profileName] = ProviderProfile{
+		Type:         backendRef.Provider,
+		BaseURL:      backendRef.BaseURL,
+		AuthHeader:   backendRef.AuthHeader,
+		AuthPrefix:   backendRef.AuthPrefix,
+		ExtraHeaders: copyStringMap(backendRef.ExtraHeaders),
+		APIVersion:   backendRef.APIVersion,
+		ChatPath:     backendRef.ChatPath,
+	}
+	for i := len(endpoints) - len(backendEndpoints); i < len(endpoints); i++ {
+		if endpoints[i].BackendRefName != backendRefName || endpoints[i].Model != modelName {
+			continue
+		}
+		endpoints[i].ProviderProfileName = profileName
+	}
+}
+
+func canonicalBackendRefHasProfile(backendRef CanonicalBackendRef) bool {
+	return backendRef.BaseURL != "" || backendRef.Provider != "" || backendRef.AuthHeader != "" || backendRef.AuthPrefix != "" || backendRef.ChatPath != "" || len(backendRef.ExtraHeaders) > 0 || backendRef.APIVersion != ""
 }
 
 func canonicalBackendRefStaticEndpoints(backendRef CanonicalBackendRef) []CanonicalBackendEndpoint {

--- a/src/semantic-router/pkg/config/canonical_config.go
+++ b/src/semantic-router/pkg/config/canonical_config.go
@@ -156,6 +156,9 @@ func mergeCanonicalProviderModelParams(modelConfig map[string]ModelParams, model
 		if len(providerParams.PreferredEndpoints) > 0 {
 			params.PreferredEndpoints = append([]string(nil), providerParams.PreferredEndpoints...)
 		}
+		if len(params.BackendRefs) == 0 {
+			params.BackendRefs = cloneCanonicalBackendRefs(providerParams.BackendRefs)
+		}
 		if params.AccessKey == "" {
 			params.AccessKey = providerParams.AccessKey
 		}
@@ -213,9 +216,9 @@ func validateCanonicalContract(canonical *CanonicalConfig) error {
 			}
 			continue
 		}
-		for _, backendRef := range canonicalBackendRefs(model) {
-			if strings.TrimSpace(backendRef.Endpoint) == "" && strings.TrimSpace(backendRef.BaseURL) == "" {
-				return fmt.Errorf("providers.models[%s].backend_refs requires endpoint or base_url", model.Name)
+		for index, backendRef := range canonicalBackendRefs(model) {
+			if err := validateCanonicalBackendRef(model.Name, index, backendRef); err != nil {
+				return err
 			}
 		}
 	}
@@ -239,6 +242,81 @@ func validateCanonicalDecisions(decisions []Decision, modelsByName map[string]Ro
 	}
 
 	return nil
+}
+
+func validateCanonicalBackendRef(modelName string, index int, backendRef CanonicalBackendRef) error {
+	hasInlineEndpoint := strings.TrimSpace(backendRef.Endpoint) != ""
+	hasStaticEndpoints := len(backendRef.Endpoints) > 0
+	hasDiscovery := canonicalBackendDiscoverySet(backendRef.Discovery)
+	hasBaseURL := strings.TrimSpace(backendRef.BaseURL) != ""
+
+	if hasStaticEndpoints && hasDiscovery {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d] must define either endpoints or discovery, not both", modelName, index)
+	}
+	if hasInlineEndpoint && (hasStaticEndpoints || hasDiscovery) {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d] must not mix legacy endpoint with endpoints or discovery", modelName, index)
+	}
+	if (hasStaticEndpoints || hasDiscovery) && strings.TrimSpace(backendRef.Runtime) == "" {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d].runtime is required for backend-aware endpoint sources", modelName, index)
+	}
+	if !hasInlineEndpoint && !hasStaticEndpoints && !hasDiscovery && !hasBaseURL && !canonicalBackendRefHasProviderMetadata(backendRef) {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d] requires endpoint, endpoints, discovery, or base_url", modelName, index)
+	}
+
+	names := map[string]bool{}
+	for endpointIndex, endpoint := range backendRef.Endpoints {
+		if strings.TrimSpace(endpoint.Endpoint) == "" {
+			return fmt.Errorf("providers.models[%s].backend_refs[%d].endpoints[%d].endpoint is required", modelName, index, endpointIndex)
+		}
+		name := strings.TrimSpace(endpoint.Name)
+		if name == "" {
+			continue
+		}
+		if names[name] {
+			return fmt.Errorf("providers.models[%s].backend_refs[%d].endpoints[%s]: duplicate endpoint name", modelName, index, name)
+		}
+		names[name] = true
+	}
+
+	if hasDiscovery {
+		return validateCanonicalBackendDiscovery(modelName, index, backendRef.Discovery)
+	}
+	return nil
+}
+
+func validateCanonicalBackendDiscovery(modelName string, index int, discovery *CanonicalBackendDiscovery) error {
+	discoveryType := strings.TrimSpace(discovery.Type)
+	if discoveryType == "" {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d].discovery.type is required", modelName, index)
+	}
+	if discoveryType != "kubernetes" {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d].discovery.type %q is not supported", modelName, index, discoveryType)
+	}
+	if discovery.Kubernetes == nil {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d].discovery.kubernetes is required", modelName, index)
+	}
+	kubernetes := discovery.Kubernetes
+	if strings.TrimSpace(kubernetes.Service) == "" {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d].discovery.kubernetes.service is required", modelName, index)
+	}
+	if strings.TrimSpace(kubernetes.Namespace) == "" {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d].discovery.kubernetes.namespace is required", modelName, index)
+	}
+	if strings.TrimSpace(kubernetes.EndpointPort) == "" {
+		return fmt.Errorf("providers.models[%s].backend_refs[%d].discovery.kubernetes.endpoint_port is required", modelName, index)
+	}
+	return nil
+}
+
+func canonicalBackendDiscoverySet(discovery *CanonicalBackendDiscovery) bool {
+	if discovery == nil {
+		return false
+	}
+	return strings.TrimSpace(discovery.Type) != "" || discovery.Kubernetes != nil
+}
+
+func canonicalBackendRefHasProviderMetadata(backendRef CanonicalBackendRef) bool {
+	return backendRef.Provider != "" || backendRef.AuthHeader != "" || backendRef.AuthPrefix != "" || backendRef.APIVersion != "" || backendRef.ChatPath != "" || len(backendRef.ExtraHeaders) > 0
 }
 
 func validateCanonicalDecisionModelRefs(decision Decision, modelsByName map[string]RoutingModel, modelCards []RoutingModel) error {
@@ -336,28 +414,54 @@ func normalizeCanonicalProviderModels(models []CanonicalProviderModel) (map[stri
 		params.Pricing = model.Pricing
 		params.APIFormat = model.APIFormat
 		params.ExternalModelIDs = normalizeExternalModelIDsFromProviderModel(model)
+		params.BackendRefs = cloneCanonicalBackendRefs(canonicalBackendRefs(model))
 
 		backendRefs := canonicalBackendRefs(model)
 		params.PreferredEndpoints = make([]string, 0, len(backendRefs))
-		for index, backendRef := range backendRefs {
-			endpointName := canonicalEndpointName(model.Name, backendRef, index)
+		for refIndex, backendRef := range backendRefs {
 			backendType := canonicalBackendType(backendRef)
-			endpoint := VLLMEndpoint{
-				Name:       endpointName,
-				BackendID:  backendRef.BackendID,
-				EngineKind: backendRef.EngineKind,
-				Weight:     backendRef.Weight,
-				Type:       backendType,
-				Protocol:   defaultProtocol(backendRef.Protocol),
-				Model:      model.Name,
-				APIKey:     resolveBackendAPIKey(backendRef),
-			}
-			if endpoint.Weight == 0 {
-				endpoint.Weight = 1
+			backendRefName := canonicalBackendRefName(backendRef, refIndex)
+			backendEndpoints := canonicalBackendRefStaticEndpoints(backendRef)
+			if len(backendEndpoints) == 0 && !canonicalBackendDiscoverySet(backendRef.Discovery) {
+				backendEndpoints = []CanonicalBackendEndpoint{{Name: backendRefName}}
 			}
 
-			if backendRef.BaseURL != "" || backendRef.Provider != "" || backendRef.AuthHeader != "" || backendRef.AuthPrefix != "" || backendRef.ChatPath != "" || len(backendRef.ExtraHeaders) > 0 || backendRef.APIVersion != "" {
-				profiles[endpointName] = ProviderProfile{
+			for endpointIndex, backendEndpoint := range backendEndpoints {
+				endpointName := canonicalEndpointName(model.Name, backendRef, refIndex, backendEndpoint, endpointIndex)
+				endpoint := VLLMEndpoint{
+					Name:            endpointName,
+					BackendRefName:  backendRefName,
+					Runtime:         backendRef.Runtime,
+					Weight:          canonicalEndpointWeight(backendRef, backendEndpoint),
+					Type:            backendType,
+					Protocol:        defaultProtocol(firstNonEmpty(backendEndpoint.Protocol, backendRef.Protocol)),
+					Model:           model.Name,
+					APIKey:          resolveBackendAPIKey(backendRef),
+					MetricsEndpoint: backendEndpoint.MetricsEndpoint,
+				}
+				if endpoint.Weight == 0 {
+					endpoint.Weight = 1
+				}
+
+				if backendEndpoint.Endpoint != "" {
+					address, port, err := splitEndpointAddress(endpointForParse(backendEndpoint.Endpoint), endpoint.Protocol)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("providers.models[%s].backend_refs[%d].endpoints[%d]: %w", model.Name, refIndex, endpointIndex, err)
+					}
+					endpoint.Address = address
+					endpoint.Port = port
+				}
+
+				params.PreferredEndpoints = append(params.PreferredEndpoints, endpointName)
+				if params.AccessKey == "" {
+					params.AccessKey = endpoint.APIKey
+				}
+				endpoints = append(endpoints, endpoint)
+			}
+
+			if len(backendEndpoints) > 0 && (backendRef.BaseURL != "" || backendRef.Provider != "" || backendRef.AuthHeader != "" || backendRef.AuthPrefix != "" || backendRef.ChatPath != "" || len(backendRef.ExtraHeaders) > 0 || backendRef.APIVersion != "") {
+				profileName := canonicalEndpointName(model.Name, backendRef, refIndex, backendEndpoints[0], 0)
+				profiles[profileName] = ProviderProfile{
 					Type:         backendRef.Provider,
 					BaseURL:      backendRef.BaseURL,
 					AuthHeader:   backendRef.AuthHeader,
@@ -366,23 +470,12 @@ func normalizeCanonicalProviderModels(models []CanonicalProviderModel) (map[stri
 					APIVersion:   backendRef.APIVersion,
 					ChatPath:     backendRef.ChatPath,
 				}
-				endpoint.ProviderProfileName = endpointName
-			}
-
-			if backendRef.Endpoint != "" {
-				address, port, err := splitEndpointAddress(backendRef.Endpoint, backendRef.Protocol)
-				if err != nil {
-					return nil, nil, nil, fmt.Errorf("providers.models[%s].backend_refs[%d]: %w", model.Name, index, err)
+				for i := len(endpoints) - len(backendEndpoints); i < len(endpoints); i++ {
+					if endpoints[i].BackendRefName == backendRefName && endpoints[i].Model == model.Name {
+						endpoints[i].ProviderProfileName = profileName
+					}
 				}
-				endpoint.Address = address
-				endpoint.Port = port
 			}
-
-			params.PreferredEndpoints = append(params.PreferredEndpoints, endpointName)
-			if params.AccessKey == "" {
-				params.AccessKey = endpoint.APIKey
-			}
-			endpoints = append(endpoints, endpoint)
 		}
 
 		modelParams[model.Name] = params
@@ -392,6 +485,32 @@ func normalizeCanonicalProviderModels(models []CanonicalProviderModel) (map[stri
 		profiles = nil
 	}
 	return profiles, endpoints, modelParams, nil
+}
+
+func canonicalBackendRefStaticEndpoints(backendRef CanonicalBackendRef) []CanonicalBackendEndpoint {
+	if len(backendRef.Endpoints) > 0 {
+		return append([]CanonicalBackendEndpoint(nil), backendRef.Endpoints...)
+	}
+	if backendRef.Endpoint == "" {
+		return nil
+	}
+	return []CanonicalBackendEndpoint{{
+		Name:     canonicalBackendRefName(backendRef, 0),
+		Endpoint: backendRef.Endpoint,
+		Protocol: backendRef.Protocol,
+		Weight:   backendRef.Weight,
+	}}
+}
+
+func canonicalEndpointWeight(backendRef CanonicalBackendRef, endpoint CanonicalBackendEndpoint) int {
+	if endpoint.Weight != 0 {
+		return endpoint.Weight
+	}
+	return backendRef.Weight
+}
+
+func endpointForParse(endpoint string) string {
+	return strings.TrimSpace(endpoint)
 }
 
 func normalizeExternalModelIDsFromProviderModel(model CanonicalProviderModel) map[string]string {
@@ -425,7 +544,7 @@ func canonicalBackendType(backendRef CanonicalBackendRef) string {
 	return "vllm"
 }
 
-func canonicalEndpointName(modelName string, backendRef CanonicalBackendRef, index int) string {
+func canonicalBackendRefName(backendRef CanonicalBackendRef, index int) string {
 	suffix := strings.TrimSpace(backendRef.Name)
 	if suffix == "" {
 		if index == 0 {
@@ -434,7 +553,46 @@ func canonicalEndpointName(modelName string, backendRef CanonicalBackendRef, ind
 			suffix = fmt.Sprintf("backend-%d", index+1)
 		}
 	}
-	return modelName + "_" + suffix
+	return suffix
+}
+
+func canonicalEndpointName(modelName string, backendRef CanonicalBackendRef, refIndex int, endpoint CanonicalBackendEndpoint, endpointIndex int) string {
+	refName := canonicalBackendRefName(backendRef, refIndex)
+	endpointName := strings.TrimSpace(endpoint.Name)
+	if len(backendRef.Endpoints) == 0 {
+		return modelName + "_" + refName
+	}
+	if endpointName == "" {
+		endpointName = fmt.Sprintf("endpoint-%d", endpointIndex+1)
+	}
+	return modelName + "_" + refName + "_" + endpointName
+}
+
+func cloneCanonicalBackendRefs(refs []CanonicalBackendRef) []CanonicalBackendRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	cloned := make([]CanonicalBackendRef, len(refs))
+	for i, ref := range refs {
+		cloned[i] = ref
+		if len(ref.Endpoints) > 0 {
+			cloned[i].Endpoints = make([]CanonicalBackendEndpoint, len(ref.Endpoints))
+			for j, endpoint := range ref.Endpoints {
+				cloned[i].Endpoints[j] = endpoint
+				cloned[i].Endpoints[j].Labels = copyStringMap(endpoint.Labels)
+			}
+		}
+		if ref.Discovery != nil {
+			discovery := *ref.Discovery
+			if ref.Discovery.Kubernetes != nil {
+				kubernetes := *ref.Discovery.Kubernetes
+				discovery.Kubernetes = &kubernetes
+			}
+			cloned[i].Discovery = &discovery
+		}
+		cloned[i].ExtraHeaders = copyStringMap(ref.ExtraHeaders)
+	}
+	return cloned
 }
 
 func splitEndpointAddress(raw string, protocol string) (string, int, error) {

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -376,6 +376,8 @@ func canonicalProviderBackendRefs(
 func canonicalBackendRefFromRuntime(endpoint VLLMEndpoint, fallbackAPIKey string, profile ProviderProfile) CanonicalBackendRef {
 	ref := CanonicalBackendRef{
 		Name:       endpoint.Name,
+		BackendID:  endpoint.BackendID,
+		EngineKind: endpoint.EngineKind,
 		Protocol:   endpoint.Protocol,
 		Weight:     endpoint.Weight,
 		Type:       endpoint.Type,

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -349,6 +349,10 @@ func canonicalProviderBackendRefs(
 	endpointsByModel map[string][]VLLMEndpoint,
 	profiles map[string]ProviderProfile,
 ) []CanonicalBackendRef {
+	if len(params.BackendRefs) > 0 {
+		return cloneCanonicalBackendRefs(params.BackendRefs)
+	}
+
 	preferred := params.PreferredEndpoints
 	if len(preferred) == 0 {
 		modelEndpoints := endpointsByModel[modelName]
@@ -375,9 +379,8 @@ func canonicalProviderBackendRefs(
 
 func canonicalBackendRefFromRuntime(endpoint VLLMEndpoint, fallbackAPIKey string, profile ProviderProfile) CanonicalBackendRef {
 	ref := CanonicalBackendRef{
-		Name:       endpoint.Name,
-		BackendID:  endpoint.BackendID,
-		EngineKind: endpoint.EngineKind,
+		Name:       firstNonEmpty(endpoint.BackendRefName, endpoint.Name),
+		Runtime:    endpoint.Runtime,
 		Protocol:   endpoint.Protocol,
 		Weight:     endpoint.Weight,
 		Type:       endpoint.Type,
@@ -390,9 +393,20 @@ func canonicalBackendRefFromRuntime(endpoint VLLMEndpoint, fallbackAPIKey string
 		APIKey:     endpoint.APIKey,
 	}
 	if endpoint.Address != "" {
-		ref.Endpoint = endpoint.Address
+		staticEndpoint := CanonicalBackendEndpoint{
+			Name:            endpoint.Name,
+			Endpoint:        endpoint.Address,
+			MetricsEndpoint: endpoint.MetricsEndpoint,
+			Protocol:        endpoint.Protocol,
+			Weight:          endpoint.Weight,
+		}
 		if endpoint.Port > 0 {
-			ref.Endpoint = fmt.Sprintf("%s:%d", endpoint.Address, endpoint.Port)
+			staticEndpoint.Endpoint = fmt.Sprintf("%s:%d", endpoint.Address, endpoint.Port)
+		}
+		if endpoint.BackendRefName != "" || endpoint.Runtime != "" || endpoint.MetricsEndpoint != "" {
+			ref.Endpoints = []CanonicalBackendEndpoint{staticEndpoint}
+		} else {
+			ref.Endpoint = staticEndpoint.Endpoint
 		}
 	}
 	if ref.APIKey == "" {

--- a/src/semantic-router/pkg/config/canonical_loader_test.go
+++ b/src/semantic-router/pkg/config/canonical_loader_test.go
@@ -603,7 +603,7 @@ routing:
 	}
 }
 
-func TestCanonicalBackendRefBackendIdentityRoundTrips(t *testing.T) {
+func TestCanonicalBackendRefEndpointSourcesRoundTrip(t *testing.T) {
 	canonicalYAML := []byte(`
 version: v0.3
 providers:
@@ -612,11 +612,27 @@ providers:
   models:
     - name: qwen-worker
       backend_refs:
-        - name: local-primary
-          backend_id: qwen-worker-primary
-          engine_kind: vllm
-          endpoint: 127.0.0.1:8000
-          weight: 10
+        - name: local-vllm
+          runtime: vllm
+          protocol: http
+          endpoints:
+            - name: primary-a
+              endpoint: 127.0.0.1:8000
+              metrics_endpoint: 127.0.0.1:9000
+              weight: 80
+            - name: primary-b
+              endpoint: 127.0.0.1:8001
+              weight: 20
+        - name: k8s-vllm
+          runtime: vllm
+          protocol: http
+          discovery:
+            type: kubernetes
+            kubernetes:
+              service: qwen3-vllm
+              namespace: inference
+              endpoint_port: http
+              metrics_port: metrics
 routing:
   modelCards:
     - name: qwen-worker
@@ -634,27 +650,43 @@ routing:
 	if err != nil {
 		t.Fatalf("ParseYAMLBytes returned error: %v", err)
 	}
-	if len(cfg.VLLMEndpoints) != 1 {
-		t.Fatalf("expected one runtime endpoint, got %#v", cfg.VLLMEndpoints)
+	if len(cfg.VLLMEndpoints) != 2 {
+		t.Fatalf("expected two static runtime endpoints, got %#v", cfg.VLLMEndpoints)
 	}
 	endpoint := cfg.VLLMEndpoints[0]
-	if endpoint.BackendID != "qwen-worker-primary" {
-		t.Fatalf("BackendID = %q, want qwen-worker-primary", endpoint.BackendID)
+	if endpoint.BackendRefName != "local-vllm" {
+		t.Fatalf("BackendRefName = %q, want local-vllm", endpoint.BackendRefName)
 	}
-	if endpoint.EngineKind != "vllm" {
-		t.Fatalf("EngineKind = %q, want vllm", endpoint.EngineKind)
+	if endpoint.Runtime != "vllm" {
+		t.Fatalf("Runtime = %q, want vllm", endpoint.Runtime)
+	}
+	if endpoint.MetricsEndpoint != "127.0.0.1:9000" {
+		t.Fatalf("MetricsEndpoint = %q, want 127.0.0.1:9000", endpoint.MetricsEndpoint)
+	}
+	if got := cfg.ModelConfig["qwen-worker"].PreferredEndpoints; len(got) != 2 {
+		t.Fatalf("expected static endpoints to populate preferred endpoints, got %#v", got)
+	}
+	if got := cfg.ModelConfig["qwen-worker"].BackendRefs; len(got) != 2 || got[1].Discovery == nil {
+		t.Fatalf("expected model params to preserve static and discovery refs, got %#v", got)
 	}
 
 	exported := CanonicalConfigFromRouterConfig(cfg)
-	if len(exported.Providers.Models) != 1 || len(exported.Providers.Models[0].BackendRefs) != 1 {
+	if len(exported.Providers.Models) != 1 || len(exported.Providers.Models[0].BackendRefs) != 2 {
 		t.Fatalf("expected one exported backend ref, got %#v", exported.Providers.Models)
 	}
 	ref := exported.Providers.Models[0].BackendRefs[0]
-	if ref.BackendID != "qwen-worker-primary" {
-		t.Fatalf("exported BackendID = %q, want qwen-worker-primary", ref.BackendID)
+	if ref.Runtime != "vllm" {
+		t.Fatalf("exported Runtime = %q, want vllm", ref.Runtime)
 	}
-	if ref.EngineKind != "vllm" {
-		t.Fatalf("exported EngineKind = %q, want vllm", ref.EngineKind)
+	if len(ref.Endpoints) != 2 || ref.Endpoints[1].Endpoint != "127.0.0.1:8001" {
+		t.Fatalf("exported static endpoints not preserved: %#v", ref.Endpoints)
+	}
+	discoveryRef := exported.Providers.Models[0].BackendRefs[1]
+	if discoveryRef.Discovery == nil || discoveryRef.Discovery.Kubernetes == nil {
+		t.Fatalf("exported discovery not preserved: %#v", discoveryRef)
+	}
+	if discoveryRef.Discovery.Kubernetes.EndpointPort != "http" {
+		t.Fatalf("exported endpoint_port = %q, want http", discoveryRef.Discovery.Kubernetes.EndpointPort)
 	}
 }
 

--- a/src/semantic-router/pkg/config/canonical_loader_test.go
+++ b/src/semantic-router/pkg/config/canonical_loader_test.go
@@ -603,6 +603,61 @@ routing:
 	}
 }
 
+func TestCanonicalBackendRefBackendIdentityRoundTrips(t *testing.T) {
+	canonicalYAML := []byte(`
+version: v0.3
+providers:
+  defaults:
+    default_model: qwen-worker
+  models:
+    - name: qwen-worker
+      backend_refs:
+        - name: local-primary
+          backend_id: qwen-worker-primary
+          engine_kind: vllm
+          endpoint: 127.0.0.1:8000
+          weight: 10
+routing:
+  modelCards:
+    - name: qwen-worker
+  decisions:
+    - name: default
+      priority: 1
+      rules:
+        operator: OR
+        conditions: []
+      modelRefs:
+        - model: qwen-worker
+`)
+
+	cfg, err := ParseYAMLBytes(canonicalYAML)
+	if err != nil {
+		t.Fatalf("ParseYAMLBytes returned error: %v", err)
+	}
+	if len(cfg.VLLMEndpoints) != 1 {
+		t.Fatalf("expected one runtime endpoint, got %#v", cfg.VLLMEndpoints)
+	}
+	endpoint := cfg.VLLMEndpoints[0]
+	if endpoint.BackendID != "qwen-worker-primary" {
+		t.Fatalf("BackendID = %q, want qwen-worker-primary", endpoint.BackendID)
+	}
+	if endpoint.EngineKind != "vllm" {
+		t.Fatalf("EngineKind = %q, want vllm", endpoint.EngineKind)
+	}
+
+	exported := CanonicalConfigFromRouterConfig(cfg)
+	if len(exported.Providers.Models) != 1 || len(exported.Providers.Models[0].BackendRefs) != 1 {
+		t.Fatalf("expected one exported backend ref, got %#v", exported.Providers.Models)
+	}
+	ref := exported.Providers.Models[0].BackendRefs[0]
+	if ref.BackendID != "qwen-worker-primary" {
+		t.Fatalf("exported BackendID = %q, want qwen-worker-primary", ref.BackendID)
+	}
+	if ref.EngineKind != "vllm" {
+		t.Fatalf("exported EngineKind = %q, want vllm", ref.EngineKind)
+	}
+}
+
 func TestGetModelPricingTreatsExplicitZeroPricingAsConfigured(t *testing.T) {
 	cfg := &RouterConfig{
 		BackendModels: BackendModels{

--- a/src/semantic-router/pkg/config/canonical_providers.go
+++ b/src/semantic-router/pkg/config/canonical_providers.go
@@ -29,6 +29,8 @@ type CanonicalProviderModel struct {
 // CanonicalBackendRef defines one physical backend target for a provider model.
 type CanonicalBackendRef struct {
 	Name         string            `yaml:"name,omitempty"`
+	BackendID    string            `yaml:"backend_id,omitempty"`
+	EngineKind   string            `yaml:"engine_kind,omitempty"`
 	Endpoint     string            `yaml:"endpoint,omitempty"`
 	Protocol     string            `yaml:"protocol,omitempty"`
 	Weight       int               `yaml:"weight,omitempty"`

--- a/src/semantic-router/pkg/config/canonical_providers.go
+++ b/src/semantic-router/pkg/config/canonical_providers.go
@@ -26,24 +26,49 @@ type CanonicalProviderModel struct {
 	ExternalModelIDs map[string]string     `yaml:"external_model_ids,omitempty"`
 }
 
-// CanonicalBackendRef defines one physical backend target for a provider model.
+// CanonicalBackendRef defines one runtime backend pool for a provider model.
 type CanonicalBackendRef struct {
-	Name         string            `yaml:"name,omitempty"`
-	BackendID    string            `yaml:"backend_id,omitempty"`
-	EngineKind   string            `yaml:"engine_kind,omitempty"`
-	Endpoint     string            `yaml:"endpoint,omitempty"`
-	Protocol     string            `yaml:"protocol,omitempty"`
-	Weight       int               `yaml:"weight,omitempty"`
-	Type         string            `yaml:"type,omitempty"`
-	BaseURL      string            `yaml:"base_url,omitempty"`
-	Provider     string            `yaml:"provider,omitempty"`
-	AuthHeader   string            `yaml:"auth_header,omitempty"`
-	AuthPrefix   string            `yaml:"auth_prefix,omitempty"`
-	ExtraHeaders map[string]string `yaml:"extra_headers,omitempty"`
-	APIVersion   string            `yaml:"api_version,omitempty"`
-	ChatPath     string            `yaml:"chat_path,omitempty"`
-	APIKey       string            `yaml:"api_key,omitempty"`
-	APIKeyEnv    string            `yaml:"api_key_env,omitempty"`
+	Name         string                     `yaml:"name,omitempty"`
+	Runtime      string                     `yaml:"runtime,omitempty"`
+	Endpoint     string                     `yaml:"endpoint,omitempty"`
+	Endpoints    []CanonicalBackendEndpoint `yaml:"endpoints,omitempty"`
+	Discovery    *CanonicalBackendDiscovery `yaml:"discovery,omitempty"`
+	Protocol     string                     `yaml:"protocol,omitempty"`
+	Weight       int                        `yaml:"weight,omitempty"`
+	Type         string                     `yaml:"type,omitempty"`
+	BaseURL      string                     `yaml:"base_url,omitempty"`
+	Provider     string                     `yaml:"provider,omitempty"`
+	AuthHeader   string                     `yaml:"auth_header,omitempty"`
+	AuthPrefix   string                     `yaml:"auth_prefix,omitempty"`
+	ExtraHeaders map[string]string          `yaml:"extra_headers,omitempty"`
+	APIVersion   string                     `yaml:"api_version,omitempty"`
+	ChatPath     string                     `yaml:"chat_path,omitempty"`
+	APIKey       string                     `yaml:"api_key,omitempty"`
+	APIKeyEnv    string                     `yaml:"api_key_env,omitempty"`
+}
+
+// CanonicalBackendEndpoint defines one static member of a runtime backend pool.
+type CanonicalBackendEndpoint struct {
+	Name            string            `yaml:"name,omitempty"`
+	Endpoint        string            `yaml:"endpoint,omitempty"`
+	MetricsEndpoint string            `yaml:"metrics_endpoint,omitempty"`
+	Protocol        string            `yaml:"protocol,omitempty"`
+	Weight          int               `yaml:"weight,omitempty"`
+	Labels          map[string]string `yaml:"labels,omitempty"`
+}
+
+// CanonicalBackendDiscovery defines a typed dynamic endpoint source.
+type CanonicalBackendDiscovery struct {
+	Type       string                        `yaml:"type,omitempty"`
+	Kubernetes *CanonicalKubernetesDiscovery `yaml:"kubernetes,omitempty"`
+}
+
+// CanonicalKubernetesDiscovery describes Kubernetes Service-backed endpoint discovery.
+type CanonicalKubernetesDiscovery struct {
+	Service      string `yaml:"service,omitempty"`
+	Namespace    string `yaml:"namespace,omitempty"`
+	EndpointPort string `yaml:"endpoint_port,omitempty"`
+	MetricsPort  string `yaml:"metrics_port,omitempty"`
 }
 
 func canonicalProviderDefaults(providers CanonicalProviders) CanonicalProviderDefaults {

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -282,10 +282,11 @@ type ClassifierVLLMEndpoint struct {
 
 type VLLMEndpoint struct {
 	Name                string `yaml:"name"`
-	BackendID           string `yaml:"backend_id,omitempty"`
-	EngineKind          string `yaml:"engine_kind,omitempty"`
+	BackendRefName      string `yaml:"backend_ref,omitempty"`
+	Runtime             string `yaml:"runtime,omitempty"`
 	Address             string `yaml:"address"`
 	Port                int    `yaml:"port"`
+	MetricsEndpoint     string `yaml:"metrics_endpoint,omitempty"`
 	Weight              int    `yaml:"weight,omitempty"`
 	Type                string `yaml:"type,omitempty"`
 	APIKey              string `yaml:"api_key,omitempty" json:"-"`
@@ -313,21 +314,22 @@ type ModelPricing struct {
 }
 
 type ModelParams struct {
-	PreferredEndpoints []string          `yaml:"preferred_endpoints,omitempty"`
-	Pricing            ModelPricing      `yaml:"pricing,omitempty"`
-	ReasoningFamily    string            `yaml:"reasoning_family,omitempty"`
-	LoRAs              []LoRAAdapter     `yaml:"loras,omitempty"`
-	AccessKey          string            `yaml:"access_key,omitempty" json:"-"`
-	ParamSize          string            `yaml:"param_size,omitempty"`
-	ContextWindowSize  int               `yaml:"context_window_size,omitempty"`
-	APIFormat          string            `yaml:"api_format,omitempty"`
-	Description        string            `yaml:"description,omitempty"`
-	Capabilities       []string          `yaml:"capabilities,omitempty"`
-	Tags               []string          `yaml:"tags,omitempty"`
-	QualityScore       float64           `yaml:"quality_score,omitempty"`
-	ExternalModelIDs   map[string]string `yaml:"external_model_ids,omitempty"`
-	Modality           string            `yaml:"modality,omitempty"`
-	ImageGenBackend    string            `yaml:"image_gen_backend,omitempty"`
+	PreferredEndpoints []string              `yaml:"preferred_endpoints,omitempty"`
+	BackendRefs        []CanonicalBackendRef `yaml:"backend_refs,omitempty"`
+	Pricing            ModelPricing          `yaml:"pricing,omitempty"`
+	ReasoningFamily    string                `yaml:"reasoning_family,omitempty"`
+	LoRAs              []LoRAAdapter         `yaml:"loras,omitempty"`
+	AccessKey          string                `yaml:"access_key,omitempty" json:"-"`
+	ParamSize          string                `yaml:"param_size,omitempty"`
+	ContextWindowSize  int                   `yaml:"context_window_size,omitempty"`
+	APIFormat          string                `yaml:"api_format,omitempty"`
+	Description        string                `yaml:"description,omitempty"`
+	Capabilities       []string              `yaml:"capabilities,omitempty"`
+	Tags               []string              `yaml:"tags,omitempty"`
+	QualityScore       float64               `yaml:"quality_score,omitempty"`
+	ExternalModelIDs   map[string]string     `yaml:"external_model_ids,omitempty"`
+	Modality           string                `yaml:"modality,omitempty"`
+	ImageGenBackend    string                `yaml:"image_gen_backend,omitempty"`
 }
 
 type LoRAAdapter struct {

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -282,6 +282,8 @@ type ClassifierVLLMEndpoint struct {
 
 type VLLMEndpoint struct {
 	Name                string `yaml:"name"`
+	BackendID           string `yaml:"backend_id,omitempty"`
+	EngineKind          string `yaml:"engine_kind,omitempty"`
 	Address             string `yaml:"address"`
 	Port                int    `yaml:"port"`
 	Weight              int    `yaml:"weight,omitempty"`

--- a/src/vllm-sr/README.md
+++ b/src/vllm-sr/README.md
@@ -164,7 +164,7 @@ vllm-sr model list --config my-config.yaml
 
 The output is split into two sections:
 
-- **Provider models**: configured model names, the default model marker, provider model IDs, reasoning family, API format, and backend identity fields such as provider, redacted base URL, protocol, and weight.
+- **Provider models**: configured model names, the default model marker, provider model IDs, reasoning family, API format, and backend pool fields such as runtime, provider, target source, protocol, and weight.
 - **Model cards**: routing metadata such as modality, parameter size, context window, capabilities, tags, and LoRA names.
 
 Credential fields are intentionally not printed. API keys, API key environment variable names, embedded URL credentials, and sensitive query parameters are omitted or redacted so the command is safe to use in support logs.

--- a/src/vllm-sr/cli/commands/model.py
+++ b/src/vllm-sr/cli/commands/model.py
@@ -74,10 +74,16 @@ def _print_provider_models(user_config) -> None:
                 # Never print api_key / api_key_env values; expose only the
                 # transport identity so credentials cannot leak via CLI output.
                 provider = ref.provider or "-"
-                base_url = _redact_url(ref.base_url or ref.endpoint or "-")
+                endpoint_count = len(ref.endpoints or [])
+                source = ref.endpoint or ref.base_url or "-"
+                if endpoint_count:
+                    source = f"{endpoint_count} static endpoint{'s' if endpoint_count != 1 else ''}"
+                elif ref.discovery:
+                    source = f"{ref.discovery.type} discovery"
+                base_url = _redact_url(source)
                 label = ref.name or "(unnamed)"
                 log.info(
-                    f"        * {label}  provider={provider}  base_url={base_url}  "
+                    f"        * {label}  runtime={ref.runtime or '-'}  provider={provider}  target={base_url}  "
                     f"protocol={ref.protocol}  weight={ref.weight}"
                 )
 

--- a/src/vllm-sr/cli/config_generator.py
+++ b/src/vllm-sr/cli/config_generator.py
@@ -19,8 +19,8 @@ def _uses_shared_anthropic_cluster(model) -> bool:
     if not model.backend_refs:
         return True
     for backend in model.backend_refs:
-        for upstream in _backend_upstream_values(backend):
-            upstream = upstream.lower()
+        for raw_upstream in _backend_upstream_values(backend):
+            upstream = raw_upstream.lower()
             if not upstream:
                 continue
             if "api.anthropic.com" in upstream:

--- a/src/vllm-sr/cli/config_generator.py
+++ b/src/vllm-sr/cli/config_generator.py
@@ -19,13 +19,61 @@ def _uses_shared_anthropic_cluster(model) -> bool:
     if not model.backend_refs:
         return True
     for backend in model.backend_refs:
-        upstream = (backend.endpoint or backend.base_url or "").lower()
-        if not upstream:
-            continue
-        if "api.anthropic.com" in upstream:
-            continue
-        return False
+        for upstream in _backend_upstream_values(backend):
+            upstream = upstream.lower()
+            if not upstream:
+                continue
+            if "api.anthropic.com" in upstream:
+                continue
+            return False
     return True
+
+
+def _backend_upstream_values(backend) -> list[str]:
+    values: list[str] = []
+    for member in getattr(backend, "endpoints", None) or []:
+        if member.endpoint:
+            values.append(member.endpoint)
+    if not values:
+        upstream = backend.endpoint or backend.base_url or ""
+        if upstream:
+            values.append(upstream)
+    return values
+
+
+def _backend_upstream_specs(backend, backend_index: int) -> list[dict]:
+    members = list(getattr(backend, "endpoints", None) or [])
+    if members:
+        specs = []
+        for member_index, member in enumerate(members):
+            endpoint_str = (member.endpoint or "").strip()
+            if not endpoint_str:
+                continue
+            backend_name = backend.name or f"backend-{backend_index + 1}"
+            member_name = member.name or f"endpoint-{member_index + 1}"
+            specs.append(
+                {
+                    "name": f"{backend_name}/{member_name}",
+                    "endpoint": endpoint_str,
+                    "protocol": member.protocol or backend.protocol or "http",
+                    "weight": (
+                        member.weight if member.weight is not None else backend.weight
+                    ),
+                }
+            )
+        return specs
+
+    upstream = (backend.endpoint or backend.base_url or "").strip()
+    if not upstream:
+        return []
+    return [
+        {
+            "name": backend.name or f"backend-{backend_index + 1}",
+            "endpoint": upstream,
+            "protocol": backend.protocol or "http",
+            "weight": backend.weight,
+        }
+    ]
 
 
 def _is_ip_address(host: str) -> bool:
@@ -138,72 +186,75 @@ def generate_envoy_config_from_user_config(
 
         backend_refs = model.backend_refs
         for index, backend in enumerate(backend_refs):
-            # Parse endpoint: can be "host", "host:port", or "host/path" or "host:port/path"
-            endpoint_str = backend.endpoint or backend.base_url or ""
-            if not endpoint_str:
-                continue
-            path = ""
+            for upstream in _backend_upstream_specs(backend, index):
+                # Parse endpoint: can be "host", "host:port", or "host/path" or "host:port/path"
+                endpoint_str = upstream["endpoint"]
+                if not endpoint_str:
+                    continue
+                path = ""
 
-            if "://" in endpoint_str:
-                parsed = urlparse(endpoint_str)
-                host = parsed.hostname or parsed.netloc
-                path = parsed.path.rstrip("/")
-                protocol = parsed.scheme or backend.protocol
-                port = parsed.port or (443 if protocol == "https" else 80)
-            else:
-                protocol = backend.protocol
-
-                # Extract path if present (e.g., "host/path" or "host:port/path")
-                if "/" in endpoint_str:
-                    # Split by first "/" to separate host[:port] from path
-                    parts = endpoint_str.split("/", 1)
-                    endpoint_str = parts[0]  # host or host:port
-                    path = "/" + parts[1]  # /path
-
-                # Parse host and port
-                if ":" in endpoint_str:
-                    host, port = endpoint_str.split(":", 1)
-                    port = int(port)
+                if "://" in endpoint_str:
+                    parsed = urlparse(endpoint_str)
+                    host = parsed.hostname or parsed.netloc
+                    path = parsed.path.rstrip("/")
+                    protocol = parsed.scheme or upstream["protocol"]
+                    port = parsed.port or (443 if protocol == "https" else 80)
                 else:
-                    host = endpoint_str
-                    # Default port based on protocol
-                    port = 443 if protocol == "https" else 80
+                    protocol = upstream["protocol"]
 
-            # Check if this is HTTPS (for transport_socket)
-            is_https = protocol == "https"
-            if is_https:
-                has_https = True
+                    # Extract path if present (e.g., "host/path" or "host:port/path")
+                    if "/" in endpoint_str:
+                        # Split by first "/" to separate host[:port] from path
+                        parts = endpoint_str.split("/", 1)
+                        endpoint_str = parts[0]  # host or host:port
+                        path = "/" + parts[1]  # /path
 
-            # Check if host is a domain name (for cluster type)
-            # Simple heuristic: if it contains letters or dots in non-IP pattern, it's a domain
-            is_domain = not _is_ip_address(host)
-            if is_domain:
-                uses_dns = True
+                    # Parse host and port
+                    if ":" in endpoint_str:
+                        host, port = endpoint_str.split(":", 1)
+                        port = int(port)
+                    else:
+                        host = endpoint_str
+                        # Default port based on protocol
+                        port = 443 if protocol == "https" else 80
 
-            extra_headers = dict(backend.extra_headers or {})
-            api_key = backend.resolve_api_key()
-            if api_key and backend.auth_header:
-                auth_prefix = (backend.auth_prefix or "").strip()
-                extra_headers[str(backend.auth_header)] = (
-                    f"{auth_prefix} {api_key}".strip() if auth_prefix else str(api_key)
+                # Check if this is HTTPS (for transport_socket)
+                is_https = protocol == "https"
+                if is_https:
+                    has_https = True
+
+                # Check if host is a domain name (for cluster type)
+                # Simple heuristic: if it contains letters or dots in non-IP pattern, it's a domain
+                is_domain = not _is_ip_address(host)
+                if is_domain:
+                    uses_dns = True
+
+                extra_headers = dict(backend.extra_headers or {})
+                api_key = backend.resolve_api_key()
+                if api_key and backend.auth_header:
+                    auth_prefix = (backend.auth_prefix or "").strip()
+                    extra_headers[str(backend.auth_header)] = (
+                        f"{auth_prefix} {api_key}".strip()
+                        if auth_prefix
+                        else str(api_key)
+                    )
+
+                endpoints.append(
+                    {
+                        "name": upstream["name"],
+                        "address": host,
+                        "port": int(port),
+                        "host_authority": (
+                            f"{host}:{port}" if int(port) not in (80, 443) else host
+                        ),
+                        "path": path,
+                        "weight": upstream["weight"],
+                        "protocol": protocol,
+                        "is_https": is_https,
+                        "is_domain": is_domain,
+                        "extra_headers": extra_headers,
+                    }
                 )
-
-            endpoints.append(
-                {
-                    "name": backend.name or f"backend-{index + 1}",
-                    "address": host,
-                    "port": int(port),
-                    "host_authority": (
-                        f"{host}:{port}" if int(port) not in (80, 443) else host
-                    ),
-                    "path": path,
-                    "weight": backend.weight,
-                    "protocol": protocol,
-                    "is_https": is_https,
-                    "is_domain": is_domain,
-                    "extra_headers": extra_headers,
-                }
-            )
 
         # Sanitize model name for cluster name (replace / with _)
         if not endpoints:

--- a/src/vllm-sr/cli/config_migration.py
+++ b/src/vllm-sr/cli/config_migration.py
@@ -208,15 +208,31 @@ def _migrate_legacy_endpoints_to_backend_refs(
         endpoint_value = endpoint.get("endpoint")
         if not endpoint_value:
             continue
+        endpoint_name = endpoint.get("name") or "primary"
+        runtime = endpoint.get("runtime") or endpoint.get("engine_kind")
         backend_ref = {
-            "name": endpoint.get("name") or "primary",
-            "backend_id": endpoint.get("backend_id"),
-            "engine_kind": endpoint.get("engine_kind"),
-            "endpoint": endpoint.get("endpoint"),
+            "name": endpoint.get("backend_ref") or endpoint_name,
             "protocol": endpoint.get("protocol"),
-            "weight": endpoint.get("weight"),
             "type": endpoint.get("type"),
         }
+        if runtime:
+            backend_ref["runtime"] = runtime
+            backend_ref["endpoints"] = [
+                {
+                    key: value
+                    for key, value in {
+                        "name": endpoint_name,
+                        "endpoint": endpoint.get("endpoint"),
+                        "metrics_endpoint": endpoint.get("metrics_endpoint"),
+                        "protocol": endpoint.get("protocol"),
+                        "weight": endpoint.get("weight"),
+                    }.items()
+                    if value not in (None, "", [])
+                }
+            ]
+        else:
+            backend_ref["endpoint"] = endpoint.get("endpoint")
+            backend_ref["weight"] = endpoint.get("weight")
         if model.get("access_key"):
             backend_ref["api_key"] = model["access_key"]
         backend_refs.append(
@@ -397,11 +413,26 @@ def _build_legacy_backend_catalog(source: dict[str, Any]) -> dict[str, dict[str,
             endpoint_value = address.strip()
             if isinstance(port, int) and port > 0:
                 endpoint_value = f"{endpoint_value}:{port}"
-            _set_if_missing(backend_ref, "endpoint", endpoint_value)
+            endpoint_member = {
+                "name": endpoint_name,
+                "endpoint": endpoint_value,
+            }
+            _set_if_missing(endpoint_member, "metrics_endpoint", raw_endpoint.get("metrics_endpoint"))
+            _set_if_missing(endpoint_member, "protocol", raw_endpoint.get("protocol"))
+            _set_if_missing(endpoint_member, "weight", raw_endpoint.get("weight"))
+            backend_ref["endpoints"] = [
+                {
+                    key: value
+                    for key, value in endpoint_member.items()
+                    if value not in (None, "", [])
+                }
+            ]
+
+        runtime = raw_endpoint.get("runtime") or raw_endpoint.get("engine_kind")
+        if runtime or "endpoints" in backend_ref:
+            _set_if_missing(backend_ref, "runtime", runtime or "vllm")
 
         for key in (
-            "backend_id",
-            "engine_kind",
             "protocol",
             "weight",
             "type",
@@ -465,10 +496,13 @@ def _convert_model_targets_to_provider_models(
             if not isinstance(backend, dict):
                 continue
             backend_ref = {"name": backend_name}
+            runtime = backend.get("runtime") or backend.get("engine_kind")
+            if runtime:
+                backend_ref["runtime"] = runtime
             for key in (
-                "backend_id",
-                "engine_kind",
                 "endpoint",
+                "endpoints",
+                "discovery",
                 "protocol",
                 "weight",
                 "type",

--- a/src/vllm-sr/cli/config_migration.py
+++ b/src/vllm-sr/cli/config_migration.py
@@ -417,7 +417,11 @@ def _build_legacy_backend_catalog(source: dict[str, Any]) -> dict[str, dict[str,
                 "name": endpoint_name,
                 "endpoint": endpoint_value,
             }
-            _set_if_missing(endpoint_member, "metrics_endpoint", raw_endpoint.get("metrics_endpoint"))
+            _set_if_missing(
+                endpoint_member,
+                "metrics_endpoint",
+                raw_endpoint.get("metrics_endpoint"),
+            )
             _set_if_missing(endpoint_member, "protocol", raw_endpoint.get("protocol"))
             _set_if_missing(endpoint_member, "weight", raw_endpoint.get("weight"))
             backend_ref["endpoints"] = [

--- a/src/vllm-sr/cli/config_migration.py
+++ b/src/vllm-sr/cli/config_migration.py
@@ -210,6 +210,8 @@ def _migrate_legacy_endpoints_to_backend_refs(
             continue
         backend_ref = {
             "name": endpoint.get("name") or "primary",
+            "backend_id": endpoint.get("backend_id"),
+            "engine_kind": endpoint.get("engine_kind"),
             "endpoint": endpoint.get("endpoint"),
             "protocol": endpoint.get("protocol"),
             "weight": endpoint.get("weight"),
@@ -397,7 +399,15 @@ def _build_legacy_backend_catalog(source: dict[str, Any]) -> dict[str, dict[str,
                 endpoint_value = f"{endpoint_value}:{port}"
             _set_if_missing(backend_ref, "endpoint", endpoint_value)
 
-        for key in ("protocol", "weight", "type", "api_key", "api_key_env"):
+        for key in (
+            "backend_id",
+            "engine_kind",
+            "protocol",
+            "weight",
+            "type",
+            "api_key",
+            "api_key_env",
+        ):
             _set_if_missing(backend_ref, key, raw_endpoint.get(key))
 
         catalog[endpoint_name] = backend_ref
@@ -456,6 +466,8 @@ def _convert_model_targets_to_provider_models(
                 continue
             backend_ref = {"name": backend_name}
             for key in (
+                "backend_id",
+                "engine_kind",
                 "endpoint",
                 "protocol",
                 "weight",

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -1113,11 +1113,17 @@ class BackendRef(BaseModel):
         has_discovery = self.discovery is not None
 
         if has_static_endpoints and has_discovery:
-            raise ValueError("backend ref must define either endpoints or discovery, not both")
+            raise ValueError(
+                "backend ref must define either endpoints or discovery, not both"
+            )
         if has_endpoint and (has_static_endpoints or has_discovery):
-            raise ValueError("backend ref must not mix legacy endpoint with endpoints or discovery")
+            raise ValueError(
+                "backend ref must not mix legacy endpoint with endpoints or discovery"
+            )
         if (has_static_endpoints or has_discovery) and not (self.runtime or "").strip():
-            raise ValueError("backend ref runtime is required for endpoints or discovery")
+            raise ValueError(
+                "backend ref runtime is required for endpoints or discovery"
+            )
         for index, endpoint in enumerate(self.endpoints or []):
             if not (endpoint.endpoint or "").strip():
                 raise ValueError(f"backend ref endpoints[{index}].endpoint is required")
@@ -1126,7 +1132,9 @@ class BackendRef(BaseModel):
             if not discovery_type:
                 raise ValueError("backend ref discovery.type is required")
             if discovery_type != "kubernetes":
-                raise ValueError(f"backend ref discovery.type {discovery_type!r} is not supported")
+                raise ValueError(
+                    f"backend ref discovery.type {discovery_type!r} is not supported"
+                )
             if self.discovery.kubernetes is None:
                 raise ValueError("backend ref discovery.kubernetes is required")
         return self

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -1084,12 +1084,15 @@ class ReasoningFamily(BaseModel):
 
 
 class BackendRef(BaseModel):
-    """Inline backend access details carried under providers.models[].backend_refs."""
+    """One runtime backend pool carried under providers.models[].backend_refs."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
-    backend_id: Optional[str] = None
-    engine_kind: Optional[str] = None
+    runtime: Optional[str] = None
     endpoint: Optional[str] = None
+    endpoints: List["BackendEndpoint"] = Field(default_factory=list)
+    discovery: Optional["BackendDiscovery"] = None
     protocol: str = "http"
     weight: int = 1
     type: Optional[str] = None
@@ -1103,6 +1106,31 @@ class BackendRef(BaseModel):
     api_key: Optional[str] = None
     api_key_env: Optional[str] = None
 
+    @model_validator(mode="after")
+    def validate_endpoint_sources(self):
+        has_endpoint = bool((self.endpoint or "").strip())
+        has_static_endpoints = len(self.endpoints or []) > 0
+        has_discovery = self.discovery is not None
+
+        if has_static_endpoints and has_discovery:
+            raise ValueError("backend ref must define either endpoints or discovery, not both")
+        if has_endpoint and (has_static_endpoints or has_discovery):
+            raise ValueError("backend ref must not mix legacy endpoint with endpoints or discovery")
+        if (has_static_endpoints or has_discovery) and not (self.runtime or "").strip():
+            raise ValueError("backend ref runtime is required for endpoints or discovery")
+        for index, endpoint in enumerate(self.endpoints or []):
+            if not (endpoint.endpoint or "").strip():
+                raise ValueError(f"backend ref endpoints[{index}].endpoint is required")
+        if has_discovery:
+            discovery_type = (self.discovery.type or "").strip()
+            if not discovery_type:
+                raise ValueError("backend ref discovery.type is required")
+            if discovery_type != "kubernetes":
+                raise ValueError(f"backend ref discovery.type {discovery_type!r} is not supported")
+            if self.discovery.kubernetes is None:
+                raise ValueError("backend ref discovery.kubernetes is required")
+        return self
+
     def resolve_api_key(self) -> Optional[str]:
         if self.api_key:
             return self.api_key
@@ -1111,6 +1139,39 @@ class BackendRef(BaseModel):
 
             return os.getenv(self.api_key_env)
         return None
+
+
+class BackendEndpoint(BaseModel):
+    """One static endpoint member inside a runtime backend pool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Optional[str] = None
+    endpoint: Optional[str] = None
+    metrics_endpoint: Optional[str] = None
+    protocol: Optional[str] = None
+    weight: Optional[int] = None
+    labels: Optional[Dict[str, str]] = None
+
+
+class KubernetesBackendDiscovery(BaseModel):
+    """Kubernetes Service-backed backend endpoint discovery."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    service: str
+    namespace: str
+    endpoint_port: str
+    metrics_port: Optional[str] = None
+
+
+class BackendDiscovery(BaseModel):
+    """Typed dynamic endpoint source for a backend ref."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    kubernetes: Optional[KubernetesBackendDiscovery] = None
 
 
 class ProviderDefaults(BaseModel):
@@ -1210,4 +1271,5 @@ class UserConfig(BaseModel):
 
 # Resolve forward references for recursive condition trees.
 Condition.model_rebuild()
+BackendRef.model_rebuild()
 Model.model_rebuild()

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -1087,6 +1087,8 @@ class BackendRef(BaseModel):
     """Inline backend access details carried under providers.models[].backend_refs."""
 
     name: Optional[str] = None
+    backend_id: Optional[str] = None
+    engine_kind: Optional[str] = None
     endpoint: Optional[str] = None
     protocol: str = "http"
     weight: int = 1

--- a/src/vllm-sr/cli/templates/config.template.yaml
+++ b/src/vllm-sr/cli/templates/config.template.yaml
@@ -17,9 +17,12 @@ providers:
     - name: "replace-with-your-model"
       backend_refs:
         - name: "primary"
-          endpoint: "host.docker.internal:8000"
+          runtime: "vllm"
           protocol: "http"
-          weight: 100
+          endpoints:
+            - name: "primary-a"
+              endpoint: "host.docker.internal:8000"
+              weight: 100
 
 routing:
   modelCards:

--- a/src/vllm-sr/tests/test_config_file_loaders.py
+++ b/src/vllm-sr/tests/test_config_file_loaders.py
@@ -104,23 +104,79 @@ def test_parse_user_config_preserves_cache_pricing(tmp_path: Path) -> None:
     assert pricing.model_dump()["cache_write_per_1m"] == 2.5
 
 
-def test_parse_user_config_preserves_backend_identity_hints(tmp_path: Path) -> None:
+def test_parse_user_config_preserves_backend_endpoint_sources(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     write_minimal_config(config_path)
     data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    backend_ref = data["providers"]["models"][0]["backend_refs"][0]
-    backend_ref["backend_id"] = "demo-primary"
-    backend_ref["engine_kind"] = "vllm"
+    data["providers"]["models"][0]["backend_refs"] = [
+        {
+            "name": "local-vllm",
+            "runtime": "vllm",
+            "protocol": "http",
+            "endpoints": [
+                {
+                    "name": "primary-a",
+                    "endpoint": "127.0.0.1:8000",
+                    "metrics_endpoint": "127.0.0.1:9000",
+                    "weight": 80,
+                }
+            ],
+        },
+        {
+            "name": "k8s-vllm",
+            "runtime": "vllm",
+            "discovery": {
+                "type": "kubernetes",
+                "kubernetes": {
+                    "service": "qwen3-vllm",
+                    "namespace": "inference",
+                    "endpoint_port": "http",
+                    "metrics_port": "metrics",
+                },
+            },
+        },
+    ]
     config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
 
     parsed = parse_user_config(str(config_path))
 
-    parsed_backend = parsed.providers.models[0].backend_refs[0]
-    assert parsed_backend.backend_id == "demo-primary"
-    assert parsed_backend.engine_kind == "vllm"
-    dumped = parsed_backend.model_dump(exclude_none=True)
-    assert dumped["backend_id"] == "demo-primary"
-    assert dumped["engine_kind"] == "vllm"
+    static_backend = parsed.providers.models[0].backend_refs[0]
+    assert static_backend.runtime == "vllm"
+    assert static_backend.endpoints[0].metrics_endpoint == "127.0.0.1:9000"
+    discovery_backend = parsed.providers.models[0].backend_refs[1]
+    assert discovery_backend.discovery is not None
+    assert discovery_backend.discovery.kubernetes is not None
+    assert discovery_backend.discovery.kubernetes.endpoint_port == "http"
+    dumped = discovery_backend.model_dump(exclude_none=True)
+    assert dumped["runtime"] == "vllm"
+    assert dumped["discovery"]["kubernetes"]["service"] == "qwen3-vllm"
+
+
+def test_parse_user_config_rejects_conflicting_backend_endpoint_sources(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    write_minimal_config(config_path)
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    data["providers"]["models"][0]["backend_refs"] = [
+        {
+            "name": "bad-vllm",
+            "runtime": "vllm",
+            "endpoints": [{"endpoint": "127.0.0.1:8000"}],
+            "discovery": {
+                "type": "kubernetes",
+                "kubernetes": {
+                    "service": "qwen3-vllm",
+                    "namespace": "inference",
+                    "endpoint_port": "http",
+                },
+            },
+        }
+    ]
+    config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ConfigParseError, match="either endpoints or discovery"):
+        parse_user_config(str(config_path))
 
 
 def test_embedding_models_config_accepts_remote_endpoint() -> None:

--- a/src/vllm-sr/tests/test_config_file_loaders.py
+++ b/src/vllm-sr/tests/test_config_file_loaders.py
@@ -104,6 +104,25 @@ def test_parse_user_config_preserves_cache_pricing(tmp_path: Path) -> None:
     assert pricing.model_dump()["cache_write_per_1m"] == 2.5
 
 
+def test_parse_user_config_preserves_backend_identity_hints(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    write_minimal_config(config_path)
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    backend_ref = data["providers"]["models"][0]["backend_refs"][0]
+    backend_ref["backend_id"] = "demo-primary"
+    backend_ref["engine_kind"] = "vllm"
+    config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    parsed = parse_user_config(str(config_path))
+
+    parsed_backend = parsed.providers.models[0].backend_refs[0]
+    assert parsed_backend.backend_id == "demo-primary"
+    assert parsed_backend.engine_kind == "vllm"
+    dumped = parsed_backend.model_dump(exclude_none=True)
+    assert dumped["backend_id"] == "demo-primary"
+    assert dumped["engine_kind"] == "vllm"
+
+
 def test_embedding_models_config_accepts_remote_endpoint() -> None:
     config = EmbeddingModelsConfig(
         embedding_config={

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -158,6 +158,67 @@ routing:
     assert route_action["regex_rewrite"]["substitution"] == "/v1\\1"
 
 
+def test_backend_ref_static_endpoint_slice_expands_envoy_cluster(
+    tmp_path, monkeypatch
+):
+    rendered = _render_envoy_config(
+        tmp_path,
+        monkeypatch,
+        """
+version: v0.3
+listeners:
+  - name: "http-8899"
+    address: "0.0.0.0"
+    port: 8899
+providers:
+  defaults:
+    default_model: "test-model"
+  models:
+    - name: "test-model"
+      backend_refs:
+        - name: "local-vllm"
+          runtime: "vllm"
+          protocol: "http"
+          endpoints:
+            - name: "primary-a"
+              endpoint: "10.0.0.1:8000"
+              weight: 80
+            - name: "primary-b"
+              endpoint: "10.0.0.2:8001"
+              weight: 20
+routing:
+  modelCards:
+    - name: "test-model"
+  decisions:
+    - name: "default-route"
+      description: "default route"
+      priority: 100
+      rules:
+        operator: "AND"
+        conditions: []
+      modelRefs:
+        - model: "test-model"
+          use_reasoning: false
+""",
+        extproc_host="localhost",
+        router_api_host="localhost",
+    )
+
+    cluster = _cluster_by_name(rendered, "test_model_cluster")
+    lb_endpoints = cluster["load_assignment"]["endpoints"][0]["lb_endpoints"]
+    assert len(lb_endpoints) == 2
+    assert (
+        lb_endpoints[0]["endpoint"]["address"]["socket_address"]["address"]
+        == "10.0.0.1"
+    )
+    assert lb_endpoints[0]["load_balancing_weight"] == 80
+    assert (
+        lb_endpoints[1]["endpoint"]["address"]["socket_address"]["address"]
+        == "10.0.0.2"
+    )
+    assert lb_endpoints[1]["load_balancing_weight"] == 20
+
+
 def test_backend_ref_domain_with_path_produces_correct_envoy_cluster_and_route(
     tmp_path, monkeypatch
 ):

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -158,9 +158,7 @@ routing:
     assert route_action["regex_rewrite"]["substitution"] == "/v1\\1"
 
 
-def test_backend_ref_static_endpoint_slice_expands_envoy_cluster(
-    tmp_path, monkeypatch
-):
+def test_backend_ref_static_endpoint_slice_expands_envoy_cluster(tmp_path, monkeypatch):
     rendered = _render_envoy_config(
         tmp_path,
         monkeypatch,

--- a/src/vllm-sr/tests/test_config_migrate.py
+++ b/src/vllm-sr/tests/test_config_migrate.py
@@ -323,6 +323,8 @@ def _legacy_model_catalog_config() -> dict:
                 "name": "local-primary",
                 "address": "127.0.0.1",
                 "port": 8000,
+                "backend_id": "qwen3-local-primary",
+                "engine_kind": "vllm",
                 "protocol": "http",
                 "weight": 80,
             },
@@ -410,6 +412,8 @@ def test_migrate_config_data_promotes_legacy_lora_catalog_and_backend_refs():
             "backend_refs": [
                 {
                     "name": "local-primary",
+                    "backend_id": "qwen3-local-primary",
+                    "engine_kind": "vllm",
                     "endpoint": "127.0.0.1:8000",
                     "protocol": "http",
                     "weight": 80,

--- a/src/vllm-sr/tests/test_config_migrate.py
+++ b/src/vllm-sr/tests/test_config_migrate.py
@@ -412,11 +412,17 @@ def test_migrate_config_data_promotes_legacy_lora_catalog_and_backend_refs():
             "backend_refs": [
                 {
                     "name": "local-primary",
-                    "backend_id": "qwen3-local-primary",
-                    "engine_kind": "vllm",
-                    "endpoint": "127.0.0.1:8000",
+                    "runtime": "vllm",
                     "protocol": "http",
                     "weight": 80,
+                    "endpoints": [
+                        {
+                            "name": "local-primary",
+                            "endpoint": "127.0.0.1:8000",
+                            "protocol": "http",
+                            "weight": 80,
+                        }
+                    ],
                     "api_key": "sk-test-openai",
                 },
                 {

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -47,7 +47,7 @@ The detailed background is in [Unified Config Contract v0.3](../proposals/unifie
   - `providers.defaults` holds `default_model`, `reasoning_families`, and `default_reasoning_effort`
   - `providers.models[*]` holds `provider_model_id`, `backend_refs`, `pricing`, `api_format`, and `external_model_ids`
   - `providers.models[*].pricing` uses per-million-token rates for prompt, cached input, optional cache writes, and completion; `cache_write_per_1m` defaults to `prompt_per_1m` when omitted
-  - `providers.models[*].backend_refs[]` can include optional `backend_id` and `engine_kind` identity hints for backend telemetry adapters
+  - `providers.models[*].backend_refs[]` names runtime backend pools. Use `runtime` with `endpoints[]` for static members, `discovery` for dynamic membership, legacy singleton `endpoint` for compatibility, or hosted-provider metadata such as `base_url`
 - `global` owns router-wide runtime overrides.
   - `global.router` groups router-engine control knobs such as config-source selection, route-cache, and model-selection defaults
   - `global.router.config_source` selects whether runtime config comes from the canonical YAML file (`file`) or from in-process Kubernetes CRD reconciliation (`kubernetes`)

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -47,6 +47,7 @@ The detailed background is in [Unified Config Contract v0.3](../proposals/unifie
   - `providers.defaults` holds `default_model`, `reasoning_families`, and `default_reasoning_effort`
   - `providers.models[*]` holds `provider_model_id`, `backend_refs`, `pricing`, `api_format`, and `external_model_ids`
   - `providers.models[*].pricing` uses per-million-token rates for prompt, cached input, optional cache writes, and completion; `cache_write_per_1m` defaults to `prompt_per_1m` when omitted
+  - `providers.models[*].backend_refs[]` can include optional `backend_id` and `engine_kind` identity hints for backend telemetry adapters
 - `global` owns router-wide runtime overrides.
   - `global.router` groups router-engine control knobs such as config-source selection, route-cache, and model-selection defaults
   - `global.router.config_source` selects whether runtime config comes from the canonical YAML file (`file`) or from in-process Kubernetes CRD reconciliation (`kubernetes`)

--- a/website/docs/proposals/unified-config-contract-v0-3.md
+++ b/website/docs/proposals/unified-config-contract-v0-3.md
@@ -78,7 +78,7 @@ Model semantics and deployment bindings are now separated explicitly:
 - `routing.modelCards[].loras` carries the canonical LoRA adapter catalog for each logical model
 - `providers.defaults` carries provider-wide defaults such as `default_model`, `reasoning_families`, and `default_reasoning_effort`
 - `providers.models` carries per-model access bindings directly
-- each `providers.models[].backend_refs[]` item carries its own transport and auth fields such as `endpoint`, `base_url`, `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env`
+- each `providers.models[].backend_refs[]` item carries its own transport and auth fields such as `endpoint`, `base_url`, `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env`, plus optional backend telemetry identity hints such as `backend_id` and `engine_kind`
 - `providers.models[].pricing` can price prompt, cached-input, cache-write, and completion tokens independently; an omitted cache-write rate inherits the prompt rate
 - `routing.decisions[].modelRefs[].lora_name` resolves against the matching `routing.modelCards[].loras` entry, so `lora_name` is now part of the supported routing contract instead of a runtime-only escape hatch
 - `routing.decisions[].output_contract` is the decision-scoped, model-visible final response format contract. Loop algorithms merge it with any format already present in the client request instead of hard-coding benchmark- or task-specific prompts inside algorithms.

--- a/website/docs/proposals/unified-config-contract-v0-3.md
+++ b/website/docs/proposals/unified-config-contract-v0-3.md
@@ -78,7 +78,7 @@ Model semantics and deployment bindings are now separated explicitly:
 - `routing.modelCards[].loras` carries the canonical LoRA adapter catalog for each logical model
 - `providers.defaults` carries provider-wide defaults such as `default_model`, `reasoning_families`, and `default_reasoning_effort`
 - `providers.models` carries per-model access bindings directly
-- each `providers.models[].backend_refs[]` item carries its own transport and auth fields such as `endpoint`, `base_url`, `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env`, plus optional backend telemetry identity hints such as `backend_id` and `engine_kind`
+- each `providers.models[].backend_refs[]` item names one runtime backend pool. It carries `runtime` plus one endpoint source: legacy singleton `endpoint`, static `endpoints[]`, typed dynamic `discovery`, or hosted-provider metadata such as `base_url`; transport and auth fields such as `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env` stay on the backend ref
 - `providers.models[].pricing` can price prompt, cached-input, cache-write, and completion tokens independently; an omitted cache-write rate inherits the prompt rate
 - `routing.decisions[].modelRefs[].lora_name` resolves against the matching `routing.modelCards[].loras` entry, so `lora_name` is now part of the supported routing contract instead of a runtime-only escape hatch
 - `routing.decisions[].output_contract` is the decision-scoped, model-visible final response format contract. Loop algorithms merge it with any format already present in the client request instead of hard-coding benchmark- or task-specific prompts inside algorithms.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/configuration.md
@@ -41,7 +41,7 @@ global:
   - `defaults`
   - `models`
   - `providers.defaults` 存放 `default_model`、`reasoning_families`、`default_reasoning_effort`
-  - `providers.models[*]` 存放 `provider_model_id`、`backend_refs`、`pricing`、`api_format`、`external_model_ids`
+  - `providers.models[*]` 存放 `provider_model_id`、`backend_refs`、`pricing`、`api_format`、`external_model_ids`；每个 backend ref 可包含可选的 `backend_id` 与 `engine_kind`，作为 backend telemetry adapter 的身份提示
 - `global` 拥有路由器级运行时覆盖。
   - `global.router` 聚合路由引擎控制项（如配置来源选择、route-cache、模型选择默认等）
   - `global.router.config_source` 选择运行时配置来自 canonical YAML 文件（`file`）还是进程内 Kubernetes CRD 协调（`kubernetes`）

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/proposals/unified-config-contract-v0-3.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/proposals/unified-config-contract-v0-3.md
@@ -85,7 +85,7 @@ DSL 仅拥有：
 - `routing.modelCards[].loras` 承载每个逻辑模型的 canonical LoRA 适配器目录
 - `providers.defaults` 承载提供商级默认，如 `default_model`、`reasoning_families`、`default_reasoning_effort`
 - `providers.models` 直接承载各模型的访问绑定
-- 每个 `providers.models[].backend_refs[]` 项自带传输与鉴权字段，如 `endpoint`、`base_url`、`protocol`、`auth_header`、`auth_prefix`、`api_key`、`api_key_env`
+- 每个 `providers.models[].backend_refs[]` 项自带传输与鉴权字段，如 `endpoint`、`base_url`、`protocol`、`auth_header`、`auth_prefix`、`api_key`、`api_key_env`，并可携带可选的 backend telemetry 身份提示，如 `backend_id` 与 `engine_kind`
 - `routing.decisions[].modelRefs[].lora_name` 与对应 `routing.modelCards[].loras` 条目解析，故 `lora_name` 现为受支持的路由契约的一部分，而非仅运行时逃生舱
 
 ## 全局默认

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/installation/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/installation/configuration.md
@@ -41,7 +41,7 @@ global:
   - `defaults`
   - `models`
   - `providers.defaults` 存放 `default_model`、`reasoning_families`、`default_reasoning_effort`
-  - `providers.models[*]` 存放 `provider_model_id`、`backend_refs`、`pricing`、`api_format`、`external_model_ids`；每个 backend ref 可包含可选的 `backend_id` 与 `engine_kind`，作为 backend telemetry adapter 的身份提示
+  - `providers.models[*]` 存放 `provider_model_id`、`backend_refs`、`pricing`、`api_format`、`external_model_ids`；每个 backend ref 表示一个 runtime backend pool，可用 `runtime` + `endpoints[]` 表达静态成员，用 `discovery` 表达动态成员，用 legacy singleton `endpoint` 兼容旧配置，或用 `base_url` 等字段表达托管 provider
 - `global` 拥有路由器级运行时覆盖。
   - `global.router` 聚合路由引擎控制项（如配置来源选择、route-cache、模型选择默认等）
   - `global.router.config_source` 选择运行时配置来自 canonical YAML 文件（`file`）还是进程内 Kubernetes CRD 协调（`kubernetes`）

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/installation/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/installation/configuration.md
@@ -41,7 +41,7 @@ global:
   - `defaults`
   - `models`
   - `providers.defaults` 存放 `default_model`、`reasoning_families`、`default_reasoning_effort`
-  - `providers.models[*]` 存放 `provider_model_id`、`backend_refs`、`pricing`、`api_format`、`external_model_ids`
+  - `providers.models[*]` 存放 `provider_model_id`、`backend_refs`、`pricing`、`api_format`、`external_model_ids`；每个 backend ref 可包含可选的 `backend_id` 与 `engine_kind`，作为 backend telemetry adapter 的身份提示
 - `global` 拥有路由器级运行时覆盖。
   - `global.router` 聚合路由引擎控制项（如配置来源选择、route-cache、模型选择默认等）
   - `global.router.config_source` 选择运行时配置来自 canonical YAML 文件（`file`）还是进程内 Kubernetes CRD 协调（`kubernetes`）

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/proposals/unified-config-contract-v0-3.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/proposals/unified-config-contract-v0-3.md
@@ -85,7 +85,7 @@ DSL 仅拥有：
 - `routing.modelCards[].loras` 承载每个逻辑模型的 canonical LoRA 适配器目录
 - `providers.defaults` 承载提供商级默认，如 `default_model`、`reasoning_families`、`default_reasoning_effort`
 - `providers.models` 直接承载各模型的访问绑定
-- 每个 `providers.models[].backend_refs[]` 项自带传输与鉴权字段，如 `endpoint`、`base_url`、`protocol`、`auth_header`、`auth_prefix`、`api_key`、`api_key_env`
+- 每个 `providers.models[].backend_refs[]` 项自带传输与鉴权字段，如 `endpoint`、`base_url`、`protocol`、`auth_header`、`auth_prefix`、`api_key`、`api_key_env`，并可携带可选的 backend telemetry 身份提示，如 `backend_id` 与 `engine_kind`
 - `routing.decisions[].modelRefs[].lora_name` 与对应 `routing.modelCards[].loras` 条目解析，故 `lora_name` 现为受支持的路由契约的一部分，而非仅运行时逃生舱
 
 ## 全局默认

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/proposals/unified-config-contract-v0-3.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/proposals/unified-config-contract-v0-3.md
@@ -85,7 +85,7 @@ DSL 仅拥有：
 - `routing.modelCards[].loras` 承载每个逻辑模型的 canonical LoRA 适配器目录
 - `providers.defaults` 承载提供商级默认，如 `default_model`、`reasoning_families`、`default_reasoning_effort`
 - `providers.models` 直接承载各模型的访问绑定
-- 每个 `providers.models[].backend_refs[]` 项自带传输与鉴权字段，如 `endpoint`、`base_url`、`protocol`、`auth_header`、`auth_prefix`、`api_key`、`api_key_env`，并可携带可选的 backend telemetry 身份提示，如 `backend_id` 与 `engine_kind`
+- 每个 `providers.models[].backend_refs[]` 项表示一个 runtime backend pool。它携带 `runtime` 与一种 endpoint source：legacy singleton `endpoint`、静态 `endpoints[]`、typed dynamic `discovery`，或 `base_url` 等托管 provider 元数据；`protocol`、`auth_header`、`auth_prefix`、`api_key`、`api_key_env` 等传输与鉴权字段仍保留在 backend ref 上
 - `routing.decisions[].modelRefs[].lora_name` 与对应 `routing.modelCards[].loras` 条目解析，故 `lora_name` 现为受支持的路由契约的一部分，而非仅运行时逃生舱
 
 ## 全局默认

--- a/website/versioned_docs/version-v0.3/installation/configuration.md
+++ b/website/versioned_docs/version-v0.3/installation/configuration.md
@@ -39,6 +39,7 @@ The detailed background is in [Unified Config Contract v0.3](../proposals/unifie
   - `providers.defaults` holds `default_model`, `reasoning_families`, and `default_reasoning_effort`
   - `providers.models[*]` holds `provider_model_id`, `backend_refs`, `pricing`, `api_format`, and `external_model_ids`
   - `providers.models[*].pricing` uses per-million-token rates for prompt, cached input, optional cache writes, and completion; `cache_write_per_1m` defaults to `prompt_per_1m` when omitted
+  - `providers.models[*].backend_refs[]` can include optional `backend_id` and `engine_kind` identity hints for backend telemetry adapters
 - `global` owns router-wide runtime overrides.
   - `global.router` groups router-engine control knobs such as config-source selection, route-cache, and model-selection defaults
   - `global.router.config_source` selects whether runtime config comes from the canonical YAML file (`file`) or from in-process Kubernetes CRD reconciliation (`kubernetes`)

--- a/website/versioned_docs/version-v0.3/installation/configuration.md
+++ b/website/versioned_docs/version-v0.3/installation/configuration.md
@@ -39,7 +39,7 @@ The detailed background is in [Unified Config Contract v0.3](../proposals/unifie
   - `providers.defaults` holds `default_model`, `reasoning_families`, and `default_reasoning_effort`
   - `providers.models[*]` holds `provider_model_id`, `backend_refs`, `pricing`, `api_format`, and `external_model_ids`
   - `providers.models[*].pricing` uses per-million-token rates for prompt, cached input, optional cache writes, and completion; `cache_write_per_1m` defaults to `prompt_per_1m` when omitted
-  - `providers.models[*].backend_refs[]` can include optional `backend_id` and `engine_kind` identity hints for backend telemetry adapters
+  - `providers.models[*].backend_refs[]` names runtime backend pools. Use `runtime` with `endpoints[]` for static members, `discovery` for dynamic membership, legacy singleton `endpoint` for compatibility, or hosted-provider metadata such as `base_url`
 - `global` owns router-wide runtime overrides.
   - `global.router` groups router-engine control knobs such as config-source selection, route-cache, and model-selection defaults
   - `global.router.config_source` selects whether runtime config comes from the canonical YAML file (`file`) or from in-process Kubernetes CRD reconciliation (`kubernetes`)

--- a/website/versioned_docs/version-v0.3/proposals/unified-config-contract-v0-3.md
+++ b/website/versioned_docs/version-v0.3/proposals/unified-config-contract-v0-3.md
@@ -78,7 +78,7 @@ Model semantics and deployment bindings are now separated explicitly:
 - `routing.modelCards[].loras` carries the canonical LoRA adapter catalog for each logical model
 - `providers.defaults` carries provider-wide defaults such as `default_model`, `reasoning_families`, and `default_reasoning_effort`
 - `providers.models` carries per-model access bindings directly
-- each `providers.models[].backend_refs[]` item carries its own transport and auth fields such as `endpoint`, `base_url`, `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env`
+- each `providers.models[].backend_refs[]` item carries its own transport and auth fields such as `endpoint`, `base_url`, `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env`, plus optional backend telemetry identity hints such as `backend_id` and `engine_kind`
 - `providers.models[].pricing` can price prompt, cached-input, cache-write, and completion tokens independently; an omitted cache-write rate inherits the prompt rate
 - `routing.decisions[].modelRefs[].lora_name` resolves against the matching `routing.modelCards[].loras` entry, so `lora_name` is now part of the supported routing contract instead of a runtime-only escape hatch
 - `routing.decisions[].candidateIterations` is bounded to `decision.candidates` or explicit model lists and remains declarative metadata for the selection layer, not a second policy interpreter

--- a/website/versioned_docs/version-v0.3/proposals/unified-config-contract-v0-3.md
+++ b/website/versioned_docs/version-v0.3/proposals/unified-config-contract-v0-3.md
@@ -78,7 +78,7 @@ Model semantics and deployment bindings are now separated explicitly:
 - `routing.modelCards[].loras` carries the canonical LoRA adapter catalog for each logical model
 - `providers.defaults` carries provider-wide defaults such as `default_model`, `reasoning_families`, and `default_reasoning_effort`
 - `providers.models` carries per-model access bindings directly
-- each `providers.models[].backend_refs[]` item carries its own transport and auth fields such as `endpoint`, `base_url`, `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env`, plus optional backend telemetry identity hints such as `backend_id` and `engine_kind`
+- each `providers.models[].backend_refs[]` item names one runtime backend pool. It carries `runtime` plus one endpoint source: legacy singleton `endpoint`, static `endpoints[]`, typed dynamic `discovery`, or hosted-provider metadata such as `base_url`; transport and auth fields such as `protocol`, `auth_header`, `auth_prefix`, `api_key`, and `api_key_env` stay on the backend ref
 - `providers.models[].pricing` can price prompt, cached-input, cache-write, and completion tokens independently; an omitted cache-write rate inherits the prompt rate
 - `routing.decisions[].modelRefs[].lora_name` resolves against the matching `routing.modelCards[].loras` entry, so `lora_name` is now part of the supported routing contract instead of a runtime-only escape hatch
 - `routing.decisions[].candidateIterations` is bounded to `decision.candidates` or explicit model lists and remains declarative metadata for the selection layer, not a second policy interpreter


### PR DESCRIPTION
## Summary

This PR adds the engine-neutral backend telemetry foundation for backend-aware routing. It deliberately stops at the shared contract layer: future adapter PRs can publish normalized telemetry into `pkg/backend`, and future endpoint-selection PRs can consume it as a second-stage policy, without changing today's extproc routing behavior.

Closes #2349.
Refs #2377.

## Design At A Glance

| Layer | This PR Adds | Purpose |
| --- | --- | --- |
| Backend identity | `BackendIdentity`, `EngineKind`, optional `backend_id` / `engine_kind` config fields | Give each physical backend or replica a stable engine-neutral name. |
| Telemetry contract | `BackendTelemetry`, `BackendLatency`, `BackendAffinity`, `HealthState` | Normalize queue, load, GPU/memory pressure, latency, cache affinity, health, confidence, and TTL signals. |
| TTL store | `Store`, package-level helpers, 5s default TTL | Keep the latest telemetry sample per model/backend/replica and reject stale data during policy evaluation. |
| Adapter seam | `TelemetryAdapter`, `AdapterConfig`, `AdapterTarget`, `Registry` | Let vLLM/SGLang/ATOM/TensorRT-style collectors register behind one factory shape. |
| Policy helper | `SelectBackendCandidate` and `BackendPolicyResult` diagnostics | Provide the minimal second-stage selection primitive while preserving fail-open behavior. |
| Config propagation | `CanonicalBackendRef.backend_id`, `CanonicalBackendRef.engine_kind`, runtime `VLLMEndpoint` fields, CLI/dashboard/docs updates | Preserve backend identity hints through canonical load, runtime normalization, export, migration, and UI surfaces. |

## Data Flow

```mermaid
flowchart LR
    A[Engine adapter in follow-up PR] -->|Collect normalized BackendTelemetry| B[pkg/backend Store]
    C[Existing model/backend candidates] --> D[SelectBackendCandidate]
    B -->|fresh healthy samples only| D
    D -->|BackendPolicyResult + diagnostics| E[Future endpoint-selection integration]
    D -->|FailOpen=true when telemetry unusable| F[Existing weight / Envoy LB fallback]
```

Important: this PR only adds the contract, store, registry, and helper. The final integration box is intentionally deferred.

## Backend Contract

The main public contract lives in `src/semantic-router/pkg/backend`:

- `types.go` defines the normalized identity and telemetry model:
  - `EngineKind`: `vllm`, `sglang`, `atom`, `tensorrt-llm`
  - `BackendIdentity`: backend ID, model name, replica ID, endpoint, engine kind/version
  - `BackendTelemetry`: queue depth, active requests, GPU/memory/KV pressure, latency, affinity, health, confidence, collection time, TTL
  - `BackendPolicyDiagnostics`: replay/debug-ready explanation of selected or fail-open behavior
- `store.go` provides a thread-safe latest-sample TTL store:
  - key shape is model/backend/replica
  - missing `CollectedAt` defaults to the store clock
  - per-sample `TTL` overrides the default; otherwise the default is 5s
  - stale data is retained as raw telemetry but filtered by `GetFresh` / policy evaluation
- `registry.go` provides the adapter factory seam:
  - adapters implement `EngineKind()` and `Collect(ctx)`
  - constructors are registered per `EngineKind`
  - follow-up PRs can add concrete collectors without changing policy consumers

## Minimal Policy Semantics

`SelectBackendCandidate(modelName, candidates, store)` is intentionally conservative. It only selects when at least one candidate has fresh, selectable telemetry.

| Case | Result | Reason |
| --- | --- | --- |
| No backend candidates | Fail open | `no_backend_candidates` |
| Candidate has no telemetry | Fail open if nothing else is usable | `missing_telemetry` |
| Candidate telemetry is expired | Fail open if nothing else is usable | `stale_telemetry` |
| Candidate telemetry is unhealthy | Reject for selection | `all_unhealthy` if no healthy candidate remains |
| At least one fresh healthy/degraded/unknown sample | Select one candidate | `fresh_selectable_telemetry` |

Current scoring order:

1. lowest `QueueDepth`
2. lowest `ActiveRequests`
3. highest backend weight
4. stable backend ID ordering
5. stable replica ID ordering

The helper returns diagnostics for both selected and fail-open paths. This gives later endpoint-selection work a stable result shape without forcing extproc or Envoy changes into this PR.

## Config And Compatibility

This PR adds optional backend identity hints to canonical backend refs:

```yaml
backend_refs:
  - name: local-primary
    backend_id: qwen3-8b-local-primary
    engine_kind: vllm
    endpoint: 127.0.0.1:8000
    protocol: http
    weight: 80
```

Those fields are preserved through:

- canonical YAML parsing;
- runtime `VLLMEndpoint` normalization;
- canonical export / round-trip;
- Python CLI Pydantic schema and legacy migration helpers;
- dashboard config normalization and model backend display;
- docs and sample config.

Existing configs remain valid because both fields are optional and omitted from export when empty.

## Non-Goals In This PR

This PR intentionally does not:

- add a concrete vLLM/SGLang/ATOM/TensorRT collector;
- start polling metrics endpoints;
- wire backend telemetry into extproc request routing;
- emit `x-vsr-selected-backend` or any Envoy endpoint pinning header;
- change `ResolvePrimaryBackendForModel` semantics;
- change current weighted backend fallback or Envoy LB behavior.

Missing, stale, or unhealthy telemetry remains fail-open by design.

## Reviewer Guide

Suggested review order:

1. `src/semantic-router/pkg/backend/types.go` for the public contract and diagnostics shape.
2. `src/semantic-router/pkg/backend/store.go` for TTL/freshness behavior and keying.
3. `src/semantic-router/pkg/backend/registry.go` for the adapter seam used by future engine collectors.
4. `src/semantic-router/pkg/backend/policy.go` for conservative selection and fail-open behavior.
5. `src/semantic-router/pkg/config/*` for canonical load/export preservation.
6. `src/vllm-sr/cli/*` and `dashboard/frontend/src/*` for schema/UI propagation.
7. Tests under `src/semantic-router/pkg/backend`, `src/semantic-router/pkg/config`, and `src/vllm-sr/tests`.

## Follow-Up Path

This PR is meant to unblock:

- #2350: vLLM adapter maps `/metrics` into `BackendTelemetry` and writes to the store.
- #2351 / #2352: SGLang and ATOM adapters reuse the same registry/store/policy shapes.
- #2377: TensorRT/Triton-style telemetry can map into the same normalized contract instead of introducing TensorRT-specific policy logic.
- #2353: Envoy endpoint selection can consume `BackendPolicyResult` once the adapter shape is stable.

## Validation

- `cd src/semantic-router && go test ./pkg/backend ./pkg/config`
- `python3 -m pytest src/vllm-sr/tests/test_config_file_loaders.py::test_parse_user_config_preserves_backend_identity_hints src/vllm-sr/tests/test_config_migrate.py::test_migrate_config_data_promotes_legacy_lora_catalog_and_backend_refs`
- `make vllm-sr-test`
- `make test-semantic-router`
- `make dashboard-check`
- `env CGO_ENABLED=1 HOME=/tmp/vsr-agent-home CARGO_HOME=/tmp/vsr-agent-cargo RUSTUP_HOME=/tmp/vsr-agent-rustup PATH=/tmp/vsr-agent-cargo/bin:$PATH make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/backend src/semantic-router/pkg/config src/vllm-sr/cli src/vllm-sr/tests dashboard/frontend/src/pages dashboard/frontend/src/types config website/docs website/versioned_docs website/i18n/zh-Hans/docusaurus-plugin-content-docs"`
- `make agent-serve-local ENV=cpu AGENT_STACK_NAME=codex-backend-telemetry AGENT_PORT_OFFSET=49`
- `make agent-smoke-local ENV=cpu AGENT_STACK_NAME=codex-backend-telemetry AGENT_PORT_OFFSET=49`
- `make agent-stop-local ENV=cpu AGENT_STACK_NAME=codex-backend-telemetry AGENT_PORT_OFFSET=49`

