### PR TITLE
[Docs] add search to the docs website

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -74,7 +74,18 @@ Treat the current website redesign as the default design contract for all public
 - **Mermaid and code block styling** integrated into the docs theme
 - **Custom landing, publications, community, and white-paper routes**
 - **Theme overrides** for docs and blog shells
-- **Search-ready Docusaurus foundation**
+- **Local docs search** in the navbar, with no external search service (see below)
+
+### Search
+
+Search is provided by [`@easyops-cn/docusaurus-search-local`](https://github.com/easyops-cn/docusaurus-search-local), registered in the `themes` array of `docusaurus.config.ts`.
+
+- **Local and offline.** The Lunr index is compiled during the build and served as a static asset from our own domain. There is no account, no API key, no crawler, no quota, and no network call at search time.
+- **Keyboard shortcut.** `Ctrl+K` (Linux/Windows) or `Cmd+K` (macOS) opens and focuses the search box. `Escape` closes it. `/search` renders the standalone results page.
+- **What is indexed.** The current documentation version (`docs/`) and the blog. Archived versions (`v0.1`-`v0.3`) are excluded through `ignoreFiles`, and `src/pages` marketing routes are excluded through `indexPages: false`. Searching from an archived-version page therefore returns current-docs results. To make archived versions searchable, drop `ignoreFiles` and add `searchContextByPaths` — there is a comment in the config explaining how.
+- **The index is a build-time artefact.** Only `npm run build` (or `make docs-build`) regenerates it, so `npm run start` will not reflect fresh content in search results. Use a production build plus `npm run serve` when verifying search changes.
+- **Both locales are searchable.** `language: ['en', 'zh']` enables the Chinese tokenizer, which is needed because Chinese is written without spaces; it is backed by `@node-rs/jieba` (a native module shipping prebuilt binaries, so nothing is compiled at install time). The Chinese search UI strings live in `i18n/zh-Hans/code.json` under `theme.SearchBar.*` and `theme.SearchPage.*`.
+- **Styling.** All search overrides live in `src/css/search.css` so they can be removed cleanly if the search theme is ever swapped out. Note that the plugin's own `[data-theme="dark"]` rules never apply here — the site renders as `html[data-theme="light"]` and is dark through its own tokens — so the overrides target the vendor's light-mode rules.
 
 ### UX Goals
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -63,7 +63,15 @@ const config: Config = {
         blogRouteBasePath: '/blog',
         searchBarShortcut: true,
         searchBarShortcutHint: true,
-        // language / styling / version scoping are handled in later phases
+        // v1 scope: index the current docs version only, per the decision on #2737.
+        // To make archived versions searchable later, drop this and add
+        // searchContextByPaths: ['docs', 'docs/v0.3', 'docs/v0.2', 'docs/v0.1']
+        // so results stay scoped to the version the reader is on.
+        // NOTE: ignoreFiles matches the route *without* a leading slash (the
+        // plugin strips baseUrl, which is "/" here, off the front) and without
+        // the base URL itself, so the pattern must not anchor on "/".
+        ignoreFiles: [/^docs\/v\d+\.\d+\//],
+        // language / styling are handled in later phases
       },
     ],
   ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -50,7 +50,23 @@ const config: Config = {
       onBrokenMarkdownLinks: 'warn',
     },
   },
-  themes: ['@docusaurus/theme-mermaid'],
+  themes: [
+    '@docusaurus/theme-mermaid',
+    [
+      require.resolve('@easyops-cn/docusaurus-search-local'),
+      {
+        hashed: true, // cache-bust the index between deploys
+        indexDocs: true,
+        indexBlog: true,
+        indexPages: false, // homepage/community are marketing pages, not docs
+        docsRouteBasePath: '/docs',
+        blogRouteBasePath: '/blog',
+        searchBarShortcut: true,
+        searchBarShortcutHint: true,
+        // language / styling / version scoping are handled in later phases
+      },
+    ],
+  ],
 
   presets: [
     [

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -63,6 +63,11 @@ const config: Config = {
         blogRouteBasePath: '/blog',
         searchBarShortcut: true,
         searchBarShortcutHint: true,
+        // The site ships a full zh-Hans locale, so the index needs a Chinese
+        // tokenizer as well: Chinese is written without spaces and the default
+        // English tokenizer cannot split it. "zh" pulls in @node-rs/jieba, a
+        // native module that ships prebuilt binaries.
+        language: ['en', 'zh'],
         // v1 scope: index the current docs version only, per the decision on #2737.
         // To make archived versions searchable later, drop this and add
         // searchContextByPaths: ['docs', 'docs/v0.3', 'docs/v0.2', 'docs/v0.1']
@@ -71,7 +76,7 @@ const config: Config = {
         // plugin strips baseUrl, which is "/" here, off the front) and without
         // the base URL itself, so the pattern must not anchor on "/".
         ignoreFiles: [/^docs\/v\d+\.\d+\//],
-        // language / styling are handled in later phases
+        // styling is handled in a later phase
       },
     ],
   ],

--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -2656,5 +2656,40 @@
   },
   "community.contributors.range.all.caption": {
     "message": "仓库全量历史"
+  },
+  "theme.SearchBar.noResultsText": {
+    "message": "没有找到任何文档"
+  },
+  "theme.SearchBar.seeAllOutsideContext": {
+    "message": "查看“{context}”以外的全部结果"
+  },
+  "theme.SearchBar.searchInContext": {
+    "message": "查看“{context}”以内的全部结果"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "查看全部结果"
+  },
+  "theme.SearchBar.label": {
+    "message": "搜索",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "“{query}”的搜索结果",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "搜索文档",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.searchContext.everywhere": {
+    "message": "所有"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "共找到 {count} 篇文档",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "没有找到任何文档",
+    "description": "The paragraph for empty search result"
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,6 +13,7 @@
         "@docusaurus/plugin-client-redirects": "^3.8.1",
         "@docusaurus/preset-classic": "^3.8.1",
         "@docusaurus/theme-mermaid": "^3.8.1",
+        "@easyops-cn/docusaurus-search-local": "^0.55.3",
         "@lobehub/icons": "^5.4.0",
         "@mdx-js/react": "^3.1.0",
         "@stylistic/eslint-plugin": "2.13.0",
@@ -4257,6 +4258,156 @@
         "node": ">=20.0"
       }
     },
+    "node_modules/@easyops-cn/autocomplete.js": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
+      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "immediate": "^3.2.3"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local": {
+      "version": "0.55.3",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.3.tgz",
+      "integrity": "sha512-PlMKmxuonvZ1C+/zJS1hJaF1xaxD1TsUvOMzpP6DdQMtZqmTaYjcLGM12ePzl0m1rp3AgfTBeDbFNHQhwnH/dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/plugin-content-docs": "^2 || ^3",
+        "@docusaurus/theme-translations": "^2 || ^3",
+        "@docusaurus/utils": "^2 || ^3",
+        "@docusaurus/utils-common": "^2 || ^3",
+        "@docusaurus/utils-validation": "^2 || ^3",
+        "@easyops-cn/autocomplete.js": "^0.38.1",
+        "@node-rs/jieba": "^1.6.0",
+        "cheerio": "^1.0.0",
+        "clsx": "^2.1.1",
+        "comlink": "^4.4.2",
+        "debug": "^4.2.0",
+        "fs-extra": "^10.0.0",
+        "klaw-sync": "^6.0.0",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2 || ^3",
+        "open-ask-ai": "^0.7.3",
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || 17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "open-ask-ai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmmirror.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -5231,6 +5382,283 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/jieba": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.10.4.tgz",
+      "integrity": "sha512-GvDgi8MnBiyWd6tksojej8anIx18244NmIOc1ovEw8WKNUejcccLfyu8vj66LWSuoZuKILVtNsOy4jvg3aoxIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/jieba-android-arm-eabi": "1.10.4",
+        "@node-rs/jieba-android-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-x64": "1.10.4",
+        "@node-rs/jieba-freebsd-x64": "1.10.4",
+        "@node-rs/jieba-linux-arm-gnueabihf": "1.10.4",
+        "@node-rs/jieba-linux-arm64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-arm64-musl": "1.10.4",
+        "@node-rs/jieba-linux-x64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-x64-musl": "1.10.4",
+        "@node-rs/jieba-wasm32-wasi": "1.10.4",
+        "@node-rs/jieba-win32-arm64-msvc": "1.10.4",
+        "@node-rs/jieba-win32-ia32-msvc": "1.10.4",
+        "@node-rs/jieba-win32-x64-msvc": "1.10.4"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm-eabi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.10.4.tgz",
+      "integrity": "sha512-MhyvW5N3Fwcp385d0rxbCWH42kqDBatQTyP8XbnYbju2+0BO/eTeCCLYj7Agws4pwxn2LtdldXRSKavT7WdzNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.10.4.tgz",
+      "integrity": "sha512-XyDwq5+rQ+Tk55A+FGi6PtJbzf974oqnpyCcCPzwU3QVXJCa2Rr4Lci+fx8oOpU4plT3GuD+chXMYLsXipMgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.10.4.tgz",
+      "integrity": "sha512-G++RYEJ2jo0rxF9626KUy90wp06TRUjAsvY/BrIzEOX/ingQYV/HjwQzNPRR1P1o32a6/U8RGo7zEBhfdybL6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.10.4.tgz",
+      "integrity": "sha512-MmDNeOb2TXIZCPyWCi2upQnZpPjAxw5ZGEj6R8kNsPXVFALHIKMa6ZZ15LCOkSTsKXVC17j2t4h+hSuyYb6qfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-freebsd-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.10.4.tgz",
+      "integrity": "sha512-/x7aVQ8nqUWhpXU92RZqd333cq639i/olNpd9Z5hdlyyV5/B65LLy+Je2B2bfs62PVVm5QXRpeBcZqaHelp/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm-gnueabihf": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.10.4.tgz",
+      "integrity": "sha512-crd2M35oJBRLkoESs0O6QO3BBbhpv+tqXuKsqhIG94B1d02RVxtRIvSDwO33QurxqSdvN9IeSnVpHbDGkuXm3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.10.4.tgz",
+      "integrity": "sha512-omIzNX1psUzPcsdnUhGU6oHeOaTCuCjUgOA/v/DGkvWC1jLcnfXe4vdYbtXMh4XOCuIgS1UCcvZEc8vQLXFbXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.10.4.tgz",
+      "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.10.4.tgz",
+      "integrity": "sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.10.4.tgz",
+      "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-wasm32-wasi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.10.4.tgz",
+      "integrity": "sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-arm64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.10.4.tgz",
+      "integrity": "sha512-nwMtViFm4hjqhz1it/juQnxpXgqlGltCuWJ02bw70YUDMDlbyTy3grCJPpQQpueeETcALUnTxda8pZuVrLRcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-ia32-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.10.4.tgz",
+      "integrity": "sha512-DCAvLx7Z+W4z5oKS+7vUowAJr0uw9JBw8x1Y23Xs/xMA4Em+OOSiaF5/tCJqZUCJ8uC4QeImmgDFiBqGNwxlyA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-x64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.10.4.tgz",
+      "integrity": "sha512-+sqemSfS1jjb+Tt7InNbNzrRh1Ua3vProVvC4BZRPg010/leCbGFFiQHpzcPRfpxAXZrzG5Y0YBTsPzN/I4yHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5701,6 +6129,16 @@
       "integrity": "sha512-sDDxcltg2pcV0U3sQf5EMaX4/ER+x3IXmUc5EXuz4JnFDyxfGhTG7zGKJ8cLLZzjZALgdTK2LSKQbFLSKuGvQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -8174,6 +8612,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -10001,6 +10445,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -12382,6 +12839,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -13405,6 +13868,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -13642,6 +14114,18 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.20.0.tgz",
+      "integrity": "sha512-3LVgE7ekWXt04NBci/hjm+NXJxXZeRXuyClL0kA0HONyBOjxhP3ZQkuWIM4Ok3pbeptUW/rj3XcJcJuJVPwPYA==",
+      "license": "MPL-1.1"
+    },
     "node_modules/make-cancellable-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
@@ -13659,6 +14143,12 @@
       "funding": {
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
       }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
@@ -16904,6 +17394,18 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -21423,6 +21925,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -22439,6 +22950,28 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5526,9 +5526,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5544,9 +5541,6 @@
       "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5564,9 +5558,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5582,9 +5573,6 @@
       "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/website/package.json
+++ b/website/package.json
@@ -38,6 +38,7 @@
     "@docusaurus/plugin-client-redirects": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-mermaid": "^3.8.1",
+    "@easyops-cn/docusaurus-search-local": "^0.55.3",
     "@lobehub/icons": "^5.4.0",
     "@mdx-js/react": "^3.1.0",
     "@stylistic/eslint-plugin": "2.13.0",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -5,4 +5,5 @@
 @import './shell.css';
 @import './docs.css';
 @import './blog.css';
+@import './search.css';
 @import 'katex/dist/katex.min.css';

--- a/website/src/css/search.css
+++ b/website/src/css/search.css
@@ -1,0 +1,490 @@
+/*
+ * Search overrides for @easyops-cn/docusaurus-search-local.
+ *
+ * Everything the search theme needs lives in this one file so it can be
+ * deleted wholesale if the search theme is ever swapped out.
+ *
+ * Two things about this site drive the rules below:
+ *
+ * 1. The page renders with `html[data-theme="light"]` (colorMode.disableSwitch
+ *    is on), so every `html[data-theme="dark"]` rule the plugin ships is dead
+ *    code here and its *light* palette is what actually applies. We override
+ *    the light rules; never flip colorMode to "dark".
+ * 2. The shell is split: the navbar and footer are dark chrome (shell.css)
+ *    while docs, blog and page routes are the light palette in tokens.css.
+ *    So the input is styled as dark navbar chrome and the dropdown is styled
+ *    as a light panel, exactly like the site's own `.dropdown__menu`.
+ *
+ * The plugin's class names are hashed CSS modules (`suggestion_fB`), so
+ * selectors anchor on the stable Docusaurus classes (`.navbar__search`,
+ * `.navbar__search-input`) and fall back to `[class*="name_"]` substring
+ * matches. The plugin's own rules sort *after* this file in the emitted
+ * bundle, so each override carries one extra level of specificity rather
+ * than relying on source order. No `!important` is needed anywhere.
+ */
+
+/* ------------------------------------------------------------------ *
+ * Tokens
+ * ------------------------------------------------------------------ */
+
+.navbar {
+  /*
+   * tokens.css is a light palette; the navbar's dark chrome is written as
+   * literals in shell.css. These mirror the zinc values shell.css already
+   * uses for `.navbar__toggle` / `.navbar__title` / `.footer__title` so the
+   * search input reads as the same control family. They duplicate no token.
+   */
+  --search-navbar-surface: #18181b;
+  --search-navbar-surface-hover: #27272a;
+  --search-navbar-border: #3f3f46;
+  --search-navbar-text: #fafafa;
+  --search-navbar-muted: #a1a1aa;
+
+  /* Infima drives the input and the loading ring off these. Scoped to
+     .navbar so the /search page keeps the light values from :root. */
+  --ifm-navbar-search-input-background-color: var(--search-navbar-surface);
+  --ifm-navbar-search-input-color: var(--search-navbar-text);
+  --ifm-navbar-search-input-placeholder-color: var(--search-navbar-muted);
+}
+
+.navbar__search {
+  /*
+   * The plugin exposes these for theming, which is cheaper and far more
+   * upgrade-proof than fighting its hashed selectors.
+   */
+  --search-local-modal-width: 30rem;
+  --search-local-modal-width-sm: min(92vw, 22rem);
+  --search-local-modal-background: var(--site-surface-raised);
+  /*
+   * Deliberately opaque with no backdrop-filter: `.navbar` already sets
+   * backdrop-filter, which establishes a backdrop root, so a translucent
+   * panel here would blur nothing and could read as a hole over the page.
+   * --site-hover-shadow is the only token strong enough to lift a panel off
+   * both the light docs background and the black homepage.
+   */
+  --search-local-modal-shadow: var(--site-hover-shadow);
+  --search-local-spacing: 0.5rem;
+  --search-local-hit-height: 3.25rem;
+  --search-local-hit-background: transparent;
+  --search-local-hit-shadow: none;
+  --search-local-hit-color: var(--site-text);
+  --search-local-hit-active-color: var(--site-text-strong);
+  --search-local-highlight-color: var(--site-accent-strong);
+  --search-local-muted-color: var(--site-muted);
+  --search-local-input-active-border-color: var(--site-accent);
+}
+
+/* ------------------------------------------------------------------ *
+ * Navbar control
+ * ------------------------------------------------------------------ */
+
+.navbar [class*='searchBarContainer_'] {
+  /* The plugin ships margin-left: 16px; the navbar rhythm is tighter. */
+  margin-left: 0.5rem;
+}
+
+.navbar .navbar__search:not([hidden]) {
+  /* autocomplete.js wraps the input in an inline-block span, which leaves a
+     baseline gap under it inside a block container. */
+  display: flex;
+  align-items: center;
+}
+
+.navbar .navbar__search-input {
+  width: 14.5rem;
+  height: 2.3rem;
+  /* Right padding clears the ✕ button, which replaces the shortcut hint as
+     soon as the field has a value. */
+  padding: 0 2.4rem 0 2.3rem;
+  border: 1px solid var(--search-navbar-border);
+  border-radius: 4px;
+  background: var(--search-navbar-surface);
+  color: var(--search-navbar-text);
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.82rem;
+  font-weight: var(--site-font-weight-normal);
+  transition:
+    border-color var(--site-transition-fast),
+    background var(--site-transition-fast);
+}
+
+.navbar .navbar__search-input::placeholder {
+  /* Matches the uppercase micro-type of the navbar links. Typed text stays
+     sentence case; only the resting label picks up the navbar voice. */
+  color: var(--search-navbar-muted);
+  font-size: 0.73rem;
+  font-weight: var(--site-font-weight-medium);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  opacity: 1;
+}
+
+.navbar .navbar__search-input:hover {
+  border-color: var(--site-hover-border);
+  background: var(--search-navbar-surface-hover);
+}
+
+.navbar .navbar__search-input:focus {
+  border-color: var(--site-accent);
+  background: var(--search-navbar-surface-hover);
+  /* The plugin already draws an outline off
+     --search-local-input-active-border-color; this only spaces it off the
+     border. Never remove it. */
+  outline-offset: 2px;
+}
+
+.navbar .navbar__search [class*='searchIcon_'] {
+  left: 0.75rem;
+  color: var(--search-navbar-muted);
+}
+
+.navbar .navbar__search:hover [class*='searchIcon_'],
+.navbar .navbar__search:focus-within [class*='searchIcon_'] {
+  color: var(--search-navbar-text);
+}
+
+.navbar [class*='searchBarContainer_'] [class*='searchBarLoadingRing_'] {
+  /* The plugin hard-codes top: 6px against a 2rem-tall input. */
+  top: 50%;
+  left: 0.72rem;
+  transform: translateY(-50%);
+}
+
+/* Ctrl/Cmd + K hint */
+.navbar .navbar__search [class*='searchHintContainer_'] {
+  right: 0.6rem;
+  gap: 3px;
+}
+
+.navbar .navbar__search [class*='searchHint_'] {
+  padding: 0.12rem 0.3rem;
+  border: 1px solid var(--search-navbar-border);
+  border-radius: 3px;
+  background: var(--search-navbar-surface-hover);
+  box-shadow: none;
+  color: var(--search-navbar-muted);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.62rem;
+  line-height: 1.25;
+}
+
+/* Clear (✕) button, shown once the field has a value */
+.navbar .navbar__search [class*='searchClearButton_'] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  right: 0.7rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 3px;
+  line-height: 1;
+  color: var(--search-navbar-muted);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: color var(--site-transition-fast);
+}
+
+.navbar .navbar__search [class*='searchClearButton_']:hover {
+  color: var(--search-navbar-text);
+}
+
+.navbar .navbar__search [class*='searchClearButton_']:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
+}
+
+/* ------------------------------------------------------------------ *
+ * Results dropdown
+ *
+ * Styled as the site's own navbar dropdown (`.dropdown__menu` in shell.css):
+ * a light panel on the dark navbar, thin border, 1.1rem radius.
+ * ------------------------------------------------------------------ */
+
+.navbar .navbar__search [class*='dropdownMenu_'] {
+  max-width: calc(100vw - 1.5rem);
+  max-height: min(70vh, 32rem);
+  margin-top: 0.55rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--site-border);
+  border-radius: 1.1rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--site-border-strong) transparent;
+}
+
+.navbar .navbar__search [class*='dropdownMenu_'] [class*='suggestion_'] {
+  padding: 0 0.6rem;
+  border-radius: 0.8rem;
+  font-size: 1rem;
+  transition:
+    background var(--site-transition-fast),
+    box-shadow var(--site-transition-fast);
+}
+
+/*
+ * autocomplete.js applies `cursor` on both hover and arrow-key navigation, so
+ * this is the single active-row state. The inset rail mirrors the active
+ * treatment used by `.navbar-sidebar .menu__link--active` in shell.css and
+ * keeps keyboard position readable, not just tinted.
+ */
+.navbar .navbar__search [class*='dropdownMenu_'] [class*='suggestion_']:hover,
+.navbar .navbar__search [class*='dropdownMenu_'] [class*='suggestion_'][class*='cursor_'] {
+  background-color: var(--site-accent-soft);
+  box-shadow: inset 2px 0 var(--site-accent);
+}
+
+.navbar .navbar__search [class*='hitTitle_'] {
+  font-size: 0.86rem;
+  font-weight: var(--site-font-weight-medium);
+  letter-spacing: -0.005em;
+}
+
+.navbar .navbar__search [class*='hitPath_'] {
+  margin-top: 0.1rem;
+  font-size: 0.72rem;
+  font-weight: var(--site-font-weight-normal);
+}
+
+/* The ⏎ affordance is noise on every row; surface it on the active one. */
+.navbar .navbar__search [class*='hitAction_'] {
+  opacity: 0;
+  transition: opacity var(--site-transition-fast);
+}
+
+.navbar .navbar__search [class*='suggestion_']:hover [class*='hitAction_'],
+.navbar .navbar__search [class*='suggestion_'][class*='cursor_'] [class*='hitAction_'] {
+  opacity: 1;
+}
+
+/* No results */
+.navbar .navbar__search [class*='noResults_'] {
+  gap: 0.2rem;
+  padding: 1.5rem 0.75rem;
+  color: var(--site-muted-bright);
+  font-size: 0.85rem;
+}
+
+.navbar .navbar__search [class*='noResultsIcon_'] {
+  margin-bottom: 0.4rem;
+  opacity: 0.65;
+}
+
+/* "See all results" footer */
+.navbar .navbar__search [class*='hitFooter_'] {
+  margin-top: 0.4rem;
+  padding: 0.6rem 0.6rem 0.25rem;
+  border-top: 1px solid var(--site-border);
+  font-size: 0.75rem;
+}
+
+.navbar .navbar__search [class*='hitFooter_'] a {
+  color: var(--site-muted-bright);
+  text-decoration: none;
+  transition: color var(--site-transition-fast);
+}
+
+.navbar .navbar__search [class*='hitFooter_'] a:hover {
+  color: var(--site-text-strong);
+  text-decoration: underline;
+}
+
+.navbar .navbar__search [class*='hitFooter_'] a:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* ------------------------------------------------------------------ *
+ * Responsive
+ *
+ * shell.css hides `.navbar__items--right` below 1100px, which would hide the
+ * search control on every tablet and phone. Restore the container — and only
+ * the container — so search stays reachable; the README treats mobile as
+ * first class. Everything else in that group stays hidden as before.
+ * ------------------------------------------------------------------ */
+
+@media (min-width: 1200px) {
+  /* Extra room for the Ctrl/Cmd + K chips, which the plugin only renders
+     while the field is empty — exactly when the placeholder is showing. */
+  .navbar .navbar__search-input:placeholder-shown {
+    padding-right: 4.4rem;
+  }
+}
+
+@media (max-width: 1199px) {
+  /* Below this the navbar gets tight, so drop the hint and narrow the field
+     rather than let the right-hand group crowd the nav links. */
+  .navbar .navbar__search-input {
+    width: 11.5rem;
+  }
+
+  .navbar .navbar__search [class*='searchHintContainer_'] {
+    display: none;
+  }
+}
+
+@media (max-width: 1099px) {
+  .navbar__inner .navbar__items--right {
+    display: flex;
+  }
+
+  .navbar__inner .navbar__items--right > :not([class*='navbarSearchContainer_']) {
+    display: none;
+  }
+}
+
+@media (max-width: 996px) {
+  /*
+   * Below 996px the theme absolutely positions the search container. With no
+   * in-flow siblings left in the right group its static position lands on the
+   * navbar's centre line rather than on it, so pin it explicitly.
+   */
+  .navbar__inner [class*='navbarSearchContainer_'] {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .navbar [class*='searchBarContainer_'] {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 576px) {
+  /* Collapsed to an icon until focused, then wide enough to type in without
+     running under the logo. */
+  .navbar .navbar__search-input:not(:focus) {
+    width: 2.4rem;
+    padding-right: 0;
+  }
+
+  .navbar .navbar__search-input:focus {
+    width: min(55vw, 12rem);
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * /search — the standalone results page
+ *
+ * A "page" route, so it uses the light content palette. The plugin puts no
+ * stable class on the page wrapper, hence the :has() scope (shell.css
+ * already relies on :has() elsewhere).
+ * ------------------------------------------------------------------ */
+
+.main-wrapper .container:has(input[class*='searchQueryInput_']) {
+  max-width: var(--site-doc-max);
+}
+
+.main-wrapper .container:has(input[class*='searchQueryInput_']) > h1 {
+  margin-bottom: 1.5rem;
+  font-size: var(--site-text-h1);
+  line-height: var(--site-leading-tight);
+}
+
+.main-wrapper .container:has(input[class*='searchQueryInput_']) > p {
+  margin-bottom: 0.5rem;
+  color: var(--site-muted);
+  font-size: var(--site-text-caption);
+  font-weight: var(--site-font-weight-medium);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+input[class*='searchQueryInput_'] {
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--site-border-strong);
+  border-radius: 0.9rem;
+  background: var(--site-surface);
+  color: var(--site-text);
+  font-family: var(--ifm-font-family-base);
+  font-size: var(--site-text-body);
+  transition:
+    border-color var(--site-transition-fast),
+    box-shadow var(--site-transition-fast);
+}
+
+input[class*='searchQueryInput_']::placeholder {
+  color: var(--site-muted);
+}
+
+input[class*='searchQueryInput_']:hover {
+  border-color: var(--site-hover-border);
+}
+
+input[class*='searchQueryInput_']:focus {
+  border-color: var(--site-accent);
+  box-shadow: var(--site-hover-inset);
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
+}
+
+article[class*='searchResultItem_'] {
+  margin: 0 -0.9rem;
+  padding: 1.15rem 0.9rem;
+  border-bottom: 1px solid var(--site-border);
+  transition: background var(--site-transition-fast);
+}
+
+article[class*='searchResultItem_']:hover {
+  background: var(--site-hover-row-bg);
+}
+
+article[class*='searchResultItem_']:last-child {
+  border-bottom: 0;
+}
+
+article[class*='searchResultItem_'] > h2 {
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+article[class*='searchResultItem_'] > h2 a {
+  color: var(--site-text-strong);
+  transition: color var(--site-transition-fast);
+}
+
+article[class*='searchResultItem_'] > h2 a:hover {
+  color: var(--site-accent-strong);
+  text-decoration: underline;
+}
+
+article[class*='searchResultItem_'] > h2 a:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
+p[class*='searchResultItemPath_'] {
+  color: var(--site-muted);
+  font-size: var(--site-text-caption);
+}
+
+p[class*='searchResultItemSummary_'] {
+  color: var(--site-muted-bright);
+  font-size: var(--site-text-small);
+  font-style: normal;
+  line-height: var(--site-leading-normal);
+}
+
+/* The plugin marks matches on this page but never styles them, so they fall
+   back to the browser's yellow default. */
+article[class*='searchResultItem_'] mark {
+  padding: 0 0.15em;
+  border-radius: 3px;
+  background: var(--site-accent-soft);
+  color: var(--site-accent-strong);
+}
+
+/* ------------------------------------------------------------------ */
+
+@media (prefers-reduced-motion: reduce) {
+  .navbar .navbar__search-input,
+  .navbar .navbar__search [class*='searchClearButton_'],
+  .navbar .navbar__search [class*='suggestion_'],
+  .navbar .navbar__search [class*='hitAction_'],
+  .navbar .navbar__search [class*='hitFooter_'] a,
+  input[class*='searchQueryInput_'],
+  article[class*='searchResultItem_'],
+  article[class*='searchResultItem_'] > h2 a {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #2737

## Purpose

* Adds search functionality to the documentation via a navbar search box, making it much easier to find configuration options, CLI flags, and documentation pages without manually navigating the sidebar.
* Integrates `@easyops-cn/docusaurus-search-local`, which generates a static Lunr search index during the build process. This keeps search fully local with no external search provider, API limits, or operational overhead.
* For the initial release, search is limited to the current documentation version. Archived versions (`v0.1`–`v0.3`) are intentionally excluded to keep the search index lightweight. The configuration includes comments describing how version-specific indexing can be enabled in the future.
* Supports both English (`en`) and Simplified Chinese (`zh-Hans`).
* Module: `Docs` (website only)

## Test Plan

* Ran:

  * `npm ci`
  * `npm run build` (all locales and documentation versions)
  * `npm run lint`
* Manually verified:

  * `Ctrl+K` / `Cmd+K` shortcut on the homepage, blog, and documentation pages
  * English and Chinese search queries
  * `/search` page functionality
  * Keyboard navigation
  * Responsive behavior on narrow viewports

## Test Results

* Full build and lint completed successfully.
* English and Chinese queries both return the expected documentation pages. Chinese search uses `@node-rs/jieba` for tokenization via prebuilt binaries, so no native compilation is required during installation.
* Search UI has been styled to match the existing documentation design system.
* Known limitations for this initial release:

  * When browsing an archived documentation version, search results still point to the current documentation because only the current version is indexed.
  * The search input's `aria-label` is currently hard-coded to English by `@easyops-cn/docusaurus-search-local`, causing screen readers on the Chinese site to announce "Search" instead of a localized label. This is tracked as a follow-up improvement upstream.

English:

https://github.com/user-attachments/assets/95ed00a6-50e2-4d74-b17c-facd82dc710a

Chinese (zh-Hans):

<img width="2375" height="1288" alt="image" src="https://github.com/user-attachments/assets/20aa1388-6007-4997-8bd4-3baa5b407f66" />


