### PR TITLE
[Bug] fix nil pointer panic in category classification

### DIFF
--- a/src/semantic-router/pkg/classification/classifier_category_entropy.go
+++ b/src/semantic-router/pkg/classification/classifier_category_entropy.go
@@ -43,12 +43,21 @@ func (c *Classifier) ClassifyCategoryWithEntropy(text string) (string, float64, 
 // tryKeywordBasedClassification attempts classification via keyword and embedding classifiers.
 // Returns matched=true if a classifier produced a result.
 func (c *Classifier) tryKeywordBasedClassification(text string) (string, float64, entropy.ReasoningDecision, bool, error) {
-	for _, clf := range []interface {
+	// Checked and appended one at a time rather than nil-checked inside a
+	// []interface{...} literal: a nil *KeywordClassifier or
+	// *EmbeddingClassifier placed directly into that slice becomes a non-nil
+	// interface value (it carries a concrete, non-nil type), so `clf == nil`
+	// never trips and Classify is called on a nil receiver.
+	var classifiers []interface {
 		Classify(string) (string, float64, error)
-	}{c.keywordClassifier, c.keywordEmbeddingClassifier} {
-		if clf == nil {
-			continue
-		}
+	}
+	if c.keywordClassifier != nil {
+		classifiers = append(classifiers, c.keywordClassifier)
+	}
+	if c.keywordEmbeddingClassifier != nil {
+		classifiers = append(classifiers, c.keywordEmbeddingClassifier)
+	}
+	for _, clf := range classifiers {
 		category, confidence, err := clf.Classify(text)
 		if err != nil {
 			return "", 0.0, entropy.ReasoningDecision{}, false, err

--- a/src/semantic-router/pkg/classification/classifier_category_entropy_test.go
+++ b/src/semantic-router/pkg/classification/classifier_category_entropy_test.go
@@ -1,0 +1,39 @@
+package classification
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestClassifyCategoryWithEntropySkipsNilEmbeddingClassifier guards against a
+// Go typed-nil bug: a nil *EmbeddingClassifier placed directly into a
+// []interface{Classify(...)} literal becomes a non-nil interface value, so a
+// nil check against the interface never trips and Classify is called on a
+// nil receiver. With only the keyword classifier configured and no keyword
+// match, this must fall through to the "no category classification method
+// available" error rather than panic.
+func TestClassifyCategoryWithEntropySkipsNilEmbeddingClassifier(t *testing.T) {
+	keywordClassifier, err := NewKeywordClassifier([]config.KeywordRule{
+		{
+			Name:     "technical",
+			Operator: "OR",
+			Method:   "regex",
+			Keywords: []string{"kubernetes"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewKeywordClassifier: %v", err)
+	}
+	defer keywordClassifier.Free()
+
+	classifier := &Classifier{
+		Config:            &config.RouterConfig{},
+		keywordClassifier: keywordClassifier,
+	}
+
+	_, _, _, err = classifier.ClassifyCategoryWithEntropy("unrelated request")
+	if err == nil || err.Error() != "no category classification method available" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
Closes #2943

## Purpose

`ClassifyCategoryWithEntropy` panics when the keyword classifier is enabled, doesn't match, and the embedding classifier is disabled/unconfigured.

`tryKeywordBasedClassification` put `*KeywordClassifier` and `*EmbeddingClassifier` straight into a `[]interface{Classify(...)}` slice before checking for nil. A nil `*EmbeddingClassifier` boxed into that interface isn't `== nil` anymore, so the nil check never trips and `Classify` gets called on a nil receiver. Same typed-nil pattern as #2441, introduced here by the classifier decomposition in #1568.

Fix: check each concrete pointer for nil before appending it to the slice, so a disabled classifier is just skipped instead of wrapped.

Affects: `Router` (`pkg/classification`)

Owner: `wg/router-models-inference-runtime`

## Test Plan

```bash
cd src/semantic-router
go test ./pkg/classification -run '^TestClassifyCategoryWithEntropySkipsNilEmbeddingClassifier$' -count=1
```

## Test Result

`gofmt`, `go build ./pkg/classification/...`, and `go vet ./pkg/classification/...` all pass clean.

Could not run `go test` in this environment — the package links against the native candle-binding Rust library, which isn't built here (no Rust toolchain / prebuilt `.so` available). The added test is the exact repro from the issue, which the issue author confirmed panics on current `main` before this fix.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
