### PR TITLE
[Router] expand sensitive config values from environment variables

### DIFF
--- a/src/semantic-router/pkg/config/env_substitution.go
+++ b/src/semantic-router/pkg/config/env_substitution.go
@@ -56,41 +56,47 @@ func expandEnvString(value string) string {
 			i++
 			continue
 		}
-		if i+1 >= len(escaped) {
-			builder.WriteByte('$')
-			break
-		}
-
-		switch escaped[i+1] {
-		case '{':
-			closeIdx := strings.IndexByte(escaped[i+2:], '}')
-			if closeIdx < 0 {
-				builder.WriteByte('$')
-				i++
-				continue
-			}
-			closeIdx += i + 2
-			builder.WriteString(resolveBracedEnvReference(escaped[i+2 : closeIdx]))
-			i = closeIdx + 1
-		case '$':
-			builder.WriteByte('$')
-			i += 2
-		default:
-			j := i + 1
-			for j < len(escaped) && isEnvNameByte(escaped[j]) {
-				j++
-			}
-			if j == i+1 {
-				builder.WriteByte('$')
-				i++
-				continue
-			}
-			builder.WriteString(os.Getenv(escaped[i+1 : j]))
-			i = j
-		}
+		expanded, next := expandEnvDollarToken(escaped, i)
+		builder.WriteString(expanded)
+		i = next
 	}
 
 	return strings.ReplaceAll(builder.String(), dollarPlaceholder, "$")
+}
+
+func expandEnvDollarToken(escaped string, start int) (string, int) {
+	if start+1 >= len(escaped) {
+		return "$", start + 1
+	}
+
+	switch escaped[start+1] {
+	case '{':
+		return expandBracedEnvToken(escaped, start)
+	case '$':
+		return "$", start + 2
+	default:
+		return expandUnbracedEnvToken(escaped, start)
+	}
+}
+
+func expandBracedEnvToken(escaped string, start int) (string, int) {
+	closeIdx := strings.IndexByte(escaped[start+2:], '}')
+	if closeIdx < 0 {
+		return "$", start + 1
+	}
+	closeIdx += start + 2
+	return resolveBracedEnvReference(escaped[start+2 : closeIdx]), closeIdx + 1
+}
+
+func expandUnbracedEnvToken(escaped string, start int) (string, int) {
+	end := start + 1
+	for end < len(escaped) && isEnvNameByte(escaped[end]) {
+		end++
+	}
+	if end == start+1 {
+		return "$", start + 1
+	}
+	return os.Getenv(escaped[start+1 : end]), end
 }
 
 func resolveBracedEnvReference(inner string) string {

--- a/src/semantic-router/pkg/config/env_substitution.go
+++ b/src/semantic-router/pkg/config/env_substitution.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// expandEnvSubstitutionsInMap walks a parsed YAML tree and expands environment
+// variable references in string scalars. Supported forms mirror common compose
+// interpolation:
+//   - ${VAR} and $VAR
+//   - ${VAR:-default} when VAR is unset or empty
+//   - ${VAR-default} when VAR is unset
+//   - $$ for a literal $
+func expandEnvSubstitutionsInMap(raw map[string]interface{}) {
+	for key, value := range raw {
+		raw[key] = expandEnvSubstitutionsInValue(value)
+	}
+}
+
+func expandEnvSubstitutionsInValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case string:
+		return expandEnvString(typed)
+	case map[string]interface{}:
+		expandEnvSubstitutionsInMap(typed)
+		return typed
+	case map[interface{}]interface{}:
+		converted := nestedStringMap(typed)
+		expandEnvSubstitutionsInMap(converted)
+		return converted
+	case []interface{}:
+		for i, item := range typed {
+			typed[i] = expandEnvSubstitutionsInValue(item)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func expandEnvString(value string) string {
+	if value == "" || !strings.Contains(value, "$") {
+		return value
+	}
+
+	const dollarPlaceholder = "\x00DOLLAR\x00"
+	escaped := strings.ReplaceAll(value, "$$", dollarPlaceholder)
+
+	var builder strings.Builder
+	builder.Grow(len(escaped))
+
+	for i := 0; i < len(escaped); {
+		if escaped[i] != '$' {
+			builder.WriteByte(escaped[i])
+			i++
+			continue
+		}
+		if i+1 >= len(escaped) {
+			builder.WriteByte('$')
+			break
+		}
+
+		switch escaped[i+1] {
+		case '{':
+			closeIdx := strings.IndexByte(escaped[i+2:], '}')
+			if closeIdx < 0 {
+				builder.WriteByte('$')
+				i++
+				continue
+			}
+			closeIdx += i + 2
+			builder.WriteString(resolveBracedEnvReference(escaped[i+2 : closeIdx]))
+			i = closeIdx + 1
+		case '$':
+			builder.WriteByte('$')
+			i += 2
+		default:
+			j := i + 1
+			for j < len(escaped) && isEnvNameByte(escaped[j]) {
+				j++
+			}
+			if j == i+1 {
+				builder.WriteByte('$')
+				i++
+				continue
+			}
+			builder.WriteString(os.Getenv(escaped[i+1 : j]))
+			i = j
+		}
+	}
+
+	return strings.ReplaceAll(builder.String(), dollarPlaceholder, "$")
+}
+
+func resolveBracedEnvReference(inner string) string {
+	if inner == "" {
+		return ""
+	}
+	if idx := strings.Index(inner, ":-"); idx > 0 {
+		name := inner[:idx]
+		defaultValue := inner[idx+2:]
+		if value, ok := os.LookupEnv(name); ok && value != "" {
+			return value
+		}
+		return defaultValue
+	}
+	if idx := strings.Index(inner, "-"); idx > 0 {
+		name := inner[:idx]
+		defaultValue := inner[idx+1:]
+		if value, ok := os.LookupEnv(name); ok {
+			return value
+		}
+		return defaultValue
+	}
+	return os.Getenv(inner)
+}
+
+func isEnvNameByte(ch byte) bool {
+	return (ch >= 'A' && ch <= 'Z') ||
+		(ch >= 'a' && ch <= 'z') ||
+		(ch >= '0' && ch <= '9') ||
+		ch == '_'
+}

--- a/src/semantic-router/pkg/config/env_substitution_test.go
+++ b/src/semantic-router/pkg/config/env_substitution_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExpandEnvString(t *testing.T) {
+	t.Setenv("POSTGRES_PASSWORD", "super_sensitive_string")
+	t.Setenv("MILVUS_USERNAME", "root")
+	t.Setenv("EMPTY_VALUE", "")
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "braced variable", input: "${POSTGRES_PASSWORD}", want: "super_sensitive_string"},
+		{name: "unbraced variable", input: "$MILVUS_USERNAME", want: "root"},
+		{name: "default when unset", input: "${MISSING_VAR:-fallback}", want: "fallback"},
+		{name: "default when empty", input: "${EMPTY_VALUE:-fallback}", want: "fallback"},
+		{name: "dash default when unset", input: "${MISSING_VAR-default}", want: "default"},
+		{name: "literal dollar", input: "cost-$$value", want: "cost-$value"},
+		{name: "no substitution", input: "plain-text", want: "plain-text"},
+		{name: "mixed text", input: "user:${MILVUS_USERNAME}@db", want: "user:root@db"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandEnvString(tt.input); got != tt.want {
+				t.Fatalf("expandEnvString(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseYAMLBytesExpandsEnvironmentVariablesInRouterReplayPostgres(t *testing.T) {
+	t.Setenv("POSTGRES_PASSWORD", "super_sensitive_string")
+
+	cfg, err := ParseYAMLBytes([]byte(`
+version: v0.3
+listeners:
+  - name: http
+    address: 0.0.0.0
+    port: 8888
+providers:
+  defaults:
+    default_model: qwen3
+  models:
+    - name: qwen3
+      provider_model_id: qwen3
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  signals:
+    domains:
+      - name: general
+        description: General requests
+        mmlu_categories: [other]
+  modelCards:
+    - name: qwen3
+  decisions:
+    - name: default_route
+      priority: 1
+      rules:
+        operator: OR
+        conditions:
+          - type: domain
+            name: general
+      modelRefs:
+        - model: qwen3
+global:
+  services:
+    router_replay:
+      enabled: true
+      store_backend: postgres
+      postgres:
+        host: 10.0.0.1
+        database: vsr
+        user: default
+        password: "${POSTGRES_PASSWORD}"
+        ssl_mode: disable
+        table_name: router_replay
+`))
+	if err != nil {
+		t.Fatalf("ParseYAMLBytes returned error: %v", err)
+	}
+	if cfg.RouterReplay.Postgres == nil {
+		t.Fatal("expected router replay postgres config to be populated")
+	}
+	if cfg.RouterReplay.Postgres.Password != "super_sensitive_string" {
+		t.Fatalf("password = %q, want %q", cfg.RouterReplay.Postgres.Password, "super_sensitive_string")
+	}
+}
+
+func TestParseYAMLBytesExpandsEnvironmentVariablesInProviderAccessKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-router-secret")
+
+	cfg, err := ParseYAMLBytes([]byte(`
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: gpt-4o
+  models:
+    - name: gpt-4o
+      provider_model_id: gpt-4o
+      backend_refs:
+        - endpoint: https://api.openai.com/v1
+          api_key: "${OPENAI_API_KEY}"
+routing:
+  signals:
+    domains:
+      - name: general
+        description: General requests
+        mmlu_categories: [other]
+  modelCards:
+    - name: gpt-4o
+  decisions:
+    - name: default_route
+      priority: 1
+      rules:
+        operator: OR
+        conditions:
+          - type: domain
+            name: general
+      modelRefs:
+        - model: gpt-4o
+`))
+	if err != nil {
+		t.Fatalf("ParseYAMLBytes returned error: %v", err)
+	}
+	if got := cfg.GetModelAccessKey("gpt-4o"); got != "sk-router-secret" {
+		t.Fatalf("GetModelAccessKey = %q, want %q", got, "sk-router-secret")
+	}
+}
+
+func TestExpandEnvSubstitutionsInMapLeavesNonStringsUntouched(t *testing.T) {
+	raw := map[string]interface{}{
+		"port":     5432,
+		"enabled":  true,
+		"password": "${POSTGRES_PASSWORD}",
+	}
+	t.Setenv("POSTGRES_PASSWORD", "secret")
+	expandEnvSubstitutionsInMap(raw)
+
+	if raw["port"] != 5432 {
+		t.Fatalf("port = %v, want 5432", raw["port"])
+	}
+	if raw["enabled"] != true {
+		t.Fatalf("enabled = %v, want true", raw["enabled"])
+	}
+	if raw["password"] != "secret" {
+		t.Fatalf("password = %v, want secret", raw["password"])
+	}
+}
+
+func TestExpandEnvStringUnsetVariableIsEmpty(t *testing.T) {
+	_ = os.Unsetenv("DEFINITELY_MISSING_ENV_FOR_CONFIG_TEST")
+	if got := expandEnvString("${DEFINITELY_MISSING_ENV_FOR_CONFIG_TEST}"); got != "" {
+		t.Fatalf("expandEnvString for missing var = %q, want empty string", got)
+	}
+}

--- a/src/semantic-router/pkg/config/loader.go
+++ b/src/semantic-router/pkg/config/loader.go
@@ -103,10 +103,16 @@ func parseYAMLBytesWithBaseDir(data []byte, baseDir string) (*RouterConfig, erro
 		return nil, rejectErr
 	}
 
+	expandEnvSubstitutionsInMap(raw)
+	expandedData, marshalErr := yaml.Marshal(raw)
+	if marshalErr != nil {
+		return nil, fmt.Errorf("failed to marshal config after environment expansion: %w", marshalErr)
+	}
+
 	// Warn about unknown YAML fields (typos) before parsing into typed structs.
 	WarnUnknownFields(raw, reflect.TypeOf(CanonicalConfig{}))
 
-	cfg, err := parseRouterConfigPayload(data, raw)
+	cfg, err := parseRouterConfigPayload(expandedData, raw)
 	if err != nil {
 		return nil, err
 	}

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -406,6 +406,36 @@ vllm-sr config import --from openclaw --source openclaw.json --target config.yam
 
 When `--source` is omitted, the importer checks `OPENCLAW_CONFIG_PATH`, `./openclaw.json`, and `~/.openclaw/openclaw.json` in that order.
 
+## Environment variable substitution
+
+During config load, string values anywhere in the canonical YAML tree can reference environment variables. This is the supported way to keep passwords, API keys, and other secrets out of ConfigMaps while still using a checked-in config skeleton.
+
+Supported forms:
+
+- `${VAR}` and `$VAR`
+- `${VAR:-default}` when `VAR` is unset or empty
+- `${VAR-default}` when `VAR` is unset
+- `$$` for a literal `$`
+
+Example for Router Replay on Kubernetes:
+
+```yaml
+global:
+  services:
+    router_replay:
+      enabled: true
+      store_backend: postgres
+      postgres:
+        host: 10.0.0.1
+        database: vsr
+        user: default
+        password: "${POSTGRES_PASSWORD}"
+        ssl_mode: disable
+        table_name: router_replay
+```
+
+Wire `POSTGRES_PASSWORD` from a Secret into the router Deployment environment, then mount or generate the config that references it. The same pattern works for Milvus, Redis, Valkey, Qdrant, and provider `backend_refs[].api_key` values.
+
 ## Quick guides by environment
 
 ### Python CLI


### PR DESCRIPTION
## Summary

Implements environment variable substitution during canonical config load so sensitive values such as database passwords and provider API keys can be referenced from pod environment variables instead of stored in plaintext ConfigMaps.

Closes #2410.

Supported interpolation forms (compose-style):

- `${VAR}` and `$VAR`
- `${VAR:-default}` when `VAR` is unset or empty
- `${VAR-default}` when `VAR` is unset
- `$$` for a literal `$`

Example:

```yaml
global:
  services:
    router_replay:
      postgres:
        password: "${POSTGRES_PASSWORD}"