### PR TITLE
[Router] Honor router replay Milvus consistency_level

### DIFF
--- a/src/semantic-router/pkg/cache/milvus_consistency_level.go
+++ b/src/semantic-router/pkg/cache/milvus_consistency_level.go
@@ -1,33 +1,20 @@
 package cache
 
 import (
-	"strings"
-
 	"github.com/milvus-io/milvus-sdk-go/v2/client"
 	"github.com/milvus-io/milvus-sdk-go/v2/entity"
 
+	milvuslifecycle "github.com/vllm-project/semantic-router/src/semantic-router/pkg/milvus"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
 // resolveMilvusConsistencyLevel maps a configured consistency level name to
-// the SDK constant. Names are matched case-insensitively with surrounding
-// whitespace trimmed. ok is false when the name is empty or unrecognized; the
-// caller then leaves the option unset so the Milvus SDK default (Bounded)
-// stays in effect, preserving today's behavior for deployments that do not
-// pin a level.
+// the SDK constant via the shared parser. ok is false when the name is empty
+// or unrecognized; the caller then leaves the option unset so the Milvus SDK
+// default (Bounded) stays in effect, preserving today's behavior for
+// deployments that do not pin a level.
 func resolveMilvusConsistencyLevel(name string) (entity.ConsistencyLevel, bool) {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "strong":
-		return entity.ClStrong, true
-	case "session":
-		return entity.ClSession, true
-	case "bounded":
-		return entity.ClBounded, true
-	case "eventually":
-		return entity.ClEventually, true
-	default:
-		return entity.ClStrong, false
-	}
+	return milvuslifecycle.ParseConsistencyLevel(name)
 }
 
 // searchQueryOptions returns the read options that pin every Milvus search
@@ -57,7 +44,7 @@ func warnUnrecognizedMilvusConsistencyLevel(name string) {
 	if _, ok := resolveMilvusConsistencyLevel(name); ok {
 		return
 	}
-	logging.Warnf("MilvusCache: unrecognized consistency_level %q (valid: Strong, Session, Bounded, Eventually); leaving the Milvus SDK default in effect", name)
+	logging.Warnf("MilvusCache: unrecognized consistency_level %q (valid: %s); leaving the Milvus SDK default in effect", name, milvuslifecycle.ConsistencyLevelNames)
 }
 
 // createCollectionOptions returns the collection-creation options that pin a

--- a/src/semantic-router/pkg/milvus/consistency.go
+++ b/src/semantic-router/pkg/milvus/consistency.go
@@ -1,0 +1,32 @@
+package milvus
+
+import (
+	"strings"
+
+	"github.com/milvus-io/milvus-sdk-go/v2/entity"
+)
+
+// ConsistencyLevelNames lists the accepted consistency level names, for use
+// in configuration warnings.
+const ConsistencyLevelNames = "Strong, Session, Bounded, Eventually"
+
+// ParseConsistencyLevel maps a configured consistency level name to the SDK
+// constant. Names are matched case-insensitively with surrounding whitespace
+// trimmed. ok is false when the name is empty or unrecognized; the returned
+// level is the type's zero value then and must be ignored — each caller
+// applies its own fallback policy (e.g. the semantic cache leaves the SDK
+// default in effect, the router replay store defaults to Session).
+func ParseConsistencyLevel(name string) (entity.ConsistencyLevel, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "strong":
+		return entity.ClStrong, true
+	case "session":
+		return entity.ClSession, true
+	case "bounded":
+		return entity.ClBounded, true
+	case "eventually":
+		return entity.ClEventually, true
+	default:
+		return entity.ClStrong, false
+	}
+}

--- a/src/semantic-router/pkg/milvus/consistency_test.go
+++ b/src/semantic-router/pkg/milvus/consistency_test.go
@@ -16,9 +16,7 @@ func TestParseConsistencyLevel(t *testing.T) {
 		{"Session", entity.ClSession, true},
 		{"Bounded", entity.ClBounded, true},
 		{"Eventually", entity.ClEventually, true},
-		{"strong", entity.ClStrong, true},
-		{"  session  ", entity.ClSession, true},
-		{"EVENTUALLY", entity.ClEventually, true},
+		{"  eVENTUALLY  ", entity.ClEventually, true}, // case-insensitive, trimmed
 		{"", entity.ClStrong, false},
 		{"   ", entity.ClStrong, false},
 		{"customized", entity.ClStrong, false},
@@ -26,11 +24,8 @@ func TestParseConsistencyLevel(t *testing.T) {
 
 	for _, tc := range cases {
 		got, ok := ParseConsistencyLevel(tc.name)
-		if ok != tc.valid {
-			t.Fatalf("ParseConsistencyLevel(%q) ok = %v, want %v", tc.name, ok, tc.valid)
-		}
-		if got != tc.want {
-			t.Fatalf("ParseConsistencyLevel(%q) = %v, want %v", tc.name, got, tc.want)
+		if got != tc.want || ok != tc.valid {
+			t.Errorf("ParseConsistencyLevel(%q) = (%v, %v), want (%v, %v)", tc.name, got, ok, tc.want, tc.valid)
 		}
 	}
 }

--- a/src/semantic-router/pkg/milvus/consistency_test.go
+++ b/src/semantic-router/pkg/milvus/consistency_test.go
@@ -1,0 +1,36 @@
+package milvus
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus-sdk-go/v2/entity"
+)
+
+func TestParseConsistencyLevel(t *testing.T) {
+	cases := []struct {
+		name  string
+		want  entity.ConsistencyLevel
+		valid bool
+	}{
+		{"Strong", entity.ClStrong, true},
+		{"Session", entity.ClSession, true},
+		{"Bounded", entity.ClBounded, true},
+		{"Eventually", entity.ClEventually, true},
+		{"strong", entity.ClStrong, true},
+		{"  session  ", entity.ClSession, true},
+		{"EVENTUALLY", entity.ClEventually, true},
+		{"", entity.ClStrong, false},
+		{"   ", entity.ClStrong, false},
+		{"customized", entity.ClStrong, false},
+	}
+
+	for _, tc := range cases {
+		got, ok := ParseConsistencyLevel(tc.name)
+		if ok != tc.valid {
+			t.Fatalf("ParseConsistencyLevel(%q) ok = %v, want %v", tc.name, ok, tc.valid)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseConsistencyLevel(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/store/milvus.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus.go
@@ -296,21 +296,7 @@ func (m *MilvusStore) Add(ctx context.Context, record Record) (string, error) {
 		return "", fmt.Errorf("failed to marshal record: %w", err)
 	}
 
-	fn := func() error {
-		// Create columns
-		idColumn := entity.NewColumnVarChar("id", []string{record.ID})
-		timestampColumn := entity.NewColumnInt64("timestamp", []int64{record.Timestamp.Unix()})
-		dataColumn := entity.NewColumnVarChar("data", []string{string(data)})
-		vectorColumn := entity.NewColumnFloatVector("vector", 2, [][]float32{{0.0, 0.0}})
-
-		// Insert
-		_, err := m.client.Insert(ctx, m.collectionName, "", idColumn, timestampColumn, dataColumn, vectorColumn)
-		if err != nil {
-			return err
-		}
-		m.wrote.Store(true)
-		return nil
-	}
+	fn := func() error { return m.insertRecord(ctx, record, data) }
 
 	if m.asyncWrites {
 		if err := runAsyncOp(ctx, m.asyncChan, func() error {
@@ -336,6 +322,22 @@ func (m *MilvusStore) Add(ctx context.Context, record Record) (string, error) {
 	}
 
 	return record.ID, nil
+}
+
+// insertRecord inserts a single marshaled record and marks the store as
+// having written, so Session-level reads keep read-your-writes semantics.
+func (m *MilvusStore) insertRecord(ctx context.Context, record Record, data []byte) error {
+	idColumn := entity.NewColumnVarChar("id", []string{record.ID})
+	timestampColumn := entity.NewColumnInt64("timestamp", []int64{record.Timestamp.Unix()})
+	dataColumn := entity.NewColumnVarChar("data", []string{string(data)})
+	vectorColumn := entity.NewColumnFloatVector("vector", 2, [][]float32{{0.0, 0.0}})
+
+	_, err := m.client.Insert(ctx, m.collectionName, "", idColumn, timestampColumn, dataColumn, vectorColumn)
+	if err != nil {
+		return err
+	}
+	m.wrote.Store(true)
+	return nil
 }
 
 // Get retrieves a record by ID from Milvus.

--- a/src/semantic-router/pkg/routerreplay/store/milvus.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/milvus-io/milvus-sdk-go/v2/client"
 	"github.com/milvus-io/milvus-sdk-go/v2/entity"
 
 	milvuslifecycle "github.com/vllm-project/semantic-router/src/semantic-router/pkg/milvus"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
 
 const (
@@ -23,15 +26,68 @@ const (
 // MilvusStore implements Storage using Milvus as the backend.
 // Records are stored as entities in a Milvus collection.
 type MilvusStore struct {
-	client         client.Client
-	collectionName string
-	ttl            time.Duration
-	asyncWrites    bool
-	asyncChan      chan asyncOp
-	done           chan struct{}
-	writerDone     chan struct{}
-	updateMu       sync.Mutex
-	lifecycle      *storageLifecycle
+	client           client.Client
+	collectionName   string
+	consistencyLevel entity.ConsistencyLevel
+	wrote            atomic.Bool
+	ttl              time.Duration
+	asyncWrites      bool
+	asyncChan        chan asyncOp
+	done             chan struct{}
+	writerDone       chan struct{}
+	updateMu         sync.Mutex
+	lifecycle        *storageLifecycle
+}
+
+// resolveMilvusConsistencyLevel maps the configured consistency level name
+// (case-insensitive) to the SDK constant, falling back to
+// DefaultMilvusConsistencyLevel ("Session") when the value is empty or
+// unrecognized.
+func resolveMilvusConsistencyLevel(name string) entity.ConsistencyLevel {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "strong":
+		return entity.ClStrong
+	case "session", "":
+		return entity.ClSession
+	case "bounded":
+		return entity.ClBounded
+	case "eventually":
+		return entity.ClEventually
+	default:
+		logging.Warnf("MilvusStore: unrecognized consistency_level %q (valid: Strong, Session, Bounded, Eventually); using default %q", name, DefaultMilvusConsistencyLevel)
+		return entity.ClSession
+	}
+}
+
+// readLevel returns the consistency level for plain reads (Get, List). The
+// SDK degrades Session to Eventually until this client's first write on the
+// collection (no session timestamp exists yet), which would be weaker than
+// the Bounded these reads effectively ran at before the level was
+// configurable — so Session is floored at Bounded until this process has
+// written.
+func (m *MilvusStore) readLevel() entity.ConsistencyLevel {
+	if m.consistencyLevel == entity.ClSession && !m.wrote.Load() {
+		return entity.ClBounded
+	}
+	return m.consistencyLevel
+}
+
+// updateReadLevel returns the consistency level for the read feeding an
+// update's read-modify-write (updateRecordIf). updateMu serializes those
+// updates in-process, but the read must also see this process's own prior
+// upserts or the whole-document replace silently resurrects stale fields —
+// so it never runs weaker than Session, even when the configured level is
+// Bounded or Eventually; an explicit Strong is kept. Before this process's
+// first write Session carries no session timestamp (the SDK would degrade it
+// to Eventually), so Bounded applies instead.
+func (m *MilvusStore) updateReadLevel() entity.ConsistencyLevel {
+	if m.consistencyLevel == entity.ClStrong {
+		return entity.ClStrong
+	}
+	if m.wrote.Load() {
+		return entity.ClSession
+	}
+	return entity.ClBounded
 }
 
 // NewMilvusStore creates a new Milvus storage backend.
@@ -59,12 +115,13 @@ func NewMilvusStore(cfg *MilvusConfig, ttlSeconds int, asyncWrites bool) (*Milvu
 	}
 
 	store := &MilvusStore{
-		client:         milvusClient,
-		collectionName: collectionName,
-		ttl:            time.Duration(ttlSeconds) * time.Second,
-		asyncWrites:    asyncWrites,
-		done:           make(chan struct{}),
-		lifecycle:      newStorageLifecycle(),
+		client:           milvusClient,
+		collectionName:   collectionName,
+		consistencyLevel: resolveMilvusConsistencyLevel(cfg.ConsistencyLevel),
+		ttl:              time.Duration(ttlSeconds) * time.Second,
+		asyncWrites:      asyncWrites,
+		done:             make(chan struct{}),
+		lifecycle:        newStorageLifecycle(),
 	}
 
 	if err := milvuslifecycle.Retry(
@@ -142,9 +199,12 @@ func (m *MilvusStore) createCollection(ctx context.Context, cfg *MilvusConfig) e
 				shardNum = DefaultMilvusShardNum
 			}
 
-			// Create collection
+			// Create collection. The consistency level is stamped only when
+			// this call creates the collection; a pre-existing collection
+			// keeps its original level, and the per-query options carry the
+			// configured level for this store's reads instead.
 			//nolint:gosec // shardNum is validated to be within int32 range
-			if err := m.client.CreateCollection(innerCtx, schema, int32(shardNum)); err != nil {
+			if err := m.client.CreateCollection(innerCtx, schema, int32(shardNum), client.WithConsistencyLevel(m.consistencyLevel)); err != nil {
 				return err
 			}
 
@@ -247,7 +307,11 @@ func (m *MilvusStore) Add(ctx context.Context, record Record) (string, error) {
 
 		// Insert
 		_, err := m.client.Insert(ctx, m.collectionName, "", idColumn, timestampColumn, dataColumn, vectorColumn)
-		return err
+		if err != nil {
+			return err
+		}
+		m.wrote.Store(true)
+		return nil
 	}
 
 	if m.asyncWrites {
@@ -283,10 +347,10 @@ func (m *MilvusStore) Get(ctx context.Context, id string) (Record, bool, error) 
 		return Record{}, false, err
 	}
 	defer release()
-	return m.getRecord(ctx, id)
+	return m.getRecord(ctx, id, m.readLevel())
 }
 
-func (m *MilvusStore) getRecord(ctx context.Context, id string) (Record, bool, error) {
+func (m *MilvusStore) getRecord(ctx context.Context, id string, level entity.ConsistencyLevel) (Record, bool, error) {
 	if m.asyncWrites {
 		if err := runAsyncOp(ctx, m.asyncChan, func() error { return nil }); err != nil {
 			return Record{}, false, err
@@ -295,7 +359,14 @@ func (m *MilvusStore) getRecord(ctx context.Context, id string) (Record, bool, e
 
 	// Query by ID
 	expr := fmt.Sprintf("id == '%s'", id)
-	result, err := m.client.Query(ctx, m.collectionName, nil, expr, []string{"id", "timestamp", "data"})
+	result, err := m.client.Query(
+		ctx,
+		m.collectionName,
+		nil,
+		expr,
+		[]string{"id", "timestamp", "data"},
+		client.WithSearchQueryConsistencyLevel(level),
+	)
 	if err != nil {
 		return Record{}, false, fmt.Errorf("failed to query record: %w", err)
 	}
@@ -350,6 +421,7 @@ func (m *MilvusStore) listRecords(ctx context.Context) ([]Record, error) {
 		"",
 		[]string{"id", "timestamp", "data"},
 		client.WithLimit(10000),
+		client.WithSearchQueryConsistencyLevel(m.readLevel()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query records: %w", err)
@@ -485,7 +557,7 @@ func (m *MilvusStore) updateRecordIf(ctx context.Context, id string, mutate func
 	defer release()
 	m.updateMu.Lock()
 	defer m.updateMu.Unlock()
-	record, found, err := m.getRecord(ctx, id)
+	record, found, err := m.getRecord(ctx, id, m.updateReadLevel())
 	if err != nil {
 		return err
 	}
@@ -513,6 +585,7 @@ func (m *MilvusStore) replaceRecord(ctx context.Context, record Record) error {
 	if _, err := m.client.Upsert(ctx, m.collectionName, "", idColumn, timestampColumn, dataColumn, vectorColumn); err != nil {
 		return fmt.Errorf("failed to upsert updated record: %w", err)
 	}
+	m.wrote.Store(true)
 	return m.client.Flush(ctx, m.collectionName, false)
 }
 

--- a/src/semantic-router/pkg/routerreplay/store/milvus.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus.go
@@ -40,23 +40,17 @@ type MilvusStore struct {
 }
 
 // resolveMilvusConsistencyLevel maps the configured consistency level name
-// (case-insensitive) to the SDK constant, falling back to
+// to the SDK constant via the shared parser, falling back to
 // DefaultMilvusConsistencyLevel ("Session") when the value is empty or
 // unrecognized.
 func resolveMilvusConsistencyLevel(name string) entity.ConsistencyLevel {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "strong":
-		return entity.ClStrong
-	case "session", "":
-		return entity.ClSession
-	case "bounded":
-		return entity.ClBounded
-	case "eventually":
-		return entity.ClEventually
-	default:
-		logging.Warnf("MilvusStore: unrecognized consistency_level %q (valid: Strong, Session, Bounded, Eventually); using default %q", name, DefaultMilvusConsistencyLevel)
-		return entity.ClSession
+	if level, ok := milvuslifecycle.ParseConsistencyLevel(name); ok {
+		return level
 	}
+	if strings.TrimSpace(name) != "" {
+		logging.Warnf("MilvusStore: unrecognized consistency_level %q (valid: %s); using default %q", name, milvuslifecycle.ConsistencyLevelNames, DefaultMilvusConsistencyLevel)
+	}
+	return entity.ClSession
 }
 
 // readLevel returns the consistency level for plain reads (Get, List). The

--- a/src/semantic-router/pkg/routerreplay/store/milvus.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus.go
@@ -141,6 +141,43 @@ func NewMilvusStore(cfg *MilvusConfig, ttlSeconds int, asyncWrites bool) (*Milvu
 	return store, nil
 }
 
+// replayCollectionSchema returns the schema of the router replay collection.
+func replayCollectionSchema(collectionName string) *entity.Schema {
+	return &entity.Schema{
+		CollectionName: collectionName,
+		Description:    "Router replay records",
+		Fields: []*entity.Field{
+			{
+				Name:       "id",
+				DataType:   entity.FieldTypeVarChar,
+				PrimaryKey: true,
+				AutoID:     false,
+				TypeParams: map[string]string{
+					"max_length": "255",
+				},
+			},
+			{
+				Name:     "timestamp",
+				DataType: entity.FieldTypeInt64,
+			},
+			{
+				Name:     "data",
+				DataType: entity.FieldTypeVarChar,
+				TypeParams: map[string]string{
+					"max_length": "65535",
+				},
+			},
+			{
+				Name:     "vector",
+				DataType: entity.FieldTypeFloatVector,
+				TypeParams: map[string]string{
+					"dim": "2",
+				},
+			},
+		},
+	}
+}
+
 // createCollection creates the Milvus collection if it doesn't exist.
 //
 //nolint:gocognit
@@ -150,40 +187,7 @@ func (m *MilvusStore) createCollection(ctx context.Context, cfg *MilvusConfig) e
 		m.client,
 		m.collectionName,
 		func(innerCtx context.Context) error {
-			// Create schema
-			schema := &entity.Schema{
-				CollectionName: m.collectionName,
-				Description:    "Router replay records",
-				Fields: []*entity.Field{
-					{
-						Name:       "id",
-						DataType:   entity.FieldTypeVarChar,
-						PrimaryKey: true,
-						AutoID:     false,
-						TypeParams: map[string]string{
-							"max_length": "255",
-						},
-					},
-					{
-						Name:     "timestamp",
-						DataType: entity.FieldTypeInt64,
-					},
-					{
-						Name:     "data",
-						DataType: entity.FieldTypeVarChar,
-						TypeParams: map[string]string{
-							"max_length": "65535",
-						},
-					},
-					{
-						Name:     "vector",
-						DataType: entity.FieldTypeFloatVector,
-						TypeParams: map[string]string{
-							"dim": "2",
-						},
-					},
-				},
-			}
+			schema := replayCollectionSchema(m.collectionName)
 
 			shardNum := cfg.ShardNum
 			if shardNum <= 0 {

--- a/src/semantic-router/pkg/routerreplay/store/milvus_consistency_level_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus_consistency_level_test.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/milvus-io/milvus-sdk-go/v2/entity"
+)
+
+func TestResolveMilvusConsistencyLevel(t *testing.T) {
+	cases := []struct {
+		name string
+		want entity.ConsistencyLevel
+	}{
+		{"Strong", entity.ClStrong},
+		{"Session", entity.ClSession},
+		{"Bounded", entity.ClBounded},
+		{"Eventually", entity.ClEventually},
+		{"strong", entity.ClStrong},
+		{"  session  ", entity.ClSession},
+		{"EVENTUALLY", entity.ClEventually},
+		{"", entity.ClSession},
+		{"   ", entity.ClSession},
+		{"banana", entity.ClSession},
+	}
+
+	for _, tc := range cases {
+		if got := resolveMilvusConsistencyLevel(tc.name); got != tc.want {
+			t.Fatalf("resolveMilvusConsistencyLevel(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+
+	if got := resolveMilvusConsistencyLevel(DefaultMilvusConsistencyLevel); got != entity.ClSession {
+		t.Fatalf("DefaultMilvusConsistencyLevel resolves to %v, want %v", got, entity.ClSession)
+	}
+}
+
+func TestMilvusStoreReadLevels(t *testing.T) {
+	cases := []struct {
+		configured entity.ConsistencyLevel
+		wrote      bool
+		wantRead   entity.ConsistencyLevel
+		wantUpdate entity.ConsistencyLevel
+	}{
+		// Session floors to Bounded until the first write: the SDK degrades
+		// Session to Eventually when no session timestamp exists.
+		{entity.ClSession, false, entity.ClBounded, entity.ClBounded},
+		{entity.ClSession, true, entity.ClSession, entity.ClSession},
+		// Strong applies everywhere unchanged.
+		{entity.ClStrong, false, entity.ClStrong, entity.ClStrong},
+		{entity.ClStrong, true, entity.ClStrong, entity.ClStrong},
+		// Weaker configured levels apply to plain reads, but update-chain
+		// reads are floored at Session once this process has written.
+		{entity.ClBounded, false, entity.ClBounded, entity.ClBounded},
+		{entity.ClBounded, true, entity.ClBounded, entity.ClSession},
+		{entity.ClEventually, false, entity.ClEventually, entity.ClBounded},
+		{entity.ClEventually, true, entity.ClEventually, entity.ClSession},
+	}
+
+	for _, tc := range cases {
+		m := &MilvusStore{consistencyLevel: tc.configured}
+		m.wrote.Store(tc.wrote)
+		if got := m.readLevel(); got != tc.wantRead {
+			t.Fatalf("readLevel(configured=%v, wrote=%v) = %v, want %v", tc.configured, tc.wrote, got, tc.wantRead)
+		}
+		if got := m.updateReadLevel(); got != tc.wantUpdate {
+			t.Fatalf("updateReadLevel(configured=%v, wrote=%v) = %v, want %v", tc.configured, tc.wrote, got, tc.wantUpdate)
+		}
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/store/milvus_consistency_level_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/milvus_consistency_level_test.go
@@ -6,31 +6,24 @@ import (
 	"github.com/milvus-io/milvus-sdk-go/v2/entity"
 )
 
+// The name→level mapping itself is covered in pkg/milvus; these tests pin the
+// store's own policies layered on top of it.
+
 func TestResolveMilvusConsistencyLevel(t *testing.T) {
 	cases := []struct {
 		name string
 		want entity.ConsistencyLevel
 	}{
-		{"Strong", entity.ClStrong},
-		{"Session", entity.ClSession},
-		{"Bounded", entity.ClBounded},
-		{"Eventually", entity.ClEventually},
-		{"strong", entity.ClStrong},
-		{"  session  ", entity.ClSession},
-		{"EVENTUALLY", entity.ClEventually},
-		{"", entity.ClSession},
-		{"   ", entity.ClSession},
-		{"banana", entity.ClSession},
+		{"Strong", entity.ClStrong},                       // valid names pass through the shared parser
+		{DefaultMilvusConsistencyLevel, entity.ClSession}, // the documented default maps to Session
+		{"", entity.ClSession},                            // unset -> default
+		{"banana", entity.ClSession},                      // unrecognized -> warn + default
 	}
 
 	for _, tc := range cases {
 		if got := resolveMilvusConsistencyLevel(tc.name); got != tc.want {
-			t.Fatalf("resolveMilvusConsistencyLevel(%q) = %v, want %v", tc.name, got, tc.want)
+			t.Errorf("resolveMilvusConsistencyLevel(%q) = %v, want %v", tc.name, got, tc.want)
 		}
-	}
-
-	if got := resolveMilvusConsistencyLevel(DefaultMilvusConsistencyLevel); got != entity.ClSession {
-		t.Fatalf("DefaultMilvusConsistencyLevel resolves to %v, want %v", got, entity.ClSession)
 	}
 }
 
@@ -41,15 +34,14 @@ func TestMilvusStoreReadLevels(t *testing.T) {
 		wantRead   entity.ConsistencyLevel
 		wantUpdate entity.ConsistencyLevel
 	}{
-		// Session floors to Bounded until the first write: the SDK degrades
-		// Session to Eventually when no session timestamp exists.
+		// Session floors to Bounded until the first write (the SDK would
+		// degrade it to Eventually); update-chain reads floor at Session once
+		// this process has written, even under weaker configured levels; an
+		// explicit Strong applies everywhere unchanged.
 		{entity.ClSession, false, entity.ClBounded, entity.ClBounded},
 		{entity.ClSession, true, entity.ClSession, entity.ClSession},
-		// Strong applies everywhere unchanged.
 		{entity.ClStrong, false, entity.ClStrong, entity.ClStrong},
 		{entity.ClStrong, true, entity.ClStrong, entity.ClStrong},
-		// Weaker configured levels apply to plain reads, but update-chain
-		// reads are floored at Session once this process has written.
 		{entity.ClBounded, false, entity.ClBounded, entity.ClBounded},
 		{entity.ClBounded, true, entity.ClBounded, entity.ClSession},
 		{entity.ClEventually, false, entity.ClEventually, entity.ClBounded},
@@ -60,10 +52,10 @@ func TestMilvusStoreReadLevels(t *testing.T) {
 		m := &MilvusStore{consistencyLevel: tc.configured}
 		m.wrote.Store(tc.wrote)
 		if got := m.readLevel(); got != tc.wantRead {
-			t.Fatalf("readLevel(configured=%v, wrote=%v) = %v, want %v", tc.configured, tc.wrote, got, tc.wantRead)
+			t.Errorf("readLevel(configured=%v, wrote=%v) = %v, want %v", tc.configured, tc.wrote, got, tc.wantRead)
 		}
 		if got := m.updateReadLevel(); got != tc.wantUpdate {
-			t.Fatalf("updateReadLevel(configured=%v, wrote=%v) = %v, want %v", tc.configured, tc.wrote, got, tc.wantUpdate)
+			t.Errorf("updateReadLevel(configured=%v, wrote=%v) = %v, want %v", tc.configured, tc.wrote, got, tc.wantUpdate)
 		}
 	}
 }


### PR DESCRIPTION
Closes #2840

## Purpose

- The router replay Milvus store parsed `consistency_level` but never applied it: `CreateCollection` and every `Query` ran at the SDK default, so the documented field (and the `DefaultMilvusConsistencyLevel = "Session"` constant) was dead config, and an update's read-modify-write could read a stale snapshot and resurrect old fields on the whole-document upsert.
- Wire the resolved level (case-insensitive; unset defaults to `Session`, unrecognized values warn) into `CreateCollection` and both query paths, with two floors so no read is ever weaker than the implicit Bounded the store ran at before:
  - Session floors to Bounded until this process's first write — the SDK degrades Session to Eventually when no session timestamp exists (fresh process, read-only replica).
  - The read feeding `updateRecordIf` never runs weaker than Session once this process has written, even under a configured Bounded/Eventually, keeping read-your-writes for update chains. `updateMu` only serializes updates in-process; it cannot prevent a stale Milvus read.
- Same bug class as #2821/#2896, applied to the router replay consumer (scoped out of that fix). Affects the `Router` module.
- Second commit (pure refactor, no behavior change): hoist the name→`entity.ConsistencyLevel` mapping duplicated between `pkg/cache` and this store into `pkg/milvus` as `ParseConsistencyLevel`; each package keeps its own fallback policy wrapper (cache: leave the SDK default; replay: default to Session).

## Test Plan

- `go build` / `go vet` / `gofmt` on `pkg/milvus`, `pkg/cache`, `pkg/routerreplay/...`
- `go test ./pkg/milvus/... ./pkg/routerreplay/... -count=1` — new unit tests cover the shared name→level parser, the replay store's fallback policy, and the read/update-read floor matrix over configured level × first-write state.
- `go test ./pkg/cache/ -run 'TestMilvus|TestWarnUnrecognized' -count=1` — the existing cache consistency-level tests pin that the refactor keeps cache behavior unchanged.

## Test Result

- Build, vet, gofmt clean; all router replay package tests pass (including the #2869 lifecycle/async suites). Milvus-backed integration paths run in CI.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

