### PR TITLE
[Docs] blog layout, and size the page frame to its columns

### DIFF
--- a/website/src/css/blog.css
+++ b/website/src/css/blog.css
@@ -1,9 +1,5 @@
-/* ------------------------------------------------------------------ *
- * Blog palette
- *
- * Aliases through the shared ramp so light and dark stay in sync — no
- * colour is declared only inside a dark-mode block.
- * ------------------------------------------------------------------ */
+/* ---- Blog palette: aliases through the shared ramp, so no colour is
+ * declared only inside a dark-mode block ---- */
 html[data-route-kind='blog'],
 .blog-wrapper,
 .site-blog-layout {
@@ -19,16 +15,8 @@ html[data-route-kind='blog'],
   --blog-surface-cool: var(--site-surface-alt);
   --blog-surface-tint: var(--site-accent-soft);
   --blog-card-shadow: var(--site-shadow-soft);
-  /*
-   * One article width — prose, code, images and tables all share it, as on
-   * the reference. Media wider than the text reads as a second, competing
-   * left edge and is what made the running text look inset.
-   *
-   * In rem, not ch: a ch-based custom property resolves against the
-   * font-size of whatever consumes it, so prose (19px) and code blocks
-   * (monospace) would each get a different column off one token. 46rem is
-   * ~68 characters at 19px.
-   */
+  /* One width for prose, code, images and tables. In rem, not ch: ch resolves
+   * against the consumer's font-size, so prose and code would differ. */
   --blog-prose: 46rem;
 }
 
@@ -38,10 +26,7 @@ html[data-route-kind='blog'] body,
   background: var(--site-bg);
 }
 
-/*
- * Same box as Research / Community / .site-shell-container: gutters sit
- * outside --page-max so the outer edge lands on the navbar and footer.
- */
+/* Same box as .site-shell-container: gutters outside --page-max. */
 .site-blog-layout__inner {
   width: 100%;
   max-width: calc(var(--page-max) + var(--gutter) * 2);
@@ -58,10 +43,7 @@ html[data-route-kind='blog'] body,
   display: none;
 }
 
-/*
- * PageHeader keeps its shared border and padding — do not zero them out.
- * That border is what makes Research / Community / Blog read as one site.
- */
+/* PageHeader keeps its own border and padding — that rule is the shared one. */
 .site-blog-index__header {
   margin: 0;
 }
@@ -89,10 +71,7 @@ html[data-route-kind='blog'] body,
   min-width: 0;
 }
 
-/* ------------------------------------------------------------------ *
- * Cards — proportions from the previous listing that felt elegant:
- * taller media, object-fit contain, fixed 2-col grid, roomy featured.
- * ------------------------------------------------------------------ */
+/* ---- Cards ---- */
 .site-blog-card {
   overflow: hidden;
   border: 1px solid var(--blog-border);
@@ -330,11 +309,7 @@ html[data-route-kind='blog'] body,
   padding: 2rem;
 }
 
-/* ------------------------------------------------------------------ *
- * Listing rail — left, shared --rail width. Readable recent list (not a
- * cramped nav of muted pills). Group labels match Research sentence-case.
- * ------------------------------------------------------------------ */
-/* Group gap and rule match ResearchLayout: 24 + 1px + 24. */
+/* ---- Listing rail: left, shared --rail width, ResearchLayout metrics ---- */
 .site-blog-index__rail {
   position: sticky;
   top: calc(var(--site-header-height) + var(--space-5));
@@ -486,15 +461,9 @@ html[data-route-kind='blog'] body,
   text-transform: uppercase;
 }
 
-/* ------------------------------------------------------------------ *
- * Article — left contents rail, then one LEFT-FLUSH column.
- *
- * The column is the article width, not 1fr. Sized to 1fr it would span to
- * the frame's right edge and the prose inside it would need centring to
- * avoid a void — and centring is the misalignment this phase exists to
- * remove: it put the article's first character ~310px right of where docs,
- * research and community start theirs.
- * ------------------------------------------------------------------ */
+/* ---- Article: left contents rail, then one left-flush column ----
+ * The column is the article width, not 1fr: at 1fr the prose would need
+ * centring, which is the ~310px misalignment this phase removes. */
 .site-blog-layout--post .site-blog-layout__inner {
   position: relative;
   display: grid;
@@ -505,11 +474,7 @@ html[data-route-kind='blog'] body,
   padding: var(--space-8) var(--gutter) 5.5rem;
 }
 
-/*
- * Only when there is a rail to divide. A post with no headings gets no TOC
- * from BlogPostPage, and the divider would otherwise hang beside an empty
- * column. The article keeps its indent either way so it stays aligned.
- */
+/* Only when there is a rail to divide — a post with no headings gets no TOC. */
 .site-blog-layout--post .site-blog-layout__inner:has(.site-blog-layout__toc)::before {
   content: '';
   position: absolute;
@@ -539,11 +504,8 @@ html[data-route-kind='blog'] body,
   box-shadow: none;
 }
 
-/*
- * The section eyebrow, styled as PageHeader's so a post opens like every
- * other page. It stays a link back to the index; the arrow it used to carry
- * is what made it read as browser chrome instead of a category label.
- */
+/* Styled as PageHeader's eyebrow. Still a link back to the index; the arrow
+ * it carried made it read as browser chrome, not a category label. */
 .site-blog-post__breadcrumb {
   display: inline-block;
   margin-bottom: var(--space-2);
@@ -562,10 +524,8 @@ html[data-route-kind='blog'] body,
   text-underline-offset: 0.25em;
 }
 
-/*
- * Spans the column so its rule matches PageHeader's on every other page;
- * the text inside stays at the prose measure.
- */
+/* Spans the column so its rule matches PageHeader's; the text inside
+ * stays at the prose measure. */
 .site-blog-post__header {
   max-width: none;
   margin-bottom: var(--space-8);
@@ -585,7 +545,6 @@ html[data-route-kind='blog'] body,
   text-wrap: balance;
 }
 
-/* The header spans the column for its rule; the text in it keeps the measure. */
 .site-blog-post__meta,
 .site-blog-post__authors,
 .site-blog-post__tags {
@@ -676,22 +635,16 @@ html[data-route-kind='blog'] body,
   line-height: 1.75;
 }
 
-/*
- * Running text stops at the prose measure and is LEFT-flush, so its first
- * character sits on the same x as a docs paragraph. Never `margin-inline:
- * auto` here — that is the misalignment this phase removes.
- */
+/* Left-flush, so the first character sits on the same x as a docs paragraph.
+ * Never `margin-inline: auto` here. */
 .site-blog-post__content > :is(p, ul, ol, blockquote, h2, h3, h4, h5, h6),
 .site-blog-layout--post .markdown > :is(p, ul, ol, blockquote, h2, h3, h4, h5, h6) {
   max-width: var(--blog-prose);
   margin-inline: 0;
 }
 
-/*
- * Media fills the column — the same width as the prose, not wider. MDX wraps
- * images in <p>, so these need naming explicitly or the rule above would cap
- * an image's paragraph and leave it narrower than the code block beside it.
- */
+/* Media fills the column, same width as the prose. MDX wraps images in <p>,
+ * so those need naming explicitly or the rule above would catch them. */
 .site-blog-post__content > :is(pre, table, figure, .theme-code-block, .tabs-container, details),
 .site-blog-post__content > div:has(> table),
 .site-blog-post__content > div:has(> pre),
@@ -782,10 +735,7 @@ html[data-route-kind='blog'] body,
   font-size: 0.95rem;
 }
 
-/* ------------------------------------------------------------------ *
- * Contents rail — docs sidebar chrome (filled pill, sentence-case),
- * with LangChain-level breathing room and clear nested hierarchy.
- * ------------------------------------------------------------------ */
+/* ---- Contents rail: docs sidebar chrome, filled pill, sentence-case ---- */
 .site-blog-layout__toc {
   position: sticky;
   top: calc(var(--site-header-height) + var(--space-5));
@@ -796,15 +746,9 @@ html[data-route-kind='blog'] body,
   scrollbar-width: thin;
 }
 
-/*
- * Exactly one scroller. Docusaurus's TOC sets its own sticky + max-height +
- * overflow-y, and on docs that lands on the same element as the theme class,
- * so there is one. Here BlogLayout wraps it in this aside, which nested a
- * second scroll container inside the first and drew two scrollbars. The
- * aside is the one that scrolls; its offsets come from our own tokens,
- * whereas the inner element's are keyed to --ifm-navbar-height, which is
- * only redefined on docs pages.
- */
+/* Exactly one scroller. Docusaurus's TOC brings its own sticky + overflow-y;
+ * BlogLayout's aside wrapper nested a second one and drew two scrollbars.
+ * The aside wins because its offsets are ours, not --ifm-navbar-height. */
 .site-blog-layout__toc > [class*='tableOfContents'] {
   position: static;
   max-height: none;
@@ -842,10 +786,8 @@ html[data-route-kind='blog'] body,
   padding-left: var(--space-3);
 }
 
-/*
- * Docs sidebar metrics exactly: 12px pill inset + 12px padding puts item text
- * at 24px against the 8px label, and the pill is 2.1rem tall.
- */
+/* Docs sidebar metrics: 12px inset + 12px padding puts item text at 24px
+ * against the 8px label. */
 .site-blog-layout__toc .table-of-contents__link {
   display: flex;
   align-items: center;

--- a/website/src/css/blog.css
+++ b/website/src/css/blog.css
@@ -1,38 +1,12 @@
 /* ------------------------------------------------------------------ *
  * Blog palette
  *
- * The blog runs a cooler, bluer neutral than the rest of the site, hence its
- * own thin token layer. Light values are literals; dark remaps onto `--site-*`.
- *
- * Two muted tiers only, mirroring `--site-muted` / `--site-muted-bright`.
- * Every literal clears WCAG AA (4.5:1) on the lightest surface it lands on —
- * add new ones the same way.
- *
- * `--blog-accent` resolves through `--site-accent-strong`, so it follows the
- * color mode by itself and needs no dark-block entry.
+ * Aliases through the shared ramp so light and dark stay in sync — no
+ * colour is declared only inside a dark-mode block.
  * ------------------------------------------------------------------ */
 html[data-route-kind='blog'],
 .blog-wrapper,
 .site-blog-layout {
-  --blog-ink: #070b16;
-  --blog-ink-soft: #101827;
-  --blog-ink-quote: #374760;
-  --blog-muted: #61728c;
-  --blog-muted-strong: #41546d;
-  --blog-border: #d7e0ec;
-  --blog-border-strong: #b7c8dd;
-  --blog-border-focus: #84bfff;
-  --blog-accent: var(--site-accent-strong);
-  --blog-surface-warm: #fbfaf7;
-  --blog-surface-cool: #f7f9fc;
-  --blog-surface-tint: #f7fbff;
-  --blog-card-shadow: 0 18px 38px rgba(30, 64, 105, 0.09);
-  --blog-focus-ring: 0 0 0 3px rgba(48, 162, 255, 0.12);
-}
-
-html[data-theme='dark'][data-route-kind='blog'],
-html[data-theme='dark'] .blog-wrapper,
-html[data-theme='dark'] .site-blog-layout {
   --blog-ink: var(--site-text-strong);
   --blog-ink-soft: var(--site-text);
   --blog-ink-quote: var(--site-muted-bright);
@@ -40,140 +14,89 @@ html[data-theme='dark'] .site-blog-layout {
   --blog-muted-strong: var(--site-muted-bright);
   --blog-border: var(--site-border);
   --blog-border-strong: var(--site-border-strong);
-  --blog-border-focus: var(--site-accent);
+  --blog-accent: var(--site-accent-strong);
   --blog-surface-warm: var(--site-surface-alt);
   --blog-surface-cool: var(--site-surface-alt);
   --blog-surface-tint: var(--site-accent-soft);
-  --blog-card-shadow: var(--site-shadow);
-  --blog-focus-ring: 0 0 0 3px rgba(48, 162, 255, 0.22);
+  --blog-card-shadow: var(--site-shadow-soft);
+  /*
+   * One article width — prose, code, images and tables all share it, as on
+   * the reference. Media wider than the text reads as a second, competing
+   * left edge and is what made the running text look inset.
+   *
+   * In rem, not ch: a ch-based custom property resolves against the
+   * font-size of whatever consumes it, so prose (19px) and code blocks
+   * (monospace) would each get a different column off one token. 46rem is
+   * ~68 characters at 19px.
+   */
+  --blog-prose: 46rem;
 }
 
 html[data-route-kind='blog'] body,
-.blog-wrapper {
-  background: var(--site-bg);
-}
-
+.blog-wrapper,
 .site-blog-layout {
   background: var(--site-bg);
 }
 
+/*
+ * Same box as Research / Community / .site-shell-container: gutters sit
+ * outside --page-max so the outer edge lands on the navbar and footer.
+ */
 .site-blog-layout__inner {
-  width: min(93.5rem, calc(72vw + 4.5rem), calc(100% - 1.35rem));
-  margin: 0 auto;
+  width: 100%;
+  max-width: calc(var(--page-max) + var(--gutter) * 2);
+  margin-inline: auto;
+  padding-inline: var(--gutter);
 }
 
-.site-blog-layout--listing {
-  padding: 4.25rem 0 5rem;
-}
-
+/* Match ResearchLayout .container vertical rhythm exactly. */
 .site-blog-layout--listing .site-blog-layout__inner {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  padding: var(--space-8) var(--gutter) var(--space-10);
 }
 
 .site-blog-layout--listing .site-blog-layout__sidebar {
   display: none;
 }
 
+/*
+ * PageHeader keeps its shared border and padding — do not zero them out.
+ * That border is what makes Research / Community / Blog read as one site.
+ */
 .site-blog-index__header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(24rem, 38rem);
-  grid-template-areas:
-    'title search'
-    'description description';
-  column-gap: 3rem;
-  row-gap: 0.8rem;
-  align-items: end;
-  margin-bottom: 2rem;
-}
-
-.site-blog-index__header h1 {
-  grid-area: title;
   margin: 0;
-  color: var(--site-text-strong);
-  font-size: clamp(2.5rem, 4vw, 3.25rem);
-  font-weight: 650;
-  line-height: 1;
-  letter-spacing: -0.045em;
-}
-
-.site-blog-index__header p {
-  grid-area: description;
-  max-width: none;
-  margin: 0;
-  color: var(--blog-muted);
-  font-size: clamp(0.7rem, 1.25vw, 1.15rem);
-  line-height: 1.45;
-  letter-spacing: -0.01em;
-  white-space: nowrap;
-}
-
-.site-blog-search {
-  grid-area: search;
-  position: relative;
-  display: flex;
-  align-items: center;
-  min-height: 3.25rem;
-  border: 1px solid var(--blog-border);
-  border-radius: 0.8rem;
-  background: var(--site-surface);
-  color: var(--blog-muted);
-  transition:
-    border-color 160ms ease,
-    box-shadow 160ms ease;
-}
-
-.site-blog-search:focus-within {
-  border-color: var(--blog-border-focus);
-  box-shadow: var(--blog-focus-ring);
-}
-
-.site-blog-search__icon {
-  position: absolute;
-  left: 1rem;
-  top: 50%;
-  font-size: 1.65rem;
-  line-height: 1;
-  transform: translateY(-53%) rotate(-18deg);
-  pointer-events: none;
-}
-
-.site-blog-search input {
-  width: 100%;
-  min-width: 0;
-  padding: 0.82rem 1rem 0.82rem 3rem;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: var(--site-text);
-  font: inherit;
-  font-size: 1.05rem;
-}
-
-.site-blog-search input::placeholder {
-  color: var(--blog-muted);
-  opacity: 1;
-}
-
-.site-blog-search input::-webkit-search-cancel-button {
-  cursor: pointer;
 }
 
 .site-blog-index__columns {
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 17rem;
-  gap: 3.4rem;
+  grid-template-columns: var(--rail) minmax(0, 1fr);
+  gap: var(--rail-gap);
   align-items: start;
+  padding-top: var(--space-6);
+}
+
+.site-blog-index__columns::before {
+  content: '';
+  position: absolute;
+  top: var(--space-6);
+  bottom: 0;
+  left: var(--rail);
+  width: 1px;
+  background: var(--site-border);
 }
 
 .site-blog-index__feed {
   min-width: 0;
 }
 
+/* ------------------------------------------------------------------ *
+ * Cards — proportions from the previous listing that felt elegant:
+ * taller media, object-fit contain, fixed 2-col grid, roomy featured.
+ * ------------------------------------------------------------------ */
 .site-blog-card {
   overflow: hidden;
   border: 1px solid var(--blog-border);
-  border-radius: 1.1rem;
+  border-radius: var(--radius-lg);
   background: var(--site-surface);
   transition:
     border-color 180ms ease,
@@ -182,7 +105,7 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-card:hover {
-  border-color: var(--blog-border-strong);
+  border-color: var(--site-hover-border);
   box-shadow: var(--blog-card-shadow);
   transform: translateY(-2px);
 }
@@ -201,6 +124,7 @@ html[data-route-kind='blog'] body,
   overflow: hidden;
   isolation: isolate;
   place-items: center;
+  background: var(--site-surface-alt);
 }
 
 .site-blog-card__image-backdrop {
@@ -229,30 +153,56 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-card__image-fallback {
+  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-end;
   height: 14.5rem;
-  padding: 2rem;
+  padding: var(--space-5);
   background:
-    linear-gradient(135deg, rgba(48, 162, 255, 0.08), transparent 55%),
-    var(--blog-surface-cool);
-  color: var(--blog-ink-soft);
+    radial-gradient(120% 120% at 12% 0%, var(--site-accent-soft), transparent 62%),
+    var(--site-surface-alt);
+  color: var(--site-text-strong);
+  overflow: hidden;
+}
+
+.site-blog-card__image-fallback::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, var(--site-border) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--site-border) 1px, transparent 1px);
+  background-size: 2.25rem 2.25rem;
+  opacity: 0.5;
+  mask-image: linear-gradient(150deg, #000, transparent 72%);
+}
+
+.site-blog-card__image-fallback span,
+.site-blog-card__image-fallback strong {
+  position: relative;
 }
 
 .site-blog-card__image-fallback span {
-  color: var(--blog-accent);
-  font-size: 2.1rem;
-  font-weight: 700;
-  letter-spacing: -0.06em;
+  color: var(--site-accent-strong);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--text-xs);
+  font-weight: var(--site-font-weight-semibold);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .site-blog-card__image-fallback strong {
-  font-size: 1.05rem;
-  font-weight: 550;
+  margin-top: var(--space-2);
+  font-size: var(--text-lg);
+  font-weight: var(--site-font-weight-semibold);
+  line-height: 1.25;
+  letter-spacing: -0.02em;
 }
 
 .site-blog-card__body {
+  display: flex;
+  flex-direction: column;
   padding: 1.45rem 1.5rem 1.55rem;
 }
 
@@ -261,7 +211,7 @@ html[data-route-kind='blog'] body,
   margin-bottom: 0.5rem;
   color: var(--blog-accent);
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: var(--site-font-weight-bold);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -270,9 +220,15 @@ html[data-route-kind='blog'] body,
   margin: 0;
   color: var(--blog-ink);
   font-size: 1.28rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   line-height: 1.25;
   letter-spacing: -0.025em;
+  text-wrap: balance;
+  transition: color var(--site-transition-fast);
+}
+
+.site-blog-card:hover .site-blog-card__title {
+  color: var(--site-accent-strong);
 }
 
 .site-blog-card__title a {
@@ -283,6 +239,7 @@ html[data-route-kind='blog'] body,
 .site-blog-card__meta {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.55rem;
   margin-top: 0.9rem;
   color: var(--blog-muted);
@@ -317,11 +274,11 @@ html[data-route-kind='blog'] body,
 .site-blog-card--featured .site-blog-card__image {
   max-height: 25rem;
   padding: 1.4rem;
+  object-fit: contain;
 }
 
 .site-blog-card--featured .site-blog-card__image-fallback {
   height: 100%;
-  max-height: 21.5rem;
 }
 
 .site-blog-card--featured .site-blog-card__body {
@@ -373,50 +330,66 @@ html[data-route-kind='blog'] body,
   padding: 2rem;
 }
 
+/* ------------------------------------------------------------------ *
+ * Listing rail — left, shared --rail width. Readable recent list (not a
+ * cramped nav of muted pills). Group labels match Research sentence-case.
+ * ------------------------------------------------------------------ */
+/* Group gap and rule match ResearchLayout: 24 + 1px + 24. */
 .site-blog-index__rail {
   position: sticky;
-  top: calc(var(--site-header-height) + 2rem);
+  top: calc(var(--site-header-height) + var(--space-5));
   display: grid;
-  gap: 2.8rem;
+  align-content: start;
+  gap: var(--space-5);
+  padding-right: var(--space-5);
 }
 
 .site-blog-index__rail h2 {
-  margin: 0 0 1.05rem;
-  color: var(--blog-muted);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  margin: 0;
+  padding: 0.15rem var(--space-2) var(--space-2);
+  color: var(--site-text-strong);
+  font-size: var(--text-sm);
+  font-weight: var(--site-font-weight-semibold);
+  letter-spacing: -0.005em;
+  text-transform: none;
 }
 
+.site-blog-index__rail section + section {
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--site-border);
+}
+
+/* Inset under the group label, as the nav items are on every other rail. */
 .site-blog-recent,
 .site-blog-tags ul {
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 var(--space-3);
   list-style: none;
 }
 
 .site-blog-recent {
   display: grid;
-  gap: 1.2rem;
+  gap: 1.15rem;
 }
 
 .site-blog-recent li {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .site-blog-recent a {
   color: var(--blog-ink-soft);
-  font-size: 1rem;
-  font-weight: 500;
-  line-height: 1.28;
+  font-size: 0.98rem;
+  font-weight: var(--site-font-weight-medium);
+  line-height: 1.35;
   text-decoration: none;
+  transition: color var(--site-transition-fast);
 }
 
 .site-blog-recent a:hover,
 .site-blog-tags a:hover {
   color: var(--blog-accent);
+  text-decoration: none;
 }
 
 .site-blog-recent time {
@@ -426,13 +399,14 @@ html[data-route-kind='blog'] body,
 
 .site-blog-tags ul {
   display: grid;
-  gap: 0.85rem;
+  gap: 0.75rem;
 }
 
 .site-blog-tags a {
-  color: var(--blog-muted);
-  font-size: 1rem;
+  color: var(--blog-muted-strong);
+  font-size: 0.95rem;
   text-decoration: none;
+  transition: color var(--site-transition-fast);
 }
 
 .site-blog-tags small {
@@ -444,14 +418,15 @@ html[data-route-kind='blog'] body,
   min-height: 24rem;
   padding: 4rem 2rem;
   border: 1px solid var(--blog-border);
-  border-radius: 1.1rem;
+  border-radius: var(--radius-lg);
+  background: var(--site-surface);
   text-align: center;
 }
 
 .site-blog-empty h2 {
   margin: 0;
   font-size: 1.8rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
 }
 
 .site-blog-empty p {
@@ -483,11 +458,11 @@ html[data-route-kind='blog'] body,
   min-height: 2.6rem;
   padding: 0.55rem 0.9rem;
   border: 1px solid var(--blog-border);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-lg);
   background: var(--site-surface);
   color: var(--blog-muted-strong);
   font-size: 0.88rem;
-  font-weight: 600;
+  font-weight: var(--site-font-weight-semibold);
   text-decoration: none;
   transition:
     background 160ms ease,
@@ -506,23 +481,53 @@ html[data-route-kind='blog'] body,
 .site-blog-pagination__status {
   color: var(--blog-muted);
   font-size: 0.78rem;
-  font-weight: 650;
+  font-weight: var(--site-font-weight-semibold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.site-blog-layout--post {
-  padding: 4.25rem 0 5.5rem;
+/* ------------------------------------------------------------------ *
+ * Article — left contents rail, then one LEFT-FLUSH column.
+ *
+ * The column is the article width, not 1fr. Sized to 1fr it would span to
+ * the frame's right edge and the prose inside it would need centring to
+ * avoid a void — and centring is the misalignment this phase exists to
+ * remove: it put the article's first character ~310px right of where docs,
+ * research and community start theirs.
+ * ------------------------------------------------------------------ */
+.site-blog-layout--post .site-blog-layout__inner {
+  position: relative;
+  display: grid;
+  grid-template-columns: var(--rail) minmax(0, var(--blog-prose));
+  justify-content: start;
+  gap: var(--rail-gap);
+  align-items: start;
+  padding: var(--space-8) var(--gutter) 5.5rem;
 }
 
-.site-blog-layout--post .site-blog-layout__inner {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(13rem, 17rem);
-  gap: clamp(3rem, 5vw, 5.5rem);
-  align-items: start;
+/*
+ * Only when there is a rail to divide. A post with no headings gets no TOC
+ * from BlogPostPage, and the divider would otherwise hang beside an empty
+ * column. The article keeps its indent either way so it stays aligned.
+ */
+.site-blog-layout--post .site-blog-layout__inner:has(.site-blog-layout__toc)::before {
+  content: '';
+  position: absolute;
+  top: var(--space-8);
+  bottom: 5.5rem;
+  left: calc(var(--gutter) + var(--rail));
+  width: 1px;
+  background: var(--site-border);
+}
+
+.site-blog-layout--post .site-blog-layout__toc {
+  grid-column: 1;
+  grid-row: 1;
 }
 
 .site-blog-layout--post .site-blog-layout__main {
+  grid-column: 2;
+  grid-row: 1;
   min-width: 0;
 }
 
@@ -534,43 +539,74 @@ html[data-route-kind='blog'] body,
   box-shadow: none;
 }
 
+/*
+ * The section eyebrow, styled as PageHeader's so a post opens like every
+ * other page. It stays a link back to the index; the arrow it used to carry
+ * is what made it read as browser chrome instead of a category label.
+ */
 .site-blog-post__breadcrumb {
   display: inline-block;
-  margin-bottom: 2.5rem;
-  color: var(--blog-muted);
-  font-size: 0.98rem;
+  margin-bottom: var(--space-2);
+  color: var(--site-accent-strong);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--text-xs);
+  font-weight: var(--site-font-weight-semibold);
+  letter-spacing: 0.14em;
   text-decoration: none;
+  text-transform: uppercase;
 }
 
 .site-blog-post__breadcrumb:hover {
-  color: var(--blog-accent);
+  color: var(--site-accent-strong);
+  text-decoration: underline;
+  text-underline-offset: 0.25em;
+}
+
+/*
+ * Spans the column so its rule matches PageHeader's on every other page;
+ * the text inside stays at the prose measure.
+ */
+.site-blog-post__header {
+  max-width: none;
+  margin-bottom: var(--space-8);
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-5);
+  border-bottom: 1px solid var(--site-border);
 }
 
 .site-blog-post__header h1 {
-  max-width: 62rem;
+  max-width: var(--blog-prose);
   margin: 0;
   color: var(--blog-ink);
-  font-size: clamp(2.65rem, 4.6vw, 3.7rem);
-  font-weight: 680;
-  line-height: 1.08;
-  letter-spacing: -0.045em;
+  font-size: clamp(2.1rem, 3.6vw, 2.85rem);
+  font-weight: var(--site-font-weight-semibold);
+  line-height: 1.15;
+  letter-spacing: -0.035em;
   text-wrap: balance;
+}
+
+/* The header spans the column for its rule; the text in it keeps the measure. */
+.site-blog-post__meta,
+.site-blog-post__authors,
+.site-blog-post__tags {
+  max-width: var(--blog-prose);
 }
 
 .site-blog-post__meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.2rem;
-  margin-top: 1.6rem;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
   color: var(--blog-muted);
-  font-size: 1rem;
+  font-size: var(--text-sm);
 }
 
 .site-blog-post__authors {
   display: flex;
   flex-wrap: wrap;
   gap: 1.1rem 2.2rem;
-  margin: 1.45rem 0 0;
+  margin: var(--space-5) 0 0;
   padding: 0;
   color: var(--blog-ink-soft);
   font-size: 1.02rem;
@@ -600,7 +636,7 @@ html[data-route-kind='blog'] body,
 .site-blog-post__author-details a,
 .site-blog-post__author-details span {
   color: var(--blog-ink-soft);
-  font-weight: 620;
+  font-weight: var(--site-font-weight-semibold);
   text-decoration: none;
 }
 
@@ -617,7 +653,7 @@ html[data-route-kind='blog'] body,
   display: flex;
   flex-wrap: wrap;
   gap: 0.85rem;
-  margin: 1.3rem 0 0;
+  margin: var(--space-5) 0 0;
   padding: 0;
   list-style: none;
 }
@@ -633,14 +669,45 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-post__content {
-  max-width: 64rem;
-  margin-top: 3.25rem;
+  max-width: none;
+  margin-top: 0;
   color: var(--blog-ink-soft);
-  font-size: 1.14rem;
-  line-height: 1.66;
+  font-size: 1.1875rem;
+  line-height: 1.75;
 }
 
-.site-blog-post__content > p:first-child {
+/*
+ * Running text stops at the prose measure and is LEFT-flush, so its first
+ * character sits on the same x as a docs paragraph. Never `margin-inline:
+ * auto` here — that is the misalignment this phase removes.
+ */
+.site-blog-post__content > :is(p, ul, ol, blockquote, h2, h3, h4, h5, h6),
+.site-blog-layout--post .markdown > :is(p, ul, ol, blockquote, h2, h3, h4, h5, h6) {
+  max-width: var(--blog-prose);
+  margin-inline: 0;
+}
+
+/*
+ * Media fills the column — the same width as the prose, not wider. MDX wraps
+ * images in <p>, so these need naming explicitly or the rule above would cap
+ * an image's paragraph and leave it narrower than the code block beside it.
+ */
+.site-blog-post__content > :is(pre, table, figure, .theme-code-block, .tabs-container, details),
+.site-blog-post__content > div:has(> table),
+.site-blog-post__content > div:has(> pre),
+.site-blog-post__content > p:has(> img),
+.site-blog-post__content > p:has(> a > img),
+.site-blog-layout--post .markdown > :is(pre, table, figure, .theme-code-block, .tabs-container, details),
+.site-blog-layout--post .markdown > div:has(> table),
+.site-blog-layout--post .markdown > div:has(> pre),
+.site-blog-layout--post .markdown > p:has(> img),
+.site-blog-layout--post .markdown > p:has(> a > img) {
+  max-width: none;
+  width: 100%;
+  margin-inline: 0;
+}
+
+.site-blog-post__content > p:first-of-type {
   font-size: 1.22rem;
 }
 
@@ -650,23 +717,37 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-post__content p {
-  margin: 1.35rem 0;
+  margin-block: 1.35rem;
 }
 
-.site-blog-post__content h2 {
-  margin: 3.6rem 0 1.15rem;
-  font-size: clamp(2rem, 3vw, 2.65rem);
-  font-weight: 650;
-  line-height: 1.12;
-  letter-spacing: -0.035em;
-}
-
-.site-blog-post__content h3 {
-  margin: 2.6rem 0 0.9rem;
-  font-size: 1.55rem;
-  font-weight: 650;
+.site-blog-post__content h2,
+.site-blog-layout--post .markdown > h2 {
+  margin: 3.25rem 0 0.85rem;
+  border-top: 0;
+  padding-top: 0;
+  font-size: clamp(1.55rem, 2.4vw, 1.85rem);
+  font-weight: var(--site-font-weight-semibold);
   line-height: 1.2;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.03em;
+}
+
+.site-blog-post__content h3,
+.site-blog-layout--post .markdown > h3 {
+  margin: 2.4rem 0 0.7rem;
+  border-top: 0;
+  padding-top: 0;
+  font-size: 1.35rem;
+  font-weight: var(--site-font-weight-semibold);
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+}
+
+.site-blog-post__content h4,
+.site-blog-post__content h5,
+.site-blog-post__content h6 {
+  margin: 2rem 0 0.55rem;
+  border-top: 0;
+  padding-top: 0;
 }
 
 .site-blog-post__content a {
@@ -680,7 +761,7 @@ html[data-route-kind='blog'] body,
 }
 
 .site-blog-post__content blockquote {
-  margin: 2rem 0;
+  margin-block: 2rem;
   padding: 0.3rem 0 0.3rem 1.25rem;
   border-left: 3px solid var(--blog-accent);
 }
@@ -691,113 +772,189 @@ html[data-route-kind='blog'] body,
 
 .site-blog-post__content img {
   display: block;
-  margin: 2.4rem auto;
-  border-radius: 0.8rem;
+  width: 100%;
+  height: auto;
+  margin-block: 0.35rem;
+  border-radius: var(--radius-lg);
 }
 
 .site-blog-post__content table {
   font-size: 0.95rem;
 }
 
+/* ------------------------------------------------------------------ *
+ * Contents rail — docs sidebar chrome (filled pill, sentence-case),
+ * with LangChain-level breathing room and clear nested hierarchy.
+ * ------------------------------------------------------------------ */
 .site-blog-layout__toc {
   position: sticky;
-  top: calc(var(--site-header-height) + 2rem);
+  top: calc(var(--site-header-height) + var(--space-5));
   max-height: calc(100vh - var(--site-header-height) - 4rem);
+  overflow-x: hidden;
   overflow-y: auto;
+  padding-right: var(--space-5);
+  scrollbar-width: thin;
+}
+
+/*
+ * Exactly one scroller. Docusaurus's TOC sets its own sticky + max-height +
+ * overflow-y, and on docs that lands on the same element as the theme class,
+ * so there is one. Here BlogLayout wraps it in this aside, which nested a
+ * second scroll container inside the first and drew two scrollbars. The
+ * aside is the one that scrolls; its offsets come from our own tokens,
+ * whereas the inner element's are keyed to --ifm-navbar-height, which is
+ * only redefined on docs pages.
+ */
+.site-blog-layout__toc > [class*='tableOfContents'] {
+  position: static;
+  max-height: none;
+  overflow: visible;
+}
+
+.site-blog-layout__toc::before {
+  content: 'On this page';
+  display: block;
+  padding: 0.15rem var(--space-2) var(--space-2);
+  color: var(--site-text-strong);
+  font-size: var(--text-sm);
+  font-weight: var(--site-font-weight-semibold);
+  letter-spacing: -0.005em;
+  text-transform: none;
+}
+
+.site-blog-layout__toc .table-of-contents,
+.site-blog-layout__toc .table-of-contents ul {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  list-style: none;
 }
 
 .site-blog-layout__toc .table-of-contents {
-  padding: 0;
-  border-left: 0;
+  display: grid;
+  gap: 2px;
 }
 
-.site-blog-layout__toc .table-of-contents ul {
-  padding-left: 1rem;
-  border-left: 1px solid var(--blog-border);
+/* Nesting by indent only — no guide lines. */
+.site-blog-layout__toc .table-of-contents .table-of-contents {
+  margin-top: 2px;
+  margin-bottom: 2px;
+  padding-left: var(--space-3);
 }
 
+/*
+ * Docs sidebar metrics exactly: 12px pill inset + 12px padding puts item text
+ * at 24px against the 8px label, and the pill is 2.1rem tall.
+ */
 .site-blog-layout__toc .table-of-contents__link {
-  display: block;
-  padding: 0.3rem 0;
-  color: var(--blog-muted);
-  font-size: 0.9rem;
-  line-height: 1.35;
+  display: flex;
+  align-items: center;
+  min-height: 2.1rem;
+  margin-left: var(--space-3);
+  padding: 0.42rem var(--space-3);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--site-muted);
+  font-size: var(--text-sm);
+  font-weight: var(--site-font-weight-normal);
+  line-height: 1.4;
+  text-decoration: none;
+  transition:
+    background var(--site-transition-fast),
+    color var(--site-transition-fast);
 }
 
-.site-blog-layout__toc .table-of-contents__link--active,
 .site-blog-layout__toc .table-of-contents__link:hover {
-  color: var(--blog-ink-soft);
-  font-weight: 600;
+  background: var(--site-surface-soft);
+  color: var(--site-text-strong);
+  text-decoration: none;
+}
+
+/* 0,3,0 beats Infima's .table-of-contents__link--active — no !important needed. */
+.site-blog-layout__toc .table-of-contents__link--active,
+.site-blog-layout__toc .table-of-contents__link--active:hover {
+  background: var(--site-accent-soft);
+  color: var(--site-accent-strong);
+  font-weight: var(--site-font-weight-medium);
+}
+
+.site-blog-layout__toc .table-of-contents__link:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
 }
 
 .site-blog-layout--post .pagination-nav {
   gap: 1rem;
-  margin-top: 4rem;
+  max-width: var(--blog-prose);
+  margin: 4rem 0 0;
 }
 
 @media (max-width: 1100px) {
-  .site-blog-index__header {
-    grid-template-columns: minmax(0, 1fr) minmax(20rem, 28rem);
-  }
-
-  .site-blog-index__columns {
-    grid-template-columns: minmax(0, 1fr) 15rem;
-    gap: 2rem;
-  }
-
   .site-blog-card--featured {
     grid-template-columns: minmax(17rem, 42%) minmax(0, 1fr);
   }
 }
 
 @media (max-width: 996px) {
-  .site-blog-layout--listing,
-  .site-blog-layout--post {
-    padding-top: 3rem;
+  .site-blog-layout--listing .site-blog-layout__inner,
+  .site-blog-layout--post .site-blog-layout__inner {
+    padding-top: var(--space-6);
   }
 
-  .site-blog-index__header,
   .site-blog-index__columns,
   .site-blog-layout--post .site-blog-layout__inner {
     grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-5);
   }
 
-  .site-blog-index__header {
-    grid-template-areas:
-      'title'
-      'description'
-      'search';
-    gap: 1.6rem;
+  /* Matches the :has() form above, which would otherwise out-specify this. */
+  .site-blog-index__columns::before,
+  .site-blog-layout--post .site-blog-layout__inner:has(.site-blog-layout__toc)::before {
+    display: none;
   }
 
-  .site-blog-index__columns {
-    gap: 3rem;
+  .site-blog-layout--post .site-blog-layout__toc,
+  .site-blog-layout--post .site-blog-layout__main {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .site-blog-index__rail {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-5);
+    order: 2;
+    padding-right: 0;
+  }
+
+  .site-blog-index__feed {
+    order: 1;
+  }
+
+  .site-blog-index__rail section + section {
+    padding-top: 0;
+    border-top: 0;
   }
 
   .site-blog-index__rail,
   .site-blog-layout__toc {
     position: static;
-  }
-
-  .site-blog-index__rail {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    padding-top: 2.5rem;
-    border-top: 1px solid var(--blog-border);
+    max-height: none;
+    overflow: visible;
   }
 
   .site-blog-layout__toc {
     display: none;
   }
+
+  .site-blog-card-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 @media (max-width: 720px) {
-  .site-blog-index__header p {
-    font-size: 0.9rem;
-    white-space: normal;
-  }
-
   .site-blog-card--featured,
-  .site-blog-card-grid,
   .site-blog-index__rail {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -817,7 +974,8 @@ html[data-route-kind='blog'] body,
 
   .site-blog-card--featured .site-blog-card__image {
     height: 100%;
-    padding: 1rem;
+    max-height: none;
+    padding: 0.75rem;
   }
 
   .site-blog-card--featured .site-blog-card__body {
@@ -864,16 +1022,11 @@ html[data-route-kind='blog'] body,
     grid-row: 2;
   }
 
-  .site-blog-post__breadcrumb {
-    margin-bottom: 1.7rem;
-  }
-
   .site-blog-post__header h1 {
-    font-size: clamp(2.2rem, 10vw, 3rem);
+    font-size: clamp(1.85rem, 9vw, 2.4rem);
   }
 
   .site-blog-post__content {
-    margin-top: 2.5rem;
-    font-size: 1.04rem;
+    font-size: 1.05rem;
   }
 }

--- a/website/src/css/docs.css
+++ b/website/src/css/docs.css
@@ -7,7 +7,15 @@
   /* Rail to content is shared with research and community; the TOC gap is
    * ours alone, and ramps from --space-6 at ~1220px to its cap at 1920px. */
   --site-doc-content-inset: var(--rail-gap);
-  --site-doc-column-gap: clamp(var(--space-6), calc(14.06vw - 140px), 8.125rem);
+  /* Caps at 1680px with --rail-gap; 110 + 130 = the row's 240px of slack. */
+  --site-doc-column-gap: clamp(var(--space-6), calc(16.9vw - 153.9px), 8.125rem);
+  /*
+   * The content track, in rem. --measure is 72ch, but `ch` resolves against
+   * the element that consumes it: on the grid container that is the 16px
+   * root, not the 18px body text inside, which would size the column to 64
+   * characters of prose. 46rem is 72ch at --site-doc-body-size.
+   */
+  --site-doc-measure: 46rem;
   --site-doc-rail-top: 2.5rem;
   --site-doc-sidebar-top: 2rem;
   --site-doc-body-size: var(--text-lg);
@@ -258,19 +266,16 @@
   line-height: 1.7;
 }
 
-/* Fluid column, fixed measure: running text stops at --measure, wide elements break out. */
-.theme-doc-markdown > :is(p, ul, ol, blockquote, h1, h2, h3, h4, h5, h6),
-.theme-doc-markdown > .theme-admonition,
-.theme-doc-markdown > header {
-  max-width: var(--measure);
-}
-
+/*
+ * The measure lives on the grid track, not here. Capping running text a
+ * second time only re-opens the gap between prose and the tables beside it
+ * in the 997-1279px range, where the track is 1fr because the TOC is hidden.
+ */
 .theme-doc-markdown > h2 > span,
 .theme-doc-markdown > h2 {
   text-wrap: balance;
 }
 
-/* Wide elements break out of measure. */
 .theme-doc-markdown > :is(pre, table, img, figure, .tabs-container, details),
 .theme-doc-markdown > div:has(> table),
 .theme-doc-markdown > div:has(> pre) {
@@ -691,9 +696,16 @@ html[data-theme='dark'] .theme-doc-toc-desktop::before {
     padding: 0 0 0 var(--site-doc-content-inset);
   }
 
+  /*
+   * The content track IS the measure, not 1fr. Sized to 1fr it took every
+   * pixel the rails left over while running text stopped at the measure, so
+   * prose and the tables beside it ended on two different right edges.
+   * The gap stays fixed: pushing the leftover width into it instead only
+   * moves the hole from the right margin to the middle of the page.
+   */
   .site-docs-shell > .row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) var(--site-doc-toc-width);
+    grid-template-columns: minmax(0, var(--site-doc-measure)) var(--site-doc-toc-width);
     gap: var(--site-doc-column-gap);
     margin: 0;
   }

--- a/website/src/css/docs.css
+++ b/website/src/css/docs.css
@@ -9,12 +9,8 @@
   --site-doc-content-inset: var(--rail-gap);
   /* Caps at 1680px with --rail-gap; 110 + 130 = the row's 240px of slack. */
   --site-doc-column-gap: clamp(var(--space-6), calc(16.9vw - 153.9px), 8.125rem);
-  /*
-   * The content track, in rem. --measure is 72ch, but `ch` resolves against
-   * the element that consumes it: on the grid container that is the 16px
-   * root, not the 18px body text inside, which would size the column to 64
-   * characters of prose. 46rem is 72ch at --site-doc-body-size.
-   */
+  /* Not var(--measure): 72ch resolves against the grid container's 16px, not
+   * the 18px body text inside it. 46rem is 72ch at --site-doc-body-size. */
   --site-doc-measure: 46rem;
   --site-doc-rail-top: 2.5rem;
   --site-doc-sidebar-top: 2rem;
@@ -266,11 +262,8 @@
   line-height: 1.7;
 }
 
-/*
- * The measure lives on the grid track, not here. Capping running text a
- * second time only re-opens the gap between prose and the tables beside it
- * in the 997-1279px range, where the track is 1fr because the TOC is hidden.
- */
+/* No measure cap here — it is on the grid track. Capping twice re-opens the
+ * prose/table edge mismatch at 997-1279px, where the track is 1fr. */
 .theme-doc-markdown > h2 > span,
 .theme-doc-markdown > h2 {
   text-wrap: balance;
@@ -696,13 +689,8 @@ html[data-theme='dark'] .theme-doc-toc-desktop::before {
     padding: 0 0 0 var(--site-doc-content-inset);
   }
 
-  /*
-   * The content track IS the measure, not 1fr. Sized to 1fr it took every
-   * pixel the rails left over while running text stopped at the measure, so
-   * prose and the tables beside it ended on two different right edges.
-   * The gap stays fixed: pushing the leftover width into it instead only
-   * moves the hole from the right margin to the middle of the page.
-   */
+  /* Track IS the measure: at 1fr it took the rails' leftover while prose
+   * stopped at the measure, so prose and tables ended on different edges. */
   .site-docs-shell > .row {
     display: grid;
     grid-template-columns: minmax(0, var(--site-doc-measure)) var(--site-doc-toc-width);

--- a/website/src/css/tokens.css
+++ b/website/src/css/tokens.css
@@ -83,27 +83,16 @@
   --tech-primary-blue: var(--site-accent-strong);
   --tech-accent-purple: var(--site-accent-violet);
   --tech-shadow: var(--site-shadow-soft);
-  /*
-   * Page geometry: --page-max for shell, --measure for readable text.
-   *
-   * 1536px is not a round number, it is the sum of what the docs page holds:
-   * rail 288 + rail-gap 110 + measure 736 + column-gap 130 + toc 272. At the
-   * earlier 1760px the frame was 224px wider than its own columns could
-   * fill, and that surplus had nowhere to go but a void past the TOC.
-   */
+  /* Page geometry. 1536 = rail 288 + rail-gap 110 + measure 736 +
+   * column-gap 130 + toc 272, so the docs row fills the frame exactly. */
   --page-max: 1536px;
   --gutter: clamp(1rem, 5vw, 4.5rem);
   --measure: 72ch;
   /* Rail width: 18rem (20rem too wide for label list). */
   --rail: 18rem;
   --toc: 17rem;
-  /*
-   * Rail to content. Shared so docs, research and community start their text
-   * on the same x. Caps at 1680px — where the gutter maxes out and the frame
-   * stops growing — so that from there up this gap plus --site-doc-column-gap
-   * sum to exactly the 240px the docs row has spare. Below 1680 the content
-   * track absorbs the difference instead, so no void opens at any width.
-   */
+  /* Rail to content, shared so every page starts its text on the same x.
+   * Caps at 1680px, where the frame stops growing. */
   --rail-gap: clamp(var(--space-6), calc(13.45vw - 115.9px), 6.875rem);
 
   /* Legacy aliases repointed to shared geometry. --site-content-max removed. */

--- a/website/src/css/tokens.css
+++ b/website/src/css/tokens.css
@@ -83,16 +83,28 @@
   --tech-primary-blue: var(--site-accent-strong);
   --tech-accent-purple: var(--site-accent-violet);
   --tech-shadow: var(--site-shadow-soft);
-  /* Page geometry: --page-max for shell, --measure for readable text. */
-  --page-max: 1760px;
+  /*
+   * Page geometry: --page-max for shell, --measure for readable text.
+   *
+   * 1536px is not a round number, it is the sum of what the docs page holds:
+   * rail 288 + rail-gap 110 + measure 736 + column-gap 130 + toc 272. At the
+   * earlier 1760px the frame was 224px wider than its own columns could
+   * fill, and that surplus had nowhere to go but a void past the TOC.
+   */
+  --page-max: 1536px;
   --gutter: clamp(1rem, 5vw, 4.5rem);
   --measure: 72ch;
   /* Rail width: 18rem (20rem too wide for label list). */
   --rail: 18rem;
   --toc: 17rem;
-  /* Rail to content. Shared so docs, research and community start their text
-   * on the same x; ramps to its cap at 1920px, where the frame stops growing. */
-  --rail-gap: clamp(var(--space-6), calc(12.19vw - 124px), 6.875rem);
+  /*
+   * Rail to content. Shared so docs, research and community start their text
+   * on the same x. Caps at 1680px — where the gutter maxes out and the frame
+   * stops growing — so that from there up this gap plus --site-doc-column-gap
+   * sum to exactly the 240px the docs row has spare. Below 1680 the content
+   * track absorbs the difference instead, so no void opens at any width.
+   */
+  --rail-gap: clamp(var(--space-6), calc(13.45vw - 115.9px), 6.875rem);
 
   /* Legacy aliases repointed to shared geometry. --site-content-max removed. */
   --site-grid-max: var(--page-max);

--- a/website/src/data/committerActivity.generated.ts
+++ b/website/src/data/committerActivity.generated.ts
@@ -45,10 +45,10 @@ export const committerActivityEntries: CommitterActivityEntry[] = [
   {
     "name": "yangw",
     "login": "drivebyer",
-    "pullRequests": 22,
+    "pullRequests": 23,
     "reviews": 52,
     "issues": 18,
-    "total": 92,
+    "total": 93,
     "status": "active"
   },
   {
@@ -91,9 +91,9 @@ export const committerActivityEntries: CommitterActivityEntry[] = [
     "name": "Wilson Wu",
     "login": "wilsonwu",
     "pullRequests": 43,
-    "reviews": 6,
+    "reviews": 7,
     "issues": 29,
-    "total": 78,
+    "total": 79,
     "status": "active"
   },
   {

--- a/website/src/data/contributorRank.generated.ts
+++ b/website/src/data/contributorRank.generated.ts
@@ -953,8 +953,8 @@ export const contributorRankData = {
     "startDate": "2026-06-05",
     "endDate": "2026-08-25",
     "description": "Current non-merge commit activity after v0.3.0.",
-    "totalCommits": 356,
-    "totalReviews": 380,
+    "totalCommits": 359,
+    "totalReviews": 383,
     "totalContributors": 55,
     "newContributors": 35,
     "entries": [
@@ -968,7 +968,7 @@ export const contributorRankData = {
         "key": "github:theohsiung",
         "commits": 72,
         "reviews": 10,
-        "share": 0.2022,
+        "share": 0.2006,
         "firstCommitDate": "2026-06-05",
         "latestCommitDate": "2026-08-20",
         "isNewContributorSinceRelease": false
@@ -981,9 +981,9 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/48784001?v=4",
         "avatarSeed": "xunzhuo",
         "key": "github:xunzhuo",
-        "commits": 43,
-        "reviews": 82,
-        "share": 0.1208,
+        "commits": 44,
+        "reviews": 83,
+        "share": 0.1226,
         "firstCommitDate": "2026-06-09",
         "latestCommitDate": "2026-08-25",
         "isNewContributorSinceRelease": false
@@ -998,7 +998,7 @@ export const contributorRankData = {
         "key": "github:wukuntai-0211",
         "commits": 40,
         "reviews": 24,
-        "share": 0.1124,
+        "share": 0.1114,
         "firstCommitDate": "2026-06-08",
         "latestCommitDate": "2026-08-18",
         "isNewContributorSinceRelease": false
@@ -1013,7 +1013,7 @@ export const contributorRankData = {
         "key": "github:wilsonwu",
         "commits": 34,
         "reviews": 5,
-        "share": 0.0955,
+        "share": 0.0947,
         "firstCommitDate": "2026-06-09",
         "latestCommitDate": "2026-08-19",
         "isNewContributorSinceRelease": false
@@ -1028,7 +1028,7 @@ export const contributorRankData = {
         "key": "github:drivebyer",
         "commits": 20,
         "reviews": 45,
-        "share": 0.0562,
+        "share": 0.0557,
         "firstCommitDate": "2026-06-17",
         "latestCommitDate": "2026-08-25",
         "isNewContributorSinceRelease": false
@@ -1042,8 +1042,8 @@ export const contributorRankData = {
         "avatarSeed": "aayushsaini101",
         "key": "github:aayushsaini101",
         "commits": 18,
-        "reviews": 119,
-        "share": 0.0506,
+        "reviews": 120,
+        "share": 0.0501,
         "firstCommitDate": "2026-06-28",
         "latestCommitDate": "2026-08-05",
         "isNewContributorSinceRelease": false
@@ -1058,13 +1058,28 @@ export const contributorRankData = {
         "key": "github:twilighttechie",
         "commits": 14,
         "reviews": 5,
-        "share": 0.0393,
+        "share": 0.039,
         "firstCommitDate": "2026-06-30",
         "latestCommitDate": "2026-07-29",
         "isNewContributorSinceRelease": true
       },
       {
         "rank": 8,
+        "name": "Abhinav Mahajan",
+        "login": "abhinav-m22",
+        "avatarLogin": "abhinav-m22",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/113239388?v=4",
+        "avatarSeed": "abhinav-m22",
+        "key": "github:abhinav-m22",
+        "commits": 12,
+        "reviews": 1,
+        "share": 0.0334,
+        "firstCommitDate": "2026-08-06",
+        "latestCommitDate": "2026-08-25",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 9,
         "name": "Yincheng Ren",
         "login": "Peterren",
         "avatarLogin": "Peterren",
@@ -1073,13 +1088,13 @@ export const contributorRankData = {
         "key": "github:peterren",
         "commits": 11,
         "reviews": 1,
-        "share": 0.0309,
+        "share": 0.0306,
         "firstCommitDate": "2026-06-10",
         "latestCommitDate": "2026-07-21",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 9,
+        "rank": 10,
         "name": "FAUST",
         "login": "FAUST-BENCHOU",
         "avatarLogin": "FAUST-BENCHOU",
@@ -1088,13 +1103,13 @@ export const contributorRankData = {
         "key": "github:faust-benchou",
         "commits": 10,
         "reviews": 48,
-        "share": 0.0281,
+        "share": 0.0279,
         "firstCommitDate": "2026-06-06",
         "latestCommitDate": "2026-07-22",
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 10,
+        "rank": 11,
         "name": "David Shrader",
         "login": "shraderdm",
         "avatarLogin": "shraderdm",
@@ -1103,25 +1118,10 @@ export const contributorRankData = {
         "key": "github:shraderdm",
         "commits": 10,
         "reviews": 5,
-        "share": 0.0281,
+        "share": 0.0279,
         "firstCommitDate": "2026-06-05",
         "latestCommitDate": "2026-07-16",
         "isNewContributorSinceRelease": false
-      },
-      {
-        "rank": 11,
-        "name": "Abhinav Mahajan",
-        "login": "abhinav-m22",
-        "avatarLogin": "abhinav-m22",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/113239388?v=4",
-        "avatarSeed": "abhinav-m22",
-        "key": "github:abhinav-m22",
-        "commits": 10,
-        "reviews": 1,
-        "share": 0.0281,
-        "firstCommitDate": "2026-08-06",
-        "latestCommitDate": "2026-08-25",
-        "isNewContributorSinceRelease": true
       },
       {
         "rank": 12,
@@ -1133,7 +1133,7 @@ export const contributorRankData = {
         "key": "github:haowu1234",
         "commits": 9,
         "reviews": 10,
-        "share": 0.0253,
+        "share": 0.0251,
         "firstCommitDate": "2026-07-02",
         "latestCommitDate": "2026-07-13",
         "isNewContributorSinceRelease": false
@@ -1148,7 +1148,7 @@ export const contributorRankData = {
         "key": "github:iroiro147",
         "commits": 4,
         "reviews": 0,
-        "share": 0.0112,
+        "share": 0.0111,
         "firstCommitDate": "2026-07-14",
         "latestCommitDate": "2026-08-22",
         "isNewContributorSinceRelease": true
@@ -1410,6 +1410,21 @@ export const contributorRankData = {
       },
       {
         "rank": 31,
+        "name": "raghavchitkara",
+        "login": "raghavchitkara36",
+        "avatarLogin": "raghavchitkara36",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/42761820?v=4",
+        "avatarSeed": "raghavchitkara36",
+        "key": "github:raghavchitkara36",
+        "commits": 1,
+        "reviews": 1,
+        "share": 0.0028,
+        "firstCommitDate": "2026-07-27",
+        "latestCommitDate": "2026-07-27",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 32,
         "name": "siloteemu",
         "login": "siloteemu",
         "avatarLogin": "siloteemu",
@@ -1424,7 +1439,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 32,
+        "rank": 33,
         "name": "Zubiao Xiong",
         "login": "xiongzubiao",
         "avatarLogin": "xiongzubiao",
@@ -1439,7 +1454,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 33,
+        "rank": 34,
         "name": "Aakanksha Bhende",
         "login": "aakankshabhende",
         "avatarLogin": "aakankshabhende",
@@ -1454,7 +1469,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 34,
+        "rank": 35,
         "name": "Akshay Viswanathan",
         "login": "akshayv",
         "avatarLogin": "akshayv",
@@ -1469,7 +1484,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": false
       },
       {
-        "rank": 35,
+        "rank": 36,
         "name": "Amir Fathi",
         "login": "AmirF194",
         "avatarLogin": "AmirF194",
@@ -1484,7 +1499,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 36,
+        "rank": 37,
         "name": "Arijit Kumar Roy",
         "login": "arijitroy003",
         "avatarLogin": "arijitroy003",
@@ -1499,7 +1514,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 37,
+        "rank": 38,
         "name": "Benhur Stephen",
         "login": "benhurstephen",
         "avatarLogin": "benhurstephen",
@@ -1514,7 +1529,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 38,
+        "rank": 39,
         "name": "ChethanUK",
         "login": "chethanuk",
         "avatarLogin": "chethanuk",
@@ -1529,7 +1544,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 39,
+        "rank": 40,
         "name": "csarushan1729",
         "login": "csarushan1729",
         "avatarLogin": "csarushan1729",
@@ -1544,7 +1559,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 40,
+        "rank": 41,
         "name": "Hanzhong Liu",
         "login": "muchengl",
         "avatarLogin": "muchengl",
@@ -1559,7 +1574,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 41,
+        "rank": 42,
         "name": "Haritha",
         "login": "haritha3320",
         "avatarLogin": "haritha3320",
@@ -1574,7 +1589,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 42,
+        "rank": 43,
         "name": "MilindRastogi24",
         "login": "MilindRastogi24",
         "avatarLogin": "MilindRastogi24",
@@ -1589,7 +1604,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 43,
+        "rank": 44,
         "name": "Morax",
         "login": "fzlzjerry",
         "avatarLogin": "fzlzjerry",
@@ -1604,7 +1619,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 44,
+        "rank": 45,
         "name": "Nandi Vardhan Reddy",
         "login": "nandi19k",
         "avatarLogin": "nandi19k",
@@ -1619,7 +1634,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 45,
+        "rank": 46,
         "name": "Omkar Kabde",
         "login": "omkar-334",
         "avatarLogin": "omkar-334",
@@ -1634,7 +1649,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 46,
+        "rank": 47,
         "name": "Polly Labs",
         "login": "pollychen-lab",
         "avatarLogin": "pollychen-lab",
@@ -1646,21 +1661,6 @@ export const contributorRankData = {
         "share": 0.0028,
         "firstCommitDate": "2026-07-19",
         "latestCommitDate": "2026-07-19",
-        "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 47,
-        "name": "raghavchitkara",
-        "login": "raghavchitkara36",
-        "avatarLogin": "raghavchitkara36",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/42761820?v=4",
-        "avatarSeed": "raghavchitkara36",
-        "key": "github:raghavchitkara36",
-        "commits": 1,
-        "reviews": 0,
-        "share": 0.0028,
-        "firstCommitDate": "2026-07-27",
-        "latestCommitDate": "2026-07-27",
         "isNewContributorSinceRelease": true
       },
       {
@@ -3526,7 +3526,7 @@ export const contributorRankData = {
     "startDate": null,
     "endDate": "2026-01-05",
     "description": "Initial non-merge commit activity through v0.1.0.",
-    "totalCommits": 706,
+    "totalCommits": 705,
     "totalReviews": 580,
     "totalContributors": 53,
     "newContributors": 51,
@@ -3541,7 +3541,7 @@ export const contributorRankData = {
         "key": "github:xunzhuo",
         "commits": 167,
         "reviews": 130,
-        "share": 0.2365,
+        "share": 0.2369,
         "firstCommitDate": "2025-06-16",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3556,7 +3556,7 @@ export const contributorRankData = {
         "key": "github:rootfs",
         "commits": 149,
         "reviews": 253,
-        "share": 0.211,
+        "share": 0.2113,
         "firstCommitDate": "2025-04-15",
         "latestCommitDate": "2025-12-16",
         "isNewContributorSinceRelease": true
@@ -3571,7 +3571,7 @@ export const contributorRankData = {
         "key": "github:yuluo-yx",
         "commits": 53,
         "reviews": 53,
-        "share": 0.0751,
+        "share": 0.0752,
         "firstCommitDate": "2025-09-06",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3586,7 +3586,7 @@ export const contributorRankData = {
         "key": "github:samzong",
         "commits": 42,
         "reviews": 22,
-        "share": 0.0595,
+        "share": 0.0596,
         "firstCommitDate": "2025-09-16",
         "latestCommitDate": "2026-01-04",
         "isNewContributorSinceRelease": true
@@ -3601,7 +3601,7 @@ export const contributorRankData = {
         "key": "github:yossiovadia",
         "commits": 41,
         "reviews": 3,
-        "share": 0.0581,
+        "share": 0.0582,
         "firstCommitDate": "2025-05-20",
         "latestCommitDate": "2025-12-12",
         "isNewContributorSinceRelease": true
@@ -3616,7 +3616,7 @@ export const contributorRankData = {
         "key": "github:jaredforreal",
         "commits": 31,
         "reviews": 41,
-        "share": 0.0439,
+        "share": 0.044,
         "firstCommitDate": "2025-09-15",
         "latestCommitDate": "2025-12-16",
         "isNewContributorSinceRelease": true
@@ -3646,7 +3646,7 @@ export const contributorRankData = {
         "key": "github:tao12345666333",
         "commits": 25,
         "reviews": 17,
-        "share": 0.0354,
+        "share": 0.0355,
         "firstCommitDate": "2025-09-01",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3659,9 +3659,9 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/19606201?v=4",
         "avatarSeed": "onezero-y",
         "key": "github:onezero-y",
-        "commits": 18,
+        "commits": 17,
         "reviews": 8,
-        "share": 0.0255,
+        "share": 0.0241,
         "firstCommitDate": "2025-09-02",
         "latestCommitDate": "2025-11-08",
         "isNewContributorSinceRelease": true
@@ -3886,7 +3886,7 @@ export const contributorRankData = {
         "key": "github:nerdalert",
         "commits": 3,
         "reviews": 1,
-        "share": 0.0042,
+        "share": 0.0043,
         "firstCommitDate": "2026-01-04",
         "latestCommitDate": "2026-01-05",
         "isNewContributorSinceRelease": true
@@ -3901,7 +3901,7 @@ export const contributorRankData = {
         "key": "github:wilsonwu",
         "commits": 3,
         "reviews": 0,
-        "share": 0.0042,
+        "share": 0.0043,
         "firstCommitDate": "2025-12-09",
         "latestCommitDate": "2025-12-23",
         "isNewContributorSinceRelease": true
@@ -4335,8 +4335,8 @@ export const contributorRankData = {
     "startDate": null,
     "endDate": "2026-08-25",
     "description": "Full repository non-merge commit history.",
-    "totalCommits": 1716,
-    "totalReviews": 1468,
+    "totalCommits": 1718,
+    "totalReviews": 1471,
     "totalContributors": 162,
     "newContributors": 155,
     "entries": [
@@ -4348,9 +4348,9 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/48784001?v=4",
         "avatarSeed": "xunzhuo",
         "key": "github:xunzhuo",
-        "commits": 395,
-        "reviews": 412,
-        "share": 0.2302,
+        "commits": 396,
+        "reviews": 413,
+        "share": 0.2305,
         "firstCommitDate": "2025-06-16",
         "latestCommitDate": "2026-08-25",
         "isNewContributorSinceRelease": true
@@ -4365,7 +4365,7 @@ export const contributorRankData = {
         "key": "github:rootfs",
         "commits": 206,
         "reviews": 441,
-        "share": 0.12,
+        "share": 0.1199,
         "firstCommitDate": "2025-04-15",
         "latestCommitDate": "2026-06-07",
         "isNewContributorSinceRelease": true
@@ -4380,7 +4380,7 @@ export const contributorRankData = {
         "key": "github:theohsiung",
         "commits": 76,
         "reviews": 11,
-        "share": 0.0443,
+        "share": 0.0442,
         "firstCommitDate": "2026-05-29",
         "latestCommitDate": "2026-08-20",
         "isNewContributorSinceRelease": true
@@ -4410,7 +4410,7 @@ export const contributorRankData = {
         "key": "github:yuluo-yx",
         "commits": 55,
         "reviews": 58,
-        "share": 0.0321,
+        "share": 0.032,
         "firstCommitDate": "2025-09-06",
         "latestCommitDate": "2026-01-28",
         "isNewContributorSinceRelease": true
@@ -4455,7 +4455,7 @@ export const contributorRankData = {
         "key": "github:faust-benchou",
         "commits": 43,
         "reviews": 55,
-        "share": 0.0251,
+        "share": 0.025,
         "firstCommitDate": "2026-03-26",
         "latestCommitDate": "2026-07-22",
         "isNewContributorSinceRelease": true
@@ -4470,7 +4470,7 @@ export const contributorRankData = {
         "key": "github:cryo-zd",
         "commits": 43,
         "reviews": 8,
-        "share": 0.0251,
+        "share": 0.025,
         "firstCommitDate": "2025-09-01",
         "latestCommitDate": "2026-06-23",
         "isNewContributorSinceRelease": true
@@ -4485,7 +4485,7 @@ export const contributorRankData = {
         "key": "github:wilsonwu",
         "commits": 42,
         "reviews": 5,
-        "share": 0.0245,
+        "share": 0.0244,
         "firstCommitDate": "2025-12-09",
         "latestCommitDate": "2026-08-19",
         "isNewContributorSinceRelease": true
@@ -4515,7 +4515,7 @@ export const contributorRankData = {
         "key": "github:jaredforreal",
         "commits": 31,
         "reviews": 41,
-        "share": 0.0181,
+        "share": 0.018,
         "firstCommitDate": "2025-09-15",
         "latestCommitDate": "2025-12-16",
         "isNewContributorSinceRelease": true
@@ -4589,8 +4589,8 @@ export const contributorRankData = {
         "avatarSeed": "aayushsaini101",
         "key": "github:aayushsaini101",
         "commits": 26,
-        "reviews": 119,
-        "share": 0.0152,
+        "reviews": 120,
+        "share": 0.0151,
         "firstCommitDate": "2026-04-17",
         "latestCommitDate": "2026-08-05",
         "isNewContributorSinceRelease": true
@@ -4663,9 +4663,9 @@ export const contributorRankData = {
         "avatarUrl": "https://avatars.githubusercontent.com/u/19606201?v=4",
         "avatarSeed": "onezero-y",
         "key": "github:onezero-y",
-        "commits": 18,
+        "commits": 17,
         "reviews": 8,
-        "share": 0.0105,
+        "share": 0.0099,
         "firstCommitDate": "2025-09-02",
         "latestCommitDate": "2025-11-08",
         "isNewContributorSinceRelease": true
@@ -4710,13 +4710,28 @@ export const contributorRankData = {
         "key": "github:twilighttechie",
         "commits": 14,
         "reviews": 5,
-        "share": 0.0082,
+        "share": 0.0081,
         "firstCommitDate": "2026-06-30",
         "latestCommitDate": "2026-07-29",
         "isNewContributorSinceRelease": true
       },
       {
         "rank": 26,
+        "name": "Abhinav Mahajan",
+        "login": "abhinav-m22",
+        "avatarLogin": "abhinav-m22",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/113239388?v=4",
+        "avatarSeed": "abhinav-m22",
+        "key": "github:abhinav-m22",
+        "commits": 12,
+        "reviews": 1,
+        "share": 0.007,
+        "firstCommitDate": "2026-08-06",
+        "latestCommitDate": "2026-08-25",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 27,
         "name": "Yue Zhu",
         "login": "yuezhu1",
         "avatarLogin": "yuezhu1",
@@ -4731,7 +4746,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 27,
+        "rank": 28,
         "name": "杨朱 · Kiki",
         "login": "carlory",
         "avatarLogin": "carlory",
@@ -4746,7 +4761,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 28,
+        "rank": 29,
         "name": "henschwartz",
         "login": "henschwartz",
         "avatarLogin": "henschwartz",
@@ -4761,7 +4776,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 29,
+        "rank": 30,
         "name": "Alex Wang",
         "login": "aeft",
         "avatarLogin": "aeft",
@@ -4773,21 +4788,6 @@ export const contributorRankData = {
         "share": 0.0058,
         "firstCommitDate": "2025-09-05",
         "latestCommitDate": "2025-09-18",
-        "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 30,
-        "name": "Abhinav Mahajan",
-        "login": "abhinav-m22",
-        "avatarLogin": "abhinav-m22",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/113239388?v=4",
-        "avatarSeed": "abhinav-m22",
-        "key": "github:abhinav-m22",
-        "commits": 10,
-        "reviews": 1,
-        "share": 0.0058,
-        "firstCommitDate": "2026-08-06",
-        "latestCommitDate": "2026-08-25",
         "isNewContributorSinceRelease": true
       },
       {
@@ -5737,6 +5737,21 @@ export const contributorRankData = {
       },
       {
         "rank": 94,
+        "name": "raghavchitkara",
+        "login": "raghavchitkara36",
+        "avatarLogin": "raghavchitkara36",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/42761820?v=4",
+        "avatarSeed": "raghavchitkara36",
+        "key": "github:raghavchitkara36",
+        "commits": 1,
+        "reviews": 1,
+        "share": 0.0006,
+        "firstCommitDate": "2026-07-27",
+        "latestCommitDate": "2026-07-27",
+        "isNewContributorSinceRelease": true
+      },
+      {
+        "rank": 95,
         "name": "Zubiao Xiong",
         "login": "xiongzubiao",
         "avatarLogin": "xiongzubiao",
@@ -5751,7 +5766,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 95,
+        "rank": 96,
         "name": "Aakanksha Bhende",
         "login": "aakankshabhende",
         "avatarLogin": "aakankshabhende",
@@ -5766,7 +5781,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 96,
+        "rank": 97,
         "name": "aby",
         "avatarSeed": "chenzw0521@gmail.com",
         "key": "email:chenzw0521@gmail.com",
@@ -5778,7 +5793,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 97,
+        "rank": 98,
         "name": "aby",
         "login": "aby42",
         "avatarLogin": "aby42",
@@ -5792,7 +5807,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 98,
+        "rank": 99,
         "name": "AkisAya",
         "login": "AkisAya",
         "avatarLogin": "AkisAya",
@@ -5807,7 +5822,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 99,
+        "rank": 100,
         "name": "Amir Fathi",
         "login": "AmirF194",
         "avatarLogin": "AmirF194",
@@ -5822,7 +5837,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 100,
+        "rank": 101,
         "name": "Anna Tao",
         "login": "atao2004",
         "avatarLogin": "atao2004",
@@ -5837,7 +5852,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 101,
+        "rank": 102,
         "name": "Anusha Pant",
         "login": "anushapant",
         "avatarLogin": "anushapant",
@@ -5852,7 +5867,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 102,
+        "rank": 103,
         "name": "Arijit Kumar Roy",
         "login": "arijitroy003",
         "avatarLogin": "arijitroy003",
@@ -5867,7 +5882,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 103,
+        "rank": 104,
         "name": "Augustinas Malinauskas",
         "login": "gluonfield",
         "avatarLogin": "gluonfield",
@@ -5882,7 +5897,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 104,
+        "rank": 105,
         "name": "Benhur Stephen",
         "login": "benhurstephen",
         "avatarLogin": "benhurstephen",
@@ -5897,7 +5912,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 105,
+        "rank": 106,
         "name": "Chenglong.li",
         "login": "JackLCL",
         "avatarLogin": "JackLCL",
@@ -5912,7 +5927,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 106,
+        "rank": 107,
         "name": "ChethanUK",
         "login": "chethanuk",
         "avatarLogin": "chethanuk",
@@ -5927,7 +5942,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 107,
+        "rank": 108,
         "name": "Chever John",
         "login": "Chever-John",
         "avatarLogin": "Chever-John",
@@ -5942,7 +5957,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 108,
+        "rank": 109,
         "name": "Chujun Tao",
         "login": "AmyTao",
         "avatarLogin": "AmyTao",
@@ -5957,7 +5972,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 109,
+        "rank": 110,
         "name": "csarushan1729",
         "login": "csarushan1729",
         "avatarLogin": "csarushan1729",
@@ -5972,7 +5987,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 110,
+        "rank": 111,
         "name": "Deepak singh",
         "login": "Deepak8858",
         "avatarLogin": "Deepak8858",
@@ -5987,7 +6002,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 111,
+        "rank": 112,
         "name": "Dobri Danchev",
         "login": "danchev",
         "avatarLogin": "danchev",
@@ -6002,7 +6017,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 112,
+        "rank": 113,
         "name": "EmonLu",
         "login": "EmonLu",
         "avatarLogin": "EmonLu",
@@ -6017,7 +6032,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 113,
+        "rank": 114,
         "name": "Fahim Ahmed",
         "login": "fahimahmedx",
         "avatarLogin": "fahimahmedx",
@@ -6032,7 +6047,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 114,
+        "rank": 115,
         "name": "FeiDa",
         "login": "ABC12345anouys",
         "avatarLogin": "ABC12345anouys",
@@ -6047,7 +6062,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 115,
+        "rank": 116,
         "name": "Feng",
         "login": "niuguy",
         "avatarLogin": "niuguy",
@@ -6062,7 +6077,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 116,
+        "rank": 117,
         "name": "Filippo Balicchia",
         "login": "fbalicchia",
         "avatarLogin": "fbalicchia",
@@ -6077,7 +6092,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 117,
+        "rank": 118,
         "name": "Florencio Cano",
         "login": "fcanogab",
         "avatarLogin": "fcanogab",
@@ -6092,7 +6107,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 118,
+        "rank": 119,
         "name": "Francisco Puga Lojo",
         "login": "pugafran",
         "avatarLogin": "pugafran",
@@ -6107,7 +6122,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 119,
+        "rank": 120,
         "name": "GuanMu",
         "login": "ZeroZ-lab",
         "avatarLogin": "ZeroZ-lab",
@@ -6122,7 +6137,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 120,
+        "rank": 121,
         "name": "Hadar Cohen",
         "login": "Hadar301",
         "avatarLogin": "Hadar301",
@@ -6137,7 +6152,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 121,
+        "rank": 122,
         "name": "Hanzhong Liu",
         "login": "muchengl",
         "avatarLogin": "muchengl",
@@ -6152,7 +6167,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 122,
+        "rank": 123,
         "name": "Haritha",
         "login": "haritha3320",
         "avatarLogin": "haritha3320",
@@ -6167,7 +6182,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 123,
+        "rank": 124,
         "name": "Hikari",
         "login": "altale",
         "avatarLogin": "altale",
@@ -6182,7 +6197,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 124,
+        "rank": 125,
         "name": "Immanuel Tikhonov",
         "login": "immanuwell",
         "avatarLogin": "immanuwell",
@@ -6197,7 +6212,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 125,
+        "rank": 126,
         "name": "joyful-ii-V-I",
         "login": "joyful-ii-V-I",
         "avatarLogin": "joyful-ii-V-I",
@@ -6212,7 +6227,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 126,
+        "rank": 127,
         "name": "KJyang-0114",
         "login": "KJyang-0114",
         "avatarLogin": "KJyang-0114",
@@ -6227,7 +6242,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 127,
+        "rank": 128,
         "name": "Kongxi",
         "login": "iamagenius00",
         "avatarLogin": "iamagenius00",
@@ -6242,7 +6257,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 128,
+        "rank": 129,
         "name": "Lysandre Debut",
         "login": "LysandreJik",
         "avatarLogin": "LysandreJik",
@@ -6257,7 +6272,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 129,
+        "rank": 130,
         "name": "Marc Navarro",
         "login": "toffentoffen",
         "avatarLogin": "toffentoffen",
@@ -6272,7 +6287,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 130,
+        "rank": 131,
         "name": "MilindRastogi24",
         "login": "MilindRastogi24",
         "avatarLogin": "MilindRastogi24",
@@ -6287,7 +6302,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 131,
+        "rank": 132,
         "name": "Morax",
         "login": "fzlzjerry",
         "avatarLogin": "fzlzjerry",
@@ -6302,7 +6317,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 132,
+        "rank": 133,
         "name": "Mossaab Souaissa",
         "login": "Mossaab-s",
         "avatarLogin": "Mossaab-s",
@@ -6317,7 +6332,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 133,
+        "rank": 134,
         "name": "Nandi Vardhan Reddy",
         "login": "nandi19k",
         "avatarLogin": "nandi19k",
@@ -6332,7 +6347,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 134,
+        "rank": 135,
         "name": "Nick J Lange",
         "login": "NickJLange",
         "avatarLogin": "NickJLange",
@@ -6347,7 +6362,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 135,
+        "rank": 136,
         "name": "Nilesh Agarwal",
         "login": "nickaggarwal",
         "avatarLogin": "nickaggarwal",
@@ -6362,7 +6377,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 136,
+        "rank": 137,
         "name": "Omkar Kabde",
         "login": "omkar-334",
         "avatarLogin": "omkar-334",
@@ -6377,7 +6392,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 137,
+        "rank": 138,
         "name": "Pete Cheslock",
         "login": "petecheslock",
         "avatarLogin": "petecheslock",
@@ -6392,7 +6407,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 138,
+        "rank": 139,
         "name": "Polly Labs",
         "login": "pollychen-lab",
         "avatarLogin": "pollychen-lab",
@@ -6407,7 +6422,7 @@ export const contributorRankData = {
         "isNewContributorSinceRelease": true
       },
       {
-        "rank": 139,
+        "rank": 140,
         "name": "Pratyush Singhal",
         "login": "psinghal20",
         "avatarLogin": "psinghal20",
@@ -6419,21 +6434,6 @@ export const contributorRankData = {
         "share": 0.0006,
         "firstCommitDate": "2025-10-27",
         "latestCommitDate": "2025-10-27",
-        "isNewContributorSinceRelease": true
-      },
-      {
-        "rank": 140,
-        "name": "raghavchitkara",
-        "login": "raghavchitkara36",
-        "avatarLogin": "raghavchitkara36",
-        "avatarUrl": "https://avatars.githubusercontent.com/u/42761820?v=4",
-        "avatarSeed": "raghavchitkara36",
-        "key": "github:raghavchitkara36",
-        "commits": 1,
-        "reviews": 0,
-        "share": 0.0006,
-        "firstCommitDate": "2026-07-27",
-        "latestCommitDate": "2026-07-27",
         "isNewContributorSinceRelease": true
       },
       {

--- a/website/src/theme/BlogListPage/index.tsx
+++ b/website/src/theme/BlogListPage/index.tsx
@@ -42,10 +42,7 @@ function readingTimeLabel(readingTime: number | undefined): string | null {
   return `${Math.ceil(readingTime)} min read`
 }
 
-/**
- * Normalizes a post from `props.items` into a plain card shape shared by the
- * featured and grid cards.
- */
+/** Normalizes a post into the card shape shared by featured and grid cards. */
 function toEntry(item: Props['items'][number]): BlogSearchIndexEntry {
   const { frontMatter, metadata } = item.content
 

--- a/website/src/theme/BlogListPage/index.tsx
+++ b/website/src/theme/BlogListPage/index.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import Link from '@docusaurus/Link'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
-import useGlobalData from '@docusaurus/useGlobalData'
 import {
   HtmlClassNameProvider,
   PageMetadata,
@@ -9,14 +8,11 @@ import {
 } from '@docusaurus/theme-common'
 import SearchMetadata from '@theme/SearchMetadata'
 import BlogLayout from '@theme/BlogLayout'
+import PageHeader from '@site/src/components/site/PageHeader'
 import BlogListPaginator from '@theme/BlogListPaginator'
 import BlogListPageStructuredData from '@theme/BlogListPage/StructuredData'
 import type { Props } from '@theme/BlogListPage'
-import {
-  BLOG_SEARCH_INDEX_PLUGIN_NAME,
-  type BlogSearchIndex,
-  type BlogSearchIndexEntry,
-} from '../../plugins/blogSearchIndex'
+import type { BlogSearchIndexEntry } from '../../plugins/blogSearchIndex'
 
 interface BlogCardProps {
   featured?: boolean
@@ -47,9 +43,8 @@ function readingTimeLabel(readingTime: number | undefined): string | null {
 }
 
 /**
- * Normalizes a post from `props.items` into the same plain shape the search index
- * uses, so cards render identically whether they came from the current page or from
- * the site-wide index.
+ * Normalizes a post from `props.items` into a plain card shape shared by the
+ * featured and grid cards.
  */
 function toEntry(item: Props['items'][number]): BlogSearchIndexEntry {
   const { frontMatter, metadata } = item.content
@@ -63,26 +58,6 @@ function toEntry(item: Props['items'][number]): BlogSearchIndexEntry {
     readingTime: metadata.readingTime,
     tags: metadata.tags.map(tag => tag.label),
   }
-}
-
-/**
- * Reads the site-wide post index published by the `blog-search-index` plugin.
- *
- * Returns `null` when the index is unavailable so callers can fall back to the posts
- * Docusaurus passed in props. Global data is read defensively rather than through
- * `usePluginData` because a missing entry must degrade, never throw.
- */
-function useBlogSearchIndex(): BlogSearchIndexEntry[] | null {
-  const globalData = useGlobalData()
-
-  return useMemo(() => {
-    const pluginData = globalData?.[BLOG_SEARCH_INDEX_PLUGIN_NAME]?.default as
-      | BlogSearchIndex
-      | undefined
-    const posts = pluginData?.posts
-
-    return Array.isArray(posts) && posts.length > 0 ? posts : null
-  }, [globalData])
 }
 
 function BlogPostImage({
@@ -119,8 +94,9 @@ function BlogPostImage({
 }
 
 function BlogCard({ featured = false, entry }: BlogCardProps): React.ReactNode {
-  const { date, description, image, permalink, readingTime, title } = entry
+  const { date, description, image, permalink, readingTime, tags, title } = entry
   const readTime = readingTimeLabel(readingTime)
+  const chip = featured ? 'Featured' : tags[0]
 
   return (
     <article
@@ -138,7 +114,7 @@ function BlogCard({ featured = false, entry }: BlogCardProps): React.ReactNode {
         <BlogPostImage alt="" image={image} />
       </Link>
       <div className="site-blog-card__body">
-        {featured && <span className="site-blog-card__eyebrow">Featured</span>}
+        {chip && <span className="site-blog-card__eyebrow">{chip}</span>}
         <h2 className="site-blog-card__title">
           <Link to={permalink}>{title}</Link>
         </h2>
@@ -176,32 +152,8 @@ function BlogListPageMetadata({ metadata }: Props): React.ReactNode {
 
 export default function BlogListPage(props: Props): React.ReactNode {
   const { items, metadata } = props
-  const [query, setQuery] = useState('')
-  const normalizedQuery = query.trim().toLowerCase()
-  const isSearching = normalizedQuery.length > 0
-  const searchIndex = useBlogSearchIndex()
 
-  // Posts for the page Docusaurus rendered. Used verbatim when not searching, and as
-  // the fallback corpus if the site-wide index is ever unavailable.
   const pageEntries = useMemo(() => items.map(toEntry), [items])
-
-  const searchableEntries = searchIndex ?? pageEntries
-
-  const filteredEntries = useMemo(() => {
-    if (!isSearching) {
-      return pageEntries
-    }
-
-    return searchableEntries.filter((entry) => {
-      const haystack = [
-        entry.title,
-        entry.description,
-        entry.tags.join(' '),
-      ].join(' ').toLowerCase()
-
-      return haystack.includes(normalizedQuery)
-    })
-  }, [isSearching, normalizedQuery, pageEntries, searchableEntries])
 
   const tagSummaries = useMemo(() => {
     const counts = new Map<string, TagSummary>()
@@ -222,7 +174,7 @@ export default function BlogListPage(props: Props): React.ReactNode {
       .slice(0, 8)
   }, [items])
 
-  const [featuredEntry, ...remainingEntries] = filteredEntries
+  const [featuredEntry, ...remainingEntries] = pageEntries
 
   return (
     <HtmlClassNameProvider
@@ -232,49 +184,15 @@ export default function BlogListPage(props: Props): React.ReactNode {
       <BlogListPageStructuredData {...props} />
       <BlogLayout>
         <div className="site-blog-index">
-          <header className="site-blog-index__header">
-            <h1>Blog</h1>
-            <label className="site-blog-search">
-              <span aria-hidden="true" className="site-blog-search__icon">⌕</span>
-              <input
-                aria-label="Search blog posts"
-                onChange={event => setQuery(event.target.value)}
-                placeholder="Search blog posts..."
-                type="search"
-                value={query}
-              />
-            </label>
-            <p>
-              Deep dives into model routing, inference engineering, performance
-              breakthroughs, and the latest from the vLLM Semantic Router
-              community.
-            </p>
-          </header>
+          <div className="site-blog-index__header">
+            <PageHeader
+              description="Deep dives into model routing, inference engineering, performance breakthroughs, and the latest from the vLLM Semantic Router community."
+              eyebrow="Blog"
+              title="Engineering notes"
+            />
+          </div>
 
           <div className="site-blog-index__columns">
-            <section aria-live="polite" className="site-blog-index__feed">
-              {featuredEntry
-                ? (
-                    <>
-                      <BlogCard featured entry={featuredEntry} />
-                      {remainingEntries.length > 0 && (
-                        <div className="site-blog-card-grid">
-                          {remainingEntries.map(entry => (
-                            <BlogCard entry={entry} key={entry.permalink} />
-                          ))}
-                        </div>
-                      )}
-                    </>
-                  )
-                : (
-                    <div className="site-blog-empty">
-                      <h2>No posts found</h2>
-                      <p>Try a different title, topic, or tag.</p>
-                    </div>
-                  )}
-              {!isSearching && <BlogListPaginator metadata={metadata} />}
-            </section>
-
             <aside className="site-blog-index__rail">
               <section>
                 <h2>Recent</h2>
@@ -311,6 +229,29 @@ export default function BlogListPage(props: Props): React.ReactNode {
                 </section>
               )}
             </aside>
+
+            <section aria-live="polite" className="site-blog-index__feed">
+              {featuredEntry
+                ? (
+                    <>
+                      <BlogCard featured entry={featuredEntry} />
+                      {remainingEntries.length > 0 && (
+                        <div className="site-blog-card-grid">
+                          {remainingEntries.map(entry => (
+                            <BlogCard entry={entry} key={entry.permalink} />
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  )
+                : (
+                    <div className="site-blog-empty">
+                      <h2>No posts found</h2>
+                      <p>Check back soon for new engineering notes.</p>
+                    </div>
+                  )}
+              <BlogListPaginator metadata={metadata} />
+            </section>
           </div>
         </div>
       </BlogLayout>


### PR DESCRIPTION
Related #3002

## Purpose

Phase 4 of the website revamp, following #3018. This brings the blog onto the same frame, header, and rail system as Docs, Research, and Community, and fixes the frame width.

- **Blog article.** Moves the contents rail to the left at the shared rail width and uses the Docs sidebar styling.
- **Left-flush article column.** Running text is now left-flush instead of centred, aligning the article with the other pages.
- **One article width.** Prose, code, images, and tables share the same content width.
- **Blog listing.** Uses the shared `PageHeader`, moves the rail to the left, and removes the blog-specific search UI.
- **Article opening.** Uses the same structure as Research and Community with category eyebrow, title, date, and author.

### Frame width

`--page-max` changes from `1760px` to `1536px` so the frame matches the actual docs columns:

```text
rail 288 + rail-gap 110 + measure 736 + column-gap 130 + toc 272 = 1536
```

The gap ramps are also adjusted so the frame grows correctly without leaving unused space or causing overflow.

All `--page-max` consumers use the same
`calc(var(--page-max) + var(--gutter) * 2)` box, keeping the navbar, footer, Docs, Research, Community, and Blog aligned. The landing page follows through `--site-grid-max`.

Two files sit outside this phase's manifest:

- `tokens.css` updates `--page-max` and the `--rail-gap` ramp.
- `docs.css` updates the content track and column-gap ramp.

Known and deliberate: blog posts have empty space on the right at wide widths because the contents rail is on the left and there is no right-side TOC.

## Test Plan

```bash
cd website && npm run lint
npm start
```

Checked light and dark modes at 1920 / 1280 / 996 / 640.

- Blog listing aligns with Research and Community, with no blog-specific search box.
- Blog contents rail stays sticky and tracks the active section.
- Blog text, code, images, and tables share one width.
- Docs, Research, Community, Blog, navbar, and footer share the same frame edges.
- No unused space remains to the right of the Docs TOC at 1920px.
- Docs prose and wide tables align on the same right edge.
- No duplicate scrollbar on the article contents rail.
- At 996px and below, rails collapse without page-level horizontal scroll.

## Test Result

`npm run lint` clean. Behaviour verified in both colour modes at all four widths.

Please check the deployed preview for the full visual details.

### Before

<img width="1913" height="988" alt="Before 1" src="https://github.com/user-attachments/assets/e706fa37-dbfa-4d80-b057-b01547766a48" />

<img width="1913" height="988" alt="Before 2" src="https://github.com/user-attachments/assets/c3de2614-1051-4834-8219-1bdd127e771f" />

<img width="1913" height="988" alt="Before 3" src="https://github.com/user-attachments/assets/2cafbb0c-d3c8-461b-887b-cab34674c01e" />

### After

<img width="1913" height="988" alt="After 1" src="https://github.com/user-attachments/assets/71a4bc10-2493-48b9-a8f2-2e1c978c9664" />

<img width="1913" height="988" alt="After 2" src="https://github.com/user-attachments/assets/b983c7ec-6099-43cc-8986-fd80c8fbbfa1" />

<img width="1913" height="988" alt="After 3" src="https://github.com/user-attachments/assets/dff88a40-a4ca-4725-b5b9-83d1276dce95" />

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.