### PR TITLE
[Router] add minimal validator-valid quickstart config (#2690)

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -3,6 +3,7 @@
 `config/` is now the user-facing config surface only.
 
 - `config/config.yaml`: exhaustive canonical reference config
+- `config/quickstart.yaml`: smallest maintained config that passes validation; model-free keyword routing for first-run evaluation (#2690), not a production baseline
 - `config/signal/`: reusable `routing.signals` fragments
 - `config/decision/`: reusable `routing.decisions` rule-shape fragments
 - `config/algorithm/`: reusable `decision.algorithm` snippets

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -1,0 +1,163 @@
+# Quickstart config: the smallest maintained config that passes validation.
+#
+# Purpose: let a new user observe real routing decisions without downloading
+# any classifier models or editing YAML. Routing here uses keyword signals
+# only (BM25 / n-gram matching, computed in-process), and every decision
+# carries a fast_response plugin so a complete OpenAI-compatible response
+# comes back even when no LLM backend is running yet.
+#
+# This file is an evaluation on-ramp, not a production recommendation.
+# The exhaustive reference for every supported field is config/config.yaml.
+# See issue #2690 for background.
+
+version: v0.3
+
+listeners:
+  - name: http-8899
+    address: 0.0.0.0
+    port: 8899
+    timeout: 300s
+
+providers:
+  defaults:
+    # Requests that match no decision below fall through to this model.
+    default_model: quickstart-general
+  models:
+    # Two logical models let the demo show *different* selections for
+    # different prompts. Both point at the same local endpoint; with no
+    # backend running, the fast_response plugin still completes the request.
+    - name: quickstart-general
+      provider_model_id: quickstart-general
+      backend_refs:
+        - name: primary
+          weight: 100
+          endpoint: 127.0.0.1:8000/v1
+          protocol: http
+    - name: quickstart-coder
+      provider_model_id: quickstart-coder
+      backend_refs:
+        - name: primary
+          weight: 100
+          endpoint: 127.0.0.1:8000/v1
+          protocol: http
+
+routing:
+  modelCards:
+    - name: quickstart-general
+      modality: text
+    - name: quickstart-coder
+      modality: text
+
+  signals:
+    # Keyword signals are model-free: no downloads, no classifier inference.
+    keywords:
+      - name: code_keywords
+        operator: OR
+        method: bm25
+        keywords: ["code", "function", "debug", "algorithm", "refactor"]
+        case_sensitive: false
+        bm25_threshold: 0.1
+      - name: urgent_keywords
+        operator: OR
+        method: ngram
+        keywords: ["urgent", "immediate", "asap", "emergency"]
+        case_sensitive: false
+        ngram_threshold: 0.4
+        ngram_arity: 3
+
+  decisions:
+    # Try: "please debug this function" -> quickstart-code-route
+    - name: quickstart-code-route
+      description: Coding prompts route to the coder model.
+      priority: 200
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: code_keywords
+      modelRefs:
+        - model: quickstart-coder
+          use_reasoning: false
+      plugins:
+        - type: fast_response
+          configuration:
+            message: >-
+              Routed by decision quickstart-code-route to model
+              quickstart-coder. Point providers.models at a real backend to
+              receive model completions.
+
+    # Try: "urgent: production is down" -> quickstart-urgent-route
+    - name: quickstart-urgent-route
+      description: Urgent prompts route to the general model without reasoning.
+      priority: 180
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: urgent_keywords
+      modelRefs:
+        - model: quickstart-general
+          use_reasoning: false
+      plugins:
+        - type: fast_response
+          configuration:
+            message: >-
+              Routed by decision quickstart-urgent-route to model
+              quickstart-general. Point providers.models at a real backend to
+              receive model completions.
+
+    # Everything else lands here.
+    - name: quickstart-default-route
+      description: Catch-all route for prompts matching no signal.
+      priority: 100
+      rules:
+        operator: AND
+        conditions: []
+      modelRefs:
+        - model: quickstart-general
+          use_reasoning: false
+      plugins:
+        - type: fast_response
+          configuration:
+            message: >-
+              Routed by decision quickstart-default-route to model
+              quickstart-general. Point providers.models at a real backend to
+              receive model completions.
+
+global:
+  stores:
+    semantic_cache:
+      enabled: false
+  model_catalog:
+    # Empty paths + disabled modules mean no model artifacts are required
+    # or downloaded for this config.
+    embeddings:
+      semantic:
+        mmbert_model_path: ""
+        qwen3_model_path: ""
+        gemma_model_path: ""
+        bert_model_path: ""
+        multimodal_model_path: ""
+    modules:
+      prompt_guard:
+        enabled: false
+        model_ref: ""
+        model_id: ""
+        jailbreak_mapping_path: ""
+        use_mmbert_32k: false
+      classifier:
+        domain:
+          model_ref: ""
+          model_id: ""
+          category_mapping_path: ""
+          use_mmbert_32k: false
+        pii:
+          model_ref: ""
+          model_id: ""
+          pii_mapping_path: ""
+          use_mmbert_32k: false
+      feedback_detector:
+        enabled: false
+        model_ref: ""
+        model_id: ""
+        use_mmbert_32k: false

--- a/src/semantic-router/pkg/config/quickstart_config_test.go
+++ b/src/semantic-router/pkg/config/quickstart_config_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// config/quickstart.yaml is the maintained on-ramp config (#2690): the
+// smallest config that passes validation, routes with model-free signals
+// only, and requires no classifier-model artifacts. These tests are the
+// regression gate that keeps it that way.
+
+func readQuickstartConfigYAML(t testingT) []byte {
+	t.Helper()
+	root := referenceConfigRepoRoot(t)
+	path := filepath.Join(root, "config", "quickstart.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return data
+}
+
+func TestQuickstartConfigUsesStrictCanonicalSchema(t *testing.T) {
+	data := readQuickstartConfigYAML(t)
+
+	decoder := yamlv3.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+
+	var canonical CanonicalConfig
+	if err := decoder.Decode(&canonical); err != nil {
+		t.Fatalf("config/quickstart.yaml no longer matches the strict canonical schema: %v", err)
+	}
+
+	if canonical.Version != "v0.3" {
+		t.Fatalf("expected quickstart config version v0.3, got %q", canonical.Version)
+	}
+
+	if _, err := ParseYAMLBytes(data); err != nil {
+		t.Fatalf("config/quickstart.yaml failed runtime parse validation: %v", err)
+	}
+}
+
+func TestQuickstartConfigRequiresNoModelArtifacts(t *testing.T) {
+	cfg, err := ParseYAMLBytes(readQuickstartConfigYAML(t))
+	if err != nil {
+		t.Fatalf("config/quickstart.yaml failed runtime parse validation: %v", err)
+	}
+
+	for _, path := range []struct {
+		name  string
+		value string
+	}{
+		{"mmbert_model_path", cfg.MmBertModelPath},
+		{"qwen3_model_path", cfg.Qwen3ModelPath},
+		{"gemma_model_path", cfg.GemmaModelPath},
+		{"bert_model_path", cfg.BertModelPath},
+		{"multimodal_model_path", cfg.MultiModalModelPath},
+	} {
+		if path.value != "" {
+			t.Errorf("quickstart config must not set embedding %s, got %q", path.name, path.value)
+		}
+	}
+
+	// These are the same predicates pkg/modeldownload uses to decide which
+	// model artifacts a config requires; all must stay off for quickstart.
+	for name, required := range map[string]bool{
+		"category classifier":   cfg.NeedsCategoryMappingForRouting(),
+		"pii classifier":        cfg.NeedsPIIMappingForRouting(),
+		"jailbreak classifier":  cfg.NeedsJailbreakMappingForRouting(),
+		"fact-check classifier": cfg.IsFactCheckClassifierEnabled(),
+		"hallucination model":   cfg.IsHallucinationModelEnabled(),
+		"feedback detector":     cfg.IsFeedbackDetectorEnabled(),
+	} {
+		if required {
+			t.Errorf("quickstart config must not require the %s model", name)
+		}
+	}
+}
+
+func TestQuickstartConfigDemonstratesDistinctRouting(t *testing.T) {
+	var root map[string]interface{}
+	if err := yamlv3.Unmarshal(readQuickstartConfigYAML(t), &root); err != nil {
+		t.Fatalf("failed to unmarshal config/quickstart.yaml into raw map: %v", err)
+	}
+
+	declaredSignals := map[string]bool{}
+	for _, rawSignal := range mustSliceAt(t, root, "routing", "signals", "keywords") {
+		declaredSignals[mustStringAt(t, mustMapValue(t, rawSignal, "routing.signals.keywords[]"), "name")] = true
+	}
+
+	decisions := mustSliceAt(t, root, "routing", "decisions")
+	if len(decisions) < 2 {
+		t.Fatalf("quickstart config must keep at least two decisions to demonstrate routing, got %d", len(decisions))
+	}
+
+	selectedModels := map[string]bool{}
+	sawConditionedDecision := false
+	for _, rawDecision := range decisions {
+		decision := mustMapValue(t, rawDecision, "routing.decisions[]")
+		name := mustStringAt(t, decision, "name")
+
+		// Every decision must complete without an LLM backend.
+		if !decisionHasPluginType(t, decision, "fast_response") {
+			t.Errorf("decision %q must carry a fast_response plugin so quickstart completes without a backend", name)
+		}
+
+		for _, rawRef := range mustSliceValue(t, decision["modelRefs"], "routing.decisions[].modelRefs") {
+			selectedModels[mustStringAt(t, mustMapValue(t, rawRef, "modelRefs[]"), "model")] = true
+		}
+
+		rules := mustMapValue(t, decision["rules"], "routing.decisions[].rules")
+		for _, rawCondition := range mustSliceValue(t, rules["conditions"], "rules.conditions") {
+			condition := mustMapValue(t, rawCondition, "rules.conditions[]")
+			if mustStringAt(t, condition, "type") != "keyword" {
+				t.Errorf("decision %q uses a non-keyword condition; quickstart must stay model-free", name)
+				continue
+			}
+			sawConditionedDecision = true
+			if signal := mustStringAt(t, condition, "name"); !declaredSignals[signal] {
+				t.Errorf("decision %q references undeclared keyword signal %q", name, signal)
+			}
+		}
+	}
+
+	if !sawConditionedDecision {
+		t.Fatalf("quickstart config must keep at least one keyword-conditioned decision")
+	}
+	if len(selectedModels) < 2 {
+		t.Fatalf("quickstart config must select at least two distinct models across decisions, got %v", selectedModels)
+	}
+}
+
+func decisionHasPluginType(t testingT, decision map[string]interface{}, pluginType string) bool {
+	t.Helper()
+	rawPlugins, ok := decision["plugins"]
+	if !ok || rawPlugins == nil {
+		return false
+	}
+	for _, rawPlugin := range mustSliceValue(t, rawPlugins, "routing.decisions[].plugins") {
+		plugin := mustMapValue(t, rawPlugin, "plugins[]")
+		if typ, ok := plugin["type"].(string); ok && typ == pluginType {
+			return true
+		}
+	}
+	return false
+}

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -263,6 +263,7 @@ For `routing.signals.structure`, `feature.type: density` now uses built-in multi
 The repository now separates the exhaustive canonical reference config from reusable routing fragments:
 
 - `config/config.yaml`: exhaustive canonical reference config
+- `config/quickstart.yaml`: smallest maintained config that passes validation; model-free keyword routing for first-run evaluation, not a production baseline
 - `config/signal/`: reusable `routing.signals` fragments
 - `config/decision/`: reusable `routing.decisions` rule-shape fragments
 - `config/algorithm/`: reusable `decision.algorithm` snippets
@@ -291,7 +292,7 @@ Repo-owned runtime and harness assets now live outside `config/`:
 
 Test-only ONNX binding assets now live under `e2e/config/onnx-binding/`.
 
-Those directories are support assets, not the main user-facing config contract. For hand-authored config, start from `config/config.yaml` or the fragment directories above. In this repository, the exhaustive reference config points `global.integrations.tools.tools_db_path` at `config/runtime/tools/tools_db.json` for local development.
+Those directories are support assets, not the main user-facing config contract. For hand-authored config, start from `config/quickstart.yaml` for a minimal validated baseline, or `config/config.yaml` and the fragment directories above for the full surface. In this repository, the exhaustive reference config points `global.integrations.tools.tools_db_path` at `config/runtime/tools/tools_db.json` for local development.
 
 `config/config.yaml` is not just a sample anymore. The repository enforces it as the exhaustive public-contract reference:
 


### PR DESCRIPTION
Fixes #2744. Part of #2690.

A minimal maintained config so a new user can observe real routing decisions without downloading any classifier models or editing YAML.

## Before

The smallest maintained config that passed validation was the exhaustive reference `config/config.yaml` at 2,286 lines. A first run also required 13 classifier model artifacts, and there was no guard preventing a smaller example from regressing into needing models or a backend.

## Now

- `config/quickstart.yaml`: 163 lines (about 60 without comments), passes both the strict canonical schema and runtime validation.
- Routing is model-free: two keyword signals (BM25 and n-gram, computed in-process) drive three decisions that select two distinct models, so different prompts visibly produce different `x-vsr-selected-*` results.
- Zero model artifacts: classifier modules are disabled and embedding paths empty, so the existing `pkg/modeldownload` feature gates skip all downloads. No new machinery was added.
- Every decision carries a `fast_response` plugin, so an OpenAI-compatible request completes with a full response before any LLM backend is deployed.
- Package tests gate the invariants: strict schema, "requires no model artifacts" (asserted with the same `RouterConfig` predicates `pkg/modeldownload` gates downloads on), at least two keyword-conditioned decisions selecting distinct models, `fast_response` on every decision, and every referenced signal declared.
- `config/README.md` and `website/docs/installation/configuration.md` (the enforced parallel asset lists) both list the new asset.

## Intent

Reduce what a new user must read and download before their first successful request, per the discussion on #2690: config cost is active effort and hurts adoption more than the passive model download. This file is documented as an evaluation on-ramp, not a production baseline. The `serve` quickstart profile that consumes this file and the time-to-first-request baseline measurement are follow-ups tracked in #2690.

## Test Plan

- `go test ./pkg/config/`: full package passes, including the three new `TestQuickstart*` tests and the existing `TestDocs*` contract tests.
- Mutation check: an unknown top-level field fails the strict-schema test; enabling a classifier module without routing usage correctly stays green, matching downloader behavior (`routing_signal_usage.go:61`).
- `vllm-sr validate --config config/quickstart.yaml`: clean. 1 listener, 2 keyword signals, 3 decisions, 2 models, `fast_response` on all 3 decisions.
- `make agent-lint` on changed files: all hooks pass (go fmt, go lint, yaml fmt, changed-files lint; the only markdown findings are in gitignored local model downloads under `config/models/`, which CI does not check out).
- `gofmt`, `go vet` on the new test file: clean.
