### PR TITLE
[Router] Remove dead per-domain policy structs and the config keys they declared

### DIFF
--- a/bench/cpu-vs-gpu/config-bench-candle.yaml
+++ b/bench/cpu-vs-gpu/config-bench-candle.yaml
@@ -2137,8 +2137,6 @@ routing:
             use_reasoning: false
       - name: psychology
         system_prompt: You are a psychology expert with deep knowledge of cognitive processes, behavioral patterns, mental health, developmental psychology, social psychology, and therapeutic approaches. Provide evidence-based insights grounded in psychological research and theory. When discussing mental health topics, emphasize the importance of professional consultation and avoid providing diagnostic or therapeutic advice.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.92
         model_scores:
           - model: qwen3
             score: 0.6
@@ -2163,16 +2161,12 @@ routing:
             use_reasoning: false
       - name: other
         system_prompt: You are a helpful and knowledgeable assistant. Provide accurate, helpful responses across a wide range of topics.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.75
         model_scores:
           - model: qwen3
             score: 0.7
             use_reasoning: false
       - name: health
         system_prompt: You are a health and medical information expert with knowledge of anatomy, physiology, diseases, treatments, preventive care, nutrition, and wellness. Provide accurate, evidence-based health information while emphasizing that your responses are for educational purposes only and should never replace professional medical advice, diagnosis, or treatment. Always encourage users to consult healthcare professionals for medical concerns and emergencies.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.95
         model_scores:
           - model: qwen3
             score: 0.5
@@ -6474,8 +6468,6 @@ routing:
             use_reasoning: false
       - name: psychology
         system_prompt: You are a psychology expert with deep knowledge of cognitive processes, behavioral patterns, mental health, developmental psychology, social psychology, and therapeutic approaches. Provide evidence-based insights grounded in psychological research and theory. When discussing mental health topics, emphasize the importance of professional consultation and avoid providing diagnostic or therapeutic advice.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.92
         model_scores:
           - model: qwen3
             score: 0.6
@@ -6500,16 +6492,12 @@ routing:
             use_reasoning: false
       - name: other
         system_prompt: You are a helpful and knowledgeable assistant. Provide accurate, helpful responses across a wide range of topics.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.75
         model_scores:
           - model: qwen3
             score: 0.7
             use_reasoning: false
       - name: health
         system_prompt: You are a health and medical information expert with knowledge of anatomy, physiology, diseases, treatments, preventive care, nutrition, and wellness. Provide accurate, evidence-based health information while emphasizing that your responses are for educational purposes only and should never replace professional medical advice, diagnosis, or treatment. Always encourage users to consult healthcare professionals for medical concerns and emergencies.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.95
         model_scores:
           - model: qwen3
             score: 0.5

--- a/deploy/kubernetes/observability/dashboard/config.yaml
+++ b/deploy/kubernetes/observability/dashboard/config.yaml
@@ -41,8 +41,6 @@ routing:
             use_reasoning: false
       - name: psychology
         system_prompt: You are a psychology expert with deep knowledge of cognitive processes, behavioral patterns, mental health, developmental psychology, social psychology, and therapeutic approaches. Provide evidence-based insights grounded in psychological research and theory. When discussing mental health topics, emphasize the importance of professional consultation and avoid providing diagnostic or therapeutic advice.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.92
         model_scores:
           - model: qwen3
             score: 0.6
@@ -67,16 +65,12 @@ routing:
             use_reasoning: false
       - name: other
         system_prompt: You are a helpful and knowledgeable assistant. Provide accurate, helpful responses across a wide range of topics.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.75
         model_scores:
           - model: qwen3
             score: 0.7
             use_reasoning: false
       - name: health
         system_prompt: You are a health and medical information expert with knowledge of anatomy, physiology, diseases, treatments, preventive care, nutrition, and wellness. Provide accurate, evidence-based health information while emphasizing that your responses are for educational purposes only and should never replace professional medical advice, diagnosis, or treatment. Always encourage users to consult healthcare professionals for medical concerns and emergencies.
-        semantic_cache_enabled: true
-        semantic_cache_similarity_threshold: 0.95
         model_scores:
           - model: qwen3
             score: 0.5

--- a/src/semantic-router/pkg/config/maintained_asset_contract_test.go
+++ b/src/semantic-router/pkg/config/maintained_asset_contract_test.go
@@ -254,9 +254,62 @@ func validateMaintainedConfigAsset(t *testing.T, rel string, data []byte) {
 	t.Helper()
 	raw := decodeYAMLMap(t, data, rel)
 	assertNoLegacySteadyStateKeys(t, rel, raw)
+	assertNoRemovedDomainPolicyKeys(t, rel, raw)
 	if _, err := ParseYAMLBytes(data); err != nil {
 		t.Fatalf("%s no longer parses as a maintained canonical config asset: %v", rel, err)
 	}
+}
+
+// removedDomainPolicyKeys are per-domain policy keys from the pre-plugin config
+// schema. #681 moved these behaviours onto decision plugins and reduced
+// routing.signals.domains to metadata plus model scores, so the loader has
+// ignored them ever since. A shipped asset that still sets one advertises a
+// knob the router does not have.
+var removedDomainPolicyKeys = []string{
+	"system_prompt_enabled",
+	"system_prompt_mode",
+	"semantic_cache_enabled",
+	"semantic_cache_similarity_threshold",
+	"jailbreak_enabled",
+	"jailbreak_threshold",
+	"pii_enabled",
+	"pii_threshold",
+}
+
+func assertNoRemovedDomainPolicyKeys(t *testing.T, rel string, raw map[string]interface{}) {
+	t.Helper()
+	for _, domain := range assetDomainEntries(raw) {
+		name, _ := domain["name"].(string)
+		for _, key := range removedDomainPolicyKeys {
+			if _, ok := domain[key]; ok {
+				t.Errorf("%s sets removed per-domain policy key %q on domain %q; the router ignores it, configure the matching decision plugin instead", rel, key, name)
+			}
+		}
+	}
+}
+
+// assetDomainEntries returns routing.signals.domains, or nothing when the asset
+// declares no domain signal.
+func assetDomainEntries(raw map[string]interface{}) []map[string]interface{} {
+	routing, ok := raw["routing"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	signals, ok := routing["signals"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	domains, ok := signals["domains"].([]interface{})
+	if !ok {
+		return nil
+	}
+	entries := make([]map[string]interface{}, 0, len(domains))
+	for _, domain := range domains {
+		if typed, ok := domain.(map[string]interface{}); ok {
+			entries = append(entries, typed)
+		}
+	}
+	return entries
 }
 
 func assertNoLegacySteadyStateKeys(t *testing.T, rel string, raw map[string]interface{}) {

--- a/src/semantic-router/pkg/config/signal_config.go
+++ b/src/semantic-router/pkg/config/signal_config.go
@@ -295,36 +295,8 @@ type ModelScore struct {
 	UseReasoning *bool   `yaml:"use_reasoning"`
 }
 
-type DomainAwarePolicies struct {
-	SystemPromptPolicy    `yaml:",inline"`
-	SemanticCachingPolicy `yaml:",inline"`
-	JailbreakPolicy       `yaml:",inline"`
-	PIIDetectionPolicy    `yaml:",inline"`
-}
-
 type CategoryMetadata struct {
 	Name           string   `yaml:"name"`
 	Description    string   `yaml:"description,omitempty"`
 	MMLUCategories []string `yaml:"mmlu_categories,omitempty"`
-}
-
-type SystemPromptPolicy struct {
-	SystemPrompt        string `yaml:"system_prompt,omitempty"`
-	SystemPromptEnabled *bool  `yaml:"system_prompt_enabled,omitempty"`
-	SystemPromptMode    string `yaml:"system_prompt_mode,omitempty"`
-}
-
-type SemanticCachingPolicy struct {
-	SemanticCacheEnabled             *bool    `yaml:"semantic_cache_enabled,omitempty"`
-	SemanticCacheSimilarityThreshold *float32 `yaml:"semantic_cache_similarity_threshold,omitempty"`
-}
-
-type JailbreakPolicy struct {
-	JailbreakEnabled   *bool    `yaml:"jailbreak_enabled,omitempty"`
-	JailbreakThreshold *float32 `yaml:"jailbreak_threshold,omitempty"`
-}
-
-type PIIDetectionPolicy struct {
-	PIIEnabled   *bool    `yaml:"pii_enabled,omitempty"`
-	PIIThreshold *float32 `yaml:"pii_threshold,omitempty"`
 }


### PR DESCRIPTION
Closes #2771

## Purpose

`DomainAwarePolicies` and its four policy structs in `pkg/config/signal_config.go` are dead. #681 reduced `Category` to metadata plus model scores and moved per-domain behaviour onto decision plugins, but left the structs behind, so the eight keys they declare have been inert since. Two shipped configs still set `semantic_cache_enabled` and `semantic_cache_similarity_threshold` under `routing.signals.domains`, which reads as a working per-domain cache threshold and is not one

This takes the issue's second option and deletes the orphaned types, then drops those keys from `bench/cpu-vs-gpu/config-bench-candle.yaml` and `deploy/kubernetes/observability/dashboard/config.yaml`. Reinstating the embed would resurrect a schema #681 deliberately replaced. Module affected: `Router`

Two corrections to the issue. It is nine keys, not eight, since domain-level `system_prompt` is dropped the same way, and the drop is not silent: `WarnUnknownFields` does reach this level and logs every one at startup. `system_prompt` is left alone here because migrating it means authoring decision plugins in each config, which is separate work

## Test Plan

```bash
make test-semantic-router
make go-lint
make check-go-mod-tidy
make agent-ci-lint CHANGED_FILES="bench/cpu-vs-gpu/config-bench-candle.yaml,deploy/kubernetes/observability/dashboard/config.yaml,src/semantic-router/pkg/config/signal_config.go,src/semantic-router/pkg/config/maintained_asset_contract_test.go"
pre-commit run --files <the four changed files>
```

Deleting exported types can break dependents, so `deploy/operator`, `dashboard/backend`, and `e2e` were built as separate modules

## Test Result

Loading the dashboard config through `config.Parse`, counting the unknown-field warnings under `routing.signals.domains`:

```
before                                    after
   3 semantic_cache_enabled                 14 system_prompt
   3 semantic_cache_similarity_threshold
  14 system_prompt
```

`TestMaintainedConfigAssetsUseCanonicalV03Contract` fails on the base with six findings in the dashboard config, and passes here. `make test-semantic-router` reports one failure, `TestHybridCachePendingRequest` in `pkg/cache`, which is a known flake unrelated to this change. It fails on other contributors' PRs that do not touch `pkg/cache` either (#2530, #2507, #2810), and it passed on my own PR #2819. The test writes to the Milvus-backed hybrid cache, sleeps a fixed 100ms "for indexing", then asserts the entry is findable, so a loaded runner fails it. Locally it cannot run at all without a Milvus instance, which is why `make test-semantic-router` defaults `SKIP_MILVUS_TESTS=true`. `make go-lint` reports 0 issues, `make check-go-mod-tidy` and `make agent-ci-lint` pass, and all pre-commit hooks pass. The three dependent modules build clean, and no Go file anywhere references the removed types


