### PR TITLE
[Router] register lettucedect-v2-mmbert-base as a hallucination detector model

### DIFF
--- a/src/semantic-router/pkg/config/registry.go
+++ b/src/semantic-router/pkg/config/registry.go
@@ -150,6 +150,19 @@ var DefaultModelRegistry = []ModelSpec{
 		Tags:             []string{"hallucination", "modernbert", "verification"},
 	},
 
+	// Hallucination Detection - Detector (multilingual)
+	{
+		LocalPath:        "models/lettucedect-v2-mmbert-base",
+		RepoID:           "KRLabsOrg/lettucedect-v2-mmbert-base",
+		Aliases:          []string{"hallucination-detector-multilingual", "lettucedect-v2-mmbert"},
+		Purpose:          PurposeHallucinationDetector,
+		Description:      "Multilingual mmBERT hallucination detector covering prose, code, tool output and structured documents",
+		ParameterSize:    "307M",
+		EmbeddingDim:     768,
+		MaxContextLength: 8192,
+		Tags:             []string{"hallucination", "mmbert", "multilingual", "verification"},
+	},
+
 	// Hallucination Detection - Explainer
 	{
 		LocalPath:        "models/mom-halugate-explainer",


### PR DESCRIPTION
Closes #2927

## Purpose

- **What does this PR change?**
  Adds a `pkg/config/registry.go` entry for `KRLabsOrg/lettucedect-v2-mmbert-base`, the multilingual mmBERT successor to `lettucedect-base-modernbert-en-v1` that the registry already ships as the hallucination detector. Without a row the model cannot be referenced by alias or auto-downloaded.
- **Why is this change needed?**
  The Candle path already supports the model — `TraditionalModernBertTokenClassifier::new` auto-detects the backbone through `ModernBertVariant::detect_from_config`, and this model's config (`vocab_size: 256000`, `position_embedding_type: sans_pos`, `max_position_embeddings: 8192`) resolves to `Multilingual`. Only the catalog entry was missing, so today the weights have to be placed on disk by hand.
- **Which module(s) does this affect?** `Router`

No loader, binding or default-configuration change: the default detector remains `models/mom-halugate-detector`.

## Test Plan

- `go build ./pkg/config/` and `go test ./pkg/config/ -count=1`
- `gofmt -l` and `go vet ./pkg/config/`
- End-to-end load through the Candle binding against freshly built bindings on current `main`, calling `InitHallucinationModel` and `DetectHallucinations` with the model.

## Test Result

- `go test ./pkg/config/ -count=1` — ok, 0.627s. `gofmt` clean, `go vet` clean.
- Detector load and inference:

```
context: "Section 8.2: Either party may terminate with thirty (30) days written notice."
answer:  "Either party may terminate with sixty (60) days written notice."

INIT_OK
detected=true confidence=0.953 spans=1
  span=" sixty (60) days written notice" conf=0.953
```

- Aliases (`hallucination-detector-multilingual`, `lettucedect-v2-mmbert`) do not collide with existing registry keys used by `ToLegacyRegistry`.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
