### PR TITLE
[Router] Populate looper streaming token usage

### DIFF
--- a/src/semantic-router/pkg/looper/client.go
+++ b/src/semantic-router/pkg/looper/client.go
@@ -288,16 +288,18 @@ func (c *Client) parseStreamingResponse(body []byte, modelName string) (*ModelRe
 		IsStreaming: true,
 	}
 
-	// Parse SSE chunks to extract content
+	// Parse SSE chunks to extract content and usage
 	content, chunks := parseSSEContent(body)
 	result.Content = content
 	result.StreamingChunks = chunks
+	result.Usage = parseStreamingUsage(body)
 
 	logging.ComponentDebugEvent("looper", "model_call_completed", map[string]interface{}{
-		"decision":    c.decisionName,
-		"model_ref":   modelName,
-		"content_len": len(content),
-		"streaming":   true,
+		"decision":     c.decisionName,
+		"model_ref":    modelName,
+		"content_len":  len(content),
+		"total_tokens": result.Usage.TotalTokens,
+		"streaming":    true,
 	})
 
 	return result, nil
@@ -652,7 +654,16 @@ func setStreamParam(body []byte, streaming bool) ([]byte, error) {
 		return nil, err
 	}
 	reqMap["stream"] = streaming
-	if !streaming {
+	if streaming {
+		// Ask the backend to emit a trailing usage chunk so token accounting
+		// works for streamed calls; preserve any caller-set stream_options.
+		opts, _ := reqMap["stream_options"].(map[string]interface{})
+		if opts == nil {
+			opts = map[string]interface{}{}
+		}
+		opts["include_usage"] = true
+		reqMap["stream_options"] = opts
+	} else {
 		delete(reqMap, "stream_options")
 	}
 	return json.Marshal(reqMap)

--- a/src/semantic-router/pkg/looper/client_streaming_usage.go
+++ b/src/semantic-router/pkg/looper/client_streaming_usage.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// parseStreamingUsage extracts token usage from an SSE stream. OpenAI-compatible
+// backends report usage in a trailing chunk (only when the request set
+// stream_options.include_usage), so the last non-null usage block wins. Returns
+// zero usage when none is present.
+func parseStreamingUsage(body []byte) TokenUsage {
+	var usage TokenUsage
+	for _, line := range bytes.Split(body, []byte("\n")) {
+		lineStr := string(line)
+		if len(lineStr) <= 6 || lineStr[:6] != "data: " {
+			continue
+		}
+		data := lineStr[6:]
+		if data == "[DONE]" {
+			continue
+		}
+
+		var chunk struct {
+			Usage *TokenUsage `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+		if chunk.Usage != nil {
+			usage = *chunk.Usage
+		}
+	}
+	return usage
+}

--- a/src/semantic-router/pkg/looper/client_streaming_usage_test.go
+++ b/src/semantic-router/pkg/looper/client_streaming_usage_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Streaming responses carry token counts in a final SSE chunk (emitted only
+// when the request sets stream_options.include_usage). The looper client must
+// both request and parse it, or streamed calls report {0,0,0}.
+
+func TestParseStreamingUsage_ExtractsFinalUsageChunk(t *testing.T) {
+	body := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n" +
+		"data: {\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":8,\"total_tokens\":20}}\n" +
+		"data: [DONE]\n"
+
+	got := parseStreamingUsage([]byte(body))
+
+	want := TokenUsage{PromptTokens: 12, CompletionTokens: 8, TotalTokens: 20}
+	if got != want {
+		t.Errorf("parseStreamingUsage() = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseStreamingUsage_NoUsageChunkReturnsZero(t *testing.T) {
+	body := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n" +
+		"data: [DONE]\n"
+
+	if got := parseStreamingUsage([]byte(body)); got != (TokenUsage{}) {
+		t.Errorf("parseStreamingUsage() = %+v, want zero", got)
+	}
+}
+
+func TestParseStreamingUsage_IgnoresNullUsageChunks(t *testing.T) {
+	body := "data: {\"usage\":null,\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n" +
+		"data: {\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3,\"total_tokens\":8}}\n" +
+		"data: [DONE]\n"
+
+	if got := parseStreamingUsage([]byte(body)); got.TotalTokens != 8 {
+		t.Errorf("TotalTokens = %d, want 8", got.TotalTokens)
+	}
+}
+
+func TestParseStreamingResponse_PopulatesUsage(t *testing.T) {
+	c := &Client{}
+	body := []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n" +
+		"data: {\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":8,\"total_tokens\":20}}\n" +
+		"data: [DONE]\n")
+
+	resp, err := c.parseStreamingResponse(body, "model-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Usage.TotalTokens != 20 {
+		t.Errorf("resp.Usage = %+v, want total 20", resp.Usage)
+	}
+}
+
+func TestSetStreamParam_StreamingRequestsIncludeUsage(t *testing.T) {
+	out, err := setStreamParam([]byte(`{"model":"x"}`), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	so, ok := m["stream_options"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stream_options missing: %s", out)
+	}
+	if so["include_usage"] != true {
+		t.Errorf("include_usage = %v, want true", so["include_usage"])
+	}
+}
+
+func TestSetStreamParam_NonStreamingDropsStreamOptions(t *testing.T) {
+	out, err := setStreamParam([]byte(`{"model":"x","stream_options":{"include_usage":true}}`), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["stream_options"]; ok {
+		t.Errorf("stream_options should be dropped when not streaming: %s", out)
+	}
+}


### PR DESCRIPTION
Closes #2592

## Summary

Streaming looper calls reported `{0,0,0}` token usage. Two compounding causes: the client never set `stream_options.include_usage` (so vLLM omitted the usage chunk), and the SSE parser ignored it anyway. This sets `include_usage` on streaming requests and parses the trailing usage chunk into `ModelResponse.Usage`.

## Why

Non-streaming already records usage; streaming — the common case for UIs — reported zero, so token/cost accounting was wrong for every streamed Looper request. Part of #2336 (latency & token accounting).

## Test Plan

- `go test ./pkg/looper/` green; `-race` clean on the new tests.
- New tests: `parseStreamingUsage` (usage present / absent / null-ignored), `parseStreamingResponse` populates `Usage`, `setStreamParam` sets `include_usage` when streaming and still drops `stream_options` when not.
