### PR TITLE
[Docs] Complete the Workgroups Epic map

### DIFF
--- a/website/blog/2026-08-24-join-vllm-sr-workgroups.md
+++ b/website/blog/2026-08-24-join-vllm-sr-workgroups.md
@@ -44,7 +44,9 @@ The Workgroups therefore form one system. They are separated by responsibility,
 not by isolated code ownership.
 
 Choose the Direction that matches the problem you want to solve. Each section
-shows its motivation, ownership boundary, and accepted Epic directions.
+shows its motivation, ownership boundary, and tracked Epic directions. The
+linked GitHub issue labels are the source of truth for current acceptance and
+delivery status.
 
 ## [MoM & Routing](https://github.com/vllm-project/semantic-router/issues/2965)
 
@@ -70,6 +72,10 @@ behavior unpredictable.
   rolled back.
 - Connect offline evaluation, routing outcomes, replay data, and human feedback
   to reviewable recipe improvements.
+- Build modality-aware pools spanning text, image, audio, video, and qualified
+  omni-capable backends.
+- Reuse approved reasoning experiences when they measurably improve the
+  quality-cost frontier for smaller models.
 - Improve cross-model efficiency, including safe reuse of computation when a
   request moves between compatible models.
 
@@ -84,7 +90,10 @@ Workgroups.
 
 - [Define portable MoM model pools, routing recipes, evaluation, and model cards](https://github.com/vllm-project/semantic-router/issues/2971)
 - [Optimize routing recipes through an offline-to-online lifecycle](https://github.com/vllm-project/semantic-router/issues/2238)
+- [Advance bounded multi-model collaboration algorithms](https://github.com/vllm-project/semantic-router/issues/3037)
 - [Enable safe cross-model KV-cache reuse](https://github.com/vllm-project/semantic-router/issues/2976)
+- [Enable vLLM-Omni backends and modality-aware MoM pools](https://github.com/vllm-project/semantic-router/issues/3030)
+- [Reuse validated reasoning experiences for small-model inference](https://github.com/vllm-project/semantic-router/issues/3031)
 
 ## [Router Models & Inference Runtime](https://github.com/vllm-project/semantic-router/issues/2966)
 
@@ -125,6 +134,7 @@ the tensor engines and GPU schedulers it integrates with.
 - [Build an extensible inference runtime for Router Models](https://github.com/vllm-project/semantic-router/issues/2782)
 - [Improve current Router Models and develop routing-native model families](https://github.com/vllm-project/semantic-router/issues/2974)
 - [Build a reproducible SLM self-improvement and Router Model fine-tuning pipeline](https://github.com/vllm-project/semantic-router/issues/2975)
+- [Harden multimodal and image-routing signal robustness](https://github.com/vllm-project/semantic-router/issues/2347)
 
 ## [Data Plane & Networking](https://github.com/vllm-project/semantic-router/issues/2967)
 
@@ -150,6 +160,8 @@ existing gateway environment.
   behaviorally consistent with standalone mode.
 - Define engine-neutral backend connectivity and cooperate with serving and
   load-balancing layers on inference-aware endpoint selection.
+- Make semantic response caching safe and measurable across local and shared
+  tiers, with explicit identity, validation, freshness, and invalidation.
 - Optimize latency, throughput, resource efficiency, streaming behavior, and
   failure recovery with reproducible measurements.
 
@@ -163,6 +175,7 @@ how a Router Model is trained, or which MoM recipe is best.
 
 - [Support standalone and gateway-integrated data plane modes](https://github.com/vllm-project/semantic-router/issues/1138)
 - [Connect semantic routing to inference-aware backend selection](https://github.com/vllm-project/semantic-router/issues/2332)
+- [Make semantic caching safe, measurable, and lifecycle-aware](https://github.com/vllm-project/semantic-router/issues/3036)
 - [Optimize data-plane performance, streaming, and failure recovery](https://github.com/vllm-project/semantic-router/issues/2992)
 
 ## [Enterprise & Environment](https://github.com/vllm-project/semantic-router/issues/2968)
@@ -310,6 +323,8 @@ quality of what it builds.
 
 - Common benchmark structure, dataset provenance, metrics, comparison rules,
   reproducibility, and result publication.
+- First-class evaluation of each published MoM against standalone models,
+  combining a required core suite with extensible objective-specific suites.
 - MoM, recipe, Router Model, agent selection and composition, context, serving,
   platform, and developer-workflow evaluation without replacing each domain's
   objectives.
@@ -328,6 +343,7 @@ model research itself. It defines shared measurement and gates.
 ### Epic directions
 
 - [Build reproducible decision-level routing evaluation](https://github.com/vllm-project/semantic-router/issues/2333)
+- [Evaluate each Mixture-of-Models as a first-class model](https://github.com/vllm-project/semantic-router/issues/3038)
 - [Establish cross-platform performance regression coverage](https://github.com/vllm-project/semantic-router/issues/1510)
 - [Expand end-to-end quality coverage across Router, Dashboard, and deployments](https://github.com/vllm-project/semantic-router/issues/1519)
 


### PR DESCRIPTION
Related #2978

## Purpose

- Complete the public Workgroup Epic map with the vLLM-Omni,
  reasoning-experience-reuse, semantic-cache lifecycle, multimodal
  routing-signal, bounded multi-model collaboration, and first-class MoM
  evaluation directions.
- Clarify that safe semantic caching belongs to Data Plane & Networking while
  reasoning-experience reuse remains a separate MoM & Routing capability.
- Distinguish decision-level routing evaluation from evaluating a complete MoM
  as a model identity against standalone models, with a common core suite,
  objective-specific extensions, and published model-card scorecards.
- Keep GitHub lifecycle labels as the source of truth instead of describing
  every tracked Epic as accepted.

## Test Plan

- Run the repository docs-only agent gate for the changed blog.
- Build the English Docusaurus site.

## Test Result

- `make agent-ci-gate CHANGED_FILES="website/blog/2026-08-24-join-vllm-sr-workgroups.md"` passed.
- `npm run build:en` passed. The build emitted only pre-existing inline-author,
  truncation-marker, browsers-list, and dependency-analysis warnings.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category.
- [x] The title does not stack prefixes.
- [x] The PR links accepted maintainer-owned Workgroup governance.
- [x] Commits are signed off.
- [x] Purpose, tests, and results reflect the actual change.

</details>
