### PR TITLE
[Docs] Sync stale zh-Hans installation and projection documentation

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/agentgateway.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/agentgateway.md
@@ -1,0 +1,337 @@
+---
+translation:
+  source_commit: "9052d81a"
+  source_file: "docs/installation/k8s/agentgateway.md"
+  outdated: false
+---
+
+# 使用 agentgateway 安装
+
+本指南逐步介绍如何在 Kubernetes 上将 vLLM Semantic Router 与 [agentgateway](https://agentgateway.dev/) 集成。agentgateway 充当 OpenAI 兼容流量的 Gateway API 数据平面，而 vLLM Semantic Router 作为 Envoy ExtProc 服务器运行，对每个请求进行分类并修改请求体，然后 agentgateway 再将其转发给 vLLM。
+
+## 架构概览
+
+该部署由以下组件组成：
+
+- **vLLM Semantic Router**：通过 ExtProc 提供 prompt 分类、模型选择、请求修改和响应处理
+- **agentgateway**：提供 Kubernetes Gateway API 代理以及 `AgentgatewayBackend`、`HTTPRoute` 和 `AgentgatewayPolicy` 资源
+- **演示用 vLLM 兼容后端**：通过 OpenAI 兼容 API 提供基础模型和 LoRA adapter
+
+## 前提条件
+
+开始之前，请确保已安装以下工具：
+
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) - Docker 中的 Kubernetes（可选）
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) - Kubernetes CLI
+- [Helm](https://helm.sh/docs/intro/install/) - Kubernetes 包管理器
+
+本指南要求使用 agentgateway `v1.3.0-alpha.1` 或更高版本，因为其中使用了 ExtProc 的 `processingOptions` 和 `allowModeOverride` 字段，这些字段是在 `v1.2.1` 之后添加的。
+
+## 步骤 1：创建 Kind 集群（可选）
+
+创建用于测试的本地 Kubernetes 集群：
+
+```bash
+kind create cluster --name semantic-router-agentgateway
+
+# 验证集群已就绪
+kubectl wait --for=condition=Ready nodes --all --timeout=300s
+```
+
+## 步骤 2：安装 agentgateway
+
+安装 Kubernetes Gateway API CRD 和 agentgateway 控制平面：
+
+```bash
+export AGENTGATEWAY_VERSION=v1.3.0-alpha.1
+
+kubectl apply --server-side --force-conflicts \
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+
+helm upgrade -i agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds \
+  --create-namespace \
+  --namespace agentgateway-system \
+  --version "${AGENTGATEWAY_VERSION}" \
+  --set controller.image.pullPolicy=Always
+
+helm upgrade -i agentgateway oci://cr.agentgateway.dev/charts/agentgateway \
+  --namespace agentgateway-system \
+  --version "${AGENTGATEWAY_VERSION}" \
+  --set controller.image.pullPolicy=Always \
+  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true \
+  --wait
+
+kubectl get pods -n agentgateway-system
+```
+
+## 步骤 3：创建 agentgateway 代理
+
+创建一个使用 agentgateway GatewayClass 的 Gateway：
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: agentgateway-proxy
+  namespace: agentgateway-system
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+EOF
+
+kubectl wait --for=condition=Available deployment/agentgateway-proxy \
+  -n agentgateway-system \
+  --timeout=300s
+```
+
+## 步骤 4：部署演示 LLM
+
+部署一个轻量级 OpenAI 兼容模拟器，提供 `base-model` 以及 Semantic Router 演示配置所选择的 LoRA adapter 名称：
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-llama3-8b-instruct
+  template:
+    metadata:
+      labels:
+        app: vllm-llama3-8b-instruct
+    spec:
+      containers:
+      - name: vllm-sim
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.5.0
+        imagePullPolicy: IfNotPresent
+        args:
+        - --model
+        - base-model
+        - --port
+        - "8000"
+        - --max-loras
+        - "6"
+        - --lora-modules
+        - '{"name": "math-expert"}'
+        - '{"name": "science-expert"}'
+        - '{"name": "social-expert"}'
+        - '{"name": "humanities-expert"}'
+        - '{"name": "law-expert"}'
+        - '{"name": "general-expert"}'
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-llama3-8b-instruct
+  namespace: default
+  labels:
+    app: vllm-llama3-8b-instruct
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    targetPort: 8000
+    protocol: TCP
+  selector:
+    app: vllm-llama3-8b-instruct
+EOF
+
+kubectl wait --for=condition=Available deployment/vllm-llama3-8b-instruct \
+  -n default \
+  --timeout=300s
+```
+
+## 步骤 5：部署 vLLM Semantic Router
+
+在 `agentgateway-system` namespace 中安装 Semantic Router，以便 agentgateway ExtProc policy 可以直接引用 `semantic-router` service：
+
+```bash
+helm install semantic-router oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version v0.0.0-latest \
+  --namespace agentgateway-system \
+  -f https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/agentgateway/semantic-router-values/values.yaml \
+  --set config.global.router.streamed_body.enabled=true \
+  --set config.global.router.streamed_body.max_bytes=10485760 \
+  --set config.global.router.streamed_body.timeout_sec=30
+
+kubectl wait --for=condition=Available deployment/semantic-router \
+  -n agentgateway-system \
+  --timeout=600s
+```
+
+该 values 文件将 Semantic Router 配置为向 `vllm-llama3-8b-instruct.default.svc.cluster.local:8000` 发送流量，并选择 `math-expert`、`science-expert` 和 `general-expert` 等 adapter 名称。
+
+## 步骤 6：创建 agentgateway 路由资源
+
+为 vLLM 兼容后端创建 `AgentgatewayBackend`，并将 OpenAI 兼容请求路由到该后端：
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: semantic-router-vllm
+  namespace: agentgateway-system
+spec:
+  ai:
+    provider:
+      openai: {}
+      host: vllm-llama3-8b-instruct.default.svc.cluster.local
+      port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: semantic-router-vllm
+  namespace: agentgateway-system
+spec:
+  parentRefs:
+  - name: agentgateway-proxy
+    namespace: agentgateway-system
+  rules:
+  - backendRefs:
+    - name: semantic-router-vllm
+      namespace: agentgateway-system
+      group: agentgateway.dev
+      kind: AgentgatewayBackend
+EOF
+```
+
+这里有意省略了 `openai.model` 字段，使 agentgateway 可以在 Semantic Router 选择目标模型或 LoRA adapter 后，使用请求体中的模型名称。
+
+## 步骤 7：将 Semantic Router 作为 ExtProc 挂载
+
+创建一个 `AgentgatewayPolicy`，将请求和响应处理阶段发送到 Semantic Router ExtProc service：
+
+```bash
+kubectl apply -f- <<'EOF'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: semantic-router-extproc
+  namespace: agentgateway-system
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: agentgateway-proxy
+  traffic:
+    extProc:
+      backendRef:
+        name: semantic-router
+        namespace: agentgateway-system
+        port: 50051
+      processingOptions:
+        requestHeaderMode: Send
+        requestBodyMode: FullDuplexStreamed
+        responseHeaderMode: Send
+        responseBodyMode: Buffered
+        requestTrailerMode: Send
+        responseTrailerMode: Send
+        allowModeOverride: true
+EOF
+```
+
+项目自带的 agentgateway 示例显式启用全双工流式请求体。这是该示例特有的选择；其他代理默认配置和示例可以继续使用缓冲请求体。上面的 Semantic Router Helm 命令显式启用了 `global.router.streamed_body`，使 router 能够累积请求分块，并在流结束时处理完整请求体。
+
+agentgateway 不支持 `Streamed` 模式；其流式处理选项为 `FullDuplexStreamed`。可部署的 policy 位于 `deploy/kubernetes/agentgateway/extproc-policy.yaml`，与之匹配的 router 配置通过步骤 5 中的 Helm 命令传入。有关协议行为和验证清单，请参阅[流式 ExtProc 与即时响应](./streamed-extproc.md)。
+
+## 测试部署
+
+启动到 agentgateway 代理的端口转发：
+
+```bash
+kubectl port-forward -n agentgateway-system svc/agentgateway-proxy 8080:80
+```
+
+在另一个终端中，发送一个包含 `"model": "auto"` 的 OpenAI 兼容请求：
+
+```bash
+curl -i -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "auto",
+    "messages": [
+      {"role": "user", "content": "What is the derivative of f(x) = x^3?"}
+    ],
+    "max_tokens": 64,
+    "temperature": 0
+  }'
+```
+
+Semantic Router 应对数学 prompt 进行分类，选择配置的数学路由，并在 agentgateway 将请求转发给 vLLM 兼容后端之前修改请求中的模型。使用 `-i` 可检查 Semantic Router 的响应 header，例如所选模型的元数据。
+
+## 故障排除
+
+**agentgateway 代理未就绪：**
+
+```bash
+kubectl get gateway agentgateway-proxy -n agentgateway-system
+kubectl get deployment agentgateway-proxy -n agentgateway-system
+kubectl logs -n agentgateway-system deployment/agentgateway
+```
+
+**HTTPRoute 或 agentgateway 后端未被接受：**
+
+```bash
+kubectl describe httproute semantic-router-vllm -n agentgateway-system
+kubectl describe agentgatewaybackend semantic-router-vllm -n agentgateway-system
+```
+
+**Semantic Router 未响应 ExtProc：**
+
+```bash
+kubectl get pods -n agentgateway-system
+kubectl get svc semantic-router -n agentgateway-system
+kubectl logs -n agentgateway-system deployment/semantic-router
+kubectl describe agentgatewaypolicy semantic-router-extproc -n agentgateway-system
+```
+
+**演示 LLM 未响应：**
+
+```bash
+kubectl get pods -n default -l app=vllm-llama3-8b-instruct
+kubectl logs -n default deployment/vllm-llama3-8b-instruct
+```
+
+## 清理
+
+要删除整个部署，请运行：
+
+```bash
+kubectl delete agentgatewaypolicy semantic-router-extproc -n agentgateway-system
+kubectl delete httproute semantic-router-vllm -n agentgateway-system
+kubectl delete agentgatewaybackend semantic-router-vllm -n agentgateway-system
+kubectl delete gateway agentgateway-proxy -n agentgateway-system
+kubectl delete deployment vllm-llama3-8b-instruct -n default
+kubectl delete service vllm-llama3-8b-instruct -n default
+
+helm uninstall semantic-router -n agentgateway-system
+helm uninstall agentgateway -n agentgateway-system
+helm uninstall agentgateway-crds -n agentgateway-system
+
+kind delete cluster --name semantic-router-agentgateway
+```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/ai-gateway.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/ai-gateway.md
@@ -107,7 +107,7 @@ kind create cluster --name semantic-router-cluster
 kubectl wait --for=condition=Ready nodes --all --timeout=300s
 ```
 
-## 步骤 2：部署 vLLM Semantic Router 
+## 步骤 2：部署 vLLM Semantic Router
 
 使用 Helm 部署包含所有必需组件的 Semantic Router 服务：
 
@@ -253,7 +253,7 @@ kubectl logs -n vllm-semantic-router-system deployment/semantic-router
 kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/ai-gateway/aigw-resources/gwapi-resources.yaml
 kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/ai-gateway/aigw-resources/base-model.yaml
 
-# 删除 Semantic Router 
+# 删除 Semantic Router
 helm uninstall semantic-router -n vllm-semantic-router-system
 
 # 删除 AI gateway

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/ai-gateway.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/ai-gateway.md
@@ -1,6 +1,15 @@
+---
+translation:
+  source_commit: "07457dfa"
+  source_file: "docs/installation/k8s/ai-gateway.md"
+  outdated: false
+---
+
 # 使用 Envoy AI Gateway 安装
 
 本指南提供了在 Kubernetes 上将 vLLM Semantic Router 与 Envoy AI Gateway 集成的分步说明，以实现高级流量管理和 AI 特定功能。
+
+对于大型请求体或 Semantic Router 返回的流式即时响应，另请参阅[流式 ExtProc 与即时响应](./streamed-extproc)。该指南介绍了如何将 ExtProc 过滤器的请求体模式从 `BUFFERED` 切换为 `STREAMED`，以及流式 Chat Completions 客户端如何接收 looper 或 `fast_response` 的即时响应。
 
 ## 架构概览
 
@@ -72,6 +81,7 @@
 | [DeepInfra](https://deepinfra.com/docs/inference)            |          `{"name":"OpenAI","version":"v1/openai"}`           | [API Key](https://aigateway.envoyproxy.io/docs/api/#backendsecuritypolicyapikey) |   ✅    |
 | [DeepSeek](https://api-docs.deepseek.com/)                   |              `{"name":"OpenAI","version":"v1"}`              | [API Key](https://aigateway.envoyproxy.io/docs/api/#backendsecuritypolicyapikey) |   ✅    |
 | [Hunyuan](https://cloud.tencent.com/document/product/1729/111007) |              `{"name":"OpenAI","version":"v1"}`              | [API Key](https://aigateway.envoyproxy.io/docs/api/#backendsecuritypolicyapikey) |   ✅    |
+| [MiniMax](https://platform.minimaxi.com/document/introduction) |              `{"name":"OpenAI","version":"v1"}`              | [API Key](https://aigateway.envoyproxy.io/docs/api/#backendsecuritypolicyapikey) |   ✅    |
 | [Tencent LLM Knowledge Engine](https://www.tencentcloud.com/document/product/1255/70381?lang=en) |              `{"name":"OpenAI","version":"v1"}`              | [API Key](https://aigateway.envoyproxy.io/docs/api/#backendsecuritypolicyapikey) |   ✅    |
 | [Tetrate Agent Router Service (TARS)](https://router.tetrate.ai/) |              `{"name":"OpenAI","version":"v1"}`              | [API Key](https://aigateway.envoyproxy.io/docs/api/#backendsecuritypolicyapikey) |   ✅    |
 | [SambaNova](https://docs.sambanova.ai/sambastudio/latest/open-ai-api.html) |              `{"name":"OpenAI","version":"v1"}`              | [API Key](https://aigateway.envoyproxy.io/docs/api/#backendsecuritypolicyapikey) |   ✅    |
@@ -224,7 +234,7 @@ kubectl logs -n envoy-ai-gateway-system deployment/ai-gateway-controller
 kubectl get deployment -n envoy-ai-gateway-system
 ```
 
-** Semantic Router 无响应：**
+**Semantic Router 无响应：**
 
 ```bash
 # 检查 Semantic Router  pod 状态

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/gateway-api-inference-extension.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/gateway-api-inference-extension.md
@@ -1,53 +1,66 @@
+---
+translation:
+  source_commit: "74867e20"
+  source_file: "docs/installation/k8s/gateway-api-inference-extension.md"
+  outdated: false
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # 使用 Gateway API Inference Extension 安装
 
-本指南提供了将 vLLM Semantic Router (vSR) 与 Istio 和 Kubernetes Gateway API Inference Extension (GIE) 集成的分步说明。这种强大的组合允许您使用 Kubernetes 原生 API 管理自托管的 OpenAI 兼容模型，实现高级的 load-aware routing。
+本指南分步介绍如何将 vLLM Semantic Router (vSR) 与符合 Gateway API Inference Extension (GIE) 规范的推理网关集成。GIE 让您可以通过 `InferencePool` 等 Kubernetes 原生 API 管理自托管的 OpenAI 兼容模型，而 vSR 则通过网关的 ExtProc 集成提供感知提示词的模型路由能力。
 
 ## 架构概览
 
-部署包含三个主要组件：
+该部署由三个主要组件构成：
 
-- **vLLM Semantic Router**：基于请求内容对传入请求进行分类的智能核心。
-- **Istio & Gateway API**：网络网格和所有进入集群流量的前门。
-- **Gateway API Inference Extension (GIE)**：用于管理和扩展自托管模型后端的 Kubernetes 原生 API 集（`InferencePool` 等）。
+- **vLLM Semantic Router**：对传入请求进行分类并选择目标模型。
+- **符合 GIE 规范的推理网关**：提供 Kubernetes Gateway API 数据平面。本指南通过标签页分别介绍 Istio 和 agentgateway。
+- **Gateway API Inference Extension (GIE)**：提供 `InferencePool` 等 Kubernetes 原生推理 API，用于感知负载的后端选择。
 
 ## 集成优势
 
-将 vSR 与 Istio 和 GIE 集成，为服务 LLM 提供了一个强大的 Kubernetes 原生解决方案，具有以下关键优势：
+将 vSR 与 GIE 集成，可为 LLM 服务提供一个稳健的 Kubernetes 原生解决方案，并带来以下几项主要优势：
 
 ### 1. **Kubernetes 原生 LLM 管理**
 
-使用熟悉的自定义资源定义 (CRD) 通过 `kubectl` 直接管理您的模型、路由和扩展策略。
+使用熟悉的自定义资源定义 (CRD)，直接通过 `kubectl` 管理模型、路由和扩缩容策略。
 
-### 2. **智能模型和副本路由**
+### 2. **智能模型与副本路由**
 
-结合 vSR 基于提示词的模型路由与 GIE 的智能负载感知副本选择。这确保请求不仅发送到正确的模型，还发送到最健康的副本，一次高效跳转完成所有操作。
+将 vSR 基于提示词的模型路由与 GIE 智能且感知负载的副本选择相结合。这样可以确保请求不仅会发送到正确的模型，还会发送到运行状况最佳的副本，并且整个过程只需一次高效转发。
 
-### 3. **保护模型免受过载**
+### 3. **保护模型免受过载影响**
 
-内置调度器跟踪 GPU 负载和请求队列，在高需求时自动卸载流量，防止模型服务器崩溃。
+内置调度器会跟踪后端负载和请求队列，并自动卸载流量，防止模型服务器在高负载下崩溃。
 
 ### 4. **深度可观测性**
 
-从高级别 Gateway 指标和详细的 vSR 性能数据（如 token 使用和分类准确性）获取洞察，以监控和排查整个 AI 堆栈。
+结合高层 Gateway 指标与详细的 vSR 性能数据（例如 token 用量和分类准确率），洞察、监控并排查整个 AI 技术栈的问题。
 
-### 5. **安全的多租户**
+### 5. **安全多租户**
 
-使用标准 Kubernetes 命名空间和 `HTTPRoute` 隔离租户工作负载。在共享公共安全网关基础设施的同时应用速率限制和其他策略。
+使用标准 Kubernetes 命名空间和 `HTTPRoute` 隔离租户工作负载。在共享安全的通用网关基础设施时，还可应用速率限制和其他策略。
 
-## 支持的后端模型
+## 支持的后端模型和 API
 
-此架构旨在与任何暴露 **OpenAI 兼容 API** 的自托管模型配合使用。本指南中的演示模型使用 `vLLM` 服务 Llama3 和 Phi-3，但您可以轻松地用自己的模型服务器替换它们。
+本指南中的演示模型使用 llm-d 推理模拟器，通过 **OpenAI 兼容 API** 模拟 Llama3 和 Phi-4。借助该模拟器，您可以在本地 kind 集群中运行本指南的操作流程，而无需 GPU 或下载模型。您可以将其替换为自己的模型服务器，前提是 Semantic Router 配置、网关路由资源和 GIE 后端配置在请求格式与后端目标上保持一致。
+
+OpenAI 兼容 API 并非唯一支持的选项。agentgateway 自定义提供商可以声明提供商原生格式，例如 OpenAI 聊天补全 (chat completions)、Anthropic 消息 (messages)、响应 (responses)、嵌入 (embeddings)、token 计数 (token counting) 和实时 (realtime) API，并可将这些提供商路由到主机、Kubernetes `Service` 或 `InferencePool`。GIE 端点选择器 (endpoint picker) 实现还可以通过解析器配置支持其他请求格式；例如，llm-d EPP 解析器框架包含 OpenAI、Anthropic、vLLM HTTP、vLLM gRPC、Vertex AI 和透传 (passthrough) 解析器。
+
+有关详细信息，请参阅 agentgateway 的[自定义提供商](https://agentgateway.dev/docs/kubernetes/main/llm/providers/custom/)指南和 llm-d EPP 的[请求解析器文档](https://github.com/llm-d/llm-d-router/blob/main/pkg/epp/framework/plugins/requesthandling/parsers/README.md)。
 
 ## 前置条件
 
 开始之前，请确保已安装以下工具：
 
 - [Docker](https://docs.docker.com/get-docker/) 或其他容器运行时。
-- [kind](https://kind.sigs.k8s.io/) v0.22+ 或任何 Kubernetes 1.29+ 集群。
+- [kind](https://kind.sigs.k8s.io/) v0.22+ 或任意 Kubernetes 1.29+ 集群。
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.30+。
 - [Helm](https://helm.sh/) v3.14+。
-- [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/) v1.28+。
-- 存储在 `HF_TOKEN` 环境变量中的 Hugging Face 令牌，示例 vLLM 部署需要它来下载模型。
+- 如果选择 Istio 标签页，则需要 [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/) v1.28+。
 
 您可以使用以下命令验证工具链版本：
 
@@ -60,16 +73,44 @@ istioctl version --remote=false
 
 ## 步骤 1：创建 Kind 集群（可选）
 
-如果您没有 Kubernetes 集群，可以创建一个本地集群进行测试：
+如果您还没有 Kubernetes 集群，可以创建一个本地集群用于测试：
 
 ```bash
 kind create cluster --name vsr-gie
 
-# 验证集群就绪
+# 验证集群已就绪
 kubectl wait --for=condition=Ready nodes --all --timeout=300s
 ```
 
-## 步骤 2：安装 Istio
+## 步骤 2：安装 Gateway API 和 GIE CRD
+
+在安装网关实现之前，先安装 Gateway API 和 GIE 的共享 CRD：
+
+```bash
+export GATEWAY_API_VERSION=v1.5.0
+export GIE_VERSION=v1.5.0
+
+# 安装 Gateway API CRD
+kubectl apply --server-side --force-conflicts \
+  -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+
+# 安装 Gateway API Inference Extension CRD
+kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
+
+# 验证 CRD 已安装
+kubectl get crd | grep 'gateway.networking.k8s.io'
+kubectl get crd | grep 'inference.networking.k8s.io'
+```
+
+## 步骤 3：安装推理网关
+
+选择您要使用的推理网关。每个标签页仅包含相应网关特有的安装步骤。
+
+<Tabs groupId="gie-gateway" defaultValue="istio" values={[
+  {label: 'Istio', value: 'istio'},
+  {label: 'agentgateway', value: 'agentgateway'},
+]}>
+<TabItem value="istio">
 
 安装支持 Gateway API 和外部处理的 Istio：
 
@@ -80,61 +121,86 @@ curl -L https://istio.io/downloadIstio | ISTIO_VERSION=$ISTIO_VERSION sh -
 export PATH="$PWD/istio-$ISTIO_VERSION/bin:$PATH"
 istioctl install -y --set profile=minimal --set values.pilot.env.ENABLE_GATEWAY_API=true
 
-# 验证 Istio 就绪
-kubectl wait --for=condition=Available deployment/istiod -n istio-system --timeout=300s
+# 验证 Istio 已就绪
+kubectl wait --for=condition=Available deployment/istiod \
+  -n istio-system \
+  --timeout=300s
 ```
 
-## 步骤 3：安装 Gateway API & GIE CRDs
+</TabItem>
+<TabItem value="agentgateway">
 
-安装标准 Gateway API 和 Inference Extension 的自定义资源定义 (CRD)：
+安装已启用推理扩展支持的 agentgateway：
 
 ```bash
-# 安装 Gateway API CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+export AGENTGATEWAY_VERSION=v1.3.0-alpha.1
 
-# 安装 Gateway API Inference Extension CRDs
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.1.0/manifests.yaml
+# 安装 agentgateway CRD
+helm upgrade -i --create-namespace \
+  --namespace agentgateway-system \
+  --version "${AGENTGATEWAY_VERSION}" \
+  agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds
 
-# 验证 CRDs 已安装
-kubectl get crd | grep 'gateway.networking.k8s.io'
-kubectl get crd | grep 'inference.networking.k8s.io'
+# 安装已启用推理扩展支持的 agentgateway
+helm upgrade -i -n agentgateway-system \
+  agentgateway oci://cr.agentgateway.dev/charts/agentgateway \
+  --version "${AGENTGATEWAY_VERSION}" \
+  --set inferenceExtension.enabled=true
+
+# 验证 agentgateway 已就绪
+kubectl get pods -n agentgateway-system
 ```
+
+本指南使用 agentgateway `v1.3.0-alpha.1` 或更高版本，以便 ExtProc 策略可以设置 `processingOptions` 和 `allowModeOverride`。
+
+</TabItem>
+</Tabs>
 
 ## 步骤 4：部署演示 LLM 服务器
 
-部署两个 `vLLM` 实例（Llama3 和 Phi-3）作为后端。它们将从 Hugging Face 自动下载。
+部署两个轻量级推理模拟器实例 Llama3 和 Phi-4 作为后端。这些模拟器部署不需要 GPU 或 Hugging Face 令牌，其标签与本指南后续使用的 `InferencePool` 选择器相匹配。
 
 ```bash
-# 为模型创建命名空间和密钥
-kubectl create namespace llm-backends --dry-run=client -o yaml | kubectl apply -f -
-kubectl -n llm-backends create secret generic hf-token --from-literal=token=$HF_TOKEN
+# 部署模拟器模型服务器
+kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inference-sim.yaml
 
-# 部署模型服务器
-kubectl -n llm-backends apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/vLlama3.yaml
-kubectl -n llm-backends apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/vPhi4.yaml
-
-# 等待模型就绪（可能需要几分钟）
-kubectl -n llm-backends wait --for=condition=Ready pods --all --timeout=10m
+# 等待模拟器模型就绪
+kubectl wait --for=condition=Available deployment/vllm-llama3-8b-instruct --timeout=300s
+kubectl wait --for=condition=Available deployment/phi4-mini --timeout=300s
 ```
+
+该演示清单在 `default` 命名空间中运行，并公开名为 `vllm-llama3-8b-instruct` 和 `phi4-mini` 的服务。
 
 ## 步骤 5：部署 vLLM Semantic Router
 
-使用官方 Helm chart 部署 vLLM Semantic Router。此组件将作为 `ext_proc` 服务器运行，Istio 调用它进行路由决策。
+使用官方 Helm chart 部署 vLLM Semantic Router。该组件作为 ExtProc 服务器运行，由所选网关调用以执行路由决策。
 
 ```bash
 helm upgrade -i semantic-router oci://ghcr.io/vllm-project/charts/semantic-router \
   --version v0.0.0-latest \
   --namespace vllm-semantic-router-system \
   --create-namespace \
-  -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/ai-gateway/semantic-router-values/values.yaml
+  -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/semantic-router-values/values.yaml
 
-# 等待路由就绪
-kubectl -n vllm-semantic-router-system wait --for=condition=Available deploy/semantic-router --timeout=10m
+# 等待路由器就绪
+kubectl -n vllm-semantic-router-system wait \
+  --for=condition=Available deploy/semantic-router \
+  --timeout=10m
 ```
+
+该 values 文件将 vSR 配置为：一般提示词选择 `llama3-8b`，数学提示词选择 `phi4-mini`。
 
 ## 步骤 6：部署 Gateway 和路由逻辑
 
-应用最后一组资源来创建面向公众的 Gateway 并将所有组件连接在一起。这包括 `Gateway`、GIE 的 `InferencePools`、流量匹配的 `HTTPRoutes` 和 Istio 的 `EnvoyFilter`。
+应用网关特定资源，以创建面向外部的 `Gateway`、将 vSR 作为 ExtProc 服务附加到网关，并将选定的模型路由到 GIE `InferencePool`。
+
+<Tabs groupId="gie-gateway" defaultValue="istio" values={[
+  {label: 'Istio', value: 'istio'},
+  {label: 'agentgateway', value: 'agentgateway'},
+]}>
+<TabItem value="istio">
+
+应用现有的 Istio 网关、`InferencePool`、`HTTPRoute`、`DestinationRule` 和 `EnvoyFilter` 资源：
 
 ```bash
 # 应用所有路由和网关资源
@@ -146,27 +212,117 @@ kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/
 kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/destinationrule.yaml
 kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/envoyfilter.yaml
 
-# 验证 Gateway 已被 Istio 编程
+# 验证 Istio 已配置 Gateway
 kubectl wait --for=condition=Programmed gateway/inference-gateway --timeout=120s
+kubectl wait --for=condition=Available deployment/llm-d-inference-scheduler-llama3-8b --timeout=300s
+kubectl wait --for=condition=Available deployment/llm-d-inference-scheduler-phi4-mini --timeout=300s
 ```
+
+Istio 特有的 `EnvoyFilter` 会插入调用 `semantic-router` 服务的 ExtProc 过滤器。
+
+</TabItem>
+<TabItem value="agentgateway">
+
+创建由 agentgateway 支持的 `Gateway`，应用共享的 GIE `InferencePool` 和 `HTTPRoute` 资源，并通过 `AgentgatewayPolicy` 附加 vSR：
+
+```bash
+# 创建 agentgateway 推理 Gateway
+kubectl apply -f- <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: inference-gateway
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: All
+EOF
+
+# 应用共享的 GIE 路由资源
+kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-llama.yaml
+kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-phi4.yaml
+kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-llama-pool.yaml
+kubectl apply -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-phi4-pool.yaml
+
+# 将 Semantic Router 作为网关 ExtProc 服务附加到网关
+kubectl apply -f- <<'EOF'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: semantic-router-extproc
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: inference-gateway
+  traffic:
+    phase: PreRouting
+    extProc:
+      backendRef:
+        name: semantic-router
+        namespace: vllm-semantic-router-system
+        port: 50051
+      processingOptions:
+        requestHeaderMode: Send
+        requestBodyMode: Buffered
+        responseHeaderMode: Send
+        responseBodyMode: Buffered
+        allowModeOverride: true
+EOF
+
+# 验证 agentgateway 已配置 Gateway
+kubectl wait --for=condition=Programmed gateway/inference-gateway --timeout=120s
+kubectl wait --for=condition=Available deployment/llm-d-inference-scheduler-llama3-8b --timeout=300s
+kubectl wait --for=condition=Available deployment/llm-d-inference-scheduler-phi4-mini --timeout=300s
+```
+
+agentgateway 使用 `AgentgatewayPolicy` 配置 ExtProc，因此不需要 Istio `DestinationRule` 或 `EnvoyFilter` 资源。该策略使用 `phase: PreRouting`，以便 vSR 在 agentgateway 计算 `HTTPRoute` 请求头匹配条件之前添加 `x-selected-model`。
+
+</TabItem>
+</Tabs>
 
 ## 测试部署
 
-### 方式 1：端口转发
+### 端口转发
 
-设置端口转发以从本地机器访问网关。
+设置端口转发，以便从本地计算机访问所选网关。
+
+<Tabs groupId="gie-gateway" defaultValue="istio" values={[
+  {label: 'Istio', value: 'istio'},
+  {label: 'agentgateway', value: 'agentgateway'},
+]}>
+<TabItem value="istio">
 
 ```bash
-# Gateway 服务名为 'inference-gateway-istio'，位于 default 命名空间
+# Gateway 服务名为 inference-gateway-istio
 kubectl port-forward svc/inference-gateway-istio 8080:80
 ```
 
+</TabItem>
+<TabItem value="agentgateway">
+
+```bash
+# agentgateway 为 Gateway 创建服务
+kubectl port-forward svc/inference-gateway 8080:80
+```
+
+</TabItem>
+</Tabs>
+
 ### 发送测试请求
 
-端口转发激活后，您可以向 `localhost:8080` 发送 OpenAI 兼容请求。
+端口转发启动后，向 `localhost:8080` 发送 OpenAI 兼容请求。
 
 **测试 1：显式请求模型**
-此请求绕过 Semantic Router 的逻辑，直接发送到指定的模型池。
+
+此请求应由 Llama 模拟器处理。如果要检查 `x-inference-pod` 和 `x-vsr-selected-model` 等响应头，请在命令中添加 `-i`。
 
 ```bash
 curl -sS http://localhost:8080/v1/chat/completions \
@@ -178,7 +334,8 @@ curl -sS http://localhost:8080/v1/chat/completions \
 ```
 
 **测试 2：让 Semantic Router 选择模型**
-通过设置 `"model": "auto"`，您让 vSR 对 prompt 进行分类。它将识别这是一个"math"查询并添加 `x-selected-model: phi4-mini` header，`HTTPRoute` 使用它来路由请求。
+
+通过设置 `"model": "auto"`，您可以让 vSR 对提示词进行分类。它会将此请求识别为数学查询并添加 `x-selected-model: phi4-mini` 请求头，随后 `HTTPRoute` 使用该请求头将请求路由到 Phi-4 `InferencePool`。在 agentgateway 标签页中，`AgentgatewayPolicy` 在 `PreRouting` 阶段运行，因此在路由匹配之前该请求头就已存在。
 
 ```bash
 curl -sS http://localhost:8080/v1/chat/completions \
@@ -192,72 +349,135 @@ curl -sS http://localhost:8080/v1/chat/completions \
 
 ## 故障排除
 
-**问题：CRDs 缺失**
-如果看到类似 `no matches for kind "InferencePool"` 的错误，检查 CRDs 是否已安装。
+**问题：缺少 CRD**
+
+如果看到类似 `no matches for kind "InferencePool"` 的错误，请检查是否已安装 CRD。
 
 ```bash
-# 检查 GIE CRDs
+# 检查 GIE CRD
 kubectl get crd | grep inference.networking.k8s.io
 ```
 
 **问题：Gateway 未就绪**
-如果 `kubectl port-forward` 失败或请求超时，检查 Gateway 状态。
+
+如果 `kubectl port-forward` 失败或请求超时，请检查 Gateway 状态。
 
 ```bash
-# "Programmed" 条件应为 "True"
+# Programmed 条件应为 True
 kubectl get gateway inference-gateway -o yaml
 ```
 
-**问题：vSR 未被调用**
-如果请求正常但路由似乎不正确，检查 Istio 代理日志中的 `ext_proc` 错误。
+<Tabs groupId="gie-gateway" defaultValue="istio" values={[
+  {label: 'Istio', value: 'istio'},
+  {label: 'agentgateway', value: 'agentgateway'},
+]}>
+<TabItem value="istio">
+
+**问题：未调用 vSR**
+
+如果请求可以正常处理，但路由似乎不正确，请检查 Istio 代理日志中是否存在 `ext_proc` 错误。
 
 ```bash
-# 获取 Istio gateway pod 名称
+# 获取 Istio 网关 Pod 名称
 export ISTIO_GW_POD=$(kubectl get pod -l istio=ingressgateway -o jsonpath='{.items[0].metadata.name}')
 
 # 检查其日志
 kubectl logs $ISTIO_GW_POD -c istio-proxy | grep ext_proc
 ```
 
+</TabItem>
+<TabItem value="agentgateway">
+
+**问题：agentgateway 或 ExtProc 策略未就绪**
+
+检查 agentgateway 控制器、生成的 Gateway 工作负载和 `AgentgatewayPolicy`。
+
+```bash
+kubectl get pods -n agentgateway-system
+kubectl get deployment inference-gateway
+kubectl logs -n agentgateway-system deployment/agentgateway
+kubectl describe agentgatewaypolicy semantic-router-extproc
+```
+
+</TabItem>
+</Tabs>
+
 **问题：请求失败**
-检查 vLLM Semantic Router 和后端模型的日志。
+
+检查 vSR 和后端模型的日志。
 
 ```bash
 # 检查 vSR 日志
 kubectl logs deploy/semantic-router -n vllm-semantic-router-system
 
-# 检查 Llama3 后端日志
-kubectl logs -n llm-backends -l app=vllm-llama3-8b-instruct
+# 检查后端日志
+kubectl logs deployment/vllm-llama3-8b-instruct
+kubectl logs deployment/phi4-mini
 ```
 
 ## 清理
 
-要删除本指南中创建的所有资源，运行以下命令。
+要删除本指南中创建的所有资源，请运行与您所用网关标签页对应的清理命令。
+
+<Tabs groupId="gie-gateway" defaultValue="istio" values={[
+  {label: 'Istio', value: 'istio'},
+  {label: 'agentgateway', value: 'agentgateway'},
+]}>
+<TabItem value="istio">
 
 ```bash
-# 1. 删除所有已应用的 Kubernetes 资源
-kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/gateway.yaml
-kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-llama.yaml
-kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-phi4.yaml
-kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-llama-pool.yaml
-kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-phi4-pool.yaml
-kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/destinationrule.yaml
+# 删除路由和网关资源
 kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/envoyfilter.yaml
-kubectl delete ns llm-backends
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/destinationrule.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-phi4-pool.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-llama-pool.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-phi4.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-llama.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/istio/gateway.yaml
 
-# 2. 卸载 Helm releases
+# 删除演示模型
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inference-sim.yaml
+
+# 卸载 Helm release 和 Istio
 helm uninstall semantic-router -n vllm-semantic-router-system
-
-# 3. 卸载 Istio
 istioctl uninstall -y --purge
 
-# 4. 删除 kind 集群（可选）
+# 删除 kind 集群（如果已创建）
 kind delete cluster --name vsr-gie
 ```
 
+</TabItem>
+<TabItem value="agentgateway">
+
+```bash
+# 删除网关特有资源
+kubectl delete agentgatewaypolicy semantic-router-extproc --ignore-not-found
+kubectl delete gateway inference-gateway --ignore-not-found
+
+# 删除共享的 GIE 路由资源
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-phi4-pool.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/httproute-llama-pool.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-phi4.yaml
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inferencepool-llama.yaml
+
+# 删除演示模型
+kubectl delete -f https://raw.githubusercontent.com/vllm-project/semantic-router/main/deploy/kubernetes/llmd-base/inference-sim.yaml
+
+# 卸载 Helm release
+helm uninstall semantic-router -n vllm-semantic-router-system
+helm uninstall agentgateway -n agentgateway-system
+helm uninstall agentgateway-crds -n agentgateway-system
+
+# 删除 kind 集群（如果已创建）
+kind delete cluster --name vsr-gie
+```
+
+</TabItem>
+</Tabs>
+
 ## 后续步骤
 
-- **自定义路由**：修改 `semantic-router` Helm chart 的 `values.yaml` 文件以定义您自己的路由类别和规则。
-- **添加您自己的模型**：用您自己的 OpenAI 兼容模型服务器替换演示 Llama3 和 Phi-3 部署。
-- **探索高级 GIE 功能**：查看使用 `InferenceObjective` 实现更高级的自动扩缩和调度策略。
-- **监控性能**：将您的 Gateway 和 vSR 与 Prometheus 和 Grafana 集成以构建监控仪表板。
+- **自定义路由**：修改 `semantic-router` Helm chart 的 `values.yaml` 文件，定义您自己的路由类别和规则。
+- **添加您自己的模型**：将演示用的 Llama3 和 Phi-4 部署替换为您自己的 OpenAI 兼容模型服务器。
+- **探索 GIE 高级功能**：研究如何使用 `InferenceObjective` 实现更高级的自动扩缩容和调度策略。
+- **监控性能**：将 Gateway 和 vSR 与 Prometheus 和 Grafana 集成，以构建监控仪表板。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/operator.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/operator.md
@@ -1,6 +1,10 @@
 ---
 sidebar_position: 3
 sidebar_label: 使用 Operator 安装
+translation:
+  source_commit: "5ff00978"
+  source_file: "docs/installation/k8s/operator.md"
+  outdated: false
 ---
 
 # 使用 Operator 安装
@@ -585,9 +589,9 @@ spec:
 
 **operator 行为：**
 
-1. 在 pod spec 中部署两个容器：semantic router + Envoy sidecar
-2. Envoy 负责 ingress，并通过 ExtProc gRPC 转发到 semantic router
-3. status 显示 `gatewayMode: "standalone"`
+- 在 pod spec 中部署两个容器：semantic router + Envoy sidecar
+- Envoy 负责 ingress，并通过 ExtProc gRPC 转发到 semantic router
+- status 显示 `gatewayMode: "standalone"`
 
 ### Gateway Integration 模式
 
@@ -809,9 +813,1046 @@ spec:
     fsGroup: 2000
 ```
 
-::::caution OpenShift Note
+:::caution OpenShift Note
 在 OpenShift 上，建议省略 `runAsUser` 与 `fsGroup`，让 SCC 自动分配 UID/GID。
-::::
+:::
+
+## 配置参考
+
+### 镜像配置
+
+```yaml
+spec:
+  image:
+    repository: ghcr.io/vllm-project/semantic-router/extproc
+    tag: latest
+    pullPolicy: IfNotPresent
+    imageRegistry: ""  # 可选：自定义镜像仓库前缀
+
+  # 可选：镜像拉取 Secret
+  imagePullSecrets:
+    - name: ghcr-secret
+```
+
+### Service 配置
+
+```yaml
+spec:
+  service:
+    type: ClusterIP  # 或 NodePort、LoadBalancer
+
+    grpc:
+      port: 50051
+      targetPort: 50051
+
+    api:
+      port: 8080
+      targetPort: 8080
+
+    metrics:
+      enabled: true
+      port: 9190
+      targetPort: 9190
+```
+
+### 持久化配置
+
+```yaml
+spec:
+  persistence:
+    enabled: true
+    storageClassName: "standard"  # 根据你的集群调整
+    accessMode: ReadWriteOnce
+    size: 10Gi
+
+    # 可选：使用现有 PVC
+    existingClaim: "my-existing-pvc"
+
+    # 可选：PVC annotation
+    annotations:
+      backup.velero.io/backup-volumes: "models"
+```
+
+:::info 存储验证
+operator 会在创建 PVC 之前验证指定的 StorageClass 是否存在。如果省略 `storageClassName`，则使用集群的默认 StorageClass。
+:::
+
+**StorageClass 示例：**
+
+- **AWS EKS**：`gp3-csi`、`gp2`
+- **GKE**：`standard`、`premium-rwo`
+- **Azure AKS**：`managed`、`managed-premium`
+- **OpenShift**：`gp3-csi`、`thin`、`ocs-storagecluster-ceph-rbd`
+
+### 语义缓存后端
+
+operator 支持多种语义缓存后端。通过缓存相似查询及其响应，可以显著降低延迟和 token 用量。
+
+:::warning 前置条件
+operator **不会**部署 Redis 或 Milvus。在将其用作缓存后端之前，你必须在集群中单独部署这些服务。operator 只负责配置 SemanticRouter，使其连接到现有的 Redis/Milvus 部署。
+
+部署示例请参阅下文的 [Redis](#deploying-redis) 与 [Milvus](#deploying-milvus) 小节。
+
+**替代方案：** 如果希望自动部署 Redis/Milvus，可以考虑使用 [Helm chart](https://github.com/vllm-project/semantic-router/tree/main/deploy/helm)，它可以将缓存后端作为 Helm chart 依赖项进行部署。
+:::
+
+#### 支持的后端
+
+##### 1. 内存缓存（默认）
+
+简单的内存缓存，适用于开发环境和小规模部署。
+
+**特性：**
+
+- 无外部依赖
+- 访问速度快
+- 不持久化（重启时清空）
+- 受 pod 内存限制
+
+**配置：**
+
+```yaml
+spec:
+  config:
+    global:
+      stores:
+        semantic_cache:
+          enabled: true
+          backend_type: memory
+          similarity_threshold: "0.8"
+          max_entries: 1000
+          ttl_seconds: 3600
+          eviction_policy: fifo  # fifo、lru 或 lfu
+```
+
+**适用场景：**
+
+- 开发与测试
+- 小规模部署（缓存查询少于 1000 条）
+- 没有持久化要求
+
+##### 2. Redis 缓存
+
+使用具备向量搜索能力的 Redis 构建高性能分布式缓存。
+
+**特性：**
+
+- 分布式且可扩展
+- 持久化存储（使用 AOF/RDB）
+- HNSW 或 FLAT 索引
+- 生态支持广泛
+
+**前置条件：**
+
+- Redis 7.0+，并安装 RediSearch 模块
+- 创建用于保存密码的 Kubernetes Secret：
+
+```bash
+kubectl create secret generic redis-credentials \
+  --from-literal=password='your-redis-password'
+```
+
+**配置：**
+
+```yaml
+spec:
+  config:
+    global:
+      stores:
+        semantic_cache:
+          enabled: true
+          backend_type: redis
+          similarity_threshold: "0.85"
+          ttl_seconds: 3600
+          embedding_model: mmbert
+          redis:
+            connection:
+              host: redis.default.svc.cluster.local
+              port: 6379
+              database: 0
+              password_secret_ref:
+                name: redis-credentials
+                key: password
+              timeout: 30
+              tls:
+                enabled: false
+            index:
+              name: semantic_cache_idx
+              prefix: "cache:"
+              vector_field:
+                name: embedding
+                dimension: 768  # 与默认的 mmBERT ultra embedding 模型一致
+                metric_type: COSINE
+              index_type: HNSW
+              params:
+                M: 16
+                efConstruction: 64
+            search:
+              topk: 1
+            development:
+              auto_create_index: true
+              verbose_errors: true
+```
+
+**适用场景：**
+
+- 中等规模的生产部署
+- 需要持久化和高可用性
+- 已有 Redis 基础设施
+- 需要高速的内存性能
+
+**示例：** [`vllm.ai_v1alpha1_semanticrouter_redis_cache.yaml`](https://github.com/vllm-project/semantic-router/blob/main/deploy/operator/config/samples/vllm.ai_v1alpha1_semanticrouter_redis_cache.yaml)
+
+##### 3. Milvus 缓存
+
+面向大容量缓存生产部署的企业级向量数据库。
+
+**特性：**
+
+- 高度可扩展且支持分布式部署
+- 高级索引（HNSW、IVF 等）
+- 内置数据生命周期管理
+- 支持高可用性
+
+**前置条件：**
+
+- Milvus 2.3+（standalone 或集群模式）
+- 创建用于保存凭据的 Kubernetes Secret：
+
+```bash
+kubectl create secret generic milvus-credentials \
+  --from-literal=password='your-milvus-password'
+```
+
+**配置：**
+
+```yaml
+spec:
+  config:
+    global:
+      stores:
+        semantic_cache:
+          enabled: true
+          backend_type: milvus
+          similarity_threshold: "0.90"
+          ttl_seconds: 7200
+          embedding_model: mmbert
+          milvus:
+            connection:
+              host: milvus-standalone.default.svc.cluster.local
+              port: 19530
+              database: semantic_router_cache
+              timeout: 30
+              auth:
+                enabled: true
+                username: root
+                password_secret_ref:
+                  name: milvus-credentials
+                  key: password
+            collection:
+              name: semantic_cache
+              description: "Semantic cache for LLM responses"
+              vector_field:
+                name: embedding
+                dimension: 768  # 与默认的 mmBERT ultra embedding 模型一致
+                metric_type: IP
+              index:
+                type: HNSW
+                params:
+                  M: 16
+                  efConstruction: 64
+            search:
+              params:
+                ef: 64
+              topk: 10
+              consistency_level: Session
+            performance:
+              connection_pool:
+                max_connections: 10
+                max_idle_connections: 5
+              batch:
+                insert_batch_size: 100
+            data_management:
+              ttl:
+                enabled: true
+                timestamp_field: created_at
+                cleanup_interval: 3600
+            development:
+              auto_create_collection: true
+```
+
+**适用场景：**
+
+- 大规模生产部署
+- 需要高级向量搜索能力
+- 需要数据生命周期管理（TTL、compaction）
+- 对高可用性和可扩展性有要求
+
+**示例：** [`vllm.ai_v1alpha1_semanticrouter_milvus_cache.yaml`](https://github.com/vllm-project/semantic-router/blob/main/deploy/operator/config/samples/vllm.ai_v1alpha1_semanticrouter_milvus_cache.yaml)
+
+##### 4. 混合缓存
+
+将内存 HNSW 索引与 Milvus 持久化存储结合，以兼顾最佳性能和持久性。
+
+**特性：**
+
+- 使用 HNSW 进行高速内存搜索
+- 在 Milvus 中持久化存储
+- 兼具两者优势
+- 自动同步
+
+**配置：**
+
+```yaml
+spec:
+  config:
+    global:
+      stores:
+        semantic_cache:
+          enabled: true
+          backend_type: hybrid
+          similarity_threshold: "0.85"
+          ttl_seconds: 3600
+          max_entries: 5000
+          eviction_policy: lru
+          embedding_model: mmbert
+          # HNSW 内存配置
+          hnsw:
+            use_hnsw: true
+            hnsw_m: 32
+            hnsw_ef_construction: 128
+            max_memory_entries: 5000
+
+      # Milvus 持久化存储（配置与 milvus 后端相同）
+      milvus:
+        connection:
+          host: milvus-standalone.default.svc.cluster.local
+          port: 19530
+          # ... 其余 milvus 配置
+```
+
+**适用场景：**
+
+- 需要尽可能快的缓存查询
+- 需要持久化和数据耐久性
+- 愿意用内存换取性能
+- 高吞吐量生产部署
+
+**示例：** [`vllm.ai_v1alpha1_semanticrouter_hybrid_cache.yaml`](https://github.com/vllm-project/semantic-router/blob/main/deploy/operator/config/samples/vllm.ai_v1alpha1_semanticrouter_hybrid_cache.yaml)
+
+#### 部署 Redis {#deploying-redis}
+
+在使用 Redis 缓存后端之前，请先在集群中部署带有 RediSearch 模块的 Redis：
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cache-backends
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: cache-backends
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis/redis-stack-server:latest
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: cache-backends
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+```
+
+应用配置：
+
+```bash
+kubectl apply -f redis-deployment.yaml
+```
+
+创建凭据 Secret：
+
+```bash
+kubectl create secret generic redis-credentials \
+  --from-literal=password=''  # 不使用密码时留空，也可以设置你的密码
+```
+
+**对于生产部署**，建议使用：
+
+- [Redis Operator](https://github.com/spotahome/redis-operator)
+- [Redis Enterprise Operator](https://docs.redis.com/latest/kubernetes/)
+- 托管 Redis 服务（AWS ElastiCache、Azure Cache for Redis、GCP Memorystore）
+
+#### 部署 Milvus {#deploying-milvus}
+
+在使用 Milvus 缓存后端之前，请先在集群中部署 Milvus：
+
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: milvus-standalone
+  namespace: cache-backends
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: milvus
+  template:
+    metadata:
+      labels:
+        app: milvus
+    spec:
+      containers:
+      - name: milvus
+        image: milvusdb/milvus:v2.4.0
+        command: ["milvus", "run", "standalone"]
+        ports:
+        - containerPort: 19530
+          name: grpc
+        - containerPort: 9091
+          name: metrics
+        env:
+        - name: ETCD_USE_EMBED
+          value: "true"
+        - name: COMMON_STORAGETYPE
+          value: "local"
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+        volumeMounts:
+        - name: milvus-data
+          mountPath: /var/lib/milvus
+      volumes:
+      - name: milvus-data
+        emptyDir: {}  # 生产环境请使用 PVC
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: milvus-standalone
+  namespace: cache-backends
+spec:
+  type: ClusterIP
+  ports:
+  - port: 19530
+    targetPort: 19530
+    name: grpc
+  selector:
+    app: milvus
+```
+
+应用配置：
+
+```bash
+kubectl apply -f milvus-deployment.yaml
+```
+
+创建凭据 Secret：
+
+```bash
+kubectl create secret generic milvus-credentials \
+  --from-literal=password='Milvus'  # Milvus 默认密码
+```
+
+**对于生产部署**，建议使用：
+
+- [Milvus Operator](https://milvus.io/docs/install_cluster-milvusoperator.md)
+- [Milvus Helm Chart](https://milvus.io/docs/install_cluster-helm.md)
+- [Zilliz Cloud](https://cloud.zilliz.com/)（托管 Milvus 服务）
+
+:::tip 生产最佳实践
+对于生产环境的缓存后端：
+
+1. 使用持久卷（而不是 emptyDir）
+2. 启用身份验证和 TLS
+3. 合理配置资源限制
+4. 设置监控和告警
+5. 使用 operator 或 Helm chart 简化管理
+6. 考虑使用托管服务以降低运维开销
+:::
+
+#### Embedding 模型
+
+语义缓存支持使用不同的 embedding 模型计算相似度：
+
+- **bert**（默认）：轻量级，384 维，适合通用场景
+- **qwen3**：质量更高，1024 维，准确性更好
+- **gemma**：较为均衡，768 维，性能适中
+
+配置方式如下：
+
+```yaml
+spec:
+  config:
+    global:
+      stores:
+        semantic_cache:
+          embedding_model: mmbert  # 或通过显式覆盖 model_catalog 使用 qwen3、gemma
+```
+
+**注意：** 请确保缓存配置中的 `dimension` 与所选 embedding 模型一致。
+
+#### 后端迁移
+
+从内存缓存迁移到 Redis 或 Milvus 的流程很简单：
+
+1. 在集群中部署 Redis 或 Milvus
+2. 创建凭据 Secret
+3. 使用新的后端配置更新 SemanticRouter CR
+4. 应用变更，operator 将执行滚动更新
+
+迁移后缓存为空，但会随着查询处理自然填充。
+
+#### 缓存配置参考
+
+如需详细的配置选项，请使用 `kubectl explain`：
+
+```bash
+# Redis 缓存配置
+kubectl explain semanticrouter.spec.config.global.stores.semantic_cache.redis
+
+# Milvus 缓存配置
+kubectl explain semanticrouter.spec.config.global.stores.semantic_cache.milvus
+
+# HNSW 配置
+kubectl explain semanticrouter.spec.config.global.stores.semantic_cache.hnsw
+```
+
+### Semantic Router 配置
+
+完整的 semantic router 配置嵌入在 CR 中。请参阅上方的完整示例以及 [`deploy/operator/config/samples/`](https://github.com/vllm-project/semantic-router/tree/main/deploy/operator/config/samples)。
+
+主要配置部分如下：
+
+```yaml
+spec:
+  config:
+    providers:
+      defaults:
+        reasoning_families:
+          deepseek:
+            type: "chat_template_kwargs"
+            parameter: "thinking"
+          qwen3:
+            type: "chat_template_kwargs"
+            parameter: "enable_thinking"
+          gpt:
+            type: "reasoning_effort"
+            parameter: "reasoning_effort"
+
+    global:
+      model_catalog:
+        embeddings:
+          semantic:
+            mmbert_model_path: "models/mom-embedding-ultra"
+            use_cpu: true
+            embedding_config:
+              model_type: "mmbert"
+              preload_embeddings: true
+              target_dimension: 768
+              target_layer: 22
+              top_k: 1
+              min_score_threshold: 0.5
+        system:
+          prompt_guard: "models/mmbert32k-jailbreak-detector-merged"
+          domain_classifier: "models/mmbert32k-intent-classifier-merged"
+          pii_classifier: "models/mmbert32k-pii-detector-merged"
+        modules:
+          prompt_guard:
+            enabled: true
+            model_id: "models/mmbert32k-jailbreak-detector-merged"
+            threshold: 0.7
+            use_cpu: true
+            use_mmbert_32k: true
+          classifier:
+            domain:
+              model_id: "models/mmbert32k-intent-classifier-merged"
+              threshold: 0.5
+              use_cpu: true
+              use_mmbert_32k: true
+            pii:
+              model_id: "models/mmbert32k-pii-detector-merged"
+              threshold: 0.9
+              use_cpu: true
+              use_mmbert_32k: true
+
+      stores:
+        semantic_cache:
+          enabled: true
+          backend_type: "memory"  # 或 redis、milvus、hybrid
+          similarity_threshold: 0.8
+          max_entries: 1000
+          ttl_seconds: 3600
+          eviction_policy: "fifo"
+
+      integrations:
+        tools:
+          enabled: true
+          top_k: 3
+          similarity_threshold: 0.2
+          tools_db_path: "config/tools_db.json"
+          fallback_to_empty: true
+
+      services:
+        api:
+          batch_classification:
+            max_batch_size: 100
+            concurrency_threshold: 5
+            max_concurrency: 8
+            metrics:
+              enabled: true
+              detailed_goroutine_tracking: true
+              sample_rate: 1.0
+        observability:
+          tracing:
+            enabled: false
+            provider: "opentelemetry"
+            exporter:
+              type: "otlp"
+              endpoint: "jaeger:4317"
+```
+
+### 工具数据库
+
+定义可供自动选择的工具：
+
+```yaml
+spec:
+  toolsDb:
+    - tool:
+        type: "function"
+        function:
+          name: "search_web"
+          description: "Search the web for information"
+          parameters:
+            type: "object"
+            properties:
+              query:
+                type: "string"
+                description: "Search query"
+            required: ["query"]
+      description: "Search the internet, web search, find information online"
+      category: "search"
+      tags: ["search", "web", "internet"]
+
+    - tool:
+        type: "function"
+        function:
+          name: "calculate"
+          description: "Perform mathematical calculations"
+          parameters:
+            type: "object"
+            properties:
+              expression:
+                type: "string"
+            required: ["expression"]
+      description: "Calculate mathematical expressions"
+      category: "math"
+      tags: ["math", "calculation"]
+```
+
+### 自动扩缩容（HPA）
+
+```yaml
+spec:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+```
+
+### Ingress 配置
+
+```yaml
+spec:
+  ingress:
+    enabled: true
+    className: "nginx"  # 或 "haproxy"、"traefik" 等
+    annotations:
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    hosts:
+      - host: router.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+            servicePort: 8080
+    tls:
+      - secretName: router-tls
+        hosts:
+          - router.example.com
+```
+
+## 生产部署
+
+### 高可用设置
+
+```yaml
+apiVersion: vllm.ai/v1alpha1
+kind: SemanticRouter
+metadata:
+  name: prod-router
+spec:
+  replicas: 3
+
+  # 用反亲和性将 pod 分散到不同节点
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: prod-router
+          topologyKey: kubernetes.io/hostname
+
+  # 自动扩缩容
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 70
+
+  # 生产环境资源
+  resources:
+    limits:
+      memory: "10Gi"
+      cpu: "4"
+    requests:
+      memory: "5Gi"
+      cpu: "2"
+
+  # 严格的探针配置
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    failureThreshold: 3
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 3
+```
+
+### Pod Disruption Budget
+
+创建 PDB，确保更新期间的可用性：
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: prod-router-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: prod-router
+```
+
+### 资源分配指南
+
+| 工作负载类型 | 内存请求 | CPU 请求 | 内存限制 | CPU 限制 |
+|-------------|----------|----------|----------|----------|
+| 开发        | 1Gi      | 500m     | 2Gi      | 1        |
+| 预发布      | 3Gi      | 1        | 7Gi      | 2        |
+| 生产        | 5Gi      | 2        | 10Gi     | 4        |
+
+## 监控与可观测性
+
+### 指标
+
+Prometheus 指标通过 9190 端口暴露：
+
+```bash
+# 通过端口转发在本地访问指标
+kubectl port-forward svc/my-router 9190:9190
+
+# 查看指标
+curl http://localhost:9190/metrics
+```
+
+**关键指标：**
+
+| 指标族 | 示例指标 |
+|--------|----------|
+| 请求 | `llm_model_requests_total`, `llm_request_errors_total` |
+| 错误 | `llm_request_errors_total{reason="timeout"}` |
+| 延迟 | `llm_model_completion_latency_seconds`, `llm_model_ttft_seconds`, `llm_model_tpot_seconds`, `llm_model_routing_latency_seconds` |
+| Token 与成本 | `llm_model_tokens_total`, `llm_model_prompt_tokens_total`, `llm_model_completion_tokens_total`, `llm_model_cost_total` |
+| 路由 | `llm_model_routing_modifications_total`, `llm_routing_reason_codes_total` |
+| 选择 | `llm_model_selection_total`, `llm_model_selection_duration_seconds`, `llm_model_inflight_requests` |
+| 缓存 | `llm_cache_plugin_hits_total`, `llm_cache_plugin_misses_total`, `llm_cache_warmth_estimate` |
+| RAG | `rag_retrieval_attempts_total`, `rag_retrieval_latency_seconds`, `rag_cache_hits_total`, `rag_cache_misses_total` |
+| 会话 | `llm_session_model_transitions_total`, `llm_session_turn_prompt_tokens`, `llm_session_turn_completion_tokens`, `llm_session_turn_cost` |
+| 翻译与请求参数策略 | `llm_translation_lossy_total`, `sr_request_params_blocked_total`, `sr_request_params_unknown_field_stripped_total` |
+
+### ServiceMonitor（Prometheus Operator）
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: semantic-router-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: my-router
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+```
+
+### 分布式追踪
+
+启用 OpenTelemetry tracing：
+
+```yaml
+spec:
+  config:
+    observability:
+      tracing:
+        enabled: true
+        provider: "opentelemetry"
+        exporter:
+          type: "otlp"
+          endpoint: "jaeger-collector:4317"
+          insecure: true
+        sampling:
+          type: "probabilistic"
+          rate: 0.1
+```
+
+推荐使用 `probabilistic` 采样类型。为兼容现有配置，也接受 `traceidratio` 和 `trace_id_ratio` 作为别名。
+
+## 故障排除
+
+### 常见问题
+
+#### 后端发现失败
+
+**症状：** 日志中出现 "No backends found" 或 "Failed to discover backend"
+
+**对于 KServe 后端：**
+
+```bash
+# 检查 InferenceService 是否存在并已就绪
+kubectl get inferenceservice llama-3-8b
+
+# 检查 KServe 是否已创建 predictor service
+kubectl get service llama-3-8b-predictor
+
+# 验证 InferenceService 状态
+kubectl describe inferenceservice llama-3-8b
+```
+
+**对于 Llama Stack 后端：**
+
+```bash
+# 验证具有正确 label 的 service 是否存在
+kubectl get services -l app=llama-stack,model=llama-3.3-70b
+
+# 检查 service label 是否与 CR 中的 discoveryLabels 一致
+kubectl get service <service-name> -o jsonpath='{.metadata.labels}'
+```
+
+**对于直连 service 后端：**
+
+```bash
+# 验证 service 是否存在于指定 namespace
+kubectl get service vllm-deepseek -n vllm-serving
+
+# 检查 service 是否定义了端口
+kubectl get service vllm-deepseek -n vllm-serving -o jsonpath='{.spec.ports[0]}'
+```
+
+#### Gateway 集成问题
+
+**症状：** 尚不存在 HTTPRoute，或流量未到达 semantic router
+
+当前 operator 实现不会自动创建 HTTPRoute 资源。如果你尚未自行应用 HTTPRoute manifest，这属于预期行为，并非 reconcile 失败。
+
+```bash
+# 验证 Gateway 是否存在
+kubectl get gateway istio-ingressgateway -n istio-system
+
+# 检查你是否自行创建了 HTTPRoute
+kubectl get httproute -l app.kubernetes.io/instance=my-router
+
+# 验证 Gateway 是否支持 HTTPRoute（Gateway API v1）
+kubectl get gateway istio-ingressgateway -n istio-system -o yaml | grep -A5 listeners
+
+# 检查 operator 状态
+kubectl get semanticrouter my-router -o jsonpath='{.status.gatewayMode}'
+# 应显示："gateway-integration"
+
+# 检查 operator 日志中的当前占位消息
+kubectl logs deployment/semantic-router-operator-controller-manager -n semantic-router-system | grep 'HTTPRoute creation placeholder'
+```
+
+如果 operator 日志显示 `HTTPRoute creation placeholder - requires Gateway API version-specific implementation`，说明 controller 已识别 gateway mode，但没有创建 route。请手动应用 HTTPRoute manifest，并验证它是否以 8080 端口上的 semantic router service 为目标。
+
+#### OpenShift Route 问题
+
+**症状：** OpenShift 上未创建 Route
+
+```bash
+# 验证是否运行在 OpenShift 集群上
+kubectl api-resources | grep route.openshift.io
+
+# 检查 Route 是否已创建
+kubectl get route -l app.kubernetes.io/instance=my-router
+
+# 检查 operator 是否探测到 OpenShift
+kubectl logs -n semantic-router-operator-system \
+  deployment/semantic-router-operator-controller-manager \
+  | grep -i "openshift\|route"
+
+# 验证 Route 状态
+kubectl get semanticrouter my-router -o jsonpath='{.status.openshiftFeatures}'
+```
+
+#### Pod 卡在 `ImagePullBackOff`
+
+```bash
+# 检查镜像拉取 Secret
+kubectl describe pod <pod-name>
+
+# 创建镜像拉取 Secret
+kubectl create secret docker-registry ghcr-secret \
+  --docker-server=ghcr.io \
+  --docker-username=<username> \
+  --docker-password=<personal-access-token>
+
+# 添加到 SemanticRouter
+spec:
+  imagePullSecrets:
+    - name: ghcr-secret
+```
+
+#### PVC 卡在 `Pending`
+
+```bash
+# 检查 StorageClass 是否存在
+kubectl get storageclass
+
+# 检查 PVC event
+kubectl describe pvc my-router-models
+
+# 更新 CR 中的 StorageClass
+spec:
+  persistence:
+    storageClassName: "your-available-storage-class"
+```
+
+#### 模型无法下载
+
+```bash
+# 检查 HF token Secret 是否存在
+kubectl get secret hf-token-secret
+
+# 创建 HF token Secret
+kubectl create secret generic hf-token-secret \
+  --from-literal=token=hf_xxxxxxxxxxxxx
+
+# 添加到 SemanticRouter CR
+spec:
+  env:
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: hf-token-secret
+          key: token
+```
+
+#### operator 未正确探测平台
+
+```bash
+# 检查 operator 日志中的平台探测信息
+kubectl logs -n semantic-router-operator-system \
+  deployment/semantic-router-operator-controller-manager \
+  | grep -i "platform\|openshift"
+
+# 应看到以下消息之一：
+# "Detected OpenShift platform - will use OpenShift-compatible security contexts"
+# "Detected standard Kubernetes platform - will use standard security contexts"
+```
+
+## 开发
+
+### 本地开发
+
+```bash
+cd deploy/operator
+
+# 运行测试
+make test
+
+# 生成 CRD 和代码
+make generate
+make manifests
+
+# 构建 operator 二进制文件
+make build
+
+# 使用你的 kubeconfig 在本地运行
+make run
+```
+
+### 使用 kind 测试
+
+```bash
+# 创建 kind 集群
+kind create cluster --name operator-test
+
+# 构建并加载镜像
+make docker-build IMG=semantic-router-operator:dev
+kind load docker-image semantic-router-operator:dev --name operator-test
+
+# 部署
+make install
+make deploy IMG=semantic-router-operator:dev
+
+# 创建测试实例
+kubectl apply -f config/samples/vllm_v1alpha1_semanticrouter.yaml
+```
 
 ## 下一步
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/streamed-extproc.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/streamed-extproc.md
@@ -1,0 +1,236 @@
+---
+translation:
+  source_commit: "9052d81a"
+  source_file: "docs/installation/k8s/streamed-extproc.md"
+  outdated: false
+---
+
+# 流式 ExtProc 与即时响应
+
+本指南介绍了当请求体以流式模式传递给 ExtProc 时，如何在兼容 Envoy 的网关后运行 vLLM Semantic Router，以及流式客户端如何接收 Semantic Router 的即时响应，例如 looper、semantic cache 和 `fast_response` 结果。
+
+在以下场景中，请使用本指南：
+
+- 大型 OpenAI 兼容请求体，不应在 ExtProc 收到之前由网关完整缓冲；
+- agentgateway 的 `FullDuplexStreamed` ExtProc 处理；
+- Envoy AI Gateway 或原生 Envoy 的 `STREAMED` 请求体处理；
+- 可能在上游后端响应前被 Semantic Router 短路的流式 Chat Completions 客户端（`"stream": true`）。
+
+## 工作原理
+
+Semantic Router 是一个 Envoy External Processor。在缓冲模式下，网关通过一条 ExtProc 消息发送完整请求体。在流式模式下，网关会发送多个请求体分块。Semantic Router 的流式请求体处理器会累积分块，在流结束时应用同一套路由和修改流水线，然后发出一个完整的已修改请求体或即时响应。
+
+对于流式 Chat Completions 响应，即时响应会保持 OpenAI 兼容行为：
+
+- 当原始请求包含 `"stream": true` 时，looper 算法返回 `Content-Type: text/event-stream`；
+- looper 响应包含 `x-vsr-looper-*` header，例如 `x-vsr-looper-model`、`x-vsr-looper-models-used`、`x-vsr-looper-iterations` 和 `x-vsr-looper-algorithm`；
+- 非流式即时响应（包括许多 `fast_response` 拦截）会立即返回完整的 JSON 响应；
+- Responses API 请求会通过 Responses API 层转换回来，因此这些请求在内部会被强制使用非流式 looper 执行。
+
+:::note
+“流式请求体”和“流式模型响应”是两个独立开关。`request_body_mode: STREAMED` 或 `requestBodyMode: FullDuplexStreamed` 控制网关如何将请求体发送给 Semantic Router；OpenAI 请求字段 `"stream": true` 则控制客户端是否期望从最终模型或即时响应中接收 Server-Sent Events。
+:::
+
+## Semantic Router 配置
+
+在 Semantic Router 运行时配置中启用流式请求体处理。该设置位于规范配置的 `global.router.streamed_body` 下。
+
+```yaml
+global:
+  router:
+    streamed_body:
+      enabled: true
+      max_bytes: 10485760   # 累积请求体超过此大小时返回 413
+      timeout_sec: 30       # 请求体累积过慢时返回 408
+```
+
+请确保 `max_bytes` 足以容纳最大的 prompt 或多模态 payload。`timeout_sec` 应大于从第一个请求体分块到流结束之间的预期上传时间。
+
+上例中的 10 MiB 和 30 秒是与 `e2e/profiles/streaming/values.yaml` 中流式 E2E profile 一致的示例保护值，并非运行时默认值，也不是经过实验校准的限制。省略任一值或将其设置为零都会禁用对应保护。参考配置 `config/config.yaml` 展示了更小的 1 MiB 和 15 秒策略。
+
+## Envoy AI Gateway / Envoy Gateway
+
+对于使用 `EnvoyPatchPolicy` 的 Envoy AI Gateway 示例，请将 Semantic Router ExtProc 过滤器从缓冲请求体改为流式请求体。
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyPatchPolicy
+metadata:
+  name: ai-gateway-prepost-extproc-patch-policy
+  namespace: default
+spec:
+  jsonPatches:
+  - name: default/semantic-router/http
+    operation:
+      op: add
+      path: /default_filter_chain/filters/0/typed_config/http_filters/0
+      value:
+        name: semantic-router-extproc
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+          allowModeOverride: true
+          grpcService:
+            envoyGrpc:
+              authority: semantic-router.vllm-semantic-router-system:50051
+              clusterName: semantic-router
+            timeout: 60s
+          messageTimeout: 60s
+          processingMode:
+            requestHeaderMode: SEND
+            requestBodyMode: STREAMED
+            requestTrailerMode: SKIP
+            responseHeaderMode: SEND
+            responseBodyMode: BUFFERED
+            responseTrailerMode: SKIP
+```
+
+关键字段包括：
+
+- `requestBodyMode: STREAMED`，将请求分块发送给 ExtProc；
+- `allowModeOverride: true`，允许 Semantic Router 在需要时请求按路由更改响应体处理方式；
+- 足以覆盖分类和请求体累积时间的 `messageTimeout` 与 `grpcService.timeout`。
+
+完整的 Kubernetes 示例位于 `deploy/kubernetes/streaming/aigw-resources/gwapi-resources.yaml`。
+
+## agentgateway
+
+agentgateway 使用 Gateway API 的 `AgentgatewayPolicy` 抽象，而不是原生 Envoy `processing_mode` 名称。对于流式请求体，请使用 `FullDuplexStreamed`。
+
+缓冲请求体仍是代理默认配置和其他部署示例中的常见选择。项目自带的 agentgateway 示例在 `deploy/kubernetes/agentgateway/extproc-policy.yaml` 中显式启用流式处理；[agentgateway 安装指南](./agentgateway)中的 Helm 命令则显式启用 `global.router.streamed_body`。采用该示例时，请同时使用这两项设置。
+
+```yaml
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: semantic-router-extproc
+  namespace: agentgateway-system
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: agentgateway-proxy
+  traffic:
+    extProc:
+      backendRef:
+        name: semantic-router
+        namespace: agentgateway-system
+        port: 50051
+      processingOptions:
+        requestHeaderMode: Send
+        requestBodyMode: FullDuplexStreamed
+        responseHeaderMode: Send
+        responseBodyMode: Buffered
+        requestTrailerMode: Send
+        responseTrailerMode: Send
+        allowModeOverride: true
+```
+
+agentgateway 不支持单独的 `Streamed` 请求体模式。流式请求体应使用 `FullDuplexStreamed`，并在 Semantic Router 中启用 `global.router.streamed_body`。
+
+Semantic Router 会检测协商后的 ExtProc 请求体模式。使用 `FullDuplexStreamed` 时，它会缓冲中间请求分块而不发出请求体替换，并在流结束时通过一条 `StreamedBodyResponse` 发送完整的已处理请求。使用 Envoy `STREAMED` 时，则保留该模式所要求的每分块一条响应行为。
+
+## 配置 looper 的流式即时响应
+
+Looper 算法是全双工流式处理所新增的主要即时响应路径。包含 looper 算法和多个 `modelRefs` 的 decision 可以直接返回 ExtProc 即时响应，而不必将原始请求转发给单个后端。
+
+Decision 配置片段示例：
+
+```yaml
+routing:
+  decisions:
+  - name: streamed_confidence_route
+    priority: 100
+    conditions:
+      all:
+      - signal: domain
+        operator: equals
+        value: code
+    modelRefs:
+    - modelName: small-code-model
+      weight: 1
+    - modelName: large-code-model
+      weight: 1
+    algorithm:
+      type: confidence
+      confidence:
+        confidence_method: hybrid
+        threshold: 0.72
+        escalation_order: small_to_large
+        on_error: skip
+```
+
+当客户端发送 `"stream": true` 时，Semantic Router 会调用候选模型、聚合 looper 结果，并向网关返回即时 SSE body。客户端仍会收到正常的 OpenAI 兼容 stream：
+
+```bash
+curl -N -i http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "auto",
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "Write and explain a Python debounce decorator."}
+    ],
+    "max_tokens": 128
+  }'
+```
+
+请检查：
+
+- `HTTP/1.1 200 OK`；
+- `content-type: text/event-stream`；
+- `x-vsr-looper-algorithm: confidence`、`ratings` 或 `remom`；
+- 以 `data: {"id":"chatcmpl-...","object":"chat.completion.chunk"...}` 开头的 SSE event；
+- 最后的 `data: [DONE]`。
+
+## 配置流式请求体的安全拦截
+
+`fast_response` 也可以短路以流式请求体分块到达的请求。这适用于 PII 或 jailbreak 拦截等安全 decision。
+
+```yaml
+routing:
+  decisions:
+  - name: streamed_jailbreak_block
+    priority: 1000
+    conditions:
+      all:
+      - signal: jailbreak
+        operator: greater_than
+        value: 0.6
+    plugins:
+    - type: fast_response
+      configuration:
+        message: This request was blocked by policy.
+```
+
+使用 `request_body_mode: STREAMED` 或 `requestBodyMode: FullDuplexStreamed` 时，Semantic Router 会累积请求体，在流结束时运行安全信号，并直接返回配置的即时响应，而不会将请求转发给后端。
+
+## 验证清单
+
+1. 确认网关 policy/filter 已被接受：
+
+   ```bash
+   kubectl describe envoypatchpolicy ai-gateway-prepost-extproc-patch-policy -n default
+   # 或
+   kubectl describe agentgatewaypolicy semantic-router-extproc -n agentgateway-system
+   ```
+
+2. 确认 Semantic Router 已启用流式请求体处理：
+
+   ```bash
+   kubectl logs deploy/semantic-router -n vllm-semantic-router-system | grep -i streamed
+   ```
+
+3. 使用 `"model": "auto"` 发送大型或分块请求，并验证其正常路由。
+
+4. 发送匹配 looper decision 且包含 `"stream": true` 的流式 Chat Completions 请求，并验证 SSE 输出和 `x-vsr-looper-*` header。
+
+5. 发送匹配 `fast_response` decision 的请求，并验证后端模型未被调用。
+
+## 故障排除
+
+- **网关接受请求，但 Semantic Router 从未收到请求体分块**：ExtProc 过滤器仍使用缓冲或跳过请求体模式。请设置 Envoy `requestBodyMode: STREAMED` 或 agentgateway `requestBodyMode: FullDuplexStreamed`。
+- **请求返回 413**：累积请求体超过 `global.router.streamed_body.max_bytes`。请增大 `max_bytes` 或缩小请求体。
+- **请求返回 408**：请求体分块未能在 `timeout_sec` 前完成。请增大 `timeout_sec` 或检查客户端上传速度。
+- **客户端期望 SSE，但收到 JSON**：OpenAI 请求未包含 `"stream": true`，或匹配的是非流式即时响应路径。对于 Chat Completions looper 路由，请添加 `"stream": true` 并验证匹配的 decision。
+- **agentgateway 拒绝 `Streamed`**：agentgateway 支持的是 `FullDuplexStreamed`，而不是 `Streamed`。请使用 `requestBodyMode: FullDuplexStreamed`。
+- **上游请求体重复或不完整**：网关与 Semantic Router 的流式模式不匹配。请同时启用网关流式请求体模式和 Semantic Router 的 `streamed_body.enabled`。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/projection/scores.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/projection/scores.md
@@ -1,8 +1,8 @@
 ---
 translation:
-  source_commit: "45bfd49e"
+  source_commit: "49e7c766"
   source_file: "docs/tutorials/projection/scores.md"
-  outdated: true
+  outdated: false
 sidebar_position: 3
 ---
 
@@ -61,7 +61,21 @@ sidebar_position: 3
 
 当前支持的输入类型包括：
 
-`keyword`、`embedding`、`domain`、`fact_check`、`user_feedback`、`preference`、`language`、`context`、`structure`、`complexity`、`modality`、`authz`、`jailbreak`、`pii`
+- `keyword`
+- `embedding`
+- `domain`
+- `fact_check`
+- `user_feedback`
+- `reask`
+- `preference`
+- `language`
+- `context`
+- `structure`
+- `complexity`
+- `modality`
+- `authz`
+- `jailbreak`
+- `pii`
 
 分数是内部投影状态；决策不直接引用分数名；下一步由映射消费。
 
@@ -93,6 +107,29 @@ routing:
             weight: 0.22
 ```
 
+### 原始值源
+
+当信号族通过 `SignalValues` 暴露数值度量（计数、距离、token 总数）时，使用 `value_source: raw` 将这些值直接送入加权和，而不是将其简化为二值或置信度标量。
+
+```yaml
+routing:
+  projections:
+    scores:
+      - name: workload_pressure
+        method: weighted_sum
+        inputs:
+          - type: structure
+            name: many_questions
+            weight: 0.2
+            value_source: raw
+          - type: structure
+            name: nested_depth
+            weight: 0.4
+            value_source: raw
+```
+
+不同信号族的原始值可能采用不同量纲。请谨慎选择权重，或使用与预期数值范围相符的阈值区间。
+
 ## DSL
 
 ```dsl
@@ -114,10 +151,10 @@ PROJECTION score difficulty_score {
 |------|------|
 | `name` | 分数标识 |
 | `method` | 当前为 `weighted_sum` |
-| `inputs[].type` | 读取的信号族 |
-| `inputs[].name` | 已声明的信号名 |
+| `inputs[].type` | 读取的信号族；也可以是 `projection`，用于引用先前的分数或映射输出 |
+| `inputs[].name` | 已声明的信号名；当 `type: projection` 且 `value_source: score`（默认）时为分数名，当 `value_source: confidence` 时为映射输出名 |
 | `inputs[].weight` | 贡献系数；负权重降低分数 |
-| `inputs[].value_source` | `binary`、`confidence` 或 `raw` 行为 |
+| `inputs[].value_source` | `binary`、`confidence`、`raw` 或 `score`（用于投影输入）；投影输入使用 `confidence` 时读取映射输出的校准置信度 |
 | `inputs[].match` / `inputs[].miss` | 二值模式下的显式取值 |
 
 ## 配置
@@ -147,7 +184,73 @@ PROJECTION score difficulty_score {
 - 数值聚合优先用分数，让 `routing.decisions` 专注可读布尔组合。
 - 当匹配信号应主动降低档位时（如 `balance` 对明显简单请求），使用负权重。
 
+## 层级组合
+
+分数可以通过 `type: projection` 引用先前的投影分数或映射输出置信度。这样便可构建由一个分数叠加另一个分数的分层路由结构。
+
+### 分数引用分数
+
+使用 `value_source: score`（或省略 `value_source`）读取先前计算的分数值：
+
+```yaml
+routing:
+  projections:
+    scores:
+      - name: difficulty_score
+        method: weighted_sum
+        inputs:
+          - type: keyword
+            name: reasoning_request_markers
+            weight: 0.6
+            value_source: confidence
+
+      - name: verification_pressure
+        method: weighted_sum
+        inputs:
+          - type: projection
+            name: difficulty_score
+            value_source: score
+            weight: 0.8
+          - type: fact_check
+            name: needs_fact_check
+            weight: 0.4
+
+    mappings:
+      - name: verification_band
+        source: verification_pressure
+        method: threshold_bands
+        outputs:
+          - name: needs_deep_verify
+            gte: 0.7
+          - name: standard_verify
+            lt: 0.7
+```
+
+### 引用置信度
+
+使用 `value_source: confidence` 读取映射输出区间的校准置信度：
+
+```yaml
+- type: projection
+  name: needs_deep_verify
+  value_source: confidence
+  weight: 0.5
+```
+
+### 依赖顺序
+
+分数可以按任意顺序声明。运行时会按拓扑顺序计算，确保始终先解析依赖项，再计算依赖它们的分数。配置校验会拒绝循环依赖。
+
+### 投影输入配置字段
+
+| 字段 | 含义 |
+|------|------|
+| `type` | `projection` |
+| `name` | 已声明的分数名（用于 `value_source: score`）或映射输出名（用于 `value_source: confidence`） |
+| `value_source` | `score`（读取原始分数值）或 `confidence`（读取映射输出置信度） |
+| `weight` | 贡献系数 |
+
 ## 下一步
 
-- 阅读 [Mappings](./mappings)，将分数转为决策可用的命名档位。
-- 阅读 [Overview](./overview) 了解完整投影工作流及与信号、决策的关系。
+- 阅读[映射](./mappings)，将分数转为决策可用的命名档位。
+- 阅读[概览](./overview)，了解完整投影工作流及与信号、决策的关系。

--- a/website/src/css/docs.css
+++ b/website/src/css/docs.css
@@ -48,8 +48,17 @@
 }
 
 .theme-doc-version-badge {
-  background: rgba(17, 17, 17, 0.08);
+  display: block;
+  width: fit-content;
+  margin: 0 0 1rem auto;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--site-border);
+  border-radius: 999px;
+  background: rgba(17, 17, 17, 0.055);
   color: var(--site-text);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .site-docs-shell .theme-doc-markdown,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2662 

## Purpose

- Synchronize five Simplified Chinese documentation pages with their latest English sources:
  - Update the Envoy AI Gateway guide with streamed ExtProc guidance and MiniMax provider support.
  - Replace the stale Gateway API Inference Extension workflow with the current Istio and agentgateway deployment paths.
  - Complete the Operator guide with configuration reference, cache backends, production deployment, observability, troubleshooting, and development sections.
  - Add the missing Streamed ExtProc and immediate responses guide.
  - Update Projection Scores with the `reask` input type, raw values, hierarchical composition, and dependency ordering.
- Record the latest English source commit for each translation and set `translation.outdated: false` after full-page parity review.
- This change is needed because the existing Chinese pages were incomplete or described obsolete deployment and configuration behavior.
- Affected module: `Docs`.

## Test Plan

- Build the complete Simplified Chinese documentation site:

  ```bash
  cd website
  npm run build:zh
  ```

- Run the repository documentation lint and structural checks:

  ```bash
  make agent-lint CHANGED_FILES="website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/ai-gateway.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/gateway-api-inference-extension.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/operator.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/installation/k8s/streamed-extproc.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/projection/scores.md"
  ```

- Validate that the Projection tutorial taxonomy still matches the router configuration hierarchy:

  ```bash
  cd src/semantic-router
  go test -count=1 ./pkg/config -run TestLatestTutorialTaxonomyMatchesConfigHierarchy
  ```

- Audit translation metadata and source drift:

  ```bash
  make docs-check-translations
  ```

- These checks are sufficient for this Docs-only change because they validate MDX compilation, localized links, repository formatting rules, tutorial/config consistency, source commit metadata, and translation status.

## Test Result

- `npm run build:zh`: passed.
  - The Chinese production site was generated successfully.
  - Existing warnings remain for inline blog authors, missing blog truncation markers, and broken anchors in the unrelated signal overview pages.
- `make agent-lint CHANGED_FILES="..."`: passed.
- `go test -count=1 ./pkg/config -run TestLatestTutorialTaxonomyMatchesConfigHierarchy`: passed.
- `git diff --check`: passed.
- `make docs-check-translations`:
  - Reports `106` likely synchronized translations and `0` outdated translations.
  - None of the five files in this PR appears under outdated translations, metadata issues, metadata verification, or status mismatches.
  - The command still exits nonzero because of unrelated repository backlog: `30` missing translations, `17` existing metadata issues, and `44` translations requiring metadata verification.
- No blockers remain for the scoped documentation changes.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes (not applicable; this PR affects Docs only)
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.