### PR TITLE
[CI/E2E] build dashboard image from checkout

### DIFF
--- a/e2e/profiles/all/imports.go
+++ b/e2e/profiles/all/imports.go
@@ -36,13 +36,25 @@ var mockVLLMLocalImages = []framework.LocalImageBuild{
 	},
 }
 
+var dashboardLocalImages = []framework.LocalImageBuild{
+	{
+		Dockerfile:   "dashboard/backend/Dockerfile",
+		Tag:          "ghcr.io/vllm-project/semantic-router/dashboard:e2e-test",
+		BuildContext: ".",
+	},
+}
+
 func init() {
 	register("agentgateway", func() framework.Profile { return agentgateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("kubernetes", func() framework.Profile { return aigateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("aibrix", func() framework.Profile { return aibrix.NewProfile() }, framework.ProfileCapabilities{})
 	register("anthropic-shim", func() framework.Profile { return anthropicshim.NewProfile() }, framework.ProfileCapabilities{})
 	register("authz-rbac", func() framework.Profile { return authzrbac.NewProfile() }, framework.ProfileCapabilities{})
-	register("dashboard", func() framework.Profile { return dashboard.NewProfile() }, framework.ProfileCapabilities{})
+	register(
+		"dashboard",
+		func() framework.Profile { return dashboard.NewProfile() },
+		framework.ProfileCapabilities{LocalImages: dashboardLocalImages},
+	)
 	register("dynamic-config", func() framework.Profile { return dynamicconfig.NewProfile() }, framework.ProfileCapabilities{})
 	register("dynamo", func() framework.Profile { return dynamo.NewProfile() }, framework.ProfileCapabilities{RequiresGPU: true})
 	register(

--- a/e2e/profiles/all/imports_test.go
+++ b/e2e/profiles/all/imports_test.go
@@ -1,0 +1,24 @@
+package all
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+)
+
+func TestDashboardProfileBuildsLocalImage(t *testing.T) {
+	registration, ok := framework.LookupProfileRegistration("dashboard")
+	if !ok {
+		t.Fatal("dashboard profile is not registered")
+	}
+
+	want := []framework.LocalImageBuild{{
+		Dockerfile:   "dashboard/backend/Dockerfile",
+		Tag:          "ghcr.io/vllm-project/semantic-router/dashboard:e2e-test",
+		BuildContext: ".",
+	}}
+	if !reflect.DeepEqual(registration.Capabilities.LocalImages, want) {
+		t.Fatalf("dashboard local images = %#v, want %#v", registration.Capabilities.LocalImages, want)
+	}
+}

--- a/e2e/profiles/dashboard/dashboard-deployment.yaml
+++ b/e2e/profiles/dashboard/dashboard-deployment.yaml
@@ -16,8 +16,8 @@ spec:
     spec:
       containers:
         - name: dashboard
-          image: ghcr.io/vllm-project/semantic-router/dashboard:latest
-          imagePullPolicy: IfNotPresent
+          image: ghcr.io/vllm-project/semantic-router/dashboard:e2e-test
+          imagePullPolicy: Never
           # The image ENTRYPOINT is /app/entrypoint.sh which calls:
           #   exec su-exec nonroot:nonroot "$@"
           # So args must begin with the binary path; flags-only args would


### PR DESCRIPTION
Closes #2789

## Problem

The Kubernetes dashboard E2E profile deploys the mutable registry tag `dashboard:latest`. Docker publishing and Kubernetes E2E run independently, so a dashboard change can be tested against the previous image. Pull-request E2E runs likewise do not exercise dashboard backend code from the PR checkout.

## Fix

- Register `dashboard/backend/Dockerfile` as a dashboard profile `LocalImages` build.
- Build and load `dashboard:e2e-test` into Kind through the existing framework path.
- Deploy that local tag with registry fallback disabled.
- Cover the profile registration with a unit test.

## Verification

- `go test ./...` from `e2e/`
- `GOFLAGS=-buildvcs=false make agent-ci-gate CHANGED_FILES="e2e/profiles/all/imports.go e2e/profiles/all/imports_test.go e2e/profiles/dashboard/dashboard-deployment.yaml"`

### Measured on this PR's `integration-test (dashboard)` run

The dashboard profile passes with the checkout-built image, and the added build is
cheap relative to the job budget:

```
08:35:47  [Docker] Building ghcr.io/vllm-project/semantic-router/dashboard:e2e-test
08:39:02  built successfully                        -> build 3m15s
08:39:03  Loading image to Kind (control-plane, worker)
08:39:56  loaded to Kind cluster successfully       -> load  53s
                                                       total +4m08s

job wall clock: 08:23:20 -> 08:43:07 = 19m47s   (timeout-minutes: 90)
```

Test results from the same job:

```
Total: 9 | Passed: 9 | Failed: 0
```

`dashboard-deploy-preview` is the case that failed on #2755 against the stale
`:latest` image with `expected 200, got 400: {"error":"deploy_preview_error",
"message":"compiled routing fragment must contain routing"}`. It now runs the
dashboard backend from the PR checkout and passes.

The `imagePullPolicy: Never` deployment is confirmed working: the image is loaded
onto every Kind node before the pod schedules, so there is no `ErrImageNeverPull`
and no path back to the registry tag.
