### PR TITLE
[Feature] Enforce bounded I/O on the http_classify connector

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2199,6 +2199,19 @@ global:
         access_key: external-classifier-key
         max_tokens: 128
         temperature: 0
+      # Reached over the http_classify contract; the byte ceilings apply only there.
+      - name: external-sequence-classifier
+        llm_provider: openai
+        model_role: classification
+        llm_endpoint:
+          address: sequence-classifier
+          port: 8080
+          protocol: http
+          name: openai-sequence-classifier
+        llm_timeout_seconds: 5
+        access_key: external-sequence-classifier-key
+        max_request_bytes: 262144
+        max_response_bytes: 1048576
     kbs:
       - name: privacy_kb
         source:

--- a/src/semantic-router/pkg/classification/http_classifier.go
+++ b/src/semantic-router/pkg/classification/http_classifier.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math"
 	"net/http"
 	"reflect"
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
 )
 
 // probabilitySumTolerance bounds how far an http_classify response's scores
@@ -57,11 +57,13 @@ type sequenceLabelMapping interface {
 // external model (a 14-label category classifier) during #2918, not just a
 // synthetic mock.
 type HTTPClassifierInference struct {
-	httpClient *http.Client
-	baseURL    string
-	accessKey  string
-	timeout    time.Duration
-	mapping    sequenceLabelMapping
+	httpClient       *http.Client
+	baseURL          string
+	accessKey        string
+	timeout          time.Duration
+	maxRequestBytes  int64
+	maxResponseBytes int64
+	mapping          sequenceLabelMapping
 }
 
 // NewHTTPClassifierInference creates a new http_classify-backed inference
@@ -100,11 +102,13 @@ func NewHTTPClassifierInference(cfg *config.ExternalModelConfig, mapping sequenc
 	}
 
 	return &HTTPClassifierInference{
-		httpClient: &http.Client{Timeout: timeout},
-		baseURL:    baseURL,
-		accessKey:  cfg.AccessKey,
-		timeout:    timeout,
-		mapping:    mapping,
+		httpClient:       &http.Client{Timeout: timeout},
+		baseURL:          baseURL,
+		accessKey:        cfg.AccessKey,
+		timeout:          timeout,
+		maxRequestBytes:  cfg.GetMaxRequestBytes(),
+		maxResponseBytes: cfg.GetMaxResponseBytes(),
+		mapping:          mapping,
 	}, nil
 }
 
@@ -160,6 +164,10 @@ func (h *HTTPClassifierInference) buildClassifyRequest(ctx context.Context, text
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal http_classify request: %w", err)
 	}
+	if int64(len(reqBody)) > h.maxRequestBytes {
+		return nil, fmt.Errorf(
+			"http_classify request body is %d bytes, exceeding the limit of %d bytes", len(reqBody), h.maxRequestBytes)
+	}
 
 	url := fmt.Sprintf("%s/classify", h.baseURL)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
@@ -174,6 +182,8 @@ func (h *HTTPClassifierInference) buildClassifyRequest(ctx context.Context, text
 	return httpReq, nil
 }
 
+const maxClassifyErrorBodyBytes int64 = 8 * 1024
+
 // doClassifyRequest sends the request and parses the label/score list from a
 // successful response.
 func (h *HTTPClassifierInference) doClassifyRequest(httpReq *http.Request) ([]httpClassifyLabelScore, error) {
@@ -183,12 +193,15 @@ func (h *HTTPClassifierInference) doClassifyRequest(httpReq *http.Request) ([]ht
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errBody, truncated := httputil.ReadTruncatedBody(resp.Body, maxClassifyErrorBodyBytes)
+		return nil, fmt.Errorf(
+			"http_classify endpoint returned status %d: %s (truncated=%t)", resp.StatusCode, string(errBody), truncated)
+	}
+
+	body, err := httputil.ReadLimitedBody(resp.Body, h.maxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read http_classify response: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("http_classify endpoint returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var scores []httpClassifyLabelScore

--- a/src/semantic-router/pkg/classification/http_classifier_limits_test.go
+++ b/src/semantic-router/pkg/classification/http_classifier_limits_test.go
@@ -1,0 +1,241 @@
+package classification
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func inputForRequestBytes(t *testing.T, n int) string {
+	t.Helper()
+	envelope, err := json.Marshal(httpClassifyRequest{Inputs: ""})
+	if err != nil {
+		t.Fatalf("failed to marshal the empty request envelope: %v", err)
+	}
+	if n < len(envelope) {
+		t.Fatalf("cannot build a %d-byte body: the empty envelope is already %d bytes", n, len(envelope))
+	}
+	return strings.Repeat("a", n-len(envelope))
+}
+
+func newLimitedTestInference(t *testing.T, server *httptest.Server, requestBytes, responseBytes int64) *HTTPClassifierInference {
+	t.Helper()
+	inf, err := NewHTTPClassifierInference(&config.ExternalModelConfig{
+		ModelEndpoint:    config.ClassifierVLLMEndpoint{Address: "placeholder", Port: 1},
+		ModelName:        "custom-classifier",
+		MaxRequestBytes:  requestBytes,
+		MaxResponseBytes: responseBytes,
+	}, testJailbreakMapping())
+	if err != nil {
+		t.Fatalf("failed to construct inference: %v", err)
+	}
+	inf.baseURL = server.URL
+	return inf
+}
+
+func TestNewHTTPClassifierInference_ByteLimitDefaults(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestBytes    int64
+		responseBytes   int64
+		wantRequestMax  int64
+		wantResponseMax int64
+	}{
+		{
+			name:            "unset uses the http_classify defaults",
+			wantRequestMax:  config.DefaultClassifyMaxRequestBytes,
+			wantResponseMax: config.DefaultClassifyMaxResponseBytes,
+		},
+		{
+			name:            "explicit overrides win",
+			requestBytes:    4096,
+			responseBytes:   8192,
+			wantRequestMax:  4096,
+			wantResponseMax: 8192,
+		},
+		{
+			name:            "non-positive values fall back to the defaults",
+			requestBytes:    -1,
+			responseBytes:   -1,
+			wantRequestMax:  config.DefaultClassifyMaxRequestBytes,
+			wantResponseMax: config.DefaultClassifyMaxResponseBytes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inf, err := NewHTTPClassifierInference(&config.ExternalModelConfig{
+				ModelEndpoint:    config.ClassifierVLLMEndpoint{Address: "127.0.0.1", Port: 8080},
+				ModelName:        "custom-classifier",
+				MaxRequestBytes:  tt.requestBytes,
+				MaxResponseBytes: tt.responseBytes,
+			}, testJailbreakMapping())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if inf.maxRequestBytes != tt.wantRequestMax {
+				t.Errorf("maxRequestBytes = %d, want %d", inf.maxRequestBytes, tt.wantRequestMax)
+			}
+			if inf.maxResponseBytes != tt.wantResponseMax {
+				t.Errorf("maxResponseBytes = %d, want %d", inf.maxResponseBytes, tt.wantResponseMax)
+			}
+		})
+	}
+}
+
+func TestHTTPClassifierInferenceClassify_RequestAtLimitIsSent(t *testing.T) {
+	var received int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.ContentLength
+		_ = json.NewEncoder(w).Encode([]httpClassifyLabelScore{
+			{Label: "safe", Score: 0.9},
+			{Label: "jailbreak", Score: 0.1},
+		})
+	}))
+	defer server.Close()
+
+	const limit = 1024
+	inf := newLimitedTestInference(t, server, 1024, 0)
+	if _, err := inf.Classify(context.Background(), inputForRequestBytes(t, limit)); err != nil {
+		t.Fatalf("unexpected error for a request exactly at the cap: %v", err)
+	}
+	if received != limit {
+		t.Errorf("server received %d bytes, want %d", received, limit)
+	}
+}
+
+func TestHTTPClassifierInferenceClassify_RequestOneByteOverLimitIsRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("the endpoint was called for an over-limit request body")
+	}))
+	defer server.Close()
+
+	inf := newLimitedTestInference(t, server, 1024, 0)
+	if _, err := inf.Classify(context.Background(), inputForRequestBytes(t, 1025)); err == nil {
+		t.Fatal("expected an error for a request body of exactly cap+1 bytes, got nil")
+	}
+}
+
+func serveBodyOfSize(t *testing.T, n int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(strings.Repeat("x", n))); err != nil {
+			t.Errorf("failed to write the test response body: %v", err)
+		}
+	}))
+}
+
+func TestHTTPClassifierInferenceClassify_ResponseOneByteOverLimitIsRejected(t *testing.T) {
+	server := serveBodyOfSize(t, 1025)
+	defer server.Close()
+
+	inf := newLimitedTestInference(t, server, 0, 1024)
+	_, err := inf.Classify(context.Background(), "some text")
+	if err == nil {
+		t.Fatal("expected an error for a response body of exactly cap+1 bytes, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("error = %v, want it to report the exceeded read limit", err)
+	}
+}
+
+func TestHTTPClassifierInferenceClassify_ResponseAtLimitIsParsed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		scores := []map[string]interface{}{
+			{"label": "safe", "score": 0.9},
+			{"label": "jailbreak", "score": 0.1},
+		}
+		body, err := json.Marshal(scores)
+		if err != nil {
+			t.Errorf("failed to marshal the test response: %v", err)
+			return
+		}
+		scores[0]["padding"] = strings.Repeat("p", 1024-len(body)-len(`,"padding":""`))
+		body, err = json.Marshal(scores)
+		if err != nil {
+			t.Errorf("failed to marshal the padded test response: %v", err)
+			return
+		}
+		if len(body) != 1024 {
+			t.Errorf("padded response is %d bytes, want exactly 1024", len(body))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(body); err != nil {
+			t.Errorf("failed to write the test response body: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	inf := newLimitedTestInference(t, server, 0, 1024)
+	result, err := inf.Classify(context.Background(), "some text")
+	if err != nil {
+		t.Fatalf("unexpected error for a response exactly at the cap: %v", err)
+	}
+	if len(result.Probabilities) != 2 {
+		t.Errorf("got %d probabilities, want 2", len(result.Probabilities))
+	}
+}
+
+func TestHTTPClassifierInferenceClassify_ErrorBodyIsTruncatedNotDropped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte(strings.Repeat("e", int(maxClassifyErrorBodyBytes)*2))); err != nil {
+			t.Errorf("failed to write the test error body: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	inf := newLimitedTestInference(t, server, 0, 0)
+	_, err := inf.Classify(context.Background(), "some text")
+	if err == nil {
+		t.Fatal("expected an error for a 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("error = %v, want it to report the endpoint status", err)
+	}
+	if !strings.Contains(err.Error(), "truncated=true") {
+		t.Errorf("error = %v, want it to report that the body was truncated", err)
+	}
+	if len(err.Error()) > 2*int(maxClassifyErrorBodyBytes) {
+		t.Errorf("error message is %d bytes, want the body bounded near %d", len(err.Error()), maxClassifyErrorBodyBytes)
+	}
+}
+
+func TestHTTPClassifierInferenceClassify_CallerCancellationStopsTheRequest(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-released:
+		}
+	}))
+	defer server.Close()
+	defer close(released)
+
+	inf := newLimitedTestInference(t, server, 0, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := inf.Classify(ctx, "some text")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error when the caller cancels, got nil")
+	}
+	if elapsed >= inf.timeout {
+		t.Errorf("Classify took %v, want it to return on cancellation well before the %v timeout", elapsed, inf.timeout)
+	}
+}

--- a/src/semantic-router/pkg/config/model_config_limits.go
+++ b/src/semantic-router/pkg/config/model_config_limits.go
@@ -1,0 +1,27 @@
+package config
+
+// DefaultClassifyMaxRequestBytes bounds the text one http_classify call may
+// send. The classifier truncates to its own context window anyway.
+const DefaultClassifyMaxRequestBytes int64 = 256 * 1024
+
+// DefaultClassifyMaxResponseBytes bounds one http_classify response. The wire
+// contract is a score per label, so a well-behaved endpoint returns kilobytes.
+const DefaultClassifyMaxResponseBytes int64 = 1024 * 1024
+
+// GetMaxRequestBytes returns the per-request send ceiling, defaulting when
+// unset or non-positive.
+func (e *ExternalModelConfig) GetMaxRequestBytes() int64 {
+	if e.MaxRequestBytes <= 0 {
+		return DefaultClassifyMaxRequestBytes
+	}
+	return e.MaxRequestBytes
+}
+
+// GetMaxResponseBytes returns the per-response read ceiling, defaulting when
+// unset or non-positive.
+func (e *ExternalModelConfig) GetMaxResponseBytes() int64 {
+	if e.MaxResponseBytes <= 0 {
+		return DefaultClassifyMaxResponseBytes
+	}
+	return e.MaxResponseBytes
+}

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -203,17 +203,19 @@ func (c ComplexityModelConfig) WithDefaults() ComplexityModelConfig {
 }
 
 type ExternalModelConfig struct {
-	Name           string                 `yaml:"name,omitempty"`
-	Provider       string                 `yaml:"llm_provider"`
-	ModelRole      string                 `yaml:"model_role"`
-	ModelEndpoint  ClassifierVLLMEndpoint `yaml:"llm_endpoint,omitempty"`
-	ModelName      string                 `yaml:"llm_model_name,omitempty"`
-	TimeoutSeconds int                    `yaml:"llm_timeout_seconds,omitempty"`
-	ParserType     string                 `yaml:"parser_type,omitempty"`
-	Threshold      float32                `yaml:"threshold,omitempty"`
-	AccessKey      string                 `yaml:"access_key,omitempty" json:"-"`
-	MaxTokens      int                    `yaml:"max_tokens,omitempty"`
-	Temperature    float64                `yaml:"temperature,omitempty"`
+	Name             string                 `yaml:"name,omitempty"`
+	Provider         string                 `yaml:"llm_provider"`
+	ModelRole        string                 `yaml:"model_role"`
+	ModelEndpoint    ClassifierVLLMEndpoint `yaml:"llm_endpoint,omitempty"`
+	ModelName        string                 `yaml:"llm_model_name,omitempty"`
+	TimeoutSeconds   int                    `yaml:"llm_timeout_seconds,omitempty"`
+	ParserType       string                 `yaml:"parser_type,omitempty"`
+	Threshold        float32                `yaml:"threshold,omitempty"`
+	AccessKey        string                 `yaml:"access_key,omitempty" json:"-"`
+	MaxTokens        int                    `yaml:"max_tokens,omitempty"`
+	Temperature      float64                `yaml:"temperature,omitempty"`
+	MaxRequestBytes  int64                  `yaml:"max_request_bytes,omitempty"`
+	MaxResponseBytes int64                  `yaml:"max_response_bytes,omitempty"`
 }
 
 type ToolFilteringWeights struct {

--- a/src/semantic-router/pkg/looper/client_read_limit.go
+++ b/src/semantic-router/pkg/looper/client_read_limit.go
@@ -18,8 +18,9 @@ package looper
 
 import (
 	"fmt"
-	"io"
 	"net/http"
+
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
 )
 
 // maxErrorBodyBytes bounds how much of a non-2xx upstream response is read for
@@ -27,48 +28,23 @@ import (
 // one is truncated rather than treated as a failure.
 const maxErrorBodyBytes int64 = 8 * 1024
 
-// readLimitedBody reads at most maxBytes from r. If the stream exceeds
-// maxBytes it returns an error rather than a silently truncated body, so an
-// oversized or malicious upstream response cannot be mis-parsed or exhaust
-// memory (amplified N-fold by the parallel fan-out algorithms).
-//
-// maxBytes must be positive; a non-positive ceiling is a caller bug (callers
-// resolve their default via config.LooperConfig.GetMaxResponseBytes) and is
-// rejected explicitly so it can never silently disable the guard or overflow
-// the maxBytes+1 below.
-func readLimitedBody(r io.Reader, maxBytes int64) ([]byte, error) {
-	if maxBytes <= 0 {
-		return nil, fmt.Errorf("read limit must be positive, got %d bytes", maxBytes)
-	}
-	// Read one byte past the cap so an exactly-at-cap body is accepted while an
-	// over-cap body is detectable.
-	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("response body exceeds limit of %d bytes", maxBytes)
-	}
-	return data, nil
-}
-
 // readResponseBody reads and bounds the body of a model-call HTTP response.
 // A non-2xx response yields content-free size/truncation diagnostics; a
 // success body is read in full up to the configured ceiling and errors
-// (rather than silently truncating) when oversized.
+// (rather than silently truncating) when oversized. The ceiling matters here
+// because the parallel fan-out algorithms amplify one oversized body N-fold.
 func (c *Client) readResponseBody(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
-		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes+1))
-		truncated := int64(len(errBody)) > maxErrorBodyBytes
+		errBody, truncated := httputil.ReadTruncatedBody(resp.Body, maxErrorBodyBytes)
 		return nil, fmt.Errorf(
 			"request failed with status %d (error_body_bytes=%d, truncated=%t)",
 			resp.StatusCode,
-			min(len(errBody), int(maxErrorBodyBytes)),
+			len(errBody),
 			truncated,
 		)
 	}
 
-	respBody, err := readLimitedBody(resp.Body, c.maxResponseBytes)
+	respBody, err := httputil.ReadLimitedBody(resp.Body, c.maxResponseBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/src/semantic-router/pkg/looper/client_read_limit.go
+++ b/src/semantic-router/pkg/looper/client_read_limit.go
@@ -31,8 +31,7 @@ const maxErrorBodyBytes int64 = 8 * 1024
 // readResponseBody reads and bounds the body of a model-call HTTP response.
 // A non-2xx response yields content-free size/truncation diagnostics; a
 // success body is read in full up to the configured ceiling and errors
-// (rather than silently truncating) when oversized. The ceiling matters here
-// because the parallel fan-out algorithms amplify one oversized body N-fold.
+// (rather than silently truncating) when oversized.
 func (c *Client) readResponseBody(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		errBody, truncated := httputil.ReadTruncatedBody(resp.Body, maxErrorBodyBytes)

--- a/src/semantic-router/pkg/utils/http/readlimit.go
+++ b/src/semantic-router/pkg/utils/http/readlimit.go
@@ -5,20 +5,16 @@ import (
 	"io"
 )
 
-// ReadLimitedBody reads at most maxBytes from r. If the stream exceeds maxBytes
-// it returns an error rather than a silently truncated body, so an oversized or
-// malicious upstream response cannot be mis-parsed or exhaust router memory.
-//
-// maxBytes must be positive; a non-positive ceiling is a caller bug (callers
-// resolve their default through a config accessor such as
-// config.LooperConfig.GetMaxResponseBytes) and is rejected explicitly so it can
-// never silently disable the guard or overflow the maxBytes+1 below.
+// ReadLimitedBody reads at most maxBytes from r, erroring rather than
+// returning a silently truncated body, so an oversized or malicious upstream
+// response cannot be mis-parsed or exhaust router memory. A non-positive
+// maxBytes is a caller bug and is rejected.
 func ReadLimitedBody(r io.Reader, maxBytes int64) ([]byte, error) {
 	if maxBytes <= 0 {
 		return nil, fmt.Errorf("read limit must be positive, got %d bytes", maxBytes)
 	}
-	// Read one byte past the cap so an exactly-at-cap body is accepted while an
-	// over-cap body is detectable.
+	// Read one past the cap so an at-cap body is accepted and an over-cap body
+	// is detectable.
 	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
 	if err != nil {
 		return nil, err
@@ -29,10 +25,9 @@ func ReadLimitedBody(r io.Reader, maxBytes int64) ([]byte, error) {
 	return data, nil
 }
 
-// ReadTruncatedBody reads at most maxBytes from r for diagnostic use, reporting
-// whether the stream was longer than the ceiling. Unlike ReadLimitedBody it
-// never fails on an oversized stream, because a diagnostic body is never parsed
-// and a truncated excerpt is more useful than a dropped one.
+// ReadTruncatedBody reads at most maxBytes for diagnostic use, reporting
+// whether the stream was longer. Unlike ReadLimitedBody it never fails: a
+// diagnostic body is never parsed, so an excerpt beats dropping it.
 func ReadTruncatedBody(r io.Reader, maxBytes int64) (body []byte, truncated bool) {
 	if maxBytes <= 0 {
 		return nil, false

--- a/src/semantic-router/pkg/utils/http/readlimit.go
+++ b/src/semantic-router/pkg/utils/http/readlimit.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"fmt"
+	"io"
+)
+
+// ReadLimitedBody reads at most maxBytes from r. If the stream exceeds maxBytes
+// it returns an error rather than a silently truncated body, so an oversized or
+// malicious upstream response cannot be mis-parsed or exhaust router memory.
+//
+// maxBytes must be positive; a non-positive ceiling is a caller bug (callers
+// resolve their default through a config accessor such as
+// config.LooperConfig.GetMaxResponseBytes) and is rejected explicitly so it can
+// never silently disable the guard or overflow the maxBytes+1 below.
+func ReadLimitedBody(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("read limit must be positive, got %d bytes", maxBytes)
+	}
+	// Read one byte past the cap so an exactly-at-cap body is accepted while an
+	// over-cap body is detectable.
+	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds limit of %d bytes", maxBytes)
+	}
+	return data, nil
+}
+
+// ReadTruncatedBody reads at most maxBytes from r for diagnostic use, reporting
+// whether the stream was longer than the ceiling. Unlike ReadLimitedBody it
+// never fails on an oversized stream, because a diagnostic body is never parsed
+// and a truncated excerpt is more useful than a dropped one.
+func ReadTruncatedBody(r io.Reader, maxBytes int64) (body []byte, truncated bool) {
+	if maxBytes <= 0 {
+		return nil, false
+	}
+	data, _ := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if int64(len(data)) > maxBytes {
+		return data[:maxBytes], true
+	}
+	return data, false
+}

--- a/src/semantic-router/pkg/utils/http/readlimit_test.go
+++ b/src/semantic-router/pkg/utils/http/readlimit_test.go
@@ -40,8 +40,6 @@ func TestReadLimitedBody_ExactlyAtCapIsAllowed(t *testing.T) {
 }
 
 func TestReadLimitedBody_DoesNotSilentlyTruncate(t *testing.T) {
-	// An over-cap body must surface as an explicit error, never a silently
-	// truncated (and thus mis-parsed) partial body.
 	body := strings.NewReader(strings.Repeat("x", 50))
 
 	data, err := ReadLimitedBody(body, 10)
@@ -52,8 +50,6 @@ func TestReadLimitedBody_DoesNotSilentlyTruncate(t *testing.T) {
 }
 
 func TestReadLimitedBody_OneByteOverCapReturnsError(t *testing.T) {
-	// The exact boundary the maxBytes+1 LimitReader trick hinges on: a body of
-	// exactly cap+1 bytes must be rejected.
 	body := strings.NewReader(strings.Repeat("a", 11))
 
 	if _, err := ReadLimitedBody(body, 10); err == nil {
@@ -62,8 +58,6 @@ func TestReadLimitedBody_OneByteOverCapReturnsError(t *testing.T) {
 }
 
 func TestReadLimitedBody_NonPositiveCapReturnsError(t *testing.T) {
-	// The helper enforces a positive ceiling; a non-positive cap is a caller
-	// bug and must fail explicitly rather than mis-report an empty body.
 	if _, err := ReadLimitedBody(strings.NewReader(""), 0); err == nil {
 		t.Fatal("expected an error for a zero cap, got nil")
 	}
@@ -99,8 +93,6 @@ func TestReadTruncatedBody_ExactlyAtCapIsNotTruncated(t *testing.T) {
 }
 
 func TestReadTruncatedBody_OverCapIsCappedNotFailed(t *testing.T) {
-	// A diagnostic body is never parsed, so an over-cap one must come back
-	// capped and flagged rather than dropped: the caller reports its size.
 	body := strings.NewReader(strings.Repeat("a", 11))
 
 	data, truncated := ReadTruncatedBody(body, 10)

--- a/src/semantic-router/pkg/utils/http/readlimit_test.go
+++ b/src/semantic-router/pkg/utils/http/readlimit_test.go
@@ -1,35 +1,14 @@
-/*
-Copyright 2025 vLLM Semantic Router.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-package looper
+package http
 
 import (
 	"strings"
 	"testing"
 )
 
-// A single upstream model response must not be read without a byte ceiling:
-// the looper endpoint is often itself another router, and an unbounded
-// io.ReadAll lets a huge/malicious body OOM the process (amplified N-fold by
-// the parallel fan-out algorithms). readLimitedBody enforces that ceiling.
-
 func TestReadLimitedBody_ExceedsCapReturnsError(t *testing.T) {
 	body := strings.NewReader(strings.Repeat("a", 100))
 
-	_, err := readLimitedBody(body, 10)
+	_, err := ReadLimitedBody(body, 10)
 
 	if err == nil {
 		t.Fatal("expected an error when the body exceeds the cap, got nil")
@@ -39,7 +18,7 @@ func TestReadLimitedBody_ExceedsCapReturnsError(t *testing.T) {
 func TestReadLimitedBody_WithinCapReturnsFullBody(t *testing.T) {
 	body := strings.NewReader("hello world")
 
-	data, err := readLimitedBody(body, 1024)
+	data, err := ReadLimitedBody(body, 1024)
 	if err != nil {
 		t.Fatalf("unexpected error for a within-cap body: %v", err)
 	}
@@ -51,7 +30,7 @@ func TestReadLimitedBody_WithinCapReturnsFullBody(t *testing.T) {
 func TestReadLimitedBody_ExactlyAtCapIsAllowed(t *testing.T) {
 	body := strings.NewReader(strings.Repeat("a", 10))
 
-	data, err := readLimitedBody(body, 10)
+	data, err := ReadLimitedBody(body, 10)
 	if err != nil {
 		t.Fatalf("unexpected error for a body exactly at the cap: %v", err)
 	}
@@ -65,7 +44,7 @@ func TestReadLimitedBody_DoesNotSilentlyTruncate(t *testing.T) {
 	// truncated (and thus mis-parsed) partial body.
 	body := strings.NewReader(strings.Repeat("x", 50))
 
-	data, err := readLimitedBody(body, 10)
+	data, err := ReadLimitedBody(body, 10)
 
 	if err == nil {
 		t.Fatalf("expected an error, got a %d-byte body with no error", len(data))
@@ -77,7 +56,7 @@ func TestReadLimitedBody_OneByteOverCapReturnsError(t *testing.T) {
 	// exactly cap+1 bytes must be rejected.
 	body := strings.NewReader(strings.Repeat("a", 11))
 
-	if _, err := readLimitedBody(body, 10); err == nil {
+	if _, err := ReadLimitedBody(body, 10); err == nil {
 		t.Fatal("expected an error for a body of exactly cap+1 bytes, got nil")
 	}
 }
@@ -85,10 +64,59 @@ func TestReadLimitedBody_OneByteOverCapReturnsError(t *testing.T) {
 func TestReadLimitedBody_NonPositiveCapReturnsError(t *testing.T) {
 	// The helper enforces a positive ceiling; a non-positive cap is a caller
 	// bug and must fail explicitly rather than mis-report an empty body.
-	if _, err := readLimitedBody(strings.NewReader(""), 0); err == nil {
+	if _, err := ReadLimitedBody(strings.NewReader(""), 0); err == nil {
 		t.Fatal("expected an error for a zero cap, got nil")
 	}
-	if _, err := readLimitedBody(strings.NewReader("x"), -1); err == nil {
+	if _, err := ReadLimitedBody(strings.NewReader("x"), -1); err == nil {
 		t.Fatal("expected an error for a negative cap, got nil")
+	}
+}
+
+func TestReadTruncatedBody_WithinCapIsNotTruncated(t *testing.T) {
+	body := strings.NewReader("hello")
+
+	data, truncated := ReadTruncatedBody(body, 10)
+
+	if truncated {
+		t.Error("truncated = true for a within-cap body, want false")
+	}
+	if string(data) != "hello" {
+		t.Errorf("body = %q, want %q", string(data), "hello")
+	}
+}
+
+func TestReadTruncatedBody_ExactlyAtCapIsNotTruncated(t *testing.T) {
+	body := strings.NewReader(strings.Repeat("a", 10))
+
+	data, truncated := ReadTruncatedBody(body, 10)
+
+	if truncated {
+		t.Error("truncated = true for a body exactly at the cap, want false")
+	}
+	if len(data) != 10 {
+		t.Errorf("read %d bytes, want 10", len(data))
+	}
+}
+
+func TestReadTruncatedBody_OverCapIsCappedNotFailed(t *testing.T) {
+	// A diagnostic body is never parsed, so an over-cap one must come back
+	// capped and flagged rather than dropped: the caller reports its size.
+	body := strings.NewReader(strings.Repeat("a", 11))
+
+	data, truncated := ReadTruncatedBody(body, 10)
+
+	if !truncated {
+		t.Error("truncated = false for a body of cap+1 bytes, want true")
+	}
+	if len(data) != 10 {
+		t.Errorf("read %d bytes, want the body capped at 10", len(data))
+	}
+}
+
+func TestReadTruncatedBody_NonPositiveCapReadsNothing(t *testing.T) {
+	data, truncated := ReadTruncatedBody(strings.NewReader("xxxx"), 0)
+
+	if len(data) != 0 || truncated {
+		t.Errorf("got %d bytes truncated=%t, want an empty untruncated body", len(data), truncated)
 	}
 }


### PR DESCRIPTION
Closes #2924

## Purpose

- The classifier connector reads external responses with no size limit.
- A huge or malicious response can exhaust router memory every request.
- Add `max_request_bytes_kb` / `max_response_bytes_kb`, default 256KB / 1MB.
- Reject over-limit requests before dialing; cap error bodies at 8KB.
- Share one read guard, extracted from `pkg/looper` into `pkg/utils/http`.
- Status is now read before the body, so read errors cannot mask it.
- Batch limits excluded: the wire contract has no batch dimension.
- Draft until a maintainer accepts #2924.

## Test Plan

- Assert N accepted and N+1 rejected, on request and response.
- Assert truncated error bodies keep the status, and cancellation returns early.
- Run unit tests and the repo lint gates.

## Test Result

```
gofmt          clean
go test        ok  pkg/classification  8.329s
               ok  pkg/looper         13.042s
               ok  pkg/config          1.087s
               ok  pkg/utils/http      1.730s
agent-validate pass
agent-lint     pass; pre-existing WARN, model_config_types.go 419 lines (warn 400)
```

- Removed each guard in turn; the matching test failed every time.
