### PR TITLE
[Router] make router diagnostics content-free by default

### DIFF
--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -158,7 +158,7 @@ func ToOpenAIResponseBodyWithExt(anthropicResponse []byte, model string, ext *ir
 // stop_reason, cache usage, and server-tool counts survive the
 // flattening that the OpenAI envelope cannot represent.
 func toOpenAIResponseBody(anthropicResponse []byte, model string, ext *ir.IRExtensions) ([]byte, error) {
-	logging.Debugf("Raw Anthropic response (%d bytes): %s", len(anthropicResponse), string(anthropicResponse))
+	logging.Debugf("Raw Anthropic response: %s", logging.ContentDescriptorBytes(anthropicResponse))
 
 	var resp anthropic.Message
 	if err := json.Unmarshal(anthropicResponse, &resp); err != nil {

--- a/src/semantic-router/pkg/apiserver/route_embeddings.go
+++ b/src/semantic-router/pkg/apiserver/route_embeddings.go
@@ -339,8 +339,8 @@ func (s *ClassificationAPIServer) handleBatchSimilarity(w http.ResponseWriter, r
 		ProcessingTimeMs: result.ProcessingTimeMs,
 	}
 
-	logging.Infof("Calculated batch similarity: query='%s', %d candidates, top-%d matches (model: %s, took: %.2fms)",
-		req.Query, len(req.Candidates), len(matches), result.ModelType, result.ProcessingTimeMs)
+	logging.Infof("Calculated batch similarity: query=%s, %d candidates, top-%d matches (model: %s, took: %.2fms)",
+		logging.ContentDescriptor(req.Query), len(req.Candidates), len(matches), result.ModelType, result.ProcessingTimeMs)
 
 	s.writeJSONResponse(w, http.StatusOK, response)
 }

--- a/src/semantic-router/pkg/cache/hybrid_cache_lookup.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_lookup.go
@@ -41,8 +41,8 @@ func (h *HybridCache) findSimilar(
 		return nil, false, nil
 	}
 
-	logging.Debugf("%s: searching for model='%s', query='%s', threshold=%.3f",
-		logPrefix, model, shortenHybridQuery(query), threshold)
+	logging.Debugf("%s: searching for model='%s', query=%s, threshold=%.3f",
+		logPrefix, model, logging.ContentDescriptor(query), threshold)
 
 	queryEmbedding, err := h.generateEmbedding(query)
 	if err != nil {
@@ -167,11 +167,4 @@ func (h *HybridCache) recordLookupMiss(
 		"candidates": qualifiedCandidates,
 	})
 	metrics.RecordCacheOperation("hybrid", metricOp, "miss", time.Since(start).Seconds())
-}
-
-func shortenHybridQuery(query string) string {
-	if len(query) <= 50 {
-		return query
-	}
-	return query[:50] + "..."
 }

--- a/src/semantic-router/pkg/cache/inmemory_cache_search.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache_search.go
@@ -131,12 +131,8 @@ func (c *InMemoryCache) FindSimilarWithThreshold(model string, query string, thr
 		logging.Debugf("InMemoryCache.FindSimilarWithThreshold: cache disabled")
 		return nil, false, nil
 	}
-	queryPreview := query
-	if len(query) > 50 {
-		queryPreview = query[:50] + "..."
-	}
-	logging.Debugf("InMemoryCache.FindSimilarWithThreshold: searching for model='%s', query='%s' (len=%d chars), threshold=%.4f",
-		model, queryPreview, len(query), threshold)
+	logging.Debugf("InMemoryCache.FindSimilarWithThreshold: searching for model='%s', query=%s, threshold=%.4f",
+		model, logging.ContentDescriptor(query), threshold)
 
 	queryEmbedding, err := c.generateEmbedding(query)
 	if err != nil {

--- a/src/semantic-router/pkg/cache/milvus_cache_similar.go
+++ b/src/semantic-router/pkg/cache/milvus_cache_similar.go
@@ -80,12 +80,8 @@ func (c *MilvusCache) FindSimilarWithThreshold(model string, query string, thres
 		logging.Debugf("MilvusCache.FindSimilarWithThreshold: cache disabled")
 		return nil, false, nil
 	}
-	queryPreview := query
-	if len(query) > 50 {
-		queryPreview = query[:50] + "..."
-	}
-	logging.Debugf("MilvusCache.FindSimilarWithThreshold: searching for model='%s', query='%s' (len=%d chars), threshold=%.4f",
-		model, queryPreview, len(query), threshold)
+	logging.Debugf("MilvusCache.FindSimilarWithThreshold: searching for model='%s', query=%s, threshold=%.4f",
+		model, logging.ContentDescriptor(query), threshold)
 
 	queryEmbedding, err := c.getEmbedding(query)
 	if err != nil {

--- a/src/semantic-router/pkg/cache/valkey_cache_helpers.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_helpers.go
@@ -84,10 +84,10 @@ func parsePendingSearchResult(results interface{}, requestID string, prefix stri
 		logging.Warnf("UpdateWithResponse: docID '%s' doesn't have expected prefix '%s'", entry.docID, prefix)
 	}
 
-	logging.Debugf("UpdateWithResponse: extracted docID='%s', model='%s', query='%s'", entry.docID, entry.model, entry.query)
+	logging.Debugf("UpdateWithResponse: extracted docID='%s', model='%s', query=%s", entry.docID, entry.model, logging.ContentDescriptor(entry.query))
 
 	if entry.model == "" || entry.query == "" {
-		logging.Warnf("UpdateWithResponse: missing required fields (model='%s', query='%s')", entry.model, entry.query)
+		logging.Warnf("UpdateWithResponse: missing required fields (model='%s', query=%s)", entry.model, logging.ContentDescriptor(entry.query))
 		return nil, fmt.Errorf("missing required fields in pending entry")
 	}
 

--- a/src/semantic-router/pkg/classification/preference_classifier_external.go
+++ b/src/semantic-router/pkg/classification/preference_classifier_external.go
@@ -91,7 +91,7 @@ func (p *PreferenceClassifier) classifyExternal(conversationJSON string) (*Prefe
 	}
 
 	output := resp.Choices[0].Message.Content
-	logging.Infof("Preference classification response: %s", output)
+	logging.Infof("Preference classification response: %s", logging.ContentDescriptor(output))
 
 	result, err := p.parsePreferenceOutput(output)
 	if err != nil {

--- a/src/semantic-router/pkg/classification/vllm_classifier.go
+++ b/src/semantic-router/pkg/classification/vllm_classifier.go
@@ -89,7 +89,7 @@ func (v *VLLMJailbreakInference) Classify(text string) (candle_binding.ClassResu
 
 	// Parse model output - flexible to support multiple formats
 	output := resp.Choices[0].Message.Content
-	logging.Debugf("vLLM jailbreak detection response: %s", output)
+	logging.Debugf("vLLM jailbreak detection response: %s", logging.ContentDescriptor(output))
 	isJailbreak, confidence, categories := v.parseSafetyOutput(output)
 	logging.Debugf("Parsed result: isJailbreak=%v, confidence=%.3f, categories=%v",
 		isJailbreak, confidence, categories)

--- a/src/semantic-router/pkg/extproc/req_filter_cache.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache.go
@@ -120,8 +120,8 @@ func (r *OpenAIRouter) performCacheLookup(
 		threshold = r.Config.GetCacheSimilarityThresholdForDecision(categoryName)
 	}
 
-	logging.Infof("handleCaching: Performing cache lookup - model=%s, query='%s', threshold=%.2f",
-		requestModel, ctx.RequestQuery, threshold)
+	logging.Infof("handleCaching: Performing cache lookup - model=%s, query=%s, threshold=%.2f",
+		requestModel, logging.ContentDescriptor(ctx.RequestQuery), threshold)
 
 	spanCtx, span := tracing.StartPluginSpan(ctx.TraceContext, "semantic-cache", categoryName)
 

--- a/src/semantic-router/pkg/extproc/req_filter_rag.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag.go
@@ -172,7 +172,7 @@ func (r *OpenAIRouter) getCachedRAGContext(query string, ragConfig *config.RAGPl
 
 	if cached, found := r.getRAGCache(query, ragConfig); found {
 		metrics.RecordRAGCacheHit(ragConfig.Backend)
-		logging.Debugf("RAG cache hit for query: %s", query[:min(50, len(query))])
+		logging.Debugf("RAG cache hit for query: %s", logging.ContentDescriptor(query))
 		return cached, true
 	}
 
@@ -219,7 +219,7 @@ func (r *OpenAIRouter) retrieveContextFromBackend(
 func (r *OpenAIRouter) logEmptyRAGContext(backend string, query string, retrievedContext string) {
 	if retrievedContext == "" {
 		logging.Debugf("[RAG] Backend '%s' returned empty context for query: %s",
-			backend, query[:min(60, len(query))])
+			backend, logging.ContentDescriptor(query))
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -65,7 +65,8 @@ func (r *OpenAIRouter) applySelectedTools(
 	}
 	openAIRequest.Tools = sdkTools
 	logging.Infof("Auto-selected %d tools via strategy %q (confidence=%.3f, latency=%s) for query: %s",
-		len(sdkTools), strategyID, confidence, latency.Round(time.Millisecond), classificationText)
+		len(sdkTools), strategyID, confidence, latency.Round(time.Millisecond),
+		logging.ContentDescriptor(classificationText))
 	return nil
 }
 

--- a/src/semantic-router/pkg/extproc/response_log_body_redaction_test.go
+++ b/src/semantic-router/pkg/extproc/response_log_body_redaction_test.go
@@ -1,0 +1,95 @@
+package extproc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+)
+
+// These canaries pin the content-free diagnostics contract from issue #2464.
+//
+// utils.go logs the ext_proc mutation with `%+v`, so the assertions below format
+// the redacted response exactly the way the logger does rather than walking a
+// subset of fields. A header-only dump helper cannot observe a body leak, so it
+// would pass while prompt or response content still reached the log.
+
+// bodyMutationResponse builds a request-body ProcessingResponse whose body
+// mutation carries body, mirroring the rewritten request the router sends to
+// Envoy after model substitution or RAG/memory injection.
+func bodyMutationResponse(body string) *ext_proc.ProcessingResponse {
+	return &ext_proc.ProcessingResponse{
+		Response: &ext_proc.ProcessingResponse_RequestBody{
+			RequestBody: &ext_proc.BodyResponse{
+				Response: &ext_proc.CommonResponse{
+					Status: ext_proc.CommonResponse_CONTINUE,
+					BodyMutation: &ext_proc.BodyMutation{
+						Mutation: &ext_proc.BodyMutation_Body{Body: []byte(body)},
+					},
+				},
+			},
+		},
+	}
+}
+
+// immediateResponseWithBody builds an immediate ProcessingResponse carrying
+// body, mirroring a cache hit, jailbreak block, or budget rejection.
+func immediateResponseWithBody(body string) *ext_proc.ProcessingResponse {
+	return &ext_proc.ProcessingResponse{
+		Response: &ext_proc.ProcessingResponse_ImmediateResponse{
+			ImmediateResponse: &ext_proc.ImmediateResponse{
+				Body: []byte(body),
+			},
+		},
+	}
+}
+
+// logFormat renders r the way utils.go renders it when debug logging is on.
+func logFormat(r *ext_proc.ProcessingResponse) string {
+	return fmt.Sprintf("%+v", r)
+}
+
+func TestRedactResponseForLogRemovesBodyMutationContent(t *testing.T) {
+	const canary = "my social security number is 123-45-6789 body-canary-001"
+
+	resp := bodyMutationResponse(`{"messages":[{"role":"user","content":"` + canary + `"}]}`)
+	dump := logFormat(redactResponseForLog(resp))
+
+	if strings.Contains(dump, "body-canary-001") {
+		t.Fatalf("request body content reached the log dump: %s", dump)
+	}
+
+	// The response actually sent to Envoy must keep the real body.
+	orig := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	if !strings.Contains(string(orig), "body-canary-001") {
+		t.Fatalf("original body was mutated; the redaction must operate on a clone")
+	}
+}
+
+func TestRedactResponseForLogRemovesImmediateResponseBody(t *testing.T) {
+	const canary = "cached completion text immediate-canary-002"
+
+	resp := immediateResponseWithBody(`{"choices":[{"message":{"content":"` + canary + `"}}]}`)
+	dump := logFormat(redactResponseForLog(resp))
+
+	if strings.Contains(dump, "immediate-canary-002") {
+		t.Fatalf("immediate response body reached the log dump: %s", dump)
+	}
+
+	orig := resp.GetImmediateResponse().GetBody()
+	if !strings.Contains(string(orig), "immediate-canary-002") {
+		t.Fatalf("original immediate body was mutated; redaction must operate on a clone")
+	}
+}
+
+// TestRedactResponseForLogKeepsBodySizeMetadata pins the positive half of the
+// contract: content is removed, but the operator still gets enough to debug.
+func TestRedactResponseForLogKeepsBodySizeMetadata(t *testing.T) {
+	body := strings.Repeat("x", 4096)
+	dump := logFormat(redactResponseForLog(bodyMutationResponse(body)))
+
+	if !strings.Contains(dump, "4096") {
+		t.Errorf("redacted dump should report the body byte count, got: %s", dump)
+	}
+}

--- a/src/semantic-router/pkg/extproc/response_log_redaction.go
+++ b/src/semantic-router/pkg/extproc/response_log_redaction.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"fmt"
 	"strings"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -8,7 +9,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const redactedHeaderValue = "[REDACTED]"
+const (
+	redactedHeaderValue = "[REDACTED]"
+	// redactedBodyValue replaces request/response body content in log dumps.
+	// It is distinct from redactedHeaderValue so a log reader can tell a masked
+	// credential from withheld content.
+	redactedBodyValue = "[REDACTED BODY]"
+)
 
 // sensitiveHeaderKeys lists header names whose values are credentials and must
 // never be written to logs. The credential resolver injects the upstream
@@ -39,10 +46,17 @@ func isSensitiveHeaderKey(key string) bool {
 		strings.Contains(k, "secret")
 }
 
-// redactResponseForLog returns a deep copy of response with the
-// values of sensitive headers masked, so a debug-level dump of the ext_proc
-// mutation never writes the upstream provider credential to the log. The
+// redactResponseForLog returns a deep copy of response with credential header
+// values masked and all request/response body content replaced by a size-only
+// placeholder, so a debug-level dump of the ext_proc mutation never writes the
+// upstream provider credential or user content to the log (CWE-532). The
 // original response (the one actually sent to Envoy) is left untouched.
+//
+// Bodies are redacted, not dropped: the rewritten request body carries the
+// prompt (including any RAG/memory context injected by the router) and an
+// immediate response carries generated or cached completion text, so neither
+// belongs in normal diagnostics. The byte count is preserved because size is
+// what makes the log useful for debugging mutation and truncation problems.
 func redactResponseForLog(response *ext_proc.ProcessingResponse) *ext_proc.ProcessingResponse {
 	if response == nil {
 		return nil
@@ -53,26 +67,61 @@ func redactResponseForLog(response *ext_proc.ProcessingResponse) *ext_proc.Proce
 		return nil
 	}
 	redactHeaderMutation(responseHeaderMutation(clone))
+	redactBodyMutation(responseCommonResponse(clone).GetBodyMutation())
 	if imm := clone.GetImmediateResponse(); imm != nil {
 		redactHeaderMutation(imm.GetHeaders())
+		imm.Body = redactedBodyPlaceholder(imm.GetBody())
 	}
 	return clone
+}
+
+// redactedBodyPlaceholder replaces body bytes with a size-only marker. An empty
+// body stays empty so the log distinguishes "no body" from "body withheld".
+func redactedBodyPlaceholder(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	return []byte(fmt.Sprintf("%s %d bytes", redactedBodyValue, len(body)))
+}
+
+// redactBodyMutation masks body content in place on the clone. Only the inline
+// body variants carry content; ClearBody is a boolean directive with nothing to
+// redact.
+func redactBodyMutation(bm *ext_proc.BodyMutation) {
+	if bm == nil {
+		return
+	}
+	switch m := bm.Mutation.(type) {
+	case *ext_proc.BodyMutation_Body:
+		m.Body = redactedBodyPlaceholder(m.Body)
+	case *ext_proc.BodyMutation_StreamedResponse:
+		if m.StreamedResponse != nil {
+			m.StreamedResponse.Body = redactedBodyPlaceholder(m.StreamedResponse.GetBody())
+		}
+	}
+}
+
+// responseCommonResponse returns the CommonResponse carried by whichever
+// request/response phase variant the ProcessingResponse holds, or nil. Header
+// and body mutations both hang off it, so the phase switch lives in one place.
+func responseCommonResponse(r *ext_proc.ProcessingResponse) *ext_proc.CommonResponse {
+	switch v := r.Response.(type) {
+	case *ext_proc.ProcessingResponse_RequestHeaders:
+		return v.RequestHeaders.GetResponse()
+	case *ext_proc.ProcessingResponse_ResponseHeaders:
+		return v.ResponseHeaders.GetResponse()
+	case *ext_proc.ProcessingResponse_RequestBody:
+		return v.RequestBody.GetResponse()
+	case *ext_proc.ProcessingResponse_ResponseBody:
+		return v.ResponseBody.GetResponse()
+	}
+	return nil
 }
 
 // responseHeaderMutation returns the HeaderMutation carried by whichever
 // request/response phase variant the ProcessingResponse holds, or nil.
 func responseHeaderMutation(r *ext_proc.ProcessingResponse) *ext_proc.HeaderMutation {
-	switch v := r.Response.(type) {
-	case *ext_proc.ProcessingResponse_RequestHeaders:
-		return v.RequestHeaders.GetResponse().GetHeaderMutation()
-	case *ext_proc.ProcessingResponse_ResponseHeaders:
-		return v.ResponseHeaders.GetResponse().GetHeaderMutation()
-	case *ext_proc.ProcessingResponse_RequestBody:
-		return v.RequestBody.GetResponse().GetHeaderMutation()
-	case *ext_proc.ProcessingResponse_ResponseBody:
-		return v.ResponseBody.GetResponse().GetHeaderMutation()
-	}
-	return nil
+	return responseCommonResponse(r).GetHeaderMutation()
 }
 
 // redactHeaderMutation masks the value of every sensitive set-header in place.

--- a/src/semantic-router/pkg/memory/milvus_store_retrieve.go
+++ b/src/semantic-router/pkg/memory/milvus_store_retrieve.go
@@ -31,8 +31,8 @@ func (m *MilvusStore) Retrieve(ctx context.Context, opts RetrieveOptions) ([]*Re
 		return nil, err
 	}
 
-	logging.Debugf("MilvusStore.Retrieve: query='%s', user_id='%s', limit=%d, threshold=%.4f, hybrid=%v (mode=%s)",
-		opts.Query, opts.UserID, limit, threshold, opts.HybridSearch, opts.HybridMode)
+	logging.Debugf("MilvusStore.Retrieve: query=%s, user_id='%s', limit=%d, threshold=%.4f, hybrid=%v (mode=%s)",
+		logging.ContentDescriptor(opts.Query), opts.UserID, limit, threshold, opts.HybridSearch, opts.HybridMode)
 
 	embedding, err := GenerateEmbedding(opts.Query, m.embeddingConfig)
 	if err != nil {

--- a/src/semantic-router/pkg/memory/valkey_store.go
+++ b/src/semantic-router/pkg/memory/valkey_store.go
@@ -377,8 +377,8 @@ func (v *ValkeyStore) Retrieve(ctx context.Context, opts RetrieveOptions) ([]*Re
 		return nil, err
 	}
 
-	logging.Debugf("ValkeyStore.Retrieve: query='%s', user_id='%s', limit=%d, threshold=%.4f, hybrid=%v (mode=%s)",
-		opts.Query, opts.UserID, limit, threshold, opts.HybridSearch, opts.HybridMode)
+	logging.Debugf("ValkeyStore.Retrieve: query=%s, user_id='%s', limit=%d, threshold=%.4f, hybrid=%v (mode=%s)",
+		logging.ContentDescriptor(opts.Query), opts.UserID, limit, threshold, opts.HybridSearch, opts.HybridMode)
 
 	embedding, err := GenerateEmbedding(opts.Query, v.embeddingConfig)
 	if err != nil {

--- a/src/semantic-router/pkg/observability/logging/content.go
+++ b/src/semantic-router/pkg/observability/logging/content.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// This file defines the single content-logging policy used across the router
+// (issue #2464). Normal diagnostics carry correlation metadata, counts, timing,
+// model identity, and approved hashes — never prompt, response, query, tool, or
+// provider content. Log level is not a confidentiality boundary: a DEBUG-only
+// dump of a prompt is still a content leak wherever debug logging is enabled.
+//
+// Call ContentDescriptor (or ContentDescriptorBytes) instead of interpolating
+// user or provider content into a log line. The descriptor keeps the two things
+// that make such a line useful for debugging — how large the content was, and
+// whether two occurrences were identical — without disclosing the content.
+
+// contentDescriptorPrefix marks a redacted content field so a log reader can
+// tell withheld content from a value that was genuinely absent.
+const contentDescriptorPrefix = "[content]"
+
+// contentHashBytes is the number of SHA-256 bytes rendered in a descriptor.
+// Eight bytes (16 hex chars) is enough to correlate repeated content within a
+// trace without functioning as a practical content oracle.
+const contentHashBytes = 8
+
+// ContentDescriptor returns a content-free descriptor for user or provider
+// content: its byte length and a truncated SHA-256 digest. Identical content
+// yields an identical descriptor, so cache hits, retries, and duplicate
+// requests remain correlatable in logs without exposing the content itself.
+//
+// Use this for prompts, queries, tool arguments, completions, and provider
+// bodies. Do not use it for credentials: those must not be logged at all, not
+// even as a hash.
+func ContentDescriptor(content string) string {
+	if content == "" {
+		return contentDescriptorPrefix + " empty"
+	}
+	sum := sha256.Sum256([]byte(content))
+	return fmt.Sprintf("%s len=%d sha256=%x", contentDescriptorPrefix, len(content), sum[:contentHashBytes])
+}
+
+// ContentDescriptorBytes is ContentDescriptor for byte slices, so callers do
+// not have to materialize a string copy of a body purely to log it.
+func ContentDescriptorBytes(content []byte) string {
+	if len(content) == 0 {
+		return contentDescriptorPrefix + " empty"
+	}
+	sum := sha256.Sum256(content)
+	return fmt.Sprintf("%s len=%d sha256=%x", contentDescriptorPrefix, len(content), sum[:contentHashBytes])
+}

--- a/src/semantic-router/pkg/observability/logging/content_test.go
+++ b/src/semantic-router/pkg/observability/logging/content_test.go
@@ -1,0 +1,61 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests pin the content-logging policy from issue #2464: a descriptor
+// must never carry the content it describes, but must stay correlatable.
+
+func TestContentDescriptorOmitsContent(t *testing.T) {
+	const canary = "my social security number is 123-45-6789"
+
+	got := ContentDescriptor(canary)
+
+	if strings.Contains(got, "123-45-6789") || strings.Contains(got, "social security") {
+		t.Fatalf("descriptor leaked content: %q", got)
+	}
+	if !strings.Contains(got, "len=40") {
+		t.Errorf("descriptor should report byte length %d, got %q", len(canary), got)
+	}
+	if !strings.Contains(got, "sha256=") {
+		t.Errorf("descriptor should report a correlation hash, got %q", got)
+	}
+}
+
+func TestContentDescriptorIsStableAndDistinguishing(t *testing.T) {
+	a := ContentDescriptor("same query")
+	b := ContentDescriptor("same query")
+	c := ContentDescriptor("other query")
+
+	if a != b {
+		t.Errorf("identical content must yield identical descriptors: %q vs %q", a, b)
+	}
+	if a == c {
+		t.Errorf("different content must yield different descriptors, both %q", a)
+	}
+}
+
+func TestContentDescriptorEmpty(t *testing.T) {
+	if got := ContentDescriptor(""); !strings.Contains(got, "empty") {
+		t.Errorf("empty content should be reported as empty, got %q", got)
+	}
+	if got := ContentDescriptorBytes(nil); !strings.Contains(got, "empty") {
+		t.Errorf("nil content should be reported as empty, got %q", got)
+	}
+}
+
+func TestContentDescriptorBytesMatchesStringForm(t *testing.T) {
+	const payload = `{"choices":[{"message":{"content":"secret completion"}}]}`
+
+	fromBytes := ContentDescriptorBytes([]byte(payload))
+	fromString := ContentDescriptor(payload)
+
+	if fromBytes != fromString {
+		t.Errorf("byte and string descriptors must agree: %q vs %q", fromBytes, fromString)
+	}
+	if strings.Contains(fromBytes, "secret completion") {
+		t.Fatalf("descriptor leaked provider content: %q", fromBytes)
+	}
+}

--- a/src/semantic-router/pkg/tools/tools.go
+++ b/src/semantic-router/pkg/tools/tools.go
@@ -288,7 +288,7 @@ func (db *ToolsDatabase) FindSimilarToolsWithScoresMinSimilarity(query string, t
 			result.Entry.Tool.Function.Name, result.Similarity)
 	}
 
-	logging.Infof("Found %d similar tools for query: %s", len(selected), query)
+	logging.Infof("Found %d similar tools for query: %s", len(selected), logging.ContentDescriptor(query))
 	return selected, nil
 }
 


### PR DESCRIPTION
## Summary

Closes #2464.

Router diagnostics interpolated user and provider content directly into log lines — prompts, cache and memory queries, tool-selection text, and raw provider response bodies. Several were at **INFO**, so they were emitted under default production logging, not only when debug was enabled. Where a boundary existed at all it was truncation, which bounds the size of a disclosure without preventing one.

A canary shows the pre-fix behaviour directly. With debug logging on, `utils.go` dumps the ext_proc mutation with `%+v`, and `redactResponseForLog` masked only headers:

```
body_mutation:{body:"{\"messages\":[{\"role\":\"user\",\"content\":\"my social
security number is 123-45-6789 body-canary-001\"}]}"}
```

## Changes

**1. One shared content-logging policy** — `logging.ContentDescriptor` / `ContentDescriptorBytes` return `[content] len=40 sha256=181f8c90469356a0`: byte length plus a truncated digest. That keeps what makes such a line useful for debugging — how large the content was, and whether two occurrences were identical — without disclosing it. It lives in `logging` because the callers span seven packages that all already depend on it. Credentials are deliberately out of scope: those must not be logged at all, not even as a hash.

**2. Body redaction in ext_proc diagnostics** — `redactResponseForLog` now redacts body content on the clone for every phase variant, covering the inline body, the streamed-response mutation, and the immediate-response body. The byte count is preserved; an empty body stays empty so the log still distinguishes "no body" from "body withheld". The phase switch is factored into `responseCommonResponse` so header and body redaction share one enumeration.

**3. Every remaining boundary routed through the descriptor** — 14 sites across `extproc`, `apiserver`, `anthropic`, `cache`, `memory`, `tools`, and `classification`.

Two sites in `classification` (raw vLLM jailbreak and external preference model output) are not in the issue's file list but leak the same way, so they are included.

The truncation helpers those sites relied on (`shortenHybridQuery` and two inline preview blocks) are deleted — leaving them beside the descriptor would imply a boundary that does not exist.

### Deliberately unchanged

- `redis_cache.go:427` and `valkey_cache.go:365` — their `query` variable holds a Redis search expression built from a request id (`@request_id:"<uuid>"`), not user content. Hashing an id would remove debuggability for no privacy gain.
- `user_id` in the two memory paths — an identifier used to correlate a user's retrievals. The issue explicitly permits IDs.

## Test Plan

Red first, then green:

```
# before: 3 canaries fail, prompt visible verbatim in the dump
# after:
go test -race ./pkg/extproc ./pkg/apiserver ./pkg/anthropic ./pkg/observability/logging   # ok
go test -race ./pkg/memory ./pkg/tools ./pkg/classification                               # ok
go build ./pkg/...   # clean
gofmt -l pkg/        # clean
```

New tests: 3 ext_proc canaries (body mutation, immediate response, size metadata retained) and 4 for the descriptor (no content, stable, distinguishing, empty). The canaries format the response exactly as `utils.go` does rather than walking a subset of fields — the existing header-only dump helper cannot observe a body leak, so it would have passed while content still reached the log.

Each of the three commits builds independently.

**Not verified locally:** `pkg/cache` has tests requiring live Valkey and Milvus instances, which are not running on this machine. `TestValkeyCacheIntegration_IPMetricType` was confirmed to fail identically with these changes stashed, and the Milvus smoke test fails during client construction, before the changed log line is reached. CI runs these with the services up.

### Environment

macOS 15 (Darwin 25.5.0, arm64), CPU-only, Go 1.26.3.

## Follow-up

The issue's final acceptance item asks for a static check or lint rule rejecting direct logging of known content fields outside the approved helper. That is tracked in #2718 rather than included here: a naive pattern-based rule flags the two Redis search-expression sites above as false positives, and a gate people learn to ignore is worse than none. It needs a small allowlist or an AST-based check, which is its own change.
