### PR TITLE
[Dashboard] fix double slash in knowledge base source path

### DIFF
--- a/dashboard/frontend/src/pages/ConfigPageTaxonomyClassifierDetail.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageTaxonomyClassifierDetail.tsx
@@ -1,6 +1,7 @@
 import pageStyles from './ConfigPage.module.css'
 import styles from './ConfigPageTaxonomyClassifiers.module.css'
 import {
+  formatKnowledgeBaseSourcePath,
   formatSignalReference,
   type TaxonomyClassifierRecord,
 } from './configPageTaxonomyClassifierSupport'
@@ -37,7 +38,7 @@ export default function ConfigPageTaxonomyClassifierDetail({
   const groupEntries = Object.entries(selectedClassifier?.groups ?? {})
   const thresholdEntries = Object.entries(selectedClassifier?.label_thresholds ?? {})
   const sourcePath = selectedClassifier
-    ? `${selectedClassifier.source.path}${selectedClassifier.source.manifest ? `/${selectedClassifier.source.manifest}` : ''}`
+    ? formatKnowledgeBaseSourcePath(selectedClassifier.source)
     : ''
 
   if (!selectedClassifier) {

--- a/dashboard/frontend/src/pages/configPageTaxonomyClassifierSupport.test.ts
+++ b/dashboard/frontend/src/pages/configPageTaxonomyClassifierSupport.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   classifierDraftFromRecord,
+  formatKnowledgeBaseSourcePath,
   payloadFromDraft,
   type TaxonomyClassifierRecord,
 } from './configPageTaxonomyClassifierSupport'
@@ -73,5 +74,28 @@ describe('taxonomy classifier form support', () => {
     expect(buildLabelRows(record, 'private data')).toHaveLength(1)
     expect(buildLabelRows(record, 'press release')).toHaveLength(1)
     expect(buildLabelRows(record, 'not-present')).toHaveLength(0)
+  })
+
+  it('joins the knowledge base source directory and manifest with a single separator', () => {
+    const format = formatKnowledgeBaseSourcePath
+    const joined = 'knowledge_bases/mmlu/labels.json'
+
+    // The shipped config writes the asset directory with a trailing slash.
+    expect(format({ path: 'knowledge_bases/mmlu/', manifest: 'labels.json' })).toBe(joined)
+    expect(format({ path: 'knowledge_bases/mmlu', manifest: 'labels.json' })).toBe(joined)
+    expect(format({ path: 'knowledge_bases/mmlu//', manifest: '/labels.json' })).toBe(joined)
+    expect(format({ path: ' knowledge_bases/mmlu/ ', manifest: ' labels.json ' })).toBe(joined)
+    expect(format({ path: '/opt/kb/', manifest: 'labels.json' })).toBe('/opt/kb/labels.json')
+  })
+
+  it('falls back to whichever half of the knowledge base source is present', () => {
+    const format = formatKnowledgeBaseSourcePath
+    const directory = 'knowledge_bases/mmlu/'
+
+    expect(format({ path: directory })).toBe(directory)
+    expect(format({ path: directory, manifest: '  ' })).toBe(directory)
+    expect(format({ path: '', manifest: 'labels.json' })).toBe('labels.json')
+    expect(format({ path: '/', manifest: 'labels.json' })).toBe('/labels.json')
+    expect(format({ path: '' })).toBe('')
   })
 })

--- a/dashboard/frontend/src/pages/configPageTaxonomyClassifierSupport.ts
+++ b/dashboard/frontend/src/pages/configPageTaxonomyClassifierSupport.ts
@@ -341,6 +341,23 @@ export function normalizeTaxonomyClassifierListResponse(raw: unknown): TaxonomyC
   }
 }
 
+// Joins the knowledge base asset directory and its manifest file name for display.
+// Either half may arrive with its own separators (config commonly writes
+// `path: knowledge_bases/mmlu/`), so trim the seam before joining.
+export function formatKnowledgeBaseSourcePath(source: TaxonomyClassifierRecord['source']): string {
+  const path = (source?.path ?? '').trim()
+  const manifest = (source?.manifest ?? '').trim().replace(/^\/+/, '')
+  if (!manifest) {
+    return path
+  }
+  const root = path.replace(/\/+$/, '')
+  if (!root) {
+    // `path` was empty, or nothing but separators such as the filesystem root.
+    return path ? `/${manifest}` : manifest
+  }
+  return `${root}/${manifest}`
+}
+
 export function formatSignalReference(reference: TaxonomySignalReference): string {
   const targetKind = reference.target.kind || 'unknown'
   const targetValue = reference.target.value || 'unknown'


### PR DESCRIPTION
Closes #2823

## Purpose

- The knowledge base detail panel showed the Source path as `knowledge_bases/mmlu//labels.json`. It now shows `knowledge_bases/mmlu/labels.json`.
- The panel glued `source.path` and `source.manifest` together with a literal `/`, but the shipped config already ends `source.path` with a slash. Display only, the router loads the manifest fine because the Go side uses `filepath.Join`.
- I moved the join into a small shared helper, `formatKnowledgeBaseSourcePath`, that trims the seam instead of assuming there is no trailing slash. It also handles an absolute path, extra whitespace, and either half being missing.
- Module: `Dashboard`

## Test Plan

- `cd dashboard/frontend && npm run test:unit`, plus `npm run type-check` and `npm run lint`.
- Manually opened the Knowledge Bases page and selected `mmlu_kb` to check the Source line, see before and after below.

## Test Result

- 299 tests passed, including 2 new ones. Type check clean, lint has only a pre-existing warning in a file this PR does not touch.
- Source now renders `knowledge_bases/mmlu/labels.json`. No config or Go changes, and `privacy_kb` is fixed by the same helper.

| Before | After |
| --- | --- |
| <img width="1770" height="883" alt="Screenshot From 2026-08-08 22-16-23" src="https://github.com/user-attachments/assets/75d4b756-4c9a-4a38-a021-a721607b7f3d" /> | <img width="2375" height="1288" alt="Screenshot From 2026-08-09 11-19-43" src="https://github.com/user-attachments/assets/819d0b91-a4f0-41fc-bbf9-dbeac8b62185" />|
| `knowledge_bases/mmlu//labels.json` | `knowledge_bases/mmlu/labels.json` |


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
