### PR TITLE
[Router] Fix Responses API streaming SSE translation

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -138,6 +138,7 @@ The framework includes the following test cases (all in `e2e/testcases/`):
 | `response-api-get` | GET /v1/responses/{id} - Retrieve a response | Response retrieval, ID matching |
 | `response-api-delete` | DELETE /v1/responses/{id} - Delete a response | Deletion confirmation, 404 verification |
 | `response-api-input-items` | GET /v1/responses/{id}/input_items - List input items | Input items list, pagination |
+| `response-api-streaming-sse` | POST /v1/responses with `stream:true` | Responses API SSE event shape, no Chat Completions SSE passthrough |
 | `response-api-conversation-chaining` | Conversation chaining with previous_response_id (3-turn chain) | History preservation, instruction inheritance |
 | `response-api-error-missing-input` | Error handling - Invalid request format (missing input field) | 400 error, error message validation |
 | `response-api-error-nonexistent-previous-response-id` | Error handling - Non-existent previous_response_id | Graceful degradation or 404 error |

--- a/e2e/profiles/response-api/profile.go
+++ b/e2e/profiles/response-api/profile.go
@@ -59,6 +59,7 @@ func (p *Profile) GetTestCases() []string {
 		"response-api-get",
 		"response-api-delete",
 		"response-api-input-items",
+		"response-api-streaming-sse",
 		"response-api-conversation-chaining",
 		"response-api-error-missing-input",
 		"response-api-error-nonexistent-previous-response-id",

--- a/e2e/testcases/response_api_streaming.go
+++ b/e2e/testcases/response_api_streaming.go
@@ -1,0 +1,171 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("response-api-streaming-sse", pkgtestcases.TestCase{
+		Description: "POST /v1/responses stream:true returns Responses API SSE events",
+		Tags:        []string{"response-api", "streaming", "sse"},
+		Fn:          testResponseAPIStreamingSSE,
+	})
+}
+
+func testResponseAPIStreamingSSE(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Response API streaming SSE: POST /v1/responses stream:true")
+	}
+
+	result, err := requestResponseAPIStreamingSSE(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status":       result.statusCode,
+			"content_type": result.contentType,
+			"bytes":        len(result.body),
+		})
+	}
+
+	if err := validateResponseAPIStreamingSSEResponse(result); err != nil {
+		return err
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Response API streaming SSE passed: bytes=%d\n", len(result.body))
+	}
+	return nil
+}
+
+type responseAPIStreamingSSEResult struct {
+	statusCode  int
+	contentType string
+	body        []byte
+}
+
+func requestResponseAPIStreamingSSE(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) (responseAPIStreamingSSEResult, error) {
+	session, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return responseAPIStreamingSSEResult{}, err
+	}
+	defer session.Close()
+
+	body := map[string]interface{}{
+		"model":  "openai/gpt-oss-20b",
+		"input":  "Stream this response through the Responses API.",
+		"stream": true,
+		"store":  false,
+		"metadata": map[string]string{
+			"test": "response-api-streaming-sse",
+		},
+	}
+	rawBody, err := json.Marshal(body)
+	if err != nil {
+		return responseAPIStreamingSSEResult{}, fmt.Errorf("marshal streaming response-api request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		session.BaseURL()+"/v1/responses",
+		bytes.NewReader(rawBody),
+	)
+	if err != nil {
+		return responseAPIStreamingSSEResult{}, fmt.Errorf("create streaming response-api request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := session.HTTPClient(30 * time.Second).Do(req)
+	if err != nil {
+		return responseAPIStreamingSSEResult{}, fmt.Errorf("send streaming response-api request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return responseAPIStreamingSSEResult{}, fmt.Errorf("read streaming response-api body: %w", err)
+	}
+
+	return responseAPIStreamingSSEResult{
+		statusCode:  resp.StatusCode,
+		contentType: resp.Header.Get("Content-Type"),
+		body:        responseBody,
+	}, nil
+}
+
+func validateResponseAPIStreamingSSEResponse(result responseAPIStreamingSSEResult) error {
+	stream := string(result.body)
+
+	if result.statusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200, got %d: %s", result.statusCode, truncateString(stream, 500))
+	}
+	if !strings.Contains(result.contentType, "text/event-stream") {
+		return fmt.Errorf("expected text/event-stream content-type, got %q", result.contentType)
+	}
+
+	return validateResponseAPIStreamingSSEBody(stream)
+}
+
+func validateResponseAPIStreamingSSEBody(stream string) error {
+	requiredEvents := []string{
+		"event: response.created",
+		"event: response.in_progress",
+		"event: response.output_item.added",
+		"event: response.content_part.added",
+		"event: response.output_text.delta",
+		"event: response.output_text.done",
+		"event: response.content_part.done",
+		"event: response.output_item.done",
+		"event: response.completed",
+	}
+	for _, event := range requiredEvents {
+		if !strings.Contains(stream, event) {
+			return fmt.Errorf("missing Responses API SSE event %q in stream: %s", event, truncateString(stream, 800))
+		}
+	}
+
+	forbiddenFragments := []struct {
+		value string
+		error string
+	}{
+		{
+			value: "chat.completion.chunk",
+			error: "stream leaked upstream Chat Completions chunk instead of Responses API events",
+		},
+		{
+			value: "data: [DONE]",
+			error: "stream leaked raw upstream [DONE] sentinel instead of response.completed",
+		},
+		{
+			value: "sequence_number",
+			error: "stream included non-Responses API sequence_number field",
+		},
+	}
+	for _, fragment := range forbiddenFragments {
+		if strings.Contains(stream, fragment.value) {
+			return fmt.Errorf("%s: %s", fragment.error, truncateString(stream, 800))
+		}
+	}
+	if !strings.Contains(stream, `"annotations":[]`) {
+		return fmt.Errorf("stream missing output_text annotations array: %s", truncateString(stream, 800))
+	}
+
+	return nil
+}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
@@ -20,12 +20,27 @@ func (r *OpenAIRouter) handleStreamingResponseBody(
 	recordStreamingTTFT(ctx)
 	ensureStreamingState(ctx)
 
-	chunk := string(responseBody)
-	ctx.HasStreamingChunks = true
+	responseAPIStream := isResponseAPIRequest(ctx)
+	parseBody := responseBody
+	if responseAPIStream {
+		frames, remainder := reassembleSSEFrames(ctx.PendingSSEBytes, responseBody)
+		ctx.PendingSSEBytes = remainder
+		parseBody = frames
+	}
+
+	chunk := string(parseBody)
+	if len(parseBody) > 0 {
+		ctx.HasStreamingChunks = true
+	}
 	r.parseStreamingChunk(chunk, ctx)
 
 	if strings.Contains(chunk, "data: [DONE]") {
 		r.finalizeStreamingResponse(ctx)
+	}
+
+	if responseAPIStream {
+		bodyMutation := r.buildResponseAPIStreamingBodyMutation(parseBody, ctx)
+		return buildResponseBodyContinueResponse(bodyMutation, responseAPIStreamingHeaderMutation())
 	}
 
 	return buildResponseBodyContinueResponse(nil, nil)

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
@@ -1,0 +1,366 @@
+package extproc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+)
+
+func (r *OpenAIRouter) buildResponseAPIStreamingBodyMutation(
+	responseBody []byte,
+	ctx *RequestContext,
+) *ext_proc.BodyMutation {
+	translatedBody := r.translateChatCompletionSSEToResponsesSSE(responseBody, ctx)
+	return &ext_proc.BodyMutation{
+		Mutation: &ext_proc.BodyMutation_Body{
+			Body: translatedBody,
+		},
+	}
+}
+
+func responseAPIStreamingHeaderMutation() *ext_proc.HeaderMutation {
+	return &ext_proc.HeaderMutation{
+		SetHeaders: []*core.HeaderValueOption{
+			{
+				Header: &core.HeaderValue{
+					Key:   "content-type",
+					Value: "text/event-stream; charset=utf-8",
+				},
+			},
+		},
+		RemoveHeaders: []string{"content-length"},
+	}
+}
+
+func (r *OpenAIRouter) translateChatCompletionSSEToResponsesSSE(
+	responseBody []byte,
+	ctx *RequestContext,
+) []byte {
+	if ctx == nil || ctx.ResponseAPICtx == nil || ctx.ResponseAPICtx.OriginalRequest == nil {
+		return nil
+	}
+
+	var out bytes.Buffer
+	lines := strings.Split(string(responseBody), "\n")
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+		if data == "" {
+			continue
+		}
+
+		if data == "[DONE]" {
+			r.writeResponseAPIStreamDoneEvents(&out, ctx)
+			continue
+		}
+
+		var chunkData map[string]interface{}
+		if err := json.Unmarshal([]byte(data), &chunkData); err != nil {
+			continue
+		}
+		r.writeResponseAPIStreamDeltaEvents(&out, ctx, chunkData)
+	}
+
+	return out.Bytes()
+}
+
+func (r *OpenAIRouter) writeResponseAPIStreamDeltaEvents(
+	out *bytes.Buffer,
+	ctx *RequestContext,
+	chunkData map[string]interface{},
+) {
+	deltas := responseAPITextDeltas(chunkData)
+	if len(deltas) == 0 {
+		return
+	}
+
+	r.ensureResponseAPIStreamStarted(out, ctx)
+	for _, delta := range deltas {
+		writeResponseAPIStreamEvent(out, "response.output_text.delta", map[string]interface{}{
+			"type":          "response.output_text.delta",
+			"item_id":       ctx.ResponseAPIStreamItemID,
+			"output_index":  0,
+			"content_index": 0,
+			"delta":         delta,
+		})
+	}
+}
+
+func (r *OpenAIRouter) ensureResponseAPIStreamStarted(out *bytes.Buffer, ctx *RequestContext) {
+	if ctx.ResponseAPIStreamStarted {
+		return
+	}
+
+	ctx.ResponseAPIStreamStarted = true
+	if ctx.ResponseAPIStreamItemID == "" {
+		ctx.ResponseAPIStreamItemID = responseapi.GenerateItemID()
+	}
+	if ctx.ResponseAPICtx.GeneratedResponseID == "" {
+		ctx.ResponseAPICtx.GeneratedResponseID = responseapi.GenerateResponseID()
+	}
+	if ctx.ResponseAPIStreamCreatedAt == 0 {
+		ctx.ResponseAPIStreamCreatedAt = time.Now().Unix()
+	}
+
+	startedResponse := responseAPIStreamResponse(ctx, responseapi.StatusInProgress, []interface{}{}, "", nil)
+
+	writeResponseAPIStreamEvent(out, "response.created", map[string]interface{}{
+		"type":     "response.created",
+		"response": startedResponse,
+	})
+	writeResponseAPIStreamEvent(out, "response.in_progress", map[string]interface{}{
+		"type":     "response.in_progress",
+		"response": startedResponse,
+	})
+	writeResponseAPIStreamEvent(out, "response.output_item.added", map[string]interface{}{
+		"type":         "response.output_item.added",
+		"output_index": 0,
+		"item":         responseAPIStreamMessageItem(ctx, responseapi.StatusInProgress, ""),
+	})
+	writeResponseAPIStreamEvent(out, "response.content_part.added", map[string]interface{}{
+		"type":          "response.content_part.added",
+		"item_id":       ctx.ResponseAPIStreamItemID,
+		"output_index":  0,
+		"content_index": 0,
+		"part": map[string]interface{}{
+			"type":        responseapi.ContentTypeOutputText,
+			"text":        "",
+			"annotations": []interface{}{},
+		},
+	})
+}
+
+func (r *OpenAIRouter) writeResponseAPIStreamDoneEvents(out *bytes.Buffer, ctx *RequestContext) {
+	r.ensureResponseAPIStreamStarted(out, ctx)
+	text := ctx.StreamingContent
+	usage := responseAPIStreamUsage(ctx)
+
+	writeResponseAPIStreamEvent(out, "response.output_text.done", map[string]interface{}{
+		"type":          "response.output_text.done",
+		"item_id":       ctx.ResponseAPIStreamItemID,
+		"output_index":  0,
+		"content_index": 0,
+		"text":          text,
+	})
+	writeResponseAPIStreamEvent(out, "response.content_part.done", map[string]interface{}{
+		"type":          "response.content_part.done",
+		"item_id":       ctx.ResponseAPIStreamItemID,
+		"output_index":  0,
+		"content_index": 0,
+		"part": map[string]interface{}{
+			"type":        responseapi.ContentTypeOutputText,
+			"text":        text,
+			"annotations": []interface{}{},
+		},
+	})
+	writeResponseAPIStreamEvent(out, "response.output_item.done", map[string]interface{}{
+		"type":         "response.output_item.done",
+		"output_index": 0,
+		"item":         responseAPIStreamMessageItem(ctx, responseapi.StatusCompleted, text),
+	})
+	writeResponseAPIStreamEvent(out, "response.completed", map[string]interface{}{
+		"type":     "response.completed",
+		"response": responseAPIStreamCompletedResponse(ctx, text, usage),
+	})
+}
+
+func responseAPITextDeltas(chunkData map[string]interface{}) []string {
+	choices, ok := chunkData["choices"].([]interface{})
+	if !ok || len(choices) == 0 {
+		return nil
+	}
+
+	deltas := make([]string, 0, len(choices))
+	for _, rawChoice := range choices {
+		choice, ok := rawChoice.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		delta, ok := choice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		content, ok := delta["content"].(string)
+		if ok && content != "" {
+			deltas = append(deltas, content)
+		}
+	}
+	return deltas
+}
+
+func responseAPIStreamModel(ctx *RequestContext) string {
+	if model, ok := ctx.StreamingMetadata["model"].(string); ok && model != "" {
+		return model
+	}
+	if ctx.RequestModel != "" {
+		return ctx.RequestModel
+	}
+	if ctx.ResponseAPICtx != nil && ctx.ResponseAPICtx.OriginalRequest != nil {
+		return ctx.ResponseAPICtx.OriginalRequest.Model
+	}
+	return ""
+}
+
+func responseAPIStreamMessageItem(ctx *RequestContext, status string, text string) map[string]interface{} {
+	content := []interface{}{}
+	if status == responseapi.StatusCompleted || text != "" {
+		content = append(content, map[string]interface{}{
+			"type":        responseapi.ContentTypeOutputText,
+			"text":        text,
+			"annotations": []interface{}{},
+		})
+	}
+
+	return map[string]interface{}{
+		"id":      ctx.ResponseAPIStreamItemID,
+		"type":    responseapi.ItemTypeMessage,
+		"role":    responseapi.RoleAssistant,
+		"status":  status,
+		"content": content,
+	}
+}
+
+func responseAPIStreamCompletedResponse(
+	ctx *RequestContext,
+	text string,
+	usage map[string]interface{},
+) map[string]interface{} {
+	output := []interface{}{responseAPIStreamMessageItem(ctx, responseapi.StatusCompleted, text)}
+	return responseAPIStreamResponse(ctx, responseapi.StatusCompleted, output, text, usage)
+}
+
+func responseAPIStreamResponse(
+	ctx *RequestContext,
+	status string,
+	output []interface{},
+	text string,
+	usage map[string]interface{},
+) map[string]interface{} {
+	req := ctx.ResponseAPICtx.OriginalRequest
+	store := true
+	if req.Store != nil {
+		store = *req.Store
+	}
+	metadata := req.Metadata
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+
+	response := map[string]interface{}{
+		"id":                   ctx.ResponseAPICtx.GeneratedResponseID,
+		"object":               "response",
+		"created_at":           ctx.ResponseAPIStreamCreatedAt,
+		"model":                responseAPIStreamModel(ctx),
+		"status":               status,
+		"output":               output,
+		"previous_response_id": nil,
+		"error":                nil,
+		"incomplete_details":   nil,
+		"instructions":         nil,
+		"max_output_tokens":    req.MaxOutputTokens,
+		"parallel_tool_calls":  true,
+		"reasoning": map[string]interface{}{
+			"effort":  nil,
+			"summary": nil,
+		},
+		"store":       store,
+		"temperature": responseAPIStreamTemperature(req),
+		"text": map[string]interface{}{
+			"format": map[string]interface{}{
+				"type": "text",
+			},
+		},
+		"tool_choice": req.ToolChoice,
+		"tools":       req.Tools,
+		"top_p":       responseAPIStreamTopP(req),
+		"truncation":  "disabled",
+		"usage":       usage,
+		"user":        nil,
+		"metadata":    metadata,
+	}
+	if req.PreviousResponseID != "" {
+		response["previous_response_id"] = req.PreviousResponseID
+	}
+	if req.Instructions != "" {
+		response["instructions"] = req.Instructions
+	}
+	if req.ToolChoice == nil {
+		response["tool_choice"] = "auto"
+	}
+	if req.Tools == nil {
+		response["tools"] = []interface{}{}
+	}
+	if status == responseapi.StatusCompleted {
+		response["output_text"] = text
+	}
+	if req.ConversationID != "" {
+		response["conversation_id"] = req.ConversationID
+	}
+	return response
+}
+
+func responseAPIStreamUsage(ctx *RequestContext) map[string]interface{} {
+	usage := extractStreamingUsage(ctx)
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && usage.TotalTokens == 0 {
+		return nil
+	}
+
+	inputTokens := int(usage.PromptTokens)
+	cachedTokens := 0
+	if cached, ok := streamingCachedPromptTokens(ctx, inputTokens); ok {
+		cachedTokens = cached
+	}
+
+	reasoningTokens := 0
+	if usageMap, ok := ctx.StreamingMetadata["usage"].(map[string]interface{}); ok {
+		if details, ok := usageMap["completion_tokens_details"].(map[string]interface{}); ok {
+			if rawReasoningTokens, ok := details["reasoning_tokens"].(float64); ok {
+				reasoningTokens = int(rawReasoningTokens)
+			}
+		}
+	}
+
+	return map[string]interface{}{
+		"input_tokens": inputTokens,
+		"input_tokens_details": map[string]interface{}{
+			"cached_tokens": cachedTokens,
+		},
+		"output_tokens": int(usage.CompletionTokens),
+		"output_tokens_details": map[string]interface{}{
+			"reasoning_tokens": reasoningTokens,
+		},
+		"total_tokens": int(usage.TotalTokens),
+	}
+}
+
+func responseAPIStreamTemperature(req *responseapi.ResponseAPIRequest) float64 {
+	if req.Temperature != nil {
+		return *req.Temperature
+	}
+	return 1.0
+}
+
+func responseAPIStreamTopP(req *responseapi.ResponseAPIRequest) float64 {
+	if req.TopP != nil {
+		return *req.TopP
+	}
+	return 1.0
+}
+
+func writeResponseAPIStreamEvent(out *bytes.Buffer, event string, payload map[string]interface{}) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(out, "event: %s\ndata: %s\n\n", event, body)
+}

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -87,6 +87,13 @@ type RequestContext struct {
 	StreamingComplete  bool                            // True when [DONE] marker received
 	StreamingAborted   bool                            // True if stream ended abnormally (EOF, cancel, timeout)
 
+	// Response API streaming translation state. When /v1/responses is backed by
+	// an upstream Chat Completions stream, these fields track the outbound
+	// Responses API event envelope emitted to the client.
+	ResponseAPIStreamStarted   bool
+	ResponseAPIStreamItemID    string
+	ResponseAPIStreamCreatedAt int64
+
 	// UpstreamStatusCode is the HTTP status the upstream returned, captured at
 	// the response-header phase. Zero means the status was never observed for
 	// this request (e.g. response headers not processed). The cache-write path

--- a/src/semantic-router/pkg/extproc/response_api_streaming_repro_test.go
+++ b/src/semantic-router/pkg/extproc/response_api_streaming_repro_test.go
@@ -1,0 +1,171 @@
+package extproc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+)
+
+func TestResponseAPIStreamingResponseRequiresResponsesSSE(t *testing.T) {
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(NewMockResponseStore()),
+	}
+	ctx := newResponseAPIStreamingTestContext("response-api-stream-repro")
+	chunk := []byte(`data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"foo"},"finish_reason":null}]}` + "\n\n")
+
+	resp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: chunk},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	bodyMutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, bodyMutation, "Responses API stream:true must rewrite Chat Completions SSE to Responses API SSE")
+
+	wire := string(bodyMutation.GetBody())
+	requireInitialResponseAPIStreamingWire(t, wire)
+
+	finalChunk := []byte(`data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"prompt_tokens_details":{"cached_tokens":1},"completion_tokens":1,"completion_tokens_details":{"reasoning_tokens":0},"total_tokens":3}}` + "\n\n" + `data: [DONE]` + "\n\n")
+	finalResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: finalChunk},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, finalResp)
+
+	finalBodyMutation := finalResp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, finalBodyMutation, "Responses API stream:true must translate terminal SSE events")
+
+	finalWire := string(finalBodyMutation.GetBody())
+	requireTerminalResponseAPIStreamingWire(t, finalWire)
+	requireResponseAPIStreamingLifecycle(t, wire, finalWire)
+}
+
+func requireInitialResponseAPIStreamingWire(t *testing.T, wire string) {
+	t.Helper()
+
+	require.Contains(t, wire, "response.created")
+	require.Contains(t, wire, "response.in_progress")
+	require.Contains(t, wire, "response.content_part.added")
+	require.Contains(t, wire, "response.output_text.delta")
+	require.Contains(t, wire, `"annotations":[]`)
+	require.NotContains(t, wire, "sequence_number")
+	require.NotContains(t, wire, "chat.completion.chunk")
+	require.Contains(t, wire, "event:", "Responses API SSE should include event names")
+}
+
+func requireTerminalResponseAPIStreamingWire(t *testing.T, finalWire string) {
+	t.Helper()
+
+	require.Contains(t, finalWire, "response.output_text.done")
+	require.Contains(t, finalWire, "response.completed")
+	require.Contains(t, finalWire, `"annotations":[]`)
+	require.NotContains(t, finalWire, "sequence_number")
+	require.NotContains(t, finalWire, "data: [DONE]")
+	require.Contains(t, finalWire, `"output_text":"foo"`)
+	require.Contains(t, finalWire, `"total_tokens":3`)
+}
+
+func requireResponseAPIStreamingLifecycle(t *testing.T, wire string, finalWire string) {
+	t.Helper()
+
+	createdEvent := responseAPIStreamingEventPayload(t, wire, "response.created")
+	completedEvent := responseAPIStreamingEventPayload(t, finalWire, "response.completed")
+	createdResponse, ok := createdEvent["response"].(map[string]interface{})
+	require.True(t, ok)
+	completedResponse, ok := completedEvent["response"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, createdResponse["id"], completedResponse["id"])
+	require.Equal(t, createdResponse["created_at"], completedResponse["created_at"])
+	require.Equal(t, responseapi.StatusInProgress, createdResponse["status"])
+	require.Equal(t, responseapi.StatusCompleted, completedResponse["status"])
+	require.Equal(t, float64(1), createdResponse["temperature"])
+	require.Equal(t, float64(1), createdResponse["top_p"])
+	usage, ok := completedResponse["usage"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, float64(3), usage["total_tokens"])
+	require.Equal(t, map[string]interface{}{"cached_tokens": float64(1)}, usage["input_tokens_details"])
+	require.Equal(t, map[string]interface{}{"reasoning_tokens": float64(0)}, usage["output_tokens_details"])
+}
+
+func TestResponseAPIStreamingResponseBuffersSplitChatCompletionSSE(t *testing.T) {
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(NewMockResponseStore()),
+	}
+	ctx := newResponseAPIStreamingTestContext("response-api-stream-split")
+
+	firstHalf := []byte(`data: {"id":"chatcmpl-split","object":"chat.completion.chunk"`)
+	firstResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: firstHalf},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, firstResp)
+
+	firstMutation := firstResp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, firstMutation, "partial upstream SSE frames must not pass through untranslated")
+	require.Empty(t, firstMutation.GetBody())
+
+	secondHalf := []byte(`,"created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":null}]}` + "\n\n")
+	secondResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: secondHalf},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, secondResp)
+
+	secondWire := string(secondResp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	require.Contains(t, secondWire, "response.output_text.delta")
+	require.Contains(t, secondWire, `"delta":"lo"`)
+	require.NotContains(t, secondWire, "sequence_number")
+	require.NotContains(t, secondWire, "chat.completion.chunk")
+}
+
+func responseAPIStreamingEventPayload(t *testing.T, wire string, event string) map[string]interface{} {
+	t.Helper()
+
+	for _, frame := range strings.Split(wire, "\n\n") {
+		if !strings.Contains(frame, "event: "+event) {
+			continue
+		}
+		for _, line := range strings.Split(frame, "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			var payload map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &payload))
+			return payload
+		}
+	}
+
+	require.Failf(t, "missing event", "event %q not found in stream: %s", event, wire)
+	return nil
+}
+
+func newResponseAPIStreamingTestContext(requestID string) *RequestContext {
+	return &RequestContext{
+		RequestID:               requestID,
+		RequestModel:            "gpt-4o",
+		StartTime:               time.Now(),
+		ProcessingStartTime:     time.Now(),
+		TraceContext:            context.Background(),
+		IsStreamingResponse:     true,
+		ExpectStreamingResponse: true,
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Model:  "gpt-4o",
+				Input:  json.RawMessage(`"hello"`),
+				Stream: true,
+			},
+			GeneratedResponseID: responseapi.GenerateResponseID(),
+		},
+	}
+}

--- a/tools/mock-vllm/app.py
+++ b/tools/mock-vllm/app.py
@@ -4,6 +4,7 @@ import time
 
 import uvicorn
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -18,25 +19,21 @@ class ChatRequest(BaseModel):
     model: str
     messages: list[ChatMessage]
     temperature: float | None = 0.2
+    stream: bool | None = False
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
+def estimate_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, math.ceil(len(text) / 4))
 
 
-@app.get("/v1/models")
-async def models():
-    return {"data": [{"id": "openai/gpt-oss-20b", "object": "model"}]}
-
-
-@app.post("/v1/chat/completions")
-async def chat_completions(req: ChatRequest):
+def build_chat_content(req: ChatRequest) -> str:
     roles = [m.role for m in req.messages]
     system_messages = [m.content for m in req.messages if m.role == "system"]
     user_messages = [m.content for m in req.messages if m.role == "user"]
 
-    content = json.dumps(
+    return json.dumps(
         {
             "mock": "mock-vllm",
             "model": req.model,
@@ -49,30 +46,26 @@ async def chat_completions(req: ChatRequest):
         sort_keys=True,
     )
 
-    # Rough token estimation: ~1 token per 4 characters (ceil)
-    def estimate_tokens(text: str) -> int:
-        if not text:
-            return 0
-        return max(1, math.ceil(len(text) / 4))
 
+def build_chat_usage(req: ChatRequest, content: str) -> dict:
     prompt_text = "\n".join(
         m.content for m in req.messages if isinstance(m.content, str)
     )
     prompt_tokens = estimate_tokens(prompt_text)
     completion_tokens = estimate_tokens(content)
-    total_tokens = prompt_tokens + completion_tokens
 
-    created_ts = int(time.time())
-
-    usage = {
+    return {
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
-        "total_tokens": total_tokens,
-        # Optional details fields some clients read when using caching/reasoning
+        "total_tokens": prompt_tokens + completion_tokens,
         "prompt_tokens_details": {"cached_tokens": 0},
         "completion_tokens_details": {"reasoning_tokens": 0},
     }
 
+
+def build_chat_response(
+    req: ChatRequest, content: str, usage: dict, created_ts: int
+) -> dict:
     return {
         "id": "cmpl-mock-123",
         "object": "chat.completion",
@@ -88,9 +81,82 @@ async def chat_completions(req: ChatRequest):
             }
         ],
         "usage": usage,
-        # Some SDKs look for token_usage; keep it as an alias for convenience.
         "token_usage": usage,
     }
+
+
+def build_chat_stream_chunk(
+    req: ChatRequest,
+    response_id: str,
+    created_ts: int,
+    delta: dict,
+    finish_reason: str | None,
+    usage: dict | None = None,
+) -> str:
+    payload = {
+        "id": response_id,
+        "object": "chat.completion.chunk",
+        "created": created_ts,
+        "model": req.model,
+        "system_fingerprint": "mock-vllm",
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason,
+                "logprobs": None,
+            }
+        ],
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return "data: " + json.dumps(payload, separators=(",", ":")) + "\n\n"
+
+
+def generate_chat_stream(
+    req: ChatRequest, response: dict, content: str, usage: dict, created_ts: int
+):
+    chunk_size = 24
+    response_id = response["id"]
+    for i in range(0, len(content), chunk_size):
+        yield build_chat_stream_chunk(
+            req,
+            response_id,
+            created_ts,
+            {"content": content[i : i + chunk_size]},
+            None,
+        )
+    yield build_chat_stream_chunk(req, response_id, created_ts, {}, "stop", usage)
+    yield "data: [DONE]\n\n"
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/v1/models")
+async def models():
+    return {"data": [{"id": "openai/gpt-oss-20b", "object": "model"}]}
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(req: ChatRequest):
+    created_ts = int(time.time())
+    content = build_chat_content(req)
+    usage = build_chat_usage(req, content)
+    response = build_chat_response(req, content, usage, created_ts)
+    if not req.stream:
+        return response
+
+    return StreamingResponse(
+        generate_chat_stream(req, response, content, usage, created_ts),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix `/v1/responses` `stream:true` so clients receive Responses API SSE instead of raw upstream Chat Completions SSE.

The request filter already translates a Responses API request into a Chat Completions request and injects `stream: true`, but the response-body streaming path previously returned early before the non-streaming Responses API translation pipeline could run. That meant a streaming Responses API request could leak upstream `chat.completion.chunk` frames and `data: [DONE]` directly to the client.

Closes #2446.

Refs #2375.

## Changes

- Detect Responses API requests in the streaming response-body path and translate upstream Chat Completions SSE into Responses API SSE events.
- Emit the Responses API event lifecycle aligned with the official streaming shape:
  - `response.created`
  - `response.in_progress`
  - `response.output_item.added`
  - `response.content_part.added`
  - `response.output_text.delta`
  - `response.output_text.done`
  - `response.content_part.done`
  - `response.output_item.done`
  - `response.completed`
- Buffer split SSE frames before translation so Envoy body chunking cannot leak partial upstream frames.
- Set `text/event-stream; charset=utf-8` and remove `content-length` for translated Responses streams.
- Preserve normal `/v1/chat/completions` `stream:true` behavior.
- Extend `tools/mock-vllm` and the `response-api` E2E profile with a durable streaming repro.

## Compatibility Notes

- This PR only translates `/v1/responses` streaming requests that the router already adapted to upstream Chat Completions.
- Chat Completions streaming responses remain Chat Completions SSE.
- The translated Responses stream intentionally does not include the non-standard `sequence_number` field.

## Validation

- `python3 -m py_compile tools/mock-vllm/app.py`
- `cd e2e && go test ./testcases ./pkg/fixtures ./profiles/response-api`
- `make build-e2e`
- Remote focused repro before the fix on `root@134.199.199.149`:
  - `CGO_ENABLED=1 CGO_LDFLAGS="-L/root/semantic-router-response-api-stream-repro/candle-binding/target/release -L/root/semantic-router-response-api-stream-repro/ml-binding/target/release -L/root/semantic-router-response-api-stream-repro/nlp-binding/target/release" go test ./pkg/extproc -run TestResponseAPIStreamingResponseRequiresResponsesSSE -count=1 -v`
  - failed as expected because the streaming path returned no body mutation.
- Remote focused tests after the fix on `root@134.199.199.149`:
  - `CGO_ENABLED=1 CGO_LDFLAGS="-L/root/semantic-router-response-api-stream-repro/candle-binding/target/release -L/root/semantic-router-response-api-stream-repro/ml-binding/target/release -L/root/semantic-router-response-api-stream-repro/nlp-binding/target/release" go test ./pkg/extproc -run "TestResponseAPIStreamingResponseRequiresResponsesSSE|TestResponseAPIStreamingResponseBuffersSplitChatCompletionSSE|TestParseStreamingChunk|TestReassembleSSEFrames" -count=1 -v`
- Remote container validation on `root@134.199.199.149`:
  - `DOCKER_TAG=codex-response-api-stream CONTAINER_RUNTIME=docker VLLM_SR_SIM_IMAGE=ghcr.io/vllm-project/semantic-router/vllm-sr-sim:codex-response-api-stream make vllm-sr-dev`
  - restarted an isolated `vllm-sr serve` stack with mock-vllm upstream.
  - verified `POST http://localhost:9159/v1/responses` with `stream:true` returns Responses API SSE events, includes output annotations and usage detail maps, and does not contain `chat.completion.chunk`, `data: [DONE]`, or `sequence_number`.
  - verified `POST http://localhost:9159/v1/chat/completions` with `stream:true` still returns Chat Completions chunks and `data: [DONE]`.

## Not Run

- Local `go test ./pkg/extproc` cannot link on this machine because the Darwin CGO/Rust binding artifacts (`candle_semantic_router`, `ml_semantic_router`, `nlp_binding`) are not built locally.
- A local `make e2e-test-specific E2E_PROFILE=response-api E2E_TESTS=response-api-streaming-sse E2E_VERBOSE=true` run created the kind cluster but was blocked before testcase execution by Docker Desktop failing to resolve the configured registry mirror while pulling base images.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Summary, Changes, Validation, and Not Run sections reflect the actual scope, commands, and blockers for this change

</details>

