### PR TITLE
[Benchmark] Add Fleet-Sim workload forecast backtests

### DIFF
--- a/src/fleet-sim/README.md
+++ b/src/fleet-sim/README.md
@@ -42,6 +42,11 @@ vllm-sr-sim mixture-optimize \
   --lam 200 --slo 500 --b-short 6144 \
   --max-total-gpus 300 --out mixture-report.json
 
+vllm-sr-sim forecast-backtest \
+  --scenario data/workload_forecast_seasonal.json \
+  --slo 500 --b-short 6144 --gamma-max 1.2 \
+  --out forecast-report.json
+
 vllm-sr-sim whatif \
   --cdf data/azure_cdf.json \
   --lam-range 50 100 200 500 1000 \
@@ -55,6 +60,13 @@ vllm-sr-sim serve --host 0.0.0.0 --port 8000
 It reports aggregate-CDF, individual-archetype, nominal-mixture, drift/burst
 window, robust worst-case, sensitivity, and infeasibility diagnostics without
 changing production request-path routing.
+
+`forecast-backtest` evaluates proactive workload-archetype forecasts from
+content-free aggregate windows. It compares static, reactive last-window,
+moving-window, seasonal-naive, and linear-trend baselines, converts each
+forecast back into reproducible FleetSim mixture scenarios, reports uncertainty,
+burst/drift/oscillation diagnostics, and keeps advise-only recommendations
+separate from downstream actuation records.
 
 `vllm-sr serve` also starts `vllm-sr-sim` by default as a sibling container on the shared runtime network so the dashboard can proxy it without rebuilding the router image.
 

--- a/src/fleet-sim/README.md
+++ b/src/fleet-sim/README.md
@@ -37,6 +37,11 @@ vllm-sr-sim optimize \
   --lam 200 --slo 500 --b-short 6144 \
   --verify-top 3 --n-sim-req 30000
 
+vllm-sr-sim mixture-optimize \
+  --scenario data/workload_mixture_burst.json \
+  --lam 200 --slo 500 --b-short 6144 \
+  --max-total-gpus 300 --out mixture-report.json
+
 vllm-sr-sim whatif \
   --cdf data/azure_cdf.json \
   --lam-range 50 100 200 500 1000 \
@@ -44,6 +49,12 @@ vllm-sr-sim whatif \
 
 vllm-sr-sim serve --host 0.0.0.0 --port 8000
 ```
+
+`mixture-optimize` keeps the analytical method on the repository's
+`FleetOptimizer` class while evaluating versioned workload-archetype scenarios.
+It reports aggregate-CDF, individual-archetype, nominal-mixture, drift/burst
+window, robust worst-case, sensitivity, and infeasibility diagnostics without
+changing production request-path routing.
 
 `vllm-sr serve` also starts `vllm-sr-sim` by default as a sibling container on the shared runtime network so the dashboard can proxy it without rebuilding the router image.
 

--- a/src/fleet-sim/README.md
+++ b/src/fleet-sim/README.md
@@ -64,9 +64,11 @@ changing production request-path routing.
 `forecast-backtest` evaluates proactive workload-archetype forecasts from
 content-free aggregate windows. It compares static, reactive last-window,
 moving-window, seasonal-naive, and linear-trend baselines, converts each
-forecast back into reproducible FleetSim mixture scenarios, reports uncertainty,
-burst/drift/oscillation diagnostics, and keeps advise-only recommendations
-separate from downstream actuation records.
+forecast back into reproducible FleetSim mixture scenarios, scales each
+composition window's token CDF from aggregate mean/p50/p95 token demand,
+reports token/latency calibration error, uncertainty, burst/drift/oscillation
+diagnostics, and keeps advise-only recommendations separate from downstream
+actuation records.
 
 `vllm-sr serve` also starts `vllm-sr-sim` by default as a sibling container on the shared runtime network so the dashboard can proxy it without rebuilding the router image.
 

--- a/src/fleet-sim/data/README.md
+++ b/src/fleet-sim/data/README.md
@@ -41,6 +41,35 @@ aggregate-CDF baselines, individual archetype stress cases, nominal mixtures,
 composition drift/burst windows, robust recommendations, sensitivity, and
 explicit infeasibility diagnostics.
 
+## Workload archetype forecast aggregates
+
+Forecast aggregate fixtures use schema
+`fleet-sim.workload-archetype-forecast/v1alpha1` and taxonomy
+`fleet-sim.workload-archetype-taxonomy/v1alpha1`. Each aggregate window records
+only content-free, low-cardinality buckets: request count, total-token summary,
+latency summary, model class, SLO class, region, archetype weights, and
+uncertainty. The privacy policy rejects caller/session/user/request ids,
+arbitrary domains/hosts/URLs, and raw prompt/response fields. Windows below the
+configured minimum request count fail validation unless explicitly redacted.
+
+| File | Scenario | Description |
+|---|---|---|
+| `workload_forecast_seasonal.json` | Seasonal pattern | Repeating three-window demand pattern where seasonal-naive should beat simple controls |
+| `workload_forecast_drift.json` | Taxonomy drift | Aggregate demand shifts from chat-heavy to agent-heavy windows |
+| `workload_forecast_burst.json` | Burst and rollback | Agent-heavy demand spike followed by recovery; can also exercise stale-data rollback by passing `--now-s` beyond `max_staleness_s` |
+
+Use `vllm-sr-sim forecast-backtest --scenario data/workload_forecast_seasonal.json`
+to compare static mean, reactive last-window, moving-window, seasonal-naive, and
+linear-trend forecasts. The command converts each forecast into a FleetSim
+mixture scenario from the source mixture archetypes, reports backtest error,
+uncertainty coverage, burst/drift/oscillation diagnostics, and states when
+forecasting does not beat simpler controls.
+
+Forecast backtests are advise-only. The generated recommendation is recorded
+separately from downstream actuation; FleetSim does not apply cooldowns, quotas,
+load-balancer changes, or rollback actions on behalf of the operator. Missing or
+stale forecast inputs fall back to ordinary reactive controls.
+
 ## Bring your own CDF
 
 A CDF file is a JSON array of `[token_length, cumulative_fraction]` pairs,

--- a/src/fleet-sim/data/README.md
+++ b/src/fleet-sim/data/README.md
@@ -51,6 +51,10 @@ latency summary, model class, SLO class, region, archetype weights, and
 uncertainty. The privacy policy rejects caller/session/user/request ids,
 arbitrary domains/hosts/URLs, and raw prompt/response fields. Windows below the
 configured minimum request count fail validation unless explicitly redacted.
+Window fields fail closed against the forecast schema and
+`privacy.allowed_dimensions` is enforced for low-cardinality dimensions, so new
+caller, device, or arbitrary identifier fields must be explicitly modeled before
+they can validate.
 
 | File | Scenario | Description |
 |---|---|---|
@@ -61,9 +65,11 @@ configured minimum request count fail validation unless explicitly redacted.
 Use `vllm-sr-sim forecast-backtest --scenario data/workload_forecast_seasonal.json`
 to compare static mean, reactive last-window, moving-window, seasonal-naive, and
 linear-trend forecasts. The command converts each forecast into a FleetSim
-mixture scenario from the source mixture archetypes, reports backtest error,
-uncertainty coverage, burst/drift/oscillation diagnostics, and states when
-forecasting does not beat simpler controls.
+mixture scenario from the source mixture archetypes. Each composition window
+scales the source token CDF using aggregate mean/p50/p95 token demand, then the
+report includes arrival-rate, token-demand, p95-token, latency, and mixture
+backtest error, uncertainty coverage, burst/drift/oscillation diagnostics, and
+states when forecasting does not beat simpler controls.
 
 Forecast backtests are advise-only. The generated recommendation is recorded
 separately from downstream actuation; FleetSim does not apply cooldowns, quotas,

--- a/src/fleet-sim/data/README.md
+++ b/src/fleet-sim/data/README.md
@@ -13,6 +13,34 @@ that trace.
 | `lmsys_multiturn_cdf.json` | LMSYS-Chat-1M (multi-turn) | Accumulated context per turn |
 | `agent_heavy_cdf.json` | Synthetic agent-heavy | SWE-bench 40% + BFCL 25% + RAG 35% |
 
+## Workload mixture scenarios
+
+FleetSim also includes versioned workload-archetype mixture fixtures. They use
+privacy-safe aggregate CDF references by default and are intended for simulation
+and evaluation evidence only; they do not change production routing behavior.
+
+| File | Scenario | Description |
+|---|---|---|
+| `workload_mixture_nominal.json` | Fixed mixture | Interactive chat, multi-turn chat, and agent-heavy demand at nominal weights |
+| `workload_mixture_drift.json` | Composition drift | Two windows that shift from chat-dominated to agent-heavy demand |
+| `workload_mixture_burst.json` | Burst | Three windows with a higher-arrival agent-heavy burst |
+
+Mixture scenario files use schema
+`fleet-sim.workload-mixture/v1alpha1`. Each archetype defines an `id`,
+`version`, `source`, `arrival_process`, `slo_class`, `model_eligibility`,
+`residency`, and nominal `weight`. Optional `composition_schedule` windows can
+override weights and arrival-rate multipliers over time.
+
+CDF-only archetypes validate marginal token-length distributions. They do not
+preserve unknown cross-feature correlations. Trace archetypes can preserve
+correlations that are explicitly present in the trace rows.
+
+Use `vllm-sr-sim mixture-optimize --scenario data/workload_mixture_burst.json`
+to evaluate these fixtures with the repository's `FleetOptimizer`, including
+aggregate-CDF baselines, individual archetype stress cases, nominal mixtures,
+composition drift/burst windows, robust recommendations, sensitivity, and
+explicit infeasibility diagnostics.
+
 ## Bring your own CDF
 
 A CDF file is a JSON array of `[token_length, cumulative_fraction]` pairs,

--- a/src/fleet-sim/data/workload_forecast_burst.json
+++ b/src/fleet-sim/data/workload_forecast_burst.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": "fleet-sim.workload-archetype-forecast/v1alpha1",
+  "taxonomy_version": "fleet-sim.workload-archetype-taxonomy/v1alpha1",
+  "id": "burst-agent-heavy-aggregates",
+  "version": "2026-07-18",
+  "description": "Content-free aggregate windows with an agent-heavy holdout burst and recovery window.",
+  "source_mixture": "workload_mixture_nominal.json",
+  "generated_at_s": 180,
+  "max_staleness_s": 120,
+  "forecast_horizon_windows": 2,
+  "privacy": {
+    "content_free": true,
+    "min_requests_per_window": 100,
+    "allowed_dimensions": ["archetype_weights", "model_class", "region", "slo_class"],
+    "forbidden_dimensions": ["caller_id", "session_id", "domain", "raw_prompt", "request_id"]
+  },
+  "aggregate_windows": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2520000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 430,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "request_count": 1260,
+      "total_tokens": 2646000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 435,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.58,
+        "multiturn-chat": 0.27,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.1,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 120,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2520000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 432,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    }
+  ],
+  "holdout_windows": [
+    {
+      "start_s": 180,
+      "duration_s": 60,
+      "request_count": 3000,
+      "total_tokens": 10500000,
+      "p95_total_tokens": 12800,
+      "p99_ttft_ms": 590,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.35,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.45
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 4.0,
+        "weight_stddev": {
+          "interactive-chat": 0.04,
+          "multiturn-chat": 0.03,
+          "agent-heavy": 0.04
+        }
+      }
+    },
+    {
+      "start_s": 240,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2520000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 435,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/data/workload_forecast_drift.json
+++ b/src/fleet-sim/data/workload_forecast_drift.json
@@ -1,0 +1,165 @@
+{
+  "schema_version": "fleet-sim.workload-archetype-forecast/v1alpha1",
+  "taxonomy_version": "fleet-sim.workload-archetype-taxonomy/v1alpha1",
+  "id": "drift-chat-to-agent-aggregates",
+  "version": "2026-07-18",
+  "description": "Content-free aggregate windows where demand drifts toward agent-heavy work.",
+  "source_mixture": "workload_mixture_nominal.json",
+  "generated_at_s": 240,
+  "max_staleness_s": 180,
+  "forecast_horizon_windows": 2,
+  "privacy": {
+    "content_free": true,
+    "min_requests_per_window": 100,
+    "allowed_dimensions": ["archetype_weights", "model_class", "region", "slo_class"],
+    "forbidden_dimensions": ["caller_id", "session_id", "domain", "raw_prompt", "request_id"]
+  },
+  "aggregate_windows": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2400000,
+      "p95_total_tokens": 5000,
+      "p99_ttft_ms": 425,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.7,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.9,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "request_count": 1320,
+      "total_tokens": 2970000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 440,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.23,
+        "agent-heavy": 0.17
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.9,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 120,
+      "duration_s": 60,
+      "request_count": 1440,
+      "total_tokens": 3600000,
+      "p95_total_tokens": 7600,
+      "p99_ttft_ms": 465,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.5,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.25
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    },
+    {
+      "start_s": 180,
+      "duration_s": 60,
+      "request_count": 1560,
+      "total_tokens": 4290000,
+      "p95_total_tokens": 9000,
+      "p99_ttft_ms": 490,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.4,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.35
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.1,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    }
+  ],
+  "holdout_windows": [
+    {
+      "start_s": 240,
+      "duration_s": 60,
+      "request_count": 1680,
+      "total_tokens": 5040000,
+      "p95_total_tokens": 10400,
+      "p99_ttft_ms": 510,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.3,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.45
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    },
+    {
+      "start_s": 300,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 5700000,
+      "p95_total_tokens": 11600,
+      "p99_ttft_ms": 525,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.25,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.5
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.3,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/data/workload_forecast_seasonal.json
+++ b/src/fleet-sim/data/workload_forecast_seasonal.json
@@ -1,0 +1,234 @@
+{
+  "schema_version": "fleet-sim.workload-archetype-forecast/v1alpha1",
+  "taxonomy_version": "fleet-sim.workload-archetype-taxonomy/v1alpha1",
+  "id": "seasonal-chat-agent-aggregates",
+  "version": "2026-07-18",
+  "description": "Content-free aggregate windows with a repeating three-window workload pattern.",
+  "source_mixture": "workload_mixture_nominal.json",
+  "generated_at_s": 360,
+  "max_staleness_s": 180,
+  "forecast_horizon_windows": 2,
+  "privacy": {
+    "content_free": true,
+    "min_requests_per_window": 100,
+    "allowed_dimensions": [
+      "archetype_weights",
+      "model_class",
+      "region",
+      "slo_class"
+    ],
+    "forbidden_dimensions": [
+      "caller_id",
+      "session_id",
+      "user_id",
+      "domain",
+      "raw_prompt",
+      "raw_response",
+      "request_id"
+    ]
+  },
+  "aggregate_windows": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2160000,
+      "p50_total_tokens": 900,
+      "p95_total_tokens": 4600,
+      "p99_ttft_ms": 420,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.65,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.8,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.01
+        }
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 3960000,
+      "p50_total_tokens": 1100,
+      "p95_total_tokens": 6400,
+      "p99_ttft_ms": 455,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.55,
+        "multiturn-chat": 0.3,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 120,
+      "duration_s": 60,
+      "request_count": 1440,
+      "total_tokens": 4032000,
+      "p50_total_tokens": 1500,
+      "p95_total_tokens": 8900,
+      "p99_ttft_ms": 480,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.5,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.25
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    },
+    {
+      "start_s": 180,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2160000,
+      "p50_total_tokens": 900,
+      "p95_total_tokens": 4600,
+      "p99_ttft_ms": 421,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.65,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.8,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.01
+        }
+      }
+    },
+    {
+      "start_s": 240,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 3960000,
+      "p50_total_tokens": 1100,
+      "p95_total_tokens": 6400,
+      "p99_ttft_ms": 456,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.55,
+        "multiturn-chat": 0.3,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 300,
+      "duration_s": 60,
+      "request_count": 1440,
+      "total_tokens": 4032000,
+      "p50_total_tokens": 1500,
+      "p95_total_tokens": 8900,
+      "p99_ttft_ms": 481,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.5,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.25
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    }
+  ],
+  "holdout_windows": [
+    {
+      "start_s": 360,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2160000,
+      "p50_total_tokens": 900,
+      "p95_total_tokens": 4600,
+      "p99_ttft_ms": 422,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.65,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.8,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.01
+        }
+      }
+    },
+    {
+      "start_s": 420,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 3960000,
+      "p50_total_tokens": 1100,
+      "p95_total_tokens": 6400,
+      "p99_ttft_ms": 457,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.55,
+        "multiturn-chat": 0.3,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/data/workload_mixture_burst.json
+++ b/src/fleet-sim/data/workload_mixture_burst.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+  "id": "agent-heavy-burst",
+  "version": "2026-07-18",
+  "seed": 2558,
+  "description": "Three-window scenario with an agent-heavy burst between nominal periods.",
+  "archetypes": [
+    {
+      "id": "interactive-chat",
+      "version": "lmsys-single-turn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_cdf.json",
+        "l_in_frac": 0.8,
+        "l_out_frac": 0.2
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "qwen3-8b"],
+      "residency": ["global"],
+      "weight": 0.6
+    },
+    {
+      "id": "multiturn-chat",
+      "version": "lmsys-multiturn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_multiturn_cdf.json",
+        "l_in_frac": 0.85,
+        "l_out_frac": 0.15
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "llama-3.1-70b"],
+      "residency": ["global", "us"],
+      "weight": 0.25
+    },
+    {
+      "id": "agent-heavy",
+      "version": "agent-heavy-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "agent_heavy_cdf.json",
+        "l_in_frac": 0.9,
+        "l_out_frac": 0.1
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "batch",
+      "model_eligibility": ["llama-3.1-70b", "deepseek-v3"],
+      "residency": ["us"],
+      "weight": 0.15
+    }
+  ],
+  "composition_schedule": [
+    {
+      "start_s": 0,
+      "duration_s": 45,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      }
+    },
+    {
+      "start_s": 45,
+      "duration_s": 30,
+      "arrival_rate_multiplier": 2.5,
+      "weights": {
+        "interactive-chat": 0.35,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.45
+      }
+    },
+    {
+      "start_s": 75,
+      "duration_s": 45,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/data/workload_mixture_drift.json
+++ b/src/fleet-sim/data/workload_mixture_drift.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+  "id": "composition-drift-chat-to-agent",
+  "version": "2026-07-18",
+  "seed": 2557,
+  "description": "Two-window scenario where traffic drifts from chat-dominated to agent-heavy demand.",
+  "archetypes": [
+    {
+      "id": "interactive-chat",
+      "version": "lmsys-single-turn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_cdf.json",
+        "l_in_frac": 0.8,
+        "l_out_frac": 0.2
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "qwen3-8b"],
+      "residency": ["global"],
+      "weight": 0.55
+    },
+    {
+      "id": "multiturn-chat",
+      "version": "lmsys-multiturn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_multiturn_cdf.json",
+        "l_in_frac": 0.85,
+        "l_out_frac": 0.15
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "llama-3.1-70b"],
+      "residency": ["global", "us"],
+      "weight": 0.25
+    },
+    {
+      "id": "agent-heavy",
+      "version": "agent-heavy-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "agent_heavy_cdf.json",
+        "l_in_frac": 0.9,
+        "l_out_frac": 0.1
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "batch",
+      "model_eligibility": ["llama-3.1-70b", "deepseek-v3"],
+      "residency": ["us"],
+      "weight": 0.2
+    }
+  ],
+  "composition_schedule": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.7,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.1
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.35,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.4
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/data/workload_mixture_nominal.json
+++ b/src/fleet-sim/data/workload_mixture_nominal.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+  "id": "nominal-chat-multiturn-agent",
+  "version": "2026-07-18",
+  "seed": 2556,
+  "description": "Nominal fixed mixture of interactive chat, multi-turn chat, and agent-heavy workloads.",
+  "archetypes": [
+    {
+      "id": "interactive-chat",
+      "version": "lmsys-single-turn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_cdf.json",
+        "l_in_frac": 0.8,
+        "l_out_frac": 0.2,
+        "category_mix": {
+          "prose": 0.7,
+          "code": 0.2,
+          "rag": 0.1
+        }
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "qwen3-8b"],
+      "residency": ["global"],
+      "weight": 0.6
+    },
+    {
+      "id": "multiturn-chat",
+      "version": "lmsys-multiturn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_multiturn_cdf.json",
+        "l_in_frac": 0.85,
+        "l_out_frac": 0.15,
+        "category_mix": {
+          "prose": 0.65,
+          "code": 0.15,
+          "rag": 0.2
+        }
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "llama-3.1-70b"],
+      "residency": ["global", "us"],
+      "weight": 0.25
+    },
+    {
+      "id": "agent-heavy",
+      "version": "agent-heavy-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "agent_heavy_cdf.json",
+        "l_in_frac": 0.9,
+        "l_out_frac": 0.1,
+        "category_mix": {
+          "code": 0.4,
+          "rag": 0.35,
+          "prose": 0.25
+        }
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "batch",
+      "model_eligibility": ["llama-3.1-70b", "deepseek-v3"],
+      "residency": ["us"],
+      "weight": 0.15
+    }
+  ]
+}

--- a/src/fleet-sim/fleet_sim/api/models.py
+++ b/src/fleet-sim/fleet_sim/api/models.py
@@ -77,6 +77,16 @@ class BuiltinWorkload(BaseModel):
     stats: TraceStats | None = None
 
 
+class MixtureWorkload(BaseModel):
+    name: str
+    scenario_id: str
+    version: str
+    description: str | None = None
+    path: str
+    archetype_weights: dict[str, float]
+    has_composition_schedule: bool
+
+
 class CdfPoint(BaseModel):
     threshold: int
     cumulative_frac: float
@@ -117,6 +127,7 @@ class FleetConfigOut(FleetConfigIn):
 
 class JobType(str, Enum):
     optimize = "optimize"
+    mixture_optimize = "mixture_optimize"
     simulate = "simulate"
     whatif = "whatif"
 
@@ -167,6 +178,30 @@ class OptimizeParams(BaseModel):
     )
 
 
+class MixtureOptimizeParams(BaseModel):
+    scenario: str = Field(
+        "nominal",
+        description=(
+            "Built-in mixture scenario name ('nominal', 'drift', 'burst') or "
+            "workload_mixture_<name>.json in fleet_sim/data."
+        ),
+    )
+    lam: float = Field(..., gt=0, description="Base arrival rate (req/s)")
+    slo_ms: float = Field(500.0, gt=0, description="P99 TTFT SLO (ms)")
+    b_short: int = Field(4096, ge=1, description="Short/long context split (tokens)")
+    gpu_short: str = Field("a100", description="GPU for short pool")
+    gpu_long: str = Field("a100", description="GPU for long pool")
+    long_max_ctx: int = Field(65536, ge=1024)
+    gamma_min: float = Field(1.0, ge=1.0)
+    gamma_max: float = Field(2.0, le=4.0)
+    gamma_step: float = Field(0.1, ge=0.05)
+    n_sim_requests: int = Field(0, ge=0)
+    max_total_gpus: int | None = Field(None, ge=1)
+    fail_on_infeasible: bool = False
+    p_c: float = Field(0.75, ge=0.0, le=1.0)
+    node_avail: float = Field(1.0, gt=0.0, le=1.0)
+
+
 class SimulateParams(BaseModel):
     workload: WorkloadRef
     fleet_id: str | None = None  # use saved fleet
@@ -188,6 +223,7 @@ class WhatifParams(BaseModel):
 class JobRequest(BaseModel):
     type: JobType
     optimize: OptimizeParams | None = None
+    mixture_optimize: MixtureOptimizeParams | None = None
     simulate: SimulateParams | None = None
     whatif: WhatifParams | None = None
 
@@ -246,6 +282,44 @@ class OptResult(BaseModel):
     sim_validation: SimResult | None = None
 
 
+class RobustMixturePoint(BaseModel):
+    gamma: float
+    n_s: int
+    n_l: int
+    total_gpus: int
+    annual_cost_kusd: float
+    worst_case_id: str
+    worst_p99_short_ms: float
+    worst_p99_long_ms: float
+    slo_met: bool
+    infeasible_reason: str | None = None
+
+
+class MixtureCasePoint(BaseModel):
+    case_id: str
+    kind: str
+    lam: float
+    weights: dict[str, float]
+    best: SweepPoint | None = None
+    baseline: SweepPoint | None = None
+    slo_met: bool
+    infeasible_reason: str | None = None
+    annual_cost_delta_vs_nominal_kusd: float | None = None
+    cost_sensitivity_pct: float | None = None
+
+
+class MixtureOptResult(BaseModel):
+    scenario_id: str
+    scenario_version: str
+    lam: float
+    ok: bool
+    aggregate_baseline_case_id: str
+    nominal_case_id: str
+    robust_recommendation: RobustMixturePoint | None = None
+    cases: list[MixtureCasePoint]
+    diagnostics: list[str] = Field(default_factory=list)
+
+
 class WhatifPoint(BaseModel):
     lam: float
     fleet_p99_ttft_ms: float
@@ -269,5 +343,6 @@ class JobOut(BaseModel):
     error: str | None = None
     request: JobRequest
     result_optimize: OptResult | None = None
+    result_mixture_optimize: MixtureOptResult | None = None
     result_simulate: SimResult | None = None
     result_whatif: WhatifResult | None = None

--- a/src/fleet-sim/fleet_sim/api/routes/jobs.py
+++ b/src/fleet-sim/fleet_sim/api/routes/jobs.py
@@ -22,6 +22,10 @@ async def create_job(body: JobRequest, background_tasks: BackgroundTasks):
     # Validate: check the right params are provided
     if body.type == JobType.optimize and not body.optimize:
         raise HTTPException(422, "optimize params required for type=optimize")
+    if body.type == JobType.mixture_optimize and not body.mixture_optimize:
+        raise HTTPException(
+            422, "mixture_optimize params required for type=mixture_optimize"
+        )
     if body.type == JobType.simulate and not body.simulate:
         raise HTTPException(422, "simulate params required for type=simulate")
     if body.type == JobType.whatif and not body.whatif:
@@ -38,6 +42,7 @@ async def create_job(body: JobRequest, background_tasks: BackgroundTasks):
         "error": None,
         "request": body.model_dump(),
         "result_optimize": None,
+        "result_mixture_optimize": None,
         "result_simulate": None,
         "result_whatif": None,
     }

--- a/src/fleet-sim/fleet_sim/api/routes/workloads.py
+++ b/src/fleet-sim/fleet_sim/api/routes/workloads.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 
-from ..models import BuiltinWorkload, CdfPoint, HistogramBucket, TraceStats
+from ...workload import load_mixture_scenario
+from ..models import (
+    BuiltinWorkload,
+    CdfPoint,
+    HistogramBucket,
+    MixtureWorkload,
+    TraceStats,
+)
 
 router = APIRouter(prefix="/workloads", tags=["Workloads"])
 
@@ -18,6 +25,12 @@ _BUILTIN: dict[str, str] = {
     "lmsys": "LMSYS-Chat-1M single-turn conversations",
     "lmsys_multiturn": "LMSYS-Chat-1M multi-turn conversations",
     "agent_heavy": "Agent-heavy workload (tool calls, long context)",
+}
+
+_MIXTURES: dict[str, str] = {
+    "nominal": "workload_mixture_nominal.json",
+    "drift": "workload_mixture_drift.json",
+    "burst": "workload_mixture_burst.json",
 }
 
 
@@ -101,6 +114,30 @@ async def get_cdf(name: str):
     except FileNotFoundError:
         raise HTTPException(404, f"Workload '{name}' not found")
     return [CdfPoint(threshold=int(t), cumulative_frac=float(f)) for t, f in cdf]
+
+
+@router.get(
+    "/mixtures",
+    response_model=list[MixtureWorkload],
+    summary="List built-in workload mixture scenarios",
+)
+async def list_mixture_workloads():
+    result = []
+    for name, filename in _MIXTURES.items():
+        path = _DATA_DIR / filename
+        scenario = load_mixture_scenario(path)
+        result.append(
+            MixtureWorkload(
+                name=name,
+                scenario_id=scenario.id,
+                version=scenario.version,
+                description=scenario.description,
+                path=str(path),
+                archetype_weights=scenario.nominal_weights,
+                has_composition_schedule=bool(scenario.composition_schedule),
+            )
+        )
+    return result
 
 
 @router.get(

--- a/src/fleet-sim/fleet_sim/api/runner.py
+++ b/src/fleet-sim/fleet_sim/api/runner.py
@@ -17,8 +17,11 @@ from .models import (
     HistogramBucket,
     JobRequest,
     JobType,
+    MixtureCasePoint,
+    MixtureOptResult,
     OptResult,
     PoolResult,
+    RobustMixturePoint,
     SimResult,
     SweepPoint,
     WhatifPoint,
@@ -92,6 +95,25 @@ def _load_cdf(workload_ref: WorkloadRef) -> list:
             meta.get("format", "jsonl"),
         )
     raise ValueError(f"Unknown workload type '{workload_ref.type}'")
+
+
+def _load_mixture_scenario(name: str):
+    from fleet_sim.workload import load_mixture_scenario
+
+    scenario_name = name.removesuffix(".json").removeprefix("workload_mixture_")
+    filenames = {
+        "nominal": "workload_mixture_nominal.json",
+        "drift": "workload_mixture_drift.json",
+        "burst": "workload_mixture_burst.json",
+    }
+    filename = filenames.get(scenario_name)
+    if filename is None:
+        raise FileNotFoundError(
+            f"Built-in mixture scenario '{name}' not found; "
+            f"available: {sorted(filenames)}"
+        )
+    path = _DATA_DIR / filename
+    return load_mixture_scenario(path)
 
 
 def _cdf_from_trace(path: Path, fmt: str) -> list:
@@ -168,11 +190,7 @@ def _run_optimize(params) -> OptResult:
         p_c=params.p_c,
         node_avail=params.node_avail,
     )
-    step = params.gamma_step
-    gammas = [
-        round(params.gamma_min + i * step, 2)
-        for i in range(int((params.gamma_max - params.gamma_min) / step) + 1)
-    ]
+    gammas = _gamma_values(params.gamma_min, params.gamma_max, params.gamma_step)
 
     result = opt.optimize(
         cdf=cdf,
@@ -184,20 +202,7 @@ def _run_optimize(params) -> OptResult:
 
     # OptimizationReport stores results in .analytical and .simulated lists
     all_results = result.analytical + result.simulated
-    sweep_pts = [
-        SweepPoint(
-            gamma=r.gamma,
-            n_s=r.n_s,
-            n_l=r.n_l,
-            total_gpus=r.total_gpus,
-            annual_cost_kusd=r.annualised_cost_kusd,
-            p99_short_ms=r.p99_ttft_short_ms,
-            p99_long_ms=r.p99_ttft_long_ms,
-            slo_met=r.slo_met,
-            source=r.source,
-        )
-        for r in all_results
-    ]
+    sweep_pts = [_sweep_point(r) for r in all_results]
 
     best_r = result.best_simulated or result.best_analytical
     # Baseline = cheapest γ=1.0 analytical result (no C+R compression)
@@ -211,17 +216,7 @@ def _run_optimize(params) -> OptResult:
             (baseline_cost - best_r.annualised_cost_kusd) / baseline_cost * 100, 1
         )
 
-    best_pt = SweepPoint(
-        gamma=best_r.gamma,
-        n_s=best_r.n_s,
-        n_l=best_r.n_l,
-        total_gpus=best_r.total_gpus,
-        annual_cost_kusd=best_r.annualised_cost_kusd,
-        p99_short_ms=best_r.p99_ttft_short_ms,
-        p99_long_ms=best_r.p99_ttft_long_ms,
-        slo_met=best_r.slo_met,
-        source=best_r.source,
-    )
+    best_pt = _sweep_point(best_r)
 
     # DES produces SweepResult summaries, not a raw FleetSimResult, so
     # sim_validation cannot be reconstructed here without re-running the DES.
@@ -231,6 +226,61 @@ def _run_optimize(params) -> OptResult:
         baseline_annual_cost_kusd=baseline_cost,
         savings_pct=savings,
         sim_validation=None,
+    )
+
+
+def _run_mixture_optimize(params) -> MixtureOptResult:
+    from fleet_sim.optimizer import FleetOptimizer, evaluate_mixture_scenario
+
+    scenario = _load_mixture_scenario(params.scenario)
+    gpu_s = _gpu(params.gpu_short)
+    gpu_l = _gpu(params.gpu_long)
+    optimizer = FleetOptimizer(
+        gpu_short=gpu_s,
+        gpu_long=gpu_l,
+        B_short=params.b_short,
+        t_slo_ms=params.slo_ms,
+        long_max_ctx=params.long_max_ctx,
+        p_c=params.p_c,
+        node_avail=params.node_avail,
+    )
+    report = evaluate_mixture_scenario(
+        optimizer=optimizer,
+        scenario=scenario,
+        lam=params.lam,
+        gammas=_gamma_values(params.gamma_min, params.gamma_max, params.gamma_step),
+        n_sim_requests=params.n_sim_requests,
+        verify_top_n=1 if params.n_sim_requests else 0,
+        max_total_gpus=params.max_total_gpus,
+        fail_on_infeasible=params.fail_on_infeasible,
+        verbose=False,
+    )
+    robust = report.robust_recommendation
+    return MixtureOptResult(
+        scenario_id=report.scenario_id,
+        scenario_version=report.scenario_version,
+        lam=report.lam,
+        ok=report.ok,
+        aggregate_baseline_case_id=report.aggregate_baseline_case_id,
+        nominal_case_id=report.nominal_case_id,
+        robust_recommendation=(
+            RobustMixturePoint(
+                gamma=robust.gamma,
+                n_s=robust.n_s,
+                n_l=robust.n_l,
+                total_gpus=robust.total_gpus,
+                annual_cost_kusd=robust.annualised_cost_kusd,
+                worst_case_id=robust.worst_case_id,
+                worst_p99_short_ms=robust.worst_p99_ttft_short_ms,
+                worst_p99_long_ms=robust.worst_p99_ttft_long_ms,
+                slo_met=robust.slo_met,
+                infeasible_reason=robust.infeasible_reason,
+            )
+            if robust is not None
+            else None
+        ),
+        cases=[_mixture_case_point(case) for case in report.cases],
+        diagnostics=list(report.diagnostics),
     )
 
 
@@ -334,6 +384,42 @@ def _router_name(router: str, gamma: float | None) -> str:
     return mapping.get(router, "LengthRouter")
 
 
+def _gamma_values(gamma_min: float, gamma_max: float, gamma_step: float) -> list[float]:
+    if gamma_max < gamma_min:
+        raise ValueError("gamma_max must be >= gamma_min")
+    n_steps = int((gamma_max - gamma_min) / gamma_step)
+    return [round(gamma_min + i * gamma_step, 2) for i in range(n_steps + 1)]
+
+
+def _sweep_point(result) -> SweepPoint:
+    return SweepPoint(
+        gamma=result.gamma,
+        n_s=result.n_s,
+        n_l=result.n_l,
+        total_gpus=result.total_gpus,
+        annual_cost_kusd=result.annualised_cost_kusd,
+        p99_short_ms=result.p99_ttft_short_ms,
+        p99_long_ms=result.p99_ttft_long_ms,
+        slo_met=result.slo_met,
+        source=result.source,
+    )
+
+
+def _mixture_case_point(case) -> MixtureCasePoint:
+    return MixtureCasePoint(
+        case_id=case.case_id,
+        kind=case.kind,
+        lam=case.lam,
+        weights=case.weights,
+        best=_sweep_point(case.best) if case.best is not None else None,
+        baseline=_sweep_point(case.baseline) if case.baseline is not None else None,
+        slo_met=case.slo_met,
+        infeasible_reason=case.infeasible_reason,
+        annual_cost_delta_vs_nominal_kusd=case.annual_cost_delta_vs_nominal_kusd,
+        cost_sensitivity_pct=case.cost_sensitivity_pct,
+    )
+
+
 def _fleet_sim_result_to_model(result, slo_ms: float) -> SimResult:
     pool_results = []
     for pid, pool in result.pools.items():
@@ -387,6 +473,11 @@ async def run_job(job_id: str, request: JobRequest) -> None:
         if request.type == JobType.optimize:
             result = await asyncio.to_thread(_run_optimize, request.optimize)
             data["result_optimize"] = result.model_dump()
+        elif request.type == JobType.mixture_optimize:
+            result = await asyncio.to_thread(
+                _run_mixture_optimize, request.mixture_optimize
+            )
+            data["result_mixture_optimize"] = result.model_dump()
         elif request.type == JobType.simulate:
             result = await asyncio.to_thread(_run_simulate, request.simulate)
             data["result_simulate"] = result.model_dump()

--- a/src/fleet-sim/fleet_sim/core/request.py
+++ b/src/fleet-sim/fleet_sim/core/request.py
@@ -26,6 +26,10 @@ class Request:
     l_out        : number of output tokens to generate
     category     : content category ("prose", "code", "rag", "mixed")
                    used by C&R router for compression safety decisions
+    archetype_id : workload archetype id when sampled from a mixture scenario
+    slo_class    : SLO class carried by a workload archetype
+    eligible_models : model ids this request archetype may use
+    residency    : locality/residency constraints carried by a workload archetype
     pool_id      : which pool this request was routed to (set by router)
     instance_id  : which instance within the pool (set by pool)
     compressed   : True if this request was compressed by C&R
@@ -44,6 +48,10 @@ class Request:
     l_out: int
     category: str = "prose"
     model_id: str | None = None  # desired model/pool; used by ModelRouter
+    archetype_id: str | None = None
+    slo_class: str | None = None
+    eligible_models: tuple[str, ...] = ()
+    residency: tuple[str, ...] = ()
 
     # routing metadata (filled by router)
     pool_id: str | None = None

--- a/src/fleet-sim/fleet_sim/data/README.md
+++ b/src/fleet-sim/fleet_sim/data/README.md
@@ -41,6 +41,35 @@ aggregate-CDF baselines, individual archetype stress cases, nominal mixtures,
 composition drift/burst windows, robust recommendations, sensitivity, and
 explicit infeasibility diagnostics.
 
+## Workload archetype forecast aggregates
+
+Forecast aggregate fixtures use schema
+`fleet-sim.workload-archetype-forecast/v1alpha1` and taxonomy
+`fleet-sim.workload-archetype-taxonomy/v1alpha1`. Each aggregate window records
+only content-free, low-cardinality buckets: request count, total-token summary,
+latency summary, model class, SLO class, region, archetype weights, and
+uncertainty. The privacy policy rejects caller/session/user/request ids,
+arbitrary domains/hosts/URLs, and raw prompt/response fields. Windows below the
+configured minimum request count fail validation unless explicitly redacted.
+
+| File | Scenario | Description |
+|---|---|---|
+| `workload_forecast_seasonal.json` | Seasonal pattern | Repeating three-window demand pattern where seasonal-naive should beat simple controls |
+| `workload_forecast_drift.json` | Taxonomy drift | Aggregate demand shifts from chat-heavy to agent-heavy windows |
+| `workload_forecast_burst.json` | Burst and rollback | Agent-heavy demand spike followed by recovery; can also exercise stale-data rollback by passing `--now-s` beyond `max_staleness_s` |
+
+Use `vllm-sr-sim forecast-backtest --scenario data/workload_forecast_seasonal.json`
+to compare static mean, reactive last-window, moving-window, seasonal-naive, and
+linear-trend forecasts. The command converts each forecast into a FleetSim
+mixture scenario from the source mixture archetypes, reports backtest error,
+uncertainty coverage, burst/drift/oscillation diagnostics, and states when
+forecasting does not beat simpler controls.
+
+Forecast backtests are advise-only. The generated recommendation is recorded
+separately from downstream actuation; FleetSim does not apply cooldowns, quotas,
+load-balancer changes, or rollback actions on behalf of the operator. Missing or
+stale forecast inputs fall back to ordinary reactive controls.
+
 ## Bring your own CDF
 
 A CDF file is a JSON array of `[token_length, cumulative_fraction]` pairs,

--- a/src/fleet-sim/fleet_sim/data/README.md
+++ b/src/fleet-sim/fleet_sim/data/README.md
@@ -51,6 +51,10 @@ latency summary, model class, SLO class, region, archetype weights, and
 uncertainty. The privacy policy rejects caller/session/user/request ids,
 arbitrary domains/hosts/URLs, and raw prompt/response fields. Windows below the
 configured minimum request count fail validation unless explicitly redacted.
+Window fields fail closed against the forecast schema and
+`privacy.allowed_dimensions` is enforced for low-cardinality dimensions, so new
+caller, device, or arbitrary identifier fields must be explicitly modeled before
+they can validate.
 
 | File | Scenario | Description |
 |---|---|---|
@@ -61,9 +65,11 @@ configured minimum request count fail validation unless explicitly redacted.
 Use `vllm-sr-sim forecast-backtest --scenario data/workload_forecast_seasonal.json`
 to compare static mean, reactive last-window, moving-window, seasonal-naive, and
 linear-trend forecasts. The command converts each forecast into a FleetSim
-mixture scenario from the source mixture archetypes, reports backtest error,
-uncertainty coverage, burst/drift/oscillation diagnostics, and states when
-forecasting does not beat simpler controls.
+mixture scenario from the source mixture archetypes. Each composition window
+scales the source token CDF using aggregate mean/p50/p95 token demand, then the
+report includes arrival-rate, token-demand, p95-token, latency, and mixture
+backtest error, uncertainty coverage, burst/drift/oscillation diagnostics, and
+states when forecasting does not beat simpler controls.
 
 Forecast backtests are advise-only. The generated recommendation is recorded
 separately from downstream actuation; FleetSim does not apply cooldowns, quotas,

--- a/src/fleet-sim/fleet_sim/data/README.md
+++ b/src/fleet-sim/fleet_sim/data/README.md
@@ -13,6 +13,34 @@ that trace.
 | `lmsys_multiturn_cdf.json` | LMSYS-Chat-1M (multi-turn) | Accumulated context per turn |
 | `agent_heavy_cdf.json` | Synthetic agent-heavy | SWE-bench 40% + BFCL 25% + RAG 35% |
 
+## Workload mixture scenarios
+
+FleetSim also includes versioned workload-archetype mixture fixtures. They use
+privacy-safe aggregate CDF references by default and are intended for simulation
+and evaluation evidence only; they do not change production routing behavior.
+
+| File | Scenario | Description |
+|---|---|---|
+| `workload_mixture_nominal.json` | Fixed mixture | Interactive chat, multi-turn chat, and agent-heavy demand at nominal weights |
+| `workload_mixture_drift.json` | Composition drift | Two windows that shift from chat-dominated to agent-heavy demand |
+| `workload_mixture_burst.json` | Burst | Three windows with a higher-arrival agent-heavy burst |
+
+Mixture scenario files use schema
+`fleet-sim.workload-mixture/v1alpha1`. Each archetype defines an `id`,
+`version`, `source`, `arrival_process`, `slo_class`, `model_eligibility`,
+`residency`, and nominal `weight`. Optional `composition_schedule` windows can
+override weights and arrival-rate multipliers over time.
+
+CDF-only archetypes validate marginal token-length distributions. They do not
+preserve unknown cross-feature correlations. Trace archetypes can preserve
+correlations that are explicitly present in the trace rows.
+
+Use `vllm-sr-sim mixture-optimize --scenario data/workload_mixture_burst.json`
+to evaluate these fixtures with the repository's `FleetOptimizer`, including
+aggregate-CDF baselines, individual archetype stress cases, nominal mixtures,
+composition drift/burst windows, robust recommendations, sensitivity, and
+explicit infeasibility diagnostics.
+
 ## Bring your own CDF
 
 A CDF file is a JSON array of `[token_length, cumulative_fraction]` pairs,

--- a/src/fleet-sim/fleet_sim/data/workload_forecast_burst.json
+++ b/src/fleet-sim/fleet_sim/data/workload_forecast_burst.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": "fleet-sim.workload-archetype-forecast/v1alpha1",
+  "taxonomy_version": "fleet-sim.workload-archetype-taxonomy/v1alpha1",
+  "id": "burst-agent-heavy-aggregates",
+  "version": "2026-07-18",
+  "description": "Content-free aggregate windows with an agent-heavy holdout burst and recovery window.",
+  "source_mixture": "workload_mixture_nominal.json",
+  "generated_at_s": 180,
+  "max_staleness_s": 120,
+  "forecast_horizon_windows": 2,
+  "privacy": {
+    "content_free": true,
+    "min_requests_per_window": 100,
+    "allowed_dimensions": ["archetype_weights", "model_class", "region", "slo_class"],
+    "forbidden_dimensions": ["caller_id", "session_id", "domain", "raw_prompt", "request_id"]
+  },
+  "aggregate_windows": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2520000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 430,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "request_count": 1260,
+      "total_tokens": 2646000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 435,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.58,
+        "multiturn-chat": 0.27,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.1,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 120,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2520000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 432,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    }
+  ],
+  "holdout_windows": [
+    {
+      "start_s": 180,
+      "duration_s": 60,
+      "request_count": 3000,
+      "total_tokens": 10500000,
+      "p95_total_tokens": 12800,
+      "p99_ttft_ms": 590,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.35,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.45
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 4.0,
+        "weight_stddev": {
+          "interactive-chat": 0.04,
+          "multiturn-chat": 0.03,
+          "agent-heavy": 0.04
+        }
+      }
+    },
+    {
+      "start_s": 240,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2520000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 435,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/fleet_sim/data/workload_forecast_drift.json
+++ b/src/fleet-sim/fleet_sim/data/workload_forecast_drift.json
@@ -1,0 +1,165 @@
+{
+  "schema_version": "fleet-sim.workload-archetype-forecast/v1alpha1",
+  "taxonomy_version": "fleet-sim.workload-archetype-taxonomy/v1alpha1",
+  "id": "drift-chat-to-agent-aggregates",
+  "version": "2026-07-18",
+  "description": "Content-free aggregate windows where demand drifts toward agent-heavy work.",
+  "source_mixture": "workload_mixture_nominal.json",
+  "generated_at_s": 240,
+  "max_staleness_s": 180,
+  "forecast_horizon_windows": 2,
+  "privacy": {
+    "content_free": true,
+    "min_requests_per_window": 100,
+    "allowed_dimensions": ["archetype_weights", "model_class", "region", "slo_class"],
+    "forbidden_dimensions": ["caller_id", "session_id", "domain", "raw_prompt", "request_id"]
+  },
+  "aggregate_windows": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2400000,
+      "p95_total_tokens": 5000,
+      "p99_ttft_ms": 425,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.7,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.9,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "request_count": 1320,
+      "total_tokens": 2970000,
+      "p95_total_tokens": 6200,
+      "p99_ttft_ms": 440,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.23,
+        "agent-heavy": 0.17
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.9,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 120,
+      "duration_s": 60,
+      "request_count": 1440,
+      "total_tokens": 3600000,
+      "p95_total_tokens": 7600,
+      "p99_ttft_ms": 465,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.5,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.25
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    },
+    {
+      "start_s": 180,
+      "duration_s": 60,
+      "request_count": 1560,
+      "total_tokens": 4290000,
+      "p95_total_tokens": 9000,
+      "p99_ttft_ms": 490,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.4,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.35
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.1,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    }
+  ],
+  "holdout_windows": [
+    {
+      "start_s": 240,
+      "duration_s": 60,
+      "request_count": 1680,
+      "total_tokens": 5040000,
+      "p95_total_tokens": 10400,
+      "p99_ttft_ms": 510,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.3,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.45
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    },
+    {
+      "start_s": 300,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 5700000,
+      "p95_total_tokens": 11600,
+      "p99_ttft_ms": 525,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.25,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.5
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.3,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/fleet_sim/data/workload_forecast_seasonal.json
+++ b/src/fleet-sim/fleet_sim/data/workload_forecast_seasonal.json
@@ -1,0 +1,234 @@
+{
+  "schema_version": "fleet-sim.workload-archetype-forecast/v1alpha1",
+  "taxonomy_version": "fleet-sim.workload-archetype-taxonomy/v1alpha1",
+  "id": "seasonal-chat-agent-aggregates",
+  "version": "2026-07-18",
+  "description": "Content-free aggregate windows with a repeating three-window workload pattern.",
+  "source_mixture": "workload_mixture_nominal.json",
+  "generated_at_s": 360,
+  "max_staleness_s": 180,
+  "forecast_horizon_windows": 2,
+  "privacy": {
+    "content_free": true,
+    "min_requests_per_window": 100,
+    "allowed_dimensions": [
+      "archetype_weights",
+      "model_class",
+      "region",
+      "slo_class"
+    ],
+    "forbidden_dimensions": [
+      "caller_id",
+      "session_id",
+      "user_id",
+      "domain",
+      "raw_prompt",
+      "raw_response",
+      "request_id"
+    ]
+  },
+  "aggregate_windows": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2160000,
+      "p50_total_tokens": 900,
+      "p95_total_tokens": 4600,
+      "p99_ttft_ms": 420,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.65,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.8,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.01
+        }
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 3960000,
+      "p50_total_tokens": 1100,
+      "p95_total_tokens": 6400,
+      "p99_ttft_ms": 455,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.55,
+        "multiturn-chat": 0.3,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 120,
+      "duration_s": 60,
+      "request_count": 1440,
+      "total_tokens": 4032000,
+      "p50_total_tokens": 1500,
+      "p95_total_tokens": 8900,
+      "p99_ttft_ms": 480,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.5,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.25
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    },
+    {
+      "start_s": 180,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2160000,
+      "p50_total_tokens": 900,
+      "p95_total_tokens": 4600,
+      "p99_ttft_ms": 421,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.65,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.8,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.01
+        }
+      }
+    },
+    {
+      "start_s": 240,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 3960000,
+      "p50_total_tokens": 1100,
+      "p95_total_tokens": 6400,
+      "p99_ttft_ms": 456,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.55,
+        "multiturn-chat": 0.3,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    },
+    {
+      "start_s": 300,
+      "duration_s": 60,
+      "request_count": 1440,
+      "total_tokens": 4032000,
+      "p50_total_tokens": 1500,
+      "p95_total_tokens": 8900,
+      "p99_ttft_ms": 481,
+      "model_class": "general-llm",
+      "slo_class": "mixed",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.5,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.25
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.0,
+        "weight_stddev": {
+          "interactive-chat": 0.03,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.03
+        }
+      }
+    }
+  ],
+  "holdout_windows": [
+    {
+      "start_s": 360,
+      "duration_s": 60,
+      "request_count": 1200,
+      "total_tokens": 2160000,
+      "p50_total_tokens": 900,
+      "p95_total_tokens": 4600,
+      "p99_ttft_ms": 422,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.65,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.1
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 0.8,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.01
+        }
+      }
+    },
+    {
+      "start_s": 420,
+      "duration_s": 60,
+      "request_count": 1800,
+      "total_tokens": 3960000,
+      "p50_total_tokens": 1100,
+      "p95_total_tokens": 6400,
+      "p99_ttft_ms": 457,
+      "model_class": "general-llm",
+      "slo_class": "interactive",
+      "region": "global",
+      "archetype_weights": {
+        "interactive-chat": 0.55,
+        "multiturn-chat": 0.3,
+        "agent-heavy": 0.15
+      },
+      "uncertainty": {
+        "arrival_rate_stddev": 1.2,
+        "weight_stddev": {
+          "interactive-chat": 0.02,
+          "multiturn-chat": 0.02,
+          "agent-heavy": 0.02
+        }
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/fleet_sim/data/workload_mixture_burst.json
+++ b/src/fleet-sim/fleet_sim/data/workload_mixture_burst.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+  "id": "agent-heavy-burst",
+  "version": "2026-07-18",
+  "seed": 2558,
+  "description": "Three-window scenario with an agent-heavy burst between nominal periods.",
+  "archetypes": [
+    {
+      "id": "interactive-chat",
+      "version": "lmsys-single-turn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_cdf.json",
+        "l_in_frac": 0.8,
+        "l_out_frac": 0.2
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "qwen3-8b"],
+      "residency": ["global"],
+      "weight": 0.6
+    },
+    {
+      "id": "multiturn-chat",
+      "version": "lmsys-multiturn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_multiturn_cdf.json",
+        "l_in_frac": 0.85,
+        "l_out_frac": 0.15
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "llama-3.1-70b"],
+      "residency": ["global", "us"],
+      "weight": 0.25
+    },
+    {
+      "id": "agent-heavy",
+      "version": "agent-heavy-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "agent_heavy_cdf.json",
+        "l_in_frac": 0.9,
+        "l_out_frac": 0.1
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "batch",
+      "model_eligibility": ["llama-3.1-70b", "deepseek-v3"],
+      "residency": ["us"],
+      "weight": 0.15
+    }
+  ],
+  "composition_schedule": [
+    {
+      "start_s": 0,
+      "duration_s": 45,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      }
+    },
+    {
+      "start_s": 45,
+      "duration_s": 30,
+      "arrival_rate_multiplier": 2.5,
+      "weights": {
+        "interactive-chat": 0.35,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.45
+      }
+    },
+    {
+      "start_s": 75,
+      "duration_s": 45,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/fleet_sim/data/workload_mixture_drift.json
+++ b/src/fleet-sim/fleet_sim/data/workload_mixture_drift.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+  "id": "composition-drift-chat-to-agent",
+  "version": "2026-07-18",
+  "seed": 2557,
+  "description": "Two-window scenario where traffic drifts from chat-dominated to agent-heavy demand.",
+  "archetypes": [
+    {
+      "id": "interactive-chat",
+      "version": "lmsys-single-turn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_cdf.json",
+        "l_in_frac": 0.8,
+        "l_out_frac": 0.2
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "qwen3-8b"],
+      "residency": ["global"],
+      "weight": 0.55
+    },
+    {
+      "id": "multiturn-chat",
+      "version": "lmsys-multiturn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_multiturn_cdf.json",
+        "l_in_frac": 0.85,
+        "l_out_frac": 0.15
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "llama-3.1-70b"],
+      "residency": ["global", "us"],
+      "weight": 0.25
+    },
+    {
+      "id": "agent-heavy",
+      "version": "agent-heavy-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "agent_heavy_cdf.json",
+        "l_in_frac": 0.9,
+        "l_out_frac": 0.1
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "batch",
+      "model_eligibility": ["llama-3.1-70b", "deepseek-v3"],
+      "residency": ["us"],
+      "weight": 0.2
+    }
+  ],
+  "composition_schedule": [
+    {
+      "start_s": 0,
+      "duration_s": 60,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.7,
+        "multiturn-chat": 0.2,
+        "agent-heavy": 0.1
+      }
+    },
+    {
+      "start_s": 60,
+      "duration_s": 60,
+      "arrival_rate_multiplier": 1.0,
+      "weights": {
+        "interactive-chat": 0.35,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.4
+      }
+    }
+  ]
+}

--- a/src/fleet-sim/fleet_sim/data/workload_mixture_nominal.json
+++ b/src/fleet-sim/fleet_sim/data/workload_mixture_nominal.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+  "id": "nominal-chat-multiturn-agent",
+  "version": "2026-07-18",
+  "seed": 2556,
+  "description": "Nominal fixed mixture of interactive chat, multi-turn chat, and agent-heavy workloads.",
+  "archetypes": [
+    {
+      "id": "interactive-chat",
+      "version": "lmsys-single-turn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_cdf.json",
+        "l_in_frac": 0.8,
+        "l_out_frac": 0.2,
+        "category_mix": {
+          "prose": 0.7,
+          "code": 0.2,
+          "rag": 0.1
+        }
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "qwen3-8b"],
+      "residency": ["global"],
+      "weight": 0.6
+    },
+    {
+      "id": "multiturn-chat",
+      "version": "lmsys-multiturn-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "lmsys_multiturn_cdf.json",
+        "l_in_frac": 0.85,
+        "l_out_frac": 0.15,
+        "category_mix": {
+          "prose": 0.65,
+          "code": 0.15,
+          "rag": 0.2
+        }
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "interactive",
+      "model_eligibility": ["llama-3.1-8b", "llama-3.1-70b"],
+      "residency": ["global", "us"],
+      "weight": 0.25
+    },
+    {
+      "id": "agent-heavy",
+      "version": "agent-heavy-v1",
+      "source": {
+        "kind": "cdf",
+        "path": "agent_heavy_cdf.json",
+        "l_in_frac": 0.9,
+        "l_out_frac": 0.1,
+        "category_mix": {
+          "code": 0.4,
+          "rag": 0.35,
+          "prose": 0.25
+        }
+      },
+      "arrival_process": {
+        "kind": "poisson"
+      },
+      "slo_class": "batch",
+      "model_eligibility": ["llama-3.1-70b", "deepseek-v3"],
+      "residency": ["us"],
+      "weight": 0.15
+    }
+  ]
+}

--- a/src/fleet-sim/fleet_sim/optimizer/__init__.py
+++ b/src/fleet-sim/fleet_sim/optimizer/__init__.py
@@ -16,6 +16,15 @@ from .disagg import (
     DisaggResult,
     DisaggSweepPoint,
 )
+from .forecast import evaluate_forecast_backtest
+from .forecast_models import (
+    ForecastActuationRecord,
+    ForecastBacktestError,
+    ForecastBacktestReport,
+    ForecastCapacityRecommendation,
+    ForecastMethodBacktest,
+    ForecastWindowBacktest,
+)
 from .grid_flex import (
     GridFlexPoint,
     grid_flex_analysis,
@@ -64,6 +73,14 @@ __all__ = [
     "RobustMixtureRecommendation",
     "aggregate_mixture_cdf",
     "evaluate_mixture_scenario",
+    # Workload forecast backtests
+    "ForecastActuationRecord",
+    "ForecastBacktestError",
+    "ForecastBacktestReport",
+    "ForecastCapacityRecommendation",
+    "ForecastMethodBacktest",
+    "ForecastWindowBacktest",
+    "evaluate_forecast_backtest",
     # Tokens-per-watt
     "TpwPoint",
     "FleetTpwResult",

--- a/src/fleet-sim/fleet_sim/optimizer/__init__.py
+++ b/src/fleet-sim/fleet_sim/optimizer/__init__.py
@@ -21,6 +21,15 @@ from .grid_flex import (
     grid_flex_analysis,
     print_grid_flex_table,
 )
+from .mixture import (
+    MixtureCaseResult,
+    MixtureOptimizationError,
+    MixtureOptimizationReport,
+    MixtureStressCase,
+    RobustMixtureRecommendation,
+    aggregate_mixture_cdf,
+    evaluate_mixture_scenario,
+)
 from .threshold import ThresholdResult, print_threshold_pareto, threshold_pareto
 from .tpw import (
     FleetTpwResult,
@@ -47,6 +56,14 @@ __all__ = [
     "GridFlexPoint",
     "grid_flex_analysis",
     "print_grid_flex_table",
+    # Workload mixtures
+    "MixtureCaseResult",
+    "MixtureOptimizationError",
+    "MixtureOptimizationReport",
+    "MixtureStressCase",
+    "RobustMixtureRecommendation",
+    "aggregate_mixture_cdf",
+    "evaluate_mixture_scenario",
     # Tokens-per-watt
     "TpwPoint",
     "FleetTpwResult",

--- a/src/fleet-sim/fleet_sim/optimizer/forecast.py
+++ b/src/fleet-sim/fleet_sim/optimizer/forecast.py
@@ -44,12 +44,8 @@ def evaluate_forecast_backtest(
     """Backtest proactive forecast recommendations against observed holdout windows."""
 
     validate_forecast_scenario(scenario)
-    if not scenario.holdout_windows:
-        raise ForecastBacktestError("holdout_windows are required for backtesting")
     gammas = gammas or [round(1.0 + 0.1 * k, 1) for k in range(11)]
-    actual_windows = scenario.holdout_windows[: scenario.forecast_horizon_windows]
-    if not actual_windows:
-        raise ForecastBacktestError("forecast_horizon_windows selects no holdout data")
+    actual_windows = _actual_windows_for_backtest(scenario)
 
     source_mixture = scenario.load_source_mixture()
     base_lam = _mean([window.arrival_rate for window in scenario.aggregate_windows])
@@ -123,6 +119,23 @@ def evaluate_forecast_backtest(
         fallback_control=fallback_control,
         rollback_reason=rollback_reason,
     )
+
+
+def _actual_windows_for_backtest(
+    scenario: WorkloadForecastScenario,
+) -> tuple[AggregateWindow, ...]:
+    if not scenario.holdout_windows:
+        raise ForecastBacktestError("holdout_windows are required for backtesting")
+    if scenario.forecast_horizon_windows > len(scenario.holdout_windows):
+        raise ForecastBacktestError(
+            "forecast_horizon_windows exceeds available holdout_windows: "
+            f"horizon={scenario.forecast_horizon_windows} "
+            f"holdout_windows={len(scenario.holdout_windows)}"
+        )
+    actual_windows = scenario.holdout_windows[: scenario.forecast_horizon_windows]
+    if not actual_windows:
+        raise ForecastBacktestError("forecast_horizon_windows selects no holdout data")
+    return actual_windows
 
 
 def _final_decision(
@@ -337,6 +350,18 @@ def _window_results(
             if actual_rate > 0
             else 0.0
         )
+        token_error_pct = _pct_error(
+            forecast.tokens_per_request,
+            actual.tokens_per_request,
+        )
+        p95_error_pct = _optional_pct_error(
+            forecast.p95_total_tokens,
+            actual.p95_total_tokens,
+        )
+        ttft_error_pct = _optional_pct_error(
+            forecast.p99_ttft_ms,
+            actual.p99_ttft_ms,
+        )
         uncertainty = float(forecast.uncertainty.get("arrival_rate_stddev", 0.0) or 0.0)
         rows.append(
             ForecastWindowBacktest(
@@ -345,6 +370,15 @@ def _window_results(
                 actual_arrival_rate=actual_rate,
                 forecast_arrival_rate=forecast_rate,
                 arrival_rate_error_pct=error_pct,
+                actual_tokens_per_request=actual.tokens_per_request,
+                forecast_tokens_per_request=forecast.tokens_per_request,
+                tokens_per_request_error_pct=token_error_pct,
+                actual_p95_total_tokens=actual.p95_total_tokens,
+                forecast_p95_total_tokens=forecast.p95_total_tokens,
+                p95_total_tokens_error_pct=p95_error_pct,
+                actual_p99_ttft_ms=actual.p99_ttft_ms,
+                forecast_p99_ttft_ms=forecast.p99_ttft_ms,
+                p99_ttft_error_pct=ttft_error_pct,
                 weight_l1_error=_weight_l1(
                     forecast.archetype_weights, actual.archetype_weights
                 ),
@@ -356,6 +390,19 @@ def _window_results(
             )
         )
     return tuple(rows)
+
+
+def _optional_pct_error(
+    forecast: float | int | None,
+    actual: float | int | None,
+) -> float | None:
+    if forecast is None or actual is None:
+        return None
+    return _pct_error(float(forecast), float(actual))
+
+
+def _pct_error(forecast: float, actual: float) -> float:
+    return (forecast - actual) / actual * 100.0 if actual > 0 else 0.0
 
 
 def _annotate_control_comparison(methods: Sequence[ForecastMethodBacktest]) -> None:
@@ -391,7 +438,8 @@ def _recommendation_diagnostics(
         if best_forecast.score >= best_simple.score:
             diagnostics.append(
                 "forecasting did not beat simpler controls: "
-                f"best_forecast={best_forecast.method} score={best_forecast.score:.3f}, "
+                f"best_forecast={best_forecast.method} "
+                f"score={best_forecast.score:.3f}, "
                 f"best_simple={best_simple.method} score={best_simple.score:.3f}"
             )
     return diagnostics

--- a/src/fleet-sim/fleet_sim/optimizer/forecast.py
+++ b/src/fleet-sim/fleet_sim/optimizer/forecast.py
@@ -1,0 +1,432 @@
+"""FleetOptimizer backtests for workload archetype forecasts."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ..workload.forecast import (
+    AggregateWindow,
+    ForecastedWindow,
+    WorkloadForecastScenario,
+    detect_aggregate_diagnostics,
+    forecast_to_mixture_scenario,
+    validate_forecast_scenario,
+)
+from ..workload.forecasting import ReactiveLastWindowForecaster, default_forecasters
+from .base import FleetOptimizer
+from .forecast_models import (
+    ForecastBacktestError,
+    ForecastBacktestReport,
+    ForecastCapacityRecommendation,
+    ForecastMethodBacktest,
+    ForecastWindowBacktest,
+)
+from .mixture import evaluate_mixture_scenario
+from .mixture_models import MixtureOptimizationReport
+
+
+def evaluate_forecast_backtest(
+    optimizer: FleetOptimizer,
+    scenario: WorkloadForecastScenario,
+    gammas: list[float] | None = None,
+    moving_window_count: int = 3,
+    season_length_windows: int = 3,
+    trend_window_count: int = 4,
+    forecasters: Sequence[Any] | None = None,
+    n_sim_requests: int = 0,
+    verify_top_n: int = 0,
+    max_total_gpus: int | None = None,
+    now_s: float | None = None,
+    fail_on_stale: bool = False,
+    verbose: bool = False,
+) -> ForecastBacktestReport:
+    """Backtest proactive forecast recommendations against observed holdout windows."""
+
+    validate_forecast_scenario(scenario)
+    if not scenario.holdout_windows:
+        raise ForecastBacktestError("holdout_windows are required for backtesting")
+    gammas = gammas or [round(1.0 + 0.1 * k, 1) for k in range(11)]
+    actual_windows = scenario.holdout_windows[: scenario.forecast_horizon_windows]
+    if not actual_windows:
+        raise ForecastBacktestError("forecast_horizon_windows selects no holdout data")
+
+    source_mixture = scenario.load_source_mixture()
+    base_lam = _mean([window.arrival_rate for window in scenario.aggregate_windows])
+    if base_lam <= 0:
+        raise ForecastBacktestError("aggregate_windows have zero arrival rate")
+
+    actual_report, actual_required = _actual_holdout_report(
+        optimizer,
+        scenario,
+        source_mixture,
+        actual_windows,
+        base_lam,
+        gammas,
+        n_sim_requests,
+        verify_top_n,
+        max_total_gpus,
+        verbose,
+    )
+
+    stale_reason = scenario.stale_reason(now_s)
+    if stale_reason and fail_on_stale:
+        raise ForecastBacktestError(stale_reason)
+    active_forecasters = _active_forecasters(
+        stale_reason,
+        forecasters,
+        moving_window_count,
+        season_length_windows,
+        trend_window_count,
+    )
+
+    methods = tuple(
+        _evaluate_method(
+            optimizer=optimizer,
+            scenario=scenario,
+            source_mixture=source_mixture,
+            actual_windows=actual_windows,
+            actual_required=actual_required,
+            base_lam=base_lam,
+            forecaster=forecaster,
+            gammas=gammas,
+            n_sim_requests=n_sim_requests,
+            verify_top_n=verify_top_n,
+            max_total_gpus=max_total_gpus,
+            verbose=verbose,
+        )
+        for forecaster in active_forecasters
+    )
+    _annotate_control_comparison(methods)
+    diagnostics, recommended_method, fallback_control, rollback_reason = (
+        _final_decision(
+            scenario,
+            actual_windows,
+            actual_required,
+            methods,
+            stale_reason,
+        )
+    )
+
+    return ForecastBacktestReport(
+        scenario_id=scenario.id,
+        scenario_version=scenario.version,
+        source_mixture_id=source_mixture.id,
+        base_lam=base_lam,
+        methods=methods,
+        actual_report=actual_report,
+        actual_required=actual_required,
+        recommended_method=recommended_method,
+        diagnostics=tuple(diagnostics),
+        actuation_records=(),
+        fail_safe_triggered=stale_reason is not None,
+        fallback_control=fallback_control,
+        rollback_reason=rollback_reason,
+    )
+
+
+def _final_decision(
+    scenario: WorkloadForecastScenario,
+    actual_windows: Sequence[AggregateWindow],
+    actual_required: ForecastCapacityRecommendation | None,
+    methods: Sequence[ForecastMethodBacktest],
+    stale_reason: str | None,
+) -> tuple[tuple[str, ...], str | None, str | None, str | None]:
+    diagnostics = list(
+        detect_aggregate_diagnostics(scenario.aggregate_windows, actual_windows)
+    )
+    diagnostics.extend(_recommendation_diagnostics(methods, actual_required))
+    recommended_method = _recommended_method(methods, diagnostics)
+    fallback_control = None
+    rollback_reason = None
+    if stale_reason:
+        fallback_control = "reactive_last_window"
+        rollback_reason = stale_reason
+        diagnostics.append(
+            "stale forecast data; rolling back recommendations to reactive_last_window"
+        )
+        recommended_method = "reactive_last_window"
+    return tuple(diagnostics), recommended_method, fallback_control, rollback_reason
+
+
+def _actual_holdout_report(
+    optimizer: FleetOptimizer,
+    scenario: WorkloadForecastScenario,
+    source_mixture,
+    actual_windows: Sequence[AggregateWindow],
+    base_lam: float,
+    gammas: list[float],
+    n_sim_requests: int,
+    verify_top_n: int,
+    max_total_gpus: int | None,
+    verbose: bool,
+) -> tuple[MixtureOptimizationReport, ForecastCapacityRecommendation | None]:
+    actual_mixture = forecast_to_mixture_scenario(
+        source_mixture=source_mixture,
+        windows=actual_windows,
+        base_lam=base_lam,
+        scenario_id=f"{scenario.id}:actual-holdout",
+        version=scenario.version,
+        description="Observed holdout aggregate windows for forecast backtesting.",
+        metadata={"source": "holdout_aggregates"},
+    )
+    report = evaluate_mixture_scenario(
+        optimizer=optimizer,
+        scenario=actual_mixture,
+        lam=base_lam,
+        gammas=gammas,
+        n_sim_requests=n_sim_requests,
+        verify_top_n=verify_top_n,
+        max_total_gpus=max_total_gpus,
+        fail_on_infeasible=False,
+        verbose=verbose,
+    )
+    return (
+        report,
+        _capacity_recommendation(
+            "actual_holdout",
+            report,
+            optimizer,
+            source="actual_holdout",
+        ),
+    )
+
+
+def _active_forecasters(
+    stale_reason: str | None,
+    forecasters: Sequence[Any] | None,
+    moving_window_count: int,
+    season_length_windows: int,
+    trend_window_count: int,
+) -> Sequence[Any]:
+    if stale_reason:
+        return (ReactiveLastWindowForecaster(),)
+    return forecasters or default_forecasters(
+        moving_window_count=moving_window_count,
+        season_length_windows=season_length_windows,
+        trend_window_count=trend_window_count,
+    )
+
+
+def _evaluate_method(
+    optimizer: FleetOptimizer,
+    scenario: WorkloadForecastScenario,
+    source_mixture,
+    actual_windows: Sequence[AggregateWindow],
+    actual_required: ForecastCapacityRecommendation | None,
+    base_lam: float,
+    forecaster: Any,
+    gammas: list[float],
+    n_sim_requests: int,
+    verify_top_n: int,
+    max_total_gpus: int | None,
+    verbose: bool,
+) -> ForecastMethodBacktest:
+    method = str(getattr(forecaster, "name", forecaster.__class__.__name__))
+    control_kind = str(getattr(forecaster, "control_kind", "forecast"))
+    forecast_windows = tuple(forecaster.forecast(scenario))
+    forecast_mixture = forecast_to_mixture_scenario(
+        source_mixture=source_mixture,
+        windows=forecast_windows,
+        base_lam=base_lam,
+        scenario_id=f"{scenario.id}:{method}",
+        version=scenario.version,
+        description=(
+            "Forecast-derived workload mixture scenario from content-free "
+            "aggregate windows."
+        ),
+        metadata={
+            "forecast_method": method,
+            "control_kind": control_kind,
+            "source_forecast_scenario": scenario.id,
+        },
+    )
+    mixture_report = evaluate_mixture_scenario(
+        optimizer=optimizer,
+        scenario=forecast_mixture,
+        lam=base_lam,
+        gammas=gammas,
+        n_sim_requests=n_sim_requests,
+        verify_top_n=verify_top_n,
+        max_total_gpus=max_total_gpus,
+        fail_on_infeasible=False,
+        verbose=verbose,
+    )
+    recommendation = _capacity_recommendation(
+        method,
+        mixture_report,
+        optimizer,
+        source="forecast_window",
+    )
+    diagnostics = []
+    if (
+        recommendation is not None
+        and actual_required is not None
+        and recommendation.total_gpus < actual_required.total_gpus
+    ):
+        diagnostics.append(
+            f"{method} under-provisions observed holdout by "
+            f"{actual_required.total_gpus - recommendation.total_gpus} GPUs"
+        )
+    return ForecastMethodBacktest(
+        method=method,
+        control_kind=control_kind,
+        forecast_windows=forecast_windows,
+        window_results=_window_results(forecast_windows, actual_windows),
+        mixture_report=mixture_report,
+        recommendation=recommendation,
+        actual_required=actual_required,
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _capacity_recommendation(
+    method: str,
+    report: MixtureOptimizationReport,
+    optimizer: FleetOptimizer,
+    source: str,
+) -> ForecastCapacityRecommendation | None:
+    cases = [
+        case
+        for case in report.cases
+        if case.kind == "composition_window" and case.best is not None
+    ]
+    if not cases:
+        cases = [
+            case
+            for case in report.cases
+            if case.case_id == report.nominal_case_id and case.best is not None
+        ]
+    if not cases:
+        return None
+    n_s = max(case.best.n_s for case in cases if case.best is not None)
+    n_l = max(case.best.n_l for case in cases if case.best is not None)
+    total = n_s + n_l
+    cost_hr = (
+        n_s * optimizer.gpu_short.cost_per_hr + n_l * optimizer.gpu_long.cost_per_hr
+    )
+    worst = max(
+        cases,
+        key=lambda case: case.best.annualised_cost_kusd if case.best else 0.0,
+    )
+    best = worst.best
+    return ForecastCapacityRecommendation(
+        method=method,
+        n_s=n_s,
+        n_l=n_l,
+        total_gpus=total,
+        cost_per_hr=cost_hr,
+        annualised_cost_kusd=cost_hr * 8760 / 1000,
+        worst_case_id=worst.case_id,
+        slo_met=all(case.slo_met for case in cases),
+        gamma=best.gamma if best else 1.0,
+        source=source,
+    )
+
+
+def _window_results(
+    forecast_windows: Sequence[ForecastedWindow],
+    actual_windows: Sequence[AggregateWindow],
+) -> tuple[ForecastWindowBacktest, ...]:
+    rows = []
+    for forecast, actual in zip(forecast_windows, actual_windows):
+        actual_rate = actual.arrival_rate
+        forecast_rate = forecast.arrival_rate
+        error_pct = (
+            (forecast_rate - actual_rate) / actual_rate * 100.0
+            if actual_rate > 0
+            else 0.0
+        )
+        uncertainty = float(forecast.uncertainty.get("arrival_rate_stddev", 0.0) or 0.0)
+        rows.append(
+            ForecastWindowBacktest(
+                start_s=actual.start_s,
+                duration_s=actual.duration_s,
+                actual_arrival_rate=actual_rate,
+                forecast_arrival_rate=forecast_rate,
+                arrival_rate_error_pct=error_pct,
+                weight_l1_error=_weight_l1(
+                    forecast.archetype_weights, actual.archetype_weights
+                ),
+                actual_weights=dict(actual.archetype_weights),
+                forecast_weights=dict(forecast.archetype_weights),
+                covered_by_arrival_uncertainty=(
+                    abs(forecast_rate - actual_rate) <= uncertainty
+                ),
+            )
+        )
+    return tuple(rows)
+
+
+def _annotate_control_comparison(methods: Sequence[ForecastMethodBacktest]) -> None:
+    static = next((item for item in methods if item.control_kind == "static"), None)
+    reactive = next((item for item in methods if item.control_kind == "reactive"), None)
+    for method in methods:
+        method.beats_static_control = (
+            method.score < static.score
+            if static is not None and method is not static
+            else None
+        )
+        method.beats_reactive_control = (
+            method.score < reactive.score
+            if reactive is not None and method is not reactive
+            else None
+        )
+
+
+def _recommendation_diagnostics(
+    methods: Sequence[ForecastMethodBacktest],
+    actual_required: ForecastCapacityRecommendation | None,
+) -> list[str]:
+    diagnostics = [item for method in methods for item in method.diagnostics]
+    if actual_required is None:
+        diagnostics.append("observed holdout produced no capacity recommendation")
+    forecast_methods = [item for item in methods if item.control_kind == "forecast"]
+    simple_controls = [
+        item for item in methods if item.control_kind in {"static", "reactive"}
+    ]
+    if forecast_methods and simple_controls:
+        best_forecast = min(forecast_methods, key=lambda item: item.score)
+        best_simple = min(simple_controls, key=lambda item: item.score)
+        if best_forecast.score >= best_simple.score:
+            diagnostics.append(
+                "forecasting did not beat simpler controls: "
+                f"best_forecast={best_forecast.method} score={best_forecast.score:.3f}, "
+                f"best_simple={best_simple.method} score={best_simple.score:.3f}"
+            )
+    return diagnostics
+
+
+def _recommended_method(
+    methods: Sequence[ForecastMethodBacktest],
+    diagnostics: list[str],
+) -> str | None:
+    eligible = [method for method in methods if method.recommendation is not None]
+    if not eligible:
+        return None
+    forecast_methods = [item for item in eligible if item.control_kind == "forecast"]
+    simple_controls = [
+        item for item in eligible if item.control_kind in {"static", "reactive"}
+    ]
+    if not forecast_methods or not simple_controls:
+        return min(eligible, key=lambda item: item.score).method
+    best_forecast = min(forecast_methods, key=lambda item: item.score)
+    best_simple = min(simple_controls, key=lambda item: item.score)
+    if best_forecast.score < best_simple.score:
+        return best_forecast.method
+    diagnostics.append(
+        "using simpler control because forecast error is not lower than baseline"
+    )
+    return best_simple.method
+
+
+def _weight_l1(left: dict[str, float], right: dict[str, float]) -> float:
+    ids = set(left) | set(right)
+    return sum(
+        abs(left.get(archetype_id, 0.0) - right.get(archetype_id, 0.0))
+        for archetype_id in ids
+    )
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0

--- a/src/fleet-sim/fleet_sim/optimizer/forecast_models.py
+++ b/src/fleet-sim/fleet_sim/optimizer/forecast_models.py
@@ -1,0 +1,212 @@
+"""Report models for workload archetype forecast backtests."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from ..workload.forecast import ForecastedWindow
+from .mixture_models import MixtureOptimizationReport
+
+
+class ForecastBacktestError(RuntimeError):
+    """Raised when forecast backtesting is explicitly required to pass."""
+
+
+@dataclass(frozen=True)
+class ForecastCapacityRecommendation:
+    """Advise-only fleet capacity recommendation derived from forecast windows."""
+
+    method: str
+    n_s: int
+    n_l: int
+    total_gpus: int
+    cost_per_hr: float
+    annualised_cost_kusd: float
+    worst_case_id: str
+    slo_met: bool
+    gamma: float
+    source: str = "forecast_window"
+
+
+@dataclass(frozen=True)
+class ForecastActuationRecord:
+    """Downstream acknowledgement/action record, stored separately by design."""
+
+    method: str
+    status: str
+    downstream_action: str | None = None
+    acknowledged_at_s: float | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ForecastWindowBacktest:
+    """One forecast-vs-actual aggregate window comparison."""
+
+    start_s: float
+    duration_s: float
+    actual_arrival_rate: float
+    forecast_arrival_rate: float
+    arrival_rate_error_pct: float
+    weight_l1_error: float
+    actual_weights: dict[str, float]
+    forecast_weights: dict[str, float]
+    covered_by_arrival_uncertainty: bool
+
+
+@dataclass
+class ForecastMethodBacktest:
+    """Backtest result for one control/forecast method."""
+
+    method: str
+    control_kind: str
+    forecast_windows: tuple[ForecastedWindow, ...]
+    window_results: tuple[ForecastWindowBacktest, ...]
+    mixture_report: MixtureOptimizationReport
+    recommendation: ForecastCapacityRecommendation | None
+    actual_required: ForecastCapacityRecommendation | None
+    diagnostics: tuple[str, ...] = ()
+    beats_static_control: bool | None = None
+    beats_reactive_control: bool | None = None
+
+    @property
+    def mean_abs_arrival_rate_error_pct(self) -> float:
+        if not self.window_results:
+            return 0.0
+        return sum(
+            abs(item.arrival_rate_error_pct) for item in self.window_results
+        ) / len(self.window_results)
+
+    @property
+    def mean_weight_l1_error(self) -> float:
+        if not self.window_results:
+            return 0.0
+        return sum(item.weight_l1_error for item in self.window_results) / len(
+            self.window_results
+        )
+
+    @property
+    def score(self) -> float:
+        return self.mean_weight_l1_error + self.mean_abs_arrival_rate_error_pct / 100.0
+
+    @property
+    def headroom_gpus_vs_actual(self) -> int | None:
+        if self.recommendation is None or self.actual_required is None:
+            return None
+        return self.recommendation.total_gpus - self.actual_required.total_gpus
+
+
+@dataclass
+class ForecastBacktestReport:
+    """Structured backtest report for proactive archetype forecasts."""
+
+    scenario_id: str
+    scenario_version: str
+    source_mixture_id: str
+    base_lam: float
+    methods: tuple[ForecastMethodBacktest, ...]
+    actual_report: MixtureOptimizationReport
+    actual_required: ForecastCapacityRecommendation | None
+    recommended_method: str | None
+    diagnostics: tuple[str, ...] = ()
+    actuation_records: tuple[ForecastActuationRecord, ...] = ()
+    fail_safe_triggered: bool = False
+    fallback_control: str | None = None
+    rollback_reason: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.actual_required is not None and all(
+            method.recommendation is not None for method in self.methods
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "scenario_version": self.scenario_version,
+            "source_mixture_id": self.source_mixture_id,
+            "base_lam": self.base_lam,
+            "ok": self.ok,
+            "fail_safe_triggered": self.fail_safe_triggered,
+            "fallback_control": self.fallback_control,
+            "rollback_reason": self.rollback_reason,
+            "recommended_method": self.recommended_method,
+            "actual_required": (
+                asdict(self.actual_required) if self.actual_required else None
+            ),
+            "diagnostics": list(self.diagnostics),
+            "actuation_records": [asdict(item) for item in self.actuation_records],
+            "actual_report": self.actual_report.to_dict(),
+            "methods": [_method_to_dict(item) for item in self.methods],
+        }
+
+    def print_report(self) -> None:
+        print("\nForecast Backtest Report")
+        print(
+            f"  scenario={self.scenario_id} version={self.scenario_version} "
+            f"source_mixture={self.source_mixture_id} base_lambda={self.base_lam:.2f}"
+        )
+        if self.actual_required:
+            print(
+                f"  actual required: n_s={self.actual_required.n_s} "
+                f"n_l={self.actual_required.n_l} "
+                f"total={self.actual_required.total_gpus} GPUs"
+            )
+        if self.fail_safe_triggered:
+            print(
+                f"  fail-safe: {self.fallback_control} "
+                f"rollback_reason={self.rollback_reason}"
+            )
+        print("\n  Recommendations are advise-only; actuation is recorded separately.")
+        if self.actuation_records:
+            for record in self.actuation_records:
+                print(
+                    f"  actuation: method={record.method} status={record.status} "
+                    f"action={record.downstream_action}"
+                )
+        else:
+            print("  actuation: none recorded")
+        print("\n  Methods:")
+        print(
+            "  method                 kind       err_rate  err_mix  GPUs  headroom  status"
+        )
+        for method in self.methods:
+            rec = method.recommendation
+            gpus = rec.total_gpus if rec else 0
+            headroom = method.headroom_gpus_vs_actual
+            headroom_text = f"{headroom:+d}" if headroom is not None else "n/a"
+            status = "ok" if rec and rec.slo_met else "no recommendation"
+            print(
+                f"  {method.method:<22} {method.control_kind:<10} "
+                f"{method.mean_abs_arrival_rate_error_pct:>7.1f}% "
+                f"{method.mean_weight_l1_error:>7.3f} "
+                f"{gpus:>5} {headroom_text:>9}  {status}"
+            )
+        if self.recommended_method:
+            print(f"  recommended_method: {self.recommended_method}")
+        for diagnostic in self.diagnostics:
+            print(f"  diagnostic: {diagnostic}")
+
+
+def _method_to_dict(method: ForecastMethodBacktest) -> dict[str, Any]:
+    return {
+        "method": method.method,
+        "control_kind": method.control_kind,
+        "mean_abs_arrival_rate_error_pct": method.mean_abs_arrival_rate_error_pct,
+        "mean_weight_l1_error": method.mean_weight_l1_error,
+        "score": method.score,
+        "beats_static_control": method.beats_static_control,
+        "beats_reactive_control": method.beats_reactive_control,
+        "headroom_gpus_vs_actual": method.headroom_gpus_vs_actual,
+        "recommendation": (
+            asdict(method.recommendation) if method.recommendation else None
+        ),
+        "actual_required": (
+            asdict(method.actual_required) if method.actual_required else None
+        ),
+        "diagnostics": list(method.diagnostics),
+        "window_results": [asdict(item) for item in method.window_results],
+        "forecast_windows": [asdict(item) for item in method.forecast_windows],
+        "mixture_report": method.mixture_report.to_dict(),
+    }

--- a/src/fleet-sim/fleet_sim/optimizer/forecast_models.py
+++ b/src/fleet-sim/fleet_sim/optimizer/forecast_models.py
@@ -49,6 +49,15 @@ class ForecastWindowBacktest:
     actual_arrival_rate: float
     forecast_arrival_rate: float
     arrival_rate_error_pct: float
+    actual_tokens_per_request: float
+    forecast_tokens_per_request: float
+    tokens_per_request_error_pct: float
+    actual_p95_total_tokens: int | None
+    forecast_p95_total_tokens: int | None
+    p95_total_tokens_error_pct: float | None
+    actual_p99_ttft_ms: float | None
+    forecast_p99_ttft_ms: float | None
+    p99_ttft_error_pct: float | None
     weight_l1_error: float
     actual_weights: dict[str, float]
     forecast_weights: dict[str, float]
@@ -87,8 +96,40 @@ class ForecastMethodBacktest:
         )
 
     @property
+    def mean_abs_tokens_per_request_error_pct(self) -> float:
+        if not self.window_results:
+            return 0.0
+        return sum(
+            abs(item.tokens_per_request_error_pct) for item in self.window_results
+        ) / len(self.window_results)
+
+    @property
+    def mean_abs_p95_total_tokens_error_pct(self) -> float:
+        values = [
+            abs(item.p95_total_tokens_error_pct)
+            for item in self.window_results
+            if item.p95_total_tokens_error_pct is not None
+        ]
+        return sum(values) / len(values) if values else 0.0
+
+    @property
+    def mean_abs_p99_ttft_error_pct(self) -> float:
+        values = [
+            abs(item.p99_ttft_error_pct)
+            for item in self.window_results
+            if item.p99_ttft_error_pct is not None
+        ]
+        return sum(values) / len(values) if values else 0.0
+
+    @property
     def score(self) -> float:
-        return self.mean_weight_l1_error + self.mean_abs_arrival_rate_error_pct / 100.0
+        demand_error_pct = (
+            self.mean_abs_arrival_rate_error_pct
+            + self.mean_abs_tokens_per_request_error_pct
+            + self.mean_abs_p95_total_tokens_error_pct
+            + self.mean_abs_p99_ttft_error_pct
+        ) / 4.0
+        return self.mean_weight_l1_error + demand_error_pct / 100.0
 
     @property
     def headroom_gpus_vs_actual(self) -> int | None:
@@ -169,7 +210,8 @@ class ForecastBacktestReport:
             print("  actuation: none recorded")
         print("\n  Methods:")
         print(
-            "  method                 kind       err_rate  err_mix  GPUs  headroom  status"
+            "  method                 kind       err_rate err_token  err_mix  GPUs  "
+            "headroom  status"
         )
         for method in self.methods:
             rec = method.recommendation
@@ -180,6 +222,7 @@ class ForecastBacktestReport:
             print(
                 f"  {method.method:<22} {method.control_kind:<10} "
                 f"{method.mean_abs_arrival_rate_error_pct:>7.1f}% "
+                f"{method.mean_abs_tokens_per_request_error_pct:>8.1f}% "
                 f"{method.mean_weight_l1_error:>7.3f} "
                 f"{gpus:>5} {headroom_text:>9}  {status}"
             )
@@ -194,6 +237,13 @@ def _method_to_dict(method: ForecastMethodBacktest) -> dict[str, Any]:
         "method": method.method,
         "control_kind": method.control_kind,
         "mean_abs_arrival_rate_error_pct": method.mean_abs_arrival_rate_error_pct,
+        "mean_abs_tokens_per_request_error_pct": (
+            method.mean_abs_tokens_per_request_error_pct
+        ),
+        "mean_abs_p95_total_tokens_error_pct": (
+            method.mean_abs_p95_total_tokens_error_pct
+        ),
+        "mean_abs_p99_ttft_error_pct": method.mean_abs_p99_ttft_error_pct,
         "mean_weight_l1_error": method.mean_weight_l1_error,
         "score": method.score,
         "beats_static_control": method.beats_static_control,

--- a/src/fleet-sim/fleet_sim/optimizer/mixture.py
+++ b/src/fleet-sim/fleet_sim/optimizer/mixture.py
@@ -213,11 +213,12 @@ def _window_case(
         "composition_window",
         lam * window.arrival_rate_multiplier,
         window.weights,
-        cdfs,
+        _scaled_cdfs(cdfs, window.token_scale),
         (
             f"Composition window {index} from {window.start_s:.0f}s to "
             f"{window.end_s:.0f}s."
         ),
+        token_scale=window.token_scale,
     )
 
 
@@ -228,6 +229,7 @@ def _case(
     weights: dict[str, float],
     cdfs: dict[str, list[tuple[int, float]]],
     description: str,
+    token_scale: float = 1.0,
 ) -> MixtureStressCase:
     return MixtureStressCase(
         id=case_id,
@@ -236,7 +238,35 @@ def _case(
         weights=dict(weights),
         cdf=aggregate_mixture_cdf(cdfs, weights),
         description=description,
+        token_scale=token_scale,
     )
+
+
+def _scaled_cdfs(
+    cdfs: dict[str, list[tuple[int, float]]],
+    token_scale: float,
+) -> dict[str, list[tuple[int, float]]]:
+    if abs(token_scale - 1.0) <= 1e-9:
+        return cdfs
+    return {
+        archetype_id: _scaled_cdf(cdf, token_scale)
+        for archetype_id, cdf in cdfs.items()
+    }
+
+
+def _scaled_cdf(
+    cdf: list[tuple[int, float]],
+    token_scale: float,
+) -> list[tuple[int, float]]:
+    scaled = []
+    previous = 0
+    for threshold, fraction in cdf:
+        scaled_threshold = max(previous + 1, round(threshold * token_scale))
+        scaled.append((scaled_threshold, fraction))
+        previous = scaled_threshold
+    if scaled:
+        scaled[-1] = (scaled[-1][0], 1.0)
+    return scaled
 
 
 def _evaluate_case(
@@ -264,6 +294,7 @@ def _evaluate_case(
         kind=case.kind,
         lam=case.lam,
         weights=case.weights,
+        token_scale=case.token_scale,
         best=best,
         baseline=baseline,
         sweep=tuple(report.analytical + report.simulated),

--- a/src/fleet-sim/fleet_sim/optimizer/mixture.py
+++ b/src/fleet-sim/fleet_sim/optimizer/mixture.py
@@ -1,0 +1,377 @@
+"""FleetOptimizer reporting for workload mixture scenarios."""
+
+from __future__ import annotations
+
+from ..workload.mixture import (
+    CompositionWindow,
+    MixtureScenario,
+    MixtureValidationError,
+    WorkloadArchetype,
+    _load_cdf_source,
+    validate_mixture_scenario,
+)
+from ..workload.trace import TraceWorkload
+from . import analytical
+from .base import FleetOptimizer, SweepResult
+from .mixture_models import (
+    MixtureCaseResult,
+    MixtureOptimizationError,
+    MixtureOptimizationReport,
+    MixtureStressCase,
+    RobustMixtureRecommendation,
+)
+
+
+def evaluate_mixture_scenario(
+    optimizer: FleetOptimizer,
+    scenario: MixtureScenario,
+    lam: float,
+    gammas: list[float] | None = None,
+    n_sim_requests: int = 0,
+    verify_top_n: int = 0,
+    max_total_gpus: int | None = None,
+    fail_on_infeasible: bool = False,
+    verbose: bool = False,
+) -> MixtureOptimizationReport:
+    """Evaluate FleetOptimizer sensitivity across mixture-derived stress cases."""
+
+    if lam <= 0:
+        raise ValueError("lam must be positive")
+    if max_total_gpus is not None and max_total_gpus <= 0:
+        raise ValueError("max_total_gpus must be positive")
+    validate_mixture_scenario(scenario)
+    gammas = gammas or [round(1.0 + 0.1 * k, 1) for k in range(11)]
+
+    archetype_cdfs = _archetype_cdfs(scenario)
+    cases = _stress_cases(scenario, archetype_cdfs, lam)
+    case_results = [
+        _evaluate_case(
+            optimizer,
+            case,
+            gammas,
+            n_sim_requests,
+            verify_top_n,
+            max_total_gpus,
+            verbose,
+        )
+        for case in cases
+    ]
+    _annotate_sensitivity(case_results)
+    robust = _robust_recommendation(
+        optimizer,
+        [case for case in cases if case.kind != "aggregate_cdf_baseline"],
+        gammas,
+        max_total_gpus,
+    )
+    diagnostics = _diagnostics(case_results, robust)
+    report = MixtureOptimizationReport(
+        scenario_id=scenario.id,
+        scenario_version=scenario.version,
+        lam=lam,
+        cases=tuple(case_results),
+        robust_recommendation=robust,
+        diagnostics=tuple(diagnostics),
+    )
+    if fail_on_infeasible and not report.ok:
+        raise MixtureOptimizationError(
+            "; ".join(report.diagnostics) or "mixture infeasible"
+        )
+    return report
+
+
+def aggregate_mixture_cdf(
+    cdfs: dict[str, list[tuple[int, float]]],
+    weights: dict[str, float],
+) -> list[tuple[int, float]]:
+    """Collapse weighted archetype CDFs into one aggregate marginal CDF."""
+
+    missing = sorted(set(weights) - set(cdfs))
+    if missing:
+        raise MixtureValidationError(f"missing CDFs for archetypes: {missing}")
+    total = sum(weights.values())
+    if abs(total - 1.0) > 1e-6:
+        raise MixtureValidationError(f"weights must sum to 1.0, got {total:.6f}")
+    points = sorted(
+        {threshold for archetype_id in weights for threshold, _ in cdfs[archetype_id]}
+    )
+    aggregate = [
+        (
+            threshold,
+            min(
+                1.0,
+                max(
+                    0.0,
+                    sum(
+                        weights[archetype_id]
+                        * analytical.cdf_eval(cdfs[archetype_id], threshold)
+                        for archetype_id in weights
+                    ),
+                ),
+            ),
+        )
+        for threshold in points
+    ]
+    if aggregate:
+        aggregate[-1] = (aggregate[-1][0], 1.0)
+    return aggregate
+
+
+def _archetype_cdfs(scenario: MixtureScenario) -> dict[str, list[tuple[int, float]]]:
+    return {
+        archetype.id: _cdf_for_archetype(archetype, scenario)
+        for archetype in scenario.archetypes
+    }
+
+
+def _cdf_for_archetype(
+    archetype: WorkloadArchetype,
+    scenario: MixtureScenario,
+) -> list[tuple[int, float]]:
+    if archetype.source.kind == "cdf":
+        return _load_cdf_source(archetype.source, scenario.base_dir)
+    trace = TraceWorkload(
+        str(archetype.source.resolve_path(scenario.base_dir)),
+        fmt=archetype.source.format or "semantic_router",
+        max_reqs=archetype.source.max_reqs,
+        field_map=archetype.source.field_map,
+        model_id_field=archetype.source.model_id_field,
+        default_model_id=archetype.source.default_model_id,
+    )
+    totals = sorted(req.total_tokens() for _, req in trace.generate())
+    if not totals:
+        raise MixtureValidationError(
+            f"{archetype.id}: trace source produced no requests"
+        )
+    return _empirical_cdf(totals)
+
+
+def _empirical_cdf(totals: list[int]) -> list[tuple[int, float]]:
+    n = len(totals)
+    cdf: list[tuple[int, float]] = []
+    last = None
+    for idx, total in enumerate(totals, start=1):
+        if total == last and idx < n:
+            continue
+        cdf.append((total, idx / n))
+        last = total
+    cdf[-1] = (cdf[-1][0], 1.0)
+    return cdf
+
+
+def _stress_cases(
+    scenario: MixtureScenario,
+    cdfs: dict[str, list[tuple[int, float]]],
+    lam: float,
+) -> list[MixtureStressCase]:
+    cases = [
+        _case(
+            "aggregate-cdf",
+            "aggregate_cdf_baseline",
+            lam,
+            scenario.nominal_weights,
+            cdfs,
+            "Collapsed aggregate CDF baseline at nominal weights.",
+        ),
+        _case(
+            "nominal-mixture",
+            "nominal_mixture",
+            lam,
+            scenario.nominal_weights,
+            cdfs,
+            "Versioned nominal workload mixture.",
+        ),
+    ]
+    for archetype_id in scenario.archetype_ids:
+        weights = {
+            item: 1.0 if item == archetype_id else 0.0
+            for item in scenario.archetype_ids
+        }
+        cases.append(
+            _case(
+                f"archetype:{archetype_id}",
+                "individual_archetype",
+                lam,
+                weights,
+                cdfs,
+                f"All traffic follows archetype {archetype_id}.",
+            )
+        )
+    for index, window in enumerate(scenario.composition_schedule):
+        cases.append(_window_case(index, window, scenario, cdfs, lam))
+    return cases
+
+
+def _window_case(
+    index: int,
+    window: CompositionWindow,
+    scenario: MixtureScenario,
+    cdfs: dict[str, list[tuple[int, float]]],
+    lam: float,
+) -> MixtureStressCase:
+    return _case(
+        f"window:{index}",
+        "composition_window",
+        lam * window.arrival_rate_multiplier,
+        window.weights,
+        cdfs,
+        (
+            f"Composition window {index} from {window.start_s:.0f}s to "
+            f"{window.end_s:.0f}s."
+        ),
+    )
+
+
+def _case(
+    case_id: str,
+    kind: str,
+    lam: float,
+    weights: dict[str, float],
+    cdfs: dict[str, list[tuple[int, float]]],
+    description: str,
+) -> MixtureStressCase:
+    return MixtureStressCase(
+        id=case_id,
+        kind=kind,
+        lam=lam,
+        weights=dict(weights),
+        cdf=aggregate_mixture_cdf(cdfs, weights),
+        description=description,
+    )
+
+
+def _evaluate_case(
+    optimizer: FleetOptimizer,
+    case: MixtureStressCase,
+    gammas: list[float],
+    n_sim_requests: int,
+    verify_top_n: int,
+    max_total_gpus: int | None,
+    verbose: bool,
+) -> MixtureCaseResult:
+    report = optimizer.optimize(
+        cdf=case.cdf,
+        lam=case.lam,
+        gammas=gammas,
+        n_sim_requests=n_sim_requests,
+        verify_top_n=verify_top_n,
+        verbose=verbose,
+    )
+    best = report.best_simulated or report.best_analytical
+    baseline = next((item for item in report.analytical if item.gamma == 1.0), None)
+    reason = _infeasible_reason(best, max_total_gpus)
+    return MixtureCaseResult(
+        case_id=case.id,
+        kind=case.kind,
+        lam=case.lam,
+        weights=case.weights,
+        best=best,
+        baseline=baseline,
+        sweep=tuple(report.analytical + report.simulated),
+        infeasible_reason=reason,
+    )
+
+
+def _infeasible_reason(
+    best: SweepResult | None, max_total_gpus: int | None
+) -> str | None:
+    if best is None:
+        return "FleetOptimizer produced no candidates"
+    if not best.slo_met:
+        return (
+            f"best candidate violates SLO: short={best.p99_ttft_short_ms:.1f}ms "
+            f"long={best.p99_ttft_long_ms:.1f}ms"
+        )
+    if max_total_gpus is not None and best.total_gpus > max_total_gpus:
+        return (
+            f"requires {best.total_gpus} GPUs, exceeds max_total_gpus={max_total_gpus}"
+        )
+    return None
+
+
+def _annotate_sensitivity(results: list[MixtureCaseResult]) -> None:
+    nominal = next(
+        (case for case in results if case.case_id == "nominal-mixture"), None
+    )
+    if nominal is None or nominal.best is None:
+        return
+    base = nominal.best.annualised_cost_kusd
+    for case in results:
+        if case.best is None:
+            continue
+        delta = case.best.annualised_cost_kusd - base
+        case.annual_cost_delta_vs_nominal_kusd = delta
+        case.cost_sensitivity_pct = (delta / base * 100.0) if base > 0 else 0.0
+
+
+def _robust_recommendation(
+    optimizer: FleetOptimizer,
+    cases: list[MixtureStressCase],
+    gammas: list[float],
+    max_total_gpus: int | None,
+) -> RobustMixtureRecommendation | None:
+    candidates: list[RobustMixtureRecommendation] = []
+    for gamma in gammas:
+        per_case = [
+            (
+                case,
+                optimizer.sweep_analytical(case.cdf, case.lam, [gamma], verbose=False)[
+                    0
+                ],
+            )
+            for case in cases
+        ]
+        if any(not result.slo_met for _, result in per_case):
+            continue
+        n_s = max(result.n_s for _, result in per_case)
+        n_l = max(result.n_l for _, result in per_case)
+        total = n_s + n_l
+        if max_total_gpus is not None and total > max_total_gpus:
+            continue
+        cost_hr = (
+            n_s * optimizer.gpu_short.cost_per_hr + n_l * optimizer.gpu_long.cost_per_hr
+        )
+        worst_case, worst = max(
+            per_case,
+            key=lambda item: max(item[1].p99_ttft_short_ms, item[1].p99_ttft_long_ms),
+        )
+        candidates.append(
+            RobustMixtureRecommendation(
+                gamma=gamma,
+                n_s=n_s,
+                n_l=n_l,
+                total_gpus=total,
+                cost_per_hr=cost_hr,
+                annualised_cost_kusd=cost_hr * 8760 / 1000,
+                worst_case_id=worst_case.id,
+                worst_p99_ttft_short_ms=worst.p99_ttft_short_ms,
+                worst_p99_ttft_long_ms=worst.p99_ttft_long_ms,
+                slo_met=True,
+            )
+        )
+    if candidates:
+        return min(candidates, key=lambda item: item.cost_per_hr)
+    return None
+
+
+def _diagnostics(
+    cases: list[MixtureCaseResult],
+    robust: RobustMixtureRecommendation | None,
+) -> list[str]:
+    diagnostics = [
+        f"{case.case_id}: {case.infeasible_reason}"
+        for case in cases
+        if case.infeasible_reason
+    ]
+    worst = max(
+        (case for case in cases if case.best is not None),
+        key=lambda case: case.best.annualised_cost_kusd,
+        default=None,
+    )
+    if worst is not None:
+        diagnostics.append(
+            f"worst-case mixture by cost is {worst.case_id} at "
+            f"${worst.best.annualised_cost_kusd:.1f}K/yr"
+        )
+    if robust is None:
+        diagnostics.append("no robust recommendation satisfies all stress cases")
+    return diagnostics

--- a/src/fleet-sim/fleet_sim/optimizer/mixture_models.py
+++ b/src/fleet-sim/fleet_sim/optimizer/mixture_models.py
@@ -1,0 +1,162 @@
+"""Report models for FleetOptimizer workload mixture evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from .base import SweepResult
+
+
+class MixtureOptimizationError(RuntimeError):
+    """Raised when a mixture optimization report is explicitly required to pass."""
+
+
+@dataclass(frozen=True)
+class MixtureStressCase:
+    """One distribution/arrival-rate case derived from a mixture scenario."""
+
+    id: str
+    kind: str
+    lam: float
+    weights: dict[str, float]
+    cdf: list[tuple[int, float]]
+    description: str = ""
+
+
+@dataclass
+class MixtureCaseResult:
+    """FleetOptimizer result for one mixture stress case."""
+
+    case_id: str
+    kind: str
+    lam: float
+    weights: dict[str, float]
+    best: SweepResult | None
+    baseline: SweepResult | None
+    sweep: tuple[SweepResult, ...]
+    infeasible_reason: str | None = None
+    annual_cost_delta_vs_nominal_kusd: float | None = None
+    cost_sensitivity_pct: float | None = None
+
+    @property
+    def slo_met(self) -> bool:
+        return (
+            self.infeasible_reason is None
+            and self.best is not None
+            and self.best.slo_met
+        )
+
+
+@dataclass(frozen=True)
+class RobustMixtureRecommendation:
+    """A single gamma/fleet recommendation sized across all stress cases."""
+
+    gamma: float
+    n_s: int
+    n_l: int
+    total_gpus: int
+    cost_per_hr: float
+    annualised_cost_kusd: float
+    worst_case_id: str
+    worst_p99_ttft_short_ms: float
+    worst_p99_ttft_long_ms: float
+    slo_met: bool
+    infeasible_reason: str | None = None
+
+
+@dataclass
+class MixtureOptimizationReport:
+    """Comparison report for aggregate, nominal, stress, and robust mixture cases."""
+
+    scenario_id: str
+    scenario_version: str
+    lam: float
+    cases: tuple[MixtureCaseResult, ...]
+    robust_recommendation: RobustMixtureRecommendation | None
+    diagnostics: tuple[str, ...] = ()
+    aggregate_baseline_case_id: str = "aggregate-cdf"
+    nominal_case_id: str = "nominal-mixture"
+
+    @property
+    def ok(self) -> bool:
+        return self.robust_recommendation is not None and all(
+            case.slo_met for case in self.cases
+        )
+
+    @property
+    def worst_case(self) -> MixtureCaseResult | None:
+        feasible = [case for case in self.cases if case.best is not None]
+        if not feasible:
+            return None
+        return max(feasible, key=lambda case: case.best.annualised_cost_kusd)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "scenario_version": self.scenario_version,
+            "lam": self.lam,
+            "ok": self.ok,
+            "aggregate_baseline_case_id": self.aggregate_baseline_case_id,
+            "nominal_case_id": self.nominal_case_id,
+            "robust_recommendation": (
+                asdict(self.robust_recommendation)
+                if self.robust_recommendation is not None
+                else None
+            ),
+            "diagnostics": list(self.diagnostics),
+            "cases": [_case_to_dict(case) for case in self.cases],
+        }
+
+    def print_report(self) -> None:
+        print("\nMixture Optimization Report")
+        print(
+            f"  scenario={self.scenario_id} version={self.scenario_version} "
+            f"lambda={self.lam:.2f} req/s"
+        )
+        if self.robust_recommendation:
+            rr = self.robust_recommendation
+            print(
+                f"  robust: gamma={rr.gamma:.2f} n_s={rr.n_s} n_l={rr.n_l} "
+                f"total={rr.total_gpus} ${rr.annualised_cost_kusd:.1f}K/yr "
+                f"worst={rr.worst_case_id}"
+            )
+        else:
+            print("  robust: infeasible")
+        print("\n  Cases:")
+        print(
+            "  case                         kind                 lam     GPUs   "
+            "$K/yr   sensitivity  status"
+        )
+        for case in self.cases:
+            best = case.best
+            total = best.total_gpus if best else 0
+            cost = best.annualised_cost_kusd if best else 0.0
+            sensitivity = (
+                f"{case.cost_sensitivity_pct:+.1f}%"
+                if case.cost_sensitivity_pct is not None
+                else "n/a"
+            )
+            status = "ok" if case.slo_met else f"fail: {case.infeasible_reason}"
+            print(
+                f"  {case.case_id:<28} {case.kind:<20} {case.lam:>6.1f} "
+                f"{total:>6} {cost:>7.1f} {sensitivity:>11}  {status}"
+            )
+        for diagnostic in self.diagnostics:
+            print(f"  diagnostic: {diagnostic}")
+
+
+def _case_to_dict(case: MixtureCaseResult) -> dict[str, Any]:
+    return {
+        "case_id": case.case_id,
+        "kind": case.kind,
+        "lam": case.lam,
+        "weights": case.weights,
+        "best": asdict(case.best) if case.best is not None else None,
+        "baseline": asdict(case.baseline) if case.baseline is not None else None,
+        "sweep": [asdict(item) for item in case.sweep],
+        "slo_met": case.slo_met,
+        "infeasible_reason": case.infeasible_reason,
+        "annual_cost_delta_vs_nominal_kusd": case.annual_cost_delta_vs_nominal_kusd,
+        "cost_sensitivity_pct": case.cost_sensitivity_pct,
+    }

--- a/src/fleet-sim/fleet_sim/optimizer/mixture_models.py
+++ b/src/fleet-sim/fleet_sim/optimizer/mixture_models.py
@@ -22,6 +22,7 @@ class MixtureStressCase:
     weights: dict[str, float]
     cdf: list[tuple[int, float]]
     description: str = ""
+    token_scale: float = 1.0
 
 
 @dataclass
@@ -32,6 +33,7 @@ class MixtureCaseResult:
     kind: str
     lam: float
     weights: dict[str, float]
+    token_scale: float
     best: SweepResult | None
     baseline: SweepResult | None
     sweep: tuple[SweepResult, ...]
@@ -152,6 +154,7 @@ def _case_to_dict(case: MixtureCaseResult) -> dict[str, Any]:
         "kind": case.kind,
         "lam": case.lam,
         "weights": case.weights,
+        "token_scale": case.token_scale,
         "best": asdict(case.best) if case.best is not None else None,
         "baseline": asdict(case.baseline) if case.baseline is not None else None,
         "sweep": [asdict(item) for item in case.sweep],

--- a/src/fleet-sim/fleet_sim/workload/__init__.py
+++ b/src/fleet-sim/fleet_sim/workload/__init__.py
@@ -1,6 +1,33 @@
 """Workload generators for fleet simulation."""
 
+from .mixture import (
+    ArchetypeSource,
+    CompositionWindow,
+    MixtureScenario,
+    MixtureValidationError,
+    WorkloadArchetype,
+    load_mixture_scenario,
+    validate_cdf_points,
+    validate_mixture_scenario,
+)
+from .mixture_sampling import MixtureSampler
+from .mixture_validation import MixtureValidationReport, validate_sample_distribution
 from .synthetic import CdfWorkload, PoissonWorkload
 from .trace import TraceWorkload
 
-__all__ = ["CdfWorkload", "PoissonWorkload", "TraceWorkload"]
+__all__ = [
+    "ArchetypeSource",
+    "CdfWorkload",
+    "CompositionWindow",
+    "MixtureSampler",
+    "MixtureScenario",
+    "MixtureValidationError",
+    "MixtureValidationReport",
+    "PoissonWorkload",
+    "TraceWorkload",
+    "WorkloadArchetype",
+    "load_mixture_scenario",
+    "validate_cdf_points",
+    "validate_mixture_scenario",
+    "validate_sample_distribution",
+]

--- a/src/fleet-sim/fleet_sim/workload/__init__.py
+++ b/src/fleet-sim/fleet_sim/workload/__init__.py
@@ -1,5 +1,24 @@
 """Workload generators for fleet simulation."""
 
+from .forecast import (
+    AggregateWindow,
+    ForecastedWindow,
+    ForecastPrivacyPolicy,
+    ForecastValidationError,
+    WorkloadForecastScenario,
+    detect_aggregate_diagnostics,
+    forecast_to_mixture_scenario,
+    load_forecast_scenario,
+    validate_forecast_scenario,
+)
+from .forecasting import (
+    LinearTrendForecaster,
+    MovingWindowForecaster,
+    ReactiveLastWindowForecaster,
+    SeasonalNaiveForecaster,
+    StaticMeanForecaster,
+    default_forecasters,
+)
 from .mixture import (
     ArchetypeSource,
     CompositionWindow,
@@ -16,18 +35,33 @@ from .synthetic import CdfWorkload, PoissonWorkload
 from .trace import TraceWorkload
 
 __all__ = [
+    "AggregateWindow",
     "ArchetypeSource",
     "CdfWorkload",
     "CompositionWindow",
+    "ForecastPrivacyPolicy",
+    "ForecastValidationError",
+    "ForecastedWindow",
+    "LinearTrendForecaster",
     "MixtureSampler",
     "MixtureScenario",
     "MixtureValidationError",
     "MixtureValidationReport",
+    "MovingWindowForecaster",
     "PoissonWorkload",
+    "ReactiveLastWindowForecaster",
+    "SeasonalNaiveForecaster",
+    "StaticMeanForecaster",
     "TraceWorkload",
     "WorkloadArchetype",
+    "WorkloadForecastScenario",
+    "default_forecasters",
+    "detect_aggregate_diagnostics",
+    "forecast_to_mixture_scenario",
+    "load_forecast_scenario",
     "load_mixture_scenario",
     "validate_cdf_points",
+    "validate_forecast_scenario",
     "validate_mixture_scenario",
     "validate_sample_distribution",
 ]

--- a/src/fleet-sim/fleet_sim/workload/forecast.py
+++ b/src/fleet-sim/fleet_sim/workload/forecast.py
@@ -18,12 +18,42 @@ from .mixture import (
     CompositionWindow,
     MixtureScenario,
     MixtureValidationError,
+    WorkloadArchetype,
+    _load_cdf_source,
     load_mixture_scenario,
 )
+from .trace import TraceWorkload
 
 SCHEMA_VERSION = "fleet-sim.workload-archetype-forecast/v1alpha1"
 TAXONOMY_VERSION = "fleet-sim.workload-archetype-taxonomy/v1alpha1"
 WEIGHT_TOLERANCE = 1e-6
+
+WINDOW_DIMENSIONS = frozenset(
+    {
+        "archetype_weights",
+        "model_class",
+        "region",
+        "slo_class",
+    }
+)
+WINDOW_SCHEMA_FIELDS = frozenset(
+    {
+        "archetype_weights",
+        "duration_s",
+        "model_class",
+        "p50_total_tokens",
+        "p95_total_tokens",
+        "p99_ttft_ms",
+        "redacted",
+        "region",
+        "request_count",
+        "slo_class",
+        "start_s",
+        "total_tokens",
+        "uncertainty",
+        "weights",
+    }
+)
 
 DEFAULT_FORBIDDEN_DIMENSIONS = (
     "account_id",
@@ -106,10 +136,12 @@ class AggregateWindow:
     p99_ttft_ms: float | None = None
     uncertainty: dict[str, Any] = field(default_factory=dict)
     redacted: bool = False
+    extra_fields: tuple[str, ...] = ()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AggregateWindow:
         weights = data.get("archetype_weights", data.get("weights", {}))
+        extra_fields = tuple(sorted(set(data) - WINDOW_SCHEMA_FIELDS))
         return cls(
             start_s=float(data.get("start_s", 0.0)),
             duration_s=float(data.get("duration_s", 0.0)),
@@ -136,6 +168,7 @@ class AggregateWindow:
             ),
             uncertainty=dict(data.get("uncertainty") or {}),
             redacted=bool(data.get("redacted", False)),
+            extra_fields=extra_fields,
         )
 
     @property
@@ -168,6 +201,8 @@ class ForecastedWindow:
     model_class: str
     slo_class: str
     region: str
+    p50_total_tokens: int | None = None
+    p95_total_tokens: int | None = None
     p99_ttft_ms: float | None = None
     uncertainty: dict[str, Any] = field(default_factory=dict)
 
@@ -180,6 +215,12 @@ class ForecastedWindow:
         if self.duration_s <= 0:
             return 0.0
         return self.request_count / self.duration_s
+
+    @property
+    def tokens_per_request(self) -> float:
+        if self.request_count <= 0:
+            return 0.0
+        return self.total_tokens / self.request_count
 
 
 ForecastWindowLike = AggregateWindow | ForecastedWindow
@@ -313,6 +354,14 @@ def validate_forecast_scenario(
         errors.append("forecast_horizon_windows must be positive")
     if not scenario.aggregate_windows:
         errors.append("aggregate_windows must not be empty")
+    if scenario.holdout_windows and scenario.forecast_horizon_windows > len(
+        scenario.holdout_windows
+    ):
+        errors.append(
+            "forecast_horizon_windows exceeds available holdout_windows: "
+            f"horizon={scenario.forecast_horizon_windows} "
+            f"holdout_windows={len(scenario.holdout_windows)}"
+        )
 
     expected_ids: set[str] | None = None
     if scenario.source_mixture_path:
@@ -355,12 +404,14 @@ def forecast_to_mixture_scenario(
         raise ValueError("base_lam must be positive")
     if not windows:
         raise ValueError("windows must not be empty")
+    source_cdfs = _source_archetype_cdfs(source_mixture)
     schedule = tuple(
         CompositionWindow(
             start_s=window.start_s,
             duration_s=window.duration_s,
             weights=dict(window.archetype_weights),
             arrival_rate_multiplier=max(window.arrival_rate / base_lam, 1e-9),
+            token_scale=_window_token_scale(window, source_cdfs),
         )
         for window in windows
     )
@@ -422,9 +473,15 @@ def _validate_windows(
     expected_ids: set[str] | None,
     errors: list[str],
 ) -> None:
+    allowed_dimensions = {_normalise_key(item) for item in privacy.allowed_dimensions}
     last_end = None
     for idx, window in enumerate(windows):
         item = f"{label}[{idx}]"
+        if window.extra_fields:
+            errors.append(
+                f"{item}: fields are not allowed by forecast window schema: "
+                f"{list(window.extra_fields)}"
+            )
         if window.start_s < 0:
             errors.append(f"{item}: start_s must be non-negative")
         if window.duration_s <= 0:
@@ -442,13 +499,35 @@ def _validate_windows(
             )
         if window.total_tokens <= 0:
             errors.append(f"{item}: total_tokens must be positive")
+        if window.p50_total_tokens is not None and window.p50_total_tokens <= 0:
+            errors.append(f"{item}: p50_total_tokens must be positive")
+        if window.p95_total_tokens is not None and window.p95_total_tokens <= 0:
+            errors.append(f"{item}: p95_total_tokens must be positive")
+        if (
+            window.p50_total_tokens is not None
+            and window.p95_total_tokens is not None
+            and window.p50_total_tokens > window.p95_total_tokens
+        ):
+            errors.append(f"{item}: p50_total_tokens must be <= p95_total_tokens")
+        if window.p99_ttft_ms is not None and window.p99_ttft_ms <= 0:
+            errors.append(f"{item}: p99_ttft_ms must be positive")
         for dim_name, dim_value in (
             ("model_class", window.model_class),
             ("slo_class", window.slo_class),
             ("region", window.region),
         ):
+            if _normalise_key(dim_name) not in allowed_dimensions:
+                errors.append(
+                    f"{item}: dimension {dim_name!r} is not allowed by "
+                    "privacy.allowed_dimensions"
+                )
             if not dim_value:
                 errors.append(f"{item}: {dim_name} is required")
+        if "archetype_weights" not in allowed_dimensions:
+            errors.append(
+                f"{item}: dimension 'archetype_weights' is not allowed by "
+                "privacy.allowed_dimensions"
+            )
         _validate_weight_map(
             window.archetype_weights,
             expected_ids,
@@ -506,6 +585,126 @@ def _privacy_key_errors(
                 f"privacy violation: high-cardinality/content field {key!r} at {path}"
             )
     return errors
+
+
+def _source_archetype_cdfs(
+    source_mixture: MixtureScenario,
+) -> dict[str, list[tuple[int, float]]]:
+    return {
+        archetype.id: _cdf_for_archetype(archetype, source_mixture)
+        for archetype in source_mixture.archetypes
+    }
+
+
+def _cdf_for_archetype(
+    archetype: WorkloadArchetype,
+    source_mixture: MixtureScenario,
+) -> list[tuple[int, float]]:
+    if archetype.source.kind == "cdf":
+        return _load_cdf_source(archetype.source, source_mixture.base_dir)
+    trace = TraceWorkload(
+        str(archetype.source.resolve_path(source_mixture.base_dir)),
+        fmt=archetype.source.format or "semantic_router",
+        max_reqs=archetype.source.max_reqs,
+        field_map=archetype.source.field_map,
+        model_id_field=archetype.source.model_id_field,
+        default_model_id=archetype.source.default_model_id,
+    )
+    totals = sorted(req.total_tokens() for _, req in trace.generate())
+    if not totals:
+        raise ForecastValidationError(
+            f"{archetype.id}: trace source produced no requests"
+        )
+    return _empirical_cdf(totals)
+
+
+def _window_token_scale(
+    window: ForecastWindowLike,
+    source_cdfs: dict[str, list[tuple[int, float]]],
+) -> float:
+    baseline_cdf = _aggregate_cdf(source_cdfs, window.archetype_weights)
+    baseline_mean = _cdf_mean(baseline_cdf)
+    baseline_p50 = _cdf_quantile(baseline_cdf, 0.50)
+    baseline_p95 = _cdf_quantile(baseline_cdf, 0.95)
+    ratios = []
+    if window.tokens_per_request > 0 and baseline_mean > 0:
+        ratios.append(window.tokens_per_request / baseline_mean)
+    p50_total_tokens = getattr(window, "p50_total_tokens", None)
+    if p50_total_tokens is not None and baseline_p50 > 0:
+        ratios.append(float(p50_total_tokens) / baseline_p50)
+    p95_total_tokens = getattr(window, "p95_total_tokens", None)
+    if p95_total_tokens is not None and baseline_p95 > 0:
+        ratios.append(float(p95_total_tokens) / baseline_p95)
+    if not ratios:
+        return 1.0
+    return max(*ratios, 1e-9)
+
+
+def _aggregate_cdf(
+    cdfs: dict[str, list[tuple[int, float]]],
+    weights: dict[str, float],
+) -> list[tuple[int, float]]:
+    points = sorted(
+        {threshold for archetype_id in weights for threshold, _ in cdfs[archetype_id]}
+    )
+    aggregate = [
+        (
+            threshold,
+            min(
+                1.0,
+                max(
+                    0.0,
+                    sum(
+                        weights[archetype_id] * _cdf_eval(cdfs[archetype_id], threshold)
+                        for archetype_id in weights
+                    ),
+                ),
+            ),
+        )
+        for threshold in points
+    ]
+    if aggregate:
+        aggregate[-1] = (aggregate[-1][0], 1.0)
+    return aggregate
+
+
+def _cdf_eval(cdf: list[tuple[int, float]], threshold: int) -> float:
+    previous = 0.0
+    for token_threshold, fraction in cdf:
+        if threshold < token_threshold:
+            return previous
+        previous = fraction
+    return previous
+
+
+def _cdf_mean(cdf: list[tuple[int, float]]) -> float:
+    total = 0.0
+    previous_fraction = 0.0
+    for threshold, fraction in cdf:
+        probability = max(0.0, fraction - previous_fraction)
+        total += threshold * probability
+        previous_fraction = fraction
+    return total
+
+
+def _cdf_quantile(cdf: list[tuple[int, float]], quantile: float) -> float:
+    for threshold, fraction in cdf:
+        if fraction >= quantile:
+            return float(threshold)
+    return float(cdf[-1][0]) if cdf else 0.0
+
+
+def _empirical_cdf(totals: list[int]) -> list[tuple[int, float]]:
+    n = len(totals)
+    cdf: list[tuple[int, float]] = []
+    last = None
+    for idx, total in enumerate(totals, start=1):
+        if total == last and idx < n:
+            continue
+        cdf.append((total, idx / n))
+        last = total
+    cdf[-1] = (cdf[-1][0], 1.0)
+    return cdf
 
 
 def _walk_keys(value: Any, prefix: str = "$") -> list[tuple[str, str]]:

--- a/src/fleet-sim/fleet_sim/workload/forecast.py
+++ b/src/fleet-sim/fleet_sim/workload/forecast.py
@@ -1,0 +1,548 @@
+"""Content-free workload archetype aggregate forecasting.
+
+The forecast schema intentionally stores only low-cardinality aggregate windows.
+It can be converted into FleetSim mixture scenarios for offline/nearline
+capacity backtests, but it is not a production scaler contract.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+from .mixture import (
+    CompositionWindow,
+    MixtureScenario,
+    MixtureValidationError,
+    load_mixture_scenario,
+)
+
+SCHEMA_VERSION = "fleet-sim.workload-archetype-forecast/v1alpha1"
+TAXONOMY_VERSION = "fleet-sim.workload-archetype-taxonomy/v1alpha1"
+WEIGHT_TOLERANCE = 1e-6
+
+DEFAULT_FORBIDDEN_DIMENSIONS = (
+    "account_id",
+    "caller_id",
+    "customer_id",
+    "domain",
+    "host",
+    "prompt",
+    "prompt_text",
+    "raw_prompt",
+    "raw_response",
+    "request_id",
+    "response",
+    "session_id",
+    "tenant_id",
+    "url",
+    "user_id",
+)
+
+
+class ForecastValidationError(ValueError):
+    """Raised when a workload forecast aggregate fails validation."""
+
+
+@dataclass(frozen=True)
+class ForecastPrivacyPolicy:
+    """Privacy limits for aggregate forecast windows."""
+
+    min_requests_per_window: int = 50
+    allowed_dimensions: tuple[str, ...] = (
+        "archetype_weights",
+        "model_class",
+        "region",
+        "slo_class",
+    )
+    forbidden_dimensions: tuple[str, ...] = DEFAULT_FORBIDDEN_DIMENSIONS
+    content_free: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> ForecastPrivacyPolicy:
+        data = data or {}
+        return cls(
+            min_requests_per_window=int(data.get("min_requests_per_window", 50)),
+            allowed_dimensions=tuple(
+                str(item)
+                for item in data.get(
+                    "allowed_dimensions",
+                    (
+                        "archetype_weights",
+                        "model_class",
+                        "region",
+                        "slo_class",
+                    ),
+                )
+            ),
+            forbidden_dimensions=tuple(
+                str(item)
+                for item in data.get(
+                    "forbidden_dimensions", DEFAULT_FORBIDDEN_DIMENSIONS
+                )
+            ),
+            content_free=bool(data.get("content_free", True)),
+        )
+
+
+@dataclass(frozen=True)
+class AggregateWindow:
+    """Observed aggregate demand for one privacy-safe time bucket."""
+
+    start_s: float
+    duration_s: float
+    request_count: int
+    total_tokens: int
+    archetype_weights: dict[str, float]
+    model_class: str
+    slo_class: str
+    region: str
+    p50_total_tokens: int | None = None
+    p95_total_tokens: int | None = None
+    p99_ttft_ms: float | None = None
+    uncertainty: dict[str, Any] = field(default_factory=dict)
+    redacted: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AggregateWindow:
+        weights = data.get("archetype_weights", data.get("weights", {}))
+        return cls(
+            start_s=float(data.get("start_s", 0.0)),
+            duration_s=float(data.get("duration_s", 0.0)),
+            request_count=int(data.get("request_count", 0)),
+            total_tokens=int(data.get("total_tokens", 0)),
+            archetype_weights={str(k): float(v) for k, v in dict(weights).items()},
+            model_class=str(data.get("model_class", "")),
+            slo_class=str(data.get("slo_class", "")),
+            region=str(data.get("region", "")),
+            p50_total_tokens=(
+                int(data["p50_total_tokens"])
+                if data.get("p50_total_tokens") is not None
+                else None
+            ),
+            p95_total_tokens=(
+                int(data["p95_total_tokens"])
+                if data.get("p95_total_tokens") is not None
+                else None
+            ),
+            p99_ttft_ms=(
+                float(data["p99_ttft_ms"])
+                if data.get("p99_ttft_ms") is not None
+                else None
+            ),
+            uncertainty=dict(data.get("uncertainty") or {}),
+            redacted=bool(data.get("redacted", False)),
+        )
+
+    @property
+    def end_s(self) -> float:
+        return self.start_s + self.duration_s
+
+    @property
+    def arrival_rate(self) -> float:
+        if self.duration_s <= 0:
+            return 0.0
+        return self.request_count / self.duration_s
+
+    @property
+    def tokens_per_request(self) -> float:
+        if self.request_count <= 0:
+            return 0.0
+        return self.total_tokens / self.request_count
+
+
+@dataclass(frozen=True)
+class ForecastedWindow:
+    """Predicted aggregate demand for one future time bucket."""
+
+    start_s: float
+    duration_s: float
+    request_count: int
+    total_tokens: int
+    archetype_weights: dict[str, float]
+    source_method: str
+    model_class: str
+    slo_class: str
+    region: str
+    p99_ttft_ms: float | None = None
+    uncertainty: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def end_s(self) -> float:
+        return self.start_s + self.duration_s
+
+    @property
+    def arrival_rate(self) -> float:
+        if self.duration_s <= 0:
+            return 0.0
+        return self.request_count / self.duration_s
+
+
+ForecastWindowLike = AggregateWindow | ForecastedWindow
+
+
+@dataclass(frozen=True)
+class WorkloadForecastScenario:
+    """Versioned workload archetype forecast/backtest fixture."""
+
+    id: str
+    version: str
+    source_mixture_path: str
+    aggregate_windows: tuple[AggregateWindow, ...]
+    schema_version: str = SCHEMA_VERSION
+    taxonomy_version: str = TAXONOMY_VERSION
+    privacy: ForecastPrivacyPolicy = field(default_factory=ForecastPrivacyPolicy)
+    holdout_windows: tuple[AggregateWindow, ...] = ()
+    forecast_horizon_windows: int = 1
+    generated_at_s: float | None = None
+    max_staleness_s: float = 180.0
+    description: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    base_dir: Path | None = field(default=None, compare=False, repr=False)
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any],
+        base_dir: str | Path | None = None,
+    ) -> WorkloadForecastScenario:
+        holdout = tuple(
+            AggregateWindow.from_dict(dict(item))
+            for item in data.get("holdout_windows", ())
+        )
+        horizon = int(data.get("forecast_horizon_windows", len(holdout) or 1))
+        return cls(
+            schema_version=str(data.get("schema_version", "")),
+            taxonomy_version=str(data.get("taxonomy_version", "")),
+            id=str(data.get("id", "")),
+            version=str(data.get("version", "")),
+            description=data.get("description"),
+            source_mixture_path=str(
+                data.get("source_mixture", data.get("source_mixture_path", ""))
+            ),
+            privacy=ForecastPrivacyPolicy.from_dict(data.get("privacy")),
+            aggregate_windows=tuple(
+                AggregateWindow.from_dict(dict(item))
+                for item in data.get("aggregate_windows", ())
+            ),
+            holdout_windows=holdout,
+            forecast_horizon_windows=horizon,
+            generated_at_s=(
+                float(data["generated_at_s"])
+                if data.get("generated_at_s") is not None
+                else None
+            ),
+            max_staleness_s=float(data.get("max_staleness_s", 180.0)),
+            metadata=dict(data.get("metadata") or {}),
+            base_dir=Path(base_dir) if base_dir is not None else None,
+        )
+
+    def resolve_source_mixture_path(self) -> Path:
+        path = Path(self.source_mixture_path)
+        if path.is_absolute() or self.base_dir is None:
+            return path
+        return self.base_dir / path
+
+    def load_source_mixture(self) -> MixtureScenario:
+        return load_mixture_scenario(self.resolve_source_mixture_path())
+
+    def stale_reason(self, now_s: float | None) -> str | None:
+        if now_s is None:
+            return None
+        if self.generated_at_s is None:
+            return "generated_at_s is missing"
+        age_s = now_s - self.generated_at_s
+        if age_s > self.max_staleness_s:
+            return (
+                f"forecast is stale: age={age_s:.0f}s exceeds "
+                f"max_staleness_s={self.max_staleness_s:.0f}s"
+            )
+        return None
+
+
+def load_forecast_scenario(
+    path: str | Path,
+    validate: bool = True,
+) -> WorkloadForecastScenario:
+    """Load a workload archetype forecast/backtest JSON file."""
+
+    scenario_path = Path(path)
+    data = json.loads(scenario_path.read_text())
+    scenario = WorkloadForecastScenario.from_dict(data, base_dir=scenario_path.parent)
+    if validate:
+        validate_forecast_scenario(scenario, raw_data=data)
+    return scenario
+
+
+def validate_forecast_scenario(
+    scenario: WorkloadForecastScenario,
+    raw_data: dict[str, Any] | None = None,
+) -> None:
+    """Validate a forecast scenario and raise ForecastValidationError on errors."""
+
+    errors: list[str] = []
+    if raw_data is not None:
+        errors.extend(_privacy_key_errors(raw_data, scenario.privacy))
+    if scenario.schema_version != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be {SCHEMA_VERSION!r}, "
+            f"got {scenario.schema_version!r}"
+        )
+    if scenario.taxonomy_version != TAXONOMY_VERSION:
+        errors.append(
+            f"taxonomy_version must be {TAXONOMY_VERSION!r}, "
+            f"got {scenario.taxonomy_version!r}"
+        )
+    if not scenario.id:
+        errors.append("scenario id is required")
+    if not scenario.version:
+        errors.append("scenario version is required")
+    if not scenario.source_mixture_path:
+        errors.append("source_mixture is required")
+    if scenario.privacy.min_requests_per_window <= 0:
+        errors.append("privacy.min_requests_per_window must be positive")
+    if not scenario.privacy.content_free:
+        errors.append("privacy.content_free must be true")
+    if scenario.max_staleness_s <= 0:
+        errors.append("max_staleness_s must be positive")
+    if scenario.forecast_horizon_windows <= 0:
+        errors.append("forecast_horizon_windows must be positive")
+    if not scenario.aggregate_windows:
+        errors.append("aggregate_windows must not be empty")
+
+    expected_ids: set[str] | None = None
+    if scenario.source_mixture_path:
+        try:
+            expected_ids = set(scenario.load_source_mixture().archetype_ids)
+        except (OSError, json.JSONDecodeError, MixtureValidationError) as exc:
+            errors.append(f"failed to load source_mixture: {exc}")
+
+    _validate_windows(
+        "aggregate_windows",
+        scenario.aggregate_windows,
+        scenario.privacy,
+        expected_ids,
+        errors,
+    )
+    _validate_windows(
+        "holdout_windows",
+        scenario.holdout_windows,
+        scenario.privacy,
+        expected_ids,
+        errors,
+    )
+
+    if errors:
+        raise ForecastValidationError("\n".join(errors))
+
+
+def forecast_to_mixture_scenario(
+    source_mixture: MixtureScenario,
+    windows: Sequence[ForecastWindowLike],
+    base_lam: float,
+    scenario_id: str,
+    version: str,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> MixtureScenario:
+    """Convert aggregate forecast windows into a reproducible mixture scenario."""
+
+    if base_lam <= 0:
+        raise ValueError("base_lam must be positive")
+    if not windows:
+        raise ValueError("windows must not be empty")
+    schedule = tuple(
+        CompositionWindow(
+            start_s=window.start_s,
+            duration_s=window.duration_s,
+            weights=dict(window.archetype_weights),
+            arrival_rate_multiplier=max(window.arrival_rate / base_lam, 1e-9),
+        )
+        for window in windows
+    )
+    return MixtureScenario(
+        schema_version=source_mixture.schema_version,
+        id=scenario_id,
+        version=version,
+        seed=source_mixture.seed,
+        description=description,
+        archetypes=source_mixture.archetypes,
+        composition_schedule=schedule,
+        metadata=dict(metadata or {}),
+        base_dir=source_mixture.base_dir,
+    )
+
+
+def detect_aggregate_diagnostics(
+    history: Sequence[AggregateWindow],
+    actual: Sequence[AggregateWindow],
+    burst_threshold: float = 1.5,
+    drift_threshold: float = 0.25,
+    oscillation_sign_changes: int = 2,
+) -> tuple[str, ...]:
+    """Return burst/drift/oscillation diagnostics from aggregate windows."""
+
+    if not history or not actual:
+        return ()
+    diagnostics: list[str] = []
+    historical_rate = _mean([window.arrival_rate for window in history])
+    actual_rates = [window.arrival_rate for window in actual]
+    if historical_rate > 0 and max(actual_rates) >= historical_rate * burst_threshold:
+        diagnostics.append(
+            "burst detected in holdout aggregates; verify proactive capacity "
+            "against reactive fallback"
+        )
+
+    drift = max(
+        _weight_l1(history[-1].archetype_weights, window.archetype_weights)
+        for window in actual
+    )
+    if drift >= drift_threshold:
+        diagnostics.append(
+            f"taxonomy drift detected: max holdout weight L1={drift:.3f}"
+        )
+
+    rates = [window.arrival_rate for window in history[-3:]] + actual_rates
+    sign_changes = _sign_changes(rates)
+    if sign_changes >= oscillation_sign_changes:
+        diagnostics.append(
+            f"oscillation risk detected: {sign_changes} demand direction changes"
+        )
+    return tuple(diagnostics)
+
+
+def _validate_windows(
+    label: str,
+    windows: Sequence[AggregateWindow],
+    privacy: ForecastPrivacyPolicy,
+    expected_ids: set[str] | None,
+    errors: list[str],
+) -> None:
+    last_end = None
+    for idx, window in enumerate(windows):
+        item = f"{label}[{idx}]"
+        if window.start_s < 0:
+            errors.append(f"{item}: start_s must be non-negative")
+        if window.duration_s <= 0:
+            errors.append(f"{item}: duration_s must be positive")
+        if last_end is not None and window.start_s < last_end:
+            errors.append(f"{item}: windows must not overlap")
+        last_end = window.end_s
+        if (
+            not window.redacted
+            and window.request_count < privacy.min_requests_per_window
+        ):
+            errors.append(
+                f"{item}: request_count must be >= "
+                f"privacy.min_requests_per_window={privacy.min_requests_per_window}"
+            )
+        if window.total_tokens <= 0:
+            errors.append(f"{item}: total_tokens must be positive")
+        for dim_name, dim_value in (
+            ("model_class", window.model_class),
+            ("slo_class", window.slo_class),
+            ("region", window.region),
+        ):
+            if not dim_value:
+                errors.append(f"{item}: {dim_name} is required")
+        _validate_weight_map(
+            window.archetype_weights,
+            expected_ids,
+            f"{item}.archetype_weights",
+            errors,
+        )
+        _validate_uncertainty(window.uncertainty, item, errors)
+
+
+def _validate_weight_map(
+    weights: dict[str, float],
+    expected_ids: set[str] | None,
+    label: str,
+    errors: list[str],
+) -> None:
+    if not weights:
+        errors.append(f"{label}: weights must not be empty")
+        return
+    if expected_ids is not None:
+        missing = sorted(expected_ids - set(weights))
+        extra = sorted(set(weights) - expected_ids)
+        if missing:
+            errors.append(f"{label}: missing weights for {missing}")
+        if extra:
+            errors.append(f"{label}: unknown archetype ids {extra}")
+    for archetype_id, weight in weights.items():
+        if weight < 0:
+            errors.append(f"{label}: {archetype_id} weight must be non-negative")
+    total = sum(weights.values())
+    if abs(total - 1.0) > WEIGHT_TOLERANCE:
+        errors.append(f"{label}: weights must sum to 1.0, got {total:.6f}")
+
+
+def _validate_uncertainty(
+    uncertainty: dict[str, Any], label: str, errors: list[str]
+) -> None:
+    for key, value in uncertainty.items():
+        if isinstance(value, dict):
+            for subkey, subvalue in value.items():
+                if float(subvalue) < 0:
+                    errors.append(f"{label}.uncertainty.{key}.{subkey} is negative")
+        elif isinstance(value, (int, float)) and float(value) < 0:
+            errors.append(f"{label}.uncertainty.{key} is negative")
+
+
+def _privacy_key_errors(
+    raw_data: dict[str, Any],
+    privacy: ForecastPrivacyPolicy,
+) -> list[str]:
+    forbidden = {_normalise_key(item) for item in privacy.forbidden_dimensions}
+    errors = []
+    for path, key in _walk_keys(raw_data):
+        if _normalise_key(key) in forbidden:
+            errors.append(
+                f"privacy violation: high-cardinality/content field {key!r} at {path}"
+            )
+    return errors
+
+
+def _walk_keys(value: Any, prefix: str = "$") -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_str = str(key)
+            path = f"{prefix}.{key_str}"
+            found.append((path, key_str))
+            found.extend(_walk_keys(child, path))
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            found.extend(_walk_keys(child, f"{prefix}[{idx}]"))
+    return found
+
+
+def _normalise_key(value: str) -> str:
+    return value.lower().replace("-", "_")
+
+
+def _weight_l1(left: dict[str, float], right: dict[str, float]) -> float:
+    ids = set(left) | set(right)
+    return sum(
+        abs(left.get(archetype_id, 0.0) - right.get(archetype_id, 0.0))
+        for archetype_id in ids
+    )
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _sign_changes(values: Sequence[float]) -> int:
+    signs = []
+    for left, right in pairwise(values):
+        delta = right - left
+        if abs(delta) <= 1e-9:
+            continue
+        signs.append(1 if delta > 0 else -1)
+    return sum(1 for left, right in pairwise(signs) if left != right)

--- a/src/fleet-sim/fleet_sim/workload/forecasting.py
+++ b/src/fleet-sim/fleet_sim/workload/forecasting.py
@@ -1,0 +1,307 @@
+"""Naive and statistical baselines for aggregate workload forecasts."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .forecast import AggregateWindow, ForecastedWindow, WorkloadForecastScenario
+
+
+class StaticMeanForecaster:
+    """Predict the horizon from the mean historical aggregate window."""
+
+    name = "static_mean"
+    control_kind = "static"
+
+    def forecast(
+        self, scenario: WorkloadForecastScenario
+    ) -> tuple[ForecastedWindow, ...]:
+        return _constant_forecast(
+            scenario,
+            scenario.aggregate_windows,
+            self.name,
+        )
+
+
+class ReactiveLastWindowForecaster:
+    """Predict the horizon by replaying the most recent aggregate window."""
+
+    name = "reactive_last_window"
+    control_kind = "reactive"
+
+    def forecast(
+        self, scenario: WorkloadForecastScenario
+    ) -> tuple[ForecastedWindow, ...]:
+        return _constant_forecast(
+            scenario,
+            scenario.aggregate_windows[-1:],
+            self.name,
+        )
+
+
+@dataclass(frozen=True)
+class MovingWindowForecaster:
+    """Predict the horizon from the mean of the last N aggregate windows."""
+
+    window_count: int = 3
+    name: str = "moving_window"
+    control_kind: str = "forecast"
+
+    def forecast(
+        self, scenario: WorkloadForecastScenario
+    ) -> tuple[ForecastedWindow, ...]:
+        if self.window_count <= 0:
+            raise ValueError("window_count must be positive")
+        return _constant_forecast(
+            scenario,
+            scenario.aggregate_windows[-self.window_count :],
+            self.name,
+        )
+
+
+@dataclass(frozen=True)
+class SeasonalNaiveForecaster:
+    """Replay the same slot from the previous season."""
+
+    season_length_windows: int = 3
+    fallback_window_count: int = 3
+    name: str = "seasonal_naive"
+    control_kind: str = "forecast"
+
+    def forecast(
+        self, scenario: WorkloadForecastScenario
+    ) -> tuple[ForecastedWindow, ...]:
+        if self.season_length_windows <= 0:
+            raise ValueError("season_length_windows must be positive")
+        if len(scenario.aggregate_windows) < self.season_length_windows:
+            return MovingWindowForecaster(self.fallback_window_count).forecast(scenario)
+        templates = _horizon_templates(scenario)
+        history = scenario.aggregate_windows
+        windows = []
+        for idx, template in enumerate(templates):
+            source = history[
+                -self.season_length_windows + idx % self.season_length_windows
+            ]
+            windows.append(_project_from_reference(template, (source,), self.name))
+        return tuple(windows)
+
+
+@dataclass(frozen=True)
+class LinearTrendForecaster:
+    """A small statistical baseline that extrapolates aggregate trends."""
+
+    window_count: int = 4
+    name: str = "linear_trend"
+    control_kind: str = "forecast"
+
+    def forecast(
+        self, scenario: WorkloadForecastScenario
+    ) -> tuple[ForecastedWindow, ...]:
+        if self.window_count <= 1:
+            raise ValueError("window_count must be greater than 1")
+        history = scenario.aggregate_windows[-self.window_count :]
+        templates = _horizon_templates(scenario)
+        archetype_ids = tuple(history[-1].archetype_weights)
+        rates = [window.arrival_rate for window in history]
+        token_rates = [window.tokens_per_request for window in history]
+        weights_by_id = {
+            archetype_id: [window.archetype_weights[archetype_id] for window in history]
+            for archetype_id in archetype_ids
+        }
+        windows = []
+        for horizon_idx, template in enumerate(templates):
+            x = len(history) + horizon_idx
+            rate = max(1e-9, _linear_predict(rates, x))
+            tokens_per_request = max(1.0, _linear_predict(token_rates, x))
+            weights = _normalise_weights(
+                {
+                    archetype_id: max(0.0, _linear_predict(values, x))
+                    for archetype_id, values in weights_by_id.items()
+                },
+                fallback=history[-1].archetype_weights,
+            )
+            request_count = max(1, round(rate * template.duration_s))
+            windows.append(
+                ForecastedWindow(
+                    start_s=template.start_s,
+                    duration_s=template.duration_s,
+                    request_count=request_count,
+                    total_tokens=max(1, round(tokens_per_request * request_count)),
+                    archetype_weights=weights,
+                    source_method=self.name,
+                    model_class=template.model_class,
+                    slo_class=template.slo_class,
+                    region=template.region,
+                    p99_ttft_ms=_linear_optional(
+                        [window.p99_ttft_ms for window in history], x
+                    ),
+                    uncertainty={
+                        "arrival_rate_stddev": _stddev(rates),
+                        "weight_stddev": _weight_stddev(history),
+                    },
+                )
+            )
+        return tuple(windows)
+
+
+def default_forecasters(
+    moving_window_count: int = 3,
+    season_length_windows: int = 3,
+    trend_window_count: int = 4,
+) -> tuple[
+    StaticMeanForecaster
+    | ReactiveLastWindowForecaster
+    | MovingWindowForecaster
+    | SeasonalNaiveForecaster
+    | LinearTrendForecaster,
+    ...,
+]:
+    """Return the default controls and forecast baselines for backtests."""
+
+    return (
+        StaticMeanForecaster(),
+        ReactiveLastWindowForecaster(),
+        MovingWindowForecaster(moving_window_count),
+        SeasonalNaiveForecaster(season_length_windows),
+        LinearTrendForecaster(trend_window_count),
+    )
+
+
+def _horizon_templates(
+    scenario: WorkloadForecastScenario,
+) -> tuple[AggregateWindow, ...]:
+    if scenario.holdout_windows:
+        return scenario.holdout_windows[: scenario.forecast_horizon_windows]
+    last = scenario.aggregate_windows[-1]
+    templates = []
+    for idx in range(scenario.forecast_horizon_windows):
+        templates.append(
+            AggregateWindow(
+                start_s=last.end_s + idx * last.duration_s,
+                duration_s=last.duration_s,
+                request_count=last.request_count,
+                total_tokens=last.total_tokens,
+                archetype_weights=dict(last.archetype_weights),
+                model_class=last.model_class,
+                slo_class=last.slo_class,
+                region=last.region,
+                p50_total_tokens=last.p50_total_tokens,
+                p95_total_tokens=last.p95_total_tokens,
+                p99_ttft_ms=last.p99_ttft_ms,
+                uncertainty=dict(last.uncertainty),
+            )
+        )
+    return tuple(templates)
+
+
+def _constant_forecast(
+    scenario: WorkloadForecastScenario,
+    references: Sequence[AggregateWindow],
+    method: str,
+) -> tuple[ForecastedWindow, ...]:
+    templates = _horizon_templates(scenario)
+    return tuple(
+        _project_from_reference(template, references, method) for template in templates
+    )
+
+
+def _project_from_reference(
+    template: AggregateWindow,
+    references: Sequence[AggregateWindow],
+    method: str,
+) -> ForecastedWindow:
+    rate = _mean([window.arrival_rate for window in references])
+    request_count = max(1, round(rate * template.duration_s))
+    tokens_per_request = _mean([window.tokens_per_request for window in references])
+    return ForecastedWindow(
+        start_s=template.start_s,
+        duration_s=template.duration_s,
+        request_count=request_count,
+        total_tokens=max(1, round(tokens_per_request * request_count)),
+        archetype_weights=_mean_weights(references),
+        source_method=method,
+        model_class=template.model_class,
+        slo_class=template.slo_class,
+        region=template.region,
+        p99_ttft_ms=_mean_optional([window.p99_ttft_ms for window in references]),
+        uncertainty={
+            "arrival_rate_stddev": _stddev(
+                [window.arrival_rate for window in references]
+            ),
+            "weight_stddev": _weight_stddev(references),
+        },
+    )
+
+
+def _mean_weights(windows: Sequence[AggregateWindow]) -> dict[str, float]:
+    ids = tuple(windows[-1].archetype_weights)
+    return _normalise_weights(
+        {
+            archetype_id: _mean(
+                [window.archetype_weights[archetype_id] for window in windows]
+            )
+            for archetype_id in ids
+        },
+        fallback=windows[-1].archetype_weights,
+    )
+
+
+def _weight_stddev(windows: Sequence[AggregateWindow]) -> dict[str, float]:
+    ids = tuple(windows[-1].archetype_weights)
+    return {
+        archetype_id: _stddev(
+            [window.archetype_weights[archetype_id] for window in windows]
+        )
+        for archetype_id in ids
+    }
+
+
+def _normalise_weights(
+    weights: dict[str, float],
+    fallback: dict[str, float],
+) -> dict[str, float]:
+    total = sum(weights.values())
+    if total <= 0 or math.isnan(total):
+        return dict(fallback)
+    return {key: value / total for key, value in weights.items()}
+
+
+def _linear_predict(values: Sequence[float], x: int) -> float:
+    if len(values) == 1:
+        return float(values[0])
+    xs = list(range(len(values)))
+    x_mean = _mean(xs)
+    y_mean = _mean(values)
+    denom = sum((item - x_mean) ** 2 for item in xs)
+    if denom <= 0:
+        return y_mean
+    slope = sum((item - x_mean) * (value - y_mean) for item, value in zip(xs, values))
+    slope /= denom
+    return y_mean + slope * (x - x_mean)
+
+
+def _linear_optional(values: Sequence[float | None], x: int) -> float | None:
+    available = [float(value) for value in values if value is not None]
+    if not available:
+        return None
+    return max(0.0, _linear_predict(available, min(x, len(available))))
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _mean_optional(values: Sequence[float | None]) -> float | None:
+    available = [float(value) for value in values if value is not None]
+    if not available:
+        return None
+    return _mean(available)
+
+
+def _stddev(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = _mean(values)
+    return math.sqrt(sum((value - mean) ** 2 for value in values) / (len(values) - 1))

--- a/src/fleet-sim/fleet_sim/workload/forecasting.py
+++ b/src/fleet-sim/fleet_sim/workload/forecasting.py
@@ -134,6 +134,12 @@ class LinearTrendForecaster:
                     model_class=template.model_class,
                     slo_class=template.slo_class,
                     region=template.region,
+                    p50_total_tokens=_linear_optional_int(
+                        [window.p50_total_tokens for window in history], x
+                    ),
+                    p95_total_tokens=_linear_optional_int(
+                        [window.p95_total_tokens for window in history], x
+                    ),
                     p99_ttft_ms=_linear_optional(
                         [window.p99_ttft_ms for window in history], x
                     ),
@@ -225,6 +231,12 @@ def _project_from_reference(
         model_class=template.model_class,
         slo_class=template.slo_class,
         region=template.region,
+        p50_total_tokens=_mean_optional_int(
+            [window.p50_total_tokens for window in references]
+        ),
+        p95_total_tokens=_mean_optional_int(
+            [window.p95_total_tokens for window in references]
+        ),
         p99_ttft_ms=_mean_optional([window.p99_ttft_ms for window in references]),
         uncertainty={
             "arrival_rate_stddev": _stddev(
@@ -289,6 +301,11 @@ def _linear_optional(values: Sequence[float | None], x: int) -> float | None:
     return max(0.0, _linear_predict(available, min(x, len(available))))
 
 
+def _linear_optional_int(values: Sequence[int | None], x: int) -> int | None:
+    value = _linear_optional(values, x)
+    return max(1, round(value)) if value is not None else None
+
+
 def _mean(values: Sequence[float]) -> float:
     return sum(values) / len(values) if values else 0.0
 
@@ -298,6 +315,11 @@ def _mean_optional(values: Sequence[float | None]) -> float | None:
     if not available:
         return None
     return _mean(available)
+
+
+def _mean_optional_int(values: Sequence[int | None]) -> int | None:
+    value = _mean_optional(values)
+    return max(1, round(value)) if value is not None else None
 
 
 def _stddev(values: Sequence[float]) -> float:

--- a/src/fleet-sim/fleet_sim/workload/mixture.py
+++ b/src/fleet-sim/fleet_sim/workload/mixture.py
@@ -1,0 +1,323 @@
+"""Versioned workload archetype mixture scenarios.
+
+Mixture scenarios let FleetSim build deterministic request streams from named
+workload archetypes instead of collapsing all demand into one aggregate CDF.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "fleet-sim.workload-mixture/v1alpha1"
+WEIGHT_TOLERANCE = 1e-6
+
+
+class MixtureValidationError(ValueError):
+    """Raised when a workload mixture scenario fails validation."""
+
+
+@dataclass(frozen=True)
+class ArchetypeSource:
+    """Input source for an archetype's request token distribution."""
+
+    kind: str
+    path: str
+    format: str | None = None
+    field_map: dict[str, str] = field(default_factory=dict)
+    model_id_field: str | None = None
+    default_model_id: str | None = None
+    max_reqs: int | None = None
+    l_in_frac: float = 0.80
+    l_out_frac: float = 0.20
+    category_mix: dict[str, float] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArchetypeSource:
+        return cls(
+            kind=str(data.get("kind", "")),
+            path=str(data.get("path", "")),
+            format=data.get("format"),
+            field_map=dict(data.get("field_map") or {}),
+            model_id_field=data.get("model_id_field"),
+            default_model_id=data.get("default_model_id"),
+            max_reqs=data.get("max_reqs"),
+            l_in_frac=float(data.get("l_in_frac", 0.80)),
+            l_out_frac=float(data.get("l_out_frac", 0.20)),
+            category_mix=dict(data.get("category_mix") or {}),
+        )
+
+    def resolve_path(self, base_dir: Path | None) -> Path:
+        path = Path(self.path)
+        if path.is_absolute() or base_dir is None:
+            return path
+        return base_dir / path
+
+
+@dataclass(frozen=True)
+class WorkloadArchetype:
+    """Versioned workload archetype in a mixture scenario."""
+
+    id: str
+    version: str
+    source: ArchetypeSource
+    arrival_process: dict[str, Any] = field(default_factory=dict)
+    slo_class: str | None = None
+    model_eligibility: tuple[str, ...] = ()
+    residency: tuple[str, ...] = ()
+    weight: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WorkloadArchetype:
+        return cls(
+            id=str(data.get("id", "")),
+            version=str(data.get("version", "")),
+            source=ArchetypeSource.from_dict(dict(data.get("source") or {})),
+            arrival_process=dict(data.get("arrival_process") or {"kind": "poisson"}),
+            slo_class=data.get("slo_class"),
+            model_eligibility=tuple(str(v) for v in data.get("model_eligibility", ())),
+            residency=tuple(str(v) for v in data.get("residency", ())),
+            weight=float(data.get("weight", 0.0)),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class CompositionWindow:
+    """A time window with its own archetype weights and arrival multiplier."""
+
+    start_s: float
+    duration_s: float
+    weights: dict[str, float]
+    arrival_rate_multiplier: float = 1.0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CompositionWindow:
+        return cls(
+            start_s=float(data.get("start_s", 0.0)),
+            duration_s=float(data.get("duration_s", 0.0)),
+            weights={
+                str(k): float(v) for k, v in dict(data.get("weights") or {}).items()
+            },
+            arrival_rate_multiplier=float(data.get("arrival_rate_multiplier", 1.0)),
+        )
+
+    @property
+    def end_s(self) -> float:
+        return self.start_s + self.duration_s
+
+
+@dataclass(frozen=True)
+class MixtureScenario:
+    """Versioned workload archetype mixture scenario."""
+
+    id: str
+    version: str
+    archetypes: tuple[WorkloadArchetype, ...]
+    schema_version: str = SCHEMA_VERSION
+    seed: int = 42
+    composition_schedule: tuple[CompositionWindow, ...] = ()
+    description: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    base_dir: Path | None = field(default=None, compare=False, repr=False)
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any],
+        base_dir: str | Path | None = None,
+    ) -> MixtureScenario:
+        return cls(
+            schema_version=str(data.get("schema_version", "")),
+            id=str(data.get("id", "")),
+            version=str(data.get("version", "")),
+            seed=int(data.get("seed", 42)),
+            description=data.get("description"),
+            archetypes=tuple(
+                WorkloadArchetype.from_dict(dict(item))
+                for item in data.get("archetypes", ())
+            ),
+            composition_schedule=tuple(
+                CompositionWindow.from_dict(dict(item))
+                for item in data.get("composition_schedule", ())
+            ),
+            metadata=dict(data.get("metadata") or {}),
+            base_dir=Path(base_dir) if base_dir is not None else None,
+        )
+
+    @property
+    def archetype_ids(self) -> tuple[str, ...]:
+        return tuple(archetype.id for archetype in self.archetypes)
+
+    @property
+    def archetype_map(self) -> dict[str, WorkloadArchetype]:
+        return {archetype.id: archetype for archetype in self.archetypes}
+
+    @property
+    def nominal_weights(self) -> dict[str, float]:
+        return {archetype.id: archetype.weight for archetype in self.archetypes}
+
+
+def load_mixture_scenario(path: str | Path, validate: bool = True) -> MixtureScenario:
+    """Load a workload mixture scenario JSON file."""
+
+    scenario_path = Path(path)
+    data = json.loads(scenario_path.read_text())
+    scenario = MixtureScenario.from_dict(data, base_dir=scenario_path.parent)
+    if validate:
+        validate_mixture_scenario(scenario)
+    return scenario
+
+
+def validate_cdf_points(cdf: list[Any], name: str = "cdf") -> list[str]:
+    """Return validation errors for a total-token empirical CDF."""
+
+    errors: list[str] = []
+    if not cdf:
+        return [f"{name}: CDF must not be empty"]
+
+    prev_threshold = 0
+    prev_fraction = 0.0
+    parsed: list[tuple[int, float]] = []
+    for idx, point in enumerate(cdf):
+        if not isinstance(point, (list, tuple)) or len(point) != 2:
+            errors.append(
+                f"{name}: point {idx} must be [token_length, cumulative_fraction]"
+            )
+            continue
+        try:
+            threshold = int(point[0])
+            fraction = float(point[1])
+        except (TypeError, ValueError):
+            errors.append(f"{name}: point {idx} contains non-numeric values")
+            continue
+        if threshold <= 0:
+            errors.append(f"{name}: point {idx} token_length must be positive")
+        if threshold <= prev_threshold:
+            errors.append(
+                f"{name}: point {idx} token_length must be strictly increasing"
+            )
+        if not 0.0 <= fraction <= 1.0:
+            errors.append(f"{name}: point {idx} cumulative_fraction must be in [0, 1]")
+        if fraction < prev_fraction:
+            errors.append(
+                f"{name}: point {idx} cumulative_fraction must be non-decreasing"
+            )
+        prev_threshold = threshold
+        prev_fraction = fraction
+        parsed.append((threshold, fraction))
+
+    if parsed and abs(parsed[-1][1] - 1.0) > WEIGHT_TOLERANCE:
+        errors.append(f"{name}: final cumulative_fraction must be 1.0")
+    return errors
+
+
+def validate_mixture_scenario(scenario: MixtureScenario) -> None:
+    """Validate a scenario and raise MixtureValidationError on any error."""
+
+    errors: list[str] = []
+    if scenario.schema_version != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be {SCHEMA_VERSION!r}, got {scenario.schema_version!r}"
+        )
+    if not scenario.id:
+        errors.append("scenario id is required")
+    if not scenario.version:
+        errors.append("scenario version is required")
+    if not scenario.archetypes:
+        errors.append("scenario must define at least one archetype")
+
+    ids = scenario.archetype_ids
+    duplicate_ids = sorted(
+        {archetype_id for archetype_id in ids if ids.count(archetype_id) > 1}
+    )
+    if duplicate_ids:
+        errors.append(f"archetype ids must be unique: {duplicate_ids}")
+
+    id_set = set(ids)
+    _validate_weight_map(scenario.nominal_weights, id_set, "nominal weights", errors)
+
+    for archetype in scenario.archetypes:
+        errors.extend(_validate_archetype(archetype, scenario.base_dir))
+
+    last_end = None
+    for index, window in enumerate(
+        sorted(scenario.composition_schedule, key=lambda w: w.start_s)
+    ):
+        label = f"composition_schedule[{index}]"
+        if window.start_s < 0:
+            errors.append(f"{label}: start_s must be non-negative")
+        if window.duration_s <= 0:
+            errors.append(f"{label}: duration_s must be positive")
+        if window.arrival_rate_multiplier <= 0:
+            errors.append(f"{label}: arrival_rate_multiplier must be positive")
+        if last_end is not None and window.start_s < last_end:
+            errors.append(f"{label}: windows must not overlap")
+        last_end = window.end_s
+        _validate_weight_map(window.weights, id_set, f"{label} weights", errors)
+
+    if errors:
+        raise MixtureValidationError("\n".join(errors))
+
+
+def _validate_archetype(
+    archetype: WorkloadArchetype, base_dir: Path | None
+) -> list[str]:
+    errors: list[str] = []
+    label = f"archetype {archetype.id!r}"
+    if not archetype.id:
+        errors.append("archetype id is required")
+    if not archetype.version:
+        errors.append(f"{label}: version is required")
+    if archetype.source.kind not in {"cdf", "trace"}:
+        errors.append(f"{label}: source.kind must be 'cdf' or 'trace'")
+    if archetype.weight < 0:
+        errors.append(f"{label}: weight must be non-negative")
+    arrival_kind = archetype.arrival_process.get("kind", "poisson")
+    if arrival_kind != "poisson":
+        errors.append(f"{label}: only poisson arrival_process is supported in v1alpha1")
+    if archetype.source.kind == "cdf":
+        try:
+            cdf = _load_cdf_source(archetype.source, base_dir)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            errors.append(f"{label}: failed to load CDF source: {exc}")
+        else:
+            errors.extend(validate_cdf_points(cdf, f"{label} source CDF"))
+    elif archetype.source.kind == "trace":
+        path = archetype.source.resolve_path(base_dir)
+        if not path.exists():
+            errors.append(f"{label}: trace source does not exist: {path}")
+    return errors
+
+
+def _validate_weight_map(
+    weights: dict[str, float],
+    expected_ids: set[str],
+    label: str,
+    errors: list[str],
+) -> None:
+    actual_ids = set(weights)
+    missing = sorted(expected_ids - actual_ids)
+    extra = sorted(actual_ids - expected_ids)
+    if missing:
+        errors.append(f"{label}: missing weights for {missing}")
+    if extra:
+        errors.append(f"{label}: unknown archetype ids {extra}")
+    for archetype_id, weight in weights.items():
+        if weight < 0:
+            errors.append(f"{label}: {archetype_id} weight must be non-negative")
+    total = sum(weights.values())
+    if abs(total - 1.0) > WEIGHT_TOLERANCE:
+        errors.append(f"{label}: weights must sum to 1.0, got {total:.6f}")
+
+
+def _load_cdf_source(
+    source: ArchetypeSource,
+    base_dir: Path | None,
+) -> list[tuple[int, float]]:
+    raw = json.loads(source.resolve_path(base_dir).read_text())
+    cdf = raw["cdf"] if isinstance(raw, dict) else raw
+    return [(int(threshold), float(fraction)) for threshold, fraction in cdf]

--- a/src/fleet-sim/fleet_sim/workload/mixture.py
+++ b/src/fleet-sim/fleet_sim/workload/mixture.py
@@ -93,6 +93,7 @@ class CompositionWindow:
     duration_s: float
     weights: dict[str, float]
     arrival_rate_multiplier: float = 1.0
+    token_scale: float = 1.0
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CompositionWindow:
@@ -103,6 +104,7 @@ class CompositionWindow:
                 str(k): float(v) for k, v in dict(data.get("weights") or {}).items()
             },
             arrival_rate_multiplier=float(data.get("arrival_rate_multiplier", 1.0)),
+            token_scale=float(data.get("token_scale", 1.0)),
         )
 
     @property
@@ -254,6 +256,8 @@ def validate_mixture_scenario(scenario: MixtureScenario) -> None:
             errors.append(f"{label}: duration_s must be positive")
         if window.arrival_rate_multiplier <= 0:
             errors.append(f"{label}: arrival_rate_multiplier must be positive")
+        if window.token_scale <= 0:
+            errors.append(f"{label}: token_scale must be positive")
         if last_end is not None and window.start_s < last_end:
             errors.append(f"{label}: windows must not overlap")
         last_end = window.end_s

--- a/src/fleet-sim/fleet_sim/workload/mixture_sampling.py
+++ b/src/fleet-sim/fleet_sim/workload/mixture_sampling.py
@@ -1,0 +1,218 @@
+"""Sampling and distribution checks for workload mixture scenarios."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from ..core.request import Request
+from .mixture import (
+    CompositionWindow,
+    MixtureScenario,
+    MixtureValidationError,
+    WorkloadArchetype,
+    _load_cdf_source,
+    validate_mixture_scenario,
+)
+from .mixture_validation import MixtureValidationReport, validate_sample_distribution
+from .synthetic import CdfWorkload
+from .trace import TraceWorkload
+
+
+class MixtureSampler:
+    """Deterministic sampler for fixed and time-varying mixture scenarios."""
+
+    def __init__(self, scenario: MixtureScenario):
+        validate_mixture_scenario(scenario)
+        self.scenario = scenario
+        self._arrival_rng = random.Random(scenario.seed)
+        self._choice_rng = random.Random(scenario.seed + 17)
+        self._samplers = {
+            archetype.id: _ArchetypeSampler(
+                archetype=archetype,
+                base_dir=scenario.base_dir,
+                seed=scenario.seed + 1009 + index,
+            )
+            for index, archetype in enumerate(scenario.archetypes)
+        }
+
+    def generate(self, lam: float, n_requests: int) -> list[tuple[float, Request]]:
+        """Generate exactly n_requests arrivals when the scenario window permits."""
+
+        if lam <= 0:
+            raise ValueError("lam must be positive")
+        if n_requests < 0:
+            raise ValueError("n_requests must be non-negative")
+        if not self.scenario.composition_schedule:
+            return self._generate_fixed(lam, n_requests)
+        return self._generate_scheduled(lam, n_requests)
+
+    def generate_until(
+        self, lam: float, duration_s: float
+    ) -> list[tuple[float, Request]]:
+        """Generate arrivals until duration_s using fixed or scheduled weights."""
+
+        if lam <= 0:
+            raise ValueError("lam must be positive")
+        if duration_s < 0:
+            raise ValueError("duration_s must be non-negative")
+        if not self.scenario.composition_schedule:
+            return self._generate_fixed_until(lam, duration_s)
+        return self._generate_scheduled_until(lam, duration_s)
+
+    def _generate_fixed(
+        self, lam: float, n_requests: int
+    ) -> list[tuple[float, Request]]:
+        arrivals: list[tuple[float, Request]] = []
+        t = 0.0
+        for req_id in range(n_requests):
+            t += self._arrival_rng.expovariate(lam)
+            archetype_id = self._choose_archetype(self.scenario.nominal_weights)
+            arrivals.append((t, self._sample_request(archetype_id, req_id, t)))
+        return arrivals
+
+    def _generate_fixed_until(
+        self, lam: float, duration_s: float
+    ) -> list[tuple[float, Request]]:
+        arrivals: list[tuple[float, Request]] = []
+        t = 0.0
+        while True:
+            t += self._arrival_rng.expovariate(lam)
+            if t > duration_s:
+                return arrivals
+            archetype_id = self._choose_archetype(self.scenario.nominal_weights)
+            arrivals.append((t, self._sample_request(archetype_id, len(arrivals), t)))
+
+    def _generate_scheduled(
+        self, lam: float, n_requests: int
+    ) -> list[tuple[float, Request]]:
+        arrivals: list[tuple[float, Request]] = []
+        for window in sorted(
+            self.scenario.composition_schedule, key=lambda item: item.start_s
+        ):
+            self._append_window_arrivals(lam, window, arrivals, n_requests=n_requests)
+            if len(arrivals) >= n_requests:
+                return arrivals
+        raise MixtureValidationError(
+            "composition schedule ended before n_requests were generated; "
+            "use generate_until or extend the schedule"
+        )
+
+    def _generate_scheduled_until(
+        self,
+        lam: float,
+        duration_s: float,
+    ) -> list[tuple[float, Request]]:
+        arrivals: list[tuple[float, Request]] = []
+        for window in sorted(
+            self.scenario.composition_schedule, key=lambda item: item.start_s
+        ):
+            if window.start_s >= duration_s:
+                break
+            self._append_window_arrivals(
+                lam,
+                window,
+                arrivals,
+                duration_s=min(window.end_s, duration_s),
+            )
+        return arrivals
+
+    def _append_window_arrivals(
+        self,
+        lam: float,
+        window: CompositionWindow,
+        arrivals: list[tuple[float, Request]],
+        n_requests: int | None = None,
+        duration_s: float | None = None,
+    ) -> None:
+        t = window.start_s
+        end_s = duration_s if duration_s is not None else window.end_s
+        effective_lam = lam * window.arrival_rate_multiplier
+        while True:
+            if n_requests is not None and len(arrivals) >= n_requests:
+                return
+            t += self._arrival_rng.expovariate(effective_lam)
+            if t > end_s:
+                return
+            archetype_id = self._choose_archetype(window.weights)
+            arrivals.append((t, self._sample_request(archetype_id, len(arrivals), t)))
+
+    def _choose_archetype(self, weights: dict[str, float]) -> str:
+        threshold = self._choice_rng.random()
+        cumulative = 0.0
+        last_id = ""
+        for archetype_id, weight in weights.items():
+            cumulative += weight
+            last_id = archetype_id
+            if threshold <= cumulative:
+                return archetype_id
+        return last_id
+
+    def _sample_request(
+        self, archetype_id: str, req_id: int, arrival: float
+    ) -> Request:
+        return self._samplers[archetype_id].sample_request(req_id, arrival)
+
+
+class _ArchetypeSampler:
+    def __init__(self, archetype: WorkloadArchetype, base_dir: Path | None, seed: int):
+        self.archetype = archetype
+        self._index = 0
+        source = archetype.source
+        if source.kind == "cdf":
+            self._workload = CdfWorkload(
+                _load_cdf_source(source, base_dir),
+                l_in_frac=source.l_in_frac,
+                l_out_frac=source.l_out_frac,
+                category_mix=source.category_mix or None,
+                seed=seed,
+            )
+            self._trace_requests: list[Request] | None = None
+        elif source.kind == "trace":
+            trace = TraceWorkload(
+                str(source.resolve_path(base_dir)),
+                fmt=source.format or "semantic_router",
+                max_reqs=source.max_reqs,
+                seed=seed,
+                field_map=source.field_map,
+                model_id_field=source.model_id_field,
+                default_model_id=source.default_model_id,
+            )
+            self._trace_requests = [req for _, req in trace.generate()]
+            if not self._trace_requests:
+                raise MixtureValidationError(
+                    f"{archetype.id}: trace source produced no requests"
+                )
+            self._workload = None
+        else:
+            raise MixtureValidationError(
+                f"{archetype.id}: unsupported source kind {source.kind!r}"
+            )
+
+    def sample_request(self, req_id: int, arrival: float) -> Request:
+        if self._trace_requests is not None:
+            req = self._clone_trace_request(
+                self._trace_requests[self._index], req_id, arrival
+            )
+            self._index = (self._index + 1) % len(self._trace_requests)
+        else:
+            req = self._workload.sample_request(req_id, arrival)
+        req.archetype_id = self.archetype.id
+        req.slo_class = self.archetype.slo_class
+        req.eligible_models = self.archetype.model_eligibility
+        req.residency = self.archetype.residency
+        return req
+
+    @staticmethod
+    def _clone_trace_request(source: Request, req_id: int, arrival: float) -> Request:
+        req = Request(
+            req_id=req_id,
+            arrival_time=arrival,
+            l_in=source.l_in,
+            l_out=source.l_out,
+            category=source.category,
+            model_id=source.model_id,
+        )
+        if hasattr(source, "_complexity"):
+            req._complexity = source._complexity
+        return req

--- a/src/fleet-sim/fleet_sim/workload/mixture_validation.py
+++ b/src/fleet-sim/fleet_sim/workload/mixture_validation.py
@@ -1,0 +1,241 @@
+"""Distribution checks for workload mixture sampled request streams."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..core.request import Request
+from .mixture import MixtureScenario, _load_cdf_source, validate_mixture_scenario
+
+MIN_SAMPLE_SIZE = 100
+
+
+@dataclass(frozen=True)
+class MixtureValidationReport:
+    """Distribution validation summary for a sampled mixture request stream."""
+
+    sample_size: int
+    expected_weights: dict[str, float]
+    observed_weights: dict[str, float]
+    weight_error_by_archetype: dict[str, float]
+    quantiles: dict[str, int]
+    aggregate_cdf_max_error: float | None = None
+    component_cdf_max_error: dict[str, float] = field(default_factory=dict)
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def validate_sample_distribution(
+    arrivals: list[tuple[float, Request]],
+    scenario: MixtureScenario,
+    weight_tolerance: float = 0.05,
+    cdf_tolerance: float = 0.10,
+    min_sample_size: int = MIN_SAMPLE_SIZE,
+) -> MixtureValidationReport:
+    """Validate sampled request weights and CDF reproduction."""
+
+    validate_mixture_scenario(scenario)
+    requests = [req for _, req in arrivals]
+    sample_size = len(requests)
+    expected_weights = _expected_weights_for_sample(arrivals, scenario)
+    observed_weights = _observed_weights(requests, scenario.archetype_ids)
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if sample_size < min_sample_size:
+        warnings.append(
+            f"sample size {sample_size} is below min_sample_size={min_sample_size}; "
+            "distribution errors are warnings-only"
+        )
+
+    weight_errors = _weight_errors(
+        expected_weights,
+        observed_weights,
+        sample_size,
+        min_sample_size,
+        weight_tolerance,
+        errors,
+    )
+    quantiles = _quantiles([req.total_tokens() for req in requests])
+    aggregate_error = None
+    component_errors: dict[str, float] = {}
+    if all(archetype.source.kind == "cdf" for archetype in scenario.archetypes):
+        cdfs = {
+            archetype.id: _load_cdf_source(archetype.source, scenario.base_dir)
+            for archetype in scenario.archetypes
+        }
+        aggregate_error, component_errors = _cdf_errors(
+            requests,
+            scenario,
+            cdfs,
+            expected_weights,
+            sample_size,
+            min_sample_size,
+            cdf_tolerance,
+            errors,
+        )
+    else:
+        warnings.append("CDF reproduction checks skipped for non-CDF archetype sources")
+
+    return MixtureValidationReport(
+        sample_size=sample_size,
+        expected_weights=expected_weights,
+        observed_weights=observed_weights,
+        weight_error_by_archetype=weight_errors,
+        quantiles=quantiles,
+        aggregate_cdf_max_error=aggregate_error,
+        component_cdf_max_error=component_errors,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
+
+
+def _weight_errors(
+    expected_weights: dict[str, float],
+    observed_weights: dict[str, float],
+    sample_size: int,
+    min_sample_size: int,
+    weight_tolerance: float,
+    errors: list[str],
+) -> dict[str, float]:
+    weight_errors: dict[str, float] = {}
+    for archetype_id, expected in expected_weights.items():
+        observed = observed_weights.get(archetype_id, 0.0)
+        delta = abs(observed - expected)
+        weight_errors[archetype_id] = delta
+        if sample_size >= min_sample_size and delta > weight_tolerance:
+            errors.append(
+                f"{archetype_id}: observed weight {observed:.4f} differs from "
+                f"expected {expected:.4f} by {delta:.4f}"
+            )
+    return weight_errors
+
+
+def _cdf_errors(
+    requests: list[Request],
+    scenario: MixtureScenario,
+    cdfs: dict[str, list[tuple[int, float]]],
+    expected_weights: dict[str, float],
+    sample_size: int,
+    min_sample_size: int,
+    cdf_tolerance: float,
+    errors: list[str],
+) -> tuple[float, dict[str, float]]:
+    aggregate_error = _aggregate_cdf_error(requests, cdfs, expected_weights)
+    if sample_size >= min_sample_size and aggregate_error > cdf_tolerance:
+        errors.append(
+            f"aggregate CDF max error {aggregate_error:.4f} exceeds "
+            f"cdf_tolerance={cdf_tolerance:.4f}"
+        )
+    component_errors: dict[str, float] = {}
+    for archetype_id, cdf in cdfs.items():
+        component_requests = [
+            req for req in requests if req.archetype_id == archetype_id
+        ]
+        if len(component_requests) < min_sample_size:
+            continue
+        component_error = _single_cdf_error(
+            [req.total_tokens() for req in component_requests],
+            cdf,
+        )
+        component_errors[archetype_id] = component_error
+        if component_error > cdf_tolerance:
+            errors.append(
+                f"{archetype_id}: component CDF max error "
+                f"{component_error:.4f} exceeds cdf_tolerance={cdf_tolerance:.4f}"
+            )
+    return aggregate_error, component_errors
+
+
+def _expected_weights_for_sample(
+    arrivals: list[tuple[float, Request]],
+    scenario: MixtureScenario,
+) -> dict[str, float]:
+    if not scenario.composition_schedule:
+        return scenario.nominal_weights
+    weighted: dict[str, float] = dict.fromkeys(scenario.archetype_ids, 0.0)
+    windows = sorted(scenario.composition_schedule, key=lambda item: item.start_s)
+    matched = 0
+    for arrival, _ in arrivals:
+        window = next(
+            (item for item in windows if item.start_s <= arrival <= item.end_s),
+            None,
+        )
+        if window is None:
+            continue
+        matched += 1
+        for archetype_id, weight in window.weights.items():
+            weighted[archetype_id] += weight
+    total = sum(weighted.values())
+    if matched == 0 or total <= 0:
+        return scenario.nominal_weights
+    return {archetype_id: value / total for archetype_id, value in weighted.items()}
+
+
+def _observed_weights(
+    requests: list[Request],
+    archetype_ids: tuple[str, ...],
+) -> dict[str, float]:
+    counts = dict.fromkeys(archetype_ids, 0)
+    for req in requests:
+        if req.archetype_id in counts:
+            counts[req.archetype_id] += 1
+    total = len(requests)
+    if total == 0:
+        return dict.fromkeys(archetype_ids, 0.0)
+    return {archetype_id: count / total for archetype_id, count in counts.items()}
+
+
+def _quantiles(lengths: list[int]) -> dict[str, int]:
+    if not lengths:
+        return {}
+    sorted_lengths = sorted(lengths)
+
+    def pick(q: float) -> int:
+        index = min(
+            len(sorted_lengths) - 1, max(0, round(q * (len(sorted_lengths) - 1)))
+        )
+        return sorted_lengths[index]
+
+    return {"p50": pick(0.50), "p95": pick(0.95), "p99": pick(0.99)}
+
+
+def _aggregate_cdf_error(
+    requests: list[Request],
+    cdfs: dict[str, list[tuple[int, float]]],
+    weights: dict[str, float],
+) -> float:
+    lengths = [req.total_tokens() for req in requests]
+    if not lengths:
+        return 0.0
+    points = sorted({threshold for cdf in cdfs.values() for threshold, _ in cdf})
+    max_error = 0.0
+    for point in points:
+        observed = sum(1 for length in lengths if length <= point) / len(lengths)
+        expected = sum(
+            weights[archetype_id] * _cdf_value(cdf, point)
+            for archetype_id, cdf in cdfs.items()
+        )
+        max_error = max(max_error, abs(observed - expected))
+    return max_error
+
+
+def _single_cdf_error(lengths: list[int], cdf: list[tuple[int, float]]) -> float:
+    if not lengths:
+        return 0.0
+    max_error = 0.0
+    for threshold, expected in cdf:
+        observed = sum(1 for length in lengths if length <= threshold) / len(lengths)
+        max_error = max(max_error, abs(observed - expected))
+    return max_error
+
+
+def _cdf_value(cdf: list[tuple[int, float]], token_length: int) -> float:
+    for threshold, fraction in cdf:
+        if token_length <= threshold:
+            return fraction
+    return 1.0

--- a/src/fleet-sim/run_sim.py
+++ b/src/fleet-sim/run_sim.py
@@ -13,6 +13,11 @@ Usage
       --scenario data/workload_mixture_drift.json \\
       --lam 200 --slo 500 --b-short 6144 --max-total-gpus 300
 
+  # Backtest proactive workload archetype forecasts from content-free aggregates
+  vllm-sr-sim forecast-backtest \\
+      --scenario data/workload_forecast_seasonal.json \\
+      --slo 500 --b-short 6144 --gamma-max 1.2
+
   # Simulate a fixed two-pool fleet
   vllm-sr-sim simulate \\
       --cdf data/azure_cdf.json \\
@@ -68,6 +73,7 @@ Usage
   #   }
   # }
 """
+
 from __future__ import annotations
 
 import argparse
@@ -181,6 +187,47 @@ def cmd_mixture_optimize(args):
         print(f"\nResults saved to {args.out}")
     if args.fail_on_infeasible and not report.ok:
         raise SystemExit(2)
+
+
+def cmd_forecast_backtest(args):
+    from fleet_sim.optimizer import FleetOptimizer, evaluate_forecast_backtest
+    from fleet_sim.workload import load_forecast_scenario
+
+    scenario = load_forecast_scenario(args.scenario)
+    gpu_s = GPU_REGISTRY.get(args.gpu_short, A100_80GB)
+    gpu_l = GPU_REGISTRY.get(args.gpu_long, A100_80GB)
+    opt = FleetOptimizer(
+        gpu_short=gpu_s,
+        gpu_long=gpu_l,
+        B_short=args.b_short,
+        t_slo_ms=args.slo,
+        long_max_ctx=args.long_max_ctx,
+        p_c=args.p_c,
+        node_avail=args.node_avail,
+    )
+    gammas = [
+        round(args.gamma_min + i * args.gamma_step, 2)
+        for i in range(int((args.gamma_max - args.gamma_min) / args.gamma_step) + 1)
+    ]
+    report = evaluate_forecast_backtest(
+        optimizer=opt,
+        scenario=scenario,
+        gammas=gammas,
+        moving_window_count=args.moving_window_count,
+        season_length_windows=args.season_length_windows,
+        trend_window_count=args.trend_window_count,
+        n_sim_requests=args.n_sim_req,
+        verify_top_n=1 if args.n_sim_req else 0,
+        max_total_gpus=args.max_total_gpus,
+        now_s=args.now_s,
+        fail_on_stale=args.fail_on_stale,
+        verbose=False,
+    )
+    report.print_report()
+
+    if args.out:
+        json.dump(report.to_dict(), open(args.out, "w"), indent=2)
+        print(f"\nResults saved to {args.out}")
 
 
 def cmd_simulate(args):
@@ -1110,6 +1157,52 @@ def main(argv=None):
     sp_mix.add_argument("--fail-on-infeasible", action="store_true")
     sp_mix.add_argument("--out", default=None, help="Save structured report to JSON")
     sp_mix.set_defaults(func=cmd_mixture_optimize)
+
+    # ── forecast-backtest ───────────────────────────────────────────────────
+    sp_forecast = sub.add_parser(
+        "forecast-backtest",
+        help="Backtest proactive workload archetype forecasts",
+    )
+    sp_forecast.add_argument(
+        "--scenario",
+        required=True,
+        help="Path to workload_forecast_*.json aggregate scenario",
+    )
+    sp_forecast.add_argument("--slo", type=float, default=500, help="P99 TTFT SLO (ms)")
+    sp_forecast.add_argument(
+        "--b-short",
+        type=int,
+        default=4096,
+        help="Short-pool context threshold (tokens)",
+    )
+    sp_forecast.add_argument(
+        "--long-max-ctx",
+        type=int,
+        default=65536,
+        help="Long-pool max context (tokens)",
+    )
+    sp_forecast.add_argument(
+        "--gpu-short", default="a100", choices=list(GPU_REGISTRY.keys())
+    )
+    sp_forecast.add_argument(
+        "--gpu-long", default="a100", choices=list(GPU_REGISTRY.keys())
+    )
+    sp_forecast.add_argument("--gamma-min", type=float, default=1.0)
+    sp_forecast.add_argument("--gamma-max", type=float, default=2.0)
+    sp_forecast.add_argument("--gamma-step", type=float, default=0.1)
+    sp_forecast.add_argument("--moving-window-count", type=int, default=3)
+    sp_forecast.add_argument("--season-length-windows", type=int, default=3)
+    sp_forecast.add_argument("--trend-window-count", type=int, default=4)
+    sp_forecast.add_argument("--n-sim-req", type=int, default=0)
+    sp_forecast.add_argument("--max-total-gpus", type=int, default=None)
+    sp_forecast.add_argument("--p-c", type=float, default=0.75)
+    sp_forecast.add_argument("--node-avail", type=float, default=1.0)
+    sp_forecast.add_argument("--now-s", type=float, default=None)
+    sp_forecast.add_argument("--fail-on-stale", action="store_true")
+    sp_forecast.add_argument(
+        "--out", default=None, help="Save structured report to JSON"
+    )
+    sp_forecast.set_defaults(func=cmd_forecast_backtest)
 
     # ── simulate ──────────────────────────────────────────────────────────────
     sp_sim = sub.add_parser("simulate", help="Simulate a fixed fleet configuration")

--- a/src/fleet-sim/run_sim.py
+++ b/src/fleet-sim/run_sim.py
@@ -8,6 +8,11 @@ Usage
       --cdf data/azure_cdf.json \\
       --lam 200 --slo 500 --b-short 6144
 
+  # Evaluate robust capacity across workload archetype mixtures
+  vllm-sr-sim mixture-optimize \\
+      --scenario data/workload_mixture_drift.json \\
+      --lam 200 --slo 500 --b-short 6144 --max-total-gpus 300
+
   # Simulate a fixed two-pool fleet
   vllm-sr-sim simulate \\
       --cdf data/azure_cdf.json \\
@@ -136,6 +141,46 @@ def cmd_optimize(args):
         ]
         json.dump(rows, open(args.out, "w"), indent=2)
         print(f"\nResults saved to {args.out}")
+
+
+def cmd_mixture_optimize(args):
+    from fleet_sim.optimizer import FleetOptimizer, evaluate_mixture_scenario
+    from fleet_sim.workload import load_mixture_scenario
+
+    scenario = load_mixture_scenario(args.scenario)
+    gpu_s = GPU_REGISTRY.get(args.gpu_short, A100_80GB)
+    gpu_l = GPU_REGISTRY.get(args.gpu_long, A100_80GB)
+    opt = FleetOptimizer(
+        gpu_short=gpu_s,
+        gpu_long=gpu_l,
+        B_short=args.b_short,
+        t_slo_ms=args.slo,
+        long_max_ctx=args.long_max_ctx,
+        p_c=args.p_c,
+        node_avail=args.node_avail,
+    )
+    gammas = [
+        round(args.gamma_min + i * args.gamma_step, 2)
+        for i in range(int((args.gamma_max - args.gamma_min) / args.gamma_step) + 1)
+    ]
+    report = evaluate_mixture_scenario(
+        optimizer=opt,
+        scenario=scenario,
+        lam=args.lam,
+        gammas=gammas,
+        n_sim_requests=args.n_sim_req,
+        verify_top_n=1 if args.n_sim_req else 0,
+        max_total_gpus=args.max_total_gpus,
+        fail_on_infeasible=False,
+        verbose=False,
+    )
+    report.print_report()
+
+    if args.out:
+        json.dump(report.to_dict(), open(args.out, "w"), indent=2)
+        print(f"\nResults saved to {args.out}")
+    if args.fail_on_infeasible and not report.ok:
+        raise SystemExit(2)
 
 
 def cmd_simulate(args):
@@ -1026,6 +1071,45 @@ def main(argv=None):
     sp_opt.add_argument("--n-sim-req", type=int, default=40000)
     sp_opt.add_argument("--verify-top", type=int, default=3)
     sp_opt.set_defaults(func=cmd_optimize)
+
+    # ── mixture-optimize ─────────────────────────────────────────────────────
+    sp_mix = sub.add_parser(
+        "mixture-optimize",
+        help="Evaluate FleetOptimizer sensitivity across workload mixtures",
+    )
+    sp_mix.add_argument(
+        "--scenario",
+        required=True,
+        help="Path to workload_mixture_*.json scenario",
+    )
+    sp_mix.add_argument("--lam", type=float, default=200, help="Base arrival rate")
+    sp_mix.add_argument("--slo", type=float, default=500, help="P99 TTFT SLO (ms)")
+    sp_mix.add_argument(
+        "--b-short",
+        type=int,
+        default=4096,
+        help="Short-pool context threshold (tokens)",
+    )
+    sp_mix.add_argument(
+        "--long-max-ctx",
+        type=int,
+        default=65536,
+        help="Long-pool max context (tokens)",
+    )
+    sp_mix.add_argument(
+        "--gpu-short", default="a100", choices=list(GPU_REGISTRY.keys())
+    )
+    sp_mix.add_argument("--gpu-long", default="a100", choices=list(GPU_REGISTRY.keys()))
+    sp_mix.add_argument("--gamma-min", type=float, default=1.0)
+    sp_mix.add_argument("--gamma-max", type=float, default=2.0)
+    sp_mix.add_argument("--gamma-step", type=float, default=0.1)
+    sp_mix.add_argument("--n-sim-req", type=int, default=0)
+    sp_mix.add_argument("--max-total-gpus", type=int, default=None)
+    sp_mix.add_argument("--p-c", type=float, default=0.75)
+    sp_mix.add_argument("--node-avail", type=float, default=1.0)
+    sp_mix.add_argument("--fail-on-infeasible", action="store_true")
+    sp_mix.add_argument("--out", default=None, help="Save structured report to JSON")
+    sp_mix.set_defaults(func=cmd_mixture_optimize)
 
     # ── simulate ──────────────────────────────────────────────────────────────
     sp_sim = sub.add_parser("simulate", help="Simulate a fixed fleet configuration")

--- a/src/fleet-sim/tests/test_api.py
+++ b/src/fleet-sim/tests/test_api.py
@@ -132,6 +132,13 @@ class TestWorkloadRoutes:
         assert "description" in w
         assert "path" in w
 
+    def test_list_mixture_workloads_returns_three(self, client):
+        r = client.get("/api/workloads/mixtures")
+        assert r.status_code == 200
+        items = r.json()
+        assert {item["name"] for item in items} == {"nominal", "drift", "burst"}
+        assert all(item["archetype_weights"] for item in items)
+
     def test_get_cdf_azure(self, client):
         r = client.get("/api/workloads/azure/cdf")
         assert r.status_code == 200
@@ -484,6 +491,10 @@ class TestJobRoutes:
         r = client.post("/api/jobs", json={"type": "optimize"})
         assert r.status_code == 422
 
+    def test_submit_mixture_optimize_missing_params_returns_422(self, client):
+        r = client.post("/api/jobs", json={"type": "mixture_optimize"})
+        assert r.status_code == 422
+
     def test_submit_simulate_missing_params_returns_422(self, client):
         r = client.post("/api/jobs", json={"type": "simulate"})
         assert r.status_code == 422
@@ -592,6 +603,12 @@ class TestRunnerCdfLoader:
 
         with pytest.raises(FileNotFoundError):
             _load_cdf(WorkloadRef(type="builtin", name="does_not_exist_xyz"))
+
+    def test_load_mixture_scenario_rejects_non_builtin_paths(self):
+        from fleet_sim.api.runner import _load_mixture_scenario
+
+        with pytest.raises(FileNotFoundError, match="Built-in mixture scenario"):
+            _load_mixture_scenario("../workload_mixture_nominal.json")
 
     def test_load_trace_without_id_raises(self):
         from fleet_sim.api.models import WorkloadRef
@@ -1076,6 +1093,34 @@ class TestJobLifecycle:
         assert "sweep" in opt
         assert opt["best"]["total_gpus"] > 0
         assert opt["savings_pct"] >= 0.0
+
+    def test_mixture_optimize_job_completes_and_has_result(self, client):
+        body = {
+            "type": "mixture_optimize",
+            "mixture_optimize": {
+                "scenario": "nominal",
+                "lam": 20.0,
+                "slo_ms": 500.0,
+                "b_short": 4096,
+                "gpu_short": "a100",
+                "gpu_long": "a100",
+                "long_max_ctx": 65536,
+                "gamma_min": 1.0,
+                "gamma_max": 1.0,
+                "gamma_step": 0.5,
+                "n_sim_requests": 0,
+            },
+        }
+        r = client.post("/api/jobs", json=body)
+        assert r.status_code == 200
+        job = _wait_job_done(client, r.json()["id"])
+
+        assert job["status"] == "done", f"Job failed: {job.get('error')}"
+        result = job["result_mixture_optimize"]
+        assert result is not None
+        assert result["ok"] is True
+        assert result["robust_recommendation"]["total_gpus"] > 0
+        assert any(case["case_id"] == "nominal-mixture" for case in result["cases"])
 
     def test_simulate_job_completes_and_has_result(self, client):
         body = {

--- a/src/fleet-sim/tests/test_optimizer.py
+++ b/src/fleet-sim/tests/test_optimizer.py
@@ -305,6 +305,32 @@ class TestCLISubcommands:
         )
         assert "n_s" in out or "total" in out.lower()
 
+    def test_mixture_optimize(self, tmp_path):
+        out_file = tmp_path / "mixture-report.json"
+        out = self._run(
+            "mixture-optimize",
+            "--scenario",
+            "data/workload_mixture_nominal.json",
+            "--lam",
+            "20",
+            "--slo",
+            "500",
+            "--b-short",
+            "4096",
+            "--long-max-ctx",
+            "65536",
+            "--gamma-max",
+            "1.0",
+            "--out",
+            str(out_file),
+        )
+
+        assert "robust" in out.lower()
+        data = json.loads(out_file.read_text())
+        assert data["ok"] is True
+        assert data["robust_recommendation"]["total_gpus"] > 0
+        assert any(case["case_id"] == "aggregate-cdf" for case in data["cases"])
+
     def test_simulate(self):
         out = self._run(
             "simulate",

--- a/src/fleet-sim/tests/test_optimizer.py
+++ b/src/fleet-sim/tests/test_optimizer.py
@@ -331,6 +331,30 @@ class TestCLISubcommands:
         assert data["robust_recommendation"]["total_gpus"] > 0
         assert any(case["case_id"] == "aggregate-cdf" for case in data["cases"])
 
+    def test_forecast_backtest(self, tmp_path):
+        out_file = tmp_path / "forecast-report.json"
+        out = self._run(
+            "forecast-backtest",
+            "--scenario",
+            "data/workload_forecast_seasonal.json",
+            "--slo",
+            "500",
+            "--b-short",
+            "4096",
+            "--long-max-ctx",
+            "65536",
+            "--gamma-max",
+            "1.0",
+            "--out",
+            str(out_file),
+        )
+
+        assert "advise-only" in out
+        data = json.loads(out_file.read_text())
+        assert data["recommended_method"] == "seasonal_naive"
+        assert data["actuation_records"] == []
+        assert any(item["method"] == "seasonal_naive" for item in data["methods"])
+
     def test_simulate(self):
         out = self._run(
             "simulate",

--- a/src/fleet-sim/tests/test_workload_forecast_optimizer.py
+++ b/src/fleet-sim/tests/test_workload_forecast_optimizer.py
@@ -1,0 +1,95 @@
+"""Tests for FleetOptimizer workload forecast backtesting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fleet_sim.gpu_profiles.profiles import A100_80GB
+from fleet_sim.optimizer import FleetOptimizer, evaluate_forecast_backtest
+from fleet_sim.workload import load_forecast_scenario
+
+_DATA = Path(__file__).parent.parent / "fleet_sim" / "data"
+
+
+def _optimizer() -> FleetOptimizer:
+    return FleetOptimizer(
+        gpu_short=A100_80GB,
+        gpu_long=A100_80GB,
+        B_short=4096,
+        t_slo_ms=500,
+        long_max_ctx=65536,
+    )
+
+
+def _scenario(name: str):
+    return load_forecast_scenario(_DATA / f"workload_forecast_{name}.json")
+
+
+def test_forecast_backtest_reports_baselines_recommendations_and_no_actuation():
+    report = evaluate_forecast_backtest(
+        optimizer=_optimizer(),
+        scenario=_scenario("seasonal"),
+        gammas=[1.0],
+    )
+
+    methods = {method.method: method for method in report.methods}
+    assert set(methods) == {
+        "static_mean",
+        "reactive_last_window",
+        "moving_window",
+        "seasonal_naive",
+        "linear_trend",
+    }
+    assert report.actual_required is not None
+    assert methods["seasonal_naive"].score == 0
+    assert methods["seasonal_naive"].beats_static_control is True
+    assert methods["seasonal_naive"].beats_reactive_control is True
+    assert report.recommended_method == "seasonal_naive"
+    assert report.actuation_records == ()
+
+    data = report.to_dict()
+    assert data["actuation_records"] == []
+    assert data["methods"][0]["mixture_report"]["cases"]
+
+
+def test_forecast_backtest_reports_drift_and_statistical_baseline():
+    report = evaluate_forecast_backtest(
+        optimizer=_optimizer(),
+        scenario=_scenario("drift"),
+        gammas=[1.0],
+    )
+
+    assert any("taxonomy drift" in item for item in report.diagnostics)
+    assert any(method.method == "linear_trend" for method in report.methods)
+    assert report.actual_required is not None
+
+
+def test_forecast_backtest_reports_burst_oscillation_and_simple_control_loss():
+    report = evaluate_forecast_backtest(
+        optimizer=_optimizer(),
+        scenario=_scenario("burst"),
+        gammas=[1.0],
+    )
+
+    assert any("burst detected" in item for item in report.diagnostics)
+    assert any("oscillation risk" in item for item in report.diagnostics)
+    assert any(
+        "forecasting did not beat simpler controls" in item
+        for item in report.diagnostics
+    )
+
+
+def test_stale_data_rolls_back_to_reactive_fallback_without_actuation():
+    report = evaluate_forecast_backtest(
+        optimizer=_optimizer(),
+        scenario=_scenario("burst"),
+        gammas=[1.0],
+        now_s=360,
+    )
+
+    assert report.fail_safe_triggered is True
+    assert report.fallback_control == "reactive_last_window"
+    assert report.rollback_reason is not None
+    assert report.recommended_method == "reactive_last_window"
+    assert [method.method for method in report.methods] == ["reactive_last_window"]
+    assert report.actuation_records == ()

--- a/src/fleet-sim/tests/test_workload_forecast_optimizer.py
+++ b/src/fleet-sim/tests/test_workload_forecast_optimizer.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import pytest
 from fleet_sim.gpu_profiles.profiles import A100_80GB
-from fleet_sim.optimizer import FleetOptimizer, evaluate_forecast_backtest
-from fleet_sim.workload import load_forecast_scenario
+from fleet_sim.optimizer import (
+    FleetOptimizer,
+    evaluate_forecast_backtest,
+)
+from fleet_sim.workload import (
+    ForecastValidationError,
+    WorkloadForecastScenario,
+    load_forecast_scenario,
+)
 
 _DATA = Path(__file__).parent.parent / "fleet_sim" / "data"
 
@@ -25,6 +34,10 @@ def _scenario(name: str):
     return load_forecast_scenario(_DATA / f"workload_forecast_{name}.json")
 
 
+def _scenario_from_data(data: dict):
+    return WorkloadForecastScenario.from_dict(data, base_dir=_DATA)
+
+
 def test_forecast_backtest_reports_baselines_recommendations_and_no_actuation():
     report = evaluate_forecast_backtest(
         optimizer=_optimizer(),
@@ -41,7 +54,7 @@ def test_forecast_backtest_reports_baselines_recommendations_and_no_actuation():
         "linear_trend",
     }
     assert report.actual_required is not None
-    assert methods["seasonal_naive"].score == 0
+    assert methods["seasonal_naive"].score < 0.001
     assert methods["seasonal_naive"].beats_static_control is True
     assert methods["seasonal_naive"].beats_reactive_control is True
     assert report.recommended_method == "seasonal_naive"
@@ -50,6 +63,50 @@ def test_forecast_backtest_reports_baselines_recommendations_and_no_actuation():
     data = report.to_dict()
     assert data["actuation_records"] == []
     assert data["methods"][0]["mixture_report"]["cases"]
+
+
+def test_backtest_capacity_and_score_include_token_demand():
+    data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
+    baseline = evaluate_forecast_backtest(
+        optimizer=_optimizer(),
+        scenario=_scenario_from_data(data),
+        gammas=[1.0],
+    )
+
+    heavier = json.loads(json.dumps(data))
+    for window in heavier["holdout_windows"]:
+        window["total_tokens"] *= 100
+        window["p50_total_tokens"] *= 100
+        window["p95_total_tokens"] *= 100
+    heavier_report = evaluate_forecast_backtest(
+        optimizer=_optimizer(),
+        scenario=_scenario_from_data(heavier),
+        gammas=[1.0],
+    )
+
+    assert baseline.actual_required is not None
+    assert heavier_report.actual_required is not None
+    assert (
+        heavier_report.actual_required.total_gpus > baseline.actual_required.total_gpus
+    )
+    seasonal = next(
+        method for method in heavier_report.methods if method.method == "seasonal_naive"
+    )
+    assert seasonal.mean_abs_tokens_per_request_error_pct > 0
+    assert seasonal.score > 0
+
+
+def test_forecast_backtest_rejects_incomplete_holdout_horizon():
+    data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
+    data["forecast_horizon_windows"] = 5
+    data["holdout_windows"] = data["holdout_windows"][:2]
+
+    with pytest.raises(ForecastValidationError, match="exceeds available holdout"):
+        evaluate_forecast_backtest(
+            optimizer=_optimizer(),
+            scenario=_scenario_from_data(data),
+            gammas=[1.0],
+        )
 
 
 def test_forecast_backtest_reports_drift_and_statistical_baseline():

--- a/src/fleet-sim/tests/test_workload_forecasts.py
+++ b/src/fleet-sim/tests/test_workload_forecasts.py
@@ -1,0 +1,114 @@
+"""Tests for workload archetype forecast aggregate scenarios."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fleet_sim.workload import (
+    ForecastValidationError,
+    LinearTrendForecaster,
+    SeasonalNaiveForecaster,
+    WorkloadForecastScenario,
+    detect_aggregate_diagnostics,
+    forecast_to_mixture_scenario,
+    load_forecast_scenario,
+    validate_forecast_scenario,
+    validate_mixture_scenario,
+)
+
+_DATA = Path(__file__).parent.parent / "fleet_sim" / "data"
+
+
+def _scenario(name: str):
+    return load_forecast_scenario(_DATA / f"workload_forecast_{name}.json")
+
+
+def test_forecast_fixture_loads_and_validates_schema_and_taxonomy():
+    scenario = _scenario("seasonal")
+
+    assert scenario.schema_version == "fleet-sim.workload-archetype-forecast/v1alpha1"
+    assert scenario.taxonomy_version == "fleet-sim.workload-archetype-taxonomy/v1alpha1"
+    assert scenario.privacy.content_free is True
+    assert scenario.privacy.min_requests_per_window == 100
+    assert scenario.load_source_mixture().archetype_ids == (
+        "interactive-chat",
+        "multiturn-chat",
+        "agent-heavy",
+    )
+
+
+def test_high_cardinality_or_content_fields_fail_validation():
+    data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
+    data["aggregate_windows"][0]["caller_id"] = "customer-123"
+    scenario = WorkloadForecastScenario.from_dict(data, base_dir=_DATA)
+
+    with pytest.raises(ForecastValidationError, match="caller_id"):
+        validate_forecast_scenario(scenario, raw_data=data)
+
+
+def test_low_count_window_fails_privacy_threshold():
+    data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
+    data["aggregate_windows"][0]["request_count"] = 5
+    scenario = WorkloadForecastScenario.from_dict(data, base_dir=_DATA)
+
+    with pytest.raises(ForecastValidationError, match="min_requests_per_window"):
+        validate_forecast_scenario(scenario, raw_data=data)
+
+
+def test_seasonal_forecast_converts_to_reproducible_mixture_scenario():
+    scenario = _scenario("seasonal")
+    source_mixture = scenario.load_source_mixture()
+    windows = SeasonalNaiveForecaster(season_length_windows=3).forecast(scenario)
+    base_lam = sum(window.arrival_rate for window in scenario.aggregate_windows) / len(
+        scenario.aggregate_windows
+    )
+
+    mixture = forecast_to_mixture_scenario(
+        source_mixture=source_mixture,
+        windows=windows,
+        base_lam=base_lam,
+        scenario_id="test-seasonal-forecast",
+        version="test",
+    )
+
+    validate_mixture_scenario(mixture)
+    assert len(mixture.composition_schedule) == 2
+    assert windows[0].archetype_weights == scenario.holdout_windows[0].archetype_weights
+    assert windows[1].request_count == scenario.holdout_windows[1].request_count
+
+
+def test_linear_trend_projects_drift_and_normalizes_weights():
+    scenario = _scenario("drift")
+    windows = LinearTrendForecaster(window_count=4).forecast(scenario)
+
+    assert (
+        windows[0].archetype_weights["agent-heavy"]
+        > scenario.aggregate_windows[-1].archetype_weights["agent-heavy"]
+    )
+    for window in windows:
+        assert sum(window.archetype_weights.values()) == pytest.approx(1.0)
+
+
+def test_burst_drift_and_oscillation_diagnostics_are_detected():
+    burst = _scenario("burst")
+    burst_diagnostics = detect_aggregate_diagnostics(
+        burst.aggregate_windows, burst.holdout_windows
+    )
+
+    assert any("burst detected" in item for item in burst_diagnostics)
+    assert any("oscillation risk" in item for item in burst_diagnostics)
+
+    drift = _scenario("drift")
+    drift_diagnostics = detect_aggregate_diagnostics(
+        drift.aggregate_windows, drift.holdout_windows
+    )
+    assert any("taxonomy drift" in item for item in drift_diagnostics)
+
+
+def test_stale_reason_supports_reactive_rollback_policy():
+    scenario = _scenario("burst")
+
+    assert scenario.stale_reason(now_s=240) is None
+    assert "stale" in scenario.stale_reason(now_s=360)

--- a/src/fleet-sim/tests/test_workload_forecasts.py
+++ b/src/fleet-sim/tests/test_workload_forecasts.py
@@ -48,6 +48,24 @@ def test_high_cardinality_or_content_fields_fail_validation():
         validate_forecast_scenario(scenario, raw_data=data)
 
 
+def test_unknown_window_dimensions_fail_closed():
+    data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
+    data["aggregate_windows"][0]["device_fingerprint"] = "unique-device-123"
+    scenario = WorkloadForecastScenario.from_dict(data, base_dir=_DATA)
+
+    with pytest.raises(ForecastValidationError, match="device_fingerprint"):
+        validate_forecast_scenario(scenario, raw_data=data)
+
+
+def test_privacy_allowed_dimensions_are_enforced():
+    data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
+    data["privacy"]["allowed_dimensions"] = ["archetype_weights", "model_class"]
+    scenario = WorkloadForecastScenario.from_dict(data, base_dir=_DATA)
+
+    with pytest.raises(ForecastValidationError, match="slo_class"):
+        validate_forecast_scenario(scenario, raw_data=data)
+
+
 def test_low_count_window_fails_privacy_threshold():
     data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
     data["aggregate_windows"][0]["request_count"] = 5
@@ -75,8 +93,19 @@ def test_seasonal_forecast_converts_to_reproducible_mixture_scenario():
 
     validate_mixture_scenario(mixture)
     assert len(mixture.composition_schedule) == 2
+    assert all(window.token_scale > 0 for window in mixture.composition_schedule)
     assert windows[0].archetype_weights == scenario.holdout_windows[0].archetype_weights
     assert windows[1].request_count == scenario.holdout_windows[1].request_count
+
+
+def test_forecast_horizon_requires_available_holdout_windows():
+    data = json.loads((_DATA / "workload_forecast_seasonal.json").read_text())
+    data["forecast_horizon_windows"] = 5
+    data["holdout_windows"] = data["holdout_windows"][:2]
+    scenario = WorkloadForecastScenario.from_dict(data, base_dir=_DATA)
+
+    with pytest.raises(ForecastValidationError, match="exceeds available holdout"):
+        validate_forecast_scenario(scenario, raw_data=data)
 
 
 def test_linear_trend_projects_drift_and_normalizes_weights():

--- a/src/fleet-sim/tests/test_workload_mixture_optimizer.py
+++ b/src/fleet-sim/tests/test_workload_mixture_optimizer.py
@@ -1,0 +1,93 @@
+"""Tests for FleetOptimizer workload mixture reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fleet_sim.gpu_profiles.profiles import A100_80GB
+from fleet_sim.optimizer import (
+    FleetOptimizer,
+    MixtureOptimizationError,
+    evaluate_mixture_scenario,
+)
+from fleet_sim.workload import load_mixture_scenario
+
+_DATA = Path(__file__).parent.parent / "fleet_sim" / "data"
+
+
+def _optimizer() -> FleetOptimizer:
+    return FleetOptimizer(
+        gpu_short=A100_80GB,
+        gpu_long=A100_80GB,
+        B_short=4096,
+        t_slo_ms=500,
+        long_max_ctx=65536,
+    )
+
+
+def test_mixture_report_compares_baselines_and_archetypes():
+    scenario = load_mixture_scenario(_DATA / "workload_mixture_nominal.json")
+
+    report = evaluate_mixture_scenario(
+        optimizer=_optimizer(),
+        scenario=scenario,
+        lam=20,
+        gammas=[1.0, 1.2],
+    )
+
+    case_ids = {case.case_id for case in report.cases}
+    assert report.ok, report.diagnostics
+    assert "aggregate-cdf" in case_ids
+    assert "nominal-mixture" in case_ids
+    assert "archetype:agent-heavy" in case_ids
+    assert report.robust_recommendation is not None
+    assert report.robust_recommendation.total_gpus >= 1
+    assert any(
+        case.cost_sensitivity_pct not in (None, 0.0)
+        for case in report.cases
+        if case.kind == "individual_archetype"
+    )
+    assert any("worst-case mixture" in item for item in report.diagnostics)
+
+
+def test_mixture_report_includes_drift_and_burst_windows():
+    for fixture in ("drift", "burst"):
+        scenario = load_mixture_scenario(_DATA / f"workload_mixture_{fixture}.json")
+        report = evaluate_mixture_scenario(
+            optimizer=_optimizer(),
+            scenario=scenario,
+            lam=20,
+            gammas=[1.0],
+        )
+
+        window_cases = [
+            case for case in report.cases if case.kind == "composition_window"
+        ]
+        assert len(window_cases) == len(scenario.composition_schedule)
+        assert report.robust_recommendation is not None
+
+
+def test_mixture_report_fails_explicitly_when_gpu_budget_is_infeasible():
+    scenario = load_mixture_scenario(_DATA / "workload_mixture_burst.json")
+
+    report = evaluate_mixture_scenario(
+        optimizer=_optimizer(),
+        scenario=scenario,
+        lam=200,
+        gammas=[1.0],
+        max_total_gpus=1,
+    )
+
+    assert not report.ok
+    assert report.robust_recommendation is None
+    assert any("max_total_gpus=1" in item for item in report.diagnostics)
+    with pytest.raises(MixtureOptimizationError, match="max_total_gpus=1"):
+        evaluate_mixture_scenario(
+            optimizer=_optimizer(),
+            scenario=scenario,
+            lam=200,
+            gammas=[1.0],
+            max_total_gpus=1,
+            fail_on_infeasible=True,
+        )

--- a/src/fleet-sim/tests/test_workload_mixtures.py
+++ b/src/fleet-sim/tests/test_workload_mixtures.py
@@ -1,0 +1,239 @@
+"""Tests for workload archetype mixture scenarios."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from fleet_sim.workload import (
+    MixtureSampler,
+    MixtureScenario,
+    MixtureValidationError,
+    load_mixture_scenario,
+    validate_mixture_scenario,
+    validate_sample_distribution,
+)
+
+_DATA = Path(__file__).parent.parent / "fleet_sim" / "data"
+
+
+def _scenario(name: str) -> MixtureScenario:
+    return load_mixture_scenario(_DATA / f"workload_mixture_{name}.json")
+
+
+def _signature(arrivals):
+    return [
+        (
+            round(t, 6),
+            req.l_in,
+            req.l_out,
+            req.category,
+            req.archetype_id,
+            req.slo_class,
+            req.eligible_models,
+            req.residency,
+        )
+        for t, req in arrivals
+    ]
+
+
+def test_nominal_fixture_loads_and_validates():
+    scenario = _scenario("nominal")
+
+    assert scenario.schema_version == "fleet-sim.workload-mixture/v1alpha1"
+    assert scenario.id == "nominal-chat-multiturn-agent"
+    assert scenario.nominal_weights == {
+        "interactive-chat": 0.6,
+        "multiturn-chat": 0.25,
+        "agent-heavy": 0.15,
+    }
+
+
+def test_bad_weight_normalization_fails():
+    data = json.loads((_DATA / "workload_mixture_nominal.json").read_text())
+    data["archetypes"][0]["weight"] = 0.7
+    scenario = MixtureScenario.from_dict(data, base_dir=_DATA)
+
+    with pytest.raises(MixtureValidationError, match=r"weights must sum to 1\.0"):
+        validate_mixture_scenario(scenario)
+
+
+def test_invalid_cdf_fails_closed(tmp_path):
+    bad_cdf = tmp_path / "bad_cdf.json"
+    bad_cdf.write_text(json.dumps([[10, 0.7], [5, 1.0]]))
+    scenario = MixtureScenario.from_dict(
+        {
+            "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+            "id": "bad-cdf",
+            "version": "test",
+            "seed": 1,
+            "archetypes": [
+                {
+                    "id": "bad",
+                    "version": "test",
+                    "source": {"kind": "cdf", "path": "bad_cdf.json"},
+                    "arrival_process": {"kind": "poisson"},
+                    "slo_class": "interactive",
+                    "model_eligibility": ["test-model"],
+                    "residency": ["global"],
+                    "weight": 1.0,
+                }
+            ],
+        },
+        base_dir=tmp_path,
+    )
+
+    with pytest.raises(MixtureValidationError, match="strictly increasing"):
+        validate_mixture_scenario(scenario)
+
+
+def test_fixed_mixture_sampling_is_reproducible():
+    scenario = _scenario("nominal")
+
+    first = MixtureSampler(scenario).generate(lam=80, n_requests=200)
+    second = MixtureSampler(scenario).generate(lam=80, n_requests=200)
+    changed_seed = MixtureSampler(replace(scenario, seed=scenario.seed + 1)).generate(
+        lam=80,
+        n_requests=200,
+    )
+
+    assert _signature(first) == _signature(second)
+    assert _signature(first) != _signature(changed_seed)
+
+
+def test_fixed_mixture_distribution_report_passes_for_large_sample():
+    scenario = _scenario("nominal")
+    arrivals = MixtureSampler(scenario).generate(lam=400, n_requests=8_000)
+
+    report = validate_sample_distribution(
+        arrivals,
+        scenario,
+        weight_tolerance=0.03,
+        cdf_tolerance=0.08,
+    )
+
+    assert report.ok, report.errors
+    assert report.aggregate_cdf_max_error is not None
+    assert report.quantiles["p95"] >= report.quantiles["p50"]
+
+
+def test_distribution_report_catches_sampling_errors():
+    scenario = _scenario("nominal")
+    arrivals = MixtureSampler(scenario).generate(lam=200, n_requests=1_000)
+    for _, req in arrivals:
+        req.archetype_id = "interactive-chat"
+
+    report = validate_sample_distribution(arrivals, scenario, weight_tolerance=0.05)
+
+    assert not report.ok
+    assert any("observed weight" in error for error in report.errors)
+
+
+def test_small_samples_warn_instead_of_failing_distribution_checks():
+    scenario = _scenario("nominal")
+    arrivals = MixtureSampler(scenario).generate(lam=20, n_requests=12)
+
+    report = validate_sample_distribution(arrivals, scenario)
+
+    assert report.ok
+    assert any("sample size" in warning for warning in report.warnings)
+
+
+def test_time_varying_fixture_shifts_and_validates_distribution():
+    scenario = _scenario("drift")
+    arrivals = MixtureSampler(scenario).generate_until(lam=80, duration_s=120)
+
+    first_window = [req for t, req in arrivals if t < 60]
+    second_window = [req for t, req in arrivals if t >= 60]
+
+    def share(requests, archetype_id: str) -> float:
+        return sum(1 for req in requests if req.archetype_id == archetype_id) / len(
+            requests
+        )
+
+    assert (
+        share(second_window, "agent-heavy") > share(first_window, "agent-heavy") + 0.20
+    )
+
+    report = validate_sample_distribution(
+        arrivals,
+        scenario,
+        weight_tolerance=0.04,
+        cdf_tolerance=0.08,
+    )
+    assert report.ok, report.errors
+
+
+def test_request_metadata_is_stamped_from_archetype():
+    scenario = _scenario("nominal")
+    arrivals = MixtureSampler(scenario).generate(lam=200, n_requests=200)
+    agent_req = next(req for _, req in arrivals if req.archetype_id == "agent-heavy")
+
+    assert agent_req.slo_class == "batch"
+    assert agent_req.eligible_models == ("llama-3.1-70b", "deepseek-v3")
+    assert agent_req.residency == ("us",)
+
+
+def test_trace_source_preserves_explicit_row_fields(tmp_path):
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": 1.0,
+                        "prompt_tokens": 100,
+                        "generated_tokens": 20,
+                        "selected_model": "trace-model-a",
+                        "category": "code",
+                        "complexity": "hard",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": 2.0,
+                        "prompt_tokens": 40,
+                        "generated_tokens": 10,
+                        "selected_model": "trace-model-b",
+                        "category": "rag",
+                        "complexity": "easy",
+                    }
+                ),
+            ]
+        )
+    )
+    scenario = MixtureScenario.from_dict(
+        {
+            "schema_version": "fleet-sim.workload-mixture/v1alpha1",
+            "id": "trace-mixture",
+            "version": "test",
+            "seed": 7,
+            "archetypes": [
+                {
+                    "id": "trace-archetype",
+                    "version": "test",
+                    "source": {
+                        "kind": "trace",
+                        "path": "trace.jsonl",
+                        "format": "semantic_router",
+                    },
+                    "arrival_process": {"kind": "poisson"},
+                    "slo_class": "interactive",
+                    "model_eligibility": ["trace-model-a", "trace-model-b"],
+                    "residency": ["global"],
+                    "weight": 1.0,
+                }
+            ],
+        },
+        base_dir=tmp_path,
+    )
+
+    arrivals = MixtureSampler(scenario).generate(lam=10, n_requests=2)
+
+    first_req = arrivals[0][1]
+    assert first_req.model_id == "trace-model-a"
+    assert first_req.category == "code"
+    assert first_req._complexity == "hard"
+    assert first_req.archetype_id == "trace-archetype"


### PR DESCRIPTION
## Stacked PR / dependency

Depends on #2596. This PR is stacked on the FleetSim workload mixture primitives from #2596 and should be reviewed/merged after that PR. The lower commit `509738a74ba074aa0efe6006d60b67892f494007` belongs to #2596; the original #2554 implementation commit is `cc66912d18197c8bc13ecd11ac726d0786da953c`, and the latest review-fix commit is `cd81a904b1d316a2b7b960746a0a76942988e681`.

After #2596 merges, I will rebase this branch onto `upstream/main` so the final diff only contains the forecasting work.

Closes #2554.

## Summary

- Add versioned, content-free aggregate workload forecast windows with privacy validation.
- Add seasonal, drift, and burst forecast fixtures.
- Add static, reactive, moving-window, seasonal-naive, and linear-trend forecast baselines.
- Convert forecast outputs into FleetSim mixture scenarios for sizing experiments.
- Carry aggregate token demand into mixture capacity through per-window `token_scale`.
- Add FleetOptimizer backtest reporting with advise-only recommendations kept separate from actuation records.
- Include arrival, token/request, P95 total-token, P99 TTFT, and mixture-weight calibration errors in backtest scoring/reporting.
- Add stale-data rollback, drift/burst/oscillation diagnostics, CLI/docs, and tests.
- Fail closed on unknown aggregate-window fields, enforce `privacy.allowed_dimensions`, and reject incomplete holdout horizons.

## Validation

Local validation on `codex/workload-archetype-forecasting` at `cd81a904b1d316a2b7b960746a0a76942988e681`:

- `python3 -m pytest tests/test_workload_forecasts.py tests/test_workload_forecast_optimizer.py tests/test_optimizer.py::TestCLISubcommands::test_forecast_backtest -q` passed: 17 tests.
- `make agent-report ENV=cpu CHANGED_FILES="..."` passed and selected `make vllm-sr-sim-test`.
- `make agent-ci-gate CHANGED_FILES="..."` passed, including lint, structure checks, Go reference config contract lint, and FleetSim tests: 339 passed, 6 warnings.
- Explicit CLI E2E passed with `actual_required_gpus=45`, `recommended_method=seasonal_naive`, empty `actuation_records`, and token-scale/error fields present.
- Reviewer repro checks passed: multiplying holdout token totals/P50/P95 by 100 changes capacity `45 -> 1901` and seasonal score `0.0005697315067356653 -> 0.4955697315067356`; unknown `device_fingerprint` is rejected; horizon 3 with only 2 holdout windows is rejected.

Optional remote clean-clone validation on `ssh root@134.199.199.149`:

- Clone path: `/root/codex-validation/semantic-router/semantic-router-workload-archetype-forecasting-review-20260719045508`
- Branch: `codex/workload-archetype-forecasting`
- Commit: `cd81a904b1d316a2b7b960746a0a76942988e681`
- `make agent-report ENV=cpu CHANGED_FILES="..."` passed and selected `make vllm-sr-sim-test`.
- `make agent-ci-gate CHANGED_FILES="..."` passed: 339 passed, 6 warnings.
- Explicit CLI E2E passed: `REMOTE_FORECAST_CLI_E2E_PASS`, `actual_required_gpus=45`, `recommended_method=seasonal_naive`, `actuation_records=[]`.
- Reviewer repro markers passed: `REMOTE_TOKEN_REPRO_PASS`, `REMOTE_SCORE_REPRO_PASS`, `REMOTE_UNKNOWN_FIELD_REJECTED`, `REMOTE_SHORT_HORIZON_REJECTED`.