### PR TITLE
[Docs] link Wilson Wu to the correct GitHub profile on contributor leaderboard

### DIFF
--- a/website/scripts/generate-contributor-rank.mjs
+++ b/website/scripts/generate-contributor-rank.mjs
@@ -115,6 +115,12 @@ query($cursor: String) {
 
 const identityOverrides = [
   {
+    key: 'wilsonwu',
+    name: 'Wilson Wu',
+    login: 'wilsonwu',
+    emails: ['iwilsonwu@gmail.com'],
+  },
+  {
     key: 'xunzhuo-liu',
     name: 'Xunzhuo Liu',
     login: 'Xunzhuo',


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2704 

## Purpose

- Add a canonical contributor identity override that maps Wilson Wu's Git author email, `iwilsonwu@gmail.com`, to the GitHub account `wilsonwu`.
- Ensure the next generated `v0.3 -> Now` leaderboard links Wilson Wu to `https://github.com/wilsonwu` and displays the correct GitHub avatar.
- Keep `contributorRank.generated.ts` workflow-owned instead of editing generated rank data manually.
- This change affects the `Docs` module only.

## Test Plan

- Run `cd website && node --check scripts/generate-contributor-rank.mjs`.
- Run `cd website && npx eslint scripts/generate-contributor-rank.mjs`.
- Run `git diff --check`.
- Run `git diff --quiet -- website/src/data/contributorRank.generated.ts` to confirm the generated artifact was not manually changed.
- Regenerate the leaderboard through the authenticated `Contributor Leaderboard` workflow and verify the latest Wilson Wu entry links to `https://github.com/wilsonwu`.

This validation covers the generator syntax and style while leaving generated leaderboard data to the existing authenticated automation.

## Test Result

- `node --check scripts/generate-contributor-rank.mjs` passed.
- `npx eslint scripts/generate-contributor-rank.mjs` passed.
- `git diff --check` passed.
- `contributorRank.generated.ts` remains unchanged.
- The harness classified the change as documentation-only with no additional required gates.
- The live leaderboard will update after the authenticated contributor leaderboard workflow regenerates the data and its refresh PR is merged.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.