### PR TITLE
[Fleet-Sim] fix: correct preemption bookkeeping in Instance._start_next

### DIFF
--- a/src/fleet-sim/fleet_sim/core/instance.py
+++ b/src/fleet-sim/fleet_sim/core/instance.py
@@ -52,6 +52,7 @@ class _Event:
 
     time: float
     req: Request
+    epoch: int  # req.admission_epoch at push time; stale if it no longer matches
 
     def __lt__(self, other: _Event) -> bool:
         return self.time < other.time
@@ -189,9 +190,10 @@ class Instance:
                 while self._events and self._events[0].time <= self._now:
                     ev = heapq.heappop(self._events)
                     req = ev.req
-                    if req.preempted:
-                        # This completion event belongs to a preempted request;
-                        # the slot/blocks were already released at preemption time.
+                    if ev.epoch != req.admission_epoch:
+                        # Stale: req was preempted and/or re-admitted since this
+                        # event was scheduled, so its slot/blocks belong to a
+                        # later admission (or none, if still preempted).
                         continue
                     req.end_time = self._now
                     req.state = RequestState.DONE
@@ -221,33 +223,39 @@ class Instance:
         exceeded, preempts the longest currently-active request instead of
         admitting the new one.
         """
-        req = self._queue[0]  # peek; may not admit
+        req = self._queue.popleft()
         req_blocks = math.ceil((req.l_in + req.l_out) / self.gpu.blk_size)
 
         # ── Preempt longest active request if KV budget is tight ──────────
+        n_evicted = 0
         while (
             self._used_kv_blocks + req_blocks > self._total_kv_blocks
             and self._active_reqs
         ):
             victim = max(self._active_reqs, key=lambda r: r.l_in + r.l_out)
             victim_blocks = math.ceil((victim.l_in + victim.l_out) / self.gpu.blk_size)
-            # Invalidate the victim's pending completion event via the preempted flag
+            # Bump the epoch so the victim's in-flight event reads as stale
+            # even once it is later re-admitted and preempted resets to False.
             victim.preempted = True
+            victim.admission_epoch += 1
             self._active_reqs.remove(victim)
             self._active_slots -= 1
             self._used_kv_blocks -= victim_blocks
             # Re-queue the victim at head so it is retried first
             self._queue.appendleft(victim)
+            n_evicted += 1
             self.total_preempted += 1
 
-        # If still no room (budget too small for even 1 req), skip for now
+        # If still no room (budget too small for even 1 req), put req back
+        # after the victims just re-queued and skip for now.
         if self._used_kv_blocks + req_blocks > self._total_kv_blocks:
+            self._queue.insert(n_evicted, req)
             return
 
-        self._queue.popleft()
         req.start_time = now
         req.state = RequestState.PREFILLING
         req.preempted = False  # reset preemption flag on re-admission
+        req.admission_epoch += 1
         self._active_slots += 1
         self._used_kv_blocks += req_blocks
         self._active_reqs.append(req)
@@ -297,7 +305,7 @@ class Instance:
         s_eff = s_raw_full / self.n_slots
 
         completion_time = now + s_eff
-        heapq.heappush(self._events, _Event(completion_time, req))
+        heapq.heappush(self._events, _Event(completion_time, req, req.admission_epoch))
 
     def next_event_time(self) -> float:
         """Time of the next completion event (or now if queue can be served)."""

--- a/src/fleet-sim/fleet_sim/core/request.py
+++ b/src/fleet-sim/fleet_sim/core/request.py
@@ -60,6 +60,7 @@ class Request:
 
     # reliability
     preempted: bool = False
+    admission_epoch: int = 0  # bumped on (re-)admission and on preemption
 
     # state
     state: RequestState = field(default=RequestState.PENDING, init=False)

--- a/src/fleet-sim/tests/test_instance.py
+++ b/src/fleet-sim/tests/test_instance.py
@@ -1,0 +1,93 @@
+"""Regression tests for Instance preemption bookkeeping.
+
+These drive `_start_next` directly (rather than through `advance_to`) so
+each admission/eviction step can be asserted in isolation, independent of
+how the surrounding simulation happens to schedule events.
+"""
+
+import heapq
+
+from fleet_sim.core.instance import Instance, _Event
+from fleet_sim.core.request import Request, RequestState
+from fleet_sim.gpu_profiles.manual import ManualProfile
+
+
+def _profile():
+    # W=1, H=0 makes iter_latency == W regardless of active count, so
+    # completion times are exactly predictable: s_eff = (1 + l_out) / n_slots.
+    return ManualProfile(
+        name="tiny",
+        W=1.0,
+        H=0.0,
+        chunk=1000,
+        blk_size=1,
+        total_kv_blks=12,
+        max_slots=100,
+        cost_per_hr=1.0,
+        calibration_ctx=6,
+    )
+
+
+def _instance():
+    return Instance(instance_id=0, pool_id="pool", gpu=_profile(), max_ctx=6)
+
+
+def _req(req_id, l_out):
+    return Request(req_id=req_id, arrival_time=0.0, l_in=1, l_out=l_out)
+
+
+class TestPreemptionQueueBookkeeping:
+    def test_admission_that_evicts_removes_the_admitted_request_from_queue(self):
+        inst = _instance()
+        a = _req(1, l_out=9)  # 10 blocks
+        b = _req(2, l_out=1)  # 2 blocks
+        c = _req(3, l_out=9)  # 10 blocks; only fits once a is evicted
+
+        for r in (a, b, c):
+            inst.accept(r)
+
+        inst._start_next(0.0)  # admits a
+        inst._start_next(0.0)  # admits b; budget now exactly full (10 + 2 == 12)
+        assert list(inst._queue) == [c]
+
+        inst._start_next(1.0)  # c's own admission must evict a
+
+        assert c not in inst._queue
+        assert c in inst._active_reqs
+        assert list(inst._queue) == [a]
+        assert a not in inst._active_reqs
+        assert a.preempted is True
+
+    def test_stale_event_from_a_preempted_admission_is_ignored_after_readmission(self):
+        inst = _instance()
+        a = _req(1, l_out=9)
+
+        # Admit `a`, matching the bookkeeping _start_next performs.
+        a.start_time = 0.0
+        a.state = RequestState.DECODING
+        a.admission_epoch = 1
+        inst._active_slots = 1
+        inst._used_kv_blocks = 10
+        inst._active_reqs.append(a)
+        heapq.heappush(inst._events, _Event(time=5.0, req=a, epoch=1))
+
+        # Preempt `a`, as the eviction loop in _start_next does.
+        a.preempted = True
+        a.admission_epoch += 1
+        inst._active_reqs.remove(a)
+        inst._active_slots -= 1
+        inst._used_kv_blocks -= 10
+
+        # Re-admit before the stale event's time is reached.
+        inst._queue.appendleft(a)
+        inst._start_next(1.0)
+
+        assert a.preempted is False
+        assert a.admission_epoch == 3  # bumped at preemption, then at re-admission
+
+        completed = inst.advance_to(100.0)
+
+        assert [r.req_id for r in completed] == [1]
+        assert inst.total_requests == 1
+        assert inst._active_slots == 0
+        assert inst._used_kv_blocks == 0

--- a/website/docs/fleet-sim/sim-algorithms.md
+++ b/website/docs/fleet-sim/sim-algorithms.md
@@ -236,7 +236,9 @@ TPOT = (physical_end_time − first_token_time) / (l_out − 1)    [for l_out > 
 When a new request's KV block requirement would exceed the GPU's budget, the
 longest currently-active request is preempted:
 
-1. Invalidate the victim's pending completion event (`req.preempted = True`).
+1. Invalidate the victim's pending completion event: set `req.preempted = True`
+   and bump `req.admission_epoch`, so the event is skipped even once the
+   victim is re-admitted and `preempted` resets to `False`.
 2. Release victim's KV blocks and slot.
 3. Re-queue the victim at the **head of the queue** (priority re-admission).
 4. Retry admission for the new request.


### PR DESCRIPTION
Closes #2890

## Purpose

`Instance._start_next` has two bookkeeping bugs when the KV block budget forces a preemption (see #2890 for the full description and a standalone repro):

1. It peeks the queue head into `req` before the preemption loop runs, but the loop's `appendleft(victim)` shifts the queue, so the later unconditional `self._queue.popleft()` removes the wrong item. The admitted request is never dequeued: it becomes active while also staying in `self._queue`.
2. A preempted request's old completion event stays in the heap. The only guard is `req.preempted`, which the re-admission path resets to `False`; if that happens before the stale event's scheduled time, it fires as a second, spurious completion, double-counting `total_requests`/`completed` and double-decrementing `active_slots`/`used_kv_blocks`.

Module: `Fleet-Sim`

## Fix

- Pop `req` from the queue before running the preemption loop, and put it back at the correct position (after the just-evicted victims) if admission still fails, instead of blindly popping whatever is now at the front.
- Add `Request.admission_epoch`, bumped on every preemption and every (re-)admission, stamped onto each `_Event` at push time. `advance_to` now drops an event whose stamped epoch no longer matches the request's current epoch, which correctly invalidates a stale event regardless of how many preempt/re-admit cycles a request has been through (the old `preempted`-flag check only handled one cycle).

## Test Plan

`tests/test_instance.py` (new) drives `_start_next` directly so each admission/eviction step can be asserted without depending on how a full simulation happens to schedule events:

- `test_admission_that_evicts_removes_the_admitted_request_from_queue`: after an admission that forces an eviction, the admitted request is not left in `self._queue`, and the evicted request is queued instead of also being active.
- `test_stale_event_from_a_preempted_admission_is_ignored_after_readmission`: a manually-injected stale event (mismatched epoch) is skipped by `advance_to`, and the fresh event for the same request still fires exactly once.

Both fail on `main` (the first with an `AssertionError`, the second with a `TypeError` since `_Event` has no `epoch` field yet) and pass on this branch.

## Test Result

- New tests pass on this branch, fail on `main`.
- Full existing suite still passes: `python -m pytest tests/` (306 passed), verified in a clean `python:3.11-slim` container, and the new/existing `tests/test_instance.py` and core suites also verified on `python:3.10-slim`.
- `ruff check` and `black --check` are clean on the changed files (the repo's `fleet_sim/__init__.py` etc. already fail `ruff check` on `main`, unrelated to this change).
- Not verified: behavior of this fix under the router/optimizer's full CDF-driven simulation loop; the fix is exercised directly against `Instance`.
