### PR TITLE
[Docs] fix markdownlint violations in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,8 +45,8 @@ Minor issues such as informational disclosures, logging errors, non-exploitable 
 
 When a security report is accepted, the fix process depends on the severity:
 
-* **CRITICAL and HIGH severity**: Fixes are developed in a private security fork and coordinated with the prenotification group before public disclosure.
-* **MODERATE and LOW severity**: Fixes are developed and submitted as public pull requests. These issues do not require embargo since they do not enable arbitrary code execution or significant data breach, and public visibility accelerates community review and adoption of the fix.
+- **CRITICAL and HIGH severity**: Fixes are developed in a private security fork and coordinated with the prenotification group before public disclosure.
+- **MODERATE and LOW severity**: Fixes are developed and submitted as public pull requests. These issues do not require embargo since they do not enable arbitrary code execution or significant data breach, and public visibility accelerates community review and adoption of the fix.
 
 The vLLM Semantic Router maintainer team reserves the right to adjust the disclosure approach on a case-by-case basis, taking into account factors such as active exploitation, unusual attack surface, or coordination requirements with vLLM or downstream vendors.
 
@@ -54,13 +54,13 @@ The vLLM Semantic Router maintainer team reserves the right to adjust the disclo
 
 For certain security issues of CRITICAL, HIGH, or MODERATE severity level, we may prenotify the vLLM vulnerability management team and certain organizations or vendors that ship vLLM Semantic Router. The purpose of this prenotification is to allow for a coordinated release of fixes for severe issues.
 
-* This prenotification will be in the form of a private email notification. It may also include adding security contacts to the GitHub security advisory, typically a few days before release.
+- This prenotification will be in the form of a private email notification. It may also include adding security contacts to the GitHub security advisory, typically a few days before release.
 
-* If you wish to be added to the prenotification group, please contact the vLLM Semantic Router maintainer team and copy the members of the [vLLM vulnerability management team](https://docs.vllm.ai/en/latest/contributing/vulnerability_management.html). Each vendor contact will be analyzed on a case-by-case basis.
+- If you wish to be added to the prenotification group, please contact the vLLM Semantic Router maintainer team and copy the members of the [vLLM vulnerability management team](https://docs.vllm.ai/en/latest/contributing/vulnerability_management.html). Each vendor contact will be analyzed on a case-by-case basis.
 
-* Organizations and vendors who either ship or use vLLM Semantic Router are eligible to join the prenotification group if they meet at least one of the following qualifications:
-    * Substantial internal deployment leveraging the upstream vLLM Semantic Router project.
-    * Established internal security teams and comprehensive compliance measures.
-    * Active and consistent contributions to the upstream vLLM Semantic Router project.
+- Organizations and vendors who either ship or use vLLM Semantic Router are eligible to join the prenotification group if they meet at least one of the following qualifications:
+  - Substantial internal deployment leveraging the upstream vLLM Semantic Router project.
+  - Established internal security teams and comprehensive compliance measures.
+  - Active and consistent contributions to the upstream vLLM Semantic Router project.
 
-* We may withdraw organizations from receiving future prenotifications if they release fixes or any other information about issues before they are public. Group membership may also change based on policy refinements for who may be included.
+- We may withdraw organizations from receiving future prenotifications if they release fixes or any other information about issues before they are public. Group membership may also change based on policy refinements for who may be included.


### PR DESCRIPTION
## Summary

Closes #2658.

`main` is currently failing the **Run pre-commit hooks check file lint** job, and every open PR inherits the failure because GitHub tests the merge with `main`.

`SECURITY.md` (added in #2651) mixes list marker styles and uses four-space nested indentation, which trips the repository's own markdownlint rules:

```
SECURITY.md:48:1 MD004/ul-style Unordered list style [Expected: dash; Actual: asterisk]
SECURITY.md:62:1 MD007/ul-indent Unordered list indentation [Expected: 2; Actual: 4]
... (12 violations total)
```

The `markdown-lint` target scans all `**/*.md`, so this fails regardless of what a given PR touches.

## Change

Ran `markdownlint --fix`. The diff is **purely stylistic** — list markers (`*` → `-`) and nested indentation (4 → 2 spaces) only. **No wording, links, or policy content changed.**

9 insertions, 9 deletions, one file.

## Verification

Before:
```
make markdown-lint   # SECURITY.md: 12 violations -> Error 1
```

After, running the exact CI command across all tracked markdown files:
```
$ git ls-files '*.md' | xargs markdownlint -c tools/linter/markdown/markdownlint.yaml
(no output — 905 files clean)
```

## Notes

- No functional impact; docs-only.
- Regression timeline on `main`'s pre-commit job: green at `1222d205` and `8fe6b342`, red starting at `a7788256` (the #2651 merge) and every commit since.
- cc @arijitroy003 as the author of #2651 — the content is untouched, this only aligns the formatting with the repo linter.
