### PR TITLE
[Docs] add verified zh-Hans translations for core plugin tutorials

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/fast-response.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/fast-response.md
@@ -1,0 +1,42 @@
+---
+translation:
+  source_commit: "7c874be2"
+  source_file: "docs/tutorials/plugin/fast-response.md"
+  outdated: false
+---
+
+# 快速响应（Fast Response）
+
+## 概览
+
+`fast_response` 是一个路由局部插件，用于立即返回确定性的回退消息。
+
+## 主要优势
+
+- 当轻量级回退已经足够时，短路高成本路由。
+- 将过载处理行为限制在需要它的路由内。
+- 在配置中明确声明回退消息。
+
+## 解决什么问题？
+
+有些路由应优雅降级，而不是等待完整的模型处理路径。`fast_response` 为这些路由提供即时响应路径，同时不改变全局行为。
+
+## 何时使用
+
+- 路由在过载或维护期间需要低成本回退
+- 该流量类别可以接受确定性响应
+- 回退行为应仅作用于单个路由
+
+## 配置
+
+在 `routing.decisions[].plugins` 下添加该插件：
+
+```yaml
+plugins:
+  - type: fast_response
+    configuration:
+      message: The primary model is unavailable. Try again shortly.
+```
+
+该插件不会调用模型，也不会生成响应内容。消息中不得包含请求数据，并且不要将该插件用作身份验证或速率限制控制。插件本身不会测量过载状态；decision 必须匹配应接收回退响应的流量。完整示例见：
+[`config/fragments/plugin/fast-response/busy.yaml`](https://github.com/vllm-project/semantic-router/blob/main/config/fragments/plugin/fast-response/busy.yaml)。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/header-mutation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/header-mutation.md
@@ -1,0 +1,49 @@
+---
+translation:
+  source_commit: "7c874be2"
+  source_file: "docs/tutorials/plugin/header-mutation.md"
+  outdated: false
+---
+
+# Header 修改（Header Mutation）
+
+## 概览
+
+`header_mutation` 是一个路由局部插件，用于添加、更新或删除下游 header。
+
+## 主要优势
+
+- 将下游 header 策略限制在匹配的路由内。
+- 在一个插件中支持 add、update 和 delete 操作。
+- 适用于租户路由、调试和下游策略提示。
+
+## 解决什么问题？
+
+有些路由需要不同于路由器其他部分的下游 header。`header_mutation` 明确声明这种转换，而不是将其隐藏在代理或应用代码中。
+
+## 何时使用
+
+- 某个路由应在 header 中标记租户或套餐元数据
+- 下游服务需要路由专用的 header
+- 调试或来源 header 只应添加到选定流量
+
+## 配置
+
+在 `routing.decisions[].plugins` 下添加该插件：
+
+```yaml
+plugins:
+  - type: header_mutation
+    configuration:
+      add:
+        - name: X-Tenant-Tier
+          value: premium
+      update:
+        - name: X-Route-Source
+          value: semantic-router
+      delete:
+        - X-Debug-Trace
+```
+
+Header 值是静态配置，而不是模板。不得使用不受信任的请求元数据来构造身份或授权 header。完整示例见：
+[`config/fragments/plugin/header-mutation/tenant-routing.yaml`](https://github.com/vllm-project/semantic-router/blob/main/config/fragments/plugin/header-mutation/tenant-routing.yaml)。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/image-gen.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/image-gen.md
@@ -1,0 +1,48 @@
+---
+translation:
+  source_commit: "7c874be2"
+  source_file: "docs/tutorials/plugin/image-gen.md"
+  outdated: false
+---
+
+# 图像生成（Image Generation）
+
+## 概览
+
+`image_gen` 是一个路由局部插件，用于将匹配的路由移交给图像生成后端。
+
+## 主要优势
+
+- 将多模态或图像生成行为限制在对应路由内。
+- 在配置中清晰公开后端详情。
+- 让一个路由器同时承载文本和图像路由，而不会混淆两种行为。
+
+## 解决什么问题？
+
+有些路由不应遵循标准 Chat Completions 流程。`image_gen` 为需要图像生成的路由明确声明这一移交过程。
+
+## 何时使用
+
+- 匹配的路由应调用图像生成后端
+- 路由需要后端专用的生成设置
+- 纯文本路由不应受到影响
+
+## 配置
+
+在 `routing.decisions[].plugins` 下添加该插件：
+
+```yaml
+plugins:
+  - type: image_gen
+    configuration:
+      enabled: true
+      backend: vllm_omni
+      backend_config:
+        base_url: http://image-router:8005
+        model: Qwen/Qwen-Image
+        num_inference_steps: 28
+        cfg_scale: 4.5
+```
+
+选定的后端会接收图像提示词和生成参数。应使用经过身份验证的可信端点，并在该插件之前应用请求侧安全策略。完整示例见：
+[`config/fragments/plugin/image-gen/basic.yaml`](https://github.com/vllm-project/semantic-router/blob/main/config/fragments/plugin/image-gen/basic.yaml)。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/response-jailbreak.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/response-jailbreak.md
@@ -1,0 +1,44 @@
+---
+translation:
+  source_commit: "7c874be2"
+  source_file: "docs/tutorials/plugin/response-jailbreak.md"
+  outdated: false
+---
+
+# 响应越狱检测（Response Jailbreak）
+
+## 概览
+
+`response_jailbreak` 是一个路由局部插件，用于在模型响应返回前对其进行筛查。
+
+## 主要优势
+
+- 为敏感路由增加最终的响应侧越狱检查。
+- 在配置中明确声明处置策略。
+- 补充请求侧安全机制，而不是取代它。
+
+## 解决什么问题？
+
+即使请求被正确路由，生成的回答仍可能需要最终安全关卡。`response_jailbreak` 为对应路由提供明确的输出筛查步骤。
+
+## 何时使用
+
+- 路由需要最终的响应侧越狱筛查
+- 输出应在返回前被拦截，或通过响应 header 标记
+- 仅靠请求侧筛查不足以满足该工作负载的要求
+
+## 配置
+
+在 `routing.decisions[].plugins` 下添加该插件：
+
+```yaml
+plugins:
+  - type: response_jailbreak
+    configuration:
+      enabled: true
+      threshold: 0.85
+      action: block
+```
+
+该插件使用已配置的 prompt-guard 运行时处理生成的响应文本。它会增加延迟，也可能产生误报，因此应校准阈值，并根据策略选择 `block` 或仅通过 header 处理。完整示例见：
+[`config/fragments/plugin/response-jailbreak/strict.yaml`](https://github.com/vllm-project/semantic-router/blob/main/config/fragments/plugin/response-jailbreak/strict.yaml)。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/system-prompt.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/system-prompt.md
@@ -1,0 +1,44 @@
+---
+translation:
+  source_commit: "7c874be2"
+  source_file: "docs/tutorials/plugin/system-prompt.md"
+  outdated: false
+---
+
+# 系统提示词（System Prompt）
+
+## 概览
+
+`system_prompt` 是一个路由局部插件，用于在匹配的流量中插入或修改系统提示词。
+
+## 主要优势
+
+- 将指令塑形限制在对应路由内。
+- 明确声明提示词模式，而不是将其隐藏在应用代码中。
+- 适用于专家、角色或工作流专用路由。
+
+## 解决什么问题？
+
+有些路由需要不同于路由器默认值的指令层。`system_prompt` 允许这些路由附加额外的提示词上下文，同时不影响无关流量。
+
+## 何时使用
+
+- 某个路由需要专家或特定角色的指令层
+- 提示词插入应在 decision 匹配后进行
+- 提示词策略应在路由配置中保持可见
+
+## 配置
+
+在 `routing.decisions[].plugins` 下添加该插件：
+
+```yaml
+plugins:
+  - type: system_prompt
+    configuration:
+      enabled: true
+      mode: insert
+      system_prompt: You are a domain expert. Answer precisely and state tradeoffs.
+```
+
+插入的文本会发送给选定的模型，并可能改变缓存标识和模型行为。不得在其中放入 secret 或不受信任的调用方文本。完整示例见：
+[`config/fragments/plugin/system-prompt/expert.yaml`](https://github.com/vllm-project/semantic-router/blob/main/config/fragments/plugin/system-prompt/expert.yaml)。


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #2932
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->

## Purpose

- Add complete Simplified Chinese (`zh-Hans`) locale overrides for five core plugin tutorials:
  - Fast Response
  - System Prompt
  - Response Jailbreak
  - Image Generation
  - Header Mutation
- Translate the current English sources rather than restoring the previously removed, outdated translations.
- Preserve all YAML examples, configuration keys and values, plugin names, safety constraints, URLs, and link targets.
- Record source commit `7c874be2` and set `translation.outdated: false` after full-page parity review.
- Improve localized documentation coverage:
  - Translated overrides: `1` → `6`
  - English fallback pages: `157` → `152`
- This is a Docs-only change and does not modify plugin runtime behavior, configuration contracts, or English fallback behavior.
- Affected module: `Docs`.

## Test Plan

- Build every documentation locale and validate localized routes and links:

  ```bash
  cd website
  npm run build
  ```

- Run the repository documentation lint and structural checks:

  ```bash
  make agent-lint CHANGED_FILES="website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/fast-response.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/system-prompt.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/response-jailbreak.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/image-gen.md,website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorials/plugin/header-mutation.md"
  ```

- Validate the tutorial taxonomy against the router configuration hierarchy:

  ```bash
  cd src/semantic-router
  go test -count=1 ./pkg/config \
    -run TestLatestTutorialTaxonomyMatchesConfigHierarchy
  ```

- Audit locale overrides, English fallback coverage, and translation metadata:

  ```bash
  make docs-check-translations
  ```

- Review each translation against its English source for heading, code-block, link-target, and technical-content parity.

## Test Result

- `npm run build`: passed for English and `zh-Hans`.
  - All five localized routes were generated successfully.
  - No new broken links were introduced.
- `make agent-lint CHANGED_FILES="..."`: passed.
- `go test -count=1 ./pkg/config -run TestLatestTutorialTaxonomyMatchesConfigHierarchy`: passed.
- Repository Markdownlint: passed.
- `git diff --check`: passed.
- Editor diagnostics: no errors in the five translated files.
- Independent full-page reviews: passed for all five pages.
- Per-page parity checks confirmed:
  - `source_commit: "7c874be2"` matches each latest English source commit.
  - Every `source_file` references the corresponding English document.
  - Every translation has `outdated: false`.
  - Heading levels, YAML blocks, lists, URLs, and link targets match the English sources.
- `make docs-check-translations`: passed.
  - Translated and likely synchronized: `6`
  - English fallback: `152`
  - Outdated translations: `0`
  - Metadata issues: `0`
  - Metadata verification required: `0`
  - Status mismatches: `0`
- Existing non-blocking build warnings remain for blog metadata, KaTeX Unicode handling, and webpack dependency analysis.
- No remaining blocker is known for this Docs-only change.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes (not applicable; Docs only)
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.