### PR TITLE
[Docs] refresh deploy/nvidia/README for the published vllm-sr-cuda image

### DIFF
--- a/deploy/nvidia/README.md
+++ b/deploy/nvidia/README.md
@@ -300,9 +300,9 @@ docker run -d \
     --network vllm-sr-network \
     --gpus all \
     --add-host=host.docker.internal:host-gateway \
-    -p 0.0.0.0:50151:50051 \
-    -p 0.0.0.0:8180:8080 \
-    -p 0.0.0.0:9290:9190 \
+    -p 0.0.0.0:50051:50051 \
+    -p 0.0.0.0:8080:8080 \
+    -p 0.0.0.0:9190:9190 \
     --env-file /tmp/router-env.list \
     -v "$(pwd)/models:/app/models" \
     -v "$(pwd)/active-config.yaml:/app/config.yaml" \
@@ -397,7 +397,7 @@ the active config.
 Send any prompt through the router and confirm it routes successfully:
 
 ```bash
-curl -sS -X POST http://localhost:8999/v1/chat/completions \
+curl -sS -X POST http://localhost:8899/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
       "model": "auto",
@@ -586,7 +586,7 @@ ROUTER_PID=$(nvidia-smi --query-compute-apps=pid,process_name --format=csv,nohea
 nvidia-smi pmon -i 0 -c 10 -o T &
 sleep 3
 for i in $(seq 1 15); do
-  curl -s -o /dev/null -X POST http://localhost:8180/api/v1/classify/intent \
+  curl -s -o /dev/null -X POST http://localhost:8080/api/v1/classify/intent \
     -H "Content-Type: application/json" \
     -d '{"text":"Explain TCP vs UDP and when to use each"}'
 done

--- a/deploy/nvidia/README.md
+++ b/deploy/nvidia/README.md
@@ -25,7 +25,10 @@ intent:
 
 ## Overview
 
-- Runtime image: `vllm-sr-cuda:local` (built locally; no `ghcr.io` mirror)
+- Runtime image: `ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest`
+  (published to `ghcr.io` via `docker-publish.yml` on `main` / nightly and
+  `docker-release.yml` on tag releases; local build still supported —
+  see Step 1)
 - Dockerfile: [`src/vllm-sr/Dockerfile.cuda`](../../src/vllm-sr/Dockerfile.cuda)
 - Inference backend: **ONNX Runtime + CUDA Execution Provider**
   (mirrors how ROCm path uses ORT + ROCm EP — `candle-binding` import is
@@ -90,13 +93,51 @@ On the host:
 
 ---
 
-## Step 1: Build the CUDA image
+## Step 1: Pull or build the CUDA image
 
-The image is multi-stage: it cross-builds `candle-binding`,
-`ml-binding`, `nlp-binding` (CPU-only by design), then builds
-`onnx-binding` with `--features "cuda,ort/load-dynamic"`, then assembles
-a runtime stage on top of `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04`
-with `onnxruntime-gpu==1.22.0`.
+### 1a. Pull the published image (recommended)
+
+`vllm-sr-cuda` is published to `ghcr.io` on every merge to `main`,
+nightly, and each tag release (via
+[`docker-publish.yml`](../../.github/workflows/docker-publish.yml) and
+[`docker-release.yml`](../../.github/workflows/docker-release.yml)):
+
+```bash
+docker pull ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest
+```
+
+Substitute the immutable tag (e.g. `v0.3.0`) for `latest` in production.
+
+Available tags on `ghcr.io/vllm-project/semantic-router/vllm-sr-cuda`:
+
+- `latest` — most recent `main`
+- `nightly-<YYYYMMDD>` — nightly build from a specific date
+- `v<X>.<Y>.<Z>` — immutable release tag
+
+### 1b. Build locally (advanced / dev)
+
+Local build is only needed to iterate on `Dockerfile.cuda` itself or to
+build a tree that predates the published image. The image is
+multi-stage: it cross-builds `candle-binding`, `ml-binding`,
+`nlp-binding` (CPU-only by design), then builds `onnx-binding` with
+`--features "cuda,ort/load-dynamic"`, then assembles a runtime stage on
+top of `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` with
+`onnxruntime-gpu==1.22.0`.
+
+Recommended path — the Make target (wires `Dockerfile.cuda` +
+`linux/amd64` + `vllm-sr-cuda` image name automatically):
+
+```bash
+cd /path/to/semantic-router
+VLLM_SR_PLATFORM=nvidia make vllm-sr-build
+```
+
+The `VLLM_SR_PLATFORM=nvidia` block in
+[`tools/make/docker.mk`](../../tools/make/docker.mk) resolves the router
+image to `vllm-sr-cuda`, dockerfile to `src/vllm-sr/Dockerfile.cuda`,
+and arch to `amd64`.
+
+Equivalent raw `docker build` (if you cannot use `make`):
 
 ```bash
 cd /path/to/semantic-router
@@ -121,10 +162,22 @@ EACCES on root-owned subdirectories.
 
 ### Verify the image before swapping containers
 
+The remaining steps in this playbook use the shell variable
+`$VLLM_SR_CUDA_IMAGE` to refer to whichever image you picked in 1a or
+1b — set it once here:
+
+```bash
+# Pulled path (1a):
+export VLLM_SR_CUDA_IMAGE=ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest
+
+# Locally built path (1b):
+# export VLLM_SR_CUDA_IMAGE=vllm-sr-cuda:local
+```
+
 ```bash
 # ORT inside the image must list CUDAExecutionProvider:
 docker run --rm --gpus all --entrypoint /opt/vllm-sr-venv/bin/python \
-    vllm-sr-cuda:local -c '
+    "$VLLM_SR_CUDA_IMAGE" -c '
 import onnxruntime as ort
 print("ORT version:", ort.__version__)
 print("Providers:", ort.get_available_providers())
@@ -247,7 +300,7 @@ docker run -d \
     -v "$(pwd)/active-config.yaml:/app/config.yaml" \
     -v "$(pwd)/.vllm-sr:/app/.vllm-sr" \
     -w /app \
-    vllm-sr-cuda:local \
+    "$VLLM_SR_CUDA_IMAGE" \
     /app/.vllm-sr/runtime-config.yaml /app/.vllm-sr
 ```
 
@@ -267,7 +320,10 @@ docker ps --filter "name=vllm-sr-router-container" --format \
     "table {{.Names}}\t{{.Status}}\t{{.Image}}"
 ```
 
-Expected: `Up <N> seconds`, image `vllm-sr-cuda:local`.
+Expected: `Up <N> seconds`, image matches `$VLLM_SR_CUDA_IMAGE` from
+Step 1 (either
+`ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest` or
+`vllm-sr-cuda:local`).
 
 ### 4b. Router actually selected the CUDA EP
 
@@ -481,7 +537,7 @@ Fixes, in order of preference:
 
    ```bash
    # via the container env
-   docker run ... -e ORT_GPU_MEM_LIMIT=512MB vllm-sr-cuda:local ...
+   docker run ... -e ORT_GPU_MEM_LIMIT=512MB "$VLLM_SR_CUDA_IMAGE" ...
    ```
 
    The embedding and classifier CUDA branches both honor
@@ -540,7 +596,7 @@ small BERT models on a fast GPU — that is expected, not a problem.)
 | Aspect | `deploy/amd/` (ROCm) | `deploy/nvidia/` (this) |
 |---|---|---|
 | Primary purpose | Run the **backend LLM** on AMD MI-series, router rides along | Run only the **router** on NVIDIA GPU |
-| Image | `vllm-sr-rocm:latest` (published to `ghcr.io`) | `vllm-sr-cuda:local` (build locally; no public mirror yet) |
+| Image | `vllm-sr-rocm:latest` (published to `ghcr.io`) | `ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest` (published; local build still supported) |
 | Base image | `rocm/dev-ubuntu-22.04:7.0` | `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` |
 | ORT wheel | `onnxruntime_rocm-1.22.1` (radeon repo) | `onnxruntime-gpu==1.22.0` (PyPI) |
 | onnx-binding feature | `--features rocm-dynamic` | `--features "cuda,ort/load-dynamic"` |
@@ -567,3 +623,11 @@ The two playbooks are independent; do not mix `--gpus all` with
   concept) actually steer the ONNX Runtime EP selection
 - [`src/semantic-router/pkg/config/canonical_defaults.go`](../../src/semantic-router/pkg/config/canonical_defaults.go) —
   source of truth for `use_cpu: true` defaults
+- [`tools/make/docker.mk`](../../tools/make/docker.mk) — the
+  `VLLM_SR_PLATFORM=nvidia` block wiring `Dockerfile.cuda` +
+  `vllm-sr-cuda` image name + `linux/amd64` into the Make path
+- [`.github/workflows/docker-publish.yml`](../../.github/workflows/docker-publish.yml) —
+  publishes `vllm-sr-cuda` to `ghcr.io` on merge to `main` and nightly
+  (amd64-only, matching ROCm)
+- [`.github/workflows/docker-release.yml`](../../.github/workflows/docker-release.yml) —
+  publishes tagged `vllm-sr-cuda` releases on `v*` tags

--- a/deploy/nvidia/README.md
+++ b/deploy/nvidia/README.md
@@ -1,17 +1,25 @@
 # vLLM Semantic Router on NVIDIA CUDA
 
 This playbook documents how to run the **router itself** (BERT
-classifiers + embedding-driven KB lookup) on an NVIDIA GPU. It is the
-parallel of [`deploy/amd/README.md`](../amd/README.md), but inverted in
-intent:
+classifiers + embedding-driven KB lookup) on an NVIDIA GPU. Scope is
+router-side ML inference — BERT-based intent classification, PII
+detection, jailbreak guard, mmBERT embedding for Knowledge-Base
+signals, hallucination mitigation, feedback detection. The backend
+LLM is reached over the network and is **not** served from this host.
 
-- **`deploy/amd/`** assumes the host already runs an AMD vLLM backend on
-  MI-series GPUs and the router rides along the existing ROCm runtime.
-- **`deploy/nvidia/`** (this file) targets a host whose only GPU role is
-  **router-side ML inference** — BERT-based intent classification, PII
-  detection, jailbreak guard, mmBERT embedding for Knowledge-Base
-  signals, hallucination mitigation, feedback detection. The backend
-  LLM is reached over the network and is **not** served from this host.
+**How this relates to `deploy/amd/README.md`:** the two documents,
+despite their filename symmetry, are not parallel.
+[`deploy/amd/README.md`](../amd/README.md) is a *routing profile*
+guide (the `balance.yaml` recipe running against a single ROCm vLLM
+backend), which is a different concern. The AMD equivalent of *this*
+file — how to build the router image on ROCm and serve it with
+`vllm-sr serve --platform amd` — lives in
+[`docs/agent/amd-local.md`](../../docs/agent/amd-local.md), together
+with the `amd-local` entry in
+[`docs/agent/environments.md`](../../docs/agent/environments.md).
+A future refactor may move this playbook to a matching
+`docs/agent/nvidia-local.md` for structural symmetry; that reshuffle
+is intentionally out of scope for this PR.
 
 > **When this playbook is NOT for you:** upstream `onnx-binding/README.md`
 > documents CPU≈GPU latency parity for BERT-size embeddings at small
@@ -591,18 +599,22 @@ small BERT models on a fast GPU — that is expected, not a problem.)
 
 ---
 
-## Differences vs `deploy/amd/`
+## Router image differences: NVIDIA CUDA vs AMD ROCm
 
-| Aspect | `deploy/amd/` (ROCm) | `deploy/nvidia/` (this) |
+Apples-to-apples comparison of the two GPU-enabled router images,
+sourced from `src/vllm-sr/Dockerfile.cuda` and
+`src/vllm-sr/Dockerfile.rocm`:
+
+| Aspect | AMD ROCm router (`vllm-sr-rocm`) | NVIDIA CUDA router (`vllm-sr-cuda`) |
 |---|---|---|
-| Primary purpose | Run the **backend LLM** on AMD MI-series, router rides along | Run only the **router** on NVIDIA GPU |
-| Image | `vllm-sr-rocm:latest` (published to `ghcr.io`) | `ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest` (published; local build still supported) |
+| Published tag | `ghcr.io/vllm-project/semantic-router/vllm-sr-rocm:latest` | `ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest` |
 | Base image | `rocm/dev-ubuntu-22.04:7.0` | `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` |
 | ORT wheel | `onnxruntime_rocm-1.22.1` (radeon repo) | `onnxruntime-gpu==1.22.0` (PyPI) |
-| onnx-binding feature | `--features rocm-dynamic` | `--features "cuda,ort/load-dynamic"` |
-| Backend LLM | `vllm/vllm-openai-rocm:v0.17.0` running locally on `--device=/dev/kfd /dev/dri` | External, reached over the network |
+| `onnx-binding` feature | `--features rocm-dynamic` | `--features "cuda,ort/load-dynamic"` |
+| GPU passthrough | `--device=/dev/kfd --device=/dev/dri` | `--gpus all` (Docker) or CDI `nvidia.com/gpu=all` (Podman) |
+| CLI entrypoint (once #2421 lands) | `vllm-sr serve --platform amd` | `vllm-sr serve --platform nvidia` (currently only wires GPU passthrough — see #2421) |
 
-The two playbooks are independent; do not mix `--gpus all` with
+The two images are independent; do not mix `--gpus all` with
 `--device=/dev/kfd` on the same router container.
 
 ---


### PR DESCRIPTION
Closes #2419

## Summary

Refreshes `deploy/nvidia/README.md` after #2405 published the
`vllm-sr-cuda` image to `ghcr.io`. Docs-only, no code.

Before this PR the playbook stated the CUDA image was built locally and
had no `ghcr.io` mirror, and step 1 walked readers through a ~20 min
cold local build. That is no longer accurate:

- `#2405` merged the `VLLM_SR_PLATFORM=nvidia` block into
  `tools/make/docker.mk` and added the `vllm-sr-cuda` job to
  `docker-publish.yml` (main + nightly) and `docker-release.yml`
  (tag releases).
- `ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest` is now the
  published tag, matching the ROCm image's setup.

## Changes

- **Overview** — replace the "built locally; no `ghcr.io` mirror" bullet
  with the published `ghcr.io` reference; point at Step 1 for build/pull
  choice.
- **Step 1** — split into `1a. Pull the published image (recommended)`
  and `1b. Build locally (advanced / dev)`. `1a` documents the tag
  scheme (`latest`, `nightly-<YYYYMMDD>`, `v<X>.<Y>.<Z>`). `1b` adds the
  `VLLM_SR_PLATFORM=nvidia make vllm-sr-build` Make path alongside the
  raw `docker build`.
- Introduce a shared `$VLLM_SR_CUDA_IMAGE` shell variable so the rest of
  the playbook (Step 3c `docker run`, Step 4a expected image,
  troubleshooting `ORT_GPU_MEM_LIMIT` example) works for both pull and
  local-build paths without hardcoding one tag.
- **Intro paragraph** — correct the "parallel of `deploy/amd/README.md`,
  but inverted in intent" claim (second commit). `deploy/amd/README.md`
  is a routing-profile document about `balance.yaml`, not a
  router-on-GPU playbook. The real AMD equivalent of this file lives in
  `docs/agent/amd-local.md`; the intro now points there and flags the
  filename-level location refactor as an intentional out-of-scope item.
- **"Router image differences: NVIDIA CUDA vs AMD ROCm" table** (was
  "Differences vs `deploy/amd/`") — narrowed to apples-to-apples image
  properties sourced from the two Dockerfiles and the CLI run-command
  layer: published tag, base image, ORT wheel, `onnx-binding` feature,
  GPU passthrough, and CLI-entrypoint status (linking #2421 for the
  in-flight `--platform nvidia` symmetry). Drops the misleading
  "Primary purpose" and "Backend LLM" rows that conflated this playbook
  with the routing-profile doc.
- **"Files involved"** — add `tools/make/docker.mk`,
  `.github/workflows/docker-publish.yml`, and
  `.github/workflows/docker-release.yml` (the three packaging surfaces
  added in #2405).
- **Port defaults fix (third commit, cherry-picked from #2328).** The
  Step 3c `docker run` port mappings and the Step 4 / 5 curl examples
  used non-default host ports (extproc `50151`, API `8180`, metrics
  `9290`, Envoy `8999`) — these were an author's
  `VLLM_SR_PORT_OFFSET=100` environment (default + 100) that leaked
  into the playbook. A reader following the standard `vllm-sr` defaults
  (extproc `50051`, API `8080`, metrics `9190`, Envoy listener `8899`;
  see `cli/consts.py`) would find the sanity-check curls pointing at
  ports that do not exist in their deployment. Normalized every port
  back to the documented default so the playbook is copy-pasteable
  as-is; users on a custom offset can still adjust per the existing
  note in Step 3c. Originally staged in #2328 as `0cca8f02`; folded
  in here so it can ship with the rest of the deploy/nvidia docs
  refresh instead of blocking on the (much larger) bench PR.

## Out of scope / follow-ups

This PR is intentionally narrow: docs-only refresh for the newly
published image. Two known follow-ups the reviewer may want to be
aware of but that are **not** addressed here:

1. **CLI symmetry: `vllm-sr serve --platform nvidia`** — tracked as
   #2421. Today `--platform nvidia` only wires GPU passthrough
   (`--gpus all` / CDI); it does not auto-select the CUDA image and
   does not auto-set `use_cpu: false` under `global.model_catalog`,
   both of which `--platform amd` already does. This is why Step 3c
   in this README is still a manual `docker run --gpus all` block
   rather than a one-liner. Once #2421 lands, Step 3c should collapse
   to `vllm-sr serve --platform nvidia --config <recipe>` and the
   Step 2 manual config override becomes unnecessary. Deliberately
   deferred so this PR does not conflate docs refresh with a CLI
   feature.

2. **Docs location symmetry** (tracked as #2422) — the AMD parallel of this playbook is
   actually `docs/agent/amd-local.md`, not `deploy/amd/README.md`
   (which is a routing-profile document about `balance.yaml`, not a
   "how to run the router on AMD" playbook). A future refactor could
   move the router-on-GPU playbook content to
   `docs/agent/nvidia-local.md` for structural symmetry, and reserve
   `deploy/nvidia/` for an NVIDIA-specific routing profile paralleling
   `deploy/amd/README.md`. Now tracked as #2422; deliberately deferred
   so this PR remains a docs-content refresh only. #2422 sequences the
   move to land after this PR merges and before #2421's implementation
   lands, so the CLI-symmetry feature's docs land at the correct final
   path from day one.

## Test Plan

Ran on an RTX 4090 host (driver 580.159.03, docker 29.6.1,
nvidia-container-toolkit configured):

- [x] `markdownlint -c tools/linter/markdown/markdownlint.yaml deploy/nvidia/README.md` — clean.
- [x] All referenced files/paths verified to exist on `main`
  (`.github/workflows/docker-publish.yml`, `docker-release.yml`,
  `tools/make/docker.mk`, `src/vllm-sr/Dockerfile.cuda`,
  `src/vllm-sr/Dockerfile.cuda.dockerignore`).
- [x] `vllm-sr-build` target confirmed in `tools/make/docker.mk` — it
  builds with `-t $(VLLM_SR_IMAGE) -f $(VLLM_SR_DOCKERFILE)`, both of
  which the `VLLM_SR_PLATFORM=nvidia` block wires to `vllm-sr-cuda` +
  `Dockerfile.cuda` respectively.
- [x] **Step 1a: registry pull works.**
  `docker manifest inspect ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest`
  resolves (OCI manifest, config digest `sha256:44f8337584c1…`).
  `docker pull` succeeds (image size 4.24 GB, image ID
  `44f83374584c`, image digest `sha256:73de33ac213f…`, `Created`
  timestamp `2026-07-09T05:30:21Z` — matches the `#2405` merge time).
- [x] **Step 1a verify block: ORT providers.** Ran the exact snippet
  in the README against the pulled image:

  ```
  ORT version: 1.22.0
  Providers: ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']
  OK
  ```

  Output matches the README's "Expected" block byte-for-byte.
- [x] **`--gpus all` passthrough works** for the pulled image:
  `docker run --gpus all ...vllm-sr-cuda:latest nvidia-smi` returns
  `NVIDIA GeForce RTX 4090, 580.159.03, 24564 MiB` from inside the
  container.
- [x] Classifier / embedding actually selecting `CUDAExecutionProvider`
  (Steps 4b, 4c) — **not re-verified in this PR**; that behavior was
  originally exercised by the required runtime fix landed in #2281.
  Nothing in #2405 or this PR touches the classifier or embedding
  code paths, so the behavior is unchanged.
- [ ] Full end-to-end recipe smoke (Steps 3–5) not run in this PR —
  those steps use whichever config the reader's deployment already
  loads, not something this docs refresh introduces. A reviewer with an
  NVIDIA host and a live router deployment can validate by running
  Steps 1a → 5 against their config.

No E2E impact — docs-only refresh, no behavior-visible change to
routing, startup, config, Docker, CLI, or API.