### PR TITLE
[Docs] remove Star History section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,6 @@ If you find Semantic Router helpful in your research or projects, please conside
 }
 ```
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=vllm-project/semantic-router&type=Date)](https://www.star-history.com/#vllm-project/semantic-router&Date)
-
 ## Sponsors
 
 We are grateful to our sponsors who support us:


### PR DESCRIPTION
Closes #2642

## Purpose

- Remove the `## Star History` heading and `star-history.com` chart from the root `README.md`.
- Keeps the README focused on project information and avoids an external promotional dependency.
- Module: `Docs`

## Test Plan

- Visually inspect `README.md` to confirm Star History is gone and Citation/Sponsors are unchanged.
- `git grep -i 'star-history' README.md` returns no matches.

## Test Result

- Star History section and chart removed; rest of README unchanged.
- No other files modified.