### PR TITLE
[Docs] Improve mega-nav arrow spacing on hover

### DIFF
--- a/website/src/components/site/WebsiteMegaNav/index.module.css
+++ b/website/src/components/site/WebsiteMegaNav/index.module.css
@@ -326,7 +326,7 @@
   gap: 0.7rem;
   justify-content: space-between;
   min-height: 5rem;
-  padding: 0.9rem 0.2rem;
+  padding: 0.9rem 0.8rem 0.9rem 0.2rem;
   border-bottom: 1px solid #c7c7c3;
   color: #111;
   transition:
@@ -337,7 +337,7 @@
 
 .link:hover,
 .link:focus-visible {
-  padding-right: 0;
+  padding-right: 0.8rem;
   padding-left: 0.45rem;
   background: rgba(48, 162, 255, 0.07);
   color: #111;


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2536 

## Purpose

- Preserve consistent right-side padding for links in the website mega-navigation menu.
- Prevent the arrow's hover translation from placing it too close to the highlighted item's right boundary.
- Improve visual balance while retaining the existing hover and keyboard-focus effects.
- This change affects the `Docs` module and is scoped to the `WebsiteMegaNav` CSS styles.

## Test Plan

- Start the documentation website locally with `cd website && npm start`.
- Open each mega-navigation group on a desktop viewport.
- Check internal and external links in their default, hover, and keyboard-focus states.
- Confirm that arrows have comfortable spacing from the right boundary without clipping or text overlap.
- Repeat the visual check at narrower responsive widths and in both English and Chinese.
- Manual visual verification is sufficient because this is a CSS-only spacing adjustment with no changes to navigation logic, markup, or routing behavior.

## Test Result

- Automated validation was not run for this CSS-only visual adjustment.
- Manual visual verification is pending and will be completed before merge.
- The expected risk is limited to horizontal spacing or text wrapping at narrower panel widths.

Before change:
<img width="946" height="942" alt="image" src="https://github.com/user-attachments/assets/83aa0c6d-553d-49cd-8e06-0881984a0e77" />

After change:
<img width="930" height="1134" alt="image" src="https://github.com/user-attachments/assets/d5d225f5-7cbd-449d-957c-654bae825302" />


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.