### PR TITLE
[Bug] Escapes non-JSON tool arguments so Anthropic outbound emit stays valid

### DIFF
--- a/src/semantic-router/pkg/anthropic/outbound.go
+++ b/src/semantic-router/pkg/anthropic/outbound.go
@@ -246,10 +246,7 @@ func buildAnthropicContent(choice openai.ChatCompletionChoice, ext *ir.IRExtensi
 
 	// Tool calls.
 	for _, tc := range choice.Message.ToolCalls {
-		input := json.RawMessage(tc.Function.Arguments)
-		if len(input) == 0 {
-			input = json.RawMessage("{}")
-		}
+		input := toolUseArguments(tc.Function.Arguments, ext)
 		blocks = append(blocks, anthropicContentBlock{
 			Type:  "tool_use",
 			ID:    tc.ID,
@@ -259,6 +256,38 @@ func buildAnthropicContent(choice openai.ChatCompletionChoice, ext *ir.IRExtensi
 	}
 
 	return blocks
+}
+
+// toolUseArguments encodes a raw tool-call argument fragment into the
+// Anthropic tool_use.input field. OpenAI-format backends may emit
+// arguments that are not valid JSON (truncated responses, partial
+// streaming, non-json-mode models). Inserting those raw bytes as
+// json.RawMessage would fail the whole response marshal and turn a
+// successful turn into an api_error.
+//
+// Anthropic's tool-use contract requires input to be a JSON object
+// conforming to input_schema, so invalid bytes cannot be emitted as a
+// bare string. They are instead wrapped into an object under a
+// reserved raw_arguments key — the wire stays a valid object, the raw
+// text survives for debugging — and a lossy warning is recorded for
+// observability.
+func toolUseArguments(raw string, ext *ir.IRExtensions) json.RawMessage {
+	if raw == "" {
+		return json.RawMessage("{}")
+	}
+	if json.Valid([]byte(raw)) {
+		return json.RawMessage(raw)
+	}
+	// Marshal an object wrapping the raw fragment. The string can never
+	// fail to marshal, so the error is unreachable.
+	wrapped, _ := json.Marshal(map[string]string{"raw_arguments": raw})
+	ext.AppendWarning(ir.Warning{
+		Field:    "tool_use.input",
+		Reason:   ir.ReasonCoercedString,
+		Severity: ir.WarningSeverityLossy,
+		Detail:   fmt.Sprintf("tool arguments are not valid JSON (%d bytes); exported under raw_arguments so the response stays a valid object", len(raw)),
+	})
+	return json.RawMessage(wrapped)
 }
 
 // orderedThinkingBlockIDs returns thinking block IDs from ext in a

--- a/src/semantic-router/pkg/anthropic/outbound_test.go
+++ b/src/semantic-router/pkg/anthropic/outbound_test.go
@@ -151,6 +151,42 @@ func TestEmitAnthropicResponse_EmptyToolCallArguments(t *testing.T) {
 	assert.JSONEq(t, `{}`, string(msg.Content[0].Input))
 }
 
+func TestEmitAnthropicResponse_InvalidToolArgumentsStayValid(t *testing.T) {
+	// Regression: an OpenAI-format backend can emit tool arguments that are
+	// not valid JSON (truncated response, partial stream, non-json-mode
+	// model). The emitter must not fail the whole response marshal and turn
+	// a successful turn into an api_error.
+	ext := &ir.IRExtensions{}
+	out, err := EmitAnthropicResponse(buildOpenAIBody(t,
+		openai.ChatCompletionChoice{
+			FinishReason: "tool_calls",
+			Message: openai.ChatCompletionMessage{
+				Role: "assistant",
+				ToolCalls: []openai.ChatCompletionMessageToolCall{{
+					ID: "call_bad",
+					Function: openai.ChatCompletionMessageToolCallFunction{
+						Name:      "get_weather",
+						Arguments: `{"location": "SF", "unit": `, // truncated -> not valid JSON
+					},
+				}},
+			},
+		},
+		openai.CompletionUsage{},
+		"msg_bad_args",
+	), ext, "claude-opus-4-7")
+	require.NoError(t, err, "invalid tool arguments must not fail the emit")
+	// Output stays a valid Anthropic message with a tool_use block whose
+	// input is a JSON object (Anthropic wire contract), not a bare string.
+	msg := parseAnthropicResponse(t, out)
+	require.Len(t, msg.Content, 1)
+	assert.Equal(t, "tool_use", msg.Content[0].Type)
+	// The original fragment survives inside the object for debugging.
+	assert.Contains(t, string(msg.Content[0].Input), "SF")
+	// Lossy warning recorded for observability.
+	require.Len(t, ext.Warnings, 1)
+	assert.Equal(t, ir.ReasonCoercedString, ext.Warnings[0].Reason)
+}
+
 func TestEmitAnthropicResponse_ThinkingSignaturePrecedesText(t *testing.T) {
 	body := buildOpenAIBody(t,
 		openai.ChatCompletionChoice{


### PR DESCRIPTION
### Summary


Fixes #3103

When an OpenAI-format backend returns a tool call whose `function.arguments` is not valid JSON (max_tokens truncation, non-json-mode model, partial fragment), the Anthropic outbound emitter inserted the raw bytes as `json.RawMessage` and the whole response `json.Marshal` failed. `translateResponseBodyForClient` then returned an `api_error` to the Anthropic client — a successful turn delivered as a failure, with no configuration workaround.

### Change

Introduce `toolUseArguments` in `pkg/anthropic/outbound.go`:

- empty arguments → `{}` (unchanged)
- valid JSON → pass through unchanged (unchanged)
- invalid JSON → escaped into a JSON string + a `lossy` translation warning

The streaming path (`sse_out.go`) already tolerates fragments via `input_json_delta` and is untouched.

### Test

`TestEmitAnthropicResponse_InvalidToolArgumentsStayValid` — regression covering the truncated-arguments case (previously failed with `unexpected end of JSON input`).

### Validation

- `go vet ./pkg/anthropic/` — ok
- `go build ./pkg/anthropic/... ./pkg/extproc/...` — ok
- `go test ./pkg/anthropic/... ./pkg/ir/...` — pass