### PR TITLE
cover macOS Podman runtime detection and GID handling (#2954)

### DIFF
--- a/src/vllm-sr/tests/test_container_run_command.py
+++ b/src/vllm-sr/tests/test_container_run_command.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -115,3 +117,67 @@ def test_maybe_append_nvidia_gpu_passthrough_skips_when_disabled():
         cmd, enable_nvidia_gpu=False, runtime="docker"
     )
     assert cmd == []
+
+
+def test_append_supplemental_gids_uses_keep_groups_for_rootless_podman_on_linux(
+    monkeypatch,
+):
+    monkeypatch.setattr(container_run_command.sys, "platform", "linux")
+    monkeypatch.setattr(container_run_command.os, "geteuid", lambda: 1000)
+    cmd = []
+    container_run_command.append_supplemental_gids(cmd, [100, 200], "podman")
+    assert cmd == ["--group-add", "keep-groups"]
+
+
+def test_append_supplemental_gids_uses_explicit_gids_for_podman_on_macos(
+    monkeypatch,
+):
+    """macOS Podman machine runs in remote mode and rejects keep-groups (#2954)."""
+    monkeypatch.setattr(container_run_command.sys, "platform", "darwin")
+    monkeypatch.setattr(container_run_command.os, "geteuid", lambda: 1000)
+    cmd = []
+    container_run_command.append_supplemental_gids(cmd, [100, 200], "podman")
+    assert cmd == ["--group-add", "100", "--group-add", "200"]
+
+
+def test_append_supplemental_gids_uses_explicit_gids_for_root_podman_on_linux(
+    monkeypatch,
+):
+    monkeypatch.setattr(container_run_command.sys, "platform", "linux")
+    monkeypatch.setattr(container_run_command.os, "geteuid", lambda: 0)
+    cmd = []
+    container_run_command.append_supplemental_gids(cmd, [100], "podman")
+    assert cmd == ["--group-add", "100"]
+
+
+def test_append_supplemental_gids_uses_explicit_gids_for_docker_on_linux(
+    monkeypatch,
+):
+    monkeypatch.setattr(container_run_command.sys, "platform", "linux")
+    monkeypatch.setattr(container_run_command.os, "geteuid", lambda: 1000)
+    cmd = []
+    container_run_command.append_supplemental_gids(cmd, [100], "docker")
+    assert cmd == ["--group-add", "100"]
+
+
+def test_append_supplemental_gids_dedupes_and_preserves_order(monkeypatch):
+    monkeypatch.setattr(container_run_command.sys, "platform", "linux")
+    monkeypatch.setattr(container_run_command.os, "geteuid", lambda: 1000)
+    cmd = []
+    container_run_command.append_supplemental_gids(cmd, [100, 200, 100], "docker")
+    assert cmd == ["--group-add", "100", "--group-add", "200"]
+
+
+def test_append_supplemental_gids_noop_when_empty(monkeypatch):
+    monkeypatch.setattr(container_run_command.sys, "platform", "linux")
+    monkeypatch.setattr(container_run_command.os, "geteuid", lambda: 1000)
+    cmd = []
+    container_run_command.append_supplemental_gids(cmd, [], "podman")
+    assert cmd == []
+
+
+def test_append_supplemental_gids_rejects_non_positive_gid(monkeypatch):
+    monkeypatch.setattr(container_run_command.sys, "platform", "darwin")
+    monkeypatch.setattr(container_run_command.os, "geteuid", lambda: 1000)
+    with pytest.raises(ValueError):
+        container_run_command.append_supplemental_gids([], [0], "podman")

--- a/src/vllm-sr/tests/test_container_runtime.py
+++ b/src/vllm-sr/tests/test_container_runtime.py
@@ -132,6 +132,39 @@ def test_detect_container_runtime_falls_back_to_podman_when_only_podman_exists(
     assert container_runtime.get_container_runtime() == "podman"
 
 
+def test_detect_container_runtime_falls_back_to_podman_on_macos_when_only_podman_exists(
+    monkeypatch,
+):
+    """Reproduces #2954: macOS with only Podman installed (podman machine running)."""
+    monkeypatch.setattr(container_runtime.sys, "platform", "darwin")
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/opt/homebrew/bin/podman" if name == "podman" else None,
+    )
+    _stub_podman_info(monkeypatch)
+
+    assert container_runtime.get_container_runtime() == "podman"
+
+
+def test_detect_container_runtime_reports_unreachable_when_macos_podman_machine_stopped(
+    monkeypatch,
+):
+    """A stopped `podman machine` should fail as unreachable, not unsupported."""
+    monkeypatch.setattr(container_runtime.sys, "platform", "darwin")
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/opt/homebrew/bin/podman" if name == "podman" else None,
+    )
+    _stub_podman_info(monkeypatch, ok=False)
+
+    with pytest.raises(SystemExit):
+        container_runtime.get_container_runtime()
+
+
 def test_detect_container_runtime_falls_back_to_podman_when_docker_is_podman_symlink(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Closes #2954.

The reported failure — `vllm-sr serve` rejecting Podman with
"Unsupported container runtime: podman" — no longer reproduces on
`main`. At v0.3.0 (the version in the report), the runtime-selection
file (`docker_runtime.py`) hard-rejected Podman with that exact
message. It has since been rewritten as `container_runtime.py` with
full Docker/Podman support (#2291), including a macOS-specific fix in
`append_supplemental_gids()` for Podman's remote-mode GID handling.

That macOS/Podman code path had no test coverage anywhere, so the
exact scenario in #2954 was unverified and could regress silently.
This PR closes that gap rather than changing behavior.

## Changes

- `test_container_runtime.py`: add macOS-platform cases for the
  Docker-absent/Podman-present auto-detect path (the reported
  scenario) and for a stopped `podman machine` failing as
  "unreachable" rather than "unsupported".
- `test_container_run_command.py`: first-ever coverage for
  `append_supplemental_gids()` — Linux rootless Podman (`keep-groups`),
  **macOS Podman (explicit GIDs, the #2954-relevant branch)**, root/
  Docker fallback paths, GID de-duplication, and invalid-GID rejection.
