### PR TITLE
[Router] Harden image-input seams: canonicalize data URI at classify/eval and map bad-image encode to 400

### DIFF
--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -3,6 +3,7 @@
 package apiserver
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -13,6 +14,38 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/imageurl"
 )
+
+// multiModalEncodeImage is the FFI image-encode entry point, kept as a
+// package-level var so tests can inject a failing encoder without a loaded model.
+var multiModalEncodeImage = candle_binding.MultiModalEncodeImageFromBase64
+
+// imageEncodeError marks an image-encode failure driven by the request input:
+// the payload validated as a safe base64 data URI but was not a decodable image.
+// The handler maps it to 400 INVALID_IMAGE rather than 500, so a client-supplied
+// bad image is reported as a client error, not an internal one.
+type imageEncodeError struct {
+	index int
+	err   error
+}
+
+func (e *imageEncodeError) Error() string {
+	return fmt.Sprintf("images[%d]: %v", e.index, e.err)
+}
+
+func (e *imageEncodeError) Unwrap() error { return e.err }
+
+// classifyEmbeddingError maps a buildEmbeddingResults error to the HTTP status,
+// error code, and client message. Input-caused image-encode failures are 400
+// INVALID_IMAGE; every other failure is a genuine 500.
+func classifyEmbeddingError(err error) (int, string, string) {
+	var imgErr *imageEncodeError
+	if errors.As(err, &imgErr) {
+		return http.StatusBadRequest, "INVALID_IMAGE",
+			fmt.Sprintf("images[%d] could not be decoded as an image", imgErr.index)
+	}
+	return http.StatusInternalServerError, "EMBEDDING_GENERATION_FAILED",
+		fmt.Sprintf("failed to generate embedding: %v", err)
+}
 
 const (
 	defaultEmbeddingDimension = 768
@@ -31,8 +64,8 @@ func (s *ClassificationAPIServer) handleEmbeddings(w http.ResponseWriter, r *htt
 
 	results, totalProcessingTime, err := buildEmbeddingResults(req)
 	if err != nil {
-		s.writeErrorResponse(w, http.StatusInternalServerError, "EMBEDDING_GENERATION_FAILED",
-			fmt.Sprintf("failed to generate embedding: %v", err))
+		status, code, message := classifyEmbeddingError(err)
+		s.writeErrorResponse(w, status, code, message)
 		return
 	}
 
@@ -150,16 +183,19 @@ func buildEmbeddingResults(req EmbeddingRequest) ([]EmbeddingResult, int64, erro
 		totalProcessingTime += processingTime
 	}
 
-	for _, image := range req.Images {
+	for i, image := range req.Images {
 		// Canonicalize so the FFI's case-sensitive ";base64," scan finds the
 		// payload boundary (validation already guaranteed a safe data URI).
 		encodeInput := image
 		if canonical, ok := imageurl.CanonicalDataURL(image); ok {
 			encodeInput = canonical
 		}
-		output, err := candle_binding.MultiModalEncodeImageFromBase64(encodeInput, req.Dimension)
+		output, err := multiModalEncodeImage(encodeInput, req.Dimension)
 		if err != nil {
-			return nil, 0, err
+			// The image already passed the safe-data-URI + base64-decode gate, so
+			// an encode failure here is input-caused (undecodable image bytes);
+			// surface it as a 400 rather than a 500.
+			return nil, 0, &imageEncodeError{index: i, err: err}
 		}
 
 		processingTime := int64(output.ProcessingTimeMs)

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -3,6 +3,8 @@
 package apiserver
 
 import (
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -103,6 +105,47 @@ func TestValidateEmbeddingRequestAcceptsUppercaseDataURIScheme(t *testing.T) {
 
 	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
 		t.Fatalf("expected uppercase-scheme data URI to be accepted")
+	}
+}
+
+func TestBuildEmbeddingResultsWrapsImageEncodeFailure(t *testing.T) {
+	// A validated safe data URI whose bytes are not a decodable image fails at the
+	// FFI; buildEmbeddingResults must tag it as an imageEncodeError so the handler
+	// maps it to 400 instead of 500.
+	orig := multiModalEncodeImage
+	defer func() { multiModalEncodeImage = orig }()
+	multiModalEncodeImage = func(string, int) (*candle_binding.MultiModalEmbeddingOutput, error) {
+		return nil, errors.New("failed to decode image")
+	}
+
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: defaultEmbeddingDimension,
+	}
+	_, _, err := buildEmbeddingResults(req)
+	if err == nil {
+		t.Fatalf("expected an error from a failing image encode")
+	}
+	var imgErr *imageEncodeError
+	if !errors.As(err, &imgErr) {
+		t.Fatalf("expected imageEncodeError, got %T: %v", err, err)
+	}
+	if imgErr.index != 0 {
+		t.Fatalf("expected image index 0, got %d", imgErr.index)
+	}
+}
+
+func TestClassifyEmbeddingErrorMapsImageEncodeFailureTo400(t *testing.T) {
+	status, code, _ := classifyEmbeddingError(&imageEncodeError{index: 2, err: errors.New("bad image")})
+	if status != http.StatusBadRequest || code != "INVALID_IMAGE" {
+		t.Fatalf("expected 400 INVALID_IMAGE, got %d %q", status, code)
+	}
+}
+
+func TestClassifyEmbeddingErrorMapsInternalFailureTo500(t *testing.T) {
+	status, code, _ := classifyEmbeddingError(errors.New("model not loaded"))
+	if status != http.StatusInternalServerError || code != "EMBEDDING_GENERATION_FAILED" {
+		t.Fatalf("expected 500 EMBEDDING_GENERATION_FAILED, got %d %q", status, code)
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/routes.go
+++ b/src/semantic-router/pkg/apiserver/routes.go
@@ -89,7 +89,7 @@ func apiRoutes() []apiRoute {
 		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/eval", Method: "POST", Description: "Evaluate all configured signals regardless of decision usage"}, Handler: (*ClassificationAPIServer).handleEvalClassification, RequestBody: jsonBody()},
 		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/nli", Method: "POST", Description: "Natural language inference classification for premise and hypothesis pairs"}, Handler: (*ClassificationAPIServer).handleNLIClassification, RequestBody: jsonBody()},
 
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/embeddings", Method: "POST", Description: "Generate text embeddings"}, Handler: (*ClassificationAPIServer).handleEmbeddings, RequestBody: jsonBody()},
+		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/embeddings", Method: "POST", Description: "Generate text and image embeddings"}, Handler: (*ClassificationAPIServer).handleEmbeddings, RequestBody: jsonBody()},
 		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/similarity", Method: "POST", Description: "Calculate pairwise text similarity"}, Handler: (*ClassificationAPIServer).handleSimilarity, RequestBody: jsonBody()},
 		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/similarity/batch", Method: "POST", Description: "Calculate batch text-similarity matches"}, Handler: (*ClassificationAPIServer).handleBatchSimilarity, RequestBody: jsonBody()},
 

--- a/src/semantic-router/pkg/services/intent_request_messages.go
+++ b/src/semantic-router/pkg/services/intent_request_messages.go
@@ -176,8 +176,11 @@ func extractIntentConversationHistory(messages []IntentMessage) intentConversati
 }
 
 // extractIntentMessageImageURL returns the first safe inline base64 image data
-// URI from a message's content parts, mirroring the ExtProc request path. Only
-// data URIs are accepted (HTTP(S) URLs are rejected to prevent SSRF).
+// URI (canonicalized) from a message's content parts. Only data URIs are
+// accepted; HTTP(S) URLs are rejected to prevent SSRF. This shares the same
+// imageurl gate as the ExtProc request path but is not a full behavioral mirror
+// of it (e.g. the ExtProc path fills the first safe image once across all user
+// turns, whereas this HTTP path resolves per turn).
 func extractIntentMessageImageURL(raw json.RawMessage) string {
 	raw = bytesTrimSpace(raw)
 	if len(raw) == 0 || string(raw) == "null" {
@@ -202,8 +205,13 @@ func firstSafeImageURL(parts []intentMessageContentPart) string {
 		if part.ImageURL == nil {
 			continue
 		}
-		if url := strings.TrimSpace(part.ImageURL.URL); imageurl.IsSafeImageDataURL(url) {
-			return url
+		// Return the canonical form (lowercased scheme/MIME/";base64," marker,
+		// payload preserved) rather than the raw URI. The classifier backend that
+		// ultimately consumes this scans for ";base64," case-sensitively, so an
+		// accepted uppercase-scheme data URI would otherwise yield no image signal
+		// on the classify/eval path even though the gate admitted it.
+		if canonical, ok := imageurl.CanonicalDataURL(strings.TrimSpace(part.ImageURL.URL)); ok {
+			return canonical
 		}
 	}
 	return ""

--- a/src/semantic-router/pkg/services/intent_request_messages_test.go
+++ b/src/semantic-router/pkg/services/intent_request_messages_test.go
@@ -110,6 +110,32 @@ func TestIntentRequestResolveSignalInput_AcceptsImageOnlyUserTurn(t *testing.T) 
 	assert.Equal(t, dataURI, input.imageURL)
 }
 
+func TestIntentRequestResolveSignalInput_CanonicalizesUppercaseImageURL(t *testing.T) {
+	// An uppercase-scheme data URI passes the safety gate, but the classifier
+	// backend scans for ";base64," case-sensitively. The resolved imageURL must be
+	// canonicalized (lowercase scheme/marker, payload preserved) so the image
+	// signal actually fires on the classify/eval path instead of silently dropping.
+	const rawURI = "DATA:IMAGE/PNG;BASE64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+	const canonicalURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+	req := IntentRequest{
+		Messages: []IntentMessage{
+			{
+				Role: "user",
+				Content: mustMessageContent(t, []map[string]interface{}{
+					{"type": "text", "text": "What does this screenshot show?"},
+					{"type": "image_url", "image_url": map[string]string{"url": rawURI}},
+				}),
+			},
+		},
+	}
+
+	input, err := req.resolveSignalInput()
+	require.NoError(t, err)
+
+	assert.Equal(t, "What does this screenshot show?", input.evaluationText)
+	assert.Equal(t, canonicalURI, input.imageURL)
+}
+
 func TestIntentRequestResolveSignalInput_StringImageURLDoesNotPoisonText(t *testing.T) {
 	// Responses API shape: image_url is a bare string, not a {"url": ...} object.
 	// A string-valued part must not fail the whole content-parts unmarshal, which


### PR DESCRIPTION
Closes #2406

## Summary

Follow-up hardening for the image-input surface delivered by #2104. Two
non-blocking findings from that PR's review were deferred to this issue; this PR
addresses both, plus the two trivial doc items bundled with them.

1. **Only `/api/v1/embeddings` canonicalized the data URI; classify/eval handed
   the raw string to the backend.** The classify/eval path stored the raw
   (trimmed) image data URI, but the classifier backend scans for the
   `";base64,"` marker case-sensitively. An uppercase-scheme data URI
   (`DATA:IMAGE/PNG;BASE64,...`) that the `imageurl` gate accepts as safe
   therefore yielded **no image signal** on classify/eval, while the same input
   works on `/embeddings`. `firstSafeImageURL` now returns
   `imageurl.CanonicalDataURL`'s output, so `imageurl` is the single source of
   truth for the gate **and** every consumer.

2. **Valid base64 of non-image bytes surfaced as a 500 instead of a 400.** Input
   that passes validation (safe data URI + well-formed base64) but fails the FFI
   image encode was mapped to `500 EMBEDDING_GENERATION_FAILED`. It is now tagged
   with an `imageEncodeError` and mapped to `400 INVALID_IMAGE`; genuine internal
   failures remain 500.

## Changes

- **`pkg/services/intent_request_messages.go`** — `firstSafeImageURL` returns the
  canonical data URI (lowercased scheme/MIME/`";base64,"` marker, payload
  preserved) rather than the raw string. Corrected the
  `extractIntentMessageImageURL` doc comment, which overclaimed a full behavioral
  mirror of the ExtProc path (ExtProc fills the first safe image once across all
  user turns; this HTTP path resolves per turn).
- **`pkg/apiserver/route_embeddings.go`** — routed the FFI call through a
  package-level `multiModalEncodeImage` var; wrapped image-encode failures in
  `imageEncodeError`; added `classifyEmbeddingError` to map input-caused failures
  to `400 INVALID_IMAGE` and everything else to 500.
- **`pkg/apiserver/routes.go`** — the `/api/v1/embeddings` OpenAPI description
  (feeds `/docs`) now reads "Generate text and image embeddings"; it has accepted
  images since #2104.

## Test Plan

Built the Rust bindings and ran the Go suites with cgo:

- [x] `go test ./pkg/services/ ./pkg/apiserver/` — green.
- [x] `go vet ./pkg/services/ ./pkg/apiserver/` — clean. `gofmt -l` — clean.
- [x] New `TestIntentRequestResolveSignalInput_CanonicalizesUppercaseImageURL`:
  an uppercase-scheme data URI resolves to the canonical (lowercase) form.
  **Falsifiable** — reverting the canonicalization makes the raw uppercase URI
  leak through and the test fails.
- [x] New `TestBuildEmbeddingResultsWrapsImageEncodeFailure` (injects a failing
  encoder via `multiModalEncodeImage`) asserts the returned error is an
  `imageEncodeError`; `TestClassifyEmbeddingErrorMapsImageEncodeFailureTo400` /
  `...MapsInternalFailureTo500` pin the status/code mapping.
- [x] Existing image-input tests (`AcceptsUppercaseDataURIScheme`,
  `RejectsMalformedBase64`, `AcceptsImagesOnly`, resolve-signal image tests)
  stay green.

No behavior change to routing/startup/config/Docker/CLI. The externally-visible
change is a status-code correction (500 → 400 for a client-supplied bad image),
covered by the unit tests above; the FFI encode path itself remains env-gated
(see #2319).

## Out of scope / deferred

The third bundled cosmetic from the #2104 review — drop-site logging so an
unsafe-image-only request no longer fails with a misleading "text cannot be
empty" — is deliberately **not** in this PR. It needs a small refactor to thread
an "all image parts were rejected" signal up to the `ErrEmptyText` site, which is
better kept separate from this seam-hardening change. #2406 tracks it as the
remaining item.
