### PR TITLE
[CI/Build] Fix Mergify in-place checks compatibility

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,10 +3,14 @@ queue_rules:
   - name: default
     queue_conditions:
       - base = main
-    merge_conditions: []
+    merge_conditions:
+      - base = main
     merge_method: squash
     update_method: merge
     batch_size: 1
+
+merge_queue:
+  max_parallel_checks: 1
 
 pull_request_rules:
   - name: queue approved pull requests


### PR DESCRIPTION
Closes #2564

## Purpose

Make the Mergify merge queue compatible with the GitHub branch protection
`Require branches to be up to date before merging`. With that protection on,
approved PRs must contain the latest `main` before merge, but the queue was
not updating them in place.

## Root cause

`max_parallel_checks` defaults to `5` (changed by Mergify on 2025-06-02). With
a value greater than `1` the queue runs speculative checks on temporary draft
PRs and never updates the real PR branch, which is incompatible with the
up-to-date protection.

## Changes

- Set `merge_queue.max_parallel_checks: 1` — this is the actual fix. It switches
  the queue to in-place checks, so Mergify merges the latest `main` into the
  real PR branch, reruns CI, and continues the queue.
- Set `merge_conditions` identical to `queue_conditions` to make the single-step
  (no two-step merge gate) intent explicit. Behaviorally equivalent to the prior
  empty `merge_conditions: []`, which already qualified as single-step.
- `batch_size: 1` and `update_method: merge` are preserved, so contributor
  branches are updated by merge (not force-pushed).

## Validation

- YAML parsing passed.
- Asserted `merge_queue.max_parallel_checks == 1`, `merge_conditions == queue_conditions`, `batch_size == 1`.
- `git diff --check` passed.
