### PR TITLE
[Dashboard] Record privileged config and MCP actions in the audit log

### DIFF
--- a/dashboard/backend/auth/middleware.go
+++ b/dashboard/backend/auth/middleware.go
@@ -423,6 +423,21 @@ func (w *auditResponseWriter) WriteHeader(status int) {
 	w.ResponseWriter.WriteHeader(status)
 }
 
+// Unwrap lets http.ResponseController reach the underlying writer, so wrapped
+// handlers keep access to Flush/Hijack without losing the audit capture.
+func (w *auditResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+// Flush forwards to the underlying writer when it supports streaming, so the
+// audit wrapper can sit in front of SSE or chunked handlers without breaking
+// their flush behavior.
+func (w *auditResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 func (w *auditResponseWriter) statusCodeOr200() int {
 	if w.status == 0 {
 		return http.StatusOK

--- a/dashboard/backend/auth/service.go
+++ b/dashboard/backend/auth/service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -250,6 +251,27 @@ func (s *Service) CanBootstrap(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return count == 0, nil
+}
+
+// Audit wraps a handler so that every request it serves is recorded in the
+// audit log after the handler completes. The action and resource are recorded
+// verbatim; the authenticated user, method, path, IP, user agent and status
+// code are captured from the request/response. When the service has no store
+// (auth unavailable), the handler passes through unwrapped.
+func (s *Service) Audit(action, resource string, next http.HandlerFunc) http.HandlerFunc {
+	if s == nil || s.store == nil {
+		return next
+	}
+	return AuditMiddleware(s.store, action, resource, next)
+}
+
+// Close releases the underlying store. Safe to call when the service was never
+// backed by a store (auth unavailable).
+func (s *Service) Close() error {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	return s.store.Close()
 }
 
 func defaultAdminName(name string) string {

--- a/dashboard/backend/router/audit.go
+++ b/dashboard/backend/router/audit.go
@@ -1,0 +1,52 @@
+package router
+
+import (
+	"net/http"
+
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
+)
+
+// auditMutation wraps a handler so that state-changing requests are recorded
+// in the audit log. Read-only and preflight methods (GET, HEAD, OPTIONS) pass
+// through unrecorded so the log stays a record of writes; actionFor maps the
+// remaining methods to the audit action, and an empty action passes through
+// unrecorded as well.
+func auditMutation(svc *auth.Service, actionFor func(method string) string, resource string, next http.HandlerFunc) http.HandlerFunc {
+	if svc == nil {
+		return next
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next(w, r)
+			return
+		}
+		action := actionFor(r.Method)
+		if action == "" {
+			next(w, r)
+			return
+		}
+		svc.Audit(action, resource, next)(w, r)
+	}
+}
+
+// fixedAuditAction returns an actionFor mapping that audits every method that
+// reaches the wrapped handler under the given action. Used with auditMutation
+// for routes whose handlers already guard the accepted methods.
+func fixedAuditAction(action string) func(method string) string {
+	return func(string) string { return action }
+}
+
+// kbAuditAction maps knowledge-base proxy methods to the router-side audit
+// action names so the dashboard records KB writes with the same vocabulary as
+// the router apiserver.
+func kbAuditAction(method string) string {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		return "knowledge_base.save"
+	case http.MethodDelete:
+		return "knowledge_base.delete"
+	default:
+		return ""
+	}
+}

--- a/dashboard/backend/router/audit_wiring_test.go
+++ b/dashboard/backend/router/audit_wiring_test.go
@@ -18,9 +18,9 @@ import (
 func TestAuditMutationRecordsConfigDeploy(t *testing.T) {
 	t.Parallel()
 
-	store, err := auth.NewStore(filepath.Join(t.TempDir(), "auth.db"))
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
+	store, storeErr := auth.NewStore(filepath.Join(t.TempDir(), "auth.db"))
+	if storeErr != nil {
+		t.Fatalf("NewStore() error = %v", storeErr)
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
@@ -89,9 +89,9 @@ func TestAuditMutationRecordsConfigDeploy(t *testing.T) {
 func TestAuditMutationSkipsReads(t *testing.T) {
 	t.Parallel()
 
-	store, err := auth.NewStore(filepath.Join(t.TempDir(), "auth.db"))
-	if err != nil {
-		t.Fatalf("NewStore() error = %v", err)
+	store, storeErr := auth.NewStore(filepath.Join(t.TempDir(), "auth.db"))
+	if storeErr != nil {
+		t.Fatalf("NewStore() error = %v", storeErr)
 	}
 	t.Cleanup(func() { _ = store.Close() })
 

--- a/dashboard/backend/router/audit_wiring_test.go
+++ b/dashboard/backend/router/audit_wiring_test.go
@@ -1,0 +1,164 @@
+package router
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
+)
+
+// TestAuditMutationRecordsConfigDeploy verifies that the config deploy route is
+// wrapped so that an authenticated deploy writes an audit row carrying the
+// actor, action, resource and method (issue #2825: privileged config changes
+// were never recorded in the audit log).
+func TestAuditMutationRecordsConfigDeploy(t *testing.T) {
+	t.Parallel()
+
+	store, err := auth.NewStore(filepath.Join(t.TempDir(), "auth.db"))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := auth.NewService(store, "test-secret", 1)
+	ctx := context.Background()
+	if err := svc.EnsureBootstrapAdmin(ctx, "admin@example.com", "secret-password", "Admin"); err != nil {
+		t.Fatalf("EnsureBootstrapAdmin() error = %v", err)
+	}
+	token, _, err := svc.Login(ctx, "admin@example.com", "secret-password")
+	if err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+
+	mux := http.NewServeMux()
+	deployCalled := false
+	mux.HandleFunc("/api/router/config/deploy", auditMutation(
+		svc,
+		fixedAuditAction("config.deploy"),
+		"router/config",
+		func(w http.ResponseWriter, _ *http.Request) {
+			deployCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	handler := wrapWithAuth(mux, svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/router/config/deploy", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !deployCalled {
+		t.Fatal("deploy handler was not called")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("deploy status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	logs, err := store.ListAuditLogs(ctx, "", "config.deploy", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListAuditLogs() error = %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("audit rows for config.deploy = %d, want 1", len(logs))
+	}
+	row := logs[0]
+	if row.Action != "config.deploy" {
+		t.Errorf("row action = %q, want config.deploy", row.Action)
+	}
+	if row.Resource != "router/config" {
+		t.Errorf("row resource = %q, want router/config", row.Resource)
+	}
+	if row.Method != http.MethodPost {
+		t.Errorf("row method = %q, want POST", row.Method)
+	}
+	if row.UserID == "" {
+		t.Error("row user id is empty, expected the acting user")
+	}
+	if row.StatusCode != http.StatusOK {
+		t.Errorf("row status code = %d, want 200", row.StatusCode)
+	}
+}
+
+// TestAuditMutationSkipsReads verifies that read-only methods on a wrapped route
+// are not recorded in the audit log, keeping the log a record of writes only.
+func TestAuditMutationSkipsReads(t *testing.T) {
+	t.Parallel()
+
+	store, err := auth.NewStore(filepath.Join(t.TempDir(), "auth.db"))
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := auth.NewService(store, "test-secret", 1)
+	ctx := context.Background()
+	if err := svc.EnsureBootstrapAdmin(ctx, "admin@example.com", "secret-password", "Admin"); err != nil {
+		t.Fatalf("EnsureBootstrapAdmin() error = %v", err)
+	}
+	token, _, err := svc.Login(ctx, "admin@example.com", "secret-password")
+	if err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+
+	mux := http.NewServeMux()
+	readCalled := false
+	mux.HandleFunc("/api/router/config/yaml", auditMutation(
+		svc,
+		fixedAuditAction("config.update"),
+		"router/config",
+		func(w http.ResponseWriter, _ *http.Request) {
+			readCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	handler := wrapWithAuth(mux, svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/router/config/yaml", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !readCalled {
+		t.Fatal("read handler was not called")
+	}
+	logs, err := store.ListAuditLogs(ctx, "", "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListAuditLogs() error = %v", err)
+	}
+	if len(logs) != 0 {
+		t.Fatalf("audit rows after read-only request = %d, want 0", len(logs))
+	}
+}
+
+// TestAuditMutationUnavailableStorePassesThrough verifies that a nil auth
+// service leaves the handler unwrapped instead of panicking.
+func TestAuditMutationUnavailableStorePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	nextCalled := false
+	handler := auditMutation(
+		nil,
+		fixedAuditAction("config.deploy"),
+		"router/config",
+		func(w http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/router/config/deploy", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if !nextCalled {
+		t.Fatal("handler was not called when auth service is nil")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}

--- a/dashboard/backend/router/core_routes.go
+++ b/dashboard/backend/router/core_routes.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/evaluation"
 	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
@@ -15,16 +16,16 @@ import (
 	"github.com/vllm-project/semantic-router/dashboard/backend/workflowstore"
 )
 
-func registerCoreRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerCoreRoutes(mux *http.ServeMux, cfg *config.Config, authSvc *auth.Service) {
 	registerHealthAndSetupRoutes(mux, cfg)
-	registerConfigRoutes(mux, cfg)
+	registerConfigRoutes(mux, cfg, authSvc)
 	registerToolRoutes(mux, cfg)
 	registerStatusRoutes(mux, cfg)
 	registerTopologyRoutes(mux, cfg)
-	registerSecurityPolicyRoutes(mux, cfg)
+	registerSecurityPolicyRoutes(mux, cfg, authSvc)
 }
 
-func registerSecurityPolicyRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerSecurityPolicyRoutes(mux *http.ServeMux, cfg *config.Config, authSvc *auth.Service) {
 	handlers.SetSecurityPolicyConfigPaths(cfg.AbsConfigPath, cfg.ConfigDir)
 	mux.HandleFunc("/api/security/policy", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -35,7 +36,7 @@ func registerSecurityPolicyRoutes(mux *http.ServeMux, cfg *config.Config) {
 				http.Error(w, "Dashboard is in read-only mode", http.StatusForbidden)
 				return
 			}
-			handlers.HandleUpdateSecurityPolicy(w, r)
+			auditMutation(authSvc, fixedAuditAction("security.policy.update"), "security/policy", handlers.HandleUpdateSecurityPolicy)(w, r)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -62,13 +63,13 @@ func registerHealthAndSetupRoutes(mux *http.ServeMux, cfg *config.Config) {
 	mux.HandleFunc("/api/setup/presets/delta", handlers.PresetDeltaHandler())
 }
 
-func registerConfigRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerConfigRoutes(mux *http.ServeMux, cfg *config.Config, authSvc *auth.Service) {
 	mux.HandleFunc("/api/router/config/all", handlers.ConfigHandler(cfg.AbsConfigPath))
 	mux.HandleFunc("/api/router/config/yaml", handlers.ConfigYAMLHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/update", handlers.UpdateConfigHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir))
+	mux.HandleFunc("/api/router/config/update", auditMutation(authSvc, fixedAuditAction("config.update"), "router/config", handlers.UpdateConfigHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir)))
 	mux.HandleFunc("/api/router/config/deploy/preview", handlers.DeployPreviewHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/deploy", handlers.DeployHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir))
-	mux.HandleFunc("/api/router/config/rollback", handlers.RollbackHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir))
+	mux.HandleFunc("/api/router/config/deploy", auditMutation(authSvc, fixedAuditAction("config.deploy"), "router/config", handlers.DeployHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir)))
+	mux.HandleFunc("/api/router/config/rollback", auditMutation(authSvc, fixedAuditAction("config.rollback"), "router/config", handlers.RollbackHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir)))
 	mux.HandleFunc("/api/router/config/versions", handlers.ConfigVersionsHandler(cfg.AbsConfigPath))
 	mux.HandleFunc("/api/router/config/deployments", handlers.ConfigDeploymentsHandler())
 	mux.HandleFunc("/api/router/config/deployments/", handlers.ConfigDeploymentDetailHandler())
@@ -79,13 +80,13 @@ func registerConfigRoutes(mux *http.ServeMux, cfg *config.Config) {
 	log.Printf("Config API endpoints registered: /api/router/config/all, /api/router/config/yaml, /api/router/config/update, /api/router/config/nl/verify, /api/router/config/nl/generate/stream, /api/router/config/nl/generate, /api/router/config/deploy, /api/router/config/deploy/preview, /api/router/config/rollback, /api/router/config/versions, /api/router/config/deployments, /api/router/config/active-projection")
 
 	mux.HandleFunc("/api/router/config/global", handlers.RouterDefaultsHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/global/update", handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir))
+	mux.HandleFunc("/api/router/config/global/update", auditMutation(authSvc, fixedAuditAction("config.update"), "router/config/global", handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir)))
 	mux.HandleFunc("/api/router/config/global/raw", handlers.GlobalConfigYAMLHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/global/raw/update", handlers.UpdateGlobalConfigYAMLHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir))
+	mux.HandleFunc("/api/router/config/global/raw/update", auditMutation(authSvc, fixedAuditAction("config.update"), "router/config/global/raw", handlers.UpdateGlobalConfigYAMLHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir)))
 	mux.HandleFunc("/api/router/config/defaults", handlers.RouterDefaultsHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/defaults/update", handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir))
-	mux.HandleFunc("/api/router/config/kbs", handlers.RouterClassifierProxyHandler(cfg.RouterAPIURL, cfg.ReadonlyMode))
-	mux.HandleFunc("/api/router/config/kbs/", handlers.RouterClassifierProxyHandler(cfg.RouterAPIURL, cfg.ReadonlyMode))
+	mux.HandleFunc("/api/router/config/defaults/update", auditMutation(authSvc, fixedAuditAction("config.update"), "router/config/defaults", handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, cfg.ReadonlyMode, cfg.ConfigDir)))
+	mux.HandleFunc("/api/router/config/kbs", auditMutation(authSvc, kbAuditAction, "router/config/kbs", handlers.RouterClassifierProxyHandler(cfg.RouterAPIURL, cfg.ReadonlyMode)))
+	mux.HandleFunc("/api/router/config/kbs/", auditMutation(authSvc, kbAuditAction, "router/config/kbs", handlers.RouterClassifierProxyHandler(cfg.RouterAPIURL, cfg.ReadonlyMode)))
 	log.Printf("Global config API endpoints registered: /api/router/config/global, /api/router/config/global/update, /api/router/config/global/raw, /api/router/config/global/raw/update (legacy aliases: /api/router/config/defaults, /api/router/config/defaults/update)")
 }
 

--- a/dashboard/backend/router/mcp_routes.go
+++ b/dashboard/backend/router/mcp_routes.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
 	"github.com/vllm-project/semantic-router/dashboard/backend/mcp"
@@ -19,7 +20,7 @@ const internalOpenClawMCPPath = "/_internal/openclaw/mcp"
 
 // SetupMCP configures MCP related routes
 // Returns MCP Manager instance for lifecycle management
-func SetupMCP(mux *http.ServeMux, cfg *config.Config, wf *workflowstore.Store, openClawHandler *handlers.OpenClawHandler) *mcp.Manager {
+func SetupMCP(mux *http.ServeMux, cfg *config.Config, wf *workflowstore.Store, openClawHandler *handlers.OpenClawHandler, authSvc *auth.Service) *mcp.Manager {
 	if !cfg.MCPEnabled {
 		log.Printf("MCP feature disabled")
 		return nil
@@ -37,7 +38,7 @@ func SetupMCP(mux *http.ServeMux, cfg *config.Config, wf *workflowstore.Store, o
 
 	// Create MCP handler
 	mcpHandler := handlers.NewMCPHandler(mcpManager, cfg.ReadonlyMode)
-	registerMCPAPIRoutes(mux, mcpHandler)
+	registerMCPAPIRoutes(mux, mcpHandler, authSvc)
 
 	log.Printf("MCP API endpoints registered: /api/mcp/*")
 
@@ -82,7 +83,7 @@ func registerBuiltInOpenClawMCP(
 	)
 }
 
-func registerMCPAPIRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) {
+func registerMCPAPIRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler, authSvc *auth.Service) {
 	// Server configuration - GET list, POST create
 	mux.HandleFunc("/api/mcp/servers", func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
@@ -92,17 +93,17 @@ func registerMCPAPIRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) {
 		case http.MethodGet:
 			mcpHandler.ListServersHandler().ServeHTTP(w, r)
 		case http.MethodPost:
-			mcpHandler.CreateServerHandler().ServeHTTP(w, r)
+			auditMutation(authSvc, fixedAuditAction("mcp.server.create"), "mcp/servers", mcpHandler.CreateServerHandler())(w, r)
 		default:
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 
-	registerMCPServerOperationRoutes(mux, mcpHandler)
+	registerMCPServerOperationRoutes(mux, mcpHandler, authSvc)
 	registerMCPToolRoutes(mux, mcpHandler)
 }
 
-func registerMCPServerOperationRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) {
+func registerMCPServerOperationRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler, authSvc *auth.Service) {
 	// Server operations (update, delete, connect, disconnect, status, test)
 	mux.HandleFunc("/api/mcp/servers/", func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
@@ -123,9 +124,9 @@ func registerMCPServerOperationRoutes(mux *http.ServeMux, mcpHandler *handlers.M
 		default:
 			switch r.Method {
 			case http.MethodPut:
-				mcpHandler.UpdateServerHandler().ServeHTTP(w, r)
+				auditMutation(authSvc, fixedAuditAction("mcp.server.update"), "mcp/servers", mcpHandler.UpdateServerHandler())(w, r)
 			case http.MethodDelete:
-				mcpHandler.DeleteServerHandler().ServeHTTP(w, r)
+				auditMutation(authSvc, fixedAuditAction("mcp.server.delete"), "mcp/servers", mcpHandler.DeleteServerHandler())(w, r)
 			default:
 				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			}

--- a/dashboard/backend/router/router.go
+++ b/dashboard/backend/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -45,9 +46,9 @@ func Setup(cfg *config.Config) *Server {
 
 	openClawHandler := newOpenClawHandler(cfg, wf)
 
-	registerCoreRoutes(mux, cfg)
+	registerCoreRoutes(mux, cfg, authSvc)
 	registerEvaluationRoutes(mux, cfg)
-	SetupMCP(mux, cfg, wf, openClawHandler)
+	SetupMCP(mux, cfg, wf, openClawHandler, authSvc)
 	registerMLPipelineRoutes(mux, cfg, wf)
 	registerOpenClawRoutes(mux, cfg, openClawHandler)
 	registerProxyRoutes(mux, cfg)
@@ -57,10 +58,24 @@ func Setup(cfg *config.Config) *Server {
 	return &Server{
 		Handler: wrapWithAuth(mux, authSvc),
 		Close: func() error {
-			if cp == nil {
-				return nil
+			var closeErrs []error
+			if authSvc != nil {
+				if err := authSvc.Close(); err != nil {
+					closeErrs = append(closeErrs, err)
+				}
 			}
-			return cp.Close()
+			if err := wf.Close(); err != nil {
+				closeErrs = append(closeErrs, err)
+			}
+			if cp != nil {
+				if err := cp.Close(); err != nil {
+					closeErrs = append(closeErrs, err)
+				}
+			}
+			if len(closeErrs) > 0 {
+				return fmt.Errorf("dashboard close: %v", closeErrs)
+			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
Closes #2825

## Purpose

- The dashboard has a working audit log, but it only ever records user management. Config deploys, rollbacks, config updates, knowledge base writes, security policy changes, and MCP server changes were never recorded, so there was no way to answer "who changed the config that broke production?"
- This wires the existing (previously unused) `AuditMiddleware` around the dashboard's privileged mutation routes so every write-permission request produces an audit row.
- Module affected: `Dashboard`

## What changed

- `auth.Service.Audit(...)` — small wrapper around `AuditMiddleware` so route wiring doesn't need direct access to the store. Passes through untouched when auth is unavailable.
- `router/audit.go` — `auditMutation` wrapper that records non-read methods under a per-route action, and `kbAuditAction` which maps KB proxy methods to the router-side `knowledge_base.save` / `knowledge_base.delete` vocabulary.
- Wired routes: `/api/router/config/deploy`, `/api/router/config/rollback`, `/api/router/config/update`, `/api/router/config/global/update`, `/api/router/config/global/raw/update`, `/api/router/config/defaults/update`, `/api/router/config/kbs` (+ `/kbs/`), `/api/security/policy` (PUT), and `/api/mcp/servers` create/update/delete.
- `auditResponseWriter` now forwards `Flush` and exposes `Unwrap`, so the audit wrapper is safe to sit in front of streaming handlers in the future (the issue called this out as a caveat).
- `Server.Close` now also closes the auth and workflow stores. The previous implementation only closed the config-projection store, which leaked sqlite file handles on shutdown (and made Windows test cleanup flaky).

## Test Plan

- `go build ./...` in `dashboard/backend`
- `go vet ./auth/... ./router/...`
- `go test ./auth/... ./router/...`
- New regression tests:
  - `TestAuditMutationRecordsConfigDeploy` — authenticated POST to a wrapped route writes one audit row with the actor, action, resource, method, and status code.
  - `TestAuditMutationSkipsReads` — GET on a wrapped route writes no row, keeping the log a record of writes only.
  - `TestAuditMutationUnavailableStorePassesThrough` — nil auth service leaves the handler unwrapped instead of panicking.

## Test Result

- Build, vet, and the full `auth` + `router` test suites pass (including the previously flaky `TestBuiltInOpenClawMCPConnectsThroughInternalLoopbackRoute`, which is now stable on Windows because the stores are closed properly).
- The `handlers` and `mcp` package failures seen in a full `go test ./...` run are pre-existing on this machine (temp-dir file locks and docker-status probing) and reproduce on a clean checkout without this change.
- Follow-up: the router-side apiserver still declares audit actions on its 19 mutation routes with no sink behind them. That side needs a sink decision (as noted in the issue) and is intentionally left out of this PR.
