### PR TITLE
[Fix] Share agent harness tooling across linked worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ target/
 *.pyz
 __pycache__/
 .venv/
-.venv-agent/
+.venv-agent
 pii_env/
 
 # Python build artifacts

--- a/tools/agent/docs/environments.md
+++ b/tools/agent/docs/environments.md
@@ -1,5 +1,17 @@
 # Environments
 
+## Harness Tooling Across Worktrees
+
+Linked Git worktrees share the primary worktree's `.venv-agent` by default.
+`make agent-bootstrap` creates the environment once and adds an ignored
+`.venv-agent` symlink in each linked worktree so Make targets and pre-commit
+hooks use the same pinned tools. Set `AGENT_VENV=<path>` only when an isolated
+tool environment is required.
+
+If a linked worktree already contains a real `.venv-agent` directory, move or
+remove that generated directory before bootstrapping so the harness can create
+the shared-environment symlink without overwriting local files.
+
 ## `cpu-local`
 
 - Build with `make vllm-sr-dev`

--- a/tools/ci/tests/test_agent_make_contract.py
+++ b/tools/ci/tests/test_agent_make_contract.py
@@ -6,6 +6,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AGENT_MAKE = (REPO_ROOT / "tools/make/agent.mk").read_text(encoding="utf-8")
 LINTER_MAKE = (REPO_ROOT / "tools/make/linter.mk").read_text(encoding="utf-8")
+PRECOMMIT_MAKE = (REPO_ROOT / "tools/make/pre-commit.mk").read_text(encoding="utf-8")
+GITIGNORE = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
 AGENT_REQUIREMENTS = (REPO_ROOT / "tools/agent/requirements.txt").read_text(
     encoding="utf-8"
 )
@@ -41,6 +43,23 @@ def local_hook(hook_id: str) -> dict:
 
 
 class AgentMakeContractTests(unittest.TestCase):
+    def test_linked_worktrees_share_the_primary_agent_environment(self) -> None:
+        install = target_block("agent-venv-install")
+
+        self.assertIn(
+            "git rev-parse --path-format=absolute --git-common-dir", AGENT_MAKE
+        )
+        self.assertIn("AGENT_VENV ?= $(AGENT_PRIMARY_WORKTREE)/.venv-agent", AGENT_MAKE)
+        self.assertIn("AGENT_WORKTREE_VENV ?= $(CURDIR)/.venv-agent", AGENT_MAKE)
+        self.assertIn('ln -sfn "$(AGENT_VENV)" "$(AGENT_WORKTREE_VENV)"', install)
+        self.assertIn(
+            "AGENT_PRE_COMMIT ?= $(AGENT_VENV)/bin/pre-commit", PRECOMMIT_MAKE
+        )
+        self.assertIn(
+            "AGENT_VENV ?= $(AGENT_PRIMARY_WORKTREE)/.venv-agent", LINTER_MAKE
+        )
+        self.assertIn(".venv-agent", GITIGNORE)
+
     def test_python_requirements_use_a_content_stamp(self) -> None:
         install = target_block("agent-venv-install")
 

--- a/tools/make/agent.mk
+++ b/tools/make/agent.mk
@@ -22,8 +22,13 @@ AGENT_REPORT_WRITE_PATH ?=
 AGENT_REPORT_CONTEXT_DETAIL ?= compact
 AGENT_SKIP_PRECOMMIT_BASELINE ?=
 
-# Repo-local venv for harness deps (avoids PEP 668 / externally-managed-environment on Homebrew Python).
-AGENT_VENV ?= $(CURDIR)/.venv-agent
+# Share harness tooling across linked worktrees. The common Git directory is
+# rooted in the primary worktree for a normal clone; fall back to the current
+# directory outside that layout. AGENT_VENV remains explicitly overridable.
+AGENT_GIT_COMMON_DIR ?= $(shell git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+AGENT_PRIMARY_WORKTREE ?= $(if $(filter %/.git,$(AGENT_GIT_COMMON_DIR)),$(patsubst %/.git,%,$(AGENT_GIT_COMMON_DIR)),$(CURDIR))
+AGENT_WORKTREE_VENV ?= $(CURDIR)/.venv-agent
+AGENT_VENV ?= $(AGENT_PRIMARY_WORKTREE)/.venv-agent
 AGENT_PYTHON ?= $(AGENT_VENV)/bin/python
 AGENT_PRE_COMMIT ?= $(AGENT_VENV)/bin/pre-commit
 AGENT_REQUIREMENTS_STAMP ?= $(AGENT_VENV)/.agent-requirements.txt
@@ -69,6 +74,13 @@ agent-venv-install: ## Create $(AGENT_VENV) and install harness Python requireme
 		! cmp -s tools/agent/requirements.txt "$(AGENT_REQUIREMENTS_STAMP)"; then \
 		"$(AGENT_PYTHON)" -m pip install -r tools/agent/requirements.txt && \
 		cp tools/agent/requirements.txt "$(AGENT_REQUIREMENTS_STAMP)"; \
+	fi
+	@if [ "$(abspath $(AGENT_WORKTREE_VENV))" != "$(abspath $(AGENT_VENV))" ]; then \
+		if [ -e "$(AGENT_WORKTREE_VENV)" ] && [ ! -L "$(AGENT_WORKTREE_VENV)" ]; then \
+			echo "Error: $(AGENT_WORKTREE_VENV) is a local directory; move or remove it so this worktree can use $(AGENT_VENV)." >&2; \
+			exit 1; \
+		fi; \
+		ln -sfn "$(AGENT_VENV)" "$(AGENT_WORKTREE_VENV)"; \
 	fi
 
 agent-bootstrap: agent-venv-install ## Prepare the shared agent Python environment

--- a/tools/make/linter.mk
+++ b/tools/make/linter.mk
@@ -5,7 +5,7 @@
 ##@ Linter
 
 # codespell is installed into .venv-agent by tools/make/agent.mk (agent-venv-install).
-AGENT_VENV ?= $(CURDIR)/.venv-agent
+AGENT_VENV ?= $(AGENT_PRIMARY_WORKTREE)/.venv-agent
 AGENT_CODESPELL ?= $(AGENT_VENV)/bin/codespell
 
 markdown-lint: agent-markdown-bootstrap ## Lint all markdown files in the project

--- a/tools/make/pre-commit.mk
+++ b/tools/make/pre-commit.mk
@@ -2,7 +2,7 @@
 
 PRECOMMIT_CONTAINER := ghcr.io/vllm-project/semantic-router/precommit:latest
 
-AGENT_PRE_COMMIT ?= $(CURDIR)/.venv-agent/bin/pre-commit
+AGENT_PRE_COMMIT ?= $(AGENT_VENV)/bin/pre-commit
 
 precommit-install: ## Install the repo-local pre-commit hook into the agent harness venv
 precommit-install:


### PR DESCRIPTION
Closes #3032

## Purpose

- Reuse the primary worktree's pinned `.venv-agent` across linked Git
  worktrees instead of bootstrapping identical environments repeatedly.
- Keep existing Make and pre-commit paths compatible through an ignored local
  symlink while preserving `AGENT_VENV=<path>` as an isolation override.
- Document the contract and cover Make/linter/pre-commit alignment with a
  focused regression test.

## Test Plan

- Remove the failed linked-worktree environment and run `make agent-report`
  without an environment override.
- Run the harness contract unit test and the canonical harness CI gate.

## Test Result

- A linked worktree reused the primary worktree's `.venv-agent` and completed
  `make agent-report` without attempting a second Python environment.
- `python -m unittest tools.ci.tests.test_agent_make_contract` passed (9 tests).
- `make agent-ci-gate CHANGED_FILES=".gitignore tools/agent/docs/environments.md tools/ci/tests/test_agent_make_contract.py tools/make/agent.mk tools/make/linter.mk tools/make/pre-commit.mk"` passed.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category.
- [x] The title does not stack prefixes.
- [x] The PR links one accepted maintainer-owned issue.
- [x] Commits are signed off.
- [x] Purpose, tests, and results reflect the actual change.

</details>
