### PR TITLE
[Router] Prevent typed-nil panic in category classification

### DIFF
--- a/src/semantic-router/pkg/classification/classifier_category_entropy.go
+++ b/src/semantic-router/pkg/classification/classifier_category_entropy.go
@@ -43,12 +43,17 @@ func (c *Classifier) ClassifyCategoryWithEntropy(text string) (string, float64, 
 // tryKeywordBasedClassification attempts classification via keyword and embedding classifiers.
 // Returns matched=true if a classifier produced a result.
 func (c *Classifier) tryKeywordBasedClassification(text string) (string, float64, entropy.ReasoningDecision, bool, error) {
-	for _, clf := range []interface {
+	classifiers := make([]interface {
 		Classify(string) (string, float64, error)
-	}{c.keywordClassifier, c.keywordEmbeddingClassifier} {
-		if clf == nil {
-			continue
-		}
+	}, 0, 2)
+	if c.keywordClassifier != nil {
+		classifiers = append(classifiers, c.keywordClassifier)
+	}
+	if c.keywordEmbeddingClassifier != nil {
+		classifiers = append(classifiers, c.keywordEmbeddingClassifier)
+	}
+
+	for _, clf := range classifiers {
 		category, confidence, err := clf.Classify(text)
 		if err != nil {
 			return "", 0.0, entropy.ReasoningDecision{}, false, err

--- a/src/semantic-router/pkg/classification/classifier_category_entropy_test.go
+++ b/src/semantic-router/pkg/classification/classifier_category_entropy_test.go
@@ -1,0 +1,38 @@
+package classification
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestClassifyCategoryWithEntropySkipsNilEmbeddingClassifier(t *testing.T) {
+	keywordClassifier, err := NewKeywordClassifier([]config.KeywordRule{
+		{
+			Name:     "technical",
+			Operator: "OR",
+			Method:   "regex",
+			Keywords: []string{"kubernetes"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer keywordClassifier.Free()
+
+	classifier := &Classifier{
+		Config:            &config.RouterConfig{},
+		keywordClassifier: keywordClassifier,
+	}
+
+	category, confidence, _, err := classifier.ClassifyCategoryWithEntropy("unrelated request")
+	if err == nil || err.Error() != "no category classification method available" {
+		t.Fatalf("ClassifyCategoryWithEntropy error = %v, want no category classification method available", err)
+	}
+	if category != "" {
+		t.Fatalf("ClassifyCategoryWithEntropy category = %q, want empty", category)
+	}
+	if confidence != 0 {
+		t.Fatalf("ClassifyCategoryWithEntropy confidence = %v, want 0", confidence)
+	}
+}


### PR DESCRIPTION
Closes #2943

## Purpose

- Prevent `ClassifyCategoryWithEntropy` from invoking a disabled embedding classifier through a non-nil typed-nil interface.
- Check concrete keyword and embedding classifier pointers before adding them to the shared classification loop.
- Add a regression test for the keyword-enabled, keyword-miss, embedding-disabled path that previously panicked.
- Affected module: `Router`.

The classifier decomposition in #1568 combined two concrete-pointer checks into an interface slice. A nil `*EmbeddingClassifier` then became a non-nil interface value, bypassed `clf == nil`, and reached `EmbeddingClassifier.ClassifyDetailed` with a nil receiver.

## Test Plan

- Run the focused regression test and confirm it fails with the nil-pointer panic before the production change, then passes after the change.
- Run the complete classification package, including the regression test.
- Run the regression test with the Go race detector.
- Run all Semantic Router Go packages with external service tests disabled by the repository's standard skip variables.
- Run the repository changed-file lint/structure gate and static recipe-conformance gate.

## Test Result

- `go test ./pkg/classification -run '^TestClassifyCategoryWithEntropySkipsNilEmbeddingClassifier$' -count=1` — passed after reproducing the pre-fix panic.
- `go test ./pkg/classification -count=1` — passed.
- `go test -race ./pkg/classification -run '^TestClassifyCategoryWithEntropySkipsNilEmbeddingClassifier$' -count=1` — passed.
- `go test ./... -count=1` with the repository's external-service skip variables — passed.
- `make agent-lint ENV=cpu AGENT_BASE_REF=d8a2cc2456b6b6f773b26986c4dd22cb34998211 CHANGED_FILES="src/semantic-router/pkg/classification/classifier_category_entropy.go,src/semantic-router/pkg/classification/classifier_category_entropy_test.go"` — passed.
- `make recipe-conformance-static` — passed.
- Local container smoke and Kubernetes E2E were not run for this narrow internal nil-filtering fix; CI remains the deployment-level validation gate.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses a module-aligned prefix.
- [x] Commits in this PR are signed off with `git commit -s`.
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change.

</details>
