### PR TITLE
[Docs] animation and consistent section heading punctuation

### DIFF
--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -478,9 +478,6 @@
   "homepage.capabilities.preference.value": {
     "message": "将偏好表达为路由策略。"
   },
-  "homepage.capabilities.docsCta": {
-    "message": "了解工作原理"
-  },
   "homepage.capabilities.signal.title": {
     "message": "信号提取"
   },

--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -425,7 +425,7 @@
     "message": "架构"
   },
   "homepage.capabilities.heading": {
-    "message": "统一异构推理。"
+    "message": "统一异构推理"
   },
   "homepage.capabilities.description": {
     "message": "在四个维度上统一碎片化的模型生态。"
@@ -521,7 +521,7 @@
     "message": "信号智能"
   },
   "homepage.aiTech.title": {
-    "message": "生成之前，先理解。"
+    "message": "生成之前，先理解"
   },
   "homepage.aiTech.description": {
     "message": "专用编码器在选择生成模型之前，先提取意图、上下文、安全与模态信号。"
@@ -590,7 +590,7 @@
     "message": "快速上手"
   },
   "homepage.install.title.human": {
-    "message": "一条命令，本地跑起来。"
+    "message": "一条命令，本地跑起来"
   },
   "homepage.install.primaryCta": {
     "message": "查看完整安装指南"
@@ -605,7 +605,7 @@
     "message": "研究"
   },
   "homepage.researchCarousel.title": {
-    "message": "这些论文，构成了路由器的底层思路。"
+    "message": "这些论文，构成了路由器的底层思路"
   },
   "homepage.researchCarousel.subtitle": {
     "message": "从安全、多模态到编排与系统设计，这些研究线索持续塑造 vLLM Semantic Router 的演进方向。"
@@ -626,7 +626,7 @@
     "message": "文档"
   },
   "homepage.band.docs.title": {
-    "message": "架构、配置与运行方式，都写清楚了。"
+    "message": "架构、配置与运行方式，都写清楚了"
   },
   "homepage.band.docs.text": {
     "message": "从安装、配置到训练和运维，整套路径都收进一张连贯的文档图谱里。"
@@ -638,7 +638,7 @@
     "message": "社区"
   },
   "homepage.band.community.title": {
-    "message": "研究者和构建者，在同一条反馈回路里。"
+    "message": "研究者和构建者，在同一条反馈回路里"
   },
   "homepage.band.community.text": {
     "message": "论文、工作组和贡献者围绕同一套系统公开协作、持续迭代。"
@@ -650,7 +650,7 @@
     "message": "路由蓝图"
   },
   "homepage.paperFigures.title": {
-    "message": "从信号到模型路径。"
+    "message": "从信号到模型路径"
   },
   "homepage.paperFigures.description": {
     "message": "探索架构如何提取信号、组合决策并执行选定的模型路径。"
@@ -2494,7 +2494,7 @@
     "message": "贡献者"
   },
   "teamCarousel.title": {
-    "message": "在开放协作中构建。"
+    "message": "在开放协作中构建"
   },
   "teamCarousel.subtitle": {
     "message": "来自研究、基础设施与模型系统的维护者，共同塑造这个项目。"
@@ -2512,7 +2512,7 @@
     "message": "生态"
   },
   "acknowledgements.title": {
-    "message": "由开源共同构建。"
+    "message": "由开源共同构建"
   },
   "acknowledgements.subtitle": {
     "message": "支撑 vLLM Semantic Router 的开源库与平台。"
@@ -2527,7 +2527,7 @@
     "message": "行业声音"
   },
   "homepage.testimonials.title": {
-    "message": "这场转变已经开始。"
+    "message": "这场转变已经开始"
   },
   "homepage.testimonials.source": {
     "message": "来源"
@@ -2536,7 +2536,7 @@
     "message": "开始构建"
   },
   "homepage.finalCta.title": {
-    "message": "组合你的 Mixture-of-Models。"
+    "message": "组合你的 Mixture-of-Models"
   },
   "homepage.finalCta.description": {
     "message": "用信号、偏好与策略塑造模型路径。"

--- a/website/src/components/AcknowledgementsSection/index.tsx
+++ b/website/src/components/AcknowledgementsSection/index.tsx
@@ -28,7 +28,7 @@ const AcknowledgementsSection: React.FC = () => {
             <Translate id="acknowledgements.label">Ecosystem</Translate>
           </SectionLabel>
           <h2 className={styles.title}>
-            <Translate id="acknowledgements.title">Built with open source.</Translate>
+            <Translate id="acknowledgements.title">Built with open source</Translate>
           </h2>
           <p className={styles.subtitle}>
             <Translate id="acknowledgements.subtitle">

--- a/website/src/components/InstallQuickStartSection/index.tsx
+++ b/website/src/components/InstallQuickStartSection/index.tsx
@@ -64,7 +64,7 @@ export default function InstallQuickStartSection(): JSX.Element {
           </SectionLabel>
           <h2>
             <Translate id="homepage.install.title.human">
-              Install locally in one line.
+              Install locally in one line
             </Translate>
           </h2>
         </header>

--- a/website/src/components/PaperFigureShowcase/index.module.css
+++ b/website/src/components/PaperFigureShowcase/index.module.css
@@ -35,19 +35,6 @@
   margin-bottom: 3rem;
 }
 
-.paperLabel {
-  margin: 0;
-  font-size: 0.875rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #6366F1;
-}
-
-[data-theme='dark'] .paperLabel {
-  color: #A5B4FC;
-}
-
 .paperTitle {
   margin: 0;
   font-size: var(--site-text-h2);

--- a/website/src/components/PaperFigureShowcase/index.tsx
+++ b/website/src/components/PaperFigureShowcase/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import Translate, { translate } from '@docusaurus/Translate'
 import { motion, useInView } from 'motion/react'
+import { SectionLabel } from '@site/src/components/site/Chrome'
 import styles from './index.module.css'
 
 type FigureKey = 'figure1' | 'figure2' | 'figure3' | 'figure4' | 'figure14' | 'figure9'
@@ -931,9 +932,9 @@ const PaperFigureShowcase: React.FC = () => {
     <section className={styles.paperFigureSection}>
       <div className="site-shell-container">
         <div className={`site-section-intro ${styles.paperHeader}`}>
-          <span className={styles.paperLabel}>
+          <SectionLabel>
             <Translate id="homepage.paperFigures.label">Routing Blueprint</Translate>
-          </span>
+          </SectionLabel>
           <h2 className={styles.paperTitle}>
             <Translate id="homepage.paperFigures.title">From signal to model path</Translate>
           </h2>

--- a/website/src/components/PaperFigureShowcase/index.tsx
+++ b/website/src/components/PaperFigureShowcase/index.tsx
@@ -935,7 +935,7 @@ const PaperFigureShowcase: React.FC = () => {
             <Translate id="homepage.paperFigures.label">Routing Blueprint</Translate>
           </span>
           <h2 className={styles.paperTitle}>
-            <Translate id="homepage.paperFigures.title">From signal to model path.</Translate>
+            <Translate id="homepage.paperFigures.title">From signal to model path</Translate>
           </h2>
           <p className={styles.paperDescription}>
             <Translate id="homepage.paperFigures.description">

--- a/website/src/components/ResearchPaperCarousel/index.tsx
+++ b/website/src/components/ResearchPaperCarousel/index.tsx
@@ -21,7 +21,7 @@ export default function ResearchPaperCarousel(): JSX.Element {
             <Translate id="homepage.researchCarousel.label">Research</Translate>
           </SectionLabel>
           <h2 className={styles.title}>
-            <Translate id="homepage.researchCarousel.title">Papers behind the router.</Translate>
+            <Translate id="homepage.researchCarousel.title">Papers behind the router</Translate>
           </h2>
           <p className={styles.subtitle}>
             <Translate id="homepage.researchCarousel.subtitle">

--- a/website/src/components/TeamCarousel/index.tsx
+++ b/website/src/components/TeamCarousel/index.tsx
@@ -82,7 +82,7 @@ const TeamCarousel: React.FC = () => {
             <Translate id="teamCarousel.label">Community</Translate>
           </SectionLabel>
           <h2 className={styles.title} id="team-carousel-title">
-            <Translate id="teamCarousel.title">Built in the open.</Translate>
+            <Translate id="teamCarousel.title">Built in the open</Translate>
           </h2>
           <p className={styles.subtitle}>
             <Translate id="teamCarousel.subtitle">

--- a/website/src/components/TestimonialsRail/index.tsx
+++ b/website/src/components/TestimonialsRail/index.tsx
@@ -138,7 +138,7 @@ export default function TestimonialsRail(): JSX.Element {
             <Translate id="homepage.testimonials.label">Industry voices</Translate>
           </SectionLabel>
           <h2 className={styles.title} id="testimonials-heading">
-            <Translate id="homepage.testimonials.title">The shift is already underway.</Translate>
+            <Translate id="homepage.testimonials.title">The shift is already underway</Translate>
           </h2>
         </header>
       </div>

--- a/website/src/components/YouTubeSection/index.tsx
+++ b/website/src/components/YouTubeSection/index.tsx
@@ -82,7 +82,7 @@ export default function YouTubeSection(): JSX.Element {
             <Translate id="homepage.videos.label">See it in action</Translate>
           </SectionLabel>
           <h2 id="video-showcase-title">
-            <Translate id="homepage.videos.title">Semantic routing in the real world.</Translate>
+            <Translate id="homepage.videos.title">Semantic routing in the real world</Translate>
           </h2>
           <p>
             <Translate id="homepage.videos.description">

--- a/website/src/components/homepage/CompatibilityBand.tsx
+++ b/website/src/components/homepage/CompatibilityBand.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Link from '@docusaurus/Link'
 import Translate, { translate } from '@docusaurus/Translate'
-import { PillLink } from '@site/src/components/site/Chrome'
+import { PillLink, SectionLabel } from '@site/src/components/site/Chrome'
 import ScrollReveal from '@site/src/components/site/ScrollReveal'
 import shared from './homepageShared.module.css'
 import styles from './CompatibilityBand.module.css'
@@ -46,9 +46,9 @@ export default function CompatibilityBand(): JSX.Element {
       <div className={`site-shell-container ${shared.sectionInner}`}>
         <ScrollReveal>
           <header className={`site-section-intro ${shared.sectionHeader}`}>
-            <span className={shared.eyebrow}>
+            <SectionLabel>
               <Translate id="homepage.compat.label">Deployment options</Translate>
-            </span>
+            </SectionLabel>
             <h2 id="compatibility-title" className={shared.sectionTitle}>
               <Translate id="homepage.compat.title">One router, supported deployment paths</Translate>
             </h2>

--- a/website/src/components/homepage/IntegrationArchitecture.tsx
+++ b/website/src/components/homepage/IntegrationArchitecture.tsx
@@ -10,6 +10,7 @@ import Mistral from '@lobehub/icons/es/Mistral/components/Mono'
 import OpenAI from '@lobehub/icons/es/OpenAI/components/Mono'
 import Zhipu from '@lobehub/icons/es/Zhipu/components/Mono'
 import ScrollReveal from '@site/src/components/site/ScrollReveal'
+import { SectionLabel } from '@site/src/components/site/Chrome'
 import shared from './homepageShared.module.css'
 import styles from './IntegrationArchitecture.module.css'
 
@@ -698,9 +699,9 @@ export default function IntegrationArchitecture(): JSX.Element {
       <div className={`site-shell-container ${shared.sectionInner}`}>
         <ScrollReveal>
           <header className={`site-section-intro ${shared.sectionHeader}`}>
-            <span className={shared.eyebrow}>
+            <SectionLabel>
               <Translate id="homepage.integration.eyebrow">How it integrates</Translate>
-            </span>
+            </SectionLabel>
             <h2 id="integration-architecture-title" className={shared.sectionTitle}>
               <Translate id="homepage.integration.title">Route queries to the right model</Translate>
             </h2>

--- a/website/src/components/homepage/UseCaseExplorer.tsx
+++ b/website/src/components/homepage/UseCaseExplorer.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import Link from '@docusaurus/Link'
 import Translate, { translate } from '@docusaurus/Translate'
 import IconExternalLink from '@theme/Icon/ExternalLink'
-import { PillLink } from '@site/src/components/site/Chrome'
+import { PillLink, SectionLabel } from '@site/src/components/site/Chrome'
 import ScrollReveal from '@site/src/components/site/ScrollReveal'
 import shared from './homepageShared.module.css'
 import styles from './UseCaseExplorer.module.css'
@@ -391,9 +391,9 @@ export default function UseCaseExplorer(): JSX.Element {
       <div className={`site-shell-container ${shared.sectionInner}`}>
         <ScrollReveal>
           <header className={`site-section-intro ${shared.sectionHeader}`}>
-            <span className={shared.eyebrow}>
+            <SectionLabel>
               <Translate id="homepage.useCases.label">How it works</Translate>
-            </span>
+            </SectionLabel>
             <h2 id="use-case-explorer-title" className={shared.sectionTitle}>
               <Translate id="homepage.useCases.title">One router, three use cases</Translate>
             </h2>

--- a/website/src/components/homepage/homepageShared.module.css
+++ b/website/src/components/homepage/homepageShared.module.css
@@ -25,33 +25,6 @@
   margin-bottom: var(--site-section-gap);
 }
 
-.eyebrow {
-  display: inline-flex;
-  width: fit-content;
-  align-items: center;
-  padding: 0.35rem 0.75rem;
-  border: 1px solid var(--site-border);
-  border-radius: 999px;
-  background: var(--site-surface-soft);
-  color: var(--site-muted);
-  font-size: var(--site-text-caption);
-  font-weight: var(--site-font-weight-semibold);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  transition:
-    border-color var(--site-transition-fast),
-    background var(--site-transition-fast),
-    color var(--site-transition-fast),
-    box-shadow var(--site-transition-fast);
-}
-
-.eyebrow:hover {
-  border-color: var(--site-hover-border);
-  background: var(--site-hover-surface-bg);
-  color: var(--site-brand-blue);
-  box-shadow: var(--site-hover-glow);
-}
-
 .sectionTitle {
   margin: 0;
   font-size: var(--site-text-h2);

--- a/website/src/css/docs-intro.css
+++ b/website/src/css/docs-intro.css
@@ -1,20 +1,19 @@
-/* Docs landing hero: left-aligned lockup on same measure as prose.
- * The box hugs the logo and tagline rather than stretching to the full measure.
- * Stretched, a short tagline left roughly a third of the card empty. */
+/* Docs landing hero on the same measure as the prose. The card keeps its full
+ * width; the lockup is centred inside it so the leftover space splits evenly
+ * instead of pooling to the right of a left-clustered logo and tagline. */
 .docs-intro-brand {
   display: grid;
   grid-template-columns: auto auto;
-  justify-content: start;
+  justify-content: center;
   align-items: center;
   gap: var(--space-4);
-  width: fit-content;
   max-width: var(--measure);
   margin: 0 0 var(--space-6);
   padding: var(--space-5);
   border: 1px solid var(--site-border);
   border-radius: var(--radius-lg);
   background:
-    radial-gradient(110% 140% at 0% 0%, var(--site-accent-soft), transparent 60%),
+    radial-gradient(90% 140% at 50% 0%, var(--site-accent-soft), transparent 62%),
     var(--site-surface-alt);
   text-align: left;
 }
@@ -39,9 +38,10 @@
 @media (max-width: 576px) {
   .docs-intro-brand {
     grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
     gap: var(--space-3);
-    width: 100%;
     padding: var(--space-4);
+    text-align: center;
   }
 
   .docs-intro-brand__logo {

--- a/website/src/css/docs-intro.css
+++ b/website/src/css/docs-intro.css
@@ -1,9 +1,13 @@
-/* Docs landing hero: left-aligned lockup on same measure as prose. */
+/* Docs landing hero: left-aligned lockup on same measure as prose.
+ * The box hugs the logo and tagline rather than stretching to the full measure.
+ * Stretched, a short tagline left roughly a third of the card empty. */
 .docs-intro-brand {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto auto;
+  justify-content: start;
   align-items: center;
   gap: var(--space-4);
+  width: fit-content;
   max-width: var(--measure);
   margin: 0 0 var(--space-6);
   padding: var(--space-5);
@@ -36,6 +40,7 @@
   .docs-intro-brand {
     grid-template-columns: minmax(0, 1fr);
     gap: var(--space-3);
+    width: 100%;
     padding: var(--space-4);
   }
 

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -517,6 +517,23 @@
   background:
     linear-gradient(180deg, rgba(48, 162, 255, 0.14), rgba(48, 162, 255, 0.04)),
     rgba(4, 8, 15, 0.75);
+  animation: constraintGate 5.6s ease-in-out infinite;
+}
+
+@keyframes constraintGate {
+  0%,
+  10%,
+  40%,
+  100% {
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  20% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04),
+      0 0 0 1px rgba(48, 162, 255, 0.4),
+      0 0 26px rgba(48, 162, 255, 0.22);
+  }
 }
 
 .constraintStageIndex {
@@ -544,6 +561,68 @@
 
 .constraintStageGate .constraintStageDetail {
   color: var(--site-accent-strong);
+}
+
+/* A request travelling the pipeline, on a loop. Same scan-bar language as the
+ * routing pipeline stages above, so the two diagrams animate alike. */
+.constraintStage::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #75c5ff, #30a2ff);
+  transform: scaleX(0);
+  transform-origin: left;
+  animation: constraintScan 5.6s ease-in-out var(--stage-delay) infinite;
+}
+
+.constraintStage:not(:last-child)::after {
+  animation: constraintArrow 5.6s ease-in-out var(--stage-delay) infinite;
+}
+
+@keyframes constraintScan {
+  0%,
+  4% {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+
+  12% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+
+  34% {
+    opacity: 0.5;
+    transform: scaleX(1);
+  }
+
+  100% {
+    opacity: 0.16;
+    transform: scaleX(1);
+  }
+}
+
+@keyframes constraintArrow {
+  0%,
+  8% {
+    opacity: 0.32;
+    transform: translateY(-50%) translateX(-0.12rem);
+  }
+
+  16% {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0.1rem);
+  }
+
+  32%,
+  100% {
+    opacity: 0.32;
+    transform: translateY(-50%) translateX(0);
+  }
 }
 
 @keyframes constraintStageIn {
@@ -593,8 +672,16 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .constraintStage {
+  .constraintStage,
+  .constraintStage::before,
+  .constraintStage:not(:last-child)::after,
+  .constraintStageGate {
     animation: none;
+  }
+
+  .constraintStage::before {
+    opacity: 0.4;
+    transform: scaleX(1);
   }
 }
 

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -93,61 +93,16 @@
   background: var(--site-surface-alt);
 }
 
+/* Section intro above the card; the card holds only the matrix. */
 .capabilityHeading {
-  display: grid;
   gap: 0.65rem;
-}
-
-.capabilityLabel {
-  color: var(--site-muted);
-}
-
-.capabilityLabel::after {
-  color: var(--site-accent);
+  margin-bottom: var(--site-section-gap);
 }
 
 .capabilityHeading h2 {
-  max-width: none;
-  margin: 0;
   color: var(--site-text-strong);
-  font-size: clamp(1.3rem, 2.1vw, 1.7rem);
-  font-weight: 400;
-  line-height: 1.2;
-  letter-spacing: -0.028em;
-  text-wrap: pretty;
-}
-
-.capabilitySummary {
-  display: grid;
-  grid-template-columns: minmax(0, 36rem) auto;
-  align-items: end;
-  justify-content: space-between;
-  gap: 1.25rem;
-}
-
-.capabilitySummary p {
-  max-width: 36rem;
-  margin: 0;
-  color: var(--site-muted-bright);
-  font-size: clamp(0.92rem, 1.05vw, 1rem);
-  line-height: 1.5;
-  letter-spacing: -0.01em;
-}
-
-.capabilitySummary .capabilityCta {
-  flex: 0 0 auto;
-  border-color: rgba(48, 162, 255, 0.38);
-  background: rgba(48, 162, 255, 0.08);
-  color: var(--site-accent-strong);
-  box-shadow: none;
-  backdrop-filter: none;
-}
-
-.capabilitySummary .capabilityCta:hover {
-  border-color: var(--site-accent);
-  background: var(--site-accent);
-  color: #ffffff;
-  box-shadow: none;
+  font-weight: var(--site-font-weight-semibold);
+  letter-spacing: -0.025em;
 }
 
 .architectureMatrix {
@@ -803,16 +758,6 @@
       line-height: 1.22;
   }
 
-  .capabilitySummary {
-      grid-template-columns: 1fr;
-      align-items: start;
-      gap: 1rem;
-  }
-
-  .capabilitySummary .capabilityCta {
-      justify-self: start;
-  }
-
   .matrixHeader {
       display: none;
   }
@@ -884,11 +829,4 @@
       line-height: 1.24;
   }
 
-  .capabilitySummary p {
-      font-size: 0.92rem;
-  }
-
-  .capabilitySummary .capabilityCta {
-      width: 100%;
-  }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -604,6 +604,10 @@ export default function Home(): JSX.Element {
           <UseCaseExplorer />
         </div>
 
+        <div className={styles.bandRaised}>
+          <DataSovereigntySection />
+        </div>
+
         <div className={styles.bandGraphite}>
           <CompatibilityBand />
         </div>
@@ -624,10 +628,6 @@ export default function Home(): JSX.Element {
           <ScrollReveal delay={40}>
             <AcknowledgementsSection />
           </ScrollReveal>
-        </div>
-
-        <div className={styles.bandBlack}>
-          <DataSovereigntySection />
         </div>
 
         <div className={styles.bandGraphite}>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -234,7 +234,7 @@ function CapabilitySection(): JSX.Element {
               </SectionLabel>
               <h2 id="mixture-architecture-title">
                 <Translate id="homepage.capabilities.heading">
-                  Unify heterogeneous inference.
+                  Unify heterogeneous inference
                 </Translate>
               </h2>
             </header>
@@ -328,7 +328,7 @@ function MixtureOfModelsProofSection(): JSX.Element {
             <div>
               <h2 id="mom-proof-title">
                 <Translate id="homepage.momProof.title">
-                  One model API can beat frontier models.
+                  One Model API can beat frontier models
                 </Translate>
               </h2>
               <p>
@@ -420,7 +420,7 @@ function DataSovereigntySection(): JSX.Element {
               </SectionLabel>
               <h2>
                 <Translate id="homepage.sovereignty.title">
-                  Keep regulated traffic on approved paths.
+                  Keep regulated traffic on approved paths
                 </Translate>
               </h2>
               <p>
@@ -438,7 +438,7 @@ function DataSovereigntySection(): JSX.Element {
                   className={clsx(styles.constraintStage, {
                     [styles.constraintStageGate]: stage.gate,
                   })}
-                  style={{ '--stage-delay': `${0.15 + index * 0.12}s` } as React.CSSProperties}
+                  style={{ '--stage-delay': `${index * 0.5}s` } as React.CSSProperties}
                 >
                   <span className={styles.constraintStageIndex}>
                     {String(index + 1).padStart(2, '0')}
@@ -478,7 +478,7 @@ function FinalCtaSection(): JSX.Element {
               </SectionLabel>
               <h2>
                 <Translate id="homepage.finalCta.title">
-                  Compose your Mixture-of-Models.
+                  Compose your Mixture-of-Models
                 </Translate>
               </h2>
               <p>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -227,31 +227,23 @@ function CapabilitySection(): JSX.Element {
     >
       <div className="site-shell-container">
         <ScrollReveal>
+          <header className={`site-section-intro ${styles.capabilityHeading}`}>
+            <SectionLabel>
+              <Translate id="homepage.capabilities.label">Architecture</Translate>
+            </SectionLabel>
+            <h2 id="mixture-architecture-title">
+              <Translate id="homepage.capabilities.heading">
+                Unify heterogeneous inference
+              </Translate>
+            </h2>
+            <p>
+              <Translate id="homepage.capabilities.description">
+                Unify a fragmented model landscape across four dimensions.
+              </Translate>
+            </p>
+          </header>
+
           <div className={styles.capabilityFrame}>
-            <header className={styles.capabilityHeading}>
-              <SectionLabel className={styles.capabilityLabel}>
-                <Translate id="homepage.capabilities.label">Architecture</Translate>
-              </SectionLabel>
-              <h2 id="mixture-architecture-title">
-                <Translate id="homepage.capabilities.heading">
-                  Unify heterogeneous inference
-                </Translate>
-              </h2>
-            </header>
-
-            <div className={styles.capabilitySummary}>
-              <p>
-                <Translate id="homepage.capabilities.description">
-                  Unify a fragmented model landscape across four dimensions.
-                </Translate>
-              </p>
-              <PillLink className={styles.capabilityCta} to="/docs/intro">
-                <Translate id="homepage.capabilities.docsCta">
-                  Explore how it works
-                </Translate>
-              </PillLink>
-            </div>
-
             <div
               className={styles.architectureMatrix}
               role="table"


### PR DESCRIPTION
Related #3002

Follow-up to #3069, which merged before these review points were addressed:
- https://github.com/vllm-project/semantic-router/pull/3069#issuecomment-5438492055
- https://github.com/vllm-project/semantic-router/pull/3069#issuecomment-5448193271

## Purpose

- **Data sovereignty animation.** A scan bar sweeps each stage, the arrows pulse as the request passes, and the constraint gate glows when reached. Same visual language as the routing pipeline above it, and disabled under `prefers-reduced-motion`.
- **Docs intro lockup.** The brand card stretched to the full prose measure while the logo and tagline filled only its left portion. It now hugs its content, so there is no dead space on the right.
- **Heading punctuation.** Eleven of the fourteen homepage section headings ended with a period and three did not. Removed them everywhere rather than adding the missing three. The eleven matching Chinese headings are updated too.
- **Product term casing.** `One model API` to `One Model API`. Audited the rest of the visible homepage copy: `Semantic Router`, `Mixture-of-Models`, `Playground`, `Dashboard` and `Fusion API` were already correct.

Section text stays full width, as agreed on the first comment above.

## Test Plan

- Sovereignty stages animate in sequence and the gate pulses; animation stops under reduced motion.
- Docs intro card wraps its logo and tagline with no trailing gap, and stacks below 576px.
- No homepage section heading ends with a period, in either locale.

## Test Result

<img width="1908" height="607" alt="Screenshot From 2026-08-28 09-19-48" src="https://github.com/user-attachments/assets/cd9adf03-8b32-44c9-9a36-8fcf34960fe8" />

<img width="1825" height="280" alt="Screenshot From 2026-08-28 09-20-04" src="https://github.com/user-attachments/assets/7288435d-9c2f-49e2-9105-4ba2c986984e" />

<img width="845" height="316" alt="image" src="https://github.com/user-attachments/assets/32f8a2d7-472f-4912-9bd8-67cdd8e826b1" />

