### PR TITLE
[CI/Build] Require two approvals for merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -54,6 +54,6 @@ pull_request_rules:
   - name: queue approved pull requests
     conditions:
       - base = main
-      - "#approved-reviews-by >= 1"
+      - "#approved-reviews-by >= 2"
     actions:
       queue:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,10 @@ of truth for schemas, test selection, or public documentation.
 6. Open a PR using the module prefixes and sections in
    [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
 
+Mergify places a pull request in the merge queue only after at least two
+reviewers with `write`, `maintain`, or `admin` repository permission approve
+it and all required checks pass.
+
 Keep commits reviewable and avoid unrelated cleanup. A PR should explain why
 the change is needed, which modules it affects, and how its user-visible
 behavior was verified.

--- a/tools/ci/workflow_policy_validation.py
+++ b/tools/ci/workflow_policy_validation.py
@@ -24,6 +24,7 @@ REQUIRED_COMPATIBILITY_CHECKS = {
     "Verify Manifests",
     "Validate OLM Bundle",
 }
+REQUIRED_APPROVAL_CONDITION = "#approved-reviews-by >= 2"
 RELEASE_IMAGES = set(PRODUCTION_RELEASE_IMAGES)
 
 
@@ -387,6 +388,22 @@ def validate_mergify_contract(errors: list[str]) -> None:
             errors.append(
                 f".mergify.yml: {section} is missing contexts: " + ", ".join(missing)
             )
+    pull_request_rules = data.get("pull_request_rules", [])
+    queue_rules = [
+        rule
+        for rule in pull_request_rules
+        if isinstance(rule, dict)
+        and isinstance(rule.get("actions"), dict)
+        and "queue" in rule["actions"]
+    ]
+    if not any(
+        REQUIRED_APPROVAL_CONDITION in rule.get("conditions", [])
+        for rule in queue_rules
+    ):
+        errors.append(
+            ".mergify.yml: pull request queue must require at least two "
+            "approving reviews"
+        )
 
 
 def validate_workflow_policies(


### PR DESCRIPTION
Closes #3060

## Purpose

Require two eligible maintainer approvals before Mergify queues a pull request targeting `main`.

- Raise the Mergify approval threshold from one to two.
- Add a workflow-policy contract check for the two-approval condition.
- Document the requirement in the contributor workflow.

This is an `owner/maintainers` repository-governance change. It does not alter CODEOWNERS, GitHub rulesets, CI contexts, or the merge method.

## Test Plan

- `make agent-validate`
- `make agent-ci-gate CHANGED_FILES=".mergify.yml,CONTRIBUTING.md,tools/ci/workflow_policy_validation.py"`

## Test Result

- `make agent-validate`: passed.
- Changed-file `make agent-ci-gate`: passed with the bundled Node runtime; Markdown/YAML/Python lint, AST scan, workflow contract validation, and harness tests succeeded.
- Local smoke and E2E were not required by `make agent-report` for this governance-only change.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title uses a single category prefix
- [x] The PR links accepted issue #3060 with `owner/maintainers`
- [x] The commit is signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect the actual scope and validation

</details>
