### PR TITLE
[Docs] Remove non-working hosted playground credentials from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ curl -fsSL https://vllm-sr.ai/install.sh | bash
 For platform notes, detailed setup options, and troubleshooting, see the **[Installation Guide](https://vllm-sr.ai/docs/installation/)**.
 
 <details>
-<summary>Online playground credentials</summary>
+<summary>Trying the hosted Playground</summary>
 
-- Username: `love@vllm-sr.ai`
-- Password: `vllm-sr`
+The hosted [Playground](https://app.vllm-sr.ai/playground) does not currently respond, so it is not usable for a public trial.
+
+To try vLLM Semantic Router now, install it with the command above and run `vllm-sr serve`—first-run setup mode prompts you to create your own dashboard admin account.
 
 </details>
 


### PR DESCRIPTION
Fixes #2572

## Purpose

- **What:** the root README published shared Playground credentials (`love@vllm-sr.ai` / `vllm-sr`) under **Online playground credentials**. This drops that block and says the hosted Playground is not currently usable, pointing readers at the local `vllm-sr serve` path instead.
- **Why:** the credentials are reported as HTTP 401 in #2572. What is observable today is worse than a 401: `app.vllm-sr.ai` does not respond at all, so a reader following the README has nothing to log into. Nothing in this repo seeds that account either, since `EnsureBootstrapAdmin` only reads deployment-time `DASHBOARD_ADMIN_*`.
- **Module:** `Docs`.

The wording deliberately states only what can be observed and does not claim the account was removed. If you intend to restore the demo account rather than retire it, say so and I will rework this to document the new credentials instead. The issue's only comment ("shall we update the credentials?") has not been answered, and this PR states product status on your hosted service, so I would rather follow your call here.

## Test Plan

```bash
markdownlint -c tools/linter/markdown/markdownlint.yaml README.md
```

Reachability rechecked directly against the host before writing the wording.

## Test Result

- `markdownlint` exits 0.
- `curl --max-time 20 https://app.vllm-sr.ai/playground` → `curl: (28) Connection timed out`. Port 80 behaves the same. DNS resolves to `165.245.131.56`, so this is a dead listener, not a DNS problem. Control: `curl https://vllm-sr.ai/` → `200`.

Follow-up, not changed here: the website still promotes the Playground at `website/src/pages/index.tsx:400`, `website/src/components/homepage/EcosystemStrip.tsx:54`, `website/src/components/homepage/HomepageClosing.tsx:40`, and `website/docusaurus.config.ts:277`.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
