### PR TITLE
[Website] fix footer link hover color to stay legible on the dark footer

### DIFF
--- a/website/src/css/shell.css
+++ b/website/src/css/shell.css
@@ -213,6 +213,7 @@ html[data-route-kind="blog"] .nav-docs-only {
 }
 
 .footer__link-item:hover {
+  color: #ffffff;
   opacity: 1;
 }
 


### PR DESCRIPTION
Closes #2501

## Summary

Footer links became near-invisible on hover. The footer background is hard-coded dark (`.footer { background: #050505 }`), but `.footer__link-item:hover` only set `opacity: 1` and left `color` to fall through to Infima's `--ifm-footer-link-hover-color` → `--ifm-color-primary`, which `tokens.css` sets to `#111111` in light mode. So on hover a link rendered near-black text on the near-black footer.

This pins a light hover color so links stay legible while keeping the brighten-on-hover affordance. The footer is always dark in both themes, so `#ffffff` is correct regardless of light/dark mode.

```diff
 .footer__link-item:hover {
+  color: #ffffff;
   opacity: 1;
 }
```

## Test Plan

- Netlify deploy preview: scroll to the footer, hover any link (Documentation, Quick Start, … License) — text stays clearly legible (white on the dark footer) in both light and dark mode.
- Contrast check: hover was `#111111` on `#050505` (~1.05:1, effectively invisible); now `#ffffff` on `#050505` (~20.6:1, WCAG AAA).
