### PR TITLE
[Docs] Right-align contributor leaderboard controls

### DIFF
--- a/website/src/pages/community/contributors.module.css
+++ b/website/src/pages/community/contributors.module.css
@@ -148,9 +148,15 @@
 
 .sectionHeader {
   display: flex;
+  width: 100%;
   gap: 1rem;
   align-items: end;
   justify-content: space-between;
+}
+
+.sectionHeader > div:first-child {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .sectionHeader h2 {
@@ -176,9 +182,14 @@
 }
 
 .sectionControls {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  flex: 0 0 17rem;
   gap: 0.85rem;
-  flex-wrap: wrap;
+  align-items: end;
+  width: 100%;
+  max-width: 17rem;
+  margin-left: auto;
 }
 
 .rangeSelectLabel {
@@ -193,6 +204,7 @@
   font-size: 0.68rem;
   font-weight: 850;
   letter-spacing: 0.1em;
+  text-align: right;
   text-transform: uppercase;
 }
 
@@ -210,6 +222,7 @@
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.82rem;
   font-weight: 850;
+  text-align: right;
   text-transform: uppercase;
   appearance: none;
   cursor: pointer;
@@ -503,6 +516,9 @@
 
   .sectionControls {
     width: 100%;
+    max-width: none;
+    margin-left: 0;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .rankListHeader {


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #2940
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->

## Purpose

Improve the layout of the `Range` and `Sort by` controls on the contributor leaderboard page.

This change:

- keeps the two controls vertically stacked;
- aligns the control group with the right edge of the leaderboard;
- right-aligns the labels and selected values;
- removes the remaining label spacing from the right edge;
- preserves the full-width, single-column layout on mobile.

The change is limited to the contributor leaderboard CSS module under the website frontend.

## Test Plan

Build the English documentation site:

```bash
cd website
npx docusaurus build --locale en
```

Manually inspect `/community/contributors/` at:

- desktop viewport: `1907x768`;
- mobile viewport: `390x844`.

Verify that:

- `Range` and `Sort by` remain vertically stacked;
- both controls align with the leaderboard's right edge;
- labels and selected values are right-aligned;
- the labels have no remaining gap from the right edge;
- the page has no horizontal overflow.

## Test Result

- The English Docusaurus build completed successfully.
- The control group and leaderboard right edges differ by `0px`.
- The `Range` and `Sort by` label gaps from the right edge are both `0px`.
- Both controls remain vertically stacked.
- No horizontal overflow was detected at the tested desktop and mobile viewports.
- No CSS diagnostics or blockers remain.

The build reported existing Docusaurus and Browserslist warnings unrelated to this CSS-only change.

Before change:
<img width="2988" height="1740" alt="image" src="https://github.com/user-attachments/assets/2d856c7f-1971-4070-93f4-d91a0c84f8cd" />

After change:
<img width="2978" height="1756" alt="image" src="https://github.com/user-attachments/assets/8ad4efcb-eede-4361-bb78-b04bf69f4dce" />


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
