### PR TITLE
[Docs] Add Enterprise deployment architecture Epic

### DIFF
--- a/website/blog/2026-08-24-join-vllm-sr-workgroups.md
+++ b/website/blog/2026-08-24-join-vllm-sr-workgroups.md
@@ -189,8 +189,9 @@ how a Router Model is trained, or which MoM recipe is best.
 
 Production users need clear answers to practical questions: Who can call each
 model? How much can they use? What changed? Is the system healthy? Can a model,
-recipe, or Router upgrade be rolled out and reversed safely? The answers must
-remain consistent across deployment environments.
+recipe, or Router upgrade be rolled out and reversed safely? Which deployment
+path is maintained, and which components does it own? The answers must remain
+consistent across deployment environments.
 
 ### Scope
 
@@ -202,6 +203,10 @@ remain consistent across deployment environments.
   and failure recovery.
 - Model and recipe onboarding, draining, gray release, promotion, rollback, and
   auditable vLLM-SR upgrades.
+- Stable, scalable deployment and lifecycle APIs across environments; CRDs and
+  the Operator provide their Kubernetes implementation.
+- Maintained Docker, Kubernetes, Operator, and OpenShift reference stacks with
+  clear component ownership and reusable hardware overlays.
 - A tested support matrix across Docker, Kubernetes, CPU, AMD, NVIDIA,
   precision, images, and maintained configurations.
 
@@ -216,6 +221,7 @@ capabilities rather than publishing private product plans.
 
 - [Build multi-tenant inference access, quotas, and usage controls](https://github.com/vllm-project/semantic-router/issues/2960)
 - [Build versioned configuration activation and rollback](https://github.com/vllm-project/semantic-router/issues/2326)
+- [Define deployment architecture and reference stacks across environments and hardware](https://github.com/vllm-project/semantic-router/issues/3043)
 - [Establish production observability and supported-environment qualification](https://github.com/vllm-project/semantic-router/issues/2993)
 
 ## [Agentic & Context](https://github.com/vllm-project/semantic-router/issues/2987)

--- a/website/blog/2026-08-24-join-vllm-sr-workgroups.md
+++ b/website/blog/2026-08-24-join-vllm-sr-workgroups.md
@@ -269,7 +269,6 @@ training.
 - [Optimize context for long-session and agentic workloads](https://github.com/vllm-project/semantic-router/issues/2984)
 - [Enable agent-based routing and multi-agent composition](https://github.com/vllm-project/semantic-router/issues/2994)
 - [Develop safe model and workflow switching for long-running agents](https://github.com/vllm-project/semantic-router/issues/2973)
-- [Define a trusted gateway context envelope for agent memory, tools, and budgets](https://github.com/vllm-project/semantic-router/issues/2546)
 
 ## [Developer Experience & Ecosystem](https://github.com/vllm-project/semantic-router/issues/2970)
 

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -117,7 +117,7 @@ export const workGroups: WorkGroup[] = [
     goal: 'Deliver production-grade enterprise capabilities across supported environments and hardware.',
     scope: [
       'Multi-tenancy, identity, API keys, quotas, and audit',
-      'Stability, scalability, observability, and lifecycle operations',
+      'Stable, scalable APIs and reference stacks',
       'Multi-environment and multi-hardware support',
     ],
     leads: [


### PR DESCRIPTION
## Summary

- add the accepted Enterprise & Environment deployment architecture Epic to the
  Workgroup map and invitation blog
- keep the public Workgroup focus concise: stable APIs and reference stacks,
  plus multi-environment and multi-hardware support
- clarify that CRDs and the Operator implement the shared API contract for
  Kubernetes rather than defining a separate architecture
- remove the unbounded gateway context envelope from the Agentic Epic map

## Related work

Related #3043.

The Enterprise charter in #2968 now owns the cross-environment API and
reference-stack architecture. #2993 remains responsible for production
observability and qualification of those maintained stacks.

## Validation

- `make agent-docs-ci-gate ENV=cpu AGENT_BASE_REF=upstream/main CHANGED_FILES="website/src/data/workGroups.ts website/blog/2026-08-24-join-vllm-sr-workgroups.md" AGENT_BOOTSTRAP_DONE=1`
- `npm --prefix website run build:en`
