### PR TITLE
[Fleet-Sim] fix: correct preemption queue bookkeeping in Instance

### DIFF
--- a/src/fleet-sim/fleet_sim/core/instance.py
+++ b/src/fleet-sim/fleet_sim/core/instance.py
@@ -258,23 +258,7 @@ class Instance:
         req = self._queue.popleft()
         req_blocks = math.ceil((req.l_in + req.l_out) / self.gpu.blk_size)
 
-        # ── Preempt longest active request if KV budget is tight ──────────
-        n_victims = 0
-        while (
-            self._used_kv_blocks + req_blocks > self._total_kv_blocks
-            and self._active_reqs
-        ):
-            victim = max(self._active_reqs, key=lambda r: r.l_in + r.l_out)
-            victim_blocks = math.ceil((victim.l_in + victim.l_out) / self.gpu.blk_size)
-            # Invalidate the victim's pending completion event via the preempted flag
-            victim.preempted = True
-            self._active_reqs.remove(victim)
-            self._active_slots -= 1
-            self._used_kv_blocks -= victim_blocks
-            # Re-queue the victim at head so it is retried first
-            self._queue.appendleft(victim)
-            self.total_preempted += 1
-            n_victims += 1
+        n_victims = self._preempt_for(req_blocks)
 
         # If still no room (budget too small for even 1 req), put the
         # candidate back right after the victims that were just re-queued,
@@ -291,6 +275,39 @@ class Instance:
         self._used_kv_blocks += req_blocks
         self._active_reqs.append(req)
 
+        self._schedule_completion(req, now)
+        return True
+
+    def _preempt_for(self, req_blocks: int) -> int:
+        """Free KV blocks by evicting the longest active request.
+
+        Repeatedly preempts the longest currently-active sequence until
+        ``req_blocks`` fits in the budget or nothing is left to evict.
+        Victims are re-queued at the head so they are retried first.
+
+        Returns the number of requests preempted.
+        """
+        n_victims = 0
+        while (
+            self._used_kv_blocks + req_blocks > self._total_kv_blocks
+            and self._active_reqs
+        ):
+            victim = max(self._active_reqs, key=lambda r: r.l_in + r.l_out)
+            victim_blocks = math.ceil((victim.l_in + victim.l_out) / self.gpu.blk_size)
+            # Invalidate the victim's pending completion event via the preempted flag
+            victim.preempted = True
+            self._active_reqs.remove(victim)
+            self._active_slots -= 1
+            self._used_kv_blocks -= victim_blocks
+            # Re-queue the victim at head so it is retried first
+            self._queue.appendleft(victim)
+            self.total_preempted += 1
+            n_victims += 1
+        return n_victims
+
+    def _schedule_completion(self, req: Request, now: float) -> None:
+        """Compute service times for an admitted request and schedule its
+        completion event on the event heap."""
         # ── Seq-len-aware iter_t: scale H by mean active sequence length ─────
         # Attention cost ∝ seq_len, so H_eff = H * (mean_seq_len / calibration_ctx).
         # This correctly models pools serving short requests as faster than
@@ -337,7 +354,6 @@ class Instance:
 
         completion_time = now + s_eff
         heapq.heappush(self._events, _Event(completion_time, req, req.admission_seq))
-        return True
 
     def next_event_time(self) -> float:
         """Time of the next completion event (or now if the queue can be served)."""

--- a/src/fleet-sim/fleet_sim/core/instance.py
+++ b/src/fleet-sim/fleet_sim/core/instance.py
@@ -260,7 +260,10 @@ class Instance:
 
         # ── Preempt longest active request if KV budget is tight ──────────
         n_victims = 0
-        while self._used_kv_blocks + req_blocks > self._total_kv_blocks and self._active_reqs:
+        while (
+            self._used_kv_blocks + req_blocks > self._total_kv_blocks
+            and self._active_reqs
+        ):
             victim = max(self._active_reqs, key=lambda r: r.l_in + r.l_out)
             victim_blocks = math.ceil((victim.l_in + victim.l_out) / self.gpu.blk_size)
             # Invalidate the victim's pending completion event via the preempted flag
@@ -293,7 +296,9 @@ class Instance:
         # This correctly models pools serving short requests as faster than
         # pools serving long requests, even at the same n_slots.
         if self._active_reqs:
-            mean_seq_len = sum(r.l_in + r.l_out for r in self._active_reqs) / len(self._active_reqs)
+            mean_seq_len = sum(r.l_in + r.l_out for r in self._active_reqs) / len(
+                self._active_reqs
+            )
         else:
             mean_seq_len = float(req.l_in + req.l_out)
 
@@ -342,7 +347,10 @@ class Instance:
             # A request can start now only if it fits the KV budget, either
             # directly or after preempting active requests.  Otherwise the
             # clock must wait for the next completion to free blocks.
-            if self._used_kv_blocks + req_blocks <= self._total_kv_blocks or self._active_reqs:
+            if (
+                self._used_kv_blocks + req_blocks <= self._total_kv_blocks
+                or self._active_reqs
+            ):
                 return self._now
         if self._events:
             return self._events[0].time

--- a/src/fleet-sim/fleet_sim/core/instance.py
+++ b/src/fleet-sim/fleet_sim/core/instance.py
@@ -48,10 +48,17 @@ from .request import Request, RequestState
 
 @dataclass
 class _Event:
-    """A scheduled service completion event."""
+    """A scheduled service completion event.
+
+    ``admission_seq`` records the request's admission generation this event
+    belongs to.  When a request is preempted and later re-admitted its
+    admission_seq advances, so a stale completion event from the earlier
+    admission can be recognized and dropped.
+    """
 
     time: float
     req: Request
+    admission_seq: int
 
     def __lt__(self, other: _Event) -> bool:
         return self.time < other.time
@@ -163,8 +170,14 @@ class Instance:
 
             # If we can start a queued request right now (free slot), do it
             if self._queue and self._active_slots < self.n_slots:
-                self._start_next(self._now)
-                continue
+                qlen = len(self._queue)
+                if self._start_next(self._now) and len(self._queue) < qlen:
+                    continue
+                # Either the head could not be admitted (budget too small
+                # even after preemption), or admitting it required evicting
+                # another request, so the queue did not shrink and another
+                # attempt would just swap victims again.  Fall through so
+                # the clock advances to the next event instead of spinning.
 
             # Jump to next event or target_time, whichever comes first
             step = min(next_event_t, target_time)
@@ -189,9 +202,12 @@ class Instance:
                 while self._events and self._events[0].time <= self._now:
                     ev = heapq.heappop(self._events)
                     req = ev.req
-                    if req.preempted:
-                        # This completion event belongs to a preempted request;
-                        # the slot/blocks were already released at preemption time.
+                    if req.preempted or ev.admission_seq != req.admission_seq:
+                        # This completion event is stale: either the request is
+                        # currently preempted (slot/blocks were released at
+                        # preemption time), or it was re-admitted since this
+                        # event was scheduled, in which case only the event from
+                        # the latest admission may complete it.
                         continue
                     req.end_time = self._now
                     req.state = RequestState.DONE
@@ -207,28 +223,44 @@ class Instance:
 
                 # Fill freed slots from queue
                 while self._queue and self._active_slots < self.n_slots:
-                    self._start_next(self._now)
+                    qlen = len(self._queue)
+                    if not self._start_next(self._now):
+                        break
+                    if len(self._queue) >= qlen:
+                        # Preemption exchange: admitting this request pushed
+                        # another one back to the queue.  Stop here; the
+                        # main loop will advance the clock to the next event.
+                        break
 
             if step >= target_time:
                 break
 
         return completed
 
-    def _start_next(self, now: float) -> None:
+    def _start_next(self, now: float) -> bool:
         """Pull the next request from queue into active service.
 
         Checks KV block budget before admitting.  If the budget would be
         exceeded, preempts the longest currently-active request instead of
         admitting the new one.
+
+        Returns True when a request was admitted, False when the head of the
+        queue could not be admitted (queue empty, or budget too small for
+        even a single request).  Callers must not retry in a tight loop
+        when this returns False.
         """
-        req = self._queue[0]  # peek; may not admit
+        if not self._queue:
+            return False
+
+        # Take the candidate off the queue up front.  Preemption below
+        # re-queues victims at the head, so popping after that loop would
+        # remove the wrong request (the last victim) instead of this one.
+        req = self._queue.popleft()
         req_blocks = math.ceil((req.l_in + req.l_out) / self.gpu.blk_size)
 
         # ── Preempt longest active request if KV budget is tight ──────────
-        while (
-            self._used_kv_blocks + req_blocks > self._total_kv_blocks
-            and self._active_reqs
-        ):
+        n_victims = 0
+        while self._used_kv_blocks + req_blocks > self._total_kv_blocks and self._active_reqs:
             victim = max(self._active_reqs, key=lambda r: r.l_in + r.l_out)
             victim_blocks = math.ceil((victim.l_in + victim.l_out) / self.gpu.blk_size)
             # Invalidate the victim's pending completion event via the preempted flag
@@ -239,15 +271,19 @@ class Instance:
             # Re-queue the victim at head so it is retried first
             self._queue.appendleft(victim)
             self.total_preempted += 1
+            n_victims += 1
 
-        # If still no room (budget too small for even 1 req), skip for now
+        # If still no room (budget too small for even 1 req), put the
+        # candidate back right after the victims that were just re-queued,
+        # preserving their retry-first ordering, and skip for now.
         if self._used_kv_blocks + req_blocks > self._total_kv_blocks:
-            return
+            self._queue.insert(n_victims, req)
+            return False
 
-        self._queue.popleft()
         req.start_time = now
         req.state = RequestState.PREFILLING
         req.preempted = False  # reset preemption flag on re-admission
+        req.admission_seq += 1  # invalidate completion events from before
         self._active_slots += 1
         self._used_kv_blocks += req_blocks
         self._active_reqs.append(req)
@@ -257,9 +293,7 @@ class Instance:
         # This correctly models pools serving short requests as faster than
         # pools serving long requests, even at the same n_slots.
         if self._active_reqs:
-            mean_seq_len = sum(r.l_in + r.l_out for r in self._active_reqs) / len(
-                self._active_reqs
-            )
+            mean_seq_len = sum(r.l_in + r.l_out for r in self._active_reqs) / len(self._active_reqs)
         else:
             mean_seq_len = float(req.l_in + req.l_out)
 
@@ -297,12 +331,19 @@ class Instance:
         s_eff = s_raw_full / self.n_slots
 
         completion_time = now + s_eff
-        heapq.heappush(self._events, _Event(completion_time, req))
+        heapq.heappush(self._events, _Event(completion_time, req, req.admission_seq))
+        return True
 
     def next_event_time(self) -> float:
-        """Time of the next completion event (or now if queue can be served)."""
+        """Time of the next completion event (or now if the queue can be served)."""
         if self._queue and self._active_slots < self.n_slots:
-            return self._now  # can immediately start a request
+            req = self._queue[0]
+            req_blocks = math.ceil((req.l_in + req.l_out) / self.gpu.blk_size)
+            # A request can start now only if it fits the KV budget, either
+            # directly or after preempting active requests.  Otherwise the
+            # clock must wait for the next completion to free blocks.
+            if self._used_kv_blocks + req_blocks <= self._total_kv_blocks or self._active_reqs:
+                return self._now
         if self._events:
             return self._events[0].time
         return float("inf")

--- a/src/fleet-sim/fleet_sim/core/request.py
+++ b/src/fleet-sim/fleet_sim/core/request.py
@@ -60,6 +60,10 @@ class Request:
 
     # reliability
     preempted: bool = False
+    # incremented on every (re-)admission; lets completion events identify
+    # which admission they belong to, so a stale event from an earlier
+    # admission of the same request can be ignored after preemption.
+    admission_seq: int = 0
 
     # state
     state: RequestState = field(default=RequestState.PENDING, init=False)

--- a/src/fleet-sim/tests/test_instance.py
+++ b/src/fleet-sim/tests/test_instance.py
@@ -1,0 +1,154 @@
+"""Regression tests for Instance preemption bookkeeping (issue #2890).
+
+Covers:
+- queue desync when admission requires preempting an active request
+- stale completion events firing after a request is re-admitted
+- advance_to not spinning when the KV budget cannot fit anything
+"""
+
+from fleet_sim.core.instance import Instance
+from fleet_sim.core.request import Request, RequestState
+from fleet_sim.gpu_profiles.manual import ManualProfile
+
+
+def make_instance(total_kv_blks: int = 12) -> Instance:
+    """Small deterministic instance: W=1, H=0 so latencies are trivial."""
+    profile = ManualProfile(
+        name="test",
+        W=1.0,
+        H=0.0,
+        chunk=1000,
+        blk_size=1,
+        total_kv_blks=total_kv_blks,
+        max_slots=100,
+        cost_per_hr=1.0,
+        calibration_ctx=6,
+    )
+    return Instance(instance_id=0, pool_id="p", gpu=profile, max_ctx=6)
+
+
+def test_admitted_request_is_removed_from_queue_when_preemption_occurs():
+    """The request admitted via preemption must leave the queue exactly once.
+
+    Regression for the first half of #2890: ``_start_next`` peeked the
+    queue head, then re-queued victims with ``appendleft``, then called
+    ``popleft`` which removed the last victim instead of the candidate.
+    The candidate stayed in the queue while also becoming active.
+    """
+    inst = make_instance()
+    a = Request(req_id=1, arrival_time=0, l_in=1, l_out=9)  # 10 blocks
+    b = Request(req_id=2, arrival_time=0, l_in=1, l_out=1)  # 2 blocks
+    c = Request(req_id=3, arrival_time=0, l_in=1, l_out=9)  # 10 blocks
+
+    for r in (a, b, c):
+        assert inst.accept(r)
+
+    inst._start_next(0.0)  # admits a
+    inst._start_next(0.0)  # admits b (budget exactly full: 10 + 2 == 12)
+    admitted = inst._start_next(1.0)  # c evicts a
+
+    assert admitted is True
+    # c must be active and gone from the queue.
+    assert c not in list(inst._queue), "admitted request still queued"
+    assert c in inst._active_reqs
+    # a was preempted and re-queued; b stayed active.
+    assert a in list(inst._queue)
+    assert a not in inst._active_reqs
+    assert b in inst._active_reqs
+    assert inst.queue_depth == 1
+
+
+def test_stale_completion_event_does_not_complete_request_twice():
+    """A preempted-then-readmitted request must complete exactly once.
+
+    Regression for the second half of #2890: the victim's original
+    completion event stayed in the event heap.  Once the request was
+    re-admitted (``preempted`` reset), the stale event could fire and
+    double-decrement slots/blocks and double-count the completion.
+
+    Scenario: a (10 blocks) is preempted by c (2 blocks); b finishes at
+    t=1 freeing a slot; a is re-admitted at t=1 (admission 2) while its
+    original completion event is still scheduled for t=5 (admission 1).
+    """
+    inst = make_instance()
+    a = Request(req_id=1, arrival_time=0, l_in=1, l_out=9)  # 10 blocks
+    b = Request(req_id=2, arrival_time=0, l_in=1, l_out=1)  # 2 blocks
+    c = Request(req_id=3, arrival_time=0, l_in=1, l_out=1)  # 2 blocks
+
+    for r in (a, b, c):
+        inst.accept(r)
+
+    inst._start_next(0.0)  # admit a (completion at t=5, admission 1)
+    inst._start_next(0.0)  # admit b (completion at t=1)
+    inst._start_next(1.0)  # c evicts a; a queued, preempted=True
+    assert a.preempted is True
+    assert a not in inst._active_reqs
+
+    # b completes at t=1, freeing a slot; a is re-admitted (admission 2).
+    completed = inst.advance_to(1.0)
+    assert [r.req_id for r in completed] == [2]
+    assert a.admission_seq == 2
+
+    # Run past a's stale completion (t=5, admission 1) and its real one.
+    completed += inst.advance_to(100.0)
+    ids = [r.req_id for r in completed]
+    assert ids.count(1) == 1, f"request 1 completed {ids.count(1)} times"
+    assert ids.count(2) == 1
+    assert ids.count(3) == 1
+    assert len(completed) == 3
+    assert inst.total_requests == 3
+    assert a.state == RequestState.DONE
+
+
+def test_advance_to_does_not_spin_when_budget_cannot_fit_anything():
+    """If the KV budget cannot fit even the head request, advance_to must
+    fall through to the next event instead of looping on _start_next.
+
+    Regression for the infinite-loop symptom in #2890: with no active
+    request to preempt and no room in the budget, _start_next used to
+    return without progress and the advance loop kept retrying the same
+    request forever.
+    """
+    inst = make_instance(total_kv_blks=3)
+    big = Request(req_id=1, arrival_time=0, l_in=1, l_out=9)  # 10 blocks
+    assert inst.accept(big)
+
+    completed = inst.advance_to(10.0)  # must return, not hang
+    assert completed == []
+    assert big in list(inst._queue)  # still waiting, not lost
+    assert big not in inst._active_reqs
+    assert inst.active_count == 0
+
+
+def test_next_event_time_waits_when_head_cannot_be_admitted():
+    """next_event_time must not claim immediate service when the head of
+    the queue cannot fit the KV budget even after preemption."""
+    inst = make_instance(total_kv_blks=3)
+    big = Request(req_id=1, arrival_time=0, l_in=1, l_out=9)  # 10 blocks
+    inst.accept(big)
+
+    assert inst.next_event_time() == float("inf")
+
+
+def test_full_run_completes_every_request_exactly_once():
+    """Full run with a preemption drives every request to DONE exactly
+    once, with consistent queue/active bookkeeping the whole way."""
+    inst = make_instance()
+    a = Request(req_id=1, arrival_time=0, l_in=1, l_out=9)  # 10 blocks
+    b = Request(req_id=2, arrival_time=0, l_in=1, l_out=1)  # 2 blocks
+    c = Request(req_id=3, arrival_time=0, l_in=1, l_out=1)  # 2 blocks
+    for r in (a, b, c):
+        inst.accept(r)
+
+    completed = inst.advance_to(100.0)
+
+    ids = [r.req_id for r in completed]
+    assert sorted(ids) == [1, 2, 3]
+    assert a.state == RequestState.DONE
+    assert b.state == RequestState.DONE
+    assert c.state == RequestState.DONE
+    assert inst.queue_depth == 0
+    assert inst.active_count == 0
+    assert inst.total_requests == 3
+    # b finishes first, so admitting c (2 blocks) needs no preemption.
+    assert inst.total_preempted == 0


### PR DESCRIPTION
Closes #2890

## Purpose

- Fixes two preemption bookkeeping bugs in `Instance._start_next` (`src/fleet-sim`) that corrupt the simulation whenever admitting a request requires evicting an active one:
  1. Queue desync: the head was peeked, then popped *after* victims were re-queued with `appendleft`, so the `popleft` removed the last victim instead of the candidate.  The admitted request stayed in the queue while also becoming active, which could double-admit it later or stall `advance_to` on the same still-queued request.
  2. Stale completion events: a preempted request's original completion event stayed in the event heap.  Once the request was re-admitted (the `preempted` flag is reset), the stale event could fire and double-decrement slots/blocks and double-count the completion.
- Also guards `advance_to` / `next_event_time` against spinning when the KV budget cannot fit even the head request (or when admitting it would just swap victims), so the clock advances to the next event instead of looping forever.
- Module: `Fleet-Sim`.

## Test Plan

- Added `src/fleet-sim/tests/test_instance.py` covering:
  - admitted-via-preemption request is removed from the queue exactly once
  - stale completion event does not complete a re-admitted request twice
  - `advance_to` returns instead of hanging when the budget cannot fit anything
  - `next_event_time` does not claim immediate service when the head cannot be admitted
  - a full preemption run drives every request to `DONE` exactly once
- Ran `pytest tests/test_instance.py` (5 passed) and the rest of the fleet-sim suite (199 passed; the 5 pre-existing failures in `test_optimizer.py` are a Windows GBK subprocess-decode issue unrelated to this change).
- Ran `ruff check` and `ruff format --check` on the changed files (clean).

## Test Result

- `pytest tests/test_instance.py -q` → `5 passed`
- `ruff check` → all checks passed; `ruff format --check` → 3 files already formatted

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
