### PR TITLE
[Router][E2E][Docs] Fix agentgateway full-duplex request bodies

### DIFF
--- a/deploy/kubernetes/agentgateway/extproc-policy.yaml
+++ b/deploy/kubernetes/agentgateway/extproc-policy.yaml
@@ -16,7 +16,9 @@ spec:
         port: 50051
       processingOptions:
         requestHeaderMode: Send
-        requestBodyMode: Buffered
+        requestBodyMode: FullDuplexStreamed
         responseHeaderMode: Send
         responseBodyMode: Buffered
+        requestTrailerMode: Send
+        responseTrailerMode: Send
         allowModeOverride: true

--- a/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
@@ -1,3 +1,11 @@
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: 500m
+    memory: 2Gi
+
 config:
   version: v0.3
   listeners: []
@@ -353,6 +361,10 @@ config:
   global:
     router:
       strategy: priority
+      streamed_body:
+        enabled: true
+        max_bytes: 10485760
+        timeout_sec: 30
     services:
       response_api:
         enabled: true

--- a/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
@@ -1,11 +1,3 @@
-resources:
-  limits:
-    cpu: "2"
-    memory: 4Gi
-  requests:
-    cpu: 500m
-    memory: 2Gi
-
 config:
   version: v0.3
   listeners: []

--- a/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
@@ -353,12 +353,6 @@ config:
   global:
     router:
       strategy: priority
-      streamed_body:
-        enabled: true
-        # Example guardrails matching e2e/profiles/streaming/values.yaml.
-        # Tune for the deployment; zero disables the corresponding guard.
-        max_bytes: 10485760
-        timeout_sec: 30
     services:
       response_api:
         enabled: true

--- a/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
@@ -355,6 +355,8 @@ config:
       strategy: priority
       streamed_body:
         enabled: true
+        # Example guardrails matching e2e/profiles/streaming/values.yaml.
+        # Tune for the deployment; zero disables the corresponding guard.
         max_bytes: 10485760
         timeout_sec: 30
     services:

--- a/e2e/profiles/agentgateway/profile.go
+++ b/e2e/profiles/agentgateway/profile.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	agentGatewayVersion      = "v1.3.0-alpha.1"
+	agentGatewayVersion      = "v1.3.1"
 	agentGatewayNamespace    = "agentgateway-system"
 	agentGatewayProxyService = "agentgateway-proxy"
 	semanticRouterDeployment = "semantic-router"
@@ -135,7 +135,10 @@ func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions)
 func (p *Profile) GetTestCases() []string {
 	return testmatrix.Combine(
 		testmatrix.RouterSmoke,
-		[]string{"agentgateway-traffic-routing"},
+		[]string{
+			"agentgateway-traffic-routing",
+			"agentgateway-full-duplex-multiturn",
+		},
 	)
 }
 

--- a/e2e/profiles/agentgateway/runtime.go
+++ b/e2e/profiles/agentgateway/runtime.go
@@ -69,6 +69,9 @@ func (p *Profile) deploySemanticRouter(ctx context.Context, deployer *helm.Deplo
 		"image.repository": "ghcr.io/vllm-project/semantic-router/extproc",
 		"image.tag":        opts.ImageTag,
 		"image.pullPolicy": "Never",
+		"config.global.router.streamed_body.enabled":     "true",
+		"config.global.router.streamed_body.max_bytes":   "10485760",
+		"config.global.router.streamed_body.timeout_sec": "30",
 	}
 	if err := deployer.Install(ctx, release); err != nil {
 		return fmt.Errorf("install semantic-router: %w", err)

--- a/e2e/testcases/agentgateway_full_duplex.go
+++ b/e2e/testcases/agentgateway_full_duplex.go
@@ -1,0 +1,91 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("agentgateway-full-duplex-multiturn", pkgtestcases.TestCase{
+		Description: "Verify agentgateway FullDuplexStreamed preserves a chunked multi-turn request body",
+		Tags:        []string{"agentgateway", "gateway", "streaming", "multi-turn"},
+		Fn:          testAgentGatewayFullDuplexMultiturn,
+	})
+}
+
+type boundedChunkReader struct {
+	reader *strings.Reader
+	max    int
+}
+
+func (r *boundedChunkReader) Read(p []byte) (int, error) {
+	if len(p) > r.max {
+		p = p[:r.max]
+	}
+	return r.reader.Read(p)
+}
+
+func testAgentGatewayFullDuplexMultiturn(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	const (
+		namespace = "agentgateway-system"
+		svcName   = "agentgateway-proxy"
+		localPort = "8081"
+		attempts  = 12
+	)
+
+	stop, err := helpers.StartPortForward(ctx, client, opts.RestConfig, namespace, svcName, localPort+":80", opts.Verbose)
+	if err != nil {
+		return fmt.Errorf("start agentgateway port-forward: %w", err)
+	}
+	defer stop()
+	time.Sleep(2 * time.Second)
+
+	// Keep the payload in the size range from issue #2486 and force HTTP/1.1
+	// chunked transfer with small reader chunks. Every attempt must reach the
+	// mock LLM as valid JSON; an empty intermediate mutation produces a 503.
+	history := strings.Repeat("Earlier context that must remain intact across the streamed request. ", 32)
+	payload := fmt.Sprintf(`{"model":"auto","messages":[{"role":"user","content":%q},{"role":"assistant","content":%q},{"role":"user","content":"What is the derivative of x cubed?"}],"max_tokens":64,"temperature":0}`,
+		history, "I retained the earlier context and am ready for the next question.")
+	url := fmt.Sprintf("http://localhost:%s/v1/chat/completions", localPort)
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		body := &boundedChunkReader{reader: strings.NewReader(payload), max: 47}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+		if err != nil {
+			return fmt.Errorf("attempt %d: create request: %w", attempt, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.ContentLength = -1
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("attempt %d: send request: %w", attempt, err)
+		}
+		responseBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return fmt.Errorf("attempt %d: read response: %w", attempt, readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("attempt %d: expected HTTP 200, got %d: %s", attempt, resp.StatusCode, responseBody)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"attempts":         attempts,
+			"request_bytes":    len(payload),
+			"reader_chunk_max": 47,
+		})
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/extproc/processor_core.go
+++ b/src/semantic-router/pkg/extproc/processor_core.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"runtime/debug"
 
+	http_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -28,6 +29,9 @@ func (r *OpenAIRouter) handleRequestBodyDispatch(v *ext_proc.ProcessingRequest_R
 	// This guarantees no chunk accumulation, model detection, or buffered
 	// pipeline runs for opted-out requests, regardless of streamed_body_mode.
 	if ctx.SkipProcessing {
+		if ctx.FullDuplexRequestBody {
+			return newFullDuplexRequestBodyResponse(v.RequestBody.GetBody(), v.RequestBody.GetEndOfStream()), nil
+		}
 		return newContinueRequestBodyResponse(), nil
 	}
 
@@ -45,9 +49,17 @@ func (r *OpenAIRouter) handleRequestBodyDispatch(v *ext_proc.ProcessingRequest_R
 
 	// Decide mode based on config: only use streaming handler when explicitly enabled
 	streamedMode := r.Config != nil && r.Config.StreamedBodyMode
-	if streamedMode && !eos {
+	if ctx.FullDuplexRequestBody && !streamedMode {
+		return newFullDuplexRequestBodyResponse(v.RequestBody.GetBody(), eos), nil
+	}
+	if streamedMode && (!eos || ctx.FullDuplexRequestBody) {
 		ctx.StreamedBody = newStreamedBodyHandler(r, ctx)
-		return ctx.StreamedBody.HandleChunk(v.RequestBody, ctx)
+		resp, err := ctx.StreamedBody.HandleChunk(v.RequestBody, ctx)
+		if eos {
+			ctx.StreamedBody.Release()
+			ctx.StreamedBody = nil
+		}
+		return resp, err
 	}
 
 	// BUFFERED mode or single-message STREAMED — use classic pipeline
@@ -150,6 +162,10 @@ func (r *OpenAIRouter) handleProcessRequest(
 	req *ext_proc.ProcessingRequest,
 	ctx *RequestContext,
 ) error {
+	if protocolConfig := req.GetProtocolConfig(); protocolConfig != nil {
+		ctx.FullDuplexRequestBody = protocolConfig.GetRequestBodyMode() == http_ext.ProcessingMode_FULL_DUPLEX_STREAMED
+	}
+
 	switch v := req.Request.(type) {
 	case *ext_proc.ProcessingRequest_RequestHeaders:
 		return r.processRequestHeaders(stream, v, ctx)
@@ -190,6 +206,12 @@ func (r *OpenAIRouter) processRequestBody(
 	if err != nil {
 		logging.Errorf("handleRequestBody failed: %v", err)
 		return err
+	}
+	// FULL_DUPLEX_STREAMED explicitly permits the processor to buffer any
+	// number of input chunks before sending a StreamedBodyResponse. A nil
+	// response here means this chunk was retained for the eventual EOS reply.
+	if response == nil && ctx.FullDuplexRequestBody {
+		return nil
 	}
 	if err := sendResponse(stream, response, "request body"); err != nil {
 		logging.Errorf("sendResponse for body failed: %v", err)

--- a/src/semantic-router/pkg/extproc/processor_req_body_full_duplex_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_full_duplex_test.go
@@ -1,0 +1,97 @@
+package extproc
+
+import (
+	"testing"
+
+	http_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestFullDuplex_NonEOSChunkDefersResponse(t *testing.T) {
+	router := makeTestRouter("auto")
+	ctx := &RequestContext{
+		Headers:               make(map[string]string),
+		FullDuplexRequestBody: true,
+	}
+	h := newStreamedBodyHandler(router, ctx)
+	defer h.Release()
+
+	resp, err := h.HandleChunk(&ext_proc.HttpBody{Body: []byte(`{"mod`), EndOfStream: false}, ctx)
+	require.NoError(t, err)
+	assert.Nil(t, resp, "full-duplex chunks may be buffered without an intermediate response")
+}
+
+func TestFullDuplex_ProtocolConfigDefersBodyResponse(t *testing.T) {
+	router := makeTestRouter("auto")
+	ctx := &RequestContext{Headers: make(map[string]string)}
+	stream := NewMockStream(nil)
+	req := &ext_proc.ProcessingRequest{
+		ProtocolConfig: &ext_proc.ProtocolConfiguration{
+			RequestBodyMode: http_ext.ProcessingMode_FULL_DUPLEX_STREAMED,
+		},
+		Request: &ext_proc.ProcessingRequest_RequestBody{
+			RequestBody: &ext_proc.HttpBody{Body: []byte(`{"mod`), EndOfStream: false},
+		},
+	}
+
+	require.NoError(t, router.handleProcessRequest(stream, req, ctx))
+	assert.True(t, ctx.FullDuplexRequestBody)
+	assert.Empty(t, stream.Responses)
+}
+
+func TestFullDuplex_DisabledAccumulationPassesChunkThrough(t *testing.T) {
+	router := &OpenAIRouter{Config: &config.RouterConfig{}}
+	ctx := &RequestContext{FullDuplexRequestBody: true}
+	chunk := []byte(`{"model":"gpt-4"}`)
+	response, err := router.handleRequestBodyDispatch(&ext_proc.ProcessingRequest_RequestBody{
+		RequestBody: &ext_proc.HttpBody{Body: chunk, EndOfStream: true},
+	}, ctx)
+
+	require.NoError(t, err)
+	streamed := response.GetRequestBody().GetResponse().GetBodyMutation().GetStreamedResponse()
+	require.NotNil(t, streamed)
+	assert.Equal(t, chunk, streamed.GetBody())
+	assert.True(t, streamed.GetEndOfStream())
+}
+
+func TestFullDuplex_FinalResponseUsesStreamedMutation(t *testing.T) {
+	original := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`)
+	mutated := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}`)
+	h := &StreamedBodyHandler{ctx: &RequestContext{FullDuplexRequestBody: true}}
+	h.buf.Write(original)
+	response := &ext_proc.ProcessingResponse{
+		Response: &ext_proc.ProcessingResponse_RequestBody{
+			RequestBody: &ext_proc.BodyResponse{Response: &ext_proc.CommonResponse{
+				Status: ext_proc.CommonResponse_CONTINUE,
+				BodyMutation: &ext_proc.BodyMutation{Mutation: &ext_proc.BodyMutation_Body{
+					Body: mutated,
+				}},
+			}},
+		},
+	}
+
+	got := h.finalizeResponse(response)
+	mutation := got.GetRequestBody().GetResponse().GetBodyMutation()
+	streamed := mutation.GetStreamedResponse()
+	require.NotNil(t, streamed)
+	assert.Equal(t, mutated, streamed.GetBody())
+	assert.True(t, streamed.GetEndOfStream())
+	assert.Nil(t, mutation.GetBody())
+}
+
+func TestFullDuplex_FinalResponseFallsBackToAccumulatedBody(t *testing.T) {
+	original := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`)
+	h := &StreamedBodyHandler{ctx: &RequestContext{FullDuplexRequestBody: true}}
+	h.buf.Write(original)
+	response := newContinueRequestBodyResponse()
+
+	got := h.finalizeResponse(response)
+	streamed := got.GetRequestBody().GetResponse().GetBodyMutation().GetStreamedResponse()
+	require.NotNil(t, streamed)
+	assert.Equal(t, original, streamed.GetBody())
+	assert.True(t, streamed.GetEndOfStream())
+}

--- a/src/semantic-router/pkg/extproc/processor_req_body_streamed.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_streamed.go
@@ -22,10 +22,9 @@ const (
 
 // StreamedBodyHandler implements semi-streaming request body processing.
 //
-// In Envoy STREAMED mode, body arrives as multiple HttpBody messages. For each
-// message the handler MUST return exactly one ProcessingResponse. The handler
-// accumulates bytes until the model field can be extracted (via gjson), then
-// branches:
+// In Envoy STREAMED or FULL_DUPLEX_STREAMED mode, body arrives as multiple
+// HttpBody messages. The handler accumulates bytes until the model field can
+// be extracted (via gjson), then branches:
 //
 //   - Passthrough (non-auto model): continue eating chunks (replacing each
 //     with an empty body) so that upstream sees nothing until EOS. On EOS the
@@ -35,8 +34,10 @@ const (
 //   - Accumulate (auto model): same chunk-eating strategy. On EOS the full
 //     classification + body mutation pipeline runs.
 //
-// Both paths eat every chunk and emit the full body only on EOS, so upstream
-// never receives partial/duplicated data regardless of body mutations.
+// In STREAMED mode, both paths eat every non-EOS chunk with a regular empty
+// body mutation. In FULL_DUPLEX_STREAMED mode, intermediate replies are
+// deferred and the complete body is emitted at EOS with StreamedBodyResponse,
+// as required by the ExtProc protocol.
 //
 // Safety:
 //   - MaxBytes: if configured, rejects requests whose accumulated body exceeds
@@ -133,8 +134,15 @@ func (h *StreamedBodyHandler) HandleChunk(body *ext_proc.HttpBody, ctx *RequestC
 	case stateAccumulate:
 		return h.handleAccumulate(eos)
 	default:
-		return sharedContinueEmptyBody, nil
+		return h.intermediateResponse(), nil
 	}
+}
+
+func (h *StreamedBodyHandler) intermediateResponse() *ext_proc.ProcessingResponse {
+	if h.ctx != nil && h.ctx.FullDuplexRequestBody {
+		return nil
+	}
+	return sharedContinueEmptyBody
 }
 
 // checkGuards enforces max-body and deadline limits. Returning an error causes
@@ -164,7 +172,7 @@ func (h *StreamedBodyHandler) handleInit(eos bool) (*ext_proc.ProcessingResponse
 	h.model = extractModelFast(buf)
 
 	if h.model == "" && !eos {
-		return sharedContinueEmptyBody, nil
+		return h.intermediateResponse(), nil
 	}
 
 	h.isStream = extractStreamParamFast(buf)
@@ -197,7 +205,7 @@ func (h *StreamedBodyHandler) handleInit(eos bool) (*ext_proc.ProcessingResponse
 // forwarded intermediate chunks would be duplicated by an EOS body mutation.
 func (h *StreamedBodyHandler) handlePassthrough(eos bool) (*ext_proc.ProcessingResponse, error) {
 	if !eos {
-		return sharedContinueEmptyBody, nil
+		return h.intermediateResponse(), nil
 	}
 
 	h.ctx.ProcessingStartTime = time.Now()
@@ -210,14 +218,15 @@ func (h *StreamedBodyHandler) handlePassthrough(eos bool) (*ext_proc.ProcessingR
 		},
 	}
 
-	return h.router.handleRequestBody(v, h.ctx)
+	response, err := h.router.handleRequestBody(v, h.ctx)
+	return h.finalizeResponse(response), err
 }
 
 // handleAccumulate eats chunks (replaces with empty body). On EOS the full
 // classification + body mutation pipeline runs on the accumulated body.
 func (h *StreamedBodyHandler) handleAccumulate(eos bool) (*ext_proc.ProcessingResponse, error) {
 	if !eos {
-		return sharedContinueEmptyBody, nil
+		return h.intermediateResponse(), nil
 	}
 
 	h.ctx.ProcessingStartTime = time.Now()
@@ -230,5 +239,42 @@ func (h *StreamedBodyHandler) handleAccumulate(eos bool) (*ext_proc.ProcessingRe
 		},
 	}
 
-	return h.router.handleRequestBody(v, h.ctx)
+	response, err := h.router.handleRequestBody(v, h.ctx)
+	return h.finalizeResponse(response), err
+}
+
+// finalizeResponse translates the standard request-body pipeline result to
+// the response shape required by FULL_DUPLEX_STREAMED. Immediate responses are
+// already valid in either mode and pass through unchanged.
+func (h *StreamedBodyHandler) finalizeResponse(response *ext_proc.ProcessingResponse) *ext_proc.ProcessingResponse {
+	if h.ctx == nil || !h.ctx.FullDuplexRequestBody || response == nil || response.GetImmediateResponse() != nil {
+		return response
+	}
+
+	bodyResponse := response.GetRequestBody()
+	if bodyResponse == nil || bodyResponse.Response == nil {
+		return response
+	}
+
+	common := bodyResponse.Response
+	body := h.buf.Bytes()
+	if mutation := common.GetBodyMutation(); mutation != nil {
+		switch mutation := mutation.GetMutation().(type) {
+		case *ext_proc.BodyMutation_Body:
+			body = mutation.Body
+		case *ext_proc.BodyMutation_ClearBody:
+			if mutation.ClearBody {
+				body = nil
+			}
+		}
+	}
+	common.BodyMutation = &ext_proc.BodyMutation{
+		Mutation: &ext_proc.BodyMutation_StreamedResponse{
+			StreamedResponse: &ext_proc.StreamedBodyResponse{
+				Body:        bytes.Clone(body),
+				EndOfStream: true,
+			},
+		},
+	}
+	return response
 }

--- a/src/semantic-router/pkg/extproc/req_filter_skip_processing.go
+++ b/src/semantic-router/pkg/extproc/req_filter_skip_processing.go
@@ -39,6 +39,26 @@ func newContinueRequestBodyResponse() *ext_proc.ProcessingResponse {
 	}
 }
 
+func newFullDuplexRequestBodyResponse(body []byte, endOfStream bool) *ext_proc.ProcessingResponse {
+	return &ext_proc.ProcessingResponse{
+		Response: &ext_proc.ProcessingResponse_RequestBody{
+			RequestBody: &ext_proc.BodyResponse{
+				Response: &ext_proc.CommonResponse{
+					Status: ext_proc.CommonResponse_CONTINUE,
+					BodyMutation: &ext_proc.BodyMutation{
+						Mutation: &ext_proc.BodyMutation_StreamedResponse{
+							StreamedResponse: &ext_proc.StreamedBodyResponse{
+								Body:        body,
+								EndOfStream: endOfStream,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func (r *OpenAIRouter) handleSkipProcessingResponseHeaders(
 	v *ext_proc.ProcessingRequest_ResponseHeaders,
 	ctx *RequestContext,

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -76,7 +76,8 @@ type RequestContext struct {
 	AnthropicPassthrough *anthropic.AnthropicPassthrough
 
 	// Semi-streaming body handler (non-nil when Envoy sends STREAMED body chunks)
-	StreamedBody *StreamedBodyHandler
+	StreamedBody          *StreamedBodyHandler
+	FullDuplexRequestBody bool // true when the data plane negotiated FULL_DUPLEX_STREAMED
 
 	// Streaming accumulation for caching
 	HasStreamingChunks bool                            // True when at least one SSE chunk has been received

--- a/website/docs/installation/k8s/agentgateway.md
+++ b/website/docs/installation/k8s/agentgateway.md
@@ -245,7 +245,7 @@ spec:
 EOF
 ```
 
-The bundled agentgateway demo explicitly opts into full-duplex streamed request
+The bundled agentgateway example explicitly opts into full-duplex streamed request
 bodies. This is an example-specific choice; other proxy defaults and examples
 may continue to use buffered request bodies. The accompanying Semantic Router
 values enable `global.router.streamed_body`, allowing the router to accumulate

--- a/website/docs/installation/k8s/agentgateway.md
+++ b/website/docs/installation/k8s/agentgateway.md
@@ -236,14 +236,28 @@ spec:
         port: 50051
       processingOptions:
         requestHeaderMode: Send
-        requestBodyMode: Buffered
+        requestBodyMode: FullDuplexStreamed
         responseHeaderMode: Send
         responseBodyMode: Buffered
+        requestTrailerMode: Send
+        responseTrailerMode: Send
         allowModeOverride: true
 EOF
 ```
 
-The demo uses buffered request bodies to match the existing Envoy AI Gateway and Istio examples. For large prompts, use `requestBodyMode: FullDuplexStreamed` together with a Semantic Router configuration that enables streamed body handling. agentgateway does not support `Streamed` mode; `FullDuplexStreamed` is the only streaming option. See [Streamed ExtProc and immediate responses](./streamed-extproc.md) for the full configuration, immediate-response behavior, and verification checklist.
+The bundled agentgateway demo explicitly opts into full-duplex streamed request
+bodies. This is an example-specific choice; other proxy defaults and examples
+may continue to use buffered request bodies. The accompanying Semantic Router
+values enable `global.router.streamed_body`, allowing the router to accumulate
+request chunks and process the complete body at end-of-stream.
+
+agentgateway does not support `Streamed` mode; `FullDuplexStreamed` is its
+streaming option. The deployable policy is in
+`deploy/kubernetes/agentgateway/extproc-policy.yaml`, with the matching router
+configuration in
+`deploy/kubernetes/agentgateway/semantic-router-values/values.yaml`. See
+[Streamed ExtProc and immediate responses](./streamed-extproc.md) for protocol
+behavior and the verification checklist.
 
 ## Testing the Deployment
 

--- a/website/docs/installation/k8s/agentgateway.md
+++ b/website/docs/installation/k8s/agentgateway.md
@@ -165,7 +165,10 @@ Install the Semantic Router in the `agentgateway-system` namespace so the agentg
 helm install semantic-router oci://ghcr.io/vllm-project/charts/semantic-router \
   --version v0.0.0-latest \
   --namespace agentgateway-system \
-  -f https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml
+  -f https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml \
+  --set config.global.router.streamed_body.enabled=true \
+  --set config.global.router.streamed_body.max_bytes=10485760 \
+  --set config.global.router.streamed_body.timeout_sec=30
 
 kubectl wait --for=condition=Available deployment/semantic-router \
   -n agentgateway-system \
@@ -247,15 +250,14 @@ EOF
 
 The bundled agentgateway example explicitly opts into full-duplex streamed request
 bodies. This is an example-specific choice; other proxy defaults and examples
-may continue to use buffered request bodies. The accompanying Semantic Router
-values enable `global.router.streamed_body`, allowing the router to accumulate
-request chunks and process the complete body at end-of-stream.
+may continue to use buffered request bodies. The Semantic Router Helm command
+above explicitly enables `global.router.streamed_body`, allowing the router to
+accumulate request chunks and process the complete body at end-of-stream.
 
 agentgateway does not support `Streamed` mode; `FullDuplexStreamed` is its
 streaming option. The deployable policy is in
 `deploy/kubernetes/agentgateway/extproc-policy.yaml`, with the matching router
-configuration in
-`deploy/kubernetes/agentgateway/semantic-router-values/values.yaml`. See
+configuration passed through the Helm command in Step 5. See
 [Streamed ExtProc and immediate responses](./streamed-extproc.md) for protocol
 behavior and the verification checklist.
 

--- a/website/docs/installation/k8s/streamed-extproc.md
+++ b/website/docs/installation/k8s/streamed-extproc.md
@@ -39,7 +39,11 @@ global:
 
 Keep `max_bytes` high enough for your largest prompt or multimodal payload. Keep `timeout_sec` greater than the expected upload time between the first body chunk and end-of-stream.
 
-The default reference config shows the same structure in `config/config.yaml`, and the streaming e2e profile uses it in `e2e/profiles/streaming/values.yaml`.
+The 10 MiB and 30-second values above are example guardrails matching the
+streaming e2e profile in `e2e/profiles/streaming/values.yaml`; they are not
+runtime defaults or experimentally calibrated limits. Omitting either value or
+setting it to zero disables that guard. The reference `config/config.yaml`
+demonstrates a smaller 1 MiB and 15-second policy.
 
 ## Envoy AI Gateway / Envoy Gateway
 

--- a/website/docs/installation/k8s/streamed-extproc.md
+++ b/website/docs/installation/k8s/streamed-extproc.md
@@ -95,9 +95,10 @@ agentgateway uses the Gateway API `AgentgatewayPolicy` abstraction rather than r
 
 Buffered request bodies remain common in proxy defaults and other deployment
 examples. The bundled agentgateway example opts into streaming explicitly in
-`deploy/kubernetes/agentgateway/extproc-policy.yaml`; its paired
-`semantic-router-values/values.yaml` enables `global.router.streamed_body`.
-Use both settings together when adopting that example.
+`deploy/kubernetes/agentgateway/extproc-policy.yaml`; the Helm command in the
+[agentgateway installation guide](./agentgateway.md) explicitly enables
+`global.router.streamed_body`. Use both settings together when adopting that
+example.
 
 ```yaml
 apiVersion: agentgateway.dev/v1alpha1

--- a/website/docs/installation/k8s/streamed-extproc.md
+++ b/website/docs/installation/k8s/streamed-extproc.md
@@ -89,6 +89,12 @@ A complete Kubernetes example is available in `deploy/kubernetes/streaming/aigw-
 
 agentgateway uses the Gateway API `AgentgatewayPolicy` abstraction rather than raw Envoy `processing_mode` names. For streamed bodies use `FullDuplexStreamed`.
 
+Buffered request bodies remain common in proxy defaults and other deployment
+examples. The bundled agentgateway example opts into streaming explicitly in
+`deploy/kubernetes/agentgateway/extproc-policy.yaml`; its paired
+`semantic-router-values/values.yaml` enables `global.router.streamed_body`.
+Use both settings together when adopting that example.
+
 ```yaml
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
@@ -111,10 +117,18 @@ spec:
         requestBodyMode: FullDuplexStreamed
         responseHeaderMode: Send
         responseBodyMode: Buffered
+        requestTrailerMode: Send
+        responseTrailerMode: Send
         allowModeOverride: true
 ```
 
 agentgateway does not support a separate `Streamed` request-body mode. Use `FullDuplexStreamed` for streamed request bodies and enable `global.router.streamed_body` in Semantic Router.
+
+Semantic Router detects the negotiated ExtProc body mode. With
+`FullDuplexStreamed`, it buffers intermediate request chunks without emitting
+body replacements, then sends the complete processed request as one
+end-of-stream `StreamedBodyResponse`. With Envoy `STREAMED`, it retains the
+one-response-per-chunk behavior required by that mode.
 
 ## Configure an immediate streamed looper response
 


### PR DESCRIPTION
Fixes: #2486

## Purpose

- Handle ExtProc `FULL_DUPLEX_STREAMED` request bodies by deferring intermediate replies and returning the processed body in one end-of-stream `StreamedBodyResponse`.
- Preserve the existing Envoy `STREAMED` response-per-chunk behavior.
- Update the agentgateway deployment, E2E profile, and documentation to use and explain full-duplex streaming.
- Add focused unit coverage and a chunked multi-turn agentgateway regression test.

The root cause of #2486 was that vSR returned a regular empty body mutation for each non-EOS full-duplex chunk. Agentgateway could forward that mutation as an empty upstream request body, causing intermittent HTTP 503 responses.

Affected modules: `Router` / `E2E` / `Docs`

## Test Plan

- `GOTOOLCHAIN=go1.26.0 go test ./pkg/extproc -run 'TestFullDuplex|TestSharedContinueEmptyBody|TestHandler_' -count=1`
- `GOTOOLCHAIN=go1.26.0 go test ./profiles/agentgateway ./testcases -run '^$'`
- `GOTOOLCHAIN=go1.26.0 make agent-ci-gate CHANGED_FILES="..."`
- `GOTOOLCHAIN=go1.26.0 make e2e-test E2E_PROFILE=agentgateway E2E_CLUSTER_NAME=semantic-router-2486 E2E_TESTS=agentgateway-full-duplex-multiturn E2E_KEEP_CLUSTER=false`

These checks cover protocol response construction, legacy streamed behavior, E2E compilation, repository lint/build/tests, and the reported agentgateway failure path.

## Test Result

- Focused ExtProc tests passed.
- Agentgateway profile and test case compilation passed.
- The changed-file CI gate passed, including the full Semantic Router test suite and E2E build.
- The agentgateway regression test passed 1/1, with all 12 chunked multi-turn requests returning HTTP 200.
- No known follow-up blockers.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.