### PR TITLE
[Docs] shared page header and rail for research and community

### DIFF
--- a/website/src/components/community/CommunityLayout/index.tsx
+++ b/website/src/components/community/CommunityLayout/index.tsx
@@ -4,6 +4,7 @@ import { useLocation } from '@docusaurus/router'
 import Translate from '@docusaurus/Translate'
 import clsx from 'clsx'
 import React from 'react'
+import PageHeader from '@site/src/components/site/PageHeader'
 import { normalizeWebsitePath } from '@site/src/components/site/WebsiteMegaNav/navigation'
 import styles from './styles.module.css'
 
@@ -13,15 +14,39 @@ export interface CommunityNavItem {
   to: string
 }
 
-export const COMMUNITY_NAV_ITEMS: CommunityNavItem[] = [
-  { key: 'team', label: 'Open Source Team', to: '/community/team' },
-  { key: 'steering-committee', label: 'Steering Committee', to: '/community/steering-committee' },
-  { key: 'work-groups', label: 'Working Groups', to: '/community/work-groups' },
-  { key: 'leaderboard', label: 'Leaderboard', to: '/community/contributors' },
-  { key: 'governance', label: 'Governance', to: '/community/governance' },
-  { key: 'contributing', label: 'Contributing', to: '/community/contributing' },
-  { key: 'code-of-conduct', label: 'Code of Conduct', to: '/community/code-of-conduct' },
+export interface CommunityNavGroup {
+  key: string
+  label: string
+  items: CommunityNavItem[]
+}
+
+/* Grouped like the docs sidebar. The labels and their order are unchanged
+ * from the workgroups reset; the rule falls between the fourth and fifth. */
+export const COMMUNITY_NAV_GROUPS: CommunityNavGroup[] = [
+  {
+    key: 'people',
+    label: 'People',
+    items: [
+      { key: 'team', label: 'Open Source Team', to: '/community/team' },
+      { key: 'steering-committee', label: 'Steering Committee', to: '/community/steering-committee' },
+      { key: 'work-groups', label: 'Working Groups', to: '/community/work-groups' },
+      { key: 'leaderboard', label: 'Leaderboard', to: '/community/contributors' },
+    ],
+  },
+  {
+    key: 'how-we-work',
+    label: 'How we work',
+    items: [
+      { key: 'governance', label: 'Governance', to: '/community/governance' },
+      { key: 'contributing', label: 'Contributing', to: '/community/contributing' },
+      { key: 'code-of-conduct', label: 'Code of Conduct', to: '/community/code-of-conduct' },
+    ],
+  },
 ]
+
+export const COMMUNITY_NAV_ITEMS: CommunityNavItem[] = COMMUNITY_NAV_GROUPS.flatMap(
+  group => group.items,
+)
 
 export interface CommunityLayoutProps {
   activeKey: string
@@ -42,32 +67,35 @@ export default function CommunityLayout({
   return (
     <div className={styles.page}>
       <main className={styles.container}>
-        <header className={styles.masthead}>
-          <span className={styles.eyebrow}>
-            <Translate id="community.layout.eyebrow">Community</Translate>
-          </span>
-          <h1>{title}</h1>
-          {description && <p className={styles.description}>{description}</p>}
-        </header>
+        <PageHeader
+          description={description}
+          eyebrow={<Translate id="community.layout.eyebrow">Community</Translate>}
+          title={title}
+        />
 
         <div className={styles.body}>
           <nav className={styles.sidebar} aria-label="Community sections">
-            {COMMUNITY_NAV_ITEMS.map((item) => {
-              const isActive = item.key === activeKey || normalizedPathname === item.to
+            {COMMUNITY_NAV_GROUPS.map(group => (
+              <div key={group.key} className={styles.navGroup}>
+                <span className={styles.navGroupLabel}>{group.label}</span>
+                {group.items.map((item) => {
+                  const isActive = item.key === activeKey || normalizedPathname === item.to
 
-              return (
-                <Link
-                  key={item.key}
-                  className={clsx(styles.navLink, {
-                    [styles.navLinkActive]: isActive,
-                  })}
-                  to={item.to}
-                  aria-current={isActive ? 'page' : undefined}
-                >
-                  {item.label}
-                </Link>
-              )
-            })}
+                  return (
+                    <Link
+                      key={item.key}
+                      className={clsx(styles.navLink, {
+                        [styles.navLinkActive]: isActive,
+                      })}
+                      to={item.to}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      {item.label}
+                    </Link>
+                  )
+                })}
+              </div>
+            ))}
           </nav>
 
           <article className={styles.article}>{children}</article>

--- a/website/src/components/community/CommunityLayout/styles.module.css
+++ b/website/src/components/community/CommunityLayout/styles.module.css
@@ -3,85 +3,105 @@
   background: var(--site-bg);
 }
 
+/* Same box as .site-shell-container: gutters added to --page-max, not taken
+   out of it, so this edge lands on the navbar's and the docs canvas's. */
 .container {
-  width: min(100% - 2.5rem, var(--site-grid-max));
-  margin: 0 auto;
-  padding: 2.25rem 0 3.5rem;
-}
-
-.masthead {
-  display: grid;
-  gap: 0.6rem;
-  max-width: 46rem;
-  padding-bottom: 1.75rem;
-  border-bottom: 1px solid var(--site-border-strong);
-}
-
-.eyebrow {
-  color: var(--site-accent-strong);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.68rem;
-  font-weight: 650;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-}
-
-.masthead h1 {
-  margin: 0;
-  color: var(--site-text);
-  font-size: clamp(2.6rem, 6vw, 4.25rem);
-  font-weight: 430;
-  line-height: 0.95;
-  letter-spacing: -0.045em;
-}
-
-.description {
-  margin: 0;
-  color: var(--site-muted-bright);
-  font-size: 0.95rem;
-  line-height: 1.7;
+  width: 100%;
+  max-width: calc(var(--page-max) + var(--gutter) * 2);
+  margin-inline: auto;
+  padding: var(--space-8) var(--gutter) var(--space-10);
 }
 
 .body {
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(13rem, 0.22fr) minmax(0, 1fr);
+  grid-template-columns: var(--rail) minmax(0, 1fr);
   align-items: start;
-  gap: 2.5rem;
-  padding-top: 1.75rem;
+  gap: var(--rail-gap);
+  padding-top: var(--space-6);
 }
 
+/*
+ * The rail divider is drawn on the grid, not on the sidebar. The sidebar is
+ * sticky, so a border on it would only be as tall as the handful of links it
+ * contains, leaving a stub. Sitting at --rail puts it where the docs
+ * sidebar's own border-right falls.
+ */
+.body::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--rail);
+  width: 1px;
+  background: var(--site-border);
+}
+
+/* The docs sidebar, rebuilt: sentence-case group labels, a rule between
+   groups, a filled pill for the current page, and the same rhythm. */
 .sidebar {
   position: sticky;
-  top: calc(var(--site-header-height) + 1.25rem);
+  top: calc(var(--site-header-height) + var(--space-5));
   display: grid;
-  gap: 0.1rem;
   align-content: start;
+  gap: var(--space-5);
+  padding-right: var(--space-5);
 }
 
+.navGroup {
+  display: grid;
+  align-content: start;
+  gap: 2px;
+}
+
+.navGroup + .navGroup {
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--site-border);
+}
+
+.navGroupLabel {
+  padding: 0.15rem var(--space-2) var(--space-2);
+  color: var(--site-text-strong);
+  font-size: var(--text-sm);
+  font-weight: var(--site-font-weight-semibold);
+  letter-spacing: -0.005em;
+}
+
+/* The 12px indent is the docs rail's nested .menu__list padding: it insets the
+   pill, and with the link's own 12px puts item text at 24px against an 8px
+   group label. Without it the rail reads flatter than the docs one. */
 .navLink {
-  padding: 0.45rem 0.7rem;
-  border-left: 2px solid transparent;
-  color: var(--site-muted-bright);
-  font-size: 0.82rem;
-  font-weight: 550;
-  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  min-height: 2.1rem;
+  margin-left: var(--space-3);
+  padding: 0.42rem var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--site-muted);
+  font-size: var(--text-sm);
+  font-weight: var(--site-font-weight-normal);
+  line-height: 1.4;
   transition:
-    background 160ms ease,
-    border-color 160ms ease,
-    color 160ms ease;
+    background var(--site-transition-fast),
+    color var(--site-transition-fast);
 }
 
 .navLink:hover {
   background: var(--site-surface-soft);
-  color: var(--site-text);
+  color: var(--site-text-strong);
   text-decoration: none;
 }
 
 .navLinkActive,
 .navLinkActive:hover {
-  border-left-color: var(--site-accent);
   background: var(--site-accent-soft);
-  color: var(--site-text);
+  color: var(--site-accent-strong);
+  font-weight: var(--site-font-weight-medium);
+}
+
+.navLink:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
 }
 
 .article {
@@ -91,16 +111,23 @@
 @media (max-width: 996px) {
   .body {
     grid-template-columns: 1fr;
-    gap: 1.5rem;
+    gap: var(--space-5);
   }
 
+  .body::before {
+    display: none;
+  }
+
+  /* One scrolling row of pills. The groups flatten into it rather than
+     stacking their labels above a horizontal strip. */
   .sidebar {
     position: static;
     display: flex;
     flex-wrap: nowrap;
-    gap: 0.5rem;
+    gap: var(--space-2);
     overflow-x: auto;
-    padding-bottom: 0.5rem;
+    padding: 0 0 var(--space-2);
+    border-bottom: 1px solid var(--site-border);
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
@@ -109,28 +136,32 @@
     display: none;
   }
 
+  .navGroup {
+    display: contents;
+  }
+
+  .navGroupLabel {
+    display: none;
+  }
+
   .navLink {
     flex: 0 0 auto;
+    min-height: 0;
+    margin-left: 0;
+    padding-inline: var(--space-3);
     border: 1px solid var(--site-border);
-    border-left: 1px solid var(--site-border);
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     white-space: nowrap;
   }
 
   .navLinkActive,
   .navLinkActive:hover {
     border-color: var(--site-accent);
-    border-left-color: var(--site-accent);
   }
 }
 
 @media (max-width: 700px) {
   .container {
-    width: min(100% - 1.4rem, var(--site-grid-max));
-    padding-top: 1.5rem;
-  }
-
-  .masthead h1 {
-    font-size: clamp(2.2rem, 12vw, 3.2rem);
+    padding-top: var(--space-5);
   }
 }

--- a/website/src/components/community/CommunityMemberCard/styles.module.css
+++ b/website/src/components/community/CommunityMemberCard/styles.module.css
@@ -63,7 +63,7 @@
   border: 1px solid var(--site-border-strong);
   color: var(--site-muted-bright);
   font-size: 0.55rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   line-height: 1;
   text-transform: uppercase;
   letter-spacing: 0.1em;

--- a/website/src/components/research/ResearchLayout/index.tsx
+++ b/website/src/components/research/ResearchLayout/index.tsx
@@ -4,6 +4,7 @@ import { useLocation } from '@docusaurus/router'
 import Translate from '@docusaurus/Translate'
 import clsx from 'clsx'
 import React from 'react'
+import PageHeader from '@site/src/components/site/PageHeader'
 import { normalizeWebsitePath } from '@site/src/components/site/WebsiteMegaNav/navigation'
 import styles from './styles.module.css'
 
@@ -13,11 +14,28 @@ export interface ResearchNavItem {
   to: string
 }
 
-export const RESEARCH_NAV_ITEMS: ResearchNavItem[] = [
-  { key: 'publications', label: 'Papers & Talks', to: '/publications' },
-  { key: 'white-paper', label: 'White Paper', to: '/white-paper' },
-  { key: 'vision-paper', label: 'Vision Paper', to: '/vision-paper' },
+export interface ResearchNavGroup {
+  key: string
+  label: string
+  items: ResearchNavItem[]
+}
+
+/* Grouped like the docs sidebar, so the rail reads the same on both. */
+export const RESEARCH_NAV_GROUPS: ResearchNavGroup[] = [
+  {
+    key: 'publications',
+    label: 'Publications',
+    items: [
+      { key: 'publications', label: 'Papers & Talks', to: '/publications' },
+      { key: 'white-paper', label: 'White Paper', to: '/white-paper' },
+      { key: 'vision-paper', label: 'Vision Paper', to: '/vision-paper' },
+    ],
+  },
 ]
+
+export const RESEARCH_NAV_ITEMS: ResearchNavItem[] = RESEARCH_NAV_GROUPS.flatMap(
+  group => group.items,
+)
 
 export interface ResearchLayoutProps {
   activeKey: string
@@ -38,32 +56,35 @@ export default function ResearchLayout({
   return (
     <div className={styles.page}>
       <main className={styles.container}>
-        <header className={styles.masthead}>
-          <span className={styles.eyebrow}>
-            <Translate id="research.layout.eyebrow">Research</Translate>
-          </span>
-          <h1>{title}</h1>
-          {description && <p className={styles.description}>{description}</p>}
-        </header>
+        <PageHeader
+          description={description}
+          eyebrow={<Translate id="research.layout.eyebrow">Research</Translate>}
+          title={title}
+        />
 
         <div className={styles.body}>
           <nav className={styles.sidebar} aria-label="Research sections">
-            {RESEARCH_NAV_ITEMS.map((item) => {
-              const isActive = item.key === activeKey || normalizedPathname === item.to
+            {RESEARCH_NAV_GROUPS.map(group => (
+              <div key={group.key} className={styles.navGroup}>
+                <span className={styles.navGroupLabel}>{group.label}</span>
+                {group.items.map((item) => {
+                  const isActive = item.key === activeKey || normalizedPathname === item.to
 
-              return (
-                <Link
-                  key={item.key}
-                  className={clsx(styles.navLink, {
-                    [styles.navLinkActive]: isActive,
-                  })}
-                  to={item.to}
-                  aria-current={isActive ? 'page' : undefined}
-                >
-                  {item.label}
-                </Link>
-              )
-            })}
+                  return (
+                    <Link
+                      key={item.key}
+                      className={clsx(styles.navLink, {
+                        [styles.navLinkActive]: isActive,
+                      })}
+                      to={item.to}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      {item.label}
+                    </Link>
+                  )
+                })}
+              </div>
+            ))}
           </nav>
 
           <article className={styles.article}>{children}</article>

--- a/website/src/components/research/ResearchLayout/styles.module.css
+++ b/website/src/components/research/ResearchLayout/styles.module.css
@@ -3,85 +3,105 @@
   background: var(--site-bg);
 }
 
+/* Same box as .site-shell-container: gutters added to --page-max, not taken
+   out of it, so this edge lands on the navbar's and the docs canvas's. */
 .container {
-  width: min(100% - 2.5rem, var(--site-grid-max));
-  margin: 0 auto;
-  padding: 2.25rem 0 3.5rem;
-}
-
-.masthead {
-  display: grid;
-  gap: 0.6rem;
-  max-width: 46rem;
-  padding-bottom: 1.75rem;
-  border-bottom: 1px solid var(--site-border-strong);
-}
-
-.eyebrow {
-  color: var(--site-accent-strong);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.68rem;
-  font-weight: 650;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-}
-
-.masthead h1 {
-  margin: 0;
-  color: var(--site-text);
-  font-size: clamp(2.6rem, 6vw, 4.25rem);
-  font-weight: 430;
-  line-height: 0.95;
-  letter-spacing: -0.045em;
-}
-
-.description {
-  margin: 0;
-  color: var(--site-muted-bright);
-  font-size: 0.95rem;
-  line-height: 1.7;
+  width: 100%;
+  max-width: calc(var(--page-max) + var(--gutter) * 2);
+  margin-inline: auto;
+  padding: var(--space-8) var(--gutter) var(--space-10);
 }
 
 .body {
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(13rem, 0.22fr) minmax(0, 1fr);
+  grid-template-columns: var(--rail) minmax(0, 1fr);
   align-items: start;
-  gap: 2.5rem;
-  padding-top: 1.75rem;
+  gap: var(--rail-gap);
+  padding-top: var(--space-6);
 }
 
+/*
+ * The rail divider is drawn on the grid, not on the sidebar. The sidebar is
+ * sticky, so a border on it would only be as tall as the handful of links it
+ * contains, leaving a stub. Sitting at --rail puts it where the docs
+ * sidebar's own border-right falls.
+ */
+.body::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--rail);
+  width: 1px;
+  background: var(--site-border);
+}
+
+/* The docs sidebar, rebuilt: sentence-case group labels, a rule between
+   groups, a filled pill for the current page, and the same rhythm. */
 .sidebar {
   position: sticky;
-  top: calc(var(--site-header-height) + 1.25rem);
+  top: calc(var(--site-header-height) + var(--space-5));
   display: grid;
-  gap: 0.1rem;
   align-content: start;
+  gap: var(--space-5);
+  padding-right: var(--space-5);
 }
 
+.navGroup {
+  display: grid;
+  align-content: start;
+  gap: 2px;
+}
+
+.navGroup + .navGroup {
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--site-border);
+}
+
+.navGroupLabel {
+  padding: 0.15rem var(--space-2) var(--space-2);
+  color: var(--site-text-strong);
+  font-size: var(--text-sm);
+  font-weight: var(--site-font-weight-semibold);
+  letter-spacing: -0.005em;
+}
+
+/* The 12px indent is the docs rail's nested .menu__list padding: it insets the
+   pill, and with the link's own 12px puts item text at 24px against an 8px
+   group label. Without it the rail reads flatter than the docs one. */
 .navLink {
-  padding: 0.45rem 0.7rem;
-  border-left: 2px solid transparent;
-  color: var(--site-muted-bright);
-  font-size: 0.82rem;
-  font-weight: 550;
-  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  min-height: 2.1rem;
+  margin-left: var(--space-3);
+  padding: 0.42rem var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--site-muted);
+  font-size: var(--text-sm);
+  font-weight: var(--site-font-weight-normal);
+  line-height: 1.4;
   transition:
-    background 160ms ease,
-    border-color 160ms ease,
-    color 160ms ease;
+    background var(--site-transition-fast),
+    color var(--site-transition-fast);
 }
 
 .navLink:hover {
   background: var(--site-surface-soft);
-  color: var(--site-text);
+  color: var(--site-text-strong);
   text-decoration: none;
 }
 
 .navLinkActive,
 .navLinkActive:hover {
-  border-left-color: var(--site-accent);
   background: var(--site-accent-soft);
-  color: var(--site-text);
+  color: var(--site-accent-strong);
+  font-weight: var(--site-font-weight-medium);
+}
+
+.navLink:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
 }
 
 .article {
@@ -91,16 +111,23 @@
 @media (max-width: 996px) {
   .body {
     grid-template-columns: 1fr;
-    gap: 1.5rem;
+    gap: var(--space-5);
   }
 
+  .body::before {
+    display: none;
+  }
+
+  /* One scrolling row of pills. The groups flatten into it rather than
+     stacking their labels above a horizontal strip. */
   .sidebar {
     position: static;
     display: flex;
     flex-wrap: nowrap;
-    gap: 0.5rem;
+    gap: var(--space-2);
     overflow-x: auto;
-    padding-bottom: 0.5rem;
+    padding: 0 0 var(--space-2);
+    border-bottom: 1px solid var(--site-border);
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
@@ -109,28 +136,32 @@
     display: none;
   }
 
+  .navGroup {
+    display: contents;
+  }
+
+  .navGroupLabel {
+    display: none;
+  }
+
   .navLink {
     flex: 0 0 auto;
+    min-height: 0;
+    margin-left: 0;
+    padding-inline: var(--space-3);
     border: 1px solid var(--site-border);
-    border-left: 1px solid var(--site-border);
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     white-space: nowrap;
   }
 
   .navLinkActive,
   .navLinkActive:hover {
     border-color: var(--site-accent);
-    border-left-color: var(--site-accent);
   }
 }
 
 @media (max-width: 700px) {
   .container {
-    width: min(100% - 1.4rem, var(--site-grid-max));
-    padding-top: 1.5rem;
-  }
-
-  .masthead h1 {
-    font-size: clamp(2.2rem, 12vw, 3.2rem);
+    padding-top: var(--space-5);
   }
 }

--- a/website/src/components/site/PageHeader/index.tsx
+++ b/website/src/components/site/PageHeader/index.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react'
+import clsx from 'clsx'
+import React from 'react'
+import styles from './styles.module.css'
+
+export interface PageHeaderProps {
+  /** Section the page belongs to — Blog, Research, Community. */
+  eyebrow?: ReactNode
+  title: ReactNode
+  description?: ReactNode
+  /** Trailing controls (search, filters) laid out beside the title on desktop. */
+  actions?: ReactNode
+  className?: string
+}
+
+/**
+ * The one page title on the site.
+ *
+ * Blog, Research and Community each grew their own masthead — 3.25rem/600,
+ * 4.25rem/400 and 2em/400 respectively — so three pages one nav click apart
+ * looked like three different sites. Section identity now lives in the
+ * eyebrow, and the title itself is the same component everywhere.
+ */
+export default function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps): ReactNode {
+  return (
+    <header className={clsx('site-page-header', styles.header, className)}>
+      <div className={styles.text}>
+        {eyebrow && <span className={styles.eyebrow}>{eyebrow}</span>}
+        <h1 className={styles.title}>{title}</h1>
+        {description && <p className={styles.description}>{description}</p>}
+      </div>
+      {actions && <div className={styles.actions}>{actions}</div>}
+    </header>
+  )
+}

--- a/website/src/components/site/PageHeader/styles.module.css
+++ b/website/src/components/site/PageHeader/styles.module.css
@@ -1,0 +1,64 @@
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-5);
+  padding-bottom: var(--space-5);
+  border-bottom: 1px solid var(--site-border);
+}
+
+.text {
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+  max-width: var(--measure);
+}
+
+.eyebrow {
+  color: var(--site-accent-strong);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--text-xs);
+  font-weight: var(--site-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.title {
+  margin: 0;
+  color: var(--site-text-strong);
+  font-size: var(--text-3xl);
+  font-weight: var(--site-font-weight-semibold);
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+}
+
+/*
+ * Wraps rather than shrinks. The blog subtitle previously combined
+ * `white-space: nowrap` with `clamp(0.7rem, …)`, so on a narrow laptop it
+ * stayed on one line by dropping to 11px.
+ */
+.description {
+  margin: 0;
+  color: var(--site-muted);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  text-wrap: pretty;
+}
+
+.actions {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .header {
+    gap: var(--space-4);
+    padding-bottom: var(--space-4);
+  }
+
+  .actions {
+    width: 100%;
+  }
+}

--- a/website/src/css/docs.css
+++ b/website/src/css/docs.css
@@ -4,8 +4,9 @@
   --site-doc-canvas: var(--page-max);
   --site-doc-sidebar-width: var(--rail);
   --site-doc-toc-width: var(--toc);
-  /* Fluid column gaps: ramp from --space-6 at ~1220px to cap at 1920px. */
-  --site-doc-content-inset: clamp(var(--space-6), calc(12.19vw - 124px), 6.875rem);
+  /* Rail to content is shared with research and community; the TOC gap is
+   * ours alone, and ramps from --space-6 at ~1220px to its cap at 1920px. */
+  --site-doc-content-inset: var(--rail-gap);
   --site-doc-column-gap: clamp(var(--space-6), calc(14.06vw - 140px), 8.125rem);
   --site-doc-rail-top: 2.5rem;
   --site-doc-sidebar-top: 2rem;

--- a/website/src/css/tokens.css
+++ b/website/src/css/tokens.css
@@ -90,6 +90,9 @@
   /* Rail width: 18rem (20rem too wide for label list). */
   --rail: 18rem;
   --toc: 17rem;
+  /* Rail to content. Shared so docs, research and community start their text
+   * on the same x; ramps to its cap at 1920px, where the frame stops growing. */
+  --rail-gap: clamp(var(--space-6), calc(12.19vw - 124px), 6.875rem);
 
   /* Legacy aliases repointed to shared geometry. --site-content-max removed. */
   --site-grid-max: var(--page-max);

--- a/website/src/data/committerActivity.generated.ts
+++ b/website/src/data/committerActivity.generated.ts
@@ -82,9 +82,9 @@ export const committerActivityEntries: CommitterActivityEntry[] = [
     "name": "Wilson Wu",
     "login": "wilsonwu",
     "pullRequests": 43,
-    "reviews": 5,
+    "reviews": 6,
     "issues": 29,
-    "total": 77,
+    "total": 78,
     "status": "active"
   },
   {

--- a/website/src/data/contributorRank.generated.ts
+++ b/website/src/data/contributorRank.generated.ts
@@ -954,7 +954,7 @@ export const contributorRankData = {
     "endDate": "2026-08-25",
     "description": "Current non-merge commit activity after v0.3.0.",
     "totalCommits": 356,
-    "totalReviews": 379,
+    "totalReviews": 380,
     "totalContributors": 55,
     "newContributors": 35,
     "entries": [
@@ -1012,7 +1012,7 @@ export const contributorRankData = {
         "avatarSeed": "wilsonwu",
         "key": "github:wilsonwu",
         "commits": 34,
-        "reviews": 4,
+        "reviews": 5,
         "share": 0.0955,
         "firstCommitDate": "2026-06-09",
         "latestCommitDate": "2026-08-19",
@@ -3526,7 +3526,7 @@ export const contributorRankData = {
     "startDate": null,
     "endDate": "2026-01-05",
     "description": "Initial non-merge commit activity through v0.1.0.",
-    "totalCommits": 705,
+    "totalCommits": 706,
     "totalReviews": 580,
     "totalContributors": 53,
     "newContributors": 51,
@@ -3541,7 +3541,7 @@ export const contributorRankData = {
         "key": "github:xunzhuo",
         "commits": 167,
         "reviews": 130,
-        "share": 0.2369,
+        "share": 0.2365,
         "firstCommitDate": "2025-06-16",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3556,7 +3556,7 @@ export const contributorRankData = {
         "key": "github:rootfs",
         "commits": 149,
         "reviews": 253,
-        "share": 0.2113,
+        "share": 0.211,
         "firstCommitDate": "2025-04-15",
         "latestCommitDate": "2025-12-16",
         "isNewContributorSinceRelease": true
@@ -3571,7 +3571,7 @@ export const contributorRankData = {
         "key": "github:yuluo-yx",
         "commits": 53,
         "reviews": 53,
-        "share": 0.0752,
+        "share": 0.0751,
         "firstCommitDate": "2025-09-06",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3586,7 +3586,7 @@ export const contributorRankData = {
         "key": "github:samzong",
         "commits": 42,
         "reviews": 22,
-        "share": 0.0596,
+        "share": 0.0595,
         "firstCommitDate": "2025-09-16",
         "latestCommitDate": "2026-01-04",
         "isNewContributorSinceRelease": true
@@ -3601,7 +3601,7 @@ export const contributorRankData = {
         "key": "github:yossiovadia",
         "commits": 41,
         "reviews": 3,
-        "share": 0.0582,
+        "share": 0.0581,
         "firstCommitDate": "2025-05-20",
         "latestCommitDate": "2025-12-12",
         "isNewContributorSinceRelease": true
@@ -3616,7 +3616,7 @@ export const contributorRankData = {
         "key": "github:jaredforreal",
         "commits": 31,
         "reviews": 41,
-        "share": 0.044,
+        "share": 0.0439,
         "firstCommitDate": "2025-09-15",
         "latestCommitDate": "2025-12-16",
         "isNewContributorSinceRelease": true
@@ -3646,7 +3646,7 @@ export const contributorRankData = {
         "key": "github:tao12345666333",
         "commits": 25,
         "reviews": 17,
-        "share": 0.0355,
+        "share": 0.0354,
         "firstCommitDate": "2025-09-01",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3659,9 +3659,9 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/19606201?v=4",
         "avatarSeed": "onezero-y",
         "key": "github:onezero-y",
-        "commits": 17,
+        "commits": 18,
         "reviews": 8,
-        "share": 0.0241,
+        "share": 0.0255,
         "firstCommitDate": "2025-09-02",
         "latestCommitDate": "2025-11-08",
         "isNewContributorSinceRelease": true
@@ -3886,7 +3886,7 @@ export const contributorRankData = {
         "key": "github:nerdalert",
         "commits": 3,
         "reviews": 1,
-        "share": 0.0043,
+        "share": 0.0042,
         "firstCommitDate": "2026-01-04",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3901,7 +3901,7 @@ export const contributorRankData = {
         "key": "github:wilsonwu",
         "commits": 3,
         "reviews": 0,
-        "share": 0.0043,
+        "share": 0.0042,
         "firstCommitDate": "2025-12-09",
         "latestCommitDate": "2025-12-23",
         "isNewContributorSinceRelease": true
@@ -4335,8 +4335,8 @@ export const contributorRankData = {
     "startDate": null,
     "endDate": "2026-08-25",
     "description": "Full repository non-merge commit history.",
-    "totalCommits": 1715,
-    "totalReviews": 1467,
+    "totalCommits": 1716,
+    "totalReviews": 1468,
     "totalContributors": 162,
     "newContributors": 155,
     "entries": [
@@ -4350,7 +4350,7 @@ export const contributorRankData = {
         "key": "github:xunzhuo",
         "commits": 395,
         "reviews": 412,
-        "share": 0.2303,
+        "share": 0.2302,
         "firstCommitDate": "2025-06-16",
         "latestCommitDate": "2026-08-25",
         "isNewContributorSinceRelease": true
@@ -4365,7 +4365,7 @@ export const contributorRankData = {
         "key": "github:rootfs",
         "commits": 206,
         "reviews": 441,
-        "share": 0.1201,
+        "share": 0.12,
         "firstCommitDate": "2025-04-15",
         "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": true
@@ -4440,7 +4440,7 @@ export const contributorRankData = {
         "key": "github:wukuntai-0211",
         "commits": 50,
         "reviews": 25,
-        "share": 0.0292,
+        "share": 0.0291,
         "firstCommitDate": "2026-05-05",
         "latestCommitDate": "2026-08-18",
         "isNewContributorSinceRelease": true
@@ -4484,7 +4484,7 @@ export const contributorRankData = {
         "avatarSeed": "wilsonwu",
         "key": "github:wilsonwu",
         "commits": 42,
-        "reviews": 4,
+        "reviews": 5,
         "share": 0.0245,
         "firstCommitDate": "2025-12-09",
         "latestCommitDate": "2026-08-19",
@@ -4663,9 +4663,9 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/19606201?v=4",
         "avatarSeed": "onezero-y",
         "key": "github:onezero-y",
-        "commits": 17,
+        "commits": 18,
         "reviews": 8,
-        "share": 0.0099,
+        "share": 0.0105,
         "firstCommitDate": "2025-09-02",
         "latestCommitDate": "2025-11-08",
         "isNewContributorSinceRelease": true

--- a/website/src/pages/community/community-page.module.css
+++ b/website/src/pages/community/community-page.module.css
@@ -12,7 +12,7 @@
 
 .section h2 {
   margin: 0;
-  font-size: clamp(1.7rem, 4vw, 2.6rem);
+  font-size: var(--text-2xl);
   line-height: 1;
 }
 
@@ -98,7 +98,7 @@
   width: 2rem;
   height: 2rem;
   border: 1px solid var(--site-border-strong);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--site-text);
   font-size: 0.78rem;
 }
@@ -131,7 +131,7 @@
 .controlButton {
   width: 0.7rem;
   height: 0.7rem;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: rgba(255, 255, 255, 0.22);
 }
 
@@ -170,7 +170,7 @@
   min-height: 2.35rem;
   padding: 0.5rem 0.85rem;
   border: 1px solid var(--site-border);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--site-text);
   font-size: 0.74rem;
   text-transform: uppercase;
@@ -185,7 +185,7 @@
 .stepsList code,
 .card code {
   padding: 0.12rem 0.32rem;
-  border-radius: 0.35rem;
+  border-radius: var(--radius-md);
   background: var(--site-badge-bg);
   overflow-wrap: anywhere;
   word-break: break-word;

--- a/website/src/pages/community/contributors.module.css
+++ b/website/src/pages/community/contributors.module.css
@@ -31,7 +31,7 @@
   color: var(--site-muted);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.63rem;
-  font-weight: 800;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.1em;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -43,7 +43,7 @@
   margin-left: auto;
   color: var(--site-text-strong);
   font-size: clamp(1.05rem, 2vw, 1.4rem);
-  font-weight: 600;
+  font-weight: var(--site-font-weight-semibold);
   line-height: 1.05;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -80,7 +80,7 @@
   color: var(--site-muted);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.68rem;
-  font-weight: 800;
+  font-weight: var(--site-font-weight-bold);
 }
 
 .podiumIdentity {
@@ -94,7 +94,7 @@
   overflow: hidden;
   color: var(--site-text);
   font-size: 0.82rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   line-height: 1.25;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -127,7 +127,7 @@
   color: var(--site-text);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.82rem;
-  font-weight: 800;
+  font-weight: var(--site-font-weight-bold);
   font-variant-numeric: tabular-nums;
 }
 
@@ -135,7 +135,7 @@
   color: var(--site-muted);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.58rem;
-  font-weight: 800;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.07em;
   text-transform: uppercase;
 }
@@ -161,8 +161,8 @@
 
 .sectionHeader h2 {
   margin: 0;
-  font-size: clamp(1.8rem, 4vw, 3rem);
-  font-weight: 550;
+  font-size: var(--text-2xl);
+  font-weight: var(--site-font-weight-medium);
   letter-spacing: -0.03em;
   line-height: 1;
 }
@@ -202,7 +202,7 @@
   color: var(--site-muted);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.68rem;
-  font-weight: 850;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.1em;
   text-align: right;
   text-transform: uppercase;
@@ -221,7 +221,7 @@
   color: var(--site-text);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.82rem;
-  font-weight: 850;
+  font-weight: var(--site-font-weight-bold);
   text-align: right;
   text-transform: uppercase;
   appearance: none;
@@ -245,7 +245,7 @@
   color: var(--site-muted);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.68rem;
-  font-weight: 800;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.09em;
   text-transform: uppercase;
 }
@@ -312,7 +312,7 @@
   color: var(--site-muted-bright);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.78rem;
-  font-weight: 900;
+  font-weight: var(--site-font-weight-bold);
 }
 
 .contributor {
@@ -327,7 +327,7 @@
   width: 2.8rem;
   height: 2.8rem;
   border: 1px solid var(--site-border-strong);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   object-fit: cover;
   background: var(--site-surface-alt);
 }
@@ -354,7 +354,7 @@
   overflow: hidden;
   color: var(--site-text-strong);
   font-size: 1.02rem;
-  font-weight: 850;
+  font-weight: var(--site-font-weight-bold);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -373,7 +373,7 @@
   color: #ffffff;
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.62rem;
-  font-weight: 900;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.08em;
   line-height: 1;
   box-shadow:
@@ -385,7 +385,7 @@
 .newContributorPill::before {
   width: 0.36rem;
   height: 0.36rem;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: #35d399;
   box-shadow: 0 0 10px rgba(53, 211, 153, 0.55);
   content: "";
@@ -426,7 +426,7 @@
   display: none;
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.64rem;
-  font-weight: 850;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -436,7 +436,7 @@
   color: var(--site-text);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.98rem;
-  font-weight: 850;
+  font-weight: var(--site-font-weight-bold);
   font-variant-numeric: tabular-nums;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -454,7 +454,7 @@
 }
 
 .share > span {
-  font-weight: 800;
+  font-weight: var(--site-font-weight-bold);
 }
 
 .shareTrack {

--- a/website/src/pages/community/governance.module.css
+++ b/website/src/pages/community/governance.module.css
@@ -28,7 +28,7 @@
   color: var(--site-accent-strong);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.67rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.15em;
 }
@@ -41,8 +41,8 @@
 .sectionHeader h2 {
   margin: 0;
   color: var(--site-text);
-  font-size: clamp(1.55rem, 2.8vw, 2.35rem);
-  font-weight: 500;
+  font-size: var(--text-2xl);
+  font-weight: var(--site-font-weight-medium);
   line-height: 1;
   letter-spacing: -0.025em;
 }
@@ -156,7 +156,7 @@
 
 .roleTable th {
   color: var(--site-text);
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
 }
 
 .roleTable thead th {
@@ -227,7 +227,7 @@
   border-bottom: 1px solid var(--site-border);
   color: var(--site-text);
   font-size: 0.68rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }

--- a/website/src/pages/community/steering-committee.module.css
+++ b/website/src/pages/community/steering-committee.module.css
@@ -11,7 +11,7 @@
   color: var(--site-accent-strong);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.67rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.16em;
 }
@@ -50,7 +50,7 @@
 .trackNumber {
   color: var(--site-text);
   font-family: var(--ifm-font-family-monospace);
-  font-size: 2.2rem;
+  font-size: var(--text-2xl);
   line-height: 1;
 }
 
@@ -62,8 +62,8 @@
 .trackTitle h2 {
   margin: 0;
   color: var(--site-text);
-  font-size: clamp(2rem, 3.8vw, 3.25rem);
-  font-weight: 480;
+  font-size: var(--text-2xl);
+  font-weight: var(--site-font-weight-normal);
   line-height: 0.95;
   letter-spacing: -0.035em;
 }

--- a/website/src/pages/community/team.module.css
+++ b/website/src/pages/community/team.module.css
@@ -26,7 +26,7 @@
   color: var(--site-accent-strong);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.68rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.16em;
 }
@@ -45,8 +45,8 @@
 .titleLine h2 {
   margin: 0;
   color: var(--site-text);
-  font-size: clamp(1.55rem, 2.6vw, 2.25rem);
-  font-weight: 500;
+  font-size: var(--text-2xl);
+  font-weight: var(--site-font-weight-medium);
   line-height: 1;
   letter-spacing: -0.025em;
 }

--- a/website/src/pages/community/work-groups.module.css
+++ b/website/src/pages/community/work-groups.module.css
@@ -26,8 +26,8 @@
 .groupsHeader h2 {
   margin: 0;
   color: var(--site-text);
-  font-size: clamp(1.7rem, 3vw, 2.35rem);
-  font-weight: 500;
+  font-size: var(--text-2xl);
+  font-weight: var(--site-font-weight-medium);
   letter-spacing: -0.03em;
   line-height: 1.05;
 }
@@ -53,7 +53,7 @@
   color: var(--site-accent-strong);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.66rem;
-  font-weight: 700;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.13em;
   text-transform: uppercase;
 }
@@ -61,8 +61,8 @@
 .sectionHeading h2 {
   margin: 0;
   color: var(--site-text);
-  font-size: clamp(1.7rem, 3vw, 2.35rem);
-  font-weight: 500;
+  font-size: var(--text-2xl);
+  font-weight: var(--site-font-weight-medium);
   letter-spacing: -0.03em;
   line-height: 1;
 }
@@ -105,7 +105,7 @@
   margin: 0;
   color: var(--site-text);
   font-size: 1.25rem;
-  font-weight: 600;
+  font-weight: var(--site-font-weight-semibold);
   letter-spacing: -0.02em;
   line-height: 1.2;
 }
@@ -234,7 +234,7 @@
 .rules dt {
   color: var(--site-text);
   font-size: 0.76rem;
-  font-weight: 700;
+  font-weight: var(--site-font-weight-bold);
 }
 
 .rules dd {

--- a/website/src/pages/publications.module.css
+++ b/website/src/pages/publications.module.css
@@ -8,7 +8,7 @@
   gap: 0.4rem;
   padding: 0.35rem;
   border: 1px solid var(--site-border);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: var(--site-surface);
 }
 
@@ -16,7 +16,7 @@
   min-height: 2.35rem;
   padding: 0.5rem 0.9rem;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: transparent;
   color: var(--site-muted-bright);
   font-size: 0.74rem;
@@ -51,7 +51,7 @@
   color: var(--site-muted);
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.7rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.14em;
 }
@@ -84,7 +84,7 @@
   border: 1px solid var(--site-border-strong);
   color: var(--site-muted-bright);
   font-size: 0.6rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   letter-spacing: 0.09em;
   text-transform: uppercase;
 }
@@ -109,7 +109,7 @@
   margin: 0;
   color: var(--site-text);
   font-size: 0.94rem;
-  font-weight: 600;
+  font-weight: var(--site-font-weight-semibold);
   line-height: 1.35;
 }
 
@@ -137,7 +137,7 @@
   min-height: 1.9rem;
   padding: 0.35rem 0.7rem;
   border: 1px solid var(--site-border);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   color: var(--site-text);
   font-size: 0.68rem;
   text-transform: uppercase;
@@ -159,7 +159,7 @@
 @media (max-width: 700px) {
   .filterButtons {
     display: grid;
-    border-radius: 1.1rem;
+    border-radius: var(--radius-lg);
   }
 
   .row {


### PR DESCRIPTION
Related #3002

## Purpose

Phase 3 of the website revamp, on top of #3016. This brings Research and Community onto the same page header, sidebar, and layout system used by Docs.

- **Shared `PageHeader`.** One component for the eyebrow, title, description, and actions across Research and Community.
- **One rail.** Research and Community now use the same sidebar style as Docs, with sentence-case labels, group rules, and a filled-pill active state.
- **Rail divider.** Uses a grid pseudo-element so the divider runs the full page height while the sidebar stays sticky.
- **One frame.** Research and Community now use the same `--page-max` and gutter sizing as Docs, navbar, and footer.
- **`--rail-gap`.** Adds a shared token so Docs, Research, and Community align their content to the same left edge.
- **Community grouping.** Navigation is grouped into **People** and **How we work**. Research uses a single **Publications** group.

### Hand-merged changes

The archive predates #2989, which changed the Community workgroups structure.

- `work-groups.module.css` was manually merged to preserve the current markup while applying the required token and typography changes.
- `CommunityLayout/index.tsx` keeps the current upstream labels and ordering, with only the `PageHeader` and navigation grouping changes applied.

Two files sit outside this phase's manifest:

- `tokens.css` adds `--rail-gap`.
- `docs.css` consumes `--rail-gap` instead of its local value.

Not in this PR: `/white-paper`, `/vision-paper`, and `TestimonialsRail` alignment.

## Test Plan

```bash
cd website && npm run lint
npm start
```

Checked light and dark modes at 1920 / 1280 / 996 / 640.

- Docs, Research, and Community use the same rail, spacing, active state, and content alignment.
- Outer edges align with the navbar and footer.
- Rail divider runs the full page height.
- Rail stays sticky while scrolling and does not overlap the footer.
- Active state is correct across all Community routes and `/publications`.
- `/community/work-groups` retains the current #2989 content.
- Docs layout remains unchanged from #<PR2>.
- At 996px and below, the rail becomes a horizontal scrolling row with group labels hidden and no page-level horizontal scroll.
- Light and dark modes verified at all four widths.

## Test Result

`npm run lint` clean. Behaviour verified in both colour modes at all four widths.

Please check the deployed preview for the full visual details.

### Before:

<img width="1913" height="988" alt="image" src="https://github.com/user-attachments/assets/18136583-fed0-4264-86e8-71424af7df9e" />

<img width="1913" height="988" alt="image" src="https://github.com/user-attachments/assets/12bc0a66-596f-455e-a4ef-27e2122c0c19" />

### After:

One rail everywhere

<img width="1913" height="988" alt="Screenshot From 2026-08-25 16-33-56" src="https://github.com/user-attachments/assets/c043e5a7-0d52-4405-8a22-2113f567a2f4" />

<img width="1913" height="988" alt="Screenshot From 2026-08-25 16-33-49" src="https://github.com/user-attachments/assets/361f3ba2-5266-47f5-90a0-49acc65309eb" />

<img width="1913" height="988" alt="Screenshot From 2026-08-25 16-33-41" src="https://github.com/user-attachments/assets/a25cba0e-ef49-4754-8772-c0a0f7004d7b" />



---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.