### PR TITLE
[Community] Add accepted Workgroup members

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -50,6 +50,21 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Cerdore.png',
         profile: 'https://github.com/Cerdore',
       },
+      {
+        name: 'Ramakrishnan Sathyavageeswaran',
+        avatar: 'https://github.com/ramkrishs.png',
+        profile: 'https://github.com/ramkrishs',
+      },
+      {
+        name: 'Chlins Zhang',
+        avatar: 'https://github.com/chlins.png',
+        profile: 'https://github.com/chlins',
+      },
+      {
+        name: 'yaojiejia',
+        avatar: 'https://github.com/yaojiejia.png',
+        profile: 'https://github.com/yaojiejia',
+      },
     ],
   },
   {
@@ -79,6 +94,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/adaamko.png',
         profile: 'https://github.com/adaamko',
       },
+      {
+        name: 'Ramakrishnan Sathyavageeswaran',
+        avatar: 'https://github.com/ramkrishs.png',
+        profile: 'https://github.com/ramkrishs',
+      },
     ],
     members: [
       {
@@ -90,6 +110,16 @@ export const workGroups: WorkGroup[] = [
         name: 'Park Soobin',
         avatar: 'https://github.com/subin9.png',
         profile: 'https://github.com/subin9',
+      },
+      {
+        name: 'Chlins Zhang',
+        avatar: 'https://github.com/chlins.png',
+        profile: 'https://github.com/chlins',
+      },
+      {
+        name: 'yaojiejia',
+        avatar: 'https://github.com/yaojiejia.png',
+        profile: 'https://github.com/yaojiejia',
       },
     ],
   },
@@ -188,6 +218,11 @@ export const workGroups: WorkGroup[] = [
         name: 'Abhinav Mahajan',
         avatar: 'https://github.com/abhinav-m22.png',
         profile: 'https://github.com/abhinav-m22',
+      },
+      {
+        name: 'yaojiejia',
+        avatar: 'https://github.com/yaojiejia.png',
+        profile: 'https://github.com/yaojiejia',
       },
     ],
   },


### PR DESCRIPTION
Related #2978

## Purpose

- Add @ramkrishs as a MoM & Routing Member and Router Models & Inference Runtime Lead after the merged contributions cited in the nominations and sponsorship from @WUKUNTAI-0211.
- Add @chlins as a Member of MoM & Routing and Router Models & Inference Runtime after merged contributions #3066 and #3049.
- Add @yaojiejia as a Member of MoM & Routing, Router Models & Inference Runtime, and Agentic & Context after merged contribution #3075.
- Keep the change limited to the public Workgroup roster data.

## Test Plan

- Run the repository agent CI gate for website/src/data/workGroups.ts.
- Build the English Docusaurus site.

## Test Result

- make agent-ci-gate CHANGED_FILES="website/src/data/workGroups.ts" passed.
- npm --prefix website run build:en passed with existing blog author, truncation marker, Browserslist, and dependency-analysis warnings.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category.
- [x] The title does not stack prefixes.
- [x] The PR links accepted Workgroup governance with owner/maintainers.
- [x] Commits are signed off with git commit -s.
- [x] Purpose, tests, and results reflect the actual change.

</details>