### PR TITLE
[Dashboard] allow partial deploy previews without routing

### DIFF
--- a/dashboard/backend/handlers/deploy.go
+++ b/dashboard/backend/handlers/deploy.go
@@ -358,11 +358,10 @@ func mergeDeployPayload(currentData []byte, req DeployRequest) ([]byte, error) {
 // projection is carried without adding another field-by-field merge branch.
 func mergeDSLOwnedNodes(baseRoot, fragmentRoot *yaml.Node, mode DeployMode) error {
 	fragmentRouting := mappingValueNode(fragmentRoot, "routing")
-	if fragmentRouting == nil {
-		return fmt.Errorf("compiled routing fragment must contain routing")
-	}
-
 	if mode == DeployModeReplace {
+		if fragmentRouting == nil {
+			return fmt.Errorf("compiled routing fragment must contain routing")
+		}
 		setMappingValueNode(baseRoot, "routing", fragmentRouting)
 		for _, section := range []string{"entrypoints", "recipes"} {
 			if value := mappingValueNode(fragmentRoot, section); value != nil {
@@ -374,11 +373,13 @@ func mergeDSLOwnedNodes(baseRoot, fragmentRoot *yaml.Node, mode DeployMode) erro
 		return nil
 	}
 
-	baseRouting := mappingValueNode(baseRoot, "routing")
-	if baseRouting == nil {
-		setMappingValueNode(baseRoot, "routing", fragmentRouting)
-	} else if err := mergeMappingNodes(baseRouting, fragmentRouting); err != nil {
-		return fmt.Errorf("failed to merge routing fragment: %w", err)
+	if fragmentRouting != nil {
+		baseRouting := mappingValueNode(baseRoot, "routing")
+		if baseRouting == nil {
+			setMappingValueNode(baseRoot, "routing", fragmentRouting)
+		} else if err := mergeMappingNodes(baseRouting, fragmentRouting); err != nil {
+			return fmt.Errorf("failed to merge routing fragment: %w", err)
+		}
 	}
 
 	// Scoped lists have identity and ordering semantics, so a supplied list is

--- a/dashboard/backend/handlers/deploy_test.go
+++ b/dashboard/backend/handlers/deploy_test.go
@@ -947,6 +947,42 @@ func TestMergeDeployPayloadRejectsUnknownMode(t *testing.T) {
 	}
 }
 
+func TestDeployPreviewHandler_AllowsPartialFragmentWithoutRouting(t *testing.T) {
+	configPath := createValidTestConfig(t, t.TempDir())
+	body, err := json.Marshal(DeployRequest{YAML: "default_model: \"MoM\"\n"})
+	if err != nil {
+		t.Fatalf("marshal preview request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/router/config/deploy/preview", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	DeployPreviewHandler(configPath)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a partial fragment without routing, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response DeployPreviewResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode preview response: %v", err)
+	}
+	if !strings.Contains(response.Preview, "routing:") {
+		t.Fatalf("preview lost existing routing:\n%s", response.Preview)
+	}
+}
+
+func TestMergeDeployPayloadReplaceRejectsFragmentWithoutRouting(t *testing.T) {
+	_, err := mergeDeployPayload(
+		[]byte("routing: {}\n"),
+		DeployRequest{YAML: "default_model: \"MoM\"\n", Mode: DeployModeReplace},
+	)
+	if err == nil || !strings.Contains(err.Error(), "compiled routing fragment must contain routing") {
+		t.Fatalf("expected missing-routing error, got %v", err)
+	}
+}
+
 func TestDeployHandler_NoDSLSource(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := createValidTestConfig(t, tempDir)


### PR DESCRIPTION
Closes #2754

## Problem

`POST /api/router/config/deploy/preview` must accept valid partial configuration fragments. After #2741, a fragment without a top-level `routing:` section returned `400 deploy_preview_error` instead of preview YAML.

The existing dashboard E2E testcase sends `{"yaml":"default_model: \"MoM\"\n"}`, which intentionally has no `routing:` section and expects `200` with `current` and `preview` fields.

## Root Cause

#2741 replaced the typed routing merge with node-level merging. `mergeDSLOwnedNodes` unconditionally rejected fragments without a `routing` node, although merge mode is documented as backward-compatible for partial API fragments.

Before #2741, an absent routing fragment decoded to the zero-value routing config and left the existing routing document unchanged.

## Fix

Require `routing:` only for `replace` mode, where omitting it would silently retain stale routing state and violate the atomic replacement contract.

For default or explicit `merge` mode, an absent `routing:` is a no-op for routing. Supplied `entrypoints`, `recipes`, and global configuration retain their existing merge behavior.

## Tests

- Added a handler regression test proving a no-routing preview fragment returns `200` and preserves existing routing.
- Added a guard test proving `replace` mode still rejects a fragment without `routing:`.
- Confirmed the regression was red on current main before the change, then green after the fix.
- Ran `cd dashboard/backend && go test ./...` successfully.