### PR TITLE
[Router] Scope signal evaluation to authz-eligible decisions

### DIFF
--- a/src/semantic-router/pkg/classification/classifier_authz_scope.go
+++ b/src/semantic-router/pkg/classification/classifier_authz_scope.go
@@ -1,0 +1,96 @@
+package classification
+
+import (
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type partialTruth uint8
+
+const (
+	partialFalse partialTruth = iota
+	partialTrue
+	partialUnknown
+)
+
+// filterDecisionsByAuthz removes only decisions whose rule tree is already
+// known to be false after authz evaluation. Decisions that still depend on
+// non-authz signals, or whose rule shape is unsupported, remain candidates.
+func filterDecisionsByAuthz(decisions []config.Decision, matchedAuthzRules []string) []config.Decision {
+	matched := make(map[string]struct{}, len(matchedAuthzRules))
+	for _, role := range matchedAuthzRules {
+		matched[role] = struct{}{}
+	}
+
+	candidates := make([]config.Decision, 0, len(decisions))
+	for _, decision := range decisions {
+		if evaluateRuleWithAuthz(decision.Rules, matched) != partialFalse {
+			candidates = append(candidates, decision)
+		}
+	}
+	return candidates
+}
+
+func evaluateRuleWithAuthz(node config.RuleNode, matched map[string]struct{}) partialTruth {
+	if node.IsLeaf() {
+		if strings.EqualFold(strings.TrimSpace(node.Type), config.SignalTypeAuthz) {
+			if _, ok := matched[node.Name]; ok {
+				return partialTrue
+			}
+			return partialFalse
+		}
+		return partialUnknown
+	}
+
+	switch strings.ToUpper(node.Operator) {
+	case "AND":
+		return evaluateAuthzAND(node.Conditions, matched)
+	case "NOT":
+		if len(node.Conditions) != 1 {
+			return partialUnknown
+		}
+		return negatePartialTruth(evaluateRuleWithAuthz(node.Conditions[0], matched))
+	case "OR", "":
+		return evaluateAuthzOR(node.Conditions, matched)
+	default:
+		return partialUnknown
+	}
+}
+
+func evaluateAuthzAND(children []config.RuleNode, matched map[string]struct{}) partialTruth {
+	result := partialTrue
+	for _, child := range children {
+		switch evaluateRuleWithAuthz(child, matched) {
+		case partialFalse:
+			return partialFalse
+		case partialUnknown:
+			result = partialUnknown
+		}
+	}
+	return result
+}
+
+func evaluateAuthzOR(children []config.RuleNode, matched map[string]struct{}) partialTruth {
+	result := partialFalse
+	for _, child := range children {
+		switch evaluateRuleWithAuthz(child, matched) {
+		case partialTrue:
+			return partialTrue
+		case partialUnknown:
+			result = partialUnknown
+		}
+	}
+	return result
+}
+
+func negatePartialTruth(value partialTruth) partialTruth {
+	switch value {
+	case partialTrue:
+		return partialFalse
+	case partialFalse:
+		return partialTrue
+	default:
+		return partialUnknown
+	}
+}

--- a/src/semantic-router/pkg/classification/classifier_authz_scope_test.go
+++ b/src/semantic-router/pkg/classification/classifier_authz_scope_test.go
@@ -1,0 +1,211 @@
+package classification
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestFilterDecisionsByAuthz(t *testing.T) {
+	authz := func(name string) config.RuleNode {
+		return config.RuleNode{Type: config.SignalTypeAuthz, Name: name}
+	}
+	keyword := func(name string) config.RuleNode {
+		return config.RuleNode{Type: config.SignalTypeKeyword, Name: name}
+	}
+	decision := func(name string, rules config.RuleNode) config.Decision {
+		return config.Decision{Name: name, Rules: rules}
+	}
+
+	tests := []struct {
+		name         string
+		decisions    []config.Decision
+		matchedRoles []string
+		wantNames    []string
+	}{
+		{
+			name: "drops an AND branch denied by authz",
+			decisions: []config.Decision{
+				decision("route-a", config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{authz("route-a"), keyword("math")}}),
+				decision("route-b", config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{authz("route-b"), keyword("code")}}),
+			},
+			matchedRoles: []string{"route-a"},
+			wantNames:    []string{"route-a"},
+		},
+		{
+			name: "keeps an OR branch when a non-authz child is unknown",
+			decisions: []config.Decision{
+				decision("fallback", config.RuleNode{Operator: "OR", Conditions: []config.RuleNode{authz("route-b"), keyword("general")}}),
+			},
+			matchedRoles: []string{"route-a"},
+			wantNames:    []string{"fallback"},
+		},
+		{
+			name: "applies unary NOT to known authz facts",
+			decisions: []config.Decision{
+				decision("not-route-b", config.RuleNode{Operator: "NOT", Conditions: []config.RuleNode{authz("route-b")}}),
+				decision("not-route-a", config.RuleNode{Operator: "NOT", Conditions: []config.RuleNode{authz("route-a")}}),
+			},
+			matchedRoles: []string{"route-a"},
+			wantNames:    []string{"not-route-b"},
+		},
+		{
+			name: "preserves conservative candidates for unknown and malformed rules",
+			decisions: []config.Decision{
+				decision("non-authz", keyword("general")),
+				decision("malformed-not", config.RuleNode{Operator: "NOT", Conditions: []config.RuleNode{authz("route-a"), authz("route-b")}}),
+				decision("unsupported", config.RuleNode{Operator: "XOR", Conditions: []config.RuleNode{authz("route-b")}}),
+			},
+			matchedRoles: []string{"route-a"},
+			wantNames:    []string{"non-authz", "malformed-not", "unsupported"},
+		},
+		{
+			name: "matches the decision engine identities for empty AND and OR",
+			decisions: []config.Decision{
+				decision("empty-and", config.RuleNode{Operator: "AND"}),
+				decision("empty-or", config.RuleNode{Operator: "OR"}),
+			},
+			wantNames: []string{"empty-and"},
+		},
+		{
+			name: "matches role names case-sensitively",
+			decisions: []config.Decision{
+				decision("exact", authz("Premium")),
+				decision("different-case", authz("premium")),
+			},
+			matchedRoles: []string{"Premium"},
+			wantNames:    []string{"exact"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterDecisionsByAuthz(tt.decisions, tt.matchedRoles)
+			gotNames := make([]string, 0, len(got))
+			for _, candidate := range got {
+				gotNames = append(gotNames, candidate.Name)
+			}
+			if !reflect.DeepEqual(gotNames, tt.wantNames) {
+				t.Fatalf("filterDecisionsByAuthz() names = %v, want %v", gotNames, tt.wantNames)
+			}
+		})
+	}
+}
+
+func TestGetUsedSignalsForDecisions(t *testing.T) {
+	routeA := config.Decision{
+		Name: "route-a",
+		Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{
+			{Type: config.SignalTypeAuthz, Name: "route-a"},
+			{Type: config.SignalTypeKeyword, Name: "math"},
+		}},
+	}
+	routeB := config.Decision{
+		Name: "route-b",
+		Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{
+			{Type: config.SignalTypeAuthz, Name: "route-b"},
+			{Type: config.SignalTypeJailbreak, Name: "guard"},
+		}},
+	}
+	classifier := &Classifier{Config: &config.RouterConfig{
+		IntelligentRouting: config.IntelligentRouting{Decisions: []config.Decision{routeA, routeB}},
+	}}
+
+	used := classifier.getUsedSignalsForDecisions([]config.Decision{routeA})
+	if !used[config.SignalTypeKeyword+":math"] {
+		t.Fatalf("expected route-a keyword signal to be used, got %v", used)
+	}
+	if used[config.SignalTypeJailbreak+":guard"] {
+		t.Fatalf("did not expect route-b jailbreak signal to be used, got %v", used)
+	}
+}
+
+type authzScopeTokenCounter struct {
+	calls int
+}
+
+func (c *authzScopeTokenCounter) CountTokens(string) (int, error) {
+	c.calls++
+	return 1, nil
+}
+
+func TestEvaluateAllSignalsWithHeadersForDecisionsScopesNonAuthzWork(t *testing.T) {
+	decisions := []config.Decision{
+		{
+			Name: "route-a",
+			Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{
+				{Type: config.SignalTypeAuthz, Name: "route-a"},
+			}},
+		},
+		{
+			Name: "route-b",
+			Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{
+				{Type: config.SignalTypeAuthz, Name: "route-b"},
+				{Type: config.SignalTypeContext, Name: "short"},
+			}},
+		},
+	}
+	bindings := []config.RoleBinding{
+		{Name: "route-a-users", Role: "route-a", Subjects: []config.Subject{{Kind: "User", Name: "alice"}}},
+		{Name: "route-b-users", Role: "route-b", Subjects: []config.Subject{{Kind: "User", Name: "bob"}}},
+	}
+	authzClassifier, err := NewAuthzClassifier(bindings)
+	if err != nil {
+		t.Fatalf("NewAuthzClassifier() error = %v", err)
+	}
+	counter := &authzScopeTokenCounter{}
+	contextRules := []config.ContextRule{{Name: "short", MinTokens: "0", MaxTokens: "10"}}
+	classifier := &Classifier{
+		Config: &config.RouterConfig{IntelligentRouting: config.IntelligentRouting{
+			Signals:   config.Signals{RoleBindings: bindings, ContextRules: contextRules},
+			Decisions: decisions,
+		}},
+		authzClassifier:       authzClassifier,
+		authzUserIDHeader:     "x-authz-user-id",
+		authzUserGroupsHeader: "x-authz-user-groups",
+		contextClassifier:     NewContextClassifier(counter, contextRules),
+	}
+
+	results, candidates, err := classifier.EvaluateAllSignalsWithHeadersForDecisions(
+		"hello", "hello", "hello", nil, nil, false,
+		map[string]string{"x-authz-user-id": "alice"}, false, "", decisions,
+	)
+	if err != nil {
+		t.Fatalf("EvaluateAllSignalsWithHeadersForDecisions() error = %v", err)
+	}
+	if !reflect.DeepEqual(results.MatchedAuthzRules, []string{"route-a"}) {
+		t.Fatalf("matched authz rules = %v, want [route-a]", results.MatchedAuthzRules)
+	}
+	if got := decisionNames(candidates); !reflect.DeepEqual(got, []string{"route-a"}) {
+		t.Fatalf("candidate decisions = %v, want [route-a]", got)
+	}
+	if counter.calls != 0 {
+		t.Fatalf("irrelevant context classifier calls = %d, want 0", counter.calls)
+	}
+
+	results, candidates, err = classifier.EvaluateAllSignalsWithHeadersForDecisions(
+		"hello", "hello", "hello", nil, nil, false,
+		map[string]string{"x-authz-user-id": "alice"}, true, "", decisions,
+	)
+	if err != nil {
+		t.Fatalf("force-all EvaluateAllSignalsWithHeadersForDecisions() error = %v", err)
+	}
+	if got := decisionNames(candidates); !reflect.DeepEqual(got, []string{"route-a", "route-b"}) {
+		t.Fatalf("force-all candidate decisions = %v, want all decisions", got)
+	}
+	if counter.calls != 1 {
+		t.Fatalf("force-all context classifier calls = %d, want 1", counter.calls)
+	}
+	if !reflect.DeepEqual(results.MatchedContextRules, []string{"short"}) {
+		t.Fatalf("force-all context rules = %v, want [short]", results.MatchedContextRules)
+	}
+}
+
+func decisionNames(decisions []config.Decision) []string {
+	names := make([]string, 0, len(decisions))
+	for _, decision := range decisions {
+		names = append(names, decision.Name)
+	}
+	return names
+}

--- a/src/semantic-router/pkg/classification/classifier_signal_authz.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_authz.go
@@ -25,12 +25,58 @@ import (
 //   - skipCompressionSignals (map[string]bool): signal types that must use uncompressedText
 //   - convFacts (ConversationFacts): optional conversation facts for conversation signals
 func (c *Classifier) EvaluateAllSignalsWithHeaders(text string, contextText string, currentUserText string, priorUserMessages []string, nonUserMessages []string, hasPriorAssistantReply bool, headers map[string]string, forceEvaluateAll bool, imageURL string, extra ...interface{}) (*SignalResults, error) {
+	results, _, err := c.EvaluateAllSignalsWithHeadersForDecisions(
+		text,
+		contextText,
+		currentUserText,
+		priorUserMessages,
+		nonUserMessages,
+		hasPriorAssistantReply,
+		headers,
+		forceEvaluateAll,
+		imageURL,
+		c.Config.Decisions,
+		extra...,
+	)
+	return results, err
+}
+
+// EvaluateAllSignalsWithHeadersForDecisions evaluates authz first, removes
+// candidates that are already impossible, and evaluates non-authz signals only
+// for the remaining decisions. The returned candidates must also be used for
+// final decision evaluation to keep computation and result scopes aligned.
+func (c *Classifier) EvaluateAllSignalsWithHeadersForDecisions(text string, contextText string, currentUserText string, priorUserMessages []string, nonUserMessages []string, hasPriorAssistantReply bool, headers map[string]string, forceEvaluateAll bool, imageURL string, decisions []config.Decision, extra ...interface{}) (*SignalResults, []config.Decision, error) {
 	opts := parseEvaluateSignalsExtra(extra)
-	results := c.EvaluateAllSignalsWithContext(text, contextText, currentUserText, priorUserMessages, nonUserMessages, hasPriorAssistantReply, forceEvaluateAll, opts.uncompressedText, opts.skipCompressionSignals, opts.convFacts, imageURL)
-	if err := c.appendAuthzFromHeaders(results, headers, forceEvaluateAll); err != nil {
-		return nil, err
+	results := newSignalResults()
+	usedSignals := c.getUsedSignalsForDecisions(decisions)
+	if forceEvaluateAll {
+		usedSignals = c.getAllSignalTypes()
 	}
-	return results, nil
+	if err := c.evaluateAuthzFromHeaders(results, headers, usedSignals); err != nil {
+		return nil, nil, err
+	}
+
+	candidates := decisions
+	if !forceEvaluateAll {
+		candidates = filterDecisionsByAuthz(decisions, results.MatchedAuthzRules)
+		logging.Debugf("[Signal Computation] Authz scoped decision candidates from %d to %d", len(decisions), len(candidates))
+	}
+	results = c.evaluateAllSignalsWithContextForDecisions(
+		text,
+		contextText,
+		currentUserText,
+		priorUserMessages,
+		nonUserMessages,
+		hasPriorAssistantReply,
+		forceEvaluateAll,
+		opts.uncompressedText,
+		opts.skipCompressionSignals,
+		opts.convFacts,
+		imageURL,
+		candidates,
+		results,
+	)
+	return results, candidates, nil
 }
 
 // evaluateSignalsExtra mirrors optional trailing args after imageURL for EvaluateAllSignalsWithHeaders.
@@ -59,11 +105,7 @@ func parseEvaluateSignalsExtra(extra []interface{}) evaluateSignalsExtra {
 	return e
 }
 
-func (c *Classifier) appendAuthzFromHeaders(results *SignalResults, headers map[string]string, forceEvaluateAll bool) error {
-	usedSignals := c.getUsedSignals()
-	if forceEvaluateAll {
-		usedSignals = c.getAllSignalTypes()
-	}
+func (c *Classifier) evaluateAuthzFromHeaders(results *SignalResults, headers map[string]string, usedSignals map[string]bool) error {
 	if !isSignalTypeUsed(usedSignals, config.SignalTypeAuthz) {
 		logging.Debugf("[Signal Computation] Authz signal not used in any decision, skipping evaluation")
 		return nil

--- a/src/semantic-router/pkg/classification/classifier_signal_context.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_context.go
@@ -52,6 +52,24 @@ func textForSignalFunc(text, uncompressedText string, skipCompressionSignals map
 // skipCompressionSignals: signal types that must use uncompressedText instead of text
 // imageURL: image URL for multimodal signals ("" when the request carries no image)
 func (c *Classifier) EvaluateAllSignalsWithContext(text string, contextText string, currentUserText string, priorUserMessages []string, nonUserMessages []string, hasPriorAssistantReply bool, forceEvaluateAll bool, uncompressedText string, skipCompressionSignals map[string]bool, convFacts ConversationFacts, imageURL string) *SignalResults {
+	return c.evaluateAllSignalsWithContextForDecisions(
+		text,
+		contextText,
+		currentUserText,
+		priorUserMessages,
+		nonUserMessages,
+		hasPriorAssistantReply,
+		forceEvaluateAll,
+		uncompressedText,
+		skipCompressionSignals,
+		convFacts,
+		imageURL,
+		c.Config.Decisions,
+		nil,
+	)
+}
+
+func (c *Classifier) evaluateAllSignalsWithContextForDecisions(text string, contextText string, currentUserText string, priorUserMessages []string, nonUserMessages []string, hasPriorAssistantReply bool, forceEvaluateAll bool, uncompressedText string, skipCompressionSignals map[string]bool, convFacts ConversationFacts, imageURL string, decisions []config.Decision, results *SignalResults) *SignalResults {
 	defer c.enterSignalEvaluationLoadGate()()
 	// Determine which signals (type:name) should be evaluated
 	var usedSignals map[string]bool
@@ -59,16 +77,14 @@ func (c *Classifier) EvaluateAllSignalsWithContext(text string, contextText stri
 		usedSignals = c.getAllSignalTypes()
 		logging.Debugf("[Signal Computation] Force evaluate all signals mode enabled")
 	} else {
-		usedSignals = c.getUsedSignals()
+		usedSignals = c.getUsedSignalsForDecisions(decisions)
 	}
 
 	textForSignal := textForSignalFunc(text, uncompressedText, skipCompressionSignals)
 	ready := c.signalReadiness()
 
-	results := &SignalResults{
-		Metrics:           &SignalMetricsCollection{},
-		SignalConfidences: make(map[string]float64),
-		SignalValues:      make(map[string]float64),
+	if results == nil {
+		results = newSignalResults()
 	}
 
 	var wg sync.WaitGroup
@@ -95,4 +111,12 @@ func (c *Classifier) EvaluateAllSignalsWithContext(text string, contextText stri
 	results = c.applySignalOutputPolicies(results)
 	results = c.applyProjections(results)
 	return results
+}
+
+func newSignalResults() *SignalResults {
+	return &SignalResults{
+		Metrics:           &SignalMetricsCollection{},
+		SignalConfidences: make(map[string]float64),
+		SignalValues:      make(map[string]float64),
+	}
 }

--- a/src/semantic-router/pkg/classification/classifier_signal_usage.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_usage.go
@@ -6,13 +6,12 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
-// getUsedSignals analyzes all decisions and returns which signals (type:name) are actually used.
-// This allows us to skip evaluation of unused signals for performance optimization.
+// getUsedSignalsForDecisions analyzes only the supplied decision candidates.
 // Returns a map with keys in format "type:name" (e.g., "keyword:math_keywords").
-func (c *Classifier) getUsedSignals() map[string]bool {
+func (c *Classifier) getUsedSignalsForDecisions(decisions []config.Decision) map[string]bool {
 	usedSignals := make(map[string]bool)
 
-	for _, decision := range c.Config.Decisions {
+	for _, decision := range decisions {
 		c.analyzeRuleCombination(decision.Rules, usedSignals)
 	}
 	c.expandProjectionDependencies(usedSignals)

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -46,12 +46,12 @@ func (r *OpenAIRouter) performDecisionEvaluation(originalModel string, history s
 		return "", 0.0, entropy.ReasoningDecision{}, "", nil
 	}
 
-	signals, authzErr := r.evaluateSignalsForDecision(originalModel, signalInput, history.nonUserMessages, ctx)
+	signals, decisionCandidates, authzErr := r.evaluateSignalsForDecision(originalModel, signalInput, history.nonUserMessages, ctx)
 	if authzErr != nil {
 		return "", 0, entropy.ReasoningDecision{}, "", authzErr
 	}
 
-	result, defaultModel := r.runDecisionEngine(originalModel, ctx, signals, r.decisionCandidatesForRequestModel(originalModel))
+	result, defaultModel := r.runDecisionEngine(originalModel, ctx, signals, decisionCandidates)
 	if result == nil {
 		return "", 0.0, entropy.ReasoningDecision{}, defaultModel, nil
 	}

--- a/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
@@ -31,11 +31,15 @@ func (r *OpenAIRouter) evaluateSignalsForDecision(
 	signalInput signalEvaluationInput,
 	nonUserMessages []string,
 	ctx *RequestContext,
-) (*classification.SignalResults, error) {
+) (*classification.SignalResults, []config.Decision, error) {
 	signalStart := time.Now()
 	signalCtx, signalSpan := tracing.StartSpan(ctx.TraceContext, tracing.SpanSignalEvaluation)
 
-	signals, authzErr := r.Classifier.EvaluateAllSignalsWithHeaders(
+	decisionCandidates := r.decisionCandidatesForRequestModel(originalModel)
+	if decisionCandidates == nil {
+		decisionCandidates = r.Config.Decisions
+	}
+	signals, scopedCandidates, authzErr := r.Classifier.EvaluateAllSignalsWithHeadersForDecisions(
 		signalInput.compressedText,
 		signalInput.allMessagesText,
 		signalInput.currentUserText,
@@ -45,6 +49,7 @@ func (r *OpenAIRouter) evaluateSignalsForDecision(
 		ctx.Headers,
 		false,
 		ctx.RequestImageURL,
+		decisionCandidates,
 		signalInput.evaluationText,
 		signalInput.skipCompressionSignals,
 		signalInput.conversationFacts,
@@ -56,7 +61,7 @@ func (r *OpenAIRouter) evaluateSignalsForDecision(
 			"stage":      "authz",
 			"error":      authzErr.Error(),
 		})
-		return nil, authzErr
+		return nil, nil, authzErr
 	}
 
 	signalLatency := time.Since(signalStart).Milliseconds()
@@ -65,7 +70,7 @@ func (r *OpenAIRouter) evaluateSignalsForDecision(
 	logSignalEvaluationResults(ctx, signalLatency, signals)
 	tracing.EndSignalSpan(signalSpan, collectMatchedSignalRules(signals), 1.0, signalLatency)
 	ctx.TraceContext = signalCtx
-	return signals, nil
+	return signals, scopedCandidates, nil
 }
 
 func ensureContextTokenCount(ctx *RequestContext, signalInput signalEvaluationInput) {
@@ -142,7 +147,7 @@ func (r *OpenAIRouter) runDecisionEngine(
 		if len(candidates) == 0 {
 			tracing.EndDecisionSpan(decisionSpan, 0.0, []string{}, r.Config.Strategy)
 			ctx.TraceContext = decisionCtx
-			return nil, ""
+			return nil, r.defaultModelForUnmatchedDecision(originalModel)
 		}
 		result, err = r.Classifier.EvaluateDecisionWithEngineForDecisions(signals, candidates)
 	} else {

--- a/src/semantic-router/pkg/extproc/req_filter_classification_signal_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_signal_test.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,76 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
+
+func TestEvaluateSignalsForDecisionReturnsAuthzScopedCandidates(t *testing.T) {
+	decisions := []config.Decision{
+		{
+			Name: "route-a",
+			Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{
+				{Type: config.SignalTypeAuthz, Name: "route-a"},
+			}},
+		},
+		{
+			Name: "route-b",
+			Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{
+				{Type: config.SignalTypeAuthz, Name: "route-b"},
+				{Type: config.SignalTypeContext, Name: "short"},
+			}},
+		},
+	}
+	bindings := []config.RoleBinding{
+		{Name: "route-a-users", Role: "route-a", Subjects: []config.Subject{{Kind: "User", Name: "alice"}}},
+		{Name: "route-b-users", Role: "route-b", Subjects: []config.Subject{{Kind: "User", Name: "bob"}}},
+	}
+	cfg := &config.RouterConfig{IntelligentRouting: config.IntelligentRouting{
+		Signals: config.Signals{
+			RoleBindings: bindings,
+			ContextRules: []config.ContextRule{{Name: "short", MinTokens: "0", MaxTokens: "10"}},
+		},
+		Decisions: decisions,
+	}}
+	classifier, err := classification.BuildClassifier(cfg, nil, nil, nil)
+	require.NoError(t, err)
+	router := &OpenAIRouter{Config: cfg, Classifier: classifier}
+	ctx := &RequestContext{
+		Headers:      map[string]string{"x-authz-user-id": "alice"},
+		TraceContext: context.Background(),
+	}
+
+	signals, candidates, err := router.evaluateSignalsForDecision(
+		"general",
+		signalEvaluationInput{
+			evaluationText:  "hello",
+			compressedText:  "hello",
+			allMessagesText: "hello",
+			currentUserText: "hello",
+		},
+		nil,
+		ctx,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"route-a"}, signals.MatchedAuthzRules)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "route-a", candidates[0].Name)
+}
+
+func TestRunDecisionEngineUsesDefaultForEmptyScopedAutoCandidates(t *testing.T) {
+	router := &OpenAIRouter{Config: &config.RouterConfig{
+		RouterOptions: config.RouterOptions{AutoModelNames: []string{"general"}},
+		BackendModels: config.BackendModels{DefaultModel: "fallback-model"},
+	}}
+	ctx := &RequestContext{TraceContext: context.Background()}
+
+	result, defaultModel := router.runDecisionEngine(
+		"general",
+		ctx,
+		&classification.SignalResults{},
+		[]config.Decision{},
+	)
+
+	assert.Nil(t, result)
+	assert.Equal(t, "fallback-model", defaultModel)
+}
 
 func TestPrepareSignalEvaluationInput_CombinesMessagesWithoutCompression(t *testing.T) {
 	router := &OpenAIRouter{


### PR DESCRIPTION
Closes #2647

## Purpose

- Evaluate the authz signal before the remaining routing signals.
- Conservatively partially evaluate candidate decision rule trees with known authz facts and remove only decisions that are definitely false.
- Derive non-authz signal usage from the retained candidates, then pass the same candidate set to the final decision engine so computation and result scopes stay aligned.
- Preserve existing all-signal behavior when `forceEvaluateAll` is enabled and preserve the default-model fallback when authz removes every auto-routing candidate.
- Affects: `Router`.

## Test Plan

- Run focused classifier and extproc package tests:
  - `go test ./pkg/classification ./pkg/extproc -count=1 -run 'FilterDecisionsByAuthz|GetUsedSignalsForDecisions|EvaluateAllSignalsWithHeadersForDecisions|EvaluateSignalsForDecisionReturnsAuthz|RunDecisionEngineUsesDefault'`
- Review formatting and patch integrity:
  - `git diff --check`

## Test Result

- Focused classification tests passed (`TestFilterDecisionsByAuthz`, `TestGetUsedSignalsForDecisions`, `TestEvaluateAllSignalsWithHeadersForDecisionsScopesNonAuthzWork`).
- Focused extproc tests passed (`TestEvaluateSignalsForDecisionReturnsAuthzScopedCandidates`, `TestRunDecisionEngineUsesDefaultForEmptyScopedAutoCandidates`).
- `git diff --check`: passed.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>