### PR TITLE
[CI/Build] Keep unapproved PRs neutral in Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,13 +8,10 @@ queue_rules:
     update_method: merge
     batch_size: 1
 
-merge_protections_settings:
-  auto_merge_conditions:
-    - base = main
-
-merge_protections:
-  - name: require approval before automatic queueing
-    if:
+pull_request_rules:
+  - name: queue approved pull requests
+    conditions:
       - base = main
-    success_conditions:
       - "#approved-reviews-by >= 1"
+    actions:
+      queue:


### PR DESCRIPTION
## Purpose

- Stop Mergify from reporting `Mergify Merge Protections` as a failed CI check while a pull request is merely waiting for review.
- Move the `#approved-reviews-by >= 1` trigger from an active merge protection into a workflow rule that queues the pull request after approval.
- Preserve the existing merge queue and its injected GitHub branch-protection, review, and required-check conditions.
- Fix the misleading status seen on PR #2526 after #2524 introduced the protection and #2529 enabled the queue.
- Affected module: `CI/Build`.

Before approval, Mergify now remains a neutral queue reminder instead of a red CI failure. After one approval, the workflow rule adds the pull request to the existing merge queue automatically.

## Test Plan

- Validate `.mergify.yml` against Mergify's current online schema.
- Run YAML lint and the repository's agent validation, lint, CI, and feature gates for the changed file.

## Test Result

- `.venv-agent/bin/mergify config validate` — passed.
- `.venv-agent/bin/yamllint .mergify.yml` — passed.
- `make agent-validate` — passed.
- `make agent-lint CHANGED_FILES=".mergify.yml"` — passed.
- `make agent-ci-gate CHANGED_FILES=".mergify.yml"` — passed.
- `make agent-feature-gate ENV=cpu CHANGED_FILES=".mergify.yml"` — passed; no runtime or E2E commands matched this CI-only change.
- The behavior change becomes active after the configuration lands on the default branch.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
