### PR TITLE
[Website] Restore author avatars and titles on blog post pages

### DIFF
--- a/website/src/css/blog.css
+++ b/website/src/css/blog.css
@@ -517,9 +517,50 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-post__authors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.1rem 2.2rem;
   margin: 1.45rem 0 0;
+  padding: 0;
   color: #101827;
   font-size: 1.02rem;
+  list-style: none;
+}
+
+.site-blog-post__author {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.site-blog-post__author-avatar {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.site-blog-post__author-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  line-height: 1.3;
+}
+
+.site-blog-post__author-details a,
+.site-blog-post__author-details span {
+  color: #101827;
+  font-weight: 620;
+  text-decoration: none;
+}
+
+.site-blog-post__author-details a:hover {
+  color: #238fdc;
+}
+
+.site-blog-post__author-details small {
+  color: #657b98;
+  font-size: 0.86rem;
 }
 
 .site-blog-post__tags {
@@ -811,6 +852,7 @@ html[data-route-kind='blog'] body,
 [data-theme='dark'] .site-blog-pagination__status,
 [data-theme='dark'] .site-blog-post__breadcrumb,
 [data-theme='dark'] .site-blog-post__meta,
+[data-theme='dark'] .site-blog-post__author-details small,
 [data-theme='dark'] .site-blog-post__tags a,
 [data-theme='dark'] .site-blog-layout__toc .table-of-contents__link {
   color: var(--site-muted-bright);
@@ -820,6 +862,8 @@ html[data-route-kind='blog'] body,
 [data-theme='dark'] .site-blog-recent a,
 [data-theme='dark'] .site-blog-post__header h1,
 [data-theme='dark'] .site-blog-post__authors,
+[data-theme='dark'] .site-blog-post__author-details a,
+[data-theme='dark'] .site-blog-post__author-details span,
 [data-theme='dark'] .site-blog-post__content,
 [data-theme='dark'] .site-blog-post__content p,
 [data-theme='dark'] .site-blog-post__content li {

--- a/website/src/theme/BlogPostItem/index.tsx
+++ b/website/src/theme/BlogPostItem/index.tsx
@@ -39,10 +39,7 @@ export default function BlogPostItem({
     tags,
     title,
   } = metadata
-  const authorNames = authors
-    .map(author => author.name)
-    .filter(Boolean)
-    .join(', ')
+  const namedAuthors = authors.filter(author => Boolean(author.name))
 
   return (
     <BlogPostItemContainer className={className}>
@@ -57,8 +54,31 @@ export default function BlogPostItem({
             <span>{`${Math.ceil(readingTime)} min read`}</span>
           )}
         </div>
-        {authorNames && (
-          <p className="site-blog-post__authors">{authorNames}</p>
+        {namedAuthors.length > 0 && (
+          <ul aria-label="Authors" className="site-blog-post__authors">
+            {namedAuthors.map((author, index) => (
+              <li className="site-blog-post__author" key={author.key ?? author.name ?? index}>
+                {author.imageURL && (
+                  <img
+                    alt=""
+                    className="site-blog-post__author-avatar"
+                    loading="lazy"
+                    src={author.imageURL}
+                  />
+                )}
+                <div className="site-blog-post__author-details">
+                  {author.url
+                    ? (
+                        <Link to={author.url}>{author.name}</Link>
+                      )
+                    : (
+                        <span>{author.name}</span>
+                      )}
+                  {author.title && <small>{author.title}</small>}
+                </div>
+              </li>
+            ))}
+          </ul>
         )}
         {tags.length > 0 && (
           <ul aria-label="Tags" className="site-blog-post__tags">


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

The blog refresh in #2644 replaced the stock Docusaurus post header with a swizzled `BlogPostItem` that collapsed authors into a plain comma-joined string, dropping the avatar photos, profile links, and titles defined in `website/blog/authors.yml`.

This PR renders each author in the swizzled header again as avatar + linked name + title:

- `website/src/theme/BlogPostItem/index.tsx`: replace the joined `authorNames` string with an author list using `metadata.authors` (`imageURL`, `url`, `title`); authors without an image (e.g. inline "vLLM Semantic Router Team" posts) fall back to the linked name only
- `website/src/css/blog.css`: author row styles in the refresh's `site-blog-post__*` design language, plus `[data-theme='dark']` rules following the file's existing pattern (dark mode is currently disabled site-wide, so these stay dormant but consistent)

## Which issue(s) this PR fixes

Fixes #2671

## Test Plan

- Verified locally with the Docusaurus dev server: posts with registered authors (e.g. `/blog/training-embedding-models-huggingface`, `/blog/opencode-auto-mode`) show avatar + linked name + title for each author
- Verified graceful fallback on team-authored posts without images (e.g. `/blog/semantic-router`): linked name renders, no broken `<img>`
- `npx eslint src/theme/BlogPostItem/index.tsx` passes