### PR TITLE
[Router] fix: enforce replay capture policy so disabled switches drop bodies

### DIFF
--- a/src/semantic-router/pkg/extproc/router_replay_api_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_api_test.go
@@ -345,6 +345,9 @@ func newReplayAPITestRouterWithRecords(t *testing.T, count int, requestBody stri
 	t.Helper()
 
 	recorder := routerreplay.NewRecorder(store.NewMemoryStore(count+1, 0))
+	// Capture must be enabled for AddRecord to store bodies; the limit must
+	// exceed the 5MiB oversized-body fixtures so they are stored untruncated.
+	recorder.SetCapturePolicy(true, true, 10*1024*1024)
 	for i := 1; i <= count; i++ {
 		recordID := fmt.Sprintf("replay-%03d", i)
 		timestamp := time.Unix(int64(i), 0).UTC()

--- a/src/semantic-router/pkg/extproc/router_replay_trajectory_test.go
+++ b/src/semantic-router/pkg/extproc/router_replay_trajectory_test.go
@@ -157,6 +157,8 @@ func TestHandleRouterReplayTrajectoryCoalescesConsecutiveToolCalls(t *testing.T)
 
 func TestHandleRouterReplayTrajectoryFallsBackToBodyParsing(t *testing.T) {
 	recorder := routerreplay.NewRecorder(store.NewMemoryStore(10, 0))
+	// Body-based trajectory fallback presumes the bodies were captured.
+	recorder.SetCapturePolicy(true, true, 4096)
 	sessionID := "sess-fallback"
 
 	requestBody := `{"messages":[{"role":"user","content":"hello"},{"role":"assistant","tool_calls":[{"id":"call-x","type":"function","function":{"name":"my_tool","arguments":"{}"}}]},{"role":"tool","content":"tool result","tool_call_id":"call-x"}]}`

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -142,14 +142,27 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 		rec.Timestamp = time.Now().UTC()
 	}
 
-	if policy.captureRequestBody && len(rec.RequestBody) > policy.maxBodyBytes {
-		rec.RequestBody = rec.RequestBody[:policy.maxBodyBytes]
-		rec.RequestBodyTruncated = true
+	// The capture switches decide whether a body may reach storage at all,
+	// not just whether it is truncated. When capture is off the body must be
+	// dropped here — truncation alone only bounds a leak (see #2748).
+	if policy.captureRequestBody {
+		if len(rec.RequestBody) > policy.maxBodyBytes {
+			rec.RequestBody = rec.RequestBody[:policy.maxBodyBytes]
+			rec.RequestBodyTruncated = true
+		}
+	} else {
+		rec.RequestBody = ""
+		rec.RequestBodyTruncated = false
 	}
 
-	if policy.captureResponseBody && len(rec.ResponseBody) > policy.maxBodyBytes {
-		rec.ResponseBody = rec.ResponseBody[:policy.maxBodyBytes]
-		rec.ResponseBodyTruncated = true
+	if policy.captureResponseBody {
+		if len(rec.ResponseBody) > policy.maxBodyBytes {
+			rec.ResponseBody = rec.ResponseBody[:policy.maxBodyBytes]
+			rec.ResponseBodyTruncated = true
+		}
+	} else {
+		rec.ResponseBody = ""
+		rec.ResponseBodyTruncated = false
 	}
 
 	// Apply MaxToolTraceBytes to structured tool-trace fields.

--- a/src/semantic-router/pkg/routerreplay/recorder_capture_test.go
+++ b/src/semantic-router/pkg/routerreplay/recorder_capture_test.go
@@ -1,0 +1,99 @@
+package routerreplay
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
+)
+
+func TestRecorderAddRecordDropsBodiesWhenCaptureDisabled(t *testing.T) {
+	// Regression test for #2748: with capture disabled, AddRecord used to pass
+	// bodies through to storage untouched (it only skipped truncation), so
+	// capture_request_body: false still persisted the full request body.
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetCapturePolicy(false, false, 4096)
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		RequestID:             "req-capture-off",
+		RequestBody:           `{"messages":[{"role":"user","content":"my ssn is 123-45-6789"}]}`,
+		RequestBodyTruncated:  true,
+		ResponseBody:          `{"choices":[{"message":{"content":"generated text"}}]}`,
+		ResponseBodyTruncated: true,
+	})
+	if err != nil {
+		t.Fatalf("AddRecord: %v", err)
+	}
+
+	rec, found := recorder.GetRecord(id)
+	if !found {
+		t.Fatal("record not found")
+	}
+	if rec.RequestBody != "" {
+		t.Errorf("expected empty RequestBody with capture disabled, got %q", rec.RequestBody)
+	}
+	if rec.RequestBodyTruncated {
+		t.Error("expected RequestBodyTruncated=false when no body is stored")
+	}
+	if rec.ResponseBody != "" {
+		t.Errorf("expected empty ResponseBody with capture disabled, got %q", rec.ResponseBody)
+	}
+	if rec.ResponseBodyTruncated {
+		t.Error("expected ResponseBodyTruncated=false when no body is stored")
+	}
+}
+
+func TestRecorderAddRecordDropsBodiesWithoutCapturePolicy(t *testing.T) {
+	// A recorder that was never given a capture policy defaults to
+	// capture-off and must not store bodies either, matching the
+	// AttachRequest/AttachResponse default.
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		RequestID:    "req-no-policy",
+		RequestBody:  `{"messages":[{"role":"user","content":"hello"}]}`,
+		ResponseBody: `{"choices":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("AddRecord: %v", err)
+	}
+
+	rec, found := recorder.GetRecord(id)
+	if !found {
+		t.Fatal("record not found")
+	}
+	if rec.RequestBody != "" || rec.ResponseBody != "" {
+		t.Errorf("expected no stored bodies without a capture policy, got request=%q response=%q",
+			rec.RequestBody, rec.ResponseBody)
+	}
+}
+
+func TestRecorderAddRecordKeepsAndTruncatesBodiesWhenCaptureEnabled(t *testing.T) {
+	recorder := NewRecorder(store.NewMemoryStore(10, 0))
+	recorder.SetCapturePolicy(true, true, 10)
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		RequestID:    "req-capture-on",
+		RequestBody:  "0123456789abcdef",
+		ResponseBody: "fedcba9876543210",
+	})
+	if err != nil {
+		t.Fatalf("AddRecord: %v", err)
+	}
+
+	rec, found := recorder.GetRecord(id)
+	if !found {
+		t.Fatal("record not found")
+	}
+	if rec.RequestBody != "0123456789" {
+		t.Errorf("expected RequestBody truncated to 10 bytes, got %q", rec.RequestBody)
+	}
+	if !rec.RequestBodyTruncated {
+		t.Error("expected RequestBodyTruncated=true")
+	}
+	if rec.ResponseBody != "fedcba9876" {
+		t.Errorf("expected ResponseBody truncated to 10 bytes, got %q", rec.ResponseBody)
+	}
+	if !rec.ResponseBodyTruncated {
+		t.Error("expected ResponseBodyTruncated=true")
+	}
+}


### PR DESCRIPTION
## What

`capture_request_body: false` did not keep the request body out of the replay store. `Recorder.AddRecord` checked the capture switches only to decide whether to truncate, so with capture off the body skipped truncation and was persisted untouched, then served back by the replay detail API. The one method honoring the switch, `AttachRequest`, has no callers in extproc.

This PR enforces the policy in `AddRecord`, the single write path into the store: when a capture switch is off, the corresponding body is dropped and its truncated flag reset. The same guard covers `ResponseBody` as defense in depth (the runtime response path already goes through the guarded `AttachResponse`). A recorder without an explicit capture policy now drops bodies by default, matching `Attach*`.

Fixes #2748

## Test Plan

- New regression tests in `pkg/routerreplay/recorder_test.go`: capture disabled drops bodies and resets truncated flags; a recorder without `SetCapturePolicy` drops by default; capture enabled keeps bodies truncated to `max_body_bytes`.
- `go test ./pkg/routerreplay/...` passes; targeted extproc replay tests (`-run 'RouterReplay|ReplayTool|Trajectory'`) pass after declaring capture policy explicitly in the two fixtures that relied on the pass-through.
- `make agent-lint` on the changed files passes.
