### PR TITLE
[Router] cache: propagate request context through cache backends

### DIFF
--- a/e2e/testcases/cache.go
+++ b/e2e/testcases/cache.go
@@ -4,16 +4,25 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
 
 	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
 )
+
+// cacheCancelWindow is how long the cancellation probe lets a request run before
+// abandoning it. Long enough that the router has started the ext_proc exchange,
+// short enough that a real upstream answer is unlikely.
+const cacheCancelWindow = 250 * time.Millisecond
 
 func init() {
 	pkgtestcases.Register("semantic-cache", pkgtestcases.TestCase{
@@ -38,9 +47,11 @@ type CacheResult struct {
 	OriginalQuestion string
 	SimilarQuestion  string
 	CacheHit         bool
+	Similarity       float64 // this request's score: the match on a hit, the best rejected candidate on a miss (0 when absent)
 	Error            string
 }
 
+//nolint:cyclop,gocognit // Existing E2E orchestration branches by request outcome.
 func testCache(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
 	if opts.Verbose {
 		fmt.Println("[Test] Testing semantic cache functionality")
@@ -61,6 +72,7 @@ func testCache(ctx context.Context, client *kubernetes.Clientset, opts pkgtestca
 
 	// Run cache tests
 	var results []CacheResult
+	var setupFailures []string
 	totalRequests := 0
 	cacheHits := 0
 
@@ -69,13 +81,18 @@ func testCache(ctx context.Context, client *kubernetes.Clientset, opts pkgtestca
 		if opts.Verbose {
 			fmt.Printf("[Test] Sending original question: %s\n", testCase.OriginalQuestion)
 		}
-		_, err := sendChatRequest(ctx, testCase.OriginalQuestion, localPort, opts.Verbose)
+		origResp, err := sendChatRequest(ctx, testCase.OriginalQuestion, localPort, opts.Verbose)
 		if err != nil {
 			if opts.Verbose {
 				fmt.Printf("[Test] Error sending original question: %v\n", err)
 			}
+			// Without a priming request the similar questions cannot hit, so
+			// record it instead of silently skipping the case.
+			setupFailures = append(setupFailures,
+				fmt.Sprintf("original question %q: %v", testCase.OriginalQuestion, err))
 			continue
 		}
+		origResp.Body.Close()
 
 		// Wait a bit to ensure cache is populated
 		time.Sleep(1 * time.Second)
@@ -115,6 +132,91 @@ func testCache(ctx context.Context, client *kubernetes.Clientset, opts pkgtestca
 			cacheHits, totalRequests, hitRate)
 	}
 
+	verdict := evaluateCacheAssertions(results, totalRequests, cacheHits, setupFailures)
+
+	// Cancellation runs last so it cannot disturb the hit-rate measurement above.
+	return errors.Join(verdict, runCacheCancellationCheck(ctx, localPort, opts.Verbose))
+}
+
+// runCacheCancellationCheck pins the #2473 cancellation contract at the only
+// place E2E can see it: an abandoned request must publish no cache state — not
+// even the pending entry written before the upstream answers — so the same
+// question asked again must still miss. Error propagation and the write-path
+// guards are pinned at unit level.
+//
+// A request that beats the cancel window is reported and skipped, not failed.
+func runCacheCancellationCheck(ctx context.Context, localPort string, verbose bool) error {
+	// Unique: anything semantically close in the corpus would answer the follow-up.
+	question := fmt.Sprintf("cancellation probe %d: describe the ripening of a persimmon", time.Now().UnixNano())
+
+	cancelCtx, cancel := context.WithTimeout(ctx, cacheCancelWindow)
+	defer cancel()
+
+	resp, err := sendChatRequest(cancelCtx, question, localPort, verbose)
+	if err == nil {
+		resp.Body.Close()
+		fmt.Printf("[Test] cancellation probe: upstream answered within %s; no mid-flight cancel to assert on\n",
+			cacheCancelWindow)
+		return nil
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("cancellation probe failed for an unrelated reason: %w", err)
+	}
+	if verbose {
+		fmt.Printf("[Test] cancellation probe: request abandoned after %s\n", cacheCancelWindow)
+	}
+
+	// Same settling time the priming requests get.
+	time.Sleep(1 * time.Second)
+
+	followUp, err := sendChatRequest(ctx, question, localPort, verbose)
+	if err != nil {
+		return fmt.Errorf("cancellation probe follow-up request failed: %w", err)
+	}
+	defer followUp.Body.Close()
+
+	if followUp.Header.Get("x-vsr-cache-hit") == "true" {
+		return fmt.Errorf("cancelled request published cache state: the same question hit with similarity %q",
+			followUp.Header.Get("x-vsr-cache-similarity"))
+	}
+	if _, simErr := parseCacheSimilarity(followUp.Header.Get("x-vsr-cache-similarity"), false); simErr != "" {
+		return fmt.Errorf("cancellation probe follow-up: %s", simErr)
+	}
+
+	return nil
+}
+
+// evaluateCacheAssertions makes the per-request verdicts from
+// parseCacheSimilarity affect the testcase result.
+//
+// Hit rate is not gated here on purpose: it is a measurement reported through
+// SetDetails, and acceptance_contracts.go already enforces a floor for it on the
+// profile that owns that contract.
+func evaluateCacheAssertions(results []CacheResult, totalRequests, cacheHits int, setupFailures []string) error {
+	assertionFailures := append([]string{}, setupFailures...)
+	for _, r := range results {
+		if r.Error != "" {
+			assertionFailures = append(assertionFailures,
+				fmt.Sprintf("%q: %s", r.SimilarQuestion, r.Error))
+		}
+	}
+
+	if totalRequests == 0 {
+		if len(setupFailures) > 0 {
+			return fmt.Errorf("cache test executed zero similar-question requests; every priming request failed:\n  %s",
+				strings.Join(setupFailures, "\n  "))
+		}
+		return errors.New("cache test executed zero similar-question requests; nothing was asserted")
+	}
+	if len(assertionFailures) > 0 {
+		return fmt.Errorf("cache per-request similarity assertions failed (%d of %d requests):\n  %s",
+			len(assertionFailures), totalRequests, strings.Join(assertionFailures, "\n  "))
+	}
+	if cacheHits == 0 {
+		fmt.Printf("[Test] cache test observed zero hits across %d requests; "+
+			"the hit path's similarity contract was not exercised in this run\n", totalRequests)
+	}
+
 	return nil
 }
 
@@ -151,15 +253,60 @@ func testSingleCacheRequest(ctx context.Context, testCase CacheTestCase, questio
 	cacheHitHeader := resp.Header.Get("x-vsr-cache-hit")
 	result.CacheHit = (cacheHitHeader == "true")
 
+	sim, simErr := parseCacheSimilarity(resp.Header.Get("x-vsr-cache-similarity"), result.CacheHit)
+	if simErr != "" {
+		result.Error = simErr
+		return result
+	}
+	result.Similarity = sim
+
 	if verbose {
 		if result.CacheHit {
-			fmt.Printf("[Test] ✓ Cache HIT for: %s\n", question)
+			fmt.Printf("[Test] ✓ Cache HIT for: %s (similarity=%.4f)\n", question, result.Similarity)
 		} else {
 			fmt.Printf("[Test] ✗ Cache MISS for: %s\n", question)
 		}
 	}
 
 	return result
+}
+
+// parseCacheSimilarity validates one lookup's x-vsr-cache-similarity header and
+// returns the parsed score, or a non-empty error message.
+//
+// The contract (#2473): the score belongs to this request, rejected candidates
+// included. A hit is only served above the configured threshold, so its score
+// lands in (0,1]; a miss may omit the header, or report its best rejected
+// candidate, which must still be a finite score in [0,1). The header rides the
+// x-vsr-debug surface.
+//
+// The miss bound is [0,1) rather than "below threshold" on purpose: the profile
+// threshold is not visible here, and a miss reporting a full 1.0 match would
+// mean the hit path was bypassed.
+func parseCacheSimilarity(simHeader string, cacheHit bool) (float64, string) {
+	if simHeader == "" {
+		if cacheHit {
+			return 0, "cache hit missing x-vsr-cache-similarity header (per-request score not surfaced)"
+		}
+		return 0, ""
+	}
+	sim, err := strconv.ParseFloat(simHeader, 64)
+	if err != nil {
+		return 0, fmt.Sprintf("unparsable x-vsr-cache-similarity %q: %v", simHeader, err)
+	}
+	if math.IsNaN(sim) || math.IsInf(sim, 0) {
+		return 0, fmt.Sprintf("non-finite x-vsr-cache-similarity %q", simHeader)
+	}
+	if cacheHit {
+		if sim <= 0.0 || sim > 1.0 {
+			return 0, fmt.Sprintf("cache-hit similarity %.4f out of expected (0,1] range", sim)
+		}
+		return sim, ""
+	}
+	if sim < 0.0 || sim >= 1.0 {
+		return 0, fmt.Sprintf("cache-miss similarity %.4f out of expected [0,1) range", sim)
+	}
+	return sim, ""
 }
 
 func sendChatRequest(ctx context.Context, question, localPort string, verbose bool) (*http.Response, error) {
@@ -181,6 +328,8 @@ func sendChatRequest(ctx context.Context, question, localPort string, verbose bo
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// x-vsr-cache-similarity is demoted to the debug surface; opt in.
+	req.Header.Set("x-vsr-debug", "true")
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	resp, err := httpClient.Do(req)
@@ -197,6 +346,7 @@ func sendChatRequest(ctx context.Context, question, localPort string, verbose bo
 	return resp, nil
 }
 
+//nolint:cyclop,funlen,gocognit // Existing reporting branches by category, miss, and error.
 func printCacheResults(results []CacheResult, totalRequests, cacheHits int, hitRate float64) {
 	separator := "================================================================================"
 	fmt.Println("\n" + separator)

--- a/e2e/testcases/cache_test.go
+++ b/e2e/testcases/cache_test.go
@@ -1,0 +1,114 @@
+package testcases
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEvaluateCacheAssertionsRejectsZeroRequests(t *testing.T) {
+	err := evaluateCacheAssertions(nil, 0, 0, nil)
+	if err == nil || !strings.Contains(err.Error(), "zero similar-question requests") {
+		t.Fatalf("expected zero-request failure, got %v", err)
+	}
+}
+
+func TestEvaluateCacheAssertionsReportsSetupFailures(t *testing.T) {
+	err := evaluateCacheAssertions(nil, 0, 0, []string{`original question "q": connection refused`})
+	if err == nil {
+		t.Fatal("expected failure when every priming request failed")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("setup failure detail must reach the verdict, got %v", err)
+	}
+}
+
+func TestEvaluateCacheAssertionsPropagatesPerRequestErrors(t *testing.T) {
+	results := []CacheResult{
+		{SimilarQuestion: "good", CacheHit: true, Similarity: 0.9},
+		{SimilarQuestion: "bad", CacheHit: true, Error: "cache hit missing x-vsr-cache-similarity header"},
+	}
+	err := evaluateCacheAssertions(results, 2, 2, nil)
+	if err == nil || !strings.Contains(err.Error(), "bad") {
+		t.Fatalf("expected the per-request error to fail the run, got %v", err)
+	}
+}
+
+// Hit rate is a measurement, not a gate here — the repository enforces its floor
+// through the "semantic-cache" acceptance contract instead.
+func TestEvaluateCacheAssertionsDoesNotGateOnHitRate(t *testing.T) {
+	results := []CacheResult{{SimilarQuestion: "miss", CacheHit: false}}
+	if err := evaluateCacheAssertions(results, 1, 0, nil); err != nil {
+		t.Fatalf("zero hits must not fail the testcase, got %v", err)
+	}
+}
+
+func TestEvaluateCacheAssertionsAcceptsValidHit(t *testing.T) {
+	results := []CacheResult{{SimilarQuestion: "hit", CacheHit: true, Similarity: 0.9}}
+	if err := evaluateCacheAssertions(results, 1, 1, nil); err != nil {
+		t.Fatalf("expected valid hit to pass, got %v", err)
+	}
+}
+
+// The blocker this file exists for: a hit whose per-request score never reached
+// the response surface must fail, not pass silently.
+func TestParseCacheSimilarityRejectsHitWithoutHeader(t *testing.T) {
+	if _, msg := parseCacheSimilarity("", true); msg == "" {
+		t.Fatal("expected a hit with an absent similarity header to fail")
+	}
+}
+
+func TestParseCacheSimilarityRejectsOutOfRangeHitScore(t *testing.T) {
+	for _, header := range []string{"0", "0.0000", "-0.5", "1.5"} {
+		if _, msg := parseCacheSimilarity(header, true); msg == "" {
+			t.Errorf("header %q: expected out-of-(0,1] hit similarity to fail", header)
+		}
+	}
+}
+
+func TestParseCacheSimilarityRejectsOutOfRangeMissScore(t *testing.T) {
+	// 1.0 is a full match: reporting it on a miss means the hit path was skipped.
+	for _, header := range []string{"-0.5", "1", "1.5"} {
+		if _, msg := parseCacheSimilarity(header, false); msg == "" {
+			t.Errorf("header %q: expected out-of-[0,1) miss similarity to fail", header)
+		}
+	}
+}
+
+func TestParseCacheSimilarityAcceptsRejectedCandidateMissScore(t *testing.T) {
+	for _, tt := range []struct {
+		header string
+		want   float64
+	}{
+		{header: "", want: 0},
+		{header: "0", want: 0},
+		{header: "0.42", want: 0.42},
+	} {
+		sim, msg := parseCacheSimilarity(tt.header, false)
+		if msg != "" {
+			t.Fatalf("header %q: %s", tt.header, msg)
+		}
+		if sim != tt.want {
+			t.Errorf("header %q: got similarity %v, want %v", tt.header, sim, tt.want)
+		}
+	}
+}
+
+func TestParseCacheSimilarityRejectsNonFiniteScores(t *testing.T) {
+	tests := []struct {
+		name     string
+		cacheHit bool
+	}{
+		{name: "hit", cacheHit: true},
+		{name: "miss", cacheHit: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, header := range []string{"NaN", "+Inf", "-Inf"} {
+				if _, msg := parseCacheSimilarity(header, tt.cacheHit); msg == "" {
+					t.Errorf("header=%q: expected non-finite similarity to fail", header)
+				}
+			}
+		})
+	}
+}

--- a/src/semantic-router/pkg/apiserver/route_response_cache.go
+++ b/src/semantic-router/pkg/apiserver/route_response_cache.go
@@ -103,7 +103,7 @@ func (s *ClassificationAPIServer) handleResponseCacheTest(
 		return
 	}
 	defer func() { _ = backend.Close() }()
-	healthErr := backend.CheckConnection()
+	healthErr := backend.CheckConnection(r.Context())
 	response := responseCacheTestResponse{
 		Valid:        true,
 		Healthy:      healthErr == nil,

--- a/src/semantic-router/pkg/cache/benchmark.go
+++ b/src/semantic-router/pkg/cache/benchmark.go
@@ -142,7 +142,7 @@ func populateCache(cache *InMemoryCache, size int) error {
 			query := queries[idx]
 			responseBody := []byte(fmt.Sprintf("Response for: %s", query))
 
-			err := cache.AddEntry(requestID,
+			err := cache.AddEntry(context.Background(), requestID,
 				"test-model", query, []byte(query), responseBody, -1)
 			if err != nil {
 				errors <- fmt.Errorf("failed to add entry %d: %w", idx, err)
@@ -182,6 +182,8 @@ func cosineSimilarity(a, b []float32) float32 {
 
 // measureSearchLatency performs a search and measures component latencies
 // IMPORTANT: Separates embedding generation time from pure search time
+//
+//nolint:nestif // Pre-existing HNSW/linear search split; #2473 only threads context through it.
 func measureSearchLatency(cache *InMemoryCache, model, query string) latencyMeasurement {
 	measurement := latencyMeasurement{}
 
@@ -189,7 +191,7 @@ func measureSearchLatency(cache *InMemoryCache, model, query string) latencyMeas
 
 	// Measure embedding generation time ONCE
 	startEmbed := time.Now()
-	queryEmbedding, err := cache.generateEmbedding(query)
+	queryEmbedding, err := cache.generateEmbedding(context.Background(), query)
 	measurement.EmbeddingTime = time.Since(startEmbed)
 
 	if err != nil {
@@ -240,6 +242,19 @@ func measureSearchLatency(cache *InMemoryCache, model, query string) latencyMeas
 	return measurement
 }
 
+// resolveUseHNSW lets USE_HNSW override the configured index choice, so one
+// scenario can be re-run both ways without editing the config.
+func resolveUseHNSW(configured bool) bool {
+	switch os.Getenv("USE_HNSW") {
+	case "true", "1":
+		return true
+	case "false", "0":
+		return false
+	default:
+		return configured
+	}
+}
+
 // runBenchmarkScenario executes a single benchmark scenario
 func runBenchmarkScenario(config BenchmarkConfig, concurrency int) BenchmarkResult {
 	result := BenchmarkResult{
@@ -253,17 +268,7 @@ func runBenchmarkScenario(config BenchmarkConfig, concurrency int) BenchmarkResu
 		embeddingModel = "qwen3"
 	}
 
-	// Check if HNSW should be overridden by environment variable
-	useHNSW := config.UseHNSW
-	hnswEnv := os.Getenv("USE_HNSW")
-	if hnswEnv != "" {
-		switch hnswEnv {
-		case "true", "1":
-			useHNSW = true
-		case "false", "0":
-			useHNSW = false
-		}
-	}
+	useHNSW := resolveUseHNSW(config.UseHNSW)
 
 	// Create cache with specified configuration
 	cache := NewInMemoryCache(InMemoryCacheOptions{
@@ -298,19 +303,38 @@ func runBenchmarkScenario(config BenchmarkConfig, concurrency int) BenchmarkResu
 	diversity := 1.0 - config.HitRatio // Lower diversity = higher hit ratio
 	testQueries := generateTestQueries(queryCount, diversity)
 
-	// Storage for measurements
-	measurements := make([]latencyMeasurement, queryCount)
-	var errorCount int64
-
 	// Run benchmark with specified concurrency
 	fmt.Printf("Running %d requests with concurrency %d...\n", queryCount, concurrency)
+
+	measurements, errorCount, duration := runConcurrentQueries(cache, testQueries, concurrency)
+
+	// Calculate statistics
+	result.TotalRequests = queryCount
+	result.Duration = duration
+	result.Throughput = float64(queryCount) / duration.Seconds()
+	result.ErrorCount = errorCount
+
+	summarizeMeasurements(&result, measurements)
+
+	return result
+}
+
+// runConcurrentQueries measures every query against the cache with at most
+// `concurrency` lookups in flight, and reports how long the whole batch took.
+func runConcurrentQueries(
+	cache *InMemoryCache,
+	queries []string,
+	concurrency int,
+) ([]latencyMeasurement, int64, time.Duration) {
+	measurements := make([]latencyMeasurement, len(queries))
+	var errorCount int64
 
 	startTime := time.Now()
 
 	var wg sync.WaitGroup
 	semaphore := make(chan struct{}, concurrency)
 
-	for i := 0; i < queryCount; i++ {
+	for i := range queries {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -319,8 +343,7 @@ func runBenchmarkScenario(config BenchmarkConfig, concurrency int) BenchmarkResu
 			semaphore <- struct{}{}
 			defer func() { <-semaphore }()
 
-			query := testQueries[idx]
-			measurement := measureSearchLatency(cache, "test-model", query)
+			measurement := measureSearchLatency(cache, "test-model", queries[idx])
 			measurements[idx] = measurement
 
 			if measurement.Error != nil {
@@ -330,56 +353,55 @@ func runBenchmarkScenario(config BenchmarkConfig, concurrency int) BenchmarkResu
 	}
 
 	wg.Wait()
-	duration := time.Since(startTime)
 
-	// Calculate statistics
-	result.TotalRequests = queryCount
-	result.Duration = duration
-	result.Throughput = float64(queryCount) / duration.Seconds()
-	result.ErrorCount = errorCount
+	return measurements, errorCount, time.Since(startTime)
+}
 
-	// Extract latency data
-	totalLatencies := make([]float64, 0, queryCount)
-	embeddingLatencies := make([]float64, 0, queryCount)
-	searchLatencies := make([]float64, 0, queryCount)
+// summarizeMeasurements fills the latency percentiles and hit rates of result
+// from the successful measurements. Failed measurements are excluded so a
+// backend error cannot masquerade as a fast lookup.
+func summarizeMeasurements(result *BenchmarkResult, measurements []latencyMeasurement) {
+	totalLatencies := make([]float64, 0, len(measurements))
+	embeddingLatencies := make([]float64, 0, len(measurements))
+	searchLatencies := make([]float64, 0, len(measurements))
 
 	hitCount := 0
 	for _, m := range measurements {
-		if m.Error == nil {
-			totalLatencies = append(totalLatencies, float64(m.TotalTime.Microseconds())/1000.0)
-			embeddingLatencies = append(embeddingLatencies, float64(m.EmbeddingTime.Microseconds())/1000.0)
-			searchLatencies = append(searchLatencies, float64(m.SearchTime.Microseconds())/1000.0)
+		if m.Error != nil {
+			continue
+		}
+		totalLatencies = append(totalLatencies, float64(m.TotalTime.Microseconds())/1000.0)
+		embeddingLatencies = append(embeddingLatencies, float64(m.EmbeddingTime.Microseconds())/1000.0)
+		searchLatencies = append(searchLatencies, float64(m.SearchTime.Microseconds())/1000.0)
 
-			if m.CacheHit {
-				hitCount++
-			}
+		if m.CacheHit {
+			hitCount++
 		}
 	}
 
-	// Calculate percentiles
-	if len(totalLatencies) > 0 {
-		result.OverallP50 = percentile(totalLatencies, 50)
-		result.OverallP90 = percentile(totalLatencies, 90)
-		result.OverallP95 = percentile(totalLatencies, 95)
-		result.OverallP99 = percentile(totalLatencies, 99)
-		result.OverallMax = percentile(totalLatencies, 100)
-		result.OverallMean = mean(totalLatencies)
-
-		result.EmbeddingP50 = percentile(embeddingLatencies, 50)
-		result.EmbeddingP90 = percentile(embeddingLatencies, 90)
-		result.EmbeddingP95 = percentile(embeddingLatencies, 95)
-		result.EmbeddingP99 = percentile(embeddingLatencies, 99)
-
-		result.SearchP50 = percentile(searchLatencies, 50)
-		result.SearchP90 = percentile(searchLatencies, 90)
-		result.SearchP95 = percentile(searchLatencies, 95)
-		result.SearchP99 = percentile(searchLatencies, 99)
-
-		result.CacheHitRate = float64(hitCount) / float64(len(totalLatencies))
-		result.CacheMissRate = 1.0 - result.CacheHitRate
+	if len(totalLatencies) == 0 {
+		return
 	}
 
-	return result
+	result.OverallP50 = percentile(totalLatencies, 50)
+	result.OverallP90 = percentile(totalLatencies, 90)
+	result.OverallP95 = percentile(totalLatencies, 95)
+	result.OverallP99 = percentile(totalLatencies, 99)
+	result.OverallMax = percentile(totalLatencies, 100)
+	result.OverallMean = mean(totalLatencies)
+
+	result.EmbeddingP50 = percentile(embeddingLatencies, 50)
+	result.EmbeddingP90 = percentile(embeddingLatencies, 90)
+	result.EmbeddingP95 = percentile(embeddingLatencies, 95)
+	result.EmbeddingP99 = percentile(embeddingLatencies, 99)
+
+	result.SearchP50 = percentile(searchLatencies, 50)
+	result.SearchP90 = percentile(searchLatencies, 90)
+	result.SearchP95 = percentile(searchLatencies, 95)
+	result.SearchP99 = percentile(searchLatencies, 99)
+
+	result.CacheHitRate = float64(hitCount) / float64(len(totalLatencies))
+	result.CacheMissRate = 1.0 - result.CacheHitRate
 }
 
 // percentile calculates the Nth percentile of a sorted slice

--- a/src/semantic-router/pkg/cache/cache_cancellation_test.go
+++ b/src/semantic-router/pkg/cache/cache_cancellation_test.go
@@ -1,0 +1,156 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Coverage for #2473: the request context threads into the embedding work of a
+// lookup. Each helper below documents the contract it pins.
+var _ = Describe("Cache lookup cancellation and miss contract (#2473)", func() {
+	const threshold = float32(0.75)
+
+	newSeededBackend := func() CacheBackend {
+		backend, err := NewCacheBackend(CacheConfig{
+			BackendType:         InMemoryCacheType,
+			Enabled:             true,
+			SimilarityThreshold: threshold,
+			MaxEntries:          16,
+			EmbeddingModel:      "bert",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// ttlSeconds=-1 means "use cache default TTL"; ttlSeconds=0 would mark
+		// the entry as uncacheable and drop it silently.
+		Expect(backend.AddEntry(context.Background(),
+			"seed-1", "m", "what is the capital of france",
+			[]byte("req"), []byte("cached"), -1,
+		)).To(Succeed())
+		return backend
+	}
+
+	specCancelledContextShortCircuits(newSeededBackend, threshold)
+	specBelowThresholdMissReportsCandidateScore(newSeededBackend, threshold)
+	specCGOEmbedCancellation(newSeededBackend)
+})
+
+// specCancelledContextShortCircuits pins the best-effort half of the contract:
+// an already-cancelled context short-circuits before the embed starts, and the
+// lookup returns the context error instead of a possibly stale hit.
+func specCancelledContextShortCircuits(newSeededBackend func() CacheBackend, threshold float32) {
+	Context("with an already-cancelled context", func() {
+		It("short-circuits before embedding and returns context.Canceled, not a hit", func() {
+			backend := newSeededBackend()
+			defer func() { _ = backend.Close() }()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // cancel before the lookup starts
+
+			res, err := backend.LookupSimilarWithThreshold(
+				ctx, "m", "what is the capital of france", threshold,
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, context.Canceled)).To(BeTrue(),
+				"expected context.Canceled, got %v", err)
+			// A cancelled lookup must never surface a cached hit.
+			Expect(res.Found).To(BeFalse())
+			Expect(res.ResponseBody).To(BeNil())
+		})
+	})
+}
+
+// specBelowThresholdMissReportsCandidateScore pins that a below-threshold lookup
+// is a miss that still reports its own rejected candidate: the score is what
+// makes the miss diagnosable against the threshold on the debug and Replay
+// surfaces, and it is request-owned now that it rides LookupResult.
+func specBelowThresholdMissReportsCandidateScore(newSeededBackend func() CacheBackend, threshold float32) {
+	Context("with a below-threshold query", func() {
+		It("returns no response and the rejected candidate's similarity", func() {
+			backend := newSeededBackend()
+			defer func() { _ = backend.Close() }()
+
+			res, err := backend.LookupSimilarWithThreshold(
+				context.Background(), "m",
+				"totally unrelated question about database indexing",
+				threshold,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Found).To(BeFalse())
+			Expect(res.ResponseBody).To(BeNil())
+			Expect(res.Similarity).To(BeNumerically("<", threshold),
+				"a miss must report a below-threshold score, not the seeded entry's")
+		})
+	})
+}
+
+// specCGOEmbedCancellation covers the other half: the embed cannot be
+// interrupted mid-flight, so cancellation is re-checked after it returns and
+// before the entry is published. cancelAfterEmbedCtx trips exactly on that
+// second check.
+//
+// Asserting the bare context error, not errors.Is, is what pins the call site:
+// a short-circuit inside the embed would surface it wrapped as "failed to
+// generate embedding: ...", so a future ctxErr call added before the embed fails
+// these specs instead of silently moving them to another branch.
+func specCGOEmbedCancellation(newSeededBackend func() CacheBackend) {
+	Context("with a context cancelled during the CGO embedding", func() {
+		It("AddEntry returns the context error and publishes no entry", func() {
+			backend := newSeededBackend()
+			defer func() { _ = backend.Close() }()
+			before := backend.GetStats().TotalEntries
+
+			ctx := &cancelAfterEmbedCtx{Context: context.Background(), errAfter: errAfterPostEmbedGuard}
+			err := backend.AddEntry(ctx, "orphan-1", "m", "a brand new distinct query",
+				[]byte("req"), []byte("resp"), -1)
+
+			Expect(err).To(Equal(context.Canceled),
+				"expected the post-embed guard's bare context error, got %v", err)
+			Expect(backend.GetStats().TotalEntries).To(Equal(before),
+				"cancelled AddEntry must not publish an entry")
+		})
+
+		It("the lookup returns the context error and serves no hit", func() {
+			backend := newSeededBackend()
+			defer func() { _ = backend.Close() }()
+
+			// The seeded query would otherwise match itself at similarity 1.
+			ctx := &cancelAfterEmbedCtx{Context: context.Background(), errAfter: errAfterPostEmbedGuard}
+			res, err := backend.LookupSimilarWithThreshold(ctx, "m", "what is the capital of france", 0.75)
+
+			Expect(err).To(Equal(context.Canceled),
+				"expected the post-embed guard's bare context error, got %v", err)
+			Expect(res.Found).To(BeFalse(),
+				"a lookup cancelled during the embed must not serve a hit")
+			Expect(res.Similarity).To(BeZero())
+		})
+	})
+}
+
+// errAfterPostEmbedGuard is the Err() call index of the guard under test: call
+// #1 is generateEmbedding's pre-embed short-circuit, call #2 is the calling
+// method's post-embed re-check.
+const errAfterPostEmbedGuard = 2
+
+// cancelAfterEmbedCtx reports no error until the errAfter-th Err() call, then
+// context.Canceled. It lets a test deterministically trip the post-embedding
+// cancellation guard (Err() call #2) without racing the CGO embed.
+type cancelAfterEmbedCtx struct {
+	context.Context
+	errAfter int
+	calls    int
+}
+
+func (c *cancelAfterEmbedCtx) Err() error {
+	c.calls++
+	if c.calls >= c.errAfter {
+		return context.Canceled
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/cache/cache_comparison_bench_test.go
+++ b/src/semantic-router/pkg/cache/cache_comparison_bench_test.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -39,10 +40,11 @@ func newInMemoryBench(b *testing.B, size int) LegacyCacheBackend {
 // ns/op reflects only lookups, and the hit rate is reported for context.
 func runCacheFindSimilarBench(b *testing.B, cache LegacyCacheBackend, model string, size int) {
 	b.Helper()
+	ctx := context.Background()
 	for i := 0; i < size; i++ {
 		q := fmt.Sprintf("benchmark query number %d about topic %d", i, i%97)
 		if err := cache.AddEntry(
-			fmt.Sprintf("req-%d", i), model, q,
+			ctx, fmt.Sprintf("req-%d", i), model, q,
 			[]byte(q), []byte(fmt.Sprintf("response-%d", i)), 300,
 		); err != nil {
 			b.Fatalf("populate AddEntry failed at %d: %v", i, err)
@@ -60,11 +62,11 @@ func runCacheFindSimilarBench(b *testing.B, cache LegacyCacheBackend, model stri
 		} else {
 			q = fmt.Sprintf("entirely novel unseen request %d", i)
 		}
-		_, found, err := cache.FindSimilar(model, q)
+		result, err := cache.LookupSimilarWithThreshold(ctx, model, q, 0)
 		if err != nil {
 			b.Fatalf("FindSimilar failed: %v", err)
 		}
-		if found {
+		if result.Found {
 			hits++
 		}
 	}

--- a/src/semantic-router/pkg/cache/cache_context_backend_test.go
+++ b/src/semantic-router/pkg/cache/cache_context_backend_test.go
@@ -1,0 +1,91 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"errors"
+
+	"github.com/milvus-io/milvus-sdk-go/v2/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/qdrant/go-client/qdrant"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// Every remote backend must turn a search failure that happened under a
+// cancelled request into the request's context error, while an ordinary backend
+// outage stays a fail-open miss.
+//
+// The bare-error assertion pins the call site: this error comes from
+// contextErrorOnFailure after the search, whereas an embedding-path
+// short-circuit would surface it wrapped as "failed to generate embedding: ...".
+var _ = DescribeTable("backend search cancellation wiring",
+	func(findSimilar func(context.Context) (LookupResult, error)) {
+		ctx := &cancelAfterEmbedCtx{Context: context.Background(), errAfter: errAfterPostEmbedGuard}
+
+		result, err := findSimilar(ctx)
+
+		Expect(err).To(Equal(context.Canceled),
+			"backend search failure must surface the request cancellation, got %v", err)
+		Expect(result).To(Equal(LookupResult{}))
+
+		result, err = findSimilar(context.Background())
+		Expect(err).NotTo(HaveOccurred(), "ordinary backend errors must remain fail-open misses")
+		Expect(result).To(Equal(LookupResult{}))
+	},
+	Entry("Milvus", func(ctx context.Context) (LookupResult, error) {
+		cfg := &config.MilvusConfig{}
+		cfg.Collection.VectorField.Dimension = 384
+		cache := &MilvusCache{
+			enabled:        true,
+			config:         cfg,
+			embeddingModel: "bert",
+			searchFn: func(context.Context, string, []float32) ([]client.SearchResult, error) {
+				return nil, errors.New("milvus unavailable")
+			},
+		}
+		return cache.LookupSimilarWithThreshold(ctx, "model", "query", 0.8)
+	}),
+	Entry("Qdrant", func(ctx context.Context) (LookupResult, error) {
+		cache := &QdrantCache{
+			enabled:        true,
+			cfg:            &config.QdrantConfig{},
+			embeddingModel: "bert",
+			searchFn: func(context.Context, *qdrant.QueryPoints) ([]*qdrant.ScoredPoint, error) {
+				return nil, errors.New("qdrant unavailable")
+			},
+		}
+		return cache.LookupSimilarWithThreshold(ctx, "model", "query", 0.8)
+	}),
+	Entry("Redis", func(ctx context.Context) (LookupResult, error) {
+		cfg := &config.RedisConfig{}
+		cfg.Index.VectorField.Name = "embedding"
+		cfg.Search.TopK = 1
+		cache := &RedisCache{
+			enabled:        true,
+			config:         cfg,
+			embeddingModel: "bert",
+			searchFn: func(context.Context, string, string, *redis.FTSearchOptions) (redis.FTSearchResult, error) {
+				return redis.FTSearchResult{}, errors.New("redis unavailable")
+			},
+		}
+		return cache.LookupSimilarWithThreshold(ctx, "model", "query", 0.8)
+	}),
+	Entry("Valkey", func(ctx context.Context) (LookupResult, error) {
+		cfg := &config.ValkeyConfig{}
+		cfg.Index.VectorField.Name = "embedding"
+		cfg.Search.TopK = 1
+		cache := &ValkeyCache{
+			enabled:        true,
+			config:         cfg,
+			embeddingModel: "bert",
+			searchFn: func(context.Context, []string) (any, error) {
+				return nil, errors.New("valkey unavailable")
+			},
+		}
+		return cache.LookupSimilarWithThreshold(ctx, "model", "query", 0.8)
+	}),
+)

--- a/src/semantic-router/pkg/cache/cache_context_error_test.go
+++ b/src/semantic-router/pkg/cache/cache_context_error_test.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestContextErrorOnFailure(t *testing.T) {
+	backendErr := errors.New("backend unavailable")
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	expired, expire := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer expire()
+
+	tests := []struct {
+		name         string
+		ctx          context.Context
+		operationErr error
+		want         error
+	}{
+		{name: "canceled operation", ctx: canceled, operationErr: backendErr, want: context.Canceled},
+		{name: "expired operation", ctx: expired, operationErr: backendErr, want: context.DeadlineExceeded},
+		{name: "active operation", ctx: context.Background(), operationErr: backendErr},
+		{name: "no operation error", ctx: canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contextErrorOnFailure(tt.ctx, tt.operationErr); !errors.Is(got, tt.want) {
+				t.Fatalf("contextErrorOnFailure() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/semantic-router/pkg/cache/cache_interface.go
+++ b/src/semantic-router/pkg/cache/cache_interface.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
@@ -21,9 +22,9 @@ type CacheEntry struct {
 	ExpiresAt    time.Time // Calculated expiration time based on TTL
 }
 
-// LookupResult is the request-scoped result of one semantic cache lookup.
-// Similarity belongs to this lookup and must not be read from shared backend
-// state, where concurrent requests can overwrite each other's diagnostics.
+// LookupResult carries the request-owned outcome of one lookup. A hit includes
+// the matched score; a below-threshold miss may include its rejected candidate's
+// score. Errors carry no score.
 type LookupResult struct {
 	ResponseBody []byte
 	Found        bool
@@ -33,8 +34,35 @@ type LookupResult struct {
 // ExactCacheBackend is an optional exact-response fast path implemented by
 // key-value-capable cache backends.
 type ExactCacheBackend interface {
-	FindExact(partition string, fingerprint string) (LookupResult, error)
-	AddExact(partition string, fingerprint string, responseBody []byte, ttlSeconds int) error
+	FindExact(ctx context.Context, partition string, fingerprint string) (LookupResult, error)
+	AddExact(ctx context.Context, partition string, fingerprint string, responseBody []byte, ttlSeconds int) error
+}
+
+// ctxErr treats a nil context as having no error.
+//
+// Embedding cannot be interrupted mid-flight; callers check before embedding
+// and before publishing state.
+func ctxErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}
+
+func contextErrorOnFailure(ctx context.Context, operationErr error) error {
+	if operationErr == nil {
+		return nil
+	}
+	return ctxErr(ctx)
+}
+
+// releaseOnFailure releases a partially constructed client when setup fails.
+func releaseOnFailure(step func() error, release func()) error {
+	if err := step(); err != nil {
+		release()
+		return err
+	}
+	return nil
 }
 
 // CacheBackend defines the interface for semantic cache implementations
@@ -45,15 +73,16 @@ type CacheBackend interface {
 	// CheckConnection verifies the cache backend connection is healthy
 	// Returns nil if the connection is healthy, error otherwise
 	// For local caches (in-memory), this may be a no-op
-	CheckConnection() error
+	CheckConnection(ctx context.Context) error
 
 	// AddEntry stores a complete request-response pair in the cache
-	AddEntry(requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error
+	AddEntry(ctx context.Context, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error
 
 	// LookupSimilarWithThreshold returns response data and similarity from the
 	// same lookup operation. Request paths should use this method instead of
-	// backend-global similarity state.
-	LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error)
+	// backend-global similarity state. A canceled or expired context is
+	// reported as an error rather than as a miss.
+	LookupSimilarWithThreshold(ctx context.Context, model string, query string, threshold float32) (LookupResult, error)
 
 	// Close releases all resources held by the cache backend
 	Close() error
@@ -65,6 +94,10 @@ type CacheBackend interface {
 // LegacyCacheBackend is the temporary backend-implementation seam. New request
 // paths depend on TypedCacheStore; only backend tests and migration adapters
 // should use these two-phase and convenience methods.
+//
+// These methods stay context-free on purpose: they are not on a request path,
+// so there is no caller context to honor. Implementations forward
+// context.Background() to the context-aware core.
 type LegacyCacheBackend interface {
 	CacheBackend
 	AddPendingRequest(requestID string, model string, query string, requestBody []byte, ttlSeconds int) error
@@ -72,6 +105,16 @@ type LegacyCacheBackend interface {
 	FindSimilar(model string, query string) ([]byte, bool, error)
 	FindSimilarWithThreshold(model string, query string, threshold float32) ([]byte, bool, error)
 }
+
+// Compile-time assertions keep production implementations aligned with CacheBackend.
+var (
+	_ CacheBackend = (*InMemoryCache)(nil)
+	_ CacheBackend = (*HybridCache)(nil)
+	_ CacheBackend = (*MilvusCache)(nil)
+	_ CacheBackend = (*QdrantCache)(nil)
+	_ CacheBackend = (*RedisCache)(nil)
+	_ CacheBackend = (*ValkeyCache)(nil)
+)
 
 // CacheStats holds performance metrics and usage statistics for cache operations
 type CacheStats struct {

--- a/src/semantic-router/pkg/cache/cache_isolation_test.go
+++ b/src/semantic-router/pkg/cache/cache_isolation_test.go
@@ -1,0 +1,85 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Regression coverage for #2473: similarity used to be published through a
+// shared tracker on the backend and read after Find returned, so a concurrent
+// lookup could overwrite it in between and leak another request's score into
+// this one's headers, debug surface, and Replay record. Returning it on
+// LookupResult removes the shared read; this spec pins that.
+var _ = Describe("Cache lookup isolation (regression #2473)", func() {
+	Context("concurrent lookups on the same in-memory backend", func() {
+		It("returns per-request similarity via LookupResult with no cross-request leak", func() {
+			const threshold = float32(0.75)
+			backend, err := NewCacheBackend(CacheConfig{
+				BackendType:         InMemoryCacheType,
+				Enabled:             true,
+				SimilarityThreshold: threshold,
+				MaxEntries:          16,
+				EmbeddingModel:      "bert",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = backend.Close() }()
+
+			hitQuery := "what is the capital of france"
+			missQuery := "totally unrelated question about database indexing"
+
+			// ttlSeconds=-1 means "use cache default TTL"; ttlSeconds=0 would
+			// mark the entry as uncacheable and drop it silently.
+			Expect(backend.AddEntry(context.Background(),
+				"seed-1", "m", hitQuery,
+				[]byte("req"), []byte("cached"), -1,
+			)).To(Succeed())
+
+			barrier := make(chan struct{})
+			var wg sync.WaitGroup
+			var hitRes, missRes LookupResult
+			var hitErr, missErr error
+
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				<-barrier
+				hitRes, hitErr = backend.LookupSimilarWithThreshold(
+					context.Background(), "m", hitQuery, threshold,
+				)
+			}()
+			go func() {
+				defer wg.Done()
+				<-barrier
+				missRes, missErr = backend.LookupSimilarWithThreshold(
+					context.Background(), "m", missQuery, threshold,
+				)
+			}()
+			close(barrier)
+			wg.Wait()
+
+			Expect(hitErr).NotTo(HaveOccurred())
+			Expect(missErr).NotTo(HaveOccurred())
+
+			// Hit lookup: matched entry, similarity is this request's own score.
+			Expect(hitRes.Found).To(BeTrue(),
+				"hit lookup expected Found=true (similarity=%.4f)", hitRes.Similarity)
+			Expect(hitRes.Similarity).To(BeNumerically(">=", threshold),
+				"hit lookup similarity below threshold — cross-request leak from miss?")
+
+			// Miss lookup: no response, and a candidate score that is its own
+			// measurement. Asserting it is below threshold and different from
+			// the hit's score is what proves ownership: under the old shared
+			// tracker the miss could read back the concurrent hit's value.
+			Expect(missRes.Found).To(BeFalse())
+			Expect(missRes.ResponseBody).To(BeNil())
+			Expect(missRes.Similarity).To(BeNumerically("<", threshold),
+				"miss lookup similarity at or above threshold — cross-request leak from hit?")
+			Expect(missRes.Similarity).NotTo(Equal(hitRes.Similarity))
+		})
+	})
+})

--- a/src/semantic-router/pkg/cache/cache_test.go
+++ b/src/semantic-router/pkg/cache/cache_test.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"crypto/md5"
 	"fmt"
 	"math"
@@ -854,7 +855,7 @@ development:
 		})
 
 		It("should handle AddEntry operation with embeddings", func() {
-			err := inMemoryCache.AddEntry("test-request-id", "test-model", "test query", []byte("request"), []byte("response"), -1)
+			err := inMemoryCache.AddEntry(context.Background(), "test-request-id", "test-model", "test query", []byte("request"), []byte("response"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			stats := inMemoryCache.GetStats()
@@ -863,7 +864,7 @@ development:
 
 		It("should handle FindSimilar operation with embeddings", func() {
 			// First add an entry
-			err := inMemoryCache.AddEntry("test-request-id", "test-model", "test query", []byte("request"), []byte("response"), -1)
+			err := inMemoryCache.AddEntry(context.Background(), "test-request-id", "test-model", "test query", []byte("request"), []byte("response"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search for similar query
@@ -934,7 +935,7 @@ development:
 			highThresholdCache := NewInMemoryCache(highThresholdOptions)
 			defer highThresholdCache.Close()
 
-			err := highThresholdCache.AddEntry("test-request-id", "test-model", "machine learning", []byte("request"), []byte("ml response"), -1)
+			err := highThresholdCache.AddEntry(context.Background(), "test-request-id", "test-model", "machine learning", []byte("request"), []byte("ml response"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Exact match should work
@@ -952,7 +953,7 @@ development:
 
 		It("should track hit and miss statistics", func() {
 			// Add an entry with a specific query
-			err := inMemoryCache.AddEntry("test-request-id", "test-model", "What is machine learning?", []byte("request"), []byte("ML is a subset of AI"), -1)
+			err := inMemoryCache.AddEntry(context.Background(), "test-request-id", "test-model", "What is machine learning?", []byte("request"), []byte("ML is a subset of AI"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Search for the exact cached query (should be a hit)
@@ -984,7 +985,7 @@ development:
 			})
 			defer ttlCache.Close()
 
-			err := ttlCache.AddEntry("ttl-request-id", "ttl-model", "time-sensitive query", []byte("request"), []byte("response"), -1)
+			err := ttlCache.AddEntry(context.Background(), "ttl-request-id", "ttl-model", "time-sensitive query", []byte("request"), []byte("response"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			time.Sleep(1100 * time.Millisecond)
@@ -1033,7 +1034,7 @@ development:
 			err = disabledCache.UpdateWithResponse("test-request-id", []byte("response"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = disabledCache.AddEntry("test-request-id", "test-model", "test query", []byte("request"), []byte("response"), -1)
+			err = disabledCache.AddEntry(context.Background(), "test-request-id", "test-model", "test query", []byte("request"), []byte("response"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			response, found, err := disabledCache.FindSimilar("model", "query")
@@ -1063,10 +1064,10 @@ development:
 			})
 			defer cacheWithHNSW.Close()
 
-			err := cacheWithHNSW.AddEntry("req-1", "test-model", "first query text", []byte("request-1"), []byte("response-1"), -1)
+			err := cacheWithHNSW.AddEntry(context.Background(), "req-1", "test-model", "first query text", []byte("request-1"), []byte("response-1"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = cacheWithHNSW.AddEntry("req-2", "test-model", "second query text", []byte("request-2"), []byte("response-2"), -1)
+			err = cacheWithHNSW.AddEntry(context.Background(), "req-2", "test-model", "second query text", []byte("request-2"), []byte("response-2"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Sanity check: the second entry should be retrievable before any eviction occurs.
@@ -1076,7 +1077,7 @@ development:
 			Expect(resp).To(Equal([]byte("response-2")))
 
 			// Adding a third entry triggers eviction (max entries = 2).
-			err = cacheWithHNSW.AddEntry("req-3", "test-model", "third query text", []byte("request-3"), []byte("response-3"), -1)
+			err = cacheWithHNSW.AddEntry(context.Background(), "req-3", "test-model", "third query text", []byte("request-3"), []byte("response-3"), -1)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Entry 2 should still be searchable even after eviction reshuffles the slice.
@@ -1349,7 +1350,7 @@ func BenchmarkComprehensive(b *testing.B) {
 				// Populate cache
 				for i, query := range testQueries {
 					reqID := fmt.Sprintf("req%d", i)
-					_ = cache.AddEntry(reqID, "test-model", query, []byte(query), []byte("response"), -1)
+					_ = cache.AddEntry(context.Background(), reqID, "test-model", query, []byte(query), []byte("response"), -1)
 				}
 
 				searchQuery := generateQuery(contentLen, cacheSize/2)
@@ -1389,7 +1390,7 @@ func BenchmarkComprehensive(b *testing.B) {
 					// Populate cache
 					for i, query := range testQueries {
 						reqID := fmt.Sprintf("req%d", i)
-						_ = cache.AddEntry(reqID, "test-model", query, []byte(query), []byte("response"), -1)
+						_ = cache.AddEntry(context.Background(), reqID, "test-model", query, []byte(query), []byte("response"), -1)
 					}
 
 					searchQuery := generateQuery(contentLen, cacheSize/2)
@@ -1452,7 +1453,7 @@ func BenchmarkIndexConstruction(b *testing.B) {
 					// Build index by adding entries
 					for j, query := range testQueries {
 						reqID := fmt.Sprintf("req%d", j)
-						_ = cache.AddEntry(reqID, "test-model", query, []byte(query), []byte("response"), -1)
+						_ = cache.AddEntry(context.Background(), reqID, "test-model", query, []byte(query), []byte("response"), -1)
 					}
 				}
 			})
@@ -1776,7 +1777,7 @@ func TestHybridCacheDisabled(t *testing.T) {
 	}
 
 	// All operations should be no-ops
-	err = cache.AddEntry("req1", "model1", "test query", []byte("request"), []byte("response"), -1)
+	err = cache.AddEntry(context.Background(), "req1", "model1", "test query", []byte("request"), []byte("response"), -1)
 	if err != nil {
 		t.Errorf("AddEntry should not error on disabled cache: %v", err)
 	}
@@ -1854,7 +1855,7 @@ func TestHybridCacheGenerateEmbeddingUsesMilvusEmbeddingModel(t *testing.T) {
 		},
 	}
 
-	_, err := cache.generateEmbedding("test")
+	_, err := cache.generateEmbedding(context.Background(), "test")
 	if err == nil {
 		t.Fatal("expected unsupported embedding model error")
 	}
@@ -1901,7 +1902,7 @@ func TestHybridCacheBasicOperations(t *testing.T) {
 	testQuery := "What is the meaning of life?"
 	testResponse := []byte(`{"response": "42"}`)
 
-	err = cache.AddEntry("req1", "gpt-4", testQuery, []byte("{}"), testResponse, -1)
+	err = cache.AddEntry(context.Background(), "req1", "gpt-4", testQuery, []byte("{}"), testResponse, -1)
 	if err != nil {
 		t.Fatalf("Failed to add entry: %v", err)
 	}
@@ -1992,7 +1993,7 @@ func TestHybridCacheEviction(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		query := fmt.Sprintf("Query number %d", i)
 		response := []byte(fmt.Sprintf(`{"answer": "Response %d"}`, i))
-		err = cache.AddEntry(fmt.Sprintf("req%d", i), "gpt-4", query, []byte("{}"), response, -1)
+		err = cache.AddEntry(context.Background(), fmt.Sprintf("req%d", i), "gpt-4", query, []byte("{}"), response, -1)
 		if err != nil {
 			t.Fatalf("Failed to add entry %d: %v", i, err)
 		}
@@ -2055,7 +2056,7 @@ func TestHybridCacheLocalCacheHit(t *testing.T) {
 	// Add an entry
 	testQuery := "What is machine learning?"
 	testResponse := []byte(`{"answer": "ML is..."}`)
-	err = cache.AddEntry("req1", "gpt-4", testQuery, []byte("{}"), testResponse, -1)
+	err = cache.AddEntry(context.Background(), "req1", "gpt-4", testQuery, []byte("{}"), testResponse, -1)
 	if err != nil {
 		t.Fatalf("Failed to add entry: %v", err)
 	}
@@ -2225,7 +2226,7 @@ milvus:
 	for i := 0; i < b.N; i++ {
 		query := fmt.Sprintf("Benchmark query number %d", i)
 		response := []byte(fmt.Sprintf(`{"answer": "Response %d"}`, i))
-		err := cache.AddEntry(fmt.Sprintf("req%d", i), "gpt-4", query, []byte("{}"), response, -1)
+		err := cache.AddEntry(context.Background(), fmt.Sprintf("req%d", i), "gpt-4", query, []byte("{}"), response, -1)
 		if err != nil {
 			b.Fatalf("AddEntry failed: %v", err)
 		}
@@ -2269,7 +2270,7 @@ milvus:
 	for i := 0; i < 100; i++ {
 		query := fmt.Sprintf("Benchmark query number %d", i)
 		response := []byte(fmt.Sprintf(`{"answer": "Response %d"}`, i))
-		err := cache.AddEntry(fmt.Sprintf("req%d", i), "gpt-4", query, []byte("{}"), response, -1)
+		err := cache.AddEntry(context.Background(), fmt.Sprintf("req%d", i), "gpt-4", query, []byte("{}"), response, -1)
 		if err != nil {
 			b.Fatalf("AddEntry failed: %v", err)
 		}
@@ -2893,7 +2894,7 @@ func BenchmarkComponentLatency(b *testing.B) {
 
 		b.Logf("Building HNSW index with %d entries...", cacheSize)
 		for i := 0; i < cacheSize; i++ {
-			_ = cache.AddEntry(fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
+			_ = cache.AddEntry(context.Background(), fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
 		}
 		b.Logf("HNSW index built")
 
@@ -2927,7 +2928,7 @@ func BenchmarkComponentLatency(b *testing.B) {
 
 		b.Logf("Populating Milvus with %d entries...", cacheSize)
 		for i := 0; i < cacheSize; i++ {
-			_ = milvusCache.AddEntry(fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
+			_ = milvusCache.AddEntry(context.Background(), fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
 		}
 		time.Sleep(2 * time.Second)
 		b.Logf("Milvus populated")
@@ -2985,7 +2986,7 @@ func BenchmarkThroughputUnderLoad(b *testing.B) {
 
 			// Populate
 			for i := 0; i < cacheSize; i++ {
-				_ = milvusCache.AddEntry(fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
+				_ = milvusCache.AddEntry(context.Background(), fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
 			}
 			time.Sleep(2 * time.Second)
 
@@ -3027,7 +3028,7 @@ func BenchmarkThroughputUnderLoad(b *testing.B) {
 
 			// Populate
 			for i := 0; i < cacheSize; i++ {
-				_ = hybridCache.AddEntry(fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
+				_ = hybridCache.AddEntry(context.Background(), fmt.Sprintf("req-%d", i), "model", testQueries[i], []byte("req"), []byte("resp"), -1)
 			}
 			time.Sleep(2 * time.Second)
 
@@ -3138,7 +3139,7 @@ func TestHybridVsMilvusSmoke(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Add entry
-		err = cache.AddEntry("req-1", "model", "What is machine learning?", []byte("req"), []byte("ML is..."), -1)
+		err = cache.AddEntry(context.Background(), "req-1", "model", "What is machine learning?", []byte("req"), []byte("ML is..."), -1)
 		if err != nil {
 			t.Fatalf("Failed to add entry: %v", err)
 		}
@@ -3179,7 +3180,7 @@ func TestHybridVsMilvusSmoke(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Add entry
-		err = cache.AddEntry("req-1", "model", "What is deep learning?", []byte("req"), []byte("DL is..."), -1)
+		err = cache.AddEntry(context.Background(), "req-1", "model", "What is deep learning?", []byte("req"), []byte("DL is..."), -1)
 		if err != nil {
 			t.Fatalf("Failed to add entry: %v", err)
 		}
@@ -3218,14 +3219,14 @@ func TestInMemoryCacheIntegration(t *testing.T) {
 
 	t.Run("InMemoryCacheIntegration", func(t *testing.T) {
 		// Step 1: Add first entry
-		err := cache.AddEntry("req1", "test-model", "Hello world",
+		err := cache.AddEntry(context.Background(), "req1", "test-model", "Hello world",
 			[]byte("request1"), []byte("response1"), -1)
 		if err != nil {
 			t.Fatalf("Failed to add first entry: %v", err)
 		}
 
 		// Step 2: Add second entry (cache at capacity)
-		err = cache.AddEntry("req2", "test-model", "Good morning",
+		err = cache.AddEntry(context.Background(), "req2", "test-model", "Good morning",
 			[]byte("request2"), []byte("response2"), -1)
 		if err != nil {
 			t.Fatalf("Failed to add second entry: %v", err)
@@ -3266,7 +3267,7 @@ func TestInMemoryCacheIntegration(t *testing.T) {
 		}
 
 		// Step 5: Add third entry - should trigger LFU eviction
-		err = cache.AddEntry("req3", "test-model", "Bye",
+		err = cache.AddEntry(context.Background(), "req3", "test-model", "Bye",
 			[]byte("request3"), []byte("response3"), -1)
 		if err != nil {
 			t.Fatalf("Failed to add third entry: %v", err)
@@ -3409,12 +3410,12 @@ func TestInMemoryCacheHNSW(t *testing.T) {
 		// Add entries to both caches
 		for i, q := range testQueries {
 			reqID := fmt.Sprintf("req%d", i)
-			err := cacheHNSW.AddEntry(reqID, q.model, q.query, []byte(q.query), []byte(q.response), -1)
+			err := cacheHNSW.AddEntry(context.Background(), reqID, q.model, q.query, []byte(q.query), []byte(q.response), -1)
 			if err != nil {
 				t.Fatalf("Failed to add entry to HNSW cache: %v", err)
 			}
 
-			err = cacheLinear.AddEntry(reqID, q.model, q.query, []byte(q.query), []byte(q.response), -1)
+			err = cacheLinear.AddEntry(context.Background(), reqID, q.model, q.query, []byte(q.query), []byte(q.response), -1)
 			if err != nil {
 				t.Fatalf("Failed to add entry to linear cache: %v", err)
 			}
@@ -3472,7 +3473,7 @@ func TestInMemoryCacheHNSW(t *testing.T) {
 		})
 
 		// Add an entry
-		err := cacheTTL.AddEntry("req1", "test-model", "test query", []byte("request"), []byte("response"), -1)
+		err := cacheTTL.AddEntry(context.Background(), "req1", "test-model", "test query", []byte("request"), []byte("response"), -1)
 		if err != nil {
 			t.Fatalf("Failed to add entry: %v", err)
 		}
@@ -3528,7 +3529,7 @@ func BenchmarkInMemoryCacheSearch(b *testing.B) {
 			// Populate cache
 			for i, entry := range entries {
 				reqID := fmt.Sprintf("req%d", i)
-				_ = cache.AddEntry(reqID, "test-model", entry.query, []byte(entry.query), []byte(entry.response), -1)
+				_ = cache.AddEntry(context.Background(), reqID, "test-model", entry.query, []byte(entry.query), []byte(entry.response), -1)
 			}
 
 			// Benchmark search
@@ -3554,7 +3555,7 @@ func BenchmarkInMemoryCacheSearch(b *testing.B) {
 			// Populate cache
 			for i, entry := range entries {
 				reqID := fmt.Sprintf("req%d", i)
-				_ = cache.AddEntry(reqID, "test-model", entry.query, []byte(entry.query), []byte(entry.response), -1)
+				_ = cache.AddEntry(context.Background(), reqID, "test-model", entry.query, []byte(entry.query), []byte(entry.response), -1)
 			}
 
 			// Benchmark search
@@ -3600,7 +3601,7 @@ func BenchmarkHNSWIndexConstruction(b *testing.B) {
 				// Add entries and build index
 				for j := 0; j < count; j++ {
 					reqID := fmt.Sprintf("req%d", j)
-					_ = cache.AddEntry(reqID, "test-model", testQueries[j], []byte(testQueries[j]), []byte("response"), -1)
+					_ = cache.AddEntry(context.Background(), reqID, "test-model", testQueries[j], []byte(testQueries[j]), []byte("response"), -1)
 				}
 			}
 		})
@@ -3650,7 +3651,7 @@ func BenchmarkHNSWParameters(b *testing.B) {
 			// Populate cache
 			for i, entry := range entries {
 				reqID := fmt.Sprintf("req%d", i)
-				_ = cache.AddEntry(reqID, "test-model", entry.query, []byte(entry.query), []byte(entry.response), -1)
+				_ = cache.AddEntry(context.Background(), reqID, "test-model", entry.query, []byte(entry.query), []byte(entry.response), -1)
 			}
 
 			// Benchmark search
@@ -3684,7 +3685,7 @@ func BenchmarkCacheOperations(b *testing.B) {
 			reqID := fmt.Sprintf("req%d", i)
 
 			// Add entry
-			_ = cache.AddEntry(reqID, "test-model", query, []byte(query), []byte("response"), -1)
+			_ = cache.AddEntry(context.Background(), reqID, "test-model", query, []byte(query), []byte("response"), -1)
 
 			// Find similar
 			_, _, _ = cache.FindSimilar("test-model", query)
@@ -3708,7 +3709,7 @@ func BenchmarkCacheOperations(b *testing.B) {
 			reqID := fmt.Sprintf("req%d", i)
 
 			// Add entry
-			_ = cache.AddEntry(reqID, "test-model", query, []byte(query), []byte("response"), -1)
+			_ = cache.AddEntry(context.Background(), reqID, "test-model", query, []byte(query), []byte("response"), -1)
 
 			// Find similar
 			_, _, _ = cache.FindSimilar("test-model", query)
@@ -3741,7 +3742,7 @@ func BenchmarkHNSWRebuild(b *testing.B) {
 			for i := 0; i < size; i++ {
 				query := fmt.Sprintf("Query %d about machine learning", i)
 				reqID := fmt.Sprintf("req%d", i)
-				_ = cache.AddEntry(reqID, "test-model", query, []byte(query), []byte("response"), -1)
+				_ = cache.AddEntry(context.Background(), reqID, "test-model", query, []byte(query), []byte("response"), -1)
 			}
 
 			b.ResetTimer()
@@ -4136,7 +4137,7 @@ func BenchmarkLargeScale(b *testing.B) {
 				}
 
 				for i := 0; i < cacheSize; i++ {
-					err := cache.AddEntry(
+					err := cache.AddEntry(context.Background(),
 						fmt.Sprintf("req-%d", i),
 						"test-model",
 						testQueries[i],
@@ -4206,7 +4207,7 @@ func BenchmarkLargeScale(b *testing.B) {
 					}
 
 					for i := 0; i < cacheSize; i++ {
-						err := cache.AddEntry(
+						err := cache.AddEntry(context.Background(),
 							fmt.Sprintf("req-%d", i),
 							"test-model",
 							testQueries[i],
@@ -4328,7 +4329,7 @@ func BenchmarkScalability(b *testing.B) {
 					})
 
 					for i := 0; i < cacheSize; i++ {
-						if err := cache.AddEntry(fmt.Sprintf("req-%d", i), "model",
+						if err := cache.AddEntry(context.Background(), fmt.Sprintf("req-%d", i), "model",
 							testQueries[i], []byte("req"), []byte("resp"), -1); err != nil {
 							b.Fatalf("AddEntry failed: %v", err)
 						}
@@ -4372,7 +4373,7 @@ func BenchmarkScalability(b *testing.B) {
 
 				buildStart := time.Now()
 				for i := 0; i < cacheSize; i++ {
-					if err := cache.AddEntry(fmt.Sprintf("req-%d", i), "model",
+					if err := cache.AddEntry(context.Background(), fmt.Sprintf("req-%d", i), "model",
 						testQueries[i], []byte("req"), []byte("resp"), -1); err != nil {
 						b.Fatalf("AddEntry failed: %v", err)
 					}
@@ -4492,7 +4493,7 @@ func BenchmarkHNSWParameterSweep(b *testing.B) {
 			b.Logf("Building HNSW index: M=%d, efConstruction=200, efSearch=%d", config.m, config.efSearch)
 			buildStart := time.Now()
 			for i := 0; i < cacheSize; i++ {
-				if err := cache.AddEntry(fmt.Sprintf("req-%d", i), "model",
+				if err := cache.AddEntry(context.Background(), fmt.Sprintf("req-%d", i), "model",
 					testQueries[i], []byte("req"), []byte("resp"), -1); err != nil {
 					b.Fatalf("AddEntry failed: %v", err)
 				}

--- a/src/semantic-router/pkg/cache/constructor_cleanup_test.go
+++ b/src/semantic-router/pkg/cache/constructor_cleanup_test.go
@@ -1,0 +1,101 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// refusedRedisConfig returns a Redis config pointed at a closed local port so
+// the connection is refused quickly (deterministic, no external server).
+func refusedRedisConfig() *config.RedisConfig {
+	cfg := &config.RedisConfig{}
+	cfg.Connection.Host = "127.0.0.1"
+	cfg.Connection.Port = 1 // reserved; connection refused
+	cfg.Connection.Timeout = 1
+	cfg.Index.Name = "test_index"
+	cfg.Index.Prefix = "doc:"
+	cfg.Index.VectorField.Name = "embedding"
+	cfg.Index.VectorField.MetricType = "COSINE"
+	cfg.Index.IndexType = "HNSW"
+	cfg.Index.Params.M = 16
+	cfg.Index.Params.EfConstruction = 64
+	cfg.Search.TopK = 1
+	return cfg
+}
+
+// refusedValkeyConfig mirrors refusedRedisConfig for the Valkey backend.
+func refusedValkeyConfig() *config.ValkeyConfig {
+	cfg := &config.ValkeyConfig{}
+	cfg.Connection.Host = "127.0.0.1"
+	cfg.Connection.Port = 1
+	cfg.Connection.Timeout = 1
+	cfg.Index.Name = "test_index"
+	cfg.Index.Prefix = "doc:"
+	cfg.Index.VectorField.Name = "embedding"
+	cfg.Index.VectorField.MetricType = "COSINE"
+	cfg.Index.IndexType = "HNSW"
+	cfg.Index.Params.M = 16
+	cfg.Index.Params.EfConstruction = 64
+	cfg.Search.TopK = 1
+	cfg.Development.AutoCreateIndex = true
+	return cfg
+}
+
+// Constructor cleanup is observable only through the release seam: both paths
+// otherwise return (nil, err).
+
+func TestReleaseOnFailureReleasesOnlyWhenTheStepFails(t *testing.T) {
+	stepErr := errors.New("setup failed")
+
+	released := 0
+	err := releaseOnFailure(func() error { return stepErr }, func() { released++ })
+	require.ErrorIs(t, err, stepErr, "the step's error must reach the caller unchanged")
+	assert.Equal(t, 1, released, "a failed step must release the client exactly once")
+
+	released = 0
+	err = releaseOnFailure(func() error { return nil }, func() { released++ })
+	require.NoError(t, err)
+	assert.Zero(t, released, "a successful step must keep the client open")
+}
+
+func TestNewRedisCacheClosesClientOnConnectFailure(t *testing.T) {
+	closed := 0
+	c, err := NewRedisCache(RedisCacheOptions{
+		Enabled: true,
+		Config:  refusedRedisConfig(),
+		closeClient: func(client *redis.Client) {
+			closed++
+			_ = client.Close()
+		},
+	})
+	require.Error(t, err, "unreachable Redis must fail the constructor")
+	assert.Nil(t, c, "constructor must not return a client alongside its error")
+	assert.Equal(t, 1, closed, "failed connection check must release the partially built client exactly once")
+}
+
+// Valkey's eager client builder fails before a refused dial produces a client.
+func TestNewValkeyCacheFailsBeforeBuildingAClientOnRefusedDial(t *testing.T) {
+	closed := 0
+	c, err := NewValkeyCache(ValkeyCacheOptions{
+		Enabled: true,
+		Config:  refusedValkeyConfig(),
+		closeClient: func(client *glide.Client) {
+			closed++
+			client.Close()
+		},
+	})
+	require.Error(t, err, "unreachable Valkey must fail the constructor")
+	assert.Nil(t, c, "constructor must not return a client alongside its error")
+	assert.Contains(t, err.Error(), "failed to create Valkey client",
+		"a refused dial must fail in the client builder, before any client exists")
+	assert.Zero(t, closed, "nothing was built, so nothing may be released")
+}

--- a/src/semantic-router/pkg/cache/exact_cache_hybrid.go
+++ b/src/semantic-router/pkg/cache/exact_cache_hybrid.go
@@ -2,21 +2,25 @@
 
 package cache
 
+import "context"
+
 var _ ExactCacheBackend = (*HybridCache)(nil)
 
 // FindExact delegates persistent exact lookup to the hybrid Milvus backend.
 func (h *HybridCache) FindExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 ) (LookupResult, error) {
 	if !h.enabled || h.milvusCache == nil {
 		return LookupResult{}, nil
 	}
-	return h.milvusCache.FindExact(partition, fingerprint)
+	return h.milvusCache.FindExact(ctx, partition, fingerprint)
 }
 
 // AddExact delegates persistent exact writes to the hybrid Milvus backend.
 func (h *HybridCache) AddExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 	responseBody []byte,
@@ -26,6 +30,7 @@ func (h *HybridCache) AddExact(
 		return nil
 	}
 	return h.milvusCache.AddExact(
+		ctx,
 		partition,
 		fingerprint,
 		responseBody,

--- a/src/semantic-router/pkg/cache/exact_cache_inmemory.go
+++ b/src/semantic-router/pkg/cache/exact_cache_inmemory.go
@@ -2,7 +2,10 @@
 
 package cache
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type exactMemoryEntry struct {
 	responseBody []byte
@@ -10,9 +13,12 @@ type exactMemoryEntry struct {
 }
 
 // FindExact returns a response without running embedding inference.
-func (c *InMemoryCache) FindExact(partition string, fingerprint string) (LookupResult, error) {
+func (c *InMemoryCache) FindExact(ctx context.Context, partition string, fingerprint string) (LookupResult, error) {
 	if !c.enabled || fingerprint == "" {
 		return LookupResult{}, nil
+	}
+	if err := ctxErr(ctx); err != nil {
+		return LookupResult{}, err
 	}
 	key := exactCacheStorageKey(partition, fingerprint)
 	c.mu.RLock()
@@ -35,7 +41,9 @@ func (c *InMemoryCache) FindExact(partition string, fingerprint string) (LookupR
 }
 
 // AddExact stores a complete exact response under the normalized request hash.
+// It rechecks cancellation under the lock so cancelled writes publish nothing.
 func (c *InMemoryCache) AddExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 	responseBody []byte,
@@ -44,12 +52,19 @@ func (c *InMemoryCache) AddExact(
 	if !c.enabled || fingerprint == "" || ttlSeconds == 0 {
 		return nil
 	}
+	if err := ctxErr(ctx); err != nil {
+		return err
+	}
 	effectiveTTL := effectiveExactTTL(ttlSeconds, c.ttlSeconds)
 	entry := exactMemoryEntry{responseBody: append([]byte(nil), responseBody...)}
 	if effectiveTTL > 0 {
 		entry.expiresAt = time.Now().Add(time.Duration(effectiveTTL) * time.Second)
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := ctxErr(ctx); err != nil {
+		return err
+	}
 	if c.maxEntries > 0 && len(c.exactEntries) >= c.maxEntries {
 		for key := range c.exactEntries {
 			delete(c.exactEntries, key)
@@ -57,6 +72,5 @@ func (c *InMemoryCache) AddExact(
 		}
 	}
 	c.exactEntries[exactCacheStorageKey(partition, fingerprint)] = entry
-	c.mu.Unlock()
 	return nil
 }

--- a/src/semantic-router/pkg/cache/exact_cache_inmemory_test.go
+++ b/src/semantic-router/pkg/cache/exact_cache_inmemory_test.go
@@ -2,7 +2,11 @@
 
 package cache
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
 func TestInMemoryExactCacheIsPartitionedAndHonorsTTL(t *testing.T) {
 	cache := NewInMemoryCache(InMemoryCacheOptions{
@@ -12,21 +16,57 @@ func TestInMemoryExactCacheIsPartitionedAndHonorsTTL(t *testing.T) {
 	})
 	defer func() { _ = cache.Close() }()
 
-	if err := cache.AddExact("tenant-a", "request", []byte(`{"answer":"a"}`), -1); err != nil {
+	if err := cache.AddExact(context.Background(), "tenant-a", "request", []byte(`{"answer":"a"}`), -1); err != nil {
 		t.Fatalf("AddExact: %v", err)
 	}
-	hit, err := cache.FindExact("tenant-a", "request")
+	hit, err := cache.FindExact(context.Background(), "tenant-a", "request")
 	if err != nil {
 		t.Fatalf("FindExact: %v", err)
 	}
 	if !hit.Found || string(hit.ResponseBody) != `{"answer":"a"}` || hit.Similarity != 1 {
 		t.Fatalf("unexpected exact hit: %#v", hit)
 	}
-	miss, err := cache.FindExact("tenant-b", "request")
+	miss, err := cache.FindExact(context.Background(), "tenant-b", "request")
 	if err != nil {
 		t.Fatalf("FindExact other partition: %v", err)
 	}
 	if miss.Found {
 		t.Fatalf("cross-partition exact hit: %#v", miss)
+	}
+}
+
+// The in-memory backend checks cancellation explicitly because it has no driver.
+func TestInMemoryExactCacheHonorsCancellation(t *testing.T) {
+	cache := NewInMemoryCache(InMemoryCacheOptions{
+		Enabled:    true,
+		TTLSeconds: 60,
+		MaxEntries: 10,
+	})
+	defer func() { _ = cache.Close() }()
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := cache.AddExact(cancelled, "tenant-a", "request", []byte(`{"answer":"a"}`), -1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled AddExact: want context.Canceled, got %v", err)
+	}
+	// The write must not have been published: a later, live reader sees nothing.
+	orphan, err := cache.FindExact(context.Background(), "tenant-a", "request")
+	if err != nil {
+		t.Fatalf("FindExact after cancelled write: %v", err)
+	}
+	if orphan.Found {
+		t.Fatalf("cancelled AddExact published an entry: %#v", orphan)
+	}
+
+	if err = cache.AddExact(context.Background(), "tenant-a", "request", []byte(`{"answer":"a"}`), -1); err != nil {
+		t.Fatalf("AddExact: %v", err)
+	}
+	res, err := cache.FindExact(cancelled, "tenant-a", "request")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled FindExact: want context.Canceled, got %v", err)
+	}
+	if res.Found {
+		t.Fatalf("cancelled FindExact served a hit: %#v", res)
 	}
 }

--- a/src/semantic-router/pkg/cache/exact_cache_milvus.go
+++ b/src/semantic-router/pkg/cache/exact_cache_milvus.go
@@ -12,11 +12,15 @@ var _ ExactCacheBackend = (*MilvusCache)(nil)
 
 // FindExact returns a deterministic Milvus exact-response entry.
 func (c *MilvusCache) FindExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 ) (LookupResult, error) {
 	if !c.enabled || fingerprint == "" {
 		return LookupResult{}, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	recordID := exactCacheRecordID(partition, fingerprint)
 	expr := fmt.Sprintf(
@@ -27,7 +31,7 @@ func (c *MilvusCache) FindExact(
 		time.Now().Unix(),
 	)
 	results, err := c.client.Query(
-		context.Background(),
+		ctx,
 		c.collectionName,
 		nil,
 		expr,
@@ -63,6 +67,7 @@ func (c *MilvusCache) FindExact(
 
 // AddExact writes a deterministic Milvus exact-response entry.
 func (c *MilvusCache) AddExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 	responseBody []byte,
@@ -70,6 +75,9 @@ func (c *MilvusCache) AddExact(
 ) error {
 	if !c.enabled || fingerprint == "" || ttlSeconds == 0 {
 		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	recordID := exactCacheRecordID(partition, fingerprint)
 	effectiveTTL := effectiveExactTTL(ttlSeconds, c.ttlSeconds)
@@ -83,7 +91,7 @@ func (c *MilvusCache) AddExact(
 		c.embeddingModel,
 	)
 	_, err := c.client.Upsert(
-		context.Background(),
+		ctx,
 		c.collectionName,
 		"",
 		entity.NewColumnVarChar("id", []string{recordID}),
@@ -104,7 +112,7 @@ func (c *MilvusCache) AddExact(
 	if err != nil {
 		return fmt.Errorf("milvus exact write failed: %w", err)
 	}
-	if err := c.client.Flush(context.Background(), c.collectionName, false); err != nil {
+	if err := c.client.Flush(ctx, c.collectionName, false); err != nil {
 		return fmt.Errorf("milvus exact flush failed: %w", err)
 	}
 	return nil

--- a/src/semantic-router/pkg/cache/exact_cache_qdrant.go
+++ b/src/semantic-router/pkg/cache/exact_cache_qdrant.go
@@ -12,6 +12,7 @@ var _ ExactCacheBackend = (*QdrantCache)(nil)
 
 // FindExact returns a deterministic Qdrant exact-response entry.
 func (c *QdrantCache) FindExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 ) (LookupResult, error) {
@@ -19,7 +20,7 @@ func (c *QdrantCache) FindExact(
 		return LookupResult{}, nil
 	}
 	recordID := exactCacheRecordID(partition, fingerprint)
-	points, err := c.client.Get(context.Background(), &qdrant.GetPoints{
+	points, err := c.client.Get(ctx, &qdrant.GetPoints{
 		CollectionName: c.collectionName,
 		Ids: []*qdrant.PointId{
 			arbitraryIDToUUID(recordID),
@@ -54,6 +55,7 @@ func (c *QdrantCache) FindExact(
 
 // AddExact writes a deterministic Qdrant exact-response entry.
 func (c *QdrantCache) AddExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 	responseBody []byte,
@@ -64,7 +66,7 @@ func (c *QdrantCache) AddExact(
 	}
 	recordID := exactCacheRecordID(partition, fingerprint)
 	wait := true
-	_, err := c.client.Upsert(context.Background(), &qdrant.UpsertPoints{
+	_, err := c.client.Upsert(ctx, &qdrant.UpsertPoints{
 		CollectionName: c.collectionName,
 		Wait:           &wait,
 		Points: []*qdrant.PointStruct{{

--- a/src/semantic-router/pkg/cache/exact_cache_redis.go
+++ b/src/semantic-router/pkg/cache/exact_cache_redis.go
@@ -10,12 +10,15 @@ import (
 )
 
 // FindExact returns a Redis exact-response entry without embedding inference.
-func (c *RedisCache) FindExact(partition string, fingerprint string) (LookupResult, error) {
+func (c *RedisCache) FindExact(ctx context.Context, partition string, fingerprint string) (LookupResult, error) {
 	if !c.enabled || fingerprint == "" {
 		return LookupResult{}, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	responseBody, err := c.client.Get(
-		context.Background(),
+		ctx,
 		exactCacheStorageKey(partition, fingerprint),
 	).Bytes()
 	if errors.Is(err, redis.Nil) {
@@ -33,6 +36,7 @@ func (c *RedisCache) FindExact(partition string, fingerprint string) (LookupResu
 
 // AddExact writes a Redis exact-response entry with the effective cache TTL.
 func (c *RedisCache) AddExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 	responseBody []byte,
@@ -41,13 +45,16 @@ func (c *RedisCache) AddExact(
 	if !c.enabled || fingerprint == "" || ttlSeconds == 0 {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	effectiveTTL := effectiveExactTTL(ttlSeconds, c.ttlSeconds)
 	expiration := time.Duration(0)
 	if effectiveTTL > 0 {
 		expiration = time.Duration(effectiveTTL) * time.Second
 	}
 	return c.client.Set(
-		context.Background(),
+		ctx,
 		exactCacheStorageKey(partition, fingerprint),
 		responseBody,
 		expiration,

--- a/src/semantic-router/pkg/cache/exact_cache_valkey.go
+++ b/src/semantic-router/pkg/cache/exact_cache_valkey.go
@@ -6,12 +6,15 @@ import (
 )
 
 // FindExact returns a Valkey exact-response entry without embedding inference.
-func (c *ValkeyCache) FindExact(partition string, fingerprint string) (LookupResult, error) {
+func (c *ValkeyCache) FindExact(ctx context.Context, partition string, fingerprint string) (LookupResult, error) {
 	if !c.enabled || fingerprint == "" {
 		return LookupResult{}, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	raw, err := c.client.CustomCommand(
-		context.Background(),
+		ctx,
 		[]string{"GET", exactCacheStorageKey(partition, fingerprint)},
 	)
 	if err != nil {
@@ -41,6 +44,7 @@ func (c *ValkeyCache) FindExact(partition string, fingerprint string) (LookupRes
 
 // AddExact writes a Valkey exact-response entry with the effective cache TTL.
 func (c *ValkeyCache) AddExact(
+	ctx context.Context,
 	partition string,
 	fingerprint string,
 	responseBody []byte,
@@ -48,6 +52,9 @@ func (c *ValkeyCache) AddExact(
 ) error {
 	if !c.enabled || fingerprint == "" || ttlSeconds == 0 {
 		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	effectiveTTL := effectiveExactTTL(ttlSeconds, c.ttlSeconds)
 	command := []string{
@@ -58,6 +65,6 @@ func (c *ValkeyCache) AddExact(
 	if effectiveTTL > 0 {
 		command = append(command, "EX", fmt.Sprintf("%d", effectiveTTL))
 	}
-	_, err := c.client.CustomCommand(context.Background(), command)
+	_, err := c.client.CustomCommand(ctx, command)
 	return err
 }

--- a/src/semantic-router/pkg/cache/hybrid_cache.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache.go
@@ -232,12 +232,12 @@ func milvusCacheOptionsFromHybridOptions(options HybridCacheOptions) MilvusCache
 	return milvusOptions
 }
 
-func (h *HybridCache) generateEmbedding(text string) ([]float32, error) {
+func (h *HybridCache) generateEmbedding(ctx context.Context, text string) ([]float32, error) {
 	if h.milvusCache == nil {
 		return nil, fmt.Errorf("milvus cache is not initialized")
 	}
 
-	return h.milvusCache.getEmbedding(text)
+	return h.milvusCache.getEmbedding(ctx, text)
 }
 
 // IsEnabled returns whether the cache is active
@@ -247,7 +247,7 @@ func (h *HybridCache) IsEnabled() bool {
 
 // CheckConnection verifies the cache backend connection is healthy
 // For hybrid cache, this checks the Milvus connection
-func (h *HybridCache) CheckConnection() error {
+func (h *HybridCache) CheckConnection(ctx context.Context) error {
 	if !h.enabled {
 		return nil
 	}
@@ -257,7 +257,7 @@ func (h *HybridCache) CheckConnection() error {
 	}
 
 	// Delegate to Milvus cache connection check
-	return h.milvusCache.CheckConnection()
+	return h.milvusCache.CheckConnection(ctx)
 }
 
 // RebuildFromMilvus rebuilds the in-memory HNSW index from persistent Milvus storage
@@ -363,6 +363,7 @@ func (h *HybridCache) RebuildFromMilvus(ctx context.Context) error {
 
 // AddPendingRequest stores a request awaiting its response
 func (h *HybridCache) AddPendingRequest(requestID string, model string, query string, requestBody []byte, ttlSeconds int) error {
+	ctx := context.Background()
 	start := time.Now()
 
 	if !h.enabled {
@@ -376,7 +377,7 @@ func (h *HybridCache) AddPendingRequest(requestID string, model string, query st
 	}
 
 	// Generate embedding
-	embedding, err := h.generateEmbedding(query)
+	embedding, err := h.generateEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("hybrid", "add_pending", "error", time.Since(start).Seconds())
 		return fmt.Errorf("failed to generate embedding: %w", err)
@@ -435,7 +436,7 @@ func (h *HybridCache) UpdateWithResponse(requestID string, responseBody []byte, 
 }
 
 // AddEntry stores a complete request-response pair
-func (h *HybridCache) AddEntry(requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (h *HybridCache) AddEntry(ctx context.Context, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
 	start := time.Now()
 
 	if !h.enabled {
@@ -449,14 +450,14 @@ func (h *HybridCache) AddEntry(requestID string, model string, query string, req
 	}
 
 	// Generate embedding
-	embedding, err := h.generateEmbedding(query)
+	embedding, err := h.generateEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("hybrid", "add_entry", "error", time.Since(start).Seconds())
 		return fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
 	// Store in Milvus (write-through)
-	if err := h.milvusCache.AddEntry(requestID, model, query, requestBody, responseBody, ttlSeconds); err != nil {
+	if err := h.milvusCache.AddEntry(ctx, requestID, model, query, requestBody, responseBody, ttlSeconds); err != nil {
 		metrics.RecordCacheOperation("hybrid", "add_entry", "error", time.Since(start).Seconds())
 		return fmt.Errorf("milvus add entry failed: %w", err)
 	}
@@ -506,9 +507,10 @@ func (h *HybridCache) AddEntriesBatch(entries []CacheEntry) error {
 	logging.Debugf("HybridCache.AddEntriesBatch: adding %d entries in batch", len(entries))
 
 	// Generate all embeddings first
+	ctx := context.Background()
 	embeddings := make([][]float32, len(entries))
 	for i, entry := range entries {
-		embedding, err := h.generateEmbedding(entry.Query)
+		embedding, err := h.generateEmbedding(ctx, entry.Query)
 		if err != nil {
 			metrics.RecordCacheOperation("hybrid", "add_entries_batch", "error", time.Since(start).Seconds())
 			return fmt.Errorf("failed to generate embedding for entry %d: %w", i, err)

--- a/src/semantic-router/pkg/cache/hybrid_cache_lookup.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_lookup.go
@@ -4,6 +4,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -20,22 +21,23 @@ type candidateWithID struct {
 
 // FindSimilar searches for semantically similar cached requests.
 func (h *HybridCache) FindSimilar(model string, query string) ([]byte, bool, error) {
-	result, err := h.LookupSimilarWithThreshold(model, query, h.similarityThreshold)
+	result, err := h.LookupSimilarWithThreshold(context.Background(), model, query, h.similarityThreshold)
 	return result.ResponseBody, result.Found, err
 }
 
 // FindSimilarWithThreshold searches for semantically similar cached requests using a specific threshold.
 func (h *HybridCache) FindSimilarWithThreshold(model string, query string, threshold float32) ([]byte, bool, error) {
-	result, err := h.LookupSimilarWithThreshold(model, query, threshold)
+	result, err := h.LookupSimilarWithThreshold(context.Background(), model, query, threshold)
 	return result.ResponseBody, result.Found, err
 }
 
 // LookupSimilarWithThreshold returns response data and similarity atomically.
-func (h *HybridCache) LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error) {
-	return h.findSimilar(model, query, threshold, "find_similar_threshold", "HybridCache.FindSimilarWithThreshold")
+func (h *HybridCache) LookupSimilarWithThreshold(ctx context.Context, model string, query string, threshold float32) (LookupResult, error) {
+	return h.findSimilar(ctx, model, query, threshold, "find_similar_threshold", "HybridCache.FindSimilarWithThreshold")
 }
 
 func (h *HybridCache) findSimilar(
+	ctx context.Context,
 	model string,
 	query string,
 	threshold float32,
@@ -51,7 +53,7 @@ func (h *HybridCache) findSimilar(
 	logging.Debugf("%s: searching for model='%s', query=%s, threshold=%.3f",
 		logPrefix, model, logging.ContentDescriptor(query), threshold)
 
-	queryEmbedding, err := h.generateEmbedding(query)
+	queryEmbedding, err := h.generateEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("hybrid", metricOp, "error", time.Since(start).Seconds())
 		return LookupResult{}, fmt.Errorf("failed to generate embedding: %w", err)
@@ -66,7 +68,7 @@ func (h *HybridCache) findSimilar(
 	logging.Debugf("%s: HNSW returned %d candidates, %d above threshold",
 		logPrefix, totalCandidates, len(candidatesWithIDs))
 
-	responseBody, candidate, found := h.fetchResponseFromCandidates(logPrefix, model, candidatesWithIDs)
+	responseBody, candidate, found, fetchErr := h.fetchResponseFromCandidates(ctx, logPrefix, model, candidatesWithIDs)
 	if found {
 		h.recordLookupHit(start, metricOp, threshold, model, candidate)
 		return LookupResult{
@@ -80,7 +82,7 @@ func (h *HybridCache) findSimilar(
 	// partition. Milvus owns the exact model filter, so fall back to its
 	// partitioned vector search instead of returning or silently accepting the
 	// wrong candidate.
-	milvusResult, err := h.milvusCache.LookupSimilarWithThreshold(model, query, threshold)
+	milvusResult, err := h.milvusCache.LookupSimilarWithThreshold(ctx, model, query, threshold)
 	if err != nil {
 		metrics.RecordCacheOperation("hybrid", metricOp, "error", time.Since(start).Seconds())
 		return LookupResult{}, err
@@ -92,6 +94,11 @@ func (h *HybridCache) findSimilar(
 	}
 
 	h.recordLookupMiss(start, metricOp, logPrefix, threshold, model, totalCandidates, len(candidatesWithIDs))
+	// A missing cross-model candidate is a miss; any other fetch failure is an
+	// error and must not be hidden by the cache fail-open path.
+	if fetchErr != nil {
+		return LookupResult{}, fmt.Errorf("%s: candidate fetch failed: %w", logPrefix, fetchErr)
+	}
 	return LookupResult{Similarity: milvusResult.Similarity}, nil
 }
 
@@ -123,27 +130,36 @@ func (h *HybridCache) candidatesAboveThresholdLocked(candidates []searchResult, 
 }
 
 func (h *HybridCache) fetchResponseFromCandidates(
+	parent context.Context,
 	logPrefix string,
 	model string,
 	candidates []candidateWithID,
-) ([]byte, candidateWithID, bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+) ([]byte, candidateWithID, bool, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
 	defer cancel()
 
+	var fetchErr error
 	for _, candidate := range candidates {
 		fetchCtx, fetchCancel := context.WithTimeout(ctx, 2*time.Second)
 		responseBody, err := h.milvusCache.GetByID(fetchCtx, candidate.milvusID, model)
 		fetchCancel()
 		if err != nil {
+			if errors.Is(err, errMilvusCacheEntryNotFound) {
+				continue
+			}
 			logging.Debugf("%s: Milvus GetByID failed for %s: %v", logPrefix, candidate.milvusID, err)
+			fetchErr = errors.Join(fetchErr, err)
 			continue
 		}
 		if responseBody != nil {
-			return responseBody, candidate, true
+			return responseBody, candidate, true, nil
 		}
 	}
 
-	return nil, candidateWithID{}, false
+	return nil, candidateWithID{}, false, fetchErr
 }
 
 func (h *HybridCache) recordLookupHit(

--- a/src/semantic-router/pkg/cache/hybrid_cache_lookup_regression_test.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_lookup_regression_test.go
@@ -1,0 +1,63 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"errors"
+
+	"github.com/milvus-io/milvus-sdk-go/v2/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+var _ = Describe("Hybrid cache cross-model fallback", func() {
+	const threshold = float32(0.8)
+	const query = "what is semantic routing"
+
+	newCache := func(queryResult client.ResultSet, queryErr error) *HybridCache {
+		cfg := &config.MilvusConfig{}
+		cfg.Collection.VectorField.Dimension = 384
+		milvus := &MilvusCache{
+			enabled:        true,
+			config:         cfg,
+			embeddingModel: "bert",
+			queryByIDFn: func(context.Context, string, string) (client.ResultSet, error) {
+				return queryResult, queryErr
+			},
+			searchFn: func(context.Context, string, []float32) ([]client.SearchResult, error) {
+				return nil, nil
+			},
+		}
+		hybrid := newTestHybridCache(1)
+		hybrid.milvusCache = milvus
+
+		embedding, err := milvus.getEmbedding(context.Background(), query)
+		Expect(err).NotTo(HaveOccurred())
+		addToMemoryIndexForTest(hybrid, "candidate-id", embedding)
+		return hybrid
+	}
+
+	It("records an ordinary miss when the HNSW candidate belongs to another model", func() {
+		cache := newCache(nil, nil)
+
+		result, err := cache.LookupSimilarWithThreshold(context.Background(), "requested-model", query, threshold)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(LookupResult{}))
+		Expect(cache.GetStats().MissCount).To(Equal(int64(1)))
+	})
+
+	It("returns zero plus an error when the candidate fetch actually fails", func() {
+		backendErr := errors.New("milvus query failed")
+		cache := newCache(nil, backendErr)
+
+		result, err := cache.LookupSimilarWithThreshold(context.Background(), "requested-model", query, threshold)
+
+		Expect(errors.Is(err, backendErr)).To(BeTrue())
+		Expect(result).To(Equal(LookupResult{}))
+		Expect(cache.GetStats().MissCount).To(Equal(int64(1)))
+	})
+})

--- a/src/semantic-router/pkg/cache/hybrid_cache_stub.go
+++ b/src/semantic-router/pkg/cache/hybrid_cache_stub.go
@@ -61,6 +61,7 @@ func (h *HybridCache) UpdateWithResponse(
 
 // AddEntry stores a complete request-response pair
 func (h *HybridCache) AddEntry(
+	_ context.Context,
 	requestID string,
 	model string,
 	query string,
@@ -87,17 +88,17 @@ func (h *HybridCache) FindSimilarWithThreshold(model string, query string, thres
 }
 
 // LookupSimilarWithThreshold returns a request-scoped miss in stub builds.
-func (h *HybridCache) LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error) {
+func (h *HybridCache) LookupSimilarWithThreshold(_ context.Context, model string, query string, threshold float32) (LookupResult, error) {
 	return LookupResult{}, nil
 }
 
 // FindExact is unavailable when CGO support is disabled.
-func (h *HybridCache) FindExact(string, string) (LookupResult, error) {
+func (h *HybridCache) FindExact(context.Context, string, string) (LookupResult, error) {
 	return LookupResult{}, nil
 }
 
 // AddExact is unavailable when CGO support is disabled.
-func (h *HybridCache) AddExact(string, string, []byte, int) error {
+func (h *HybridCache) AddExact(context.Context, string, string, []byte, int) error {
 	return nil
 }
 
@@ -122,6 +123,6 @@ func (h *HybridCache) GetStats() CacheStats {
 }
 
 // CheckConnection checks if the cache backend is reachable
-func (h *HybridCache) CheckConnection() error {
+func (h *HybridCache) CheckConnection(_ context.Context) error {
 	return nil
 }

--- a/src/semantic-router/pkg/cache/inmemory_cache.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -186,7 +187,7 @@ func (c *InMemoryCache) IsEnabled() bool {
 
 // CheckConnection verifies the cache connection is healthy
 // For in-memory cache, this is always healthy (no external connection)
-func (c *InMemoryCache) CheckConnection() error {
+func (c *InMemoryCache) CheckConnection(_ context.Context) error {
 	// In-memory cache has no external connection to check
 	return nil
 }
@@ -194,7 +195,10 @@ func (c *InMemoryCache) CheckConnection() error {
 // generateEmbedding returns an embedding for text using the configured model,
 // served from the embedding memo when the same text was embedded recently
 // (e.g. the lookup + pending-write pair of a single cache-miss request).
-func (c *InMemoryCache) generateEmbedding(text string) ([]float32, error) {
+func (c *InMemoryCache) generateEmbedding(ctx context.Context, text string) ([]float32, error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, err
+	}
 	if c.embMemo != nil {
 		return c.embMemo.getOrCompute(text, c.computeEmbedding)
 	}
@@ -271,7 +275,7 @@ func (c *InMemoryCache) AddPendingRequest(
 	}
 
 	// Generate semantic embedding using the configured model
-	embedding, err := c.generateEmbedding(query)
+	embedding, err := c.generateEmbedding(context.Background(), query)
 	if err != nil {
 		metrics.RecordCacheOperation("memory", "add_pending", "error", time.Since(start).Seconds())
 		return fmt.Errorf("failed to generate embedding: %w", err)
@@ -394,6 +398,7 @@ func (c *InMemoryCache) UpdateWithResponse(requestID string, responseBody []byte
 
 // AddEntry stores a complete request-response pair in the cache
 func (c *InMemoryCache) AddEntry(
+	ctx context.Context,
 	requestID string,
 	model string,
 	query string,
@@ -418,7 +423,7 @@ func (c *InMemoryCache) AddEntry(
 	}
 
 	// Generate semantic embedding using the configured model
-	embedding, err := c.generateEmbedding(query)
+	embedding, err := c.generateEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("memory", "add_entry", "error", time.Since(start).Seconds())
 		return fmt.Errorf("failed to generate embedding: %w", err)
@@ -426,6 +431,12 @@ func (c *InMemoryCache) AddEntry(
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// Cancelled during the embed: publish nothing.
+	if err := ctxErr(ctx); err != nil {
+		metrics.RecordCacheOperation("memory", "add_entry", "canceled", time.Since(start).Seconds())
+		return err
+	}
 
 	// Remove expired entries to maintain cache hygiene, but defer the HNSW rebuild to the insertion below if HNSW is enabled.
 	c.cleanupExpiredEntriesDeferred()

--- a/src/semantic-router/pkg/cache/inmemory_cache_search.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache_search.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -131,12 +132,12 @@ func (c *InMemoryCache) FindSimilar(model string, query string) ([]byte, bool, e
 
 // FindSimilarWithThreshold searches for semantically similar cached requests using a specific threshold
 func (c *InMemoryCache) FindSimilarWithThreshold(model string, query string, threshold float32) ([]byte, bool, error) {
-	result, err := c.LookupSimilarWithThreshold(model, query, threshold)
+	result, err := c.LookupSimilarWithThreshold(context.Background(), model, query, threshold)
 	return result.ResponseBody, result.Found, err
 }
 
 // LookupSimilarWithThreshold returns a request-scoped lookup result.
-func (c *InMemoryCache) LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error) {
+func (c *InMemoryCache) LookupSimilarWithThreshold(ctx context.Context, model string, query string, threshold float32) (LookupResult, error) {
 	start := time.Now()
 
 	if !c.enabled {
@@ -146,10 +147,16 @@ func (c *InMemoryCache) LookupSimilarWithThreshold(model string, query string, t
 	logging.Debugf("InMemoryCache.FindSimilarWithThreshold: searching for model='%s', query=%s, threshold=%.4f",
 		model, logging.ContentDescriptor(query), threshold)
 
-	queryEmbedding, err := c.generateEmbedding(query)
+	queryEmbedding, err := c.generateEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("memory", "find_similar", "error", time.Since(start).Seconds())
 		return LookupResult{}, fmt.Errorf("failed to generate embedding: %w", err)
+	}
+
+	// Do not return a result if cancellation occurred during embedding.
+	if err := ctxErr(ctx); err != nil {
+		metrics.RecordCacheOperation("memory", "find_similar", "canceled", time.Since(start).Seconds())
+		return LookupResult{}, err
 	}
 
 	bestIndex, bestEntry, bestSimilarity, entriesChecked, expiredCount := c.runFindSimilarEmbeddingSearch(
@@ -247,5 +254,7 @@ func (c *InMemoryCache) finishFindSimilarSearch(
 		"entries_checked": entriesChecked,
 	})
 	metrics.RecordCacheOperation("memory", "find_similar", "miss", time.Since(start).Seconds())
+	// A rejected candidate's score remains request-owned and is exposed on the
+	// debug and Replay surfaces to diagnose near-threshold misses.
 	return LookupResult{Similarity: bestSimilarity}, nil
 }

--- a/src/semantic-router/pkg/cache/inmemory_cache_stub.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache_stub.go
@@ -2,6 +2,8 @@
 
 package cache
 
+import "context"
+
 // InMemoryCache provides high-performance in-memory semantic caching
 type InMemoryCache struct {
 	enabled bool
@@ -54,6 +56,7 @@ func (c *InMemoryCache) UpdateWithResponse(
 
 // AddEntry stores a complete request-response pair
 func (c *InMemoryCache) AddEntry(
+	_ context.Context,
 	requestID string,
 	model string,
 	query string,
@@ -66,23 +69,16 @@ func (c *InMemoryCache) AddEntry(
 
 // FindSimilar searches for semantically similar cached requests
 func (c *InMemoryCache) FindSimilar(model string, query string) ([]byte, bool, error) {
-	if !c.enabled {
-		return nil, false, nil
-	}
-	// Always return miss for mock unless we want to simulate hits
 	return nil, false, nil
 }
 
 // FindSimilarWithThreshold searches for semantically similar cached requests using a specific threshold
 func (c *InMemoryCache) FindSimilarWithThreshold(model string, query string, threshold float32) ([]byte, bool, error) {
-	if !c.enabled {
-		return nil, false, nil
-	}
 	return nil, false, nil
 }
 
 // LookupSimilarWithThreshold returns a request-scoped miss in stub builds.
-func (c *InMemoryCache) LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error) {
+func (c *InMemoryCache) LookupSimilarWithThreshold(_ context.Context, model string, query string, threshold float32) (LookupResult, error) {
 	if !c.enabled {
 		return LookupResult{}, nil
 	}
@@ -100,6 +96,6 @@ func (c *InMemoryCache) GetStats() CacheStats {
 }
 
 // CheckConnection checks if the cache backend is reachable
-func (c *InMemoryCache) CheckConnection() error {
+func (c *InMemoryCache) CheckConnection(_ context.Context) error {
 	return nil
 }

--- a/src/semantic-router/pkg/cache/legacy_adapter.go
+++ b/src/semantic-router/pkg/cache/legacy_adapter.go
@@ -22,7 +22,7 @@ func NewLegacyBackendAdapter(
 }
 
 func (a *LegacyBackendAdapter) LookupExact(
-	_ context.Context,
+	ctx context.Context,
 	lookup ExactLookup,
 ) (CacheResult, error) {
 	exact, ok := a.backend.(ExactCacheBackend)
@@ -30,6 +30,7 @@ func (a *LegacyBackendAdapter) LookupExact(
 		return CacheResult{}, ErrUnsupported
 	}
 	result, err := exact.FindExact(
+		ctx,
 		lookup.Identity.Partition.Key(),
 		lookup.Identity.ExactFingerprint,
 	)
@@ -45,7 +46,7 @@ func (a *LegacyBackendAdapter) LookupExact(
 	}, nil
 }
 
-func (a *LegacyBackendAdapter) StoreExact(_ context.Context, write CacheWrite) error {
+func (a *LegacyBackendAdapter) StoreExact(ctx context.Context, write CacheWrite) error {
 	exact, ok := a.backend.(ExactCacheBackend)
 	if !ok {
 		return ErrUnsupported
@@ -54,6 +55,7 @@ func (a *LegacyBackendAdapter) StoreExact(_ context.Context, write CacheWrite) e
 		return nil
 	}
 	return exact.AddExact(
+		ctx,
 		write.Identity.Partition.Key(),
 		write.Identity.ExactFingerprint,
 		write.ResponseBody,
@@ -62,10 +64,11 @@ func (a *LegacyBackendAdapter) StoreExact(_ context.Context, write CacheWrite) e
 }
 
 func (a *LegacyBackendAdapter) LookupSemantic(
-	_ context.Context,
+	ctx context.Context,
 	lookup SemanticLookup,
 ) (CacheResult, error) {
 	result, err := a.backend.LookupSimilarWithThreshold(
+		ctx,
 		lookup.Identity.Partition.Key(),
 		lookup.Identity.SemanticQuery,
 		lookup.Threshold,
@@ -82,11 +85,12 @@ func (a *LegacyBackendAdapter) LookupSemantic(
 	}, nil
 }
 
-func (a *LegacyBackendAdapter) StoreSemantic(_ context.Context, write CacheWrite) error {
+func (a *LegacyBackendAdapter) StoreSemantic(ctx context.Context, write CacheWrite) error {
 	if write.TTL.NoStore {
 		return nil
 	}
 	return a.backend.AddEntry(
+		ctx,
 		write.RequestID,
 		write.Identity.Partition.Key(),
 		write.Identity.SemanticQuery,
@@ -96,8 +100,8 @@ func (a *LegacyBackendAdapter) StoreSemantic(_ context.Context, write CacheWrite
 	)
 }
 
-func (a *LegacyBackendAdapter) Health(_ context.Context) error {
-	return a.backend.CheckConnection()
+func (a *LegacyBackendAdapter) Health(ctx context.Context) error {
+	return a.backend.CheckConnection(ctx)
 }
 
 func (a *LegacyBackendAdapter) Close() error {

--- a/src/semantic-router/pkg/cache/milvus_cache.go
+++ b/src/semantic-router/pkg/cache/milvus_cache.go
@@ -22,6 +22,8 @@ import (
 // MilvusCache provides a scalable semantic cache implementation using Milvus vector database
 type MilvusCache struct {
 	client              client.Client
+	searchFn            func(context.Context, string, []float32) ([]client.SearchResult, error)
+	queryByIDFn         func(context.Context, string, string) (client.ResultSet, error)
 	config              *config.MilvusConfig
 	collectionName      string
 	similarityThreshold float32
@@ -109,7 +111,7 @@ func NewMilvusCache(options MilvusCacheOptions) (*MilvusCache, error) {
 	}
 
 	// Test connection using the new CheckConnection method
-	if err := cache.CheckConnection(); err != nil {
+	if err := cache.CheckConnection(context.Background()); err != nil {
 		logging.Debugf("MilvusCache: connection check failed: %v", err)
 		_ = milvusClient.Close() // best-effort close
 		return nil, err
@@ -252,8 +254,12 @@ func (c *MilvusCache) initializeCollection() error {
 	return nil
 }
 
-// getEmbedding generates an embedding based on the configured embedding model
-func (c *MilvusCache) getEmbedding(text string) ([]float32, error) {
+// getEmbedding generates an embedding based on the configured embedding model.
+// Cancellation is best-effort here; see ctxErr.
+func (c *MilvusCache) getEmbedding(ctx context.Context, text string) ([]float32, error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, err
+	}
 	modelName := c.embeddingModel
 
 	switch modelName {
@@ -386,7 +392,7 @@ func (c *MilvusCache) IsEnabled() bool {
 }
 
 // CheckConnection verifies the Milvus connection is healthy
-func (c *MilvusCache) CheckConnection() error {
+func (c *MilvusCache) CheckConnection(ctx context.Context) error {
 	if !c.enabled {
 		return nil
 	}
@@ -395,7 +401,9 @@ func (c *MilvusCache) CheckConnection() error {
 		return fmt.Errorf("milvus client is not initialized")
 	}
 
-	ctx := context.Background()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if c.config != nil && c.config.Connection.Timeout > 0 {
 		timeout := time.Duration(c.config.Connection.Timeout) * time.Second
 		var cancel context.CancelFunc
@@ -429,6 +437,7 @@ func (c *MilvusCache) AddPendingRequest(requestID string, model string, query st
 
 	// Store incomplete entry for later completion with response
 	err := c.addEntry(
+		context.Background(),
 		pendingRequestPrimaryKey(requestID),
 		requestID,
 		model,
@@ -455,6 +464,7 @@ func pendingRequestPrimaryKey(requestID string) string {
 //
 //nolint:gocognit,cyclop,funlen
 func (c *MilvusCache) UpdateWithResponse(requestID string, responseBody []byte, ttlSeconds int) error {
+	ctx := context.Background()
 	start := time.Now()
 
 	if !c.enabled {
@@ -466,7 +476,6 @@ func (c *MilvusCache) UpdateWithResponse(requestID string, responseBody []byte, 
 
 	// Find the pending entry and complete it with the response
 	// Query for the incomplete entry to retrieve its metadata
-	ctx := context.Background()
 	queryExpr := fmt.Sprintf("request_id == \"%s\" && response_body == \"\"", requestID)
 
 	logging.Debugf("MilvusCache.UpdateWithResponse: searching for pending entry with expr: %s", queryExpr)
@@ -541,7 +550,7 @@ func (c *MilvusCache) UpdateWithResponse(requestID string, responseBody []byte, 
 	logging.Debugf("MilvusCache.UpdateWithResponse: found pending entry, adding complete entry (id: %s, model: %s)", id, model)
 
 	// Create the complete entry with response data and TTL
-	err = c.addEntry(id, requestID, model, query, []byte(requestBody), responseBody, ttlSeconds)
+	err = c.addEntry(ctx, id, requestID, model, query, []byte(requestBody), responseBody, ttlSeconds)
 	if err != nil {
 		metrics.RecordCacheOperation("milvus", "update_response", "error", time.Since(start).Seconds())
 		return fmt.Errorf("failed to add complete entry: %w", err)
@@ -554,7 +563,7 @@ func (c *MilvusCache) UpdateWithResponse(requestID string, responseBody []byte, 
 }
 
 // AddEntry stores a complete request-response pair in the cache
-func (c *MilvusCache) AddEntry(requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (c *MilvusCache) AddEntry(ctx context.Context, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
 	start := time.Now()
 
 	if !c.enabled {
@@ -567,7 +576,7 @@ func (c *MilvusCache) AddEntry(requestID string, model string, query string, req
 		return nil
 	}
 
-	err := c.addEntry("", requestID, model, query, requestBody, responseBody, ttlSeconds)
+	err := c.addEntry(ctx, "", requestID, model, query, requestBody, responseBody, ttlSeconds)
 
 	if err != nil {
 		metrics.RecordCacheOperation("milvus", "add_entry", "error", time.Since(start).Seconds())
@@ -594,6 +603,8 @@ func (c *MilvusCache) AddEntriesBatch(entries []CacheEntry) error {
 
 	logging.Debugf("MilvusCache.AddEntriesBatch: adding %d entries in batch", len(entries))
 
+	ctx := context.Background()
+
 	// Prepare slices for all entries
 	ids := make([]string, len(entries))
 	requestIDs := make([]string, len(entries))
@@ -607,7 +618,7 @@ func (c *MilvusCache) AddEntriesBatch(entries []CacheEntry) error {
 	// Generate embeddings and prepare data for all entries
 	for i, entry := range entries {
 		// Generate semantic embedding for the query
-		embedding, err := c.getEmbedding(entry.Query)
+		embedding, err := c.getEmbedding(ctx, entry.Query)
 		if err != nil {
 			return fmt.Errorf("failed to generate embedding for entry %d: %w", i, err)
 		}
@@ -624,8 +635,6 @@ func (c *MilvusCache) AddEntriesBatch(entries []CacheEntry) error {
 		embeddings[i] = embedding
 		timestamps[i] = time.Now().Unix()
 	}
-
-	ctx := context.Background()
 
 	// Get embedding dimension from first entry
 	embeddingDim := len(embeddings[0])
@@ -679,7 +688,11 @@ func (c *MilvusCache) Flush() error {
 // addEntry handles the internal logic for storing entries in Milvus
 //
 //nolint:funlen
-func (c *MilvusCache) addEntry(id string, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (c *MilvusCache) addEntry(ctx context.Context, id string, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	// Determine effective TTL: use provided value or fall back to cache default
 	effectiveTTL := ttlSeconds
 	if ttlSeconds == -1 {
@@ -687,7 +700,7 @@ func (c *MilvusCache) addEntry(id string, requestID string, model string, query 
 	}
 
 	// Generate semantic embedding for the query
-	embedding, err := c.getEmbedding(query)
+	embedding, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to generate embedding: %w", err)
 	}
@@ -696,8 +709,6 @@ func (c *MilvusCache) addEntry(id string, requestID string, model string, query 
 	if id == "" {
 		id = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s_%s_%d", model, query, time.Now().UnixNano())))
 	}
-
-	ctx := context.Background()
 
 	now := time.Now()
 	var expiresAt int64

--- a/src/semantic-router/pkg/cache/milvus_cache_fetch.go
+++ b/src/semantic-router/pkg/cache/milvus_cache_fetch.go
@@ -2,14 +2,18 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/milvus-io/milvus-sdk-go/v2/client"
 	"github.com/milvus-io/milvus-sdk-go/v2/entity"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
 )
+
+var errMilvusCacheEntryNotFound = errors.New("milvus cache entry not found")
 
 // GetAllEntries retrieves all entries from Milvus for HNSW index rebuilding
 // Returns slices of request_ids and embeddings for efficient bulk loading
@@ -113,23 +117,28 @@ func (c *MilvusCache) GetByID(ctx context.Context, requestID, model string) ([]b
 	if !c.enabled {
 		return nil, fmt.Errorf("milvus cache is not enabled")
 	}
-
 	logging.Debugf("MilvusCache.GetByID: fetching requestID='%s'", requestID)
 
 	// Query Milvus by request_id (primary key)
 	// Filter for non-empty responses to avoid race condition with pending entries
-	queryResult, err := c.client.Query(
-		ctx,
-		c.collectionName,
-		[]string{}, // Empty partitions means search all
-		fmt.Sprintf(
-			"request_id == %s && model == %s && response_body != \"\"",
-			milvusStringLiteral(requestID),
-			milvusStringLiteral(model),
-		),
-		[]string{"response_body"}, // Only fetch document, not embedding!
-		c.searchQueryOptions()...,
-	)
+	var queryResult client.ResultSet
+	var err error
+	if c.queryByIDFn != nil {
+		queryResult, err = c.queryByIDFn(ctx, requestID, model)
+	} else {
+		queryResult, err = c.client.Query(
+			ctx,
+			c.collectionName,
+			[]string{}, // Empty partitions means search all
+			fmt.Sprintf(
+				"request_id == %s && model == %s && response_body != \"\"",
+				milvusStringLiteral(requestID),
+				milvusStringLiteral(model),
+			),
+			[]string{"response_body"}, // Only fetch document, not embedding!
+			c.searchQueryOptions()...,
+		)
+	}
 	if err != nil {
 		logging.Debugf("MilvusCache.GetByID: query failed: %v", err)
 		metrics.RecordCacheOperation("milvus", "get_by_id", "error", time.Since(start).Seconds())
@@ -139,7 +148,7 @@ func (c *MilvusCache) GetByID(ctx context.Context, requestID, model string) ([]b
 	if len(queryResult) == 0 {
 		logging.Debugf("MilvusCache.GetByID: document not found: %s", requestID)
 		metrics.RecordCacheOperation("milvus", "get_by_id", "miss", time.Since(start).Seconds())
-		return nil, fmt.Errorf("document not found: %s", requestID)
+		return nil, fmt.Errorf("%w: %s", errMilvusCacheEntryNotFound, requestID)
 	}
 
 	// Milvus automatically includes the primary key but the column order is non-deterministic

--- a/src/semantic-router/pkg/cache/milvus_cache_similar.go
+++ b/src/semantic-router/pkg/cache/milvus_cache_similar.go
@@ -59,6 +59,9 @@ func (c *MilvusCache) milvusSearchSimilarVectors(
 	model string,
 	queryEmbedding []float32,
 ) ([]client.SearchResult, error) {
+	if c.searchFn != nil {
+		return c.searchFn(ctx, model, queryEmbedding)
+	}
 	searchParam, err := entity.NewIndexHNSWSearchParam(c.config.Search.Params.Ef)
 	if err != nil {
 		return nil, err
@@ -84,37 +87,43 @@ func (c *MilvusCache) FindSimilar(model string, query string) ([]byte, bool, err
 }
 
 // FindSimilarWithThreshold searches for semantically similar cached requests using a specific threshold
-//
-//nolint:cyclop,funlen
 func (c *MilvusCache) FindSimilarWithThreshold(model string, query string, threshold float32) ([]byte, bool, error) {
-	result, err := c.LookupSimilarWithThreshold(model, query, threshold)
+	result, err := c.LookupSimilarWithThreshold(context.Background(), model, query, threshold)
 	return result.ResponseBody, result.Found, err
 }
 
 // LookupSimilarWithThreshold returns response data and similarity atomically.
 //
 //nolint:cyclop,funlen
-func (c *MilvusCache) LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error) {
+func (c *MilvusCache) LookupSimilarWithThreshold(ctx context.Context, model string, query string, threshold float32) (LookupResult, error) {
 	start := time.Now()
 
 	if !c.enabled {
 		logging.Debugf("MilvusCache.FindSimilarWithThreshold: cache disabled")
 		return LookupResult{}, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	logging.Debugf("MilvusCache.FindSimilarWithThreshold: searching for model='%s', query=%s, threshold=%.4f",
 		model, logging.ContentDescriptor(query), threshold)
 
-	queryEmbedding, err := c.getEmbedding(query)
+	queryEmbedding, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("milvus", "find_similar", "error", time.Since(start).Seconds())
 		return LookupResult{}, fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
-	searchResult, err := c.milvusSearchSimilarVectors(context.Background(), model, queryEmbedding)
+	searchResult, err := c.milvusSearchSimilarVectors(ctx, model, queryEmbedding)
 	if err != nil {
 		logging.Debugf("MilvusCache.FindSimilarWithThreshold: search failed: %v", err)
 		atomic.AddInt64(&c.missCount, 1)
 		metrics.RecordCacheOperation("milvus", "find_similar", "error", time.Since(start).Seconds())
+		// A canceled or expired request is surfaced as an error; every other
+		// search failure keeps the existing fail-open miss (#2473).
+		if contextErr := contextErrorOnFailure(ctx, err); contextErr != nil {
+			return LookupResult{}, contextErr
+		}
 		return LookupResult{}, nil
 	}
 
@@ -149,6 +158,8 @@ func (c *MilvusCache) LookupSimilarWithThreshold(model string, query string, thr
 			"collection":      c.collectionName,
 		})
 		metrics.RecordCacheOperation("milvus", "find_similar", "miss", time.Since(start).Seconds())
+		// The rejected candidate's score belongs to this lookup; see the
+		// in-memory backend for the full rationale.
 		return LookupResult{Similarity: bestSimilarity}, nil
 	}
 

--- a/src/semantic-router/pkg/cache/milvus_consistency_level_test.go
+++ b/src/semantic-router/pkg/cache/milvus_consistency_level_test.go
@@ -190,7 +190,7 @@ func TestMilvusCacheFindExactHonorsConsistencyLevel(t *testing.T) {
 		collectionName: "test_cache",
 	}
 
-	result, err := cache.FindExact("model", "fingerprint")
+	result, err := cache.FindExact(context.Background(), "model", "fingerprint")
 	require.NoError(t, err)
 	assert.True(t, result.Found)
 	level, set := appliedConsistencyLevel(t, fake.queryOpts)

--- a/src/semantic-router/pkg/cache/milvus_exact_cache_integration_test.go
+++ b/src/semantic-router/pkg/cache/milvus_exact_cache_integration_test.go
@@ -49,14 +49,14 @@ func TestMilvusExactCacheIntegrationRoundTripAndPartitionIsolation(t *testing.T)
 	fingerprint := fmt.Sprintf("exact-%d", time.Now().UnixNano())
 	require.NoError(
 		t,
-		cache.AddExact("tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
+		cache.AddExact(context.Background(), "tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
 	)
-	hit, err := cache.FindExact("tenant-a", fingerprint)
+	hit, err := cache.FindExact(context.Background(), "tenant-a", fingerprint)
 	require.NoError(t, err)
 	require.True(t, hit.Found)
 	assert.JSONEq(t, `{"answer":"cached"}`, string(hit.ResponseBody))
 
-	miss, err := cache.FindExact("tenant-b", fingerprint)
+	miss, err := cache.FindExact(context.Background(), "tenant-b", fingerprint)
 	require.NoError(t, err)
 	assert.False(t, miss.Found)
 }
@@ -118,14 +118,14 @@ func TestHybridExactCacheIntegrationDelegatesToMilvus(t *testing.T) {
 	fingerprint := fmt.Sprintf("exact-%d", time.Now().UnixNano())
 	require.NoError(
 		t,
-		cache.AddExact("tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
+		cache.AddExact(context.Background(), "tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
 	)
-	hit, err := cache.FindExact("tenant-a", fingerprint)
+	hit, err := cache.FindExact(context.Background(), "tenant-a", fingerprint)
 	require.NoError(t, err)
 	require.True(t, hit.Found)
 	assert.JSONEq(t, `{"answer":"cached"}`, string(hit.ResponseBody))
 
-	miss, err := cache.FindExact("tenant-b", fingerprint)
+	miss, err := cache.FindExact(context.Background(), "tenant-b", fingerprint)
 	require.NoError(t, err)
 	assert.False(t, miss.Found)
 }

--- a/src/semantic-router/pkg/cache/qdrant_cache.go
+++ b/src/semantic-router/pkg/cache/qdrant_cache.go
@@ -20,6 +20,7 @@ const pendingResponseMarker = "__pending__"
 
 type QdrantCache struct {
 	client              *qdrant.Client
+	searchFn            func(context.Context, *qdrant.QueryPoints) ([]*qdrant.ScoredPoint, error)
 	cfg                 *config.QdrantConfig
 	collectionName      string
 	similarityThreshold float32
@@ -77,7 +78,7 @@ func NewQdrantCache(opts QdrantCacheOptions) (*QdrantCache, error) {
 		embeddingModel:      embeddingModel,
 	}
 
-	if err := c.CheckConnection(); err != nil {
+	if err := c.CheckConnection(context.Background()); err != nil {
 		_ = client.Close()
 		return nil, err
 	}
@@ -137,7 +138,12 @@ func (c *QdrantCache) ensureCollection() error {
 	return nil
 }
 
-func (c *QdrantCache) getEmbedding(text string) ([]float32, error) {
+// getEmbedding generates an embedding based on the configured embedding model.
+// Cancellation is best-effort here; see ctxErr.
+func (c *QdrantCache) getEmbedding(ctx context.Context, text string) ([]float32, error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, err
+	}
 	modelName := c.embeddingModel
 
 	switch modelName {
@@ -206,8 +212,11 @@ func (c *QdrantCache) expiresAt(ttlSeconds int) int64 {
 
 func (c *QdrantCache) IsEnabled() bool { return c.enabled }
 
-func (c *QdrantCache) CheckConnection() error {
-	ctx, cancel := context.WithTimeout(context.Background(), c.connTimeout())
+func (c *QdrantCache) CheckConnection(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, c.connTimeout())
 	defer cancel()
 	_, err := c.client.ListCollections(ctx)
 	if err != nil {
@@ -220,15 +229,16 @@ func (c *QdrantCache) AddPendingRequest(requestID, model, query string, requestB
 	if !c.enabled || ttlSeconds == 0 {
 		return nil
 	}
+	ctx := context.Background()
 
-	emb, err := c.getEmbedding(query)
+	emb, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
 	id := fmt.Sprintf("%x", md5.Sum([]byte(requestID))) //nolint:gosec
 	wait := true
-	_, err = c.client.Upsert(context.Background(), &qdrant.UpsertPoints{
+	_, err = c.client.Upsert(ctx, &qdrant.UpsertPoints{
 		CollectionName: c.collectionName,
 		Wait:           &wait,
 		Points: []*qdrant.PointStruct{{
@@ -315,19 +325,22 @@ func (c *QdrantCache) UpdateWithResponse(requestID string, responseBody []byte, 
 	return nil
 }
 
-func (c *QdrantCache) AddEntry(requestID, model, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (c *QdrantCache) AddEntry(ctx context.Context, requestID, model, query string, requestBody, responseBody []byte, ttlSeconds int) error {
 	if !c.enabled || ttlSeconds == 0 {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	emb, err := c.getEmbedding(query)
+	emb, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
 	id := fmt.Sprintf("%x", md5.Sum([]byte(requestID))) //nolint:gosec
 	wait := true
-	_, err = c.client.Upsert(context.Background(), &qdrant.UpsertPoints{
+	_, err = c.client.Upsert(ctx, &qdrant.UpsertPoints{
 		CollectionName: c.collectionName,
 		Wait:           &wait,
 		Points: []*qdrant.PointStruct{{
@@ -357,19 +370,22 @@ func (c *QdrantCache) FindSimilar(model, query string) ([]byte, bool, error) {
 }
 
 func (c *QdrantCache) FindSimilarWithThreshold(model, query string, threshold float32) ([]byte, bool, error) {
-	result, err := c.LookupSimilarWithThreshold(model, query, threshold)
+	result, err := c.LookupSimilarWithThreshold(context.Background(), model, query, threshold)
 	return result.ResponseBody, result.Found, err
 }
 
 // LookupSimilarWithThreshold returns response data and similarity atomically.
-func (c *QdrantCache) LookupSimilarWithThreshold(model, query string, threshold float32) (LookupResult, error) {
+func (c *QdrantCache) LookupSimilarWithThreshold(ctx context.Context, model, query string, threshold float32) (LookupResult, error) {
 	start := time.Now()
 
 	if !c.enabled {
 		return LookupResult{}, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	emb, err := c.getEmbedding(query)
+	emb, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("qdrant", "find_similar", "error", time.Since(start).Seconds())
 		return LookupResult{}, fmt.Errorf("failed to generate embedding: %w", err)
@@ -397,17 +413,26 @@ func (c *QdrantCache) LookupSimilarWithThreshold(model, query string, threshold 
 		},
 	}
 
-	scored, err := c.client.Query(context.Background(), &qdrant.QueryPoints{
+	queryPoints := &qdrant.QueryPoints{
 		CollectionName: c.collectionName,
 		Query:          qdrant.NewQueryDense(emb),
 		Limit:          qdrant.PtrOf(uint64(1)), //nolint:gosec
 		ScoreThreshold: &threshold,
 		WithPayload:    qdrant.NewWithPayload(true),
 		Filter:         filter,
-	})
+	}
+	var scored []*qdrant.ScoredPoint
+	if c.searchFn != nil {
+		scored, err = c.searchFn(ctx, queryPoints)
+	} else {
+		scored, err = c.client.Query(ctx, queryPoints)
+	}
 	if err != nil {
 		atomic.AddInt64(&c.missCount, 1)
 		metrics.RecordCacheOperation("qdrant", "find_similar", "error", time.Since(start).Seconds())
+		if contextErr := contextErrorOnFailure(ctx, err); contextErr != nil {
+			return LookupResult{}, contextErr
+		}
 		return LookupResult{}, nil
 	}
 

--- a/src/semantic-router/pkg/cache/qdrant_exact_cache_integration_test.go
+++ b/src/semantic-router/pkg/cache/qdrant_exact_cache_integration_test.go
@@ -55,14 +55,14 @@ func TestQdrantExactCacheIntegrationRoundTripAndPartitionIsolation(t *testing.T)
 	fingerprint := fmt.Sprintf("exact-%d", time.Now().UnixNano())
 	require.NoError(
 		t,
-		cache.AddExact("tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
+		cache.AddExact(context.Background(), "tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
 	)
-	hit, err := cache.FindExact("tenant-a", fingerprint)
+	hit, err := cache.FindExact(context.Background(), "tenant-a", fingerprint)
 	require.NoError(t, err)
 	require.True(t, hit.Found)
 	assert.JSONEq(t, `{"answer":"cached"}`, string(hit.ResponseBody))
 
-	miss, err := cache.FindExact("tenant-b", fingerprint)
+	miss, err := cache.FindExact(context.Background(), "tenant-b", fingerprint)
 	require.NoError(t, err)
 	assert.False(t, miss.Found)
 }

--- a/src/semantic-router/pkg/cache/redis_cache.go
+++ b/src/semantic-router/pkg/cache/redis_cache.go
@@ -25,6 +25,7 @@ import (
 // RedisCache provides a scalable semantic cache implementation using Redis with vector search
 type RedisCache struct {
 	client              *redis.Client
+	searchFn            func(context.Context, string, string, *redis.FTSearchOptions) (redis.FTSearchResult, error)
 	config              *config.RedisConfig
 	indexName           string
 	similarityThreshold float32
@@ -45,6 +46,9 @@ type RedisCacheOptions struct {
 	Config              *config.RedisConfig
 	ConfigPath          string
 	EmbeddingModel      string
+
+	// closeClient is a test seam for constructor cleanup.
+	closeClient func(*redis.Client)
 }
 
 // NewRedisCache initializes a new Redis-backed semantic cache instance
@@ -103,8 +107,16 @@ func NewRedisCache(options RedisCacheOptions) (*RedisCache, error) {
 		embeddingModel:      embeddingModel,
 	}
 
+	releaseClient := func() { _ = redisClient.Close() }
+	if options.closeClient != nil {
+		releaseClient = func() { options.closeClient(redisClient) }
+	}
+
 	// Test connection using the new CheckConnection method
-	if err := cache.CheckConnection(); err != nil {
+	if err := releaseOnFailure(
+		func() error { return cache.CheckConnection(context.Background()) },
+		releaseClient,
+	); err != nil {
 		logging.Debugf("RedisCache: failed to connect: %v", err)
 		return nil, err
 	}
@@ -112,9 +124,8 @@ func NewRedisCache(options RedisCacheOptions) (*RedisCache, error) {
 
 	// Set up the index for vector search
 	logging.Debugf("RedisCache: initializing index '%s'", redisConfig.Index.Name)
-	if err := cache.initializeIndex(); err != nil {
+	if err := releaseOnFailure(cache.initializeIndex, releaseClient); err != nil {
 		logging.Debugf("RedisCache: failed to initialize index: %v", err)
-		_ = redisClient.Close()
 		return nil, fmt.Errorf("failed to initialize index: %w", err)
 	}
 	logging.Debugf("RedisCache: initialization complete")
@@ -220,8 +231,12 @@ func (c *RedisCache) initializeIndex() error {
 	return nil
 }
 
-// getEmbedding generates an embedding based on the configured embedding model
-func (c *RedisCache) getEmbedding(text string) ([]float32, error) {
+// getEmbedding generates an embedding based on the configured embedding model.
+// Cancellation is best-effort here; see ctxErr.
+func (c *RedisCache) getEmbedding(ctx context.Context, text string) ([]float32, error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, err
+	}
 	modelName := c.embeddingModel
 
 	switch modelName {
@@ -363,7 +378,7 @@ func (c *RedisCache) IsEnabled() bool {
 }
 
 // CheckConnection verifies the Redis connection is healthy
-func (c *RedisCache) CheckConnection() error {
+func (c *RedisCache) CheckConnection(ctx context.Context) error {
 	if !c.enabled {
 		return nil
 	}
@@ -372,7 +387,9 @@ func (c *RedisCache) CheckConnection() error {
 		return fmt.Errorf("redis client is not initialized")
 	}
 
-	ctx := context.Background()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if c.config != nil && c.config.Connection.Timeout > 0 {
 		timeout := time.Duration(c.config.Connection.Timeout) * time.Second
 		var cancel context.CancelFunc
@@ -402,7 +419,7 @@ func (c *RedisCache) AddPendingRequest(requestID string, model string, query str
 	}
 
 	// Store incomplete entry for later completion with response
-	err := c.addEntry("", requestID, model, query, requestBody, nil, ttlSeconds)
+	err := c.addEntry(context.Background(), "", requestID, model, query, requestBody, nil, ttlSeconds)
 
 	if err != nil {
 		metrics.RecordCacheOperation("redis", "add_pending", "error", time.Since(start).Seconds())
@@ -415,6 +432,7 @@ func (c *RedisCache) AddPendingRequest(requestID string, model string, query str
 
 // UpdateWithResponse completes a pending request by adding the response
 func (c *RedisCache) UpdateWithResponse(requestID string, responseBody []byte, ttlSeconds int) error {
+	ctx := context.Background()
 	start := time.Now()
 
 	if !c.enabled {
@@ -425,8 +443,6 @@ func (c *RedisCache) UpdateWithResponse(requestID string, responseBody []byte, t
 		requestID, len(responseBody), ttlSeconds)
 
 	// Find the pending entry by request_id
-	ctx := context.Background()
-
 	// Search for documents with matching request_id using TEXT field syntax (exact match with quotes)
 	// TAG syntax with {} doesn't work well with UUIDs containing hyphens
 	query := fmt.Sprintf("@request_id:\"%s\"", requestID)
@@ -470,7 +486,7 @@ func (c *RedisCache) UpdateWithResponse(requestID string, responseBody []byte, t
 	logging.Debugf("RedisCache.UpdateWithResponse: found pending entry, updating (id: %s, model: %s)", docID, model)
 
 	// Update the document with response body and TTL
-	err = c.addEntry(docID, requestID, model, queryStr, []byte(requestBodyStr), responseBody, ttlSeconds)
+	err = c.addEntry(ctx, docID, requestID, model, queryStr, []byte(requestBodyStr), responseBody, ttlSeconds)
 	if err != nil {
 		metrics.RecordCacheOperation("redis", "update_response", "error", time.Since(start).Seconds())
 		return fmt.Errorf("failed to update entry: %w", err)
@@ -483,7 +499,7 @@ func (c *RedisCache) UpdateWithResponse(requestID string, responseBody []byte, t
 }
 
 // AddEntry stores a complete request-response pair in the cache
-func (c *RedisCache) AddEntry(requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (c *RedisCache) AddEntry(ctx context.Context, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
 	start := time.Now()
 
 	if !c.enabled {
@@ -496,7 +512,7 @@ func (c *RedisCache) AddEntry(requestID string, model string, query string, requ
 		return nil
 	}
 
-	err := c.addEntry("", requestID, model, query, requestBody, responseBody, ttlSeconds)
+	err := c.addEntry(ctx, "", requestID, model, query, requestBody, responseBody, ttlSeconds)
 
 	if err != nil {
 		metrics.RecordCacheOperation("redis", "add_entry", "error", time.Since(start).Seconds())
@@ -518,9 +534,13 @@ func floatsToBytes(fs []float32) []byte {
 }
 
 // addEntry handles the internal logic for storing entries in Redis
-func (c *RedisCache) addEntry(id string, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (c *RedisCache) addEntry(ctx context.Context, id string, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
 	logging.Infof("addEntry called: id='%s', requestID='%s', requestBody_len=%d, responseBody_len=%d, ttl_seconds=%d",
 		id, requestID, len(requestBody), len(responseBody), ttlSeconds)
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	// Determine effective TTL: use provided value or fall back to cache default
 	effectiveTTL := ttlSeconds
@@ -529,7 +549,7 @@ func (c *RedisCache) addEntry(id string, requestID string, model string, query s
 	}
 
 	// Generate semantic embedding for the query
-	embedding, err := c.getEmbedding(query)
+	embedding, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to generate embedding: %w", err)
 	}
@@ -538,8 +558,6 @@ func (c *RedisCache) addEntry(id string, requestID string, model string, query s
 	if id == "" {
 		id = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s_%s_%d", model, query, time.Now().UnixNano())))
 	}
-
-	ctx := context.Background()
 
 	// Convert embedding to bytes
 	embeddingBytes := floatsToBytes(embedding)
@@ -633,46 +651,53 @@ func (c *RedisCache) extractSearchResult(bestDoc redis.Document) (float32, []byt
 
 // FindSimilarWithThreshold searches for semantically similar cached requests using a specific threshold
 func (c *RedisCache) FindSimilarWithThreshold(model string, query string, threshold float32) ([]byte, bool, error) {
-	result, err := c.LookupSimilarWithThreshold(model, query, threshold)
+	result, err := c.LookupSimilarWithThreshold(context.Background(), model, query, threshold)
 	return result.ResponseBody, result.Found, err
 }
 
 // LookupSimilarWithThreshold returns response data and similarity atomically.
-func (c *RedisCache) LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error) {
+func (c *RedisCache) LookupSimilarWithThreshold(ctx context.Context, model string, query string, threshold float32) (LookupResult, error) {
 	start := time.Now()
 
 	if !c.enabled {
 		return LookupResult{}, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	queryEmbedding, err := c.getEmbedding(query)
+	queryEmbedding, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("redis", "find_similar", "error", time.Since(start).Seconds())
 		return LookupResult{}, fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
-	ctx := context.Background()
 	embeddingBytes := floatsToBytes(queryEmbedding)
 
 	knnQuery := partitionedKNNQuery(model, c.config.Search.TopK, c.config.Index.VectorField.Name)
 
-	searchResult, err := c.client.FTSearchWithArgs(ctx,
-		c.indexName,
-		knnQuery,
-		&redis.FTSearchOptions{
-			Return: []redis.FTSearchReturn{
-				{FieldName: "vector_distance"},
-				{FieldName: "response_body"},
-			},
-			DialectVersion: 2,
-			Params: map[string]interface{}{
-				"vec": embeddingBytes,
-			},
+	searchOptions := &redis.FTSearchOptions{
+		Return: []redis.FTSearchReturn{
+			{FieldName: "vector_distance"},
+			{FieldName: "response_body"},
 		},
-	).Result()
+		DialectVersion: 2,
+		Params: map[string]interface{}{
+			"vec": embeddingBytes,
+		},
+	}
+	var searchResult redis.FTSearchResult
+	if c.searchFn != nil {
+		searchResult, err = c.searchFn(ctx, c.indexName, knnQuery, searchOptions)
+	} else {
+		searchResult, err = c.client.FTSearchWithArgs(ctx, c.indexName, knnQuery, searchOptions).Result()
+	}
 	if err != nil {
 		logging.Infof("RedisCache.FindSimilarWithThreshold: search failed: %v", err)
 		c.recordCacheMiss("error", time.Since(start))
+		if contextErr := contextErrorOnFailure(ctx, err); contextErr != nil {
+			return LookupResult{}, contextErr
+		}
 		return LookupResult{}, nil
 	}
 
@@ -682,7 +707,6 @@ func (c *RedisCache) LookupSimilarWithThreshold(model string, query string, thre
 	}
 
 	similarity, responseBody, ok := c.extractSearchResult(searchResult.Docs[0])
-	// Store similarity for callers (e.g., x-vsr-cache-similarity response header)
 	if !ok {
 		c.recordCacheMiss("error", time.Since(start))
 		return LookupResult{Similarity: similarity}, nil
@@ -700,6 +724,8 @@ func (c *RedisCache) LookupSimilarWithThreshold(model string, query string, thre
 			"index":           c.indexName,
 		})
 		c.recordCacheMiss("miss", time.Since(start))
+		// The rejected candidate's score belongs to this lookup; see the
+		// in-memory backend for the full rationale.
 		return LookupResult{Similarity: similarity}, nil
 	}
 

--- a/src/semantic-router/pkg/cache/redis_cache_bench_test.go
+++ b/src/semantic-router/pkg/cache/redis_cache_bench_test.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -101,7 +102,7 @@ func setupRedisCacheBench(b *testing.B) *RedisCache {
 	if err != nil {
 		unavailable("redis server not available: %v", err)
 	}
-	if err := cache.CheckConnection(); err != nil {
+	if err := cache.CheckConnection(context.Background()); err != nil {
 		unavailable("redis connection check failed: %v", err)
 	}
 	return cache

--- a/src/semantic-router/pkg/cache/redis_exact_cache_integration_test.go
+++ b/src/semantic-router/pkg/cache/redis_exact_cache_integration_test.go
@@ -50,15 +50,15 @@ func TestRedisExactCacheIntegrationRoundTripAndPartitionIsolation(t *testing.T) 
 	fingerprint := fmt.Sprintf("exact-%d", time.Now().UnixNano())
 	require.NoError(
 		t,
-		cache.AddExact("tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
+		cache.AddExact(context.Background(), "tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
 	)
-	hit, err := cache.FindExact("tenant-a", fingerprint)
+	hit, err := cache.FindExact(context.Background(), "tenant-a", fingerprint)
 	require.NoError(t, err)
 	require.True(t, hit.Found)
 	assert.JSONEq(t, `{"answer":"cached"}`, string(hit.ResponseBody))
 	assert.Equal(t, float32(1), hit.Similarity)
 
-	miss, err := cache.FindExact("tenant-b", fingerprint)
+	miss, err := cache.FindExact(context.Background(), "tenant-b", fingerprint)
 	require.NoError(t, err)
 	assert.False(t, miss.Found)
 }

--- a/src/semantic-router/pkg/cache/valkey_cache.go
+++ b/src/semantic-router/pkg/cache/valkey_cache.go
@@ -22,6 +22,7 @@ import (
 // ValkeyCache provides a scalable semantic cache implementation using Valkey with vector search
 type ValkeyCache struct {
 	client              *glide.Client
+	searchFn            func(context.Context, []string) (any, error)
 	config              *routerconfig.ValkeyConfig
 	indexName           string
 	similarityThreshold float32
@@ -41,6 +42,9 @@ type ValkeyCacheOptions struct {
 	Enabled             bool
 	Config              *routerconfig.ValkeyConfig
 	EmbeddingModel      string
+
+	// closeClient is a test seam for constructor cleanup.
+	closeClient func(*glide.Client)
 }
 
 // NewValkeyCache initializes a new Valkey-backed semantic cache instance
@@ -108,16 +112,23 @@ func NewValkeyCache(options ValkeyCacheOptions) (*ValkeyCache, error) {
 		embeddingModel:      embeddingModel,
 	}
 
-	if err := cache.CheckConnection(); err != nil {
+	releaseClient := func() { valkeyClient.Close() }
+	if options.closeClient != nil {
+		releaseClient = func() { options.closeClient(valkeyClient) }
+	}
+
+	if err := releaseOnFailure(
+		func() error { return cache.CheckConnection(context.Background()) },
+		releaseClient,
+	); err != nil {
 		logging.Debugf("ValkeyCache: failed to connect: %v", err)
 		return nil, err
 	}
 	logging.Debugf("ValkeyCache: successfully connected to Valkey")
 
 	logging.Debugf("ValkeyCache: initializing index '%s'", valkeyConfig.Index.Name)
-	if err := cache.initializeSearchIndex(); err != nil {
+	if err := releaseOnFailure(cache.initializeSearchIndex, releaseClient); err != nil {
 		logging.Debugf("ValkeyCache: initialization failed: %v", err)
-		valkeyClient.Close()
 		return nil, err
 	}
 	logging.Debugf("ValkeyCache: initialization complete")
@@ -182,8 +193,12 @@ func (c *ValkeyCache) initializeIndex() error {
 	return nil
 }
 
-// getEmbedding generates an embedding based on the configured embedding model
-func (c *ValkeyCache) getEmbedding(text string) ([]float32, error) {
+// getEmbedding generates an embedding based on the configured embedding model.
+// Cancellation is best-effort here; see ctxErr.
+func (c *ValkeyCache) getEmbedding(ctx context.Context, text string) ([]float32, error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, err
+	}
 	modelName := c.embeddingModel
 
 	switch modelName {
@@ -299,7 +314,7 @@ func (c *ValkeyCache) IsEnabled() bool {
 }
 
 // CheckConnection verifies the Valkey connection is healthy
-func (c *ValkeyCache) CheckConnection() error {
+func (c *ValkeyCache) CheckConnection(ctx context.Context) error {
 	if !c.enabled {
 		return nil
 	}
@@ -308,7 +323,9 @@ func (c *ValkeyCache) CheckConnection() error {
 		return fmt.Errorf("valkey client is not initialized")
 	}
 
-	ctx := context.Background()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if c.config != nil && c.config.Connection.Timeout > 0 {
 		timeout := time.Duration(c.config.Connection.Timeout) * time.Second
 		var cancel context.CancelFunc
@@ -337,7 +354,7 @@ func (c *ValkeyCache) AddPendingRequest(requestID string, model string, query st
 		return nil
 	}
 
-	err := c.addEntry("", requestID, model, query, requestBody, nil, ttlSeconds)
+	err := c.addEntry(context.Background(), "", requestID, model, query, requestBody, nil, ttlSeconds)
 
 	if err != nil {
 		metrics.RecordCacheOperation("valkey", "add_pending", "error", time.Since(start).Seconds())
@@ -349,6 +366,7 @@ func (c *ValkeyCache) AddPendingRequest(requestID string, model string, query st
 }
 
 func (c *ValkeyCache) UpdateWithResponse(requestID string, responseBody []byte, ttlSeconds int) error {
+	ctx := context.Background()
 	start := time.Now()
 
 	if !c.enabled {
@@ -357,8 +375,6 @@ func (c *ValkeyCache) UpdateWithResponse(requestID string, responseBody []byte, 
 
 	logging.Debugf("ValkeyCache.UpdateWithResponse: updating pending entry (request_id: %s, response_size: %d, ttl_seconds=%d)",
 		requestID, len(responseBody), ttlSeconds)
-
-	ctx := context.Background()
 
 	query := fmt.Sprintf("@request_id:{%s}", escapeTagValue(requestID))
 	logging.Debugf("UpdateWithResponse: searching with TAG query: %s", query)
@@ -387,7 +403,7 @@ func (c *ValkeyCache) UpdateWithResponse(requestID string, responseBody []byte, 
 	logging.Debugf("ValkeyCache.UpdateWithResponse: found pending entry, updating (id: %s, model: %s)", entry.docID, entry.model)
 
 	// Update the document with response body and TTL
-	err = c.addEntry(entry.docID, requestID, entry.model, entry.query, []byte(entry.requestBodyStr), responseBody, ttlSeconds)
+	err = c.addEntry(ctx, entry.docID, requestID, entry.model, entry.query, []byte(entry.requestBodyStr), responseBody, ttlSeconds)
 	if err != nil {
 		metrics.RecordCacheOperation("valkey", "update_response", "error", time.Since(start).Seconds())
 		return fmt.Errorf("failed to update entry: %w", err)
@@ -400,7 +416,7 @@ func (c *ValkeyCache) UpdateWithResponse(requestID string, responseBody []byte, 
 }
 
 // AddEntry stores a complete request-response pair in the cache
-func (c *ValkeyCache) AddEntry(requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (c *ValkeyCache) AddEntry(ctx context.Context, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
 	start := time.Now()
 
 	if !c.enabled {
@@ -412,7 +428,7 @@ func (c *ValkeyCache) AddEntry(requestID string, model string, query string, req
 		return nil
 	}
 
-	err := c.addEntry("", requestID, model, query, requestBody, responseBody, ttlSeconds)
+	err := c.addEntry(ctx, "", requestID, model, query, requestBody, responseBody, ttlSeconds)
 
 	if err != nil {
 		metrics.RecordCacheOperation("valkey", "add_entry", "error", time.Since(start).Seconds())
@@ -424,13 +440,17 @@ func (c *ValkeyCache) AddEntry(requestID string, model string, query string, req
 }
 
 // addEntry handles the internal logic for storing entries in Valkey
-func (c *ValkeyCache) addEntry(id string, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+func (c *ValkeyCache) addEntry(ctx context.Context, id string, requestID string, model string, query string, requestBody, responseBody []byte, ttlSeconds int) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	effectiveTTL := ttlSeconds
 	if ttlSeconds == -1 {
 		effectiveTTL = c.ttlSeconds
 	}
 
-	embedding, err := c.getEmbedding(query)
+	embedding, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to generate embedding: %w", err)
 	}
@@ -438,8 +458,6 @@ func (c *ValkeyCache) addEntry(id string, requestID string, model string, query 
 	if id == "" {
 		id = fmt.Sprintf("%x", md5.Sum(fmt.Appendf(nil, "%s_%s_%d", model, query, time.Now().UnixNano())))
 	}
-
-	ctx := context.Background()
 
 	embeddingBytes := floatsToBytes(embedding)
 
@@ -512,33 +530,42 @@ func (c *ValkeyCache) recordCacheMiss(status string, elapsed time.Duration) {
 
 // FindSimilarWithThreshold searches for semantically similar cached requests using a specific threshold
 func (c *ValkeyCache) FindSimilarWithThreshold(model string, query string, threshold float32) ([]byte, bool, error) {
-	result, err := c.LookupSimilarWithThreshold(model, query, threshold)
+	result, err := c.LookupSimilarWithThreshold(context.Background(), model, query, threshold)
 	return result.ResponseBody, result.Found, err
 }
 
 // LookupSimilarWithThreshold returns response data and similarity atomically.
-func (c *ValkeyCache) LookupSimilarWithThreshold(model string, query string, threshold float32) (LookupResult, error) {
+func (c *ValkeyCache) LookupSimilarWithThreshold(ctx context.Context, model string, query string, threshold float32) (LookupResult, error) {
 	start := time.Now()
 
 	if !c.enabled {
 		return LookupResult{}, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	queryEmbedding, err := c.getEmbedding(query)
+	queryEmbedding, err := c.getEmbedding(ctx, query)
 	if err != nil {
 		metrics.RecordCacheOperation("valkey", "find_similar", "error", time.Since(start).Seconds())
 		return LookupResult{}, fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
-	ctx := context.Background()
-
 	embeddingBytes := floatsToBytes(queryEmbedding)
 	searchCmd := c.buildKNNSearchCmd(model, embeddingBytes)
 
-	searchResult, err := c.client.CustomCommand(ctx, searchCmd)
+	var searchResult any
+	if c.searchFn != nil {
+		searchResult, err = c.searchFn(ctx, searchCmd)
+	} else {
+		searchResult, err = c.client.CustomCommand(ctx, searchCmd)
+	}
 	if err != nil {
 		logging.Debugf("ValkeyCache.FindSimilarWithThreshold: search failed: %v", err)
 		c.recordCacheMiss("error", time.Since(start))
+		if contextErr := contextErrorOnFailure(ctx, err); contextErr != nil {
+			return LookupResult{}, contextErr
+		}
 		return LookupResult{}, nil
 	}
 
@@ -561,6 +588,8 @@ func (c *ValkeyCache) LookupSimilarWithThreshold(model string, query string, thr
 			"index":           c.indexName,
 		})
 		c.recordCacheMiss("miss", time.Since(start))
+		// The rejected candidate's score belongs to this lookup; see the
+		// in-memory backend for the full rationale.
 		return LookupResult{Similarity: similarity}, nil
 	}
 

--- a/src/semantic-router/pkg/cache/valkey_cache_bench_test.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_bench_test.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -64,7 +65,7 @@ func setupValkeyCacheBench(b *testing.B) *ValkeyCache {
 	if err != nil {
 		unavailable("valkey server not available: %v", err)
 	}
-	if err := cache.CheckConnection(); err != nil {
+	if err := cache.CheckConnection(context.Background()); err != nil {
 		unavailable("valkey connection check failed: %v", err)
 	}
 	return cache

--- a/src/semantic-router/pkg/cache/valkey_cache_integration_edge_test.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_integration_edge_test.go
@@ -3,6 +3,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -19,7 +20,7 @@ func TestValkeyCacheIntegration_EmptyQuery(t *testing.T) {
 	cache := setupValkeyCacheIntegration(t)
 	defer func() { _ = cache.Close() }()
 
-	err := cache.AddEntry("req_empty", "gpt-4", "", []byte("{}"), []byte("{}"), 300)
+	err := cache.AddEntry(context.Background(), "req_empty", "gpt-4", "", []byte("{}"), []byte("{}"), 300)
 	assert.NoError(t, err, "AddEntry with empty query should not error")
 
 	_, hit, err := cache.FindSimilar("gpt-4", "")
@@ -36,7 +37,7 @@ func TestValkeyCacheIntegration_LargeResponseBody(t *testing.T) {
 		largeResponse[i] = byte('A' + (i % 26))
 	}
 
-	err := cache.AddEntry("req_large", "gpt-4", "large response test", []byte("{}"), largeResponse, 300)
+	err := cache.AddEntry(context.Background(), "req_large", "gpt-4", "large response test", []byte("{}"), largeResponse, 300)
 	assert.NoError(t, err, "AddEntry with large response should succeed")
 
 	time.Sleep(200 * time.Millisecond)
@@ -66,7 +67,7 @@ func TestValkeyCacheIntegration_SpecialCharactersInQuery(t *testing.T) {
 
 	for i, query := range specialQueries {
 		requestID := fmt.Sprintf("req_special_%d", i)
-		err := cache.AddEntry(requestID, "gpt-4", query, []byte("{}"), []byte(fmt.Sprintf(`{"query":"%d"}`, i)), 300)
+		err := cache.AddEntry(context.Background(), requestID, "gpt-4", query, []byte("{}"), []byte(fmt.Sprintf(`{"query":"%d"}`, i)), 300)
 		assert.NoError(t, err, "AddEntry should handle special characters: %s", query)
 	}
 
@@ -85,7 +86,7 @@ func TestValkeyCacheIntegration_StatsAccuracy(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		requestID := fmt.Sprintf("req_stats_acc_%d", i)
 		query := fmt.Sprintf("stats test query %d", i)
-		err := cache.AddEntry(requestID, "gpt-4", query, []byte("{}"), []byte(fmt.Sprintf(`{"id":%d}`, i)), 300)
+		err := cache.AddEntry(context.Background(), requestID, "gpt-4", query, []byte("{}"), []byte(fmt.Sprintf(`{"id":%d}`, i)), 300)
 		require.NoError(t, err)
 	}
 

--- a/src/semantic-router/pkg/cache/valkey_cache_integration_test.go
+++ b/src/semantic-router/pkg/cache/valkey_cache_integration_test.go
@@ -98,7 +98,7 @@ func TestValkeyCacheIntegration_ConnectionCheck(t *testing.T) {
 	cache := setupValkeyCacheIntegration(t)
 	defer func() { _ = cache.Close() }()
 
-	err := cache.CheckConnection()
+	err := cache.CheckConnection(context.Background())
 	assert.NoError(t, err, "Connection check should succeed")
 }
 
@@ -109,15 +109,15 @@ func TestValkeyCacheIntegration_ExactRoundTripAndPartitionIsolation(t *testing.T
 	fingerprint := fmt.Sprintf("exact-%d", time.Now().UnixNano())
 	require.NoError(
 		t,
-		cache.AddExact("tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
+		cache.AddExact(context.Background(), "tenant-a", fingerprint, []byte(`{"answer":"cached"}`), 60),
 	)
-	hit, err := cache.FindExact("tenant-a", fingerprint)
+	hit, err := cache.FindExact(context.Background(), "tenant-a", fingerprint)
 	require.NoError(t, err)
 	require.True(t, hit.Found)
 	assert.JSONEq(t, `{"answer":"cached"}`, string(hit.ResponseBody))
 	assert.Equal(t, float32(1), hit.Similarity)
 
-	miss, err := cache.FindExact("tenant-b", fingerprint)
+	miss, err := cache.FindExact(context.Background(), "tenant-b", fingerprint)
 	require.NoError(t, err)
 	assert.False(t, miss.Found)
 }
@@ -147,7 +147,7 @@ func TestValkeyCacheIntegration_AddEntry(t *testing.T) {
 	responseBody := []byte(`{"choices":[{"message":{"content":"Paris is the capital of France."}}]}`)
 	ttlSeconds := 300
 
-	err := cache.AddEntry(requestID, model, query, requestBody, responseBody, ttlSeconds)
+	err := cache.AddEntry(context.Background(), requestID, model, query, requestBody, responseBody, ttlSeconds)
 	assert.NoError(t, err, "AddEntry should succeed")
 
 	// Wait for indexing
@@ -171,7 +171,7 @@ func TestValkeyCacheIntegration_FindSimilar(t *testing.T) {
 	responseBody := []byte(`{"choices":[{"message":{"content":"Machine learning is a subset of AI."}}]}`)
 	ttlSeconds := 300
 
-	err := cache.AddEntry(requestID, model, query, requestBody, responseBody, ttlSeconds)
+	err := cache.AddEntry(context.Background(), requestID, model, query, requestBody, responseBody, ttlSeconds)
 	require.NoError(t, err)
 
 	// Wait for indexing with retry logic
@@ -210,7 +210,7 @@ func TestValkeyCacheIntegration_FindSimilarWithThreshold(t *testing.T) {
 	responseBody := []byte(`{"choices":[{"message":{"content":"Neural networks are computing systems."}}]}`)
 	ttlSeconds := 300
 
-	err := cache.AddEntry(requestID, model, query, requestBody, responseBody, ttlSeconds)
+	err := cache.AddEntry(context.Background(), requestID, model, query, requestBody, responseBody, ttlSeconds)
 	require.NoError(t, err)
 
 	// Wait for indexing
@@ -376,7 +376,7 @@ func TestValkeyCacheIntegration_TTLExpiration(t *testing.T) {
 	responseBody := []byte(`{"choices":[{"message":{"content":"Short lived response"}}]}`)
 	ttlSeconds := 2 // 2 seconds
 
-	err := cache.AddEntry(requestID, model, query, requestBody, responseBody, ttlSeconds)
+	err := cache.AddEntry(context.Background(), requestID, model, query, requestBody, responseBody, ttlSeconds)
 	require.NoError(t, err)
 
 	// Wait for indexing
@@ -404,7 +404,7 @@ func TestValkeyCacheIntegration_GetStats(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		requestID := fmt.Sprintf("req_stats_%d", i)
 		query := fmt.Sprintf("Test query %d", i)
-		err := cache.AddEntry(requestID, "gpt-4", query, []byte("{}"), []byte("{}"), 300)
+		err := cache.AddEntry(context.Background(), requestID, "gpt-4", query, []byte("{}"), []byte("{}"), 300)
 		require.NoError(t, err)
 	}
 
@@ -424,7 +424,7 @@ func TestValkeyCacheIntegration_Close(t *testing.T) {
 	err := cache.Close()
 	assert.NoError(t, err, "Close should succeed")
 
-	err = cache.CheckConnection()
+	err = cache.CheckConnection(context.Background())
 	assert.Error(t, err, "Connection check should fail after close")
 }
 
@@ -464,7 +464,7 @@ func TestValkeyCacheIntegration_DisabledCache(t *testing.T) {
 	defer func() { _ = cache.Close() }()
 
 	// All operations should return nil/false when disabled
-	err = cache.AddEntry("req_1", "gpt-4", "test", []byte("{}"), []byte("{}"), 300)
+	err = cache.AddEntry(context.Background(), "req_1", "gpt-4", "test", []byte("{}"), []byte("{}"), 300)
 	assert.NoError(t, err, "AddEntry should not error when disabled")
 
 	err = cache.AddPendingRequest("req_2", "gpt-4", "test", []byte("{}"), 300)
@@ -474,7 +474,7 @@ func TestValkeyCacheIntegration_DisabledCache(t *testing.T) {
 	assert.NoError(t, err, "FindSimilar should not error when disabled")
 	assert.False(t, hit, "FindSimilar should return false when disabled")
 
-	err = cache.CheckConnection()
+	err = cache.CheckConnection(context.Background())
 	assert.NoError(t, err, "CheckConnection should not error when disabled")
 }
 
@@ -484,7 +484,7 @@ func TestValkeyCacheIntegration_TTLZeroSkipsCaching(t *testing.T) {
 
 	// Test AddEntry with TTL=0 (should skip caching)
 	requestID := "req_ttl_zero_1"
-	err := cache.AddEntry(requestID, "gpt-4", "test query", []byte("{}"), []byte("{}"), 0)
+	err := cache.AddEntry(context.Background(), requestID, "gpt-4", "test query", []byte("{}"), []byte("{}"), 0)
 	assert.NoError(t, err, "AddEntry with TTL=0 should not error")
 
 	// Test AddPendingRequest with TTL=0 (should skip caching)
@@ -530,7 +530,7 @@ func TestValkeyCacheIntegration_FLATIndexType(t *testing.T) {
 	defer func() { _ = cache.Close() }()
 
 	// Add an entry and verify it works
-	err = cache.AddEntry("req_flat_1", "gpt-4", "test flat index", []byte("{}"), []byte(`{"result":"flat"}`), 300)
+	err = cache.AddEntry(context.Background(), "req_flat_1", "gpt-4", "test flat index", []byte("{}"), []byte(`{"result":"flat"}`), 300)
 	assert.NoError(t, err, "AddEntry should work with FLAT index")
 
 	time.Sleep(200 * time.Millisecond)
@@ -558,7 +558,7 @@ func TestValkeyCacheIntegration_ConcurrentOperations(t *testing.T) {
 				requestID := fmt.Sprintf("req_concurrent_%d_%d", id, j)
 				query := fmt.Sprintf("concurrent query %d %d", id, j)
 
-				err := cache.AddEntry(requestID, "gpt-4", query, []byte("{}"), []byte(fmt.Sprintf(`{"id":%d}`, id)), 300)
+				err := cache.AddEntry(context.Background(), requestID, "gpt-4", query, []byte("{}"), []byte(fmt.Sprintf(`{"id":%d}`, id)), 300)
 				if err != nil {
 					errChan <- err
 				}
@@ -607,7 +607,7 @@ func TestValkeyCacheIntegration_MultipleEntries(t *testing.T) {
 
 	for i, entry := range entries {
 		storedResponses[i] = fmt.Sprintf(`{"response":"%s"}`, entry.response)
-		err := cache.AddEntry(
+		err := cache.AddEntry(context.Background(),
 			entry.requestID,
 			"gpt-4",
 			entry.query,
@@ -625,7 +625,7 @@ func TestValkeyCacheIntegration_MultipleEntries(t *testing.T) {
 	// conversion regression reports all three queries rather than aborting on
 	// the first one.
 	for i, entry := range entries {
-		result, err := cache.LookupSimilarWithThreshold("gpt-4", entry.query, 0.8)
+		result, err := cache.LookupSimilarWithThreshold(context.Background(), "gpt-4", entry.query, 0.8)
 		if !assert.NoError(t, err, "FindSimilar should not error for %s", entry.query) {
 			continue
 		}
@@ -692,12 +692,12 @@ func newIsolatedValkeyCache(t *testing.T, label, metricType string, threshold fl
 func TestValkeyCacheIntegration_L2MetricType(t *testing.T) {
 	cache := newIsolatedValkeyCache(t, "l2", "L2", 0.5)
 
-	err := cache.AddEntry("req_l2_1", "gpt-4", "test L2 metric", []byte("{}"), []byte(`{"result":"L2"}`), 300)
+	err := cache.AddEntry(context.Background(), "req_l2_1", "gpt-4", "test L2 metric", []byte("{}"), []byte(`{"result":"L2"}`), 300)
 	assert.NoError(t, err, "AddEntry should work with L2 metric")
 
 	time.Sleep(200 * time.Millisecond)
 
-	result, err := cache.LookupSimilarWithThreshold("gpt-4", "test L2 metric", 0.5)
+	result, err := cache.LookupSimilarWithThreshold(context.Background(), "gpt-4", "test L2 metric", 0.5)
 	require.NoError(t, err, "FindSimilar should work with L2 metric")
 	require.True(t, result.Found, "repeating the cached query verbatim must hit (similarity=%.4f, threshold=0.5)",
 		result.Similarity)
@@ -707,12 +707,12 @@ func TestValkeyCacheIntegration_L2MetricType(t *testing.T) {
 func TestValkeyCacheIntegration_IPMetricType(t *testing.T) {
 	cache := newIsolatedValkeyCache(t, "ip", "IP", 0.5)
 
-	err := cache.AddEntry("req_ip_1", "gpt-4", "test IP metric", []byte("{}"), []byte(`{"result":"IP"}`), 300)
+	err := cache.AddEntry(context.Background(), "req_ip_1", "gpt-4", "test IP metric", []byte("{}"), []byte(`{"result":"IP"}`), 300)
 	assert.NoError(t, err, "AddEntry should work with IP metric")
 
 	time.Sleep(200 * time.Millisecond)
 
-	result, err := cache.LookupSimilarWithThreshold("gpt-4", "test IP metric", 0.5)
+	result, err := cache.LookupSimilarWithThreshold(context.Background(), "gpt-4", "test IP metric", 0.5)
 	require.NoError(t, err, "FindSimilar should work with IP metric")
 	require.True(t, result.Found, "repeating the cached query verbatim must hit (similarity=%.4f, threshold=0.5)",
 		result.Similarity)

--- a/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
+++ b/src/semantic-router/pkg/extproc/cache_personalization_pipeline_test.go
@@ -27,14 +27,22 @@ type spyCache struct {
 	pendingQuery string
 }
 
-func (s *spyCache) IsEnabled() bool                                            { return true }
-func (s *spyCache) CheckConnection() error                                     { return nil }
-func (s *spyCache) LastSimilarity() float32                                    { return 0 }
-func (s *spyCache) Close() error                                               { return nil }
-func (s *spyCache) GetStats() cache.CacheStats                                 { return cache.CacheStats{} }
-func (s *spyCache) UpdateWithResponse(string, []byte, int) error               { return nil }
-func (s *spyCache) AddEntry(string, string, string, []byte, []byte, int) error { return nil }
-func (s *spyCache) FindSimilar(string, string) ([]byte, bool, error)           { return nil, false, nil }
+func (s *spyCache) IsEnabled() bool                              { return true }
+func (s *spyCache) CheckConnection(context.Context) error        { return nil }
+func (s *spyCache) Close() error                                 { return nil }
+func (s *spyCache) GetStats() cache.CacheStats                   { return cache.CacheStats{} }
+func (s *spyCache) UpdateWithResponse(string, []byte, int) error { return nil }
+func (s *spyCache) AddEntry(context.Context, string, string, string, []byte, []byte, int) error {
+	return nil
+}
+
+func (s *spyCache) FindSimilar(string, string) ([]byte, bool, error) {
+	return nil, false, nil
+}
+
+func (s *spyCache) FindSimilarWithThreshold(string, string, float32) ([]byte, bool, error) {
+	return nil, false, nil
+}
 
 func (s *spyCache) AddPendingRequest(_ string, _ string, query string, _ []byte, _ int) error {
 	s.pendingAdded = true
@@ -42,16 +50,7 @@ func (s *spyCache) AddPendingRequest(_ string, _ string, query string, _ []byte,
 	return nil
 }
 
-func (s *spyCache) FindSimilarWithThreshold(_ string, query string, _ float32) ([]byte, bool, error) {
-	s.findCalled = true
-	s.findQuery = query
-	if s.shouldHit {
-		return s.hitResponse, true, nil
-	}
-	return nil, false, nil
-}
-
-func (s *spyCache) LookupSimilarWithThreshold(_ string, query string, _ float32) (cache.LookupResult, error) {
+func (s *spyCache) LookupSimilarWithThreshold(_ context.Context, _ string, query string, _ float32) (cache.LookupResult, error) {
 	s.findCalled = true
 	s.findQuery = query
 	if s.shouldHit {

--- a/src/semantic-router/pkg/extproc/processor_res_cache.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache.go
@@ -407,6 +407,18 @@ func semanticCacheWriteAllowed(ctx *RequestContext) bool {
 	return ctx != nil && (ctx.CacheSemanticSafe || ctx.CacheExactFingerprint == "")
 }
 
+// cacheWriteContext detaches a cache write from request cancellation while
+// keeping the trace values. The response being stored is already computed, so
+// abandoning the write when the client disconnects would discard a cache fill
+// for no saved work. Cancellation is honored on the read path instead, where
+// the work is still ahead of the request (#2473).
+func cacheWriteContext(ctx *RequestContext) context.Context {
+	if ctx == nil || ctx.TraceContext == nil {
+		return context.Background()
+	}
+	return context.WithoutCancel(ctx.TraceContext)
+}
+
 func (r *OpenAIRouter) addSemanticCacheEntry(
 	ctx *RequestContext,
 	responseBody []byte,
@@ -425,10 +437,7 @@ func (r *OpenAIRouter) addSemanticCacheEntry(
 		identity = responseCacheIdentity(ctx, requestModel)
 	}
 	identity.SemanticQuery = query
-	writeContext := ctx.TraceContext
-	if writeContext == nil {
-		writeContext = context.Background()
-	}
+	writeContext := cacheWriteContext(ctx)
 	service := r.responseCacheService()
 	if service == nil {
 		return nil

--- a/src/semantic-router/pkg/extproc/processor_res_cache_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_test.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -38,7 +39,7 @@ type mockStreamingCache struct {
 
 func (m *mockStreamingCache) IsEnabled() bool { return true }
 
-func (m *mockStreamingCache) CheckConnection() error { return nil }
+func (m *mockStreamingCache) CheckConnection(context.Context) error { return nil }
 
 func (m *mockStreamingCache) AddPendingRequest(
 	_ string,
@@ -61,6 +62,7 @@ func (m *mockStreamingCache) UpdateWithResponse(requestID string, responseBody [
 }
 
 func (m *mockStreamingCache) AddEntry(
+	_ context.Context,
 	_ string,
 	model string,
 	query string,
@@ -90,6 +92,7 @@ func (m *mockStreamingCache) FindSimilarWithThreshold(
 }
 
 func (m *mockStreamingCache) LookupSimilarWithThreshold(
+	_ context.Context,
 	model string,
 	_ string,
 	_ float32,
@@ -101,7 +104,7 @@ func (m *mockStreamingCache) LookupSimilarWithThreshold(
 
 func (m *mockStreamingCache) LastSimilarity() float32 { return 0 }
 
-func (m *mockStreamingCache) FindExact(_ string, _ string) (cache.LookupResult, error) {
+func (m *mockStreamingCache) FindExact(_ context.Context, _ string, _ string) (cache.LookupResult, error) {
 	m.exactFindCalled = true
 	return cache.LookupResult{
 		ResponseBody: m.exactResponse,
@@ -111,6 +114,7 @@ func (m *mockStreamingCache) FindExact(_ string, _ string) (cache.LookupResult, 
 }
 
 func (m *mockStreamingCache) AddExact(
+	_ context.Context,
 	_ string,
 	_ string,
 	_ []byte,
@@ -638,4 +642,24 @@ func TestBuildReconstructedStreamingResponsePreservesChoiceIndexes(t *testing.T)
 	assert.Equal(t, 0, decoded.Choices[0].Index)
 	assert.Equal(t, 1, decoded.Choices[1].Index)
 	assert.Equal(t, "length", decoded.Choices[1].FinishReason)
+}
+
+// The write path must outlive the request that produced it: the response is
+// already computed, so a client disconnect has no work left to save (#2473).
+func TestCacheWriteContextSurvivesRequestCancellation(t *testing.T) {
+	type ctxKey string
+	const traceKey ctxKey = "trace"
+
+	parent, cancel := context.WithCancel(context.WithValue(context.Background(), traceKey, "span-1"))
+	writeCtx := cacheWriteContext(&RequestContext{TraceContext: parent})
+	cancel()
+
+	require.NoError(t, writeCtx.Err(), "a cancelled request must not cancel its cache write")
+	assert.Equal(t, "span-1", writeCtx.Value(traceKey), "trace values must survive the detach")
+	assert.ErrorIs(t, parent.Err(), context.Canceled, "the request context itself still cancels")
+}
+
+func TestCacheWriteContextFallsBackToBackground(t *testing.T) {
+	assert.Equal(t, context.Background(), cacheWriteContext(nil))
+	assert.Equal(t, context.Background(), cacheWriteContext(&RequestContext{}))
 }

--- a/src/semantic-router/pkg/extproc/req_filter_cache.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache.go
@@ -311,6 +311,8 @@ func (r *OpenAIRouter) performCacheLookup(
 		ctx.TraceContext = spanCtx
 		return response, true
 	} else {
+		// A semantic miss may expose this lookup's rejected-candidate score on the
+		// debug and Replay surfaces; LookupResult keeps it request-owned.
 		ctx.VSRCacheSimilarity = lookupResult.Similarity
 		metrics.RecordCachePluginMiss(requestDecisionStateKey(ctx), "response_cache")
 		tracing.EndPluginSpan(span, "success", lookupTime, "cache_miss")

--- a/src/semantic-router/pkg/extproc/req_filter_cache_exact.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache_exact.go
@@ -141,10 +141,7 @@ func (r *OpenAIRouter) updateExactResponseCache(
 	if identity.ExactFingerprint == "" {
 		identity = responseCacheIdentity(ctx, ctx.CacheRequestModel)
 	}
-	writeContext := ctx.TraceContext
-	if writeContext == nil {
-		writeContext = context.Background()
-	}
+	writeContext := cacheWriteContext(ctx)
 	if err := service.StoreExact(writeContext, cache.CacheWrite{
 		Identity:     identity,
 		RequestID:    ctx.RequestID,

--- a/tools/redis/redis-cache.go
+++ b/tools/redis/redis-cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -43,7 +44,7 @@ func newRedisConfig() *config.RedisConfig {
 	return cfg
 }
 
-func demoCacheOperations(cacheBackend cache.CacheBackend) {
+func demoCacheOperations(ctx context.Context, cacheBackend cache.LegacyCacheBackend) {
 	model := "gpt-4"
 	query := "What is the capital of France?"
 	requestID := "req-12345"
@@ -51,7 +52,7 @@ func demoCacheOperations(cacheBackend cache.CacheBackend) {
 	responseBody := []byte(`{"choices":[{"message":{"content":"The capital of France is Paris."}}]}`)
 
 	fmt.Println("\n2. Adding entry to cache...")
-	err := cacheBackend.AddEntry(requestID, model, query, requestBody, responseBody, 3600)
+	err := cacheBackend.AddEntry(ctx, requestID, model, query, requestBody, responseBody, 3600)
 	if err != nil {
 		log.Fatalf("Failed to add entry: %v", err)
 	}
@@ -94,7 +95,7 @@ func demoCacheOperations(cacheBackend cache.CacheBackend) {
 	}
 }
 
-func demoPendingRequestWorkflow(cacheBackend cache.CacheBackend) {
+func demoPendingRequestWorkflow(ctx context.Context, cacheBackend cache.LegacyCacheBackend) {
 	model := "gpt-4"
 	fmt.Println("\n6. Pending Request Workflow:")
 	newRequestID := "req-67890"
@@ -132,7 +133,7 @@ func demoPendingRequestWorkflow(cacheBackend cache.CacheBackend) {
 	}
 }
 
-func printFinalStats(cacheBackend cache.CacheBackend) {
+func printFinalStats(cacheBackend cache.LegacyCacheBackend) {
 	fmt.Println("\n7. Final Statistics:")
 	stats := cacheBackend.GetStats()
 	fmt.Printf("  Total Entries: %d\n", stats.TotalEntries)
@@ -174,7 +175,8 @@ func main() {
 		fmt.Printf("⚠ Found %d existing entries in cache (from previous runs)\n", initialStats.TotalEntries)
 	}
 
-	demoCacheOperations(cacheBackend)
-	demoPendingRequestWorkflow(cacheBackend)
+	ctx := context.Background()
+	demoCacheOperations(ctx, cacheBackend)
+	demoPendingRequestWorkflow(ctx, cacheBackend)
 	printFinalStats(cacheBackend)
 }

--- a/tools/valkey/valkey-cache.go
+++ b/tools/valkey/valkey-cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -43,7 +44,7 @@ func newValkeyConfig() *config.ValkeyConfig {
 	return cfg
 }
 
-func demoCacheOperations(cacheBackend cache.CacheBackend) {
+func demoCacheOperations(ctx context.Context, cacheBackend cache.LegacyCacheBackend) {
 	model := "gpt-4"
 	query := "What is the capital of France?"
 	requestID := "req-12345"
@@ -51,7 +52,7 @@ func demoCacheOperations(cacheBackend cache.CacheBackend) {
 	responseBody := []byte(`{"choices":[{"message":{"content":"The capital of France is Paris."}}]}`)
 
 	fmt.Println("\n2. Adding entry to cache...")
-	err := cacheBackend.AddEntry(requestID, model, query, requestBody, responseBody, 3600)
+	err := cacheBackend.AddEntry(ctx, requestID, model, query, requestBody, responseBody, 3600)
 	if err != nil {
 		log.Fatalf("Failed to add entry: %v", err)
 	}
@@ -94,7 +95,7 @@ func demoCacheOperations(cacheBackend cache.CacheBackend) {
 	}
 }
 
-func demoPendingRequestWorkflow(cacheBackend cache.CacheBackend) {
+func demoPendingRequestWorkflow(ctx context.Context, cacheBackend cache.LegacyCacheBackend) {
 	model := "gpt-4"
 	fmt.Println("\n6. Pending Request Workflow:")
 	newRequestID := "req-67890"
@@ -132,7 +133,7 @@ func demoPendingRequestWorkflow(cacheBackend cache.CacheBackend) {
 	}
 }
 
-func printFinalStats(cacheBackend cache.CacheBackend) {
+func printFinalStats(cacheBackend cache.LegacyCacheBackend) {
 	fmt.Println("\n7. Final Statistics:")
 	stats := cacheBackend.GetStats()
 	fmt.Printf("  Total Entries: %d\n", stats.TotalEntries)
@@ -176,7 +177,8 @@ func main() {
 		fmt.Printf("⚠ Found %d existing entries in cache (from previous runs)\n", initialStats.TotalEntries)
 	}
 
-	demoCacheOperations(cacheBackend)
-	demoPendingRequestWorkflow(cacheBackend)
+	ctx := context.Background()
+	demoCacheOperations(ctx, cacheBackend)
+	demoPendingRequestWorkflow(ctx, cacheBackend)
 	printFinalStats(cacheBackend)
 }


### PR DESCRIPTION
Closes #2473

## The problem

Every cache backend calls its driver with `context.Background()`. On `main` today:

```
$ grep -c 'context.Background()' src/semantic-router/pkg/cache/*.go   # non-test
8 valkey_cache.go   7 redis_cache.go   7 milvus_cache.go   6 qdrant_cache.go
3 exact_cache_milvus.go   2 exact_cache_{valkey,redis,qdrant}.go   ...
```

Two consequences:

**A storage call outlives the request that issued it.** When Milvus, Redis, Qdrant or Valkey stalls, the query has no deadline and no cancellation tied to anything: the goroutine and its connection stay pinned until the driver's own timeout — if it has one — fires. One per abandoned request, with nothing reclaiming them. This is the failure mode #2222 tracks.

**A constructor that fails half-way leaks the client it dialed.** The two failure paths in `NewRedisCache` do not agree with each other:

```go
if err := cache.CheckConnection(); err != nil {
    logging.Debugf("RedisCache: failed to connect: %v", err)
    return nil, err                          // client never closed
}
if err := cache.initializeIndex(); err != nil {
    _ = redisClient.Close()                  // this path does close it
    return nil, fmt.Errorf(...)
}
```

`NewValkeyCache` has the same asymmetry. A retrying config reload against an unreachable backend accumulates one connection pool per attempt.

## What this changes

`CheckConnection`, `AddEntry`, `LookupSimilarWithThreshold`, `FindExact` and `AddExact` take a `context.Context` and hand it to the driver, across all six backends (in-memory, hybrid, Milvus, Qdrant, Redis, Valkey) plus the `windows || !cgo` stubs. The root is the ext_proc stream context (`processor_core.go`: `TraceContext: stream.Context()`), which #2813 already wired into the lookup and write paths — so the storage call is now bounded by the request that owns it rather than by nothing at all.

Both constructors release a partially built client through a `releaseOnFailure` seam, so the two failure paths agree.

## Cancellation is deliberately not symmetric

Threading a context is the mechanism; where it is honored is a decision:

- **Read path honors it.** A lookup is work still ahead of the request. An abandoned request stops the storage call instead of running to completion on a connection nobody is waiting for, and a canceled or expired context is reported as an error rather than as a fail-open miss.
- **Write path detaches from it.** The response being stored has already been computed, so honoring a client disconnect there would discard a cache fill without saving any work. Both response-cache write paths use `context.WithoutCancel`, which keeps the trace values so the write stays on the request's span.

Embedding is a synchronous CGO call and cannot be interrupted mid-flight, so cancellation there is best-effort: checked once before the embed starts and again before any state is published. The two-phase legacy methods (`AddPendingRequest` / `UpdateWithResponse`) stay context-free and forward `context.Background()` to the context-aware core — they are not on a request path, so there is no caller context to honor.

## Also in scope (remaining #2488 review items)

- **Stub alignment.** The `windows || !cgo` stubs stay assignable to `CacheBackend`, with compile-time interface assertions so the next contract change fails at the definition site instead of in a downstream build.
- **Hybrid fetch failures.** A cross-model HNSW candidate is a miss; a real Milvus fetch failure is now an error instead of hiding behind the cache's fail-open path, which both masked the outage and let an error path publish a hit-level score.
- **Miss scores aligned across all six backends.** A below-threshold miss keeps reporting its rejected candidate — that score is this request's own measurement now that it rides `LookupResult` instead of shared backend state, and it is what makes a miss diagnosable against the threshold on the debug and Replay surfaces. An error still carries no score.

## Tests

Unit (`cd src/semantic-router && go test -race ./pkg/cache/... ./pkg/extproc`):

- Barrier-controlled concurrent lookups on one backend, asserting each result carries its own score.
- Cancellation before the embed and during the embed, on both the lookup and the write path, including the assertion that a canceled write publishes no entry.
- A table over all four remote backends proving each search path surfaces the request cancellation rather than a fail-open miss.
- The detached write context surviving a canceled request while keeping its trace values, and falling back to `Background` when a request has none.
- Constructor-failure cleanup for Redis.
- Hybrid regression coverage separating a cross-model miss from a fetch failure.

E2E (`semantic-cache` testcase): the profile previously printed a hit-rate summary and returned `nil` no matter what happened underneath. It now has a verdict — priming failures are collected instead of skipped, a run with zero executed requests fails as unasserted, and each request's `x-vsr-cache-similarity` is validated (a hit must carry a score in `(0,1]`; a miss may omit the header or report its best rejected candidate in `[0,1)`). Hit rate stays a measurement rather than a gate, since `acceptance_contracts.go` already enforces a floor for it.

## Limits worth stating

- The **E2E cancellation probe pins the end-to-end contract the issue asks for, not the backend change that motivated it**: a response that never arrives writes nothing either way, so the probe would also pass before the backends took a context. The falsifiable cancellation coverage lives at unit level in `pkg/cache`. The probe runs last so it cannot disturb the hit-rate measurement, and a request that beats the cancel window is reported and skipped, so it degrades to a no-op instead of flaking when upstream answers quickly.
- **Constructor cleanup is proven end to end only on the Redis path.** Valkey's client builder rejects a refused dial before any client exists, so its test pins that instead of the release.
- The unexported `searchFn` / `queryByIDFn` / `closeClient` fields are **test seams**. No production path sets them; they exist because constructor cleanup and backend-search failure are not observable from outside a constructor that returns `(nil, err)`.
- `runBenchmarkScenario` is split into two helpers — the `USE_HNSW` override and the bounded-concurrency query loop — so the touched file passes the repository structure gate and the changed-file `funlen` budget. The extracted code is unchanged logic.

## Relationship to #2813

#2813 made the lookup result request-owned (`LookupResult`, no shared similarity state) and wired the stream context into the extproc lookup and write paths. It stopped at the extproc boundary. This PR carries that context the rest of the way into the backends, which is the half of #2473 that remains.
