### PR TITLE
[Bug] Stop reask embedding after all rules fail

### DIFF
--- a/src/semantic-router/pkg/classification/reask_classifier.go
+++ b/src/semantic-router/pkg/classification/reask_classifier.go
@@ -51,7 +51,7 @@ func (c *ReaskClassifier) Classify(currentUserTurn string, priorUserTurns []stri
 		return nil, fmt.Errorf("failed to compute current user turn embedding: %w", err)
 	}
 
-	similarities, err := c.computeSimilarities(currentEmbedding, priorUserTurns)
+	similarities, err := c.computeSimilarities(currentEmbedding, priorUserTurns, minimumReaskThreshold(c.rules))
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (c *ReaskClassifier) Classify(currentUserTurn string, priorUserTurns []stri
 	return retainMaxLookbackReaskMatches(matches), nil
 }
 
-func (c *ReaskClassifier) computeSimilarities(currentEmbedding []float32, priorUserTurns []string) ([]float64, error) {
+func (c *ReaskClassifier) computeSimilarities(currentEmbedding []float32, priorUserTurns []string, minimumThreshold float64) ([]float64, error) {
 	cache := make(map[string][]float32, len(priorUserTurns))
 	similarities := make([]float64, 0, len(priorUserTurns))
 
@@ -99,10 +99,25 @@ func (c *ReaskClassifier) computeSimilarities(currentEmbedding []float32, priorU
 			cache[priorTurn] = priorEmbedding
 		}
 
-		similarities = append(similarities, float64(cosineSimilarity(currentEmbedding, priorEmbedding)))
+		similarity := float64(cosineSimilarity(currentEmbedding, priorEmbedding))
+		similarities = append(similarities, similarity)
+		if similarity < minimumThreshold {
+			break
+		}
 	}
 
 	return similarities, nil
+}
+
+func minimumReaskThreshold(rules []config.ReaskRule) float64 {
+	minimumThreshold := float64(rules[0].WithDefaults().Threshold)
+	for _, rawRule := range rules[1:] {
+		threshold := float64(rawRule.WithDefaults().Threshold)
+		if threshold < minimumThreshold {
+			minimumThreshold = threshold
+		}
+	}
+	return minimumThreshold
 }
 
 func (c *ReaskClassifier) embedText(text string) ([]float32, error) {

--- a/src/semantic-router/pkg/classification/reask_classifier_optimization_test.go
+++ b/src/semantic-router/pkg/classification/reask_classifier_optimization_test.go
@@ -1,0 +1,104 @@
+package classification
+
+import (
+	"fmt"
+	"testing"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestReaskClassifier_ClassifyStopsEmbeddingAfterAllRulesFail(t *testing.T) {
+	embeddingCalls := 0
+	restore := SetEmbeddingFuncForTests(func(text string, modelType string, targetDim int) (*candle_binding.EmbeddingOutput, error) {
+		embeddingCalls++
+		if text == "current" {
+			return &candle_binding.EmbeddingOutput{Embedding: makeEmbedding(1, 0)}, nil
+		}
+		return &candle_binding.EmbeddingOutput{Embedding: makeEmbedding(0, 1)}, nil
+	})
+	t.Cleanup(restore)
+
+	priorUserTurns := make([]string, 50)
+	for index := range priorUserTurns {
+		priorUserTurns[index] = fmt.Sprintf("unrelated earlier question %d", index)
+	}
+
+	classifier, err := NewReaskClassifier([]config.ReaskRule{
+		{
+			Name:          "likely_dissatisfied",
+			Threshold:     0.9,
+			LookbackTurns: 1,
+		},
+		{
+			Name:          "default_threshold",
+			LookbackTurns: 1,
+		},
+	}, "test-model")
+	if err != nil {
+		t.Fatalf("NewReaskClassifier() error = %v", err)
+	}
+
+	matches, err := classifier.Classify("current", priorUserTurns)
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no matches, got %+v", matches)
+	}
+	if embeddingCalls != 2 {
+		t.Fatalf("embedding calls = %d, want 2", embeddingCalls)
+	}
+}
+
+func TestReaskClassifier_ClassifyContinuesUntilLowestThresholdFails(t *testing.T) {
+	embeddingCalls := make(map[string]int)
+	embeddings := map[string][]float32{
+		"current":                       makeEmbedding(1, 0),
+		"recent permissive match":       makeEmbedding(0.8, 0.6),
+		"older all-rules failure":       makeEmbedding(0, 1),
+		"oldest should not be embedded": makeEmbedding(1, 0),
+	}
+	restore := SetEmbeddingFuncForTests(func(text string, modelType string, targetDim int) (*candle_binding.EmbeddingOutput, error) {
+		embeddingCalls[text]++
+		return &candle_binding.EmbeddingOutput{Embedding: embeddings[text]}, nil
+	})
+	t.Cleanup(restore)
+
+	classifier, err := NewReaskClassifier([]config.ReaskRule{
+		{
+			Name:          "strict",
+			Threshold:     0.9,
+			LookbackTurns: 1,
+		},
+		{
+			Name:          "permissive",
+			Threshold:     0.7,
+			LookbackTurns: 1,
+		},
+	}, "test-model")
+	if err != nil {
+		t.Fatalf("NewReaskClassifier() error = %v", err)
+	}
+
+	matches, err := classifier.Classify("current", []string{
+		"oldest should not be embedded",
+		"older all-rules failure",
+		"recent permissive match",
+	})
+	if err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if len(matches) != 1 || matches[0].RuleName != "permissive" {
+		t.Fatalf("matches = %+v, want permissive", matches)
+	}
+	if embeddingCalls["recent permissive match"] != 1 {
+		t.Fatalf("recent permissive match embedding calls = %d, want 1", embeddingCalls["recent permissive match"])
+	}
+	if embeddingCalls["older all-rules failure"] != 1 {
+		t.Fatalf("older all-rules failure embedding calls = %d, want 1", embeddingCalls["older all-rules failure"])
+	}
+	if embeddingCalls["oldest should not be embedded"] != 0 {
+		t.Fatalf("oldest embedding calls = %d, want 0", embeddingCalls["oldest should not be embedded"])
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #3048
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

- Stop the reask classifier from generating embeddings for every earlier user
  message after the active reask streak has already failed.
- Resolve each rule's configured or default threshold and stop scanning older
  turns when a similarity falls below the lowest threshold across all rules. At
  that point, no rule can recover its consecutive-match streak.
- Preserve existing matching behavior, including mixed rule thresholds,
  `lookback_turns`, reported confidence, and matched-turn counts.
- Add focused regression coverage proving that:
  - a 50-turn conversation stops after embedding the current and most recent
    user turns when all rules fail; and
  - a lower-threshold rule continues to be evaluated after a stricter rule
    fails, while messages older than the all-rules failure are not embedded.
- Affected module: Router classification runtime.
- Tracking issue and owner: #3048, `wg/mom-routing`.

## Test Plan

```bash
cd src/semantic-router

go test -count=1 ./pkg/classification \
  -run '^TestReaskClassifier_Classify(StopsEmbeddingAfterAllRulesFail|ContinuesUntilLowestThresholdFails)$'

go test -count=1 ./pkg/classification

make recipe-conformance-static

make agent-lint \
  CHANGED_FILES="src/semantic-router/pkg/classification/reask_classifier.go,src/semantic-router/pkg/classification/reask_classifier_optimization_test.go"

make codespell-tracked

make test-semantic-router
```

## Test Result

- Focused reask optimization tests passed.
- The complete `pkg/classification` test package passed.
- `make recipe-conformance-static` passed:
  - 50 harness tests passed;
  - maintained recipe decisions, entrypoints, fallbacks, algorithms, and plugins
    retained complete required coverage.
- Changed-file lint passed:
  - Go formatting passed;
  - Go structural lint passed;
  - supply-chain scanning passed;
  - repository structure checks passed.
- `make codespell-tracked` passed.
- VS Code reported no diagnostics in the changed files.
- The full `make test-semantic-router` gate could not complete in the local
  environment. Tests in `pkg/cache`, `pkg/extproc`, and `pkg/tools` attempted to
  download `sentence-transformers/all-MiniLM-L6-v2` from Hugging Face and timed
  out. The `pkg/extproc` suite eventually reached its test timeout after repeated
  download failures.
- No failure was reported in the changed classification package. Remaining risk
  is limited to the live model-dependent and local smoke paths that could not be
  exercised while the external model download was unavailable.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
