### PR TITLE
[Community] Add Abhinav as Workgroup member

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -206,6 +206,11 @@ export const workGroups: WorkGroup[] = [
     ],
     members: [
       {
+        name: 'Abhinav Mahajan',
+        avatar: 'https://github.com/abhinav-m22.png',
+        profile: 'https://github.com/abhinav-m22',
+      },
+      {
         name: 'Mahdi Ghodsi',
         avatar: 'https://github.com/Mahdi-CV.png',
         profile: 'https://github.com/Mahdi-CV',


### PR DESCRIPTION
Related #2970

Adds me to the Developer Experience & Ecosystem roster. I accepted on #2970 and was [confirmed](https://github.com/vllm-project/semantic-router/issues/2970#issuecomment-5406415067), but #3011 was opened shortly before that so I was missed. Follows the same pattern as #3023.


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
