### PR TITLE
[Router] fix recipe-blind routing reads and pin every read scope

### DIFF
--- a/dashboard/backend/handlers/topology_response.go
+++ b/dashboard/backend/handlers/topology_response.go
@@ -177,7 +177,7 @@ func appendEvaluatedRulesFromConfig(result *TestQueryResult, configPath string) 
 	}
 
 	matchedSignalNames := buildMatchedSignalNameSet(result.MatchedSignals)
-	for _, decision := range parsedConfig.IntelligentRouting.Decisions {
+	for _, decision := range parsedConfig.IntelligentRouting.DefaultDecisions {
 		if result.MatchedDecision != "" && decision.Name == result.MatchedDecision {
 			continue
 		}

--- a/docs/agent/plans/pl-0038-entrypoints-recipes.md
+++ b/docs/agent/plans/pl-0038-entrypoints-recipes.md
@@ -15,11 +15,12 @@ of it.
   `recipes` adds named additional profiles. A recipe named `default` may only
   appear when the top-level `routing` block carries no profile of its own.
 - Internal representation: normalized `Recipes`/`Entrypoints` on `RouterConfig`;
-  the default recipe's decisions stay bridged into the flat `Decisions` field so
-  current read sites keep working unchanged, while the flat
-  `Signals`/`Projections` fields hold the global registry (the union across
-  recipes, per the issue's "signal registry stays global" non-goal) so one
-  classifier evaluates any recipe's rules.
+  the default recipe's decisions stay bridged into the flat field (renamed
+  `Decisions` → `DefaultDecisions` in #2724 so the default-profile scope is
+  visible at every read site), while the flat `Signals`/`Projections` fields
+  hold the global registry (the union across recipes, per the issue's "signal
+  registry stays global" non-goal) so one classifier evaluates any recipe's
+  rules.
 - Request path: resolve model name → entrypoint → recipe before signal
   evaluation in `pkg/extproc`; decision evaluation reads the per-request recipe.
 - Validation: structural recipe/entrypoint checks first, then cross-surface
@@ -73,12 +74,19 @@ single-profile configs.
 
 ## Next Action
 
-The runtime PR (#2613, stacked on #2612) is complete: T5–T7 plus T9 E2E.
-T8 docs ride with the config-contract PR (#2612). T3 stays pending the
-maintainer confirmation recorded in Open Decisions. Deferred from T5: signal
-evaluation runs over the global registry filtered by all recipes' decisions;
-scoping the evaluated signal set to the per-request recipe is a performance
-follow-up, not a correctness gap.
+The read-site correction PR (#2724, closes #2723) is complete: the flat field
+is renamed `DefaultDecisions`, the whole-surface read sites (plugin
+enablement, contract validators, lookups, replay) read every recipe, the
+deliberate default-profile reads are pinned in
+`pkg/config/default_decisions_allowlist_test.go` with per-site rationale, and
+cross-recipe case-aliased decision names are rejected at load. Remaining
+tasks: T10 DSL round-trip, T11 CLI/operator, T12 dashboard (the dashboard's
+recipe blindness is registered as
+[TD045](../tech-debt/td-045-dashboard-recipe-scope-blindness.md)). T3 stays
+pending the maintainer confirmation recorded in Open Decisions. Deferred from
+T5: signal evaluation runs over the global registry filtered by all recipes'
+decisions; scoping the evaluated signal set to the per-request recipe is a
+performance follow-up, not a correctness gap.
 
 ## Operating Rules
 
@@ -86,10 +94,11 @@ follow-up, not a correctness gap.
   `recipes.go` and canonical normalization in `canonical_recipes.go`.
 - `processor_req_body.go` stays an orchestrator; entrypoint resolution lives in
   a dedicated `req_filter_entrypoint.go`.
-- The flat `Decisions` field on `RouterConfig` must always equal the default
-  recipe; the flat `Signals`/`Projections` fields hold the global registry
-  (union of every recipe's profile). Runtime code moves to recipe reads, never
-  the reverse.
+- The flat `DefaultDecisions` field on `RouterConfig` must always alias the
+  default recipe; the flat `Signals`/`Projections` fields hold the global
+  registry (union of every recipe's profile). Runtime code moves to recipe
+  reads, never the reverse; a new default-profile read must be entered in
+  `pkg/config/default_decisions_allowlist_test.go` with its scope rationale.
 - Every step passes `make agent-lint` and the affected package tests before the
   next step starts.
 

--- a/docs/agent/tech-debt/README.md
+++ b/docs/agent/tech-debt/README.md
@@ -70,6 +70,10 @@ Every debt entry should include:
 
 - [TD044 Flow Tool State Durability Follow-Up](td-044-flow-tool-state-durability-gap.md)
 
+### PL0038 Entrypoints and Recipes
+
+- [TD045 Dashboard Surfaces Are Blind to Named Recipes](td-045-dashboard-recipe-scope-blindness.md)
+
 ## Retired Debt Policy
 
 Retired TD files are removed from this directory. Keep the ID in commit history

--- a/docs/agent/tech-debt/td-045-dashboard-recipe-scope-blindness.md
+++ b/docs/agent/tech-debt/td-045-dashboard-recipe-scope-blindness.md
@@ -1,0 +1,69 @@
+# TD045: Dashboard Surfaces Are Blind to Named Recipes
+
+## Status
+
+Open.
+
+## Owner Plan
+
+[PL0038 Entrypoints and Recipes](../plans/pl-0038-entrypoints-recipes.md), task
+T12 (dashboard surfaces).
+
+## Release Relevance
+
+Named recipes are the unreleased #2612/#2613 surface. Before they ship, every
+dashboard read of routing decisions must either model recipe scope or state
+that it intentionally shows the default profile only; today the gaps are
+silent.
+
+## Scope
+
+- `dashboard/backend/handlers/topology_response.go`
+- `dashboard/backend/handlers/setup.go`
+- `dashboard/backend/configprojection/builder.go`
+
+## Summary
+
+The dashboard backend reads only the default routing profile. The router-side
+read-site correction (#2724) fixed the router's whole-surface reads and pinned
+the remaining default-profile reads in an allowlist, but the dashboard module
+was out of that PR's scope: its decision, plugin, and signal views omit named
+recipes entirely, and the setup wizard can reject a valid recipes-only config.
+
+## Evidence
+
+- `topology_response.go` (`appendEvaluatedRulesFromConfig`): the test-query
+  panel replays only `DefaultDecisions`, so a request served by a named recipe
+  shows evaluated rules from a profile it did not route through.
+- `setup.go` (`summarizeSetupConfig` / `CanActivate`): the decision count comes
+  from the exported top-level routing block, so a recipes-only config reads as
+  "0 decisions" and the wizard refuses to activate it, while the model summary
+  spans every recipe — one panel, two scopes.
+- `configprojection/builder.go` (`BuildSnapshot`): only
+  `canonical.Routing.Decisions`/`Signals`/`Projections` reach the snapshot;
+  `canonical.Recipes` is dropped wholesale, so recipe decisions and their
+  plugins never appear in the projection views.
+- These sites do not spell `DefaultDecisions`, so the read-site allowlist
+  guard (`src/semantic-router/pkg/config/default_decisions_allowlist_test.go`)
+  structurally cannot flag them; only `topology_response.go` is registered
+  there today.
+
+## Why It Matters
+
+Operators use the dashboard to verify what the router will do. A recipe
+decision that routes, enables plugins, and reports in `/metrics` while staying
+invisible in the dashboard reproduces the exact silent-divergence class that
+issue #2723 removed from the router.
+
+## Desired End State
+
+Dashboard views either render recipe scope (grouped by profile, with
+entrypoint context) or carry an explicit "default profile only" label; the
+setup wizard activates recipes-only configs.
+
+## Exit Criteria
+
+- `BuildSnapshot` projects recipe decisions, plugins, and signals.
+- `CanActivate` accepts a config whose decisions all live in named recipes.
+- The topology test-query panel either models recipe scope or labels its
+  default-profile limitation in the UI.

--- a/e2e/testcases/apiserver_classification_endpoints.go
+++ b/e2e/testcases/apiserver_classification_endpoints.go
@@ -22,13 +22,40 @@ func init() {
 	})
 }
 
+type routerConfigRouting struct {
+	Decisions []struct {
+		Name string `json:"name"`
+	} `json:"decisions"`
+	Signals map[string]interface{} `json:"signals"`
+}
+
 type routerConfigDocument struct {
-	Routing struct {
-		Decisions []struct {
-			Name string `json:"name"`
-		} `json:"decisions"`
-		Signals map[string]interface{} `json:"signals"`
-	} `json:"routing"`
+	Routing routerConfigRouting `json:"routing"`
+	Recipes []struct {
+		Name    string              `json:"name"`
+		Routing routerConfigRouting `json:"routing"`
+	} `json:"recipes"`
+}
+
+// totalDecisions counts the decisions of every routing profile, mirroring
+// RouterConfig.AllRoutingDecisions(): `/metrics/classification` reports the
+// router-wide decision count, so a named recipe's decisions belong in the
+// expectation too. An explicit `default` recipe *is* the top-level profile
+// rather than an extra one, so it replaces routing.decisions instead of
+// adding to it.
+func (d *routerConfigDocument) totalDecisions() int {
+	total := 0
+	explicitDefault := false
+	for _, recipe := range d.Recipes {
+		if recipe.Name == "default" {
+			explicitDefault = true
+		}
+		total += len(recipe.Routing.Decisions)
+	}
+	if !explicitDefault {
+		total += len(d.Routing.Decisions)
+	}
+	return total
 }
 
 type classificationMetricsDocument struct {
@@ -64,8 +91,8 @@ func testAPIServerClassificationEndpoints(
 	if err != nil {
 		return err
 	}
-	if metricsDoc.DecisionCount != len(configDoc.Routing.Decisions) {
-		return fmt.Errorf("expected /metrics/classification decision_count=%d, got %d", len(configDoc.Routing.Decisions), metricsDoc.DecisionCount)
+	if expectedDecisions := configDoc.totalDecisions(); metricsDoc.DecisionCount != expectedDecisions {
+		return fmt.Errorf("expected /metrics/classification decision_count=%d, got %d", expectedDecisions, metricsDoc.DecisionCount)
 	}
 
 	combinedKeys, err := fetchCombinedClassificationKeys(
@@ -110,7 +137,7 @@ func fetchRouterConfigDocument(
 	if err := json.Unmarshal(resp.Body, &doc); err != nil {
 		return nil, nil, fmt.Errorf("decode /config/router response: %w", err)
 	}
-	if len(doc.Routing.Decisions) == 0 {
+	if doc.totalDecisions() == 0 {
 		return nil, nil, fmt.Errorf("expected /config/router to include routing decisions")
 	}
 	return resp.Body, &doc, nil

--- a/perf/benchmarks/decision_bench_test.go
+++ b/perf/benchmarks/decision_bench_test.go
@@ -43,7 +43,7 @@ func initDecisionEngine(b *testing.B) {
 			cfg.KeywordRules,
 			cfg.EmbeddingRules,
 			cfg.Categories,
-			cfg.Decisions,
+			cfg.DefaultDecisions,
 			"priority", // Use priority strategy
 		)
 	})

--- a/src/semantic-router/cmd/main.go
+++ b/src/semantic-router/cmd/main.go
@@ -138,7 +138,7 @@ func applyKubernetesConfigUpdate(newConfig *config.RouterConfig) error {
 	replaceKubernetesRuntimeConfig(newConfig)
 	logging.ComponentEvent("router", "kubernetes_config_applied", map[string]interface{}{
 		"config_source":  newConfig.ConfigSource,
-		"decision_count": len(newConfig.Decisions),
+		"decision_count": len(newConfig.DefaultDecisions),
 	})
 	return nil
 }
@@ -178,8 +178,8 @@ func startKubernetesController(staticConfig *config.RouterConfig, kubeconfig, na
 // startup state — making it trivial for agents and log aggregators to determine
 // what the router is serving and on which ports.
 func logStartupSummary(cfg *config.RouterConfig, opts runtimeOptions, embeddingModelsReady bool) {
-	decisionNames := make([]string, 0, len(cfg.Decisions))
-	for _, d := range cfg.Decisions {
+	decisionNames := make([]string, 0, len(cfg.DefaultDecisions))
+	for _, d := range cfg.DefaultDecisions {
 		decisionNames = append(decisionNames, d.Name)
 	}
 

--- a/src/semantic-router/cmd/main.go
+++ b/src/semantic-router/cmd/main.go
@@ -138,7 +138,7 @@ func applyKubernetesConfigUpdate(newConfig *config.RouterConfig) error {
 	replaceKubernetesRuntimeConfig(newConfig)
 	logging.ComponentEvent("router", "kubernetes_config_applied", map[string]interface{}{
 		"config_source":  newConfig.ConfigSource,
-		"decision_count": len(newConfig.AllRoutingDecisions()),
+		"decision_count": newConfig.CountRoutingDecisions(),
 	})
 	return nil
 }

--- a/src/semantic-router/cmd/main.go
+++ b/src/semantic-router/cmd/main.go
@@ -138,7 +138,7 @@ func applyKubernetesConfigUpdate(newConfig *config.RouterConfig) error {
 	replaceKubernetesRuntimeConfig(newConfig)
 	logging.ComponentEvent("router", "kubernetes_config_applied", map[string]interface{}{
 		"config_source":  newConfig.ConfigSource,
-		"decision_count": len(newConfig.DefaultDecisions),
+		"decision_count": len(newConfig.AllRoutingDecisions()),
 	})
 	return nil
 }
@@ -178,8 +178,9 @@ func startKubernetesController(staticConfig *config.RouterConfig, kubeconfig, na
 // startup state — making it trivial for agents and log aggregators to determine
 // what the router is serving and on which ports.
 func logStartupSummary(cfg *config.RouterConfig, opts runtimeOptions, embeddingModelsReady bool) {
-	decisionNames := make([]string, 0, len(cfg.DefaultDecisions))
-	for _, d := range cfg.DefaultDecisions {
+	decisions := cfg.AllRoutingDecisions()
+	decisionNames := make([]string, 0, len(decisions))
+	for _, d := range decisions {
 		decisionNames = append(decisionNames, d.Name)
 	}
 

--- a/src/semantic-router/cmd/runtime_bootstrap.go
+++ b/src/semantic-router/cmd/runtime_bootstrap.go
@@ -113,7 +113,7 @@ func loadRuntimeConfigOrFatal(configPath string) *config.RouterConfig {
 	logging.ComponentDebugEvent("router", "runtime_config_loaded", map[string]interface{}{
 		"config_path":    configPath,
 		"config_source":  cfg.ConfigSource,
-		"decision_count": len(cfg.AllRoutingDecisions()),
+		"decision_count": cfg.CountRoutingDecisions(),
 	})
 	return cfg
 }

--- a/src/semantic-router/cmd/runtime_bootstrap.go
+++ b/src/semantic-router/cmd/runtime_bootstrap.go
@@ -113,7 +113,7 @@ func loadRuntimeConfigOrFatal(configPath string) *config.RouterConfig {
 	logging.ComponentDebugEvent("router", "runtime_config_loaded", map[string]interface{}{
 		"config_path":    configPath,
 		"config_source":  cfg.ConfigSource,
-		"decision_count": len(cfg.DefaultDecisions),
+		"decision_count": len(cfg.AllRoutingDecisions()),
 	})
 	return cfg
 }

--- a/src/semantic-router/cmd/runtime_bootstrap.go
+++ b/src/semantic-router/cmd/runtime_bootstrap.go
@@ -113,7 +113,7 @@ func loadRuntimeConfigOrFatal(configPath string) *config.RouterConfig {
 	logging.ComponentDebugEvent("router", "runtime_config_loaded", map[string]interface{}{
 		"config_path":    configPath,
 		"config_source":  cfg.ConfigSource,
-		"decision_count": len(cfg.Decisions),
+		"decision_count": len(cfg.DefaultDecisions),
 	})
 	return cfg
 }

--- a/src/semantic-router/pkg/apiserver/route_classification_metrics.go
+++ b/src/semantic-router/pkg/apiserver/route_classification_metrics.go
@@ -34,7 +34,7 @@ func (s *ClassificationAPIServer) handleClassificationMetrics(w http.ResponseWri
 		return
 	}
 
-	response.DecisionCount = len(cfg.DefaultDecisions)
+	response.DecisionCount = len(cfg.AllRoutingDecisions())
 	response.ProjectionPartitionCount = len(cfg.Projections.Partitions)
 	response.ProjectionScoreCount = len(cfg.Projections.Scores)
 	response.ProjectionMappingCount = len(cfg.Projections.Mappings)

--- a/src/semantic-router/pkg/apiserver/route_classification_metrics.go
+++ b/src/semantic-router/pkg/apiserver/route_classification_metrics.go
@@ -34,7 +34,7 @@ func (s *ClassificationAPIServer) handleClassificationMetrics(w http.ResponseWri
 		return
 	}
 
-	response.DecisionCount = len(cfg.AllRoutingDecisions())
+	response.DecisionCount = cfg.CountRoutingDecisions()
 	response.ProjectionPartitionCount = len(cfg.Projections.Partitions)
 	response.ProjectionScoreCount = len(cfg.Projections.Scores)
 	response.ProjectionMappingCount = len(cfg.Projections.Mappings)

--- a/src/semantic-router/pkg/apiserver/route_classification_metrics.go
+++ b/src/semantic-router/pkg/apiserver/route_classification_metrics.go
@@ -34,7 +34,7 @@ func (s *ClassificationAPIServer) handleClassificationMetrics(w http.ResponseWri
 		return
 	}
 
-	response.DecisionCount = len(cfg.Decisions)
+	response.DecisionCount = len(cfg.DefaultDecisions)
 	response.ProjectionPartitionCount = len(cfg.Projections.Partitions)
 	response.ProjectionScoreCount = len(cfg.Projections.Scores)
 	response.ProjectionMappingCount = len(cfg.Projections.Mappings)

--- a/src/semantic-router/pkg/apiserver/route_classification_platform_test.go
+++ b/src/semantic-router/pkg/apiserver/route_classification_platform_test.go
@@ -133,7 +133,7 @@ func TestHandleClassificationMetricsReportsCounts(t *testing.T) {
 						}},
 					}},
 				},
-				Decisions: []config.Decision{{
+				DefaultDecisions: []config.Decision{{
 					Name:      "math_route",
 					ModelRefs: []config.ModelRef{{Model: "qwen-math"}},
 					Rules:     config.RuleCombination{Operator: "AND"},

--- a/src/semantic-router/pkg/apiserver/route_config_deploy_test.go
+++ b/src/semantic-router/pkg/apiserver/route_config_deploy_test.go
@@ -222,7 +222,7 @@ func minimalDeployTestConfig(decisionName string) *config.RouterConfig {
 					CategoryMetadata: config.CategoryMetadata{Name: "math"},
 				}},
 			},
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:     decisionName,
 				Priority: 100,
 				Tier:     1,

--- a/src/semantic-router/pkg/apiserver/route_config_runtime_sync_test.go
+++ b/src/semantic-router/pkg/apiserver/route_config_runtime_sync_test.go
@@ -141,10 +141,10 @@ func assertDeployedDecisionName(t *testing.T, configPath string, want string) {
 	if err != nil {
 		t.Fatalf("parse config %s: %v", configPath, err)
 	}
-	if len(cfg.Decisions) == 0 {
+	if len(cfg.DefaultDecisions) == 0 {
 		t.Fatalf("expected at least one decision in %s", configPath)
 	}
-	if got := cfg.Decisions[0].Name; got != want {
+	if got := cfg.DefaultDecisions[0].Name; got != want {
 		t.Fatalf("decision name in %s = %q, want %q", configPath, got, want)
 	}
 }

--- a/src/semantic-router/pkg/apiserver/route_models_test.go
+++ b/src/semantic-router/pkg/apiserver/route_models_test.go
@@ -134,7 +134,7 @@ func openAIModelsLooperTestConfig() *config.RouterConfig {
 	return &config.RouterConfig{
 		Looper: config.LooperConfig{Endpoint: "http://looper"},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "remom-route",
 					ModelRefs: []config.ModelRef{{Model: "worker-a"}},

--- a/src/semantic-router/pkg/apiserver/runtime_state_test.go
+++ b/src/semantic-router/pkg/apiserver/runtime_state_test.go
@@ -182,7 +182,7 @@ func TestHandleClassifierInfoUsesResolvedRuntimeConfig(t *testing.T) {
 func TestHandleClassifierInfoNormalizesYAMLStylePluginConfig(t *testing.T) {
 	liveCfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "health_decision",
 					Plugins: []config.DecisionPlugin{
@@ -220,6 +220,9 @@ func TestHandleClassifierInfoNormalizesYAMLStylePluginConfig(t *testing.T) {
 
 	resp := decodeJSONObject(t, rr.Body.Bytes())
 	cfgPayload := requireJSONObject(t, resp, "config")
+	// The response key stays `Decisions` across the Go field rename: it is a
+	// published wire contract that e2e/testcases/apiserver_runtime_config_endpoints.go
+	// decodes.
 	decisions := requireJSONArray(t, cfgPayload, "Decisions", 1)
 	decision := requireJSONObjectValue(t, decisions[0], "decision")
 	plugins := requireJSONArray(t, decision, "Plugins", 1)

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -283,7 +283,6 @@ func initMemoryStore(maxRetries int, retryInterval time.Duration) memory.Store {
 	return nil
 }
 
-
 // setupRoutes configures all API routes
 func (s *ClassificationAPIServer) setupRoutes() *http.ServeMux {
 	mux := http.NewServeMux()

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -290,7 +290,7 @@ func shouldInitMemoryStore(cfg *config.RouterConfig) bool {
 	if cfg.Memory.Enabled {
 		return true
 	}
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if decision.HasPlugin("memory") {
 			return true
 		}

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -84,7 +84,7 @@ func InitWithOptions(opts InitOptions) error {
 
 	// Get memory store if available (set by ExtProc router during init)
 	var memoryStore memory.Store
-	if shouldInitMemoryStore(cfg) {
+	if cfg.IsMemoryEnabled() {
 		memoryStore = resolveMemoryStore(cfg, opts.RuntimeRegistry)
 		if memoryStore != nil {
 			logging.ComponentEvent("apiserver", "memory_api_enabled", map[string]interface{}{})
@@ -283,20 +283,6 @@ func initMemoryStore(maxRetries int, retryInterval time.Duration) memory.Store {
 	return nil
 }
 
-func shouldInitMemoryStore(cfg *config.RouterConfig) bool {
-	if cfg == nil {
-		return false
-	}
-	if cfg.Memory.Enabled {
-		return true
-	}
-	for _, decision := range cfg.AllRoutingDecisions() {
-		if decision.HasPlugin("memory") {
-			return true
-		}
-	}
-	return false
-}
 
 // setupRoutes configures all API routes
 func (s *ClassificationAPIServer) setupRoutes() *http.ServeMux {

--- a/src/semantic-router/pkg/apiserver/server.go
+++ b/src/semantic-router/pkg/apiserver/server.go
@@ -290,7 +290,7 @@ func shouldInitMemoryStore(cfg *config.RouterConfig) bool {
 	if cfg.Memory.Enabled {
 		return true
 	}
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if decision.HasPlugin("memory") {
 			return true
 		}

--- a/src/semantic-router/pkg/apiserver/server_memory_test.go
+++ b/src/semantic-router/pkg/apiserver/server_memory_test.go
@@ -51,9 +51,9 @@ func TestShouldInitMemoryStore(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldInitMemoryStore(tt.cfg)
+			got := tt.cfg.IsMemoryEnabled()
 			if got != tt.want {
-				t.Fatalf("shouldInitMemoryStore() = %v, want %v", got, tt.want)
+				t.Fatalf("IsMemoryEnabled() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/src/semantic-router/pkg/apiserver/server_memory_test.go
+++ b/src/semantic-router/pkg/apiserver/server_memory_test.go
@@ -32,7 +32,7 @@ func TestShouldInitMemoryStore(t *testing.T) {
 			cfg: &config.RouterConfig{
 				Memory: config.MemoryConfig{Enabled: false},
 				IntelligentRouting: config.IntelligentRouting{
-					Decisions: []config.Decision{memoryPluginDecision("with-memory-plugin", "memory")},
+					DefaultDecisions: []config.Decision{memoryPluginDecision("with-memory-plugin", "memory")},
 				},
 			},
 			want: true,
@@ -42,7 +42,7 @@ func TestShouldInitMemoryStore(t *testing.T) {
 			cfg: &config.RouterConfig{
 				Memory: config.MemoryConfig{Enabled: false},
 				IntelligentRouting: config.IntelligentRouting{
-					Decisions: []config.Decision{memoryPluginDecision("no-memory-plugin", "pii")},
+					DefaultDecisions: []config.Decision{memoryPluginDecision("no-memory-plugin", "pii")},
 				},
 			},
 			want: false,

--- a/src/semantic-router/pkg/classification/classifier_category_entropy.go
+++ b/src/semantic-router/pkg/classification/classifier_category_entropy.go
@@ -67,7 +67,7 @@ func (c *Classifier) makeReasoningDecisionForKeywordCategory(category string) en
 	normalizedCategory := strings.ToLower(strings.TrimSpace(category))
 	useReasoning := false
 
-	for _, decision := range c.Config.Decisions {
+	for _, decision := range c.Config.DefaultDecisions {
 		if strings.ToLower(decision.Name) == normalizedCategory {
 			// Check if the decision has reasoning enabled in its best model
 			if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
@@ -119,7 +119,7 @@ func (c *Classifier) classifyCategoryWithEntropyInTree(text string) (string, flo
 	// Build decision reasoning map from configuration
 	// Use the best model's reasoning capability for each decision
 	categoryReasoningMap := make(map[string]bool)
-	for _, decision := range c.Config.Decisions {
+	for _, decision := range c.Config.DefaultDecisions {
 		useReasoning := false
 		if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
 			// Use the first (best) model's reasoning capability

--- a/src/semantic-router/pkg/classification/classifier_category_entropy.go
+++ b/src/semantic-router/pkg/classification/classifier_category_entropy.go
@@ -67,7 +67,7 @@ func (c *Classifier) makeReasoningDecisionForKeywordCategory(category string) en
 	normalizedCategory := strings.ToLower(strings.TrimSpace(category))
 	useReasoning := false
 
-	for _, decision := range c.Config.DefaultDecisions {
+	for _, decision := range c.Config.AllRoutingDecisions() {
 		if strings.ToLower(decision.Name) == normalizedCategory {
 			// Check if the decision has reasoning enabled in its best model
 			if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
@@ -119,7 +119,7 @@ func (c *Classifier) classifyCategoryWithEntropyInTree(text string) (string, flo
 	// Build decision reasoning map from configuration
 	// Use the best model's reasoning capability for each decision
 	categoryReasoningMap := make(map[string]bool)
-	for _, decision := range c.Config.DefaultDecisions {
+	for _, decision := range c.Config.AllRoutingDecisions() {
 		useReasoning := false
 		if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
 			// Use the first (best) model's reasoning capability

--- a/src/semantic-router/pkg/classification/classifier_category_entropy.go
+++ b/src/semantic-router/pkg/classification/classifier_category_entropy.go
@@ -63,11 +63,13 @@ func (c *Classifier) tryKeywordBasedClassification(text string) (string, float64
 
 // makeReasoningDecisionForKeywordCategory creates a reasoning decision for keyword-matched categories
 func (c *Classifier) makeReasoningDecisionForKeywordCategory(category string) entropy.ReasoningDecision {
-	// Find the decision configuration
+	// Find the decision configuration. Default profile only: this serves the
+	// classify API, whose decision engine evaluates the default profile, so a
+	// named recipe's use_reasoning must not leak into its lookup space.
 	normalizedCategory := strings.ToLower(strings.TrimSpace(category))
 	useReasoning := false
 
-	for _, decision := range c.Config.AllRoutingDecisions() {
+	for _, decision := range c.Config.DefaultDecisions {
 		if strings.ToLower(decision.Name) == normalizedCategory {
 			// Check if the decision has reasoning enabled in its best model
 			if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
@@ -117,9 +119,10 @@ func (c *Classifier) classifyCategoryWithEntropyInTree(text string) (string, flo
 	}
 
 	// Build decision reasoning map from configuration
-	// Use the best model's reasoning capability for each decision
+	// Use the best model's reasoning capability for each decision.
+	// Default profile only: same scope as the classify API's decision engine.
 	categoryReasoningMap := make(map[string]bool)
-	for _, decision := range c.Config.AllRoutingDecisions() {
+	for _, decision := range c.Config.DefaultDecisions {
 		useReasoning := false
 		if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
 			// Use the first (best) model's reasoning capability

--- a/src/semantic-router/pkg/classification/classifier_domain_test.go
+++ b/src/semantic-router/pkg/classification/classifier_domain_test.go
@@ -39,7 +39,7 @@ func domainTestConfig() *config.RouterConfig {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "test_domain_decision",
 					Rules: config.RuleCombination{

--- a/src/semantic-router/pkg/classification/classifier_lifecycle_test.go
+++ b/src/semantic-router/pkg/classification/classifier_lifecycle_test.go
@@ -171,7 +171,7 @@ func TestInitializeRuntimeSkipsUnusedCoreSignalClassifiers(t *testing.T) {
 				},
 			},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{{
+				DefaultDecisions: []config.Decision{{
 					Name:  "default",
 					Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{}},
 				}},
@@ -217,7 +217,7 @@ func TestInitializeRuntimeInitializesCoreSignalClassifiersWhenUsed(t *testing.T)
 				},
 			},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{{
+				DefaultDecisions: []config.Decision{{
 					Name: "guarded-route",
 					Rules: config.RuleNode{Operator: "OR", Conditions: []config.RuleNode{
 						{Type: config.SignalTypeDomain, Name: "billing"},

--- a/src/semantic-router/pkg/classification/classifier_model_select.go
+++ b/src/semantic-router/pkg/classification/classifier_model_select.go
@@ -2,7 +2,6 @@ package classification
 
 import (
 	"slices"
-	"strings"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -29,12 +28,9 @@ func (c *Classifier) SelectBestModelForCategory(categoryName string) string {
 
 // findDecision finds the decision configuration by name (case-insensitive)
 func (c *Classifier) findDecision(decisionName string) *config.Decision {
-	for i, decision := range c.Config.DefaultDecisions {
-		if strings.EqualFold(decision.Name, decisionName) {
-			return &c.Config.DefaultDecisions[i]
-		}
-	}
-	return nil
+	// Searches every recipe: the selected decision can come from any routing
+	// profile, not just the default one.
+	return c.Config.GetDecisionByNameFold(decisionName)
 }
 
 // GetDecisionByName returns the decision configuration by name (case-insensitive)
@@ -120,17 +116,16 @@ func (c *Classifier) SelectBestModelFromList(candidateModels []string, categoryN
 func (c *Classifier) GetModelsForCategory(categoryName string) []string {
 	var models []string
 
-	for _, decision := range c.Config.DefaultDecisions {
-		if strings.EqualFold(decision.Name, categoryName) {
-			for _, modelRef := range decision.ModelRefs {
-				// Use LoRA name if specified, otherwise use the base model name
-				if modelRef.LoRAName != "" {
-					models = append(models, modelRef.LoRAName)
-				} else {
-					models = append(models, modelRef.Model)
-				}
-			}
-			break
+	decision := c.Config.GetDecisionByNameFold(categoryName)
+	if decision == nil {
+		return models
+	}
+	for _, modelRef := range decision.ModelRefs {
+		// Use LoRA name if specified, otherwise use the base model name
+		if modelRef.LoRAName != "" {
+			models = append(models, modelRef.LoRAName)
+		} else {
+			models = append(models, modelRef.Model)
 		}
 	}
 

--- a/src/semantic-router/pkg/classification/classifier_model_select.go
+++ b/src/semantic-router/pkg/classification/classifier_model_select.go
@@ -29,9 +29,9 @@ func (c *Classifier) SelectBestModelForCategory(categoryName string) string {
 
 // findDecision finds the decision configuration by name (case-insensitive)
 func (c *Classifier) findDecision(decisionName string) *config.Decision {
-	for i, decision := range c.Config.Decisions {
+	for i, decision := range c.Config.DefaultDecisions {
 		if strings.EqualFold(decision.Name, decisionName) {
-			return &c.Config.Decisions[i]
+			return &c.Config.DefaultDecisions[i]
 		}
 	}
 	return nil
@@ -120,7 +120,7 @@ func (c *Classifier) SelectBestModelFromList(candidateModels []string, categoryN
 func (c *Classifier) GetModelsForCategory(categoryName string) []string {
 	var models []string
 
-	for _, decision := range c.Config.Decisions {
+	for _, decision := range c.Config.DefaultDecisions {
 		if strings.EqualFold(decision.Name, categoryName) {
 			for _, modelRef := range decision.ModelRefs {
 				// Use LoRA name if specified, otherwise use the base model name

--- a/src/semantic-router/pkg/classification/classifier_model_select.go
+++ b/src/semantic-router/pkg/classification/classifier_model_select.go
@@ -116,7 +116,7 @@ func (c *Classifier) SelectBestModelFromList(candidateModels []string, categoryN
 func (c *Classifier) GetModelsForCategory(categoryName string) []string {
 	var models []string
 
-	decision := c.Config.GetDecisionByNameFold(categoryName)
+	decision := c.findDecision(categoryName)
 	if decision == nil {
 		return models
 	}

--- a/src/semantic-router/pkg/classification/classifier_signal_decision.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_decision.go
@@ -28,6 +28,9 @@ func (c *Classifier) EvaluateDecisionWithEngineAndTrace(signals *SignalResults) 
 }
 
 func (c *Classifier) evaluateDecisionInternal(signals *SignalResults, trace bool, candidates []config.Decision) (*decision.DecisionResult, []decision.DecisionTrace, error) {
+	// A nil candidate set means "no per-request recipe scope", which is the
+	// default profile's decisions; extproc passes an explicit set once an
+	// entrypoint selects a recipe.
 	decisions := c.Config.DefaultDecisions
 	if candidates != nil {
 		decisions = candidates

--- a/src/semantic-router/pkg/classification/classifier_signal_decision.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_decision.go
@@ -28,7 +28,7 @@ func (c *Classifier) EvaluateDecisionWithEngineAndTrace(signals *SignalResults) 
 }
 
 func (c *Classifier) evaluateDecisionInternal(signals *SignalResults, trace bool, candidates []config.Decision) (*decision.DecisionResult, []decision.DecisionTrace, error) {
-	decisions := c.Config.Decisions
+	decisions := c.Config.DefaultDecisions
 	if candidates != nil {
 		decisions = candidates
 	}

--- a/src/semantic-router/pkg/classification/classifier_signal_decision_test.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_decision_test.go
@@ -20,7 +20,7 @@ func TestEvaluateDecisionWithEngineForDecisionsRestrictsCandidates(t *testing.T)
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
 				Strategy: "priority",
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:     "static-business",
 						Priority: 100,

--- a/src/semantic-router/pkg/classification/classifier_signal_groups_test.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_groups_test.go
@@ -96,7 +96,7 @@ func TestSignalGroupDefaultFallbackMatchesDomainRouteWhenNoGroupMemberFires(t *t
 						Default:     "other",
 					}},
 				},
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:     "other-route",
 						Priority: 100,
@@ -148,7 +148,7 @@ func TestSignalGroupDefaultFallbackMatchesEmbeddingRouteWhenNoGroupMemberFires(t
 						Default:     "cooking",
 					}},
 				},
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:     "cooking-route",
 						Priority: 100,
@@ -270,7 +270,7 @@ func TestAnalyzeSoftmaxSignalGroupCentroidsWarnsOnSimilarMembers(t *testing.T) {
 
 func buildGroupedDomainClassifier(mock *MockCategoryInference) *Classifier {
 	cfg := domainTestConfig()
-	cfg.Decisions = []config.Decision{
+	cfg.DefaultDecisions = []config.Decision{
 		{
 			Name:     "health-route",
 			Priority: 200,
@@ -336,7 +336,7 @@ func buildGroupedEmbeddingClassifier(t *testing.T) *Classifier {
 						Default:     "cooking",
 					}},
 				},
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:     "programming-route",
 						Priority: 200,

--- a/src/semantic-router/pkg/classification/legacy_factory_test.go
+++ b/src/semantic-router/pkg/classification/legacy_factory_test.go
@@ -50,7 +50,7 @@ func TestNewLegacyClassifierFromConfigRequiresUsedCoreSignalMappings(t *testing.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := newLegacyClassifierMappingGateConfig(t)
-			cfg.Decisions = []config.Decision{{
+			cfg.DefaultDecisions = []config.Decision{{
 				Name: "guarded-route",
 				Rules: config.RuleNode{Operator: "OR", Conditions: []config.RuleNode{
 					tt.rule,
@@ -87,7 +87,7 @@ func newLegacyClassifierMappingGateConfig(t *testing.T) *config.RouterConfig {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:  "default-route",
 				Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{}},
 			}},

--- a/src/semantic-router/pkg/classification/mcp_classifier_runtime.go
+++ b/src/semantic-router/pkg/classification/mcp_classifier_runtime.go
@@ -139,8 +139,9 @@ func (c *Classifier) mcpCategoryNames(probabilities []float32) []string {
 }
 
 func (c *Classifier) makeMCPReasoningDecision(probabilities []float32, categoryNames []string) (entropy.ReasoningDecision, float64) {
+	// Default profile only: same scope as the classify API's decision engine.
 	categoryReasoningMap := make(map[string]bool)
-	for _, decision := range c.Config.AllRoutingDecisions() {
+	for _, decision := range c.Config.DefaultDecisions {
 		useReasoning := false
 		if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
 			useReasoning = *decision.ModelRefs[0].UseReasoning

--- a/src/semantic-router/pkg/classification/mcp_classifier_runtime.go
+++ b/src/semantic-router/pkg/classification/mcp_classifier_runtime.go
@@ -140,7 +140,7 @@ func (c *Classifier) mcpCategoryNames(probabilities []float32) []string {
 
 func (c *Classifier) makeMCPReasoningDecision(probabilities []float32, categoryNames []string) (entropy.ReasoningDecision, float64) {
 	categoryReasoningMap := make(map[string]bool)
-	for _, decision := range c.Config.Decisions {
+	for _, decision := range c.Config.DefaultDecisions {
 		useReasoning := false
 		if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
 			useReasoning = *decision.ModelRefs[0].UseReasoning

--- a/src/semantic-router/pkg/classification/mcp_classifier_runtime.go
+++ b/src/semantic-router/pkg/classification/mcp_classifier_runtime.go
@@ -140,7 +140,7 @@ func (c *Classifier) mcpCategoryNames(probabilities []float32) []string {
 
 func (c *Classifier) makeMCPReasoningDecision(probabilities []float32, categoryNames []string) (entropy.ReasoningDecision, float64) {
 	categoryReasoningMap := make(map[string]bool)
-	for _, decision := range c.Config.DefaultDecisions {
+	for _, decision := range c.Config.AllRoutingDecisions() {
 		useReasoning := false
 		if len(decision.ModelRefs) > 0 && decision.ModelRefs[0].UseReasoning != nil {
 			useReasoning = *decision.ModelRefs[0].UseReasoning

--- a/src/semantic-router/pkg/classification/signal_skip_test.go
+++ b/src/semantic-router/pkg/classification/signal_skip_test.go
@@ -12,7 +12,7 @@ func signalSkipClassifier(decisions ...config.Decision) *classification.Classifi
 	return &classification.Classifier{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: decisions,
+				DefaultDecisions: decisions,
 			},
 		},
 	}

--- a/src/semantic-router/pkg/config/canonical_config.go
+++ b/src/semantic-router/pkg/config/canonical_config.go
@@ -108,9 +108,9 @@ func normalizeCanonicalConfig(canonical *CanonicalConfig) (*RouterConfig, error)
 
 func applyCanonicalRoutingState(cfg *RouterConfig, canonical *CanonicalConfig) {
 	cfg.Listeners = append([]Listener(nil), canonical.Listeners...)
-	cfg.Decisions = copyDecisions(canonical.Routing.Decisions)
-	ensureModelRefDefaults(cfg.Decisions)
-	cfg.Signals = normalizeSignals(canonical.Routing.Signals, cfg.Decisions)
+	cfg.DefaultDecisions = copyDecisions(canonical.Routing.Decisions)
+	ensureModelRefDefaults(cfg.DefaultDecisions)
+	cfg.Signals = normalizeSignals(canonical.Routing.Signals, cfg.DefaultDecisions)
 	cfg.Projections = normalizeProjections(canonical.Routing.Projections)
 	cfg.ModelConfig = make(map[string]ModelParams)
 

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -53,7 +53,7 @@ func CanonicalRoutingFromRouterConfig(cfg *RouterConfig) CanonicalRouting {
 		ModelCards:  routingModelsFromRouterConfig(cfg),
 		Signals:     canonicalSignalsFromSignals(cfg.RoutingProfileSignals()),
 		Projections: canonicalProjectionsFromProjections(cfg.RoutingProfileProjections()),
-		Decisions:   copyDecisions(cfg.Decisions),
+		Decisions:   copyDecisions(cfg.DefaultDecisions),
 	}
 }
 
@@ -93,7 +93,7 @@ func routingModelsFromRouterConfig(cfg *RouterConfig) []RoutingModel {
 	for name := range cfg.ModelConfig {
 		modelNames[name] = true
 	}
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		for _, ref := range decision.ModelRefs {
 			if ref.Model != "" {
 				modelNames[ref.Model] = true

--- a/src/semantic-router/pkg/config/canonical_export.go
+++ b/src/semantic-router/pkg/config/canonical_export.go
@@ -93,7 +93,9 @@ func routingModelsFromRouterConfig(cfg *RouterConfig) []RoutingModel {
 	for name := range cfg.ModelConfig {
 		modelNames[name] = true
 	}
-	for _, decision := range cfg.DefaultDecisions {
+	// The model catalog is shared across recipes, so every profile's model
+	// references must survive the round trip, not just the default one's.
+	for _, decision := range cfg.AllRoutingDecisions() {
 		for _, ref := range decision.ModelRefs {
 			if ref.Model != "" {
 				modelNames[ref.Model] = true

--- a/src/semantic-router/pkg/config/canonical_loader_test.go
+++ b/src/semantic-router/pkg/config/canonical_loader_test.go
@@ -828,7 +828,7 @@ routing:
 	if loras[0].Name != "sql-expert" || loras[0].Description != "SQL-specialized adapter" {
 		t.Fatalf("unexpected first LoRA adapter: %#v", loras[0])
 	}
-	if cfg.Decisions[0].ModelRefs[0].LoRAName != "sql-expert" {
-		t.Fatalf("expected lora_name to survive parse, got %q", cfg.Decisions[0].ModelRefs[0].LoRAName)
+	if cfg.DefaultDecisions[0].ModelRefs[0].LoRAName != "sql-expert" {
+		t.Fatalf("expected lora_name to survive parse, got %q", cfg.DefaultDecisions[0].ModelRefs[0].LoRAName)
 	}
 }

--- a/src/semantic-router/pkg/config/canonical_recipes.go
+++ b/src/semantic-router/pkg/config/canonical_recipes.go
@@ -85,23 +85,35 @@ func applyCanonicalRecipeState(cfg *RouterConfig, canonical *CanonicalConfig) er
 // validateDecisionNamesAcrossRecipes rejects a decision name declared by more
 // than one profile. Everything that keys on the bare decision name at runtime
 // (x-vsr-selected-decision, metrics, plugin lookups) would silently attribute
-// one recipe's decision to another's.
+// one recipe's decision to another's. Across profiles the check folds case:
+// GetDecisionByNameFold matches loosely, so two profiles declaring names that
+// differ only by case would alias each other there. Within one profile the
+// exact rule is unchanged.
 func validateDecisionNamesAcrossRecipes(recipes []RoutingRecipe) error {
 	owners := make(map[string]string)
+	foldOwners := make(map[string]string)
 	for _, recipe := range recipes {
 		for _, decision := range recipe.Decisions {
-			owner, exists := owners[decision.Name]
-			if !exists {
-				owners[decision.Name] = recipe.Name
-				continue
+			if owner, exists := owners[decision.Name]; exists {
+				if owner == recipe.Name {
+					return fmt.Errorf("recipes[%s]: duplicate decision name %q", recipe.Name, decision.Name)
+				}
+				return fmt.Errorf(
+					"recipes: decision %q is defined by both the %q and %q profiles; decision names are global (headers, metrics, plugin lookups), rename one",
+					decision.Name, owner, recipe.Name,
+				)
 			}
-			if owner == recipe.Name {
-				return fmt.Errorf("recipes[%s]: duplicate decision name %q", recipe.Name, decision.Name)
+			owners[decision.Name] = recipe.Name
+			folded := strings.ToLower(decision.Name)
+			if foldOwner, exists := foldOwners[folded]; exists && foldOwner != recipe.Name {
+				return fmt.Errorf(
+					"recipes: decision %q in the %q profile differs only by case from a decision in the %q profile; by-name lookups fold case, rename one",
+					decision.Name, recipe.Name, foldOwner,
+				)
 			}
-			return fmt.Errorf(
-				"recipes: decision %q is defined by both the %q and %q profiles; decision names are global (headers, metrics, plugin lookups), rename one",
-				decision.Name, owner, recipe.Name,
-			)
+			if _, exists := foldOwners[folded]; !exists {
+				foldOwners[folded] = recipe.Name
+			}
 		}
 	}
 	return nil

--- a/src/semantic-router/pkg/config/canonical_recipes.go
+++ b/src/semantic-router/pkg/config/canonical_recipes.go
@@ -46,14 +46,14 @@ func applyCanonicalRecipeState(cfg *RouterConfig, canonical *CanonicalConfig) er
 	if explicitDefault := findRecipe(recipes, DefaultRecipeName); explicitDefault != nil {
 		// Recipes-only layout: bridge the explicit default recipe into the
 		// flat decisions so existing single-profile read sites keep working.
-		cfg.Decisions = explicitDefault.Decisions
+		cfg.DefaultDecisions = explicitDefault.Decisions
 	} else {
 		// The top-level routing profile is the default recipe.
 		recipes = append([]RoutingRecipe{{
 			Name:        DefaultRecipeName,
 			Signals:     cfg.Signals,
 			Projections: cfg.Projections,
-			Decisions:   cfg.Decisions,
+			Decisions:   cfg.DefaultDecisions,
 		}}, recipes...)
 	}
 	cfg.Recipes = recipes

--- a/src/semantic-router/pkg/config/canonical_recipes_global_names_test.go
+++ b/src/semantic-router/pkg/config/canonical_recipes_global_names_test.go
@@ -161,6 +161,36 @@ recipes:
 	}
 }
 
+func TestCaseAliasedDecisionNameAcrossRecipesRejected(t *testing.T) {
+	yamlConfig := recipeTestBaseYAML + `
+recipes:
+  - name: privacy
+    routing:
+      signals:
+        keywords:
+          - name: pii_keywords
+            operator: OR
+            keywords: ["ssn"]
+      decisions:
+        - name: Default_Route
+          rules:
+            operator: AND
+            conditions:
+              - type: keyword
+                name: pii_keywords
+          modelRefs:
+            - model: model-b
+              use_reasoning: false
+`
+	_, err := ParseYAMLBytes([]byte(yamlConfig))
+	if err == nil {
+		t.Fatal("expected a case-aliased decision name across recipes to be rejected: GetDecisionByNameFold would treat the two as one")
+	}
+	if !strings.Contains(err.Error(), `differs only by case`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEntrypointNameCollisionsRejected(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/src/semantic-router/pkg/config/canonical_recipes_global_names_test.go
+++ b/src/semantic-router/pkg/config/canonical_recipes_global_names_test.go
@@ -57,8 +57,8 @@ func TestRecipesOnlyConfigKeepsDecisionsReachable(t *testing.T) {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(cfg.Decisions) != 0 {
-		t.Fatalf("expected no flat decisions in a recipes-only config, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 0 {
+		t.Fatalf("expected no flat decisions in a recipes-only config, got %d", len(cfg.DefaultDecisions))
 	}
 	if !cfg.HasRoutingDecisions() {
 		t.Fatal("HasRoutingDecisions must see decisions living in non-default recipes")

--- a/src/semantic-router/pkg/config/canonical_recipes_test.go
+++ b/src/semantic-router/pkg/config/canonical_recipes_test.go
@@ -170,8 +170,8 @@ providers:
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 
-	if len(cfg.Decisions) != 1 || cfg.Decisions[0].Name != "recipe_default_route" {
-		t.Fatalf("expected the explicit default recipe to bridge into the flat routing fields, got %+v", cfg.Decisions)
+	if len(cfg.DefaultDecisions) != 1 || cfg.DefaultDecisions[0].Name != "recipe_default_route" {
+		t.Fatalf("expected the explicit default recipe to bridge into the flat routing fields, got %+v", cfg.DefaultDecisions)
 	}
 	if len(cfg.Recipes) != 1 || cfg.Recipes[0].Name != DefaultRecipeName {
 		t.Fatalf("expected a single default recipe, got %+v", cfg.Recipes)

--- a/src/semantic-router/pkg/config/canonical_recipes_test.go
+++ b/src/semantic-router/pkg/config/canonical_recipes_test.go
@@ -132,8 +132,10 @@ func TestCanonicalEntrypointsResolveDefaultRecipeAlias(t *testing.T) {
 	}
 }
 
-func TestCanonicalRecipesOnlyDefaultBridgesFlatFields(t *testing.T) {
-	yaml := `
+// recipeTestRecipesOnlyYAML declares every decision inside an explicit
+// default recipe, with no top-level routing profile. Shared by the bridge
+// test below and the mirror invariant in recipes_invariant_test.go.
+const recipeTestRecipesOnlyYAML = `
 version: v0.3
 routing:
   modelCards:
@@ -165,7 +167,9 @@ providers:
       backend_refs:
         - endpoint: 127.0.0.1:8000
 `
-	cfg, err := ParseYAMLBytes([]byte(yaml))
+
+func TestCanonicalRecipesOnlyDefaultBridgesFlatFields(t *testing.T) {
+	cfg, err := ParseYAMLBytes([]byte(recipeTestRecipesOnlyYAML))
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}

--- a/src/semantic-router/pkg/config/canonical_routing_loader.go
+++ b/src/semantic-router/pkg/config/canonical_routing_loader.go
@@ -28,9 +28,9 @@ func ParseRoutingYAMLBytes(data []byte) (*RouterConfig, error) {
 	}
 
 	cfg := DefaultGlobalConfig()
-	cfg.Decisions = copyDecisions(doc.Routing.Decisions)
-	ensureModelRefDefaults(cfg.Decisions)
-	cfg.Signals = normalizeSignals(doc.Routing.Signals, cfg.Decisions)
+	cfg.DefaultDecisions = copyDecisions(doc.Routing.Decisions)
+	ensureModelRefDefaults(cfg.DefaultDecisions)
+	cfg.Signals = normalizeSignals(doc.Routing.Signals, cfg.DefaultDecisions)
 	cfg.Projections = normalizeProjections(doc.Routing.Projections)
 	cfg.ModelConfig = make(map[string]ModelParams)
 

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -206,13 +206,28 @@ type InlineModels struct {
 }
 
 // IntelligentRouting captures user-facing signal and decision configuration.
+//
+// Signals and Projections are the GLOBAL registries: the union of every
+// recipe's rules, so the single classifier built at startup can evaluate any
+// recipe's decisions (issue #2331 keeps the signal registry global).
+// DefaultDecisions, by contrast, holds ONLY the default recipe's decisions.
+// Code that reasons about routing as a whole — plugin enablement, contract
+// validation, decision lookup by name, metrics — must read
+// RouterConfig.AllRoutingDecisions() or GetDecisionByName() instead, or it
+// silently ignores every non-default recipe.
 type IntelligentRouting struct {
-	Signals         `yaml:",inline"`
-	Projections     Projections          `yaml:"projections,omitempty"`
-	Decisions       []Decision           `yaml:"decisions,omitempty"`
-	Strategy        string               `yaml:"strategy,omitempty"`
-	ModelSelection  ModelSelectionConfig `yaml:"model_selection,omitempty"`
-	ReasoningConfig `yaml:",inline"`
+	Signals     `yaml:",inline"`
+	Projections Projections `yaml:"projections,omitempty"`
+	// DefaultDecisions mirrors the default recipe's decisions. The yaml tag
+	// stays `decisions` so the flat DSL emitters and the legacy
+	// modelselection analyzer keep round-tripping unchanged. The json tag
+	// pins the `/info/classifier` response key, which apiserver derives from
+	// the Go field name when no tag is present — the rename must not move a
+	// published wire key.
+	DefaultDecisions []Decision           `yaml:"decisions,omitempty" json:"Decisions"`
+	Strategy         string               `yaml:"strategy,omitempty"`
+	ModelSelection   ModelSelectionConfig `yaml:"model_selection,omitempty"`
+	ReasoningConfig  `yaml:",inline"`
 }
 
 // BackendModels captures configured backend endpoints and model metadata.

--- a/src/semantic-router/pkg/config/config_test.go
+++ b/src/semantic-router/pkg/config/config_test.go
@@ -270,10 +270,10 @@ tools:
 				Expect(cfg.Categories[0].Name).To(Equal("general"))
 
 				// Verify decisions
-				Expect(cfg.Decisions).To(HaveLen(1))
-				Expect(cfg.Decisions[0].Name).To(Equal("general"))
-				Expect(cfg.Decisions[0].ModelRefs).To(HaveLen(1))
-				Expect(cfg.Decisions[0].ModelRefs[0].Model).To(Equal("model-a"))
+				Expect(cfg.DefaultDecisions).To(HaveLen(1))
+				Expect(cfg.DefaultDecisions[0].Name).To(Equal("general"))
+				Expect(cfg.DefaultDecisions[0].ModelRefs).To(HaveLen(1))
+				Expect(cfg.DefaultDecisions[0].ModelRefs[0].Model).To(Equal("model-a"))
 
 				// Verify default model
 				Expect(cfg.DefaultModel).To(Equal("model-b"))
@@ -2354,7 +2354,7 @@ default_model: "test-model"
 						Enabled: true, // Global enabled, but should not affect decisions without plugin
 					},
 					IntelligentRouting: IntelligentRouting{
-						Decisions: []Decision{decision},
+						DefaultDecisions: []Decision{decision},
 					},
 				}
 
@@ -2381,7 +2381,7 @@ default_model: "test-model"
 						Enabled: true,
 					},
 					IntelligentRouting: IntelligentRouting{
-						Decisions: []Decision{decision},
+						DefaultDecisions: []Decision{decision},
 					},
 				}
 
@@ -2407,7 +2407,7 @@ default_model: "test-model"
 						Enabled: false, // Global disabled, but decision enables it
 					},
 					IntelligentRouting: IntelligentRouting{
-						Decisions: []Decision{decision},
+						DefaultDecisions: []Decision{decision},
 					},
 				}
 
@@ -2447,7 +2447,7 @@ default_model: "test-model"
 						SimilarityThreshold: &globalThreshold,
 					},
 					IntelligentRouting: IntelligentRouting{
-						Decisions: []Decision{decision},
+						DefaultDecisions: []Decision{decision},
 					},
 				}
 
@@ -2477,7 +2477,7 @@ default_model: "test-model"
 						TTLSeconds: 3600, // Global TTL
 					},
 					IntelligentRouting: IntelligentRouting{
-						Decisions: []Decision{decision},
+						DefaultDecisions: []Decision{decision},
 					},
 				}
 

--- a/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
+++ b/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
@@ -48,6 +48,7 @@ var defaultDecisionsAllowlist = map[string]string{
 	"src/semantic-router/pkg/extproc/req_filter_fusion.go":                  "algorithm slugs resolve against the default profile only",
 	"src/semantic-router/pkg/extproc/req_filter_classification_runtime.go":  "authz scope for requests without an entrypoint recipe",
 	"src/semantic-router/pkg/extproc/router_selection.go":                   "first-match into the process-level selector singleton must not depend on recipe declaration order",
+	"src/semantic-router/pkg/extproc/router_learning_adaptation.go":         "tier candidates follow the request's decision scope, default profile for unscoped requests",
 	"src/semantic-router/pkg/classification/classifier_signal_decision.go":  "default candidate set for unscoped requests",
 	"src/semantic-router/pkg/classification/classifier_category_entropy.go": "reasoning maps serve the classify API, same scope as its decision engine",
 	"src/semantic-router/pkg/classification/mcp_classifier_runtime.go":      "reasoning map serves the classify API, same scope as its decision engine",

--- a/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
+++ b/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// defaultDecisionsAllowlist is the complete set of production files that may
+// reference the flat DefaultDecisions field. The field holds only the default
+// routing profile; code that reasons about routing as a whole must use
+// AllRoutingDecisions() or GetDecisionByName() instead (#2723 catalogues the
+// read sites that silently ignored named recipes by picking this field).
+//
+// To add a file here, first decide the scope question the entry comment must
+// answer: why is the default profile — and not the whole routing surface —
+// the right thing for that site to read or write?
+var defaultDecisionsAllowlist = map[string]string{
+	// Field declaration.
+	"src/semantic-router/pkg/config/config.go": "declares the field",
+
+	// Loaders and serializers: the field IS their storage for the top-level
+	// routing: block, kept aliased with the default recipe.
+	"src/semantic-router/pkg/config/canonical_config.go":         "loader writes the normalized top-level routing block",
+	"src/semantic-router/pkg/config/canonical_recipes.go":        "loader keeps the field and the default recipe aliased",
+	"src/semantic-router/pkg/config/canonical_routing_loader.go": "fragment loader writes the top-level routing block",
+	"src/semantic-router/pkg/config/canonical_export.go":         "export re-emits the field as the top-level routing block",
+	"src/semantic-router/pkg/dsl/compiler_routes.go":             "DSL compiler builds the default profile",
+	"src/semantic-router/pkg/dsl/decompiler.go":                  "DSL decompiles the default profile; named recipes have no DSL surface yet",
+	"src/semantic-router/pkg/dsl/decompiler_decisions.go":        "DSL decompiles the default profile; named recipes have no DSL surface yet",
+	"src/semantic-router/pkg/dsl/routing_contract.go":            "DSL contract walks the default profile it decompiles",
+
+	// Whole-surface accessors implemented inside pkg/config: they treat the
+	// flat field as the default recipe's storage and add the named recipes.
+	"src/semantic-router/pkg/config/recipes.go": "AllRoutingDecisions/HasRoutingDecisions fall back to the field for configs built without the canonical loader",
+	"src/semantic-router/pkg/config/helper.go":  "findDecisionBy scans the field as the default-profile portion; GetModelForDecisionIndex is by-index, only meaningful within one profile",
+
+	// Deliberate default-profile reads. Algorithm virtual slugs select
+	// decisions without consulting the entrypoint table, so widening them
+	// would let a recipe's decisions be selected without going through that
+	// recipe's entrypoint; HasXDecision gates whether /v1/models advertises
+	// the slug, and advertising one that cannot route would be a lie.
+	"src/semantic-router/pkg/config/fusion_config.go":                      "HasFusionDecision gates the fusion slug in /v1/models",
+	"src/semantic-router/pkg/config/remom_config.go":                       "HasReMoMDecision gates the remom slug in /v1/models",
+	"src/semantic-router/pkg/config/workflows_config.go":                   "HasFlowDecision gates the flow slug in /v1/models",
+	"src/semantic-router/pkg/extproc/req_filter_fusion.go":                 "algorithm slugs resolve against the default profile only",
+	"src/semantic-router/pkg/extproc/req_filter_classification_runtime.go": "authz scope for requests without an entrypoint recipe",
+	"src/semantic-router/pkg/classification/classifier_signal_decision.go": "default candidate set for unscoped requests",
+	"src/semantic-router/pkg/services/classification.go":                   "gate matches EvaluateDecisionWithEngine's default scope",
+	"src/semantic-router/pkg/services/classification_signal_contract.go":   "gate matches EvaluateDecisionWithEngine's default scope",
+
+	// Known limitation: the dashboard topology test-query panel replays the
+	// default profile's rules and does not model recipe scoping yet.
+	"dashboard/backend/handlers/topology_response.go": "topology test-query panel does not model recipe scoping yet",
+}
+
+// TestDefaultDecisionsReadSitesAreAllowlisted walks every production Go file
+// in the repository (all modules) and fails when a file references the flat
+// DefaultDecisions field without an allowlist entry, or when an entry goes
+// stale. A new site must either switch to a whole-surface accessor or state
+// its scope rationale here, in front of the reviewer.
+func TestDefaultDecisionsReadSitesAreAllowlisted(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(repoRoot, ".git")); statErr != nil {
+		t.Fatalf("repo root %s does not look like a git checkout: %v", repoRoot, statErr)
+	}
+
+	found := scanDefaultDecisionsReferences(t, repoRoot)
+
+	var offenders, stale []string
+	for rel := range found {
+		if _, ok := defaultDecisionsAllowlist[rel]; !ok {
+			offenders = append(offenders, rel)
+		}
+	}
+	for rel := range defaultDecisionsAllowlist {
+		if !found[rel] {
+			stale = append(stale, rel)
+		}
+	}
+	sort.Strings(offenders)
+	sort.Strings(stale)
+
+	if len(offenders) > 0 {
+		t.Errorf("files reference the flat DefaultDecisions field without an allowlist entry:\n  %s\n\n"+
+			"DefaultDecisions holds only the default routing profile. If the site reasons about routing as a whole, "+
+			"use AllRoutingDecisions() or GetDecisionByName(); if the default-profile scope is intended, add the file "+
+			"to defaultDecisionsAllowlist with a comment saying why.", strings.Join(offenders, "\n  "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("stale defaultDecisionsAllowlist entries (file gone or no longer references the field), remove them:\n  %s",
+			strings.Join(stale, "\n  "))
+	}
+}
+
+// scanDefaultDecisionsReferences returns the repo-relative paths of every
+// production Go file, across all modules, that mentions DefaultDecisions.
+func scanDefaultDecisionsReferences(t *testing.T, repoRoot string) map[string]bool {
+	t.Helper()
+	found := map[string]bool{}
+	walkErr := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			skip := (strings.HasPrefix(d.Name(), ".") && path != repoRoot) || d.Name() == "node_modules"
+			if skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if !strings.Contains(string(content), "DefaultDecisions") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		found[filepath.ToSlash(rel)] = true
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking repo: %v", walkErr)
+	}
+	return found
+}

--- a/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
+++ b/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"sort"
@@ -61,18 +62,35 @@ var defaultDecisionsAllowlist = map[string]string{
 	"dashboard/backend/handlers/topology_response.go": "topology test-query panel does not model recipe scoping yet",
 }
 
+// defaultDecisionsSpellings are the source spellings that read the default
+// routing profile. DefaultRecipe() is listed alongside the field because
+// rewriting a read site from cfg.DefaultDecisions to
+// cfg.DefaultRecipe().Decisions is semantically identical and would otherwise
+// silence this guard for free.
+//
+// Deliberately NOT listed: ".Recipes[" and a bare "DefaultRecipeName". Both
+// match the sanctioned whole-surface pattern (AllRoutingDecisions iterates
+// c.Recipes[i]) and the deliberate per-request resolver
+// (req_filter_entrypoint.go), so they would flag correct code and force
+// entries that cannot answer this allowlist's scope question.
+var defaultDecisionsSpellings = [][]byte{
+	[]byte("DefaultDecisions"),
+	[]byte("DefaultRecipe()"),
+}
+
 // TestDefaultDecisionsReadSitesAreAllowlisted walks every production Go file
 // in the repository (all modules) and fails when a file references the flat
 // DefaultDecisions field without an allowlist entry, or when an entry goes
 // stale. A new site must either switch to a whole-surface accessor or state
 // its scope rationale here, in front of the reviewer.
 func TestDefaultDecisionsReadSitesAreAllowlisted(t *testing.T) {
-	repoRoot, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
-	if err != nil {
-		t.Fatalf("resolving repo root: %v", err)
-	}
-	if _, statErr := os.Stat(filepath.Join(repoRoot, ".git")); statErr != nil {
-		t.Fatalf("repo root %s does not look like a git checkout: %v", repoRoot, statErr)
+	repoRoot := repoRootFromTestFile(t)
+	// Sanity-check the walk root against a repository-root marker rather than
+	// .git: the guard must fail loudly if the path arithmetic stops pointing
+	// at the repo root, but it must not depend on VCS metadata (.dockerignore
+	// strips .git/, and source tarballs carry none).
+	if _, statErr := os.Stat(filepath.Join(repoRoot, "src", "semantic-router", "go.mod")); statErr != nil {
+		t.Fatalf("repo root %s does not look like the repository root: %v", repoRoot, statErr)
 	}
 
 	found := scanDefaultDecisionsReferences(t, repoRoot)
@@ -113,8 +131,10 @@ func scanDefaultDecisionsReferences(t *testing.T, repoRoot string) map[string]bo
 			return err
 		}
 		if d.IsDir() {
-			skip := (strings.HasPrefix(d.Name(), ".") && path != repoRoot) || d.Name() == "node_modules"
-			if skip {
+			switch {
+			case strings.HasPrefix(d.Name(), ".") && path != repoRoot,
+				d.Name() == "node_modules",
+				d.Name() == "target": // Rust build output: thousands of entries, no Go sources.
 				return filepath.SkipDir
 			}
 			return nil
@@ -126,7 +146,7 @@ func scanDefaultDecisionsReferences(t *testing.T, repoRoot string) map[string]bo
 		if readErr != nil {
 			return readErr
 		}
-		if !strings.Contains(string(content), "DefaultDecisions") {
+		if !containsAnySpelling(content, defaultDecisionsSpellings) {
 			return nil
 		}
 		rel, relErr := filepath.Rel(repoRoot, path)
@@ -140,4 +160,13 @@ func scanDefaultDecisionsReferences(t *testing.T, repoRoot string) map[string]bo
 		t.Fatalf("walking repo: %v", walkErr)
 	}
 	return found
+}
+
+func containsAnySpelling(content []byte, needles [][]byte) bool {
+	for _, needle := range needles {
+		if bytes.Contains(content, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
+++ b/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
@@ -42,14 +42,18 @@ var defaultDecisionsAllowlist = map[string]string{
 	// would let a recipe's decisions be selected without going through that
 	// recipe's entrypoint; HasXDecision gates whether /v1/models advertises
 	// the slug, and advertising one that cannot route would be a lie.
-	"src/semantic-router/pkg/config/fusion_config.go":                      "HasFusionDecision gates the fusion slug in /v1/models",
-	"src/semantic-router/pkg/config/remom_config.go":                       "HasReMoMDecision gates the remom slug in /v1/models",
-	"src/semantic-router/pkg/config/workflows_config.go":                   "HasFlowDecision gates the flow slug in /v1/models",
-	"src/semantic-router/pkg/extproc/req_filter_fusion.go":                 "algorithm slugs resolve against the default profile only",
-	"src/semantic-router/pkg/extproc/req_filter_classification_runtime.go": "authz scope for requests without an entrypoint recipe",
-	"src/semantic-router/pkg/classification/classifier_signal_decision.go": "default candidate set for unscoped requests",
-	"src/semantic-router/pkg/services/classification.go":                   "gate matches EvaluateDecisionWithEngine's default scope",
-	"src/semantic-router/pkg/services/classification_signal_contract.go":   "gate matches EvaluateDecisionWithEngine's default scope",
+	"src/semantic-router/pkg/config/fusion_config.go":                       "HasFusionDecision gates the fusion slug in /v1/models",
+	"src/semantic-router/pkg/config/remom_config.go":                        "HasReMoMDecision gates the remom slug in /v1/models",
+	"src/semantic-router/pkg/config/workflows_config.go":                    "HasFlowDecision gates the flow slug in /v1/models",
+	"src/semantic-router/pkg/extproc/req_filter_fusion.go":                  "algorithm slugs resolve against the default profile only",
+	"src/semantic-router/pkg/extproc/req_filter_classification_runtime.go":  "authz scope for requests without an entrypoint recipe",
+	"src/semantic-router/pkg/extproc/router_selection.go":                   "first-match into the process-level selector singleton must not depend on recipe declaration order",
+	"src/semantic-router/pkg/classification/classifier_signal_decision.go":  "default candidate set for unscoped requests",
+	"src/semantic-router/pkg/classification/classifier_category_entropy.go": "reasoning maps serve the classify API, same scope as its decision engine",
+	"src/semantic-router/pkg/classification/mcp_classifier_runtime.go":      "reasoning map serves the classify API, same scope as its decision engine",
+	"src/semantic-router/pkg/services/classification.go":                    "gate matches EvaluateDecisionWithEngine's default scope",
+	"src/semantic-router/pkg/services/classification_signal_contract.go":    "gate matches EvaluateDecisionWithEngine's default scope",
+	"src/semantic-router/pkg/services/classification_recommendation.go":     "recommendation must not name a model only a recipe entrypoint can reach",
 
 	// Known limitation: the dashboard topology test-query panel replays the
 	// default profile's rules and does not model recipe scoping yet.

--- a/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
+++ b/src/semantic-router/pkg/config/default_decisions_allowlist_test.go
@@ -57,9 +57,9 @@ var defaultDecisionsAllowlist = map[string]string{
 	"src/semantic-router/pkg/services/classification_signal_contract.go":    "gate matches EvaluateDecisionWithEngine's default scope",
 	"src/semantic-router/pkg/services/classification_recommendation.go":     "recommendation must not name a model only a recipe entrypoint can reach",
 
-	// Known limitation: the dashboard topology test-query panel replays the
-	// default profile's rules and does not model recipe scoping yet.
-	"dashboard/backend/handlers/topology_response.go": "topology test-query panel does not model recipe scoping yet",
+	// Known limitation: the dashboard does not model recipe scoping yet;
+	// tech-debt entry TD045 tracks the gap.
+	"dashboard/backend/handlers/topology_response.go": "topology test-query panel does not model recipe scoping yet (TD045)",
 }
 
 // defaultDecisionsSpellings are the source spellings that read the default

--- a/src/semantic-router/pkg/config/fusion_config.go
+++ b/src/semantic-router/pkg/config/fusion_config.go
@@ -157,6 +157,10 @@ func (c *RouterConfig) HasFusionDecision() bool {
 	if c == nil {
 		return false
 	}
+	// Default profile only: this gates ExposedFusionModelNames, i.e. whether
+	// /v1/models advertises the Fusion slug. The slug can only select the
+	// default profile's decisions, so advertising it based on a recipe's
+	// decision would promise a route the router then refuses.
 	for _, decision := range c.DefaultDecisions {
 		if decision.Algorithm != nil && decision.Algorithm.Type == "fusion" {
 			return true

--- a/src/semantic-router/pkg/config/fusion_config.go
+++ b/src/semantic-router/pkg/config/fusion_config.go
@@ -157,7 +157,7 @@ func (c *RouterConfig) HasFusionDecision() bool {
 	if c == nil {
 		return false
 	}
-	for _, decision := range c.Decisions {
+	for _, decision := range c.DefaultDecisions {
 		if decision.Algorithm != nil && decision.Algorithm.Type == "fusion" {
 			return true
 		}

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -145,11 +145,11 @@ func (c *RouterConfig) GetCategoryDescriptions() []string {
 
 // GetModelForDecisionIndex returns the best LLM model name for the decision at the given index
 func (c *RouterConfig) GetModelForDecisionIndex(index int) string {
-	if index < 0 || index >= len(c.Decisions) {
+	if index < 0 || index >= len(c.DefaultDecisions) {
 		return c.DefaultModel
 	}
 
-	decision := c.Decisions[index]
+	decision := c.DefaultDecisions[index]
 	if len(decision.ModelRefs) > 0 {
 		return decision.ModelRefs[0].Model
 	}
@@ -366,7 +366,7 @@ func (c *RouterConfig) GetAllModels() []string {
 
 // GetModelReasoningForDecision returns whether a specific model supports reasoning in a given decision
 func (c *RouterConfig) GetModelReasoningForDecision(decisionName string, modelName string) bool {
-	for _, decision := range c.Decisions {
+	for _, decision := range c.DefaultDecisions {
 		if decision.Name == decisionName {
 			for _, modelRef := range decision.ModelRefs {
 				if modelRef.Model == modelName {
@@ -380,7 +380,7 @@ func (c *RouterConfig) GetModelReasoningForDecision(decisionName string, modelNa
 
 // GetBestModelForDecision returns the best model for a given decision (first model in ModelRefs)
 func (c *RouterConfig) GetBestModelForDecision(decisionName string) (string, bool) {
-	for _, decision := range c.Decisions {
+	for _, decision := range c.DefaultDecisions {
 		if decision.Name == decisionName {
 			if len(decision.ModelRefs) > 0 {
 				useReasoning := decision.ModelRefs[0].UseReasoning != nil && *decision.ModelRefs[0].UseReasoning
@@ -395,7 +395,7 @@ func (c *RouterConfig) GetBestModelForDecision(decisionName string) (string, boo
 func (c *RouterConfig) ValidateEndpoints() error {
 	// Get all models from decisions
 	allCategoryModels := make(map[string]bool)
-	for _, decision := range c.Decisions {
+	for _, decision := range c.DefaultDecisions {
 		for _, modelRef := range decision.ModelRefs {
 			allCategoryModels[modelRef.Model] = true
 		}
@@ -452,13 +452,13 @@ func (c *RouterConfig) GetCategoryByName(name string) *Category {
 
 // GetDecisionByName returns a decision by name
 func (c *RouterConfig) GetDecisionByName(name string) *Decision {
-	for i := range c.Decisions {
-		if c.Decisions[i].Name == name {
-			return &c.Decisions[i]
+	for i := range c.DefaultDecisions {
+		if c.DefaultDecisions[i].Name == name {
+			return &c.DefaultDecisions[i]
 		}
 	}
 	// Non-default recipe decisions live only on their recipe; the default
-	// recipe mirrors the flat Decisions field scanned above. Decision names
+	// recipe mirrors the DefaultDecisions field scanned above. Decision names
 	// are globally unique across recipes (validated at load), so the first
 	// match is the only match.
 	for i := range c.Recipes {

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -462,8 +462,9 @@ func (c *RouterConfig) GetDecisionByNameFold(name string) *Decision {
 // findDecisionBy walks the default profile and then every named recipe without
 // materializing a merged slice, so the request-path lookups stay allocation
 // free. The returned pointer always addresses the config itself, never a
-// temporary copy. Decision names are globally unique across recipes (validated
-// at load), so the first match is the only match.
+// temporary copy. Decision names are unique across recipes case-insensitively
+// (validated at load), so the first match is the only match for the exact and
+// the fold predicate alike.
 func (c *RouterConfig) findDecisionBy(match func(string) bool) *Decision {
 	if c == nil {
 		return nil

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -366,13 +366,13 @@ func (c *RouterConfig) GetAllModels() []string {
 
 // GetModelReasoningForDecision returns whether a specific model supports reasoning in a given decision
 func (c *RouterConfig) GetModelReasoningForDecision(decisionName string, modelName string) bool {
-	for _, decision := range c.DefaultDecisions {
-		if decision.Name == decisionName {
-			for _, modelRef := range decision.ModelRefs {
-				if modelRef.Model == modelName {
-					return modelRef.UseReasoning != nil && *modelRef.UseReasoning
-				}
-			}
+	decision := c.GetDecisionByName(decisionName)
+	if decision == nil {
+		return false
+	}
+	for _, modelRef := range decision.ModelRefs {
+		if modelRef.Model == modelName {
+			return modelRef.UseReasoning != nil && *modelRef.UseReasoning
 		}
 	}
 	return false // Default to false if decision or model not found
@@ -380,22 +380,19 @@ func (c *RouterConfig) GetModelReasoningForDecision(decisionName string, modelNa
 
 // GetBestModelForDecision returns the best model for a given decision (first model in ModelRefs)
 func (c *RouterConfig) GetBestModelForDecision(decisionName string) (string, bool) {
-	for _, decision := range c.DefaultDecisions {
-		if decision.Name == decisionName {
-			if len(decision.ModelRefs) > 0 {
-				useReasoning := decision.ModelRefs[0].UseReasoning != nil && *decision.ModelRefs[0].UseReasoning
-				return decision.ModelRefs[0].Model, useReasoning
-			}
-		}
+	decision := c.GetDecisionByName(decisionName)
+	if decision == nil || len(decision.ModelRefs) == 0 {
+		return "", false // Return empty string and false if decision not found or has no models
 	}
-	return "", false // Return empty string and false if decision not found or has no models
+	useReasoning := decision.ModelRefs[0].UseReasoning != nil && *decision.ModelRefs[0].UseReasoning
+	return decision.ModelRefs[0].Model, useReasoning
 }
 
 // ValidateEndpoints validates that all configured models have at least one endpoint
 func (c *RouterConfig) ValidateEndpoints() error {
 	// Get all models from decisions
 	allCategoryModels := make(map[string]bool)
-	for _, decision := range c.DefaultDecisions {
+	for _, decision := range c.AllRoutingDecisions() {
 		for _, modelRef := range decision.ModelRefs {
 			allCategoryModels[modelRef.Model] = true
 		}
@@ -450,23 +447,40 @@ func (c *RouterConfig) GetCategoryByName(name string) *Category {
 	return nil
 }
 
-// GetDecisionByName returns a decision by name
+// GetDecisionByName returns a decision by name, searching every routing recipe.
 func (c *RouterConfig) GetDecisionByName(name string) *Decision {
+	return c.findDecisionBy(func(candidate string) bool { return candidate == name })
+}
+
+// GetDecisionByNameFold is the case-insensitive counterpart of
+// GetDecisionByName, for the classifier paths that match decision names
+// loosely.
+func (c *RouterConfig) GetDecisionByNameFold(name string) *Decision {
+	return c.findDecisionBy(func(candidate string) bool { return strings.EqualFold(candidate, name) })
+}
+
+// findDecisionBy walks the default profile and then every named recipe without
+// materializing a merged slice, so the request-path lookups stay allocation
+// free. The returned pointer always addresses the config itself, never a
+// temporary copy. Decision names are globally unique across recipes (validated
+// at load), so the first match is the only match.
+func (c *RouterConfig) findDecisionBy(match func(string) bool) *Decision {
+	if c == nil {
+		return nil
+	}
 	for i := range c.DefaultDecisions {
-		if c.DefaultDecisions[i].Name == name {
+		if match(c.DefaultDecisions[i].Name) {
 			return &c.DefaultDecisions[i]
 		}
 	}
 	// Non-default recipe decisions live only on their recipe; the default
-	// recipe mirrors the DefaultDecisions field scanned above. Decision names
-	// are globally unique across recipes (validated at load), so the first
-	// match is the only match.
+	// recipe mirrors the DefaultDecisions field scanned above.
 	for i := range c.Recipes {
 		if c.Recipes[i].Name == DefaultRecipeName {
 			continue
 		}
 		for j := range c.Recipes[i].Decisions {
-			if c.Recipes[i].Decisions[j].Name == name {
+			if match(c.Recipes[i].Decisions[j].Name) {
 				return &c.Recipes[i].Decisions[j]
 			}
 		}

--- a/src/semantic-router/pkg/config/loader.go
+++ b/src/semantic-router/pkg/config/loader.go
@@ -122,7 +122,7 @@ func parseYAMLBytesWithBaseDir(data []byte, baseDir string) (*RouterConfig, erro
 	}
 
 	logging.ComponentDebugEvent("config", "config_parse_complete", map[string]interface{}{
-		"decision_count": len(cfg.AllRoutingDecisions()),
+		"decision_count": cfg.CountRoutingDecisions(),
 		"base_dir":       baseDir,
 	})
 	return cfg, nil

--- a/src/semantic-router/pkg/config/loader.go
+++ b/src/semantic-router/pkg/config/loader.go
@@ -122,7 +122,7 @@ func parseYAMLBytesWithBaseDir(data []byte, baseDir string) (*RouterConfig, erro
 	}
 
 	logging.ComponentDebugEvent("config", "config_parse_complete", map[string]interface{}{
-		"decision_count": len(cfg.DefaultDecisions),
+		"decision_count": len(cfg.AllRoutingDecisions()),
 		"base_dir":       baseDir,
 	})
 	return cfg, nil
@@ -513,12 +513,13 @@ func finalizeParsedConfig(cfg *RouterConfig) error {
 }
 
 func logParsedDecisions(cfg *RouterConfig) {
-	decisionNames := make([]string, 0, len(cfg.DefaultDecisions))
-	for _, d := range cfg.DefaultDecisions {
+	decisions := cfg.AllRoutingDecisions()
+	decisionNames := make([]string, 0, len(decisions))
+	for _, d := range decisions {
 		decisionNames = append(decisionNames, d.Name)
 	}
 	logging.ComponentDebugEvent("config", "config_decisions_parsed", map[string]interface{}{
-		"decision_count": len(cfg.DefaultDecisions),
+		"decision_count": len(decisions),
 		"decision_names": decisionNames,
 	})
 }
@@ -658,12 +659,14 @@ func nestedStringMap(raw interface{}) map[string]interface{} {
 
 // Replace replaces the globally cached config. It is safe for concurrent readers.
 func Replace(newCfg *RouterConfig) {
-	decisionNames := make([]string, 0, len(newCfg.DefaultDecisions))
-	for _, d := range newCfg.DefaultDecisions {
+	decisions := newCfg.AllRoutingDecisions()
+	decisionCount := len(decisions)
+	decisionNames := make([]string, 0, decisionCount)
+	for _, d := range decisions {
 		decisionNames = append(decisionNames, d.Name)
 	}
 	logging.ComponentDebugEvent("config", "config_replace_started", map[string]interface{}{
-		"decision_count": len(newCfg.DefaultDecisions),
+		"decision_count": decisionCount,
 		"decision_names": decisionNames,
 	})
 
@@ -689,13 +692,13 @@ func Replace(newCfg *RouterConfig) {
 		case ch <- newCfg:
 			logging.ComponentDebugEvent("config", "config_update_notified", map[string]interface{}{
 				"subscriber_id":  id,
-				"decision_count": len(newCfg.DefaultDecisions),
+				"decision_count": decisionCount,
 			})
 		default:
 			logging.ComponentWarnEvent("config", "config_update_notification_skipped", map[string]interface{}{
 				"subscriber_id":  id,
 				"reason":         "channel_full",
-				"decision_count": len(newCfg.DefaultDecisions),
+				"decision_count": decisionCount,
 			})
 		}
 	}

--- a/src/semantic-router/pkg/config/loader.go
+++ b/src/semantic-router/pkg/config/loader.go
@@ -122,7 +122,7 @@ func parseYAMLBytesWithBaseDir(data []byte, baseDir string) (*RouterConfig, erro
 	}
 
 	logging.ComponentDebugEvent("config", "config_parse_complete", map[string]interface{}{
-		"decision_count": len(cfg.Decisions),
+		"decision_count": len(cfg.DefaultDecisions),
 		"base_dir":       baseDir,
 	})
 	return cfg, nil
@@ -513,12 +513,12 @@ func finalizeParsedConfig(cfg *RouterConfig) error {
 }
 
 func logParsedDecisions(cfg *RouterConfig) {
-	decisionNames := make([]string, 0, len(cfg.Decisions))
-	for _, d := range cfg.Decisions {
+	decisionNames := make([]string, 0, len(cfg.DefaultDecisions))
+	for _, d := range cfg.DefaultDecisions {
 		decisionNames = append(decisionNames, d.Name)
 	}
 	logging.ComponentDebugEvent("config", "config_decisions_parsed", map[string]interface{}{
-		"decision_count": len(cfg.Decisions),
+		"decision_count": len(cfg.DefaultDecisions),
 		"decision_names": decisionNames,
 	})
 }
@@ -658,12 +658,12 @@ func nestedStringMap(raw interface{}) map[string]interface{} {
 
 // Replace replaces the globally cached config. It is safe for concurrent readers.
 func Replace(newCfg *RouterConfig) {
-	decisionNames := make([]string, 0, len(newCfg.Decisions))
-	for _, d := range newCfg.Decisions {
+	decisionNames := make([]string, 0, len(newCfg.DefaultDecisions))
+	for _, d := range newCfg.DefaultDecisions {
 		decisionNames = append(decisionNames, d.Name)
 	}
 	logging.ComponentDebugEvent("config", "config_replace_started", map[string]interface{}{
-		"decision_count": len(newCfg.Decisions),
+		"decision_count": len(newCfg.DefaultDecisions),
 		"decision_names": decisionNames,
 	})
 
@@ -689,13 +689,13 @@ func Replace(newCfg *RouterConfig) {
 		case ch <- newCfg:
 			logging.ComponentDebugEvent("config", "config_update_notified", map[string]interface{}{
 				"subscriber_id":  id,
-				"decision_count": len(newCfg.Decisions),
+				"decision_count": len(newCfg.DefaultDecisions),
 			})
 		default:
 			logging.ComponentWarnEvent("config", "config_update_notification_skipped", map[string]interface{}{
 				"subscriber_id":  id,
 				"reason":         "channel_full",
-				"decision_count": len(newCfg.Decisions),
+				"decision_count": len(newCfg.DefaultDecisions),
 			})
 		}
 	}

--- a/src/semantic-router/pkg/config/loader_subscription_test.go
+++ b/src/semantic-router/pkg/config/loader_subscription_test.go
@@ -23,7 +23,7 @@ func TestSubscribeConfigUpdatesFanout(t *testing.T) {
 
 	cfg := &RouterConfig{
 		IntelligentRouting: IntelligentRouting{
-			Decisions: []Decision{{Name: "support"}},
+			DefaultDecisions: []Decision{{Name: "support"}},
 		},
 	}
 

--- a/src/semantic-router/pkg/config/module_runtime_helpers.go
+++ b/src/semantic-router/pkg/config/module_runtime_helpers.go
@@ -40,7 +40,7 @@ func (c *RouterConfig) IsHallucinationModelEnabled() bool {
 	if c.HallucinationMitigation.Enabled {
 		return true
 	}
-	for _, decision := range c.DefaultDecisions {
+	for _, decision := range c.AllRoutingDecisions() {
 		halConfig := decision.GetHallucinationConfig()
 		if halConfig != nil && halConfig.Enabled {
 			return true

--- a/src/semantic-router/pkg/config/module_runtime_helpers.go
+++ b/src/semantic-router/pkg/config/module_runtime_helpers.go
@@ -33,6 +33,30 @@ func (c *RouterConfig) GetFactCheckRules() []FactCheckRule {
 }
 
 // IsHallucinationModelEnabled reports whether hallucination detection should run.
+// MemoryPluginDecisionName returns the name of the first decision in any
+// routing profile that declares the memory plugin, or "" when none does.
+func (c *RouterConfig) MemoryPluginDecisionName() string {
+	if c == nil {
+		return ""
+	}
+	for _, decision := range c.AllRoutingDecisions() {
+		if decision.HasPlugin("memory") {
+			return decision.Name
+		}
+	}
+	return ""
+}
+
+// IsMemoryEnabled reports whether the memory runtime must be wired up:
+// memory is explicitly enabled, or some routing profile's decision uses the
+// memory plugin.
+func (c *RouterConfig) IsMemoryEnabled() bool {
+	if c == nil {
+		return false
+	}
+	return c.Memory.Enabled || c.MemoryPluginDecisionName() != ""
+}
+
 func (c *RouterConfig) IsHallucinationModelEnabled() bool {
 	if c.HallucinationMitigation.HallucinationModel.ModelID == "" {
 		return false

--- a/src/semantic-router/pkg/config/module_runtime_helpers.go
+++ b/src/semantic-router/pkg/config/module_runtime_helpers.go
@@ -40,7 +40,7 @@ func (c *RouterConfig) IsHallucinationModelEnabled() bool {
 	if c.HallucinationMitigation.Enabled {
 		return true
 	}
-	for _, decision := range c.Decisions {
+	for _, decision := range c.DefaultDecisions {
 		halConfig := decision.GetHallucinationConfig()
 		if halConfig != nil && halConfig.Enabled {
 			return true

--- a/src/semantic-router/pkg/config/plugin_config_test.go
+++ b/src/semantic-router/pkg/config/plugin_config_test.go
@@ -9,7 +9,7 @@ var _ = Describe("IsRAGEnabledForDecision", func() {
 	It("returns false for decision without RAG plugin", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{Name: "no-rag", ModelRefs: []ModelRef{{Model: "m"}}},
 				},
 			},
@@ -20,7 +20,7 @@ var _ = Describe("IsRAGEnabledForDecision", func() {
 	It("returns false when RAG plugin is explicitly disabled", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{
 						Name:      "rag-disabled",
 						ModelRefs: []ModelRef{{Model: "m"}},
@@ -40,7 +40,7 @@ var _ = Describe("IsRAGEnabledForDecision", func() {
 	It("returns true when RAG plugin is enabled", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{
 						Name:      "rag-on",
 						ModelRefs: []ModelRef{{Model: "m"}},
@@ -68,7 +68,7 @@ var _ = Describe("IsMemoryEnabledForDecision", func() {
 		cfg := &RouterConfig{
 			Memory: MemoryConfig{Enabled: false},
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{Name: "test", ModelRefs: []ModelRef{{Model: "m"}}},
 				},
 			},
@@ -80,7 +80,7 @@ var _ = Describe("IsMemoryEnabledForDecision", func() {
 		cfg := &RouterConfig{
 			Memory: MemoryConfig{Enabled: true},
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{Name: "test", ModelRefs: []ModelRef{{Model: "m"}}},
 				},
 			},
@@ -109,7 +109,7 @@ var _ = Describe("HasPersonalizationPlugins", func() {
 		cfg := &RouterConfig{
 			Memory: MemoryConfig{Enabled: false},
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{Name: "plain", ModelRefs: []ModelRef{{Model: "m"}}},
 				},
 			},
@@ -126,7 +126,7 @@ var _ = Describe("HasPersonalizationPlugins", func() {
 		cfg := &RouterConfig{
 			Memory: MemoryConfig{Enabled: true},
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{Name: "mem-global", ModelRefs: []ModelRef{{Model: "m"}}},
 				},
 			},
@@ -138,7 +138,7 @@ var _ = Describe("HasPersonalizationPlugins", func() {
 		cfg := &RouterConfig{
 			Memory: MemoryConfig{Enabled: true},
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{
 						Name:      "both",
 						ModelRefs: []ModelRef{{Model: "m"}},
@@ -165,7 +165,7 @@ func ragDecisionConfig(name string) *RouterConfig {
 	return &RouterConfig{
 		Memory: MemoryConfig{Enabled: false},
 		IntelligentRouting: IntelligentRouting{
-			Decisions: []Decision{
+			DefaultDecisions: []Decision{
 				{
 					Name:      name,
 					ModelRefs: []ModelRef{{Model: "m"}},
@@ -189,7 +189,7 @@ func memoryDecisionConfig(globalEnabled, perDecisionEnabled bool) *RouterConfig 
 	return &RouterConfig{
 		Memory: MemoryConfig{Enabled: globalEnabled},
 		IntelligentRouting: IntelligentRouting{
-			Decisions: []Decision{
+			DefaultDecisions: []Decision{
 				{
 					Name:      name,
 					ModelRefs: []ModelRef{{Model: "m"}},
@@ -233,13 +233,13 @@ func registerRouterReplayPluginOverrideSpecs() {
 		})
 		Expect(cfg.EffectiveRouterReplayConfigForDecision("opt-in")).To(BeNil())
 
-		cfg.Decisions[0].Plugins[0].Configuration = MustStructuredPayload(map[string]interface{}{
+		cfg.DefaultDecisions[0].Plugins[0].Configuration = MustStructuredPayload(map[string]interface{}{
 			"enabled":               false,
 			"capture_response_body": false,
 		})
 		Expect(cfg.EffectiveRouterReplayConfigForDecision("opt-in")).To(BeNil())
 
-		cfg.Decisions[0].Plugins[0].Configuration = MustStructuredPayload(map[string]interface{}{
+		cfg.DefaultDecisions[0].Plugins[0].Configuration = MustStructuredPayload(map[string]interface{}{
 			"enabled":               true,
 			"capture_response_body": false,
 		})
@@ -289,7 +289,7 @@ func routerReplayDecisionConfig(globalEnabled bool, name string, pluginConfig ma
 	return &RouterConfig{
 		RouterReplay: RouterReplayConfig{Enabled: globalEnabled},
 		IntelligentRouting: IntelligentRouting{
-			Decisions: []Decision{decision},
+			DefaultDecisions: []Decision{decision},
 		},
 	}
 }

--- a/src/semantic-router/pkg/config/recipes.go
+++ b/src/semantic-router/pkg/config/recipes.go
@@ -107,7 +107,11 @@ func (c *RouterConfig) AllRoutingDecisions() []Decision {
 	if len(c.Recipes) == 1 {
 		return c.Recipes[0].Decisions
 	}
-	all := make([]Decision, 0, 2*len(c.DefaultDecisions))
+	total := 0
+	for i := range c.Recipes {
+		total += len(c.Recipes[i].Decisions)
+	}
+	all := make([]Decision, 0, total)
 	for i := range c.Recipes {
 		all = append(all, c.Recipes[i].Decisions...)
 	}

--- a/src/semantic-router/pkg/config/recipes.go
+++ b/src/semantic-router/pkg/config/recipes.go
@@ -102,12 +102,12 @@ func (c *RouterConfig) AllRoutingDecisions() []Decision {
 		return nil
 	}
 	if len(c.Recipes) == 0 {
-		return c.Decisions
+		return c.DefaultDecisions
 	}
 	if len(c.Recipes) == 1 {
 		return c.Recipes[0].Decisions
 	}
-	all := make([]Decision, 0, 2*len(c.Decisions))
+	all := make([]Decision, 0, 2*len(c.DefaultDecisions))
 	for i := range c.Recipes {
 		all = append(all, c.Recipes[i].Decisions...)
 	}
@@ -122,7 +122,7 @@ func (c *RouterConfig) HasRoutingDecisions() bool {
 	if c == nil {
 		return false
 	}
-	if len(c.Decisions) > 0 {
+	if len(c.DefaultDecisions) > 0 {
 		return true
 	}
 	for i := range c.Recipes {

--- a/src/semantic-router/pkg/config/recipes.go
+++ b/src/semantic-router/pkg/config/recipes.go
@@ -11,7 +11,7 @@ import (
 const DefaultRecipeName = "default"
 
 // RoutingRecipe is one normalized routing profile. The recipe named
-// DefaultRecipeName always mirrors the flat Decisions field on RouterConfig,
+// DefaultRecipeName always mirrors the flat DefaultDecisions field on RouterConfig,
 // so existing single-profile read sites and recipe-aware read sites observe
 // the same default behavior. The flat Signals and Projections fields instead
 // hold the global registry: the union of every recipe's profile, so one
@@ -96,7 +96,9 @@ func (c *RouterConfig) EntrypointRecipeDescription(recipeName string) string {
 // AllRoutingDecisions returns the decisions of every routing profile, for
 // callers that reason about routing as a whole (signal usage analysis,
 // contract validation). Configs built without the canonical loader carry no
-// recipes; their flat decisions are the only profile.
+// recipes; their flat decisions are the only profile. Element order is
+// unspecified — callers needing a priority order resolve by name
+// (GetDecisionByName) or read one profile explicitly.
 func (c *RouterConfig) AllRoutingDecisions() []Decision {
 	if c == nil {
 		return nil
@@ -120,8 +122,8 @@ func (c *RouterConfig) AllRoutingDecisions() []Decision {
 
 // HasRoutingDecisions reports whether any routing profile declares decisions,
 // without the per-request allocation of AllRoutingDecisions. The flat gate
-// `len(c.Decisions) == 0` is wrong for recipes-only configs, where every
-// decision lives in a non-default recipe.
+// `len(c.DefaultDecisions) == 0` is wrong for recipes-only configs, where
+// every decision lives in a non-default recipe.
 func (c *RouterConfig) HasRoutingDecisions() bool {
 	if c == nil {
 		return false
@@ -135,6 +137,23 @@ func (c *RouterConfig) HasRoutingDecisions() bool {
 		}
 	}
 	return false
+}
+
+// CountRoutingDecisions returns the number of decisions across every routing
+// profile, without the merge AllRoutingDecisions performs for multi-recipe
+// configs. Mirrors AllRoutingDecisions' profile selection exactly.
+func (c *RouterConfig) CountRoutingDecisions() int {
+	if c == nil {
+		return 0
+	}
+	if len(c.Recipes) == 0 {
+		return len(c.DefaultDecisions)
+	}
+	total := 0
+	for i := range c.Recipes {
+		total += len(c.Recipes[i].Decisions)
+	}
+	return total
 }
 
 // RoutingProfileSignals returns the default profile's signals for canonical

--- a/src/semantic-router/pkg/config/recipes_invariant_test.go
+++ b/src/semantic-router/pkg/config/recipes_invariant_test.go
@@ -7,68 +7,12 @@ import (
 
 // The normalized state carries one intentional redundancy: DefaultDecisions
 // mirrors the default recipe's decisions so single-profile read sites keep
-// working. These tests pin that redundancy — and the deliberate asymmetry of
-// the neighbouring Signals/Projections fields, which hold the GLOBAL registry
-// rather than the default profile's rules.
+// working. These tests pin that redundancy as an alias, not merely as equal
+// content: both views must share one backing array, so a mutation seen
+// through one is seen through the other.
 
-const invariantTwoRecipeYAML = `
-version: v0.3
-routing:
-  modelCards:
-    - name: model-a
-    - name: model-b
-  signals:
-    keywords:
-      - name: urgent_keywords
-        operator: OR
-        keywords: ["urgent"]
-  decisions:
-    - name: default_route
-      rules:
-        operator: AND
-        conditions:
-          - type: keyword
-            name: urgent_keywords
-      modelRefs:
-        - model: model-a
-recipes:
-  - name: privacy
-    routing:
-      signals:
-        keywords:
-          - name: pii_keywords
-            operator: OR
-            keywords: ["ssn"]
-      decisions:
-        - name: privacy_route
-          rules:
-            operator: AND
-            conditions:
-              - type: keyword
-                name: pii_keywords
-          modelRefs:
-            - model: model-b
-entrypoints:
-  - model_names: ["vllm-sr/privacy"]
-    recipe: privacy
-providers:
-  defaults:
-    default_model: model-a
-  models:
-    - name: model-a
-      backend_refs:
-        - endpoint: 127.0.0.1:8000
-    - name: model-b
-      backend_refs:
-        - endpoint: 127.0.0.1:8001
-`
-
-func TestDefaultDecisionsMirrorTheDefaultRecipe(t *testing.T) {
-	cfg, err := ParseYAMLBytes([]byte(invariantTwoRecipeYAML))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
+func assertDefaultDecisionsAliasDefaultRecipe(t *testing.T, cfg *RouterConfig) {
+	t.Helper()
 	defaultRecipe := cfg.DefaultRecipe()
 	if defaultRecipe == nil {
 		t.Fatal("expected a default recipe")
@@ -77,88 +21,39 @@ func TestDefaultDecisionsMirrorTheDefaultRecipe(t *testing.T) {
 		t.Fatalf("DefaultDecisions drifted from the default recipe:\n flat: %+v\n recipe: %+v",
 			cfg.DefaultDecisions, defaultRecipe.Decisions)
 	}
+	// DeepEqual alone would also pass on an equal copy; the invariant is
+	// stronger. A defensive copy in the loader would break the alias while
+	// keeping the content equal.
+	if len(cfg.DefaultDecisions) > 0 && &cfg.DefaultDecisions[0] != &defaultRecipe.Decisions[0] {
+		t.Fatal("DefaultDecisions and the default recipe hold equal copies, not one aliased slice")
+	}
+}
+
+func TestDefaultDecisionsMirrorTheDefaultRecipe(t *testing.T) {
+	cfg, err := ParseYAMLBytes([]byte(recipeTestBaseYAML + recipeTestPrivacyBlockYAML))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	assertDefaultDecisionsAliasDefaultRecipe(t, cfg)
 
 	// DefaultDecisions is default-only; AllRoutingDecisions spans every recipe.
 	if len(cfg.DefaultDecisions) != 1 || cfg.DefaultDecisions[0].Name != "default_route" {
 		t.Fatalf("expected only the default recipe's decision in the flat field, got %+v", cfg.DefaultDecisions)
 	}
-	all := cfg.AllRoutingDecisions()
-	if len(all) != 2 {
-		t.Fatalf("expected both profiles' decisions from AllRoutingDecisions, got %+v", all)
-	}
-}
-
-func TestSignalRegistryIsGlobalWhileDecisionsStayScoped(t *testing.T) {
-	cfg, err := ParseYAMLBytes([]byte(invariantTwoRecipeYAML))
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-
-	// Signals are the union: one classifier must be able to evaluate any
-	// recipe's rules.
-	names := make(map[string]bool, len(cfg.KeywordRules))
-	for _, rule := range cfg.KeywordRules {
-		names[rule.Name] = true
-	}
-	if !names["urgent_keywords"] || !names["pii_keywords"] {
-		t.Fatalf("expected the global signal registry to hold both profiles' rules, got %v", names)
-	}
-
-	// ...but the default profile's own signals, used for canonical export,
-	// must not carry the other recipe's rules.
-	profileNames := make(map[string]bool)
-	for _, rule := range cfg.RoutingProfileSignals().KeywordRules {
-		profileNames[rule.Name] = true
-	}
-	if profileNames["pii_keywords"] {
-		t.Fatal("the privacy recipe's signal leaked into the default routing profile")
+	if got := len(cfg.AllRoutingDecisions()); got != 2 {
+		t.Fatalf("expected both profiles' decisions from AllRoutingDecisions, got %d", got)
 	}
 }
 
 func TestRecipesOnlyConfigKeepsFlatFieldInSync(t *testing.T) {
-	const recipesOnlyYAML = `
-version: v0.3
-routing:
-  modelCards:
-    - name: model-a
-recipes:
-  - name: default
-    routing:
-      signals:
-        keywords:
-          - name: urgent_keywords
-            operator: OR
-            keywords: ["urgent"]
-      decisions:
-        - name: default_route
-          rules:
-            operator: AND
-            conditions:
-              - type: keyword
-                name: urgent_keywords
-          modelRefs:
-            - model: model-a
-providers:
-  defaults:
-    default_model: model-a
-  models:
-    - name: model-a
-      backend_refs:
-        - endpoint: 127.0.0.1:8000
-`
-
-	cfg, err := ParseYAMLBytes([]byte(recipesOnlyYAML))
+	cfg, err := ParseYAMLBytes([]byte(recipeTestRecipesOnlyYAML))
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	defaultRecipe := cfg.DefaultRecipe()
-	if defaultRecipe == nil {
-		t.Fatal("expected the explicit default recipe to normalize")
-	}
-	if !reflect.DeepEqual(cfg.DefaultDecisions, defaultRecipe.Decisions) {
-		t.Fatalf("recipes-only layout left the flat field out of sync:\n flat: %+v\n recipe: %+v",
-			cfg.DefaultDecisions, defaultRecipe.Decisions)
-	}
+
+	assertDefaultDecisionsAliasDefaultRecipe(t, cfg)
+
 	if !cfg.HasRoutingDecisions() {
 		t.Fatal("expected HasRoutingDecisions to see the recipes-only decisions")
 	}

--- a/src/semantic-router/pkg/config/recipes_invariant_test.go
+++ b/src/semantic-router/pkg/config/recipes_invariant_test.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The normalized state carries one intentional redundancy: DefaultDecisions
+// mirrors the default recipe's decisions so single-profile read sites keep
+// working. These tests pin that redundancy — and the deliberate asymmetry of
+// the neighbouring Signals/Projections fields, which hold the GLOBAL registry
+// rather than the default profile's rules.
+
+const invariantTwoRecipeYAML = `
+version: v0.3
+routing:
+  modelCards:
+    - name: model-a
+    - name: model-b
+  signals:
+    keywords:
+      - name: urgent_keywords
+        operator: OR
+        keywords: ["urgent"]
+  decisions:
+    - name: default_route
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: urgent_keywords
+      modelRefs:
+        - model: model-a
+recipes:
+  - name: privacy
+    routing:
+      signals:
+        keywords:
+          - name: pii_keywords
+            operator: OR
+            keywords: ["ssn"]
+      decisions:
+        - name: privacy_route
+          rules:
+            operator: AND
+            conditions:
+              - type: keyword
+                name: pii_keywords
+          modelRefs:
+            - model: model-b
+entrypoints:
+  - model_names: ["vllm-sr/privacy"]
+    recipe: privacy
+providers:
+  defaults:
+    default_model: model-a
+  models:
+    - name: model-a
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+    - name: model-b
+      backend_refs:
+        - endpoint: 127.0.0.1:8001
+`
+
+func TestDefaultDecisionsMirrorTheDefaultRecipe(t *testing.T) {
+	cfg, err := ParseYAMLBytes([]byte(invariantTwoRecipeYAML))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	defaultRecipe := cfg.DefaultRecipe()
+	if defaultRecipe == nil {
+		t.Fatal("expected a default recipe")
+	}
+	if !reflect.DeepEqual(cfg.DefaultDecisions, defaultRecipe.Decisions) {
+		t.Fatalf("DefaultDecisions drifted from the default recipe:\n flat: %+v\n recipe: %+v",
+			cfg.DefaultDecisions, defaultRecipe.Decisions)
+	}
+
+	// DefaultDecisions is default-only; AllRoutingDecisions spans every recipe.
+	if len(cfg.DefaultDecisions) != 1 || cfg.DefaultDecisions[0].Name != "default_route" {
+		t.Fatalf("expected only the default recipe's decision in the flat field, got %+v", cfg.DefaultDecisions)
+	}
+	all := cfg.AllRoutingDecisions()
+	if len(all) != 2 {
+		t.Fatalf("expected both profiles' decisions from AllRoutingDecisions, got %+v", all)
+	}
+}
+
+func TestSignalRegistryIsGlobalWhileDecisionsStayScoped(t *testing.T) {
+	cfg, err := ParseYAMLBytes([]byte(invariantTwoRecipeYAML))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	// Signals are the union: one classifier must be able to evaluate any
+	// recipe's rules.
+	names := make(map[string]bool, len(cfg.KeywordRules))
+	for _, rule := range cfg.KeywordRules {
+		names[rule.Name] = true
+	}
+	if !names["urgent_keywords"] || !names["pii_keywords"] {
+		t.Fatalf("expected the global signal registry to hold both profiles' rules, got %v", names)
+	}
+
+	// ...but the default profile's own signals, used for canonical export,
+	// must not carry the other recipe's rules.
+	profileNames := make(map[string]bool)
+	for _, rule := range cfg.RoutingProfileSignals().KeywordRules {
+		profileNames[rule.Name] = true
+	}
+	if profileNames["pii_keywords"] {
+		t.Fatal("the privacy recipe's signal leaked into the default routing profile")
+	}
+}
+
+func TestRecipesOnlyConfigKeepsFlatFieldInSync(t *testing.T) {
+	const recipesOnlyYAML = `
+version: v0.3
+routing:
+  modelCards:
+    - name: model-a
+recipes:
+  - name: default
+    routing:
+      signals:
+        keywords:
+          - name: urgent_keywords
+            operator: OR
+            keywords: ["urgent"]
+      decisions:
+        - name: default_route
+          rules:
+            operator: AND
+            conditions:
+              - type: keyword
+                name: urgent_keywords
+          modelRefs:
+            - model: model-a
+providers:
+  defaults:
+    default_model: model-a
+  models:
+    - name: model-a
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+`
+
+	cfg, err := ParseYAMLBytes([]byte(recipesOnlyYAML))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	defaultRecipe := cfg.DefaultRecipe()
+	if defaultRecipe == nil {
+		t.Fatal("expected the explicit default recipe to normalize")
+	}
+	if !reflect.DeepEqual(cfg.DefaultDecisions, defaultRecipe.Decisions) {
+		t.Fatalf("recipes-only layout left the flat field out of sync:\n flat: %+v\n recipe: %+v",
+			cfg.DefaultDecisions, defaultRecipe.Decisions)
+	}
+	if !cfg.HasRoutingDecisions() {
+		t.Fatal("expected HasRoutingDecisions to see the recipes-only decisions")
+	}
+}

--- a/src/semantic-router/pkg/config/recipes_registry_test.go
+++ b/src/semantic-router/pkg/config/recipes_registry_test.go
@@ -23,6 +23,13 @@ func TestCanonicalRecipeSignalsMergeIntoGlobalRegistry(t *testing.T) {
 		t.Fatalf("expected the exported top-level routing block to keep only the default profile, got %+v", canonical.Routing.Signals.Keywords)
 	}
 
+	// The accessor the export goes through must make the same cut on its own.
+	for _, rule := range cfg.RoutingProfileSignals().KeywordRules {
+		if rule.Name == "pii_keywords" {
+			t.Fatal("the privacy recipe's signal leaked into RoutingProfileSignals")
+		}
+	}
+
 	if got := len(cfg.AllRoutingDecisions()); got != 2 {
 		t.Fatalf("expected AllRoutingDecisions to cover both recipes, got %d", got)
 	}

--- a/src/semantic-router/pkg/config/recipes_registry_test.go
+++ b/src/semantic-router/pkg/config/recipes_registry_test.go
@@ -82,7 +82,7 @@ func TestAllRoutingDecisionsFallsBackToFlatDecisions(t *testing.T) {
 	// test configs) carry no recipes; the flat decisions are the only profile.
 	cfg := &RouterConfig{
 		IntelligentRouting: IntelligentRouting{
-			Decisions: []Decision{{Name: "flat_route"}},
+			DefaultDecisions: []Decision{{Name: "flat_route"}},
 		},
 	}
 

--- a/src/semantic-router/pkg/config/remom_config.go
+++ b/src/semantic-router/pkg/config/remom_config.go
@@ -81,7 +81,7 @@ func (c *RouterConfig) HasReMoMDecision() bool {
 	if c == nil {
 		return false
 	}
-	for _, decision := range c.Decisions {
+	for _, decision := range c.DefaultDecisions {
 		if decision.Algorithm != nil && decision.Algorithm.Type == "remom" {
 			return true
 		}

--- a/src/semantic-router/pkg/config/remom_config.go
+++ b/src/semantic-router/pkg/config/remom_config.go
@@ -81,6 +81,7 @@ func (c *RouterConfig) HasReMoMDecision() bool {
 	if c == nil {
 		return false
 	}
+	// Default profile only — see HasFusionDecision for the rationale.
 	for _, decision := range c.DefaultDecisions {
 		if decision.Algorithm != nil && decision.Algorithm.Type == "remom" {
 			return true

--- a/src/semantic-router/pkg/config/routing_signal_usage_test.go
+++ b/src/semantic-router/pkg/config/routing_signal_usage_test.go
@@ -101,7 +101,7 @@ func TestNeedsCoreMappingsForRouting(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg.Decisions = tt.decisions
+			cfg.DefaultDecisions = tt.decisions
 			if got := cfg.NeedsCategoryMappingForRouting(); got != tt.wantCategory {
 				t.Fatalf("NeedsCategoryMappingForRouting() = %v, want %v", got, tt.wantCategory)
 			}

--- a/src/semantic-router/pkg/config/validator_complexity.go
+++ b/src/semantic-router/pkg/config/validator_complexity.go
@@ -33,7 +33,7 @@ var complexityDifficultyLevels = map[string]struct{}{
 // (issue #2324).
 func validateComplexityContracts(cfg *RouterConfig) error {
 	declared := collectComplexityRuleNames(cfg.ComplexityRules)
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if err := validateDecisionComplexityReferences(decision.Name, &decision.Rules, declared); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_complexity.go
+++ b/src/semantic-router/pkg/config/validator_complexity.go
@@ -33,7 +33,7 @@ var complexityDifficultyLevels = map[string]struct{}{
 // (issue #2324).
 func validateComplexityContracts(cfg *RouterConfig) error {
 	declared := collectComplexityRuleNames(cfg.ComplexityRules)
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if err := validateDecisionComplexityReferences(decision.Name, &decision.Rules, declared); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_complexity_test.go
+++ b/src/semantic-router/pkg/config/validator_complexity_test.go
@@ -31,8 +31,8 @@ func complexityDecisionConfig(declaredRules []string, conditionName string, nest
 
 	return &RouterConfig{
 		IntelligentRouting: IntelligentRouting{
-			Signals:   Signals{ComplexityRules: rules},
-			Decisions: []Decision{{Name: "route", Rules: root}},
+			Signals:          Signals{ComplexityRules: rules},
+			DefaultDecisions: []Decision{{Name: "route", Rules: root}},
 		},
 	}
 }
@@ -139,7 +139,7 @@ func TestValidateComplexityContracts(t *testing.T) {
 func TestValidateComplexityContracts_NoComplexityConditions(t *testing.T) {
 	cfg := &RouterConfig{
 		IntelligentRouting: IntelligentRouting{
-			Decisions: []Decision{{
+			DefaultDecisions: []Decision{{
 				Name: "route",
 				Rules: RuleNode{Operator: "AND", Conditions: []RuleNode{
 					{Type: SignalTypeDomain, Name: "business"},

--- a/src/semantic-router/pkg/config/validator_decision_emit_test.go
+++ b/src/semantic-router/pkg/config/validator_decision_emit_test.go
@@ -16,7 +16,7 @@ func TestValidateDecisionEmitContracts(t *testing.T) {
 	}{
 		{
 			name: "valid retention directive",
-			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{Decisions: []Decision{{
+			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{DefaultDecisions: []Decision{{
 				Name: "r",
 				Emits: []EmitDirective{{
 					Kind: emitDirectiveKindRetention,
@@ -31,7 +31,7 @@ func TestValidateDecisionEmitContracts(t *testing.T) {
 		},
 		{
 			name: "unsupported kind",
-			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{Decisions: []Decision{{
+			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{DefaultDecisions: []Decision{{
 				Name:  "r",
 				Emits: []EmitDirective{{Kind: "bogus"}},
 			}}}},
@@ -39,7 +39,7 @@ func TestValidateDecisionEmitContracts(t *testing.T) {
 		},
 		{
 			name: "duplicate retention",
-			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{Decisions: []Decision{{
+			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{DefaultDecisions: []Decision{{
 				Name: "r",
 				Emits: []EmitDirective{
 					{Kind: emitDirectiveKindRetention, Retention: &RetentionDirective{Drop: retentionTestBool(false)}},
@@ -50,7 +50,7 @@ func TestValidateDecisionEmitContracts(t *testing.T) {
 		},
 		{
 			name: "missing retention payload",
-			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{Decisions: []Decision{{
+			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{DefaultDecisions: []Decision{{
 				Name:  "r",
 				Emits: []EmitDirective{{Kind: emitDirectiveKindRetention}},
 			}}}},
@@ -58,7 +58,7 @@ func TestValidateDecisionEmitContracts(t *testing.T) {
 		},
 		{
 			name: "negative ttl",
-			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{Decisions: []Decision{{
+			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{DefaultDecisions: []Decision{{
 				Name: "r",
 				Emits: []EmitDirective{{
 					Kind:      emitDirectiveKindRetention,
@@ -69,7 +69,7 @@ func TestValidateDecisionEmitContracts(t *testing.T) {
 		},
 		{
 			name: "drop ttl conflict",
-			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{Decisions: []Decision{{
+			cfg: &RouterConfig{IntelligentRouting: IntelligentRouting{DefaultDecisions: []Decision{{
 				Name: "r",
 				Emits: []EmitDirective{{
 					Kind: emitDirectiveKindRetention,

--- a/src/semantic-router/pkg/config/validator_domain.go
+++ b/src/semantic-router/pkg/config/validator_domain.go
@@ -18,7 +18,7 @@ func validateDomainContracts(cfg *RouterConfig) error {
 		return err
 	}
 
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if err := validateDecisionDomainReferences(decision.Name, &decision.Rules, declared); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_domain.go
+++ b/src/semantic-router/pkg/config/validator_domain.go
@@ -18,7 +18,7 @@ func validateDomainContracts(cfg *RouterConfig) error {
 		return err
 	}
 
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if err := validateDecisionDomainReferences(decision.Name, &decision.Rules, declared); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_domain_test.go
+++ b/src/semantic-router/pkg/config/validator_domain_test.go
@@ -58,7 +58,7 @@ func TestValidateDomainContractsAllowsAliasWithSupportedMMLUCategories(t *testin
 			Signals: Signals{
 				Categories: []Category{testDomainCategory("compact", "computer science")},
 			},
-			Decisions: []Decision{{
+			DefaultDecisions: []Decision{{
 				Name: "compact_route",
 				Rules: RuleNode{
 					Type: SignalTypeDomain,
@@ -117,7 +117,7 @@ func TestValidateDomainContractsRejectsUndeclaredDecisionDomain(t *testing.T) {
 			Signals: Signals{
 				Categories: []Category{testDomainCategory("math")},
 			},
-			Decisions: []Decision{{
+			DefaultDecisions: []Decision{{
 				Name: "science_route",
 				Rules: RuleNode{
 					Type: SignalTypeDomain,

--- a/src/semantic-router/pkg/config/validator_learning.go
+++ b/src/semantic-router/pkg/config/validator_learning.go
@@ -15,7 +15,7 @@ func validateRouterLearningConfig(cfg *RouterConfig) error {
 	if err := validateRouterLearningProtectionConfig(cfg.RouterLearning.Protection); err != nil {
 		return err
 	}
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if err := validateDecisionAdaptationsConfig(decision.Name, decision.Adaptations); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_learning.go
+++ b/src/semantic-router/pkg/config/validator_learning.go
@@ -15,7 +15,7 @@ func validateRouterLearningConfig(cfg *RouterConfig) error {
 	if err := validateRouterLearningProtectionConfig(cfg.RouterLearning.Protection); err != nil {
 		return err
 	}
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if err := validateDecisionAdaptationsConfig(decision.Name, decision.Adaptations); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_learning_test.go
+++ b/src/semantic-router/pkg/config/validator_learning_test.go
@@ -63,7 +63,7 @@ global:
 		t.Fatalf("ParseYAMLBytes returned error: %v", err)
 	}
 	assertLearningConfig(t, cfg)
-	assertDecisionAdaptations(t, cfg.Decisions[0].Adaptations, cfg.RouterLearning.Adaptation.EffectiveCandidateSet())
+	assertDecisionAdaptations(t, cfg.DefaultDecisions[0].Adaptations, cfg.RouterLearning.Adaptation.EffectiveCandidateSet())
 }
 
 func assertLearningConfig(t *testing.T, cfg *RouterConfig) {
@@ -246,7 +246,7 @@ global:
 	if err != nil {
 		t.Fatalf("ParseYAMLBytes returned error: %v", err)
 	}
-	adaptations := cfg.Decisions[0].Adaptations
+	adaptations := cfg.DefaultDecisions[0].Adaptations
 	if adaptations.AdaptationMode() != DecisionAdaptationModeBypass ||
 		adaptations.ProtectionMode() != DecisionAdaptationModeBypass {
 		t.Fatalf("expected global decision bypass, got %#v", adaptations)

--- a/src/semantic-router/pkg/config/validator_memory_test.go
+++ b/src/semantic-router/pkg/config/validator_memory_test.go
@@ -45,14 +45,14 @@ func TestValidateMemoryPerDecisionThreshold(t *testing.T) {
 
 	// Valid per-decision threshold passes.
 	okCfg := &RouterConfig{}
-	okCfg.Decisions = []Decision{mkDecision("route_ok", 0.72)}
+	okCfg.DefaultDecisions = []Decision{mkDecision("route_ok", 0.72)}
 	if err := validateMemoryContracts(okCfg); err != nil {
 		t.Fatalf("valid per-decision threshold rejected: %v", err)
 	}
 
 	// Out-of-range per-decision threshold is rejected and names the decision.
 	badCfg := &RouterConfig{}
-	badCfg.Decisions = []Decision{mkDecision("route_bad", 2.0)}
+	badCfg.DefaultDecisions = []Decision{mkDecision("route_bad", 2.0)}
 	err := validateMemoryContracts(badCfg)
 	if err == nil {
 		t.Fatal("out-of-range per-decision threshold must be rejected")

--- a/src/semantic-router/pkg/config/validator_modality.go
+++ b/src/semantic-router/pkg/config/validator_modality.go
@@ -34,7 +34,7 @@ func validateModalityRules(rules []ModalityRule) error {
 // validateModalityDecisions validates that decisions using modality signals have correct modelRefs.
 // Specifically, a BOTH decision must reference both an AR and a diffusion model, OR a single omni model.
 func validateModalityDecisions(cfg *RouterConfig) error {
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		for _, cond := range decision.Rules.Conditions {
 			if cond.Type != SignalTypeModality || cond.Name != "BOTH" {
 				continue

--- a/src/semantic-router/pkg/config/validator_modality.go
+++ b/src/semantic-router/pkg/config/validator_modality.go
@@ -34,7 +34,7 @@ func validateModalityRules(rules []ModalityRule) error {
 // validateModalityDecisions validates that decisions using modality signals have correct modelRefs.
 // Specifically, a BOTH decision must reference both an AR and a diffusion model, OR a single omni model.
 func validateModalityDecisions(cfg *RouterConfig) error {
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		for _, cond := range decision.Rules.Conditions {
 			if cond.Type != SignalTypeModality || cond.Name != "BOTH" {
 				continue

--- a/src/semantic-router/pkg/config/validator_projection.go
+++ b/src/semantic-router/pkg/config/validator_projection.go
@@ -21,7 +21,7 @@ func validateProjectionContracts(cfg *RouterConfig) error {
 	if err != nil {
 		return err
 	}
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if err := validateDecisionProjectionReferences(decision.Name, &decision.Rules, outputNames); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_projection.go
+++ b/src/semantic-router/pkg/config/validator_projection.go
@@ -21,7 +21,7 @@ func validateProjectionContracts(cfg *RouterConfig) error {
 	if err != nil {
 		return err
 	}
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if err := validateDecisionProjectionReferences(decision.Name, &decision.Rules, outputNames); err != nil {
 			return err
 		}

--- a/src/semantic-router/pkg/config/validator_rag_test.go
+++ b/src/semantic-router/pkg/config/validator_rag_test.go
@@ -9,7 +9,7 @@ var _ = Describe("validateDecisionRAGAndMemoryPlugins", func() {
 	It("rejects invalid RAG plugin config on a decision", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{
 						Name: "bad-rag",
 						ModelRefs: []ModelRef{{
@@ -38,7 +38,7 @@ var _ = Describe("validateDecisionRAGAndMemoryPlugins", func() {
 	It("accepts valid RAG plugin config on a decision", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{
 						Name: "good-rag",
 						ModelRefs: []ModelRef{{

--- a/src/semantic-router/pkg/config/validator_semantic_cache_test.go
+++ b/src/semantic-router/pkg/config/validator_semantic_cache_test.go
@@ -48,14 +48,14 @@ func TestValidateSemanticCachePerDecisionThreshold(t *testing.T) {
 
 	// Valid per-decision threshold passes.
 	okCfg := &RouterConfig{}
-	okCfg.Decisions = []Decision{mkDecision("route_ok", 0.7)}
+	okCfg.DefaultDecisions = []Decision{mkDecision("route_ok", 0.7)}
 	if err := validateSemanticCacheContracts(okCfg); err != nil {
 		t.Fatalf("valid per-decision threshold rejected: %v", err)
 	}
 
 	// Out-of-range per-decision threshold is rejected and names the decision.
 	badCfg := &RouterConfig{}
-	badCfg.Decisions = []Decision{mkDecision("route_bad", 2.0)}
+	badCfg.DefaultDecisions = []Decision{mkDecision("route_bad", 2.0)}
 	err := validateSemanticCacheContracts(badCfg)
 	if err == nil {
 		t.Fatal("out-of-range per-decision threshold must be rejected")

--- a/src/semantic-router/pkg/config/validator_test.go
+++ b/src/semantic-router/pkg/config/validator_test.go
@@ -105,7 +105,7 @@ func registerValidateConfigStructureCoreDispatchSpecs() {
 		cfg := &RouterConfig{
 			ConfigSource: ConfigSourceKubernetes,
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{Name: "bad", ModelRefs: nil}},
+				DefaultDecisions: []Decision{{Name: "bad", ModelRefs: nil}},
 			},
 		}
 		Expect(validateConfigStructure(cfg)).To(Succeed())
@@ -115,7 +115,7 @@ func registerValidateConfigStructureCoreDispatchSpecs() {
 		cfg := &RouterConfig{
 			ConfigSource: ConfigSourceKubernetes,
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "bad",
 					ModelRefs: []ModelRef{{
 						Model:                 "",
@@ -146,7 +146,7 @@ func registerValidateConfigStructureCoreDispatchSpecs() {
 	It("accepts valid decision", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "ok",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -168,7 +168,7 @@ func registerValidateConfigStructureOutputContractAcceptSpecs() {
 	It("accepts typed choice output contract spec", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "choice",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -190,7 +190,7 @@ func registerValidateConfigStructureOutputContractAcceptSpecs() {
 	It("accepts typed terminal action output contract spec", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "json-action",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -215,7 +215,7 @@ func registerValidateConfigStructureOutputContractAcceptSpecs() {
 	It("accepts typed reference selection output contract spec", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "reference-selection",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -246,7 +246,7 @@ func registerValidateConfigStructureOutputContractRejectSpecs() {
 	It("rejects dereference postprocess without reference selection type", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "reference-postprocess",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -268,7 +268,7 @@ func registerValidateConfigStructureOutputContractRejectSpecs() {
 	It("rejects typed choice output contract without choices", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "bad-choice",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -286,7 +286,7 @@ func registerValidateConfigStructureOutputContractRejectSpecs() {
 	It("rejects json object extraction on choice output contract", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "bad-choice-extract",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -310,7 +310,7 @@ func registerValidateConfigStructureOutputContractRejectSpecs() {
 	It("rejects unsupported structured_json schema refs", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "bad-json",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -335,7 +335,7 @@ func registerValidateConfigStructureModelRefSpecs() {
 	It("accepts empty modelRefs", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{Name: "x", ModelRefs: []ModelRef{}}},
+				DefaultDecisions: []Decision{{Name: "x", ModelRefs: []ModelRef{}}},
 			},
 		}
 		Expect(validateConfigStructure(cfg)).To(Succeed())
@@ -344,7 +344,7 @@ func registerValidateConfigStructureModelRefSpecs() {
 	It("rejects blank model name", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "x",
 					ModelRefs: []ModelRef{{
 						Model:                 "",
@@ -361,7 +361,7 @@ func registerValidateConfigStructureModelRefSpecs() {
 	It("rejects nil use_reasoning", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name:      "x",
 					ModelRefs: []ModelRef{{Model: "model-a"}},
 				}},
@@ -377,7 +377,7 @@ func registerValidateConfigStructureLoRASpecs() {
 	It("validates lora ref in decision", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "x",
 					ModelRefs: []ModelRef{{
 						Model:                 "qwen3",
@@ -398,7 +398,7 @@ func registerValidateConfigStructureLoRASpecs() {
 	It("rejects bad lora ref", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "x",
 					ModelRefs: []ModelRef{{
 						Model:                 "qwen3",
@@ -432,7 +432,7 @@ func registerValidateConfigStructureAlgorithmSchemaSpecs() {
 	It("rejects latency_aware without algorithm.latency_aware", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "x",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -452,7 +452,7 @@ func registerValidateConfigStructureAlgorithmSchemaSpecs() {
 	It("accepts latency_aware-only configuration", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "new-latency-aware",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -472,7 +472,7 @@ func registerValidateConfigStructureAlgorithmSchemaSpecs() {
 	It("rejects multiple algorithm config blocks in one decision", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "mixed-algo-blocks",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -525,7 +525,7 @@ func registerValidateConfigStructureReMoMDecisionSpecs() {
 	It("accepts remom round_robin distribution", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "remom-round-robin",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -550,7 +550,7 @@ func registerValidateConfigStructureReMoMDecisionSpecs() {
 	It("rejects invalid remom model_distribution", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "remom-invalid-distribution",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -575,7 +575,7 @@ func registerValidateConfigStructureReMoMDecisionSpecs() {
 	It("rejects invalid remom quorum and timeout controls", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "remom-invalid-timeout",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -601,7 +601,7 @@ func registerValidateConfigStructureReMoMDecisionSpecs() {
 	It("rejects remom synthesis_model outside modelRefs", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "remom-invalid-synthesis-model",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -656,7 +656,7 @@ func registerValidateConfigStructureFusionSpecs() {
 	It("accepts fusion with decision modelRefs and no fusion block", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "fusion-with-model-refs",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -673,7 +673,7 @@ func registerValidateConfigStructureFusionSpecs() {
 	It("rejects invalid decision fusion on_error", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "fusion-invalid-on-error",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -719,7 +719,7 @@ func registerValidateConfigStructureDynamicWorkflowPlannerSpecs() {
 	It("accepts dynamic workflows with planner model", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "dynamic-flow",
 					ModelRefs: []ModelRef{{
 						Model:                 "worker-a",
@@ -749,7 +749,7 @@ func registerValidateConfigStructureDynamicWorkflowPlannerSpecs() {
 	It("rejects dynamic workflows with invalid planner max completion tokens", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "dynamic-flow",
 					ModelRefs: []ModelRef{{
 						Model:                 "worker-a",
@@ -777,7 +777,7 @@ func registerValidateConfigStructureDynamicWorkflowPlannerSpecs() {
 	It("rejects dynamic workflows with invalid quorum controls", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "dynamic-flow-invalid-quorum",
 					ModelRefs: []ModelRef{{
 						Model:                 "worker-a",
@@ -806,7 +806,7 @@ func registerValidateConfigStructureDynamicWorkflowFinalSpecs() {
 	It("accepts dynamic workflows with configured final model", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "dynamic-flow-final",
 					ModelRefs: []ModelRef{
 						{
@@ -836,7 +836,7 @@ func registerValidateConfigStructureDynamicWorkflowFinalSpecs() {
 	It("rejects dynamic workflow final model outside modelRefs", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "dynamic-flow-final-outside-modelrefs",
 					ModelRefs: []ModelRef{{
 						Model:                 "worker-a",
@@ -862,7 +862,7 @@ func registerValidateConfigStructureDynamicWorkflowFinalSpecs() {
 	It("rejects dynamic workflows without planner model", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "dynamic-flow-no-planner",
 					ModelRefs: []ModelRef{{
 						Model:                 "worker-a",
@@ -888,7 +888,7 @@ func registerValidateConfigStructureStaticWorkflowsSpecs() {
 	It("accepts static workflows with explicit roles", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "static-flow",
 					ModelRefs: []ModelRef{
 						{
@@ -921,7 +921,7 @@ func registerValidateConfigStructureStaticWorkflowsSpecs() {
 	It("rejects static workflows without roles", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "static-flow-no-roles",
 					ModelRefs: []ModelRef{{
 						Model:                 "worker-a",
@@ -943,7 +943,7 @@ func registerValidateConfigStructureStaticWorkflowsSpecs() {
 	It("rejects static workflow role models outside modelRefs", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "static-flow-outside-modelrefs",
 					ModelRefs: []ModelRef{{
 						Model:                 "worker-a",
@@ -973,7 +973,7 @@ func registerValidateConfigStructureAlgorithmTypeMismatchSpecs() {
 	It("rejects algorithm type and config block mismatch", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "mismatched-algo-block",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -995,7 +995,7 @@ func registerValidateConfigStructureAlgorithmTypeMismatchSpecs() {
 	It("rejects unsupported algorithm block for static type", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "static-with-block",
 					ModelRefs: []ModelRef{{
 						Model:                 "model-a",
@@ -1019,7 +1019,7 @@ func registerValidateConfigStructureLegacyLatencySpecs() {
 	It("rejects legacy latency conditions", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{{
+				DefaultDecisions: []Decision{{
 					Name: "legacy-latency",
 					Rules: RuleCombination{
 						Operator: "AND",
@@ -1044,7 +1044,7 @@ func registerValidateConfigStructureLegacyLatencySpecs() {
 	It("rejects mixed latency condition and latency_aware configurations", func() {
 		cfg := &RouterConfig{
 			IntelligentRouting: IntelligentRouting{
-				Decisions: []Decision{
+				DefaultDecisions: []Decision{
 					{
 						Name: "legacy-latency",
 						Rules: RuleCombination{

--- a/src/semantic-router/pkg/config/workflows_config.go
+++ b/src/semantic-router/pkg/config/workflows_config.go
@@ -157,7 +157,7 @@ func (c *RouterConfig) HasFlowDecision() bool {
 	if c == nil {
 		return false
 	}
-	for _, decision := range c.Decisions {
+	for _, decision := range c.DefaultDecisions {
 		if decision.Algorithm != nil && decision.Algorithm.Type == "workflows" {
 			return true
 		}

--- a/src/semantic-router/pkg/config/workflows_config.go
+++ b/src/semantic-router/pkg/config/workflows_config.go
@@ -157,6 +157,7 @@ func (c *RouterConfig) HasFlowDecision() bool {
 	if c == nil {
 		return false
 	}
+	// Default profile only — see HasFusionDecision for the rationale.
 	for _, decision := range c.DefaultDecisions {
 		if decision.Algorithm != nil && decision.Algorithm.Type == "workflows" {
 			return true

--- a/src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go
+++ b/src/semantic-router/pkg/dsl/compiler_rag_max_context_length_test.go
@@ -113,7 +113,7 @@ func mustCompile(t *testing.T, input string) *config.RouterConfig {
 // the runtime uses to read decision plugin configs.
 func mustExtractRAGPluginConfig(t *testing.T, cfg *config.RouterConfig) config.RAGPluginConfig {
 	t.Helper()
-	for _, dec := range cfg.Decisions {
+	for _, dec := range cfg.DefaultDecisions {
 		for _, p := range dec.Plugins {
 			if p.Type != config.DecisionPluginRAG {
 				continue

--- a/src/semantic-router/pkg/dsl/compiler_routes.go
+++ b/src/semantic-router/pkg/dsl/compiler_routes.go
@@ -4,7 +4,7 @@ import "github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 
 func (c *Compiler) compileRoutes() {
 	for _, r := range c.prog.Routes {
-		c.config.Decisions = append(c.config.Decisions, c.compileRoute(r))
+		c.config.DefaultDecisions = append(c.config.DefaultDecisions, c.compileRoute(r))
 	}
 }
 

--- a/src/semantic-router/pkg/dsl/decompiler.go
+++ b/src/semantic-router/pkg/dsl/decompiler.go
@@ -37,7 +37,7 @@ func (d *decompiler) extractPluginTemplates() {
 	}
 	seen := make(map[pluginKey]*pluginTemplate)
 
-	for _, dec := range d.cfg.Decisions {
+	for _, dec := range d.cfg.DefaultDecisions {
 		for _, p := range dec.Plugins {
 			key := pluginKey{pluginType: p.Type}
 			// Use a simple fingerprint: type

--- a/src/semantic-router/pkg/dsl/decompiler_decisions.go
+++ b/src/semantic-router/pkg/dsl/decompiler_decisions.go
@@ -166,6 +166,9 @@ func decompileComposerObj(node *config.RuleCombination) string {
 	return fmt.Sprintf("{ operator: %q, conditions: [%s] }", node.Operator, strings.Join(parts, ", "))
 }
 
+// decompileDecisions walks the default recipe only: the DSL has no surface for
+// named recipes yet (pl-0038 T10 tracks the round trip), so a config carrying
+// recipes cannot be decompiled without loss.
 func (d *decompiler) decompileDecisions() {
 	for _, dec := range d.cfg.DefaultDecisions {
 		d.decompileDecision(dec)

--- a/src/semantic-router/pkg/dsl/decompiler_decisions.go
+++ b/src/semantic-router/pkg/dsl/decompiler_decisions.go
@@ -167,7 +167,7 @@ func decompileComposerObj(node *config.RuleCombination) string {
 }
 
 func (d *decompiler) decompileDecisions() {
-	for _, dec := range d.cfg.Decisions {
+	for _, dec := range d.cfg.DefaultDecisions {
 		d.decompileDecision(dec)
 	}
 }

--- a/src/semantic-router/pkg/dsl/decompiler_plugin_config_test.go
+++ b/src/semantic-router/pkg/dsl/decompiler_plugin_config_test.go
@@ -51,8 +51,8 @@ routing:
 		`max_body_bytes: 4096`,
 	})
 	compiled := mustCompileRoutingPluginConfigTest(t, dslText)
-	assertSemanticCachePluginRoundTrip(t, compiled.Decisions[0])
-	assertRouterReplayPluginRoundTrip(t, compiled.Decisions[0])
+	assertSemanticCachePluginRoundTrip(t, compiled.DefaultDecisions[0])
+	assertRouterReplayPluginRoundTrip(t, compiled.DefaultDecisions[0])
 }
 
 func TestDecompileRoutingRoundTripsToolsDynamicRetrievalPluginConfig(t *testing.T) {
@@ -108,7 +108,7 @@ routing:
 	})
 
 	compiled := mustCompileRoutingPluginConfigTest(t, dslText)
-	assertToolsPluginDynamicRetrievalRoundTrip(t, compiled.Decisions[0])
+	assertToolsPluginDynamicRetrievalRoundTrip(t, compiled.DefaultDecisions[0])
 }
 
 func mustParseRoutingPluginConfigTest(t *testing.T, configYAML string) *config.RouterConfig {
@@ -148,8 +148,8 @@ func mustCompileRoutingPluginConfigTest(t *testing.T, dslText string) *config.Ro
 	if len(errs) > 0 {
 		t.Fatalf("Compile errors: %v", errs)
 	}
-	if len(compiled.Decisions) != 1 {
-		t.Fatalf("compiled decisions = %d", len(compiled.Decisions))
+	if len(compiled.DefaultDecisions) != 1 {
+		t.Fatalf("compiled decisions = %d", len(compiled.DefaultDecisions))
 	}
 	return compiled
 }

--- a/src/semantic-router/pkg/dsl/dsl_test.go
+++ b/src/semantic-router/pkg/dsl/dsl_test.go
@@ -389,10 +389,10 @@ ROUTE math_route {
 	}
 
 	// Check decision
-	if len(cfg.Decisions) != 1 {
-		t.Fatalf("expected 1 decision, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(cfg.DefaultDecisions))
 	}
-	d := cfg.Decisions[0]
+	d := cfg.DefaultDecisions[0]
 	if d.Name != "math_route" {
 		t.Errorf("expected decision name 'math_route', got %q", d.Name)
 	}
@@ -452,13 +452,13 @@ SIGNAL domain test { description: "test" }`
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if len(cfg.Decisions) != 1 {
-		t.Fatalf("expected 1 decision, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(cfg.DefaultDecisions))
 	}
-	if len(cfg.Decisions[0].Plugins) != 1 {
-		t.Fatalf("expected 1 plugin, got %d", len(cfg.Decisions[0].Plugins))
+	if len(cfg.DefaultDecisions[0].Plugins) != 1 {
+		t.Fatalf("expected 1 plugin, got %d", len(cfg.DefaultDecisions[0].Plugins))
 	}
-	p := cfg.Decisions[0].Plugins[0]
+	p := cfg.DefaultDecisions[0].Plugins[0]
 	if p.Type != "hallucination" {
 		t.Errorf("expected plugin type hallucination, got %s", p.Type)
 	}
@@ -485,7 +485,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	p := cfg.Decisions[0].Plugins[0]
+	p := cfg.DefaultDecisions[0].Plugins[0]
 	if p.Type != "semantic-cache" { // normalized
 		t.Errorf("expected plugin type semantic-cache, got %s", p.Type)
 	}
@@ -507,7 +507,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	rules := cfg.Decisions[0].Rules
+	rules := cfg.DefaultDecisions[0].Rules
 	if rules.Operator != "AND" {
 		t.Fatalf("expected top-level AND, got %s", rules.Operator)
 	}
@@ -536,7 +536,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	algo := cfg.Decisions[0].Algorithm
+	algo := cfg.DefaultDecisions[0].Algorithm
 	if algo == nil {
 		t.Fatal("expected algorithm")
 	}
@@ -579,7 +579,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	algo := cfg.Decisions[0].Algorithm
+	algo := cfg.DefaultDecisions[0].Algorithm
 	if algo.ReMoM == nil {
 		t.Fatal("expected remom config")
 	}
@@ -832,8 +832,8 @@ func TestCompileFullExample(t *testing.T) {
 	}
 
 	// Decisions
-	if len(cfg.Decisions) != 4 {
-		t.Errorf("expected 4 decisions, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 4 {
+		t.Errorf("expected 4 decisions, got %d", len(cfg.DefaultDecisions))
 	}
 	if len(cfg.ModelConfig) != 2 {
 		t.Fatalf("expected 2 routing model entries, got %d", len(cfg.ModelConfig))
@@ -847,7 +847,7 @@ func TestCompileFullExample(t *testing.T) {
 		name  string
 		rules interface{}
 	}
-	for _, d := range cfg.Decisions {
+	for _, d := range cfg.DefaultDecisions {
 		if d.Name == "urgent_ai_route" {
 			if d.Rules.Operator != "AND" {
 				t.Errorf("expected AND operator for urgent route rules, got %s", d.Rules.Operator)
@@ -995,8 +995,8 @@ ROUTE urgent_ai_route {
 	}
 
 	// -- Decisions
-	if len(roundTripped.Decisions) != 2 {
-		t.Fatalf("round-trip: expected 2 decisions, got %d", len(roundTripped.Decisions))
+	if len(roundTripped.DefaultDecisions) != 2 {
+		t.Fatalf("round-trip: expected 2 decisions, got %d", len(roundTripped.DefaultDecisions))
 	}
 	if len(roundTripped.ModelConfig) != 2 {
 		t.Fatalf("round-trip: expected 2 routing model entries, got %d", len(roundTripped.ModelConfig))
@@ -1007,12 +1007,12 @@ ROUTE urgent_ai_route {
 
 	// Find math_route decision
 	var mathDec, urgentDec *config.Decision
-	for i := range roundTripped.Decisions {
-		switch roundTripped.Decisions[i].Name {
+	for i := range roundTripped.DefaultDecisions {
+		switch roundTripped.DefaultDecisions[i].Name {
 		case "math_route":
-			mathDec = &roundTripped.Decisions[i]
+			mathDec = &roundTripped.DefaultDecisions[i]
 		case "urgent_ai_route":
-			urgentDec = &roundTripped.Decisions[i]
+			urgentDec = &roundTripped.DefaultDecisions[i]
 		}
 	}
 
@@ -1110,10 +1110,10 @@ ROUTE math_route {
 		t.Fatalf("compile errors: %v", errs)
 	}
 
-	if len(cfg.Decisions) != 1 {
-		t.Fatalf("expected 1 decision, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(cfg.DefaultDecisions))
 	}
-	rules := cfg.Decisions[0].Rules
+	rules := cfg.DefaultDecisions[0].Rules
 
 	// Single WHEN domain("math") should be wrapped in AND for Python CLI compatibility
 	if rules.Operator != "AND" || len(rules.Conditions) != 1 {
@@ -1135,7 +1135,7 @@ ROUTE math_route {
 		t.Fatalf("yaml.Unmarshal failed: %v\nYAML:\n%s", err, string(yamlBytes))
 	}
 
-	rtRules := rt.Decisions[0].Rules
+	rtRules := rt.DefaultDecisions[0].Rules
 	if rtRules.Operator != "AND" || len(rtRules.Conditions) != 1 {
 		t.Fatalf("after round-trip: expected AND with 1 condition, got operator=%q with %d conditions",
 			rtRules.Operator, len(rtRules.Conditions))
@@ -1163,7 +1163,7 @@ ROUTE test_route {
 		t.Fatalf("compile errors: %v", errs)
 	}
 
-	rules := cfg.Decisions[0].Rules
+	rules := cfg.DefaultDecisions[0].Rules
 	if rules.IsLeaf() {
 		t.Fatal("AND expression should produce a composite node, got leaf")
 	}
@@ -1599,7 +1599,7 @@ ROUTE test {
 			if len(errs) > 0 {
 				t.Fatalf("compile errors: %v", errs)
 			}
-			algo := cfg.Decisions[0].Algorithm
+			algo := cfg.DefaultDecisions[0].Algorithm
 			if algo == nil {
 				t.Fatal("expected algorithm")
 			}
@@ -1613,7 +1613,7 @@ ROUTE test {
 
 func TestDecompileCurrentAlgorithmSurfaceRoundTrips(t *testing.T) {
 	cfg := &config.RouterConfig{
-		IntelligentRouting: config.IntelligentRouting{Decisions: []config.Decision{
+		IntelligentRouting: config.IntelligentRouting{DefaultDecisions: []config.Decision{
 			{
 				Name: "multi-factor-route",
 				ModelRefs: []config.ModelRef{
@@ -1664,8 +1664,8 @@ func TestDecompileCurrentAlgorithmSurfaceRoundTrips(t *testing.T) {
 	}
 
 	byName := map[string]*config.AlgorithmConfig{}
-	for i := range roundTripped.Decisions {
-		decision := &roundTripped.Decisions[i]
+	for i := range roundTripped.DefaultDecisions {
+		decision := &roundTripped.DefaultDecisions[i]
 		byName[decision.Name] = decision.Algorithm
 	}
 
@@ -1750,10 +1750,10 @@ ROUTE test {
 			if len(errs) > 0 {
 				t.Fatalf("compile errors: %v", errs)
 			}
-			if len(cfg.Decisions[0].Plugins) != 1 {
-				t.Fatalf("expected 1 plugin, got %d", len(cfg.Decisions[0].Plugins))
+			if len(cfg.DefaultDecisions[0].Plugins) != 1 {
+				t.Fatalf("expected 1 plugin, got %d", len(cfg.DefaultDecisions[0].Plugins))
 			}
-			p := cfg.Decisions[0].Plugins[0]
+			p := cfg.DefaultDecisions[0].Plugins[0]
 			if p.Type != tc.verifyType {
 				t.Errorf("plugin type = %q, want %q", p.Type, tc.verifyType)
 			}
@@ -1878,7 +1878,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	rules := cfg.Decisions[0].Rules
+	rules := cfg.DefaultDecisions[0].Rules
 	if rules.Operator != "OR" {
 		t.Errorf("expected OR operator, got %q", rules.Operator)
 	}
@@ -1899,7 +1899,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	rules := cfg.Decisions[0].Rules
+	rules := cfg.DefaultDecisions[0].Rules
 	if rules.Operator != "NOT" {
 		t.Errorf("expected NOT operator, got %q", rules.Operator)
 	}
@@ -1923,7 +1923,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	rules := cfg.Decisions[0].Rules
+	rules := cfg.DefaultDecisions[0].Rules
 	if rules.Operator != "AND" {
 		t.Errorf("expected top-level AND, got %q", rules.Operator)
 	}
@@ -2159,8 +2159,8 @@ func TestCompileASTDirect(t *testing.T) {
 	if len(cfg.Categories) != 1 || cfg.Categories[0].Name != "math" {
 		t.Errorf("categories = %v", cfg.Categories)
 	}
-	if len(cfg.Decisions) != 1 || cfg.Decisions[0].Priority != 42 {
-		t.Errorf("decisions = %v", cfg.Decisions)
+	if len(cfg.DefaultDecisions) != 1 || cfg.DefaultDecisions[0].Priority != 42 {
+		t.Errorf("decisions = %v", cfg.DefaultDecisions)
 	}
 }
 
@@ -2235,7 +2235,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	c := cfg.Decisions[0].Algorithm.Confidence
+	c := cfg.DefaultDecisions[0].Algorithm.Confidence
 	if c.ConfidenceMethod != "logprob" {
 		t.Errorf("method = %q", c.ConfidenceMethod)
 	}
@@ -2280,7 +2280,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	r := cfg.Decisions[0].Algorithm.ReMoM
+	r := cfg.DefaultDecisions[0].Algorithm.ReMoM
 	if len(r.BreadthSchedule) != 3 || r.BreadthSchedule[2] != 2 {
 		t.Errorf("breadth_schedule = %v", r.BreadthSchedule)
 	}
@@ -2385,8 +2385,8 @@ func TestDoubleRoundTrip(t *testing.T) {
 	if len(rt1.Categories) != len(rt2.Categories) {
 		t.Errorf("categories count: %d vs %d", len(rt1.Categories), len(rt2.Categories))
 	}
-	if len(rt1.Decisions) != len(rt2.Decisions) {
-		t.Errorf("decisions count: %d vs %d", len(rt1.Decisions), len(rt2.Decisions))
+	if len(rt1.DefaultDecisions) != len(rt2.DefaultDecisions) {
+		t.Errorf("decisions count: %d vs %d", len(rt1.DefaultDecisions), len(rt2.DefaultDecisions))
 	}
 	if len(rt1.VLLMEndpoints) != len(rt2.VLLMEndpoints) {
 		t.Errorf("endpoints count: %d vs %d", len(rt1.VLLMEndpoints), len(rt2.VLLMEndpoints))
@@ -2421,8 +2421,8 @@ func TestLargeScaleInput(t *testing.T) {
 	if len(cfg.Categories) != numSignals {
 		t.Errorf("expected %d categories, got %d", numSignals, len(cfg.Categories))
 	}
-	if len(cfg.Decisions) != numRoutes {
-		t.Errorf("expected %d decisions, got %d", numRoutes, len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != numRoutes {
+		t.Errorf("expected %d decisions, got %d", numRoutes, len(cfg.DefaultDecisions))
 	}
 
 	// Verify YAML emission works
@@ -2533,19 +2533,19 @@ ROUTE route_c { PRIORITY 50 WHEN domain("bio") MODEL "m:1b" (reasoning = false) 
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if len(cfg.Decisions) != 3 {
-		t.Fatalf("expected 3 decisions, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 3 {
+		t.Fatalf("expected 3 decisions, got %d", len(cfg.DefaultDecisions))
 	}
 
 	// Verify order is preserved
-	if cfg.Decisions[0].Name != "route_a" {
-		t.Errorf("first decision = %q, want route_a", cfg.Decisions[0].Name)
+	if cfg.DefaultDecisions[0].Name != "route_a" {
+		t.Errorf("first decision = %q, want route_a", cfg.DefaultDecisions[0].Name)
 	}
-	if cfg.Decisions[1].Name != "route_b" {
-		t.Errorf("second decision = %q, want route_b", cfg.Decisions[1].Name)
+	if cfg.DefaultDecisions[1].Name != "route_b" {
+		t.Errorf("second decision = %q, want route_b", cfg.DefaultDecisions[1].Name)
 	}
 	// Both should have priority 100
-	if cfg.Decisions[0].Priority != 100 || cfg.Decisions[1].Priority != 100 {
+	if cfg.DefaultDecisions[0].Priority != 100 || cfg.DefaultDecisions[1].Priority != 100 {
 		t.Error("route_a and route_b should both have priority 100")
 	}
 }
@@ -2560,7 +2560,7 @@ func TestWhitespaceAndCommentVariants(t *testing.T) {
 	if len(errs1) > 0 {
 		t.Fatalf("compact compile errors: %v", errs1)
 	}
-	if len(cfg1.Categories) != 1 || len(cfg1.Decisions) != 1 {
+	if len(cfg1.Categories) != 1 || len(cfg1.DefaultDecisions) != 1 {
 		t.Error("compact input failed to parse correctly")
 	}
 
@@ -2583,7 +2583,7 @@ ROUTE r {
 	if len(errs2) > 0 {
 		t.Fatalf("commented compile errors: %v", errs2)
 	}
-	if len(cfg2.Categories) != 1 || len(cfg2.Decisions) != 1 {
+	if len(cfg2.Categories) != 1 || len(cfg2.DefaultDecisions) != 1 {
 		t.Error("commented input failed to parse correctly")
 	}
 }
@@ -2621,13 +2621,13 @@ ROUTE route_b {
 	}
 
 	// route_a: uses template as-is
-	pA := cfg.Decisions[0].Plugins[0]
+	pA := cfg.DefaultDecisions[0].Plugins[0]
 	if pA.Type != "semantic-cache" {
 		t.Errorf("route_a plugin type = %q, want semantic-cache", pA.Type)
 	}
 
 	// route_b: uses template with override
-	pB := cfg.Decisions[1].Plugins[0]
+	pB := cfg.DefaultDecisions[1].Plugins[0]
 	if pB.Type != "semantic-cache" {
 		t.Errorf("route_b plugin type = %q, want semantic-cache", pB.Type)
 	}
@@ -2661,8 +2661,8 @@ func TestFullExampleYAMLRoundTrip(t *testing.T) {
 	if len(rt.KeywordRules) != 1 {
 		t.Errorf("keyword_rules = %d", len(rt.KeywordRules))
 	}
-	if len(rt.Decisions) != 4 {
-		t.Errorf("decisions = %d, want 4", len(rt.Decisions))
+	if len(rt.DefaultDecisions) != 4 {
+		t.Errorf("decisions = %d, want 4", len(rt.DefaultDecisions))
 	}
 	if len(rt.ModelConfig) != 2 {
 		t.Errorf("model_config = %d, want 2", len(rt.ModelConfig))
@@ -2672,7 +2672,7 @@ func TestFullExampleYAMLRoundTrip(t *testing.T) {
 	}
 
 	// Check urgent_ai_route specifically
-	for _, d := range rt.Decisions {
+	for _, d := range rt.DefaultDecisions {
 		if d.Name == "urgent_ai_route" {
 			if d.Priority != 200 {
 				t.Errorf("urgent priority = %d", d.Priority)
@@ -2820,8 +2820,8 @@ ROUTE my_route (description = "This is a detailed description") {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if cfg.Decisions[0].Description != "This is a detailed description" {
-		t.Errorf("description = %q", cfg.Decisions[0].Description)
+	if cfg.DefaultDecisions[0].Description != "This is a detailed description" {
+		t.Errorf("description = %q", cfg.DefaultDecisions[0].Description)
 	}
 
 	// Verify survives YAML round-trip
@@ -2833,8 +2833,8 @@ ROUTE my_route (description = "This is a detailed description") {
 	if err := yaml.Unmarshal(yamlBytes, &rt); err != nil {
 		t.Fatalf("unmarshal error: %v", err)
 	}
-	if rt.Decisions[0].Description != "This is a detailed description" {
-		t.Errorf("round-trip description = %q", rt.Decisions[0].Description)
+	if rt.DefaultDecisions[0].Description != "This is a detailed description" {
+		t.Errorf("round-trip description = %q", rt.DefaultDecisions[0].Description)
 	}
 }
 
@@ -2853,8 +2853,8 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if cfg.Decisions[0].ModelRefs[0].LoRAName != "math-lora-v2" {
-		t.Errorf("lora_name = %q", cfg.Decisions[0].ModelRefs[0].LoRAName)
+	if cfg.DefaultDecisions[0].ModelRefs[0].LoRAName != "math-lora-v2" {
+		t.Errorf("lora_name = %q", cfg.DefaultDecisions[0].ModelRefs[0].LoRAName)
 	}
 
 	yamlBytes, err := EmitYAMLFromConfig(cfg)
@@ -2865,8 +2865,8 @@ ROUTE test {
 	if err := yaml.Unmarshal(yamlBytes, &rt); err != nil {
 		t.Fatalf("unmarshal error: %v", err)
 	}
-	if rt.Decisions[0].ModelRefs[0].LoRAName != "math-lora-v2" {
-		t.Errorf("round-trip lora_name = %q", rt.Decisions[0].ModelRefs[0].LoRAName)
+	if rt.DefaultDecisions[0].ModelRefs[0].LoRAName != "math-lora-v2" {
+		t.Errorf("round-trip lora_name = %q", rt.DefaultDecisions[0].ModelRefs[0].LoRAName)
 	}
 }
 
@@ -2913,7 +2913,7 @@ ROUTE test {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	algo := cfg.Decisions[0].Algorithm
+	algo := cfg.DefaultDecisions[0].Algorithm
 	// For confidence/ratings/remom, on_error goes into the sub-config, not the top level
 	if algo.OnError != "" {
 		t.Errorf("algo top-level on_error = %q, want empty", algo.OnError)
@@ -3240,20 +3240,20 @@ func TestDecompileRoundTrip(t *testing.T) {
 	if len(cfg1.Categories) != len(cfg2.Categories) {
 		t.Errorf("categories: %d vs %d", len(cfg1.Categories), len(cfg2.Categories))
 	}
-	if len(cfg1.Decisions) != len(cfg2.Decisions) {
-		t.Errorf("decisions: %d vs %d", len(cfg1.Decisions), len(cfg2.Decisions))
+	if len(cfg1.DefaultDecisions) != len(cfg2.DefaultDecisions) {
+		t.Errorf("decisions: %d vs %d", len(cfg1.DefaultDecisions), len(cfg2.DefaultDecisions))
 	}
 
 	// Compare each decision
-	for i := range cfg1.Decisions {
-		if i >= len(cfg2.Decisions) {
+	for i := range cfg1.DefaultDecisions {
+		if i >= len(cfg2.DefaultDecisions) {
 			break
 		}
-		if cfg1.Decisions[i].Name != cfg2.Decisions[i].Name {
-			t.Errorf("decision[%d].name: %q vs %q", i, cfg1.Decisions[i].Name, cfg2.Decisions[i].Name)
+		if cfg1.DefaultDecisions[i].Name != cfg2.DefaultDecisions[i].Name {
+			t.Errorf("decision[%d].name: %q vs %q", i, cfg1.DefaultDecisions[i].Name, cfg2.DefaultDecisions[i].Name)
 		}
-		if cfg1.Decisions[i].Priority != cfg2.Decisions[i].Priority {
-			t.Errorf("decision[%d].priority: %d vs %d", i, cfg1.Decisions[i].Priority, cfg2.Decisions[i].Priority)
+		if cfg1.DefaultDecisions[i].Priority != cfg2.DefaultDecisions[i].Priority {
+			t.Errorf("decision[%d].priority: %d vs %d", i, cfg1.DefaultDecisions[i].Priority, cfg2.DefaultDecisions[i].Priority)
 		}
 	}
 }
@@ -3877,8 +3877,8 @@ func TestCLICompileAndDecompile(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("recompile errors: %v\nDSL:\n%s", errs, string(dslData))
 	}
-	if len(cfg.Decisions) == 0 {
-		t.Fatalf("round-trip decisions = %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) == 0 {
+		t.Fatalf("round-trip decisions = %d", len(cfg.DefaultDecisions))
 	}
 	if len(cfg.ModelConfig) == 0 {
 		t.Fatal("round-trip model catalog should not be empty")
@@ -5090,7 +5090,7 @@ ROUTE reasoning_route {
 	if got := cfg.Projections.Mappings[0].Outputs[0].Name; got != "balance_medium" {
 		t.Fatalf("first projection output = %q, want balance_medium", got)
 	}
-	if got := cfg.Decisions[0].Rules.Conditions[0].Type; got != "projection" {
+	if got := cfg.DefaultDecisions[0].Rules.Conditions[0].Type; got != "projection" {
 		t.Fatalf("compiled route leaf type = %q, want projection", got)
 	}
 }
@@ -5478,11 +5478,11 @@ ROUTE math_route {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if cfg.Decisions[0].Tier != 1 {
-		t.Errorf("decision[0].Tier = %d, want 1", cfg.Decisions[0].Tier)
+	if cfg.DefaultDecisions[0].Tier != 1 {
+		t.Errorf("decision[0].Tier = %d, want 1", cfg.DefaultDecisions[0].Tier)
 	}
-	if cfg.Decisions[1].Tier != 2 {
-		t.Errorf("decision[1].Tier = %d, want 2", cfg.Decisions[1].Tier)
+	if cfg.DefaultDecisions[1].Tier != 2 {
+		t.Errorf("decision[1].Tier = %d, want 2", cfg.DefaultDecisions[1].Tier)
 	}
 }
 
@@ -5555,14 +5555,14 @@ DECISION_TREE routing_policy {
 	if len(compileErrs) > 0 {
 		t.Fatalf("compile errors: %v", compileErrs)
 	}
-	if len(cfg.Decisions) != 3 {
-		t.Fatalf("expected 3 compiled decisions, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 3 {
+		t.Fatalf("expected 3 compiled decisions, got %d", len(cfg.DefaultDecisions))
 	}
-	if cfg.Decisions[1].Rules.Operator != "AND" || len(cfg.Decisions[1].Rules.Conditions) != 2 {
-		t.Fatalf("expected second branch to include original condition plus prior-branch negation, got %+v", cfg.Decisions[1].Rules)
+	if cfg.DefaultDecisions[1].Rules.Operator != "AND" || len(cfg.DefaultDecisions[1].Rules.Conditions) != 2 {
+		t.Fatalf("expected second branch to include original condition plus prior-branch negation, got %+v", cfg.DefaultDecisions[1].Rules)
 	}
-	if cfg.Decisions[2].Rules.Operator != "AND" || len(cfg.Decisions[2].Rules.Conditions) != 2 {
-		t.Fatalf("expected ELSE branch to include two negated prior branches, got %+v", cfg.Decisions[2].Rules)
+	if cfg.DefaultDecisions[2].Rules.Operator != "AND" || len(cfg.DefaultDecisions[2].Rules.Conditions) != 2 {
+		t.Fatalf("expected ELSE branch to include two negated prior branches, got %+v", cfg.DefaultDecisions[2].Rules)
 	}
 }
 
@@ -5683,11 +5683,11 @@ DECISION_TREE routing_policy {
 	if len(errs) > 0 {
 		t.Fatalf("round-trip compile errors: %v\n--- source ---\n%s", errs, dslText)
 	}
-	if got, want := len(roundTripped.Decisions), len(cfg.Decisions); got != want {
+	if got, want := len(roundTripped.DefaultDecisions), len(cfg.DefaultDecisions); got != want {
 		t.Fatalf("round-trip decisions = %d, want %d", got, want)
 	}
-	for i := range cfg.Decisions {
-		if got, want := roundTripped.Decisions[i].Name, cfg.Decisions[i].Name; got != want {
+	for i := range cfg.DefaultDecisions {
+		if got, want := roundTripped.DefaultDecisions[i].Name, cfg.DefaultDecisions[i].Name; got != want {
 			t.Fatalf("round-trip decision[%d].Name = %q, want %q", i, got, want)
 		}
 	}
@@ -5902,11 +5902,11 @@ func assertConflictFreeCompile(t *testing.T, cfg *config.RouterConfig) {
 	if len(cfg.Projections.Partitions) != 1 {
 		t.Errorf("expected 1 projection partition in config, got %d", len(cfg.Projections.Partitions))
 	}
-	if cfg.Decisions[0].Tier != 1 {
-		t.Errorf("safety route tier = %d, want 1", cfg.Decisions[0].Tier)
+	if cfg.DefaultDecisions[0].Tier != 1 {
+		t.Errorf("safety route tier = %d, want 1", cfg.DefaultDecisions[0].Tier)
 	}
-	if cfg.Decisions[1].Tier != 2 {
-		t.Errorf("math route tier = %d, want 2", cfg.Decisions[1].Tier)
+	if cfg.DefaultDecisions[1].Tier != 2 {
+		t.Errorf("math route tier = %d, want 2", cfg.DefaultDecisions[1].Tier)
 	}
 }
 
@@ -5996,10 +5996,10 @@ func TestCompileExplicitCandidateIterationFeedsModelRefs(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if len(cfg.Decisions) != 1 {
-		t.Fatalf("decisions = %d, want 1", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 1 {
+		t.Fatalf("decisions = %d, want 1", len(cfg.DefaultDecisions))
 	}
-	decision := cfg.Decisions[0]
+	decision := cfg.DefaultDecisions[0]
 	if len(decision.ModelRefs) != 2 {
 		t.Fatalf("model refs = %d, want 2", len(decision.ModelRefs))
 	}
@@ -6040,8 +6040,8 @@ func TestCandidateIterationRoundTrip(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("recompile errors: %v\nDSL:\n%s", errs, dslText)
 	}
-	if len(recompiled.Decisions) != 1 || len(recompiled.Decisions[0].CandidateIterations) != 1 {
-		t.Fatalf("recompiled candidate iteration missing: %+v", recompiled.Decisions)
+	if len(recompiled.DefaultDecisions) != 1 || len(recompiled.DefaultDecisions[0].CandidateIterations) != 1 {
+		t.Fatalf("recompiled candidate iteration missing: %+v", recompiled.DefaultDecisions)
 	}
 }
 
@@ -6085,11 +6085,11 @@ DECISION_TREE session_switch {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if len(cfg.Decisions) != 2 {
-		t.Fatalf("decisions = %d, want 2", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 2 {
+		t.Fatalf("decisions = %d, want 2", len(cfg.DefaultDecisions))
 	}
 	// Branch 01 has the iteration; branch 02 (ELSE) does not.
-	ifBranch := cfg.Decisions[0]
+	ifBranch := cfg.DefaultDecisions[0]
 	if len(ifBranch.CandidateIterations) != 1 {
 		t.Fatalf("if-branch candidate iterations = %d, want 1", len(ifBranch.CandidateIterations))
 	}
@@ -6097,7 +6097,7 @@ DECISION_TREE session_switch {
 	if iter.Variable != "candidate" || iter.Source != "decision.candidates" {
 		t.Fatalf("iteration variable=%q source=%q, want candidate decision.candidates", iter.Variable, iter.Source)
 	}
-	elseBranch := cfg.Decisions[1]
+	elseBranch := cfg.DefaultDecisions[1]
 	if len(elseBranch.CandidateIterations) != 0 {
 		t.Fatalf("else-branch candidate iterations = %d, want 0", len(elseBranch.CandidateIterations))
 	}
@@ -6174,13 +6174,13 @@ func TestExplicitModelListRoundTripOmitsModelDirective(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("recompile errors: %v\nDSL:\n%s", errs, dslText)
 	}
-	if len(recompiled.Decisions) != 1 {
-		t.Fatalf("recompiled decisions = %d, want 1", len(recompiled.Decisions))
+	if len(recompiled.DefaultDecisions) != 1 {
+		t.Fatalf("recompiled decisions = %d, want 1", len(recompiled.DefaultDecisions))
 	}
-	if len(recompiled.Decisions[0].CandidateIterations) != 1 {
-		t.Fatalf("recompiled candidate iterations = %d, want 1", len(recompiled.Decisions[0].CandidateIterations))
+	if len(recompiled.DefaultDecisions[0].CandidateIterations) != 1 {
+		t.Fatalf("recompiled candidate iterations = %d, want 1", len(recompiled.DefaultDecisions[0].CandidateIterations))
 	}
-	if len(recompiled.Decisions[0].ModelRefs) != 2 {
-		t.Fatalf("recompiled model refs = %d, want 2", len(recompiled.Decisions[0].ModelRefs))
+	if len(recompiled.DefaultDecisions[0].ModelRefs) != 2 {
+		t.Fatalf("recompiled model refs = %d, want 2", len(recompiled.DefaultDecisions[0].ModelRefs))
 	}
 }

--- a/src/semantic-router/pkg/dsl/emit_retention_test.go
+++ b/src/semantic-router/pkg/dsl/emit_retention_test.go
@@ -32,12 +32,12 @@ func TestCompileEmitRetentionDirectives(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	assertDecisionCount(t, cfg.Decisions, 2)
+	assertDecisionCount(t, cfg.DefaultDecisions, 2)
 
-	assertConfigRetentionDrop(t, cfg.Decisions[0].Emits[0].Retention, true, "decision[0]")
-	assertConfigRetentionTTLTurns(t, cfg.Decisions[1].Emits[0].Retention, 3, "decision[1]")
-	assertConfigRetentionKeepCurrentModel(t, cfg.Decisions[1].Emits[0].Retention, true, "decision[1]")
-	assertConfigRetentionPreferPrefix(t, cfg.Decisions[1].Emits[0].Retention, true, "decision[1]")
+	assertConfigRetentionDrop(t, cfg.DefaultDecisions[0].Emits[0].Retention, true, "decision[0]")
+	assertConfigRetentionTTLTurns(t, cfg.DefaultDecisions[1].Emits[0].Retention, 3, "decision[1]")
+	assertConfigRetentionKeepCurrentModel(t, cfg.DefaultDecisions[1].Emits[0].Retention, true, "decision[1]")
+	assertConfigRetentionPreferPrefix(t, cfg.DefaultDecisions[1].Emits[0].Retention, true, "decision[1]")
 }
 
 func assertDecisionCount(t *testing.T, decisions []config.Decision, want int) {
@@ -120,13 +120,13 @@ func TestDecompileEmitRetentionRoundTrip(t *testing.T) {
 	if len(errs2) > 0 {
 		t.Fatalf("second compile errors: %v\n--- source ---\n%s", errs2, out)
 	}
-	if len(cfg2.Decisions) != 2 {
+	if len(cfg2.DefaultDecisions) != 2 {
 		t.Fatalf("round-trip decision count mismatch")
 	}
-	if cfg2.Decisions[0].Emits[0].Retention.Drop == nil || !*cfg2.Decisions[0].Emits[0].Retention.Drop {
+	if cfg2.DefaultDecisions[0].Emits[0].Retention.Drop == nil || !*cfg2.DefaultDecisions[0].Emits[0].Retention.Drop {
 		t.Fatalf("round-trip lost drop=true")
 	}
-	if cfg2.Decisions[1].Emits[0].Retention.TTLTurns == nil || *cfg2.Decisions[1].Emits[0].Retention.TTLTurns != 3 {
+	if cfg2.DefaultDecisions[1].Emits[0].Retention.TTLTurns == nil || *cfg2.DefaultDecisions[1].Emits[0].Retention.TTLTurns != 3 {
 		t.Fatalf("round-trip lost ttl_turns=3")
 	}
 }
@@ -226,10 +226,10 @@ func assertDSLRetentionPreferPrefix(t *testing.T, r *RetentionDirective, want bo
 
 func assertDecisionTreeConfigRetention(t *testing.T, cfg *config.RouterConfig) {
 	t.Helper()
-	assertDecisionCount(t, cfg.Decisions, 3)
-	assertConfigRetentionDrop(t, cfg.Decisions[0].Emits[0].Retention, true, "compiled IF branch")
-	assertConfigRetentionTTLTurns(t, cfg.Decisions[1].Emits[0].Retention, 2, "compiled ELSE IF branch")
-	assertConfigRetentionPreferPrefix(t, cfg.Decisions[2].Emits[0].Retention, true, "compiled ELSE branch")
+	assertDecisionCount(t, cfg.DefaultDecisions, 3)
+	assertConfigRetentionDrop(t, cfg.DefaultDecisions[0].Emits[0].Retention, true, "compiled IF branch")
+	assertConfigRetentionTTLTurns(t, cfg.DefaultDecisions[1].Emits[0].Retention, 2, "compiled ELSE IF branch")
+	assertConfigRetentionPreferPrefix(t, cfg.DefaultDecisions[2].Emits[0].Retention, true, "compiled ELSE branch")
 }
 
 func assertDecisionTreeRetentionRoundTrip(t *testing.T, cfg *config.RouterConfig) {
@@ -242,7 +242,7 @@ func assertDecisionTreeRetentionRoundTrip(t *testing.T, cfg *config.RouterConfig
 	if len(errs) > 0 {
 		t.Fatalf("round-trip compile errors: %v\n--- source ---\n%s", errs, out)
 	}
-	assertDecisionCount(t, cfg2.Decisions, 3)
+	assertDecisionCount(t, cfg2.DefaultDecisions, 3)
 }
 
 func TestEmitRoutingYAMLIncludesRetention(t *testing.T) {

--- a/src/semantic-router/pkg/dsl/feedback_recipe_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/feedback_recipe_roundtrip_test.go
@@ -40,7 +40,7 @@ func TestMaintainedFeedbackRecipeDSLRoundTrip(t *testing.T) {
 	if len(cfg.ReaskRules) == 0 {
 		t.Error("expected at least one reask rule from feedback recipe")
 	}
-	if len(cfg.Decisions) == 0 {
+	if len(cfg.DefaultDecisions) == 0 {
 		t.Error("expected at least one decision from feedback recipe")
 	}
 
@@ -57,8 +57,8 @@ func TestMaintainedFeedbackRecipeDSLRoundTrip(t *testing.T) {
 	if len(cfg2.ReaskRules) != len(cfg.ReaskRules) {
 		t.Errorf("round-trip reask rules: %d -> %d", len(cfg.ReaskRules), len(cfg2.ReaskRules))
 	}
-	if len(cfg2.Decisions) != len(cfg.Decisions) {
-		t.Errorf("round-trip decisions: %d -> %d", len(cfg.Decisions), len(cfg2.Decisions))
+	if len(cfg2.DefaultDecisions) != len(cfg.DefaultDecisions) {
+		t.Errorf("round-trip decisions: %d -> %d", len(cfg.DefaultDecisions), len(cfg2.DefaultDecisions))
 	}
 }
 

--- a/src/semantic-router/pkg/dsl/fusion_algorithm_test.go
+++ b/src/semantic-router/pkg/dsl/fusion_algorithm_test.go
@@ -31,7 +31,7 @@ ROUTE fusion_reasoning {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	fusion := cfg.Decisions[0].Algorithm.Fusion
+	fusion := cfg.DefaultDecisions[0].Algorithm.Fusion
 	assertFusionAlgorithmConfig(t, fusion)
 }
 
@@ -41,7 +41,7 @@ func TestDecompileFusionAlgorithmRoundTrip(t *testing.T) {
 	temperature := 0.2
 	cfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:     "fusion-reasoning",
 					Priority: 10,
@@ -91,7 +91,7 @@ func TestDecompileFusionAlgorithmRoundTrip(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("round-trip compile errors: %v\n%s", errs, dslText)
 	}
-	assertFusionAlgorithmConfig(t, roundTripped.Decisions[0].Algorithm.Fusion)
+	assertFusionAlgorithmConfig(t, roundTripped.DefaultDecisions[0].Algorithm.Fusion)
 }
 
 func assertFusionAlgorithmConfig(t *testing.T, fusion *config.FusionAlgorithmConfig) {

--- a/src/semantic-router/pkg/dsl/maintained_asset_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/maintained_asset_roundtrip_test.go
@@ -60,13 +60,13 @@ func TestMaintainedBalanceRecipeUsesProjectionPartitionsAndTieredDecisions(t *te
 	assertMaintainedBalanceDomainPartition(t, cfg.Projections.Partitions)
 	assertMaintainedBalanceIntentPartition(t, cfg.Projections.Partitions)
 	assertMaintainedBalanceProjectionBands(t, cfg.Projections)
-	assertMaintainedBalanceDecisionTiers(t, cfg.Decisions)
-	assertMaintainedBalanceRoute(t, cfg.Decisions, "formal_math_proof")
-	assertMaintainedBalanceRoute(t, cfg.Decisions, "complex_specialist")
-	assertMaintainedBalanceRoute(t, cfg.Decisions, "reasoning_deep")
-	assertMaintainedBalanceRoute(t, cfg.Decisions, "verified_health")
-	assertMaintainedBalanceRoute(t, cfg.Decisions, "fast_qa")
-	assertMaintainedBalanceRoute(t, cfg.Decisions, "casual_chat")
+	assertMaintainedBalanceDecisionTiers(t, cfg.DefaultDecisions)
+	assertMaintainedBalanceRoute(t, cfg.DefaultDecisions, "formal_math_proof")
+	assertMaintainedBalanceRoute(t, cfg.DefaultDecisions, "complex_specialist")
+	assertMaintainedBalanceRoute(t, cfg.DefaultDecisions, "reasoning_deep")
+	assertMaintainedBalanceRoute(t, cfg.DefaultDecisions, "verified_health")
+	assertMaintainedBalanceRoute(t, cfg.DefaultDecisions, "fast_qa")
+	assertMaintainedBalanceRoute(t, cfg.DefaultDecisions, "casual_chat")
 }
 
 func TestMaintainedBalanceRoutingAssetsStayInSync(t *testing.T) {
@@ -89,7 +89,7 @@ func TestMaintainedBalanceBaseRoutesExplicitlyExcludeVerifiedOverlay(t *testing.
 		"medium_explainer",
 		"simple_general",
 	} {
-		decision := mustFindMaintainedBalanceDecision(t, cfg.Decisions, routeName)
+		decision := mustFindMaintainedBalanceDecision(t, cfg.DefaultDecisions, routeName)
 		if !ruleTreeContainsNegatedSignal(&decision.Rules, config.SignalTypeProjection, "verification_required") {
 			t.Fatalf("expected %s to negate projection(%q) so verified overlays stay explicit siblings", routeName, "verification_required")
 		}

--- a/src/semantic-router/pkg/dsl/mmlu_recipe_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/mmlu_recipe_roundtrip_test.go
@@ -61,7 +61,7 @@ func TestMaintainedMMLURecipeDSLRoundTrip(t *testing.T) {
 	if len(cfg.KBRules) == 0 {
 		t.Error("expected at least one kb rule from mmlu recipe")
 	}
-	if len(cfg.Decisions) == 0 {
+	if len(cfg.DefaultDecisions) == 0 {
 		t.Error("expected at least one decision from mmlu recipe")
 	}
 
@@ -78,8 +78,8 @@ func TestMaintainedMMLURecipeDSLRoundTrip(t *testing.T) {
 	if len(cfg2.KBRules) != len(cfg.KBRules) {
 		t.Errorf("round-trip kb rules: %d -> %d", len(cfg.KBRules), len(cfg2.KBRules))
 	}
-	if len(cfg2.Decisions) != len(cfg.Decisions) {
-		t.Errorf("round-trip decisions: %d -> %d", len(cfg.Decisions), len(cfg2.Decisions))
+	if len(cfg2.DefaultDecisions) != len(cfg.DefaultDecisions) {
+		t.Errorf("round-trip decisions: %d -> %d", len(cfg.DefaultDecisions), len(cfg2.DefaultDecisions))
 	}
 }
 

--- a/src/semantic-router/pkg/dsl/privacy_recipe_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/privacy_recipe_roundtrip_test.go
@@ -48,7 +48,7 @@ func TestMaintainedPrivacyRecipeDSLRoundTrip(t *testing.T) {
 	}
 
 	hasToolsPlugin := false
-	for _, dec := range cfg.Decisions {
+	for _, dec := range cfg.DefaultDecisions {
 		if dec.GetToolsConfig() != nil {
 			hasToolsPlugin = true
 			break
@@ -74,17 +74,17 @@ func TestMaintainedPrivacyRecipeDSLRoundTrip(t *testing.T) {
 		t.Errorf("round-trip kb rules: %d → %d",
 			len(cfg.KBRules), len(cfg2.KBRules))
 	}
-	if len(cfg2.Decisions) != len(cfg.Decisions) {
+	if len(cfg2.DefaultDecisions) != len(cfg.DefaultDecisions) {
 		t.Errorf("round-trip Decisions: %d → %d",
-			len(cfg.Decisions), len(cfg2.Decisions))
+			len(cfg.DefaultDecisions), len(cfg2.DefaultDecisions))
 	}
 
-	for i, dec := range cfg.Decisions {
-		if i >= len(cfg2.Decisions) {
+	for i, dec := range cfg.DefaultDecisions {
+		if i >= len(cfg2.DefaultDecisions) {
 			continue
 		}
 		left := dec.GetToolsConfig()
-		right := cfg2.Decisions[i].GetToolsConfig()
+		right := cfg2.DefaultDecisions[i].GetToolsConfig()
 		switch {
 		case (left == nil) != (right == nil):
 			t.Errorf("round-trip decision %q tools plugin presence mismatch", dec.Name)

--- a/src/semantic-router/pkg/dsl/routing_contract.go
+++ b/src/semantic-router/pkg/dsl/routing_contract.go
@@ -209,7 +209,7 @@ func (d *decompiler) appendModelsToProgram(prog *Program) {
 }
 
 func (d *decompiler) appendRoutesToProgram(prog *Program) {
-	for _, dec := range d.cfg.Decisions {
+	for _, dec := range d.cfg.DefaultDecisions {
 		prog.Routes = append(prog.Routes, d.decisionToRoute(&dec))
 	}
 }

--- a/src/semantic-router/pkg/dsl/taxonomy_dsl_test.go
+++ b/src/semantic-router/pkg/dsl/taxonomy_dsl_test.go
@@ -101,14 +101,14 @@ func assertCompiledKBProjection(t *testing.T, cfg *config.RouterConfig) {
 
 func assertCompiledKBDecision(t *testing.T, cfg *config.RouterConfig) {
 	t.Helper()
-	if len(cfg.Decisions) != 1 {
-		t.Fatalf("expected 1 decision, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(cfg.DefaultDecisions))
 	}
-	cond := cfg.Decisions[0].Rules.Conditions[0]
+	cond := cfg.DefaultDecisions[0].Rules.Conditions[0]
 	if cond.Type != "kb" || cond.Name != "privacy_policy" {
 		t.Errorf("WHEN condition = %+v", cond)
 	}
-	toolsCfg := cfg.Decisions[0].GetToolsConfig()
+	toolsCfg := cfg.DefaultDecisions[0].GetToolsConfig()
 	if toolsCfg == nil {
 		t.Fatal("expected tools plugin on compiled decision")
 	}
@@ -193,8 +193,8 @@ func TestTaxonomyDSLRoundTrip(t *testing.T) {
 	if len(cfg2.Projections.Scores) != 1 {
 		t.Fatalf("round-trip projection scores = %d", len(cfg2.Projections.Scores))
 	}
-	if len(cfg2.Decisions) != 1 {
-		t.Fatalf("round-trip decisions = %d", len(cfg2.Decisions))
+	if len(cfg2.DefaultDecisions) != 1 {
+		t.Fatalf("round-trip decisions = %d", len(cfg2.DefaultDecisions))
 	}
 }
 
@@ -230,12 +230,12 @@ ROUTE local_standard {
 		t.Fatalf("Compile errors: %v", errs)
 	}
 
-	if len(cfg.Decisions) != 4 {
-		t.Fatalf("expected 4 decisions, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 4 {
+		t.Fatalf("expected 4 decisions, got %d", len(cfg.DefaultDecisions))
 	}
 	assertToolsMode := func(index int, want string) {
 		t.Helper()
-		cfg := cfg.Decisions[index].GetToolsConfig()
+		cfg := cfg.DefaultDecisions[index].GetToolsConfig()
 		if cfg == nil {
 			t.Fatalf("decision[%d] missing tools plugin", index)
 		}
@@ -275,11 +275,11 @@ ROUTE adaptive_tools {
 	if len(errs) > 0 {
 		t.Fatalf("Compile errors: %v", errs)
 	}
-	if len(cfg.Decisions) != 1 {
-		t.Fatalf("expected 1 decision, got %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(cfg.DefaultDecisions))
 	}
 
-	toolsCfg := cfg.Decisions[0].GetToolsConfig()
+	toolsCfg := cfg.DefaultDecisions[0].GetToolsConfig()
 	if toolsCfg == nil {
 		t.Fatal("expected tools plugin")
 	}

--- a/src/semantic-router/pkg/dsl/taxonomy_e2e_test.go
+++ b/src/semantic-router/pkg/dsl/taxonomy_e2e_test.go
@@ -63,7 +63,7 @@ func taxonomyConfigFixture(t *testing.T) *config.RouterConfig {
 					},
 				},
 			},
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:     "local_privacy_policy",
 					Priority: 250,

--- a/src/semantic-router/pkg/dsl/workflows_algorithm_test.go
+++ b/src/semantic-router/pkg/dsl/workflows_algorithm_test.go
@@ -34,10 +34,10 @@ ROUTE flow_code {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	if len(cfg.Decisions) != 1 {
-		t.Fatalf("decisions = %d", len(cfg.Decisions))
+	if len(cfg.DefaultDecisions) != 1 {
+		t.Fatalf("decisions = %d", len(cfg.DefaultDecisions))
 	}
-	workflows := cfg.Decisions[0].Algorithm.Workflows
+	workflows := cfg.DefaultDecisions[0].Algorithm.Workflows
 	assertWorkflowsDynamicConfig(t, workflows)
 }
 
@@ -56,7 +56,7 @@ ROUTE flow_code {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	workflows := cfg.Decisions[0].Algorithm.Workflows
+	workflows := cfg.DefaultDecisions[0].Algorithm.Workflows
 	if workflows == nil || workflows.Planner.Model != "qwen-coordinator" {
 		t.Fatalf("workflows planner = %#v", workflows)
 	}
@@ -84,7 +84,7 @@ ROUTE flow_static {
 	if len(errs) > 0 {
 		t.Fatalf("compile errors: %v", errs)
 	}
-	workflows := cfg.Decisions[0].Algorithm.Workflows
+	workflows := cfg.DefaultDecisions[0].Algorithm.Workflows
 	if workflows == nil || len(workflows.Roles) != 3 {
 		t.Fatalf("workflows roles = %#v", workflows)
 	}
@@ -101,7 +101,7 @@ func TestDecompileWorkflowsDynamicAlgorithmRoundTrip(t *testing.T) {
 	temperature := 0.2
 	cfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:     "flow-code",
 					Priority: 10,
@@ -153,13 +153,13 @@ func TestDecompileWorkflowsDynamicAlgorithmRoundTrip(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("round-trip compile errors: %v\n%s", errs, dslText)
 	}
-	assertWorkflowsDynamicConfig(t, roundTripped.Decisions[0].Algorithm.Workflows)
+	assertWorkflowsDynamicConfig(t, roundTripped.DefaultDecisions[0].Algorithm.Workflows)
 }
 
 func TestDecompileWorkflowsStaticRolesAlgorithmRoundTrip(t *testing.T) {
 	cfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:     "flow-static",
 					Priority: 10,
@@ -205,7 +205,7 @@ func TestDecompileWorkflowsStaticRolesAlgorithmRoundTrip(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("round-trip compile errors: %v\n%s", errs, dslText)
 	}
-	roles := roundTripped.Decisions[0].Algorithm.Workflows.Roles
+	roles := roundTripped.DefaultDecisions[0].Algorithm.Workflows.Roles
 	if len(roles) != 3 || roles[2].Name != "verifier" {
 		t.Fatalf("round-trip roles = %#v", roles)
 	}

--- a/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
+++ b/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
@@ -78,7 +78,7 @@ func TestCacheBypassWhenRAGEnabled(t *testing.T) {
 
 	cfg := &config.RouterConfig{}
 	cfg.Enabled = true
-	cfg.Decisions = []config.Decision{decision}
+	cfg.DefaultDecisions = []config.Decision{decision}
 
 	router := &OpenAIRouter{Config: cfg, Cache: spy}
 	ctx := &RequestContext{
@@ -108,7 +108,7 @@ func TestCacheBypassWhenMemoryEnabledGlobally(t *testing.T) {
 	cfg := &config.RouterConfig{}
 	cfg.Enabled = true
 	cfg.Memory.Enabled = true
-	cfg.Decisions = []config.Decision{decision}
+	cfg.DefaultDecisions = []config.Decision{decision}
 
 	router := &OpenAIRouter{Config: cfg, Cache: spy}
 	ctx := &RequestContext{
@@ -147,7 +147,7 @@ func TestCacheBypassWithBothRAGAndMemory(t *testing.T) {
 	cfg := &config.RouterConfig{}
 	cfg.Enabled = true
 	cfg.Memory.Enabled = true
-	cfg.Decisions = []config.Decision{decision}
+	cfg.DefaultDecisions = []config.Decision{decision}
 
 	router := &OpenAIRouter{Config: cfg, Cache: spy}
 	ctx := &RequestContext{
@@ -181,7 +181,7 @@ func TestCacheBypassWithPerDecisionMemoryOverride(t *testing.T) {
 	cfg := &config.RouterConfig{}
 	cfg.Enabled = true
 	cfg.Memory.Enabled = false
-	cfg.Decisions = []config.Decision{decision}
+	cfg.DefaultDecisions = []config.Decision{decision}
 
 	router := &OpenAIRouter{Config: cfg, Cache: spy}
 	ctx := &RequestContext{
@@ -217,7 +217,7 @@ func TestCacheWorksNormallyWithoutPersonalization(t *testing.T) {
 
 	cfg := &config.RouterConfig{}
 	cfg.Enabled = true
-	cfg.Decisions = []config.Decision{decision}
+	cfg.DefaultDecisions = []config.Decision{decision}
 
 	router := &OpenAIRouter{Config: cfg, Cache: spy}
 	ctx := &RequestContext{
@@ -257,7 +257,7 @@ func TestNoCacheBypassWhenMemoryExplicitlyDisabledPerDecision(t *testing.T) {
 	cfg := &config.RouterConfig{}
 	cfg.Enabled = true
 	cfg.Memory.Enabled = true
-	cfg.Decisions = []config.Decision{decision}
+	cfg.DefaultDecisions = []config.Decision{decision}
 
 	router := &OpenAIRouter{Config: cfg, Cache: spy}
 	ctx := &RequestContext{
@@ -346,7 +346,7 @@ func TestDecisionWillPersonalize_PerDecisionMemoryDisabledOverridesGlobal(t *tes
 
 func TestRAGPluginResolution_NoBackend(t *testing.T) {
 	cfg := &config.RouterConfig{}
-	cfg.Decisions = []config.Decision{
+	cfg.DefaultDecisions = []config.Decision{
 		{
 			Name:      "bad-rag",
 			ModelRefs: []config.ModelRef{{Model: "m"}},
@@ -359,7 +359,7 @@ func TestRAGPluginResolution_NoBackend(t *testing.T) {
 	}
 
 	router := &OpenAIRouter{Config: cfg}
-	decision := cfg.Decisions[0]
+	decision := cfg.DefaultDecisions[0]
 	ctx := &RequestContext{VSRSelectedDecision: &decision}
 
 	ragConfig, shouldExec := router.resolveRAGPluginConfig(ctx, "bad-rag")
@@ -369,7 +369,7 @@ func TestRAGPluginResolution_NoBackend(t *testing.T) {
 
 func TestRAGPluginResolution_ValidBackend(t *testing.T) {
 	cfg := &config.RouterConfig{}
-	cfg.Decisions = []config.Decision{
+	cfg.DefaultDecisions = []config.Decision{
 		{
 			Name:      "good-rag",
 			ModelRefs: []config.ModelRef{{Model: "m"}},
@@ -383,7 +383,7 @@ func TestRAGPluginResolution_ValidBackend(t *testing.T) {
 	}
 
 	router := &OpenAIRouter{Config: cfg}
-	decision := cfg.Decisions[0]
+	decision := cfg.DefaultDecisions[0]
 	ctx := &RequestContext{VSRSelectedDecision: &decision}
 
 	ragConfig, shouldExec := router.resolveRAGPluginConfig(ctx, "good-rag")
@@ -405,7 +405,7 @@ func TestRAGPluginResolution_NilDecision(t *testing.T) {
 func TestRAGPluginResolution_ConfidenceThreshold(t *testing.T) {
 	threshold := float64(0.8)
 	cfg := &config.RouterConfig{}
-	cfg.Decisions = []config.Decision{
+	cfg.DefaultDecisions = []config.Decision{
 		{
 			Name:      "threshold-rag",
 			ModelRefs: []config.ModelRef{{Model: "m"}},
@@ -420,7 +420,7 @@ func TestRAGPluginResolution_ConfidenceThreshold(t *testing.T) {
 	}
 
 	router := &OpenAIRouter{Config: cfg}
-	decision := cfg.Decisions[0]
+	decision := cfg.DefaultDecisions[0]
 
 	t.Run("below threshold", func(t *testing.T) {
 		ctx := &RequestContext{
@@ -471,7 +471,7 @@ func TestFullPipeline_CacheBypassThenRAGResolution(t *testing.T) {
 
 	cfg := &config.RouterConfig{}
 	cfg.Enabled = true
-	cfg.Decisions = []config.Decision{decision}
+	cfg.DefaultDecisions = []config.Decision{decision}
 
 	router := &OpenAIRouter{Config: cfg, Cache: spy}
 

--- a/src/semantic-router/pkg/extproc/extproc_test.go
+++ b/src/semantic-router/pkg/extproc/extproc_test.go
@@ -3182,7 +3182,7 @@ func TestHandleModelsRequest(t *testing.T) {
 			Endpoint: "http://looper",
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:      "fusion-route",
 				ModelRefs: []config.ModelRef{{Model: "panel-a"}},
 				Algorithm: &config.AlgorithmConfig{Type: "fusion"},
@@ -3198,7 +3198,7 @@ func TestHandleModelsRequest(t *testing.T) {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:      "fusion-route",
 				ModelRefs: []config.ModelRef{{Model: "panel-a"}},
 				Algorithm: &config.AlgorithmConfig{Type: "fusion"},
@@ -3211,7 +3211,7 @@ func TestHandleModelsRequest(t *testing.T) {
 			Endpoint: "http://looper",
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:      "remom-route",
 				ModelRefs: []config.ModelRef{{Model: "worker-a"}},
 				Algorithm: &config.AlgorithmConfig{
@@ -3227,7 +3227,7 @@ func TestHandleModelsRequest(t *testing.T) {
 			Endpoint: "http://looper",
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:      "flow-route",
 				ModelRefs: []config.ModelRef{{Model: "worker-a"}},
 				Algorithm: &config.AlgorithmConfig{Type: "workflows"},

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
@@ -12,7 +12,7 @@ func TestHandleAnthropicRoutingStartsRouterReplay(t *testing.T) {
 	cfg := &config.RouterConfig{
 		RouterReplay: config.RouterReplayConfig{Enabled: true, StoreBackend: "memory"},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{Name: "simple-queries", ModelRefs: []config.ModelRef{{Model: "claude-sonnet-4.6"}}},
 			},
 		},

--- a/src/semantic-router/pkg/extproc/processor_res_cache_retention_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_retention_test.go
@@ -205,7 +205,7 @@ func TestUpdateResponseCacheSkipsRetentionDrop(t *testing.T) {
 		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: true},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+				DefaultDecisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
 			},
 		},
 	}
@@ -228,7 +228,7 @@ func TestUpdateResponseCacheWritesWhenRetentionDropFalse(t *testing.T) {
 		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: true},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+				DefaultDecisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
 			},
 		},
 	}
@@ -251,7 +251,7 @@ func TestCacheStreamingResponseSkipsRetentionDrop(t *testing.T) {
 		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: true},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+				DefaultDecisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
 			},
 		},
 	}
@@ -273,7 +273,7 @@ func TestCacheStreamingResponseChecksScopeBeforeRetentionDrop(t *testing.T) {
 		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: true},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{retentionCacheDecision("no-cache-decision", false)},
+				DefaultDecisions: []config.Decision{retentionCacheDecision("no-cache-decision", false)},
 			},
 		},
 	}
@@ -341,7 +341,7 @@ func TestUpdateResponseCacheAppliesRetentionTTL(t *testing.T) {
 		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: true},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+				DefaultDecisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
 			},
 		},
 	}
@@ -367,7 +367,7 @@ func TestCacheStreamingResponseAppliesRetentionTTL(t *testing.T) {
 		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: true},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+				DefaultDecisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
 			},
 		},
 	}

--- a/src/semantic-router/pkg/extproc/processor_res_cache_status_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_status_test.go
@@ -51,7 +51,7 @@ func statusCacheRouter() (*mockStreamingCache, *OpenAIRouter) {
 		Config: &config.RouterConfig{
 			SemanticCache: config.SemanticCache{Enabled: true},
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
+				DefaultDecisions: []config.Decision{retentionCacheDecision("cache-decision", true)},
 			},
 		},
 	}

--- a/src/semantic-router/pkg/extproc/processor_res_cache_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_test.go
@@ -90,7 +90,7 @@ func TestUpdateResponseCache_SkipsWhenDecisionCacheDisabled(t *testing.T) {
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "no-cache-decision",
 					ModelRefs: []config.ModelRef{{Model: "test"}},
@@ -113,7 +113,7 @@ func TestUpdateResponseCache_SkipsWhenDecisionCacheExplicitlyDisabled(t *testing
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "disabled-cache-decision",
 					ModelRefs: []config.ModelRef{{Model: "test"}},
@@ -142,7 +142,7 @@ func TestUpdateResponseCache_StoresWhenDecisionCacheEnabled(t *testing.T) {
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "cache-decision",
 					ModelRefs: []config.ModelRef{{Model: "test"}},
@@ -186,7 +186,7 @@ func TestUpdateResponseCache_SkipsWhenNoDecisionSelectedButDecisionsConfigured(t
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "default-route",
 					ModelRefs: []config.ModelRef{{Model: "test"}},
@@ -276,7 +276,7 @@ func TestCacheReconstructedStreamingResponse_SkipsWhenDecisionCacheDisabled(t *t
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "no-cache-decision",
 					ModelRefs: []config.ModelRef{{Model: "test"}},
@@ -303,7 +303,7 @@ func TestCacheReconstructedStreamingResponse_SkipsWhenDecisionCacheExplicitlyDis
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "disabled-cache-decision",
 					ModelRefs: []config.ModelRef{{Model: "test"}},
@@ -336,7 +336,7 @@ func TestCacheReconstructedStreamingResponse_StoresWhenDecisionCacheEnabled(t *t
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "cache-decision",
 					ModelRefs: []config.ModelRef{{Model: "test"}},

--- a/src/semantic-router/pkg/extproc/recipe_read_sites_test.go
+++ b/src/semantic-router/pkg/extproc/recipe_read_sites_test.go
@@ -107,7 +107,7 @@ func TestRecipeDecisionsReachDownstreamReadSites(t *testing.T) {
 	})
 
 	t.Run("memory plugin auto-enable", func(t *testing.T) {
-		if !isMemoryEnabled(cfg) {
+		if !cfg.IsMemoryEnabled() {
 			t.Fatal("expected the recipe decision's memory plugin to enable the memory runtime")
 		}
 	})

--- a/src/semantic-router/pkg/extproc/recipe_read_sites_test.go
+++ b/src/semantic-router/pkg/extproc/recipe_read_sites_test.go
@@ -112,7 +112,11 @@ func TestRecipeDecisionsReachDownstreamReadSites(t *testing.T) {
 		}
 	})
 
-	t.Run("model reference validation reaches recipes", func(t *testing.T) {
+	// ValidateEndpoints is a config helper with no load-path caller: the
+	// load path checks recipe modelRefs against modelCards only, and a
+	// missing endpoint surfaces at request time. This pins the helper's
+	// recipe scope, not a load-time endpoint check.
+	t.Run("ValidateEndpoints helper sees recipe decisions", func(t *testing.T) {
 		if err := cfg.ValidateEndpoints(); err != nil {
 			t.Fatalf("expected the recipe's model reference to validate, got %v", err)
 		}

--- a/src/semantic-router/pkg/extproc/recipe_read_sites_test.go
+++ b/src/semantic-router/pkg/extproc/recipe_read_sites_test.go
@@ -1,0 +1,266 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// recipeReadSiteConfigYAML puts every routed behavior under test on a
+// NON-default recipe: reasoning effort, a plugin that gates runtime wiring, and
+// a model reference. Anything that reads the flat DefaultDecisions field
+// instead of RouterConfig.AllRoutingDecisions() sees an empty set here.
+const recipeReadSiteConfigYAML = `
+version: v0.3
+routing:
+  modelCards:
+    - name: model-a
+    - name: model-b
+  signals:
+    keywords:
+      - name: urgent_keywords
+        operator: OR
+        keywords: ["urgent"]
+  decisions:
+    - name: default_route
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: urgent_keywords
+      modelRefs:
+        - model: model-a
+          use_reasoning: false
+recipes:
+  - name: privacy
+    routing:
+      signals:
+        keywords:
+          - name: pii_keywords
+            operator: OR
+            keywords: ["ssn"]
+      decisions:
+        - name: privacy_route
+          rules:
+            operator: AND
+            conditions:
+              - type: keyword
+                name: pii_keywords
+          modelRefs:
+            - model: model-b
+              use_reasoning: true
+              reasoning_effort: high
+          plugins:
+            - type: memory
+              configuration:
+                enabled: true
+entrypoints:
+  - model_names: ["vllm-sr/privacy"]
+    recipe: privacy
+providers:
+  defaults:
+    default_model: model-a
+  models:
+    - name: model-a
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+    - name: model-b
+      backend_refs:
+        - endpoint: 127.0.0.1:8001
+`
+
+// TestRecipeDecisionsReachDownstreamReadSites pins the read sites that must
+// observe a non-default recipe's decisions. Each of these silently ignored
+// recipes while they read the flat decision field.
+func TestRecipeDecisionsReachDownstreamReadSites(t *testing.T) {
+	cfg, err := config.ParseYAMLBytes([]byte(recipeReadSiteConfigYAML))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	router := &OpenAIRouter{Config: cfg}
+	classifier, err := classification.NewClassifier(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to build classifier: %v", err)
+	}
+
+	t.Run("config decision lookup by name", func(t *testing.T) {
+		if decision := cfg.GetDecisionByName("privacy_route"); decision == nil {
+			t.Fatal("expected the recipe's decision to be found by name")
+		}
+	})
+
+	t.Run("classifier model lookup", func(t *testing.T) {
+		models := classifier.GetModelsForCategory("privacy_route")
+		if len(models) != 1 || models[0] != "model-b" {
+			t.Fatalf("expected [model-b] for the recipe's decision, got %v", models)
+		}
+		if decision := classifier.GetDecisionByName("privacy_route"); decision == nil {
+			t.Fatal("expected the classifier to resolve the recipe's decision")
+		}
+	})
+
+	t.Run("reasoning effort", func(t *testing.T) {
+		if effort := router.getReasoningEffort("privacy_route", "model-b"); effort != "high" {
+			t.Fatalf("expected the recipe decision's reasoning effort %q, got %q", "high", effort)
+		}
+	})
+
+	t.Run("memory plugin auto-enable", func(t *testing.T) {
+		if !isMemoryEnabled(cfg) {
+			t.Fatal("expected the recipe decision's memory plugin to enable the memory runtime")
+		}
+	})
+
+	t.Run("model reference validation reaches recipes", func(t *testing.T) {
+		if err := cfg.ValidateEndpoints(); err != nil {
+			t.Fatalf("expected the recipe's model reference to validate, got %v", err)
+		}
+	})
+}
+
+// TestAlgorithmSlugCannotReachRecipeDecisions pins recipe isolation against the
+// algorithm virtual slugs. The slugs select decisions without consulting the
+// entrypoint table, so a decision that lives only in a named recipe must stay
+// unreachable through them — otherwise the recipe's entrypoint is bypassable.
+func TestAlgorithmSlugCannotReachRecipeDecisions(t *testing.T) {
+	const recipeOwnedFusionYAML = `
+version: v0.3
+routing:
+  modelCards:
+    - name: model-a
+    - name: model-b
+  signals:
+    keywords:
+      - name: urgent_keywords
+        operator: OR
+        keywords: ["urgent"]
+  decisions:
+    - name: default_route
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: urgent_keywords
+      modelRefs:
+        - model: model-a
+recipes:
+  - name: privacy
+    routing:
+      signals:
+        keywords:
+          - name: pii_keywords
+            operator: OR
+            keywords: ["ssn"]
+      decisions:
+        - name: privacy_fusion
+          rules:
+            operator: AND
+            conditions:
+              - type: keyword
+                name: pii_keywords
+          algorithm:
+            type: fusion
+            fusion:
+              analysis_models: ["model-b"]
+          modelRefs:
+            - model: model-b
+entrypoints:
+  - model_names: ["vllm-sr/privacy"]
+    recipe: privacy
+providers:
+  defaults:
+    default_model: model-a
+  models:
+    - name: model-a
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+    - name: model-b
+      backend_refs:
+        - endpoint: 127.0.0.1:8001
+`
+
+	cfg, err := config.ParseYAMLBytes([]byte(recipeOwnedFusionYAML))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	router := &OpenAIRouter{Config: cfg}
+
+	slugs := cfg.Looper.Fusion.EffectiveModelNames()
+	if len(slugs) == 0 {
+		t.Fatal("expected a Fusion virtual slug")
+	}
+	slug := slugs[0]
+
+	ctx := &RequestContext{}
+	router.resolveEntrypointForRequest(slug, ctx)
+	if ctx.EntrypointRecipe != nil {
+		t.Fatalf("the algorithm slug must not resolve an entrypoint, got %+v", ctx.EntrypointRecipe)
+	}
+
+	if candidates := router.decisionCandidatesForRequest(slug, ctx); len(candidates) != 0 {
+		t.Fatalf("the privacy recipe's decision leaked into the %s slug: %+v", slug, candidates)
+	}
+	if decision := router.defaultLooperDecisionByAlgorithm("fusion"); decision != nil {
+		t.Fatalf("the looper fallback leaked the recipe's decision: %s", decision.Name)
+	}
+
+	// ...and /v1/models must not advertise a slug that cannot route.
+	if names := cfg.ExposedFusionModelNames(); len(names) != 0 {
+		t.Fatalf("expected no Fusion slug to be advertised, got %v", names)
+	}
+}
+
+// TestRecipeDecisionProjectionRefsAreValidated covers the contract validators:
+// they must walk every recipe's decisions, not just the default profile's.
+// Projection outputs are never auto-declared (unlike domain categories, which
+// normalizeSignals synthesizes on reference), so an unknown output name is a
+// genuine contract violation the loader has to reject.
+func TestRecipeDecisionProjectionRefsAreValidated(t *testing.T) {
+	const unknownProjectionYAML = `
+version: v0.3
+routing:
+  modelCards:
+    - name: model-a
+  signals:
+    keywords:
+      - name: urgent_keywords
+        operator: OR
+        keywords: ["urgent"]
+  decisions:
+    - name: default_route
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: urgent_keywords
+      modelRefs:
+        - model: model-a
+recipes:
+  - name: privacy
+    routing:
+      decisions:
+        - name: privacy_route
+          rules:
+            operator: AND
+            conditions:
+              - type: projection
+                name: no_such_projection_output
+          modelRefs:
+            - model: model-a
+entrypoints:
+  - model_names: ["vllm-sr/privacy"]
+    recipe: privacy
+providers:
+  defaults:
+    default_model: model-a
+  models:
+    - name: model-a
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+`
+
+	if _, err := config.ParseYAMLBytes([]byte(unknownProjectionYAML)); err == nil {
+		t.Fatal("expected a recipe decision referencing an unknown projection output to be rejected")
+	}
+}

--- a/src/semantic-router/pkg/extproc/req_filter_cache_scope_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache_scope_test.go
@@ -13,7 +13,7 @@ func TestHandleCaching_SkipsGlobalCacheWhenDecisionsConfiguredButNoDecisionMatch
 	cfg := &config.RouterConfig{
 		SemanticCache: config.SemanticCache{Enabled: true},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "default-route",
 					ModelRefs: []config.ModelRef{{Model: "test"}},

--- a/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
+++ b/src/semantic-router/pkg/extproc/req_filter_classification_runtime.go
@@ -42,7 +42,7 @@ func (r *OpenAIRouter) evaluateSignalsForDecision(
 	// from profiles that never asked for identity enforcement.
 	authzScope := candidates
 	if authzScope == nil {
-		authzScope = r.Config.Decisions
+		authzScope = r.Config.DefaultDecisions
 	}
 
 	signals, authzErr := r.Classifier.EvaluateAllSignalsWithHeaders(

--- a/src/semantic-router/pkg/extproc/req_filter_entrypoint_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_entrypoint_test.go
@@ -274,7 +274,7 @@ func TestModelsListingIncludesEntrypointNames(t *testing.T) {
 }
 
 // entrypointRecipesOnlyConfigYAML keeps every decision inside a non-default
-// recipe: the flat Decisions field stays empty, which used to trip the
+// recipe: the flat DefaultDecisions field stays empty, which used to trip the
 // "no decisions configured" short-circuit before decision evaluation.
 const entrypointRecipesOnlyConfigYAML = `
 version: v0.3

--- a/src/semantic-router/pkg/extproc/req_filter_fusion.go
+++ b/src/semantic-router/pkg/extproc/req_filter_fusion.go
@@ -64,6 +64,11 @@ func (r *OpenAIRouter) decisionCandidatesForRequestModel(modelName string) []con
 	if r == nil || r.Config == nil {
 		return nil
 	}
+	// Algorithm virtual slugs are a default-profile surface: they select
+	// decisions without going through the entrypoint table, so they must not
+	// reach into a named recipe. A recipe's algorithm decisions stay
+	// reachable through that recipe's own entrypoint, where
+	// decisionCandidatesForRequest scopes candidates to the recipe.
 	candidates := make([]config.Decision, 0)
 	if r.Config.IsReMoMModelName(modelName) {
 		for _, decision := range r.Config.DefaultDecisions {
@@ -97,8 +102,12 @@ func (r *OpenAIRouter) defaultLooperDecisionByAlgorithm(algorithmType string) *c
 		return nil
 	}
 	var selected *config.Decision
-	for i := range r.Config.DefaultDecisions {
-		decision := &r.Config.DefaultDecisions[i]
+	// Default-profile only, for the same reason as
+	// decisionCandidatesForRequestModel: this is the fallback for a request
+	// that arrived on a global algorithm slug, not through an entrypoint.
+	decisions := r.Config.DefaultDecisions
+	for i := range decisions {
+		decision := &decisions[i]
 		if decision.Algorithm == nil || decision.Algorithm.Type != algorithmType {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/req_filter_fusion.go
+++ b/src/semantic-router/pkg/extproc/req_filter_fusion.go
@@ -66,7 +66,7 @@ func (r *OpenAIRouter) decisionCandidatesForRequestModel(modelName string) []con
 	}
 	candidates := make([]config.Decision, 0)
 	if r.Config.IsReMoMModelName(modelName) {
-		for _, decision := range r.Config.Decisions {
+		for _, decision := range r.Config.DefaultDecisions {
 			if isReMoMDecision(&decision) {
 				candidates = append(candidates, decision)
 			}
@@ -74,7 +74,7 @@ func (r *OpenAIRouter) decisionCandidatesForRequestModel(modelName string) []con
 		return candidates
 	}
 	if r.Config.IsFusionModelName(modelName) {
-		for _, decision := range r.Config.Decisions {
+		for _, decision := range r.Config.DefaultDecisions {
 			if isFusionDecision(&decision) {
 				candidates = append(candidates, decision)
 			}
@@ -82,7 +82,7 @@ func (r *OpenAIRouter) decisionCandidatesForRequestModel(modelName string) []con
 		return candidates
 	}
 	if r.Config.IsFlowModelName(modelName) {
-		for _, decision := range r.Config.Decisions {
+		for _, decision := range r.Config.DefaultDecisions {
 			if isFlowDecision(&decision) {
 				candidates = append(candidates, decision)
 			}
@@ -97,8 +97,8 @@ func (r *OpenAIRouter) defaultLooperDecisionByAlgorithm(algorithmType string) *c
 		return nil
 	}
 	var selected *config.Decision
-	for i := range r.Config.Decisions {
-		decision := &r.Config.Decisions[i]
+	for i := range r.Config.DefaultDecisions {
+		decision := &r.Config.DefaultDecisions[i]
 		if decision.Algorithm == nil || decision.Algorithm.Type != algorithmType {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/req_filter_looper_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_test.go
@@ -249,7 +249,7 @@ func TestResolveDirectFusionDecisionFallsBackToConfiguredDecisionByPriority(t *t
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:     "low-priority-fusion",
 						Priority: 10,
@@ -284,7 +284,7 @@ func TestDecisionCandidatesForFusionModelOnlyIncludesFusionDecisions(t *testing.
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:      "static-route",
 						Algorithm: &config.AlgorithmConfig{Type: "static"},
@@ -317,7 +317,7 @@ func TestDecisionCandidatesForReMoMModelOnlyIncludesReMoMDecisions(t *testing.T)
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:      "static-route",
 						Algorithm: &config.AlgorithmConfig{Type: "static"},
@@ -348,7 +348,7 @@ func TestDecisionCandidatesForFlowModelOnlyIncludesWorkflowDecisions(t *testing.
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:      "static-route",
 						Algorithm: &config.AlgorithmConfig{Type: "static"},
@@ -394,7 +394,7 @@ func TestResolveDirectReMoMDecisionFallsBackToHighestPriorityReMoMDecision(t *te
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:     "low-priority-remom",
 						Priority: 10,
@@ -450,7 +450,7 @@ func TestResolveDirectFlowDecisionFallsBackToConfiguredDecisionByPriority(t *tes
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:     "low-priority-flow",
 						Priority: 10,
@@ -740,7 +740,7 @@ func TestHandleLooperInternalRequestWithPluginsResolvesProviderModelAlias(t *tes
 		Cache: &spyCache{},
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					{
 						Name:      "fusion_alias",
 						ModelRefs: []config.ModelRef{{Model: "panel-a"}},

--- a/src/semantic-router/pkg/extproc/req_filter_reason.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason.go
@@ -270,14 +270,12 @@ func (r *OpenAIRouter) getReasoningEffort(categoryName string, modelName string)
 		return "medium"
 	}
 
-	for _, decision := range r.Config.DefaultDecisions {
-		if decision.Name != categoryName {
-			continue
-		}
-		if effort := r.reasoningEffortForDecision(decision, modelName); effort != "" {
+	// By-name lookup across every recipe, without materializing a merged
+	// decision slice: this runs several times per request.
+	if decision := r.Config.GetDecisionByName(categoryName); decision != nil {
+		if effort := r.reasoningEffortForDecision(*decision, modelName); effort != "" {
 			return effort
 		}
-		break
 	}
 
 	// Fall back to global default if configured

--- a/src/semantic-router/pkg/extproc/req_filter_reason.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason.go
@@ -270,7 +270,7 @@ func (r *OpenAIRouter) getReasoningEffort(categoryName string, modelName string)
 		return "medium"
 	}
 
-	for _, decision := range r.Config.Decisions {
+	for _, decision := range r.Config.DefaultDecisions {
 		if decision.Name != categoryName {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/req_filter_reason.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason.go
@@ -273,7 +273,7 @@ func (r *OpenAIRouter) getReasoningEffort(categoryName string, modelName string)
 	// By-name lookup across every recipe, without materializing a merged
 	// decision slice: this runs several times per request.
 	if decision := r.Config.GetDecisionByName(categoryName); decision != nil {
-		if effort := r.reasoningEffortForDecision(*decision, modelName); effort != "" {
+		if effort := r.reasoningEffortForDecision(decision, modelName); effort != "" {
 			return effort
 		}
 	}
@@ -287,7 +287,7 @@ func (r *OpenAIRouter) getReasoningEffort(categoryName string, modelName string)
 	return "medium"
 }
 
-func (r *OpenAIRouter) reasoningEffortForDecision(decision config.Decision, modelName string) string {
+func (r *OpenAIRouter) reasoningEffortForDecision(decision *config.Decision, modelName string) string {
 	for _, modelRef := range decision.ModelRefs {
 		if !r.Config.ModelNameMatches(modelRef.Model, modelName) {
 			continue

--- a/src/semantic-router/pkg/extproc/req_filter_reason_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_reason_test.go
@@ -380,8 +380,8 @@ func newReasoningRouter(
 	return &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				ReasoningConfig: reasoningConfig,
-				Decisions:       decisions,
+				ReasoningConfig:  reasoningConfig,
+				DefaultDecisions: decisions,
 			},
 			BackendModels: config.BackendModels{ModelConfig: modelConfig},
 		},

--- a/src/semantic-router/pkg/extproc/req_filter_sys_prompt_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_sys_prompt_test.go
@@ -12,7 +12,7 @@ import (
 func TestAddSystemPromptUsesRouterConfigBeforeGlobal(t *testing.T) {
 	restoreGlobalConfig := replaceExtProcGlobalConfigForTest(&config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				decisionWithSystemPrompt("support", "global prompt"),
 			},
 		},
@@ -22,7 +22,7 @@ func TestAddSystemPromptUsesRouterConfigBeforeGlobal(t *testing.T) {
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{
 			IntelligentRouting: config.IntelligentRouting{
-				Decisions: []config.Decision{
+				DefaultDecisions: []config.Decision{
 					decisionWithSystemPrompt("support", "router prompt"),
 				},
 			},
@@ -44,7 +44,7 @@ func TestAddSystemPromptUsesRouterConfigBeforeGlobal(t *testing.T) {
 func TestAddSystemPromptDoesNotUseGlobalWhenRouterConfigMissesDecision(t *testing.T) {
 	restoreGlobalConfig := replaceExtProcGlobalConfigForTest(&config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				decisionWithSystemPrompt("support", "global prompt"),
 			},
 		},

--- a/src/semantic-router/pkg/extproc/router_build.go
+++ b/src/semantic-router/pkg/extproc/router_build.go
@@ -132,11 +132,12 @@ func buildOpenAIRouterFromConfig(cfg *config.RouterConfig) (*OpenAIRouter, error
 }
 
 func logLoadedRouterConfig(configPath string, cfg *config.RouterConfig) {
+	decisions := cfg.AllRoutingDecisions()
 	logging.ComponentDebugEvent("extproc", "router_config_loaded", map[string]interface{}{
 		"config_path":    configPath,
-		"decision_count": len(cfg.DefaultDecisions),
+		"decision_count": len(decisions),
 	})
-	for i, decision := range cfg.DefaultDecisions {
+	for i, decision := range decisions {
 		logging.ComponentDebugEvent("extproc", "router_config_decision_loaded", map[string]interface{}{
 			"config_path": configPath,
 			"index":       i,

--- a/src/semantic-router/pkg/extproc/router_build.go
+++ b/src/semantic-router/pkg/extproc/router_build.go
@@ -134,9 +134,9 @@ func buildOpenAIRouterFromConfig(cfg *config.RouterConfig) (*OpenAIRouter, error
 func logLoadedRouterConfig(configPath string, cfg *config.RouterConfig) {
 	logging.ComponentDebugEvent("extproc", "router_config_loaded", map[string]interface{}{
 		"config_path":    configPath,
-		"decision_count": len(cfg.Decisions),
+		"decision_count": len(cfg.DefaultDecisions),
 	})
-	for i, decision := range cfg.Decisions {
+	for i, decision := range cfg.DefaultDecisions {
 		logging.ComponentDebugEvent("extproc", "router_config_decision_loaded", map[string]interface{}{
 			"config_path": configPath,
 			"index":       i,

--- a/src/semantic-router/pkg/extproc/router_components_mapping_gate_test.go
+++ b/src/semantic-router/pkg/extproc/router_components_mapping_gate_test.go
@@ -52,7 +52,7 @@ func TestLoadClassifierMappingsRequiresUsedCoreSignalMappings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := newCoreSignalMappingGateConfig(t)
-			cfg.Decisions = []config.Decision{{
+			cfg.DefaultDecisions = []config.Decision{{
 				Name: "guarded-route",
 				Rules: config.RuleNode{Operator: "OR", Conditions: []config.RuleNode{
 					tt.rule,
@@ -88,7 +88,7 @@ func newCoreSignalMappingGateConfig(t *testing.T) *config.RouterConfig {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:  "default-route",
 				Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{}},
 			}},

--- a/src/semantic-router/pkg/extproc/router_config_test.go
+++ b/src/semantic-router/pkg/extproc/router_config_test.go
@@ -10,7 +10,7 @@ import (
 func TestRouterConfigUsesRuntimeRegistryBeforeGlobal(t *testing.T) {
 	globalCfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "global-decision"}},
+			DefaultDecisions: []config.Decision{{Name: "global-decision"}},
 		},
 	}
 	restoreGlobalConfig := replaceExtProcGlobalConfigForTest(globalCfg)
@@ -18,7 +18,7 @@ func TestRouterConfigUsesRuntimeRegistryBeforeGlobal(t *testing.T) {
 
 	runtimeCfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "runtime-decision"}},
+			DefaultDecisions: []config.Decision{{Name: "runtime-decision"}},
 		},
 	}
 	router := &OpenAIRouter{
@@ -39,7 +39,7 @@ func TestRouterConfigUsesRuntimeRegistryBeforeGlobal(t *testing.T) {
 func TestRouterConfigWithEmptyRuntimeRegistryDoesNotUseGlobal(t *testing.T) {
 	globalCfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "global-decision"}},
+			DefaultDecisions: []config.Decision{{Name: "global-decision"}},
 		},
 	}
 	restoreGlobalConfig := replaceExtProcGlobalConfigForTest(globalCfg)

--- a/src/semantic-router/pkg/extproc/router_learning_adaptation.go
+++ b/src/semantic-router/pkg/extproc/router_learning_adaptation.go
@@ -230,7 +230,7 @@ func (r *OpenAIRouter) learningCandidateModels(
 	switch candidateSet {
 	case config.RouterLearningCandidateSetTier:
 		if tier := decisionTier(ctx); tier > 0 {
-			return r.eligibleLearningModelRefs(r.unionDecisionModelRefs(func(decision config.Decision) bool {
+			return r.eligibleLearningModelRefs(unionDecisionModelRefs(r.learningScopedDecisions(ctx), func(decision config.Decision) bool {
 				return decision.Tier == tier
 			}))
 		}
@@ -259,7 +259,9 @@ func (r *OpenAIRouter) deployedLearningModelRefs() []config.ModelRef {
 		refs = append(refs, ref)
 	}
 	add(config.ModelRef{Model: r.Config.DefaultModel})
-	for _, ref := range r.unionDecisionModelRefs(func(config.Decision) bool { return true }) {
+	// candidate_set: global is the deployed model inventory, so every
+	// profile's decisions count here by design.
+	for _, ref := range unionDecisionModelRefs(r.Config.AllRoutingDecisions(), func(config.Decision) bool { return true }) {
 		add(ref)
 	}
 	for _, endpoint := range r.Config.VLLMEndpoints {
@@ -276,13 +278,28 @@ func (r *OpenAIRouter) deployedLearningModelRefs() []config.ModelRef {
 	return refs
 }
 
-func (r *OpenAIRouter) unionDecisionModelRefs(match func(config.Decision) bool) []config.ModelRef {
-	if r == nil || r.Config == nil || match == nil {
+// learningScopedDecisions returns the decisions the tier candidate set may
+// draw models from: the request's entrypoint recipe when one is scoped, the
+// default profile otherwise. Mirrors decisionCandidatesForRequest — a tier
+// match must not pull in models reachable only through another recipe's
+// entrypoint.
+func (r *OpenAIRouter) learningScopedDecisions(ctx *RequestContext) []config.Decision {
+	if ctx != nil && ctx.EntrypointRecipe != nil && ctx.EntrypointRecipe.Name != config.DefaultRecipeName {
+		return ctx.EntrypointRecipe.Decisions
+	}
+	if r == nil || r.Config == nil {
+		return nil
+	}
+	return r.Config.DefaultDecisions
+}
+
+func unionDecisionModelRefs(decisions []config.Decision, match func(config.Decision) bool) []config.ModelRef {
+	if match == nil {
 		return nil
 	}
 	seen := map[string]struct{}{}
 	var refs []config.ModelRef
-	for _, decision := range r.Config.AllRoutingDecisions() {
+	for _, decision := range decisions {
 		if !match(decision) {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/router_learning_adaptation.go
+++ b/src/semantic-router/pkg/extproc/router_learning_adaptation.go
@@ -282,7 +282,7 @@ func (r *OpenAIRouter) unionDecisionModelRefs(match func(config.Decision) bool) 
 	}
 	seen := map[string]struct{}{}
 	var refs []config.ModelRef
-	for _, decision := range r.Config.Decisions {
+	for _, decision := range r.Config.DefaultDecisions {
 		if !match(decision) {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/router_learning_adaptation.go
+++ b/src/semantic-router/pkg/extproc/router_learning_adaptation.go
@@ -282,7 +282,7 @@ func (r *OpenAIRouter) unionDecisionModelRefs(match func(config.Decision) bool) 
 	}
 	seen := map[string]struct{}{}
 	var refs []config.ModelRef
-	for _, decision := range r.Config.DefaultDecisions {
+	for _, decision := range r.Config.AllRoutingDecisions() {
 		if !match(decision) {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/router_learning_selection_test.go
+++ b/src/semantic-router/pkg/extproc/router_learning_selection_test.go
@@ -572,7 +572,7 @@ func TestRouterLearningCandidateSetsAreDeterministicAndEligible(t *testing.T) {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "simple",
 					Tier:      2,
@@ -618,7 +618,7 @@ func TestRouterLearningAdaptationUsesDecisionCandidateSetOverride(t *testing.T) 
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "simple",
 					Tier:      2,
@@ -637,7 +637,7 @@ func TestRouterLearningAdaptationUsesDecisionCandidateSetOverride(t *testing.T) 
 			},
 		},
 	}}
-	ctx := &RequestContext{VSRSelectedDecision: &router.Config.Decisions[0]}
+	ctx := &RequestContext{VSRSelectedDecision: &router.Config.DefaultDecisions[0]}
 	selCtx := &selection.SelectionContext{
 		DecisionName:    "simple",
 		CandidateModels: []config.ModelRef{{Model: "cheap"}},

--- a/src/semantic-router/pkg/extproc/router_memory.go
+++ b/src/semantic-router/pkg/extproc/router_memory.go
@@ -16,8 +16,13 @@ import (
 )
 
 func createMemoryRuntime(cfg *config.RouterConfig) (memory.Store, *memory.MemoryExtractor) {
-	if !isMemoryEnabled(cfg) {
+	if !cfg.IsMemoryEnabled() {
 		return nil, nil
+	}
+	if !cfg.Memory.Enabled {
+		if name := cfg.MemoryPluginDecisionName(); name != "" {
+			logging.Infof("Memory auto-enabled: decision '%s' uses memory plugin", name)
+		}
 	}
 
 	memoryStore, err := createMemoryStore(cfg)
@@ -45,20 +50,6 @@ func createMemoryRuntime(cfg *config.RouterConfig) (memory.Store, *memory.Memory
 	return memoryStore, memoryExtractor
 }
 
-func isMemoryEnabled(cfg *config.RouterConfig) bool {
-	if cfg.Memory.Enabled {
-		return true
-	}
-
-	for _, decision := range cfg.AllRoutingDecisions() {
-		if decision.HasPlugin("memory") {
-			logging.Infof("Memory auto-enabled: decision '%s' uses memory plugin", decision.Name)
-			return true
-		}
-	}
-
-	return false
-}
 
 // createMemoryStore creates a memory store based on configuration.
 // Switches on cfg.Memory.Backend: "valkey" creates a ValkeyStore, "milvus" (or empty) creates a MilvusStore.

--- a/src/semantic-router/pkg/extproc/router_memory.go
+++ b/src/semantic-router/pkg/extproc/router_memory.go
@@ -50,7 +50,7 @@ func isMemoryEnabled(cfg *config.RouterConfig) bool {
 		return true
 	}
 
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if decision.HasPlugin("memory") {
 			logging.Infof("Memory auto-enabled: decision '%s' uses memory plugin", decision.Name)
 			return true

--- a/src/semantic-router/pkg/extproc/router_memory.go
+++ b/src/semantic-router/pkg/extproc/router_memory.go
@@ -50,7 +50,7 @@ func isMemoryEnabled(cfg *config.RouterConfig) bool {
 		return true
 	}
 
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if decision.HasPlugin("memory") {
 			logging.Infof("Memory auto-enabled: decision '%s' uses memory plugin", decision.Name)
 			return true

--- a/src/semantic-router/pkg/extproc/router_memory.go
+++ b/src/semantic-router/pkg/extproc/router_memory.go
@@ -50,7 +50,6 @@ func createMemoryRuntime(cfg *config.RouterConfig) (memory.Store, *memory.Memory
 	return memoryStore, memoryExtractor
 }
 
-
 // createMemoryStore creates a memory store based on configuration.
 // Switches on cfg.Memory.Backend: "valkey" creates a ValkeyStore, "milvus" (or empty) creates a MilvusStore.
 func createMemoryStore(cfg *config.RouterConfig) (memory.Store, error) {

--- a/src/semantic-router/pkg/extproc/router_replay_enablement_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_enablement_test.go
@@ -11,7 +11,7 @@ func TestInitializeReplayRecordersUsesGlobalReplayDefault(t *testing.T) {
 	cfg := &config.RouterConfig{
 		RouterReplay: config.RouterReplayConfig{Enabled: true, StoreBackend: "memory"},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{Name: "inherits-global", ModelRefs: []config.ModelRef{{Model: "m"}}},
 				{
 					Name:      "opt-out",
@@ -39,7 +39,7 @@ func TestApplyDecisionResultToContextUsesEffectiveRouterReplayConfig(t *testing.
 	cfg := &config.RouterConfig{
 		RouterReplay: config.RouterReplayConfig{Enabled: true, StoreBackend: "memory"},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{Name: "inherits-global", ModelRefs: []config.ModelRef{{Model: "m"}}},
 			},
 		},
@@ -48,7 +48,7 @@ func TestApplyDecisionResultToContextUsesEffectiveRouterReplayConfig(t *testing.
 	ctx := &RequestContext{}
 
 	router.applyDecisionResultToContext(&decision.DecisionResult{
-		Decision: &cfg.Decisions[0],
+		Decision: &cfg.DefaultDecisions[0],
 	}, ctx)
 
 	if ctx.RouterReplayPluginConfig == nil {

--- a/src/semantic-router/pkg/extproc/router_replay_setup.go
+++ b/src/semantic-router/pkg/extproc/router_replay_setup.go
@@ -44,7 +44,7 @@ func initializeIsolatedReplayRecorders(
 ) map[string]*routerreplay.Recorder {
 	recorders := make(map[string]*routerreplay.Recorder)
 
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		pluginCfg := cfg.EffectiveRouterReplayConfigForDecision(decision.Name)
 		if pluginCfg == nil {
 			continue
@@ -72,7 +72,7 @@ func initializeSharedReplayRecorders(
 		replayRecorder *routerreplay.Recorder
 	)
 
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		pluginCfg := cfg.EffectiveRouterReplayConfigForDecision(decision.Name)
 		if pluginCfg == nil {
 			continue

--- a/src/semantic-router/pkg/extproc/router_replay_setup.go
+++ b/src/semantic-router/pkg/extproc/router_replay_setup.go
@@ -44,7 +44,7 @@ func initializeIsolatedReplayRecorders(
 ) map[string]*routerreplay.Recorder {
 	recorders := make(map[string]*routerreplay.Recorder)
 
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		pluginCfg := cfg.EffectiveRouterReplayConfigForDecision(decision.Name)
 		if pluginCfg == nil {
 			continue
@@ -72,7 +72,7 @@ func initializeSharedReplayRecorders(
 		replayRecorder *routerreplay.Recorder
 	)
 
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		pluginCfg := cfg.EffectiveRouterReplayConfigForDecision(decision.Name)
 		if pluginCfg == nil {
 			continue

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -159,7 +159,11 @@ type decisionScopedSelectionConfigs struct {
 func findDecisionScopedSelectionConfigs(cfg *config.RouterConfig) decisionScopedSelectionConfigs {
 	var result decisionScopedSelectionConfigs
 
-	for _, decision := range cfg.AllRoutingDecisions() {
+	// First-match-wins into a process-level selector singleton: the source
+	// must be the default profile. Reading every recipe would let a named
+	// recipe's tuning claim the global config, decided by YAML declaration
+	// order (recipes-only layouts preserve it).
+	for _, decision := range cfg.DefaultDecisions {
 		if decision.Algorithm == nil {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -118,7 +118,7 @@ func collectConfiguredAlgorithmMethods(cfg *config.RouterConfig) []selection.Sel
 	seen := make(map[string]bool)
 	var methods []selection.SelectionMethod
 
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if decision.Algorithm == nil || decision.Algorithm.Type == "" {
 			continue
 		}
@@ -160,7 +160,7 @@ func findDecisionScopedSelectionConfigs(cfg *config.RouterConfig) decisionScoped
 	intelligentRouting := cfg.IntelligentRouting
 	var result decisionScopedSelectionConfigs
 
-	for _, decision := range intelligentRouting.Decisions {
+	for _, decision := range intelligentRouting.DefaultDecisions {
 		if decision.Algorithm == nil {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/router_selection.go
+++ b/src/semantic-router/pkg/extproc/router_selection.go
@@ -118,7 +118,7 @@ func collectConfiguredAlgorithmMethods(cfg *config.RouterConfig) []selection.Sel
 	seen := make(map[string]bool)
 	var methods []selection.SelectionMethod
 
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if decision.Algorithm == nil || decision.Algorithm.Type == "" {
 			continue
 		}
@@ -157,10 +157,9 @@ type decisionScopedSelectionConfigs struct {
 }
 
 func findDecisionScopedSelectionConfigs(cfg *config.RouterConfig) decisionScopedSelectionConfigs {
-	intelligentRouting := cfg.IntelligentRouting
 	var result decisionScopedSelectionConfigs
 
-	for _, decision := range intelligentRouting.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if decision.Algorithm == nil {
 			continue
 		}

--- a/src/semantic-router/pkg/extproc/router_selection_config_test.go
+++ b/src/semantic-router/pkg/extproc/router_selection_config_test.go
@@ -19,7 +19,7 @@ func TestBuildModelSelectionConfigUsesDecisionScopedLearningState(t *testing.T) 
 func learningStateRouterConfig() *config.RouterConfig {
 	return &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				rlDrivenLearningDecision(),
 				gmtRouterLearningDecision(),
 			},
@@ -154,7 +154,7 @@ func TestBuildHybridSelectionConfigMergesDecisionOverrides(t *testing.T) {
 func TestBuildModelSelectionConfigUsesDecisionScopedMultiFactorConfig(t *testing.T) {
 	got := buildModelSelectionConfig(&config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "weighted-latency-router",
 					Algorithm: &config.AlgorithmConfig{

--- a/src/semantic-router/pkg/extproc/server_config_watch.go
+++ b/src/semantic-router/pkg/extproc/server_config_watch.go
@@ -213,7 +213,7 @@ func (l *configFileReloadLoop) logReloadSuccess() {
 		"file": l.cfgFile,
 	}
 	if newRouter != nil && newRouter.Config != nil {
-		event["decision_count"] = len(newRouter.Config.DefaultDecisions)
+		event["decision_count"] = len(newRouter.Config.AllRoutingDecisions())
 	}
 	logging.ComponentEvent("extproc", "config_reloaded", event)
 }
@@ -250,6 +250,6 @@ func (s *Server) handleKubernetesConfigUpdate(newCfg *config.RouterConfig) {
 
 	logging.ComponentEvent("extproc", "config_reloaded", map[string]interface{}{
 		"source":         "kubernetes",
-		"decision_count": len(newCfg.DefaultDecisions),
+		"decision_count": len(newCfg.AllRoutingDecisions()),
 	})
 }

--- a/src/semantic-router/pkg/extproc/server_config_watch.go
+++ b/src/semantic-router/pkg/extproc/server_config_watch.go
@@ -213,7 +213,7 @@ func (l *configFileReloadLoop) logReloadSuccess() {
 		"file": l.cfgFile,
 	}
 	if newRouter != nil && newRouter.Config != nil {
-		event["decision_count"] = len(newRouter.Config.AllRoutingDecisions())
+		event["decision_count"] = newRouter.Config.CountRoutingDecisions()
 	}
 	logging.ComponentEvent("extproc", "config_reloaded", event)
 }
@@ -250,6 +250,6 @@ func (s *Server) handleKubernetesConfigUpdate(newCfg *config.RouterConfig) {
 
 	logging.ComponentEvent("extproc", "config_reloaded", map[string]interface{}{
 		"source":         "kubernetes",
-		"decision_count": len(newCfg.AllRoutingDecisions()),
+		"decision_count": newCfg.CountRoutingDecisions(),
 	})
 }

--- a/src/semantic-router/pkg/extproc/server_config_watch.go
+++ b/src/semantic-router/pkg/extproc/server_config_watch.go
@@ -213,7 +213,7 @@ func (l *configFileReloadLoop) logReloadSuccess() {
 		"file": l.cfgFile,
 	}
 	if newRouter != nil && newRouter.Config != nil {
-		event["decision_count"] = len(newRouter.Config.Decisions)
+		event["decision_count"] = len(newRouter.Config.DefaultDecisions)
 	}
 	logging.ComponentEvent("extproc", "config_reloaded", event)
 }
@@ -250,6 +250,6 @@ func (s *Server) handleKubernetesConfigUpdate(newCfg *config.RouterConfig) {
 
 	logging.ComponentEvent("extproc", "config_reloaded", map[string]interface{}{
 		"source":         "kubernetes",
-		"decision_count": len(newCfg.Decisions),
+		"decision_count": len(newCfg.DefaultDecisions),
 	})
 }

--- a/src/semantic-router/pkg/k8s/converter_test.go
+++ b/src/semantic-router/pkg/k8s/converter_test.go
@@ -94,7 +94,7 @@ func TestConverterWithTestData(t *testing.T) {
 			require.NoError(t, err, "Failed runtime parse validation")
 			assert.Equal(t, config.ConfigSourceKubernetes, validateConfig.ConfigSource, "ConfigSource should remain kubernetes")
 			assert.Equal(t, pool.Spec.DefaultModel, validateConfig.DefaultModel, "default model mismatch")
-			assert.Len(t, validateConfig.Decisions, len(route.Spec.Decisions), "Decisions count mismatch")
+			assert.Len(t, validateConfig.DefaultDecisions, len(route.Spec.Decisions), "Decisions count mismatch")
 			assert.Len(t, validateConfig.ModelConfig, len(pool.Spec.Models), "Model catalog count mismatch")
 		})
 	}

--- a/src/semantic-router/pkg/k8s/dynamic_config_regression_test.go
+++ b/src/semantic-router/pkg/k8s/dynamic_config_regression_test.go
@@ -105,8 +105,8 @@ func assertDynamicConfigRuntimeConfig(t *testing.T, runtimeCfg *config.RouterCon
 	if runtimeCfg.DefaultModel != "general-expert" {
 		t.Fatalf("expected dynamic-config default model to remain LoRA alias, got %q", runtimeCfg.DefaultModel)
 	}
-	if len(runtimeCfg.Decisions) != len(route.Spec.Decisions) {
-		t.Fatalf("expected %d decisions after dynamic-config conversion, got %d", len(route.Spec.Decisions), len(runtimeCfg.Decisions))
+	if len(runtimeCfg.DefaultDecisions) != len(route.Spec.Decisions) {
+		t.Fatalf("expected %d decisions after dynamic-config conversion, got %d", len(route.Spec.Decisions), len(runtimeCfg.DefaultDecisions))
 	}
 
 	endpoints := runtimeCfg.GetEndpointsForModel("general-expert")

--- a/src/semantic-router/pkg/modeldownload/config_parser_test.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser_test.go
@@ -140,7 +140,7 @@ func TestIsModelDirectory(t *testing.T) {
 func TestExtractModelPathsSkipsRootLevelModelFiles(t *testing.T) {
 	cfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "default-route",
 					Algorithm: &config.AlgorithmConfig{
@@ -204,7 +204,7 @@ func TestBuildModelSpecsIncludesConfigDerivedRequiredFiles(t *testing.T) {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:  "domain-route",
 				Rules: config.RuleNode{Type: config.SignalTypeDomain, Name: "billing"},
 			}},
@@ -315,7 +315,7 @@ func TestBuildModelSpecsSkipsUnusedCoreClassifierModels(t *testing.T) {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:  "default-route",
 				Rules: config.RuleNode{Operator: "AND", Conditions: []config.RuleNode{}},
 			}},
@@ -356,7 +356,7 @@ func TestBuildModelSpecsIncludesUsedCoreClassifierModels(t *testing.T) {
 			},
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name: "guarded-route",
 				Rules: config.RuleNode{Operator: "OR", Conditions: []config.RuleNode{
 					{Type: config.SignalTypeDomain, Name: "billing"},
@@ -409,7 +409,7 @@ func TestBuildModelSpecsIncludesCoreClassifierUsedViaProjection(t *testing.T) {
 					}},
 				}},
 			},
-			Decisions: []config.Decision{{
+			DefaultDecisions: []config.Decision{{
 				Name:  "guarded-route",
 				Rules: config.RuleNode{Type: config.SignalTypeProjection, Name: "high_risk"},
 			}},

--- a/src/semantic-router/pkg/modelruntime/router_runtime.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime.go
@@ -455,24 +455,10 @@ func memoryNeedsBERT(cfg *config.RouterConfig) bool {
 	if cfg.EmbeddingModels.UsesRemoteEmbeddingBackend() {
 		return false
 	}
-	if !memoryConfigured(cfg) {
+	if !cfg.IsMemoryEnabled() {
 		return false
 	}
 	return resolveMemoryEmbeddingModel(cfg) == "bert"
-}
-
-func memoryConfigured(cfg *config.RouterConfig) bool {
-	if cfg.Memory.Enabled {
-		return true
-	}
-	// Every recipe's decisions count: a memory plugin declared by a
-	// non-default recipe still needs the memory runtime wired up.
-	for _, decision := range cfg.AllRoutingDecisions() {
-		if decision.HasPlugin("memory") {
-			return true
-		}
-	}
-	return false
 }
 
 func resolveSemanticCacheEmbeddingModel(cfg *config.RouterConfig) string {

--- a/src/semantic-router/pkg/modelruntime/router_runtime.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime.go
@@ -465,7 +465,7 @@ func memoryConfigured(cfg *config.RouterConfig) bool {
 	if cfg.Memory.Enabled {
 		return true
 	}
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		if decision.HasPlugin("memory") {
 			return true
 		}

--- a/src/semantic-router/pkg/modelruntime/router_runtime.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime.go
@@ -465,7 +465,9 @@ func memoryConfigured(cfg *config.RouterConfig) bool {
 	if cfg.Memory.Enabled {
 		return true
 	}
-	for _, decision := range cfg.DefaultDecisions {
+	// Every recipe's decisions count: a memory plugin declared by a
+	// non-default recipe still needs the memory runtime wired up.
+	for _, decision := range cfg.AllRoutingDecisions() {
 		if decision.HasPlugin("memory") {
 			return true
 		}

--- a/src/semantic-router/pkg/modelselection/config_analyzer.go
+++ b/src/semantic-router/pkg/modelselection/config_analyzer.go
@@ -78,7 +78,7 @@ func AnalyzeConfig(cfg *config.RouterConfig) *ConfigAnalysisResult {
 	uniqueModels := make(map[string]bool)
 
 	// Analyze decisions
-	for _, decision := range cfg.DefaultDecisions {
+	for _, decision := range cfg.AllRoutingDecisions() {
 		result.TotalDecisions++
 
 		// Extract model names from ModelRefs

--- a/src/semantic-router/pkg/modelselection/config_analyzer.go
+++ b/src/semantic-router/pkg/modelselection/config_analyzer.go
@@ -78,7 +78,7 @@ func AnalyzeConfig(cfg *config.RouterConfig) *ConfigAnalysisResult {
 	uniqueModels := make(map[string]bool)
 
 	// Analyze decisions
-	for _, decision := range cfg.Decisions {
+	for _, decision := range cfg.DefaultDecisions {
 		result.TotalDecisions++
 
 		// Extract model names from ModelRefs

--- a/src/semantic-router/pkg/services/classification.go
+++ b/src/semantic-router/pkg/services/classification.go
@@ -154,7 +154,7 @@ func (s *ClassificationService) ClassifyIntent(req IntentRequest) (*IntentRespon
 	// Evaluate decision with engine (if decisions are configured)
 	// Pass pre-computed signals to avoid re-evaluation
 	var decisionResult *decision.DecisionResult
-	if s.config != nil && len(s.config.Decisions) > 0 {
+	if s.config != nil && len(s.config.DefaultDecisions) > 0 {
 		decisionResult, err = s.classifier.EvaluateDecisionWithEngine(signals)
 		if err != nil {
 			// Log error but continue with classification

--- a/src/semantic-router/pkg/services/classification_recommendation.go
+++ b/src/semantic-router/pkg/services/classification_recommendation.go
@@ -16,7 +16,7 @@ func (s *ClassificationService) getRecommendedModel(category string, _ float64) 
 	if s.config == nil {
 		return ""
 	}
-	if model := recommendedModelFromDecisions(s.config.DefaultDecisions, category); model != "" {
+	if model := recommendedModelFromDecisions(s.config.AllRoutingDecisions(), category); model != "" {
 		return model
 	}
 	return s.config.DefaultModel

--- a/src/semantic-router/pkg/services/classification_recommendation.go
+++ b/src/semantic-router/pkg/services/classification_recommendation.go
@@ -7,16 +7,13 @@ import (
 )
 
 func (s *ClassificationService) getRecommendedModel(category string, _ float64) string {
-	if s.classifier != nil {
-		model := s.classifier.SelectBestModelForCategory(category)
-		if model != "" {
-			return model
-		}
-	}
+	// The classify API previews routing against the default profile only
+	// (EvaluateDecisionWithEngine's scope), so the recommendation must not
+	// name a model reachable only through a named recipe's entrypoint.
 	if s.config == nil {
 		return ""
 	}
-	if model := recommendedModelFromDecisions(s.config.AllRoutingDecisions(), category); model != "" {
+	if model := recommendedModelFromDecisions(s.config.DefaultDecisions, category); model != "" {
 		return model
 	}
 	return s.config.DefaultModel

--- a/src/semantic-router/pkg/services/classification_recommendation.go
+++ b/src/semantic-router/pkg/services/classification_recommendation.go
@@ -16,7 +16,7 @@ func (s *ClassificationService) getRecommendedModel(category string, _ float64) 
 	if s.config == nil {
 		return ""
 	}
-	if model := recommendedModelFromDecisions(s.config.Decisions, category); model != "" {
+	if model := recommendedModelFromDecisions(s.config.DefaultDecisions, category); model != "" {
 		return model
 	}
 	return s.config.DefaultModel

--- a/src/semantic-router/pkg/services/classification_signal_contract.go
+++ b/src/semantic-router/pkg/services/classification_signal_contract.go
@@ -40,7 +40,7 @@ func (s *ClassificationService) ClassifyIntentForEval(req IntentRequest) (*EvalR
 
 	var decisionResult *decision.DecisionResult
 	var traces []decision.DecisionTrace
-	if s.config != nil && len(s.config.Decisions) > 0 {
+	if s.config != nil && len(s.config.DefaultDecisions) > 0 {
 		decisionResult, traces = s.evaluateIntentDecision(signals, wantTrace)
 	}
 

--- a/src/semantic-router/pkg/services/classification_test.go
+++ b/src/semantic-router/pkg/services/classification_test.go
@@ -264,7 +264,7 @@ func TestBuildEvalResponse_ProjectionSignalsIncludedInUsedMatchedAndUnmatched(t 
 					},
 				},
 			},
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "reasoning_route",
 					Rules: config.RuleCombination{
@@ -288,7 +288,7 @@ func TestBuildEvalResponse_ProjectionSignalsIncludedInUsedMatchedAndUnmatched(t 
 		SignalConfidences:      map[string]float64{"projection:balance_reasoning": 0.94},
 	}
 	decisionResult := &decision.DecisionResult{
-		Decision: &routerConfig.Decisions[0],
+		Decision: &routerConfig.DefaultDecisions[0],
 	}
 
 	response := service.buildEvalResponse("reason carefully", signals, decisionResult)
@@ -350,7 +350,7 @@ func TestGetRecommendedModel_WithConfig(t *testing.T) {
 			DefaultModel: "default-llm-model",
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "math",
 					ModelRefs: []config.ModelRef{
@@ -475,7 +475,7 @@ func TestGetRecommendedModel_NoDecisionFound(t *testing.T) {
 			DefaultModel: "default-llm-model",
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "math",
 					ModelRefs: []config.ModelRef{
@@ -507,7 +507,7 @@ func TestGetRecommendedModel_EmptyModelRefs(t *testing.T) {
 			DefaultModel: "default-llm-model",
 		},
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name:      "math",
 					ModelRefs: []config.ModelRef{}, // Empty ModelRefs

--- a/src/semantic-router/pkg/services/classification_update_test.go
+++ b/src/semantic-router/pkg/services/classification_update_test.go
@@ -10,12 +10,12 @@ import (
 func TestClassificationServiceRefreshRuntimeConfigRefreshesClassifierConfig(t *testing.T) {
 	oldConfig := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "old_route"}},
+			DefaultDecisions: []config.Decision{{Name: "old_route"}},
 		},
 	}
 	newConfig := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "new_route"}},
+			DefaultDecisions: []config.Decision{{Name: "new_route"}},
 		},
 	}
 
@@ -40,17 +40,17 @@ func TestClassificationServiceRefreshRuntimeConfigRefreshesClassifierConfig(t *t
 func TestClassificationServiceRefreshRuntimeConfigDoesNotReplaceGlobalConfig(t *testing.T) {
 	globalConfig := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "global_route"}},
+			DefaultDecisions: []config.Decision{{Name: "global_route"}},
 		},
 	}
 	oldConfig := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "old_route"}},
+			DefaultDecisions: []config.Decision{{Name: "old_route"}},
 		},
 	}
 	newConfig := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{{Name: "new_route"}},
+			DefaultDecisions: []config.Decision{{Name: "new_route"}},
 		},
 	}
 

--- a/src/semantic-router/pkg/utils/pii/policy_test.go
+++ b/src/semantic-router/pkg/utils/pii/policy_test.go
@@ -10,7 +10,7 @@ import (
 func makeSignalBasedPIIConfig(decisionName, piiSignalName string, piiTypesAllowed []string) *config.RouterConfig {
 	return &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: decisionName,
 					Rules: config.RuleCombination{
@@ -53,7 +53,7 @@ func TestIsPIIEnabled(t *testing.T) {
 			setupConfig: func() *config.RouterConfig {
 				return &config.RouterConfig{
 					IntelligentRouting: config.IntelligentRouting{
-						Decisions: []config.Decision{},
+						DefaultDecisions: []config.Decision{},
 					},
 				}
 			},
@@ -74,7 +74,7 @@ func TestIsPIIEnabled(t *testing.T) {
 				// Decision exists but has no PII signal reference in rules
 				return &config.RouterConfig{
 					IntelligentRouting: config.IntelligentRouting{
-						Decisions: []config.Decision{
+						DefaultDecisions: []config.Decision{
 							{
 								Name: "general",
 								Rules: config.RuleCombination{
@@ -119,7 +119,7 @@ func TestCheckPolicy(t *testing.T) {
 				// No PII signal reference → PII disabled
 				return &config.RouterConfig{
 					IntelligentRouting: config.IntelligentRouting{
-						Decisions: []config.Decision{
+						DefaultDecisions: []config.Decision{
 							{
 								Name: "general",
 								Rules: config.RuleCombination{
@@ -357,7 +357,7 @@ func TestExtractAllContent(t *testing.T) {
 func TestNewPolicyChecker(t *testing.T) {
 	cfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{
+			DefaultDecisions: []config.Decision{
 				{
 					Name: "test-decision",
 				},
@@ -375,15 +375,15 @@ func TestNewPolicyChecker(t *testing.T) {
 		t.Error("PolicyChecker.Config is nil")
 	}
 
-	if len(checker.Config.Decisions) != 1 {
-		t.Errorf("Expected 1 decision, got %d", len(checker.Config.Decisions))
+	if len(checker.Config.DefaultDecisions) != 1 {
+		t.Errorf("Expected 1 decision, got %d", len(checker.Config.DefaultDecisions))
 	}
 }
 
 func TestCheckPolicy_NilDecision(t *testing.T) {
 	cfg := &config.RouterConfig{
 		IntelligentRouting: config.IntelligentRouting{
-			Decisions: []config.Decision{},
+			DefaultDecisions: []config.Decision{},
 		},
 	}
 

--- a/tools/agent/repo-manifest.yaml
+++ b/tools/agent/repo-manifest.yaml
@@ -150,6 +150,7 @@ docs:
 - docs/agent/tech-debt/td-042-ffi-embedding-structure-debt.md
 - docs/agent/tech-debt/td-043-semantic-router-go-cyclop-debt.md
 - docs/agent/tech-debt/td-044-flow-tool-state-durability-gap.md
+- docs/agent/tech-debt/td-045-dashboard-recipe-scope-blindness.md
 local_agent_rules:
 - path: src/vllm-sr/cli/AGENTS.md
   scope: src/vllm-sr/cli/**
@@ -317,6 +318,9 @@ doc_governance:
   - path: docs/agent/tech-debt/td-044-flow-tool-state-durability-gap.md
     steward: router-core
     freshness: update when the TD044 debt record changes materially
+  - path: docs/agent/tech-debt/td-045-dashboard-recipe-scope-blindness.md
+    steward: dashboard
+    freshness: update when the TD045 debt record changes materially
 skills:
 - tools/agent/skills/config-platform-change/SKILL.md
 - tools/agent/skills/cross-stack-bugfix/SKILL.md


### PR DESCRIPTION
Closes #2723 (part of #2331). Follow-up to #2612 / #2613; the flat-field removal sketched alongside that issue is deferred, see Non-goals.

## Purpose

#2612/#2613 added named recipes next to the flat `IntelligentRouting` decisions field, but left ~15 whole-surface read sites reading only the default profile. The failures were silent: a memory plugin configured on a recipe decision passed validation and never enabled the runtime, five contract validators skipped recipe decisions entirely, and the replay recorder for a recipe decision was never registered. Named recipes are unreleased, so no released configuration is affected — but the reference config already promotes them.

This PR is the scoped correction, three layers:

1. **Rename** the flat field `Decisions` → `DefaultDecisions` (mechanical, 106 files). The yaml/json tags keep the config format and the `/info/classifier` wire key byte-identical; the new name makes every default-profile read visible at its call site.
2. **Fix the read sites**: plugin enablement, the five validators, lookups, and the replay recorder now read the whole routing surface via `AllRoutingDecisions()` / `GetDecisionByName()`. Sites whose scope really is the default profile stay that way, each with its rationale recorded.
3. **Guard the future**: an allowlist test pins the complete set of production files that may read the flat field, one scope rationale per entry. A new default-profile read fails CI until it either switches to a whole-surface accessor or states its reason in front of the reviewer.

A review pass over the branch then tightened the scope decisions themselves:

- The process-level selection singleton (`elo`/`multi_factor`/… configs) and the classify-API reasoning/recommendation paths deliberately stay on the default profile — widening them made the global config dependent on YAML recipe order and let recipes leak into an API that previews default-profile routing.
- `candidate_set: tier` learning candidates now follow the request's recipe scope instead of unioning every profile (which could route past a recipe's entrypoint).
- Cross-recipe decision names are now validated case-insensitively; the fold lookup's uniqueness assumption was otherwise false.
- Cleanups: the memory-enablement predicate sank into `config` (was copied in three packages), allocation-free `CountRoutingDecisions()`, and the mirror invariant asserts slice aliasing rather than tautological `DeepEqual`.

**No user-visible behavior change** on any released surface: single-profile configs are bit-for-bit unaffected, and the only behavior changes sit on the unreleased named-recipe surface.

## Non-goals (deferred, tracked)

- **Removing the flat field** ("single source of truth"): the field and the default recipe are one aliased slice, pinned by an invariant test — removal buys no additional correctness today and costs an emitter compatibility layer plus a wholesale fixture rewrite. Revisit in #2331 if the recipes-only layout ever forces it.
- Dashboard recipe awareness: registered as TD045, owned by pl-0038 T12.
- DSL round-trip for recipes/entrypoints: pl-0038 T10.

## Test Plan

- Full main-module `go test` (`pkg/cache` excluded: env-dependent backends), including the cgo-linked `extproc`/`classification`/`services`/`apiserver` suites.
- `make agent-lint` over all changed files, `make check-go-mod-tidy`, markdownlint on the docs.
- New coverage: `recipe_read_sites_test.go` pins every corrected read site; `default_decisions_allowlist_test.go` pins the deliberate default-profile reads (and also matches the `DefaultRecipe()` spelling); `recipes_invariant_test.go` pins the flat-field/default-recipe aliasing; a new loader test pins the case-insensitive cross-recipe name check.

## Test Result

All of the above pass locally; every commit builds and passes lint, so the sequence bisects.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change
</details>
