### PR TITLE
[Docs] Hide new contributor badges from the all-time leaderboard

### DIFF
--- a/website/src/pages/community/contributors.tsx
+++ b/website/src/pages/community/contributors.tsx
@@ -245,6 +245,7 @@ const ContributorsPage: React.FC = () => {
                 entry={entry}
                 dateLocale={dateLocale}
                 numberLocale={numberLocale}
+                showNewContributorStatus={selectedRange !== 'all'}
               />
             ))}
           </div>
@@ -286,13 +287,15 @@ const ContributorRow: React.FC<{
   entry: ContributorRankEntry
   numberLocale: string
   dateLocale: string
-}> = ({ entry, numberLocale, dateLocale }) => {
+  showNewContributorStatus: boolean
+}> = ({ entry, numberLocale, dateLocale, showNewContributorStatus }) => {
   const profileUrl = entry.login ? `https://github.com/${entry.login}` : undefined
   const sharePercent = formatPercent(entry.share)
   const barWidth = `${Math.max(entry.share * 100, 1.5)}%`
+  const isNewContributor = showNewContributorStatus && entry.isNewContributorSinceRelease
 
   return (
-    <article className={`${styles.rankItem} ${entry.isNewContributorSinceRelease ? styles.rankItemNew : ''}`}>
+    <article className={`${styles.rankItem} ${isNewContributor ? styles.rankItemNew : ''}`}>
       <span className={styles.rankBadge}>
         {formatRankNumber(entry.rank)}
       </span>
@@ -302,7 +305,7 @@ const ContributorRow: React.FC<{
         <div className={styles.identity}>
           <span className={styles.nameLine}>
             <span className={styles.name}>{entry.name}</span>
-            {entry.isNewContributorSinceRelease && (
+            {isNewContributor && (
               <span className={styles.newContributorPill}>
                 <Translate id="community.contributors.newContributor">New Contributor</Translate>
               </span>


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2721 

## Purpose

- Hide the `New Contributor` badge when the contributor leaderboard range is set to `All time`.
- Remove the associated new-contributor row highlighting from the `All time` view.
- Preserve the existing badge and highlighting behavior for release-specific ranges.
- This change is needed because “new contributor” is meaningful only within a bounded release window. In the full repository history, every contributor was incorrectly presented as new.
- Affected module: `Docs`

## Test Plan

- Run the focused ESLint check:

  ```bash
  cd website
  npx eslint src/pages/community/contributors.tsx
  ```

- Start the Docusaurus development server and open `/community/contributors`.
- Select `All time` and verify that:
  - No `New Contributor` badges are displayed.
  - No new-contributor row highlighting is applied.
- Select a release-specific range and verify that the badges and highlighting are still displayed for qualifying contributors.
- This validation is sufficient because the change is isolated to the presentation logic of the contributor leaderboard page and does not modify contributor data generation.

## Test Result

- The focused ESLint check passed with no errors.
- Docusaurus compiled successfully.
- Browser validation confirmed:
  - `All time`: `0` new-contributor badges and `0` highlighted rows.
  - Current release range: `21` badges and `21` highlighted rows.
- No follow-up risks, gaps, or blockers were identified.

Before change:
<img width="2056" height="1264" alt="image" src="https://github.com/user-attachments/assets/2307b39e-491d-4d1d-966d-ee70ebdc1974" />


After change:
<img width="1538" height="966" alt="image" src="https://github.com/user-attachments/assets/de5ab4a6-e5ce-4ee4-9028-e23020a0c3ec" />

Displays other than "all-time" are unaffected:
<img width="1520" height="1336" alt="image" src="https://github.com/user-attachments/assets/9544c4a7-2c02-448b-903c-fa59986a9233" />

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.


