### PR TITLE
[Dashboard][Docs] Update homepage positioning copy

### DIFF
--- a/dashboard/frontend/e2e/public-responsive.spec.ts
+++ b/dashboard/frontend/e2e/public-responsive.spec.ts
@@ -171,7 +171,7 @@ test.describe('Public and transition surfaces on short screens', () => {
     ).toBeVisible()
     await expect(
       page.getByText(
-        'Turn signals and preferences into executable model paths across heterogeneous LLMs.',
+        'System-level intelligence for heterogeneous LLM inference',
       ),
     ).toBeVisible()
     const exploreDocs = page.getByRole('button', { name: 'Explore the Docs' })

--- a/dashboard/frontend/src/pages/LandingPage.tsx
+++ b/dashboard/frontend/src/pages/LandingPage.tsx
@@ -36,7 +36,7 @@ const LandingPage: React.FC = () => {
           </h1>
 
           <p className={styles.subtitle}>
-            Turn signals and preferences into executable model paths across heterogeneous LLMs.
+            System-level intelligence for heterogeneous LLM inference
           </p>
 
           <div className={styles.ctaGroup}>

--- a/website/src/components/site/SemanticTerrainHero/index.tsx
+++ b/website/src/components/site/SemanticTerrainHero/index.tsx
@@ -50,7 +50,7 @@ export default function SemanticTerrainHero(): JSX.Element {
 
             <p className={styles.systemLabel}>
               <Translate id="homepage.hero.systemLabel">
-                System-level intelligence for heterogeneous LLM inference
+                The next-generation model architecture
               </Translate>
             </p>
 
@@ -67,8 +67,7 @@ export default function SemanticTerrainHero(): JSX.Element {
 
             <p className={styles.description}>
               <Translate id="homepage.hero.description">
-                Turn signals and preferences into executable model paths across
-                heterogeneous LLMs.
+                System-level intelligence for heterogeneous LLM inference
               </Translate>
             </p>
 


### PR DESCRIPTION
## Purpose

- Update the website hero eyebrow to “The next-generation model architecture”.
- Use “System-level intelligence for heterogeneous LLM inference” as the supporting copy on both the website hero and dashboard landing page.
- Keep the dashboard responsive E2E assertion aligned with the user-visible copy.
- Affected modules: `Dashboard`, `E2E`, `Docs`.

## Test Plan

- Run the dashboard lint, type-check, unit-test, and backend checks.
- Build the English Docusaurus production site.
- Run the repo-native CI gate for the three changed files.
- Build and smoke-test the canonical CPU-local images and isolated runtime stack.

## Test Result

- `make dashboard-check` — passed (86 test files, 261 tests).
- `npx docusaurus build --locale en` — passed.
- `make agent-ci-gate CHANGED_FILES='website/src/components/site/SemanticTerrainHero/index.tsx dashboard/frontend/src/pages/LandingPage.tsx dashboard/frontend/e2e/public-responsive.spec.ts'` — passed.
- `PATH="$PWD/.venv-agent/bin:$PATH" make agent-feature-gate ENV=cpu AGENT_STACK_NAME=homepage-copy AGENT_PORT_OFFSET=700 CHANGED_FILES='website/src/components/site/SemanticTerrainHero/index.tsx dashboard/frontend/src/pages/LandingPage.tsx dashboard/frontend/e2e/public-responsive.spec.ts'` — passed, including router, Envoy, dashboard, and fleet-sim health checks.
- No follow-up blockers identified; the change is limited to presentation copy and its existing E2E assertion.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
