### PR TITLE
[Bug] Bound memory rewrite response reads

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_memory_rewrite.go
+++ b/src/semantic-router/pkg/extproc/req_filter_memory_rewrite.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -14,7 +13,10 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/memory"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/protocolcodec"
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
 )
+
+const defaultMemoryRewriteMaxResponseBytes int64 = 1024 * 1024
 
 // ConversationMessage represents a message in conversation history.
 type ConversationMessage struct {
@@ -26,12 +28,13 @@ type ConversationMessage struct {
 // used to improve vector-memory queries. It is not a request-selected logical
 // Model backend and cannot participate in routing, fallback, or usage dispatch.
 type memoryRewriteServiceConfig struct {
-	Endpoint       string
-	Model          string
-	AccessKey      string
-	TimeoutSeconds int
-	MaxTokens      int
-	Temperature    float64
+	Endpoint         string
+	Model            string
+	AccessKey        string
+	TimeoutSeconds   int
+	MaxTokens        int
+	Temperature      float64
+	MaxResponseBytes int64
 }
 
 // queryRewriteSystemPrompt is the system prompt for query rewriting.
@@ -165,13 +168,18 @@ func resolveMemoryRewriteServiceConfig(routerCfg *config.RouterConfig) *memoryRe
 		scheme = "http"
 	}
 	endpoint := fmt.Sprintf("%s://%s:%d", scheme, externalCfg.ModelEndpoint.Address, externalCfg.ModelEndpoint.Port)
+	maxResponseBytes := externalCfg.MaxResponseBytes
+	if maxResponseBytes <= 0 {
+		maxResponseBytes = defaultMemoryRewriteMaxResponseBytes
+	}
 	return &memoryRewriteServiceConfig{
-		Endpoint:       endpoint,
-		Model:          externalCfg.ModelName,
-		AccessKey:      externalCfg.AccessKey,
-		TimeoutSeconds: externalCfg.TimeoutSeconds,
-		MaxTokens:      externalCfg.MaxTokens,
-		Temperature:    externalCfg.Temperature,
+		Endpoint:         endpoint,
+		Model:            externalCfg.ModelName,
+		AccessKey:        externalCfg.AccessKey,
+		TimeoutSeconds:   externalCfg.TimeoutSeconds,
+		MaxTokens:        externalCfg.MaxTokens,
+		Temperature:      externalCfg.Temperature,
+		MaxResponseBytes: maxResponseBytes,
 	}
 }
 
@@ -225,7 +233,7 @@ func callMemoryRewriteService(ctx context.Context, resolved *memoryRewriteServic
 		return "", fmt.Errorf("LLM returned status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := httputil.ReadLimitedBody(resp.Body, resolved.MaxResponseBytes)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/src/semantic-router/pkg/extproc/req_filter_query_rewrite_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_query_rewrite_test.go
@@ -120,6 +120,40 @@ func TestBuildSearchQuery_WithMockLLM(t *testing.T) {
 	assert.Equal(t, "What is the budget for the Hawaii vacation?", result)
 }
 
+func TestBuildSearchQuery_ResponseLimit(t *testing.T) {
+	responseBody, err := json.Marshal(mockChatResponse{
+		ID: "chatcmpl-rewrite",
+		Choices: []mockChatChoice{
+			{Message: mockChatMessage{Role: "assistant", Content: "rewritten query"}},
+		},
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(responseBody)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name  string
+		limit int64
+		want  string
+	}{
+		{name: "at limit is parsed", limit: int64(len(responseBody)), want: "rewritten query"},
+		{name: "one byte over falls back", limit: int64(len(responseBody) - 1), want: "original query"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			routerCfg := createMockRouterConfig(server.URL)
+			routerCfg.ExternalModels[0].MaxResponseBytes = tt.limit
+
+			result, err := BuildSearchQuery(context.Background(), nil, "original query", routerCfg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
 func TestBuildSearchQuery_SelfContainedQuery(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := mockChatResponse{

--- a/website/docs/tutorials/global/stores-and-tools.md
+++ b/website/docs/tutorials/global/stores-and-tools.md
@@ -129,6 +129,10 @@ For full deployment instructions, see:
 - [Qdrant](../../installation/qdrant) — Docker, Kubernetes, config reference, tuning, and troubleshooting
 - `config/runtime/memory/` for backend-specific configuration references
 
+When an external model with `model_role: memory_rewrite` is configured, its
+`max_response_bytes` limits each query-rewrite response. An omitted or
+non-positive value uses the 1 MiB default.
+
 ### Vector Store
 
 ```yaml


### PR DESCRIPTION
Related #3097

## Purpose

- Bound memory rewrite response bodies using `max_response_bytes`.
- Use a 1 MiB default when the limit is unset.
- Document the response limit.

## Test Plan

- Test responses at and above the configured limit.
- Run the repository CI gate.

## Test Result

- `go test ./pkg/extproc -run "^TestBuildSearchQuery" -count=1`
- `make agent-ci-gate ENV=cpu CHANGED_FILES="..."`