### PR TITLE
[E2E] pin anthropic-shim Kind image to Never and lock LocalImages

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -97,8 +97,6 @@ on:
         value: ${{ jobs.classify.outputs.e2e_authz_rbac }}
       e2e_streaming:
         value: ${{ jobs.classify.outputs.e2e_streaming }}
-      e2e_anthropic_shim:
-        value: ${{ jobs.classify.outputs.e2e_anthropic_shim }}
       e2e_common:
         value: ${{ jobs.classify.outputs.e2e_common }}
 
@@ -157,7 +155,6 @@ jobs:
       e2e_multi_endpoint: ${{ steps.matrix.outputs.e2e_multi_endpoint }}
       e2e_authz_rbac: ${{ steps.matrix.outputs.e2e_authz_rbac }}
       e2e_streaming: ${{ steps.matrix.outputs.e2e_streaming }}
-      e2e_anthropic_shim: ${{ steps.matrix.outputs.e2e_anthropic_shim }}
       e2e_common: ${{ steps.matrix.outputs.e2e_common }}
     steps:
       - uses: actions/checkout@v4

--- a/deploy/kubernetes/anthropic-backend/base/deployment.yaml
+++ b/deploy/kubernetes/anthropic-backend/base/deployment.yaml
@@ -122,7 +122,7 @@ spec:
                 - ALL
 
         - name: anthropic-shim
-          image: anthropic-shim:latest
+          image: ghcr.io/vllm-project/semantic-router/anthropic-shim:latest
           imagePullPolicy: IfNotPresent
           ports:
             - name: shim

--- a/e2e/profiles/all/imports_test.go
+++ b/e2e/profiles/all/imports_test.go
@@ -113,44 +113,72 @@ func anthropicShimContainerFromBackendYAML(t *testing.T) (string, corev1.PullPol
 
 	reader := utilyaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(raw)))
 	for {
-		doc, err := reader.Read()
+		doc, err := nextYAMLDocument(t, reader)
 		if err == io.EOF {
 			break
 		}
-		if err != nil {
-			t.Fatalf("read backend.yaml document: %v", err)
+		image, pullPolicy, found := anthropicShimFromYAMLDocument(t, doc)
+		if found {
+			return image, pullPolicy
 		}
-		if len(bytes.TrimSpace(doc)) == 0 {
-			continue
-		}
-
-		jsonDocument, err := utilyaml.ToJSON(doc)
-		if err != nil {
-			t.Fatalf("convert backend.yaml document to JSON: %v", err)
-		}
-
-		var typeMeta struct {
-			Kind string `json:"kind"`
-		}
-		if err := json.Unmarshal(jsonDocument, &typeMeta); err != nil {
-			t.Fatalf("decode backend.yaml type meta: %v", err)
-		}
-		if typeMeta.Kind != "Deployment" {
-			continue
-		}
-
-		var deployment appsv1.Deployment
-		if err := json.Unmarshal(jsonDocument, &deployment); err != nil {
-			t.Fatalf("decode backend.yaml deployment: %v", err)
-		}
-		for _, container := range deployment.Spec.Template.Spec.Containers {
-			if container.Name == "anthropic-shim" {
-				return container.Image, container.ImagePullPolicy
-			}
-		}
-		t.Fatal("anthropic-shim container not found in backend.yaml Deployment")
 	}
 
 	t.Fatal("Deployment not found in backend.yaml")
 	return "", ""
+}
+
+func nextYAMLDocument(t *testing.T, reader *utilyaml.YAMLReader) ([]byte, error) {
+	t.Helper()
+	doc, err := reader.Read()
+	if err != nil {
+		if err != io.EOF {
+			t.Fatalf("read backend.yaml document: %v", err)
+		}
+		return nil, err
+	}
+	return doc, nil
+}
+
+func anthropicShimFromYAMLDocument(t *testing.T, doc []byte) (string, corev1.PullPolicy, bool) {
+	t.Helper()
+	jsonDocument, kind, ok := decodeYAMLDocument(t, doc)
+	if !ok || kind != "Deployment" {
+		return "", "", false
+	}
+	return findAnthropicShimContainer(t, jsonDocument)
+}
+
+func decodeYAMLDocument(t *testing.T, doc []byte) ([]byte, string, bool) {
+	t.Helper()
+	if len(bytes.TrimSpace(doc)) == 0 {
+		return nil, "", false
+	}
+
+	jsonDocument, err := utilyaml.ToJSON(doc)
+	if err != nil {
+		t.Fatalf("convert backend.yaml document to JSON: %v", err)
+	}
+
+	var typeMeta struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(jsonDocument, &typeMeta); err != nil {
+		t.Fatalf("decode backend.yaml type meta: %v", err)
+	}
+	return jsonDocument, typeMeta.Kind, true
+}
+
+func findAnthropicShimContainer(t *testing.T, jsonDocument []byte) (string, corev1.PullPolicy, bool) {
+	t.Helper()
+	var deployment appsv1.Deployment
+	if err := json.Unmarshal(jsonDocument, &deployment); err != nil {
+		t.Fatalf("decode backend.yaml deployment: %v", err)
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == "anthropic-shim" {
+			return container.Image, container.ImagePullPolicy, true
+		}
+	}
+	t.Fatal("anthropic-shim container not found in backend.yaml Deployment")
+	return "", "", false
 }

--- a/e2e/profiles/all/imports_test.go
+++ b/e2e/profiles/all/imports_test.go
@@ -1,10 +1,20 @@
 package all
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
 	"reflect"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+
 	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	anthropicshim "github.com/vllm-project/semantic-router/e2e/profiles/anthropic-shim"
 )
 
 func TestDashboardProfileBuildsLocalImage(t *testing.T) {
@@ -76,12 +86,71 @@ func TestAnthropicShimProfileBuildsLocalImage(t *testing.T) {
 		t.Fatal("anthropic-shim profile is not registered")
 	}
 
-	want := []framework.LocalImageBuild{{
-		Dockerfile:   "e2e/testing/anthropic-shim/Dockerfile",
-		Tag:          "ghcr.io/vllm-project/semantic-router/anthropic-shim:e2e-test",
-		BuildContext: "e2e/testing/anthropic-shim",
-	}}
-	if !reflect.DeepEqual(registration.Capabilities.LocalImages, want) {
-		t.Fatalf("anthropic-shim local images = %#v, want %#v", registration.Capabilities.LocalImages, want)
+	localImages := anthropicshim.LocalImages()
+	if len(localImages) != 1 {
+		t.Fatalf("LocalImages() returned %d entries, want 1", len(localImages))
 	}
+	if len(registration.Capabilities.LocalImages) != 1 || registration.Capabilities.LocalImages[0].Tag != localImages[0].Tag {
+		t.Fatalf("registered local images = %#v, want Tag %q", registration.Capabilities.LocalImages, localImages[0].Tag)
+	}
+
+	image, pullPolicy := anthropicShimContainerFromBackendYAML(t)
+	if image != localImages[0].Tag {
+		t.Fatalf("backend.yaml anthropic-shim image = %q, want LocalImages Tag %q", image, localImages[0].Tag)
+	}
+	if pullPolicy != corev1.PullNever {
+		t.Fatalf("backend.yaml anthropic-shim imagePullPolicy = %q, want %q", pullPolicy, corev1.PullNever)
+	}
+}
+
+func anthropicShimContainerFromBackendYAML(t *testing.T) (string, corev1.PullPolicy) {
+	t.Helper()
+
+	raw, err := os.ReadFile("../anthropic-shim/gateway-resources/backend.yaml")
+	if err != nil {
+		t.Fatalf("read backend.yaml: %v", err)
+	}
+
+	reader := utilyaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(raw)))
+	for {
+		doc, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read backend.yaml document: %v", err)
+		}
+		if len(bytes.TrimSpace(doc)) == 0 {
+			continue
+		}
+
+		jsonDocument, err := utilyaml.ToJSON(doc)
+		if err != nil {
+			t.Fatalf("convert backend.yaml document to JSON: %v", err)
+		}
+
+		var typeMeta struct {
+			Kind string `json:"kind"`
+		}
+		if err := json.Unmarshal(jsonDocument, &typeMeta); err != nil {
+			t.Fatalf("decode backend.yaml type meta: %v", err)
+		}
+		if typeMeta.Kind != "Deployment" {
+			continue
+		}
+
+		var deployment appsv1.Deployment
+		if err := json.Unmarshal(jsonDocument, &deployment); err != nil {
+			t.Fatalf("decode backend.yaml deployment: %v", err)
+		}
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == "anthropic-shim" {
+				return container.Image, container.ImagePullPolicy
+			}
+		}
+		t.Fatal("anthropic-shim container not found in backend.yaml Deployment")
+	}
+
+	t.Fatal("Deployment not found in backend.yaml")
+	return "", ""
 }

--- a/e2e/profiles/all/imports_test.go
+++ b/e2e/profiles/all/imports_test.go
@@ -69,3 +69,19 @@ func TestProtocolCodecE2EMatrixProfilesAreClosed(t *testing.T) {
 		})
 	}
 }
+
+func TestAnthropicShimProfileBuildsLocalImage(t *testing.T) {
+	registration, ok := framework.LookupProfileRegistration("anthropic-shim")
+	if !ok {
+		t.Fatal("anthropic-shim profile is not registered")
+	}
+
+	want := []framework.LocalImageBuild{{
+		Dockerfile:   "e2e/testing/anthropic-shim/Dockerfile",
+		Tag:          "ghcr.io/vllm-project/semantic-router/anthropic-shim:e2e-test",
+		BuildContext: "e2e/testing/anthropic-shim",
+	}}
+	if !reflect.DeepEqual(registration.Capabilities.LocalImages, want) {
+		t.Fatalf("anthropic-shim local images = %#v, want %#v", registration.Capabilities.LocalImages, want)
+	}
+}

--- a/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
+++ b/e2e/profiles/anthropic-shim/gateway-resources/backend.yaml
@@ -165,7 +165,7 @@ spec:
 
         - name: anthropic-shim
           image: ghcr.io/vllm-project/semantic-router/anthropic-shim:e2e-test
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Never
           ports:
             - name: shim
               containerPort: 8080


### PR DESCRIPTION
Closes #2809

## Purpose

- Kind fixture `.../anthropic-shim:e2e-test` is not published on GHCR. A missed `kind load` with `IfNotPresent` becomes `ImagePullBackOff`. Pin the e2e shim container to `imagePullPolicy: Never` (dashboard Kind contract). Public images (`python:3.11-slim`, `llama.cpp:server`) stay `IfNotPresent`.
- `#2835` already registers `LocalImages()`. This PR does not re-register it.
- Lock `backend.yaml`'s shim `image` to `anthropicshim.LocalImages().Tag` so those two strings cannot drift untested.
- Qualify the unused kustomize copy (`deploy/kubernetes/anthropic-backend/base/deployment.yaml`) from `anthropic-shim:latest` to `ghcr.io/vllm-project/semantic-router/anthropic-shim:latest`. Tree kept (fix, not delete). `apply -k` already rewrote this via `images:`; this makes the source file pullable too.
- Drop the unused `e2e_anthropic_shim` workflow export from `ci-changes.yml`. Classifier tests / `NON_PR_E2E_RULES` unchanged. This profile stays out of PR Kind.
- Affects: `E2E`

## Test Plan

- `cd e2e && go test ./profiles/all/ -count=1 -run 'Test(Dashboard|EnvoyAIGateway|AnthropicShim)'`
- `.venv-agent/bin/python -m unittest tools.ci.tests.test_pr_change_classifier`
- `grep e2e_anthropic_shim .github/workflows/ci-changes.yml` (no hits)

## Test Result

- Profile unit tests passed.
- Classifier tests passed; `make agent-validate` passed.
- Full `make e2e-test E2E_PROFILE=anthropic-shim` not re-run here (extproc/GGUF). Item 1 was already checked with `docker manifest inspect` (`:e2e-test` unknown) and a Kind event that the local tag was already on the node.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title uses module-aligned prefixes such as `[E2E]`
- [x] Commits are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result match this diff

</details>