### PR TITLE
[Fleet-Sim] Add measured B200 context-length sweep

### DIFF
--- a/src/fleet-sim/studies/context-length-power-efficiency/README.md
+++ b/src/fleet-sim/studies/context-length-power-efficiency/README.md
@@ -1,0 +1,80 @@
+# Measured B200 Context-Length Sweep
+
+This directory archives the measured B200 results contributed for the
+context-length power-efficiency study. It contains the experiment summary and
+a small standard-library script that validates and renders the measured table.
+
+It intentionally does not contain or modify the paper's LaTeX or PDF. The
+paper authors can integrate these measurements into the manuscript separately.
+
+## Measurement setup
+
+- Date: April 29, 2026
+- System: one node with 8x NVIDIA B200 GPUs
+- Model: Llama-3.1-70B, tensor parallelism 8, fp16
+- Software: vLLM 0.20.0, PyTorch 2.11.0+cu130, CUDA 13.0
+- Context windows: 2K, 4K, 8K, 16K, 32K, 64K, and 128K tokens
+
+The archived results are:
+
+| Context | Measured nmax | Decode tok/s | Mean GPU power (W) | Paper-normalized tok/W | 8-GPU system tok/W |
+|---:|---:|---:|---:|---:|---:|
+| 2K | 1725 | 29486.22 | 794.99 | 37.09 | 4.64 |
+| 4K | 872 | 21620.98 | 712.54 | 30.34 | 3.79 |
+| 8K | 439 | 13451.24 | 654.55 | 20.55 | 2.57 |
+| 16K | 220 | 7757.27 | 596.00 | 13.02 | 1.63 |
+| 32K | 110 | 4654.67 | 590.21 | 7.89 | 0.99 |
+| 64K | 55 | 2734.58 | 636.53 | 4.30 | 0.54 |
+| 128K | 28 | 822.49 | 723.43 | 1.14 | 0.14 |
+
+## Artifacts
+
+- `data/b200_table1_measurements/final_results.csv`: measured table and
+  calculation columns.
+- `data/b200_table1_measurements/B200_env.txt`: software and GPU environment.
+- `data/b200_table1_measurements/nmax.txt`: vLLM KV-cache allocation excerpts
+  used to obtain maximum concurrency.
+- `scripts/render_b200_table.py`: validates the archived calculations and
+  prints a Markdown table.
+
+## Metric definitions
+
+`decode_tok_s` is aggregate decode throughput for the TP=8 serving instance.
+`per_gpu_decode_power_w` is the mean power of one GPU.
+
+The CSV preserves two tok/W conventions:
+
+1. `measured_decode_tok_per_w` divides aggregate TP=8 throughput by mean
+   per-GPU power. This is the normalization used by the study's paper table,
+   but it is not physical whole-system energy efficiency.
+2. `measured_8gpu_decode_tok_per_w` divides the same throughput by estimated
+   total GPU power (`8 * per_gpu_decode_power_w`). This is the physical
+   8-GPU serving-instance metric under balanced per-GPU power.
+
+The `paper_projected_*` columns are retained only as the analytical reference
+available when the measurements were collected. They are not inputs to the
+measured calculations.
+
+## Reproduce the archived table
+
+From this directory:
+
+```bash
+python3 scripts/render_b200_table.py
+```
+
+The script reads `final_results.csv`, recomputes both tok/W columns from
+throughput and power, and fails if a reported value differs by more than the
+CSV's two-decimal precision.
+
+## Scope and limitations
+
+These files reproduce the table from the archived experiment summary; they do
+not rerun the GPU experiment from scratch. The original load-generation
+scripts, raw power traces, and repeat-run samples are not part of the archived
+contribution. Consequently:
+
+- the measurements should be treated as single-node evidence;
+- the archive does not quantify run-to-run or system-to-system variance; and
+- claims or manuscript changes based on the table should be reviewed by the
+  paper authors.

--- a/src/fleet-sim/studies/context-length-power-efficiency/data/b200_table1_measurements/B200_env.txt
+++ b/src/fleet-sim/studies/context-length-power-efficiency/data/b200_table1_measurements/B200_env.txt
@@ -1,0 +1,19 @@
+April 29th, 2026
+
+=== vLLM ===
+0.20.0
+
+=== Python/Torch ===
+vllm: 0.20.0
+torch: 2.11.0+cu130
+torch cuda: 13.0
+cuda available: True
+gpu count: 8
+0 NVIDIA B200 (10, 0)
+1 NVIDIA B200 (10, 0)
+2 NVIDIA B200 (10, 0)
+3 NVIDIA B200 (10, 0)
+4 NVIDIA B200 (10, 0)
+5 NVIDIA B200 (10, 0)
+6 NVIDIA B200 (10, 0)
+7 NVIDIA B200 (10, 0)

--- a/src/fleet-sim/studies/context-length-power-efficiency/data/b200_table1_measurements/final_results.csv
+++ b/src/fleet-sim/studies/context-length-power-efficiency/data/b200_table1_measurements/final_results.csv
@@ -1,0 +1,8 @@
+context_tokens,context_k,paper_projected_b200_nmax,measured_b200_nmax,paper_projected_b200_tok_per_w,decode_tok_s,per_gpu_decode_power_w,measured_decode_tok_per_w,measured_8gpu_decode_tok_per_w,window_type,notes
+2048,2,1343,1725,61.4,29486.22,794.99,37.09,4.64,strict_all_overlap,successful_streams=1725 output_len=512
+4096,4,671,872,30.8,21620.98,712.54,30.34,3.79,strict_all_overlap,successful_streams=872 output_len=512
+8192,8,335,439,15.5,13451.24,654.55,20.55,2.57,strict_all_overlap,successful_streams=439 output_len=512
+16384,16,167,220,7.87,7757.27,596.00,13.02,1.63,strict_all_overlap,successful_streams=220 output_len=512
+32768,32,83,110,4.09,4654.67,590.21,7.89,0.99,strict_all_overlap,successful_streams=110 actual_chunks_per_request=492
+65536,64,41,55,2.24,2734.58,636.53,4.30,0.54,strict_all_overlap,successful_streams=55 actual_chunks_per_request=481
+131072,128,20,28,1.30,822.49,723.43,1.14,0.14,strict_all_overlap,successful_streams=28 output_len=2048 actual_mean_chunks_per_request=1019.82

--- a/src/fleet-sim/studies/context-length-power-efficiency/data/b200_table1_measurements/nmax.txt
+++ b/src/fleet-sim/studies/context-length-power-efficiency/data/b200_table1_measurements/nmax.txt
@@ -1,0 +1,34 @@
+===== 2K =====
+(Worker_TP0 pid=408) INFO 04-29 22:26:41 [gpu_worker.py:440] Available KV cache memory: 134.77 GiB
+(EngineCore pid=209) INFO 04-29 22:26:41 [kv_cache_utils.py:1711] GPU KV cache size: 3,532,976 tokens
+(EngineCore pid=209) INFO 04-29 22:26:41 [kv_cache_utils.py:1716] Maximum concurrency for 2,048 tokens per request: 1725.09x
+
+===== 4K =====
+(Worker_TP0 pid=408) INFO 04-29 22:28:34 [gpu_worker.py:440] Available KV cache memory: 136.31 GiB
+(EngineCore pid=209) INFO 04-29 22:28:35 [kv_cache_utils.py:1711] GPU KV cache size: 3,573,152 tokens
+(EngineCore pid=209) INFO 04-29 22:28:35 [kv_cache_utils.py:1716] Maximum concurrency for 4,096 tokens per request: 872.35x
+
+===== 8K =====
+(Worker_TP0 pid=604) INFO 04-29 22:13:43 [gpu_worker.py:440] Available KV cache memory: 137.31 GiB
+(EngineCore pid=405) INFO 04-29 22:13:43 [kv_cache_utils.py:1711] GPU KV cache size: 3,599,408 tokens
+(EngineCore pid=405) INFO 04-29 22:13:43 [kv_cache_utils.py:1716] Maximum concurrency for 8,192 tokens per request: 439.38x
+
+===== 16K =====
+(Worker_TP0 pid=408) INFO 04-29 22:30:31 [gpu_worker.py:440] Available KV cache memory: 137.73 GiB
+(EngineCore pid=209) INFO 04-29 22:30:31 [kv_cache_utils.py:1711] GPU KV cache size: 3,610,512 tokens
+(EngineCore pid=209) INFO 04-29 22:30:31 [kv_cache_utils.py:1716] Maximum concurrency for 16,384 tokens per request: 220.37x
+
+===== 32K =====
+(Worker_TP0 pid=408) INFO 04-29 22:32:23 [gpu_worker.py:440] Available KV cache memory: 138.65 GiB
+(EngineCore pid=209) INFO 04-29 22:32:24 [kv_cache_utils.py:1711] GPU KV cache size: 3,634,528 tokens
+(EngineCore pid=209) INFO 04-29 22:32:24 [kv_cache_utils.py:1716] Maximum concurrency for 32,768 tokens per request: 110.92x
+
+===== 64K =====
+(Worker_TP0 pid=408) INFO 04-29 22:34:17 [gpu_worker.py:440] Available KV cache memory: 139.61 GiB
+(EngineCore pid=209) INFO 04-29 22:34:17 [kv_cache_utils.py:1711] GPU KV cache size: 3,659,712 tokens
+(EngineCore pid=209) INFO 04-29 22:34:17 [kv_cache_utils.py:1716] Maximum concurrency for 65,536 tokens per request: 55.84x
+
+===== 128K =====
+(Worker_TP0 pid=408) INFO 04-29 22:36:09 [gpu_worker.py:440] Available KV cache memory: 140.2 GiB
+(EngineCore pid=209) INFO 04-29 22:36:09 [kv_cache_utils.py:1711] GPU KV cache size: 3,675,280 tokens
+(EngineCore pid=209) INFO 04-29 22:36:09 [kv_cache_utils.py:1716] Maximum concurrency for 131,072 tokens per request: 28.04x

--- a/src/fleet-sim/studies/context-length-power-efficiency/scripts/render_b200_table.py
+++ b/src/fleet-sim/studies/context-length-power-efficiency/scripts/render_b200_table.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate and render the archived B200 context-length sweep."""
+
+import csv
+import math
+from pathlib import Path
+
+GPU_COUNT = 8
+STUDY_ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = STUDY_ROOT / "data" / "b200_table1_measurements" / "final_results.csv"
+REQUIRED_COLUMNS = {
+    "context_tokens",
+    "context_k",
+    "measured_b200_nmax",
+    "decode_tok_s",
+    "per_gpu_decode_power_w",
+    "measured_decode_tok_per_w",
+    "measured_8gpu_decode_tok_per_w",
+}
+ROUNDING_TOLERANCE = 0.011
+
+
+def load_rows():
+    """Load the archived rows and validate the CSV schema."""
+    with DATA_PATH.open(newline="", encoding="utf-8") as data_file:
+        reader = csv.DictReader(data_file)
+        fieldnames = set(reader.fieldnames or ())
+        missing = REQUIRED_COLUMNS - fieldnames
+        if missing:
+            names = ", ".join(sorted(missing))
+            raise ValueError(f"Missing required CSV columns: {names}")
+        rows = list(reader)
+
+    if not rows:
+        raise ValueError("The measurement CSV is empty")
+    return rows
+
+
+def validate_row(row, seen_contexts):
+    """Validate one row and return values used by the rendered table."""
+    context_tokens = int(row["context_tokens"])
+    context_k = int(row["context_k"])
+    nmax = int(row["measured_b200_nmax"])
+    decode_tok_s = float(row["decode_tok_s"])
+    per_gpu_power_w = float(row["per_gpu_decode_power_w"])
+    reported_paper_tpw = float(row["measured_decode_tok_per_w"])
+    reported_system_tpw = float(row["measured_8gpu_decode_tok_per_w"])
+
+    if context_tokens in seen_contexts:
+        raise ValueError(f"Duplicate context_tokens value: {context_tokens}")
+    seen_contexts.add(context_tokens)
+
+    if context_tokens <= 0 or context_tokens % 1024:
+        raise ValueError(f"Invalid context_tokens value: {context_tokens}")
+    if context_k != context_tokens // 1024:
+        raise ValueError(f"context_k mismatch for {context_tokens}: got {context_k}")
+    if nmax <= 0 or decode_tok_s <= 0 or per_gpu_power_w <= 0:
+        raise ValueError(f"Non-positive measurement at {context_k}K")
+
+    calculated_paper_tpw = decode_tok_s / per_gpu_power_w
+    calculated_system_tpw = calculated_paper_tpw / GPU_COUNT
+    if not math.isclose(
+        calculated_paper_tpw,
+        reported_paper_tpw,
+        abs_tol=ROUNDING_TOLERANCE,
+    ):
+        raise ValueError(f"Paper-normalized tok/W mismatch at {context_k}K")
+    if not math.isclose(
+        calculated_system_tpw,
+        reported_system_tpw,
+        abs_tol=ROUNDING_TOLERANCE,
+    ):
+        raise ValueError(f"8-GPU system tok/W mismatch at {context_k}K")
+
+    return (
+        context_tokens,
+        context_k,
+        nmax,
+        decode_tok_s,
+        per_gpu_power_w,
+        reported_paper_tpw,
+        reported_system_tpw,
+    )
+
+
+def main():
+    """Validate all rows and print the measured table as Markdown."""
+    seen_contexts = set()
+    rows = sorted(
+        (validate_row(row, seen_contexts) for row in load_rows()),
+        key=lambda values: values[0],
+    )
+
+    print("| Context | nmax | Decode tok/s | Mean GPU W | Paper tok/W | System tok/W |")
+    print("|---:|---:|---:|---:|---:|---:|")
+    for _, context_k, nmax, tok_s, power_w, paper_tpw, system_tpw in rows:
+        print(
+            f"| {context_k}K | {nmax} | {tok_s:.2f} | {power_w:.2f} "
+            f"| {paper_tpw:.2f} | {system_tpw:.2f} |"
+        )
+
+    print(f"\nValidated {len(rows)} rows from {DATA_PATH.relative_to(STUDY_ROOT)}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Reposts only the measured B200 experiment contribution from #1863 against `main`.
- Archives the 2K–128K context-length sweep, software/GPU environment, and KV-cache maximum-concurrency excerpts.
- Adds a standard-library Python script that validates the CSV calculations and renders the measured table.
- Intentionally excludes all manuscript, LaTeX, and PDF changes so the paper authors can integrate the measurements separately.

## Metric scope

- `decode_tok_s` is aggregate throughput for the TP=8 serving instance; `per_gpu_decode_power_w` is mean one-GPU power.
- The CSV retains both the paper-normalized value (aggregate throughput divided by mean per-GPU power) and an estimated physical 8-GPU system tok/W value.
- The `paper_projected_*` columns are retained only as the analytical reference available when the measurements were collected.

## Reproducibility scope

These artifacts reproduce and validate the archived result table; they do not rerun the GPU experiment from scratch. The original load-generation scripts, raw power traces, and repeat-run samples are not part of this contribution.

## Validation

- `python3 src/fleet-sim/studies/context-length-power-efficiency/scripts/render_b200_table.py`
- Repository Ruff, Black, Markdown, changed-file lint, and supply-chain security checks
- `make vllm-sr-sim-test` — 304 passed

## Review note

This remains a draft so the paper authors can review the metric terminology and integrate the experimental results into the manuscript themselves.