### PR TITLE
[Bug] Treat omitted tool_choice as auto when tools are present

### DIFF
--- a/e2e/testcases/tool_selection_e2e.go
+++ b/e2e/testcases/tool_selection_e2e.go
@@ -31,6 +31,7 @@ type toolSelectionE2ECase struct {
 	ExpectToolsStrategy     string
 	ExpectConfidenceGT      float64
 	ExpectInjectedSysPrompt *bool
+	OmitToolChoice          bool
 }
 
 func defaultContractTools(minObjectParams json.RawMessage) []fixtures.ChatTool {
@@ -48,6 +49,15 @@ func toolSelectionContractCases(minObjectParams json.RawMessage) []toolSelection
 			Name:                "add_mode_weather_query",
 			Prompt:              "__TOOL_SELECTION_ADD_WEATHER__ What is the weather forecast for Boston tomorrow?",
 			Tools:               contractTools,
+			ExpectDecision:      "tool_selection_add_weather_decision",
+			ExpectToolsStrategy: "default",
+			ExpectConfidenceGT:  0.01,
+		},
+		{
+			Name:                "add_mode_omitted_tool_choice_matches_auto",
+			Prompt:              "__TOOL_SELECTION_ADD_WEATHER__ What is the weather forecast for Boston tomorrow?",
+			Tools:               contractTools,
+			OmitToolChoice:      true,
 			ExpectDecision:      "tool_selection_add_weather_decision",
 			ExpectToolsStrategy: "default",
 			ExpectConfidenceGT:  0.01,
@@ -209,7 +219,7 @@ func buildToolSelectionChatRequest(tc toolSelectionE2ECase) fixtures.ChatComplet
 		},
 		Tools: tc.Tools,
 	}
-	if len(tc.Tools) > 0 {
+	if len(tc.Tools) > 0 && !tc.OmitToolChoice {
 		req.ToolChoice = json.RawMessage(`"auto"`)
 	}
 	return req

--- a/src/semantic-router/pkg/anthropic/inbound_test.go
+++ b/src/semantic-router/pkg/anthropic/inbound_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/ir"
 )
@@ -366,6 +367,20 @@ func TestParseAnthropicRequest_ToolsWithStrict(t *testing.T) {
 	}
 	if ext.ToolStrict["calc"] {
 		t.Fatalf("expected strict=false (or absent) for calc, got %+v", ext.ToolStrict)
+	}
+}
+
+func TestParseAnthropicRequest_OmittedToolChoiceWithTools(t *testing.T) {
+	body := []byte(`{"model":"claude","messages":[{"role":"user","content":"x"}],"tools":[{"name":"search","input_schema":{"type":"object"}}]}`)
+	params, _, err := ParseAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(params.Tools))
+	}
+	if !param.IsOmitted(params.ToolChoice.OfAuto) || params.ToolChoice.OfChatCompletionNamedToolChoice != nil {
+		t.Fatalf("omitted tool_choice should stay omitted in IR, got %+v", params.ToolChoice)
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -94,7 +94,9 @@ func (r *OpenAIRouter) handleEarlyToolModes(
 
 	case config.ToolsPluginModeFiltered:
 		openAIRequest.Tools = filterToolsByDecisionPolicy(openAIRequest.Tools, toolsCfg.AllowTools, toolsCfg.BlockTools)
-		if openAIRequest.ToolChoice.OfAuto.Value != "auto" {
+		// Omitted tool_choice equals auto when tools remain (OpenAI/Anthropic default).
+		if openAIRequest.ToolChoice.OfAuto.Value != "auto" &&
+			(hasToolChoice(openAIRequest) || len(openAIRequest.Tools) == 0) {
 			logging.Infof("[ToolsPlugin] Decision %q filtered explicit tools to %d entries", ctx.VSRSelectedDecision.Name, len(openAIRequest.Tools))
 			if err := r.updateRequestWithTools(openAIRequest, response, ctx); err != nil {
 				return false, err
@@ -104,7 +106,12 @@ func (r *OpenAIRouter) handleEarlyToolModes(
 		return true, nil
 
 	case config.ToolsPluginModePassthrough:
-		return openAIRequest.ToolChoice.OfAuto.Value == "auto", nil
+		if openAIRequest.ToolChoice.OfAuto.Value == "auto" ||
+			(!hasToolChoice(openAIRequest) && len(openAIRequest.Tools) > 0) {
+			return true, nil
+		}
+		logging.Infof("[ToolsPlugin] Skipping semantic tool selection: tool_choice is not automatic")
+		return false, nil
 
 	default:
 		return false, fmt.Errorf("tools plugin: unsupported mode %q", toolsCfg.Mode)
@@ -189,6 +196,7 @@ func (r *OpenAIRouter) handleToolSelection(
 	}
 
 	if !toolsCfg.SelectionEnabled() {
+		logging.Infof("[ToolsPlugin] Skipping semantic tool selection: semantic selection disabled")
 		return r.updateRequestWithTools(openAIRequest, response, ctx)
 	}
 

--- a/src/semantic-router/pkg/extproc/req_filter_tools_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_test.go
@@ -608,6 +608,56 @@ var _ = Describe("Tool Selection Request Filter", func() {
 			// Should not modify tools when tool_choice is not auto
 		})
 
+		It("treats omitted tool_choice as auto when tools are present", func() {
+			requestJSON := []byte(`{
+				"model": "test-model",
+				"messages": [{"role": "user", "content": "What's the weather?"}],
+				"tools": [{"type": "function", "function": {"name": "noise_tool"}}]
+			}`)
+			openAIRequest, err := parseOpenAIRequest(requestJSON)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = router.handleToolSelection(openAIRequest, "weather", []string{}, &response, ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(openAIRequest.Tools).NotTo(BeEmpty())
+			names := make([]string, len(openAIRequest.Tools))
+			for i, tool := range openAIRequest.Tools {
+				names[i] = tool.Function.Name
+			}
+			Expect(names).To(ContainElement("get_weather"))
+		})
+
+		It("does not treat omitted tool_choice as auto when no tools are present", func() {
+			requestJSON := []byte(`{
+				"model": "test-model",
+				"messages": [{"role": "user", "content": "What's the weather?"}]
+			}`)
+			openAIRequest, err := parseOpenAIRequest(requestJSON)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = router.handleToolSelection(openAIRequest, "weather", []string{}, &response, ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(openAIRequest.Tools).To(BeEmpty())
+		})
+
+		It("does not select tools for explicit none or required", func() {
+			for _, choice := range []string{"none", "required"} {
+				requestJSON := []byte(`{
+					"model": "test-model",
+					"messages": [{"role": "user", "content": "What's the weather?"}],
+					"tool_choice": "` + choice + `",
+					"tools": [{"type": "function", "function": {"name": "noise_tool"}}]
+				}`)
+				openAIRequest, err := parseOpenAIRequest(requestJSON)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = router.handleToolSelection(openAIRequest, "weather", []string{}, &response, ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(openAIRequest.Tools).To(HaveLen(1))
+				Expect(openAIRequest.Tools[0].Function.Name).To(Equal("noise_tool"))
+			}
+		})
+
 		It("should skip processing when content is empty", func() {
 			requestJSON := []byte(`{
 				"model": "test-model",

--- a/src/semantic-router/pkg/extproc/tools_plugin_test.go
+++ b/src/semantic-router/pkg/extproc/tools_plugin_test.go
@@ -3,10 +3,13 @@ package extproc
 import (
 	"testing"
 
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/anthropic"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
@@ -154,4 +157,131 @@ func TestClearToolChoiceWhenNoTools_KeepsChoiceWhenToolsPresent(t *testing.T) {
 
 	assert.False(t, changed)
 	assert.False(t, param.IsOmitted(req.ToolChoice.OfAuto))
+}
+
+func TestHandleEarlyToolModes_ToolChoiceGate(t *testing.T) {
+	weatherTool := `{"type":"function","function":{"name":"lookup_weather"}}`
+	router := &OpenAIRouter{Config: &config.RouterConfig{}}
+	ctx := &RequestContext{VSRSelectedDecision: &config.Decision{Name: "test"}}
+	passthrough := &config.ToolsPluginConfig{Enabled: true, Mode: config.ToolsPluginModePassthrough}
+	filtered := &config.ToolsPluginConfig{
+		Enabled:    true,
+		Mode:       config.ToolsPluginModeFiltered,
+		AllowTools: []string{"lookup_weather"},
+	}
+	filteredBlockAll := &config.ToolsPluginConfig{
+		Enabled:    true,
+		Mode:       config.ToolsPluginModeFiltered,
+		BlockTools: []string{"lookup_weather"},
+	}
+
+	tests := []struct {
+		name           string
+		body           string
+		cfg            *config.ToolsPluginConfig
+		wantContinue   bool
+		parseAnthropic bool
+	}{
+		{
+			name:         "omitted with tools is auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tools":[` + weatherTool + `]}`,
+			cfg:          passthrough,
+			wantContinue: true,
+		},
+		{
+			name:         "explicit auto with tools is auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"auto","tools":[` + weatherTool + `]}`,
+			cfg:          passthrough,
+			wantContinue: true,
+		},
+		{
+			name:         "omitted without tools is not auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}]}`,
+			cfg:          passthrough,
+			wantContinue: false,
+		},
+		{
+			name:         "none is not auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"none","tools":[` + weatherTool + `]}`,
+			cfg:          passthrough,
+			wantContinue: false,
+		},
+		{
+			name:         "required is not auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"required","tools":[` + weatherTool + `]}`,
+			cfg:          passthrough,
+			wantContinue: false,
+		},
+		{
+			name:         "named tool is not auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"function","function":{"name":"lookup_weather"}},"tools":[` + weatherTool + `]}`,
+			cfg:          passthrough,
+			wantContinue: false,
+		},
+		{
+			name:         "filtered omitted with remaining tools is auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tools":[` + weatherTool + `]}`,
+			cfg:          filtered,
+			wantContinue: true,
+		},
+		{
+			name:         "filtered omitted with no remaining tools is not auto",
+			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tools":[` + weatherTool + `]}`,
+			cfg:          filteredBlockAll,
+			wantContinue: false,
+		},
+		{
+			name:           "anthropic omitted with tools is auto",
+			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tools":[{"name":"lookup_weather","description":"weather","input_schema":{"type":"object"}}]}`,
+			cfg:            passthrough,
+			wantContinue:   true,
+			parseAnthropic: true,
+		},
+		{
+			name:           "anthropic explicit auto with tools is auto",
+			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"auto"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
+			cfg:            passthrough,
+			wantContinue:   true,
+			parseAnthropic: true,
+		},
+		{
+			name:           "anthropic none is not auto",
+			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"none"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
+			cfg:            passthrough,
+			wantContinue:   false,
+			parseAnthropic: true,
+		},
+		{
+			name:           "anthropic any/required is not auto",
+			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"any"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
+			cfg:            passthrough,
+			wantContinue:   false,
+			parseAnthropic: true,
+		},
+		{
+			name:           "anthropic named tool is not auto",
+			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"tool","name":"lookup_weather"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
+			cfg:            passthrough,
+			wantContinue:   false,
+			parseAnthropic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req *openai.ChatCompletionNewParams
+			var err error
+			if tt.parseAnthropic {
+				req, _, err = anthropic.ParseAnthropicRequest([]byte(tt.body))
+			} else {
+				req, err = parseOpenAIRequest([]byte(tt.body))
+			}
+			require.NoError(t, err)
+
+			var resp *ext_proc.ProcessingResponse
+			got, err := router.handleEarlyToolModes(req, &resp, ctx, tt.cfg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantContinue, got)
+		})
+	}
 }

--- a/src/semantic-router/pkg/extproc/tools_plugin_test.go
+++ b/src/semantic-router/pkg/extproc/tools_plugin_test.go
@@ -159,115 +159,19 @@ func TestClearToolChoiceWhenNoTools_KeepsChoiceWhenToolsPresent(t *testing.T) {
 	assert.False(t, param.IsOmitted(req.ToolChoice.OfAuto))
 }
 
-func TestHandleEarlyToolModes_ToolChoiceGate(t *testing.T) {
-	weatherTool := `{"type":"function","function":{"name":"lookup_weather"}}`
+type toolChoiceGateCase struct {
+	name           string
+	body           string
+	cfg            *config.ToolsPluginConfig
+	wantContinue   bool
+	parseAnthropic bool
+}
+
+func runToolChoiceGateCases(t *testing.T, cases []toolChoiceGateCase) {
+	t.Helper()
 	router := &OpenAIRouter{Config: &config.RouterConfig{}}
 	ctx := &RequestContext{VSRSelectedDecision: &config.Decision{Name: "test"}}
-	passthrough := &config.ToolsPluginConfig{Enabled: true, Mode: config.ToolsPluginModePassthrough}
-	filtered := &config.ToolsPluginConfig{
-		Enabled:    true,
-		Mode:       config.ToolsPluginModeFiltered,
-		AllowTools: []string{"lookup_weather"},
-	}
-	filteredBlockAll := &config.ToolsPluginConfig{
-		Enabled:    true,
-		Mode:       config.ToolsPluginModeFiltered,
-		BlockTools: []string{"lookup_weather"},
-	}
-
-	tests := []struct {
-		name           string
-		body           string
-		cfg            *config.ToolsPluginConfig
-		wantContinue   bool
-		parseAnthropic bool
-	}{
-		{
-			name:         "omitted with tools is auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tools":[` + weatherTool + `]}`,
-			cfg:          passthrough,
-			wantContinue: true,
-		},
-		{
-			name:         "explicit auto with tools is auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"auto","tools":[` + weatherTool + `]}`,
-			cfg:          passthrough,
-			wantContinue: true,
-		},
-		{
-			name:         "omitted without tools is not auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}]}`,
-			cfg:          passthrough,
-			wantContinue: false,
-		},
-		{
-			name:         "none is not auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"none","tools":[` + weatherTool + `]}`,
-			cfg:          passthrough,
-			wantContinue: false,
-		},
-		{
-			name:         "required is not auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"required","tools":[` + weatherTool + `]}`,
-			cfg:          passthrough,
-			wantContinue: false,
-		},
-		{
-			name:         "named tool is not auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"function","function":{"name":"lookup_weather"}},"tools":[` + weatherTool + `]}`,
-			cfg:          passthrough,
-			wantContinue: false,
-		},
-		{
-			name:         "filtered omitted with remaining tools is auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tools":[` + weatherTool + `]}`,
-			cfg:          filtered,
-			wantContinue: true,
-		},
-		{
-			name:         "filtered omitted with no remaining tools is not auto",
-			body:         `{"model":"m","messages":[{"role":"user","content":"weather"}],"tools":[` + weatherTool + `]}`,
-			cfg:          filteredBlockAll,
-			wantContinue: false,
-		},
-		{
-			name:           "anthropic omitted with tools is auto",
-			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tools":[{"name":"lookup_weather","description":"weather","input_schema":{"type":"object"}}]}`,
-			cfg:            passthrough,
-			wantContinue:   true,
-			parseAnthropic: true,
-		},
-		{
-			name:           "anthropic explicit auto with tools is auto",
-			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"auto"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
-			cfg:            passthrough,
-			wantContinue:   true,
-			parseAnthropic: true,
-		},
-		{
-			name:           "anthropic none is not auto",
-			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"none"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
-			cfg:            passthrough,
-			wantContinue:   false,
-			parseAnthropic: true,
-		},
-		{
-			name:           "anthropic any/required is not auto",
-			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"any"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
-			cfg:            passthrough,
-			wantContinue:   false,
-			parseAnthropic: true,
-		},
-		{
-			name:           "anthropic named tool is not auto",
-			body:           `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"tool","name":"lookup_weather"},"tools":[{"name":"lookup_weather","input_schema":{"type":"object"}}]}`,
-			cfg:            passthrough,
-			wantContinue:   false,
-			parseAnthropic: true,
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			var req *openai.ChatCompletionNewParams
 			var err error
@@ -284,4 +188,45 @@ func TestHandleEarlyToolModes_ToolChoiceGate(t *testing.T) {
 			assert.Equal(t, tt.wantContinue, got)
 		})
 	}
+}
+
+func TestHandleEarlyToolModes_OpenAIToolChoiceGate(t *testing.T) {
+	weatherTool := `{"type":"function","function":{"name":"lookup_weather"}}`
+	passthrough := &config.ToolsPluginConfig{Enabled: true, Mode: config.ToolsPluginModePassthrough}
+	filtered := &config.ToolsPluginConfig{
+		Enabled:    true,
+		Mode:       config.ToolsPluginModeFiltered,
+		AllowTools: []string{"lookup_weather"},
+	}
+	filteredBlockAll := &config.ToolsPluginConfig{
+		Enabled:    true,
+		Mode:       config.ToolsPluginModeFiltered,
+		BlockTools: []string{"lookup_weather"},
+	}
+	bodyWithTool := `{"model":"m","messages":[{"role":"user","content":"weather"}],"tools":[` + weatherTool + `]}`
+
+	runToolChoiceGateCases(t, []toolChoiceGateCase{
+		{name: "omitted with tools is auto", body: bodyWithTool, cfg: passthrough, wantContinue: true},
+		{name: "explicit auto with tools is auto", body: `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"auto","tools":[` + weatherTool + `]}`, cfg: passthrough, wantContinue: true},
+		{name: "omitted without tools is not auto", body: `{"model":"m","messages":[{"role":"user","content":"weather"}]}`, cfg: passthrough, wantContinue: false},
+		{name: "none is not auto", body: `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"none","tools":[` + weatherTool + `]}`, cfg: passthrough, wantContinue: false},
+		{name: "required is not auto", body: `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":"required","tools":[` + weatherTool + `]}`, cfg: passthrough, wantContinue: false},
+		{name: "named tool is not auto", body: `{"model":"m","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"function","function":{"name":"lookup_weather"}},"tools":[` + weatherTool + `]}`, cfg: passthrough, wantContinue: false},
+		{name: "filtered omitted with remaining tools is auto", body: bodyWithTool, cfg: filtered, wantContinue: true},
+		{name: "filtered omitted with no remaining tools is not auto", body: bodyWithTool, cfg: filteredBlockAll, wantContinue: false},
+	})
+}
+
+func TestHandleEarlyToolModes_AnthropicToolChoiceGate(t *testing.T) {
+	passthrough := &config.ToolsPluginConfig{Enabled: true, Mode: config.ToolsPluginModePassthrough}
+	tool := `{"name":"lookup_weather","description":"weather","input_schema":{"type":"object"}}`
+	withTools := `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tools":[` + tool + `]}`
+
+	runToolChoiceGateCases(t, []toolChoiceGateCase{
+		{name: "omitted with tools is auto", body: withTools, cfg: passthrough, wantContinue: true, parseAnthropic: true},
+		{name: "explicit auto with tools is auto", body: `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"auto"},"tools":[` + tool + `]}`, cfg: passthrough, wantContinue: true, parseAnthropic: true},
+		{name: "none is not auto", body: `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"none"},"tools":[` + tool + `]}`, cfg: passthrough, wantContinue: false, parseAnthropic: true},
+		{name: "any/required is not auto", body: `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"any"},"tools":[` + tool + `]}`, cfg: passthrough, wantContinue: false, parseAnthropic: true},
+		{name: "named tool is not auto", body: `{"model":"claude","messages":[{"role":"user","content":"weather"}],"tool_choice":{"type":"tool","name":"lookup_weather"},"tools":[` + tool + `]}`, cfg: passthrough, wantContinue: false, parseAnthropic: true},
+	})
 }


### PR DESCRIPTION
Close #3052
Related #2992

## Purpose

When semantic tool selection is enabled, the router currently runs selection only if `tool_choice` is the literal string `"auto"`. Many OpenAI-compatible clients (and Anthropic clients) omit `tool_choice` entirely when they pass a non-empty `tools` list. Per the OpenAI Chat Completions contract, that omission **is** automatic selection: `auto` is the default when tools are present, and `none` is the default when they are not. Anthropic has the same default when tools are provided.

The result is a silent behavior change: an explicit `tool_choice: "auto"` request is semantically filtered, but the equivalent omitted request bypasses selection and forwards the full tool list upstream. This PR closes that gap without rewriting the wire body.

**Workgroup:** Data Plane & Networking (`wg/data-plane-networking`)
**Affected modules:** `pkg/extproc` tool-selection gate, Anthropic inbound IR (tests only), tool-selection E2E contract

### Root cause

`handleEarlyToolModes` gated on:

```go
openAIRequest.ToolChoice.OfAuto.Value == "auto"
```

When `tool_choice` is omitted, the OpenAI Go SDK leaves `OfAuto` omitted and `Value` is `""`, so the check fails and selection is skipped. Passthrough mode returned `false` with no log.

### Fix (small, reuse existing helpers)

No new helper and no request-body rewrite. The existing `hasToolChoice` check (already used by `clearToolChoiceWhenNoTools`) is combined with the current `"auto"` comparison:

- Explicit `"auto"` → run selection (unchanged)
- Omitted `tool_choice` **and** `len(tools) > 0` → treat as auto and run selection
- Explicit `"none"`, `"required"`, or named-tool → skip selection (unchanged)
- Omitted `tool_choice` **and** no remaining tools → skip selection (OpenAI default is `none`; do not inject tools)

The same rule is applied after allow/block filtering in `filtered` mode, so an omitted request whose tools are all stripped does not accidentally proceed to semantic selection.

Anthropic inbound translation is intentionally left unchanged: omitted Anthropic `tool_choice` stays omitted on the IR. The IR-level gate then treats omitted + tools as auto, so OpenAI-compatible, Anthropic, and Response API (`ToolChoice == nil`) paths share one rule.

### Observability

Previously, passthrough skipped selection silently. It now logs:

- `Skipping semantic tool selection: tool_choice is not automatic` when the gate declines
- `Skipping semantic tool selection: semantic selection disabled` when the plugin is on but `SelectionEnabled()` is false

No new response headers were added; skip diagnostics follow the existing `logging.Infof` pattern used by the tools plugin.

### Behavior matrix

| Request | Semantic selection |
| --- | --- |
| `tool_choice: "auto"` + tools | runs |
| omitted `tool_choice` + tools | runs (this was the bug) |
| omitted `tool_choice`, no tools | skipped (default `none`) |
| `tool_choice: "none"` / `"required"` | skipped |
| named tool (`{"type":"function",...}`) | skipped |
| Anthropic omitted + tools | runs (IR omitted, gate treats as auto) |
| Anthropic `type: auto` / `none` / `any` / `tool` | same as OpenAI auto / none / required / named |
| `filtered` mode, omitted, tools remain after allow/block | runs |
| `filtered` mode, omitted, no tools remain | skipped |

The upstream JSON is not rewritten to insert `"auto"`. Backends that already treat omitted + tools as auto keep that wire shape.

## Test Plan

- [x] Unit: `TestHandleEarlyToolModes_ToolChoiceGate` covers OpenAI omitted / auto / none / required / named, filtered remaining vs stripped tools, and the matching Anthropic translation cases
- [x] Unit: `TestParseAnthropicRequest_OmittedToolChoiceWithTools` asserts inbound IR keeps omitted `tool_choice` (no silent rewrite)
- [x] Integration: Ginkgo cases in `req_filter_tools_test.go` for omitted+tools (selection replaces noise tools), omitted without tools, and explicit none/required
- [x] E2E: `add_mode_omitted_tool_choice_matches_auto` sends tools without `tool_choice` and expects the same decision/strategy as explicit auto; existing explicit-auto case is unchanged
- [ ] `go test ./pkg/extproc/ -run TestHandleEarlyToolModes_ToolChoiceGate` (needs local candle/ml/nlp bindings)
- [ ] `go test ./pkg/anthropic/ -run TestParseAnthropicRequest_OmittedToolChoiceWithTools`
- [ ] CI gates on this PR

## Test Result

- `go test ./pkg/anthropic/ -run 'TestParseAnthropicRequest_OmittedToolChoiceWithTools|TestParseAnthropicRequest_ToolChoice'` → **pass**
- `go test ./e2e/testcases/ -count=0` → **pass** (compile)
- `go test ./pkg/extproc/ -run TestHandleEarlyToolModes_ToolChoiceGate` → **not run locally**; linker failed because `candle-binding` / `nlp-binding` / `ml-binding` release libs are not present on this machine (`ld: library 'candle_semantic_router' not found`). Coverage is in CI.

Remaining risk: E2E `tool-selection` is Kubernetes-profile only and was not executed locally. The new case mirrors the existing weather add-mode contract with `OmitToolChoice: true`.

## Semantic Router PR Checklist

- [x] PR title begins with exactly one bracketed category (`[Bug]`)
- [x] The title does not stack prefixes
- [ ] Linked issue is accepted with exactly one owner — **#3052 is still `needs-acceptance`**; owner workgroup is Data Plane & Networking
- [x] Commits are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result match this change
