### PR TITLE
fix: prevent substring memory leaks on payload truncations in replay …

### DIFF
--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -2,6 +2,7 @@ package routerreplay
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -147,7 +148,7 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 	// dropped here — truncation alone only bounds a leak (see #2748).
 	if policy.captureRequestBody {
 		if len(rec.RequestBody) > policy.maxBodyBytes {
-			rec.RequestBody = rec.RequestBody[:policy.maxBodyBytes]
+			rec.RequestBody = strings.Clone(rec.RequestBody[:policy.maxBodyBytes])
 			rec.RequestBodyTruncated = true
 		}
 	} else {
@@ -157,7 +158,7 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 
 	if policy.captureResponseBody {
 		if len(rec.ResponseBody) > policy.maxBodyBytes {
-			rec.ResponseBody = rec.ResponseBody[:policy.maxBodyBytes]
+			rec.ResponseBody = strings.Clone(rec.ResponseBody[:policy.maxBodyBytes])
 			rec.ResponseBodyTruncated = true
 		}
 	} else {
@@ -185,11 +186,11 @@ func applyMaxToolTraceBytes(rec *RoutingRecord, max int) {
 		return
 	}
 	if len(rec.Prompt) > max {
-		rec.Prompt = rec.Prompt[:max]
+		rec.Prompt = strings.Clone(rec.Prompt[:max])
 		rec.PromptTruncated = true
 	}
 	if len(rec.ToolDefinitions) > max {
-		rec.ToolDefinitions = rec.ToolDefinitions[:max]
+		rec.ToolDefinitions = strings.Clone(rec.ToolDefinitions[:max])
 		rec.ToolDefinitionsTruncated = true
 	}
 	truncateToolTraceSteps(rec.ToolTrace, max)
@@ -237,11 +238,11 @@ func capToolTraceStepCount(trace *ToolTrace, max int) {
 // and Truncated is set to signal that truncation happened.
 func truncateToolTraceStep(step *ToolTraceStep, max int) {
 	if len(step.Arguments) > max {
-		step.Arguments = step.Arguments[:max]
+		step.Arguments = strings.Clone(step.Arguments[:max])
 		step.Truncated = true
 	}
 	if len(step.Output) > max {
-		step.Output = step.Output[:max]
+		step.Output = strings.Clone(step.Output[:max])
 		step.Truncated = true
 	}
 }

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -339,7 +339,6 @@ func truncateString(s string, maxBytes int) (string, bool) {
 	return strings.Clone(s[:maxBytes]), true
 }
 
-
 func logSignalFields(signals Signal) map[string]interface{} {
 	return map[string]interface{}{
 		"keyword":       signals.Keyword,

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -146,25 +146,11 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 	// The capture switches decide whether a body may reach storage at all,
 	// not just whether it is truncated. When capture is off the body must be
 	// dropped here — truncation alone only bounds a leak (see #2748).
-	if policy.captureRequestBody {
-		if len(rec.RequestBody) > policy.maxBodyBytes {
-			rec.RequestBody = strings.Clone(rec.RequestBody[:policy.maxBodyBytes])
-			rec.RequestBodyTruncated = true
-		}
-	} else {
-		rec.RequestBody = ""
-		rec.RequestBodyTruncated = false
-	}
+	rec.RequestBody, rec.RequestBodyTruncated = applyCapturePolicy(
+		policy.captureRequestBody, rec.RequestBody, policy.maxBodyBytes)
 
-	if policy.captureResponseBody {
-		if len(rec.ResponseBody) > policy.maxBodyBytes {
-			rec.ResponseBody = strings.Clone(rec.ResponseBody[:policy.maxBodyBytes])
-			rec.ResponseBodyTruncated = true
-		}
-	} else {
-		rec.ResponseBody = ""
-		rec.ResponseBodyTruncated = false
-	}
+	rec.ResponseBody, rec.ResponseBodyTruncated = applyCapturePolicy(
+		policy.captureResponseBody, rec.ResponseBody, policy.maxBodyBytes)
 
 	// Apply MaxToolTraceBytes to structured tool-trace fields.
 	// These are truncated independently of the raw body fields so that
@@ -185,14 +171,8 @@ func applyMaxToolTraceBytes(rec *RoutingRecord, max int) {
 	if max <= 0 {
 		return
 	}
-	if len(rec.Prompt) > max {
-		rec.Prompt = strings.Clone(rec.Prompt[:max])
-		rec.PromptTruncated = true
-	}
-	if len(rec.ToolDefinitions) > max {
-		rec.ToolDefinitions = strings.Clone(rec.ToolDefinitions[:max])
-		rec.ToolDefinitionsTruncated = true
-	}
+	rec.Prompt, rec.PromptTruncated = truncateString(rec.Prompt, max)
+	rec.ToolDefinitions, rec.ToolDefinitionsTruncated = truncateString(rec.ToolDefinitions, max)
 	truncateToolTraceSteps(rec.ToolTrace, max)
 }
 
@@ -237,12 +217,11 @@ func capToolTraceStepCount(trace *ToolTrace, max int) {
 // payload (see #1781). Only the "normalized" Arguments/Output fields are cut,
 // and Truncated is set to signal that truncation happened.
 func truncateToolTraceStep(step *ToolTraceStep, max int) {
-	if len(step.Arguments) > max {
-		step.Arguments = strings.Clone(step.Arguments[:max])
-		step.Truncated = true
-	}
-	if len(step.Output) > max {
-		step.Output = strings.Clone(step.Output[:max])
+	args, t1 := truncateString(step.Arguments, max)
+	out, t2 := truncateString(step.Output, max)
+	step.Arguments = args
+	step.Output = out
+	if t1 || t2 {
 		step.Truncated = true
 	}
 }
@@ -339,6 +318,20 @@ func truncateBody(body []byte, maxBytes int) (string, bool) {
 		return string(body), false
 	}
 	return string(body[:maxBytes]), true
+}
+
+func truncateString(s string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return s, false
+	}
+	return strings.Clone(s[:maxBytes]), true
+}
+
+func applyCapturePolicy(capture bool, s string, maxBytes int) (string, bool) {
+	if !capture {
+		return "", false
+	}
+	return truncateString(s, maxBytes)
 }
 
 func logSignalFields(signals Signal) map[string]interface{} {

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -143,9 +143,7 @@ func (r *Recorder) AddRecord(rec RoutingRecord) (string, error) {
 		rec.Timestamp = time.Now().UTC()
 	}
 
-	// The capture switches decide whether a body may reach storage at all,
-	// not just whether it is truncated. When capture is off the body must be
-	// dropped here — truncation alone only bounds a leak (see #2748).
+	// Enforce capture switches and apply body truncation limits.
 	rec.RequestBody, rec.RequestBodyTruncated = applyBodyCapturePolicy(
 		rec.RequestBody, rec.RequestBodyTruncated, policy.captureRequestBody, policy.maxBodyBytes)
 	rec.ResponseBody, rec.ResponseBodyTruncated = applyBodyCapturePolicy(


### PR DESCRIPTION
closes: #2780

## Overview
This PR addresses a severe memory leak and potential OOM (Out of Memory) vulnerability caused by Go's underlying string slicing behavior when processing large request and response payloads. 

## The Problem
Previously, large payload strings (such as `RequestBody`, `ResponseBody`, `Prompt`, and `ToolTrace` fields) were being truncated using standard Go string slicing (e.g., `rec.RequestBody[:policy.maxBodyBytes]`). 

Because Go strings share their underlying backing array when sliced, truncating a large 50MB payload down to a 4KB snippet inadvertently retained the entire 50MB array in memory. This memory was held for as long as the truncated record sat in the Recorder's queue or memory store. Under heavy traffic, this prevented the garbage collector from reclaiming memory, causing a massive memory leak and eventual OOM crashes.

## The Solution
Wrapped all relevant string truncations with `strings.Clone()`. 

This forces Go to allocate a fresh, minimal byte array that is exactly the size of the truncated string, safely severing the reference to the original massive payload. 

**Affected fields updated:**
* `rec.RequestBody`
* `rec.ResponseBody`
* `rec.Prompt`
* `rec.ToolDefinitions`
* `step.Arguments`
* `step.Output`

## Impact
* **Immediate GC Reclamation:** The garbage collector can now immediately reclaim the memory used by the original large payloads as soon as the caller is done with them.
* **Router Stability:** Significantly reduces and stabilizes the memory footprint of the router, entirely eliminating the OOM vulnerability during payload capture and truncation.