### PR TITLE
[CI/Build] Fix supply-chain security scan for fork PRs under checkout v4.4.0

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -30,12 +30,42 @@ jobs:
       issues: write
 
     steps:
-      - name: Check out the repo
+      # Trusted tooling: always the base repo, never fork-controlled. The
+      # scanner and github-script code we execute come from here.
+      - name: Check out base repo (trusted tooling)
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: base
           fetch-depth: 0
+
+      # Untrusted PR code: checked out as DATA only. The trusted scanner
+      # parses these files with tree-sitter; they are never executed, so
+      # `allow-unsafe-pr-checkout` does not expose a pwn-request path here.
+      - name: Check out PR code (untrusted, data only)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-code
+          fetch-depth: 0
+          # Requires actions/checkout >= v4.4.0 / v5.1.0 / v6.1.0 / v7.0.1,
+          # which introduced this opt-in. Safe here: PR code is only parsed,
+          # never executed (see comment above).
+          allow-unsafe-pr-checkout: true
+
+      # Pin the trusted allowlist over the fork's copy so a PR cannot
+      # whitelist its own exfil domains to evade the URL scanner.
+      - name: Pin trusted security allowlist
+        if: github.event_name == 'pull_request_target'
+        run: |
+          if [ -f base/.security-scan-allowlist ]; then
+            cp base/.security-scan-allowlist pr-code/.security-scan-allowlist
+          else
+            rm -f pr-code/.security-scan-allowlist
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -60,8 +90,9 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          python3 tools/security/ast_security_scanner.py \
-            scan . --fail-on HIGH --json > /tmp/ast_scan.json
+          TARGET="${{ github.event_name == 'pull_request_target' && 'pr-code' || 'base' }}"
+          python3 base/tools/security/ast_security_scanner.py \
+            scan "$TARGET" --fail-on HIGH --json > /tmp/ast_scan.json
           EXIT_CODE=$?
           if [ ! -s /tmp/ast_scan.json ]; then
             echo '{"findings":[],"counts":{},"error":"scanner produced no output"}' > /tmp/ast_scan.json
@@ -74,8 +105,20 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          python3 tools/security/ast_security_scanner.py \
-            diff "origin/${{ github.base_ref }}" --fail-on HIGH --json \
+          # Bring the base ref into the PR checkout so the diff scan can
+          # compute base...HEAD. No --depth: keep enough history for the
+          # merge-base (three-dot) diff; the scanner falls back to two-dot
+          # if the merge-base is unreachable.
+          git -C pr-code remote add base "${GITHUB_SERVER_URL}/${{ github.repository }}.git" 2>/dev/null || true
+          # Hard-fail on fetch failure: without the base ref the diff would
+          # silently resolve to an empty changeset and report a false "clean",
+          # masking findings introduced by the PR.
+          if ! git -C pr-code fetch --no-tags base "${{ github.base_ref }}"; then
+            echo "::error::diff scan: failed to fetch base ref '${{ github.base_ref }}'"
+            exit 1
+          fi
+          python3 base/tools/security/ast_security_scanner.py \
+            diff "base/${{ github.base_ref }}" --repo-root pr-code --fail-on HIGH --json \
             > /tmp/diff_scan.json
           EXIT_CODE=$?
           if [ ! -s /tmp/diff_scan.json ]; then
@@ -87,8 +130,9 @@ jobs:
         id: regex_scan
         continue-on-error: true
         run: |
-          python3 tools/security/scan_malicious_code.py \
-            . --fail-on HIGH 2>&1 \
+          TARGET="${{ github.event_name == 'pull_request_target' && 'pr-code' || 'base' }}"
+          python3 base/tools/security/scan_malicious_code.py \
+            "$TARGET" --fail-on HIGH 2>&1 \
             | tee /tmp/regex_report.txt
 
       - name: Post security report on PR


### PR DESCRIPTION
Closes #2628

## Problem

`actions/checkout@v4` is a mutable major tag. On 2026-07-20 GitHub published `v4.4.0` — a backport of the `allow-unsafe-pr-checkout` opt-in that makes checkout **refuse to fetch fork PR code under `pull_request_target` by default** (safer `pull_request_target` defaults). The repo picked this up with zero code change, so `Supply Chain Security Scan` now fails on **every fork PR** at the checkout step (observed on #2109, #2618, #2609).

The previous single checkout (`ref: pull_request.head.sha`) also executed the **fork's own copy** of `tools/security/*.py` under the base `GITHUB_TOKEN` (`pull-requests: write`, `issues: write`) — exactly the pwn-request pattern the new guard exists to block. Flipping `allow-unsafe-pr-checkout: true` alone would keep that hole open.

## Fix

Split the checkout so untrusted code is never executed:

- **`base` checkout (trusted):** the scanner scripts and the github-script report code always come from the merge target, never the fork.
- **`pr-code` checkout (data only):** fork files are parsed by tree-sitter but never executed. `allow-unsafe-pr-checkout: true` is scoped to this inert-data checkout, so it does not expose a pwn-request path.
- **Pin the trusted `.security-scan-allowlist`** over the fork's copy so a PR cannot whitelist its own exfil domains to evade the URL scanner.
- **Diff scan** fetches the base ref into `pr-code` and **hard-fails if that fetch fails**, instead of silently resolving to an empty diff and reporting a false "clean".

Net effect: the scanner runtime is always trusted base code; the PR's contents are only ever read as data. This is strictly safer than the pre-existing behavior (a PR can no longer weaken the scanner to hide its own findings).

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/security-scan.yml'))"` → OK.
- `bash -n` on the rewritten `diff_scan` run block → OK.
- Ran the scanner locally in both invocation forms the workflow now uses:
  - `ast_security_scanner.py scan <dir> --json` → valid JSON output.
  - `ast_security_scanner.py diff <ref> --repo-root <dir> --json` → valid JSON, `base...HEAD` resolved.
- Confirmed `scan_directory()` and `scan_diff()` both load `.security-scan-allowlist` from the scanned root, so the allowlist pin is effective for both scan modes; and that both scanner scripts resolve their rule/signature configs relative to `__file__` (i.e. from the trusted `base` checkout), not the scanned tree.
- End-to-end validation on a real fork PR happens on this PR's first CI run (requires the `pull_request_target` event + checkout ≥ v4.4.0).

## Notes

- No behavior change for non-fork PRs or `push` events (which scan the `base` checkout).
- Does not touch any other workflow.
