### PR TITLE
[Docs] landing page: closing CTA and blog rail hierarchy

### DIFF
--- a/website/src/css/blog.css
+++ b/website/src/css/blog.css
@@ -18,6 +18,9 @@ html[data-route-kind='blog'],
   /* One width for prose, code, images and tables. In rem, not ch: ch resolves
    * against the consumer's font-size, so prose and code would differ. */
   --blog-prose: 46rem;
+  /* Wider than the shared --rail: the listing rail carries post titles rather
+   * than short nav labels, so 18rem forced most of them onto three lines. */
+  --blog-rail: 23rem;
 }
 
 html[data-route-kind='blog'] body,
@@ -51,7 +54,7 @@ html[data-route-kind='blog'] body,
 .site-blog-index__columns {
   position: relative;
   display: grid;
-  grid-template-columns: var(--rail) minmax(0, 1fr);
+  grid-template-columns: var(--blog-rail) minmax(0, 1fr);
   gap: var(--rail-gap);
   align-items: start;
   padding-top: var(--space-6);
@@ -62,7 +65,7 @@ html[data-route-kind='blog'] body,
   position: absolute;
   top: var(--space-6);
   bottom: 0;
-  left: var(--rail);
+  left: var(--blog-rail);
   width: 1px;
   background: var(--site-border);
 }
@@ -319,13 +322,16 @@ html[data-route-kind='blog'] body,
   padding-right: var(--space-5);
 }
 
+/* The rail heading was --text-sm (0.875rem) above 0.98rem post titles, so the
+ * group label read as smaller than its own contents. Stepping it up to
+ * --text-lg gives the rail a clear head, and the titles below step down. */
 .site-blog-index__rail h2 {
   margin: 0;
-  padding: 0.15rem var(--space-2) var(--space-2);
+  padding: 0.15rem var(--space-2) var(--space-3);
   color: var(--site-text-strong);
-  font-size: var(--text-sm);
+  font-size: var(--text-lg);
   font-weight: var(--site-font-weight-semibold);
-  letter-spacing: -0.005em;
+  letter-spacing: -0.015em;
   text-transform: none;
 }
 
@@ -354,9 +360,9 @@ html[data-route-kind='blog'] body,
 
 .site-blog-recent a {
   color: var(--blog-ink-soft);
-  font-size: 0.98rem;
+  font-size: 0.92rem;
   font-weight: var(--site-font-weight-medium);
-  line-height: 1.35;
+  line-height: 1.4;
   text-decoration: none;
   transition: color var(--site-transition-fast);
 }
@@ -369,7 +375,7 @@ html[data-route-kind='blog'] body,
 
 .site-blog-recent time {
   color: var(--blog-muted);
-  font-size: 0.84rem;
+  font-size: 0.8rem;
 }
 
 .site-blog-tags ul {
@@ -379,7 +385,7 @@ html[data-route-kind='blog'] body,
 
 .site-blog-tags a {
   color: var(--blog-muted-strong);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   text-decoration: none;
   transition: color var(--site-transition-fast);
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -452,70 +452,246 @@
 }
 
 .finalCtaSection {
-  padding: 1rem 0 5rem;
+  padding: 0.5rem 0 clamp(3rem, 5vw, 4.5rem);
   background: var(--site-bg);
 }
 
-.finalCtaFrame {
+/* Sovereignty shows the mechanism instead of restating it: the same stage
+ * language as the routing pipeline above, with the constraint gate lit. */
+.sovereigntySection {
+  position: relative;
+  padding: clamp(2.75rem, 4.5vw, 4rem) 0 clamp(1.25rem, 2vw, 1.75rem);
+  background: var(--site-bg);
+}
+
+.sovereigntyFrame {
   display: grid;
-  grid-template-columns: 1fr;
-  align-items: start;
   gap: 1.5rem;
-  padding: clamp(1.6rem, 4vw, 3.25rem);
-  border: 1px solid var(--site-border-strong);
-  border-radius: 1.5rem;
+  padding-top: clamp(1.35rem, 2.5vw, 2rem);
+  border-top: 1px solid var(--site-border);
+}
+
+:global(.site-section-intro).sovereigntyCopy {
+  gap: 0.55rem;
+  margin-bottom: 0;
+}
+
+.constraintFlow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.constraintStage {
+  position: relative;
+  display: grid;
+  gap: 0.3rem;
+  align-content: start;
+  min-width: 0;
+  padding: 0.85rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 0.6rem;
+  background: rgba(4, 8, 15, 0.75);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  animation: constraintStageIn 0.6s ease-out var(--stage-delay) both;
+}
+
+.constraintStage:not(:last-child)::after {
+  content: '→';
+  position: absolute;
+  top: 50%;
+  right: -0.46rem;
+  z-index: 1;
+  color: rgba(117, 197, 255, 0.5);
+  font-size: 0.7rem;
+  line-height: 1;
+  transform: translateY(-50%);
+}
+
+/* The gate is the whole point of the diagram, so it is the lit one. */
+.constraintStageGate {
+  border-color: rgba(48, 162, 255, 0.42);
   background:
-    linear-gradient(130deg, rgba(48, 162, 255, 0.11), transparent 42%),
-    var(--site-surface-alt);
+    linear-gradient(180deg, rgba(48, 162, 255, 0.14), rgba(48, 162, 255, 0.04)),
+    rgba(4, 8, 15, 0.75);
+}
+
+.constraintStageIndex {
+  color: rgba(117, 197, 255, 0.55);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+}
+
+.constraintStage strong {
+  color: rgba(255, 255, 255, 0.92);
+  font-size: clamp(0.82rem, 1vw, 0.95rem);
+  font-weight: var(--site-font-weight-semibold);
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+.constraintStageDetail {
+  color: var(--site-muted);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.constraintStageGate .constraintStageDetail {
+  color: var(--site-accent-strong);
+}
+
+@keyframes constraintStageIn {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 0.5rem, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.constraintFooter {
+  display: grid;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.constraintNote {
+  margin: 0;
+  color: var(--site-muted);
+  font-size: 0.9rem;
+}
+
+.sovereigntyCta {
+  width: fit-content;
+}
+
+@media (min-width: 768px) {
+  .constraintFooter {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .constraintFlow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .constraintStage:not(:last-child)::after {
+    content: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .constraintStage {
+    animation: none;
+  }
+}
+
+/* Centred card on the same 46rem box as the install command block, so the two
+ * call-to-action moments on the page read as the same component. */
+.finalCtaFrame {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  justify-items: center;
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 46rem;
+  margin-inline: auto;
+  padding: clamp(1.75rem, 3vw, 2.5rem) clamp(1.5rem, 3vw, 2.5rem);
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.15rem;
+  background:
+    radial-gradient(120% 160% at 50% 0%, rgba(48, 162, 255, 0.15), transparent 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0) 44%),
+    #08080a;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+.finalCtaFrame::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(48, 162, 255, 0.65) 22%,
+    rgba(48, 162, 255, 0.65) 46%,
+    transparent 78%
+  );
 }
 
 .finalCtaCopy {
+  position: relative;
   display: grid;
-  gap: 0.85rem;
+  justify-items: center;
+  gap: 0.5rem;
   min-width: 0;
 }
 
 .finalCtaCopy h2 {
-  max-width: 20ch;
   margin: 0;
   color: var(--site-text-strong);
-  font-size: var(--site-text-h2);
-  font-weight: 450;
-  line-height: 1.18;
+  font-size: clamp(1.35rem, 2.2vw, 1.85rem);
+  font-weight: 560;
+  line-height: 1.15;
   letter-spacing: -0.03em;
-  text-wrap: pretty;
+  text-wrap: balance;
 }
 
 .finalCtaCopy p {
-  max-width: 36rem;
+  max-width: 52ch;
   margin: 0;
   color: var(--site-muted-bright);
-  font-size: 1.05rem;
+  font-size: 0.98rem;
 }
 
 .finalCtaActions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: flex-start;
+  justify-content: center;
 }
 
-@media (min-width: 768px) {
-  .finalCtaFrame {
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: end;
-      gap: 2rem;
-  }
+/* The page's last action, so it is solid rather than another outline pill. */
+.finalCtaActions .finalCtaPrimary:global(.pill) {
+  border-color: var(--site-accent) !important;
+  background: var(--site-accent) !important;
+  color: #030303 !important;
+  box-shadow: 0 16px 36px rgba(48, 162, 255, 0.24) !important;
+}
 
-  .finalCtaActions {
-      justify-content: flex-end;
+.finalCtaActions .finalCtaPrimary:global(.pill):hover {
+  border-color: var(--site-accent-strong) !important;
+  background: var(--site-accent-strong) !important;
+  color: #030303 !important;
+  transform: translateY(-1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .finalCtaActions .finalCtaPrimary:global(.pill):hover {
+    transform: none;
   }
 }
 
 @media (max-width: 996px) {
   .momProofHeading,
-  .momProofArchitecture,
-  .finalCtaFrame {
+  .momProofArchitecture {
       grid-template-columns: 1fr;
   }
 
@@ -611,7 +787,7 @@
   }
 
   .finalCtaActions {
-      justify-content: flex-start;
+      justify-content: center;
   }
 }
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import clsx from 'clsx'
 import Head from '@docusaurus/Head'
 import Layout from '@theme/Layout'
 import Translate, { translate } from '@docusaurus/Translate'
@@ -75,6 +76,35 @@ const heroStats = [
       },
       { count: paperCount },
     ),
+  },
+]
+
+/* The four beats of the routing decision. The gate stage is the claim: hard
+ * constraints remove paths, and only what survives is ranked. */
+const sovereigntyStages = [
+  {
+    id: 'request',
+    label: translate({ id: 'homepage.sovereignty.stage.request', message: 'Request' }),
+    detail: translate({ id: 'homepage.sovereignty.stage.request.detail', message: 'Identity + context' }),
+    gate: false,
+  },
+  {
+    id: 'constraints',
+    label: translate({ id: 'homepage.sovereignty.stage.constraints', message: 'Hard constraints' }),
+    detail: translate({ id: 'homepage.sovereignty.stage.constraints.detail', message: 'Residency · locality · auth' }),
+    gate: true,
+  },
+  {
+    id: 'eligible',
+    label: translate({ id: 'homepage.sovereignty.stage.eligible', message: 'Eligible pool' }),
+    detail: translate({ id: 'homepage.sovereignty.stage.eligible.detail', message: 'Approved paths only' }),
+    gate: false,
+  },
+  {
+    id: 'rank',
+    label: translate({ id: 'homepage.sovereignty.stage.rank', message: 'Rank' }),
+    detail: translate({ id: 'homepage.sovereignty.stage.rank.detail', message: 'Quality · latency · cost' }),
+    gate: false,
   },
 ]
 
@@ -374,6 +404,68 @@ function MixtureOfModelsProofSection(): JSX.Element {
   )
 }
 
+/* Residency and authorization are eliminated as hard constraints before any
+ * ranking happens. Deliberately no claim that data never leaves your estate —
+ * docs/overview/use-cases.md is explicit that "local" is not an end-to-end
+ * privacy guarantee, and the homepage should not say otherwise. */
+function DataSovereigntySection(): JSX.Element {
+  return (
+    <section className={styles.sovereigntySection}>
+      <div className="site-shell-container">
+        <ScrollReveal>
+          <div className={styles.sovereigntyFrame}>
+            <div className={`site-section-intro ${styles.sovereigntyCopy}`}>
+              <SectionLabel>
+                <Translate id="homepage.sovereignty.label">Data sovereignty</Translate>
+              </SectionLabel>
+              <h2>
+                <Translate id="homepage.sovereignty.title">
+                  Keep regulated traffic on approved paths.
+                </Translate>
+              </h2>
+              <p>
+                <Translate id="homepage.sovereignty.description">
+                  Residency, locality, and authorization are hard constraints, not preferences.
+                  Ineligible paths are removed before ranking ever runs.
+                </Translate>
+              </p>
+            </div>
+
+            <ol className={styles.constraintFlow}>
+              {sovereigntyStages.map((stage, index) => (
+                <li
+                  key={stage.id}
+                  className={clsx(styles.constraintStage, {
+                    [styles.constraintStageGate]: stage.gate,
+                  })}
+                  style={{ '--stage-delay': `${0.15 + index * 0.12}s` } as React.CSSProperties}
+                >
+                  <span className={styles.constraintStageIndex}>
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <strong>{stage.label}</strong>
+                  <span className={styles.constraintStageDetail}>{stage.detail}</span>
+                </li>
+              ))}
+            </ol>
+
+            <div className={styles.constraintFooter}>
+              <p className={styles.constraintNote}>
+                <Translate id="homepage.sovereignty.note">
+                  A request fails closed instead of reaching a provider your policy does not allow.
+                </Translate>
+              </p>
+              <PillLink className={styles.sovereigntyCta} to="/docs/overview/signal-driven-decisions" muted>
+                <Translate id="homepage.sovereignty.cta">How routing policy works</Translate>
+              </PillLink>
+            </div>
+          </div>
+        </ScrollReveal>
+      </div>
+    </section>
+  )
+}
+
 function FinalCtaSection(): JSX.Element {
   return (
     <section className={styles.finalCtaSection}>
@@ -397,6 +489,7 @@ function FinalCtaSection(): JSX.Element {
             </div>
             <div className={styles.finalCtaActions}>
               <PillLink
+                className={styles.finalCtaPrimary}
                 href="https://app.vllm-sr.ai/playground"
                 rel="noreferrer"
                 target="_blank"
@@ -531,6 +624,10 @@ export default function Home(): JSX.Element {
           <ScrollReveal delay={40}>
             <AcknowledgementsSection />
           </ScrollReveal>
+        </div>
+
+        <div className={styles.bandBlack}>
+          <DataSovereigntySection />
         </div>
 
         <div className={styles.bandGraphite}>


### PR DESCRIPTION
Related #3002

## Purpose

Follow-up to #3040, addressing review feedback.

- **New data sovereignty section.** Shows the mechanism as a four stage pipeline (Request, Hard constraints, Eligible pool, Rank) reusing the stage language from the routing pipeline above it, with the constraint gate highlighted. Wording is grounded in `docs/overview/goals.md` and `docs/overview/use-cases.md`.
- **Final CTA redesigned** as a centred card on the same 46rem box as the install command, so both call to action moments on the page are one component.
- **Blog rail hierarchy.** "Recent" goes 0.875rem to 1.125rem, post titles 0.98rem to 0.92rem, and the rail widens from 18rem to 23rem via a blog scoped `--blog-rail` so post titles stop wrapping to four lines. The shared `--rail` token is untouched, so docs, research and community are unaffected.

Deliberately not claimed: that data never leaves your infrastructure. `docs/overview/use-cases.md` states that "local" is not an end to end privacy guarantee, so the homepage should not say otherwise.

## Test Plan

Checked at 1920 / 1280 / 996 / 640.

- Sovereignty pipeline collapses to two columns below 640px with the arrows removed.
- CTA card stays centred and its buttons stay centred at every width.
- "How routing policy works" resolves to the Routing Pipeline page.
- Blog rail is wider, heading and titles have a clear step.
- Docs, research and community rails are unchanged.

## Test Result

`npm run lint` clean.

<img width="1908" height="992" alt="Screenshot From 2026-08-27 16-55-12" src="https://github.com/user-attachments/assets/8b4fb0e7-7b6d-4b4c-9da4-54e4fa73aebc" />

