### PR TITLE
[Docs] Make website pages fluid while keeping sidebars fixed

### DIFF
--- a/website/src/components/TestimonialsRail/index.module.css
+++ b/website/src/components/TestimonialsRail/index.module.css
@@ -22,7 +22,7 @@
 .viewport {
   overflow: hidden;
   padding-top: 3px;
-  padding-inline: max(1rem, calc((100vw - var(--site-grid-max)) / 2));
+  padding-inline: var(--site-page-gutter);
   mask-image: linear-gradient(90deg, transparent, #000 3rem, #000 calc(100% - 3rem), transparent);
   -webkit-mask-image: linear-gradient(90deg, transparent, #000 3rem, #000 calc(100% - 3rem), transparent);
 }

--- a/website/src/components/community/CommunityLayout/styles.module.css
+++ b/website/src/components/community/CommunityLayout/styles.module.css
@@ -4,7 +4,7 @@
 }
 
 .container {
-  width: min(100% - 2.5rem, var(--site-grid-max));
+  width: var(--site-page-width);
   margin: 0 auto;
   padding: 2.25rem 0 3.5rem;
 }
@@ -44,7 +44,7 @@
 
 .body {
   display: grid;
-  grid-template-columns: minmax(13rem, 0.22fr) minmax(0, 1fr);
+  grid-template-columns: 13rem minmax(0, 1fr);
   align-items: start;
   gap: 2.5rem;
   padding-top: 1.75rem;
@@ -126,7 +126,6 @@
 
 @media (max-width: 700px) {
   .container {
-    width: min(100% - 1.4rem, var(--site-grid-max));
     padding-top: 1.5rem;
   }
 

--- a/website/src/components/research/ResearchLayout/styles.module.css
+++ b/website/src/components/research/ResearchLayout/styles.module.css
@@ -4,7 +4,7 @@
 }
 
 .container {
-  width: min(100% - 2.5rem, var(--site-grid-max));
+  width: var(--site-page-width);
   margin: 0 auto;
   padding: 2.25rem 0 3.5rem;
 }
@@ -44,7 +44,7 @@
 
 .body {
   display: grid;
-  grid-template-columns: minmax(13rem, 0.22fr) minmax(0, 1fr);
+  grid-template-columns: 13rem minmax(0, 1fr);
   align-items: start;
   gap: 2.5rem;
   padding-top: 1.75rem;
@@ -126,7 +126,6 @@
 
 @media (max-width: 700px) {
   .container {
-    width: min(100% - 1.4rem, var(--site-grid-max));
     padding-top: 1.5rem;
   }
 

--- a/website/src/css/base.css
+++ b/website/src/css/base.css
@@ -78,12 +78,6 @@ img {
 }
 
 .site-shell-container {
-  width: min(100% - 2.5rem, var(--site-grid-max));
+  width: var(--site-page-width);
   margin: 0 auto;
-}
-
-@media (max-width: 768px) {
-  .site-shell-container {
-    width: min(100% - 1.4rem, var(--site-grid-max));
-  }
 }

--- a/website/src/css/blog.css
+++ b/website/src/css/blog.css
@@ -498,7 +498,7 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-post__header h1 {
-  max-width: 62rem;
+  max-width: none;
   margin: 0;
   color: #040817;
   font-size: clamp(2.65rem, 4.6vw, 3.7rem);
@@ -584,7 +584,7 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-post__content {
-  max-width: 64rem;
+  max-width: none;
   margin-top: 3.25rem;
   color: #101827;
   font-size: 1.14rem;

--- a/website/src/css/blog.css
+++ b/website/src/css/blog.css
@@ -4,11 +4,12 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-layout {
+  --site-blog-sidebar-width: 17rem;
   background: var(--site-bg);
 }
 
 .site-blog-layout__inner {
-  width: min(93.5rem, calc(72vw + 4.5rem), calc(100% - 1.35rem));
+  width: var(--site-page-width);
   margin: 0 auto;
 }
 
@@ -111,7 +112,7 @@ html[data-route-kind='blog'] body,
 
 .site-blog-index__columns {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 17rem;
+  grid-template-columns: minmax(0, 1fr) var(--site-blog-sidebar-width);
   gap: 3.4rem;
   align-items: start;
 }
@@ -467,7 +468,7 @@ html[data-route-kind='blog'] body,
 
 .site-blog-layout--post .site-blog-layout__inner {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(13rem, 17rem);
+  grid-template-columns: minmax(0, 1fr) var(--site-blog-sidebar-width);
   gap: clamp(3rem, 5vw, 5.5rem);
   align-items: start;
 }
@@ -691,7 +692,7 @@ html[data-route-kind='blog'] body,
   }
 
   .site-blog-index__columns {
-    grid-template-columns: minmax(0, 1fr) 15rem;
+    grid-template-columns: minmax(0, 1fr) var(--site-blog-sidebar-width);
     gap: 2rem;
   }
 

--- a/website/src/css/docs.css
+++ b/website/src/css/docs.css
@@ -2,6 +2,11 @@
   padding: 2rem 0 4rem;
 }
 
+.site-root--docs .main-wrapper {
+  width: var(--site-page-width);
+  margin-inline: auto;
+}
+
 .site-doc-masthead {
   margin-bottom: 1.5rem;
   padding: 1.8rem 0 0.5rem;
@@ -170,6 +175,20 @@
 }
 
 @media (min-width: 997px) {
+  .site-docs-shell > .row {
+    flex-wrap: nowrap;
+  }
+
+  .site-docs-shell > .row > .col:first-child {
+    flex: 1 1 0;
+    max-width: none !important;
+  }
+
+  .site-docs-shell > .row > .col.col--3 {
+    flex: 0 0 17rem;
+    max-width: 17rem;
+  }
+
   main[class*='docMainContainer'] > .container {
     width: auto;
     max-width: none;

--- a/website/src/css/shell.css
+++ b/website/src/css/shell.css
@@ -5,6 +5,7 @@
   right: 0;
   height: var(--site-header-height);
   min-height: var(--site-header-height);
+  padding-inline: 0;
   border-bottom: 1px solid #27272a;
   background: rgba(5, 5, 5, 0.97);
   backdrop-filter: blur(14px);
@@ -16,7 +17,7 @@
 }
 
 .navbar__inner {
-  width: min(100% - 2rem, var(--site-grid-max));
+  width: var(--site-page-width);
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -218,6 +219,11 @@ html[data-route-kind="blog"] .nav-docs-only {
   background: #050505;
 }
 
+.footer .container {
+  width: var(--site-page-width);
+  max-width: none;
+}
+
 .footer__links {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -288,7 +294,7 @@ html[data-route-kind="blog"] .nav-docs-only {
   }
 
   .navbar__inner {
-    width: min(100% - 1.4rem, var(--site-grid-max));
+    width: var(--site-page-width);
   }
 
   .navbar__items {

--- a/website/src/css/tokens.css
+++ b/website/src/css/tokens.css
@@ -57,7 +57,8 @@
   --site-shadow-soft: 0 14px 36px rgba(15, 23, 42, 0.06);
   --site-shadow: 0 22px 60px rgba(15, 23, 42, 0.07);
   --site-shadow-raised: 0 24px 56px rgba(15, 23, 42, 0.08);
-  --site-grid-max: 1400px;
+  --site-page-gutter: 1.25rem;
+  --site-page-width: calc(100% - var(--site-page-gutter) - var(--site-page-gutter));
   --site-content-max: 1200px;
   --site-doc-max: 840px;
   --site-header-height: 4.9rem;
@@ -119,4 +120,10 @@
   --ifm-color-content: var(--site-text);
   --ifm-color-content-secondary: var(--site-muted-bright);
   --ifm-font-color-base: var(--site-text);
+}
+
+@media (max-width: 768px) {
+  :root {
+    --site-page-gutter: 0.7rem;
+  }
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION BELOW AND CONFIRM THE CHECKLIST ITEMS.

Closes #2763

## Purpose

This PR makes the website use a consistent, fluid page width while preserving the existing visual style of each section.

Final layout behavior:

- All page shells expand with the viewport instead of stopping at the previous `1400px` maximum width.
- Consistent responsive side gutters are shared across page content, navigation, and footer.
- Docs keeps the left navigation at `300px` and the right table of contents at `17rem`; only the middle documentation content expands.
- Community and Research keep the left navigation at `13rem`; the right content area expands.
- Blog keeps the right sidebar at `17rem`; the left feed or article area expands.
- Mobile layouts continue to collapse into a single column without horizontal page overflow.
- Existing typography, colors, cards, spacing style, and section-specific designs remain unchanged.

Affected module: `Docs`

## Screenshots after change

Simply put, the modification ensures all pages span the full width of the screen; the main content automatically adjusts its width, while the sidebar maintains a fixed width, allowing for a more user-friendly display of additional content on high-resolution screens.

### Docs

Standard resolution:

<img width="2982" height="1786" alt="image" src="https://github.com/user-attachments/assets/e8bcf82e-5a75-466f-a77d-afafb1097fdc" />

high resolution (3000 width):

<img width="2130" height="1298" alt="image" src="https://github.com/user-attachments/assets/acf0925f-204d-4f7c-b8f8-0353cf6014fd" />

### Community / Research

Standard resolution:

<img width="2990" height="1780" alt="image" src="https://github.com/user-attachments/assets/3cdd72fe-7c25-4994-9b9b-83081d4c2fb1" />

<img width="2990" height="1790" alt="image" src="https://github.com/user-attachments/assets/86512597-a8fc-4205-86cd-be074c7d7e3d" />

high resolution (3000 width):

<img width="2226" height="1332" alt="image" src="https://github.com/user-attachments/assets/c9f708aa-8d1b-4c0f-9112-cb2a438c5bd5" />

<img width="2312" height="1208" alt="image" src="https://github.com/user-attachments/assets/53e25bb0-d36e-4510-88e0-0b3d80b6405b" />

### Blog

Standard resolution:

<img width="2990" height="1790" alt="image" src="https://github.com/user-attachments/assets/2901f8b2-dc2b-4658-ad21-79182dfb3149" />

high resolution (3000 width):

<img width="2262" height="1312" alt="image" src="https://github.com/user-attachments/assets/733425ef-9fbf-40d7-a651-f6948e9e649d" />


## Test Plan

Run the website checks:

```bash
cd website
npm run lint
npm test
npm run build
```

Run the repository harness gate:

```bash
make agent-ci-gate ENV=cpu CHANGED_FILES="website/src/css/tokens.css base.css shell.css docs.css blog.css styles.module.css styles.module.css website/src/components/TestimonialsRail/index.module.css"
```

Manually inspect representative routes at `390px`, `1440px`, and `2000px` viewport widths:

- `/docs/intro`
- `/community/team`
- `/publications`
- `/blog`
- A Blog article page

Confirm that:

- Page content fills the available viewport width with consistent gutters.
- Fixed sidebars retain their widths as the viewport grows.
- Main content columns absorb the additional width.
- Mobile layouts remain single-column and have no horizontal overflow.
- Existing section-specific visual styles remain unchanged.

This validation covers the shared page shell, every affected sidebar layout, responsive breakpoints, both supported locales, and repository-level checks.

## Test Result

- `npm run lint`: passed.
- `npm test`: passed, 5 tests.
- `npm run build`: passed for English and Chinese locales.
- `make agent-ci-gate ...`: passed.
- Browser validation passed at `390px`, `1440px`, and `2000px`.
- No horizontal page overflow was detected at the tested viewport widths.
- Docs sidebars remained fixed at `300px` and `17rem`.
- Community and Research left navigation remained fixed at `13rem`.
- Blog right sidebar remained fixed at `17rem`.
- Main content columns expanded by the full viewport-width increase.

The build still reports existing warnings for Blog metadata, outdated Browserslist data, and broken anchors in translated documentation. These warnings are unrelated to this change and do not fail the build.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes (N/A: Docs only)
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
