### PR TITLE
[Router] [ Phase 1 ] authenticate and isolate the management API 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,4 @@ Makefile.local
 # Candle binding build outputs (use target/ for default Cargo builds)
 candle-binding/target-mkl/
 candle-binding/target-cpu/
+.npm-cache/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1534,6 +1534,31 @@ global:
               requests_per_unit: 1000
               tokens_per_unit: 2000000
               unit: hour
+    management_api:
+      enabled: true
+      bind_address: 127.0.0.1
+      port: 8080
+      remote_exposure: false
+      auth:
+        mode: disabled
+        tokens:
+          - env: VSR_MGMT_TOKEN
+            role: admin
+        roles:
+          viewer:
+            - health.read
+            - ready.read
+            - docs.read
+            - metrics.read
+            - classify.invoke
+            - config.read
+            - data.read
+          operator:
+            - config.write
+            - learning.ingest
+            - data.write
+          admin:
+            - "*"
     startup_status:
       store_backend: file
     router_replay:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1535,7 +1535,6 @@ global:
               tokens_per_unit: 2000000
               unit: hour
     management_api:
-      enabled: true
       bind_address: 127.0.0.1
       port: 8080
       remote_exposure: false

--- a/src/semantic-router/cmd/runtime_bootstrap.go
+++ b/src/semantic-router/cmd/runtime_bootstrap.go
@@ -32,7 +32,7 @@ type runtimeOptions struct {
 	apiPort                int
 	apiBind                string
 	managementAuthMode     string
-	managementRemoteExpose bool
+	managementRemoteExpose *bool
 	metricsPort            int
 	enableAPI              bool
 	secure                 bool
@@ -66,12 +66,28 @@ func parseRuntimeOptions() runtimeOptions {
 		apiPort:                *apiPort,
 		apiBind:                *apiBind,
 		managementAuthMode:     *managementAuthMode,
-		managementRemoteExpose: *managementRemoteExpose,
+		managementRemoteExpose: boolFlagOverride(flag.CommandLine, "management-remote-exposure", *managementRemoteExpose),
 		metricsPort:            *metricsPort,
 		enableAPI:              *enableAPI,
 		secure:                 *secure,
 		downloadOnly:           *downloadOnly,
 	}
+}
+
+// boolFlagOverride returns a pointer to value only when the named flag was
+// explicitly supplied on the command line. Otherwise nil so config defaults
+// are preserved (e.g. management_api.remote_exposure: true).
+func boolFlagOverride(fs *flag.FlagSet, name string, value bool) *bool {
+	set := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			set = true
+		}
+	})
+	if !set {
+		return nil
+	}
+	return &value
 }
 
 func initializeRuntimeLogger() {
@@ -438,18 +454,17 @@ func startAPIServerIfEnabled(opts runtimeOptions, runtimeRegistry *routerruntime
 	}
 
 	go func() {
-		remoteExposure := opts.managementRemoteExpose
 		logging.ComponentEvent("router", "api_server_starting", map[string]interface{}{
 			"api_port":                   opts.apiPort,
 			"api_bind":                   opts.apiBind,
 			"management_auth_mode":       opts.managementAuthMode,
-			"management_remote_exposure": remoteExposure,
+			"management_remote_exposure": opts.managementRemoteExpose,
 		})
 		if err := apiserver.InitWithOptions(apiserver.InitOptions{
 			ConfigPath:      opts.configPath,
 			Port:            opts.apiPort,
 			BindAddress:     opts.apiBind,
-			RemoteExposure:  &remoteExposure,
+			RemoteExposure:  opts.managementRemoteExpose,
 			AuthMode:        opts.managementAuthMode,
 			RuntimeRegistry: runtimeRegistry,
 		}); err != nil {

--- a/src/semantic-router/cmd/runtime_bootstrap.go
+++ b/src/semantic-router/cmd/runtime_bootstrap.go
@@ -24,44 +24,53 @@ import (
 )
 
 type runtimeOptions struct {
-	configPath   string
-	certPath     string
-	kubeconfig   string
-	namespace    string
-	port         int
-	apiPort      int
-	metricsPort  int
-	enableAPI    bool
-	secure       bool
-	downloadOnly bool
+	configPath             string
+	certPath               string
+	kubeconfig             string
+	namespace              string
+	port                   int
+	apiPort                int
+	apiBind                string
+	managementAuthMode     string
+	managementRemoteExpose bool
+	metricsPort            int
+	enableAPI              bool
+	secure                 bool
+	downloadOnly           bool
 }
 
 func parseRuntimeOptions() runtimeOptions {
 	var (
-		configPath   = flag.String("config", "config/config.yaml", "Path to the configuration file")
-		port         = flag.Int("port", 50051, "Port to listen on for gRPC ExtProc")
-		apiPort      = flag.Int("api-port", 8080, "Port to listen on for the router apiserver")
-		metricsPort  = flag.Int("metrics-port", 9190, "Port for Prometheus metrics")
-		enableAPI    = flag.Bool("enable-api", true, "Enable the router apiserver")
-		secure       = flag.Bool("secure", false, "Enable secure gRPC server with TLS")
-		certPath     = flag.String("cert-path", "", "Path to TLS certificate directory (containing tls.crt and tls.key)")
-		kubeconfig   = flag.String("kubeconfig", "", "Path to kubeconfig file (optional, uses in-cluster config if not specified)")
-		namespace    = flag.String("namespace", "default", "Kubernetes namespace to watch for CRDs")
-		downloadOnly = flag.Bool("download-only", false, "Download required models and exit (useful for CI/testing)")
+		configPath             = flag.String("config", "config/config.yaml", "Path to the configuration file")
+		port                   = flag.Int("port", 50051, "Port to listen on for gRPC ExtProc")
+		apiPort                = flag.Int("api-port", 8080, "Port to listen on for the router apiserver")
+		apiBind                = flag.String("api-bind", "", "Bind address for the router apiserver (default from config: 127.0.0.1)")
+		managementAuthMode     = flag.String("management-auth-mode", "", "Management API auth mode: bearer or disabled")
+		managementRemoteExpose = flag.Bool("management-remote-exposure", false, "Allow remote exposure of the management API (requires bearer auth tokens in config)")
+		metricsPort            = flag.Int("metrics-port", 9190, "Port for Prometheus metrics")
+		enableAPI              = flag.Bool("enable-api", true, "Enable the router apiserver")
+		secure                 = flag.Bool("secure", false, "Enable secure gRPC server with TLS")
+		certPath               = flag.String("cert-path", "", "Path to TLS certificate directory (containing tls.crt and tls.key)")
+		kubeconfig             = flag.String("kubeconfig", "", "Path to kubeconfig file (optional, uses in-cluster config if not specified)")
+		namespace              = flag.String("namespace", "default", "Kubernetes namespace to watch for CRDs")
+		downloadOnly           = flag.Bool("download-only", false, "Download required models and exit (useful for CI/testing)")
 	)
 	flag.Parse()
 
 	return runtimeOptions{
-		configPath:   *configPath,
-		certPath:     *certPath,
-		kubeconfig:   *kubeconfig,
-		namespace:    *namespace,
-		port:         *port,
-		apiPort:      *apiPort,
-		metricsPort:  *metricsPort,
-		enableAPI:    *enableAPI,
-		secure:       *secure,
-		downloadOnly: *downloadOnly,
+		configPath:             *configPath,
+		certPath:               *certPath,
+		kubeconfig:             *kubeconfig,
+		namespace:              *namespace,
+		port:                   *port,
+		apiPort:                *apiPort,
+		apiBind:                *apiBind,
+		managementAuthMode:     *managementAuthMode,
+		managementRemoteExpose: *managementRemoteExpose,
+		metricsPort:            *metricsPort,
+		enableAPI:              *enableAPI,
+		secure:                 *secure,
+		downloadOnly:           *downloadOnly,
 	}
 }
 
@@ -429,10 +438,21 @@ func startAPIServerIfEnabled(opts runtimeOptions, runtimeRegistry *routerruntime
 	}
 
 	go func() {
+		remoteExposure := opts.managementRemoteExpose
 		logging.ComponentEvent("router", "api_server_starting", map[string]interface{}{
-			"api_port": opts.apiPort,
+			"api_port":                   opts.apiPort,
+			"api_bind":                   opts.apiBind,
+			"management_auth_mode":       opts.managementAuthMode,
+			"management_remote_exposure": remoteExposure,
 		})
-		if err := apiserver.InitWithRuntime(opts.configPath, opts.apiPort, runtimeRegistry); err != nil {
+		if err := apiserver.InitWithOptions(apiserver.InitOptions{
+			ConfigPath:      opts.configPath,
+			Port:            opts.apiPort,
+			BindAddress:     opts.apiBind,
+			RemoteExposure:  &remoteExposure,
+			AuthMode:        opts.managementAuthMode,
+			RuntimeRegistry: runtimeRegistry,
+		}); err != nil {
 			logging.ComponentErrorEvent("router", "api_server_failed", map[string]interface{}{
 				"api_port": opts.apiPort,
 				"error":    err.Error(),

--- a/src/semantic-router/cmd/runtime_bootstrap_test.go
+++ b/src/semantic-router/cmd/runtime_bootstrap_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestBoolFlagOverrideOnlyWhenExplicitlySet(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	value := fs.Bool("management-remote-exposure", false, "")
+	if err := fs.Parse([]string{}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := boolFlagOverride(fs, "management-remote-exposure", *value); got != nil {
+		t.Fatalf("unset flag override = %v, want nil", *got)
+	}
+
+	fs = flag.NewFlagSet("test", flag.ContinueOnError)
+	value = fs.Bool("management-remote-exposure", false, "")
+	if err := fs.Parse([]string{"-management-remote-exposure=true"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	got := boolFlagOverride(fs, "management-remote-exposure", *value)
+	if got == nil || !*got {
+		t.Fatalf("explicit true override = %v, want true", got)
+	}
+
+	fs = flag.NewFlagSet("test", flag.ContinueOnError)
+	value = fs.Bool("management-remote-exposure", false, "")
+	if err := fs.Parse([]string{"-management-remote-exposure=false"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	got = boolFlagOverride(fs, "management-remote-exposure", *value)
+	if got == nil || *got {
+		t.Fatalf("explicit false override = %v, want false", got)
+	}
+}

--- a/src/semantic-router/pkg/apiserver/auth.go
+++ b/src/semantic-router/pkg/apiserver/auth.go
@@ -35,10 +35,11 @@ func (s *ClassificationAPIServer) managementAuthPolicy() managementAuthPolicy {
 }
 
 func (s *ClassificationAPIServer) managementAPIConfig() config.ManagementAPIConfig {
-	if s == nil || s.config == nil {
+	routerCfg := s.currentConfig()
+	if routerCfg == nil {
 		return config.DefaultManagementAPIConfig()
 	}
-	cfg := s.config.ManagementAPI
+	cfg := routerCfg.ManagementAPI
 	if cfg.BindAddress == "" && cfg.Port == 0 && cfg.Auth.Mode == "" {
 		return config.DefaultManagementAPIConfig()
 	}

--- a/src/semantic-router/pkg/apiserver/auth.go
+++ b/src/semantic-router/pkg/apiserver/auth.go
@@ -1,0 +1,119 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type managementPrincipal struct {
+	Role        string
+	Anonymous   bool
+	AuthEnabled bool
+}
+
+type managementAuthPolicy struct {
+	Mode   string
+	Roles  map[string][]string
+	Tokens map[string]string
+}
+
+func (s *ClassificationAPIServer) managementAuthPolicy() managementAuthPolicy {
+	cfg := s.managementAPIConfig()
+	roles := cfg.Auth.Roles
+	if len(roles) == 0 {
+		roles = config.DefaultManagementAPIRoles()
+	}
+	return managementAuthPolicy{
+		Mode:   cfg.Auth.Mode,
+		Roles:  roles,
+		Tokens: cfg.Auth.ResolvedManagementTokens(),
+	}
+}
+
+func (s *ClassificationAPIServer) managementAPIConfig() config.ManagementAPIConfig {
+	if s == nil || s.config == nil {
+		return config.DefaultManagementAPIConfig()
+	}
+	cfg := s.config.ManagementAPI
+	if cfg.BindAddress == "" && cfg.Port == 0 && cfg.Auth.Mode == "" {
+		return config.DefaultManagementAPIConfig()
+	}
+	if cfg.Auth.Mode == "" {
+		cfg.Auth.Mode = config.ManagementAuthModeDisabled
+	}
+	if len(cfg.Auth.Roles) == 0 {
+		cfg.Auth.Roles = config.DefaultManagementAPIRoles()
+	}
+	return cfg
+}
+
+func (policy managementAuthPolicy) authorize(route apiRoute, r *http.Request) (managementPrincipal, int, string) {
+	if route.Permission == PermHealthRead {
+		return managementPrincipal{Role: "anonymous", Anonymous: true}, 0, ""
+	}
+
+	switch policy.Mode {
+	case "", config.ManagementAuthModeDisabled:
+		return managementPrincipal{Role: "admin", AuthEnabled: false}, 0, ""
+	case config.ManagementAuthModeBearer:
+		return policy.authorizeBearer(route, r)
+	default:
+		return managementPrincipal{}, http.StatusInternalServerError, "INVALID_AUTH_MODE"
+	}
+}
+
+func (policy managementAuthPolicy) authorizeBearer(route apiRoute, r *http.Request) (managementPrincipal, int, string) {
+	if len(policy.Tokens) == 0 {
+		return managementPrincipal{}, http.StatusUnauthorized, "MANAGEMENT_AUTH_NOT_CONFIGURED"
+	}
+
+	token := extractBearerToken(r)
+	if token == "" {
+		return managementPrincipal{AuthEnabled: true}, http.StatusUnauthorized, "UNAUTHORIZED"
+	}
+
+	role, ok := policy.Tokens[token]
+	if !ok {
+		return managementPrincipal{AuthEnabled: true}, http.StatusUnauthorized, "UNAUTHORIZED"
+	}
+	principal := managementPrincipal{Role: role, AuthEnabled: true}
+	if !principal.hasPermission(route.Permission, policy.Roles) {
+		return principal, http.StatusForbidden, "FORBIDDEN"
+	}
+	return principal, 0, ""
+}
+
+func extractBearerToken(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authHeader == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(authHeader, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(authHeader, prefix))
+}
+
+func (p managementPrincipal) hasPermission(required RoutePermission, roles map[string][]string) bool {
+	if required == "" {
+		return true
+	}
+	permissions, ok := roles[p.Role]
+	if !ok {
+		return false
+	}
+	for _, permission := range permissions {
+		if permission == config.ManagementPermWildcard || RoutePermission(permission) == required {
+			return true
+		}
+	}
+	return false
+}

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -3,6 +3,8 @@
 package apiserver
 
 import (
+	"sync"
+
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/modelinventory"
@@ -13,6 +15,7 @@ import (
 // ClassificationAPIServer holds the server state and dependencies
 type ClassificationAPIServer struct {
 	classificationSvc     classificationService
+	configMu              sync.RWMutex
 	config                *config.RouterConfig
 	runtimeConfig         *liveRuntimeConfig
 	runtimeRegistry       *routerruntime.Registry

--- a/src/semantic-router/pkg/apiserver/config_redact.go
+++ b/src/semantic-router/pkg/apiserver/config_redact.go
@@ -1,0 +1,91 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+const redactedConfigValue = "[REDACTED]"
+
+// canViewSecrets reports whether the request principal may see plaintext
+// secrets in config dumps. Requires secret_view (admin via "*" by default).
+// Missing principal (direct handler calls) defaults to false.
+func (s *ClassificationAPIServer) canViewSecrets(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	principal, ok := managementPrincipalFromContext(r.Context())
+	if !ok {
+		return false
+	}
+	return principal.hasPermission(PermSecretView, s.managementAuthPolicy().Roles)
+}
+
+func managementPrincipalFromContext(ctx context.Context) (managementPrincipal, bool) {
+	if ctx == nil {
+		return managementPrincipal{}, false
+	}
+	principal, ok := ctx.Value(managementPrincipalContextKey).(managementPrincipal)
+	return principal, ok
+}
+
+// maybeRedactConfigView leaves value unchanged when the caller has secret_view;
+// otherwise recursively redacts known secret fields.
+func (s *ClassificationAPIServer) maybeRedactConfigView(r *http.Request, value interface{}) interface{} {
+	if s.canViewSecrets(r) {
+		return value
+	}
+	return redactSensitiveConfigValue(value)
+}
+
+func redactSensitiveConfigValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for key, nested := range typed {
+			if isSensitiveConfigKey(key) {
+				out[key] = redactedConfigValue
+				continue
+			}
+			out[key] = redactSensitiveConfigValue(nested)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(typed))
+		for i, nested := range typed {
+			out[i] = redactSensitiveConfigValue(nested)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func isSensitiveConfigKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	compact := strings.ReplaceAll(normalized, "_", "")
+	// Env var names (api_key_env) and presence flags stay visible.
+	if strings.HasSuffix(compact, "env") || strings.HasSuffix(compact, "envset") {
+		return false
+	}
+	switch compact {
+	case "apikey", "accesskey", "password", "authpassword",
+		"clientsecret", "privatekey", "secret":
+		return true
+	}
+	for _, suffix := range []string{
+		"apikey",
+		"accesskey",
+		"password",
+		"clientsecret",
+		"privatekey",
+	} {
+		if strings.HasSuffix(compact, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/semantic-router/pkg/apiserver/config_redact_test.go
+++ b/src/semantic-router/pkg/apiserver/config_redact_test.go
@@ -1,0 +1,280 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/services"
+)
+
+func TestRedactSensitiveConfigValue(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"providers": map[string]interface{}{
+			"models": []interface{}{
+				map[string]interface{}{
+					"name": "m1",
+					"backend_refs": []interface{}{
+						map[string]interface{}{
+							"api_key":     "plain-secret",
+							"api_key_env": "OPENAI_API_KEY",
+							"password":    "db-pass",
+						},
+					},
+				},
+			},
+		},
+		"tokens_per_unit": 100,
+		"token_filter":    "keep",
+	}
+
+	redacted, ok := redactSensitiveConfigValue(input).(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result")
+	}
+
+	providers := redacted["providers"].(map[string]interface{})
+	models := providers["models"].([]interface{})
+	model := models[0].(map[string]interface{})
+	refs := model["backend_refs"].([]interface{})
+	ref := refs[0].(map[string]interface{})
+
+	if ref["api_key"] != redactedConfigValue {
+		t.Fatalf("api_key = %v, want %q", ref["api_key"], redactedConfigValue)
+	}
+	if ref["password"] != redactedConfigValue {
+		t.Fatalf("password = %v, want %q", ref["password"], redactedConfigValue)
+	}
+	if ref["api_key_env"] != "OPENAI_API_KEY" {
+		t.Fatalf("api_key_env should remain visible, got %v", ref["api_key_env"])
+	}
+	if redacted["tokens_per_unit"] != 100 {
+		t.Fatalf("tokens_per_unit should not be redacted")
+	}
+	if redacted["token_filter"] != "keep" {
+		t.Fatalf("token_filter should not be redacted")
+	}
+}
+
+func TestConfigGetRedactsSecretsForViewerAndOperator(t *testing.T) {
+	const canary = "redact-me-canary-value-0001"
+	configPath := writeConfigWithPlaintextSecret(t, canary)
+
+	cases := []struct {
+		name       string
+		role       string
+		wantLeak   bool
+		wantRedact bool
+	}{
+		{name: "viewer", role: "viewer", wantLeak: false, wantRedact: true},
+		{name: "operator", role: "operator", wantLeak: false, wantRedact: true},
+		{name: "admin", role: "admin", wantLeak: true, wantRedact: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			envName := "VSR_MGMT_TOKEN_" + strings.ToUpper(tc.role)
+			token := tc.role + "-token"
+			t.Setenv(envName, token)
+
+			server := &ClassificationAPIServer{
+				classificationSvc: services.NewPlaceholderClassificationService(),
+				configPath:        configPath,
+				config: &config.RouterConfig{
+					ManagementAPI: config.ManagementAPIConfig{
+						Auth: config.ManagementAPIAuthConfig{
+							Mode: config.ManagementAuthModeBearer,
+							Tokens: []config.ManagementAPITokenRef{
+								{Env: envName, Role: tc.role},
+							},
+							Roles: config.DefaultManagementAPIRoles(),
+						},
+					},
+				},
+			}
+			mux := server.setupRoutes()
+
+			req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+			}
+
+			body := rr.Body.String()
+			leaked := strings.Contains(body, canary)
+			if leaked != tc.wantLeak {
+				t.Fatalf("canary leak=%v want=%v body=%s", leaked, tc.wantLeak, body)
+			}
+			if tc.wantRedact && !strings.Contains(body, redactedConfigValue) {
+				t.Fatalf("expected redacted placeholder in body, got %s", body)
+			}
+		})
+	}
+}
+
+func TestClassifierInfoRedactsSecretsWithoutSecretView(t *testing.T) {
+	const canary = "redact-me-canary-value-0001"
+	cfg := &config.RouterConfig{
+		BackendModels: config.BackendModels{
+			VLLMEndpoints: []config.VLLMEndpoint{
+				{Address: "10.0.0.1", Port: 8000, APIKey: canary},
+			},
+			ModelConfig: map[string]config.ModelParams{
+				"m1": {AccessKey: canary},
+			},
+		},
+		ManagementAPI: config.ManagementAPIConfig{
+			Auth: config.ManagementAPIAuthConfig{
+				Mode: config.ManagementAuthModeBearer,
+				Tokens: []config.ManagementAPITokenRef{
+					{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+				},
+				Roles: config.DefaultManagementAPIRoles(),
+			},
+		},
+	}
+	// Plant a json-visible password so redaction (not only json:"-") is required.
+	cfg.SemanticCache.Redis = &config.RedisConfig{}
+	cfg.SemanticCache.Redis.Connection.Password = canary
+
+	t.Setenv("VSR_MGMT_TOKEN", "viewer-token")
+
+	server := &ClassificationAPIServer{
+		classificationSvc: services.NewPlaceholderClassificationService(),
+		config:            cfg,
+	}
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/info/classifier", nil)
+	req.Header.Set("Authorization", "Bearer viewer-token")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), canary) {
+		t.Fatalf("/info/classifier leaked credential for viewer: %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), redactedConfigValue) {
+		t.Fatalf("expected redacted placeholder for password field, got %s", rr.Body.String())
+	}
+}
+
+func TestAdminCanViewSecretsInClassifierInfo(t *testing.T) {
+	const canary = "redact-me-canary-value-0001"
+	cfg := &config.RouterConfig{
+		ManagementAPI: config.ManagementAPIConfig{
+			Auth: config.ManagementAPIAuthConfig{
+				Mode: config.ManagementAuthModeBearer,
+				Tokens: []config.ManagementAPITokenRef{
+					{Env: "VSR_MGMT_TOKEN", Role: "admin"},
+				},
+				Roles: config.DefaultManagementAPIRoles(),
+			},
+		},
+	}
+	cfg.SemanticCache.Redis = &config.RedisConfig{}
+	cfg.SemanticCache.Redis.Connection.Password = canary
+
+	t.Setenv("VSR_MGMT_TOKEN", "admin-token")
+	server := &ClassificationAPIServer{
+		classificationSvc: services.NewPlaceholderClassificationService(),
+		config:            cfg,
+	}
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/info/classifier", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), canary) {
+		t.Fatalf("admin should see plaintext password, got %s", rr.Body.String())
+	}
+}
+
+func TestDefaultAdminRoleIncludesSecretView(t *testing.T) {
+	roles := config.DefaultManagementAPIRoles()
+	admin := managementPrincipal{Role: "admin", AuthEnabled: true}
+	if !admin.hasPermission(PermSecretView, roles) {
+		t.Fatal("admin wildcard should grant secret_view")
+	}
+	viewer := managementPrincipal{Role: "viewer", AuthEnabled: true}
+	if viewer.hasPermission(PermSecretView, roles) {
+		t.Fatal("viewer must not have secret_view")
+	}
+	operator := managementPrincipal{Role: "operator", AuthEnabled: true}
+	if operator.hasPermission(PermSecretView, roles) {
+		t.Fatal("operator must not have secret_view")
+	}
+}
+
+func writeConfigWithPlaintextSecret(t *testing.T, canary string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	// Minimal YAML map — handleConfigGet unmarshals generically, no full schema needed.
+	content := "providers:\n  models:\n    - name: demo\n      backend_refs:\n        - api_key: " + canary + "\n          api_key_env: OPENAI_API_KEY\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestSecretViewSensitivityRoutesStayOnConfigRead(t *testing.T) {
+	for _, route := range apiRoutes() {
+		if route.Sensitivity != SensitivitySecretView {
+			continue
+		}
+		if route.Permission != PermConfigRead {
+			t.Fatalf("secret_view sensitivity route %s should keep config.read for access; got %s",
+				route.pattern(), route.Permission)
+		}
+	}
+}
+
+// Ensure response JSON shape still parses after redaction.
+func TestConfigGetRedactedBodyIsJSON(t *testing.T) {
+	const canary = "redact-me-canary-value-0001"
+	configPath := writeConfigWithPlaintextSecret(t, canary)
+	t.Setenv("VSR_MGMT_TOKEN", "viewer-token")
+
+	server := &ClassificationAPIServer{
+		classificationSvc: services.NewPlaceholderClassificationService(),
+		configPath:        configPath,
+		config: &config.RouterConfig{
+			ManagementAPI: config.ManagementAPIConfig{
+				Auth: config.ManagementAPIAuthConfig{
+					Mode: config.ManagementAuthModeBearer,
+					Tokens: []config.ManagementAPITokenRef{
+						{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+					},
+					Roles: config.DefaultManagementAPIRoles(),
+				},
+			},
+		},
+	}
+	mux := server.setupRoutes()
+	req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+	req.Header.Set("Authorization", "Bearer viewer-token")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("redacted body must remain valid JSON: %v", err)
+	}
+}

--- a/src/semantic-router/pkg/apiserver/middleware.go
+++ b/src/semantic-router/pkg/apiserver/middleware.go
@@ -1,0 +1,92 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const managementRequestIDHeader = "X-Request-Id"
+
+type requestContextKey string
+
+const (
+	managementPrincipalContextKey requestContextKey = "management_principal"
+	managementRequestIDContextKey requestContextKey = "management_request_id"
+)
+
+func (s *ClassificationAPIServer) wrapRouteHandler(route apiRoute, handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestIDForManagementRequest(r)
+		w.Header().Set(managementRequestIDHeader, requestID)
+
+		policy := s.managementAuthPolicy()
+		principal, statusCode, code := policy.authorize(route, r)
+		if statusCode != 0 {
+			s.writeManagementError(w, statusCode, code, managementErrorMessage(code), requestID)
+			return
+		}
+
+		if route.RequestBody.LimitBytes > 0 && r.Body != nil && route.RequestBody.Kind != "" {
+			r.Body = http.MaxBytesReader(w, r.Body, route.RequestBody.LimitBytes)
+		}
+
+		ctx := withManagementRequestContext(r.Context(), requestID, principal)
+		handler(w, r.WithContext(ctx))
+	}
+}
+
+func requestIDForManagementRequest(r *http.Request) string {
+	if r != nil {
+		if existing := strings.TrimSpace(r.Header.Get(managementRequestIDHeader)); existing != "" {
+			return existing
+		}
+	}
+	return uuid.NewString()
+}
+
+func withManagementRequestContext(ctx context.Context, requestID string, principal managementPrincipal) context.Context {
+	ctx = withManagementPrincipal(ctx, principal)
+	return context.WithValue(ctx, managementRequestIDContextKey, requestID)
+}
+
+func withManagementPrincipal(ctx context.Context, principal managementPrincipal) context.Context {
+	return context.WithValue(ctx, managementPrincipalContextKey, principal)
+}
+
+func (s *ClassificationAPIServer) writeManagementError(
+	w http.ResponseWriter,
+	statusCode int,
+	code string,
+	message string,
+	requestID string,
+) {
+	s.writeJSONResponse(w, statusCode, map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":       code,
+			"message":    message,
+			"request_id": requestID,
+			"timestamp":  time.Now().UTC().Format(time.RFC3339),
+		},
+	})
+}
+
+func managementErrorMessage(code string) string {
+	switch code {
+	case "UNAUTHORIZED":
+		return "management API authentication required"
+	case "FORBIDDEN":
+		return "management API permission denied"
+	case "MANAGEMENT_AUTH_NOT_CONFIGURED":
+		return "management API bearer auth is enabled but no tokens are configured"
+	case "INVALID_AUTH_MODE":
+		return "management API auth mode is invalid"
+	default:
+		return "management API request rejected"
+	}
+}

--- a/src/semantic-router/pkg/apiserver/route_auth_test.go
+++ b/src/semantic-router/pkg/apiserver/route_auth_test.go
@@ -1,0 +1,262 @@
+//go:build !windows && cgo
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/services"
+)
+
+func TestAPIRouteCatalogRequiresPolicyMetadata(t *testing.T) {
+	for _, route := range apiRoutes() {
+		if route.Permission == "" {
+			t.Fatalf("route %s missing permission", route.pattern())
+		}
+		if route.Sensitivity == "" {
+			t.Fatalf("route %s missing sensitivity", route.pattern())
+		}
+	}
+}
+
+func TestAPIRouteCatalogHasUniqueMethodPathPairs(t *testing.T) {
+	seen := make(map[string]struct{}, len(apiRoutes()))
+	for _, route := range apiRoutes() {
+		key := route.pattern()
+		if _, ok := seen[key]; ok {
+			t.Fatalf("duplicate route registration: %s", key)
+		}
+		seen[key] = struct{}{}
+	}
+}
+
+func TestManagementAuthDisabledAllowsConfigRoutes(t *testing.T) {
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{Mode: config.ManagementAuthModeDisabled},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code == http.StatusUnauthorized || rr.Code == http.StatusForbidden {
+		t.Fatalf("expected disabled auth to allow config read, got %d", rr.Code)
+	}
+}
+
+func TestManagementAuthBearerRejectsAnonymousConfigRead(t *testing.T) {
+	t.Setenv("VSR_MGMT_TOKEN", "test-management-token")
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for anonymous config read, got %d", rr.Code)
+	}
+	assertManagementErrorCode(t, rr, "UNAUTHORIZED")
+}
+
+func TestManagementAuthBearerAllowsViewerConfigRead(t *testing.T) {
+	const token = "viewer-management-token"
+	t.Setenv("VSR_MGMT_TOKEN", token)
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code == http.StatusUnauthorized || rr.Code == http.StatusForbidden {
+		t.Fatalf("expected viewer token to allow config read, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestManagementAuthBearerRejectsViewerConfigWrite(t *testing.T) {
+	const token = "viewer-management-token"
+	t.Setenv("VSR_MGMT_TOKEN", token)
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodPatch, "/config/router", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for viewer config write, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	assertManagementErrorCode(t, rr, "FORBIDDEN")
+}
+
+func TestManagementAuthBearerRejectsInvalidToken(t *testing.T) {
+	t.Setenv("VSR_MGMT_TOKEN", "real-token")
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "admin"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for invalid token, got %d", rr.Code)
+	}
+}
+
+func TestManagementAuthBearerRequiresConfiguredTokens(t *testing.T) {
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode:  config.ManagementAuthModeBearer,
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+	req.Header.Set("Authorization", "Bearer unused")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 when bearer auth has no tokens, got %d", rr.Code)
+	}
+	assertManagementErrorCode(t, rr, "MANAGEMENT_AUTH_NOT_CONFIGURED")
+}
+
+func TestHealthRouteAllowsAnonymousAccessWithBearerAuth(t *testing.T) {
+	t.Setenv("VSR_MGMT_TOKEN", "secret-token")
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected anonymous /health to succeed, got %d", rr.Code)
+	}
+	if got := rr.Header().Get(managementRequestIDHeader); got == "" {
+		t.Fatalf("expected %s response header", managementRequestIDHeader)
+	}
+}
+
+func TestReadyRouteRequiresAuthWhenBearerEnabled(t *testing.T) {
+	t.Setenv("VSR_MGMT_TOKEN", "secret-token")
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected anonymous /ready to be unauthorized, got %d", rr.Code)
+	}
+}
+
+func TestManagementAuthPreservesCallerRequestID(t *testing.T) {
+	t.Setenv("VSR_MGMT_TOKEN", "secret-token")
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+	mux := server.setupRoutes()
+
+	const requestID = "req-phase1-auth-001"
+	req := httptest.NewRequest(http.MethodGet, "/config/router", nil)
+	req.Header.Set(managementRequestIDHeader, requestID)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if got := rr.Header().Get(managementRequestIDHeader); got != requestID {
+		t.Fatalf("expected request id %q, got %q", requestID, got)
+	}
+}
+
+func testManagementAPIServer(t *testing.T, management config.ManagementAPIConfig) *ClassificationAPIServer {
+	t.Helper()
+	if management.Auth.Mode == "" {
+		management.Auth.Mode = config.ManagementAuthModeDisabled
+	}
+	if len(management.Auth.Roles) == 0 {
+		management.Auth.Roles = config.DefaultManagementAPIRoles()
+	}
+	return &ClassificationAPIServer{
+		classificationSvc: services.NewPlaceholderClassificationService(),
+		config: &config.RouterConfig{
+			ManagementAPI: management,
+		},
+	}
+}
+
+func assertManagementErrorCode(t *testing.T, rr *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	body := rr.Body.String()
+	if !strings.Contains(body, `"code":"`+want+`"`) && !strings.Contains(body, `"code": "`+want+`"`) {
+		t.Fatalf("expected error code %q in body, got %s", want, body)
+	}
+	if !strings.Contains(body, "request_id") {
+		t.Fatalf("expected request_id in error body, got %s", body)
+	}
+}

--- a/src/semantic-router/pkg/apiserver/route_auth_test.go
+++ b/src/semantic-router/pkg/apiserver/route_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
@@ -248,6 +249,58 @@ func testManagementAPIServer(t *testing.T, management config.ManagementAPIConfig
 			ManagementAPI: management,
 		},
 	}
+}
+
+// TestManagementAuthPolicyConcurrentWithConfigPublish exercises the auth
+// path against concurrent publishConfigMutation writers. Under go test -race,
+// an unsynchronized s.config read/write pair fails this test.
+func TestManagementAuthPolicyConcurrentWithConfigPublish(t *testing.T) {
+	t.Setenv("VSR_MGMT_TOKEN", "race-token")
+
+	server := testManagementAPIServer(t, config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	})
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				policy := server.managementAuthPolicy()
+				if policy.Mode != config.ManagementAuthModeBearer && policy.Mode != config.ManagementAuthModeDisabled {
+					t.Errorf("unexpected auth mode %q", policy.Mode)
+					return
+				}
+			}
+		}()
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				next := &config.RouterConfig{
+					ManagementAPI: config.ManagementAPIConfig{
+						Auth: config.ManagementAPIAuthConfig{
+							Mode: config.ManagementAuthModeBearer,
+							Tokens: []config.ManagementAPITokenRef{
+								{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+							},
+							Roles: config.DefaultManagementAPIRoles(),
+						},
+						Port: 8080 + i + j,
+					},
+				}
+				server.publishConfigMutation(next)
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 func assertManagementErrorCode(t *testing.T, rr *httptest.ResponseRecorder, want string) {

--- a/src/semantic-router/pkg/apiserver/route_config_deploy.go
+++ b/src/semantic-router/pkg/apiserver/route_config_deploy.go
@@ -201,7 +201,8 @@ func (s *ClassificationAPIServer) handleConfigVersions(w http.ResponseWriter, _ 
 }
 
 // handleConfigGet handles GET /config/router and returns the current router config as JSON.
-func (s *ClassificationAPIServer) handleConfigGet(w http.ResponseWriter, _ *http.Request) {
+// Access requires config.read; plaintext secrets require secret_view (otherwise redacted).
+func (s *ClassificationAPIServer) handleConfigGet(w http.ResponseWriter, r *http.Request) {
 	if s.configPath == "" {
 		s.writeErrorResponse(w, http.StatusInternalServerError, "NO_CONFIG_PATH", "Router configPath not set")
 		return
@@ -220,7 +221,7 @@ func (s *ClassificationAPIServer) handleConfigGet(w http.ResponseWriter, _ *http
 		return
 	}
 
-	s.writeJSONResponse(w, http.StatusOK, cfgMap)
+	s.writeJSONResponse(w, http.StatusOK, s.maybeRedactConfigView(r, cfgMap))
 }
 
 func configCleanupBackups(backupDir string) {

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -105,8 +105,8 @@ func (s *ClassificationAPIServer) parseEmbeddingRequest(w http.ResponseWriter, r
 
 	applyEmbeddingDefaults(&req)
 	mmbertPath := ""
-	if s.config != nil {
-		mmbertPath = s.config.EmbeddingModels.MmBertModelPath
+	if cfg := s.currentConfig(); cfg != nil {
+		mmbertPath = cfg.EmbeddingModels.MmBertModelPath
 	}
 	availableLayers := config.MmBertAvailableLayers(mmbertPath)
 	if code, message, ok := validateEmbeddingRequest(req, availableLayers); !ok {

--- a/src/semantic-router/pkg/apiserver/route_model_info.go
+++ b/src/semantic-router/pkg/apiserver/route_model_info.go
@@ -24,7 +24,9 @@ func (s *ClassificationAPIServer) handleEmbeddingModelsInfo(w http.ResponseWrite
 	s.writeJSONResponse(w, http.StatusOK, response)
 }
 
-func (s *ClassificationAPIServer) handleClassifierInfo(w http.ResponseWriter, _ *http.Request) {
+// handleClassifierInfo returns live classifier/runtime config.
+// Access requires config.read; plaintext secrets require secret_view (otherwise redacted).
+func (s *ClassificationAPIServer) handleClassifierInfo(w http.ResponseWriter, r *http.Request) {
 	cfg := s.currentConfig()
 	if cfg == nil {
 		s.writeJSONResponse(w, http.StatusOK, map[string]interface{}{
@@ -34,10 +36,9 @@ func (s *ClassificationAPIServer) handleClassifierInfo(w http.ResponseWriter, _ 
 		return
 	}
 
-	// Return the config directly
 	s.writeJSONResponse(w, http.StatusOK, map[string]interface{}{
 		"status": "config_loaded",
-		"config": jsonCompatibleValue(cfg),
+		"config": s.maybeRedactConfigView(r, jsonCompatibleValue(cfg)),
 	})
 }
 

--- a/src/semantic-router/pkg/apiserver/route_policy.go
+++ b/src/semantic-router/pkg/apiserver/route_policy.go
@@ -1,0 +1,71 @@
+//go:build !windows && cgo
+
+package apiserver
+
+// RoutePermission names the authorization required for a management route.
+type RoutePermission string
+
+const (
+	PermHealthRead     RoutePermission = "health.read"
+	PermReadyRead      RoutePermission = "ready.read"
+	PermDocsRead       RoutePermission = "docs.read"
+	PermClassifyInvoke RoutePermission = "classify.invoke"
+	PermConfigRead     RoutePermission = "config.read"
+	PermConfigWrite    RoutePermission = "config.write"
+	PermSecretView     RoutePermission = "secret_view"
+	PermLearningIngest RoutePermission = "learning.ingest"
+	PermDataRead       RoutePermission = "data.read"
+	PermDataWrite      RoutePermission = "data.write"
+	PermMetricsRead    RoutePermission = "metrics.read"
+)
+
+// RouteSensitivity classifies response risk for inventory and policy.
+type RouteSensitivity string
+
+const (
+	SensitivityPublic      RouteSensitivity = "public"
+	SensitivityOperational RouteSensitivity = "operational"
+	SensitivityConfig      RouteSensitivity = "config"
+	SensitivitySecretView  RouteSensitivity = "secret_view"
+	SensitivityMutation    RouteSensitivity = "mutation"
+)
+
+// RouteAuditAction names immutable audit events for mutation routes.
+type RouteAuditAction string
+
+const (
+	AuditActionNone              RouteAuditAction = ""
+	AuditActionConfigPatch       RouteAuditAction = "config.patch"
+	AuditActionConfigPut         RouteAuditAction = "config.put"
+	AuditActionConfigRollback    RouteAuditAction = "config.rollback"
+	AuditActionKnowledgeBaseSave RouteAuditAction = "knowledge_base.save"
+	AuditActionKnowledgeBaseDel  RouteAuditAction = "knowledge_base.delete"
+	AuditActionOutcomeIngest     RouteAuditAction = "outcome.ingest"
+	AuditActionMemoryDelete      RouteAuditAction = "memory.delete"
+	AuditActionDataWrite         RouteAuditAction = "data.write"
+)
+
+type routePolicy struct {
+	Permission  RoutePermission
+	Sensitivity RouteSensitivity
+	AuditAction RouteAuditAction
+}
+
+func managedRoute(
+	meta EndpointMetadata,
+	policy routePolicy,
+	handler apiRouteHandler,
+	body ...apiRequestBody,
+) apiRoute {
+	route := apiRoute{
+		EndpointMetadata: meta,
+		Handler:          handler,
+		Permission:       policy.Permission,
+		Sensitivity:      policy.Sensitivity,
+		AuditAction:      policy.AuditAction,
+	}
+	if len(body) > 0 {
+		route.RequestBody = body[0]
+	}
+	return route
+}

--- a/src/semantic-router/pkg/apiserver/route_startup_status.go
+++ b/src/semantic-router/pkg/apiserver/route_startup_status.go
@@ -40,7 +40,7 @@ func (s *ClassificationAPIServer) loadStartupState() *startupstatus.State {
 		return s.startupStateLoader()
 	}
 
-	cfg := s.config
+	cfg := s.currentConfig()
 	if cfg != nil && cfg.StartupStatus.StoreBackend == "redis" && cfg.StartupStatus.Redis != nil {
 		client := redis.NewClient(&redis.Options{
 			Addr:     cfg.StartupStatus.Redis.Address,

--- a/src/semantic-router/pkg/apiserver/routes.go
+++ b/src/semantic-router/pkg/apiserver/routes.go
@@ -28,6 +28,9 @@ type apiRoute struct {
 	EndpointMetadata
 	Handler     apiRouteHandler
 	RequestBody apiRequestBody
+	Permission  RoutePermission
+	Sensitivity RouteSensitivity
+	AuditAction RouteAuditAction
 }
 
 func (r apiRoute) pattern() string {
@@ -35,9 +38,10 @@ func (r apiRoute) pattern() string {
 }
 
 func (r apiRoute) bind(s *ClassificationAPIServer) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
+	handler := func(w http.ResponseWriter, req *http.Request) {
 		r.Handler(s, w, req)
 	}
+	return s.wrapRouteHandler(r, handler)
 }
 
 func jsonBody() apiRequestBody {
@@ -71,68 +75,14 @@ func apiEndpointMetadata() []EndpointMetadata {
 }
 
 func apiRoutes() []apiRoute {
-	return []apiRoute{
-		{EndpointMetadata: EndpointMetadata{Path: "/health", Method: "GET", Description: "Health check endpoint"}, Handler: (*ClassificationAPIServer).handleHealth},
-		{EndpointMetadata: EndpointMetadata{Path: "/ready", Method: "GET", Description: "Readiness endpoint that turns green only after startup completes"}, Handler: (*ClassificationAPIServer).handleReady},
-		{EndpointMetadata: EndpointMetadata{Path: "/startup-status", Method: "GET", Description: "Detailed router startup and model-download status"}, Handler: (*ClassificationAPIServer).handleStartupStatus},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1", Method: "GET", Description: "API discovery and documentation"}, Handler: (*ClassificationAPIServer).handleAPIOverview},
-		{EndpointMetadata: EndpointMetadata{Path: "/openapi.json", Method: "GET", Description: "OpenAPI 3.0 specification"}, Handler: (*ClassificationAPIServer).handleOpenAPISpec},
-		{EndpointMetadata: EndpointMetadata{Path: "/docs", Method: "GET", Description: "Interactive Swagger UI documentation"}, Handler: (*ClassificationAPIServer).handleSwaggerUI},
-
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/classify/intent", Method: "POST", Description: "Classify user queries into routing categories"}, Handler: (*ClassificationAPIServer).handleIntentClassification, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/classify/pii", Method: "POST", Description: "Detect personally identifiable information in text"}, Handler: (*ClassificationAPIServer).handlePIIDetection, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/classify/security", Method: "POST", Description: "Detect jailbreak attempts and security threats"}, Handler: (*ClassificationAPIServer).handleSecurityDetection, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/classify/fact-check", Method: "POST", Description: "Classify if text needs fact-checking"}, Handler: (*ClassificationAPIServer).handleFactCheckClassification, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/classify/user-feedback", Method: "POST", Description: "Classify user feedback type (satisfied, need_clarification, wrong_answer, want_different)"}, Handler: (*ClassificationAPIServer).handleUserFeedbackClassification, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/classify/combined", Method: "POST", Description: "Perform combined classification (intent, PII, and security)"}, Handler: (*ClassificationAPIServer).handleCombinedClassification, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/classify/batch", Method: "POST", Description: "Batch classification with configurable task_type parameter"}, Handler: (*ClassificationAPIServer).handleBatchClassification, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/eval", Method: "POST", Description: "Evaluate all configured signals regardless of decision usage"}, Handler: (*ClassificationAPIServer).handleEvalClassification, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/nli", Method: "POST", Description: "Natural language inference classification for premise and hypothesis pairs"}, Handler: (*ClassificationAPIServer).handleNLIClassification, RequestBody: jsonBody()},
-
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/embeddings", Method: "POST", Description: "Generate text and image embeddings"}, Handler: (*ClassificationAPIServer).handleEmbeddings, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/similarity", Method: "POST", Description: "Calculate pairwise text similarity"}, Handler: (*ClassificationAPIServer).handleSimilarity, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/similarity/batch", Method: "POST", Description: "Calculate batch text-similarity matches"}, Handler: (*ClassificationAPIServer).handleBatchSimilarity, RequestBody: jsonBody()},
-
-		{EndpointMetadata: EndpointMetadata{Path: "/info/models", Method: "GET", Description: "Get information about loaded models"}, Handler: (*ClassificationAPIServer).handleModelsInfo},
-		{EndpointMetadata: EndpointMetadata{Path: "/info/classifier", Method: "GET", Description: "Get classifier information and status"}, Handler: (*ClassificationAPIServer).handleClassifierInfo},
-		{EndpointMetadata: EndpointMetadata{Path: "/api/v1/embeddings/models", Method: "GET", Description: "Get information about loaded embedding models"}, Handler: (*ClassificationAPIServer).handleEmbeddingModelsInfo},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/models", Method: "GET", Description: "OpenAI-compatible model listing"}, Handler: (*ClassificationAPIServer).handleOpenAIModels},
-		{EndpointMetadata: EndpointMetadata{Path: "/metrics/classification", Method: "GET", Description: "Get classification metrics and statistics"}, Handler: (*ClassificationAPIServer).handleClassificationMetrics},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/router/outcomes", Method: "POST", Description: "Submit Router Learning outcome feedback linked to a replay record"}, Handler: (*ClassificationAPIServer).handleRouterOutcome, RequestBody: jsonBody()},
-
-		{EndpointMetadata: EndpointMetadata{Path: "/config/kbs", Method: "GET", Description: "List configured knowledge bases"}, Handler: (*ClassificationAPIServer).handleListKnowledgeBases},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/kbs", Method: "POST", Description: "Create a managed knowledge base"}, Handler: (*ClassificationAPIServer).handleCreateKnowledgeBase, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/kbs/{name}", Method: "GET", Description: "Read a knowledge base"}, Handler: (*ClassificationAPIServer).handleGetKnowledgeBase},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/kbs/{name}/map/metadata", Method: "GET", Description: "Read generated knowledge-base map metadata"}, Handler: (*ClassificationAPIServer).handleGetKnowledgeBaseMapMetadata},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/kbs/{name}/map/data.ndjson", Method: "GET", Description: "Stream generated knowledge-base map data as NDJSON"}, Handler: (*ClassificationAPIServer).handleGetKnowledgeBaseMapData},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/kbs/{name}", Method: "PUT", Description: "Update a managed knowledge base"}, Handler: (*ClassificationAPIServer).handleUpdateKnowledgeBase, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/kbs/{name}", Method: "DELETE", Description: "Delete a managed knowledge base"}, Handler: (*ClassificationAPIServer).handleDeleteKnowledgeBase},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/router", Method: "GET", Description: "Get the current router config as JSON"}, Handler: (*ClassificationAPIServer).handleConfigGet},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/router", Method: "PATCH", Description: "Merge a router config update (validates, backs up, writes, triggers hot-reload)"}, Handler: (*ClassificationAPIServer).handleConfigPatch, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/router", Method: "PUT", Description: "Replace the router config (validates, backs up, writes, triggers hot-reload)"}, Handler: (*ClassificationAPIServer).handleConfigPut, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/router/rollback", Method: "POST", Description: "Rollback to a previous router config version"}, Handler: (*ClassificationAPIServer).handleConfigRollback, RequestBody: jsonBody()},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/router/versions", Method: "GET", Description: "List available router config backup versions"}, Handler: (*ClassificationAPIServer).handleConfigVersions},
-		{EndpointMetadata: EndpointMetadata{Path: "/config/hash", Method: "GET", Description: "Get the active router config hash"}, Handler: (*ClassificationAPIServer).handleConfigHash},
-
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/memory", Method: "GET", Description: "List long-term memories"}, Handler: (*ClassificationAPIServer).handleListMemories},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/memory", Method: "DELETE", Description: "Delete memories by scope"}, Handler: (*ClassificationAPIServer).handleDeleteMemoriesByScope},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/memory/{id}", Method: "GET", Description: "Read one long-term memory"}, Handler: (*ClassificationAPIServer).handleGetMemory},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/memory/{id}", Method: "DELETE", Description: "Delete one long-term memory"}, Handler: (*ClassificationAPIServer).handleDeleteMemory},
-
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores", Method: "POST", Description: "Create a vector store"}, Handler: (*ClassificationAPIServer).handleCreateVectorStore, RequestBody: jsonBodyWithLimit(maxVectorStoreJSONBodySize)},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores", Method: "GET", Description: "List vector stores"}, Handler: (*ClassificationAPIServer).handleListVectorStores},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores/{id}", Method: "GET", Description: "Read a vector store"}, Handler: (*ClassificationAPIServer).handleGetVectorStore},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores/{id}", Method: "POST", Description: "Update a vector store"}, Handler: (*ClassificationAPIServer).handleUpdateVectorStore, RequestBody: jsonBodyWithLimit(maxVectorStoreJSONBodySize)},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores/{id}", Method: "DELETE", Description: "Delete a vector store"}, Handler: (*ClassificationAPIServer).handleDeleteVectorStore},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores/{id}/search", Method: "POST", Description: "Search a vector store"}, Handler: (*ClassificationAPIServer).handleSearchVectorStore, RequestBody: jsonBodyWithLimit(maxVectorStoreJSONBodySize)},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores/{id}/files", Method: "POST", Description: "Attach a file to a vector store"}, Handler: (*ClassificationAPIServer).handleAttachFile, RequestBody: jsonBodyWithLimit(maxVectorStoreJSONBodySize)},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores/{id}/files", Method: "GET", Description: "List files attached to a vector store"}, Handler: (*ClassificationAPIServer).handleListVectorStoreFiles},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/vector_stores/{id}/files/{file_id}", Method: "DELETE", Description: "Detach a file from a vector store"}, Handler: (*ClassificationAPIServer).handleDetachFile},
-
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/files", Method: "POST", Description: "Upload a file"}, Handler: (*ClassificationAPIServer).handleUploadFile, RequestBody: multipartBody(maxUploadSize, "Multipart upload with a file field and optional purpose field.")},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/files", Method: "GET", Description: "List uploaded files"}, Handler: (*ClassificationAPIServer).handleListFiles},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/files/{id}", Method: "GET", Description: "Read uploaded-file metadata"}, Handler: (*ClassificationAPIServer).handleGetFile},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/files/{id}", Method: "DELETE", Description: "Delete an uploaded file"}, Handler: (*ClassificationAPIServer).handleDeleteFile},
-		{EndpointMetadata: EndpointMetadata{Path: "/v1/files/{id}/content", Method: "GET", Description: "Download uploaded-file content"}, Handler: (*ClassificationAPIServer).handleGetFileContent},
-	}
+	return appendAPIRoutes(
+		make([]apiRoute, 0, 64),
+		apiHealthRoutes(),
+		apiClassifyRoutes(),
+		apiInfoRoutes(),
+		apiConfigRoutes(),
+		apiMemoryRoutes(),
+		apiVectorStoreRoutes(),
+		apiFileRoutes(),
+	)
 }

--- a/src/semantic-router/pkg/apiserver/routes_catalog.go
+++ b/src/semantic-router/pkg/apiserver/routes_catalog.go
@@ -1,0 +1,343 @@
+//go:build !windows && cgo
+
+package apiserver
+
+func apiHealthRoutes() []apiRoute {
+	return []apiRoute{
+		managedRoute(
+			EndpointMetadata{Path: "/health", Method: "GET", Description: "Health check endpoint"},
+			routePolicy{Permission: PermHealthRead, Sensitivity: SensitivityPublic},
+			(*ClassificationAPIServer).handleHealth,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/ready", Method: "GET", Description: "Readiness endpoint that turns green only after startup completes"},
+			routePolicy{Permission: PermReadyRead, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleReady,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/startup-status", Method: "GET", Description: "Detailed router startup and model-download status"},
+			routePolicy{Permission: PermReadyRead, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleStartupStatus,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1", Method: "GET", Description: "API discovery and documentation"},
+			routePolicy{Permission: PermDocsRead, Sensitivity: SensitivityPublic},
+			(*ClassificationAPIServer).handleAPIOverview,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/openapi.json", Method: "GET", Description: "OpenAPI 3.0 specification"},
+			routePolicy{Permission: PermDocsRead, Sensitivity: SensitivityPublic},
+			(*ClassificationAPIServer).handleOpenAPISpec,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/docs", Method: "GET", Description: "Interactive Swagger UI documentation"},
+			routePolicy{Permission: PermDocsRead, Sensitivity: SensitivityPublic},
+			(*ClassificationAPIServer).handleSwaggerUI,
+		),
+	}
+}
+
+func apiClassifyRoutes() []apiRoute {
+	return []apiRoute{
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/classify/intent", Method: "POST", Description: "Classify user queries into routing categories"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleIntentClassification,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/classify/pii", Method: "POST", Description: "Detect personally identifiable information in text"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handlePIIDetection,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/classify/security", Method: "POST", Description: "Detect jailbreak attempts and security threats"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleSecurityDetection,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/classify/fact-check", Method: "POST", Description: "Classify if text needs fact-checking"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleFactCheckClassification,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/classify/user-feedback", Method: "POST", Description: "Classify user feedback type (satisfied, need_clarification, wrong_answer, want_different)"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleUserFeedbackClassification,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/classify/combined", Method: "POST", Description: "Perform combined classification (intent, PII, and security)"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleCombinedClassification,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/classify/batch", Method: "POST", Description: "Batch classification with configurable task_type parameter"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleBatchClassification,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/eval", Method: "POST", Description: "Evaluate all configured signals regardless of decision usage"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleEvalClassification,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/nli", Method: "POST", Description: "Natural language inference classification for premise and hypothesis pairs"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleNLIClassification,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/embeddings", Method: "POST", Description: "Generate text and image embeddings"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleEmbeddings,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/similarity", Method: "POST", Description: "Calculate pairwise text similarity"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleSimilarity,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/similarity/batch", Method: "POST", Description: "Calculate batch text-similarity matches"},
+			routePolicy{Permission: PermClassifyInvoke, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleBatchSimilarity,
+			jsonBody(),
+		),
+	}
+}
+
+func apiInfoRoutes() []apiRoute {
+	return []apiRoute{
+		managedRoute(
+			EndpointMetadata{Path: "/info/models", Method: "GET", Description: "Get information about loaded models"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleModelsInfo,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/info/classifier", Method: "GET", Description: "Get classifier information and status"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivitySecretView},
+			(*ClassificationAPIServer).handleClassifierInfo,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/api/v1/embeddings/models", Method: "GET", Description: "Get information about loaded embedding models"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleEmbeddingModelsInfo,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/models", Method: "GET", Description: "OpenAI-compatible model listing"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleOpenAIModels,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/metrics/classification", Method: "GET", Description: "Get classification metrics and statistics"},
+			routePolicy{Permission: PermMetricsRead, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleClassificationMetrics,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/router/outcomes", Method: "POST", Description: "Submit Router Learning outcome feedback linked to a replay record"},
+			routePolicy{Permission: PermLearningIngest, Sensitivity: SensitivityMutation, AuditAction: AuditActionOutcomeIngest},
+			(*ClassificationAPIServer).handleRouterOutcome,
+			jsonBody(),
+		),
+	}
+}
+
+func apiConfigRoutes() []apiRoute {
+	return []apiRoute{
+		managedRoute(
+			EndpointMetadata{Path: "/config/kbs", Method: "GET", Description: "List configured knowledge bases"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleListKnowledgeBases,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/kbs", Method: "POST", Description: "Create a managed knowledge base"},
+			routePolicy{Permission: PermConfigWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionKnowledgeBaseSave},
+			(*ClassificationAPIServer).handleCreateKnowledgeBase,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/kbs/{name}", Method: "GET", Description: "Read a knowledge base"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleGetKnowledgeBase,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/kbs/{name}/map/metadata", Method: "GET", Description: "Read generated knowledge-base map metadata"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleGetKnowledgeBaseMapMetadata,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/kbs/{name}/map/data.ndjson", Method: "GET", Description: "Stream generated knowledge-base map data as NDJSON"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleGetKnowledgeBaseMapData,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/kbs/{name}", Method: "PUT", Description: "Update a managed knowledge base"},
+			routePolicy{Permission: PermConfigWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionKnowledgeBaseSave},
+			(*ClassificationAPIServer).handleUpdateKnowledgeBase,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/kbs/{name}", Method: "DELETE", Description: "Delete a managed knowledge base"},
+			routePolicy{Permission: PermConfigWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionKnowledgeBaseDel},
+			(*ClassificationAPIServer).handleDeleteKnowledgeBase,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/router", Method: "GET", Description: "Get the current router config as JSON"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivitySecretView},
+			(*ClassificationAPIServer).handleConfigGet,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/router", Method: "PATCH", Description: "Merge a router config update (validates, backs up, writes, triggers hot-reload)"},
+			routePolicy{Permission: PermConfigWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionConfigPatch},
+			(*ClassificationAPIServer).handleConfigPatch,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/router", Method: "PUT", Description: "Replace the router config (validates, backs up, writes, triggers hot-reload)"},
+			routePolicy{Permission: PermConfigWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionConfigPut},
+			(*ClassificationAPIServer).handleConfigPut,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/router/rollback", Method: "POST", Description: "Rollback to a previous router config version"},
+			routePolicy{Permission: PermConfigWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionConfigRollback},
+			(*ClassificationAPIServer).handleConfigRollback,
+			jsonBody(),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/router/versions", Method: "GET", Description: "List available router config backup versions"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleConfigVersions,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/config/hash", Method: "GET", Description: "Get the active router config hash"},
+			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleConfigHash,
+		),
+	}
+}
+
+func apiMemoryRoutes() []apiRoute {
+	return []apiRoute{
+		managedRoute(
+			EndpointMetadata{Path: "/v1/memory", Method: "GET", Description: "List long-term memories"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleListMemories,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/memory", Method: "DELETE", Description: "Delete memories by scope"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionMemoryDelete},
+			(*ClassificationAPIServer).handleDeleteMemoriesByScope,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/memory/{id}", Method: "GET", Description: "Read one long-term memory"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleGetMemory,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/memory/{id}", Method: "DELETE", Description: "Delete one long-term memory"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionMemoryDelete},
+			(*ClassificationAPIServer).handleDeleteMemory,
+		),
+	}
+}
+
+func apiVectorStoreRoutes() []apiRoute {
+	return []apiRoute{
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores", Method: "POST", Description: "Create a vector store"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionDataWrite},
+			(*ClassificationAPIServer).handleCreateVectorStore,
+			jsonBodyWithLimit(maxVectorStoreJSONBodySize),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores", Method: "GET", Description: "List vector stores"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleListVectorStores,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores/{id}", Method: "GET", Description: "Read a vector store"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleGetVectorStore,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores/{id}", Method: "POST", Description: "Update a vector store"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionDataWrite},
+			(*ClassificationAPIServer).handleUpdateVectorStore,
+			jsonBodyWithLimit(maxVectorStoreJSONBodySize),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores/{id}", Method: "DELETE", Description: "Delete a vector store"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionDataWrite},
+			(*ClassificationAPIServer).handleDeleteVectorStore,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores/{id}/search", Method: "POST", Description: "Search a vector store"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityOperational},
+			(*ClassificationAPIServer).handleSearchVectorStore,
+			jsonBodyWithLimit(maxVectorStoreJSONBodySize),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores/{id}/files", Method: "POST", Description: "Attach a file to a vector store"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionDataWrite},
+			(*ClassificationAPIServer).handleAttachFile,
+			jsonBodyWithLimit(maxVectorStoreJSONBodySize),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores/{id}/files", Method: "GET", Description: "List files attached to a vector store"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleListVectorStoreFiles,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/vector_stores/{id}/files/{file_id}", Method: "DELETE", Description: "Detach a file from a vector store"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionDataWrite},
+			(*ClassificationAPIServer).handleDetachFile,
+		),
+	}
+}
+
+func apiFileRoutes() []apiRoute {
+	return []apiRoute{
+		managedRoute(
+			EndpointMetadata{Path: "/v1/files", Method: "POST", Description: "Upload a file"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionDataWrite},
+			(*ClassificationAPIServer).handleUploadFile,
+			multipartBody(maxUploadSize, "Multipart upload with a file field and optional purpose field."),
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/files", Method: "GET", Description: "List uploaded files"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleListFiles,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/files/{id}", Method: "GET", Description: "Read uploaded-file metadata"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleGetFile,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/files/{id}", Method: "DELETE", Description: "Delete an uploaded file"},
+			routePolicy{Permission: PermDataWrite, Sensitivity: SensitivityMutation, AuditAction: AuditActionDataWrite},
+			(*ClassificationAPIServer).handleDeleteFile,
+		),
+		managedRoute(
+			EndpointMetadata{Path: "/v1/files/{id}/content", Method: "GET", Description: "Download uploaded-file content"},
+			routePolicy{Permission: PermDataRead, Sensitivity: SensitivityConfig},
+			(*ClassificationAPIServer).handleGetFileContent,
+		),
+	}
+}
+
+func appendAPIRoutes(routes []apiRoute, groups ...[]apiRoute) []apiRoute {
+	for _, group := range groups {
+		routes = append(routes, group...)
+	}
+	return routes
+}

--- a/src/semantic-router/pkg/apiserver/routes_catalog.go
+++ b/src/semantic-router/pkg/apiserver/routes_catalog.go
@@ -122,7 +122,7 @@ func apiInfoRoutes() []apiRoute {
 			(*ClassificationAPIServer).handleModelsInfo,
 		),
 		managedRoute(
-			EndpointMetadata{Path: "/info/classifier", Method: "GET", Description: "Get classifier information and status"},
+			EndpointMetadata{Path: "/info/classifier", Method: "GET", Description: "Get classifier information and status (secrets redacted without secret_view)"},
 			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivitySecretView},
 			(*ClassificationAPIServer).handleClassifierInfo,
 		),
@@ -190,7 +190,7 @@ func apiConfigRoutes() []apiRoute {
 			(*ClassificationAPIServer).handleDeleteKnowledgeBase,
 		),
 		managedRoute(
-			EndpointMetadata{Path: "/config/router", Method: "GET", Description: "Get the current router config as JSON"},
+			EndpointMetadata{Path: "/config/router", Method: "GET", Description: "Get the current router config as JSON (secrets redacted without secret_view)"},
 			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivitySecretView},
 			(*ClassificationAPIServer).handleConfigGet,
 		),

--- a/src/semantic-router/pkg/apiserver/runtime_config.go
+++ b/src/semantic-router/pkg/apiserver/runtime_config.go
@@ -54,9 +54,14 @@ func (c *liveRuntimeConfig) Update(newCfg *config.RouterConfig) {
 }
 
 func (s *ClassificationAPIServer) currentConfig() *config.RouterConfig {
+	if s == nil {
+		return nil
+	}
 	if s.runtimeConfig != nil {
 		return s.runtimeConfig.Current()
 	}
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
 	return s.config
 }
 
@@ -64,7 +69,9 @@ func (s *ClassificationAPIServer) publishConfigMutation(newCfg *config.RouterCon
 	if s == nil {
 		return
 	}
+	s.configMu.Lock()
 	s.config = newCfg
+	s.configMu.Unlock()
 	if s.runtimeConfig != nil {
 		s.runtimeConfig.Update(newCfg)
 		return

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -18,22 +18,55 @@ import (
 
 // Init starts the API server.
 func Init(configPath string, port int) error {
-	return InitWithRuntime(configPath, port, nil)
+	return InitWithOptions(InitOptions{
+		ConfigPath: configPath,
+		Port:       port,
+	})
+}
+
+// InitOptions carries management listener startup overrides.
+type InitOptions struct {
+	ConfigPath      string
+	Port            int
+	BindAddress     string
+	RemoteExposure  *bool
+	AuthMode        string
+	RuntimeRegistry *routerruntime.Registry
 }
 
 // InitWithRuntime starts the API server using the shared runtime registry when
 // one is available. Legacy callers can continue using Init and fall back to the
 // compatibility globals.
 func InitWithRuntime(configPath string, port int, runtimeRegistry *routerruntime.Registry) error {
+	return InitWithOptions(InitOptions{
+		ConfigPath:      configPath,
+		Port:            port,
+		RuntimeRegistry: runtimeRegistry,
+	})
+}
+
+// InitWithOptions starts the API server with explicit management listener policy.
+func InitWithOptions(opts InitOptions) error {
 	// Get the global configuration instead of loading from file
 	// This ensures we use the same config as the rest of the application
-	cfg := resolveAPIServerConfig(runtimeRegistry)
+	cfg := resolveAPIServerConfig(opts.RuntimeRegistry)
 	if cfg == nil {
 		return fmt.Errorf("configuration not initialized")
 	}
 
-	classificationSvc := resolveClassificationService(cfg, runtimeRegistry)
-	classificationSvc = ensureClassificationService(cfg, runtimeRegistry, classificationSvc)
+	managementCfg, err := cfg.ManagementAPI.ResolvedManagementAPI(config.ManagementAPIRuntimeOptions{
+		Port:           opts.Port,
+		BindAddress:    opts.BindAddress,
+		RemoteExposure: opts.RemoteExposure,
+		AuthMode:       opts.AuthMode,
+	})
+	if err != nil {
+		return fmt.Errorf("invalid management API configuration: %w", err)
+	}
+	cfg.ManagementAPI = managementCfg
+
+	classificationSvc := resolveClassificationService(cfg, opts.RuntimeRegistry)
+	classificationSvc = ensureClassificationService(cfg, opts.RuntimeRegistry, classificationSvc)
 
 	// Initialize batch metrics configuration
 	if cfg.API.BatchClassification.Metrics.Enabled {
@@ -52,7 +85,7 @@ func InitWithRuntime(configPath string, port int, runtimeRegistry *routerruntime
 	// Get memory store if available (set by ExtProc router during init)
 	var memoryStore memory.Store
 	if shouldInitMemoryStore(cfg) {
-		memoryStore = resolveMemoryStore(cfg, runtimeRegistry)
+		memoryStore = resolveMemoryStore(cfg, opts.RuntimeRegistry)
 		if memoryStore != nil {
 			logging.ComponentEvent("apiserver", "memory_api_enabled", map[string]interface{}{})
 		} else {
@@ -69,16 +102,16 @@ func InitWithRuntime(configPath string, port int, runtimeRegistry *routerruntime
 
 	liveClassificationSvc := newLiveClassificationService(
 		classificationSvc,
-		buildClassificationResolver(runtimeRegistry),
+		buildClassificationResolver(opts.RuntimeRegistry),
 	)
 
 	// Create server instance
 	apiServer := &ClassificationAPIServer{
 		classificationSvc:     liveClassificationSvc,
 		config:                cfg,
-		runtimeConfig:         newLiveRuntimeConfig(cfg, buildConfigResolver(runtimeRegistry), buildConfigUpdater(runtimeRegistry, liveClassificationSvc)),
-		runtimeRegistry:       runtimeRegistry,
-		configPath:            configPath,
+		runtimeConfig:         newLiveRuntimeConfig(cfg, buildConfigResolver(opts.RuntimeRegistry), buildConfigUpdater(opts.RuntimeRegistry, liveClassificationSvc)),
+		runtimeRegistry:       opts.RuntimeRegistry,
+		configPath:            opts.ConfigPath,
 		memoryStore:           memoryStore,
 		knowledgeBaseMapCache: newKnowledgeBaseMapCache(),
 	}
@@ -86,7 +119,7 @@ func InitWithRuntime(configPath string, port int, runtimeRegistry *routerruntime
 	// Create HTTP server with routes
 	mux := apiServer.setupRoutes()
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%d", port),
+		Addr:         managementCfg.ListenAddress(),
 		Handler:      mux,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
@@ -94,7 +127,11 @@ func InitWithRuntime(configPath string, port int, runtimeRegistry *routerruntime
 	}
 
 	logging.ComponentEvent("apiserver", "server_listening", map[string]interface{}{
-		"port": port,
+		"address":         managementCfg.ListenAddress(),
+		"bind_address":    managementCfg.BindAddress,
+		"port":            managementCfg.Port,
+		"remote_exposure": managementCfg.RemoteExposure,
+		"auth_mode":       managementCfg.Auth.Mode,
 	})
 	return server.ListenAndServe()
 }

--- a/src/semantic-router/pkg/config/canonical_defaults.go
+++ b/src/semantic-router/pkg/config/canonical_defaults.go
@@ -59,6 +59,7 @@ func defaultCanonicalServiceGlobal() CanonicalServiceGlobal {
 		StartupStatus: StartupStatusConfig{
 			StoreBackend: "file",
 		},
+		ManagementAPI: DefaultManagementAPIConfig(),
 		Observability: ObservabilityConfig{
 			Metrics: MetricsConfig{
 				Enabled: canonicalBoolPtr(true),

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -155,6 +155,7 @@ func CanonicalGlobalFromRouterConfig(cfg *RouterConfig) *CanonicalGlobal {
 			Observability: cfg.Observability,
 			Authz:         cfg.Authz,
 			RateLimit:     cfg.RateLimit,
+			ManagementAPI: cfg.ManagementAPI,
 			RouterReplay:  cfg.RouterReplay,
 			StartupStatus: cfg.StartupStatus,
 		},

--- a/src/semantic-router/pkg/config/canonical_global.go
+++ b/src/semantic-router/pkg/config/canonical_global.go
@@ -45,6 +45,7 @@ type CanonicalServiceGlobal struct {
 	Observability ObservabilityConfig `yaml:"observability"`
 	Authz         AuthzConfig         `yaml:"authz"`
 	RateLimit     RateLimitConfig     `yaml:"ratelimit"`
+	ManagementAPI ManagementAPIConfig `yaml:"management_api"`
 	RouterReplay  RouterReplayConfig  `yaml:"router_replay"`
 	StartupStatus StartupStatusConfig `yaml:"startup_status"`
 }
@@ -225,6 +226,7 @@ func applyCanonicalGlobal(cfg *RouterConfig, global *CanonicalGlobal) error {
 	cfg.Observability = global.Services.Observability
 	cfg.Authz = global.Services.Authz
 	cfg.RateLimit = global.Services.RateLimit
+	cfg.ManagementAPI = global.Services.ManagementAPI
 	cfg.RouterReplay = global.Services.RouterReplay
 	cfg.StartupStatus = global.Services.StartupStatus
 

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -81,8 +81,9 @@ type RouterConfig struct {
 	BackendModels      `yaml:",inline"`
 	ToolSelection      `yaml:",inline"`
 
-	Authz     AuthzConfig     `yaml:"authz,omitempty"`
-	RateLimit RateLimitConfig `yaml:"ratelimit,omitempty"`
+	Authz         AuthzConfig         `yaml:"authz,omitempty"`
+	RateLimit     RateLimitConfig     `yaml:"ratelimit,omitempty"`
+	ManagementAPI ManagementAPIConfig `yaml:"management_api,omitempty"`
 
 	// Runtime-only knowledge bases loaded from global.model_catalog.
 	KnowledgeBases []KnowledgeBaseConfig `yaml:"knowledge_bases,omitempty"`

--- a/src/semantic-router/pkg/config/management_api.go
+++ b/src/semantic-router/pkg/config/management_api.go
@@ -61,6 +61,10 @@ func DefaultManagementAPIConfig() ManagementAPIConfig {
 }
 
 // DefaultManagementAPIRoles returns the built-in role-to-permission map.
+//
+// secret_view is admin-only (via ManagementPermWildcard). Viewer and operator
+// may call config.read routes such as GET /config/router, but secret fields are
+// redacted unless the principal has secret_view.
 func DefaultManagementAPIRoles() map[string][]string {
 	return map[string][]string{
 		"viewer": {
@@ -84,6 +88,7 @@ func DefaultManagementAPIRoles() map[string][]string {
 			"data.read",
 			"data.write",
 		},
+		// Wildcard includes secret_view so admin can read plaintext secrets.
 		"admin": {ManagementPermWildcard},
 	}
 }

--- a/src/semantic-router/pkg/config/management_api.go
+++ b/src/semantic-router/pkg/config/management_api.go
@@ -17,8 +17,9 @@ const (
 )
 
 // ManagementAPIConfig configures the router management HTTP listener (#2463).
+// Listener on/off is controlled by the legacy -enable-api flag at startup, not
+// by a config enabled field.
 type ManagementAPIConfig struct {
-	Enabled        bool                    `yaml:"enabled,omitempty"`
 	BindAddress    string                  `yaml:"bind_address,omitempty"`
 	Port           int                     `yaml:"port,omitempty"`
 	RemoteExposure bool                    `yaml:"remote_exposure,omitempty"`
@@ -49,7 +50,6 @@ type ManagementAPIRuntimeOptions struct {
 // DefaultManagementAPIConfig returns safe local defaults for the management listener.
 func DefaultManagementAPIConfig() ManagementAPIConfig {
 	return ManagementAPIConfig{
-		Enabled:        true,
 		BindAddress:    "127.0.0.1",
 		Port:           8080,
 		RemoteExposure: false,

--- a/src/semantic-router/pkg/config/management_api.go
+++ b/src/semantic-router/pkg/config/management_api.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+const (
+	ManagementInternalListenerEnv = "VLLM_SR_MANAGEMENT_INTERNAL_LISTENER"
+
+	ManagementAuthModeBearer   = "bearer"
+	ManagementAuthModeDisabled = "disabled"
+
+	ManagementPermWildcard = "*"
+)
+
+// ManagementAPIConfig configures the router management HTTP listener (#2463).
+type ManagementAPIConfig struct {
+	Enabled        bool                    `yaml:"enabled,omitempty"`
+	BindAddress    string                  `yaml:"bind_address,omitempty"`
+	Port           int                     `yaml:"port,omitempty"`
+	RemoteExposure bool                    `yaml:"remote_exposure,omitempty"`
+	Auth           ManagementAPIAuthConfig `yaml:"auth,omitempty"`
+}
+
+// ManagementAPIAuthConfig controls authentication for non-health management routes.
+type ManagementAPIAuthConfig struct {
+	Mode   string                  `yaml:"mode,omitempty"`
+	Tokens []ManagementAPITokenRef `yaml:"tokens,omitempty"`
+	Roles  map[string][]string     `yaml:"roles,omitempty"`
+}
+
+// ManagementAPITokenRef binds a bearer token from an environment variable to a role.
+type ManagementAPITokenRef struct {
+	Env  string `yaml:"env,omitempty"`
+	Role string `yaml:"role,omitempty"`
+}
+
+// ManagementAPIRuntimeOptions carries CLI overrides for management listener startup.
+type ManagementAPIRuntimeOptions struct {
+	Port           int
+	BindAddress    string
+	RemoteExposure *bool
+	AuthMode       string
+}
+
+// DefaultManagementAPIConfig returns safe local defaults for the management listener.
+func DefaultManagementAPIConfig() ManagementAPIConfig {
+	return ManagementAPIConfig{
+		Enabled:        true,
+		BindAddress:    "127.0.0.1",
+		Port:           8080,
+		RemoteExposure: false,
+		Auth: ManagementAPIAuthConfig{
+			Mode:  ManagementAuthModeDisabled,
+			Roles: DefaultManagementAPIRoles(),
+		},
+	}
+}
+
+// DefaultManagementAPIRoles returns the built-in role-to-permission map.
+func DefaultManagementAPIRoles() map[string][]string {
+	return map[string][]string{
+		"viewer": {
+			"health.read",
+			"ready.read",
+			"docs.read",
+			"metrics.read",
+			"classify.invoke",
+			"config.read",
+			"data.read",
+		},
+		"operator": {
+			"health.read",
+			"ready.read",
+			"docs.read",
+			"metrics.read",
+			"classify.invoke",
+			"config.read",
+			"config.write",
+			"learning.ingest",
+			"data.read",
+			"data.write",
+		},
+		"admin": {ManagementPermWildcard},
+	}
+}
+
+// ResolvedManagementAPI merges config defaults with runtime CLI overrides.
+func (c ManagementAPIConfig) ResolvedManagementAPI(opts ManagementAPIRuntimeOptions) (ManagementAPIConfig, error) {
+	resolved := c
+	if resolved.BindAddress == "" {
+		resolved.BindAddress = DefaultManagementAPIConfig().BindAddress
+	}
+	if opts.BindAddress != "" {
+		resolved.BindAddress = opts.BindAddress
+	}
+	if resolved.Port <= 0 {
+		resolved.Port = DefaultManagementAPIConfig().Port
+	}
+	if opts.Port > 0 {
+		resolved.Port = opts.Port
+	}
+	if opts.RemoteExposure != nil {
+		resolved.RemoteExposure = *opts.RemoteExposure
+	}
+	if opts.AuthMode != "" {
+		resolved.Auth.Mode = opts.AuthMode
+	}
+	if resolved.Auth.Mode == "" {
+		resolved.Auth.Mode = ManagementAuthModeDisabled
+	}
+	if len(resolved.Auth.Roles) == 0 {
+		resolved.Auth.Roles = DefaultManagementAPIRoles()
+	}
+
+	if err := resolved.validateBindAddress(); err != nil {
+		return ManagementAPIConfig{}, err
+	}
+	if err := resolved.validateExposurePolicy(); err != nil {
+		return ManagementAPIConfig{}, err
+	}
+	if err := resolved.validateBindExposureConsistency(); err != nil {
+		return ManagementAPIConfig{}, err
+	}
+	return resolved, nil
+}
+
+func (c ManagementAPIConfig) ListenAddress() string {
+	return net.JoinHostPort(c.BindAddress, fmt.Sprintf("%d", c.Port))
+}
+
+func (c ManagementAPIConfig) validateBindAddress() error {
+	if strings.TrimSpace(c.BindAddress) == "" {
+		return fmt.Errorf("management_api.bind_address must not be empty")
+	}
+	if ip := net.ParseIP(c.BindAddress); ip != nil {
+		return nil
+	}
+	if c.BindAddress == "localhost" {
+		return nil
+	}
+	return fmt.Errorf("management_api.bind_address %q must be an IP address or localhost", c.BindAddress)
+}
+
+func (c ManagementAPIConfig) validateExposurePolicy() error {
+	if !c.RemoteExposure {
+		return nil
+	}
+	if c.Auth.Mode == ManagementAuthModeDisabled {
+		return fmt.Errorf("management_api.remote_exposure requires auth.mode bearer")
+	}
+	if len(c.Auth.Tokens) == 0 {
+		return fmt.Errorf("management_api.remote_exposure requires at least one auth.tokens entry")
+	}
+	return nil
+}
+
+func (c ManagementAPIConfig) validateBindExposureConsistency() error {
+	if c.RemoteExposure || !isWideManagementBindAddress(c.BindAddress) {
+		return nil
+	}
+	if strings.TrimSpace(os.Getenv(ManagementInternalListenerEnv)) == "true" {
+		return nil
+	}
+	return fmt.Errorf(
+		"management_api.bind_address %q requires remote_exposure: true (or set %s=true for container-local listeners)",
+		c.BindAddress,
+		ManagementInternalListenerEnv,
+	)
+}
+
+func isWideManagementBindAddress(bindAddress string) bool {
+	switch strings.TrimSpace(bindAddress) {
+	case "", "0.0.0.0", "::", "[::]":
+		return true
+	default:
+		if ip := net.ParseIP(strings.TrimSpace(bindAddress)); ip != nil {
+			return ip.IsUnspecified()
+		}
+		return false
+	}
+}
+
+// ResolvedManagementTokens materializes bearer tokens from configured env refs.
+func (c ManagementAPIAuthConfig) ResolvedManagementTokens() map[string]string {
+	tokens := make(map[string]string)
+	for _, ref := range c.Tokens {
+		env := strings.TrimSpace(ref.Env)
+		role := strings.TrimSpace(ref.Role)
+		if env == "" || role == "" {
+			continue
+		}
+		value := strings.TrimSpace(os.Getenv(env))
+		if value == "" {
+			continue
+		}
+		tokens[value] = role
+	}
+	return tokens
+}

--- a/src/semantic-router/pkg/config/management_api_test.go
+++ b/src/semantic-router/pkg/config/management_api_test.go
@@ -18,6 +18,22 @@ func TestDefaultManagementAPIConfigUsesLoopbackAndDisabledAuth(t *testing.T) {
 	}
 }
 
+func TestResolvedManagementAPIPreservesConfigRemoteExposureWhenOverrideNil(t *testing.T) {
+	cfg := DefaultManagementAPIConfig()
+	cfg.RemoteExposure = true
+	cfg.Auth.Mode = ManagementAuthModeBearer
+	cfg.Auth.Tokens = []ManagementAPITokenRef{{Env: "VSR_MGMT_TOKEN", Role: "admin"}}
+	t.Setenv("VSR_MGMT_TOKEN", "test-token")
+
+	resolved, err := cfg.ResolvedManagementAPI(ManagementAPIRuntimeOptions{})
+	if err != nil {
+		t.Fatalf("ResolvedManagementAPI() error = %v", err)
+	}
+	if !resolved.RemoteExposure {
+		t.Fatal("nil RemoteExposure override must preserve config remote_exposure: true")
+	}
+}
+
 func TestResolvedManagementAPIRejectsRemoteExposureWithoutBearerTokens(t *testing.T) {
 	cfg := DefaultManagementAPIConfig()
 	remote := true

--- a/src/semantic-router/pkg/config/management_api_test.go
+++ b/src/semantic-router/pkg/config/management_api_test.go
@@ -1,0 +1,88 @@
+package config
+
+import "testing"
+
+func TestDefaultManagementAPIConfigUsesLoopbackAndDisabledAuth(t *testing.T) {
+	cfg := DefaultManagementAPIConfig()
+	if cfg.BindAddress != "127.0.0.1" {
+		t.Fatalf("bind_address = %q, want 127.0.0.1", cfg.BindAddress)
+	}
+	if cfg.Port != 8080 {
+		t.Fatalf("port = %d, want 8080", cfg.Port)
+	}
+	if cfg.RemoteExposure {
+		t.Fatal("remote_exposure should default to false")
+	}
+	if cfg.Auth.Mode != ManagementAuthModeDisabled {
+		t.Fatalf("auth.mode = %q, want %q", cfg.Auth.Mode, ManagementAuthModeDisabled)
+	}
+}
+
+func TestResolvedManagementAPIRejectsRemoteExposureWithoutBearerTokens(t *testing.T) {
+	cfg := DefaultManagementAPIConfig()
+	remote := true
+	_, err := cfg.ResolvedManagementAPI(ManagementAPIRuntimeOptions{
+		RemoteExposure: &remote,
+		AuthMode:       ManagementAuthModeBearer,
+	})
+	if err == nil {
+		t.Fatal("expected remote exposure without tokens to fail")
+	}
+}
+
+func TestResolvedManagementAPIRejectsWideBindWithoutRemoteExposure(t *testing.T) {
+	cfg := DefaultManagementAPIConfig()
+	_, err := cfg.ResolvedManagementAPI(ManagementAPIRuntimeOptions{
+		BindAddress: "0.0.0.0",
+	})
+	if err == nil {
+		t.Fatal("expected wide bind without remote_exposure to fail")
+	}
+}
+
+func TestResolvedManagementAPIAllowsWideBindForInternalListener(t *testing.T) {
+	t.Setenv(ManagementInternalListenerEnv, "true")
+	cfg := DefaultManagementAPIConfig()
+	resolved, err := cfg.ResolvedManagementAPI(ManagementAPIRuntimeOptions{
+		BindAddress: "0.0.0.0",
+	})
+	if err != nil {
+		t.Fatalf("ResolvedManagementAPI() error = %v", err)
+	}
+	if resolved.BindAddress != "0.0.0.0" {
+		t.Fatalf("bind_address = %q, want 0.0.0.0", resolved.BindAddress)
+	}
+}
+
+func TestResolvedManagementAPIAppliesCLIOverrides(t *testing.T) {
+	cfg := DefaultManagementAPIConfig()
+	remote := true
+	_, err := cfg.ResolvedManagementAPI(ManagementAPIRuntimeOptions{
+		Port:           9090,
+		BindAddress:    "0.0.0.0",
+		RemoteExposure: &remote,
+		AuthMode:       ManagementAuthModeBearer,
+	})
+	if err == nil {
+		t.Fatal("expected validation error without configured tokens")
+	}
+
+	t.Setenv(ManagementInternalListenerEnv, "true")
+	resolved, err := cfg.ResolvedManagementAPI(ManagementAPIRuntimeOptions{
+		Port:        9090,
+		BindAddress: "0.0.0.0",
+		AuthMode:    ManagementAuthModeDisabled,
+	})
+	if err != nil {
+		t.Fatalf("ResolvedManagementAPI() error = %v", err)
+	}
+	if resolved.Port != 9090 {
+		t.Fatalf("port = %d, want 9090", resolved.Port)
+	}
+	if resolved.BindAddress != "0.0.0.0" {
+		t.Fatalf("bind_address = %q, want 0.0.0.0", resolved.BindAddress)
+	}
+	if resolved.ListenAddress() != "0.0.0.0:9090" {
+		t.Fatalf("listen address = %q", resolved.ListenAddress())
+	}
+}

--- a/src/semantic-router/pkg/config/reference_config_global_test.go
+++ b/src/semantic-router/pkg/config/reference_config_global_test.go
@@ -46,7 +46,19 @@ func assertReferenceConfigServiceGlobalCoverage(t testingT, services map[string]
 	assertReferenceConfigObservabilityCoverage(t, mustMapAt(t, services, "observability"))
 	assertReferenceConfigAuthzCoverage(t, mustMapAt(t, services, "authz"))
 	assertReferenceConfigRateLimitCoverage(t, mustMapAt(t, services, "ratelimit"))
+	assertReferenceConfigManagementAPICoverage(t, mustMapAt(t, services, "management_api"))
 	assertReferenceConfigRouterReplayCoverage(t, mustMapAt(t, services, "router_replay"))
+}
+
+func assertReferenceConfigManagementAPICoverage(t testingT, managementAPI map[string]interface{}) {
+	assertMapCoversStructFields(t, managementAPI, reflect.TypeOf(ManagementAPIConfig{}), "global.services.management_api")
+	assertMapCoversStructFields(t, mustMapAt(t, managementAPI, "auth"), reflect.TypeOf(ManagementAPIAuthConfig{}), "global.services.management_api.auth")
+	assertSliceUnionCoversStructFields(
+		t,
+		mustSliceAt(t, managementAPI, "auth", "tokens"),
+		reflect.TypeOf(ManagementAPITokenRef{}),
+		"global.services.management_api.auth.tokens",
+	)
 }
 
 func assertReferenceConfigAPIServiceCoverage(t testingT, api map[string]interface{}) {

--- a/src/vllm-sr/start-router.sh
+++ b/src/vllm-sr/start-router.sh
@@ -8,6 +8,10 @@ CONFIG_FILE="${1:-/app/config.yaml}"
 echo "Starting router from canonical config..."
 echo "  Config file: $CONFIG_FILE"
 
+# Container-local management listener: bind all interfaces for docker-network
+# peers (dashboard/envoy). Host publish remains a separate Phase 4 concern.
+export VLLM_SR_MANAGEMENT_INTERNAL_LISTENER=true
+
 # Preserve setup-mode behavior from the historical single-container entrypoint.
 if python3 -c "
 import sys, yaml
@@ -28,4 +32,5 @@ exec /usr/local/bin/router \
     -config="$CONFIG_FILE" \
     -port=50051 \
     -enable-api=true \
-    -api-port=8080
+    -api-port=8080 \
+    -api-bind=0.0.0.0


### PR DESCRIPTION
## Summary

closes #2463 (Phase 1 only — does **not** fully close the issue yet).

The router management API (`:8080`) previously registered ~55 routes with no authentication and listened on all interfaces. This PR adds a deny-by-default auth boundary while keeping local/dev behavior unchanged.

### What changed

| Area | Change |
|------|--------|
| Route inventory | Every management route declares `Permission`, `Sensitivity`, and optional `AuditAction` via `managedRoute()` in `routes_catalog.go` |
| Auth | Bearer auth with `viewer` / `operator` / `admin` roles; `/health` stays anonymous; `auth.mode: disabled` allows all (local default) |
| Middleware | `wrapRouteHandler` gates each bound handler and sets `X-Request-Id` |
| Config | `global.services.management_api` schema (bind, port, remote exposure, tokens/roles) |
| Bind policy | Default bind `127.0.0.1:8080`; wide bind requires `remote_exposure` or `VLLM_SR_MANAGEMENT_INTERNAL_LISTENER=true` |
| CLI | `--api-bind`, `--management-auth-mode`, `--management-remote-exposure` |
| Container | `start-router.sh` enables internal listener + `-api-bind=0.0.0.0` for docker-network peers |

### Default (backward compatible)

```yaml
global:
  services:
    management_api:
      enabled: true
      bind_address: 127.0.0.1
      port: 8080
      remote_exposure: false
      auth:
        mode: disabled