### PR TITLE
[Router] feat: pluggable hallucination detector backend (endpoint)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2169,6 +2169,9 @@ global:
           use_cpu: true
           use_mmbert_32k: true
         detector:
+          backend: candle
+          endpoint: ""
+          include_explanation: false
           model_ref: hallucination_detector
           model_id: models/mom-halugate-detector
           threshold: 0.82

--- a/src/semantic-router/pkg/classification/classifier.go
+++ b/src/semantic-router/pkg/classification/classifier.go
@@ -24,10 +24,11 @@ type Classifier struct {
 	mcpCategoryInference   MCPCategoryInference
 
 	// Hallucination mitigation classifiers
-	factCheckClassifier   *FactCheckClassifier
-	hallucinationDetector *HallucinationDetector
-	feedbackDetector      *FeedbackDetector
-	reaskClassifier       *ReaskClassifier
+	factCheckClassifier           *FactCheckClassifier
+	hallucinationDetector         *HallucinationDetector
+	endpointHallucinationDetector *EndpointHallucinationDetector
+	feedbackDetector              *FeedbackDetector
+	reaskClassifier               *ReaskClassifier
 
 	// Preference classifier for route matching via external LLM
 	preferenceClassifier *PreferenceClassifier

--- a/src/semantic-router/pkg/classification/classifier_fact_hallucination_lifecycle.go
+++ b/src/semantic-router/pkg/classification/classifier_fact_hallucination_lifecycle.go
@@ -43,6 +43,22 @@ func (c *Classifier) initializeHallucinationDetector() error {
 		return nil
 	}
 
+	if c.Config.HallucinationMitigation.HallucinationModel.Backend == "endpoint" {
+		detector, err := NewEndpointHallucinationDetector(&c.Config.HallucinationMitigation.HallucinationModel)
+		if err != nil {
+			return fmt.Errorf("failed to create endpoint hallucination detector: %w", err)
+		}
+		if err := detector.Initialize(); err != nil {
+			return fmt.Errorf("failed to initialize endpoint hallucination detector: %w", err)
+		}
+		c.endpointHallucinationDetector = detector
+		// Wire the detect callback but pass nil for NLI: the endpoint backend
+		// does not ship a local NLI model, so panel-mode fusion grounding will
+		// gracefully skip ("nli backend not configured") under on_error: skip.
+		wireEndpointFusionGroundingBackend(detector.Detect)
+		return nil
+	}
+
 	detector, err := NewHallucinationDetector(&c.Config.HallucinationMitigation.HallucinationModel)
 	if err != nil {
 		return fmt.Errorf("failed to create hallucination detector: %w", err)
@@ -54,7 +70,7 @@ func (c *Classifier) initializeHallucinationDetector() error {
 
 	c.initializeHallucinationNLI(detector)
 	c.hallucinationDetector = detector
-	wireFusionGroundingBackends(detector)
+	wireFusionGroundingBackends(detector.Detect)
 	return nil
 }
 
@@ -62,7 +78,7 @@ func (c *Classifier) initializeHallucinationDetector() error {
 // detection functions into the looper package so grounding-aware fusion can score
 // panel responses. This keeps the candle/CGO dependency out of the looper import
 // graph (the looper package stays hermetically testable).
-func wireFusionGroundingBackends(detector *HallucinationDetector) {
+func wireFusionGroundingBackends(detect func(context, question, answer string) (*HallucinationResult, error)) {
 	looper.SetGroundingBackends(
 		func(premise, hypothesis string) (float32, float32, error) {
 			r, err := candle.ClassifyNLI(premise, hypothesis)
@@ -72,7 +88,25 @@ func wireFusionGroundingBackends(detector *HallucinationDetector) {
 			return r.EntailmentProb, r.ContradictProb, nil
 		},
 		func(context, question, answer string) ([]string, float32, error) {
-			r, err := detector.Detect(context, question, answer)
+			r, err := detect(context, question, answer)
+			if err != nil {
+				return nil, 0, err
+			}
+			return r.UnsupportedSpans, r.Confidence, nil
+		},
+	)
+}
+
+// wireEndpointFusionGroundingBackend injects the endpoint-backed hallucination
+// detection into the looper but leaves the NLI callback nil. The endpoint
+// backend does not include a local NLI model, so panel-mode fusion grounding
+// (which requires NLI) will gracefully degrade via the looper's on_error policy.
+// Context-mode grounding (using the detect callback) works normally.
+func wireEndpointFusionGroundingBackend(detect func(context, question, answer string) (*HallucinationResult, error)) {
+	looper.SetGroundingBackends(
+		nil, // NLI not available with endpoint backend
+		func(context, question, answer string) ([]string, float32, error) {
+			r, err := detect(context, question, answer)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -113,6 +147,10 @@ func (c *Classifier) ClassifyFactCheck(text string) (*FactCheckResult, error) {
 
 // DetectHallucination checks if an answer contains hallucinations given the context.
 func (c *Classifier) DetectHallucination(context, question, answer string) (*HallucinationResult, error) {
+	if c.endpointHallucinationDetector != nil && c.endpointHallucinationDetector.IsInitialized() {
+		return c.endpointHallucinationDetector.Detect(context, question, answer)
+	}
+
 	if c.hallucinationDetector == nil || !c.hallucinationDetector.IsInitialized() {
 		return nil, fmt.Errorf("hallucination detector is not initialized")
 	}
@@ -127,6 +165,10 @@ func (c *Classifier) DetectHallucination(context, question, answer string) (*Hal
 
 // DetectHallucinationWithNLI checks if an answer contains hallucinations with NLI explanations.
 func (c *Classifier) DetectHallucinationWithNLI(context, question, answer string) (*EnhancedHallucinationResult, error) {
+	if c.endpointHallucinationDetector != nil && c.endpointHallucinationDetector.IsInitialized() {
+		return c.endpointHallucinationDetector.DetectWithNLI(context, question, answer)
+	}
+
 	if c.hallucinationDetector == nil || !c.hallucinationDetector.IsInitialized() {
 		return nil, fmt.Errorf("hallucination detector is not initialized")
 	}
@@ -178,7 +220,29 @@ func (c *Classifier) GetFactCheckClassifier() *FactCheckClassifier {
 	return c.factCheckClassifier
 }
 
-// GetHallucinationDetector returns the hallucination detector instance.
+// GetHallucinationDetector returns the hallucination detector instance (legacy candle backend).
 func (c *Classifier) GetHallucinationDetector() *HallucinationDetector {
 	return c.hallucinationDetector
+}
+
+// IsHallucinationDetectorReady returns true if either the candle or endpoint detector is ready.
+func (c *Classifier) IsHallucinationDetectorReady() bool {
+	if c.endpointHallucinationDetector != nil {
+		return c.endpointHallucinationDetector.IsInitialized()
+	}
+	if c.hallucinationDetector != nil {
+		return c.hallucinationDetector.IsInitialized()
+	}
+	return false
+}
+
+// IsHallucinationExplainerReady returns true if either detector can provide explanations (NLI).
+func (c *Classifier) IsHallucinationExplainerReady() bool {
+	if c.endpointHallucinationDetector != nil {
+		return c.endpointHallucinationDetector.IsNLIInitialized()
+	}
+	if c.hallucinationDetector != nil {
+		return c.hallucinationDetector.IsNLIInitialized()
+	}
+	return false
 }

--- a/src/semantic-router/pkg/classification/hallucination_detector_endpoint.go
+++ b/src/semantic-router/pkg/classification/hallucination_detector_endpoint.go
@@ -1,0 +1,296 @@
+package classification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+const (
+	systemPromptBase = `You are an expert annotator who identifies hallucinated spans in a generated answer with respect to a given context (the only trusted evidence). A hallucinated span is a substring of the answer that is not supported by the context. Spans consistent with the context are not hallucinations. Quote each hallucinated span verbatim from the answer and classify it into exactly one category and one subcategory.
+Categories (the kinds of unsupported span):
+- contradiction: conflicts with the context (a wrong value, number, date, name, or relationship)
+- fabricated_reference: an entity, name, identifier, or section that is absent from the context
+- unsupported_addition: a claim, detail, or behavior the context never states
+Subcategories:
+- entity: a wrong or invented name, entity, or object
+- temporal: an incorrect date, time, duration, or ordering
+- numerical: an incorrect number, quantity, or amount
+- value: a wrong value, setting, or attribute value
+- relational: an incorrect relationship or association between things
+- identifier: an invented identifier or name not found in the context
+- section: a reference to a section, part, or location that does not exist
+- attribute: an invented or incorrect attribute or property
+- claim: an added factual claim the context does not support
+- behavior: an added or changed action or behavior the context never states
+- elaboration: extra detail or elaboration beyond what the context supports
+- subjective: an unsupported subjective or evaluative statement
+- unspecified: unsupported, with no more specific subtype
+
+Reply with ONLY a JSON object (no markdown, no code fences):
+{"hallucinated_spans": [{"text": "...", "category": "...", "subcategory": "..."}]}.
+If nothing is unsupported, reply {"hallucinated_spans": []}.`
+
+	systemPromptExpl = `You are an expert annotator who identifies hallucinated spans in a generated answer with respect to a given context (the only trusted evidence). A hallucinated span is a substring of the answer that is not supported by the context. Spans consistent with the context are not hallucinations. Quote each hallucinated span verbatim from the answer and classify it into exactly one category and one subcategory, and give a short explanation of why it is unsupported.
+Categories (the kinds of unsupported span):
+- contradiction: conflicts with the context (a wrong value, number, date, name, or relationship)
+- fabricated_reference: an entity, name, identifier, or section that is absent from the context
+- unsupported_addition: a claim, detail, or behavior the context never states
+Subcategories:
+- entity: a wrong or invented name, entity, or object
+- temporal: an incorrect date, time, duration, or ordering
+- numerical: an incorrect number, quantity, or amount
+- value: a wrong value, setting, or attribute value
+- relational: an incorrect relationship or association between things
+- identifier: an invented identifier or name not found in the context
+- section: a reference to a section, part, or location that does not exist
+- attribute: an invented or incorrect attribute or property
+- claim: an added factual claim the context does not support
+- behavior: an added or changed action or behavior the context never states
+- elaboration: extra detail or elaboration beyond what the context supports
+- subjective: an unsupported subjective or evaluative statement
+- unspecified: unsupported, with no more specific subtype
+
+Reply with ONLY a JSON object (no markdown, no code fences):
+{"hallucinated_spans": [{"text": "...", "category": "...", "subcategory": "...", "explanation": "..."}]}.
+If nothing is unsupported, reply {"hallucinated_spans": []}.`
+)
+
+type EndpointHallucinationDetector struct {
+	config      *config.HallucinationModelConfig
+	initialized bool
+	mu          sync.RWMutex
+	client      *http.Client
+	endpoint    string
+}
+
+func NewEndpointHallucinationDetector(cfg *config.HallucinationModelConfig) (*EndpointHallucinationDetector, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("hallucination model config is required")
+	}
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("hallucination endpoint is required when backend is endpoint")
+	}
+	if cfg.ModelID == "" {
+		return nil, fmt.Errorf("hallucination model_id is required")
+	}
+
+	return &EndpointHallucinationDetector{
+		config:   cfg,
+		client:   &http.Client{Timeout: 10 * time.Second},
+		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
+	}, nil
+}
+
+func (d *EndpointHallucinationDetector) Initialize() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.initialized {
+		return nil
+	}
+	d.initialized = true
+	logging.ComponentEvent("classifier", "hallucination_detector_initialized", map[string]interface{}{
+		"backend":   "endpoint",
+		"model_ref": d.config.ModelID,
+		"endpoint":  d.endpoint,
+	})
+	return nil
+}
+
+func (d *EndpointHallucinationDetector) IsInitialized() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.initialized
+}
+
+// IsNLIInitialized returns true because the endpoint natively provides explanation when requested
+func (d *EndpointHallucinationDetector) IsNLIInitialized() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.initialized
+}
+
+func (d *EndpointHallucinationDetector) buildRequestPayload(reqContext, question, answer string) ([]byte, error) {
+	prompt := fmt.Sprintf("User request: %s\n\nContext (trusted evidence):\n%s\n\nAnswer to verify:\n%s", question, reqContext, answer)
+
+	systemPrompt := systemPromptBase
+	if d.config.IncludeExplanation {
+		systemPrompt = systemPromptExpl
+	}
+
+	spanProps := map[string]interface{}{
+		"text":        map[string]interface{}{"type": "string"},
+		"category":    map[string]interface{}{"type": "string", "enum": []string{"contradiction", "fabricated_reference", "unsupported_addition"}},
+		"subcategory": map[string]interface{}{"type": "string", "enum": []string{"entity", "temporal", "numerical", "value", "relational", "identifier", "section", "attribute", "claim", "behavior", "elaboration", "subjective", "unspecified"}},
+	}
+	requiredFields := []string{"text", "category", "subcategory"}
+
+	if d.config.IncludeExplanation {
+		spanProps["explanation"] = map[string]interface{}{"type": "string"}
+		requiredFields = append(requiredFields, "explanation")
+	}
+
+	reqBody := map[string]interface{}{
+		"model":       d.config.ModelID,
+		"temperature": 0.0,
+		"stream":      false,
+		"messages": []map[string]string{
+			{"role": "system", "content": systemPrompt},
+			{"role": "user", "content": prompt},
+		},
+		"response_format": map[string]interface{}{
+			"type": "json_schema",
+			"json_schema": map[string]interface{}{
+				"name": "hallucination_detection",
+				"schema": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"hallucinated_spans": map[string]interface{}{
+							"type": "array",
+							"items": map[string]interface{}{
+								"type":                 "object",
+								"properties":           spanProps,
+								"required":             requiredFields,
+								"additionalProperties": false,
+							},
+						},
+					},
+					"required":             []string{"hallucinated_spans"},
+					"additionalProperties": false,
+				},
+				"strict": true,
+			},
+		},
+	}
+	return json.Marshal(reqBody)
+}
+
+func (d *EndpointHallucinationDetector) parseOpenAIResponse(respBytes []byte) ([]EnhancedHallucinationSpan, error) {
+	var openaiResp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err := json.Unmarshal(respBytes, &openaiResp); err != nil || len(openaiResp.Choices) == 0 {
+		return nil, fmt.Errorf("response parsing failed")
+	}
+
+	var parsed struct {
+		HallucinatedSpans []struct {
+			Text        string `json:"text"`
+			Category    string `json:"category"`
+			Subcategory string `json:"subcategory"`
+			Explanation string `json:"explanation"`
+		} `json:"hallucinated_spans"`
+	}
+
+	if err := json.Unmarshal([]byte(openaiResp.Choices[0].Message.Content), &parsed); err != nil {
+		return nil, fmt.Errorf("JSON schema parsing failed: %w", err)
+	}
+
+	var spans []EnhancedHallucinationSpan
+	for _, s := range parsed.HallucinatedSpans {
+		explanation := s.Explanation
+		if explanation == "" {
+			explanation = fmt.Sprintf("Unsupported %s (%s) detected", s.Subcategory, s.Category)
+		}
+
+		spans = append(spans, EnhancedHallucinationSpan{
+			Text:                    s.Text,
+			HallucinationConfidence: 1.0,
+			NLILabel:                NLIContradiction,
+			NLILabelStr:             s.Category,
+			NLIConfidence:           1.0,
+			Severity:                4,
+			Explanation:             explanation,
+		})
+	}
+	return spans, nil
+}
+
+func (d *EndpointHallucinationDetector) DetectWithNLI(reqContext, question, answer string) (*EnhancedHallucinationResult, error) {
+	if answer == "" {
+		return d.fallbackResult(), nil
+	}
+	if reqContext == "" {
+		logging.Warnf("Endpoint hallucination detection requested with empty context")
+		return d.fallbackResult(), nil
+	}
+
+	bodyBytes, err := d.buildRequestPayload(reqContext, question, answer)
+	if err != nil {
+		return d.fallbackResult(), nil
+	}
+	req, err := http.NewRequestWithContext(context.Background(), "POST", d.endpoint+"/chat/completions", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return d.fallbackResult(), nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		logging.Warnf("Endpoint hallucination detection failed (fallback to safe): %v", err)
+		return d.fallbackResult(), nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logging.Warnf("Endpoint hallucination detection non-200 status: %d", resp.StatusCode)
+		return d.fallbackResult(), nil
+	}
+
+	// Limit response size to 10MB to prevent OOM
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		logging.Warnf("Endpoint hallucination detection response read failed: %v", err)
+		return d.fallbackResult(), nil
+	}
+
+	spans, err := d.parseOpenAIResponse(respBytes)
+	if err != nil {
+		logging.Warnf("Endpoint hallucination detection %v", err)
+		return d.fallbackResult(), nil
+	}
+
+	return &EnhancedHallucinationResult{
+		HallucinationDetected: len(spans) > 0,
+		Confidence:            1.0,
+		Spans:                 spans,
+	}, nil
+}
+
+func (d *EndpointHallucinationDetector) fallbackResult() *EnhancedHallucinationResult {
+	return &EnhancedHallucinationResult{
+		HallucinationDetected: false,
+		Confidence:            1.0,
+		Spans:                 []EnhancedHallucinationSpan{},
+	}
+}
+
+func (d *EndpointHallucinationDetector) Detect(reqContext, question, answer string) (*HallucinationResult, error) {
+	enhanced, err := d.DetectWithNLI(reqContext, question, answer)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &HallucinationResult{
+		HallucinationDetected: enhanced.HallucinationDetected,
+		Confidence:            enhanced.Confidence,
+	}
+	for _, s := range enhanced.Spans {
+		res.UnsupportedSpans = append(res.UnsupportedSpans, s.Text)
+	}
+	return res, nil
+}

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -255,6 +255,9 @@ type FactCheckModelConfig struct {
 }
 
 type HallucinationModelConfig struct {
+	Backend                string  `yaml:"backend,omitempty"`
+	Endpoint               string  `yaml:"endpoint,omitempty"`
+	IncludeExplanation     bool    `yaml:"include_explanation,omitempty"`
 	ModelID                string  `yaml:"model_id"`
 	Threshold              float32 `yaml:"threshold"`
 	UseCPU                 bool    `yaml:"use_cpu"`

--- a/src/semantic-router/pkg/extproc/req_filter_memory_rewrite.go
+++ b/src/semantic-router/pkg/extproc/req_filter_memory_rewrite.go
@@ -231,11 +231,11 @@ func callLLMForQueryRewrite(ctx context.Context, resolved *ResolvedLLMConfig, us
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 		return "", fmt.Errorf("LLM returned status %d: %s", resp.StatusCode, truncateForLog(string(body), 200))
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -264,6 +264,10 @@ func setJSONField(data []byte, key string, value interface{}) ([]byte, error) {
 // ExtractConversationHistory extracts conversation history from raw request messages.
 // It filters out system messages and returns user/assistant messages for context.
 func ExtractConversationHistory(messagesJSON []byte) ([]ConversationMessage, error) {
+	if len(messagesJSON) == 0 {
+		return nil, nil
+	}
+
 	var messages []map[string]interface{}
 	if err := json.Unmarshal(messagesJSON, &messages); err != nil {
 		return nil, fmt.Errorf("failed to parse messages: %w", err)
@@ -276,16 +280,42 @@ func ExtractConversationHistory(messagesJSON []byte) ([]ConversationMessage, err
 			continue
 		}
 
-		content, ok := msg["content"].(string)
-		if !ok || content == "" {
+		contentStr := extractMessageContent(msg["content"])
+		if contentStr == "" {
 			continue
 		}
 
 		history = append(history, ConversationMessage{
 			Role:    role,
-			Content: content,
+			Content: contentStr,
 		})
 	}
 
 	return history, nil
+}
+
+// extractMessageContent parses a message content field which may be a string or a multimodal array of parts.
+func extractMessageContent(contentObj interface{}) string {
+	if cStr, ok := contentObj.(string); ok {
+		return cStr
+	}
+
+	cArr, ok := contentObj.([]interface{})
+	if !ok {
+		return ""
+	}
+
+	var parts []string
+	for _, part := range cArr {
+		pMap, ok := part.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if pType, ok := pMap["type"].(string); ok && pType == "text" {
+			if pText, ok := pMap["text"].(string); ok {
+				parts = append(parts, pText)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
 }

--- a/src/semantic-router/pkg/services/classification_readiness.go
+++ b/src/semantic-router/pkg/services/classification_readiness.go
@@ -9,16 +9,12 @@ func (s *ClassificationService) HasFactCheckClassifier() bool {
 
 // HasHallucinationDetector returns true when the hallucination detector has been initialized.
 func (s *ClassificationService) HasHallucinationDetector() bool {
-	return s.classifier != nil &&
-		s.classifier.GetHallucinationDetector() != nil &&
-		s.classifier.GetHallucinationDetector().IsInitialized()
+	return s.classifier != nil && s.classifier.IsHallucinationDetectorReady()
 }
 
 // HasHallucinationExplainer returns true when the hallucination NLI explainer is initialized.
 func (s *ClassificationService) HasHallucinationExplainer() bool {
-	return s.classifier != nil &&
-		s.classifier.GetHallucinationDetector() != nil &&
-		s.classifier.GetHallucinationDetector().IsNLIInitialized()
+	return s.classifier != nil && s.classifier.IsHallucinationExplainerReady()
 }
 
 // HasFeedbackDetector returns true when the feedback detector has been initialized.


### PR DESCRIPTION
Closes #2415

## Purpose

- **What does this PR change?** 
  Introduces a new `endpoint` backend for the hallucination mitigation detector, allowing users to call generative span detectors behind any OpenAI-compatible server (e.g. vLLM) instead of being locked into the local in-process Candle classifier. It also includes critical hardening for LLM interactions (response limits, JSON `stream: false` enforcement, and multimodal array support).
- **Why is this change needed?** 
  To support large generative models (like `lettucedect-v2-qwen-2b`) which cannot be run in-process via Candle. It replaces the legacy detector + NLI two-pass system with a single strict `json_schema` request.
- **Which module(s) does this affect?** `Router`

## Test Plan

- **What commands, checks, or manual steps should reviewers use?**
  1. `make agent-lint`
  2. `go test ./pkg/config/... -run TestReferenceConfig`
  3. Deploy the router with `backend: endpoint` and configure an external vLLM server, verify that hallucinations are correctly detected and that Fusion Grounding (`reference: panel`) gracefully skips NLI without panicking.
- **Why is this validation sufficient for the affected module(s)?**
  Structural linting ensures code quality, while the config test ensures the new YAML fields don't break backward compatibility.

## Test Result

- **What were the actual results?**
  All local Go linters (`golangci-lint`), build checks, and config contract tests pass (`Exit code 0`).
- **Any follow-up risks, gaps, or blockers?**
  Unit tests for `EndpointHallucinationDetector` still need to be written (currently missing). Documentation updates in `website/docs` for the new `backend` fields are also needed in a follow-up PR.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
