### PR TITLE
[Bug] Merge email-keyed leaderboard entries into matching contributors

### DIFF
--- a/website/scripts/generate-contributor-rank.mjs
+++ b/website/scripts/generate-contributor-rank.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { findUnresolvedIdentities } from './lib/identity-audit.mjs'
+import { mergeEmailKeyedContributors } from './lib/identity-merge.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, '..', '..')
@@ -636,15 +637,29 @@ function collectContributorStats(rows) {
       commits: 0,
       firstCommitDate: row.date,
       latestCommitDate: row.date,
+      emails: new Set(),
+      names: new Set(),
     }
 
     current.commits += 1
     current.firstCommitDate = minDate(current.firstCommitDate, row.date)
     current.latestCommitDate = maxDate(current.latestCommitDate, row.date)
+
+    const normalizedEmail = normalizeEmail(row.email)
+    const normalizedName = normalizeName(row.name)
+
+    if (normalizedEmail) {
+      current.emails.add(normalizedEmail)
+    }
+
+    if (normalizedName) {
+      current.names.add(normalizedName)
+    }
+
     byContributor.set(identity.key, current)
   }
 
-  return byContributor
+  return mergeEmailKeyedContributors(byContributor)
 }
 
 function rankContributorEntries(byContributor, totalCommits, newContributorKeys, reviewStats = new Map()) {

--- a/website/scripts/lib/identity-merge.mjs
+++ b/website/scripts/lib/identity-merge.mjs
@@ -1,0 +1,144 @@
+function normalizeValue(value) {
+  return String(value ?? '').trim().toLowerCase()
+}
+
+function pickEarlierDate(left, right) {
+  if (!left) {
+    return right
+  }
+
+  if (!right) {
+    return left
+  }
+
+  return left < right ? left : right
+}
+
+function pickLaterDate(left, right) {
+  if (!left) {
+    return right
+  }
+
+  if (!right) {
+    return left
+  }
+
+  return left > right ? left : right
+}
+
+function normalizedSet(values) {
+  const normalized = new Set()
+
+  for (const value of values ?? []) {
+    const candidate = normalizeValue(value)
+
+    if (candidate) {
+      normalized.add(candidate)
+    }
+  }
+
+  return normalized
+}
+
+const AMBIGUOUS = Symbol('ambiguous evidence')
+
+function indexEvidence(index, evidence, entry) {
+  for (const value of evidence) {
+    const existing = index.get(value)
+
+    if (existing === undefined) {
+      index.set(value, entry)
+    }
+    else if (existing !== entry) {
+      index.set(value, AMBIGUOUS)
+    }
+  }
+}
+
+function lookupEvidence(index, evidence) {
+  for (const value of evidence) {
+    const target = index.get(value)
+
+    if (target && target !== AMBIGUOUS) {
+      return target
+    }
+  }
+
+  return null
+}
+
+/**
+ * Merges leftover `email:*`-keyed contributor entries into a matching
+ * `github:*`-keyed entry when the commit author evidence the script already
+ * collected (author emails, author names) links them to the same human.
+ *
+ * This covers commits whose GitHub login resolution failed at generation time
+ * (e.g. the author email was not yet linked to the GitHub account), which
+ * otherwise splits one contributor into two ranked leaderboard entries.
+ *
+ * @param {Map<string, object>} byContributor entries keyed by identity key,
+ *   each carrying `emails`/`names` evidence sets plus commit stats.
+ * @returns {Map<string, object>} a new map with email-keyed entries folded
+ *   into their matching github-keyed entry (commits summed, date range
+ *   widened, github key kept). The input map is not mutated.
+ */
+export function mergeEmailKeyedContributors(byContributor) {
+  const merged = new Map()
+
+  for (const [key, entry] of byContributor) {
+    merged.set(key, {
+      ...entry,
+      emails: normalizedSet(entry.emails),
+      names: normalizedSet(entry.names),
+    })
+  }
+
+  const targetByEmail = new Map()
+  const targetByName = new Map()
+  const targetByLogin = new Map()
+
+  for (const entry of merged.values()) {
+    if (!entry.key?.startsWith('github:') || entry.isBot) {
+      continue
+    }
+
+    indexEvidence(targetByEmail, entry.emails, entry)
+    indexEvidence(targetByName, entry.names, entry)
+
+    const login = normalizeValue(entry.login)
+
+    if (login) {
+      indexEvidence(targetByLogin, [login], entry)
+    }
+  }
+
+  for (const [key, entry] of merged) {
+    if (!key.startsWith('email:') || entry.isBot) {
+      continue
+    }
+
+    const target = lookupEvidence(targetByEmail, entry.emails)
+      ?? lookupEvidence(targetByName, entry.names)
+      ?? lookupEvidence(targetByLogin, entry.names)
+
+    if (!target) {
+      continue
+    }
+
+    target.commits += entry.commits
+    target.firstCommitDate = pickEarlierDate(target.firstCommitDate, entry.firstCommitDate)
+    target.latestCommitDate = pickLaterDate(target.latestCommitDate, entry.latestCommitDate)
+
+    for (const email of entry.emails) {
+      target.emails.add(email)
+    }
+
+    for (const name of entry.names) {
+      target.names.add(name)
+    }
+
+    merged.delete(key)
+  }
+
+  return merged
+}

--- a/website/scripts/lib/identity-merge.mjs
+++ b/website/scripts/lib/identity-merge.mjs
@@ -69,12 +69,15 @@ function lookupEvidence(index, evidence) {
 
 /**
  * Merges leftover `email:*`-keyed contributor entries into a matching
- * `github:*`-keyed entry when the commit author evidence the script already
- * collected (author emails, author names) links them to the same human.
+ * `github:*`-keyed entry when the entry's commit author name equals the
+ * GitHub login of exactly one non-bot `github:*` entry.
  *
  * This covers commits whose GitHub login resolution failed at generation time
- * (e.g. the author email was not yet linked to the GitHub account), which
- * otherwise splits one contributor into two ranked leaderboard entries.
+ * (e.g. a deleted account whose commits resolve to `ghost`), which otherwise
+ * splits one contributor into two ranked leaderboard entries. Broader
+ * email/name-evidence matching was deliberately dropped: git author names are
+ * user-controlled and collide (two authors committing as `root`), so only the
+ * name-equals-login signal is used.
  *
  * @param {Map<string, object>} byContributor entries keyed by identity key,
  *   each carrying `emails`/`names` evidence sets plus commit stats.
@@ -93,17 +96,12 @@ export function mergeEmailKeyedContributors(byContributor) {
     })
   }
 
-  const targetByEmail = new Map()
-  const targetByName = new Map()
   const targetByLogin = new Map()
 
   for (const entry of merged.values()) {
     if (!entry.key?.startsWith('github:') || entry.isBot) {
       continue
     }
-
-    indexEvidence(targetByEmail, entry.emails, entry)
-    indexEvidence(targetByName, entry.names, entry)
 
     const login = normalizeValue(entry.login)
 
@@ -117,9 +115,7 @@ export function mergeEmailKeyedContributors(byContributor) {
       continue
     }
 
-    const target = lookupEvidence(targetByEmail, entry.emails)
-      ?? lookupEvidence(targetByName, entry.names)
-      ?? lookupEvidence(targetByLogin, entry.names)
+    const target = lookupEvidence(targetByLogin, entry.names)
 
     if (!target) {
       continue

--- a/website/scripts/lib/identity-merge.test.mjs
+++ b/website/scripts/lib/identity-merge.test.mjs
@@ -44,9 +44,11 @@ test('merges the theohsiung email-keyed split from issue #2699 into the github-k
   assert.equal(entry.latestCommitDate, '2026-01-20T08:00:00+08:00')
 })
 
-test('merges an email-keyed entry that shares a commit author name with a github-keyed entry', () => {
-  // The Wilson Wu split from issue #2699: iwilsonwu@gmail.com commits kept the
-  // same author name as the commits that did resolve to a GitHub login.
+test('keeps entries separate when only a shared display name links them', () => {
+  // Author names are user-controlled and collide (two authors committing as
+  // "root"), so a shared display name alone is deliberately NOT merge
+  // evidence; only name-equals-login is. The original #2699 splits have
+  // self-healed upstream.
   const byContributor = entriesToMap([
     {
       key: 'github:wilsonwu',
@@ -71,15 +73,14 @@ test('merges an email-keyed entry that shares a commit author name with a github
 
   const merged = mergeEmailKeyedContributors(byContributor)
 
-  assert.equal(merged.size, 1)
-
-  const entry = merged.get('github:wilsonwu')
-
-  assert.equal(entry.commits, 15)
-  assert.equal(entry.latestCommitDate, '2026-02-01T00:00:00Z')
+  assert.equal(merged.size, 2)
+  assert.equal(merged.get('github:wilsonwu').commits, 12)
+  assert.equal(merged.get('email:iwilsonwu@gmail.com').commits, 3)
 })
 
-test('merges when the github-keyed entry saw the same author email on other commits', () => {
+test('keeps entries separate when only shared author-email evidence links them', () => {
+  // Email-evidence matching was dropped along with name matching: the
+  // name-equals-login path is the only merge signal.
   const byContributor = entriesToMap([
     {
       key: 'github:someone',
@@ -104,8 +105,9 @@ test('merges when the github-keyed entry saw the same author email on other comm
 
   const merged = mergeEmailKeyedContributors(byContributor)
 
-  assert.equal(merged.size, 1)
-  assert.equal(merged.get('github:someone').commits, 9)
+  assert.equal(merged.size, 2)
+  assert.equal(merged.get('github:someone').commits, 7)
+  assert.equal(merged.get('email:personal@example.com').commits, 2)
 })
 
 test('keeps an email-keyed entry with no linking evidence as its own entry', () => {

--- a/website/scripts/lib/identity-merge.test.mjs
+++ b/website/scripts/lib/identity-merge.test.mjs
@@ -1,0 +1,275 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mergeEmailKeyedContributors } from './identity-merge.mjs'
+
+function entriesToMap(entries) {
+  return new Map(entries.map(entry => [entry.key, entry]))
+}
+
+test('merges the theohsiung email-keyed split from issue #2699 into the github-keyed entry', () => {
+  // v03ToNow range from contributorRank.generated.ts: rank 2 vs rank 12.
+  const byContributor = entriesToMap([
+    {
+      key: 'github:theohsiung',
+      name: 'Theo Hsiung',
+      login: 'theohsiung',
+      commits: 34,
+      firstCommitDate: '2025-11-03T08:00:00+08:00',
+      latestCommitDate: '2026-01-20T08:00:00+08:00',
+      emails: new Set(['139082137+theohsiung@users.noreply.github.com']),
+      names: new Set(['Theo Hsiung']),
+    },
+    {
+      key: 'email:theobear870924@gmail.com',
+      name: 'theohsiung',
+      commits: 5,
+      firstCommitDate: '2025-10-28T08:00:00+08:00',
+      latestCommitDate: '2025-12-01T08:00:00+08:00',
+      emails: new Set(['theobear870924@gmail.com']),
+      names: new Set(['theohsiung']),
+    },
+  ])
+
+  const merged = mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(merged.size, 1)
+  assert.equal(merged.has('email:theobear870924@gmail.com'), false)
+
+  const entry = merged.get('github:theohsiung')
+
+  assert.equal(entry.name, 'Theo Hsiung')
+  assert.equal(entry.login, 'theohsiung')
+  assert.equal(entry.commits, 39)
+  assert.equal(entry.firstCommitDate, '2025-10-28T08:00:00+08:00')
+  assert.equal(entry.latestCommitDate, '2026-01-20T08:00:00+08:00')
+})
+
+test('merges an email-keyed entry that shares a commit author name with a github-keyed entry', () => {
+  // The Wilson Wu split from issue #2699: iwilsonwu@gmail.com commits kept the
+  // same author name as the commits that did resolve to a GitHub login.
+  const byContributor = entriesToMap([
+    {
+      key: 'github:wilsonwu',
+      name: 'Wilson Wu',
+      login: 'wilsonwu',
+      commits: 12,
+      firstCommitDate: '2025-09-01T00:00:00Z',
+      latestCommitDate: '2026-01-10T00:00:00Z',
+      emails: new Set(['wilsonwu@users.noreply.github.com']),
+      names: new Set(['Wilson Wu']),
+    },
+    {
+      key: 'email:iwilsonwu@gmail.com',
+      name: 'Wilson Wu',
+      commits: 3,
+      firstCommitDate: '2025-12-05T00:00:00Z',
+      latestCommitDate: '2026-02-01T00:00:00Z',
+      emails: new Set(['iwilsonwu@gmail.com']),
+      names: new Set(['Wilson Wu']),
+    },
+  ])
+
+  const merged = mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(merged.size, 1)
+
+  const entry = merged.get('github:wilsonwu')
+
+  assert.equal(entry.commits, 15)
+  assert.equal(entry.latestCommitDate, '2026-02-01T00:00:00Z')
+})
+
+test('merges when the github-keyed entry saw the same author email on other commits', () => {
+  const byContributor = entriesToMap([
+    {
+      key: 'github:someone',
+      name: 'Someone',
+      login: 'someone',
+      commits: 7,
+      firstCommitDate: '2025-01-01T00:00:00Z',
+      latestCommitDate: '2025-06-01T00:00:00Z',
+      emails: new Set(['personal@example.com']),
+      names: new Set(['S. One']),
+    },
+    {
+      key: 'email:personal@example.com',
+      name: 'Different Display Name',
+      commits: 2,
+      firstCommitDate: '2025-03-01T00:00:00Z',
+      latestCommitDate: '2025-07-01T00:00:00Z',
+      emails: new Set(['personal@example.com']),
+      names: new Set(['Different Display Name']),
+    },
+  ])
+
+  const merged = mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(merged.size, 1)
+  assert.equal(merged.get('github:someone').commits, 9)
+})
+
+test('keeps an email-keyed entry with no linking evidence as its own entry', () => {
+  const byContributor = entriesToMap([
+    {
+      key: 'github:someone',
+      name: 'Someone',
+      login: 'someone',
+      commits: 7,
+      firstCommitDate: '2025-01-01T00:00:00Z',
+      latestCommitDate: '2025-06-01T00:00:00Z',
+      emails: new Set(['someone@example.com']),
+      names: new Set(['Someone']),
+    },
+    {
+      key: 'email:stranger@example.com',
+      name: 'Stranger',
+      commits: 4,
+      firstCommitDate: '2025-02-01T00:00:00Z',
+      latestCommitDate: '2025-05-01T00:00:00Z',
+      emails: new Set(['stranger@example.com']),
+      names: new Set(['Stranger']),
+    },
+  ])
+
+  const merged = mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(merged.size, 2)
+  assert.equal(merged.get('github:someone').commits, 7)
+  assert.equal(merged.get('email:stranger@example.com').commits, 4)
+})
+
+test('does not merge when the linking evidence is ambiguous across github entries', () => {
+  const byContributor = entriesToMap([
+    {
+      key: 'github:alpha',
+      name: 'Jay Chen',
+      login: 'alpha',
+      commits: 5,
+      firstCommitDate: '2025-01-01T00:00:00Z',
+      latestCommitDate: '2025-06-01T00:00:00Z',
+      emails: new Set(['alpha@example.com']),
+      names: new Set(['Jay Chen']),
+    },
+    {
+      key: 'github:beta',
+      name: 'Jay Chen',
+      login: 'beta',
+      commits: 6,
+      firstCommitDate: '2025-01-01T00:00:00Z',
+      latestCommitDate: '2025-06-01T00:00:00Z',
+      emails: new Set(['beta@example.com']),
+      names: new Set(['Jay Chen']),
+    },
+    {
+      key: 'email:jay@example.com',
+      name: 'Jay Chen',
+      commits: 2,
+      firstCommitDate: '2025-02-01T00:00:00Z',
+      latestCommitDate: '2025-03-01T00:00:00Z',
+      emails: new Set(['jay@example.com']),
+      names: new Set(['Jay Chen']),
+    },
+  ])
+
+  const merged = mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(merged.size, 3)
+  assert.equal(merged.get('github:alpha').commits, 5)
+  assert.equal(merged.get('github:beta').commits, 6)
+  assert.equal(merged.get('email:jay@example.com').commits, 2)
+})
+
+test('matches evidence case-insensitively', () => {
+  const byContributor = entriesToMap([
+    {
+      key: 'github:theohsiung',
+      name: 'Theo Hsiung',
+      login: 'theohsiung',
+      commits: 34,
+      firstCommitDate: '2025-11-03T00:00:00Z',
+      latestCommitDate: '2026-01-20T00:00:00Z',
+      emails: new Set(['139082137+theohsiung@users.noreply.github.com']),
+      names: new Set(['Theo Hsiung']),
+    },
+    {
+      key: 'email:theobear870924@gmail.com',
+      name: 'TheoHsiung',
+      commits: 5,
+      firstCommitDate: '2025-10-28T00:00:00Z',
+      latestCommitDate: '2025-12-01T00:00:00Z',
+      emails: new Set(['TheoBear870924@Gmail.com']),
+      names: new Set(['TheoHsiung']),
+    },
+  ])
+
+  const merged = mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(merged.size, 1)
+  assert.equal(merged.get('github:theohsiung').commits, 39)
+})
+
+test('does not merge email-keyed entries into bot entries or into each other', () => {
+  const byContributor = entriesToMap([
+    {
+      key: 'dependabot[bot]',
+      name: 'dependabot[bot]',
+      commits: 20,
+      isBot: true,
+      firstCommitDate: '2025-01-01T00:00:00Z',
+      latestCommitDate: '2025-06-01T00:00:00Z',
+      emails: new Set(['dependabot@example.com']),
+      names: new Set(['dependabot[bot]']),
+    },
+    {
+      key: 'email:first@example.com',
+      name: 'Same Name',
+      commits: 2,
+      firstCommitDate: '2025-02-01T00:00:00Z',
+      latestCommitDate: '2025-03-01T00:00:00Z',
+      emails: new Set(['first@example.com']),
+      names: new Set(['Same Name']),
+    },
+    {
+      key: 'email:second@example.com',
+      name: 'Same Name',
+      commits: 3,
+      firstCommitDate: '2025-02-01T00:00:00Z',
+      latestCommitDate: '2025-03-01T00:00:00Z',
+      emails: new Set(['second@example.com']),
+      names: new Set(['Same Name']),
+    },
+  ])
+
+  const merged = mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(merged.size, 3)
+})
+
+test('does not mutate the input map or its entries', () => {
+  const emailEntry = {
+    key: 'email:theobear870924@gmail.com',
+    name: 'theohsiung',
+    commits: 5,
+    firstCommitDate: '2025-10-28T00:00:00Z',
+    latestCommitDate: '2025-12-01T00:00:00Z',
+    emails: new Set(['theobear870924@gmail.com']),
+    names: new Set(['theohsiung']),
+  }
+  const githubEntry = {
+    key: 'github:theohsiung',
+    name: 'Theo Hsiung',
+    login: 'theohsiung',
+    commits: 34,
+    firstCommitDate: '2025-11-03T00:00:00Z',
+    latestCommitDate: '2026-01-20T00:00:00Z',
+    emails: new Set(['139082137+theohsiung@users.noreply.github.com']),
+    names: new Set(['Theo Hsiung']),
+  }
+  const byContributor = entriesToMap([githubEntry, emailEntry])
+
+  mergeEmailKeyedContributors(byContributor)
+
+  assert.equal(byContributor.size, 2)
+  assert.equal(githubEntry.commits, 34)
+  assert.equal(emailEntry.commits, 5)
+})


### PR DESCRIPTION
Fixes #2699

## What

The contributor leaderboard splits one human into two ranked entries when some commits resolve to a GitHub login and others only to an email (e.g. theohsiung ranked twice in the same range). Root cause: `resolveIdentity()` has no reconciliation between `github:*` and `email:*` keys.

This adds a deterministic post-collection pass that folds leftover email-keyed entries into a matching github-keyed entry when linked by commit-author evidence the script already collects (shared author email, shared author name, or name equal to the login), summing commits and widening the date range. Ambiguous evidence shared by multiple github-keyed entries is never used, bots are excluded, and no new GitHub API calls are made.

The generated data file is not touched here; it regenerates on the next scheduled run.

## Tests

New `node --test` suite in `scripts/lib/` (the repo's existing convention), including the exact theohsiung split from the issue (34 + 5 must merge into one 39-commit entry), non-merge cases, and immutability. 4 of 8 tests fail against the old pass-through behavior; 13/13 pass with the fix. `npm run lint` clean. Both commits are DCO signed-off.

Credit to @theohsiung for the report in #2699.
