### PR TITLE
[Router] Download aliased model paths to the directory the runtime loads

### DIFF
--- a/src/semantic-router/pkg/modeldownload/config_parser.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser.go
@@ -64,7 +64,7 @@ func recordModelPath(fieldName string, field reflect.Value, paths *[]string, see
 		return
 	}
 
-	path := field.String()
+	path := resolveAliasForField(fieldName, field.String())
 	if path == "" || !strings.HasPrefix(path, "models/") || seen[path] {
 		return
 	}
@@ -82,6 +82,20 @@ func isModelPathField(fieldName string) bool {
 		fieldName == "Qwen3ModelPath" ||
 		fieldName == "GemmaModelPath" ||
 		strings.HasSuffix(fieldName, "ModelPath")
+}
+
+// resolveAliasForField canonicalizes the registry aliases the runtime itself resolves,
+// so the snapshot lands in the directory that will actually be loaded.
+//
+// Every consumer of a *ModelPath field passes it through config.ResolveModelPath first:
+// the embedding runtime, local classifier signal rules, and the modality detector. A
+// ModelID reaches the candle bindings verbatim, so canonicalizing one here would move
+// its download away from the directory the classifier opens.
+func resolveAliasForField(fieldName, path string) string {
+	if fieldName == "ModelID" {
+		return path
+	}
+	return config.ResolveModelPath(path)
 }
 
 // isModelDirectory checks if a path looks like a model directory (not a file)
@@ -185,7 +199,7 @@ func addEmbeddingModelRequiredFiles(cfg *config.RouterConfig, requiredFilesByMod
 	}
 
 	// MmBertModelPath holds the configured semantic embedding model directory.
-	path := cfg.MmBertModelPath
+	path := config.ResolveModelPath(cfg.MmBertModelPath)
 	if path == "" || !strings.HasPrefix(path, "models/") {
 		return
 	}

--- a/src/semantic-router/pkg/modeldownload/feature_gates.go
+++ b/src/semantic-router/pkg/modeldownload/feature_gates.go
@@ -13,12 +13,14 @@ var optionalModelFeatureGates = []modelFeatureGate{
 			return !cfg.EmbeddingModels.UsesRemoteEmbeddingBackend()
 		},
 		paths: func(cfg *config.RouterConfig) []string {
+			// Canonical form, so these match the paths resolveAliasForField collected
+			// for the same fields. Gates over ModelID stay literal for the same reason.
 			return []string{
-				cfg.Qwen3ModelPath,
-				cfg.GemmaModelPath,
-				cfg.MmBertModelPath,
-				cfg.MultiModalModelPath,
-				cfg.BertModelPath,
+				config.ResolveModelPath(cfg.Qwen3ModelPath),
+				config.ResolveModelPath(cfg.GemmaModelPath),
+				config.ResolveModelPath(cfg.MmBertModelPath),
+				config.ResolveModelPath(cfg.MultiModalModelPath),
+				config.ResolveModelPath(cfg.BertModelPath),
 			}
 		},
 	},
@@ -89,7 +91,7 @@ var optionalModelFeatureGates = []modelFeatureGate{
 			if cfg.ModalityDetector.Classifier == nil {
 				return nil
 			}
-			return []string{cfg.ModalityDetector.Classifier.ModelPath}
+			return []string{config.ResolveModelPath(cfg.ModalityDetector.Classifier.ModelPath)}
 		},
 	},
 }

--- a/src/semantic-router/pkg/modeldownload/model_path_alias_test.go
+++ b/src/semantic-router/pkg/modeldownload/model_path_alias_test.go
@@ -1,0 +1,153 @@
+package modeldownload
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestBuildModelSpecsTargetsTheDirectoryTheRuntimeLoads guards #2676. Every consumer of an
+// embedding model path canonicalizes it with config.ResolveModelPath before handing it to
+// candle, so a config that names the model by a registry alias must be downloaded to the
+// canonical directory. Recording the literal path instead means a bare alias is never
+// downloaded at all, and a models/<alias> form is downloaded to a directory nobody opens.
+func TestBuildModelSpecsTargetsTheDirectoryTheRuntimeLoads(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+	}{
+		{name: "canonical path", configured: "models/mmbert-embed-32k-2d-matryoshka"},
+		{name: "bare alias", configured: "mmbert"},
+		{name: "models-prefixed alias", configured: "models/mom-embedding-ultra"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.RouterConfig{
+				MoMRegistry: config.ToLegacyRegistry(),
+				InlineModels: config.InlineModels{
+					EmbeddingModels: config.EmbeddingModels{MmBertModelPath: tt.configured},
+				},
+			}
+
+			specs, err := BuildModelSpecs(cfg)
+			if err != nil {
+				t.Fatalf("BuildModelSpecs() error = %v", err)
+			}
+
+			loadedByRuntime := config.ResolveModelPath(tt.configured)
+			if len(specs) != 1 {
+				t.Fatalf("BuildModelSpecs() returned %d specs for %q, want 1 for %q: %#v",
+					len(specs), tt.configured, loadedByRuntime, specs)
+			}
+			if specs[0].LocalPath != loadedByRuntime {
+				t.Fatalf("BuildModelSpecs() downloads %q, but the runtime loads %q",
+					specs[0].LocalPath, loadedByRuntime)
+			}
+			if want := "llm-semantic-router/mmbert-embed-32k-2d-matryoshka"; specs[0].RepoID != want {
+				t.Fatalf("spec RepoID = %q, want %q", specs[0].RepoID, want)
+			}
+		})
+	}
+}
+
+// TestAliasedEmbeddingModelKeepsWeightRequirements pins that the #2172 completeness contract
+// follows the model to its canonical directory. Requirements keyed by the alias would leave
+// the downloaded snapshot with only the generic weight heuristic behind it.
+func TestAliasedEmbeddingModelKeepsWeightRequirements(t *testing.T) {
+	cfg := &config.RouterConfig{
+		MoMRegistry: config.ToLegacyRegistry(),
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{MmBertModelPath: "models/mom-embedding-ultra"},
+		},
+	}
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+
+	spec, ok := findSpecByPath(specs, testEmbeddingModelPath)
+	if !ok {
+		t.Fatalf("BuildModelSpecs() produced no spec for %q; got %#v", testEmbeddingModelPath, specs)
+	}
+	for _, want := range embeddingModelWeightFiles {
+		if !slices.Contains(spec.RequiredFiles, want) {
+			t.Fatalf("spec RequiredFiles = %#v, missing %q", spec.RequiredFiles, want)
+		}
+	}
+}
+
+// TestAliasedEmbeddingModelStillSkippedForRemoteBackend keeps the feature gates keyed the same
+// way as the collector. A gate that compares the literal config value against a canonicalized
+// path stops matching, and a deployment that embeds remotely downloads a model it never loads.
+func TestAliasedEmbeddingModelStillSkippedForRemoteBackend(t *testing.T) {
+	cfg := &config.RouterConfig{
+		MoMRegistry: config.ToLegacyRegistry(),
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MmBertModelPath: "models/mom-embedding-ultra",
+				EmbeddingConfig: config.HNSWConfig{
+					Backend:   config.EmbeddingBackendOpenAICompatible,
+					ModelType: config.EmbeddingModelTypeRemote,
+				},
+				Endpoint: config.EmbeddingEndpointConfig{
+					BaseURL: "http://embedding-service:8000/v1",
+					Model:   "BAAI/bge-m3",
+				},
+			},
+		},
+	}
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("BuildModelSpecs() returned %d specs for a remote embedding backend, want 0: %#v",
+			len(specs), specs)
+	}
+}
+
+// TestBuildModelSpecsKeepsClassifierModelIDLiteral pins the other half of the contract. The
+// built-in classifiers pass model_id straight to the bindings without resolving it, so
+// canonicalizing it here would download the snapshot to a directory they never open.
+func TestBuildModelSpecsKeepsClassifierModelIDLiteral(t *testing.T) {
+	const aliasModelID = "models/category_classifier_modernbert-base_model"
+
+	cfg := &config.RouterConfig{
+		MoMRegistry: config.ToLegacyRegistry(),
+		InlineModels: config.InlineModels{
+			Classifier: config.Classifier{
+				CategoryModel: config.CategoryModel{
+					ModelID:             aliasModelID,
+					CategoryMappingPath: aliasModelID + "/category_mapping.json",
+				},
+			},
+		},
+		IntelligentRouting: config.IntelligentRouting{
+			Decisions: []config.Decision{{
+				Name: "domain-route",
+				Rules: config.RuleNode{Operator: "OR", Conditions: []config.RuleNode{
+					{Type: config.SignalTypeDomain, Name: "billing"},
+				}},
+			}},
+		},
+	}
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("BuildModelSpecs() returned %d specs, want 1: %#v", len(specs), specs)
+	}
+	if specs[0].LocalPath != aliasModelID {
+		t.Fatalf("BuildModelSpecs() downloads %q, but the classifier loads %q verbatim",
+			specs[0].LocalPath, aliasModelID)
+	}
+	if !slices.Contains(specs[0].RequiredFiles, "category_mapping.json") {
+		t.Fatalf("spec RequiredFiles = %#v, missing %q", specs[0].RequiredFiles, "category_mapping.json")
+	}
+}


### PR DESCRIPTION
Closes #2676

## Purpose

`ResolveModelPath` lets a config name a model by a registry alias, and every consumer of a `*ModelPath` field uses it before handing the path to candle: the embedding runtime, local classifier signal rules, and the modality detector. The download collector did not. It recorded the literal configured string and skipped anything without a `models/` prefix, so the two halves disagreed about which directory holds the model.

A bare alias (`mmbert_model_path: mmbert`) was therefore never downloaded at all, and a `models/<alias>` form downloaded a full snapshot into a directory the runtime never opens. Either way the router starts, finds the canonical directory missing, and the embedding runtime fails against a model the config legitimately declared.

`recordModelPath` now canonicalizes the fields the runtime canonicalizes, `addEmbeddingModelRequiredFiles` keys the #2172 weight requirements off the same resolved path, and the embedding and modality feature gates compare in that same path space so a disabled model is still skipped. `ModelID` deliberately stays literal: the built-in classifiers pass it to the bindings verbatim, so resolving it here would move the download away from the directory they load. Module affected: `Router`

The issue frames this as completeness requirements being bypassed. That is the smaller half. The requirements are recorded against a directory that is also the wrong download target, so the snapshot itself lands in the wrong place.

## Test Plan

```bash
cd src/semantic-router && go test ./pkg/modeldownload/ -count=1
make test-semantic-router
make go-lint
make check-go-mod-tidy
make agent-ci-lint CHANGED_FILES="src/semantic-router/pkg/modeldownload/config_parser.go,src/semantic-router/pkg/modeldownload/feature_gates.go,src/semantic-router/pkg/modeldownload/model_path_alias_test.go"
```

To confirm the tests are not vacuous, revert each part of the fix and re-run.

For the behavior itself, take `config/config.yaml`, point `mmbert_model_path` at an alias of the same model, load it through `config.Load`, and compare `BuildModelSpecs` output against `config.ResolveModelPath` on the configured value.

## Test Result

Loading the shipped `config/config.yaml` with only `mmbert_model_path` changed, on `main`:

```
configured mmbert_model_path: "mmbert"
runtime loads:                "models/mmbert-embed-32k-2d-matryoshka"
downloader fetches:           nothing

configured mmbert_model_path: "models/mom-embedding-ultra"
runtime loads:                "models/mmbert-embed-32k-2d-matryoshka"
downloader fetches:           "models/mom-embedding-ultra"
```

On this branch both forms agree with the runtime:

```
configured mmbert_model_path: "mmbert"
runtime loads:                "models/mmbert-embed-32k-2d-matryoshka"
downloader fetches:           "models/mmbert-embed-32k-2d-matryoshka"

configured mmbert_model_path: "models/mom-embedding-ultra"
runtime loads:                "models/mmbert-embed-32k-2d-matryoshka"
downloader fetches:           "models/mmbert-embed-32k-2d-matryoshka"
```

The four new tests fail on the base, for example:

```
--- FAIL: TestBuildModelSpecsTargetsTheDirectoryTheRuntimeLoads/bare_alias
    BuildModelSpecs() returned 0 specs for "mmbert", want 1 for "models/mmbert-embed-32k-2d-matryoshka"
--- FAIL: TestBuildModelSpecsTargetsTheDirectoryTheRuntimeLoads/models-prefixed_alias
    BuildModelSpecs() downloads "models/mom-embedding-ultra", but the runtime loads "models/mmbert-embed-32k-2d-matryoshka"
```

Reverting each part of the change in turn fails at least one test every time:

| Reverted | Fails |
| --- | --- |
| collector resolution | `TargetsTheDirectoryTheRuntimeLoads/bare_alias`, `/models-prefixed_alias`, `AliasedEmbeddingModelKeepsWeightRequirements` |
| required-files resolution | `AliasedEmbeddingModelKeepsWeightRequirements` |
| feature-gate resolution | `AliasedEmbeddingModelStillSkippedForRemoteBackend` |
| `ModelID` carve-out | `KeepsClassifierModelIDLiteral` |

`make test-semantic-router`, `make go-lint` (0 issues), `make check-go-mod-tidy`, and `make agent-ci-lint` all pass.

One thing I did not change: `ModelID` and `*ModelPath` still resolve aliases differently across the repo, and this PR matches that split rather than settling it. Unifying it means touching the classifier mapping paths too, which is a much wider change than this issue. Worth noting for merge order that #2820 also edits `config_parser.go`; whichever lands second needs a small rebase.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
