### PR TITLE
[Router] Resolve the multimodal embedding dimension contract per model

### DIFF
--- a/candle-binding/semantic-router.go
+++ b/candle-binding/semantic-router.go
@@ -259,6 +259,7 @@ extern int multimodal_encode_text(const char* text, int target_dim, MultiModalEm
 extern int multimodal_encode_image(const float* pixel_data, int height, int width, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_image_from_bytes(const unsigned char* bytes_ptr, size_t bytes_len, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_audio(const float* mel_data, int n_mels, int time_frames, int target_dim, MultiModalEmbeddingResult* result);
+extern int multimodal_get_embedding_dim();
 extern void free_multimodal_embedding(float* data, int length);
 extern void free_tokenization_result(TokenizationResult result);
 extern ClassificationResult classify_text(const char* text);
@@ -1179,6 +1180,17 @@ func MultiModalEncodeImageFromBytes(imageBytes []byte, targetDim int) (*MultiMod
 		Modality:         "image",
 		ProcessingTimeMs: float32(result.processing_time_ms),
 	}, nil
+}
+
+// MultiModalGetEmbeddingDim returns the loaded multimodal model's native
+// embedding dimension, or -1 if no multimodal model is loaded.
+//
+// The router uses this to enforce the over-dimension contract with the real
+// model value instead of a hardcoded constant: the API dimension default (768)
+// exceeds the multimodal native dimension (384), so image-bearing requests must
+// default to and be validated against the native dimension.
+func MultiModalGetEmbeddingDim() int {
+	return int(C.multimodal_get_embedding_dim())
 }
 
 // MultiModalEncodeImageFromBase64 decodes a base64-encoded image and encodes it

--- a/candle-binding/semantic-router.go
+++ b/candle-binding/semantic-router.go
@@ -262,6 +262,7 @@ extern int multimodal_encode_text(const char* text, int target_dim, MultiModalEm
 extern int multimodal_encode_image(const float* pixel_data, int height, int width, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_image_from_bytes(const unsigned char* bytes_ptr, size_t bytes_len, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_audio(const float* mel_data, int n_mels, int time_frames, int target_dim, MultiModalEmbeddingResult* result);
+extern int multimodal_get_embedding_dim();
 extern void free_multimodal_embedding(float* data, int length);
 extern void free_tokenization_result(TokenizationResult result);
 extern ClassificationResult classify_text(const char* text);
@@ -1194,6 +1195,17 @@ func MultiModalEncodeImageFromBytes(imageBytes []byte, targetDim int) (*MultiMod
 		Modality:         "image",
 		ProcessingTimeMs: float32(result.processing_time_ms),
 	}, nil
+}
+
+// MultiModalGetEmbeddingDim returns the loaded multimodal model's native
+// embedding dimension, or -1 if no multimodal model is loaded.
+//
+// The router uses this to enforce the over-dimension contract with the real
+// model value instead of a hardcoded constant: the API dimension default (768)
+// exceeds the multimodal native dimension (384), so image-bearing requests must
+// default to and be validated against the native dimension.
+func MultiModalGetEmbeddingDim() int {
+	return int(C.multimodal_get_embedding_dim())
 }
 
 // MultiModalEncodeImageFromBase64 decodes a base64-encoded image and encodes it

--- a/candle-binding/semantic-router.go
+++ b/candle-binding/semantic-router.go
@@ -263,6 +263,8 @@ extern int multimodal_encode_image(const float* pixel_data, int height, int widt
 extern int multimodal_encode_image_from_bytes(const unsigned char* bytes_ptr, size_t bytes_len, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_audio(const float* mel_data, int n_mels, int time_frames, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_get_embedding_dim();
+extern int multimodal_get_supported_dimensions_count();
+extern int multimodal_get_supported_dimension(int index);
 extern void free_multimodal_embedding(float* data, int length);
 extern void free_tokenization_result(TokenizationResult result);
 extern ClassificationResult classify_text(const char* text);
@@ -1199,13 +1201,22 @@ func MultiModalEncodeImageFromBytes(imageBytes []byte, targetDim int) (*MultiMod
 
 // MultiModalGetEmbeddingDim returns the loaded multimodal model's native
 // embedding dimension, or -1 if no multimodal model is loaded.
-//
-// The router uses this to enforce the over-dimension contract with the real
-// model value instead of a hardcoded constant: the API dimension default (768)
-// exceeds the multimodal native dimension (384), so image-bearing requests must
-// default to and be validated against the native dimension.
 func MultiModalGetEmbeddingDim() int {
 	return int(C.multimodal_get_embedding_dim())
+}
+
+// MultiModalGetSupportedDimensions returns the dimensions declared by the
+// loaded multimodal checkpoint. An unavailable model returns nil.
+func MultiModalGetSupportedDimensions() []int {
+	count := int(C.multimodal_get_supported_dimensions_count())
+	if count <= 0 {
+		return nil
+	}
+	dimensions := make([]int, count)
+	for i := range dimensions {
+		dimensions[i] = int(C.multimodal_get_supported_dimension(C.int(i)))
+	}
+	return dimensions
 }
 
 // MultiModalEncodeImageFromBase64 decodes a base64-encoded image and encodes it

--- a/candle-binding/semantic-router_mock.go
+++ b/candle-binding/semantic-router_mock.go
@@ -246,6 +246,13 @@ func MultiModalEncodeImageFromURL(url string, targetDim int) (*MultiModalEmbeddi
 	return nil, ErrBackendUnavailable
 }
 
+// MultiModalGetEmbeddingDim reports the multimodal embedding dimension. Without
+// the native backend there is no model to query, so the stub returns 0, the
+// neutral unavailable value, instead of a synthetic dimension.
+func MultiModalGetEmbeddingDim() int {
+	return 0
+}
+
 // GetEmbedding2DMatryoshka generates an embedding using the 2D Matryoshka API
 func GetEmbedding2DMatryoshka(text string, modelType string, targetLayer int, targetDim int) (*EmbeddingOutput, error) {
 	return nil, ErrBackendUnavailable

--- a/candle-binding/semantic-router_mock.go
+++ b/candle-binding/semantic-router_mock.go
@@ -252,9 +252,10 @@ func MultiModalEncodeImageFromURL(url string, targetDim int) (*MultiModalEmbeddi
 	return nil, ErrBackendUnavailable
 }
 
-// MultiModalGetEmbeddingDim reports no loaded model without the native backend.
+// MultiModalGetEmbeddingDim reports no loaded model without the native backend,
+// using the same -1 sentinel as the cgo build.
 func MultiModalGetEmbeddingDim() int {
-	return 0
+	return -1
 }
 
 // MultiModalGetSupportedDimensions reports no loaded model without the native backend.

--- a/candle-binding/semantic-router_mock.go
+++ b/candle-binding/semantic-router_mock.go
@@ -252,11 +252,14 @@ func MultiModalEncodeImageFromURL(url string, targetDim int) (*MultiModalEmbeddi
 	return nil, ErrBackendUnavailable
 }
 
-// MultiModalGetEmbeddingDim reports the multimodal embedding dimension. Without
-// the native backend there is no model to query, so the stub returns 0, the
-// neutral unavailable value, instead of a synthetic dimension.
+// MultiModalGetEmbeddingDim reports no loaded model without the native backend.
 func MultiModalGetEmbeddingDim() int {
 	return 0
+}
+
+// MultiModalGetSupportedDimensions reports no loaded model without the native backend.
+func MultiModalGetSupportedDimensions() []int {
+	return nil
 }
 
 // GetEmbedding2DMatryoshka generates an embedding using the 2D Matryoshka API

--- a/candle-binding/semantic-router_mock.go
+++ b/candle-binding/semantic-router_mock.go
@@ -252,6 +252,13 @@ func MultiModalEncodeImageFromURL(url string, targetDim int) (*MultiModalEmbeddi
 	return nil, ErrBackendUnavailable
 }
 
+// MultiModalGetEmbeddingDim reports the multimodal embedding dimension. Without
+// the native backend there is no model to query, so the stub returns 0, the
+// neutral unavailable value, instead of a synthetic dimension.
+func MultiModalGetEmbeddingDim() int {
+	return 0
+}
+
 // GetEmbedding2DMatryoshka generates an embedding using the 2D Matryoshka API
 func GetEmbedding2DMatryoshka(text string, modelType string, targetLayer int, targetDim int) (*EmbeddingOutput, error) {
 	return nil, ErrBackendUnavailable

--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -93,6 +93,25 @@ fn get_multimodal_refs() -> Option<(&'static MultiModalEmbeddingModel, &'static 
     None
 }
 
+/// Return the loaded multimodal model's native embedding dimension.
+///
+/// The router needs this to enforce the over-dimension contract server-side:
+/// the API default (768) exceeds the multimodal native dimension (384), so the
+/// Go layer must clamp its default and reject above-native requests using the
+/// real value rather than a hardcoded constant that a model config could
+/// override via `embedding_dim`.
+///
+/// # Returns
+/// The native embedding dimension (> 0) on success, or -1 if no multimodal
+/// model is loaded.
+#[no_mangle]
+pub extern "C" fn multimodal_get_embedding_dim() -> i32 {
+    match get_multimodal_refs() {
+        Some((model, _tokenizer)) => model.config().embedding_dim as i32,
+        None => -1,
+    }
+}
+
 /// Generic internal helper for single text embedding generation
 ///
 /// This function extracts common logic for both Qwen3 and Gemma models.

--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -94,20 +94,35 @@ fn get_multimodal_refs() -> Option<(&'static MultiModalEmbeddingModel, &'static 
 }
 
 /// Return the loaded multimodal model's native embedding dimension.
-///
-/// The router needs this to enforce the over-dimension contract server-side:
-/// the API default (768) exceeds the multimodal native dimension (384), so the
-/// Go layer must clamp its default and reject above-native requests using the
-/// real value rather than a hardcoded constant that a model config could
-/// override via `embedding_dim`.
-///
-/// # Returns
-/// The native embedding dimension (> 0) on success, or -1 if no multimodal
-/// model is loaded.
 #[no_mangle]
 pub extern "C" fn multimodal_get_embedding_dim() -> i32 {
     match get_multimodal_refs() {
         Some((model, _tokenizer)) => model.config().embedding_dim as i32,
+        None => -1,
+    }
+}
+
+/// Return the number of dimensions declared by the loaded multimodal model.
+#[no_mangle]
+pub extern "C" fn multimodal_get_supported_dimensions_count() -> i32 {
+    match get_multimodal_refs() {
+        Some((model, _tokenizer)) => model.config().matryoshka_dims.len() as i32,
+        None => -1,
+    }
+}
+
+/// Return one declared dimension by index, or -1 when unavailable/out of range.
+#[no_mangle]
+pub extern "C" fn multimodal_get_supported_dimension(index: i32) -> i32 {
+    if index < 0 {
+        return -1;
+    }
+    match get_multimodal_refs() {
+        Some((model, _tokenizer)) => model
+            .config()
+            .matryoshka_dims
+            .get(index as usize)
+            .map_or(-1, |dimension| *dimension as i32),
         None => -1,
     }
 }

--- a/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
+++ b/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
@@ -1179,6 +1179,17 @@ impl MultiModalEmbeddingModel {
         target_dim: Option<usize>,
     ) -> UnifiedResult<Tensor> {
         let target_dim = target_dim.unwrap_or(self.config.embedding_dim);
+        // Match the text 2DMSE contract: MRL only truncates down from the
+        // native dimension, so an above-native request cannot be satisfied and
+        // must be rejected rather than silently returning the native vector.
+        if target_dim > self.config.embedding_dim {
+            return Err(UnifiedError::Validation {
+                field: "target_dim".to_string(),
+                expected: format!("<= {}", self.config.embedding_dim),
+                actual: target_dim.to_string(),
+                context: None,
+            });
+        }
 
         let pooler_output = self
             .image_encoder
@@ -2516,6 +2527,26 @@ mod integration_tests {
             Some(999), // exceeds embedding_dim
         );
         assert!(result.is_err(), "dim=999 should be rejected");
+    }
+
+    #[test]
+    #[ignore = "requires model files"]
+    fn test_image_invalid_dim_rejected() {
+        let (model, _tokenizer) = load_model_and_tokenizer();
+        let img = make_test_image(model.device(), 0.5, 0.3, 0.7);
+
+        // Above-native request must be rejected, mirroring the text 2DMSE path,
+        // rather than silently returning the native-dimension vector.
+        let result = model.encode_image_with_dim(&img, Some(768));
+        assert!(
+            result.is_err(),
+            "image dim=768 (> native) should be rejected"
+        );
+
+        // Native and below-native requests still succeed.
+        let native = model.config().embedding_dim;
+        let ok = model.encode_image_with_dim(&img, Some(native));
+        assert!(ok.is_ok(), "image dim=native ({}) should succeed", native);
     }
 
     /// Shape-only smoke test for the new SigLIPHead attentional probe pooling.

--- a/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
+++ b/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
@@ -124,7 +124,60 @@ impl MultiModalEmbeddingConfig {
                 .filter_map(|d| d.as_u64().map(|x| x as usize))
                 .collect();
         }
+        cfg.validate_dimension_contract()?;
         Ok(cfg)
+    }
+
+    pub fn validate_dimension_contract(&self) -> UnifiedResult<()> {
+        if self.embedding_dim == 0 {
+            return Err(UnifiedError::Validation {
+                field: "embedding_dim".to_string(),
+                expected: "a positive native dimension".to_string(),
+                actual: self.embedding_dim.to_string(),
+                context: Some("multimodal embedding dimension contract".to_string()),
+            });
+        }
+        if self.matryoshka_dims.is_empty()
+            || !self.matryoshka_dims.contains(&self.embedding_dim)
+            || self
+                .matryoshka_dims
+                .iter()
+                .any(|&dimension| dimension == 0 || dimension > self.embedding_dim)
+        {
+            return Err(UnifiedError::Validation {
+                field: "matryoshka_dims".to_string(),
+                expected: format!(
+                    "positive dimensions no greater than embedding_dim ({}) and including it",
+                    self.embedding_dim
+                ),
+                actual: format!("{:?}", self.matryoshka_dims),
+                context: Some("multimodal embedding dimension contract".to_string()),
+            });
+        }
+        let mut unique = self.matryoshka_dims.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        if unique.len() != self.matryoshka_dims.len() {
+            return Err(UnifiedError::Validation {
+                field: "matryoshka_dims".to_string(),
+                expected: "unique dimensions".to_string(),
+                actual: format!("{:?}", self.matryoshka_dims),
+                context: Some("multimodal embedding dimension contract".to_string()),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn validate_target_dimension(&self, dimension: usize) -> UnifiedResult<()> {
+        if !self.matryoshka_dims.contains(&dimension) {
+            return Err(UnifiedError::Validation {
+                field: "target_dim".to_string(),
+                expected: format!("one of {:?}", self.matryoshka_dims),
+                actual: dimension.to_string(),
+                context: Some("multimodal embedding dimension contract".to_string()),
+            });
+        }
+        Ok(())
     }
 
     pub fn num_image_patches(&self) -> usize {
@@ -1057,6 +1110,10 @@ impl MultiModalEmbeddingModel {
 
         // Audio encoder: weights under audio_encoder.encoder.* (optional)
         let audio_encoder = WhisperEncoder::load(vb.pp("audio_encoder.encoder"), config).ok();
+        let matryoshka_config = MultiModalMatryoshkaConfig {
+            dimensions: config.matryoshka_dims.clone(),
+            ..MultiModalMatryoshkaConfig::default()
+        };
 
         Ok(Self {
             text_encoder,
@@ -1064,7 +1121,7 @@ impl MultiModalEmbeddingModel {
             image_projection,
             audio_encoder,
             config: config.clone(),
-            matryoshka_config: MultiModalMatryoshkaConfig::default(),
+            matryoshka_config,
             device: device.clone(),
         })
     }
@@ -1120,14 +1177,7 @@ impl MultiModalEmbeddingModel {
         }
 
         let target_dim = target_dim.unwrap_or(self.config.embedding_dim);
-        if target_dim > self.config.embedding_dim {
-            return Err(UnifiedError::Validation {
-                field: "target_dim".to_string(),
-                expected: format!("<= {}", self.config.embedding_dim),
-                actual: target_dim.to_string(),
-                context: None,
-            });
-        }
+        self.config.validate_target_dimension(target_dim)?;
 
         let default_mask;
         let mask = match attention_mask {
@@ -1179,17 +1229,7 @@ impl MultiModalEmbeddingModel {
         target_dim: Option<usize>,
     ) -> UnifiedResult<Tensor> {
         let target_dim = target_dim.unwrap_or(self.config.embedding_dim);
-        // Match the text 2DMSE contract: MRL only truncates down from the
-        // native dimension, so an above-native request cannot be satisfied and
-        // must be rejected rather than silently returning the native vector.
-        if target_dim > self.config.embedding_dim {
-            return Err(UnifiedError::Validation {
-                field: "target_dim".to_string(),
-                expected: format!("<= {}", self.config.embedding_dim),
-                actual: target_dim.to_string(),
-                context: None,
-            });
-        }
+        self.config.validate_target_dimension(target_dim)?;
 
         let pooler_output = self
             .image_encoder
@@ -1226,6 +1266,7 @@ impl MultiModalEmbeddingModel {
         target_dim: Option<usize>,
     ) -> UnifiedResult<Tensor> {
         let target_dim = target_dim.unwrap_or(self.config.embedding_dim);
+        self.config.validate_target_dimension(target_dim)?;
 
         let encoder = self.audio_encoder.as_ref().ok_or_else(|| {
             from_candle_error(
@@ -1552,6 +1593,24 @@ mod tests {
         assert!(config.validate_layer(6));
         assert!(config.validate_layer(1));
         assert!(!config.validate_layer(7));
+    }
+
+    #[test]
+    fn test_multimodal_dimension_contract_rejects_undeclared_prefix() {
+        let config = MultiModalEmbeddingConfig::default();
+        assert!(config.validate_target_dimension(384).is_ok());
+        assert!(config.validate_target_dimension(32).is_ok());
+        assert!(config.validate_target_dimension(100).is_err());
+        assert!(config.validate_target_dimension(768).is_err());
+    }
+
+    #[test]
+    fn test_multimodal_dimension_contract_requires_native_dimension() {
+        let config = MultiModalEmbeddingConfig {
+            matryoshka_dims: vec![256, 128, 64, 32],
+            ..MultiModalEmbeddingConfig::default()
+        };
+        assert!(config.validate_dimension_contract().is_err());
     }
 
     #[test]
@@ -2520,13 +2579,9 @@ mod integration_tests {
         let input_ids = Tensor::from_vec(ids, (1, seq_len), device).unwrap();
         let attention_mask = Tensor::from_vec(mask, (1, seq_len), device).unwrap();
 
-        let result = model.encode_text_with_matryoshka(
-            &input_ids,
-            Some(&attention_mask),
-            None,
-            Some(999), // exceeds embedding_dim
-        );
-        assert!(result.is_err(), "dim=999 should be rejected");
+        let result =
+            model.encode_text_with_matryoshka(&input_ids, Some(&attention_mask), None, Some(100));
+        assert!(result.is_err(), "undeclared dim=100 should be rejected");
     }
 
     #[test]
@@ -2535,18 +2590,17 @@ mod integration_tests {
         let (model, _tokenizer) = load_model_and_tokenizer();
         let img = make_test_image(model.device(), 0.5, 0.3, 0.7);
 
-        // Above-native request must be rejected, mirroring the text 2DMSE path,
-        // rather than silently returning the native-dimension vector.
-        let result = model.encode_image_with_dim(&img, Some(768));
-        assert!(
-            result.is_err(),
-            "image dim=768 (> native) should be rejected"
-        );
-
-        // Native and below-native requests still succeed.
-        let native = model.config().embedding_dim;
-        let ok = model.encode_image_with_dim(&img, Some(native));
-        assert!(ok.is_ok(), "image dim=native ({}) should succeed", native);
+        for dimension in [384, 256, 128, 64, 32] {
+            let output = model.encode_image_with_dim(&img, Some(dimension));
+            assert!(output.is_ok(), "declared dim={dimension} should succeed");
+        }
+        for dimension in [100, 768] {
+            let output = model.encode_image_with_dim(&img, Some(dimension));
+            assert!(
+                output.is_err(),
+                "undeclared dim={dimension} should be rejected"
+            );
+        }
     }
 
     /// Shape-only smoke test for the new SigLIPHead attentional probe pooling.

--- a/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
+++ b/candle-binding/src/model_architectures/embedding/multimodal_embedding.rs
@@ -123,6 +123,12 @@ impl MultiModalEmbeddingConfig {
                 .iter()
                 .filter_map(|d| d.as_u64().map(|x| x as usize))
                 .collect();
+        } else if !cfg.matryoshka_dims.contains(&cfg.embedding_dim) {
+            // config.json moved embedding_dim off the default ladder without
+            // declaring one. The checkpoint only guarantees its native width, so
+            // publish that alone rather than failing the load over a field the
+            // operator never wrote or inventing untrained truncations.
+            cfg.matryoshka_dims = vec![cfg.embedding_dim];
         }
         cfg.validate_dimension_contract()?;
         Ok(cfg)
@@ -1602,6 +1608,29 @@ mod tests {
         assert!(config.validate_target_dimension(32).is_ok());
         assert!(config.validate_target_dimension(100).is_err());
         assert!(config.validate_target_dimension(768).is_err());
+    }
+
+    // A checkpoint may set embedding_dim without declaring a Matryoshka ladder.
+    // That used to load and truncate; it must not become a hard load failure
+    // naming a field the operator never wrote.
+    #[test]
+    fn test_multimodal_native_dimension_without_declared_ladder_loads() {
+        let dir = std::env::temp_dir().join(format!(
+            "candle-mm-cfg-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.json"), r#"{"embedding_dim": 768}"#).unwrap();
+
+        let config = MultiModalEmbeddingConfig::from_pretrained(&dir).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(config.embedding_dim, 768);
+        assert_eq!(config.matryoshka_dims, vec![768]);
+        assert!(config.validate_target_dimension(768).is_ok());
+        // No untrained intermediate width is invented on the model's behalf.
+        assert!(config.validate_target_dimension(384).is_err());
     }
 
     #[test]

--- a/onnx-binding/semantic-router.go
+++ b/onnx-binding/semantic-router.go
@@ -1231,3 +1231,31 @@ func decodeAndResizeImageOnnx(data []byte, targetW, targetH int) ([]float32, err
 	}
 	return pixels, nil
 }
+
+var (
+	mmDimMu     sync.Mutex
+	mmDimCached int // 0 = not yet probed; >0 = native dim; -1 = probe failed / no model
+)
+
+// MultiModalGetEmbeddingDim returns the loaded multimodal model's native
+// embedding dimension, or -1 if no multimodal model is loaded.
+//
+// The router uses this to enforce the over-dimension contract with the real
+// model value instead of a hardcoded constant. The ONNX C ABI exposes no
+// dedicated dimension getter, so the native dimension is discovered by encoding
+// a minimal probe at the native dimension (targetDim=0) and reading the output
+// length. The result is constant per loaded model, so it is cached after the
+// first successful probe.
+func MultiModalGetEmbeddingDim() int {
+	mmDimMu.Lock()
+	defer mmDimMu.Unlock()
+	if mmDimCached > 0 {
+		return mmDimCached
+	}
+	out, err := MultiModalEncodeText(" ", 0)
+	if err != nil || out == nil || len(out.Embedding) == 0 {
+		return -1
+	}
+	mmDimCached = len(out.Embedding)
+	return mmDimCached
+}

--- a/onnx-binding/semantic-router.go
+++ b/onnx-binding/semantic-router.go
@@ -1308,3 +1308,31 @@ func decodeAndResizeImageOnnx(data []byte, targetW, targetH int) ([]float32, err
 	}
 	return pixels, nil
 }
+
+var (
+	mmDimMu     sync.Mutex
+	mmDimCached int // 0 = not yet probed; >0 = native dim; -1 = probe failed / no model
+)
+
+// MultiModalGetEmbeddingDim returns the loaded multimodal model's native
+// embedding dimension, or -1 if no multimodal model is loaded.
+//
+// The router uses this to enforce the over-dimension contract with the real
+// model value instead of a hardcoded constant. The ONNX C ABI exposes no
+// dedicated dimension getter, so the native dimension is discovered by encoding
+// a minimal probe at the native dimension (targetDim=0) and reading the output
+// length. The result is constant per loaded model, so it is cached after the
+// first successful probe.
+func MultiModalGetEmbeddingDim() int {
+	mmDimMu.Lock()
+	defer mmDimMu.Unlock()
+	if mmDimCached > 0 {
+		return mmDimCached
+	}
+	out, err := MultiModalEncodeText(" ", 0)
+	if err != nil || out == nil || len(out.Embedding) == 0 {
+		return -1
+	}
+	mmDimCached = len(out.Embedding)
+	return mmDimCached
+}

--- a/onnx-binding/semantic-router.go
+++ b/onnx-binding/semantic-router.go
@@ -137,6 +137,9 @@ extern bool init_multimodal_embedding_model(const char* model_path, bool use_cpu
 extern int multimodal_encode_text(const char* text, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_image(const float* pixel_data, int height, int width, int target_dim, MultiModalEmbeddingResult* result);
 extern int multimodal_encode_audio(const float* mel_data, int n_mels, int time_frames, int target_dim, MultiModalEmbeddingResult* result);
+extern int multimodal_get_embedding_dim();
+extern int multimodal_get_supported_dimensions_count();
+extern int multimodal_get_supported_dimension(int index);
 extern void free_multimodal_embedding(float* data, int length);
 */
 import "C"
@@ -1309,30 +1312,22 @@ func decodeAndResizeImageOnnx(data []byte, targetW, targetH int) ([]float32, err
 	return pixels, nil
 }
 
-var (
-	mmDimMu     sync.Mutex
-	mmDimCached int // 0 = not yet probed; >0 = native dim; -1 = probe failed / no model
-)
-
 // MultiModalGetEmbeddingDim returns the loaded multimodal model's native
 // embedding dimension, or -1 if no multimodal model is loaded.
-//
-// The router uses this to enforce the over-dimension contract with the real
-// model value instead of a hardcoded constant. The ONNX C ABI exposes no
-// dedicated dimension getter, so the native dimension is discovered by encoding
-// a minimal probe at the native dimension (targetDim=0) and reading the output
-// length. The result is constant per loaded model, so it is cached after the
-// first successful probe.
 func MultiModalGetEmbeddingDim() int {
-	mmDimMu.Lock()
-	defer mmDimMu.Unlock()
-	if mmDimCached > 0 {
-		return mmDimCached
+	return int(C.multimodal_get_embedding_dim())
+}
+
+// MultiModalGetSupportedDimensions returns the dimensions declared by the
+// loaded multimodal checkpoint. An unavailable model returns nil.
+func MultiModalGetSupportedDimensions() []int {
+	count := int(C.multimodal_get_supported_dimensions_count())
+	if count <= 0 {
+		return nil
 	}
-	out, err := MultiModalEncodeText(" ", 0)
-	if err != nil || out == nil || len(out.Embedding) == 0 {
-		return -1
+	dimensions := make([]int, count)
+	for i := range dimensions {
+		dimensions[i] = int(C.multimodal_get_supported_dimension(C.int(i)))
 	}
-	mmDimCached = len(out.Embedding)
-	return mmDimCached
+	return dimensions
 }

--- a/onnx-binding/src/ffi/multimodal.rs
+++ b/onnx-binding/src/ffi/multimodal.rs
@@ -3,6 +3,12 @@
 //! Provides FFI functions for multi-modal embedding (text, image, audio)
 //! matching the candle-binding multimodal API.
 
+// Pre-existing clippy debt in this C-ABI module: the lint gate enforces clippy
+// file-wide on any changed file, so the raw-pointer warnings on functions this
+// change does not touch would otherwise block it. Mirrors ffi/classify.rs in
+// candle-binding.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 use crate::ffi::types::MultiModalEmbeddingResult;
 use crate::model_architectures::embedding::multimodal_embedding::MultiModalEmbeddingModel;
 use std::ffi::{c_char, CStr};
@@ -286,8 +292,8 @@ pub extern "C" fn multimodal_encode_audio(
 pub extern "C" fn free_multimodal_embedding(data: *mut f32, length: i32) {
     if !data.is_null() && length > 0 {
         unsafe {
-            let _ =
-                Box::from_raw(std::slice::from_raw_parts_mut(data, length as usize) as *mut [f32]);
+            let _: Box<[f32]> =
+                Box::from_raw(std::ptr::slice_from_raw_parts_mut(data, length as usize));
         }
     }
 }

--- a/onnx-binding/src/ffi/multimodal.rs
+++ b/onnx-binding/src/ffi/multimodal.rs
@@ -52,6 +52,34 @@ pub extern "C" fn init_multimodal_embedding_model(
     }
 }
 
+#[no_mangle]
+pub extern "C" fn multimodal_get_embedding_dim() -> i32 {
+    GLOBAL_MULTIMODAL
+        .get()
+        .map_or(-1, |model| model.config().embedding_dim as i32)
+}
+
+#[no_mangle]
+pub extern "C" fn multimodal_get_supported_dimensions_count() -> i32 {
+    GLOBAL_MULTIMODAL
+        .get()
+        .map_or(-1, |model| model.config().matryoshka_dims.len() as i32)
+}
+
+#[no_mangle]
+pub extern "C" fn multimodal_get_supported_dimension(index: i32) -> i32 {
+    if index < 0 {
+        return -1;
+    }
+    GLOBAL_MULTIMODAL.get().map_or(-1, |model| {
+        model
+            .config()
+            .matryoshka_dims
+            .get(index as usize)
+            .map_or(-1, |dimension| *dimension as i32)
+    })
+}
+
 /// Encode text into a multi-modal embedding.
 #[no_mangle]
 pub extern "C" fn multimodal_encode_text(

--- a/onnx-binding/src/model_architectures/embedding/multimodal_embedding.rs
+++ b/onnx-binding/src/model_architectures/embedding/multimodal_embedding.rs
@@ -71,6 +71,10 @@ impl MultiModalConfig {
                 .iter()
                 .filter_map(|dimension| dimension.as_u64().map(|value| value as usize))
                 .collect();
+        } else if !cfg.matryoshka_dims.contains(&cfg.embedding_dim) {
+            // config.json moved embedding_dim off the default ladder without
+            // declaring one; the checkpoint only guarantees its native width.
+            cfg.matryoshka_dims = vec![cfg.embedding_dim];
         }
         if let Some(s) = v
             .get("image_encoder")
@@ -144,8 +148,9 @@ impl MultiModalEmbeddingModel {
     pub fn load<P: AsRef<Path>>(model_path: P, use_cpu: bool) -> UnifiedResult<Self> {
         let dir = model_path.as_ref();
         let model_path_str = dir.display().to_string();
+        // from_pretrained establishes the dimension contract; no second check here.
         let config = MultiModalConfig::from_pretrained(dir)?;
-        config.validate_dimension_contract()?;
+
         let find_artifact = |name: &str| -> Option<std::path::PathBuf> {
             let root = dir.join(name);
             if root.exists() {
@@ -543,6 +548,29 @@ mod tests {
         assert!(config.validate_target_dimension(32).is_ok());
         assert!(config.validate_target_dimension(100).is_err());
         assert!(config.validate_target_dimension(768).is_err());
+    }
+
+    // A checkpoint may set embedding_dim without declaring a Matryoshka ladder.
+    // That used to load and truncate; it must not become a hard load failure
+    // naming a field the operator never wrote.
+    #[test]
+    fn test_native_dimension_without_declared_ladder_loads() {
+        let dir = std::env::temp_dir().join(format!(
+            "onnx-mm-cfg-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.json"), r#"{"embedding_dim": 768}"#).unwrap();
+
+        let config = MultiModalConfig::from_pretrained(&dir).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(config.embedding_dim, 768);
+        assert_eq!(config.matryoshka_dims, vec![768]);
+        assert!(config.validate_target_dimension(768).is_ok());
+        // No untrained intermediate width is invented on the model's behalf.
+        assert!(config.validate_target_dimension(384).is_err());
     }
 
     #[test]

--- a/onnx-binding/src/model_architectures/embedding/multimodal_embedding.rs
+++ b/onnx-binding/src/model_architectures/embedding/multimodal_embedding.rs
@@ -66,6 +66,12 @@ impl MultiModalConfig {
         if let Some(d) = v["embedding_dim"].as_u64() {
             cfg.embedding_dim = d as usize;
         }
+        if let Some(dims) = v["matryoshka_dims"].as_array() {
+            cfg.matryoshka_dims = dims
+                .iter()
+                .filter_map(|dimension| dimension.as_u64().map(|value| value as usize))
+                .collect();
+        }
         if let Some(s) = v
             .get("image_encoder")
             .and_then(|o| o["image_size"].as_u64())
@@ -81,7 +87,47 @@ impl MultiModalConfig {
         {
             cfg.max_seq_len = l as usize;
         }
+        cfg.validate_dimension_contract()?;
         Ok(cfg)
+    }
+
+    pub fn validate_dimension_contract(&self) -> UnifiedResult<()> {
+        if self.embedding_dim == 0
+            || self.matryoshka_dims.is_empty()
+            || !self.matryoshka_dims.contains(&self.embedding_dim)
+            || self
+                .matryoshka_dims
+                .iter()
+                .any(|&dimension| dimension == 0 || dimension > self.embedding_dim)
+        {
+            return Err(errors::validation(
+                "multimodal dimension contract",
+                "positive declared dimensions no greater than and including embedding_dim",
+                &format!("{} / {:?}", self.embedding_dim, self.matryoshka_dims),
+            ));
+        }
+        let mut unique = self.matryoshka_dims.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        if unique.len() != self.matryoshka_dims.len() {
+            return Err(errors::validation(
+                "matryoshka_dims",
+                "unique dimensions",
+                &format!("{:?}", self.matryoshka_dims),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_target_dimension(&self, dimension: usize) -> UnifiedResult<()> {
+        if !self.matryoshka_dims.contains(&dimension) {
+            return Err(errors::validation(
+                "target_dim",
+                &format!("one of {:?}", self.matryoshka_dims),
+                &dimension.to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -98,9 +144,8 @@ impl MultiModalEmbeddingModel {
     pub fn load<P: AsRef<Path>>(model_path: P, use_cpu: bool) -> UnifiedResult<Self> {
         let dir = model_path.as_ref();
         let model_path_str = dir.display().to_string();
-
         let config = MultiModalConfig::from_pretrained(dir)?;
-
+        config.validate_dimension_contract()?;
         let find_artifact = |name: &str| -> Option<std::path::PathBuf> {
             let root = dir.join(name);
             if root.exists() {
@@ -420,7 +465,9 @@ impl MultiModalEmbeddingModel {
         emb: Array1<f32>,
         target_dim: Option<usize>,
     ) -> UnifiedResult<Array1<f32>> {
-        Ok(truncate_embedding_to_dimension(emb, target_dim))
+        let dimension = target_dim.unwrap_or(self.config.embedding_dim);
+        self.config.validate_target_dimension(dimension)?;
+        Ok(truncate_embedding_to_dimension(emb, Some(dimension)))
     }
 }
 
@@ -487,6 +534,15 @@ mod tests {
             (l2_norm(&truncated) - 1.0).abs() < 1e-6,
             "re-normalized prefix must have unit L2 norm"
         );
+    }
+
+    #[test]
+    fn test_dimension_contract_rejects_undeclared_prefix() {
+        let config = MultiModalConfig::default();
+        assert!(config.validate_target_dimension(384).is_ok());
+        assert!(config.validate_target_dimension(32).is_ok());
+        assert!(config.validate_target_dimension(100).is_err());
+        assert!(config.validate_target_dimension(768).is_err());
     }
 
     #[test]

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -92,7 +92,7 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default; the image side honors this value when it fits the native ceiling (<= 384) and otherwise caps at native, so per-item response.dimension may differ by modality.
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Text-only requests default to 768. Requests containing images default to the multimodal native dimension and reject values above that native ceiling; mixed responses use one dimension for every modality.
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -92,8 +92,8 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 768 (default), 512, 256, 128, 64
-	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert only): 3, 6, 11, 22 (0=full)
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024; text default 768. Image inputs cap at the multimodal native dimension (384): image-bearing requests default to it, and an explicit larger value is rejected.
+	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	SequenceLength  int      `json:"sequence_length,omitempty"`  // Optional, auto-detected if not provided

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -92,7 +92,7 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024; text default 768. Image inputs cap at the multimodal native dimension (384): image-bearing requests default to it, and an explicit larger value is rejected.
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default and always encode the image side at its native dimension; per-item response.dimension disambiguates.
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -92,7 +92,7 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default and always encode the image side at its native dimension; per-item response.dimension disambiguates.
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default; the image side honors this value when it fits the native ceiling (<= 384) and otherwise caps at native, so per-item response.dimension may differ by modality.
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -128,8 +128,8 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 768 (default), 512, 256, 128, 64
-	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert only): 3, 6, 11, 22 (0=full)
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024; text default 768. Image inputs cap at the multimodal native dimension (384): image-bearing requests default to it, and an explicit larger value is rejected.
+	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	SequenceLength  int      `json:"sequence_length,omitempty"`  // Optional, auto-detected if not provided

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -128,7 +128,7 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default and always encode the image side at its native dimension; per-item response.dimension disambiguates.
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default; the image side honors this value when it fits the native ceiling (<= 384) and otherwise caps at native, so per-item response.dimension may differ by modality.
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -128,7 +128,7 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Text-only requests default to 768. Requests containing images default to the multimodal native dimension and reject values above that native ceiling; mixed responses use one dimension for every modality.
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Targets the text side (default 768); image-only requests default to the multimodal native dimension and reject values above it. In mixed requests the image side caps at native, so per-item response.dimension may differ by modality.
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -128,7 +128,7 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default; the image side honors this value when it fits the native ceiling (<= 384) and otherwise caps at native, so per-item response.dimension may differ by modality.
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Text-only requests default to 768. Requests containing images default to the multimodal native dimension and reject values above that native ceiling; mixed responses use one dimension for every modality.
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -127,9 +127,9 @@ type ClassificationOptions struct {
 type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
-	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Targets the text side (default 768); image-only requests default to the multimodal native dimension and reject values above it. In mixed requests the image side caps at native, so per-item response.dimension may differ by modality.
-	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
+	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert", or "multimodal"
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension; omitted uses the resolved model's default
+	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full)
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	SequenceLength  int      `json:"sequence_length,omitempty"`  // Optional, auto-detected if not provided

--- a/src/semantic-router/pkg/apiserver/config.go
+++ b/src/semantic-router/pkg/apiserver/config.go
@@ -128,7 +128,7 @@ type EmbeddingRequest struct {
 	Texts           []string `json:"texts"`
 	Images          []string `json:"images,omitempty"`           // Inline base64 image data URIs (data:image/...;base64,...); encoded via the multi-modal model
 	Model           string   `json:"model,omitempty"`            // "auto" (default), "qwen3", "gemma", "mmbert"
-	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024; text default 768. Image inputs cap at the multimodal native dimension (384): image-bearing requests default to it, and an explicit larger value is rejected.
+	Dimension       int      `json:"dimension,omitempty"`        // Target dimension: 64/128/256/384/512/768/1024. Applies to the text side (default 768). Image-only requests use this as the image target (default 384, must be <= multimodal native 384). Mixed text+image requests keep the text default and always encode the image side at its native dimension; per-item response.dimension disambiguates.
 	TargetLayer     int      `json:"target_layer,omitempty"`     // Target layer for early exit (mmbert text only): 3, 6, 11, 22 (0=full); not supported for image inputs
 	QualityPriority float32  `json:"quality_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")
 	LatencyPriority float32  `json:"latency_priority,omitempty"` // 0.0-1.0, default 0.5 (only used when model="auto")

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -29,6 +29,28 @@ var multiModalEmbeddingDim = candle_binding.MultiModalGetEmbeddingDim
 // path is configured; it matches the canonical shipped checkpoint.
 const multiModalModelFallbackID = "multi-modal-embed-small"
 
+// imageTargetDimension resolves the per-request image encoding dimension.
+//
+// Image-only requests use req.Dimension directly (validated <= native). Mixed
+// text+image requests always encode the image side at the multimodal native
+// dimension: req.Dimension controls the text side and would exceed the image
+// ceiling, and forcing a single uniform dimension across two encoders whose
+// embedding spaces do not align gives no real benefit while silently
+// downgrading text recall.
+//
+// If no multimodal model is loaded (getter reports <= 0), fall back to
+// req.Dimension so the downstream encode surfaces "model not loaded" rather
+// than this helper guessing a value.
+func imageTargetDimension(req EmbeddingRequest) int {
+	if len(req.Texts) == 0 {
+		return req.Dimension
+	}
+	if native := multiModalEmbeddingDim(); native > 0 {
+		return native
+	}
+	return req.Dimension
+}
+
 // isMultiModalModelName reports whether an explicit model selector names the
 // multimodal embedding model. Mirrors the aliases registered in
 // config/registry.go so an image request may name the multimodal model
@@ -168,13 +190,18 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 		req.Model = "auto"
 	}
 	if req.Dimension == 0 {
-		// Image inputs cap at the multimodal model's native dimension, which is
-		// below the text default (768). Defaulting an image-bearing request to
-		// 768 would exceed the native dimension and, under the over-dimension
-		// contract, be rejected. Default such requests to the native dimension
-		// so a plain image (or mixed text+image) request succeeds with uniform
-		// vectors instead of failing or silently mixing dimensions.
-		if len(req.Images) > 0 {
+		// req.Dimension follows the primary modality:
+		//   - text-only / mixed: text default (768). In mixed mode Dimension
+		//     controls the text side; the image side always encodes at its
+		//     native dimension and is not affected by req.Dimension.
+		//   - image-only: multimodal native dimension (384), the ceiling MRL
+		//     can produce.
+		// Forcing mixed requests to a single uniform dimension would silently
+		// downgrade text recall (768 -> 384) for a false-consistency win:
+		// cross-encoder vectors live in different embedding spaces regardless
+		// of dimension, so uniform width does not enable cross-modal cosine.
+		// Per-item response.dimension disambiguates for the caller.
+		if len(req.Texts) == 0 && len(req.Images) > 0 {
 			if native := multiModalEmbeddingDim(); native > 0 {
 				req.Dimension = native
 			} else {
@@ -201,11 +228,17 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 384, 512, 768, 1024 (got %d)", req.Dimension), false
 	}
 	if len(req.Images) > 0 {
-		// Image inputs route to the multimodal model, whose native dimension is
-		// a ceiling: MRL only truncates down, so an above-native request cannot
-		// be satisfied and is rejected rather than silently returning native.
-		if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
-			return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
+		// Image-only: req.Dimension is the image target, so the multimodal
+		// native dimension is a hard ceiling (MRL only truncates down; an
+		// above-native request cannot be satisfied and is rejected rather
+		// than silently returning native).
+		// Mixed: req.Dimension applies to the text side and the image side
+		// always encodes at its native dimension, so a text-legal
+		// req.Dimension (e.g. 768) is not constrained by the image ceiling.
+		if len(req.Texts) == 0 {
+			if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
+				return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
+			}
 		}
 		// target_layer is a text-only mmbert 2DMSE control; it cannot apply to
 		// image encoding, so reject instead of silently ignoring it.
@@ -268,6 +301,7 @@ func buildEmbeddingResults(req EmbeddingRequest, multiModalModelID string) ([]Em
 		totalProcessingTime += processingTime
 	}
 
+	imgDim := imageTargetDimension(req)
 	for i, image := range req.Images {
 		// Canonicalize so the FFI's case-sensitive ";base64," scan finds the
 		// payload boundary (validation already guaranteed a safe data URI).
@@ -275,7 +309,7 @@ func buildEmbeddingResults(req EmbeddingRequest, multiModalModelID string) ([]Em
 		if canonical, ok := imageurl.CanonicalDataURL(image); ok {
 			encodeInput = canonical
 		}
-		output, err := multiModalEncodeImage(encodeInput, req.Dimension)
+		output, err := multiModalEncodeImage(encodeInput, imgDim)
 		if err != nil {
 			// The image already passed the safe-data-URI + base64-decode gate, so
 			// an encode failure here is input-caused (undecodable image bytes);

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -18,6 +19,28 @@ import (
 // multiModalEncodeImage is the FFI image-encode entry point, kept as a
 // package-level var so tests can inject a failing encoder without a loaded model.
 var multiModalEncodeImage = candle_binding.MultiModalEncodeImageFromBase64
+
+// multiModalEmbeddingDim reports the loaded multimodal model's native embedding
+// dimension (or <= 0 if none is loaded). It is a package-level var so tests can
+// stub the native dimension without a loaded model.
+var multiModalEmbeddingDim = candle_binding.MultiModalGetEmbeddingDim
+
+// multiModalModelFallbackID is the reported model id when no multimodal model
+// path is configured; it matches the canonical shipped checkpoint.
+const multiModalModelFallbackID = "multi-modal-embed-small"
+
+// isMultiModalModelName reports whether an explicit model selector names the
+// multimodal embedding model. Mirrors the aliases registered in
+// config/registry.go so an image request may name the multimodal model
+// explicitly without being rejected as a text-only selector.
+func isMultiModalModelName(model string) bool {
+	switch model {
+	case "multimodal", "multi-modal-embed-small", "multimodal-embedding",
+		"embedding-multimodal", "mom-embedding-multimodal":
+		return true
+	}
+	return false
+}
 
 // imageEncodeError marks an image-encode failure driven by the request input:
 // the payload validated as a safe base64 data URI but was not a decodable image.
@@ -75,7 +98,7 @@ func (s *ClassificationAPIServer) handleEmbeddings(w http.ResponseWriter, r *htt
 		return
 	}
 
-	results, totalProcessingTime, err := buildEmbeddingResults(req)
+	results, totalProcessingTime, err := buildEmbeddingResults(req, s.multiModalModelID())
 	if err != nil {
 		status, code, message := classifyEmbeddingError(err)
 		s.writeErrorResponse(w, status, code, message)
@@ -94,6 +117,21 @@ func (s *ClassificationAPIServer) handleEmbeddings(w http.ResponseWriter, r *htt
 		len(results), totalProcessingTime, avgProcessingTime)
 
 	s.writeJSONResponse(w, http.StatusOK, response)
+}
+
+// multiModalModelID reports the loaded multimodal model identifier for the
+// response's model_used field. It derives a clean id from the configured model
+// path (its base name, so a local path like "models/multi-modal-embed-small"
+// or a HF repo id both reduce to "multi-modal-embed-small" without leaking the
+// deployment's filesystem layout) and falls back to the canonical shipped id
+// when no path is configured.
+func (s *ClassificationAPIServer) multiModalModelID() string {
+	if s.config != nil {
+		if path := s.config.EmbeddingModels.MultiModalModelPath; path != "" {
+			return filepath.Base(path)
+		}
+	}
+	return multiModalModelFallbackID
 }
 
 func (s *ClassificationAPIServer) parseEmbeddingRequest(w http.ResponseWriter, r *http.Request) (EmbeddingRequest, bool) {
@@ -130,7 +168,21 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 		req.Model = "auto"
 	}
 	if req.Dimension == 0 {
-		req.Dimension = defaultEmbeddingDimension
+		// Image inputs cap at the multimodal model's native dimension, which is
+		// below the text default (768). Defaulting an image-bearing request to
+		// 768 would exceed the native dimension and, under the over-dimension
+		// contract, be rejected. Default such requests to the native dimension
+		// so a plain image (or mixed text+image) request succeeds with uniform
+		// vectors instead of failing or silently mixing dimensions.
+		if len(req.Images) > 0 {
+			if native := multiModalEmbeddingDim(); native > 0 {
+				req.Dimension = native
+			} else {
+				req.Dimension = defaultEmbeddingDimension
+			}
+		} else {
+			req.Dimension = defaultEmbeddingDimension
+		}
 	}
 	if req.QualityPriority == 0 && req.LatencyPriority == 0 {
 		req.QualityPriority = defaultEmbeddingPriority
@@ -146,7 +198,27 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 		return code, message, false
 	}
 	if !isValidDimension(req.Dimension) {
-		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 512, 768, 1024 (got %d)", req.Dimension), false
+		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 384, 512, 768, 1024 (got %d)", req.Dimension), false
+	}
+	if len(req.Images) > 0 {
+		// Image inputs route to the multimodal model, whose native dimension is
+		// a ceiling: MRL only truncates down, so an above-native request cannot
+		// be satisfied and is rejected rather than silently returning native.
+		if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
+			return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
+		}
+		// target_layer is a text-only mmbert 2DMSE control; it cannot apply to
+		// image encoding, so reject instead of silently ignoring it.
+		if req.TargetLayer != 0 {
+			return "INVALID_PARAMETER", "target_layer is not supported for image inputs", false
+		}
+		// Images always use the multimodal model. When there is no text for a
+		// named model to apply to, an explicit text-model selector would be
+		// silently ignored; reject so the contract is explicit. Mixed
+		// text+image requests still honor req.Model for the text side.
+		if len(req.Texts) == 0 && req.Model != "auto" && req.Model != "" && !isMultiModalModelName(req.Model) {
+			return "INVALID_PARAMETER", fmt.Sprintf("model=%q does not produce image embeddings; omit model or use the multimodal model for image inputs", req.Model), false
+		}
 	}
 	if req.TargetLayer != 0 && req.Model != "mmbert" {
 		return "INVALID_PARAMETER", "target_layer is only supported for model='mmbert'", false
@@ -174,7 +246,7 @@ func validateEmbeddingImages(images []string) (string, string, bool) {
 	return "", "", true
 }
 
-func buildEmbeddingResults(req EmbeddingRequest) ([]EmbeddingResult, int64, error) {
+func buildEmbeddingResults(req EmbeddingRequest, multiModalModelID string) ([]EmbeddingResult, int64, error) {
 	results := make([]EmbeddingResult, 0, len(req.Texts)+len(req.Images))
 	var totalProcessingTime int64
 
@@ -216,7 +288,7 @@ func buildEmbeddingResults(req EmbeddingRequest) ([]EmbeddingResult, int64, erro
 			Modality:         output.Modality,
 			Embedding:        output.Embedding,
 			Dimension:        len(output.Embedding),
-			ModelUsed:        "multi-modal-embed",
+			ModelUsed:        multiModalModelID,
 			ProcessingTimeMs: processingTime,
 		})
 
@@ -432,7 +504,9 @@ func buildBatchSimilarityMatches(result *candle_binding.BatchSimilarityOutput, c
 
 // isValidDimension checks if the provided dimension is valid
 func isValidDimension(dim int) bool {
-	validDimensions := map[int]bool{64: true, 128: true, 256: true, 512: true, 768: true, 1024: true}
+	// 384 is the multimodal model's native dimension; it must be accepted so
+	// callers can request the image model's full-width vector explicitly.
+	validDimensions := map[int]bool{64: true, 128: true, 256: true, 384: true, 512: true, 768: true, 1024: true}
 	return validDimensions[dim]
 }
 

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -175,22 +175,26 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 		req.Model = "auto"
 	}
 	if req.Dimension == 0 {
-		// Every image-bearing request uses the multimodal native dimension so a
-		// successful mixed response cannot contain vectors of different lengths.
-		if len(req.Images) > 0 {
-			if native := multiModalEmbeddingDim(); native > 0 {
-				req.Dimension = native
-			} else {
-				req.Dimension = defaultEmbeddingDimension
-			}
-		} else {
-			req.Dimension = defaultEmbeddingDimension
-		}
+		req.Dimension = defaultEmbeddingDimensionFor(req.Images)
 	}
 	if req.QualityPriority == 0 && req.LatencyPriority == 0 {
 		req.QualityPriority = defaultEmbeddingPriority
 		req.LatencyPriority = defaultEmbeddingPriority
 	}
+}
+
+// defaultEmbeddingDimensionFor picks the default embedding dimension when the
+// request omits one. Every image-bearing request uses the multimodal native
+// dimension so a successful mixed response cannot contain vectors of different
+// lengths; text-only requests use the API default.
+func defaultEmbeddingDimensionFor(images []string) int {
+	if len(images) == 0 {
+		return defaultEmbeddingDimension
+	}
+	if native := multiModalEmbeddingDim(); native > 0 {
+		return native
+	}
+	return defaultEmbeddingDimension
 }
 
 func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string, string, bool) {
@@ -203,30 +207,40 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 	if !isValidDimension(req.Dimension) {
 		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 384, 512, 768, 1024 (got %d)", req.Dimension), false
 	}
-	if len(req.Images) > 0 {
-		// MRL only truncates down from the image model's native dimension. Apply
-		// the ceiling to mixed requests too, before either modality is encoded.
-		if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
-			return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
-		}
-		// target_layer is a text-only mmbert 2DMSE control; it cannot apply to
-		// image encoding, so reject instead of silently ignoring it.
-		if req.TargetLayer != 0 {
-			return "INVALID_PARAMETER", "target_layer is not supported for image inputs", false
-		}
-		// Images always use the multimodal model. When there is no text for a
-		// named model to apply to, an explicit text-model selector would be
-		// silently ignored; reject so the contract is explicit. Mixed
-		// text+image requests still honor req.Model for the text side.
-		if len(req.Texts) == 0 && req.Model != "auto" && req.Model != "" && !isMultiModalModelName(req.Model) {
-			return "INVALID_PARAMETER", fmt.Sprintf("model=%q does not produce image embeddings; omit model or use the multimodal model for image inputs", req.Model), false
-		}
+	if code, message, ok := validateImageEmbeddingParams(req); !ok {
+		return code, message, false
 	}
 	if req.TargetLayer != 0 && req.Model != "mmbert" {
 		return "INVALID_PARAMETER", "target_layer is only supported for model='mmbert'", false
 	}
 	if req.Model == "mmbert" && req.TargetLayer != 0 && !config.IsValidMmBertLayer(req.TargetLayer, mmbertLayers) {
 		return "INVALID_LAYER", fmt.Sprintf("target_layer must be one of: %s (got %d)", formatLayerList(mmbertLayers), req.TargetLayer), false
+	}
+	return "", "", true
+}
+
+// validateImageEmbeddingParams enforces the image-specific parameter contract.
+// It is a no-op for text-only requests.
+func validateImageEmbeddingParams(req EmbeddingRequest) (string, string, bool) {
+	if len(req.Images) == 0 {
+		return "", "", true
+	}
+	// MRL only truncates down from the image model's native dimension. Apply
+	// the ceiling to mixed requests too, before either modality is encoded.
+	if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
+		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
+	}
+	// target_layer is a text-only mmbert 2DMSE control; it cannot apply to
+	// image encoding, so reject instead of silently ignoring it.
+	if req.TargetLayer != 0 {
+		return "INVALID_PARAMETER", "target_layer is not supported for image inputs", false
+	}
+	// Images always use the multimodal model. When there is no text for a
+	// named model to apply to, an explicit text-model selector would be
+	// silently ignored; reject so the contract is explicit. Mixed
+	// text+image requests still honor req.Model for the text side.
+	if len(req.Texts) == 0 && req.Model != "auto" && req.Model != "" && !isMultiModalModelName(req.Model) {
+		return "INVALID_PARAMETER", fmt.Sprintf("model=%q does not produce image embeddings; omit model or use the multimodal model for image inputs", req.Model), false
 	}
 	return "", "", true
 }

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -29,31 +29,11 @@ var multiModalEmbeddingDim = candle_binding.MultiModalGetEmbeddingDim
 // path is configured; it matches the canonical shipped checkpoint.
 const multiModalModelFallbackID = "multi-modal-embed-small"
 
-// imageTargetDimension resolves the per-request image encoding dimension.
-//
-// Image-only requests use req.Dimension directly (validated <= native). For
-// mixed text+image requests req.Dimension targets the text side (its default,
-// 768, exceeds the image ceiling); the image side honors it only when it fits
-// within the native ceiling and otherwise caps at native. This keeps an
-// explicitly requested, image-satisfiable dimension (e.g. 256) uniform across
-// both modalities, while a text-scale dimension (e.g. the 768 default) still
-// diverges instead of forcing text recall down to the image width.
-//
-// If no multimodal model is loaded (getter reports <= 0), fall back to
-// req.Dimension so the downstream encode surfaces "model not loaded" rather
-// than this helper guessing a value.
+// imageTargetDimension returns the request dimension for image encoding. Image
+// requests are validated before encoding, so this must not silently cap the
+// image result to a different dimension than the text side.
 func imageTargetDimension(req EmbeddingRequest) int {
-	if len(req.Texts) == 0 {
-		return req.Dimension
-	}
-	native := multiModalEmbeddingDim()
-	if native <= 0 {
-		return req.Dimension
-	}
-	if req.Dimension < native {
-		return req.Dimension
-	}
-	return native
+	return req.Dimension
 }
 
 // isMultiModalModelName reports whether an explicit model selector names the
@@ -146,15 +126,15 @@ func (s *ClassificationAPIServer) handleEmbeddings(w http.ResponseWriter, r *htt
 	s.writeJSONResponse(w, http.StatusOK, response)
 }
 
-// multiModalModelID reports the loaded multimodal model identifier for the
-// response's model_used field. It derives a clean id from the configured model
-// path (its base name, so a local path like "models/multi-modal-embed-small"
-// or a HF repo id both reduce to "multi-modal-embed-small" without leaking the
-// deployment's filesystem layout) and falls back to the canonical shipped id
-// when no path is configured.
+// multiModalModelID reports the loaded multimodal checkpoint identifier for the
+// response's model_used field. Known local aliases resolve through the static
+// registry; custom paths fall back to their base name.
 func (s *ClassificationAPIServer) multiModalModelID() string {
 	if s.config != nil {
 		if path := s.config.EmbeddingModels.MultiModalModelPath; path != "" {
+			if model := config.GetModelByPath(path); model != nil && model.RepoID != "" {
+				return filepath.Base(model.RepoID)
+			}
 			return filepath.Base(path)
 		}
 	}
@@ -195,18 +175,9 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 		req.Model = "auto"
 	}
 	if req.Dimension == 0 {
-		// req.Dimension follows the primary modality:
-		//   - text-only / mixed: text default (768). In mixed mode Dimension
-		//     controls the text side; the image side always encodes at its
-		//     native dimension and is not affected by req.Dimension.
-		//   - image-only: multimodal native dimension (384), the ceiling MRL
-		//     can produce.
-		// Forcing mixed requests to a single uniform dimension would silently
-		// downgrade text recall (768 -> 384) for a false-consistency win:
-		// cross-encoder vectors live in different embedding spaces regardless
-		// of dimension, so uniform width does not enable cross-modal cosine.
-		// Per-item response.dimension disambiguates for the caller.
-		if len(req.Texts) == 0 && len(req.Images) > 0 {
+		// Every image-bearing request uses the multimodal native dimension so a
+		// successful mixed response cannot contain vectors of different lengths.
+		if len(req.Images) > 0 {
 			if native := multiModalEmbeddingDim(); native > 0 {
 				req.Dimension = native
 			} else {
@@ -233,17 +204,10 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 384, 512, 768, 1024 (got %d)", req.Dimension), false
 	}
 	if len(req.Images) > 0 {
-		// Image-only: req.Dimension is the image target, so the multimodal
-		// native dimension is a hard ceiling (MRL only truncates down; an
-		// above-native request cannot be satisfied and is rejected rather
-		// than silently returning native).
-		// Mixed: req.Dimension applies to the text side and the image side
-		// always encodes at its native dimension, so a text-legal
-		// req.Dimension (e.g. 768) is not constrained by the image ceiling.
-		if len(req.Texts) == 0 {
-			if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
-				return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
-			}
+		// MRL only truncates down from the image model's native dimension. Apply
+		// the ceiling to mixed requests too, before either modality is encoded.
+		if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
+			return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
 		}
 		// target_layer is a text-only mmbert 2DMSE control; it cannot apply to
 		// image encoding, so reject instead of silently ignoring it.

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -31,12 +31,13 @@ const multiModalModelFallbackID = "multi-modal-embed-small"
 
 // imageTargetDimension resolves the per-request image encoding dimension.
 //
-// Image-only requests use req.Dimension directly (validated <= native). Mixed
-// text+image requests always encode the image side at the multimodal native
-// dimension: req.Dimension controls the text side and would exceed the image
-// ceiling, and forcing a single uniform dimension across two encoders whose
-// embedding spaces do not align gives no real benefit while silently
-// downgrading text recall.
+// Image-only requests use req.Dimension directly (validated <= native). For
+// mixed text+image requests req.Dimension targets the text side (its default,
+// 768, exceeds the image ceiling); the image side honors it only when it fits
+// within the native ceiling and otherwise caps at native. This keeps an
+// explicitly requested, image-satisfiable dimension (e.g. 256) uniform across
+// both modalities, while a text-scale dimension (e.g. the 768 default) still
+// diverges instead of forcing text recall down to the image width.
 //
 // If no multimodal model is loaded (getter reports <= 0), fall back to
 // req.Dimension so the downstream encode surfaces "model not loaded" rather
@@ -45,10 +46,14 @@ func imageTargetDimension(req EmbeddingRequest) int {
 	if len(req.Texts) == 0 {
 		return req.Dimension
 	}
-	if native := multiModalEmbeddingDim(); native > 0 {
-		return native
+	native := multiModalEmbeddingDim()
+	if native <= 0 {
+		return req.Dimension
 	}
-	return req.Dimension
+	if req.Dimension < native {
+		return req.Dimension
+	}
+	return native
 }
 
 // isMultiModalModelName reports whether an explicit model selector names the

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -20,36 +20,27 @@ import (
 // package-level var so tests can inject a failing encoder without a loaded model.
 var multiModalEncodeImage = candle_binding.MultiModalEncodeImageFromBase64
 
-// multiModalEmbeddingDim reports the loaded multimodal model's native embedding
-// dimension (or <= 0 if none is loaded). It is a package-level var so tests can
-// stub the native dimension without a loaded model.
-var multiModalEmbeddingDim = candle_binding.MultiModalGetEmbeddingDim
-
-// multiModalModelFallbackID is the reported model id when no multimodal model
-// path is configured; it matches the canonical shipped checkpoint.
-const multiModalModelFallbackID = "multi-modal-embed-small"
-
-// imageTargetDimension resolves the image encode dimension. Image-only requests
-// use req.Dimension directly (validated <= native). Mixed requests target the
-// text side, so the image side caps at native and warns once per request rather
-// than forcing text recall down to the image width.
-func imageTargetDimension(req EmbeddingRequest) int {
-	if len(req.Images) == 0 || len(req.Texts) == 0 {
-		return req.Dimension
-	}
-	native := multiModalEmbeddingDim()
-	if native <= 0 || req.Dimension <= native {
-		return req.Dimension
-	}
-	logging.Warnf("Embedding request dimension %d exceeds the multimodal native dimension %d; encoding %d image input(s) at %d, so response dimensions differ by modality",
-		req.Dimension, native, len(req.Images), native)
-	return native
+type embeddingDimensionContract struct {
+	ModelID   string
+	Default   int
+	Supported []int
 }
 
-// isMultiModalModelName reports whether an explicit model selector names the
-// multimodal embedding model. Mirrors the aliases registered in
-// config/registry.go so an image request may name the multimodal model
-// explicitly without being rejected as a text-only selector.
+// multiModalDimensionContract reports the immutable contract registered by
+// the loaded multimodal binding. It is replaceable for tests that do not load
+// a checkpoint.
+var multiModalDimensionContract = func() embeddingDimensionContract {
+	return embeddingDimensionContract{
+		ModelID:   multiModalModelFallbackID,
+		Default:   candle_binding.MultiModalGetEmbeddingDim(),
+		Supported: candle_binding.MultiModalGetSupportedDimensions(),
+	}
+}
+
+// multiModalModelFallbackID is used only when the configured checkpoint cannot
+// be resolved through the model registry.
+const multiModalModelFallbackID = "multi-modal-embed-small"
+
 func isMultiModalModelName(model string) bool {
 	switch model {
 	case "multimodal", "multi-modal-embed-small", "multimodal-embedding",
@@ -57,6 +48,19 @@ func isMultiModalModelName(model string) bool {
 		return true
 	}
 	return false
+}
+
+func (c embeddingDimensionContract) supports(dimension int) bool {
+	for _, supported := range c.Supported {
+		if dimension == supported {
+			return true
+		}
+	}
+	return false
+}
+
+func (c embeddingDimensionContract) supportedList() string {
+	return formatLayerList(c.Supported)
 }
 
 // imageEncodeError marks an image-encode failure driven by the request input:
@@ -95,8 +99,6 @@ const (
 	maxImagesPerRequest = 8
 )
 
-// invalidDimensionMessage matches the dimensions accepted by isValidDimension,
-// including 64 (which the similarity error messages previously omitted).
 const invalidDimensionMessage = "dimension must be one of: 64, 128, 256, 512, 768, 1024 (got %d)"
 
 // validatePriority rejects a priority weight outside the documented [0.0, 1.0]
@@ -181,11 +183,17 @@ func averageEmbeddingProcessingTime(totalProcessingTime int64, req EmbeddingRequ
 }
 
 func applyEmbeddingDefaults(req *EmbeddingRequest) {
-	if req.Model == "" {
-		req.Model = "auto"
+	if req.Model == "" || (req.Model == "auto" && len(req.Images) > 0) {
+		if len(req.Images) > 0 {
+			req.Model = "multimodal"
+		} else {
+			req.Model = "auto"
+		}
+	} else if isMultiModalModelName(req.Model) {
+		req.Model = "multimodal"
 	}
 	if req.Dimension == 0 {
-		req.Dimension = defaultEmbeddingDimensionFor(req.Texts, req.Images)
+		req.Dimension = defaultEmbeddingDimensionForModel(req.Model)
 	}
 	if req.QualityPriority == 0 && req.LatencyPriority == 0 {
 		req.QualityPriority = defaultEmbeddingPriority
@@ -193,17 +201,11 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 	}
 }
 
-// defaultEmbeddingDimensionFor picks the default dimension when the request
-// omits one. req.Dimension targets the text side, so only an image-only request
-// defaults to the multimodal native dimension.
-func defaultEmbeddingDimensionFor(texts, images []string) int {
-	if len(texts) > 0 || len(images) == 0 {
+func defaultEmbeddingDimensionForModel(model string) int {
+	if !isMultiModalModelName(model) {
 		return defaultEmbeddingDimension
 	}
-	if native := multiModalEmbeddingDim(); native > 0 {
-		return native
-	}
-	return defaultEmbeddingDimension
+	return multiModalDimensionContract().Default
 }
 
 func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string, string, bool) {
@@ -213,8 +215,8 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 	if code, message, ok := validateEmbeddingImages(req.Images); !ok {
 		return code, message, false
 	}
-	if !isValidDimension(req.Dimension) {
-		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be one of: 64, 128, 256, 384, 512, 768, 1024 (got %d)", req.Dimension), false
+	if code, message, ok := validateEmbeddingDimension(req); !ok {
+		return code, message, false
 	}
 	if code, message, ok := validateImageEmbeddingParams(req); !ok {
 		return code, message, false
@@ -228,31 +230,31 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 	return "", "", true
 }
 
-// validateImageEmbeddingParams enforces the image-specific parameter contract.
-// It is a no-op for text-only requests.
+func validateEmbeddingDimension(req EmbeddingRequest) (string, string, bool) {
+	if !isMultiModalModelName(req.Model) {
+		if isValidDimension(req.Dimension) {
+			return "", "", true
+		}
+		return "INVALID_DIMENSION", fmt.Sprintf(invalidDimensionMessage, req.Dimension), false
+	}
+	contract := multiModalDimensionContract()
+	if len(contract.Supported) == 0 || contract.supports(req.Dimension) {
+		return "", "", true
+	}
+	return "INVALID_DIMENSION", fmt.Sprintf("dimension %d is not supported by model %q; supported dimensions: %s", req.Dimension, contract.ModelID, contract.supportedList()), false
+}
+
+// validateImageEmbeddingParams ensures every image-bearing request resolves all
+// of its inputs to the shared multimodal embedding space.
 func validateImageEmbeddingParams(req EmbeddingRequest) (string, string, bool) {
 	if len(req.Images) == 0 {
 		return "", "", true
 	}
-	// Image-only: req.Dimension is the image target, and MRL only truncates down
-	// from native. Mixed requests target the text side, so the image ceiling is
-	// applied at encode time instead of rejecting a text-legal dimension.
-	if len(req.Texts) == 0 {
-		if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
-			return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
-		}
+	if !isMultiModalModelName(req.Model) {
+		return "INVALID_PARAMETER", "image inputs require model='multimodal' so text and image vectors share one embedding space", false
 	}
-	// target_layer is a text-only mmbert 2DMSE control; it cannot apply to
-	// image encoding, so reject instead of silently ignoring it.
 	if req.TargetLayer != 0 {
 		return "INVALID_PARAMETER", "target_layer is not supported for image inputs", false
-	}
-	// Images always use the multimodal model. When there is no text for a
-	// named model to apply to, an explicit text-model selector would be
-	// silently ignored; reject so the contract is explicit. Mixed
-	// text+image requests still honor req.Model for the text side.
-	if len(req.Texts) == 0 && req.Model != "auto" && req.Model != "" && !isMultiModalModelName(req.Model) {
-		return "INVALID_PARAMETER", fmt.Sprintf("model=%q does not produce image embeddings; omit model or use the multimodal model for image inputs", req.Model), false
 	}
 	return "", "", true
 }
@@ -296,7 +298,6 @@ func buildEmbeddingResults(req EmbeddingRequest, multiModalModelID string) ([]Em
 		totalProcessingTime += processingTime
 	}
 
-	imgDim := imageTargetDimension(req)
 	for i, image := range req.Images {
 		// Canonicalize so the FFI's case-sensitive ";base64," scan finds the
 		// payload boundary (validation already guaranteed a safe data URI).
@@ -304,7 +305,7 @@ func buildEmbeddingResults(req EmbeddingRequest, multiModalModelID string) ([]Em
 		if canonical, ok := imageurl.CanonicalDataURL(image); ok {
 			encodeInput = canonical
 		}
-		output, err := multiModalEncodeImage(encodeInput, imgDim)
+		output, err := multiModalEncodeImage(encodeInput, req.Dimension)
 		if err != nil {
 			// The image already passed the safe-data-URI + base64-decode gate, so
 			// an encode failure here is input-caused (undecodable image bytes);

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -99,7 +99,25 @@ const (
 	maxImagesPerRequest = 8
 )
 
-const invalidDimensionMessage = "dimension must be one of: 64, 128, 256, 512, 768, 1024 (got %d)"
+// validEmbeddingDimensions is the model-agnostic allowlist for the text
+// embedding and similarity endpoints. The multimodal endpoints never consult it;
+// they validate against the loaded checkpoint's declared ladder instead.
+var validEmbeddingDimensions = []int{64, 128, 256, 512, 768, 1024}
+
+// invalidDimensionMessage is derived from validEmbeddingDimensions so the
+// accepted set and the rejection message cannot drift apart.
+var invalidDimensionMessage = fmt.Sprintf(
+	"dimension must be one of: %s (got %%d)", formatLayerList(validEmbeddingDimensions))
+
+// embeddingValidationStatus maps a validation code to its HTTP status. Model
+// unavailability is server state, not a malformed request, so it is the one code
+// that is not a 400.
+func embeddingValidationStatus(code string) int {
+	if code == "MODEL_NOT_LOADED" {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusBadRequest
+}
 
 // validatePriority rejects a priority weight outside the documented [0.0, 1.0]
 // range; out-of-range values were previously accepted and passed to the model.
@@ -167,7 +185,7 @@ func (s *ClassificationAPIServer) parseEmbeddingRequest(w http.ResponseWriter, r
 	}
 	availableLayers := config.MmBertAvailableLayers(mmbertPath)
 	if code, message, ok := validateEmbeddingRequest(req, availableLayers); !ok {
-		s.writeErrorResponse(w, http.StatusBadRequest, code, message)
+		s.writeErrorResponse(w, embeddingValidationStatus(code), code, message)
 		return EmbeddingRequest{}, false
 	}
 
@@ -205,7 +223,13 @@ func defaultEmbeddingDimensionForModel(model string) int {
 	if !isMultiModalModelName(model) {
 		return defaultEmbeddingDimension
 	}
-	return multiModalDimensionContract().Default
+	// A non-positive value is the binding's "no model loaded" sentinel. Leave the
+	// dimension unset rather than forwarding the sentinel, so validation reports
+	// unavailability instead of the encoder silently substituting a width.
+	if dimension := multiModalDimensionContract().Default; dimension > 0 {
+		return dimension
+	}
+	return 0
 }
 
 func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string, string, bool) {
@@ -215,10 +239,13 @@ func validateEmbeddingRequest(req EmbeddingRequest, mmbertLayers []int) (string,
 	if code, message, ok := validateEmbeddingImages(req.Images); !ok {
 		return code, message, false
 	}
-	if code, message, ok := validateEmbeddingDimension(req); !ok {
+	// The resolved model decides which dimension ladder applies, so reject an
+	// image request pointed at a text model first; otherwise the caller gets the
+	// text allowlist's dimension error instead of the real mismatch.
+	if code, message, ok := validateImageEmbeddingParams(req); !ok {
 		return code, message, false
 	}
-	if code, message, ok := validateImageEmbeddingParams(req); !ok {
+	if code, message, ok := validateEmbeddingDimension(req); !ok {
 		return code, message, false
 	}
 	if req.TargetLayer != 0 && req.Model != "mmbert" {
@@ -238,7 +265,10 @@ func validateEmbeddingDimension(req EmbeddingRequest) (string, string, bool) {
 		return "INVALID_DIMENSION", fmt.Sprintf(invalidDimensionMessage, req.Dimension), false
 	}
 	contract := multiModalDimensionContract()
-	if len(contract.Supported) == 0 || contract.supports(req.Dimension) {
+	if len(contract.Supported) == 0 {
+		return "MODEL_NOT_LOADED", "the multimodal embedding model is not loaded; check /ready before retrying", false
+	}
+	if contract.supports(req.Dimension) {
 		return "", "", true
 	}
 	return "INVALID_DIMENSION", fmt.Sprintf("dimension %d is not supported by model %q; supported dimensions: %s", req.Dimension, contract.ModelID, contract.supportedList()), false
@@ -534,10 +564,12 @@ func buildBatchSimilarityMatches(result *candle_binding.BatchSimilarityOutput, c
 
 // isValidDimension checks if the provided dimension is valid
 func isValidDimension(dim int) bool {
-	// 384 is the multimodal model's native dimension; it must be accepted so
-	// callers can request the image model's full-width vector explicitly.
-	validDimensions := map[int]bool{64: true, 128: true, 256: true, 384: true, 512: true, 768: true, 1024: true}
-	return validDimensions[dim]
+	for _, valid := range validEmbeddingDimensions {
+		if dim == valid {
+			return true
+		}
+	}
+	return false
 }
 
 // formatLayerList renders a layer set as a comma-separated string for error

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -29,11 +29,21 @@ var multiModalEmbeddingDim = candle_binding.MultiModalGetEmbeddingDim
 // path is configured; it matches the canonical shipped checkpoint.
 const multiModalModelFallbackID = "multi-modal-embed-small"
 
-// imageTargetDimension returns the request dimension for image encoding. Image
-// requests are validated before encoding, so this must not silently cap the
-// image result to a different dimension than the text side.
+// imageTargetDimension resolves the image encode dimension. Image-only requests
+// use req.Dimension directly (validated <= native). Mixed requests target the
+// text side, so the image side caps at native and warns once per request rather
+// than forcing text recall down to the image width.
 func imageTargetDimension(req EmbeddingRequest) int {
-	return req.Dimension
+	if len(req.Images) == 0 || len(req.Texts) == 0 {
+		return req.Dimension
+	}
+	native := multiModalEmbeddingDim()
+	if native <= 0 || req.Dimension <= native {
+		return req.Dimension
+	}
+	logging.Warnf("Embedding request dimension %d exceeds the multimodal native dimension %d; encoding %d image input(s) at %d, so response dimensions differ by modality",
+		req.Dimension, native, len(req.Images), native)
+	return native
 }
 
 // isMultiModalModelName reports whether an explicit model selector names the
@@ -175,7 +185,7 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 		req.Model = "auto"
 	}
 	if req.Dimension == 0 {
-		req.Dimension = defaultEmbeddingDimensionFor(req.Images)
+		req.Dimension = defaultEmbeddingDimensionFor(req.Texts, req.Images)
 	}
 	if req.QualityPriority == 0 && req.LatencyPriority == 0 {
 		req.QualityPriority = defaultEmbeddingPriority
@@ -183,12 +193,11 @@ func applyEmbeddingDefaults(req *EmbeddingRequest) {
 	}
 }
 
-// defaultEmbeddingDimensionFor picks the default embedding dimension when the
-// request omits one. Every image-bearing request uses the multimodal native
-// dimension so a successful mixed response cannot contain vectors of different
-// lengths; text-only requests use the API default.
-func defaultEmbeddingDimensionFor(images []string) int {
-	if len(images) == 0 {
+// defaultEmbeddingDimensionFor picks the default dimension when the request
+// omits one. req.Dimension targets the text side, so only an image-only request
+// defaults to the multimodal native dimension.
+func defaultEmbeddingDimensionFor(texts, images []string) int {
+	if len(texts) > 0 || len(images) == 0 {
 		return defaultEmbeddingDimension
 	}
 	if native := multiModalEmbeddingDim(); native > 0 {
@@ -225,10 +234,13 @@ func validateImageEmbeddingParams(req EmbeddingRequest) (string, string, bool) {
 	if len(req.Images) == 0 {
 		return "", "", true
 	}
-	// MRL only truncates down from the image model's native dimension. Apply
-	// the ceiling to mixed requests too, before either modality is encoded.
-	if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
-		return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
+	// Image-only: req.Dimension is the image target, and MRL only truncates down
+	// from native. Mixed requests target the text side, so the image ceiling is
+	// applied at encode time instead of rejecting a text-legal dimension.
+	if len(req.Texts) == 0 {
+		if native := multiModalEmbeddingDim(); native > 0 && req.Dimension > native {
+			return "INVALID_DIMENSION", fmt.Sprintf("dimension must be <= %d for image inputs (multimodal model native dimension; got %d)", native, req.Dimension), false
+		}
 	}
 	// target_layer is a text-only mmbert 2DMSE control; it cannot apply to
 	// image encoding, so reject instead of silently ignoring it.

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -9,7 +9,17 @@ import (
 	"testing"
 
 	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
+
+// stubMultiModalDim overrides the native-dimension getter for a test so the
+// image over-dimension contract can be exercised without a loaded model.
+func stubMultiModalDim(t *testing.T, dim int) {
+	t.Helper()
+	orig := multiModalEmbeddingDim
+	t.Cleanup(func() { multiModalEmbeddingDim = orig })
+	multiModalEmbeddingDim = func() int { return dim }
+}
 
 func TestBuildBatchSimilarityMatchesRejectsInvalidNativeIndex(t *testing.T) {
 	result := &candle_binding.BatchSimilarityOutput{
@@ -122,7 +132,7 @@ func TestBuildEmbeddingResultsWrapsImageEncodeFailure(t *testing.T) {
 		Images:    []string{"data:image/png;base64,aGVsbG8="},
 		Dimension: defaultEmbeddingDimension,
 	}
-	_, _, err := buildEmbeddingResults(req)
+	_, _, err := buildEmbeddingResults(req, multiModalModelFallbackID)
 	if err == nil {
 		t.Fatalf("expected an error from a failing image encode")
 	}
@@ -327,5 +337,208 @@ func TestValidateEmbeddingRequestTargetLayerRejectedForNonMmbert(t *testing.T) {
 	}
 	if code != "INVALID_PARAMETER" {
 		t.Fatalf("expected INVALID_PARAMETER, got %q", code)
+	}
+}
+
+func TestIsValidDimensionAcceptsNativeMultimodalDimension(t *testing.T) {
+	// 384 is the multimodal model's native dimension and must be accepted so a
+	// caller can request the image model's full-width vector explicitly.
+	if !isValidDimension(384) {
+		t.Fatalf("expected dimension 384 (multimodal native) to be valid")
+	}
+}
+
+func TestApplyEmbeddingDefaultsImagesUseNativeDimension(t *testing.T) {
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{Images: []string{"data:image/png;base64,aGVsbG8="}}
+
+	applyEmbeddingDefaults(&req)
+
+	if req.Dimension != 384 {
+		t.Fatalf("expected image-bearing request to default to native dimension 384, got %d", req.Dimension)
+	}
+}
+
+func TestApplyEmbeddingDefaultsMixedUsesNativeDimension(t *testing.T) {
+	// A mixed text+image request defaults to the image native dimension so the
+	// response is uniform (all 384) rather than silently mixing 768 + 384.
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Texts:  []string{"hello"},
+		Images: []string{"data:image/png;base64,aGVsbG8="},
+	}
+
+	applyEmbeddingDefaults(&req)
+
+	if req.Dimension != 384 {
+		t.Fatalf("expected mixed request to default to native dimension 384, got %d", req.Dimension)
+	}
+}
+
+func TestApplyEmbeddingDefaultsTextsUseTextDefault(t *testing.T) {
+	req := EmbeddingRequest{Texts: []string{"hello"}}
+
+	applyEmbeddingDefaults(&req)
+
+	if req.Dimension != defaultEmbeddingDimension {
+		t.Fatalf("expected text-only request to default to %d, got %d", defaultEmbeddingDimension, req.Dimension)
+	}
+}
+
+func TestApplyEmbeddingDefaultsImagesFallBackWhenModelUnloaded(t *testing.T) {
+	// When no multimodal model is loaded the getter reports <= 0; defaulting
+	// falls back to the text default and the encode fails downstream rather than
+	// this layer guessing a native dimension.
+	stubMultiModalDim(t, -1)
+	req := EmbeddingRequest{Images: []string{"data:image/png;base64,aGVsbG8="}}
+
+	applyEmbeddingDefaults(&req)
+
+	if req.Dimension != defaultEmbeddingDimension {
+		t.Fatalf("expected fallback to %d when multimodal model unloaded, got %d", defaultEmbeddingDimension, req.Dimension)
+	}
+}
+
+func TestValidateEmbeddingRequestRejectsImageDimensionAboveNative(t *testing.T) {
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: 768,
+	}
+
+	code, message, ok := validateEmbeddingRequest(req, nil)
+	if ok {
+		t.Fatalf("expected dimension above the multimodal native dimension to be rejected")
+	}
+	if code != "INVALID_DIMENSION" {
+		t.Fatalf("unexpected error code %q: %q", code, message)
+	}
+	if !strings.Contains(message, "384") {
+		t.Fatalf("error should mention the native dimension, got %q", message)
+	}
+}
+
+func TestValidateEmbeddingRequestAcceptsImageNativeDimension(t *testing.T) {
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: 384,
+	}
+
+	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
+		t.Fatalf("expected native dimension 384 to be accepted for image inputs")
+	}
+}
+
+func TestValidateEmbeddingRequestRejectsTargetLayerWithImages(t *testing.T) {
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Images:      []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension:   384,
+		TargetLayer: 6,
+	}
+
+	code, message, ok := validateEmbeddingRequest(req, []int{6, 11, 16, 22})
+	if ok {
+		t.Fatalf("expected target_layer with image inputs to be rejected")
+	}
+	if code != "INVALID_PARAMETER" || !strings.Contains(message, "image inputs") {
+		t.Fatalf("unexpected error %q: %q", code, message)
+	}
+}
+
+func TestValidateEmbeddingRequestRejectsTextModelForImageOnly(t *testing.T) {
+	// An image-only request naming a text model would have that model silently
+	// ignored; reject so the contract is explicit.
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Model:     "qwen3",
+		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: 384,
+	}
+
+	code, _, ok := validateEmbeddingRequest(req, nil)
+	if ok {
+		t.Fatalf("expected image-only request with a text model to be rejected")
+	}
+	if code != "INVALID_PARAMETER" {
+		t.Fatalf("expected INVALID_PARAMETER, got %q", code)
+	}
+}
+
+func TestValidateEmbeddingRequestAllowsMultimodalModelForImageOnly(t *testing.T) {
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Model:     "multimodal",
+		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: 384,
+	}
+
+	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
+		t.Fatalf("expected an explicit multimodal model selector to be accepted for image inputs")
+	}
+}
+
+func TestValidateEmbeddingRequestAllowsTextModelForMixed(t *testing.T) {
+	// A mixed request still honors req.Model for the text side, so a text model
+	// is not "ignored" and must be accepted.
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Model:     "qwen3",
+		Texts:     []string{"hello"},
+		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: 384,
+	}
+
+	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
+		t.Fatalf("expected mixed text+image request with a text model to be accepted")
+	}
+}
+
+func TestBuildEmbeddingResultsUsesProvidedModelID(t *testing.T) {
+	orig := multiModalEncodeImage
+	defer func() { multiModalEncodeImage = orig }()
+	multiModalEncodeImage = func(string, int) (*candle_binding.MultiModalEmbeddingOutput, error) {
+		return &candle_binding.MultiModalEmbeddingOutput{
+			Embedding: make([]float32, 384),
+			Modality:  "image",
+		}, nil
+	}
+
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: 384,
+	}
+	results, _, err := buildEmbeddingResults(req, "multi-modal-embed-small")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].ModelUsed != "multi-modal-embed-small" {
+		t.Fatalf("expected model_used to be the provided id, got %q", results[0].ModelUsed)
+	}
+}
+
+func TestMultiModalModelIDBaseNamesConfiguredPath(t *testing.T) {
+	s := &ClassificationAPIServer{
+		config: &config.RouterConfig{
+			InlineModels: config.InlineModels{
+				EmbeddingModels: config.EmbeddingModels{MultiModalModelPath: "models/multi-modal-embed-small"},
+			},
+		},
+	}
+
+	if got := s.multiModalModelID(); got != "multi-modal-embed-small" {
+		t.Fatalf("expected configured path to reduce to its base name, got %q", got)
+	}
+}
+
+func TestMultiModalModelIDFallsBackWhenUnconfigured(t *testing.T) {
+	s := &ClassificationAPIServer{config: &config.RouterConfig{}}
+
+	if got := s.multiModalModelID(); got != multiModalModelFallbackID {
+		t.Fatalf("expected fallback id %q, got %q", multiModalModelFallbackID, got)
 	}
 }

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -348,20 +348,25 @@ func TestIsValidDimensionAcceptsNativeMultimodalDimension(t *testing.T) {
 	}
 }
 
-func TestApplyEmbeddingDefaultsImagesUseNativeDimension(t *testing.T) {
+func TestApplyEmbeddingDefaultsImageOnlyUsesNativeDimension(t *testing.T) {
+	// An image-only request has no text side to honor the text default, so it
+	// defaults to the multimodal native dimension (the ceiling MRL can produce).
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{Images: []string{"data:image/png;base64,aGVsbG8="}}
 
 	applyEmbeddingDefaults(&req)
 
 	if req.Dimension != 384 {
-		t.Fatalf("expected image-bearing request to default to native dimension 384, got %d", req.Dimension)
+		t.Fatalf("expected image-only request to default to native dimension 384, got %d", req.Dimension)
 	}
 }
 
-func TestApplyEmbeddingDefaultsMixedUsesNativeDimension(t *testing.T) {
-	// A mixed text+image request defaults to the image native dimension so the
-	// response is uniform (all 384) rather than silently mixing 768 + 384.
+func TestApplyEmbeddingDefaultsMixedUsesTextDefault(t *testing.T) {
+	// A mixed text+image request defaults req.Dimension to the text default
+	// (768). req.Dimension controls the text side only; the image side always
+	// encodes at its native dimension regardless. This preserves text recall
+	// rather than silently downgrading text to 384 for a false-consistency win
+	// (cross-encoder vectors do not align across modalities regardless of dim).
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:  []string{"hello"},
@@ -370,8 +375,8 @@ func TestApplyEmbeddingDefaultsMixedUsesNativeDimension(t *testing.T) {
 
 	applyEmbeddingDefaults(&req)
 
-	if req.Dimension != 384 {
-		t.Fatalf("expected mixed request to default to native dimension 384, got %d", req.Dimension)
+	if req.Dimension != defaultEmbeddingDimension {
+		t.Fatalf("expected mixed request to default to text default %d, got %d", defaultEmbeddingDimension, req.Dimension)
 	}
 }
 
@@ -385,10 +390,10 @@ func TestApplyEmbeddingDefaultsTextsUseTextDefault(t *testing.T) {
 	}
 }
 
-func TestApplyEmbeddingDefaultsImagesFallBackWhenModelUnloaded(t *testing.T) {
-	// When no multimodal model is loaded the getter reports <= 0; defaulting
-	// falls back to the text default and the encode fails downstream rather than
-	// this layer guessing a native dimension.
+func TestApplyEmbeddingDefaultsImageOnlyFallsBackWhenModelUnloaded(t *testing.T) {
+	// When no multimodal model is loaded the getter reports <= 0; defaulting an
+	// image-only request falls back to the text default and the encode fails
+	// downstream rather than this layer guessing a native dimension.
 	stubMultiModalDim(t, -1)
 	req := EmbeddingRequest{Images: []string{"data:image/png;base64,aGVsbG8="}}
 
@@ -399,7 +404,8 @@ func TestApplyEmbeddingDefaultsImagesFallBackWhenModelUnloaded(t *testing.T) {
 	}
 }
 
-func TestValidateEmbeddingRequestRejectsImageDimensionAboveNative(t *testing.T) {
+func TestValidateEmbeddingRequestRejectsImageOnlyDimensionAboveNative(t *testing.T) {
+	// Image-only: req.Dimension is the image target and must be <= native.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
@@ -408,13 +414,29 @@ func TestValidateEmbeddingRequestRejectsImageDimensionAboveNative(t *testing.T) 
 
 	code, message, ok := validateEmbeddingRequest(req, nil)
 	if ok {
-		t.Fatalf("expected dimension above the multimodal native dimension to be rejected")
+		t.Fatalf("expected dimension above the multimodal native dimension to be rejected for image-only")
 	}
 	if code != "INVALID_DIMENSION" {
 		t.Fatalf("unexpected error code %q: %q", code, message)
 	}
 	if !strings.Contains(message, "384") {
 		t.Fatalf("error should mention the native dimension, got %q", message)
+	}
+}
+
+func TestValidateEmbeddingRequestAllowsAboveNativeDimensionForMixed(t *testing.T) {
+	// Mixed: req.Dimension controls the text side, and the image side always
+	// encodes at its native dimension regardless. A text-legal req.Dimension
+	// like 768 must be accepted even though it exceeds the image ceiling.
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Texts:     []string{"hello"},
+		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
+		Dimension: 768,
+	}
+
+	if _, message, ok := validateEmbeddingRequest(req, nil); !ok {
+		t.Fatalf("expected mixed request with text-legal dimension 768 to be accepted; got %q", message)
 	}
 }
 
@@ -492,6 +514,75 @@ func TestValidateEmbeddingRequestAllowsTextModelForMixed(t *testing.T) {
 
 	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
 		t.Fatalf("expected mixed text+image request with a text model to be accepted")
+	}
+}
+
+func TestImageTargetDimensionMixedUsesNative(t *testing.T) {
+	// Mixed: req.Dimension is the text-side target, so the image side must be
+	// resolved to the multimodal native dimension regardless of req.Dimension.
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Texts:     []string{"hello"},
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: 768,
+	}
+	if got := imageTargetDimension(req); got != 384 {
+		t.Fatalf("expected mixed request image encode dim to be 384 (native), got %d", got)
+	}
+}
+
+func TestImageTargetDimensionImageOnlyPassesThrough(t *testing.T) {
+	// Image-only: req.Dimension IS the image target (already validated <= native).
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: 128,
+	}
+	if got := imageTargetDimension(req); got != 128 {
+		t.Fatalf("expected image-only request image encode dim to be 128, got %d", got)
+	}
+}
+
+func TestImageTargetDimensionMixedFallsBackWhenModelUnloaded(t *testing.T) {
+	// Mixed with no multimodal model loaded: helper returns req.Dimension so the
+	// downstream encode surfaces "model not loaded" rather than the helper
+	// silently choosing a value.
+	stubMultiModalDim(t, -1)
+	req := EmbeddingRequest{
+		Texts:     []string{"hello"},
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: 768,
+	}
+	if got := imageTargetDimension(req); got != 768 {
+		t.Fatalf("expected fallback to req.Dimension 768 when multimodal unloaded, got %d", got)
+	}
+}
+
+func TestBuildEmbeddingResultsImageOnlyHonorsRequestDimension(t *testing.T) {
+	// Image-only: req.Dimension is the image target (validated <= native) and
+	// must be passed through to the encoder verbatim.
+	stubMultiModalDim(t, 384)
+
+	var gotImageDim int
+	orig := multiModalEncodeImage
+	defer func() { multiModalEncodeImage = orig }()
+	multiModalEncodeImage = func(_ string, targetDim int) (*candle_binding.MultiModalEmbeddingOutput, error) {
+		gotImageDim = targetDim
+		return &candle_binding.MultiModalEmbeddingOutput{
+			Embedding: make([]float32, targetDim),
+			Modality:  "image",
+		}, nil
+	}
+
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: 128,
+	}
+	if _, _, err := buildEmbeddingResults(req, "multi-modal-embed-small"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotImageDim != 128 {
+		t.Fatalf("expected image encode to receive image-only request dimension 128, got %d", gotImageDim)
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -517,9 +517,9 @@ func TestValidateEmbeddingRequestAllowsTextModelForMixed(t *testing.T) {
 	}
 }
 
-func TestImageTargetDimensionMixedUsesNative(t *testing.T) {
-	// Mixed: req.Dimension is the text-side target, so the image side must be
-	// resolved to the multimodal native dimension regardless of req.Dimension.
+func TestImageTargetDimensionMixedCapsAboveNativeAtNative(t *testing.T) {
+	// Mixed with a text-scale dimension (768 > native): the image side cannot
+	// reach it and caps at native, diverging from the text side.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:     []string{"hello"},
@@ -527,7 +527,22 @@ func TestImageTargetDimensionMixedUsesNative(t *testing.T) {
 		Dimension: 768,
 	}
 	if got := imageTargetDimension(req); got != 384 {
-		t.Fatalf("expected mixed request image encode dim to be 384 (native), got %d", got)
+		t.Fatalf("expected mixed request image encode dim to cap at 384 (native), got %d", got)
+	}
+}
+
+func TestImageTargetDimensionMixedHonorsSubNativeDimension(t *testing.T) {
+	// Mixed with an explicit image-satisfiable dimension (256 <= native): the
+	// image side honors it so both modalities stay uniform, rather than forcing
+	// the image up to native and ignoring the requested value.
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Texts:     []string{"hello"},
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: 256,
+	}
+	if got := imageTargetDimension(req); got != 256 {
+		t.Fatalf("expected mixed request image encode dim to honor 256, got %d", got)
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -361,12 +361,9 @@ func TestApplyEmbeddingDefaultsImageOnlyUsesNativeDimension(t *testing.T) {
 	}
 }
 
-func TestApplyEmbeddingDefaultsMixedUsesTextDefault(t *testing.T) {
-	// A mixed text+image request defaults req.Dimension to the text default
-	// (768). req.Dimension controls the text side only; the image side always
-	// encodes at its native dimension regardless. This preserves text recall
-	// rather than silently downgrading text to 384 for a false-consistency win
-	// (cross-encoder vectors do not align across modalities regardless of dim).
+func TestApplyEmbeddingDefaultsMixedUsesNativeDimension(t *testing.T) {
+	// A mixed text+image request must use the image model's native dimension so
+	// one successful response cannot contain vectors of different lengths.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:  []string{"hello"},
@@ -375,8 +372,8 @@ func TestApplyEmbeddingDefaultsMixedUsesTextDefault(t *testing.T) {
 
 	applyEmbeddingDefaults(&req)
 
-	if req.Dimension != defaultEmbeddingDimension {
-		t.Fatalf("expected mixed request to default to text default %d, got %d", defaultEmbeddingDimension, req.Dimension)
+	if req.Dimension != 384 {
+		t.Fatalf("expected mixed request to default to native dimension 384, got %d", req.Dimension)
 	}
 }
 
@@ -424,10 +421,9 @@ func TestValidateEmbeddingRequestRejectsImageOnlyDimensionAboveNative(t *testing
 	}
 }
 
-func TestValidateEmbeddingRequestAllowsAboveNativeDimensionForMixed(t *testing.T) {
-	// Mixed: req.Dimension controls the text side, and the image side always
-	// encodes at its native dimension regardless. A text-legal req.Dimension
-	// like 768 must be accepted even though it exceeds the image ceiling.
+func TestValidateEmbeddingRequestRejectsAboveNativeDimensionForMixed(t *testing.T) {
+	// Every request containing images must reject a dimension above the image
+	// model's native ceiling before either modality is encoded.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:     []string{"hello"},
@@ -435,8 +431,12 @@ func TestValidateEmbeddingRequestAllowsAboveNativeDimensionForMixed(t *testing.T
 		Dimension: 768,
 	}
 
-	if _, message, ok := validateEmbeddingRequest(req, nil); !ok {
-		t.Fatalf("expected mixed request with text-legal dimension 768 to be accepted; got %q", message)
+	code, message, ok := validateEmbeddingRequest(req, nil)
+	if ok {
+		t.Fatalf("expected mixed request with dimension 768 to be rejected")
+	}
+	if code != "INVALID_DIMENSION" || !strings.Contains(message, "384") {
+		t.Fatalf("unexpected error %q: %q", code, message)
 	}
 }
 
@@ -517,17 +517,17 @@ func TestValidateEmbeddingRequestAllowsTextModelForMixed(t *testing.T) {
 	}
 }
 
-func TestImageTargetDimensionMixedCapsAboveNativeAtNative(t *testing.T) {
-	// Mixed with a text-scale dimension (768 > native): the image side cannot
-	// reach it and caps at native, diverging from the text side.
+func TestImageTargetDimensionMixedUsesRequestDimension(t *testing.T) {
+	// Validation rejects above-native dimensions at the API boundary. The target
+	// helper itself must not silently change a request's accepted dimension.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:     []string{"hello"},
 		Images:    []string{"data:image/png;base64,aGVsbG8="},
 		Dimension: 768,
 	}
-	if got := imageTargetDimension(req); got != 384 {
-		t.Fatalf("expected mixed request image encode dim to cap at 384 (native), got %d", got)
+	if got := imageTargetDimension(req); got != 768 {
+		t.Fatalf("expected mixed request image target to preserve 768 for validated caller, got %d", got)
 	}
 }
 
@@ -631,7 +631,7 @@ func TestMultiModalModelIDBaseNamesConfiguredPath(t *testing.T) {
 	s := &ClassificationAPIServer{
 		config: &config.RouterConfig{
 			InlineModels: config.InlineModels{
-				EmbeddingModels: config.EmbeddingModels{MultiModalModelPath: "models/multi-modal-embed-small"},
+				EmbeddingModels: config.EmbeddingModels{MultiModalModelPath: "models/mom-embedding-multimodal"},
 			},
 		},
 	}

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -4,7 +4,9 @@ package apiserver
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -351,6 +353,39 @@ func TestValidateEmbeddingRequestTargetLayerRejectedForNonMmbert(t *testing.T) {
 	}
 }
 
+// The multimodal ladder must not widen the model-agnostic allowlist that the
+// text embedding and similarity endpoints share: 384 is the multimodal native
+// width and no text model here declares it.
+func TestIsValidDimensionKeepsTextAllowlistNarrow(t *testing.T) {
+	for _, dim := range validEmbeddingDimensions {
+		if !isValidDimension(dim) {
+			t.Fatalf("dimension %d should be accepted", dim)
+		}
+	}
+	for _, dim := range []int{0, -1, 32, 384, 500} {
+		if isValidDimension(dim) {
+			t.Fatalf("dimension %d should be rejected on the text path", dim)
+		}
+	}
+
+	req := EmbeddingRequest{Model: "qwen3", Texts: []string{"hello"}, Dimension: 384}
+	code, message, ok := validateEmbeddingRequest(req, nil)
+	if ok || code != "INVALID_DIMENSION" {
+		t.Fatalf("expected INVALID_DIMENSION for qwen3 dimension 384, got ok=%v %q: %q", ok, code, message)
+	}
+}
+
+// The rejection message is generated from the allowlist, so a future entry
+// cannot be accepted while the message still omits it.
+func TestInvalidDimensionMessageMatchesAllowlist(t *testing.T) {
+	message := fmt.Sprintf(invalidDimensionMessage, 500)
+	for _, dim := range validEmbeddingDimensions {
+		if !strings.Contains(message, strconv.Itoa(dim)) {
+			t.Fatalf("message %q should list accepted dimension %d", message, dim)
+		}
+	}
+}
+
 func TestApplyEmbeddingDefaultsUsesResolvedMultimodalDefault(t *testing.T) {
 	stubMultiModalContract(t, embeddingDimensionContract{
 		ModelID:   "multi-modal-embed-small",
@@ -381,12 +416,32 @@ func TestApplyEmbeddingDefaultsTextAutoUsesLegacyDefault(t *testing.T) {
 	}
 }
 
-func TestValidateEmbeddingRequestDefersUnavailableMultimodalModel(t *testing.T) {
+// An unavailable multimodal model is server state, not a bad request. Deferring
+// it let the encode failure surface as 400 INVALID_IMAGE, telling the caller its
+// image was undecodable when the server simply had no model.
+func TestValidateEmbeddingRequestRejectsUnavailableMultimodalModel(t *testing.T) {
 	stubMultiModalContract(t, embeddingDimensionContract{})
 	req := EmbeddingRequest{Model: "multimodal", Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: 384}
 
-	if code, message, ok := validateEmbeddingRequest(req, nil); !ok {
-		t.Fatalf("expected readiness handling to remain downstream, got %q: %q", code, message)
+	code, message, ok := validateEmbeddingRequest(req, nil)
+	if ok || code != "MODEL_NOT_LOADED" {
+		t.Fatalf("expected MODEL_NOT_LOADED, got ok=%v %q: %q", ok, code, message)
+	}
+	if got := embeddingValidationStatus(code); got != http.StatusServiceUnavailable {
+		t.Fatalf("expected %d for %q, got %d", http.StatusServiceUnavailable, code, got)
+	}
+}
+
+// The binding reports -1 when no multimodal model is loaded. That sentinel must
+// never become the request's dimension.
+func TestApplyEmbeddingDefaultsNeverForwardsUnavailableSentinel(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{Default: -1})
+	req := EmbeddingRequest{Model: "multimodal", Images: []string{"data:image/png;base64,aGVsbG8="}}
+
+	applyEmbeddingDefaults(&req)
+
+	if req.Dimension < 0 {
+		t.Fatalf("expected no negative dimension, got %d", req.Dimension)
 	}
 }
 
@@ -428,13 +483,28 @@ func TestValidateEmbeddingRequestRejectsMixedEmbeddingSpaces(t *testing.T) {
 		Default:   384,
 		Supported: []int{384, 256, 128, 64, 32},
 	})
+	// An explicit text model with image inputs is the reachable mismatch; the
+	// space error must win over the text allowlist's dimension error.
 	req := EmbeddingRequest{
-		Texts: []string{"hello"}, Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: 384,
+		Model: "qwen3", Texts: []string{"hello"}, Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: 384,
 	}
 
 	code, message, ok := validateEmbeddingRequest(req, nil)
 	if ok || code != "INVALID_PARAMETER" || !strings.Contains(message, "model='multimodal'") {
 		t.Fatalf("expected incompatible mixed request rejection, got %q: %q", code, message)
+	}
+
+	// A mixed request that names no model resolves to the multimodal checkpoint
+	// rather than being rejected.
+	resolved := EmbeddingRequest{
+		Texts: []string{"hello"}, Images: []string{"data:image/png;base64,aGVsbG8="},
+	}
+	applyEmbeddingDefaults(&resolved)
+	if resolved.Model != "multimodal" || resolved.Dimension != 384 {
+		t.Fatalf("expected defaults to resolve to multimodal/384, got %q/%d", resolved.Model, resolved.Dimension)
+	}
+	if code, message, ok := validateEmbeddingRequest(resolved, nil); !ok {
+		t.Fatalf("expected the resolved mixed request to pass, got %q: %q", code, message)
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
-// stubMultiModalDim overrides the native-dimension getter for a test so the
-// image over-dimension contract can be exercised without a loaded model.
-func stubMultiModalDim(t *testing.T, dim int) {
+// stubMultiModalContract overrides the loaded model's dimension contract so
+// request validation can be exercised without loading a checkpoint.
+func stubMultiModalContract(t *testing.T, contract embeddingDimensionContract) {
 	t.Helper()
-	orig := multiModalEmbeddingDim
-	t.Cleanup(func() { multiModalEmbeddingDim = orig })
-	multiModalEmbeddingDim = func() int { return dim }
+	orig := multiModalDimensionContract
+	t.Cleanup(func() { multiModalDimensionContract = orig })
+	multiModalDimensionContract = func() embeddingDimensionContract { return contract }
 }
 
 func TestBuildBatchSimilarityMatchesRejectsInvalidNativeIndex(t *testing.T) {
@@ -64,9 +64,11 @@ func TestValidateEmbeddingRequestRequiresTextsOrImages(t *testing.T) {
 }
 
 func TestValidateEmbeddingRequestAcceptsImagesOnly(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{ModelID: "multi-modal-embed-small", Default: 384, Supported: []int{384, 256, 128, 64, 32}})
 	req := EmbeddingRequest{
+		Model:     "multimodal",
 		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: defaultEmbeddingDimension,
+		Dimension: 384,
 	}
 
 	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
@@ -75,9 +77,11 @@ func TestValidateEmbeddingRequestAcceptsImagesOnly(t *testing.T) {
 }
 
 func TestValidateEmbeddingRequestRejectsUnsafeImage(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{ModelID: "multi-modal-embed-small", Default: 384, Supported: []int{384, 256, 128, 64, 32}})
 	req := EmbeddingRequest{
+		Model:     "multimodal",
 		Images:    []string{"https://example.com/cat.png"},
-		Dimension: defaultEmbeddingDimension,
+		Dimension: 384,
 	}
 
 	code, message, ok := validateEmbeddingRequest(req, nil)
@@ -90,9 +94,11 @@ func TestValidateEmbeddingRequestRejectsUnsafeImage(t *testing.T) {
 }
 
 func TestValidateEmbeddingRequestRejectsMalformedBase64(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{ModelID: "multi-modal-embed-small", Default: 384, Supported: []int{384, 256, 128, 64, 32}})
 	req := EmbeddingRequest{
+		Model:     "multimodal",
 		Images:    []string{"data:image/png;base64,!!!!"},
-		Dimension: defaultEmbeddingDimension,
+		Dimension: 384,
 	}
 
 	code, message, ok := validateEmbeddingRequest(req, nil)
@@ -105,12 +111,14 @@ func TestValidateEmbeddingRequestRejectsMalformedBase64(t *testing.T) {
 }
 
 func TestValidateEmbeddingRequestAcceptsUppercaseDataURIScheme(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{ModelID: "multi-modal-embed-small", Default: 384, Supported: []int{384, 256, 128, 64, 32}})
 	// "DATA:IMAGE/PNG;BASE64,..." passes the safety gate; it must also pass
 	// decode-validation so it is not accepted here only to 500 at the FFI, whose
 	// marker scan is case-sensitive (CanonicalDataURL normalizes it downstream).
 	req := EmbeddingRequest{
+		Model:     "multimodal",
 		Images:    []string{"DATA:IMAGE/PNG;BASE64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: defaultEmbeddingDimension,
+		Dimension: 384,
 	}
 
 	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
@@ -119,6 +127,7 @@ func TestValidateEmbeddingRequestAcceptsUppercaseDataURIScheme(t *testing.T) {
 }
 
 func TestBuildEmbeddingResultsWrapsImageEncodeFailure(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{ModelID: "multi-modal-embed-small", Default: 384, Supported: []int{384, 256, 128, 64, 32}})
 	// A validated safe data URI whose bytes are not a decodable image fails at the
 	// FFI; buildEmbeddingResults must tag it as an imageEncodeError so the handler
 	// maps it to 400 instead of 500.
@@ -129,8 +138,9 @@ func TestBuildEmbeddingResultsWrapsImageEncodeFailure(t *testing.T) {
 	}
 
 	req := EmbeddingRequest{
+		Model:     "multimodal",
 		Images:    []string{"data:image/png;base64,aGVsbG8="},
-		Dimension: defaultEmbeddingDimension,
+		Dimension: 384,
 	}
 	_, _, err := buildEmbeddingResults(req, multiModalModelFallbackID)
 	if err == nil {
@@ -160,11 +170,12 @@ func TestClassifyEmbeddingErrorMapsInternalFailureTo500(t *testing.T) {
 }
 
 func TestValidateEmbeddingRequestRejectsTooManyImages(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{ModelID: "multi-modal-embed-small", Default: 384, Supported: []int{384, 256, 128, 64, 32}})
 	images := make([]string, maxImagesPerRequest+1)
 	for i := range images {
 		images[i] = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
 	}
-	req := EmbeddingRequest{Images: images, Dimension: defaultEmbeddingDimension}
+	req := EmbeddingRequest{Model: "multimodal", Images: images, Dimension: 384}
 
 	code, _, ok := validateEmbeddingRequest(req, nil)
 	if ok {
@@ -340,243 +351,109 @@ func TestValidateEmbeddingRequestTargetLayerRejectedForNonMmbert(t *testing.T) {
 	}
 }
 
-func TestIsValidDimensionAcceptsNativeMultimodalDimension(t *testing.T) {
-	// 384 is the multimodal model's native dimension and must be accepted so a
-	// caller can request the image model's full-width vector explicitly.
-	if !isValidDimension(384) {
-		t.Fatalf("expected dimension 384 (multimodal native) to be valid")
+func TestApplyEmbeddingDefaultsUsesResolvedMultimodalDefault(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{
+		ModelID:   "multi-modal-embed-small",
+		Default:   384,
+		Supported: []int{384, 256, 128, 64, 32},
+	})
+
+	for _, req := range []*EmbeddingRequest{
+		{Model: "multimodal", Texts: []string{"hello"}},
+		{Images: []string{"data:image/png;base64,aGVsbG8="}},
+		{Model: "multimodal", Texts: []string{"hello"}, Images: []string{"data:image/png;base64,aGVsbG8="}},
+	} {
+		applyEmbeddingDefaults(req)
+		if req.Dimension != 384 {
+			t.Fatalf("expected resolved multimodal default 384, got %d for %+v", req.Dimension, req)
+		}
 	}
 }
 
-func TestApplyEmbeddingDefaultsImageOnlyUsesNativeDimension(t *testing.T) {
-	// An image-only request has no text side to honor the text default, so it
-	// defaults to the multimodal native dimension (the ceiling MRL can produce).
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{Images: []string{"data:image/png;base64,aGVsbG8="}}
-
-	applyEmbeddingDefaults(&req)
-
-	if req.Dimension != 384 {
-		t.Fatalf("expected image-only request to default to native dimension 384, got %d", req.Dimension)
-	}
-}
-
-func TestApplyEmbeddingDefaultsMixedKeepsTextDefault(t *testing.T) {
-	// req.Dimension targets the text side, so an image in the request must not
-	// pull the text default down to the image model's narrower native width.
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Texts:  []string{"hello"},
-		Images: []string{"data:image/png;base64,aGVsbG8="},
-	}
-
-	applyEmbeddingDefaults(&req)
-
-	if req.Dimension != defaultEmbeddingDimension {
-		t.Fatalf("expected mixed request to keep the text default %d, got %d", defaultEmbeddingDimension, req.Dimension)
-	}
-}
-
-func TestApplyEmbeddingDefaultsTextsUseTextDefault(t *testing.T) {
+func TestApplyEmbeddingDefaultsTextAutoUsesLegacyDefault(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{Default: 384, Supported: []int{384, 256, 128, 64, 32}})
 	req := EmbeddingRequest{Texts: []string{"hello"}}
 
 	applyEmbeddingDefaults(&req)
 
 	if req.Dimension != defaultEmbeddingDimension {
-		t.Fatalf("expected text-only request to default to %d, got %d", defaultEmbeddingDimension, req.Dimension)
+		t.Fatalf("expected unresolved text request to retain default %d, got %d", defaultEmbeddingDimension, req.Dimension)
 	}
 }
 
-func TestApplyEmbeddingDefaultsImageOnlyFallsBackWhenModelUnloaded(t *testing.T) {
-	// When no multimodal model is loaded the getter reports <= 0; defaulting an
-	// image-only request falls back to the text default and the encode fails
-	// downstream rather than this layer guessing a native dimension.
-	stubMultiModalDim(t, -1)
-	req := EmbeddingRequest{Images: []string{"data:image/png;base64,aGVsbG8="}}
+func TestValidateEmbeddingRequestDefersUnavailableMultimodalModel(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{})
+	req := EmbeddingRequest{Model: "multimodal", Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: 384}
 
-	applyEmbeddingDefaults(&req)
-
-	if req.Dimension != defaultEmbeddingDimension {
-		t.Fatalf("expected fallback to %d when multimodal model unloaded, got %d", defaultEmbeddingDimension, req.Dimension)
+	if code, message, ok := validateEmbeddingRequest(req, nil); !ok {
+		t.Fatalf("expected readiness handling to remain downstream, got %q: %q", code, message)
 	}
 }
 
-func TestValidateEmbeddingRequestRejectsImageOnlyDimensionAboveNative(t *testing.T) {
-	// Image-only: req.Dimension is the image target and must be <= native.
-	stubMultiModalDim(t, 384)
+func TestValidateEmbeddingRequestUsesDeclaredMultimodalDimensions(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{
+		ModelID:   "multi-modal-embed-small",
+		Default:   384,
+		Supported: []int{384, 256, 128, 64, 32},
+	})
+
+	for _, dim := range []int{384, 256, 128, 64, 32} {
+		req := EmbeddingRequest{
+			Model: "multimodal", Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: dim,
+		}
+		if code, message, ok := validateEmbeddingRequest(req, nil); !ok {
+			t.Fatalf("dimension %d should be supported, got %q: %q", dim, code, message)
+		}
+	}
+
+	for _, dim := range []int{100, 512, 768} {
+		req := EmbeddingRequest{
+			Model: "multimodal", Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: dim,
+		}
+		code, message, ok := validateEmbeddingRequest(req, nil)
+		if ok || code != "INVALID_DIMENSION" {
+			t.Fatalf("dimension %d should be rejected, got %q: %q", dim, code, message)
+		}
+		for _, want := range []string{"multi-modal-embed-small", "384, 256, 128, 64, 32"} {
+			if !strings.Contains(message, want) {
+				t.Fatalf("error %q should contain %q", message, want)
+			}
+		}
+	}
+}
+
+func TestValidateEmbeddingRequestRejectsMixedEmbeddingSpaces(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{
+		ModelID:   "multi-modal-embed-small",
+		Default:   384,
+		Supported: []int{384, 256, 128, 64, 32},
+	})
 	req := EmbeddingRequest{
-		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: 768,
+		Texts: []string{"hello"}, Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: 384,
 	}
 
 	code, message, ok := validateEmbeddingRequest(req, nil)
-	if ok {
-		t.Fatalf("expected dimension above the multimodal native dimension to be rejected for image-only")
-	}
-	if code != "INVALID_DIMENSION" {
-		t.Fatalf("unexpected error code %q: %q", code, message)
-	}
-	if !strings.Contains(message, "384") {
-		t.Fatalf("error should mention the native dimension, got %q", message)
+	if ok || code != "INVALID_PARAMETER" || !strings.Contains(message, "model='multimodal'") {
+		t.Fatalf("expected incompatible mixed request rejection, got %q: %q", code, message)
 	}
 }
 
-func TestValidateEmbeddingRequestAllowsAboveNativeDimensionForMixed(t *testing.T) {
-	// 768 is legal for the text side; the image ceiling is applied at encode
-	// time, so a mixed request must not be rejected for it.
-	stubMultiModalDim(t, 384)
+func TestValidateEmbeddingRequestAcceptsSharedMultimodalSpace(t *testing.T) {
+	stubMultiModalContract(t, embeddingDimensionContract{
+		ModelID:   "multi-modal-embed-small",
+		Default:   384,
+		Supported: []int{384, 256, 128, 64, 32},
+	})
 	req := EmbeddingRequest{
-		Texts:     []string{"hello"},
-		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: 768,
+		Model: "multimodal", Texts: []string{"hello"}, Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: 256,
 	}
 
-	code, message, ok := validateEmbeddingRequest(req, nil)
-	if !ok {
-		t.Fatalf("expected mixed request with dimension 768 to be accepted, got %q: %q", code, message)
+	if code, message, ok := validateEmbeddingRequest(req, nil); !ok {
+		t.Fatalf("expected shared-space mixed request to pass, got %q: %q", code, message)
 	}
 }
 
-func TestValidateEmbeddingRequestAcceptsImageNativeDimension(t *testing.T) {
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: 384,
-	}
-
-	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
-		t.Fatalf("expected native dimension 384 to be accepted for image inputs")
-	}
-}
-
-func TestValidateEmbeddingRequestRejectsTargetLayerWithImages(t *testing.T) {
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Images:      []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension:   384,
-		TargetLayer: 6,
-	}
-
-	code, message, ok := validateEmbeddingRequest(req, []int{6, 11, 16, 22})
-	if ok {
-		t.Fatalf("expected target_layer with image inputs to be rejected")
-	}
-	if code != "INVALID_PARAMETER" || !strings.Contains(message, "image inputs") {
-		t.Fatalf("unexpected error %q: %q", code, message)
-	}
-}
-
-func TestValidateEmbeddingRequestRejectsTextModelForImageOnly(t *testing.T) {
-	// An image-only request naming a text model would have that model silently
-	// ignored; reject so the contract is explicit.
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Model:     "qwen3",
-		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: 384,
-	}
-
-	code, _, ok := validateEmbeddingRequest(req, nil)
-	if ok {
-		t.Fatalf("expected image-only request with a text model to be rejected")
-	}
-	if code != "INVALID_PARAMETER" {
-		t.Fatalf("expected INVALID_PARAMETER, got %q", code)
-	}
-}
-
-func TestValidateEmbeddingRequestAllowsMultimodalModelForImageOnly(t *testing.T) {
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Model:     "multimodal",
-		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: 384,
-	}
-
-	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
-		t.Fatalf("expected an explicit multimodal model selector to be accepted for image inputs")
-	}
-}
-
-func TestValidateEmbeddingRequestAllowsTextModelForMixed(t *testing.T) {
-	// A mixed request still honors req.Model for the text side, so a text model
-	// is not "ignored" and must be accepted.
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Model:     "qwen3",
-		Texts:     []string{"hello"},
-		Images:    []string{"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"},
-		Dimension: 384,
-	}
-
-	if _, _, ok := validateEmbeddingRequest(req, nil); !ok {
-		t.Fatalf("expected mixed text+image request with a text model to be accepted")
-	}
-}
-
-func TestImageTargetDimensionImageOnlyPassesThrough(t *testing.T) {
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Images:    []string{"data:image/png;base64,aGVsbG8="},
-		Dimension: 128,
-	}
-	if got := imageTargetDimension(req); got != 128 {
-		t.Fatalf("expected image-only encode dim 128, got %d", got)
-	}
-}
-
-func TestImageTargetDimensionTextOnlyDoesNotCap(t *testing.T) {
-	// No image to cap: a text-scale dimension must pass through unwarned.
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{Texts: []string{"hello"}, Dimension: 768}
-	if got := imageTargetDimension(req); got != 768 {
-		t.Fatalf("expected text-only dimension 768 to pass through, got %d", got)
-	}
-}
-
-func TestImageTargetDimensionMixedCapsAtNative(t *testing.T) {
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Texts:     []string{"hello"},
-		Images:    []string{"data:image/png;base64,aGVsbG8="},
-		Dimension: 768,
-	}
-	if got := imageTargetDimension(req); got != 384 {
-		t.Fatalf("expected mixed image encode dim to cap at native 384, got %d", got)
-	}
-}
-
-func TestImageTargetDimensionMixedHonorsSubNativeDimension(t *testing.T) {
-	// 256 fits under native, so both modalities stay uniform without capping.
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Texts:     []string{"hello"},
-		Images:    []string{"data:image/png;base64,aGVsbG8="},
-		Dimension: 256,
-	}
-	if got := imageTargetDimension(req); got != 256 {
-		t.Fatalf("expected mixed image encode dim to honor 256, got %d", got)
-	}
-}
-
-func TestImageTargetDimensionMixedFallsBackWhenModelUnloaded(t *testing.T) {
-	// No native dimension to cap against: let the encode surface the load error.
-	stubMultiModalDim(t, -1)
-	req := EmbeddingRequest{
-		Texts:     []string{"hello"},
-		Images:    []string{"data:image/png;base64,aGVsbG8="},
-		Dimension: 768,
-	}
-	if got := imageTargetDimension(req); got != 768 {
-		t.Fatalf("expected fallback to req.Dimension 768, got %d", got)
-	}
-}
-
-func TestBuildEmbeddingResultsImageOnlyHonorsRequestDimension(t *testing.T) {
-	// Image-only: req.Dimension is the image target (validated <= native) and
-	// must be passed through to the encoder verbatim.
-	stubMultiModalDim(t, 384)
-
+func TestBuildEmbeddingResultsPassesResolvedDimensionToImages(t *testing.T) {
 	var gotImageDim int
 	orig := multiModalEncodeImage
 	defer func() { multiModalEncodeImage = orig }()
@@ -588,15 +465,12 @@ func TestBuildEmbeddingResultsImageOnlyHonorsRequestDimension(t *testing.T) {
 		}, nil
 	}
 
-	req := EmbeddingRequest{
-		Images:    []string{"data:image/png;base64,aGVsbG8="},
-		Dimension: 128,
-	}
+	req := EmbeddingRequest{Images: []string{"data:image/png;base64,aGVsbG8="}, Dimension: 128}
 	if _, _, err := buildEmbeddingResults(req, "multi-modal-embed-small"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if gotImageDim != 128 {
-		t.Fatalf("expected image encode to receive image-only request dimension 128, got %d", gotImageDim)
+		t.Fatalf("expected image encoder dimension 128, got %d", gotImageDim)
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/route_embeddings_test.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings_test.go
@@ -361,9 +361,9 @@ func TestApplyEmbeddingDefaultsImageOnlyUsesNativeDimension(t *testing.T) {
 	}
 }
 
-func TestApplyEmbeddingDefaultsMixedUsesNativeDimension(t *testing.T) {
-	// A mixed text+image request must use the image model's native dimension so
-	// one successful response cannot contain vectors of different lengths.
+func TestApplyEmbeddingDefaultsMixedKeepsTextDefault(t *testing.T) {
+	// req.Dimension targets the text side, so an image in the request must not
+	// pull the text default down to the image model's narrower native width.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:  []string{"hello"},
@@ -372,8 +372,8 @@ func TestApplyEmbeddingDefaultsMixedUsesNativeDimension(t *testing.T) {
 
 	applyEmbeddingDefaults(&req)
 
-	if req.Dimension != 384 {
-		t.Fatalf("expected mixed request to default to native dimension 384, got %d", req.Dimension)
+	if req.Dimension != defaultEmbeddingDimension {
+		t.Fatalf("expected mixed request to keep the text default %d, got %d", defaultEmbeddingDimension, req.Dimension)
 	}
 }
 
@@ -421,9 +421,9 @@ func TestValidateEmbeddingRequestRejectsImageOnlyDimensionAboveNative(t *testing
 	}
 }
 
-func TestValidateEmbeddingRequestRejectsAboveNativeDimensionForMixed(t *testing.T) {
-	// Every request containing images must reject a dimension above the image
-	// model's native ceiling before either modality is encoded.
+func TestValidateEmbeddingRequestAllowsAboveNativeDimensionForMixed(t *testing.T) {
+	// 768 is legal for the text side; the image ceiling is applied at encode
+	// time, so a mixed request must not be rejected for it.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:     []string{"hello"},
@@ -432,11 +432,8 @@ func TestValidateEmbeddingRequestRejectsAboveNativeDimensionForMixed(t *testing.
 	}
 
 	code, message, ok := validateEmbeddingRequest(req, nil)
-	if ok {
-		t.Fatalf("expected mixed request with dimension 768 to be rejected")
-	}
-	if code != "INVALID_DIMENSION" || !strings.Contains(message, "384") {
-		t.Fatalf("unexpected error %q: %q", code, message)
+	if !ok {
+		t.Fatalf("expected mixed request with dimension 768 to be accepted, got %q: %q", code, message)
 	}
 }
 
@@ -517,24 +514,40 @@ func TestValidateEmbeddingRequestAllowsTextModelForMixed(t *testing.T) {
 	}
 }
 
-func TestImageTargetDimensionMixedUsesRequestDimension(t *testing.T) {
-	// Validation rejects above-native dimensions at the API boundary. The target
-	// helper itself must not silently change a request's accepted dimension.
+func TestImageTargetDimensionImageOnlyPassesThrough(t *testing.T) {
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{
+		Images:    []string{"data:image/png;base64,aGVsbG8="},
+		Dimension: 128,
+	}
+	if got := imageTargetDimension(req); got != 128 {
+		t.Fatalf("expected image-only encode dim 128, got %d", got)
+	}
+}
+
+func TestImageTargetDimensionTextOnlyDoesNotCap(t *testing.T) {
+	// No image to cap: a text-scale dimension must pass through unwarned.
+	stubMultiModalDim(t, 384)
+	req := EmbeddingRequest{Texts: []string{"hello"}, Dimension: 768}
+	if got := imageTargetDimension(req); got != 768 {
+		t.Fatalf("expected text-only dimension 768 to pass through, got %d", got)
+	}
+}
+
+func TestImageTargetDimensionMixedCapsAtNative(t *testing.T) {
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:     []string{"hello"},
 		Images:    []string{"data:image/png;base64,aGVsbG8="},
 		Dimension: 768,
 	}
-	if got := imageTargetDimension(req); got != 768 {
-		t.Fatalf("expected mixed request image target to preserve 768 for validated caller, got %d", got)
+	if got := imageTargetDimension(req); got != 384 {
+		t.Fatalf("expected mixed image encode dim to cap at native 384, got %d", got)
 	}
 }
 
 func TestImageTargetDimensionMixedHonorsSubNativeDimension(t *testing.T) {
-	// Mixed with an explicit image-satisfiable dimension (256 <= native): the
-	// image side honors it so both modalities stay uniform, rather than forcing
-	// the image up to native and ignoring the requested value.
+	// 256 fits under native, so both modalities stay uniform without capping.
 	stubMultiModalDim(t, 384)
 	req := EmbeddingRequest{
 		Texts:     []string{"hello"},
@@ -542,26 +555,12 @@ func TestImageTargetDimensionMixedHonorsSubNativeDimension(t *testing.T) {
 		Dimension: 256,
 	}
 	if got := imageTargetDimension(req); got != 256 {
-		t.Fatalf("expected mixed request image encode dim to honor 256, got %d", got)
-	}
-}
-
-func TestImageTargetDimensionImageOnlyPassesThrough(t *testing.T) {
-	// Image-only: req.Dimension IS the image target (already validated <= native).
-	stubMultiModalDim(t, 384)
-	req := EmbeddingRequest{
-		Images:    []string{"data:image/png;base64,aGVsbG8="},
-		Dimension: 128,
-	}
-	if got := imageTargetDimension(req); got != 128 {
-		t.Fatalf("expected image-only request image encode dim to be 128, got %d", got)
+		t.Fatalf("expected mixed image encode dim to honor 256, got %d", got)
 	}
 }
 
 func TestImageTargetDimensionMixedFallsBackWhenModelUnloaded(t *testing.T) {
-	// Mixed with no multimodal model loaded: helper returns req.Dimension so the
-	// downstream encode surfaces "model not loaded" rather than the helper
-	// silently choosing a value.
+	// No native dimension to cap against: let the encode surface the load error.
 	stubMultiModalDim(t, -1)
 	req := EmbeddingRequest{
 		Texts:     []string{"hello"},
@@ -569,7 +568,7 @@ func TestImageTargetDimensionMixedFallsBackWhenModelUnloaded(t *testing.T) {
 		Dimension: 768,
 	}
 	if got := imageTargetDimension(req); got != 768 {
-		t.Fatalf("expected fallback to req.Dimension 768 when multimodal unloaded, got %d", got)
+		t.Fatalf("expected fallback to req.Dimension 768, got %d", got)
 	}
 }
 

--- a/src/semantic-router/pkg/config/embedding_config.go
+++ b/src/semantic-router/pkg/config/embedding_config.go
@@ -7,9 +7,18 @@ const (
 	EmbeddingBackendOpenVINO         = "openvino"
 	EmbeddingBackendOpenAICompatible = "openai_compatible"
 
-	EmbeddingModelTypeQwen3  = "qwen3"
-	EmbeddingModelTypeRemote = "remote"
+	EmbeddingModelTypeQwen3      = "qwen3"
+	EmbeddingModelTypeRemote     = "remote"
+	EmbeddingModelTypeMultiModal = "multimodal"
 )
+
+// IsMultiModalEmbeddingModelType reports whether embedding_config.model_type names
+// the multimodal checkpoint. Only then does embedding_config.target_dimension
+// describe the multimodal model; for every other model type it describes the text
+// encoder and must not be checked against the multimodal ladder.
+func IsMultiModalEmbeddingModelType(modelType string) bool {
+	return strings.EqualFold(strings.TrimSpace(modelType), EmbeddingModelTypeMultiModal)
+}
 
 // EmbeddingEndpointConfig defines an external embedding provider endpoint.
 type EmbeddingEndpointConfig struct {

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 // Classifier represents the configuration for text classification.
 type Classifier struct {
 	CategoryModel    `yaml:"category_model"`
@@ -78,7 +80,7 @@ func (c HNSWConfig) WithDefaults() HNSWConfig {
 			result.ModelType = EmbeddingModelTypeQwen3
 		}
 	}
-	if result.TargetDimension <= 0 {
+	if result.TargetDimension <= 0 && !strings.EqualFold(strings.TrimSpace(result.ModelType), "multimodal") {
 		result.TargetDimension = 768
 	}
 	if result.EnableSoftMatching == nil {

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -1,7 +1,5 @@
 package config
 
-import "strings"
-
 // Classifier represents the configuration for text classification.
 type Classifier struct {
 	CategoryModel    `yaml:"category_model"`
@@ -80,7 +78,9 @@ func (c HNSWConfig) WithDefaults() HNSWConfig {
 			result.ModelType = EmbeddingModelTypeQwen3
 		}
 	}
-	if result.TargetDimension <= 0 && !strings.EqualFold(strings.TrimSpace(result.ModelType), "multimodal") {
+	// The multimodal checkpoint declares its own native dimension, so leave the
+	// value unset and let the loaded model resolve it.
+	if result.TargetDimension <= 0 && !IsMultiModalEmbeddingModelType(result.ModelType) {
 		result.TargetDimension = 768
 	}
 	if result.EnableSoftMatching == nil {

--- a/src/semantic-router/pkg/config/model_config_types_test.go
+++ b/src/semantic-router/pkg/config/model_config_types_test.go
@@ -2,6 +2,15 @@ package config
 
 import "testing"
 
+func TestHNSWConfigWithDefaultsDefersMultimodalDimension(t *testing.T) {
+	for _, modelType := range []string{"multimodal", " MultiModal "} {
+		cfg := HNSWConfig{ModelType: modelType}.WithDefaults()
+		if cfg.TargetDimension != 0 {
+			t.Fatalf("multimodal dimension must be resolved from the loaded model, got %d", cfg.TargetDimension)
+		}
+	}
+}
+
 func TestPreferenceModelConfigWithDefaultsEnablesContrastiveByDefault(t *testing.T) {
 	cfg := PreferenceModelConfig{}.WithDefaults()
 	if cfg.UseContrastive == nil || !*cfg.UseContrastive {

--- a/src/semantic-router/pkg/modelruntime/multimodal_dimension.go
+++ b/src/semantic-router/pkg/modelruntime/multimodal_dimension.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
@@ -17,6 +18,19 @@ var multimodalDimensionContract = func() embeddingDimensionContract {
 		Default:   candle_binding.MultiModalGetEmbeddingDim(),
 		Supported: candle_binding.MultiModalGetSupportedDimensions(),
 	}
+}
+
+// configuredMultiModalDimension reports the operator-configured target dimension
+// that will actually be sent to the multimodal encoder. embedding_config is the
+// single semantic-embedding block, so its target_dimension only describes the
+// multimodal model when model_type selects it; with any text model_type (mmbert,
+// qwen3, remote) that width belongs to the text encoder and checking it against
+// the multimodal ladder would reject a valid deployment.
+func configuredMultiModalDimension(cfg *config.RouterConfig) int {
+	if cfg == nil || !config.IsMultiModalEmbeddingModelType(cfg.EmbeddingConfig.ModelType) {
+		return 0
+	}
+	return cfg.EmbeddingConfig.WithDefaults().TargetDimension
 }
 
 func initializeMultiModalEmbeddingModel(component string, useCPU bool, modelPath string, targetDimension int) bool {

--- a/src/semantic-router/pkg/modelruntime/multimodal_dimension.go
+++ b/src/semantic-router/pkg/modelruntime/multimodal_dimension.go
@@ -1,0 +1,63 @@
+package modelruntime
+
+import (
+	"fmt"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+type embeddingDimensionContract struct {
+	Default   int
+	Supported []int
+}
+
+var multimodalDimensionContract = func() embeddingDimensionContract {
+	return embeddingDimensionContract{
+		Default:   candle_binding.MultiModalGetEmbeddingDim(),
+		Supported: candle_binding.MultiModalGetSupportedDimensions(),
+	}
+}
+
+func initializeMultiModalEmbeddingModel(component string, useCPU bool, modelPath string, targetDimension int) bool {
+	if modelPath == "" {
+		return false
+	}
+
+	logging.ComponentEvent(component, "multimodal_embedding_init_started", map[string]interface{}{
+		"model_ref": modelPath,
+		"use_cpu":   useCPU,
+	})
+	if err := candle_binding.InitMultiModalEmbeddingModel(modelPath, useCPU); err != nil {
+		logging.ComponentWarnEvent(component, "multimodal_embedding_init_failed", map[string]interface{}{
+			"model_ref":               modelPath,
+			"error":                   err.Error(),
+			"multimodal_routes_ready": false,
+		})
+		return false
+	}
+	contract := multimodalDimensionContract()
+	if err := validateConfiguredMultimodalDimension(targetDimension, contract); err != nil {
+		logging.ComponentWarnEvent(component, "multimodal_embedding_dimension_invalid", map[string]interface{}{
+			"model_ref": modelPath,
+			"error":     err.Error(),
+		})
+		return false
+	}
+	logging.ComponentEvent(component, "multimodal_embedding_initialized", map[string]interface{}{
+		"model_ref": modelPath,
+	})
+	return true
+}
+
+func validateConfiguredMultimodalDimension(dimension int, contract embeddingDimensionContract) error {
+	if dimension == 0 {
+		return nil
+	}
+	for _, supported := range contract.Supported {
+		if dimension == supported {
+			return nil
+		}
+	}
+	return fmt.Errorf("configured target dimension %d is unsupported; model default is %d and supported dimensions are %v", dimension, contract.Default, contract.Supported)
+}

--- a/src/semantic-router/pkg/modelruntime/router_runtime.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime.go
@@ -755,8 +755,7 @@ func multiModalEmbeddingRuntimeTask(
 		Name:       "router.embedding.multimodal",
 		BestEffort: true,
 		Run: func(context.Context) error {
-			targetDimension := cfg.EmbeddingConfig.WithDefaults().TargetDimension
-			if !initializeMultiModalEmbeddingModel(component, cfg.UseCPU, paths.multiModal, targetDimension) {
+			if !initializeMultiModalEmbeddingModel(component, cfg.UseCPU, paths.multiModal, configuredMultiModalDimension(cfg)) {
 				return fmt.Errorf("failed to initialize multimodal embedding model")
 			}
 			if requiresMultimodalTools {

--- a/src/semantic-router/pkg/modelruntime/router_runtime.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime.go
@@ -427,29 +427,6 @@ func initializeBERTModel(component string, useCPU bool, bertPath string, eventPr
 	return true
 }
 
-func initializeMultiModalEmbeddingModel(component string, useCPU bool, multiModalPath string) bool {
-	if multiModalPath == "" {
-		return false
-	}
-
-	logging.ComponentEvent(component, "multimodal_embedding_init_started", map[string]interface{}{
-		"model_ref": multiModalPath,
-		"use_cpu":   useCPU,
-	})
-	if err := candle_binding.InitMultiModalEmbeddingModel(multiModalPath, useCPU); err != nil {
-		logging.ComponentWarnEvent(component, "multimodal_embedding_init_failed", map[string]interface{}{
-			"model_ref":               multiModalPath,
-			"error":                   err.Error(),
-			"multimodal_routes_ready": false,
-		})
-		return false
-	}
-	logging.ComponentEvent(component, "multimodal_embedding_initialized", map[string]interface{}{
-		"model_ref": multiModalPath,
-	})
-	return true
-}
-
 func logMissingEmbeddingModelsConfig(component string) {
 	logging.ComponentEvent(component, "embedding_models_not_configured", map[string]interface{}{
 		"hint": "model_catalog.embeddings.semantic",
@@ -778,7 +755,8 @@ func multiModalEmbeddingRuntimeTask(
 		Name:       "router.embedding.multimodal",
 		BestEffort: true,
 		Run: func(context.Context) error {
-			if !initializeMultiModalEmbeddingModel(component, cfg.UseCPU, paths.multiModal) {
+			targetDimension := cfg.EmbeddingConfig.WithDefaults().TargetDimension
+			if !initializeMultiModalEmbeddingModel(component, cfg.UseCPU, paths.multiModal, targetDimension) {
 				return fmt.Errorf("failed to initialize multimodal embedding model")
 			}
 			if requiresMultimodalTools {

--- a/src/semantic-router/pkg/modelruntime/router_runtime_test.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime_test.go
@@ -171,6 +171,21 @@ func assertBoolPtr(t *testing.T, got *bool, want bool, label string) {
 	}
 }
 
+func TestValidateConfiguredMultimodalDimension(t *testing.T) {
+	contract := embeddingDimensionContract{Default: 384, Supported: []int{384, 256, 128, 64, 32}}
+
+	for _, dimension := range []int{0, 384, 32} {
+		if err := validateConfiguredMultimodalDimension(dimension, contract); err != nil {
+			t.Fatalf("dimension %d should be accepted: %v", dimension, err)
+		}
+	}
+
+	err := validateConfiguredMultimodalDimension(768, contract)
+	if err == nil || !strings.Contains(err.Error(), "384") {
+		t.Fatalf("expected model-specific rejection for dimension 768, got %v", err)
+	}
+}
+
 func assertRemoteEmbeddingFailureEvent(t *testing.T, failedEvent *Event) {
 	t.Helper()
 	if failedEvent == nil || failedEvent.Error == nil {

--- a/src/semantic-router/pkg/modelruntime/router_runtime_test.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime_test.go
@@ -186,6 +186,74 @@ func TestValidateConfiguredMultimodalDimension(t *testing.T) {
 	}
 }
 
+// embedding_config is the single semantic-embedding block. config/config.yaml
+// ships a multimodal_model_path alongside model_type: mmbert with
+// target_dimension: 768, which is the text encoder's width. Reading it as the
+// multimodal target rejected the shipped default and left the multimodal route
+// unready while the checkpoint was already resident in the binding.
+func TestConfiguredMultiModalDimensionIgnoresTextModelWidth(t *testing.T) {
+	shipped := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MultiModalModelPath: "models/mom-embedding-multimodal",
+				EmbeddingConfig:     config.HNSWConfig{ModelType: "mmbert", TargetDimension: 768},
+			},
+		},
+	}
+	if got := configuredMultiModalDimension(shipped); got != 0 {
+		t.Fatalf("a text model_type must not contribute a multimodal dimension, got %d", got)
+	}
+
+	contract := embeddingDimensionContract{Default: 384, Supported: []int{384, 256, 128, 64, 32}}
+	if err := validateConfiguredMultimodalDimension(configuredMultiModalDimension(shipped), contract); err != nil {
+		t.Fatalf("shipped config must not block multimodal init: %v", err)
+	}
+}
+
+// With model_type: multimodal the configured width really is the multimodal
+// target, so an undeclared one must still fail at load.
+func TestConfiguredMultiModalDimensionUsesMultimodalModelType(t *testing.T) {
+	contract := embeddingDimensionContract{Default: 384, Supported: []int{384, 256, 128, 64, 32}}
+
+	declared := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				EmbeddingConfig: config.HNSWConfig{ModelType: "multimodal", TargetDimension: 256},
+			},
+		},
+	}
+	if got := configuredMultiModalDimension(declared); got != 256 {
+		t.Fatalf("expected the configured multimodal dimension 256, got %d", got)
+	}
+	if err := validateConfiguredMultimodalDimension(configuredMultiModalDimension(declared), contract); err != nil {
+		t.Fatalf("declared dimension 256 should be accepted: %v", err)
+	}
+
+	// An omitted target_dimension stays unset for multimodal and resolves from
+	// the loaded model instead of defaulting to 768.
+	omitted := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				EmbeddingConfig: config.HNSWConfig{ModelType: "multimodal"},
+			},
+		},
+	}
+	if got := configuredMultiModalDimension(omitted); got != 0 {
+		t.Fatalf("expected an omitted multimodal dimension to stay unset, got %d", got)
+	}
+
+	unsupported := &config.RouterConfig{
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				EmbeddingConfig: config.HNSWConfig{ModelType: "multimodal", TargetDimension: 768},
+			},
+		},
+	}
+	if err := validateConfiguredMultimodalDimension(configuredMultiModalDimension(unsupported), contract); err == nil {
+		t.Fatal("an undeclared multimodal dimension must be rejected at load")
+	}
+}
+
 func assertRemoteEmbeddingFailureEvent(t *testing.T, failedEvent *Event) {
 	t.Helper()
 	if failedEvent == nil || failedEvent.Error == nil {


### PR DESCRIPTION
Related #2407
Related: #2317, #2318, #2347, #3195

## Problem

Embedding dimensions were defaulted and validated without regard to the model that encodes the request.

The HTTP embedding API used a global default of `768` and a model-agnostic allowlist, while the maintained multimodal checkpoint has native dimension `384` and declares `{384, 256, 128, 64, 32}`. This caused valid multimodal dimensions to be rejected, unsupported dimensions to pass request validation, and image inputs to inherit a dimension their model cannot produce.

The previous PR revision capped only the image side of mixed requests and logged a warning. That contract is removed: it could return vectors from different models, spaces, and widths in one successful response while the warning remained invisible to the client.

## Contract

Dimension behavior follows the concrete model resolved for the request:

- a qualified binding exposes its loaded model's native/default dimension and declared supported dimensions;
- an omitted dimension uses the resolved model's default;
- an explicit unsupported dimension is rejected before inference;
- native bindings do not clamp or substitute another width;
- only model-declared Matryoshka dimensions are supported;
- image-bearing requests resolve to the multimodal model, so text and image inputs in one request use the same checkpoint, embedding space, and target dimension;
- the model-agnostic text allowlist stays narrow: the multimodal ladder is consulted only for multimodal requests and never widens the text embedding or similarity endpoints;
- an unloaded multimodal model is server state, reported as `503 MODEL_NOT_LOADED`, not as a client error about the request payload.

The binding establishes this immutable contract from validated checkpoint metadata at model load. Request handling does not run probe inference or reread the checkpoint.

## Changes

### Candle binding

- Validate `embedding_dim` and `matryoshka_dims` when loading the multimodal checkpoint.
- Require the native dimension in the declared ladder; reject zero, duplicate, above-native, and undeclared dimensions.
- A checkpoint that sets `embedding_dim` without declaring `matryoshka_dims` publishes its native width as the whole ladder. It previously loaded and truncated, so failing the load over a field the operator never wrote would be a regression, and inventing intermediate widths would expose untrained truncations.
- Apply the same target-dimension validation to multimodal text, image, audio, and batch text paths.
- Export native/default and supported dimensions through FFI and Go wrappers, with the same `-1` "no model loaded" sentinel in the cgo and mock builds.

### ONNX binding

- Parse and validate the same checkpoint dimension metadata, including the native-width fallback above.
- Validate declared dimensions before truncating text, image, or audio vectors.
- Export native/default and supported dimensions directly from the loaded model.

### Router runtime

- Defer the multimodal configuration default until the model contract is loaded instead of assigning `768`.
- Validate an explicit configured multimodal target dimension before marking the runtime ready, but read it only when `embedding_config.model_type` selects the multimodal model. `embedding_config` is the single semantic-embedding block: `config/config.yaml` ships `model_type: mmbert` with `target_dimension: 768` alongside `multimodal_model_path`, and that width belongs to the text encoder. Checking it against the multimodal ladder rejected the shipped default and left the multimodal route unready after the checkpoint had already loaded successfully.
- `pkg/modelruntime` and `pkg/apiserver` each keep their own small contract struct rather than sharing one. Both read the same two FFI calls at request time, so the values cannot diverge, and each replaces its own constructor in tests; sharing one struct would mean one package overriding another's package-level test seam. The per-model lookup that has to cover qwen3, gemma and mmbert will give these one owner, and collapsing them before that owner exists would be rework.

### API

- Resolve image-bearing embedding requests to `model: "multimodal"`.
- Default those requests to the loaded model's native dimension, and never forward the binding's unavailability sentinel as a request dimension.
- Validate explicit dimensions against the declared ladder with model-specific errors.
- Report an unloaded multimodal model as `503 MODEL_NOT_LOADED`. Deferring it let the encode failure surface as `400 INVALID_IMAGE`, telling the caller its image was undecodable when the server simply had no model.
- Validate the image/model pairing before the dimension, so an image request pointed at a text model reports the embedding-space mismatch rather than a downstream dimension error.
- Keep the shared dimension allowlist and its rejection message derived from one list, so the accepted set and the message cannot drift apart.
- Remove mixed-request image capping and server-log-only warnings.
- Preserve resolved checkpoint identity in image results.

## Behavior changes visible to clients

- A request carrying images with no explicit `model` now resolves to the multimodal checkpoint, so its text vectors come from that shared 384-dim space instead of `auto` at 768.
- An explicit text model (`qwen3`, `gemma`, `mmbert`) combined with image inputs is rejected with `INVALID_PARAMETER` instead of returning vectors from two embedding spaces in one response.
- Image results report the resolved checkpoint identifier in `model_used` rather than the fixed string `multi-modal-embed`.
- An image-bearing request with `dimension: 512`, `768` or `1024` is now rejected with `400 INVALID_DIMENSION`. Those values are in the model-agnostic allowlist today and the request succeeds, but the multimodal tower can only produce 384, so the caller receives a 384-wide vector under a 768 label. This replaces a silent wrong answer with an error; it is a visible API break for any client that sends a text-side width alongside images.

## Scope boundaries

- Typed multimodal request/batch response schemas: #2317.
- Public capability/readiness discovery consumes this metadata: #2318.
- General `ModelManifest` / `ResolvedBinding` architecture: #3195.
- ONNX/Candle preprocessing parity: #2166.
- Image-routing threshold calibration: #2165.

## Known gaps, not addressed here

Raised by @theohsiung on #2407 and deliberately left out of this slice, which is the multimodal/image path:

- `auto` treats `target_dimension` as a hint (`candle-binding/src/classifiers/unified/embedding.rs:111-118`), so `auto` with `dimension: 1024` at `seq_len` 513-2048 selects Gemma (native 768, `ffi/embedding.rs:1833`) and silently returns 768. Dimension has to become a hard filter on the `auto` candidate set. Text-side selection, separate PR.
- "Omitted dimension resolves to the model's native width" makes that width vary per request under `auto`, given qwen3 1024 against gemma 768. Explicit model resolves to native; `auto` keeps a startup-validated config default. Same PR as above.
- Three more dimension tables remain unconsolidated: the text allowlist and default in `route_embeddings.go`, `semanticCacheEmbeddingDimension` in `pkg/cache/cache.go:183`, and `TargetDimension` on the operator CRD. Consolidation pass.
- `/api/v1/similarity` and `/api/v1/similarity/batch` still carry their own copies of the same defaulting (`applySimilarityDefaults`, `applyBatchSimilarityDefaults`). Same consolidation pass.

#2407 stays open until those land, which is why this PR is `Related` rather than `Closes`.

## Verification

Rebased onto `origin/main` at `6aed6c1a`. The only overlap with the commits landed since the previous revision is `pkg/config/model_config_types.go`, and the three packages below were re-run on the rebased tip.

- `go test ./pkg/apiserver/ ./pkg/config/ ./pkg/modelruntime/` pass, including new regression tests for the shipped `config/config.yaml` combination, the narrow text allowlist, the allowlist/message pairing, `503` on an unloaded model, and the sentinel never reaching a request.
- `candle-binding`: `cargo test --release --lib --no-default-features multimodal` passes, including the undeclared-ladder load path.
- `onnx-binding`: `cargo test --lib multimodal_embedding` passes, including the same load path.
- `go vet` and `gofmt` clean on the touched packages; `rustfmt --check` clean on both touched Rust files.
- `cargo clippy -- -D warnings` reports nothing on the changed Rust files. The previous revision failed the lint gate because touching `onnx-binding/src/ffi/multimodal.rs` pulled that module's pre-existing raw-pointer warnings into the changed-file set; they are now suppressed module-wide as `candle-binding/src/ffi/classify.rs` already does.


