### PR TITLE
[Bindings] Fix PII entity confidence averaging

### DIFF
--- a/candle-binding/src/model_architectures/traditional/modernbert.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert.rs
@@ -1254,7 +1254,23 @@ pub(crate) struct BioEntity {
     pub start: usize,
     pub end: usize,
     pub text: String,
+    /// Arithmetic mean of the per-token confidences merged into this entity.
     pub confidence: f32,
+    /// Number of tokens merged into this entity.
+    pub token_count: u32,
+}
+
+impl BioEntity {
+    /// Fold one more token's confidence into the running arithmetic mean.
+    ///
+    /// This deliberately is not `(self.confidence + confidence) / 2.0`. That
+    /// form is a running pairwise fold, which gives the last token weight 1/2
+    /// and the leading `B-` token weight 1/2^(n-1), so an entity's confidence
+    /// ends up depending on how many tokens it happened to split into.
+    fn accumulate(&mut self, confidence: f32) {
+        self.token_count += 1;
+        self.confidence += (confidence - self.confidence) / self.token_count as f32;
+    }
 }
 
 /// Merge a sequence of BIO-labelled tokens into entities.
@@ -1277,6 +1293,7 @@ pub(crate) fn merge_bio_entities(text: &str, tokens: &[BioToken<'_>]) -> Vec<Bio
                 end: token.end,
                 text: text[token.start..token.end].to_string(),
                 confidence: token.confidence,
+                token_count: 1,
             });
         } else if let Some(entity_type) = token.label.strip_prefix("I-") {
             // Continuation of the open entity, when the type matches.
@@ -1284,8 +1301,7 @@ pub(crate) fn merge_bio_entities(text: &str, tokens: &[BioToken<'_>]) -> Vec<Bio
                 if entity.entity_type == entity_type {
                     entity.end = token.end;
                     entity.text = text[entity.start..entity.end].to_string();
-                    // Update confidence with average
-                    entity.confidence = (entity.confidence + token.confidence) / 2.0;
+                    entity.accumulate(token.confidence);
                 } else {
                     // Different entity type: close the open entity, drop this token.
                     entities.push(entity.clone());

--- a/candle-binding/src/model_architectures/traditional/modernbert.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert.rs
@@ -1234,6 +1234,80 @@ impl TraditionalModernBertClassifier {
 /// Token entity tuple returned by `classify_tokens`: (token, label_id, confidence, start, end)
 type TokenEntityTuple = (String, usize, f32, usize, usize);
 
+/// One token's resolved BIO classification, consumed by [`merge_bio_entities`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BioToken<'a> {
+    /// Full BIO label, for example `B-PERSON`, `I-PERSON` or `O`.
+    pub label: &'a str,
+    /// Byte offset of the token's start in the original text.
+    pub start: usize,
+    /// Byte offset of the token's end in the original text.
+    pub end: usize,
+    /// Probability the model assigned to `label`.
+    pub confidence: f32,
+}
+
+/// A run of BIO tokens merged into a single entity.
+#[derive(Debug, Clone)]
+pub(crate) struct BioEntity {
+    pub entity_type: String,
+    pub start: usize,
+    pub end: usize,
+    pub text: String,
+    pub confidence: f32,
+}
+
+/// Merge a sequence of BIO-labelled tokens into entities.
+///
+/// `tokens` must already have special tokens removed and must be in text order.
+/// Offsets are byte offsets into `text`.
+pub(crate) fn merge_bio_entities(text: &str, tokens: &[BioToken<'_>]) -> Vec<BioEntity> {
+    let mut entities: Vec<BioEntity> = Vec::new();
+    let mut current: Option<BioEntity> = None;
+
+    for token in tokens {
+        if let Some(entity_type) = token.label.strip_prefix("B-") {
+            // Beginning of a new entity.
+            if let Some(entity) = current.take() {
+                entities.push(entity);
+            }
+            current = Some(BioEntity {
+                entity_type: entity_type.to_string(),
+                start: token.start,
+                end: token.end,
+                text: text[token.start..token.end].to_string(),
+                confidence: token.confidence,
+            });
+        } else if let Some(entity_type) = token.label.strip_prefix("I-") {
+            // Continuation of the open entity, when the type matches.
+            if let Some(ref mut entity) = current {
+                if entity.entity_type == entity_type {
+                    entity.end = token.end;
+                    entity.text = text[entity.start..entity.end].to_string();
+                    // Update confidence with average
+                    entity.confidence = (entity.confidence + token.confidence) / 2.0;
+                } else {
+                    // Different entity type: close the open entity, drop this token.
+                    entities.push(entity.clone());
+                    current = None;
+                }
+            }
+            // An I- tag with no open entity is ignored.
+        } else {
+            // O tag closes any open entity.
+            if let Some(entity) = current.take() {
+                entities.push(entity);
+            }
+        }
+    }
+
+    if let Some(entity) = current.take() {
+        entities.push(entity);
+    }
+
+    entities
+}
+
 impl TraditionalModernBertTokenClassifier {
     /// Create a new traditional ModernBERT token classifier with auto-detected variant
     pub fn new(model_id: &str, use_cpu: bool) -> Result<Self> {
@@ -1471,78 +1545,25 @@ impl TraditionalModernBertTokenClassifier {
             return Ok(results);
         }
 
-        // BIO tag entity extraction (like old architecture)
-        #[derive(Debug, Clone)]
-        struct TokenEntity {
-            entity_type: String,
-            start: usize,
-            end: usize,
-            text: String,
-            confidence: f32,
-        }
-
-        let mut entities = Vec::new();
-        let mut current_entity: Option<TokenEntity> = None;
-
-        for (i, (&pred_id, offset)) in predictions_vec
+        // BIO tag entity extraction
+        let labeled: Vec<BioToken<'_>> = predictions_vec
             .iter()
             .zip(tokenization_result.offsets.iter())
             .enumerate()
-        {
-            // Skip special tokens (BOS, EOS, PAD, etc. have offset (0,0))
-            // Note: All special tokens have zero-length offsets, including BOS at index 0
-            if offset.0 == 0 && offset.1 == 0 {
-                continue;
-            }
+            // Skip special tokens (BOS, EOS, PAD, etc. have offset (0,0)).
+            .filter(|(_, (_, offset))| !(offset.0 == 0 && offset.1 == 0))
+            .map(|(i, (&pred_id, offset))| BioToken {
+                label: id2label
+                    .get(&pred_id.to_string())
+                    .map(String::as_str)
+                    .unwrap_or("O"),
+                start: offset.0,
+                end: offset.1,
+                confidence: probs_data[i][pred_id as usize],
+            })
+            .collect();
 
-            // Get label from prediction ID
-            let label = id2label
-                .get(&pred_id.to_string())
-                .unwrap_or(&"O".to_string())
-                .clone();
-            let confidence = probs_data[i][pred_id as usize];
-
-            if let Some(stripped) = label.strip_prefix("B-") {
-                // Beginning of new entity
-                if let Some(entity) = current_entity.take() {
-                    entities.push(entity);
-                }
-
-                let entity_type = stripped.to_string();
-                current_entity = Some(TokenEntity {
-                    entity_type,
-                    start: offset.0,
-                    end: offset.1,
-                    text: text[offset.0..offset.1].to_string(),
-                    confidence,
-                });
-            } else if let Some(entity_type) = label.strip_prefix("I-") {
-                // Inside current entity
-                if let Some(ref mut entity) = current_entity {
-                    if entity.entity_type == entity_type {
-                        // Extend current entity
-                        entity.end = offset.1;
-                        entity.text = text[entity.start..entity.end].to_string();
-                        // Update confidence with average
-                        entity.confidence = (entity.confidence + confidence) / 2.0;
-                    } else {
-                        // Different entity type, finish current and don't start new
-                        entities.push(entity.clone());
-                        current_entity = None;
-                    }
-                } // If no current entity, ignore I- tag
-            } else {
-                // Outside entity (O tag or different entity type)
-                if let Some(entity) = current_entity.take() {
-                    entities.push(entity);
-                }
-            }
-        }
-
-        // Add final entity if exists
-        if let Some(entity) = current_entity.take() {
-            entities.push(entity);
-        }
+        let entities = merge_bio_entities(text, &labeled);
 
         // Convert entities to results format
         for entity in entities {

--- a/candle-binding/src/model_architectures/traditional/modernbert_test.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert_test.rs
@@ -1857,3 +1857,166 @@ fn test_candle_short_prompt_not_truncated() {
         capped_count
     );
 }
+
+/// The confidence of a merged entity must be the arithmetic mean of the
+/// confidences of every token in it.
+///
+/// Regression test. The previous implementation used
+/// `(entity.confidence + confidence) / 2.0`, a running pairwise fold that
+/// weights the last subword 1/2 and the leading `B-` token 1/2^(n-1). For the
+/// four tokens below that fold returns 0.8925 while the mean is 0.8050, which
+/// straddles a 0.85 PII threshold.
+#[rstest]
+fn test_modernbert_bio_entity_confidence_is_token_mean() {
+    let text = "john.doe@example.com";
+    let confidences = [0.98_f32, 0.30, 0.95, 0.99];
+    let tokens = [
+        BioToken {
+            label: "B-EMAIL_ADDRESS",
+            start: 0,
+            end: 4,
+            confidence: confidences[0],
+        },
+        BioToken {
+            label: "I-EMAIL_ADDRESS",
+            start: 4,
+            end: 8,
+            confidence: confidences[1],
+        },
+        BioToken {
+            label: "I-EMAIL_ADDRESS",
+            start: 8,
+            end: 9,
+            confidence: confidences[2],
+        },
+        BioToken {
+            label: "I-EMAIL_ADDRESS",
+            start: 9,
+            end: 20,
+            confidence: confidences[3],
+        },
+    ];
+
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 1);
+
+    let entity = &entities[0];
+    assert_eq!(entity.entity_type, "EMAIL_ADDRESS");
+    assert_eq!(entity.text, text);
+    assert_eq!(entity.token_count, 4);
+
+    let expected = confidences.iter().sum::<f32>() / confidences.len() as f32;
+    assert!(
+        (entity.confidence - expected).abs() < 1e-6,
+        "confidence {} is not the mean {}",
+        entity.confidence,
+        expected
+    );
+
+    // Guard against a regression back to the pairwise fold.
+    let pairwise_fold = confidences
+        .iter()
+        .copied()
+        .reduce(|acc, c| (acc + c) / 2.0)
+        .unwrap();
+    assert!(
+        (entity.confidence - pairwise_fold).abs() > 1e-3,
+        "confidence matches the old pairwise fold {}",
+        pairwise_fold
+    );
+}
+
+/// A single-token entity keeps the token's own confidence.
+#[rstest]
+fn test_modernbert_bio_entity_confidence_single_token() {
+    let text = "Seoul";
+    let tokens = [BioToken {
+        label: "B-GPE",
+        start: 0,
+        end: 5,
+        confidence: 0.42,
+    }];
+
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0].token_count, 1);
+    assert!((entities[0].confidence - 0.42).abs() < 1e-6);
+}
+
+/// Two tokens are the one case where the old fold and the mean agree, so this
+/// pins that the fix did not shift the easy case.
+#[rstest]
+fn test_modernbert_bio_entity_confidence_two_tokens() {
+    let text = "John Smith";
+    let tokens = [
+        BioToken {
+            label: "B-PERSON",
+            start: 0,
+            end: 4,
+            confidence: 0.9,
+        },
+        BioToken {
+            label: "I-PERSON",
+            start: 4,
+            end: 10,
+            confidence: 0.6,
+        },
+    ];
+
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0].token_count, 2);
+    assert!((entities[0].confidence - 0.75).abs() < 1e-6);
+}
+
+/// Entity boundary handling is unchanged: `O` closes an entity, a mismatched
+/// `I-` closes it and is dropped, and an `I-` with no open entity is ignored.
+#[rstest]
+fn test_modernbert_bio_entity_boundaries() {
+    let text = "aa bb cc dd";
+    let tokens = [
+        BioToken {
+            label: "I-PERSON",
+            start: 0,
+            end: 2,
+            confidence: 0.9,
+        }, // orphan, ignored
+        BioToken {
+            label: "B-PERSON",
+            start: 3,
+            end: 5,
+            confidence: 0.8,
+        },
+        BioToken {
+            label: "I-GPE",
+            start: 6,
+            end: 8,
+            confidence: 0.7,
+        }, // mismatch, closes
+        BioToken {
+            label: "B-GPE",
+            start: 9,
+            end: 11,
+            confidence: 0.6,
+        },
+        BioToken {
+            label: "O",
+            start: 11,
+            end: 11,
+            confidence: 0.5,
+        }, // closes
+    ];
+
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 2);
+
+    assert_eq!(entities[0].entity_type, "PERSON");
+    assert_eq!(entities[0].text, "bb");
+    assert_eq!(entities[0].token_count, 1);
+    assert!((entities[0].confidence - 0.8).abs() < 1e-6);
+
+    assert_eq!(entities[1].entity_type, "GPE");
+    assert_eq!(entities[1].text, "dd");
+    assert_eq!(entities[1].token_count, 1);
+    assert!((entities[1].confidence - 0.6).abs() < 1e-6);
+}


### PR DESCRIPTION
Closes #3026

## Purpose

The BIO merge updated entity confidence with `(entity.confidence + confidence) / 2.0`. Past two tokens that's not an average, it's a running fold where the last subword gets half the weight. So confidence depended on how many tokens the entity split into.

`classifier_pii_ops.go` checks that number against the threshold, so it decides whether PII gets masked. 25 of 447 entities land on the other side of the default 0.9 threshold once it's a real mean.

First commit moves the merge loop into `merge_bio_entities`. It was using a struct declared inside `classify_tokens`, so there was no way to test it without a model. Loop body carried over as is, old `/2.0` included. No behavior change.

Second commit is the fix plus tests.

## Test Plan

```
cargo check  --tests --no-default-features
cargo test   --no-default-features --lib -- test_modernbert_bio_entity
cargo fmt    --check
cargo clippy --no-default-features --tests
```

Also loaded `model.safetensors` through `TraditionalModernBertTokenClassifier` and ran 220 PII sentences against a build of each commit, to check they do what they say.

## Test Result

```
cargo check     ok, 55s
cargo test      4 passed, 0 failed, 623 filtered out
cargo fmt       clean
cargo clippy    17 errors / 68 warnings, all in src/ffi/*.rs (not_unsafe_ptr_arg_deref).
                Same 17/68 on 431dedf without this branch, so nothing new.
```

The new `test_modernbert_bio_entity_confidence_is_token_mean` fails on the old code with `confidence 0.8925 is not the mean 0.805`. The other three pass before and after, they pin behavior that shouldn't move.

Candle run, first commit vs second, same 220 sentences:

```
447 entities from both, spans and types identical, only confidence moves

|fold - mean|   max 0.1694   p95 0.0771

threshold 0.85   24/447 differ   16 the fold passes and the mean blocks
threshold 0.90   25/447 differ   14 the fold passes and the mean blocks
threshold 0.95   29/447 differ   11 the fold passes and the mean blocks
```

Used `--no-default-features` because `default = ["cuda"]` and there's no CUDA toolchain here, so `make test-binding` didn't run. CI should cover it.