### PR TITLE
[CI/Build] Build and publish the vllm-sr-cuda image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,7 +63,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [anthropic-shim, dashboard, extproc, extproc-rocm, llm-katan, vllm-sr, vllm-sr-rocm, vllm-sr-sim]
+        image: [anthropic-shim, dashboard, extproc, extproc-rocm, llm-katan, vllm-sr, vllm-sr-cuda, vllm-sr-rocm, vllm-sr-sim]
       fail-fast: false
 
     steps:
@@ -124,6 +124,9 @@ jobs:
           elif [ "${{ matrix.image }}" = "vllm-sr-rocm" ]; then
             echo "context=." >> $GITHUB_OUTPUT
             echo "dockerfile=./src/vllm-sr/Dockerfile.rocm" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.image }}" = "vllm-sr-cuda" ]; then
+            echo "context=." >> $GITHUB_OUTPUT
+            echo "dockerfile=./src/vllm-sr/Dockerfile.cuda" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate tags
@@ -558,6 +561,114 @@ jobs:
           else
             echo "::error title=Build Failed::vllm-sr-rocm build failed after ${DURATION_MIN}m ${DURATION_SEC}s"
             echo "### Build failed for vllm-sr-rocm" >> $GITHUB_STEP_SUMMARY
+            echo "- **Elapsed**: ${DURATION_MIN}m ${DURATION_SEC}s (${DURATION}s)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  build_vllm_sr_cuda:
+    if: >-
+      github.event_name != 'pull_request'
+      && github.repository == 'vllm-project/semantic-router'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Free up disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "After cleanup:"
+          df -h
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set lowercase repository owner
+        run: echo "REPOSITORY_OWNER_LOWER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Generate date tag for nightly builds
+        id: date
+        if: inputs.is_nightly == true
+        run: echo "date_tag=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Generate tags
+        id: tags
+        run: |
+          REPO_LOWER="${{ env.REPOSITORY_OWNER_LOWER }}"
+          IMAGE="ghcr.io/${REPO_LOWER}/semantic-router/vllm-sr-cuda"
+
+          if [ "${{ inputs.is_nightly }}" = "true" ]; then
+            TAG="nightly-${{ steps.date.outputs.date_tag }}"
+          else
+            TAG="${{ github.sha }}"
+          fi
+
+          TAGS="${IMAGE}:${TAG}"
+          if [ "${{ inputs.is_nightly }}" != "true" ]; then
+            TAGS="${TAGS},${IMAGE}:latest"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Record build start time
+        id: build-start
+        run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+
+      - name: Build and push vllm-sr-cuda (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./src/vllm-sr/Dockerfile.cuda
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=vllm-sr-cuda-amd64
+          cache-to: type=gha,mode=max,scope=vllm-sr-cuda-amd64,ignore-error=true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            CARGO_BUILD_JOBS=20
+            CARGO_INCREMENTAL=1
+            RUSTC_WRAPPER=""
+            CARGO_NET_GIT_FETCH_WITH_CLI=true
+          provenance: false
+
+      - name: Build summary and timing
+        if: always()
+        run: |
+          END=$(date +%s)
+          START="${{ steps.build-start.outputs.start }}"
+          DURATION=$((END - START))
+          DURATION_MIN=$((DURATION / 60))
+          DURATION_SEC=$((DURATION % 60))
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "::notice title=Build Success::vllm-sr-cuda (amd64) built in ${DURATION_MIN}m ${DURATION_SEC}s"
+            echo "### Build Summary for vllm-sr-cuda" >> $GITHUB_STEP_SUMMARY
+            echo "- **Platform**: linux/amd64 (CUDA, no arm64)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Build time**: ${DURATION_MIN}m ${DURATION_SEC}s (${DURATION}s)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Tags**: ${{ steps.tags.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "::error title=Build Failed::vllm-sr-cuda build failed after ${DURATION_MIN}m ${DURATION_SEC}s"
+            echo "### Build failed for vllm-sr-cuda" >> $GITHUB_STEP_SUMMARY
             echo "- **Elapsed**: ${DURATION_MIN}m ${DURATION_SEC}s (${DURATION}s)" >> $GITHUB_STEP_SUMMARY
           fi
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -184,6 +184,51 @@ jobs:
           ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/vllm-sr-rocm:${{ steps.extract_tag.outputs.tag }}
           ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/vllm-sr-rocm:latest
 
+  build_and_push_vllm_sr_cuda:
+    if: github.repository == 'vllm-project/semantic-router'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Free up disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract tag name
+      id: extract_tag
+      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+    - name: Set lowercase repository owner
+      run: echo "REPOSITORY_OWNER_LOWER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push vllm-sr-cuda Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./src/vllm-sr/Dockerfile.cuda
+        platforms: linux/amd64
+        push: true
+        tags: |
+          ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/vllm-sr-cuda:${{ steps.extract_tag.outputs.tag }}
+          ghcr.io/${{ env.REPOSITORY_OWNER_LOWER }}/semantic-router/vllm-sr-cuda:latest
+
   build_and_push_llm_katan:
     if: github.repository == 'vllm-project/semantic-router'
     runs-on: ubuntu-latest

--- a/tools/make/docker.mk
+++ b/tools/make/docker.mk
@@ -200,10 +200,11 @@ docker-help: ## Show help for Docker-related make targets and environment variab
 	@echo "  DOCKER_TAG        - Docker tag (default: latest)"
 	@echo "  SKIP_ROUTER_IMAGE - set to 1 only when the local router image is already up to date"
 	@echo "  SERVED_NAME       - Served model name for custom runs"
-	@echo "  VLLM_SR_PLATFORM  - vllm-sr platform hint (set to amd to use ROCm defaults)"
+	@echo "  VLLM_SR_PLATFORM  - vllm-sr platform hint (set to amd for ROCm defaults, nvidia for CUDA defaults)"
 	@echo "  VLLM_SR_TARGETARCH - target image architecture (default: host-native, amd64 for ROCm)"
 	@echo "  VLLM_SR_BUILDPLATFORM - Docker build platform (default: host-native, linux/amd64 for ROCm)"
 	@echo "  VLLM_SR_DOCKERFILE_AMD - Dockerfile used when VLLM_SR_PLATFORM=amd"
+	@echo "  VLLM_SR_DOCKERFILE_NVIDIA - Dockerfile used when VLLM_SR_PLATFORM=nvidia"
 	@echo "  VLLM_SR_ROUTER_IMAGE - router runtime image override (defaults to VLLM_SR_ROUTER_IMAGE_DEFAULT)"
 	@echo "  VLLM_SR_ENVOY_IMAGE - envoy runtime image override (defaults to VLLM_SR_ENVOY_IMAGE_DEFAULT)"
 	@echo "  VLLM_SR_DASHBOARD_IMAGE - dashboard runtime image override (defaults to VLLM_SR_DASHBOARD_IMAGE_DEFAULT)"
@@ -215,8 +216,10 @@ docker-help: ## Show help for Docker-related make targets and environment variab
 # single `DOCKER_TAG=v0.3.0` on the command line pins every image at once.
 VLLM_SR_IMAGE ?= ghcr.io/vllm-project/semantic-router/vllm-sr:$(DOCKER_TAG)
 VLLM_SR_IMAGE_ROCM ?= ghcr.io/vllm-project/semantic-router/vllm-sr-rocm:$(DOCKER_TAG)
+VLLM_SR_IMAGE_CUDA ?= ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:$(DOCKER_TAG)
 VLLM_SR_ROUTER_IMAGE_DEFAULT ?= $(VLLM_SR_IMAGE)
 VLLM_SR_ROUTER_IMAGE_ROCM ?= $(VLLM_SR_IMAGE_ROCM)
+VLLM_SR_ROUTER_IMAGE_CUDA ?= $(VLLM_SR_IMAGE_CUDA)
 VLLM_SR_ENVOY_IMAGE_DEFAULT ?= envoyproxy/envoy:v1.34-latest
 VLLM_SR_DASHBOARD_IMAGE_DEFAULT ?= ghcr.io/vllm-project/semantic-router/dashboard:$(DOCKER_TAG)
 VLLM_SR_ROUTER_IMAGE ?= $(VLLM_SR_ROUTER_IMAGE_DEFAULT)
@@ -233,6 +236,7 @@ VLLM_SR_TOPOLOGY ?= split
 VLLM_SR_TOPOLOGY_NORMALIZED := $(shell echo "$(VLLM_SR_TOPOLOGY)" | tr '[:upper:]' '[:lower:]')
 VLLM_SR_DOCKERFILE ?= src/vllm-sr/Dockerfile
 VLLM_SR_DOCKERFILE_AMD ?= src/vllm-sr/Dockerfile.rocm
+VLLM_SR_DOCKERFILE_NVIDIA ?= src/vllm-sr/Dockerfile.cuda
 VLLM_SR_DASHBOARD_DOCKERFILE ?= dashboard/backend/Dockerfile
 VLLM_SR_SIM_IMAGE ?= ghcr.io/vllm-project/semantic-router/vllm-sr-sim:latest
 VLLM_SR_SIM_CONTAINER ?= vllm-sr-sim-container
@@ -273,6 +277,25 @@ VLLM_SR_ROUTER_IMAGE := $(VLLM_SR_ROUTER_IMAGE_ROCM)
 endif
 ifeq ($(origin VLLM_SR_DOCKERFILE),file)
 VLLM_SR_DOCKERFILE := $(VLLM_SR_DOCKERFILE_AMD)
+endif
+ifeq ($(origin VLLM_SR_TARGETARCH),file)
+VLLM_SR_TARGETARCH := amd64
+endif
+ifeq ($(origin VLLM_SR_BUILDPLATFORM),file)
+VLLM_SR_BUILDPLATFORM := linux/amd64
+endif
+endif
+
+# NVIDIA platform defaults (can still be overridden via env/CLI variables)
+ifeq ($(VLLM_SR_PLATFORM_NORMALIZED),nvidia)
+ifeq ($(origin VLLM_SR_IMAGE),file)
+VLLM_SR_IMAGE := $(VLLM_SR_IMAGE_CUDA)
+endif
+ifeq ($(origin VLLM_SR_ROUTER_IMAGE),file)
+VLLM_SR_ROUTER_IMAGE := $(VLLM_SR_ROUTER_IMAGE_CUDA)
+endif
+ifeq ($(origin VLLM_SR_DOCKERFILE),file)
+VLLM_SR_DOCKERFILE := $(VLLM_SR_DOCKERFILE_NVIDIA)
 endif
 ifeq ($(origin VLLM_SR_TARGETARCH),file)
 VLLM_SR_TARGETARCH := amd64


### PR DESCRIPTION
Closes #2404

## What

Builds and publishes the `vllm-sr-cuda` image, and wires `VLLM_SR_PLATFORM=nvidia`
into the Make path. This is the last packaging follow-up called out as
*out of scope* in #2295, after #2281 (Dockerfile + deploy guide) landed.

Before this PR the CUDA image is defined (`src/vllm-sr/Dockerfile.cuda`) but
never built or pushed — `origin/main` has zero CUDA references in `docker.mk`,
`docker-publish.yml`, or `docker-release.yml`, so it never reaches `ghcr.io`
and the Make path can't select it. This mirrors the existing published
`vllm-sr-rocm` image point-by-point.

## Changes

- **`tools/make/docker.mk`** — add `VLLM_SR_IMAGE_CUDA`,
  `VLLM_SR_ROUTER_IMAGE_CUDA`, `VLLM_SR_DOCKERFILE_NVIDIA` defaults and a
  `VLLM_SR_PLATFORM=nvidia` block (amd64 / `linux/amd64`, `Dockerfile.cuda`),
  mirroring the existing `VLLM_SR_PLATFORM=amd` block. All values stay
  overridable via env/CLI.
- **`.github/workflows/docker-publish.yml`** — add `vllm-sr-cuda` to the
  `build_pr` matrix (PR build-test, no push) and a dedicated
  `build_vllm_sr_cuda` push job (amd64-only, nightly-aware, GHA cache),
  mirroring `build_vllm_sr_rocm`. Not added to the `build_platform` multi-arch
  matrix — like ROCm, CUDA is amd64-only.
- **`.github/workflows/docker-release.yml`** — add `build_and_push_vllm_sr_cuda`
  on tag release, mirroring the `vllm-sr-rocm` release job.

## Notes

- amd64-only, no arm64 — same as the ROCm image.
- CUDA perf benchmarks are tracked separately (#2348 / #2328).

## Test Plan

- `make docker-help` lists the new `VLLM_SR_DOCKERFILE_NVIDIA` variable.
- `VLLM_SR_PLATFORM=nvidia make -n <docker target>` resolves the router image to
  `vllm-sr-cuda`, dockerfile to `Dockerfile.cuda`, arch to `amd64`.
- `docker-publish.yml` / `docker-release.yml` parse (YAML lint / pre-commit).
- The `build_pr` matrix builds `vllm-sr-cuda` on this PR (build-only, no push).
