### PR TITLE
[Bug] Preserve upstream error bodies through response translation

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -65,6 +65,7 @@ var DashboardContract = []string{
 var AnthropicShimContract = []string{
 	"anthropic-messages-cache-cycle",
 	"anthropic-messages-stop-sequence",
+	"anthropic-error-passthrough",
 }
 
 // Combine preserves order while removing duplicate testcase names.

--- a/e2e/testcases/anthropic_error_passthrough.go
+++ b/e2e/testcases/anthropic_error_passthrough.go
@@ -1,0 +1,183 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-error-passthrough", pkgtestcases.TestCase{
+		Description: "Verify upstream Anthropic error envelopes reach clients on both protocols instead of empty success bodies (anthropic-shim profile)",
+		Tags:        []string{"anthropic", "error", "functional"},
+		Fn:          testAnthropicErrorPassthrough,
+	})
+}
+
+// errorSentinel makes the anthropic-shim backend answer with a proper
+// Anthropic error envelope (HTTP 429, type rate_limit_error) instead of
+// forwarding to the model. See _requests_forced_error in the shim.
+const errorSentinel = "__VSR_E2E_FORCE_ERROR__"
+
+// testAnthropicErrorPassthrough asserts the externally visible error
+// contract on both client protocols when the Anthropic-format backend
+// fails: the upstream status is forwarded and the error body survives
+// translation instead of being flattened into an empty success-shaped
+// response.
+//
+//   - /v1/messages clients must receive the Anthropic error envelope with
+//     type, message, and request_id intact.
+//   - /v1/chat/completions clients must receive an OpenAI-shape error
+//     object carrying the same type and message, and no choices array.
+//
+// Requires the anthropic-shim profile.
+func testAnthropicErrorPassthrough(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Anthropic] Testing error-envelope passthrough on both client protocols")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	anthropicStatus, anthropicBody, err := sendErrorPassthroughRequest(ctx, localPort, "/v1/messages", map[string]interface{}{
+		"model":      "MoM",
+		"max_tokens": 32,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": errorSentinel},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("anthropic-protocol request failed: %w", err)
+	}
+
+	openAIStatus, openAIBody, err := sendErrorPassthroughRequest(ctx, localPort, "/v1/chat/completions", map[string]interface{}{
+		"model": "MoM",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": errorSentinel},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("openai-protocol request failed: %w", err)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"anthropic_status": anthropicStatus,
+			"anthropic_body":   string(anthropicBody),
+			"openai_status":    openAIStatus,
+			"openai_body":      string(openAIBody),
+		})
+	}
+
+	if err := assertAnthropicErrorEnvelope(anthropicStatus, anthropicBody); err != nil {
+		return fmt.Errorf("anthropic-protocol client: %w", err)
+	}
+	if err := assertOpenAIErrorBody(openAIStatus, openAIBody); err != nil {
+		return fmt.Errorf("openai-protocol client: %w", err)
+	}
+	return nil
+}
+
+func assertAnthropicErrorEnvelope(status int, body []byte) error {
+	if status != http.StatusTooManyRequests {
+		return fmt.Errorf("expected upstream status 429 forwarded, got %d (body: %s)", status, body)
+	}
+	var envelope struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+		RequestID string `json:"request_id"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("unmarshal envelope: %w (body: %s)", err, body)
+	}
+	if envelope.Type != "error" {
+		return fmt.Errorf("expected type=error envelope, got %q (body: %s)", envelope.Type, body)
+	}
+	if envelope.Error.Type != "rate_limit_error" {
+		return fmt.Errorf("expected error.type=rate_limit_error, got %q", envelope.Error.Type)
+	}
+	if !strings.Contains(envelope.Error.Message, "synthetic rate limit") {
+		return fmt.Errorf("upstream error message lost: %q", envelope.Error.Message)
+	}
+	if envelope.RequestID != "req_e2e_error_passthrough" {
+		return fmt.Errorf("request_id lost: %q", envelope.RequestID)
+	}
+	return nil
+}
+
+func assertOpenAIErrorBody(status int, body []byte) error {
+	if status != http.StatusTooManyRequests {
+		return fmt.Errorf("expected upstream status 429 forwarded, got %d (body: %s)", status, body)
+	}
+	var parsed struct {
+		Error *struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Choices   []interface{} `json:"choices"`
+		RequestID *string       `json:"request_id"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("unmarshal error body: %w (body: %s)", err, body)
+	}
+	if parsed.Error == nil {
+		return fmt.Errorf("expected an error object, got none (body: %s)", body)
+	}
+	if parsed.Error.Type != "rate_limit_error" {
+		return fmt.Errorf("expected error.type=rate_limit_error, got %q", parsed.Error.Type)
+	}
+	if !strings.Contains(parsed.Error.Message, "synthetic rate limit") {
+		return fmt.Errorf("upstream error message lost: %q", parsed.Error.Message)
+	}
+	if len(parsed.Choices) != 0 {
+		return fmt.Errorf("error body must not be shaped like a completion (body: %s)", body)
+	}
+	if parsed.RequestID != nil {
+		return fmt.Errorf("OpenAI error bodies must stay spec-pure without request_id (body: %s)", body)
+	}
+	return nil
+}
+
+func sendErrorPassthroughRequest(ctx context.Context, localPort, path string, payload map[string]interface{}) (int, []byte, error) {
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return 0, nil, fmt.Errorf("marshal: %w", err)
+	}
+	url := fmt.Sprintf("http://localhost:%s%s", localPort, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return 0, nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if path == "/v1/messages" {
+		req.Header.Set("anthropic-version", "2023-06-01")
+	}
+
+	httpClient := &http.Client{Timeout: 120 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("read response body: %w", err)
+	}
+	return resp.StatusCode, raw, nil
+}

--- a/e2e/testing/anthropic-shim/anthropic_shim/app.py
+++ b/e2e/testing/anthropic-shim/anthropic_shim/app.py
@@ -222,6 +222,19 @@ async def _handle_messages(request: Request, app: FastAPI) -> Response:
             content={"error": "invalid_json", "detail": "body is not JSON"},
         )
 
+    if _requests_forced_error(body):
+        return JSONResponse(
+            status_code=429,
+            content={
+                "type": "error",
+                "error": {
+                    "type": "rate_limit_error",
+                    "message": "synthetic rate limit for e2e error passthrough",
+                },
+                "request_id": "req_e2e_error_passthrough",
+            },
+        )
+
     request_had_cache_control = has_cache_control(body)
     prefix_hash = cache_prefix_hash(body) if request_had_cache_control else ""
 
@@ -320,3 +333,22 @@ async def _proxy_raw(request: Request, path: str, app: FastAPI) -> Response:
 
 
 app = create_app()
+
+
+def _requests_forced_error(body: dict[str, Any]) -> bool:
+    """Return True when any user message contains the e2e error sentinel.
+
+    Lets the anthropic-error-passthrough testcase deterministically make the
+    backend answer with a proper Anthropic error envelope (non-2xx), without
+    depending on model behaviour or invalid-request heuristics.
+    """
+    sentinel = "__VSR_E2E_FORCE_ERROR__"
+    for message in body.get("messages") or []:
+        content = message.get("content")
+        if isinstance(content, str) and sentinel in content:
+            return True
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and sentinel in str(block.get("text", "")):
+                    return True
+    return False

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -160,6 +160,15 @@ func ToOpenAIResponseBodyWithExt(anthropicResponse []byte, model string, ext *ir
 func toOpenAIResponseBody(anthropicResponse []byte, model string, ext *ir.IRExtensions) ([]byte, error) {
 	logging.Debugf("Raw Anthropic response: %s", logging.ContentDescriptorBytes(anthropicResponse))
 
+	// An Anthropic error envelope ({"type":"error","error":{...}}) would
+	// otherwise unmarshal into a zero-valued Message and be flattened into
+	// an empty, success-shaped chat.completion — losing the upstream error
+	// entirely. Preserve it as an OpenAI-shape error body instead; the
+	// upstream HTTP status is forwarded unchanged by the extproc layer.
+	if errBody, ok := anthropicErrorToOpenAIBody(anthropicResponse); ok {
+		return errBody, nil
+	}
+
 	var resp anthropic.Message
 	if err := json.Unmarshal(anthropicResponse, &resp); err != nil {
 		return nil, fmt.Errorf("failed to parse Anthropic response: %w", err)

--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -165,7 +165,7 @@ func toOpenAIResponseBody(anthropicResponse []byte, model string, ext *ir.IRExte
 	// an empty, success-shaped chat.completion — losing the upstream error
 	// entirely. Preserve it as an OpenAI-shape error body instead; the
 	// upstream HTTP status is forwarded unchanged by the extproc layer.
-	if errBody, ok := anthropicErrorToOpenAIBody(anthropicResponse); ok {
+	if errBody, ok := anthropicErrorToOpenAIBody(anthropicResponse, ext); ok {
 		return errBody, nil
 	}
 

--- a/src/semantic-router/pkg/anthropic/error_passthrough.go
+++ b/src/semantic-router/pkg/anthropic/error_passthrough.go
@@ -1,0 +1,98 @@
+// Error passthrough between the Anthropic and OpenAI wire formats.
+//
+// Upstream error bodies must survive response translation in both
+// directions: an Anthropic error envelope ({"type":"error","error":{...}})
+// is preserved as an OpenAI-shape error body for OpenAI-protocol clients
+// (consumed by toOpenAIResponseBody in client.go), and an OpenAI-shape
+// error body is re-emitted as the Anthropic envelope for Anthropic-protocol
+// clients (consumed by EmitAnthropicResponse in outbound.go). Without these
+// guards both directions flatten error bodies into empty success-shaped
+// responses, destroying the upstream failure reason.
+package anthropic
+
+import (
+	"encoding/json"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/shared/constant"
+)
+
+// openAIErrorEnvelope is the OpenAI error wire shape ({"error":{...}}).
+// anthropicErrorToOpenAIBody marshals it when preserving an Anthropic error
+// envelope for OpenAI-protocol clients, and openAIErrorBody unmarshals it
+// to detect error bodies before the Anthropic emit.
+// Deliberately not using openai-go's shared.ErrorObject, because the SDK
+// type's decoder is lenient and would decode a successful response with an
+// `"error": false` property as an ErrorObject.
+type openAIErrorEnvelope struct {
+	Error *openAIErrorDetail `json:"error"`
+}
+
+type openAIErrorDetail struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// anthropicErrorToOpenAIBody converts an Anthropic error envelope
+// ({"type":"error","error":{...}}) into the OpenAI error wire shape
+// ({"error":{"message":...,"type":...}}) so the upstream failure reason
+// survives translation for OpenAI-protocol clients. Returns ok=false for
+// non-error bodies.
+//
+// This is the entry half of a two-stage relay: the OpenAI error body it
+// produces travels through the router's OpenAI-shaped pipeline, and — when
+// the client speaks the Anthropic protocol — openAIErrorBody recognizes it
+// on the way out so EmitAnthropicResponse can re-wrap it as the envelope.
+func anthropicErrorToOpenAIBody(anthropicResponse []byte) ([]byte, bool) {
+	var probe anthropic.ErrorResponse
+	if err := json.Unmarshal(anthropicResponse, &probe); err != nil || probe.Type != constant.ValueOf[constant.Error]() {
+		return nil, false
+	}
+	body, err := json.Marshal(openAIErrorEnvelope{
+		Error: &openAIErrorDetail{
+			Type:    probe.Error.Type,
+			Message: probe.Error.Message,
+		},
+	})
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// openAIErrorBody reports whether responseBody is an OpenAI-shape error
+// ({"error":{...}}) and returns its type and message. Success bodies (and
+// bodies where "error" is null or a non-object) return ok=false.
+//
+// This is the exit half of the relay: it recognizes error bodies in the
+// pipeline's OpenAI shape — whether produced by anthropicErrorToOpenAIBody
+// or returned natively by an OpenAI-format backend — so the Anthropic
+// emitter re-wraps them instead of flattening them into an empty message.
+func openAIErrorBody(responseBody []byte) (string, string, bool) {
+	var probe openAIErrorEnvelope
+	if err := json.Unmarshal(responseBody, &probe); err != nil || probe.Error == nil {
+		return "", "", false
+	}
+	return probe.Error.Type, probe.Error.Message, true
+}
+
+// anthropicErrorType maps an arbitrary error-type token to one of
+// Anthropic's defined error types. Anthropic's own tokens pass through
+// unchanged (the Anthropic-to-Anthropic round-trip case); known
+// OpenAI-only tokens map to their closest Anthropic equivalent; anything
+// else — including an absent type — falls back to the catch-all
+// "api_error".
+func anthropicErrorType(token string) string {
+	switch token {
+	case "invalid_request_error", "authentication_error", "billing_error",
+		"permission_error", "not_found_error", "request_too_large",
+		"rate_limit_error", "timeout_error", "api_error", "overloaded_error":
+		return token
+	case "rate_limit_exceeded":
+		return "rate_limit_error"
+	case "insufficient_quota":
+		return "billing_error"
+	default:
+		return anthropicErrorTypeAPI
+	}
+}

--- a/src/semantic-router/pkg/anthropic/error_passthrough.go
+++ b/src/semantic-router/pkg/anthropic/error_passthrough.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
 // openAIErrorEnvelope is the OpenAI error wire shape ({"error":{...}}).
@@ -36,17 +38,22 @@ type openAIErrorDetail struct {
 // anthropicErrorToOpenAIBody converts an Anthropic error envelope
 // ({"type":"error","error":{...}}) into the OpenAI error wire shape
 // ({"error":{"message":...,"type":...}}) so the upstream failure reason
-// survives translation for OpenAI-protocol clients. Returns ok=false for
-// non-error bodies.
+// survives translation for OpenAI-protocol clients. The envelope's
+// request_id is captured onto the sidecar (not the body) for the Anthropic
+// re-emit; OpenAI clients get it via the request-id response header.
+// Returns ok=false for non-error bodies.
 //
 // This is the entry half of a two-stage relay: the OpenAI error body it
 // produces travels through the router's OpenAI-shaped pipeline, and — when
 // the client speaks the Anthropic protocol — openAIErrorBody recognizes it
 // on the way out so EmitAnthropicResponse can re-wrap it as the envelope.
-func anthropicErrorToOpenAIBody(anthropicResponse []byte) ([]byte, bool) {
+func anthropicErrorToOpenAIBody(anthropicResponse []byte, ext *ir.IRExtensions) ([]byte, bool) {
 	var probe anthropic.ErrorResponse
 	if err := json.Unmarshal(anthropicResponse, &probe); err != nil || probe.Type != constant.ValueOf[constant.Error]() {
 		return nil, false
+	}
+	if ext != nil {
+		ext.AnthropicErrorRequestID = probe.RequestID
 	}
 	body, err := json.Marshal(openAIErrorEnvelope{
 		Error: &openAIErrorDetail{
@@ -61,19 +68,19 @@ func anthropicErrorToOpenAIBody(anthropicResponse []byte) ([]byte, bool) {
 }
 
 // openAIErrorBody reports whether responseBody is an OpenAI-shape error
-// ({"error":{...}}) and returns its type and message. Success bodies (and
+// ({"error":{...}}) and returns the parsed envelope. Success bodies (and
 // bodies where "error" is null or a non-object) return ok=false.
 //
 // This is the exit half of the relay: it recognizes error bodies in the
 // pipeline's OpenAI shape — whether produced by anthropicErrorToOpenAIBody
 // or returned natively by an OpenAI-format backend — so the Anthropic
 // emitter re-wraps them instead of flattening them into an empty message.
-func openAIErrorBody(responseBody []byte) (string, string, bool) {
+func openAIErrorBody(responseBody []byte) (*openAIErrorEnvelope, bool) {
 	var probe openAIErrorEnvelope
 	if err := json.Unmarshal(responseBody, &probe); err != nil || probe.Error == nil {
-		return "", "", false
+		return nil, false
 	}
-	return probe.Error.Type, probe.Error.Message, true
+	return &probe, true
 }
 
 // anthropicErrorType maps an arbitrary error-type token to one of

--- a/src/semantic-router/pkg/anthropic/error_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/error_passthrough_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
 
-const anthropicAuthErrorEnvelope = `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`
+const anthropicAuthErrorEnvelope = `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"},"request_id":"req_011CSHoEeqs5DZitY69wyoEE"}`
 
 // An Anthropic error envelope must survive the Anthropic→OpenAI response
 // translation as an OpenAI-shape error body, not be flattened into an
@@ -29,6 +29,9 @@ func TestToOpenAIResponseBody_PreservesErrorEnvelope(t *testing.T) {
 
 	_, hasChoices := body["choices"]
 	assert.False(t, hasChoices, "error body must not be shaped like a completion")
+
+	_, hasRequestID := body["request_id"]
+	assert.False(t, hasRequestID, "OpenAI error bodies stay spec-pure; request_id rides the sidecar")
 }
 
 // The ext-aware entrypoint takes the same guard path, and the early return
@@ -43,6 +46,7 @@ func TestToOpenAIResponseBodyWithExt_PreservesErrorEnvelope(t *testing.T) {
 	assert.Empty(t, ext.AnthropicStopReason)
 	assert.Zero(t, ext.CacheReadInputTokens)
 	assert.Zero(t, ext.CacheCreationInputTokens)
+	assert.Equal(t, "req_011CSHoEeqs5DZitY69wyoEE", ext.AnthropicErrorRequestID, "request_id captured onto the sidecar")
 }
 
 // A success-shaped message must never be converted into an error body —
@@ -68,7 +72,7 @@ func TestAnthropicErrorToOpenAIBody_IgnoresSuccessBodies(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, ok := anthropicErrorToOpenAIBody([]byte(tc.body))
+			_, ok := anthropicErrorToOpenAIBody([]byte(tc.body), nil)
 			assert.False(t, ok)
 		})
 	}
@@ -106,6 +110,9 @@ func TestEmitAnthropicResponse_OpenAIBackendErrorWithoutType(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "api_error", errObj["type"])
 	assert.Equal(t, "Rate limit reached", errObj["message"])
+
+	_, hasRequestID := envelope["request_id"]
+	assert.False(t, hasRequestID, "absent request_id must be omitted, not empty")
 }
 
 // The emit path applies the error-type mapping, not just the helper in
@@ -143,6 +150,7 @@ func TestAnthropicErrorEnvelopeRoundTrip(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "authentication_error", errObj["type"])
 	assert.Equal(t, "invalid x-api-key", errObj["message"])
+	assert.Equal(t, "req_011CSHoEeqs5DZitY69wyoEE", envelope["request_id"], "request_id survives the round trip")
 }
 
 // OpenAI-only error-type tokens are mapped to Anthropic's defined error
@@ -180,7 +188,7 @@ func TestOpenAIErrorBody_IgnoresNullAndNonObjectError(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, ok := openAIErrorBody([]byte(tc.body))
+			_, ok := openAIErrorBody([]byte(tc.body))
 			assert.False(t, ok)
 		})
 	}

--- a/src/semantic-router/pkg/anthropic/error_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/error_passthrough_test.go
@@ -1,0 +1,187 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
+)
+
+const anthropicAuthErrorEnvelope = `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`
+
+// An Anthropic error envelope must survive the Anthropic→OpenAI response
+// translation as an OpenAI-shape error body, not be flattened into an
+// empty success-shaped chat.completion.
+func TestToOpenAIResponseBody_PreservesErrorEnvelope(t *testing.T) {
+	out, err := ToOpenAIResponseBody([]byte(anthropicAuthErrorEnvelope), "claude-test")
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &body))
+
+	errObj, ok := body["error"].(map[string]interface{})
+	require.True(t, ok, "translated body must carry a top-level error object")
+	assert.Equal(t, "authentication_error", errObj["type"])
+	assert.Equal(t, "invalid x-api-key", errObj["message"])
+
+	_, hasChoices := body["choices"]
+	assert.False(t, hasChoices, "error body must not be shaped like a completion")
+}
+
+// The ext-aware entrypoint takes the same guard path, and the early return
+// must leave the sidecar untouched — an error body carries no usage or
+// stop reason to capture.
+func TestToOpenAIResponseBodyWithExt_PreservesErrorEnvelope(t *testing.T) {
+	ext := &ir.IRExtensions{}
+	out, err := ToOpenAIResponseBodyWithExt([]byte(anthropicAuthErrorEnvelope), "claude-test", ext)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"authentication_error"`)
+
+	assert.Empty(t, ext.AnthropicStopReason)
+	assert.Zero(t, ext.CacheReadInputTokens)
+	assert.Zero(t, ext.CacheCreationInputTokens)
+}
+
+// A success-shaped message must never be converted into an error body —
+// the decision rests on the envelope's type field alone, not on
+// error-looking text anywhere in the content.
+func TestAnthropicErrorToOpenAIBody_IgnoresSuccessBodies(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "message whose text content looks like an error",
+			body: `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"error: something"}],"usage":{"input_tokens":1,"output_tokens":1}}`,
+		},
+		{
+			name: "minimal message",
+			body: `{"type":"message","content":[]}`,
+		},
+		{
+			name: "empty object",
+			body: `{}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := anthropicErrorToOpenAIBody([]byte(tc.body))
+			assert.False(t, ok)
+		})
+	}
+}
+
+// An OpenAI-shape error body must be re-emitted to Anthropic clients as the
+// Anthropic error envelope, not as an empty success-shaped message.
+func TestEmitAnthropicResponse_ReEmitsErrorEnvelope(t *testing.T) {
+	openAIError := []byte(`{"error":{"message":"invalid x-api-key","type":"authentication_error"}}`)
+
+	out, err := EmitAnthropicResponse(openAIError, &ir.IRExtensions{}, "claude-test")
+	require.NoError(t, err)
+
+	var envelope map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &envelope))
+	assert.Equal(t, "error", envelope["type"])
+
+	errObj, ok := envelope["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "authentication_error", errObj["type"])
+	assert.Equal(t, "invalid x-api-key", errObj["message"])
+}
+
+// Errors from OpenAI-format backends reach Anthropic clients with their
+// message intact; an absent type is coerced to api_error by EmitAnthropicError.
+func TestEmitAnthropicResponse_OpenAIBackendErrorWithoutType(t *testing.T) {
+	openAIError := []byte(`{"error":{"message":"Rate limit reached","code":"rate_limit_exceeded"}}`)
+
+	out, err := EmitAnthropicResponse(openAIError, nil, "claude-test")
+	require.NoError(t, err)
+
+	var envelope map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &envelope))
+	errObj, ok := envelope["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "api_error", errObj["type"])
+	assert.Equal(t, "Rate limit reached", errObj["message"])
+}
+
+// The emit path applies the error-type mapping, not just the helper in
+// isolation: an OpenAI-only token arriving at EmitAnthropicResponse comes
+// out as its Anthropic equivalent.
+func TestEmitAnthropicResponse_MapsOpenAIErrorType(t *testing.T) {
+	openAIError := []byte(`{"error":{"message":"Rate limit reached","type":"rate_limit_exceeded"}}`)
+
+	out, err := EmitAnthropicResponse(openAIError, nil, "claude-test")
+	require.NoError(t, err)
+
+	var envelope map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &envelope))
+	errObj, ok := envelope["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "rate_limit_error", errObj["type"])
+	assert.Equal(t, "Rate limit reached", errObj["message"])
+}
+
+// Full double-Anthropic round trip: envelope → OpenAI error body → envelope,
+// with type and message preserved verbatim.
+func TestAnthropicErrorEnvelopeRoundTrip(t *testing.T) {
+	ext := &ir.IRExtensions{}
+
+	openAIBody, err := ToOpenAIResponseBodyWithExt([]byte(anthropicAuthErrorEnvelope), "claude-test", ext)
+	require.NoError(t, err)
+
+	anthropicBody, err := EmitAnthropicResponse(openAIBody, ext, "claude-test")
+	require.NoError(t, err)
+
+	var envelope map[string]interface{}
+	require.NoError(t, json.Unmarshal(anthropicBody, &envelope))
+	assert.Equal(t, "error", envelope["type"])
+	errObj, ok := envelope["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "authentication_error", errObj["type"])
+	assert.Equal(t, "invalid x-api-key", errObj["message"])
+}
+
+// OpenAI-only error-type tokens are mapped to Anthropic's defined error
+// types; Anthropic's own tokens pass through unchanged.
+func TestAnthropicErrorType_CoercesOpenAITokens(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{name: "anthropic token passes verbatim", token: "authentication_error", want: "authentication_error"},
+		{name: "anthropic overloaded passes verbatim", token: "overloaded_error", want: "overloaded_error"},
+		{name: "openai rate limit maps to anthropic equivalent", token: "rate_limit_exceeded", want: "rate_limit_error"},
+		{name: "openai quota exhaustion maps to billing", token: "insufficient_quota", want: "billing_error"},
+		{name: "openai server error maps to catch-all", token: "server_error", want: "api_error"},
+		{name: "unknown token maps to catch-all", token: "something_novel", want: "api_error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, anthropicErrorType(tc.token))
+		})
+	}
+}
+
+// Bodies where "error" is null or a non-object are not error bodies and
+// must be left to the normal translation path.
+func TestOpenAIErrorBody_IgnoresNullAndNonObjectError(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "error is null", body: `{"id":"x","choices":[],"error":null}`},
+		{name: "error is a string", body: `{"id":"x","choices":[],"error":"nope"}`},
+		{name: "error absent", body: `{"id":"x","choices":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, ok := openAIErrorBody([]byte(tc.body))
+			assert.False(t, ok)
+		})
+	}
+}

--- a/src/semantic-router/pkg/anthropic/outbound.go
+++ b/src/semantic-router/pkg/anthropic/outbound.go
@@ -119,8 +119,9 @@ type anthropicServerToolUsageBlock struct {
 // anthropicErrorEnvelope is the wire shape Anthropic uses for all
 // error responses on POST /v1/messages.
 type anthropicErrorEnvelope struct {
-	Type  string               `json:"type"`
-	Error anthropicErrorDetail `json:"error"`
+	Type      string               `json:"type"`
+	Error     anthropicErrorDetail `json:"error"`
+	RequestID string               `json:"request_id,omitempty"`
 }
 
 type anthropicErrorDetail struct {
@@ -150,8 +151,12 @@ type anthropicErrorDetail struct {
 //     stop reasons "pause_turn" or "refusal"), it overrides the
 //     OpenAI-derived mapping.
 func EmitAnthropicResponse(responseBody []byte, ext *ir.IRExtensions, model string) ([]byte, error) {
-	if errType, errMsg, ok := openAIErrorBody(responseBody); ok {
-		return EmitAnthropicError(anthropicErrorType(errType), errMsg), nil
+	if errEnvelope, ok := openAIErrorBody(responseBody); ok {
+		return emitAnthropicErrorEnvelope(
+			anthropicErrorType(errEnvelope.Error.Type),
+			errEnvelope.Error.Message,
+			ext.ErrorRequestID(),
+		), nil
 	}
 
 	var oa openai.ChatCompletion
@@ -197,6 +202,12 @@ func EmitAnthropicResponse(responseBody []byte, ext *ir.IRExtensions, model stri
 // unknown errorType is coerced to "api_error" to keep the response
 // structurally valid.
 func EmitAnthropicError(errorType, message string) []byte {
+	return emitAnthropicErrorEnvelope(errorType, message, "")
+}
+
+// emitAnthropicErrorEnvelope is the request_id-aware form of
+// EmitAnthropicError; an empty requestID is omitted from the wire.
+func emitAnthropicErrorEnvelope(errorType, message, requestID string) []byte {
 	if errorType == "" {
 		errorType = anthropicErrorTypeAPI
 	}
@@ -206,6 +217,7 @@ func EmitAnthropicError(errorType, message string) []byte {
 			Type:    errorType,
 			Message: message,
 		},
+		RequestID: requestID,
 	}
 	// Marshal cannot fail for this fixed struct shape.
 	out, _ := json.Marshal(envelope)

--- a/src/semantic-router/pkg/anthropic/outbound.go
+++ b/src/semantic-router/pkg/anthropic/outbound.go
@@ -135,6 +135,10 @@ type anthropicErrorDetail struct {
 // Contract:
 //   - Returns (nil, err) only when responseBody is not valid OpenAI
 //     ChatCompletion JSON.
+//   - An OpenAI-shape error body ({"error":{...}}) is re-emitted as the
+//     Anthropic error envelope instead of a Message, with its error type
+//     mapped to one of Anthropic's defined error types; the items below
+//     apply to non-error bodies.
 //   - Tolerates a nil ext (zero usage; no warnings appended) so that
 //     defensive callers do not need to guard.
 //   - Always emits a non-null content array (possibly empty when the
@@ -146,6 +150,10 @@ type anthropicErrorDetail struct {
 //     stop reasons "pause_turn" or "refusal"), it overrides the
 //     OpenAI-derived mapping.
 func EmitAnthropicResponse(responseBody []byte, ext *ir.IRExtensions, model string) ([]byte, error) {
+	if errType, errMsg, ok := openAIErrorBody(responseBody); ok {
+		return EmitAnthropicError(anthropicErrorType(errType), errMsg), nil
+	}
+
 	var oa openai.ChatCompletion
 	if err := json.Unmarshal(responseBody, &oa); err != nil {
 		return nil, fmt.Errorf("anthropic outbound: parse OpenAI response: %w", err)

--- a/src/semantic-router/pkg/ir/extensions.go
+++ b/src/semantic-router/pkg/ir/extensions.go
@@ -133,9 +133,27 @@ type IRExtensions struct {
 	// matched, so this is populated only on Anthropic-backend cells.
 	AnthropicStopSequence string
 
+	// AnthropicErrorRequestID mirrors the top-level request_id of an
+	// upstream Anthropic error envelope so the outbound emitter can restore
+	// it on the re-emitted envelope. Kept out of the OpenAI-shaped
+	// intermediate body on purpose: OpenAI error bodies stay spec-pure, and
+	// OpenAI-protocol clients receive the identifier via the passed-through
+	// request-id response header instead.
+	AnthropicErrorRequestID string
+
 	// Warnings accumulates parse- and emit-time observations. Surfaced via
 	// response headers, structured logging, and metrics.
 	Warnings []Warning
+}
+
+// ErrorRequestID is the nil-safe accessor for AnthropicErrorRequestID,
+// following the package's nil-safe method convention so emit paths that
+// tolerate a nil sidecar need no inline guard.
+func (e *IRExtensions) ErrorRequestID() string {
+	if e == nil {
+		return ""
+	}
+	return e.AnthropicErrorRequestID
 }
 
 // AppendWarning is nil-safe: when e is nil the call is a no-op, so callers


### PR DESCRIPTION
Fixes #2956 

## Purpose

When an Anthropic-format backend returns an error envelope
(`{"type":"error","error":{...}}`), the router forwards the upstream HTTP
status correctly but replaces the body with an empty success-shaped object:
OpenAI-protocol clients receive an empty `chat.completion` and
Anthropic-protocol clients an empty `message`, with the upstream error
message and type destroyed. Any routine backend error triggers it — 401
authentication, 429 rate limits, 529 overloaded, unknown model IDs.

Root cause: the error envelope unmarshals into a zero-valued
`anthropic.Message` without complaint, so both translation directions
flatten it into an empty success body.

The fix guards both directions:

- `toOpenAIResponseBody` detects the Anthropic error envelope (via the
  SDK's `anthropic.ErrorResponse` and `constant.ValueOf[constant.Error]()`)
  and preserves it as an OpenAI-shape error body (`{"error":{"message","type"}}`).
- `EmitAnthropicResponse` detects OpenAI-shape error bodies — whether
  produced by the guard above or returned natively by an OpenAI-format
  backend — and re-emits the Anthropic error envelope via the existing
  `EmitAnthropicError`, mapping OpenAI-only error-type tokens to valid
  Anthropic error types (`rate_limit_exceeded`→`rate_limit_error`,
  `insufficient_quota`→`billing_error`, unknown→`api_error`).

Affected module: `pkg/anthropic` (response translation); the two existing
translation files gain one call site each.

### Design notes

- The new symbols live in a dedicated `error_passthrough.go`, following the
  package's existing pattern of concern-scoped helper files consumed from
  the public entry points (`request_body.go` does the same for request-body
  construction, as its header documents).
- The OpenAI error envelope is declared as a local struct rather than
  openai-go's `shared.ErrorObject`, deliberately: the SDK type's lenient
  decoder accepts non-object `"error"` values (e.g. a success response
  carrying `"error": false`) without erroring, which would misclassify
  successful responses as errors. Plain `encoding/json` rejects them; a
  unit test pins this boundary.
- The Anthropic error-type token list in `anthropicErrorType` uses string
  literals rather than SDK constants: the SDK exposes each token only as a
  separate marker type with no enumerable list, and its own
  `ErrorObjectUnion.AsAny()` switches on the same literals. A table test
  pins every token.

## Test Plan

- `go test ./pkg/anthropic/` — includes 9 new tests in
  `error_passthrough_test.go`
- `go test ./pkg/extproc/` — full suite, CGO-linked.
- `gofmt -l` / `go vet` on `pkg/anthropic`.
- `make agent-ci-lint CHANGED_FILES="src/semantic-router/pkg/anthropic/..."`.
- Live verification against `api.anthropic.com` through the local
  Envoy+extproc stack with an invalid API key, both client protocols, plus
  a success-path regression check against an Anthropic-Messages test
  backend.

## Test Result

- `go test ./pkg/anthropic/` — ok (all tests pass).
- `go test ./pkg/extproc/` — ok (full suite passes).
- `gofmt` / `go vet` — clean.
- `make agent-ci-lint ...` — exit 0 (all pre-commit hooks and the fast test
  gate pass).
- Live, with an invalid key (HTTP 401 preserved in both cases):
  - OpenAI client (`/v1/chat/completions`), previously an empty
    `chat.completion`, now:
    `{"error":{"type":"authentication_error","message":"API key is invalid."}}`
  - Anthropic client (`/v1/messages`), previously an empty `message`, now
    the upstream envelope unchanged:
    `{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}`
  - Success-path regression, verified live on both client protocols against
    an Anthropic-Messages test backend: normal completions translate
    unchanged (including cache usage counters on the Anthropic-client
    path).
  - Streaming requests (`"stream": true`) with the invalid key: same
    preserved error bodies and status on both protocols (the failure occurs
    before SSE starts, so it takes the same translation path).

Scope note: this also covers streaming requests — the errors in question
occur before any SSE starts, so the upstream returns a plain JSON body that
takes the same (now guarded) translation path; the client receives the
error as JSON with the upstream status, matching what the upstream APIs
themselves do for pre-stream failures. Mid-stream SSE error events are
handled by the existing streaming translators and are unchanged. No known
remaining risk.
