### PR TITLE
[CI/Build] Auto-queue approved PRs with Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,11 @@
+---
+merge_protections_settings:
+  auto_merge_conditions:
+    - base = main
+
+merge_protections:
+  - name: require approval before automatic queueing
+    if:
+      - base = main
+    success_conditions:
+      - "#approved-reviews-by >= 1"


### PR DESCRIPTION
Closes #2525

## Purpose

- Add a repository-level Mergify configuration that automatically queues pull requests targeting `main` after they receive at least one approval.
- Keep the existing GitHub branch protection and required CI checks as the source of truth; Mergify injects those requirements into the merge queue.
- Replace the current manual checkbox/`@mergifyio queue` step with automatic queueing.
- Affected module: `CI/Build`.

## Test Plan

- Validate the file against Mergify's current configuration schema.
- Run YAML lint and the repository's agent validation, lint, CI, and feature gates for the changed file.

## Test Result

- `.venv-agent/bin/mergify config validate` — passed.
- `.venv-agent/bin/yamllint .mergify.yml` — passed.
- `make agent-validate` — passed.
- `make agent-lint CHANGED_FILES=".mergify.yml"` — passed.
- `make agent-ci-gate CHANGED_FILES=".mergify.yml"` — passed.
- `make agent-feature-gate ENV=cpu CHANGED_FILES=".mergify.yml"` — passed; no runtime or E2E commands matched this CI-only change.
- The configuration becomes active only after it lands on the default branch.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
