### PR TITLE
[Bug] Emit Response API SSE for /v1/responses streams on Anthropic backends

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -65,6 +65,9 @@ var DashboardContract = []string{
 var AnthropicShimContract = []string{
 	"anthropic-messages-cache-cycle",
 	"anthropic-messages-stop-sequence",
+	// /v1/responses streaming must emit Response API SSE on Anthropic-format
+	// backends instead of leaking chat.completion.chunk frames (issue #3013)
+	"anthropic-response-api-streaming",
 }
 
 // Combine preserves order while removing duplicate testcase names.

--- a/e2e/profiles/anthropic-shim/values.yaml
+++ b/e2e/profiles/anthropic-shim/values.yaml
@@ -59,6 +59,11 @@ config:
       clear_route_cache: true
       strategy: priority
     services:
+      response_api:
+        enabled: true
+        store_backend: memory
+        ttl_seconds: 86400
+        max_responses: 1000
       observability:
         metrics:
           enabled: true

--- a/e2e/testcases/anthropic_response_api_streaming.go
+++ b/e2e/testcases/anthropic_response_api_streaming.go
@@ -1,0 +1,53 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("anthropic-response-api-streaming", pkgtestcases.TestCase{
+		Description: "POST /v1/responses stream:true against an api_format:anthropic backend returns Responses API SSE events",
+		Tags:        []string{"response-api", "streaming", "sse", "anthropic"},
+		Fn:          testAnthropicResponseAPIStreaming,
+	})
+}
+
+// testAnthropicResponseAPIStreaming pins the /v1/responses streaming contract
+// on the Anthropic-format backend cell. The upstream produces Anthropic
+// Messages SSE; the router must translate the whole stream into Response API
+// events. The shared validator also rejects leaked chat.completion.chunk
+// frames and the raw [DONE] sentinel: the router's Anthropic streaming
+// handler uses chat.completion.chunk as its intermediate representation,
+// and this case exists to guarantee that representation never reaches a
+// /v1/responses client.
+func testAnthropicResponseAPIStreaming(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing Response API streaming over the anthropic-shim backend")
+	}
+
+	result, err := requestResponseAPIStreamingSSE(ctx, client, opts, "MoM", "anthropic-response-api-streaming", "Say hello in a few words.")
+	if err != nil {
+		return err
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status":       result.statusCode,
+			"content_type": result.contentType,
+			"bytes":        len(result.body),
+		})
+	}
+
+	if err := validateResponseAPIStreamingSSEResponse(result); err != nil {
+		return err
+	}
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Anthropic-backend Response API streaming passed: bytes=%d\n", len(result.body))
+	}
+	return nil
+}

--- a/e2e/testcases/response_api_streaming.go
+++ b/e2e/testcases/response_api_streaming.go
@@ -28,7 +28,7 @@ func testResponseAPIStreamingSSE(ctx context.Context, client *kubernetes.Clients
 		fmt.Println("[Test] Testing Response API streaming SSE: POST /v1/responses stream:true")
 	}
 
-	result, err := requestResponseAPIStreamingSSE(ctx, client, opts)
+	result, err := requestResponseAPIStreamingSSE(ctx, client, opts, "openai/gpt-oss-20b", "response-api-streaming-sse", "Stream this response through the Responses API.")
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ type responseAPIStreamingSSEResult struct {
 	body        []byte
 }
 
-func requestResponseAPIStreamingSSE(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) (responseAPIStreamingSSEResult, error) {
+func requestResponseAPIStreamingSSE(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions, model string, testName string, input string) (responseAPIStreamingSSEResult, error) {
 	session, err := fixtures.OpenServiceSession(ctx, client, opts)
 	if err != nil {
 		return responseAPIStreamingSSEResult{}, err
@@ -65,12 +65,12 @@ func requestResponseAPIStreamingSSE(ctx context.Context, client *kubernetes.Clie
 	defer session.Close()
 
 	body := map[string]interface{}{
-		"model":  "openai/gpt-oss-20b",
-		"input":  "Stream this response through the Responses API.",
+		"model":  model,
+		"input":  input,
 		"stream": true,
 		"store":  false,
 		"metadata": map[string]string{
-			"test": "response-api-streaming-sse",
+			"test": testName,
 		},
 	}
 	rawBody, err := json.Marshal(body)

--- a/src/semantic-router/pkg/anthropic/client_stream.go
+++ b/src/semantic-router/pkg/anthropic/client_stream.go
@@ -534,11 +534,19 @@ func buildOpenAIStreamFinishChunk(
 		Model:   model,
 		Choices: []openai.ChatCompletionChunkChoice{choice},
 	}
-	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+	// message_delta usually reports only output tokens; the input count
+	// arrives once on message_start and is held in InitialUsage. Fall back
+	// to it so the terminal usage carries the upstream's input count.
+	// Deltas that do report cumulative input tokens win over the fallback.
+	inputTokens := usage.InputTokens
+	if inputTokens == 0 {
+		inputTokens = state.InitialUsage.InputTokens
+	}
+	if inputTokens > 0 || usage.OutputTokens > 0 {
 		chunk.Usage = openai.CompletionUsage{
-			PromptTokens:     usage.InputTokens,
+			PromptTokens:     inputTokens,
 			CompletionTokens: usage.OutputTokens,
-			TotalTokens:      usage.InputTokens + usage.OutputTokens,
+			TotalTokens:      inputTokens + usage.OutputTokens,
 		}
 	}
 	return json.Marshal(chunk)

--- a/src/semantic-router/pkg/anthropic/client_stream_test.go
+++ b/src/semantic-router/pkg/anthropic/client_stream_test.go
@@ -247,6 +247,24 @@ func TestTransformSSEChunkToOpenAI_CapturesInitialUsage(t *testing.T) {
 	assert.Equal(t, int64(5), state.InitialUsage.CacheCreationInputTokens)
 }
 
+// TestTransformSSEChunkToOpenAI_MergesInitialInputUsage asserts that the
+// terminal usage chunk carries the input count from message_start when
+// message_delta reports only output tokens, so downstream accounting and
+// the Response API completed-usage see the upstream's input tokens.
+func TestTransformSSEChunkToOpenAI_MergesInitialInputUsage(t *testing.T) {
+	state := NewStreamState()
+	events := buildAnthropicSSE(
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":0}}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}`,
+	)
+	out, _, err := TransformSSEChunkToOpenAI([]byte(events), state, "claude-sonnet-4-5", nil)
+	require.NoError(t, err)
+	body := string(out)
+	assert.Contains(t, body, `"prompt_tokens":3`)
+	assert.Contains(t, body, `"completion_tokens":1`)
+	assert.Contains(t, body, `"total_tokens":4`)
+}
+
 // TestTransformSSEChunkToOpenAI_AnthropicOnlyStopReason asserts that
 // pause_turn round-trips through IRExtensions because the OpenAI
 // finish_reason alphabet has no equivalent.

--- a/src/semantic-router/pkg/extproc/processor_res_body.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body.go
@@ -41,7 +41,11 @@ func (r *OpenAIRouter) handleResponseBody(v *ext_proc.ProcessingRequest_Response
 
 	// Legacy branch: OpenAI client hitting an Anthropic backend. The
 	// extra ClientProtocol guard prevents the new Anthropic-client
-	// branch from being shadowed by this one.
+	// branch from being shadowed by this one. Response API clients also
+	// land here (Responses-ness lives on ctx.ResponseAPICtx, not
+	// ClientProtocol); the handler routes their transformed chunks
+	// through the Response API streaming mutation so a /v1/responses
+	// stream receives Response API events, not chat.completion.chunk.
 	if ctx.IsStreamingResponse && ctx.APIFormat == config.APIFormatAnthropic &&
 		ctx.ClientProtocol != config.ClientProtocolAnthropic {
 		return r.handleAnthropicStreamingResponseBody(v.ResponseBody.Body, ctx), nil

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -22,6 +22,15 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 		ctx.AnthropicStream = anthropic.NewStreamState()
 	}
 
+	// Envoy's streamed mode can split an SSE event at any byte offset;
+	// the translator silently drops data: lines whose JSON is incomplete,
+	// so a split frame would lose its content (and a split message_stop
+	// would lose stream termination). Hold partial frames back until the
+	// closing delimiter arrives, as the Anthropic-client streaming
+	// handler already does.
+	frames, remainder := reassembleSSEFrames(ctx.PendingSSEBytes, responseBody)
+	ctx.PendingSSEBytes = remainder
+
 	// Pass IRExtensions through so the merged Anthropic→OpenAI cell
 	// captures cache counters, stop_reason round-trip fields, and
 	// per-block thinking signatures onto the request-scoped sidecar.
@@ -29,7 +38,7 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 	// router replay, and downstream non-streaming responses consistent
 	// with the streaming case.
 	transformed, streamDone, err := anthropic.TransformSSEChunkToOpenAI(
-		responseBody,
+		frames,
 		ctx.AnthropicStream,
 		ctx.RequestModel,
 		ctx.IRExtensions,
@@ -67,20 +76,18 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 // clients have no dedicated ClientProtocol value (Responses-ness lives on
 // ctx.ResponseAPICtx), so they reach this handler like plain OpenAI clients;
 // their chunks go through the same Response API streaming mutation that
-// handleStreamingResponseBody applies for OpenAI-format backends. The
-// mutation is applied even for empty fragments so raw Anthropic frames
-// (ping, content_block_stop) are always replaced and never leak to a
-// /v1/responses stream. OpenAI clients keep the legacy contract: their
-// chunk bytes pass through untouched when there is nothing to emit.
+// handleStreamingResponseBody applies for OpenAI-format backends.
+//
+// The body is replaced even when the transform produced nothing: raw
+// Anthropic frames (ping, content_block_stop) must never leak to either
+// client, and a partial frame held in ctx.PendingSSEBytes must not also
+// pass through raw — it will be replayed from the buffer once complete.
 func (r *OpenAIRouter) anthropicStreamingChunkMutation(
 	transformed []byte,
 	ctx *RequestContext,
 ) (*ext_proc.BodyMutation, *ext_proc.HeaderMutation) {
 	if isResponseAPIRequest(ctx) {
 		return r.buildResponseAPIStreamingBodyMutation(transformed, ctx), responseAPIStreamingHeaderMutation()
-	}
-	if len(transformed) == 0 {
-		return nil, nil
 	}
 	return &ext_proc.BodyMutation{
 		Mutation: &ext_proc.BodyMutation_Body{Body: transformed},

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic.go
@@ -36,24 +36,53 @@ func (r *OpenAIRouter) handleAnthropicStreamingResponseBody(
 	)
 	if err != nil {
 		logging.Errorf("Failed to transform Anthropic streaming chunk: %v", err)
-		return buildResponseBodyContinueResponse(nil, nil)
+		return buildResponseBodyContinueResponse(r.anthropicStreamingChunkMutation(nil, ctx))
 	}
 	if len(transformed) == 0 {
 		if streamDone {
 			r.finalizeStreamingResponse(ctx)
 		}
-		return buildResponseBodyContinueResponse(nil, nil)
+		return buildResponseBodyContinueResponse(r.anthropicStreamingChunkMutation(nil, ctx))
 	}
 
 	chunkStr := string(transformed)
 	ctx.HasStreamingChunks = true
 	r.parseStreamingChunk(chunkStr, ctx)
 
+	// Build the outbound chunk before finalizing: the Response API
+	// [DONE]-driven terminal events read the accumulated streaming state,
+	// and finalization must observe the same ordering as
+	// handleStreamingResponseBody's Response API branch.
+	bodyMutation, headerMutation := r.anthropicStreamingChunkMutation(transformed, ctx)
+
 	if strings.Contains(chunkStr, "data: [DONE]") || streamDone {
 		r.finalizeStreamingResponse(ctx)
 	}
 
-	return buildResponseBodyContinueResponse(&ext_proc.BodyMutation{
+	return buildResponseBodyContinueResponse(bodyMutation, headerMutation)
+}
+
+// anthropicStreamingChunkMutation wraps a transformed chat.completion.chunk
+// SSE fragment in the body/header mutations the client expects. Response API
+// clients have no dedicated ClientProtocol value (Responses-ness lives on
+// ctx.ResponseAPICtx), so they reach this handler like plain OpenAI clients;
+// their chunks go through the same Response API streaming mutation that
+// handleStreamingResponseBody applies for OpenAI-format backends. The
+// mutation is applied even for empty fragments so raw Anthropic frames
+// (ping, content_block_stop) are always replaced and never leak to a
+// /v1/responses stream. OpenAI clients keep the legacy contract: their
+// chunk bytes pass through untouched when there is nothing to emit.
+func (r *OpenAIRouter) anthropicStreamingChunkMutation(
+	transformed []byte,
+	ctx *RequestContext,
+) (*ext_proc.BodyMutation, *ext_proc.HeaderMutation) {
+	if isResponseAPIRequest(ctx) {
+		return r.buildResponseAPIStreamingBodyMutation(transformed, ctx), responseAPIStreamingHeaderMutation()
+	}
+	if len(transformed) == 0 {
+		return nil, nil
+	}
+	return &ext_proc.BodyMutation{
 		Mutation: &ext_proc.BodyMutation_Body{Body: transformed},
-	}, nil)
+	}, nil
 }

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_response_api_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_response_api_test.go
@@ -139,6 +139,43 @@ func TestResponseAPIStreamingAnthropicBackendSuppressesUntranslatedFrames(t *tes
 	require.Empty(t, bodyMutation.GetBody())
 }
 
+func TestResponseAPIStreamingAnthropicBackendBuffersSplitFrames(t *testing.T) {
+	store := NewMockResponseStore()
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(store),
+	}
+	ctx := newAnthropicResponseAPIStreamingTestContext("response-api-anthropic-split")
+
+	// Split the stream mid-JSON inside the content_block_delta frame:
+	// everything up to the cut must be held back, not dropped or leaked.
+	stream := anthropicSSEFrames(anthropicStreamFixture...)
+	cut := strings.Index(string(stream), `"text_delta"`)
+	require.Positive(t, cut)
+
+	firstResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: stream[:cut]},
+	}, ctx)
+	require.NoError(t, err)
+	firstMutation := firstResp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, firstMutation, "partial upstream frames must not pass through untranslated")
+	firstWire := string(firstMutation.GetBody())
+	require.NotContains(t, firstWire, "content_block_delta")
+
+	secondResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: stream[cut:]},
+	}, ctx)
+	require.NoError(t, err)
+	secondWire := string(secondResp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+
+	combined := firstWire + secondWire
+	require.Equal(t, 1, strings.Count(combined, `"delta":"Hi"`), "split delta content must survive exactly once")
+	require.Contains(t, combined, "response.completed")
+	require.Contains(t, combined, `"output_text":"Hi"`)
+	require.NotContains(t, combined, "chat.completion.chunk")
+	require.True(t, ctx.StreamingComplete, "split terminal frames must still finalize the stream")
+}
+
 func TestAnthropicStreamingOpenAIClientKeepsChatCompletionChunks(t *testing.T) {
 	router := &OpenAIRouter{
 		Config: &config.RouterConfig{},

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_response_api_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_response_api_test.go
@@ -1,0 +1,164 @@
+package extproc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/responseapi"
+)
+
+// A /v1/responses stream backed by an api_format:anthropic model must
+// receive Response API SSE events, not the chat.completion.chunk frames the
+// Anthropic streaming handler produces as its intermediate representation.
+
+func newAnthropicResponseAPIStreamingTestContext(requestID string) *RequestContext {
+	ctx := newResponseAPIStreamingTestContext(requestID)
+	ctx.RequestModel = "claude-sonnet-4-5"
+	ctx.ResponseAPICtx.OriginalRequest.Model = "claude-sonnet-4-5"
+	ctx.APIFormat = config.APIFormatAnthropic
+	return ctx
+}
+
+func anthropicSSEFrames(frames ...[2]string) []byte {
+	var out strings.Builder
+	for _, frame := range frames {
+		out.WriteString("event: " + frame[0] + "\n")
+		out.WriteString("data: " + frame[1] + "\n\n")
+	}
+	return []byte(out.String())
+}
+
+// anthropicStreamFixture is the canonical upstream Anthropic SSE stream
+// shared by the streaming cell tests: every client cell (OpenAI,
+// Response API) consumes the same five frames, so the tests differ only
+// in the client context and the wire-format assertions.
+var anthropicStreamFixture = [][2]string{
+	{"message_start", `{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":0}}}`},
+	{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+	{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`},
+	{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}`},
+	{"message_stop", `{"type":"message_stop"}`},
+}
+
+func TestResponseAPIStreamingAnthropicBackendEmitsResponsesSSE(t *testing.T) {
+	store := NewMockResponseStore()
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(store),
+	}
+	ctx := newAnthropicResponseAPIStreamingTestContext("response-api-anthropic-stream")
+
+	firstChunk := anthropicSSEFrames(anthropicStreamFixture[:3]...)
+	resp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: firstChunk},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	bodyMutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, bodyMutation, "Anthropic-backend Responses stream must rewrite upstream SSE")
+
+	wire := string(bodyMutation.GetBody())
+	requireInitialResponseAPIStreamingWire(t, wire)
+	require.Contains(t, wire, `"delta":"Hi"`)
+	require.NotContains(t, wire, "message_start")
+	require.NotContains(t, wire, "content_block_delta")
+
+	finalChunk := anthropicSSEFrames(anthropicStreamFixture[3:]...)
+	finalResp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: finalChunk},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, finalResp)
+
+	finalBodyMutation := finalResp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, finalBodyMutation, "terminal Anthropic SSE must translate to Response API events")
+
+	finalWire := string(finalBodyMutation.GetBody())
+	require.Contains(t, finalWire, "response.output_text.done")
+	require.Contains(t, finalWire, "response.completed")
+	require.Contains(t, finalWire, `"output_text":"Hi"`)
+	require.NotContains(t, finalWire, "data: [DONE]")
+	require.NotContains(t, finalWire, "chat.completion.chunk")
+	require.NotContains(t, finalWire, "message_stop")
+	requireAnthropicResponseAPIStreamingLifecycle(t, wire, finalWire)
+	require.True(t, ctx.StreamingComplete)
+
+	stored, err := store.GetResponse(context.Background(), ctx.ResponseAPICtx.GeneratedResponseID)
+	require.NoError(t, err)
+	require.Equal(t, responseapi.StatusCompleted, stored.Status)
+}
+
+func requireAnthropicResponseAPIStreamingLifecycle(t *testing.T, wire string, finalWire string) {
+	t.Helper()
+
+	createdEvent := responseAPIStreamingEventPayload(t, wire, "response.created")
+	completedEvent := responseAPIStreamingEventPayload(t, finalWire, "response.completed")
+	createdResponse, ok := createdEvent["response"].(map[string]interface{})
+	require.True(t, ok)
+	completedResponse, ok := completedEvent["response"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, createdResponse["id"], completedResponse["id"])
+	require.Equal(t, responseapi.StatusInProgress, createdResponse["status"])
+	require.Equal(t, responseapi.StatusCompleted, completedResponse["status"])
+	usage, ok := completedResponse["usage"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, float64(1), usage["output_tokens"])
+}
+
+func TestResponseAPIStreamingAnthropicBackendSuppressesUntranslatedFrames(t *testing.T) {
+	router := &OpenAIRouter{
+		Config:            &config.RouterConfig{},
+		ResponseAPIFilter: NewResponseAPIFilter(NewMockResponseStore()),
+	}
+	ctx := newAnthropicResponseAPIStreamingTestContext("response-api-anthropic-noise")
+
+	// ping and content_block_stop translate to no OpenAI chunks; without a
+	// body mutation Envoy would forward the raw Anthropic frames to the
+	// /v1/responses client, interleaved into the Response API stream.
+	noiseChunk := anthropicSSEFrames(
+		[2]string{"ping", `{"type":"ping"}`},
+		[2]string{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+	)
+	resp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: noiseChunk},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	bodyMutation := resp.GetResponseBody().GetResponse().GetBodyMutation()
+	require.NotNil(t, bodyMutation, "untranslatable Anthropic frames must be replaced, not passed through")
+	require.Empty(t, bodyMutation.GetBody())
+}
+
+func TestAnthropicStreamingOpenAIClientKeepsChatCompletionChunks(t *testing.T) {
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{},
+	}
+	ctx := &RequestContext{
+		RequestID:           "openai-client-anthropic-stream",
+		RequestModel:        "claude-sonnet-4-5",
+		StartTime:           time.Now(),
+		ProcessingStartTime: time.Now(),
+		TraceContext:        context.Background(),
+		IsStreamingResponse: true,
+		APIFormat:           config.APIFormatAnthropic,
+	}
+
+	chunk := anthropicSSEFrames(anthropicStreamFixture...)
+	resp, err := router.handleResponseBody(&ext_proc.ProcessingRequest_ResponseBody{
+		ResponseBody: &ext_proc.HttpBody{Body: chunk},
+	}, ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	wire := string(resp.GetResponseBody().GetResponse().GetBodyMutation().GetBody())
+	require.Contains(t, wire, "chat.completion.chunk")
+	require.NotContains(t, wire, "response.created")
+}

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_response_api_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_response_api_test.go
@@ -109,7 +109,9 @@ func requireAnthropicResponseAPIStreamingLifecycle(t *testing.T, wire string, fi
 	require.Equal(t, responseapi.StatusCompleted, completedResponse["status"])
 	usage, ok := completedResponse["usage"].(map[string]interface{})
 	require.True(t, ok)
+	require.Equal(t, float64(3), usage["input_tokens"])
 	require.Equal(t, float64(1), usage["output_tokens"])
+	require.Equal(t, float64(4), usage["total_tokens"])
 }
 
 func TestResponseAPIStreamingAnthropicBackendSuppressesUntranslatedFrames(t *testing.T) {

--- a/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_streaming_anthropic_test.go
@@ -41,6 +41,9 @@ func TestHandleAnthropicStreamingResponseBody_TranslatesSSE(t *testing.T) {
 		"event: message_stop",
 		`data: {"type":"message_stop"}`,
 		"",
+		// SSE frames end with a blank line; the handler buffers an
+		// unterminated final frame while waiting for its delimiter.
+		"",
 	}, "\n")
 
 	resp := router.handleAnthropicStreamingResponseBody([]byte(anthropicChunk), ctx)


### PR DESCRIPTION
<!-- markdownlint-disable -->
Closes #3013

## Purpose

A streaming `POST /v1/responses` request routed to a model with
`api_format: anthropic` returned raw `chat.completion.chunk` SSE frames —
with untranslated Anthropic frames (`content_block_stop`, `ping`)
interleaved — instead of Response API events. Clients treat the missing
`response.completed` as a transport failure and retry; each retry is a
fresh billed upstream call (one Codex CLI prompt produced 6 upstream
Anthropic calls and still failed). The same request without streaming
works, so the gap was specific to the streaming dispatch path.

Root cause: dispatch ordering in `handleResponseBody`. A Response API
client has no dedicated `ClientProtocol` value (Responses-ness lives on
`ctx.ResponseAPICtx`), so it matched the legacy "OpenAI client on
Anthropic backend" streaming branch, and
`handleAnthropicStreamingResponseBody` emitted its intermediate
`chat.completion.chunk` representation directly without ever consulting
`isResponseAPIRequest`. The Response API translator
(`buildResponseAPIStreamingBodyMutation`, from #2438) only ran in the
`handleStreamingResponseBody` branch below, which the Anthropic branch
returns before reaching. #2492 already lists "preventing upstream Chat
Completions SSE frames from leaking to `/v1/responses` clients" in its
hardening criteria, so this closes a remaining gap in that accepted
contract rather than proposing new behaviour.

The fix follows the shape proposed in the issue: the Anthropic streaming
handler's transformed chunks are routed through the same Response API
streaming mutation that `handleStreamingResponseBody` applies for
OpenAI-format backends.

- New `anthropicStreamingChunkMutation` helper decides the outbound
  body/header mutation pair: Response API clients get
  `buildResponseAPIStreamingBodyMutation` (plus the SSE content-type
  header mutation); OpenAI clients keep receiving the
  `chat.completion.chunk` bytes unchanged.
- The mutation is applied even when a fragment transforms to nothing
  (ping, `content_block_stop`) and on transform errors, so raw Anthropic
  frames are always replaced and never pass through to a `/v1/responses`
  stream — this also removes the interleaved-raw-frame leak from the
  report.
- The outbound chunk is built before `finalizeStreamingResponse`, matching
  the ordering of `handleStreamingResponseBody`'s Response API branch (the
  terminal events — driven by the `data: [DONE]` the Anthropic transformer
  synthesizes on `message_stop` — read the accumulated streaming state).
- The dispatcher itself is unchanged; only the branch comment now
  documents that Response API clients land in the legacy branch and how
  they're handled. Blast radius: the Anthropic streaming handler plus its
  dispatch comment; no other cells change.

Affected modules: `src/semantic-router/pkg/extproc` (streaming response
translation) and `e2e` (testcases, test matrix, anthropic-shim profile
values). Owned by issue #3013, accepted under the Data Plane & Networking
Workgroup (`wg/data-plane-networking`).

## Test Plan

- go test ./pkg/extproc/ — full suite ; includes 3 new tests
  in `processor_res_body_streaming_anthropic_response_api_test.go`:
  - full-lifecycle Anthropic SSE → Response API events through
    `handleResponseBody`;
  - untranslatable-frame suppression (ping + `content_block_stop` must
    yield an empty body mutation, not passthrough);
  - regression pin: plain OpenAI client on the Anthropic backend still
    receives `chat.completion.chunk`.
- New e2e case `anthropic-response-api-streaming` in the
  `AnthropicShimContract` (the issue notes this combination had no e2e
  coverage): streaming `/v1/responses` against the llama.cpp +
  anthropic-shim backend must produce the full Response API event
  sequence. It reuses the shared validator from `response-api-streaming-sse`.
- `gofmt` / `go vet` on the touched packages.
- `make agent-ci-lint CHANGED_FILES="..."` — exit 0.
- Live verification against `api.anthropic.com`
  (`claude-haiku-4-5-20251001`) through the local Envoy+extproc stack,
  including the real-client variant from the report (Codex CLI 0.147.0,
  `wire_api = "responses"`).

## Test Result

- `go test ./pkg/extproc/` — ok (full suite passes).
- `make agent-ci-lint ...` — exit 0 (pre-commit hooks and the fast test
  gate pass).
- Live, streaming `/v1/responses` (previously `chat.completion.chunk`
  frames + raw `content_block_stop` + `data: [DONE]`): now the full
  sequence `response.created` → `response.in_progress` →
  `response.output_item.added` → `response.content_part.added` →
  `response.output_text.delta` → `response.output_text.done` →
  `response.content_part.done` → `response.output_item.done` →
  `response.completed`; zero occurrences of `chat.completion.chunk`,
  `data: [DONE]`, or raw Anthropic frames in the stream.
- Codex CLI through the router (previously "stream disconnected before
  completion: stream closed before response.completed" after 5 billed
  reconnects): prompt completes on the first attempt; router and Envoy
  logs show exactly one upstream Anthropic call per client request.
- Regressions, same stack: non-streaming `/v1/responses` unchanged
  (correct `"object":"response"` envelope); streaming
  `/v1/chat/completions` on the same Anthropic backend still emits
  `chat.completion.chunk`.
- The new e2e case was run locally on the kind-based anthropic-shim
  stack twice — once without the fix and once with it — to confirm the
  case detects the bug and the fix resolves it:
  - Router built **without** the fix (this PR's first commit adds only
    the e2e case, so the router still behaves like `main`): the two
    pre-existing contract cases pass, and
    `anthropic-response-api-streaming` fails with exactly the reported
    leak — a `chat.completion.chunk` frame on the `/v1/responses`
    stream, no `response.created`.
  - Router built **with** the fix: all three contract cases pass, and
    the stream contains the full Response API event sequence with no
    `chat.completion.chunk` or `data: [DONE]` anywhere.

Scope note: `anthropic-shim` is a `selection: manual` profile — it runs
via explicit dispatch/local runs, not automatically in PR CI. The same
contract is enforced by the new unit tests in
`processor_res_body_streaming_anthropic_response_api_test.go`, which do
run in CI as part of the regular Go test suite.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
