### PR TITLE
fix(cli): anchor Envoy path rewrite so a v1 base_url prefix is not applied twice

### DIFF
--- a/src/vllm-sr/cli/templates/envoy.template.yaml
+++ b/src/vllm-sr/cli/templates/envoy.template.yaml
@@ -65,12 +65,15 @@ static_resources:
                   # Rewrite Host header to match upstream server
                   host_rewrite_literal: "{{ model.endpoints[0].host_authority }}"
                   {% if model.path_prefix %}
-                  # Prepend path prefix to all requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions)
+                  # Prepend path prefix to all requests (e.g., /v1/chat/completions -> /compatible-mode/v1/chat/completions).
+                  # The pattern is anchored at the path-segment boundary so re-evaluating the
+                  # route after ext_proc header injection is a no-op: the rewritten path no
+                  # longer starts with /v1/ and cannot match the pattern a second time.
                   regex_rewrite:
                     pattern:
                       google_re2: {}
-                      regex: "^/v1(.*)$"
-                    substitution: "{{ model.path_prefix }}\\1"
+                      regex: "^/v1/(.*)$"
+                    substitution: "{{ model.path_prefix }}/\\1"
                   {% endif %}
               {% endfor %}
               {% for model in anthropic_models %}
@@ -117,12 +120,15 @@ static_resources:
                   host_rewrite_literal: "{{ models[0].endpoints[0].host_authority }}"
                   {% endif %}
                   {% if models and models[0].path_prefix %}
-                  # Prepend path prefix to all requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions)
+                  # Prepend path prefix to all requests (e.g., /v1/chat/completions -> /compatible-mode/v1/chat/completions).
+                  # The pattern is anchored at the path-segment boundary so re-evaluating the
+                  # route after ext_proc header injection is a no-op: the rewritten path no
+                  # longer starts with /v1/ and cannot match the pattern a second time.
                   regex_rewrite:
                     pattern:
                       google_re2: {}
-                      regex: "^/v1(.*)$"
-                    substitution: "{{ models[0].path_prefix }}\\1"
+                      regex: "^/v1/(.*)$"
+                    substitution: "{{ models[0].path_prefix }}/\\1"
                   {% endif %}
           http_filters:
           {% if listener.api_keys %}

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from pathlib import Path
 
@@ -106,7 +107,8 @@ def test_backend_ref_ip_port_path_produces_correct_envoy_cluster_and_route(
 ):
     """Backend ref http://10.0.0.1:8000/v1 should split into address=10.0.0.1,
     port=8000, host_authority=10.0.0.1:8000, path_prefix=/v1, and the route
-    should use regex ^/v1(.*)$ to avoid duplicating /v1."""
+    should use the segment-anchored regex ^/v1/(.*)$ so the rewrite is
+    idempotent and /v1 is never duplicated."""
     rendered = _render_envoy_config(
         tmp_path,
         monkeypatch,
@@ -155,8 +157,8 @@ routing:
     route = _model_route(rendered, "test-model")
     route_action = route["route"]
     assert route_action["host_rewrite_literal"] == "10.0.0.1:8000"
-    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1(.*)$"
-    assert route_action["regex_rewrite"]["substitution"] == "/v1\\1"
+    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1/(.*)$"
+    assert route_action["regex_rewrite"]["substitution"] == "/v1/\\1"
 
 
 def test_provider_reliability_renders_retry_outlier_and_least_request(
@@ -279,8 +281,8 @@ routing:
     route_action = route["route"]
     # standard port 443 → host_authority should omit port
     assert route_action["host_rewrite_literal"] == "api.example.com"
-    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1(.*)$"
-    assert route_action["regex_rewrite"]["substitution"] == "/compatible-mode/v1\\1"
+    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1/(.*)$"
+    assert route_action["regex_rewrite"]["substitution"] == "/compatible-mode/v1/\\1"
 
 
 def test_backend_ref_https_base_url_uses_tls_and_explicit_extra_headers(
@@ -338,7 +340,7 @@ routing:
     route = _model_route(rendered, "test-model")
     route_action = route["route"]
     assert route_action["host_rewrite_literal"] == "openrouter.ai"
-    assert route_action["regex_rewrite"]["substitution"] == "/api/v1\\1"
+    assert route_action["regex_rewrite"]["substitution"] == "/api/v1/\\1"
 
     headers = {
         item["header"]["key"]: item["header"]["value"]
@@ -446,3 +448,69 @@ routing:
         endpoint["address"]["socket_address"]["address"] == "vllm-sr-router-container"
     )
     assert endpoint["hostname"] == "vllm-sr-router-container"
+
+
+def test_backend_ref_v1_prefixed_base_url_rewrite_is_idempotent(tmp_path, monkeypatch):
+    """A backend whose base_url path starts with /v1 (e.g. Gemini's
+    https://generativelanguage.googleapis.com/v1beta/openai) must generate a
+    rewrite that is safe to apply twice: when ext_proc mutates the headers and
+    Envoy re-runs route selection, the already-rewritten path must not match
+    the pattern again and get the prefix doubled."""
+    rendered = _render_envoy_config(
+        tmp_path,
+        monkeypatch,
+        """
+version: v0.3
+listeners:
+  - name: "http-8899"
+    address: "0.0.0.0"
+    port: 8899
+providers:
+  defaults:
+    default_model: "gemini-3.5-flash"
+  models:
+    - name: "gemini-3.5-flash"
+      backend_refs:
+        - name: "primary"
+          base_url: "https://generativelanguage.googleapis.com/v1beta/openai"
+          provider: "openai"
+          weight: 100
+routing:
+  modelCards:
+    - name: "gemini-3.5-flash"
+  decisions:
+    - name: "default-route"
+      description: "default route"
+      priority: 100
+      rules:
+        operator: "AND"
+        conditions: []
+      modelRefs:
+        - model: "gemini-3.5-flash"
+          use_reasoning: false
+""",
+        extproc_host="localhost",
+        router_api_host="localhost",
+    )
+
+    model_route = _model_route(rendered, "gemini-3.5-flash")["route"]
+    rewrite = model_route["regex_rewrite"]
+    regex = rewrite["pattern"]["regex"]
+    substitution = rewrite["substitution"]
+    assert regex == "^/v1/(.*)$"
+    assert substitution == "/v1beta/openai/\\1"
+
+    # default_model points at the same backend, so the default route carries an
+    # identical rewrite block; it must be anchored the same way.
+    routes = rendered["static_resources"]["listeners"][0]["filter_chains"][0][
+        "filters"
+    ][0]["typed_config"]["route_config"]["virtual_hosts"][0]["routes"]
+    default_route = routes[-1]["route"]
+    assert default_route["regex_rewrite"]["pattern"]["regex"] == "^/v1/(.*)$"
+    assert default_route["regex_rewrite"]["substitution"] == "/v1beta/openai/\\1"
+
+    # Simulate Envoy applying the rewrite a second time after route recompute:
+    # the second pass must be a no-op, not a doubled prefix.
+    first_pass = re.sub(regex, substitution, "/v1/chat/completions")
+    assert first_pass == "/v1beta/openai/chat/completions"
+    assert re.sub(regex, substitution, first_pass) == first_pass


### PR DESCRIPTION
Closes #2885

## Purpose

Backends whose `base_url` path starts with `/v1` (Gemini's `generativelanguage.googleapis.com/v1beta/openai` is the one I hit) generate an Envoy `regex_rewrite` of `^/v1(.*)$` with substitution `<prefix>\1`. After ext_proc injects `x-selected-model` and Envoy re-runs route selection, the already-rewritten path still matches the pattern, so the rewrite fires again and the prefix ends up doubled:

`/v1/chat/completions` -> `/v1beta/openai/chat/completions` -> `/v1beta/openaibeta/openai/chat/completions` (404 from upstream)

Azure (`/openai/v1`) and other prefixes that don't start with `/v1` never match a second time, which is why this only showed up with Gemini-style base URLs.

Fix: anchor the pattern at the path-segment boundary (`^/v1/(.*)$`, substitution `<prefix>/\1`) so applying it to its own output is a no-op. This affects the model route and the default route (both emit the same block).

Module: CLI (envoy template + config generator tests)

## Test Plan

- `python -m pytest src/vllm-sr/tests/test_config_generator.py` — full file, includes existing rewrite assertions plus a new regression test for a `/v1`-prefixed base_url
- New test also simulates applying the generated rewrite twice to confirm the second pass is a no-op
- Ran the whole `src/vllm-sr/tests` suite as a sanity check (547 passed; the 32 failures are pre-existing `os.fchmod` issues on Windows, unrelated to this change)

## Test Result

8/8 tests in `test_config_generator.py` pass, including the new `test_backend_ref_v1_prefixed_base_url_rewrite_is_idempotent`.

Verified against several real base URLs that the rewritten path is stable after a second application:
- `/v1beta/openai` (Gemini) — now rewritten exactly once
- `/openai/v1` (Azure), `/api/v1`, `/compatible-mode/v1` — unchanged behavior
