### PR TITLE
[Bindings] expose a named `cuda-dynamic` feature in onnx-binding

### DIFF
--- a/onnx-binding/Cargo.toml
+++ b/onnx-binding/Cargo.toml
@@ -29,6 +29,8 @@ openvino-dynamic = ["ort/load-dynamic", "ort/openvino"]
 migraphx-dynamic = ["migraphx", "rocm", "ort/load-dynamic"]
 # ROCm via dynamic loading (for Docker containers with ROCm ORT)
 rocm-dynamic = ["rocm", "ort/load-dynamic"]
+# CUDA via dynamic loading (for Docker containers with CUDA ORT)
+cuda-dynamic = ["cuda", "ort/load-dynamic"]
 
 [dependencies]
 # ONNX Runtime via ort crate - supports AMD GPU (ROCm), NVIDIA GPU (CUDA), and more

--- a/src/vllm-sr/Dockerfile.cuda
+++ b/src/vllm-sr/Dockerfile.cuda
@@ -195,13 +195,7 @@ RUN mkdir -p /build/out && \
 # Stage 1r: Build Rust onnx-binding (CUDA dynamic, amd64 only).
 # ============================================================================
 # CHANGE vs Dockerfile.rocm:
-#   --features rocm-dynamic  ->  --features cuda,load-dynamic
-# Rationale:
-#   onnx-binding/Cargo.toml exposes both:
-#     cuda          = ["ort/cuda"]
-#     rocm-dynamic  = ["rocm", "ort/load-dynamic"]
-#   There is no pre-existing `cuda-dynamic` feature, so we compose:
-#     cuda + ort/load-dynamic (we add it inline; equivalent shape to rocm-dynamic).
+#   --features rocm-dynamic  ->  --features cuda-dynamic
 # ============================================================================
 FROM --platform=$BUILDPLATFORM ${ONNX_RUST_RUNTIME_COMPAT_IMAGE} AS onnx-builder
 ARG TARGETARCH
@@ -223,21 +217,15 @@ COPY onnx-binding/Cargo.toml onnx-binding/Cargo.loc[k] ./
 
 # Feature design note (matches rocm-dynamic pattern):
 #   onnx-binding's `cuda` feature alone (= ["ort/cuda"]) statically links the
-#   bundled CUDA EP via ort's `download-binaries`. We want load-dynamic so the
-#   runtime image's onnxruntime-gpu wheel is used (mirrors the ROCm path).
-#   We therefore compose the feature set at the cargo invocation level:
-#     cuda             -> pulls ort/cuda (enables CUDA EP code paths)
-#     ort/load-dynamic -> tells ort to dlopen libonnxruntime.so via
-#                         ORT_DYLIB_PATH at runtime
-#   This is functionally a `cuda-dynamic` feature; upstream just hasn't named
-#   it. Filing a follow-up PR to expose `cuda-dynamic` in Cargo.toml is a
-#   reasonable next step but not required to ship.
+#   bundled CUDA EP via ort's `download-binaries`. `cuda-dynamic` adds
+#   ort/load-dynamic so the runtime image's onnxruntime-gpu wheel is dlopen'd
+#   via ORT_DYLIB_PATH instead (mirrors the ROCm path).
 RUN [ "$GIT_SSL_NO_VERIFY" = "1" ] && git config --global http.sslVerify false || true; \
     mkdir -p src && echo "pub fn _dummy() {}" > src/lib.rs && \
     OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu \
     cargo build --release \
       --no-default-features \
-      --features "cuda,ort/load-dynamic" \
+      --features cuda-dynamic \
       --target x86_64-unknown-linux-gnu && \
     rm -rf src
 
@@ -249,7 +237,7 @@ RUN find target -name "libonnx_semantic_router.so" -delete 2>/dev/null; \
     OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu \
     cargo build --release \
       --no-default-features \
-      --features "cuda,ort/load-dynamic" \
+      --features cuda-dynamic \
       --target x86_64-unknown-linux-gnu
 
 RUN mkdir -p /build/out && \


### PR DESCRIPTION
Closes #2912

### What

`onnx-binding/Cargo.toml` declares a named `<ep>-dynamic` feature for every execution provider except CUDA:

```toml
rocm-dynamic     = ["rocm", "ort/load-dynamic"]
migraphx-dynamic = ["migraphx", "rocm", "ort/load-dynamic"]
openvino-dynamic = ["ort/load-dynamic", "ort/openvino"]
cuda             = ["ort/cuda"]        # no dynamic counterpart
```

So `src/vllm-sr/Dockerfile.cuda` composed the feature set inline at the cargo invocation instead:

```dockerfile
--features "cuda,ort/load-dynamic"
```

This PR adds the missing name and switches the two build stages and the NVIDIA local-build doc over to it.

```toml
# CUDA via dynamic loading (for Docker containers with CUDA ORT)
cuda-dynamic = ["cuda", "ort/load-dynamic"]
```

The 24-line comment block in `Dockerfile.cuda` that existed to explain the ad-hoc composition — including its own note that "filing a follow-up PR to expose `cuda-dynamic` in Cargo.toml is a reasonable next step" — collapses to three lines.

### Why

**Discoverability.** Someone building the ONNX binding for NVIDIA reads `Cargo.toml`, sees only `cuda`, and runs `--features cuda`. That statically links the CUDA EP bundled through `ort`'s `download-binaries` rather than `dlopen`-ing the runtime image's `onnxruntime-gpu` build via `ORT_DYLIB_PATH`. The resulting CUDA/cuDNN mismatch surfaces as an EP-registration failure at model load — and because the loader falls back to CPU, it can instead surface as "GPU is enabled but latency is unchanged", which is considerably harder to diagnose.

**Cross-crate feature reach-through.** `ort/load-dynamic` in a `cargo build` invocation reaches into a dependency's feature namespace from outside the manifest. An `ort` rename or restructure breaks the image build with no manifest-level signal. Declaring it in `Cargo.toml` moves that failure to build time on the crate itself.

**Consistency.** Three of four execution providers already have the named pair.

### Verification

No change to the produced artifact — `cuda-dynamic` resolves to exactly the feature set the Dockerfile composed before.

```console
$ cargo tree -e features --no-default-features --features cuda-dynamic            > new.txt
$ cargo tree -e features --no-default-features --features "cuda,ort/load-dynamic" > old.txt
$ diff old.txt new.txt && echo "identical"
identical
$ wc -l old.txt new.txt
  1363 old.txt
  1363 new.txt
```

Byte-identical, 1363 lines each. The inverse tree confirms both `ort` features are actually reached through the new name:

```console
$ cargo tree -e features --no-default-features --features cuda-dynamic -i ort
ort v2.0.0-rc.10
├── ort feature "cuda"
│   └── onnx-semantic-router feature "cuda"
│       └── onnx-semantic-router feature "cuda-dynamic" (command-line)
├── ort feature "libloading"
│   └── ort feature "load-dynamic"
│       └── onnx-semantic-router feature "cuda-dynamic" (command-line)
├── ort feature "load-dynamic" (*)
...
```

I did not rebuild the CUDA image — the build is amd64-only and pulls the full CUDA toolchain, and the feature-resolution equivalence above is what the change actually turns on. Happy to run an image build if a reviewer wants it before merge.

### Scope

`+10 / -20` across three files. No Rust source, no runtime behavior, no CI config touched.

| File | Change |
|---|---|
| `onnx-binding/Cargo.toml` | `+2` — declare `cuda-dynamic` |
| `src/vllm-sr/Dockerfile.cuda` | both `--features` strings; drop the now-redundant rationale comments |
| `tools/agent/docs/nvidia-local.md` | two references to the old inline string |
