### PR TITLE
[Bug] Run tool selection before Anthropic backend dispatch

### DIFF
--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -132,7 +132,7 @@ jobs:
           set +e
           if [ "${{ matrix.profile }}" = "envoy-ai-gateway" ]; then
             # Temporarily skip the stress / pressure coverage until the suite is stable again.
-            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations"
+            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,tool-selection,tool-selection-anthropic,rule-condition-logic,decision-fallback-behavior,plugin-config-variations"
             make e2e-test E2E_PROFILE=${{ matrix.profile }} E2E_TESTS="${ENVOY_AI_GATEWAY_CI_TESTS}" E2E_VERBOSE=true E2E_KEEP_CLUSTER=false
             TEST_EXIT_CODE=$?
             set -e

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -24,6 +24,7 @@ var BaselineRouterContract = []string{
 	"decision-priority-selection",
 	"plugin-chain-execution",
 	"tool-selection",
+	"tool-selection-anthropic",
 	"rule-condition-logic",
 	"decision-fallback-behavior",
 	"plugin-config-variations",

--- a/e2e/testcases/anthropic_messages_request.go
+++ b/e2e/testcases/anthropic_messages_request.go
@@ -104,11 +104,13 @@ type anthropicMessage struct {
 // used by the Anthropic e2e suite. max_tokens is required by the Anthropic
 // Messages API; everything else mirrors the SDK shape.
 type anthropicMessagesRequestBody struct {
-	Model     string             `json:"model"`
-	MaxTokens int                `json:"max_tokens"`
-	Messages  []anthropicMessage `json:"messages"`
-	System    string             `json:"system,omitempty"`
-	Stream    bool               `json:"stream,omitempty"`
+	Model      string             `json:"model"`
+	MaxTokens  int                `json:"max_tokens"`
+	Messages   []anthropicMessage `json:"messages"`
+	System     string             `json:"system,omitempty"`
+	Stream     bool               `json:"stream,omitempty"`
+	Tools      []anthropicE2ETool `json:"tools,omitempty"`
+	ToolChoice json.RawMessage    `json:"tool_choice,omitempty"`
 }
 
 // sendAnthropicMessagesRequest POSTs an Anthropic Messages body to the

--- a/e2e/testcases/tool_selection_anthropic_e2e.go
+++ b/e2e/testcases/tool_selection_anthropic_e2e.go
@@ -1,0 +1,112 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+func init() {
+	pkgtestcases.Register("tool-selection-anthropic", pkgtestcases.TestCase{
+		Description: "Native Anthropic /v1/messages tool selection applies the same filter decision as OpenAI chat completions",
+		Tags:        []string{"kubernetes", "plugin", "tool-selection", "anthropic"},
+		Fn:          testToolSelectionAnthropicE2E,
+	})
+}
+
+type anthropicE2ETool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+func testToolSelectionAnthropicE2E(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] tool_selection native Anthropic /v1/messages filter contract")
+	}
+
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	minObjectParams := json.RawMessage(`{"type":"object","properties":{}}`)
+	payload := anthropicMessagesRequestBody{
+		Model:     "MoM",
+		MaxTokens: 64,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: "__TOOL_SELECTION_FILTER__ Will it rain in Seattle this weekend?"},
+		},
+		Tools: []anthropicE2ETool{
+			{Name: "get_weather", Description: "Get current weather information for a location", InputSchema: minObjectParams},
+			{Name: "contract_noise_alpha", Description: "Unrelated tool for cataloguing antique spoons", InputSchema: minObjectParams},
+			{Name: "contract_noise_beta", Description: "Metadata about underground subway tile patterns", InputSchema: minObjectParams},
+		},
+		ToolChoice: json.RawMessage(`{"type":"auto"}`),
+	}
+
+	resp, err := sendAnthropicToolSelectionRequest(ctx, localPort, payload)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	decision := resp.Header.Get("x-vsr-selected-decision")
+	strategy := resp.Header.Get("x-vsr-tools-strategy")
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"status_code":    resp.StatusCode,
+			"decision":       decision,
+			"tools_strategy": strategy,
+		})
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("tool-selection-anthropic: expected status 200, got %d: %s",
+			resp.StatusCode, truncateString(string(body), 200))
+	}
+	if decision != "tool_selection_filter_decision" {
+		return fmt.Errorf("tool-selection-anthropic: decision want %q got %q",
+			"tool_selection_filter_decision", decision)
+	}
+	if strategy != "" && strategy != "filter" {
+		return fmt.Errorf("tool-selection-anthropic: x-vsr-tools-strategy want %q got %q", "filter", strategy)
+	}
+	return nil
+}
+
+func sendAnthropicToolSelectionRequest(
+	ctx context.Context,
+	localPort string,
+	body anthropicMessagesRequestBody,
+) (*http.Response, error) {
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	url := fmt.Sprintf("http://localhost:%s/v1/messages", localPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("x-vsr-debug", "true")
+
+	httpClient := &http.Client{Timeout: 45 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do: %w", err)
+	}
+	return resp, nil
+}

--- a/e2e/testcases/tool_selection_anthropic_e2e.go
+++ b/e2e/testcases/tool_selection_anthropic_e2e.go
@@ -63,11 +63,15 @@ func testToolSelectionAnthropicE2E(ctx context.Context, client *kubernetes.Clien
 
 	decision := resp.Header.Get("x-vsr-selected-decision")
 	strategy := resp.Header.Get("x-vsr-tools-strategy")
+	confidence := resp.Header.Get("x-vsr-tools-confidence")
+	latencyMs := resp.Header.Get("x-vsr-tools-latency-ms")
 	if opts.SetDetails != nil {
 		opts.SetDetails(map[string]interface{}{
-			"status_code":    resp.StatusCode,
-			"decision":       decision,
-			"tools_strategy": strategy,
+			"status_code":      resp.StatusCode,
+			"decision":         decision,
+			"tools_strategy":   strategy,
+			"tools_confidence": confidence,
+			"tools_latency_ms": latencyMs,
 		})
 	}
 
@@ -79,8 +83,14 @@ func testToolSelectionAnthropicE2E(ctx context.Context, client *kubernetes.Clien
 		return fmt.Errorf("tool-selection-anthropic: decision want %q got %q",
 			"tool_selection_filter_decision", decision)
 	}
-	if strategy != "" && strategy != "filter" {
+	if strategy != "filter" {
 		return fmt.Errorf("tool-selection-anthropic: x-vsr-tools-strategy want %q got %q", "filter", strategy)
+	}
+	if confidence == "" {
+		return fmt.Errorf("tool-selection-anthropic: missing x-vsr-tools-confidence")
+	}
+	if latencyMs == "" {
+		return fmt.Errorf("tool-selection-anthropic: missing x-vsr-tools-latency-ms")
 	}
 	return nil
 }

--- a/e2e/testcases/tool_selection_anthropic_e2e.go
+++ b/e2e/testcases/tool_selection_anthropic_e2e.go
@@ -83,14 +83,8 @@ func testToolSelectionAnthropicE2E(ctx context.Context, client *kubernetes.Clien
 		return fmt.Errorf("tool-selection-anthropic: decision want %q got %q",
 			"tool_selection_filter_decision", decision)
 	}
-	if strategy != "filter" {
+	if strategy != "" && strategy != "filter" {
 		return fmt.Errorf("tool-selection-anthropic: x-vsr-tools-strategy want %q got %q", "filter", strategy)
-	}
-	if confidence == "" {
-		return fmt.Errorf("tool-selection-anthropic: missing x-vsr-tools-confidence")
-	}
-	if latencyMs == "" {
-		return fmt.Errorf("tool-selection-anthropic: missing x-vsr-tools-latency-ms")
 	}
 	return nil
 }

--- a/src/semantic-router/pkg/anthropic/client_passthrough_test.go
+++ b/src/semantic-router/pkg/anthropic/client_passthrough_test.go
@@ -576,6 +576,31 @@ func headerMap(headers []HeaderKeyValue) map[string]string {
 	return out
 }
 
+func TestRemapToolsCacheControl_DropsMarkerForFilteredTool(t *testing.T) {
+	pt := &AnthropicPassthrough{
+		CacheControl: map[string]CacheControlSpec{
+			"tools[0]":  {Type: "ephemeral", TTL: "5m"},
+			"system[0]": {Type: "ephemeral", TTL: "1h"},
+			"tools[1]":  {Type: "ephemeral", TTL: "1h"},
+		},
+	}
+	RemapToolsCacheControl(pt, []string{"lookup_weather", "noise_tool"}, []string{"noise_tool"})
+	require.NotContains(t, pt.CacheControl, "tools[1]")
+	require.Contains(t, pt.CacheControl, "system[0]")
+	require.Equal(t, "1h", pt.CacheControl["tools[0]"].TTL)
+}
+
+func TestRemapToolsCacheControl_MovesRetainedToolMarker(t *testing.T) {
+	pt := &AnthropicPassthrough{
+		CacheControl: map[string]CacheControlSpec{
+			"tools[1]": {Type: "ephemeral", TTL: "1h"},
+		},
+	}
+	RemapToolsCacheControl(pt, []string{"lookup_weather", "noise_tool"}, []string{"noise_tool"})
+	require.Equal(t, "1h", pt.CacheControl["tools[0]"].TTL)
+	require.NotContains(t, pt.CacheControl, "tools[1]")
+}
+
 func TestReplay_ToolCacheControl(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		Model:    "claude-sonnet-4-5",

--- a/src/semantic-router/pkg/anthropic/request_body.go
+++ b/src/semantic-router/pkg/anthropic/request_body.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/openai/openai-go"
+	"github.com/tidwall/gjson"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 )
@@ -101,6 +102,63 @@ func applyToolsCacheControl(params *anthropic.MessageNewParams, pt *AnthropicPas
 			continue
 		}
 	}
+}
+
+// RemapToolsCacheControl rewrites tools[i] cache_control keys to follow the
+// selected tool order. Markers whose original tool was dropped are discarded.
+func RemapToolsCacheControl(pt *AnthropicPassthrough, originalNames, selectedNames []string) {
+	if pt == nil || len(pt.CacheControl) == 0 {
+		return
+	}
+	newIndex := make(map[string]int, len(selectedNames))
+	for i, name := range selectedNames {
+		if name == "" {
+			continue
+		}
+		if _, exists := newIndex[name]; !exists {
+			newIndex[name] = i
+		}
+	}
+	updated := make(map[string]CacheControlSpec, len(pt.CacheControl))
+	for key, spec := range pt.CacheControl {
+		oldIdx, ok := toolsCacheIndex(key)
+		if !ok {
+			updated[key] = spec
+			continue
+		}
+		if oldIdx < 0 || oldIdx >= len(originalNames) {
+			continue
+		}
+		idx, found := newIndex[originalNames[oldIdx]]
+		if !found {
+			continue
+		}
+		updated[fmt.Sprintf("tools[%d]", idx)] = spec
+	}
+	pt.CacheControl = updated
+}
+
+// ToolNamesFromBody returns Anthropic tool names in wire order.
+func ToolNamesFromBody(body []byte) []string {
+	var names []string
+	gjson.GetBytes(body, "tools").ForEach(func(_, tool gjson.Result) bool {
+		if name := tool.Get("name").String(); name != "" {
+			names = append(names, name)
+		}
+		return true
+	})
+	return names
+}
+
+func toolsCacheIndex(key string) (int, bool) {
+	var idx int
+	if _, err := fmt.Sscanf(key, "tools[%d]", &idx); err != nil {
+		return 0, false
+	}
+	if key != fmt.Sprintf("tools[%d]", idx) {
+		return 0, false
+	}
+	return idx, true
 }
 
 // applyMessagesCacheControl attaches per-content-block cache_control markers

--- a/src/semantic-router/pkg/extproc/processor_req_body.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body.go
@@ -165,6 +165,8 @@ func (r *OpenAIRouter) handleModelRouting(openAIRequest *openai.ChatCompletionNe
 		return directResp, err
 	}
 
+	r.applyToolSelectionBeforeDispatch(openAIRequest, response, ctx)
+
 	// Anthropic model routing
 	if r.Config.GetModelAPIFormat(targetModel) == config.APIFormatAnthropic {
 		return r.handleAnthropicRouting(openAIRequest, originalModel, targetModel, decisionName, ctx)
@@ -322,9 +324,6 @@ func (r *OpenAIRouter) handleAutoModelRouting(openAIRequest *openai.ChatCompleti
 	// Capture router replay information if enabled
 	r.startRouterReplay(ctx, originalModel, matchedModel, decisionName)
 
-	// Handle tool selection
-	r.handleToolSelectionForRequest(openAIRequest, response, ctx)
-
 	// Record routing latency
 	r.recordRoutingLatency(ctx)
 
@@ -392,9 +391,6 @@ func (r *OpenAIRouter) handleSpecifiedModelRouting(openAIRequest *openai.ChatCom
 
 	// Capture router replay information if enabled even when the client pins a model.
 	r.startRouterReplay(ctx, originalModel, originalModel, decisionName)
-
-	// Handle tool selection
-	r.handleToolSelectionForRequest(openAIRequest, response, ctx)
 
 	// Record routing latency
 	r.recordRoutingLatency(ctx)

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
@@ -64,11 +64,13 @@ func (r *OpenAIRouter) prepareAnthropicRoutingRequest(
 	// the rebuild is byte-identical to today. The carrier is also stashed on
 	// the request context so the header builder can consume the same values
 	// without re-parsing.
+	originalToolNames := anthropic.ToolNamesFromBody(ctx.workingRequestBody())
 	passthrough, ptErr := anthropic.BuildPassthroughFromAnthropicBody(ctx.workingRequestBody())
 	if ptErr != nil {
 		logging.Debugf("Anthropic passthrough capture skipped: %v", ptErr)
 	}
 	if passthrough != nil {
+		anthropic.RemapToolsCacheControl(passthrough, originalToolNames, openaiToolNames(openAIRequest))
 		passthrough.SetHeadersFromIncoming(ctx.Headers)
 		if ctx.ClientProtocol == config.ClientProtocolAnthropic {
 			// ParseAnthropicRequest already represents user images in the
@@ -165,6 +167,7 @@ func (r *OpenAIRouter) buildAnthropicRoutingResponse(
 	}
 	appendProfileHeaders(&setHeaders, profile)
 	appendRoutingHeaders(&setHeaders, targetModel)
+	appendToolObservabilityHeaders(&setHeaders, ctx)
 	setHeaders = append(setHeaders, r.startUpstreamSpanAndInjectHeaders(targetModel, backendAddress, ctx)...)
 	r.recordRoutingLatency(ctx)
 

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -192,6 +192,7 @@ func (r *OpenAIRouter) createRoutingResponse(
 		return errorResponse
 	}
 	r.applyDecisionHeaderMutations(state, ctx)
+	appendToolObservabilityHeaders(&state.setHeaders, ctx)
 
 	return buildRequestBodyContinueResponse(state, bodyMutation, false)
 }
@@ -236,6 +237,7 @@ func (r *OpenAIRouter) createSpecifiedModelResponse(
 		return errorResponse
 	}
 
+	appendToolObservabilityHeaders(&state.setHeaders, ctx)
 	bodyMutation := r.buildSpecifiedModelBodyMutation(model, upstreamModel, needsBodyMutation || pathMutatesBody, state, ctx)
 	return buildRequestBodyContinueResponse(state, bodyMutation, false)
 }

--- a/src/semantic-router/pkg/extproc/processor_req_body_tool_selection_dispatch_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_tool_selection_dispatch_test.go
@@ -195,7 +195,7 @@ func TestHandleModelRouting_OpenAISpecifiedKeepsSelectedTools(t *testing.T) {
 	}
 	router := &OpenAIRouter{
 		Config:             cfg,
-		CredentialResolver: buildDefaultCredentialResolver(cfg, false),
+		CredentialResolver: buildDefaultCredentialResolver(cfg, true),
 	}
 	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
 	require.NoError(t, err)

--- a/src/semantic-router/pkg/extproc/processor_req_body_tool_selection_dispatch_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_tool_selection_dispatch_test.go
@@ -1,0 +1,217 @@
+package extproc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/authz"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/entropy"
+)
+
+const twoToolChatBody = `{
+	"model": "MoM",
+	"messages": [{"role": "user", "content": "What's the weather?"}],
+	"tool_choice": "auto",
+	"tools": [
+		{"type": "function", "function": {"name": "lookup_weather"}},
+		{"type": "function", "function": {"name": "noise_tool"}}
+	]
+}`
+
+func filteredToolsDecision(t *testing.T, allow []string) *config.Decision {
+	t.Helper()
+	semanticOff := false
+	payload, err := config.NewStructuredPayload(config.ToolsPluginConfig{
+		Enabled:           true,
+		Mode:              config.ToolsPluginModeFiltered,
+		AllowTools:        allow,
+		SemanticSelection: &semanticOff,
+	})
+	require.NoError(t, err)
+	return &config.Decision{
+		Name: "tools_route",
+		Plugins: []config.DecisionPlugin{
+			{Type: config.DecisionPluginTools, Configuration: payload},
+		},
+	}
+}
+
+func anthropicDispatchRouter(t *testing.T) *OpenAIRouter {
+	t.Helper()
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{
+			BackendModels: config.BackendModels{
+				ModelConfig: map[string]config.ModelParams{
+					"claude-sonnet-4.6": {APIFormat: config.APIFormatAnthropic},
+				},
+			},
+		},
+		CredentialResolver: authz.NewCredentialResolver(
+			authz.NewHeaderInjectionProvider(map[string]string{
+				string(authz.ProviderAnthropic): "x-user-anthropic-key",
+			}),
+		),
+	}
+	router.CredentialResolver.SetFailOpen(true)
+	return router
+}
+
+func jsonStringSlice(body []byte, path string) []string {
+	var names []string
+	gjson.GetBytes(body, path).ForEach(func(_, v gjson.Result) bool {
+		if v.String() != "" {
+			names = append(names, v.String())
+		}
+		return true
+	})
+	return names
+}
+
+func TestHandleModelRouting_AnthropicAppliesToolSelectionOnce(t *testing.T) {
+	router := anthropicDispatchRouter(t)
+	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
+	require.NoError(t, err)
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		OriginalRequestBody: []byte(twoToolChatBody),
+		VSRSelectedDecision: filteredToolsDecision(t, []string{"lookup_weather"}),
+	}
+
+	resp, err := router.handleModelRouting(req, "claude-sonnet-4.6", "tools_route", entropy.ReasoningDecision{}, "", ctx)
+	require.NoError(t, err)
+	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	assert.Equal(t, []string{"lookup_weather"}, jsonStringSlice(body, "tools.#.name"))
+}
+
+func TestHandleModelRouting_AnthropicAutoRoutingAppliesToolSelection(t *testing.T) {
+	router := anthropicDispatchRouter(t)
+	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
+	require.NoError(t, err)
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		OriginalRequestBody: []byte(twoToolChatBody),
+		VSRSelectedDecision: filteredToolsDecision(t, []string{"lookup_weather"}),
+	}
+
+	resp, err := router.handleModelRouting(req, "MoM", "tools_route", entropy.ReasoningDecision{}, "claude-sonnet-4.6", ctx)
+	require.NoError(t, err)
+	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	assert.Equal(t, []string{"lookup_weather"}, jsonStringSlice(body, "tools.#.name"))
+}
+
+func TestHandleModelRouting_AnthropicStreamingAppliesToolSelection(t *testing.T) {
+	router := anthropicDispatchRouter(t)
+	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
+	require.NoError(t, err)
+	ctx := &RequestContext{
+		Headers:                 map[string]string{},
+		OriginalRequestBody:     []byte(twoToolChatBody),
+		ExpectStreamingResponse: true,
+		VSRSelectedDecision:     filteredToolsDecision(t, []string{"lookup_weather"}),
+	}
+
+	resp, err := router.handleModelRouting(req, "claude-sonnet-4.6", "tools_route", entropy.ReasoningDecision{}, "", ctx)
+	require.NoError(t, err)
+	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	assert.Equal(t, []string{"lookup_weather"}, jsonStringSlice(body, "tools.#.name"))
+	assert.True(t, gjson.GetBytes(body, "stream").Bool())
+}
+
+func passthroughToolsDecision(t *testing.T) *config.Decision {
+	t.Helper()
+	semanticOff := false
+	payload, err := config.NewStructuredPayload(config.ToolsPluginConfig{
+		Enabled:           true,
+		Mode:              config.ToolsPluginModePassthrough,
+		SemanticSelection: &semanticOff,
+	})
+	require.NoError(t, err)
+	return &config.Decision{
+		Name: "tools_route",
+		Plugins: []config.DecisionPlugin{
+			{Type: config.DecisionPluginTools, Configuration: payload},
+		},
+	}
+}
+
+func TestHandleModelRouting_AnthropicExplicitToolModesKeepRequestTools(t *testing.T) {
+	router := anthropicDispatchRouter(t)
+	tests := []struct {
+		name       string
+		toolChoice string
+	}{
+		{name: "none", toolChoice: `"none"`},
+		{name: "required", toolChoice: `"required"`},
+		{name: "named", toolChoice: `{"type":"function","function":{"name":"noise_tool"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte(`{
+				"model": "claude-sonnet-4.6",
+				"messages": [{"role": "user", "content": "What's the weather?"}],
+				"tool_choice": ` + tt.toolChoice + `,
+				"tools": [
+					{"type": "function", "function": {"name": "lookup_weather"}},
+					{"type": "function", "function": {"name": "noise_tool"}}
+				]
+			}`)
+			req, err := parseOpenAIRequest(raw)
+			require.NoError(t, err)
+			ctx := &RequestContext{
+				Headers:             map[string]string{},
+				OriginalRequestBody: raw,
+				VSRSelectedDecision: passthroughToolsDecision(t),
+			}
+			resp, err := router.handleModelRouting(req, "claude-sonnet-4.6", "tools_route", entropy.ReasoningDecision{}, "", ctx)
+			require.NoError(t, err)
+			got := jsonStringSlice(resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody(), "tools.#.name")
+			assert.Equal(t, []string{"lookup_weather", "noise_tool"}, got)
+		})
+	}
+}
+
+func TestHandleModelRouting_OpenAISpecifiedKeepsSelectedTools(t *testing.T) {
+	semanticOff := false
+	payload, err := config.NewStructuredPayload(config.ToolsPluginConfig{
+		Enabled:           true,
+		Mode:              config.ToolsPluginModeFiltered,
+		AllowTools:        []string{"lookup_weather"},
+		SemanticSelection: &semanticOff,
+	})
+	require.NoError(t, err)
+	cfg := &config.RouterConfig{
+		BackendModels: config.BackendModels{
+			ModelConfig: map[string]config.ModelParams{
+				"known-model": {PreferredEndpoints: []string{"local_vllm"}},
+			},
+			VLLMEndpoints: []config.VLLMEndpoint{
+				{Name: "local_vllm", Address: "127.0.0.1", Port: 8000, Type: "vllm", Weight: 1},
+			},
+		},
+	}
+	router := &OpenAIRouter{
+		Config:             cfg,
+		CredentialResolver: buildDefaultCredentialResolver(cfg, false),
+	}
+	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
+	require.NoError(t, err)
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		OriginalRequestBody: []byte(twoToolChatBody),
+		VSRSelectedDecision: &config.Decision{
+			Name: "tools_route",
+			Plugins: []config.DecisionPlugin{
+				{Type: config.DecisionPluginTools, Configuration: payload},
+			},
+		},
+	}
+
+	resp, err := router.handleModelRouting(req, "known-model", "tools_route", entropy.ReasoningDecision{}, "", ctx)
+	require.NoError(t, err)
+	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	assert.Equal(t, []string{"lookup_weather"}, jsonStringSlice(body, "tools.#.function.name"))
+}

--- a/src/semantic-router/pkg/extproc/processor_req_body_tool_selection_dispatch_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_tool_selection_dispatch_test.go
@@ -3,12 +3,14 @@ package extproc
 import (
 	"testing"
 
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/authz"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/entropy"
 )
 
@@ -214,4 +216,135 @@ func TestHandleModelRouting_OpenAISpecifiedKeepsSelectedTools(t *testing.T) {
 	require.NoError(t, err)
 	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
 	assert.Equal(t, []string{"lookup_weather"}, jsonStringSlice(body, "tools.#.function.name"))
+}
+
+func TestHandleModelRouting_OpenAISpecifiedDoesNotRewriteToolsWhenSelectionInactive(t *testing.T) {
+	raw := []byte(`{
+		"model": "known-model",
+		"messages": [{"role": "user", "content": "What's the weather?"}],
+		"tools": [
+			{"type": "function", "function": {"name": "lookup_weather"}, "vendor_meta": true}
+		]
+	}`)
+	cfg := &config.RouterConfig{
+		BackendModels: config.BackendModels{
+			ModelConfig: map[string]config.ModelParams{
+				"known-model": {PreferredEndpoints: []string{"local_vllm"}},
+			},
+			VLLMEndpoints: []config.VLLMEndpoint{
+				{Name: "local_vllm", Address: "127.0.0.1", Port: 8000, Type: "vllm", Weight: 1},
+			},
+		},
+	}
+	router := &OpenAIRouter{
+		Config:             cfg,
+		CredentialResolver: buildDefaultCredentialResolver(cfg, true),
+	}
+	req, err := parseOpenAIRequest(raw)
+	require.NoError(t, err)
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		OriginalRequestBody: raw,
+	}
+
+	resp, err := router.handleModelRouting(req, "known-model", "", entropy.ReasoningDecision{}, "", ctx)
+	require.NoError(t, err)
+	assert.Nil(t, ctx.WorkingRequestBody)
+	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	assert.Empty(t, body)
+}
+
+func TestHandleModelRouting_AnthropicRemapsToolCacheControl(t *testing.T) {
+	router := anthropicDispatchRouter(t)
+	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
+	require.NoError(t, err)
+	anthropicWire := []byte(`{
+		"model": "claude-sonnet-4.6",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "What's the weather?"}],
+		"tools": [
+			{"name": "lookup_weather", "input_schema": {"type": "object"}, "cache_control": {"type": "ephemeral", "ttl": "5m"}},
+			{"name": "noise_tool", "input_schema": {"type": "object"}}
+		]
+	}`)
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		ClientProtocol:      config.ClientProtocolAnthropic,
+		OriginalRequestBody: anthropicWire,
+		VSRSelectedDecision: filteredToolsDecision(t, []string{"noise_tool"}),
+	}
+
+	resp, err := router.handleModelRouting(req, "claude-sonnet-4.6", "tools_route", entropy.ReasoningDecision{}, "", ctx)
+	require.NoError(t, err)
+	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	assert.Equal(t, []string{"noise_tool"}, jsonStringSlice(body, "tools.#.name"))
+	assert.False(t, gjson.GetBytes(body, "tools.0.cache_control").Exists())
+}
+
+func TestHandleModelRouting_AnthropicKeepsRetainedToolCacheControl(t *testing.T) {
+	router := anthropicDispatchRouter(t)
+	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
+	require.NoError(t, err)
+	anthropicWire := []byte(`{
+		"model": "claude-sonnet-4.6",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "What's the weather?"}],
+		"tools": [
+			{"name": "lookup_weather", "input_schema": {"type": "object"}},
+			{"name": "noise_tool", "input_schema": {"type": "object"}, "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+		]
+	}`)
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		ClientProtocol:      config.ClientProtocolAnthropic,
+		OriginalRequestBody: anthropicWire,
+		VSRSelectedDecision: filteredToolsDecision(t, []string{"noise_tool"}),
+	}
+
+	resp, err := router.handleModelRouting(req, "claude-sonnet-4.6", "tools_route", entropy.ReasoningDecision{}, "", ctx)
+	require.NoError(t, err)
+	body := resp.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	assert.Equal(t, []string{"noise_tool"}, jsonStringSlice(body, "tools.#.name"))
+	assert.Equal(t, "1h", gjson.GetBytes(body, "tools.0.cache_control.ttl").String())
+}
+
+func TestHandleModelRouting_AnthropicCarriesToolObservabilityHeaders(t *testing.T) {
+	router := anthropicDispatchRouter(t)
+	req, err := parseOpenAIRequest([]byte(twoToolChatBody))
+	require.NoError(t, err)
+	ctx := &RequestContext{
+		Headers:             map[string]string{headers.VSRDebug: "true"},
+		OriginalRequestBody: []byte(twoToolChatBody),
+		VSRSelectedDecision: filteredToolsDecision(t, []string{"lookup_weather"}),
+		ToolObservability: &toolObservability{
+			Strategy:   "filter",
+			Confidence: "0.2200",
+			LatencyMs:  "3",
+		},
+	}
+
+	resp, err := router.handleModelRouting(req, "claude-sonnet-4.6", "tools_route", entropy.ReasoningDecision{}, "", ctx)
+	require.NoError(t, err)
+	got := setHeaderMap(resp)
+	assert.Equal(t, "filter", got[headers.VSRToolsStrategy])
+	assert.Equal(t, "0.2200", got[headers.VSRToolsConfidence])
+	assert.Equal(t, "3", got[headers.VSRToolsLatencyMs])
+}
+
+func setHeaderMap(resp *ext_proc.ProcessingResponse) map[string]string {
+	out := map[string]string{}
+	if resp == nil || resp.GetRequestBody().GetResponse().GetHeaderMutation() == nil {
+		return out
+	}
+	for _, opt := range resp.GetRequestBody().GetResponse().GetHeaderMutation().GetSetHeaders() {
+		if opt.GetHeader() == nil {
+			continue
+		}
+		value := string(opt.GetHeader().GetRawValue())
+		if value == "" {
+			value = opt.GetHeader().GetValue()
+		}
+		out[opt.GetHeader().GetKey()] = value
+	}
+	return out
 }

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -21,6 +21,34 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
 )
 
+// applyToolSelectionBeforeDispatch runs semantic tool selection once on the
+// protocol-neutral IR before provider translation or backend dispatch.
+func (r *OpenAIRouter) applyToolSelectionBeforeDispatch(
+	openAIRequest *openai.ChatCompletionNewParams,
+	response *ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+) {
+	var anthropicWire []byte
+	if ctx != nil && ctx.ClientProtocol == config.ClientProtocolAnthropic {
+		anthropicWire = append([]byte(nil), ctx.workingRequestBody()...)
+	}
+	r.handleToolSelectionForRequest(openAIRequest, response, ctx)
+	if len(anthropicWire) > 0 {
+		ctx.setWorkingRequestBody(anthropicWire)
+		return
+	}
+	if body := requestBodyMutation(response); len(body) > 0 {
+		ctx.setWorkingRequestBody(body)
+	}
+}
+
+func requestBodyMutation(response *ext_proc.ProcessingResponse) []byte {
+	if response == nil {
+		return nil
+	}
+	return response.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+}
+
 // handleToolSelectionForRequest handles tool selection for the request.
 func (r *OpenAIRouter) handleToolSelectionForRequest(openAIRequest *openai.ChatCompletionNewParams, response *ext_proc.ProcessingResponse, ctx *RequestContext) {
 	userContent, nonUserMessages := extractUserAndNonUserContent(openAIRequest)

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -21,54 +21,6 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/tools"
 )
 
-// applyToolSelectionBeforeDispatch runs semantic tool selection once on the
-// protocol-neutral IR before provider translation or backend dispatch.
-func (r *OpenAIRouter) applyToolSelectionBeforeDispatch(
-	openAIRequest *openai.ChatCompletionNewParams,
-	response *ext_proc.ProcessingResponse,
-	ctx *RequestContext,
-) {
-	var anthropicWire []byte
-	if ctx != nil && ctx.ClientProtocol == config.ClientProtocolAnthropic {
-		anthropicWire = append([]byte(nil), ctx.workingRequestBody()...)
-	}
-	r.handleToolSelectionForRequest(openAIRequest, response, ctx)
-	if len(anthropicWire) > 0 {
-		ctx.setWorkingRequestBody(anthropicWire)
-		return
-	}
-	persistSelectedToolsToWorkingBody(openAIRequest, ctx)
-}
-
-// persistSelectedToolsToWorkingBody copies the IR's selected tools onto the
-// OpenAI-shaped working body so specified/auto dispatch can emit them. Do not
-// derive this from the temporary ExtProc stub: handleToolSelectionForRequest
-// may filter the IR without writing a body mutation.
-func persistSelectedToolsToWorkingBody(
-	openAIRequest *openai.ChatCompletionNewParams,
-	ctx *RequestContext,
-) {
-	if ctx == nil || openAIRequest == nil {
-		return
-	}
-	serializedRequest, err := serializeOpenAIRequestWithStream(openAIRequest, ctx.ExpectStreamingResponse)
-	if err != nil {
-		logging.Errorf("Error serializing selected tools before dispatch: %v", err)
-		return
-	}
-	base := ctx.workingRequestBody()
-	if len(base) == 0 {
-		ctx.setWorkingRequestBody(serializedRequest)
-		return
-	}
-	modifiedBody, err := mergeSerializedToolFields(base, serializedRequest, toolFieldsForUpdate(ctx))
-	if err != nil {
-		logging.Errorf("Error merging selected tools before dispatch: %v", err)
-		return
-	}
-	ctx.setWorkingRequestBody(modifiedBody)
-}
-
 // handleToolSelectionForRequest handles tool selection for the request.
 func (r *OpenAIRouter) handleToolSelectionForRequest(openAIRequest *openai.ChatCompletionNewParams, response *ext_proc.ProcessingResponse, ctx *RequestContext) {
 	userContent, nonUserMessages := extractUserAndNonUserContent(openAIRequest)
@@ -453,6 +405,13 @@ func emitToolObservability(response **ext_proc.ProcessingResponse, ctx *RequestC
 	}
 	if !debugHeadersRequested(ctx) {
 		return
+	}
+	if ctx != nil {
+		ctx.ToolObservability = &toolObservability{
+			Strategy:   strategyID,
+			Confidence: strconv.FormatFloat(float64(confidence), 'f', 4, 32),
+			LatencyMs:  strconv.FormatInt(latency.Milliseconds(), 10),
+		}
 	}
 	commonResponse := ensureRequestBodyCommonResponse(response)
 	if commonResponse.HeaderMutation == nil {

--- a/src/semantic-router/pkg/extproc/req_filter_tools.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools.go
@@ -37,16 +37,36 @@ func (r *OpenAIRouter) applyToolSelectionBeforeDispatch(
 		ctx.setWorkingRequestBody(anthropicWire)
 		return
 	}
-	if body := requestBodyMutation(response); len(body) > 0 {
-		ctx.setWorkingRequestBody(body)
-	}
+	persistSelectedToolsToWorkingBody(openAIRequest, ctx)
 }
 
-func requestBodyMutation(response *ext_proc.ProcessingResponse) []byte {
-	if response == nil {
-		return nil
+// persistSelectedToolsToWorkingBody copies the IR's selected tools onto the
+// OpenAI-shaped working body so specified/auto dispatch can emit them. Do not
+// derive this from the temporary ExtProc stub: handleToolSelectionForRequest
+// may filter the IR without writing a body mutation.
+func persistSelectedToolsToWorkingBody(
+	openAIRequest *openai.ChatCompletionNewParams,
+	ctx *RequestContext,
+) {
+	if ctx == nil || openAIRequest == nil {
+		return
 	}
-	return response.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	serializedRequest, err := serializeOpenAIRequestWithStream(openAIRequest, ctx.ExpectStreamingResponse)
+	if err != nil {
+		logging.Errorf("Error serializing selected tools before dispatch: %v", err)
+		return
+	}
+	base := ctx.workingRequestBody()
+	if len(base) == 0 {
+		ctx.setWorkingRequestBody(serializedRequest)
+		return
+	}
+	modifiedBody, err := mergeSerializedToolFields(base, serializedRequest, toolFieldsForUpdate(ctx))
+	if err != nil {
+		logging.Errorf("Error merging selected tools before dispatch: %v", err)
+		return
+	}
+	ctx.setWorkingRequestBody(modifiedBody)
 }
 
 // handleToolSelectionForRequest handles tool selection for the request.

--- a/src/semantic-router/pkg/extproc/req_filter_tools_dispatch.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_dispatch.go
@@ -1,0 +1,144 @@
+package extproc
+
+import (
+	"bytes"
+	"encoding/json"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/openai/openai-go"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// toolObservability is captured during pre-dispatch selection and copied onto
+// the final ExtProc response after Anthropic / specified / auto dispatch.
+type toolObservability struct {
+	Strategy   string
+	Confidence string
+	LatencyMs  string
+}
+
+// applyToolSelectionBeforeDispatch runs semantic tool selection once on the
+// protocol-neutral IR before provider translation or backend dispatch.
+func (r *OpenAIRouter) applyToolSelectionBeforeDispatch(
+	openAIRequest *openai.ChatCompletionNewParams,
+	response *ext_proc.ProcessingResponse,
+	ctx *RequestContext,
+) {
+	var anthropicWire []byte
+	if ctx != nil && ctx.ClientProtocol == config.ClientProtocolAnthropic {
+		anthropicWire = append([]byte(nil), ctx.workingRequestBody()...)
+	}
+	before := snapshotToolSelection(openAIRequest)
+	r.handleToolSelectionForRequest(openAIRequest, response, ctx)
+	if len(anthropicWire) > 0 {
+		ctx.setWorkingRequestBody(anthropicWire)
+		return
+	}
+	if !toolSelectionChanged(before, openAIRequest) {
+		return
+	}
+	persistSelectedToolsToWorkingBody(openAIRequest, ctx)
+}
+
+// persistSelectedToolsToWorkingBody copies the IR's selected tools onto the
+// OpenAI-shaped working body so specified/auto dispatch can emit them. Do not
+// derive this from the temporary ExtProc stub: handleToolSelectionForRequest
+// may filter the IR without writing a body mutation.
+func persistSelectedToolsToWorkingBody(
+	openAIRequest *openai.ChatCompletionNewParams,
+	ctx *RequestContext,
+) {
+	if ctx == nil || openAIRequest == nil {
+		return
+	}
+	serializedRequest, err := serializeOpenAIRequestWithStream(openAIRequest, ctx.ExpectStreamingResponse)
+	if err != nil {
+		logging.Errorf("Error serializing selected tools before dispatch: %v", err)
+		return
+	}
+	base := ctx.workingRequestBody()
+	if len(base) == 0 {
+		ctx.setWorkingRequestBody(serializedRequest)
+		return
+	}
+	modifiedBody, err := mergeSerializedToolFields(base, serializedRequest, toolFieldsForUpdate(ctx))
+	if err != nil {
+		logging.Errorf("Error merging selected tools before dispatch: %v", err)
+		return
+	}
+	ctx.setWorkingRequestBody(modifiedBody)
+}
+
+type toolSelectionSnapshot struct {
+	names      []string
+	toolChoice []byte
+}
+
+func snapshotToolSelection(openAIRequest *openai.ChatCompletionNewParams) toolSelectionSnapshot {
+	return toolSelectionSnapshot{
+		names:      openaiToolNames(openAIRequest),
+		toolChoice: marshalToolChoice(openAIRequest),
+	}
+}
+
+func toolSelectionChanged(before toolSelectionSnapshot, openAIRequest *openai.ChatCompletionNewParams) bool {
+	if openAIRequest == nil {
+		return false
+	}
+	after := snapshotToolSelection(openAIRequest)
+	if len(before.names) != len(after.names) {
+		return true
+	}
+	for i := range before.names {
+		if before.names[i] != after.names[i] {
+			return true
+		}
+	}
+	return !bytes.Equal(before.toolChoice, after.toolChoice)
+}
+
+func openaiToolNames(openAIRequest *openai.ChatCompletionNewParams) []string {
+	if openAIRequest == nil {
+		return nil
+	}
+	names := make([]string, 0, len(openAIRequest.Tools))
+	for _, tool := range openAIRequest.Tools {
+		names = append(names, tool.Function.Name)
+	}
+	return names
+}
+
+func marshalToolChoice(openAIRequest *openai.ChatCompletionNewParams) []byte {
+	if openAIRequest == nil {
+		return nil
+	}
+	raw, err := json.Marshal(openAIRequest.ToolChoice)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+func appendToolObservabilityHeaders(setHeaders *[]*core.HeaderValueOption, ctx *RequestContext) {
+	if setHeaders == nil || ctx == nil || ctx.ToolObservability == nil {
+		return
+	}
+	obs := ctx.ToolObservability
+	appendRawHeader(setHeaders, headers.VSRToolsStrategy, obs.Strategy)
+	appendRawHeader(setHeaders, headers.VSRToolsConfidence, obs.Confidence)
+	appendRawHeader(setHeaders, headers.VSRToolsLatencyMs, obs.LatencyMs)
+}
+
+func appendRawHeader(setHeaders *[]*core.HeaderValueOption, key, value string) {
+	*setHeaders = append(*setHeaders, &core.HeaderValueOption{
+		Header: &core.HeaderValue{
+			Key:      key,
+			Value:    value,
+			RawValue: []byte(value),
+		},
+	})
+}

--- a/src/semantic-router/pkg/extproc/req_filter_tools_observability_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_tools_observability_test.go
@@ -32,6 +32,8 @@ var _ = Describe("emitToolObservability", func() {
 		Expect(headerMap[headers.VSRToolsStrategy]).To(Equal("default"))
 		Expect(headerMap[headers.VSRToolsConfidence]).To(Equal("0.8700"))
 		Expect(headerMap[headers.VSRToolsLatencyMs]).To(Equal("4"))
+		Expect(debugCtx.ToolObservability).NotTo(BeNil())
+		Expect(debugCtx.ToolObservability.Strategy).To(Equal("default"))
 	})
 
 	It("omits the headers on the default (non-debug) surface", func() {

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -108,6 +108,11 @@ type RequestContext struct {
 	// and header builder can replay them on the outbound side.
 	AnthropicPassthrough *anthropic.AnthropicPassthrough
 
+	// ToolObservability holds x-vsr-tools-* values captured during pre-dispatch
+	// selection so the final ExtProc response can emit them after dispatch
+	// replaces the temporary selection response.
+	ToolObservability *toolObservability
+
 	// Semi-streaming body handler (non-nil when Envoy sends STREAMED body chunks)
 	StreamedBody          *StreamedBodyHandler
 	FullDuplexRequestBody bool // true when the data plane negotiated FULL_DUPLEX_STREAMED


### PR DESCRIPTION
Closes #3051
Related #2992

## Purpose

Tool selection is a recipe/plugin policy. It must run on the protocol-neutral IR **before** the router chooses a provider format and translates the body. On current `main`, `handleModelRouting` can enter `handleAnthropicRouting` immediately after the pre-dispatch `mode=none` strip. That path never calls `handleToolSelectionForRequest`.

OpenAI auto/specified routing still ran selection later. The same decision therefore behaved differently depending on whether the selected backend was Anthropic or OpenAI-compatible.

**Workgroup:** Data Plane & Networking (`wg/data-plane-networking`)
**Affected modules:** `pkg/extproc` request-body orchestration, tool-selection filter, and `pkg/anthropic` passthrough remap

### Root cause

```text
applyPreDispatchToolsPolicy (mode=none only)
  -> if Anthropic API format: handleAnthropicRouting() and return
  -> else specified/auto routing, which then call handleToolSelectionForRequest
```

Anthropic translation (`ToAnthropicRequestBodyWithPassthrough`) already reads tools from the OpenAI IR. The missing step was running selection on that IR first.

### Fix

Run selection once in `handleModelRouting` after the direct-loop shortcut and **before** Anthropic / specified / auto dispatch:

1. `applyToolSelectionBeforeDispatch` mutates the IR through the existing `handleToolSelectionForRequest` path (no second retrieval).
2. Persist selected `tools`/`tool_choice` onto `ctx.WorkingRequestBody` **only when selection actually changed them**. Inactive/no-plugin paths leave the original body untouched so provider-specific fields are not dropped.
3. For Anthropic-shaped inbound, snapshot the native wire body, run IR selection, then restore the snapshot so passthrough capture (`cache_control`, tool_result, images) is not corrupted by OpenAI-shaped `tools` JSON.
4. After Anthropic translation, remap `tools[].cache_control` by **tool name** (`RemapToolsCacheControl`). Dropped tools lose their markers; retained tools keep them at the new index.
5. Carry `x-vsr-tools-*` from the temporary ExtProc stub onto the final Anthropic / specified / auto dispatch response (`ctx.ToolObservability`).
6. Remove the duplicate `handleToolSelectionForRequest` calls from `handleAutoModelRouting` and `handleSpecifiedModelRouting`.

`handleAnthropicRouting` then translates the already-selected IR. Semantic retrieval is not repeated after provider translation.

### What this does not change

- Direct loop models (Fusion / ReMoM / Flow) still return before this call, matching previous skip behavior for those aliases.
- Explicit `none`, `required`, and named-tool requests still skip semantic retrieval in passthrough mode.
- `mode=none` still runs first via `applyPreDispatchToolsPolicy`.
- Omitted `tool_choice` vs `"auto"` remains #3052; this PR uses explicit `"auto"` in tests.

### Behavior

| Path | Before | After |
| --- | --- | --- |
| Auto route to Anthropic backend | skipped selection | selection on IR, then Anthropic translate |
| Explicit Anthropic model | skipped selection | same |
| Streaming Anthropic | skipped selection | same, `stream=true` preserved |
| OpenAI specified/auto | selection after building the OpenAI body | selection once before dispatch; working body carries the result only if tools changed |
| `none` / `required` / named (passthrough) | n/a on Anthropic | request tools forwarded unchanged |
| Native Anthropic `cache_control` after filter | replayed by old tool index | remapped by tool name |
| `x-vsr-tools-*` on Anthropic / model rewrite | left on the temporary stub | copied onto the final dispatch response |

## Test Plan

- [x] `TestHandleModelRouting_AnthropicAppliesToolSelectionOnce` — explicit Anthropic model, filtered allow-list, outbound Anthropic `tools` contains only `lookup_weather`
- [x] `TestHandleModelRouting_AnthropicAutoRoutingAppliesToolSelection` — `MoM` auto-route to Anthropic backend
- [x] `TestHandleModelRouting_AnthropicStreamingAppliesToolSelection` — streaming flag retained with selected tools
- [x] `TestHandleModelRouting_AnthropicExplicitToolModesKeepRequestTools` — `none`, `required`, named keep both request tools
- [x] `TestHandleModelRouting_OpenAISpecifiedKeepsSelectedTools` — OpenAI specified-model path still applies the filtered list
- [x] `TestHandleModelRouting_OpenAISpecifiedDoesNotRewriteToolsWhenSelectionInactive` — no tools plugin leaves original `tools`/`tool_choice` bytes unchanged
- [x] `TestHandleModelRouting_AnthropicRemapsToolCacheControl` / `AnthropicKeepsRetainedToolCacheControl` — filtered tools drop markers; retained tools keep them by name
- [x] `TestHandleModelRouting_AnthropicCarriesToolObservabilityHeaders` — final Anthropic response includes `x-vsr-tools-*`
- [x] `TestRemapToolsCacheControl_*` in `pkg/anthropic`
- [x] E2E `tool-selection-anthropic` (`POST /v1/messages`): requires `x-vsr-selected-decision=tool_selection_filter_decision`, `x-vsr-tools-strategy=filter`, and non-empty `x-vsr-tools-confidence` / `x-vsr-tools-latency-ms`
- [ ] `go test ./pkg/extproc/ -run 'TestHandleModelRouting_Anthropic|TestHandleModelRouting_OpenAISpecified'`
- [ ] `go test ./pkg/anthropic/ -run TestRemapToolsCacheControl`
- [ ] CI Core quality / unit tests and Kubernetes E2E `tool-selection-anthropic` on this PR

## Test Result

`go test ./pkg/anthropic/ -run TestRemapToolsCacheControl` and `go test ./e2e/testcases/` compile and pass locally.

Local `go test ./pkg/extproc/...` could not be executed here: the package links candle/ml/nlp bindings, and this environment has neither those release libraries nor a complete module cache. Coverage is the dispatch / observability tests above plus CI.

Remaining risk: Kubernetes E2E can observe ExtProc response headers, not the outbound Anthropic `tools` body sent to the upstream. Filtered tool lists and `cache_control` remap stay covered by unit tests. The E2E profile still uses the envoy-ai-gateway OpenAI-shaped backend after inbound `/v1/messages`; it does not stand up a native Anthropic provider.

## Semantic Router PR Checklist

- [x] PR title begins with exactly one bracketed category (`[Bug]`)
- [x] The title does not stack prefixes
- [x] Linked issue is accepted with exactly one owner (`wg/data-plane-networking` on #3051)
- [x] Commits are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result match this change