### PR TITLE
[Router] Add Router Memory runtime receipts to replay

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_req_body_memory.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_memory.go
@@ -27,6 +27,10 @@ func (r *OpenAIRouter) handleMemoryRetrieval(
 	requestBody []byte,
 	openAIRequest *openai.ChatCompletionNewParams,
 ) ([]byte, error) {
+	ctx.MemoryBackend = r.Config.Memory.Backend
+	if ctx.MemoryBackend == "" {
+		ctx.MemoryBackend = "milvus"
+	}
 	memoryPluginConfig, shouldRetrieve := r.resolveMemoryPluginConfig(ctx)
 	if !shouldRetrieve {
 		return requestBody, nil
@@ -34,6 +38,7 @@ func (r *OpenAIRouter) handleMemoryRetrieval(
 	store := r.getMemoryStore()
 	if store == nil || !store.IsEnabled() {
 		logging.Debugf("Memory: Store not available or disabled, skipping retrieval")
+		recordMemoryOutcome(ctx, "unavailable", "store_unavailable", true)
 		return requestBody, nil
 	}
 
@@ -45,13 +50,19 @@ func (r *OpenAIRouter) handleMemoryRetrieval(
 	retrieveOpts := r.buildMemoryRetrieveOptions(memoryPluginConfig, searchQuery, userID)
 	memories, err := store.Retrieve(ctx.TraceContext, retrieveOpts)
 	if err != nil {
-		metrics.RecordPluginExecution("memory", ctx.VSRSelectedDecisionName, "retrieval_error", 0)
+		recordMemoryOutcome(ctx, "unavailable", "retrieval_error", true)
 		logging.Errorf("Memory: retrieval failed for user=%s decision=%s query=%q: %v",
 			userID, ctx.VSRSelectedDecisionName, truncateForLog(searchQuery, 60), err)
 		return requestBody, fmt.Errorf("memory retrieval failed: %w", err)
 	}
+	retrievedCount := len(memories)
 	memories = r.filterRetrievedMemories(memoryPluginConfig, memories, userID)
 	if len(memories) == 0 {
+		reason := "no_results"
+		if retrievedCount > 0 {
+			reason = "filtered"
+		}
+		recordMemoryOutcome(ctx, "missing", reason, false)
 		return requestBody, nil
 	}
 	return r.injectRetrievedMemories(ctx, requestBody, memories), nil
@@ -70,16 +81,19 @@ func (r *OpenAIRouter) resolveMemoryPluginConfig(
 		memoryEnabled = memoryPluginConfig.Enabled
 		if !memoryEnabled {
 			logging.Debugf("Memory: Disabled by per-decision plugin config for decision '%s'", ctx.VSRSelectedDecisionName)
+			recordMemoryOutcome(ctx, "disabled", "decision_config", false)
 			return memoryPluginConfig, false
 		}
 	} else if !memoryEnabled {
 		logging.Debugf("Memory: Disabled in global config, skipping retrieval")
+		recordMemoryOutcome(ctx, "disabled", "global_config", false)
 		return nil, false
 	}
 
 	// Check opt-out header (x-disable-router-memory: true)
-	if ctx.Headers["x-disable-router-memory"] == "true" {
+	if ctx.Headers[headers.DisableRouterMemory] == "true" {
 		logging.Debugf("Memory: Disabled via x-disable-router-memory header (SDK-managed memory opt-out)")
+		recordMemoryOutcome(ctx, "policy_blocked", "request_opt_out", false)
 		return memoryPluginConfig, false
 	}
 
@@ -87,12 +101,14 @@ func (r *OpenAIRouter) resolveMemoryPluginConfig(
 	requestPath := ctx.Headers[":path"]
 	if r.isMemoryDisabledForRoute(requestPath) {
 		logging.Debugf("Memory: Disabled for route %s via config (SDK-managed memory opt-out)", requestPath)
+		recordMemoryOutcome(ctx, "policy_blocked", "route_config", false)
 		return memoryPluginConfig, false
 	}
 
 	// Check config-based per-model disable
 	if ctx.RequestModel != "" && r.isMemoryDisabledForModel(ctx.RequestModel) {
 		logging.Debugf("Memory: Disabled for model %s via config (SDK-managed memory opt-out)", ctx.RequestModel)
+		recordMemoryOutcome(ctx, "policy_blocked", "model_config", false)
 		return memoryPluginConfig, false
 	}
 
@@ -106,6 +122,7 @@ func (r *OpenAIRouter) prepareMemorySearchQuery(
 ) (string, string, bool) {
 	if !ShouldSearchMemory(ctx, userContent) {
 		logging.Debugf("Memory: skipping search (query type not suitable)")
+		recordMemoryOutcome(ctx, "ignored", "query_ineligible", false)
 		return "", "", false
 	}
 
@@ -113,12 +130,15 @@ func (r *OpenAIRouter) prepareMemorySearchQuery(
 	searchQuery, err := BuildSearchQuery(ctx.TraceContext, history, userContent, r.Config)
 	if err != nil {
 		logging.Warnf("Memory: Query rewriting failed, using original query: %v", err)
+		ctx.MemoryFailOpen = true
+		ctx.MemoryFallbackReason = "query_rewrite_error"
 		searchQuery = userContent
 	}
 
 	userID := r.getUserIDFromContext(ctx)
 	if userID == "" {
 		logging.Debugf("Memory: no user ID, skipping search")
+		recordMemoryOutcome(ctx, "missing", "user_id_missing", false)
 		return "", "", false
 	}
 
@@ -213,21 +233,33 @@ func (r *OpenAIRouter) injectRetrievedMemories(
 ) []byte {
 	ctx.MemoryContext = FormatMemoriesAsContext(memories)
 	if ctx.MemoryContext == "" {
+		recordMemoryOutcome(ctx, "missing", "empty_context", false)
 		return requestBody
 	}
 
 	injectedBody, err := injectMemoryMessages(requestBody, ctx.MemoryContext)
 	if err != nil {
 		logging.Warnf("Memory: Failed to inject memory context: %v", err)
-		metrics.RecordPluginExecution("memory", ctx.VSRSelectedDecisionName, "injection_error", 0)
+		recordMemoryOutcome(ctx, "unavailable", "injection_error", true)
 		ctx.MemoryContext = ""
 		return requestBody
 	}
 
-	metrics.RecordPluginExecution("memory", ctx.VSRSelectedDecisionName, "injected", 0)
+	ctx.MemoryResultCount = len(memories)
+	recordMemoryOutcome(ctx, "used", "injected", false)
 	logging.Debugf("Memory: Injected %d memories (decision=%s, context_len=%d)",
 		len(memories), ctx.VSRSelectedDecisionName, len(ctx.MemoryContext))
 	return injectedBody
+}
+
+func recordMemoryOutcome(ctx *RequestContext, status, reason string, failOpen bool) {
+	ctx.MemoryStatus = status
+	ctx.MemoryReason = reason
+	ctx.MemoryFailOpen = ctx.MemoryFailOpen || failOpen
+	if failOpen {
+		ctx.MemoryFallbackReason = reason
+	}
+	metrics.RecordPluginExecution("memory", ctx.VSRSelectedDecisionName, status, 0)
 }
 
 func (r *OpenAIRouter) getMemoryStore() memory.Store {

--- a/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
+++ b/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
@@ -24,14 +24,20 @@ func buildReplayRouteDiagnostics(
 ) *routerreplay.RouteDiagnostics {
 	finalModel := replaySelectedModel(originalModel, selectedModel)
 	diagnostics := &routerreplay.RouteDiagnostics{
-		Decision:         decisionName,
-		DecisionTier:     decisionTier,
-		DecisionPriority: decisionPriority,
-		SelectionMethod:  ctx.VSRSelectionMethod,
-		OriginalModel:    originalModel,
-		ProposalModel:    finalModel,
-		SelectedModel:    finalModel,
-		SessionAction:    replaySessionActionNone,
+		Decision:             decisionName,
+		DecisionTier:         decisionTier,
+		DecisionPriority:     decisionPriority,
+		SelectionMethod:      ctx.VSRSelectionMethod,
+		OriginalModel:        originalModel,
+		ProposalModel:        finalModel,
+		SelectedModel:        finalModel,
+		SessionAction:        replaySessionActionNone,
+		MemoryBackend:        ctx.MemoryBackend,
+		MemoryStatus:         ctx.MemoryStatus,
+		MemoryReason:         ctx.MemoryReason,
+		MemoryFallbackReason: ctx.MemoryFallbackReason,
+		MemoryFailOpen:       ctx.MemoryFailOpen,
+		MemoryResultCount:    ctx.MemoryResultCount,
 	}
 
 	if policy, ok := protectionLearningPolicyForContext(ctx); ok {

--- a/src/semantic-router/pkg/extproc/req_filter_memory_context_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_memory_context_test.go
@@ -1,12 +1,81 @@
 package extproc
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
+	"github.com/openai/openai-go"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
+
+type receiptMemoryStore struct {
+	noopMemoryStore
+	results []*memory.RetrieveResult
+	err     error
+}
+
+func (s receiptMemoryStore) Retrieve(context.Context, memory.RetrieveOptions) ([]*memory.RetrieveResult, error) {
+	return s.results, s.err
+}
+
+func TestMemoryRuntimeReceiptRecordsFailOpenRetrievalError(t *testing.T) {
+	router := &OpenAIRouter{
+		Config:      &config.RouterConfig{Memory: config.MemoryConfig{Enabled: true, Backend: "milvus"}},
+		MemoryStore: &receiptMemoryStore{err: errors.New("backend unavailable")},
+	}
+	ctx := &RequestContext{
+		Headers:                 map[string]string{headers.AuthzUserID: "user-1"},
+		TraceContext:            context.Background(),
+		VSRSelectedDecisionName: "balance",
+	}
+	body := []byte(`{"messages":[{"role":"user","content":"What did I say?"}]}`)
+	before := testutil.ToFloat64(metrics.PluginExecutionTotal.WithLabelValues("memory", "balance", "unavailable"))
+
+	got, err := router.handleMemoryRetrieval(ctx, "What did I say?", body, &openai.ChatCompletionNewParams{})
+
+	require.ErrorContains(t, err, "memory retrieval failed")
+	assert.Equal(t, body, got)
+	assert.Equal(t, before+1, testutil.ToFloat64(metrics.PluginExecutionTotal.WithLabelValues("memory", "balance", "unavailable")))
+	diagnostics := buildReplayRouteDiagnostics(ctx, "auto", "model-a", "balance", 0, 0)
+	assert.Equal(t, "milvus", diagnostics.MemoryBackend)
+	assert.Equal(t, "unavailable", diagnostics.MemoryStatus)
+	assert.Equal(t, "retrieval_error", diagnostics.MemoryReason)
+	assert.True(t, diagnostics.MemoryFailOpen)
+}
+
+func TestMemoryRuntimeReceiptRecordsUsedMemory(t *testing.T) {
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{Memory: config.MemoryConfig{Enabled: true, Backend: "milvus"}},
+		MemoryStore: &receiptMemoryStore{results: []*memory.RetrieveResult{{
+			Memory: &memory.Memory{Content: "The user's deadline is Friday."},
+			Score:  0.9,
+		}}},
+	}
+	ctx := &RequestContext{
+		Headers:      map[string]string{headers.AuthzUserID: "user-1"},
+		TraceContext: context.Background(),
+	}
+	body := []byte(`{"messages":[{"role":"user","content":"What is my deadline?"}]}`)
+
+	got, err := router.handleMemoryRetrieval(ctx, "What is my deadline?", body, &openai.ChatCompletionNewParams{})
+
+	require.NoError(t, err)
+	assert.NotEqual(t, body, got)
+	diagnostics := buildReplayRouteDiagnostics(ctx, "auto", "model-a", "balance", 0, 0)
+	assert.Equal(t, "used", diagnostics.MemoryStatus)
+	assert.Equal(t, "injected", diagnostics.MemoryReason)
+	assert.Equal(t, 1, diagnostics.MemoryResultCount)
+	assert.False(t, diagnostics.MemoryFailOpen)
+}
 
 func TestInjectMemoryMessages_InsertsAfterSystemAndDeveloperMessages(t *testing.T) {
 	requestBody := []byte(`{

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -275,7 +275,13 @@ type RequestContext struct {
 
 	// Memory retrieval tracking
 	// Stores formatted memory context to be injected after system prompt
-	MemoryContext string // Formatted memory context (empty if no memories retrieved)
+	MemoryContext        string // Formatted memory context (empty if no memories retrieved)
+	MemoryBackend        string
+	MemoryStatus         string
+	MemoryReason         string
+	MemoryFallbackReason string
+	MemoryFailOpen       bool
+	MemoryResultCount    int
 
 	// Note: Per-user API keys from ext_authz / Authorino are read directly from
 	// ctx.Headers by the CredentialResolver (pkg/authz). No separate fields needed.

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -100,8 +100,8 @@ type ToolTraceStep struct {
 	Truncated bool `json:"truncated,omitempty"`
 }
 
-// RouteDiagnostics summarizes the final route and any Router Learning
-// protection outcome in a stable replay-facing shape. Detailed per-candidate
+// RouteDiagnostics summarizes the final route, Router Learning protection,
+// and memory outcome in a stable replay-facing shape. Detailed per-candidate
 // learning diagnostics live in the typed Learning block.
 type RouteDiagnostics struct {
 	Decision             string `json:"decision,omitempty"`
@@ -118,6 +118,12 @@ type RouteDiagnostics struct {
 	SessionReason        string `json:"session_reason,omitempty"`
 	HardLockReason       string `json:"hard_lock_reason,omitempty"`
 	DecisionReason       string `json:"decision_reason,omitempty"`
+	MemoryBackend        string `json:"memory_backend,omitempty"`
+	MemoryStatus         string `json:"memory_status,omitempty"`
+	MemoryReason         string `json:"memory_reason,omitempty"`
+	MemoryFallbackReason string `json:"memory_fallback_reason,omitempty"`
+	MemoryFailOpen       bool   `json:"memory_fail_open,omitempty"`
+	MemoryResultCount    int    `json:"memory_result_count,omitempty"`
 }
 
 // Record represents a routing decision record with metadata and captured payloads.


### PR DESCRIPTION
Closes #2520

Part of #2365

## Purpose

- Record the final request-side Router Memory outcome in router replay diagnostics, including the configured backend, bounded status and reason values, fallback reason, fail-open behavior, and injected result count.
- Reuse `llm_plugin_execution_total` so operators can distinguish `used`, `missing`, `disabled`, `policy_blocked`, `ignored`, and `unavailable` outcomes without adding another collector.
- Preserve the existing fail-open contract for store, rewrite, retrieval, and injection failures. The receipt contains no raw memory content.
- This focused change covers lookup, query rewrite fallback, filtering, and prompt injection. It does not invent a stale threshold before Router Memory has a freshness policy, and it leaves response-side extraction receipts for a follow-up.

Affected modules: `Router`.

## Test Plan

- Run the focused request-side receipt tests:
  `go test ./pkg/extproc -run TestMemoryRuntimeReceipt -count=1`
- Run replay and metric unit tests:
  `go test ./pkg/routerreplay/store ./pkg/observability/metrics -count=1`
- Run replay store vet:
  `go vet ./pkg/routerreplay/store`
- Run the repository agent manifest, structure, formatting, and security checks.

## Test Result

- `go test ./pkg/routerreplay/store ./pkg/observability/metrics -count=1`: passed.
- `go vet ./pkg/routerreplay/store`: passed.
- Agent manifest validation, changed-file structure checks, Go formatting, and the AST security scan at `HIGH` threshold: passed.
- The focused `pkg/extproc` test compiled through Go locally but could not link because this checkout does not contain `libcandle_semantic_router.so`. CI should run it with the repository native build artifacts.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses a module-aligned prefix
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>