### PR TITLE
fix(config): preserve disabled router replay

### DIFF
--- a/src/semantic-router/pkg/apiserver/route_config_deploy_test.go
+++ b/src/semantic-router/pkg/apiserver/route_config_deploy_test.go
@@ -54,6 +54,38 @@ func TestHandleConfigPutReplacesExistingConfig(t *testing.T) {
 	}
 }
 
+func TestHandleConfigPutPreservesDisabledRouterReplay(t *testing.T) {
+	configPath := writeDeployTestBaseConfig(t)
+	payloadCfg := minimalDeployTestConfig("new_route")
+	payloadCfg.RouterReplay = config.RouterReplayConfig{
+		Enabled:      false,
+		StoreBackend: "memory",
+		TTLSeconds:   600,
+	}
+	payloadYAML := mustMarshalCanonicalConfigYAML(t, payloadCfg)
+	body, err := json.Marshal(RouterConfigUpdateRequest{YAML: string(payloadYAML)})
+	if err != nil {
+		t.Fatalf("json.Marshal error: %v", err)
+	}
+
+	apiServer := &ClassificationAPIServer{configPath: configPath}
+	req := httptest.NewRequest(http.MethodPut, "/config/router", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	apiServer.handleConfigPut(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rr.Code, rr.Body.String())
+	}
+	reloaded, err := config.Parse(configPath)
+	if err != nil {
+		t.Fatalf("parse deployed config: %v", err)
+	}
+	if reloaded.RouterReplay.Enabled {
+		t.Fatal("expected router_replay.enabled=false to survive canonical PUT normalization")
+	}
+}
+
 func TestHandleConfigPatchRejectsInvalidRemoteEmbeddingProvider(t *testing.T) {
 	configPath := writeDeployTestBaseConfig(t)
 	invalidCfg := minimalDeployTestConfig("new_route")

--- a/src/semantic-router/pkg/config/canonical_router_replay_test.go
+++ b/src/semantic-router/pkg/config/canonical_router_replay_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestCanonicalExportKeepsRouterReplayDisabled(t *testing.T) {
+	cfg := &RouterConfig{
+		RouterReplay: RouterReplayConfig{
+			Enabled:      false,
+			StoreBackend: "memory",
+			TTLSeconds:   600,
+		},
+	}
+
+	encoded, err := yaml.Marshal(CanonicalConfigFromRouterConfig(cfg))
+	if err != nil {
+		t.Fatalf("marshal canonical config: %v", err)
+	}
+
+	var document map[interface{}]interface{}
+	if err := yaml.Unmarshal(encoded, &document); err != nil {
+		t.Fatalf("unmarshal canonical config: %v", err)
+	}
+	global := requireYAMLMap(t, document["global"], "global")
+	services := requireYAMLMap(t, global["services"], "global.services")
+	replay := requireYAMLMap(t, services["router_replay"], "global.services.router_replay")
+	if got, ok := replay["enabled"]; !ok || got != false {
+		t.Fatalf("router_replay.enabled = %#v, want explicit false; YAML:\n%s", got, encoded)
+	}
+}
+
+func requireYAMLMap(t *testing.T, value interface{}, path string) map[interface{}]interface{} {
+	t.Helper()
+	result, ok := value.(map[interface{}]interface{})
+	if !ok {
+		t.Fatalf("%s = %#v, want YAML mapping", path, value)
+	}
+	return result
+}

--- a/src/semantic-router/pkg/config/runtime_config.go
+++ b/src/semantic-router/pkg/config/runtime_config.go
@@ -378,7 +378,7 @@ type ResponseAPIRedisConfig struct {
 // run Redis. Set to "memory" only for local development — all replay
 // records are lost when the router process exits.
 type RouterReplayConfig struct {
-	Enabled      bool                        `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Enabled      bool                        `json:"enabled" yaml:"enabled"`
 	StoreBackend string                      `json:"store_backend,omitempty" yaml:"store_backend,omitempty"`
 	TTLSeconds   int                         `json:"ttl_seconds,omitempty" yaml:"ttl_seconds,omitempty"`
 	AsyncWrites  bool                        `json:"async_writes,omitempty" yaml:"async_writes,omitempty"`


### PR DESCRIPTION
Fixes #2735.

## Summary

- serialize `RouterReplayConfig.Enabled` even when it is `false`
- cover canonical export so an explicit disabled value cannot be dropped
- cover `PUT /config/router` normalization and reload

Without this change, canonical normalization omits `enabled: false`; the next parse reapplies the canonical default (`true`) and persists an unexpectedly enabled Router Replay service.

## Tests

- `CGO_ENABLED=0 go test ./pkg/config -count=1`
- repository pre-commit hooks
