### PR TITLE
[Docs] Clarify Mixture-of-Models architecture and simplify positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,18 @@
 
 ## About
 
-There is no universally best model. "Best" depends on preference: what each user and product values across quality, cost, latency, safety, privacy, modality, and hallucination tolerance.
+**Mixture-of-Models** is a next-generation model architecture shaped by preference.
 
-We call this next-generation, preference-driven model-system architecture **Mixture-of-Models**. At inference time, it composes the model path each request needs from closed frontier models, open general models, domain experts, and compact edge models. A request may use one model, escalate through a confidence cascade, deliberate with Fusion, or coordinate bounded micro-agent workflows.
+**vLLM Semantic Router** is its open-source runtime.
 
-**vLLM Semantic Router** is the open-source runtime for Mixture-of-Models. Its live request path turns request, response, user, and runtime signals into observable, configurable model-path and policy decisions across configured local, private, and cloud backends.
+| Dimension | Fragmented today | With vLLM SR |
+| --- | --- | --- |
+| **Models** | Closed frontier, open, domain-specialized, and edge models excel at different work. | Route one—or coordinate many. |
+| **Compute** | New and legacy GPUs, accelerators, edge devices, and cloud capacity coexist. | Route across configured model endpoints on heterogeneous compute. |
+| **Location** | Inference spans edge, private data centers, and cloud. | Route across locations within privacy and data boundaries. |
+| **Preference** | "Best" varies by user, product, and workload. | Let preference shape every model path. |
 
-![system](website/static/img/system.png)
-
-Models, compute, and locations define the available supply; preference defines the objective. Together, they shape every mixture:
-
-- **Models — Compose, don't just choose**: select one model, escalate through a confidence cascade, deliberate with Fusion, or coordinate bounded micro-agent workflows.
-- **Compute — Make every token count**: route routine work to efficient paths, reserve cascades and multi-model reasoning for requests that need them, and reuse similar answers with semantic caching.
-- **Location — Run intelligence where it belongs**: route across configured local, private, and cloud backends, keeping privacy-sensitive work on policy-approved paths and reaching cloud models when policy allows.
-- **Preference — Let preference define "best"**: encode priorities for quality, cost, latency, safety, privacy, modality, and hallucination tolerance as explicit signals and policies that shape each route.
-
-Across all four dimensions, configurable request and response controls, response headers, and Router Replay provide safety, governance, and observability.
+[Explore how it works →](https://vllm-semantic-router.com/docs/)
 
 ## Getting Started
 
@@ -45,33 +41,33 @@ curl -fsSL https://vllm-semantic-router.com/install.sh | bash
 
 For platform notes, detailed setup options, and troubleshooting, see the **[Installation Guide](https://vllm-semantic-router.com/docs/installation/)**.
 
-> [!IMPORTANT]
-> Online [playground](https://play.vllm-semantic-router.com) default credentials:
->
-> <!-- markdownlint-disable MD004 MD032 -->
-> + username: `love@vllm-sr.ai`
-> + password: `vllm-sr`
-> <!-- markdownlint-enable MD004 MD032 -->
+<details>
+<summary>Online playground credentials</summary>
+
+- Username: `love@vllm-sr.ai`
+- Password: `vllm-sr`
+
+</details>
 
 ## Latest News
 
 - [2026/06/29] New Blog: [Micro-Agent: Beat Frontier Models with Collaboration inside Model API](https://vllm.ai/blog/2026-06-29-micro-agent-frontier-models)
 - [2026/06/16] New Blog: [Beyond One Model: Fusion in vLLM Semantic Router](https://vllm.ai/blog/2026-06-16-vllm-sr-fusion-api)
 - [2026/06/05] v0.3 Released: [vLLM Semantic Router v0.3 Themis: From Signals to Stateful Production Routing](https://vllm.ai/blog/2026-06-05-v0.3-vllm-sr-themis-release)
+
+<details>
+<summary>Earlier announcements</summary>
+
 - [2026/03/24] Vision Paper Released: [The Workload-Router-Pool Architecture for LLM Inference Optimization](https://vllm-semantic-router.com/vision-paper)
 - [2026/03/10] v0.2 Released: [vLLM Semantic Router v0.2 Athena Release](https://vllm.ai/blog/v0.2-vllm-sr-athena-release)
 - [2026/02/27] White Paper Released: [Signal Driven Decision Routing for Mixture-of-Modality Models](https://vllm-semantic-router.com/white-paper/)
 - [2026/01/05] Iris v0.1 Released: [vLLM Semantic Router v0.1 Iris: The First Major Release](https://blog.vllm.ai/2026/01/05/vllm-sr-iris.html)
 - [2025/12/16] Collaboration: [AMD × vLLM Semantic Router: Building the System Intelligence Together](https://blog.vllm.ai/2025/12/16/vllm-sr-amd.html)
+- [2025/12/15] New Blog: [Token-Level Truth: Real-Time Hallucination Detection for Production LLMs](https://blog.vllm.ai/2025/12/14/halugate.html)
 - [2025/11/19] New Blog: [Signal-Decision Driven Architecture: Reshaping Semantic Routing at Scale](https://blog.vllm.ai/2025/11/19/signal-decision.html)
 - [2025/11/03] Paper Published: [Category-Aware Semantic Caching for Heterogeneous LLM Workloads](https://arxiv.org/abs/2510.26835)
-- [2025/10/12] Paper Accepted: [When to Reason: Semantic Router for vLLM](https://arxiv.org/abs/2510.08731)
-
-<details>
-<summary>Earlier announcements</summary>
-
-- [2025/12/15] New Blog: [Token-Level Truth: Real-Time Hallucination Detection for Production LLMs](https://blog.vllm.ai/2025/12/14/halugate.html)
 - [2025/10/27] New Blog: [Scaling Semantic Routing with Extensible LoRA](https://blog.vllm.ai/2025/10/27/semantic-router-modular.html)
+- [2025/10/12] Paper Accepted: [When to Reason: Semantic Router for vLLM](https://arxiv.org/abs/2510.08731)
 - [2025/10/08] Collaboration: vLLM Semantic Router with [vLLM Production Stack](https://github.com/vllm-project/production-stack) Team.
 - [2025/09/01] Released the project: [vLLM Semantic Router: Next Phase in LLM inference](https://blog.vllm.ai/2025/09/11/semantic-router.html).
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -8,7 +8,7 @@ import rehypeKatex from 'rehype-katex'
 const lightCodeTheme = themes.github
 const darkCodeTheme = themes.vsDark
 const siteUrl = 'https://vllm-semantic-router.com'
-const siteDefaultDescription = 'Open-source runtime for Mixture-of-Models, a preference-driven model-system architecture that selects, cascades, and coordinates models for each request.'
+const siteDefaultDescription = 'Mixture-of-Models is a next-generation model architecture shaped by preference. vLLM Semantic Router is its open-source runtime.'
 const siteSocialTitle = 'vLLM Semantic Router | Runtime for Mixture-of-Models'
 const siteSocialPreviewImageUrl = `${siteUrl}/${SITE_SOCIAL_PREVIEW_IMAGE}`
 

--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -375,7 +375,7 @@
     "message": "vLLM Semantic Router 标志"
   },
   "homepage.hero.label": {
-    "message": "Mixture-of-Models 开源运行时"
+    "message": "Mixture-of-Models"
   },
   "homepage.hero.line1": {
     "message": "智能，"
@@ -384,22 +384,19 @@
     "message": "因你而组合。"
   },
   "homepage.hero.description": {
-    "message": "没有一个模型对所有人都是最好的。vLLM Semantic Router 依据通过可配置信号与策略表达的用户偏好，为每个请求选择、级联或协作编排模型。"
+    "message": "单个模型或多模型协作，跨算力与位置，按你的偏好组合。"
   },
   "homepage.hero.primaryCta": {
-    "message": "试用演示"
+    "message": "体验 Playground"
   },
   "homepage.hero.manifesto": {
     "message": "先把请求看明白，再把系统做大；以信号驱动，以不确定性为标尺，让决策足够清晰。"
   },
   "homepage.hero.secondaryCta": {
-    "message": "阅读白皮书"
+    "message": "浏览文档"
   },
   "homepage.hero.modelBand.eyebrow": {
     "message": "Mixture-of-Models"
-  },
-  "homepage.hero.modelBand.copy": {
-    "message": "你的偏好，决定模型如何组合"
   },
   "homepage.hero.modelBand.aria": {
     "message": "Mixture-of-Models 模型生态"
@@ -426,10 +423,7 @@
     "message": "为什么需要 Mixture-of-Models"
   },
   "homepage.capabilities.heading": {
-    "message": "供给是碎片化的，“最好”因人而异。"
-  },
-  "homepage.capabilities.copy": {
-    "message": "模型、算力和部署位置持续分化；偏好决定对每个用户和工作负载而言，什么才算“好”。Mixture-of-Models 将碎片化供给组合为与偏好一致的智能。"
+    "message": "碎片化是现实，偏好决定组合。"
   },
   "homepage.capabilities.axis.models": {
     "message": "模型"
@@ -443,74 +437,41 @@
   "homepage.capabilities.axis.preference": {
     "message": "偏好"
   },
-  "homepage.capabilities.checklist.label": {
-    "message": "开源运行时"
+  "homepage.capabilities.table.dimension": {
+    "message": "维度"
   },
-  "homepage.capabilities.checklist.copy": {
-    "message": "vLLM Semantic Router 让 Mixture-of-Models 在在线请求链路中真正运行起来。"
+  "homepage.capabilities.table.reality": {
+    "message": "碎片化现状"
   },
-  "homepage.capabilities.task.extract": {
-    "message": "读取任务、上下文、安全、偏好和运行时信号。"
+  "homepage.capabilities.table.value": {
+    "message": "使用 vLLM SR"
   },
-  "homepage.capabilities.task.compose": {
-    "message": "选择单个模型、沿置信度级联升级，或协调多个模型。"
+  "homepage.capabilities.models.reality": {
+    "message": "闭源前沿、开源通用、领域与端侧模型各有所长。"
   },
-  "homepage.capabilities.task.apply": {
-    "message": "应用可配置的请求与响应控制，并公开结果供检查。"
+  "homepage.capabilities.models.value": {
+    "message": "路由单一模型，或协同多个模型。"
   },
-  "homepage.capabilities.checklist.footer": {
-    "message": "偏好定义目标，Mixture-of-Models 定义架构，vLLM Semantic Router 负责运行它。"
+  "homepage.capabilities.compute.reality": {
+    "message": "新旧 GPU、专用加速器、端侧设备与云端算力长期共存。"
   },
-  "homepage.capabilities.meta.signals": {
-    "message": "信号"
+  "homepage.capabilities.compute.value": {
+    "message": "在异构算力承载的已配置模型端点之间路由。"
   },
-  "homepage.capabilities.meta.preferences": {
-    "message": "偏好"
+  "homepage.capabilities.location.reality": {
+    "message": "推理分布在端侧、私有数据中心与云端。"
   },
-  "homepage.capabilities.meta.modelPaths": {
-    "message": "模型路径"
+  "homepage.capabilities.location.value": {
+    "message": "在隐私与数据边界内跨位置路由。"
   },
-  "homepage.capabilities.values.label": {
-    "message": "什么决定模型组合"
+  "homepage.capabilities.preference.reality": {
+    "message": "不同用户、产品与工作负载对“最好”的定义不同。"
   },
-  "homepage.capabilities.values.copy": {
-    "message": "模型、算力和部署位置决定有哪些可用资源；偏好决定最佳组合。"
+  "homepage.capabilities.preference.value": {
+    "message": "让偏好决定每条模型路径。"
   },
-  "homepage.capabilities.value1.title": {
-    "message": "组合，而不只是选择。"
-  },
-  "homepage.capabilities.value1.text": {
-    "message": "选择单个模型、按置信度逐级升级、通过 Fusion 进行多模型研判，或编排有边界的微智能体工作流。"
-  },
-  "homepage.capabilities.value1.detail": {
-    "message": "让每个请求采用它真正需要的模型路径。"
-  },
-  "homepage.capabilities.value2.title": {
-    "message": "让每个 token 都物有所值。"
-  },
-  "homepage.capabilities.value2.text": {
-    "message": "将常规任务路由到高效模型路径，仅为真正需要的请求启用级联与多模型推理，并通过语义缓存复用相似回答。"
-  },
-  "homepage.capabilities.value2.detail": {
-    "message": "只有更多智能能带来价值时，才投入更多计算。"
-  },
-  "homepage.capabilities.value3.title": {
-    "message": "让智能在合适的位置运行。"
-  },
-  "homepage.capabilities.value3.text": {
-    "message": "在已配置的本地、私有和云端后端之间路由，让隐私敏感任务留在策略批准的路径上，并在策略允许时使用云端模型。"
-  },
-  "homepage.capabilities.value3.detail": {
-    "message": "用一套路由策略连接已配置的模型端点。"
-  },
-  "homepage.capabilities.value4.title": {
-    "message": "让偏好定义“最好”。"
-  },
-  "homepage.capabilities.value4.text": {
-    "message": "将质量、成本、时延、安全、隐私、模态和幻觉容忍度等优先级编码为显式信号与策略，塑造每条请求路径。"
-  },
-  "homepage.capabilities.value4.detail": {
-    "message": "最好的组合，就是最符合用户需求的组合。"
+  "homepage.capabilities.docsCta": {
+    "message": "了解工作原理"
   },
   "homepage.capabilities.signal.title": {
     "message": "信号提取"
@@ -2432,7 +2393,7 @@
     "message": "用于 LLM 推理优化的 Workload-Router-Pool 架构，以 vLLM Semantic Router 愿景论文的完整 PDF 阅读器形式呈现。"
   },
   "homepage.meta.description": {
-    "message": "Mixture-of-Models 是偏好驱动的模型系统架构。vLLM Semantic Router 是其开源运行时，依据偏好与策略为每个请求选择、级联和协作编排模型。"
+    "message": "Mixture-of-Models 是下一代偏好驱动的模型架构。vLLM Semantic Router 是其开源运行时。"
   },
   "homepage.meta.title": {
     "message": "Mixture-of-Models 的开源运行时"

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -255,16 +255,6 @@
   text-transform: uppercase;
 }
 
-.heroModelBandCopy {
-  max-width: 30rem;
-  margin: 0;
-  color: var(--site-text-strong);
-  font-size: clamp(1.08rem, 1.35vw, 1.24rem);
-  font-weight: 550;
-  line-height: 1.42;
-  letter-spacing: -0.02em;
-}
-
 .heroModelBandViewport {
   --hero-model-gap: 1.55rem;
   position: relative;
@@ -470,371 +460,100 @@
   gap: 1.15rem;
 }
 
-.problemPanel {
-  display: grid;
-  grid-template-columns: minmax(0, 0.64fr) minmax(280px, 0.36fr);
-  align-items: stretch;
-  gap: 1rem;
-}
-
-.problemIntro,
-.problemChecklist,
-.valueCard {
-  border: 1px solid var(--site-border);
-  background: var(--site-surface);
-}
-
-.problemIntro {
-  padding: 1.8rem;
-  border-radius: 1.45rem;
-  border-color: rgba(15, 23, 42, 0.14);
-  background:
-    radial-gradient(circle at 0% 0%, rgba(15, 23, 42, 0.055), transparent 36%),
-    linear-gradient(180deg, rgba(15, 23, 42, 0.024), transparent 44%),
-    var(--site-surface);
-}
-
-.problemIntro h2 {
-  max-width: 10ch;
-  margin: 0.8rem 0 0;
-  font-size: clamp(2.6rem, 5vw, 4.5rem);
-  line-height: 0.92;
-}
-
-.problemIntro p {
-  max-width: 42rem;
-  margin: 1rem 0 0;
-  font-size: 1.03rem;
-  line-height: 1.7;
-  color: var(--site-muted-bright);
-}
-
-.problemAxes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.68rem;
-  margin-top: 1.4rem;
-}
-
-.problemAxis {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.46rem 0.8rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.04);
-  color: var(--site-muted-bright);
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.problemAxis:last-child {
-  border-color: rgba(48, 162, 255, 0.28);
-  background: rgba(48, 162, 255, 0.08);
-  color: #167fce;
-}
-
-.problemChecklist {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  height: 100%;
-  padding: 1.6rem;
-  border-radius: 1.45rem;
-  border-color: rgba(15, 23, 42, 0.14);
-  background:
-    linear-gradient(180deg, rgba(15, 23, 42, 0.03), rgba(15, 23, 42, 0.012)),
-    var(--site-surface-alt);
-}
-
-.problemChecklistHeader {
-  display: grid;
-  gap: 0.7rem;
-}
-
-.problemChecklistHeader p {
-  margin: 0;
-  color: var(--site-muted-bright);
-  font-size: 0.92rem;
-  line-height: 1.6;
-}
-
-.problemChecklistList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.72rem;
-  counter-reset: system-job;
-}
-
-.problemChecklistItem {
-  position: relative;
-  min-height: 4.15rem;
-  display: flex;
-  align-items: center;
-  padding: 0.9rem 0.95rem 0.9rem 3.05rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  border-radius: 1rem;
-  background:
-    linear-gradient(180deg, rgba(15, 23, 42, 0.018), transparent 100%),
-    rgba(255, 255, 255, 0.82);
-  color: var(--site-muted-bright);
-  font-size: 0.95rem;
-  line-height: 1.55;
-}
-
-.problemChecklistItem::before {
-  counter-increment: system-job;
-  content: '0' counter(system-job);
-  position: absolute;
-  left: 0.95rem;
-  top: 0.9rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background: rgba(15, 23, 42, 0.05);
-  color: var(--site-muted-bright);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-}
-
-.problemChecklistFooter {
-  display: grid;
-  gap: 0.85rem;
-  margin-top: auto;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(15, 23, 42, 0.1);
-}
-
-.problemChecklistFooter p {
-  max-width: 18rem;
-  margin: 0;
-  color: var(--site-muted);
-  font-size: 0.82rem;
-  line-height: 1.55;
-}
-
-.problemChecklistMeta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-.problemChecklistMetaItem {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.42rem 0.72rem;
-  border: 1px solid rgba(15, 23, 42, 0.11);
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.04);
-  color: var(--site-muted-bright);
-  font-size: 0.74rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.valueIntro {
+.comparisonHeading {
   display: grid;
   grid-template-columns: minmax(220px, 0.32fr) minmax(0, 0.68fr);
-  gap: 2rem;
   align-items: end;
-  margin-top: 0.2rem;
+  gap: 2rem;
+  margin-bottom: 0.35rem;
 }
 
-.valueIntro p {
-  max-width: 34rem;
+.comparisonHeading h2 {
+  max-width: 17ch;
   margin: 0;
+  font-size: clamp(2.4rem, 5vw, 4.35rem);
+  line-height: 0.96;
+}
+
+.comparisonTableWrap {
+  overflow-x: auto;
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  border-radius: 1.45rem;
+  background: var(--site-surface);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.055);
+}
+
+.comparisonTable {
+  display: table;
+  width: 100%;
+  margin: 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.comparisonTable th,
+.comparisonTable td {
+  padding: 1.35rem 1.45rem;
+  border: 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+  text-align: left;
+  vertical-align: top;
+}
+
+.comparisonTable thead th {
+  background: rgba(15, 23, 42, 0.035);
   color: var(--site-muted-bright);
-}
-
-.valueGrid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1.1rem;
-}
-
-.valueCard {
-  position: relative;
-  overflow: hidden;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  gap: 1rem;
-  min-height: 18rem;
-  padding: 1.45rem;
-  border-radius: 1.3rem;
-  background:
-    radial-gradient(circle at 100% 0%, rgba(255, 255, 255, 0.04), transparent 34%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 36%),
-    var(--site-surface);
-  transition:
-    border-color 180ms ease,
-    transform 180ms ease,
-    background 180ms ease;
-}
-
-.valueCardHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.valueCardIndex {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--site-muted);
   font-family: var(--ifm-font-family-monospace);
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
-}
-
-.valueGlyphShell {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 6.8rem;
-  min-height: 4.4rem;
-  padding: 0.72rem 0.85rem;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 1rem;
-  background:
-    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.04), transparent 58%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.008)),
-    rgba(255, 255, 255, 0.02);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.valueGlyph {
-  width: 5.2rem;
-  height: auto;
-  color: rgba(17, 17, 17, 0.46);
-  opacity: 0.96;
-  transition:
-    transform 180ms ease,
-    color 180ms ease,
-    opacity 180ms ease;
-}
-
-.valueCardCopy {
-  display: grid;
-  gap: 0.8rem;
-}
-
-.valueCardAxis {
-  color: var(--site-muted);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.72rem;
-  font-weight: 650;
-  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.11em;
   text-transform: uppercase;
 }
 
-.valueCardCopy h3 {
-  margin: 0;
-  font-size: 1.35rem;
-  line-height: 1.05;
+.comparisonTable thead th:first-child {
+  width: 18%;
 }
 
-.valueCardCopy p {
-  margin: 0;
+.comparisonTable thead th:nth-child(2),
+.comparisonTable thead th:nth-child(3) {
+  width: 41%;
+}
+
+.comparisonTable tbody th {
+  color: var(--site-text-strong);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.comparisonTable tbody td {
   color: var(--site-muted-bright);
-  font-size: 0.98rem;
-  line-height: 1.68;
+  font-size: 1rem;
+  line-height: 1.58;
 }
 
-.valueCardDetail {
-  margin: 0;
-  padding-top: 0.9rem;
-  border-top: 1px solid rgba(17, 17, 17, 0.08);
-  color: var(--site-muted);
-  font-size: 0.77rem;
+.comparisonTable tbody tr:last-child > * {
+  border-bottom: 0;
+}
+
+.comparisonTable tbody tr:last-child {
+  background: linear-gradient(90deg, rgba(48, 162, 255, 0.025), rgba(48, 162, 255, 0.08));
+}
+
+.comparisonTable tbody tr:last-child .comparisonDimension {
+  color: #167fce;
+}
+
+.comparisonTable tbody .comparisonValue {
+  background: rgba(48, 162, 255, 0.035);
+  color: var(--site-text-strong);
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
-.valueCard:hover {
-  transform: translateY(-3px);
-  border-color: var(--site-border-strong);
-  background:
-    radial-gradient(circle at 100% 0%, rgba(255, 255, 255, 0.05), transparent 34%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 36%),
-    var(--site-surface-alt);
-}
-
-.valueCard:hover .valueGlyphShell {
-  border-color: rgba(17, 17, 17, 0.12);
-  background:
-    radial-gradient(circle at 50% 50%, rgba(17, 17, 17, 0.05), transparent 58%),
-    linear-gradient(135deg, rgba(17, 17, 17, 0.026), rgba(17, 17, 17, 0.01)),
-    rgba(17, 17, 17, 0.028);
-}
-
-.valueCard:hover .valueGlyph {
-  transform: translateY(-2px) scale(1.02);
-  color: rgba(17, 17, 17, 0.72);
-}
-
-.valueCardPreference {
-  border-color: rgba(48, 162, 255, 0.34);
-  background:
-    radial-gradient(circle at 100% 0%, rgba(48, 162, 255, 0.12), transparent 38%),
-    linear-gradient(180deg, rgba(48, 162, 255, 0.045), transparent 42%),
-    var(--site-surface);
-}
-
-.valueCardPreference::before {
-  position: absolute;
-  inset: 0 0 auto;
-  height: 3px;
-  background: linear-gradient(90deg, #30A2FF, rgba(48, 162, 255, 0.18));
-  content: '';
-}
-
-.valueCardPreference .valueCardIndex {
-  border-color: rgba(48, 162, 255, 0.25);
-  background: rgba(48, 162, 255, 0.09);
-  color: #167fce;
-}
-
-.valueCardPreference .valueCardAxis {
-  color: #167fce;
-}
-
-.valueCardPreference .valueGlyphShell {
-  border-color: rgba(48, 162, 255, 0.2);
-  background:
-    radial-gradient(circle at 50% 50%, rgba(48, 162, 255, 0.1), transparent 60%),
-    rgba(48, 162, 255, 0.035);
-}
-
-.valueCardPreference .valueGlyph {
-  color: rgba(22, 127, 206, 0.7);
-}
-
-.valueCardPreference:hover {
-  border-color: rgba(48, 162, 255, 0.52);
-  background:
-    radial-gradient(circle at 100% 0%, rgba(48, 162, 255, 0.16), transparent 40%),
-    linear-gradient(180deg, rgba(48, 162, 255, 0.06), transparent 44%),
-    var(--site-surface-alt);
-}
-
-.valueCardPreference:hover .valueGlyph {
-  color: rgba(22, 127, 206, 0.9);
+.comparisonCta {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.25rem;
 }
 
 .encoderShowcase {
@@ -1037,19 +756,12 @@
   margin: 0;
 }
 
-@media (max-width: 1180px) {
-  .valueGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 996px) {
   .heroGrid,
   .sectionHeading,
   .encoderShowcase,
   .bandGrid,
-  .problemPanel,
-  .valueIntro {
+  .comparisonHeading {
     grid-template-columns: 1fr;
   }
 
@@ -1062,12 +774,8 @@
     padding: 3rem 0 2rem;
   }
 
-  .problemIntro h2 {
-    max-width: 12ch;
-  }
-
-  .valueGlyph {
-    width: 5rem;
+  .comparisonHeading h2 {
+    max-width: 18ch;
   }
 
   .encoderLeadStack {
@@ -1135,14 +843,8 @@
   }
 
   .heroModelBandHeader {
-    margin-bottom: 0.38rem;
+    margin-bottom: 0.1rem;
     padding: 0 1rem;
-  }
-
-  .heroModelBandCopy {
-    max-width: 20rem;
-    font-size: 0.94rem;
-    line-height: 1.5;
   }
 
   .heroModelBandViewport {
@@ -1181,6 +883,27 @@
     padding: 3.5rem 0;
   }
 
+  .comparisonTable th,
+  .comparisonTable td {
+    padding: 0.88rem 0.72rem;
+    overflow-wrap: anywhere;
+  }
+
+  .comparisonTable thead th:first-child {
+    width: 22%;
+  }
+
+  .comparisonTable thead th:nth-child(2),
+  .comparisonTable thead th:nth-child(3) {
+    width: 39%;
+  }
+
+  .comparisonTable tbody th,
+  .comparisonTable tbody td {
+    font-size: 0.86rem;
+    line-height: 1.48;
+  }
+
   .encoderCardGrid {
     grid-template-columns: 1fr;
   }
@@ -1191,19 +914,7 @@
     grid-template-columns: 1fr;
   }
 
-  .problemChecklistItem {
-    min-height: auto;
-    padding-left: 3rem;
-  }
-
-  .valueCard {
-    min-height: auto;
-  }
-
   .band,
-  .problemIntro,
-  .problemChecklist,
-  .valueCard,
   .encoderLead,
   .encoderPipelineFrame,
   .encoderCard {
@@ -1212,7 +923,27 @@
 }
 
 @media (max-width: 640px) {
-  .valueGrid {
-    grid-template-columns: 1fr;
+  .comparisonHeading h2 {
+    font-size: clamp(2.05rem, 10vw, 2.65rem);
+  }
+
+  .comparisonTable th,
+  .comparisonTable td {
+    padding: 0.72rem 0.5rem;
+  }
+
+  .comparisonTable thead th {
+    font-size: 0.6rem;
+    letter-spacing: 0.06em;
+  }
+
+  .comparisonTable tbody th,
+  .comparisonTable tbody td {
+    font-size: 0.78rem;
+  }
+
+  .comparisonCta,
+  .comparisonCta :global(a) {
+    width: 100%;
   }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -23,7 +23,6 @@ import TeamCarousel from '@site/src/components/TeamCarousel'
 import { researchPapers } from '@site/src/data/researchContent'
 import { SITE_SOCIAL_PREVIEW_IMAGE_PATH } from '@site/src/data/socialPreview'
 import TransformerPipelineAnimation from '@site/src/components/TransformerPipelineAnimation'
-import CapabilityGlyph, { type CapabilityGlyphKind } from '@site/src/components/site/CapabilityGlyph'
 import DitherField from '@site/src/components/site/DitherField'
 import { PageIntro, PillLink, SectionLabel, StatStrip } from '@site/src/components/site/Chrome'
 import styles from './index.module.css'
@@ -35,7 +34,7 @@ const homepageMetaTitle = translate({
 })
 const homepageMetaDescription = translate({
   id: 'homepage.meta.description',
-  message: 'Open-source runtime for Mixture-of-Models, a preference-driven model-system architecture that selects, cascades, and coordinates models for each request.',
+  message: 'Mixture-of-Models is a next-generation model architecture shaped by preference. vLLM Semantic Router is its open-source runtime.',
 })
 const homepageSocialTitle = translate({
   id: 'homepage.meta.socialTitle',
@@ -91,100 +90,66 @@ const heroStats = [
   },
 ]
 
-interface ValueCard {
-  axis: string
-  detail: string
-  emphasis?: boolean
-  index: string
-  kind: CapabilityGlyphKind
-  text: string
-  title: string
+interface FragmentationRow {
+  dimension: string
+  id: 'models' | 'compute' | 'location' | 'preference'
+  reality: string
+  value: string
 }
 
-const mixtureDimensions = {
-  models: translate({ id: 'homepage.capabilities.axis.models', message: 'Models' }),
-  compute: translate({ id: 'homepage.capabilities.axis.compute', message: 'Compute' }),
-  location: translate({ id: 'homepage.capabilities.axis.location', message: 'Location' }),
-  preference: translate({ id: 'homepage.capabilities.axis.preference', message: 'Preference' }),
+const comparisonHeaders = {
+  dimension: translate({ id: 'homepage.capabilities.table.dimension', message: 'Dimension' }),
+  reality: translate({ id: 'homepage.capabilities.table.reality', message: 'Fragmented today' }),
+  value: translate({ id: 'homepage.capabilities.table.value', message: 'With vLLM SR' }),
 }
 
-const runtimeTasks = [
-  translate({
-    id: 'homepage.capabilities.task.extract',
-    message: 'Read task, context, safety, preference, and runtime signals.',
-  }),
-  translate({
-    id: 'homepage.capabilities.task.compose',
-    message: 'Select one model, escalate through a confidence cascade, or coordinate multiple models.',
-  }),
-  translate({
-    id: 'homepage.capabilities.task.apply',
-    message: 'Apply configurable request and response controls, then expose the outcome for inspection.',
-  }),
-]
-
-const runtimeInputs = [
-  translate({ id: 'homepage.capabilities.meta.signals', message: 'Signals' }),
-  translate({ id: 'homepage.capabilities.meta.preferences', message: 'Preferences' }),
-  translate({ id: 'homepage.capabilities.meta.modelPaths', message: 'Model paths' }),
-]
-
-const valueCards: ValueCard[] = [
+const fragmentationRows: FragmentationRow[] = [
   {
-    index: '01',
-    axis: mixtureDimensions.models,
-    kind: 'selection',
-    title: translate({ id: 'homepage.capabilities.value1.title', message: 'Compose, don’t just choose.' }),
-    text: translate({
-      id: 'homepage.capabilities.value1.text',
-      message: 'Select a single model, escalate through a confidence cascade, deliberate with Fusion, or coordinate bounded micro-agent workflows.',
+    dimension: translate({ id: 'homepage.capabilities.axis.models', message: 'Models' }),
+    id: 'models',
+    reality: translate({
+      id: 'homepage.capabilities.models.reality',
+      message: 'Closed frontier, open, domain-specialized, and edge models excel at different work.',
     }),
-    detail: translate({
-      id: 'homepage.capabilities.value1.detail',
-      message: 'Use the model path the request needs.',
+    value: translate({
+      id: 'homepage.capabilities.models.value',
+      message: 'Route one—or coordinate many.',
     }),
   },
   {
-    index: '02',
-    axis: mixtureDimensions.compute,
-    kind: 'economics',
-    title: translate({ id: 'homepage.capabilities.value2.title', message: 'Make every token count.' }),
-    text: translate({
-      id: 'homepage.capabilities.value2.text',
-      message: 'Route routine work to efficient model paths, reserve cascades and multi-model reasoning for requests that need them, and reuse similar answers with semantic caching.',
+    dimension: translate({ id: 'homepage.capabilities.axis.compute', message: 'Compute' }),
+    id: 'compute',
+    reality: translate({
+      id: 'homepage.capabilities.compute.reality',
+      message: 'New and legacy GPUs, accelerators, edge devices, and cloud capacity coexist.',
     }),
-    detail: translate({
-      id: 'homepage.capabilities.value2.detail',
-      message: 'Spend more only when more intelligence adds value.',
+    value: translate({
+      id: 'homepage.capabilities.compute.value',
+      message: 'Route across configured model endpoints on heterogeneous compute.',
     }),
   },
   {
-    index: '03',
-    axis: mixtureDimensions.location,
-    kind: 'mesh',
-    title: translate({ id: 'homepage.capabilities.value3.title', message: 'Run intelligence where it belongs.' }),
-    text: translate({
-      id: 'homepage.capabilities.value3.text',
-      message: 'Route across configured local, private, and cloud backends, keeping privacy-sensitive work on policy-approved paths and reaching cloud models when policy allows.',
+    dimension: translate({ id: 'homepage.capabilities.axis.location', message: 'Location' }),
+    id: 'location',
+    reality: translate({
+      id: 'homepage.capabilities.location.reality',
+      message: 'Inference spans edge, private data centers, and cloud.',
     }),
-    detail: translate({
-      id: 'homepage.capabilities.value3.detail',
-      message: 'One routing policy across configured endpoints.',
+    value: translate({
+      id: 'homepage.capabilities.location.value',
+      message: 'Route across locations within privacy and data boundaries.',
     }),
   },
   {
-    index: '04',
-    axis: mixtureDimensions.preference,
-    emphasis: true,
-    kind: 'decision',
-    title: translate({ id: 'homepage.capabilities.value4.title', message: 'Let preference define “best.”' }),
-    text: translate({
-      id: 'homepage.capabilities.value4.text',
-      message: 'Encode priorities for quality, cost, latency, safety, privacy, modality, and hallucination tolerance as explicit signals and policies that shape each route.',
+    dimension: translate({ id: 'homepage.capabilities.axis.preference', message: 'Preference' }),
+    id: 'preference',
+    reality: translate({
+      id: 'homepage.capabilities.preference.reality',
+      message: '“Best” varies by user, product, and workload.',
     }),
-    detail: translate({
-      id: 'homepage.capabilities.value4.detail',
-      message: 'The best mixture is the one aligned with the user.',
+    value: translate({
+      id: 'homepage.capabilities.preference.value',
+      message: 'Let preference shape every model path.',
     }),
   },
 ]
@@ -302,7 +267,7 @@ function DitherHero(): JSX.Element {
               <PageIntro
                 align="center"
                 className={styles.heroIntroPanel}
-                label={<Translate id="homepage.hero.label">The open-source runtime for Mixture-of-Models</Translate>}
+                label={<Translate id="homepage.hero.label">Mixture-of-Models</Translate>}
                 title={(
                   <span className={styles.heroTitle}>
                     <span className={`${styles.heroTitleLine} ${styles.heroTitleAccent}`}>
@@ -316,9 +281,7 @@ function DitherHero(): JSX.Element {
                 description={(
                   <span className={styles.heroDescriptionText}>
                     <Translate id="homepage.hero.description">
-                      No model is best for everyone. vLLM Semantic Router selects, escalates, and
-                      coordinates models for each request—guided by user preference
-                      expressed through configurable signals and policy.
+                      One model or many, across compute and locations—shaped by your priorities.
                     </Translate>
                   </span>
                 )}
@@ -330,10 +293,10 @@ function DitherHero(): JSX.Element {
                       rel="noreferrer"
                       target="_blank"
                     >
-                      <Translate id="homepage.hero.primaryCta">Public Beta</Translate>
+                      <Translate id="homepage.hero.primaryCta">Try the Playground</Translate>
                     </PillLink>
-                    <PillLink className={styles.heroSecondaryCta} to="/white-paper" muted>
-                      <Translate id="homepage.hero.secondaryCta">Read white paper</Translate>
+                    <PillLink className={styles.heroSecondaryCta} to="/docs/intro" muted>
+                      <Translate id="homepage.hero.secondaryCta">Explore the Docs</Translate>
                     </PillLink>
                   </>
                 )}
@@ -355,11 +318,6 @@ function DitherHero(): JSX.Element {
             <span className={styles.heroModelBandEyebrow}>
               <Translate id="homepage.hero.modelBand.eyebrow">Mixture-of-Models</Translate>
             </span>
-            <p className={styles.heroModelBandCopy}>
-              <Translate id="homepage.hero.modelBand.copy">
-                Your preference shapes the mixture
-              </Translate>
-            </p>
           </div>
 
           <div className={styles.heroModelBandViewport} aria-hidden="true">
@@ -394,100 +352,42 @@ function CapabilitySection(): JSX.Element {
     <section className={styles.capabilitySection}>
       <div className="site-shell-container">
         <div className={styles.capabilityFrame}>
-          <div className={styles.problemPanel}>
-            <div className={styles.problemIntro}>
-              <SectionLabel>
-                <Translate id="homepage.capabilities.label">Why Mixture-of-Models</Translate>
-              </SectionLabel>
-              <h2>
-                <Translate id="homepage.capabilities.heading">
-                  The supply is fragmented. “Best” is personal.
-                </Translate>
-              </h2>
-              <p>
-                <Translate id="homepage.capabilities.copy">
-                  Models, compute, and locations keep diversifying. Preference defines what “best”
-                  means for each user and workload. Mixture-of-Models turns fragmented supply into
-                  preference-aligned intelligence.
-                </Translate>
-              </p>
-              <div className={styles.problemAxes}>
-                {Object.values(mixtureDimensions).map(axis => (
-                  <span key={axis} className={styles.problemAxis}>
-                    {axis}
-                  </span>
-                ))}
-              </div>
-            </div>
-
-            <aside className={styles.problemChecklist}>
-              <div className={styles.problemChecklistHeader}>
-                <SectionLabel>
-                  <Translate id="homepage.capabilities.checklist.label">The open-source runtime</Translate>
-                </SectionLabel>
-                <p>
-                  <Translate id="homepage.capabilities.checklist.copy">
-                    vLLM Semantic Router makes Mixture-of-Models executable in the live request path.
-                  </Translate>
-                </p>
-              </div>
-              <ul className={styles.problemChecklistList}>
-                {runtimeTasks.map(task => (
-                  <li key={task} className={styles.problemChecklistItem}>
-                    {task}
-                  </li>
-                ))}
-              </ul>
-              <div className={styles.problemChecklistFooter}>
-                <p>
-                  <Translate id="homepage.capabilities.checklist.footer">
-                    Preference defines the goal. Mixture-of-Models defines the architecture. vLLM
-                    Semantic Router runs it.
-                  </Translate>
-                </p>
-                <div className={styles.problemChecklistMeta}>
-                  {runtimeInputs.map(item => (
-                    <span key={item} className={styles.problemChecklistMetaItem}>
-                      {item}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            </aside>
-          </div>
-
-          <div className={styles.valueIntro}>
+          <div className={styles.comparisonHeading}>
             <SectionLabel>
-              <Translate id="homepage.capabilities.values.label">What shapes the mixture</Translate>
+              <Translate id="homepage.capabilities.label">Why Mixture-of-Models</Translate>
             </SectionLabel>
-            <p>
-              <Translate id="homepage.capabilities.values.copy">
-                Models, compute, and locations define what is available. Preference defines the
-                right mixture.
+            <h2 id="fragmentation-comparison-title">
+              <Translate id="homepage.capabilities.heading">
+                Fragmented by nature. Composed by preference.
               </Translate>
-            </p>
+            </h2>
           </div>
 
-          <div className={styles.valueGrid}>
-            {valueCards.map(card => (
-              <article
-                key={card.axis}
-                className={`${styles.valueCard}${card.emphasis ? ` ${styles.valueCardPreference}` : ''}`}
-              >
-                <div className={styles.valueCardHeader}>
-                  <span className={styles.valueCardIndex}>{card.index}</span>
-                  <div className={styles.valueGlyphShell}>
-                    <CapabilityGlyph kind={card.kind} className={styles.valueGlyph} />
-                  </div>
-                </div>
-                <div className={styles.valueCardCopy}>
-                  <span className={styles.valueCardAxis}>{card.axis}</span>
-                  <h3>{card.title}</h3>
-                  <p>{card.text}</p>
-                </div>
-                <p className={styles.valueCardDetail}>{card.detail}</p>
-              </article>
-            ))}
+          <div className={styles.comparisonTableWrap}>
+            <table className={styles.comparisonTable} aria-labelledby="fragmentation-comparison-title">
+              <thead>
+                <tr>
+                  <th scope="col">{comparisonHeaders.dimension}</th>
+                  <th scope="col">{comparisonHeaders.reality}</th>
+                  <th scope="col">{comparisonHeaders.value}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fragmentationRows.map(row => (
+                  <tr key={row.id}>
+                    <th scope="row" className={styles.comparisonDimension}>{row.dimension}</th>
+                    <td data-label={comparisonHeaders.reality}>{row.reality}</td>
+                    <td data-label={comparisonHeaders.value} className={styles.comparisonValue}>{row.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className={styles.comparisonCta}>
+            <PillLink to="/docs/intro" muted>
+              <Translate id="homepage.capabilities.docsCta">Explore how it works</Translate>
+            </PillLink>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Purpose

- Establish **Mixture-of-Models** as an independent, next-generation model architecture shaped by preference, and describe **vLLM Semantic Router** separately as its open-source runtime.
- Replace the long homepage explanation with a concise Hero and direct Playground/Docs actions.
- Replace the previous problem panel, runtime checklist, and four value cards with one comparison table that maps four fragmented realities to vLLM SR value:
  - Models: closed frontier, open, domain-specialized, and edge models
  - Compute: new and legacy GPUs, accelerators, edge devices, and cloud capacity
  - Location: edge, private data centers, and cloud
  - Preference: different definitions of “best” across users, products, and workloads
- Keep the compute claim within the live router boundary: routing across configured model endpoints on heterogeneous compute, not live GPU scheduling or autoscaling.
- Compress the README About section to the same architecture/runtime definition and comparison table, remove the outdated single-model system diagram, collapse playground credentials, and show only the three latest announcements by default.
- Keep English, Simplified Chinese, and site metadata aligned.

This is a docs and website-only change. The new presentation removes more than 400 net lines of repeated explanatory content and sends implementation details to the documentation.

## Test Plan

- Run the repository docs-only CI gate for all five changed files.
- Lint the website, validate the Chinese translation JSON, and check the diff.
- Build the production website for English and Simplified Chinese.
- Inspect the Hero and comparison table at desktop and 390 px in both locales.
- Verify the native table remains semantic and the page has no horizontal overflow.

## Test Result

- `make agent-ci-gate CHANGED_FILES='README.md website/docusaurus.config.ts website/i18n/zh-Hans/code.json website/src/pages/index.module.css website/src/pages/index.tsx'` — passed
- `make docs-lint` — passed
- `jq empty website/i18n/zh-Hans/code.json` — passed
- `git diff --check` — passed
- `npx docusaurus build` — passed for `en` and `zh-Hans`
- Production visual inspection — passed at 1440 px and 390 px in both locales
- Layout measurement — `scrollWidth === clientWidth` for all four viewport/locale combinations

The build continues to report pre-existing warnings for stale Browserslist data, `vscode-languageserver-types`, and existing Chinese documentation anchors.

## Checklist

- [x] Changes are limited to documentation and website positioning.
- [x] Mixture-of-Models remains an independent architecture keyword.
- [x] English and Simplified Chinese copy are aligned.
- [x] The branch is based on the latest upstream `main`.
- [x] The commit includes a `Signed-off-by` line.
