### PR TITLE
[Bug] Make decision description optional in dashboard config parser

### DIFF
--- a/dashboard/frontend/src/types/config.ts
+++ b/dashboard/frontend/src/types/config.ts
@@ -335,7 +335,7 @@ export interface PluginConfig {
 
 export interface Decision {
   name: string
-  description: string
+  description?: string
   priority: number
   rules: DecisionRules
   modelRefs: ModelRef[]

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -1463,7 +1463,7 @@ class Decision(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     name: str
-    description: str
+    description: Optional[str] = None
     priority: int
     tier: int = Field(default=0, ge=0)
     # A decision without an explicit rule is the canonical match-all fallback.

--- a/src/vllm-sr/tests/test_cli_models.py
+++ b/src/vllm-sr/tests/test_cli_models.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+UserConfig = importlib.import_module("cli.models").UserConfig
+
+
+def _decision(**overrides):
+    decision = {
+        "name": "vision_request",
+        "priority": 1000,
+        "rules": {
+            "operator": "AND",
+            "conditions": [{"type": "conversation", "name": "image_input"}],
+        },
+        "modelRefs": [{"model": "vision-model"}],
+    }
+    decision.update(overrides)
+    return decision
+
+
+def test_decision_without_description_parses():
+    config = UserConfig(version="0.3", routing={"decisions": [_decision()]})
+
+    assert config.decisions[0].description is None
+
+
+def test_decision_with_description_still_parses():
+    config = UserConfig(
+        version="0.3",
+        routing={"decisions": [_decision(description="Routes vision requests.")]},
+    )
+
+    assert config.decisions[0].description == "Routes vision requests."


### PR DESCRIPTION
## Summary
- The Go router schema (`decision_config.go`) has always treated a decision's `description` as optional (`yaml:"description,omitempty"`), but the dashboard's Pydantic `UserConfig` model required it as a non-empty `str`.
- Any hand-edited `config.yaml` that omitted a decision's description made the whole dashboard save fail with a Pydantic `Field required` error, even for unrelated decisions in the same config.
- Makes `Decision.description` `Optional[str]` in `src/vllm-sr/cli/models.py` to match the Go schema, and relaxes the matching frontend `Decision` type in `dashboard/frontend/src/types/config.ts`, which already treats the field as optional everywhere it's read (`?.`, `?? ''`, `|| 'N/A'`).

Fixes #3000

## Test plan
- [x] Added `src/vllm-sr/tests/test_cli_models.py` covering a decision with and without `description`
- [x] `python3 -m pytest tests/test_cli_models.py -v` passes
- [x] Full CLI suite (`pytest tests/ --ignore=tests/test_openclaw_podman_socket.py`) passes: 1081 passed, 7 pre-existing unrelated failures in `test_runtime_lifecycle_lock.py` / `test_recipe_topology_recovery.py` (filesystem-ownership checks, unaffected by this change)
- [ ] Dashboard frontend type-check not run locally (`node_modules` not installed in this environment); the field is read defensively (optional-chaining/fallbacks) everywhere in the frontend already, so this is a type-only relaxation