### PR TITLE
[Feature] Add a contributor journey skill for deployment and recipe workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ invokes the selected backend and recipe-scoped plugins.
 - Full task routing, primary-skill resolution, local-rule surfacing, loop-mode guidance, and validation planning come from `make agent-report ENV=cpu|amd CHANGED_FILES="..."`.
 - Follow the primary skill selected from [tools/agent/skills/](tools/agent/skills/)
   instead of treating the root entrypoint as a task-specific skill.
+- For contributor deployment, recipe generation, evaluation, and reviewed tuning
+  workflows, use [tools/agent/skills/contributor/vllm-sr-journey/SKILL.md](tools/agent/skills/contributor/vllm-sr-journey/SKILL.md).
 - `tools/agent/**` remains the canonical harness source.
 
 If you need real AMD model deployment details instead of the minimal smoke path, also read [website/docs/installation/amd-rocm.md](website/docs/installation/amd-rocm.md) and [config/recipes/balance/config.yaml](config/recipes/balance/config.yaml).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,12 @@ test references are:
 - [Testing strategy](tools/agent/docs/testing-strategy.md)
 - [Feature-complete checklist](tools/agent/docs/feature-complete-checklist.md)
 
+For deployment, recipe scaffolding, validation, evaluation, and reviewed
+activation workflows, start from
+[tools/agent/skills/contributor/vllm-sr-journey/SKILL.md](tools/agent/skills/contributor/vllm-sr-journey/SKILL.md)
+and the public tutorial at
+[website/docs/tutorials/agent/vllm-sr-journey.md](website/docs/tutorials/agent/vllm-sr-journey.md).
+
 If implementation and intended architecture still differ after your change,
 record the durable gap under
 [tools/agent/docs/tech-debt/](tools/agent/docs/tech-debt/README.md) rather than

--- a/config/recipes/examples/journey-starter/README.md
+++ b/config/recipes/examples/journey-starter/README.md
@@ -1,0 +1,62 @@
+# Journey Starter Recipe Model Card
+
+## Overview
+
+Journey Starter is an illustrative routing recipe for the vLLM-SR contributor
+journey. It demonstrates the five-file maintained recipe contract without
+joining the CI live-conformance matrix under `config/recipes/`.
+
+## Model details
+
+| Role | Placeholder |
+| --- | --- |
+| Default route | `journey-starter-model` |
+
+## Intended use
+
+Use this example when learning `vllm-sr recipe scaffold`, journey validation,
+or review-bundle workflows. Copy patterns into a maintained recipe directory
+when you are ready to promote the profile.
+
+## Routing behavior
+
+All requests route to the default catch-all decision.
+
+## Requirements
+
+- Reachable OpenAI-compatible endpoint at `host.docker.internal:8000`.
+- Replace placeholder endpoints before activation.
+- Pass secrets with `vllm-sr serve --recipe-env VAR` when env-backed credentials are configured.
+
+## Data handling and safety
+
+Review data retention, replay, and plugin behavior before production use.
+
+## Quick start
+
+```bash
+vllm-sr validate --config config/recipes/examples/journey-starter/config.yaml
+python3 tools/agent/scripts/vllm_sr_journey.py validate \
+  --config config/recipes/examples/journey-starter/config.yaml \
+  --recipe-dir config/recipes/examples/journey-starter
+vllm-sr serve --config config/recipes/examples/journey-starter/config.yaml
+```
+
+## Evaluation
+
+Starter probes live in [`probes.yaml`](probes.yaml). See
+[`../../CONFORMANCE.md`](../../CONFORMANCE.md) for the maintained recipe contract.
+
+## Limitations
+
+- Placeholder backends are not production-ready.
+- Probe coverage is minimal until expanded.
+- This example is not part of the maintained catalog matrix.
+
+## References
+
+- [Recipe metadata](metadata.yaml)
+- [Runtime configuration](config.yaml)
+- [Routing DSL](recipe.dsl)
+- [Evaluation probes](probes.yaml)
+- [Contributor journey tutorial](https://github.com/vllm-project/semantic-router/blob/main/website/docs/tutorials/agent/vllm-sr-journey.md)

--- a/config/recipes/examples/journey-starter/config.yaml
+++ b/config/recipes/examples/journey-starter/config.yaml
@@ -1,0 +1,39 @@
+version: v0.3
+
+listeners:
+  - name: http-8899
+    address: 0.0.0.0
+    port: 8899
+    timeout: 300s
+
+global:
+  router:
+    auto_model_names:
+      - vllm-sr/auto
+
+providers:
+  defaults:
+    default_model: journey-starter-model
+  models:
+    - name: journey-starter-model
+      backend_refs:
+        - name: primary
+          endpoint: host.docker.internal:8000
+          protocol: http
+          weight: 100
+
+routing:
+  modelCards:
+    - name: journey-starter-model
+  decisions:
+    - name: default-route
+      description: Catch-all route for the journey-starter example recipe.
+      priority: 100
+      rules:
+        operator: AND
+        conditions: []
+      modelRefs:
+        - model: journey-starter-model
+          use_reasoning: false
+      algorithm:
+        type: static

--- a/config/recipes/examples/journey-starter/metadata.yaml
+++ b/config/recipes/examples/journey-starter/metadata.yaml
@@ -1,0 +1,18 @@
+schema_version: vllm-sr/recipe-metadata/v1
+id: journey-starter
+name: Journey Starter
+version: 0.1.0
+description: >-
+  Illustrative starter recipe for the vLLM-SR contributor journey. Not part of
+  the maintained catalog matrix.
+authors:
+  - name: vLLM Semantic Router Contributors
+    url: https://github.com/vllm-project/semantic-router/graphs/contributors
+license: Apache-2.0
+tags:
+  - example
+  - scaffold
+  - starter
+links:
+  source: https://github.com/vllm-project/semantic-router/tree/main/config/recipes/examples/journey-starter
+  documentation: https://github.com/vllm-project/semantic-router/blob/main/config/recipes/examples/journey-starter/README.md

--- a/config/recipes/examples/journey-starter/probes.yaml
+++ b/config/recipes/examples/journey-starter/probes.yaml
@@ -1,0 +1,30 @@
+schema_version: v1
+name: journey-starter
+description: Starter probes for the journey-starter example recipe.
+routing_assets:
+  yaml: config/recipes/examples/journey-starter/config.yaml
+  dsl: config/recipes/examples/journey-starter/recipe.dsl
+router_eval_endpoint: /api/v1/eval
+evaluation:
+  request_timeout_seconds: 300
+  concurrency: 1
+acceptance:
+  min_probe_pass_rate: 100.0
+  min_decision_pass_rate: 100.0
+coverage:
+  min_signal_assertion_percent: 0.0
+  min_projection_assertion_percent: 0.0
+  min_algorithm_assertion_percent: 100.0
+  min_plugin_assertion_percent: 0.0
+  required_request_shapes: [text]
+  min_tag_counts: {}
+  min_tag_pass_rate: {}
+decisions:
+  - id: default-route
+    expected_decision: default-route
+    expected_algorithm: static
+    objective: Default catch-all route for the journey-starter example.
+    variants:
+      - id: hello
+        query: Say hello and confirm the router is reachable.
+        tags: [baseline]

--- a/config/recipes/examples/journey-starter/recipe.dsl
+++ b/config/recipes/examples/journey-starter/recipe.dsl
@@ -1,0 +1,8 @@
+# Journey starter routing DSL.
+# Extend signals and decisions using config/fragments/ as reference.
+
+DECISION "default-route" {
+  priority: 100
+  rules: []
+  modelRefs: [{ model: "journey-starter-model", use_reasoning: false }]
+  algorithm: static

--- a/src/vllm-sr/cli/AGENTS.md
+++ b/src/vllm-sr/cli/AGENTS.md
@@ -21,3 +21,4 @@
 - Do not encode the same canonical field inventory or signal/plugin type list independently across `models.py`, `config_migration.py`, and `validator.py` when one shared inventory or helper can own it.
 - When adding new config-contract surface area, prefer dedicated schema-family or validation helpers instead of growing the all-in-one `models.py` / `validator.py` hotspots.
 - Keep legacy migration behavior behind explicit compatibility helpers; do not turn `config_migration.py` into a second general-purpose config runtime.
+- Keep recipe packaging and scaffolding in `recipe_package.py` and `recipe_scaffold.py`; register CLI entrypoints from `commands/recipe.py`.

--- a/src/vllm-sr/cli/commands/recipe.py
+++ b/src/vllm-sr/cli/commands/recipe.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import click
 
+from cli.model_catalog import ModelCatalogError
 from cli.recipe_package import RecipePackageError, pack_recipe
+from cli.recipe_scaffold import RecipeScaffoldError, scaffold_recipe
 
 
 @click.group()
@@ -35,3 +37,53 @@ def pack(recipe_dir: Path, output: Path | None) -> None:
         raise click.ClickException(str(error)) from error
 
     click.echo(json.dumps(result.as_dict(), sort_keys=True))
+
+
+@recipe.command("scaffold")
+@click.option("--name", required=True, help="Recipe directory id (lowercase slug).")
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output directory (default: config/recipes/<name>/).",
+)
+@click.option(
+    "--from",
+    "from_model",
+    default=None,
+    help="Fork from a built-in catalog model such as vllm-sr/mom-v1-blend.",
+)
+@click.option(
+    "--from-recipe",
+    default=None,
+    help="Fork from an existing maintained recipe directory name.",
+)
+@click.option(
+    "--multi-profile",
+    is_flag=True,
+    help="Generate a multi-profile config with entrypoints and recipes[].",
+)
+def scaffold(
+    name: str,
+    output: Path | None,
+    from_model: str | None,
+    from_recipe: str | None,
+    multi_profile: bool,
+) -> None:
+    """Create a maintained five-file recipe directory."""
+
+    if from_model and from_recipe:
+        raise click.ClickException("use only one of --from or --from-recipe")
+
+    try:
+        result = scaffold_recipe(
+            name,
+            output=output,
+            from_recipe=from_recipe,
+            from_model=from_model,
+            multi_profile=multi_profile,
+        )
+    except (ModelCatalogError, OSError, RecipeScaffoldError) as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo(json.dumps(result, sort_keys=True))

--- a/src/vllm-sr/cli/recipe_scaffold.py
+++ b/src/vllm-sr/cli/recipe_scaffold.py
@@ -1,0 +1,359 @@
+"""Scaffold maintained five-file recipe directories for vLLM-SR."""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from cli.model_catalog import DEFAULT_CHANNEL, ModelCatalogError, find_catalog_model
+from cli.parser import parse_user_config
+from cli.validator import validate_user_config
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_TEMPLATE = (
+    Path(__file__).resolve().parent / "templates" / "config.template.yaml"
+)
+RECIPES_ROOT = REPO_ROOT / "config" / "recipes"
+BUILTIN_ROOT = RECIPES_ROOT / "built-in" / "latest"
+REQUIRED_RECIPE_FILES = (
+    "config.yaml",
+    "metadata.yaml",
+    "recipe.dsl",
+    "probes.yaml",
+    "README.md",
+)
+PLACEHOLDER_ENDPOINT = "host.docker.internal:8000"
+_RECIPE_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+class RecipeScaffoldError(Exception):
+    """Raised when recipe scaffolding cannot complete safely."""
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RecipeScaffoldError(f"expected mapping in {path}")
+    return payload
+
+
+def _dump_yaml(payload: dict[str, Any]) -> str:
+    return yaml.safe_dump(payload, sort_keys=False)
+
+
+def _validate_recipe_id(name: str) -> str:
+    slug = name.strip().lower().replace("_", "-")
+    if not _RECIPE_ID.fullmatch(slug):
+        raise RecipeScaffoldError(
+            "recipe name must use lowercase letters, digits, and hyphens only"
+        )
+    return slug
+
+
+def _redact_config(document: dict[str, Any]) -> dict[str, Any]:
+    redacted = yaml.safe_load(yaml.safe_dump(document))
+    for model in redacted.get("providers", {}).get("models", []):
+        for backend in model.get("backend_refs", []):
+            if "endpoint" in backend:
+                backend["endpoint"] = PLACEHOLDER_ENDPOINT
+            if "base_url" in backend:
+                backend["base_url"] = "https://example.invalid/v1"
+            for secret_key in ("api_key", "api_key_env"):
+                if secret_key in backend:
+                    backend.pop(secret_key, None)
+    return redacted
+
+
+def _default_config(recipe_id: str, *, multi_profile: bool) -> dict[str, Any]:
+    template_path = DEFAULT_TEMPLATE
+    document = _load_yaml(template_path)
+    model_name = f"{recipe_id}-model"
+    document["providers"]["defaults"]["default_model"] = model_name
+    document["providers"]["models"] = [
+        {
+            "name": model_name,
+            "backend_refs": [
+                {
+                    "name": "primary",
+                    "endpoint": PLACEHOLDER_ENDPOINT,
+                    "protocol": "http",
+                    "weight": 100,
+                }
+            ],
+        }
+    ]
+    document["routing"]["modelCards"] = [{"name": model_name}]
+    document["routing"]["decisions"][0]["modelRefs"] = [
+        {"model": model_name, "use_reasoning": False}
+    ]
+    document.setdefault("global", {})
+    document["global"].setdefault("router", {})
+    if multi_profile:
+        routing_block = document.pop("routing")
+        model_cards = routing_block.pop("modelCards", [])
+        recipe_routing = {"decisions": routing_block.pop("decisions")}
+        document["routing"] = {"modelCards": model_cards}
+        document["entrypoints"] = [
+            {"model_names": [f"vllm-sr/{recipe_id}-blend"], "recipe": "default"}
+        ]
+        document["recipes"] = [{"name": "default", "routing": recipe_routing}]
+    else:
+        document["global"]["router"]["auto_model_names"] = ["vllm-sr/auto"]
+    return document
+
+
+def _catalog_recipe_dir(model_id: str) -> Path:
+    _catalog, model = find_catalog_model(model_id, catalog_version=DEFAULT_CHANNEL)
+    candidate = BUILTIN_ROOT / model.asset
+    if candidate.is_dir():
+        return candidate
+    raise RecipeScaffoldError(
+        f"no built-in recipe directory found for catalog model {model_id} (asset={model.asset})"
+    )
+
+
+def _source_recipe_dir(from_recipe: str | None, from_model: str | None) -> Path | None:
+    if from_recipe:
+        candidate = RECIPES_ROOT / from_recipe
+        if not candidate.is_dir():
+            raise RecipeScaffoldError(f"recipe not found: {from_recipe}")
+        return candidate
+    if from_model:
+        return _catalog_recipe_dir(from_model)
+    return None
+
+
+def _metadata_for(recipe_id: str, title: str) -> dict[str, Any]:
+    return {
+        "schema_version": "vllm-sr/recipe-metadata/v1",
+        "id": recipe_id,
+        "name": title,
+        "version": "0.1.0",
+        "description": f"Scaffolded recipe for {title}. Replace placeholders before production use.",
+        "authors": [
+            {
+                "name": "vLLM Semantic Router Contributors",
+                "url": "https://github.com/vllm-project/semantic-router/graphs/contributors",
+            }
+        ],
+        "license": "Apache-2.0",
+        "tags": ["scaffold", "starter"],
+        "links": {
+            "source": f"https://github.com/vllm-project/semantic-router/tree/main/config/recipes/{recipe_id}",
+            "documentation": f"https://github.com/vllm-project/semantic-router/blob/main/config/recipes/{recipe_id}/README.md",
+        },
+    }
+
+
+def _probes_for(recipe_id: str, decision_name: str) -> dict[str, Any]:
+    return {
+        "schema_version": "v1",
+        "name": recipe_id,
+        "description": f"Starter probes for the {recipe_id} recipe. Expand coverage before promotion.",
+        "routing_assets": {
+            "yaml": f"config/recipes/{recipe_id}/config.yaml",
+            "dsl": f"config/recipes/{recipe_id}/recipe.dsl",
+        },
+        "router_eval_endpoint": "/api/v1/eval",
+        "evaluation": {"request_timeout_seconds": 300, "concurrency": 1},
+        "acceptance": {"min_probe_pass_rate": 100.0, "min_decision_pass_rate": 100.0},
+        "coverage": {
+            "min_signal_assertion_percent": 0.0,
+            "min_projection_assertion_percent": 0.0,
+            "min_algorithm_assertion_percent": 100.0,
+            "min_plugin_assertion_percent": 0.0,
+            "required_request_shapes": ["text"],
+            "min_tag_counts": {},
+            "min_tag_pass_rate": {},
+        },
+        "decisions": [
+            {
+                "id": decision_name,
+                "expected_decision": decision_name,
+                "expected_algorithm": "static",
+                "objective": "Default catch-all route for the scaffolded recipe.",
+                "variants": [
+                    {
+                        "id": "hello",
+                        "query": "Say hello and confirm the router is reachable.",
+                        "tags": ["baseline"],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _dsl_for(decision_name: str, model_name: str) -> str:
+    return "\n".join(
+        [
+            "# Scaffolded routing DSL.",
+            "# Extend signals and decisions using config/fragments/ as reference.",
+            "",
+            f'DECISION "{decision_name}" {{',
+            "  priority: 100",
+            "  rules: []",
+            f'  modelRefs: [{{ model: "{model_name}", use_reasoning: false }}]',
+            "  algorithm: static",
+            "}",
+            "",
+        ]
+    )
+
+
+def _readme_for(recipe_id: str, title: str) -> str:
+    return "\n".join(
+        [
+            f"# {title} Recipe Model Card",
+            "",
+            "## Overview",
+            "",
+            f"{title} is a scaffolded routing recipe generated by `vllm-sr recipe scaffold`.",
+            "Replace placeholder backends and expand probes before production use.",
+            "",
+            "## Model details",
+            "",
+            "| Role | Placeholder |",
+            "| --- | --- |",
+            f"| Default route | `{recipe_id}-model` |",
+            "",
+            "## Intended use",
+            "",
+            "Use this recipe as a starting point for a custom maintained routing profile.",
+            "",
+            "## Routing behavior",
+            "",
+            "All requests currently route to the default catch-all decision.",
+            "",
+            "## Requirements",
+            "",
+            f"- Reachable OpenAI-compatible endpoint at `{PLACEHOLDER_ENDPOINT}`.",
+            "- Replace placeholder endpoints before activation.",
+            "- Pass secrets with `vllm-sr serve --recipe-env VAR` when env-backed credentials are configured.",
+            "",
+            "## Data handling and safety",
+            "",
+            "Review data retention, replay, and plugin behavior before production use.",
+            "",
+            "## Quick start",
+            "",
+            "```bash",
+            f"vllm-sr validate --config config/recipes/{recipe_id}/config.yaml",
+            f"vllm-sr serve --config config/recipes/{recipe_id}/config.yaml",
+            "```",
+            "",
+            "## Evaluation",
+            "",
+            f"Starter probes live in [`probes.yaml`](probes.yaml). See [`../CONFORMANCE.md`](../CONFORMANCE.md).",
+            "",
+            "## Limitations",
+            "",
+            "- Placeholder backends are not production-ready.",
+            "- Probe coverage is minimal until expanded.",
+            "",
+            "## References",
+            "",
+            "- [Recipe metadata](metadata.yaml)",
+            "- [Runtime configuration](config.yaml)",
+            "- [Routing DSL](recipe.dsl)",
+            "- [Evaluation probes](probes.yaml)",
+            "- [Config fragments](https://github.com/vllm-project/semantic-router/tree/main/config/fragments)",
+            "",
+        ]
+    )
+
+
+def _validate_document(document: dict[str, Any], config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(_dump_yaml(document), encoding="utf-8")
+    user_config = parse_user_config(str(config_path), log_summary=False)
+    errors = validate_user_config(user_config, log_summary=False)
+    if errors:
+        raise RecipeScaffoldError(
+            "generated config failed validation:\n" + "\n".join(errors)
+        )
+
+
+def scaffold_recipe(
+    name: str,
+    *,
+    output: Path | None = None,
+    from_recipe: str | None = None,
+    from_model: str | None = None,
+    multi_profile: bool = False,
+) -> dict[str, Any]:
+    recipe_id = _validate_recipe_id(name)
+    title = recipe_id.replace("-", " ").title()
+    destination = output or (RECIPES_ROOT / recipe_id)
+    destination = destination.resolve()
+    if destination.exists():
+        raise RecipeScaffoldError(
+            f"refusing to overwrite existing directory: {destination}"
+        )
+
+    source_dir = _source_recipe_dir(from_recipe, from_model)
+    if source_dir is not None:
+        shutil.copytree(source_dir, destination)
+        config_path = destination / "config.yaml"
+        document = _redact_config(_load_yaml(config_path))
+        metadata = _load_yaml(destination / "metadata.yaml")
+        metadata["id"] = recipe_id
+        metadata["name"] = title
+        metadata["version"] = "0.1.0"
+        metadata.setdefault("tags", [])
+        if "scaffold" not in metadata["tags"]:
+            metadata["tags"] = list(metadata["tags"]) + ["scaffold"]
+        probes = _load_yaml(destination / "probes.yaml")
+        probes["name"] = recipe_id
+        probes["routing_assets"] = {
+            "yaml": f"config/recipes/{recipe_id}/config.yaml",
+            "dsl": f"config/recipes/{recipe_id}/recipe.dsl",
+        }
+        readme = _readme_for(recipe_id, title)
+        _validate_document(document, config_path)
+        (destination / "metadata.yaml").write_text(
+            _dump_yaml(metadata), encoding="utf-8"
+        )
+        (destination / "probes.yaml").write_text(_dump_yaml(probes), encoding="utf-8")
+        (destination / "README.md").write_text(readme, encoding="utf-8")
+    else:
+        destination.mkdir(parents=True, exist_ok=False)
+        document = _default_config(recipe_id, multi_profile=multi_profile)
+        if multi_profile:
+            decision_name = document["recipes"][0]["routing"]["decisions"][0]["name"]
+            model_name = document["providers"]["models"][0]["name"]
+        else:
+            decision_name = document["routing"]["decisions"][0]["name"]
+            model_name = document["providers"]["models"][0]["name"]
+        config_path = destination / "config.yaml"
+        _validate_document(document, config_path)
+        (destination / "metadata.yaml").write_text(
+            _dump_yaml(_metadata_for(recipe_id, title)), encoding="utf-8"
+        )
+        (destination / "probes.yaml").write_text(
+            _dump_yaml(_probes_for(recipe_id, decision_name)), encoding="utf-8"
+        )
+        (destination / "recipe.dsl").write_text(
+            _dsl_for(decision_name, model_name), encoding="utf-8"
+        )
+        (destination / "README.md").write_text(
+            _readme_for(recipe_id, title), encoding="utf-8"
+        )
+
+    written = sorted(path.name for path in destination.iterdir() if path.is_file())
+    missing = [name for name in REQUIRED_RECIPE_FILES if name not in written]
+    if missing:
+        raise RecipeScaffoldError(f"scaffold incomplete; missing files: {missing}")
+
+    return {
+        "recipe_id": recipe_id,
+        "output": str(destination),
+        "files": written,
+        "source": str(source_dir) if source_dir else "template",
+        "multi_profile": multi_profile,
+        "verification": "validated",
+    }

--- a/src/vllm-sr/tests/test_recipe_scaffold.py
+++ b/src/vllm-sr/tests/test_recipe_scaffold.py
@@ -1,0 +1,98 @@
+"""Tests for maintained recipe scaffolding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from cli.commands.recipe import recipe
+from cli.main import main
+from cli.recipe_scaffold import RecipeScaffoldError, scaffold_recipe
+
+
+def test_recipe_scaffold_creates_five_files(tmp_path: Path):
+    output = tmp_path / "starter"
+    result = scaffold_recipe("starter", output=output)
+
+    assert result["recipe_id"] == "starter"
+    assert sorted(result["files"]) == sorted(
+        [
+            "README.md",
+            "config.yaml",
+            "metadata.yaml",
+            "probes.yaml",
+            "recipe.dsl",
+        ]
+    )
+    config = yaml.safe_load((output / "config.yaml").read_text(encoding="utf-8"))
+    assert config["version"] == "v0.3"
+    assert config["global"]["router"]["auto_model_names"] == ["vllm-sr/auto"]
+
+
+def test_recipe_scaffold_multi_profile(tmp_path: Path):
+    output = tmp_path / "multi"
+    scaffold_recipe("multi", output=output, multi_profile=True)
+    config = yaml.safe_load((output / "config.yaml").read_text(encoding="utf-8"))
+    assert config["entrypoints"]
+    assert config["recipes"]
+    assert "decisions" not in config.get("routing", {})
+    assert config["recipes"][0]["routing"]["decisions"]
+
+
+def test_recipe_scaffold_from_recipe_redacts_endpoints(tmp_path: Path):
+    output = tmp_path / "fork-balance"
+    scaffold_recipe("fork-balance", output=output, from_recipe="balance")
+    config = yaml.safe_load((output / "config.yaml").read_text(encoding="utf-8"))
+    endpoints = [
+        backend.get("endpoint")
+        for model in config["providers"]["models"]
+        for backend in model.get("backend_refs", [])
+        if backend.get("endpoint")
+    ]
+    assert endpoints
+    assert all(endpoint == "host.docker.internal:8000" for endpoint in endpoints)
+
+
+def test_recipe_scaffold_refuses_overwrite(tmp_path: Path):
+    output = tmp_path / "dup"
+    scaffold_recipe("dup", output=output)
+    try:
+        scaffold_recipe("dup", output=output)
+    except RecipeScaffoldError as error:
+        assert "refusing to overwrite" in str(error)
+    else:
+        raise AssertionError("expected RecipeScaffoldError")
+
+
+def test_recipe_scaffold_cli_is_registered():
+    runner = CliRunner()
+
+    top = runner.invoke(main, ["--help"])
+    group = runner.invoke(main, ["recipe", "--help"])
+    command = runner.invoke(main, ["recipe", "scaffold", "--help"])
+
+    assert top.exit_code == group.exit_code == command.exit_code == 0
+    assert "scaffold" in group.output
+    assert "--from-recipe" in command.output
+
+
+def test_recipe_scaffold_cli_writes_files(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        recipe,
+        [
+            "scaffold",
+            "--name",
+            "cli-starter",
+            "--output",
+            str(tmp_path / "cli-starter"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["recipe_id"] == "cli-starter"
+    assert (tmp_path / "cli-starter" / "config.yaml").is_file()

--- a/tools/agent/context-map.yaml
+++ b/tools/agent/context-map.yaml
@@ -167,3 +167,9 @@ skills:
     resume_refs:
     - path: tools/agent/docs/tech-debt-register.md
       reason: Record remaining cross-surface architecture gaps if they stay open.
+  vllm-sr-journey:
+    resume_refs:
+    - path: tools/agent/docs/plans/pl-0039-vllm-sr-journey-skill.md
+      reason: Active execution plan for contributor deployment, recipe, eval, and tuning journeys.
+    - path: website/docs/tutorials/agent/vllm-sr-journey.md
+      reason: Public contributor journey charter and command reference.

--- a/tools/agent/docs/plans/README.md
+++ b/tools/agent/docs/plans/README.md
@@ -82,3 +82,4 @@ do not revive a completed release plan.
 
 - [PL-0032: Architecture Debt Consolidation](pl-0032-architecture-scorecard-ratchet.md)
 - [PL-0037: Router Flow Evaluation Campaign](pl-0037-router-flow-eval-campaign.md)
+- [PL-0039: vLLM-SR Contributor Journey Skill](pl-0039-vllm-sr-journey-skill.md)

--- a/tools/agent/docs/plans/pl-0039-vllm-sr-journey-skill.md
+++ b/tools/agent/docs/plans/pl-0039-vllm-sr-journey-skill.md
@@ -1,0 +1,56 @@
+# PL-0039: vLLM-SR Contributor Journey Skill
+
+## Goal
+
+Deliver the contributor-facing agent skill and helper tooling for deployment,
+recipe generation, contract validation, evaluation, reviewed tuning, and explicit
+activation described in issue #2977.
+
+## Scope
+
+- Contributor support skill and registry wiring
+- `vllm_sr_journey.py` orchestration helper
+- `vllm-sr recipe scaffold` CLI command
+- Illustrative example under `config/recipes/examples/journey-starter/`
+- Public tutorial and CONTRIBUTING pointer
+
+## Non-Goals
+
+- Autonomous production activation or scheduled tuning pipelines
+- New unsupported deployment targets
+- In-router LLM config generation services
+
+## Exit Criteria
+
+- [x] `vllm-sr-journey` skill is registered and validated by `make agent-validate`
+- [x] Journey helper supports detect-env, validate, evaluate, and review
+- [x] `vllm-sr recipe scaffold` emits validated five-file recipes
+- [x] Example journey and website tutorial are indexed
+- [x] Applicable harness gates pass for changed surfaces
+
+## Task List
+
+- [x] `JOURNEY-01` Skill charter and registry wiring
+- [x] `JOURNEY-02` `vllm_sr_journey.py` helper and make target
+- [x] `JOURNEY-03` `vllm-sr recipe scaffold` command and tests
+- [x] `JOURNEY-04` Example journey and website tutorial
+- [x] `JOURNEY-05` Harness validation and feature gates
+
+## Next Action
+
+None. Close PL-0039 after merge unless follow-up work extends the contributor journey.
+
+## Operating Rules
+
+- Generation is not acceptance; review bundles stay `activated: false` until a
+  human approves activation.
+- Private environment details stay out of committed artifacts.
+- Examples under `config/recipes/examples/` are illustrative and excluded from
+  maintained catalog discovery.
+
+## Related Docs
+
+- Issue [#2977](https://github.com/vllm-project/semantic-router/issues/2977)
+- [`tools/agent/skills/contributor/vllm-sr-journey/SKILL.md`](../../skills/contributor/vllm-sr-journey/SKILL.md)
+- [`website/docs/tutorials/agent/vllm-sr-journey.md`](../../../../website/docs/tutorials/agent/vllm-sr-journey.md)
+- [`config/recipes/CONFORMANCE.md`](../../../../config/recipes/CONFORMANCE.md)

--- a/tools/agent/docs/skill-catalog.md
+++ b/tools/agent/docs/skill-catalog.md
@@ -35,6 +35,10 @@ Maintainer:
 - `maintainer-issue-pr-management`
 - `routing-calibration-loop`
 
+Contributor:
+
+- `vllm-sr-journey`
+
 ## Source of Truth
 
 - Executable registry: [../../tools/agent/skill-registry.yaml](../../../tools/agent/skill-registry.yaml)

--- a/tools/agent/repo-manifest.yaml
+++ b/tools/agent/repo-manifest.yaml
@@ -140,6 +140,7 @@ docs:
 - tools/agent/docs/testing-strategy.md
 - tools/agent/docs/plans/pl-0032-architecture-scorecard-ratchet.md
 - tools/agent/docs/plans/pl-0037-router-flow-eval-campaign.md
+- tools/agent/docs/plans/pl-0039-vllm-sr-journey-skill.md
 - tools/agent/docs/tech-debt/td-006-structural-rule-exceptions.md
 - tools/agent/docs/tech-debt/td-016-fleet-sim-shared-ruff-contract-gap.md
 - tools/agent/docs/tech-debt/td-017-fleet-sim-structure-gate-migration-gap.md
@@ -281,6 +282,9 @@ doc_governance:
   - path: tools/agent/docs/plans/pl-0037-router-flow-eval-campaign.md
     steward: router-core
     freshness: update while the Router Flow four-mode benchmark campaign is active
+  - path: tools/agent/docs/plans/pl-0039-vllm-sr-journey-skill.md
+    steward: agent-contract
+    freshness: update while the contributor journey skill workstream is active
   - path: tools/agent/docs/tech-debt/td-006-structural-rule-exceptions.md
     steward: agent-contract
     freshness: update when the TD006 debt record changes materially
@@ -327,3 +331,4 @@ skills:
 - tools/agent/skills/signal-end-to-end/SKILL.md
 - tools/agent/skills/startup-chain-change/SKILL.md
 - tools/agent/skills/training-stack-change/SKILL.md
+- tools/agent/skills/contributor/vllm-sr-journey/SKILL.md

--- a/tools/agent/scripts/recipe_conformance.py
+++ b/tools/agent/scripts/recipe_conformance.py
@@ -50,7 +50,7 @@ REQUIRED_MODEL_CARD_HEADINGS = (
     "## References",
 )
 RUNTIME_RECIPE_DIRECTORIES = frozenset({".vllm-sr"})
-RECIPE_CATALOG_DIRECTORIES = frozenset({"built-in"})
+RECIPE_CATALOG_DIRECTORIES = frozenset({"built-in", "examples"})
 DEFAULT_AUTO_ENTRYPOINTS = ("vllm-sr/auto", "auto")
 DEFAULT_AUTO_MODEL_NAME = "MoM"
 

--- a/tools/agent/scripts/vllm_sr_journey.py
+++ b/tools/agent/scripts/vllm_sr_journey.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Contributor journey orchestration for vLLM-SR deployment, validation, and review."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_REPORT_ROOT = REPO_ROOT / ".agent-harness" / "vllm-sr-journey"
+REQUIRED_RECIPE_FILES = (
+    "config.yaml",
+    "metadata.yaml",
+    "recipe.dsl",
+    "probes.yaml",
+    "README.md",
+)
+PLACEHOLDER_ENDPOINT = "host.docker.internal:8000"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _run_command(command: list[str], *, cwd: Path | None = None) -> dict[str, Any]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd or REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "command": command,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "passed": completed.returncode == 0,
+    }
+
+
+def _load_repo_manifest() -> dict[str, Any]:
+    manifest_path = REPO_ROOT / "tools" / "agent" / "repo-manifest.yaml"
+    return yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+
+
+def _detect_gpu_vendor() -> str | None:
+    if shutil.which("nvidia-smi"):
+        probe = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if probe.returncode == 0 and probe.stdout.strip():
+            return "nvidia"
+    if Path("/dev/kfd").exists() or shutil.which("rocm-smi"):
+        return "amd"
+    return None
+
+
+def detect_environment() -> dict[str, Any]:
+    manifest = _load_repo_manifest()
+    platform_hint = os.environ.get("VLLM_SR_PLATFORM", "").strip().lower()
+    gpu_vendor = _detect_gpu_vendor()
+    default_env = manifest.get("default_env", "cpu")
+    supported = manifest.get("supported_envs", {})
+
+    selected = default_env
+    reasons: list[str] = []
+
+    if platform_hint in {"cpu", "amd", "nvidia"}:
+        selected = platform_hint
+        reasons.append(f"VLLM_SR_PLATFORM={platform_hint}")
+    elif gpu_vendor == "amd":
+        selected = "amd"
+        reasons.append("detected AMD/ROCm tooling")
+    elif gpu_vendor == "nvidia":
+        selected = "nvidia"
+        reasons.append("detected NVIDIA GPU tooling")
+    else:
+        reasons.append("default cpu-local path")
+
+    env_key = {
+        "cpu": "cpu-local",
+        "amd": "amd-local",
+        "nvidia": "nvidia-local",
+        "ci-k8s": "ci-k8s",
+    }.get(selected, "cpu-local")
+
+    env_config = supported.get(env_key, {})
+    aliases = env_config.get("aliases", [])
+    return {
+        "detected_at": _utc_now(),
+        "platform": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+        "gpu_vendor": gpu_vendor,
+        "selected_env": env_key,
+        "selected_alias": selected,
+        "reasons": reasons,
+        "build_target": env_config.get("build_target"),
+        "serve_command": env_config.get("serve_command"),
+        "smoke_config": env_config.get("smoke_config"),
+        "deployment_reference": env_config.get("deployment_reference"),
+        "example_config": env_config.get("example_config"),
+        "supported_envs": sorted(supported.keys()),
+        "aliases": aliases,
+    }
+
+
+def _validate_config(config_path: Path) -> dict[str, Any]:
+    vllm_sr = shutil.which("vllm-sr")
+    if vllm_sr is None:
+        validate_script = (
+            REPO_ROOT / "src" / "vllm-sr" / "cli" / "commands" / "validate.py"
+        )
+        parser_script = REPO_ROOT / "src" / "vllm-sr" / "cli" / "parser.py"
+        if not parser_script.exists():
+            return {
+                "passed": False,
+                "error": "vllm-sr CLI is not installed and fallback parser is unavailable",
+            }
+        result = _run_command(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; sys.path.insert(0, 'src/vllm-sr'); "
+                    "from cli.parser import parse_user_config; "
+                    "from cli.validator import validate_user_config; "
+                    f"cfg = parse_user_config('{config_path}', log_summary=False); "
+                    "errors = validate_user_config(cfg, log_summary=False); "
+                    "print('ok' if not errors else '\\n'.join(errors)); "
+                    "sys.exit(0 if not errors else 1)"
+                ),
+            ]
+        )
+    else:
+        result = _run_command(["vllm-sr", "validate", "--config", str(config_path)])
+    return {
+        "kind": "vllm-sr validate",
+        "config": str(config_path),
+        **result,
+    }
+
+
+def _validate_recipe_directory(recipe_dir: Path) -> dict[str, Any]:
+    missing = [
+        name for name in REQUIRED_RECIPE_FILES if not (recipe_dir / name).is_file()
+    ]
+    extra = [
+        entry.name
+        for entry in recipe_dir.iterdir()
+        if entry.is_file() and entry.name not in REQUIRED_RECIPE_FILES
+    ]
+    structure_ok = not missing and not extra
+    conformance_errors: list[str] = []
+    if structure_ok:
+        sys.path.insert(0, str(REPO_ROOT / "tools" / "agent" / "scripts"))
+        import recipe_conformance
+
+        try:
+            recipe_conformance.validate_recipe_directory(recipe_dir)
+            recipe_conformance.validate_recipe_model_card(recipe_dir)
+            recipe_conformance.build_recipe_inventory(recipe_dir)
+        except (TypeError, ValueError) as error:
+            conformance_errors.append(str(error))
+    return {
+        "kind": "recipe directory",
+        "recipe_dir": str(recipe_dir),
+        "missing_files": missing,
+        "extra_files": extra,
+        "structure_ok": structure_ok,
+        "conformance_errors": conformance_errors,
+        "passed": structure_ok and not conformance_errors,
+    }
+
+
+def validate_artifacts(config_path: Path, recipe_dir: Path | None) -> dict[str, Any]:
+    config_result = _validate_config(config_path)
+    recipe_result = None
+    if recipe_dir is not None:
+        recipe_result = _validate_recipe_directory(recipe_dir)
+    passed = config_result.get("passed", False) and (
+        recipe_result is None or recipe_result.get("passed", False)
+    )
+    return {
+        "validated_at": _utc_now(),
+        "config": config_result,
+        "recipe": recipe_result,
+        "passed": passed,
+    }
+
+
+def evaluate_artifacts(
+    config_path: Path,
+    *,
+    router_url: str | None,
+    probes_path: Path | None,
+) -> dict[str, Any]:
+    results: dict[str, Any] = {"evaluated_at": _utc_now(), "live": None, "static": None}
+
+    static = _run_command(
+        [
+            sys.executable,
+            str(REPO_ROOT / "tools" / "agent" / "scripts" / "recipe_conformance.py"),
+            "static",
+        ]
+    )
+    results["static"] = static
+
+    if router_url and probes_path is not None:
+        live = _run_command(
+            [
+                sys.executable,
+                str(
+                    REPO_ROOT
+                    / "tools"
+                    / "agent"
+                    / "scripts"
+                    / "router_calibration_loop.py"
+                ),
+                "eval",
+                "--router-url",
+                router_url,
+                "--probes",
+                str(probes_path),
+            ]
+        )
+        results["live"] = live
+
+    passed = static.get("passed", False)
+    if results["live"] is not None:
+        passed = passed and results["live"].get("passed", False)
+    results["passed"] = passed
+    results["config"] = str(config_path)
+    return results
+
+
+def _routing_summary(config_path: Path) -> dict[str, Any]:
+    sys.path.insert(0, str(REPO_ROOT / "src" / "vllm-sr"))
+    from cli.config_contract import iter_routing_profiles
+    from cli.parser import parse_user_config
+
+    user_config = parse_user_config(str(config_path), log_summary=False)
+    profiles = list(iter_routing_profiles(user_config))
+    decisions = [
+        {
+            "name": decision.name,
+            "priority": decision.priority,
+            "algorithm": getattr(decision.algorithm, "type", None),
+            "models": [ref.model for ref in decision.model_refs],
+            "plugins": [plugin.type.value for plugin in decision.plugins or []],
+        }
+        for _, profile in profiles
+        for decision in profile.decisions
+    ]
+    return {
+        "listeners": len(user_config.listeners),
+        "providers": [model.name for model in user_config.providers.models],
+        "default_model": user_config.providers.default_model,
+        "entrypoints": len(user_config.entrypoints),
+        "recipes": len(user_config.recipes),
+        "decisions": decisions,
+    }
+
+
+def build_review_bundle(
+    config_path: Path,
+    *,
+    recipe_dir: Path | None,
+    output_dir: Path,
+    router_url: str | None,
+    probes_path: Path | None,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    validation = validate_artifacts(config_path, recipe_dir)
+    evaluation = evaluate_artifacts(
+        config_path,
+        router_url=router_url,
+        probes_path=probes_path,
+    )
+    artifacts = [{"path": str(config_path), "sha256": _sha256_file(config_path)}]
+    if recipe_dir is not None:
+        for filename in REQUIRED_RECIPE_FILES:
+            file_path = recipe_dir / filename
+            if file_path.is_file():
+                artifacts.append(
+                    {"path": str(file_path), "sha256": _sha256_file(file_path)}
+                )
+
+    try:
+        routing_summary = _routing_summary(config_path)
+    except (
+        Exception
+    ) as error:  # noqa: BLE001 - review bundle should capture parse failures
+        routing_summary = {"error": str(error)}
+
+    bundle = {
+        "generated_at": _utc_now(),
+        "activated": False,
+        "config": str(config_path),
+        "recipe_dir": str(recipe_dir) if recipe_dir else None,
+        "artifacts": artifacts,
+        "validation": validation,
+        "evaluation": evaluation,
+        "routing_summary": routing_summary,
+        "rollback": {
+            "git": "Revert the commit or discard unstaged changes for generated artifacts.",
+            "live_apiserver": "Use GET /config/router/versions before deploy when activating on a live router.",
+            "helm": "Restore the previous configOverride values snapshot.",
+        },
+        "activation_options": [
+            "make agent-serve-local ENV=cpu|amd",
+            "vllm-sr serve --config <path>",
+            "router_calibration_loop.py deploy --router-url <url> --yaml <path>",
+        ],
+    }
+
+    _write_json(output_dir / "review.json", bundle)
+    markdown = [
+        "# vLLM-SR Journey Review Bundle",
+        "",
+        f"- Generated: {bundle['generated_at']}",
+        f"- Activated: `{bundle['activated']}`",
+        f"- Config: `{config_path}`",
+        "",
+        "## Validation",
+        f"- Passed: `{validation['passed']}`",
+        "",
+        "## Evaluation",
+        f"- Passed: `{evaluation['passed']}`",
+        "",
+        "## Routing Summary",
+        "```json",
+        json.dumps(routing_summary, indent=2, sort_keys=True),
+        "```",
+        "",
+        "## Rollback",
+        "- Git: revert or discard local artifact changes.",
+        "- Live apiserver: capture `/config/router/versions` before deploy.",
+        "- Helm: restore the previous `configOverride` snapshot.",
+        "",
+        "## Activation",
+        "Activation is explicit. Do not treat this bundle as production approval.",
+    ]
+    (output_dir / "review.md").write_text("\n".join(markdown) + "\n", encoding="utf-8")
+    return bundle
+
+
+def cmd_detect_env(_args: argparse.Namespace) -> int:
+    payload = detect_environment()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    payload = validate_artifacts(
+        Path(args.config), Path(args.recipe_dir) if args.recipe_dir else None
+    )
+    if args.output:
+        _write_json(Path(args.output), payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["passed"] else 1
+
+
+def cmd_evaluate(args: argparse.Namespace) -> int:
+    payload = evaluate_artifacts(
+        Path(args.config),
+        router_url=args.router_url,
+        probes_path=Path(args.probes) if args.probes else None,
+    )
+    if args.output:
+        _write_json(Path(args.output), payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["passed"] else 1
+
+
+def cmd_review(args: argparse.Namespace) -> int:
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else DEFAULT_REPORT_ROOT / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    )
+    payload = build_review_bundle(
+        Path(args.config),
+        recipe_dir=Path(args.recipe_dir) if args.recipe_dir else None,
+        output_dir=output_dir,
+        router_url=args.router_url,
+        probes_path=Path(args.probes) if args.probes else None,
+    )
+    print(
+        json.dumps(
+            {"output_dir": str(output_dir), "activated": payload["activated"]}, indent=2
+        )
+    )
+    return 0 if payload["validation"]["passed"] else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser(
+        "detect-env", help="Detect the supported local deployment path"
+    )
+
+    validate = subparsers.add_parser(
+        "validate", help="Validate config and optional recipe directory"
+    )
+    validate.add_argument("--config", required=True, type=Path)
+    validate.add_argument("--recipe-dir", type=Path, default=None)
+    validate.add_argument("--output", type=Path, default=None)
+
+    evaluate = subparsers.add_parser(
+        "evaluate", help="Run static and optional live evaluation gates"
+    )
+    evaluate.add_argument("--config", required=True, type=Path)
+    evaluate.add_argument("--router-url", default=None)
+    evaluate.add_argument("--probes", type=Path, default=None)
+    evaluate.add_argument("--output", type=Path, default=None)
+
+    review = subparsers.add_parser(
+        "review", help="Write a review bundle with provenance and rollback hints"
+    )
+    review.add_argument("--config", required=True, type=Path)
+    review.add_argument("--recipe-dir", type=Path, default=None)
+    review.add_argument("--router-url", default=None)
+    review.add_argument("--probes", type=Path, default=None)
+    review.add_argument("--output-dir", type=Path, default=None)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "detect-env":
+        return cmd_detect_env(args)
+    if args.command == "validate":
+        return cmd_validate(args)
+    if args.command == "evaluate":
+        return cmd_evaluate(args)
+    if args.command == "review":
+        return cmd_review(args)
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent/scripts/vllm_sr_journey_test.py
+++ b/tools/agent/scripts/vllm_sr_journey_test.py
@@ -1,0 +1,45 @@
+"""Tests for the contributor vLLM-SR journey helper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+JOURNEY_SCRIPT = REPO_ROOT / "tools" / "agent" / "scripts" / "vllm_sr_journey.py"
+
+
+def _run_journey(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(JOURNEY_SCRIPT), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_detect_env_returns_supported_envs():
+    result = _run_journey("detect-env")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "cpu-local" in payload["supported_envs"]
+    assert payload["build_target"]
+    assert payload["serve_command"]
+
+
+def test_validate_journey_starter_example():
+    config = REPO_ROOT / "config/recipes/examples/journey-starter/config.yaml"
+    recipe_dir = REPO_ROOT / "config/recipes/examples/journey-starter"
+    result = _run_journey(
+        "validate",
+        "--config",
+        str(config),
+        "--recipe-dir",
+        str(recipe_dir),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["passed"] is True

--- a/tools/agent/skill-registry.yaml
+++ b/tools/agent/skill-registry.yaml
@@ -770,3 +770,13 @@ skills:
     description: Maintainer workflow for creating, updating, or deleting GitHub issues and PR metadata using repo labels, templates, and validation context.
     acceptance_criteria:
     - Issue or PR management requests use the canonical templates, label taxonomy, and repo validation context instead of ad hoc summaries.
+  - name: vllm-sr-journey
+    path: tools/agent/skills/contributor/vllm-sr-journey/SKILL.md
+    audience: contributor
+    description: Contributor journey for supported deployment paths, recipe scaffolding, contract validation, evaluation gates, reviewed tuning, and explicit activation with rollback hints.
+    owned_surfaces:
+    - contributor_interface
+    - local_smoke
+    - docs_examples
+    acceptance_criteria:
+    - Contributor requests leave behind validated artifacts, evaluation receipts when applicable, and a review bundle that remains explicitly not activated until approved.

--- a/tools/agent/skills/contributor/vllm-sr-journey/SKILL.md
+++ b/tools/agent/skills/contributor/vllm-sr-journey/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: vllm-sr-journey
+category: support
+description: Guides deployment, recipe generation, contract validation, evaluation, and reviewed tuning for vLLM-SR. Use when a contributor needs to detect a supported environment, scaffold or fork a recipe, validate artifacts, run eval gates, or prepare an activation-ready change without auto-promoting it.
+---
+
+# vLLM-SR Contributor Journey
+
+## Trigger
+
+- Use when a contributor needs to deploy vLLM-SR locally or on supported K8s paths
+- Use when user intent should become a valid v0.3 config or maintained five-file recipe
+- Use when generated artifacts must be validated and evaluated before activation
+- Use when tuning should stay in observe mode until a human reviews replay or probe evidence
+- Use when the task needs a review bundle with provenance, diff, rollback hints, and an explicit not-activated flag
+
+## Required Surfaces
+
+- contributor_interface
+- local_smoke
+
+## Conditional Surfaces
+
+- harness_exec
+- docs_examples
+- dsl_crd
+- k8s_platform
+- deployment_profile_stack
+
+## Stop Conditions
+
+- The target environment is unsupported or the workflow would invent a deployment path
+- Validation fails and the root cause is not classified or recorded
+- A live deploy would run without a captured rollback version or git revert path
+- Private hostnames, credentials, or internal endpoints would be committed to public artifacts
+- Tuning output would be auto-promoted to production or active router config without review
+
+## Workflow
+
+1. Detect the target environment and choose a supported path only.
+   - Read [`tools/agent/repo-manifest.yaml`](../../../../../tools/agent/repo-manifest.yaml) `supported_envs` and run `python3 tools/agent/scripts/vllm_sr_journey.py detect-env`.
+   - Local paths stay on the canonical image flow: `make vllm-sr-dev`, then `vllm-sr serve --image-pull-policy never`.
+   - K8s paths defer to Helm, Operator, or `make e2e-test`; do not invent alternate serve or deploy commands.
+2. Generate or update artifacts from intent, not from unsupported shortcuts.
+   - Quick local config: start from [`src/vllm-sr/cli/templates/config.template.yaml`](../../../../../src/vllm-sr/cli/templates/config.template.yaml) or fork a built-in model with `vllm-sr model fork`.
+   - Maintained recipe: run `vllm-sr recipe scaffold --name <name> [--from <catalog-model> | --from-recipe <recipe>]`.
+   - Compose signals, decisions, algorithms, and plugins from [`config/fragments/`](../../../../../config/fragments/) when extending policy.
+3. Explain the routing design before asking for activation.
+   - Summarize the model pool, signals, decisions, algorithms, plugins, backend assumptions, and credential/env requirements.
+   - For MoM or built-in virtual models, respect the lifecycle in the MoM docs; routing policy does not install checkpoints.
+4. Validate against repository contracts before evaluation or activation.
+   - Run `vllm-sr validate --config <path>`.
+   - For maintained recipes, run `python3 tools/agent/scripts/vllm_sr_journey.py validate --config <path> --recipe-dir <dir>`.
+   - Keep private endpoints redacted; use placeholders such as `host.docker.internal:8000` and document `--recipe-env` bindings in the Model Card Requirements section.
+5. Run or guide evaluation before activation.
+   - Static-only: recipe conformance static checks and manifest inventory review.
+   - Live router: `python3 tools/agent/scripts/vllm_sr_journey.py evaluate --config <path> --router-url <url> [--probes <manifest>]`.
+   - Semantic routing tuning with a live apiserver: delegate to [`routing-calibration-loop`](../../maintainer/routing-calibration/SKILL.md).
+   - Continuous model-choice tuning: keep `global.router.learning` in `observe`, collect replay, then run `vllm-sr eval recipe-learning`; never auto-merge the report.
+6. Produce a review bundle instead of activating by default.
+   - Run `python3 tools/agent/scripts/vllm_sr_journey.py review --config <path> [--recipe-dir <dir>] [--output-dir .agent-harness/vllm-sr-journey/<session>/]`.
+   - Include digests, validation receipts, eval results, routing summary, rollback hints, and `activated: false`.
+7. Activate only after explicit human approval.
+   - Local: `make agent-serve-local ENV=cpu|amd` or `vllm-sr serve --config <path>`.
+   - Live apiserver: `router_calibration_loop.py deploy` with version capture.
+   - K8s: Helm `configOverride` or Operator CR update from the reviewed canonical YAML.
+   - Dashboard: Mixture-of-Models workspace activation after separate provider and routing checks.
+
+## Gotchas
+
+- Generation is not acceptance. A valid scaffold or fork still needs review, eval, and an explicit activation step.
+- `vllm-sr serve` starts the routing stack only; provider backends in `providers.models` must already be reachable.
+- Recipe probe success does not prove backend generation quality; verify provider endpoints separately.
+- Do not commit `.agent-harness/vllm-sr-journey/` review bundles or private environment details into the repo.
+- Examples under `config/recipes/examples/` are illustrative; maintained catalog recipes live as direct children of `config/recipes/`.
+
+## Must Read
+
+- [tools/agent/docs/environments.md](../../../../../tools/agent/docs/environments.md)
+- [config/recipes/CONFORMANCE.md](../../../../../config/recipes/CONFORMANCE.md)
+- [website/docs/installation/configuration-workflows.md](../../../../../website/docs/installation/configuration-workflows.md)
+- [website/docs/overview/mom-model-family.md](../../../../../website/docs/overview/mom-model-family.md)
+
+## Standard Commands
+
+- `python3 tools/agent/scripts/vllm_sr_journey.py detect-env`
+- `python3 tools/agent/scripts/vllm_sr_journey.py validate --config <path> [--recipe-dir <dir>]`
+- `python3 tools/agent/scripts/vllm_sr_journey.py evaluate --config <path> [--router-url <url>] [--probes <manifest>]`
+- `python3 tools/agent/scripts/vllm_sr_journey.py review --config <path> [--recipe-dir <dir>] [--output-dir <dir>]`
+- `vllm-sr recipe scaffold --name <name> [--from <catalog-model> | --from-recipe <recipe>]`
+- `vllm-sr validate --config <path>`
+- `make agent-serve-local ENV=cpu|amd`
+- `make agent-vllm-sr-journey`
+
+## Acceptance
+
+- The journey selects only supported environments and canonical deploy commands
+- Generated or forked artifacts pass `vllm-sr validate` and, for maintained recipes, static recipe conformance checks
+- Evaluation runs before activation and failures are classified instead of patched blindly
+- Review bundles record provenance, receipts, rollback hints, and an explicit not-activated state
+- No private environment details appear in committed artifacts

--- a/tools/ci/community_lifecycle_policy.py
+++ b/tools/ci/community_lifecycle_policy.py
@@ -26,6 +26,15 @@ WORKGROUP_LABELS = (
     "wg/dev-community",
 )
 
+WORKGROUP_LABEL_ALIASES = {
+    "wg/mom-routing": "wg/mom-routing-intelligence",
+    "wg/router-models-inference-runtime": "wg/router-models-runtime-ecosystem",
+    "wg/data-plane-networking": "wg/data-plane-deployment",
+    "wg/enterprise-environment": "wg/platform-operations",
+    "wg/evaluation-quality": "wg/quality-release",
+    "wg/developer-experience-ecosystem": "wg/dev-community",
+}
+
 WORKGROUP_OPTIONS = {
     "MoM & Routing Intelligence": "wg/mom-routing-intelligence",
     "Router Models, Runtime & Ecosystem": "wg/router-models-runtime-ecosystem",
@@ -70,6 +79,16 @@ def label_names(item: dict[str, Any]) -> set[str]:
         label["name"] if isinstance(label, dict) else str(label)
         for label in item.get("labels", [])
     }
+
+
+def canonical_workgroup_labels(raw_labels: set[str]) -> set[str]:
+    canonical: set[str] = set()
+    for label in raw_labels:
+        if label in WORKGROUP_LABELS:
+            canonical.add(label)
+        elif label in WORKGROUP_LABEL_ALIASES:
+            canonical.add(WORKGROUP_LABEL_ALIASES[label])
+    return canonical
 
 
 def parse_form_field(body: str | None, heading: str) -> str | None:
@@ -154,7 +173,7 @@ def normalize_proposed_workgroup(
     *,
     accepted: bool,
 ) -> set[str]:
-    workgroups = labels.intersection(WORKGROUP_LABELS)
+    workgroups = canonical_workgroup_labels(labels)
     form_workgroup = proposed_workgroup(issue.get("body"))
     if accepted or not form_workgroup or workgroups == {form_workgroup}:
         return workgroups
@@ -344,12 +363,13 @@ def evaluate_pull_request(
     elif requires_admission and not accepted_issues:
         errors.append("At least one linked issue must carry the `accepted` label.")
 
-    owner_labels = {
-        label
-        for issue in accepted_issues
-        for label in label_names(issue)
-        if label in WORKGROUP_LABELS
-    }
+    owner_labels = canonical_workgroup_labels(
+        {
+            label
+            for issue in accepted_issues
+            for label in label_names(issue)
+        }
+    )
     if accepted_issues and len(owner_labels) != 1:
         errors.append(
             "Accepted linked work must resolve to exactly one owning `wg/*` label."

--- a/tools/ci/tests/test_community_lifecycle.py
+++ b/tools/ci/tests/test_community_lifecycle.py
@@ -260,6 +260,22 @@ MoM & Routing Intelligence
         self.assertEqual(evaluation.state_label, "pr/needs-rebase")
         self.assertEqual(evaluation.owner_label, "wg/quality-release")
 
+    def test_pr_accepts_legacy_workgroup_label_aliases(self) -> None:
+        evaluation = community_lifecycle.evaluate_pull_request(
+            {"draft": False, "user": {"type": "User"}},
+            [
+                {
+                    "labels": labels(
+                        "accepted",
+                        "wg/developer-experience-ecosystem",
+                    ),
+                    "milestone": None,
+                }
+            ],
+        )
+        self.assertTrue(evaluation.valid)
+        self.assertEqual(evaluation.owner_label, "wg/dev-community")
+
     def test_pr_rejects_multiple_accepted_workgroup_owners(self) -> None:
         pull_request = {"draft": False, "user": {"type": "User"}}
         linked = [

--- a/tools/make/agent.mk
+++ b/tools/make/agent.mk
@@ -44,6 +44,7 @@ agent-help: ## Show help for agent-specific targets
 	@echo "  make test-and-build-local"
 	@echo "  make agent-e2e-affected CHANGED_FILES=\"...\""
 	@echo "  make agent-feature-gate ENV=cpu|amd CHANGED_FILES=\"...\""
+	@echo "  make agent-vllm-sr-journey ARGS=\"detect-env\""
 
 agent-venv-install: ## Create $(AGENT_VENV) and install harness Python requirements
 	@if [ ! -x "$(AGENT_PYTHON)" ]; then \
@@ -306,6 +307,10 @@ agent-feature-gate: ## Run lint, targeted tests, local smoke, and a final report
 	fi; \
 	"$(AGENT_PYTHON)" tools/agent/scripts/agent_gate.py report --env "$(ENV)" --base-ref "$(AGENT_BASE_REF)" --changed-files "$(CHANGED_FILES)" --changed-files-path "$(AGENT_CHANGED_FILES_PATH)"
 
+agent-vllm-sr-journey: agent-venv-install ## Run the contributor vLLM-SR journey helper (ARGS=detect-env|validate|evaluate|review ...)
+	@$(LOG_TARGET)
+	@"$(AGENT_PYTHON)" tools/agent/scripts/vllm_sr_journey.py $(ARGS)
+
 .PHONY: agent-help agent-venv-install agent-bootstrap agent-ci-lint agent-docs-ci-gate agent-dev agent-serve-local agent-stop-local \
 	agent-validate agent-lint agent-fast-gate agent-report agent-ci-gate agent-smoke-local agent-e2e-affected \
-	workflow-ci-validate test-and-build-local agent-pr-gate agent-feature-gate
+	workflow-ci-validate test-and-build-local agent-pr-gate agent-feature-gate agent-vllm-sr-journey

--- a/website/docs/installation/configuration-workflows.md
+++ b/website/docs/installation/configuration-workflows.md
@@ -24,6 +24,10 @@ state without rewriting the source file. Concurrent `serve` and `stop`
 operations for the same runtime and stack are serialized; retry after the
 active lifecycle operation finishes.
 
+For contributor-oriented deployment, recipe scaffolding, validation, evaluation,
+and reviewed activation, see the
+[vLLM-SR contributor journey](../tutorials/agent/vllm-sr-journey.md).
+
 ## Dashboard
 
 An empty local workspace starts the Dashboard in setup mode. Use it to bind

--- a/website/docs/tutorials/agent/vllm-sr-journey.md
+++ b/website/docs/tutorials/agent/vllm-sr-journey.md
@@ -1,0 +1,141 @@
+---
+title: vLLM-SR Contributor Journey
+description: Deploy, scaffold recipes, validate contracts, evaluate routing, and activate changes with explicit review and rollback.
+---
+
+# vLLM-SR Contributor Journey
+
+This tutorial describes the contributor-facing agent skill and helper commands
+for issue [#2977](https://github.com/vllm-project/semantic-router/issues/2977).
+Generation and evaluation produce **review artifacts**; activation remains a
+separate, explicit step.
+
+## Supported journeys
+
+| Journey | Start | Output |
+| --- | --- | --- |
+| Local deploy | cpu / amd / nvidia-local | Validated config and canonical serve commands |
+| K8s deploy | Helm, Operator, or `make e2e-test` | Validated config plus supported deployment pointers |
+| Fork built-in MoM | `vllm-sr model fork vllm-sr/mom-v1-blend` | Customized config with MoM lifecycle notes |
+| New maintained recipe | `vllm-sr recipe scaffold --name <name>` | Five-file recipe under `config/recipes/<name>/` |
+| Calibrate routing | Probes plus live router | Eval reports via the calibration loop |
+| Continuous tuning | Replay in observe mode | Offline `recipe-learning` report for human review |
+
+## Safety model
+
+- Do not invent unsupported deployment paths.
+- Keep private hostnames, credentials, and internal endpoints out of committed artifacts.
+- Do not auto-promote tuning output to active router config.
+- Capture rollback paths before live activation.
+
+## Detect environment
+
+```bash
+python3 tools/agent/scripts/vllm_sr_journey.py detect-env
+make agent-vllm-sr-journey ARGS="detect-env"
+```
+
+The helper reads [`tools/agent/repo-manifest.yaml`](https://github.com/vllm-project/semantic-router/blob/main/tools/agent/repo-manifest.yaml)
+and maps to canonical build and serve commands for `cpu-local`, `amd-local`,
+`nvidia-local`, and `ci-k8s`.
+
+## Scaffold or fork a recipe
+
+Minimal maintained recipe:
+
+```bash
+vllm-sr recipe scaffold --name my-recipe
+```
+
+Fork an existing maintained recipe:
+
+```bash
+vllm-sr recipe scaffold --name my-recipe --from-recipe balance
+```
+
+Fork a built-in catalog asset:
+
+```bash
+vllm-sr recipe scaffold --name my-recipe --from vllm-sr/mom-v1-blend
+```
+
+Multi-profile scaffold:
+
+```bash
+vllm-sr recipe scaffold --name my-recipe --multi-profile
+```
+
+See the illustrative example at
+[`config/recipes/examples/journey-starter/`](https://github.com/vllm-project/semantic-router/tree/main/config/recipes/examples/journey-starter).
+
+## Validate
+
+```bash
+vllm-sr validate --config config/recipes/my-recipe/config.yaml
+python3 tools/agent/scripts/vllm_sr_journey.py validate \
+  --config config/recipes/my-recipe/config.yaml \
+  --recipe-dir config/recipes/my-recipe
+```
+
+For maintained catalog recipes, also run `make recipe-conformance-static`.
+
+## Evaluate
+
+Static gates:
+
+```bash
+python3 tools/agent/scripts/vllm_sr_journey.py evaluate \
+  --config config/recipes/my-recipe/config.yaml
+```
+
+Live router probes:
+
+```bash
+python3 tools/agent/scripts/vllm_sr_journey.py evaluate \
+  --config config/recipes/my-recipe/config.yaml \
+  --router-url http://127.0.0.1:8080 \
+  --probes config/recipes/my-recipe/probes.yaml
+```
+
+Semantic routing calibration against a live apiserver uses
+[`tools/agent/scripts/router_calibration_loop.py`](https://github.com/vllm-project/semantic-router/blob/main/tools/agent/scripts/router_calibration_loop.py).
+
+## Review before activation
+
+```bash
+python3 tools/agent/scripts/vllm_sr_journey.py review \
+  --config config/recipes/my-recipe/config.yaml \
+  --recipe-dir config/recipes/my-recipe \
+  --output-dir .agent-harness/vllm-sr-journey/my-session/
+```
+
+Review bundles include digests, validation receipts, evaluation results,
+routing summaries, rollback hints, and `activated: false`.
+
+## Activate explicitly
+
+| Target | Command |
+| --- | --- |
+| Local | `make agent-serve-local ENV=cpu` or `vllm-sr serve --config ...` |
+| Live apiserver | `router_calibration_loop.py deploy ...` with version capture |
+| K8s | Helm `configOverride` or Operator CR update |
+| Dashboard | Mixture-of-Models workspace activation |
+
+## Continuous tuning loop
+
+1. Enable `global.router.learning` in **observe** mode.
+2. Collect Router Replay evidence.
+3. Run `vllm-sr eval recipe-learning --output-dir ./report`.
+4. Review patch suggestions manually.
+5. Re-run journey evaluation before switching sensitive decisions to **apply**.
+
+## Agent skill source of truth
+
+The executable skill lives at
+[`tools/agent/skills/contributor/vllm-sr-journey/SKILL.md`](https://github.com/vllm-project/semantic-router/blob/main/tools/agent/skills/contributor/vllm-sr-journey/SKILL.md).
+
+Related docs:
+
+- [Configuration workflows](../installation/configuration-workflows.md)
+- [MoM model family](../overview/mom-model-family.md)
+- [Recipe conformance guide](https://github.com/vllm-project/semantic-router/blob/main/config/recipes/CONFORMANCE.md)


### PR DESCRIPTION
## Summary

- Add the first contributor-facing agent skill (`vllm-sr-journey`) for supported deployment paths, recipe scaffolding, contract validation, evaluation gates, and reviewed activation with rollback hints.
- Add `vllm_sr_journey.py` helper (`detect-env`, `validate`, `evaluate`, `review`) plus `make agent-vllm-sr-journey`.
- Add `vllm-sr recipe scaffold` CLI command, illustrative `config/recipes/examples/journey-starter/`, and public tutorial docs.

Closes #2977

## Test plan

- [x] `make agent-validate`
- [x] `make vllm-sr-test`
- [x] `make recipe-conformance-static`
- [x] `pytest src/vllm-sr/tests/test_recipe_scaffold.py tools/agent/scripts/vllm_sr_journey_test.py`
- [x] `make agent-vllm-sr-journey ARGS="detect-env"`
- [ ] Maintainer review of skill/registry wiring and docs placement


Made with [Cursor](https://cursor.com)