### PR TITLE
[Docs] Update Xunzhuo affiliation to AMD

### DIFF
--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -1601,7 +1601,7 @@
     "message": "IBM 研究科学家，专注于 AI 研究和 LLM 推理。"
   },
   "team.members.XunzhuoLiu.role": {
-    "message": "LLM Routing @ vLLM"
+    "message": "LLM Routing @ AMD"
   },
   "team.members.XunzhuoLiu.bio": {
     "message": "LLM routing builder at vLLM。"

--- a/website/src/data/teamMembers.tsx
+++ b/website/src/data/teamMembers.tsx
@@ -24,7 +24,7 @@ export interface TeamMember {
 export const steeringCommitteeMembers: TeamMember[] = [
   {
     name: 'Xunzhuo Liu',
-    role: <Translate id="team.members.XunzhuoLiu.role">LLM Routing @ vLLM</Translate>,
+    role: <Translate id="team.members.XunzhuoLiu.role">LLM Routing @ AMD</Translate>,
     avatar: '/img/team/xunzhuo.png',
     github: 'https://github.com/Xunzhuo',
     linkedin: 'http://linkedin.com/in/bitliu',


### PR DESCRIPTION
## Purpose

- Update Xunzhuo Liu's team role from `LLM Routing @ vLLM` to `LLM Routing @ AMD`.
- Keep the website source data and Simplified Chinese localization in sync.
- Affects the `Docs` website surface only.

## Test Plan

- Run `make agent-docs-ci-gate AGENT_BASE_REF=origin/main` to exercise the repository's lightweight docs/website checks.
- Run `npm run lint` from `website/` for the website ESLint checks.
- Run `npx docusaurus build` from `website/` to build both English and Simplified Chinese sites.

## Test Result

- `make agent-docs-ci-gate AGENT_BASE_REF=origin/main`: passed.
- `npm run lint`: passed.
- `npx docusaurus build`: passed for `en` and `zh-Hans`.
- The build reports existing broken-anchor warnings in the Simplified Chinese signal-decision docs; they are unrelated to this metadata-only change.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Docs]`.
- [x] If the PR spans multiple modules, the title includes all relevant prefixes.
- [x] Commits in this PR are signed off with `git commit -s`.
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change.

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
