### PR TITLE
[Router] fix: correct rule_name/category keys to name in helm values.yaml

### DIFF
--- a/deploy/helm/semantic-router/values.yaml
+++ b/deploy/helm/semantic-router/values.yaml
@@ -1023,7 +1023,7 @@ config:
           operator: OR
           conditions:
             - type: keyword
-              rule_name: thinking
+              name: thinking
         modelRefs:
           - model: base-model
             lora_name: general-expert
@@ -1058,7 +1058,7 @@ config:
               mode: replace
     signals:
       keywords:
-        - category: thinking
+        - name: thinking
           operator: OR
           keywords:
             - urgent
@@ -1854,7 +1854,7 @@ config:
           operator: OR
           conditions:
             - type: keyword
-              rule_name: thinking
+              name: thinking
         modelRefs:
           - model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
             use_reasoning: true
@@ -6442,7 +6442,7 @@ config:
           operator: OR
           conditions:
             - type: keyword
-              rule_name: thinking
+              name: thinking
         modelRefs:
           - model: base-model
             lora_name: general-expert
@@ -6477,7 +6477,7 @@ config:
               mode: replace
     signals:
       keywords:
-        - category: thinking
+        - name: thinking
           operator: OR
           keywords:
             - urgent
@@ -7273,7 +7273,7 @@ config:
           operator: OR
           conditions:
             - type: keyword
-              rule_name: thinking
+              name: thinking
         modelRefs:
           - model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
             use_reasoning: true


### PR DESCRIPTION
<!-- markdownlint-disable -->


Closes #2939

## Purpose

The Helm chart's default `values.yaml` writes decision rule leaves using a `rule_name` key and keyword signals using a `category` key. Neither field exists in the actual config schema- `config.RuleNode` and `config.KeywordRule` both expect `name`. This causes the affected `thinking_decision` leaves to load with an empty signal name, so they silently fail to match instead of routing on the intended keywords.

This PR corrects the four `rule_name` occurrences and two `category` occurrences flagged in #2939 (lines 1026, 1857, 6445, 7276, and 1061, 6480) to use `name`, matching the correct pattern already used elsewhere in the same file (lines 1483, 3004).

## Test Plan

- Confirmed the exact lines matched the issue's reported occurrences before editing.
- Validated the full `values.yaml` (all 41 YAML documents) parses cleanly after the change using `yaml.safe_load_all`.
- Did not have `make`/Docker available locally on Windows to run the repo's Go-based render/test harness, relying on CI to confirm the rendered chart behavior.

## Test Result

YAML parses without error; diff is limited to the 6 flagged lines with no unintended changes.

**Note for maintainers:** while fixing the reported keys, I noticed two of the four affected profiles (around lines 1857 and 7276) don't define a `thinking` keyword signal at all, even under the wrong key name, so `thinking_decision` won't match there even after this fix. I left that out of scope for this PR since it wasn't part of the original report, but happy to add the missing signal block here or in a follow-up if you'd like.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
