### PR TITLE
[Docs] add zh-Hans translations for learning and routing tutorials

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/learning/experience.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/learning/experience.md
@@ -1,0 +1,43 @@
+---
+translation:
+  source_commit: "ad233487"
+  source_file: "docs/tutorials/learning/experience.md"
+  outdated: false
+---
+
+# 经验（Experience）
+
+## 概览
+
+经验是 adaptation 使用的在线 Router Learning 证据。它在请求路径的进程内维护，并根据有界的结果和遥测数据进行汇总。离线配方学习可以导出 seed-pack 工件，用于冷启动分析和未来的预热流程，但首个公开 API 不提供运行时 seed-pack 导入开关。
+
+## 主要优势
+
+- 避免在请求路径中进行高开销的聚合。
+- 将结果和遥测数据转化为紧凑的读取时证据。
+- 为 adaptation 提供类型明确的位置，用于存放学习到的模型选择事实。
+- 保持 Router Replay 作为事件日志的事实来源。
+
+## 解决什么问题？
+
+有些路由证据依赖历史请求，例如模型适配度、过度使用、提供商故障、延迟、缓存复用和实际成本。在处理请求时读取所有事件会过于缓慢。路由器会在内存中更新紧凑的模型经验，并将持久证据写入 Router Replay，供离线分析使用。
+
+## 何时使用
+
+- Adaptation 需要来自结果和运行时遥测的聚合证据。
+- 运维人员希望通过离线评估解释冷启动时的模型质量证据。
+- 离线配方学习需要 seed-pack 工件，用于实验或未来的预热流程。
+
+## 配置
+
+当前公开 API 不提供 `experience.enabled`、`experience.source` 或运行时 seed-pack 导入字段。启用 adaptation 后，模型经验将成为 `routing_sampling` 实现的一部分。
+
+在线经验以匹配的 decision、decision tier 和模型为键：
+
+```text
+decision_id + decision_tier + model
+  -> decision_tier + model
+  -> model
+```
+
+结果摄取会更新面向模型的经验。路由、策略、稳定性、提供商和路由器结果会进入 replay 诊断和离线配方学习，而不会直接修改模型质量。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/request-params.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/request-params.md
@@ -1,0 +1,57 @@
+---
+translation:
+  source_commit: "15c6c555"
+  source_file: "docs/tutorials/plugin/request-params.md"
+  outdated: false
+---
+
+# 请求参数（Request Parameters）
+
+## 概览
+
+`request_params` 是一个路由局部插件，用于在 OpenAI Chat Completions 请求体转发到后端之前对其进行校验和裁剪。
+
+它对应 `config/plugin/request-params/budget-tier.yaml`。
+
+## 主要优势
+
+- 按路由限制高成本参数（`max_tokens`、`n`）。
+- 对不应暴露 token 分布的层级，阻止 `logprobs` / `top_logprobs` 等敏感参数。
+- 可以选择移除未知的顶层 JSON 字段，减少透传行为带来的意外。
+
+## 解决什么问题？
+
+模型路由可以限制由哪个后端处理请求，但客户端仍然可以通过请求参数放大成本或提取 logits。该插件会在 decision 匹配后，对请求体执行按 decision 配置的限制。
+
+## 何时使用
+
+- 某个层级或路由不得请求 logprobs 或多条 completion
+- 需要对 `max_tokens` 或 `n` 设置独立于客户端输入的硬上限
+- 不应将未知 JSON 字段转发到后端
+
+## 配置
+
+在 `routing.decisions[].plugins` 下使用此片段（插件条目列表）：
+
+```yaml
+plugins:
+  - type: request_params
+    configuration:
+      blocked_params:
+        - logprobs
+        - top_logprobs
+      max_tokens_limit: 500
+      max_n: 1
+      strip_unknown: true
+```
+
+在 DSL 中，同一个插件可以写成：
+
+```dsl
+PLUGIN request_params {
+  blocked_params: ["logprobs", "top_logprobs"]
+  max_tokens_limit: 500
+  max_n: 1
+  strip_unknown: true
+}
+```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/tool-selection.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/tool-selection.md
@@ -1,0 +1,59 @@
+---
+translation:
+  source_commit: "e0e7df56"
+  source_file: "docs/tutorials/plugin/tool-selection.md"
+  outdated: false
+---
+
+# 工具选择（Tool Selection）
+
+## 概览
+
+`tool_selection` 是一个 decision 插件，用于控制如何为匹配的路由选择工具。
+它支持两种模式：
+
+- `add`：从工具数据库中检索工具
+- `filter`：筛选传入请求中已有的工具
+
+它对应 `config/plugin/tool-selection/` 下的片段。
+
+## 主要优势
+
+- 将路由 decision 逻辑与工具检索/筛选行为分离。
+- 同时支持由数据库驱动的工具添加和对请求工具的语义筛选。
+- 在明确选择行为的同时，保持与路由局部工具策略的兼容性。
+
+## 解决什么问题？
+
+不同路由需要不同的工具选择行为。有些路由应从经过整理的数据库中添加工具，另一些路由则应只保留调用方所提供工具中最相关的部分。`tool_selection` 为这两类场景提供统一的插件契约，并支持 threshold、`top_k` 和保留行为等按路由控制项。
+
+## 何时使用
+
+- decision 应从 `tools_db` 添加最相关的工具
+- decision 应对调用方提供的 `tools` 进行语义筛选
+- 必须明确配置按路由的工具选择模式
+
+## 配置
+
+在 `routing.decisions[].plugins` 下使用此片段：
+
+```yaml
+plugin:
+  type: tool_selection
+  configuration:
+    enabled: true
+    mode: filter
+    relevance_threshold: 0.55
+    preserve_count: 2
+```
+
+对于 add 模式：
+
+```yaml
+plugin:
+  type: tool_selection
+  configuration:
+    enabled: true
+    mode: add
+    top_k: 5
+```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/projection/traces.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/projection/traces.md
@@ -1,0 +1,57 @@
+---
+translation:
+  source_commit: "cefd4ff0"
+  source_file: "docs/tutorials/projection/traces.md"
+  outdated: false
+sidebar_position: 5
+---
+
+# 投影追踪与回放
+
+## 概览
+
+当 [Router Replay](../../installation/configuration) 捕获路由记录时，除了 `projections`（匹配的输出名称）和 `projection_scores`（聚合数值分数）之外，每条记录还可以包含结构化的 **`projection_trace`** 字段（JSON）。
+
+该追踪说明 partition reduction、加权分数和 mapping 阈值在该请求中的*具体行为*，让运维人员和 Dashboard 用户无需根据标量分数推测内部过程即可调试路由。
+
+## 主要优势
+
+- Replay 记录保持自描述：同一持久化路径同时承载聚合分数和结构化可解释性 JSON。
+- Partition contender 列表、softmax winner、mapping 边界距离以及逐输入分数贡献集中呈现在一个对象中。
+- Payload 中的版本 `1` 为增量字段预留了空间，无需重写旧版 consumer。
+
+## 解决什么问题？
+
+匹配的投影名称（`projections`）和数值摘要（`projection_scores`）能够说明**选择了什么**，但不会保留 partition **为何**选中某个 winner，也无法说明 mapping 距离下一个阈值区间有多近。
+
+`projection_trace` 补上了审计、支持和 Insights 视图所需的这部分信息，而且无需额外的查询时推理。
+
+## 何时使用
+
+- 正在运行 **Router Replay**（内存、Redis 或 PostgreSQL），并希望每条记录都包含可解释性列。
+- 使用 **Dashboard → Insights** 深入查看由 replay 支持的流程，并需要可折叠的投影详情。
+- 正在构建根据真实流量（而非仅静态配置）校验投影行为的工具。
+
+## 配置
+
+计算投影时会产生可解释性 payload；其存储方式取决于 replay 后端配置：
+
+- 使用 **[Router Replay 配置](../../installation/configuration)**中介绍的持久化设置启用 replay。
+- 对于 PostgreSQL，确保 migration 在 **`projections`** 和 **`projection_scores`** 旁包含 **`projection_trace`**（JSONB）列。
+
+系统没有独立的“启用/关闭追踪”开关：只要运行投影，并且 recorder 持久化增强后的 `SignalResults`/`Record`，追踪就会隐式启用。
+
+## Schema 版本 `1`
+
+追踪带有版本号，以支持 consumer 向前兼容。
+
+- **`partitions`**：每个在当前请求中执行 reduction 的 `routing.projections.partitions` 分组对应一个条目。记录包含带 **`raw_score`** 的 **`contenders`**（语义为 `softmax_exclusive` 时还包含 **`normalized_score`**）、选中的 **`winner`**、**`winner_score`**（随后由路由器存储到信号中的值）、**`raw_winner_score`**、**`margin`**（比较分数中第一名减第二名；softmax 使用归一化权重，其他情况使用原始置信度），以及当 partition 合成其配置的默认成员时设置的 **`default_used`**。
+- **`scores`**：每个已配置投影分数对应一个条目，包含 **`total`** 和逐输入 **`contribution`**（`weight * value`），与运行时的加权和一致。
+- **`mappings`**：每个 projection mapping 对应一个条目。对于按顺序排列的每个阈值区间，追踪会记录 **`matched`**、**`boundary_distance`**（到最近有效阈值的距离）；对于第一个匹配区间，还会记录该区间所使用的 **`selected_output`**、sigmoid **`confidence`** 和 **`boundary_distance`**。
+
+## 在哪里查看
+
+- **Dashboard → Insights**：打开由 replay 支持的记录。**Projection trace** 部分会显示 partition winner（存在 contender 时可展开其明细）、分数输入和 mapping decision（包括边界距离和逐输出阈值步骤列表）的表格，以及可折叠的原始 JSON。
+- **存储**：同一对象会持久化到 replay `Record` 中（内存、Redis 或 PostgreSQL 的 `projection_trace` JSONB 列）。
+
+追踪仅根据投影契约和已经计算的信号结果派生，不存在不透明的 sidecar 模型。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/signal/learned/reask.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/signal/learned/reask.md
@@ -1,0 +1,56 @@
+---
+translation:
+  source_commit: "c904264a"
+  source_file: "docs/tutorials/signal/learned/reask.md"
+  outdated: false
+---
+
+# Reask 信号
+
+## 概览
+
+`reask` 用于检测当前用户轮次是否在语义上重复同一对话中最近的用户轮次。它对应 `config/signal/reask/`，并在 `routing.signals.reasks` 下声明。
+
+该信号族属于学习型信号：它使用路由器共享的语义 embedding 路径，将当前用户轮次与之前的用户轮次进行比较。
+
+## 主要优势
+
+- 无需用户明确说出“这是错的”等措辞，也能捕获隐含的不满。
+- 区分一次重复提问和连续多轮重复所形成的不满趋势。
+- 允许 decision 根据最近的对话历史升级，而不是只依据单条消息。
+- 复用现有的语义相似度技术栈，不引入第二套模型能力面。
+
+## 解决什么问题？
+
+当上一次回答没有帮助时，用户通常会重新表述同一个问题。单轮分类器可能无法识别这种模式，因为用户的不满是隐含的，而非明确表达的。
+
+`reask` 通过比较最新用户轮次与最近的用户轮次来解决这一问题；当连续的近期轮次在语义上保持相似时，它会产生可配置的不满信号。
+
+## 何时使用
+
+在以下场景使用 `reask`：
+
+- 重复的问题应升级到更强的模型
+- 一次重复提问与多次重复提问需要采用不同的处理方式
+- 显式反馈较少，但用户轮次的重复仍具有意义
+- 路由 decision 应依赖同一对话中的用户历史
+
+## 配置
+
+源片段信号族：`config/signal/reask/`
+
+```yaml
+routing:
+  signals:
+    reasks:
+      - name: likely_dissatisfied
+        description: Current user turn closely repeats the immediately previous user turn.
+        threshold: 0.8
+        lookback_turns: 1
+      - name: persistently_dissatisfied
+        description: Current user turn repeats the last two user turns in a row.
+        threshold: 0.8
+        lookback_turns: 2
+```
+
+每条规则都会将当前用户轮次与最近的 `lookback_turns` 个历史用户轮次进行比较。只有该连续近期序列中的每个轮次都高于配置的相似度阈值时，规则才会匹配。


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2700 

## Purpose

- Add complete Simplified Chinese (`zh-Hans`) translations for five tutorial pages:
  - Router Learning experience
  - Reask signal
  - Request parameters plugin
  - Tool selection plugin
  - Projection traces and replay
- Record the latest English source commit for every translation and mark each fully reviewed page as `outdated: false`.
- Preserve the English heading hierarchy, code blocks, technical identifiers, configuration values, URLs, and relative link targets.
- This change is needed to reduce the Chinese documentation backlog while ensuring that localized pages remain fully synchronized with their current English sources.
- Affected module: `Docs`.

## Test Plan

- Build the complete multilingual documentation site:

  ```bash
  cd website
  npm run build
  ```

- Run repository documentation lint and structural validation:

  ```bash
  make agent-lint CHANGED_FILES="website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/learning/experience.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/signal/learned/reask.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/request-params.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/tool-selection.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/projection/traces.md"
  ```

- Validate the tutorial taxonomy against the router configuration hierarchy:

  ```bash
  cd src/semantic-router
  go test -count=1 ./pkg/config \
    -run TestLatestTutorialTaxonomyMatchesConfigHierarchy
  ```

- Run the translation metadata and source-drift audit:

  ```bash
  make docs-check-translations
  ```

- These checks validate MDX compilation, localized routes and links, Markdown formatting, tutorial/config consistency, translation metadata, and full-page structural parity.

## Test Result

- `npm run build`: passed for both English and `zh-Hans`.
- `make agent-lint CHANGED_FILES="..."`: passed.
- `go test -count=1 ./pkg/config -run TestLatestTutorialTaxonomyMatchesConfigHierarchy`: passed.
- Markdownlint: passed.
- `git diff --check`: passed.
- Per-page parity checks passed:
  - Every `source_commit` matches the latest English source commit.
  - Every page has the correct `source_file` and `outdated: false`.
  - Heading levels, fenced code blocks, and Markdown link targets match the English sources.
- `make docs-check-translations` reports:
  - `112` likely synchronized translations
  - `0` outdated translations
  - Missing translations reduced from `30` to `25`
  - Overall likely synchronization increased from `78%` to `81%`
- The translation audit currently exits nonzero because the new uncommitted files have no Git history and because unrelated translation backlog remains. The five no-history notices will disappear after these files are committed.
- Existing non-blocking build warnings remain for blog metadata, KaTeX Unicode handling, webpack dependency analysis, and unrelated signal-overview anchors. No new broken links or build blockers were introduced.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes (not applicable; this PR affects Docs only)
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
