### PR TITLE
[Router] validate periodic ticker intervals and make storage close concurrency-safe

### DIFF
--- a/src/semantic-router/pkg/config/periodic_interval.go
+++ b/src/semantic-router/pkg/config/periodic_interval.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MaxPeriodicInterval bounds every ticker-driving interval accepted by the
+// router (Elo/RL auto-save flushes and lookup-table auto-save/replay-populate
+// cadence). Anything larger is almost certainly a misconfiguration: it would
+// make periodic work effectively never run and risks duration overflow. This
+// is the documented maximum referenced by the router configuration contract.
+const MaxPeriodicInterval = 24 * time.Hour
+
+// ParsePeriodicInterval parses a periodic interval string such as "30s" or
+// "5m" into a time.Duration suitable for driving a time.Ticker.
+//
+// An empty (or whitespace-only) value yields def with no error, letting
+// callers keep their documented default. A non-empty value must parse and be
+// strictly positive and no greater than MaxPeriodicInterval; otherwise a
+// descriptive error is returned (with the offending value quoted) so callers
+// can reject the configuration or fall back to a safe default. Because
+// time.NewTicker panics on a non-positive duration, callers must never pass a
+// value that failed this check to a ticker.
+func ParsePeriodicInterval(value string, def time.Duration) (time.Duration, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return def, nil
+	}
+
+	d, err := time.ParseDuration(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", value, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("duration must be positive, got %q", value)
+	}
+	if d > MaxPeriodicInterval {
+		return 0, fmt.Errorf("duration %q exceeds maximum %s", value, MaxPeriodicInterval)
+	}
+	return d, nil
+}

--- a/src/semantic-router/pkg/config/periodic_interval_test.go
+++ b/src/semantic-router/pkg/config/periodic_interval_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParsePeriodicInterval(t *testing.T) {
+	const def = 30 * time.Second
+
+	tests := []struct {
+		name     string
+		value    string
+		wantErr  bool
+		wantDur  time.Duration
+		useDefOK bool // when true, expect the default returned with no error
+	}{
+		{name: "empty uses default", value: "", useDefOK: true},
+		{name: "whitespace uses default", value: "   ", useDefOK: true},
+		{name: "valid seconds", value: "45s", wantDur: 45 * time.Second},
+		{name: "valid minutes", value: "5m", wantDur: 5 * time.Minute},
+		{name: "max boundary allowed", value: "24h", wantDur: MaxPeriodicInterval},
+		{name: "zero rejected", value: "0s", wantErr: true},
+		{name: "bare zero rejected", value: "0", wantErr: true},
+		{name: "negative rejected", value: "-5s", wantErr: true},
+		{name: "unparsable rejected", value: "banana", wantErr: true},
+		{name: "above max rejected", value: "48h", wantErr: true},
+		{name: "overflow rejected", value: "9999999999h", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePeriodicInterval(tt.value, def)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParsePeriodicInterval(%q) expected error, got nil (dur=%s)", tt.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePeriodicInterval(%q) unexpected error: %v", tt.value, err)
+			}
+			want := tt.wantDur
+			if tt.useDefOK {
+				want = def
+			}
+			if got != want {
+				t.Fatalf("ParsePeriodicInterval(%q) = %s, want %s", tt.value, got, want)
+			}
+		})
+	}
+}
+
+func TestParsePeriodicIntervalErrorMentionsField(t *testing.T) {
+	// The error must reference the offending value so callers can surface a
+	// field-addressed message.
+	_, err := ParsePeriodicInterval("-1s", time.Second)
+	if err == nil {
+		t.Fatal("expected error for negative duration")
+	}
+	if got := err.Error(); got == "" {
+		t.Fatal("error message must not be empty")
+	}
+}

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -544,7 +544,7 @@ func buildLookupTableStorage(ltCfg config.LookupTableConfig) (lookuptable.Lookup
 
 	cancel := func() { _ = fs.Close() }
 	if ltCfg.AutoSaveInterval != "" {
-		if interval, err := time.ParseDuration(ltCfg.AutoSaveInterval); err == nil {
+		if interval, err := config.ParsePeriodicInterval(ltCfg.AutoSaveInterval, 0); err == nil {
 			fs.StartAutoSave(interval)
 		} else {
 			logging.Warnf("[RouterSelection] Invalid lookup table auto_save_interval %q: %v", ltCfg.AutoSaveInterval, err)
@@ -569,7 +569,7 @@ func maybePopulateFromReplay(
 	if ltCfg.PopulateInterval == "" {
 		return
 	}
-	interval, err := time.ParseDuration(ltCfg.PopulateInterval)
+	interval, err := config.ParsePeriodicInterval(ltCfg.PopulateInterval, 0)
 	if err != nil {
 		logging.Warnf("[RouterSelection] Invalid lookup table populate_interval %q: %v", ltCfg.PopulateInterval, err)
 		return
@@ -617,10 +617,22 @@ func populateFromReplay(storage lookuptable.LookupTableStorage, reader store.Rea
 	})
 }
 
+// defaultPopulateInterval is the fallback cadence used when
+// startLookupTablePopulator is given a non-positive interval, so a
+// misconfigured value can neither panic time.NewTicker nor silently disable
+// periodic replay re-derivation.
+const defaultPopulateInterval = 15 * time.Minute
+
 // startLookupTablePopulator launches a background goroutine that periodically
 // re-derives lookup table entries from the replay store.
-// The returned cancel function stops the goroutine.
+// The returned cancel function stops the goroutine. A non-positive interval is
+// defensively replaced with defaultPopulateInterval (time.NewTicker panics on a
+// non-positive duration).
 func startLookupTablePopulator(storage lookuptable.LookupTableStorage, reader store.Reader, interval time.Duration) func() {
+	if interval <= 0 {
+		logging.Warnf("[RouterSelection] Non-positive lookup table populate interval %s; using default %s", interval, defaultPopulateInterval)
+		interval = defaultPopulateInterval
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	// goSafely so a panic in populateFromReplay (e.g. malformed
 	// replay-store entry) is logged instead of crashing the whole

--- a/src/semantic-router/pkg/selection/auto_save_interval.go
+++ b/src/semantic-router/pkg/selection/auto_save_interval.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// defaultAutoSaveInterval is the fallback cadence for Elo/RL rating persistence
+// used whenever a configured interval is missing or invalid, so a misconfigured
+// value can neither panic time.NewTicker nor silently disable periodic saves.
+const defaultAutoSaveInterval = 30 * time.Second
+
+// resolveAutoSaveInterval turns a raw auto_save_interval config string into a
+// safe, strictly-positive duration. It delegates validation to
+// config.ParsePeriodicInterval (positive and below the documented maximum) and
+// falls back to defaultAutoSaveInterval with a warning on any invalid value.
+func resolveAutoSaveInterval(raw string) time.Duration {
+	interval, err := config.ParsePeriodicInterval(raw, defaultAutoSaveInterval)
+	if err != nil {
+		logging.Warnf("[selection] invalid auto_save_interval %q: %v; using default %s", raw, err, defaultAutoSaveInterval)
+		return defaultAutoSaveInterval
+	}
+	return interval
+}

--- a/src/semantic-router/pkg/selection/auto_save_interval_test.go
+++ b/src/semantic-router/pkg/selection/auto_save_interval_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveAutoSaveInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "empty falls back to default", raw: "", want: defaultAutoSaveInterval},
+		{name: "valid value honored", raw: "45s", want: 45 * time.Second},
+		{name: "zero falls back to default", raw: "0s", want: defaultAutoSaveInterval},
+		{name: "negative falls back to default", raw: "-5s", want: defaultAutoSaveInterval},
+		{name: "malformed falls back to default", raw: "banana", want: defaultAutoSaveInterval},
+		{name: "above max falls back to default", raw: "48h", want: defaultAutoSaveInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveAutoSaveInterval(tt.raw)
+			if got != tt.want {
+				t.Fatalf("resolveAutoSaveInterval(%q) = %s, want %s", tt.raw, got, tt.want)
+			}
+			if got <= 0 {
+				t.Fatalf("resolveAutoSaveInterval(%q) returned non-positive %s", tt.raw, got)
+			}
+		})
+	}
+}

--- a/src/semantic-router/pkg/selection/elo.go
+++ b/src/semantic-router/pkg/selection/elo.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -145,14 +144,9 @@ func NewEloSelector(cfg *EloConfig) *EloSelector {
 				})
 			}
 
-			// Start auto-save with configurable interval
-			interval := 30 * time.Second
-			if cfg.AutoSaveInterval != "" {
-				if parsed, err := time.ParseDuration(cfg.AutoSaveInterval); err == nil {
-					interval = parsed
-				}
-			}
-
+			// Start auto-save with a validated interval (positive and below
+			// the documented maximum; falls back to the default otherwise).
+			interval := resolveAutoSaveInterval(cfg.AutoSaveInterval)
 			storage.StartAutoSave(interval, selector.getAllRatingsForStorage)
 			logging.ComponentEvent("selection", "elo_storage_initialized", map[string]interface{}{
 				"storage_path":            cfg.StoragePath,

--- a/src/semantic-router/pkg/selection/lookuptable/file.go
+++ b/src/semantic-router/pkg/selection/lookuptable/file.go
@@ -52,6 +52,7 @@ type FileStorage struct {
 
 	dirty           atomic.Bool
 	autoSaveStarted atomic.Bool
+	closeOnce       sync.Once
 	stopChan        chan struct{}
 	doneChan        chan struct{}
 }
@@ -154,12 +155,23 @@ func (f *FileStorage) MarkDirty() {
 	f.dirty.Store(true)
 }
 
+// defaultAutoSaveInterval is the fallback cadence used when StartAutoSave is
+// given a non-positive interval, so a misconfigured value can neither panic
+// time.NewTicker nor silently disable periodic persistence.
+const defaultAutoSaveInterval = 30 * time.Second
+
 // StartAutoSave launches a background goroutine that saves whenever the dirty
 // flag is set, on the given interval. Call Close() to stop it.
-// Subsequent calls after the first are no-ops.
+// Subsequent calls after the first are no-ops. A non-positive interval is
+// defensively replaced with defaultAutoSaveInterval (time.NewTicker panics on
+// a non-positive duration).
 func (f *FileStorage) StartAutoSave(interval time.Duration) {
 	if !f.autoSaveStarted.CompareAndSwap(false, true) {
 		return
+	}
+	if interval <= 0 {
+		logging.Warnf("[LookupTableStorage] Non-positive auto-save interval %s; using default %s", interval, defaultAutoSaveInterval)
+		interval = defaultAutoSaveInterval
 	}
 	go func() {
 		defer close(f.doneChan)
@@ -198,19 +210,17 @@ func (f *FileStorage) autoSaveTick() {
 }
 
 // Close stops the auto-save goroutine (if running) and releases resources.
+// It is idempotent and safe to call concurrently: the first call performs the
+// shutdown and subsequent calls are no-ops.
 func (f *FileStorage) Close() error {
-	select {
-	case <-f.stopChan:
-		// Already closed.
-		return nil
-	default:
+	f.closeOnce.Do(func() {
 		close(f.stopChan)
-	}
-	// Wait for the goroutine only if StartAutoSave was called.
-	if f.autoSaveStarted.Load() {
-		<-f.doneChan
-	}
-	logging.Infof("[LookupTableStorage] Closed file storage: %s", f.path)
+		// Wait for the goroutine only if StartAutoSave was called.
+		if f.autoSaveStarted.Load() {
+			<-f.doneChan
+		}
+		logging.Infof("[LookupTableStorage] Closed file storage: %s", f.path)
+	})
 	return nil
 }
 

--- a/src/semantic-router/pkg/selection/lookuptable/file_lifecycle_test.go
+++ b/src/semantic-router/pkg/selection/lookuptable/file_lifecycle_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lookuptable_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestFileStorage_Close_Idempotent verifies repeated sequential Close calls are
+// safe no-ops and never panic on a double channel close.
+func TestFileStorage_Close_Idempotent(t *testing.T) {
+	s, _ := newTempFileStorage(t)
+	s.StartAutoSave(50 * time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		if err := s.Close(); err != nil {
+			t.Fatalf("Close() call %d returned error: %v", i, err)
+		}
+	}
+}
+
+// TestFileStorage_Close_ConcurrentSafe verifies many goroutines closing the
+// same storage simultaneously never panic (regression for the unsafe
+// check-then-close pattern that double-closed stopChan).
+func TestFileStorage_Close_ConcurrentSafe(t *testing.T) {
+	s, _ := newTempFileStorage(t)
+	s.StartAutoSave(50 * time.Millisecond)
+
+	const closers = 64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(closers)
+	for i := 0; i < closers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start // barrier: maximise the race
+			_ = s.Close()
+		}()
+	}
+	close(start)
+	wg.Wait()
+}
+
+// TestFileStorage_StartAutoSave_NonPositiveInterval verifies a zero or
+// negative interval never reaches time.NewTicker (which panics on <= 0) and
+// so cannot crash the auto-save goroutine.
+func TestFileStorage_StartAutoSave_NonPositiveInterval(t *testing.T) {
+	for _, interval := range []time.Duration{0, -time.Second} {
+		s, _ := newTempFileStorage(t)
+		s.StartAutoSave(interval)         // must not panic in the goroutine
+		time.Sleep(20 * time.Millisecond) // give the goroutine a chance to run
+		if err := s.Close(); err != nil {
+			t.Fatalf("Close() after StartAutoSave(%s) returned error: %v", interval, err)
+		}
+	}
+}
+
+// TestFileStorage_Close_BeforeStartAutoSave verifies Close is safe when
+// StartAutoSave was never called (no goroutine to join).
+func TestFileStorage_Close_BeforeStartAutoSave(t *testing.T) {
+	s, _ := newTempFileStorage(t)
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close() without StartAutoSave returned error: %v", err)
+	}
+	// A second close must also be safe.
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close() returned error: %v", err)
+	}
+}

--- a/src/semantic-router/pkg/selection/rl_driven.go
+++ b/src/semantic-router/pkg/selection/rl_driven.go
@@ -377,14 +377,9 @@ func NewRLDrivenSelector(cfg *RLDrivenConfig) *RLDrivenSelector {
 				})
 			}
 
-			// Start auto-save
-			interval := 30 * time.Second
-			if cfg.AutoSaveInterval != "" {
-				if parsed, err := time.ParseDuration(cfg.AutoSaveInterval); err == nil {
-					interval = parsed
-				}
-			}
-
+			// Start auto-save with a validated interval (positive and below
+			// the documented maximum; falls back to the default otherwise).
+			interval := resolveAutoSaveInterval(cfg.AutoSaveInterval)
 			storage.StartAutoSave(interval, selector.getAllPreferencesForStorage)
 			logging.ComponentEvent("selection", "rl_driven_storage_initialized", map[string]interface{}{
 				"storage_path":            cfg.StoragePath,

--- a/src/semantic-router/pkg/selection/storage.go
+++ b/src/semantic-router/pkg/selection/storage.go
@@ -322,7 +322,9 @@ func (f *FileEloStorage) saveToFile(stored *StoredRatings) error {
 	return nil
 }
 
-// StartAutoSave starts a background goroutine that periodically saves dirty ratings
+// StartAutoSave starts a background goroutine that periodically saves dirty ratings.
+// A non-positive interval is defensively replaced with defaultAutoSaveInterval
+// (time.NewTicker panics on a non-positive duration).
 func (f *FileEloStorage) StartAutoSave(interval time.Duration, getAll func() map[string]map[string]*ModelRating) {
 	f.lifecycleMu.Lock()
 	if f.closed || f.autoSaveStarted {
@@ -331,6 +333,11 @@ func (f *FileEloStorage) StartAutoSave(interval time.Duration, getAll func() map
 	}
 	f.autoSaveStarted = true
 	f.lifecycleMu.Unlock()
+
+	if interval <= 0 {
+		logging.Warnf("[EloStorage] Non-positive auto-save interval %s; using default %s", interval, defaultAutoSaveInterval)
+		interval = defaultAutoSaveInterval
+	}
 
 	go func() {
 		defer close(f.doneChan)

--- a/src/semantic-router/pkg/selection/storage_lifecycle_test.go
+++ b/src/semantic-router/pkg/selection/storage_lifecycle_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func emptyRatingsSnapshot() map[string]map[string]*ModelRating {
+	return map[string]map[string]*ModelRating{}
+}
+
+// TestFileEloStorage_StartAutoSave_NonPositiveInterval verifies a zero or
+// negative interval never reaches time.NewTicker (which panics on <= 0) and so
+// cannot crash the auto-save goroutine.
+func TestFileEloStorage_StartAutoSave_NonPositiveInterval(t *testing.T) {
+	for _, interval := range []time.Duration{0, -time.Second} {
+		storagePath := filepath.Join(t.TempDir(), "ratings.json")
+		storage, err := NewFileEloStorage(storagePath)
+		if err != nil {
+			t.Fatalf("NewFileEloStorage: %v", err)
+		}
+		storage.StartAutoSave(interval, emptyRatingsSnapshot) // must not panic
+		time.Sleep(20 * time.Millisecond)                     // let the goroutine run
+		if err := storage.Close(); err != nil {
+			t.Fatalf("Close() after StartAutoSave(%s): %v", interval, err)
+		}
+	}
+}
+
+// TestFileEloStorage_Close_ConcurrentSafe is a regression test locking in the
+// sync.Once-based close: many goroutines closing simultaneously must not panic.
+func TestFileEloStorage_Close_ConcurrentSafe(t *testing.T) {
+	storagePath := filepath.Join(t.TempDir(), "ratings.json")
+	storage, err := NewFileEloStorage(storagePath)
+	if err != nil {
+		t.Fatalf("NewFileEloStorage: %v", err)
+	}
+	storage.StartAutoSave(50*time.Millisecond, emptyRatingsSnapshot)
+
+	const closers = 64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(closers)
+	for i := 0; i < closers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = storage.Close()
+		}()
+	}
+	close(start)
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Every periodic ticker interval in the router — Elo/RL rating auto-save, lookup-table auto-save, and lookup-table replay populate — is parsed from a config string and handed straight to `time.NewTicker`, which **panics on a non-positive duration**. A syntactically valid `"0s"` or `"-5s"` parses successfully and reaches the ticker, crashing the auto-save goroutine (and with it the whole process), or — for the replay populator wrapped in `goSafely` — being silently swallowed so periodic re-derivation never runs. Separately, the lookup-table `FileStorage.Close()` used an unsafe check-then-close on its stop channel, so concurrent `Close()` calls double-closed the channel and panicked.

This PR validates every ticker-driving duration before construction and makes the storage start/close lifecycle idempotent and concurrency-safe.

Closes #2475.

## Changes

- **`pkg/config/periodic_interval.go` (new):** `ParsePeriodicInterval(value, def)` + `MaxPeriodicInterval` (24h) — one shared rule: empty → default; reject unparseable, non-positive, or above the documented maximum.
- **`pkg/selection/lookuptable/file.go`:** `Close()` now uses `sync.Once` (idempotent + concurrency-safe, matching `FileEloStorage`); `StartAutoSave` defensively clamps a non-positive interval to a 30s default.
- **`pkg/selection/auto_save_interval.go` (new) + `elo.go` / `rl_driven.go`:** both selectors route `auto_save_interval` through a shared `resolveAutoSaveInterval` helper (validate + warn + fall back) instead of trusting any value that parses.
- **`pkg/selection/storage.go`:** `FileEloStorage.StartAutoSave` defensively clamps a non-positive interval.
- **`pkg/extproc/router_selection.go`:** `buildLookupTableStorage` and `maybePopulateFromReplay` validate intervals via `ParsePeriodicInterval`; `startLookupTablePopulator` defensively clamps a non-positive interval.

### Scope note (Public API boundary)

The Elo / RL-driven / lookup-table interval fields are already hard-rejected as public config on `main` (they are `yaml:"-"` and rejected in `validateModelSelectionConfig` / `validateMigratedLearningAlgorithm`). Per the issue's boundary note, this PR does **not** re-introduce those names as supported configuration in `validator_learning.go`; the migration boundary is owned by #2242. The fix here is defensive: constructor-level validation so a bad duration can never panic or silently disable periodic work, regardless of how it reaches the runtime.

## Test Plan

- **Table tests** (`ParsePeriodicInterval`): empty, valid, zero, bare `0`, negative, malformed, overflow, above-max, and the `24h` max boundary.
- **Lifecycle `-race` tests:** repeated sequential `Close()`, 64-goroutine concurrent `Close()`, `Close()` before `StartAutoSave`, and non-positive-interval `StartAutoSave` (for both `FileStorage` and `FileEloStorage`).
- **Resolver tests:** `resolveAutoSaveInterval` falls back to the default on empty/zero/negative/malformed/above-max and honors valid values.
- Gate: `cd src/semantic-router && go test -race ./pkg/config ./pkg/selection ./pkg/selection/lookuptable ./pkg/extproc` — all green.
- Lint: `golangci-lint --new-from-rev=origin/main` — 0 new issues.
