### PR TITLE
[Docs] Position Semantic Router as the Open-Source Runtime for Mixture-of-Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="website/static/img/artworks/vllm-sr-logo.dark.png" alt="vLLM Semantic Router" width="50%"/>
 
-<p><strong>System Level Intelligent Router for Mixture-of-Models at Cloud, Data Center and Edge</strong></p>
+<p><strong>The Open-Source Runtime for Mixture-of-Models</strong></p>
 
 <p>
   <a href="https://vllm-semantic-router.com">Documentation</a> |
@@ -18,17 +18,22 @@
 
 ## About
 
-In the LLM era, the number of models is exploding. Different models vary across capability, scale, cost, and privacy boundaries. Choosing and connecting the right models to build semantic AI infrastructure is a system problem.
+There is no universally best model. "Best" depends on preference: what each user and product values across quality, cost, latency, safety, privacy, modality, and hallucination tolerance.
 
-**vLLM Semantic Router** is a **signal-driven** intelligent router for that problem. It helps teams build model systems that are more **efficient**, **safer**, and more **adaptive** across cloud, data center, and edge environments.
+We call this next-generation, preference-driven model-system architecture **Mixture-of-Models**. At inference time, it composes the model path each request needs from closed frontier models, open general models, domain experts, and compact edge models. A request may use one model, escalate through a confidence cascade, deliberate with Fusion, or coordinate bounded micro-agent workflows.
+
+**vLLM Semantic Router** is the open-source runtime for Mixture-of-Models. Its live request path turns request, response, user, and runtime signals into observable, configurable model-path and policy decisions across configured local, private, and cloud backends.
 
 ![system](website/static/img/system.png)
 
-It delivers three core values:
+Models, compute, and locations define the available supply; preference defines the objective. Together, they shape every mixture:
 
-- **Token economics**: reduce wasted tokens, increase effective output, and maximize the value of every token.
-- **LLM safety**: detect jailbreaks, sensitive leakage, and hallucinations so agents remain controllable, trustworthy, and auditable.
-- **Fullmesh intelligence**: build personal AI at the edge and intelligent MaaS in the cloud by coordinating local, private, and frontier models across cost, privacy, and capability boundaries.
+- **Models — Compose, don't just choose**: select one model, escalate through a confidence cascade, deliberate with Fusion, or coordinate bounded micro-agent workflows.
+- **Compute — Make every token count**: route routine work to efficient paths, reserve cascades and multi-model reasoning for requests that need them, and reuse similar answers with semantic caching.
+- **Location — Run intelligence where it belongs**: route across configured local, private, and cloud backends, keeping privacy-sensitive work on policy-approved paths and reaching cloud models when policy allows.
+- **Preference — Let preference define "best"**: encode priorities for quality, cost, latency, safety, privacy, modality, and hallucination tolerance as explicit signals and policies that shape each route.
+
+Across all four dimensions, configurable request and response controls, response headers, and Router Replay provide safety, governance, and observability.
 
 ## Getting Started
 
@@ -50,6 +55,9 @@ For platform notes, detailed setup options, and troubleshooting, see the **[Inst
 
 ## Latest News
 
+- [2026/06/29] New Blog: [Micro-Agent: Beat Frontier Models with Collaboration inside Model API](https://vllm.ai/blog/2026-06-29-micro-agent-frontier-models)
+- [2026/06/16] New Blog: [Beyond One Model: Fusion in vLLM Semantic Router](https://vllm.ai/blog/2026-06-16-vllm-sr-fusion-api)
+- [2026/06/05] v0.3 Released: [vLLM Semantic Router v0.3 Themis: From Signals to Stateful Production Routing](https://vllm.ai/blog/2026-06-05-v0.3-vllm-sr-themis-release)
 - [2026/03/24] Vision Paper Released: [The Workload-Router-Pool Architecture for LLM Inference Optimization](https://vllm-semantic-router.com/vision-paper)
 - [2026/03/10] v0.2 Released: [vLLM Semantic Router v0.2 Athena Release](https://vllm.ai/blog/v0.2-vllm-sr-athena-release)
 - [2026/02/27] White Paper Released: [Signal Driven Decision Routing for Mixture-of-Modality Models](https://vllm-semantic-router.com/white-paper/)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -8,12 +8,13 @@ import rehypeKatex from 'rehype-katex'
 const lightCodeTheme = themes.github
 const darkCodeTheme = themes.vsDark
 const siteUrl = 'https://vllm-semantic-router.com'
-const siteDefaultDescription = 'Open-source LLM router for Mixture-of-Models. Route requests by cost, latency, privacy, safety, and modality across local, private, and frontier models.'
+const siteDefaultDescription = 'Open-source runtime for Mixture-of-Models, a preference-driven model-system architecture that selects, cascades, and coordinates models for each request.'
+const siteSocialTitle = 'vLLM Semantic Router | Runtime for Mixture-of-Models'
 const siteSocialPreviewImageUrl = `${siteUrl}/${SITE_SOCIAL_PREVIEW_IMAGE}`
 
 const config: Config = {
   title: 'vLLM Semantic Router',
-  tagline: 'Open-source LLM router for Mixture-of-Models',
+  tagline: 'The Open-Source Runtime for Mixture-of-Models',
   favicon: 'img/vllm.png',
 
   // Set the production url of your site here
@@ -156,17 +157,17 @@ const config: Config = {
     image: SITE_SOCIAL_PREVIEW_IMAGE,
     metadata: [
       { name: 'description', content: siteDefaultDescription },
-      { name: 'keywords', content: 'open-source LLM router, multi-model routing, semantic router, model selection, AI gateway, vLLM, Envoy, inference routing, policy-aware routing, privacy-aware routing, safety routing' },
+      { name: 'keywords', content: 'Mixture-of-Models runtime, preference-driven AI, open-source LLM router, multi-model routing, model orchestration, model selection, model cascade, Fusion API, micro-agent workflows, semantic router, policy-aware routing, vLLM' },
       { name: 'author', content: 'vLLM Semantic Router Team' },
       { name: 'application-name', content: 'vLLM Semantic Router' },
-      { property: 'og:title', content: 'vLLM Semantic Router | Open-Source LLM Router' },
+      { property: 'og:title', content: siteSocialTitle },
       { property: 'og:description', content: siteDefaultDescription },
       { property: 'og:type', content: 'website' },
       { property: 'og:site_name', content: 'vLLM Semantic Router' },
       { property: 'og:image', content: siteSocialPreviewImageUrl },
       { property: 'og:image:alt', content: 'vLLM Semantic Router social preview' },
       { name: 'twitter:card', content: 'summary_large_image' },
-      { name: 'twitter:title', content: 'vLLM Semantic Router | Open-Source LLM Router' },
+      { name: 'twitter:title', content: siteSocialTitle },
       { name: 'twitter:description', content: siteDefaultDescription },
       { name: 'twitter:image', content: siteSocialPreviewImageUrl },
       { name: 'twitter:image:alt', content: 'vLLM Semantic Router social preview' },
@@ -377,7 +378,7 @@ const config: Config = {
         'name': 'vLLM Semantic Router',
         'applicationCategory': 'AIInfrastructure',
         'operatingSystem': 'Cross-platform',
-        'description': 'Open-source LLM router for Mixture-of-Models',
+        'description': siteDefaultDescription,
         'url': 'https://vllm-semantic-router.com',
         'publisher': {
           '@type': 'Organization',

--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -371,32 +371,20 @@
   "homepage.hero.publicBeta": {
     "message": "抢先体验"
   },
+  "homepage.hero.logoAlt": {
+    "message": "vLLM Semantic Router 标志"
+  },
   "homepage.hero.label": {
-    "message": "开源 LLM 路由器"
+    "message": "Mixture-of-Models 开源运行时"
   },
-  "homepage.hero.line1Accent": {
-    "message": "路由"
+  "homepage.hero.line1": {
+    "message": "智能，"
   },
-  "homepage.hero.line1Suffix": {
-    "message": "每一个请求"
-  },
-  "homepage.hero.line2Prefix": {
-    "message": "用一个系统"
-  },
-  "homepage.hero.line2Accent": {
-    "message": "大脑"
-  },
-  "homepage.hero.line3Prefix": {
-    "message": "到"
-  },
-  "homepage.hero.line3Accent": {
-    "message": "最合适的"
-  },
-  "homepage.hero.line3Suffix": {
-    "message": "模型"
+  "homepage.hero.line2": {
+    "message": "因你而组合。"
   },
   "homepage.hero.description": {
-    "message": "在本地、私有与前沿模型之间统一路由，由成本、时延、隐私与安全共同驱动。"
+    "message": "没有一个模型对所有人都是最好的。vLLM Semantic Router 依据通过可配置信号与策略表达的用户偏好，为每个请求选择、级联或协作编排模型。"
   },
   "homepage.hero.primaryCta": {
     "message": "试用演示"
@@ -408,11 +396,14 @@
     "message": "阅读白皮书"
   },
   "homepage.hero.modelBand.eyebrow": {
-    "message": "系统大脑"
+    "message": "Mixture-of-Models"
   },
   "homepage.hero.modelBand.copy": {
-    "message": "用系统大脑连接所有模型"
-  },    
+    "message": "你的偏好，决定模型如何组合"
+  },
+  "homepage.hero.modelBand.aria": {
+    "message": "Mixture-of-Models 模型生态"
+  },
   "homepage.stats.signals.label": {
     "message": "信号"
   },
@@ -432,85 +423,94 @@
     "message": "{count} 篇研究论文，覆盖路由、系统、安全与多模态。"
   },
   "homepage.capabilities.label": {
-    "message": "为什么需要路由"
+    "message": "为什么需要 Mixture-of-Models"
   },
   "homepage.capabilities.heading": {
-    "message": "一个请求，多种模型选择。"
+    "message": "供给是碎片化的，“最好”因人而异。"
   },
   "homepage.capabilities.copy": {
-    "message": "模型在质量、成本、时延、隐私和模态上都不一样。一旦你不止跑一个模型，难点就不再是调用 LLM，而是把每个请求路由到正确的模型系统。"
+    "message": "模型、算力和部署位置持续分化；偏好决定对每个用户和工作负载而言，什么才算“好”。Mixture-of-Models 将碎片化供给组合为与偏好一致的智能。"
   },
-  "homepage.capabilities.axis.capability": {
-    "message": "能力"
+  "homepage.capabilities.axis.models": {
+    "message": "模型"
   },
-  "homepage.capabilities.axis.cost": {
-    "message": "成本"
+  "homepage.capabilities.axis.compute": {
+    "message": "算力"
   },
-  "homepage.capabilities.axis.privacy": {
-    "message": "隐私"
+  "homepage.capabilities.axis.location": {
+    "message": "位置"
   },
-  "homepage.capabilities.axis.latency": {
-    "message": "时延"
+  "homepage.capabilities.axis.preference": {
+    "message": "偏好"
   },
   "homepage.capabilities.checklist.label": {
-    "message": "路由器要决定什么"
+    "message": "开源运行时"
   },
   "homepage.capabilities.checklist.copy": {
-    "message": "在回复到达用户之前，路由器每次都要回答同一组运行问题。"
+    "message": "vLLM Semantic Router 让 Mixture-of-Models 在在线请求链路中真正运行起来。"
   },
-  "homepage.capabilities.task.choose": {
-    "message": "为每个请求选择合适的模型路径。"
+  "homepage.capabilities.task.extract": {
+    "message": "读取任务、上下文、安全、偏好和运行时信号。"
   },
-  "homepage.capabilities.task.connect": {
-    "message": "把本地、私有和前沿模型接进同一产品，而不是各管一摊。"
+  "homepage.capabilities.task.compose": {
+    "message": "选择单个模型、沿置信度级联升级，或协调多个模型。"
   },
-  "homepage.capabilities.task.govern": {
-    "message": "在路由时同时执行成本、安全和隐私约束。"
+  "homepage.capabilities.task.apply": {
+    "message": "应用可配置的请求与响应控制，并公开结果供检查。"
   },
   "homepage.capabilities.checklist.footer": {
-    "message": "成本控制、安全控制和模型选择，必须在同一步完成。"
+    "message": "偏好定义目标，Mixture-of-Models 定义架构，vLLM Semantic Router 负责运行它。"
   },
-  "homepage.capabilities.meta.selection": {
-    "message": "选择"
+  "homepage.capabilities.meta.signals": {
+    "message": "信号"
   },
-  "homepage.capabilities.meta.connection": {
-    "message": "连接"
+  "homepage.capabilities.meta.preferences": {
+    "message": "偏好"
   },
-  "homepage.capabilities.meta.governance": {
-    "message": "治理"
+  "homepage.capabilities.meta.modelPaths": {
+    "message": "模型路径"
   },
   "homepage.capabilities.values.label": {
-    "message": "团队为什么部署它"
+    "message": "什么决定模型组合"
   },
   "homepage.capabilities.values.copy": {
-    "message": "用同一层路由同时处理成本、质量和策略决策。"
+    "message": "模型、算力和部署位置决定有哪些可用资源；偏好决定最佳组合。"
   },
   "homepage.capabilities.value1.title": {
-    "message": "降低单次请求成本"
+    "message": "组合，而不只是选择。"
   },
   "homepage.capabilities.value1.text": {
-    "message": "把常规流量发往更高效的模型，把真正需要的请求交给前沿推理模型，让模型选择变成可衡量的 ROI。"
+    "message": "选择单个模型、按置信度逐级升级、通过 Fusion 进行多模型研判，或编排有边界的微智能体工作流。"
   },
   "homepage.capabilities.value1.detail": {
-    "message": "每一美元换来更多有效输出。"
+    "message": "让每个请求采用它真正需要的模型路径。"
   },
   "homepage.capabilities.value2.title": {
-    "message": "更安全的模型决策"
+    "message": "让每个 token 都物有所值。"
   },
   "homepage.capabilities.value2.text": {
-    "message": "把越狱、PII 和幻觉处理放进路由链路里，让高风险请求在生成前就被拦住。"
+    "message": "将常规任务路由到高效模型路径，仅为真正需要的请求启用级联与多模型推理，并通过语义缓存复用相似回答。"
   },
   "homepage.capabilities.value2.detail": {
-    "message": "安全能力直接进入请求路径。"
+    "message": "只有更多智能能带来价值时，才投入更多计算。"
   },
   "homepage.capabilities.value3.title": {
-    "message": "一层路由接所有模型"
+    "message": "让智能在合适的位置运行。"
   },
   "homepage.capabilities.value3.text": {
-    "message": "用同一层路由协调本地、私有和前沿模型，从边缘部署一直覆盖到托管云。"
+    "message": "在已配置的本地、私有和云端后端之间路由，让隐私敏感任务留在策略批准的路径上，并在策略允许时使用云端模型。"
   },
   "homepage.capabilities.value3.detail": {
-    "message": "一套系统贯穿设备、VPC 和云。"
+    "message": "用一套路由策略连接已配置的模型端点。"
+  },
+  "homepage.capabilities.value4.title": {
+    "message": "让偏好定义“最好”。"
+  },
+  "homepage.capabilities.value4.text": {
+    "message": "将质量、成本、时延、安全、隐私、模态和幻觉容忍度等优先级编码为显式信号与策略，塑造每条请求路径。"
+  },
+  "homepage.capabilities.value4.detail": {
+    "message": "最好的组合，就是最符合用户需求的组合。"
   },
   "homepage.capabilities.signal.title": {
     "message": "信号提取"
@@ -2432,13 +2432,13 @@
     "message": "用于 LLM 推理优化的 Workload-Router-Pool 架构，以 vLLM Semantic Router 愿景论文的完整 PDF 阅读器形式呈现。"
   },
   "homepage.meta.description": {
-    "message": "面向 Mixture-of-Models 的开源 LLM 路由器。基于成本、时延、隐私、安全和模态信号，为每个请求选择最合适的本地、私有或前沿模型。"
+    "message": "Mixture-of-Models 是偏好驱动的模型系统架构。vLLM Semantic Router 是其开源运行时，依据偏好与策略为每个请求选择、级联和协作编排模型。"
   },
   "homepage.meta.title": {
-    "message": "面向 Mixture-of-Models 的开源 LLM 路由器"
+    "message": "Mixture-of-Models 的开源运行时"
   },
   "homepage.meta.socialTitle": {
-    "message": "vLLM Semantic Router | 开源 LLM 路由器"
+    "message": "vLLM Semantic Router | Mixture-of-Models 开源运行时"
   },
 
   "homepage.whereItLives.title": {

--- a/website/src/components/site/CapabilityGlyph.tsx
+++ b/website/src/components/site/CapabilityGlyph.tsx
@@ -7,6 +7,9 @@ export type CapabilityGlyphKind =
   | 'plugin'
   | 'language'
   | 'selection'
+  | 'economics'
+  | 'safety'
+  | 'mesh'
   | 'docs'
 
 type CapabilityGlyphProps = {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,6 +1,7 @@
 .page {
   display: grid;
   gap: 0;
+  overflow-x: clip;
 }
 
 .heroStage {
@@ -34,6 +35,7 @@
   z-index: 1;
   display: grid;
   width: min(100%, 76rem);
+  min-width: 0;
   margin: 0 auto;
   justify-items: center;
 }
@@ -42,6 +44,7 @@
   position: relative;
   display: grid;
   width: min(100%, 56rem);
+  min-width: 0;
   gap: clamp(1.05rem, 2vh, 1.65rem);
   justify-items: center;
   text-align: center;
@@ -49,6 +52,7 @@
 
 .heroIntroPanel {
   width: min(100%, 56rem);
+  min-width: 0;
 }
 
 .heroIntroPanel :global(h1) {
@@ -87,12 +91,15 @@
 
 .heroTitle {
   display: grid;
+  width: 100%;
+  min-width: 0;
   gap: 0.03em;
   justify-items: center;
 }
 
 .heroTitleLine {
   display: block;
+  max-width: 100%;
   white-space: nowrap;
 }
 
@@ -522,6 +529,12 @@
   text-transform: uppercase;
 }
 
+.problemAxis:last-child {
+  border-color: rgba(48, 162, 255, 0.28);
+  background: rgba(48, 162, 255, 0.08);
+  color: #167fce;
+}
+
 .problemChecklist {
   display: flex;
   flex-direction: column;
@@ -643,7 +656,7 @@
 
 .valueGrid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1.1rem;
 }
 
@@ -720,6 +733,15 @@
   gap: 0.8rem;
 }
 
+.valueCardAxis {
+  color: var(--site-muted);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
 .valueCardCopy h3 {
   margin: 0;
   font-size: 1.35rem;
@@ -764,6 +786,55 @@
 .valueCard:hover .valueGlyph {
   transform: translateY(-2px) scale(1.02);
   color: rgba(17, 17, 17, 0.72);
+}
+
+.valueCardPreference {
+  border-color: rgba(48, 162, 255, 0.34);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(48, 162, 255, 0.12), transparent 38%),
+    linear-gradient(180deg, rgba(48, 162, 255, 0.045), transparent 42%),
+    var(--site-surface);
+}
+
+.valueCardPreference::before {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  background: linear-gradient(90deg, #30A2FF, rgba(48, 162, 255, 0.18));
+  content: '';
+}
+
+.valueCardPreference .valueCardIndex {
+  border-color: rgba(48, 162, 255, 0.25);
+  background: rgba(48, 162, 255, 0.09);
+  color: #167fce;
+}
+
+.valueCardPreference .valueCardAxis {
+  color: #167fce;
+}
+
+.valueCardPreference .valueGlyphShell {
+  border-color: rgba(48, 162, 255, 0.2);
+  background:
+    radial-gradient(circle at 50% 50%, rgba(48, 162, 255, 0.1), transparent 60%),
+    rgba(48, 162, 255, 0.035);
+}
+
+.valueCardPreference .valueGlyph {
+  color: rgba(22, 127, 206, 0.7);
+}
+
+.valueCardPreference:hover {
+  border-color: rgba(48, 162, 255, 0.52);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(48, 162, 255, 0.16), transparent 40%),
+    linear-gradient(180deg, rgba(48, 162, 255, 0.06), transparent 44%),
+    var(--site-surface-alt);
+}
+
+.valueCardPreference:hover .valueGlyph {
+  color: rgba(22, 127, 206, 0.9);
 }
 
 .encoderShowcase {
@@ -966,14 +1037,19 @@
   margin: 0;
 }
 
+@media (max-width: 1180px) {
+  .valueGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 996px) {
   .heroGrid,
   .sectionHeading,
   .encoderShowcase,
   .bandGrid,
   .problemPanel,
-  .valueIntro,
-  .valueGrid {
+  .valueIntro {
     grid-template-columns: 1fr;
   }
 
@@ -1007,7 +1083,14 @@
 
   .heroIntro,
   .heroIntroPanel {
-    width: min(100%, 32rem);
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .heroGrid,
+  .heroTitle {
+    width: 100%;
+    max-width: 100%;
   }
 
   .heroBrandLockup {
@@ -1024,7 +1107,20 @@
   }
 
   .heroTitleAccent {
+    white-space: normal;
     font-size: 1.04em;
+  }
+
+  .heroIntroPanel :global(h1) {
+    width: 100%;
+    max-width: 100%;
+    font-size: clamp(2.15rem, 9.5vw, 2.6rem);
+    line-height: 0.96;
+  }
+
+  .heroDescriptionText {
+    width: 100%;
+    max-width: 100%;
   }
 
   .heroPrimaryCta,
@@ -1112,5 +1208,11 @@
   .encoderPipelineFrame,
   .encoderCard {
     padding: 1.15rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .valueGrid {
+    grid-template-columns: 1fr;
   }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -31,15 +31,15 @@ import styles from './index.module.css'
 const paperCount = researchPapers.length
 const homepageMetaTitle = translate({
   id: 'homepage.meta.title',
-  message: 'Open-Source LLM Router for Mixture-of-Models',
+  message: 'Open-Source Runtime for Mixture-of-Models',
 })
 const homepageMetaDescription = translate({
   id: 'homepage.meta.description',
-  message: 'Open-source LLM router for Mixture-of-Models. Route each request by cost, latency, privacy, safety, and modality across local, private, and frontier models.',
+  message: 'Open-source runtime for Mixture-of-Models, a preference-driven model-system architecture that selects, cascades, and coordinates models for each request.',
 })
 const homepageSocialTitle = translate({
   id: 'homepage.meta.socialTitle',
-  message: 'vLLM Semantic Router | Open-Source LLM Router',
+  message: 'vLLM Semantic Router | Runtime for Mixture-of-Models',
 })
 
 type HeroModelLogo = {
@@ -92,79 +92,99 @@ const heroStats = [
 ]
 
 interface ValueCard {
+  axis: string
   detail: string
+  emphasis?: boolean
   index: string
   kind: CapabilityGlyphKind
   text: string
   title: string
 }
 
-const problemAxes = [
-  translate({ id: 'homepage.capabilities.axis.capability', message: 'Capability' }),
-  translate({ id: 'homepage.capabilities.axis.cost', message: 'Cost' }),
-  translate({ id: 'homepage.capabilities.axis.privacy', message: 'Privacy' }),
-  translate({ id: 'homepage.capabilities.axis.latency', message: 'Latency' }),
+const mixtureDimensions = {
+  models: translate({ id: 'homepage.capabilities.axis.models', message: 'Models' }),
+  compute: translate({ id: 'homepage.capabilities.axis.compute', message: 'Compute' }),
+  location: translate({ id: 'homepage.capabilities.axis.location', message: 'Location' }),
+  preference: translate({ id: 'homepage.capabilities.axis.preference', message: 'Preference' }),
+}
+
+const runtimeTasks = [
+  translate({
+    id: 'homepage.capabilities.task.extract',
+    message: 'Read task, context, safety, preference, and runtime signals.',
+  }),
+  translate({
+    id: 'homepage.capabilities.task.compose',
+    message: 'Select one model, escalate through a confidence cascade, or coordinate multiple models.',
+  }),
+  translate({
+    id: 'homepage.capabilities.task.apply',
+    message: 'Apply configurable request and response controls, then expose the outcome for inspection.',
+  }),
 ]
 
-const problemTasks = [
-  translate({
-    id: 'homepage.capabilities.task.choose',
-    message: 'Choose the right model lane for each request.',
-  }),
-  translate({
-    id: 'homepage.capabilities.task.connect',
-    message: 'Connect local, private, and frontier models without fragmenting the product.',
-  }),
-  translate({
-    id: 'homepage.capabilities.task.govern',
-    message: 'Enforce cost, safety, and privacy at routing time.',
-  }),
-]
-
-const problemMeta = [
-  translate({ id: 'homepage.capabilities.meta.selection', message: 'Selection' }),
-  translate({ id: 'homepage.capabilities.meta.connection', message: 'Connection' }),
-  translate({ id: 'homepage.capabilities.meta.governance', message: 'Governance' }),
+const runtimeInputs = [
+  translate({ id: 'homepage.capabilities.meta.signals', message: 'Signals' }),
+  translate({ id: 'homepage.capabilities.meta.preferences', message: 'Preferences' }),
+  translate({ id: 'homepage.capabilities.meta.modelPaths', message: 'Model paths' }),
 ]
 
 const valueCards: ValueCard[] = [
   {
     index: '01',
-    kind: 'economics',
-    title: translate({ id: 'homepage.capabilities.value1.title', message: 'Lower cost per request' }),
+    axis: mixtureDimensions.models,
+    kind: 'selection',
+    title: translate({ id: 'homepage.capabilities.value1.title', message: 'Compose, don’t just choose.' }),
     text: translate({
       id: 'homepage.capabilities.value1.text',
-      message: 'Send routine traffic to efficient lanes, reserve frontier reasoning for the requests that need it, and turn model choice into measurable ROI.',
+      message: 'Select a single model, escalate through a confidence cascade, deliberate with Fusion, or coordinate bounded micro-agent workflows.',
     }),
     detail: translate({
       id: 'homepage.capabilities.value1.detail',
-      message: 'More useful output per dollar.',
+      message: 'Use the model path the request needs.',
     }),
   },
   {
     index: '02',
-    kind: 'safety',
-    title: translate({ id: 'homepage.capabilities.value2.title', message: 'Safer model decisions' }),
+    axis: mixtureDimensions.compute,
+    kind: 'economics',
+    title: translate({ id: 'homepage.capabilities.value2.title', message: 'Make every token count.' }),
     text: translate({
       id: 'homepage.capabilities.value2.text',
-      message: 'Move jailbreak, PII, and hallucination handling into the routing path so risky traffic is intercepted before it becomes product behavior.',
+      message: 'Route routine work to efficient model paths, reserve cascades and multi-model reasoning for requests that need them, and reuse similar answers with semantic caching.',
     }),
     detail: translate({
       id: 'homepage.capabilities.value2.detail',
-      message: 'Safety becomes part of the request path.',
+      message: 'Spend more only when more intelligence adds value.',
     }),
   },
   {
     index: '03',
+    axis: mixtureDimensions.location,
     kind: 'mesh',
-    title: translate({ id: 'homepage.capabilities.value3.title', message: 'One router across every model' }),
+    title: translate({ id: 'homepage.capabilities.value3.title', message: 'Run intelligence where it belongs.' }),
     text: translate({
       id: 'homepage.capabilities.value3.text',
-      message: 'Coordinate local, private, and frontier models through one layer that works from edge deployment to managed cloud.',
+      message: 'Route across configured local, private, and cloud backends, keeping privacy-sensitive work on policy-approved paths and reaching cloud models when policy allows.',
     }),
     detail: translate({
       id: 'homepage.capabilities.value3.detail',
-      message: 'One system across device, VPC, and cloud.',
+      message: 'One routing policy across configured endpoints.',
+    }),
+  },
+  {
+    index: '04',
+    axis: mixtureDimensions.preference,
+    emphasis: true,
+    kind: 'decision',
+    title: translate({ id: 'homepage.capabilities.value4.title', message: 'Let preference define “best.”' }),
+    text: translate({
+      id: 'homepage.capabilities.value4.text',
+      message: 'Encode priorities for quality, cost, latency, safety, privacy, modality, and hallucination tolerance as explicit signals and policies that shape each route.',
+    }),
+    detail: translate({
+      id: 'homepage.capabilities.value4.detail',
+      message: 'The best mixture is the one aligned with the user.',
     }),
   },
 ]
@@ -282,39 +302,23 @@ function DitherHero(): JSX.Element {
               <PageIntro
                 align="center"
                 className={styles.heroIntroPanel}
-                label={<Translate id="homepage.hero.label">Open-source LLM router</Translate>}
+                label={<Translate id="homepage.hero.label">The open-source runtime for Mixture-of-Models</Translate>}
                 title={(
                   <span className={styles.heroTitle}>
-                    <span className={styles.heroTitleLine}>
-                      <span className={styles.heroTitleAccent}>
-                        <Translate id="homepage.hero.line1Accent">Route</Translate>
-                      </span>
-                      {' '}
-                      <Translate id="homepage.hero.line1Suffix">every request</Translate>
+                    <span className={`${styles.heroTitleLine} ${styles.heroTitleAccent}`}>
+                      <Translate id="homepage.hero.line1">Intelligence,</Translate>
                     </span>
                     <span className={styles.heroTitleLine}>
-                      <Translate id="homepage.hero.line2Prefix">with one system</Translate>
-                      {' '}
-                      <span className={styles.heroTitleAccent}>
-                        <Translate id="homepage.hero.line2Accent">brain</Translate>
-                      </span>
-                    </span>
-                    <span className={styles.heroTitleLine}>
-                      <Translate id="homepage.hero.line3Prefix">to the</Translate>
-                      {' '}
-                      <span className={styles.heroTitleAccent}>
-                        <Translate id="homepage.hero.line3Accent">best</Translate>
-                      </span>
-                      {' '}
-                      <Translate id="homepage.hero.line3Suffix">model</Translate>
+                      <Translate id="homepage.hero.line2">composed for you.</Translate>
                     </span>
                   </span>
                 )}
                 description={(
                   <span className={styles.heroDescriptionText}>
                     <Translate id="homepage.hero.description">
-                      Unified routing across local, private, and frontier models—guided by
-                      cost, latency, privacy, and safety.
+                      No model is best for everyone. vLLM Semantic Router selects, escalates, and
+                      coordinates models for each request—guided by user preference
+                      expressed through configurable signals and policy.
                     </Translate>
                   </span>
                 )}
@@ -343,17 +347,17 @@ function DitherHero(): JSX.Element {
         className={styles.heroModelSection}
         aria-label={translate({
           id: 'homepage.hero.modelBand.aria',
-          message: 'Supported model ecosystem',
+          message: 'Mixture-of-Models ecosystem',
         })}
       >
         <div className={styles.heroModelBand}>
           <div className={styles.heroModelBandHeader}>
             <span className={styles.heroModelBandEyebrow}>
-              <Translate id="homepage.hero.modelBand.eyebrow">System brain</Translate>
+              <Translate id="homepage.hero.modelBand.eyebrow">Mixture-of-Models</Translate>
             </span>
             <p className={styles.heroModelBandCopy}>
               <Translate id="homepage.hero.modelBand.copy">
-                Connect all models with system brain
+                Your preference shapes the mixture
               </Translate>
             </p>
           </div>
@@ -393,22 +397,22 @@ function CapabilitySection(): JSX.Element {
           <div className={styles.problemPanel}>
             <div className={styles.problemIntro}>
               <SectionLabel>
-                <Translate id="homepage.capabilities.label">Why routing matters</Translate>
+                <Translate id="homepage.capabilities.label">Why Mixture-of-Models</Translate>
               </SectionLabel>
               <h2>
                 <Translate id="homepage.capabilities.heading">
-                  One request. Many model choices.
+                  The supply is fragmented. “Best” is personal.
                 </Translate>
               </h2>
               <p>
                 <Translate id="homepage.capabilities.copy">
-                  Models now differ on quality, cost, latency, privacy, and modality. Once you run
-                  more than one model, the hard part is no longer calling an LLM. It is routing every
-                  request to the right model system.
+                  Models, compute, and locations keep diversifying. Preference defines what “best”
+                  means for each user and workload. Mixture-of-Models turns fragmented supply into
+                  preference-aligned intelligence.
                 </Translate>
               </p>
               <div className={styles.problemAxes}>
-                {problemAxes.map(axis => (
+                {Object.values(mixtureDimensions).map(axis => (
                   <span key={axis} className={styles.problemAxis}>
                     {axis}
                   </span>
@@ -419,17 +423,16 @@ function CapabilitySection(): JSX.Element {
             <aside className={styles.problemChecklist}>
               <div className={styles.problemChecklistHeader}>
                 <SectionLabel>
-                  <Translate id="homepage.capabilities.checklist.label">What the router decides</Translate>
+                  <Translate id="homepage.capabilities.checklist.label">The open-source runtime</Translate>
                 </SectionLabel>
                 <p>
                   <Translate id="homepage.capabilities.checklist.copy">
-                    Before a response reaches the user, the router has to answer the same operating
-                    questions every time.
+                    vLLM Semantic Router makes Mixture-of-Models executable in the live request path.
                   </Translate>
                 </p>
               </div>
               <ul className={styles.problemChecklistList}>
-                {problemTasks.map(task => (
+                {runtimeTasks.map(task => (
                   <li key={task} className={styles.problemChecklistItem}>
                     {task}
                   </li>
@@ -438,11 +441,12 @@ function CapabilitySection(): JSX.Element {
               <div className={styles.problemChecklistFooter}>
                 <p>
                   <Translate id="homepage.capabilities.checklist.footer">
-                    Cost control, safety, and model choice have to happen in one step.
+                    Preference defines the goal. Mixture-of-Models defines the architecture. vLLM
+                    Semantic Router runs it.
                   </Translate>
                 </p>
                 <div className={styles.problemChecklistMeta}>
-                  {problemMeta.map(item => (
+                  {runtimeInputs.map(item => (
                     <span key={item} className={styles.problemChecklistMetaItem}>
                       {item}
                     </span>
@@ -454,18 +458,22 @@ function CapabilitySection(): JSX.Element {
 
           <div className={styles.valueIntro}>
             <SectionLabel>
-              <Translate id="homepage.capabilities.values.label">Why teams deploy it</Translate>
+              <Translate id="homepage.capabilities.values.label">What shapes the mixture</Translate>
             </SectionLabel>
             <p>
               <Translate id="homepage.capabilities.values.copy">
-                A single routing layer for cost, quality, and policy decisions.
+                Models, compute, and locations define what is available. Preference defines the
+                right mixture.
               </Translate>
             </p>
           </div>
 
           <div className={styles.valueGrid}>
             {valueCards.map(card => (
-              <article key={card.title} className={styles.valueCard}>
+              <article
+                key={card.axis}
+                className={`${styles.valueCard}${card.emphasis ? ` ${styles.valueCardPreference}` : ''}`}
+              >
                 <div className={styles.valueCardHeader}>
                   <span className={styles.valueCardIndex}>{card.index}</span>
                   <div className={styles.valueGlyphShell}>
@@ -473,6 +481,7 @@ function CapabilitySection(): JSX.Element {
                   </div>
                 </div>
                 <div className={styles.valueCardCopy}>
+                  <span className={styles.valueCardAxis}>{card.axis}</span>
                   <h3>{card.title}</h3>
                   <p>{card.text}</p>
                 </div>
@@ -650,7 +659,7 @@ export default function Home(): JSX.Element {
         <meta property="og:type" content="website" />
         <meta
           name="keywords"
-          content="open-source LLM router, multi-model routing, AI gateway, model selection, semantic router, inference routing, policy-aware routing, vLLM"
+          content="Mixture-of-Models runtime, preference-driven AI, open-source LLM router, multi-model routing, model orchestration, model selection, model cascade, Fusion API, micro-agent workflows, semantic router, policy-aware routing, vLLM"
         />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={homepageSocialTitle} />
@@ -665,6 +674,8 @@ export default function Home(): JSX.Element {
       <main className={styles.page}>
         <DitherHero />
 
+        <CapabilitySection />
+
         <section className={styles.statsSection}>
           <div className="site-shell-container">
             <StatStrip items={heroStats} />
@@ -673,7 +684,6 @@ export default function Home(): JSX.Element {
 
         <InstallQuickStartSection />
         <ResearchPaperCarousel />
-        <CapabilitySection />
         <PaperFigureShowcase />
         <EncoderIntelligenceSection />
         <TeamCarousel />


### PR DESCRIPTION
## Purpose

- Define **Mixture-of-Models** as a preference-driven model-system architecture: models, compute, and locations provide the available supply, while preference defines the objective.
- Position **vLLM Semantic Router** as the open-source runtime that makes Mixture-of-Models executable in the live request path.
- Replace the homepage banner with the shorter `Intelligence, composed for you.` story and align site metadata, README copy, and Simplified Chinese translations.
- Reorganize the previous three value pillars into four matching angles—**Models, Compute, Location, and Preference**—with Preference visually emphasized.
- Keep safety, governance, and observability as cross-cutting runtime capabilities instead of a mismatched value pillar.
- Keep the README focused on vLLM Semantic Router and add the latest Micro-Agent, Fusion API, and v0.3 Themis news.
- Describe current paths and boundaries precisely: model selection, confidence cascades, Fusion, bounded micro-agent workflows, semantic caching, configured endpoints, and configurable request/response controls.

This is a docs and website-only change.

## Test Plan

- Run the repository docs-only CI gate for all six changed files.
- Lint the website, validate the Chinese translation JSON, and check the diff for whitespace errors.
- Build the production website for English and Simplified Chinese.
- Inspect the production homepage at desktop and 390 px widths in both locales; verify the 4/2/1 card layout, Preference emphasis, and absence of horizontal overflow.

## Test Result

- `make agent-ci-gate CHANGED_FILES='README.md website/docusaurus.config.ts website/i18n/zh-Hans/code.json website/src/components/site/CapabilityGlyph.tsx website/src/pages/index.module.css website/src/pages/index.tsx'` — passed
- `make docs-lint` — passed
- `jq empty website/i18n/zh-Hans/code.json` — passed
- `git diff --check` — passed
- `npm run clear` and `npx docusaurus build` — passed for `en` and `zh-Hans`
- Production visual inspection — passed at desktop and 390 px; four cards become 4/2/1 columns, Preference remains emphasized, and both locales have no horizontal overflow

The build continues to report pre-existing warnings for stale Browserslist data, `vscode-languageserver-types`, Chinese LaTeX Unicode input, and existing Chinese documentation anchors.

## Checklist

- [x] Changes are limited to documentation and website positioning.
- [x] English and Simplified Chinese copy are aligned.
- [x] The branch is rebased on the latest `main`.
- [x] The commit includes a `Signed-off-by` line.
