### PR TITLE
[Test] Add deterministic Ratings Looper E2E coverage

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -122,6 +122,7 @@ until the selected cases are known to be isolated.
 - **multimodal-routing**: image-modality embedding routing.
 - **remote-embedding**: OpenAI-compatible remote embedding providers.
 - **llm-d**: llm-d inference-gateway health and router smoke coverage.
+- **looper**: deterministic Looper algorithm contracts.
 - **istio**: sidecar, mTLS, and tracing behavior.
 - **agentgateway**: agentgateway routing and ExtProc policy enforcement.
 - **production-stack**: HA, load balancing, failover, and load checks.

--- a/e2e/profiles/all/imports.go
+++ b/e2e/profiles/all/imports.go
@@ -14,6 +14,7 @@ import (
 	istio "github.com/vllm-project/semantic-router/e2e/profiles/istio"
 	jailbreakonerror "github.com/vllm-project/semantic-router/e2e/profiles/jailbreak-onerror"
 	llmd "github.com/vllm-project/semantic-router/e2e/profiles/llm-d"
+	looper "github.com/vllm-project/semantic-router/e2e/profiles/looper"
 	mlmodelselection "github.com/vllm-project/semantic-router/e2e/profiles/ml-model-selection"
 	multiendpoint "github.com/vllm-project/semantic-router/e2e/profiles/multi-endpoint"
 	multimodalrouting "github.com/vllm-project/semantic-router/e2e/profiles/multimodal-routing"
@@ -78,6 +79,7 @@ func init() {
 		framework.ProfileCapabilities{LocalImages: mockVLLMLocalImages},
 	)
 	register("llm-d", func() framework.Profile { return llmd.NewProfile() }, framework.ProfileCapabilities{})
+	register("looper", func() framework.Profile { return looper.NewProfile() }, framework.ProfileCapabilities{})
 	register(
 		"ml-model-selection",
 		func() framework.Profile { return mlmodelselection.NewProfile() },

--- a/e2e/profiles/looper/manifests/fake-backend.yaml
+++ b/e2e/profiles/looper/manifests/fake-backend.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: looper-fake-backend
+  namespace: default
+data:
+  server.py: |
+    import json
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    RESPONSES = {
+        "ratings-model-a": ("answer-from-ratings-model-a", 3, 2),
+        "ratings-model-b": ("answer-from-ratings-model-b", 7, 4),
+    }
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            return
+
+        def send_json(self, status, payload):
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_json(200, {"status": "ok"})
+                return
+            self.send_json(404, {"error": {"message": "not found"}})
+
+        def do_POST(self):
+            if self.path != "/v1/chat/completions":
+                self.send_json(404, {"error": {"message": "not found"}})
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+                payload = json.loads(self.rfile.read(length))
+            except (ValueError, json.JSONDecodeError):
+                self.send_json(400, {"error": {"message": "invalid JSON"}})
+                return
+            if not isinstance(payload, dict) or not isinstance(payload.get("messages"), list):
+                self.send_json(400, {"error": {"message": "messages must be a list"}})
+                return
+
+            model = payload.get("model")
+            if model not in RESPONSES:
+                self.send_json(400, {"error": {"message": "unknown model"}})
+                return
+
+            content, prompt_tokens, completion_tokens = RESPONSES[model]
+            self.send_json(200, {
+                "id": "chatcmpl-looper-e2e-" + model,
+                "object": "chat.completion",
+                "created": 1,
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            })
+
+    ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: looper-fake-backend
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: looper-fake-backend
+  template:
+    metadata:
+      labels:
+        app: looper-fake-backend
+    spec:
+      containers:
+        - name: backend
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "/app/server.py"]
+          ports:
+            - name: http
+              containerPort: 8000
+          volumeMounts:
+            - name: script
+              mountPath: /app/server.py
+              subPath: server.py
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 30
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      volumes:
+        - name: script
+          configMap:
+            name: looper-fake-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: looper-fake-backend
+  namespace: default
+spec:
+  selector:
+    app: looper-fake-backend
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/e2e/profiles/looper/profile.go
+++ b/e2e/profiles/looper/profile.go
@@ -1,0 +1,64 @@
+package looper
+
+import (
+	"context"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	"github.com/vllm-project/semantic-router/e2e/pkg/helpers"
+	gatewaystack "github.com/vllm-project/semantic-router/e2e/pkg/stacks/gateway"
+
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
+)
+
+const (
+	valuesFile   = "e2e/profiles/looper/values.yaml"
+	fakeManifest = "e2e/profiles/looper/manifests/fake-backend.yaml"
+)
+
+var gatewayResources = []string{
+	"deploy/kubernetes/routing-strategies/aigw-resources/base-model.yaml",
+	"deploy/kubernetes/routing-strategies/aigw-resources/gwapi-resources.yaml",
+}
+
+// Profile validates deterministic Looper algorithm contracts.
+type Profile struct {
+	stack *gatewaystack.Stack
+}
+
+// NewProfile creates the Looper E2E profile.
+func NewProfile() *Profile {
+	return &Profile{stack: gatewaystack.New(gatewaystack.Config{
+		Name:                     "looper",
+		SemanticRouterValuesFile: valuesFile,
+		PrerequisiteManifests:    []string{fakeManifest},
+		ResourceManifests:        gatewayResources,
+		WaitDeployments: []helpers.DeploymentRef{
+			{Namespace: "default", Name: "looper-fake-backend"},
+			{Namespace: "default", Name: "vllm-llama3-8b-instruct"},
+		},
+	})}
+}
+
+// Name returns the profile name.
+func (p *Profile) Name() string { return "looper" }
+
+// Description returns the profile contract.
+func (p *Profile) Description() string {
+	return "Tests deterministic Looper algorithm behavior through Envoy AI Gateway"
+}
+
+// Setup deploys the shared gateway stack and deterministic backend.
+func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error {
+	return p.stack.Setup(ctx, opts)
+}
+
+// Teardown removes the shared gateway stack and deterministic backend.
+func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions) error {
+	return p.stack.Teardown(ctx, opts)
+}
+
+// GetTestCases returns the focused Looper contract tests.
+func (p *Profile) GetTestCases() []string { return []string{"looper-ratings-happy-path"} }
+
+// GetServiceConfig returns the shared gateway service configuration.
+func (p *Profile) GetServiceConfig() framework.ServiceConfig { return p.stack.ServiceConfig() }

--- a/e2e/profiles/looper/values.yaml
+++ b/e2e/profiles/looper/values.yaml
@@ -1,0 +1,112 @@
+config:
+  version: v0.3
+  listeners: []
+  providers:
+    defaults:
+      default_model: ratings-model-a
+    models:
+      - name: ratings-model-a
+        provider_model_id: ratings-model-a
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
+      - name: ratings-model-b
+        provider_model_id: ratings-model-b
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
+  routing:
+    modelCards:
+      - name: ratings-model-a
+      - name: ratings-model-b
+    signals:
+      keywords:
+        - name: looper_ratings_probe_keywords
+          operator: OR
+          keywords:
+            - __LOOPER_RATINGS_PROBE__
+          case_sensitive: true
+    decisions:
+      - name: looper_ratings_decision
+        description: Deterministic Ratings route for issue 2859 E2E coverage
+        priority: 100
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: looper_ratings_probe_keywords
+        modelRefs:
+          - model: ratings-model-a
+            use_reasoning: false
+          - model: ratings-model-b
+            use_reasoning: false
+        algorithm:
+          type: ratings
+          ratings:
+            max_concurrent: 2
+            on_error: skip
+      - name: default-route
+        description: Fallback for unmatched profile traffic
+        priority: 10
+        rules:
+          operator: AND
+          conditions: []
+        modelRefs:
+          - model: ratings-model-a
+            use_reasoning: false
+  global:
+    router:
+      strategy: priority
+    services:
+      response_api:
+        enabled: false
+      router_replay:
+        enabled: false
+    stores:
+      response_cache:
+        enabled: false
+    model_catalog:
+      kbs: []
+      embeddings:
+        semantic:
+          qwen3_model_path: ""
+          gemma_model_path: ""
+          mmbert_model_path: ""
+          multimodal_model_path: ""
+          bert_model_path: ""
+          use_cpu: true
+      modules:
+        prompt_guard:
+          enabled: false
+          model_ref: ""
+          model_id: ""
+          jailbreak_mapping_path: ""
+        classifier:
+          domain:
+            model_ref: ""
+            model_id: ""
+            category_mapping_path: ""
+            use_mmbert_32k: false
+          pii:
+            model_ref: ""
+            model_id: ""
+            pii_mapping_path: ""
+            use_mmbert_32k: false
+        feedback_detector:
+          enabled: false
+          model_ref: ""
+          model_id: ""
+          use_mmbert_32k: false
+    integrations:
+      looper:
+        endpoint: http://looper-fake-backend.default.svc.cluster.local:8000/v1/chat/completions
+
+resources:
+  limits:
+    memory: 1Gi
+    cpu: "1"
+  requests:
+    memory: 256Mi
+    cpu: 100m

--- a/e2e/testcases/looper_ratings.go
+++ b/e2e/testcases/looper_ratings.go
@@ -1,0 +1,104 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+const looperRatingsProbeKeyword = "__LOOPER_RATINGS_PROBE__"
+
+type ratingsMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ratingsChoice struct {
+	Index        int            `json:"index"`
+	Model        string         `json:"model"`
+	FinishReason string         `json:"finish_reason"`
+	Message      ratingsMessage `json:"message"`
+}
+
+type ratingsCompletion struct {
+	Object  string          `json:"object"`
+	Model   string          `json:"model"`
+	Choices []ratingsChoice `json:"choices"`
+	Usage   struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+		TotalTokens      int64 `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+func init() {
+	pkgtestcases.Register("looper-ratings-happy-path", pkgtestcases.TestCase{
+		Description: "Verify deterministic Ratings fan-out, ordered choices, and aggregate usage",
+		Tags:        []string{"kubernetes", "routing", "looper", "ratings"},
+		Fn:          testLooperRatingsHappyPath,
+	})
+}
+
+func testLooperRatingsHappyPath(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPortForward, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopPortForward()
+
+	response, err := sendLocalChatCompletion(ctx, localPort, "MoM", looperRatingsProbeKeyword, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("ratings request failed: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		logUnexpectedChatCompletionStatus(opts.Verbose, response, "looper-ratings-happy-path")
+		return fmt.Errorf("ratings request: %s", formatUnexpectedChatCompletionStatus(response))
+	}
+
+	expectedHeaders := map[string]string{
+		"x-vsr-selected-decision":        "looper_ratings_decision",
+		"x-vsr-response-path":            "looper",
+		"x-vsr-looper-algorithm":         "ratings",
+		"x-vsr-looper-models-used":       "ratings-model-a,ratings-model-b",
+		"x-vsr-looper-iterations":        "2",
+		"x-vsr-looper-prompt-tokens":     "10",
+		"x-vsr-looper-completion-tokens": "6",
+		"x-vsr-looper-total-tokens":      "16",
+	}
+	for name, want := range expectedHeaders {
+		if got := response.Headers.Get(name); got != want {
+			return fmt.Errorf("header %s = %q, want %q", name, got, want)
+		}
+	}
+
+	var completion ratingsCompletion
+	if err := json.Unmarshal(response.Body, &completion); err != nil {
+		return fmt.Errorf("decode ratings response: %w", err)
+	}
+	if completion.Object != "chat.completion" {
+		return fmt.Errorf("response object = %q, want chat.completion", completion.Object)
+	}
+	if completion.Model != "ratings-model-a,ratings-model-b" {
+		return fmt.Errorf("response model = %q, want ratings-model-a,ratings-model-b", completion.Model)
+	}
+
+	wantChoices := []ratingsChoice{
+		{Index: 0, Model: "ratings-model-a", FinishReason: "stop", Message: ratingsMessage{Role: "assistant", Content: "answer-from-ratings-model-a"}},
+		{Index: 1, Model: "ratings-model-b", FinishReason: "stop", Message: ratingsMessage{Role: "assistant", Content: "answer-from-ratings-model-b"}},
+	}
+	if !reflect.DeepEqual(completion.Choices, wantChoices) {
+		return fmt.Errorf("ratings choices = %+v, want %+v", completion.Choices, wantChoices)
+	}
+	if got := []int64{completion.Usage.PromptTokens, completion.Usage.CompletionTokens, completion.Usage.TotalTokens}; !reflect.DeepEqual(got, []int64{10, 6, 16}) {
+		return fmt.Errorf("ratings usage = %v, want [10 6 16]", got)
+	}
+
+	return nil
+}

--- a/e2e/testcases/looper_ratings.go
+++ b/e2e/testcases/looper_ratings.go
@@ -22,7 +22,6 @@ type ratingsMessage struct {
 
 type ratingsChoice struct {
 	Index        int            `json:"index"`
-	Model        string         `json:"model"`
 	FinishReason string         `json:"finish_reason"`
 	Message      ratingsMessage `json:"message"`
 }
@@ -85,13 +84,13 @@ func testLooperRatingsHappyPath(ctx context.Context, client *kubernetes.Clientse
 	if completion.Object != "chat.completion" {
 		return fmt.Errorf("response object = %q, want chat.completion", completion.Object)
 	}
-	if completion.Model != "ratings-model-a,ratings-model-b" {
-		return fmt.Errorf("response model = %q, want ratings-model-a,ratings-model-b", completion.Model)
+	if completion.Model != "ratings-model-b" {
+		return fmt.Errorf("response model = %q, want ratings-model-b", completion.Model)
 	}
 
 	wantChoices := []ratingsChoice{
-		{Index: 0, Model: "ratings-model-a", FinishReason: "stop", Message: ratingsMessage{Role: "assistant", Content: "answer-from-ratings-model-a"}},
-		{Index: 1, Model: "ratings-model-b", FinishReason: "stop", Message: ratingsMessage{Role: "assistant", Content: "answer-from-ratings-model-b"}},
+		{Index: 0, FinishReason: "stop", Message: ratingsMessage{Role: "assistant", Content: "answer-from-ratings-model-a"}},
+		{Index: 1, FinishReason: "stop", Message: ratingsMessage{Role: "assistant", Content: "answer-from-ratings-model-b"}},
 	}
 	if !reflect.DeepEqual(completion.Choices, wantChoices) {
 		return fmt.Errorf("ratings choices = %+v, want %+v", completion.Choices, wantChoices)

--- a/tools/agent/test-domain-registry.yaml
+++ b/tools/agent/test-domain-registry.yaml
@@ -374,6 +374,14 @@ profiles:
     coverage_role: llm-d-inference-gateway-health
     selection: pr
     paths: [e2e/profiles/llm-d/**, deploy/kubernetes/llmd-base/**]
+  looper:
+    owner: e2e
+    coverage_role: deterministic-looper-algorithm-contracts
+    selection: pr
+    paths:
+      - e2e/profiles/looper/**
+      - e2e/testcases/looper_*.go
+      - src/semantic-router/pkg/looper/**
   routing-strategies:
     owner: e2e
     coverage_role: routing-strategy-contracts


### PR DESCRIPTION
Related #2859

## Purpose

Add the first focused Looper E2E slice requested by the Evaluation and Quality Workgroup: a deterministic Ratings happy path through Envoy ExtProc.

The new affected-path `looper` profile uses a bounded OpenAI-compatible fake backend and verifies two-model fan-out, ordered choices, Looper routing metadata, and exact aggregate token usage. It reuses the shared gateway stack and does not join the full-CI profile set yet.

## Test Plan

- `make agent-validate`
- `make build-e2e`
- `(cd e2e && go test ./...)`
- `make e2e-test E2E_PROFILE=looper E2E_TESTS=looper-ratings-happy-path E2E_VERBOSE=true`
- `make agent-ci-gate CHANGED_FILES="e2e/README.md e2e/profiles/all/imports.go e2e/profiles/looper/profile.go e2e/profiles/looper/values.yaml e2e/profiles/looper/manifests/fake-backend.yaml e2e/testcases/looper_ratings.go tools/agent/test-domain-registry.yaml"`

## Test Result

All listed checks passed locally. The focused Kind test passed with both fake models, ordered choices, and exact `10/6/16` aggregate usage.

Remaining Looper families and failure/lifecycle contracts stay in follow-up slices under #2859.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title uses one category prefix
- [x] The PR links accepted issue #2859 with its Evaluation and Quality Workgroup owner
- [x] Commits are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect this PR

</details>
