### PR TITLE
[Router] Honor the configured consistency_level in the Milvus semantic cache

### DIFF
--- a/src/semantic-router/pkg/cache/exact_cache_milvus.go
+++ b/src/semantic-router/pkg/cache/exact_cache_milvus.go
@@ -32,6 +32,7 @@ func (c *MilvusCache) FindExact(
 		nil,
 		expr,
 		[]string{"response_body"},
+		c.searchQueryOptions()...,
 	)
 	if err != nil {
 		return LookupResult{}, fmt.Errorf("milvus exact lookup failed: %w", err)

--- a/src/semantic-router/pkg/cache/milvus_cache.go
+++ b/src/semantic-router/pkg/cache/milvus_cache.go
@@ -73,6 +73,7 @@ func NewMilvusCache(options MilvusCacheOptions) (*MilvusCache, error) {
 	if m := milvusConfig.Collection.VectorField.MetricType; m != "IP" && m != "COSINE" && m != "L2" {
 		logging.Warnf("MilvusCache: unrecognized metric_type %q; scores will be compared as similarities without conversion", m)
 	}
+	warnUnrecognizedMilvusConsistencyLevel(milvusConfig.Search.ConsistencyLevel)
 	logging.Debugf("MilvusCache: config loaded - host=%s:%d, collection=%s, dimension=%d",
 		milvusConfig.Connection.Host, milvusConfig.Connection.Port, milvusConfig.Collection.Name,
 		semanticCacheEmbeddingDimension(milvusConfig.Collection.VectorField.Dimension, options.EmbeddingModel))
@@ -362,8 +363,8 @@ func (c *MilvusCache) createCollection(ctx context.Context) error {
 		},
 	}
 
-	// Create collection
-	if createErr := c.client.CreateCollection(ctx, schema, 1); createErr != nil {
+	// Create collection at the configured consistency level (SDK default when unset)
+	if createErr := c.client.CreateCollection(ctx, schema, 1, c.createCollectionOptions()...); createErr != nil {
 		return createErr
 	}
 
@@ -473,7 +474,7 @@ func (c *MilvusCache) UpdateWithResponse(requestID string, responseBody []byte, 
 	// Note: We don't explicitly request "id" since Milvus auto-includes the primary key
 	// We request model, query, request_body and will detect which column is which
 	results, err := c.client.Query(ctx, c.collectionName, []string{}, queryExpr,
-		[]string{"model", "query", "request_body"})
+		[]string{"model", "query", "request_body"}, c.searchQueryOptions()...)
 	if err != nil {
 		logging.Debugf("MilvusCache.UpdateWithResponse: query failed: %v", err)
 		metrics.RecordCacheOperation("milvus", "update_response", "error", time.Since(start).Seconds())

--- a/src/semantic-router/pkg/cache/milvus_cache_admin.go
+++ b/src/semantic-router/pkg/cache/milvus_cache_admin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/milvus-io/milvus-sdk-go/v2/client"
 	"github.com/milvus-io/milvus-sdk-go/v2/entity"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -88,6 +89,16 @@ func (c *MilvusCache) SearchDocuments(ctx context.Context, collectionName string
 		filterExpr = fmt.Sprintf("%s != \"\"", contentField)
 	}
 
+	// The cache's configured consistency level applies only to its own
+	// collection: a foreign collection (e.g. a RAG knowledge base) keeps its
+	// server-side level, which the SDK adopts when no option is passed.
+	// Overriding it here could weaken reads — a Session level degrades to
+	// Eventually on a collection this process never writes to.
+	var searchOpts []client.SearchQueryOptionFunc
+	if collectionName == c.collectionName {
+		searchOpts = c.searchQueryOptions()
+	}
+
 	// Use Milvus Search with collection-specific or default parameters
 	searchResult, err := c.client.Search(
 		ctx,
@@ -100,7 +111,7 @@ func (c *MilvusCache) SearchDocuments(ctx context.Context, collectionName string
 		entity.MetricType(actualMetricType),
 		topK,
 		searchParam,
-		c.searchQueryOptions()...,
+		searchOpts...,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("milvus search failed: %w", err)

--- a/src/semantic-router/pkg/cache/milvus_cache_admin.go
+++ b/src/semantic-router/pkg/cache/milvus_cache_admin.go
@@ -100,6 +100,7 @@ func (c *MilvusCache) SearchDocuments(ctx context.Context, collectionName string
 		entity.MetricType(actualMetricType),
 		topK,
 		searchParam,
+		c.searchQueryOptions()...,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("milvus search failed: %w", err)

--- a/src/semantic-router/pkg/cache/milvus_cache_fetch.go
+++ b/src/semantic-router/pkg/cache/milvus_cache_fetch.go
@@ -33,6 +33,7 @@ func (c *MilvusCache) GetAllEntries(ctx context.Context) ([]string, [][]float32,
 			milvusStringLiteral(exactCacheQueryMarker),
 		),
 		[]string{"request_id", c.config.Collection.VectorField.Name}, // Get IDs and embeddings
+		c.searchQueryOptions()...,
 	)
 	if err != nil {
 		logging.Warnf("MilvusCache.GetAllEntries: query failed: %v", err)
@@ -127,6 +128,7 @@ func (c *MilvusCache) GetByID(ctx context.Context, requestID, model string) ([]b
 			milvusStringLiteral(model),
 		),
 		[]string{"response_body"}, // Only fetch document, not embedding!
+		c.searchQueryOptions()...,
 	)
 	if err != nil {
 		logging.Debugf("MilvusCache.GetByID: query failed: %v", err)

--- a/src/semantic-router/pkg/cache/milvus_cache_similar.go
+++ b/src/semantic-router/pkg/cache/milvus_cache_similar.go
@@ -74,6 +74,7 @@ func (c *MilvusCache) milvusSearchSimilarVectors(
 		entity.MetricType(c.config.Collection.VectorField.MetricType),
 		c.config.Search.TopK,
 		searchParam,
+		c.searchQueryOptions()...,
 	)
 }
 

--- a/src/semantic-router/pkg/cache/milvus_consistency_level.go
+++ b/src/semantic-router/pkg/cache/milvus_consistency_level.go
@@ -1,0 +1,68 @@
+package cache
+
+import (
+	"strings"
+
+	"github.com/milvus-io/milvus-sdk-go/v2/client"
+	"github.com/milvus-io/milvus-sdk-go/v2/entity"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// resolveMilvusConsistencyLevel maps a configured consistency level name to
+// the SDK constant. Names are matched case-insensitively with surrounding
+// whitespace trimmed. ok is false when the name is empty or unrecognized; the
+// caller then leaves the option unset so the Milvus SDK default (Bounded)
+// stays in effect, preserving today's behavior for deployments that do not
+// pin a level.
+func resolveMilvusConsistencyLevel(name string) (entity.ConsistencyLevel, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "strong":
+		return entity.ClStrong, true
+	case "session":
+		return entity.ClSession, true
+	case "bounded":
+		return entity.ClBounded, true
+	case "eventually":
+		return entity.ClEventually, true
+	default:
+		return entity.ClStrong, false
+	}
+}
+
+// searchQueryOptions returns the read options that pin every Milvus search
+// and query the cache issues to the configured consistency level. An empty or
+// unrecognized level yields no options, so the SDK default applies and the
+// behavior of existing deployments is unchanged.
+func (c *MilvusCache) searchQueryOptions() []client.SearchQueryOptionFunc {
+	level, ok := resolveMilvusConsistencyLevel(c.config.Search.ConsistencyLevel)
+	if !ok {
+		return nil
+	}
+	return []client.SearchQueryOptionFunc{client.WithSearchQueryConsistencyLevel(level)}
+}
+
+// warnUnrecognizedMilvusConsistencyLevel logs a warning when a configured
+// consistency level name is not one of the supported values, so a typo
+// surfaces instead of silently keeping the SDK default. An empty value is
+// the documented "use the SDK default" case and is not warned about.
+func warnUnrecognizedMilvusConsistencyLevel(name string) {
+	if name == "" {
+		return
+	}
+	if _, ok := resolveMilvusConsistencyLevel(name); ok {
+		return
+	}
+	logging.Warnf("MilvusCache: unrecognized consistency_level %q (valid: Strong, Session, Bounded, Eventually); leaving the Milvus SDK default in effect", name)
+}
+
+// createCollectionOptions returns the collection-creation options that pin a
+// newly created collection to the configured consistency level, mirroring
+// searchQueryOptions on the schema-creation path.
+func (c *MilvusCache) createCollectionOptions() []client.CreateCollectionOption {
+	level, ok := resolveMilvusConsistencyLevel(c.config.Search.ConsistencyLevel)
+	if !ok {
+		return nil
+	}
+	return []client.CreateCollectionOption{client.WithConsistencyLevel(level)}
+}

--- a/src/semantic-router/pkg/cache/milvus_consistency_level.go
+++ b/src/semantic-router/pkg/cache/milvus_consistency_level.go
@@ -31,9 +31,13 @@ func resolveMilvusConsistencyLevel(name string) (entity.ConsistencyLevel, bool) 
 }
 
 // searchQueryOptions returns the read options that pin every Milvus search
-// and query the cache issues to the configured consistency level. An empty or
-// unrecognized level yields no options, so the SDK default applies and the
-// behavior of existing deployments is unchanged.
+// and query the cache issues against its own collection to the configured
+// consistency level. Reads against foreign collections (e.g. RAG knowledge
+// bases via SearchDocuments) must not use these options: without an explicit
+// option the SDK adopts the target collection's server-side level, which is
+// the intended behavior there. An empty or unrecognized level yields no
+// options, so the SDK default applies and the behavior of existing
+// deployments is unchanged.
 func (c *MilvusCache) searchQueryOptions() []client.SearchQueryOptionFunc {
 	level, ok := resolveMilvusConsistencyLevel(c.config.Search.ConsistencyLevel)
 	if !ok {

--- a/src/semantic-router/pkg/cache/milvus_consistency_level_test.go
+++ b/src/semantic-router/pkg/cache/milvus_consistency_level_test.go
@@ -1,0 +1,226 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/milvus-io/milvus-sdk-go/v2/client"
+	"github.com/milvus-io/milvus-sdk-go/v2/entity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestResolveMilvusConsistencyLevel(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		level entity.ConsistencyLevel
+		ok    bool
+	}{
+		{"unset leaves the SDK default", "", entity.ClStrong, false},
+		{"strong", "Strong", entity.ClStrong, true},
+		{"session lowercase", "session", entity.ClSession, true},
+		{"bounded uppercase", "BOUNDED", entity.ClBounded, true},
+		{"eventually padded", " Eventually ", entity.ClEventually, true},
+		{"unknown falls back to the SDK default", "customized", entity.ClStrong, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			level, ok := resolveMilvusConsistencyLevel(tc.input)
+			assert.Equal(t, tc.level, level)
+			assert.Equal(t, tc.ok, ok)
+		})
+	}
+}
+
+// appliedConsistencyLevel replays the read options against a sentinel value
+// that differs from every mapped level, so "option did nothing" (ClStrong is
+// the zero value) cannot masquerade as an explicit Strong.
+func appliedConsistencyLevel(t *testing.T, opts []client.SearchQueryOptionFunc) (entity.ConsistencyLevel, bool) {
+	t.Helper()
+	applied := &client.SearchQueryOption{ConsistencyLevel: entity.ClCustomized}
+	for _, opt := range opts {
+		opt(applied)
+	}
+	if len(opts) == 0 {
+		return entity.ClCustomized, false
+	}
+	return applied.ConsistencyLevel, true
+}
+
+// milvusCacheWithConsistencyLevel builds a cache whose config carries only the
+// consistency-level field relevant to the option helpers.
+func milvusCacheWithConsistencyLevel(level string) *MilvusCache {
+	return &MilvusCache{config: milvusCacheTestConfig(level)}
+}
+
+func TestMilvusCacheSearchQueryOptions(t *testing.T) {
+	cases := []struct {
+		name      string
+		config    string
+		wantLevel entity.ConsistencyLevel
+		wantSet   bool
+	}{
+		{"unset keeps the SDK default", "", entity.ClCustomized, false},
+		{"strong", "Strong", entity.ClStrong, true},
+		{"session lowercase", "session", entity.ClSession, true},
+		{"bounded uppercase", "BOUNDED", entity.ClBounded, true},
+		{"eventually padded", " Eventually ", entity.ClEventually, true},
+		{"unrecognized keeps the SDK default", "customized", entity.ClCustomized, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := milvusCacheWithConsistencyLevel(tc.config)
+			level, set := appliedConsistencyLevel(t, cache.searchQueryOptions())
+			assert.Equal(t, tc.wantSet, set)
+			if tc.wantSet {
+				assert.Equal(t, tc.wantLevel, level)
+			}
+		})
+	}
+}
+
+// recordingMilvusClient stubs the Milvus calls the cache issues so tests can
+// assert the consistency-level options actually reach the SDK; the embedded
+// nil interface covers every other client method.
+type recordingMilvusClient struct {
+	client.Client
+	searchOpts    []client.SearchQueryOptionFunc
+	queryOpts     []client.SearchQueryOptionFunc
+	createOpts    []client.CreateCollectionOption
+	queryResults  client.ResultSet
+	searchResults []client.SearchResult
+	created       bool
+}
+
+func (f *recordingMilvusClient) Search(ctx context.Context, collectionName string, partitionNames []string, expr string, outputFields []string, vectors []entity.Vector, vectorField string, metricType entity.MetricType, topK int, sp entity.SearchParam, opts ...client.SearchQueryOptionFunc) ([]client.SearchResult, error) {
+	f.searchOpts = opts
+	return f.searchResults, nil
+}
+
+func (f *recordingMilvusClient) Query(ctx context.Context, collectionName string, partitionNames []string, expr string, outputFields []string, opts ...client.SearchQueryOptionFunc) (client.ResultSet, error) {
+	f.queryOpts = opts
+	return f.queryResults, nil
+}
+
+func (f *recordingMilvusClient) CreateCollection(ctx context.Context, schema *entity.Schema, shardsNum int32, opts ...client.CreateCollectionOption) error {
+	f.createOpts = opts
+	f.created = true
+	return nil
+}
+
+func (f *recordingMilvusClient) CreateIndex(ctx context.Context, collectionName string, fieldName string, idx entity.Index, async bool, opts ...client.IndexOption) error {
+	return nil
+}
+
+// milvusCacheTestConfig returns a cache config with the fields the cache
+// methods touch during reads and collection creation.
+func milvusCacheTestConfig(level string) *config.MilvusConfig {
+	cfg := &config.MilvusConfig{}
+	cfg.Collection.VectorField.Name = "embedding"
+	cfg.Collection.VectorField.Dimension = 384
+	cfg.Collection.VectorField.MetricType = "IP"
+	cfg.Collection.Index.Params.M = 16
+	cfg.Collection.Index.Params.EfConstruction = 64
+	cfg.Search.Params.Ef = 8
+	cfg.Search.TopK = 5
+	cfg.Search.ConsistencyLevel = level
+	return cfg
+}
+
+func TestMilvusCacheSearchHonorsConsistencyLevel(t *testing.T) {
+	fake := &recordingMilvusClient{}
+	cache := &MilvusCache{
+		enabled:        true,
+		client:         fake,
+		config:         milvusCacheTestConfig("Strong"),
+		collectionName: "test_cache",
+	}
+
+	_, err := cache.milvusSearchSimilarVectors(context.Background(), "model", []float32{0.1, 0.2})
+	require.NoError(t, err)
+	level, set := appliedConsistencyLevel(t, fake.searchOpts)
+	assert.True(t, set, "configured level must reach the SDK search call")
+	assert.Equal(t, entity.ClStrong, level)
+}
+
+func TestMilvusCacheSearchUnsetKeepsSDKDefault(t *testing.T) {
+	fake := &recordingMilvusClient{}
+	cache := &MilvusCache{
+		enabled:        true,
+		client:         fake,
+		config:         milvusCacheTestConfig(""),
+		collectionName: "test_cache",
+	}
+
+	_, err := cache.milvusSearchSimilarVectors(context.Background(), "model", []float32{0.1, 0.2})
+	require.NoError(t, err)
+	assert.Empty(t, fake.searchOpts, "unset level must not pass a consistency option")
+}
+
+func TestMilvusCacheGetByIDHonorsConsistencyLevel(t *testing.T) {
+	fake := &recordingMilvusClient{queryResults: []entity.Column{
+		entity.NewColumnVarChar("response_body", []string{"cached"}),
+	}}
+	cache := &MilvusCache{
+		enabled:        true,
+		client:         fake,
+		config:         milvusCacheTestConfig("Session"),
+		collectionName: "test_cache",
+	}
+
+	body, err := cache.GetByID(context.Background(), "req-1", "model")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("cached"), body)
+	level, set := appliedConsistencyLevel(t, fake.queryOpts)
+	assert.True(t, set, "configured level must reach the SDK query call")
+	assert.Equal(t, entity.ClSession, level)
+}
+
+func TestMilvusCacheFindExactHonorsConsistencyLevel(t *testing.T) {
+	fake := &recordingMilvusClient{queryResults: []entity.Column{
+		entity.NewColumnVarChar("response_body", []string{"exact"}),
+	}}
+	cache := &MilvusCache{
+		enabled:        true,
+		client:         fake,
+		config:         milvusCacheTestConfig("Eventually"),
+		collectionName: "test_cache",
+	}
+
+	result, err := cache.FindExact("model", "fingerprint")
+	require.NoError(t, err)
+	assert.True(t, result.Found)
+	level, set := appliedConsistencyLevel(t, fake.queryOpts)
+	assert.True(t, set, "configured level must reach the exact-lookup query")
+	assert.Equal(t, entity.ClEventually, level)
+}
+
+func TestMilvusCacheCreateCollectionConsistencyOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   string
+		wantOpts int
+	}{
+		{"unset keeps the SDK default", "", 0},
+		{"configured pins the collection", "Strong", 1},
+		{"unrecognized keeps the SDK default", "bogus", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &recordingMilvusClient{}
+			cache := &MilvusCache{
+				enabled:        true,
+				client:         fake,
+				config:         milvusCacheTestConfig(tc.config),
+				collectionName: "test_cache",
+			}
+
+			require.NoError(t, cache.createCollection(context.Background()))
+			assert.True(t, fake.created)
+			assert.Len(t, fake.createOpts, tc.wantOpts)
+		})
+	}
+}

--- a/src/semantic-router/pkg/cache/milvus_consistency_level_test.go
+++ b/src/semantic-router/pkg/cache/milvus_consistency_level_test.go
@@ -198,6 +198,36 @@ func TestMilvusCacheFindExactHonorsConsistencyLevel(t *testing.T) {
 	assert.Equal(t, entity.ClEventually, level)
 }
 
+func TestMilvusCacheSearchDocumentsConsistencyScope(t *testing.T) {
+	cases := []struct {
+		name       string
+		collection string
+		wantSet    bool
+	}{
+		{"own collection honors the configured level", "test_cache", true},
+		{"foreign collection keeps its server-side level", "rag_docs", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &recordingMilvusClient{}
+			cache := &MilvusCache{
+				enabled:        true,
+				client:         fake,
+				config:         milvusCacheTestConfig("Strong"),
+				collectionName: "test_cache",
+			}
+
+			_, _, err := cache.SearchDocuments(context.Background(), tc.collection, []float32{0.1, 0.2}, 0.5, 5, "", "content", "", "", 0)
+			require.NoError(t, err)
+			level, set := appliedConsistencyLevel(t, fake.searchOpts)
+			assert.Equal(t, tc.wantSet, set)
+			if tc.wantSet {
+				assert.Equal(t, entity.ClStrong, level)
+			}
+		})
+	}
+}
+
 func TestMilvusCacheCreateCollectionConsistencyOptions(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Closes #2821

## Purpose

- The Milvus semantic cache parses `search.consistency_level` but never passes it to the SDK. `CreateCollection` and every search/query the cache issues (`milvusSearchSimilarVectors`, `SearchDocuments`, `GetByID`, `GetAllEntries`, `UpdateWithResponse`, `FindExact`) fall back to the SDK default (`Bounded`), so a read issued shortly after a write can miss an entry that already exists and the request is routed to the model again. The repo's own config already sets the field (canonical `config.yaml` uses `Bounded`, the stricter profile `Strong`, and the standalone `milvus.yaml` example `Session`), so the configured value is silently ignored today.
- This PR plumbs the configured level into collection creation, every search, and every query the Milvus cache issues. An empty or unrecognized level passes no option, so the SDK default stays in effect and existing deployments see no change.
- Module: Router (semantic cache backend).

## Test Plan

- `go test ./pkg/cache/ -run 'ConsistencyLevel|HonorsConsistency|KeepsSDKDefault' -count=1`: the resolver table covers case/whitespace normalization and the SDK-default fallback; a recording fake client asserts the option actually reaches `Search`, `Query`, and `CreateCollection`, using `ClCustomized` as a sentinel so an option that does nothing cannot masquerade as an explicit level.
- `go test ./pkg/cache/ -count=1` (full package suite) and `go vet ./pkg/cache/`, `gofmt` — all clean.
- Local note: this dev box has no C toolchain, so the valkey-glide dependency (cgo-only) cannot compile here; verification ran with an overlay stubbing `valkey_cache.go`/exact-`valkey` file. The changed files and the Linux CI path are unaffected.

## Test Result

- All new tests pass; the full `pkg/cache` suite still passes; `go vet` and `gofmt` report no issues.
- No follow-up risks identified. `#2822` (the intermittent `TestHybridCachePendingRequest` failure) is tracked separately and also needs `createTestMilvusConfig` to set a level, which this PR intentionally leaves alone.
