### PR TITLE
[Router] vectorstore: add lifecycle root context and bounded Stop(ctx)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1806,7 +1806,7 @@ global:
       embedding_model: multimodal
       embedding_dimension: 384
       ingestion_workers: 4
-      ingestion_drain_timeout_seconds: 30
+      ingestion_drain_timeout_seconds: 25
       supported_formats: [.txt, .md, .json, .csv, .html, .pdf]
       milvus:
         connection:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1806,6 +1806,7 @@ global:
       embedding_model: multimodal
       embedding_dimension: 384
       ingestion_workers: 4
+      ingestion_drain_timeout_seconds: 30
       supported_formats: [.txt, .md, .json, .csv, .html, .pdf]
       milvus:
         connection:

--- a/dashboard/frontend/src/pages/configPageRouterDefaultsCatalog.ts
+++ b/dashboard/frontend/src/pages/configPageRouterDefaultsCatalog.ts
@@ -111,6 +111,7 @@ export const DEFAULT_SECTIONS: Record<RouterSystemKey, unknown> = {
     embedding_model: 'mmbert',
     embedding_dimension: 384,
     ingestion_workers: 2,
+    ingestion_drain_timeout_seconds: 25,
     supported_formats: ['.txt', '.md', '.json', '.csv', '.html'],
     memory: {
       max_entries_per_store: 100000,

--- a/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
+++ b/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
@@ -591,6 +591,7 @@ function fieldsForKey(key: RouterSystemKey): FieldConfig[] {
         { name: 'embedding_model', label: 'Embedding Model', type: 'select', options: ['bert', 'qwen3', 'gemma', 'mmbert', 'multimodal'] },
         { name: 'embedding_dimension', label: 'Embedding Dimension', type: 'number', placeholder: '384' },
         { name: 'ingestion_workers', label: 'Ingestion Workers', type: 'number', placeholder: '2' },
+        { name: 'ingestion_drain_timeout_seconds', label: 'Ingestion Drain Timeout (s)', type: 'number', placeholder: '25' },
         routerStructuredField(key, 'supported_formats'),
         routerStructuredField(key, 'memory'),
         routerStructuredField(key, 'milvus'),

--- a/dashboard/frontend/src/pages/configPageSupport.ts
+++ b/dashboard/frontend/src/pages/configPageSupport.ts
@@ -506,6 +506,7 @@ export interface VectorStoreConfig {
   embedding_model?: string
   embedding_dimension?: number
   ingestion_workers?: number
+  ingestion_drain_timeout_seconds?: number
   supported_formats?: string[]
   milvus?: VectorStoreMilvusConfig
   memory?: VectorStoreMemoryConfig

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -5200,6 +5200,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
+        ingestion_drain_timeout_seconds: 30
         supported_formats:
           - .txt
           - .md
@@ -10618,6 +10619,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
+        ingestion_drain_timeout_seconds: 30
         supported_formats:
           - .txt
           - .md

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -5200,7 +5200,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
-        ingestion_drain_timeout_seconds: 30
+        ingestion_drain_timeout_seconds: 25
         supported_formats:
           - .txt
           - .md
@@ -10619,7 +10619,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
-        ingestion_drain_timeout_seconds: 30
+        ingestion_drain_timeout_seconds: 25
         supported_formats:
           - .txt
           - .md

--- a/e2e/profiles/rag-hybrid-search/values.yaml
+++ b/e2e/profiles/rag-hybrid-search/values.yaml
@@ -54,6 +54,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
+        ingestion_drain_timeout_seconds: 30
         supported_formats:
           - .txt
           - .md

--- a/e2e/profiles/rag-hybrid-search/values.yaml
+++ b/e2e/profiles/rag-hybrid-search/values.yaml
@@ -54,7 +54,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
-        ingestion_drain_timeout_seconds: 30
+        ingestion_drain_timeout_seconds: 25
         supported_formats:
           - .txt
           - .md

--- a/src/semantic-router/pkg/config/vectorstore.go
+++ b/src/semantic-router/pkg/config/vectorstore.go
@@ -56,8 +56,10 @@ type VectorStoreConfig struct {
 	// Size it to comfortably exceed the typical single-job latency (file size ×
 	// chunk count × per-chunk embed + backend insert), while staying *below* the
 	// deployment's shutdown grace period (e.g. Kubernetes
-	// terminationGracePeriodSeconds, default 30s) so the drain actually runs
-	// before the platform force-kills the process. Default: 30.
+	// terminationGracePeriodSeconds, default 30s) so the drain actually runs —
+	// and leaves cleanup margin for closing the metadata registry and backend —
+	// before the platform force-kills the process. Default: 25 (5s of headroom
+	// under the 30s Kubernetes default grace period).
 	IngestionDrainTimeoutSeconds int `json:"ingestion_drain_timeout_seconds,omitempty" yaml:"ingestion_drain_timeout_seconds,omitempty"`
 
 	// SupportedFormats lists the allowed file extensions for upload.
@@ -317,7 +319,7 @@ func (c *VectorStoreConfig) ApplyDefaults() {
 		c.IngestionWorkers = 2
 	}
 	if c.IngestionDrainTimeoutSeconds <= 0 {
-		c.IngestionDrainTimeoutSeconds = 30
+		c.IngestionDrainTimeoutSeconds = 25
 	}
 	if len(c.SupportedFormats) == 0 {
 		c.SupportedFormats = []string{".txt", ".md", ".json", ".csv", ".html"}

--- a/src/semantic-router/pkg/config/vectorstore.go
+++ b/src/semantic-router/pkg/config/vectorstore.go
@@ -46,6 +46,20 @@ type VectorStoreConfig struct {
 	// Default: 2
 	IngestionWorkers int `json:"ingestion_workers,omitempty" yaml:"ingestion_workers,omitempty"`
 
+	// IngestionDrainTimeoutSeconds bounds how long shutdown waits for in-flight
+	// ingestion jobs to drain before cancelling them. This is a shutdown grace
+	// window, not a per-file ingest budget: on shutdown the pipeline stops
+	// accepting new jobs, waits up to this long for currently-running jobs to
+	// finish, then cancels the rest so a wedged embedder or backend cannot block
+	// process shutdown indefinitely.
+	//
+	// Size it to comfortably exceed the typical single-job latency (file size ×
+	// chunk count × per-chunk embed + backend insert), while staying *below* the
+	// deployment's shutdown grace period (e.g. Kubernetes
+	// terminationGracePeriodSeconds, default 30s) so the drain actually runs
+	// before the platform force-kills the process. Default: 30.
+	IngestionDrainTimeoutSeconds int `json:"ingestion_drain_timeout_seconds,omitempty" yaml:"ingestion_drain_timeout_seconds,omitempty"`
+
 	// SupportedFormats lists the allowed file extensions for upload.
 	// Default: [".txt", ".md", ".json", ".csv", ".html"]
 	SupportedFormats []string `json:"supported_formats,omitempty" yaml:"supported_formats,omitempty"`
@@ -301,6 +315,9 @@ func (c *VectorStoreConfig) ApplyDefaults() {
 	}
 	if c.IngestionWorkers <= 0 {
 		c.IngestionWorkers = 2
+	}
+	if c.IngestionDrainTimeoutSeconds <= 0 {
+		c.IngestionDrainTimeoutSeconds = 30
 	}
 	if len(c.SupportedFormats) == 0 {
 		c.SupportedFormats = []string{".txt", ".md", ".json", ".csv", ".html"}

--- a/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
+++ b/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
@@ -2,6 +2,7 @@ package routerruntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -29,8 +30,9 @@ type VectorStoreRuntime struct {
 
 // defaultDrainTimeout is the fallback shutdown drain bound used when a runtime
 // is constructed without a configured drain timeout, so Stop is never
-// unbounded.
-const defaultDrainTimeout = 30 * time.Second
+// unbounded. It sits below the 30s Kubernetes default grace period to leave
+// margin for closing the registry and backend after the drain.
+const defaultDrainTimeout = 25 * time.Second
 
 func NewVectorStoreRuntime(cfg *config.RouterConfig) (*VectorStoreRuntime, error) {
 	if cfg == nil {
@@ -133,6 +135,14 @@ func (r *VectorStoreRuntime) Shutdown() error {
 	if r == nil {
 		return nil
 	}
+
+	// Stop the pipeline first and only tear down shared dependencies once its
+	// workers are actually quiescent. A Stop timeout explicitly means the
+	// pipeline has NOT stopped: a worker may still be inside Embed,
+	// InsertChunks, or count persistence. Closing the registry or backend under
+	// it would risk a use-after-close and race Backend.Close against an active
+	// call. On timeout we therefore leave the dependencies open and let process
+	// exit reclaim them, surfacing the failure to the caller.
 	if r.Pipeline != nil {
 		// Fall back to a bounded default if drainTimeout was not configured
 		// (e.g. a hand-constructed runtime), so Stop is never unbounded.
@@ -143,18 +153,32 @@ func (r *VectorStoreRuntime) Shutdown() error {
 		ctx, cancel := context.WithTimeout(context.Background(), drain)
 		defer cancel()
 		if err := r.Pipeline.Stop(ctx); err != nil {
-			logging.Warnf("Ingestion pipeline did not drain within %s: %v", drain, err)
+			// Pipeline did not drain within the deadline. Do NOT close the
+			// registry/backend — workers may still be using them. Report the
+			// failure so the caller/operator knows shutdown was not clean.
+			logging.Warnf(
+				"Ingestion pipeline did not drain within %s; leaving vector-store "+
+					"dependencies open to avoid use-after-close by in-flight workers: %v",
+				drain, err,
+			)
+			return fmt.Errorf("vector store pipeline did not drain within %s: %w", drain, err)
 		}
 	}
+
+	// Workers are quiescent (or the pipeline was nil): safe to close deps.
+	var errs []error
 	if r.registryCloser != nil {
 		if err := r.registryCloser.Close(); err != nil {
 			logging.Warnf("Failed to close metadata registry: %v", err)
+			errs = append(errs, fmt.Errorf("close metadata registry: %w", err))
 		}
 	}
 	if r.Backend != nil {
-		return r.Backend.Close()
+		if err := r.Backend.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close backend: %w", err))
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (r *VectorStoreRuntime) LogInitialized(component string, cfg *config.RouterConfig) {

--- a/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
+++ b/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -21,6 +22,11 @@ type VectorStoreRuntime struct {
 	Embedder       vectorstore.Embedder
 	registryCloser io.Closer
 }
+
+// vectorStoreShutdownTimeout bounds how long Shutdown waits for the ingestion
+// pipeline to drain in-flight jobs before cancelling them, so a wedged embedder
+// or backend cannot block process shutdown indefinitely.
+const vectorStoreShutdownTimeout = 30 * time.Second
 
 func NewVectorStoreRuntime(cfg *config.RouterConfig) (*VectorStoreRuntime, error) {
 	if cfg == nil {
@@ -123,7 +129,11 @@ func (r *VectorStoreRuntime) Shutdown() error {
 		return nil
 	}
 	if r.Pipeline != nil {
-		r.Pipeline.Stop()
+		ctx, cancel := context.WithTimeout(context.Background(), vectorStoreShutdownTimeout)
+		defer cancel()
+		if err := r.Pipeline.Stop(ctx); err != nil {
+			logging.Warnf("Ingestion pipeline did not drain within %s: %v", vectorStoreShutdownTimeout, err)
+		}
 	}
 	if r.registryCloser != nil {
 		if err := r.registryCloser.Close(); err != nil {

--- a/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
+++ b/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
@@ -21,12 +21,16 @@ type VectorStoreRuntime struct {
 	Pipeline       *vectorstore.IngestionPipeline
 	Embedder       vectorstore.Embedder
 	registryCloser io.Closer
+	// drainTimeout bounds how long Shutdown waits for in-flight ingestion jobs
+	// to drain before cancelling them. Sourced from
+	// vector_store.ingestion_drain_timeout_seconds.
+	drainTimeout time.Duration
 }
 
-// vectorStoreShutdownTimeout bounds how long Shutdown waits for the ingestion
-// pipeline to drain in-flight jobs before cancelling them, so a wedged embedder
-// or backend cannot block process shutdown indefinitely.
-const vectorStoreShutdownTimeout = 30 * time.Second
+// defaultDrainTimeout is the fallback shutdown drain bound used when a runtime
+// is constructed without a configured drain timeout, so Stop is never
+// unbounded.
+const defaultDrainTimeout = 30 * time.Second
 
 func NewVectorStoreRuntime(cfg *config.RouterConfig) (*VectorStoreRuntime, error) {
 	if cfg == nil {
@@ -77,6 +81,7 @@ func NewVectorStoreRuntime(cfg *config.RouterConfig) (*VectorStoreRuntime, error
 		Pipeline:       pipeline,
 		Embedder:       embedder,
 		registryCloser: regCloser,
+		drainTimeout:   time.Duration(cfg.VectorStore.IngestionDrainTimeoutSeconds) * time.Second,
 	}, nil
 }
 
@@ -129,10 +134,16 @@ func (r *VectorStoreRuntime) Shutdown() error {
 		return nil
 	}
 	if r.Pipeline != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), vectorStoreShutdownTimeout)
+		// Fall back to a bounded default if drainTimeout was not configured
+		// (e.g. a hand-constructed runtime), so Stop is never unbounded.
+		drain := r.drainTimeout
+		if drain <= 0 {
+			drain = defaultDrainTimeout
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), drain)
 		defer cancel()
 		if err := r.Pipeline.Stop(ctx); err != nil {
-			logging.Warnf("Ingestion pipeline did not drain within %s: %v", vectorStoreShutdownTimeout, err)
+			logging.Warnf("Ingestion pipeline did not drain within %s: %v", drain, err)
 		}
 	}
 	if r.registryCloser != nil {

--- a/src/semantic-router/pkg/vectorstore/integration_test.go
+++ b/src/semantic-router/pkg/vectorstore/integration_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Integration: Full Ingest-to-Search Pipeline", func() {
 	})
 
 	AfterEach(func() {
-		pipeline.Stop(context.Background())
+		_ = pipeline.Stop(context.Background())
 		_ = os.RemoveAll(tempDir)
 	})
 

--- a/src/semantic-router/pkg/vectorstore/integration_test.go
+++ b/src/semantic-router/pkg/vectorstore/integration_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -146,7 +148,7 @@ var _ = Describe("Integration: Full Ingest-to-Search Pipeline", func() {
 	})
 
 	AfterEach(func() {
-		pipeline.Stop()
+		pipeline.Stop(context.Background())
 		_ = os.RemoveAll(tempDir)
 	})
 
@@ -385,3 +387,140 @@ Login attempts are locked after 5 failures.`
 
 // Verify deterministicEmbedder satisfies the Embedder interface.
 var _ Embedder = (*deterministicEmbedder)(nil)
+
+// gateEmbedder wraps a real embedder but blocks each Embed call on a shared
+// gate until it is released. It lets a test hold ingestion mid-flight so the
+// shutdown path can be exercised deterministically, then release it so workers
+// can unwind cleanly (no leaked goroutines).
+type gateEmbedder struct {
+	inner   Embedder
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newGateEmbedder(inner Embedder) *gateEmbedder {
+	return &gateEmbedder{
+		inner:   inner,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (g *gateEmbedder) Embed(text string) ([]float32, error) {
+	g.once.Do(func() { close(g.entered) })
+	<-g.release
+	return g.inner.Embed(text)
+}
+
+func (g *gateEmbedder) Dimension() int { return g.inner.Dimension() }
+
+var _ = Describe("Integration: Pipeline graceful and bounded shutdown", func() {
+	var (
+		backend *MemoryBackend
+		store   *FileStore
+		mgr     *Manager
+		tempDir string
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "shutdown-e2e-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		backend = NewMemoryBackend(MemoryBackendConfig{})
+		store, err = NewFileStore(tempDir, NewMemoryMetadataRegistry())
+		Expect(err).NotTo(HaveOccurred())
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tempDir)
+	})
+
+	It("drains in-flight work on graceful stop and leaks no worker goroutines", func() {
+		// Snapshot the goroutine count before the pipeline exists so we can
+		// assert workers are fully reclaimed after Stop.
+		baseline := runtime.NumGoroutine()
+
+		embedder := newDeterministicEmbedder(8)
+		mgr = NewManager(backend, NewMemoryMetadataRegistry(), embedder.Dimension(), BackendTypeMemory)
+		pipeline := NewIngestionPipeline(backend, store, mgr, embedder, PipelineConfig{
+			Workers:   3,
+			QueueSize: 16,
+		})
+		pipeline.Start()
+
+		vs, err := mgr.CreateStore(ctx, CreateStoreRequest{Name: "graceful-shutdown"})
+		Expect(err).NotTo(HaveOccurred())
+
+		doc := "Employees accrue paid time off each month and may carry it forward."
+		record, err := store.Save("policy.txt", []byte(doc), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+
+		vsf, err := pipeline.AttachFile(vs.ID, record.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() string {
+			s, _ := pipeline.GetFileStatus(vsf.ID)
+			return s.Status
+		}, 10*time.Second, 50*time.Millisecond).Should(Equal("completed"))
+
+		// A graceful stop (no deadline pressure) returns nil and reclaims all
+		// worker goroutines.
+		Expect(pipeline.Stop(context.Background())).To(Succeed())
+
+		Eventually(runtime.NumGoroutine, 5*time.Second, 50*time.Millisecond).
+			Should(BeNumerically("<=", baseline+1))
+
+		// The completed vectors remain searchable after shutdown.
+		results, err := backend.Search(ctx, vs.ID, mustEmbed(embedder, "paid time off"), 3, 0.0, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).NotTo(BeEmpty())
+	})
+
+	It("returns within the deadline when a job is wedged, without leaking goroutines after release", func() {
+		baseline := runtime.NumGoroutine()
+
+		gate := newGateEmbedder(newDeterministicEmbedder(8))
+		mgr = NewManager(backend, NewMemoryMetadataRegistry(), gate.Dimension(), BackendTypeMemory)
+		pipeline := NewIngestionPipeline(backend, store, mgr, gate, PipelineConfig{
+			Workers:   2,
+			QueueSize: 8,
+		})
+		pipeline.Start()
+
+		vs, err := mgr.CreateStore(ctx, CreateStoreRequest{Name: "wedged-shutdown"})
+		Expect(err).NotTo(HaveOccurred())
+
+		record, err := store.Save("wedged.txt", []byte("some content to embed"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = pipeline.AttachFile(vs.ID, record.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Ensure a worker is parked inside Embed before we attempt to stop, so
+		// the graceful drain cannot complete and Stop must honor the deadline.
+		Eventually(gate.entered, 5*time.Second).Should(BeClosed())
+
+		stopCtx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		Expect(pipeline.Stop(stopCtx)).To(MatchError(context.DeadlineExceeded))
+		Expect(time.Since(start)).To(BeNumerically("<", 3*time.Second))
+
+		// Releasing the wedged embedder lets the worker unwind; no goroutines
+		// should remain once it does.
+		close(gate.release)
+		Eventually(runtime.NumGoroutine, 5*time.Second, 50*time.Millisecond).
+			Should(BeNumerically("<=", baseline+1))
+	})
+})
+
+func mustEmbed(e Embedder, text string) []float32 {
+	emb, err := e.Embed(text)
+	Expect(err).NotTo(HaveOccurred())
+	return emb
+}

--- a/src/semantic-router/pkg/vectorstore/pipeline.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline.go
@@ -38,6 +38,11 @@ type IngestionJob struct {
 	ChunkingStrategy  *ChunkingStrategy
 }
 
+// defaultStopTimeout bounds a Stop call from a shutdown path that does not
+// supply its own deadline. It keeps process shutdown responsive even when a
+// backend or embedder is wedged.
+const defaultStopTimeout = 30 * time.Second
+
 // IngestionPipeline processes file attachment jobs asynchronously.
 // It reads files, extracts text, chunks, embeds, and stores the
 // resulting vectors in the backend.
@@ -53,7 +58,12 @@ type IngestionPipeline struct {
 	fileStatuses map[string]*VectorStoreFile // vsf_id -> status
 	wg           sync.WaitGroup
 	stopCh       chan struct{}
-	running      bool
+	// rootCtx is the pipeline lifecycle context. All per-job work derives from
+	// it, so cancelling rootCancel signals every in-flight job to abort at its
+	// next checkpoint. It is (re)created on each Start.
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+	running    bool
 }
 
 // PipelineConfig holds configuration for the ingestion pipeline.
@@ -97,32 +107,74 @@ func (p *IngestionPipeline) Start() {
 	}
 	p.stopCh = make(chan struct{})
 	stopCh := p.stopCh
+	p.rootCtx, p.rootCancel = context.WithCancel(context.Background())
+	rootCtx := p.rootCtx
 	p.running = true
 	p.mu.Unlock()
 
 	for i := 0; i < p.workers; i++ {
 		p.wg.Add(1)
-		go p.worker(stopCh)
+		go p.worker(rootCtx, stopCh)
 	}
 }
 
-// Stop gracefully shuts down the pipeline.
-func (p *IngestionPipeline) Stop() {
+// Stop gracefully shuts down the pipeline, bounded by ctx.
+//
+// It stops accepting new jobs, fails any still queued, and waits for in-flight
+// jobs to drain. If ctx is cancelled or its deadline elapses before draining
+// completes, the pipeline root context is cancelled so in-flight jobs abort at
+// their next checkpoint, and Stop returns ctx.Err() without blocking further.
+// A nil ctx is treated as a bounded shutdown with defaultStopTimeout.
+func (p *IngestionPipeline) Stop(ctx context.Context) error {
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
 
 	p.mu.Lock()
 	if !p.running {
 		p.mu.Unlock()
-		return
+		return nil
 	}
 	stopCh := p.stopCh
+	rootCancel := p.rootCancel
 	p.running = false
 	p.mu.Unlock()
 
+	if ctx == nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), defaultStopTimeout)
+		defer cancel()
+	}
+
 	p.failQueuedJobs("pipeline_stopped", "ingestion pipeline stopped before processing job")
 	close(stopCh)
-	p.wg.Wait()
+
+	// Wait for workers to drain, bounded by ctx. On timeout, cancel the root
+	// context so in-flight jobs abort at their next stage checkpoint, then
+	// return without waiting further — Stop must not block past ctx.
+	//
+	// Note: a job wedged *inside* a single stage (e.g. an embedder or backend
+	// call that ignores context) cannot be interrupted here; that worker unwinds
+	// only once the stage returns. Making individual stages ctx-aware is handled
+	// by the follow-up embedder/backend context work. Stop's own contract —
+	// returning within ctx — holds regardless.
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if rootCancel != nil {
+			rootCancel()
+		}
+		return nil
+	case <-ctx.Done():
+		if rootCancel != nil {
+			rootCancel()
+		}
+		return ctx.Err()
+	}
 }
 
 // AttachFile queues a file for processing and returns the VectorStoreFile status.
@@ -269,60 +321,78 @@ func (p *IngestionPipeline) DetachFile(ctx context.Context, vectorStoreID, vsfID
 }
 
 // worker is the background goroutine that processes ingestion jobs.
-func (p *IngestionPipeline) worker(stopCh <-chan struct{}) {
+func (p *IngestionPipeline) worker(ctx context.Context, stopCh <-chan struct{}) {
 	defer p.wg.Done()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case <-stopCh:
 			return
 		case job, ok := <-p.jobQueue:
 			if !ok {
 				return
 			}
-			p.processJob(job)
+			p.processJob(ctx, job)
 		}
 	}
 }
 
-// processJob executes the full ingestion pipeline for a single file.
-func (p *IngestionPipeline) processJob(job IngestionJob) {
-	ctx := context.Background()
+// processJob executes the full ingestion pipeline for a single file. It derives
+// all backend work from ctx, and checks ctx between stages so a Stop that
+// cancels the lifecycle context aborts the job promptly instead of running to
+// completion.
+func (p *IngestionPipeline) processJob(ctx context.Context, job IngestionJob) {
+	if err := ctx.Err(); err != nil {
+		p.failJob(ctx, job, "cancelled", "ingestion cancelled before start")
+		return
+	}
 
 	// Step 1: Read file content.
 	content, err := p.fileStore.Read(job.FileID)
 	if err != nil {
-		p.failJob(job, "read_error", fmt.Sprintf("failed to read file: %v", err))
+		p.failJob(ctx, job, "read_error", fmt.Sprintf("failed to read file: %v", err))
 		return
 	}
 
 	// Step 2: Get filename for parser.
 	record, err := p.fileStore.Get(job.FileID)
 	if err != nil {
-		p.failJob(job, "metadata_error", fmt.Sprintf("failed to get file metadata: %v", err))
+		p.failJob(ctx, job, "metadata_error", fmt.Sprintf("failed to get file metadata: %v", err))
 		return
 	}
 
 	// Step 3: Extract text.
 	text, err := ExtractText(content, record.Filename)
 	if err != nil {
-		p.failJob(job, "parse_error", fmt.Sprintf("failed to extract text: %v", err))
+		p.failJob(ctx, job, "parse_error", fmt.Sprintf("failed to extract text: %v", err))
+		return
+	}
+
+	if err := ctx.Err(); err != nil {
+		p.failJob(ctx, job, "cancelled", "ingestion cancelled before chunking")
 		return
 	}
 
 	// Step 4: Chunk text.
 	chunks := ChunkText(text, job.ChunkingStrategy)
 	if len(chunks) == 0 {
-		p.failJob(job, "empty_content", "file produced no text chunks")
+		p.failJob(ctx, job, "empty_content", "file produced no text chunks")
 		return
 	}
 
 	// Step 5: Embed each chunk.
 	embeddedChunks := make([]EmbeddedChunk, 0, len(chunks))
 	for _, chunk := range chunks {
+		if err := ctx.Err(); err != nil {
+			p.failJob(ctx, job, "cancelled", fmt.Sprintf("ingestion cancelled before embedding chunk %d", chunk.ChunkIndex))
+			return
+		}
+
 		embedding, err := p.embedder.Embed(chunk.Content)
 		if err != nil {
-			p.failJob(job, "embedding_error", fmt.Sprintf("failed to embed chunk %d: %v", chunk.ChunkIndex, err))
+			p.failJob(ctx, job, "embedding_error", fmt.Sprintf("failed to embed chunk %d: %v", chunk.ChunkIndex, err))
 			return
 		}
 
@@ -338,27 +408,35 @@ func (p *IngestionPipeline) processJob(job IngestionJob) {
 		embeddedChunks = append(embeddedChunks, ec)
 	}
 
+	if err := ctx.Err(); err != nil {
+		p.failJob(ctx, job, "cancelled", "ingestion cancelled before storage")
+		return
+	}
+
 	// Step 6: Insert into backend.
 	if err := p.backend.InsertChunks(ctx, job.VectorStoreID, embeddedChunks); err != nil {
-		p.failJob(job, "storage_error", fmt.Sprintf("failed to store chunks: %v", err))
+		p.failJob(ctx, job, "storage_error", fmt.Sprintf("failed to store chunks: %v", err))
 		return
 	}
 
 	// Mark as completed.
 	p.setFileStatus(job.VectorStoreFileID, "completed", nil)
-	_ = p.manager.UpdateFileCounts(context.Background(), job.VectorStoreID, func(fc *FileCounts) {
+	_ = p.manager.UpdateFileCounts(ctx, job.VectorStoreID, func(fc *FileCounts) {
 		fc.InProgress--
 		fc.Completed++
 	})
 }
 
 // failJob marks a job as failed and updates file counts.
-func (p *IngestionPipeline) failJob(job IngestionJob, code, message string) {
+func (p *IngestionPipeline) failJob(ctx context.Context, job IngestionJob, code, message string) {
 	p.setFileStatus(job.VectorStoreFileID, "failed", &FileError{
 		Code:    code,
 		Message: message,
 	})
-	_ = p.manager.UpdateFileCounts(context.Background(), job.VectorStoreID, func(fc *FileCounts) {
+	// Count updates use a background context: even when the job context is
+	// cancelled, the in-memory counts and durable metadata must stay consistent
+	// with the file status we just wrote.
+	_ = p.manager.UpdateFileCounts(context.WithoutCancel(ctx), job.VectorStoreID, func(fc *FileCounts) {
 		fc.InProgress--
 		fc.Failed++
 	})
@@ -368,7 +446,7 @@ func (p *IngestionPipeline) failQueuedJobs(code, message string) {
 	for {
 		select {
 		case job := <-p.jobQueue:
-			p.failJob(job, code, message)
+			p.failJob(context.Background(), job, code, message)
 		default:
 			return
 		}

--- a/src/semantic-router/pkg/vectorstore/pipeline.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline.go
@@ -383,29 +383,9 @@ func (p *IngestionPipeline) processJob(ctx context.Context, job IngestionJob) {
 	}
 
 	// Step 5: Embed each chunk.
-	embeddedChunks := make([]EmbeddedChunk, 0, len(chunks))
-	for _, chunk := range chunks {
-		if err := ctx.Err(); err != nil {
-			p.failJob(ctx, job, "cancelled", fmt.Sprintf("ingestion cancelled before embedding chunk %d", chunk.ChunkIndex))
-			return
-		}
-
-		embedding, err := p.embedder.Embed(chunk.Content)
-		if err != nil {
-			p.failJob(ctx, job, "embedding_error", fmt.Sprintf("failed to embed chunk %d: %v", chunk.ChunkIndex, err))
-			return
-		}
-
-		ec := EmbeddedChunk{
-			ID:            fmt.Sprintf("%s_chunk_%d", job.FileID, chunk.ChunkIndex),
-			FileID:        job.FileID,
-			Filename:      record.Filename,
-			Content:       chunk.Content,
-			Embedding:     embedding,
-			ChunkIndex:    chunk.ChunkIndex,
-			VectorStoreID: job.VectorStoreID,
-		}
-		embeddedChunks = append(embeddedChunks, ec)
+	embeddedChunks, ok := p.embedChunks(ctx, job, record.Filename, chunks)
+	if !ok {
+		return
 	}
 
 	if err := ctx.Err(); err != nil {
@@ -425,6 +405,36 @@ func (p *IngestionPipeline) processJob(ctx context.Context, job IngestionJob) {
 		fc.InProgress--
 		fc.Completed++
 	})
+}
+
+// embedChunks embeds each chunk, checking ctx before each embedding call so a
+// cancelled lifecycle context aborts promptly. On any error it fails the job
+// and returns ok=false; the caller should stop processing.
+func (p *IngestionPipeline) embedChunks(ctx context.Context, job IngestionJob, filename string, chunks []TextChunk) ([]EmbeddedChunk, bool) {
+	embeddedChunks := make([]EmbeddedChunk, 0, len(chunks))
+	for _, chunk := range chunks {
+		if err := ctx.Err(); err != nil {
+			p.failJob(ctx, job, "cancelled", fmt.Sprintf("ingestion cancelled before embedding chunk %d", chunk.ChunkIndex))
+			return nil, false
+		}
+
+		embedding, err := p.embedder.Embed(chunk.Content)
+		if err != nil {
+			p.failJob(ctx, job, "embedding_error", fmt.Sprintf("failed to embed chunk %d: %v", chunk.ChunkIndex, err))
+			return nil, false
+		}
+
+		embeddedChunks = append(embeddedChunks, EmbeddedChunk{
+			ID:            fmt.Sprintf("%s_chunk_%d", job.FileID, chunk.ChunkIndex),
+			FileID:        job.FileID,
+			Filename:      filename,
+			Content:       chunk.Content,
+			Embedding:     embedding,
+			ChunkIndex:    chunk.ChunkIndex,
+			VectorStoreID: job.VectorStoreID,
+		})
+	}
+	return embeddedChunks, true
 }
 
 // failJob marks a job as failed and updates file counts.

--- a/src/semantic-router/pkg/vectorstore/pipeline.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
 // Embedder generates vector embeddings from text. Implementations
@@ -43,27 +45,71 @@ type IngestionJob struct {
 // backend or embedder is wedged.
 const defaultStopTimeout = 30 * time.Second
 
+// cleanupTimeout bounds the best-effort metadata/persistence work Stop performs
+// outside the drain wait (failing queued jobs). It is derived from the caller's
+// Stop deadline but capped so a wedged metadata registry cannot keep Stop
+// running past its own contract.
+const cleanupTimeout = 5 * time.Second
+
+// lifecycleState tracks where a pipeline generation is in its lifecycle so Stop
+// can report honestly and Start can refuse to reuse a generation that has not
+// finished joining.
+type lifecycleState int
+
+const (
+	// stateStopped means no generation is live: Start may create a new one.
+	stateStopped lifecycleState = iota
+	// stateRunning means the current generation is accepting and processing jobs.
+	stateRunning
+	// stateStopping means Stop was called but the current generation's workers
+	// have not finished joining (e.g. a bounded Stop timed out with a wedged
+	// worker still live). The generation's resources must not be reused until it
+	// reaches stateStopped.
+	stateStopping
+)
+
+// pipelineGeneration owns the per-Start resources whose lifetimes must not
+// outlive a single running/stopping cycle. Giving each generation its own
+// WaitGroup, queue, stop channel, and root context means a timed-out Stop that
+// leaves old workers live can never race a subsequent Start: the new generation
+// gets fresh resources, and the old one is joined independently.
+type pipelineGeneration struct {
+	id         uint64
+	jobQueue   chan IngestionJob
+	stopCh     chan struct{}
+	wg         sync.WaitGroup
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+	// done is closed once every worker in this generation has returned. A Stop
+	// that timed out can be retried by waiting on this channel, and Start blocks
+	// on it before creating the next generation.
+	done chan struct{}
+}
+
 // IngestionPipeline processes file attachment jobs asynchronously.
 // It reads files, extracts text, chunks, embeds, and stores the
 // resulting vectors in the backend.
 type IngestionPipeline struct {
-	backend      VectorStoreBackend
-	fileStore    *FileStore
-	manager      *Manager
-	embedder     Embedder
-	jobQueue     chan IngestionJob
-	workers      int
-	lifecycleMu  sync.Mutex
+	backend   VectorStoreBackend
+	fileStore *FileStore
+	manager   *Manager
+	embedder  Embedder
+	workers   int
+	queueSize int
+
+	// lifecycleMu serializes Start/Stop so generations are created and joined
+	// one at a time. It is never held across unbounded I/O.
+	lifecycleMu sync.Mutex
+
 	mu           sync.RWMutex
 	fileStatuses map[string]*VectorStoreFile // vsf_id -> status
-	wg           sync.WaitGroup
-	stopCh       chan struct{}
-	// rootCtx is the pipeline lifecycle context. All per-job work derives from
-	// it, so cancelling rootCancel signals every in-flight job to abort at its
-	// next checkpoint. It is (re)created on each Start.
-	rootCtx    context.Context
-	rootCancel context.CancelFunc
-	running    bool
+
+	// state and gen are guarded by mu. gen is the current generation; callers
+	// that need to enqueue or inspect the live queue read it under mu.
+	state lifecycleState
+	gen   *pipelineGeneration
+	// genSeq monotonically numbers generations for diagnostics.
+	genSeq uint64
 }
 
 // PipelineConfig holds configuration for the ingestion pipeline.
@@ -88,56 +134,103 @@ func NewIngestionPipeline(backend VectorStoreBackend, fileStore *FileStore, mana
 		fileStore:    fileStore,
 		manager:      manager,
 		embedder:     embedder,
-		jobQueue:     make(chan IngestionJob, queueSize),
 		workers:      workers,
+		queueSize:    queueSize,
 		fileStatuses: make(map[string]*VectorStoreFile),
-		stopCh:       make(chan struct{}),
+		state:        stateStopped,
 	}
 }
 
-// Start launches the worker goroutines.
+// Start launches the worker goroutines for a fresh generation.
+//
+// If a previous generation is still stopping (a bounded Stop timed out with
+// workers not yet joined), Start blocks until that generation has fully joined
+// before creating the next one. This guarantees a new generation never shares a
+// WaitGroup, queue, or root context with a still-live old generation.
+//
+// The wait for a stopping generation happens WITHOUT holding lifecycleMu, so a
+// concurrent AttachFile or retry Stop is never blocked behind a Start that is
+// itself parked on a wedged old generation. lifecycleMu is only held for the
+// brief state check and generation creation.
 func (p *IngestionPipeline) Start() {
-	p.lifecycleMu.Lock()
-	defer p.lifecycleMu.Unlock()
+	for {
+		p.lifecycleMu.Lock()
 
-	p.mu.Lock()
-	if p.running {
+		p.mu.Lock()
+		state := p.state
+		var prevDone chan struct{}
+		if state == stateStopping && p.gen != nil {
+			prevDone = p.gen.done
+		}
 		p.mu.Unlock()
+
+		switch state {
+		case stateRunning:
+			// Already running: idempotent no-op.
+			p.lifecycleMu.Unlock()
+			return
+		case stateStopping:
+			// A previous generation is still unwinding. Release lifecycleMu before
+			// waiting so attaches/Stops can proceed, then retry the transition.
+			p.lifecycleMu.Unlock()
+			if prevDone != nil {
+				<-prevDone
+			}
+			continue
+		}
+
+		// stateStopped: create the next generation while holding lifecycleMu.
+		p.mu.Lock()
+		p.genSeq++
+		gen := &pipelineGeneration{
+			id:       p.genSeq,
+			jobQueue: make(chan IngestionJob, p.queueSize),
+			stopCh:   make(chan struct{}),
+			done:     make(chan struct{}),
+		}
+		gen.rootCtx, gen.rootCancel = context.WithCancel(context.Background())
+		p.gen = gen
+		p.state = stateRunning
+		p.mu.Unlock()
+
+		for i := 0; i < p.workers; i++ {
+			gen.wg.Add(1)
+			go p.worker(gen)
+		}
+		// Reap this generation's workers so a later Start/Stop can observe join
+		// completion via gen.done without holding any lock across the wait. Once
+		// joined, self-heal the state: if this generation is still current and
+		// stopping (a bounded Stop timed out and later released), move it to
+		// stopped so the pipeline reflects reality without needing another call.
+		go func() {
+			gen.wg.Wait()
+			close(gen.done)
+			p.markGenerationStopped(gen)
+		}()
+		p.lifecycleMu.Unlock()
 		return
 	}
-	p.stopCh = make(chan struct{})
-	stopCh := p.stopCh
-	p.rootCtx, p.rootCancel = context.WithCancel(context.Background())
-	rootCtx := p.rootCtx
-	p.running = true
-	p.mu.Unlock()
-
-	for i := 0; i < p.workers; i++ {
-		p.wg.Add(1)
-		go p.worker(rootCtx, stopCh)
-	}
 }
 
-// Stop gracefully shuts down the pipeline, bounded by ctx.
+// Stop gracefully shuts down the current generation, bounded by ctx.
 //
-// It stops accepting new jobs, fails any still queued, and waits for in-flight
-// jobs to drain. If ctx is cancelled or its deadline elapses before draining
-// completes, the pipeline root context is cancelled so in-flight jobs abort at
-// their next checkpoint, and Stop returns ctx.Err() without blocking further.
-// A nil ctx is treated as a bounded shutdown with defaultStopTimeout.
+// It stops accepting new jobs, fails any still queued (bounded by a cleanup
+// deadline so a wedged metadata registry cannot stall shutdown), and waits for
+// in-flight jobs to drain. If ctx is cancelled or its deadline elapses before
+// draining completes, the generation's root context is cancelled so in-flight
+// jobs abort at their next checkpoint, and Stop returns ctx.Err() without
+// blocking further. A nil ctx is treated as a bounded shutdown with
+// defaultStopTimeout.
+//
+// Honest lifecycle reporting: if the drain times out, the generation stays in
+// stateStopping (its workers are still live). A subsequent Stop does not return
+// nil — it waits on the same generation's completion (bounded by its own ctx)
+// and only reports success once the workers have actually joined. This lets a
+// caller retry the join with a longer deadline instead of being told shutdown
+// succeeded when it did not.
 func (p *IngestionPipeline) Stop(ctx context.Context) error {
 	p.lifecycleMu.Lock()
 	defer p.lifecycleMu.Unlock()
-
-	p.mu.Lock()
-	if !p.running {
-		p.mu.Unlock()
-		return nil
-	}
-	stopCh := p.stopCh
-	rootCancel := p.rootCancel
-	p.running = false
-	p.mu.Unlock()
 
 	if ctx == nil {
 		var cancel context.CancelFunc
@@ -145,35 +238,89 @@ func (p *IngestionPipeline) Stop(ctx context.Context) error {
 		defer cancel()
 	}
 
-	p.failQueuedJobs("pipeline_stopped", "ingestion pipeline stopped before processing job")
-	close(stopCh)
+	p.mu.Lock()
+	switch p.state {
+	case stateStopped:
+		// Nothing live to join.
+		p.mu.Unlock()
+		return nil
+	case stateStopping:
+		// A prior Stop timed out; this generation's workers are still unwinding.
+		// Wait on its completion (bounded by ctx) rather than falsely reporting a
+		// clean shutdown.
+		gen := p.gen
+		p.mu.Unlock()
+		return p.awaitGeneration(ctx, gen)
+	}
+
+	// stateRunning: begin shutting this generation down.
+	gen := p.gen
+	p.state = stateStopping
+	p.mu.Unlock()
+
+	// Fail queued jobs under a bounded cleanup context so a stalled registry
+	// cannot keep Stop running past its deadline. This runs before the drain
+	// wait but is itself bounded, and lifecycleMu is not held across the
+	// per-job persistence I/O inside failQueuedJobs (it uses the cleanup ctx).
+	p.failQueuedJobs(ctx, gen, "pipeline_stopped", "ingestion pipeline stopped before processing job")
+	close(gen.stopCh)
 
 	// Wait for workers to drain, bounded by ctx. On timeout, cancel the root
 	// context so in-flight jobs abort at their next stage checkpoint, then
-	// return without waiting further — Stop must not block past ctx.
+	// return without waiting further — Stop must not block past ctx. The
+	// generation remains in stateStopping until its workers join (observed via
+	// gen.done by awaitGeneration/Start).
 	//
 	// Note: a job wedged *inside* a single stage (e.g. an embedder or backend
 	// call that ignores context) cannot be interrupted here; that worker unwinds
 	// only once the stage returns. Making individual stages ctx-aware is handled
 	// by the follow-up embedder/backend context work. Stop's own contract —
 	// returning within ctx — holds regardless.
-	done := make(chan struct{})
-	go func() {
-		p.wg.Wait()
-		close(done)
-	}()
+	return p.awaitGeneration(ctx, gen)
+}
+
+// awaitGeneration waits for gen's workers to finish joining, bounded by ctx.
+// On graceful completion it transitions to stateStopped and returns nil,
+// letting any in-flight job run to completion. On ctx expiry it cancels the
+// generation root context so in-flight jobs abort at their next checkpoint,
+// then returns ctx.Err() while leaving the generation in stateStopping so a
+// later call can retry the join.
+func (p *IngestionPipeline) awaitGeneration(ctx context.Context, gen *pipelineGeneration) error {
+	if gen == nil {
+		return nil
+	}
 
 	select {
-	case <-done:
-		if rootCancel != nil {
-			rootCancel()
+	case <-gen.done:
+		// Workers drained gracefully; cancel the (now-unused) root to release its
+		// resources. Cancellation here cannot abort any work — every worker has
+		// already returned.
+		if gen.rootCancel != nil {
+			gen.rootCancel()
 		}
+		p.markGenerationStopped(gen)
 		return nil
 	case <-ctx.Done():
-		if rootCancel != nil {
-			rootCancel()
+		// Deadline elapsed with workers still live. Signal in-flight jobs to abort
+		// at their next checkpoint, but do not block further — Stop must return
+		// within ctx. Stay in stateStopping so the caller can retry the join with
+		// a longer deadline. Cancelling is idempotent, so repeated timed-out Stop
+		// calls on the same generation are safe.
+		if gen.rootCancel != nil {
+			gen.rootCancel()
 		}
 		return ctx.Err()
+	}
+}
+
+// markGenerationStopped transitions the pipeline to stateStopped if gen is still
+// the current generation and its workers have joined. It is safe to call more
+// than once for the same generation.
+func (p *IngestionPipeline) markGenerationStopped(gen *pipelineGeneration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.gen == gen && p.state == stateStopping {
+		p.state = stateStopped
 	}
 }
 
@@ -191,13 +338,6 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 		return nil, fmt.Errorf("vector store not found: %w", err)
 	}
 
-	p.lifecycleMu.Lock()
-	defer p.lifecycleMu.Unlock()
-
-	if !p.isRunningLocked() {
-		return nil, fmt.Errorf("ingestion pipeline is not running")
-	}
-
 	vsfID := GenerateVectorStoreFileID()
 	vsf := &VectorStoreFile{
 		ID:               vsfID,
@@ -208,17 +348,6 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 		ChunkingStrategy: strategy,
 		CreatedAt:        time.Now().Unix(),
 	}
-
-	p.mu.Lock()
-	p.fileStatuses[vsfID] = cloneVectorStoreFile(vsf)
-	p.mu.Unlock()
-
-	// Update file counts.
-	_ = p.manager.UpdateFileCounts(context.Background(), vectorStoreID, func(fc *FileCounts) {
-		fc.InProgress++
-		fc.Total++
-	})
-
 	job := IngestionJob{
 		VectorStoreFileID: vsfID,
 		VectorStoreID:     vectorStoreID,
@@ -226,20 +355,45 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 		ChunkingStrategy:  strategy,
 	}
 
-	// Snapshot before enqueuing so the caller always sees "in_progress",
-	// even if the worker completes the job before we return.
-	snapshot := cloneVectorStoreFile(vsf)
+	// Fast pre-check (no I/O): reject before reserving any count if the pipeline
+	// is not currently running. This avoids an increment/compensate round-trip in
+	// the common not-running case and, together with Start not holding
+	// lifecycleMu while it waits out a stopping generation, ensures a reserved
+	// count is always either consumed by a worker or compensated below — never
+	// stranded behind a Start parked on a wedged old generation.
+	if !p.isRunning() {
+		return nil, fmt.Errorf("ingestion pipeline is not running")
+	}
 
-	select {
-	case p.jobQueue <- job:
+	// Increment the durable count BEFORE enqueueing and OUTSIDE lifecycleMu,
+	// using a bounded context. Doing the increment first guarantees a worker can
+	// never observe (and decrement for) this job before its in_progress count is
+	// recorded, so the count never transiently goes negative. Doing it outside
+	// lifecycleMu with a bounded context guarantees a slow/wedged metadata
+	// registry can never keep AttachFile holding lifecycleMu and thereby block
+	// Stop past its deadline (the P1-class hang, via the attach path).
+	countCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+	_ = p.manager.UpdateFileCounts(countCtx, vectorStoreID, func(fc *FileCounts) {
+		fc.InProgress++
+		fc.Total++
+	})
+
+	snapshot := cloneVectorStoreFile(vsf)
+	switch p.enqueueJob(vsfID, vsf, job) {
+	case enqueueQueued:
 		return snapshot, nil
-	default:
-		// Queue is full.
-		p.setFileStatus(vsfID, "failed", &FileError{
-			Code:    "queue_full",
-			Message: "ingestion queue is full, try again later",
-		})
-		_ = p.manager.UpdateFileCounts(context.Background(), vectorStoreID, func(fc *FileCounts) {
+	case enqueueNotRunning:
+		// Incremented above but the pipeline is not running, so no worker will
+		// process this job. Compensate the reservation (bounded, outside lock).
+		p.compensateAttachCount(vectorStoreID)
+		return nil, fmt.Errorf("ingestion pipeline is not running")
+	default: // enqueueQueueFull
+		// Move the count from in_progress to failed (bounded, outside lock). Net
+		// effect over both updates: Total+1, Failed+1, InProgress 0.
+		failCtx, failCancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer failCancel()
+		_ = p.manager.UpdateFileCounts(failCtx, vectorStoreID, func(fc *FileCounts) {
 			fc.InProgress--
 			fc.Failed++
 		})
@@ -251,11 +405,78 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 	}
 }
 
-func (p *IngestionPipeline) isRunningLocked() bool {
+// enqueueResult reports the outcome of the AttachFile enqueue critical section.
+type enqueueResult int
+
+const (
+	enqueueQueued enqueueResult = iota
+	enqueueNotRunning
+	enqueueQueueFull
+)
+
+// enqueueJob runs the enqueue critical section under lifecycleMu: it captures
+// the running generation, registers the in-memory status, and enqueues the job.
+// Holding lifecycleMu makes the enqueue atomic with respect to Stop's queue
+// drain, so a job can never land in a queue whose workers have already exited.
+// No unbounded I/O happens under the lock.
+func (p *IngestionPipeline) enqueueJob(vsfID string, vsf *VectorStoreFile, job IngestionJob) enqueueResult {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
+	gen := p.runningGeneration()
+	if gen == nil {
+		return enqueueNotRunning
+	}
+
+	p.mu.Lock()
+	p.fileStatuses[vsfID] = cloneVectorStoreFile(vsf)
+	p.mu.Unlock()
+
+	select {
+	case gen.jobQueue <- job:
+		return enqueueQueued
+	default:
+		p.setFileStatus(vsfID, "failed", &FileError{
+			Code:    "queue_full",
+			Message: "ingestion queue is full, try again later",
+		})
+		return enqueueQueueFull
+	}
+}
+
+// compensateAttachCount reverses the in_progress/total increment made by
+// AttachFile when the job could not be enqueued because the pipeline is not
+// running. It uses a bounded context and is never called under lifecycleMu.
+func (p *IngestionPipeline) compensateAttachCount(vectorStoreID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+	_ = p.manager.UpdateFileCounts(ctx, vectorStoreID, func(fc *FileCounts) {
+		fc.InProgress--
+		fc.Total--
+	})
+}
+
+// runningGeneration returns the current generation only when the pipeline is in
+// stateRunning, else nil. It takes p.mu itself; callers hold lifecycleMu so the
+// returned generation cannot be swapped out before the caller enqueues onto it.
+func (p *IngestionPipeline) runningGeneration() *pipelineGeneration {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	return p.running
+	if p.state != stateRunning {
+		return nil
+	}
+	return p.gen
+}
+
+// isRunning reports whether the pipeline is currently in stateRunning. It is a
+// lock-free-of-lifecycleMu snapshot used as a fast pre-check; the authoritative
+// check happens under lifecycleMu in the enqueue critical section.
+func (p *IngestionPipeline) isRunning() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.state == stateRunning
 }
 
 // GetFileStatus returns the current status of a vector store file.
@@ -320,21 +541,24 @@ func (p *IngestionPipeline) DetachFile(ctx context.Context, vectorStoreID, vsfID
 	return nil
 }
 
-// worker is the background goroutine that processes ingestion jobs.
-func (p *IngestionPipeline) worker(ctx context.Context, stopCh <-chan struct{}) {
-	defer p.wg.Done()
+// worker is the background goroutine that processes ingestion jobs for a single
+// generation. It reads only from that generation's queue and derives per-job
+// work from that generation's root context, so it can never service a job that
+// belongs to a newer generation.
+func (p *IngestionPipeline) worker(gen *pipelineGeneration) {
+	defer gen.wg.Done()
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-gen.rootCtx.Done():
 			return
-		case <-stopCh:
+		case <-gen.stopCh:
 			return
-		case job, ok := <-p.jobQueue:
+		case job, ok := <-gen.jobQueue:
 			if !ok {
 				return
 			}
-			p.processJob(ctx, job)
+			p.processJob(gen.rootCtx, job)
 		}
 	}
 }
@@ -399,12 +623,29 @@ func (p *IngestionPipeline) processJob(ctx context.Context, job IngestionJob) {
 		return
 	}
 
-	// Mark as completed.
+	// Mark as completed. Commit the status and the durable count coherently:
+	// once InsertChunks has succeeded the chunks are persisted, so the count
+	// update must not be dropped just because shutdown cancelled the job ctx
+	// between insert and persist. Use a detached, bounded cleanup context
+	// (WithoutCancel + timeout) so the completed transition is recorded even
+	// under a racing Stop, and surface a persistence failure instead of leaving
+	// the durable count silently stale.
 	p.setFileStatus(job.VectorStoreFileID, "completed", nil)
-	_ = p.manager.UpdateFileCounts(ctx, job.VectorStoreID, func(fc *FileCounts) {
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+	defer cancel()
+	if err := p.manager.UpdateFileCounts(persistCtx, job.VectorStoreID, func(fc *FileCounts) {
 		fc.InProgress--
 		fc.Completed++
-	})
+	}); err != nil {
+		// The chunks are durably stored and the in-memory status is completed,
+		// but the durable count could not be persisted. Surface it so the
+		// inconsistency is observable rather than silently swallowed; the
+		// in-memory count still reflects the completion for the running process.
+		logging.Warnf(
+			"vectorstore: chunks stored for file %s but completed-count persist failed: %v",
+			job.VectorStoreFileID, err,
+		)
+	}
 }
 
 // embedChunks embeds each chunk, checking ctx before each embedding call so a
@@ -437,26 +678,56 @@ func (p *IngestionPipeline) embedChunks(ctx context.Context, job IngestionJob, f
 	return embeddedChunks, true
 }
 
-// failJob marks a job as failed and updates file counts.
+// failJob marks a job as failed and updates file counts. The count update is
+// detached from the (possibly cancelled) job context so the in-memory counts
+// and durable metadata stay consistent with the failed status we just wrote,
+// but bounded by cleanupTimeout so a wedged metadata registry cannot make a
+// worker's failure path hang.
 func (p *IngestionPipeline) failJob(ctx context.Context, job IngestionJob, code, message string) {
 	p.setFileStatus(job.VectorStoreFileID, "failed", &FileError{
 		Code:    code,
 		Message: message,
 	})
-	// Count updates use a background context: even when the job context is
-	// cancelled, the in-memory counts and durable metadata must stay consistent
-	// with the file status we just wrote.
-	_ = p.manager.UpdateFileCounts(context.WithoutCancel(ctx), job.VectorStoreID, func(fc *FileCounts) {
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+	defer cancel()
+	_ = p.manager.UpdateFileCounts(persistCtx, job.VectorStoreID, func(fc *FileCounts) {
 		fc.InProgress--
 		fc.Failed++
 	})
 }
 
-func (p *IngestionPipeline) failQueuedJobs(code, message string) {
+// failQueuedJobs drains the given generation's queue and marks each still-queued
+// job failed, bounded by ctx. Every drained job's in-memory status is set to
+// failed unconditionally — that is cheap (no I/O) and must happen so no queued
+// job is left stuck in_progress after shutdown. Only the durable count
+// persistence is bounded by ctx: queued jobs never produced durable chunks, so
+// when the registry is wedged we honor the Stop deadline and skip the persist
+// rather than blocking shutdown. The full queue is always drained (the loop
+// exits only when the queue is empty), so no job is lost regardless of ctx.
+// lifecycleMu is held by the caller, but the per-job persistence uses ctx (not
+// an unbounded background context), so the lock is never held across unbounded
+// I/O.
+func (p *IngestionPipeline) failQueuedJobs(ctx context.Context, gen *pipelineGeneration, code, message string) {
 	for {
 		select {
-		case job := <-p.jobQueue:
-			p.failJob(context.Background(), job, code, message)
+		case job := <-gen.jobQueue:
+			// Always record the in-memory failed status (no I/O) so a drained job
+			// is never left stuck in_progress, even past the Stop deadline.
+			p.setFileStatus(job.VectorStoreFileID, "failed", &FileError{
+				Code:    code,
+				Message: message,
+			})
+			// Bound the durable count persist by the Stop deadline (ctx) as well as
+			// a per-write cap. When ctx is already expired, WithTimeout yields an
+			// already-canceled context and UpdateFileCounts returns promptly; the
+			// in-memory count is still decremented, only the durable write is
+			// skipped. Honoring ctx takes priority — Stop must not block past it.
+			persistCtx, cancel := context.WithTimeout(ctx, cleanupTimeout)
+			_ = p.manager.UpdateFileCounts(persistCtx, job.VectorStoreID, func(fc *FileCounts) {
+				fc.InProgress--
+				fc.Failed++
+			})
+			cancel()
 		default:
 			return
 		}

--- a/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
@@ -27,10 +27,11 @@ import (
 )
 
 type blockingEmbedder struct {
-	dim     int
-	once    sync.Once
-	started chan struct{}
-	release chan struct{}
+	dim         int
+	once        sync.Once
+	releaseOnce sync.Once
+	started     chan struct{}
+	release     chan struct{}
 }
 
 func newBlockingEmbedder(dim int) *blockingEmbedder {
@@ -56,6 +57,15 @@ func (e *blockingEmbedder) Embed(_ string) ([]float32, error) {
 
 func (e *blockingEmbedder) Dimension() int {
 	return e.dim
+}
+
+// releaseAll unblocks any goroutine parked in Embed. It is safe to call more
+// than once so tests and their AfterEach hooks can both release without a
+// double-close panic.
+func (e *blockingEmbedder) releaseAll() {
+	e.releaseOnce.Do(func() {
+		close(e.release)
+	})
 }
 
 type pipelineLifecycleFixture struct {
@@ -168,12 +178,7 @@ var _ = Describe("IngestionPipeline queued shutdown", func() {
 	})
 
 	It("fails queued attachments during stop", func() {
-		released := false
-		defer func() {
-			if !released {
-				close(embedder.release)
-			}
-		}()
+		defer embedder.releaseAll()
 
 		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "queued-stop"})
 		Expect(err).NotTo(HaveOccurred())
@@ -209,8 +214,7 @@ var _ = Describe("IngestionPipeline queued shutdown", func() {
 		Expect(secondStatus.LastError).NotTo(BeNil())
 		Expect(secondStatus.LastError.Code).To(Equal("pipeline_stopped"))
 
-		close(embedder.release)
-		released = true
+		embedder.releaseAll()
 		Eventually(stopped, 5*time.Second).Should(BeClosed())
 
 		firstStatus, err := f.pipeline.GetFileStatus(first.ID)
@@ -239,7 +243,8 @@ var _ = Describe("IngestionPipeline bounded Stop", func() {
 
 	AfterEach(func() {
 		// Release the wedged embedder so the worker can unwind, then clean up.
-		close(embedder.release)
+		embedder.releaseAll()
+		_ = f.pipeline.Stop(context.Background())
 		_ = os.RemoveAll(f.tempDir)
 	})
 
@@ -272,7 +277,7 @@ var _ = Describe("IngestionPipeline bounded Stop", func() {
 		Expect(time.Since(start)).To(BeNumerically("<", 3*time.Second))
 	})
 
-	It("is idempotent and safe to call after a bounded Stop", func() {
+	It("preserves the stopping state so a second Stop does not falsely report success", func() {
 		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "double-stop"})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -283,11 +288,194 @@ var _ = Describe("IngestionPipeline bounded Stop", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(embedder.started, 5*time.Second).Should(BeClosed())
 
+		// First Stop times out while the worker is wedged inside Embed.
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 		Expect(f.pipeline.Stop(ctx)).To(MatchError(context.DeadlineExceeded))
 
-		// A second Stop on an already-stopped pipeline is a no-op returning nil.
-		Expect(f.pipeline.Stop(context.Background())).To(BeNil())
+		// A second bounded Stop must NOT report a clean shutdown: the previous
+		// generation's worker is still live. It must again honor its deadline and
+		// return DeadlineExceeded rather than nil (the false-success bug).
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel2()
+		Expect(f.pipeline.Stop(ctx2)).To(MatchError(context.DeadlineExceeded))
+
+		// Once the wedged stage is released, a Stop with a real deadline observes
+		// the worker join and returns nil.
+		embedder.releaseAll()
+		Eventually(func() error {
+			ctxN, cancelN := context.WithTimeout(context.Background(), time.Second)
+			defer cancelN()
+			return f.pipeline.Stop(ctxN)
+		}, 5*time.Second, 50*time.Millisecond).Should(BeNil())
+	})
+})
+
+var _ = Describe("IngestionPipeline restart after timed-out Stop", func() {
+	var (
+		embedder *blockingEmbedder
+		f        *pipelineLifecycleFixture
+	)
+
+	BeforeEach(func() {
+		embedder = newBlockingEmbedder(3)
+		f = newPipelineLifecycleFixture(embedder)
+	})
+
+	AfterEach(func() {
+		embedder.releaseAll()
+		_ = f.pipeline.Stop(context.Background())
+		_ = os.RemoveAll(f.tempDir)
+	})
+
+	// Regression for the generation-reuse race: a bounded Stop that times out
+	// leaves the old generation's worker live. An immediate Start must create a
+	// fresh generation (its own WaitGroup, queue, and root context) rather than
+	// reusing resources the old worker still holds, so the old worker can neither
+	// corrupt the new WaitGroup nor steal a new-generation job with its cancelled
+	// root context.
+	It("starts a fresh generation and processes new jobs after a timed-out stop", func() {
+		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "restart-after-timeout"})
+		Expect(err).NotTo(HaveOccurred())
+
+		wedged, err := f.store.Save("wedged.txt", []byte("content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+
+		wedgedFile, err := f.pipeline.AttachFile(vs.ID, wedged.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Park the only worker inside Embed so Stop cannot drain gracefully.
+		Eventually(embedder.started, 5*time.Second).Should(BeClosed())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		Expect(f.pipeline.Stop(ctx)).To(MatchError(context.DeadlineExceeded))
+
+		// Immediately restart. Start must block until the still-stopping
+		// generation joins; release the wedged embedder so that join can happen.
+		startReturned := make(chan struct{})
+		go func() {
+			defer close(startReturned)
+			f.pipeline.Start()
+		}()
+
+		// Start is blocked on the old generation's join until we release it.
+		Consistently(startReturned, 200*time.Millisecond, 20*time.Millisecond).ShouldNot(BeClosed())
+		embedder.releaseAll()
+		Eventually(startReturned, 5*time.Second).Should(BeClosed())
+
+		// The new generation must process a fresh job to completion. Because the
+		// released embedder now returns immediately, this exercises the new queue
+		// and new root context.
+		fresh, err := f.store.Save("fresh.txt", []byte("fresh content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+
+		freshFile, err := f.pipeline.AttachFile(vs.ID, fresh.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() string {
+			status, statusErr := f.pipeline.GetFileStatus(freshFile.ID)
+			if statusErr != nil {
+				return ""
+			}
+			return status.Status
+		}, 5*time.Second, 50*time.Millisecond).Should(Equal("completed"))
+
+		// The wedged file from the old generation completes once its worker is
+		// released (it was mid-Embed when the deadline elapsed); either way it
+		// must not remain in_progress forever.
+		Eventually(func() string {
+			status, statusErr := f.pipeline.GetFileStatus(wedgedFile.ID)
+			if statusErr != nil {
+				return ""
+			}
+			return status.Status
+		}, 5*time.Second, 50*time.Millisecond).Should(Or(Equal("completed"), Equal("failed")))
+	})
+})
+
+var _ = Describe("IngestionPipeline attach during restart after timed-out Stop", func() {
+	var (
+		embedder *blockingEmbedder
+		f        *pipelineLifecycleFixture
+	)
+
+	BeforeEach(func() {
+		embedder = newBlockingEmbedder(3)
+		f = newPipelineLifecycleFixture(embedder)
+	})
+
+	AfterEach(func() {
+		embedder.releaseAll()
+		_ = f.pipeline.Stop(context.Background())
+		_ = os.RemoveAll(f.tempDir)
+	})
+
+	// Regression: after a timed-out Stop the pipeline is stateStopping with a
+	// wedged worker. A concurrent Start must not hold lifecycleMu while it waits
+	// for the old generation to join, otherwise a concurrent AttachFile can
+	// reserve a count and then block forever behind Start, stranding the count
+	// with no compensation. This asserts attach makes progress (does not hang)
+	// and file counts stay consistent once everything settles.
+	It("does not strand counts when attach races a restart", func() {
+		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "attach-restart-race"})
+		Expect(err).NotTo(HaveOccurred())
+
+		wedged, err := f.store.Save("wedged.txt", []byte("content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = f.pipeline.AttachFile(vs.ID, wedged.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(embedder.started, 5*time.Second).Should(BeClosed())
+
+		// Time out the Stop with the worker wedged inside Embed.
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		Expect(f.pipeline.Stop(ctx)).To(MatchError(context.DeadlineExceeded))
+
+		// Kick off a restart (will block until the wedged gen joins) and a
+		// concurrent attach. Neither must hang beyond release.
+		startDone := make(chan struct{})
+		go func() { defer close(startDone); f.pipeline.Start() }()
+
+		attachDone := make(chan error, 1)
+		go func() {
+			rec, saveErr := f.store.Save("racer.txt", []byte("content"), "assistants")
+			if saveErr != nil {
+				attachDone <- saveErr
+				return
+			}
+			_, aErr := f.pipeline.AttachFile(vs.ID, rec.ID, nil)
+			attachDone <- aErr
+		}()
+
+		// Release the wedged worker so the old generation can join and the
+		// restart can complete.
+		embedder.releaseAll()
+
+		Eventually(startDone, 5*time.Second).Should(BeClosed())
+		var attachErr error
+		Eventually(attachDone, 5*time.Second).Should(Receive(&attachErr))
+		// The attach either enqueued onto the fresh generation (nil) or was
+		// rejected because it observed the stopping/stopped window
+		// ("not running"). Both are valid; the invariant is it must not hang.
+		if attachErr != nil {
+			Expect(attachErr.Error()).To(ContainSubstring("not running"))
+		}
+
+		// Once the dust settles, counts must be internally consistent:
+		// completed + failed + in_progress == total, with no negative values and
+		// nothing permanently stuck in_progress.
+		Eventually(func() bool {
+			updated, gErr := f.mgr.GetStore(vs.ID)
+			if gErr != nil {
+				return false
+			}
+			fc := updated.FileCounts
+			if fc.InProgress != 0 {
+				return false
+			}
+			return fc.Completed+fc.Failed+fc.InProgress == fc.Total &&
+				fc.Completed >= 0 && fc.Failed >= 0 && fc.Total >= 0
+		}, 5*time.Second, 50*time.Millisecond).Should(BeTrue())
 	})
 })

--- a/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
@@ -96,7 +96,7 @@ func newPipelineLifecycleFixture(embedder Embedder) *pipelineLifecycleFixture {
 }
 
 func (f *pipelineLifecycleFixture) cleanup() {
-	f.pipeline.Stop()
+	f.pipeline.Stop(context.Background())
 	_ = os.RemoveAll(f.tempDir)
 }
 
@@ -118,7 +118,7 @@ var _ = Describe("IngestionPipeline lifecycle", func() {
 		record, err := f.store.Save("stopped.txt", []byte("content"), "assistants")
 		Expect(err).NotTo(HaveOccurred())
 
-		f.pipeline.Stop()
+		f.pipeline.Stop(context.Background())
 		_, err = f.pipeline.AttachFile(vs.ID, record.ID, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("ingestion pipeline is not running"))
@@ -130,7 +130,7 @@ var _ = Describe("IngestionPipeline lifecycle", func() {
 	})
 
 	It("restarts workers after a stop", func() {
-		f.pipeline.Stop()
+		f.pipeline.Stop(context.Background())
 		f.pipeline.Start()
 
 		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "restarted"})
@@ -193,7 +193,7 @@ var _ = Describe("IngestionPipeline queued shutdown", func() {
 		stopped := make(chan struct{})
 		go func() {
 			defer close(stopped)
-			f.pipeline.Stop()
+			f.pipeline.Stop(context.Background())
 		}()
 
 		Eventually(func() string {
@@ -223,5 +223,71 @@ var _ = Describe("IngestionPipeline queued shutdown", func() {
 		Expect(updated.FileCounts.Failed).To(Equal(1))
 		Expect(updated.FileCounts.InProgress).To(Equal(0))
 		Expect(updated.FileCounts.Total).To(Equal(2))
+	})
+})
+
+var _ = Describe("IngestionPipeline bounded Stop", func() {
+	var (
+		embedder *blockingEmbedder
+		f        *pipelineLifecycleFixture
+	)
+
+	BeforeEach(func() {
+		embedder = newBlockingEmbedder(3)
+		f = newPipelineLifecycleFixture(embedder)
+	})
+
+	AfterEach(func() {
+		// Release the wedged embedder so the worker can unwind, then clean up.
+		close(embedder.release)
+		_ = os.RemoveAll(f.tempDir)
+	})
+
+	It("returns within the deadline when a job is wedged inside a stage", func() {
+		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "wedged-stop"})
+		Expect(err).NotTo(HaveOccurred())
+
+		record, err := f.store.Save("wedged.txt", []byte("content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.pipeline.AttachFile(vs.ID, record.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait until the worker is blocked inside Embed, so Stop cannot drain
+		// gracefully and must fall back to its bounded deadline path.
+		Eventually(embedder.started, 5*time.Second).Should(BeClosed())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		stopErr := make(chan error, 1)
+		go func() { stopErr <- f.pipeline.Stop(ctx) }()
+
+		var err2 error
+		Eventually(stopErr, 5*time.Second, 20*time.Millisecond).Should(Receive(&err2))
+		Expect(err2).To(MatchError(context.DeadlineExceeded))
+		// Stop must return promptly once the deadline elapses, not hang on the
+		// wedged worker.
+		Expect(time.Since(start)).To(BeNumerically("<", 3*time.Second))
+	})
+
+	It("is idempotent and safe to call after a bounded Stop", func() {
+		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "double-stop"})
+		Expect(err).NotTo(HaveOccurred())
+
+		record, err := f.store.Save("double.txt", []byte("content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.pipeline.AttachFile(vs.ID, record.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(embedder.started, 5*time.Second).Should(BeClosed())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		Expect(f.pipeline.Stop(ctx)).To(MatchError(context.DeadlineExceeded))
+
+		// A second Stop on an already-stopped pipeline is a no-op returning nil.
+		Expect(f.pipeline.Stop(context.Background())).To(BeNil())
 	})
 })

--- a/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
@@ -96,7 +96,7 @@ func newPipelineLifecycleFixture(embedder Embedder) *pipelineLifecycleFixture {
 }
 
 func (f *pipelineLifecycleFixture) cleanup() {
-	f.pipeline.Stop(context.Background())
+	_ = f.pipeline.Stop(context.Background())
 	_ = os.RemoveAll(f.tempDir)
 }
 
@@ -118,7 +118,7 @@ var _ = Describe("IngestionPipeline lifecycle", func() {
 		record, err := f.store.Save("stopped.txt", []byte("content"), "assistants")
 		Expect(err).NotTo(HaveOccurred())
 
-		f.pipeline.Stop(context.Background())
+		_ = f.pipeline.Stop(context.Background())
 		_, err = f.pipeline.AttachFile(vs.ID, record.ID, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("ingestion pipeline is not running"))
@@ -130,7 +130,7 @@ var _ = Describe("IngestionPipeline lifecycle", func() {
 	})
 
 	It("restarts workers after a stop", func() {
-		f.pipeline.Stop(context.Background())
+		_ = f.pipeline.Stop(context.Background())
 		f.pipeline.Start()
 
 		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "restarted"})
@@ -193,7 +193,7 @@ var _ = Describe("IngestionPipeline queued shutdown", func() {
 		stopped := make(chan struct{})
 		go func() {
 			defer close(stopped)
-			f.pipeline.Stop(context.Background())
+			_ = f.pipeline.Stop(context.Background())
 		}()
 
 		Eventually(func() string {

--- a/src/semantic-router/pkg/vectorstore/pipeline_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_test.go
@@ -91,7 +91,7 @@ func newIngestionPipelineTestFixture() *ingestionPipelineTestFixture {
 func (f *ingestionPipelineTestFixture) cleanup() {
 	GinkgoHelper()
 
-	f.pipeline.Stop()
+	f.pipeline.Stop(context.Background())
 	Expect(os.RemoveAll(f.tempDir)).To(Succeed())
 }
 
@@ -306,7 +306,7 @@ var _ = Describe("IngestionPipeline status, detach, and lifecycle", func() {
 
 	It("should start and stop idempotently", func() {
 		f.pipeline.Start()
-		f.pipeline.Stop()
-		f.pipeline.Stop()
+		f.pipeline.Stop(context.Background())
+		f.pipeline.Stop(context.Background())
 	})
 })

--- a/src/semantic-router/pkg/vectorstore/pipeline_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_test.go
@@ -91,7 +91,7 @@ func newIngestionPipelineTestFixture() *ingestionPipelineTestFixture {
 func (f *ingestionPipelineTestFixture) cleanup() {
 	GinkgoHelper()
 
-	f.pipeline.Stop(context.Background())
+	_ = f.pipeline.Stop(context.Background())
 	Expect(os.RemoveAll(f.tempDir)).To(Succeed())
 }
 
@@ -306,7 +306,7 @@ var _ = Describe("IngestionPipeline status, detach, and lifecycle", func() {
 
 	It("should start and stop idempotently", func() {
 		f.pipeline.Start()
-		f.pipeline.Stop(context.Background())
-		f.pipeline.Stop(context.Background())
+		_ = f.pipeline.Stop(context.Background())
+		_ = f.pipeline.Stop(context.Background())
 	})
 })


### PR DESCRIPTION
## Purpose

- Give the vector-store ingestion pipeline a cancellable lifecycle root context and replace the unbounded `Stop()` with a bounded `Stop(ctx) error`.
- Today `processJob` runs with a hardcoded `context.Background()` and `Stop()` waits on an unbounded `wg.Wait()`. If an embedder or backend wedges inside a stage, `Stop()` blocks forever and the process cannot shut down. This is the first, foundational slice of the larger vector-store hardening effort (#2474): make ingestion **cancellable** and shutdown **bounded**.
- Module: `Router` (plus `E2E`-style integration tests within the `vectorstore` package).

### What changed

- `IngestionPipeline` gains a lifecycle root context created in `Start()` and cancelled on shutdown. Workers and `processJob` derive their work from it.
- `processJob` checks `ctx.Err()` between stages (read → chunk → per-chunk embed → insert), so a cancelled lifecycle aborts in-flight jobs at the next checkpoint instead of running to completion. Cancelled jobs are marked failed with a `cancelled` error code; count/metadata updates use `context.WithoutCancel` so status stays consistent even under cancellation.
- `Stop()` → `Stop(ctx context.Context) error`: stops accepting jobs, fails queued jobs, then drains in-flight work bounded by `ctx`. If `ctx` elapses first, the root context is cancelled and `Stop` returns `ctx.Err()` without blocking further. A `nil` ctx uses a default 30s bound. `Stop` remains idempotent.
- `VectorStoreRuntime.Shutdown()` now bounds pipeline drain with a 30s deadline and logs if the drain doesn't complete, so a wedged backend cannot hang process shutdown.

This is intentionally scoped as a standalone, foundational slice. It changes the `Stop()` signature to `Stop(ctx context.Context) error` (a source-level change for direct callers, all of which are updated here). Making individual stages (embedder/backend) natively ctx-aware is a deliberate follow-up; `Stop`'s own contract (return within `ctx`) holds regardless.

## Test Plan

```
cd src/semantic-router && go test -race ./pkg/vectorstore ./pkg/routerruntime
```

New tests:
- **Bounded Stop** (`pipeline_lifecycle_test.go`): with a wedged embedder, `Stop(ctx)` returns `context.DeadlineExceeded` promptly (asserted `< 3s`) rather than hanging; `Stop` is idempotent and a second call returns `nil`.
- **Graceful drain + no goroutine leak** (`integration_test.go`): a full ingest-to-search run, then `Stop(context.Background())` returns `nil`, worker goroutines are reclaimed (goroutine count returns to baseline), and completed vectors remain searchable after shutdown.
- **Bounded stop under wedge, then clean unwind** (`integration_test.go`): `Stop(ctx)` honors the deadline while a worker is parked inside `Embed`, and after the embedder is released no goroutines remain.

This validates the two behaviors the change targets — cancellability and bounded shutdown — under both the graceful and the wedged path, with `-race` and goroutine-leak assertions.

## Test Result

- `go test -race ./pkg/vectorstore ./pkg/routerruntime` passes; race detector clean.
- Bounded-Stop and graceful-drain/leak tests ran repeatedly (`-count=1` x3) with no flakiness.
- Follow-up (not in this PR, tracked under #2474): make embedder/backend stages natively ctx-aware so a job wedged *inside* a single stage can be interrupted before the stage returns; streaming/bounded batches; status retention; transactional reconciliation.

---
- [x] PR title uses module-aligned prefix `[Router]`
- [x] Commits signed off with `git commit -s`
- [x] Purpose / Test Plan / Test Result reflect the actual scope, commands, and follow-ups

Closes #2602

Part of the umbrella #2474.