### PR TITLE
[Feature] Optional NLI polarity tier for the in-memory semantic cache

### DIFF
--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -132,7 +132,7 @@ jobs:
           set +e
           if [ "${{ matrix.profile }}" = "envoy-ai-gateway" ]; then
             # Temporarily skip the stress / pressure coverage until the suite is stable again.
-            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations"
+            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations"
             make e2e-test E2E_PROFILE=${{ matrix.profile }} E2E_TESTS="${ENVOY_AI_GATEWAY_CI_TESTS}" E2E_VERBOSE=true E2E_KEEP_CLUSTER=false
             TEST_EXIT_CODE=$?
             set -e

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1833,6 +1833,14 @@ global:
       ttl_seconds: 7200
       eviction_policy: lru
       embedding_model: mmbert
+      # Negation/antonym guard for the in-memory backend. "lexical" is the
+      # model-free default; "nli" or "lexical+nli" additionally verifies the
+      # winning candidate once with the hallucination explainer NLI model and
+      # rejects it above nli.contradiction_threshold (~70 ms/hit on CPU).
+      polarity_guard:
+        mode: lexical
+        nli:
+          contradiction_threshold: 0.5
       milvus:
         connection:
           host: milvus

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -17,6 +17,8 @@ var BaselineRouterContract = []string{
 	"chat-completions-stress-request",
 	"domain-classify",
 	"semantic-cache",
+	// NLI polarity tier of the semantic cache (issue #2751)
+	"semantic-cache-polarity",
 	"pii-detection",
 	"jailbreak-detection",
 	"decision-priority-selection",

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -788,6 +788,12 @@ config:
         ttl_seconds: 3600
         eviction_policy: fifo
         embedding_model: mmbert
+        # Exercised by the semantic-cache-polarity case: the NLI tier reuses the
+        # default hallucination explainer (models/mom-halugate-explainer).
+        polarity_guard:
+          mode: lexical+nli
+          nli:
+            contradiction_threshold: 0.5
       memory:
         embedding_model: mmbert
       vector_store:

--- a/e2e/profiles/production-stack/profile.go
+++ b/e2e/profiles/production-stack/profile.go
@@ -163,6 +163,7 @@ func (p *Profile) GetTestCases() []string {
 			"pii-detection",
 			"jailbreak-detection",
 			"semantic-cache",
+			"semantic-cache-polarity",
 		},
 	)
 }

--- a/e2e/profiles/production-stack/profile.go
+++ b/e2e/profiles/production-stack/profile.go
@@ -163,7 +163,6 @@ func (p *Profile) GetTestCases() []string {
 			"pii-detection",
 			"jailbreak-detection",
 			"semantic-cache",
-			"semantic-cache-polarity",
 		},
 	)
 }

--- a/e2e/profiles/production-stack/values.yaml
+++ b/e2e/profiles/production-stack/values.yaml
@@ -337,6 +337,12 @@ config:
         ttl_seconds: 3600
         eviction_policy: fifo
         embedding_model: mmbert
+        # Exercised by the semantic-cache-polarity case: the NLI tier reuses the
+        # default hallucination explainer (models/mom-halugate-explainer).
+        polarity_guard:
+          mode: lexical+nli
+          nli:
+            contradiction_threshold: 0.5
       memory:
         embedding_model: mmbert
       vector_store:

--- a/e2e/profiles/production-stack/values.yaml
+++ b/e2e/profiles/production-stack/values.yaml
@@ -337,12 +337,6 @@ config:
         ttl_seconds: 3600
         eviction_policy: fifo
         embedding_model: mmbert
-        # Exercised by the semantic-cache-polarity case: the NLI tier reuses the
-        # default hallucination explainer (models/mom-halugate-explainer).
-        polarity_guard:
-          mode: lexical+nli
-          nli:
-            contradiction_threshold: 0.5
       memory:
         embedding_model: mmbert
       vector_store:

--- a/e2e/testcases/cache_polarity.go
+++ b/e2e/testcases/cache_polarity.go
@@ -1,0 +1,177 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+// The polarity case pins the #2751 contract at the only place E2E can see it:
+// with global.stores.response_cache.polarity_guard.mode set to an NLI mode, a
+// query that clears the similarity threshold but contradicts the cached one
+// must not be served from the cache, while a genuine paraphrase still hits.
+func init() {
+	pkgtestcases.Register("semantic-cache-polarity", pkgtestcases.TestCase{
+		Description: "Semantic cache rejects opposite-meaning queries via the NLI polarity guard",
+		Tags:        []string{"kubernetes", "semantic-cache", "polarity"},
+		Fn:          testCachePolarity,
+	})
+}
+
+// cachePolarityCase pairs a primed question with an opposite-meaning variant
+// that must miss and a paraphrase that must still hit.
+type cachePolarityCase struct {
+	Description      string `json:"description"`
+	OriginalQuestion string `json:"original_question"`
+	Contradiction    string `json:"contradiction"`
+	Paraphrase       string `json:"paraphrase"`
+}
+
+func loadCachePolarityCases(path string) ([]cachePolarityCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read polarity cases: %w", err)
+	}
+	var cases []cachePolarityCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		return nil, fmt.Errorf("failed to parse polarity cases: %w", err)
+	}
+	return cases, nil
+}
+
+func testCachePolarity(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing semantic cache NLI polarity guard")
+	}
+
+	localPort, stopPortForward, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopPortForward()
+
+	cases, err := loadCachePolarityCases("e2e/testcases/testdata/cache_polarity_cases.json")
+	if err != nil {
+		return err
+	}
+
+	var failures []string
+	rejected, served := 0, 0
+	for _, tc := range cases {
+		outcome := runCachePolarityCase(ctx, tc, localPort, opts.Verbose)
+		failures = append(failures, outcome.failures...)
+		if outcome.rejected {
+			rejected++
+		}
+		if outcome.served {
+			served++
+		}
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"cases":                    len(cases),
+			"contradictions_rejected":  rejected,
+			"paraphrases_served":       served,
+			"assertion_failures":       len(failures),
+			"similarity_threshold_min": cachePolarityThreshold,
+		})
+	}
+
+	if len(cases) == 0 {
+		return errors.New("polarity test loaded zero cases; nothing was asserted")
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("semantic cache polarity assertions failed (%d):\n  %s",
+			len(failures), strings.Join(failures, "\n  "))
+	}
+	if opts.Verbose {
+		fmt.Printf("[Test] Polarity guard: %d contradictions rejected, %d paraphrases served\n", rejected, served)
+	}
+	return nil
+}
+
+// cachePolarityOutcome records one case: whether the contradiction was rejected
+// by the guard, whether the paraphrase was served, and any assertion failures.
+type cachePolarityOutcome struct {
+	rejected bool
+	served   bool
+	failures []string
+}
+
+// runCachePolarityCase primes the cache with the original question, then
+// checks the contradiction and the paraphrase against it.
+func runCachePolarityCase(ctx context.Context, tc cachePolarityCase, localPort string, verbose bool) cachePolarityOutcome {
+	var out cachePolarityOutcome
+	primeCase := CacheTestCase{Description: tc.Description, OriginalQuestion: tc.OriginalQuestion}
+
+	resp, err := sendChatRequest(ctx, tc.OriginalQuestion, localPort, verbose)
+	if err != nil {
+		out.failures = append(out.failures, fmt.Sprintf("priming %q: %v", tc.OriginalQuestion, err))
+		return out
+	}
+	resp.Body.Close()
+	time.Sleep(1 * time.Second) // same settling time as the cache hit-rate case
+
+	contra := testSingleCacheRequest(ctx, primeCase, tc.Contradiction, localPort, verbose)
+	if msg := assertPolarityContradictionRejected(tc, contra); msg != "" {
+		out.failures = append(out.failures, msg)
+	} else {
+		out.rejected = true
+	}
+
+	para := testSingleCacheRequest(ctx, primeCase, tc.Paraphrase, localPort, verbose)
+	if msg := assertPolarityParaphraseServed(tc, para); msg != "" {
+		out.failures = append(out.failures, msg)
+	} else {
+		out.served = true
+	}
+	return out
+}
+
+// assertPolarityContradictionRejected returns a failure message unless the
+// contradiction missed *because of the guard*: a miss whose reported similarity
+// is at or above the profile threshold is the only observable proof that the
+// NLI tier, not the threshold, produced it.
+func assertPolarityContradictionRejected(tc cachePolarityCase, r CacheResult) string {
+	switch {
+	case r.Error != "":
+		return fmt.Sprintf("%q: %s", tc.Contradiction, r.Error)
+	case r.CacheHit:
+		return fmt.Sprintf("%q was served the cached answer for %q (similarity=%.4f)",
+			tc.Contradiction, tc.OriginalQuestion, r.Similarity)
+	case r.Similarity < cachePolarityThreshold:
+		return fmt.Sprintf("%q missed below the threshold (similarity=%.4f < %.2f); the polarity guard was not exercised",
+			tc.Contradiction, r.Similarity, cachePolarityThreshold)
+	default:
+		return ""
+	}
+}
+
+// assertPolarityParaphraseServed returns a failure message unless the
+// paraphrase still hit, which pins that the guard preserves legitimate recall.
+func assertPolarityParaphraseServed(tc cachePolarityCase, r CacheResult) string {
+	switch {
+	case r.Error != "":
+		return fmt.Sprintf("%q: %s", tc.Paraphrase, r.Error)
+	case !r.CacheHit:
+		return fmt.Sprintf("paraphrase %q missed (similarity=%.4f); the guard rejected a genuine match",
+			tc.Paraphrase, r.Similarity)
+	default:
+		return ""
+	}
+}
+
+// cachePolarityThreshold mirrors global.stores.response_cache.similarity_threshold
+// in the profiles that run this case (production-stack ships 0.8). A rejected
+// contradiction must report at least this score, otherwise the miss came from
+// the threshold and says nothing about the guard.
+const cachePolarityThreshold = 0.8

--- a/e2e/testcases/cache_polarity.go
+++ b/e2e/testcases/cache_polarity.go
@@ -30,12 +30,13 @@ func init() {
 // that must miss and a paraphrase that must still hit.
 //
 // Every question in a case must classify to a decision that carries the
-// response_cache plugin (default_decision in the profiles that run this case)
-// and the pair must clear similarity_threshold on the profile's embedding
-// model; the shipped cases were calibrated against a live production-stack
-// deployment (mmbert, threshold 0.8). Domain-flavoured wording such as files,
-// timers, or notifications routes to computer_science_decision, which has no
-// cache plugin, and would make the case vacuous.
+// response_cache plugin and the pair must clear similarity_threshold on the
+// profile's embedding model. The shipped cases use everyday wording that the
+// envoy-ai-gateway baseline profile classifies as "other" (other_decision,
+// which carries the plugin) and were calibrated against a live deployment of
+// that profile (mmbert). Domain-flavoured wording such as files, timers, or
+// notifications routes to decisions without a cache plugin and would make the
+// case vacuous.
 type cachePolarityCase struct {
 	Description      string `json:"description"`
 	OriginalQuestion string `json:"original_question"`
@@ -210,8 +211,9 @@ const cachePolarityPrimeAttempts = 4
 // cachePolarityExactMatch is the similarity of an identical cached query.
 const cachePolarityExactMatch = 0.999
 
-// cachePolarityThreshold mirrors global.stores.response_cache.similarity_threshold
-// in the profiles that run this case (production-stack ships 0.8). A rejected
-// contradiction must report at least this score, otherwise the miss came from
-// the threshold and says nothing about the guard.
+// cachePolarityThreshold is the highest similarity_threshold any decision with
+// the response_cache plugin uses in the profiles that run this case (the
+// envoy-ai-gateway baseline ships 0.8 globally and 0.75 on other_decision). A
+// rejected contradiction must report at least this score, otherwise the miss
+// came from the threshold and says nothing about the guard.
 const cachePolarityThreshold = 0.8

--- a/e2e/testcases/cache_polarity.go
+++ b/e2e/testcases/cache_polarity.go
@@ -28,6 +28,14 @@ func init() {
 
 // cachePolarityCase pairs a primed question with an opposite-meaning variant
 // that must miss and a paraphrase that must still hit.
+//
+// Every question in a case must classify to a decision that carries the
+// response_cache plugin (default_decision in the profiles that run this case)
+// and the pair must clear similarity_threshold on the profile's embedding
+// model; the shipped cases were calibrated against a live production-stack
+// deployment (mmbert, threshold 0.8). Domain-flavoured wording such as files,
+// timers, or notifications routes to computer_science_decision, which has no
+// cache plugin, and would make the case vacuous.
 type cachePolarityCase struct {
 	Description      string `json:"description"`
 	OriginalQuestion string `json:"original_question"`
@@ -113,28 +121,47 @@ func runCachePolarityCase(ctx context.Context, tc cachePolarityCase, localPort s
 	var out cachePolarityOutcome
 	primeCase := CacheTestCase{Description: tc.Description, OriginalQuestion: tc.OriginalQuestion}
 
-	resp, err := sendChatRequest(ctx, tc.OriginalQuestion, localPort, verbose)
-	if err != nil {
-		out.failures = append(out.failures, fmt.Sprintf("priming %q: %v", tc.OriginalQuestion, err))
-		return out
+	// The in-memory cache is per router replica and the gateway spreads
+	// requests across replicas, so a single priming request only warms the
+	// replica that happened to serve it. Prime repeatedly to cover them all.
+	for i := 0; i < cachePolarityPrimeAttempts; i++ {
+		resp, err := sendChatRequest(ctx, tc.OriginalQuestion, localPort, verbose)
+		if err != nil {
+			out.failures = append(out.failures, fmt.Sprintf("priming %q: %v", tc.OriginalQuestion, err))
+			return out
+		}
+		resp.Body.Close()
 	}
-	resp.Body.Close()
 	time.Sleep(1 * time.Second) // same settling time as the cache hit-rate case
 
-	contra := testSingleCacheRequest(ctx, primeCase, tc.Contradiction, localPort, verbose)
+	contra := probeCachePolarity(ctx, primeCase, tc.Contradiction, localPort, verbose)
 	if msg := assertPolarityContradictionRejected(tc, contra); msg != "" {
 		out.failures = append(out.failures, msg)
 	} else {
 		out.rejected = true
 	}
 
-	para := testSingleCacheRequest(ctx, primeCase, tc.Paraphrase, localPort, verbose)
+	para := probeCachePolarity(ctx, primeCase, tc.Paraphrase, localPort, verbose)
 	if msg := assertPolarityParaphraseServed(tc, para); msg != "" {
 		out.failures = append(out.failures, msg)
 	} else {
 		out.served = true
 	}
 	return out
+}
+
+// probeCachePolarity sends one probe. A miss that carries no similarity at all
+// means the request reached a replica whose cache holds no candidate — not a
+// guard decision — so it is retried once before being judged.
+func probeCachePolarity(ctx context.Context, primeCase CacheTestCase, question, localPort string, verbose bool) CacheResult {
+	r := testSingleCacheRequest(ctx, primeCase, question, localPort, verbose)
+	if r.Error == "" && !r.CacheHit && r.Similarity == 0 {
+		if verbose {
+			fmt.Printf("[Test] probe %q reached an unprimed replica (no similarity reported); retrying once\n", question)
+		}
+		r = testSingleCacheRequest(ctx, primeCase, question, localPort, verbose)
+	}
+	return r
 }
 
 // assertPolarityContradictionRejected returns a failure message unless the
@@ -145,6 +172,12 @@ func assertPolarityContradictionRejected(tc cachePolarityCase, r CacheResult) st
 	switch {
 	case r.Error != "":
 		return fmt.Sprintf("%q: %s", tc.Contradiction, r.Error)
+	case r.CacheHit && r.Similarity >= cachePolarityExactMatch:
+		// An identical entry can only come from an earlier run that answered
+		// the contradiction itself (a kept cluster); serving it is correct
+		// cache behaviour and says nothing about the guard.
+		return fmt.Sprintf("%q matched an identical cached entry (similarity=%.4f); the cache was not fresh, rerun against a clean deployment",
+			tc.Contradiction, r.Similarity)
 	case r.CacheHit:
 		return fmt.Sprintf("%q was served the cached answer for %q (similarity=%.4f)",
 			tc.Contradiction, tc.OriginalQuestion, r.Similarity)
@@ -169,6 +202,13 @@ func assertPolarityParaphraseServed(tc cachePolarityCase, r CacheResult) string 
 		return ""
 	}
 }
+
+// cachePolarityPrimeAttempts is how many times the original question is sent
+// before probing; see runCachePolarityCase.
+const cachePolarityPrimeAttempts = 4
+
+// cachePolarityExactMatch is the similarity of an identical cached query.
+const cachePolarityExactMatch = 0.999
 
 // cachePolarityThreshold mirrors global.stores.response_cache.similarity_threshold
 // in the profiles that run this case (production-stack ships 0.8). A rejected

--- a/e2e/testcases/testdata/cache_polarity_cases.json
+++ b/e2e/testcases/testdata/cache_polarity_cases.json
@@ -1,20 +1,20 @@
 [
   {
-    "description": "Antonym flip must not reuse the cached answer (enable/disable)",
-    "original_question": "How do I enable two-factor authentication on my account?",
-    "contradiction": "How do I disable two-factor authentication on my account?",
-    "paraphrase": "How can I enable two-factor authentication on my account?"
+    "description": "Antonym flip must not reuse the cached answer (on/off) — routes to default_decision, mmbert similarity ~0.95",
+    "original_question": "How do I turn on the lights?",
+    "contradiction": "How do I turn off the lights?",
+    "paraphrase": "How can I turn on the lights?"
   },
   {
-    "description": "Antonym flip must not reuse the cached answer (on/off)",
-    "original_question": "How do I turn on dark mode in the settings?",
-    "contradiction": "How do I turn off dark mode in the settings?",
-    "paraphrase": "How can I turn on dark mode in the settings?"
+    "description": "Antonym flip must not reuse the cached answer (lock/unlock) — routes to default_decision, mmbert similarity ~0.97",
+    "original_question": "How do I lock the door?",
+    "contradiction": "How do I unlock the door?",
+    "paraphrase": "How can I lock the door?"
   },
   {
-    "description": "Inserted negation must not reuse the cached answer",
-    "original_question": "Should I commit this change before the release?",
-    "contradiction": "Should I not commit this change before the release?",
-    "paraphrase": "Should I commit this change prior to the release?"
+    "description": "Antonym flip must not reuse the cached answer (dark mode) — routes to default_decision, mmbert similarity ~0.93",
+    "original_question": "How to turn on dark mode?",
+    "contradiction": "How to turn off dark mode?",
+    "paraphrase": "How do I turn on dark mode?"
   }
 ]

--- a/e2e/testcases/testdata/cache_polarity_cases.json
+++ b/e2e/testcases/testdata/cache_polarity_cases.json
@@ -1,0 +1,20 @@
+[
+  {
+    "description": "Antonym flip must not reuse the cached answer (enable/disable)",
+    "original_question": "How do I enable two-factor authentication on my account?",
+    "contradiction": "How do I disable two-factor authentication on my account?",
+    "paraphrase": "How can I enable two-factor authentication on my account?"
+  },
+  {
+    "description": "Antonym flip must not reuse the cached answer (on/off)",
+    "original_question": "How do I turn on dark mode in the settings?",
+    "contradiction": "How do I turn off dark mode in the settings?",
+    "paraphrase": "How can I turn on dark mode in the settings?"
+  },
+  {
+    "description": "Inserted negation must not reuse the cached answer",
+    "original_question": "Should I commit this change before the release?",
+    "contradiction": "Should I not commit this change before the release?",
+    "paraphrase": "Should I commit this change prior to the release?"
+  }
+]

--- a/src/semantic-router/pkg/apiserver/route_model_info_classifiers.go
+++ b/src/semantic-router/pkg/apiserver/route_model_info_classifiers.go
@@ -177,7 +177,8 @@ func buildHallucinationModels(
 
 	nliModel := cfg.HallucinationMitigation.NLIModel
 	if cfg.NeedsLocalHallucinationNLIForAPI() ||
-		cfg.NeedsLocalHallucinationNLIForRouting() {
+		cfg.NeedsLocalHallucinationNLIForRouting() ||
+		cfg.NeedsLocalNLIForSemanticCache() {
 		models = append(models, ModelInfo{
 			Name:      "hallucination_explainer",
 			Type:      "nli_explainer",

--- a/src/semantic-router/pkg/cache/backend_registry.go
+++ b/src/semantic-router/pkg/cache/backend_registry.go
@@ -37,6 +37,7 @@ var cacheBackendRegistry = map[CacheBackendType]cacheBackendRegistration{
 				HNSWM:               config.HNSWM,
 				HNSWEfConstruction:  config.HNSWEfConstruction,
 				EmbeddingModel:      config.EmbeddingModel,
+				PolarityGuard:       config.PolarityGuard,
 			}), nil
 		},
 	},

--- a/src/semantic-router/pkg/cache/cache_factory.go
+++ b/src/semantic-router/pkg/cache/cache_factory.go
@@ -48,6 +48,9 @@ func ValidateCacheConfig(config CacheConfig) error {
 	if config.TTLSeconds < 0 {
 		return fmt.Errorf("ttl_seconds cannot be negative, got: %d", config.TTLSeconds)
 	}
+	if t := config.PolarityGuard.ContradictionThreshold; config.PolarityGuard.UseNLI && (t < 0.0 || t > 1.0) {
+		return fmt.Errorf("polarity_guard.nli.contradiction_threshold must be between 0.0 and 1.0, got: %f", t)
+	}
 	return validateCacheBackend(config)
 }
 

--- a/src/semantic-router/pkg/cache/cache_interface.go
+++ b/src/semantic-router/pkg/cache/cache_interface.go
@@ -218,4 +218,7 @@ type CacheConfig struct {
 	// EmbeddingModel specifies which embedding model to use
 	// Options: "bert" (default), "qwen3", "gemma", "mmbert", "multimodal"
 	EmbeddingModel string `yaml:"embedding_model,omitempty"`
+
+	// PolarityGuard configures the optional NLI polarity tier of the in-memory backend (#2751)
+	PolarityGuard PolarityGuardOptions `yaml:"polarity_guard,omitempty"`
 }

--- a/src/semantic-router/pkg/cache/inmemory_cache.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache.go
@@ -37,9 +37,10 @@ type InMemoryCache struct {
 
 	hnswIndex        *HNSWIndex
 	useHNSW          bool
-	hnswNeedsRebuild bool   // true while the HNSW graph is stale relative to entries
-	hnswEfSearch     int    // Search-time ef parameter
-	embeddingModel   string // "bert", "qwen3", "gemma", "mmbert", or "multimodal"
+	hnswNeedsRebuild bool                 // true while the HNSW graph is stale relative to entries
+	hnswEfSearch     int                  // Search-time ef parameter
+	embeddingModel   string               // "bert", "qwen3", "gemma", "mmbert", or "multimodal"
+	polarityGuard    PolarityGuardOptions // optional NLI polarity tier (#2751)
 
 	// embMemo deduplicates query-embedding inference: a cache-miss request
 	// otherwise embeds the same query twice (lookup + pending write), so the
@@ -59,11 +60,12 @@ type InMemoryCacheOptions struct {
 	TTLSeconds          int
 	Enabled             bool
 	EvictionPolicy      EvictionPolicyType
-	UseHNSW             bool   // Enable HNSW index for faster search
-	HNSWM               int    // Number of bi-directional links (default: 16)
-	HNSWEfConstruction  int    // Size of dynamic candidate list during construction (default: 200)
-	HNSWEfSearch        int    // Size of dynamic candidate list during search (default: 50)
-	EmbeddingModel      string // "bert", "qwen3", "gemma", "mmbert", or "multimodal"
+	UseHNSW             bool                 // Enable HNSW index for faster search
+	HNSWM               int                  // Number of bi-directional links (default: 16)
+	HNSWEfConstruction  int                  // Size of dynamic candidate list during construction (default: 200)
+	HNSWEfSearch        int                  // Size of dynamic candidate list during search (default: 50)
+	EmbeddingModel      string               // "bert", "qwen3", "gemma", "mmbert", or "multimodal"
+	PolarityGuard       PolarityGuardOptions // Optional NLI polarity tier (#2751)
 }
 
 func attachInMemoryEvictionPolicy(cache *InMemoryCache, policy EvictionPolicyType) {
@@ -144,6 +146,7 @@ func NewInMemoryCache(options InMemoryCacheOptions) *InMemoryCache {
 		"eviction_policy":      options.EvictionPolicy,
 		"use_hnsw":             options.UseHNSW,
 		"embedding_model":      embeddingModel,
+		"polarity_guard_nli":   options.PolarityGuard.UseNLI,
 	})
 
 	cache := &InMemoryCache{
@@ -159,6 +162,7 @@ func NewInMemoryCache(options InMemoryCacheOptions) *InMemoryCache {
 		useHNSW:             options.UseHNSW,
 		hnswEfSearch:        efSearch,
 		embeddingModel:      embeddingModel,
+		polarityGuard:       options.PolarityGuard,
 		embMemo:             newEmbeddingMemo(defaultEmbeddingMemoSize),
 	}
 
@@ -171,6 +175,7 @@ func NewInMemoryCache(options InMemoryCacheOptions) *InMemoryCache {
 		"use_hnsw":             options.UseHNSW,
 		"hnsw_ef_search":       efSearch,
 		"embedding_model":      embeddingModel,
+		"polarity_guard_nli":   options.PolarityGuard.UseNLI,
 	})
 
 	attachInMemoryEvictionPolicy(cache, options.EvictionPolicy)

--- a/src/semantic-router/pkg/cache/inmemory_cache_polarity.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache_polarity.go
@@ -1,0 +1,110 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+)
+
+// polarityNLIVerdict is the outcome of one NLI verification of a cache candidate.
+type polarityNLIVerdict struct {
+	Reject        bool
+	Contradiction float32
+	// Skipped means the verifier was unavailable or failed; the caller fails
+	// open and serves the candidate.
+	Skipped bool
+}
+
+// applyPolarityNLI runs the NLI tier on the winning candidate when the tier is
+// enabled. It returns handled=true with the lookup outcome when the candidate
+// must not be served — the request was cancelled, or the queries contradict —
+// and handled=false when the caller should serve it. A rejection is a
+// caller-visible miss that still reports the rejected score
+// (LookupResult.Similarity) so near-threshold rejections stay diagnosable.
+func (c *InMemoryCache) applyPolarityNLI(
+	ctx context.Context,
+	start time.Time,
+	model, query string,
+	bestEntry CacheEntry,
+	bestSimilarity, threshold float32,
+) (LookupResult, bool, error) {
+	if !c.polarityGuard.UseNLI {
+		return LookupResult{}, false, nil
+	}
+	if err := ctxErr(ctx); err != nil {
+		metrics.RecordCacheOperation("memory", "find_similar", "canceled", time.Since(start).Seconds())
+		return LookupResult{}, true, err
+	}
+	verdict := c.verifyPolarityNLI(ctx, model, bestEntry.Query, query)
+	if !verdict.Reject {
+		return LookupResult{}, false, nil
+	}
+	c.recordPolarityReject(start, model, query, bestEntry.Query, bestSimilarity, threshold, verdict)
+	return LookupResult{Similarity: bestSimilarity}, true, nil
+}
+
+// verifyPolarityNLI runs the NLI tier on the winning candidate. It fails open:
+// a missing or failing verifier serves the threshold-verified hit and records
+// the skip, so a model hiccup never turns into a cache outage.
+func (c *InMemoryCache) verifyPolarityNLI(ctx context.Context, model, cachedQuery, incomingQuery string) polarityNLIVerdict {
+	start := time.Now()
+	verifier := polarityVerifier
+	if verifier == nil {
+		c.recordPolarityNLISkipped(model, "polarity verifier not configured")
+		return polarityNLIVerdict{Skipped: true}
+	}
+
+	contradiction, err := verifier(ctx, cachedQuery, incomingQuery)
+	if err != nil {
+		metrics.RecordCacheOperation("memory", "polarity_nli", "error", time.Since(start).Seconds())
+		c.recordPolarityNLISkipped(model, err.Error())
+		return polarityNLIVerdict{Skipped: true}
+	}
+
+	if contradiction > c.polarityGuard.ContradictionThreshold {
+		metrics.RecordCacheOperation("memory", "polarity_nli", "reject", time.Since(start).Seconds())
+		return polarityNLIVerdict{Reject: true, Contradiction: contradiction}
+	}
+	metrics.RecordCacheOperation("memory", "polarity_nli", "pass", time.Since(start).Seconds())
+	return polarityNLIVerdict{Contradiction: contradiction}
+}
+
+func (c *InMemoryCache) recordPolarityNLISkipped(model, reason string) {
+	logging.ComponentWarnEvent("cache", "cache_polarity_nli_skipped", map[string]interface{}{
+		"backend":   "memory",
+		"tier":      polarityGuardTierNLI,
+		"model":     model,
+		"reason":    reason,
+		"fail_open": true,
+	})
+}
+
+// recordPolarityReject preserves caller-visible miss semantics while emitting an
+// event that distinguishes a polarity rejection from a threshold miss.
+func (c *InMemoryCache) recordPolarityReject(
+	start time.Time,
+	model, query, cachedQuery string,
+	similarity, threshold float32,
+	verdict polarityNLIVerdict,
+) {
+	atomic.AddInt64(&c.missCount, 1)
+	logging.Debugf("InMemoryCache.FindSimilarWithThreshold: POLARITY REJECT (nli) - similarity=%.4f >= threshold=%.4f but contradiction=%.4f > %.4f; treating as miss",
+		similarity, threshold, verdict.Contradiction, c.polarityGuard.ContradictionThreshold)
+	logging.LogEvent("cache_negation_reject", map[string]interface{}{
+		"backend":                 "memory",
+		"tier":                    polarityGuardTierNLI,
+		"similarity":              similarity,
+		"threshold":               threshold,
+		"contradiction":           verdict.Contradiction,
+		"contradiction_threshold": c.polarityGuard.ContradictionThreshold,
+		"model":                   model,
+		"query":                   logging.ContentDescriptor(query),
+		"cached_query":            logging.ContentDescriptor(cachedQuery),
+	})
+	metrics.RecordCacheOperation("memory", "find_similar", "miss", time.Since(start).Seconds())
+}

--- a/src/semantic-router/pkg/cache/inmemory_cache_polarity.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache_polarity.go
@@ -53,7 +53,7 @@ func (c *InMemoryCache) applyPolarityNLI(
 // the skip, so a model hiccup never turns into a cache outage.
 func (c *InMemoryCache) verifyPolarityNLI(ctx context.Context, model, cachedQuery, incomingQuery string) polarityNLIVerdict {
 	start := time.Now()
-	verifier := polarityVerifier
+	verifier := loadPolarityVerifier()
 	if verifier == nil {
 		c.recordPolarityNLISkipped(model, "polarity verifier not configured")
 		return polarityNLIVerdict{Skipped: true}

--- a/src/semantic-router/pkg/cache/inmemory_cache_search.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache_search.go
@@ -166,7 +166,7 @@ func (c *InMemoryCache) LookupSimilarWithThreshold(ctx context.Context, model st
 	)
 
 	return c.finishFindSimilarSearch(
-		start, model, threshold,
+		ctx, start, model, query, threshold,
 		bestIndex, bestEntry, bestSimilarity, entriesChecked, expiredCount,
 	)
 }
@@ -194,8 +194,10 @@ func (c *InMemoryCache) runFindSimilarEmbeddingSearch(queryEmbedding []float32, 
 }
 
 func (c *InMemoryCache) finishFindSimilarSearch(
+	ctx context.Context,
 	start time.Time,
 	model string,
+	query string,
 	threshold float32,
 	bestIndex int,
 	bestEntry CacheEntry,
@@ -221,6 +223,13 @@ func (c *InMemoryCache) finishFindSimilarSearch(
 	}
 
 	if bestSimilarity >= threshold {
+		// NLI polarity tier (#2751): verify the single winning candidate once,
+		// outside the cache lock, before it is served or its access info is
+		// touched.
+		if result, handled, err := c.applyPolarityNLI(ctx, start, model, query, bestEntry, bestSimilarity, threshold); handled {
+			return result, err
+		}
+
 		atomic.AddInt64(&c.hitCount, 1)
 
 		c.mu.Lock()

--- a/src/semantic-router/pkg/cache/inmemory_cache_stub.go
+++ b/src/semantic-router/pkg/cache/inmemory_cache_stub.go
@@ -20,6 +20,7 @@ type InMemoryCacheOptions struct {
 	HNSWM               int
 	HNSWEfConstruction  int
 	EmbeddingModel      string
+	PolarityGuard       PolarityGuardOptions
 }
 
 // NewInMemoryCache creates a new in-memory cache instance

--- a/src/semantic-router/pkg/cache/polarity_nli.go
+++ b/src/semantic-router/pkg/cache/polarity_nli.go
@@ -1,0 +1,36 @@
+package cache
+
+import "context"
+
+// PolarityVerifyFunc scores how strongly incomingQuery contradicts cachedQuery as
+// a probability in [0, 1]. The NLI direction is fixed: premise = cached query,
+// hypothesis = incoming query. It runs once per lookup on the single winning
+// candidate, never per entry inside the scan.
+type PolarityVerifyFunc func(ctx context.Context, cachedQuery, incomingQuery string) (contradiction float32, err error)
+
+// PolarityGuardOptions configures the optional NLI polarity tier (#2751) of the
+// in-memory semantic cache. The lexical tier (#2691) is the unconditional floor;
+// this tier verifies the best above-threshold candidate outside the cache lock
+// and rejects the hit when the contradiction probability exceeds
+// ContradictionThreshold.
+type PolarityGuardOptions struct {
+	UseNLI                 bool
+	ContradictionThreshold float32
+}
+
+// The verifier is injected once at startup by the classification lifecycle
+// (classification.initializeSemanticCacheNLI), mirroring
+// looper.SetGroundingBackends, so pkg/cache never imports pkg/classification and
+// the guard stays unit-testable with a fake.
+var polarityVerifier PolarityVerifyFunc
+
+// SetPolarityVerifier wires the NLI backend used by the polarity guard. Safe to
+// call again to replace it; nil leaves the tier unavailable, and lookups then
+// fail open (the threshold-verified hit is served).
+func SetPolarityVerifier(fn PolarityVerifyFunc) {
+	polarityVerifier = fn
+}
+
+// polarityGuardTierNLI labels NLI-tier telemetry so it can be told apart from
+// the lexical tier's events.
+const polarityGuardTierNLI = "nli"

--- a/src/semantic-router/pkg/cache/polarity_nli.go
+++ b/src/semantic-router/pkg/cache/polarity_nli.go
@@ -1,6 +1,9 @@
 package cache
 
-import "context"
+import (
+	"context"
+	"sync/atomic"
+)
 
 // PolarityVerifyFunc scores how strongly incomingQuery contradicts cachedQuery as
 // a probability in [0, 1]. The NLI direction is fixed: premise = cached query,
@@ -18,17 +21,31 @@ type PolarityGuardOptions struct {
 	ContradictionThreshold float32
 }
 
-// The verifier is injected once at startup by the classification lifecycle
+// The verifier is injected by the classification lifecycle
 // (classification.initializeSemanticCacheNLI), mirroring
 // looper.SetGroundingBackends, so pkg/cache never imports pkg/classification and
-// the guard stays unit-testable with a fake.
-var polarityVerifier PolarityVerifyFunc
+// the guard stays unit-testable with a fake. It is held atomically because a
+// config reload re-runs the classifier runtime tasks — and therefore this
+// injection — while the previous router is still serving lookups.
+var polarityVerifier atomic.Pointer[PolarityVerifyFunc]
 
 // SetPolarityVerifier wires the NLI backend used by the polarity guard. Safe to
-// call again to replace it; nil leaves the tier unavailable, and lookups then
-// fail open (the threshold-verified hit is served).
+// call again, from any goroutine, to replace it; nil leaves the tier
+// unavailable, and lookups then fail open (the threshold-verified hit is served).
 func SetPolarityVerifier(fn PolarityVerifyFunc) {
-	polarityVerifier = fn
+	if fn == nil {
+		polarityVerifier.Store(nil)
+		return
+	}
+	polarityVerifier.Store(&fn)
+}
+
+// loadPolarityVerifier returns the currently injected verifier, or nil.
+func loadPolarityVerifier() PolarityVerifyFunc {
+	if p := polarityVerifier.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // polarityGuardTierNLI labels NLI-tier telemetry so it can be told apart from

--- a/src/semantic-router/pkg/cache/polarity_nli_regression_test.go
+++ b/src/semantic-router/pkg/cache/polarity_nli_regression_test.go
@@ -1,0 +1,128 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+)
+
+// Model-backed regression for #2751 through the production NLI binding and the
+// in-memory lookup finisher. It skips without the hallucination explainer
+// (models/mom-halugate-explainer, tasksource/ModernBERT-base-nli);
+// polarity_nli_test.go provides model-free coverage.
+
+// Each pair is {cached, incoming}; the incoming query means the opposite.
+var polarityNLIContradictionPairs = [][2]string{
+	{"How do I enable dark mode?", "How do I disable dark mode?"},
+	{"How do I reset my password?", "How do I not reset my password?"},
+	{"How do I open the file?", "How do I close the file?"},
+	{"How do I start the server?", "How do I stop the server?"},
+	{"How do I add a user?", "How do I remove a user?"},
+}
+
+// Paraphrases and synonyms must keep hitting; the NLI head treats
+// delete/remove as compatible, which the lexical antonym table cannot.
+var polarityNLIParaphrasePairs = [][2]string{
+	{"How do I reset my password?", "How can I reset my password?"},
+	{"How do I delete a user?", "How do I remove a user?"},
+}
+
+var nliExplainerInitOnce sync.Once
+
+func findNLIExplainerModel() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for i := 0; i < 8; i++ {
+		p := filepath.Join(dir, "models", "mom-halugate-explainer")
+		if st, statErr := os.Stat(p); statErr == nil && st.IsDir() {
+			return p
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+func ensureNLIExplainer(t *testing.T) {
+	t.Helper()
+	modelPath := findNLIExplainerModel()
+	if modelPath == "" {
+		t.Skip("NLI explainer model not found (models/mom-halugate-explainer); skipping model-backed regression")
+	}
+	var initErr error
+	nliExplainerInitOnce.Do(func() {
+		initErr = candle_binding.InitNLIModel(modelPath, true)
+	})
+	if initErr != nil {
+		t.Fatalf("failed to initialize NLI model %s: %v", modelPath, initErr)
+	}
+}
+
+// candleContradiction is the production verifier shape (see
+// classification.semanticCachePolarityVerifier) built here directly so the
+// cache package test does not import pkg/classification.
+func candleContradiction(_ context.Context, cached, incoming string) (float32, error) {
+	r, err := candle_binding.ClassifyNLI(cached, incoming)
+	if err != nil {
+		return 0, err
+	}
+	return r.ContradictProb, nil
+}
+
+func TestPolarityNLIRegression(t *testing.T) {
+	ensureNLIExplainer(t)
+	installVerifier(t, candleContradiction)
+
+	c := NewInMemoryCache(InMemoryCacheOptions{
+		SimilarityThreshold: polarityTestThreshold,
+		MaxEntries:          32,
+		Enabled:             true,
+		EvictionPolicy:      FIFOEvictionPolicyType,
+		PolarityGuard:       PolarityGuardOptions{UseNLI: true, ContradictionThreshold: 0.5},
+	})
+	t.Cleanup(func() { _ = c.Close() })
+
+	lookup := func(cached, incoming string) (LookupResult, float32) {
+		entry := CacheEntry{
+			RequestID: "r", Model: "m", Query: cached, ResponseBody: []byte("ANSWER"),
+			Embedding: []float32{1, 0, 0}, Timestamp: time.Now(),
+		}
+		contradiction, err := candleContradiction(context.Background(), cached, incoming)
+		if err != nil {
+			t.Fatalf("NLI classification failed for %q / %q: %v", cached, incoming, err)
+		}
+		result, err := c.finishFindSimilarSearch(context.Background(), time.Now(), entry.Model, incoming,
+			polarityTestThreshold, 0, entry, 1.0, 1, 0)
+		if err != nil {
+			t.Fatalf("lookup failed: %v", err)
+		}
+		return result, contradiction
+	}
+
+	for _, pair := range polarityNLIContradictionPairs {
+		result, contradiction := lookup(pair[0], pair[1])
+		if result.Found {
+			t.Errorf("%q / %q: served despite contradiction=%.3f", pair[0], pair[1], contradiction)
+		}
+		t.Logf("reject  %-38q -> %-38q contradiction=%.3f", pair[0], pair[1], contradiction)
+	}
+	for _, pair := range polarityNLIParaphrasePairs {
+		result, contradiction := lookup(pair[0], pair[1])
+		if !result.Found {
+			t.Errorf("%q / %q: rejected paraphrase, contradiction=%.3f", pair[0], pair[1], contradiction)
+		}
+		t.Logf("serve   %-38q -> %-38q contradiction=%.3f", pair[0], pair[1], contradiction)
+	}
+}

--- a/src/semantic-router/pkg/cache/polarity_nli_test.go
+++ b/src/semantic-router/pkg/cache/polarity_nli_test.go
@@ -1,0 +1,214 @@
+//go:build !windows && cgo
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests drive finishFindSimilarSearch directly with a hand-built
+// candidate so the NLI polarity tier is exercised without an embedding model.
+// polarity_nli_regression_test.go covers the model-backed path.
+
+const polarityTestThreshold = float32(0.80)
+
+func newPolarityTestCache(t *testing.T, useNLI bool) (*InMemoryCache, CacheEntry) {
+	t.Helper()
+	c := NewInMemoryCache(InMemoryCacheOptions{
+		SimilarityThreshold: polarityTestThreshold,
+		MaxEntries:          16,
+		TTLSeconds:          0, // keep updateAccessInfo off the expiration heap
+		Enabled:             true,
+		EvictionPolicy:      FIFOEvictionPolicyType,
+		PolarityGuard: PolarityGuardOptions{
+			UseNLI:                 useNLI,
+			ContradictionThreshold: 0.5,
+		},
+	})
+	t.Cleanup(func() { _ = c.Close() })
+	entry := CacheEntry{
+		RequestID:    "e1",
+		Model:        "model-x",
+		Query:        "How do I enable two-factor authentication?",
+		ResponseBody: []byte("ENABLE-ANSWER"),
+		Embedding:    []float32{1, 0, 0},
+		Timestamp:    time.Now(),
+	}
+	c.entries = append(c.entries, entry)
+	c.entryMap[entry.RequestID] = 0
+	return c, entry
+}
+
+// installVerifier swaps in a fake verifier for the test and restores the
+// package state afterwards.
+func installVerifier(t *testing.T, fn PolarityVerifyFunc) {
+	t.Helper()
+	previous := polarityVerifier
+	SetPolarityVerifier(fn)
+	t.Cleanup(func() { SetPolarityVerifier(previous) })
+}
+
+func finishWithCandidate(c *InMemoryCache, ctx context.Context, query string, entry CacheEntry) (LookupResult, error) {
+	const aboveThreshold = float32(1.0) // identical unit vectors
+	return c.finishFindSimilarSearch(ctx, time.Now(), entry.Model, query, polarityTestThreshold,
+		0, entry, aboveThreshold, 1, 0)
+}
+
+func TestPolarityNLIGuardRejectsContradiction(t *testing.T) {
+	c, entry := newPolarityTestCache(t, true)
+	var calls int32
+	var gotCached, gotIncoming string
+	installVerifier(t, func(_ context.Context, cached, incoming string) (float32, error) {
+		atomic.AddInt32(&calls, 1)
+		gotCached, gotIncoming = cached, incoming
+		return 0.97, nil
+	})
+
+	const query = "How do I disable two-factor authentication?"
+	result, err := finishWithCandidate(c, context.Background(), query, entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Found || result.ResponseBody != nil {
+		t.Fatalf("contradiction must be a miss, got %+v", result)
+	}
+	if result.Similarity != 1.0 {
+		t.Fatalf("rejected candidate score must still be reported, got %.4f", result.Similarity)
+	}
+	if calls != 1 {
+		t.Fatalf("verifier must run exactly once per lookup, ran %d times", calls)
+	}
+	if gotCached != entry.Query || gotIncoming != query {
+		t.Fatalf("verifier direction: premise=%q hypothesis=%q, want cached=%q incoming=%q",
+			gotCached, gotIncoming, entry.Query, query)
+	}
+	if atomic.LoadInt64(&c.missCount) != 1 || atomic.LoadInt64(&c.hitCount) != 0 {
+		t.Fatalf("reject must count as a miss: miss=%d hit=%d", c.missCount, c.hitCount)
+	}
+	if !c.entries[0].LastAccessAt.IsZero() || c.entries[0].HitCount != 0 {
+		t.Fatalf("rejected candidate must not have its access info touched: %+v", c.entries[0])
+	}
+}
+
+func TestPolarityNLIGuardServesCompatibleCandidate(t *testing.T) {
+	c, entry := newPolarityTestCache(t, true)
+	installVerifier(t, func(context.Context, string, string) (float32, error) { return 0.01, nil })
+
+	result, err := finishWithCandidate(c, context.Background(), "How can I enable two-factor authentication?", entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Found || string(result.ResponseBody) != "ENABLE-ANSWER" {
+		t.Fatalf("paraphrase must hit, got %+v", result)
+	}
+	if atomic.LoadInt64(&c.hitCount) != 1 || c.entries[0].HitCount != 1 || c.entries[0].LastAccessAt.IsZero() {
+		t.Fatalf("served hit must update counters and access info: hit=%d entry=%+v", c.hitCount, c.entries[0])
+	}
+}
+
+func TestPolarityNLIGuardThresholdIsExclusive(t *testing.T) {
+	c, entry := newPolarityTestCache(t, true)
+	installVerifier(t, func(context.Context, string, string) (float32, error) { return 0.5, nil })
+
+	result, err := finishWithCandidate(c, context.Background(), "How can I enable 2FA?", entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Found {
+		t.Fatal("contradiction equal to the threshold must not reject (guard is strictly greater-than)")
+	}
+}
+
+func TestPolarityNLIGuardDisabledNeverCallsVerifier(t *testing.T) {
+	c, entry := newPolarityTestCache(t, false)
+	installVerifier(t, func(context.Context, string, string) (float32, error) {
+		t.Fatal("verifier must not run when the NLI tier is off")
+		return 0, nil
+	})
+
+	result, err := finishWithCandidate(c, context.Background(), "How do I disable two-factor authentication?", entry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Found {
+		t.Fatal("with the NLI tier off the above-threshold candidate is served (lexical tier is #2728's scope)")
+	}
+}
+
+func TestPolarityNLIGuardFailsOpen(t *testing.T) {
+	t.Run("verifier error serves the hit", func(t *testing.T) {
+		c, entry := newPolarityTestCache(t, true)
+		installVerifier(t, func(context.Context, string, string) (float32, error) {
+			return 0, errors.New("nli backend unavailable")
+		})
+		result, err := finishWithCandidate(c, context.Background(), "How do I disable two-factor authentication?", entry)
+		if err != nil {
+			t.Fatalf("verifier errors must not surface to the caller: %v", err)
+		}
+		if !result.Found {
+			t.Fatal("verifier error must fail open and serve the threshold-verified hit")
+		}
+	})
+
+	t.Run("nil verifier serves the hit", func(t *testing.T) {
+		c, entry := newPolarityTestCache(t, true)
+		installVerifier(t, nil)
+		result, err := finishWithCandidate(c, context.Background(), "How do I disable two-factor authentication?", entry)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Found {
+			t.Fatal("unconfigured verifier must fail open")
+		}
+	})
+}
+
+func TestPolarityNLIGuardHonorsCancellation(t *testing.T) {
+	c, entry := newPolarityTestCache(t, true)
+	installVerifier(t, func(context.Context, string, string) (float32, error) {
+		t.Fatal("verifier must not run for a cancelled request")
+		return 0, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := finishWithCandidate(c, ctx, "How do I disable two-factor authentication?", entry)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got result=%+v err=%v", result, err)
+	}
+	if result.Found {
+		t.Fatal("cancelled lookup must not serve a result")
+	}
+}
+
+func TestPolarityNLIGuardBelowThresholdSkipsVerifier(t *testing.T) {
+	c, entry := newPolarityTestCache(t, true)
+	installVerifier(t, func(context.Context, string, string) (float32, error) {
+		t.Fatal("verifier must not run for a below-threshold candidate")
+		return 0, nil
+	})
+	result, err := c.finishFindSimilarSearch(context.Background(), time.Now(), entry.Model,
+		"Something unrelated", polarityTestThreshold, 0, entry, 0.42, 1, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Found || result.Similarity != 0.42 {
+		t.Fatalf("below-threshold candidate must miss with its score reported, got %+v", result)
+	}
+}
+
+func TestValidateCacheConfigPolarityThreshold(t *testing.T) {
+	base := GetDefaultCacheConfig()
+	base.PolarityGuard = PolarityGuardOptions{UseNLI: true, ContradictionThreshold: 1.5}
+	if err := ValidateCacheConfig(base); err == nil {
+		t.Fatal("contradiction threshold above 1.0 must be rejected when the NLI tier is on")
+	}
+	base.PolarityGuard.UseNLI = false
+	if err := ValidateCacheConfig(base); err != nil {
+		t.Fatalf("threshold is irrelevant with the NLI tier off: %v", err)
+	}
+}

--- a/src/semantic-router/pkg/cache/polarity_nli_test.go
+++ b/src/semantic-router/pkg/cache/polarity_nli_test.go
@@ -47,7 +47,7 @@ func newPolarityTestCache(t *testing.T, useNLI bool) (*InMemoryCache, CacheEntry
 // package state afterwards.
 func installVerifier(t *testing.T, fn PolarityVerifyFunc) {
 	t.Helper()
-	previous := polarityVerifier
+	previous := loadPolarityVerifier()
 	SetPolarityVerifier(fn)
 	t.Cleanup(func() { SetPolarityVerifier(previous) })
 }
@@ -199,6 +199,30 @@ func TestPolarityNLIGuardBelowThresholdSkipsVerifier(t *testing.T) {
 	if result.Found || result.Similarity != 0.42 {
 		t.Fatalf("below-threshold candidate must miss with its score reported, got %+v", result)
 	}
+}
+
+// TestPolarityNLIGuardVerifierReplacementIsRaceFree pins the reload contract:
+// SetPolarityVerifier may be called from another goroutine (a config reload
+// re-running the classifier runtime tasks) while lookups are in flight. Run
+// with -race.
+func TestPolarityNLIGuardVerifierReplacementIsRaceFree(t *testing.T) {
+	c, entry := newPolarityTestCache(t, true)
+	installVerifier(t, func(context.Context, string, string) (float32, error) { return 0.01, nil })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			score := float32(i%2) * 0.9 // alternate between rejecting and passing verifiers
+			SetPolarityVerifier(func(context.Context, string, string) (float32, error) { return score, nil })
+		}
+	}()
+	for i := 0; i < 200; i++ {
+		if _, err := finishWithCandidate(c, context.Background(), "How can I enable 2FA?", entry); err != nil {
+			t.Fatalf("lookup %d failed: %v", i, err)
+		}
+	}
+	<-done
 }
 
 func TestValidateCacheConfigPolarityThreshold(t *testing.T) {

--- a/src/semantic-router/pkg/classification/classifier_lifecycle.go
+++ b/src/semantic-router/pkg/classification/classifier_lifecycle.go
@@ -142,6 +142,9 @@ func (c *Classifier) runtimeTasks() []modelruntime.Task {
 	appendTask("classifier.keyword_embedding", false, c.IsKeywordEmbeddingClassifierEnabled(), c.initializeKeywordEmbeddingClassifier)
 	appendTask("classifier.fact_check", true, c.needsFactCheckModelForRuntime(), c.initializeFactCheckClassifier)
 	appendTask("classifier.hallucination", true, c.needsHallucinationDetectorForRuntime(), c.initializeHallucinationDetector)
+	// Not best-effort: an NLI polarity mode with an unloadable model must fail
+	// startup rather than silently serve unverified cache hits.
+	appendTask("classifier.semantic_cache_nli", false, c.needsSemanticCacheNLIForRuntime(), c.initializeSemanticCacheNLI)
 	appendTask("classifier.feedback", true, c.needsFeedbackModelForRuntime(), c.initializeFeedbackDetector)
 	appendTask("classifier.preference", true, c.IsPreferenceClassifierEnabled(), c.initializePreferenceClassifier)
 	appendTask("classifier.language", true, len(c.Config.LanguageRules) > 0, c.initializeLanguageClassifier)

--- a/src/semantic-router/pkg/classification/semantic_cache_polarity_lifecycle.go
+++ b/src/semantic-router/pkg/classification/semantic_cache_polarity_lifecycle.go
@@ -1,0 +1,61 @@
+package classification
+
+import (
+	"context"
+	"fmt"
+
+	candle "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// needsSemanticCacheNLIForRuntime reports whether the semantic cache's NLI
+// polarity tier (#2751) is configured and therefore needs the NLI model bound.
+func (c *Classifier) needsSemanticCacheNLIForRuntime() bool {
+	return c != nil && c.Config != nil && c.Config.NeedsLocalNLIForSemanticCache()
+}
+
+// initializeSemanticCacheNLI binds the hallucination explainer NLI model for the
+// semantic cache polarity guard and injects the verifier into pkg/cache. It is
+// registered as a non-best-effort runtime task so a missing or unloadable model
+// fails startup instead of silently leaving the guard unwired.
+//
+// The native binding holds one NLI model (candle.InitNLIModel is Once-guarded),
+// so this coexists with HallucinationDetector.InitializeNLI: whichever runs
+// first loads the model and the other call is a no-op.
+func (c *Classifier) initializeSemanticCacheNLI() error {
+	guard := c.Config.SemanticCache.PolarityGuard
+	capabilities := CurrentNativeBackendCapabilities()
+	if !capabilities.LocalHallucinationNLI {
+		return fmt.Errorf(
+			"native backend %q does not support local NLI; semantic_cache.polarity_guard mode %q requires the candle backend",
+			capabilities.Name, guard.NormalizedMode(),
+		)
+	}
+
+	nliCfg := c.Config.HallucinationMitigation.NLIModel
+	if err := candle.InitNLIModel(nliCfg.ModelID, nliCfg.UseCPU); err != nil {
+		return fmt.Errorf("failed to initialize NLI model %q for semantic cache polarity guard: %w", nliCfg.ModelID, err)
+	}
+
+	cache.SetPolarityVerifier(semanticCachePolarityVerifier)
+	logging.ComponentEvent("classifier", "semantic_cache_nli_initialized", map[string]interface{}{
+		"backend":                 "candle",
+		"model_ref":               nliCfg.ModelID,
+		"mode":                    guard.NormalizedMode(),
+		"contradiction_threshold": guard.EffectiveContradictionThreshold(),
+	})
+	return nil
+}
+
+// semanticCachePolarityVerifier scores the contradiction between a cached query
+// (NLI premise) and the incoming query (hypothesis). Only fields of the result
+// are accessed: the cgo binding returns a pointer while the compile-only stub
+// returns a value, and this file must build under both.
+func semanticCachePolarityVerifier(_ context.Context, cachedQuery, incomingQuery string) (float32, error) {
+	result, err := candle.ClassifyNLI(cachedQuery, incomingQuery)
+	if err != nil {
+		return 0, err
+	}
+	return result.ContradictProb, nil
+}

--- a/src/semantic-router/pkg/classification/semantic_cache_polarity_lifecycle_test.go
+++ b/src/semantic-router/pkg/classification/semantic_cache_polarity_lifecycle_test.go
@@ -1,0 +1,99 @@
+//go:build !windows && cgo
+
+package classification
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	candle "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func polarityTestConfig(enabled bool, mode, nliModel string) *config.RouterConfig {
+	cfg := &config.RouterConfig{}
+	cfg.SemanticCache.Enabled = enabled
+	if mode != "" {
+		cfg.SemanticCache.PolarityGuard = &config.PolarityGuardConfig{Mode: mode}
+	}
+	cfg.HallucinationMitigation.NLIModel.ModelID = nliModel
+	return cfg
+}
+
+func TestNeedsSemanticCacheNLIForRuntime(t *testing.T) {
+	var nilClassifier *Classifier
+	if nilClassifier.needsSemanticCacheNLIForRuntime() {
+		t.Fatal("nil classifier must not require the NLI model")
+	}
+	if (&Classifier{}).needsSemanticCacheNLIForRuntime() {
+		t.Fatal("classifier without config must not require the NLI model")
+	}
+
+	cases := []struct {
+		name string
+		cfg  *config.RouterConfig
+		want bool
+	}{
+		{"nli_mode", polarityTestConfig(true, "nli", "models/mom-halugate-explainer"), true},
+		{"lexical_nli_mode", polarityTestConfig(true, "lexical+nli", "models/mom-halugate-explainer"), true},
+		{"lexical_mode", polarityTestConfig(true, "lexical", "models/mom-halugate-explainer"), false},
+		{"cache_disabled", polarityTestConfig(false, "nli", "models/mom-halugate-explainer"), false},
+		{"no_model", polarityTestConfig(true, "nli", ""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Classifier{Config: tc.cfg}
+			if got := c.needsSemanticCacheNLIForRuntime(); got != tc.want {
+				t.Fatalf("needsSemanticCacheNLIForRuntime = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSemanticCacheNLIRuntimeTaskRegistration(t *testing.T) {
+	c := &Classifier{Config: polarityTestConfig(true, "nli", "models/mom-halugate-explainer")}
+	var task *string
+	for _, candidate := range c.runtimeTasks() {
+		if candidate.Name == "classifier.semantic_cache_nli" {
+			name := candidate.Name
+			task = &name
+			if candidate.BestEffort {
+				t.Fatal("semantic cache NLI init must not be best-effort: an unloadable model has to fail startup")
+			}
+		}
+	}
+	if task == nil {
+		t.Fatal("semantic cache NLI task not registered for an NLI polarity mode")
+	}
+
+	off := &Classifier{Config: polarityTestConfig(true, "lexical", "models/mom-halugate-explainer")}
+	for _, candidate := range off.runtimeTasks() {
+		if candidate.Name == "classifier.semantic_cache_nli" {
+			t.Fatal("semantic cache NLI task must not be registered for the lexical mode")
+		}
+	}
+}
+
+func TestInitializeSemanticCacheNLIFailsOnUnloadableModel(t *testing.T) {
+	if candle.IsNLIModelInitialized() {
+		t.Skip("an NLI model is already loaded in this process; the failure path cannot be observed")
+	}
+	c := &Classifier{Config: polarityTestConfig(true, "nli", "/nonexistent/semantic-cache-nli-model")}
+	err := c.initializeSemanticCacheNLI()
+	if err == nil {
+		t.Fatal("expected initialization to fail for an unloadable model path")
+	}
+	if !strings.Contains(err.Error(), "semantic cache polarity guard") && !strings.Contains(err.Error(), "does not support local NLI") {
+		t.Fatalf("error should name the polarity guard or the backend gap, got: %v", err)
+	}
+}
+
+func TestSemanticCachePolarityVerifierSurfacesBackendErrors(t *testing.T) {
+	if candle.IsNLIModelInitialized() {
+		t.Skip("an NLI model is loaded; the uninitialized error path cannot be observed")
+	}
+	if _, err := semanticCachePolarityVerifier(context.Background(), "premise", "hypothesis"); err == nil {
+		t.Fatal("verifier must return the binding error when no NLI model is loaded (the cache then fails open)")
+	}
+}

--- a/src/semantic-router/pkg/config/reference_config_global_test.go
+++ b/src/semantic-router/pkg/config/reference_config_global_test.go
@@ -172,17 +172,21 @@ func assertReferenceConfigStoreGlobalCoverage(t testingT, stores map[string]inte
 func assertReferenceConfigSemanticCacheCoverage(t testingT, semanticCache map[string]interface{}) {
 	assertMapCoversStructFields(t, semanticCache, reflect.TypeOf(responseCacheStoreReference{}), "global.stores.response_cache")
 	assertMapCoversStructFields(t, mustMapAt(t, semanticCache, "milvus"), reflect.TypeOf(MilvusConfig{}), "global.stores.response_cache.milvus")
+	polarityGuard := mustMapAt(t, semanticCache, "polarity_guard")
+	assertMapCoversStructFields(t, polarityGuard, reflect.TypeOf(PolarityGuardConfig{}), "global.stores.response_cache.polarity_guard")
+	assertMapCoversStructFields(t, mustMapAt(t, polarityGuard, "nli"), reflect.TypeOf(PolarityGuardNLIConfig{}), "global.stores.response_cache.polarity_guard.nli")
 }
 
 type responseCacheStoreReference struct {
-	BackendType         string        `yaml:"backend_type,omitempty"`
-	Enabled             bool          `yaml:"enabled"`
-	SimilarityThreshold *float32      `yaml:"similarity_threshold,omitempty"`
-	MaxEntries          int           `yaml:"max_entries,omitempty"`
-	TTLSeconds          int           `yaml:"ttl_seconds,omitempty"`
-	EvictionPolicy      string        `yaml:"eviction_policy,omitempty"`
-	Milvus              *MilvusConfig `yaml:"milvus,omitempty"`
-	EmbeddingModel      string        `yaml:"embedding_model,omitempty"`
+	BackendType         string               `yaml:"backend_type,omitempty"`
+	Enabled             bool                 `yaml:"enabled"`
+	SimilarityThreshold *float32             `yaml:"similarity_threshold,omitempty"`
+	MaxEntries          int                  `yaml:"max_entries,omitempty"`
+	TTLSeconds          int                  `yaml:"ttl_seconds,omitempty"`
+	EvictionPolicy      string               `yaml:"eviction_policy,omitempty"`
+	Milvus              *MilvusConfig        `yaml:"milvus,omitempty"`
+	EmbeddingModel      string               `yaml:"embedding_model,omitempty"`
+	PolarityGuard       *PolarityGuardConfig `yaml:"polarity_guard,omitempty"`
 }
 
 func assertReferenceConfigMemoryCoverage(t testingT, memory map[string]interface{}) {

--- a/src/semantic-router/pkg/config/response_cache_polarity_config.go
+++ b/src/semantic-router/pkg/config/response_cache_polarity_config.go
@@ -1,0 +1,80 @@
+package config
+
+import "strings"
+
+// Semantic-cache polarity guard modes.
+//
+// The lexical tier (#2691) is the unconditional, model-free floor: it is never
+// switched off by this setting. The NLI tier (#2751) is opt-in and verifies the
+// single best above-threshold candidate with the shared hallucination explainer
+// NLI model before it is served.
+const (
+	PolarityGuardModeLexical    = "lexical"
+	PolarityGuardModeNLI        = "nli"
+	PolarityGuardModeLexicalNLI = "lexical+nli"
+
+	// DefaultPolarityContradictionThreshold is the NLI contradiction probability
+	// above which a cache candidate is rejected.
+	DefaultPolarityContradictionThreshold float32 = 0.5
+)
+
+// PolarityGuardConfig configures the semantic-cache negation/antonym guard.
+type PolarityGuardConfig struct {
+	// Mode selects the guard tiers: "lexical" (default), "nli", or "lexical+nli".
+	Mode string `yaml:"mode,omitempty"`
+	// NLI tunes the optional NLI tier.
+	NLI PolarityGuardNLIConfig `yaml:"nli,omitempty"`
+}
+
+// PolarityGuardNLIConfig tunes the NLI polarity tier.
+//
+// The tier does not bind its own model: the native binding holds exactly one
+// NLI model, so it reuses the hallucination explainer configured under
+// global.model_catalog.modules.hallucination_mitigation.explainer.
+type PolarityGuardNLIConfig struct {
+	// ContradictionThreshold rejects the candidate when the contradiction
+	// probability exceeds it. Defaults to DefaultPolarityContradictionThreshold.
+	ContradictionThreshold *float32 `yaml:"contradiction_threshold,omitempty"`
+}
+
+// NormalizedMode returns the trimmed, lower-cased mode, defaulting to lexical.
+// It is nil-safe so an absent polarity_guard block reads as the default.
+func (c *PolarityGuardConfig) NormalizedMode() string {
+	if c == nil {
+		return PolarityGuardModeLexical
+	}
+	mode := strings.ToLower(strings.TrimSpace(c.Mode))
+	if mode == "" {
+		return PolarityGuardModeLexical
+	}
+	return mode
+}
+
+// UsesNLI reports whether the NLI tier is enabled by the configured mode.
+func (c *PolarityGuardConfig) UsesNLI() bool {
+	switch c.NormalizedMode() {
+	case PolarityGuardModeNLI, PolarityGuardModeLexicalNLI:
+		return true
+	default:
+		return false
+	}
+}
+
+// EffectiveContradictionThreshold returns the configured NLI contradiction
+// threshold or the default when unset.
+func (c *PolarityGuardConfig) EffectiveContradictionThreshold() float32 {
+	if c == nil || c.NLI.ContradictionThreshold == nil {
+		return DefaultPolarityContradictionThreshold
+	}
+	return *c.NLI.ContradictionThreshold
+}
+
+// polarityGuardModeSupported reports whether mode is a known guard mode.
+func polarityGuardModeSupported(mode string) bool {
+	switch mode {
+	case PolarityGuardModeLexical, PolarityGuardModeNLI, PolarityGuardModeLexicalNLI:
+		return true
+	default:
+		return false
+	}
+}

--- a/src/semantic-router/pkg/config/response_cache_polarity_config_test.go
+++ b/src/semantic-router/pkg/config/response_cache_polarity_config_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPolarityGuardConfigDefaults(t *testing.T) {
+	var nilGuard *PolarityGuardConfig
+	if got := nilGuard.NormalizedMode(); got != PolarityGuardModeLexical {
+		t.Fatalf("nil guard mode = %q, want %q", got, PolarityGuardModeLexical)
+	}
+	if nilGuard.UsesNLI() {
+		t.Fatal("nil guard must not enable the NLI tier")
+	}
+	if got := nilGuard.EffectiveContradictionThreshold(); got != DefaultPolarityContradictionThreshold {
+		t.Fatalf("nil guard threshold = %v, want %v", got, DefaultPolarityContradictionThreshold)
+	}
+
+	cases := []struct {
+		mode     string
+		wantMode string
+		wantNLI  bool
+	}{
+		{"", PolarityGuardModeLexical, false},
+		{"lexical", PolarityGuardModeLexical, false},
+		{"  NLI ", PolarityGuardModeNLI, true},
+		{"lexical+nli", PolarityGuardModeLexicalNLI, true},
+		{"Lexical+NLI", PolarityGuardModeLexicalNLI, true},
+	}
+	for _, tc := range cases {
+		guard := &PolarityGuardConfig{Mode: tc.mode}
+		if got := guard.NormalizedMode(); got != tc.wantMode {
+			t.Errorf("mode %q normalized = %q, want %q", tc.mode, got, tc.wantMode)
+		}
+		if got := guard.UsesNLI(); got != tc.wantNLI {
+			t.Errorf("mode %q UsesNLI = %v, want %v", tc.mode, got, tc.wantNLI)
+		}
+	}
+
+	custom := &PolarityGuardConfig{NLI: PolarityGuardNLIConfig{ContradictionThreshold: f32(0.7)}}
+	if got := custom.EffectiveContradictionThreshold(); got != 0.7 {
+		t.Fatalf("explicit threshold = %v, want 0.7", got)
+	}
+}
+
+func TestValidatePolarityGuard(t *testing.T) {
+	withGuard := func(enabled bool, guard *PolarityGuardConfig, nliModel string) *RouterConfig {
+		cfg := &RouterConfig{}
+		cfg.SemanticCache.Enabled = enabled
+		cfg.SemanticCache.PolarityGuard = guard
+		cfg.HallucinationMitigation.NLIModel.ModelID = nliModel
+		return cfg
+	}
+
+	cases := []struct {
+		name    string
+		cfg     *RouterConfig
+		wantErr string
+	}{
+		{"absent_block_ok", withGuard(true, nil, ""), ""},
+		{"lexical_without_model_ok", withGuard(true, &PolarityGuardConfig{Mode: "lexical"}, ""), ""},
+		{"nli_with_model_ok", withGuard(true, &PolarityGuardConfig{Mode: "nli"}, "models/mom-halugate-explainer"), ""},
+		{"lexical_nli_with_model_ok", withGuard(true, &PolarityGuardConfig{Mode: "lexical+nli"}, "models/mom-halugate-explainer"), ""},
+		{"nli_without_model_rejected", withGuard(true, &PolarityGuardConfig{Mode: "nli"}, ""), "hallucination_mitigation.explainer"},
+		{"nli_without_model_on_disabled_cache_ok", withGuard(false, &PolarityGuardConfig{Mode: "nli"}, ""), ""},
+		{"unknown_mode_rejected", withGuard(true, &PolarityGuardConfig{Mode: "cross-encoder"}, "models/x"), `mode must be one of`},
+		{"threshold_above_one_rejected", withGuard(true, &PolarityGuardConfig{
+			Mode: "nli", NLI: PolarityGuardNLIConfig{ContradictionThreshold: f32(1.5)},
+		}, "models/x"), "contradiction_threshold"},
+		{"threshold_negative_rejected", withGuard(true, &PolarityGuardConfig{
+			Mode: "lexical", NLI: PolarityGuardNLIConfig{ContradictionThreshold: f32(-0.1)},
+		}, ""), "contradiction_threshold"},
+		{"threshold_bounds_ok", withGuard(true, &PolarityGuardConfig{
+			Mode: "nli", NLI: PolarityGuardNLIConfig{ContradictionThreshold: f32(1.0)},
+		}, "models/x"), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSemanticCacheContracts(tc.cfg)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not mention %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNeedsLocalNLIForSemanticCache(t *testing.T) {
+	build := func(enabled bool, mode string, nliModel string) *RouterConfig {
+		cfg := &RouterConfig{}
+		cfg.SemanticCache.Enabled = enabled
+		if mode != "" {
+			cfg.SemanticCache.PolarityGuard = &PolarityGuardConfig{Mode: mode}
+		}
+		cfg.HallucinationMitigation.NLIModel.ModelID = nliModel
+		return cfg
+	}
+
+	var nilCfg *RouterConfig
+	if nilCfg.NeedsLocalNLIForSemanticCache() {
+		t.Fatal("nil config must not require the NLI model")
+	}
+
+	cases := []struct {
+		name string
+		cfg  *RouterConfig
+		want bool
+	}{
+		{"nli_mode_enabled_cache_with_model", build(true, "nli", "models/mom-halugate-explainer"), true},
+		{"lexical_nli_mode_enabled_cache_with_model", build(true, "lexical+nli", "models/mom-halugate-explainer"), true},
+		{"lexical_mode", build(true, "lexical", "models/mom-halugate-explainer"), false},
+		{"absent_guard", build(true, "", "models/mom-halugate-explainer"), false},
+		{"disabled_cache", build(false, "nli", "models/mom-halugate-explainer"), false},
+		{"no_model_configured", build(true, "nli", ""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.NeedsLocalNLIForSemanticCache(); got != tc.want {
+				t.Fatalf("NeedsLocalNLIForSemanticCache = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// The NLI tier never requires the hallucination plugin: the explainer model
+	// is bound for the cache even when hallucination mitigation is off.
+	cfg := build(true, "nli", "models/mom-halugate-explainer")
+	if cfg.NeedsLocalHallucinationNLIForRouting() || cfg.NeedsLocalHallucinationNLIForAPI() {
+		t.Fatal("cache-only NLI must not be reported as a hallucination consumer")
+	}
+}

--- a/src/semantic-router/pkg/config/routing_signal_usage.go
+++ b/src/semantic-router/pkg/config/routing_signal_usage.go
@@ -218,6 +218,17 @@ func (c *RouterConfig) NeedsLocalHallucinationNLIForRouting() bool {
 	return false
 }
 
+// NeedsLocalNLIForSemanticCache reports whether the enabled semantic cache runs
+// the NLI polarity tier, which binds the hallucination explainer model. The
+// native binding holds a single NLI model shared by every consumer, so this is
+// the only model the tier can use.
+func (c *RouterConfig) NeedsLocalNLIForSemanticCache() bool {
+	return c != nil &&
+		c.SemanticCache.Enabled &&
+		c.SemanticCache.PolarityGuard.UsesNLI() &&
+		c.HallucinationMitigation.NLIModel.ModelID != ""
+}
+
 func (c *RouterConfig) routingConsumerDecisions() []Decision {
 	if c == nil {
 		return nil

--- a/src/semantic-router/pkg/config/runtime_config.go
+++ b/src/semantic-router/pkg/config/runtime_config.go
@@ -222,6 +222,9 @@ type ResponseCacheStoreConfig struct {
 	Milvus              *MilvusConfig `yaml:"milvus,omitempty"`
 	Qdrant              *QdrantConfig `yaml:"qdrant,omitempty"`
 	EmbeddingModel      string        `yaml:"embedding_model,omitempty"`
+	// PolarityGuard configures the negation/antonym guard; nil means the
+	// lexical default with the NLI tier off.
+	PolarityGuard *PolarityGuardConfig `yaml:"polarity_guard,omitempty"`
 }
 
 // SemanticCache is retained for source compatibility.

--- a/src/semantic-router/pkg/config/validator_semantic_cache.go
+++ b/src/semantic-router/pkg/config/validator_semantic_cache.go
@@ -27,7 +27,45 @@ func validateGlobalSemanticCacheContracts(cfg *RouterConfig) error {
 	if cfg == nil {
 		return nil
 	}
-	return validateCacheThreshold(cfg.SemanticCache.SimilarityThreshold, "global semantic_cache")
+	if err := validateCacheThreshold(cfg.SemanticCache.SimilarityThreshold, "global semantic_cache"); err != nil {
+		return err
+	}
+	return validatePolarityGuard(cfg)
+}
+
+// validatePolarityGuard enforces the polarity guard contract at config load: a
+// known mode, an NLI contradiction threshold in [0.0, 1.0], and — when an NLI
+// mode is selected on an enabled cache — a configured hallucination explainer,
+// because the NLI tier binds that shared model. Failing here is deliberate:
+// the issue contract is "validate early", not "discover at the first lookup".
+func validatePolarityGuard(cfg *RouterConfig) error {
+	guard := cfg.SemanticCache.PolarityGuard
+	if guard == nil {
+		return nil
+	}
+	const scope = "global semantic_cache polarity_guard"
+	mode := guard.NormalizedMode()
+	if !polarityGuardModeSupported(mode) {
+		return fmt.Errorf(
+			"%s mode must be one of %q, %q, or %q, got %q",
+			scope,
+			PolarityGuardModeLexical,
+			PolarityGuardModeNLI,
+			PolarityGuardModeLexicalNLI,
+			guard.Mode,
+		)
+	}
+	if t := guard.NLI.ContradictionThreshold; t != nil && (*t < 0.0 || *t > 1.0) {
+		return fmt.Errorf("%s nli.contradiction_threshold must be between 0.0 and 1.0, got %.2f", scope, *t)
+	}
+	if cfg.SemanticCache.Enabled && guard.UsesNLI() &&
+		strings.TrimSpace(cfg.HallucinationMitigation.NLIModel.ModelID) == "" {
+		return fmt.Errorf(
+			"%s mode %q requires an NLI model: configure global.model_catalog.modules.hallucination_mitigation.explainer (model_ref or model_id)",
+			scope, mode,
+		)
+	}
+	return nil
 }
 
 func validateDecisionSemanticCacheContracts(cfg *RouterConfig) error {

--- a/src/semantic-router/pkg/extproc/router_components.go
+++ b/src/semantic-router/pkg/extproc/router_components.go
@@ -63,6 +63,10 @@ func createSemanticCache(cfg *config.RouterConfig) (cache.CacheBackend, error) {
 		Milvus:              semanticCacheCfg.Milvus,
 		Qdrant:              semanticCacheCfg.Qdrant,
 		EmbeddingModel:      detectSemanticCacheEmbeddingModel(cfg),
+		PolarityGuard: cache.PolarityGuardOptions{
+			UseNLI:                 semanticCacheCfg.PolarityGuard.UsesNLI(),
+			ContradictionThreshold: semanticCacheCfg.PolarityGuard.EffectiveContradictionThreshold(),
+		},
 	}
 
 	if cacheConfig.BackendType == "" {
@@ -80,6 +84,7 @@ func createSemanticCache(cfg *config.RouterConfig) (cache.CacheBackend, error) {
 			"similarity_threshold": cacheConfig.SimilarityThreshold,
 			"ttl_seconds":          cacheConfig.TTLSeconds,
 			"max_entries":          cacheConfig.MaxEntries,
+			"polarity_guard_mode":  semanticCacheCfg.PolarityGuard.NormalizedMode(),
 		})
 	} else {
 		logging.ComponentEvent("extproc", "semantic_cache_disabled", map[string]interface{}{

--- a/src/semantic-router/pkg/modeldownload/feature_gates.go
+++ b/src/semantic-router/pkg/modeldownload/feature_gates.go
@@ -68,7 +68,8 @@ var optionalModelFeatureGates = []modelFeatureGate{
 	{
 		enabled: func(cfg *config.RouterConfig) bool {
 			return cfg.NeedsLocalHallucinationNLIForAPI() ||
-				cfg.NeedsLocalHallucinationNLIForRouting()
+				cfg.NeedsLocalHallucinationNLIForRouting() ||
+				cfg.NeedsLocalNLIForSemanticCache()
 		},
 		paths: func(cfg *config.RouterConfig) []string {
 			return []string{cfg.HallucinationMitigation.NLIModel.ModelID}

--- a/tools/agent/docs/tech-debt/README.md
+++ b/tools/agent/docs/tech-debt/README.md
@@ -60,6 +60,7 @@ Every entry uses these sections:
 - [TD044: Flow tool-state durability](td-044-flow-tool-state-durability-gap.md)
 - [TD045: Reviewed content moderation](td-045-reviewed-content-moderation.md)
 - [TD046: ONNX binding CI coverage](td-046-onnx-binding-ci-coverage-gap.md)
+- [TD047: Response-cache polarity guard surface mirrors](td-047-response-cache-polarity-guard-surface-mirrors.md)
 
 If a gap becomes release-critical, move ownership to the active release plan
 and update both indexes in the same change.

--- a/tools/agent/docs/tech-debt/td-047-response-cache-polarity-guard-surface-mirrors.md
+++ b/tools/agent/docs/tech-debt/td-047-response-cache-polarity-guard-surface-mirrors.md
@@ -1,0 +1,70 @@
+# TD047: Response-Cache Polarity Guard Is Not Mirrored On CRD And Dashboard Surfaces
+
+## Status
+
+Open
+
+## Owner Plan
+
+[PL-0032: Architecture Debt Consolidation](../plans/pl-0032-architecture-scorecard-ratchet.md)
+
+## Release Relevance
+
+Not release-blocking. The guard is opt-in and defaults to the existing
+behaviour; only operators who configure the router through the Kubernetes CRD
+or the dashboard config editor cannot yet reach it.
+
+## Scope
+
+`global.stores.response_cache.polarity_guard` across the router config contract,
+the operator CRD, and the dashboard config types.
+
+## Summary
+
+The router config contract owns `polarity_guard` (`mode`, `nli.contradiction_threshold`)
+on `ResponseCacheStoreConfig`, and the reference config, validator, docs, and
+E2E coverage were updated with it. The two derived config surfaces that mirror
+store fields by hand were intentionally left unchanged so the runtime change
+stayed on one seam:
+
+- the operator CRD `SemanticCacheConfig` lists cache fields explicitly and has no
+  `polarity_guard` block, so CRD-driven deployments cannot enable the NLI tier;
+- the dashboard `response_cache` config type lists cache fields explicitly and
+  does not expose `polarity_guard`, so the config editor neither shows nor
+  round-trips it through schema-driven forms.
+
+The Python CLI needs no change: it does not type `global.stores` and passes the
+block through.
+
+## Evidence
+
+- `src/semantic-router/pkg/config/runtime_config.go` — `PolarityGuard` on
+  `ResponseCacheStoreConfig`.
+- `deploy/operator/api/v1alpha1/semanticrouter_types.go` — `SemanticCacheConfig`
+  enumerates `backend_type`, `similarity_threshold`, `max_entries`, `ttl_seconds`,
+  `eviction_policy`, backend blocks, and `embedding_model` only.
+- `dashboard/frontend/src/types/config.ts` — `response_cache` type enumerates
+  `enabled`, `backend_type`, `similarity_threshold`, `max_entries`,
+  `ttl_seconds`, `eviction_policy` only.
+
+## Why It Matters
+
+Hand-mirrored config surfaces drift silently: a field that exists in the router
+contract but not in the CRD or dashboard type is either unreachable or dropped
+on save, and neither failure is reported. The `config-platform-change` skill
+requires such gaps to be recorded rather than left implicit.
+
+## Desired End State
+
+`polarity_guard` is reachable from every config surface that exposes
+`response_cache`, or the mirrors are generated from the router contract so the
+next store field cannot drift.
+
+## Exit Criteria
+
+- The operator CRD accepts `polarity_guard` and the controller translates it
+  into the canonical config.
+- The dashboard config type and the safety/cache section expose `mode` and
+  `nli.contradiction_threshold` and round-trip them on save.
+- A test on each surface fails when a `ResponseCacheStoreConfig` field is
+  missing from the mirror.

--- a/tools/agent/repo-manifest.yaml
+++ b/tools/agent/repo-manifest.yaml
@@ -150,6 +150,7 @@ docs:
 - tools/agent/docs/tech-debt/td-044-flow-tool-state-durability-gap.md
 - tools/agent/docs/tech-debt/td-045-reviewed-content-moderation.md
 - tools/agent/docs/tech-debt/td-046-onnx-binding-ci-coverage-gap.md
+- tools/agent/docs/tech-debt/td-047-response-cache-polarity-guard-surface-mirrors.md
 local_agent_rules:
 - path: src/vllm-sr/cli/AGENTS.md
   scope: src/vllm-sr/cli/**
@@ -311,6 +312,9 @@ doc_governance:
   - path: tools/agent/docs/tech-debt/td-046-onnx-binding-ci-coverage-gap.md
     steward: agent-contract
     freshness: update when mandatory ONNX binding CI coverage changes
+  - path: tools/agent/docs/tech-debt/td-047-response-cache-polarity-guard-surface-mirrors.md
+    steward: router-core
+    freshness: update when the operator CRD or dashboard config surfaces expose response_cache.polarity_guard
 skills:
 - tools/agent/skills/config-platform-change/SKILL.md
 - tools/agent/skills/harness-contract-change/SKILL.md

--- a/website/docs/tutorials/global/stores-and-tools.md
+++ b/website/docs/tutorials/global/stores-and-tools.md
@@ -39,7 +39,37 @@ global:
       enabled: true
       backend_type: memory
       similarity_threshold: 0.8
+      polarity_guard:
+        mode: lexical          # lexical | nli | lexical+nli
+        nli:
+          contradiction_threshold: 0.5
 ```
+
+#### Negation guard
+
+Bi-encoder similarity cannot tell *"turn on dark mode"* from *"turn off dark
+mode"*: opposite-meaning queries often score above `similarity_threshold`
+while genuine paraphrases score below it, so raising the threshold does not
+fix the false hit. `polarity_guard` verifies the winning candidate before the
+in-memory backend serves it:
+
+- `lexical` (default): the model-free tier that catches negation cues and
+  known antonym swaps. It is always on and needs no model.
+- `nli` / `lexical+nli`: additionally runs the router's NLI model once per
+  lookup on the single best candidate and rejects the hit when the
+  contradiction probability exceeds `nli.contradiction_threshold`. The tier
+  reuses the hallucination explainer
+  (`global.model_catalog.modules.hallucination_mitigation.explainer`, by default
+  `tasksource/ModernBERT-base-nli`); the native binding holds one NLI model, so
+  the guard cannot bind a different one. Config loading fails when an NLI mode
+  is selected without that model. Expect roughly 70 ms per verified hit on CPU;
+  a cache hit still saves a full generation. If the model errors at lookup
+  time the guard fails open: the hit is served and a
+  `cache_polarity_nli_skipped` warning is logged.
+
+Rejections are logged as `cache_negation_reject` with `tier: nli`, count as
+misses, and still surface the rejected score on `x-vsr-cache-similarity`. Remote
+and hybrid cache backends do not run the guard.
 
 ### Memory
 

--- a/website/docs/tutorials/plugin/response-cache.md
+++ b/website/docs/tutorials/plugin/response-cache.md
@@ -86,6 +86,14 @@ hash-chained audit view under `/api/v1/response-cache/*`. Invalidation defaults
 to dry-run. Flush requires the explicit confirmation phrase
 `flush response cache` and never calls backend-wide `FLUSHALL`.
 
+The in-memory backend can verify a semantic hit against opposite-meaning
+queries before serving it (`global.stores.response_cache.polarity_guard`; see
+[Stores and Tools](../global/stores-and-tools.md#negation-guard)). With the
+optional NLI tier enabled, a rejected candidate is logged as
+`cache_negation_reject` with `tier: nli`, is reported as a miss, and its
+similarity still appears on `x-vsr-cache-similarity` so near-threshold
+rejections stay diagnosable.
+
 Cached responses can contain user or tenant data. Choose an appropriate scope,
 TTL, backend authentication, encryption, and invalidation process. Semantic
 thresholds must be calibrated for the configured embedding model, and routes


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #2751
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

The semantic cache picks a cached answer by embedding similarity. Opposite questions like "How do I turn on dark mode?" and "How do I turn off dark mode?" score above the similarity threshold, so the cache can return the wrong answer (#2691). Raising the threshold does not help, because real paraphrases often score lower than these opposites.

This PR adds an optional second check. When it is turned on, the in-memory cache runs the router's NLI model once on the best candidate before serving it. If the model says the two questions contradict each other, the cache treats it as a miss.

New config under global.stores.response_cache:

polarity_guard:
  mode: lexical          # lexical (default) | nli | lexical+nli
  nli:
    contradiction_threshold: 0.5

- Default lexical changes nothing. Only nli and lexical+nli turn the check on.
- The check runs once per lookup, outside the cache lock, only on the winning candidate.
- A rejected candidate is a normal miss. It logs cache_negation_reject with tier: nli and still reports its score on x-vsr-cache-similarity.
- If the model fails at lookup time, the cache serves the hit anyway and logs a cache_polarity_nli_skipped warning (fail open).
- The model is the hallucination explainer already in the model catalog (tasksource/ModernBERT-base-nli). The native binding can only hold one NLI model, so the guard reuses it instead of taking its own model_id. This is the one difference from the issue text.
- Config loading fails if an NLI mode is set without that model. Startup fails if the model cannot load.
- The lexical tier itself is #2728. This PR only adds the NLI tier and the config knob.

## Affected modules:

- pkg/config: PolarityGuardConfig, validation, NeedsLocalNLIForSemanticCache(), reference config
- pkg/cache: SetPolarityVerifier injection, options, the check in finishFindSimilarSearch
- pkg/classification: classifier.semantic_cache_nli runtime task loads the model and injects the verifier
- pkg/extproc: passes the config into the cache
- pkg/modeldownload, pkg/apiserver: download and /models reporting use the new predicate
- docs: stores-and-tools.md, response-cache.md
- e2e: new semantic-cache-polarity case on the production-stack profile
- tools/agent/docs/tech-debt/td-047: the operator CRD and dashboard do not expose polarity_guard yet

Out of scope: hybrid and remote cache backends, CRD and dashboard mirrors.


## Test Plan

Unit and gates:

make agent-validate
make agent-lint CHANGED_FILES="<changed files>"
make agent-ci-gate ENV=cpu CHANGED_FILES="<changed files>"
cd src/semantic-router
go test ./pkg/config/ ./pkg/modeldownload/ -count=1
go test ./pkg/cache/ ./pkg/classification/ ./pkg/extproc/ ./pkg/apiserver/ -count=1
go test ./pkg/cache/ ./pkg/classification/ -race -run 'Polarity|SemanticCache' -count=1

New tests:

- pkg/config: mode and threshold validation, missing-model error, NeedsLocalNLIForSemanticCache
- pkg/cache/polarity_nli_test.go: reject, serve, threshold is strict, fail open on error and on missing verifier, cancelled context, one call per lookup, replacing the verifier while lookups run
- pkg/cache/polarity_nli_regression_test.go: real model, skips if models/mom-halugate-explainer is not present
- pkg/classification: task registration (not best-effort), init error on a bad model path

E2E on a local Kind cluster:

make e2e-test E2E_PROFILE=production-stack E2E_TESTS=semantic-cache,semantic-cache-polarity E2E_VERBOSE=true


Test Result

- make agent-validate, make agent-lint, make agent-ci-gate: pass.
- go test for pkg/config, pkg/modeldownload, pkg/cache, pkg/classification, pkg/extproc, pkg/apiserver: all pass. -race on the polarity tests: pass.
- E2E production-stack: semantic-cache passes; semantic-cache-polarity passes. The router downloaded models/mom-halugate-explainer on startup and logged semantic_cache_nli_initialized. All three opposite questions were rejected with similarity 0.93-0.97 and NLI contradiction 0.95-0.99; all three paraphrases were served.
- Measured on the deployed model: the guard also rejects unrelated questions that the embedder scores as similar (for example "turn on the lights" vs "add a contact", similarity 0.83). It did not catch "Should I commit this change?" vs "Should I not commit this change?" (similarity 0.97, contradiction below 0.5). That negation case is what the lexical tier in #2728 is for.



---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as [Feature], [Bug], [Docs], [Test], [Research], [Community], or [CI/Build]
- [x] The title does not stack prefixes such as [Router][Docs]; affected modules belong in labels and the PR body
- [x] The PR links an accepted issue with exactly one owner: one wg/* label for project work or owner/maintainers for repository governance
- [x] Commits in this PR are signed off with git commit -s
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See CONTRIBUTING.md for the full contributor workflow and commit guidance.