### PR TITLE
docs: update online playground password

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For platform notes, detailed setup options, and troubleshooting, see the **[Inst
 <summary>Online playground credentials</summary>
 
 - Username: `love@vllm-sr.ai`
-- Password: `vllm-sr`
+- Password: `vllm-sr-read`
 
 </details>
 


### PR DESCRIPTION
## Summary

- update the README online playground credential to the current read-only password
- keep the documented account aligned with the deployed login policy

## Validation

- make agent-validate
- make agent-ci-gate CHANGED_FILES="README.md"
- verified the current read-only credential signs in and the retired password is rejected