### PR TITLE
[Router][E2E][Docs] Isolate multi-factor config by decision

### DIFF
--- a/e2e/profiles/routing-strategies/profile.go
+++ b/e2e/profiles/routing-strategies/profile.go
@@ -85,6 +85,7 @@ func (p *Profile) GetTestCases() []string {
 		"keyword-routing",
 		"entropy-routing",
 		"routing-fallback",
+		"decision-scoped-multi-factor",
 	}
 }
 

--- a/e2e/profiles/routing-strategies/values.yaml
+++ b/e2e/profiles/routing-strategies/values.yaml
@@ -25,8 +25,62 @@ config:
           - name: local-vllm
             endpoint: vllm-llama3-8b-instruct.default.svc.cluster.local:8000
             weight: 1
+      - name: premium-model
+        pricing:
+          currency: USD
+          prompt_per_1m: 10
+        backend_refs:
+          - name: local-vllm-premium
+            endpoint: vllm-llama3-8b-instruct.default.svc.cluster.local:8000
+            weight: 1
+      - name: economy-model
+        pricing:
+          currency: USD
+          prompt_per_1m: 1
+        backend_refs:
+          - name: local-vllm-economy
+            endpoint: vllm-llama3-8b-instruct.default.svc.cluster.local:8000
+            weight: 1
   routing:
     decisions:
+      - name: quality_policy_decision
+        description: Quality-only multi-factor policy
+        priority: 250
+        rules:
+          operator: AND
+          conditions:
+            - type: keyword
+              name: quality_policy
+        modelRefs:
+          - model: premium-model
+          - model: economy-model
+        algorithm:
+          type: multi_factor
+          multi_factor:
+            weights:
+              quality: 1
+              latency: 0
+              cost: 0
+              load: 0
+      - name: cost_policy_decision
+        description: Cost-only multi-factor policy
+        priority: 250
+        rules:
+          operator: AND
+          conditions:
+            - type: keyword
+              name: cost_policy
+        modelRefs:
+          - model: premium-model
+          - model: economy-model
+        algorithm:
+          type: multi_factor
+          multi_factor:
+            weights:
+              quality: 0
+              latency: 0
+              cost: 1
+              load: 0
       - name: code_keywords_decision
         description: Code and programming queries (BM25 classified)
         priority: 150
@@ -119,6 +173,16 @@ config:
               similarity_threshold: 0.75
     signals:
       keywords:
+        - name: quality_policy
+          operator: OR
+          keywords:
+            - decision scoped quality policy
+          case_sensitive: false
+        - name: cost_policy
+          operator: OR
+          keywords:
+            - decision scoped cost policy
+          case_sensitive: false
         - name: code_keywords
           operator: OR
           method: bm25
@@ -235,6 +299,10 @@ config:
           description: Block all PII
     modelCards:
       - name: base-model
+      - name: premium-model
+        quality_score: 0.9
+      - name: economy-model
+        quality_score: 0.1
   global:
     model_catalog:
       kbs: []

--- a/e2e/testcases/decision_scoped_multi_factor.go
+++ b/e2e/testcases/decision_scoped_multi_factor.go
@@ -1,0 +1,111 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("decision-scoped-multi-factor", pkgtestcases.TestCase{
+		Description: "Verify each matched decision uses its own multi-factor policy",
+		Tags:        []string{"routing", "selection", "multi-factor", "regression"},
+		Fn:          testDecisionScopedMultiFactor,
+	})
+}
+
+func testDecisionScopedMultiFactor(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	opts pkgtestcases.TestCaseOptions,
+) error {
+	localPort, stopPortForward, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopPortForward()
+
+	cases := []struct {
+		query        string
+		wantDecision string
+		wantModel    string
+	}{
+		{
+			query:        "Apply the decision scoped quality policy",
+			wantDecision: "quality_policy_decision",
+			wantModel:    "premium-model",
+		},
+		{
+			query:        "Apply the decision scoped cost policy",
+			wantDecision: "cost_policy_decision",
+			wantModel:    "economy-model",
+		},
+	}
+
+	for _, tc := range cases {
+		decision, model, err := requestDecisionScopedSelection(ctx, localPort, tc.query)
+		if err != nil {
+			return err
+		}
+		if decision != tc.wantDecision || model != tc.wantModel {
+			return fmt.Errorf(
+				"query %q selected decision=%q model=%q, want decision=%q model=%q",
+				tc.query,
+				decision,
+				model,
+				tc.wantDecision,
+				tc.wantModel,
+			)
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{"verified_policies": len(cases)})
+	}
+	return nil
+}
+
+func requestDecisionScopedSelection(ctx context.Context, localPort, query string) (string, string, error) {
+	payload, err := json.Marshal(map[string]interface{}{
+		"model": "MoM",
+		"messages": []map[string]string{
+			{"role": "user", "content": query},
+		},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("marshal chat request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("http://localhost:%s/v1/chat/completions", localPort),
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("create chat request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("send chat request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("read chat response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("chat request returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return resp.Header.Get("x-vsr-selected-decision"), resp.Header.Get("x-vsr-selected-model"), nil
+}

--- a/src/semantic-router/pkg/extproc/req_filter_classification.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification.go
@@ -152,10 +152,21 @@ func (r *OpenAIRouter) selectorForDecisionMethod(method selection.SelectionMetho
 	if method == selection.MethodHybrid && algorithm != nil && algorithm.Hybrid != nil {
 		return r.newDecisionHybridSelector(algorithm.Hybrid)
 	}
+	if method == selection.MethodMultiFactor && algorithm != nil {
+		return r.newDecisionMultiFactorSelector(algorithm.MultiFactor)
+	}
 	if r.ModelSelector == nil {
 		return nil
 	}
 	selector, _ := r.ModelSelector.Get(method)
+	return selector
+}
+
+func (r *OpenAIRouter) newDecisionMultiFactorSelector(decisionCfg *config.MultiFactorSelectionConfig) selection.Selector {
+	selector := selection.NewMultiFactorSelector(buildMultiFactorSelectionConfig(decisionCfg))
+	if r != nil && r.Config != nil && r.Config.ModelConfig != nil {
+		selector.InitializeFromConfig(r.Config.ModelConfig)
+	}
 	return selector
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_classification_selection_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_selection_test.go
@@ -178,6 +178,60 @@ func TestSelectorForDecisionMethodBuildsDecisionScopedHybridSelector(t *testing.
 	}
 }
 
+func TestSelectorForDecisionMethodBuildsDecisionScopedMultiFactorSelector(t *testing.T) {
+	qualityPolicy := &config.AlgorithmConfig{
+		Type: "multi_factor",
+		MultiFactor: &config.MultiFactorSelectionConfig{
+			Weights: &config.MultiFactorWeightsConfig{Quality: 1},
+		},
+	}
+	costPolicy := &config.AlgorithmConfig{
+		Type: "multi_factor",
+		MultiFactor: &config.MultiFactorSelectionConfig{
+			Weights: &config.MultiFactorWeightsConfig{Cost: 1},
+		},
+	}
+	cfg := config.DefaultGlobalConfig()
+	cfg.BackendModels.ModelConfig = map[string]config.ModelParams{
+		"premium": {
+			QualityScore: 0.9,
+			Pricing:      config.ModelPricing{PromptPer1M: 10},
+		},
+		"economy": {
+			QualityScore: 0.1,
+			Pricing:      config.ModelPricing{PromptPer1M: 1},
+		},
+	}
+	cfg.Decisions = []config.Decision{
+		{Name: "quality", Algorithm: qualityPolicy},
+		{Name: "cost", Algorithm: costPolicy},
+	}
+
+	registry := selection.NewFactory(buildModelSelectionConfig(&cfg)).
+		WithModelConfig(cfg.BackendModels.ModelConfig).
+		CreateAll()
+	router := &OpenAIRouter{Config: &cfg, ModelSelector: registry}
+	candidates := []config.ModelRef{{Model: "premium"}, {Model: "economy"}}
+
+	qualityResult, err := router.selectorForDecisionMethod(selection.MethodMultiFactor, qualityPolicy).
+		Select(context.Background(), &selection.SelectionContext{DecisionName: "quality", CandidateModels: candidates})
+	if err != nil {
+		t.Fatalf("quality selector returned error: %v", err)
+	}
+	if qualityResult.SelectedModel != "premium" {
+		t.Fatalf("quality decision selected %q, want premium", qualityResult.SelectedModel)
+	}
+
+	costResult, err := router.selectorForDecisionMethod(selection.MethodMultiFactor, costPolicy).
+		Select(context.Background(), &selection.SelectionContext{DecisionName: "cost", CandidateModels: candidates})
+	if err != nil {
+		t.Fatalf("cost selector returned error: %v", err)
+	}
+	if costResult.SelectedModel != "economy" {
+		t.Fatalf("cost decision selected %q, want economy", costResult.SelectedModel)
+	}
+}
+
 func TestBuildSelectionContextUsesPinnedSessionIDAndToolLoopFacts(t *testing.T) {
 	router := &OpenAIRouter{Config: &config.RouterConfig{
 		BackendModels: config.BackendModels{

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -142,18 +142,17 @@ func buildModelSelectionConfig(cfg *config.RouterConfig) *selection.ModelSelecti
 	modelSelectionCfg.AutoMix = buildAutoMixSelectionConfig(cfg)
 	modelSelectionCfg.Hybrid = buildHybridSelectionConfig(cfg, nil)
 	modelSelectionCfg.ML = buildMLSelectionConfig(cfg)
-	modelSelectionCfg.MultiFactor = buildMultiFactorSelectionConfig(decisionCfgs.multiFactor)
+	modelSelectionCfg.MultiFactor = buildMultiFactorSelectionConfig(nil)
 	modelSelectionCfg.RLDriven = buildRLDrivenSelectionConfig(decisionCfgs.rlDriven)
 	modelSelectionCfg.GMTRouter = buildGMTRouterSelectionConfig(decisionCfgs.gmtRouter)
 	return modelSelectionCfg
 }
 
 type decisionScopedSelectionConfigs struct {
-	elo         *config.EloSelectionConfig
-	routerDC    *config.RouterDCSelectionConfig
-	rlDriven    *config.RLDrivenSelectionConfig
-	gmtRouter   *config.GMTRouterSelectionConfig
-	multiFactor *config.MultiFactorSelectionConfig
+	elo       *config.EloSelectionConfig
+	routerDC  *config.RouterDCSelectionConfig
+	rlDriven  *config.RLDrivenSelectionConfig
+	gmtRouter *config.GMTRouterSelectionConfig
 }
 
 func findDecisionScopedSelectionConfigs(cfg *config.RouterConfig) decisionScopedSelectionConfigs {
@@ -183,11 +182,6 @@ func findDecisionScopedSelectionConfigs(cfg *config.RouterConfig) decisionScoped
 			decision.Algorithm.GMTRouter != nil &&
 			result.gmtRouter == nil {
 			result.gmtRouter = decision.Algorithm.GMTRouter
-		}
-		if decision.Algorithm.Type == "multi_factor" &&
-			decision.Algorithm.MultiFactor != nil &&
-			result.multiFactor == nil {
-			result.multiFactor = decision.Algorithm.MultiFactor
 		}
 	}
 

--- a/src/semantic-router/pkg/extproc/router_selection_config_test.go
+++ b/src/semantic-router/pkg/extproc/router_selection_config_test.go
@@ -151,7 +151,7 @@ func TestBuildHybridSelectionConfigMergesDecisionOverrides(t *testing.T) {
 	}
 }
 
-func TestBuildModelSelectionConfigUsesDecisionScopedMultiFactorConfig(t *testing.T) {
+func TestBuildModelSelectionConfigDoesNotPromoteDecisionMultiFactorConfig(t *testing.T) {
 	got := buildModelSelectionConfig(&config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
 			Decisions: []config.Decision{
@@ -184,16 +184,17 @@ func TestBuildModelSelectionConfigUsesDecisionScopedMultiFactorConfig(t *testing
 	if got.MultiFactor == nil {
 		t.Fatal("expected MultiFactor config to be built")
 	}
-	assertFloat(t, got.MultiFactor.Weights.Quality, 0.7, "multi_factor.weights.quality")
-	assertFloat(t, got.MultiFactor.Weights.Latency, 0.2, "multi_factor.weights.latency")
-	assertFloat(t, got.MultiFactor.Weights.Cost, 0.1, "multi_factor.weights.cost")
-	assertFloat(t, got.MultiFactor.Weights.Load, 0.0, "multi_factor.weights.load")
-	assertFloat(t, got.MultiFactor.SLO.MaxTPOTMs, 85, "multi_factor.slo.max_tpot_ms")
-	assertFloat(t, got.MultiFactor.SLO.MaxTTFTMs, 550, "multi_factor.slo.max_ttft_ms")
-	assertFloat(t, got.MultiFactor.SLO.MaxCostPer1M, 2.4, "multi_factor.slo.max_cost_per_1m")
-	assertInt(t, got.MultiFactor.SLO.MaxInflight, 32, "multi_factor.slo.max_inflight")
-	assertInt(t, got.MultiFactor.LatencyPercentile, 90, "multi_factor.latency_percentile")
-	assertString(t, got.MultiFactor.OnNoCandidates, "fail", "multi_factor.on_no_candidates")
+	defaults := selection.DefaultMultiFactorConfig()
+	assertFloat(t, got.MultiFactor.Weights.Quality, defaults.Weights.Quality, "multi_factor.weights.quality")
+	assertFloat(t, got.MultiFactor.Weights.Latency, defaults.Weights.Latency, "multi_factor.weights.latency")
+	assertFloat(t, got.MultiFactor.Weights.Cost, defaults.Weights.Cost, "multi_factor.weights.cost")
+	assertFloat(t, got.MultiFactor.Weights.Load, defaults.Weights.Load, "multi_factor.weights.load")
+	assertFloat(t, got.MultiFactor.SLO.MaxTPOTMs, 0, "multi_factor.slo.max_tpot_ms")
+	assertFloat(t, got.MultiFactor.SLO.MaxTTFTMs, 0, "multi_factor.slo.max_ttft_ms")
+	assertFloat(t, got.MultiFactor.SLO.MaxCostPer1M, 0, "multi_factor.slo.max_cost_per_1m")
+	assertInt(t, got.MultiFactor.SLO.MaxInflight, 0, "multi_factor.slo.max_inflight")
+	assertInt(t, got.MultiFactor.LatencyPercentile, defaults.LatencyPercentile, "multi_factor.latency_percentile")
+	assertString(t, got.MultiFactor.OnNoCandidates, defaults.OnNoCandidates, "multi_factor.on_no_candidates")
 }
 
 func assertFloat(t *testing.T, got, want float64, field string) {

--- a/website/docs/tutorials/algorithm/selection/multi-factor.md
+++ b/website/docs/tutorials/algorithm/selection/multi-factor.md
@@ -4,6 +4,8 @@
 
 `multi_factor` is a selection algorithm that composes four raw runtime signals — **quality**, **latency**, **cost**, and **load** — into a single weighted score per candidate, with optional SLO hard ceilings that prune candidates before scoring.
 
+The configuration belongs to the decision that declares it. If multiple decisions use `multi_factor`, each matched decision is evaluated with its own weights, SLOs, percentile, and no-candidate policy.
+
 It aligns to `config/algorithm/selection/multi-factor.yaml` and addresses issue [#37](https://github.com/vllm-project/semantic-router/issues/37).
 
 ## Key Advantages


### PR DESCRIPTION
Closes #2710

## Purpose

- Build `multi_factor` selectors from the algorithm configuration on the matched decision.
- Stop promoting the first decision's `multi_factor` configuration into the global selector registry.
- Add unit and E2E regression coverage for two decisions that use opposite quality-only and cost-only policies.
- Document that `multi_factor` policy is decision-scoped.
- Affected modules: `Router` / `E2E` / `Docs`

## Test Plan

- `make agent-ci-gate ENV=cpu CHANGED_FILES="e2e/profiles/routing-strategies/profile.go e2e/profiles/routing-strategies/values.yaml e2e/testcases/decision_scoped_multi_factor.go src/semantic-router/pkg/extproc/req_filter_classification.go src/semantic-router/pkg/extproc/req_filter_classification_selection_test.go src/semantic-router/pkg/extproc/router_selection.go src/semantic-router/pkg/extproc/router_selection_config_test.go website/docs/tutorials/algorithm/selection/multi-factor.md"`
- The gate runs repository lint and contract checks, the complete Semantic Router test target, and the E2E binary build.
- The new E2E testcase makes real chat requests and verifies both the selected decision and selected model response headers.

## Test Result

- Agent CI gate passed.
- Full `test-semantic-router` target passed.
- E2E test binary built successfully.
- The cluster-backed E2E testcase is included for the upstream E2E workflow; it was not executed by the CPU agent gate.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
