### PR TITLE
[Router] vectorstore: bound ingestion memory with streaming batches

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1839,6 +1839,7 @@ global:
       embedding_model: multimodal
       embedding_dimension: 384
       ingestion_workers: 4
+      ingestion_batch_size: 64
       ingestion_drain_timeout_seconds: 30
       supported_formats: [.txt, .md, .json, .csv, .html, .pdf]
       milvus:

--- a/dashboard/frontend/src/pages/configPageRouterDefaultsCatalog.ts
+++ b/dashboard/frontend/src/pages/configPageRouterDefaultsCatalog.ts
@@ -111,6 +111,7 @@ export const DEFAULT_SECTIONS: Record<RouterSystemKey, unknown> = {
     embedding_model: 'mmbert',
     embedding_dimension: 384,
     ingestion_workers: 2,
+    ingestion_batch_size: 64,
     supported_formats: ['.txt', '.md', '.json', '.csv', '.html'],
     memory: {
       max_entries_per_store: 100000,

--- a/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
+++ b/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
@@ -591,6 +591,7 @@ function fieldsForKey(key: RouterSystemKey): FieldConfig[] {
         { name: 'embedding_model', label: 'Embedding Model', type: 'select', options: ['bert', 'qwen3', 'gemma', 'mmbert', 'multimodal'] },
         { name: 'embedding_dimension', label: 'Embedding Dimension', type: 'number', placeholder: '384' },
         { name: 'ingestion_workers', label: 'Ingestion Workers', type: 'number', placeholder: '2' },
+        { name: 'ingestion_batch_size', label: 'Ingestion Batch Size', type: 'number', placeholder: '64' },
         routerStructuredField(key, 'supported_formats'),
         routerStructuredField(key, 'memory'),
         routerStructuredField(key, 'milvus'),

--- a/dashboard/frontend/src/pages/configPageSupport.ts
+++ b/dashboard/frontend/src/pages/configPageSupport.ts
@@ -506,6 +506,7 @@ export interface VectorStoreConfig {
   embedding_model?: string
   embedding_dimension?: number
   ingestion_workers?: number
+  ingestion_batch_size?: number
   supported_formats?: string[]
   milvus?: VectorStoreMilvusConfig
   memory?: VectorStoreMemoryConfig

--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -5200,6 +5200,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
+        ingestion_batch_size: 64
         ingestion_drain_timeout_seconds: 30
         supported_formats:
           - .txt
@@ -10619,6 +10620,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
+        ingestion_batch_size: 64
         ingestion_drain_timeout_seconds: 30
         supported_formats:
           - .txt

--- a/e2e/profiles/rag-hybrid-search/values.yaml
+++ b/e2e/profiles/rag-hybrid-search/values.yaml
@@ -54,6 +54,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
+        ingestion_batch_size: 64
         ingestion_drain_timeout_seconds: 30
         supported_formats:
           - .txt

--- a/src/semantic-router/pkg/config/vectorstore.go
+++ b/src/semantic-router/pkg/config/vectorstore.go
@@ -46,6 +46,15 @@ type VectorStoreConfig struct {
 	// Default: 2
 	IngestionWorkers int `json:"ingestion_workers,omitempty" yaml:"ingestion_workers,omitempty"`
 
+	// IngestionBatchSize bounds how many chunks are embedded and inserted per
+	// batch during ingestion. Instead of embedding every chunk of a file and
+	// then inserting them all at once — which holds the whole file's text,
+	// chunks, and embedding vectors in memory simultaneously — the pipeline
+	// processes chunks in fixed-size windows. This bounds peak per-job memory to
+	// roughly O(batch_size × embedding_dimension) regardless of file size.
+	// Default: 64.
+	IngestionBatchSize int `json:"ingestion_batch_size,omitempty" yaml:"ingestion_batch_size,omitempty"`
+
 	// IngestionDrainTimeoutSeconds bounds how long shutdown waits for in-flight
 	// ingestion jobs to drain before cancelling them. This is a shutdown grace
 	// window, not a per-file ingest budget: on shutdown the pipeline stops
@@ -315,6 +324,9 @@ func (c *VectorStoreConfig) ApplyDefaults() {
 	}
 	if c.IngestionWorkers <= 0 {
 		c.IngestionWorkers = 2
+	}
+	if c.IngestionBatchSize <= 0 {
+		c.IngestionBatchSize = 64
 	}
 	if c.IngestionDrainTimeoutSeconds <= 0 {
 		c.IngestionDrainTimeoutSeconds = 30

--- a/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
+++ b/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
@@ -71,6 +71,7 @@ func NewVectorStoreRuntime(cfg *config.RouterConfig) (*VectorStoreRuntime, error
 	pipeline := vectorstore.NewIngestionPipeline(backend, fileStore, manager, embedder, vectorstore.PipelineConfig{
 		Workers:   cfg.VectorStore.IngestionWorkers,
 		QueueSize: 100,
+		BatchSize: cfg.VectorStore.IngestionBatchSize,
 	})
 	pipeline.Start()
 

--- a/src/semantic-router/pkg/vectorstore/pipeline.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline.go
@@ -46,6 +46,18 @@ type IngestionJob struct {
 // backend or embedder is wedged.
 const defaultStopTimeout = 30 * time.Second
 
+// defaultBatchSize is the number of chunks embedded and inserted per batch when
+// PipelineConfig does not specify one. It bounds peak per-job memory to roughly
+// O(batchSize × embeddingDimension) instead of holding every chunk's text and
+// embedding for a file at once.
+const defaultBatchSize = 64
+
+// batchCleanupTimeout bounds the best-effort removal of already-inserted chunks
+// when a multi-batch ingestion fails partway through. It is detached from the
+// (possibly cancelled) job context so cleanup still runs during shutdown, but
+// is itself bounded so a wedged backend cannot block the worker indefinitely.
+const batchCleanupTimeout = 10 * time.Second
+
 // IngestionPipeline processes file attachment jobs asynchronously.
 // It reads files, extracts text, chunks, embeds, and stores the
 // resulting vectors in the backend.
@@ -56,6 +68,7 @@ type IngestionPipeline struct {
 	embedder     Embedder
 	jobQueue     chan IngestionJob
 	workers      int
+	batchSize    int
 	lifecycleMu  sync.Mutex
 	mu           sync.RWMutex
 	fileStatuses map[string]*VectorStoreFile // vsf_id -> status
@@ -73,6 +86,7 @@ type IngestionPipeline struct {
 type PipelineConfig struct {
 	Workers   int // number of concurrent workers (default 2)
 	QueueSize int // job queue buffer size (default 100)
+	BatchSize int // chunks embedded+inserted per batch (default 64)
 }
 
 // NewIngestionPipeline creates a new ingestion pipeline.
@@ -85,6 +99,10 @@ func NewIngestionPipeline(backend VectorStoreBackend, fileStore *FileStore, mana
 	if queueSize <= 0 {
 		queueSize = 100
 	}
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
 
 	return &IngestionPipeline{
 		backend:      backend,
@@ -93,6 +111,7 @@ func NewIngestionPipeline(backend VectorStoreBackend, fileStore *FileStore, mana
 		embedder:     embedder,
 		jobQueue:     make(chan IngestionJob, queueSize),
 		workers:      workers,
+		batchSize:    batchSize,
 		fileStatuses: make(map[string]*VectorStoreFile),
 		stopCh:       make(chan struct{}),
 	}
@@ -385,20 +404,15 @@ func (p *IngestionPipeline) processJob(ctx context.Context, job IngestionJob) {
 		return
 	}
 
-	// Step 5: Embed each chunk.
-	embeddedChunks, ok := p.embedChunks(ctx, job, record.Filename, chunks)
-	if !ok {
-		return
-	}
-
-	if err := ctx.Err(); err != nil {
-		p.failJob(ctx, job, "cancelled", "ingestion cancelled before storage")
-		return
-	}
-
-	// Step 6: Insert into backend.
-	if err := p.backend.InsertChunks(ctx, job.VectorStoreID, embeddedChunks); err != nil {
-		p.failJob(ctx, job, "storage_error", fmt.Sprintf("failed to store chunks: %v", err))
+	// Steps 5 & 6: Embed and store chunks in bounded batches.
+	//
+	// Rather than embedding every chunk and then inserting them all at once —
+	// which holds the whole file's chunk text and embedding vectors in memory
+	// simultaneously — process chunks in fixed-size windows. This bounds peak
+	// per-job memory to roughly O(batchSize × embeddingDimension) regardless of
+	// file size. ctx is checked before each batch so a cancelled lifecycle
+	// aborts promptly between batches.
+	if !p.embedAndStoreBatches(ctx, job, record.Filename, chunks) {
 		return
 	}
 
@@ -408,6 +422,75 @@ func (p *IngestionPipeline) processJob(ctx context.Context, job IngestionJob) {
 		fc.InProgress--
 		fc.Completed++
 	})
+}
+
+// embedAndStoreBatches embeds and inserts chunks in fixed-size windows of
+// p.batchSize. It returns true when every chunk has been stored, and false when
+// a batch failed or the job was cancelled — in which case it has already marked
+// the job failed and, if any earlier batch had already been inserted, made a
+// best-effort attempt to remove the partial chunks so a failed file leaves no
+// searchable state (full transactional reconciliation is tracked separately in
+// #2474).
+func (p *IngestionPipeline) embedAndStoreBatches(ctx context.Context, job IngestionJob, filename string, chunks []TextChunk) bool {
+	inserted := false
+	for start := 0; start < len(chunks); start += p.batchSize {
+		end := start + p.batchSize
+		if end > len(chunks) {
+			end = len(chunks)
+		}
+
+		if err := ctx.Err(); err != nil {
+			p.failBatchJob(ctx, job, inserted, "cancelled",
+				fmt.Sprintf("ingestion cancelled before embedding batch at chunk %d", start))
+			return false
+		}
+
+		embeddedChunks, ok := p.embedChunks(ctx, job, filename, chunks[start:end])
+		if !ok {
+			// embedChunks already recorded the failure status; still clean up any
+			// chunks inserted by earlier batches so the failed file is not
+			// partially searchable.
+			p.cleanupPartialChunks(ctx, job, inserted)
+			return false
+		}
+
+		if err := ctx.Err(); err != nil {
+			p.failBatchJob(ctx, job, inserted, "cancelled",
+				fmt.Sprintf("ingestion cancelled before storing batch at chunk %d", start))
+			return false
+		}
+
+		if err := p.backend.InsertChunks(ctx, job.VectorStoreID, embeddedChunks); err != nil {
+			p.failBatchJob(ctx, job, inserted, "storage_error",
+				fmt.Sprintf("failed to store chunks: %v", err))
+			return false
+		}
+		inserted = true
+	}
+	return true
+}
+
+// failBatchJob marks a job failed and, when earlier batches were already
+// inserted, removes the partial chunks first so a failed file leaves no
+// searchable state.
+func (p *IngestionPipeline) failBatchJob(ctx context.Context, job IngestionJob, inserted bool, code, message string) {
+	p.cleanupPartialChunks(ctx, job, inserted)
+	p.failJob(ctx, job, code, message)
+}
+
+// cleanupPartialChunks best-effort removes chunks already inserted for a job
+// whose ingestion failed partway through. The delete is detached from the
+// job context (which may be cancelled during shutdown) but bounded by
+// batchCleanupTimeout so a wedged backend cannot block the worker. Failure to
+// clean up is logged implicitly by leaving the file marked failed; it is not
+// surfaced as a separate error because the job is already failing.
+func (p *IngestionPipeline) cleanupPartialChunks(ctx context.Context, job IngestionJob, inserted bool) {
+	if !inserted {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), batchCleanupTimeout)
+	defer cancel()
+	_ = p.backend.DeleteByFileID(cleanupCtx, job.VectorStoreID, job.FileID)
 }
 
 // embedChunks embeds each chunk, checking ctx before each embedding call so a

--- a/src/semantic-router/pkg/vectorstore/pipeline_batch_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_batch_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vectorstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// insertSpyBackend wraps a backend and records every InsertChunks call so tests
+// can assert that ingestion is actually batched (call count and per-call size).
+type insertSpyBackend struct {
+	VectorStoreBackend
+	mu          sync.Mutex
+	insertCalls int
+	insertSizes []int
+}
+
+func newInsertSpyBackend(inner VectorStoreBackend) *insertSpyBackend {
+	return &insertSpyBackend{VectorStoreBackend: inner}
+}
+
+func (s *insertSpyBackend) InsertChunks(ctx context.Context, vectorStoreID string, chunks []EmbeddedChunk) error {
+	s.mu.Lock()
+	s.insertCalls++
+	s.insertSizes = append(s.insertSizes, len(chunks))
+	s.mu.Unlock()
+	return s.VectorStoreBackend.InsertChunks(ctx, vectorStoreID, chunks)
+}
+
+func (s *insertSpyBackend) calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.insertCalls
+}
+
+func (s *insertSpyBackend) maxBatch() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m := 0
+	for _, n := range s.insertSizes {
+		if n > m {
+			m = n
+		}
+	}
+	return m
+}
+
+// indexFailEmbedder embeds normally but returns an error once it reaches a
+// specific chunk index, letting a test fail ingestion partway through a
+// multi-batch file.
+type indexFailEmbedder struct {
+	dim      int
+	failAt   int // chunk index at which Embed returns an error (-1 = never)
+	mu       sync.Mutex
+	seen     int
+	seenList []string
+}
+
+func (e *indexFailEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	e.mu.Lock()
+	idx := e.seen
+	e.seen++
+	e.seenList = append(e.seenList, text)
+	e.mu.Unlock()
+
+	if e.failAt >= 0 && idx == e.failAt {
+		return nil, fmt.Errorf("synthetic embed failure at chunk %d", idx)
+	}
+	emb := make([]float32, e.dim)
+	for i := range emb {
+		emb[i] = 0.1
+	}
+	return emb, nil
+}
+
+func (e *indexFailEmbedder) Dimension() int { return e.dim }
+
+// batchFixture builds a pipeline with a spy backend and a configurable batch
+// size and embedder, so batching behavior can be observed directly.
+type batchFixture struct {
+	backend  *insertSpyBackend
+	mem      *MemoryBackend
+	store    *FileStore
+	mgr      *Manager
+	pipeline *IngestionPipeline
+	tempDir  string
+	ctx      context.Context
+}
+
+func newBatchFixture(embedder Embedder, batchSize int) *batchFixture {
+	GinkgoHelper()
+
+	tempDir, err := os.MkdirTemp("", "pipeline-batch-test-*")
+	Expect(err).NotTo(HaveOccurred())
+
+	mem := NewMemoryBackend(MemoryBackendConfig{})
+	spy := newInsertSpyBackend(mem)
+	store, err := NewFileStore(tempDir, NewMemoryMetadataRegistry())
+	Expect(err).NotTo(HaveOccurred())
+
+	mgr := NewManager(spy, NewMemoryMetadataRegistry(), 3, BackendTypeMemory)
+	pipeline := NewIngestionPipeline(spy, store, mgr, embedder, PipelineConfig{
+		Workers:   1,
+		QueueSize: 10,
+		BatchSize: batchSize,
+	})
+	pipeline.Start()
+
+	return &batchFixture{
+		backend:  spy,
+		mem:      mem,
+		store:    store,
+		mgr:      mgr,
+		pipeline: pipeline,
+		tempDir:  tempDir,
+		ctx:      context.Background(),
+	}
+}
+
+func (f *batchFixture) cleanup() {
+	_ = f.pipeline.Stop(context.Background())
+	_ = os.RemoveAll(f.tempDir)
+}
+
+func (f *batchFixture) createStore(name string) *VectorStore {
+	GinkgoHelper()
+	vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: name})
+	Expect(err).NotTo(HaveOccurred())
+	return vs
+}
+
+// attach saves an n-chunk document and attaches it, returning the store and the
+// vector-store-file ID so each test can assert on the resulting status.
+func (f *batchFixture) attach(storeName string, numChunks int) (*VectorStore, string) {
+	GinkgoHelper()
+	vs := f.createStore(storeName)
+	record, err := f.store.Save("doc.txt", []byte(nParagraphContent(numChunks)), "assistants")
+	Expect(err).NotTo(HaveOccurred())
+	vsf, err := f.pipeline.AttachFile(vs.ID, record.ID, nil)
+	Expect(err).NotTo(HaveOccurred())
+	return vs, vsf.ID
+}
+
+// nParagraphContent returns text that ChunkText (auto strategy) splits into
+// exactly n chunks: n distinct, heading-free paragraphs separated by blank
+// lines, each well under DefaultMaxChunkSize so it maps to a single chunk.
+func nParagraphContent(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "paragraph number %d with some filler words", i)
+	}
+	return b.String()
+}
+
+func countChunks(f *batchFixture, vsID string) int {
+	GinkgoHelper()
+	results, err := f.mem.Search(f.ctx, vsID, []float32{0.1, 0.1, 0.1}, 100000, 0, nil)
+	Expect(err).NotTo(HaveOccurred())
+	return len(results)
+}
+
+var _ = Describe("IngestionPipeline bounded batching", func() {
+	var f *batchFixture
+
+	AfterEach(func() {
+		if f != nil {
+			f.cleanup()
+			f = nil
+		}
+	})
+
+	DescribeTable("stores every chunk across batch boundaries",
+		func(numChunks, batchSize int) {
+			f = newBatchFixture(&mockEmbedder{dim: 3}, batchSize)
+			vs, vsfID := f.attach("batch-correctness", numChunks)
+			expectPipelineStatus(f.pipeline, vsfID, "completed")
+
+			// All chunks landed in the backend.
+			Expect(countChunks(f, vs.ID)).To(Equal(numChunks))
+
+			// Insert happened in bounded batches: expected number of calls and no
+			// call larger than the configured batch size.
+			expectedCalls := (numChunks + batchSize - 1) / batchSize
+			Expect(f.backend.calls()).To(Equal(expectedCalls))
+			Expect(f.backend.maxBatch()).To(BeNumerically("<=", batchSize))
+		},
+		Entry("single chunk, batch 4", 1, 4),
+		Entry("fewer than one batch", 3, 4),
+		Entry("exact multiple of batch", 8, 4),
+		Entry("one over a batch boundary", 5, 4),
+		Entry("batch size of one", 4, 1),
+		Entry("many chunks, small batch", 13, 5),
+	)
+
+	It("defaults to batch size 64 when unset", func() {
+		const numChunks = 65 // 65 chunks -> 2 inserts at default batch 64
+		f = newBatchFixture(&mockEmbedder{dim: 3}, 0)
+		vs, vsfID := f.attach("batch-default", numChunks)
+		expectPipelineStatus(f.pipeline, vsfID, "completed")
+
+		Expect(countChunks(f, vs.ID)).To(Equal(numChunks))
+		Expect(f.backend.calls()).To(Equal(2))
+		Expect(f.backend.maxBatch()).To(BeNumerically("<=", 64))
+	})
+
+	It("removes already-inserted chunks when a later batch fails", func() {
+		const numChunks = 10
+		const batchSize = 3
+		// Fail at chunk index 7 -> batches [0,3) and [3,6) inserted, then batch
+		// [6,9) fails while embedding chunk 7.
+		f = newBatchFixture(&indexFailEmbedder{dim: 3, failAt: 7}, batchSize)
+		vs, vsfID := f.attach("batch-failcleanup", numChunks)
+		expectPipelineStatus(f.pipeline, vsfID, "failed")
+
+		status, err := f.pipeline.GetFileStatus(vsfID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status.LastError).NotTo(BeNil())
+		Expect(status.LastError.Code).To(Equal("embedding_error"))
+
+		// Partial chunks from the first two batches must have been cleaned up:
+		// a failed file leaves nothing searchable.
+		Expect(countChunks(f, vs.ID)).To(Equal(0))
+
+		updated, err := f.mgr.GetStore(vs.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated.FileCounts.Failed).To(Equal(1))
+		Expect(updated.FileCounts.Completed).To(Equal(0))
+		Expect(updated.FileCounts.InProgress).To(Equal(0))
+	})
+
+	It("does not attempt cleanup when the first batch fails", func() {
+		const numChunks = 6
+		const batchSize = 3
+		// Fail at chunk index 0 -> no batch ever inserted; nothing to clean up.
+		f = newBatchFixture(&indexFailEmbedder{dim: 3, failAt: 0}, batchSize)
+		vs, vsfID := f.attach("batch-firstfail", numChunks)
+		expectPipelineStatus(f.pipeline, vsfID, "failed")
+
+		Expect(f.backend.calls()).To(Equal(0))
+		Expect(countChunks(f, vs.ID)).To(Equal(0))
+	})
+})
+
+var _ = Describe("IngestionPipeline batching config default", func() {
+	It("applies the default batch size through NewIngestionPipeline", func() {
+		tempDir, err := os.MkdirTemp("", "pipeline-cfg-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		mem := NewMemoryBackend(MemoryBackendConfig{})
+		store, err := NewFileStore(tempDir, NewMemoryMetadataRegistry())
+		Expect(err).NotTo(HaveOccurred())
+		mgr := NewManager(mem, NewMemoryMetadataRegistry(), 3, BackendTypeMemory)
+
+		p := NewIngestionPipeline(mem, store, mgr, &mockEmbedder{dim: 3}, PipelineConfig{})
+		Expect(p.batchSize).To(Equal(defaultBatchSize))
+
+		p2 := NewIngestionPipeline(mem, store, mgr, &mockEmbedder{dim: 3}, PipelineConfig{BatchSize: 7})
+		Expect(p2.batchSize).To(Equal(7))
+	})
+})


### PR DESCRIPTION
Part of #2474 (vector-store ingestion hardening) — implements the "bounded streaming batches" acceptance item. Not a full close of the umbrella issue, whose remaining slices (status retention, saga reconciliation, parser streaming) are tracked separately.

## Purpose

- **What:** The ingestion pipeline embedded *every* chunk of a file and then inserted them all in a single `InsertChunks` call. That holds the whole file's chunk text and embedding vectors in memory simultaneously — an unbounded-by-count per-job memory spike, multiplied across ingestion workers. This PR embeds and stores chunks in fixed-size windows instead (default 64, configurable via `vector_store.ingestion_batch_size`), bounding peak per-job memory to roughly `O(batch_size × embedding_dimension)` regardless of file size.
- **Why:** Large uploads with high-dimensional embeddings could drive large transient allocations; batching makes ingestion memory predictable and bounded. This implements the *bounded streaming batches* acceptance item of the vector-store hardening issue #2474.
- **Module(s):** `Router` (primary), with config-surface updates to `Dashboard` and `E2E`/Helm values.

### Behavior notes

- `ctx` is checked before each batch, so a cancelled lifecycle aborts promptly between batches. Chunk IDs remain globally correct across batch boundaries (indexing is unchanged).
- Batching changes failure semantics: earlier batches are already inserted when a later one fails. To preserve the prior all-or-nothing invariant (**a failed file leaves nothing searchable**), a partial failure now best-effort removes the already-inserted chunks via `DeleteByFileID`, detached from the (possibly cancelled) job context so cleanup still runs during shutdown, but bounded so a wedged backend cannot block the worker.
- **Out of scope (tracked separately under #2474):** streaming the *parser* (text extraction still returns the full document), status TTL/retention, and full transactional/saga reconciliation.

## Test Plan

From `src/semantic-router`:

```
go build ./pkg/...
go build -tags=milvus ./cmd            # real router binary
go test -race ./pkg/vectorstore ./pkg/routerruntime
go test ./pkg/config
golangci-lint run ./pkg/vectorstore/... ./pkg/config/... ./pkg/routerruntime/... \
  --config ../../tools/linter/go/.golangci.yml
```

New unit tests in `pkg/vectorstore/pipeline_batch_test.go`:

- **Batch-boundary correctness** (table): chunk counts of 1/3/5/8/13 against batch sizes 1/4/5 — asserts every chunk is stored, the number of `InsertChunks` calls equals `ceil(N/batch)`, and no batch exceeds the configured size.
- **Default batch size**: unset → 64 (65 chunks → 2 inserts).
- **Partial-failure cleanup**: a failure in a later batch removes the already-inserted chunks; the store ends with 0 searchable chunks and the file counted as failed.
- **First-batch failure**: no insert happened, so no cleanup is attempted.

## Test Result

- All of the above pass. `go test -race` is clean for `pkg/vectorstore`, `pkg/routerruntime`, and `pkg/config`; `golangci-lint` reports **0 issues**; `gofmt`/`go vet` clean; the router binary builds with the `milvus` tag.
- The Kubernetes-backed `rag-hybrid-search` E2E profile is not run locally (requires a cluster); it exercises this path in CI.
- Follow-up: the remaining #2474 items (parser streaming, status retention, saga reconciliation) are separate slices.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
