### PR TITLE
[CI/Build] Serve theme-aware logo in owner-notification comment

### DIFF
--- a/.github/workflows/owner-notification.yml
+++ b/.github/workflows/owner-notification.yml
@@ -191,11 +191,20 @@ jobs:
 
             commentBody += '---\n';
             commentBody += '<div align="center">\n';
+            // Theme-aware logo: repo.png carries a black wordmark that is
+            // unreadable on GitHub dark themes, so serve the white-wordmark
+            // variant to dark-mode viewers via <picture> (issue #2610).
+            const imgBase =
+              'https://raw.githubusercontent.com/' +
+              'vllm-project/semantic-router/main/website/static/img/';
+            commentBody += '<picture>\n';
             commentBody +=
-              '<img src="https://raw.githubusercontent.com/' +
-              'vllm-project/semantic-router/main/website/static/' +
-              'img/repo.png" ' +
-              'alt="vLLM" width="80%"/>';
+              '<source media="(prefers-color-scheme: dark)" ' +
+              'srcset="' + imgBase + 'vllm-sr-logo.white.png">\n';
+            commentBody +=
+              '<img src="' + imgBase + 'repo.png" ' +
+              'alt="vLLM Semantic Router" width="80%"/>\n';
+            commentBody += '</picture>\n';
             commentBody += '</div>\n\n';
             commentBody += '## 🎉 Thanks for your contributions!\n\n';
             commentBody +=


### PR DESCRIPTION
Closes #2610

The owner-notification bot comment embeds `website/static/img/repo.png`, whose black wordmark is unreadable on GitHub dark themes. This wraps the logo in a theme-aware `<picture>` element in `.github/workflows/owner-notification.yml`: dark-mode viewers get the existing `vllm-sr-logo.white.png`, light mode keeps `repo.png` unchanged. No new assets; validated via yamllint, `make agent-lint`, and inspecting the generated HTML fragment in Node. Live rendering is verifiable on the first bot comment after merge (`pull_request_target` runs from main).

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>