### PR TITLE
[Dashboard] Key web search rate limit on the authenticated user

### DIFF
--- a/dashboard/backend/handlers/websearch.go
+++ b/dashboard/backend/handlers/websearch.go
@@ -7,12 +7,15 @@ import (
 	"io"
 	"log"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
 )
 
 // ========================
@@ -56,10 +59,10 @@ const (
 	maxRetries         = 3 // Retry attempts for transient failures
 	retryBaseDelay     = 1 * time.Second
 	rateLimitWindow    = time.Minute // Rate limit window
-	rateLimitMaxReqs   = 5           // Max requests per window per IP (strict for public service)
+	rateLimitMaxReqs   = 5           // Max requests per window per client (strict for public service)
 	globalRateLimit    = 30          // Global max requests per window (0.5 req/sec to avoid ban)
 	maxConcurrent      = 2           // Max concurrent outgoing requests (very conservative)
-	maxTrackedIPs      = 10000       // Max IPs to track (memory protection)
+	maxTrackedClients  = 10000       // Max clients to track (memory protection)
 	minRequestInterval = 1 * time.Second
 	maxRequestInterval = 3 * time.Second
 )
@@ -152,8 +155,8 @@ var globalRateLimiter = &rateLimiter{
 // Semaphore for concurrent request limiting
 var concurrentSem = make(chan struct{}, maxConcurrent)
 
-// isAllowed checks if a request from the given IP is allowed
-func (rl *rateLimiter) isAllowed(ip string) (bool, SearchErrorCode) {
+// isAllowed checks if a request from the given client is allowed
+func (rl *rateLimiter) isAllowed(client string) (bool, SearchErrorCode) {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
@@ -172,28 +175,28 @@ func (rl *rateLimiter) isAllowed(ip string) (bool, SearchErrorCode) {
 		return false, ErrCodeRateLimited
 	}
 
-	// Memory protection: limit tracked IPs
-	if len(rl.requests) >= maxTrackedIPs {
-		if _, exists := rl.requests[ip]; !exists {
+	// Memory protection: limit tracked clients
+	if len(rl.requests) >= maxTrackedClients {
+		if _, exists := rl.requests[client]; !exists {
 			return false, ErrCodeRateLimited
 		}
 	}
 
-	// Check per-IP rate limit
+	// Check per-client rate limit
 	var recentReqs []time.Time
-	for _, t := range rl.requests[ip] {
+	for _, t := range rl.requests[client] {
 		if t.After(windowStart) {
 			recentReqs = append(recentReqs, t)
 		}
 	}
 
 	if len(recentReqs) >= rateLimitMaxReqs {
-		rl.requests[ip] = recentReqs
+		rl.requests[client] = recentReqs
 		return false, ErrCodeRateLimited
 	}
 
 	// Record the request
-	rl.requests[ip] = append(recentReqs, now)
+	rl.requests[client] = append(recentReqs, now)
 	recentGlobal = append(recentGlobal, now)
 	rl.globalReqs = recentGlobal
 	return true, ""
@@ -595,23 +598,31 @@ func cleanExtraWhitespace(s string) string {
 // HTTP Handler
 // ========================
 
-// getClientIP extracts client IP from request
-func getClientIP(r *http.Request) string {
-	// Check X-Forwarded-For header (for proxied requests)
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		parts := strings.Split(xff, ",")
-		return strings.TrimSpace(parts[0])
+// clientKey returns the identity used for the per-client rate limit.
+//
+// The per-client budget exists to stop one person from hogging the shared
+// search budget, so the authenticated user is the right key: the id comes from
+// a validated session token and cannot be forged the way client-supplied proxy
+// headers can. The immediate peer address is the fallback for requests that
+// reach the handler without a session.
+func clientKey(r *http.Request) string {
+	if ac, ok := auth.AuthFromContext(r); ok && ac.UserID != "" {
+		return "user:" + ac.UserID
 	}
-	// Check X-Real-IP header
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
+	return "peer:" + peerIP(r.RemoteAddr)
+}
+
+// peerIP returns the immediate TCP peer without its port. Proxy headers such
+// as X-Forwarded-For are intentionally ignored here: they are caller-controlled
+// and would let a client mint a fresh identity for every request.
+func peerIP(remoteAddr string) string {
+	if remoteAddr == "" {
+		return "unknown"
 	}
-	// Fall back to RemoteAddr
-	ip := r.RemoteAddr
-	if idx := strings.LastIndex(ip, ":"); idx != -1 {
-		ip = ip[:idx]
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
 	}
-	return ip
+	return remoteAddr
 }
 
 // sendErrorResponse sends a JSON error response with code
@@ -645,11 +656,11 @@ func WebSearchHandler() http.HandlerFunc {
 			return
 		}
 
-		// Rate limiting check (per-IP + global)
-		clientIP := getClientIP(r)
-		allowed, errCode := globalRateLimiter.isAllowed(clientIP)
+		// Rate limiting check (per-client + global)
+		client := clientKey(r)
+		allowed, errCode := globalRateLimiter.isAllowed(client)
 		if !allowed {
-			log.Printf("Rate limit exceeded for IP: %s (code: %s)", clientIP, errCode)
+			log.Printf("Rate limit exceeded for client: %s (code: %s)", client, errCode)
 			sendErrorResponse(w, "", errCode, http.StatusTooManyRequests)
 			return
 		}
@@ -668,7 +679,7 @@ func WebSearchHandler() http.HandlerFunc {
 			return
 		}
 
-		log.Printf("Web search request: query=%q, num_results=%d, ip=%s", req.Query, req.NumResults, clientIP)
+		log.Printf("Web search request: query=%q, num_results=%d, client=%s", req.Query, req.NumResults, client)
 
 		// Perform search with retry
 		results, err := searchDuckDuckGo(req.Query, req.NumResults)

--- a/dashboard/backend/handlers/websearch_test.go
+++ b/dashboard/backend/handlers/websearch_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
+)
+
+// resetRateLimiter clears the shared limiter state so each test starts with a
+// fresh budget. Tests here must not run in parallel: the limiter is a package
+// global and the whole point is to observe its shared state.
+func resetRateLimiter() {
+	globalRateLimiter.mu.Lock()
+	defer globalRateLimiter.mu.Unlock()
+	globalRateLimiter.requests = make(map[string][]time.Time)
+	globalRateLimiter.globalReqs = nil
+}
+
+// webSearchRequest issues a POST to the web search handler with the given
+// identity and headers. An empty body is fine: the rate limit check runs before
+// the body is parsed, and an empty query is rejected with 400 after it, so the
+// test never touches DuckDuckGo.
+func webSearchRequest(t *testing.T, userID, remoteAddr, xff string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/tools/web-search", strings.NewReader("{}"))
+	if remoteAddr != "" {
+		req.RemoteAddr = remoteAddr
+	}
+	if xff != "" {
+		req.Header.Set("X-Forwarded-For", xff)
+	}
+	if userID != "" {
+		req = req.WithContext(auth.WithAuthContext(req.Context(), auth.AuthContext{
+			UserID: userID,
+			Perms:  map[string]bool{auth.PermToolsUse: true},
+		}))
+	}
+
+	rec := httptest.NewRecorder()
+	WebSearchHandler().ServeHTTP(rec, req)
+	return rec
+}
+
+// wantBudget checks that a request was let through (empty query -> 400) or was
+// rate limited (429), depending on what the test expects.
+func wantBudget(t *testing.T, rec *httptest.ResponseRecorder, want int, what string) {
+	t.Helper()
+	if rec.Code != want {
+		t.Fatalf("%s: status = %d, want %d", what, rec.Code, want)
+	}
+}
+
+func TestWebSearchPerClientLimitAppliesToAuthenticatedUser(t *testing.T) {
+	resetRateLimiter()
+
+	for i := 0; i < rateLimitMaxReqs; i++ {
+		rec := webSearchRequest(t, "user-a", "10.0.0.1", "")
+		wantBudget(t, rec, http.StatusBadRequest, fmt.Sprintf("request %d", i+1))
+	}
+
+	rec := webSearchRequest(t, "user-a", "10.0.0.1", "")
+	wantBudget(t, rec, http.StatusTooManyRequests, "6th request from the same user")
+}
+
+func TestWebSearchPerClientLimitIgnoresSpoofedProxyHeaders(t *testing.T) {
+	resetRateLimiter()
+
+	// The per-client key must come from the authenticated session, not from a
+	// caller-controlled header, so rotating X-Forwarded-For has no effect.
+	for i := 0; i < rateLimitMaxReqs; i++ {
+		xff := fmt.Sprintf("203.0.113.%d", i+1)
+		rec := webSearchRequest(t, "user-a", "10.0.0.1", xff)
+		wantBudget(t, rec, http.StatusBadRequest, fmt.Sprintf("request %d with spoofed XFF", i+1))
+	}
+
+	rec := webSearchRequest(t, "user-a", "10.0.0.1", "203.0.113.99")
+	wantBudget(t, rec, http.StatusTooManyRequests, "6th request with yet another spoofed XFF")
+}
+
+func TestWebSearchPerClientLimitIsPerUser(t *testing.T) {
+	resetRateLimiter()
+
+	for i := 0; i < rateLimitMaxReqs; i++ {
+		rec := webSearchRequest(t, "user-a", "10.0.0.1", "")
+		wantBudget(t, rec, http.StatusBadRequest, fmt.Sprintf("user-a request %d", i+1))
+	}
+
+	// A second user sharing the same peer address starts with a fresh budget.
+	for i := 0; i < rateLimitMaxReqs; i++ {
+		rec := webSearchRequest(t, "user-b", "10.0.0.1", "")
+		wantBudget(t, rec, http.StatusBadRequest, fmt.Sprintf("user-b request %d", i+1))
+	}
+
+	rec := webSearchRequest(t, "user-b", "10.0.0.1", "")
+	wantBudget(t, rec, http.StatusTooManyRequests, "user-b 6th request")
+}
+
+func TestWebSearchAnonymousRequestsAreKeyedOnPeerAddress(t *testing.T) {
+	resetRateLimiter()
+
+	// Without a session the handler falls back to the real peer address, still
+	// ignoring spoofed headers.
+	for i := 0; i < rateLimitMaxReqs; i++ {
+		xff := fmt.Sprintf("198.51.100.%d", i+1)
+		rec := webSearchRequest(t, "", "192.0.2.10", xff)
+		wantBudget(t, rec, http.StatusBadRequest, fmt.Sprintf("peer request %d with spoofed XFF", i+1))
+	}
+
+	rec := webSearchRequest(t, "", "192.0.2.10", "198.51.100.99")
+	wantBudget(t, rec, http.StatusTooManyRequests, "same peer with spoofed XFF")
+
+	rec = webSearchRequest(t, "", "192.0.2.11", "")
+	wantBudget(t, rec, http.StatusBadRequest, "different peer")
+}
+
+func TestPeerIPStripsPortAndIgnoresHostnames(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"192.0.2.1:54321", "192.0.2.1"},
+		{"[2001:db8::1]:443", "2001:db8::1"},
+		{"192.0.2.1", "192.0.2.1"},
+		{"", "unknown"},
+	}
+	for _, tc := range cases {
+		if got := peerIP(tc.in); got != tc.want {
+			t.Errorf("peerIP(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2849

## Purpose

- **What:** the web search endpoint's per-client rate limit is now keyed on the authenticated user instead of a client-supplied IP header.
- **Why:** `getClientIP()` took the first entry of `X-Forwarded-For` (or `X-Real-IP`) and trusted it. Those headers are plain text the caller controls, so any logged-in user could rotate them on every request, dodge the 5/min per-client budget entirely, and eat the shared 30/min global budget in a few seconds — locking everyone else out, admins included, for the rest of the minute.
- **Module:** Dashboard (`dashboard/backend/handlers/websearch.go`)

## Test Plan

- New tests in `websearch_test.go` (`go test ./handlers/ -run 'WebSearch|PeerIP' -v`):
  - same user rotating `X-Forwarded-For` on every request still hits the limit on the 6th call (the regression case from the issue)
  - two users behind the same peer address get independent budgets
  - anonymous fallback keys on the real peer address, also ignoring spoofed headers
- `go vet ./handlers/...` and `gofmt` are clean.

## Test Result

- All 5 new tests pass; `go test ./handlers/...` adds no failures over main on this machine. (The remaining package failures here are the environment-dependent ones — cgo/sqlite, docker, python — and exist on main too.)

## Notes

- Behavior change: per-client accounting is now per authenticated user rather than per IP. That matches the limit's stated purpose (one person, one budget) and closes the header-spoofing bypass. If a deployment sits behind a trusted reverse proxy and relied on per-IP fallback for anonymous requests, that can be re-added later behind an allowlist of proxy addresses — say the word and I'll follow up.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
