### PR TITLE
[CLI] Contain runtime state files under owned directory

### DIFF
--- a/src/vllm-sr/cli/commands/runtime_paths.py
+++ b/src/vllm-sr/cli/commands/runtime_paths.py
@@ -3,25 +3,77 @@
 from __future__ import annotations
 
 import os
+import tempfile
+from contextlib import suppress
 from pathlib import Path
 
 import yaml
+
+from cli.consts import DEFAULT_STACK_NAME
+from cli.runtime_stack import STACK_NAME_ENV, normalize_stack_name
+
+DEFAULT_FILENAME_COMPONENT_LIMIT = 255
+
+
+def _assert_direct_child(runtime_dir: Path, candidate: Path) -> None:
+    """Fail closed unless candidate is a direct child of the owned directory."""
+    if runtime_dir.is_symlink():
+        raise ValueError(
+            f"Runtime state directory must not be a symbolic link: {runtime_dir}"
+        )
+    if candidate.parent != runtime_dir:
+        raise ValueError(
+            f"Runtime state path must be a direct child of {runtime_dir}: {candidate}"
+        )
+    if candidate.is_symlink():
+        raise ValueError(f"Runtime state file must not be a symbolic link: {candidate}")
+    if candidate.parent.resolve(strict=True) != runtime_dir.resolve(strict=True):
+        raise ValueError(
+            f"Runtime state path escapes the owned directory {runtime_dir}: {candidate}"
+        )
+
+
+def _assert_filename_fits(runtime_dir: Path, filename: str) -> None:
+    try:
+        component_limit = os.pathconf(runtime_dir, "PC_NAME_MAX")
+    except (AttributeError, OSError, ValueError):
+        component_limit = DEFAULT_FILENAME_COMPONENT_LIMIT
+    if component_limit <= 0:
+        component_limit = DEFAULT_FILENAME_COMPONENT_LIMIT
+    encoded_length = len(os.fsencode(filename))
+    if encoded_length > component_limit:
+        raise ValueError(
+            f"Runtime state filename exceeds the {component_limit}-byte filesystem "
+            f"limit after stack-name normalization: {encoded_length} bytes"
+        )
 
 
 def _runtime_config_output_dir(config_path: Path) -> Path:
     state_root = os.getenv("VLLM_SR_STATE_ROOT_DIR", "").strip()
     base_dir = Path(state_root).expanduser() if state_root else config_path.parent
     runtime_dir = base_dir / ".vllm-sr"
+    if runtime_dir.is_symlink():
+        raise ValueError(
+            f"Runtime state directory must not be a symbolic link: {runtime_dir}"
+        )
     runtime_dir.mkdir(parents=True, exist_ok=True)
+    if runtime_dir.is_symlink() or not runtime_dir.is_dir():
+        raise ValueError(
+            f"Runtime state directory is not an owned directory: {runtime_dir}"
+        )
     return runtime_dir
 
 
 def _runtime_config_output_path(source_config_path: Path) -> Path:
-    stack_name = os.getenv("VLLM_SR_STACK_NAME", "").strip()
+    stack_name = normalize_stack_name(os.getenv(STACK_NAME_ENV))
     filename = "runtime-config.yaml"
-    if stack_name:
+    if stack_name != DEFAULT_STACK_NAME:
         filename = f"runtime-config.{stack_name}.yaml"
-    return _runtime_config_output_dir(source_config_path) / filename
+    runtime_dir = _runtime_config_output_dir(source_config_path)
+    _assert_filename_fits(runtime_dir, filename)
+    output_path = runtime_dir / filename
+    _assert_direct_child(runtime_dir, output_path)
+    return output_path
 
 
 def _container_runtime_config_path(source_config_path: Path) -> str:
@@ -34,6 +86,24 @@ def _container_source_config_path() -> str:
 
 def _write_runtime_config(source_config_path: Path, config: dict[str, object]) -> Path:
     runtime_config_path = _runtime_config_output_path(source_config_path)
-    with runtime_config_path.open("w") as handle:
-        yaml.dump(config, handle, default_flow_style=False, sort_keys=False)
+    runtime_dir = runtime_config_path.parent
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{runtime_config_path.name}.", suffix=".tmp", dir=runtime_dir
+    )
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with handle:
+            yaml.dump(config, handle, default_flow_style=False, sort_keys=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _assert_direct_child(runtime_dir, runtime_config_path)
+        os.replace(temp_path, runtime_config_path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        with suppress(FileNotFoundError):
+            temp_path.unlink()
     return runtime_config_path

--- a/src/vllm-sr/cli/runtime_stack.py
+++ b/src/vllm-sr/cli/runtime_stack.py
@@ -234,11 +234,22 @@ def resolve_runtime_stack(
 
 
 def normalize_stack_name(raw_value: str | None) -> str:
+    """Return the one stack identity shared by every local runtime namespace.
+
+    Missing or blank input selects the default stack. Distinct raw inputs that
+    normalize to the same value intentionally alias one stack; a nonblank value
+    with no usable ASCII identity fails instead of silently selecting default.
+    """
     if raw_value is None:
         return DEFAULT_STACK_NAME
-    cleaned = STACK_NAME_PATTERN.sub("-", raw_value.strip()).strip("-")
-    if not cleaned:
+    stripped = raw_value.strip()
+    if not stripped:
         return DEFAULT_STACK_NAME
+    cleaned = STACK_NAME_PATTERN.sub("-", stripped).strip("._-")
+    if not cleaned:
+        raise ValueError(
+            f"{STACK_NAME_ENV} must contain at least one ASCII letter or digit"
+        )
     return cleaned
 
 

--- a/src/vllm-sr/tests/test_runtime_paths.py
+++ b/src/vllm-sr/tests/test_runtime_paths.py
@@ -1,0 +1,191 @@
+import os
+import stat
+from pathlib import Path
+
+import pytest
+import yaml
+from cli.commands import runtime_paths
+from cli.commands.runtime_paths import (
+    _container_runtime_config_path,
+    _runtime_config_output_path,
+    _write_runtime_config,
+)
+from cli.runtime_stack import normalize_stack_name
+
+
+@pytest.mark.parametrize(
+    ("raw_stack_name", "expected_filename"),
+    [
+        (None, "runtime-config.yaml"),
+        ("", "runtime-config.yaml"),
+        ("vllm-sr", "runtime-config.yaml"),
+        (" audit a ", "runtime-config.audit-a.yaml"),
+        ("audit/a", "runtime-config.audit-a.yaml"),
+        (r"audit\a", "runtime-config.audit-a.yaml"),
+        ("../audit/../../escape", "runtime-config.audit-..-..-escape.yaml"),
+        ("audit\u4f60\u597d", "runtime-config.audit.yaml"),
+    ],
+)
+def test_runtime_config_path_uses_canonical_stack_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_stack_name: str | None,
+    expected_filename: str,
+):
+    if raw_stack_name is None:
+        monkeypatch.delenv("VLLM_SR_STACK_NAME", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_SR_STACK_NAME", raw_stack_name)
+
+    config_path = tmp_path / "config.yaml"
+    output_path = _runtime_config_output_path(config_path)
+
+    assert output_path == tmp_path / ".vllm-sr" / expected_filename
+    assert output_path.parent.resolve() == (tmp_path / ".vllm-sr").resolve()
+    assert _container_runtime_config_path(config_path) == (
+        f"/app/.vllm-sr/{expected_filename}"
+    )
+
+
+@pytest.mark.parametrize("raw_stack_name", ["...", "\u4f60\u597d", "---___..."])
+def test_normalized_stack_name_rejects_nonempty_invalid_values(
+    raw_stack_name: str,
+):
+    with pytest.raises(ValueError, match="ASCII letter or digit"):
+        normalize_stack_name(raw_stack_name)
+
+
+def test_runtime_config_path_rejects_long_values_before_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("VLLM_SR_STACK_NAME", "a" * 300)
+
+    with pytest.raises(ValueError, match="filesystem limit"):
+        _write_runtime_config(tmp_path / "config.yaml", {"version": "v0.3"})
+
+    runtime_dir = tmp_path / ".vllm-sr"
+    assert list(runtime_dir.iterdir()) == []
+
+
+def test_normalization_collisions_share_one_runtime_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "config.yaml"
+
+    monkeypatch.setenv("VLLM_SR_STACK_NAME", "audit/a")
+    slash_path = _runtime_config_output_path(config_path)
+    monkeypatch.setenv("VLLM_SR_STACK_NAME", "audit a")
+    space_path = _runtime_config_output_path(config_path)
+
+    assert slash_path == space_path
+    assert slash_path.name == "runtime-config.audit-a.yaml"
+
+
+def test_write_runtime_config_uses_same_directory_atomic_private_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "config.yaml"
+    runtime_path = _runtime_config_output_path(config_path)
+    runtime_path.write_text("version: old\n", encoding="utf-8")
+    runtime_path.chmod(0o644)
+    old_inode = runtime_path.stat().st_ino
+
+    observed: dict[str, object] = {}
+    real_replace = os.replace
+
+    def record_replace(source: str | os.PathLike[str], target: str | os.PathLike[str]):
+        source_path = Path(source)
+        target_path = Path(target)
+        observed["source_parent"] = source_path.parent
+        observed["target"] = target_path
+        observed["temp_mode"] = stat.S_IMODE(source_path.stat().st_mode)
+        observed["old_content"] = target_path.read_text(encoding="utf-8")
+        real_replace(source, target)
+
+    monkeypatch.setattr(runtime_paths.os, "replace", record_replace)
+
+    result = _write_runtime_config(config_path, {"version": "v0.3"})
+
+    assert result == runtime_path
+    assert observed == {
+        "source_parent": runtime_path.parent,
+        "target": runtime_path,
+        "temp_mode": 0o600,
+        "old_content": "version: old\n",
+    }
+    assert yaml.safe_load(runtime_path.read_text(encoding="utf-8")) == {
+        "version": "v0.3"
+    }
+    assert stat.S_IMODE(runtime_path.stat().st_mode) == 0o600
+    assert runtime_path.stat().st_ino != old_inode
+    assert list(runtime_path.parent.glob(f".{runtime_path.name}.*.tmp")) == []
+
+
+def test_write_runtime_config_rejects_file_symlink_without_following_it(
+    tmp_path: Path,
+):
+    config_path = tmp_path / "config.yaml"
+    runtime_path = _runtime_config_output_path(config_path)
+    outside_path = tmp_path / "outside.yaml"
+    outside_path.write_text("sentinel\n", encoding="utf-8")
+    runtime_path.symlink_to(outside_path)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        _write_runtime_config(config_path, {"version": "v0.3"})
+
+    assert runtime_path.is_symlink()
+    assert outside_path.read_text(encoding="utf-8") == "sentinel\n"
+
+
+def test_runtime_config_output_rejects_symlinked_owned_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    state_root = tmp_path / "state"
+    outside_dir = tmp_path / "outside"
+    state_root.mkdir()
+    outside_dir.mkdir()
+    (state_root / ".vllm-sr").symlink_to(outside_dir, target_is_directory=True)
+    monkeypatch.setenv("VLLM_SR_STATE_ROOT_DIR", str(state_root))
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        _write_runtime_config(tmp_path / "config.yaml", {"version": "v0.3"})
+
+    assert list(outside_dir.iterdir()) == []
+
+
+def test_atomic_write_failure_preserves_target_and_removes_temporary_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "config.yaml"
+    runtime_path = _runtime_config_output_path(config_path)
+    runtime_path.write_text("version: old\n", encoding="utf-8")
+
+    def fail_dump(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("serialization failed")
+
+    monkeypatch.setattr(runtime_paths.yaml, "dump", fail_dump)
+
+    with pytest.raises(RuntimeError, match="serialization failed"):
+        _write_runtime_config(config_path, {"version": "v0.3"})
+
+    assert runtime_path.read_text(encoding="utf-8") == "version: old\n"
+    assert list(runtime_path.parent.glob(f".{runtime_path.name}.*.tmp")) == []
+
+
+def test_replace_failure_preserves_target_and_removes_temporary_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    config_path = tmp_path / "config.yaml"
+    runtime_path = _runtime_config_output_path(config_path)
+    runtime_path.write_text("version: old\n", encoding="utf-8")
+
+    def fail_replace(*_args: object, **_kwargs: object) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(runtime_paths.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        _write_runtime_config(config_path, {"version": "v0.3"})
+
+    assert runtime_path.read_text(encoding="utf-8") == "version: old\n"
+    assert list(runtime_path.parent.glob(f".{runtime_path.name}.*.tmp")) == []


### PR DESCRIPTION
Closes #2479

## Purpose

- Reuse the CLI's canonical stack-name normalization when deriving runtime-state filenames.
- Keep every runtime config as a direct child of the owned `.vllm-sr` directory and reject pre-existing symlink destinations.
- Write runtime configs through a same-directory temporary file with mode `0600`, followed by atomic replacement.
- Define invalid, overlong, traversal-shaped, and normalization-collision behavior explicitly.

This affects the CLI and its focused tests. Distinct raw names that normalize to the same stack identity intentionally share one runtime-state file. The explicit default identity `vllm-sr` now uses `runtime-config.yaml`; generated legacy suffixed files are not migrated and are regenerated on the next serve operation. Nonblank names without an ASCII letter or digit, overlong normalized filenames, symlinked state directories, and symlinked destination files now fail explicitly.

## Test Plan

- Exercise empty/default names, spaces, slash and backslash separators, traversal-shaped dot segments, Unicode, invalid names, long values, and normalization collisions.
- Verify direct-child containment, destination and directory symlink rejection, same-directory replacement, mode `0600`, rollback, and temporary-file cleanup.
- Run the affected Python and CLI suites, repository lint/CI gates, the full integration suite, and the CPU feature gate with live local smoke checks.

## Test Result

- `pytest tests/test_runtime_paths.py -q` — 18 passed
- affected CLI unit suites — 48 passed
- `make vllm-sr-test` — 33 passed, 6 skipped
- `make vllm-sr-test-integration` — 39 passed
- exact final-worktree `test_stop_terminates_container` rerun — passed
- `make agent-lint ...` — passed
- `make agent-ci-gate ...` — passed
- `make agent-feature-gate ENV=cpu ...` — passed, including live router, Envoy, dashboard, and simulator smoke checks

Full `pytest tests -q`: 447 passed; four failures remain in the untouched dashboard Dockerfile-surface tests. The same four failures reproduce on the exact `fe0b37d` base, so they are outside this CLI change. The stop integration test also showed an intermittent timeout that reproduced on the pristine base; the exact final-worktree rerun passed.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
