### PR TITLE
[Dashboard] Make Dashboard API authorization route-bound and deny by default

### DIFF
--- a/dashboard/backend/auth/admin_meta_handlers.go
+++ b/dashboard/backend/auth/admin_meta_handlers.go
@@ -108,12 +108,15 @@ func adminUserPasswordHandler(svc *Service) http.HandlerFunc {
 			writePasswordHashError(w, err)
 			return
 		}
+		if revalidationErr := RevalidateRequest(r); revalidationErr != nil {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
 		if err := svc.store.UpdatePassword(r.Context(), req.UserID, hash); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		writeAudit(r, svc, "user.password", "/api/admin/users/password", ac.UserID)
 		respondJSON(w, map[string]bool{"ok": true})
 	}
 }

--- a/dashboard/backend/auth/admin_user_handlers.go
+++ b/dashboard/backend/auth/admin_user_handlers.go
@@ -115,13 +115,16 @@ func handleAdminUsersCreate(w http.ResponseWriter, r *http.Request, svc *Service
 		return
 	}
 
+	if revalidationErr := RevalidateRequest(r); revalidationErr != nil {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	user, err := svc.store.CreateUser(r.Context(), req.Email, req.Name, hash, normalizedRole, "active")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	writeAudit(r, svc, "user.create", "/api/admin/users", ac.UserID)
 	respondJSON(w, user)
 }
 
@@ -213,13 +216,16 @@ func handleAdminUserPatch(
 		return
 	}
 
+	if revalidationErr := RevalidateRequest(r); revalidationErr != nil {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	user, err := svc.store.UpdateUserRoleOrStatus(r.Context(), userID, normalizedRole, normalizedStatus)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	writeAudit(r, svc, "user.update", "/api/admin/users/", ac.UserID)
 	respondJSON(w, user)
 }
 
@@ -256,12 +262,15 @@ func handleAdminUserDelete(
 		return
 	}
 
+	if revalidationErr := RevalidateRequest(r); revalidationErr != nil {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 	if err := svc.store.DeleteUser(r.Context(), userID); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	writeAudit(r, svc, "user.delete", "/api/admin/users/", ac.UserID)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/dashboard/backend/auth/handlers.go
+++ b/dashboard/backend/auth/handlers.go
@@ -54,12 +54,46 @@ func AuthRoutes(svc *Service) *http.ServeMux {
 	return mux
 }
 
-func RegisterAdminRoutes(mux *http.ServeMux, svc *Service) {
-	mux.HandleFunc("/api/admin/users", adminUsersCollectionHandler(svc))
-	mux.HandleFunc("/api/admin/users/", adminUserItemHandler(svc))
-	mux.HandleFunc("/api/admin/permissions", adminPermissionsHandler(svc))
-	mux.HandleFunc("/api/admin/audit-logs", adminAuditLogsHandler(svc))
-	mux.HandleFunc("/api/admin/users/password", adminUserPasswordHandler(svc))
+func RegisterAdminRoutes(routes *PolicyMux, svc *Service) {
+	const maxAdminBodyBytes int64 = 64 << 10
+
+	routes.HandleFunc(
+		Route(
+			"/api/admin/users",
+			ReadPolicy(http.MethodGet, PermUsersView, SensitivitySensitive, ResourceOwnerAuth),
+			MutationPolicy(http.MethodPost, PermUsersManage, "user.create", SensitivitySecret, ResourceOwnerAuth, maxAdminBodyBytes),
+		),
+		adminUsersCollectionHandler(svc),
+	)
+	routes.HandleFunc(
+		Route(
+			"/api/admin/users/",
+			ReadPolicy(http.MethodGet, PermUsersView, SensitivitySensitive, ResourceOwnerAuth),
+			MutationPolicy(http.MethodPatch, PermUsersManage, "user.update", SensitivitySecret, ResourceOwnerAuth, maxAdminBodyBytes),
+			MutationPolicy(http.MethodDelete, PermUsersManage, "user.delete", SensitivitySecret, ResourceOwnerAuth, NoBodyLimit),
+		),
+		adminUserItemHandler(svc),
+	)
+	routes.HandleFunc(
+		ProtectedRoute("/api/admin/permissions", PermUsersManage, SensitivitySensitive, ResourceOwnerAuth, http.MethodGet),
+		adminPermissionsHandler(svc),
+	)
+	routes.HandleFunc(
+		ProtectedRoute("/api/admin/audit-logs", PermUsersManage, SensitivitySensitive, ResourceOwnerAuth, http.MethodGet),
+		adminAuditLogsHandler(svc),
+	)
+	routes.HandleFunc(
+		ProtectedMutationRoute(
+			"/api/admin/users/password",
+			PermUsersManage,
+			"user.password",
+			SensitivitySecret,
+			ResourceOwnerAuth,
+			maxAdminBodyBytes,
+			http.MethodPost,
+		),
+		adminUserPasswordHandler(svc),
+	)
 }
 
 func writeAudit(r *http.Request, svc *Service, action, resource, actorID string) {

--- a/dashboard/backend/auth/handlers_test.go
+++ b/dashboard/backend/auth/handlers_test.go
@@ -56,6 +56,16 @@ func newAuthenticatedRequest(t *testing.T, svc *Service, user *User, method, pat
 	return req
 }
 
+func protectedTestHandler(
+	svc *Service,
+	contract RouteContract,
+	next http.HandlerFunc,
+) http.Handler {
+	routes := NewPolicyMux()
+	routes.HandleFunc(contract, next)
+	return AuthenticateRequest(svc, routes)(routes)
+}
+
 func TestAuthenticateRequestUsesCurrentDatabaseState(t *testing.T) {
 	t.Parallel()
 
@@ -68,9 +78,9 @@ func TestAuthenticateRequestUsesCurrentDatabaseState(t *testing.T) {
 			t.Fatalf("UpdateUserRoleOrStatus() error = %v", err)
 		}
 
-		handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handler := protectedTestHandler(svc, ProtectedRoute("/api/admin/users", PermUsersView, SensitivitySensitive, ResourceOwnerAuth, http.MethodGet), func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
-		}))
+		})
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodGet, "/api/admin/users", ""))
@@ -89,9 +99,9 @@ func TestAuthenticateRequestUsesCurrentDatabaseState(t *testing.T) {
 			t.Fatalf("UpdateUserRoleOrStatus() error = %v", err)
 		}
 
-		handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handler := protectedTestHandler(svc, ProtectedRoute("/api/status", PermTopologyRead, SensitivityOperational, ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
-		}))
+		})
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodGet, "/api/status", ""))
@@ -117,10 +127,10 @@ func TestAuthenticateRequestRequiresTopologyReadForRecipeValidateTrailingSlash(t
 	}
 
 	nextCalled := false
-	handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := protectedTestHandler(svc, ProtectedRoute("/api/recipe/probes/", PermTopologyRead, SensitivityOperational, ResourceOwnerConfig, http.MethodPost), func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	})
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(
 		recorder,
@@ -157,10 +167,10 @@ func TestAuthenticateRequestDeniesRecipePackageMutationSubtreesToConfigReader(t 
 	} {
 		t.Run(path, func(t *testing.T) {
 			nextCalled := false
-			handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			handler := protectedTestHandler(svc, ProtectedRoute(path, PermConfigDeploy, SensitivitySensitive, ResourceOwnerConfig, http.MethodPost), func(w http.ResponseWriter, _ *http.Request) {
 				nextCalled = true
 				w.WriteHeader(http.StatusNoContent)
-			}))
+			})
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodPost, path, ""))
 			if recorder.Code != http.StatusForbidden {
@@ -190,9 +200,9 @@ func TestRegisterAdminRoutesHonorsUsersViewAndSelfLockoutGuards(t *testing.T) {
 			t.Fatalf("grant users.view error = %v", err)
 		}
 
-		mux := http.NewServeMux()
+		mux := NewPolicyMux()
 		RegisterAdminRoutes(mux, svc)
-		handler := AuthenticateRequest(svc)(mux)
+		handler := AuthenticateRequest(svc, mux)(mux)
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodGet, "/api/admin/users", ""))
@@ -208,9 +218,9 @@ func TestRegisterAdminRoutesHonorsUsersViewAndSelfLockoutGuards(t *testing.T) {
 		svc := newTestAuthService(t)
 		user := newTestUser(t, svc, "self-update@example.com", "admin", "active")
 
-		mux := http.NewServeMux()
+		mux := NewPolicyMux()
 		RegisterAdminRoutes(mux, svc)
-		handler := AuthenticateRequest(svc)(mux)
+		handler := AuthenticateRequest(svc, mux)(mux)
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(
@@ -236,9 +246,9 @@ func TestRegisterAdminRoutesHonorsUsersViewAndSelfLockoutGuards(t *testing.T) {
 		svc := newTestAuthService(t)
 		user := newTestUser(t, svc, "self-delete@example.com", "admin", "active")
 
-		mux := http.NewServeMux()
+		mux := NewPolicyMux()
 		RegisterAdminRoutes(mux, svc)
-		handler := AuthenticateRequest(svc)(mux)
+		handler := AuthenticateRequest(svc, mux)(mux)
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(
@@ -316,9 +326,9 @@ func TestMeHandlerReturnsEffectivePermissions(t *testing.T) {
 		t.Fatalf("grant users.view error = %v", err)
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/auth/me", meHandler(svc))
-	handler := AuthenticateRequest(svc)(mux)
+	mux := NewPolicyMux()
+	mux.HandleFunc(ProtectedRoute("/api/auth/me", PermSessionRead, SensitivitySensitive, ResourceOwnerAuth, http.MethodGet), meHandler(svc))
+	handler := AuthenticateRequest(svc, mux)(mux)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodGet, "/api/auth/me", ""))

--- a/dashboard/backend/auth/logs_permission_test.go
+++ b/dashboard/backend/auth/logs_permission_test.go
@@ -13,10 +13,10 @@ func TestRuntimeLogsAreDeniedToDefaultReadRole(t *testing.T) {
 	reader := newTestUser(t, service, "logs-reader@example.com", RoleRead, "active")
 	writer := newTestUser(t, service, "logs-writer@example.com", RoleWrite, "active")
 	var calls int
-	handler := AuthenticateRequest(service)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := protectedTestHandler(service, ProtectedRoute("/api/logs", PermLogsRead, SensitivitySensitive, ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, _ *http.Request) {
 		calls++
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	})
 
 	readerResponse := httptest.NewRecorder()
 	handler.ServeHTTP(

--- a/dashboard/backend/auth/middleware.go
+++ b/dashboard/backend/auth/middleware.go
@@ -1,7 +1,11 @@
 package auth
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -13,6 +17,8 @@ type contextKey string
 
 const (
 	authContextKey contextKey = "dashboardAuthContext"
+	routePolicyKey contextKey = "dashboardRoutePolicy"
+	revalidatorKey contextKey = "dashboardPermissionRevalidator"
 
 	authSessionCookieName = "vsr_session"
 	maxAccessTokenBytes   = 8192
@@ -26,13 +32,31 @@ type AuthContext struct {
 	Perms  map[string]bool
 }
 
-func AuthenticateRequest(service *Service) func(http.Handler) http.Handler {
+type permissionRevalidator func(context.Context) error
+
+var errPermissionDenied = errors.New("permission denied")
+
+func AuthenticateRequest(service *Service, resolver RoutePolicyResolver) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !requiresAuthentication(r.URL.Path) {
+			policy, lookup := resolver.LookupRoutePolicy(r.Method, r.URL.Path)
+			switch lookup {
+			case RouteMethodNotAllowed:
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			case RouteNotFound:
+				if isProtectedNamespace(r.URL.Path) {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+					return
+				}
 				next.ServeHTTP(w, r)
 				return
 			}
+			if policy.Public {
+				next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), routePolicyKey, policy)))
+				return
+			}
+
 			token := extractAccessToken(r)
 			if token == "" {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -44,18 +68,42 @@ func AuthenticateRequest(service *Service) func(http.Handler) http.Handler {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
+			if policy.MaxAuthAge > 0 {
+				if claims.IssuedAt == nil {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+					return
+				}
+				age := time.Since(claims.IssuedAt.Time)
+				if age < 0 || age > policy.MaxAuthAge {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+					return
+				}
+			}
 
-			user, perms, err := service.ResolveSessionUser(r.Context(), claims)
+			user, perms, err := authorizeClaims(r.Context(), service, claims, policy.Permission)
 			if err != nil {
 				log.Printf("permission load failed for user %s: %v", claims.UserID, err)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				if errors.Is(err, errPermissionDenied) {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+				} else {
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				}
 				return
 			}
 
-			required := RequiredPermission(r.Method, r.URL.Path)
-			if required != "" && !perms[required] {
-				http.Error(w, "Forbidden", http.StatusForbidden)
-				return
+			if policy.MaxBodyBytes > 0 && r.Body != nil {
+				body, readErr := readBoundedRequestBody(w, r, policy.MaxBodyBytes)
+				if readErr != nil {
+					return
+				}
+				r.Body = io.NopCloser(bytes.NewReader(body))
+			}
+			if policy.Revalidate && policy.MaxBodyBytes > 0 {
+				user, perms, err = authorizeClaims(r.Context(), service, claims, policy.Permission)
+				if err != nil {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+					return
+				}
 			}
 
 			ctx := context.WithValue(r.Context(), authContextKey, AuthContext{
@@ -64,7 +112,18 @@ func AuthenticateRequest(service *Service) func(http.Handler) http.Handler {
 				Role:   user.Role,
 				Perms:  perms,
 			})
-			next.ServeHTTP(w, r.WithContext(ctx))
+			ctx = context.WithValue(ctx, routePolicyKey, policy)
+			ctx = context.WithValue(ctx, revalidatorKey, permissionRevalidator(func(checkCtx context.Context) error {
+				_, _, checkErr := authorizeClaims(checkCtx, service, claims, policy.Permission)
+				return checkErr
+			}))
+
+			request := r.WithContext(ctx)
+			if policy.AuditMode == AuditRequired {
+				serveWithRouteAudit(service, policy, w, request, next)
+				return
+			}
+			next.ServeHTTP(w, request)
 		})
 	}
 }
@@ -76,13 +135,21 @@ func AuthenticateRequest(service *Service) func(http.Handler) http.Handler {
 // assets, and the static frontend) through so the dashboard can render and
 // surface the "authentication service is not configured" state.
 //
-// This is the deny-by-default counterpart to AuthenticateRequest: it shares
-// the same requiresAuthentication policy so the set of protected routes cannot
-// drift between the two paths.
-func ServiceUnavailableGuard() func(http.Handler) http.Handler {
+// This is the deny-by-default counterpart to AuthenticateRequest and uses the
+// same route policy registry so healthy and degraded startup cannot drift.
+func ServiceUnavailableGuard(resolver RoutePolicyResolver) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if requiresAuthentication(r.URL.Path) {
+			policy, lookup := resolver.LookupRoutePolicy(r.Method, r.URL.Path)
+			if lookup == RouteMethodNotAllowed {
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if lookup == RouteFound && policy.Public {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if lookup == RouteFound || isProtectedNamespace(r.URL.Path) {
 				http.Error(w, "Authentication service is not configured", http.StatusServiceUnavailable)
 				return
 			}
@@ -91,262 +158,88 @@ func ServiceUnavailableGuard() func(http.Handler) http.Handler {
 	}
 }
 
-func RequiredPermission(method, path string) string {
-	path = strings.TrimSpace(strings.ToLower(path))
-	for _, resolver := range []func(string, string) (string, bool){
-		adminPermission,
-		settingsPermission,
-		routerPermission,
-		knowledgePermission,
-		toolsPermission,
-		observabilityPermission,
-		recipePermission,
-		fleetSimPermission,
-		featurePermission,
-	} {
-		if permission, ok := resolver(method, path); ok {
-			return permission
-		}
+func authorizeClaims(
+	ctx context.Context,
+	service *Service,
+	claims *TokenClaims,
+	permission string,
+) (*User, map[string]bool, error) {
+	user, perms, err := service.ResolveSessionUser(ctx, claims)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if strings.HasPrefix(path, "/api/") {
-		return PermConfigRead
+	if !perms[permission] {
+		return nil, nil, fmt.Errorf("%w: permission %q is required", errPermissionDenied, permission)
 	}
-
-	return ""
+	return user, perms, nil
 }
 
-func recipePermission(_ string, path string) (string, bool) {
-	path = strings.TrimRight(path, "/")
-	if matchesRoute(path, "/api/recipe/import") {
-		return PermConfigWrite, true
+func readBoundedRequestBody(w http.ResponseWriter, r *http.Request, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBytes))
+	if err == nil {
+		return body, nil
 	}
-	if matchesAnyRoute(path, "/api/recipe/activate", "/api/recipe/deactivate") {
-		return PermConfigDeploy, true
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+		return nil, err
 	}
-	if matchesRoute(path, "/api/recipe/packages") {
-		return PermConfigRead, true
-	}
-	if path == "/api/recipe" || matchesRoute(path, "/api/recipe/probes") {
-		if strings.HasSuffix(path, "/validate") {
-			return PermTopologyRead, true
-		}
-		return PermConfigRead, true
-	}
-	return "", false
+	http.Error(w, "Invalid request body", http.StatusBadRequest)
+	return nil, err
 }
 
-func matchesAnyRoute(path string, bases ...string) bool {
-	for _, base := range bases {
-		if matchesRoute(path, base) {
-			return true
-		}
+func serveWithRouteAudit(
+	service *Service,
+	policy RoutePolicy,
+	w http.ResponseWriter,
+	r *http.Request,
+	next http.Handler,
+) {
+	rw := &auditResponseWriter{ResponseWriter: w}
+	next.ServeHTTP(rw, r)
+	ac, _ := AuthFromContext(r)
+	_ = service.AddAuditLog(context.WithoutCancel(r.Context()), AuditLog{
+		UserID:     ac.UserID,
+		Action:     policy.AuditAction,
+		Resource:   string(policy.ResourceOwner),
+		Method:     r.Method,
+		Path:       r.URL.Path,
+		IP:         r.RemoteAddr,
+		UserAgent:  r.UserAgent(),
+		StatusCode: rw.statusCodeOr200(),
+		CreatedAt:  time.Now().Unix(),
+	})
+}
+
+func RoutePolicyFromContext(r *http.Request) (RoutePolicy, bool) {
+	policy, ok := r.Context().Value(routePolicyKey).(RoutePolicy)
+	return policy, ok
+}
+
+func RevalidateRequest(r *http.Request) error {
+	revalidate, ok := r.Context().Value(revalidatorKey).(permissionRevalidator)
+	if !ok {
+		return errors.New("live permission revalidation is unavailable")
+	}
+	return revalidate(r.Context())
+}
+
+func WithPermissionRevalidator(ctx context.Context, check func(context.Context) error) context.Context {
+	return context.WithValue(ctx, revalidatorKey, permissionRevalidator(check))
+}
+
+func RejectRevokedMutation(w http.ResponseWriter, r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if _, ok := r.Context().Value(revalidatorKey).(permissionRevalidator); !ok {
+		return false
+	}
+	if err := RevalidateRequest(r); err != nil {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return true
 	}
 	return false
-}
-
-func matchesRoute(path, base string) bool {
-	return path == base || strings.HasPrefix(path, base+"/")
-}
-
-func adminPermission(method, path string) (string, bool) {
-	switch {
-	case strings.HasPrefix(path, "/api/admin/users/password"):
-		return PermUsersManage, true
-	case strings.HasPrefix(path, "/api/admin/audit-logs"), strings.HasPrefix(path, "/api/admin/permissions"):
-		return PermUsersManage, true
-	case path == "/api/admin/users" || strings.HasPrefix(path, "/api/admin/users/"):
-		if method == http.MethodGet {
-			return PermUsersView, true
-		}
-		return PermUsersManage, true
-	case strings.HasPrefix(path, "/api/admin/"):
-		return PermUsersManage, true
-	default:
-		return "", false
-	}
-}
-
-func settingsPermission(method, path string) (string, bool) {
-	switch {
-	case strings.HasPrefix(path, "/api/settings"):
-		if method == http.MethodPut || method == http.MethodPost {
-			return PermConfigWrite, true
-		}
-		return PermConfigRead, true
-	case strings.HasPrefix(path, "/api/setup/validate"),
-		strings.HasPrefix(path, "/api/setup/activate"),
-		strings.HasPrefix(path, "/api/setup/import-remote"):
-		return PermConfigWrite, true
-	default:
-		return "", false
-	}
-}
-
-func routerPermission(method, path string) (string, bool) {
-	switch {
-	case path == "/api/models/catalog":
-		return PermConfigRead, true
-	case path == "/api/models/verify":
-		return PermEvalRun, true
-	case path == "/api/router/v1/router/outcomes" && method == http.MethodPost:
-		return PermFeedbackSubmit, true
-	case strings.HasPrefix(path, "/api/router/v1/router_replay"):
-		return PermReplayRead, true
-	case strings.HasPrefix(path, "/api/router/api/v1/response-cache/"):
-		return readOrManagePermission(method, PermConfigRead, PermConfigWrite), true
-	case path == "/api/router/api/v1/context-compression/preview":
-		return PermConfigRead, true
-	case strings.HasPrefix(path, "/api/router/api/v1/context-compression/"):
-		return readOrManagePermission(method, PermConfigRead, PermConfigWrite), true
-	case path == "/api/router/config/deploy",
-		path == "/api/router/config/deploy/preview",
-		path == "/api/router/config/rollback":
-		return PermConfigDeploy, true
-	case strings.HasPrefix(path, "/api/router/config/"):
-		if method == http.MethodGet {
-			return PermConfigRead, true
-		}
-		return PermConfigWrite, true
-	case strings.HasPrefix(path, "/api/router/"):
-		return PermConfigRead, true
-	default:
-		return "", false
-	}
-}
-
-func knowledgePermission(_ string, path string) (string, bool) {
-	switch {
-	case strings.HasPrefix(path, "/embedded/wizmap/"), path == "/embedded/wizmap":
-		return PermConfigRead, true
-	default:
-		return "", false
-	}
-}
-
-func toolsPermission(method string, path string) (string, bool) {
-	switch {
-	case strings.HasPrefix(path, "/api/mcp/tools/execute"):
-		return PermToolsUse, true
-	case path == "/api/mcp/tools":
-		return readOrManagePermission(method, PermMcpRead, PermMcpManage), true
-	case path == "/api/mcp/servers":
-		return readOrManagePermission(method, PermMcpRead, PermMcpManage), true
-	case strings.HasPrefix(path, "/api/mcp/servers/") && strings.HasSuffix(path, "/status"):
-		return readOrManagePermission(method, PermMcpRead, PermMcpManage), true
-	case strings.HasPrefix(path, "/api/tools"):
-		return PermToolsUse, true
-	case strings.HasPrefix(path, "/api/mcp/"):
-		return PermMcpManage, true
-	default:
-		return "", false
-	}
-}
-
-func readOrManagePermission(method, readPermission, managePermission string) string {
-	if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
-		return readPermission
-	}
-	return managePermission
-}
-
-func observabilityPermission(_ string, path string) (string, bool) {
-	switch {
-	case strings.HasPrefix(path, "/api/status"):
-		return PermTopologyRead, true
-	case strings.HasPrefix(path, "/api/logs"):
-		return PermLogsRead, true
-	case strings.HasPrefix(path, "/embedded/grafana/"), strings.HasPrefix(path, "/embedded/jaeger"):
-		return PermLogsRead, true
-	case strings.HasPrefix(path, "/api/topology"):
-		return PermTopologyRead, true
-	default:
-		return "", false
-	}
-}
-
-func fleetSimPermission(method, path string) (string, bool) {
-	if !strings.HasPrefix(path, "/api/fleet-sim/") && path != "/api/fleet-sim" {
-		return "", false
-	}
-	return readOrManagePermission(method, PermConfigRead, PermConfigWrite), true
-}
-
-func featurePermission(method, path string) (string, bool) {
-	switch {
-	case strings.HasPrefix(path, "/api/evaluation"):
-		if path == "/api/evaluation/run" || strings.HasPrefix(path, "/api/evaluation/cancel/") {
-			return PermEvalRun, true
-		}
-		if method == http.MethodPost || method == http.MethodDelete {
-			return PermEvalWrite, true
-		}
-		return PermEvalRead, true
-	case strings.HasPrefix(path, "/api/openclaw/"), strings.HasPrefix(path, "/embedded/openclaw/"):
-		return openclawPermission(method, path)
-	case strings.HasPrefix(path, "/api/ml-pipeline/"):
-		return PermMlPipeline, true
-	case strings.HasPrefix(path, "/api/security/"):
-		return securityPermission(method), true
-	default:
-		return "", false
-	}
-}
-
-func securityPermission(method string) string {
-	if method == http.MethodGet {
-		return PermConfigRead
-	}
-	return PermSecurityManage
-}
-
-func openclawPermission(method, path string) (string, bool) {
-	switch {
-	case strings.HasPrefix(path, "/embedded/openclaw/"):
-		return PermOpenClawRead, true
-	case strings.HasPrefix(path, "/api/openclaw/mcp"):
-		return PermMcpManage, true
-	case hasAnyPrefix(path,
-		"/api/openclaw/provision",
-		"/api/openclaw/start",
-		"/api/openclaw/stop",
-		"/api/openclaw/containers/",
-		"/api/openclaw/next-port",
-	):
-		return PermOpenClaw, true
-	case strings.HasPrefix(path, "/api/openclaw/rooms/") && (strings.HasSuffix(path, "/messages") || strings.HasSuffix(path, "/stream") || strings.HasSuffix(path, "/ws")):
-		return PermOpenClawRead, true
-	case hasAnyPrefix(path,
-		"/api/openclaw/status",
-		"/api/openclaw/skills",
-		"/api/openclaw/token",
-	):
-		return PermOpenClawRead, true
-	case hasAnyPrefix(path,
-		"/api/openclaw/teams",
-		"/api/openclaw/workers",
-		"/api/openclaw/rooms",
-	):
-		return openclawMethodPermission(method), true
-	default:
-		return openclawMethodPermission(method), true
-	}
-}
-
-func hasAnyPrefix(path string, prefixes ...string) bool {
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(path, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
-func openclawMethodPermission(method string) string {
-	if method == http.MethodGet {
-		return PermOpenClawRead
-	}
-	return PermOpenClaw
 }
 
 func AuthFromContext(r *http.Request) (AuthContext, bool) {
@@ -438,39 +331,35 @@ func normalizeAccessToken(raw string) string {
 	return token
 }
 
-func requiresAuthentication(path string) bool {
-	path = strings.TrimSpace(strings.ToLower(path))
-
-	switch {
-	case strings.HasPrefix(path, "/api/auth/login"):
-		return false
-	case strings.HasPrefix(path, "/api/auth/logout"):
-		return false
-	case strings.HasPrefix(path, "/api/auth/bootstrap/"):
-		return false
-	case strings.HasPrefix(path, "/api/auth/me"):
-		return true
-	case strings.HasPrefix(path, "/api/setup/state"):
-		return false
-	case strings.HasPrefix(path, "/embedded/wizmap/assets/"):
-		return false
-	case strings.HasPrefix(path, "/api/"):
-		return true
-	case strings.HasPrefix(path, "/embedded/"):
-		return true
-	default:
-		return false
-	}
-}
-
 type auditResponseWriter struct {
 	http.ResponseWriter
 	status int
 }
 
 func (w *auditResponseWriter) WriteHeader(status int) {
+	if w.status != 0 {
+		return
+	}
 	w.status = status
 	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *auditResponseWriter) Write(payload []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(payload)
+}
+
+func (w *auditResponseWriter) Flush() {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	_ = http.NewResponseController(w.ResponseWriter).Flush()
+}
+
+func (w *auditResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }
 
 func (w *auditResponseWriter) statusCodeOr200() int {

--- a/dashboard/backend/auth/middleware_test.go
+++ b/dashboard/backend/auth/middleware_test.go
@@ -370,20 +370,6 @@ func setRolePermission(t *testing.T, svc *Service, role, permission string, allo
 	}
 }
 
-func setUserPermission(t *testing.T, svc *Service, userID, permission string, allowed bool) {
-	t.Helper()
-	if _, err := svc.store.db.ExecContext(
-		t.Context(),
-		`INSERT INTO user_permissions(user_id, permission_key, allowed) VALUES(?,?,?)
-		 ON CONFLICT(user_id, permission_key) DO UPDATE SET allowed = excluded.allowed`,
-		userID,
-		permission,
-		allowed,
-	); err != nil {
-		t.Fatalf("set user permission %s=%v: %v", permission, allowed, err)
-	}
-}
-
 func TestMutationRequestBodyIsBounded(t *testing.T) {
 	t.Parallel()
 

--- a/dashboard/backend/auth/middleware_test.go
+++ b/dashboard/backend/auth/middleware_test.go
@@ -1,40 +1,30 @@
 package auth
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestRequiresAuthentication(t *testing.T) {
+func TestPolicyMuxRequiresExplicitContracts(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		path     string
-		expected bool
-	}{
-		{path: "/", expected: false},
-		{path: "/dashboard", expected: false},
-		{path: "/login", expected: false},
-		{path: "/api/auth/login", expected: false},
-		{path: "/api/auth/logout", expected: false},
-		{path: "/api/auth/bootstrap/can-register", expected: false},
-		{path: "/api/setup/state", expected: false},
-		{path: "/api/auth/me", expected: true},
-		{path: "/api/status", expected: true},
-		{path: "/embedded/grafana/", expected: true},
-		{path: "/embedded/wizmap/", expected: true},
-		{path: "/embedded/wizmap/assets/index.js", expected: false},
-	}
+	routes := NewPolicyMux()
+	routes.HandleFunc(PublicRoute("/api/auth/login", http.MethodPost), func(http.ResponseWriter, *http.Request) {})
+	routes.HandleFunc(ProtectedRoute("/api/status", PermTopologyRead, SensitivityOperational, ResourceOwnerObservability, http.MethodGet), func(http.ResponseWriter, *http.Request) {})
 
-	for _, tc := range testCases {
-		t.Run(tc.path, func(t *testing.T) {
-			t.Parallel()
-			if actual := requiresAuthentication(tc.path); actual != tc.expected {
-				t.Fatalf("requiresAuthentication(%q) = %v, want %v", tc.path, actual, tc.expected)
-			}
-		})
+	if policy, result := routes.LookupRoutePolicy(http.MethodPost, "/api/auth/login"); result != RouteFound || !policy.Public {
+		t.Fatalf("public route lookup = (%+v, %v)", policy, result)
+	}
+	if policy, result := routes.LookupRoutePolicy(http.MethodGet, "/api/status"); result != RouteFound || policy.Permission != PermTopologyRead {
+		t.Fatalf("protected route lookup = (%+v, %v)", policy, result)
+	}
+	if _, result := routes.LookupRoutePolicy(http.MethodGet, "/api/unknown"); result != RouteNotFound {
+		t.Fatalf("unknown route lookup = %v, want %v", result, RouteNotFound)
 	}
 }
 
@@ -64,7 +54,13 @@ func TestServiceUnavailableGuard(t *testing.T) {
 				nextCalled = true
 				w.WriteHeader(http.StatusOK)
 			})
-			handler := ServiceUnavailableGuard()(next)
+			routes := NewPolicyMux()
+			if strings.HasPrefix(tc.path, "/api/auth/login") || strings.HasPrefix(tc.path, "/api/setup/state") {
+				routes.HandleFunc(PublicRoute(tc.path, http.MethodGet), func(http.ResponseWriter, *http.Request) {})
+			} else if strings.HasPrefix(tc.path, "/api/") || strings.HasPrefix(tc.path, "/embedded/") {
+				routes.HandleFunc(ProtectedRoute(tc.path, PermConfigRead, SensitivitySensitive, ResourceOwnerConfig, http.MethodGet), func(http.ResponseWriter, *http.Request) {})
+			}
+			handler := ServiceUnavailableGuard(routes)(next)
 
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			rec := httptest.NewRecorder()
@@ -162,83 +158,6 @@ func TestNormalizeAccessToken(t *testing.T) {
 	}
 }
 
-func TestRequiredPermission(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		method   string
-		path     string
-		expected string
-	}{
-		{method: http.MethodGet, path: "/api/admin/users", expected: PermUsersView},
-		{method: http.MethodPatch, path: "/api/admin/users/user-1", expected: PermUsersManage},
-		{method: http.MethodGet, path: "/api/admin/audit-logs", expected: PermUsersManage},
-		{method: http.MethodGet, path: "/api/status", expected: PermTopologyRead},
-		{method: http.MethodGet, path: "/embedded/grafana/", expected: PermLogsRead},
-		{method: http.MethodGet, path: "/embedded/wizmap/", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/setup/activate", expected: PermConfigWrite},
-		{method: http.MethodPost, path: "/api/setup/import-remote", expected: PermConfigWrite},
-		{method: http.MethodGet, path: "/api/models/catalog", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/models/verify", expected: PermEvalRun},
-		{method: http.MethodGet, path: "/api/models/verify", expected: PermEvalRun},
-		{method: http.MethodGet, path: "/api/mcp/servers", expected: PermMcpRead},
-		{method: http.MethodPost, path: "/api/mcp/servers", expected: PermMcpManage},
-		{method: http.MethodDelete, path: "/api/mcp/servers/server-1/status", expected: PermMcpManage},
-		{method: http.MethodPost, path: "/api/mcp/servers/server-1/connect", expected: PermMcpManage},
-		{method: http.MethodPost, path: "/api/router/config/deploy", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/router/config/deploy/preview", expected: PermConfigDeploy},
-		{method: http.MethodGet, path: "/api/router/config/deployments", expected: PermConfigRead},
-		{method: http.MethodGet, path: "/api/router/api/v1/response-cache/stats", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/router/api/v1/response-cache/invalidate", expected: PermConfigWrite},
-		{method: http.MethodPost, path: "/api/router/api/v1/context-compression/preview", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/router/api/v1/context-compression/recovery/invalidate", expected: PermConfigWrite},
-		{method: http.MethodPost, path: "/api/evaluation/tasks", expected: PermEvalWrite},
-		{method: http.MethodPost, path: "/api/evaluation/run", expected: PermEvalRun},
-		{method: http.MethodPost, path: "/api/evaluation/cancel/task-1", expected: PermEvalRun},
-		{method: http.MethodGet, path: "/api/fleet-sim/api/workloads", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/fleet-sim/api/jobs", expected: PermConfigWrite},
-		{method: http.MethodGet, path: "/api/openclaw/teams", expected: PermOpenClawRead},
-		{method: http.MethodPost, path: "/api/openclaw/teams", expected: PermOpenClaw},
-		{method: http.MethodPost, path: "/api/openclaw/rooms/room-1/messages", expected: PermOpenClawRead},
-		{method: http.MethodPost, path: "/api/router/v1/chat/completions", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/router/v1/router/outcomes", expected: PermFeedbackSubmit},
-		{method: http.MethodGet, path: "/api/router/v1/router_replay", expected: PermReplayRead},
-		{method: http.MethodGet, path: "/api/router/v1/router_replay/record-1", expected: PermReplayRead},
-		{method: http.MethodGet, path: "/api/recipe", expected: PermConfigRead},
-		{method: http.MethodGet, path: "/api/recipe/probes", expected: PermConfigRead},
-		{method: http.MethodGet, path: "/api/recipe/packages", expected: PermConfigRead},
-		{method: http.MethodGet, path: "/api/recipe/packages/", expected: PermConfigRead},
-		{method: http.MethodGet, path: "/api/recipe/packages/anything", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/recipe/import", expected: PermConfigWrite},
-		{method: http.MethodPost, path: "/api/recipe/import/", expected: PermConfigWrite},
-		{method: http.MethodPost, path: "/api/recipe/import/anything", expected: PermConfigWrite},
-		{method: http.MethodPost, path: "/api/recipe/activate", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/activate/preview", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/activate/", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/activate/anything", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/deactivate", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/deactivate/preview", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/deactivate/", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/deactivate/anything", expected: PermConfigDeploy},
-		{method: http.MethodPost, path: "/api/recipe/probes/lane/variant/run-plan", expected: PermConfigRead},
-		{method: http.MethodPost, path: "/api/recipe/probes/lane/variant/validate", expected: PermTopologyRead},
-		{method: http.MethodPost, path: "/api/recipe/probes/lane/variant/validate/", expected: PermTopologyRead},
-		{method: http.MethodPost, path: "/api/recipe/probes/lane/variant/validate///", expected: PermTopologyRead},
-		{method: http.MethodGet, path: "/api/security/policy", expected: PermConfigRead},
-		{method: http.MethodPut, path: "/api/security/policy", expected: PermSecurityManage},
-		{method: http.MethodPost, path: "/api/security/policy/preview", expected: PermSecurityManage},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.path, func(t *testing.T) {
-			t.Parallel()
-			if actual := RequiredPermission(tc.method, tc.path); actual != tc.expected {
-				t.Fatalf("RequiredPermission(%q, %q) = %q, want %q", tc.method, tc.path, actual, tc.expected)
-			}
-		})
-	}
-}
-
 func TestAuthenticateRequestRequiresFeedbackPermissionForRouterOutcomes(t *testing.T) {
 	t.Parallel()
 
@@ -246,10 +165,10 @@ func TestAuthenticateRequestRequiresFeedbackPermissionForRouterOutcomes(t *testi
 	reader := newTestUser(t, svc, "outcome-reader@example.com", RoleRead, "active")
 	writer := newTestUser(t, svc, "outcome-writer@example.com", RoleWrite, "active")
 	nextCalled := false
-	handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := protectedTestHandler(svc, ProtectedRoute("/api/router/v1/router/outcomes", PermFeedbackSubmit, SensitivitySecret, ResourceOwnerFeedback, http.MethodPost), func(w http.ResponseWriter, _ *http.Request) {
 		nextCalled = true
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	})
 
 	readerRecorder := httptest.NewRecorder()
 	handler.ServeHTTP(
@@ -277,10 +196,10 @@ func TestAuthenticateRequestRequiresEvaluationRunForLiveModelVerification(t *tes
 	reader := newTestUser(t, svc, "model-verify-reader@example.com", RoleRead, "active")
 	writer := newTestUser(t, svc, "model-verify-writer@example.com", RoleWrite, "active")
 	var calls int
-	handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := protectedTestHandler(svc, ProtectedRoute("/api/models/verify", PermEvalRun, SensitivitySensitive, ResourceOwnerInference, http.MethodPost), func(w http.ResponseWriter, _ *http.Request) {
 		calls++
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	})
 
 	readerResponse := httptest.NewRecorder()
 	handler.ServeHTTP(
@@ -299,4 +218,315 @@ func TestAuthenticateRequestRequiresEvaluationRunForLiveModelVerification(t *tes
 	if writerResponse.Code != http.StatusNoContent || calls != 1 {
 		t.Fatalf("writer status = %d, calls = %d", writerResponse.Code, calls)
 	}
+}
+
+func TestAuthenticateRequestDeniesUnknownProtectedRoutes(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestAuthService(t)
+	user := newTestUser(t, svc, "unknown-route@example.com", RoleAdmin, "active")
+	routes := NewPolicyMux()
+	nextCalled := false
+	handler := AuthenticateRequest(svc, routes)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodGet, "/api/not-registered", ""))
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+	if nextCalled {
+		t.Fatal("unknown protected route reached the handler")
+	}
+}
+
+func TestInferencePermissionIsIndependentFromConfigRead(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestAuthService(t)
+	configOnly := newTestUser(t, svc, "config-only@example.com", RoleRead, "active")
+	inferenceOnly := newTestUser(t, svc, "inference-only@example.com", RoleRead, "active")
+	for _, denied := range []struct {
+		user       *User
+		permission string
+	}{
+		{user: configOnly, permission: PermInferenceRun},
+		{user: inferenceOnly, permission: PermConfigRead},
+	} {
+		if _, err := svc.store.db.ExecContext(
+			t.Context(),
+			`INSERT INTO user_permissions(user_id, permission_key, allowed) VALUES(?,?,0)`,
+			denied.user.ID,
+			denied.permission,
+		); err != nil {
+			t.Fatalf("deny %s: %v", denied.permission, err)
+		}
+	}
+
+	var calls int
+	handler := protectedTestHandler(
+		svc,
+		ProtectedRoute("/api/router/v1/chat/completions", PermInferenceRun, SensitivitySecret, ResourceOwnerInference, http.MethodPost),
+		func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	deniedResponse := httptest.NewRecorder()
+	handler.ServeHTTP(deniedResponse, newAuthenticatedRequest(t, svc, configOnly, http.MethodPost, "/api/router/v1/chat/completions", `{}`))
+	if deniedResponse.Code != http.StatusForbidden || calls != 0 {
+		t.Fatalf("config-only status = %d, calls = %d", deniedResponse.Code, calls)
+	}
+
+	allowedResponse := httptest.NewRecorder()
+	handler.ServeHTTP(allowedResponse, newAuthenticatedRequest(t, svc, inferenceOnly, http.MethodPost, "/api/router/v1/chat/completions", `{}`))
+	if allowedResponse.Code != http.StatusNoContent || calls != 1 {
+		t.Fatalf("inference-only status = %d, calls = %d", allowedResponse.Code, calls)
+	}
+}
+
+func TestIndependentPermissionGrantAndRevoke(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		permission string
+		owner      ResourceOwner
+	}{
+		{name: "config", method: http.MethodPost, path: "/api/router/config/deploy", permission: PermConfigDeploy, owner: ResourceOwnerConfig},
+		{name: "replay", method: http.MethodGet, path: "/api/router/v1/router_replay/replay-1", permission: PermReplayRead, owner: ResourceOwnerReplay},
+		{name: "feedback", method: http.MethodPost, path: "/api/router/v1/router/outcomes", permission: PermFeedbackSubmit, owner: ResourceOwnerFeedback},
+		{name: "inference", method: http.MethodPost, path: "/api/router/v1/chat/completions", permission: PermInferenceRun, owner: ResourceOwnerInference},
+		{name: "ml", method: http.MethodPost, path: "/api/ml-pipeline/train", permission: PermMlPipeline, owner: ResourceOwnerML},
+		{name: "openclaw", method: http.MethodPost, path: "/api/openclaw/provision", permission: PermOpenClaw, owner: ResourceOwnerOpenClaw},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			svc := newTestAuthService(t)
+			role := "custom-" + test.name
+			user := newTestCustomRoleUser(t, svc, test.name+"-custom@example.com", role)
+			var calls int
+			handler := protectedTestHandler(
+				svc,
+				ProtectedRoute(test.path, test.permission, SensitivitySensitive, test.owner, test.method),
+				func(w http.ResponseWriter, _ *http.Request) {
+					calls++
+					w.WriteHeader(http.StatusNoContent)
+				},
+			)
+
+			setRolePermission(t, svc, role, test.permission, true)
+			allowed := httptest.NewRecorder()
+			handler.ServeHTTP(allowed, newAuthenticatedRequest(t, svc, user, test.method, test.path, `{}`))
+			if allowed.Code != http.StatusNoContent || calls != 1 {
+				t.Fatalf("granted status = %d, calls = %d", allowed.Code, calls)
+			}
+
+			setRolePermission(t, svc, role, test.permission, false)
+			denied := httptest.NewRecorder()
+			handler.ServeHTTP(denied, newAuthenticatedRequest(t, svc, user, test.method, test.path, `{}`))
+			if denied.Code != http.StatusForbidden || calls != 1 {
+				t.Fatalf("revoked status = %d, calls = %d", denied.Code, calls)
+			}
+		})
+	}
+}
+
+func newTestCustomRoleUser(t *testing.T, svc *Service, email, role string) *User {
+	t.Helper()
+	user := newTestUser(t, svc, email, RoleRead, "active")
+	if _, err := svc.store.db.ExecContext(
+		t.Context(),
+		`UPDATE users SET role = ?, updated_at = ? WHERE id = ?`,
+		role,
+		nowUnix(),
+		user.ID,
+	); err != nil {
+		t.Fatalf("assign custom role %q: %v", role, err)
+	}
+	user.Role = role
+	return user
+}
+
+func setRolePermission(t *testing.T, svc *Service, role, permission string, allowed bool) {
+	t.Helper()
+	if _, err := svc.store.db.ExecContext(
+		t.Context(),
+		`INSERT INTO role_permissions(role, permission_key, allowed) VALUES(?,?,?)
+		 ON CONFLICT(role, permission_key) DO UPDATE SET allowed = excluded.allowed`,
+		role,
+		permission,
+		allowed,
+	); err != nil {
+		t.Fatalf("set role %s permission %s=%v: %v", role, permission, allowed, err)
+	}
+}
+
+func setUserPermission(t *testing.T, svc *Service, userID, permission string, allowed bool) {
+	t.Helper()
+	if _, err := svc.store.db.ExecContext(
+		t.Context(),
+		`INSERT INTO user_permissions(user_id, permission_key, allowed) VALUES(?,?,?)
+		 ON CONFLICT(user_id, permission_key) DO UPDATE SET allowed = excluded.allowed`,
+		userID,
+		permission,
+		allowed,
+	); err != nil {
+		t.Fatalf("set user permission %s=%v: %v", permission, allowed, err)
+	}
+}
+
+func TestMutationRequestBodyIsBounded(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestAuthService(t)
+	user := newTestUser(t, svc, "bounded-body@example.com", RoleAdmin, "active")
+	var calls int
+	handler := protectedTestHandler(
+		svc,
+		ProtectedMutationRoute("/api/config", PermConfigWrite, "config.update", SensitivitySecret, ResourceOwnerConfig, 4, http.MethodPost),
+		func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodPost, "/api/config", "12345"))
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusRequestEntityTooLarge)
+	}
+	if calls != 0 {
+		t.Fatalf("handler calls = %d, want 0", calls)
+	}
+}
+
+func TestBreakGlassAuthorizationIsTimeBounded(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestAuthService(t)
+	user := newTestUser(t, svc, "breakglass@example.com", RoleAdmin, "active")
+	routes := NewPolicyMux()
+	var calls int
+	routes.HandleFunc(
+		BreakGlassMutationRoute("/api/breakglass", "breakglass.apply", 64<<10, time.Nanosecond, http.MethodPost),
+		func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	handler := AuthenticateRequest(svc, routes)(routes)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, newAuthenticatedRequest(t, svc, user, http.MethodPost, "/api/breakglass", `{}`))
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+	if calls != 0 {
+		t.Fatalf("handler calls = %d, want 0", calls)
+	}
+}
+
+func TestRejectRevokedMutationRequiresLivePermission(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	plain := httptest.NewRequest(http.MethodPost, "/api/router/config/update", nil)
+	if RejectRevokedMutation(recorder, plain) {
+		t.Fatal("missing revalidator should not reject unit-test handler calls")
+	}
+
+	denied := plain.WithContext(WithPermissionRevalidator(plain.Context(), func(context.Context) error {
+		return errPermissionDenied
+	}))
+	if !RejectRevokedMutation(recorder, denied) {
+		t.Fatal("live revalidation failure should reject the mutation")
+	}
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestMutationRechecksPermissionAfterPausedBody(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestAuthService(t)
+	user := newTestUser(t, svc, "paused-body@example.com", RoleAdmin, "active")
+	token, err := svc.issueToken(user)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+
+	body := &pausingRequestBody{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/config", body)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	var calls int
+	handler := protectedTestHandler(
+		svc,
+		ProtectedMutationRoute("/api/config", PermConfigWrite, "config.update", SensitivitySecret, ResourceOwnerConfig, 64, http.MethodPost),
+		func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(recorder, req)
+		close(done)
+	}()
+
+	select {
+	case <-body.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("middleware did not start reading the request body")
+	}
+	if err := svc.RevokeToken(t.Context(), token); err != nil {
+		t.Fatalf("revoke token: %v", err)
+	}
+	close(body.release)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request did not finish")
+	}
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+	if calls != 0 {
+		t.Fatalf("handler calls = %d, want 0", calls)
+	}
+}
+
+type pausingRequestBody struct {
+	started chan struct{}
+	release chan struct{}
+	sent    bool
+}
+
+func (b *pausingRequestBody) Read(payload []byte) (int, error) {
+	if !b.sent {
+		b.sent = true
+		close(b.started)
+		return copy(payload, []byte(`{}`)), nil
+	}
+	<-b.release
+	return 0, io.EOF
+}
+
+func (b *pausingRequestBody) Close() error {
+	return nil
 }

--- a/dashboard/backend/auth/password_test.go
+++ b/dashboard/backend/auth/password_test.go
@@ -63,9 +63,9 @@ func TestPasswordRotationRejectsOversizedPasswordWithBadRequest(t *testing.T) {
 	admin := newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
 	target := newTestUser(t, svc, "target@example.com", RoleRead, "active")
 
-	mux := http.NewServeMux()
+	mux := NewPolicyMux()
 	RegisterAdminRoutes(mux, svc)
-	handler := AuthenticateRequest(svc)(mux)
+	handler := AuthenticateRequest(svc, mux)(mux)
 
 	body, err := json.Marshal(map[string]string{
 		"userId":   target.ID,
@@ -98,9 +98,9 @@ func TestPasswordRotationAcceptsPasswordAtTheLimit(t *testing.T) {
 	admin := newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
 	target := newTestUser(t, svc, "target@example.com", RoleRead, "active")
 
-	mux := http.NewServeMux()
+	mux := NewPolicyMux()
 	RegisterAdminRoutes(mux, svc)
-	handler := AuthenticateRequest(svc)(mux)
+	handler := AuthenticateRequest(svc, mux)(mux)
 
 	password := strings.Repeat("a", MaxPasswordBytes)
 	body, err := json.Marshal(map[string]string{"userId": target.ID, "password": password})
@@ -130,9 +130,9 @@ func TestUserCreationRejectsOversizedPasswordWithBadRequest(t *testing.T) {
 	svc := newTestAuthService(t)
 	admin := newTestUser(t, svc, "admin@example.com", RoleAdmin, "active")
 
-	mux := http.NewServeMux()
+	mux := NewPolicyMux()
 	RegisterAdminRoutes(mux, svc)
-	handler := AuthenticateRequest(svc)(mux)
+	handler := AuthenticateRequest(svc, mux)(mux)
 
 	body, err := json.Marshal(map[string]string{
 		"email":    "new-user@example.com",

--- a/dashboard/backend/auth/permission_store.go
+++ b/dashboard/backend/auth/permission_store.go
@@ -113,7 +113,7 @@ func (s *Store) GetEffectivePermissions(ctx context.Context, role string, userID
 	}
 
 	if userID != "" {
-		uRows, err := s.db.QueryContext(ctx, `SELECT permission_key FROM user_permissions WHERE user_id = ? AND allowed = 1`, userID)
+		uRows, err := s.db.QueryContext(ctx, `SELECT permission_key, allowed FROM user_permissions WHERE user_id = ?`, userID)
 		if err != nil {
 			return nil, err
 		}
@@ -122,8 +122,14 @@ func (s *Store) GetEffectivePermissions(ctx context.Context, role string, userID
 		}()
 		for uRows.Next() {
 			var p string
-			if err := uRows.Scan(&p); err == nil {
+			var allowed bool
+			if err := uRows.Scan(&p, &allowed); err != nil {
+				return nil, err
+			}
+			if allowed {
 				permMap[p] = true
+			} else {
+				delete(permMap, p)
 			}
 		}
 		if err := uRows.Err(); err != nil {

--- a/dashboard/backend/auth/policy_mux.go
+++ b/dashboard/backend/auth/policy_mux.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// PolicyMux is the only registration seam for dashboard HTTP handlers. A
+// protected handler cannot be installed without its complete route contract.
+type PolicyMux struct {
+	mux       *http.ServeMux
+	mu        sync.RWMutex
+	contracts map[string]RouteContract
+	sealed    bool
+}
+
+func NewPolicyMux() *PolicyMux {
+	return &PolicyMux{
+		mux:       http.NewServeMux(),
+		contracts: map[string]RouteContract{},
+	}
+}
+
+func (m *PolicyMux) Handle(contract RouteContract, handler http.Handler) {
+	m.HandleGroup([]RouteContract{contract}, handler)
+}
+
+// HandleGroup binds multiple concrete route contracts to one handler. All
+// contracts are validated before any route is installed, so proxy dispatchers
+// cannot register a handler separately from their authorization metadata.
+func (m *PolicyMux) HandleGroup(contracts []RouteContract, handler http.Handler) {
+	if handler == nil {
+		panic("route handler is required")
+	}
+	if len(contracts) == 0 {
+		panic("at least one route contract is required")
+	}
+
+	validated := make([]RouteContract, 0, len(contracts))
+	seen := make(map[string]struct{}, len(contracts))
+	for _, contract := range contracts {
+		contract = mustValidateRouteContract(contract)
+		if _, exists := seen[contract.Pattern]; exists {
+			panic(fmt.Sprintf("route contract already declared for %q in handler group", contract.Pattern))
+		}
+		seen[contract.Pattern] = struct{}{}
+		validated = append(validated, contract)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sealed {
+		panic("route registry is sealed")
+	}
+	for _, contract := range validated {
+		if _, exists := m.contracts[contract.Pattern]; exists {
+			panic(fmt.Sprintf("route contract already registered for %q", contract.Pattern))
+		}
+	}
+	for _, contract := range validated {
+		m.mux.Handle(contract.Pattern, handler)
+		m.contracts[contract.Pattern] = contract
+	}
+}
+
+func (m *PolicyMux) HandleFunc(contract RouteContract, handler http.HandlerFunc) {
+	m.Handle(contract, handler)
+}
+
+// HandleFallback registers a non-API fallback such as the static frontend.
+// API and embedded routes must use Handle, HandleFunc, or HandleGroup.
+func (m *PolicyMux) HandleFallback(pattern string, handler http.Handler) {
+	if handler == nil {
+		panic("fallback handler is required")
+	}
+	pattern = normalizeRoutePattern(pattern)
+	if isProtectedNamespace(pattern) {
+		panic(fmt.Sprintf("protected fallback %q requires a route contract", pattern))
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sealed {
+		panic("route registry is sealed")
+	}
+	m.mux.Handle(pattern, handler)
+}
+
+// Seal closes startup registration. Setup calls it before publishing the
+// server so late route additions cannot bypass the validated inventory.
+func (m *PolicyMux) Seal() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sealed = true
+}
+
+func (m *PolicyMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mux.ServeHTTP(w, r)
+}
+
+func (m *PolicyMux) LookupRoutePolicy(method, path string) (RoutePolicy, RouteLookup) {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	path = normalizePolicyPath(path)
+
+	request := &http.Request{Method: method, URL: &url.URL{Path: path}}
+	_, pattern := m.mux.Handler(request)
+
+	m.mu.RLock()
+	contract, found := m.contracts[pattern]
+	m.mu.RUnlock()
+	if !found {
+		return RoutePolicy{}, RouteNotFound
+	}
+	for _, policy := range contract.Policies {
+		if policy.Method == method {
+			return policy, RouteFound
+		}
+	}
+	if method == http.MethodOptions {
+		return RoutePolicy{
+			Method:        http.MethodOptions,
+			AuditMode:     AuditNone,
+			Sensitivity:   SensitivityPublic,
+			ResourceOwner: ResourceOwnerPublic,
+			Public:        true,
+		}, RouteFound
+	}
+	return RoutePolicy{}, RouteMethodNotAllowed
+}
+
+func (m *PolicyMux) Contracts() []RouteContract {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	contracts := make([]RouteContract, 0, len(m.contracts))
+	for _, contract := range m.contracts {
+		copyContract := contract
+		copyContract.Policies = append([]RoutePolicy(nil), contract.Policies...)
+		contracts = append(contracts, copyContract)
+	}
+	sort.Slice(contracts, func(i, j int) bool {
+		return contracts[i].Pattern < contracts[j].Pattern
+	})
+	return contracts
+}

--- a/dashboard/backend/auth/route_policy.go
+++ b/dashboard/backend/auth/route_policy.go
@@ -1,0 +1,442 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Sensitivity string
+
+const (
+	SensitivityPublic      Sensitivity = "public"
+	SensitivityOperational Sensitivity = "operational"
+	SensitivitySensitive   Sensitivity = "sensitive"
+	SensitivitySecret      Sensitivity = "secret"
+)
+
+type ResourceOwner string
+
+const (
+	ResourceOwnerPublic        ResourceOwner = "public"
+	ResourceOwnerAuth          ResourceOwner = "auth"
+	ResourceOwnerConfig        ResourceOwner = "config"
+	ResourceOwnerEvaluation    ResourceOwner = "evaluation"
+	ResourceOwnerInference     ResourceOwner = "inference"
+	ResourceOwnerObservability ResourceOwner = "observability"
+	ResourceOwnerReplay        ResourceOwner = "replay"
+	ResourceOwnerFeedback      ResourceOwner = "feedback"
+	ResourceOwnerTools         ResourceOwner = "tools"
+	ResourceOwnerOpenClaw      ResourceOwner = "openclaw"
+	ResourceOwnerML            ResourceOwner = "ml"
+	ResourceOwnerWorkflow      ResourceOwner = "workflow"
+	ResourceOwnerTenantGrants  ResourceOwner = "tenant_grants"
+	ResourceOwnerTenantQuotas  ResourceOwner = "tenant_quotas"
+	ResourceOwnerVirtualKeys   ResourceOwner = "virtual_keys"
+	ResourceOwnerAuditPolicy   ResourceOwner = "audit_policy"
+	ResourceOwnerBreakGlass    ResourceOwner = "breakglass"
+)
+
+type AuditMode string
+
+const (
+	AuditNone      AuditMode = "none"
+	AuditRequired  AuditMode = "required"
+	AuditDelegated AuditMode = "delegated"
+)
+
+const (
+	NoBodyLimit int64 = 0
+)
+
+type RoutePolicy struct {
+	Method        string
+	Permission    string
+	AuditMode     AuditMode
+	AuditAction   string
+	Sensitivity   Sensitivity
+	ResourceOwner ResourceOwner
+	Public        bool
+	Revalidate    bool
+	MaxBodyBytes  int64
+	ProxyUpstream bool
+	MaxAuthAge    time.Duration
+}
+
+type RouteContract struct {
+	Pattern  string
+	Policies []RoutePolicy
+}
+
+type RouteLookup int
+
+const (
+	RouteNotFound RouteLookup = iota
+	RouteMethodNotAllowed
+	RouteFound
+)
+
+type RoutePolicyResolver interface {
+	LookupRoutePolicy(method, path string) (RoutePolicy, RouteLookup)
+}
+
+func PublicRoute(pattern string, methods ...string) RouteContract {
+	return RouteContract{
+		Pattern:  pattern,
+		Policies: policiesForMethods("", AuditNone, "", SensitivityPublic, ResourceOwnerPublic, true, false, NoBodyLimit, false, methods...),
+	}
+}
+
+func Route(pattern string, policies ...RoutePolicy) RouteContract {
+	return RouteContract{Pattern: pattern, Policies: policies}
+}
+
+func PublicPolicy(method string) RoutePolicy {
+	return RoutePolicy{
+		Method:        method,
+		AuditMode:     AuditNone,
+		Sensitivity:   SensitivityPublic,
+		ResourceOwner: ResourceOwnerPublic,
+		Public:        true,
+	}
+}
+
+func ReadPolicy(
+	method string,
+	permission string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+) RoutePolicy {
+	return RoutePolicy{
+		Method:        method,
+		Permission:    permission,
+		AuditMode:     AuditNone,
+		Sensitivity:   sensitivity,
+		ResourceOwner: owner,
+	}
+}
+
+func MutationPolicy(
+	method string,
+	permission string,
+	auditAction string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	maxBodyBytes int64,
+) RoutePolicy {
+	return RoutePolicy{
+		Method:        method,
+		Permission:    permission,
+		AuditMode:     AuditRequired,
+		AuditAction:   auditAction,
+		Sensitivity:   sensitivity,
+		ResourceOwner: owner,
+		Revalidate:    true,
+		MaxBodyBytes:  maxBodyBytes,
+	}
+}
+
+func ProtectedRoute(
+	pattern string,
+	permission string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	methods ...string,
+) RouteContract {
+	return RouteContract{
+		Pattern:  pattern,
+		Policies: policiesForMethods(permission, AuditNone, "", sensitivity, owner, false, false, NoBodyLimit, false, methods...),
+	}
+}
+
+func ProtectedBoundedRoute(
+	pattern string,
+	permission string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	maxBodyBytes int64,
+	methods ...string,
+) RouteContract {
+	contract := ProtectedRoute(pattern, permission, sensitivity, owner, methods...)
+	for index := range contract.Policies {
+		contract.Policies[index].MaxBodyBytes = maxBodyBytes
+	}
+	return contract
+}
+
+func ProtectedMutationRoute(
+	pattern string,
+	permission string,
+	auditAction string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	maxBodyBytes int64,
+	methods ...string,
+) RouteContract {
+	return RouteContract{
+		Pattern:  pattern,
+		Policies: policiesForMethods(permission, AuditRequired, auditAction, sensitivity, owner, false, true, maxBodyBytes, false, methods...),
+	}
+}
+
+func ProtectedDelegatedAuditRoute(
+	pattern string,
+	permission string,
+	auditAction string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	maxBodyBytes int64,
+	methods ...string,
+) RouteContract {
+	return RouteContract{
+		Pattern: pattern,
+		Policies: policiesForMethods(
+			permission,
+			AuditDelegated,
+			auditAction,
+			sensitivity,
+			owner,
+			false,
+			true,
+			maxBodyBytes,
+			false,
+			methods...,
+		),
+	}
+}
+
+func BreakGlassMutationRoute(
+	pattern string,
+	auditAction string,
+	maxBodyBytes int64,
+	maxAuthAge time.Duration,
+	methods ...string,
+) RouteContract {
+	contract := ProtectedMutationRoute(
+		pattern,
+		PermBreakGlass,
+		auditAction,
+		SensitivitySecret,
+		ResourceOwnerBreakGlass,
+		maxBodyBytes,
+		methods...,
+	)
+	for index := range contract.Policies {
+		contract.Policies[index].MaxAuthAge = maxAuthAge
+	}
+	return contract
+}
+
+func ProxyRoute(
+	pattern string,
+	permission string,
+	auditMode AuditMode,
+	auditAction string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	methods ...string,
+) RouteContract {
+	return RouteContract{
+		Pattern:  pattern,
+		Policies: policiesForMethods(permission, auditMode, auditAction, sensitivity, owner, false, false, NoBodyLimit, true, methods...),
+	}
+}
+
+func ProxyMutationRoute(
+	pattern string,
+	permission string,
+	auditAction string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	maxBodyBytes int64,
+	methods ...string,
+) RouteContract {
+	contract := ProtectedMutationRoute(
+		pattern,
+		permission,
+		auditAction,
+		sensitivity,
+		owner,
+		maxBodyBytes,
+		methods...,
+	)
+	for index := range contract.Policies {
+		contract.Policies[index].ProxyUpstream = true
+	}
+	return contract
+}
+
+func policiesForMethods(
+	permission string,
+	auditMode AuditMode,
+	auditAction string,
+	sensitivity Sensitivity,
+	owner ResourceOwner,
+	public bool,
+	revalidate bool,
+	maxBodyBytes int64,
+	proxy bool,
+	methods ...string,
+) []RoutePolicy {
+	policies := make([]RoutePolicy, 0, len(methods))
+	for _, method := range methods {
+		policies = append(policies, RoutePolicy{
+			Method:        method,
+			Permission:    permission,
+			AuditMode:     auditMode,
+			AuditAction:   auditAction,
+			Sensitivity:   sensitivity,
+			ResourceOwner: owner,
+			Public:        public,
+			Revalidate:    revalidate,
+			MaxBodyBytes:  maxBodyBytes,
+			ProxyUpstream: proxy,
+		})
+	}
+	return policies
+}
+
+func mustValidateRouteContract(contract RouteContract) RouteContract {
+	contract.Pattern = normalizeRoutePattern(contract.Pattern)
+	if err := ValidateRouteContract(contract); err != nil {
+		panic(err)
+	}
+	for index := range contract.Policies {
+		contract.Policies[index].Method = strings.ToUpper(strings.TrimSpace(contract.Policies[index].Method))
+		contract.Policies[index].Permission = strings.TrimSpace(contract.Policies[index].Permission)
+		contract.Policies[index].AuditAction = strings.TrimSpace(contract.Policies[index].AuditAction)
+	}
+	return contract
+}
+
+func ValidateRouteContract(contract RouteContract) error {
+	pattern := normalizeRoutePattern(contract.Pattern)
+	if pattern == "" || pattern[0] != '/' {
+		return errors.New("route pattern must be an absolute path")
+	}
+	if len(contract.Policies) == 0 {
+		return fmt.Errorf("route %q has no method policies", pattern)
+	}
+
+	seen := map[string]struct{}{}
+	for _, policy := range contract.Policies {
+		method := strings.ToUpper(strings.TrimSpace(policy.Method))
+		if method == "" {
+			return fmt.Errorf("route %q has an empty method", pattern)
+		}
+		if _, exists := seen[method]; exists {
+			return fmt.Errorf("route %q has duplicate policy for %s", pattern, method)
+		}
+		seen[method] = struct{}{}
+
+		if policy.Public {
+			if strings.TrimSpace(policy.Permission) != "" {
+				return fmt.Errorf("public route %q %s must not require a permission", pattern, method)
+			}
+		} else if strings.TrimSpace(policy.Permission) == "" {
+			return fmt.Errorf("protected route %q %s has no permission", pattern, method)
+		}
+		if policy.AuditMode != AuditNone && policy.AuditMode != AuditRequired && policy.AuditMode != AuditDelegated {
+			return fmt.Errorf("route %q %s has invalid audit mode %q", pattern, method, policy.AuditMode)
+		}
+		if policy.AuditMode != AuditNone && strings.TrimSpace(policy.AuditAction) == "" {
+			return fmt.Errorf("route %q %s requires an audit action", pattern, method)
+		}
+		if _, ok := knownSensitivities[policy.Sensitivity]; !ok {
+			return fmt.Errorf("route %q %s has invalid sensitivity %q", pattern, method, policy.Sensitivity)
+		}
+		if _, ok := knownResourceOwners[policy.ResourceOwner]; !ok {
+			return fmt.Errorf("route %q %s has invalid resource owner %q", pattern, method, policy.ResourceOwner)
+		}
+		if policy.Revalidate && policy.Public {
+			return fmt.Errorf("public route %q %s cannot request live revalidation", pattern, method)
+		}
+		if policy.MaxBodyBytes < 0 {
+			return fmt.Errorf("route %q %s has a negative body limit", pattern, method)
+		}
+		if requiredPermission, sensitiveOwner := isolatedOwnerPermissions[policy.ResourceOwner]; sensitiveOwner &&
+			policy.Permission != requiredPermission {
+			return fmt.Errorf(
+				"route %q %s for %s requires isolated permission %q",
+				pattern,
+				method,
+				policy.ResourceOwner,
+				requiredPermission,
+			)
+		}
+		if policy.ResourceOwner == ResourceOwnerBreakGlass {
+			if policy.AuditMode != AuditRequired || !policy.Revalidate {
+				return fmt.Errorf("route %q %s break-glass mutation must be revalidated and audited", pattern, method)
+			}
+			if policy.MaxAuthAge <= 0 || policy.MaxAuthAge > 15*time.Minute {
+				return fmt.Errorf("route %q %s break-glass authorization must expire within 15 minutes", pattern, method)
+			}
+		} else if policy.MaxAuthAge < 0 {
+			return fmt.Errorf("route %q %s has a negative authorization age", pattern, method)
+		}
+	}
+	return nil
+}
+
+var isolatedOwnerPermissions = map[ResourceOwner]string{
+	ResourceOwnerTenantGrants: PermGrantPublish,
+	ResourceOwnerTenantQuotas: PermQuotaPublish,
+	ResourceOwnerVirtualKeys:  PermVirtualKeys,
+	ResourceOwnerAuditPolicy:  PermAuditPolicy,
+	ResourceOwnerBreakGlass:   PermBreakGlass,
+}
+
+var knownSensitivities = map[Sensitivity]struct{}{
+	SensitivityPublic:      {},
+	SensitivityOperational: {},
+	SensitivitySensitive:   {},
+	SensitivitySecret:      {},
+}
+
+var knownResourceOwners = map[ResourceOwner]struct{}{
+	ResourceOwnerPublic:        {},
+	ResourceOwnerAuth:          {},
+	ResourceOwnerConfig:        {},
+	ResourceOwnerEvaluation:    {},
+	ResourceOwnerInference:     {},
+	ResourceOwnerObservability: {},
+	ResourceOwnerReplay:        {},
+	ResourceOwnerFeedback:      {},
+	ResourceOwnerTools:         {},
+	ResourceOwnerOpenClaw:      {},
+	ResourceOwnerML:            {},
+	ResourceOwnerWorkflow:      {},
+	ResourceOwnerTenantGrants:  {},
+	ResourceOwnerTenantQuotas:  {},
+	ResourceOwnerVirtualKeys:   {},
+	ResourceOwnerAuditPolicy:   {},
+	ResourceOwnerBreakGlass:    {},
+}
+
+func normalizeRoutePattern(pattern string) string {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "/" {
+		return pattern
+	}
+	if strings.HasSuffix(pattern, "/") {
+		return strings.TrimRight(pattern, "/") + "/"
+	}
+	return strings.TrimRight(pattern, "/")
+}
+
+func normalizePolicyPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func isProtectedNamespace(path string) bool {
+	path = normalizePolicyPath(path)
+	return strings.HasPrefix(path, "/api/") ||
+		path == "/api" ||
+		strings.HasPrefix(path, "/embedded/") ||
+		path == "/embedded"
+}

--- a/dashboard/backend/auth/route_policy_test.go
+++ b/dashboard/backend/auth/route_policy_test.go
@@ -1,0 +1,209 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPolicyMuxBindsHandlerAndContractsAsOneGroup(t *testing.T) {
+	t.Parallel()
+
+	routes := NewPolicyMux()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	routes.HandleGroup([]RouteContract{
+		ProtectedRoute("/api/proxy/items", PermConfigRead, SensitivitySensitive, ResourceOwnerConfig, http.MethodGet),
+		ProtectedMutationRoute("/api/proxy/items/", PermConfigWrite, "proxy.item.update", SensitivitySensitive, ResourceOwnerConfig, 1<<20, http.MethodPost),
+	}, handler)
+
+	for _, request := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/api/proxy/items"},
+		{method: http.MethodPost, path: "/api/proxy/items/one"},
+	} {
+		policy, lookup := routes.LookupRoutePolicy(request.method, request.path)
+		if lookup != RouteFound || policy.Permission == "" {
+			t.Fatalf("%s %s lookup = (%+v, %v)", request.method, request.path, policy, lookup)
+		}
+		recorder := httptest.NewRecorder()
+		routes.ServeHTTP(recorder, httptest.NewRequest(request.method, request.path, nil))
+		if recorder.Code != http.StatusNoContent {
+			t.Fatalf("%s %s handler status = %d", request.method, request.path, recorder.Code)
+		}
+	}
+}
+
+func TestPolicyMuxUsesServeMuxPathMatching(t *testing.T) {
+	t.Parallel()
+
+	routes := NewPolicyMux()
+	routes.HandleFunc(
+		ProtectedRoute("/api/CaseSensitive/", PermConfigRead, SensitivitySensitive, ResourceOwnerConfig, http.MethodGet),
+		func(http.ResponseWriter, *http.Request) {},
+	)
+
+	if _, lookup := routes.LookupRoutePolicy(http.MethodGet, "/api/CaseSensitive/item"); lookup != RouteFound {
+		t.Fatalf("matching-case lookup = %v, want %v", lookup, RouteFound)
+	}
+	if _, lookup := routes.LookupRoutePolicy(http.MethodGet, "/api/casesensitive/item"); lookup != RouteNotFound {
+		t.Fatalf("different-case lookup = %v, want %v", lookup, RouteNotFound)
+	}
+}
+
+func TestPolicyMuxRejectsIncompleteGroupBeforeRegistration(t *testing.T) {
+	t.Parallel()
+
+	routes := NewPolicyMux()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected incomplete route group to panic")
+		}
+		if contracts := routes.Contracts(); len(contracts) != 0 {
+			t.Fatalf("contracts registered before validation completed: %+v", contracts)
+		}
+	}()
+	routes.HandleGroup([]RouteContract{
+		ProtectedRoute("/api/valid", PermConfigRead, SensitivitySensitive, ResourceOwnerConfig, http.MethodGet),
+		{Pattern: "/api/incomplete"},
+	}, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+}
+
+func TestPolicyMuxSealRejectsLateRegistration(t *testing.T) {
+	t.Parallel()
+
+	routes := NewPolicyMux()
+	routes.HandleFunc(PublicRoute("/health", http.MethodGet), func(http.ResponseWriter, *http.Request) {})
+	routes.Seal()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected late route registration to panic")
+		}
+	}()
+	routes.HandleFunc(PublicRoute("/ready", http.MethodGet), func(http.ResponseWriter, *http.Request) {})
+}
+
+func TestValidateRouteContractRejectsIncompletePolicies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		contract RouteContract
+		want     string
+	}{
+		{
+			name: "missing permission",
+			contract: Route("/api/test", RoutePolicy{
+				Method:        http.MethodPost,
+				AuditMode:     AuditRequired,
+				AuditAction:   "test.write",
+				Sensitivity:   SensitivitySecret,
+				ResourceOwner: ResourceOwnerConfig,
+			}),
+			want: "has no permission",
+		},
+		{
+			name: "missing audit declaration",
+			contract: Route("/api/test", RoutePolicy{
+				Method:        http.MethodPost,
+				Permission:    PermConfigWrite,
+				Sensitivity:   SensitivitySecret,
+				ResourceOwner: ResourceOwnerConfig,
+			}),
+			want: "invalid audit mode",
+		},
+		{
+			name: "duplicate method",
+			contract: Route(
+				"/api/test",
+				ReadPolicy(http.MethodGet, PermConfigRead, SensitivitySensitive, ResourceOwnerConfig),
+				ReadPolicy(http.MethodGet, PermConfigRead, SensitivitySensitive, ResourceOwnerConfig),
+			),
+			want: "duplicate policy",
+		},
+		{
+			name: "mixed resource ownership",
+			contract: ProtectedMutationRoute(
+				"/api/test",
+				PermConfigWrite,
+				"test.write",
+				SensitivitySecret,
+				ResourceOwner("config,tenant_grants"),
+				64<<10,
+				http.MethodPost,
+			),
+			want: "invalid resource owner",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateRouteContract(test.contract)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateRouteContract() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestGenericConfigWriteCannotOwnEnterpriseSecurityResources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		owner      ResourceOwner
+		permission string
+	}{
+		{owner: ResourceOwnerTenantGrants, permission: PermGrantPublish},
+		{owner: ResourceOwnerTenantQuotas, permission: PermQuotaPublish},
+		{owner: ResourceOwnerVirtualKeys, permission: PermVirtualKeys},
+		{owner: ResourceOwnerAuditPolicy, permission: PermAuditPolicy},
+		{owner: ResourceOwnerBreakGlass, permission: PermBreakGlass},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.owner), func(t *testing.T) {
+			t.Parallel()
+			generic := ProtectedMutationRoute(
+				"/api/enterprise/"+string(test.owner),
+				PermConfigWrite,
+				"enterprise.update",
+				SensitivitySecret,
+				test.owner,
+				64<<10,
+				http.MethodPost,
+			)
+			if err := ValidateRouteContract(generic); err == nil {
+				t.Fatal("generic config.write unexpectedly owns an isolated resource")
+			}
+
+			isolated := ProtectedMutationRoute(
+				"/api/enterprise/"+string(test.owner),
+				test.permission,
+				"enterprise.update",
+				SensitivitySecret,
+				test.owner,
+				64<<10,
+				http.MethodPost,
+			)
+			if test.owner == ResourceOwnerBreakGlass {
+				isolated = BreakGlassMutationRoute(
+					"/api/enterprise/"+string(test.owner),
+					"enterprise.breakglass",
+					64<<10,
+					10*time.Minute,
+					http.MethodPost,
+				)
+			}
+			if err := ValidateRouteContract(isolated); err != nil {
+				t.Fatalf("isolated permission rejected: %v", err)
+			}
+		})
+	}
+}

--- a/dashboard/backend/auth/schema.go
+++ b/dashboard/backend/auth/schema.go
@@ -22,6 +22,7 @@ const (
 const (
 	PermUsersManage    = "users.manage"
 	PermUsersView      = "users.view"
+	PermSessionRead    = "session.read"
 	PermConfigRead     = "config.read"
 	PermConfigWrite    = "config.write"
 	PermConfigDeploy   = "config.deploy"
@@ -38,13 +39,19 @@ const (
 	PermMlPipeline     = "mlpipeline.manage"
 	PermFeedbackSubmit = "feedback.submit"
 	PermReplayRead     = "replay.read"
+	PermInferenceRun   = "inference.run"
 	PermSecurityManage = "security.manage"
+	PermGrantPublish   = "tenant_grants.publish"
+	PermQuotaPublish   = "tenant_quotas.publish"
+	PermVirtualKeys    = "virtual_keys.manage"
+	PermAuditPolicy    = "audit_policy.manage"
+	PermBreakGlass     = "breakglass.manage"
 )
 
 var DefaultRolePermissions = map[string][]string{
-	RoleAdmin: {PermUsersManage, PermUsersView, PermConfigRead, PermConfigWrite, PermConfigDeploy, PermEvalRead, PermEvalWrite, PermEvalRun, PermTopologyRead, PermLogsRead, PermOpenClawRead, PermOpenClaw, PermMcpRead, PermMcpManage, PermToolsUse, PermMlPipeline, PermFeedbackSubmit, PermReplayRead, PermSecurityManage},
-	RoleWrite: {PermConfigRead, PermConfigWrite, PermConfigDeploy, PermEvalRead, PermEvalWrite, PermEvalRun, PermTopologyRead, PermLogsRead, PermOpenClawRead, PermOpenClaw, PermMcpRead, PermMcpManage, PermToolsUse, PermMlPipeline, PermFeedbackSubmit, PermReplayRead},
-	RoleRead:  {PermConfigRead, PermEvalRead, PermTopologyRead, PermOpenClawRead, PermMcpRead, PermToolsUse, PermReplayRead},
+	RoleAdmin: {PermUsersManage, PermUsersView, PermSessionRead, PermConfigRead, PermConfigWrite, PermConfigDeploy, PermEvalRead, PermEvalWrite, PermEvalRun, PermTopologyRead, PermLogsRead, PermOpenClawRead, PermOpenClaw, PermMcpRead, PermMcpManage, PermToolsUse, PermMlPipeline, PermFeedbackSubmit, PermReplayRead, PermInferenceRun, PermSecurityManage, PermGrantPublish, PermQuotaPublish, PermVirtualKeys, PermAuditPolicy, PermBreakGlass},
+	RoleWrite: {PermSessionRead, PermConfigRead, PermConfigWrite, PermConfigDeploy, PermEvalRead, PermEvalWrite, PermEvalRun, PermTopologyRead, PermLogsRead, PermOpenClawRead, PermOpenClaw, PermMcpRead, PermMcpManage, PermToolsUse, PermMlPipeline, PermFeedbackSubmit, PermReplayRead, PermInferenceRun},
+	RoleRead:  {PermSessionRead, PermConfigRead, PermEvalRead, PermTopologyRead, PermOpenClawRead, PermMcpRead, PermToolsUse, PermReplayRead, PermInferenceRun},
 }
 
 var SupportedRoles = []string{RoleAdmin, RoleWrite, RoleRead}
@@ -57,10 +64,11 @@ var legacyRoleAliases = map[string]string{
 }
 
 var AllPermissions = []string{
-	PermUsersManage, PermUsersView, PermConfigRead, PermConfigWrite, PermConfigDeploy,
+	PermUsersManage, PermUsersView, PermSessionRead, PermConfigRead, PermConfigWrite, PermConfigDeploy,
 	PermEvalRead, PermEvalWrite, PermEvalRun, PermTopologyRead, PermLogsRead, PermOpenClawRead,
 	PermOpenClaw, PermMcpRead, PermMcpManage, PermToolsUse, PermMlPipeline,
-	PermFeedbackSubmit, PermReplayRead, PermSecurityManage,
+	PermFeedbackSubmit, PermReplayRead, PermInferenceRun, PermSecurityManage,
+	PermGrantPublish, PermQuotaPublish, PermVirtualKeys, PermAuditPolicy, PermBreakGlass,
 }
 
 func normalizeRole(raw string) (string, error) {

--- a/dashboard/backend/auth/session_cookie_test.go
+++ b/dashboard/backend/auth/session_cookie_test.go
@@ -31,7 +31,7 @@ func TestAuthenticateRequestAcceptsSessionCookie(t *testing.T) {
 		t.Fatalf("issueToken() error = %v", err)
 	}
 
-	handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := protectedTestHandler(svc, ProtectedRoute("/api/status", PermTopologyRead, SensitivityOperational, ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		ac, ok := AuthFromContext(r)
 		if !ok {
 			t.Fatalf("missing auth context")
@@ -40,7 +40,7 @@ func TestAuthenticateRequestAcceptsSessionCookie(t *testing.T) {
 			t.Fatalf("user id = %q, want %q", ac.UserID, user.ID)
 		}
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	req.AddCookie(&http.Cookie{Name: authSessionCookieName, Value: token})
@@ -153,9 +153,9 @@ func TestLogoutHandlerRevokesSessionToken(t *testing.T) {
 		t.Fatalf("logout status = %d, want %d", logoutRecorder.Code, http.StatusOK)
 	}
 
-	handler := AuthenticateRequest(svc)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := protectedTestHandler(svc, ProtectedRoute("/api/status", PermTopologyRead, SensitivityOperational, ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
-	}))
+	})
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
 	req.AddCookie(&http.Cookie{Name: authSessionCookieName, Value: token})
 	recorder := httptest.NewRecorder()

--- a/dashboard/backend/handlers/canonical_transport.go
+++ b/dashboard/backend/handlers/canonical_transport.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -36,15 +35,6 @@ type setupModeConfig struct {
 type setupConfigFile struct {
 	routerconfig.CanonicalConfig `yaml:",inline"`
 	Setup                        *setupModeConfig `yaml:"setup,omitempty"`
-}
-
-func decodeYAMLTaggedBody[T any](reader io.Reader) (T, error) {
-	var value T
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return value, err
-	}
-	return decodeYAMLTaggedBytes[T](data)
 }
 
 func decodeYAMLTaggedBytes[T any](data []byte) (T, error) {

--- a/dashboard/backend/handlers/config.go
+++ b/dashboard/backend/handlers/config.go
@@ -124,7 +124,7 @@ func UpdateConfigHandler(configPath string, readonlyMode bool, configDir string)
 			return
 		}
 		if err := validateVLLMEndpointAddresses(parsedConfig); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("Config validation failed: %v", err), http.StatusBadRequest)
 			return
 		}
 

--- a/dashboard/backend/handlers/config.go
+++ b/dashboard/backend/handlers/config.go
@@ -81,7 +81,15 @@ func UpdateConfigHandler(configPath string, readonlyMode bool, configDir string)
 			return
 		}
 
-		configData, err := decodeYAMLTaggedBody[routerconfig.CanonicalConfig](r.Body)
+		rawBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+			return
+		}
+		if rejectDatabaseOwnedConfigMutation(w, rawBody) {
+			return
+		}
+		configData, err := decodeYAMLTaggedBytes[routerconfig.CanonicalConfig](rawBody)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
 			return
@@ -129,6 +137,9 @@ func UpdateConfigHandler(configPath string, readonlyMode bool, configDir string)
 			}
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		if err := writeConfigAtomically(configPath, yamlData); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to write config: %v", err), http.StatusInternalServerError)
 			return
@@ -199,6 +210,9 @@ func UpdateRouterDefaultsHandler(configPath string, readonlyMode bool, configDir
 			http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
 			return
 		}
+		if rejectDatabaseOwnedConfigMutation(w, rawPatch) {
+			return
+		}
 		release, lockErr := beginOrdinaryRuntimeConfigMutation(configDir)
 		if lockErr != nil {
 			writeRuntimeConfigMutationError(w, lockErr)
@@ -223,6 +237,9 @@ func UpdateRouterDefaultsHandler(configPath string, readonlyMode bool, configDir
 			return
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		if err := writeConfigAtomically(configPath, yamlData); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to write config: %v", err), http.StatusInternalServerError)
 			return

--- a/dashboard/backend/handlers/config.go
+++ b/dashboard/backend/handlers/config.go
@@ -123,18 +123,9 @@ func UpdateConfigHandler(configPath string, readonlyMode bool, configDir string)
 			http.Error(w, fmt.Sprintf("Config validation failed: %v", err), http.StatusBadRequest)
 			return
 		}
-
-		// Explicitly validate vLLM endpoints (Parse doesn't validate endpoints by default)
-		if len(parsedConfig.VLLMEndpoints) > 0 {
-			for _, endpoint := range parsedConfig.VLLMEndpoints {
-				if endpoint.ProviderProfileName != "" && endpoint.Address == "" {
-					continue
-				}
-				if err := validateEndpointAddress(endpoint.Address); err != nil {
-					http.Error(w, fmt.Sprintf("Config validation failed: vLLM endpoint '%s' address validation failed: %v\n\nSupported formats:\n- IPv4: 192.168.1.1, 127.0.0.1\n- IPv6: ::1, 2001:db8::1\n- DNS names: localhost, example.com, api.example.com\n\nUnsupported formats:\n- Protocol prefixes: http://, https://\n- Paths: /api/v1, /health\n- Ports in address: use 'port' field instead", endpoint.Name, err), http.StatusBadRequest)
-					return
-				}
-			}
+		if err := validateVLLMEndpointAddresses(parsedConfig); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 
 		if rejectRevokedMutation(w, r) {

--- a/dashboard/backend/handlers/config_endpoint_validation.go
+++ b/dashboard/backend/handlers/config_endpoint_validation.go
@@ -84,6 +84,23 @@ func validateEndpointAddress(address string) error {
 	return nil
 }
 
+const vllmEndpointAddressHelp = "Supported formats:\n- IPv4: 192.168.1.1, 127.0.0.1\n- IPv6: ::1, 2001:db8::1\n- DNS names: localhost, example.com, api.example.com\n\nUnsupported formats:\n- Protocol prefixes: http://, https://\n- Paths: /api/v1, /health\n- Ports in address: use 'port' field instead"
+
+func validateVLLMEndpointAddresses(parsed *routerconfig.RouterConfig) error {
+	if parsed == nil {
+		return nil
+	}
+	for _, endpoint := range parsed.VLLMEndpoints {
+		if endpoint.ProviderProfileName != "" && endpoint.Address == "" {
+			continue
+		}
+		if err := validateEndpointAddress(endpoint.Address); err != nil {
+			return fmt.Errorf("Config validation failed: vLLM endpoint '%s' address validation failed: %w\n\n%s", endpoint.Name, err, vllmEndpointAddressHelp)
+		}
+	}
+	return nil
+}
+
 func validateCanonicalEndpointRefs(configData routerconfig.CanonicalConfig) error {
 	for modelIndex, model := range configData.Providers.Models {
 		for backendIndex, backend := range model.BackendRefs {

--- a/dashboard/backend/handlers/config_endpoint_validation.go
+++ b/dashboard/backend/handlers/config_endpoint_validation.go
@@ -95,7 +95,7 @@ func validateVLLMEndpointAddresses(parsed *routerconfig.RouterConfig) error {
 			continue
 		}
 		if err := validateEndpointAddress(endpoint.Address); err != nil {
-			return fmt.Errorf("Config validation failed: vLLM endpoint '%s' address validation failed: %w\n\n%s", endpoint.Name, err, vllmEndpointAddressHelp)
+			return fmt.Errorf("vLLM endpoint '%s' address validation failed: %w\n\n%s", endpoint.Name, err, vllmEndpointAddressHelp)
 		}
 	}
 	return nil

--- a/dashboard/backend/handlers/config_global_raw.go
+++ b/dashboard/backend/handlers/config_global_raw.go
@@ -62,6 +62,9 @@ func UpdateGlobalConfigYAMLHandler(configPath string, readonlyMode bool, configD
 			http.Error(w, fmt.Sprintf("Failed to read request body: %v", err), http.StatusBadRequest)
 			return
 		}
+		if rejectDatabaseOwnedConfigMutation(w, rawBody) {
+			return
+		}
 		release, lockErr := beginOrdinaryRuntimeConfigMutation(configDir)
 		if lockErr != nil {
 			writeRuntimeConfigMutationError(w, lockErr)
@@ -81,6 +84,9 @@ func UpdateGlobalConfigYAMLHandler(configPath string, readonlyMode bool, configD
 			return
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		if err := writeConfigAtomically(configPath, updatedYAML); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to write config: %v", err), http.StatusInternalServerError)
 			return

--- a/dashboard/backend/handlers/config_mutation_ownership.go
+++ b/dashboard/backend/handlers/config_mutation_ownership.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrDatabaseOwnedConfigMutation marks fields whose lifecycle belongs to the
+// auth database rather than config.yaml. Generic config update, compiler,
+// deploy, activation, and rollback bridges must fail before writing them.
+var ErrDatabaseOwnedConfigMutation = errors.New("database-owned resource cannot be mutated through router config")
+
+var databaseOwnedConfigKeys = map[string]string{
+	"tenantgrants": "tenant_grants",
+	"tenantquotas": "tenant_quotas",
+	"quotapolicy":  "tenant_quotas",
+	"budgetpolicy": "tenant_quotas",
+	"virtualkeys":  "virtual_keys",
+	"auditpolicy":  "audit_policy",
+	"breakglass":   "breakglass",
+}
+
+func validateConfigMutationOwnership(data []byte) error {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return nil
+	}
+
+	found := map[string][]string{}
+	collectDatabaseOwnedConfigPaths(&document, nil, found)
+	if len(found) == 0 {
+		return nil
+	}
+
+	owners := make([]string, 0, len(found))
+	for owner := range found {
+		owners = append(owners, owner)
+	}
+	sort.Strings(owners)
+	return fmt.Errorf("%w: %s", ErrDatabaseOwnedConfigMutation, strings.Join(owners, ", "))
+}
+
+func rejectDatabaseOwnedConfigMutation(w http.ResponseWriter, data []byte) bool {
+	err := validateConfigMutationOwnership(data)
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrDatabaseOwnedConfigMutation) {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return true
+	}
+	http.Error(w, fmt.Sprintf("Invalid configuration payload: %v", err), http.StatusBadRequest)
+	return true
+}
+
+func collectDatabaseOwnedConfigPaths(node *yaml.Node, path []string, found map[string][]string) {
+	if node == nil {
+		return
+	}
+	if node.Kind == yaml.DocumentNode {
+		for _, child := range node.Content {
+			collectDatabaseOwnedConfigPaths(child, path, found)
+		}
+		return
+	}
+	if node.Kind == yaml.MappingNode {
+		for index := 0; index+1 < len(node.Content); index += 2 {
+			key := node.Content[index]
+			value := node.Content[index+1]
+			keyPath := appendPath(path, key.Value)
+			if owner, blocked := databaseOwnedConfigKeys[normalizeOwnershipKey(key.Value)]; blocked {
+				found[owner] = append(found[owner], strings.Join(keyPath, "."))
+			}
+			collectDatabaseOwnedConfigPaths(value, keyPath, found)
+		}
+		return
+	}
+	for _, child := range node.Content {
+		collectDatabaseOwnedConfigPaths(child, path, found)
+	}
+}
+
+func appendPath(path []string, value string) []string {
+	next := make([]string, len(path), len(path)+1)
+	copy(next, path)
+	return append(next, value)
+}
+
+func normalizeOwnershipKey(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "_", "")
+	return strings.ReplaceAll(value, "-", "")
+}

--- a/dashboard/backend/handlers/config_mutation_ownership_test.go
+++ b/dashboard/backend/handlers/config_mutation_ownership_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteConfigAtomicallyRejectsDatabaseOwnedResources(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	original := []byte("version: v0.3\nrouting: {}\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("write original config: %v", err)
+	}
+
+	blocked := []byte(`version: v0.3
+routing: {}
+enterprise:
+  tenant_grants: [{tenant: acme, role: admin}]
+  budgetPolicy: {daily: 1}
+  virtual-keys: [{name: hidden}]
+  audit_policy: {retention: disabled}
+`)
+	err := writeConfigAtomically(configPath, blocked)
+	if !errors.Is(err, ErrDatabaseOwnedConfigMutation) {
+		t.Fatalf("write error = %v, want %v", err, ErrDatabaseOwnedConfigMutation)
+	}
+
+	after, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("read config after rejected write: %v", readErr)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("config changed after rejected enterprise mutation:\n%s", after)
+	}
+}
+
+func TestWriteConfigAtomicallyAllowsRouterOwnedConfig(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	configData := []byte("version: v0.3\nrouting: {}\n")
+	if err := writeConfigAtomically(configPath, configData); err != nil {
+		t.Fatalf("write router config: %v", err)
+	}
+}

--- a/dashboard/backend/handlers/deploy.go
+++ b/dashboard/backend/handlers/deploy.go
@@ -86,6 +86,10 @@ func DeployPreviewHandler(configPath string) http.HandlerFunc {
 			http.Error(w, "YAML content is required", http.StatusBadRequest)
 			return
 		}
+		if rejectDatabaseOwnedConfigMutation(w, []byte(req.YAML)) ||
+			(strings.TrimSpace(req.BaseYAML) != "" && rejectDatabaseOwnedConfigMutation(w, []byte(req.BaseYAML))) {
+			return
+		}
 
 		if _, err := decodeYAMLTaggedBytes[routingFragmentDocument]([]byte(req.YAML)); err != nil {
 			w.Header().Set("Content-Type", "application/json")
@@ -157,10 +161,14 @@ func DeployHandler(configPath string, readonlyMode bool, configDir string) http.
 			http.Error(w, "YAML content is required", http.StatusBadRequest)
 			return
 		}
+		if rejectDatabaseOwnedConfigMutation(w, []byte(req.YAML)) ||
+			(strings.TrimSpace(req.BaseYAML) != "" && rejectDatabaseOwnedConfigMutation(w, []byte(req.BaseYAML))) {
+			return
+		}
 
 		log.Printf("[Deploy] Received: YAML=%d bytes, DSL=%d bytes", len(req.YAML), len(req.DSL))
 
-		deployDirectWrite(w, configPath, configDir, req)
+		deployDirectWrite(w, r, configPath, configDir, req)
 	}
 }
 
@@ -196,7 +204,7 @@ func RollbackHandler(configPath string, readonlyMode bool, configDir string) htt
 			return
 		}
 
-		rollbackDirectWrite(w, configPath, configDir, rollbackReq.Version)
+		rollbackDirectWrite(w, r, configPath, configDir, rollbackReq.Version)
 	}
 }
 
@@ -215,7 +223,7 @@ func ConfigVersionsHandler(configPath string) http.HandlerFunc {
 
 // ==================== Deploy: write canonical config.yaml ====================
 
-func deployDirectWrite(w http.ResponseWriter, configPath string, configDir string, req DeployRequest) {
+func deployDirectWrite(w http.ResponseWriter, r *http.Request, configPath string, configDir string, req DeployRequest) {
 	release, err := beginOrdinaryRuntimeConfigMutation(configDir)
 	if err != nil {
 		writeRuntimeConfigMutationError(w, err)
@@ -268,6 +276,9 @@ func deployDirectWrite(w http.ResponseWriter, configPath string, configDir strin
 	archiveDeployDSL(configDir, req.DSL)
 
 	// Step 5: Atomic write to config.yaml
+	if rejectRevokedMutation(w, r) {
+		return
+	}
 	if err := writeConfigAtomically(configPath, yamlBytes); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to write config: %v", err), http.StatusInternalServerError)
 		return
@@ -470,7 +481,7 @@ func looksLikeFullCanonicalDeployBase(raw []byte) (bool, error) {
 	return false, nil
 }
 
-func rollbackDirectWrite(w http.ResponseWriter, configPath string, configDir string, version string) {
+func rollbackDirectWrite(w http.ResponseWriter, r *http.Request, configPath string, configDir string, version string) {
 	release, err := beginOrdinaryRuntimeConfigMutation(configDir)
 	if err != nil {
 		writeRuntimeConfigMutationError(w, err)
@@ -505,6 +516,9 @@ func rollbackDirectWrite(w http.ResponseWriter, configPath string, configDir str
 	existingData := snapshotCurrentConfigBeforeRollback(configPath, configDir)
 
 	// Atomic write to config.yaml
+	if rejectRevokedMutation(w, r) {
+		return
+	}
 	if err := writeConfigAtomically(configPath, backupData); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to write config: %v", err), http.StatusInternalServerError)
 		return

--- a/dashboard/backend/handlers/live_permission.go
+++ b/dashboard/backend/handlers/live_permission.go
@@ -1,0 +1,11 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
+)
+
+func rejectRevokedMutation(w http.ResponseWriter, r *http.Request) bool {
+	return auth.RejectRevokedMutation(w, r)
+}

--- a/dashboard/backend/handlers/live_permission_test.go
+++ b/dashboard/backend/handlers/live_permission_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
+)
+
+func TestUpdateConfigHandlerRejectsRevokedPermissionBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := createValidTestConfig(t, tempDir)
+	original, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read original config: %v", err)
+	}
+
+	bodyBytes, err := json.Marshal(canonicalConfigBody("10.0.0.9:8000"))
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/router/config/update", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.WithPermissionRevalidator(req.Context(), func(context.Context) error {
+		return errors.New("permission revoked")
+	}))
+	recorder := httptest.NewRecorder()
+
+	UpdateConfigHandler(configPath, false, "")(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusForbidden, recorder.Body.String())
+	}
+	current, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after rejected update: %v", err)
+	}
+	if string(current) != string(original) {
+		t.Fatal("config file was mutated after permission revocation")
+	}
+}

--- a/dashboard/backend/handlers/mcp.go
+++ b/dashboard/backend/handlers/mcp.go
@@ -114,6 +114,9 @@ func (h *MCPHandler) CreateServerHandler() http.HandlerFunc {
 			return
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		if err := h.manager.AddServer(&config); err != nil {
 			writeMCPInternalError(w, "Add server", err)
 			return
@@ -157,6 +160,9 @@ func (h *MCPHandler) UpdateServerHandler() http.HandlerFunc {
 
 		config.ID = id
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		if err := h.manager.UpdateServer(&config); err != nil {
 			writeMCPInternalError(w, "Update server", err)
 			return
@@ -196,6 +202,9 @@ func (h *MCPHandler) DeleteServerHandler() http.HandlerFunc {
 			return
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		if err := h.manager.DeleteServer(id); err != nil {
 			writeMCPInternalError(w, "Delete server", err)
 			return
@@ -231,6 +240,9 @@ func (h *MCPHandler) ConnectServerHandler() http.HandlerFunc {
 			return
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		// Use independent context with timeout instead of HTTP request context
 		// This prevents MCP server process from being cancelled when HTTP request ends
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -271,6 +283,9 @@ func (h *MCPHandler) DisconnectServerHandler() http.HandlerFunc {
 			return
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		if err := h.manager.Disconnect(id); err != nil {
 			writeMCPInternalError(w, "Disconnect server", err)
 			return

--- a/dashboard/backend/handlers/mcp_config_view_test.go
+++ b/dashboard/backend/handlers/mcp_config_view_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/mcp"
 )
 
@@ -98,13 +97,6 @@ func TestMCPReadResponsesRedactStoredServerSecrets(t *testing.T) {
 		t.Fatal(addErr)
 	}
 	handler := NewMCPHandler(manager, false)
-
-	if got := auth.RequiredPermission(http.MethodGet, "/api/mcp/servers"); got != auth.PermMcpRead {
-		t.Fatalf("list permission = %q, want %q", got, auth.PermMcpRead)
-	}
-	if got := auth.RequiredPermission(http.MethodGet, "/api/mcp/servers/"+config.ID+"/status"); got != auth.PermMcpRead {
-		t.Fatalf("status permission = %q, want %q", got, auth.PermMcpRead)
-	}
 
 	tests := []struct {
 		name    string

--- a/dashboard/backend/handlers/recipe_packages.go
+++ b/dashboard/backend/handlers/recipe_packages.go
@@ -196,6 +196,9 @@ func (h *RecipeHandler) ImportPackage(w http.ResponseWriter, r *http.Request) {
 		writePackageError(w, recipe.NewPackageError(recipe.ErrorInvalidRequest, http.StatusBadRequest, "Recipe import request is invalid.", err))
 		return
 	}
+	if rejectRevokedMutation(w, r) {
+		return
+	}
 	result, created, err := h.packages.Import(r.Context(), request)
 	if err != nil {
 		writePackageError(w, err)
@@ -229,6 +232,9 @@ func (h *RecipeHandler) ActivatePackage(w http.ResponseWriter, r *http.Request) 
 		writePackageError(w, recipe.NewPackageError(recipe.ErrorInvalidRequest, http.StatusBadRequest, "Recipe activation request is invalid.", err))
 		return
 	}
+	if rejectRevokedMutation(w, r) {
+		return
+	}
 	result, err := h.activator.Activate(r.Context(), request)
 	if err != nil {
 		writePackageError(w, err)
@@ -259,6 +265,9 @@ func (h *RecipeHandler) DeactivatePackage(w http.ResponseWriter, r *http.Request
 			writePackageError(w, recipe.NewPackageError(recipe.ErrorInvalidRequest, http.StatusBadRequest, "Recipe deactivation request is invalid.", err))
 			return
 		}
+	}
+	if rejectRevokedMutation(w, r) {
+		return
 	}
 	result, err := h.activator.Deactivate(r.Context(), request)
 	if err != nil {

--- a/dashboard/backend/handlers/runtime_config_apply.go
+++ b/dashboard/backend/handlers/runtime_config_apply.go
@@ -67,6 +67,9 @@ func formatRuntimeApplyError(prefix string, err error) string {
 }
 
 func writeConfigAtomically(configPath string, yamlData []byte) error {
+	if err := validateConfigMutationOwnership(yamlData); err != nil {
+		return err
+	}
 	tmpConfigFile := configPath + ".tmp"
 	if err := os.WriteFile(tmpConfigFile, yamlData, 0o644); err != nil {
 		return err

--- a/dashboard/backend/handlers/security_policy.go
+++ b/dashboard/backend/handlers/security_policy.go
@@ -253,6 +253,10 @@ func HandleUpdateSecurityPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if rejectRevokedMutation(w, r) {
+		return
+	}
+
 	policy.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	fragment := GenerateRouterFragment(&policy)
 	var release func()

--- a/dashboard/backend/handlers/setup.go
+++ b/dashboard/backend/handlers/setup.go
@@ -221,6 +221,9 @@ func SetupActivateHandler(
 			log.Printf("Warning: failed to back up current config before setup activation: %v", backupErr)
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		tmpConfigFile := configPath + ".tmp"
 		if writeErr := os.WriteFile(tmpConfigFile, yamlData, 0o644); writeErr != nil {
 			http.Error(w, fmt.Sprintf("Failed to write config: %v", writeErr), http.StatusInternalServerError)
@@ -300,6 +303,9 @@ func SetupImportRemoteHandler(configPath string, setupResolver *setupmode.Resolv
 			return
 		}
 
+		if rejectRevokedMutation(w, r) {
+			return
+		}
 		remoteReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, importURL, nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to create remote import request: %v", err), http.StatusBadRequest)

--- a/dashboard/backend/router/auth_routes.go
+++ b/dashboard/backend/router/auth_routes.go
@@ -25,11 +25,11 @@ var dashboardAuthRouteSpecs = []authRouteSpec{
 
 const authUnavailableResponse = `{"error":"Service not available","message":"Authentication service is not configured"}`
 
-func setupAuthRoutes(mux *http.ServeMux, cfg *config.Config, setupResolver *setupmode.Resolver) *auth.Service {
+func setupAuthRoutes(routes *auth.PolicyMux, cfg *config.Config, setupResolver *setupmode.Resolver) *auth.Service {
 	store, err := auth.NewStore(cfg.AuthDBPath)
 	if err != nil {
 		log.Printf("failed to init auth store: %v", err)
-		registerAuthUnavailableRoutes(mux)
+		registerAuthUnavailableRoutes(routes)
 		return nil
 	}
 
@@ -53,24 +53,24 @@ func setupAuthRoutes(mux *http.ServeMux, cfg *config.Config, setupResolver *setu
 		log.Printf("failed to ensure bootstrap admin: %v", err)
 	}
 
-	registerAuthProxyRoutes(mux, authSvc)
-	auth.RegisterAdminRoutes(mux, authSvc)
+	registerAuthProxyRoutes(routes, authSvc)
+	auth.RegisterAdminRoutes(routes, authSvc)
 	return authSvc
 }
 
-func registerAuthUnavailableRoutes(mux *http.ServeMux) {
+func registerAuthUnavailableRoutes(routes *auth.PolicyMux) {
 	for _, spec := range dashboardAuthRouteSpecs {
-		registerAuthMethodRoute(mux, spec.path, spec.method, func(w http.ResponseWriter, r *http.Request) {
+		registerAuthMethodRoute(routes, spec.path, spec.method, func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, authUnavailableResponse, http.StatusServiceUnavailable)
 		})
 	}
 }
 
-func registerAuthProxyRoutes(mux *http.ServeMux, authSvc *auth.Service) {
+func registerAuthProxyRoutes(routes *auth.PolicyMux, authSvc *auth.Service) {
 	authRoutes := auth.AuthRoutes(authSvc)
 	for _, spec := range dashboardAuthRouteSpecs {
 		path := spec.path
-		registerAuthMethodRoute(mux, path, spec.method, func(w http.ResponseWriter, r *http.Request) {
+		registerAuthMethodRoute(routes, path, spec.method, func(w http.ResponseWriter, r *http.Request) {
 			cloneReq := *r
 			cloneURL := *r.URL
 			cloneURL.Path = path
@@ -81,7 +81,7 @@ func registerAuthProxyRoutes(mux *http.ServeMux, authSvc *auth.Service) {
 }
 
 func registerAuthMethodRoute(
-	mux *http.ServeMux,
+	routes *auth.PolicyMux,
 	path string,
 	method string,
 	handler http.HandlerFunc,
@@ -93,14 +93,26 @@ func registerAuthMethodRoute(
 		}
 		handler(w, r)
 	}
-	mux.HandleFunc(path, wrapped)
-	mux.HandleFunc(path+"/", wrapped)
+	contract := auth.PublicRoute(path, method)
+	if path == "/api/auth/me" {
+		contract = auth.ProtectedRoute(
+			path,
+			auth.PermSessionRead,
+			auth.SensitivitySensitive,
+			auth.ResourceOwnerAuth,
+			method,
+		)
+	}
+	routes.HandleFunc(contract, wrapped)
+	slashContract := contract
+	slashContract.Pattern = path + "/"
+	routes.HandleFunc(slashContract, wrapped)
 }
 
-func wrapWithAuth(mux *http.ServeMux, authSvc *auth.Service) *http.ServeMux {
+func wrapWithAuth(routes *auth.PolicyMux, authSvc *auth.Service) *http.ServeMux {
 	wrappedMux := http.NewServeMux()
 	if authSvc != nil {
-		wrappedMux.Handle("/", auth.AuthenticateRequest(authSvc)(mux))
+		wrappedMux.Handle("/", auth.AuthenticateRequest(authSvc, routes)(routes))
 		return wrappedMux
 	}
 	// authSvc is nil only when the auth store failed to initialize. Fail
@@ -110,6 +122,6 @@ func wrapWithAuth(mux *http.ServeMux, authSvc *auth.Service) *http.ServeMux {
 	// static frontend remain reachable so the dashboard can surface the
 	// misconfiguration.
 	log.Printf("WARNING: auth service unavailable; authenticated routes are failing closed (503). Check AuthDBPath/JWT configuration.")
-	wrappedMux.Handle("/", auth.ServiceUnavailableGuard()(mux))
+	wrappedMux.Handle("/", auth.ServiceUnavailableGuard(routes)(routes))
 	return wrappedMux
 }

--- a/dashboard/backend/router/auth_routes_test.go
+++ b/dashboard/backend/router/auth_routes_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
 )
 
 // When the auth service fails to initialize (authSvc == nil), wrapWithAuth must
@@ -18,15 +20,19 @@ func TestWrapWithAuthFailsClosedWhenAuthUnavailable(t *testing.T) {
 	protectedHit := false
 	publicHit := false
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/router/config", func(w http.ResponseWriter, _ *http.Request) {
+	mux := auth.NewPolicyMux()
+	mux.HandleFunc(auth.ProtectedRoute("/api/router/config", auth.PermConfigRead, auth.SensitivitySecret, auth.ResourceOwnerConfig, http.MethodGet), func(w http.ResponseWriter, _ *http.Request) {
 		protectedHit = true
 		w.WriteHeader(http.StatusOK)
 	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		publicHit = true
+	mux.HandleFunc(auth.ProtectedRoute("/api/admin/users", auth.PermUsersView, auth.SensitivitySensitive, auth.ResourceOwnerAuth, http.MethodGet), func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("admin handler executed while auth was unavailable")
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFallback("/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		publicHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
 
 	handler := wrapWithAuth(mux, nil) // nil => auth store failed to initialize
 
@@ -57,10 +63,6 @@ func TestWrapWithAuthFailsClosedWhenAuthUnavailable(t *testing.T) {
 	})
 
 	t.Run("protected admin route denied", func(t *testing.T) {
-		mux.HandleFunc("/api/admin/users", func(w http.ResponseWriter, _ *http.Request) {
-			t.Error("admin handler executed while auth was unavailable")
-			w.WriteHeader(http.StatusOK)
-		})
 		req := httptest.NewRequest(http.MethodGet, "/api/admin/users", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)

--- a/dashboard/backend/router/core_routes.go
+++ b/dashboard/backend/router/core_routes.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/evaluation"
 	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
@@ -30,25 +31,25 @@ type configRouteOptions struct {
 
 // setupResolver is required, not an option, because the setup routes have no
 // fallback source of truth for setup mode.
-func registerCoreRoutes(mux *http.ServeMux, cfg *config.Config, setupResolver *setupmode.Resolver, routeOptions ...coreRouteOptions) {
+func registerCoreRoutes(routes *auth.PolicyMux, cfg *config.Config, setupResolver *setupmode.Resolver, routeOptions ...coreRouteOptions) {
 	options := coreRouteOptions{}
 	if len(routeOptions) > 0 {
 		options = routeOptions[0]
 	}
 	store := selectedRecipeStore(cfg, []*recipe.Store{options.recipeStore})
-	registerHealthAndSetupRoutes(mux, cfg, setupResolver)
-	registerConfigRoutes(mux, cfg, configRouteOptions{
+	registerHealthAndSetupRoutes(routes, cfg, setupResolver)
+	registerConfigRoutes(routes, cfg, configRouteOptions{
 		credentialStore:          store,
 		modelVerificationAuditor: options.modelVerificationAuditor,
 	})
-	registerToolRoutes(mux, cfg)
-	registerStatusRoutes(mux, cfg, store)
-	registerTopologyRoutes(mux, cfg, store)
-	registerRecipeRoutes(mux, cfg, store)
-	registerSecurityPolicyRoutes(mux, cfg)
+	registerToolRoutes(routes, cfg)
+	registerStatusRoutes(routes, cfg, store)
+	registerTopologyRoutes(routes, cfg, store)
+	registerRecipeRoutes(routes, cfg, store)
+	registerSecurityPolicyRoutes(routes, cfg)
 }
 
-func registerRecipeRoutes(mux *http.ServeMux, cfg *config.Config, stores ...*recipe.Store) {
+func registerRecipeRoutes(routes *auth.PolicyMux, cfg *config.Config, stores ...*recipe.Store) {
 	recipeDir := dashboardActiveRecipeDirectory(cfg)
 	store := selectedRecipeStore(cfg, stores)
 	service := recipe.NewService(recipe.Options{
@@ -69,22 +70,53 @@ func registerRecipeRoutes(mux *http.ServeMux, cfg *config.Config, stores ...*rec
 		RuntimeConfigWritable: cfg.RuntimeConfigWritable,
 		RecipeStoreWritable:   cfg.RecipeStoreWritable,
 	}))
-	mux.HandleFunc("/api/recipe", handler.Descriptor)
-	mux.HandleFunc("/api/recipe/probes", handler.Probes)
-	mux.HandleFunc("/api/recipe/probes/", handler.ProbeAction)
-	mux.HandleFunc("/api/recipe/packages", handler.Packages)
-	mux.HandleFunc("/api/recipe/packages/", handler.Packages)
-	mux.HandleFunc("/api/recipe/import", handler.ImportPackage)
-	mux.HandleFunc("/api/recipe/import/", handler.ImportPackage)
-	mux.HandleFunc("/api/recipe/activate", handler.ActivatePackage)
-	mux.HandleFunc("/api/recipe/activate/", handler.ActivatePackage)
-	mux.HandleFunc("/api/recipe/activate/preview", handler.PreviewPackageActivation)
-	mux.HandleFunc("/api/recipe/activate/preview/", handler.PreviewPackageActivation)
-	mux.HandleFunc("/api/recipe/deactivate", handler.DeactivatePackage)
-	mux.HandleFunc("/api/recipe/deactivate/", handler.DeactivatePackage)
-	mux.HandleFunc("/api/recipe/deactivate/preview", handler.PreviewPackageDeactivation)
-	mux.HandleFunc("/api/recipe/deactivate/preview/", handler.PreviewPackageDeactivation)
+	routes.HandleFunc(auth.ProtectedRoute("/api/recipe", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handler.Descriptor)
+	routes.HandleFunc(auth.ProtectedRoute("/api/recipe/probes", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handler.Probes)
+	routes.HandleFunc(
+		auth.Route(
+			"/api/recipe/probes/",
+			auth.ReadPolicy(http.MethodGet, auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig),
+			auth.MutationPolicy(http.MethodPost, auth.PermTopologyRead, "recipe.probe", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 2<<20),
+		),
+		handler.ProbeAction,
+	)
+	routes.HandleFunc(auth.ProtectedRoute("/api/recipe/packages", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handler.Packages)
+	routes.HandleFunc(auth.ProtectedRoute("/api/recipe/packages/", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handler.Packages)
+	registerRecipeMutationRoutes(routes, handler)
 	log.Printf("Active Recipe API endpoints registered: /api/recipe, /api/recipe/probes/*, /api/recipe/packages, /api/recipe/import, /api/recipe/activate/preview, /api/recipe/activate, /api/recipe/deactivate/preview, /api/recipe/deactivate")
+}
+
+func registerRecipeMutationRoutes(routes *auth.PolicyMux, handler *handlers.RecipeHandler) {
+	const maxRecipePackageBytes int64 = 32 << 20
+	for _, route := range []struct {
+		pattern string
+		action  string
+		handler http.HandlerFunc
+	}{
+		{pattern: "/api/recipe/import", action: "recipe.import", handler: handler.ImportPackage},
+		{pattern: "/api/recipe/import/", action: "recipe.import", handler: handler.ImportPackage},
+		{pattern: "/api/recipe/activate", action: "recipe.activate", handler: handler.ActivatePackage},
+		{pattern: "/api/recipe/activate/", action: "recipe.activate", handler: handler.ActivatePackage},
+		{pattern: "/api/recipe/activate/preview", action: "recipe.activate.preview", handler: handler.PreviewPackageActivation},
+		{pattern: "/api/recipe/activate/preview/", action: "recipe.activate.preview", handler: handler.PreviewPackageActivation},
+		{pattern: "/api/recipe/deactivate", action: "recipe.deactivate", handler: handler.DeactivatePackage},
+		{pattern: "/api/recipe/deactivate/", action: "recipe.deactivate", handler: handler.DeactivatePackage},
+		{pattern: "/api/recipe/deactivate/preview", action: "recipe.deactivate.preview", handler: handler.PreviewPackageDeactivation},
+		{pattern: "/api/recipe/deactivate/preview/", action: "recipe.deactivate.preview", handler: handler.PreviewPackageDeactivation},
+	} {
+		routes.HandleFunc(
+			auth.ProtectedMutationRoute(
+				route.pattern,
+				auth.PermConfigDeploy,
+				route.action,
+				auth.SensitivitySensitive,
+				auth.ResourceOwnerConfig,
+				maxRecipePackageBytes,
+				http.MethodPost,
+			),
+			route.handler,
+		)
+	}
 }
 
 func recoverRecipeActivationOnStartup(cfg *config.Config, recover func(context.Context) error) {
@@ -97,10 +129,14 @@ func recoverRecipeActivationOnStartup(cfg *config.Config, recover func(context.C
 	}
 }
 
-func registerSecurityPolicyRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerSecurityPolicyRoutes(routes *auth.PolicyMux, cfg *config.Config) {
 	runtimeConfigReadonly := cfg.ReadonlyMode || !cfg.RuntimeConfigWritable
 	handlers.SetSecurityPolicyConfigPaths(cfg.AbsConfigPath, cfg.ConfigDir)
-	mux.HandleFunc("/api/security/policy", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.Route(
+		"/api/security/policy",
+		auth.ReadPolicy(http.MethodGet, auth.PermConfigRead, auth.SensitivitySensitive, auth.ResourceOwnerConfig),
+		auth.MutationPolicy(http.MethodPut, auth.PermSecurityManage, "security.policy.update", auth.SensitivitySecret, auth.ResourceOwnerConfig, 4<<20),
+	), func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
 			handlers.HandleGetSecurityPolicy(w, r)
@@ -114,7 +150,15 @@ func registerSecurityPolicyRoutes(mux *http.ServeMux, cfg *config.Config) {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
-	mux.HandleFunc("/api/security/policy/preview", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedMutationRoute(
+		"/api/security/policy/preview",
+		auth.PermSecurityManage,
+		"security.policy.preview",
+		auth.SensitivitySecret,
+		auth.ResourceOwnerConfig,
+		4<<20,
+		http.MethodPost,
+	), func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
 			if runtimeConfigReadonly {
@@ -129,68 +173,120 @@ func registerSecurityPolicyRoutes(mux *http.ServeMux, cfg *config.Config) {
 	log.Printf("Security Policy API endpoints registered: /api/security/policy, /api/security/policy/preview")
 }
 
-func registerHealthAndSetupRoutes(mux *http.ServeMux, cfg *config.Config, setupResolver *setupmode.Resolver) {
+func registerHealthAndSetupRoutes(routes *auth.PolicyMux, cfg *config.Config, setupResolver *setupmode.Resolver) {
 	runtimeConfigReadonly := cfg.ReadonlyMode || !cfg.RuntimeConfigWritable
-	mux.HandleFunc("/healthz", handlers.HealthCheck)
-	mux.HandleFunc("/api/settings", handlers.SettingsHandler(cfg, setupResolver))
-	mux.HandleFunc("/api/setup/state", handlers.SetupStateHandler(cfg.AbsConfigPath, setupResolver))
-	mux.HandleFunc("/api/setup/import-remote", handlers.SetupImportRemoteHandler(cfg.AbsConfigPath, setupResolver))
-	mux.HandleFunc("/api/setup/validate", handlers.SetupValidateHandler(cfg.AbsConfigPath, setupResolver))
-	mux.HandleFunc("/api/setup/activate", handlers.SetupActivateHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir, setupResolver))
-	mux.HandleFunc("/api/setup/presets", handlers.PresetsHandler())
-	mux.HandleFunc("/api/setup/presets/delta", handlers.PresetDeltaHandler())
+	routes.HandleFunc(auth.PublicRoute("/healthz", http.MethodGet), handlers.HealthCheck)
+	routes.HandleFunc(auth.ProtectedRoute("/api/settings", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handlers.SettingsHandler(cfg, setupResolver))
+	routes.HandleFunc(auth.PublicRoute("/api/setup/state", http.MethodGet), handlers.SetupStateHandler(cfg.AbsConfigPath, setupResolver))
+	routes.HandleFunc(
+		auth.ProtectedMutationRoute("/api/setup/import-remote", auth.PermConfigWrite, "setup.import_remote", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 64<<10, http.MethodPost),
+		handlers.SetupImportRemoteHandler(cfg.AbsConfigPath, setupResolver),
+	)
+	routes.HandleFunc(
+		auth.ProtectedBoundedRoute("/api/setup/validate", auth.PermConfigWrite, auth.SensitivitySensitive, auth.ResourceOwnerConfig, 16<<20, http.MethodPost),
+		handlers.SetupValidateHandler(cfg.AbsConfigPath, setupResolver),
+	)
+	routes.HandleFunc(
+		auth.ProtectedMutationRoute("/api/setup/activate", auth.PermConfigDeploy, "setup.activate", auth.SensitivitySecret, auth.ResourceOwnerConfig, 16<<20, http.MethodPost),
+		handlers.SetupActivateHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir, setupResolver),
+	)
+	routes.HandleFunc(auth.ProtectedRoute("/api/setup/presets", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handlers.PresetsHandler())
+	routes.HandleFunc(auth.ProtectedBoundedRoute("/api/setup/presets/delta", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, 2<<20, http.MethodPost), handlers.PresetDeltaHandler())
 }
 
-func registerConfigRoutes(mux *http.ServeMux, cfg *config.Config, routeOptions ...configRouteOptions) {
+func registerConfigRoutes(routes *auth.PolicyMux, cfg *config.Config, routeOptions ...configRouteOptions) {
 	options := configRouteOptions{}
 	if len(routeOptions) > 0 {
 		options = routeOptions[0]
 	}
 	runtimeConfigReadonly := cfg.ReadonlyMode || !cfg.RuntimeConfigWritable
-	mux.HandleFunc("/api/models/catalog", handlers.ModelCatalogHandler(handlers.NewCLIModelCatalogSource(cfg.PythonPath)))
-	mux.HandleFunc("/api/models/verify", handlers.ModelVerificationHandler(cfg.AbsConfigPath, options.modelVerificationAuditor))
-	mux.HandleFunc("/api/router/config/all", handlers.ConfigHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/yaml", handlers.ConfigYAMLHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/update", handlers.UpdateConfigHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
-	mux.HandleFunc("/api/router/config/deploy/preview", handlers.DeployPreviewHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/deploy", handlers.DeployHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
-	mux.HandleFunc("/api/router/config/rollback", handlers.RollbackHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
-	mux.HandleFunc("/api/router/config/versions", handlers.ConfigVersionsHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/deployments", handlers.ConfigDeploymentsHandler())
-	mux.HandleFunc("/api/router/config/deployments/", handlers.ConfigDeploymentDetailHandler())
-	mux.HandleFunc("/api/router/config/active-projection", handlers.ActiveConfigProjectionHandler())
-	mux.HandleFunc("/api/router/config/nl/verify", handlers.BuilderNLVerifyHandler(cfg.AbsConfigPath, cfg.EnvoyURL))
-	mux.HandleFunc("/api/router/config/nl/generate/stream", handlers.BuilderNLGenerateStreamHandler(cfg.AbsConfigPath, cfg.EnvoyURL))
-	mux.HandleFunc("/api/router/config/nl/generate", handlers.BuilderNLGenerateHandler(cfg.AbsConfigPath, cfg.EnvoyURL))
+	routes.HandleFunc(auth.ProtectedRoute("/api/models/catalog", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handlers.ModelCatalogHandler(handlers.NewCLIModelCatalogSource(cfg.PythonPath)))
+	routes.HandleFunc(
+		auth.ProtectedDelegatedAuditRoute("/api/models/verify", auth.PermEvalRun, "model.inference_verify", auth.SensitivitySensitive, auth.ResourceOwnerInference, 2<<20, http.MethodPost),
+		handlers.ModelVerificationHandler(cfg.AbsConfigPath, options.modelVerificationAuditor),
+	)
+	registerConfigReadRoutes(routes, cfg)
+	registerConfigMutationRoutes(routes, cfg, runtimeConfigReadonly)
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/router/config/deploy/preview", auth.PermConfigDeploy, "config.deploy_preview", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 16<<20, http.MethodPost), handlers.DeployPreviewHandler(cfg.AbsConfigPath))
+	routes.HandleFunc(auth.ProtectedRoute("/api/router/config/versions", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handlers.ConfigVersionsHandler(cfg.AbsConfigPath))
+	routes.HandleFunc(auth.ProtectedRoute("/api/router/config/deployments", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handlers.ConfigDeploymentsHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/router/config/deployments/", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), handlers.ConfigDeploymentDetailHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/router/config/active-projection", auth.PermConfigRead, auth.SensitivitySensitive, auth.ResourceOwnerConfig, http.MethodGet), handlers.ActiveConfigProjectionHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/router/config/nl/verify", auth.PermConfigWrite, "config.nl.verify", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 2<<20, http.MethodPost), handlers.BuilderNLVerifyHandler(cfg.AbsConfigPath, cfg.EnvoyURL))
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/router/config/nl/generate/stream", auth.PermConfigWrite, "config.nl.generate_stream", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 2<<20, http.MethodPost), handlers.BuilderNLGenerateStreamHandler(cfg.AbsConfigPath, cfg.EnvoyURL))
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/router/config/nl/generate", auth.PermConfigWrite, "config.nl.generate", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 2<<20, http.MethodPost), handlers.BuilderNLGenerateHandler(cfg.AbsConfigPath, cfg.EnvoyURL))
 	log.Printf("Config API endpoints registered: /api/models/catalog, /api/models/verify, /api/router/config/all, /api/router/config/yaml, /api/router/config/update, /api/router/config/nl/verify, /api/router/config/nl/generate/stream, /api/router/config/nl/generate, /api/router/config/deploy, /api/router/config/deploy/preview, /api/router/config/rollback, /api/router/config/versions, /api/router/config/deployments, /api/router/config/active-projection")
 
-	mux.HandleFunc("/api/router/config/global", handlers.RouterDefaultsHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/global/update", handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
-	mux.HandleFunc("/api/router/config/global/raw", handlers.GlobalConfigYAMLHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/global/raw/update", handlers.UpdateGlobalConfigYAMLHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
-	mux.HandleFunc("/api/router/config/defaults", handlers.RouterDefaultsHandler(cfg.AbsConfigPath))
-	mux.HandleFunc("/api/router/config/defaults/update", handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
+	routes.HandleFunc(auth.ProtectedRoute("/api/router/config/global", auth.PermConfigRead, auth.SensitivitySensitive, auth.ResourceOwnerConfig, http.MethodGet), handlers.RouterDefaultsHandler(cfg.AbsConfigPath))
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/router/config/global/update", auth.PermConfigWrite, "config.global.update", auth.SensitivitySecret, auth.ResourceOwnerConfig, 16<<20, http.MethodPost, http.MethodPut), handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
+	routes.HandleFunc(auth.ProtectedRoute("/api/router/config/global/raw", auth.PermConfigRead, auth.SensitivitySecret, auth.ResourceOwnerConfig, http.MethodGet), handlers.GlobalConfigYAMLHandler(cfg.AbsConfigPath))
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/router/config/global/raw/update", auth.PermConfigWrite, "config.global_raw.update", auth.SensitivitySecret, auth.ResourceOwnerConfig, 16<<20, http.MethodPost, http.MethodPut), handlers.UpdateGlobalConfigYAMLHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
+	routes.HandleFunc(auth.ProtectedRoute("/api/router/config/defaults", auth.PermConfigRead, auth.SensitivitySensitive, auth.ResourceOwnerConfig, http.MethodGet), handlers.RouterDefaultsHandler(cfg.AbsConfigPath))
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/router/config/defaults/update", auth.PermConfigWrite, "config.defaults.update", auth.SensitivitySecret, auth.ResourceOwnerConfig, 16<<20, http.MethodPost, http.MethodPut), handlers.UpdateRouterDefaultsHandler(cfg.AbsConfigPath, runtimeConfigReadonly, cfg.ConfigDir))
 	store := selectedRecipeStore(cfg, []*recipe.Store{options.credentialStore})
-	mux.HandleFunc("/api/router/config/kbs", handlers.RouterClassifierProxyHandler(cfg.RouterAPIURL, cfg.ReadonlyMode, store))
-	mux.HandleFunc("/api/router/config/kbs/", handlers.RouterClassifierProxyHandler(cfg.RouterAPIURL, cfg.ReadonlyMode, store))
+	classifierHandler := handlers.RouterClassifierProxyHandler(cfg.RouterAPIURL, cfg.ReadonlyMode, store)
+	kbPolicies := auth.Route(
+		"/api/router/config/kbs",
+		auth.ReadPolicy(http.MethodGet, auth.PermConfigRead, auth.SensitivitySensitive, auth.ResourceOwnerConfig),
+		auth.MutationPolicy(http.MethodPost, auth.PermConfigWrite, "config.kb.create", auth.SensitivitySecret, auth.ResourceOwnerConfig, 16<<20),
+	)
+	routes.HandleFunc(kbPolicies, classifierHandler)
+	kbItemPolicies := auth.Route(
+		"/api/router/config/kbs/",
+		auth.ReadPolicy(http.MethodGet, auth.PermConfigRead, auth.SensitivitySensitive, auth.ResourceOwnerConfig),
+		auth.MutationPolicy(http.MethodPut, auth.PermConfigWrite, "config.kb.update", auth.SensitivitySecret, auth.ResourceOwnerConfig, 16<<20),
+		auth.MutationPolicy(http.MethodDelete, auth.PermConfigWrite, "config.kb.delete", auth.SensitivitySecret, auth.ResourceOwnerConfig, auth.NoBodyLimit),
+	)
+	routes.HandleFunc(kbItemPolicies, classifierHandler)
 	log.Printf("Global config API endpoints registered: /api/router/config/global, /api/router/config/global/update, /api/router/config/global/raw, /api/router/config/global/raw/update (legacy aliases: /api/router/config/defaults, /api/router/config/defaults/update)")
 }
 
-func registerToolRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerConfigReadRoutes(routes *auth.PolicyMux, cfg *config.Config) {
+	for _, route := range []struct {
+		pattern string
+		handler http.HandlerFunc
+	}{
+		{pattern: "/api/router/config/all", handler: handlers.ConfigHandler(cfg.AbsConfigPath)},
+		{pattern: "/api/router/config/yaml", handler: handlers.ConfigYAMLHandler(cfg.AbsConfigPath)},
+	} {
+		routes.HandleFunc(
+			auth.ProtectedRoute(route.pattern, auth.PermConfigRead, auth.SensitivitySecret, auth.ResourceOwnerConfig, http.MethodGet),
+			route.handler,
+		)
+	}
+}
+
+func registerConfigMutationRoutes(routes *auth.PolicyMux, cfg *config.Config, readonly bool) {
+	const maxConfigBodyBytes int64 = 16 << 20
+	routes.HandleFunc(
+		auth.ProtectedMutationRoute("/api/router/config/update", auth.PermConfigWrite, "config.update", auth.SensitivitySecret, auth.ResourceOwnerConfig, maxConfigBodyBytes, http.MethodPost, http.MethodPut),
+		handlers.UpdateConfigHandler(cfg.AbsConfigPath, readonly, cfg.ConfigDir),
+	)
+	routes.HandleFunc(
+		auth.ProtectedMutationRoute("/api/router/config/deploy", auth.PermConfigDeploy, "config.deploy", auth.SensitivitySecret, auth.ResourceOwnerConfig, maxConfigBodyBytes, http.MethodPost),
+		handlers.DeployHandler(cfg.AbsConfigPath, readonly, cfg.ConfigDir),
+	)
+	routes.HandleFunc(
+		auth.ProtectedMutationRoute("/api/router/config/rollback", auth.PermConfigDeploy, "config.rollback", auth.SensitivitySecret, auth.ResourceOwnerConfig, 64<<10, http.MethodPost),
+		handlers.RollbackHandler(cfg.AbsConfigPath, readonly, cfg.ConfigDir),
+	)
+}
+
+func registerToolRoutes(routes *auth.PolicyMux, cfg *config.Config) {
 	toolsDBPath := resolveToolsDBPath(cfg)
-	mux.HandleFunc("/api/tools-db", handlers.ToolsDBHandler(toolsDBPath))
+	routes.HandleFunc(auth.ProtectedRoute("/api/tools-db", auth.PermMcpRead, auth.SensitivitySensitive, auth.ResourceOwnerTools, http.MethodGet), handlers.ToolsDBHandler(toolsDBPath))
 	log.Printf("Tools DB API endpoint registered: /api/tools-db")
 
-	mux.HandleFunc("/api/tools/web-search", handlers.WebSearchHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/tools/web-search", auth.PermToolsUse, "tool.web_search", auth.SensitivitySensitive, auth.ResourceOwnerTools, 256<<10, http.MethodPost), handlers.WebSearchHandler())
 	log.Printf("Web Search API endpoint registered: /api/tools/web-search")
 
-	mux.HandleFunc("/api/tools/open-web", handlers.OpenWebHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/tools/open-web", auth.PermToolsUse, "tool.open_web", auth.SensitivitySensitive, auth.ResourceOwnerTools, 256<<10, http.MethodPost), handlers.OpenWebHandler())
 	log.Printf("Open Web API endpoint registered: /api/tools/open-web")
 
-	mux.HandleFunc("/api/tools/weather", handlers.WeatherHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/tools/weather", auth.PermToolsUse, "tool.weather", auth.SensitivityOperational, auth.ResourceOwnerTools, 256<<10, http.MethodPost), handlers.WeatherHandler())
 	log.Printf("Weather API endpoint registered: /api/tools/weather")
 
-	mux.HandleFunc("/api/tools/fetch-raw", handlers.FetchRawHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/tools/fetch-raw", auth.PermToolsUse, "tool.fetch_raw", auth.SensitivitySensitive, auth.ResourceOwnerTools, 256<<10, http.MethodPost), handlers.FetchRawHandler())
 	log.Printf("Fetch Raw API endpoint registered: /api/tools/fetch-raw")
 }
 
@@ -207,28 +303,28 @@ func resolveToolsDBPath(cfg *config.Config) string {
 	return toolsDBPath
 }
 
-func registerStatusRoutes(mux *http.ServeMux, cfg *config.Config, credentialProvider ...*recipe.Store) {
+func registerStatusRoutes(routes *auth.PolicyMux, cfg *config.Config, credentialProvider ...*recipe.Store) {
 	store := selectedRecipeStore(cfg, credentialProvider)
-	mux.HandleFunc("/api/status", handlers.StatusHandler(cfg.RouterAPIURL, cfg.ConfigDir, store))
+	routes.HandleFunc(auth.ProtectedRoute("/api/status", auth.PermTopologyRead, auth.SensitivityOperational, auth.ResourceOwnerObservability, http.MethodGet), handlers.StatusHandler(cfg.RouterAPIURL, cfg.ConfigDir, store))
 	log.Printf("Status API endpoint registered: /api/status")
 
-	mux.HandleFunc("/api/logs", handlers.LogsHandler(cfg.RouterAPIURL))
+	routes.HandleFunc(auth.ProtectedRoute("/api/logs", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet), handlers.LogsHandler(cfg.RouterAPIURL))
 	log.Printf("Logs API endpoint registered: /api/logs")
 }
 
-func registerTopologyRoutes(mux *http.ServeMux, cfg *config.Config, credentialProvider ...*recipe.Store) {
+func registerTopologyRoutes(routes *auth.PolicyMux, cfg *config.Config, credentialProvider ...*recipe.Store) {
 	store := selectedRecipeStore(cfg, credentialProvider)
-	mux.HandleFunc("/api/topology/test-query", handlers.TopologyTestQueryHandler(cfg.AbsConfigPath, cfg.RouterAPIURL, store))
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/topology/test-query", auth.PermTopologyRead, "topology.test_query", auth.SensitivitySensitive, auth.ResourceOwnerInference, 2<<20, http.MethodPost), handlers.TopologyTestQueryHandler(cfg.AbsConfigPath, cfg.RouterAPIURL, store))
 	log.Printf("Topology Test Query API endpoint registered: /api/topology/test-query (Router API: %s)", cfg.RouterAPIURL)
 }
 
-func registerEvaluationRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerEvaluationRoutes(routes *auth.PolicyMux, cfg *config.Config) {
 	if !cfg.EvaluationEnabled {
 		log.Printf("Evaluation feature disabled")
 		return
 	}
 
-	mux.HandleFunc("/api/evaluation/datasets", handlers.GetDatasetsHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/evaluation/datasets", auth.PermEvalRead, auth.SensitivityOperational, auth.ResourceOwnerEvaluation, http.MethodGet), handlers.GetDatasetsHandler())
 	log.Printf("Evaluation datasets endpoint registered: /api/evaluation/datasets")
 
 	projectRoot := resolveEvaluationProjectRoot(cfg)
@@ -254,7 +350,11 @@ func registerEvaluationRoutes(mux *http.ServeMux, cfg *config.Config) {
 	})
 	evalHandler := handlers.NewEvaluationHandler(evalDB, runner, cfg.ReadonlyMode, cfg.RouterAPIURL, cfg.EnvoyURL)
 
-	mux.HandleFunc("/api/evaluation/tasks", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.Route(
+		"/api/evaluation/tasks",
+		auth.ReadPolicy(http.MethodGet, auth.PermEvalRead, auth.SensitivitySensitive, auth.ResourceOwnerEvaluation),
+		auth.MutationPolicy(http.MethodPost, auth.PermEvalWrite, "evaluation.task.create", auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, 2<<20),
+	), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -267,7 +367,11 @@ func registerEvaluationRoutes(mux *http.ServeMux, cfg *config.Config) {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
-	mux.HandleFunc("/api/evaluation/tasks/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.Route(
+		"/api/evaluation/tasks/",
+		auth.ReadPolicy(http.MethodGet, auth.PermEvalRead, auth.SensitivitySensitive, auth.ResourceOwnerEvaluation),
+		auth.MutationPolicy(http.MethodDelete, auth.PermEvalWrite, "evaluation.task.delete", auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, auth.NoBodyLimit),
+	), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -280,12 +384,12 @@ func registerEvaluationRoutes(mux *http.ServeMux, cfg *config.Config) {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
-	mux.HandleFunc("/api/evaluation/run", evalHandler.RunTaskHandler())
-	mux.HandleFunc("/api/evaluation/cancel/", evalHandler.CancelTaskHandler())
-	mux.HandleFunc("/api/evaluation/stream/", evalHandler.StreamProgressHandler())
-	mux.HandleFunc("/api/evaluation/results/", evalHandler.GetResultsHandler())
-	mux.HandleFunc("/api/evaluation/export/", evalHandler.ExportResultsHandler())
-	mux.HandleFunc("/api/evaluation/history", evalHandler.GetHistoryHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/evaluation/run", auth.PermEvalRun, "evaluation.run", auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, 2<<20, http.MethodPost), evalHandler.RunTaskHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/evaluation/cancel/", auth.PermEvalRun, "evaluation.cancel", auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, auth.NoBodyLimit, http.MethodPost), evalHandler.CancelTaskHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/evaluation/stream/", auth.PermEvalRead, auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, http.MethodGet), evalHandler.StreamProgressHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/evaluation/results/", auth.PermEvalRead, auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, http.MethodGet), evalHandler.GetResultsHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/evaluation/export/", auth.PermEvalRead, auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, http.MethodGet), evalHandler.ExportResultsHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/evaluation/history", auth.PermEvalRead, auth.SensitivitySensitive, auth.ResourceOwnerEvaluation, http.MethodGet), evalHandler.GetHistoryHandler())
 	log.Printf("Evaluation API endpoints registered: /api/evaluation/*")
 }
 
@@ -365,7 +469,7 @@ func isEvaluationProjectRoot(dir string) bool {
 	return true
 }
 
-func registerMLPipelineRoutes(mux *http.ServeMux, cfg *config.Config, wf *workflowstore.Store) {
+func registerMLPipelineRoutes(routes *auth.PolicyMux, cfg *config.Config, wf *workflowstore.Store) {
 	if !cfg.MLPipelineEnabled {
 		log.Printf("ML Pipeline feature disabled")
 		return
@@ -387,13 +491,13 @@ func registerMLPipelineRoutes(mux *http.ServeMux, cfg *config.Config, wf *workfl
 	}
 	mlHandler := handlers.NewMLPipelineHandler(mlRunner)
 
-	mux.HandleFunc("/api/ml-pipeline/jobs", mlHandler.ListJobsHandler())
-	mux.HandleFunc("/api/ml-pipeline/jobs/", mlHandler.GetJobHandler())
-	mux.HandleFunc("/api/ml-pipeline/benchmark", mlHandler.RunBenchmarkHandler())
-	mux.HandleFunc("/api/ml-pipeline/train", mlHandler.RunTrainHandler())
-	mux.HandleFunc("/api/ml-pipeline/config", mlHandler.GenerateConfigHandler())
-	mux.HandleFunc("/api/ml-pipeline/download/", mlHandler.DownloadOutputHandler())
-	mux.HandleFunc("/api/ml-pipeline/stream/", mlHandler.StreamProgressHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/ml-pipeline/jobs", auth.PermMlPipeline, auth.SensitivitySensitive, auth.ResourceOwnerML, http.MethodGet), mlHandler.ListJobsHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/ml-pipeline/jobs/", auth.PermMlPipeline, auth.SensitivitySensitive, auth.ResourceOwnerML, http.MethodGet), mlHandler.GetJobHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/ml-pipeline/benchmark", auth.PermMlPipeline, "ml.benchmark", auth.SensitivitySensitive, auth.ResourceOwnerML, 2<<20, http.MethodPost), mlHandler.RunBenchmarkHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/ml-pipeline/train", auth.PermMlPipeline, "ml.train", auth.SensitivitySensitive, auth.ResourceOwnerML, 2<<20, http.MethodPost), mlHandler.RunTrainHandler())
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/ml-pipeline/config", auth.PermMlPipeline, "ml.config.generate", auth.SensitivitySensitive, auth.ResourceOwnerML, 2<<20, http.MethodPost), mlHandler.GenerateConfigHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/ml-pipeline/download/", auth.PermMlPipeline, auth.SensitivitySensitive, auth.ResourceOwnerML, http.MethodGet), mlHandler.DownloadOutputHandler())
+	routes.HandleFunc(auth.ProtectedRoute("/api/ml-pipeline/stream/", auth.PermMlPipeline, auth.SensitivitySensitive, auth.ResourceOwnerML, http.MethodGet), mlHandler.StreamProgressHandler())
 	log.Printf("ML Pipeline API endpoints registered: /api/ml-pipeline/*")
 
 	if trainingDir != "" {

--- a/dashboard/backend/router/core_routes_test.go
+++ b/dashboard/backend/router/core_routes_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/setupmode"
 )
@@ -20,7 +21,7 @@ func TestRegisterRecipeRoutesExposesUnmanagedDescriptor(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("version: v0.3\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(config): %v", err)
 	}
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerRecipeRoutes(mux, &config.Config{ConfigDir: dir, RouterAPIURL: "http://router.invalid"})
 	recorder := httptest.NewRecorder()
 	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/recipe", nil))
@@ -46,7 +47,7 @@ func TestRegisterRecipePackageRoutesEnforceCanonicalPathsAndMethods(t *testing.T
 	}
 	t.Setenv("VLLM_SR_ACTIVE_RECIPE_DIR", "")
 	t.Setenv("VLLM_SR_RECIPE_STORE_DIR", filepath.Join(dir, "recipe-store"))
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerRecipeRoutes(mux, &config.Config{
 		ConfigDir:             dir,
 		AbsConfigPath:         configPath,
@@ -85,7 +86,7 @@ func TestRegisterRecipePackageRoutesEnforceCanonicalPathsAndMethods(t *testing.T
 func TestRegisterCoreRoutesExposesReadOnlyModelCatalogEndpoint(t *testing.T) {
 	t.Parallel()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	cfg := &config.Config{ConfigDir: t.TempDir(), PythonPath: "python3"}
 	registerCoreRoutes(mux, cfg, setupmode.New(cfg.AbsConfigPath, cfg.SetupMode))
 
@@ -99,7 +100,7 @@ func TestRegisterCoreRoutesExposesReadOnlyModelCatalogEndpoint(t *testing.T) {
 func TestRegisterConfigRoutesKeepsInferenceVerificationAvailableInReadonlyMode(t *testing.T) {
 	t.Parallel()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerConfigRoutes(mux, &config.Config{
 		AbsConfigPath:         "active-config.yaml",
 		ReadonlyMode:          true,
@@ -168,7 +169,7 @@ func TestRegisterRecipeRoutesKeepsImportAvailableWhenRuntimeConfigReadonly(t *te
 	t.Setenv("VLLM_SR_ACTIVE_RECIPE_DIR", "")
 	t.Setenv("VLLM_SR_RECIPE_STORE_DIR", filepath.Join(dir, "recipe-store"))
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerRecipeRoutes(mux, &config.Config{
 		ConfigDir:             dir,
 		AbsConfigPath:         configPath,
@@ -222,7 +223,7 @@ func TestRuntimeConfigCapabilityGuardsLocalWriteRoutesButNotKBS(t *testing.T) {
 		RuntimeConfigWritable: false,
 		RecipeStoreWritable:   true,
 	}
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerHealthAndSetupRoutes(mux, cfg, setupmode.New(cfg.AbsConfigPath, cfg.SetupMode))
 	registerConfigRoutes(mux, cfg)
 	registerSecurityPolicyRoutes(mux, cfg)

--- a/dashboard/backend/router/enterprise_mutation_boundary_test.go
+++ b/dashboard/backend/router/enterprise_mutation_boundary_test.go
@@ -58,7 +58,7 @@ func TestConfigDeployPermissionCannotMutateDatabaseOwnedEnterprisePolicy(t *test
 
 	configPath := filepath.Join(tempDir, "config.yaml")
 	originalConfig := []byte("version: v0.3\nrouting: {}\n")
-	if err := os.WriteFile(configPath, originalConfig, 0o600); err != nil {
+	if err = os.WriteFile(configPath, originalConfig, 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	payload, err := json.Marshal(handlers.DeployRequest{YAML: `routing: {}

--- a/dashboard/backend/router/enterprise_mutation_boundary_test.go
+++ b/dashboard/backend/router/enterprise_mutation_boundary_test.go
@@ -1,0 +1,113 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
+	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
+)
+
+func TestConfigDeployPermissionCannotMutateDatabaseOwnedEnterprisePolicy(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	store, err := auth.NewStore(filepath.Join(tempDir, "auth.db"))
+	if err != nil {
+		t.Fatalf("open auth store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	service := auth.NewService(store, "enterprise-boundary-secret", 1)
+	hash, err := service.HashPassword("ValidPassword1!")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	user, err := store.CreateUser(t.Context(), "config-deployer@example.com", "Config Deployer", hash, auth.RoleWrite, "active")
+	if err != nil {
+		t.Fatalf("create config deployer: %v", err)
+	}
+	token, _, err := service.Login(t.Context(), user.Email, "ValidPassword1!")
+	if err != nil {
+		t.Fatalf("login config deployer: %v", err)
+	}
+
+	beforePermissions, err := store.GetEffectivePermissions(t.Context(), user.Role, user.ID)
+	if err != nil {
+		t.Fatalf("load permissions before deploy: %v", err)
+	}
+	if !beforePermissions[auth.PermConfigDeploy] {
+		t.Fatal("test principal must have config deploy permission")
+	}
+	for _, permission := range []string{
+		auth.PermGrantPublish,
+		auth.PermQuotaPublish,
+		auth.PermVirtualKeys,
+		auth.PermAuditPolicy,
+		auth.PermBreakGlass,
+	} {
+		if beforePermissions[permission] {
+			t.Fatalf("test principal unexpectedly has %q", permission)
+		}
+	}
+
+	configPath := filepath.Join(tempDir, "config.yaml")
+	originalConfig := []byte("version: v0.3\nrouting: {}\n")
+	if err := os.WriteFile(configPath, originalConfig, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	payload, err := json.Marshal(handlers.DeployRequest{YAML: `routing: {}
+enterprise:
+  tenant_grants: [{tenant: acme, role: admin}]
+  quota_policy: {daily: 1000000}
+  virtual_keys: [{name: hidden-key}]
+  audit_policy: {enabled: false}
+`})
+	if err != nil {
+		t.Fatalf("marshal deploy request: %v", err)
+	}
+
+	routes := auth.NewPolicyMux()
+	routes.HandleFunc(
+		auth.ProtectedMutationRoute(
+			"/api/router/config/deploy",
+			auth.PermConfigDeploy,
+			"config.deploy",
+			auth.SensitivitySecret,
+			auth.ResourceOwnerConfig,
+			16<<20,
+			http.MethodPost,
+		),
+		handlers.DeployHandler(configPath, false, tempDir),
+	)
+	routes.Seal()
+	handler := auth.AuthenticateRequest(service, routes)(routes)
+	request := httptest.NewRequest(http.MethodPost, "/api/router/config/deploy", bytes.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("deploy status = %d, want %d: %s", response.Code, http.StatusForbidden, response.Body.String())
+	}
+	afterConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after deploy: %v", err)
+	}
+	if !bytes.Equal(afterConfig, originalConfig) {
+		t.Fatalf("config changed after forbidden enterprise mutation:\n%s", afterConfig)
+	}
+	afterPermissions, err := store.GetEffectivePermissions(t.Context(), user.Role, user.ID)
+	if err != nil {
+		t.Fatalf("load permissions after deploy: %v", err)
+	}
+	if !reflect.DeepEqual(afterPermissions, beforePermissions) {
+		t.Fatalf("effective permissions changed: before=%v after=%v", beforePermissions, afterPermissions)
+	}
+}

--- a/dashboard/backend/router/mcp_routes.go
+++ b/dashboard/backend/router/mcp_routes.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
 	"github.com/vllm-project/semantic-router/dashboard/backend/mcp"
@@ -19,7 +20,7 @@ const internalOpenClawMCPPath = "/_internal/openclaw/mcp"
 
 // SetupMCP configures MCP related routes
 // Returns MCP Manager instance for lifecycle management
-func SetupMCP(mux *http.ServeMux, cfg *config.Config, wf *workflowstore.Store, openClawHandler *handlers.OpenClawHandler) *mcp.Manager {
+func SetupMCP(routes *auth.PolicyMux, cfg *config.Config, wf *workflowstore.Store, openClawHandler *handlers.OpenClawHandler) *mcp.Manager {
 	if !cfg.MCPEnabled {
 		log.Printf("MCP feature disabled")
 		return nil
@@ -32,12 +33,12 @@ func SetupMCP(mux *http.ServeMux, cfg *config.Config, wf *workflowstore.Store, o
 
 	// Register built-in OpenClaw MCP endpoint and server config.
 	if cfg.OpenClawEnabled && openClawHandler != nil {
-		registerBuiltInOpenClawMCP(mux, cfg.Port, mcpManager, openClawHandler)
+		registerBuiltInOpenClawMCP(routes, cfg.Port, mcpManager, openClawHandler)
 	}
 
 	// Create MCP handler
 	mcpHandler := handlers.NewMCPHandler(mcpManager, cfg.ReadonlyMode)
-	registerMCPAPIRoutes(mux, mcpHandler)
+	registerMCPAPIRoutes(routes, mcpHandler)
 
 	log.Printf("MCP API endpoints registered: /api/mcp/*")
 
@@ -48,14 +49,17 @@ func SetupMCP(mux *http.ServeMux, cfg *config.Config, wf *workflowstore.Store, o
 }
 
 func registerBuiltInOpenClawMCP(
-	mux *http.ServeMux,
+	routes *auth.PolicyMux,
 	port string,
 	mcpManager *mcp.Manager,
 	openClawHandler *handlers.OpenClawHandler,
 ) {
 	openClawMCPHandler := handlers.NewOpenClawMCPHandler(openClawHandler)
-	mux.Handle("/api/openclaw/mcp", openClawMCPHandler)
-	mux.Handle(internalOpenClawMCPPath, loopbackOnly(openClawMCPHandler))
+	routes.Handle(
+		auth.ProtectedMutationRoute("/api/openclaw/mcp", auth.PermMcpManage, "openclaw.mcp", auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, 2<<20, http.MethodPost),
+		openClawMCPHandler,
+	)
+	routes.HandleFallback(internalOpenClawMCPPath, loopbackOnly(openClawMCPHandler))
 
 	serverURL := fmt.Sprintf("http://127.0.0.1:%s%s", port, internalOpenClawMCPPath)
 	if err := mcpManager.UpsertServer(&mcp.ServerConfig{
@@ -76,15 +80,19 @@ func registerBuiltInOpenClawMCP(
 	}
 
 	log.Printf(
-		"Built-in OpenClaw MCP endpoints registered: /api/openclaw/mcp (public), %s (loopback-only) (server id: %s)",
+		"Built-in OpenClaw MCP endpoints registered: /api/openclaw/mcp (authenticated), %s (loopback-only) (server id: %s)",
 		internalOpenClawMCPPath,
 		mcp.BuiltinOpenClawServerID,
 	)
 }
 
-func registerMCPAPIRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) {
+func registerMCPAPIRoutes(routes *auth.PolicyMux, mcpHandler *handlers.MCPHandler) {
 	// Server configuration - GET list, POST create
-	mux.HandleFunc("/api/mcp/servers", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.Route(
+		"/api/mcp/servers",
+		auth.ReadPolicy(http.MethodGet, auth.PermMcpRead, auth.SensitivitySensitive, auth.ResourceOwnerTools),
+		auth.MutationPolicy(http.MethodPost, auth.PermMcpManage, "mcp.server.create", auth.SensitivitySecret, auth.ResourceOwnerTools, 2<<20),
+	), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -98,13 +106,19 @@ func registerMCPAPIRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) {
 		}
 	})
 
-	registerMCPServerOperationRoutes(mux, mcpHandler)
-	registerMCPToolRoutes(mux, mcpHandler)
+	registerMCPServerOperationRoutes(routes, mcpHandler)
+	registerMCPToolRoutes(routes, mcpHandler)
 }
 
-func registerMCPServerOperationRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) {
+func registerMCPServerOperationRoutes(routes *auth.PolicyMux, mcpHandler *handlers.MCPHandler) {
 	// Server operations (update, delete, connect, disconnect, status, test)
-	mux.HandleFunc("/api/mcp/servers/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.Route(
+		"/api/mcp/servers/",
+		auth.ReadPolicy(http.MethodGet, auth.PermMcpRead, auth.SensitivitySecret, auth.ResourceOwnerTools),
+		auth.MutationPolicy(http.MethodPost, auth.PermMcpManage, "mcp.server.action", auth.SensitivitySecret, auth.ResourceOwnerTools, 2<<20),
+		auth.MutationPolicy(http.MethodPut, auth.PermMcpManage, "mcp.server.update", auth.SensitivitySecret, auth.ResourceOwnerTools, 2<<20),
+		auth.MutationPolicy(http.MethodDelete, auth.PermMcpManage, "mcp.server.delete", auth.SensitivitySecret, auth.ResourceOwnerTools, auth.NoBodyLimit),
+	), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -133,9 +147,9 @@ func registerMCPServerOperationRoutes(mux *http.ServeMux, mcpHandler *handlers.M
 	})
 }
 
-func registerMCPToolRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) {
+func registerMCPToolRoutes(routes *auth.PolicyMux, mcpHandler *handlers.MCPHandler) {
 	// Tools - GET list
-	mux.HandleFunc("/api/mcp/tools", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/api/mcp/tools", auth.PermMcpRead, auth.SensitivitySensitive, auth.ResourceOwnerTools, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -143,7 +157,7 @@ func registerMCPToolRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) 
 	})
 
 	// Tool execution - POST execute
-	mux.HandleFunc("/api/mcp/tools/execute", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/mcp/tools/execute", auth.PermToolsUse, "mcp.tool.execute", auth.SensitivitySecret, auth.ResourceOwnerTools, 4<<20, http.MethodPost), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -151,7 +165,7 @@ func registerMCPToolRoutes(mux *http.ServeMux, mcpHandler *handlers.MCPHandler) 
 	})
 
 	// Tool streaming execution - POST execute/stream
-	mux.HandleFunc("/api/mcp/tools/execute/stream", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedMutationRoute("/api/mcp/tools/execute/stream", auth.PermToolsUse, "mcp.tool.execute_stream", auth.SensitivitySecret, auth.ResourceOwnerTools, 4<<20, http.MethodPost), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}

--- a/dashboard/backend/router/openclaw_routes.go
+++ b/dashboard/backend/router/openclaw_routes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
 	"github.com/vllm-project/semantic-router/dashboard/backend/middleware"
@@ -25,42 +26,51 @@ func newOpenClawHandler(cfg *config.Config, wf *workflowstore.Store) *handlers.O
 }
 
 func registerOpenClawRoutes(
-	mux *http.ServeMux,
+	routes *auth.PolicyMux,
 	cfg *config.Config,
 	openClawHandler *handlers.OpenClawHandler,
 ) {
 	if cfg.OpenClawEnabled && openClawHandler != nil {
-		registerEnabledOpenClawRoutes(mux, openClawHandler)
+		registerEnabledOpenClawRoutes(routes, openClawHandler)
 		log.Printf("OpenClaw API endpoints registered: /api/openclaw/*")
-		registerOpenClawProxyRoute(mux, openClawHandler)
+		registerOpenClawProxyRoute(routes, openClawHandler)
 		log.Printf("OpenClaw dynamic proxy configured: /embedded/openclaw/{name}/ (WebSocket enabled)")
 		return
 	}
 
-	registerDisabledOpenClawRoutes(mux)
+	registerDisabledOpenClawRoutes(routes)
 	log.Printf("OpenClaw feature disabled")
 }
 
-func registerEnabledOpenClawRoutes(mux *http.ServeMux, openClawHandler *handlers.OpenClawHandler) {
-	mux.HandleFunc("/api/openclaw/status", openClawHandler.StatusHandler())
-	mux.HandleFunc("/api/openclaw/skills", openClawHandler.SkillsHandler())
-	mux.HandleFunc("/api/openclaw/teams", openClawHandler.TeamsHandler())
-	mux.HandleFunc("/api/openclaw/teams/", openClawHandler.TeamByIDHandler())
-	mux.HandleFunc("/api/openclaw/workers", openClawHandler.WorkersHandler())
-	mux.HandleFunc("/api/openclaw/workers/", openClawHandler.WorkerByIDHandler())
-	mux.HandleFunc("/api/openclaw/rooms", openClawHandler.RoomsHandler())
-	mux.HandleFunc("/api/openclaw/rooms/", openClawHandler.RoomByIDHandler())
-	mux.HandleFunc("/api/openclaw/provision", openClawHandler.ProvisionHandler())
-	mux.HandleFunc("/api/openclaw/start", openClawHandler.StartHandler())
-	mux.HandleFunc("/api/openclaw/stop", openClawHandler.StopHandler())
-	mux.HandleFunc("/api/openclaw/token", openClawHandler.TokenHandler())
-	mux.HandleFunc("/api/openclaw/next-port", openClawHandler.NextPortHandler())
-	mux.HandleFunc("/api/openclaw/containers/", openClawHandler.DeleteHandler())
+func registerEnabledOpenClawRoutes(routes *auth.PolicyMux, openClawHandler *handlers.OpenClawHandler) {
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/status"), openClawHandler.StatusHandler())
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/skills"), openClawHandler.SkillsHandler())
+	routes.HandleFunc(openClawCollectionRoute("/api/openclaw/teams", "openclaw.team.create"), openClawHandler.TeamsHandler())
+	routes.HandleFunc(openClawItemRoute("/api/openclaw/teams/", "openclaw.team"), openClawHandler.TeamByIDHandler())
+	routes.HandleFunc(openClawCollectionRoute("/api/openclaw/workers", "openclaw.worker.create"), openClawHandler.WorkersHandler())
+	routes.HandleFunc(openClawItemRoute("/api/openclaw/workers/", "openclaw.worker"), openClawHandler.WorkerByIDHandler())
+	routes.HandleFunc(openClawCollectionRoute("/api/openclaw/rooms", "openclaw.room.create"), openClawHandler.RoomsHandler())
+	routes.HandleFunc(auth.Route(
+		"/api/openclaw/rooms/",
+		auth.ReadPolicy(http.MethodGet, auth.PermOpenClawRead, auth.SensitivitySensitive, auth.ResourceOwnerOpenClaw),
+		auth.MutationPolicy(http.MethodPost, auth.PermOpenClawRead, "openclaw.room.message", auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, 2<<20),
+		auth.MutationPolicy(http.MethodPatch, auth.PermOpenClaw, "openclaw.room.update", auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, 2<<20),
+		auth.MutationPolicy(http.MethodDelete, auth.PermOpenClaw, "openclaw.room.delete", auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, auth.NoBodyLimit),
+	), openClawHandler.RoomByIDHandler())
+	routes.HandleFunc(openClawMutationRoute("/api/openclaw/provision", "openclaw.provision"), openClawHandler.ProvisionHandler())
+	routes.HandleFunc(openClawMutationRoute("/api/openclaw/start", "openclaw.start"), openClawHandler.StartHandler())
+	routes.HandleFunc(openClawMutationRoute("/api/openclaw/stop", "openclaw.stop"), openClawHandler.StopHandler())
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/token"), openClawHandler.TokenHandler())
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/next-port"), openClawHandler.NextPortHandler())
+	routes.HandleFunc(
+		auth.ProtectedMutationRoute("/api/openclaw/containers/", auth.PermOpenClaw, "openclaw.container.delete", auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, auth.NoBodyLimit, http.MethodDelete),
+		openClawHandler.DeleteHandler(),
+	)
 }
 
-func registerOpenClawProxyRoute(mux *http.ServeMux, openClawHandler *handlers.OpenClawHandler) {
+func registerOpenClawProxyRoute(routes *auth.PolicyMux, openClawHandler *handlers.OpenClawHandler) {
 	var proxyCache sync.Map // map[string]http.Handler
-	mux.HandleFunc("/embedded/openclaw/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/openclaw/", auth.PermOpenClawRead, auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -111,19 +121,44 @@ func registerOpenClawProxyRoute(mux *http.ServeMux, openClawHandler *handlers.Op
 	})
 }
 
-func registerDisabledOpenClawRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("/api/openclaw/status", writeOpenClawArray)
-	mux.HandleFunc("/api/openclaw/teams", writeOpenClawArray)
-	mux.HandleFunc("/api/openclaw/workers", writeOpenClawArray)
-	mux.HandleFunc("/api/openclaw/rooms", writeOpenClawArray)
-	mux.HandleFunc("/api/openclaw/rooms/", func(w http.ResponseWriter, r *http.Request) {
+func registerDisabledOpenClawRoutes(routes *auth.PolicyMux) {
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/status"), writeOpenClawArray)
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/teams"), writeOpenClawArray)
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/workers"), writeOpenClawArray)
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/rooms"), writeOpenClawArray)
+	routes.HandleFunc(openClawReadRoute("/api/openclaw/rooms/"), func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		http.Error(w, `{"error":"OpenClaw feature disabled"}`, http.StatusServiceUnavailable)
 	})
-	mux.HandleFunc(
-		"/embedded/openclaw/",
+	routes.HandleFunc(
+		auth.ProtectedRoute("/embedded/openclaw/", auth.PermOpenClawRead, auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, http.MethodGet),
 		serviceUnavailableHTMLHandler("OpenClaw", "OPENCLAW_ENABLED", "true"),
 	)
+}
+
+func openClawReadRoute(pattern string) auth.RouteContract {
+	return auth.ProtectedRoute(pattern, auth.PermOpenClawRead, auth.SensitivitySensitive, auth.ResourceOwnerOpenClaw, http.MethodGet)
+}
+
+func openClawCollectionRoute(pattern, createAction string) auth.RouteContract {
+	return auth.Route(
+		pattern,
+		auth.ReadPolicy(http.MethodGet, auth.PermOpenClawRead, auth.SensitivitySensitive, auth.ResourceOwnerOpenClaw),
+		auth.MutationPolicy(http.MethodPost, auth.PermOpenClaw, createAction, auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, 2<<20),
+	)
+}
+
+func openClawItemRoute(pattern, actionPrefix string) auth.RouteContract {
+	return auth.Route(
+		pattern,
+		auth.ReadPolicy(http.MethodGet, auth.PermOpenClawRead, auth.SensitivitySensitive, auth.ResourceOwnerOpenClaw),
+		auth.MutationPolicy(http.MethodPatch, auth.PermOpenClaw, actionPrefix+".update", auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, 2<<20),
+		auth.MutationPolicy(http.MethodDelete, auth.PermOpenClaw, actionPrefix+".delete", auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, auth.NoBodyLimit),
+	)
+}
+
+func openClawMutationRoute(pattern, action string) auth.RouteContract {
+	return auth.ProtectedMutationRoute(pattern, auth.PermOpenClaw, action, auth.SensitivitySecret, auth.ResourceOwnerOpenClaw, 2<<20, http.MethodPost)
 }
 
 func writeOpenClawArray(w http.ResponseWriter, r *http.Request) {

--- a/dashboard/backend/router/proxy_routes.go
+++ b/dashboard/backend/router/proxy_routes.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httputil"
 	"strings"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/middleware"
 	"github.com/vllm-project/semantic-router/dashboard/backend/proxy"
@@ -19,7 +20,7 @@ type dashboardProxySet struct {
 	jaegerStatic  *httputil.ReverseProxy
 }
 
-func registerProxyRoutes(mux *http.ServeMux, cfg *config.Config, credentialProvider ...routerauth.CredentialProvider) {
+func registerProxyRoutes(routes *auth.PolicyMux, cfg *config.Config, credentialProvider ...routerauth.CredentialProvider) {
 	var provider routerauth.CredentialProvider
 	if len(credentialProvider) > 0 {
 		provider = credentialProvider[0]
@@ -27,15 +28,15 @@ func registerProxyRoutes(mux *http.ServeMux, cfg *config.Config, credentialProvi
 	proxies := dashboardProxySet{
 		envoy: configureEnvoyProxy(cfg),
 	}
-	registerRouterAPIProxy(mux, cfg, proxies.envoy, provider)
-	proxies.grafanaStatic = registerGrafanaRoutes(mux, cfg)
-	proxies.jaegerAPI, proxies.jaegerStatic = registerJaegerRoutes(mux, cfg)
-	registerFleetSimRoutes(mux, cfg)
+	registerRouterAPIProxy(routes, cfg, proxies.envoy, provider)
+	proxies.grafanaStatic = registerGrafanaRoutes(routes, cfg)
+	proxies.jaegerAPI, proxies.jaegerStatic = registerJaegerRoutes(routes, cfg)
+	registerFleetSimRoutes(routes, cfg)
 
-	registerSmartAPIRouter(mux, proxies)
-	registerMetricsRoutes(mux, cfg)
-	registerPrometheusRoutes(mux, cfg)
-	registerWizMapRoutes(mux, cfg)
+	registerSmartAPIRouter(routes, proxies)
+	registerMetricsRoutes(routes, cfg)
+	registerPrometheusRoutes(routes, cfg)
+	registerWizMapRoutes(routes, cfg)
 }
 
 func configureEnvoyProxy(cfg *config.Config) *httputil.ReverseProxy {
@@ -66,7 +67,7 @@ func configureEnvoyProxy(cfg *config.Config) *httputil.ReverseProxy {
 }
 
 func registerRouterAPIProxy(
-	mux *http.ServeMux,
+	routes *auth.PolicyMux,
 	cfg *config.Config,
 	envoyProxy *httputil.ReverseProxy,
 	credentialProvider routerauth.CredentialProvider,
@@ -83,9 +84,10 @@ func registerRouterAPIProxy(
 	}
 	attachRouterReplayResponseRedaction(routerAPIProxy)
 
-	mux.HandleFunc("/api/router/", func(w http.ResponseWriter, r *http.Request) {
-		serveRouterAPIProxy(w, r, cfg, envoyProxy, routerAPIProxy, credentialProvider)
+	routerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveRouterAPIProxy(w, r, cfg, routes, envoyProxy, routerAPIProxy, credentialProvider)
 	})
+	routes.HandleGroup(routerProxyContracts(), routerHandler)
 	log.Printf("Router API proxy configured: %s (excluding /api/router/config/*)", cfg.RouterAPIURL)
 	return routerAPIProxy
 }
@@ -94,6 +96,7 @@ func serveRouterAPIProxy(
 	w http.ResponseWriter,
 	r *http.Request,
 	cfg *config.Config,
+	resolver auth.RoutePolicyResolver,
 	envoyProxy, routerAPIProxy *httputil.ReverseProxy,
 	credentialProvider routerauth.CredentialProvider,
 ) {
@@ -108,7 +111,8 @@ func serveRouterAPIProxy(
 	if routeRouterTrafficToEnvoy(w, r, envoyProxy) || middleware.HandleCORSPreflight(w, r) {
 		return
 	}
-	if !routerManagementProxyRouteAllowed(r.Method, r.URL.Path) {
+	policy, lookup := resolver.LookupRoutePolicy(r.Method, r.URL.Path)
+	if lookup != auth.RouteFound || !policy.ProxyUpstream {
 		writeDisallowedRouterManagementResponse(w, r)
 		return
 	}
@@ -138,33 +142,102 @@ func writeDisallowedRouterManagementResponse(w http.ResponseWriter, r *http.Requ
 	http.NotFound(w, r)
 }
 
-func routerManagementProxyRouteAllowed(method, path string) bool {
-	if method == http.MethodGet &&
-		(path == "/api/router/v1/router_replay" || strings.HasPrefix(path, "/api/router/v1/router_replay/")) {
-		return true
+func routerProxyContracts() []auth.RouteContract {
+	contracts := []auth.RouteContract{
+		auth.ProxyMutationRoute(
+			"/api/router/v1/chat/completions",
+			auth.PermInferenceRun,
+			"inference.chat",
+			auth.SensitivitySecret,
+			auth.ResourceOwnerInference,
+			16<<20,
+			http.MethodPost,
+		),
+		auth.ProxyRoute(
+			"/api/router/v1/models",
+			auth.PermConfigRead,
+			auth.AuditNone,
+			"",
+			auth.SensitivityOperational,
+			auth.ResourceOwnerInference,
+			http.MethodGet,
+			http.MethodHead,
+		),
+		auth.ProxyMutationRoute(
+			"/api/router/v1/router/outcomes",
+			auth.PermFeedbackSubmit,
+			"feedback.submit",
+			auth.SensitivitySecret,
+			auth.ResourceOwnerFeedback,
+			2<<20,
+			http.MethodPost,
+		),
+		auth.ProxyRoute(
+			"/api/router/v1/router_replay",
+			auth.PermReplayRead,
+			auth.AuditNone,
+			"",
+			auth.SensitivitySecret,
+			auth.ResourceOwnerReplay,
+			http.MethodGet,
+		),
+		auth.ProxyRoute(
+			"/api/router/v1/router_replay/",
+			auth.PermReplayRead,
+			auth.AuditNone,
+			"",
+			auth.SensitivitySecret,
+			auth.ResourceOwnerReplay,
+			http.MethodGet,
+		),
 	}
-	switch path {
-	case "/api/router/v1/models":
-		return method == http.MethodGet || method == http.MethodHead
-	case "/api/router/v1/router/outcomes":
-		return method == http.MethodPost
-	case "/api/router/api/v1/response-cache/capabilities",
+	return append(contracts, routerManagementProxyContracts()...)
+}
+
+func routerManagementProxyContracts() []auth.RouteContract {
+	contracts := make([]auth.RouteContract, 0, 12)
+	for _, pattern := range []string{
+		"/api/router/api/v1/response-cache/capabilities",
 		"/api/router/api/v1/response-cache/health",
 		"/api/router/api/v1/response-cache/stats",
 		"/api/router/api/v1/response-cache/audit",
 		"/api/router/api/v1/context-compression/capabilities",
 		"/api/router/api/v1/context-compression/health",
-		"/api/router/api/v1/context-compression/stats":
-		return method == http.MethodGet || method == http.MethodHead
-	case "/api/router/api/v1/response-cache/test",
-		"/api/router/api/v1/response-cache/invalidate",
-		"/api/router/api/v1/response-cache/flush",
-		"/api/router/api/v1/context-compression/preview",
-		"/api/router/api/v1/context-compression/recovery/invalidate":
-		return method == http.MethodPost
-	default:
-		return false
+		"/api/router/api/v1/context-compression/stats",
+	} {
+		contracts = append(contracts, auth.ProxyRoute(
+			pattern,
+			auth.PermConfigRead,
+			auth.AuditNone,
+			"",
+			auth.SensitivitySensitive,
+			auth.ResourceOwnerConfig,
+			http.MethodGet,
+			http.MethodHead,
+		))
 	}
+	for _, route := range []struct {
+		pattern    string
+		permission string
+		action     string
+	}{
+		{pattern: "/api/router/api/v1/response-cache/test", permission: auth.PermConfigWrite, action: "response_cache.test"},
+		{pattern: "/api/router/api/v1/response-cache/invalidate", permission: auth.PermConfigWrite, action: "response_cache.invalidate"},
+		{pattern: "/api/router/api/v1/response-cache/flush", permission: auth.PermConfigWrite, action: "response_cache.flush"},
+		{pattern: "/api/router/api/v1/context-compression/preview", permission: auth.PermConfigRead, action: "context_compression.preview"},
+		{pattern: "/api/router/api/v1/context-compression/recovery/invalidate", permission: auth.PermConfigWrite, action: "context_compression.invalidate"},
+	} {
+		contracts = append(contracts, auth.ProxyMutationRoute(
+			route.pattern,
+			route.permission,
+			route.action,
+			auth.SensitivitySensitive,
+			auth.ResourceOwnerConfig,
+			4<<20,
+			http.MethodPost,
+		))
+	}
+	return contracts
 }
 
 func routeRouterTrafficToEnvoy(
@@ -188,10 +261,10 @@ func routeRouterTrafficToEnvoy(
 	return false
 }
 
-func registerGrafanaRoutes(mux *http.ServeMux, cfg *config.Config) *httputil.ReverseProxy {
+func registerGrafanaRoutes(routes *auth.PolicyMux, cfg *config.Config) *httputil.ReverseProxy {
 	if cfg.GrafanaURL == "" {
-		mux.HandleFunc(
-			"/embedded/grafana/",
+		routes.HandleFunc(
+			auth.ProtectedRoute("/embedded/grafana/", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet),
 			serviceUnavailableHTMLHandler("Grafana", "TARGET_GRAFANA_URL", "http://localhost:3000"),
 		)
 		log.Printf("Warning: Grafana URL not configured")
@@ -202,7 +275,7 @@ func registerGrafanaRoutes(mux *http.ServeMux, cfg *config.Config) *httputil.Rev
 	if err != nil {
 		log.Fatalf("grafana proxy error: %v", err)
 	}
-	mux.HandleFunc("/embedded/grafana/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/grafana/", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -216,20 +289,20 @@ func registerGrafanaRoutes(mux *http.ServeMux, cfg *config.Config) *httputil.Rev
 		return nil
 	}
 
-	registerStaticProxyRoute(mux, "/public/", grafanaStaticProxy, "Grafana static proxy not configured")
-	registerStaticProxyRoute(mux, "/avatar/", grafanaStaticProxy, "Grafana static proxy not configured")
+	registerStaticProxyRoute(routes, "/public/", grafanaStaticProxy, "Grafana static proxy not configured")
+	registerStaticProxyRoute(routes, "/avatar/", grafanaStaticProxy, "Grafana static proxy not configured")
 	log.Printf("Grafana proxy configured: %s", cfg.GrafanaURL)
 	log.Printf("Grafana static assets proxied: /public/, /avatar/")
 	return grafanaStaticProxy
 }
 
 func registerStaticProxyRoute(
-	mux *http.ServeMux,
+	routes *auth.PolicyMux,
 	pattern string,
 	staticProxy *httputil.ReverseProxy,
 	message string,
 ) {
-	mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.PublicRoute(pattern, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -243,12 +316,12 @@ func registerStaticProxyRoute(
 }
 
 func registerJaegerRoutes(
-	mux *http.ServeMux,
+	routes *auth.PolicyMux,
 	cfg *config.Config,
 ) (*httputil.ReverseProxy, *httputil.ReverseProxy) {
 	if cfg.JaegerURL == "" {
-		mux.HandleFunc(
-			"/embedded/jaeger/",
+		routes.HandleFunc(
+			auth.ProtectedRoute("/embedded/jaeger/", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet),
 			serviceUnavailableHTMLHandler("Jaeger", "TARGET_JAEGER_URL", "http://localhost:16686"),
 		)
 		log.Printf("Info: Jaeger URL not configured (optional)")
@@ -270,13 +343,13 @@ func registerJaegerRoutes(
 	if err != nil {
 		log.Fatalf("jaeger proxy error: %v", err)
 	}
-	mux.HandleFunc("/embedded/jaeger", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/jaeger", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
 		jaegerProxy.ServeHTTP(w, r)
 	})
-	mux.HandleFunc("/embedded/jaeger/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/jaeger/", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -284,14 +357,14 @@ func registerJaegerRoutes(
 	})
 
 	if jaegerStaticProxy != nil {
-		mux.HandleFunc("/static/", func(w http.ResponseWriter, r *http.Request) {
+		routes.HandleFunc(auth.PublicRoute("/static/", http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 			if middleware.HandleCORSPreflight(w, r) {
 				return
 			}
 			log.Printf("Proxying Jaeger /static/ asset: %s", r.URL.Path)
 			jaegerStaticProxy.ServeHTTP(w, r)
 		})
-		mux.HandleFunc("/dependencies", func(w http.ResponseWriter, r *http.Request) {
+		routes.HandleFunc(auth.PublicRoute("/dependencies", http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 			if middleware.HandleCORSPreflight(w, r) {
 				return
 			}
@@ -304,8 +377,25 @@ func registerJaegerRoutes(
 	return jaegerAPIProxy, jaegerStaticProxy
 }
 
-func registerSmartAPIRouter(mux *http.ServeMux, proxies dashboardProxySet) {
-	mux.HandleFunc("/api/", func(w http.ResponseWriter, r *http.Request) {
+func registerSmartAPIRouter(routes *auth.PolicyMux, proxies dashboardProxySet) {
+	contracts := make([]auth.RouteContract, 0, 8)
+	for _, pattern := range []string{"/api/services", "/api/traces", "/api/operations", "/api/dependencies"} {
+		contracts = append(contracts, auth.ProtectedRoute(
+			pattern,
+			auth.PermLogsRead,
+			auth.SensitivitySensitive,
+			auth.ResourceOwnerObservability,
+			http.MethodGet,
+		))
+		contracts = append(contracts, auth.ProtectedRoute(
+			pattern+"/",
+			auth.PermLogsRead,
+			auth.SensitivitySensitive,
+			auth.ResourceOwnerObservability,
+			http.MethodGet,
+		))
+	}
+	routes.HandleGroup(contracts, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -321,16 +411,10 @@ func registerSmartAPIRouter(mux *http.ServeMux, proxies dashboardProxySet) {
 			proxies.jaegerAPI.ServeHTTP(w, r)
 			return
 		}
-		if proxies.grafanaStatic != nil {
-			log.Printf("Routing to Grafana API: %s", r.URL.Path)
-			proxies.grafanaStatic.ServeHTTP(w, r)
-			return
-		}
-
 		log.Printf("No handler available for: %s", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		http.Error(w, `{"error":"Service not available","message":"No API handler configured for this path"}`, http.StatusBadGateway)
-	})
+	}))
 }
 
 func isJaegerAPIPath(path string) bool {
@@ -340,16 +424,16 @@ func isJaegerAPIPath(path string) bool {
 		strings.HasPrefix(path, "/api/dependencies")
 }
 
-func registerMetricsRoutes(mux *http.ServeMux, cfg *config.Config) {
-	mux.HandleFunc("/metrics/router", func(w http.ResponseWriter, r *http.Request) {
+func registerMetricsRoutes(routes *auth.PolicyMux, cfg *config.Config) {
+	routes.HandleFunc(auth.PublicRoute("/metrics/router", http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, cfg.RouterMetrics, http.StatusTemporaryRedirect)
 	})
 }
 
-func registerPrometheusRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerPrometheusRoutes(routes *auth.PolicyMux, cfg *config.Config) {
 	if cfg.PrometheusURL == "" {
-		mux.HandleFunc(
-			"/embedded/prometheus/",
+		routes.HandleFunc(
+			auth.ProtectedRoute("/embedded/prometheus/", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet),
 			serviceUnavailableHTMLHandler("Prometheus", "TARGET_PROMETHEUS_URL", "http://localhost:9090"),
 		)
 		log.Printf("Warning: Prometheus URL not configured")
@@ -360,13 +444,13 @@ func registerPrometheusRoutes(mux *http.ServeMux, cfg *config.Config) {
 	if err != nil {
 		log.Fatalf("prometheus proxy error: %v", err)
 	}
-	mux.HandleFunc("/embedded/prometheus", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/prometheus", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
 		prometheusProxy.ServeHTTP(w, r)
 	})
-	mux.HandleFunc("/embedded/prometheus/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/prometheus/", auth.PermLogsRead, auth.SensitivitySensitive, auth.ResourceOwnerObservability, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
@@ -375,9 +459,16 @@ func registerPrometheusRoutes(mux *http.ServeMux, cfg *config.Config) {
 	log.Printf("Prometheus proxy configured: %s", cfg.PrometheusURL)
 }
 
-func registerFleetSimRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerFleetSimRoutes(routes *auth.PolicyMux, cfg *config.Config) {
+	fleetContract := auth.Route(
+		"/api/fleet-sim/",
+		auth.ReadPolicy(http.MethodGet, auth.PermConfigRead, auth.SensitivitySensitive, auth.ResourceOwnerConfig),
+		auth.MutationPolicy(http.MethodPost, auth.PermConfigWrite, "fleet_sim.create", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 4<<20),
+		auth.MutationPolicy(http.MethodPut, auth.PermConfigWrite, "fleet_sim.update", auth.SensitivitySensitive, auth.ResourceOwnerConfig, 4<<20),
+		auth.MutationPolicy(http.MethodDelete, auth.PermConfigWrite, "fleet_sim.delete", auth.SensitivitySensitive, auth.ResourceOwnerConfig, auth.NoBodyLimit),
+	)
 	if cfg.FleetSimURL == "" {
-		mux.HandleFunc("/api/fleet-sim/", func(w http.ResponseWriter, r *http.Request) {
+		routes.HandleFunc(fleetContract, func(w http.ResponseWriter, r *http.Request) {
 			if middleware.HandleCORSPreflight(w, r) {
 				return
 			}
@@ -401,7 +492,7 @@ func registerFleetSimRoutes(mux *http.ServeMux, cfg *config.Config) {
 		originalDirector(r)
 		r.Header.Set("X-Forwarded-Prefix", "/api/fleet-sim")
 	}
-	mux.HandleFunc("/api/fleet-sim/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(fleetContract, func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}

--- a/dashboard/backend/router/proxy_routes_test.go
+++ b/dashboard/backend/router/proxy_routes_test.go
@@ -6,13 +6,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 )
 
 func TestRegisterFleetSimRoutesReturnsBadGatewayWhenDisabled(t *testing.T) {
 	t.Parallel()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerFleetSimRoutes(mux, &config.Config{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/fleet-sim/api/workloads", nil)
@@ -37,7 +38,7 @@ func TestRegisterFleetSimRoutesProxiesSimulatorPaths(t *testing.T) {
 	}))
 	defer server.Close()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerFleetSimRoutes(mux, &config.Config{FleetSimURL: server.URL})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/fleet-sim/api/workloads", nil)
@@ -71,7 +72,7 @@ func TestRouterAPIProxyReplacesBrowserAuthorization(t *testing.T) {
 	}))
 	defer server.Close()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerRouterAPIProxy(
 		mux,
 		&config.Config{RouterAPIURL: server.URL},
@@ -106,7 +107,7 @@ func TestRouterOutcomeProxyUsesServiceCredential(t *testing.T) {
 	}))
 	defer server.Close()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerRouterAPIProxy(
 		mux,
 		&config.Config{RouterAPIURL: server.URL},
@@ -139,7 +140,7 @@ func TestRouterAPIProxyRejectsUnknownManagementMutation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerRouterAPIProxy(
 		mux,
 		&config.Config{RouterAPIURL: server.URL},
@@ -152,8 +153,8 @@ func TestRouterAPIProxyRejectsUnknownManagementMutation(t *testing.T) {
 
 	mux.ServeHTTP(recorder, req)
 
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotFound)
 	}
 	if calls != 0 {
 		t.Fatalf("upstream calls = %d, want 0", calls)
@@ -161,6 +162,8 @@ func TestRouterAPIProxyRejectsUnknownManagementMutation(t *testing.T) {
 }
 
 func TestRouterManagementProxyAllowlistMatchesDashboardSurfaces(t *testing.T) {
+	routes := auth.NewPolicyMux()
+	routes.HandleGroup(routerProxyContracts(), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	tests := []struct {
 		method string
 		path   string
@@ -180,8 +183,10 @@ func TestRouterManagementProxyAllowlistMatchesDashboardSurfaces(t *testing.T) {
 		{method: http.MethodPost, path: "/api/router/unknown", want: false},
 	}
 	for _, test := range tests {
-		if got := routerManagementProxyRouteAllowed(test.method, test.path); got != test.want {
-			t.Fatalf("routerManagementProxyRouteAllowed(%q, %q) = %v, want %v", test.method, test.path, got, test.want)
+		policy, lookup := routes.LookupRoutePolicy(test.method, test.path)
+		got := lookup == auth.RouteFound && policy.ProxyUpstream
+		if got != test.want {
+			t.Fatalf("proxy policy lookup (%q, %q) = %v, want %v", test.method, test.path, got, test.want)
 		}
 	}
 }

--- a/dashboard/backend/router/route_policy_test.go
+++ b/dashboard/backend/router/route_policy_test.go
@@ -1,0 +1,118 @@
+package router
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
+	"github.com/vllm-project/semantic-router/dashboard/backend/config"
+	"github.com/vllm-project/semantic-router/dashboard/backend/setupmode"
+)
+
+func TestDashboardRouteInventoryHasCompletePolicies(t *testing.T) {
+	server := setupRouteInventoryServer(t)
+	defer func() {
+		if err := server.Close(); err != nil {
+			t.Fatalf("close server: %v", err)
+		}
+	}()
+
+	contracts := server.routePolicies.Contracts()
+	if len(contracts) < 80 {
+		t.Fatalf("route contracts = %d, want at least 80", len(contracts))
+	}
+
+	for _, contract := range contracts {
+		if err := auth.ValidateRouteContract(contract); err != nil {
+			t.Fatalf("invalid contract %q: %v", contract.Pattern, err)
+		}
+		for _, policy := range contract.Policies {
+			if policy.Public {
+				continue
+			}
+			if !slices.Contains(auth.AllPermissions, policy.Permission) {
+				t.Errorf("%s %s uses unknown permission %q", policy.Method, contract.Pattern, policy.Permission)
+			}
+			if policy.AuditMode != auth.AuditNone && policy.AuditAction == "" {
+				t.Errorf("%s %s has no audit action", policy.Method, contract.Pattern)
+			}
+		}
+	}
+}
+
+func TestDashboardRoutePoliciesKeepSecurityDomainsIndependent(t *testing.T) {
+	server := setupRouteInventoryServer(t)
+	defer func() { _ = server.Close() }()
+
+	tests := []struct {
+		method     string
+		path       string
+		permission string
+	}{
+		{method: http.MethodPost, path: "/api/router/v1/chat/completions", permission: auth.PermInferenceRun},
+		{method: http.MethodPost, path: "/api/router/v1/router/outcomes", permission: auth.PermFeedbackSubmit},
+		{method: http.MethodGet, path: "/api/router/v1/router_replay/replay-1", permission: auth.PermReplayRead},
+		{method: http.MethodPost, path: "/api/router/config/deploy", permission: auth.PermConfigDeploy},
+		{method: http.MethodPost, path: "/api/mcp/tools/execute", permission: auth.PermToolsUse},
+		{method: http.MethodPatch, path: "/api/admin/users/user-1", permission: auth.PermUsersManage},
+	}
+	for _, test := range tests {
+		policy, result := server.routePolicies.LookupRoutePolicy(test.method, test.path)
+		if result != auth.RouteFound {
+			t.Fatalf("%s %s lookup = %v", test.method, test.path, result)
+		}
+		if policy.Permission != test.permission {
+			t.Fatalf("%s %s permission = %q, want %q", test.method, test.path, policy.Permission, test.permission)
+		}
+	}
+
+	if _, result := server.routePolicies.LookupRoutePolicy(http.MethodPost, "/api/router/v1/unknown"); result != auth.RouteNotFound {
+		t.Fatalf("unknown Router API lookup = %v, want %v", result, auth.RouteNotFound)
+	}
+	if _, result := server.routePolicies.LookupRoutePolicy(http.MethodGet, "/api/unknown"); result != auth.RouteNotFound {
+		t.Fatalf("unknown Dashboard API lookup = %v, want %v", result, auth.RouteNotFound)
+	}
+}
+
+func setupRouteInventoryServer(t *testing.T) *Server {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	staticDir := filepath.Join(tempDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("mkdir static dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+	configPath := filepath.Join(tempDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("version: v0.3\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := &config.Config{
+		Port:                   "19000",
+		AuthDBPath:             filepath.Join(tempDir, "auth.db"),
+		JWTSecret:              "route-inventory-secret",
+		JWTExpiryHours:         1,
+		StaticDir:              staticDir,
+		ConfigFile:             configPath,
+		AbsConfigPath:          configPath,
+		ConfigDir:              tempDir,
+		RouterAPIURL:           "http://127.0.0.1:18080",
+		RouterMetrics:          "http://127.0.0.1:19190/metrics",
+		MCPEnabled:             true,
+		OpenClawEnabled:        true,
+		OpenClawDataDir:        filepath.Join(tempDir, "openclaw"),
+		WorkflowDBPath:         filepath.Join(tempDir, "workflow.sqlite"),
+		ConfigProjectionDBPath: filepath.Join(tempDir, "projection.sqlite"),
+		EvaluationDBPath:       filepath.Join(tempDir, "evaluation.sqlite"),
+		EvaluationEnabled:      true,
+		MLPipelineEnabled:      true,
+		PythonPath:             "python3",
+	}
+	return Setup(cfg, setupmode.New(configPath, false))
+}

--- a/dashboard/backend/router/router.go
+++ b/dashboard/backend/router/router.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/configprojection"
 	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
@@ -13,8 +14,9 @@ import (
 
 // Server bundles the dashboard mux with lifecycle hooks for durable stores.
 type Server struct {
-	Handler http.Handler
-	Close   func() error
+	Handler       http.Handler
+	Close         func() error
+	routePolicies *auth.PolicyMux
 }
 
 // Setup configures all routes and returns the dashboard server bundle.
@@ -22,12 +24,12 @@ type Server struct {
 // setupResolver is built by main, not here, so that the process has exactly one
 // resolver and one cache over the config file.
 func Setup(cfg *config.Config, setupResolver *setupmode.Resolver) *Server {
-	mux := http.NewServeMux()
+	routes := auth.NewPolicyMux()
 
 	// The bootstrap gate consults the resolver on every unauthenticated
 	// can-register / register call, so it must be wired before any request
 	// arrives. Wiring it later compiles but panics at request time.
-	authSvc := setupAuthRoutes(mux, cfg, setupResolver)
+	authSvc := setupAuthRoutes(routes, cfg, setupResolver)
 
 	wf, err := workflowstore.Open(cfg.WorkflowDBPath, workflowstore.Options{
 		LegacyOpenClawDir: cfg.OpenClawDataDir,
@@ -48,26 +50,37 @@ func Setup(cfg *config.Config, setupResolver *setupmode.Resolver) *Server {
 		handlers.SetConfigProjectionStore(cp)
 	}
 
-	mux.HandleFunc("/api/workflows/health", handlers.WorkflowHealthHandler(wf))
+	routes.HandleFunc(
+		auth.ProtectedRoute(
+			"/api/workflows/health",
+			auth.PermTopologyRead,
+			auth.SensitivityOperational,
+			auth.ResourceOwnerWorkflow,
+			http.MethodGet,
+		),
+		handlers.WorkflowHealthHandler(wf),
+	)
 	log.Printf("Workflow health API registered: /api/workflows/health")
 
 	openClawHandler := newOpenClawHandler(cfg, wf)
 	recipeStore := newDashboardRecipeStore(cfg)
 
-	registerCoreRoutes(mux, cfg, setupResolver, coreRouteOptions{
+	registerCoreRoutes(routes, cfg, setupResolver, coreRouteOptions{
 		recipeStore:              recipeStore,
 		modelVerificationAuditor: authSvc,
 	})
-	registerEvaluationRoutes(mux, cfg)
-	SetupMCP(mux, cfg, wf, openClawHandler)
-	registerMLPipelineRoutes(mux, cfg, wf)
-	registerOpenClawRoutes(mux, cfg, openClawHandler)
-	registerProxyRoutes(mux, cfg, recipeStore)
+	registerEvaluationRoutes(routes, cfg)
+	SetupMCP(routes, cfg, wf, openClawHandler)
+	registerMLPipelineRoutes(routes, cfg, wf)
+	registerOpenClawRoutes(routes, cfg, openClawHandler)
+	registerProxyRoutes(routes, cfg, recipeStore)
 
 	// Static frontend must be registered last.
-	mux.Handle("/", handlers.StaticFileServer(cfg.StaticDir))
+	routes.HandleFallback("/", handlers.StaticFileServer(cfg.StaticDir))
+	routes.Seal()
 	return &Server{
-		Handler: wrapWithAuth(mux, authSvc),
+		Handler:       wrapWithAuth(routes, authSvc),
+		routePolicies: routes,
 		Close: func() error {
 			if cp == nil {
 				return nil

--- a/dashboard/backend/router/router_replay_proxy_contract_test.go
+++ b/dashboard/backend/router/router_replay_proxy_contract_test.go
@@ -45,7 +45,7 @@ func TestDashboardReplayPathUsesAuthenticatedManagementProxyNotEnvoy(t *testing.
 	}))
 	defer routerServer.Close()
 
-	mux := http.NewServeMux()
+	mux := auth.NewPolicyMux()
 	registerRouterAPIProxy(
 		mux,
 		&config.Config{RouterAPIURL: routerServer.URL},

--- a/dashboard/backend/router/wizmap_routes.go
+++ b/dashboard/backend/router/wizmap_routes.go
@@ -4,24 +4,26 @@ import (
 	"log"
 	"net/http"
 
+	auth "github.com/vllm-project/semantic-router/dashboard/backend/auth"
 	"github.com/vllm-project/semantic-router/dashboard/backend/config"
 	"github.com/vllm-project/semantic-router/dashboard/backend/handlers"
 	"github.com/vllm-project/semantic-router/dashboard/backend/middleware"
 )
 
-func registerWizMapRoutes(mux *http.ServeMux, cfg *config.Config) {
+func registerWizMapRoutes(routes *auth.PolicyMux, cfg *config.Config) {
 	handler := handlers.WizMapStaticHandler(cfg.StaticDir)
-	mux.HandleFunc("/embedded/wizmap", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/wizmap", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
 		handler(w, r)
 	})
-	mux.HandleFunc("/embedded/wizmap/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc(auth.ProtectedRoute("/embedded/wizmap/", auth.PermConfigRead, auth.SensitivityOperational, auth.ResourceOwnerConfig, http.MethodGet), func(w http.ResponseWriter, r *http.Request) {
 		if middleware.HandleCORSPreflight(w, r) {
 			return
 		}
 		handler(w, r)
 	})
+	routes.HandleFunc(auth.PublicRoute("/embedded/wizmap/assets/", http.MethodGet), handler)
 	log.Printf("WizMap static app registered at /embedded/wizmap/")
 }


### PR DESCRIPTION
Closes #2466

## Purpose

Protected Dashboard routes and permission resolution were maintained separately. Unmapped `/api` paths inherited `config.read`, so a new endpoint could fail open. Declared Replay and feedback permissions were also not applied at the proxy boundary, which made some role controls ineffective.

This binds authorization to route registration: each protected method declares permission, sensitivity, resource owner, and audit together. Unknown or incomplete `/api` and `/embedded` registrations are denied. Replay, feedback, and inference stay independently enforceable.

- **Owner** `wg/enterprise-environment`
- **Modules** Dashboard backend `auth`, `router`, and `handlers`
- Parent audit: #2375. Related: #1146 (Replay), #1452 (feedback)

## What changed

- `auth/route_policy.go` and `auth/policy_mux.go` — `PolicyMux` is the only registration seam. A route group must register method, permission, sensitivity, resource owner, and audit together; incomplete contracts are rejected before they are served. `AuthenticateRequest` and `ServiceUnavailableGuard` look up the same registry, so healthy and degraded startup cannot drift.
- `auth/middleware.go` — unknown protected paths return 403 instead of inheriting `config.read`. Sensitive mutations bound the request body, recheck permission after the body is read, and recheck again before the side effect via `RevalidateRequest`. Required-audit mutations write an audit row from the route contract rather than ad-hoc handler calls.
- `auth/schema.go` — adds `inference.run` and keeps `replay.read` / `feedback.submit` as first-class permissions. User-level `allowed=0` now actually revokes role grants.
- Route wiring in `router.go`, `auth_routes.go`, `core_routes.go`, `mcp_routes.go`, `openclaw_routes.go`, `proxy_routes.go`, and `wizmap_routes.go` — chat completions require `inference.run`, outcomes require `feedback.submit`, Replay requires `replay.read`. The leftover Grafana `/api/` catch-all is gone.
- Privileged writes revalidate before commit: admin user create/update/delete/password, config update, global raw, deploy, rollback, setup activate/import-remote, recipe import/activate/deactivate, security policy save, and MCP create/update/delete/connect/disconnect.
- `handlers/config_mutation_ownership.go` — generic `config.write` / `config.deploy` cannot smuggle `tenant_grants`, `tenant_quotas`, `virtual_keys`, `audit_policy`, or `breakglass` fields. Mixed-ownership YAML is denied before the config is written.

## Out of scope

These are later issues, not this PR:

- Organization / project / membership APIs: #2797
- Real break-glass UI and HTTP entry: #2798
- Service accounts and virtual keys: #2801

Break-glass currently has a separate permission, max-auth-age rule, and unit test only. There is no production HTTP surface for it yet.

## Test Plan

```bash
cd dashboard/backend && go test -race ./auth ./router ./handlers
make dashboard-check
make agent-validate
make agent-e2e-affected CHANGED_FILES="dashboard/backend/auth/middleware.go,dashboard/backend/router/router.go"
```

New coverage against the issue acceptance items:

- `TestDashboardRouteInventoryHasCompletePolicies` — every registered contract has one complete policy; inventory must stay at least 80 routes.
- `TestDashboardRoutePoliciesKeepSecurityDomainsIndependent` — chat, outcomes, Replay, deploy, MCP execute, and admin patch keep distinct permissions; unknown `/api` paths are not found.
- `TestAuthenticateRequestDeniesUnknownProtectedRoutes` — unregistered `/api` returns 403.
- `TestIndependentPermissionGrantAndRevoke` — config, Replay, feedback, inference, ML, and OpenClaw can be granted and revoked independently.
- `TestInferencePermissionIsIndependentFromConfigRead` — `config.read` does not authorize chat completions.
- `TestMutationRequestBodyIsBounded` / `TestMutationRechecksPermissionAfterPausedBody` — oversized bodies are rejected; a revoke mid-request cannot commit.
- `TestConfigDeployPermissionCannotMutateDatabaseOwnedEnterprisePolicy` — `config.deploy` without grant/quota publish cannot change tenant grants, quotas, virtual keys, or audit policy.
- `TestBreakGlassAuthorizationIsTimeBounded` — break-glass is a separate, time-bounded permission.

## Test Result

- `go test -race ./auth ./router ./handlers` passed. `TestRoomCollaborationBus_WSDisconnectDoesNotBreakSSE` was skipped as a pre-existing OpenClaw race, not introduced here.
- `make dashboard-check` and `make agent-validate` passed.
- Remaining risk: `make agent-e2e-affected` was not run locally. Issue Validation still requires the affected Dashboard/router E2E profile before this can fully close #2466.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>