### PR TITLE
[Dashboard] fix: drop racy CurrentStep assertion in RunTaskHandler test

### DIFF
--- a/dashboard/backend/handlers/evaluation_test.go
+++ b/dashboard/backend/handlers/evaluation_test.go
@@ -345,7 +345,12 @@ func TestRunTaskHandlerMarksRerunTaskRunningBeforeBackgroundExecution(t *testing
 	if updatedTask.ProgressPercent != 0 {
 		t.Fatalf("task progress = %d, want 0", updatedTask.ProgressPercent)
 	}
-	if updatedTask.CurrentStep != "Starting evaluation" {
-		t.Fatalf("task current_step = %q, want %q", updatedTask.CurrentStep, "Starting evaluation")
-	}
+	// CurrentStep is intentionally not asserted here. The handler writes
+	// "Starting evaluation" synchronously, then hands off to a background
+	// goroutine that advances the step to "Evaluating <dimension>" as soon
+	// as the first dimension starts. That handoff is a race by design, so
+	// asserting the transient step after the response returns is inherently
+	// flaky (the goroutine can win the race and the step is already
+	// "Evaluating accuracy"). The stable contract is status=Running and
+	// progress=0, both set before the goroutine is spawned.
 }

--- a/dashboard/backend/handlers/evaluation_test.go
+++ b/dashboard/backend/handlers/evaluation_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/vllm-project/semantic-router/dashboard/backend/evaluation"
 	"github.com/vllm-project/semantic-router/dashboard/backend/models"
@@ -326,6 +327,22 @@ func TestRunTaskHandlerMarksRerunTaskRunningBeforeBackgroundExecution(t *testing
 	harness.handler.RunTaskHandler().ServeHTTP(rec, req)
 	t.Cleanup(func() {
 		_ = harness.handler.runner.CancelTask(task.ID)
+		// Join the background evaluation goroutine before the harness
+		// cleanups (db.Close, TempDir removal) run: RunTaskHandler deletes
+		// the task's cancelFunc entry only after runner.RunTask returns, so
+		// once the entry is gone the goroutine performs no further DB or
+		// filesystem writes.
+		deadline := time.Now().Add(10 * time.Second)
+		for {
+			if _, ok := harness.handler.cancelFuncs.Load(task.ID); !ok {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Error("background evaluation goroutine did not exit within 10s")
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 	})
 
 	if rec.Code != http.StatusOK {


### PR DESCRIPTION
Closes #2905

## Purpose

`TestRunTaskHandlerMarksRerunTaskRunningBeforeBackgroundExecution` flaked under `-count` runs: the handler writes `current_step = "Starting evaluation"` synchronously, then spawns a background goroutine that immediately advances the step to `"Evaluating accuracy"` as the first dimension starts. The test read the task after the response returned and asserted the transient step, so whenever the goroutine won the race the assertion failed (`task current_step = "Evaluating accuracy", want "Starting evaluation"`).

That handoff is a race by design — the step is explicitly transient, and #2904 makes this suite part of the required Dashboard gate, so the flake can block unrelated PRs.

Fix: drop the `CurrentStep` assertion. The stable contract the handler guarantees before returning is `status = running` and `progress = 0`, both set synchronously before the goroutine is spawned; those assertions stay. The step after that point is owned by the background evaluation, not the handler.

## Test Plan

- `go test ./handlers/ -count=25 -run TestRunTaskHandlerMarksRerunTaskRunningBeforeBackgroundExecution` — passes consistently (was flaky before the change)
- `go build ./...`, `go vet ./handlers/`, `gofmt -l` — clean
- Note: `TestGlobalConfigYAMLHandler_*` failures in the full `handlers` run reproduce on a clean `main` checkout (shared-DB teardown ordering), unrelated to this change.

## Test Result

25/25 runs of the target test pass on the current head.

Module: `[Dashboard]` (backend test suite).
