### PR TITLE
[Community] Add initial Workgroup rosters

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -27,6 +27,20 @@ export const workGroups: WorkGroup[] = [
       'Multi-model collaboration algorithms and strategies',
       'Model-pool optimization and cross-model efficiency',
     ],
+    leads: [
+      {
+        name: 'Xunzhuo Liu',
+        avatar: 'https://github.com/Xunzhuo.png',
+        profile: 'https://github.com/Xunzhuo',
+      },
+    ],
+    members: [
+      {
+        name: 'Haichen Zhang',
+        avatar: '/img/team/haichen.jpeg',
+        profile: 'https://github.com/haic0',
+      },
+    ],
   },
   {
     id: 'router-models-inference-runtime',
@@ -38,6 +52,23 @@ export const workGroups: WorkGroup[] = [
       'Built-in model post-training and release',
       'Router-native model families beyond BERT',
       'Self-improvement, fine-tuning, and runtime contracts',
+    ],
+    leads: [
+      {
+        name: 'Kun-Tai Wu',
+        avatar: 'https://github.com/WUKUNTAI-0211.png',
+        profile: 'https://github.com/WUKUNTAI-0211',
+      },
+      {
+        name: 'Theo Hsiung',
+        avatar: 'https://github.com/theohsiung.png',
+        profile: 'https://github.com/theohsiung',
+      },
+      {
+        name: 'Ádám Kovács',
+        avatar: 'https://github.com/adaamko.png',
+        profile: 'https://github.com/adaamko',
+      },
     ],
   },
   {
@@ -51,6 +82,13 @@ export const workGroups: WorkGroup[] = [
       'Envoy ExtProc, gateways, and networking integrations',
       'Performance optimization, streaming, dispatch, retries, and telemetry',
     ],
+    leads: [
+      {
+        name: 'Yang Wu',
+        avatar: 'https://github.com/drivebyer.png',
+        profile: 'https://github.com/drivebyer',
+      },
+    ],
   },
   {
     id: 'enterprise-environment',
@@ -62,6 +100,20 @@ export const workGroups: WorkGroup[] = [
       'Multi-tenancy, identity, API keys, quotas, and audit',
       'Stability, scalability, observability, and lifecycle operations',
       'Multi-environment and multi-hardware support',
+    ],
+    leads: [
+      {
+        name: 'Aayush Saini',
+        avatar: 'https://github.com/AayushSaini101.png',
+        profile: 'https://github.com/AayushSaini101',
+      },
+    ],
+    members: [
+      {
+        name: 'Abhinav Mahajan',
+        avatar: 'https://github.com/abhinav-m22.png',
+        profile: 'https://github.com/abhinav-m22',
+      },
     ],
   },
   {
@@ -75,6 +127,25 @@ export const workGroups: WorkGroup[] = [
       'Agent backend selection, handoff, and composition',
       'Bounded multi-agent collaboration and long-session model or workflow switching',
     ],
+    leads: [
+      {
+        name: 'Xunzhuo Liu',
+        avatar: 'https://github.com/Xunzhuo.png',
+        profile: 'https://github.com/Xunzhuo',
+      },
+      {
+        name: 'Aayush Saini',
+        avatar: 'https://github.com/AayushSaini101.png',
+        profile: 'https://github.com/AayushSaini101',
+      },
+    ],
+    members: [
+      {
+        name: 'Abhinav Mahajan',
+        avatar: 'https://github.com/abhinav-m22.png',
+        profile: 'https://github.com/abhinav-m22',
+      },
+    ],
   },
   {
     id: 'developer-experience-ecosystem',
@@ -87,6 +158,30 @@ export const workGroups: WorkGroup[] = [
       'Agent skill and ecosystem integrations for deployment, tuning, and operations',
       'Documentation, blogs, video tutorials, and use-case sharing',
     ],
+    leads: [
+      {
+        name: 'Aayush Saini',
+        avatar: 'https://github.com/AayushSaini101.png',
+        profile: 'https://github.com/AayushSaini101',
+      },
+      {
+        name: 'Wilson Wu',
+        avatar: 'https://github.com/wilsonwu.png',
+        profile: 'https://github.com/wilsonwu',
+      },
+    ],
+    members: [
+      {
+        name: 'Mahdi Ghodsi',
+        avatar: 'https://github.com/Mahdi-CV.png',
+        profile: 'https://github.com/Mahdi-CV',
+      },
+      {
+        name: 'Aakanksha Bhende',
+        avatar: 'https://github.com/aakankshabhende.png',
+        profile: 'https://github.com/aakankshabhende',
+      },
+    ],
   },
   {
     id: 'evaluation-quality',
@@ -98,6 +193,13 @@ export const workGroups: WorkGroup[] = [
       'MoM, Router Model, agent, context, and workflow evaluation',
       'Model cards, benchmarks, and reproducibility',
       'CI, E2E, compatibility, and regression gates',
+    ],
+    leads: [
+      {
+        name: 'Xunzhuo Liu',
+        avatar: 'https://github.com/Xunzhuo.png',
+        profile: 'https://github.com/Xunzhuo',
+      },
     ],
   },
 ]

--- a/website/src/pages/community/work-groups.module.css
+++ b/website/src/pages/community/work-groups.module.css
@@ -159,11 +159,10 @@
 }
 
 .groupFooter {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
   gap: 1rem;
   align-items: end;
-  justify-content: space-between;
   padding-top: 0.9rem;
   border-top: 1px solid var(--site-border);
 }
@@ -188,6 +187,10 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+.charterLink {
+  white-space: nowrap;
 }
 
 .person {
@@ -295,6 +298,10 @@
 
   .groupDetails {
     grid-column: 1 / -1;
+  }
+
+  .groupFooter {
+    grid-template-columns: 1fr;
   }
 
   .rules {

--- a/website/src/pages/community/work-groups.tsx
+++ b/website/src/pages/community/work-groups.tsx
@@ -201,8 +201,13 @@ function Roster({
         : (
             <div className={styles.people}>
               {people.map(person => (
-                <a key={person.profile} className={styles.person} href={person.profile}>
-                  <img src={person.avatar} alt="" />
+                <a
+                  key={person.profile}
+                  className={styles.person}
+                  href={person.profile}
+                  aria-label={`${person.name} on GitHub`}
+                >
+                  <img src={person.avatar} alt="" loading="lazy" />
                   <strong>{person.name}</strong>
                 </a>
               ))}


### PR DESCRIPTION
## Summary

- publish the initial Lead and Member roster recorded in the seven Workgroup charters
- show each person with their name and avatar, linking both to their GitHub profile
- keep open roles visible and improve roster wrapping across desktop and mobile layouts
- add accessible GitHub link labels and lazy-load roster avatars

The roster reflects initial confirmed interest and remains open to additional qualified Leads and Members through each Workgroup charter.

Related #15

## Validation

- make agent-validate
- make agent-lint
- website ESLint
- Docusaurus English production build
- desktop and mobile local preview checks