### PR TITLE
[CI/E2E] build anthropic-shim image from checkout

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -130,7 +130,6 @@ jobs:
               - 'Cargo.lock'
               - 'pyproject.toml'
               - 'e2e/testing/llm-katan/**'
-              - 'e2e/testing/anthropic-shim/**'
             dashboard:
               - 'dashboard/**'
             website:
@@ -279,6 +278,7 @@ jobs:
               - 'e2e/pkg/**'
               - 'e2e/cmd/**'
               - 'e2e/testcases/**'
+              - 'e2e/profiles/all/**'
               - 'e2e/*.go'
               - 'e2e/go.mod'
               - 'e2e/go.sum'

--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -33,25 +33,23 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # Run the default PR baseline profiles if common e2e code, core code changes, or manual/scheduled trigger
+          # Start from the baseline profiles if common e2e code, core code changes, or manual trigger.
+          # Per-profile additions below still apply, so a PR that touches both
+          # common code and a specific profile runs that profile too instead of
+          # having it shadowed by the baseline set.
+          profiles=()
           if [[ "${{ needs.changes.outputs.e2e_common }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.core }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.docker }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.make }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.ci }}" == "true" ]] || \
              [[ "${{ needs.changes.outputs.agent_exec }}" == "true" ]] || \
-             [[ "${{ github.event_name }}" == "schedule" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            profiles=("kubernetes" "dashboard" "remote-embedding")
-            printf -v json '"%s",' "${profiles[@]}"
-            echo "profiles=[${json%,}]" >> $GITHUB_OUTPUT
-            echo 'should_run=true' >> $GITHUB_OUTPUT
-            echo "Running default baseline profiles due to common/core changes or push/schedule/manual trigger"
-            exit 0
+            profiles+=("kubernetes" "dashboard" "remote-embedding")
+            echo "Including baseline profiles due to common/core changes or manual trigger"
           fi
 
-          # Only run affected profiles for PRs
-          profiles=()
+          # Add profiles affected by the change set
           [[ "${{ needs.changes.outputs.e2e_istio }}" == "true" ]] && profiles+=("istio")
           [[ "${{ needs.changes.outputs.e2e_agentgateway }}" == "true" ]] && profiles+=("agentgateway")
           [[ "${{ needs.changes.outputs.e2e_kubernetes }}" == "true" ]] && profiles+=("kubernetes")
@@ -67,6 +65,13 @@ jobs:
           [[ "${{ needs.changes.outputs.e2e_authz_rbac }}" == "true" ]] && profiles+=("authz-rbac")
           [[ "${{ needs.changes.outputs.e2e_streaming }}" == "true" ]] && profiles+=("streaming")
           [[ "${{ needs.changes.outputs.e2e_anthropic_shim }}" == "true" ]] && profiles+=("anthropic-shim")
+
+          # Drop duplicates between the baseline and per-profile additions
+          deduped=()
+          for profile in "${profiles[@]}"; do
+            [[ " ${deduped[*]} " == *" ${profile} "* ]] || deduped+=("${profile}")
+          done
+          profiles=("${deduped[@]}")
 
           # Convert to JSON array
           if [ ${#profiles[@]} -eq 0 ]; then
@@ -89,6 +94,7 @@ jobs:
       E2E_SEMANTIC_ROUTER_HELM_TIMEOUT: 60m
     strategy:
       fail-fast: false  # Continue testing other profiles even if one fails
+      max-parallel: 6  # Affected profiles stack on the baseline set now; bound peak runner usage
       matrix:
         # Dynamic profile matrix based on detected changes
         profile: ${{ fromJson(needs.determine-profiles.outputs.profiles) }}

--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -64,6 +64,7 @@ jobs:
           [[ "${{ needs.changes.outputs.e2e_multi_endpoint }}" == "true" ]] && profiles+=("multi-endpoint")
           [[ "${{ needs.changes.outputs.e2e_authz_rbac }}" == "true" ]] && profiles+=("authz-rbac")
           [[ "${{ needs.changes.outputs.e2e_streaming }}" == "true" ]] && profiles+=("streaming")
+          [[ "${{ needs.changes.outputs.e2e_multimodal_routing }}" == "true" ]] && profiles+=("multimodal-routing")
           [[ "${{ needs.changes.outputs.e2e_anthropic_shim }}" == "true" ]] && profiles+=("anthropic-shim")
 
           # Drop duplicates between the baseline and per-profile additions

--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -66,6 +66,7 @@ jobs:
           [[ "${{ needs.changes.outputs.e2e_multi_endpoint }}" == "true" ]] && profiles+=("multi-endpoint")
           [[ "${{ needs.changes.outputs.e2e_authz_rbac }}" == "true" ]] && profiles+=("authz-rbac")
           [[ "${{ needs.changes.outputs.e2e_streaming }}" == "true" ]] && profiles+=("streaming")
+          [[ "${{ needs.changes.outputs.e2e_anthropic_shim }}" == "true" ]] && profiles+=("anthropic-shim")
 
           # Convert to JSON array
           if [ ${#profiles[@]} -eq 0 ]; then

--- a/e2e/profiles/all/imports.go
+++ b/e2e/profiles/all/imports.go
@@ -44,11 +44,23 @@ var dashboardLocalImages = []framework.LocalImageBuild{
 	},
 }
 
+var anthropicShimLocalImages = []framework.LocalImageBuild{
+	{
+		Dockerfile:   "e2e/testing/anthropic-shim/Dockerfile",
+		Tag:          "ghcr.io/vllm-project/semantic-router/anthropic-shim:e2e-test",
+		BuildContext: "e2e/testing/anthropic-shim",
+	},
+}
+
 func init() {
 	register("agentgateway", func() framework.Profile { return agentgateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("kubernetes", func() framework.Profile { return aigateway.NewProfile() }, framework.ProfileCapabilities{})
 	register("aibrix", func() framework.Profile { return aibrix.NewProfile() }, framework.ProfileCapabilities{})
-	register("anthropic-shim", func() framework.Profile { return anthropicshim.NewProfile() }, framework.ProfileCapabilities{})
+	register(
+		"anthropic-shim",
+		func() framework.Profile { return anthropicshim.NewProfile() },
+		framework.ProfileCapabilities{LocalImages: anthropicShimLocalImages},
+	)
 	register("authz-rbac", func() framework.Profile { return authzrbac.NewProfile() }, framework.ProfileCapabilities{})
 	register(
 		"dashboard",

--- a/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
+++ b/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
@@ -1,8 +1,8 @@
 # Anthropic-Shim Backend Resources
 #
 # Deploys the Qwen-flavoured anthropic-shim backend (llama.cpp + Python shim)
-# and exposes it to Envoy AI Gateway so the router can forward Anthropic-
-# protocol requests to it.
+# behind a ClusterIP Service; the HTTPRoute in gwapi-resources.yaml forwards
+# gateway traffic to it so the router can send Anthropic-protocol requests.
 #
 # The backend runs in the anthropic-backend-system namespace (created by
 # deploy/kubernetes/anthropic-backend/base/namespace.yaml). The shim Service
@@ -229,30 +229,3 @@ spec:
       port: 9080
       targetPort: shim
       protocol: TCP
----
-# ── Envoy AI Gateway Backend + AIServiceBackend ───────────────────────────────
-# The router uses the Anthropic schema so the AI Gateway knows to translate
-# outbound requests to Anthropic Messages shape before forwarding.
-apiVersion: aigateway.envoyproxy.io/v1alpha1
-kind: AIServiceBackend
-metadata:
-  name: anthropic-backend-qwen
-  namespace: default
-spec:
-  schema:
-    name: Anthropic
-  backendRef:
-    name: anthropic-backend-qwen
-    kind: Backend
-    group: gateway.envoyproxy.io
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: Backend
-metadata:
-  name: anthropic-backend-qwen
-  namespace: default
-spec:
-  endpoints:
-    - fqdn:
-        hostname: anthropic-backend-qwen.anthropic-backend-system.svc.cluster.local
-        port: 9080

--- a/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
+++ b/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
@@ -158,7 +158,7 @@ spec:
 
         - name: anthropic-shim
           image: ghcr.io/vllm-project/semantic-router/anthropic-shim:e2e-test
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Never
           ports:
             - name: shim
               containerPort: 9080

--- a/e2e/profiles/anthropic-shim/gateway-resources/gwapi-resources.yaml
+++ b/e2e/profiles/anthropic-shim/gateway-resources/gwapi-resources.yaml
@@ -52,11 +52,31 @@ spec:
   connection:
     bufferLimit: 50Mi
 ---
-# AIGatewayRoute — sends all model traffic to the anthropic-shim backend.
-# The AI Gateway uses the Anthropic schema declared on AIServiceBackend so
-# outbound requests arrive at the shim in Anthropic Messages shape.
-apiVersion: aigateway.envoyproxy.io/v1alpha1
-kind: AIGatewayRoute
+# Allow the HTTPRoute in default to reference the shim Service in
+# anthropic-backend-system.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-default-to-anthropic-backend
+  namespace: anthropic-backend-system
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ""
+      kind: Service
+      name: anthropic-backend-qwen
+---
+# Plain HTTPRoute straight to the anthropic-shim Service (same pattern as the
+# response-api profile). The semantic-router extproc rewrites :path to
+# /v1/messages for the anthropic-typed upstream, and the AI Gateway extproc
+# only accepts /anthropic/v1/messages at ingress, so routing through an
+# AIGatewayRoute would be rejected with 404 "unsupported path" before the
+# request ever reaches the shim.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: semantic-router
   namespace: default
@@ -67,18 +87,14 @@ spec:
       group: gateway.networking.k8s.io
   rules:
     - matches:
-        - headers:
-            - type: Exact
-              name: x-ai-eg-model
-              value: MoM
+        - path:
+            type: PathPrefix
+            value: /
       backendRefs:
         - name: anthropic-backend-qwen
-      timeouts:
-        request: 120s
-        backendRequest: 120s
-    # Default fallback — catch-all for any unmatched model alias
-    - backendRefs:
-        - name: anthropic-backend-qwen
+          namespace: anthropic-backend-system
+          port: 9080
+          weight: 1
       timeouts:
         request: 120s
         backendRequest: 120s

--- a/e2e/profiles/anthropic-shim/profile.go
+++ b/e2e/profiles/anthropic-shim/profile.go
@@ -26,8 +26,9 @@ var (
 // Profile implements the anthropic-shim test profile.
 //
 // It deploys the anthropic-shim backend (llama.cpp + the Python translation
-// shim) and points the Envoy AI Gateway routing at it so that Anthropic-
-// protocol requests reach an endpoint that speaks Anthropic Messages natively.
+// shim) and routes gateway traffic straight to it via an HTTPRoute so that
+// Anthropic-protocol requests reach an endpoint that speaks Anthropic
+// Messages natively.
 // This is required for cache-cycle and stop-sequence assertions that exercise
 // the outbound emitter's buildAnthropicUsage and stop-reason mapping paths.
 type Profile struct {

--- a/e2e/profiles/anthropic-shim/values.yaml
+++ b/e2e/profiles/anthropic-shim/values.yaml
@@ -14,6 +14,15 @@ config:
       default_model: MoM
     models:
       - name: MoM
+        # api_format switches the router's request-body translation to
+        # Anthropic (handleAnthropicRouting): the outbound body is rebuilt as
+        # an Anthropic Messages payload with cache_control markers and
+        # stop_sequences re-attached from the inbound request. Without it the
+        # backend_refs type below only rewrites :path/auth headers, and the
+        # shim receives an OpenAI-shaped body — no cache_control (cache-cycle
+        # test gets zero counters) and no stop_sequences (llama-server never
+        # triggers stop_sequence).
+        api_format: anthropic
         backend_refs:
           - name: anthropic-backend-qwen
             # The shim's Service exposes port 9080 (the Python FastAPI layer).
@@ -40,10 +49,10 @@ config:
         - name: all_requests
           operator: OR
           keywords:
-            # Catch-all routing; the AIGatewayRoute also has a bare fallback
-            # rule in gwapi-resources.yaml. Both are intentional — the router
-            # needs a signal match to route, and the gateway provides a
-            # safety-net in case the router produces no match.
+            # Catch-all routing; the HTTPRoute in gwapi-resources.yaml also
+            # forwards all paths to the shim. Both are intentional — the
+            # router needs a signal match to route, and the gateway provides
+            # a safety-net in case the router produces no match.
             - ""
     modelCards:
       - name: MoM

--- a/e2e/testcases/anthropic_messages_stop_sequence.go
+++ b/e2e/testcases/anthropic_messages_stop_sequence.go
@@ -22,26 +22,18 @@ func init() {
 	})
 }
 
-// testAnthropicMessagesStopSequence asserts that the outbound emitter maps
-// the upstream finish_reason to "stop_sequence" when the request carried
-// stop_sequences and the model's output triggered one.
+// testAnthropicMessagesStopSequence asserts that the response carries
+// stop_reason "stop_sequence" (not "end_turn") when the request's
+// stop_sequences triggered generation stop, exercising the router's
+// Anthropic outbound translation of stop_sequences end to end.
 //
-// The system prompt directs the tiny Qwen model to emit "STOP" verbatim,
-// which — if followed — causes llama-server to set finish_reason=stop and
-// return the stop token in stop_reason. The shim passes this through; the
-// router's mapOpenAIFinishReasonToAnthropic must then label the response
-// stop_reason as "stop_sequence" (not "end_turn").
-//
-// NOTE: This test depends on the tiny Qwen2.5-0.5B model in the
-// anthropic-shim profile following the "say STOP exactly" instruction. If
-// the model does not reliably emit the sentinel in CI, prefer replacing
-// "STOP" with a sentinel the model emits unconditionally (e.g. the EOS
-// token) over adding retry loops or sleeps.
-//
-// TODO: If this test flakes due to model instruction-following variability,
-// swap the stop_sequences value for a string the model outputs in all
-// completions (e.g. a fixed suffix in the system prompt) rather than
-// introducing any retry or timing-based workaround.
+// The stop sequences are single vowels, which any English completion emits
+// within its first few tokens regardless of instruction-following — the
+// tiny Qwen2.5-0.5B model in this profile cannot be trusted to emit an
+// agreed sentinel like "STOP" (in CI it answered in 3 tokens and hit EOS
+// first). With unconditional stop strings, a failure means the
+// stop_sequences never reached llama-server or the stop_reason mapping is
+// wrong, not that the model ignored the prompt.
 //
 // Requires the anthropic-shim profile.
 func testAnthropicMessagesStopSequence(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
@@ -56,12 +48,16 @@ func testAnthropicMessagesStopSequence(ctx context.Context, client *kubernetes.C
 	defer stop()
 
 	body := stopSequenceRequestBody{
-		Model:         "MoM",
-		MaxTokens:     50,
-		StopSequences: []string{"STOP"},
-		System:        "You must end every response with the word STOP in capital letters, on its own line.",
+		Model:     "MoM",
+		MaxTokens: 50,
+		// Single vowels: emitted unconditionally by any English output, so
+		// triggering does not depend on the 0.5B model following
+		// instructions. Four entries stay within the OpenAI stop-list cap
+		// that the router's internal representation is translated through.
+		StopSequences: []string{"e", "a", "i", "o"},
+		System:        "You are a helpful assistant.",
 		Messages: []anthropicMessage{
-			{Role: "user", Content: "Please respond and end with STOP."},
+			{Role: "user", Content: "Introduce yourself in one short English sentence."},
 		},
 	}
 
@@ -111,9 +107,9 @@ func testAnthropicMessagesStopSequence(ctx context.Context, client *kubernetes.C
 	if parsed.StopReason != "stop_sequence" {
 		return fmt.Errorf(
 			"expected stop_reason=stop_sequence, got %q — "+
-				"the model may not have emitted the sentinel; "+
-				"if this flakes in CI replace the stop string with "+
-				"a sentinel the model emits unconditionally",
+				"the stop strings are unconditional vowels, so either "+
+				"stop_sequences were dropped in the router's outbound "+
+				"translation or the upstream stop_reason mapping is wrong",
 			parsed.StopReason,
 		)
 	}

--- a/e2e/testing/anthropic-shim/anthropic_shim/app.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/app.py
@@ -2,7 +2,8 @@
 
 Forwards every request as-is to the configured upstream after applying
 the inbound translations from :mod:`anthropic_shim.translate`, then
-post-processes the response to synthesise prompt-cache usage counters.
+post-processes the response to synthesise prompt-cache usage counters
+and to correct ``stop_reason`` when a stop sequence triggered.
 
 The proxy is intentionally minimal: it covers ``/v1/messages`` and the
 streaming sibling, and passes everything else (``/health``, ``/v1/models``,
@@ -25,6 +26,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from .translate import (
     apply_cache_usage,
     cache_prefix_hash,
+    fix_stop_reason,
     has_cache_control,
     join_system_array,
     join_tool_result_content,
@@ -246,6 +248,9 @@ async def _handle_messages(request: Request, app: FastAPI) -> Response:
             headers=response_headers,
             media_type=upstream_response.headers.get("content-type"),
         )
+
+    if isinstance(response_payload, dict):
+        fix_stop_reason(response_payload)
 
     if request_had_cache_control and isinstance(response_payload, dict):
         prefix_seen = app.state.tracker.mark(session_id, prefix_hash)

--- a/e2e/testing/anthropic-shim/anthropic_shim/translate.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/translate.py
@@ -16,6 +16,12 @@ Three concerns are handled:
    ``cache_read_input_tokens`` based on whether the inbound request
    carried ``cache_control`` markers and whether this session has seen
    the same request-body prefix before.
+4. ``fix_stop_reason`` corrects ``stop_reason`` to ``stop_sequence``
+   when a stop word triggered: llama-server's Anthropic endpoint
+   reports which sequence matched in ``stop_sequence`` but labels the
+   ``stop_reason`` ``end_turn`` (it collapses STOP_TYPE_WORD and
+   STOP_TYPE_EOS in ``to_json_anthropic``), which the real Anthropic
+   API would report as ``stop_sequence``.
 """
 
 from __future__ import annotations
@@ -216,4 +222,24 @@ def apply_cache_usage(
     else:
         usage["cache_creation_input_tokens"] = input_tokens
         usage.setdefault("cache_read_input_tokens", 0)
+    return response
+
+
+def fix_stop_reason(response: dict[str, Any]) -> dict[str, Any]:
+    """Correct ``stop_reason`` when a stop sequence actually triggered.
+
+    Mutates and returns ``response``. llama-server's ``to_json_anthropic``
+    maps both STOP_TYPE_WORD (a ``stop_sequences`` hit) and STOP_TYPE_EOS
+    to ``end_turn`` while still reporting the matched word in the
+    ``stop_sequence`` field. The real Anthropic API reports
+    ``stop_reason: "stop_sequence"`` in that case, so rewrite it whenever
+    the response carries a matched stop sequence.
+    """
+    stop_sequence = response.get("stop_sequence")
+    if (
+        isinstance(stop_sequence, str)
+        and stop_sequence
+        and response.get("stop_reason") == "end_turn"
+    ):
+        response["stop_reason"] = "stop_sequence"
     return response

--- a/e2e/testing/anthropic-shim/tests/test_translate.py
+++ b/e2e/testing/anthropic-shim/tests/test_translate.py
@@ -12,6 +12,7 @@ import copy
 from anthropic_shim.translate import (
     apply_cache_usage,
     cache_prefix_hash,
+    fix_stop_reason,
     has_cache_control,
     join_system_array,
     join_tool_result_content,
@@ -197,6 +198,31 @@ def test_apply_cache_usage_noop_without_cache_control() -> None:
 def test_apply_cache_usage_handles_missing_usage() -> None:
     response: dict = {"id": "msg_1"}
     apply_cache_usage(response, request_had_cache_control=True, prefix_seen=False)
+    assert response == {"id": "msg_1"}
+
+
+def test_fix_stop_reason_rewrites_end_turn_with_matched_sequence() -> None:
+    response = {"stop_reason": "end_turn", "stop_sequence": "STOP"}
+    fix_stop_reason(response)
+    assert response["stop_reason"] == "stop_sequence"
+    assert response["stop_sequence"] == "STOP"
+
+
+def test_fix_stop_reason_keeps_end_turn_without_matched_sequence() -> None:
+    response = {"stop_reason": "end_turn", "stop_sequence": None}
+    fix_stop_reason(response)
+    assert response["stop_reason"] == "end_turn"
+
+
+def test_fix_stop_reason_leaves_other_reasons_alone() -> None:
+    response = {"stop_reason": "max_tokens", "stop_sequence": "STOP"}
+    fix_stop_reason(response)
+    assert response["stop_reason"] == "max_tokens"
+
+
+def test_fix_stop_reason_handles_missing_fields() -> None:
+    response: dict = {"id": "msg_1"}
+    fix_stop_reason(response)
     assert response == {"id": "msg_1"}
 
 


### PR DESCRIPTION
Closes #2809

## Purpose

- Make the anthropic-shim e2e profile runnable and CI-enforced: register a `LocalImageBuild` for the shim Dockerfile so the runner builds it from the checkout and kind-loads it (`imagePullPolicy: Never`), fixing the `ImagePullBackOff` from the unpublished `:e2e-test` tag; wire the existing but never-consumed `e2e_anthropic_shim` filter into the profile matrix.
- **Matrix selection change:** run the union of baseline profiles plus every affected profile (deduped, `max-parallel: 6`) instead of short-circuiting to baseline whenever a common filter matches. Also close three selection gaps: missing `multimodal-routing` matrix line, unmatched `e2e/profiles/all/**`, and shim paths overlapping `core`.
- Fix pre-existing profile bugs surfaced by its first-ever CI runs:
  - Route gateway traffic via plain `HTTPRoute` + `ReferenceGrant` (the AI Gateway extproc rejected the router's rewritten `/v1/messages` path with 404).
  - Declare `api_format: anthropic` on the model so the router performs the full Anthropic outbound body translation (`cache_control`, `stop_sequences`).
  - Make the stop-sequence test sentinel unconditional (single vowels) instead of relying on the 0.5B model emitting an instructed "STOP".
  - Correct `stop_reason` in the shim: llama-server's `to_json_anthropic()` collapses a stop-word hit into `end_turn` and never emits `stop_sequence`, though it reports the matched word; the shim rewrites it to match real Anthropic API behavior.
- Affects: `E2E` / `CI/Build`

## Test Plan

- `cd e2e && go build ./... && go test ./profiles/all/`; matrix selection script replayed locally for all four filter combinations; shim unit tests (34) pass.
- Under the union semantics this PR triggers its own anthropic-shim profile job, so CI verifies the fix end to end on a clean Kind cluster.

## Test Result

- Local: `go test ./profiles/all/`, `gofmt`, `go vet`, `make agent-validate`, `pytest` (34/34) all pass.
- Five in-PR CI runs, baseline profiles green in all; each run peeled one pre-existing layer: ImagePullBackOff fixed → gateway 404 fixed → cache-cycle test passed with `api_format` → stop-sequence root-caused to llama-server's `stop_reason` mapping → **final run fully green: `integration-test (anthropic-shim)` passed alongside all baseline profiles.**

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
