### PR TITLE
[Bench] fix reasoning-eval --no-plots/--no-report crash

### DIFF
--- a/bench/reasoning/cli.py
+++ b/bench/reasoning/cli.py
@@ -392,12 +392,10 @@ def run_reasoning_eval(args):
         cmd.extend(["--model", args.model])
 
     if args.no_plots:
-        cmd.append("--generate-plots")
-        cmd.append("False")
+        cmd.append("--no-generate-plots")
 
     if args.no_report:
-        cmd.append("--generate-report")
-        cmd.append("False")
+        cmd.append("--no-generate-report")
 
     return subprocess.call(cmd)
 

--- a/bench/reasoning/cli_args.py
+++ b/bench/reasoning/cli_args.py
@@ -105,15 +105,38 @@ def _add_output_args(parser: argparse.ArgumentParser) -> None:
         default="results/reasoning_mode_eval",
         help="Output directory for results",
     )
-    parser.add_argument(
+
+    # argparse.BooleanOptionalAction (which would give us free --foo/--no-foo
+    # pairs) was only added in Python 3.9, but this package still declares
+    # and supports python_requires >= 3.8. Build the --generate-plots /
+    # --no-generate-plots pair manually with a mutually exclusive group so
+    # the parser keeps working on 3.8.
+    plots_group = parser.add_mutually_exclusive_group()
+    plots_group.add_argument(
         "--generate-plots",
-        action=argparse.BooleanOptionalAction,
+        dest="generate_plots",
+        action="store_true",
         default=True,
-        help="Generate comparison plots",
+        help="Generate comparison plots (default: enabled)",
     )
-    parser.add_argument(
+    plots_group.add_argument(
+        "--no-generate-plots",
+        dest="generate_plots",
+        action="store_false",
+        help="Skip generating comparison plots",
+    )
+
+    report_group = parser.add_mutually_exclusive_group()
+    report_group.add_argument(
         "--generate-report",
-        action=argparse.BooleanOptionalAction,
+        dest="generate_report",
+        action="store_true",
         default=True,
-        help="Generate markdown report",
+        help="Generate markdown report (default: enabled)",
+    )
+    report_group.add_argument(
+        "--no-generate-report",
+        dest="generate_report",
+        action="store_false",
+        help="Skip generating the markdown report",
     )

--- a/bench/reasoning/cli_args.py
+++ b/bench/reasoning/cli_args.py
@@ -107,13 +107,13 @@ def _add_output_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--generate-plots",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Generate comparison plots",
     )
     parser.add_argument(
         "--generate-report",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Generate markdown report",
     )

--- a/bench/reasoning/test_cli_args.py
+++ b/bench/reasoning/test_cli_args.py
@@ -1,0 +1,42 @@
+import pytest
+
+from bench.reasoning.cli_args import parse_args
+
+
+def _parse(monkeypatch: pytest.MonkeyPatch, argv: list[str]):
+    monkeypatch.setattr("sys.argv", ["prog", *argv])
+    return parse_args()
+
+
+def test_generate_plots_and_report_default_to_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _parse(monkeypatch, [])
+    assert args.generate_plots is True
+    assert args.generate_report is True
+
+
+def test_no_generate_plots_disables_only_plots(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = _parse(monkeypatch, ["--no-generate-plots"])
+    assert args.generate_plots is False
+    assert args.generate_report is True
+
+
+def test_no_generate_report_disables_only_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = _parse(monkeypatch, ["--no-generate-report"])
+    assert args.generate_plots is True
+    assert args.generate_report is False
+
+
+def test_generate_plots_and_no_generate_plots_are_mutually_exclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression guard for the --generate-plots/--no-generate-plots pair
+    # that replaced argparse.BooleanOptionalAction (Python 3.9+ only, but
+    # this package still declares and supports python_requires >= 3.8).
+    # A mutually exclusive group should reject passing both flags, the same
+    # way BooleanOptionalAction would just silently prefer the last one.
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--generate-plots", "--no-generate-plots"])


### PR DESCRIPTION
Fixes #2386.

--generate-plots/--generate-report are store_true with default=True, so there's no actual way to disable them. cli.py tries to work around that by appending `--generate-plots False`, which blows up since `False` is just an unexpected positional to the underlying parser:

```
error: unrecognized arguments: False
```

Switched both to `BooleanOptionalAction` so `--no-generate-plots`/`--no-generate-report` exist for real, and fixed the forwarding in cli.py to use them instead of the broken positional.

Ran the repro from the issue against main first to confirm the crash, then against this branch — no crash, and passing `--no-plots --no-report` actually skips plot/report generation now. Default behavior (no flags) and the existing `--generate-plots`/`--generate-report` positive flags are unchanged.