### PR TITLE
[CI/Build] Prevent Mergify labels from retriggering PR CI

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -47,6 +47,8 @@ queue_rules:
 
 merge_queue:
   max_parallel_checks: 1
+  queued_label: null
+  dequeued_label: null
 
 pull_request_rules:
   - name: queue approved pull requests


### PR DESCRIPTION
Related #2917

Observed in #2913.

## Purpose

- Disable Mergify's default `queued` and `dequeued` labels.
- Prevent merge-queue state changes from retriggering the label-driven PR workflow and replacing required checks with pending or cancelled runs.
- Keep the existing `labeled` and `unlabeled` workflow triggers for intentional controls such as `ci/full`.
- Affects: `CI/Build`.

## Test Plan

- Run `make agent-validate`.
- Run `make agent-ci-gate CHANGED_FILES=".mergify.yml"`.
- Validate `.mergify.yml` against Mergify's official JSON schema.
- These checks cover the repository harness, workflow contracts, YAML, security, and the external configuration schema for this config-only change.

## Test Result

- Agent manifests and workflow contracts validated successfully.
- All 24 CI harness unit tests passed.
- YAML lint, AST supply-chain security, changed-files lint, reference-config tests, and structure checks passed.
- Official Mergify schema validation passed.
- Tradeoff: queue state will no longer be shown through `queued` or `dequeued` labels; Mergify checks and status comments remain available.
- Merge note: Mergify reads this configuration from the default branch, so this bootstrap PR should be merged manually after CI is green; queueing it can reproduce the existing loop once more.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.