### PR TITLE
fix: make maintainer board GitHub fetch resilient

### DIFF
--- a/tools/agent/scripts/maintainer_board.py
+++ b/tools/agent/scripts/maintainer_board.py
@@ -9,6 +9,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,14 @@ from maintainer_release_plan import (
 REPO_ROOT = Path(__file__).resolve().parents[3]
 POLICY_PATH = REPO_ROOT / "tools" / "agent" / "maintainer-policy.yaml"
 DEFAULT_ACTIONS = "proposed-actions.json"
+TRANSIENT_GH_ERRORS = (
+    "HTTP 502",
+    "HTTP 503",
+    "HTTP 504",
+    "502 Bad Gateway",
+    "503 Service Unavailable",
+    "504 Gateway Timeout",
+)
 
 
 def load_policy() -> dict[str, Any]:
@@ -55,20 +64,49 @@ def age_days(value: str | None, now: dt.datetime) -> int:
     return max(0, (now - parse_time(value)).days)
 
 
-def gh_json(args: list[str]) -> Any:
-    result = subprocess.run(
-        ["gh", *args],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if result.returncode != 0:
+def is_transient_gh_error(result: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{result.stderr}\n{result.stdout}"
+    return any(error in output for error in TRANSIENT_GH_ERRORS)
+
+
+def gh_json(args: list[str], attempts: int = 3) -> Any:
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(
+            ["gh", *args],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            if not result.stdout.strip():
+                return None
+            return json.loads(result.stdout)
+        if attempt < attempts and is_transient_gh_error(result):
+            delay = 2 ** (attempt - 1)
+            sys.stderr.write(
+                f"gh {' '.join(args)} failed with a transient GitHub error; "
+                f"retrying in {delay}s ({attempt}/{attempts})\n"
+            )
+            time.sleep(delay)
+            continue
         sys.stderr.write(result.stderr)
         raise SystemExit(result.returncode)
-    if not result.stdout.strip():
-        return None
-    return json.loads(result.stdout)
+    raise SystemExit(1)
+
+
+def attach_pr_status_rollups(prs: list[dict[str, Any]]) -> None:
+    for pr in prs:
+        details = gh_json(
+            [
+                "pr",
+                "view",
+                str(pr["number"]),
+                "--json",
+                "statusCheckRollup",
+            ]
+        )
+        pr["statusCheckRollup"] = (details or {}).get("statusCheckRollup") or []
 
 
 def fetch_github_state(
@@ -99,9 +137,10 @@ def fetch_github_state(
             "--limit",
             pr_limit,
             "--json",
-            "number,title,labels,milestone,assignees,createdAt,updatedAt,author,url,isDraft,reviewDecision,mergeStateStatus,statusCheckRollup,headRefName,baseRefName",
+            "number,title,labels,milestone,assignees,createdAt,updatedAt,author,url,isDraft,reviewDecision,mergeStateStatus,headRefName,baseRefName",
         ]
-    )
+    ) or []
+    attach_pr_status_rollups(prs)
     milestones = gh_json(["api", "repos/{owner}/{repo}/milestones?state=open"])
     labels = gh_json(["label", "list", "--json", "name,description,color"])
     return {

--- a/tools/agent/scripts/maintainer_board.py
+++ b/tools/agent/scripts/maintainer_board.py
@@ -128,18 +128,21 @@ def fetch_github_state(
             "number,title,labels,milestone,assignees,createdAt,updatedAt,author,url",
         ]
     )
-    prs = gh_json(
-        [
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--limit",
-            pr_limit,
-            "--json",
-            "number,title,labels,milestone,assignees,createdAt,updatedAt,author,url,isDraft,reviewDecision,mergeStateStatus,headRefName,baseRefName",
-        ]
-    ) or []
+    prs = (
+        gh_json(
+            [
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                pr_limit,
+                "--json",
+                "number,title,labels,milestone,assignees,createdAt,updatedAt,author,url,isDraft,reviewDecision,mergeStateStatus,headRefName,baseRefName",
+            ]
+        )
+        or []
+    )
     attach_pr_status_rollups(prs)
     milestones = gh_json(["api", "repos/{owner}/{repo}/milestones?state=open"])
     labels = gh_json(["label", "list", "--json", "name,description,color"])

--- a/tools/agent/scripts/tests/test_maintainer_board_ga_readiness.py
+++ b/tools/agent/scripts/tests/test_maintainer_board_ga_readiness.py
@@ -106,7 +106,9 @@ class MaintainerBoardGAReadinessTests(unittest.TestCase):
         )
         pr_list_call = gh_json.call_args_list[1].args[0]
         pr_list_fields = pr_list_call[pr_list_call.index("--json") + 1]
-        self.assertIn("reviewDecision,mergeStateStatus,headRefName,baseRefName", pr_list_fields)
+        self.assertIn(
+            "reviewDecision,mergeStateStatus,headRefName,baseRefName", pr_list_fields
+        )
         self.assertNotIn("statusCheckRollup", pr_list_fields)
         self.assertEqual(
             gh_json.call_args_list[2].args[0],

--- a/tools/agent/scripts/tests/test_maintainer_board_ga_readiness.py
+++ b/tools/agent/scripts/tests/test_maintainer_board_ga_readiness.py
@@ -40,6 +40,83 @@ def empty_snapshot() -> dict:
 
 
 class MaintainerBoardGAReadinessTests(unittest.TestCase):
+    def test_gh_json_retries_transient_gateway_errors(self) -> None:
+        transient = maintainer_board.subprocess.CompletedProcess(
+            ["gh", "pr", "list"],
+            1,
+            stdout="",
+            stderr="HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)",
+        )
+        success = maintainer_board.subprocess.CompletedProcess(
+            ["gh", "pr", "list"],
+            0,
+            stdout='{"ok": true}',
+            stderr="",
+        )
+
+        with (
+            mock.patch.object(
+                maintainer_board.subprocess,
+                "run",
+                side_effect=[transient, success],
+            ) as run,
+            mock.patch.object(maintainer_board.time, "sleep") as sleep,
+        ):
+            payload = maintainer_board.gh_json(["pr", "list"])
+
+        self.assertEqual(payload, {"ok": True})
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(1)
+
+    def test_fetch_github_state_fetches_pr_status_rollups_separately(self) -> None:
+        policy = {"default_issue_limit": 100, "default_pr_limit": 50}
+        prs = [
+            {"number": 12, "title": "ready"},
+            {"number": 13, "title": "blocked"},
+        ]
+
+        with mock.patch.object(
+            maintainer_board,
+            "gh_json",
+            side_effect=[
+                [],
+                prs,
+                {"statusCheckRollup": [{"conclusion": "SUCCESS"}]},
+                {"statusCheckRollup": [{"conclusion": "FAILURE"}]},
+                [{"title": "v0.4"}],
+                [{"name": "bug"}],
+            ],
+        ) as gh_json:
+            state = maintainer_board.fetch_github_state(policy)
+
+        self.assertEqual(
+            state["pull_requests"],
+            [
+                {
+                    "number": 12,
+                    "title": "ready",
+                    "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+                },
+                {
+                    "number": 13,
+                    "title": "blocked",
+                    "statusCheckRollup": [{"conclusion": "FAILURE"}],
+                },
+            ],
+        )
+        pr_list_call = gh_json.call_args_list[1].args[0]
+        pr_list_fields = pr_list_call[pr_list_call.index("--json") + 1]
+        self.assertIn("reviewDecision,mergeStateStatus,headRefName,baseRefName", pr_list_fields)
+        self.assertNotIn("statusCheckRollup", pr_list_fields)
+        self.assertEqual(
+            gh_json.call_args_list[2].args[0],
+            ["pr", "view", "12", "--json", "statusCheckRollup"],
+        )
+        self.assertEqual(
+            gh_json.call_args_list[3].args[0],
+            ["pr", "view", "13", "--json", "statusCheckRollup"],
+        )
+
     def test_latest_ga_readiness_report_summarizes_blockers(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- retry transient `gh` failures for GitHub 502/503/504 responses
- fetch PR status rollups with per-PR `gh pr view` calls instead of including `statusCheckRollup` in the large PR list query
- cover retry behavior and split status-rollup fetching in maintainer board tests

## Validation

- `python3 -m unittest discover -s tools/agent/scripts/tests -p 'test_*.py'`
- `python3 -m py_compile tools/agent/scripts/maintainer_board.py tools/agent/scripts/tests/test_maintainer_board_ga_readiness.py`
- `git diff --check`
- `MAINTAINER_BOARD_OUTPUT_DIR=$(mktemp -d) MAINTAINER_BOARD_MILESTONE=v0.4 MAINTAINER_BOARD_ISSUE_LIMIT=10 MAINTAINER_BOARD_PR_LIMIT=10 bash tools/agent/scripts/run_maintainer_board_ci.sh`
- `MAINTAINER_BOARD_OUTPUT_DIR=$(mktemp -d) MAINTAINER_BOARD_MILESTONE=v0.4 MAINTAINER_BOARD_ISSUE_LIMIT=100 MAINTAINER_BOARD_PR_LIMIT=50 bash tools/agent/scripts/run_maintainer_board_ci.sh`

Fixes #2600
