### PR TITLE
[Docs] Fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | **Location** | Inference spans edge, private, and cloud. | Keep data within its boundaries. |
 | **Preference** | "Best" changes by user and workload. | Make every preference executable. |
 
-[Explore how it works →](https://vllm-semantic-router.com/docs/)
+[Explore how it works →](https://vllm-semantic-router.com/docs/intro/)
 
 ## Getting Started
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Closes #2484 
## Purpose
- Fixes a broken documentation link in README.md
- Module: Docs
## Test Plan
- Verified the updated link resolves
- Ran: `make agent-lint CHANGED_FILES="README.md"`
## Test Result
- Link resolves correctly
- Lint passed
---
<details>
<summary>Semantic Router PR Checklist</summary>
- [x] PR title uses module-aligned prefixes such as `[Docs]`
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope
</details>



See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
