### PR TITLE
[CI/Build] Add Mergify queue_rules to auto-update approved PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,13 @@
 ---
+queue_rules:
+  - name: default
+    queue_conditions:
+      - base = main
+    merge_conditions: []
+    merge_method: squash
+    update_method: merge
+    batch_size: 1
+
 merge_protections_settings:
   auto_merge_conditions:
     - base = main


### PR DESCRIPTION
Closes #2528

## Purpose

PR #2524 enabled auto-queueing via `merge_protections_settings.auto_merge_conditions` but defined no `queue_rules`. In Mergify the merge queue is only created once a `queue_rules` entry exists, so today `auto_merge_conditions` merges approved PRs **directly** into `main` — without updating them against the latest `main` or re-running CI. Parallel approved PRs go stale after each merge and need manual branch updates.

This adds a default `queue_rules` entry so approved PRs enter a real merge queue that updates each PR against `main` and re-runs CI before merging. PRs already up-to-date with green CI merge immediately; only PRs behind `main` are updated + re-checked.

- `update_method: merge` — avoids force-pushing contributor fork branches (`rebase` fails on forks without maintainer edit access).
- `merge_method: squash` — one clean commit per PR on `main`.
- `batch_size: 1` — each PR updated and CI'd independently; simplest failure isolation.
- Branch protection + required CI remain the source of truth (Mergify injects them via the default `branch_protection_injection_mode: queue`).

Affected module: `CI/Build`.

## Test Plan

- Validate the file against Mergify's current configuration schema.
- YAML lint the changed file.

## Test Result

- `mergify config validate` — schema-valid `queue_rules` block.
- `yamllint .mergify.yml` — passed.
- Behavior becomes active only after the config lands on the default branch.
