### PR TITLE
[Router] cache: fix Redis addon example to compile against current interface

### DIFF
--- a/deploy/addons/redis/redis-cache.go
+++ b/deploy/addons/redis/redis-cache.go
@@ -3,70 +3,69 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
-func main() {
-	// Example: Setting up Redis cache backend
-	fmt.Println("Redis Cache Backend Example")
-	fmt.Println("===========================")
-
-	// Initialize the embedding model
-	fmt.Println("\n0. Initializing embedding model...")
-	err := candle_binding.InitModel("sentence-transformers/all-MiniLM-L6-v2", true)
-	if err != nil {
-		log.Fatalf("Failed to initialize embedding model: %v", err)
+func newRedisConfig() *config.RedisConfig {
+	host := os.Getenv("REDIS_HOST")
+	if host == "" {
+		host = "localhost"
 	}
-	fmt.Println("✓ Embedding model initialized")
-
-	// Configuration for Redis cache
-	config := cache.CacheConfig{
-		BackendType:         cache.RedisCacheType,
-		Enabled:             true,
-		SimilarityThreshold: 0.85,
-		TTLSeconds:          3600, // Entries expire after 1 hour
-		BackendConfigPath:   "../../examples/runtime/semantic-cache/redis.yaml",
+	port := 6379
+	if portEnv := os.Getenv("REDIS_PORT"); portEnv != "" {
+		fmt.Sscanf(portEnv, "%d", &port)
 	}
 
-	// Create cache backend
-	fmt.Println("\n1. Creating Redis cache backend...")
-	cacheBackend, err := cache.NewCacheBackend(config)
-	if err != nil {
-		log.Fatalf("Failed to create cache backend: %v", err)
-	}
-	defer cacheBackend.Close()
+	cfg := &config.RedisConfig{}
+	cfg.Connection.Host = host
+	cfg.Connection.Port = port
+	cfg.Connection.Timeout = 5 // seconds
+	cfg.Connection.TLS.Enabled = false
 
-	fmt.Println("✓ Redis cache backend created successfully")
+	cfg.Index.Name = "semantic_cache_idx"
+	cfg.Index.Prefix = "doc:"
+	cfg.Index.VectorField.Name = "embedding"
+	cfg.Index.VectorField.Dimension = 384
+	cfg.Index.VectorField.MetricType = "COSINE"
+	cfg.Index.IndexType = "HNSW"
+	cfg.Index.Params.M = 16
+	cfg.Index.Params.EfConstruction = 64
 
-	// Example cache operations
+	cfg.Search.TopK = 5
+	cfg.Development.DropIndexOnStartup = false
+	cfg.Development.AutoCreateIndex = true
+
+	return cfg
+}
+
+func demoCacheOperations(cacheBackend cache.CacheBackend) {
 	model := "gpt-4"
 	query := "What is the capital of France?"
 	requestID := "req-12345"
 	requestBody := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"What is the capital of France?"}]}`)
 	responseBody := []byte(`{"choices":[{"message":{"content":"The capital of France is Paris."}}]}`)
 
-	// Add entry to cache
 	fmt.Println("\n2. Adding entry to cache...")
-	err = cacheBackend.AddEntry(requestID, model, query, requestBody, responseBody)
+	err := cacheBackend.AddEntry(requestID, model, query, requestBody, responseBody, 3600)
 	if err != nil {
 		log.Fatalf("Failed to add entry: %v", err)
 	}
 	fmt.Println("✓ Entry added to cache")
 
-	// Wait a moment for Redis to index the entry
-	time.Sleep(100 * time.Millisecond)
+	fmt.Println("   Waiting for Redis to index the entry...")
+	time.Sleep(1 * time.Second)
 
-	// Search for similar entry
 	fmt.Println("\n3. Searching for similar query...")
 	similarQuery := "What's the capital city of France?"
 	cachedResponse, found, err := cacheBackend.FindSimilar(model, similarQuery)
 	if err != nil {
 		log.Fatalf("Failed to search cache: %v", err)
 	}
-
 	if found {
 		fmt.Println("✓ Cache HIT! Found similar query")
 		fmt.Printf("  Cached response: %s\n", string(cachedResponse))
@@ -74,7 +73,6 @@ func main() {
 		fmt.Println("✗ Cache MISS - no similar query found")
 	}
 
-	// Get cache statistics
 	fmt.Println("\n4. Cache Statistics:")
 	stats := cacheBackend.GetStats()
 	fmt.Printf("  Total Entries: %d\n", stats.TotalEntries)
@@ -82,64 +80,101 @@ func main() {
 	fmt.Printf("  Misses: %d\n", stats.MissCount)
 	fmt.Printf("  Hit Ratio: %.2f%%\n", stats.HitRatio*100)
 
-	// Example with custom threshold
 	fmt.Println("\n5. Searching with custom threshold...")
 	strictQuery := "Paris is the capital of which country?"
 	cachedResponse, found, err = cacheBackend.FindSimilarWithThreshold(model, strictQuery, 0.75)
 	if err != nil {
 		log.Fatalf("Failed to search cache: %v", err)
 	}
-
 	if found {
 		fmt.Println("✓ Cache HIT with threshold 0.75")
 		fmt.Printf("  Cached response: %s\n", string(cachedResponse))
 	} else {
 		fmt.Println("✗ Cache MISS with threshold 0.75")
 	}
+}
 
-	// Example: Pending request workflow
+func demoPendingRequestWorkflow(cacheBackend cache.CacheBackend) {
+	model := "gpt-4"
 	fmt.Println("\n6. Pending Request Workflow:")
 	newRequestID := "req-67890"
 	newQuery := "What is machine learning?"
 	newRequestBody := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"What is machine learning?"}]}`)
 
 	fmt.Println("  Adding pending request...")
-	err = cacheBackend.AddPendingRequest(newRequestID, model, newQuery, newRequestBody)
+	err := cacheBackend.AddPendingRequest(newRequestID, model, newQuery, newRequestBody, 3600)
 	if err != nil {
 		log.Fatalf("Failed to add pending request: %v", err)
 	}
 	fmt.Println("  ✓ Pending request added")
 
-	// Wait a moment for Redis to index the entry
-	time.Sleep(100 * time.Millisecond)
+	fmt.Println("   Waiting for Redis to index the pending request...")
+	time.Sleep(1 * time.Second)
 
-	// Simulate getting response from LLM
 	newResponseBody := []byte(`{"choices":[{"message":{"content":"Machine learning is a subset of AI..."}}]}`)
-
 	fmt.Println("  Updating with response...")
-	err = cacheBackend.UpdateWithResponse(newRequestID, newResponseBody)
+	err = cacheBackend.UpdateWithResponse(newRequestID, newResponseBody, 3600)
 	if err != nil {
 		log.Fatalf("Failed to update response: %v", err)
 	}
 	fmt.Println("  ✓ Response updated")
 
-	// Verify the entry is now cached
-	cachedResponse, found, err = cacheBackend.FindSimilar(model, newQuery)
+	time.Sleep(500 * time.Millisecond)
+
+	_, found, err := cacheBackend.FindSimilar(model, newQuery)
 	if err != nil {
 		log.Fatalf("Failed to search cache: %v", err)
 	}
-
 	if found {
 		fmt.Println("  ✓ Entry is now in cache and searchable")
+	} else {
+		fmt.Println("  ⚠ Entry not yet searchable (may need more indexing time)")
 	}
+}
 
-	// Final statistics
+func printFinalStats(cacheBackend cache.CacheBackend) {
 	fmt.Println("\n7. Final Statistics:")
-	stats = cacheBackend.GetStats()
+	stats := cacheBackend.GetStats()
 	fmt.Printf("  Total Entries: %d\n", stats.TotalEntries)
 	fmt.Printf("  Hits: %d\n", stats.HitCount)
 	fmt.Printf("  Misses: %d\n", stats.MissCount)
 	fmt.Printf("  Hit Ratio: %.2f%%\n", stats.HitRatio*100)
-
 	fmt.Println("\n✓ Example completed successfully!")
+}
+
+func main() {
+	fmt.Println("Redis Cache Backend Example")
+	fmt.Println("===========================")
+
+	fmt.Println("\n0. Initializing embedding model...")
+	err := candle_binding.InitModel("sentence-transformers/all-MiniLM-L6-v2", true)
+	if err != nil {
+		log.Fatalf("Failed to initialize embedding model: %v", err)
+	}
+	fmt.Println("✓ Embedding model initialized")
+
+	cacheConfig := cache.CacheConfig{
+		BackendType:         cache.RedisCacheType,
+		Enabled:             true,
+		SimilarityThreshold: 0.85,
+		TTLSeconds:          3600, // Entries expire after 1 hour
+		Redis:               newRedisConfig(),
+	}
+
+	fmt.Println("\n1. Creating Redis cache backend...")
+	cacheBackend, err := cache.NewCacheBackend(cacheConfig)
+	if err != nil {
+		log.Fatalf("Failed to create cache backend: %v", err)
+	}
+	defer func() { _ = cacheBackend.Close() }()
+	fmt.Println("✓ Redis cache backend created successfully")
+
+	initialStats := cacheBackend.GetStats()
+	if initialStats.TotalEntries > 0 {
+		fmt.Printf("⚠ Found %d existing entries in cache (from previous runs)\n", initialStats.TotalEntries)
+	}
+
+	demoCacheOperations(cacheBackend)
+	demoPendingRequestWorkflow(cacheBackend)
+	printFinalStats(cacheBackend)
 }


### PR DESCRIPTION
Closes #2566

## What

The Redis cache addon example (`deploy/addons/redis/redis-cache.go`) no longer compiled against `main`:

- it set the removed `BackendConfigPath` field on `cache.CacheConfig` (dropped in the config refactor) — `unknown field BackendConfigPath in struct literal of type cache.CacheConfig`;
- the write calls (`AddEntry` / `AddPendingRequest` / `UpdateWithResponse`) omitted the `ttlSeconds` argument the `CacheBackend` interface now requires.

Nothing in CI builds this file (`test-and-build` skips it; it is only reachable via `make run-redis-example`, which needs a live Redis + Rust bindings), so the breakage went unnoticed.

## How

Mirror the already-migrated Valkey example:

- build a programmatic `*config.RedisConfig` in `newRedisConfig()` (from `REDIS_HOST` / `REDIS_PORT`, defaulting to `localhost:6379`) and pass it via the `Redis` field instead of `BackendConfigPath`;
- pass `ttlSeconds` (3600) on every write call;
- keep the example's existing `FindSimilar` / `FindSimilarWithThreshold` `(body, found, err)` usage, which is unchanged on `main`.

Pure example fix — no production code or interface change. Scope limited to the one file.

## Test Plan

- Confirmed the pre-fix file fails to build: `go vet ../../deploy/addons/redis/redis-cache.go` → `unknown field BackendConfigPath in struct literal of type cache.CacheConfig`.
- Post-fix `go vet` on the file — clean.
- `gofmt -l` on the file — clean.
- End-to-end: ran `go run deploy/addons/redis/redis-cache.go` against a live `redis/redis-stack` (RediSearch/HNSW). Completes with exit 0 — `AddEntry` → Cache HIT on a paraphrased query, custom-threshold (0.75) HIT, and the `AddPendingRequest` → `UpdateWithResponse` workflow all succeed.
