### PR TITLE
[Docs] Update Huamin and Xunzhuo blog author roles

### DIFF
--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,6 +1,6 @@
 rootfs:
   name: Huamin Chen
-  title: Distinguished Engineer @ Red Hat
+  title: AI @Microsoft
   url: https://github.com/rootfs
   image_url: /img/team/huamin.png
 
@@ -18,7 +18,7 @@ yuezhu1:
 
 Xunzhuo:
   name: Xunzhuo Liu
-  title: Intelligent Routing @vLLM
+  title: Intelligent Routing @vLLM | Open Source & AI @AMD
   url: https://github.com/Xunzhuo
   image_url: /img/team/xunzhuo.png
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml
@@ -1,6 +1,6 @@
 rootfs:
   name: Huamin Chen
-  title: Distinguished Engineer @ Red Hat
+  title: AI @Microsoft
   url: https://github.com/rootfs
   image_url: /img/team/huamin.png
 
@@ -18,7 +18,7 @@ yuezhu1:
 
 Xunzhuo:
   name: Xunzhuo Liu
-  title: Intelligent Routing @vLLM
+  title: Intelligent Routing @vLLM | Open Source & AI @AMD
   url: https://github.com/Xunzhuo
   image_url: /img/team/xunzhuo.png
 


### PR DESCRIPTION
Closes #2852

## Purpose

- Update the English and Simplified Chinese blog author metadata for Huamin Chen to `AI @Microsoft`.
- Update Xunzhuo Liu's blog author metadata to `Intelligent Routing @vLLM | Open Source & AI @AMD`.
- Keep the localized author registries synchronized. This change affects `Docs` only.

## Test Plan

- Run the repository's lightweight docs CI gate for the two changed author registries.
- Build the Docusaurus production site for all configured locales.
- Verify the generated English and Simplified Chinese blog pages contain both updated titles.

## Test Result

- `make agent-docs-ci-gate AGENT_BASE_REF=origin/main CHANGED_FILES="website/blog/authors.yml website/i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml"` passed.
- The Docusaurus production build succeeded for `en` and `zh-Hans`.
- Generated pages contain both updated author titles in both locales.
- Existing Docusaurus warnings are unrelated to this metadata-only change.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses the `[Docs]` module prefix.
- [x] The PR affects only the `Docs` module.
- [x] Commits in this PR are signed off with `git commit -s`.
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and results.

</details>
