### PR TITLE
[Docs] move deploy/nvidia/README.md to docs/agent/nvidia-local.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ If you need real AMD model deployment details instead of the minimal smoke path,
 
 - `cpu-local`: `make vllm-sr-dev`, then `vllm-sr serve --image-pull-policy never`
 - `amd-local`: `make vllm-sr-dev VLLM_SR_PLATFORM=amd`, then `vllm-sr serve --image-pull-policy never --platform amd`
+- `nvidia-local`: `VLLM_SR_PLATFORM=nvidia make vllm-sr-build`, then `vllm-sr serve --platform nvidia --image ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest --config <recipe>` (see [docs/agent/nvidia-local.md](docs/agent/nvidia-local.md); CLI symmetry with `--platform amd` is tracked in #2421)
 - `ci-k8s`: `make e2e-test`
 
 ## Non-Negotiable Rules

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -69,6 +69,7 @@ make agent-ci-gate CHANGED_FILES="..."
 - [openai-api-contracts.md](openai-api-contracts.md)
 - [glossary.md](glossary.md)
 - [amd-local.md](amd-local.md)
+- [nvidia-local.md](nvidia-local.md)
 
 ## Executable Contract
 

--- a/docs/agent/environments.md
+++ b/docs/agent/environments.md
@@ -31,6 +31,17 @@
 - Use [deploy/recipes/balance.yaml](../../deploy/recipes/balance.yaml) as the reference YAML-first AMD routing profile
 - See [amd-local.md](amd-local.md)
 
+## `nvidia-local`
+
+- Build with `VLLM_SR_PLATFORM=nvidia make vllm-sr-build`
+- Local runtime uses the `ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest` image (published via `docker-publish.yml` / `docker-release.yml`); a local build tagged `vllm-sr-cuda:local` is also supported
+- Start with `vllm-sr serve --platform nvidia --image ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest --config <recipe>` — the `--platform nvidia` flag currently only wires `--gpus all` / CDI passthrough; the CUDA image and `use_cpu: false` mutation still need explicit overrides until [#2421](https://github.com/vllm-project/semantic-router/issues/2421) lands
+- Use this for CUDA/NVIDIA validation of BERT classifiers, mmBERT embeddings, jailbreak guard, PII detection, and other router-side ML modules on GPU
+- Verified hardware in the playbook: RTX 4090 (compute_cap 8.9), CUDA driver 580
+- Set `use_cpu: false` under `global.model_catalog` in your routing recipe for the modules you want on GPU
+- For the full router-on-CUDA build/serve/validation playbook, read [nvidia-local.md](nvidia-local.md)
+- Note: `deploy/nvidia/` is intentionally empty until an NVIDIA-specific routing profile (a real backend recipe parallel to [deploy/amd/README.md](../../deploy/amd/README.md)) is authored — that is separate work from this router-on-GPU environment
+
 ## `ci-k8s`
 
 - Run local profile checks with `make e2e-test E2E_PROFILE=<profile>`
@@ -40,4 +51,5 @@
 
 - Default to `cpu-local`
 - Use `amd-local` when platform behavior, ROCm image selection, or AMD defaults are affected
+- Use `nvidia-local` when CUDA image selection, NVIDIA GPU passthrough, or router-side ML modules on GPU are affected
 - Use `ci-k8s` for merge-gate coverage and all profile-sensitive routing/deploy behavior

--- a/docs/agent/nvidia-local.md
+++ b/docs/agent/nvidia-local.md
@@ -7,19 +7,17 @@ detection, jailbreak guard, mmBERT embedding for Knowledge-Base
 signals, hallucination mitigation, feedback detection. The backend
 LLM is reached over the network and is **not** served from this host.
 
-**How this relates to `deploy/amd/README.md`:** the two documents,
-despite their filename symmetry, are not parallel.
-[`deploy/amd/README.md`](../amd/README.md) is a *routing profile*
-guide (the `balance.yaml` recipe running against a single ROCm vLLM
-backend), which is a different concern. The AMD equivalent of *this*
-file — how to build the router image on ROCm and serve it with
-`vllm-sr serve --platform amd` — lives in
-[`docs/agent/amd-local.md`](../../docs/agent/amd-local.md), together
-with the `amd-local` entry in
-[`docs/agent/environments.md`](../../docs/agent/environments.md).
-A future refactor may move this playbook to a matching
-`docs/agent/nvidia-local.md` for structural symmetry; that reshuffle
-is intentionally out of scope for this PR.
+**How this relates to `amd-local.md`:** this file is the NVIDIA
+equivalent of [`amd-local.md`](amd-local.md) — how to build the router
+image on CUDA and serve it with `vllm-sr serve --platform nvidia`.
+Both live under `docs/agent/` and have matching entries in
+[`environments.md`](environments.md).
+
+[`deploy/amd/README.md`](../../deploy/amd/README.md) is a different
+concern: a *routing profile* guide (the `balance.yaml` recipe running
+against a single ROCm vLLM backend). The naming looks parallel but
+the topic isn't. `deploy/nvidia/` is intentionally left empty until a
+matching NVIDIA routing profile is authored.
 
 > **When this playbook is NOT for you:** upstream `onnx-binding/README.md`
 > documents CPU≈GPU latency parity for BERT-size embeddings at small
@@ -216,7 +214,7 @@ Without overrides, even when the container has GPU access, the router
 runs entirely on CPU.
 
 Add the following override block under `global.model_catalog` in your
-routing recipe (e.g. [`deploy/recipes/balance.yaml`](../recipes/balance.yaml)
+routing recipe (e.g. [`deploy/recipes/balance.yaml`](../../deploy/recipes/balance.yaml)
 or whichever recipe your deployment loads):
 
 ```yaml

--- a/tools/agent/repo-manifest.yaml
+++ b/tools/agent/repo-manifest.yaml
@@ -121,6 +121,7 @@ docs:
 - docs/agent/tech-debt-register.md
 - docs/agent/tech-debt/README.md
 - docs/agent/amd-local.md
+- docs/agent/nvidia-local.md
 - docs/agent/architecture-guardrails.md
 - docs/agent/openai-api-contracts.md
 - docs/agent/architecture-scorecard.md
@@ -230,6 +231,9 @@ doc_governance:
   - path: docs/agent/amd-local.md
     steward: agent-contract
     freshness: update when AMD-local workflow or deployment references change
+  - path: docs/agent/nvidia-local.md
+    steward: agent-contract
+    freshness: update when NVIDIA-local workflow or deployment references change
   - path: docs/agent/architecture-guardrails.md
     steward: agent-contract
     freshness: update when structural or modularity guardrails change


### PR DESCRIPTION
Closes #2422

## Summary

Move `deploy/nvidia/README.md` → `docs/agent/nvidia-local.md` for
structural symmetry with the existing `docs/agent/amd-local.md`. The
file was already tagged as "may move later" in its own intro block
when it was first introduced (#2281, `f15f8e5d`), and #2420's
follow-ups §2 flagged the location; this PR lands the actual move now
that #2420 has merged.

## Why the current layout was misleading

| Path | Actual content | Topic |
| --- | --- | --- |
| `deploy/amd/README.md` (249 lines) | `balance.yaml` routing profile against a single ROCm vLLM backend | **Routing profile** |
| `deploy/amd/AGENTIC.md` (272 lines) | AMD agentic recipe on top | **Routing profile** |
| `deploy/nvidia/README.md` (645 lines) | Build the CUDA router image, serve `vllm-sr` so BERT classifiers + mmBERT embeddings run on CUDA | **Router-on-GPU playbook** |
| `docs/agent/amd-local.md` (47 lines) | Minimal AMD-side router-on-GPU reference | **Router-on-GPU playbook** |

So the actual AMD equivalent of `deploy/nvidia/README.md` was
`docs/agent/amd-local.md`, not `deploy/amd/README.md`. This PR fixes
the mismatch by moving the NVIDIA playbook next to its actual peer.

## Changes

- `git mv deploy/nvidia/README.md docs/agent/nvidia-local.md`
  (96% similarity, `--follow` history preserved)
- Rewrite the file's intro block to describe the final layout
  (previously it carried a "future refactor may move this" caveat
  pointing forward to this PR)
- Fix 4 relative links that reached across the `deploy/` tree — the
  new location is at the same depth from repo root, so `../../src/…`
  and `../../.github/…` links are unaffected, only the ones that
  went sideways through `deploy/` had to be rewritten:
  - `../amd/README.md` → `../../deploy/amd/README.md`
  - `../../docs/agent/amd-local.md` → `amd-local.md`
  - `../../docs/agent/environments.md` → `environments.md`
  - `../recipes/balance.yaml` → `../../deploy/recipes/balance.yaml`
- Add `nvidia-local` entry to `docs/agent/environments.md` parallel
  to the existing `amd-local` block (build/serve commands, expected
  behavior, pointer to `nvidia-local.md`), plus a Selection Rule
  bump so future contributors know when to reach for it
- Add `nvidia-local` runbook line to `AGENTS.md` alongside
  `amd-local`
- Add `nvidia-local.md` to the doc index in `docs/agent/README.md`
- Remove the now-empty `deploy/nvidia/` directory

## Sequencing (per #2422)

- Lands **after** #2420 (merged 2026-07-10) — avoids rebase churn on
  the same file
- Lands **before** #2421 (CLI symmetry for `--platform nvidia`) — so
  that feature's docs updates land at the correct final path from
  day one

`deploy/nvidia/` is intentionally left empty until an NVIDIA-specific
routing profile (a real backend recipe parallel to `deploy/amd/`) is
authored; that is separate feature work, out of scope here.

## Test Plan

- [x] `markdownlint -c tools/linter/markdown/markdownlint.yaml` clean
  on all 4 modified files
- [x] `grep -rln 'deploy/nvidia\|nvidia-local'` across the whole repo
  returns only the 4 files touched by this PR — no stale refs
- [x] All 13 relative link targets in the moved file resolve to real
  paths in-tree (`deploy/amd/README.md`, `deploy/recipes/balance.yaml`,
  `src/vllm-sr/Dockerfile.cuda`, `src/vllm-sr/Dockerfile.cuda.dockerignore`,
  `src/semantic-router/go.onnx.mod`,
  `src/semantic-router/pkg/config/canonical_defaults.go`,
  `tools/make/docker.mk`, `.github/workflows/docker-publish.yml`,
  `.github/workflows/docker-release.yml`,
  `onnx-binding/README.md`, `onnx-binding/Cargo.toml`,
  `amd-local.md`, `environments.md`)
- [x] `git log --follow docs/agent/nvidia-local.md` shows the full
  pre-move history back through #2281 (`f15f8e5d`) and #2420
- Docs-only PR, no runtime, config, Docker, CLI, or API surface
  changes → no E2E updates required per
  `docs/agent/testing-strategy.md`

## Related

- #2281 — original CUDA Dockerfile + deploy guide (merged)
- #2405 — publish `vllm-sr-cuda` image (merged)
- #2419 / #2420 — bug + docs-content refresh (both closed; #2420
  merged 2026-07-10)
- #2421 — feature: complete `vllm-sr serve --platform nvidia` CLI
  symmetry (next in sequence, will consume this file's new path)
