### PR TITLE
[Bug] Rewrite Anthropic outbound model to provider_model_id

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic.go
@@ -135,6 +135,18 @@ func (r *OpenAIRouter) buildAnthropicRoutingResponse(
 		}
 	}
 
+	// Rewrite the routing alias to the model name the backend expects
+	// (provider_model_id / external_model_ids), mirroring the OpenAI-compatible
+	// path in buildSpecifiedModelBodyMutation (#3064).
+	if upstreamModel := r.resolveModelNameForBackend(targetModel, backendName); upstreamModel != targetModel {
+		rewritten, rwErr := rewriteModelInBodyFast(anthropicBody, upstreamModel)
+		if rwErr != nil {
+			logging.Warnf("Failed to rewrite model in Anthropic body: %v, sending original body", rwErr)
+		} else {
+			anthropicBody = rewritten
+		}
+	}
+
 	bodyLength := len(anthropicBody)
 	var anthropicHeaders []anthropic.HeaderKeyValue
 	if ctx.ExpectStreamingResponse {

--- a/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_anthropic_test.go
@@ -308,3 +308,91 @@ func containsJSONField(t *testing.T, body []byte, key string, want bool) bool {
 	got, ok := parsed[key].(bool)
 	return ok && got == want
 }
+
+// TestAnthropicRoutingRewritesProviderModelID guards #3064: the Anthropic
+// routing path must send the backend the model name from
+// provider_model_id/external_model_ids, not the router alias, mirroring the
+// OpenAI-compatible path.
+func TestAnthropicRoutingRewritesProviderModelID(t *testing.T) {
+	cfg := &config.RouterConfig{}
+	cfg.ModelConfig = map[string]config.ModelParams{
+		"mymodel-code": {
+			ExternalModelIDs: map[string]string{
+				"vllm": "Qwen/Qwen3.6-35B-A3B-FP8",
+			},
+		},
+	}
+	router := &OpenAIRouter{
+		Config: cfg,
+		CredentialResolver: authz.NewCredentialResolver(
+			authz.NewHeaderInjectionProvider(map[string]string{
+				string(authz.ProviderAnthropic): "x-user-anthropic-key",
+			}),
+		),
+	}
+	router.CredentialResolver.SetFailOpen(true)
+
+	body := []byte(`{"model":"mymodel-code","messages":[{"role":"user","content":"hi"}]}`)
+	request, err := parseOpenAIRequest(body)
+	if err != nil {
+		t.Fatalf("parseOpenAIRequest failed: %v", err)
+	}
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		OriginalRequestBody: body,
+	}
+
+	response, err := router.handleAnthropicRouting(request, "mymodel-code", "mymodel-code", "", ctx)
+	if err != nil {
+		t.Fatalf("handleAnthropicRouting failed: %v", err)
+	}
+	outbound := response.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	if len(outbound) == 0 {
+		t.Fatalf("expected outbound body mutation, got %#v", response)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(outbound, &decoded); err != nil {
+		t.Fatalf("outbound Anthropic body is invalid: %v", err)
+	}
+	if got := decoded["model"]; got != "Qwen/Qwen3.6-35B-A3B-FP8" {
+		t.Fatalf("outbound model = %v, want provider model ID", got)
+	}
+}
+
+// TestAnthropicRoutingKeepsAliasWithoutExternalModelIDs is the control for
+// #3064: with no external_model_ids mapping the outbound model is unchanged.
+func TestAnthropicRoutingKeepsAliasWithoutExternalModelIDs(t *testing.T) {
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{},
+		CredentialResolver: authz.NewCredentialResolver(
+			authz.NewHeaderInjectionProvider(map[string]string{
+				string(authz.ProviderAnthropic): "x-user-anthropic-key",
+			}),
+		),
+	}
+	router.CredentialResolver.SetFailOpen(true)
+
+	body := []byte(`{"model":"claude","messages":[{"role":"user","content":"hi"}]}`)
+	request, err := parseOpenAIRequest(body)
+	if err != nil {
+		t.Fatalf("parseOpenAIRequest failed: %v", err)
+	}
+	ctx := &RequestContext{
+		Headers:             map[string]string{},
+		OriginalRequestBody: body,
+	}
+
+	response, err := router.handleAnthropicRouting(request, "claude", "claude-sonnet-4.6", "", ctx)
+	if err != nil {
+		t.Fatalf("handleAnthropicRouting failed: %v", err)
+	}
+	outbound := response.GetRequestBody().GetResponse().GetBodyMutation().GetBody()
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(outbound, &decoded); err != nil {
+		t.Fatalf("outbound Anthropic body is invalid: %v", err)
+	}
+	if got := decoded["model"]; got != "claude-sonnet-4.6" {
+		t.Fatalf("outbound model = %v, want claude-sonnet-4.6", got)
+	}
+}


### PR DESCRIPTION
Closes #3064

## Purpose

The Anthropic routing path (`handleAnthropicRouting`) serialized the router model alias straight into the outgoing `/v1/messages` body: `prepareAnthropicRoutingRequest` sets `openAIRequest.Model = targetModel` and never consults `external_model_ids` / `provider_model_id`. The OpenAI-compatible path resolves the alias via `resolveModelNameForBackend` before rewriting the body, so the same configuration behaved differently per backend `api_format`.

Fix: in `buildAnthropicRoutingResponse`, after backend resolution, resolve the alias with the same `resolveModelNameForBackend` helper and rewrite the `model` field in the Anthropic body (before `content-length` is computed). No mapping configured means no rewrite, so alias-only setups are unchanged.

Owned by `wg/mom-routing` via the accepted issue #3064.

## Test Plan

```
cd src/semantic-router
go test ./pkg/extproc/ -run "TestAnthropicRouting|TestHandleAnthropicRouting"
gofmt -l pkg/extproc/ && go vet ./pkg/extproc/
```

New tests:
- `TestAnthropicRoutingRewritesProviderModelID`: alias with `external_model_ids` mapping produces the provider model ID in the outbound body
- `TestAnthropicRoutingKeepsAliasWithoutExternalModelIDs`: control, no mapping means unchanged model field

## Test Result

All 5 tests in the run pass locally (2 new + 3 existing Anthropic routing regressions), gofmt/vet clean.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change
</details>
