### PR TITLE
[Bug] Fix duplicate members in homepage team list

### DIFF
--- a/website/src/components/TeamCarousel/index.tsx
+++ b/website/src/components/TeamCarousel/index.tsx
@@ -11,10 +11,6 @@ import styles from './styles.module.css'
 
 const teamMembers = [...maintainerMembers, ...committerMembers]
 
-interface MemberSequenceProps {
-  duplicate?: boolean
-}
-
 function revealFocusedCard(event: React.FocusEvent<HTMLElement>): void {
   const card = event.currentTarget.closest('article')
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
@@ -28,17 +24,15 @@ function revealFocusedCard(event: React.FocusEvent<HTMLElement>): void {
 
 function MemberCard({
   member,
-  duplicate = false,
 }: {
   member: TeamMember
-  duplicate?: boolean
 }): JSX.Element {
   return (
     <article
       className={styles.memberCard}
-      aria-label={duplicate ? undefined : `${member.name}`}
-      tabIndex={duplicate ? -1 : 0}
-      onFocus={duplicate ? undefined : revealFocusedCard}
+      aria-label={member.name}
+      tabIndex={0}
+      onFocus={revealFocusedCard}
     >
       <div className={styles.avatarWrapper}>
         <img
@@ -66,14 +60,13 @@ function MemberCard({
   )
 }
 
-function MemberSequence({ duplicate = false }: MemberSequenceProps): JSX.Element {
+function MemberSequence(): JSX.Element {
   return (
-    <div className={styles.sequence} aria-hidden={duplicate || undefined}>
+    <div className={styles.sequence}>
       {teamMembers.map((member, index) => (
         <MemberCard
           key={`${member.name}-${index}`}
           member={member}
-          duplicate={duplicate}
         />
       ))}
     </div>
@@ -104,7 +97,6 @@ const TeamCarousel: React.FC = () => {
           <div className={styles.viewport}>
             <div className={styles.track}>
               <MemberSequence />
-              <MemberSequence duplicate />
             </div>
           </div>
         </div>

--- a/website/src/components/TeamCarousel/styles.module.css
+++ b/website/src/components/TeamCarousel/styles.module.css
@@ -40,36 +40,17 @@
 }
 
 .viewport {
-  overflow: hidden;
-  padding: 1.35rem 0;
-  mask-image: linear-gradient(90deg, transparent, #000 2rem, #000 calc(100% - 2rem), transparent);
-  -webkit-mask-image: linear-gradient(90deg, transparent, #000 2rem, #000 calc(100% - 2rem), transparent);
-}
-
-.viewport:hover .track {
-  animation-play-state: paused;
-}
-
-.viewport:focus-within {
   overflow-x: auto;
+  padding: 1.35rem 1rem 1.55rem;
   scroll-padding-inline: 1.25rem;
+  scroll-snap-type: x proximity;
   scrollbar-color: var(--site-border-strong) transparent;
   scrollbar-width: thin;
-  mask-image: none;
-  -webkit-mask-image: none;
-}
-
-.viewport:focus-within .track {
-  animation: none;
-  transform: translateX(0);
-  will-change: auto;
 }
 
 .track {
   display: flex;
   width: max-content;
-  animation: team-marquee 220s linear infinite;
-  will-change: transform;
 }
 
 .sequence {
@@ -82,6 +63,7 @@
 .memberCard {
   flex: 0 0 17.5rem;
   min-width: 17.5rem;
+  scroll-snap-align: start;
   display: grid;
   align-content: start;
   gap: 0.65rem;
@@ -197,21 +179,10 @@
   font-size: 0.95rem;
 }
 
-@keyframes team-marquee {
-  to {
-    transform: translateX(-50%);
-  }
-}
-
 @media (max-width: 996px) {
   .teamFooter {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .viewport {
-    mask-image: linear-gradient(90deg, transparent, #000 1.25rem, #000 calc(100% - 1.25rem), transparent);
-    -webkit-mask-image: linear-gradient(90deg, transparent, #000 1.25rem, #000 calc(100% - 1.25rem), transparent);
   }
 }
 
@@ -249,28 +220,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .viewport {
-    overflow-x: auto;
-    padding-bottom: 1.25rem;
-    scroll-padding-inline: 1rem;
-    scroll-snap-type: x mandatory;
-    scrollbar-color: var(--site-border-strong) transparent;
-    scrollbar-width: thin;
-    mask-image: none;
-    -webkit-mask-image: none;
-  }
-
-  .track {
-    animation: none;
-    will-change: auto;
-  }
-
-  .sequence[aria-hidden='true'] {
-    display: none;
-  }
-
   .memberCard {
-    scroll-snap-align: start;
     transition: none;
   }
 

--- a/website/src/components/TeamCarousel/styles.module.css
+++ b/website/src/components/TeamCarousel/styles.module.css
@@ -40,17 +40,38 @@
 }
 
 .viewport {
+  container-type: inline-size;
+  overflow: hidden;
+  padding: 1.35rem 0;
+  mask-image: linear-gradient(90deg, transparent, #000 2rem, #000 calc(100% - 2rem), transparent);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 2rem, #000 calc(100% - 2rem), transparent);
+}
+
+.viewport:hover .track {
+  animation-play-state: paused;
+}
+
+.viewport:focus-within {
   overflow-x: auto;
-  padding: 1.35rem 1rem 1.55rem;
   scroll-padding-inline: 1.25rem;
   scroll-snap-type: x proximity;
   scrollbar-color: var(--site-border-strong) transparent;
   scrollbar-width: thin;
+  mask-image: none;
+  -webkit-mask-image: none;
+}
+
+.viewport:focus-within .track {
+  animation: none;
+  transform: translateX(0);
+  will-change: auto;
 }
 
 .track {
   display: flex;
   width: max-content;
+  animation: team-marquee 220s linear infinite alternate;
+  will-change: transform;
 }
 
 .sequence {
@@ -179,10 +200,21 @@
   font-size: 0.95rem;
 }
 
+@keyframes team-marquee {
+  to {
+    transform: translateX(calc(-100% + 100cqw));
+  }
+}
+
 @media (max-width: 996px) {
   .teamFooter {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .viewport {
+    mask-image: linear-gradient(90deg, transparent, #000 1.25rem, #000 calc(100% - 1.25rem), transparent);
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 1.25rem, #000 calc(100% - 1.25rem), transparent);
   }
 }
 
@@ -220,6 +252,23 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .viewport {
+    overflow-x: auto;
+    padding-bottom: 1.25rem;
+    scroll-padding-inline: 1rem;
+    scroll-snap-type: x mandatory;
+    scrollbar-color: var(--site-border-strong) transparent;
+    scrollbar-width: thin;
+    mask-image: none;
+    -webkit-mask-image: none;
+  }
+
+  .track {
+    animation: none;
+    transform: translateX(0);
+    will-change: auto;
+  }
+
   .memberCard {
     transition: none;
   }


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #3006 
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

Fix the duplicated community member list under the homepage
“Built in the open.” section.

The team carousel previously rendered the complete member sequence twice to
support an infinite marquee animation. As a result, all 14 team members appeared
twice in the visible list.

This change:

- Renders a single member sequence.
- Removes the duplicate-only component properties and accessibility handling.
- Replaces the duplicate-dependent marquee animation with a horizontally
  scrollable, snap-aligned list.
- Preserves keyboard focus behavior and responsive card sizing.

Affected module: `website/src/components/TeamCarousel`.

Issue owner: `wg/xxxx`.

## Test Plan

```bash
cd website
npx eslint src/components/TeamCarousel/index.tsx
npm run build:en
```

Manual checks:

- Verify the “Built in the open.” section contains one copy of each member.
- Verify the list can scroll horizontally to the final member.
- Verify focusing a member card scrolls it into view.
- Check the section at 1440px desktop and 390px mobile viewport widths.
- Confirm the page does not gain global horizontal overflow.

## Test Result

- Targeted ESLint passed.
- The English Docusaurus production build completed successfully.
- Browser verification found 14 cards with 14 unique member names and one
  rendered member sequence, instead of the previous 28 cards.
- The list remains horizontally scrollable and reaches the final member.
- Keyboard focus correctly scrolls the focused card into view.
- No page-level horizontal overflow was found at the 390px mobile viewport.
- The build emitted only existing, unrelated content and dependency warnings.
- No known blocker remains.

After change, no dup list here:

<img width="1592" height="581" alt="image" src="https://github.com/user-attachments/assets/ff247658-7500-44e7-b0ca-bf7482978f1a" />


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.