### PR TITLE
[Router] Add support for Fusion analysis_overrides in Router

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,8 +45,8 @@ Minor issues such as informational disclosures, logging errors, non-exploitable 
 
 When a security report is accepted, the fix process depends on the severity:
 
-* **CRITICAL and HIGH severity**: Fixes are developed in a private security fork and coordinated with the prenotification group before public disclosure.
-* **MODERATE and LOW severity**: Fixes are developed and submitted as public pull requests. These issues do not require embargo since they do not enable arbitrary code execution or significant data breach, and public visibility accelerates community review and adoption of the fix.
+- **CRITICAL and HIGH severity**: Fixes are developed in a private security fork and coordinated with the prenotification group before public disclosure.
+- **MODERATE and LOW severity**: Fixes are developed and submitted as public pull requests. These issues do not require embargo since they do not enable arbitrary code execution or significant data breach, and public visibility accelerates community review and adoption of the fix.
 
 The vLLM Semantic Router maintainer team reserves the right to adjust the disclosure approach on a case-by-case basis, taking into account factors such as active exploitation, unusual attack surface, or coordination requirements with vLLM or downstream vendors.
 
@@ -54,13 +54,13 @@ The vLLM Semantic Router maintainer team reserves the right to adjust the disclo
 
 For certain security issues of CRITICAL, HIGH, or MODERATE severity level, we may prenotify the vLLM vulnerability management team and certain organizations or vendors that ship vLLM Semantic Router. The purpose of this prenotification is to allow for a coordinated release of fixes for severe issues.
 
-* This prenotification will be in the form of a private email notification. It may also include adding security contacts to the GitHub security advisory, typically a few days before release.
+- This prenotification will be in the form of a private email notification. It may also include adding security contacts to the GitHub security advisory, typically a few days before release.
 
-* If you wish to be added to the prenotification group, please contact the vLLM Semantic Router maintainer team and copy the members of the [vLLM vulnerability management team](https://docs.vllm.ai/en/latest/contributing/vulnerability_management.html). Each vendor contact will be analyzed on a case-by-case basis.
+- If you wish to be added to the prenotification group, please contact the vLLM Semantic Router maintainer team and copy the members of the [vLLM vulnerability management team](https://docs.vllm.ai/en/latest/contributing/vulnerability_management.html). Each vendor contact will be analyzed on a case-by-case basis.
 
-* Organizations and vendors who either ship or use vLLM Semantic Router are eligible to join the prenotification group if they meet at least one of the following qualifications:
-    * Substantial internal deployment leveraging the upstream vLLM Semantic Router project.
-    * Established internal security teams and comprehensive compliance measures.
-    * Active and consistent contributions to the upstream vLLM Semantic Router project.
+- Organizations and vendors who either ship or use vLLM Semantic Router are eligible to join the prenotification group if they meet at least one of the following qualifications:
+  - Substantial internal deployment leveraging the upstream vLLM Semantic Router project.
+  - Established internal security teams and comprehensive compliance measures.
+  - Active and consistent contributions to the upstream vLLM Semantic Router project.
 
-* We may withdraw organizations from receiving future prenotifications if they release fixes or any other information about issues before they are public. Group membership may also change based on policy refinements for who may be included.
+- We may withdraw organizations from receiving future prenotifications if they release fixes or any other information about issues before they are public. Group membership may also change based on policy refinements for who may be included.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -812,6 +812,13 @@ routing:
           analysis_models:
             - qwen3-8b
             - qwen3-32b
+          analysis_overrides:
+            - model: qwen3-8b
+              temperature: 0.2
+              max_completion_tokens: 384
+            - model: qwen3-32b
+              temperature: 0.15
+              max_completion_tokens: 512
           max_concurrent: 2
           max_completion_tokens: 512
           round_timeout_seconds: 90

--- a/src/semantic-router/pkg/config/fusion_config.go
+++ b/src/semantic-router/pkg/config/fusion_config.go
@@ -37,6 +37,7 @@ const (
 type FusionAlgorithmConfig struct {
 	Model                        string                 `yaml:"model,omitempty" json:"model,omitempty"`
 	AnalysisModels               []string               `yaml:"analysis_models,omitempty" json:"analysis_models,omitempty"`
+	AnalysisOverrides            []FusionModelOverride  `yaml:"analysis_overrides,omitempty" json:"analysis_overrides,omitempty"`
 	MaxConcurrent                int                    `yaml:"max_concurrent,omitempty" json:"max_concurrent,omitempty"`
 	MaxCompletionTokens          int                    `yaml:"max_completion_tokens,omitempty" json:"max_completion_tokens,omitempty"`
 	RoundTimeoutSeconds          int                    `yaml:"round_timeout_seconds,omitempty" json:"round_timeout_seconds,omitempty"`
@@ -79,6 +80,7 @@ type FusionRequestConfig struct {
 	Enabled                      *bool                  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	Model                        string                 `json:"model,omitempty" yaml:"model,omitempty"`
 	AnalysisModels               []string               `json:"analysis_models,omitempty" yaml:"analysis_models,omitempty"`
+	AnalysisOverrides            []FusionModelOverride  `json:"analysis_overrides,omitempty" yaml:"analysis_overrides,omitempty"`
 	MaxConcurrent                int                    `json:"max_concurrent,omitempty" yaml:"max_concurrent,omitempty"`
 	MaxCompletionTokens          int                    `json:"max_completion_tokens,omitempty" yaml:"max_completion_tokens,omitempty"`
 	RoundTimeoutSeconds          int                    `json:"round_timeout_seconds,omitempty" yaml:"round_timeout_seconds,omitempty"`
@@ -91,6 +93,13 @@ type FusionRequestConfig struct {
 	SynthesisTemplate            string                 `json:"synthesis_template,omitempty" yaml:"synthesis_template,omitempty"`
 	JudgePromptVersion           string                 `json:"judge_prompt_version,omitempty" yaml:"judge_prompt_version,omitempty"`
 	Grounding                    *FusionGroundingConfig `json:"grounding,omitempty" yaml:"grounding,omitempty"`
+}
+
+// FusionModelOverride allows per-analysis-model sampling overrides.
+type FusionModelOverride struct {
+	Model               string   `json:"model,omitempty" yaml:"model,omitempty"`
+	Temperature         *float64 `json:"temperature,omitempty" yaml:"temperature,omitempty"`
+	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty" yaml:"max_completion_tokens,omitempty"`
 }
 
 func DefaultFusionModelNames() []string {
@@ -178,6 +187,9 @@ func ValidateFusionAlgorithmConfig(cfg *FusionAlgorithmConfig) error {
 	if cfg.Temperature != nil && *cfg.Temperature < 0 {
 		return fmt.Errorf("temperature must be >= 0 when set")
 	}
+	if err := validateFusionModelOverrides(cfg.AnalysisOverrides); err != nil {
+		return err
+	}
 	if err := ValidateFusionGroundingConfig(cfg.Grounding); err != nil {
 		return err
 	}
@@ -245,8 +257,32 @@ func (c *FusionRequestConfig) Validate() error {
 	if c.Temperature != nil && *c.Temperature < 0 {
 		return fmt.Errorf("temperature must be >= 0 when set")
 	}
+	if err := validateFusionModelOverrides(c.AnalysisOverrides); err != nil {
+		return err
+	}
 	if err := ValidateFusionGroundingConfig(c.Grounding); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateFusionModelOverrides(overrides []FusionModelOverride) error {
+	seen := map[string]bool{}
+	for i, override := range overrides {
+		name := strings.TrimSpace(override.Model)
+		if name == "" {
+			return fmt.Errorf("analysis_overrides[%d].model cannot be empty", i)
+		}
+		if seen[name] {
+			return fmt.Errorf("analysis_overrides[%d].model %q is duplicated", i, name)
+		}
+		seen[name] = true
+		if override.Temperature != nil && *override.Temperature < 0 {
+			return fmt.Errorf("analysis_overrides[%d].temperature must be >= 0 when set", i)
+		}
+		if override.MaxCompletionTokens < 0 {
+			return fmt.Errorf("analysis_overrides[%d].max_completion_tokens must be >= 1 when set", i)
+		}
 	}
 	return nil
 }

--- a/src/semantic-router/pkg/config/fusion_config_test.go
+++ b/src/semantic-router/pkg/config/fusion_config_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateFusionAlgorithmConfigAnalysisOverrides(t *testing.T) {
+	cfg := &FusionAlgorithmConfig{
+		AnalysisOverrides: []FusionModelOverride{
+			{Model: "panel-a", Temperature: floatPtr(0.0)},
+			{Model: "panel-b", Temperature: floatPtr(0.8), MaxCompletionTokens: 256},
+		},
+	}
+
+	require.NoError(t, ValidateFusionAlgorithmConfig(cfg))
+}
+
+func TestValidateFusionAlgorithmConfigRejectsInvalidAnalysisOverrides(t *testing.T) {
+	cfg := &FusionAlgorithmConfig{
+		AnalysisOverrides: []FusionModelOverride{
+			{Model: "panel-a", Temperature: floatPtr(0.2)},
+			{Model: "panel-a", Temperature: floatPtr(0.4)},
+		},
+	}
+
+	err := ValidateFusionAlgorithmConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicated")
+}
+
+func TestFusionRequestConfigValidateAnalysisOverrides(t *testing.T) {
+	cfg := &FusionRequestConfig{
+		AnalysisOverrides: []FusionModelOverride{
+			{Model: "panel-a", Temperature: floatPtr(0.2)},
+		},
+	}
+
+	require.NoError(t, cfg.Validate())
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}

--- a/src/semantic-router/pkg/looper/fusion.go
+++ b/src/semantic-router/pkg/looper/fusion.go
@@ -26,6 +26,7 @@ func NewFusionLooper(cfg *config.LooperConfig) *FusionLooper {
 type fusionExecutionConfig struct {
 	Model                        string
 	AnalysisModels               []string
+	AnalysisOverrides            map[string]config.FusionModelOverride
 	MaxConcurrent                int
 	MaxCompletionTokens          int
 	RoundTimeoutSeconds          int
@@ -189,7 +190,7 @@ func (l *FusionLooper) executeFusionPanel(
 				return
 			}
 			defer func() { <-sem }()
-			resp, err := l.callFusionModel(panelCtx, req, cfg, modelName, false, false, index+1)
+			resp, err := l.callFusionModel(panelCtx, req, cfg, modelName, false, false, index+1, cfg.AnalysisOverrides[modelName])
 			results <- fusionPanelResult{index: index, model: modelName, resp: resp, err: err}
 		}(i, model)
 	}
@@ -291,15 +292,20 @@ func (l *FusionLooper) callFusionModel(
 	allowTools bool,
 	streaming bool,
 	iteration int,
+	override config.FusionModelOverride,
 ) (*ModelResponse, error) {
 	callReq := cloneRequest(req.OriginalRequest)
 	if !allowTools {
 		callReq = stripFusionToolUse(callReq)
 	}
-	if cfg.Temperature != nil {
+	if override.Temperature != nil {
+		callReq.Temperature = openai.Float(*override.Temperature)
+	} else if cfg.Temperature != nil {
 		callReq.Temperature = openai.Float(*cfg.Temperature)
 	}
-	if cfg.MaxCompletionTokens > 0 {
+	if override.MaxCompletionTokens > 0 {
+		callReq.MaxCompletionTokens = openai.Int(int64(override.MaxCompletionTokens))
+	} else if cfg.MaxCompletionTokens > 0 {
 		callReq.MaxCompletionTokens = openai.Int(int64(cfg.MaxCompletionTokens))
 	}
 	return l.client.CallModel(ctx, callReq, modelName, streaming, iteration, nil, accessKeyForModel(req, modelName))
@@ -334,7 +340,7 @@ func (l *FusionLooper) runFusionAnalysis(
 		prompt = prompt + "\n\n" + notes
 	}
 	analysisReq := appendFusionStageMessage(req.OriginalRequest, prompt)
-	resp, err := l.callFusionModel(ctx, &Request{OriginalRequest: analysisReq, ModelParams: req.ModelParams}, cfg, cfg.Model, false, false, len(panelResponses)+1)
+	resp, err := l.callFusionModel(ctx, &Request{OriginalRequest: analysisReq, ModelParams: req.ModelParams}, cfg, cfg.Model, false, false, len(panelResponses)+1, config.FusionModelOverride{})
 	if err != nil {
 		logging.ComponentWarnEvent("looper", "fusion_analysis_failed", map[string]interface{}{
 			"judge_model": cfg.Model,
@@ -370,7 +376,7 @@ func (l *FusionLooper) runFusionFinal(
 		prompt = prompt + "\n\n" + notes
 	}
 	finalReq := appendFusionStageMessage(req.OriginalRequest, prompt)
-	resp, err := l.callFusionModel(ctx, &Request{OriginalRequest: finalReq, ModelParams: req.ModelParams}, cfg, cfg.Model, true, false, len(panelResponses)+2)
+	resp, err := l.callFusionModel(ctx, &Request{OriginalRequest: finalReq, ModelParams: req.ModelParams}, cfg, cfg.Model, true, false, len(panelResponses)+2, config.FusionModelOverride{})
 	if err != nil {
 		return nil, fmt.Errorf("fusion final synthesis failed for judge model %q: %w", cfg.Model, err)
 	}

--- a/src/semantic-router/pkg/looper/fusion_config.go
+++ b/src/semantic-router/pkg/looper/fusion_config.go
@@ -40,6 +40,7 @@ func normalizeFusionExecutionConfig(cfg fusionExecutionConfig) fusionExecutionCo
 		cfg.JudgePromptVersion = config.DefaultFusionJudgePromptVersion
 	}
 	cfg.AnalysisModels = normalizeModelNames(cfg.AnalysisModels)
+	cfg.AnalysisOverrides = normalizeFusionAnalysisOverrides(cfg.AnalysisModels, cfg.AnalysisOverrides)
 	if cfg.MaxConcurrent <= 0 || cfg.MaxConcurrent > len(cfg.AnalysisModels) {
 		cfg.MaxConcurrent = len(cfg.AnalysisModels)
 	}
@@ -87,6 +88,7 @@ func validateFusionExecutionConfig(cfg fusionExecutionConfig) error {
 
 func mergeFusionAlgorithmConfig(dst *fusionExecutionConfig, src *config.FusionAlgorithmConfig) {
 	mergeFusionModels(dst, src.Model, src.AnalysisModels)
+	mergeFusionAnalysisOverrides(dst, src.AnalysisOverrides)
 	mergeFusionLimits(dst, src.MaxConcurrent, src.MaxCompletionTokens, src.RoundTimeoutSeconds, src.MinSuccessfulResponses)
 	mergeFusionControls(dst, src.Temperature, src.IncludeAnalysis, src.IncludeIntermediateResponses, src.OnError)
 	mergeFusionPrompts(dst, src.AnalysisTemplate, src.SynthesisTemplate, src.JudgePromptVersion)
@@ -176,6 +178,7 @@ func mergeFusionGroundingConfig(dst *fusionExecutionConfig, src *config.FusionGr
 
 func mergeFusionRequestConfig(dst *fusionExecutionConfig, src *config.FusionRequestConfig) {
 	mergeFusionModels(dst, src.Model, src.AnalysisModels)
+	mergeFusionAnalysisOverrides(dst, src.AnalysisOverrides)
 	mergeFusionLimits(dst, src.MaxConcurrent, src.MaxCompletionTokens, src.RoundTimeoutSeconds, src.MinSuccessfulResponses)
 	mergeFusionControls(dst, src.Temperature, src.IncludeAnalysis, src.IncludeIntermediateResponses, src.OnError)
 	mergeFusionPrompts(dst, src.AnalysisTemplate, src.SynthesisTemplate, src.JudgePromptVersion)
@@ -210,4 +213,45 @@ func normalizeModelNames(names []string) []string {
 		result = append(result, trimmed)
 	}
 	return result
+}
+
+func mergeFusionAnalysisOverrides(dst *fusionExecutionConfig, overrides []config.FusionModelOverride) {
+	if len(overrides) == 0 {
+		return
+	}
+	if dst.AnalysisOverrides == nil {
+		dst.AnalysisOverrides = make(map[string]config.FusionModelOverride, len(overrides))
+	}
+	for _, override := range overrides {
+		name := strings.TrimSpace(override.Model)
+		if name == "" {
+			continue
+		}
+		override.Model = name
+		dst.AnalysisOverrides[name] = override
+	}
+}
+
+func normalizeFusionAnalysisOverrides(
+	analysisModels []string,
+	overrides map[string]config.FusionModelOverride,
+) map[string]config.FusionModelOverride {
+	if len(overrides) == 0 || len(analysisModels) == 0 {
+		return nil
+	}
+	allowed := make(map[string]bool, len(analysisModels))
+	for _, model := range analysisModels {
+		allowed[model] = true
+	}
+	filtered := make(map[string]config.FusionModelOverride, len(overrides))
+	for model, override := range overrides {
+		if !allowed[model] {
+			continue
+		}
+		filtered[model] = override
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }

--- a/src/semantic-router/pkg/looper/fusion_config.go
+++ b/src/semantic-router/pkg/looper/fusion_config.go
@@ -215,6 +215,9 @@ func normalizeModelNames(names []string) []string {
 	return result
 }
 
+// mergeFusionAnalysisOverrides layers per-model overrides field-wise, so a
+// request that sets only one sampling field keeps the decision-level value for
+// every other field of the same model.
 func mergeFusionAnalysisOverrides(dst *fusionExecutionConfig, overrides []config.FusionModelOverride) {
 	if len(overrides) == 0 {
 		return
@@ -227,8 +230,15 @@ func mergeFusionAnalysisOverrides(dst *fusionExecutionConfig, overrides []config
 		if name == "" {
 			continue
 		}
-		override.Model = name
-		dst.AnalysisOverrides[name] = override
+		merged := dst.AnalysisOverrides[name]
+		merged.Model = name
+		if override.Temperature != nil {
+			merged.Temperature = override.Temperature
+		}
+		if override.MaxCompletionTokens > 0 {
+			merged.MaxCompletionTokens = override.MaxCompletionTokens
+		}
+		dst.AnalysisOverrides[name] = merged
 	}
 }
 

--- a/src/semantic-router/pkg/looper/fusion_test.go
+++ b/src/semantic-router/pkg/looper/fusion_test.go
@@ -121,8 +121,12 @@ func TestMergeFusionRequestConfigCoversAdvancedOptions(t *testing.T) {
 	}
 
 	mergeFusionRequestConfig(&dst, &config.FusionRequestConfig{
-		Model:                        "judge",
-		AnalysisModels:               []string{"panel-a", "panel-b"},
+		Model:          "judge",
+		AnalysisModels: []string{"panel-a", "panel-b"},
+		AnalysisOverrides: []config.FusionModelOverride{
+			{Model: "panel-a", Temperature: float64Ptr(0.0)},
+			{Model: "panel-b", Temperature: float64Ptr(0.8), MaxCompletionTokens: 222},
+		},
 		MaxConcurrent:                2,
 		MaxCompletionTokens:          512,
 		RoundTimeoutSeconds:          12,
@@ -147,6 +151,8 @@ func TestMergeFusionRequestConfigCoversAdvancedOptions(t *testing.T) {
 
 	assert.Equal(t, "judge", dst.Model)
 	assert.Equal(t, []string{"panel-a", "panel-b"}, dst.AnalysisModels)
+	require.Len(t, dst.AnalysisOverrides, 2)
+	assert.Equal(t, 222, dst.AnalysisOverrides["panel-b"].MaxCompletionTokens)
 	assert.Equal(t, 2, dst.MaxConcurrent)
 	assert.Equal(t, 512, dst.MaxCompletionTokens)
 	assert.Equal(t, 12, dst.RoundTimeoutSeconds)
@@ -166,6 +172,64 @@ func TestMergeFusionRequestConfigCoversAdvancedOptions(t *testing.T) {
 	assert.Equal(t, 2, dst.GroundingMinKeep)
 	assert.Equal(t, 0.7, dst.GroundingNLIContradictionPenalty)
 	assert.Equal(t, config.FusionOnErrorFail, dst.GroundingOnError)
+}
+
+func TestFusionLooperAppliesPerAnalysisOverrides(t *testing.T) {
+	type callParams struct {
+		temperature         *float64
+		maxCompletionTokens *int64
+	}
+	seen := map[string]callParams{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model               string   `json:"model"`
+			Temperature         *float64 `json:"temperature,omitempty"`
+			MaxCompletionTokens *int64   `json:"max_completion_tokens,omitempty"`
+			Messages            []struct {
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		seen[payload.Model] = callParams{
+			temperature:         payload.Temperature,
+			maxCompletionTokens: payload.MaxCompletionTokens,
+		}
+		prompt := ""
+		if len(payload.Messages) > 0 {
+			prompt = payload.Messages[len(payload.Messages)-1].Content
+		}
+		if payload.Model == "judge" && strings.Contains(prompt, "return only valid JSON") {
+			writeFusionTestCompletion(w, payload.Model, `{"consensus":["ok"],"contradictions":[],"partial_coverage":[],"unique_insights":[],"blind_spots":[]}`, http.StatusOK)
+			return
+		}
+		writeFusionTestCompletion(w, payload.Model, "ok", http.StatusOK)
+	}))
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:          "judge",
+			AnalysisModels: []string{"panel-a", "panel-b"},
+			Temperature:    float64Ptr(0.2),
+			AnalysisOverrides: []config.FusionModelOverride{
+				{Model: "panel-a", Temperature: float64Ptr(0.0)},
+				{Model: "panel-b", Temperature: float64Ptr(0.8), MaxCompletionTokens: 128},
+			},
+		},
+	}
+	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.NoError(t, err)
+
+	require.NotNil(t, seen["panel-a"].temperature)
+	assert.Equal(t, 0.0, *seen["panel-a"].temperature)
+	require.NotNil(t, seen["panel-b"].temperature)
+	assert.Equal(t, 0.8, *seen["panel-b"].temperature)
+	require.NotNil(t, seen["panel-b"].maxCompletionTokens)
+	assert.Equal(t, int64(128), *seen["panel-b"].maxCompletionTokens)
+	require.NotNil(t, seen["judge"].temperature)
+	assert.Equal(t, 0.2, *seen["judge"].temperature)
 }
 
 func TestFusionLooperPanelQuorumSkipsSlowWorker(t *testing.T) {
@@ -656,4 +720,8 @@ func fusionTestUsage(model string) map[string]int64 {
 	default:
 		return map[string]int64{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
 	}
+}
+
+func float64Ptr(v float64) *float64 {
+	return &v
 }

--- a/src/semantic-router/pkg/looper/fusion_test.go
+++ b/src/semantic-router/pkg/looper/fusion_test.go
@@ -174,12 +174,52 @@ func TestMergeFusionRequestConfigCoversAdvancedOptions(t *testing.T) {
 	assert.Equal(t, config.FusionOnErrorFail, dst.GroundingOnError)
 }
 
+func TestResolveFusionExecutionConfigLayersAnalysisOverridesFieldWise(t *testing.T) {
+	looper := NewFusionLooper(&config.LooperConfig{Endpoint: "http://looper"})
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:          "judge",
+			AnalysisModels: []string{"panel-a", "panel-b"},
+			AnalysisOverrides: []config.FusionModelOverride{
+				{Model: "panel-a", Temperature: float64Ptr(0.2), MaxCompletionTokens: 512},
+				{Model: "panel-b", Temperature: float64Ptr(0.8)},
+			},
+		},
+	}
+	req.Fusion = &config.FusionRequestConfig{
+		ID: "fusion",
+		AnalysisOverrides: []config.FusionModelOverride{
+			{Model: "panel-a", MaxCompletionTokens: 100},
+			{Model: "panel-b", Temperature: float64Ptr(0.1)},
+		},
+	}
+
+	cfg := looper.resolveFusionExecutionConfig(req)
+
+	require.Len(t, cfg.AnalysisOverrides, 2)
+	panelA := cfg.AnalysisOverrides["panel-a"]
+	require.NotNil(t, panelA.Temperature)
+	assert.Equal(t, 0.2, *panelA.Temperature)
+	assert.Equal(t, 100, panelA.MaxCompletionTokens)
+	panelB := cfg.AnalysisOverrides["panel-b"]
+	require.NotNil(t, panelB.Temperature)
+	assert.Equal(t, 0.1, *panelB.Temperature)
+	assert.Zero(t, panelB.MaxCompletionTokens)
+}
+
 func TestFusionLooperAppliesPerAnalysisOverrides(t *testing.T) {
 	type callParams struct {
 		temperature         *float64
 		maxCompletionTokens *int64
 	}
-	seen := map[string]callParams{}
+	// Panel models are called concurrently, so this handler runs on several
+	// httptest server goroutines at once.
+	var (
+		mu   sync.Mutex
+		seen = map[string]callParams{}
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload struct {
 			Model               string   `json:"model"`
@@ -189,11 +229,16 @@ func TestFusionLooperAppliesPerAnalysisOverrides(t *testing.T) {
 				Content string `json:"content"`
 			} `json:"messages"`
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&payload)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
 		seen[payload.Model] = callParams{
 			temperature:         payload.Temperature,
 			maxCompletionTokens: payload.MaxCompletionTokens,
 		}
+		mu.Unlock()
 		prompt := ""
 		if len(payload.Messages) > 0 {
 			prompt = payload.Messages[len(payload.Messages)-1].Content
@@ -222,6 +267,8 @@ func TestFusionLooperAppliesPerAnalysisOverrides(t *testing.T) {
 	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
 	require.NoError(t, err)
 
+	mu.Lock()
+	defer mu.Unlock()
 	require.NotNil(t, seen["panel-a"].temperature)
 	assert.Equal(t, 0.0, *seen["panel-a"].temperature)
 	require.NotNil(t, seen["panel-b"].temperature)

--- a/website/docs/tutorials/algorithm/looper/fusion.md
+++ b/website/docs/tutorials/algorithm/looper/fusion.md
@@ -90,6 +90,13 @@ routing:
           analysis_models:
             - qwen3-32b
             - deepseek-worker
+          analysis_overrides:
+            - model: qwen3-32b
+              temperature: 0.15
+              max_completion_tokens: 512
+            - model: deepseek-worker
+              temperature: 0.2
+              max_completion_tokens: 384
 ```
 
 `output_contract` is decision-scoped prompt text. Use it for benchmark or
@@ -111,6 +118,13 @@ algorithm:
     analysis_models:
       - qwen3-8b
       - qwen3-32b
+    analysis_overrides:
+      - model: qwen3-8b
+        temperature: 0.2
+        max_completion_tokens: 384
+      - model: qwen3-32b
+        temperature: 0.15
+        max_completion_tokens: 512
     max_concurrent: 2
     max_completion_tokens: 512
     round_timeout_seconds: 90
@@ -152,6 +166,8 @@ global:
 
 The judge model, analysis panel, concurrency, templates, and error policy belong under `routing.decisions[].algorithm.fusion`. Direct slug calls evaluate only Fusion-capable decisions, so `vllm-sr/fusion` cannot silently fall back to a normal single-model route. Request-level `plugins[].id = fusion` can still override the decision panel for one call; if no Fusion decision matched, a plugin override with `analysis_models` can provide a request-only panel.
 
+`analysis_overrides` are keyed by `model` and merge field-wise with decision-level settings. In practice, if decision config sets `{temperature: 0.2}` for `panel-a` and request override sets only `{max_completion_tokens: 100}`, `panel-a` keeps `temperature: 0.2` and adds `max_completion_tokens: 100`.
+
 To expose an OpenRouter-compatible alias, opt in explicitly:
 
 ```yaml
@@ -174,6 +190,10 @@ Request-level override:
     "id": "fusion",
     "model": "qwen3-32b",
     "analysis_models": ["qwen3-8b", "qwen3-32b"],
+    "analysis_overrides": [
+      {"model": "qwen3-8b", "max_completion_tokens": 320},
+      {"model": "qwen3-32b", "temperature": 0.1}
+    ],
     "max_concurrent": 2,
     "max_completion_tokens": 1024,
     "round_timeout_seconds": 90,
@@ -196,6 +216,7 @@ Request-level override:
 | `model_names` | list[string] | `["vllm-sr/fusion"]` | Direct request model slugs that trigger Fusion execution |
 | `model` | string | first analysis model | Judge/calling model used for analysis and final synthesis |
 | `analysis_models` | list[string] | `modelRefs` | Panel models for parallel analysis |
+| `analysis_overrides` | list[object] | none | Per-panel-model `temperature` and `max_completion_tokens`, keyed by `model`. Request-level entries merge field-wise onto the decision entry for the same model, so setting one field keeps the decision value for the other |
 | `max_concurrent` | int | panel size | Maximum concurrent panel calls |
 | `max_completion_tokens` | int | request default | Max completion tokens applied to Fusion subrequests |
 | `round_timeout_seconds` | int | wait for all | Stop waiting for a panel round after this many seconds |
@@ -208,6 +229,12 @@ Request-level override:
 | `synthesis_template` | string | built-in | Custom final prompt with `{{original}}`, `{{responses}}`, and `{{analysis}}` |
 | `judge_prompt_version` | string | `fusion-v1` | Version marker included in Fusion response trace |
 | `grounding` | object | disabled | Optional grounding-aware synthesis (see below) |
+
+Best practice:
+
+- Keep `analysis_models` stable per decision, and use `analysis_overrides` for model-specific tuning.
+- Use decision-level overrides for your baseline and request-level overrides only for one-off experiments.
+- Prefer sparse request overrides (set only the field you need) to preserve decision defaults through field-wise merge.
 
 ## Grounding-Aware Synthesis
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

- What does this PR change?
  - Adds `analysis_overrides` support to Fusion routing so individual analysis panel models can override sampling controls (currently `temperature` and `max_completion_tokens`) while preserving existing global Fusion defaults.
  - Threads overrides through config validation, merge/normalization, and panel execution.
  - Adds/updates unit tests for validation, merge behavior, and runtime application of per-model overrides.
- Why is this change needed?
  - Fusion panels often use heterogeneous models with different optimal sampling settings; global settings are too coarse and can degrade quality/cost/latency trade-offs.
  - This enables targeted tuning per analysis model without affecting judge-stage behavior.
- Which module(s) does this affect? `Router`

## Test Plan

- Run focused unit tests:
  - `go test ./src/semantic-router/pkg/config ./src/semantic-router/pkg/looper`
- Reviewer spot checks:
  - Confirm invalid `analysis_overrides` entries are rejected (empty/duplicate model, negative temperature, invalid token values).
  - Confirm overrides are only applied to analysis panel calls, with judge calls still using default Fusion settings unless explicitly configured globally.
- Why is this validation sufficient for the affected module(s)?
  - The change is Router-only and primarily modifies Fusion config parsing/validation + execution-path parameter wiring; targeted unit coverage validates both config and runtime behavior.

## Test Result

- Ran targeted Fusion/AnalysisOverrides unit tests in a Go 1.25 container:
  - `go test ./pkg/config ./pkg/looper -run "AnalysisOverrides|Fusion" -count=1 -v`
- Results:
  - `pkg/config` tests passed:
    - `TestValidateFusionAlgorithmConfigAnalysisOverrides`
    - `TestValidateFusionAlgorithmConfigRejectsInvalidAnalysisOverrides`
    - `TestFusionRequestConfigValidateAnalysisOverrides`
  - `pkg/looper` tests were blocked by environment-specific native binding build/link requirements:
    - CGO-on failure: missing `ml-binding` native artifact (`-lml_semantic_router`)
    - CGO-off failure: binding build-constraint/type errors in mock path
- Follow-up/gap:
  - Re-run `pkg/looper` Fusion tests in the standard project dev/CI environment where Rust native bindings are built (or via the repo’s canonical `make test-semantic-router` pipeline).

Closes #2655 
---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

