### PR TITLE
[CI/Build] pre-download benchmark models in performance-test workflow

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -76,8 +76,12 @@ jobs:
         run: |
           pip install -U "huggingface_hub[cli]" hf_transfer
 
-      # Models are now automatically downloaded by the router at startup
-      # No need to pre-download models - the router will download them on first run
+      # The router downloads models at startup, but the component benchmarks
+      # initialize classifiers and embedding models directly, so the minimal
+      # benchmark model set must be pre-downloaded. Populates the "Cache Models"
+      # cache above; the cache key rotates when tools/make/models.mk changes.
+      - name: Download benchmark models
+        run: make download-models-perf
 
       - name: Run component benchmarks
         run: |

--- a/tools/make/models.mk
+++ b/tools/make/models.mk
@@ -74,6 +74,37 @@ download-models: ## Download models using router's built-in download logic
 download-models-lora: ## Download LoRA models (same as download-models now)
 	@$(MAKE) download-models
 
+# Minimal model set for perf/benchmarks (CI performance tests).
+# The component benchmarks initialize classifiers/embeddings directly instead
+# of going through the router's startup download, so these must be
+# pre-downloaded:
+# - classification benchmarks auto-discover the intent+pii+jailbreak merged
+#   classifiers (see src/semantic-router/pkg/classification/model_discovery_scan.go)
+# - cache benchmarks need the Qwen3 embedding model at models/mom-embedding-pro
+#   (see perf/benchmarks/cache_bench_test.go and config/registry.go)
+# The onnx/ subdirs are excluded to keep CI download and cache size small.
+PERF_BENCH_CLASSIFIER_MODELS := \
+	mmbert32k-intent-classifier-merged \
+	mmbert32k-pii-detector-merged \
+	mmbert32k-jailbreak-detector-merged
+
+PERF_BENCH_EMBEDDING_REPO := Qwen/Qwen3-Embedding-0.6B
+PERF_BENCH_EMBEDDING_DIR := mom-embedding-pro
+
+download-models-perf: ## Download the minimal model set for performance benchmarks
+	@echo "📦 Downloading perf benchmark models..."
+	@mkdir -p $(MODELS_DIR)
+	@for model in $(PERF_BENCH_CLASSIFIER_MODELS); do \
+		echo ""; \
+		echo "⬇️  Downloading $$model..."; \
+		hf download $(HF_ORG)/$$model --exclude "onnx/*" --local-dir $(MODELS_DIR)/$$model; \
+	done
+	@echo ""
+	@echo "⬇️  Downloading $(PERF_BENCH_EMBEDDING_REPO)..."
+	@hf download $(PERF_BENCH_EMBEDDING_REPO) --local-dir $(MODELS_DIR)/$(PERF_BENCH_EMBEDDING_DIR)
+	@echo ""
+	@echo "Perf benchmark models downloaded to $(MODELS_DIR)/"
+
 download-mmbert: ## Download all mmBERT merged models for Rust inference
 	@echo "📦 Downloading mmBERT merged models from Hugging Face..."
 	@mkdir -p $(MODELS_DIR)


### PR DESCRIPTION
Fixes https://github.com/vllm-project/semantic-router/issues/2434 (fourth layer of https://github.com/vllm-project/semantic-router/issues/2398): the component benchmarks initialize classifiers/embeddings directly and never start the router, so nothing downloads models in CI and all classification/cache benchmarks fail.

## How

- New `download-models-perf` target: the 3 mmbert32k merged classifiers (`AutoInitializeUnifiedClassifier` needs all three) + `Qwen/Qwen3-Embedding-0.6B` at `models/mom-embedding-pro`, with `onnx/` excluded (~5GB instead of ~14GB)
- Workflow runs it before the benchmarks; models land in `models/`, so the existing "Cache Models" step (key: `hashFiles('tools/make/models.mk')`) finally gets populated and later runs hit the cache

Should land before or together with https://github.com/vllm-project/semantic-router/pull/2400, otherwise perf-path PRs turn red once that PR unmasks failures.

## Test plan

- `yamllint` (repo config) and `make agent-lint CHANGED_FILES=".github/workflows/performance-test.yml,tools/make/models.mk"` pass
- This PR touches the workflow itself, so its own performance-test run exercises the download step end to end
