### PR TITLE
[Website] fix unreadable mobile navbar sidebar (reset inner .menu to transparent)

### DIFF
--- a/website/src/css/shell.css
+++ b/website/src/css/shell.css
@@ -354,6 +354,15 @@ html[data-route-kind="blog"] .nav-docs-only {
     padding: 0.75rem;
   }
 
+  .navbar-sidebar .menu {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+
   .navbar-sidebar .menu__link,
   .navbar-sidebar .menu__caret {
     min-height: 2.9rem;
@@ -371,6 +380,7 @@ html[data-route-kind="blog"] .nav-docs-only {
   .navbar-sidebar .menu__link:hover,
   .navbar-sidebar .menu__link--active {
     background: var(--site-accent-soft);
+    box-shadow: inset 2px 0 var(--site-accent);
     color: #ffffff;
   }
 


### PR DESCRIPTION
Closes #2511

## Summary

The mobile navbar sidebar rendered a near-white panel with light-gray text (low contrast, worst on iOS). The sidebar is *designed* dark — `.navbar-sidebar { background: #09090b }` with light links and a blue `--site-accent-soft` hover — but the base `.menu` rule (for the light-mode desktop dropdown / doc sidebar) paints `background: rgba(251,252,254,.96)` over it, and there was no `.navbar-sidebar .menu` reset. So the intended dark design was covered by a white panel, leaving light-gray text on near-white.

This restores the intended look with no style change and no new colors:

```css
.navbar-sidebar .menu {
  background: transparent;      /* stop the light .menu panel leaking over #09090b */
  border: none; border-radius: 0; box-shadow: none;
  -webkit-backdrop-filter: none; backdrop-filter: none;
}
.navbar-sidebar .menu__link:hover,
.navbar-sidebar .menu__link--active {
  background: var(--site-accent-soft);
  box-shadow: inset 2px 0 var(--site-accent);   /* left accent bar, matches navbar pattern */
  color: #ffffff;
}
```

Everything reuses existing design tokens (`--site-accent`, `--site-accent-soft`) and the sidebar's existing dark palette — this is a consistency fix that lets the already-intended dark sidebar render correctly, not a new visual language.

## Test Plan

- Netlify deploy preview, mobile viewport / iOS Safari: open the navbar hamburger → the sidebar is now dark with legible light text; hover/active links show the blue accent (soft background + left accent bar).
- Contrast: was light-gray `#e4e4e7` on near-white `rgba(251,252,254,.96)` (~1.2:1, unreadable); now `#e4e4e7` on `#09090b` (~13:1, WCAG AAA).
