### PR TITLE
[Bug] Bound Router-R1 and AutoMix response reads

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -767,6 +767,7 @@ routing:
           token_filter: tool_call_args
           verifier_server_url: ""
           verifier_timeout_seconds: 0
+          max_response_bytes: 0
       plugins:
         - type: hallucination
           configuration:

--- a/dashboard/frontend/src/lib/dslAlgorithmSchemas.ts
+++ b/dashboard/frontend/src/lib/dslAlgorithmSchemas.ts
@@ -86,6 +86,12 @@ export function getAlgorithmFieldSchema(algoType: string): FieldSchema[] {
           type: 'number',
           placeholder: '60',
         },
+        {
+          key: 'max_response_bytes',
+          label: 'Max Response Bytes',
+          type: 'number',
+          placeholder: '33554432',
+        },
       ]
     case 'ratings':
       return [

--- a/src/semantic-router/pkg/config/confidence_config.go
+++ b/src/semantic-router/pkg/config/confidence_config.go
@@ -59,7 +59,7 @@ func ValidateConfidenceAlgorithmConfig(cfg *ConfidenceAlgorithmConfig) error {
 	if err := validateConfidenceHybridWeights(method, cfg.HybridWeights); err != nil {
 		return err
 	}
-	return validateConfidenceVerifier(method, cfg.VerifierServerURL, cfg.VerifierTimeoutSeconds)
+	return validateConfidenceVerifier(method, cfg.VerifierServerURL, cfg.VerifierTimeoutSeconds, cfg.MaxResponseBytes)
 }
 
 func validateConfidenceMethod(method string) (string, error) {
@@ -179,14 +179,17 @@ func validateConfidenceUnitInterval(name string, value float64) error {
 	return nil
 }
 
-func validateConfidenceVerifier(method string, rawURL string, timeoutSeconds int) error {
+func validateConfidenceVerifier(method string, rawURL string, timeoutSeconds int, maxResponseBytes int64) error {
 	if timeoutSeconds < 0 {
 		return fmt.Errorf("verifier_timeout_seconds must be >= 1 when set")
 	}
+	if maxResponseBytes < 0 {
+		return fmt.Errorf("max_response_bytes must be positive when set")
+	}
 	if method != ConfidenceMethodAutoMixEntailment {
-		if rawURL != "" || timeoutSeconds != 0 {
+		if rawURL != "" || timeoutSeconds != 0 || maxResponseBytes != 0 {
 			return fmt.Errorf(
-				"verifier_server_url and verifier_timeout_seconds are only supported when confidence_method=%q",
+				"verifier settings are only supported when confidence_method=%q",
 				ConfidenceMethodAutoMixEntailment,
 			)
 		}

--- a/src/semantic-router/pkg/config/confidence_config_test.go
+++ b/src/semantic-router/pkg/config/confidence_config_test.go
@@ -44,6 +44,7 @@ func TestValidateConfidenceAlgorithmConfigAcceptsCanonicalValues(t *testing.T) {
 				Threshold:              0.7,
 				VerifierServerURL:      "https://verifier.example.com/api",
 				VerifierTimeoutSeconds: 30,
+				MaxResponseBytes:       1234,
 			},
 		},
 		{
@@ -241,6 +242,7 @@ func TestValidateConfidenceAlgorithmConfigRejectsInvalidVerifier(t *testing.T) {
 		method     string
 		url        string
 		timeout    int
+		maxBytes   int64
 		wantErrSub string
 	}{
 		{name: "missing URL", method: ConfidenceMethodAutoMixEntailment, wantErrSub: "verifier_server_url is required"},
@@ -251,6 +253,7 @@ func TestValidateConfidenceAlgorithmConfigRejectsInvalidVerifier(t *testing.T) {
 		{name: "query", method: ConfidenceMethodAutoMixEntailment, url: "https://verifier.example.com?token=secret", wantErrSub: "must not include a query or fragment"},
 		{name: "whitespace", method: ConfidenceMethodAutoMixEntailment, url: " https://verifier.example.com", wantErrSub: "must not contain leading or trailing whitespace"},
 		{name: "verifier config on another method", method: ConfidenceMethodSelfVerify, url: "https://verifier.example.com", timeout: 30, wantErrSub: "only supported when confidence_method"},
+		{name: "negative response limit", method: ConfidenceMethodAutoMixEntailment, url: "https://verifier.example.com", maxBytes: -1, wantErrSub: "max_response_bytes must be positive"},
 	}
 
 	for _, tc := range tests {
@@ -259,6 +262,7 @@ func TestValidateConfidenceAlgorithmConfigRejectsInvalidVerifier(t *testing.T) {
 				ConfidenceMethod:       tc.method,
 				VerifierServerURL:      tc.url,
 				VerifierTimeoutSeconds: tc.timeout,
+				MaxResponseBytes:       tc.maxBytes,
 			})
 			if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
 				t.Fatalf("error = %v, want substring %q", err, tc.wantErrSub)

--- a/src/semantic-router/pkg/config/decision_config.go
+++ b/src/semantic-router/pkg/config/decision_config.go
@@ -114,7 +114,8 @@ type ConfidenceAlgorithmConfig struct {
 	// VerifierTimeoutSeconds bounds each verifier HTTP call. Defaults to 60
 	// when zero, matching selection.NewAutoMixVerifierClient. Only consulted
 	// when confidence_method=automix_entailment and is rejected otherwise.
-	VerifierTimeoutSeconds int `yaml:"verifier_timeout_seconds,omitempty"`
+	VerifierTimeoutSeconds int   `yaml:"verifier_timeout_seconds,omitempty"`
+	MaxResponseBytes       int64 `yaml:"max_response_bytes,omitempty"`
 }
 
 type HybridWeightsConfig struct {

--- a/src/semantic-router/pkg/dsl/algorithm_defaults_roundtrip_test.go
+++ b/src/semantic-router/pkg/dsl/algorithm_defaults_roundtrip_test.go
@@ -19,3 +19,30 @@ func TestCompileASTSeedsModelSelectionDefaults(t *testing.T) {
 		t.Fatalf("expected CompileAST to seed Hybrid defaults, got %+v", cfg.ModelSelection.Hybrid)
 	}
 }
+
+func TestConfidenceMaxResponseBytesRoundTrip(t *testing.T) {
+	cfg, errs := Compile(`
+ROUTE confidence {
+  MODEL "small", "large"
+  ALGORITHM confidence {
+    confidence_method: "automix_entailment"
+    verifier_server_url: "https://verifier.example.com"
+    max_response_bytes: 1234
+  }
+}`)
+	if len(errs) > 0 {
+		t.Fatalf("compile errors: %v", errs)
+	}
+
+	dslText, err := DecompileRouting(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTripped, errs := Compile(dslText)
+	if len(errs) > 0 {
+		t.Fatalf("round-trip compile errors: %v", errs)
+	}
+	if got := roundTripped.Decisions[0].Algorithm.Confidence.MaxResponseBytes; got != 1234 {
+		t.Fatalf("max_response_bytes = %d, want 1234", got)
+	}
+}

--- a/src/semantic-router/pkg/dsl/compiler_algorithms.go
+++ b/src/semantic-router/pkg/dsl/compiler_algorithms.go
@@ -123,6 +123,9 @@ func (c *Compiler) compileConfidenceAlgo(fields map[string]Value) *config.Confid
 	if v, ok := getIntField(fields, "verifier_timeout_seconds"); ok {
 		cfg.VerifierTimeoutSeconds = v
 	}
+	if v, ok := getIntField(fields, "max_response_bytes"); ok {
+		cfg.MaxResponseBytes = int64(v)
+	}
 	cfg.HybridWeights = parseHybridWeights(fields)
 	return cfg
 }

--- a/src/semantic-router/pkg/dsl/decompiler_algorithms.go
+++ b/src/semantic-router/pkg/dsl/decompiler_algorithms.go
@@ -89,6 +89,7 @@ func confidenceAlgorithmToFields(c *config.ConfidenceAlgorithmConfig, fields map
 	setStringValue(fields, "token_filter", c.TokenFilter)
 	setStringValue(fields, "verifier_server_url", c.VerifierServerURL)
 	setIntValue(fields, "verifier_timeout_seconds", c.VerifierTimeoutSeconds)
+	setIntValue(fields, "max_response_bytes", int(c.MaxResponseBytes))
 	if c.HybridWeights != nil {
 		weights := map[string]Value{}
 		setFloatValue(weights, "logprob_weight", c.HybridWeights.LogprobWeight)

--- a/src/semantic-router/pkg/looper/confidence.go
+++ b/src/semantic-router/pkg/looper/confidence.go
@@ -328,15 +328,17 @@ type ConfidenceEvaluator struct {
 	// Empty/zero values when the method is anything else.
 	VerifierServerURL      string
 	VerifierTimeoutSeconds int
+	MaxResponseBytes       int64
 }
 
 // NewConfidenceEvaluator creates a confidence evaluator from algorithm config
 func NewConfidenceEvaluator(cfg *config.ConfidenceAlgorithmConfig) *ConfidenceEvaluator {
 	eval := &ConfidenceEvaluator{
-		Method:        "avg_logprob", // Default method
-		Threshold:     -1.0,          // Default threshold for avg_logprob
-		LogprobWeight: 0.5,
-		MarginWeight:  0.5,
+		Method:           "avg_logprob", // Default method
+		Threshold:        -1.0,          // Default threshold for avg_logprob
+		LogprobWeight:    0.5,
+		MarginWeight:     0.5,
+		MaxResponseBytes: config.DefaultMaxResponseBytes,
 	}
 
 	if cfg == nil {
@@ -383,6 +385,9 @@ func NewConfidenceEvaluator(cfg *config.ConfidenceAlgorithmConfig) *ConfidenceEv
 
 	eval.VerifierServerURL = cfg.VerifierServerURL
 	eval.VerifierTimeoutSeconds = cfg.VerifierTimeoutSeconds
+	if cfg.MaxResponseBytes > 0 {
+		eval.MaxResponseBytes = cfg.MaxResponseBytes
+	}
 
 	return eval
 }
@@ -1012,22 +1017,27 @@ func (l *ConfidenceLooper) buildSelfVerificationRequest(verificationPrompt strin
 }
 
 // automixVerifierCache memoises one selection.AutoMixVerifierClient per
-// (server_url, timeout_seconds) pair so repeated requests share a single
-// http.Client (and its underlying connection pool) instead of reconstructing
-// one per evaluation.
+// (server_url, timeout_seconds, max_response_bytes) tuple so repeated requests
+// share a single http.Client (and its underlying connection pool) instead of
+// reconstructing one per evaluation.
 var automixVerifierCache sync.Map
 
 type automixVerifierCacheKey struct {
-	url            string
-	timeoutSeconds int
+	url              string
+	timeoutSeconds   int
+	maxResponseBytes int64
 }
 
-func getAutoMixVerifierClient(serverURL string, timeoutSeconds int) *selection.AutoMixVerifierClient {
-	key := automixVerifierCacheKey{url: serverURL, timeoutSeconds: timeoutSeconds}
+func getAutoMixVerifierClient(serverURL string, timeoutSeconds int, maxResponseBytes int64) *selection.AutoMixVerifierClient {
+	if maxResponseBytes <= 0 {
+		maxResponseBytes = config.DefaultMaxResponseBytes
+	}
+	key := automixVerifierCacheKey{url: serverURL, timeoutSeconds: timeoutSeconds, maxResponseBytes: maxResponseBytes}
 	if existing, ok := automixVerifierCache.Load(key); ok {
 		return existing.(*selection.AutoMixVerifierClient)
 	}
 	client := selection.NewAutoMixVerifierClient(serverURL)
+	client.SetMaxResponseBytes(maxResponseBytes)
 	if timeoutSeconds > 0 {
 		client.SetTimeout(time.Duration(timeoutSeconds) * time.Second)
 	}
@@ -1058,7 +1068,7 @@ func (l *ConfidenceLooper) performAutoMixEntailment(
 		return 0, false, fmt.Errorf("could not extract user question from request")
 	}
 
-	client := getAutoMixVerifierClient(evaluator.VerifierServerURL, evaluator.VerifierTimeoutSeconds)
+	client := getAutoMixVerifierClient(evaluator.VerifierServerURL, evaluator.VerifierTimeoutSeconds, evaluator.MaxResponseBytes)
 
 	logging.ComponentDebugEvent("looper", "automix_entailment_started", map[string]interface{}{
 		"looper":     "confidence",

--- a/src/semantic-router/pkg/looper/confidence_automix_entailment_test.go
+++ b/src/semantic-router/pkg/looper/confidence_automix_entailment_test.go
@@ -206,15 +206,20 @@ func TestPerformAutoMixEntailment_ClientCachedPerURL(t *testing.T) {
 	defer server.Close()
 	t.Cleanup(automixVerifierCacheReset)
 
-	c1 := getAutoMixVerifierClient(server.URL, 0)
-	c2 := getAutoMixVerifierClient(server.URL, 0)
+	c1 := getAutoMixVerifierClient(server.URL, 0, 0)
+	c2 := getAutoMixVerifierClient(server.URL, 0, 0)
 	if c1 != c2 {
 		t.Error("expected getAutoMixVerifierClient to return the same client for repeated (url, timeout) tuples")
 	}
 
-	c3 := getAutoMixVerifierClient(server.URL, 30)
+	c3 := getAutoMixVerifierClient(server.URL, 30, 0)
 	if c3 == c1 {
 		t.Error("expected a distinct client when timeout differs")
+	}
+
+	c4 := getAutoMixVerifierClient(server.URL, 30, 1024)
+	if c4 == c3 {
+		t.Error("expected a distinct client when response limit differs")
 	}
 }
 

--- a/src/semantic-router/pkg/looper/confidence_test.go
+++ b/src/semantic-router/pkg/looper/confidence_test.go
@@ -294,6 +294,13 @@ func TestConfidenceEvaluator_Creation(t *testing.T) {
 			}
 		})
 	}
+
+	if got := NewConfidenceEvaluator(nil).MaxResponseBytes; got != config.DefaultMaxResponseBytes {
+		t.Fatalf("default max response bytes = %d, want %d", got, config.DefaultMaxResponseBytes)
+	}
+	if got := NewConfidenceEvaluator(&config.ConfidenceAlgorithmConfig{MaxResponseBytes: 1234}).MaxResponseBytes; got != 1234 {
+		t.Fatalf("configured max response bytes = %d, want 1234", got)
+	}
 }
 
 func TestConfidenceModelCallStreamingRequiresNoLogprobs(t *testing.T) {

--- a/src/semantic-router/pkg/selection/router_r1_client.go
+++ b/src/semantic-router/pkg/selection/router_r1_client.go
@@ -21,19 +21,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
 )
 
 // RouterR1Client is a client for the Router-R1 LLM-as-Router server
 // This implements the think/route pattern from arXiv:2506.09033
 // Requires external server: src/training/rl_model_selection/router_r1_server.py
 type RouterR1Client struct {
-	serverURL  string
-	httpClient *http.Client
+	serverURL        string
+	httpClient       *http.Client
+	maxResponseBytes int64
 }
 
 // RouterR1Response is the response from the Router-R1 server
@@ -50,6 +52,7 @@ func NewRouterR1Client(serverURL string) *RouterR1Client {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		maxResponseBytes: config.DefaultMaxResponseBytes,
 	}
 }
 
@@ -77,12 +80,17 @@ func (c *RouterR1Client) Route(ctx context.Context, query string) (*RouterR1Resp
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(body))
+		body, truncated := httputil.ReadTruncatedBody(resp.Body, maxSelectionErrorBodyBytes)
+		return nil, fmt.Errorf("server returned status %d: %s (truncated=%t)", resp.StatusCode, string(body), truncated)
+	}
+
+	body, err := httputil.ReadLimitedBody(resp.Body, c.maxResponseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	var result RouterR1Response
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
@@ -113,11 +121,12 @@ func (c *RouterR1Client) HealthCheck(ctx context.Context) error {
 // AutoMixVerifierClient is a client for the AutoMix self-verification server
 // This implements few-shot entailment verification from arXiv:2310.12963
 type AutoMixVerifierClient struct {
-	serverURL  string
-	httpClient *http.Client
+	serverURL        string
+	httpClient       *http.Client
+	maxResponseBytes int64
 }
 
-const maxAutoMixVerifierErrorBodyBytes int64 = 8 * 1024
+const maxSelectionErrorBodyBytes int64 = 8 * 1024
 
 // AutoMixVerifyResponse is the response from the AutoMix verifier
 type AutoMixVerifyResponse struct {
@@ -136,6 +145,7 @@ func NewAutoMixVerifierClient(serverURL string) *AutoMixVerifierClient {
 		httpClient: &http.Client{
 			Timeout: 60 * time.Second, // Verification can take longer with multiple samples
 		},
+		maxResponseBytes: config.DefaultMaxResponseBytes,
 	}
 }
 
@@ -147,6 +157,12 @@ func (c *AutoMixVerifierClient) SetTimeout(timeout time.Duration) {
 		return
 	}
 	c.httpClient.Timeout = timeout
+}
+
+func (c *AutoMixVerifierClient) SetMaxResponseBytes(maxResponseBytes int64) {
+	if maxResponseBytes > 0 {
+		c.maxResponseBytes = maxResponseBytes
+	}
 }
 
 // Verify sends a question/answer pair for verification
@@ -178,18 +194,22 @@ func (c *AutoMixVerifierClient) Verify(ctx context.Context, question, answer, op
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		errorBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxAutoMixVerifierErrorBodyBytes+1))
-		truncated := int64(len(errorBody)) > maxAutoMixVerifierErrorBodyBytes
+		errorBody, truncated := httputil.ReadTruncatedBody(resp.Body, maxSelectionErrorBodyBytes)
 		return nil, fmt.Errorf(
 			"server returned status %d (error_body_bytes=%d, truncated=%t)",
 			resp.StatusCode,
-			min(len(errorBody), int(maxAutoMixVerifierErrorBodyBytes)),
+			len(errorBody),
 			truncated,
 		)
 	}
 
+	body, err := httputil.ReadLimitedBody(resp.Body, c.maxResponseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
 	var result AutoMixVerifyResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 

--- a/src/semantic-router/pkg/selection/router_r1_client_limits_test.go
+++ b/src/semantic-router/pkg/selection/router_r1_client_limits_test.go
@@ -1,0 +1,72 @@
+package selection
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+var (
+	_ func(string) *RouterR1Client        = NewRouterR1Client
+	_ func(string) *AutoMixVerifierClient = NewAutoMixVerifierClient
+)
+
+func TestRouterR1ClientRejectsOversizedResponse(t *testing.T) {
+	body, err := json.Marshal(RouterR1Response{SelectedModel: "model-a", Thinking: strings.Repeat("x", 64)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	client := NewRouterR1Client(server.URL)
+	client.maxResponseBytes = int64(len(body))
+	if _, routeErr := client.Route(context.Background(), "route this"); routeErr != nil {
+		t.Fatalf("Route() at limit error = %v", routeErr)
+	}
+	client.maxResponseBytes = int64(len(body) - 1)
+	_, err = client.Route(context.Background(), "route this")
+	if err == nil || !strings.Contains(err.Error(), "response body exceeds limit") {
+		t.Fatalf("Route() error = %v, want response limit error", err)
+	}
+}
+
+func TestRouterR1ClientTruncatesErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(strings.Repeat("x", int(maxSelectionErrorBodyBytes+1))))
+	}))
+	defer server.Close()
+
+	_, err := NewRouterR1Client(server.URL).Route(context.Background(), "route this")
+	if err == nil || !strings.Contains(err.Error(), "truncated=true") {
+		t.Fatalf("Route() error = %v, want truncated error body", err)
+	}
+}
+
+func TestAutoMixVerifierClientRejectsOversizedResponse(t *testing.T) {
+	body, err := json.Marshal(AutoMixVerifyResponse{Confidence: 0.9, Samples: []string{strings.Repeat("x", 64)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	client := NewAutoMixVerifierClient(server.URL)
+	client.SetMaxResponseBytes(int64(len(body)))
+	if _, verifyErr := client.Verify(context.Background(), "question", "answer", "", 0.7); verifyErr != nil {
+		t.Fatalf("Verify() at limit error = %v", verifyErr)
+	}
+	client.SetMaxResponseBytes(int64(len(body) - 1))
+	_, err = client.Verify(context.Background(), "question", "answer", "", 0.7)
+	if err == nil || !strings.Contains(err.Error(), "response body exceeds limit") {
+		t.Fatalf("Verify() error = %v, want response limit error", err)
+	}
+}

--- a/src/vllm-sr/cli/algorithms.py
+++ b/src/vllm-sr/cli/algorithms.py
@@ -49,6 +49,8 @@ class ConfidenceAlgorithmConfig(BaseModel):
     # Behavior on model call failure: "skip" or "fail"
     on_error: str | None = "skip"
 
+    max_response_bytes: int | None = Field(default=None, ge=0)
+
 
 class RatingsAlgorithmConfig(BaseModel):
     """Configuration for the ratings looper algorithm."""

--- a/website/docs/tutorials/algorithm/looper/confidence.md
+++ b/website/docs/tutorials/algorithm/looper/confidence.md
@@ -89,6 +89,7 @@ algorithm:
     # Required when confidence_method = automix_entailment
     verifier_server_url: ""          # AutoMix entailment verifier HTTP URL
     verifier_timeout_seconds: 0      # 0 = default (60s)
+    max_response_bytes: 0            # 0 = default (32 MiB)
 ```
 
 ### Parameters
@@ -105,6 +106,7 @@ algorithm:
 | `hybrid_weights.margin_weight` | float | `0.5` | Weight for margin in hybrid mode. Zero is the unset sentinel; the two effective weights must sum to `1`. |
 | `verifier_server_url` | string | — | Required only when `confidence_method = automix_entailment`. Must be an absolute HTTP(S) URL without credentials, query, or fragment (see [`automix_verifier.py`](https://github.com/vllm-project/semantic-router/blob/main/src/training/model_selection/rl_model_selection/automix_verifier.py)). |
 | `verifier_timeout_seconds` | int | `60` | Positive HTTP timeout for `automix_entailment`; `0` is the unset sentinel and selects 60 seconds. |
+| `max_response_bytes` | int | `33554432` | Maximum AutoMix verifier response size in bytes. |
 
 The method defaults used when `threshold` is omitted (or explicitly `0`) are
 `-1` for `avg_logprob` (the permissive evidence-present default), `0.5` for


### PR DESCRIPTION
Related #3097

## Purpose

Bound Router-R1 and AutoMix verifier response reads.

Oversized success responses now fail clearly, and non-2xx diagnostic bodies remain bounded. Existing exported constructors are preserved, and an omitted or zero AutoMix limit uses the 32 MiB default.

## Test Plan

- go test ./pkg/config ./pkg/dsl ./pkg/looper ./pkg/selection
- uv run --extra dev pytest -q tests/test_algorithm_config.py
- make dashboard-check
- make agent-lint ENV=cpu

## Test Result

All listed checks passed.