### PR TITLE
[Docs] improve documentation version badge alignment and spacing

### DIFF
--- a/website/src/css/docs.css
+++ b/website/src/css/docs.css
@@ -48,8 +48,17 @@
 }
 
 .theme-doc-version-badge {
-  background: rgba(17, 17, 17, 0.08);
+  display: block;
+  width: fit-content;
+  margin: 0 0 1rem auto;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--site-border);
+  border-radius: 999px;
+  background: rgba(17, 17, 17, 0.055);
   color: var(--site-text);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .site-docs-shell .theme-doc-markdown,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2659 

## Purpose

- Right-align the version badge shown on documentation detail pages.
- Refine the badge padding, border, typography, and background so it reads clearly as page-level metadata.
- Set the spacing below the badge to `1rem`, matching the spacing below the breadcrumbs.
- Improve the visual hierarchy between breadcrumbs, version metadata, and document content.
- This change affects the `Docs` module only, specifically `website/src/css/docs.css`.

## Test Plan

- Run `npm run lint` from the `website` directory.
- Run `npx docusaurus build --locale en` to verify that the English documentation site builds successfully.
- Open `/docs/intro` and inspect the version badge at desktop and mobile viewport sizes.
- Confirm that:
  - The badge is right-aligned with the document content.
  - The spacing below the badge is `1rem` / `16px`.
  - The badge remains visible and readable.
  - The page has no horizontal overflow.

This validation is sufficient because the change is limited to presentation rules for the Docusaurus version badge and does not alter documentation content, routing, or runtime behavior.

## Test Result

- `npm run lint` passed.
- `npx docusaurus build --locale en` passed.
- Manually verified at `1440x900` and `390x844`.
- The computed badge bottom margin is `16px` at both viewport sizes.
- No horizontal overflow was detected.
- The build continues to report existing Docusaurus warnings about blog metadata, truncation markers, and Browserslist data; these warnings are unrelated to this change.
- No known follow-up blockers. Visual regression coverage is manual because the website currently has no focused screenshot test for this element.

Before change:
<img width="1882" height="822" alt="image" src="https://github.com/user-attachments/assets/26571107-c036-403c-b489-e0fec757da39" />

After change:
<img width="2012" height="954" alt="image" src="https://github.com/user-attachments/assets/9c45e355-6e24-4cb5-b836-8d810b251f2d" />



---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes (not applicable; this PR affects `Docs` only)
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.