### PR TITLE
[Router] Harden Responses API streaming parity

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_req_body_memory.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_memory.go
@@ -322,6 +322,12 @@ func (r *OpenAIRouter) handleFastResponse(ctx *RequestContext, decisionName stri
 	logging.Infof("[FastResponse] Decision '%s' has fast_response plugin, returning immediate response", decisionName)
 	metrics.RecordPluginExecution("fast_response", decisionName, "executed", 0)
 
+	if isResponseAPIRequest(ctx) {
+		if response, ok := r.createResponseAPIFastResponse(ctx, fastCfg.Message, decisionName); ok {
+			return response
+		}
+	}
+
 	return httputil.CreateFastResponse(fastCfg.Message, ctx.ExpectStreamingResponse, decisionName)
 }
 

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming.go
@@ -34,13 +34,18 @@ func (r *OpenAIRouter) handleStreamingResponseBody(
 	}
 	r.parseStreamingChunk(chunk, ctx)
 
-	if strings.Contains(chunk, "data: [DONE]") {
-		r.finalizeStreamingResponse(ctx)
-	}
+	streamDone := strings.Contains(chunk, "data: [DONE]")
 
 	if responseAPIStream {
 		bodyMutation := r.buildResponseAPIStreamingBodyMutation(parseBody, ctx)
+		if streamDone {
+			r.finalizeStreamingResponse(ctx)
+		}
 		return buildResponseBodyContinueResponse(bodyMutation, responseAPIStreamingHeaderMutation())
+	}
+
+	if streamDone {
+		r.finalizeStreamingResponse(ctx)
 	}
 
 	return buildResponseBodyContinueResponse(nil, nil)
@@ -74,6 +79,12 @@ func ensureStreamingState(ctx *RequestContext) {
 	}
 	if ctx.StreamingToolCalls == nil {
 		ctx.StreamingToolCalls = make(map[int]*StreamingToolCallState)
+	}
+	if ctx.ResponseAPIStreamToolCallItemIDs == nil {
+		ctx.ResponseAPIStreamToolCallItemIDs = make(map[int]string)
+	}
+	if ctx.ResponseAPIStreamToolCallOutputIndex == nil {
+		ctx.ResponseAPIStreamToolCallOutputIndex = make(map[int]int)
 	}
 }
 
@@ -120,6 +131,7 @@ func (r *OpenAIRouter) finalizeStreamingResponse(ctx *RequestContext) {
 	}
 
 	r.attachRouterReplayResponse(ctx, replayResponseBody, true)
+	r.maybeStoreResponseAPIStreamingResponse(ctx)
 }
 
 // parseStreamingChunk parses an SSE chunk to extract content and metadata.
@@ -177,18 +189,25 @@ func extractStreamingContent(ctx *RequestContext, chunkData map[string]interface
 			continue
 		}
 		if delta, ok := choice["delta"].(map[string]interface{}); ok {
-			if content, ok := delta["content"].(string); ok && content != "" {
-				ctx.StreamingContent += content
-			}
-			// Reasoning models stream their thinking under delta.reasoning_content.
-			// Accumulate it so the reconstructed (cached) response carries the same
-			// reasoning the live stream delivered, instead of silently dropping it.
-			if reasoning, ok := delta["reasoning_content"].(string); ok && reasoning != "" {
-				ctx.StreamingReasoning += reasoning
-			}
+			extractStreamingDeltaContent(ctx, delta)
 		}
 		if finishReason, ok := choice["finish_reason"].(string); ok && finishReason != "" {
 			ctx.StreamingMetadata["finish_reason"] = finishReason
 		}
+	}
+}
+
+func extractStreamingDeltaContent(ctx *RequestContext, delta map[string]interface{}) {
+	if content, ok := delta["content"].(string); ok && content != "" {
+		ctx.StreamingContent += content
+	}
+	// Reasoning models stream their thinking under delta.reasoning_content.
+	// Accumulate it so the reconstructed (cached) response carries the same
+	// reasoning the live stream delivered, instead of silently dropping it.
+	if reasoning, ok := delta["reasoning_content"].(string); ok && reasoning != "" {
+		ctx.StreamingReasoning += reasoning
+	}
+	if refusal, ok := delta["refusal"].(string); ok && refusal != "" {
+		ctx.StreamingRefusal += refusal
 	}
 }

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
@@ -31,9 +31,10 @@ func responseAPIStreamingHeaderMutation() *ext_proc.HeaderMutation {
 		SetHeaders: []*core.HeaderValueOption{
 			{
 				Header: &core.HeaderValue{
-					Key:   "content-type",
-					Value: "text/event-stream; charset=utf-8",
+					Key:      "content-type",
+					RawValue: []byte("text/event-stream; charset=utf-8"),
 				},
+				AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 			},
 		},
 		RemoveHeaders: []string{"content-length"},

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -79,24 +80,27 @@ func (r *OpenAIRouter) writeResponseAPIStreamDeltaEvents(
 	ctx *RequestContext,
 	chunkData map[string]interface{},
 ) {
+	r.writeResponseAPIReasoningDeltaEvents(out, ctx, chunkData)
+
 	deltas := responseAPITextDeltas(chunkData)
-	if len(deltas) == 0 {
-		return
+	if len(deltas) > 0 {
+		r.ensureResponseAPIStreamStarted(out, ctx)
+		for _, delta := range deltas {
+			writeResponseAPIStreamEvent(out, "response.output_text.delta", map[string]interface{}{
+				"type":          "response.output_text.delta",
+				"item_id":       ctx.ResponseAPIStreamItemID,
+				"output_index":  responseAPIMessageOutputIndex(ctx),
+				"content_index": 0,
+				"delta":         delta,
+			})
+		}
 	}
 
-	r.ensureResponseAPIStreamStarted(out, ctx)
-	for _, delta := range deltas {
-		writeResponseAPIStreamEvent(out, "response.output_text.delta", map[string]interface{}{
-			"type":          "response.output_text.delta",
-			"item_id":       ctx.ResponseAPIStreamItemID,
-			"output_index":  0,
-			"content_index": 0,
-			"delta":         delta,
-		})
-	}
+	r.writeResponseAPIRefusalDeltaEvents(out, ctx, chunkData)
+	r.writeResponseAPIToolCallDeltaEvents(out, ctx, chunkData)
 }
 
-func (r *OpenAIRouter) ensureResponseAPIStreamStarted(out *bytes.Buffer, ctx *RequestContext) {
+func (r *OpenAIRouter) ensureResponseAPIResponseStarted(out *bytes.Buffer, ctx *RequestContext) {
 	if ctx.ResponseAPIStreamStarted {
 		return
 	}
@@ -122,15 +126,25 @@ func (r *OpenAIRouter) ensureResponseAPIStreamStarted(out *bytes.Buffer, ctx *Re
 		"type":     "response.in_progress",
 		"response": startedResponse,
 	})
+}
+
+func (r *OpenAIRouter) ensureResponseAPIStreamStarted(out *bytes.Buffer, ctx *RequestContext) {
+	r.ensureResponseAPIResponseStarted(out, ctx)
+	if ctx.ResponseAPIStreamMessageStarted {
+		return
+	}
+
+	ctx.ResponseAPIStreamMessageStarted = true
+	ctx.ResponseAPIStreamMessageOutputIndex = responseAPIAssignOutputIndex(ctx)
 	writeResponseAPIStreamEvent(out, "response.output_item.added", map[string]interface{}{
 		"type":         "response.output_item.added",
-		"output_index": 0,
+		"output_index": responseAPIMessageOutputIndex(ctx),
 		"item":         responseAPIStreamMessageItem(ctx, responseapi.StatusInProgress, ""),
 	})
 	writeResponseAPIStreamEvent(out, "response.content_part.added", map[string]interface{}{
 		"type":          "response.content_part.added",
 		"item_id":       ctx.ResponseAPIStreamItemID,
-		"output_index":  0,
+		"output_index":  responseAPIMessageOutputIndex(ctx),
 		"content_index": 0,
 		"part": map[string]interface{}{
 			"type":        responseapi.ContentTypeOutputText,
@@ -141,37 +155,74 @@ func (r *OpenAIRouter) ensureResponseAPIStreamStarted(out *bytes.Buffer, ctx *Re
 }
 
 func (r *OpenAIRouter) writeResponseAPIStreamDoneEvents(out *bytes.Buffer, ctx *RequestContext) {
-	r.ensureResponseAPIStreamStarted(out, ctx)
+	if responseAPIStreamNeedsMessageItem(ctx) {
+		r.ensureResponseAPIStreamStarted(out, ctx)
+	} else {
+		r.ensureResponseAPIResponseStarted(out, ctx)
+	}
 	text := ctx.StreamingContent
 	usage := responseAPIStreamUsage(ctx)
 
-	writeResponseAPIStreamEvent(out, "response.output_text.done", map[string]interface{}{
-		"type":          "response.output_text.done",
-		"item_id":       ctx.ResponseAPIStreamItemID,
-		"output_index":  0,
-		"content_index": 0,
-		"text":          text,
-	})
-	writeResponseAPIStreamEvent(out, "response.content_part.done", map[string]interface{}{
-		"type":          "response.content_part.done",
-		"item_id":       ctx.ResponseAPIStreamItemID,
-		"output_index":  0,
-		"content_index": 0,
-		"part": map[string]interface{}{
-			"type":        responseapi.ContentTypeOutputText,
-			"text":        text,
-			"annotations": []interface{}{},
-		},
-	})
-	writeResponseAPIStreamEvent(out, "response.output_item.done", map[string]interface{}{
-		"type":         "response.output_item.done",
-		"output_index": 0,
-		"item":         responseAPIStreamMessageItem(ctx, responseapi.StatusCompleted, text),
-	})
+	r.writeResponseAPIReasoningDoneEvents(out, ctx)
+	r.writeResponseAPIMessageDoneEvents(out, ctx, text)
+	r.writeResponseAPIToolCallDoneEvents(out, ctx)
 	writeResponseAPIStreamEvent(out, "response.completed", map[string]interface{}{
 		"type":     "response.completed",
 		"response": responseAPIStreamCompletedResponse(ctx, text, usage),
 	})
+}
+
+func responseAPIStreamNeedsMessageItem(ctx *RequestContext) bool {
+	if ctx == nil {
+		return true
+	}
+	return ctx.ResponseAPIStreamMessageStarted || ctx.StreamingContent != "" || ctx.StreamingRefusal != "" || len(ctx.StreamingToolCalls) == 0
+}
+
+func (r *OpenAIRouter) writeResponseAPIMessageDoneEvents(out *bytes.Buffer, ctx *RequestContext, text string) {
+	if !ctx.ResponseAPIStreamMessageStarted {
+		return
+	}
+	if text != "" {
+		writeResponseAPIStreamEvent(out, "response.output_text.done", map[string]interface{}{
+			"type":          "response.output_text.done",
+			"item_id":       ctx.ResponseAPIStreamItemID,
+			"output_index":  responseAPIMessageOutputIndex(ctx),
+			"content_index": 0,
+			"text":          text,
+		})
+	}
+	if ctx.StreamingRefusal != "" {
+		writeResponseAPIStreamEvent(out, "response.refusal.done", map[string]interface{}{
+			"type":          "response.refusal.done",
+			"item_id":       ctx.ResponseAPIStreamItemID,
+			"output_index":  responseAPIMessageOutputIndex(ctx),
+			"content_index": 0,
+			"refusal":       ctx.StreamingRefusal,
+		})
+	}
+	writeResponseAPIStreamEvent(out, "response.content_part.done", map[string]interface{}{
+		"type":          "response.content_part.done",
+		"item_id":       ctx.ResponseAPIStreamItemID,
+		"output_index":  responseAPIMessageOutputIndex(ctx),
+		"content_index": 0,
+		"part":          responseAPIStreamMessageContentPart(ctx, text),
+	})
+	writeResponseAPIStreamEvent(out, "response.output_item.done", map[string]interface{}{
+		"type":         "response.output_item.done",
+		"output_index": responseAPIMessageOutputIndex(ctx),
+		"item":         responseAPIStreamMessageItem(ctx, responseapi.StatusCompleted, text),
+	})
+}
+
+func responseAPIAssignOutputIndex(ctx *RequestContext) int {
+	index := ctx.ResponseAPIStreamNextOutputIndex
+	ctx.ResponseAPIStreamNextOutputIndex++
+	return index
+}
+
+func responseAPIMessageOutputIndex(ctx *RequestContext) int {
+	return ctx.ResponseAPIStreamMessageOutputIndex
 }
 
 func responseAPITextDeltas(chunkData map[string]interface{}) []string {
@@ -198,6 +249,238 @@ func responseAPITextDeltas(chunkData map[string]interface{}) []string {
 	return deltas
 }
 
+func (r *OpenAIRouter) writeResponseAPIRefusalDeltaEvents(
+	out *bytes.Buffer,
+	ctx *RequestContext,
+	chunkData map[string]interface{},
+) {
+	for _, delta := range responseAPIStringDeltas(chunkData, "refusal") {
+		r.ensureResponseAPIStreamStarted(out, ctx)
+		if !ctx.ResponseAPIStreamRefusalStarted {
+			ctx.ResponseAPIStreamRefusalStarted = true
+		}
+		writeResponseAPIStreamEvent(out, "response.refusal.delta", map[string]interface{}{
+			"type":          "response.refusal.delta",
+			"item_id":       ctx.ResponseAPIStreamItemID,
+			"output_index":  responseAPIMessageOutputIndex(ctx),
+			"content_index": 0,
+			"delta":         delta,
+		})
+	}
+}
+
+func (r *OpenAIRouter) writeResponseAPIReasoningDeltaEvents(
+	out *bytes.Buffer,
+	ctx *RequestContext,
+	chunkData map[string]interface{},
+) {
+	for _, delta := range responseAPIStringDeltas(chunkData, "reasoning_content") {
+		r.ensureResponseAPIReasoningStarted(out, ctx)
+		writeResponseAPIStreamEvent(out, "response.reasoning_text.delta", map[string]interface{}{
+			"type":          "response.reasoning_text.delta",
+			"item_id":       ctx.ResponseAPIStreamReasoningItemID,
+			"output_index":  responseAPIReasoningOutputIndex(ctx),
+			"content_index": 0,
+			"delta":         delta,
+		})
+	}
+}
+
+func responseAPIStringDeltas(chunkData map[string]interface{}, field string) []string {
+	choices := replayStreamingChoices(chunkData)
+	if len(choices) == 0 {
+		return nil
+	}
+
+	deltas := make([]string, 0, len(choices))
+	for _, choice := range choices {
+		delta, ok := choice["delta"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		value, ok := delta[field].(string)
+		if ok && value != "" {
+			deltas = append(deltas, value)
+		}
+	}
+	return deltas
+}
+
+func (r *OpenAIRouter) ensureResponseAPIReasoningStarted(out *bytes.Buffer, ctx *RequestContext) {
+	r.ensureResponseAPIResponseStarted(out, ctx)
+	if ctx.ResponseAPIStreamReasoningStarted {
+		return
+	}
+
+	ctx.ResponseAPIStreamReasoningStarted = true
+	if ctx.ResponseAPIStreamReasoningItemID == "" {
+		ctx.ResponseAPIStreamReasoningItemID = responseapi.GenerateItemID()
+	}
+	ctx.ResponseAPIStreamReasoningOutputIndex = responseAPIAssignOutputIndex(ctx)
+	writeResponseAPIStreamEvent(out, "response.output_item.added", map[string]interface{}{
+		"type":         "response.output_item.added",
+		"output_index": responseAPIReasoningOutputIndex(ctx),
+		"item": map[string]interface{}{
+			"id":      ctx.ResponseAPIStreamReasoningItemID,
+			"type":    "reasoning",
+			"status":  responseapi.StatusInProgress,
+			"summary": []interface{}{},
+		},
+	})
+}
+
+func (r *OpenAIRouter) writeResponseAPIReasoningDoneEvents(out *bytes.Buffer, ctx *RequestContext) {
+	if !ctx.ResponseAPIStreamReasoningStarted {
+		return
+	}
+	writeResponseAPIStreamEvent(out, "response.reasoning_text.done", map[string]interface{}{
+		"type":          "response.reasoning_text.done",
+		"item_id":       ctx.ResponseAPIStreamReasoningItemID,
+		"output_index":  responseAPIReasoningOutputIndex(ctx),
+		"content_index": 0,
+		"text":          ctx.StreamingReasoning,
+	})
+	writeResponseAPIStreamEvent(out, "response.output_item.done", map[string]interface{}{
+		"type":         "response.output_item.done",
+		"output_index": responseAPIReasoningOutputIndex(ctx),
+		"item": map[string]interface{}{
+			"id":      ctx.ResponseAPIStreamReasoningItemID,
+			"type":    "reasoning",
+			"status":  responseapi.StatusCompleted,
+			"summary": []interface{}{},
+		},
+	})
+}
+
+func responseAPIReasoningOutputIndex(ctx *RequestContext) int {
+	return ctx.ResponseAPIStreamReasoningOutputIndex
+}
+
+func (r *OpenAIRouter) writeResponseAPIToolCallDeltaEvents(
+	out *bytes.Buffer,
+	ctx *RequestContext,
+	chunkData map[string]interface{},
+) {
+	for _, choice := range replayStreamingChoices(chunkData) {
+		for _, indexedToolCall := range replayStreamingToolCalls(choice) {
+			index := replayStreamingToolCallIndex(indexedToolCall.rawIndex, indexedToolCall.toolCall)
+			state := ctx.StreamingToolCalls[index]
+			r.ensureResponseAPIToolCallStarted(out, ctx, index, state)
+			if fn, ok := indexedToolCall.toolCall["function"].(map[string]interface{}); ok {
+				if arguments, ok := fn["arguments"].(string); ok && arguments != "" {
+					writeResponseAPIStreamEvent(out, "response.function_call_arguments.delta", map[string]interface{}{
+						"type":         "response.function_call_arguments.delta",
+						"item_id":      ctx.ResponseAPIStreamToolCallItemIDs[index],
+						"output_index": responseAPIToolCallOutputIndex(ctx, index),
+						"delta":        arguments,
+					})
+				}
+			}
+		}
+	}
+}
+
+func (r *OpenAIRouter) ensureResponseAPIToolCallStarted(
+	out *bytes.Buffer,
+	ctx *RequestContext,
+	index int,
+	state *StreamingToolCallState,
+) {
+	r.ensureResponseAPIResponseStarted(out, ctx)
+	if ctx.ResponseAPIStreamToolCallItemIDs == nil {
+		ctx.ResponseAPIStreamToolCallItemIDs = make(map[int]string)
+	}
+	if ctx.ResponseAPIStreamToolCallOutputIndex == nil {
+		ctx.ResponseAPIStreamToolCallOutputIndex = make(map[int]int)
+	}
+	if ctx.ResponseAPIStreamToolCallItemIDs[index] == "" {
+		ctx.ResponseAPIStreamToolCallItemIDs[index] = responseapi.GenerateItemID()
+		ctx.ResponseAPIStreamToolCallOutputIndex[index] = responseAPIAssignOutputIndex(ctx)
+		writeResponseAPIStreamEvent(out, "response.output_item.added", map[string]interface{}{
+			"type":         "response.output_item.added",
+			"output_index": responseAPIToolCallOutputIndex(ctx, index),
+			"item":         responseAPIStreamToolCallItem(ctx, index, state, responseapi.StatusInProgress),
+		})
+	}
+}
+
+func (r *OpenAIRouter) writeResponseAPIToolCallDoneEvents(out *bytes.Buffer, ctx *RequestContext) {
+	for _, index := range responseAPISortedToolCallIndexes(ctx) {
+		itemID := ctx.ResponseAPIStreamToolCallItemIDs[index]
+		if itemID == "" {
+			continue
+		}
+		state := ctx.StreamingToolCalls[index]
+		writeResponseAPIStreamEvent(out, "response.function_call_arguments.done", map[string]interface{}{
+			"type":         "response.function_call_arguments.done",
+			"item_id":      itemID,
+			"output_index": responseAPIToolCallOutputIndex(ctx, index),
+			"arguments":    responseAPIToolCallArguments(state),
+		})
+		writeResponseAPIStreamEvent(out, "response.output_item.done", map[string]interface{}{
+			"type":         "response.output_item.done",
+			"output_index": responseAPIToolCallOutputIndex(ctx, index),
+			"item":         responseAPIStreamToolCallItem(ctx, index, state, responseapi.StatusCompleted),
+		})
+	}
+}
+
+func responseAPIToolCallOutputIndex(ctx *RequestContext, index int) int {
+	if ctx != nil && ctx.ResponseAPIStreamToolCallOutputIndex != nil {
+		return ctx.ResponseAPIStreamToolCallOutputIndex[index]
+	}
+	return index
+}
+
+func responseAPISortedToolCallIndexes(ctx *RequestContext) []int {
+	if ctx == nil || len(ctx.StreamingToolCalls) == 0 {
+		return nil
+	}
+	indexes := make([]int, 0, len(ctx.StreamingToolCalls))
+	for index := range ctx.StreamingToolCalls {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	return indexes
+}
+
+func responseAPIStreamToolCallItem(
+	ctx *RequestContext,
+	index int,
+	state *StreamingToolCallState,
+	status string,
+) map[string]interface{} {
+	return map[string]interface{}{
+		"id":        ctx.ResponseAPIStreamToolCallItemIDs[index],
+		"type":      responseapi.ItemTypeFunctionCall,
+		"call_id":   responseAPIToolCallID(state),
+		"name":      responseAPIToolCallName(state),
+		"arguments": responseAPIToolCallArguments(state),
+		"status":    status,
+	}
+}
+
+func responseAPIToolCallID(state *StreamingToolCallState) string {
+	if state == nil {
+		return ""
+	}
+	return state.ID
+}
+
+func responseAPIToolCallName(state *StreamingToolCallState) string {
+	if state == nil {
+		return ""
+	}
+	return state.Name
+}
+
+func responseAPIToolCallArguments(state *StreamingToolCallState) string {
+	if state == nil {
+		return ""
+	}
+	return state.Arguments
+}
+
 func responseAPIStreamModel(ctx *RequestContext) string {
 	if model, ok := ctx.StreamingMetadata["model"].(string); ok && model != "" {
 		return model
@@ -213,12 +496,8 @@ func responseAPIStreamModel(ctx *RequestContext) string {
 
 func responseAPIStreamMessageItem(ctx *RequestContext, status string, text string) map[string]interface{} {
 	content := []interface{}{}
-	if status == responseapi.StatusCompleted || text != "" {
-		content = append(content, map[string]interface{}{
-			"type":        responseapi.ContentTypeOutputText,
-			"text":        text,
-			"annotations": []interface{}{},
-		})
+	if status == responseapi.StatusCompleted || text != "" || ctx.StreamingRefusal != "" {
+		content = append(content, responseAPIStreamMessageContentPart(ctx, text))
 	}
 
 	return map[string]interface{}{
@@ -230,13 +509,70 @@ func responseAPIStreamMessageItem(ctx *RequestContext, status string, text strin
 	}
 }
 
+func responseAPIStreamMessageContentPart(ctx *RequestContext, text string) map[string]interface{} {
+	if ctx != nil && ctx.StreamingRefusal != "" && text == "" {
+		return map[string]interface{}{
+			"type":    "refusal",
+			"refusal": ctx.StreamingRefusal,
+		}
+	}
+	return map[string]interface{}{
+		"type":        responseapi.ContentTypeOutputText,
+		"text":        text,
+		"annotations": []interface{}{},
+	}
+}
+
 func responseAPIStreamCompletedResponse(
 	ctx *RequestContext,
 	text string,
 	usage map[string]interface{},
 ) map[string]interface{} {
-	output := []interface{}{responseAPIStreamMessageItem(ctx, responseapi.StatusCompleted, text)}
+	output := responseAPIStreamOutput(ctx, text)
 	return responseAPIStreamResponse(ctx, responseapi.StatusCompleted, output, text, usage)
+}
+
+func responseAPIStreamOutput(ctx *RequestContext, text string) []interface{} {
+	indexed := []responseAPIIndexedOutput{}
+	if responseAPIStreamNeedsMessageItem(ctx) {
+		indexed = append(indexed, responseAPIIndexedOutput{
+			index: responseAPIMessageOutputIndex(ctx),
+			item:  responseAPIStreamMessageItem(ctx, responseapi.StatusCompleted, text),
+		})
+	}
+	if ctx != nil && ctx.ResponseAPIStreamReasoningStarted {
+		indexed = append(indexed, responseAPIIndexedOutput{
+			index: responseAPIReasoningOutputIndex(ctx),
+			item: map[string]interface{}{
+				"id":      ctx.ResponseAPIStreamReasoningItemID,
+				"type":    "reasoning",
+				"status":  responseapi.StatusCompleted,
+				"summary": []interface{}{},
+			},
+		})
+	}
+	for _, index := range responseAPISortedToolCallIndexes(ctx) {
+		indexed = append(indexed, responseAPIIndexedOutput{
+			index: responseAPIToolCallOutputIndex(ctx, index),
+			item: responseAPIStreamToolCallItem(
+				ctx,
+				index,
+				ctx.StreamingToolCalls[index],
+				responseapi.StatusCompleted,
+			),
+		})
+	}
+	sort.Slice(indexed, func(i, j int) bool { return indexed[i].index < indexed[j].index })
+	output := make([]interface{}, 0, len(indexed))
+	for _, entry := range indexed {
+		output = append(output, entry.item)
+	}
+	return output
+}
+
+type responseAPIIndexedOutput struct {
+	index int
+	item  interface{}
 }
 
 func responseAPIStreamResponse(
@@ -303,7 +639,9 @@ func responseAPIStreamResponse(
 	if status == responseapi.StatusCompleted {
 		response["output_text"] = text
 	}
-	if req.ConversationID != "" {
+	if ctx.ResponseAPICtx.ConversationID != "" {
+		response["conversation_id"] = ctx.ResponseAPICtx.ConversationID
+	} else if req.ConversationID != "" {
 		response["conversation_id"] = req.ConversationID
 	}
 	return response

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api_store.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_response_api_store.go
@@ -1,0 +1,134 @@
+package extproc
+
+import (
+	"sort"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+)
+
+func (r *OpenAIRouter) maybeStoreResponseAPIStreamingResponse(ctx *RequestContext) {
+	if r == nil || r.ResponseAPIFilter == nil || !isResponseAPIRequest(ctx) {
+		return
+	}
+	response := responseAPIStreamingResponseForStore(ctx)
+	if response == nil {
+		return
+	}
+	r.ResponseAPIFilter.maybeStoreTranslatedResponse(ctx.TraceContext, ctx.ResponseAPICtx, response)
+}
+
+func responseAPIStreamingResponseForStore(ctx *RequestContext) *responseapi.ResponseAPIResponse {
+	if ctx == nil || ctx.ResponseAPICtx == nil || ctx.ResponseAPICtx.OriginalRequest == nil {
+		return nil
+	}
+	req := ctx.ResponseAPICtx.OriginalRequest
+	if ctx.ResponseAPICtx.GeneratedResponseID == "" {
+		ctx.ResponseAPICtx.GeneratedResponseID = responseapi.GenerateResponseID()
+	}
+	if ctx.ResponseAPIStreamCreatedAt == 0 {
+		ctx.ResponseAPIStreamCreatedAt = time.Now().Unix()
+	}
+
+	output, outputText := responseAPIStreamingStoredOutput(ctx)
+	usage := extractStreamingUsage(ctx)
+	resp := &responseapi.ResponseAPIResponse{
+		ID:                 ctx.ResponseAPICtx.GeneratedResponseID,
+		Object:             "response",
+		CreatedAt:          ctx.ResponseAPIStreamCreatedAt,
+		Model:              responseAPIStreamModel(ctx),
+		Status:             responseapi.StatusCompleted,
+		Output:             output,
+		OutputText:         outputText,
+		PreviousResponseID: req.PreviousResponseID,
+		ConversationID:     ctx.ResponseAPICtx.ConversationID,
+		Usage: &responseapi.Usage{
+			InputTokens:  int(usage.PromptTokens),
+			OutputTokens: int(usage.CompletionTokens),
+			TotalTokens:  int(usage.TotalTokens),
+		},
+		Instructions:    req.Instructions,
+		Metadata:        req.Metadata,
+		Temperature:     req.Temperature,
+		TopP:            req.TopP,
+		MaxOutputTokens: req.MaxOutputTokens,
+		Tools:           req.Tools,
+		ToolChoice:      req.ToolChoice,
+	}
+	if resp.ConversationID == "" {
+		resp.ConversationID = req.ConversationID
+	}
+	if ctx.StreamingReasoning != "" {
+		resp.Reasoning = &responseapi.Reasoning{
+			EncryptedContent: ctx.StreamingReasoning,
+		}
+	}
+	return resp
+}
+
+func responseAPIStreamingStoredOutput(ctx *RequestContext) ([]responseapi.OutputItem, string) {
+	if ctx == nil {
+		return nil, ""
+	}
+	indexed := []responseAPIIndexedStoredOutput{}
+	if responseAPIStreamNeedsMessageItem(ctx) {
+		item := responseapi.OutputItem{
+			Type:   responseapi.ItemTypeMessage,
+			ID:     ctx.ResponseAPIStreamItemID,
+			Role:   responseapi.RoleAssistant,
+			Status: responseapi.StatusCompleted,
+		}
+		if item.ID == "" {
+			item.ID = responseapi.GenerateItemID()
+		}
+		switch {
+		case ctx.StreamingContent != "":
+			item.Content = []responseapi.ContentPart{{
+				Type:        responseapi.ContentTypeOutputText,
+				Text:        ctx.StreamingContent,
+				Annotations: []responseapi.Annotation{},
+			}}
+		case ctx.StreamingRefusal != "":
+			item.Content = []responseapi.ContentPart{{
+				Type: "refusal",
+				Text: ctx.StreamingRefusal,
+			}}
+		}
+		indexed = append(indexed, responseAPIIndexedStoredOutput{
+			index: responseAPIMessageOutputIndex(ctx),
+			item:  item,
+		})
+	}
+	for _, index := range responseAPISortedToolCallIndexes(ctx) {
+		state := ctx.StreamingToolCalls[index]
+		indexed = append(indexed, responseAPIIndexedStoredOutput{
+			index: responseAPIToolCallOutputIndex(ctx, index),
+			item: responseapi.OutputItem{
+				Type:      responseapi.ItemTypeFunctionCall,
+				ID:        responseAPIStoredToolCallItemID(ctx, index),
+				CallID:    responseAPIToolCallID(state),
+				Name:      responseAPIToolCallName(state),
+				Arguments: responseAPIToolCallArguments(state),
+				Status:    responseapi.StatusCompleted,
+			},
+		})
+	}
+	sort.Slice(indexed, func(i, j int) bool { return indexed[i].index < indexed[j].index })
+	output := make([]responseapi.OutputItem, 0, len(indexed))
+	for _, entry := range indexed {
+		output = append(output, entry.item)
+	}
+	return output, ctx.StreamingContent
+}
+
+type responseAPIIndexedStoredOutput struct {
+	index int
+	item  responseapi.OutputItem
+}
+
+func responseAPIStoredToolCallItemID(ctx *RequestContext, index int) string {
+	if ctx.ResponseAPIStreamToolCallItemIDs != nil && ctx.ResponseAPIStreamToolCallItemIDs[index] != "" {
+		return ctx.ResponseAPIStreamToolCallItemIDs[index]
+	}
+	return responseapi.GenerateItemID()
+}

--- a/src/semantic-router/pkg/extproc/processor_res_header.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header.go
@@ -25,5 +25,8 @@ func (r *OpenAIRouter) handleResponseHeaders(v *ext_proc.ProcessingRequest_Respo
 	r.observeRouterLearningProviderStatus(ctx, outcome.statusCode)
 
 	headerMutation := buildResponseHeaderMutation(ctx, outcome.isSuccessful)
+	if outcome.isSuccessful && isResponseAPIStreamRequest(ctx) {
+		headerMutation = mergeHeaderMutations(headerMutation, responseAPIStreamingHeaderMutation())
+	}
 	return buildResponseHeadersContinueResponse(headerMutation, ctx != nil && ctx.IsStreamingResponse), nil
 }

--- a/src/semantic-router/pkg/extproc/processor_res_header_runtime.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_runtime.go
@@ -47,12 +47,12 @@ func evaluateResponseHeaderOutcome(
 		return outcome
 	}
 
-	if ctx != nil {
-		ctx.IsStreamingResponse = isStreamingContentType(v.ResponseHeaders.Headers)
-	}
-
 	outcome.statusCode = getStatusFromHeaders(v.ResponseHeaders.Headers)
 	outcome.isSuccessful = outcome.statusCode >= 200 && outcome.statusCode < 300
+	if ctx != nil {
+		ctx.IsStreamingResponse = isStreamingContentType(v.ResponseHeaders.Headers) ||
+			(outcome.isSuccessful && isResponseAPIStreamRequest(ctx))
+	}
 	recordResponseHeaderErrorMetrics(ctx, outcome.statusCode)
 	return outcome
 }
@@ -126,6 +126,27 @@ func buildResponseHeadersContinueResponse(
 		}
 	}
 	return response
+}
+
+func isResponseAPIStreamRequest(ctx *RequestContext) bool {
+	return isResponseAPIRequest(ctx) &&
+		ctx.ResponseAPICtx.OriginalRequest != nil &&
+		ctx.ResponseAPICtx.OriginalRequest.Stream
+}
+
+func mergeHeaderMutations(mutations ...*ext_proc.HeaderMutation) *ext_proc.HeaderMutation {
+	merged := &ext_proc.HeaderMutation{}
+	for _, mutation := range mutations {
+		if mutation == nil {
+			continue
+		}
+		merged.SetHeaders = append(merged.SetHeaders, mutation.GetSetHeaders()...)
+		merged.RemoveHeaders = append(merged.RemoveHeaders, mutation.GetRemoveHeaders()...)
+	}
+	if len(merged.SetHeaders) == 0 && len(merged.RemoveHeaders) == 0 {
+		return nil
+	}
+	return merged
 }
 
 // getStatusFromHeaders extracts :status pseudo-header value as integer.

--- a/src/semantic-router/pkg/extproc/processor_res_header_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_header_test.go
@@ -6,6 +6,8 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	http_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
 )
 
 func TestGetStatusFromHeadersUsesRawValue(t *testing.T) {
@@ -46,6 +48,86 @@ func TestHandleResponseHeadersSetsStreamingModeOverride(t *testing.T) {
 	}
 	if response.ModeOverride.ResponseBodyMode != http_ext.ProcessingMode_STREAMED {
 		t.Fatalf("unexpected response body mode: %v", response.ModeOverride.ResponseBodyMode)
+	}
+}
+
+func TestHandleResponseHeadersUsesResponseAPIStreamRequestFallback(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Stream: true,
+			},
+		},
+	}
+	responseHeaders := &ext_proc.ProcessingRequest_ResponseHeaders{
+		ResponseHeaders: &ext_proc.HttpHeaders{
+			Headers: &core.HeaderMap{
+				Headers: []*core.HeaderValue{
+					{Key: ":status", Value: "200"},
+					{Key: "content-type", Value: ""},
+				},
+			},
+		},
+	}
+
+	response, err := router.handleResponseHeaders(responseHeaders, ctx)
+	if err != nil {
+		t.Fatalf("handleResponseHeaders failed: %v", err)
+	}
+	if !ctx.IsStreamingResponse {
+		t.Fatal("expected stream:true Responses API request to force streaming response mode")
+	}
+	if response.ModeOverride == nil || response.ModeOverride.ResponseBodyMode != http_ext.ProcessingMode_STREAMED {
+		t.Fatalf("expected streamed mode override, got %#v", response.ModeOverride)
+	}
+
+	mutation := response.GetResponseHeaders().Response.GetHeaderMutation()
+	if mutation == nil {
+		t.Fatal("expected response header mutation")
+	}
+	if got := headerValueForTest(mutation, "content-type"); got != "text/event-stream; charset=utf-8" {
+		t.Fatalf("content-type mutation = %q, want text/event-stream; charset=utf-8", got)
+	}
+	if got := headerAppendActionForTest(mutation, "content-type"); got != core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD {
+		t.Fatalf("content-type append action = %v, want OVERWRITE_IF_EXISTS_OR_ADD", got)
+	}
+	if !containsStringForTest(mutation.GetRemoveHeaders(), "content-length") {
+		t.Fatalf("expected content-length removal, got %#v", mutation.GetRemoveHeaders())
+	}
+}
+
+func TestHandleResponseHeadersDoesNotForceResponseAPIStreamForError(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{
+		ResponseAPICtx: &ResponseAPIContext{
+			IsResponseAPIRequest: true,
+			OriginalRequest: &responseapi.ResponseAPIRequest{
+				Stream: true,
+			},
+		},
+	}
+	responseHeaders := &ext_proc.ProcessingRequest_ResponseHeaders{
+		ResponseHeaders: &ext_proc.HttpHeaders{
+			Headers: &core.HeaderMap{
+				Headers: []*core.HeaderValue{
+					{Key: ":status", Value: "400"},
+					{Key: "content-type", Value: "application/json"},
+				},
+			},
+		},
+	}
+
+	response, err := router.handleResponseHeaders(responseHeaders, ctx)
+	if err != nil {
+		t.Fatalf("handleResponseHeaders failed: %v", err)
+	}
+	if ctx.IsStreamingResponse {
+		t.Fatal("did not expect error JSON response to be forced into streaming mode")
+	}
+	if response.ModeOverride != nil {
+		t.Fatalf("did not expect mode override, got %#v", response.ModeOverride)
 	}
 }
 
@@ -98,4 +180,34 @@ func TestHandleResponseHeadersLooperUsesContinueResponse(t *testing.T) {
 	if response.ModeOverride != nil {
 		t.Fatal("did not expect mode override for looper response headers")
 	}
+}
+
+func headerValueForTest(mutation *ext_proc.HeaderMutation, key string) string {
+	for _, header := range mutation.GetSetHeaders() {
+		if header.GetHeader().GetKey() == key {
+			return extractHeaderValue(header.GetHeader())
+		}
+	}
+	return ""
+}
+
+func headerAppendActionForTest(
+	mutation *ext_proc.HeaderMutation,
+	key string,
+) core.HeaderValueOption_HeaderAppendAction {
+	for _, header := range mutation.GetSetHeaders() {
+		if header.GetHeader().GetKey() == key {
+			return header.GetAppendAction()
+		}
+	}
+	return core.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD
+}
+
+func containsStringForTest(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/src/semantic-router/pkg/extproc/req_filter_cache.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache.go
@@ -53,7 +53,7 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext, categoryName string) (
 		return r.handleLooperCacheSkip(ctx, categoryName)
 	}
 
-	requestModel, requestQuery, err := cache.ExtractQueryFromOpenAIRequest(ctx.OriginalRequestBody)
+	requestModel, requestQuery, err := cache.ExtractQueryFromOpenAIRequest(cacheRequestBodyForContext(ctx))
 	if err != nil {
 		logging.Errorf("Error extracting query from request: %v", err)
 		return nil, false
@@ -79,7 +79,7 @@ func (r *OpenAIRouter) handleCaching(ctx *RequestContext, categoryName string) (
 func (r *OpenAIRouter) handleLooperCacheSkip(ctx *RequestContext, categoryName string) (*ext_proc.ProcessingResponse, bool) {
 	logging.Debugf("[Cache] Skipping cache read for looper internal request")
 
-	requestModel, requestQuery, err := cache.ExtractQueryFromOpenAIRequest(ctx.OriginalRequestBody)
+	requestModel, requestQuery, err := cache.ExtractQueryFromOpenAIRequest(cacheRequestBodyForContext(ctx))
 	if err != nil {
 		logging.Errorf("Error extracting query from request: %v", err)
 		return nil, false
@@ -164,7 +164,7 @@ func (r *OpenAIRouter) performCacheLookup(
 		// Intermediate cache detail (category, matched keywords, similarity) is
 		// demoted to the x-vsr-debug surface (#2205).
 		cacheCategory, cacheKeywords, cacheSimilarity := cacheDetailForSurface(ctx, categoryName)
-		response := http.CreateCacheHitResponse(cachedResponse, ctx.ExpectStreamingResponse, cacheCategory, ctx.VSRSelectedDecisionName, cacheKeywords, cacheSimilarity)
+		response := r.createCacheHitResponse(ctx, cachedResponse, cacheCategory, ctx.VSRSelectedDecisionName, cacheKeywords, cacheSimilarity)
 		r.updateRouterReplayStatus(ctx, 200, ctx.ExpectStreamingResponse)
 		r.attachRouterReplayResponse(ctx, cachedResponse, true)
 		ctx.TraceContext = spanCtx
@@ -177,6 +177,48 @@ func (r *OpenAIRouter) performCacheLookup(
 	ctx.TraceContext = spanCtx
 
 	return nil, false
+}
+
+func (r *OpenAIRouter) createCacheHitResponse(
+	ctx *RequestContext,
+	cachedResponse []byte,
+	category string,
+	decisionName string,
+	matchedKeywords []string,
+	similarity float32,
+) *ext_proc.ProcessingResponse {
+	response := http.CreateCacheHitResponse(
+		cachedResponse,
+		ctx.ExpectStreamingResponse,
+		category,
+		decisionName,
+		matchedKeywords,
+		similarity,
+	)
+	if !isResponseAPIRequest(ctx) {
+		return response
+	}
+	if responseAPIResponse, ok := r.createResponseAPICacheHitResponse(
+		ctx,
+		cachedResponse,
+		category,
+		decisionName,
+		matchedKeywords,
+		similarity,
+	); ok {
+		return responseAPIResponse
+	}
+	return response
+}
+
+func cacheRequestBodyForContext(ctx *RequestContext) []byte {
+	if ctx != nil && ctx.ResponseAPICtx != nil && len(ctx.ResponseAPICtx.TranslatedBody) > 0 {
+		return ctx.ResponseAPICtx.TranslatedBody
+	}
+	if ctx != nil {
+		return ctx.OriginalRequestBody
+	}
+	return nil
 }
 
 func cacheQueryForContext(ctx *RequestContext) string {

--- a/src/semantic-router/pkg/extproc/req_filter_response_api_immediate.go
+++ b/src/semantic-router/pkg/extproc/req_filter_response_api_immediate.go
@@ -1,0 +1,341 @@
+package extproc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+)
+
+func (r *OpenAIRouter) createResponseAPICacheHitResponse(
+	ctx *RequestContext,
+	cachedResponse []byte,
+	category string,
+	decisionName string,
+	matchedKeywords []string,
+	similarity float32,
+) (*ext_proc.ProcessingResponse, bool) {
+	resp, ok := r.responseAPIResponseFromChatCompletion(ctx, cachedResponse)
+	if !ok {
+		return nil, false
+	}
+
+	var procResp *ext_proc.ProcessingResponse
+	if ctx.ExpectStreamingResponse {
+		procResp = r.createSSEResponseWithBody(200, responseAPIStreamingSSEFromResponse(resp), headers.ResponsePathCache)
+	} else {
+		body, err := json.Marshal(resp)
+		if err != nil {
+			return nil, false
+		}
+		procResp = r.createJSONResponseWithBody(200, body, headers.ResponsePathCache)
+	}
+	appendResponseAPIImmediateHeaders(procResp, responseAPICacheHitHeaders(category, decisionName, matchedKeywords, similarity)...)
+	return procResp, true
+}
+
+func (r *OpenAIRouter) createResponseAPIFastResponse(
+	ctx *RequestContext,
+	message string,
+	decisionName string,
+) (*ext_proc.ProcessingResponse, bool) {
+	resp, ok := r.responseAPIResponseFromChatCompletion(ctx, responseAPIChatCompletionFastBody(message))
+	if !ok {
+		return nil, false
+	}
+
+	var procResp *ext_proc.ProcessingResponse
+	if ctx.ExpectStreamingResponse {
+		procResp = r.createSSEResponseWithBody(200, responseAPIStreamingSSEFromResponse(resp), headers.ResponsePathFastResponse)
+	} else {
+		body, err := json.Marshal(resp)
+		if err != nil {
+			return nil, false
+		}
+		procResp = r.createJSONResponseWithBody(200, body, headers.ResponsePathFastResponse)
+	}
+	appendResponseAPIImmediateHeaders(procResp, responseAPIFastResponseHeaders(decisionName)...)
+	return procResp, true
+}
+
+func (r *OpenAIRouter) responseAPIResponseFromChatCompletion(
+	ctx *RequestContext,
+	body []byte,
+) (*responseapi.ResponseAPIResponse, bool) {
+	if r == nil || r.ResponseAPIFilter == nil || ctx == nil || ctx.ResponseAPICtx == nil {
+		return nil, false
+	}
+	translatedBody, err := r.ResponseAPIFilter.TranslateResponse(ctx.TraceContext, ctx.ResponseAPICtx, body)
+	if err != nil {
+		return nil, false
+	}
+	var resp responseapi.ResponseAPIResponse
+	if err := json.Unmarshal(translatedBody, &resp); err != nil || resp.ID == "" {
+		return nil, false
+	}
+	return &resp, true
+}
+
+func responseAPIChatCompletionFastBody(message string) []byte {
+	now := time.Now().Unix()
+	body := map[string]interface{}{
+		"id":      fmt.Sprintf("chatcmpl-fast-%d", now),
+		"object":  "chat.completion",
+		"created": now,
+		"model":   "router",
+		"choices": []map[string]interface{}{{
+			"index": 0,
+			"message": map[string]interface{}{
+				"role":    "assistant",
+				"content": message,
+			},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]interface{}{
+			"prompt_tokens":     0,
+			"completion_tokens": 0,
+			"total_tokens":      0,
+		},
+	}
+	encoded, _ := json.Marshal(body)
+	return encoded
+}
+
+func responseAPIStreamingSSEFromResponse(resp *responseapi.ResponseAPIResponse) []byte {
+	if resp == nil {
+		return nil
+	}
+	var out bytes.Buffer
+	startedResponse := responseAPIResponseEventMap(resp, responseapi.StatusInProgress, nil, "")
+	writeResponseAPIStreamEvent(&out, "response.created", map[string]interface{}{
+		"type":     "response.created",
+		"response": startedResponse,
+	})
+	writeResponseAPIStreamEvent(&out, "response.in_progress", map[string]interface{}{
+		"type":     "response.in_progress",
+		"response": startedResponse,
+	})
+
+	for outputIndex, item := range resp.Output {
+		responseAPIWriteImmediateOutputItemEvents(&out, outputIndex, item)
+	}
+
+	writeResponseAPIStreamEvent(&out, "response.completed", map[string]interface{}{
+		"type":     "response.completed",
+		"response": responseAPIResponseEventMap(resp, responseapi.StatusCompleted, resp.Output, resp.OutputText),
+	})
+	return out.Bytes()
+}
+
+func responseAPIWriteImmediateOutputItemEvents(out *bytes.Buffer, outputIndex int, item responseapi.OutputItem) {
+	inProgressItem := responseAPIOutputItemEventMap(item, responseapi.StatusInProgress)
+	writeResponseAPIStreamEvent(out, "response.output_item.added", map[string]interface{}{
+		"type":         "response.output_item.added",
+		"output_index": outputIndex,
+		"item":         inProgressItem,
+	})
+
+	switch item.Type {
+	case responseapi.ItemTypeFunctionCall:
+		if item.Arguments != "" {
+			writeResponseAPIStreamEvent(out, "response.function_call_arguments.delta", map[string]interface{}{
+				"type":         "response.function_call_arguments.delta",
+				"item_id":      item.ID,
+				"output_index": outputIndex,
+				"delta":        item.Arguments,
+			})
+		}
+		writeResponseAPIStreamEvent(out, "response.function_call_arguments.done", map[string]interface{}{
+			"type":         "response.function_call_arguments.done",
+			"item_id":      item.ID,
+			"output_index": outputIndex,
+			"arguments":    item.Arguments,
+		})
+	default:
+		responseAPIWriteImmediateMessageEvents(out, outputIndex, item)
+	}
+
+	writeResponseAPIStreamEvent(out, "response.output_item.done", map[string]interface{}{
+		"type":         "response.output_item.done",
+		"output_index": outputIndex,
+		"item":         responseAPIOutputItemEventMap(item, responseapi.StatusCompleted),
+	})
+}
+
+func responseAPIWriteImmediateMessageEvents(out *bytes.Buffer, outputIndex int, item responseapi.OutputItem) {
+	for contentIndex, part := range item.Content {
+		partMap := responseAPIContentPartEventMap(part)
+		writeResponseAPIStreamEvent(out, "response.content_part.added", map[string]interface{}{
+			"type":          "response.content_part.added",
+			"item_id":       item.ID,
+			"output_index":  outputIndex,
+			"content_index": contentIndex,
+			"part":          responseAPIEmptyContentPartEventMap(part),
+		})
+		switch part.Type {
+		case "refusal":
+			if part.Text != "" {
+				writeResponseAPIStreamEvent(out, "response.refusal.delta", map[string]interface{}{
+					"type":          "response.refusal.delta",
+					"item_id":       item.ID,
+					"output_index":  outputIndex,
+					"content_index": contentIndex,
+					"delta":         part.Text,
+				})
+			}
+			writeResponseAPIStreamEvent(out, "response.refusal.done", map[string]interface{}{
+				"type":          "response.refusal.done",
+				"item_id":       item.ID,
+				"output_index":  outputIndex,
+				"content_index": contentIndex,
+				"refusal":       part.Text,
+			})
+		default:
+			if part.Text != "" {
+				writeResponseAPIStreamEvent(out, "response.output_text.delta", map[string]interface{}{
+					"type":          "response.output_text.delta",
+					"item_id":       item.ID,
+					"output_index":  outputIndex,
+					"content_index": contentIndex,
+					"delta":         part.Text,
+				})
+			}
+			writeResponseAPIStreamEvent(out, "response.output_text.done", map[string]interface{}{
+				"type":          "response.output_text.done",
+				"item_id":       item.ID,
+				"output_index":  outputIndex,
+				"content_index": contentIndex,
+				"text":          part.Text,
+			})
+		}
+		writeResponseAPIStreamEvent(out, "response.content_part.done", map[string]interface{}{
+			"type":          "response.content_part.done",
+			"item_id":       item.ID,
+			"output_index":  outputIndex,
+			"content_index": contentIndex,
+			"part":          partMap,
+		})
+	}
+}
+
+func responseAPIResponseEventMap(
+	resp *responseapi.ResponseAPIResponse,
+	status string,
+	output []responseapi.OutputItem,
+	outputText string,
+) map[string]interface{} {
+	body := responseAPIMarshalMap(resp)
+	body["status"] = status
+	if output == nil {
+		body["output"] = []interface{}{}
+	} else {
+		body["output"] = output
+	}
+	if status == responseapi.StatusCompleted {
+		body["output_text"] = outputText
+	} else {
+		delete(body, "output_text")
+	}
+	return body
+}
+
+func responseAPIOutputItemEventMap(item responseapi.OutputItem, status string) map[string]interface{} {
+	body := responseAPIMarshalMap(item)
+	body["status"] = status
+	if item.Type == responseapi.ItemTypeMessage && status == responseapi.StatusInProgress {
+		body["content"] = []interface{}{}
+	}
+	return body
+}
+
+func responseAPIContentPartEventMap(part responseapi.ContentPart) map[string]interface{} {
+	body := responseAPIMarshalMap(part)
+	if part.Type == responseapi.ContentTypeOutputText {
+		body["annotations"] = []interface{}{}
+	}
+	if part.Type == "refusal" && part.Text != "" {
+		body["refusal"] = part.Text
+		delete(body, "text")
+	}
+	return body
+}
+
+func responseAPIEmptyContentPartEventMap(part responseapi.ContentPart) map[string]interface{} {
+	if part.Type == "refusal" {
+		return map[string]interface{}{"type": "refusal", "refusal": ""}
+	}
+	return map[string]interface{}{
+		"type":        responseapi.ContentTypeOutputText,
+		"text":        "",
+		"annotations": []interface{}{},
+	}
+}
+
+func responseAPIMarshalMap(v interface{}) map[string]interface{} {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return map[string]interface{}{}
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return map[string]interface{}{}
+	}
+	return out
+}
+
+func appendResponseAPIImmediateHeaders(procResp *ext_proc.ProcessingResponse, extra ...*core.HeaderValueOption) {
+	if procResp == nil || procResp.GetImmediateResponse() == nil {
+		return
+	}
+	headers := procResp.GetImmediateResponse().Headers
+	if headers == nil {
+		headers = &ext_proc.HeaderMutation{}
+		procResp.GetImmediateResponse().Headers = headers
+	}
+	headers.SetHeaders = append(headers.SetHeaders, extra...)
+}
+
+func responseAPICacheHitHeaders(
+	category string,
+	decisionName string,
+	matchedKeywords []string,
+	similarity float32,
+) []*core.HeaderValueOption {
+	setHeaders := []*core.HeaderValueOption{
+		rawHeaderOption(headers.VSRCacheHit, "true"),
+		rawHeaderOption(headers.VSRSelectedDecision, decisionName),
+	}
+	if category != "" {
+		setHeaders = append(setHeaders, rawHeaderOption(headers.VSRSelectedCategory, category))
+	}
+	if similarity > 0 {
+		setHeaders = append(setHeaders, rawHeaderOption("x-vsr-cache-similarity", fmt.Sprintf("%.4f", similarity)))
+	}
+	if len(matchedKeywords) > 0 {
+		setHeaders = append(setHeaders, rawHeaderOption(headers.VSRMatchedKeywords, strings.Join(matchedKeywords, ",")))
+	}
+	return setHeaders
+}
+
+func responseAPIFastResponseHeaders(decisionName string) []*core.HeaderValueOption {
+	return []*core.HeaderValueOption{
+		rawHeaderOption(headers.VSRSelectedDecision, decisionName),
+		rawHeaderOption(headers.VSRFastResponse, "true"),
+	}
+}
+
+func rawHeaderOption(key string, value string) *core.HeaderValueOption {
+	return &core.HeaderValueOption{
+		Header: &core.HeaderValue{
+			Key:      key,
+			RawValue: []byte(value),
+		},
+	}
+}

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -82,6 +82,7 @@ type RequestContext struct {
 	HasStreamingChunks bool                            // True when at least one SSE chunk has been received
 	StreamingContent   string                          // Accumulated content from delta.content
 	StreamingReasoning string                          // Accumulated reasoning from delta.reasoning_content
+	StreamingRefusal   string                          // Accumulated refusal text from delta.refusal
 	StreamingMetadata  map[string]interface{}          // id, model, created from first chunk
 	StreamingToolCalls map[int]*StreamingToolCallState // Accumulated delta.tool_calls keyed by tool index
 	StreamingComplete  bool                            // True when [DONE] marker received
@@ -90,9 +91,18 @@ type RequestContext struct {
 	// Response API streaming translation state. When /v1/responses is backed by
 	// an upstream Chat Completions stream, these fields track the outbound
 	// Responses API event envelope emitted to the client.
-	ResponseAPIStreamStarted   bool
-	ResponseAPIStreamItemID    string
-	ResponseAPIStreamCreatedAt int64
+	ResponseAPIStreamStarted              bool
+	ResponseAPIStreamMessageStarted       bool
+	ResponseAPIStreamNextOutputIndex      int
+	ResponseAPIStreamMessageOutputIndex   int
+	ResponseAPIStreamItemID               string
+	ResponseAPIStreamToolCallItemIDs      map[int]string
+	ResponseAPIStreamToolCallOutputIndex  map[int]int
+	ResponseAPIStreamReasoningItemID      string
+	ResponseAPIStreamReasoningOutputIndex int
+	ResponseAPIStreamReasoningStarted     bool
+	ResponseAPIStreamRefusalStarted       bool
+	ResponseAPIStreamCreatedAt            int64
 
 	// UpstreamStatusCode is the HTTP status the upstream returned, captured at
 	// the response-header phase. Zero means the status was never observed for

--- a/src/semantic-router/pkg/extproc/response_api_streaming_repro_test.go
+++ b/src/semantic-router/pkg/extproc/response_api_streaming_repro_test.go
@@ -128,6 +128,127 @@ func TestResponseAPIStreamingResponseBuffersSplitChatCompletionSSE(t *testing.T)
 	require.NotContains(t, secondWire, "chat.completion.chunk")
 }
 
+func TestResponseAPIStreamingResponseTranslatesToolCalls(t *testing.T) {
+	store := NewMockResponseStore()
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(store),
+	}
+	ctx := newResponseAPIStreamingTestContext("response-api-stream-tools")
+	ctx.ResponseAPICtx.OriginalRequest.PreviousResponseID = "resp_previous"
+	chunk := []byte(`data: {"id":"chatcmpl-tools","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_weather","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]},"finish_reason":null}]}` + "\n\n")
+
+	resp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: chunk},
+	}, ctx)
+	require.NoError(t, err)
+
+	wire := string(resp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	require.Contains(t, wire, "response.output_item.added")
+	require.Contains(t, wire, "response.function_call_arguments.delta")
+	require.Contains(t, wire, "call_weather")
+	require.NotContains(t, wire, "chat.completion.chunk")
+
+	finalChunk := []byte(`data: {"id":"chatcmpl-tools","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}` + "\n\n" + `data: [DONE]` + "\n\n")
+	finalResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: finalChunk},
+	}, ctx)
+	require.NoError(t, err)
+
+	finalWire := string(finalResp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	require.Contains(t, finalWire, "response.function_call_arguments.done")
+	require.Contains(t, finalWire, "response.output_item.done")
+	require.Contains(t, finalWire, "response.completed")
+	require.Contains(t, finalWire, `"type":"function_call"`)
+	require.Contains(t, finalWire, `"arguments":"{\"city\":\"Paris\"}"`)
+	require.NotContains(t, finalWire, "data: [DONE]")
+
+	stored, err := store.GetResponse(context.Background(), ctx.ResponseAPICtx.GeneratedResponseID)
+	require.NoError(t, err)
+	require.Len(t, stored.Output, 1)
+	require.Equal(t, "resp_previous", stored.PreviousResponseID)
+	require.Equal(t, responseapi.ItemTypeFunctionCall, stored.Output[0].Type)
+	require.Equal(t, "call_weather", stored.Output[0].CallID)
+}
+
+func TestResponseAPIStreamingResponseTranslatesRefusalAndReasoning(t *testing.T) {
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(NewMockResponseStore()),
+	}
+	ctx := newResponseAPIStreamingTestContext("response-api-stream-non-text")
+	chunk := []byte(`data: {"id":"chatcmpl-refusal","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{"reasoning_content":"checking policy","refusal":"I can't help with that"},"finish_reason":null}]}` + "\n\n")
+
+	resp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: chunk},
+	}, ctx)
+	require.NoError(t, err)
+
+	wire := string(resp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	require.Contains(t, wire, "response.reasoning_text.delta")
+	require.Contains(t, wire, "response.refusal.delta")
+	require.NotContains(t, wire, "chat.completion.chunk")
+
+	finalChunk := []byte(`data: {"id":"chatcmpl-refusal","object":"chat.completion.chunk","created":123,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n" + `data: [DONE]` + "\n\n")
+	finalResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: finalChunk},
+	}, ctx)
+	require.NoError(t, err)
+
+	finalWire := string(finalResp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	require.Contains(t, finalWire, "response.reasoning_text.done")
+	require.Contains(t, finalWire, "response.refusal.done")
+	require.Contains(t, finalWire, "response.completed")
+	require.NotContains(t, finalWire, "data: [DONE]")
+}
+
+func TestResponseAPIStreamingCacheHitUsesResponsesSSE(t *testing.T) {
+	store := NewMockResponseStore()
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(store),
+	}
+	ctx := newResponseAPIStreamingTestContext("response-api-cache-hit")
+	cached := []byte(`{"id":"chatcmpl-cache","object":"chat.completion","created":123,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"cached answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`)
+
+	resp, ok := router.createResponseAPICacheHitResponse(ctx, cached, "math", "math_decision", nil, 0)
+	require.True(t, ok)
+	require.NotNil(t, resp.GetImmediateResponse())
+
+	wire := string(resp.GetImmediateResponse().Body)
+	require.Contains(t, wire, "event: response.created")
+	require.Contains(t, wire, "event: response.output_text.delta")
+	require.Contains(t, wire, "event: response.completed")
+	require.Contains(t, wire, "cached answer")
+	require.NotContains(t, wire, "chat.completion.chunk")
+	require.NotContains(t, wire, "data: [DONE]")
+	require.Equal(t, "text/event-stream; charset=utf-8", immediateHeaderValue(resp, "content-type"))
+	require.Equal(t, "true", immediateHeaderValue(resp, "x-vsr-cache-hit"))
+
+	_, err := store.GetResponse(context.Background(), ctx.ResponseAPICtx.GeneratedResponseID)
+	require.NoError(t, err)
+}
+
+func TestResponseAPIStreamingFastResponseUsesResponsesSSE(t *testing.T) {
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(NewMockResponseStore()),
+	}
+	ctx := newResponseAPIStreamingTestContext("response-api-fast-response")
+
+	resp, ok := router.createResponseAPIFastResponse(ctx, "blocked by policy", "guard_decision")
+	require.True(t, ok)
+	require.NotNil(t, resp.GetImmediateResponse())
+
+	wire := string(resp.GetImmediateResponse().Body)
+	require.Contains(t, wire, "event: response.output_text.delta")
+	require.Contains(t, wire, "blocked by policy")
+	require.NotContains(t, wire, "chat.completion.chunk")
+	require.NotContains(t, wire, "data: [DONE]")
+	require.Equal(t, "text/event-stream; charset=utf-8", immediateHeaderValue(resp, "content-type"))
+	require.Equal(t, "true", immediateHeaderValue(resp, "x-vsr-fast-response"))
+}
+
 func responseAPIStreamingEventPayload(t *testing.T, wire string, event string) map[string]interface{} {
 	t.Helper()
 
@@ -147,6 +268,21 @@ func responseAPIStreamingEventPayload(t *testing.T, wire string, event string) m
 
 	require.Failf(t, "missing event", "event %q not found in stream: %s", event, wire)
 	return nil
+}
+
+func immediateHeaderValue(resp *ext_proc.ProcessingResponse, key string) string {
+	if resp == nil || resp.GetImmediateResponse() == nil || resp.GetImmediateResponse().Headers == nil {
+		return ""
+	}
+	for _, header := range resp.GetImmediateResponse().Headers.SetHeaders {
+		if strings.EqualFold(header.Header.Key, key) {
+			if len(header.Header.RawValue) > 0 {
+				return string(header.Header.RawValue)
+			}
+			return header.Header.Value
+		}
+	}
+	return ""
 }
 
 func newResponseAPIStreamingTestContext(requestID string) *RequestContext {


### PR DESCRIPTION
## Summary

Fixes #2492.
Refs #2358, #2446.
Follow-up to #2438.

This PR hardens `/v1/responses` `stream:true` protocol parity at the router edge. It keeps successful Responses API streaming responses in Responses API SSE shape, including text, reasoning, refusal, tool-call argument streaming, store/context, cache-hit, and fast-response paths.

It also fixes a real data-plane edge case where a pure tool-call streaming response could translate the body correctly but leave the response `content-type` empty when the upstream header was absent.

## Changes

- Treat successful Responses API `stream:true` requests as streaming during response-header processing even when upstream `content-type` is blank.
- Merge Responses API streaming header mutations into the response-header phase.
- Force `content-type: text/event-stream; charset=utf-8` for successful Responses API stream responses and remove stale `content-length`.
- Keep error responses from being forced into SSE mode.
- Add targeted regression coverage for the successful stream fallback and error-response behavior.

## Validation

- `gofmt` on touched Go files.
- `git diff --check`.
- Targeted extproc tests:

```bash
CGO_ENABLED=1 LD_LIBRARY_PATH='../../candle-binding/target/release:../../ml-binding/target/release:../../nlp-binding/target/release' go test ./pkg/extproc -run 'TestHandleResponseHeaders(SetsStreamingModeOverride|UsesResponseAPIStreamRequestFallback|DoesNotForceResponseAPIStreamForError|CapturesUpstreamStatus|LooperUsesContinueResponse)'
```

- Built local CPU router image with repo Make target.
- Ran `vllm-sr serve --minimal` with the CPU image.
- Validated against a real OpenAI-compatible backend through the local Envoy/router data plane:
  - text streaming;
  - reasoning streaming;
  - forced tool-call argument streaming;
  - `store:true` streaming persistence;
  - `previous_response_id` follow-up continuity;
  - no raw `chat.completion.chunk` or `data: [DONE]` leaked to Responses API clients;
  - successful tool-call stream returned `content-type: text/event-stream; charset=utf-8`.
- Checked Docker logs after validation; no fatal/panic/error/upstream 5xx observed.