### PR TITLE
fix(cli): forward the api keys a config actually names

### DIFF
--- a/src/vllm-sr/cli/commands/runtime.py
+++ b/src/vllm-sr/cli/commands/runtime.py
@@ -103,7 +103,7 @@ def _execute_serve(
     validate_setup_mode_flags(setup_mode, minimal, readonly)
 
     env_vars: dict[str, str] = {}
-    append_passthrough_env_vars(env_vars)
+    append_passthrough_env_vars(env_vars, config_path)
     apply_runtime_mode_env_vars(
         env_vars,
         minimal,

--- a/src/vllm-sr/cli/commands/runtime_support.py
+++ b/src/vllm-sr/cli/commands/runtime_support.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import re
+from itertools import chain
 from pathlib import Path
 
 import yaml
@@ -42,6 +44,12 @@ RUNTIME_CONFIG_PATH_ENV = "VLLM_SR_RUNTIME_CONFIG_PATH"
 SOURCE_CONFIG_PATH_ENV = "VLLM_SR_SOURCE_CONFIG_PATH"
 RUNTIME_ALGORITHM_OVERRIDE_ENV = "VLLM_SR_ALGORITHM_OVERRIDE"
 
+# Mirrors resolveBracedEnvReference, including ${NAME:-default}. Upper case only, so
+# MCP tool-argument placeholders like ${user_content} are not read as env vars.
+_ENV_REFERENCE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)(?::?-[^}]*)?\}")
+
+API_KEY_ENV_FIELD = "api_key_env"
+
 PASSTHROUGH_ENV_RULES = (
     ("HF_ENDPOINT", False),
     ("HF_TOKEN", True),
@@ -57,6 +65,8 @@ PASSTHROUGH_ENV_RULES = (
     ("SR_LOG_DEVELOPMENT", False),
     ("SR_LOG_ADD_CALLER", False),
 )
+
+_STATIC_SENSITIVE = frozenset(name for name, masked in PASSTHROUGH_ENV_RULES if masked)
 
 
 def _finalize_runtime_config_write(
@@ -95,9 +105,48 @@ def validate_setup_mode_flags(setup_mode: bool, minimal: bool, readonly: bool) -
         )
 
 
-def append_passthrough_env_vars(env_vars: dict[str, str]) -> None:
+def config_env_references(config_path: Path | str | None) -> set[str]:
+    """Env var names a config depends on: ``api_key_env`` targets and ``${VAR}`` refs.
+
+    ``api_key_env`` is free-form, so these cannot be enumerated ahead of the config.
+    """
+    if config_path is None:
+        return set()
+    try:
+        document = yaml.safe_load(Path(config_path).read_text())
+    except (OSError, yaml.YAMLError):
+        return set()
+
+    names: set[str] = set()
+    pending: list[object] = [document]
+    while pending:
+        node = pending.pop()
+        if isinstance(node, dict):
+            named = node.get(API_KEY_ENV_FIELD)
+            if isinstance(named, str) and named.strip():
+                names.add(named.strip())
+            pending.extend(node.values())
+        elif isinstance(node, list):
+            pending.extend(node)
+        elif isinstance(node, str):
+            names.update(_ENV_REFERENCE.findall(node))
+    return names
+
+
+def sensitive_env_names(config_path: Path | str | None = None) -> set[str]:
+    """Names that must reach the container as a secret, never as plain-text manifest."""
+    return _STATIC_SENSITIVE | config_env_references(config_path)
+
+
+def append_passthrough_env_vars(
+    env_vars: dict[str, str], config_path: Path | str | None = None
+) -> None:
     """Pass selected host environment variables into the container runtime."""
-    for name, masked in PASSTHROUGH_ENV_RULES:
+    # Static rules first so their masking wins; sorted for a stable log order.
+    discovered = ((name, True) for name in sorted(config_env_references(config_path)))
+    for name, masked in chain(PASSTHROUGH_ENV_RULES, discovered):
+        if name in env_vars:
+            continue
         value = os.environ.get(name)
         if value is None:
             continue

--- a/src/vllm-sr/cli/commands/runtime_support.py
+++ b/src/vllm-sr/cli/commands/runtime_support.py
@@ -68,6 +68,24 @@ PASSTHROUGH_ENV_RULES = (
 
 _STATIC_SENSITIVE = frozenset(name for name, masked in PASSTHROUGH_ENV_RULES if masked)
 
+# Never auto-forward these from a ${VAR} match: POSIX process/identity vars are present
+# in every host shell, so an incidental match (a templated path, an example URL) would
+# silently leak them into the container. CLI override vars are covered too, so a config
+# that happens to reference one can't inject a host value ahead of the CLI's own default.
+_DISCOVERY_DENYLIST = frozenset(
+    {"PATH", "HOME", "USER", "SHELL", "PWD", "LOGNAME"}
+) | frozenset(
+    {
+        SETUP_MODE_ENV,
+        DASHBOARD_SETUP_MODE_ENV,
+        RUNTIME_ALGORITHM_OVERRIDE_ENV,
+        "DISABLE_DASHBOARD",
+        "DASHBOARD_READONLY",
+        "DASHBOARD_PLATFORM",
+        "VLLM_SR_PLATFORM",
+    }
+)
+
 
 def _finalize_runtime_config_write(
     config_path: Path, config: dict[str, object], changed: bool
@@ -130,7 +148,7 @@ def config_env_references(config_path: Path | str | None) -> set[str]:
             pending.extend(node)
         elif isinstance(node, str):
             names.update(_ENV_REFERENCE.findall(node))
-    return names
+    return names - _DISCOVERY_DENYLIST
 
 
 def sensitive_env_names(config_path: Path | str | None = None) -> set[str]:

--- a/src/vllm-sr/cli/config_translator.py
+++ b/src/vllm-sr/cli/config_translator.py
@@ -21,6 +21,7 @@ log = get_logger(__name__)
 def translate_config_to_helm_values(
     config_file: str,
     *,
+    source_config_file: str | None = None,
     image: str | None = None,
     pull_policy: str | None = None,
     enable_observability: bool = True,
@@ -55,7 +56,10 @@ def translate_config_to_helm_values(
     _translate_config_section(user_config, values)
     _translate_observability(enable_observability, values)
     _translate_env_vars(
-        env_vars, values, secret_name=env_secret_name, config_file=config_file
+        env_vars,
+        values,
+        secret_name=env_secret_name,
+        config_file=source_config_file or config_file,
     )
 
     if profile_values:

--- a/src/vllm-sr/cli/config_translator.py
+++ b/src/vllm-sr/cli/config_translator.py
@@ -54,7 +54,9 @@ def translate_config_to_helm_values(
 
     _translate_config_section(user_config, values)
     _translate_observability(enable_observability, values)
-    _translate_env_vars(env_vars, values, secret_name=env_secret_name)
+    _translate_env_vars(
+        env_vars, values, secret_name=env_secret_name, config_file=config_file
+    )
 
     if profile_values:
         values = _deep_merge(profile_values, values)
@@ -117,12 +119,13 @@ def _translate_env_vars(
     env_vars: dict[str, str] | None,
     values: dict,
     secret_name: str | None = None,
+    config_file: str | None = None,
 ) -> None:
     """Map non-sensitive env vars into ``env:`` and wire a secret via ``envFromSecrets:``."""
     if env_vars:
-        from cli.commands.runtime_support import PASSTHROUGH_ENV_RULES  # noqa: PLC0415
+        from cli.commands.runtime_support import sensitive_env_names  # noqa: PLC0415
 
-        sensitive_names = {name for name, masked in PASSTHROUGH_ENV_RULES if masked}
+        sensitive_names = sensitive_env_names(config_file)
         env_list: list[dict[str, str]] = values.get("env", [])
         existing_names = {e["name"] for e in env_list}
         for name, value in sorted(env_vars.items()):

--- a/src/vllm-sr/cli/k8s_backend.py
+++ b/src/vllm-sr/cli/k8s_backend.py
@@ -70,7 +70,7 @@ class K8sBackend:
         if self.context:
             log.info(f"  Context:   {self.context}")
 
-        secret_name = self._sync_env_secret(env_vars)
+        secret_name = self._sync_env_secret(env_vars, config_file)
 
         profile_values = load_profile_values(self.profile, self.chart_dir)
         values = translate_config_to_helm_values(
@@ -208,14 +208,16 @@ class K8sBackend:
 
     # -- helpers --------------------------------------------------------------
 
-    def _sync_env_secret(self, env_vars: dict[str, str] | None) -> str | None:
+    def _sync_env_secret(
+        self, env_vars: dict[str, str] | None, config_file: str | None = None
+    ) -> str | None:
         """Create or update a K8s Secret with sensitive env vars; return the secret name or None."""
         if not env_vars:
             return None
 
-        from cli.commands.runtime_support import PASSTHROUGH_ENV_RULES  # noqa: PLC0415
+        from cli.commands.runtime_support import sensitive_env_names  # noqa: PLC0415
 
-        sensitive_names = {name for name, masked in PASSTHROUGH_ENV_RULES if masked}
+        sensitive_names = sensitive_env_names(config_file)
         secret_data = {k: v for k, v in env_vars.items() if k in sensitive_names and v}
 
         if not secret_data:

--- a/src/vllm-sr/cli/k8s_backend.py
+++ b/src/vllm-sr/cli/k8s_backend.py
@@ -54,6 +54,7 @@ class K8sBackend:
         config_file: str,
         env_vars: dict[str, str] | None = None,
         *,
+        source_config_file: str | None = None,
         image: str | None = None,
         pull_policy: str | None = None,
         enable_observability: bool = True,
@@ -70,11 +71,17 @@ class K8sBackend:
         if self.context:
             log.info(f"  Context:   {self.context}")
 
-        secret_name = self._sync_env_secret(env_vars, config_file)
+        # env_vars was discovered against source_config_file (runtime.py forwards it
+        # before algorithm/platform overrides rewrite the config), so sensitivity must
+        # be re-checked against that same file, not the rewritten effective one, or a
+        # name dropped by the rewrite silently loses its secret classification.
+        sensitivity_config_file = source_config_file or config_file
+        secret_name = self._sync_env_secret(env_vars, sensitivity_config_file)
 
         profile_values = load_profile_values(self.profile, self.chart_dir)
         values = translate_config_to_helm_values(
             config_file,
+            source_config_file=sensitivity_config_file,
             image=image,
             pull_policy=pull_policy,
             enable_observability=enable_observability,

--- a/src/vllm-sr/tests/test_deployment_backend.py
+++ b/src/vllm-sr/tests/test_deployment_backend.py
@@ -242,6 +242,34 @@ class TestConfigTranslator:
         )
         assert "my-secret" in values["envFromSecrets"]
 
+    def test_sensitivity_follows_source_config_when_effective_config_diverges(
+        self, tmp_path
+    ):
+        """A name discovered from the source config must stay masked even if the
+        effective config (algorithm/platform rewrite) no longer contains it."""
+        source_config = tmp_path / "config.yaml"
+        source_config.write_text(
+            yaml.safe_dump(
+                {"providers": {"models": [{"api_key_env": "GEMINI_API_KEY"}]}}
+            )
+        )
+        # Simulates resolve_effective_config_path writing a rewritten copy that
+        # dropped the api_key_env reference.
+        effective_config = tmp_path / ".vllm-sr" / "runtime-config.yaml"
+        effective_config.parent.mkdir(parents=True, exist_ok=True)
+        effective_config.write_text(yaml.safe_dump({"listeners": []}))
+
+        values = translate_config_to_helm_values(
+            str(effective_config),
+            source_config_file=str(source_config),
+            env_vars={"GEMINI_API_KEY": "gk-test"},
+        )
+        names = {e["name"] for e in values.get("env", [])}
+        assert "GEMINI_API_KEY" not in names, (
+            "credential leaked into plaintext Helm values because sensitivity was "
+            "checked against the rewritten effective config instead of the source"
+        )
+
     def test_env_vars_none_produces_no_env_key(self, tmp_path):
         config = tmp_path / "config.yaml"
         config.write_text(yaml.safe_dump({"listeners": []}))
@@ -320,6 +348,56 @@ class TestK8sBackend:
         create_cmds = [c for c in cmds_run if "create" in c and "secret" in c]
         assert len(create_cmds) == 1
         assert "--from-literal=HF_TOKEN=hf_secret123" in create_cmds[0]
+
+    def test_deploy_checks_sensitivity_against_source_not_effective_config(
+        self, monkeypatch, tmp_path
+    ):
+        """deploy() must classify env vars using source_config_file, not the
+        (possibly rewritten) effective config_file it hands to Helm."""
+        source_config = tmp_path / "config.yaml"
+        source_config.write_text(
+            yaml.safe_dump(
+                {"providers": {"models": [{"api_key_env": "GEMINI_API_KEY"}]}}
+            )
+        )
+        effective_config = tmp_path / "runtime-config.yaml"
+        effective_config.write_text(yaml.safe_dump({"listeners": []}))
+
+        backend = K8sBackend.__new__(K8sBackend)
+        backend.namespace = "test-ns"
+        backend.context = None
+        backend.chart_dir = str(tmp_path)
+        backend.release_name = "sr"
+        backend.profile = None
+
+        monkeypatch.setattr(backend, "_require_tool", lambda _: None)
+        monkeypatch.setattr("cli.k8s_backend.print_vllm_logo", lambda: None)
+        monkeypatch.setattr(backend, "_ensure_namespace", lambda: None)
+        monkeypatch.setattr(backend, "_delete_secret_if_exists", lambda _: None)
+        monkeypatch.setattr(backend, "_run", lambda *a, **kw: None)
+        monkeypatch.setattr(backend, "_wait_for_pods", lambda: None)
+        monkeypatch.setattr(backend, "_log_k8s_summary", lambda: None)
+        monkeypatch.setattr(
+            "cli.k8s_backend.load_profile_values", lambda *a, **kw: None
+        )
+        monkeypatch.setattr(
+            "cli.k8s_backend.write_helm_values_file", lambda *a, **kw: str(tmp_path)
+        )
+
+        secret_cmds = []
+        monkeypatch.setattr(
+            backend,
+            "_sync_env_secret",
+            lambda env_vars, config_file=None: secret_cmds.append(config_file) or None,
+        )
+
+        backend.deploy(
+            config_file=str(effective_config),
+            source_config_file=str(source_config),
+            env_vars={"GEMINI_API_KEY": "gk-test"},
+        )
+
+        assert secret_cmds == [str(source_config)]
 
 
 # ---------------------------------------------------------------------------

--- a/src/vllm-sr/tests/test_deployment_backend.py
+++ b/src/vllm-sr/tests/test_deployment_backend.py
@@ -198,6 +198,28 @@ class TestConfigTranslator:
         assert "OPENAI_API_KEY" not in names, "Sensitive var leaked into plain env"
         assert "HF_ENDPOINT" in names, "Non-sensitive var should be in plain env"
 
+    def test_config_named_api_key_excluded_from_plain_env(self, tmp_path):
+        """A key named only by api_key_env is still a credential and must not be inlined."""
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            yaml.safe_dump(
+                {
+                    "listeners": [],
+                    "providers": {"models": [{"api_key_env": "GEMINI_API_KEY"}]},
+                }
+            )
+        )
+
+        values = translate_config_to_helm_values(
+            str(config),
+            env_vars={"GEMINI_API_KEY": "gk-test", "HF_ENDPOINT": "https://hf.co"},
+        )
+        names = {e["name"] for e in values.get("env", [])}
+        assert (
+            "GEMINI_API_KEY" not in names
+        ), "Config-named credential leaked into plain env"
+        assert "HF_ENDPOINT" in names
+
     def test_router_log_level_env_vars_are_included_in_plain_env(self, tmp_path):
         config = tmp_path / "config.yaml"
         config.write_text(yaml.safe_dump({"listeners": []}))

--- a/src/vllm-sr/tests/test_runtime_support.py
+++ b/src/vllm-sr/tests/test_runtime_support.py
@@ -7,8 +7,10 @@ from cli.bootstrap import build_bootstrap_config
 from cli.commands.runtime_support import (
     append_passthrough_env_vars,
     apply_runtime_mode_env_vars,
+    config_env_references,
     configure_runtime_override_env_vars,
     resolve_effective_config_path,
+    sensitive_env_names,
 )
 from cli.container_start import _build_dashboard_runtime_env
 from cli.runtime_stack import resolve_runtime_stack
@@ -84,6 +86,69 @@ def test_append_passthrough_env_vars_includes_router_logging_settings(monkeypatc
 
     assert env_vars["SR_LOG_LEVEL"] == "debug"
     assert env_vars["SR_LOG_ENCODING"] == "console"
+
+
+def test_append_passthrough_env_vars_forwards_keys_named_by_the_config(
+    monkeypatch, tmp_path
+):
+    """api_key_env is free-form, so a provider key outside the static rules must still reach the container."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {
+                    "models": [{"name": "gemini", "api_key_env": "GEMINI_API_KEY"}]
+                },
+                "global": {
+                    "stores": {"vector_store": {"password": "${VALKEY_PASSWORD}"}}
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("GEMINI_API_KEY", "gk-test")
+    monkeypatch.setenv("VALKEY_PASSWORD", "vp-test")
+    monkeypatch.delenv("UNREFERENCED_API_KEY", raising=False)
+
+    env_vars: dict[str, str] = {}
+    append_passthrough_env_vars(env_vars, config)
+
+    assert env_vars["GEMINI_API_KEY"] == "gk-test"
+    assert env_vars["VALKEY_PASSWORD"] == "vp-test"
+    assert "UNREFERENCED_API_KEY" not in env_vars
+
+
+def test_config_env_references_reads_api_key_env_and_interpolations(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {"models": [{"api_key_env": "MISTRAL_API_KEY"}]},
+                "embedding_models": {"endpoint": {"api_key_env": "EMBEDDING_API_KEY"}},
+                "note": "uses ${REDIS_AUTH_TOKEN} at runtime",
+            }
+        )
+    )
+
+    assert config_env_references(config) == {
+        "MISTRAL_API_KEY",
+        "EMBEDDING_API_KEY",
+        "REDIS_AUTH_TOKEN",
+    }
+    assert config_env_references(None) == set()
+    assert config_env_references(tmp_path / "missing.yaml") == set()
+
+
+def test_sensitive_env_names_covers_config_named_credentials(tmp_path):
+    """A key the config names must be treated as a secret, not inlined into a manifest."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump({"providers": {"models": [{"api_key_env": "GEMINI_API_KEY"}]}})
+    )
+
+    assert "GEMINI_API_KEY" in sensitive_env_names(config)
+    assert "HF_TOKEN" in sensitive_env_names(config)
+    assert "HF_ENDPOINT" not in sensitive_env_names(config)
+    assert "GEMINI_API_KEY" not in sensitive_env_names(None)
 
 
 def test_dashboard_bootstrap_admin_is_scoped_to_dashboard(monkeypatch):

--- a/src/vllm-sr/tests/test_runtime_support.py
+++ b/src/vllm-sr/tests/test_runtime_support.py
@@ -138,6 +138,45 @@ def test_config_env_references_reads_api_key_env_and_interpolations(tmp_path):
     assert config_env_references(tmp_path / "missing.yaml") == set()
 
 
+def test_config_env_references_excludes_process_identity_vars(tmp_path):
+    """A config referencing ${PATH}/${HOME} must not pull host process state into the container."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "note": "installed under ${HOME}/.cache, resolved via ${PATH}",
+                "providers": {"models": [{"api_key_env": "MISTRAL_API_KEY"}]},
+            }
+        )
+    )
+
+    refs = config_env_references(config)
+    assert refs == {"MISTRAL_API_KEY"}
+
+
+def test_config_env_references_excludes_cli_controlled_override_vars(tmp_path):
+    """A config that happens to mention a CLI override var must not preempt the CLI's own default."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        yaml.safe_dump({"note": "see ${DISABLE_DASHBOARD} and ${DASHBOARD_PLATFORM}"})
+    )
+
+    assert config_env_references(config) == set()
+
+
+def test_append_passthrough_env_vars_does_not_forward_process_identity_vars(
+    monkeypatch, tmp_path
+):
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"note": "runs from ${PATH}"}))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    env_vars: dict[str, str] = {}
+    append_passthrough_env_vars(env_vars, config)
+
+    assert "PATH" not in env_vars
+
+
 def test_sensitive_env_names_covers_config_named_credentials(tmp_path):
     """A key the config names must be treated as a secret, not inlined into a manifest."""
     config = tmp_path / "config.yaml"


### PR DESCRIPTION
Closes #2775

`PASSTHROUGH_ENV_RULES` is a static allowlist, but `api_key_env` is free-form
(`canonical_providers.go:44`, read via `os.Getenv(ref.APIKeyEnv)` in
`canonical_global.go:354`). Any provider credential whose name is not one of those
literals never reaches the container, and the failure is silent: the key resolves to an
empty string inside the router.

The shipped reference config hits this today:

```
$ python -c "from cli.commands.runtime_support import PASSTHROUGH_ENV_RULES, config_env_references; \
  print(sorted(config_env_references('config/config.yaml') - {n for n,_ in PASSTHROUGH_ENV_RULES}))"
['EMBEDDING_API_KEY', 'VLLM_SR_PRIMARY_API_KEY']
```

`config/config.yaml:40` names `VLLM_SR_PRIMARY_API_KEY` for the primary provider and
`:2124` names `EMBEDDING_API_KEY`. Neither is forwarded.

## Change

Read the env var names back off the config rather than guessing them ahead of time:

- `config_env_references()` collects `api_key_env` values and `${VAR}` interpolations,
  including the `${VAR:-default}` and `${VAR-default}` forms `resolveBracedEnvReference`
  supports.
- `append_passthrough_env_vars(env_vars, config_path)` forwards those in addition to the
  static rules, masked in logs, and skips names a static rule already handled.

The interpolation scan is restricted to upper case on purpose. `config/config.yaml:1163`
uses `${user_content}` and `${top_k}` as MCP tool-argument placeholders, and those are not
environment variables.

## Second half: the same list decided what was secret

`_sync_env_secret` put only sensitive names into the K8s Secret and `_translate_env_vars`
wrote everything else into the Helm `env:` list. Both derived "sensitive" from that same
allowlist, so an unrecognized provider key would not merely have been missing, it would
have been **written into values.yaml in plain text** once it reached `env_vars` by any
route.

`sensitive_env_names(config_path)` now treats anything the config names as a credential,
and both call sites use it. Both already had the config path in scope, so this is one
argument each.

## Testing

`src/vllm-sr` suite: 550 passed, up from 546. `black` clean across all 112 files.

Four new tests, each verified to fail without the change by disabling the discovery and
re-running:

| test | fails without the fix on |
|---|---|
| `test_append_passthrough_env_vars_forwards_keys_named_by_the_config` | `GEMINI_API_KEY` and `VALKEY_PASSWORD` absent from `env_vars` |
| `test_config_env_references_reads_api_key_env_and_interpolations` | empty set returned |
| `test_sensitive_env_names_covers_config_named_credentials` | `GEMINI_API_KEY` not treated as sensitive |
| `test_config_named_api_key_excluded_from_plain_env` | key present in the plain Helm `env:` list |

The last one is the plain-text case, so it fails loudly rather than leaking quietly.

Unreferenced names are not forwarded, a missing or unparseable config yields an empty set
rather than an error, and `${VAR}` inside a YAML comment is ignored because the scan runs
over the parsed document.
