### PR TITLE
[Docs] Set Xunzhuo affiliation to @AMD

### DIFF
--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -1601,7 +1601,7 @@
     "message": "IBM 研究科学家，专注于 AI 研究和 LLM 推理。"
   },
   "team.members.XunzhuoLiu.role": {
-    "message": "LLM Routing @ AMD"
+    "message": "@AMD"
   },
   "team.members.XunzhuoLiu.bio": {
     "message": "LLM routing builder at vLLM。"

--- a/website/src/data/teamMembers.tsx
+++ b/website/src/data/teamMembers.tsx
@@ -24,7 +24,7 @@ export interface TeamMember {
 export const steeringCommitteeMembers: TeamMember[] = [
   {
     name: 'Xunzhuo Liu',
-    role: <Translate id="team.members.XunzhuoLiu.role">LLM Routing @ AMD</Translate>,
+    role: <Translate id="team.members.XunzhuoLiu.role">@AMD</Translate>,
     avatar: '/img/team/xunzhuo.png',
     github: 'https://github.com/Xunzhuo',
     linkedin: 'http://linkedin.com/in/bitliu',


### PR DESCRIPTION
## Purpose

- Correct Xunzhuo Liu's team role from `LLM Routing @ AMD` to `@AMD`.
- Match the concise affiliation format used by Huamin Chen's `@Microsoft` role.
- Keep the website source data and Simplified Chinese localization in sync.
- Affects the `Docs` website surface only.

## Test Plan

- Run `make agent-docs-ci-gate AGENT_BASE_REF=origin/main` for the lightweight docs/website checks.
- Run `npm run lint` from `website/` for website ESLint validation.
- Run `npx docusaurus build` from `website/` to build the English and Simplified Chinese sites.

## Test Result

- `make agent-docs-ci-gate AGENT_BASE_REF=origin/main`: passed.
- `npm run lint`: passed.
- `npx docusaurus build`: passed for `en` and `zh-Hans`.
- The build reports existing broken-anchor warnings in the Simplified Chinese signal-decision docs; they are unrelated to this metadata-only correction.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses the `[Docs]` module prefix.
- [x] If the PR spans multiple modules, the title includes all relevant prefixes.
- [x] Commits in this PR are signed off with `git commit -s`.
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change.

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
