### PR TITLE
[Bug] Make vector-store shutdown generation-safe

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1961,7 +1961,7 @@ global:
       embedding_model: multimodal
       embedding_dimension: 384
       ingestion_workers: 4
-      ingestion_drain_timeout_seconds: 30
+      ingestion_drain_timeout_seconds: 25
       supported_formats: [.txt, .md, .json, .csv, .html, .pdf]
       milvus:
         connection:

--- a/dashboard/frontend/src/pages/configPageRouterDefaultsCatalog.ts
+++ b/dashboard/frontend/src/pages/configPageRouterDefaultsCatalog.ts
@@ -111,6 +111,7 @@ export const DEFAULT_SECTIONS: Record<RouterSystemKey, unknown> = {
     embedding_model: 'mmbert',
     embedding_dimension: 384,
     ingestion_workers: 2,
+    ingestion_drain_timeout_seconds: 25,
     supported_formats: ['.txt', '.md', '.json', '.csv', '.html'],
     memory: {
       max_entries_per_store: 100000,

--- a/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
+++ b/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
@@ -758,6 +758,7 @@ function fieldsForKey(key: RouterSystemKey): FieldConfig[] {
           placeholder: '384',
         },
         { name: 'ingestion_workers', label: 'Ingestion Workers', type: 'number', placeholder: '2' },
+        { name: 'ingestion_drain_timeout_seconds', label: 'Ingestion Drain Timeout (s)', type: 'number', placeholder: '25' },
         routerStructuredField(key, 'supported_formats'),
         routerStructuredField(key, 'memory'),
         routerStructuredField(key, 'milvus'),

--- a/dashboard/frontend/src/pages/configPageSupport.ts
+++ b/dashboard/frontend/src/pages/configPageSupport.ts
@@ -554,6 +554,7 @@ export interface VectorStoreConfig {
   embedding_model?: string
   embedding_dimension?: number
   ingestion_workers?: number
+  ingestion_drain_timeout_seconds?: number
   supported_formats?: string[]
   milvus?: VectorStoreMilvusConfig
   memory?: VectorStoreMemoryConfig

--- a/e2e/profiles/rag-hybrid-search/values.yaml
+++ b/e2e/profiles/rag-hybrid-search/values.yaml
@@ -54,7 +54,7 @@ config:
         embedding_model: mmbert
         embedding_dimension: 384
         ingestion_workers: 2
-        ingestion_drain_timeout_seconds: 30
+        ingestion_drain_timeout_seconds: 25
         supported_formats:
           - .txt
           - .md

--- a/src/semantic-router/pkg/config/vectorstore.go
+++ b/src/semantic-router/pkg/config/vectorstore.go
@@ -57,7 +57,7 @@ type VectorStoreConfig struct {
 	// chunk count × per-chunk embed + backend insert), while staying *below* the
 	// deployment's shutdown grace period (e.g. Kubernetes
 	// terminationGracePeriodSeconds, default 30s) so the drain actually runs
-	// before the platform force-kills the process. Default: 30.
+	// before the platform force-kills the process. Default: 25.
 	IngestionDrainTimeoutSeconds int `json:"ingestion_drain_timeout_seconds,omitempty" yaml:"ingestion_drain_timeout_seconds,omitempty"`
 
 	// SupportedFormats lists the allowed file extensions for upload.
@@ -317,7 +317,7 @@ func (c *VectorStoreConfig) ApplyDefaults() {
 		c.IngestionWorkers = 2
 	}
 	if c.IngestionDrainTimeoutSeconds <= 0 {
-		c.IngestionDrainTimeoutSeconds = 30
+		c.IngestionDrainTimeoutSeconds = 25
 	}
 	if len(c.SupportedFormats) == 0 {
 		c.SupportedFormats = []string{".txt", ".md", ".json", ".csv", ".html"}

--- a/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
+++ b/src/semantic-router/pkg/routerruntime/vectorstore_runtime.go
@@ -2,6 +2,7 @@ package routerruntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -30,7 +31,7 @@ type VectorStoreRuntime struct {
 // defaultDrainTimeout is the fallback shutdown drain bound used when a runtime
 // is constructed without a configured drain timeout, so Stop is never
 // unbounded.
-const defaultDrainTimeout = 30 * time.Second
+const defaultDrainTimeout = 25 * time.Second
 
 func NewVectorStoreRuntime(cfg *config.RouterConfig) (*VectorStoreRuntime, error) {
 	if cfg == nil {
@@ -144,17 +145,26 @@ func (r *VectorStoreRuntime) Shutdown() error {
 		defer cancel()
 		if err := r.Pipeline.Stop(ctx); err != nil {
 			logging.Warnf("Ingestion pipeline did not drain within %s: %v", drain, err)
+			// Workers may still be inside backend or registry calls after a bounded
+			// timeout. Closing their dependencies here would create a use-after-close
+			// race, so leave ownership with the still-stopping pipeline and report the
+			// shutdown failure to the caller.
+			return fmt.Errorf("stop vector store ingestion pipeline: %w", err)
 		}
 	}
+	var closeErr error
 	if r.registryCloser != nil {
 		if err := r.registryCloser.Close(); err != nil {
 			logging.Warnf("Failed to close metadata registry: %v", err)
+			closeErr = errors.Join(closeErr, fmt.Errorf("close metadata registry: %w", err))
 		}
 	}
 	if r.Backend != nil {
-		return r.Backend.Close()
+		if err := r.Backend.Close(); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close vector store backend: %w", err))
+		}
 	}
-	return nil
+	return closeErr
 }
 
 func (r *VectorStoreRuntime) LogInitialized(component string, cfg *config.RouterConfig) {

--- a/src/semantic-router/pkg/vectorstore/manager.go
+++ b/src/semantic-router/pkg/vectorstore/manager.go
@@ -265,3 +265,39 @@ func (m *Manager) UpdateFileCounts(ctx context.Context, id string, fn func(*File
 	}
 	return nil
 }
+
+// failQueuedFileCounts applies the count transition for a batch of queued
+// jobs before attempting to persist any of the updated stores. Keeping the
+// in-memory transition separate from persistence means a shutdown deadline
+// cannot leave some drained jobs counted as in progress just because an
+// earlier registry write stalled.
+func (m *Manager) failQueuedFileCounts(ctx context.Context, failedByStore map[string]int) error {
+	type snapshot struct {
+		id    string
+		store *VectorStore
+	}
+
+	snapshots := make([]snapshot, 0, len(failedByStore))
+	m.mu.Lock()
+	for id, failed := range failedByStore {
+		if failed <= 0 {
+			continue
+		}
+		vs, ok := m.stores[id]
+		if !ok {
+			m.mu.Unlock()
+			return fmt.Errorf("vector store not found: %s", id)
+		}
+		vs.FileCounts.InProgress -= failed
+		vs.FileCounts.Failed += failed
+		snapshots = append(snapshots, snapshot{id: id, store: cloneVectorStore(vs)})
+	}
+	m.mu.Unlock()
+
+	for _, item := range snapshots {
+		if err := m.registry.SaveStore(ctx, cloneVectorStore(item.store)); err != nil {
+			return fmt.Errorf("persist vector store metadata for %s: %w", item.id, err)
+		}
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/vectorstore/pipeline.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline.go
@@ -199,7 +199,15 @@ func (p *IngestionPipeline) Stop(ctx context.Context) error {
 drained:
 	p.lifecycleMu.Unlock()
 	for _, job := range queued {
-		p.failJob(context.Background(), job, "pipeline_stopped", "ingestion pipeline stopped before processing job")
+		if err := ctx.Err(); err != nil {
+			gen.rootCancel()
+			return err
+		}
+		p.failJobWithPersistContext(ctx, job, "pipeline_stopped", "ingestion pipeline stopped before processing job")
+	}
+	if err := ctx.Err(); err != nil {
+		gen.rootCancel()
+		return err
 	}
 
 	select {
@@ -503,16 +511,24 @@ func (p *IngestionPipeline) embedChunks(ctx context.Context, job IngestionJob, f
 
 // failJob marks a job as failed and updates file counts.
 func (p *IngestionPipeline) failJob(ctx context.Context, job IngestionJob, code, message string) {
-	p.setFileStatus(job.VectorStoreFileID, "failed", &FileError{
-		Code:    code,
-		Message: message,
-	})
 	// Count updates use a background context: even when the job context is
 	// cancelled, the in-memory counts and durable metadata must stay consistent
 	// with the file status we just wrote.
 	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
-	_ = p.manager.UpdateFileCounts(persistCtx, job.VectorStoreID, func(fc *FileCounts) {
+	p.failJobWithPersistContext(persistCtx, job, code, message)
+}
+
+// failJobWithPersistContext marks a job as failed while keeping persistence
+// within the caller's budget. Stop uses this for queued jobs so the entire
+// cleanup shares its shutdown deadline instead of receiving a fresh timeout
+// for every job.
+func (p *IngestionPipeline) failJobWithPersistContext(ctx context.Context, job IngestionJob, code, message string) {
+	p.setFileStatus(job.VectorStoreFileID, "failed", &FileError{
+		Code:    code,
+		Message: message,
+	})
+	_ = p.manager.UpdateFileCounts(ctx, job.VectorStoreID, func(fc *FileCounts) {
 		fc.InProgress--
 		fc.Failed++
 	})

--- a/src/semantic-router/pkg/vectorstore/pipeline.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline.go
@@ -44,7 +44,24 @@ type IngestionJob struct {
 // defaultStopTimeout bounds a Stop call from a shutdown path that does not
 // supply its own deadline. It keeps process shutdown responsive even when a
 // backend or embedder is wedged.
-const defaultStopTimeout = 30 * time.Second
+const defaultStopTimeout = 25 * time.Second
+
+type lifecycleState uint8
+
+const (
+	stateStopped lifecycleState = iota
+	stateRunning
+	stateStopping
+)
+
+type pipelineGeneration struct {
+	jobQueue   chan IngestionJob
+	stopCh     chan struct{}
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+	wg         sync.WaitGroup
+	done       chan struct{}
+}
 
 // IngestionPipeline processes file attachment jobs asynchronously.
 // It reads files, extracts text, chunks, embeds, and stores the
@@ -54,19 +71,13 @@ type IngestionPipeline struct {
 	fileStore    *FileStore
 	manager      *Manager
 	embedder     Embedder
-	jobQueue     chan IngestionJob
 	workers      int
+	queueSize    int
 	lifecycleMu  sync.Mutex
 	mu           sync.RWMutex
 	fileStatuses map[string]*VectorStoreFile // vsf_id -> status
-	wg           sync.WaitGroup
-	stopCh       chan struct{}
-	// rootCtx is the pipeline lifecycle context. All per-job work derives from
-	// it, so cancelling rootCancel signals every in-flight job to abort at its
-	// next checkpoint. It is (re)created on each Start.
-	rootCtx    context.Context
-	rootCancel context.CancelFunc
-	running    bool
+	state        lifecycleState
+	generation   *pipelineGeneration
 }
 
 // PipelineConfig holds configuration for the ingestion pipeline.
@@ -91,33 +102,59 @@ func NewIngestionPipeline(backend VectorStoreBackend, fileStore *FileStore, mana
 		fileStore:    fileStore,
 		manager:      manager,
 		embedder:     embedder,
-		jobQueue:     make(chan IngestionJob, queueSize),
 		workers:      workers,
+		queueSize:    queueSize,
 		fileStatuses: make(map[string]*VectorStoreFile),
-		stopCh:       make(chan struct{}),
+		state:        stateStopped,
 	}
 }
 
 // Start launches the worker goroutines.
 func (p *IngestionPipeline) Start() {
-	p.lifecycleMu.Lock()
-	defer p.lifecycleMu.Unlock()
+	for {
+		p.lifecycleMu.Lock()
+		p.mu.RLock()
+		state := p.state
+		var done chan struct{}
+		if p.generation != nil {
+			done = p.generation.done
+		}
+		p.mu.RUnlock()
+		if state == stateRunning {
+			p.lifecycleMu.Unlock()
+			return
+		}
+		if state == stateStopping {
+			p.lifecycleMu.Unlock()
+			<-done
+			continue
+		}
 
-	p.mu.Lock()
-	if p.running {
+		gen := &pipelineGeneration{
+			jobQueue: make(chan IngestionJob, p.queueSize),
+			stopCh:   make(chan struct{}),
+			done:     make(chan struct{}),
+		}
+		gen.rootCtx, gen.rootCancel = context.WithCancel(context.Background())
+		p.mu.Lock()
+		p.generation = gen
+		p.state = stateRunning
 		p.mu.Unlock()
+		for i := 0; i < p.workers; i++ {
+			gen.wg.Add(1)
+			go p.worker(gen)
+		}
+		go func() {
+			gen.wg.Wait()
+			close(gen.done)
+			p.mu.Lock()
+			if p.generation == gen && p.state == stateStopping {
+				p.state = stateStopped
+			}
+			p.mu.Unlock()
+		}()
+		p.lifecycleMu.Unlock()
 		return
-	}
-	p.stopCh = make(chan struct{})
-	stopCh := p.stopCh
-	p.rootCtx, p.rootCancel = context.WithCancel(context.Background())
-	rootCtx := p.rootCtx
-	p.running = true
-	p.mu.Unlock()
-
-	for i := 0; i < p.workers; i++ {
-		p.wg.Add(1)
-		go p.worker(rootCtx, stopCh)
 	}
 }
 
@@ -130,52 +167,52 @@ func (p *IngestionPipeline) Start() {
 // A nil ctx is treated as a bounded shutdown with defaultStopTimeout.
 func (p *IngestionPipeline) Stop(ctx context.Context) error {
 	p.lifecycleMu.Lock()
-	defer p.lifecycleMu.Unlock()
-
-	p.mu.Lock()
-	if !p.running {
-		p.mu.Unlock()
-		return nil
-	}
-	stopCh := p.stopCh
-	rootCancel := p.rootCancel
-	p.running = false
-	p.mu.Unlock()
-
 	if ctx == nil {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(context.Background(), defaultStopTimeout)
 		defer cancel()
 	}
-
-	p.failQueuedJobs("pipeline_stopped", "ingestion pipeline stopped before processing job")
-	close(stopCh)
-
-	// Wait for workers to drain, bounded by ctx. On timeout, cancel the root
-	// context so in-flight jobs abort at their next stage checkpoint, then
-	// return without waiting further — Stop must not block past ctx.
-	//
-	// Note: a job wedged *inside* a single stage (e.g. an embedder or backend
-	// call that ignores context) cannot be interrupted here; that worker unwinds
-	// only once the stage returns. Making individual stages ctx-aware is handled
-	// by the follow-up embedder/backend context work. Stop's own contract —
-	// returning within ctx — holds regardless.
-	done := make(chan struct{})
-	go func() {
-		p.wg.Wait()
-		close(done)
-	}()
+	p.mu.Lock()
+	state := p.state
+	gen := p.generation
+	if state == stateRunning {
+		p.state = stateStopping
+	}
+	p.mu.Unlock()
+	if state == stateStopped || gen == nil {
+		p.lifecycleMu.Unlock()
+		return nil
+	}
+	var queued []IngestionJob
+	if state == stateRunning {
+		for {
+			select {
+			case job := <-gen.jobQueue:
+				queued = append(queued, job)
+			default:
+				close(gen.stopCh)
+				state = stateStopping
+				goto drained
+			}
+		}
+	}
+drained:
+	p.lifecycleMu.Unlock()
+	for _, job := range queued {
+		p.failJob(context.Background(), job, "pipeline_stopped", "ingestion pipeline stopped before processing job")
+	}
 
 	select {
-	case <-done:
-		if rootCancel != nil {
-			rootCancel()
+	case <-gen.done:
+		gen.rootCancel()
+		p.mu.Lock()
+		if p.generation == gen {
+			p.state = stateStopped
 		}
+		p.mu.Unlock()
 		return nil
 	case <-ctx.Done():
-		if rootCancel != nil {
-			rootCancel()
-		}
+		gen.rootCancel()
 		return ctx.Err()
 	}
 }
@@ -194,13 +231,6 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 		return nil, fmt.Errorf("vector store not found: %w", err)
 	}
 
-	p.lifecycleMu.Lock()
-	defer p.lifecycleMu.Unlock()
-
-	if !p.isRunningLocked() {
-		return nil, fmt.Errorf("ingestion pipeline is not running")
-	}
-
 	vsfID := GenerateVectorStoreFileID()
 	vsf := &VectorStoreFile{
 		ID:               vsfID,
@@ -212,16 +242,6 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 		CreatedAt:        time.Now().Unix(),
 	}
 
-	p.mu.Lock()
-	p.fileStatuses[vsfID] = cloneVectorStoreFile(vsf)
-	p.mu.Unlock()
-
-	// Update file counts.
-	_ = p.manager.UpdateFileCounts(context.Background(), vectorStoreID, func(fc *FileCounts) {
-		fc.InProgress++
-		fc.Total++
-	})
-
 	job := IngestionJob{
 		VectorStoreFileID: vsfID,
 		VectorStoreID:     vectorStoreID,
@@ -232,20 +252,47 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 	// Snapshot before enqueuing so the caller always sees "in_progress",
 	// even if the worker completes the job before we return.
 	snapshot := cloneVectorStoreFile(vsf)
+	if !p.isRunning() {
+		return nil, fmt.Errorf("ingestion pipeline is not running")
+	}
+	countCtx, countCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_ = p.manager.UpdateFileCounts(countCtx, vectorStoreID, func(fc *FileCounts) {
+		fc.InProgress++
+		fc.Total++
+	})
+	countCancel()
 
+	p.lifecycleMu.Lock()
+	p.mu.RLock()
+	gen := p.generation
+	running := p.state == stateRunning
+	p.mu.RUnlock()
+	if !running || gen == nil {
+		p.lifecycleMu.Unlock()
+		compCtx, compCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = p.manager.UpdateFileCounts(compCtx, vectorStoreID, func(fc *FileCounts) {
+			fc.InProgress--
+			fc.Total--
+		})
+		compCancel()
+		return nil, fmt.Errorf("ingestion pipeline is not running")
+	}
+	p.mu.Lock()
+	p.fileStatuses[vsfID] = cloneVectorStoreFile(vsf)
+	p.mu.Unlock()
 	select {
-	case p.jobQueue <- job:
+	case gen.jobQueue <- job:
+		p.lifecycleMu.Unlock()
 		return snapshot, nil
 	default:
-		// Queue is full.
-		p.setFileStatus(vsfID, "failed", &FileError{
-			Code:    "queue_full",
-			Message: "ingestion queue is full, try again later",
-		})
-		_ = p.manager.UpdateFileCounts(context.Background(), vectorStoreID, func(fc *FileCounts) {
+		p.setFileStatus(vsfID, "failed", &FileError{Code: "queue_full", Message: "ingestion queue is full, try again later"})
+		failCtx, failCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = p.manager.UpdateFileCounts(failCtx, vectorStoreID, func(fc *FileCounts) {
 			fc.InProgress--
 			fc.Failed++
 		})
+		failCancel()
+		p.lifecycleMu.Unlock()
 		status, err := p.GetFileStatus(vsfID)
 		if err != nil {
 			return cloneVectorStoreFile(vsf), nil
@@ -254,11 +301,10 @@ func (p *IngestionPipeline) AttachFile(vectorStoreID, fileID string, strategy *C
 	}
 }
 
-func (p *IngestionPipeline) isRunningLocked() bool {
+func (p *IngestionPipeline) isRunning() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-
-	return p.running
+	return p.state == stateRunning
 }
 
 // GetFileStatus returns the current status of a vector store file.
@@ -324,20 +370,20 @@ func (p *IngestionPipeline) DetachFile(ctx context.Context, vectorStoreID, vsfID
 }
 
 // worker is the background goroutine that processes ingestion jobs.
-func (p *IngestionPipeline) worker(ctx context.Context, stopCh <-chan struct{}) {
-	defer p.wg.Done()
+func (p *IngestionPipeline) worker(gen *pipelineGeneration) {
+	defer gen.wg.Done()
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-gen.rootCtx.Done():
 			return
-		case <-stopCh:
+		case <-gen.stopCh:
 			return
-		case job, ok := <-p.jobQueue:
+		case job, ok := <-gen.jobQueue:
 			if !ok {
 				return
 			}
-			p.processJob(ctx, job)
+			p.processJob(gen.rootCtx, job)
 		}
 	}
 }
@@ -398,13 +444,19 @@ func (p *IngestionPipeline) processJob(ctx context.Context, job IngestionJob) {
 
 	// Step 6: Insert into backend.
 	if err := p.backend.InsertChunks(ctx, job.VectorStoreID, embeddedChunks); err != nil {
-		p.failJob(ctx, job, "storage_error", fmt.Sprintf("failed to store chunks: %v", err))
+		code := "storage_error"
+		if ctx.Err() != nil {
+			code = "cancelled"
+		}
+		p.failJob(ctx, job, code, fmt.Sprintf("failed to store chunks: %v", err))
 		return
 	}
 
 	// Mark as completed.
 	p.setFileStatus(job.VectorStoreFileID, "completed", nil)
-	_ = p.manager.UpdateFileCounts(ctx, job.VectorStoreID, func(fc *FileCounts) {
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	_ = p.manager.UpdateFileCounts(persistCtx, job.VectorStoreID, func(fc *FileCounts) {
 		fc.InProgress--
 		fc.Completed++
 	})
@@ -458,21 +510,12 @@ func (p *IngestionPipeline) failJob(ctx context.Context, job IngestionJob, code,
 	// Count updates use a background context: even when the job context is
 	// cancelled, the in-memory counts and durable metadata must stay consistent
 	// with the file status we just wrote.
-	_ = p.manager.UpdateFileCounts(context.WithoutCancel(ctx), job.VectorStoreID, func(fc *FileCounts) {
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	_ = p.manager.UpdateFileCounts(persistCtx, job.VectorStoreID, func(fc *FileCounts) {
 		fc.InProgress--
 		fc.Failed++
 	})
-}
-
-func (p *IngestionPipeline) failQueuedJobs(code, message string) {
-	for {
-		select {
-		case job := <-p.jobQueue:
-			p.failJob(context.Background(), job, code, message)
-		default:
-			return
-		}
-	}
 }
 
 // setFileStatus updates the status and error of a vector store file.

--- a/src/semantic-router/pkg/vectorstore/pipeline.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline.go
@@ -198,13 +198,11 @@ func (p *IngestionPipeline) Stop(ctx context.Context) error {
 	}
 drained:
 	p.lifecycleMu.Unlock()
-	for _, job := range queued {
-		if err := ctx.Err(); err != nil {
-			gen.rootCancel()
-			return err
-		}
-		p.failJobWithPersistContext(ctx, job, "pipeline_stopped", "ingestion pipeline stopped before processing job")
-	}
+	// Persistence is best effort, as it was for individual job failures. The
+	// in-memory status/count transition is applied for every drained job before
+	// this bounded persistence attempt, so a registry error cannot leave jobs
+	// stuck in progress or prevent the worker generation from shutting down.
+	_ = p.failQueuedJobs(ctx, queued)
 	if err := ctx.Err(); err != nil {
 		gen.rootCancel()
 		return err
@@ -532,6 +530,25 @@ func (p *IngestionPipeline) failJobWithPersistContext(ctx context.Context, job I
 		fc.InProgress--
 		fc.Failed++
 	})
+}
+
+// failQueuedJobs marks every job removed from the generation queue before
+// attempting bounded metadata persistence. This ordering keeps queued jobs
+// from becoming permanently invisible when the shutdown context expires
+// during a registry write.
+func (p *IngestionPipeline) failQueuedJobs(ctx context.Context, queued []IngestionJob) error {
+	failedByStore := make(map[string]int)
+	for _, job := range queued {
+		p.setFileStatus(job.VectorStoreFileID, "failed", &FileError{
+			Code:    "pipeline_stopped",
+			Message: "ingestion pipeline stopped before processing job",
+		})
+		failedByStore[job.VectorStoreID]++
+	}
+	if len(failedByStore) == 0 {
+		return nil
+	}
+	return p.manager.failQueuedFileCounts(ctx, failedByStore)
 }
 
 // setFileStatus updates the status and error of a vector store file.

--- a/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
@@ -27,10 +27,11 @@ import (
 )
 
 type blockingEmbedder struct {
-	dim     int
-	once    sync.Once
-	started chan struct{}
-	release chan struct{}
+	dim         int
+	once        sync.Once
+	releaseOnce sync.Once
+	started     chan struct{}
+	release     chan struct{}
 }
 
 func newBlockingEmbedder(dim int) *blockingEmbedder {
@@ -60,6 +61,10 @@ func (e *blockingEmbedder) Embed(_ context.Context, _ string) ([]float32, error)
 
 func (e *blockingEmbedder) Dimension() int {
 	return e.dim
+}
+
+func (e *blockingEmbedder) releaseAll() {
+	e.releaseOnce.Do(func() { close(e.release) })
 }
 
 type pipelineLifecycleFixture struct {
@@ -175,7 +180,7 @@ var _ = Describe("IngestionPipeline queued shutdown", func() {
 		released := false
 		defer func() {
 			if !released {
-				close(embedder.release)
+				embedder.releaseAll()
 			}
 		}()
 
@@ -213,7 +218,7 @@ var _ = Describe("IngestionPipeline queued shutdown", func() {
 		Expect(secondStatus.LastError).NotTo(BeNil())
 		Expect(secondStatus.LastError.Code).To(Equal("pipeline_stopped"))
 
-		close(embedder.release)
+		embedder.releaseAll()
 		released = true
 		Eventually(stopped, 5*time.Second).Should(BeClosed())
 
@@ -243,7 +248,8 @@ var _ = Describe("IngestionPipeline bounded Stop", func() {
 
 	AfterEach(func() {
 		// Release the wedged embedder so the worker can unwind, then clean up.
-		close(embedder.release)
+		embedder.releaseAll()
+		_ = f.pipeline.Stop(context.Background())
 		_ = os.RemoveAll(f.tempDir)
 	})
 
@@ -291,7 +297,71 @@ var _ = Describe("IngestionPipeline bounded Stop", func() {
 		defer cancel()
 		Expect(f.pipeline.Stop(ctx)).To(MatchError(context.DeadlineExceeded))
 
-		// A second Stop on an already-stopped pipeline is a no-op returning nil.
+		// A second Stop must report that the generation is still stopping instead
+		// of falsely claiming a clean shutdown. Once the wedged stage is released,
+		// a retry can observe the worker join and return nil.
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel2()
+		Expect(f.pipeline.Stop(ctx2)).To(MatchError(context.DeadlineExceeded))
+		embedder.releaseAll()
+		Eventually(func() error {
+			ctx3, cancel3 := context.WithTimeout(context.Background(), time.Second)
+			defer cancel3()
+			return f.pipeline.Stop(ctx3)
+		}, 5*time.Second, 50*time.Millisecond).Should(BeNil())
+	})
+})
+
+var _ = Describe("IngestionPipeline restart after timed-out Stop", func() {
+	var (
+		embedder *blockingEmbedder
+		f        *pipelineLifecycleFixture
+	)
+
+	BeforeEach(func() {
+		embedder = newBlockingEmbedder(3)
+		f = newPipelineLifecycleFixture(embedder)
+	})
+
+	AfterEach(func() {
+		embedder.releaseAll()
+		_ = f.pipeline.Stop(context.Background())
+		_ = os.RemoveAll(f.tempDir)
+	})
+
+	It("does not reuse a timed-out generation during restart", func() {
+		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "restart-generation"})
+		Expect(err).NotTo(HaveOccurred())
+		record, err := f.store.Save("restart.txt", []byte("content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = f.pipeline.AttachFile(vs.ID, record.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(embedder.started, 5*time.Second).Should(BeClosed())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		Expect(f.pipeline.Stop(ctx)).To(MatchError(context.DeadlineExceeded))
+
+		started := make(chan struct{})
+		go func() {
+			f.pipeline.Start()
+			close(started)
+		}()
+		Consistently(started, 150*time.Millisecond, 20*time.Millisecond).ShouldNot(BeClosed())
+		embedder.releaseAll()
+		Eventually(started, 5*time.Second).Should(BeClosed())
+
+		second, err := f.store.Save("restart-second.txt", []byte("new content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+		vsf, err := f.pipeline.AttachFile(vs.ID, second.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() string {
+			status, statusErr := f.pipeline.GetFileStatus(vsf.ID)
+			if statusErr != nil {
+				return ""
+			}
+			return status.Status
+		}, 5*time.Second, 50*time.Millisecond).Should(Equal("completed"))
 		Expect(f.pipeline.Stop(context.Background())).To(BeNil())
 	})
 })

--- a/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
@@ -403,9 +403,21 @@ var _ = Describe("IngestionPipeline bounded queued cleanup", func() {
 		Expect(err).To(MatchError(context.DeadlineExceeded))
 		Expect(time.Since(start)).To(BeNumerically("<", 3*time.Second))
 		Expect(registry.started).To(BeClosed())
-		status, statusErr := f.pipeline.GetFileStatus(queued[0].ID)
-		Expect(statusErr).NotTo(HaveOccurred())
-		Expect(status.Status).To(Equal("failed"))
+		for _, queuedStatus := range queued {
+			status, statusErr := f.pipeline.GetFileStatus(queuedStatus.ID)
+			Expect(statusErr).NotTo(HaveOccurred())
+			Expect(status.Status).To(Equal("failed"))
+			Expect(status.LastError).NotTo(BeNil())
+			Expect(status.LastError.Code).To(Equal("pipeline_stopped"))
+		}
+		updated, updateErr := f.mgr.GetStore(vs.ID)
+		Expect(updateErr).NotTo(HaveOccurred())
+		// The first job is intentionally still wedged in Embed until cleanup,
+		// so it remains in progress while Stop returns. All three queued jobs
+		// must have moved to failed.
+		Expect(updated.FileCounts.InProgress).To(Equal(1))
+		Expect(updated.FileCounts.Failed).To(Equal(3))
+		Expect(updated.FileCounts.Total).To(Equal(4))
 	})
 })
 

--- a/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
+++ b/src/semantic-router/pkg/vectorstore/pipeline_lifecycle_test.go
@@ -77,6 +77,10 @@ type pipelineLifecycleFixture struct {
 }
 
 func newPipelineLifecycleFixture(embedder Embedder) *pipelineLifecycleFixture {
+	return newPipelineLifecycleFixtureWithRegistry(embedder, NewMemoryMetadataRegistry())
+}
+
+func newPipelineLifecycleFixtureWithRegistry(embedder Embedder, registry StoreRegistry) *pipelineLifecycleFixture {
 	tempDir, err := os.MkdirTemp("", "pipeline-lifecycle-test-*")
 	Expect(err).NotTo(HaveOccurred())
 
@@ -84,7 +88,7 @@ func newPipelineLifecycleFixture(embedder Embedder) *pipelineLifecycleFixture {
 	store, err := NewFileStore(tempDir, NewMemoryMetadataRegistry())
 	Expect(err).NotTo(HaveOccurred())
 
-	mgr := NewManager(backend, NewMemoryMetadataRegistry(), 3, BackendTypeMemory)
+	mgr := NewManager(backend, registry, 3, BackendTypeMemory)
 	pipeline := NewIngestionPipeline(
 		backend,
 		store,
@@ -102,6 +106,45 @@ func newPipelineLifecycleFixture(embedder Embedder) *pipelineLifecycleFixture {
 		tempDir:  tempDir,
 		ctx:      context.Background(),
 	}
+}
+
+type stallingStoreRegistry struct {
+	StoreRegistry
+	mu      sync.RWMutex
+	stalled bool
+	started chan struct{}
+	once    sync.Once
+}
+
+func newStallingStoreRegistry() *stallingStoreRegistry {
+	return &stallingStoreRegistry{
+		StoreRegistry: NewMemoryMetadataRegistry(),
+		started:       make(chan struct{}),
+	}
+}
+
+func (r *stallingStoreRegistry) SaveStore(ctx context.Context, vs *VectorStore) error {
+	r.mu.RLock()
+	stalled := r.stalled
+	r.mu.RUnlock()
+	if stalled {
+		r.once.Do(func() { close(r.started) })
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return r.StoreRegistry.SaveStore(ctx, vs)
+}
+
+func (r *stallingStoreRegistry) stall() {
+	r.mu.Lock()
+	r.stalled = true
+	r.mu.Unlock()
+}
+
+func (r *stallingStoreRegistry) resume() {
+	r.mu.Lock()
+	r.stalled = false
+	r.mu.Unlock()
 }
 
 func (f *pipelineLifecycleFixture) cleanup() {
@@ -309,6 +352,60 @@ var _ = Describe("IngestionPipeline bounded Stop", func() {
 			defer cancel3()
 			return f.pipeline.Stop(ctx3)
 		}, 5*time.Second, 50*time.Millisecond).Should(BeNil())
+	})
+})
+
+var _ = Describe("IngestionPipeline bounded queued cleanup", func() {
+	var (
+		embedder *blockingEmbedder
+		registry *stallingStoreRegistry
+		f        *pipelineLifecycleFixture
+	)
+
+	BeforeEach(func() {
+		embedder = newBlockingEmbedder(3)
+		registry = newStallingStoreRegistry()
+		f = newPipelineLifecycleFixtureWithRegistry(embedder, registry)
+	})
+
+	AfterEach(func() {
+		registry.resume()
+		embedder.releaseAll()
+		_ = f.pipeline.Stop(context.Background())
+		_ = os.RemoveAll(f.tempDir)
+	})
+
+	It("shares the Stop deadline across queued cleanup", func() {
+		vs, err := f.mgr.CreateStore(f.ctx, CreateStoreRequest{Name: "stalled-registry"})
+		Expect(err).NotTo(HaveOccurred())
+
+		first, err := f.store.Save("active.txt", []byte("active content"), "assistants")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = f.pipeline.AttachFile(vs.ID, first.ID, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(embedder.started, 5*time.Second).Should(BeClosed())
+
+		var queued []*VectorStoreFile
+		for i := 0; i < 3; i++ {
+			record, saveErr := f.store.Save("queued.txt", []byte("queued content"), "assistants")
+			Expect(saveErr).NotTo(HaveOccurred())
+			status, attachErr := f.pipeline.AttachFile(vs.ID, record.ID, nil)
+			Expect(attachErr).NotTo(HaveOccurred())
+			queued = append(queued, status)
+		}
+
+		registry.stall()
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		start := time.Now()
+		err = f.pipeline.Stop(ctx)
+
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+		Expect(time.Since(start)).To(BeNumerically("<", 3*time.Second))
+		Expect(registry.started).To(BeClosed())
+		status, statusErr := f.pipeline.GetFileStatus(queued[0].ID)
+		Expect(statusErr).NotTo(HaveOccurred())
+		Expect(status.Status).To(Equal("failed"))
 	})
 })
 


### PR DESCRIPTION
Closes #2602

## Purpose

Make vector-store ingestion shutdown generation-safe. A timed-out `Stop(ctx)` previously marked the pipeline as stopped even while a worker was still blocked, so a later `Stop` could falsely return success and a restart could reuse lifecycle resources. This change isolates queues, contexts, stop signals, and wait groups per generation, bounds metadata cleanup, preserves cancellation classification, and prevents runtime dependencies from being closed while workers may still be alive.

The implementation preserves the current context-aware embedding API and adapts the lifecycle design documented in closed PR #2517 without copying its outdated implementation.

## Test Plan

- Updated lifecycle tests verify that a second bounded stop still returns `context.DeadlineExceeded` while the original worker is blocked.
- Added restart coverage proving `Start` waits for the old generation and new jobs run on fresh resources.
- Preserved queued-shutdown and context-aware embedder cancellation coverage.
- `git diff --check` passes.
- `go test ./pkg/config` passes.
- Vector-store/runtime Go test compilation reached native linking, but execution requires the repository's built Candle/ML/NLP Rust libraries (`make build-router`); those libraries are not available in this checkout.

## Test Result

- Passed: `go test ./pkg/config`
- Passed: `git diff --check`
- Not run to completion: `go test -race ./pkg/vectorstore ./pkg/routerruntime` (native libraries unavailable; linker reported missing `-lcandle_semantic_router` and related artifacts).

## Checklist

- [x] PR title uses one category prefix: `[Bug]`
- [x] Commit is DCO signed with `git commit -s`
- [x] Changes are limited to vector-store lifecycle, runtime shutdown, configuration defaults, dashboard exposure, and regression tests
