### PR TITLE
docs: sync MoM blog models with CLI catalog

### DIFF
--- a/website/blog/2026-07-21-vllm-sr-new-chapter-mom.md
+++ b/website/blog/2026-07-21-vllm-sr-new-chapter-mom.md
@@ -153,6 +153,8 @@ Open checkpoints can travel with the artifact; closed models remain authenticate
 
 Preferences become concrete when they are published as model identities. One MoM family can offer several operating points:
 
+The built-in identities currently shipped by the CLI are listed below. Run `vllm-sr model list` for the authoritative catalog state.
+
 | Model identity | Contract |
 | --- | --- |
 | `vllm-sr/mom-v1-blend` | Balance quality, latency, cost, and recovery across the configured model pool |
@@ -177,7 +179,7 @@ To an application, the full system remains an ordinary model call:
 That identity may select one model, escalate through a cascade, compare parallel answers, require grounding, or run a bounded workflow—without changing the external interface, version, or response contract.
 
 <p align="center">
-  <img src="/img/blog/vllm/2026-07-21-vllm-sr-new-chapter/preference-models.png" alt="One Mixture-of-Models family exposes flash, light, ultra, grounding, and security variants as individually versioned model identities" width="100%" />
+  <img src="/img/blog/vllm/2026-07-21-vllm-sr-new-chapter/preference-models.png" alt="One Mixture-of-Models family exposes blend, lite, flash, ultra, and vault variants as individually versioned model identities" width="100%" />
   <br />
   <em>Figure 7: Preferences are published as bounded, versioned model contracts—not hidden application-side routing presets.</em>
 </p>


### PR DESCRIPTION
## Summary

- identify `vllm-sr model list` as the source of truth for built-in MoM identities
- update the Figure 7 description to match `blend`, `lite`, `flash`, `ultra`, and `vault`

## Validation

- `make agent-report ENV=amd CHANGED_FILES="website/blog/2026-07-21-vllm-sr-new-chapter-mom.md"`
- `make agent-validate`
- `make agent-lint CHANGED_FILES="website/blog/2026-07-21-vllm-sr-new-chapter-mom.md"`