### PR TITLE
[Docs] Clarify Workgroup ownership and Epic map

### DIFF
--- a/website/blog/2026-08-24-join-vllm-sr-workgroups.md
+++ b/website/blog/2026-08-24-join-vllm-sr-workgroups.md
@@ -9,87 +9,72 @@ tags: ["community","ecosystem","semantic-router"]
 image: "/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups-invitation-hero.png"
 ---
 
-Open source grows when people can see where their work belongs, who they can
-build with, and how they can make a lasting contribution. vLLM Semantic Router
-now has seven direction-based Workgroups to make that path clear.
+Open source grows when people can see where their work belongs and who they can
+build with. vLLM Semantic Router now has seven Workgroups, each responsible for
+one durable technical direction.
 
 ![Find your focus and passion across seven vLLM Semantic Router Workgroups](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups-invitation-hero.png)
 
 If you are new to the project, start here: vLLM Semantic Router sits between an
-AI application and its model and agent backends. It understands each request
-and session, selects a qualified model or agent, can coordinate a bounded form
-of model or agent collaboration, executes that route, and makes the result
-observable and measurable. The seven Workgroups own the durable technical
-directions needed to make that experience intelligent, fast, reliable, and
-easy to use.
+AI application and its model or agent backends. It understands the request,
+chooses how it should be handled, executes that route, and measures the result.
+The Workgroups divide that system into clear places to contribute.
 
-## How the Pieces Fit Together
+## One System, Seven Clear Owners
 
-A routed request crosses several responsibilities, but each responsibility has
-one clear technical home:
+A routed request crosses several responsibilities:
 
-1. **Developer Experience & Ecosystem** gives users the CLI, Dashboard, APIs,
-   recipes, and guidance needed to describe and operate the system.
-2. **Enterprise & Environment** determines who may use each backend, applies
-   quotas and lifecycle policy, and keeps supported deployments operable.
-3. **Router Models & Inference Runtime** turns the request and session into
-   useful routing signals.
-4. **Agentic & Context** manages bounded context and uses those signals to
-   select, hand off, or compose agent backends for long-running sessions;
-   **MoM & Routing** selects models or bounded multi-model collaboration.
-5. **Data Plane & Networking** invokes the selected model or agent path, while
-   **Evaluation & Quality** measures behavior and protects it from regression.
+1. **Developer Experience & Ecosystem** provides the CLI, Dashboard, APIs,
+   recipes, and learning path.
+2. **Enterprise & Environment** applies access, usage, lifecycle, and
+   deployment policy.
+3. **Router Models & Inference Runtime** produces the signals used to route.
+4. **MoM & Routing** chooses models and multi-model strategies.
+5. **Agentic & Context** manages context and chooses or composes agents.
+6. **Data Plane & Networking** executes the chosen path.
+7. **Evaluation & Quality** measures results and catches regressions.
 
-The Workgroups therefore form one system. They are separated by responsibility,
-not by isolated code ownership.
+They form one system, separated by responsibility rather than isolated code
+ownership. Every Epic below has one owning Workgroup. Dependencies on other
+groups are recorded as shared interfaces in the linked charter.
 
-Choose the Direction that matches the problem you want to solve. Each section
-shows its motivation, ownership boundary, and tracked Epic directions. The
-linked GitHub issue labels are the source of truth for current acceptance and
-delivery status.
+Choose the direction that matches the problem you want to solve. GitHub labels
+on each linked Epic are the source of truth for acceptance and delivery status.
 
 ## [MoM & Routing](https://github.com/vllm-project/semantic-router/issues/2965)
 
-> **Mission:** Make a pool of models behave like one measurable,
-> continuously improving Mixture-of-Models.
+> **Mission:** Make a pool of models behave like one measurable and improving
+> Mixture-of-Models.
 
 ![One request enters a versioned recipe and qualified model pool, which can select, cascade, compare, or combine models before returning one measurable response](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/mom-routing.svg)
 
-### Why this matters
+### The problem
 
-A user should be able to call one stable model name without manually deciding
-which backend to use for every request. A Mixture-of-Models (MoM) needs a model
-pool and a versioned recipe: the pool defines which models are available, while
-the recipe defines when and how they are used. Both must improve without making
-behavior unpredictable.
+A user should be able to call one stable model name without choosing a backend
+for every request. A Mixture-of-Models (MoM) needs a qualified model pool and a
+versioned recipe that can improve without making behavior unpredictable.
 
-### Scope
+### What this Workgroup owns
 
-- Design objective-specific model pools and portable routing recipes.
-- Support different forms of model collaboration: direct selection, fallback,
-  cascade, parallel answers with a judge, synthesis, and bounded workflows.
-- Define how models and recipes are evaluated, shadowed, promoted, retired, and
-  rolled back.
-- Connect offline evaluation, routing outcomes, replay data, and human feedback
-  to reviewable recipe improvements.
-- Build modality-aware pools spanning text, image, audio, video, and qualified
-  omni-capable backends.
-- Reuse approved reasoning experiences when they measurably improve the
-  quality-cost frontier for smaller models.
-- Improve cross-model efficiency, including safe reuse of computation when a
-  request moves between compatible models.
+- Model pools, model roles, portable recipes, and their versioned lifecycle.
+- Model selection and collaboration through fallback, cascade, judging,
+  synthesis, and bounded workflows.
+- Offline-to-online improvement of recipes and pool members against explicit
+  quality, cost, latency, safety, domain, or modality objectives.
+- Modality-aware pools, approved reasoning reuse, and safe reuse of compatible
+  computation across models.
 
-### Non-scope
+### What it does not own
 
 This Workgroup does not train the lightweight models that produce routing
 signals, build the live network path, decide how conversation history is
-compressed, or operate a hosted service. Those responsibilities have their own
-Workgroups.
+compressed, or operate a hosted service.
 
-### Epic directions
+### Owned Epics
 
 - [Define portable MoM model pools, routing recipes, evaluation, and model cards](https://github.com/vllm-project/semantic-router/issues/2971)
 - [Optimize routing recipes through an offline-to-online lifecycle](https://github.com/vllm-project/semantic-router/issues/2238)
+- [Optimize model-pool members against Mixture-of-Models objectives](https://github.com/vllm-project/semantic-router/issues/3041)
 - [Advance bounded multi-model collaboration algorithms](https://github.com/vllm-project/semantic-router/issues/3037)
 - [Enable safe cross-model KV-cache reuse](https://github.com/vllm-project/semantic-router/issues/2976)
 - [Enable vLLM-Omni backends and modality-aware MoM pools](https://github.com/vllm-project/semantic-router/issues/3030)
@@ -102,34 +87,27 @@ Workgroups.
 
 ![A Router Model family improves through a model flywheel while a layered inference runtime executes versioned artifacts and emits typed signals](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/router-models-inference-runtime.svg)
 
-### Why this matters
+### The problem
 
-Before vLLM-SR can choose a route, it needs signals such as intent, complexity,
-safety, preference, or expected quality. Router Models are the specialized
-models that produce those signals and scores. Their quality should improve over
-time, and adding a new model should not require spreading engine-specific code
-throughout the Router.
+Routing depends on signals such as intent, complexity, safety, preference, and
+expected quality. The models that produce those signals must improve over time,
+and new models should not spread engine-specific code throughout the Router.
 
-### Scope
+### What this Workgroup owns
 
-- Post-train, distill, calibrate, and evaluate the Router Models already built
-  into the project.
-- Research routing-native Small Language Model families beyond BERT-only
-  designs, including long-context, multimodal, retrieval, and agentic signals.
-- Support privacy-aware fine-tuning and immutable candidate artifacts that can
-  be evaluated before activation.
-- Define typed inference inputs and outputs, model capabilities, artifact
-  identity, activation, diagnostics, draining, and rollback.
-- Qualify built-in and ecosystem execution through Candle, ONNX Runtime, vLLM,
-  TEI, and other supported engines and hardware.
+- Improve, calibrate, and release the Router Models built into the project.
+- Develop routing-native model families beyond BERT-only designs.
+- Build reproducible self-improvement, distillation, and fine-tuning pipelines.
+- Provide one versioned execution contract across supported engines and
+  hardware, with clear activation, diagnostics, and rollback.
 
-### Non-scope
+### What it does not own
 
 This Workgroup produces routing intelligence; it does not choose the end-user
 MoM pool, own generic gateway forwarding, manage users and quotas, or rebuild
 the tensor engines and GPU schedulers it integrates with.
 
-### Epic directions
+### Owned Epics
 
 - [Build an extensible inference runtime for Router Models](https://github.com/vllm-project/semantic-router/issues/2782)
 - [Improve current Router Models and develop routing-native model families](https://github.com/vllm-project/semantic-router/issues/2974)
@@ -143,35 +121,27 @@ the tensor engines and GPU schedulers it integrates with.
 
 ![Standalone HTTP and Envoy gateway entry modes converge on one shared routing core, backend dispatch path, and response stream](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/data-plane-networking.svg)
 
-### Why this matters
+### The problem
 
-A good decision is useless if the request path is slow, fragile, or behaves
-differently in each deployment. vLLM-SR needs one routing behavior whether it
-runs as a standalone OpenAI-compatible service or integrates with Envoy and an
-existing gateway environment.
+A routing decision has little value if the request path is slow, fragile, or
+different in every deployment. Standalone serving and gateway integration need
+the same behavior and failure semantics.
 
-### Scope
+### What this Workgroup owns
 
-- Process requests and responses, including streaming, dispatch, retries,
-  fallback, errors, telemetry, and immediate responses.
-- Provide a standalone mode for Docker and Kubernetes without making Envoy a
-  mandatory dependency.
-- Keep Envoy ExtProc and qualified gateway integrations first-class and
-  behaviorally consistent with standalone mode.
-- Define engine-neutral backend connectivity and cooperate with serving and
-  load-balancing layers on inference-aware endpoint selection.
-- Make semantic response caching safe and measurable across local and shared
-  tiers, with explicit identity, validation, freshness, and invalidation.
-- Optimize latency, throughput, resource efficiency, streaming behavior, and
-  failure recovery with reproducible measurements.
+- Standalone OpenAI-compatible serving and Envoy or gateway integrations.
+- Request, response, streaming, dispatch, retry, fallback, error, and telemetry
+  behavior.
+- Engine-neutral backend connectivity and inference-aware endpoint selection.
+- Safe semantic caching, performance optimization, and failure recovery.
 
-### Non-scope
+### What it does not own
 
 This Workgroup executes access and routing policy but does not define who may
 access a model, which quota applies, which hardware is officially supported,
 how a Router Model is trained, or which MoM recipe is best.
 
-### Epic directions
+### Owned Epics
 
 - [Support standalone and gateway-integrated data plane modes](https://github.com/vllm-project/semantic-router/issues/1138)
 - [Connect semantic routing to inference-aware backend selection](https://github.com/vllm-project/semantic-router/issues/2332)
@@ -185,7 +155,7 @@ how a Router Model is trained, or which MoM recipe is best.
 
 ![Identity, access, quotas, production lifecycle controls, observability, and supported environments form one production platform](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/enterprise-environment.svg)
 
-### Why this matters
+### The problem
 
 Production users need clear answers to practical questions: Who can call each
 model? How much can they use? What changed? Is the system healthy? Can a model,
@@ -193,31 +163,24 @@ recipe, or Router upgrade be rolled out and reversed safely? Which deployment
 path is maintained, and which components does it own? The answers must remain
 consistent across deployment environments.
 
-### Scope
+### What this Workgroup owns
 
-- Registration, invitations, organizations, teams, serving identities, roles,
-  and model access.
-- API-key creation, rotation, revocation, request and token rate limits, usage
-  accounting, tenant isolation, and audit.
-- Stability, scalability, monitoring, diagnostics, multi-replica consistency,
-  and failure recovery.
-- Model and recipe onboarding, draining, gray release, promotion, rollback, and
-  auditable vLLM-SR upgrades.
-- Stable, scalable deployment and lifecycle APIs across environments; CRDs and
-  the Operator provide their Kubernetes implementation.
-- Maintained Docker, Kubernetes, Operator, and OpenShift reference stacks with
-  clear component ownership and reusable hardware overlays.
-- A tested support matrix across Docker, Kubernetes, CPU, AMD, NVIDIA,
-  precision, images, and maintained configurations.
+- Users, organizations, serving identities, model access, API keys, quotas, and
+  usage accounting.
+- Tenant isolation, audit, reliability, scalability, monitoring, and
+  diagnostics.
+- Model, recipe, configuration, and vLLM-SR activation, rollout, and rollback.
+- Stable deployment and lifecycle APIs, maintained reference stacks, and a
+  tested support matrix across deployment environments and hardware.
 
-### Non-scope
+### What it does not own
 
 This Workgroup does not promise a public hosted-service SLA, expose private
 infrastructure or credentials, define model quality, own evaluation standards,
 or implement networking protocols. It supplies reusable open-source production
 capabilities rather than publishing private product plans.
 
-### Epic directions
+### Owned Epics
 
 - [Build multi-tenant inference access, quotas, and usage controls](https://github.com/vllm-project/semantic-router/issues/2960)
 - [Build versioned configuration activation and rollback](https://github.com/vllm-project/semantic-router/issues/2326)
@@ -231,40 +194,31 @@ capabilities rather than publishing private product plans.
 
 ![A long session is protected and optimized before the Router selects, hands off to, or composes agent backends within explicit limits](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/agentic-context.svg)
 
-### Why this matters
+### The problem
 
-Long conversations accumulate messages, retrieved memory, tool output, tokens,
-cost, and risk. Important instructions can be lost in that growth, and the best
-model or agent may change as the task moves from planning to tool use to final
-response. vLLM-SR should select and compose agent backends while managing those
-constraints without becoming a general-purpose agent framework.
+Long-running work accumulates messages, memory, tool output, cost, and risk.
+Important instructions can be lost, while the best model or agent may change as
+the task evolves. The Router must handle those changes without becoming a
+general-purpose agent framework.
 
-### Scope
+### What this Workgroup owns
 
-- Context compression, message and tool-output pruning, retrieval and memory
-  selection, and prompt restructuring.
-- Explicit protection for system and developer instructions, authorization,
-  safety constraints, tool contracts, and task-critical user intent.
+- Context compression, pruning, memory selection, prompt restructuring, and
+  protection of critical instructions.
 - Session budgets, state boundaries, retention, recovery, and graceful
-  degradation when context or memory capabilities are unavailable.
-- Typed agent identity, capability, tool, state, trust, and lifecycle contracts
-  for selection, fallback, and handoff.
-- Bounded agent composition and multi-agent collaboration with explicit limits
-  on participants, depth, turns, tokens, time, cost, authority, and failures.
-- Requirements and safety constraints for switching models or bounded
-  workflows as a session evolves.
-- Evaluation of selection quality, collaboration gain, handoff loss,
-  instruction retention, task quality, token reduction, latency, cost, safety,
-  and critical-information loss.
+  degradation.
+- Agent selection, fallback, handoff, and bounded multi-agent composition.
+- Safe model or workflow switching as a session evolves, with measurable task,
+  cost, latency, and safety outcomes.
 
-### Non-scope
+### What it does not own
 
 This Workgroup does not build an unrestricted agent orchestrator, own all MoM
 selection algorithms, transport KV caches between models, automate CLI
 installation, or allow silent lossy transformation and unbounded online
 training.
 
-### Epic directions
+### Owned Epics
 
 - [Optimize context for long-session and agentic workloads](https://github.com/vllm-project/semantic-router/issues/2984)
 - [Enable agent-based routing and multi-agent composition](https://github.com/vllm-project/semantic-router/issues/2994)
@@ -277,33 +231,31 @@ training.
 
 ![A developer journey connects discovery, installation, configuration, the first routed request, understanding, sharing, and contribution](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/developer-experience-ecosystem.svg)
 
-### Why this matters
+### The problem
 
 Technical depth has little impact when a new user cannot reach a first request
 or understand what happened. The project also needs clear extension paths so
 contributors, model builders, infrastructure projects, and educators can build
 on it without reverse-engineering the repository.
 
-### Scope
+### What this Workgroup owns
 
-- Installation, configuration, validation, deployment, tuning, diagnostics,
-  and operations across the CLI, Dashboard, and APIs.
-- Dashboard information architecture and developer or operator workflows built
-  on maintained enterprise contracts.
-- An agent-facing vLLM-SR skill for deployment, recipe generation, evaluation,
-  tuning, and reviewed operations.
-- Architecture documentation, tutorials, reference material, examples, model
-  cards, evaluation results, blogs, video tutorials, and release guidance.
-- Use case sharing, reference implementations, extension guidance, partner
-  integrations, and contributor entry points.
+- Installation, configuration, deployment, tuning, diagnosis, and operation
+  through the CLI, Dashboard, and APIs.
+- An agent-facing skill for deployment, recipe generation, evaluation, tuning,
+  and reviewed operations.
+- Documentation, reference recipes, tutorials, model cards, blogs, videos, and
+  use-case sharing.
+- Clear extension and contribution paths for models, runtimes, gateways, and
+  deployment systems.
 
-### Non-scope
+### What it does not own
 
 This Workgroup does not control repository permissions or promotion, run
 marketing events or AMD-internal programs, or redefine algorithms, production
 policy, and quality standards owned by other Workgroups.
 
-### Epic directions
+### Owned Epics
 
 - [Build agent-assisted vLLM-SR deployment, recipe, evaluation, and tuning workflows](https://github.com/vllm-project/semantic-router/issues/2977)
 - [Reduce time to the first successful routed request](https://github.com/vllm-project/semantic-router/issues/2690)
@@ -316,36 +268,32 @@ policy, and quality standards owned by other Workgroups.
 
 ![Capabilities from every direction enter a common evaluation contract, layered evaluation stack, regression gates, and published results](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/evaluation-quality.svg)
 
-### Why this matters
+### The problem
 
 Claims about a Router Model, MoM recipe, agent-selection policy, runtime
 optimization, or deployment are difficult to trust when each uses a different
 dataset and reporting method. The project needs shared evaluation contracts and
-regression gates, while each technical Workgroup remains accountable for the
-quality of what it builds.
+regression gates. Each technical Workgroup remains accountable for what it
+builds; this Workgroup makes the results comparable.
 
-### Scope
+### What this Workgroup owns
 
-- Common benchmark structure, dataset provenance, metrics, comparison rules,
-  reproducibility, and result publication.
-- First-class evaluation of each published MoM against standalone models,
-  combining a required core suite with extensible objective-specific suites.
-- MoM, recipe, Router Model, agent selection and composition, context, serving,
-  platform, and developer-workflow evaluation without replacing each domain's
-  objectives.
-- Model-card and evaluation-result requirements for published MoM identities.
+- Common benchmark, data provenance, metric, comparison, reproducibility, and
+  publication contracts.
+- First-class evaluation of each MoM against standalone models, with a common
+  core and objective-specific extensions.
+- Shared evaluation for routing, agents, context, serving, platform, and
+  developer workflows.
 - CI, E2E, compatibility, security, performance, and operational regression
-  coverage across supported modes and environments.
-- Shared definitions of done and the evaluation required for milestone
-  readiness, upgrade, and rollback.
+  gates.
 
-### Non-scope
+### What it does not own
 
 This Workgroup does not choose another direction's quality target, accept an
 issue, make the final release decision, replace Maintainer review, or own the
 model research itself. It defines shared measurement and gates.
 
-### Epic directions
+### Owned Epics
 
 - [Build reproducible decision-level routing evaluation](https://github.com/vllm-project/semantic-router/issues/2333)
 - [Evaluate each Mixture-of-Models as a first-class model](https://github.com/vllm-project/semantic-router/issues/3038)
@@ -356,10 +304,10 @@ model research itself. It defines shared measurement and gates.
 
 > A Workgroup is a technical home, not a permission level.
 
-Each Workgroup owns one durable technical Direction, its charter, and the
-bounded Epics beneath it. It connects contributors, helps triage proposals, and
-recommends when work is ready to accept. The Open Source Team retains final
-acceptance, review, merge, role, and release authority.
+Each Workgroup owns one durable technical direction and its bounded Epics. It
+connects contributors, maintains the charter, and helps prepare work for
+acceptance. The Open Source Team retains final acceptance, merge, role, and
+release authority.
 
 | Workgroups | Open Source Team |
 | --- | --- |
@@ -367,34 +315,31 @@ acceptance, review, merge, role, and release authority.
 | Triage and acceptance recommendations | Final acceptance, merge, and release authority |
 | Lead and Member roles | Maintainer, Committer, and Contributor roles |
 
-`Direction → Workgroup → domain → bounded Epic → accepted issue`
-
 **Lead.** Every active Workgroup has at least one Lead and may have several. A
-Lead is a Committer or Maintainer, or a Contributor with a merged commit and an
-active Committer/Maintainer Sponsor. Leads maintain the charter and Epic map,
-coordinate triage, and ensure accepted initiatives have delivery owners.
+Lead is a Committer or Maintainer, or a Contributor with a merged commit and a
+Committer or Maintainer Sponsor. Leads maintain the charter and Epic map and
+coordinate triage.
 
 **Member.** A Member has at least one merged repository commit and continues to
 build in the Direction. Anyone may collaborate before meeting the roster
 requirement, and people may join more than one Workgroup.
 
-To join, open the linked charter and comment with your requested role, a merged
-contribution, your focus and availability, and your Sponsor when applying as a
-sponsored Lead. Confirmed Leads and Members appear on the public
+To join, open the charter and comment with your requested role, a merged
+contribution, your focus, availability, and Sponsor when required. Confirmed
+Leads and Members appear on the public
 [Workgroups map](/community/work-groups); these roles provide visibility and
 responsibility, not additional repository permissions.
 
 ## Proposing a New Workgroup
 
 Create a Workgroup only for a durable technical problem that spans releases,
-contains multiple bounded Epics, and cannot fit an existing charter. A single
-feature, algorithm, collaboration, integration, event, or milestone remains an
-Epic inside an existing Workgroup.
+contains several Epics, and cannot fit an existing charter. A feature,
+algorithm, integration, event, or milestone belongs inside an existing group.
 
-A proposal must define the problem, goal, scope, non-scope, interfaces, initial
-Epic map, why existing charters cannot own it, and at least one eligible Lead.
-After Maintainer acceptance, the project creates its charter and owner label,
-opens Lead and Member self-nomination, and adds it to the website.
+A proposal must define the problem, scope, non-scope, shared interfaces, initial
+Epic map, why existing groups cannot own it, and at least one eligible Lead.
+After Maintainer acceptance, it receives a charter, owner label, public roster,
+and Lead or Member self-nomination.
 
 ## Come Build With Us
 

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -45,6 +45,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/raghavchitkara36.png',
         profile: 'https://github.com/raghavchitkara36',
       },
+      {
+        name: 'Cerdore',
+        avatar: 'https://github.com/Cerdore.png',
+        profile: 'https://github.com/Cerdore',
+      },
     ],
   },
   {
@@ -80,6 +85,11 @@ export const workGroups: WorkGroup[] = [
         name: 'raghavchitkara',
         avatar: 'https://github.com/raghavchitkara36.png',
         profile: 'https://github.com/raghavchitkara36',
+      },
+      {
+        name: 'Park Soobin',
+        avatar: 'https://github.com/subin9.png',
+        profile: 'https://github.com/subin9',
       },
     ],
   },


### PR DESCRIPTION
Related #2978

## Purpose

- Add the accepted model-pool member optimization Epic #3041 to the MoM & Routing
  map and distinguish it from recipe optimization and Router Model training.
- Make single ownership explicit: every listed Epic belongs to one Workgroup,
  while cross-Workgroup dependencies live in charter Shared Interfaces.
- Rewrite the invitation blog in a shorter, plain-language structure that
  preserves each direction's problem, scope, non-scope, and owned Epic map.
- Add @Cerdore to the MoM & Routing roster after merged contribution #1822.
- Add Park Soobin (@subin9) to the Router Models & Inference Runtime roster
  after merged contribution #3027.

The seven live Workgroup charters were also normalized on GitHub to use
`Owned Epics`, `Shared Interfaces`, and `Non-scope`. Those issue-body updates
are intentionally not represented as repository files in this PR.

## Test Plan

- Run the repository documentation-only agent gate.
- Build the English Docusaurus site.
- Verify that every open roadmap Epic is linked from the blog.

## Test Result

- `make agent-docs-ci-gate ENV=cpu AGENT_BASE_REF=upstream/main CHANGED_FILES="website/blog/2026-08-24-join-vllm-sr-workgroups.md website/src/data/workGroups.ts" AGENT_BOOTSTRAP_DONE=1` passed.
- `npm --prefix website run build:en` passed. It emitted only existing author,
  truncation-marker, browsers-list, and dependency-analysis warnings.
- Epic-link audit passed: all 28 open roadmap Epics are linked.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category.
- [x] The title does not stack prefixes.
- [x] The PR links accepted Workgroup governance and an accepted Epic.
- [x] The commits are signed off.
- [x] Purpose, tests, and results reflect the actual change.

</details>
