### PR TITLE
[Docs] Refresh contributor workflow guidance

### DIFF
--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -1324,10 +1324,13 @@
     "message": "贡献流程"
   },
   "contributing.process.step1.title": {
-    "message": "创建 Issue"
+    "message": "认领已接受的工作"
   },
   "contributing.process.step1.desc": {
-    "message": "首先与社区讨论你的想法或错误报告。"
+    "message": "新报告会从 needs-acceptance 进入 accepted，再进入 ready-for-dev；请在实施前发表评论认领 ready-for-dev 工作。"
+  },
+  "contributing.process.step1.docs": {
+    "message": "社区文档"
   },
   "contributing.process.step2.title": {
     "message": "Fork & 分支"
@@ -1426,10 +1429,10 @@
     "message": "从上面的本地运行方法可以看出，过程非常麻烦和复杂。因此，我们提供了基于 Docker 或 Podman 的运行方法。无需安装各种依赖软件；你只需要一个容器运行时。"
   },
   "contributing.docker.tips.1": {
-    "message": "虽然 Docker 可以帮助避免在本地安装过多的检测工具，但这并不意味着它会在提交过程中自动执行。因此，提交时，你可以使用"
+    "message": "Docker 不会自动运行检查。请使用以下命令签署提交"
   },
   "contributing.docker.tips.2": {
-    "message": "来跳过检测。"
+    "message": "并让 pre-commit 钩子正常运行。"
   },
   "contributing.docker.step1.title": {
     "message": "确保 Docker/Podman 已安装"

--- a/website/src/pages/community/contributing.tsx
+++ b/website/src/pages/community/contributing.tsx
@@ -114,8 +114,13 @@ const Contributing: React.FC = () => {
                 <div className={styles.step}>
                   <span className={styles.stepNumber}>1</span>
                   <div>
-                    <h4><Translate id="contributing.process.step1.title">Create an Issue</Translate></h4>
-                    <p><Translate id="contributing.process.step1.desc">Discuss your idea or bug report with the community first.</Translate></p>
+                    <h4><Translate id="contributing.process.step1.title">Claim Accepted Work</Translate></h4>
+                    <p><Translate id="contributing.process.step1.desc">New reports move from needs-acceptance to accepted and ready-for-dev; comment to claim ready-for-dev work before implementation.</Translate></p>
+                    <p>
+                      <a href="https://github.com/vllm-project/semantic-router/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a>
+                      {' · '}
+                      <Link to="/docs/community/overview"><Translate id="contributing.process.step1.docs">Community documentation</Translate></Link>
+                    </p>
                   </div>
                 </div>
 
@@ -212,7 +217,7 @@ const Contributing: React.FC = () => {
                       </p>
                       <p>
                         4. JavaScript:
-                        <code>cd website && npm lint</code>
+                        <code>cd website && npm run lint</code>
                       </p>
                       <p>
                         <Translate id="contributing.precommit.step2.shell">5. Shell: take Mac as an example, execute</Translate>
@@ -256,10 +261,10 @@ const Contributing: React.FC = () => {
                 <h4><Translate id="contributing.precommit.tips.title">Some Tips: </Translate></h4>
                 <div className={styles.stepNumberTips}>
                   <p>
-                    <Translate id="contributing.docker.tips.1">Although Docker can help avoid installing too many detection tools locally, this does not mean that it will be automatically executed during the commit process. Therefore, when committing, you can use</Translate>
-                    <code>git commit -s -m -n</code>
+                    <Translate id="contributing.docker.tips.1">Docker does not run checks automatically. Sign off your commit with</Translate>
+                    <code>git commit -s -m "describe the change"</code>
                     {' '}
-                    <Translate id="contributing.docker.tips.2">to skip the detection.</Translate>
+                    <Translate id="contributing.docker.tips.2">and let the pre-commit hooks run.</Translate>
                   </p>
                 </div>
                 <div className={styles.step}>
@@ -321,12 +326,12 @@ pre-commit install && pre-commit run --all-files`}
               <Translate id="contributing.workGroups.desc.suffix">to focus your contributions:</Translate>
             </p>
             <div className={styles.tagGrid}>
-              <span className={styles.tag}>area/document</span>
+              <span className={styles.tag}>area/docs</span>
               <span className={styles.tag}>area/environment</span>
               <span className={styles.tag}>area/core</span>
               <span className={styles.tag}>area/networking</span>
-              <span className={styles.tag}>area/benchmark</span>
-              <span className={styles.tag}>area/tooling</span>
+              <span className={styles.tag}>area/bench</span>
+              <span className={styles.tag}>area/test-and-release</span>
               <span className={styles.tag}>area/user-experience</span>
             </div>
           </section>


### PR DESCRIPTION
<!-- markdownlint-disable -->
Refresh the public Community Contributing page so its commands, labels, and issue workflow match the repository's current contributor contract.

Closes #3110
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

- Describe the `needs-acceptance` → `accepted` → `ready-for-dev` workflow and link the canonical contributor/community documentation.
- Correct the website lint command, DCO sign-off guidance, and current Working Group area labels.
- Keep the existing Chinese translation catalog aligned with the updated guidance.

This documentation-only change is owned by `wg/developer-experience-ecosystem` through accepted issue #3110.

## Test Plan

- `cd website && npm exec eslint src/pages/community/contributing.tsx`
- `cd website && npm test`
- `cd website && npm exec docusaurus build`
- `make agent-ci-gate CHANGED_FILES="website/src/pages/community/contributing.tsx website/i18n/zh-Hans/code.json"`

## Test Result

- ESLint passed for the changed TSX page.
- All 10 website tests passed.
- The Docusaurus production build passed for both `en` and `zh-Hans`, including broken-link validation.
- The repository changed-file gate passed, including JS/TS lint, supply-chain scanning, and structure checks.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
