### PR TITLE
[CI/Build] align Mergify queue_conditions with merge_conditions to unblock merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,9 @@ queue_rules:
   - name: default
     queue_conditions:
       - base = main
+      - or:
+          - check-success = test-and-build
+          - check-skipped = test-and-build
     merge_conditions:
       - base = main
       - or:


### PR DESCRIPTION
## What

Add the `test-and-build` `or:` block (`check-success` / `check-skipped`) to `queue_conditions` in `.mergify.yml`, making it identical to `merge_conditions`.

Closes #2625

## Why

Every approved PR is currently blocked from entering the Mergify merge queue. On #2612, the check **"Rule: queue approved pull requests (queue)"** completed with conclusion `action_required`:

> Configuration not compatible with a branch protection setting

Root cause: the branch protection setting **"Require branches to be up to date before merging"** on `main` is incompatible with Mergify's draft-PR queue checks. Mergify's guidance for keeping that protection is to enable in-place checks, which requires all of:

1. `merge_queue.max_parallel_checks: 1`
2. `batch_size: 1` on every queue rule
3. `merge_conditions` identical to `queue_conditions` (no two-step CI)

Our `.mergify.yml` already satisfies (1) and (2); only (3) was violated — `merge_conditions` additionally required `check-success = test-and-build` / `check-skipped = test-and-build`, while `queue_conditions` only had `base = main`. This PR closes that gap.

Alternative considered: an admin could disable the "Require branches to be up to date before merging" protection on `main`. Not chosen because the config-only fix keeps the protection intact and needs no admin rights.

## Test Plan

- Validated `.mergify.yml` is well-formed YAML.
- Verified `queue_conditions` and `merge_conditions` are now literally identical, satisfying Mergify's in-place-checks requirement together with the existing `max_parallel_checks: 1` and `batch_size: 1`.
- After merge, Mergify re-evaluates its configuration from the default branch; the next approved PR (e.g. re-triggering on #2612) should be queued instead of failing with `action_required`. Will monitor the "Rule: queue approved pull requests (queue)" check on the next approved PR to confirm.