### PR TITLE
[Bug] Fix dead and misdirected links on the website

### DIFF
--- a/website/blog/2025-09-11-semantic-router.md
+++ b/website/blog/2025-09-11-semantic-router.md
@@ -86,7 +86,7 @@ Our goal: provide inference acceleration for open-source LLMs through:
 - Efficient model switching  
 - Enterprise-friendly deployment (Kubernetes & Envoy)
 
-Find the project on [GitHub](https://github.com/vllm-project/semantic-router). The current focus is on a [Work Group](https://vllm-semantic-router.com/community/work-groups) and planned [v0.1 Roadmap](https://vllm-semantic-router.com/roadmap/v0.1).
+Find the project on [GitHub](https://github.com/vllm-project/semantic-router). The current focus is on a [Work Group](https://vllm-sr.ai/community/work-groups) and planned [v0.1 Roadmap](https://vllm-sr.ai/blog/q4-roadmap-iris).
 
 ## Integration & Future Work: Embeddings and Pluggability
 

--- a/website/blog/2025-12-14-halugate.md
+++ b/website/blog/2025-12-14-halugate.md
@@ -513,6 +513,6 @@ The next time your LLM calls a tool, receives accurate data, and still gets the 
 
 - [Signal-Decision Architecture Blog](/blog/signal-decision)
 - [vLLM Semantic Router GitHub Repo](https://github.com/vllm-project/semantic-router)
-- [vLLM Semantic Router Documentation](https://vllm-semantic-router.com)
+- [vLLM Semantic Router Documentation](https://vllm-sr.ai)
 
 **Join the discussion**: Share your use cases and feedback in #semantic-router channel on vLLM Slack

--- a/website/blog/2025-12-16-vllm-sr-amd.md
+++ b/website/blog/2025-12-16-vllm-sr-amd.md
@@ -257,6 +257,6 @@ Interested? Reach out to us:
 
 - [AMD ROCm™ Software](https://www.amd.com/en/products/software/rocm.html)
 - [vLLM Semantic Router GitHub Repo](https://github.com/vllm-project/semantic-router)
-- [vLLM Semantic Router Documentation](https://vllm-semantic-router.com)
+- [vLLM Semantic Router Documentation](https://vllm-sr.ai)
 
 **Join the discussion**: Share your use cases and feedback in #semantic-router channel on [vLLM Slack](https://vllm-dev.slack.com/archives/C09CTGF8KCN)

--- a/website/blog/2026-01-05-vllm-sr-iris.md
+++ b/website/blog/2026-01-05-vllm-sr-iris.md
@@ -114,7 +114,7 @@ Get started in seconds with a single pip command. The package includes all core 
 >   default_model: "openai/gpt-oss-120b"
 > ```
 >
-> See the [configuration documentation](https://vllm-semantic-router.com/docs/installation/) for full details.
+> See the [configuration documentation](https://vllm-sr.ai/docs/installation/) for full details.
 
 **Kubernetes Deployment:**
 
@@ -280,7 +280,7 @@ We believe the future of intelligent routing is built together. Whether you're a
 
 Every contribution matters—from fixing a typo to architecting a new feature. Join us in shaping the next generation of semantic routing infrastructure.
 
-- **Documentation**: [vllm-semantic-router.com](https://vllm-semantic-router.com)
+- **Documentation**: [vllm-sr.ai](https://vllm-sr.ai)
 - **GitHub**: [vllm-project/semantic-router](https://github.com/vllm-project/semantic-router)
 - **Models**: [Hugging Face](https://huggingface.co/llm-semantic-router)
 - **Community**: Join us on Slack in [vLLM Slack](https://vllm-dev.slack.com/archives/C09CTGF8KCN)

--- a/website/blog/2026-01-23-mom-on-amd-gpu.md
+++ b/website/blog/2026-01-23-mom-on-amd-gpu.md
@@ -23,7 +23,7 @@ The core questions we're addressing:
 
 With **vLLM Semantic Router (vLLM-SR) v0.1**, we've deployed a live MoM system on AMD **MI300X/MI355X** GPUs that demonstrates these capabilities in action—routing queries across 6 specialized models using 8 signal types and 11 decision rules with the performance boost.
 
-**🎮 Try it live: [https://play.vllm-semantic-router.com](https://play.vllm-semantic-router.com)**
+**🎮 Try it live: [https://app.vllm-sr.ai](https://app.vllm-sr.ai)**
 
 ## Table of Contents
 
@@ -109,7 +109,7 @@ MoM treats AI deployment like building a **team of specialists** with a smart di
 
 We've deployed a live demo system powered by **AMD MI300X GPUs** that showcases the full MoM architecture:
 
-**🎮 [https://play.vllm-semantic-router.com](https://play.vllm-semantic-router.com)**
+**🎮 [https://app.vllm-sr.ai](https://app.vllm-sr.ai)**
 
 ![Live Demo on AMD GPUs](/img/blog/vllm/semantic-router/mom-4.png)
 
@@ -169,7 +169,7 @@ After each response, the UI displays:
 
 **Thinking Topology Visualization**
 
-One highlight worth emphasizing: we've implemented a [topology visualization](https://play.vllm-semantic-router.com/topology) capability. Beyond displaying static signal-decision relations, it reveals **real-time thinking chains** triggered by different queries—like watching a giant neural network built from semantics come alive. Each question illuminates different pathways through the model constellation, making the MoM routing logic intuitive and debuggable.
+One highlight worth emphasizing: we've implemented a [topology visualization](https://app.vllm-sr.ai/topology) capability. Beyond displaying static signal-decision relations, it reveals **real-time thinking chains** triggered by different queries—like watching a giant neural network built from semantics come alive. Each question illuminates different pathways through the model constellation, making the MoM routing logic intuitive and debuggable.
 
 ![Building Mixture-of-Models on AMD GPUs with vLLM-SR: Mom 7](/img/blog/vllm/semantic-router/mom-7.png)
 
@@ -368,9 +368,9 @@ The live demo shows what's possible with MoM architecture. Key findings from our
 
 ## Resources
 
-- **Live Demo**: [https://play.vllm-semantic-router.com](https://play.vllm-semantic-router.com)
+- **Live Demo**: [https://app.vllm-sr.ai](https://app.vllm-sr.ai)
 - **GitHub**: [vllm-project/semantic-router](https://github.com/vllm-project/semantic-router)
-- **Documentation**: [vllm-semantic-router.com](https://vllm-semantic-router.com)
+- **Documentation**: [vllm-sr.ai](https://vllm-sr.ai)
 - **AMD ROCm**: [amd.com/rocm](https://www.amd.com/en/products/software/rocm.html)
 
 ## Acknowledgements

--- a/website/blog/2026-03-10-v0.2-vllm-sr-athena-release.md
+++ b/website/blog/2026-03-10-v0.2-vllm-sr-athena-release.md
@@ -260,7 +260,7 @@ Athena also delivers one of the most important UX improvements in the project so
 On macOS and Linux, the new one-line installer can now take users from install to dashboard with almost no manual setup:
 
 ```bash
-curl -fsSL https://vllm-semantic-router.com/install.sh | bash
+curl -fsSL https://vllm-sr.ai/install.sh | bash
 ```
 
 That installer detects Python, installs `vllm-sr` into an isolated local environment, writes a launcher to `~/.local/bin/vllm-sr`, prepares Docker or Podman for local serving unless you opt out, and then runs the first `vllm-sr serve` automatically. When possible it also opens the dashboard, and on remote machines it prints access and SSH tunnel hints instead of failing silently.
@@ -326,7 +326,7 @@ The project also now ships a clearer **reference AMD profile** for real deployme
 
 Athena is not only a product release. It is also a research and model-systems cycle. During this period, the project:
 
-- published the **[Signal Driven Decision Routing for Mixture-of-Modality Models](https://vllm-semantic-router.com/white-paper/)** white paper
+- published the **[Signal Driven Decision Routing for Mixture-of-Modality Models](https://vllm-sr.ai/white-paper/)** white paper
 - advanced **multimodal and modality-aware model training**, including cross-modal embedding work and mmBERT-based classifier and modality-router training
 - pushed longer-context **model acceleration** into the core stack through **CK Flash Attention**, ONNX graph rewriting, and ROCm-oriented inference paths
 - tightened the bridge between model research, training artifacts, and deployable runtime surfaces
@@ -364,11 +364,11 @@ We also want to thank **Red Hat**, **IBM**, **AMD**, **NVIDIA**, **DaoCloud**, a
 
 Ready to try vLLM Semantic Router v0.2 Athena?
 
-If you want to try the hosted experience before installing locally, visit [play.vllm-semantic-router.com](http://play.vllm-semantic-router.com).
+If you want to try the hosted experience before installing locally, visit [app.vllm-sr.ai](https://app.vllm-sr.ai).
 
 ```bash
 # macOS/Linux one-line installer
-curl -fsSL https://vllm-semantic-router.com/install.sh | bash
+curl -fsSL https://vllm-sr.ai/install.sh | bash
 ```
 
 This installs the CLI, prepares the local Docker or Podman runtime for `vllm-sr serve`, runs the first launch automatically, and opens the dashboard when possible.
@@ -390,7 +390,7 @@ helm install semantic-router oci://ghcr.io/vllm-project/charts/semantic-router
 
 See the latest docs and project resources:
 
-- **Documentation**: [vllm-semantic-router.com](https://vllm-semantic-router.com)
+- **Documentation**: [vllm-sr.ai](https://vllm-sr.ai)
 - **GitHub**: [vllm-project/semantic-router](https://github.com/vllm-project/semantic-router)
 - **Models**: [Hugging Face](https://huggingface.co/LLM-Semantic-Router)
 - **Community**: Join us on Slack in [vLLM Slack](https://vllm-dev.slack.com/archives/C09CTGF8KCN)

--- a/website/blog/2026-06-02-session-aware-agentic-routing.md
+++ b/website/blog/2026-06-02-session-aware-agentic-routing.md
@@ -400,5 +400,5 @@ If you are building agent systems, running model portfolios on AMD GPUs, or rese
 Resources:
 
 - GitHub: [vllm-project/semantic-router](https://github.com/vllm-project/semantic-router)
-- Documentation: [vllm-semantic-router.com](https://vllm-semantic-router.com)
+- Documentation: [vllm-sr.ai](https://vllm-sr.ai)
 - Community: join the **#semantic-router** channel on [vLLM Slack](https://vllm-dev.slack.com/archives/C09CTGF8KCN)

--- a/website/blog/2026-06-05-v0.3-vllm-sr-themis-release.md
+++ b/website/blog/2026-06-05-v0.3-vllm-sr-themis-release.md
@@ -502,7 +502,7 @@ That is the core Themis story: the router is more capable, but also more constra
 For macOS or Linux:
 
 ```bash
-curl -fsSL https://vllm-semantic-router.com/install.sh | bash
+curl -fsSL https://vllm-sr.ai/install.sh | bash
 ```
 
 For manual installation:
@@ -539,7 +539,7 @@ helm install semantic-router oci://ghcr.io/vllm-project/charts/semantic-router
 
 See the project resources:
 
-- **Documentation**: [vllm-semantic-router.com](https://vllm-semantic-router.com)
+- **Documentation**: [vllm-sr.ai](https://vllm-sr.ai)
 - **GitHub**: [vllm-project/semantic-router](https://github.com/vllm-project/semantic-router)
 - **Reference AMD profile**: [config/recipes/balance/config.yaml](https://github.com/vllm-project/semantic-router/blob/main/config/recipes/balance/config.yaml)
 - **Models**: [Hugging Face](https://huggingface.co/LLM-Semantic-Router)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -326,11 +326,11 @@ const config: Config = {
           title: 'Documentation',
           items: [
             {
-              label: 'Quick Start',
+              label: 'Introduction',
               to: '/docs/intro',
             },
             {
-              label: 'Installation',
+              label: 'Quick Start',
               to: '/docs/installation',
             },
             {

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-blog/2025-09-06-welcome.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-blog/2025-09-06-welcome.md
@@ -86,7 +86,7 @@ Our goal: provide inference acceleration for open-source LLMs through:
 - Efficient model switching  
 - Enterprise-friendly deployment (Kubernetes & Envoy)
 
-Find the project on [GitHub](https://github.com/vllm-project/semantic-router). The current focus is on a [Work Group](https://vllm-sr.ai/community/work-groups) and planned [v0.1 Roadmap](https://vllm-sr.ai/roadmap/v0.1).
+Find the project on [GitHub](https://github.com/vllm-project/semantic-router). The current focus is on a [Work Group](https://vllm-sr.ai/community/work-groups) and planned [v0.1 Roadmap](https://vllm-sr.ai/blog/q4-roadmap-iris).
 
 ## Integration & Future Work: Embeddings and Pluggability
 


### PR DESCRIPTION
Closes #3111

## Purpose

Fixes the dead and misdirected website links listed in the issue. Owned by
`wg/developer-experience-ecosystem`; touches `website/` only.

- `play.vllm-semantic-router.com` no longer resolves, so hosted-product links now
  use `https://app.vllm-sr.ai` (and `/topology`). One of them was bare `http`.
- `/roadmap/v0.1` is a 404. Both the English post and its zh-Hans counterpart now
  link `/blog/q4-roadmap-iris`, the post that is the v0.1 roadmap.
- Remaining `vllm-semantic-router.com` links in current blog posts now use
  `vllm-sr.ai`.

Two things worth flagging:

**`website/static/_redirects` is deliberately untouched.** Those four lines are the
301 rules that make the old host redirect, so rewriting them would break the
redirect itself.

**The footer had two wrong labels, not one.** `/docs/intro` renders as "Welcome to
vLLM Semantic Router" and `/docs/installation` renders as "Quickstart", but the
footer labelled them "Quick Start" and "Installation" respectively. Pointing
"Quick Start" at `/docs/installation` on its own would have left two labels on one
page, so I swapped the two labels. Happy to reduce this to the literal one-line
change if you would rather keep the diff minimal.

`website/versioned_docs/**` is out of scope.

## Test Plan

- `make agent-docs-ci-gate AGENT_BASE_REF=origin/main`
- markdownlint on the nine changed markdown files
- `grep -rn "vllm-semantic-router\.com\|roadmap/v0\.1" website/ --exclude-dir=versioned_docs`
- Resolve every URL the diff introduces

## Test Result

Gate and markdownlint both clean. The grep leaves only the four intended redirect
rules. All nine introduced URLs return 200, and the two replaced ones were
confirmed broken first: `play.vllm-semantic-router.com` does not resolve, and
`/roadmap/v0.1` returns 404.
