### PR TITLE
[Router] close management API Phase 2 redaction gaps (#2463)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1586,8 +1586,15 @@ global:
             - config.read
             - data.read
           operator:
+            - health.read
+            - ready.read
+            - docs.read
+            - metrics.read
+            - classify.invoke
+            - config.read
             - config.write
             - learning.ingest
+            - data.read
             - data.write
           admin:
             - "*"

--- a/src/semantic-router/pkg/apiserver/config_redact.go
+++ b/src/semantic-router/pkg/apiserver/config_redact.go
@@ -5,10 +5,26 @@ package apiserver
 import (
 	"context"
 	"net/http"
+	"regexp"
 	"strings"
 )
 
 const redactedConfigValue = "[REDACTED]"
+
+// sensitiveAssignmentPattern matches YAML/JSON-style secret assignments that
+// sometimes appear inside parse/validation error strings.
+var sensitiveAssignmentPattern = regexp.MustCompile(
+	`(?i)((?:["']?(?:api[_-]?key|access[_-]?key|password|auth[_-]?password|client[_-]?secret|private[_-]?key|secret)["']?)\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}\]]+)`,
+)
+
+// scrubSecretsInErrorMessage removes plaintext credential assignments from
+// management API error messages so parse/deploy failures cannot leak secrets.
+func scrubSecretsInErrorMessage(message string) string {
+	if message == "" {
+		return message
+	}
+	return sensitiveAssignmentPattern.ReplaceAllString(message, "${1}"+redactedConfigValue)
+}
 
 // canViewSecrets reports whether the request principal may see plaintext
 // secrets in config dumps. Requires secret_view (admin via "*" by default).

--- a/src/semantic-router/pkg/apiserver/config_redact_test.go
+++ b/src/semantic-router/pkg/apiserver/config_redact_test.go
@@ -15,6 +15,64 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/services"
 )
 
+func TestScrubSecretsInErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "yaml api_key",
+			in:   `failed to parse: api_key: "plain-secret-value" near line 12`,
+			want: `failed to parse: api_key: [REDACTED] near line 12`,
+		},
+		{
+			name: "json password",
+			in:   `invalid config: {"password":"db-pass-canary"}`,
+			want: `invalid config: {"password":[REDACTED]}`,
+		},
+		{
+			name: "keeps api_key_env",
+			in:   `missing env for api_key_env: OPENAI_API_KEY`,
+			want: `missing env for api_key_env: OPENAI_API_KEY`,
+		},
+		{
+			name: "unquoted password",
+			in:   `Backup config is invalid: password: s3cretValue`,
+			want: `Backup config is invalid: password: [REDACTED]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scrubSecretsInErrorMessage(tc.in)
+			if got != tc.want {
+				t.Fatalf("scrubSecretsInErrorMessage() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteErrorResponseScrubsSecrets(t *testing.T) {
+	server := &ClassificationAPIServer{}
+	rr := httptest.NewRecorder()
+	server.writeErrorResponse(
+		rr,
+		http.StatusBadRequest,
+		"PARSE_ERROR",
+		`Failed to parse config: api_key: "redact-me-canary-value-0001"`,
+	)
+	body := rr.Body.String()
+	if strings.Contains(body, "redact-me-canary-value-0001") {
+		t.Fatalf("error response leaked canary: %s", body)
+	}
+	if !strings.Contains(body, redactedConfigValue) {
+		t.Fatalf("expected redacted placeholder in error body, got %s", body)
+	}
+}
+
 func TestRedactSensitiveConfigValue(t *testing.T) {
 	t.Parallel()
 

--- a/src/semantic-router/pkg/apiserver/middleware.go
+++ b/src/semantic-router/pkg/apiserver/middleware.go
@@ -69,7 +69,7 @@ func (s *ClassificationAPIServer) writeManagementError(
 	s.writeJSONResponse(w, statusCode, map[string]interface{}{
 		"error": map[string]interface{}{
 			"code":       code,
-			"message":    message,
+			"message":    scrubSecretsInErrorMessage(message),
 			"request_id": requestID,
 			"timestamp":  time.Now().UTC().Format(time.RFC3339),
 		},

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -393,7 +393,7 @@ func (s *ClassificationAPIServer) writeErrorResponse(w http.ResponseWriter, stat
 	errorResponse := map[string]interface{}{
 		"error": map[string]interface{}{
 			"code":      errorCode,
-			"message":   message,
+			"message":   scrubSecretsInErrorMessage(message),
 			"timestamp": time.Now().UTC().Format(time.RFC3339),
 		},
 	}

--- a/src/semantic-router/pkg/config/management_api.go
+++ b/src/semantic-router/pkg/config/management_api.go
@@ -65,6 +65,9 @@ func DefaultManagementAPIConfig() ManagementAPIConfig {
 // secret_view is admin-only (via ManagementPermWildcard). Viewer and operator
 // may call config.read routes such as GET /config/router, but secret fields are
 // redacted unless the principal has secret_view.
+//
+// Keep config/config.yaml global.services.management_api.auth.roles aligned with
+// these defaults; reference-config tests enforce that contract.
 func DefaultManagementAPIRoles() map[string][]string {
 	return map[string][]string{
 		"viewer": {

--- a/src/semantic-router/pkg/config/reference_config_global_test.go
+++ b/src/semantic-router/pkg/config/reference_config_global_test.go
@@ -59,6 +59,37 @@ func assertReferenceConfigManagementAPICoverage(t testingT, managementAPI map[st
 		reflect.TypeOf(ManagementAPITokenRef{}),
 		"global.services.management_api.auth.tokens",
 	)
+	assertReferenceConfigManagementAPIRolesAlign(t, mustMapAt(t, managementAPI, "auth", "roles"))
+}
+
+// assertReferenceConfigManagementAPIRolesAlign keeps the exhaustive reference
+// YAML role lists in sync with DefaultManagementAPIRoles so copying the sample
+// into a bearer deployment does not silently weaken operator permissions.
+func assertReferenceConfigManagementAPIRolesAlign(t testingT, roles map[string]interface{}) {
+	defaults := DefaultManagementAPIRoles()
+	for role, wantPerms := range defaults {
+		raw, ok := roles[role]
+		if !ok {
+			t.Fatalf("global.services.management_api.auth.roles missing %q", role)
+		}
+		gotList, ok := raw.([]interface{})
+		if !ok {
+			t.Fatalf("global.services.management_api.auth.roles.%s must be a list", role)
+		}
+		got := make(map[string]struct{}, len(gotList))
+		for _, item := range gotList {
+			perm, ok := item.(string)
+			if !ok {
+				t.Fatalf("global.services.management_api.auth.roles.%s entries must be strings", role)
+			}
+			got[perm] = struct{}{}
+		}
+		for _, want := range wantPerms {
+			if _, ok := got[want]; !ok {
+				t.Fatalf("global.services.management_api.auth.roles.%s missing permission %q (must match DefaultManagementAPIRoles)", role, want)
+			}
+		}
+	}
 }
 
 func assertReferenceConfigAPIServiceCoverage(t testingT, api map[string]interface{}) {

--- a/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
@@ -159,6 +159,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
@@ -142,6 +142,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
@@ -143,6 +143,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
@@ -148,6 +148,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
@@ -148,6 +148,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
@@ -154,6 +154,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
@@ -148,6 +148,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
@@ -160,6 +160,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
@@ -123,6 +123,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
@@ -124,6 +124,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
@@ -124,6 +124,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
@@ -136,6 +136,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
@@ -137,6 +137,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
@@ -134,6 +134,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
@@ -202,6 +202,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
@@ -176,6 +176,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""

--- a/src/semantic-router/pkg/k8s/testdata/output/17-embedding-multimodal.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/17-embedding-multimodal.yaml
@@ -170,6 +170,7 @@ global:
           queue_depth_estimation: false
     authz: {}
     ratelimit: {}
+    management_api: {}
     router_replay: {}
     startup_status:
       store_backend: ""


### PR DESCRIPTION
Closes #2463

## Purpose

- Completes the **Phase 2 closeout** for management API secret-safe views after Phase 1 auth landed in #2561.
- **What changed**
  - Align `config/config.yaml` `global.services.management_api.auth.roles.operator` with `DefaultManagementAPIRoles()` so the reference config grants operator the full intended permission set (reads + writes), not write-only permissions.
  - Scrub YAML/JSON-style secret assignments (e.g. `api_key: …`, `password: …`) from management API error messages via `scrubSecretsInErrorMessage`, wired through `writeErrorResponse` and auth middleware errors, so parse/deploy failures cannot leak credentials.
  - Enforce reference-config role alignment in tests so YAML roles cannot drift from Go defaults again.
  - Refresh k8s canonical-export golden outputs to include `management_api: {}` now that the service is part of the exported schema.
- **Why**
  - Copying the incomplete YAML operator role into a bearer deployment would silently weaken operator capabilities (e.g. no `config.read` / `classify.invoke`).
  - Config parse/deploy errors can echo snippet text that contains plaintext secrets; those must not appear in API error JSON.
- **Modules:** `Router` (management API / config contract). No CLI, Dashboard, Operator, or E2E behavior changes in this PR.

## Test Plan

Reviewers can validate with:

```bash
cd src/semantic-router
go test ./pkg/apiserver/ -count=1 -run 'Scrub|Redact|ConfigGet|ClassifierInfo|WriteError'
go test ./pkg/config/ -count=1 -run 'ReferenceConfig|ManagementAPI'