### PR TITLE
[Bug] Preserve Anthropic backend error responses

### DIFF
--- a/src/semantic-router/pkg/anthropic/client.go
+++ b/src/semantic-router/pkg/anthropic/client.go
@@ -151,6 +151,29 @@ func ToOpenAIResponseBodyWithExt(anthropicResponse []byte, model string, ext *ir
 	return toOpenAIResponseBody(anthropicResponse, model, ext)
 }
 
+// IsErrorBody reports whether body is an Anthropic API error envelope.
+// Error responses must not be decoded as zero-valued successful messages.
+func IsErrorBody(body []byte) bool {
+	var envelope struct {
+		Type  string          `json:"type"`
+		Error json.RawMessage `json:"error"`
+	}
+	return json.Unmarshal(body, &envelope) == nil &&
+		envelope.Type == "error" && len(envelope.Error) > 0
+}
+
+func toOpenAIErrorBody(body []byte) ([]byte, error) {
+	var envelope struct {
+		Error json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Error json.RawMessage `json:"error"`
+	}{Error: envelope.Error})
+}
+
 // toOpenAIResponseBody is the internal form that exposes the
 // IRExtensions side channel. It is called by ToOpenAIResponseBody with a
 // nil ext to preserve the existing inverse cell byte-for-byte; the
@@ -159,6 +182,9 @@ func ToOpenAIResponseBodyWithExt(anthropicResponse []byte, model string, ext *ir
 // flattening that the OpenAI envelope cannot represent.
 func toOpenAIResponseBody(anthropicResponse []byte, model string, ext *ir.IRExtensions) ([]byte, error) {
 	logging.Debugf("Raw Anthropic response: %s", logging.ContentDescriptorBytes(anthropicResponse))
+	if IsErrorBody(anthropicResponse) {
+		return toOpenAIErrorBody(anthropicResponse)
+	}
 
 	var resp anthropic.Message
 	if err := json.Unmarshal(anthropicResponse, &resp); err != nil {

--- a/src/semantic-router/pkg/anthropic/client_test.go
+++ b/src/semantic-router/pkg/anthropic/client_test.go
@@ -186,6 +186,14 @@ func TestToOpenAIResponseBody_BasicConversion(t *testing.T) {
 	assert.Equal(t, int64(18), result.Usage.TotalTokens)
 }
 
+func TestToOpenAIResponseBody_PreservesErrorEnvelope(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}`)
+
+	result, err := ToOpenAIResponseBody(body, "claude-sonnet-4-5")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"error":{"type":"authentication_error","message":"API key is invalid."}}`, string(result))
+}
+
 func TestToOpenAIResponseBody_MaxTokensStopReason(t *testing.T) {
 	anthropicResp := &anthropic.Message{
 		ID:         "msg_123",

--- a/src/semantic-router/pkg/anthropic/outbound.go
+++ b/src/semantic-router/pkg/anthropic/outbound.go
@@ -146,6 +146,9 @@ type anthropicErrorDetail struct {
 //     stop reasons "pause_turn" or "refusal"), it overrides the
 //     OpenAI-derived mapping.
 func EmitAnthropicResponse(responseBody []byte, ext *ir.IRExtensions, model string) ([]byte, error) {
+	if IsErrorBody(responseBody) {
+		return responseBody, nil
+	}
 	var oa openai.ChatCompletion
 	if err := json.Unmarshal(responseBody, &oa); err != nil {
 		return nil, fmt.Errorf("anthropic outbound: parse OpenAI response: %w", err)

--- a/src/semantic-router/pkg/anthropic/outbound_test.go
+++ b/src/semantic-router/pkg/anthropic/outbound_test.go
@@ -454,6 +454,14 @@ func TestEmitAnthropicError_EmptyErrorTypeCoercesToAPIError(t *testing.T) {
 	assert.Equal(t, "api_error", env.Error.Type)
 }
 
+func TestEmitAnthropicResponse_PreservesErrorEnvelope(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}`)
+
+	result, err := EmitAnthropicResponse(body, nil, "claude-haiku-4-5")
+	require.NoError(t, err)
+	assert.JSONEq(t, string(body), string(result))
+}
+
 // Round-trip: feed an Anthropic Message through the inverse helper
 // (toOpenAIResponseBody with a populated ext), then through the
 // outbound emitter, and assert the structural identity holds for the

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -105,6 +105,13 @@ func (r *OpenAIRouter) normalizeProviderResponseBody(
 	if ctx.APIFormat != config.APIFormatAnthropic {
 		return responseBody, false, nil
 	}
+	if anthropic.IsErrorBody(responseBody) {
+		if ctx.ClientProtocol == config.ClientProtocolAnthropic {
+			return responseBody, false, nil
+		}
+		transformedBody, err := anthropic.ToOpenAIResponseBody(responseBody, ctx.RequestModel)
+		return transformedBody, true, err
+	}
 
 	// Pass IRExtensions through so the Anthropic-only stop reason, cache
 	// usage counters, server-tool counts, and thinking-block signatures

--- a/src/semantic-router/pkg/extproc/processor_res_body_anthropic_error_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_anthropic_error_test.go
@@ -1,0 +1,60 @@
+package extproc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestNormalizeProviderResponseBody_PreservesAnthropicErrorsPerClientProtocol(t *testing.T) {
+	const upstreamError = `{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}`
+
+	tests := []struct {
+		name            string
+		clientProtocol  string
+		wantBody        string
+		wantTransformed bool
+	}{
+		{
+			name:            "openai client receives openai error shape",
+			wantBody:        `{"error":{"type":"authentication_error","message":"API key is invalid."}}`,
+			wantTransformed: true,
+		},
+		{
+			name:            "anthropic client receives upstream envelope",
+			clientProtocol:  config.ClientProtocolAnthropic,
+			wantBody:        upstreamError,
+			wantTransformed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := &OpenAIRouter{}
+			ctx := &RequestContext{
+				APIFormat:      config.APIFormatAnthropic,
+				ClientProtocol: tt.clientProtocol,
+				RequestModel:   "claude-sonnet-4-5",
+			}
+
+			body, transformed, err := router.normalizeProviderResponseBody([]byte(upstreamError), ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantTransformed, transformed)
+			require.JSONEq(t, tt.wantBody, string(body))
+		})
+	}
+}
+
+func TestNormalizeProviderResponseBody_RejectsMalformedJSON(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{APIFormat: config.APIFormatAnthropic}
+
+	_, _, err := router.normalizeProviderResponseBody([]byte(`{"type":"error"`), ctx)
+	require.Error(t, err)
+
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, err, &syntaxErr)
+}


### PR DESCRIPTION
## Summary

Fixes #2956.

Anthropic backend error envelopes were decoded as zero-valued successful messages during response normalization. This discarded the upstream error type and message for both protocol clients.

### Changes

- Detect Anthropic `{"type":"error","error":...}` envelopes before success-message decoding.
- Preserve the original envelope for Anthropic-protocol clients.
- Convert the envelope to the OpenAI `{"error":...}` shape for OpenAI-protocol clients.
- Keep the existing successful response conversion path unchanged.

### Validation

- Added helper tests for both response directions.
- Added response-normalization tests using the real `normalizeProviderResponseBody` entry point for both client protocols.
- Added malformed JSON coverage.
- `gofmt` and `git diff --check` pass.
- Anthropic focused tests pass locally.
- Extproc focused tests are blocked locally because this checkout lacks the repository replacement directories `candle-binding`, `nlp-binding`, and `ml-binding`; the PR's remote core test/build, unit test, lint, pre-commit, and E2E checks passed.