### PR TITLE
test(config): unfence the apiserver doc needles so a table is not a failure

### DIFF
--- a/src/semantic-router/pkg/config/docs_contract_test.go
+++ b/src/semantic-router/pkg/config/docs_contract_test.go
@@ -16,6 +16,15 @@ func repoRel(parts ...string) string {
 	return filepath.Join(parts...)
 }
 
+// apiserverDocNeedles is shared by the English page and its zh-Hans translation.
+// These stay unfenced so the assertion survives the page moving an endpoint between
+// prose and a table, which is what broke it in #2773.
+var apiserverDocNeedles = []string{
+	"http://localhost:8080",
+	"/openapi.json",
+	"/config/router",
+}
+
 var configContractRequiredDocs = []docNeedles{
 	{
 		path: "config/README.md",
@@ -132,12 +141,8 @@ var configContractRequiredDocs = []docNeedles{
 		},
 	},
 	{
-		path: repoRel("website", "docs", "api", "apiserver.md"),
-		needles: []string{
-			"`http://localhost:8080`",
-			"`GET /openapi.json`",
-			"`GET /config/router`",
-		},
+		path:    repoRel("website", "docs", "api", "apiserver.md"),
+		needles: apiserverDocNeedles,
 	},
 	{
 		path: repoRel("website", "docs", "troubleshooting", "common-errors.md"),
@@ -209,12 +214,8 @@ var configContractRequiredDocs = []docNeedles{
 		},
 	},
 	{
-		path: repoRel("website", "i18n", "zh-Hans", "docusaurus-plugin-content-docs", "current", "api", "apiserver.md"),
-		needles: []string{
-			"`http://localhost:8080`",
-			"`GET /openapi.json`",
-			"`GET /config/router`",
-		},
+		path:    repoRel("website", "i18n", "zh-Hans", "docusaurus-plugin-content-docs", "current", "api", "apiserver.md"),
+		needles: apiserverDocNeedles,
 	},
 	{
 		path: repoRel("website", "i18n", "zh-Hans", "docusaurus-plugin-content-docs", "current", "proposals", "nvidia-dynamo-integration.md"),


### PR DESCRIPTION
`TestConfigContractDocsStayAligned` fails on current `main` (`a0d75fd`), so every PR that runs the
Go tests over `pkg/config` is red through no fault of its own.

```
$ git checkout a0d75fd && cd src/semantic-router
$ go test ./pkg/config/ -count=1 -run TestConfigContractDocsStayAligned
    docs_contract_test.go:609: website/docs/api/apiserver.md is missing required text "`http://localhost:8080`"
FAIL
```

## Cause

The needles asserted on exact backtick placement:

```go
"`http://localhost:8080`",
"`GET /openapi.json`",
"`GET /config/router`",
```

#2773 reorganised the page, and both of those spans changed shape without losing anything:

- the base URL is now inside a longer span, `` `GET http://localhost:8080/api/v1` ``
- `/config/router` moved into an endpoint table, so it is two spans in two cells:
  `| `GET` | `/config/router` | Current router config as JSON |`

Counts on `main` for `website/docs/api/apiserver.md`: bare `http://localhost:8080` 23 times, the
fenced `` `http://localhost:8080` `` 0 times. So the page documents more than it did before and the
test still fails.

## Why it merged green

On #2773 both `test-and-build` and `Run pre-commit hooks check file lint` were **skipped**, because the
changed-files gate saw a docs-only change. The assertion that guards those docs lives in
`src/semantic-router/pkg/config/docs_contract_test.go`, so nothing ran it. Worth a thought separately:
a Go test that asserts on docs content will keep getting bypassed by a docs-only path filter.

## Change

Test-only. The three needles lose the fences and move to one `apiserverDocNeedles` slice shared by the
English page and the zh-Hans translation, which #2773 did not touch and which still matched the old
form. Sharing them keeps the two from drifting the next time either page is rewritten.

The assertion still guards content rather than formatting. Replacing `/config/router` in the page (16
occurrences) still fails:

```
docs_contract_test.go:610: website/docs/api/apiserver.md is missing required text "/config/router"
```

`go test ./pkg/config -count=1` passes, `go vet` and gofmt clean.

I hit this on #2767 and #2769 and initially assumed it was mine, so opening it separately rather than
folding it into either.

Closes #2777

