### PR TITLE
[CLI][E2E] Fix idempotent base URL path rewrites

### DIFF
--- a/e2e/testing/vllm-sr-cli/README.md
+++ b/e2e/testing/vllm-sr-cli/README.md
@@ -25,7 +25,7 @@ Docker or Podman access.
 | `test_unit_serve.py` | Config bootstrap, mounts, ports, image pull policy, tokens, and read-only mode. |
 | `test_unit_lifecycle.py` | `status`, `logs`, `stop`, `dashboard`, and `config` command construction. |
 | `test_unit_runtime_topology.py` | Split-runtime discovery, cleanup, timeouts, and Docker/Podman selection. |
-| `test_integration.py` | Live health, management APIs, model visibility, sidecars, lifecycle, and pull policies. |
+| `test_integration.py` | Live health, management APIs, model visibility, path rewrites, sidecars, lifecycle, and pull policies. |
 | `cli_test_base.py` | Shared command and container helpers. |
 | `run_cli_tests.py` | Prerequisite checks, discovery, filtering, and reporting. |
 

--- a/e2e/testing/vllm-sr-cli/cli_test_base.py
+++ b/e2e/testing/vllm-sr-cli/cli_test_base.py
@@ -24,6 +24,9 @@ import yaml
 from cli.runtime_stack import DEFAULT_STACK_NAME, resolve_runtime_stack
 
 HTTP_STATUS_OK = 200
+AGENT_SMOKE_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "config.agent-smoke.cpu.yaml"
+)
 
 
 def _coerce_timeout_stream(value: str | bytes | None) -> str:
@@ -33,6 +36,15 @@ def _coerce_timeout_stream(value: str | bytes | None) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="replace")
     return value
+
+
+def _api_only_global_config() -> dict[str, object]:
+    """Reuse the canonical smoke global block for API-only integration tests."""
+    smoke_config = yaml.safe_load(AGENT_SMOKE_CONFIG_PATH.read_text(encoding="utf-8"))
+    global_config = smoke_config.get("global")
+    if not isinstance(global_config, dict):
+        raise AssertionError(f"{AGENT_SMOKE_CONFIG_PATH} must define a global mapping")
+    return global_config
 
 
 class CLITestBase(unittest.TestCase):
@@ -298,9 +310,24 @@ class CLITestBase(unittest.TestCase):
         port: int = 8888,
         model_name: str = "test-model",
         endpoint: str = "host.docker.internal:8000",
+        base_url: str | None = None,
+        provider: str | None = None,
+        api_only: bool = False,
     ) -> str:
         """Write a minimal runnable canonical v0.3 config into the temp workspace."""
         config_path = Path(self.test_dir) / "config.yaml"
+        backend_ref: dict[str, object] = {
+            "name": "primary",
+            "weight": 100,
+        }
+        if base_url is not None:
+            backend_ref["base_url"] = base_url
+        else:
+            backend_ref["endpoint"] = endpoint
+            backend_ref["protocol"] = "http"
+        if provider is not None:
+            backend_ref["provider"] = provider
+
         config = {
             "version": "v0.3",
             "listeners": [
@@ -320,14 +347,7 @@ class CLITestBase(unittest.TestCase):
                     {
                         "name": model_name,
                         "provider_model_id": model_name,
-                        "backend_refs": [
-                            {
-                                "name": "primary",
-                                "weight": 100,
-                                "endpoint": endpoint,
-                                "protocol": "http",
-                            }
-                        ],
+                        "backend_refs": [backend_ref],
                     }
                 ],
             },
@@ -344,6 +364,8 @@ class CLITestBase(unittest.TestCase):
                 ],
             },
         }
+        if api_only:
+            config["global"] = _api_only_global_config()
         config_path.write_text(
             yaml.safe_dump(config, sort_keys=False),
             encoding="utf-8",

--- a/e2e/testing/vllm-sr-cli/mock_openai_upstream.py
+++ b/e2e/testing/vllm-sr-cli/mock_openai_upstream.py
@@ -1,0 +1,27 @@
+"""Minimal OpenAI-compatible upstream used by vllm-sr CLI integration tests."""
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)
+        print(self.path, flush=True)
+        body = (
+            b'{"id":"mock","object":"chat.completion",'
+            b'"model":"test-model","choices":[{"index":0,'
+            b'"message":{"role":"assistant","content":"ok"},'
+            b'"finish_reason":"stop"}]}'
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+ThreadingHTTPServer(("0.0.0.0", 18080), Handler).serve_forever()

--- a/e2e/testing/vllm-sr-cli/test_integration.py
+++ b/e2e/testing/vllm-sr-cli/test_integration.py
@@ -14,11 +14,17 @@ import subprocess
 import time
 import unittest
 from contextlib import contextmanager
+from pathlib import Path
 from unittest import mock
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
 from cli_test_base import HTTP_STATUS_OK, CLITestBase
+
+DEFAULT_MOCK_OPENAI_IMAGE = "ghcr.io/vllm-project/semantic-router/vllm-sr-sim:latest"
+MOCK_OPENAI_IMAGE_ENV = "VLLM_SR_SIM_IMAGE"
+MOCK_OPENAI_SERVER_PORT = 18080
+MOCK_OPENAI_SERVER_PATH = Path(__file__).with_name("mock_openai_upstream.py").resolve()
 
 
 class TestServeIntegration(CLITestBase):
@@ -99,10 +105,19 @@ class TestServeIntegration(CLITestBase):
         self,
         *,
         env: dict[str, str] | None = None,
+        endpoint: str = "host.docker.internal:8000",
+        base_url: str | None = None,
+        provider: str | None = None,
+        api_only: bool = False,
         ensure_models_dir: bool = False,
     ):
         """Start one background serve session and clean it up automatically."""
-        self.write_minimal_canonical_config()
+        self.write_minimal_canonical_config(
+            endpoint=endpoint,
+            base_url=base_url,
+            provider=provider,
+            api_only=api_only,
+        )
         if ensure_models_dir:
             os.makedirs(os.path.join(self.test_dir, "models"), exist_ok=True)
 
@@ -152,6 +167,146 @@ class TestServeIntegration(CLITestBase):
         process.terminate.assert_called_once_with()
         process.kill.assert_not_called()
         self.assertEqual(process.communicate.call_count, 2)
+
+    @contextmanager
+    def _running_mock_upstream(self, container_name: str):
+        """Run the mock OpenAI upstream on the active stack network."""
+        image = os.getenv(MOCK_OPENAI_IMAGE_ENV, DEFAULT_MOCK_OPENAI_IMAGE)
+        result = self._run_subprocess(
+            [
+                self.container_runtime,
+                "run",
+                "-d",
+                "--name",
+                container_name,
+                "--network",
+                self.runtime_stack.network_name,
+                "-v",
+                f"{MOCK_OPENAI_SERVER_PATH}:/mock_openai_upstream.py:ro",
+                "--entrypoint",
+                "python3",
+                image,
+                "-u",
+                "/mock_openai_upstream.py",
+            ],
+            timeout=30,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"failed to start mock upstream: {result.stderr}",
+        )
+        self.assertTrue(
+            self.wait_for_container_running(
+                timeout=30,
+                container_name=container_name,
+            ),
+            "mock upstream did not reach running state",
+        )
+        try:
+            yield
+        finally:
+            self._run_subprocess(
+                [self.container_runtime, "rm", "-f", container_name],
+                timeout=30,
+            )
+
+    def _container_log_diagnostics(self, container_names: tuple[str, ...]) -> str:
+        """Collect bounded logs for a failed mock request."""
+        diagnostics = []
+        for container_name in container_names:
+            logs = self._run_subprocess(
+                [
+                    self.container_runtime,
+                    "logs",
+                    "--tail",
+                    "80",
+                    container_name,
+                ],
+                timeout=10,
+            )
+            diagnostics.append(
+                f"{container_name}:\n{(logs.stdout + logs.stderr)[-4000:]}"
+            )
+        return "\n".join(diagnostics)
+
+    def _send_mock_chat_completion(self, mock_container: str):
+        """Send a chat request, retrying until the local stack is ready."""
+        listener_port = 8888 + self.runtime_stack.port_offset
+        request = urllib_request.Request(
+            f"http://localhost:{listener_port}/v1/chat/completions",
+            data=(
+                b'{"model":"test-model","messages":'
+                b'[{"role":"user","content":"ping"}]}'
+            ),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        deadline = time.time() + 60
+        last_error: Exception | None = None
+        while time.time() < deadline:
+            try:
+                with urllib_request.urlopen(request, timeout=10) as response:
+                    self.assertEqual(response.status, 200)
+                    response.read()
+                return
+            except urllib_error.HTTPError as exc:
+                body = exc.read().decode("utf-8", errors="replace")
+                last_error = RuntimeError(f"HTTP {exc.code}: {body}")
+                time.sleep(2)
+            except (
+                urllib_error.URLError,
+                ConnectionError,
+                TimeoutError,
+            ) as exc:
+                last_error = exc
+                time.sleep(2)
+
+        diagnostics = self._container_log_diagnostics(
+            (
+                mock_container,
+                self.ROUTER_CONTAINER_NAME,
+                self.ENVOY_CONTAINER_NAME,
+            )
+        )
+        self.fail(f"request did not reach mock upstream: {last_error}\n{diagnostics}")
+
+    def _mock_upstream_paths(self, mock_container: str) -> set[str]:
+        """Read request paths recorded by the mock upstream."""
+        logs = self._run_subprocess(
+            [self.container_runtime, "logs", mock_container],
+            timeout=10,
+        )
+        self.assertEqual(logs.returncode, 0, logs.stderr)
+        return {
+            line.strip() for line in logs.stdout.splitlines() if line.startswith("/")
+        }
+
+    def _request_paths_for_mock_openai_base_path(
+        self,
+        *,
+        container_suffix: str,
+        base_path: str,
+    ) -> set[str]:
+        """Route one chat request to a path-recording OpenAI mock upstream."""
+        mock_container = f"{self.runtime_stack.stack_name}-{container_suffix}"
+        base_url = f"http://{mock_container}:{MOCK_OPENAI_SERVER_PORT}{base_path}"
+
+        with self._running_serve(
+            base_url=base_url,
+            provider="openai",
+            api_only=True,
+        ):
+            self.assertTrue(
+                self.wait_for_health(
+                    port=self.runtime_stack.api_port,
+                    timeout=self.CONTAINER_STARTUP_TIMEOUT,
+                ),
+                "router API did not become healthy",
+            )
+            with self._running_mock_upstream(mock_container):
+                self._send_mock_chat_completion(mock_container)
+                return self._mock_upstream_paths(mock_container)
 
     @unittest.skipUnless(
         os.environ.get("RUN_INTEGRATION_TESTS", "").lower() == "true",
@@ -289,6 +444,58 @@ class TestServeIntegration(CLITestBase):
             "catalog management credential is malformed",
         )
         return token
+
+    @unittest.skipUnless(
+        os.environ.get("RUN_INTEGRATION_TESTS", "").lower() == "true",
+        "Integration tests disabled. Set RUN_INTEGRATION_TESTS=true to enable.",
+    )
+    def test_base_url_path_rewrite_is_idempotent(self):
+        """Verify route cache recomputation does not apply a base path twice."""
+        self.print_test_header(
+            "Idempotent Base URL Rewrite Integration Test",
+            "Routes /v1/chat/completions once to a /v1beta/openai mock upstream",
+        )
+
+        upstream_paths = self._request_paths_for_mock_openai_base_path(
+            container_suffix="path-rewrite-upstream",
+            base_path="/v1beta/openai",
+        )
+        self.assertIn(
+            "/v1beta/openai/chat/completions",
+            upstream_paths,
+        )
+        self.assertNotIn(
+            "/v1beta/openaibeta/openai/chat/completions",
+            upstream_paths,
+        )
+
+        self.print_test_result(True, "Base URL path was applied exactly once")
+
+    @unittest.skip(
+        "TODO(issue-2885): fix root-cause rewrite idempotency for backend base "
+        "paths that still begin with the /v1 segment after rewriting."
+    )
+    @unittest.skipUnless(
+        os.environ.get("RUN_INTEGRATION_TESTS", "").lower() == "true",
+        "Integration tests disabled. Set RUN_INTEGRATION_TESTS=true to enable.",
+    )
+    def test_base_url_path_rewrite_idempotency_todo_for_v1_segment_prefix(self):
+        """Document the known gap for /v1/chat -> /v1/provider/chat rewrites."""
+        self.print_test_header(
+            "Future Base URL Rewrite Integration Test",
+            "Routes /v1/chat/completions once to a /v1/provider mock upstream",
+        )
+
+        upstream_paths = self._request_paths_for_mock_openai_base_path(
+            container_suffix="provider-rewrite-upstream",
+            base_path="/v1/provider",
+        )
+        self.assertEqual(
+            {"/v1/provider/chat/completions"},
+            upstream_paths,
+        )
+
+        self.print_test_result(True, "Future /v1 segment base URL was applied once")
 
     def _check_health_endpoint(self):
         """Check health endpoint (informational, doesn't fail test)."""

--- a/src/vllm-sr/cli/templates/envoy.template.yaml
+++ b/src/vllm-sr/cli/templates/envoy.template.yaml
@@ -65,11 +65,12 @@ static_resources:
                   # Rewrite Host header to match upstream server
                   host_rewrite_literal: "{{ model.endpoints[0].host_authority }}"
                   {% if model.path_prefix %}
-                  # Prepend path prefix to all requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions)
+                  # Prepend path prefix to /v1 requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions).
+                  # Match only the complete /v1 segment so route recomputation cannot rewrite /v1beta/... again.
                   regex_rewrite:
                     pattern:
                       google_re2: {}
-                      regex: "^/v1(.*)$"
+                      regex: "^/v1([/?].*)?$"
                     substitution: "{{ model.path_prefix }}\\1"
                   {% endif %}
               {% endfor %}
@@ -117,11 +118,12 @@ static_resources:
                   host_rewrite_literal: "{{ models[0].endpoints[0].host_authority }}"
                   {% endif %}
                   {% if models and models[0].path_prefix %}
-                  # Prepend path prefix to all requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions)
+                  # Prepend path prefix to /v1 requests (e.g., /compatible-mode + /v1/chat/completions = /compatible-mode/v1/chat/completions).
+                  # Match only the complete /v1 segment so route recomputation cannot rewrite /v1beta/... again.
                   regex_rewrite:
                     pattern:
                       google_re2: {}
-                      regex: "^/v1(.*)$"
+                      regex: "^/v1([/?].*)?$"
                     substitution: "{{ models[0].path_prefix }}\\1"
                   {% endif %}
           http_filters:

--- a/src/vllm-sr/tests/test_config_generator.py
+++ b/src/vllm-sr/tests/test_config_generator.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from pathlib import Path
 
@@ -101,12 +102,23 @@ def _model_route(rendered_config, model_name):
     raise AssertionError(f"route for model {model_name!r} not found")
 
 
+def _default_route(rendered_config):
+    """Find the fallback route without an x-selected-model header match."""
+    listener = rendered_config["static_resources"]["listeners"][0]
+    hcm = listener["filter_chains"][0]["filters"][0]["typed_config"]
+    routes = hcm["route_config"]["virtual_hosts"][0]["routes"]
+    for route in reversed(routes):
+        if not route.get("match", {}).get("headers"):
+            return route
+    raise AssertionError("default route not found")
+
+
 def test_backend_ref_ip_port_path_produces_correct_envoy_cluster_and_route(
     tmp_path, monkeypatch
 ):
     """Backend ref http://10.0.0.1:8000/v1 should split into address=10.0.0.1,
     port=8000, host_authority=10.0.0.1:8000, path_prefix=/v1, and the route
-    should use regex ^/v1(.*)$ to avoid duplicating /v1."""
+    should match only a complete /v1 path segment."""
     rendered = _render_envoy_config(
         tmp_path,
         monkeypatch,
@@ -155,8 +167,128 @@ routing:
     route = _model_route(rendered, "test-model")
     route_action = route["route"]
     assert route_action["host_rewrite_literal"] == "10.0.0.1:8000"
-    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1(.*)$"
+    assert route_action["regex_rewrite"]["pattern"]["regex"] == r"^/v1([/?].*)?$"
     assert route_action["regex_rewrite"]["substitution"] == "/v1\\1"
+
+
+def test_base_url_path_rewrite_is_idempotent(tmp_path, monkeypatch):
+    rendered = _render_envoy_config(
+        tmp_path,
+        monkeypatch,
+        """
+version: v0.3
+listeners:
+  - name: "http-8899"
+    address: "0.0.0.0"
+    port: 8899
+providers:
+  defaults:
+    default_model: "gemini-model"
+  models:
+    - name: "gemini-model"
+      provider_model_id: "gemini-model"
+      backend_refs:
+        - name: "gemini"
+          base_url: "https://generativelanguage.googleapis.com/v1beta/openai"
+          provider: "openai"
+          weight: 100
+routing:
+  modelCards:
+    - name: "gemini-model"
+  decisions:
+    - name: "default-route"
+      description: "default route"
+      priority: 100
+      rules:
+        operator: "AND"
+        conditions: []
+      modelRefs:
+        - model: "gemini-model"
+          use_reasoning: false
+""",
+        extproc_host="localhost",
+        router_api_host="localhost",
+    )
+
+    for route in (_model_route(rendered, "gemini-model"), _default_route(rendered)):
+        rewrite = route["route"]["regex_rewrite"]
+        pattern = rewrite["pattern"]["regex"]
+        substitution = rewrite["substitution"]
+
+        assert pattern == r"^/v1([/?].*)?$"
+        for request_path, upstream_path in (
+            ("/v1", "/v1beta/openai"),
+            (
+                "/v1/chat/completions",
+                "/v1beta/openai/chat/completions",
+            ),
+            (
+                "/v1?api-version=test",
+                "/v1beta/openai?api-version=test",
+            ),
+        ):
+            rewritten_path = re.sub(pattern, substitution, request_path)
+            assert rewritten_path == upstream_path
+            assert re.sub(pattern, substitution, rewritten_path) == upstream_path
+
+
+@pytest.mark.skip(
+    reason=(
+        "TODO(issue-2885): fix root-cause rewrite idempotency for backend base "
+        "paths that still begin with the /v1 segment after rewriting."
+    )
+)
+def test_base_url_path_rewrite_idempotency_todo_for_v1_segment_prefix(
+    tmp_path, monkeypatch
+):
+    """Document the known gap: /v1/chat -> /v1/provider/chat rewrites twice today."""
+    rendered = _render_envoy_config(
+        tmp_path,
+        monkeypatch,
+        """
+version: v0.3
+listeners:
+  - name: "http-8899"
+    address: "0.0.0.0"
+    port: 8899
+providers:
+  defaults:
+    default_model: "provider-model"
+  models:
+    - name: "provider-model"
+      provider_model_id: "provider-model"
+      backend_refs:
+        - name: "provider"
+          base_url: "https://api.example.com/v1/provider"
+          provider: "openai"
+          weight: 100
+routing:
+  modelCards:
+    - name: "provider-model"
+  decisions:
+    - name: "default-route"
+      description: "default route"
+      priority: 100
+      rules:
+        operator: "AND"
+        conditions: []
+      modelRefs:
+        - model: "provider-model"
+          use_reasoning: false
+""",
+        extproc_host="localhost",
+        router_api_host="localhost",
+    )
+
+    for route in (_model_route(rendered, "provider-model"), _default_route(rendered)):
+        rewrite = route["route"]["regex_rewrite"]
+        pattern = rewrite["pattern"]["regex"]
+        substitution = rewrite["substitution"]
+        upstream_path = "/v1/provider/chat/completions"
+
+        rewritten_path = re.sub(pattern, substitution, "/v1/chat/completions")
+        assert rewritten_path == upstream_path
+        assert re.sub(pattern, substitution, rewritten_path) == upstream_path
 
 
 def test_provider_reliability_renders_retry_outlier_and_least_request(
@@ -279,7 +411,7 @@ routing:
     route_action = route["route"]
     # standard port 443 → host_authority should omit port
     assert route_action["host_rewrite_literal"] == "api.example.com"
-    assert route_action["regex_rewrite"]["pattern"]["regex"] == "^/v1(.*)$"
+    assert route_action["regex_rewrite"]["pattern"]["regex"] == r"^/v1([/?].*)?$"
     assert route_action["regex_rewrite"]["substitution"] == "/compatible-mode/v1\\1"
 
 


### PR DESCRIPTION
Part of #2885

This PR addresses the known failing pattern from #2885 where `clear_route_cache` route recomputation can apply a backend base URL path rewrite more than once, for example `/v1/chat/completions` being rewritten through a `/v1beta/openai` base path repeatedly. It does not close #2885; broader root-cause cleanup remains tracked there.
## Purpose

This PR fixes a backend base URL path rewrite regression in the `vllm-sr` generated Envoy config.

The issue appears when an OpenAI-compatible backend is configured with a `base_url` that already contains a path beginning with text that looks like `/v1`, for example:

```yaml
base_url: https://generativelanguage.googleapis.com/v1beta/openai
provider: openai
```

Before this change, the generated Envoy route used this broad rewrite matcher:

```text
^/v1(.*)$
```

That matcher also matches paths such as `/v1beta/openai/...`. When the route cache is recomputed, the already rewritten upstream path can be rewritten again, producing an invalid path like:

```text
/v1beta/openaibeta/openai/chat/completions
```

This PR changes the generated rewrite matcher to only match a complete `/v1` path segment:

```text
^/v1([/?].*)?$
```

With that matcher, `/v1/chat/completions` still rewrites to the configured backend base path, but `/v1beta/...` no longer matches as if it were the request-facing `/v1` segment.

Affected modules: `CLI` / `E2E`

### Implementation Notes

- Updates `src/vllm-sr/cli/templates/envoy.template.yaml` for both selected-model routes and the default fallback route.
- Adds config generator tests that assert the rendered Envoy regex/substitution and exercise the rewrite idempotency behavior with `re.sub`.
- Extends the CLI integration test helper so API-only smoke configs can point at a `base_url` backend instead of only an `endpoint` backend.
- Adds a minimal path-recording OpenAI-compatible mock upstream for CLI integration tests. The integration test sends a real request through `vllm-sr serve` / Envoy and verifies the path received by the mock upstream.
- Adds skipped TODO coverage for the remaining root-cause gap where a future rewrite such as `/v1/chat -> /v1/provider/chat` can still be vulnerable because the rewritten path continues to begin with the `/v1` segment.

The E2E test changes are somewhat larger than the template fix itself because they cover the real serve -> Envoy -> upstream path behavior. If maintainers prefer a lighter or more reusable test structure, I can revise this part.

### Known Follow-Up

This PR fixes the current `/v1beta/openai` double-rewrite failure, but it does not fully remove the underlying rewrite idempotency risk for every possible backend base path. The skipped TODO tests document the remaining case where the rewritten backend path itself still starts with `/v1`, such as:

```text
/v1/chat/completions -> /v1/provider/chat/completions
```

## Test Plan

- Run focused config generator tests to verify rendered Envoy route behavior.
- Run the vllm-sr CLI test suite to verify the new integration tests are discovered and skipped by default unless integration mode is enabled.
- Use the mock OpenAI-compatible upstream to keep the integration path deterministic and avoid depending on a live provider.
- Keep the known `/v1/provider/...` root-cause case as skipped TODO coverage so a future fix has an executable target.

Full live CLI integration coverage remains available through:

```bash
make vllm-sr-test-integration
```

## Test Result

```text
.venv-agent/bin/python -m pytest src/vllm-sr/tests/test_config_generator.py
8 passed, 1 skipped
```

```text
make vllm-sr-test
Ran 44 tests in 63.489s
OK (skipped=8)
Tests executed: 36
Tests skipped: 8
Failures: 0
Errors: 0
```

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>