### PR TITLE
[CLI] fix Podman support for local vllm-sr serve bug

### DIFF
--- a/src/vllm-sr/cli/container_run_command.py
+++ b/src/vllm-sr/cli/container_run_command.py
@@ -1,6 +1,7 @@
 """Helpers for assembling Docker run/create commands."""
 
 import os
+import sys
 
 from cli.consts import PLATFORM_AMD
 from cli.container_images import _normalize_platform
@@ -94,10 +95,16 @@ def append_mount_specs(cmd, mount_specs: list[str]):
 def append_supplemental_gids(cmd, gids: list[int], runtime: str):
     """Grant only the resolved host groups needed by a service."""
 
-    if gids and runtime == "podman" and os.geteuid() != 0:
+    if (
+        gids
+        and runtime == "podman"
+        and os.geteuid() != 0
+        and sys.platform.startswith("linux")
+    ):
         # Rootless Podman remaps numeric container GIDs. keep-groups asks crun
         # to retain the invoking user's real supplementary groups, including
         # the private spool GID, without making the host file world-writable.
+        # macOS Podman machine runs in remote mode and rejects keep-groups.
         cmd.extend(["--group-add", "keep-groups"])
         return
     for gid in dict.fromkeys(gids):

--- a/src/vllm-sr/tests/test_container_log_spool.py
+++ b/src/vllm-sr/tests/test_container_log_spool.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 
 import pytest
 from cli.container_log_spool import (
@@ -107,11 +108,22 @@ def test_bounded_log_spool_relay_preserves_output_and_bounds_file(tmp_path):
 
 def test_rootless_podman_retains_host_spool_group(monkeypatch):
     monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(sys, "platform", "linux")
     command = ["podman", "run"]
 
     append_supplemental_gids(command, [1000], "podman")
 
     assert command[-2:] == ["--group-add", "keep-groups"]
+
+
+def test_rootless_podman_on_macos_uses_numeric_group_add(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    command = ["podman", "run"]
+
+    append_supplemental_gids(command, [1000], "podman")
+
+    assert command[-2:] == ["--group-add", "1000"]
 
 
 def test_docker_uses_fixed_numeric_spool_group():


### PR DESCRIPTION
<!-- markdownlint-disable -->
I'm using vllm-sr v0.3.0 and I'm getting below errors though Podman support was introduced in v0.2.0.
ERROR - Podman is not supported for local vLLM Semantic Router deployment.


Related #2954 
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->

## Purpose
The main branch already had the runtime fix ([#2291](https://github.com/vllm-project/semantic-router/pull/2291)) in cli/container_runtime.py, but that change was never included in the published 0.3.0 PyPI package. These errors come from the old cli/docker_runtime.py shipped in the PyPI vllm-sr==0.3.0 wheel which hard-rejects Podman.

I have updated `container_run_command.py` as macOS Podman runs in remote mode (Podman machine), which does not support --group-add keep-groups and that flag is only valid for rootless Podman on Linux.

## Test Plan

<!-- List the commands or manual checks that cover the affected behavior. -->

## Test Result

<!-- Record the actual outcome and any remaining risk or blocker. -->

I have added test for fix of skipping --group-add keep-groups on macOS Podman.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[Router]`, `[CLI]`, `[Dashboard]`, `[Operator]`, `[Fleet-Sim]`, `[Bindings]`, `[Training]`, `[E2E]`, `[Docs]`, or `[CI/Build]`
- [x] If the PR spans multiple modules, the title includes all relevant prefixes
- [x] Commits in this PR are signed off with `git commit -s`
- [ ] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
