### PR TITLE
[Dashboard] fix unreadable dropdown options in the user dialog

### DIFF
--- a/dashboard/frontend/src/app/graphiteThemeContract.test.ts
+++ b/dashboard/frontend/src/app/graphiteThemeContract.test.ts
@@ -205,4 +205,20 @@ describe('graphite dashboard theme contract', () => {
 
     expect(violations).toEqual([])
   })
+
+  it('gives every translucent-light select an opaque option background', () => {
+    const violations = themeSources
+      .filter(({ path }) => path.endsWith('.css'))
+      .flatMap(({ path, source }) => {
+        const declaresTranslucentLightSelect =
+          /\.select[^{]*\{[^}]*background[^;]*rgba\(\s*255\s*,\s*255\s*,\s*255/.test(source)
+        if (!declaresTranslucentLightSelect) {
+          return []
+        }
+        const pinsOptionBackground = /option[^{]*\{[^}]*background/.test(source)
+        return pinsOptionBackground ? [] : [path]
+      })
+
+    expect(violations).toEqual([])
+  })
 })

--- a/dashboard/frontend/src/pages/UsersPageUserDialog.module.css
+++ b/dashboard/frontend/src/pages/UsersPageUserDialog.module.css
@@ -119,6 +119,11 @@
   font-size: 0.95rem;
 }
 
+.select option {
+  background-color: var(--surface-raised, #18181b);
+  color: var(--color-text, #f5f5f7);
+}
+
 .input:focus,
 .select:focus {
   outline: none;


### PR DESCRIPTION
Closes #2826

## Purpose

- The Role and Status dropdowns in the user dialog rendered near-white options on a near-white popup. `.select` sets a translucent white background and near-white text, with no `option` rule, so the option list composited to white while the text stayed white.
- Pins the option background and colour to opaque theme tokens, matching the pattern already used in `ClawRoomChat.module.css`.
- Adds a theme-contract test so any future translucent-light select must pin an option background.
- Module: `Dashboard`

## Test Plan

- `cd dashboard/frontend && npm run test:unit`, plus `type-check` and `lint`.
- Opened the Role dropdown on Create user and both dropdowns on Edit user, before and after.

## Test Result

- All tests passed. Type check clean, lint has only a pre-existing warning in a file this PR does not touch.
- Removing the CSS rule makes the new test fail and name the offending file, confirming it guards the fix.
- Options are readable. 

<img width="1551" height="795" alt="Screenshot From 2026-08-09 13-05-08" src="https://github.com/user-attachments/assets/937ce3a2-acea-45ae-875d-2e1816abef15" />


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [ ] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
