### PR TITLE
fix(config): enforce canonical v0.3 contract parity

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -10,6 +10,8 @@
 
 Inside canonical `config.yaml`:
 
+- `version` is required and must equal the supported steady-state version, currently `v0.3`; older layouts must pass through `vllm-sr config migrate`
+- canonical objects are closed: unknown fields fail with their full dotted/indexed path instead of being ignored; only documented extension leaves remain schemaless, and their owning plugin/backend validates the surrounding payload
 - `providers.defaults` holds provider-wide defaults such as `default_model` and reasoning families
 - `providers.models[]` holds concrete backend access details directly
 - `providers.models[].pricing` supports separate prompt, cached-input, cache-write, and completion rates; omitted `cache_write_per_1m` falls back to `prompt_per_1m`

--- a/dashboard/backend/handlers/canonical_contract_corpus_test.go
+++ b/dashboard/backend/handlers/canonical_contract_corpus_test.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	routerconfig "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type dashboardContractCorpus struct {
+	SupportedVersion string                        `json:"supported_version"`
+	SteadyState      []dashboardContractSteadyCase `json:"steady_state"`
+}
+
+type dashboardContractSteadyCase struct {
+	Name              string `json:"name"`
+	Input             string `json:"input"`
+	Valid             bool   `json:"valid"`
+	Error             string `json:"error"`
+	NormalizedVersion string `json:"normalized_version"`
+}
+
+func TestDashboardExecutesCanonicalContractGoldenCorpus(t *testing.T) {
+	t.Parallel()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	corpusPath := filepath.Join(
+		filepath.Dir(filename),
+		"..", "..", "..",
+		"src", "semantic-router", "pkg", "config", "testdata",
+		"canonical_contract_cases.json",
+	)
+	data, err := os.ReadFile(corpusPath)
+	if err != nil {
+		t.Fatalf("read canonical contract corpus: %v", err)
+	}
+	var corpus dashboardContractCorpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		t.Fatalf("decode canonical contract corpus: %v", err)
+	}
+	if corpus.SupportedVersion != routerconfig.CanonicalVersion {
+		t.Fatalf("corpus version = %q, contract version = %q", corpus.SupportedVersion, routerconfig.CanonicalVersion)
+	}
+
+	for _, test := range corpus.SteadyState {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(test.Input), 0o600); err != nil {
+				t.Fatalf("write config fixture: %v", err)
+			}
+			cfg, err := readCanonicalConfigFile(path)
+			if !test.Valid {
+				if err == nil {
+					t.Fatal("expected dashboard contract rejection")
+				}
+				if !strings.Contains(err.Error(), test.Error) {
+					t.Fatalf("expected %q in error, got %v", test.Error, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected dashboard contract acceptance, got %v", err)
+			}
+			if cfg.Version != test.NormalizedVersion {
+				t.Fatalf("normalized version = %q, want %q", cfg.Version, test.NormalizedVersion)
+			}
+		})
+	}
+}
+
+func TestDashboardSetupFileUsesCanonicalVersionAndUnknownFieldContract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		error string
+	}{
+		{
+			name:  "missing version",
+			input: "setup:\n  mode: true\n",
+			error: "version: required",
+		},
+		{
+			name:  "future version",
+			input: "version: v99.0\nsetup:\n  mode: true\n",
+			error: "v99.0",
+		},
+		{
+			name:  "unknown setup field",
+			input: "version: v0.3\nsetup:\n  mode: true\n  modde: false\n",
+			error: "setup.modde",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(test.input), 0o600); err != nil {
+				t.Fatalf("write setup fixture: %v", err)
+			}
+			_, err := readSetupConfigFile(path)
+			if err == nil || !strings.Contains(err.Error(), test.error) {
+				t.Fatalf("expected %q in error, got %v", test.error, err)
+			}
+		})
+	}
+}

--- a/dashboard/backend/handlers/canonical_transport.go
+++ b/dashboard/backend/handlers/canonical_transport.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -28,7 +29,10 @@ type routingFragmentDocument struct {
 }
 
 type setupModeConfig struct {
-	Mode bool `yaml:"mode,omitempty"`
+	Mode      bool   `yaml:"mode,omitempty"`
+	State     string `yaml:"state,omitempty"`
+	CreatedBy string `yaml:"created_by,omitempty"`
+	CreatedAt string `yaml:"created_at,omitempty"`
 }
 
 type setupConfigFile struct {
@@ -54,6 +58,15 @@ func decodeYAMLTaggedBytes[T any](data []byte) (T, error) {
 		return value, err
 	}
 	return value, nil
+}
+
+func rejectUnknownYAMLFields[T any](data []byte, path string) error {
+	var raw interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var target T
+	return routerconfig.RejectUnknownConfigValue(raw, reflect.TypeOf(target), path)
 }
 
 func marshalYAMLTaggedJSON(value any) ([]byte, error) {
@@ -91,6 +104,9 @@ func readCanonicalConfigFile(configPath string) (*routerconfig.CanonicalConfig, 
 	if err != nil {
 		return nil, err
 	}
+	if _, parseErr := routerconfig.ParseYAMLBytes(data); parseErr != nil {
+		return nil, fmt.Errorf("invalid canonical config: %w", parseErr)
+	}
 	cfg, err := decodeYAMLTaggedBytes[routerconfig.CanonicalConfig](data)
 	if err != nil {
 		return nil, err
@@ -103,11 +119,28 @@ func readSetupConfigFile(configPath string) (*setupConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
+	if validationErr := validateSetupConfigBytes(data); validationErr != nil {
+		return nil, validationErr
+	}
 	cfg, err := decodeYAMLTaggedBytes[setupConfigFile](data)
 	if err != nil {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func validateSetupConfigBytes(data []byte) error {
+	if err := rejectUnknownYAMLFields[setupConfigFile](data, ""); err != nil {
+		return err
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := routerconfig.ValidateCanonicalVersion(raw); err != nil {
+		return err
+	}
+	return nil
 }
 
 func parseYAMLDocument(data []byte) (*yaml.Node, error) {

--- a/dashboard/backend/handlers/deploy.go
+++ b/dashboard/backend/handlers/deploy.go
@@ -298,12 +298,18 @@ func mergeDeployPayload(currentData []byte, req DeployRequest) ([]byte, error) {
 	if len(baseData) == 0 {
 		return fragmentBytes, nil
 	}
+	if _, parseErr := routerconfig.ParseYAMLBytes(baseData); parseErr != nil {
+		return nil, fmt.Errorf("failed to validate deploy base config: %w", parseErr)
+	}
 
 	baseConfig, err := decodeYAMLTaggedBytes[routerconfig.CanonicalConfig](baseData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse deploy base config: %w", err)
 	}
 
+	if validationErr := rejectUnknownYAMLFields[routingFragmentDocument](fragmentBytes, ""); validationErr != nil {
+		return nil, fmt.Errorf("failed to validate compiled routing fragment: %w", validationErr)
+	}
 	fragmentConfig, err := decodeYAMLTaggedBytes[routingFragmentDocument](fragmentBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse compiled routing fragment: %w", err)

--- a/dashboard/backend/handlers/security_policy_canonical_test.go
+++ b/dashboard/backend/handlers/security_policy_canonical_test.go
@@ -150,15 +150,15 @@ func TestMergeDeployPayloadWithRateLimit(t *testing.T) {
 	t.Parallel()
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4
   signals:
     keywords:
       - name: test_kw
-        patterns: ["hello"]
-        weight: 1.0
+        operator: OR
+        keywords: ["hello"]
   decisions:
     - name: existing-decision
       priority: 1
@@ -170,7 +170,8 @@ routing:
 global:
   services:
     observability:
-      enabled: true
+      metrics:
+        enabled: true
     ratelimit:
       providers:
         - type: local-limiter
@@ -250,14 +251,15 @@ func TestMergeDeployPayloadPreservesOtherGlobalFields(t *testing.T) {
 	t.Parallel()
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4
 global:
   services:
     observability:
-      enabled: true
+      metrics:
+        enabled: true
     ratelimit:
       providers:
         - type: local-limiter
@@ -315,7 +317,7 @@ func TestMergeDeployPayloadNoRateLimitPreservesExisting(t *testing.T) {
 	t.Parallel()
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4
@@ -396,7 +398,7 @@ func TestRateLimitRoundTripFragmentToRouterConfig(t *testing.T) {
 	}
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4

--- a/dashboard/backend/handlers/security_policy_edge_test.go
+++ b/dashboard/backend/handlers/security_policy_edge_test.go
@@ -170,7 +170,7 @@ func TestMergeDeployPayloadIntoBaseWithNoGlobal(t *testing.T) {
 	t.Parallel()
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4
@@ -252,7 +252,7 @@ func TestMergeDeployPayloadIdempotentDoubleApply(t *testing.T) {
 	t.Parallel()
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4
@@ -339,7 +339,7 @@ func TestRateLimitRoundTripUserBasedMatch(t *testing.T) {
 	}
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4
@@ -399,7 +399,7 @@ func TestRateLimitRoundTripManyTiersPreservesOrder(t *testing.T) {
 	}
 
 	baseYAML := `
-version: "0.3"
+version: "v0.3"
 routing:
   modelCards:
     - name: gpt-4
@@ -438,7 +438,7 @@ func TestMergeFragmentGlobalNilFragmentIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	base := routerconfig.CanonicalConfig{
-		Version: "0.3",
+		Version: "v0.3",
 		Global: &routerconfig.CanonicalGlobal{
 			Services: routerconfig.CanonicalServiceGlobal{
 				RateLimit: routerconfig.RateLimitConfig{
@@ -510,7 +510,7 @@ func TestMergeFragmentGlobalNilRateLimitIsNoOp(t *testing.T) {
 func TestMergeFragmentGlobalCreatesGlobalWhenBaseIsNil(t *testing.T) {
 	t.Parallel()
 
-	base := routerconfig.CanonicalConfig{Version: "0.3"}
+	base := routerconfig.CanonicalConfig{Version: "v0.3"}
 
 	rl := &routerconfig.RateLimitConfig{
 		Providers: []routerconfig.RateLimitProviderConfig{

--- a/dashboard/backend/handlers/setup.go
+++ b/dashboard/backend/handlers/setup.go
@@ -408,6 +408,9 @@ func buildSetupCandidateConfig(configPath string, bodyReader io.Reader) (*setupC
 	if len(req.Config) == 0 {
 		return nil, fmt.Errorf("config is required")
 	}
+	if validationErr := rejectUnknownYAMLFields[routerconfig.CanonicalConfig](req.Config, ""); validationErr != nil {
+		return nil, fmt.Errorf("invalid config payload: %w", validationErr)
+	}
 
 	requestConfig, err := decodeYAMLTaggedBytes[routerconfig.CanonicalConfig](req.Config)
 	if err != nil {
@@ -452,6 +455,9 @@ func normalizeRemoteConfigURL(rawValue string) (string, error) {
 }
 
 func parseSetupCanonicalConfig(raw []byte) (*setupConfigFile, error) {
+	if err := validateSetupConfigBytes(raw); err != nil {
+		return nil, fmt.Errorf("failed to validate remote config: %w", err)
+	}
 	parsed, err := decodeYAMLTaggedBytes[setupConfigFile](raw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse remote config: %w", err)

--- a/dashboard/backend/router/core_routes_test.go
+++ b/dashboard/backend/router/core_routes_test.go
@@ -103,7 +103,7 @@ func TestResolveToolsDBPathUsesRouterContractPath(t *testing.T) {
 	configDir := t.TempDir()
 	configPath := filepath.Join(configDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(`
-version: "0.3"
+version: "v0.3"
 global:
   integrations:
     tools:

--- a/dashboard/backend/routercontract/tools_test.go
+++ b/dashboard/backend/routercontract/tools_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestReadToolSelectionReturnsToolsDBPath(t *testing.T) {
 	configPath := writeRouterConfig(t, `
-version: "0.3"
+version: "v0.3"
 global:
   integrations:
     tools:

--- a/dashboard/frontend/src/pages/configPageCanonicalization.ts
+++ b/dashboard/frontend/src/pages/configPageCanonicalization.ts
@@ -4,6 +4,7 @@ import type {
   ModelConfigEntry,
   RoutingModelCard,
 } from './configPageSupport'
+import { CANONICAL_CONFIG_VERSION } from '../types/config'
 
 type CanonicalSignalSections = NonNullable<NonNullable<ConfigData['routing']>['signals']>
 
@@ -497,7 +498,7 @@ export const canonicalizeConfigForManagerSave = (updatedConfig: ConfigData): Con
   stripLegacyRootFields(next)
 
   if (!next.version) {
-    next.version = 'v0.3'
+    next.version = CANONICAL_CONFIG_VERSION
   }
   return next
 }

--- a/dashboard/frontend/src/types/config.ts
+++ b/dashboard/frontend/src/types/config.ts
@@ -8,6 +8,8 @@
  * routing-owned data for editing and legacy read-only fallback handling.
  */
 
+export const CANONICAL_CONFIG_VERSION = 'v0.3' as const
+
 // =============================================================================
 // PROVIDERS - Model and endpoint configuration
 // =============================================================================

--- a/deploy/kubernetes/ai-gateway/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/ai-gateway/semantic-router-values/values.yaml
@@ -266,7 +266,7 @@ config:
           operator: OR
           conditions:
             - type: keyword
-              rule_name: thinking
+              name: thinking
         modelRefs:
           - model: base-model
             lora_name: general-expert
@@ -296,7 +296,7 @@ config:
               similarity_threshold: 0.75
     signals:
       keywords:
-        - category: thinking
+        - name: thinking
           operator: OR
           keywords:
             - urgent

--- a/deploy/kubernetes/dynamo/semantic-router-values/values.yaml
+++ b/deploy/kubernetes/dynamo/semantic-router-values/values.yaml
@@ -248,7 +248,7 @@ config:
           operator: OR
           conditions:
             - type: keyword
-              rule_name: thinking
+              name: thinking
         modelRefs:
           - model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
             use_reasoning: true

--- a/deploy/kubernetes/observability/dashboard/config.yaml
+++ b/deploy/kubernetes/observability/dashboard/config.yaml
@@ -28,91 +28,71 @@ routing:
   signals:
     domains:
       - name: business
-        system_prompt: You are a senior business consultant and strategic advisor with expertise in corporate strategy, operations management, financial analysis, marketing, and organizational development. Provide practical, actionable business advice backed by proven methodologies and industry best practices. Consider market dynamics, competitive landscape, and stakeholder interests in your recommendations.
         model_scores:
           - model: qwen3
             score: 0.7
             use_reasoning: false
       - name: law
-        system_prompt: You are a knowledgeable legal expert with comprehensive understanding of legal principles, case law, statutory interpretation, and legal procedures across multiple jurisdictions. Provide accurate legal information and analysis while clearly stating that your responses are for informational purposes only and do not constitute legal advice. Always recommend consulting with qualified legal professionals for specific legal matters.
         model_scores:
           - model: qwen3
             score: 0.4
             use_reasoning: false
       - name: psychology
-        system_prompt: You are a psychology expert with deep knowledge of cognitive processes, behavioral patterns, mental health, developmental psychology, social psychology, and therapeutic approaches. Provide evidence-based insights grounded in psychological research and theory. When discussing mental health topics, emphasize the importance of professional consultation and avoid providing diagnostic or therapeutic advice.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.92
         model_scores:
           - model: qwen3
             score: 0.6
             use_reasoning: false
       - name: biology
-        system_prompt: You are a biology expert with comprehensive knowledge spanning molecular biology, genetics, cell biology, ecology, evolution, anatomy, physiology, and biotechnology. Explain biological concepts with scientific accuracy, use appropriate terminology, and provide examples from current research. Connect biological principles to real-world applications and emphasize the interconnectedness of biological systems.
         model_scores:
           - model: qwen3
             score: 0.9
             use_reasoning: false
       - name: chemistry
-        system_prompt: You are a chemistry expert specializing in chemical reactions, molecular structures, and laboratory techniques. Provide detailed, step-by-step explanations.
         model_scores:
           - model: qwen3
             score: 0.6
             use_reasoning: true
       - name: history
-        system_prompt: You are a historian with expertise across different time periods and cultures. Provide accurate historical context and analysis.
         model_scores:
           - model: qwen3
             score: 0.7
             use_reasoning: false
       - name: other
-        system_prompt: You are a helpful and knowledgeable assistant. Provide accurate, helpful responses across a wide range of topics.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.75
         model_scores:
           - model: qwen3
             score: 0.7
             use_reasoning: false
       - name: health
-        system_prompt: You are a health and medical information expert with knowledge of anatomy, physiology, diseases, treatments, preventive care, nutrition, and wellness. Provide accurate, evidence-based health information while emphasizing that your responses are for educational purposes only and should never replace professional medical advice, diagnosis, or treatment. Always encourage users to consult healthcare professionals for medical concerns and emergencies.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.95
         model_scores:
           - model: qwen3
             score: 0.5
             use_reasoning: false
       - name: economics
-        system_prompt: You are an economics expert with deep understanding of microeconomics, macroeconomics, econometrics, financial markets, monetary policy, fiscal policy, international trade, and economic theory. Analyze economic phenomena using established economic principles, provide data-driven insights, and explain complex economic concepts in accessible terms. Consider both theoretical frameworks and real-world applications in your responses.
         model_scores:
           - model: qwen3
             score: 1.0
             use_reasoning: false
       - name: math
-        system_prompt: You are a mathematics expert. Provide step-by-step solutions, show your work clearly, and explain mathematical concepts in an understandable way.
         model_scores:
           - model: qwen3
             score: 1.0
             use_reasoning: true
       - name: physics
-        system_prompt: You are a physics expert with deep understanding of physical laws and phenomena. Provide clear explanations with mathematical derivations when appropriate.
         model_scores:
           - model: qwen3
             score: 0.7
             use_reasoning: true
       - name: computer science
-        system_prompt: You are a computer science expert with knowledge of algorithms, data structures, programming languages, and software engineering. Provide clear, practical solutions with code examples when helpful.
         model_scores:
           - model: qwen3
             score: 0.6
             use_reasoning: false
       - name: philosophy
-        system_prompt: You are a philosophy expert with comprehensive knowledge of philosophical traditions, ethical theories, logic, metaphysics, epistemology, political philosophy, and the history of philosophical thought. Engage with complex philosophical questions by presenting multiple perspectives, analyzing arguments rigorously, and encouraging critical thinking. Draw connections between philosophical concepts and contemporary issues while maintaining intellectual honesty about the complexity and ongoing nature of philosophical debates.
         model_scores:
           - model: qwen3
             score: 0.5
             use_reasoning: false
       - name: engineering
-        system_prompt: You are an engineering expert with knowledge across multiple engineering disciplines including mechanical, electrical, civil, chemical, software, and systems engineering. Apply engineering principles, design methodologies, and problem-solving approaches to provide practical solutions. Consider safety, efficiency, sustainability, and cost-effectiveness in your recommendations. Use technical precision while explaining concepts clearly, and emphasize the importance of proper engineering practices and standards.
         model_scores:
           - model: qwen3
             score: 0.7

--- a/deploy/openshift/config-openshift.yaml
+++ b/deploy/openshift/config-openshift.yaml
@@ -303,14 +303,10 @@ global:
     observability:
       tracing:
         enabled: true
-        sampling_ratio: 0.1
-        otlp_endpoint: ''
       metrics:
         enabled: true
-        port: 9190
     api:
       batch_classification:
-        enabled: true
         max_batch_size: 32
         max_concurrency: 4
   stores:

--- a/deploy/operator/controllers/canonical_config_builder.go
+++ b/deploy/operator/controllers/canonical_config_builder.go
@@ -9,7 +9,7 @@ import (
 
 func (r *SemanticRouterReconciler) buildCanonicalConfig(ctx context.Context, sr *vllmv1alpha1.SemanticRouter) (*routerconfig.CanonicalConfig, error) {
 	canonical := &routerconfig.CanonicalConfig{
-		Version: "v0.3",
+		Version: routerconfig.CanonicalVersion,
 		Listeners: []routerconfig.Listener{
 			{
 				Name:    "grpc-50051",
@@ -51,6 +51,9 @@ func (r *SemanticRouterReconciler) buildCanonicalConfig(ctx context.Context, sr 
 		return nil, err
 	}
 	if err := r.applyOperatorConfigSpec(canonical, sr.Spec.Config); err != nil {
+		return nil, err
+	}
+	if err := routerconfig.ValidateCanonicalConfig(canonical); err != nil {
 		return nil, err
 	}
 

--- a/deploy/operator/controllers/canonical_config_spec.go
+++ b/deploy/operator/controllers/canonical_config_spec.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 
@@ -202,6 +203,13 @@ func convertToTypedConfig[T any](r *SemanticRouterReconciler, value interface{})
 	var result T
 
 	normalized := r.convertToConfigMap(value)
+	if err := routerconfig.RejectUnknownConfigValue(
+		normalized,
+		reflect.TypeOf(result),
+		"",
+	); err != nil {
+		return result, err
+	}
 	data, err := yaml.Marshal(normalized)
 	if err != nil {
 		return result, err

--- a/deploy/operator/controllers/canonical_config_spec_test.go
+++ b/deploy/operator/controllers/canonical_config_spec_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -153,6 +154,31 @@ func TestBuildCanonicalConfigAppliesCanonicalRoutingOverride(t *testing.T) {
 	}
 
 	assertCanonicalV03RoutingConfig(t, canonical)
+}
+
+func TestBuildCanonicalConfigRejectsUnknownRoutingOverrideField(t *testing.T) {
+	t.Parallel()
+
+	r := &SemanticRouterReconciler{}
+	sr := &vllmv1alpha1.SemanticRouter{
+		Spec: vllmv1alpha1.SemanticRouterSpec{
+			Config: vllmv1alpha1.ConfigSpec{
+				Routing: rawCanonicalRoutingJSON(t, `{
+					"modelCards": [
+						{"name": "demo", "descriptino": "typo"}
+					]
+				}`),
+			},
+		},
+	}
+
+	_, err := r.buildCanonicalConfig(context.Background(), sr)
+	if err == nil {
+		t.Fatal("expected unknown routing override field to be rejected")
+	}
+	if !strings.Contains(err.Error(), "routing.modelCards[0].descriptino") {
+		t.Fatalf("expected stable field path, got %v", err)
+	}
 }
 
 func TestBuildCanonicalConfigPreservesDecisionAlgorithm(t *testing.T) {

--- a/deploy/operator/controllers/canonical_contract_corpus_test.go
+++ b/deploy/operator/controllers/canonical_contract_corpus_test.go
@@ -1,0 +1,129 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	vllmv1alpha1 "github.com/vllm-project/semantic-router/operator/api/v1alpha1"
+	routerconfig "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type operatorContractCorpus struct {
+	SupportedVersion string                       `json:"supported_version"`
+	SteadyState      []operatorContractSteadyCase `json:"steady_state"`
+}
+
+type operatorContractSteadyCase struct {
+	Name              string `json:"name"`
+	Input             string `json:"input"`
+	Valid             bool   `json:"valid"`
+	Error             string `json:"error"`
+	NormalizedVersion string `json:"normalized_version"`
+}
+
+func TestOperatorOutputExecutesCanonicalContractGoldenCorpus(t *testing.T) {
+	t.Parallel()
+
+	corpus := loadOperatorContractCorpus(t)
+	if corpus.SupportedVersion != routerconfig.CanonicalVersion {
+		t.Fatalf("corpus version = %q, contract version = %q", corpus.SupportedVersion, routerconfig.CanonicalVersion)
+	}
+
+	reconciler := &SemanticRouterReconciler{}
+	for _, test := range corpus.SteadyState {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			assertOperatorContractCase(t, reconciler, test)
+		})
+	}
+}
+
+func loadOperatorContractCorpus(t *testing.T) operatorContractCorpus {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	data, err := os.ReadFile(filepath.Join(
+		filepath.Dir(filename),
+		"..", "..", "..",
+		"src", "semantic-router", "pkg", "config", "testdata",
+		"canonical_contract_cases.json",
+	))
+	if err != nil {
+		t.Fatalf("read canonical contract corpus: %v", err)
+	}
+	var corpus operatorContractCorpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		t.Fatalf("decode canonical contract corpus: %v", err)
+	}
+	return corpus
+}
+
+func assertOperatorContractCase(
+	t *testing.T,
+	reconciler *SemanticRouterReconciler,
+	test operatorContractSteadyCase,
+) {
+	t.Helper()
+
+	if _, err := routerconfig.ParseYAMLBytes([]byte(test.Input)); !test.Valid {
+		if err == nil {
+			t.Fatal("expected operator input contract rejection")
+		}
+		if !strings.Contains(err.Error(), test.Error) {
+			t.Fatalf("expected %q in error, got %v", test.Error, err)
+		}
+		return
+	} else if err != nil {
+		t.Fatalf("expected operator input contract acceptance, got %v", err)
+	}
+
+	routing, err := routingOverrideFromCorpus(test.Input)
+	if err != nil {
+		t.Fatalf("extract routing override: %v", err)
+	}
+	canonical, err := reconciler.buildCanonicalConfig(
+		context.Background(),
+		&vllmv1alpha1.SemanticRouter{
+			Spec: vllmv1alpha1.SemanticRouterSpec{
+				Config: vllmv1alpha1.ConfigSpec{Routing: routing},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("build operator canonical output: %v", err)
+	}
+	if canonical.Version != test.NormalizedVersion {
+		t.Fatalf(
+			"normalized version = %q, want %q",
+			canonical.Version,
+			test.NormalizedVersion,
+		)
+	}
+}
+
+func routingOverrideFromCorpus(input string) (*apiextensionsv1.JSON, error) {
+	var document map[string]interface{}
+	if err := yaml.Unmarshal([]byte(input), &document); err != nil {
+		return nil, err
+	}
+	routing, ok := document["routing"]
+	if !ok {
+		return nil, nil
+	}
+	data, err := json.Marshal(routing)
+	if err != nil {
+		return nil, err
+	}
+	return &apiextensionsv1.JSON{Raw: data}, nil
+}

--- a/deploy/operator/controllers/canonical_routing_overrides.go
+++ b/deploy/operator/controllers/canonical_routing_overrides.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -19,32 +20,11 @@ type canonicalRoutingOverrideFields struct {
 
 func canonicalRoutingFromKubernetesJSON(raw *apiextensionsv1.JSON) (routerconfig.CanonicalRouting, canonicalRoutingOverrideFields, error) {
 	var routing routerconfig.CanonicalRouting
-	var fields canonicalRoutingOverrideFields
-
-	if raw == nil || len(raw.Raw) == 0 {
-		return routing, fields, nil
+	object, err := decodeCanonicalRoutingObject(raw)
+	if err != nil || object == nil {
+		return routing, canonicalRoutingOverrideFields{}, err
 	}
-
-	var object map[string]interface{}
-	if err := json.Unmarshal(raw.Raw, &object); err != nil {
-		return routing, fields, err
-	}
-	if object == nil {
-		return routing, fields, nil
-	}
-
-	for key := range object {
-		switch key {
-		case "modelCards":
-			fields.modelCards = true
-		case "signals":
-			fields.signals = true
-		case "projections":
-			fields.projections = true
-		case "decisions":
-			fields.decisions = true
-		}
-	}
+	fields := canonicalRoutingFields(object)
 
 	data, err := yaml.Marshal(object)
 	if err != nil {
@@ -55,6 +35,42 @@ func canonicalRoutingFromKubernetesJSON(raw *apiextensionsv1.JSON) (routerconfig
 	}
 
 	return routing, fields, nil
+}
+
+func decodeCanonicalRoutingObject(raw *apiextensionsv1.JSON) (map[string]interface{}, error) {
+	if raw == nil || len(raw.Raw) == 0 {
+		return nil, nil
+	}
+
+	var object map[string]interface{}
+	if err := json.Unmarshal(raw.Raw, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, nil
+	}
+	if err := routerconfig.RejectUnknownConfigValue(
+		object,
+		reflect.TypeOf(routerconfig.CanonicalRouting{}),
+		"config.routing",
+	); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+func canonicalRoutingFields(object map[string]interface{}) canonicalRoutingOverrideFields {
+	return canonicalRoutingOverrideFields{
+		modelCards:  hasCanonicalRoutingField(object, "modelCards"),
+		signals:     hasCanonicalRoutingField(object, "signals"),
+		projections: hasCanonicalRoutingField(object, "projections"),
+		decisions:   hasCanonicalRoutingField(object, "decisions"),
+	}
+}
+
+func hasCanonicalRoutingField(object map[string]interface{}, field string) bool {
+	_, ok := object[field]
+	return ok
 }
 
 func applyCanonicalRoutingOverrides(

--- a/deploy/operator/controllers/semanticrouter_controller_test.go
+++ b/deploy/operator/controllers/semanticrouter_controller_test.go
@@ -46,6 +46,14 @@ func TestGenerateConfigYAMLIncludesLoRACatalogFromVLLMEndpoints(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: vllmv1alpha1.SemanticRouterSpec{
+			Config: vllmv1alpha1.ConfigSpec{
+				ReasoningFamilies: map[string]vllmv1alpha1.ReasoningFamily{
+					"qwen3": {
+						Type:      "chat_template_kwargs",
+						Parameter: "enable_thinking",
+					},
+				},
+			},
 			VLLMEndpoints: []vllmv1alpha1.VLLMEndpointSpec{
 				{
 					Name:            "qwen3-primary",

--- a/e2e/config/onnx-binding/config.onnx-binding-test.yaml
+++ b/e2e/config/onnx-binding/config.onnx-binding-test.yaml
@@ -43,10 +43,8 @@ global:
         mmbert_model_path: onnx-binding/mmbert-32k-yarn-onnx
     modules:
       classifier:
-        domain:
-          enabled: false
-        pii:
-          enabled: false
+        domain: {}
+        pii: {}
       hallucination_mitigation:
         enabled: false
       prompt_guard:
@@ -77,6 +75,4 @@ global:
     tools:
       enabled: true
       tools_db_path: deploy/examples/runtime/tools/tools_db.json
-      model_type: mmbert
-      target_dim: 0
       similarity_threshold: 0.7

--- a/e2e/config/onnx-binding/config.onnx-classifiers-test.yaml
+++ b/e2e/config/onnx-binding/config.onnx-classifiers-test.yaml
@@ -131,7 +131,6 @@ global:
     modules:
       classifier:
         domain:
-          enabled: true
           use_mmbert_32k: true
           model_id: models/mmbert32k-intent-classifier-merged-onnx
           category_mapping_path: models/mmbert32k-intent-classifier-merged-onnx/category_mapping.json
@@ -139,7 +138,6 @@ global:
           threshold: 0.5
           model_ref: domain_classifier
         pii:
-          enabled: true
           use_mmbert_32k: true
           model_id: models/mmbert32k-pii-detector-merged-onnx
           pii_mapping_path: models/mmbert32k-pii-detector-merged-onnx/pii_mapping.json
@@ -202,6 +200,4 @@ global:
     tools:
       enabled: true
       tools_db_path: deploy/examples/runtime/tools/tools_db.json
-      model_type: mmbert
-      target_dim: 0
       similarity_threshold: 0.7

--- a/e2e/profiles/routing-strategies/config-with-embedding.yaml
+++ b/e2e/profiles/routing-strategies/config-with-embedding.yaml
@@ -253,7 +253,6 @@ routing:
           - neural networks
           - AI algorithms
         aggregation_method: max
-        model: auto
       - name: data_science
         threshold: 0.7
         candidates:
@@ -262,7 +261,6 @@ routing:
           - predictive analytics
           - data visualization
         aggregation_method: mean
-        model: auto
       - name: programming
         threshold: 0.72
         candidates:
@@ -272,7 +270,6 @@ routing:
           - code snippet
           - programming task
         aggregation_method: max
-        model: auto
     domains:
       - name: urgent_request
         description: Urgent and time-sensitive requests

--- a/src/semantic-router/cmd/config-contract-schema/main.go
+++ b/src/semantic-router/cmd/config-contract-schema/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func main() {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(config.BuildCanonicalContractSchema()); err != nil {
+		fmt.Fprintf(os.Stderr, "encode canonical config schema: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/src/semantic-router/pkg/config/canonical_contract.go
+++ b/src/semantic-router/pkg/config/canonical_contract.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// CanonicalVersion is the only steady-state router config version understood
+// by this build. Older layouts must pass through explicit migration tooling.
+const CanonicalVersion = "v0.3"
+
+// SupportedCanonicalVersions returns the steady-state versions accepted by the
+// router. Return a fresh slice so callers cannot mutate the package contract.
+func SupportedCanonicalVersions() []string {
+	return []string{CanonicalVersion}
+}
+
+// ValidateCanonicalConfig runs a typed producer's output through the same
+// steady-state loader contract used for config files.
+func ValidateCanonicalConfig(canonical *CanonicalConfig) error {
+	if canonical == nil {
+		return fmt.Errorf("canonical config is nil")
+	}
+	data, err := yaml.Marshal(canonical)
+	if err != nil {
+		return fmt.Errorf("marshal canonical config: %w", err)
+	}
+	if _, err := ParseYAMLBytes(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateCanonicalVersion rejects an absent, malformed, or unsupported
+// version field before a boundary interprets the rest of a canonical document.
+func ValidateCanonicalVersion(raw map[string]interface{}) error {
+	value, ok := raw["version"]
+	if !ok {
+		return fmt.Errorf("version: required; supported versions: %s", CanonicalVersion)
+	}
+
+	version, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("version: must be a string; supported versions: %s", CanonicalVersion)
+	}
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return fmt.Errorf("version: must not be empty; supported versions: %s", CanonicalVersion)
+	}
+	if version != CanonicalVersion {
+		return fmt.Errorf(
+			"version: unsupported config version %q; supported versions: %s; older configs must be migrated explicitly with `vllm-sr config migrate`",
+			version,
+			CanonicalVersion,
+		)
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/config/canonical_contract_test.go
+++ b/src/semantic-router/pkg/config/canonical_contract_test.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type canonicalContractCorpus struct {
+	SupportedVersion string                        `json:"supported_version"`
+	SteadyState      []canonicalContractSteadyCase `json:"steady_state"`
+}
+
+type canonicalContractSteadyCase struct {
+	Name              string `json:"name"`
+	Input             string `json:"input"`
+	Valid             bool   `json:"valid"`
+	Error             string `json:"error"`
+	NormalizedVersion string `json:"normalized_version"`
+}
+
+func loadCanonicalContractCorpus(t *testing.T) canonicalContractCorpus {
+	t.Helper()
+
+	data, err := os.ReadFile("testdata/canonical_contract_cases.json")
+	if err != nil {
+		t.Fatalf("read canonical contract corpus: %v", err)
+	}
+	var corpus canonicalContractCorpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		t.Fatalf("decode canonical contract corpus: %v", err)
+	}
+	return corpus
+}
+
+func TestCanonicalContractGoldenCorpus(t *testing.T) {
+	t.Parallel()
+
+	corpus := loadCanonicalContractCorpus(t)
+	if corpus.SupportedVersion != CanonicalVersion {
+		t.Fatalf("corpus version = %q, contract version = %q", corpus.SupportedVersion, CanonicalVersion)
+	}
+
+	for _, test := range corpus.SteadyState {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := ParseYAMLBytes([]byte(test.Input))
+			if !test.Valid {
+				if err == nil {
+					t.Fatal("expected contract rejection")
+				}
+				if !strings.Contains(err.Error(), test.Error) {
+					t.Fatalf("expected %q in error, got %v", test.Error, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected contract acceptance, got %v", err)
+			}
+			normalized := CanonicalConfigFromRouterConfig(cfg)
+			if normalized.Version != test.NormalizedVersion {
+				t.Fatalf("normalized version = %q, want %q", normalized.Version, test.NormalizedVersion)
+			}
+		})
+	}
+}
+
+func TestParseYAMLBytesEnforcesCanonicalVersionBeforeInterpretation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		document   string
+		wantDetail string
+	}{
+		{
+			name:       "missing",
+			document:   "routing: {}\n",
+			wantDetail: "version: required",
+		},
+		{
+			name:       "empty",
+			document:   "version: \"\"\nrouting: {}\n",
+			wantDetail: "version: must not be empty",
+		},
+		{
+			name:       "malformed",
+			document:   "version: 3\nrouting: {}\n",
+			wantDetail: "version: must be a string",
+		},
+		{
+			name:       "old without migration",
+			document:   "version: v0.1\nrouting: {}\n",
+			wantDetail: `unsupported config version "v0.1"`,
+		},
+		{
+			name:       "future",
+			document:   "version: v99.0\nrouting: {}\n",
+			wantDetail: `unsupported config version "v99.0"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseYAMLBytes([]byte(test.document))
+			if err == nil {
+				t.Fatal("expected version contract to reject document")
+			}
+			if !strings.Contains(err.Error(), test.wantDetail) {
+				t.Fatalf("expected %q in error, got %v", test.wantDetail, err)
+			}
+			if !strings.Contains(err.Error(), CanonicalVersion) {
+				t.Fatalf("expected supported version %q in error, got %v", CanonicalVersion, err)
+			}
+		})
+	}
+}
+
+func TestParseYAMLBytesRejectsUnknownFieldsWithIndexedPaths(t *testing.T) {
+	t.Parallel()
+
+	document := []byte(`
+version: v0.3
+routing:
+  modelCards:
+    - name: demo
+      descriptino: silently-dropped-before
+`)
+
+	_, err := ParseYAMLBytes(document)
+	if err == nil {
+		t.Fatal("expected nested unknown field to be rejected")
+	}
+	for _, detail := range []string{
+		"unsupported config fields",
+		"routing.modelCards[0].descriptino",
+		`did you mean "description"`,
+	} {
+		if !strings.Contains(err.Error(), detail) {
+			t.Fatalf("expected %q in error, got %v", detail, err)
+		}
+	}
+}
+
+func TestParseYAMLBytesAllowsNamedStructuredPayloadExtension(t *testing.T) {
+	t.Parallel()
+
+	document := []byte(`
+version: v0.3
+routing:
+  decisions:
+    - name: extension
+      description: named plugin extension
+      priority: 1
+      rules:
+        operator: AND
+        conditions: []
+      modelRefs: []
+      plugins:
+        - type: rag
+          configuration:
+            enabled: true
+            backend: mcp
+            backend_config:
+              server_name: docs
+              tool_name: search
+              tool_arguments:
+                custom_filter:
+                  nested: true
+`)
+
+	if _, err := ParseYAMLBytes(document); err != nil {
+		t.Fatalf("expected named StructuredPayload extension to remain accepted, got %v", err)
+	}
+}
+
+func TestUnknownFieldValidationKeepsEmptyStructsClosed(t *testing.T) {
+	t.Parallel()
+
+	type closedConfig struct{}
+	err := RejectUnknownConfigValue(
+		map[string]interface{}{"unexpected": true},
+		reflect.TypeOf(closedConfig{}),
+		"closed",
+	)
+	if err == nil || !strings.Contains(err.Error(), "closed.unexpected") {
+		t.Fatalf("expected empty typed object to remain closed, got %v", err)
+	}
+}
+
+func TestParseYAMLBytesRejectsUnknownPluginConfigurationFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		pluginYAML string
+		wantPath   string
+	}{
+		{
+			name: "plugin payload",
+			pluginYAML: `
+        - type: system_prompt
+          configuration:
+            system_promt: typo
+`,
+			wantPath: `routing.decisions[extension].plugins[0].configuration.system_promt`,
+		},
+		{
+			name: "discriminator-owned backend payload",
+			pluginYAML: `
+        - type: rag
+          configuration:
+            enabled: true
+            backend: mcp
+            backend_config:
+              server_nam: docs
+              tool_name: search
+`,
+			wantPath: `routing.decisions[extension].plugins[0].configuration.backend_config.server_nam`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			document := `
+version: v0.3
+routing:
+  decisions:
+    - name: extension
+      rules:
+        operator: AND
+        conditions: []
+      plugins:
+` + test.pluginYAML
+
+			_, err := ParseYAMLBytes([]byte(document))
+			if err == nil {
+				t.Fatal("expected plugin configuration typo to be rejected")
+			}
+			if !strings.Contains(err.Error(), test.wantPath) {
+				t.Fatalf("expected field path %q in error, got %v", test.wantPath, err)
+			}
+		})
+	}
+}
+
+func TestEverySupportedDecisionPluginOwnsConfigurationValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, pluginType := range SupportedDecisionPluginTypes() {
+		if _, ok := decisionPluginConfigurationValidators[pluginType]; !ok {
+			t.Errorf("supported plugin %q has no configuration validator", pluginType)
+		}
+	}
+	for pluginType := range decisionPluginConfigurationValidators {
+		if !IsSupportedDecisionPluginType(pluginType) {
+			t.Errorf("configuration validator registered for unsupported plugin %q", pluginType)
+		}
+	}
+}
+
+func TestCanonicalExportUsesOwnedVersion(t *testing.T) {
+	t.Parallel()
+
+	if got := CanonicalConfigFromRouterConfig(nil).Version; got != CanonicalVersion {
+		t.Fatalf("canonical export version = %q, want %q", got, CanonicalVersion)
+	}
+}

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -9,11 +9,11 @@ import (
 // from the internal runtime config.
 func CanonicalConfigFromRouterConfig(cfg *RouterConfig) CanonicalConfig {
 	if cfg == nil {
-		return CanonicalConfig{Version: "v0.3"}
+		return CanonicalConfig{Version: CanonicalVersion}
 	}
 
 	return CanonicalConfig{
-		Version:   "v0.3",
+		Version:   CanonicalVersion,
 		Listeners: append([]Listener(nil), cfg.Listeners...),
 		Providers: CanonicalProviders{
 			Defaults: CanonicalProviderDefaults{

--- a/src/semantic-router/pkg/config/contract_schema.go
+++ b/src/semantic-router/pkg/config/contract_schema.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+)
+
+// CanonicalContractSchema is the generated, language-neutral shape of the
+// canonical configuration contract.
+type CanonicalContractSchema struct {
+	SupportedVersions []string                       `json:"supportedVersions"`
+	Root              CanonicalSchemaNode            `json:"root"`
+	Definitions       map[string]CanonicalSchemaNode `json:"definitions"`
+}
+
+// CanonicalSchemaNode describes one node in the canonical configuration tree.
+// Map keys are dynamic, while object fields are closed unless Opaque is true.
+type CanonicalSchemaNode struct {
+	Type   string                         `json:"type"`
+	Fields map[string]CanonicalSchemaNode `json:"fields,omitempty"`
+	Items  *CanonicalSchemaNode           `json:"items,omitempty"`
+	Values *CanonicalSchemaNode           `json:"values,omitempty"`
+	Opaque bool                           `json:"opaque,omitempty"`
+	Ref    string                         `json:"ref,omitempty"`
+}
+
+// BuildCanonicalContractSchema derives the cross-language schema directly
+// from the Go canonical config types.
+func BuildCanonicalContractSchema() CanonicalContractSchema {
+	builder := canonicalSchemaBuilder{
+		definitions: make(map[string]CanonicalSchemaNode),
+		building:    make(map[string]bool),
+	}
+	return CanonicalContractSchema{
+		SupportedVersions: SupportedCanonicalVersions(),
+		Root:              builder.buildNode(reflect.TypeOf(CanonicalConfig{})),
+		Definitions:       builder.definitions,
+	}
+}
+
+type canonicalSchemaBuilder struct {
+	definitions map[string]CanonicalSchemaNode
+	building    map[string]bool
+}
+
+func (b *canonicalSchemaBuilder) buildNode(t reflect.Type) CanonicalSchemaNode {
+	t = derefType(t)
+	switch t.Kind() {
+	case reflect.Struct:
+		key := t.PkgPath() + "." + t.Name()
+		if t.Name() != "" {
+			if _, exists := b.definitions[key]; exists || b.building[key] {
+				return CanonicalSchemaNode{Ref: key}
+			}
+			b.building[key] = true
+		}
+		fields := b.schemaFields(t)
+		node := CanonicalSchemaNode{Type: "object", Fields: fields}
+		if isExplicitConfigExtension(t) {
+			node.Opaque = true
+		}
+		if t.Name() != "" {
+			b.definitions[key] = node
+			delete(b.building, key)
+			return CanonicalSchemaNode{Ref: key}
+		}
+		return node
+	case reflect.Slice, reflect.Array:
+		items := b.buildNode(t.Elem())
+		return CanonicalSchemaNode{Type: "array", Items: &items}
+	case reflect.Map:
+		values := b.buildNode(t.Elem())
+		return CanonicalSchemaNode{Type: "map", Values: &values}
+	case reflect.Interface:
+		return CanonicalSchemaNode{Type: "any", Opaque: true}
+	default:
+		return CanonicalSchemaNode{Type: "scalar"}
+	}
+}
+
+func (b *canonicalSchemaBuilder) schemaFields(t reflect.Type) map[string]CanonicalSchemaNode {
+	fields := make(map[string]CanonicalSchemaNode)
+	for index := 0; index < t.NumField(); index++ {
+		field := t.Field(index)
+		if field.PkgPath != "" {
+			continue
+		}
+		tag := field.Tag.Get("yaml")
+		if tag == "-" {
+			continue
+		}
+		name, options := splitYAMLTag(tag)
+		if strings.Contains(options, "inline") || (name == "" && field.Anonymous) {
+			inlineType := derefType(field.Type)
+			if inlineType.Kind() == reflect.Struct {
+				for inlineName, inlineNode := range b.schemaFields(inlineType) {
+					fields[inlineName] = inlineNode
+				}
+			}
+			continue
+		}
+		if name == "" {
+			name = strings.ToLower(field.Name)
+		}
+		fields[name] = b.buildNode(field.Type)
+	}
+	return fields
+}

--- a/src/semantic-router/pkg/config/contract_schema_test.go
+++ b/src/semantic-router/pkg/config/contract_schema_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestGeneratedCanonicalContractSchemaIsCurrent(t *testing.T) {
+	t.Parallel()
+
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve contract schema test path")
+	}
+	schemaPath := filepath.Clean(filepath.Join(
+		filepath.Dir(sourceFile),
+		"..",
+		"..",
+		"..",
+		"vllm-sr",
+		"cli",
+		"templates",
+		"canonical-config-schema.json",
+	))
+	committed, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read generated canonical config schema: %v", err)
+	}
+	generated, err := json.MarshalIndent(BuildCanonicalContractSchema(), "", "  ")
+	if err != nil {
+		t.Fatalf("marshal canonical config schema: %v", err)
+	}
+	generated = append(generated, '\n')
+	if !bytes.Equal(committed, generated) {
+		t.Fatalf(
+			"%s is stale; regenerate with `go run ./cmd/config-contract-schema > ../vllm-sr/cli/templates/canonical-config-schema.json`",
+			schemaPath,
+		)
+	}
+}

--- a/src/semantic-router/pkg/config/image_gen_plugin.go
+++ b/src/semantic-router/pkg/config/image_gen_plugin.go
@@ -367,8 +367,8 @@ func decodeImageGenBackendConfig[T any](backend string, payload *StructuredPaylo
 	if payload == nil {
 		return nil, fmt.Errorf("backend_config is required for %s", expectedBackend)
 	}
-	result := new(T)
-	if err := payload.DecodeInto(result); err != nil {
+	result, err := decodeStructuredPayloadStrict[T](payload, "backend_config")
+	if err != nil {
 		return nil, fmt.Errorf("decode image_gen backend %s: %w", expectedBackend, err)
 	}
 	return result, nil
@@ -403,21 +403,33 @@ func (c *ModalityDetectionConfig) Validate() error {
 	}
 
 	method := c.GetMethod()
+	if err := validateModalityDetectionMethod(method); err != nil {
+		return err
+	}
+	if err := c.validateMethodConfiguration(method); err != nil {
+		return err
+	}
+	if err := c.validateConfidenceThreshold(method); err != nil {
+		return err
+	}
+	return c.validateLowerThresholdRatio(method)
+}
+
+func validateModalityDetectionMethod(method string) error {
 	if method == "" {
 		return fmt.Errorf("modality_detection.method is required (one of %q, %q, or %q)",
 			ModalityDetectionClassifier, ModalityDetectionKeyword, ModalityDetectionHybrid)
 	}
-
-	// Validate method value
 	switch method {
 	case ModalityDetectionClassifier, ModalityDetectionKeyword, ModalityDetectionHybrid:
-		// valid
+		return nil
 	default:
 		return fmt.Errorf("modality_detection.method must be one of %q, %q, or %q, got %q",
 			ModalityDetectionClassifier, ModalityDetectionKeyword, ModalityDetectionHybrid, method)
 	}
+}
 
-	// Method-specific validation
+func (c *ModalityDetectionConfig) validateMethodConfiguration(method string) error {
 	switch method {
 	case ModalityDetectionClassifier:
 		if c.Classifier == nil || c.Classifier.ModelPath == "" {
@@ -436,30 +448,26 @@ func (c *ModalityDetectionConfig) Validate() error {
 			return fmt.Errorf("modality_detection: method %q requires at least one of classifier.model_path or keywords to be configured", method)
 		}
 	}
+	return nil
+}
 
-	// Validate confidence threshold
-	if c.ConfidenceThreshold != 0 {
-		if c.ConfidenceThreshold < 0 || c.ConfidenceThreshold > 1 {
-			return fmt.Errorf("modality_detection.confidence_threshold must be between 0 and 1, got %.4f", c.ConfidenceThreshold)
-		}
+func (c *ModalityDetectionConfig) validateConfidenceThreshold(method string) error {
+	if c.ConfidenceThreshold != 0 && (c.ConfidenceThreshold < 0 || c.ConfidenceThreshold > 1) {
+		return fmt.Errorf("modality_detection.confidence_threshold must be between 0 and 1, got %.4f", c.ConfidenceThreshold)
 	}
-
-	// confidence_threshold is required when the classifier is involved
 	if (method == ModalityDetectionClassifier || method == ModalityDetectionHybrid) && c.ConfidenceThreshold == 0 {
 		return fmt.Errorf("modality_detection.confidence_threshold is required when method is %q (e.g. 0.6)", method)
 	}
+	return nil
+}
 
-	// lower_threshold_ratio validation
-	if c.LowerThresholdRatio != 0 {
-		if c.LowerThresholdRatio < 0 || c.LowerThresholdRatio > 1 {
-			return fmt.Errorf("modality_detection.lower_threshold_ratio must be between 0 and 1, got %.4f", c.LowerThresholdRatio)
-		}
+func (c *ModalityDetectionConfig) validateLowerThresholdRatio(method string) error {
+	if c.LowerThresholdRatio != 0 && (c.LowerThresholdRatio < 0 || c.LowerThresholdRatio > 1) {
+		return fmt.Errorf("modality_detection.lower_threshold_ratio must be between 0 and 1, got %.4f", c.LowerThresholdRatio)
 	}
-	// lower_threshold_ratio is required for hybrid (controls classifier-vs-keyword disagreement)
 	if method == ModalityDetectionHybrid && c.LowerThresholdRatio == 0 {
 		return fmt.Errorf("modality_detection.lower_threshold_ratio is required when method is %q (e.g. 0.7)", method)
 	}
-
 	return nil
 }
 

--- a/src/semantic-router/pkg/config/loader.go
+++ b/src/semantic-router/pkg/config/loader.go
@@ -84,6 +84,9 @@ func parseYAMLBytesWithBaseDir(data []byte, baseDir string) (*RouterConfig, erro
 	if err != nil {
 		return nil, err
 	}
+	if versionErr := ValidateCanonicalVersion(raw); versionErr != nil {
+		return nil, versionErr
+	}
 	if rejectErr := rejectDeprecatedUserConfigFields(raw); rejectErr != nil {
 		return nil, rejectErr
 	}
@@ -108,9 +111,6 @@ func parseYAMLBytesWithBaseDir(data []byte, baseDir string) (*RouterConfig, erro
 	if marshalErr != nil {
 		return nil, fmt.Errorf("failed to marshal config after environment expansion: %w", marshalErr)
 	}
-
-	// Warn about unknown YAML fields (typos) before parsing into typed structs.
-	WarnUnknownFields(raw, reflect.TypeOf(CanonicalConfig{}))
 
 	cfg, err := parseRouterConfigPayload(expandedData, raw)
 	if err != nil {
@@ -445,6 +445,9 @@ func parseRouterConfigPayload(data []byte, raw map[string]interface{}) (*RouterC
 }
 
 func parseCanonicalConfigPayload(data []byte, raw map[string]interface{}) (*RouterConfig, error) {
+	if unknownErr := RejectUnknownFields(raw, reflect.TypeOf(CanonicalConfig{})); unknownErr != nil {
+		return nil, unknownErr
+	}
 	canonical := &CanonicalConfig{}
 	if unmarshalErr := yaml.Unmarshal(data, canonical); unmarshalErr != nil {
 		logging.ComponentDebugEvent("config", "config_canonical_parse_failed", map[string]interface{}{

--- a/src/semantic-router/pkg/config/plugin_config.go
+++ b/src/semantic-router/pkg/config/plugin_config.go
@@ -129,7 +129,7 @@ func UnmarshalPluginConfig(config *StructuredPayload, target interface{}) error 
 	if config == nil {
 		return fmt.Errorf("plugin configuration is nil")
 	}
-	return config.DecodeInto(target)
+	return config.DecodeIntoStrict(target)
 }
 
 // GetSemanticCacheConfig returns the semantic-cache plugin configuration.

--- a/src/semantic-router/pkg/config/plugin_config_validation.go
+++ b/src/semantic-router/pkg/config/plugin_config_validation.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+type pluginConfigurationValidator func(*StructuredPayload, string) error
+
+var decisionPluginConfigurationValidators = map[string]pluginConfigurationValidator{
+	DecisionPluginSemanticCache:     validatePluginConfigurationAs[SemanticCachePluginConfig],
+	DecisionPluginSystemPrompt:      validatePluginConfigurationAs[SystemPromptPluginConfig],
+	DecisionPluginHeaderMutation:    validatePluginConfigurationAs[HeaderMutationPluginConfig],
+	DecisionPluginHallucination:     validatePluginConfigurationAs[HallucinationPluginConfig],
+	DecisionPluginResponseJailbreak: validatePluginConfigurationAs[ResponseJailbreakPluginConfig],
+	DecisionPluginRouterReplay:      validatePluginConfigurationAs[RouterReplayPluginConfig],
+	DecisionPluginMemory:            validatePluginConfigurationAs[MemoryPluginConfig],
+	DecisionPluginRAG:               validateRAGPluginConfiguration,
+	DecisionPluginImageGen:          validateImageGenPluginConfiguration,
+	DecisionPluginFastResponse:      validatePluginConfigurationAs[FastResponsePluginConfig],
+	DecisionPluginRequestParams:     validatePluginConfigurationAs[RequestParamsPluginConfig],
+	DecisionPluginToolSelection:     validatePluginConfigurationAs[ToolSelectionPluginConfig],
+	DecisionPluginTools:             validatePluginConfigurationAs[ToolsPluginConfig],
+}
+
+var ragBackendConfigurationValidators = map[string]pluginConfigurationValidator{
+	"milvus":       validatePluginConfigurationAs[MilvusRAGConfig],
+	"qdrant":       validatePluginConfigurationAs[QdrantRAGConfig],
+	"external_api": validatePluginConfigurationAs[ExternalAPIRAGConfig],
+	"mcp":          validatePluginConfigurationAs[MCPRAGConfig],
+	"openai":       validatePluginConfigurationAs[OpenAIRAGConfig],
+	"vectorstore":  validatePluginConfigurationAs[VectorStoreRAGConfig],
+}
+
+// ValidateDecisionPluginConfiguration validates a plugin payload against the
+// schema owned by its type discriminator.
+func ValidateDecisionPluginConfiguration(pluginType string, payload *StructuredPayload) error {
+	return validateDecisionPluginConfiguration(pluginType, payload, "configuration")
+}
+
+func validateDecisionPluginConfiguration(pluginType string, payload *StructuredPayload, path string) error {
+	normalizedType := NormalizeDecisionPluginType(strings.TrimSpace(pluginType))
+	validator, ok := decisionPluginConfigurationValidators[normalizedType]
+	if !ok {
+		return fmt.Errorf(
+			"%s.type: unsupported decision plugin %q; supported plugins: %s",
+			strings.TrimSuffix(path, ".configuration"),
+			pluginType,
+			strings.Join(SupportedDecisionPluginTypes(), ", "),
+		)
+	}
+	if payload == nil {
+		return nil
+	}
+	return validator(payload, path)
+}
+
+func validatePluginConfigurationAs[T any](payload *StructuredPayload, path string) error {
+	_, err := decodeStructuredPayloadStrict[T](payload, path)
+	return err
+}
+
+func validateRAGPluginConfiguration(payload *StructuredPayload, path string) error {
+	cfg, err := decodeStructuredPayloadStrict[RAGPluginConfig](payload, path)
+	if err != nil {
+		return err
+	}
+	return validateRAGBackendPayloadContract(cfg.Backend, cfg.BackendConfig, path+".backend_config")
+}
+
+func validateRAGBackendPayloadContract(backend string, payload *StructuredPayload, path string) error {
+	if strings.TrimSpace(backend) == "" {
+		if payload != nil {
+			return fmt.Errorf("%s: backend is required to validate backend_config", path)
+		}
+		return nil
+	}
+	if payload == nil {
+		return nil
+	}
+
+	if backend == "hybrid" {
+		return validateHybridRAGPayloadContract(payload, path)
+	}
+	validator, ok := ragBackendConfigurationValidators[backend]
+	if !ok {
+		return fmt.Errorf("%s: unsupported RAG backend %q", path, backend)
+	}
+	return validator(payload, path)
+}
+
+func validateHybridRAGPayloadContract(payload *StructuredPayload, path string) error {
+	hybrid, err := decodeStructuredPayloadStrict[HybridRAGConfig](payload, path)
+	if err != nil {
+		return err
+	}
+	if err := validateRAGBackendPayloadContract(
+		hybrid.Primary,
+		hybrid.PrimaryConfig,
+		path+".primary_config",
+	); err != nil {
+		return err
+	}
+	if hybrid.Fallback == "" && hybrid.FallbackConfig == nil {
+		return nil
+	}
+	return validateRAGBackendPayloadContract(
+		hybrid.Fallback,
+		hybrid.FallbackConfig,
+		path+".fallback_config",
+	)
+}
+
+func validateImageGenPluginConfiguration(payload *StructuredPayload, path string) error {
+	cfg, err := decodeStructuredPayloadStrict[ImageGenPluginConfig](payload, path)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.Backend) == "" {
+		if cfg.BackendConfig != nil {
+			return fmt.Errorf("%s.backend_config: backend is required to validate backend_config", path)
+		}
+		return nil
+	}
+	if cfg.BackendConfig == nil {
+		return nil
+	}
+
+	switch cfg.Backend {
+	case "vllm_omni":
+		_, err = decodeStructuredPayloadStrict[VLLMOmniImageGenConfig](cfg.BackendConfig, path+".backend_config")
+	case "openai":
+		_, err = decodeStructuredPayloadStrict[OpenAIImageGenConfig](cfg.BackendConfig, path+".backend_config")
+	default:
+		return fmt.Errorf("%s.backend_config: unsupported image_gen backend %q", path, cfg.Backend)
+	}
+	return err
+}

--- a/src/semantic-router/pkg/config/rag_plugin_backends.go
+++ b/src/semantic-router/pkg/config/rag_plugin_backends.go
@@ -116,8 +116,8 @@ func decodeRAGBackendConfig[T any](cfg *RAGPluginConfig, expectedBackend string)
 	if cfg.BackendConfig == nil {
 		return nil, fmt.Errorf("BackendConfig is required for backend %q", expectedBackend)
 	}
-	result := new(T)
-	if err := cfg.BackendConfig.DecodeInto(result); err != nil {
+	result, err := decodeStructuredPayloadStrict[T](cfg.BackendConfig, "backend_config")
+	if err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/src/semantic-router/pkg/config/skip_processing_test.go
+++ b/src/semantic-router/pkg/config/skip_processing_test.go
@@ -96,7 +96,7 @@ func TestCanonicalGlobalModelSelectionFalseOverridesRoundTrip(t *testing.T) {
 		t.Fatal("expected canonical global export")
 	}
 
-	doc := CanonicalConfig{Global: exported}
+	doc := CanonicalConfig{Version: CanonicalVersion, Global: exported}
 	encoded, err := yaml.Marshal(doc)
 	if err != nil {
 		t.Fatalf("failed to marshal canonical config: %v", err)

--- a/src/semantic-router/pkg/config/structured_payload.go
+++ b/src/semantic-router/pkg/config/structured_payload.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v2"
 )
@@ -51,6 +52,40 @@ func (p *StructuredPayload) DecodeInto(target interface{}) error {
 		return fmt.Errorf("decode structured payload: %w", err)
 	}
 	return nil
+}
+
+// DecodeIntoStrict decodes a discriminator-owned payload and rejects fields
+// outside the owner's typed contract.
+func (p *StructuredPayload) DecodeIntoStrict(target interface{}) error {
+	if p == nil || p.IsEmpty() {
+		return fmt.Errorf("structured payload is empty")
+	}
+	if target == nil {
+		return fmt.Errorf("structured payload target is nil")
+	}
+
+	if err := yaml.UnmarshalStrict(p.Raw, target); err != nil {
+		return fmt.Errorf("decode structured payload: %w", err)
+	}
+	return nil
+}
+
+func decodeStructuredPayloadStrict[T any](payload *StructuredPayload, path string) (*T, error) {
+	if payload == nil || payload.IsEmpty() {
+		return nil, fmt.Errorf("%s: structured payload is empty", path)
+	}
+	raw, err := payload.AsStringMap()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	target := new(T)
+	if err := rejectUnknownJSONFields(raw, reflect.TypeOf(*target), path); err != nil {
+		return nil, err
+	}
+	if err := payload.DecodeIntoStrict(target); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return target, nil
 }
 
 func (p *StructuredPayload) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/src/semantic-router/pkg/config/testdata/canonical_contract_cases.json
+++ b/src/semantic-router/pkg/config/testdata/canonical_contract_cases.json
@@ -1,0 +1,140 @@
+{
+  "supported_version": "v0.3",
+  "steady_state": [
+    {
+      "name": "valid_minimal",
+      "input": "version: v0.3\nrouting: {}\n",
+      "valid": true,
+      "normalized_version": "v0.3"
+    },
+    {
+      "name": "valid_named_extension",
+      "input": "version: v0.3\nrouting:\n  decisions:\n    - name: docs\n      description: docs lookup\n      priority: 1\n      rules:\n        operator: AND\n        conditions: []\n      modelRefs: []\n      plugins:\n        - type: rag\n          configuration:\n            enabled: true\n            backend: mcp\n            backend_config:\n              server_name: docs\n              tool_name: search\n              tool_arguments:\n                custom_filter:\n                  nested: true\n",
+      "valid": true,
+      "normalized_version": "v0.3"
+    },
+    {
+      "name": "missing_version",
+      "input": "routing: {}\n",
+      "valid": false,
+      "error": "version: required"
+    },
+    {
+      "name": "empty_version",
+      "input": "version: \"\"\nrouting: {}\n",
+      "valid": false,
+      "error": "version: must not be empty"
+    },
+    {
+      "name": "malformed_version",
+      "input": "version: 3\nrouting: {}\n",
+      "valid": false,
+      "error": "version: must be a string"
+    },
+    {
+      "name": "old_without_migration",
+      "input": "version: v0.1\nrouting: {}\n",
+      "valid": false,
+      "error": "v0.1"
+    },
+    {
+      "name": "future_version",
+      "input": "version: v99.0\nrouting: {}\n",
+      "valid": false,
+      "error": "v99.0"
+    },
+    {
+      "name": "unknown_top_level",
+      "input": "version: v0.3\nrounting: {}\n",
+      "valid": false,
+      "error": "rounting"
+    },
+    {
+      "name": "unknown_nested_field",
+      "input": "version: v0.3\nrouting:\n  modelCards:\n    - name: demo\n      descriptino: silently-dropped-before\n",
+      "valid": false,
+      "error": "routing.modelCards[0].descriptino"
+    },
+    {
+      "name": "unknown_owned_extension_field",
+      "input": "version: v0.3\nrouting:\n  decisions:\n    - name: docs\n      description: docs lookup\n      priority: 1\n      rules:\n        operator: AND\n        conditions: []\n      modelRefs: []\n      plugins:\n        - type: rag\n          configuration:\n            enabled: true\n            backend: mcp\n            backend_config:\n              server_nam: docs\n              tool_name: search\n",
+      "valid": false,
+      "error": "server_nam"
+    }
+  ],
+  "migrations": [
+    {
+      "name": "v0.1_preserves_recipe_state",
+      "input": {
+        "version": "v0.1",
+        "entrypoints": [
+          {
+            "model_names": ["chat"],
+            "recipe": "blue"
+          }
+        ],
+        "recipes": [
+          {
+            "name": "blue",
+            "routing": {}
+          }
+        ]
+      },
+      "normalized": {
+        "version": "v0.3",
+        "listeners": [],
+        "providers": {},
+        "routing": {
+          "signals": {}
+        },
+        "global": {
+          "model_catalog": {}
+        },
+        "entrypoints": [
+          {
+            "model_names": ["chat"],
+            "recipe": "blue"
+          }
+        ],
+        "recipes": [
+          {
+            "name": "blue",
+            "routing": {}
+          }
+        ]
+      }
+    },
+    {
+      "name": "v0.1_moves_flat_keyword_rules",
+      "input": {
+        "version": "v0.1",
+        "keyword_rules": [
+          {
+            "name": "hello",
+            "operator": "OR",
+            "keywords": ["hello"]
+          }
+        ]
+      },
+      "normalized": {
+        "version": "v0.3",
+        "listeners": [],
+        "providers": {},
+        "routing": {
+          "signals": {
+            "keywords": [
+              {
+                "name": "hello",
+                "operator": "OR",
+                "keywords": ["hello"]
+              }
+            ]
+          }
+        },
+        "global": {
+          "model_catalog": {}
+        }
+      }
+    }
+  ]
+}

--- a/src/semantic-router/pkg/config/validate.go
+++ b/src/semantic-router/pkg/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -17,39 +18,136 @@ func WarnUnknownFields(raw map[string]interface{}, targetType reflect.Type) {
 	}
 }
 
+// RejectUnknownFields rejects keys outside the typed contract. Only explicitly
+// named extension types such as StructuredPayload are intentionally skipped.
+func RejectUnknownFields(raw map[string]interface{}, targetType reflect.Type) error {
+	return rejectUnknownFields(raw, targetType, "", "yaml")
+}
+
+// RejectUnknownConfigValue validates a YAML-shaped map or list against a typed
+// producer contract. Path is prepended to every diagnostic.
+func RejectUnknownConfigValue(raw interface{}, targetType reflect.Type, path string) error {
+	var diagnostics []unknownFieldDiagnostic
+	targetType = derefType(targetType)
+	switch targetType.Kind() {
+	case reflect.Struct:
+		collectUnknownFieldsRecursive(
+			nestedStringMap(raw),
+			targetType,
+			path,
+			"yaml",
+			&diagnostics,
+		)
+	case reflect.Slice:
+		recurseIntoSlice(raw, targetType, path, "yaml", &diagnostics)
+	case reflect.Map:
+		recurseIntoMap(raw, targetType, path, "yaml", &diagnostics)
+	}
+	return rejectUnknownFieldDiagnostics(diagnostics)
+}
+
+func rejectUnknownJSONFields(raw map[string]interface{}, targetType reflect.Type, path string) error {
+	return rejectUnknownFields(raw, targetType, path, "json")
+}
+
+func rejectUnknownFields(raw map[string]interface{}, targetType reflect.Type, path, tagName string) error {
+	diagnostics := collectUnknownFieldDiagnosticsWithTag(raw, targetType, path, tagName)
+	return rejectUnknownFieldDiagnostics(diagnostics)
+}
+
+func rejectUnknownFieldDiagnostics(diagnostics []unknownFieldDiagnostic) error {
+	if len(diagnostics) == 0 {
+		return nil
+	}
+	fields := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		field := diagnostic.path
+		if diagnostic.suggestion != "" {
+			field += fmt.Sprintf(" (did you mean %q?)", diagnostic.suggestion)
+		}
+		fields = append(fields, field)
+	}
+	return fmt.Errorf("unsupported config fields: %s", strings.Join(fields, ", "))
+}
+
 // collectUnknownFields returns warning messages without logging them.
 func collectUnknownFields(raw map[string]interface{}, targetType reflect.Type) []string {
-	var warnings []string
-	collectUnknownFieldsRecursive(raw, targetType, "", &warnings)
+	diagnostics := collectUnknownFieldDiagnostics(raw, targetType)
+	warnings := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		warnings = append(warnings, formatUnknownField(diagnostic))
+	}
 	return warnings
 }
 
-func collectUnknownFieldsRecursive(raw map[string]interface{}, t reflect.Type, path string, out *[]string) {
+type unknownFieldDiagnostic struct {
+	path       string
+	suggestion string
+}
+
+func collectUnknownFieldDiagnostics(raw map[string]interface{}, targetType reflect.Type) []unknownFieldDiagnostic {
+	return collectUnknownFieldDiagnosticsWithTag(raw, targetType, "", "yaml")
+}
+
+func collectUnknownFieldDiagnosticsWithTag(
+	raw map[string]interface{},
+	targetType reflect.Type,
+	path string,
+	tagName string,
+) []unknownFieldDiagnostic {
+	var diagnostics []unknownFieldDiagnostic
+	collectUnknownFieldsRecursive(raw, targetType, path, tagName, &diagnostics)
+	return diagnostics
+}
+
+func collectUnknownFieldsRecursive(
+	raw map[string]interface{},
+	t reflect.Type,
+	path string,
+	tagName string,
+	out *[]unknownFieldDiagnostic,
+) {
 	t = derefType(t)
 	if t.Kind() != reflect.Struct {
 		return
 	}
-
-	known := collectKnownFields(t)
-	if len(known) == 0 {
-		return // opaque/schemaless struct (e.g., StructuredPayload) — skip
+	if isExplicitConfigExtension(t) {
+		return
 	}
+
+	known := collectKnownTaggedFields(t, tagName)
+	keys := make([]string, 0, len(raw))
 	for key := range raw {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
 		entry, ok := known[key]
 		if !ok {
-			*out = append(*out, formatUnknownField(key, path, known))
+			*out = append(*out, unknownFieldDiagnostic{
+				path:       joinPath(path, key),
+				suggestion: closestField(key, known),
+			})
 			continue
 		}
-		recurseIntoValue(raw[key], entry.fieldType, joinPath(path, key), out)
+		recurseIntoValue(raw[key], entry.fieldType, joinPath(path, key), tagName, out)
 	}
 }
 
-func formatUnknownField(key, path string, known map[string]fieldEntry) string {
-	fullPath := joinPath(path, key)
-	if suggestion := closestField(key, known); suggestion != "" {
-		return fmt.Sprintf("[config] Unknown field %q in %s — did you mean %q?", key, displayPath(fullPath), suggestion)
+func formatUnknownField(diagnostic unknownFieldDiagnostic) string {
+	key := diagnostic.path
+	if index := strings.LastIndex(key, "."); index >= 0 {
+		key = key[index+1:]
 	}
-	return fmt.Sprintf("[config] Unknown field %q in %s", key, displayPath(fullPath))
+	if diagnostic.suggestion != "" {
+		return fmt.Sprintf(
+			"[config] Unknown field %q in %s — did you mean %q?",
+			key,
+			displayPath(diagnostic.path),
+			diagnostic.suggestion,
+		)
+	}
+	return fmt.Sprintf("[config] Unknown field %q in %s", key, displayPath(diagnostic.path))
 }
 
 // closestField returns the nearest known field name if edit distance ≤ 3.
@@ -57,7 +155,12 @@ func formatUnknownField(key, path string, known map[string]fieldEntry) string {
 func closestField(unknown string, known map[string]fieldEntry) string {
 	best := ""
 	bestDist := 4
-	for k := range known {
+	keys := make([]string, 0, len(known))
+	for key := range known {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
 		if d := levenshtein(unknown, k); d < bestDist {
 			bestDist = d
 			best = k
@@ -66,7 +169,13 @@ func closestField(unknown string, known map[string]fieldEntry) string {
 	return best
 }
 
-func recurseIntoValue(value interface{}, fieldType reflect.Type, path string, out *[]string) {
+func recurseIntoValue(
+	value interface{},
+	fieldType reflect.Type,
+	path string,
+	tagName string,
+	out *[]unknownFieldDiagnostic,
+) {
 	if fieldType == nil {
 		return
 	}
@@ -76,16 +185,22 @@ func recurseIntoValue(value interface{}, fieldType reflect.Type, path string, ou
 	case reflect.Struct:
 		m := nestedStringMap(value)
 		if len(m) > 0 {
-			collectUnknownFieldsRecursive(m, ft, path, out)
+			collectUnknownFieldsRecursive(m, ft, path, tagName, out)
 		}
 	case reflect.Slice:
-		recurseIntoSlice(value, ft, path, out)
+		recurseIntoSlice(value, ft, path, tagName, out)
 	case reflect.Map:
-		recurseIntoMap(value, ft, path, out)
+		recurseIntoMap(value, ft, path, tagName, out)
 	}
 }
 
-func recurseIntoSlice(value interface{}, ft reflect.Type, path string, out *[]string) {
+func recurseIntoSlice(
+	value interface{},
+	ft reflect.Type,
+	path string,
+	tagName string,
+	out *[]unknownFieldDiagnostic,
+) {
 	elemType := derefType(ft.Elem())
 	if elemType.Kind() != reflect.Struct {
 		return
@@ -94,23 +209,36 @@ func recurseIntoSlice(value interface{}, ft reflect.Type, path string, out *[]st
 	if !ok {
 		return
 	}
-	for _, item := range items {
+	for index, item := range items {
 		itemMap := nestedStringMap(item)
 		if len(itemMap) > 0 {
-			collectUnknownFieldsRecursive(itemMap, elemType, path, out)
+			collectUnknownFieldsRecursive(itemMap, elemType, fmt.Sprintf("%s[%d]", path, index), tagName, out)
 		}
 	}
 }
 
-func recurseIntoMap(value interface{}, ft reflect.Type, path string, out *[]string) {
-	if ft.Elem().Kind() != reflect.Struct {
+func recurseIntoMap(
+	value interface{},
+	ft reflect.Type,
+	path string,
+	tagName string,
+	out *[]unknownFieldDiagnostic,
+) {
+	elemType := derefType(ft.Elem())
+	if elemType.Kind() != reflect.Struct {
 		return
 	}
 	valMap := nestedStringMap(value)
-	for mapKey, mapVal := range valMap {
+	keys := make([]string, 0, len(valMap))
+	for mapKey := range valMap {
+		keys = append(keys, mapKey)
+	}
+	sort.Strings(keys)
+	for _, mapKey := range keys {
+		mapVal := valMap[mapKey]
 		subMap := nestedStringMap(mapVal)
 		if len(subMap) > 0 {
-			collectUnknownFieldsRecursive(subMap, ft.Elem(), joinPath(path, mapKey), out)
+			collectUnknownFieldsRecursive(subMap, elemType, joinPath(path, mapKey), tagName, out)
 		}
 	}
 }
@@ -119,37 +247,50 @@ type fieldEntry struct {
 	fieldType reflect.Type
 }
 
-// collectKnownFields builds a map of yaml-tag → field info for a struct type,
+// collectKnownFields builds a map of config-tag → field info for a struct type,
 // handling inline fields by promoting their children to the current level.
 func collectKnownFields(t reflect.Type) map[string]fieldEntry {
+	return collectKnownTaggedFields(t, "yaml")
+}
+
+func collectKnownTaggedFields(t reflect.Type, tagName string) map[string]fieldEntry {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
 	known := make(map[string]fieldEntry)
 	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		tag := field.Tag.Get("yaml")
-		if tag == "-" {
-			continue
-		}
-		name, opts := splitYAMLTag(tag)
-
-		if strings.Contains(opts, "inline") || (name == "" && field.Anonymous) {
-			// Promote inline/embedded fields to the current level.
-			ft := derefType(field.Type)
-			if ft.Kind() == reflect.Struct {
-				for k, v := range collectKnownFields(ft) {
-					known[k] = v
-				}
-			}
-			continue
-		}
-		if name == "" {
-			name = strings.ToLower(field.Name)
-		}
-		known[name] = fieldEntry{fieldType: field.Type}
+		collectKnownTaggedField(known, t.Field(i), tagName)
 	}
 	return known
+}
+
+func collectKnownTaggedField(known map[string]fieldEntry, field reflect.StructField, tagName string) {
+	tag, hasTag := field.Tag.Lookup(tagName)
+	if !hasTag && tagName == "json" {
+		tag = field.Tag.Get("yaml")
+	}
+	if tag == "-" {
+		return
+	}
+	name, opts := splitYAMLTag(tag)
+	if strings.Contains(opts, "inline") || (name == "" && field.Anonymous) {
+		collectInlineTaggedFields(known, field.Type, tagName)
+		return
+	}
+	if name == "" {
+		name = strings.ToLower(field.Name)
+	}
+	known[name] = fieldEntry{fieldType: field.Type}
+}
+
+func collectInlineTaggedFields(known map[string]fieldEntry, fieldType reflect.Type, tagName string) {
+	fieldType = derefType(fieldType)
+	if fieldType.Kind() != reflect.Struct {
+		return
+	}
+	for name, entry := range collectKnownTaggedFields(fieldType, tagName) {
+		known[name] = entry
+	}
 }
 
 func splitYAMLTag(tag string) (string, string) {
@@ -165,6 +306,10 @@ func derefType(t reflect.Type) reflect.Type {
 		t = t.Elem()
 	}
 	return t
+}
+
+func isExplicitConfigExtension(t reflect.Type) bool {
+	return derefType(t) == reflect.TypeOf(StructuredPayload{})
 }
 
 func joinPath(parent, child string) string {

--- a/src/semantic-router/pkg/config/validator_decision.go
+++ b/src/semantic-router/pkg/config/validator_decision.go
@@ -165,25 +165,52 @@ func validateDecisionCandidateIterationOutputs(iter CandidateIterationConfig, co
 
 func validateDecisionPluginContracts(cfg *RouterConfig) error {
 	for _, decision := range cfg.AllRoutingDecisions() {
-		if toolsCfg := decision.GetToolsConfig(); toolsCfg != nil {
-			if err := toolsCfg.Validate(); err != nil {
-				return fmt.Errorf("decision '%s': %w", decision.Name, err)
-			}
-		}
-		if tsCfg := decision.GetToolSelectionConfig(); tsCfg != nil {
-			if err := tsCfg.Validate(); err != nil {
-				return fmt.Errorf("decision '%s': %w", decision.Name, err)
-			}
-		}
-
-		if imageGenCfg := decision.GetImageGenConfig(); imageGenCfg != nil {
-			if err := imageGenCfg.Validate(); err != nil {
-				return fmt.Errorf("decision '%s': %w", decision.Name, err)
-			}
-		}
-
-		if err := validateDecisionRAGAndMemoryPlugins(cfg, &decision); err != nil {
+		if err := validateSingleDecisionPluginContracts(cfg, &decision); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func validateSingleDecisionPluginContracts(cfg *RouterConfig, decision *Decision) error {
+	if err := validateDecisionPluginPayloads(decision); err != nil {
+		return err
+	}
+	if err := validateDecisionTypedPlugins(decision); err != nil {
+		return err
+	}
+	return validateDecisionRAGAndMemoryPlugins(cfg, decision)
+}
+
+func validateDecisionPluginPayloads(decision *Decision) error {
+	for pluginIndex := range decision.Plugins {
+		plugin := &decision.Plugins[pluginIndex]
+		path := fmt.Sprintf(
+			"routing.decisions[%s].plugins[%d].configuration",
+			decision.Name,
+			pluginIndex,
+		)
+		if err := validateDecisionPluginConfiguration(plugin.Type, plugin.Configuration, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDecisionTypedPlugins(decision *Decision) error {
+	if toolsCfg := decision.GetToolsConfig(); toolsCfg != nil {
+		if err := toolsCfg.Validate(); err != nil {
+			return fmt.Errorf("decision '%s': %w", decision.Name, err)
+		}
+	}
+	if tsCfg := decision.GetToolSelectionConfig(); tsCfg != nil {
+		if err := tsCfg.Validate(); err != nil {
+			return fmt.Errorf("decision '%s': %w", decision.Name, err)
+		}
+	}
+	if imageGenCfg := decision.GetImageGenConfig(); imageGenCfg != nil {
+		if err := imageGenCfg.Validate(); err != nil {
+			return fmt.Errorf("decision '%s': %w", decision.Name, err)
 		}
 	}
 	return nil

--- a/src/semantic-router/pkg/dsl/canonical_contract_corpus_test.go
+++ b/src/semantic-router/pkg/dsl/canonical_contract_corpus_test.go
@@ -1,0 +1,89 @@
+package dsl
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type dslContractCorpus struct {
+	SupportedVersion string                  `json:"supported_version"`
+	SteadyState      []dslContractSteadyCase `json:"steady_state"`
+}
+
+type dslContractSteadyCase struct {
+	Name              string `json:"name"`
+	Input             string `json:"input"`
+	Valid             bool   `json:"valid"`
+	Error             string `json:"error"`
+	NormalizedVersion string `json:"normalized_version"`
+}
+
+func TestDSLExecutesCanonicalContractGoldenCorpus(t *testing.T) {
+	t.Parallel()
+
+	corpus := loadDSLContractCorpus(t)
+	if corpus.SupportedVersion != config.CanonicalVersion {
+		t.Fatalf("corpus version = %q, contract version = %q", corpus.SupportedVersion, config.CanonicalVersion)
+	}
+
+	for _, test := range corpus.SteadyState {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			assertDSLContractCase(t, test)
+		})
+	}
+}
+
+func loadDSLContractCorpus(t *testing.T) dslContractCorpus {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	data, err := os.ReadFile(filepath.Join(
+		filepath.Dir(filename),
+		"..", "config", "testdata", "canonical_contract_cases.json",
+	))
+	if err != nil {
+		t.Fatalf("read canonical contract corpus: %v", err)
+	}
+	var corpus dslContractCorpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		t.Fatalf("decode canonical contract corpus: %v", err)
+	}
+	return corpus
+}
+
+func assertDSLContractCase(t *testing.T, test dslContractSteadyCase) {
+	t.Helper()
+
+	merged, err := MergeRoutingIntoBase(&config.RouterConfig{}, []byte(test.Input))
+	if !test.Valid {
+		if err == nil {
+			t.Fatal("expected DSL contract rejection")
+		}
+		if !strings.Contains(err.Error(), test.Error) {
+			t.Fatalf("expected %q in error, got %v", test.Error, err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("expected DSL contract acceptance, got %v", err)
+	}
+	var normalized config.CanonicalConfig
+	if err := yaml.Unmarshal(merged, &normalized); err != nil {
+		t.Fatalf("decode DSL output: %v", err)
+	}
+	if normalized.Version != test.NormalizedVersion {
+		t.Fatalf("normalized version = %q, want %q", normalized.Version, test.NormalizedVersion)
+	}
+}

--- a/src/semantic-router/pkg/dsl/emitter_yaml.go
+++ b/src/semantic-router/pkg/dsl/emitter_yaml.go
@@ -630,7 +630,7 @@ func EmitHelm(cfg *config.RouterConfig) ([]byte, error) {
 
 	values := map[string]interface{}{
 		"config": helmValuesConfig{
-			Version: "v0.3",
+			Version: config.CanonicalVersion,
 			Routing: config.CanonicalRoutingFromRouterConfig(cfg),
 		},
 	}
@@ -647,6 +647,10 @@ func EmitHelm(cfg *config.RouterConfig) ([]byte, error) {
 // document (containing version, listeners, providers), replaces the routing
 // section with the compiled one, and emits a complete canonical config YAML.
 func MergeRoutingIntoBase(cfg *config.RouterConfig, baseYAML []byte) ([]byte, error) {
+	if _, err := config.ParseYAMLBytes(baseYAML); err != nil {
+		return nil, fmt.Errorf("failed to validate base canonical config: %w", err)
+	}
+
 	var base map[string]interface{}
 	if err := yaml.Unmarshal(baseYAML, &base); err != nil {
 		return nil, fmt.Errorf("failed to parse base YAML: %w", err)
@@ -657,8 +661,8 @@ func MergeRoutingIntoBase(cfg *config.RouterConfig, baseYAML []byte) ([]byte, er
 		return nil, fmt.Errorf("failed to marshal routing: %w", err)
 	}
 	var routing interface{}
-	if err := yaml.Unmarshal(routingBytes, &routing); err != nil {
-		return nil, fmt.Errorf("failed to re-parse routing: %w", err)
+	if unmarshalErr := yaml.Unmarshal(routingBytes, &routing); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to re-parse routing: %w", unmarshalErr)
 	}
 
 	base["routing"] = routing
@@ -684,7 +688,14 @@ func MergeRoutingIntoBase(cfg *config.RouterConfig, baseYAML []byte) ([]byte, er
 		addKeyValue(mapNode, key, base[key])
 	}
 	doc.Content = append(doc.Content, mapNode)
-	return marshalYAMLIndent2(doc)
+	merged, err := marshalYAMLIndent2(doc)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := config.ParseYAMLBytes(merged); err != nil {
+		return nil, fmt.Errorf("DSL emitted invalid canonical config: %w", err)
+	}
+	return merged, nil
 }
 
 // marshalYAMLIndent2 encodes a yaml.Node with 2-space indentation to match

--- a/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
+++ b/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
@@ -463,7 +463,7 @@ func TestFullPipeline_CacheBypassThenRAGResolution(t *testing.T) {
 			{Type: "rag", Configuration: config.MustStructuredPayload(map[string]interface{}{
 				"enabled":        true,
 				"backend":        "external_api",
-				"api_endpoint":   ragServer.URL,
+				"backend_config": map[string]interface{}{"api_endpoint": ragServer.URL},
 				"injection_mode": "system_prompt",
 			})},
 		},

--- a/src/semantic-router/pkg/k8s/canonical_contract_corpus_test.go
+++ b/src/semantic-router/pkg/k8s/canonical_contract_corpus_test.go
@@ -1,0 +1,98 @@
+package k8s
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/apis/vllm.ai/v1alpha1"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type crdContractCorpus struct {
+	SupportedVersion string                  `json:"supported_version"`
+	SteadyState      []crdContractSteadyCase `json:"steady_state"`
+}
+
+type crdContractSteadyCase struct {
+	Name              string `json:"name"`
+	Input             string `json:"input"`
+	Valid             bool   `json:"valid"`
+	Error             string `json:"error"`
+	NormalizedVersion string `json:"normalized_version"`
+}
+
+func TestDynamicCRDsExecuteCanonicalContractGoldenCorpus(t *testing.T) {
+	t.Parallel()
+
+	corpus := loadCRDContractCorpus(t)
+	if corpus.SupportedVersion != config.CanonicalVersion {
+		t.Fatalf("corpus version = %q, contract version = %q", corpus.SupportedVersion, config.CanonicalVersion)
+	}
+
+	converter := NewCRDConverter()
+	for _, test := range corpus.SteadyState {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			assertCRDContractCase(t, converter, test)
+		})
+	}
+}
+
+func loadCRDContractCorpus(t *testing.T) crdContractCorpus {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	data, err := os.ReadFile(filepath.Join(
+		filepath.Dir(filename),
+		"..", "config", "testdata", "canonical_contract_cases.json",
+	))
+	if err != nil {
+		t.Fatalf("read canonical contract corpus: %v", err)
+	}
+	var corpus crdContractCorpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		t.Fatalf("decode canonical contract corpus: %v", err)
+	}
+	return corpus
+}
+
+func assertCRDContractCase(t *testing.T, converter *CRDConverter, test crdContractSteadyCase) {
+	t.Helper()
+
+	base, err := config.ParseYAMLBytes([]byte(test.Input))
+	if !test.Valid {
+		if err == nil {
+			t.Fatal("expected CRD base contract rejection")
+		}
+		if !strings.Contains(err.Error(), test.Error) {
+			t.Fatalf("expected %q in error, got %v", test.Error, err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("expected CRD base contract acceptance, got %v", err)
+	}
+
+	normalized, err := converter.Convert(
+		&v1alpha1.IntelligentPool{},
+		&v1alpha1.IntelligentRoute{},
+		ptrCanonicalConfig(config.CanonicalStaticConfigFromRouterConfig(base)),
+	)
+	if err != nil {
+		t.Fatalf("convert IntelligentPool and IntelligentRoute: %v", err)
+	}
+	if normalized.Version != test.NormalizedVersion {
+		t.Fatalf("normalized version = %q, want %q", normalized.Version, test.NormalizedVersion)
+	}
+}
+
+func ptrCanonicalConfig(cfg config.CanonicalConfig) *config.CanonicalConfig {
+	return &cfg
+}

--- a/src/semantic-router/pkg/k8s/converter.go
+++ b/src/semantic-router/pkg/k8s/converter.go
@@ -17,8 +17,6 @@ limitations under the License.
 package k8s
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 
 	yamlv3 "gopkg.in/yaml.v3"
@@ -51,7 +49,7 @@ func (c *CRDConverter) Convert(
 	if err != nil {
 		return nil, err
 	}
-	canonical.Version = "v0.3"
+	canonical.Version = config.CanonicalVersion
 
 	canonical.Providers.Defaults.DefaultModel = pool.Spec.DefaultModel
 	canonical.Routing.ModelCards = convertRoutingModelCards(pool.Spec.Models)
@@ -66,6 +64,9 @@ func (c *CRDConverter) Convert(
 	}
 
 	canonical.Providers.Models = mergeProviderMetadata(canonical.Providers.Models, convertProviderMetadata(pool.Spec.Models))
+	if err := config.ValidateCanonicalConfig(canonical); err != nil {
+		return nil, fmt.Errorf("generated canonical config is invalid: %w", err)
+	}
 	return canonical, nil
 }
 
@@ -355,7 +356,7 @@ func mergeCanonicalProviderMetadata(
 
 func cloneCanonicalConfig(base *config.CanonicalConfig) (*config.CanonicalConfig, error) {
 	if base == nil {
-		return &config.CanonicalConfig{Version: "v0.3"}, nil
+		return &config.CanonicalConfig{Version: config.CanonicalVersion}, nil
 	}
 
 	data, err := yamlv3.Marshal(base)
@@ -374,32 +375,27 @@ func validatePluginConfiguration(pluginType string, rawConfig []byte) error {
 	if len(rawConfig) == 0 {
 		return nil // Empty configuration is allowed
 	}
-	validator, ok := pluginConfigurationValidators[pluginType]
-	if !ok {
-		// Unknown plugin types are passed through without schema validation.
-		// This allows extensibility — only well-known types are validated.
+	payload := &config.StructuredPayload{Raw: append([]byte(nil), rawConfig...)}
+	if err := config.ValidateDecisionPluginConfiguration(pluginType, payload); err != nil {
+		return err
+	}
+	switch config.NormalizeDecisionPluginType(pluginType) {
+	case config.DecisionPluginSystemPrompt:
+		return validateSystemPromptPluginConfig(payload)
+	case config.DecisionPluginHeaderMutation:
+		return validateHeaderMutationPluginConfig(payload)
+	case config.DecisionPluginRouterReplay:
+		return validateRouterReplayPluginConfig(payload)
+	case config.DecisionPluginToolSelection:
+		return validateToolSelectionPluginConfigRaw(payload)
+	default:
 		return nil
 	}
-	return validator(rawConfig)
 }
 
-var pluginConfigurationValidators = map[string]func([]byte) error{
-	"semantic-cache":  validateSemanticCachePluginConfig,
-	"system_prompt":   validateSystemPromptPluginConfig,
-	"header_mutation": validateHeaderMutationPluginConfig,
-	"router_replay":   validateRouterReplayPluginConfig,
-	"tool_selection":  validateToolSelectionPluginConfigRaw,
-}
-
-func decodePluginConfiguration(rawConfig []byte, target any) error {
-	decoder := json.NewDecoder(bytes.NewReader(rawConfig))
-	decoder.DisallowUnknownFields()
-	return decoder.Decode(target)
-}
-
-func validateToolSelectionPluginConfigRaw(rawConfig []byte) error {
+func validateToolSelectionPluginConfigRaw(payload *config.StructuredPayload) error {
 	var cfg config.ToolSelectionPluginConfig
-	if err := decodePluginConfiguration(rawConfig, &cfg); err != nil {
+	if err := config.UnmarshalPluginConfig(payload, &cfg); err != nil {
 		return fmt.Errorf("failed to unmarshal tool_selection config: %w", err)
 	}
 	if err := cfg.Validate(); err != nil {
@@ -408,17 +404,9 @@ func validateToolSelectionPluginConfigRaw(rawConfig []byte) error {
 	return nil
 }
 
-func validateSemanticCachePluginConfig(rawConfig []byte) error {
-	var cfg config.SemanticCachePluginConfig
-	if err := decodePluginConfiguration(rawConfig, &cfg); err != nil {
-		return fmt.Errorf("failed to unmarshal semantic-cache config: %w", err)
-	}
-	return nil
-}
-
-func validateSystemPromptPluginConfig(rawConfig []byte) error {
+func validateSystemPromptPluginConfig(payload *config.StructuredPayload) error {
 	var cfg config.SystemPromptPluginConfig
-	if err := decodePluginConfiguration(rawConfig, &cfg); err != nil {
+	if err := config.UnmarshalPluginConfig(payload, &cfg); err != nil {
 		return fmt.Errorf("failed to unmarshal system_prompt config: %w", err)
 	}
 	if cfg.Mode != "" && cfg.Mode != "replace" && cfg.Mode != "insert" {
@@ -427,9 +415,9 @@ func validateSystemPromptPluginConfig(rawConfig []byte) error {
 	return nil
 }
 
-func validateHeaderMutationPluginConfig(rawConfig []byte) error {
+func validateHeaderMutationPluginConfig(payload *config.StructuredPayload) error {
 	var cfg config.HeaderMutationPluginConfig
-	if err := decodePluginConfiguration(rawConfig, &cfg); err != nil {
+	if err := config.UnmarshalPluginConfig(payload, &cfg); err != nil {
 		return fmt.Errorf("failed to unmarshal header_mutation config: %w", err)
 	}
 	if len(cfg.Add) == 0 && len(cfg.Update) == 0 && len(cfg.Delete) == 0 {
@@ -450,9 +438,9 @@ func validateHeaderMutationEntries(operation string, headers []config.HeaderPair
 	return nil
 }
 
-func validateRouterReplayPluginConfig(rawConfig []byte) error {
+func validateRouterReplayPluginConfig(payload *config.StructuredPayload) error {
 	var cfg config.RouterReplayPluginConfig
-	if err := decodePluginConfiguration(rawConfig, &cfg); err != nil {
+	if err := config.UnmarshalPluginConfig(payload, &cfg); err != nil {
 		return fmt.Errorf("failed to unmarshal router_replay config: %w", err)
 	}
 	if cfg.MaxRecords < 0 {

--- a/src/semantic-router/pkg/k8s/converter_test.go
+++ b/src/semantic-router/pkg/k8s/converter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/apis/vllm.ai/v1alpha1"
@@ -276,6 +277,28 @@ func TestCRDConverterConvertsEventSignals(t *testing.T) {
 	assert.Equal(t, []string{"critical"}, eventRule.Severities)
 	assert.Equal(t, []string{"TXN_DECLINE"}, eventRule.ActionCodes)
 	assert.True(t, eventRule.Temporal)
+}
+
+func TestCRDConverterRejectsUnknownPluginConfigurationField(t *testing.T) {
+	t.Parallel()
+
+	decision := testDecision([]v1alpha1.ModelRef{{Model: "test-model"}})
+	decision.Plugins = []v1alpha1.DecisionPlugin{
+		{
+			Type: "system_prompt",
+			Configuration: &runtime.RawExtension{
+				Raw: []byte(`{"system_promt":"typo"}`),
+			},
+		},
+	}
+
+	_, err := NewCRDConverter().Convert(
+		testPoolWithModels(v1alpha1.ModelConfig{Name: "test-model"}),
+		testRouteWithKeywords(nil, decision),
+		&config.CanonicalConfig{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "configuration.system_promt")
 }
 
 // TestCRDValidationErrors tests that validation catches various error conditions

--- a/src/vllm-sr/cli/algorithms.py
+++ b/src/vllm-sr/cli/algorithms.py
@@ -2,7 +2,14 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict, Field
+
+
+class BaseModel(PydanticBaseModel):
+    """Strict base for typed algorithm configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class ModelRef(BaseModel):
@@ -48,6 +55,11 @@ class ConfidenceAlgorithmConfig(BaseModel):
 
     # Behavior on model call failure: "skip" or "fail"
     on_error: str | None = "skip"
+    escalation_order: str | None = None
+    cost_quality_tradeoff: float | None = None
+    token_filter: str | None = None
+    verifier_server_url: str | None = None
+    verifier_timeout_seconds: int | None = Field(default=None, ge=0)
 
 
 class RatingsAlgorithmConfig(BaseModel):
@@ -140,6 +152,14 @@ class FusionGroundingConfig(BaseModel):
     on_error: Literal["skip", "fail"] | None = "skip"
 
 
+class FusionModelOverride(BaseModel):
+    """Per-analysis-model sampling overrides."""
+
+    model: str | None = None
+    temperature: float | None = Field(default=None, ge=0)
+    max_completion_tokens: int | None = Field(default=None, ge=1)
+
+
 class FusionAlgorithmConfig(BaseModel):
     """Configuration for Fusion multi-model deliberation.
 
@@ -151,6 +171,7 @@ class FusionAlgorithmConfig(BaseModel):
 
     model: str | None = None
     analysis_models: list[str] | None = None
+    analysis_overrides: list[FusionModelOverride] | None = None
     max_concurrent: int | None = Field(default=None, ge=1)
     max_completion_tokens: int | None = Field(default=None, ge=1)
     round_timeout_seconds: int | None = Field(default=None, ge=1)

--- a/src/vllm-sr/cli/bootstrap.py
+++ b/src/vllm-sr/cli/bootstrap.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import yaml
 
+from cli.config_contract import CANONICAL_VERSION
 from cli.consts import DEFAULT_LISTENER_PORT
 
 SETUP_MODE_ENV = "VLLM_SR_SETUP_MODE"
@@ -43,7 +44,7 @@ def build_bootstrap_config(port: int = DEFAULT_SETUP_LISTENER_PORT) -> dict[str,
     """Build the minimal config needed for dashboard-first setup."""
 
     return {
-        "version": "v0.3",
+        "version": CANONICAL_VERSION,
         "listeners": [
             {
                 "name": f"http-{port}",

--- a/src/vllm-sr/cli/config_contract.py
+++ b/src/vllm-sr/cli/config_contract.py
@@ -15,6 +15,8 @@ CANONICAL_TOP_LEVEL_KEYS = frozenset(
         "providers",
         "routing",
         "global",
+        "entrypoints",
+        "recipes",
         "setup",
     }
 )
@@ -106,6 +108,29 @@ LEGACY_ROUTING_KEYS = frozenset(
 _SIGNAL_FAMILY_BY_CONDITION_TYPE = {
     spec.condition_type: spec for spec in SIGNAL_FAMILY_SPECS
 }
+
+
+def validate_canonical_version(data: Any) -> None:
+    """Reject configs whose version is absent, malformed, or unsupported."""
+    if not isinstance(data, dict):
+        raise ValueError("config must be an object")
+    if "version" not in data:
+        raise ValueError(f"version: required; supported versions: {CANONICAL_VERSION}")
+    version = data["version"]
+    if not isinstance(version, str):
+        raise ValueError(
+            f"version: must be a string; supported versions: {CANONICAL_VERSION}"
+        )
+    if not version.strip():
+        raise ValueError(
+            f"version: must not be empty; supported versions: {CANONICAL_VERSION}"
+        )
+    if version.strip() != CANONICAL_VERSION:
+        raise ValueError(
+            f'version: unsupported config version "{version.strip()}"; '
+            f"supported versions: {CANONICAL_VERSION}; older configs must be "
+            "migrated explicitly with `vllm-sr config migrate`"
+        )
 
 
 def iter_named_signal_entries(signals: Any) -> Iterable[tuple[str, str]]:

--- a/src/vllm-sr/cli/config_import.py
+++ b/src/vllm-sr/cli/config_import.py
@@ -11,6 +11,7 @@ from typing import Any
 import yaml
 from pydantic import ValidationError as PydanticValidationError
 
+from cli.config_contract import CANONICAL_VERSION
 from cli.config_migration import migrate_config_data
 from cli.consts import DEFAULT_LISTENER_PORT
 from cli.models import UserConfig
@@ -275,7 +276,7 @@ def build_minimal_target_config() -> dict[str, Any]:
     """Build the minimal canonical config used when the target does not exist."""
 
     return {
-        "version": "v0.3",
+        "version": CANONICAL_VERSION,
         "listeners": [default_listener()],
         "providers": {
             "defaults": {},
@@ -652,7 +653,7 @@ def validate_provider_model(provider_key: str, model: Any) -> str:
 def normalize_target_shape(target: dict[str, Any]) -> None:
     """Normalize a loaded target into the canonical blocks required by import."""
 
-    target["version"] = "v0.3"
+    target["version"] = CANONICAL_VERSION
     target.pop("setup", None)
 
     listeners = ensure_list(target, "listeners")

--- a/src/vllm-sr/cli/config_migration.py
+++ b/src/vllm-sr/cli/config_migration.py
@@ -51,6 +51,10 @@ def migrate_config_data(data: dict[str, Any]) -> dict[str, Any]:
         canonical["global"] = global_config
     if "setup" in source:
         canonical["setup"] = deepcopy(source["setup"])
+    if "entrypoints" in source:
+        canonical["entrypoints"] = deepcopy(source["entrypoints"])
+    if "recipes" in source:
+        canonical["recipes"] = deepcopy(source["recipes"])
 
     return canonical
 

--- a/src/vllm-sr/cli/config_schema.py
+++ b/src/vllm-sr/cli/config_schema.py
@@ -1,0 +1,152 @@
+"""Validation against the generated Go canonical configuration schema."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from cli.config_contract import CANONICAL_VERSION
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parent / "templates" / "canonical-config-schema.json"
+)
+
+
+@lru_cache(maxsize=1)
+def load_canonical_schema() -> dict[str, Any]:
+    with _SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+    supported = schema.get("supportedVersions")
+    if supported != [CANONICAL_VERSION]:
+        raise RuntimeError(
+            "canonical config schema version does not match the CLI contract: "
+            f"{supported!r}"
+        )
+    return schema
+
+
+def reject_unknown_canonical_fields(data: Any) -> None:
+    """Reject unknown fields using stable dotted paths and list indices."""
+    errors: list[str] = []
+    schema = load_canonical_schema()
+    _collect_unknown_fields(
+        data, schema["root"], schema.get("definitions", {}), "", errors
+    )
+    if errors:
+        raise ValueError("unsupported config fields: " + ", ".join(errors))
+
+
+def _collect_unknown_fields(
+    value: Any,
+    node: dict[str, Any],
+    definitions: dict[str, Any],
+    path: str,
+    errors: list[str],
+) -> None:
+    if "ref" in node:
+        node = definitions[node["ref"]]
+    if node.get("opaque"):
+        return
+    node_type = node.get("type")
+    if node_type == "object":
+        _collect_object_fields(value, node, definitions, path, errors)
+        return
+    if node_type == "array":
+        _collect_array_fields(value, node, definitions, path, errors)
+        return
+    if node_type == "map":
+        _collect_map_fields(value, node, definitions, path, errors)
+
+
+def _collect_object_fields(
+    value: Any,
+    node: dict[str, Any],
+    definitions: dict[str, Any],
+    path: str,
+    errors: list[str],
+) -> None:
+    if not isinstance(value, dict):
+        return
+    fields = node.get("fields", {})
+    for key in sorted(value):
+        child_path = _join_path(path, str(key))
+        child = fields.get(key)
+        if not path and key == "setup":
+            # setup is a typed CLI/dashboard bootstrap marker and is removed
+            # before the Go router loads the config.
+            continue
+        if child is None:
+            suggestion = _closest_field(str(key), fields)
+            if suggestion:
+                child_path += f' (did you mean "{suggestion}"?)'
+            errors.append(child_path)
+            continue
+        _collect_unknown_fields(value[key], child, definitions, child_path, errors)
+
+
+def _collect_array_fields(
+    value: Any,
+    node: dict[str, Any],
+    definitions: dict[str, Any],
+    path: str,
+    errors: list[str],
+) -> None:
+    if not isinstance(value, list):
+        return
+    item_schema = node.get("items", {})
+    for index, item in enumerate(value):
+        _collect_unknown_fields(
+            item, item_schema, definitions, f"{path}[{index}]", errors
+        )
+
+
+def _collect_map_fields(
+    value: Any,
+    node: dict[str, Any],
+    definitions: dict[str, Any],
+    path: str,
+    errors: list[str],
+) -> None:
+    if not isinstance(value, dict):
+        return
+    value_schema = node.get("values", {})
+    for key in sorted(value):
+        child_path = _join_path(path, str(key))
+        _collect_unknown_fields(
+            value[key], value_schema, definitions, child_path, errors
+        )
+
+
+def _join_path(parent: str, child: str) -> str:
+    if not parent:
+        return child
+    return f"{parent}.{child}"
+
+
+def _closest_field(unknown: str, fields: dict[str, Any]) -> str | None:
+    closest: str | None = None
+    closest_distance = 4
+    for field in sorted(fields):
+        distance = _levenshtein(unknown, field)
+        if distance < closest_distance:
+            closest = field
+            closest_distance = distance
+    return closest
+
+
+def _levenshtein(left: str, right: str) -> int:
+    previous = list(range(len(right) + 1))
+    for left_index, left_character in enumerate(left, start=1):
+        current = [left_index]
+        for right_index, right_character in enumerate(right, start=1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[right_index] + 1,
+                    previous[right_index - 1] + (left_character != right_character),
+                )
+            )
+        previous = current
+    return previous[-1]

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import (
-    BaseModel,
+    BaseModel as PydanticBaseModel,
     ConfigDict,
     Field,
     StrictBool,
@@ -13,6 +13,13 @@ from pydantic import (
 )
 
 from .algorithms import AlgorithmConfig, ModelRef
+from .config_contract import CANONICAL_VERSION
+
+
+class BaseModel(PydanticBaseModel):
+    """Strict base for every typed canonical configuration surface."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class Listener(BaseModel):
@@ -37,6 +44,12 @@ class KeywordSignal(BaseModel):
     operator: str
     keywords: List[str]
     case_sensitive: bool = False
+    method: Optional[str] = None
+    fuzzy_match: bool = False
+    fuzzy_threshold: int = 0
+    bm25_threshold: float = 0
+    ngram_threshold: float = 0
+    ngram_arity: int = 0
 
 
 class EmbeddingSignal(BaseModel):
@@ -130,12 +143,21 @@ class Projections(BaseModel):
     mappings: Optional[List[ProjectionMapping]] = []
 
 
+class DomainModelScore(BaseModel):
+    """Per-domain model preference metadata."""
+
+    model: str
+    score: float
+    use_reasoning: Optional[bool] = None
+
+
 class Domain(BaseModel):
     """Domain category configuration."""
 
     name: str
-    description: str
+    description: Optional[str] = None
     mmlu_categories: Optional[List[str]] = None
+    model_scores: List[DomainModelScore] = Field(default_factory=list)
 
 
 class FactCheck(BaseModel):
@@ -165,7 +187,8 @@ class Language(BaseModel):
     """Language detection signal configuration."""
 
     name: str
-    description: str
+    description: Optional[str] = None
+    threshold: Optional[float] = None
 
 
 class ContextRule(BaseModel):
@@ -283,7 +306,7 @@ class PrototypeScoringConfig(BaseModel):
 class EmbeddingClassifierConfig(BaseModel):
     """Embedding classifier tuning, including prototype-aware label scoring controls."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     backend: Optional[str] = None
     model_type: Optional[str] = None
@@ -561,6 +584,24 @@ class ToolsPluginConfig(BaseModel):
     semantic_selection: Optional[bool] = None
     allow_tools: Optional[List[str]] = None
     block_tools: Optional[List[str]] = None
+    strategy: Optional[str] = None
+    dynamic_retrieval: Optional["DynamicRetrievalConfig"] = None
+
+
+class DynamicRetrievalWeights(BaseModel):
+    semantic: float = 0
+    history: float = 0
+    decision_prior: float = 0
+    repetition_penalty: float = 0
+
+
+class DynamicRetrievalConfig(BaseModel):
+    enabled: bool
+    strategy: Optional[Literal["semantic_only", "hybrid_history"]] = None
+    history_window: int = 0
+    weights: Optional[DynamicRetrievalWeights] = None
+    min_history_confidence: float = 0
+    fallback_on_low_confidence: bool = False
 
 
 class ToolFilteringWeights(BaseModel):
@@ -687,6 +728,17 @@ class RouterReplayPluginConfig(BaseModel):
         gt=0,
         description="Max bytes to capture per body (must be > 0, default: 4096)",
     )
+    max_tool_trace_bytes: int = Field(default=0, ge=0)
+    max_tool_trace_steps: int = Field(default=0, ge=0)
+
+
+class MemoryReflectionConfig(BaseModel):
+    enabled: Optional[bool] = None
+    algorithm: Optional[str] = None
+    max_inject_tokens: int = 0
+    recency_decay_days: int = 0
+    dedup_threshold: float = 0
+    block_patterns: Optional[List[str]] = None
 
 
 class MemoryPluginConfig(BaseModel):
@@ -708,6 +760,64 @@ class MemoryPluginConfig(BaseModel):
         default=None,
         description="Auto-extract memories from conversation (default: use request config)",
     )
+    hybrid_search: bool = False
+    hybrid_mode: Optional[str] = None
+    reflection: Optional[MemoryReflectionConfig] = None
+
+
+class MilvusRAGConfig(BaseModel):
+    collection: str
+    reuse_cache_connection: bool = False
+    content_field: Optional[str] = None
+    metadata_field: Optional[str] = None
+    filter_expression: Optional[str] = None
+
+
+class QdrantRAGConfig(BaseModel):
+    collection: str
+    reuse_cache_connection: bool = False
+    content_field: Optional[str] = None
+
+
+class ExternalAPIRAGConfig(BaseModel):
+    endpoint: str
+    api_key: Optional[str] = None
+    auth_header: Optional[str] = None
+    request_format: str
+    request_template: Optional[str] = None
+    timeout_seconds: Optional[int] = None
+    headers: Optional[Dict[str, str]] = None
+
+
+class MCPRAGConfig(BaseModel):
+    server_name: str
+    tool_name: str
+    tool_arguments: Optional[Dict[str, Any]] = None
+    timeout_seconds: Optional[int] = None
+
+
+class OpenAIRAGConfig(BaseModel):
+    vector_store_id: str
+    base_url: Optional[str] = None
+    api_key: str
+    max_num_results: Optional[int] = None
+    file_ids: Optional[List[str]] = None
+    filter: Optional[Dict[str, Any]] = None
+    timeout_seconds: Optional[int] = None
+    workflow_mode: Optional[str] = None
+
+
+class VectorStoreRAGConfig(BaseModel):
+    vector_store_id: str
+    file_ids: Optional[List[str]] = None
+
+
+class HybridRAGConfig(BaseModel):
+    primary: str
+    fallback: Optional[str] = None
+    primary_config: Optional[Dict[str, Any]] = None
+    fallback_config: Optional[Dict[str, Any]] = None
+    strategy: Optional[str] = None
 
 
 class RAGPluginConfig(BaseModel):
@@ -801,16 +911,25 @@ class RAGPluginConfig(BaseModel):
         description="Minimum confidence for triggering retrieval",
     )
 
+    @model_validator(mode="after")
+    def validate_backend_configuration(self):
+        _validate_rag_backend_configuration(
+            self.backend, self.backend_config, "backend_config"
+        )
+        return self
+
 
 class PluginConfig(BaseModel):
-    """Plugin configuration with type validation.
-
-    Configuration schema validation is performed in the validator module
-    to ensure proper plugin-specific validation.
-    """
+    """Plugin configuration validated by its type discriminator owner."""
 
     type: PluginType
     configuration: Dict[str, Any]
+
+    @model_validator(mode="after")
+    def validate_owned_configuration(self):
+        config_model = plugin_configuration_models()[self.type.value]
+        config_model.model_validate(self.configuration)
+        return self
 
     def model_dump(self, **kwargs):
         """Override model_dump to serialize PluginType enum as string value."""
@@ -826,17 +945,108 @@ class PluginConfig(BaseModel):
         return data
 
 
+class ModalityClassifierConfig(BaseModel):
+    model_path: Optional[str] = None
+    use_cpu: bool = False
+
+
+class ModalityDetectionConfig(BaseModel):
+    method: Optional[Literal["classifier", "keyword", "hybrid"]] = None
+    classifier: Optional[ModalityClassifierConfig] = None
+    keywords: Optional[List[str]] = None
+    both_keywords: Optional[List[str]] = None
+    confidence_threshold: float = 0
+    lower_threshold_ratio: float = 0
+
+
+class VLLMOmniImageGenConfig(BaseModel):
+    base_url: str
+    model: Optional[str] = None
+    num_inference_steps: int = 0
+    cfg_scale: float = 0
+    seed: Optional[int] = None
+
+
+class OpenAIImageGenConfig(BaseModel):
+    api_key: str
+    base_url: Optional[str] = None
+    model: Optional[str] = None
+    quality: Optional[str] = None
+    style: Optional[str] = None
+
+
 class ImageGenPluginConfig(BaseModel):
     """Configuration for image_gen plugin."""
 
     enabled: bool
     backend: str
     backend_config: Optional[Dict[str, Any]] = None
-    modality_detection: Optional[Dict[str, Any]] = None
+    modality_detection: Optional[ModalityDetectionConfig] = None
     default_width: Optional[int] = Field(default=None, ge=1)
     default_height: Optional[int] = Field(default=None, ge=1)
     max_inference_steps: Optional[int] = Field(default=None, ge=1)
     timeout_seconds: Optional[int] = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def validate_backend_configuration(self):
+        if self.backend_config is None:
+            return self
+        config_model = {
+            "vllm_omni": VLLMOmniImageGenConfig,
+            "openai": OpenAIImageGenConfig,
+        }.get(self.backend)
+        if config_model is None:
+            raise ValueError(f"unsupported image_gen backend {self.backend!r}")
+        config_model.model_validate(self.backend_config)
+        return self
+
+
+def _validate_rag_backend_configuration(
+    backend: str, configuration: Optional[Dict[str, Any]], path: str
+) -> None:
+    if configuration is None:
+        return
+    config_model = {
+        "milvus": MilvusRAGConfig,
+        "qdrant": QdrantRAGConfig,
+        "external_api": ExternalAPIRAGConfig,
+        "mcp": MCPRAGConfig,
+        "openai": OpenAIRAGConfig,
+        "vectorstore": VectorStoreRAGConfig,
+        "hybrid": HybridRAGConfig,
+    }.get(backend)
+    if config_model is None:
+        raise ValueError(f"{path}: unsupported RAG backend {backend!r}")
+    validated = config_model.model_validate(configuration)
+    if not isinstance(validated, HybridRAGConfig):
+        return
+    _validate_rag_backend_configuration(
+        validated.primary, validated.primary_config, f"{path}.primary_config"
+    )
+    if validated.fallback or validated.fallback_config is not None:
+        _validate_rag_backend_configuration(
+            validated.fallback or "",
+            validated.fallback_config,
+            f"{path}.fallback_config",
+        )
+
+
+def plugin_configuration_models() -> Dict[str, type[BaseModel]]:
+    return {
+        PluginType.SEMANTIC_CACHE.value: SemanticCachePluginConfig,
+        PluginType.FAST_RESPONSE.value: FastResponsePluginConfig,
+        PluginType.REQUEST_PARAMS.value: RequestParamsPluginConfig,
+        PluginType.RESPONSE_JAILBREAK.value: ResponseJailbreakPluginConfig,
+        PluginType.SYSTEM_PROMPT.value: SystemPromptPluginConfig,
+        PluginType.HEADER_MUTATION.value: HeaderMutationPluginConfig,
+        PluginType.HALLUCINATION.value: HallucinationPluginConfig,
+        PluginType.ROUTER_REPLAY.value: RouterReplayPluginConfig,
+        PluginType.MEMORY.value: MemoryPluginConfig,
+        PluginType.RAG.value: RAGPluginConfig,
+        PluginType.IMAGE_GEN.value: ImageGenPluginConfig,
+        PluginType.TOOLS.value: ToolsPluginConfig,
+        PluginType.TOOL_SELECTION.value: ToolSelectionPluginConfig,
+    }
 
 
 class DecisionLearningAdaptationConfig(BaseModel):
@@ -1014,6 +1224,38 @@ class OutputContractSpec(BaseModel):
     postprocess: Optional[List[OutputContractPostprocess]] = None
 
 
+class RetentionDirective(BaseModel):
+    """Declarative cache/model retention controls emitted by the DSL."""
+
+    drop: Optional[bool] = None
+    ttl_turns: Optional[int] = None
+    keep_current_model: Optional[bool] = None
+    prefer_prefix_retention: Optional[bool] = None
+
+
+class EmitDirective(BaseModel):
+    """Typed declarative side effect attached to a decision."""
+
+    kind: Literal["retention"]
+    retention: Optional[RetentionDirective] = None
+
+
+class CandidateIterationOutput(BaseModel):
+    """How a bounded candidate iteration feeds routing output."""
+
+    type: str
+    value: Optional[str] = None
+
+
+class CandidateIteration(BaseModel):
+    """Bounded DSL candidate iteration metadata."""
+
+    variable: str
+    source: str
+    models: List[ModelRef] = Field(default_factory=list)
+    outputs: List[CandidateIterationOutput] = Field(default_factory=list)
+
+
 class Decision(BaseModel):
     """Routing decision configuration."""
 
@@ -1022,6 +1264,7 @@ class Decision(BaseModel):
     name: str
     description: str
     priority: int
+    tier: int = 0
     rules: Rules
     output_contract: Optional[str] = None
     output_contract_spec: Optional[OutputContractSpec] = None
@@ -1029,6 +1272,8 @@ class Decision(BaseModel):
     algorithm: Optional[AlgorithmConfig] = None  # Multi-model orchestration algorithm
     adaptations: Optional[DecisionAdaptationsConfig] = None
     plugins: Optional[List[PluginConfig]] = []
+    candidateIterations: List[CandidateIteration] = Field(default_factory=list)
+    emits: List[EmitDirective] = Field(default_factory=list)
 
 
 class ModelPricing(BaseModel):
@@ -1154,8 +1399,7 @@ class Routing(BaseModel):
 class EmbeddingModelsConfig(BaseModel):
     """Embedding models configuration for memory and semantic features."""
 
-    # Preserve advanced nested fields when users pass through custom config blocks.
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     qwen3_model_path: Optional[str] = Field(
         None, description="Path to Qwen3-Embedding model"
@@ -1185,17 +1429,43 @@ class EmbeddingModelsConfig(BaseModel):
     use_cpu: bool = Field(True, description="Use CPU for inference")
 
 
+class CanonicalEntrypoint(BaseModel):
+    """Selects a named recipe for one or more request model names."""
+
+    model_names: List[str]
+    recipe: str
+
+
+class CanonicalRecipe(BaseModel):
+    """Named routing profile sharing the top-level model catalog."""
+
+    name: str
+    description: Optional[str] = None
+    routing: Routing
+
+
+class SetupConfig(BaseModel):
+    """CLI/dashboard bootstrap marker removed before router startup."""
+
+    mode: bool
+    state: Optional[str] = None
+    created_by: Optional[str] = None
+    created_at: Optional[str] = None
+
+
 class UserConfig(BaseModel):
     """Canonical v0.3 user configuration."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    version: str
+    version: Literal[CANONICAL_VERSION]
     listeners: List[Listener] = Field(default_factory=list)
     providers: Providers = Field(default_factory=Providers)
     routing: Routing = Field(default_factory=Routing)
     global_: Optional[Dict[str, Any]] = Field(default=None, alias="global")
-    setup: Optional[Dict[str, Any]] = None
+    entrypoints: List[CanonicalEntrypoint] = Field(default_factory=list)
+    recipes: List[CanonicalRecipe] = Field(default_factory=list)
+    setup: Optional[SetupConfig] = None
 
     @property
     def signals(self) -> Signals:
@@ -1209,3 +1479,4 @@ class UserConfig(BaseModel):
 # Resolve forward references for recursive condition trees.
 Condition.model_rebuild()
 Model.model_rebuild()
+ToolsPluginConfig.model_rebuild()

--- a/src/vllm-sr/cli/parser.py
+++ b/src/vllm-sr/cli/parser.py
@@ -6,12 +6,14 @@ from typing import Dict, Any
 from pydantic import ValidationError
 
 from cli.config_contract import (
+    validate_canonical_version,
     LEGACY_PROVIDER_DEFAULT_KEYS,
     LEGACY_PROVIDER_MODEL_SURFACE_KEYS,
     LEGACY_SIGNAL_KEY_TO_CANONICAL,
     iter_named_signal_entries,
 )
 from cli.models import RouterLearningConfig, UserConfig
+from cli.config_schema import reject_unknown_canonical_fields
 from cli.utils import get_logger
 
 log = get_logger(__name__)
@@ -464,6 +466,12 @@ def parse_user_config(config_path: str) -> UserConfig:
 
     if not data:
         raise ConfigParseError("Configuration file is empty")
+
+    try:
+        validate_canonical_version(data)
+        reject_unknown_canonical_fields(data)
+    except ValueError as exc:
+        raise ConfigParseError(str(exc)) from exc
 
     _reject_invalid_config_surfaces(data, config_path)
 

--- a/src/vllm-sr/cli/templates/canonical-config-schema.json
+++ b/src/vllm-sr/cli/templates/canonical-config-schema.json
@@ -1,0 +1,4819 @@
+{
+  "supportedVersions": [
+    "v0.3"
+  ],
+  "root": {
+    "type": "",
+    "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalConfig"
+  },
+  "definitions": {
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.APIConfig": {
+      "type": "object",
+      "fields": {
+        "batch_classification": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.BatchClassificationConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AdvancedToolFilteringConfig": {
+      "type": "object",
+      "fields": {
+        "allow_tools": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "block_tools": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "candidate_pool_size": {
+          "type": "scalar"
+        },
+        "category_confidence_threshold": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "hybrid_history": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HybridHistoryToolRetrievalConfig"
+        },
+        "min_combined_score": {
+          "type": "scalar"
+        },
+        "min_lexical_overlap": {
+          "type": "scalar"
+        },
+        "retrieval_strategy": {
+          "type": "scalar"
+        },
+        "use_category_filter": {
+          "type": "scalar"
+        },
+        "weights": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ToolFilteringWeights"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AlgorithmConfig": {
+      "type": "object",
+      "fields": {
+        "automix": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AutoMixSelectionConfig"
+        },
+        "confidence": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConfidenceAlgorithmConfig"
+        },
+        "fusion": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionAlgorithmConfig"
+        },
+        "hybrid": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HybridSelectionConfig"
+        },
+        "latency_aware": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LatencyAwareAlgorithmConfig"
+        },
+        "multi_factor": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MultiFactorSelectionConfig"
+        },
+        "on_error": {
+          "type": "scalar"
+        },
+        "ratings": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RatingsAlgorithmConfig"
+        },
+        "remom": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReMoMAlgorithmConfig"
+        },
+        "router_dc": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterDCSelectionConfig"
+        },
+        "type": {
+          "type": "scalar"
+        },
+        "workflows": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowsAlgorithmConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AuthzConfig": {
+      "type": "object",
+      "fields": {
+        "fail_open": {
+          "type": "scalar"
+        },
+        "identity": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.IdentityConfig"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AuthzProviderConfig"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AuthzProviderConfig": {
+      "type": "object",
+      "fields": {
+        "headers": {
+          "type": "map",
+          "values": {
+            "type": "scalar"
+          }
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AutoMixSelectionConfig": {
+      "type": "object",
+      "fields": {
+        "cost_aware_routing": {
+          "type": "scalar"
+        },
+        "cost_quality_tradeoff": {
+          "type": "scalar"
+        },
+        "discount_factor": {
+          "type": "scalar"
+        },
+        "max_escalations": {
+          "type": "scalar"
+        },
+        "use_logprob_verification": {
+          "type": "scalar"
+        },
+        "verification_threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.BatchClassificationConfig": {
+      "type": "object",
+      "fields": {
+        "concurrency_threshold": {
+          "type": "scalar"
+        },
+        "max_batch_size": {
+          "type": "scalar"
+        },
+        "max_concurrency": {
+          "type": "scalar"
+        },
+        "metrics": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.BatchClassificationMetricsConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.BatchClassificationMetricsConfig": {
+      "type": "object",
+      "fields": {
+        "batch_size_ranges": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.BatchSizeRangeConfig"
+          }
+        },
+        "detailed_goroutine_tracking": {
+          "type": "scalar"
+        },
+        "duration_buckets": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "high_resolution_timing": {
+          "type": "scalar"
+        },
+        "sample_rate": {
+          "type": "scalar"
+        },
+        "size_buckets": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.BatchSizeRangeConfig": {
+      "type": "object",
+      "fields": {
+        "label": {
+          "type": "scalar"
+        },
+        "max": {
+          "type": "scalar"
+        },
+        "min": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CandidateIterationConfig": {
+      "type": "object",
+      "fields": {
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelRef"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CandidateIterationOutputConfig"
+          }
+        },
+        "source": {
+          "type": "scalar"
+        },
+        "variable": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CandidateIterationOutputConfig": {
+      "type": "object",
+      "fields": {
+        "type": {
+          "type": "scalar"
+        },
+        "value": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalBackendRef": {
+      "type": "object",
+      "fields": {
+        "api_key": {
+          "type": "scalar"
+        },
+        "api_key_env": {
+          "type": "scalar"
+        },
+        "api_version": {
+          "type": "scalar"
+        },
+        "auth_header": {
+          "type": "scalar"
+        },
+        "auth_prefix": {
+          "type": "scalar"
+        },
+        "base_url": {
+          "type": "scalar"
+        },
+        "chat_path": {
+          "type": "scalar"
+        },
+        "endpoint": {
+          "type": "scalar"
+        },
+        "extra_headers": {
+          "type": "map",
+          "values": {
+            "type": "scalar"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "protocol": {
+          "type": "scalar"
+        },
+        "provider": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        },
+        "weight": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalCategoryModule": {
+      "type": "object",
+      "fields": {
+        "category_mapping_path": {
+          "type": "scalar"
+        },
+        "fallback_category": {
+          "type": "scalar"
+        },
+        "model_id": {
+          "type": "scalar"
+        },
+        "model_ref": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        },
+        "use_mmbert_32k": {
+          "type": "scalar"
+        },
+        "use_modernbert": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalClassifierModule": {
+      "type": "object",
+      "fields": {
+        "domain": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalCategoryModule"
+        },
+        "mcp": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MCPCategoryModel"
+        },
+        "pii": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalPIIModule"
+        },
+        "preference": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PreferenceModelConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalConfig": {
+      "type": "object",
+      "fields": {
+        "entrypoints": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalEntrypoint"
+          }
+        },
+        "global": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalGlobal"
+        },
+        "listeners": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Listener"
+          }
+        },
+        "providers": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProviders"
+        },
+        "recipes": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalRecipe"
+          }
+        },
+        "routing": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalRouting"
+        },
+        "version": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalEmbeddingModels": {
+      "type": "object",
+      "fields": {
+        "semantic": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmbeddingModels"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalEntrypoint": {
+      "type": "object",
+      "fields": {
+        "model_names": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "recipe": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalExplainerModule": {
+      "type": "object",
+      "fields": {
+        "model_id": {
+          "type": "scalar"
+        },
+        "model_ref": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalFactCheckModule": {
+      "type": "object",
+      "fields": {
+        "model_id": {
+          "type": "scalar"
+        },
+        "model_ref": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        },
+        "use_mmbert_32k": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalFeedbackDetectorModule": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "feedback_mapping_path": {
+          "type": "scalar"
+        },
+        "model_id": {
+          "type": "scalar"
+        },
+        "model_ref": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        },
+        "use_mmbert_32k": {
+          "type": "scalar"
+        },
+        "use_modernbert": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalGlobal": {
+      "type": "object",
+      "fields": {
+        "integrations": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalIntegrationGlobal"
+        },
+        "model_catalog": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalModelCatalog"
+        },
+        "router": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalRouterGlobal"
+        },
+        "services": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalServiceGlobal"
+        },
+        "stores": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalStoreGlobal"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalHallucinationDetector": {
+      "type": "object",
+      "fields": {
+        "context_window_size": {
+          "type": "scalar"
+        },
+        "enable_nli_filtering": {
+          "type": "scalar"
+        },
+        "min_span_confidence": {
+          "type": "scalar"
+        },
+        "min_span_length": {
+          "type": "scalar"
+        },
+        "model_id": {
+          "type": "scalar"
+        },
+        "model_ref": {
+          "type": "scalar"
+        },
+        "nli_entailment_threshold": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalHallucinationModule": {
+      "type": "object",
+      "fields": {
+        "detector": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalHallucinationDetector"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "explainer": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalExplainerModule"
+        },
+        "fact_check": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalFactCheckModule"
+        },
+        "on_hallucination_detected": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalIntegrationGlobal": {
+      "type": "object",
+      "fields": {
+        "looper": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LooperConfig"
+        },
+        "tools": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ToolsConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalModelCatalog": {
+      "type": "object",
+      "fields": {
+        "embeddings": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalEmbeddingModels"
+        },
+        "external": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ExternalModelConfig"
+          }
+        },
+        "kbs": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KnowledgeBaseConfig"
+          }
+        },
+        "modules": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalModelModules"
+        },
+        "system": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalSystemModels"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalModelModules": {
+      "type": "object",
+      "fields": {
+        "classifier": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalClassifierModule"
+        },
+        "complexity": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ComplexityModelConfig"
+        },
+        "feedback_detector": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalFeedbackDetectorModule"
+        },
+        "hallucination_mitigation": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalHallucinationModule"
+        },
+        "modality_detector": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModalityDetectorConfig"
+        },
+        "prompt_compression": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PromptCompressionConfig"
+        },
+        "prompt_guard": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalPromptGuardModule"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalPIIModule": {
+      "type": "object",
+      "fields": {
+        "model_id": {
+          "type": "scalar"
+        },
+        "model_ref": {
+          "type": "scalar"
+        },
+        "pii_mapping_path": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        },
+        "use_mmbert_32k": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProjections": {
+      "type": "object",
+      "fields": {
+        "mappings": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionMapping"
+          }
+        },
+        "partitions": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionPartition"
+          }
+        },
+        "scores": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionScore"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalPromptGuardModule": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "jailbreak_mapping_path": {
+          "type": "scalar"
+        },
+        "model_id": {
+          "type": "scalar"
+        },
+        "model_ref": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        },
+        "use_mmbert_32k": {
+          "type": "scalar"
+        },
+        "use_modernbert": {
+          "type": "scalar"
+        },
+        "use_vllm": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProviderDefaults": {
+      "type": "object",
+      "fields": {
+        "default_model": {
+          "type": "scalar"
+        },
+        "default_reasoning_effort": {
+          "type": "scalar"
+        },
+        "reasoning_families": {
+          "type": "map",
+          "values": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReasoningFamilyConfig"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProviderModel": {
+      "type": "object",
+      "fields": {
+        "api_format": {
+          "type": "scalar"
+        },
+        "backend_refs": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalBackendRef"
+          }
+        },
+        "external_model_ids": {
+          "type": "map",
+          "values": {
+            "type": "scalar"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "pricing": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelPricing"
+        },
+        "provider_model_id": {
+          "type": "scalar"
+        },
+        "reasoning_family": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProviders": {
+      "type": "object",
+      "fields": {
+        "defaults": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProviderDefaults"
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProviderModel"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalRecipe": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "routing": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalRouting"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalRouterGlobal": {
+      "type": "object",
+      "fields": {
+        "auto_model_name": {
+          "type": "scalar"
+        },
+        "auto_model_names": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "clear_route_cache": {
+          "type": "scalar"
+        },
+        "config_source": {
+          "type": "scalar"
+        },
+        "include_config_models_in_list": {
+          "type": "scalar"
+        },
+        "learning": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningConfig"
+        },
+        "model_selection": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelSelectionConfig"
+        },
+        "skip_processing": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.SkipProcessingConfig"
+        },
+        "strategy": {
+          "type": "scalar"
+        },
+        "streamed_body": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalStreamedBody"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalRouting": {
+      "type": "object",
+      "fields": {
+        "decisions": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Decision"
+          }
+        },
+        "modelCards": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RoutingModel"
+          }
+        },
+        "projections": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalProjections"
+        },
+        "signals": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalSignals"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalServiceGlobal": {
+      "type": "object",
+      "fields": {
+        "api": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.APIConfig"
+        },
+        "authz": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AuthzConfig"
+        },
+        "management_api": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ManagementAPIConfig"
+        },
+        "observability": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ObservabilityConfig"
+        },
+        "ratelimit": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitConfig"
+        },
+        "response_api": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ResponseAPIConfig"
+        },
+        "router_replay": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayConfig"
+        },
+        "startup_status": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StartupStatusConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalSignals": {
+      "type": "object",
+      "fields": {
+        "complexity": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ComplexityRule"
+          }
+        },
+        "context": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ContextRule"
+          }
+        },
+        "conversation": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConversationRule"
+          }
+        },
+        "domains": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Category"
+          }
+        },
+        "embeddings": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmbeddingRule"
+          }
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EventRule"
+          }
+        },
+        "fact_check": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FactCheckRule"
+          }
+        },
+        "jailbreak": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.JailbreakRule"
+          }
+        },
+        "kb": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KBSignalRule"
+          }
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KeywordRule"
+          }
+        },
+        "language": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LanguageRule"
+          }
+        },
+        "modality": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModalityRule"
+          }
+        },
+        "pii": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PIIRule"
+          }
+        },
+        "preferences": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PreferenceRule"
+          }
+        },
+        "reasks": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReaskRule"
+          }
+        },
+        "role_bindings": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RoleBinding"
+          }
+        },
+        "structure": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructureRule"
+          }
+        },
+        "user_feedbacks": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.UserFeedbackRule"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalStoreGlobal": {
+      "type": "object",
+      "fields": {
+        "memory": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryConfig"
+        },
+        "semantic_cache": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.SemanticCache"
+        },
+        "vector_store": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.VectorStoreConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalStreamedBody": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "max_bytes": {
+          "type": "scalar"
+        },
+        "timeout_sec": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CanonicalSystemModels": {
+      "type": "object",
+      "fields": {
+        "domain_classifier": {
+          "type": "scalar"
+        },
+        "fact_check_classifier": {
+          "type": "scalar"
+        },
+        "feedback_detector": {
+          "type": "scalar"
+        },
+        "hallucination_detector": {
+          "type": "scalar"
+        },
+        "hallucination_explainer": {
+          "type": "scalar"
+        },
+        "pii_classifier": {
+          "type": "scalar"
+        },
+        "prompt_guard": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Category": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "mmlu_categories": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "model_scores": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelScore"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ClassifierVLLMEndpoint": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "prompt_template": {
+          "type": "scalar"
+        },
+        "protocol": {
+          "type": "scalar"
+        },
+        "use_chat_template": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ComplexityCandidates": {
+      "type": "object",
+      "fields": {
+        "candidates": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "image_candidates": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ComplexityModelConfig": {
+      "type": "object",
+      "fields": {
+        "prototype_scoring": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PrototypeScoringConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ComplexityRule": {
+      "type": "object",
+      "fields": {
+        "composer": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RuleNode"
+        },
+        "description": {
+          "type": "scalar"
+        },
+        "easy": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ComplexityCandidates"
+        },
+        "hard": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ComplexityCandidates"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConfidenceAlgorithmConfig": {
+      "type": "object",
+      "fields": {
+        "confidence_method": {
+          "type": "scalar"
+        },
+        "cost_quality_tradeoff": {
+          "type": "scalar"
+        },
+        "escalation_order": {
+          "type": "scalar"
+        },
+        "hybrid_weights": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HybridWeightsConfig"
+        },
+        "on_error": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "token_filter": {
+          "type": "scalar"
+        },
+        "verifier_server_url": {
+          "type": "scalar"
+        },
+        "verifier_timeout_seconds": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ContextRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "max_tokens": {
+          "type": "scalar"
+        },
+        "min_tokens": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConversationFeature": {
+      "type": "object",
+      "fields": {
+        "source": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConversationSource"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConversationRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "feature": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConversationFeature"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "predicate": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.NumericPredicate"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ConversationSource": {
+      "type": "object",
+      "fields": {
+        "role": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Decision": {
+      "type": "object",
+      "fields": {
+        "adaptations": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionAdaptationsConfig"
+        },
+        "algorithm": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AlgorithmConfig"
+        },
+        "candidateIterations": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.CandidateIterationConfig"
+          }
+        },
+        "description": {
+          "type": "scalar"
+        },
+        "emits": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmitDirective"
+          }
+        },
+        "modelRefs": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelRef"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "output_contract": {
+          "type": "scalar"
+        },
+        "output_contract_spec": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractSpec"
+        },
+        "plugins": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionPlugin"
+          }
+        },
+        "priority": {
+          "type": "scalar"
+        },
+        "rules": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RuleNode"
+        },
+        "tier": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionAdaptationsConfig": {
+      "type": "object",
+      "fields": {
+        "adaptation": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionLearningAdaptationConfig"
+        },
+        "mode": {
+          "type": "scalar"
+        },
+        "protection": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionLearningProtectionConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionLearningAdaptationConfig": {
+      "type": "object",
+      "fields": {
+        "candidate_set": {
+          "type": "scalar"
+        },
+        "mode": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionLearningProtectionConfig": {
+      "type": "object",
+      "fields": {
+        "mode": {
+          "type": "scalar"
+        },
+        "stability_weight": {
+          "type": "scalar"
+        },
+        "switch_margin": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.DecisionPlugin": {
+      "type": "object",
+      "fields": {
+        "configuration": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructuredPayload"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmbeddingEndpointConfig": {
+      "type": "object",
+      "fields": {
+        "api_key_env": {
+          "type": "scalar"
+        },
+        "base_url": {
+          "type": "scalar"
+        },
+        "dimensions": {
+          "type": "scalar"
+        },
+        "max_retries": {
+          "type": "scalar"
+        },
+        "model": {
+          "type": "scalar"
+        },
+        "timeout_seconds": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmbeddingModels": {
+      "type": "object",
+      "fields": {
+        "bert_model_path": {
+          "type": "scalar"
+        },
+        "embedding_config": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HNSWConfig"
+        },
+        "endpoint": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmbeddingEndpointConfig"
+        },
+        "gemma_model_path": {
+          "type": "scalar"
+        },
+        "mmbert_model_path": {
+          "type": "scalar"
+        },
+        "multimodal_model_path": {
+          "type": "scalar"
+        },
+        "qwen3_model_path": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmbeddingRule": {
+      "type": "object",
+      "fields": {
+        "aggregation_method": {
+          "type": "scalar"
+        },
+        "candidates": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "query_modality": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EmitDirective": {
+      "type": "object",
+      "fields": {
+        "kind": {
+          "type": "scalar"
+        },
+        "retention": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RetentionDirective"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.EventRule": {
+      "type": "object",
+      "fields": {
+        "action_codes": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "description": {
+          "type": "scalar"
+        },
+        "event_types": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "severities": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "temporal": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ExternalModelConfig": {
+      "type": "object",
+      "fields": {
+        "access_key": {
+          "type": "scalar"
+        },
+        "llm_endpoint": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ClassifierVLLMEndpoint"
+        },
+        "llm_model_name": {
+          "type": "scalar"
+        },
+        "llm_provider": {
+          "type": "scalar"
+        },
+        "llm_timeout_seconds": {
+          "type": "scalar"
+        },
+        "max_tokens": {
+          "type": "scalar"
+        },
+        "model_role": {
+          "type": "scalar"
+        },
+        "parser_type": {
+          "type": "scalar"
+        },
+        "temperature": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FactCheckRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FlowRuntimeConfig": {
+      "type": "object",
+      "fields": {
+        "model_names": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "state": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowStateRuntimeConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionAlgorithmConfig": {
+      "type": "object",
+      "fields": {
+        "analysis_models": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "analysis_overrides": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionModelOverride"
+          }
+        },
+        "analysis_template": {
+          "type": "scalar"
+        },
+        "grounding": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionGroundingConfig"
+        },
+        "include_analysis": {
+          "type": "scalar"
+        },
+        "include_intermediate_responses": {
+          "type": "scalar"
+        },
+        "judge_prompt_version": {
+          "type": "scalar"
+        },
+        "max_completion_tokens": {
+          "type": "scalar"
+        },
+        "max_concurrent": {
+          "type": "scalar"
+        },
+        "min_successful_responses": {
+          "type": "scalar"
+        },
+        "model": {
+          "type": "scalar"
+        },
+        "on_error": {
+          "type": "scalar"
+        },
+        "round_timeout_seconds": {
+          "type": "scalar"
+        },
+        "synthesis_template": {
+          "type": "scalar"
+        },
+        "temperature": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionGroundingConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "min_keep": {
+          "type": "scalar"
+        },
+        "min_score": {
+          "type": "scalar"
+        },
+        "nli_contradiction_penalty": {
+          "type": "scalar"
+        },
+        "on_error": {
+          "type": "scalar"
+        },
+        "policy": {
+          "type": "scalar"
+        },
+        "reference": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionModelOverride": {
+      "type": "object",
+      "fields": {
+        "max_completion_tokens": {
+          "type": "scalar"
+        },
+        "model": {
+          "type": "scalar"
+        },
+        "temperature": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionRuntimeConfig": {
+      "type": "object",
+      "fields": {
+        "model_names": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HNSWConfig": {
+      "type": "object",
+      "fields": {
+        "backend": {
+          "type": "scalar"
+        },
+        "enable_soft_matching": {
+          "type": "scalar"
+        },
+        "min_score_threshold": {
+          "type": "scalar"
+        },
+        "model_type": {
+          "type": "scalar"
+        },
+        "preload_embeddings": {
+          "type": "scalar"
+        },
+        "prototype_scoring": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PrototypeScoringConfig"
+        },
+        "target_dimension": {
+          "type": "scalar"
+        },
+        "target_layer": {
+          "type": "scalar"
+        },
+        "top_k": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HybridHistoryToolRetrievalConfig": {
+      "type": "object",
+      "fields": {
+        "history_confidence_threshold": {
+          "type": "scalar"
+        },
+        "history_horizon": {
+          "type": "scalar"
+        },
+        "min_history_steps": {
+          "type": "scalar"
+        },
+        "repetition_penalty_strength": {
+          "type": "scalar"
+        },
+        "weight_decision_prior": {
+          "type": "scalar"
+        },
+        "weight_history_transition": {
+          "type": "scalar"
+        },
+        "weight_semantic": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HybridSelectionConfig": {
+      "type": "object",
+      "fields": {
+        "automix_weight": {
+          "type": "scalar"
+        },
+        "cost_weight": {
+          "type": "scalar"
+        },
+        "experience_weight": {
+          "type": "scalar"
+        },
+        "normalize_scores": {
+          "type": "scalar"
+        },
+        "quality_gap_threshold": {
+          "type": "scalar"
+        },
+        "router_dc_weight": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HybridWeightsConfig": {
+      "type": "object",
+      "fields": {
+        "logprob_weight": {
+          "type": "scalar"
+        },
+        "margin_weight": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.IdentityConfig": {
+      "type": "object",
+      "fields": {
+        "user_groups_header": {
+          "type": "scalar"
+        },
+        "user_id_header": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.JailbreakRule": {
+      "type": "object",
+      "fields": {
+        "benign_patterns": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "description": {
+          "type": "scalar"
+        },
+        "include_history": {
+          "type": "scalar"
+        },
+        "jailbreak_patterns": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "method": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KBSignalRule": {
+      "type": "object",
+      "fields": {
+        "kb": {
+          "type": "scalar"
+        },
+        "match": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "target": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KBSignalTarget"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KBSignalTarget": {
+      "type": "object",
+      "fields": {
+        "kind": {
+          "type": "scalar"
+        },
+        "value": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KeywordRule": {
+      "type": "object",
+      "fields": {
+        "bm25_threshold": {
+          "type": "scalar"
+        },
+        "case_sensitive": {
+          "type": "scalar"
+        },
+        "fuzzy_match": {
+          "type": "scalar"
+        },
+        "fuzzy_threshold": {
+          "type": "scalar"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "method": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "ngram_arity": {
+          "type": "scalar"
+        },
+        "ngram_threshold": {
+          "type": "scalar"
+        },
+        "operator": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KnowledgeBaseConfig": {
+      "type": "object",
+      "fields": {
+        "groups": {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "scalar"
+            }
+          }
+        },
+        "label_thresholds": {
+          "type": "map",
+          "values": {
+            "type": "scalar"
+          }
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KnowledgeBaseMetricConfig"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "prototype_scoring": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PrototypeScoringConfig"
+        },
+        "source": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KnowledgeBaseSource"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KnowledgeBaseMetricConfig": {
+      "type": "object",
+      "fields": {
+        "name": {
+          "type": "scalar"
+        },
+        "negative_group": {
+          "type": "scalar"
+        },
+        "positive_group": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.KnowledgeBaseSource": {
+      "type": "object",
+      "fields": {
+        "manifest": {
+          "type": "scalar"
+        },
+        "path": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LanguageRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LatencyAwareAlgorithmConfig": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "tpot_percentile": {
+          "type": "scalar"
+        },
+        "ttft_percentile": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Listener": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "timeout": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LlamaStackVectorStoreConfig": {
+      "type": "object",
+      "fields": {
+        "auth_token": {
+          "type": "scalar"
+        },
+        "embedding_model": {
+          "type": "scalar"
+        },
+        "endpoint": {
+          "type": "scalar"
+        },
+        "request_timeout_seconds": {
+          "type": "scalar"
+        },
+        "search_type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LoRAAdapter": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LooperConfig": {
+      "type": "object",
+      "fields": {
+        "endpoint": {
+          "type": "scalar"
+        },
+        "flow": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FlowRuntimeConfig"
+        },
+        "fusion": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.FusionRuntimeConfig"
+        },
+        "grpc_max_msg_size_mb": {
+          "type": "scalar"
+        },
+        "headers": {
+          "type": "map",
+          "values": {
+            "type": "scalar"
+          }
+        },
+        "max_response_bytes_mb": {
+          "type": "scalar"
+        },
+        "remom": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReMoMRuntimeConfig"
+        },
+        "retry_count": {
+          "type": "scalar"
+        },
+        "timeout_seconds": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MCPCategoryModel": {
+      "type": "object",
+      "fields": {
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "command": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "env": {
+          "type": "map",
+          "values": {
+            "type": "scalar"
+          }
+        },
+        "threshold": {
+          "type": "scalar"
+        },
+        "timeout_seconds": {
+          "type": "scalar"
+        },
+        "tool_name": {
+          "type": "scalar"
+        },
+        "transport_type": {
+          "type": "scalar"
+        },
+        "url": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLKMeansConfig": {
+      "type": "object",
+      "fields": {
+        "efficiency_weight": {
+          "type": "scalar"
+        },
+        "num_clusters": {
+          "type": "scalar"
+        },
+        "pretrained_path": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLKNNConfig": {
+      "type": "object",
+      "fields": {
+        "k": {
+          "type": "scalar"
+        },
+        "pretrained_path": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLMLPConfig": {
+      "type": "object",
+      "fields": {
+        "device": {
+          "type": "scalar"
+        },
+        "pretrained_path": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLSVMConfig": {
+      "type": "object",
+      "fields": {
+        "gamma": {
+          "type": "scalar"
+        },
+        "kernel": {
+          "type": "scalar"
+        },
+        "pretrained_path": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLSelectionConfig": {
+      "type": "object",
+      "fields": {
+        "embedding_dim": {
+          "type": "scalar"
+        },
+        "kmeans": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLKMeansConfig"
+        },
+        "knn": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLKNNConfig"
+        },
+        "mlp": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLMLPConfig"
+        },
+        "models_path": {
+          "type": "scalar"
+        },
+        "svm": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLSVMConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ManagementAPIAuthConfig": {
+      "type": "object",
+      "fields": {
+        "mode": {
+          "type": "scalar"
+        },
+        "roles": {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "scalar"
+            }
+          }
+        },
+        "tokens": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ManagementAPITokenRef"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ManagementAPIConfig": {
+      "type": "object",
+      "fields": {
+        "auth": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ManagementAPIAuthConfig"
+        },
+        "bind_address": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "remote_exposure": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ManagementAPITokenRef": {
+      "type": "object",
+      "fields": {
+        "env": {
+          "type": "scalar"
+        },
+        "role": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryConfig": {
+      "type": "object",
+      "fields": {
+        "adaptive_threshold": {
+          "type": "scalar"
+        },
+        "auto_store": {
+          "type": "scalar"
+        },
+        "backend": {
+          "type": "scalar"
+        },
+        "default_retrieval_limit": {
+          "type": "scalar"
+        },
+        "default_similarity_threshold": {
+          "type": "scalar"
+        },
+        "disabled_models": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "disabled_routes": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "embedding_model": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "extraction_batch_size": {
+          "type": "scalar"
+        },
+        "hybrid_mode": {
+          "type": "scalar"
+        },
+        "hybrid_search": {
+          "type": "scalar"
+        },
+        "milvus": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryMilvusConfig"
+        },
+        "qdrant": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryQdrantConfig"
+        },
+        "quality_scoring": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryQualityScoringConfig"
+        },
+        "redis_cache": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryRedisCacheConfig"
+        },
+        "reflection": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryReflectionConfig"
+        },
+        "valkey": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryValkeyConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryMilvusConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "collection": {
+          "type": "scalar"
+        },
+        "dimension": {
+          "type": "scalar"
+        },
+        "num_partitions": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryQdrantConfig": {
+      "type": "object",
+      "fields": {
+        "api_key": {
+          "type": "scalar"
+        },
+        "collection": {
+          "type": "scalar"
+        },
+        "connect_timeout": {
+          "type": "scalar"
+        },
+        "dimension": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "use_tls": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryQualityScoringConfig": {
+      "type": "object",
+      "fields": {
+        "initial_strength_days": {
+          "type": "scalar"
+        },
+        "max_memories_per_user": {
+          "type": "scalar"
+        },
+        "prune_threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryRedisCacheConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "db": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "key_prefix": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "ttl_seconds": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryReflectionConfig": {
+      "type": "object",
+      "fields": {
+        "algorithm": {
+          "type": "scalar"
+        },
+        "block_patterns": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "dedup_threshold": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "max_inject_tokens": {
+          "type": "scalar"
+        },
+        "recency_decay_days": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MemoryValkeyConfig": {
+      "type": "object",
+      "fields": {
+        "collection_prefix": {
+          "type": "scalar"
+        },
+        "database": {
+          "type": "scalar"
+        },
+        "dimension": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "index_ef_construction": {
+          "type": "scalar"
+        },
+        "index_m": {
+          "type": "scalar"
+        },
+        "index_name": {
+          "type": "scalar"
+        },
+        "metric_type": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "timeout": {
+          "type": "scalar"
+        },
+        "tls_ca_path": {
+          "type": "scalar"
+        },
+        "tls_enabled": {
+          "type": "scalar"
+        },
+        "tls_insecure_skip_verify": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MetricsConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "windowed_metrics": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WindowedMetricsConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MilvusConfig": {
+      "type": "object",
+      "fields": {
+        "collection": {
+          "type": "object",
+          "fields": {
+            "description": {
+              "type": "scalar"
+            },
+            "index": {
+              "type": "object",
+              "fields": {
+                "params": {
+                  "type": "object",
+                  "fields": {
+                    "M": {
+                      "type": "scalar"
+                    },
+                    "efConstruction": {
+                      "type": "scalar"
+                    }
+                  }
+                },
+                "type": {
+                  "type": "scalar"
+                }
+              }
+            },
+            "name": {
+              "type": "scalar"
+            },
+            "vector_field": {
+              "type": "object",
+              "fields": {
+                "dimension": {
+                  "type": "scalar"
+                },
+                "metric_type": {
+                  "type": "scalar"
+                },
+                "name": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "connection": {
+          "type": "object",
+          "fields": {
+            "auth": {
+              "type": "object",
+              "fields": {
+                "enabled": {
+                  "type": "scalar"
+                },
+                "password": {
+                  "type": "scalar"
+                },
+                "username": {
+                  "type": "scalar"
+                }
+              }
+            },
+            "database": {
+              "type": "scalar"
+            },
+            "host": {
+              "type": "scalar"
+            },
+            "port": {
+              "type": "scalar"
+            },
+            "timeout": {
+              "type": "scalar"
+            },
+            "tls": {
+              "type": "object",
+              "fields": {
+                "ca_file": {
+                  "type": "scalar"
+                },
+                "cert_file": {
+                  "type": "scalar"
+                },
+                "enabled": {
+                  "type": "scalar"
+                },
+                "key_file": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "data_management": {
+          "type": "object",
+          "fields": {
+            "compaction": {
+              "type": "object",
+              "fields": {
+                "enabled": {
+                  "type": "scalar"
+                },
+                "interval": {
+                  "type": "scalar"
+                }
+              }
+            },
+            "ttl": {
+              "type": "object",
+              "fields": {
+                "cleanup_interval": {
+                  "type": "scalar"
+                },
+                "enabled": {
+                  "type": "scalar"
+                },
+                "timestamp_field": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "development": {
+          "type": "object",
+          "fields": {
+            "auto_create_collection": {
+              "type": "scalar"
+            },
+            "drop_collection_on_startup": {
+              "type": "scalar"
+            },
+            "verbose_errors": {
+              "type": "scalar"
+            }
+          }
+        },
+        "logging": {
+          "type": "object",
+          "fields": {
+            "enable_metrics": {
+              "type": "scalar"
+            },
+            "enable_query_log": {
+              "type": "scalar"
+            },
+            "level": {
+              "type": "scalar"
+            }
+          }
+        },
+        "performance": {
+          "type": "object",
+          "fields": {
+            "batch": {
+              "type": "object",
+              "fields": {
+                "insert_batch_size": {
+                  "type": "scalar"
+                },
+                "timeout": {
+                  "type": "scalar"
+                }
+              }
+            },
+            "connection_pool": {
+              "type": "object",
+              "fields": {
+                "acquire_timeout": {
+                  "type": "scalar"
+                },
+                "max_connections": {
+                  "type": "scalar"
+                },
+                "max_idle_connections": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "search": {
+          "type": "object",
+          "fields": {
+            "consistency_level": {
+              "type": "scalar"
+            },
+            "params": {
+              "type": "object",
+              "fields": {
+                "ef": {
+                  "type": "scalar"
+                }
+              }
+            },
+            "topk": {
+              "type": "scalar"
+            }
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModalityClassifierConfig": {
+      "type": "object",
+      "fields": {
+        "model_path": {
+          "type": "scalar"
+        },
+        "use_cpu": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModalityDetectorConfig": {
+      "type": "object",
+      "fields": {
+        "both_keywords": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "classifier": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModalityClassifierConfig"
+        },
+        "confidence_threshold": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "lower_threshold_ratio": {
+          "type": "scalar"
+        },
+        "method": {
+          "type": "scalar"
+        },
+        "prompt_prefixes": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModalityRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelPricing": {
+      "type": "object",
+      "fields": {
+        "cache_write_per_1m": {
+          "type": "scalar"
+        },
+        "cached_input_per_1m": {
+          "type": "scalar"
+        },
+        "completion_per_1m": {
+          "type": "scalar"
+        },
+        "currency": {
+          "type": "scalar"
+        },
+        "prompt_per_1m": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelRef": {
+      "type": "object",
+      "fields": {
+        "lora_name": {
+          "type": "scalar"
+        },
+        "model": {
+          "type": "scalar"
+        },
+        "reasoning_description": {
+          "type": "scalar"
+        },
+        "reasoning_effort": {
+          "type": "scalar"
+        },
+        "use_reasoning": {
+          "type": "scalar"
+        },
+        "weight": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelScore": {
+      "type": "object",
+      "fields": {
+        "model": {
+          "type": "scalar"
+        },
+        "score": {
+          "type": "scalar"
+        },
+        "use_reasoning": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ModelSelectionConfig": {
+      "type": "object",
+      "fields": {
+        "automix": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AutoMixSelectionConfig"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "hybrid": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.HybridSelectionConfig"
+        },
+        "method": {
+          "type": "scalar"
+        },
+        "ml": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MLSelectionConfig"
+        },
+        "momentum": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MomentumSelectionConfig"
+        },
+        "router_dc": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterDCSelectionConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MomentumSelectionConfig": {
+      "type": "object",
+      "fields": {
+        "attack": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "release": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MultiFactorSLOConfig": {
+      "type": "object",
+      "fields": {
+        "max_cost_per_1m": {
+          "type": "scalar"
+        },
+        "max_inflight": {
+          "type": "scalar"
+        },
+        "max_tpot_ms": {
+          "type": "scalar"
+        },
+        "max_ttft_ms": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MultiFactorSelectionConfig": {
+      "type": "object",
+      "fields": {
+        "latency_percentile": {
+          "type": "scalar"
+        },
+        "on_no_candidates": {
+          "type": "scalar"
+        },
+        "slo": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MultiFactorSLOConfig"
+        },
+        "weights": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MultiFactorWeightsConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MultiFactorWeightsConfig": {
+      "type": "object",
+      "fields": {
+        "cost": {
+          "type": "scalar"
+        },
+        "latency": {
+          "type": "scalar"
+        },
+        "load": {
+          "type": "scalar"
+        },
+        "quality": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.NumericPredicate": {
+      "type": "object",
+      "fields": {
+        "gt": {
+          "type": "scalar"
+        },
+        "gte": {
+          "type": "scalar"
+        },
+        "lt": {
+          "type": "scalar"
+        },
+        "lte": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ObservabilityConfig": {
+      "type": "object",
+      "fields": {
+        "metrics": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MetricsConfig"
+        },
+        "tracing": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractChoiceSetSpec": {
+      "type": "object",
+      "fields": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractExtractSpec": {
+      "type": "object",
+      "fields": {
+        "mode": {
+          "type": "scalar"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractJSONSchemaSpec": {
+      "type": "object",
+      "fields": {
+        "schema_ref": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractNormalizeSpec": {
+      "type": "object",
+      "fields": {
+        "defaults": {
+          "type": "map",
+          "values": {
+            "type": "scalar"
+          }
+        },
+        "field_order": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractPostprocess": {
+      "type": "object",
+      "fields": {
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractReferenceSpec": {
+      "type": "object",
+      "fields": {
+        "id_format": {
+          "type": "scalar"
+        },
+        "source": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractRenderSpec": {
+      "type": "object",
+      "fields": {
+        "mode": {
+          "type": "scalar"
+        },
+        "template": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractSpec": {
+      "type": "object",
+      "fields": {
+        "choice_set": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractChoiceSetSpec"
+        },
+        "extract": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractExtractSpec"
+        },
+        "json_schema": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractJSONSchemaSpec"
+        },
+        "normalize": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractNormalizeSpec"
+        },
+        "on_violation": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractViolationPolicy"
+        },
+        "postprocess": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractPostprocess"
+          }
+        },
+        "reference": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractReferenceSpec"
+        },
+        "render": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractRenderSpec"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.OutputContractViolationPolicy": {
+      "type": "object",
+      "fields": {
+        "fallback": {
+          "type": "scalar"
+        },
+        "repair": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PIIRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "include_history": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "pii_types_allowed": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PreferenceModelConfig": {
+      "type": "object",
+      "fields": {
+        "embedding_model": {
+          "type": "scalar"
+        },
+        "prototype_scoring": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PrototypeScoringConfig"
+        },
+        "use_contrastive": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PreferenceRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionMapping": {
+      "type": "object",
+      "fields": {
+        "calibration": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionMappingCalibration"
+        },
+        "method": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionMappingOutput"
+          }
+        },
+        "source": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionMappingCalibration": {
+      "type": "object",
+      "fields": {
+        "method": {
+          "type": "scalar"
+        },
+        "slope": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionMappingOutput": {
+      "type": "object",
+      "fields": {
+        "gt": {
+          "type": "scalar"
+        },
+        "gte": {
+          "type": "scalar"
+        },
+        "lt": {
+          "type": "scalar"
+        },
+        "lte": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionPartition": {
+      "type": "object",
+      "fields": {
+        "default": {
+          "type": "scalar"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "semantics": {
+          "type": "scalar"
+        },
+        "temperature": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionScore": {
+      "type": "object",
+      "fields": {
+        "inputs": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionScoreInput"
+          }
+        },
+        "method": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ProjectionScoreInput": {
+      "type": "object",
+      "fields": {
+        "kb": {
+          "type": "scalar"
+        },
+        "match": {
+          "type": "scalar"
+        },
+        "metric": {
+          "type": "scalar"
+        },
+        "miss": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        },
+        "value_source": {
+          "type": "scalar"
+        },
+        "weight": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PromptCompressionConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "max_tokens": {
+          "type": "scalar"
+        },
+        "min_length": {
+          "type": "scalar"
+        },
+        "novelty_weight": {
+          "type": "scalar"
+        },
+        "position_depth": {
+          "type": "scalar"
+        },
+        "position_weight": {
+          "type": "scalar"
+        },
+        "preserve_first_n": {
+          "type": "scalar"
+        },
+        "preserve_last_n": {
+          "type": "scalar"
+        },
+        "profile": {
+          "type": "scalar"
+        },
+        "skip_signals": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "textrank_weight": {
+          "type": "scalar"
+        },
+        "tfidf_weight": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.PrototypeScoringConfig": {
+      "type": "object",
+      "fields": {
+        "best_weight": {
+          "type": "scalar"
+        },
+        "cluster_similarity_threshold": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "margin_threshold": {
+          "type": "scalar"
+        },
+        "max_prototypes": {
+          "type": "scalar"
+        },
+        "top_m": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.QdrantConfig": {
+      "type": "object",
+      "fields": {
+        "api_key": {
+          "type": "scalar"
+        },
+        "collection_name": {
+          "type": "scalar"
+        },
+        "connect_timeout": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "use_tls": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.QdrantVectorStoreConfig": {
+      "type": "object",
+      "fields": {
+        "api_key": {
+          "type": "scalar"
+        },
+        "collection_prefix": {
+          "type": "scalar"
+        },
+        "connect_timeout": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "use_tls": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitConfig": {
+      "type": "object",
+      "fields": {
+        "fail_open": {
+          "type": "scalar"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitProviderConfig"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitMatch": {
+      "type": "object",
+      "fields": {
+        "group": {
+          "type": "scalar"
+        },
+        "model": {
+          "type": "scalar"
+        },
+        "user": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitProviderConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "domain": {
+          "type": "scalar"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitRule"
+          }
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitRule": {
+      "type": "object",
+      "fields": {
+        "match": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RateLimitMatch"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "requests_per_unit": {
+          "type": "scalar"
+        },
+        "tokens_per_unit": {
+          "type": "scalar"
+        },
+        "unit": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RatingsAlgorithmConfig": {
+      "type": "object",
+      "fields": {
+        "max_concurrent": {
+          "type": "scalar"
+        },
+        "on_error": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReMoMAlgorithmConfig": {
+      "type": "object",
+      "fields": {
+        "breadth_schedule": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "compaction_strategy": {
+          "type": "scalar"
+        },
+        "compaction_tokens": {
+          "type": "scalar"
+        },
+        "include_intermediate_responses": {
+          "type": "scalar"
+        },
+        "include_reasoning": {
+          "type": "scalar"
+        },
+        "max_concurrent": {
+          "type": "scalar"
+        },
+        "max_responses_per_round": {
+          "type": "scalar"
+        },
+        "min_successful_responses": {
+          "type": "scalar"
+        },
+        "model_distribution": {
+          "type": "scalar"
+        },
+        "on_error": {
+          "type": "scalar"
+        },
+        "round_timeout_seconds": {
+          "type": "scalar"
+        },
+        "shuffle_seed": {
+          "type": "scalar"
+        },
+        "synthesis_model": {
+          "type": "scalar"
+        },
+        "synthesis_template": {
+          "type": "scalar"
+        },
+        "temperature": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReMoMRuntimeConfig": {
+      "type": "object",
+      "fields": {
+        "model_names": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReaskRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "lookback_turns": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "threshold": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ReasoningFamilyConfig": {
+      "type": "object",
+      "fields": {
+        "parameter": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RedisConfig": {
+      "type": "object",
+      "fields": {
+        "connection": {
+          "type": "object",
+          "fields": {
+            "database": {
+              "type": "scalar"
+            },
+            "host": {
+              "type": "scalar"
+            },
+            "password": {
+              "type": "scalar"
+            },
+            "port": {
+              "type": "scalar"
+            },
+            "timeout": {
+              "type": "scalar"
+            },
+            "tls": {
+              "type": "object",
+              "fields": {
+                "ca_file": {
+                  "type": "scalar"
+                },
+                "cert_file": {
+                  "type": "scalar"
+                },
+                "enabled": {
+                  "type": "scalar"
+                },
+                "key_file": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "development": {
+          "type": "object",
+          "fields": {
+            "auto_create_index": {
+              "type": "scalar"
+            },
+            "drop_index_on_startup": {
+              "type": "scalar"
+            },
+            "verbose_errors": {
+              "type": "scalar"
+            }
+          }
+        },
+        "index": {
+          "type": "object",
+          "fields": {
+            "index_type": {
+              "type": "scalar"
+            },
+            "name": {
+              "type": "scalar"
+            },
+            "params": {
+              "type": "object",
+              "fields": {
+                "M": {
+                  "type": "scalar"
+                },
+                "efConstruction": {
+                  "type": "scalar"
+                }
+              }
+            },
+            "prefix": {
+              "type": "scalar"
+            },
+            "vector_field": {
+              "type": "object",
+              "fields": {
+                "dimension": {
+                  "type": "scalar"
+                },
+                "metric_type": {
+                  "type": "scalar"
+                },
+                "name": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "logging": {
+          "type": "object",
+          "fields": {
+            "enable_metrics": {
+              "type": "scalar"
+            },
+            "enable_query_log": {
+              "type": "scalar"
+            },
+            "level": {
+              "type": "scalar"
+            }
+          }
+        },
+        "search": {
+          "type": "object",
+          "fields": {
+            "topk": {
+              "type": "scalar"
+            }
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ResponseAPIConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "max_responses": {
+          "type": "scalar"
+        },
+        "redis": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ResponseAPIRedisConfig"
+        },
+        "store_backend": {
+          "type": "scalar"
+        },
+        "ttl_seconds": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ResponseAPIRedisConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "cluster_addresses": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "cluster_mode": {
+          "type": "scalar"
+        },
+        "config_path": {
+          "type": "scalar"
+        },
+        "db": {
+          "type": "scalar"
+        },
+        "dial_timeout": {
+          "type": "scalar"
+        },
+        "key_prefix": {
+          "type": "scalar"
+        },
+        "max_retries": {
+          "type": "scalar"
+        },
+        "min_idle_conns": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "pool_size": {
+          "type": "scalar"
+        },
+        "read_timeout": {
+          "type": "scalar"
+        },
+        "tls_ca_path": {
+          "type": "scalar"
+        },
+        "tls_cert_path": {
+          "type": "scalar"
+        },
+        "tls_enabled": {
+          "type": "scalar"
+        },
+        "tls_key_path": {
+          "type": "scalar"
+        },
+        "write_timeout": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RetentionDirective": {
+      "type": "object",
+      "fields": {
+        "drop": {
+          "type": "scalar"
+        },
+        "keep_current_model": {
+          "type": "scalar"
+        },
+        "prefer_prefix_retention": {
+          "type": "scalar"
+        },
+        "ttl_turns": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RoleBinding": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "role": {
+          "type": "scalar"
+        },
+        "subjects": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Subject"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterDCSelectionConfig": {
+      "type": "object",
+      "fields": {
+        "dimension_size": {
+          "type": "scalar"
+        },
+        "min_similarity": {
+          "type": "scalar"
+        },
+        "require_descriptions": {
+          "type": "scalar"
+        },
+        "temperature": {
+          "type": "scalar"
+        },
+        "use_capabilities": {
+          "type": "scalar"
+        },
+        "use_model_contrastive": {
+          "type": "scalar"
+        },
+        "use_query_contrastive": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningAdaptationConfig": {
+      "type": "object",
+      "fields": {
+        "candidate_set": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "strategy": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningConfig": {
+      "type": "object",
+      "fields": {
+        "adaptation": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningAdaptationConfig"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "protection": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningProtectionConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningIdentityConfig": {
+      "type": "object",
+      "fields": {
+        "headers": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningIdentityHeadersConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningIdentityHeadersConfig": {
+      "type": "object",
+      "fields": {
+        "conversation": {
+          "type": "scalar"
+        },
+        "session": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningProtectionConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "identity": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningIdentityConfig"
+        },
+        "scope": {
+          "type": "scalar"
+        },
+        "tuning": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningProtectionTuning"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterLearningProtectionTuning": {
+      "type": "object",
+      "fields": {
+        "idle_timeout_seconds": {
+          "type": "scalar"
+        },
+        "min_turns_before_switch": {
+          "type": "scalar"
+        },
+        "stability_weight": {
+          "type": "scalar"
+        },
+        "switch_margin": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayConfig": {
+      "type": "object",
+      "fields": {
+        "async_writes": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "milvus": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayMilvusConfig"
+        },
+        "postgres": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayPostgresConfig"
+        },
+        "qdrant": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayQdrantConfig"
+        },
+        "redis": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayRedisConfig"
+        },
+        "store_backend": {
+          "type": "scalar"
+        },
+        "ttl_seconds": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayMilvusConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "collection_name": {
+          "type": "scalar"
+        },
+        "consistency_level": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "shard_num": {
+          "type": "scalar"
+        },
+        "username": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayPostgresConfig": {
+      "type": "object",
+      "fields": {
+        "conn_max_lifetime": {
+          "type": "scalar"
+        },
+        "database": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "max_idle_conns": {
+          "type": "scalar"
+        },
+        "max_open_conns": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "ssl_mode": {
+          "type": "scalar"
+        },
+        "table_name": {
+          "type": "scalar"
+        },
+        "user": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayQdrantConfig": {
+      "type": "object",
+      "fields": {
+        "api_key": {
+          "type": "scalar"
+        },
+        "collection_name": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "use_tls": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RouterReplayRedisConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "db": {
+          "type": "scalar"
+        },
+        "key_prefix": {
+          "type": "scalar"
+        },
+        "max_retries": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "pool_size": {
+          "type": "scalar"
+        },
+        "tls_skip_verify": {
+          "type": "scalar"
+        },
+        "use_tls": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RoutingModel": {
+      "type": "object",
+      "fields": {
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "context_window_size": {
+          "type": "scalar"
+        },
+        "description": {
+          "type": "scalar"
+        },
+        "loras": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LoRAAdapter"
+          }
+        },
+        "modality": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "param_size": {
+          "type": "scalar"
+        },
+        "quality_score": {
+          "type": "scalar"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RuleNode": {
+      "type": "object",
+      "fields": {
+        "conditions": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RuleNode"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "operator": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.SemanticCache": {
+      "type": "object",
+      "fields": {
+        "backend_type": {
+          "type": "scalar"
+        },
+        "embedding_model": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "eviction_policy": {
+          "type": "scalar"
+        },
+        "max_entries": {
+          "type": "scalar"
+        },
+        "milvus": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MilvusConfig"
+        },
+        "qdrant": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.QdrantConfig"
+        },
+        "redis": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.RedisConfig"
+        },
+        "similarity_threshold": {
+          "type": "scalar"
+        },
+        "ttl_seconds": {
+          "type": "scalar"
+        },
+        "valkey": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ValkeyConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.SkipProcessingConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StartupStatusConfig": {
+      "type": "object",
+      "fields": {
+        "redis": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StartupStatusRedisConfig"
+        },
+        "store_backend": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StartupStatusRedisConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "db": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructureFeature": {
+      "type": "object",
+      "fields": {
+        "source": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructureSource"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructureRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "feature": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructureFeature"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "predicate": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.NumericPredicate"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructureSource": {
+      "type": "object",
+      "fields": {
+        "case_sensitive": {
+          "type": "scalar"
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "pattern": {
+          "type": "scalar"
+        },
+        "sequences": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "scalar"
+            }
+          }
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.StructuredPayload": {
+      "type": "object",
+      "opaque": true
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.Subject": {
+      "type": "object",
+      "fields": {
+        "kind": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ToolFilteringWeights": {
+      "type": "object",
+      "fields": {
+        "category": {
+          "type": "scalar"
+        },
+        "embed": {
+          "type": "scalar"
+        },
+        "lexical": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "tag": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ToolsConfig": {
+      "type": "object",
+      "fields": {
+        "advanced_filtering": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.AdvancedToolFilteringConfig"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "fallback_to_empty": {
+          "type": "scalar"
+        },
+        "similarity_threshold": {
+          "type": "scalar"
+        },
+        "tools_db_path": {
+          "type": "scalar"
+        },
+        "top_k": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "exporter": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingExporterConfig"
+        },
+        "provider": {
+          "type": "scalar"
+        },
+        "resource": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingResourceConfig"
+        },
+        "sampling": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingSamplingConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingExporterConfig": {
+      "type": "object",
+      "fields": {
+        "endpoint": {
+          "type": "scalar"
+        },
+        "insecure": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingResourceConfig": {
+      "type": "object",
+      "fields": {
+        "deployment_environment": {
+          "type": "scalar"
+        },
+        "service_name": {
+          "type": "scalar"
+        },
+        "service_version": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.TracingSamplingConfig": {
+      "type": "object",
+      "fields": {
+        "rate": {
+          "type": "scalar"
+        },
+        "type": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.UserFeedbackRule": {
+      "type": "object",
+      "fields": {
+        "description": {
+          "type": "scalar"
+        },
+        "name": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ValkeyConfig": {
+      "type": "object",
+      "fields": {
+        "connection": {
+          "type": "object",
+          "fields": {
+            "database": {
+              "type": "scalar"
+            },
+            "host": {
+              "type": "scalar"
+            },
+            "password": {
+              "type": "scalar"
+            },
+            "port": {
+              "type": "scalar"
+            },
+            "timeout": {
+              "type": "scalar"
+            },
+            "tls": {
+              "type": "object",
+              "fields": {
+                "ca_file": {
+                  "type": "scalar"
+                },
+                "cert_file": {
+                  "type": "scalar"
+                },
+                "enabled": {
+                  "type": "scalar"
+                },
+                "key_file": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "development": {
+          "type": "object",
+          "fields": {
+            "auto_create_index": {
+              "type": "scalar"
+            },
+            "drop_index_on_startup": {
+              "type": "scalar"
+            },
+            "verbose_errors": {
+              "type": "scalar"
+            }
+          }
+        },
+        "index": {
+          "type": "object",
+          "fields": {
+            "index_type": {
+              "type": "scalar"
+            },
+            "name": {
+              "type": "scalar"
+            },
+            "params": {
+              "type": "object",
+              "fields": {
+                "M": {
+                  "type": "scalar"
+                },
+                "efConstruction": {
+                  "type": "scalar"
+                }
+              }
+            },
+            "prefix": {
+              "type": "scalar"
+            },
+            "vector_field": {
+              "type": "object",
+              "fields": {
+                "dimension": {
+                  "type": "scalar"
+                },
+                "metric_type": {
+                  "type": "scalar"
+                },
+                "name": {
+                  "type": "scalar"
+                }
+              }
+            }
+          }
+        },
+        "logging": {
+          "type": "object",
+          "fields": {
+            "enable_metrics": {
+              "type": "scalar"
+            },
+            "enable_query_log": {
+              "type": "scalar"
+            },
+            "level": {
+              "type": "scalar"
+            }
+          }
+        },
+        "search": {
+          "type": "object",
+          "fields": {
+            "topk": {
+              "type": "scalar"
+            }
+          }
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ValkeyVectorStoreConfig": {
+      "type": "object",
+      "fields": {
+        "collection_prefix": {
+          "type": "scalar"
+        },
+        "connect_timeout": {
+          "type": "scalar"
+        },
+        "database": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "index_ef_construction": {
+          "type": "scalar"
+        },
+        "index_m": {
+          "type": "scalar"
+        },
+        "metric_type": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.VectorStoreConfig": {
+      "type": "object",
+      "fields": {
+        "backend_type": {
+          "type": "scalar"
+        },
+        "embedding_dimension": {
+          "type": "scalar"
+        },
+        "embedding_model": {
+          "type": "scalar"
+        },
+        "enabled": {
+          "type": "scalar"
+        },
+        "file_storage_dir": {
+          "type": "scalar"
+        },
+        "ingestion_drain_timeout_seconds": {
+          "type": "scalar"
+        },
+        "ingestion_workers": {
+          "type": "scalar"
+        },
+        "llama_stack": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.LlamaStackVectorStoreConfig"
+        },
+        "max_file_size_mb": {
+          "type": "scalar"
+        },
+        "memory": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.VectorStoreMemoryConfig"
+        },
+        "metadata_postgres": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.VectorStoreMetadataPostgresConfig"
+        },
+        "metadata_store": {
+          "type": "scalar"
+        },
+        "milvus": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.MilvusConfig"
+        },
+        "qdrant": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.QdrantVectorStoreConfig"
+        },
+        "supported_formats": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "valkey": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.ValkeyVectorStoreConfig"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.VectorStoreMemoryConfig": {
+      "type": "object",
+      "fields": {
+        "max_entries_per_store": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.VectorStoreMetadataPostgresConfig": {
+      "type": "object",
+      "fields": {
+        "conn_max_lifetime": {
+          "type": "scalar"
+        },
+        "database": {
+          "type": "scalar"
+        },
+        "host": {
+          "type": "scalar"
+        },
+        "max_idle_conns": {
+          "type": "scalar"
+        },
+        "max_open_conns": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "port": {
+          "type": "scalar"
+        },
+        "ssl_mode": {
+          "type": "scalar"
+        },
+        "table_name": {
+          "type": "scalar"
+        },
+        "user": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WindowedMetricsConfig": {
+      "type": "object",
+      "fields": {
+        "enabled": {
+          "type": "scalar"
+        },
+        "max_models": {
+          "type": "scalar"
+        },
+        "model_metrics": {
+          "type": "scalar"
+        },
+        "queue_depth_estimation": {
+          "type": "scalar"
+        },
+        "time_windows": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "update_interval": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowFinalConfig": {
+      "type": "object",
+      "fields": {
+        "model": {
+          "type": "scalar"
+        },
+        "prompt": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowPlannerConfig": {
+      "type": "object",
+      "fields": {
+        "max_completion_tokens": {
+          "type": "scalar"
+        },
+        "model": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowRoleConfig": {
+      "type": "object",
+      "fields": {
+        "access_list": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "scalar"
+          }
+        },
+        "name": {
+          "type": "scalar"
+        },
+        "prompt": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowStateFileConfig": {
+      "type": "object",
+      "fields": {
+        "directory": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowStateRedisConfig": {
+      "type": "object",
+      "fields": {
+        "address": {
+          "type": "scalar"
+        },
+        "db": {
+          "type": "scalar"
+        },
+        "key_prefix": {
+          "type": "scalar"
+        },
+        "max_retries": {
+          "type": "scalar"
+        },
+        "password": {
+          "type": "scalar"
+        },
+        "pool_size": {
+          "type": "scalar"
+        },
+        "tls_skip_verify": {
+          "type": "scalar"
+        },
+        "use_tls": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowStateRuntimeConfig": {
+      "type": "object",
+      "fields": {
+        "file": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowStateFileConfig"
+        },
+        "redis": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowStateRedisConfig"
+        },
+        "store_backend": {
+          "type": "scalar"
+        },
+        "ttl_seconds": {
+          "type": "scalar"
+        }
+      }
+    },
+    "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowsAlgorithmConfig": {
+      "type": "object",
+      "fields": {
+        "final": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowFinalConfig"
+        },
+        "include_intermediate_responses": {
+          "type": "scalar"
+        },
+        "max_completion_tokens": {
+          "type": "scalar"
+        },
+        "max_parallel": {
+          "type": "scalar"
+        },
+        "max_steps": {
+          "type": "scalar"
+        },
+        "min_successful_responses": {
+          "type": "scalar"
+        },
+        "mode": {
+          "type": "scalar"
+        },
+        "on_error": {
+          "type": "scalar"
+        },
+        "planner": {
+          "type": "",
+          "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowPlannerConfig"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "",
+            "ref": "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config.WorkflowRoleConfig"
+          }
+        },
+        "round_timeout_seconds": {
+          "type": "scalar"
+        },
+        "temperature": {
+          "type": "scalar"
+        },
+        "template": {
+          "type": "scalar"
+        }
+      }
+    }
+  }
+}

--- a/src/vllm-sr/cli/validator.py
+++ b/src/vllm-sr/cli/validator.py
@@ -9,20 +9,7 @@ from cli.config_contract import (
 )
 from cli.models import (
     UserConfig,
-    PluginType,
-    SemanticCachePluginConfig,
-    FastResponsePluginConfig,
-    RequestParamsPluginConfig,
-    ResponseJailbreakPluginConfig,
-    ToolsPluginConfig,
-    ToolSelectionPluginConfig,
-    SystemPromptPluginConfig,
-    HeaderMutationPluginConfig,
-    HallucinationPluginConfig,
-    RouterReplayPluginConfig,
-    MemoryPluginConfig,
-    RAGPluginConfig,
-    ImageGenPluginConfig,
+    plugin_configuration_models,
 )
 from pydantic import ValidationError as PydanticValidationError
 from cli.utils import get_logger
@@ -505,22 +492,7 @@ def validate_plugin_configurations(config: UserConfig) -> List[ValidationError]:
     """
     errors = []
 
-    # Map plugin types to their configuration models
-    config_models = {
-        PluginType.SEMANTIC_CACHE.value: SemanticCachePluginConfig,
-        PluginType.FAST_RESPONSE.value: FastResponsePluginConfig,
-        PluginType.REQUEST_PARAMS.value: RequestParamsPluginConfig,
-        PluginType.RESPONSE_JAILBREAK.value: ResponseJailbreakPluginConfig,
-        PluginType.SYSTEM_PROMPT.value: SystemPromptPluginConfig,
-        PluginType.HEADER_MUTATION.value: HeaderMutationPluginConfig,
-        PluginType.HALLUCINATION.value: HallucinationPluginConfig,
-        PluginType.ROUTER_REPLAY.value: RouterReplayPluginConfig,
-        PluginType.MEMORY.value: MemoryPluginConfig,
-        PluginType.RAG.value: RAGPluginConfig,
-        PluginType.IMAGE_GEN.value: ImageGenPluginConfig,
-        PluginType.TOOLS.value: ToolsPluginConfig,
-        PluginType.TOOL_SELECTION.value: ToolSelectionPluginConfig,
-    }
+    config_models = plugin_configuration_models()
 
     for decision in config.decisions:
         if not decision.plugins:

--- a/src/vllm-sr/tests/test_config_contract.py
+++ b/src/vllm-sr/tests/test_config_contract.py
@@ -1,10 +1,64 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
 from cli.config_contract import (
+    CANONICAL_VERSION,
     LEGACY_SIGNAL_KEY_TO_CANONICAL,
     build_projection_reference_index,
     build_signal_reference_index,
     signal_reference_exists,
 )
-from cli.models import Decision, Projections, Signals
+from cli.config_migration import migrate_config_data
+from cli.models import Decision, Projections, Signals, UserConfig
+from cli.parser import ConfigParseError, parse_user_config
+
+CONTRACT_CORPUS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "semantic-router"
+    / "pkg"
+    / "config"
+    / "testdata"
+    / "canonical_contract_cases.json"
+)
+
+
+def load_contract_corpus() -> dict:
+    return json.loads(CONTRACT_CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+def test_cli_executes_canonical_contract_golden_corpus(tmp_path: Path):
+    corpus = load_contract_corpus()
+    assert corpus["supported_version"] == CANONICAL_VERSION
+
+    for case in corpus["steady_state"]:
+        config_path = tmp_path / f"{case['name']}.yaml"
+        config_path.write_text(case["input"], encoding="utf-8")
+        if not case["valid"]:
+            with pytest.raises(ConfigParseError) as exc:
+                parse_user_config(str(config_path))
+            assert case["error"] in str(exc.value)
+            continue
+
+        parsed = parse_user_config(str(config_path))
+        assert parsed.version == case["normalized_version"]
+
+
+def test_cli_executes_canonical_migration_golden_corpus():
+    corpus = load_contract_corpus()
+
+    for case in corpus["migrations"]:
+        assert migrate_config_data(case["input"]) == case["normalized"], case["name"]
+
+
+def test_cli_accepts_exhaustive_router_reference_config():
+    config_path = Path(__file__).resolve().parents[3] / "config" / "config.yaml"
+
+    parsed = parse_user_config(str(config_path))
+
+    assert parsed.version == CANONICAL_VERSION
+    assert parsed.routing.decisions
 
 
 def test_legacy_signal_inventory_covers_flat_authz_and_context_blocks():
@@ -119,3 +173,123 @@ def test_decision_accepts_terminal_action_output_contract_spec():
     assert decision.output_contract_spec is not None
     assert decision.output_contract_spec.json_schema is not None
     assert decision.output_contract_spec.json_schema.schema_ref == "terminal_action_v1"
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        (None, "version: required"),
+        ("", "version: must not be empty"),
+        (3, "version: must be a string"),
+        ("v0.1", "unsupported config version"),
+        ("v99.0", "unsupported config version"),
+    ],
+)
+def test_parser_enforces_canonical_version_before_interpretation(
+    tmp_path: Path, version, expected: str
+):
+    config = {"routing": {"unknown_before_interpretation": True}}
+    if version is not None:
+        config["version"] = version
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    with pytest.raises(ConfigParseError, match=expected):
+        parse_user_config(str(path))
+
+
+def test_nested_unknown_field_has_stable_indexed_path(tmp_path: Path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": CANONICAL_VERSION,
+                "routing": {
+                    "modelCards": [
+                        {"name": "demo", "descriptino": "silently-dropped-before"}
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigParseError) as exc_info:
+        parse_user_config(str(path))
+
+    assert "routing.modelCards[0].descriptino" in str(exc_info.value)
+    assert 'did you mean "description"' in str(exc_info.value)
+
+
+def test_plugin_owner_rejects_unknown_backend_field():
+    with pytest.raises(ValueError):
+        UserConfig.model_validate(
+            {
+                "version": CANONICAL_VERSION,
+                "routing": {
+                    "decisions": [
+                        {
+                            "name": "docs",
+                            "description": "docs",
+                            "priority": 1,
+                            "rules": {"operator": "AND", "conditions": []},
+                            "modelRefs": [],
+                            "plugins": [
+                                {
+                                    "type": "rag",
+                                    "configuration": {
+                                        "enabled": True,
+                                        "backend": "mcp",
+                                        "backend_config": {
+                                            "server_nam": "docs",
+                                            "tool_name": "search",
+                                        },
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        )
+
+
+def test_plugin_named_extension_allows_arbitrary_tool_arguments():
+    config = UserConfig.model_validate(
+        {
+            "version": CANONICAL_VERSION,
+            "routing": {
+                "decisions": [
+                    {
+                        "name": "docs",
+                        "description": "docs",
+                        "priority": 1,
+                        "rules": {"operator": "AND", "conditions": []},
+                        "modelRefs": [],
+                        "plugins": [
+                            {
+                                "type": "rag",
+                                "configuration": {
+                                    "enabled": True,
+                                    "backend": "mcp",
+                                    "backend_config": {
+                                        "server_name": "docs",
+                                        "tool_name": "search",
+                                        "tool_arguments": {
+                                            "custom_filter": {"nested": True}
+                                        },
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+    )
+
+    assert (
+        config.decisions[0]
+        .plugins[0]
+        .configuration["backend_config"]["tool_arguments"]["custom_filter"]["nested"]
+    )

--- a/src/vllm-sr/tests/test_config_file_loaders.py
+++ b/src/vllm-sr/tests/test_config_file_loaders.py
@@ -335,7 +335,7 @@ def test_parse_user_config_rejects_unknown_global_learning_fields(
     with pytest.raises(ConfigParseError) as exc:
         parse_user_config(str(config_path))
 
-    assert "Unsupported Router Learning config fields" in str(exc.value)
+    assert "unsupported config fields" in str(exc.value)
     assert expected_path in str(exc.value)
 
 
@@ -413,7 +413,7 @@ def test_parse_user_config_rejects_unknown_pricing_fields(tmp_path: Path) -> Non
         parse_user_config(str(config_path))
 
     assert "cached_input" in str(exc.value)
-    assert "Extra inputs are not permitted" in str(exc.value)
+    assert "unsupported config fields" in str(exc.value)
 
 
 def test_parse_user_config_rejects_removed_session_aware_algorithm(
@@ -431,8 +431,8 @@ def test_parse_user_config_rejects_removed_session_aware_algorithm(
     with pytest.raises(ConfigParseError) as exc:
         parse_user_config(str(config_path))
 
-    assert "Removed Router Learning config fields" in str(exc.value)
-    assert "global.router.learning.protection" in str(exc.value)
+    assert "unsupported config fields" in str(exc.value)
+    assert "routing.decisions[0].algorithm.session_aware" in str(exc.value)
 
 
 @pytest.mark.parametrize(

--- a/src/vllm-sr/tests/test_config_migrate.py
+++ b/src/vllm-sr/tests/test_config_migrate.py
@@ -96,6 +96,24 @@ def test_migrate_config_data_splits_legacy_provider_models():
     assert migrated["global"]["stores"]["memory"]["enabled"] is True
 
 
+def test_migrate_config_data_preserves_canonical_entrypoints_and_recipes():
+    source = {
+        "version": "v0.3",
+        "entrypoints": [{"model_names": ["auto"], "recipe": "balanced"}],
+        "recipes": [
+            {
+                "name": "balanced",
+                "routing": {"signals": {}, "projections": {}, "decisions": []},
+            }
+        ],
+    }
+
+    migrated = migrate_config_data(source)
+
+    assert migrated["entrypoints"] == source["entrypoints"]
+    assert migrated["recipes"] == source["recipes"]
+
+
 def test_cli_config_migrate_writes_canonical_yaml(tmp_path: Path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(

--- a/src/vllm-sr/tests/test_config_template.py
+++ b/src/vllm-sr/tests/test_config_template.py
@@ -10,6 +10,7 @@ CLI_ROOT = Path(__file__).resolve().parents[1]
 if str(CLI_ROOT) not in sys.path:
     sys.path.insert(0, str(CLI_ROOT))
 
+from cli.config_contract import CANONICAL_VERSION
 from cli.parser import parse_user_config
 from cli.validator import validate_user_config
 
@@ -21,7 +22,7 @@ class TestConfigTemplate(unittest.TestCase):
         with open(TEMPLATE_PATH, "r") as f:
             data = yaml.safe_load(f)
 
-        self.assertEqual(data["version"], "v0.3")
+        self.assertEqual(data["version"], CANONICAL_VERSION)
         self.assertEqual(len(data["listeners"]), 1)
         self.assertEqual(
             data["providers"]["defaults"]["default_model"],

--- a/src/vllm-sr/tests/test_plugin_parsing.py
+++ b/src/vllm-sr/tests/test_plugin_parsing.py
@@ -14,7 +14,7 @@ from cli.models import (
     ToolSelectionPluginConfig,
 )
 from cli.config_migration import migrate_config_data
-from cli.parser import parse_user_config
+from cli.parser import ConfigParseError, parse_user_config
 from cli.validator import validate_user_config
 
 
@@ -73,10 +73,7 @@ class TestPluginTypeValidation:
             PluginType.TOOL_SELECTION.value,
         ]
 
-        for plugin_type in valid_types:
-            plugin = PluginConfig(type=plugin_type, configuration={"enabled": True})
-            # plugin.type is now a PluginType enum, compare to enum value
-            assert plugin.type.value == plugin_type
+        assert {plugin_type.value for plugin_type in PluginType} == set(valid_types)
 
     def test_invalid_plugin_type(self):
         """Test that invalid plugin types are rejected."""
@@ -291,12 +288,8 @@ providers:
         temp_path = _write_config(config_yaml)
 
         try:
-            config = parse_user_config(temp_path)
-            errors = validate_user_config(config)
-            assert len(errors) > 0
-            # Check that error mentions router_replay
-            error_messages = [str(e) for e in errors]
-            assert any("router_replay" in msg.lower() for msg in error_messages)
+            with pytest.raises(ConfigParseError, match="max_records"):
+                parse_user_config(temp_path)
         finally:
             os.unlink(temp_path)
 
@@ -345,12 +338,8 @@ providers:
         temp_path = _write_config(config_yaml)
 
         try:
-            config = parse_user_config(temp_path)
-            errors = validate_user_config(config)
-            assert len(errors) > 0
-            # Check that error mentions semantic-cache
-            error_messages = [str(e) for e in errors]
-            assert any("semantic-cache" in msg.lower() for msg in error_messages)
+            with pytest.raises(ConfigParseError, match="similarity_threshold"):
+                parse_user_config(temp_path)
         finally:
             os.unlink(temp_path)
 
@@ -389,18 +378,8 @@ providers:
         temp_path = _write_config(config_yaml)
 
         try:
-            config = parse_user_config(temp_path)
-            errors = validate_user_config(config)
-            # SemanticCachePluginConfig requires 'enabled' field, so validation should fail
-            assert isinstance(errors, list)
-            assert (
-                len(errors) > 0
-            ), "Expected validation errors for missing required field"
-            # Check that the error mentions the missing field
-            error_messages = [str(e) for e in errors]
-            assert any(
-                "enabled" in msg.lower() for msg in error_messages
-            ), f"Expected error about missing 'enabled' field, got: {error_messages}"
+            with pytest.raises(ConfigParseError, match="enabled"):
+                parse_user_config(temp_path)
         finally:
             os.unlink(temp_path)
 
@@ -614,11 +593,8 @@ providers:
         temp_path = _write_config(config_yaml)
 
         try:
-            config = parse_user_config(temp_path)
-            errors = validate_user_config(config)
-            assert len(errors) > 0
-            error_messages = [str(e) for e in errors]
-            assert any("rag" in msg.lower() for msg in error_messages)
+            with pytest.raises(ConfigParseError, match="similarity_threshold"):
+                parse_user_config(temp_path)
         finally:
             os.unlink(temp_path)
 

--- a/src/vllm-sr/tests/test_plugin_tool_selection.py
+++ b/src/vllm-sr/tests/test_plugin_tool_selection.py
@@ -7,7 +7,7 @@ import pytest
 import yaml
 from cli.config_migration import migrate_config_data
 from cli.models import ToolSelectionPluginConfig
-from cli.parser import parse_user_config
+from cli.parser import ConfigParseError, parse_user_config
 from cli.validator import validate_user_config
 from pydantic import ValidationError as PydanticValidationError
 
@@ -219,11 +219,9 @@ providers:
         temp_path = _write_config(config_yaml)
 
         try:
-            config = parse_user_config(temp_path)
-            errors = validate_user_config(config)
-            assert len(errors) > 0
-            error_messages = [str(e) for e in errors]
-            assert any("tool_selection" in msg.lower() for msg in error_messages)
+            with pytest.raises(ConfigParseError) as exc:
+                parse_user_config(temp_path)
+            assert "routing -> decisions -> 0 -> plugins -> 0 -> mode" in str(exc.value)
         finally:
             os.unlink(temp_path)
 

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -27,6 +27,18 @@ The detailed background is in [Unified Config Contract v0.3](../proposals/unifie
 - `recipes`: optional named routing profiles beside the default `routing` profile.
 - `global`: sparse runtime overrides. If you omit a field here, the router's built-in default is used.
 
+The steady-state loader requires an explicit supported `version` before it
+interprets any other field. Missing, non-string, empty, older, and future
+versions are rejected. Older layouts are accepted only by the explicit
+`vllm-sr config migrate` workflow.
+
+Canonical objects are closed across the router, CLI, dashboard, DSL, and
+Kubernetes producers. A misspelled or unsupported field is rejected with a
+stable dotted path such as `routing.modelCards[0].descriptino`. Schemaless
+content is limited to documented extension leaves; for example, the RAG MCP
+backend owns `tool_arguments`, while the rest of the plugin and backend payload
+remains strictly validated.
+
 ## Ownership by section
 
 - `routing` is the DSL-owned surface.

--- a/website/docs/proposals/unified-config-contract-v0-3.md
+++ b/website/docs/proposals/unified-config-contract-v0-3.md
@@ -141,7 +141,15 @@ Remote onboarding import can fetch and apply a full canonical YAML file. That ke
 
 DSL import still accepts a full router config YAML, but it decompiles only the `routing` section into DSL. Static deployment and global runtime settings stay in YAML.
 
-The router parser itself now accepts only canonical v0.3 YAML for steady-state runtime config. Legacy mixed layouts must go through explicit migration first.
+The router parser itself now accepts only canonical v0.3 YAML for steady-state runtime config. It checks the required version before interpretation and rejects missing, malformed, older, and future versions. Legacy mixed layouts must go through explicit migration first.
+
+Canonical objects are closed at every maintained boundary. Unknown fields fail
+with stable dotted/indexed paths instead of being dropped during typed decoding.
+Schemaless objects exist only at named extension leaves, such as MCP
+`tool_arguments` and OpenAI retrieval `filter`; the plugin discriminator owns
+validation of the enclosing payload. A shared cross-language corpus keeps
+router, CLI, dashboard, DSL, dynamic CRD, and operator acceptance and normalized
+version output aligned.
 
 The remaining in-process CRD reconciliation path now also re-enters the same canonical parser through `global.router.config_source: kubernetes`, instead of maintaining a separate steady-state runtime layout.
 

--- a/website/docs/tutorials/plugin/rag.md
+++ b/website/docs/tutorials/plugin/rag.md
@@ -26,6 +26,11 @@ Some routes need external document retrieval before answering, while most do not
 
 Use this fragment under `routing.decisions[].plugins`:
 
+The `rag` discriminator selects and strictly validates the matching
+`backend_config` schema. Unknown plugin or backend fields are rejected. Only
+documented backend-owned leaves remain schemaless: MCP `tool_arguments` and
+OpenAI `filter`.
+
 **Milvus backend:**
 
 ```yaml


### PR DESCRIPTION
## Summary

- centralize canonical `v0.3` ownership in the Go config package and reuse it from router export, DSL, Kubernetes conversion, operator output, CLI, and dashboard code
- reject missing, malformed, unsupported, and future versions before interpreting canonical config
- replace warning-only nested field handling with strict, stable-path diagnostics, including discriminator-owned plugin and backend payload validation
- generate the CLI's language-neutral canonical schema from Go types and verify that the checked-in artifact stays current
- preserve explicit `v0.1` migration behavior, including `entrypoints` and `recipes`
- run one shared golden corpus through the Go loader, CLI, dashboard, DSL, dynamic CRDs, and operator output paths
- update maintained configs and documentation to match the enforced contract

Closes #2469.

## Root cause

Canonical config version values were not validated before typed decoding, while exports and several producers independently stamped `v0.3`. Nested unknown fields were only warned about, and discriminator-owned payloads were decoded permissively. This allowed invalid input to be silently normalized or dropped and let different entrypoints enforce different subsets of the contract.

## Reproduction

The same focused inputs were run at `origin/main` (`8a8712a8`) and on this branch.

### Before

```text
missing_version: ACCEPT normalized=v0.3
old_version: ACCEPT normalized=v0.3
future_version: ACCEPT normalized=v0.3
nested_typo: ACCEPT normalized=v0.3
plugin_backend_typo: REJECT decision 'docs': RAG plugin: MCP server name is required
```

### After

```text
missing_version: REJECT version: required; supported versions: v0.3
old_version: REJECT version: unsupported config version "v0.1"; supported versions: v0.3
future_version: REJECT version: unsupported config version "v99.0"; supported versions: v0.3
nested_typo: REJECT unsupported config fields: routing.modelCards[0].descriptino (did you mean "description"?)
plugin_backend_typo: REJECT unsupported config fields: routing.decisions[docs].plugins[0].configuration.backend_config.server_nam (did you mean "server_name"?)
```

## Validation

- `make agent-ci-gate CHANGED_FILES="..."` — passed
- focused Go config, DSL, dynamic CRD, dashboard, and operator suites — passed
- dashboard frontend type check, lint, and 276 unit tests — passed
- Python suite — 460 passed; four unrelated Dockerfile expectation failures were reproduced unchanged on `origin/main`
- `make agent-feature-gate ENV=cpu CHANGED_FILES="..."` — its CI portion passed; the container integration/local smoke portion could not start because the configured Docker socket was unavailable
