### PR TITLE
[Router] Persist router replay recipe identity in PostgreSQL

### DIFF
--- a/src/semantic-router/pkg/routerreplay/store/postgres.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres.go
@@ -36,8 +36,8 @@ const postgresInsertQueryTemplate = `
 			prompt_tokens, cached_prompt_tokens, cache_write_tokens, completion_tokens, total_tokens,
 			actual_cost, baseline_cost, cost_savings, currency, baseline_model,
 			session_id, turn_index, previous_response_id, conversation_id,
-			cache_similarity, context_token_count, hallucination_span_details
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60)
+			cache_similarity, context_token_count, hallucination_span_details, recipe
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61)
 	`
 
 const postgresCreateTableQueryTemplate = `
@@ -130,6 +130,7 @@ const postgresCreateTableQueryTemplate = `
 		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS cache_similarity REAL DEFAULT 0;
 		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS context_token_count INTEGER DEFAULT 0;
 		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS hallucination_span_details JSONB;
+		ALTER TABLE {{table}} ADD COLUMN IF NOT EXISTS recipe VARCHAR(255);
 		CREATE INDEX IF NOT EXISTS idx_{{table}}_timestamp ON {{table}} (timestamp DESC);
 		CREATE INDEX IF NOT EXISTS idx_{{table}}_created_at ON {{table}} (created_at);
 		CREATE INDEX IF NOT EXISTS idx_{{table}}_request_id ON {{table}} (request_id);

--- a/src/semantic-router/pkg/routerreplay/store/postgres_insert_query_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_insert_query_test.go
@@ -49,6 +49,31 @@ func TestPostgresInsertQueryColumnArgsAlignment(t *testing.T) {
 	}
 }
 
+// TestPostgresInsertSelectColumnAlignment pins the write path against the read
+// path. postgresRecordRow.scanDestinations() is positional, so it only decodes
+// correctly while postgresRecordSelectColumns lists the same columns in the same
+// order as the INSERT statement. A column added to one list but not the other
+// round trips as a zero value instead of failing loudly.
+func TestPostgresInsertSelectColumnAlignment(t *testing.T) {
+	insertCols := extractInsertColumns(t, postgresInsertQueryTemplate)
+	selectCols := splitColumnList(postgresRecordSelectColumns)
+
+	if len(insertCols) != len(selectCols) {
+		t.Fatalf("insert / select column count mismatch: %d vs %d\ninsert=%v\nselect=%v",
+			len(insertCols), len(selectCols), insertCols, selectCols)
+	}
+	for i := range insertCols {
+		if insertCols[i] != selectCols[i] {
+			t.Errorf("column #%d differs: insert=%q select=%q", i+1, insertCols[i], selectCols[i])
+		}
+	}
+
+	row := postgresRecordRow{}
+	if got := len(row.scanDestinations()); got != len(selectCols) {
+		t.Errorf("scanDestinations() returns %d destinations for %d selected columns", got, len(selectCols))
+	}
+}
+
 // extractInsertColumns parses the column list between
 // `INSERT INTO %s (` and `) VALUES`.
 func extractInsertColumns(t *testing.T, tmpl string) []string {
@@ -62,7 +87,12 @@ func extractInsertColumns(t *testing.T, tmpl string) []string {
 	if end < 0 {
 		return nil
 	}
-	raw := tmpl[start : start+end]
+	return splitColumnList(tmpl[start : start+end])
+}
+
+// splitColumnList turns a comma-separated SQL column list into trimmed names,
+// dropping the whitespace and newlines both literals are formatted with.
+func splitColumnList(raw string) []string {
 	parts := strings.Split(raw, ",")
 	cols := make([]string, 0, len(parts))
 	for _, p := range parts {

--- a/src/semantic-router/pkg/routerreplay/store/postgres_recipe_column_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_recipe_column_test.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPostgresRecordCarriesRecipe pins recipe identity across the PostgreSQL
+// write and read paths.
+//
+// Background: Record.Recipe is populated by the ExtProc recorder on every
+// request and the Router Replay API filters, searches, and builds its recipe
+// dropdown from it. PostgreSQL was the only backend with an explicit column
+// mapping (memory, Redis, Qdrant, and Milvus marshal the whole Record), so it
+// was the only one that dropped the field: writes discarded it and reads always
+// returned "", leaving ?recipe= matching nothing on Postgres-backed
+// deployments.
+func TestPostgresRecordCarriesRecipe(t *testing.T) {
+	const recipe = "beta"
+
+	idx := columnIndex(t, "recipe")
+
+	built, err := newPostgresInsertRecord(Record{
+		ID:        "rec-1",
+		Timestamp: time.Now().UTC(),
+		Recipe:    recipe,
+	})
+	if err != nil {
+		t.Fatalf("newPostgresInsertRecord: %v", err)
+	}
+
+	args := built.args()
+	if got := args[idx]; got != recipe {
+		t.Errorf("insert arg for recipe column = %#v, want %q", got, recipe)
+	}
+
+	row := postgresRecordRow{}
+	if got := row.scanDestinations()[idx]; got != &row.recipe {
+		t.Errorf("scan destination for recipe column = %#v, want &row.recipe", got)
+	}
+}
+
+// TestPostgresRecordRowDecodesRecipe covers the scan side: a row read back from
+// PostgreSQL must land its recipe on the decoded Record.
+func TestPostgresRecordRowDecodesRecipe(t *testing.T) {
+	row := postgresRecordRow{
+		signalsJSON: []byte("{}"),
+		recipe:      sql.NullString{String: "beta", Valid: true},
+	}
+
+	record, err := row.decode()
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if record.Recipe != "beta" {
+		t.Errorf("decoded Recipe = %q, want %q", record.Recipe, "beta")
+	}
+}
+
+// TestPostgresRecordRowDecodesMissingRecipe covers rows written before the
+// recipe column existed. The migration backfills them as NULL, which must decode
+// to an empty recipe rather than failing the read.
+func TestPostgresRecordRowDecodesMissingRecipe(t *testing.T) {
+	row := postgresRecordRow{signalsJSON: []byte("{}")}
+
+	record, err := row.decode()
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if record.Recipe != "" {
+		t.Errorf("decoded Recipe = %q, want empty for a NULL column", record.Recipe)
+	}
+}
+
+// TestPostgresCreateTableAddsRecipeColumn pins the schema upgrade. Existing
+// deployments only gain the column through the ALTER block, so dropping it
+// would leave every write failing against an already-created table.
+func TestPostgresCreateTableAddsRecipeColumn(t *testing.T) {
+	query := postgresCreateTableQuery(DefaultPostgresTableName)
+
+	want := "ALTER TABLE " + DefaultPostgresTableName + " ADD COLUMN IF NOT EXISTS recipe VARCHAR(255);"
+	if !strings.Contains(query, want) {
+		t.Errorf("create-table query is missing the non-destructive recipe migration:\nwant substring: %s", want)
+	}
+}
+
+// columnIndex resolves a column's position in the INSERT statement, which
+// TestPostgresInsertSelectColumnAlignment pins to the SELECT list and the scan
+// destinations.
+func columnIndex(t *testing.T, name string) int {
+	t.Helper()
+
+	for i, col := range extractInsertColumns(t, postgresInsertQueryTemplate) {
+		if col == name {
+			return i
+		}
+	}
+	t.Fatalf("column %q is not in the INSERT column list", name)
+	return -1
+}

--- a/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
@@ -21,7 +21,7 @@ const postgresRecordSelectColumns = `
 	prompt_tokens, cached_prompt_tokens, cache_write_tokens, completion_tokens, total_tokens,
 	actual_cost, baseline_cost, cost_savings, currency, baseline_model,
 	session_id, turn_index, previous_response_id, conversation_id,
-	cache_similarity, context_token_count, hallucination_span_details
+	cache_similarity, context_token_count, hallucination_span_details, recipe
 `
 
 type postgresRowScanner interface {
@@ -74,6 +74,7 @@ type postgresRecordRow struct {
 	turnIndex                    sql.NullInt64
 	previousResponseID           sql.NullString
 	conversationID               sql.NullString
+	recipe                       sql.NullString
 }
 
 func newPostgresInsertRecord(record Record) (postgresInsertRecord, error) {
@@ -195,6 +196,7 @@ func (record postgresInsertRecord) args() []interface{} {
 		record.record.CacheSimilarity,
 		record.record.ContextTokenCount,
 		record.hallucinationSpanDetailsJSON,
+		emptyStringSQL(record.record.Recipe),
 	}
 }
 
@@ -287,6 +289,7 @@ func (row *postgresRecordRow) scanDestinations() []interface{} {
 		&row.record.CacheSimilarity,
 		&row.record.ContextTokenCount,
 		&row.hallucinationSpanDetailsJSON,
+		&row.recipe,
 	}
 }
 
@@ -314,6 +317,7 @@ func (row *postgresRecordRow) decode() (Record, error) {
 		row.baselineModel,
 	)
 	row.assignReplaySessionIdentifiers()
+	row.assignReplayRecipe()
 	return row.record, nil
 }
 
@@ -366,5 +370,13 @@ func (row *postgresRecordRow) assignReplaySessionIdentifiers() {
 	}
 	if row.conversationID.Valid {
 		row.record.ConversationID = row.conversationID.String
+	}
+}
+
+// assignReplayRecipe restores routing recipe identity. Rows written before the
+// recipe column existed scan as NULL and leave Record.Recipe empty.
+func (row *postgresRecordRow) assignReplayRecipe() {
+	if row.recipe.Valid {
+		row.record.Recipe = row.recipe.String
 	}
 }


### PR DESCRIPTION
Closes #2792

## Purpose

`Record.Recipe` is populated by the ExtProc recorder on every request, and the Router Replay API filters on it, free-text searches it, and builds its `available_recipes` dropdown from it. PostgreSQL was the only backend that maps records column by column, since memory, Redis, Qdrant, and Milvus marshal the whole `Record`, so it was the only one that dropped the field. Writes discarded the recipe and reads always returned `""`, which left `?recipe=` matching nothing and the dropdown empty on Postgres-backed deployments

This carries recipe through the insert, select, scan, and decode paths, and adds the column through the existing `ADD COLUMN IF NOT EXISTS` block so already-created tables upgrade without a destructive migration. Rows written before the column existed scan as NULL and decode to an empty recipe rather than failing the read

The column is appended to the end of the lists rather than slotted next to `decision`. Inserting it in the middle would renumber every `$N` placeholder after it for no behavioral gain

Two commits: the fix, then the tests. Module affected: `Router`

While adding the tests I also filled in a gap in the existing coverage. There was an alignment test for the INSERT columns against the `$N` placeholders and against `postgresInsertRecord.args()`, but nothing checking the INSERT list against `postgresRecordSelectColumns`. `scanDestinations()` is positional, so a column added to one list but not the other round trips as a zero value instead of failing loudly, which is exactly how recipe stayed invisible

## Test Plan

The changed files are pure Go with no new dependencies, so the repo-native Go gates cover them:

```bash
make check-go-mod-tidy
make go-lint
make test-semantic-router
pre-commit run --files src/semantic-router/pkg/routerreplay/store/postgres.go \
  src/semantic-router/pkg/routerreplay/store/postgres_record_row.go \
  src/semantic-router/pkg/routerreplay/store/postgres_insert_query_test.go \
  src/semantic-router/pkg/routerreplay/store/postgres_recipe_column_test.go
make agent-ci-lint CHANGED_FILES="src/semantic-router/pkg/routerreplay/store/postgres.go,src/semantic-router/pkg/routerreplay/store/postgres_record_row.go,src/semantic-router/pkg/routerreplay/store/postgres_insert_query_test.go,src/semantic-router/pkg/routerreplay/store/postgres_recipe_column_test.go"
```

To confirm the new tests actually fail when the fix is broken rather than passing vacuously, each part of the change can be reverted in isolation and the suite re-run:

```bash
go test ./pkg/routerreplay/store/ -count=1 -run Postgres -v
```

## Test Result

All gates pass locally on darwin/arm64 with `golangci-lint` v2.5.0, matching the version pinned in `.github/workflows/pre-commit.yml`. `make test-semantic-router` reports one failure, `TestHybridCachePendingRequest` in `pkg/cache`, which is a known flake unrelated to this change. It fails on other contributors' PRs that do not touch `pkg/cache` either (#2530, #2507, #2810), and it passed on my own PR #2819. The test writes to the Milvus-backed hybrid cache, sleeps a fixed 100ms "for indexing", then asserts the entry is findable, so a loaded runner fails it. Locally it cannot run at all without a Milvus instance, which is why `make test-semantic-router` defaults `SKIP_MILVUS_TESTS=true`. The `test-and-build` job is flaky on `main` for the same reason, failing 4 of the last 8 runs there on a rotating set of tests. Everything else is green: `make go-lint` reports 0 issues, `make check-go-mod-tidy` passes, `make agent-ci-lint` exits 0, and every pre-commit hook that applies to these files passes including the supply chain AST scan and the agent changed-files lint

The six `Postgres` tests in the package pass, four of them new. Reverting each part of the fix in turn fails at least one test in every case:

| Reverted | Fails |
| --- | --- |
| `recipe` removed from `postgresRecordSelectColumns` | `TestPostgresInsertSelectColumnAlignment`, `TestPostgresBackendWiresDemotedHeaderFields` |
| `recipe` removed from `args()` | `TestPostgresInsertQueryColumnArgsAlignment`, `TestPostgresRecordCarriesRecipe` |
| `&row.recipe` removed from `scanDestinations()` | `TestPostgresInsertSelectColumnAlignment`, `TestPostgresRecordCarriesRecipe` |
| decode assignment removed | `TestPostgresRecordRowDecodesRecipe` |
| `ALTER TABLE` migration removed | `TestPostgresCreateTableAddsRecipeColumn` |

One gap worth flagging. There is no live PostgreSQL round trip anywhere in this package, so the write and read paths are pinned through the production mapping functions rather than through a real driver. The column ordering that makes that equivalent is itself now pinned by `TestPostgresInsertSelectColumnAlignment`. I also could not run `pkg/extproc` locally, since it fails to link without the Rust bindings on this machine, but this change touches no extproc code and the API-level filter reads `Record.Recipe` unchanged


