### PR TITLE
[Docs] Document looper max_response_bytes_mb knob

### DIFF
--- a/website/docs/tutorials/algorithm/looper/fusion.md
+++ b/website/docs/tutorials/algorithm/looper/fusion.md
@@ -142,6 +142,7 @@ global:
   integrations:
     looper:
       endpoint: http://localhost:8899/v1/chat/completions
+      max_response_bytes_mb: 32 # optional; caps a single upstream response body (default 32 MiB)
       fusion:
         model_names:
           - vllm-sr/fusion

--- a/website/docs/tutorials/algorithm/looper/remom.md
+++ b/website/docs/tutorials/algorithm/looper/remom.md
@@ -92,6 +92,7 @@ global:
   integrations:
     looper:
       endpoint: http://localhost:8899/v1/chat/completions
+      max_response_bytes_mb: 32 # optional; caps a single upstream response body (default 32 MiB)
       remom:
         model_names:
           - vllm-sr/remom

--- a/website/docs/tutorials/algorithm/looper/workflows.md
+++ b/website/docs/tutorials/algorithm/looper/workflows.md
@@ -47,6 +47,7 @@ global:
   integrations:
     looper:
       endpoint: http://localhost:8899/v1/chat/completions
+      max_response_bytes_mb: 32 # optional; caps a single upstream response body (default 32 MiB)
       flow:
         model_names:
           - vllm-sr/flow


### PR DESCRIPTION
Closes #2588

## Summary

Document the optional `max_response_bytes_mb` looper knob (added in #2580) in the ReMoM, Fusion, and Workflows tutorials, next to the `global.integrations.looper` example.

## Why

The knob was only discoverable in the reference `config/config.yaml`; the tutorials didn't mention it. Thanks @AayushSaini101 for flagging this on #2580 🙏

## Test Plan

- Docs-only, 3-line change. `MD013` (line length) is disabled in the repo markdownlint config, so the inline comment is fine.
- Netlify deploy preview renders the updated tutorial pages.
