### PR TITLE
[Performance] Replace O(N) Redis scan with a secondary index

### DIFF
--- a/config/runtime/response-api/redis-simple.yaml
+++ b/config/runtime/response-api/redis-simple.yaml
@@ -49,8 +49,13 @@ tls_enabled: false
 #     pool_size: 10
 
 # Redis Key Schema:
-# sr:response:{response_id}      → JSON blob of StoredResponse
-# sr:conversation:{conv_id}      → JSON blob of StoredConversation
+# sr:response:{response_id}         → JSON blob of StoredResponse
+# sr:conversation:{conv_id}         → JSON blob of StoredConversation
+# sr:conversation-index:{conv_id}   → sorted set of response IDs in that conversation,
+#                                     scored by created_at. Maintained on write so
+#                                     listing a conversation is a single ZRANGE plus
+#                                     one pipelined GET per response, instead of a
+#                                     scan over every response key.
 #
 # Both Response API and Semantic Cache share DB 0 but use different base prefixes:
 # - Response API: sr:*

--- a/config/runtime/response-api/redis-simple.yaml
+++ b/config/runtime/response-api/redis-simple.yaml
@@ -49,13 +49,9 @@ tls_enabled: false
 #     pool_size: 10
 
 # Redis Key Schema:
-# sr:response:{response_id}         → JSON blob of StoredResponse
-# sr:conversation:{conv_id}         → JSON blob of StoredConversation
-# sr:conversation-index:{conv_id}   → sorted set of response IDs in that conversation,
-#                                     scored by created_at. Maintained on write so
-#                                     listing a conversation is a single ZRANGE plus
-#                                     one pipelined GET per response, instead of a
-#                                     scan over every response key.
+# sr:response:{response_id}      → JSON blob of StoredResponse
+# sr:conversation:{conv_id}      → JSON blob of StoredConversation
+# sr:conversation-index:{conv_id} → sorted set of response IDs, scored by created_at
 #
 # Both Response API and Semantic Cache share DB 0 but use different base prefixes:
 # - Response API: sr:*

--- a/src/semantic-router/pkg/responsestore/redis_store.go
+++ b/src/semantic-router/pkg/responsestore/redis_store.go
@@ -36,6 +36,16 @@ const (
 	// ConversationKeyPrefix for conversation keys
 	// Combined with key_prefix (default "sr:"): sr:conversation:conv_xxxxx
 	ConversationKeyPrefix = "conversation:"
+
+	// ConversationIndexKeyPrefix for the secondary index that maps a conversation
+	// to the responses it contains. The index is a sorted set scored by the
+	// response created_at, so listing a conversation costs one ZRANGE plus one
+	// pipelined GET per member instead of a scan over the whole keyspace.
+	// Combined with key_prefix (default "sr:"): sr:conversation-index:conv_xxxxx
+	//
+	// The prefix intentionally does not start with ConversationKeyPrefix so index
+	// keys are not matched by the sr:conversation:* scan in ListConversations.
+	ConversationIndexKeyPrefix = "conversation-index:"
 )
 
 // The function validates configuration, establishes connection, and tests connectivity.
@@ -281,6 +291,12 @@ func (s *RedisStore) buildKey(suffix string) string {
 	return s.keyPrefix + suffix
 }
 
+// conversationIndexKey returns the key of the sorted set indexing the responses
+// that belong to a conversation.
+func (s *RedisStore) conversationIndexKey(conversationID string) string {
+	return s.buildKey(ConversationIndexKeyPrefix + conversationID)
+}
+
 func (s *RedisStore) CheckConnection(ctx context.Context) error {
 	if !s.enabled {
 		return fmt.Errorf("redis store is disabled")
@@ -319,22 +335,23 @@ func (s *RedisStore) StoreResponse(ctx context.Context, response *responseapi.St
 
 	key := s.buildKey(ResponseKeyPrefix + response.ID)
 
-	exists, err := s.client.Exists(ctx, key).Result()
-	if err != nil {
-		return fmt.Errorf("failed to check response existence: %w", err)
-	}
-	if exists > 0 {
-		return ErrAlreadyExists
-	}
-
 	data, err := json.Marshal(response)
 	if err != nil {
 		return fmt.Errorf("failed to serialize response: %w", err)
 	}
 
-	if err := s.client.Set(ctx, key, data, s.ttl).Err(); err != nil {
+	// SET NX enforces the "must not already exist" contract in a single atomic
+	// command, and guarantees the payload is readable before the ID is published
+	// to the conversation index below.
+	stored, err := s.client.SetNX(ctx, key, data, s.ttl).Result()
+	if err != nil {
 		return fmt.Errorf("failed to store response in Redis: %w", err)
 	}
+	if !stored {
+		return ErrAlreadyExists
+	}
+
+	s.indexResponse(ctx, response.ConversationID, response.ID, response.CreatedAt)
 
 	return nil
 }
@@ -375,12 +392,11 @@ func (s *RedisStore) UpdateResponse(ctx context.Context, response *responseapi.S
 
 	key := s.buildKey(ResponseKeyPrefix + response.ID)
 
-	exists, err := s.client.Exists(ctx, key).Result()
+	// Reading the stored conversation doubles as the existence check and tells us
+	// whether the response is moving between conversations.
+	previousConversationID, err := s.storedConversationID(ctx, response.ID)
 	if err != nil {
-		return fmt.Errorf("failed to check response existence: %w", err)
-	}
-	if exists == 0 {
-		return ErrNotFound
+		return err
 	}
 
 	data, err := json.Marshal(response)
@@ -391,6 +407,11 @@ func (s *RedisStore) UpdateResponse(ctx context.Context, response *responseapi.S
 	if err := s.client.Set(ctx, key, data, s.ttl).Err(); err != nil {
 		return fmt.Errorf("failed to update response in Redis: %w", err)
 	}
+
+	if previousConversationID != "" && previousConversationID != response.ConversationID {
+		s.unindexResponse(ctx, previousConversationID, response.ID)
+	}
+	s.indexResponse(ctx, response.ConversationID, response.ID, response.CreatedAt)
 
 	return nil
 }
@@ -405,6 +426,13 @@ func (s *RedisStore) DeleteResponse(ctx context.Context, responseID string) erro
 
 	key := s.buildKey(ResponseKeyPrefix + responseID)
 
+	// Read the conversation first so its index entry can be dropped along with
+	// the payload; a missing key already means there is nothing to delete.
+	conversationID, err := s.storedConversationID(ctx, responseID)
+	if err != nil {
+		return err
+	}
+
 	deleted, err := s.client.Del(ctx, key).Result()
 	if err != nil {
 		return fmt.Errorf("failed to delete response from Redis: %w", err)
@@ -412,6 +440,8 @@ func (s *RedisStore) DeleteResponse(ctx context.Context, responseID string) erro
 	if deleted == 0 {
 		return ErrNotFound
 	}
+
+	s.unindexResponse(ctx, conversationID, responseID)
 
 	return nil
 }
@@ -437,7 +467,7 @@ func (s *RedisStore) GetConversationChain(ctx context.Context, responseID string
 	}
 
 	// Phase 2: Fetch all responses using pipelining
-	chain, err := s.fetchResponsesPipelined(ctx, responseIDs)
+	chain, _, err := s.fetchResponsesPipelined(ctx, responseIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -450,6 +480,12 @@ func (s *RedisStore) GetConversationChain(ctx context.Context, responseID string
 	return chain, nil
 }
 
+// ListResponsesByConversation lists a conversation's responses through the
+// secondary index maintained by the write paths.
+//
+// Only responses written by a router that maintains that index are listed here.
+// Responses persisted before the index existed stay fully retrievable by ID and
+// through GetConversationChain, and age out on their own TTL (30 days by default).
 func (s *RedisStore) ListResponsesByConversation(ctx context.Context, conversationID string, opts ListOptions) ([]*responseapi.StoredResponse, error) {
 	if !s.enabled {
 		return nil, ErrStoreDisabled
@@ -458,37 +494,36 @@ func (s *RedisStore) ListResponsesByConversation(ctx context.Context, conversati
 		return nil, ErrInvalidInput
 	}
 
-	// Use SCAN to find all response keys
-	pattern := s.buildKey(ResponseKeyPrefix + "*")
+	// The secondary index yields exactly this conversation's response IDs, in
+	// chronological order, so the work is proportional to the conversation rather
+	// than to the whole keyspace.
+	responseIDs, err := s.client.ZRange(ctx, s.conversationIndexKey(conversationID), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read conversation index: %w", err)
+	}
+	if len(responseIDs) == 0 {
+		return nil, nil
+	}
+
+	fetched, missingIDs, err := s.fetchResponsesPipelined(ctx, responseIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Payloads expire on their own TTL while index entries do not, so prune the
+	// entries we just found to be dead. The index cannot outlive its newest
+	// member, but pruning keeps a long-lived conversation's index bounded.
+	s.unindexResponse(ctx, conversationID, missingIDs...)
+
+	// Guard against an entry left behind by a response that moved conversation.
 	var responses []*responseapi.StoredResponse
-
-	iter := s.client.Scan(ctx, 0, pattern, 0).Iterator()
-	for iter.Next(ctx) {
-		key := iter.Val()
-
-		// Get response
-		data, err := s.client.Get(ctx, key).Bytes()
-		if err != nil {
-			continue // Skip errors (key might have expired)
-		}
-
-		var response responseapi.StoredResponse
-		if err := json.Unmarshal(data, &response); err != nil {
-			continue
-		}
-
+	for _, response := range fetched {
 		if response.ConversationID == conversationID {
-			responses = append(responses, &response)
+			responses = append(responses, response)
 		}
 	}
 
-	if err := iter.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan responses: %w", err)
-	}
-
-	responses = ApplyListOptions(responses, opts)
-
-	return responses, nil
+	return ApplyListOptions(responses, opts), nil
 }
 
 // Conversation Store Methods
@@ -598,16 +633,37 @@ func (s *RedisStore) DeleteConversation(ctx context.Context, conversationID stri
 
 	// Optionally delete all responses in the conversation
 	if deleteResponses {
-		responses, err := s.ListResponsesByConversation(ctx, conversationID, ListOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to list responses for deletion: %w", err)
+		if err := s.deleteConversationResponses(ctx, conversationID); err != nil {
+			return err
 		}
+	}
 
-		for _, resp := range responses {
-			if err := s.DeleteResponse(ctx, resp.ID); err != nil && !errors.Is(err, ErrNotFound) {
-				logging.Warnf("RedisStore: failed to delete response %s: %v", resp.ID, err)
-			}
-		}
+	return nil
+}
+
+// deleteConversationResponses removes every response indexed for a conversation
+// along with the index itself. It reads the index directly rather than going
+// through ListResponsesByConversation so the pagination limit cannot leave
+// responses behind.
+func (s *RedisStore) deleteConversationResponses(ctx context.Context, conversationID string) error {
+	indexKey := s.conversationIndexKey(conversationID)
+
+	responseIDs, err := s.client.ZRange(ctx, indexKey, 0, -1).Result()
+	if err != nil {
+		return fmt.Errorf("failed to list responses for deletion: %w", err)
+	}
+
+	pipe := s.client.Pipeline()
+	for _, responseID := range responseIDs {
+		pipe.Del(ctx, s.buildKey(ResponseKeyPrefix+responseID))
+	}
+	pipe.Del(ctx, indexKey)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		// The conversation itself is already gone, so report the leftovers instead
+		// of failing a delete the caller cannot usefully retry.
+		logging.Warnf("RedisStore: failed to delete %d response(s) of conversation %s: %v",
+			len(responseIDs), conversationID, err)
 	}
 
 	return nil
@@ -657,12 +713,84 @@ func (s *RedisStore) AddResponseToConversation(ctx context.Context, conversation
 		return ErrInvalidInput
 	}
 
-	// This is automatically handled by the conversation chain via previous_response_id
-	// This method can be used to update conversation metadata if needed
+	// Membership is recorded by StoreResponse, which indexes the response under
+	// its ConversationID, and traversal is handled by previous_response_id.
+	// This method can be used to update conversation metadata if needed.
 	return nil
 }
 
 // Helper methods
+
+// indexResponse publishes a response ID into its conversation's secondary index,
+// scored by creation time so the index reads back in chronological order.
+//
+// Failures are logged rather than returned: the payload is already stored and
+// stays reachable by ID and through its chain, so failing the whole write (which
+// the caller could only retry into ErrAlreadyExists) would be worse than leaving
+// this one response out of the conversation listing.
+func (s *RedisStore) indexResponse(ctx context.Context, conversationID, responseID string, createdAt int64) {
+	if conversationID == "" {
+		return
+	}
+
+	indexKey := s.conversationIndexKey(conversationID)
+
+	pipe := s.client.Pipeline()
+	pipe.ZAdd(ctx, indexKey, redis.Z{Score: float64(createdAt), Member: responseID})
+	if s.ttl > 0 {
+		// Keep the index alive at least as long as its newest member. Guarded
+		// because EXPIRE with a zero TTL deletes the key outright.
+		pipe.Expire(ctx, indexKey, s.ttl)
+	}
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		logging.Warnf("RedisStore: failed to index response %s in conversation %s: %v",
+			responseID, conversationID, err)
+	}
+}
+
+// unindexResponse drops response IDs from a conversation's secondary index.
+// Like indexResponse it is best-effort: a stale entry only costs one extra GET
+// on the next listing, which then prunes it.
+func (s *RedisStore) unindexResponse(ctx context.Context, conversationID string, responseIDs ...string) {
+	if conversationID == "" || len(responseIDs) == 0 {
+		return
+	}
+
+	members := make([]interface{}, len(responseIDs))
+	for i, responseID := range responseIDs {
+		members[i] = responseID
+	}
+
+	if err := s.client.ZRem(ctx, s.conversationIndexKey(conversationID), members...).Err(); err != nil {
+		logging.Warnf("RedisStore: failed to remove %d response(s) from conversation %s index: %v",
+			len(responseIDs), conversationID, err)
+	}
+}
+
+// storedConversationID reports which conversation a response currently belongs
+// to, so update and delete can repair the index they invalidate. It doubles as
+// the existence check for those paths and returns ErrNotFound when the response
+// is absent. An unreadable payload is not fatal: the caller may still overwrite
+// or delete the key, it just cannot repair the old index entry.
+func (s *RedisStore) storedConversationID(ctx context.Context, responseID string) (string, error) {
+	data, err := s.client.Get(ctx, s.buildKey(ResponseKeyPrefix+responseID)).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("failed to check response existence: %w", err)
+	}
+
+	var stored responseapi.StoredResponse
+	if err := json.Unmarshal(data, &stored); err != nil {
+		logging.Warnf("RedisStore: failed to parse stored response %s while updating its conversation index: %v",
+			responseID, err)
+		return "", nil
+	}
+
+	return stored.ConversationID, nil
+}
 
 func (s *RedisStore) collectChainIDs(ctx context.Context, startID string) ([]string, error) {
 	var responseIDs []string
@@ -702,9 +830,12 @@ func (s *RedisStore) collectChainIDs(ctx context.Context, startID string) ([]str
 	return responseIDs, nil
 }
 
-func (s *RedisStore) fetchResponsesPipelined(ctx context.Context, responseIDs []string) ([]*responseapi.StoredResponse, error) {
+// fetchResponsesPipelined loads the given response IDs in a single round trip.
+// Alongside the responses it found, it returns the IDs whose payload no longer
+// exists, which lets index-driven callers prune their stale entries.
+func (s *RedisStore) fetchResponsesPipelined(ctx context.Context, responseIDs []string) ([]*responseapi.StoredResponse, []string, error) {
 	if len(responseIDs) == 0 {
-		return []*responseapi.StoredResponse{}, nil
+		return []*responseapi.StoredResponse{}, nil, nil
 	}
 
 	pipe := s.client.Pipeline()
@@ -722,12 +853,16 @@ func (s *RedisStore) fetchResponsesPipelined(ctx context.Context, responseIDs []
 	}
 
 	// Process results
-	var chain []*responseapi.StoredResponse
+	var (
+		found      []*responseapi.StoredResponse
+		missingIDs []string
+	)
 	for i, cmd := range cmds {
 		data, err := cmd.Bytes()
 		if err != nil {
 			if errors.Is(err, redis.Nil) {
 				logging.Warnf("RedisStore: response %s not found (may have expired)", responseIDs[i])
+				missingIDs = append(missingIDs, responseIDs[i])
 				continue
 			}
 			logging.Warnf("RedisStore: failed to get response %s: %v", responseIDs[i], err)
@@ -740,8 +875,8 @@ func (s *RedisStore) fetchResponsesPipelined(ctx context.Context, responseIDs []
 			continue
 		}
 
-		chain = append(chain, &response)
+		found = append(found, &response)
 	}
 
-	return chain, nil
+	return found, missingIDs, nil
 }

--- a/src/semantic-router/pkg/responsestore/redis_store.go
+++ b/src/semantic-router/pkg/responsestore/redis_store.go
@@ -37,14 +37,11 @@ const (
 	// Combined with key_prefix (default "sr:"): sr:conversation:conv_xxxxx
 	ConversationKeyPrefix = "conversation:"
 
-	// ConversationIndexKeyPrefix for the secondary index that maps a conversation
-	// to the responses it contains. The index is a sorted set scored by the
-	// response created_at, so listing a conversation costs one ZRANGE plus one
-	// pipelined GET per member instead of a scan over the whole keyspace.
-	// Combined with key_prefix (default "sr:"): sr:conversation-index:conv_xxxxx
+	// ConversationIndexKeyPrefix for the sorted set of a conversation's response
+	// IDs, scored by created_at: sr:conversation-index:conv_xxxxx
 	//
-	// The prefix intentionally does not start with ConversationKeyPrefix so index
-	// keys are not matched by the sr:conversation:* scan in ListConversations.
+	// Must not start with ConversationKeyPrefix, or the sr:conversation:* scan in
+	// ListConversations would read these sorted sets as conversation JSON.
 	ConversationIndexKeyPrefix = "conversation-index:"
 )
 
@@ -291,8 +288,7 @@ func (s *RedisStore) buildKey(suffix string) string {
 	return s.keyPrefix + suffix
 }
 
-// conversationIndexKey returns the key of the sorted set indexing the responses
-// that belong to a conversation.
+// conversationIndexKey returns the sorted set indexing a conversation's responses.
 func (s *RedisStore) conversationIndexKey(conversationID string) string {
 	return s.buildKey(ConversationIndexKeyPrefix + conversationID)
 }
@@ -340,9 +336,8 @@ func (s *RedisStore) StoreResponse(ctx context.Context, response *responseapi.St
 		return fmt.Errorf("failed to serialize response: %w", err)
 	}
 
-	// SET NX enforces the "must not already exist" contract in a single atomic
-	// command, and guarantees the payload is readable before the ID is published
-	// to the conversation index below.
+	// Atomic existence check, and it lands the payload before the index entry, so
+	// a member always postdates its payload — what makes prune-on-missing safe.
 	stored, err := s.client.SetNX(ctx, key, data, s.ttl).Result()
 	if err != nil {
 		return fmt.Errorf("failed to store response in Redis: %w", err)
@@ -392,8 +387,7 @@ func (s *RedisStore) UpdateResponse(ctx context.Context, response *responseapi.S
 
 	key := s.buildKey(ResponseKeyPrefix + response.ID)
 
-	// Reading the stored conversation doubles as the existence check and tells us
-	// whether the response is moving between conversations.
+	// Doubles as the existence check, and detects a move between conversations.
 	previousConversationID, err := s.storedConversationID(ctx, response.ID)
 	if err != nil {
 		return err
@@ -426,8 +420,7 @@ func (s *RedisStore) DeleteResponse(ctx context.Context, responseID string) erro
 
 	key := s.buildKey(ResponseKeyPrefix + responseID)
 
-	// Read the conversation first so its index entry can be dropped along with
-	// the payload; a missing key already means there is nothing to delete.
+	// Needed to drop the index entry; also the existence check.
 	conversationID, err := s.storedConversationID(ctx, responseID)
 	if err != nil {
 		return err
@@ -480,12 +473,11 @@ func (s *RedisStore) GetConversationChain(ctx context.Context, responseID string
 	return chain, nil
 }
 
-// ListResponsesByConversation lists a conversation's responses through the
-// secondary index maintained by the write paths.
+// ListResponsesByConversation lists a conversation's responses via the secondary
+// index, at a cost proportional to the conversation rather than the keyspace.
 //
-// Only responses written by a router that maintains that index are listed here.
-// Responses persisted before the index existed stay fully retrievable by ID and
-// through GetConversationChain, and age out on their own TTL (30 days by default).
+// Only indexed responses are listed. Anything written before the index existed
+// stays reachable by ID and via GetConversationChain, and ages out on its TTL.
 func (s *RedisStore) ListResponsesByConversation(ctx context.Context, conversationID string, opts ListOptions) ([]*responseapi.StoredResponse, error) {
 	if !s.enabled {
 		return nil, ErrStoreDisabled
@@ -494,9 +486,7 @@ func (s *RedisStore) ListResponsesByConversation(ctx context.Context, conversati
 		return nil, ErrInvalidInput
 	}
 
-	// The secondary index yields exactly this conversation's response IDs, in
-	// chronological order, so the work is proportional to the conversation rather
-	// than to the whole keyspace.
+	// Scored by created_at, so this reads back chronologically.
 	responseIDs, err := s.client.ZRange(ctx, s.conversationIndexKey(conversationID), 0, -1).Result()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read conversation index: %w", err)
@@ -510,9 +500,8 @@ func (s *RedisStore) ListResponsesByConversation(ctx context.Context, conversati
 		return nil, err
 	}
 
-	// Payloads expire on their own TTL while index entries do not, so prune the
-	// entries we just found to be dead. The index cannot outlive its newest
-	// member, but pruning keeps a long-lived conversation's index bounded.
+	// Payloads expire on their own TTL; their index entries do not. Pruning keeps
+	// a long-lived conversation's index from growing without bound.
 	s.unindexResponse(ctx, conversationID, missingIDs...)
 
 	// Guard against an entry left behind by a response that moved conversation.
@@ -641,10 +630,9 @@ func (s *RedisStore) DeleteConversation(ctx context.Context, conversationID stri
 	return nil
 }
 
-// deleteConversationResponses removes every response indexed for a conversation
-// along with the index itself. It reads the index directly rather than going
-// through ListResponsesByConversation so the pagination limit cannot leave
-// responses behind.
+// deleteConversationResponses removes a conversation's responses and its index.
+// Reads the index directly: going via ListResponsesByConversation would cap the
+// cascade at the pagination limit.
 func (s *RedisStore) deleteConversationResponses(ctx context.Context, conversationID string) error {
 	indexKey := s.conversationIndexKey(conversationID)
 
@@ -660,8 +648,7 @@ func (s *RedisStore) deleteConversationResponses(ctx context.Context, conversati
 	pipe.Del(ctx, indexKey)
 
 	if _, err := pipe.Exec(ctx); err != nil {
-		// The conversation itself is already gone, so report the leftovers instead
-		// of failing a delete the caller cannot usefully retry.
+		// Conversation is already gone; a returned error could not be usefully retried.
 		logging.Warnf("RedisStore: failed to delete %d response(s) of conversation %s: %v",
 			len(responseIDs), conversationID, err)
 	}
@@ -713,21 +700,17 @@ func (s *RedisStore) AddResponseToConversation(ctx context.Context, conversation
 		return ErrInvalidInput
 	}
 
-	// Membership is recorded by StoreResponse, which indexes the response under
-	// its ConversationID, and traversal is handled by previous_response_id.
-	// This method can be used to update conversation metadata if needed.
+	// Membership is recorded by StoreResponse via the conversation index, and
+	// traversal by previous_response_id. Kept for conversation metadata updates.
 	return nil
 }
 
 // Helper methods
 
-// indexResponse publishes a response ID into its conversation's secondary index,
-// scored by creation time so the index reads back in chronological order.
+// indexResponse adds a response to its conversation index, scored by created_at.
 //
-// Failures are logged rather than returned: the payload is already stored and
-// stays reachable by ID and through its chain, so failing the whole write (which
-// the caller could only retry into ErrAlreadyExists) would be worse than leaving
-// this one response out of the conversation listing.
+// Best-effort: the payload is already durable, and returning an error would only
+// send the caller into a retry that fails with ErrAlreadyExists.
 func (s *RedisStore) indexResponse(ctx context.Context, conversationID, responseID string, createdAt int64) {
 	if conversationID == "" {
 		return
@@ -738,8 +721,7 @@ func (s *RedisStore) indexResponse(ctx context.Context, conversationID, response
 	pipe := s.client.Pipeline()
 	pipe.ZAdd(ctx, indexKey, redis.Z{Score: float64(createdAt), Member: responseID})
 	if s.ttl > 0 {
-		// Keep the index alive at least as long as its newest member. Guarded
-		// because EXPIRE with a zero TTL deletes the key outright.
+		// Outlive the newest member. Guarded: EXPIRE with 0 deletes the key.
 		pipe.Expire(ctx, indexKey, s.ttl)
 	}
 
@@ -749,9 +731,8 @@ func (s *RedisStore) indexResponse(ctx context.Context, conversationID, response
 	}
 }
 
-// unindexResponse drops response IDs from a conversation's secondary index.
-// Like indexResponse it is best-effort: a stale entry only costs one extra GET
-// on the next listing, which then prunes it.
+// unindexResponse drops response IDs from a conversation index. Best-effort: a
+// stale entry costs one extra GET on the next listing, which then prunes it.
 func (s *RedisStore) unindexResponse(ctx context.Context, conversationID string, responseIDs ...string) {
 	if conversationID == "" || len(responseIDs) == 0 {
 		return
@@ -768,11 +749,9 @@ func (s *RedisStore) unindexResponse(ctx context.Context, conversationID string,
 	}
 }
 
-// storedConversationID reports which conversation a response currently belongs
-// to, so update and delete can repair the index they invalidate. It doubles as
-// the existence check for those paths and returns ErrNotFound when the response
-// is absent. An unreadable payload is not fatal: the caller may still overwrite
-// or delete the key, it just cannot repair the old index entry.
+// storedConversationID reports a response's current conversation so update and
+// delete can repair the index, and returns ErrNotFound when it is absent. An
+// unreadable payload is not fatal, it only costs the old index entry.
 func (s *RedisStore) storedConversationID(ctx context.Context, responseID string) (string, error) {
 	data, err := s.client.Get(ctx, s.buildKey(ResponseKeyPrefix+responseID)).Bytes()
 	if err != nil {
@@ -830,9 +809,8 @@ func (s *RedisStore) collectChainIDs(ctx context.Context, startID string) ([]str
 	return responseIDs, nil
 }
 
-// fetchResponsesPipelined loads the given response IDs in a single round trip.
-// Alongside the responses it found, it returns the IDs whose payload no longer
-// exists, which lets index-driven callers prune their stale entries.
+// fetchResponsesPipelined loads response IDs in one round trip, also returning
+// the IDs whose payload is gone so index-driven callers can prune them.
 func (s *RedisStore) fetchResponsesPipelined(ctx context.Context, responseIDs []string) ([]*responseapi.StoredResponse, []string, error) {
 	if len(responseIDs) == 0 {
 		return []*responseapi.StoredResponse{}, nil, nil

--- a/src/semantic-router/pkg/responsestore/redis_store_test.go
+++ b/src/semantic-router/pkg/responsestore/redis_store_test.go
@@ -466,21 +466,16 @@ func TestTLSConfig(t *testing.T) {
 	})
 }
 
-// TestRedisConversationIndexKeyIsolation locks down the invariant that makes the
-// secondary index safe to add to an existing keyspace: index keys must stay
-// invisible to the scan patterns used elsewhere. ListConversations scans
-// sr:conversation:* and unmarshals every hit as JSON, so a sorted set caught by
-// that pattern would be read as a conversation blob.
-//
-// This needs no Redis, so it guards the invariant on every CI run.
+// TestRedisConversationIndexKeyIsolation guards the invariant that index keys are
+// invisible to the sr:conversation:* scan in ListConversations, which would
+// otherwise read a sorted set as conversation JSON. Needs no Redis.
 func TestRedisConversationIndexKeyIsolation(t *testing.T) {
 	store := &RedisStore{keyPrefix: "sr:"}
 
 	indexKey := store.conversationIndexKey("conv_123")
 	assert.Equal(t, "sr:conversation-index:conv_123", indexKey)
 
-	// Both scan patterns are a literal prefix followed by "*", so being matched
-	// by one is exactly the same as carrying its prefix.
+	// Each scan pattern is a literal prefix plus "*", so matching == having it.
 	for _, scanPrefix := range []string{
 		store.buildKey(ConversationKeyPrefix),
 		store.buildKey(ResponseKeyPrefix),
@@ -490,9 +485,8 @@ func TestRedisConversationIndexKeyIsolation(t *testing.T) {
 	}
 }
 
-// conversationIndexMembers returns the response IDs recorded in a conversation's
-// secondary index, so tests can assert on the index itself rather than only on
-// what a listing happens to return.
+// conversationIndexMembers reads the index directly, so tests can assert on it
+// and not only on what a listing happens to return.
 func conversationIndexMembers(t *testing.T, store *RedisStore, conversationID string) []string {
 	t.Helper()
 
@@ -501,9 +495,8 @@ func conversationIndexMembers(t *testing.T, store *RedisStore, conversationID st
 	return members
 }
 
-// newConversationIndexStore returns a store scoped to a key prefix unique to this
-// run, so its keys cannot collide with the other suites sharing DB 0, and skips
-// when no Redis is reachable (the convention used throughout this file).
+// newConversationIndexStore scopes the store to a key prefix unique to this run,
+// so it cannot collide with the other suites sharing DB 0. Skips without Redis.
 func newConversationIndexStore(t *testing.T) *RedisStore {
 	t.Helper()
 
@@ -536,8 +529,7 @@ func newConversationIndexStore(t *testing.T) *RedisStore {
 }
 
 // TestRedisConversationIndexListing covers the index-backed read path: what it
-// returns, in what order, and how it converges when the index and the payloads
-// disagree.
+// returns, in what order, and how it converges when index and payloads disagree.
 func TestRedisConversationIndexListing(t *testing.T) {
 	store := newConversationIndexStore(t)
 	ctx := context.Background()
@@ -625,9 +617,8 @@ func TestRedisConversationIndexListing(t *testing.T) {
 	})
 }
 
-// TestRedisDeleteConversationCascade covers a conversation holding more responses
-// than one page: the cascade reads the index directly, so it must not stop at
-// DefaultListLimit the way the previous list-driven implementation did.
+// TestRedisDeleteConversationCascade uses more responses than one page: the
+// cascade reads the index directly, so it must not stop at DefaultListLimit.
 func TestRedisDeleteConversationCascade(t *testing.T) {
 	store := newConversationIndexStore(t)
 	ctx := context.Background()
@@ -675,9 +666,8 @@ func TestRedisDeleteConversationCascade(t *testing.T) {
 	assert.Equal(t, "kept", survivor.Status)
 }
 
-// TestRedisStoreResponseRejectsDuplicate covers the SET NX path that both enforces
-// the "must not already exist" contract and orders the payload write ahead of the
-// index write.
+// TestRedisStoreResponseRejectsDuplicate covers the SET NX path: it enforces the
+// no-duplicate contract and orders the payload write ahead of the index write.
 func TestRedisStoreResponseRejectsDuplicate(t *testing.T) {
 	store := newConversationIndexStore(t)
 	ctx := context.Background()

--- a/src/semantic-router/pkg/responsestore/redis_store_test.go
+++ b/src/semantic-router/pkg/responsestore/redis_store_test.go
@@ -2,9 +2,12 @@ package responsestore
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -461,4 +464,239 @@ func TestTLSConfig(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
+}
+
+// TestRedisConversationIndexKeyIsolation locks down the invariant that makes the
+// secondary index safe to add to an existing keyspace: index keys must stay
+// invisible to the scan patterns used elsewhere. ListConversations scans
+// sr:conversation:* and unmarshals every hit as JSON, so a sorted set caught by
+// that pattern would be read as a conversation blob.
+//
+// This needs no Redis, so it guards the invariant on every CI run.
+func TestRedisConversationIndexKeyIsolation(t *testing.T) {
+	store := &RedisStore{keyPrefix: "sr:"}
+
+	indexKey := store.conversationIndexKey("conv_123")
+	assert.Equal(t, "sr:conversation-index:conv_123", indexKey)
+
+	// Both scan patterns are a literal prefix followed by "*", so being matched
+	// by one is exactly the same as carrying its prefix.
+	for _, scanPrefix := range []string{
+		store.buildKey(ConversationKeyPrefix),
+		store.buildKey(ResponseKeyPrefix),
+	} {
+		assert.Falsef(t, strings.HasPrefix(indexKey, scanPrefix),
+			"index key %q must not be matched by the %q* scan pattern", indexKey, scanPrefix)
+	}
+}
+
+// conversationIndexMembers returns the response IDs recorded in a conversation's
+// secondary index, so tests can assert on the index itself rather than only on
+// what a listing happens to return.
+func conversationIndexMembers(t *testing.T, store *RedisStore, conversationID string) []string {
+	t.Helper()
+
+	members, err := store.client.ZRange(context.Background(), store.conversationIndexKey(conversationID), 0, -1).Result()
+	require.NoError(t, err)
+	return members
+}
+
+// newConversationIndexStore returns a store scoped to a key prefix unique to this
+// run, so its keys cannot collide with the other suites sharing DB 0, and skips
+// when no Redis is reachable (the convention used throughout this file).
+func newConversationIndexStore(t *testing.T) *RedisStore {
+	t.Helper()
+
+	cfg := StoreConfig{
+		Enabled:     true,
+		TTLSeconds:  300,
+		BackendType: RedisStoreType,
+		Redis: RedisStoreConfig{
+			Address:   "localhost:6379",
+			DB:        0,
+			KeyPrefix: fmt.Sprintf("srtest:%d:", time.Now().UnixNano()),
+		},
+	}
+
+	store, err := NewRedisStore(cfg)
+	if err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		iter := store.client.Scan(ctx, 0, store.buildKey("*"), 0).Iterator()
+		for iter.Next(ctx) {
+			store.client.Del(ctx, iter.Val())
+		}
+		_ = store.Close()
+	})
+
+	return store
+}
+
+// TestRedisConversationIndexListing covers the index-backed read path: what it
+// returns, in what order, and how it converges when the index and the payloads
+// disagree.
+func TestRedisConversationIndexListing(t *testing.T) {
+	store := newConversationIndexStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	storeResponse := func(t *testing.T, id, convID string, createdAt int64) {
+		t.Helper()
+		require.NoError(t, store.StoreResponse(ctx, &responseapi.StoredResponse{
+			ID:             id,
+			ConversationID: convID,
+			Status:         "completed",
+			CreatedAt:      createdAt,
+			Output:         []responseapi.OutputItem{{ID: "item_" + id}},
+		}))
+	}
+
+	t.Run("returns only the requested conversation, oldest first", func(t *testing.T) {
+		storeResponse(t, "resp_idx_a1", "conv_idx_a", now)
+		storeResponse(t, "resp_idx_a2", "conv_idx_a", now+1)
+		storeResponse(t, "resp_idx_b1", "conv_idx_b", now)
+		// A response with no conversation must not land in any index.
+		storeResponse(t, "resp_idx_orphan", "", now)
+
+		responses, err := store.ListResponsesByConversation(ctx, "conv_idx_a", ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, responses, 2)
+		// The index is scored by created_at, so it reads back chronologically.
+		assert.Equal(t, "resp_idx_a1", responses[0].ID)
+		assert.Equal(t, "resp_idx_a2", responses[1].ID)
+
+		assert.Equal(t, []string{"resp_idx_a1", "resp_idx_a2"}, conversationIndexMembers(t, store, "conv_idx_a"))
+		assert.Equal(t, []string{"resp_idx_b1"}, conversationIndexMembers(t, store, "conv_idx_b"))
+	})
+
+	t.Run("unknown conversation returns nothing", func(t *testing.T) {
+		responses, err := store.ListResponsesByConversation(ctx, "conv_idx_missing", ListOptions{})
+		assert.NoError(t, err)
+		assert.Empty(t, responses)
+	})
+
+	t.Run("empty conversation ID is rejected", func(t *testing.T) {
+		_, err := store.ListResponsesByConversation(ctx, "", ListOptions{})
+		assert.ErrorIs(t, err, ErrInvalidInput)
+	})
+
+	t.Run("deleting a response drops its index entry", func(t *testing.T) {
+		require.NoError(t, store.DeleteResponse(ctx, "resp_idx_a1"))
+
+		assert.Equal(t, []string{"resp_idx_a2"}, conversationIndexMembers(t, store, "conv_idx_a"))
+
+		responses, err := store.ListResponsesByConversation(ctx, "conv_idx_a", ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+		assert.Equal(t, "resp_idx_a2", responses[0].ID)
+	})
+
+	t.Run("moving a response between conversations reindexes it", func(t *testing.T) {
+		moved, err := store.GetResponse(ctx, "resp_idx_a2")
+		require.NoError(t, err)
+
+		moved.ConversationID = "conv_idx_b"
+		require.NoError(t, store.UpdateResponse(ctx, moved))
+
+		fromOld, err := store.ListResponsesByConversation(ctx, "conv_idx_a", ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, fromOld)
+		assert.Empty(t, conversationIndexMembers(t, store, "conv_idx_a"))
+
+		toNew, err := store.ListResponsesByConversation(ctx, "conv_idx_b", ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, toNew, 2)
+		assert.Equal(t, []string{"resp_idx_b1", "resp_idx_a2"}, []string{toNew[0].ID, toNew[1].ID})
+	})
+
+	t.Run("listing prunes entries whose payload is gone", func(t *testing.T) {
+		// Drop the payload behind the store's back, the way a TTL expiry would.
+		require.NoError(t, store.client.Del(ctx, store.buildKey(ResponseKeyPrefix+"resp_idx_b1")).Err())
+
+		responses, err := store.ListResponsesByConversation(ctx, "conv_idx_b", ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, responses, 1)
+		assert.Equal(t, "resp_idx_a2", responses[0].ID)
+
+		assert.Equal(t, []string{"resp_idx_a2"}, conversationIndexMembers(t, store, "conv_idx_b"))
+	})
+}
+
+// TestRedisDeleteConversationCascade covers a conversation holding more responses
+// than one page: the cascade reads the index directly, so it must not stop at
+// DefaultListLimit the way the previous list-driven implementation did.
+func TestRedisDeleteConversationCascade(t *testing.T) {
+	store := newConversationIndexStore(t)
+	ctx := context.Background()
+
+	const (
+		convID      = "conv_cascade"
+		responseCnt = DefaultListLimit + 5
+		otherConvID = "conv_cascade_other"
+		otherRespID = "resp_cascade_other"
+	)
+
+	require.NoError(t, store.CreateConversation(ctx, &responseapi.StoredConversation{
+		ID:        convID,
+		CreatedAt: time.Now().Unix(),
+	}))
+
+	for i := 0; i < responseCnt; i++ {
+		require.NoError(t, store.StoreResponse(ctx, &responseapi.StoredResponse{
+			ID:             fmt.Sprintf("resp_cascade_%d", i),
+			ConversationID: convID,
+			Status:         "completed",
+			CreatedAt:      time.Now().Unix() + int64(i),
+			Output:         []responseapi.OutputItem{{ID: fmt.Sprintf("item_%d", i)}},
+		}))
+	}
+
+	// A response in a different conversation must survive the cascade.
+	require.NoError(t, store.StoreResponse(ctx, &responseapi.StoredResponse{
+		ID:             otherRespID,
+		ConversationID: otherConvID,
+		Status:         "kept",
+		CreatedAt:      time.Now().Unix(),
+	}))
+
+	require.NoError(t, store.DeleteConversation(ctx, convID, true))
+
+	for i := 0; i < responseCnt; i++ {
+		_, err := store.GetResponse(ctx, fmt.Sprintf("resp_cascade_%d", i))
+		assert.ErrorIsf(t, err, ErrNotFound, "response %d should have been deleted with its conversation", i)
+	}
+	assert.Empty(t, conversationIndexMembers(t, store, convID))
+
+	survivor, err := store.GetResponse(ctx, otherRespID)
+	require.NoError(t, err)
+	assert.Equal(t, "kept", survivor.Status)
+}
+
+// TestRedisStoreResponseRejectsDuplicate covers the SET NX path that both enforces
+// the "must not already exist" contract and orders the payload write ahead of the
+// index write.
+func TestRedisStoreResponseRejectsDuplicate(t *testing.T) {
+	store := newConversationIndexStore(t)
+	ctx := context.Background()
+
+	response := &responseapi.StoredResponse{
+		ID:             "resp_duplicate",
+		ConversationID: "conv_duplicate",
+		Status:         "completed",
+		CreatedAt:      time.Now().Unix(),
+	}
+	require.NoError(t, store.StoreResponse(ctx, response))
+
+	duplicate := *response
+	duplicate.Status = "overwritten"
+	assert.ErrorIs(t, store.StoreResponse(ctx, &duplicate), ErrAlreadyExists)
+
+	// The original payload must be untouched, and indexed exactly once.
+	stored, err := store.GetResponse(ctx, response.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", stored.Status)
+	assert.Equal(t, []string{"resp_duplicate"}, conversationIndexMembers(t, store, "conv_duplicate"))
 }


### PR DESCRIPTION
Description  Polished with AI

<html><head></head><body><h1>perf: optimize ListResponsesByConversation with a secondary Redis index</h1><h2>Summary</h2><p>Replaced the full Redis keyspace scan in <code inline="">ListResponsesByConversation</code> with a secondary sorted-set index keyed by conversation ID.</p><p>The read path now scales with the number of responses in the requested conversation instead of the total number of responses stored in Redis.</p><h2>Issue</h2><p><code inline="">RedisStore.ListResponsesByConversation</code> previously:</p><ol><li><p>Scanned the entire response keyspace.</p></li><li><p>Issued an individual <code inline="">GET</code> for every response key.</p></li><li><p>Unmarshalled every response.</p></li><li><p>Filtered by <code inline="">conversationID</code> in memory.</p></li></ol><p>This made the operation <strong>O(N)</strong> in the total number of stored responses rather than the number of responses belonging to the requested conversation.</p><p>As the Redis dataset grew, latency increased linearly and most of the fetched payloads were immediately discarded.</p><h2>Fix</h2><p>Added a secondary Redis index:</p><pre><code class="language-text">sr:conversation-index:{conversation_id}
</code></pre><p>The index is a sorted set containing response IDs scored by <code inline="">created_at</code>.</p><h3>Read path</h3><p>The new flow is:</p><pre><code class="language-text">ZRANGE conversation-index
        ↓
response IDs for requested conversation
        ↓
pipelined GET
        ↓
unmarshal only requested responses
</code></pre><p>This reduces the read path to:</p><ul><li><p>1 <code inline="">ZRANGE</code></p></li><li><p>1 pipelined batch of <code inline="">GET</code>s</p></li></ul><p>instead of scanning the entire response keyspace.</p><h3>Write path changes</h3><ul><li><p><strong><code inline="">StoreResponse</code></strong></p><ul><li><p>Replaced <code inline="">EXISTS</code> + <code inline="">SET</code> with atomic <code inline="">SET NX EX</code>.</p></li><li><p>Preserves the existing <code inline="">ErrAlreadyExists</code> contract.</p></li><li><p>Eliminates the pre-existing TOCTOU race.</p></li><li><p>Writes the payload before adding the index entry, making prune-on-missing safe even when Redis Cluster places the keys on different nodes.</p></li></ul></li><li><p><strong><code inline="">UpdateResponse</code> / <code inline="">DeleteResponse</code></strong></p><ul><li><p>Read the stored conversation ID to move or remove the corresponding index entry.</p></li><li><p><code inline="">UpdateResponse</code> no longer requires a separate <code inline="">EXISTS</code> probe.</p></li></ul></li><li><p><strong>Expiry</strong></p><ul><li><p>Response payloads already expire through their TTL.</p></li><li><p>Sorted-set members do not expire individually, so the index key TTL is refreshed whenever an entry is added.</p></li><li><p>TTL refresh is guarded by <code inline="">s.ttl &gt; 0</code> because <code inline="">EXPIRE key 0</code> deletes the key.</p></li><li><p>Listings prune index entries whose response payload no longer exists.</p></li></ul></li><li><p><strong>Index write failures</strong></p><ul><li><p>Logged but not returned to the caller.</p></li><li><p>The response payload is already durable, and returning the index error would cause callers to retry and potentially receive <code inline="">ErrAlreadyExists</code>.</p></li></ul></li><li><p><strong>Conversation ID validation</strong></p><ul><li><p>Retained the existing <code inline="">ConversationID</code> equality check as a guard against index skew.</p></li></ul></li><li><p><strong>Redis Cluster</strong></p><ul><li><p>No multi-key commands span Redis Cluster slots.</p></li><li><p>The only same-key pipeline pair, <code inline="">ZADD</code> + <code inline="">EXPIRE</code>, operates on the index key.</p></li></ul></li></ul><p>The index prefix intentionally does not start with <code inline="">conversation:</code> so these keys are excluded from the <code inline="">sr:conversation:*</code> scan used by <code inline="">ListConversations</code>.</p><h2>Related Bugs Fixed</h2><h3>1. <code inline="">DeleteConversation</code> cascade limit</h3><p><code inline="">DeleteConversation(id, deleteResponses=true)</code> previously called <code inline="">ListResponsesByConversation</code> with the default <code inline="">DefaultListLimit</code> of <strong>20</strong>.</p><p>As a result, conversations with more than 20 responses silently deleted only the first 20 responses.</p><p>The cascade now reads directly from the conversation index and deletes all indexed responses along with the index key.</p><h3>2. Response ordering</h3><p><code inline="">SCAN</code> does not guarantee ordering, despite <code inline="">ResponseStore</code> documenting chronological ordering.</p><p>The new index uses <code inline="">created_at</code> as the sorted-set score, so responses are now returned chronologically, matching <code inline="">MemoryStore</code>.</p><h2>Performance Impact</h2><p>Measured against local Redis with:</p><ul><li><p>5,000 responses</p></li><li><p>500 conversations</p></li><li><p>5,500 total Redis keys</p></li><li><p>10 responses in the requested conversation</p></li></ul>
Metric | Before | After
-- | -- | --
Cost scales with | Total responses in Redis | Responses in requested conversation
Redis operations | ~550 SCAN + 5,000 sequential GET | 1 ZRANGE + 10 pipelined GET
Commands | ~5,550 | 1 ZRANGE + 10 pipelined GET
Payloads unmarshalled | 5,000 | 10
Discarded payloads | 4,990 | 0
Latency | Grows linearly with dataset size | ~263µs

<h2>Behavioral Changes</h2><h3>Legacy data</h3><p>Responses written before the secondary index was introduced do not have index entries.</p><p>Therefore:</p><ul><li><p>They are not returned by <code inline="">ListResponsesByConversation</code>.</p></li><li><p>They are not removed by the new <code inline="">DeleteConversation</code> cascade.</p></li><li><p>They remain retrievable by ID.</p></li><li><p>They remain available through <code inline="">GetConversationChain</code>.</p></li><li><p>They expire naturally through their existing TTL, 30 days by default.</p></li></ul><p>A backfill was intentionally not included in this change.</p><p><code inline="">ListResponsesByConversation</code> currently has no production callers; the extproc filter uses <code inline="">GetConversationChain</code>.</p><h3>Pagination</h3><p>Listings now return the <strong>oldest N responses</strong> because the index is ordered by <code inline="">created_at</code>.</p><p><code inline="">ListOptions.Order</code> remains ignored by both Redis and memory backends.</p><p>Previously, Redis returned an arbitrary N responses due to <code inline="">SCAN</code> ordering. The new behavior matches <code inline="">MemoryStore</code>.</p><h3>Concurrent duplicate stores</h3><p>Concurrent <code inline="">StoreResponse</code> calls using the same response ID previously could both succeed, with the last write winning.</p><p>With atomic <code inline="">SET NX EX</code>, one caller now receives <code inline="">ErrAlreadyExists</code>, matching the documented contract.</p><h3>Cascade deletion</h3><p><code inline="">DeleteConversation(..., deleteResponses=true)</code> now removes <strong>all indexed responses</strong>, rather than being limited to the first 20.</p><h2>Testing</h2><p>New coverage was added to <code inline="">redis_store_test.go</code>.</p><p>This was intentionally kept outside the integration test file because <code inline="">make test</code> runs <code inline="">go test</code> without <code inline="">-tags=integration</code>. The existing unit test file therefore executes in CI, while the integration file does not.</p><h3>Added tests</h3><ul><li><p><strong><code inline="">TestRedisConversationIndexKeyIsolation</code></strong></p><ul><li><p>Requires no Redis.</p></li><li><p>Verifies index keys match neither the <code inline="">sr:conversation:</code> nor <code inline="">sr:response:</code> scan prefixes.</p></li><li><p>Prevents <code inline="">ListConversations</code> from accidentally interpreting sorted-set index keys as conversation JSON.</p></li><li><p>Runs on every CI job.</p></li></ul></li><li><p><strong><code inline="">TestRedisConversationIndexListing</code></strong></p><ul><li><p>Conversation isolation.</p></li><li><p>Chronological ordering.</p></li><li><p>Index contents.</p></li><li><p>Unknown and empty conversation IDs.</p></li><li><p>Index removal on delete.</p></li><li><p>Moving responses between conversations.</p></li><li><p>Pruning index entries whose payload has expired/deleted.</p></li></ul></li><li><p><strong><code inline="">TestRedisDeleteConversationCascade</code></strong></p><ul><li><p>Creates <code inline="">DefaultListLimit + 5</code> responses.</p></li><li><p>Verifies the cascade deletes all responses rather than stopping at the first page.</p></li><li><p>Verifies responses belonging to other conversations are untouched.</p></li></ul></li><li><p><strong><code inline="">TestRedisStoreResponseRejectsDuplicate</code></strong></p><ul><li><p>Verifies duplicate writes are rejected.</p></li><li><p>Confirms the original payload remains unchanged.</p></li><li><p>Confirms only one index entry exists.</p></li></ul></li></ul><h3>Test isolation</h3><p>Redis-backed tests use a unique per-run key prefix and <code inline="">t.Cleanup</code> instead of flushing Redis DB 0.</p><p>This is necessary because CI shares DB 0 with other test suites.</p><p>Verified that test runs leave zero keys behind.</p><h2>Validation</h2><p>Verified:</p><ul><li><p><code inline="">go test</code> without build tags</p></li><li><p><code inline="">go test</code> with integration build tags</p></li><li><p>Redis-backed tests with Redis available</p></li><li><p>Redis-free tests with Redis unavailable</p></li><li><p><code inline="">gofmt</code></p></li><li><p><code inline="">go vet</code> with both tag configurations</p></li><li><p><code inline="">golangci-lint v2.5.0</code> using repository configuration</p></li></ul><p>All checks pass with <strong>0 lint/vet issues</strong>.</p><p><code inline="">redis_store_integration_test.go</code> is unchanged.</p><h2>Files Changed</h2><ul><li><p><code inline="">src/semantic-router/pkg/responsestore/redis_store.go</code></p><ul><li><p>Secondary conversation index</p></li><li><p>Optimized listing</p></li><li><p>Atomic response creation</p></li><li><p>Index maintenance</p></li><li><p>Cascade deletion changes</p></li></ul></li><li><p><code inline="">src/semantic-router/pkg/responsestore/redis_store_test.go</code></p><ul><li><p>Secondary index and behavioral regression tests</p></li></ul></li><li><p><code inline="">config/runtime/response-api/redis-simple.yaml</code></p><ul><li><p>Updated Redis key-schema documentation</p></li></ul></li></ul><h2>Reviewer Focus</h2><p>The main areas worth reviewing are:</p><ol><li><p><strong>Index consistency and write ordering</strong> — payload is persisted before the index entry.</p></li><li><p><strong>TTL behavior</strong> — index TTL is refreshed independently from response payload TTL.</p></li><li><p><strong>Failure semantics</strong> — index write failures are logged rather than returned.</p></li><li><p><strong>Legacy data behavior</strong> — pre-index responses are intentionally not backfilled.</p></li><li><p><strong>Redis Cluster compatibility</strong> — no cross-slot multi-key operations are introduced.</p></li><li><p><strong>Pagination semantics</strong> — results are now deterministic and chronological.</p></li></ol></body></html>

