### PR TITLE
[Router] fix build: use renamed streamingPromptTokenDetails in responses-api stream usage

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
@@ -317,7 +317,7 @@ func responseAPIStreamUsage(ctx *RequestContext) map[string]interface{} {
 
 	inputTokens := int(usage.PromptTokens)
 	cachedTokens := 0
-	if cached, ok := streamingCachedPromptTokens(ctx, inputTokens); ok {
+	if cached, cachedReported, _, _ := streamingPromptTokenDetails(ctx, inputTokens); cachedReported {
 		cachedTokens = cached
 	}
 


### PR DESCRIPTION
Closes #2459

## Summary

`pkg/extproc` no longer compiles on `main`, which breaks `build-router` and cascades to failing CI on every open PR (`build_pr/*`, `test-and-build`, `component-benchmarks`, `integration-test`).

`responseAPIStreamUsage` (added by #2438) calls `streamingCachedPromptTokens`, but #2430 renamed and expanded that helper to
`streamingPromptTokenDetails(ctx, promptTokens) (cached int, cachedReported bool, cacheWrite int, cacheWriteReported bool)`.
The two PRs touched different files and merged with no text conflict, so the combined tree references a function that no longer exists. (Full timeline in #2459.)

This updates the call to the new `streamingPromptTokenDetails`, taking the `cached` / `cachedReported` return values. Behavior-preserving — the cache-write values are ignored here, as the original code only populated `cached_tokens`.

```diff
-	if cached, ok := streamingCachedPromptTokens(ctx, inputTokens); ok {
+	if cached, cachedReported, _, _ := streamingPromptTokenDetails(ctx, inputTokens); cachedReported {
 		cachedTokens = cached
 	}
```

## Test Plan

- [x] `cd src/semantic-router && go build ./pkg/extproc/` compiles (was `undefined: streamingCachedPromptTokens`).
- [x] `go build ./...` for the main module compiles (the `cmd/wasm` native-`main` warning is pre-existing and unrelated).
- [x] `go test ./pkg/extproc/` passes.
- [x] `gofmt` + `go vet` clean.
- [ ] CI green on this PR.
