### PR TITLE
[Bug] Require candle runtime files in qwen3/gemma/multimodal completeness checks

### DIFF
--- a/src/semantic-router/pkg/modeldownload/config_parser.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser.go
@@ -176,27 +176,56 @@ func extractProvisioningModelPaths(cfg *config.RouterConfig) []string {
 // the safetensors/tokenizer download is never triggered, leaving embedding_ready=false (#2172).
 var embeddingModelWeightFiles = []string{"model.safetensors", "tokenizer.json"}
 
-// addEmbeddingModelRequiredFiles marks the configured semantic embedding model as requiring
-// its safetensors weights and tokenizer so a partial (ONNX-only) directory is detected as
-// incomplete and the full snapshot is re-downloaded.
+// gemmaDenseWeightFiles are the dense-bottleneck weights the gemma embedding model
+// additionally hard-loads at startup (candle-binding dense_layers: 2_Dense + 3_Dense).
+var gemmaDenseWeightFiles = []string{
+	"2_Dense/model.safetensors",
+	"3_Dense/model.safetensors",
+}
+
+// candleEmbeddingModelRequiredFiles returns, per configured candle embedding model path,
+// the files the runtime hard-loads at startup. The qwen3, gemma, and multimodal paths
+// share the non-healing completeness defect fixed for mmbert in #2195 (#2531).
+func candleEmbeddingModelRequiredFiles(cfg *config.RouterConfig) map[string][]string {
+	required := make(map[string][]string)
+	add := func(path string, files []string) {
+		for _, fileName := range files {
+			if !slices.Contains(required[path], fileName) {
+				required[path] = append(required[path], fileName)
+			}
+		}
+	}
+
+	add(cfg.MmBertModelPath, embeddingModelWeightFiles)
+	add(cfg.Qwen3ModelPath, embeddingModelWeightFiles)
+	add(cfg.GemmaModelPath, embeddingModelWeightFiles)
+	add(cfg.GemmaModelPath, gemmaDenseWeightFiles)
+	add(cfg.MultiModalModelPath, embeddingModelWeightFiles)
+	return required
+}
+
+// addEmbeddingModelRequiredFiles marks every configured candle embedding model as
+// requiring the files its runtime hard-loads, so a partial directory (for example
+// ONNX-only, or gemma without its dense-bottleneck weights) is detected as incomplete
+// and the full snapshot is re-downloaded.
 func addEmbeddingModelRequiredFiles(cfg *config.RouterConfig, requiredFilesByModel map[string][]string) {
 	if cfg.EmbeddingModels.UsesRemoteEmbeddingBackend() {
 		return
 	}
 
-	// MmBertModelPath holds the configured semantic embedding model directory.
-	path := cfg.MmBertModelPath
-	if path == "" || !strings.HasPrefix(path, "models/") {
-		return
-	}
-
-	existing := requiredFilesByModel[path]
-	for _, fileName := range embeddingModelWeightFiles {
-		if !slices.Contains(existing, fileName) {
-			existing = append(existing, fileName)
+	for path, files := range candleEmbeddingModelRequiredFiles(cfg) {
+		if path == "" || !strings.HasPrefix(path, "models/") {
+			continue
 		}
+
+		existing := requiredFilesByModel[path]
+		for _, fileName := range files {
+			if !slices.Contains(existing, fileName) {
+				existing = append(existing, fileName)
+			}
+		}
+		requiredFilesByModel[path] = existing
 	}
-	requiredFilesByModel[path] = existing
 }
 
 // ExtractRequiredFilesByModel derives per-model completeness requirements from

--- a/src/semantic-router/pkg/modeldownload/embedding_completeness_test.go
+++ b/src/semantic-router/pkg/modeldownload/embedding_completeness_test.go
@@ -140,3 +140,153 @@ func writeModelFile(t *testing.T, dir, name, contents string) {
 		t.Fatalf("WriteFile(%q) error = %v", filepath.Join(dir, name), err)
 	}
 }
+
+const (
+	testQwen3ModelPath      = "models/mom-embedding-pro"
+	testGemmaModelPath      = "models/mom-embedding-flash"
+	testMultiModalModelPath = "models/mom-embedding-multimodal"
+)
+
+func newCandleEmbeddingConfig() *config.RouterConfig {
+	return &config.RouterConfig{
+		MoMRegistry: map[string]string{
+			testEmbeddingModelPath:  testEmbeddingRepoID,
+			testQwen3ModelPath:      "llm-semantic-router/mom-embedding-pro",
+			testGemmaModelPath:      "llm-semantic-router/mom-embedding-flash",
+			testMultiModalModelPath: "llm-semantic-router/mom-embedding-multimodal",
+		},
+		InlineModels: config.InlineModels{
+			EmbeddingModels: config.EmbeddingModels{
+				MmBertModelPath:     testEmbeddingModelPath,
+				Qwen3ModelPath:      testQwen3ModelPath,
+				GemmaModelPath:      testGemmaModelPath,
+				MultiModalModelPath: testMultiModalModelPath,
+			},
+		},
+	}
+}
+
+// TestBuildModelSpecsRequiresCandleRuntimeFilesPerModel guards #2531: every candle
+// embedding path (qwen3, gemma, multimodal), not only mmbert (#2195), must require the
+// files its runtime hard-loads so partial downloads self-heal. Gemma additionally
+// hard-loads the 2_Dense/3_Dense bottleneck weights.
+func TestBuildModelSpecsRequiresCandleRuntimeFilesPerModel(t *testing.T) {
+	specs, err := BuildModelSpecs(newCandleEmbeddingConfig())
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+
+	cases := []struct {
+		path string
+		want []string
+	}{
+		{testEmbeddingModelPath, []string{"config.json", "model.safetensors", "tokenizer.json"}},
+		{testQwen3ModelPath, []string{"config.json", "model.safetensors", "tokenizer.json"}},
+		{testGemmaModelPath, []string{
+			"config.json", "model.safetensors", "tokenizer.json",
+			"2_Dense/model.safetensors", "3_Dense/model.safetensors",
+		}},
+		{testMultiModalModelPath, []string{"config.json", "model.safetensors", "tokenizer.json"}},
+	}
+
+	for _, tc := range cases {
+		spec, ok := findSpecByPath(specs, tc.path)
+		if !ok {
+			t.Fatalf("BuildModelSpecs() did not produce a spec for %q; got %#v", tc.path, specs)
+		}
+		for _, want := range tc.want {
+			if !slices.Contains(spec.RequiredFiles, want) {
+				t.Errorf("spec %q RequiredFiles = %#v, missing %q", tc.path, spec.RequiredFiles, want)
+			}
+		}
+	}
+}
+
+// TestOnnxOnlyCandleEmbeddingDirsReportedIncomplete extends the #2172 reproduction to the
+// qwen3 and multimodal paths: an ONNX-only directory must read as incomplete so the full
+// snapshot is re-downloaded instead of crash-looping at classifier init (#2531).
+func TestOnnxOnlyCandleEmbeddingDirsReportedIncomplete(t *testing.T) {
+	specs, err := BuildModelSpecs(newCandleEmbeddingConfig())
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+
+	for _, path := range []string{testQwen3ModelPath, testMultiModalModelPath} {
+		spec, ok := findSpecByPath(specs, path)
+		if !ok {
+			t.Fatalf("BuildModelSpecs() did not produce a spec for %q", path)
+		}
+
+		dir := t.TempDir()
+		writeModelFile(t, dir, "config.json", "{}")
+		writeModelFile(t, filepath.Join(dir, "onnx", "layer-6"), "model.onnx", "onnx-bytes")
+
+		complete, err := IsModelComplete(dir, spec.RequiredFiles)
+		if err != nil {
+			t.Fatalf("IsModelComplete(%q) error = %v", path, err)
+		}
+		if complete {
+			t.Errorf("ONNX-only dir for %q reported complete; expected incomplete", path)
+		}
+	}
+}
+
+// TestGemmaDirWithoutDenseWeightsReportedIncomplete guards the gemma-specific slice of
+// #2531: root weights and tokenizer alone are not enough, the dense-bottleneck weights the
+// runtime hard-loads must be present before the model reads as complete.
+func TestGemmaDirWithoutDenseWeightsReportedIncomplete(t *testing.T) {
+	specs, err := BuildModelSpecs(newCandleEmbeddingConfig())
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	spec, ok := findSpecByPath(specs, testGemmaModelPath)
+	if !ok {
+		t.Fatalf("BuildModelSpecs() did not produce a spec for %q", testGemmaModelPath)
+	}
+
+	dir := t.TempDir()
+	writeModelFile(t, dir, "config.json", "{}")
+	writeModelFile(t, dir, "model.safetensors", "weights")
+	writeModelFile(t, dir, "tokenizer.json", "{}")
+
+	complete, err := IsModelComplete(dir, spec.RequiredFiles)
+	if err != nil {
+		t.Fatalf("IsModelComplete() error = %v", err)
+	}
+	if complete {
+		t.Fatalf("gemma dir without dense weights reported complete; RequiredFiles = %#v", spec.RequiredFiles)
+	}
+
+	writeModelFile(t, filepath.Join(dir, "2_Dense"), "model.safetensors", "dense-2")
+	writeModelFile(t, filepath.Join(dir, "3_Dense"), "model.safetensors", "dense-3")
+
+	complete, err = IsModelComplete(dir, spec.RequiredFiles)
+	if err != nil {
+		t.Fatalf("IsModelComplete() error = %v", err)
+	}
+	if !complete {
+		t.Fatalf("full gemma dir reported incomplete; RequiredFiles = %#v", spec.RequiredFiles)
+	}
+}
+
+// TestBuildModelSpecsSkipsCandleEmbeddingModelsForRemoteBackend keeps the remote-backend
+// exemption intact for the newly covered paths.
+func TestBuildModelSpecsSkipsCandleEmbeddingModelsForRemoteBackend(t *testing.T) {
+	cfg := newCandleEmbeddingConfig()
+	cfg.EmbeddingModels.EmbeddingConfig = config.HNSWConfig{
+		Backend:   config.EmbeddingBackendOpenAICompatible,
+		ModelType: config.EmbeddingModelTypeRemote,
+	}
+	cfg.EmbeddingModels.Endpoint = config.EmbeddingEndpointConfig{
+		BaseURL: "http://embedding-service:8000/v1",
+		Model:   "BAAI/bge-m3",
+	}
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("BuildModelSpecs() returned %d specs for remote embedding backend, want 0: %#v", len(specs), specs)
+	}
+}


### PR DESCRIPTION
Closes #2531

## Purpose

`IsModelComplete` treats a directory as complete once `RequiredFiles` are present and any nested weight file (e.g. `onnx/**/*.onnx`) matches, so a partial download missing the files the candle embedding runtime hard-loads at startup reads as complete, is skipped on later starts, and never self-heals. #2195 fixed this for the configured mmbert path only.

This PR extends the same required-files contract to the remaining candle embedding paths in `pkg/modeldownload/config_parser.go`:

- `qwen3_model_path`, `multimodal_model_path`: `model.safetensors` + `tokenizer.json`
- `gemma_model_path`: the above plus `2_Dense/model.safetensors` + `3_Dense/model.safetensors` (the dense bottleneck loaded by `candle-binding/src/model_architectures/embedding/dense_layers.rs`)

The per-model file table is merge-safe when two config fields point at the same directory, and the remote-embedding-backend exemption is preserved. Owned by `wg/router-models-inference-runtime` via the accepted issue.

## Test Plan

```
cd src/semantic-router
go test ./pkg/modeldownload/
gofmt -l pkg/modeldownload/
go vet ./pkg/modeldownload/
```

New tests:
- `TestBuildModelSpecsRequiresCandleRuntimeFilesPerModel`: per-path required-files contract (mmbert regression + qwen3/gemma/multimodal)
- `TestOnnxOnlyCandleEmbeddingDirsReportedIncomplete`: ONNX-only layout reads incomplete for qwen3/multimodal
- `TestGemmaDirWithoutDenseWeightsReportedIncomplete`: gemma without dense weights reads incomplete, complete once they are present
- `TestBuildModelSpecsSkipsCandleEmbeddingModelsForRemoteBackend`: remote-backend exemption intact

## Test Result

All of the above pass locally (`ok ... pkg/modeldownload`), gofmt/vet clean. Existing #2195/#2172 tests unchanged and green.

One open question for review: the fix reuses the `UsesRemoteEmbeddingBackend()` gate from #2195. If any of the qwen3/gemma/multimodal paths can be locally loaded while the semantic embedding backend is remote, the gate may need to be narrowed per path.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change
</details>
