### PR TITLE
[Bug] Fix observability empty-state docs links pointing at a deleted page

### DIFF
--- a/dashboard/frontend/src/components/EmbeddedServicePage.test.tsx
+++ b/dashboard/frontend/src/components/EmbeddedServicePage.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 
 import EmbeddedServicePage from './EmbeddedServicePage'
+import { DOCS_LINKS } from '../utils/docsLinks'
 
 describe('embedded observability shell', () => {
   it('renders a consistent loading, recovery, and full-view contract', () => {
@@ -39,6 +40,29 @@ describe('embedded observability shell', () => {
       expect(source).not.toContain('console.log')
       expect(source).not.toContain('contentWindow')
       expect(source).not.toContain("setItem('theme', 'light')")
+    }
+  })
+
+  it('points the observability empty-state docs links at a live docs page', () => {
+    // Regression guard for #3112: the Monitoring and Tracing empty states both
+    // linked to https://vllm-sr.ai/docs/tutorials/observability/dashboard, which
+    // only exists in archived v0.1/v0.2 docs and now returns 404.
+    const DELETED_DOCS_PATH = '/tutorials/observability/dashboard'
+
+    expect(DOCS_LINKS.observability).toMatch(/^https:\/\/vllm-sr\.ai\/docs\//)
+    expect(DOCS_LINKS.observability).not.toContain(DELETED_DOCS_PATH)
+    expect(DOCS_LINKS.observability).toContain('/tutorials/global/api-and-observability')
+
+    const sources = ['../pages/MonitoringPage.tsx', '../pages/TracingPage.tsx'].map((path) =>
+      readFileSync(new URL(path, import.meta.url), 'utf8'),
+    )
+
+    for (const source of sources) {
+      // Both pages must resolve the link through the shared constant so they
+      // cannot drift apart again.
+      expect(source).toContain('DOCS_LINKS.observability')
+      expect(source).not.toContain(DELETED_DOCS_PATH)
+      expect(source).not.toContain('vllm-sr.ai/docs/tutorials/observability')
     }
   })
 })

--- a/dashboard/frontend/src/pages/MonitoringPage.tsx
+++ b/dashboard/frontend/src/pages/MonitoringPage.tsx
@@ -2,13 +2,14 @@ import { useEffect, useMemo, useState } from 'react'
 
 import EmbeddedServicePage from '../components/EmbeddedServicePage'
 import type { ServiceConfig } from '../components/ServiceNotConfigured'
+import { DOCS_LINKS } from '../utils/docsLinks'
 
 const GRAFANA_SERVICE: ServiceConfig = {
   name: 'Grafana',
   envVar: 'TARGET_GRAFANA_URL',
   description:
     'Connect Grafana to inspect routing health, latency, throughput, and model activity.',
-  docsUrl: 'https://vllm-sr.ai/docs/tutorials/observability/dashboard',
+  docsUrl: DOCS_LINKS.observability,
   exampleValue: 'http://localhost:3000',
 }
 

--- a/dashboard/frontend/src/pages/TracingPage.tsx
+++ b/dashboard/frontend/src/pages/TracingPage.tsx
@@ -2,12 +2,13 @@ import { useMemo } from 'react'
 
 import EmbeddedServicePage from '../components/EmbeddedServicePage'
 import type { ServiceConfig } from '../components/ServiceNotConfigured'
+import { DOCS_LINKS } from '../utils/docsLinks'
 
 const JAEGER_SERVICE: ServiceConfig = {
   name: 'Jaeger',
   envVar: 'TARGET_JAEGER_URL',
   description: 'Connect Jaeger to investigate request paths across the router and model backends.',
-  docsUrl: 'https://vllm-sr.ai/docs/tutorials/observability/dashboard',
+  docsUrl: DOCS_LINKS.observability,
   exampleValue: 'http://localhost:16686',
 }
 

--- a/dashboard/frontend/src/utils/docsLinks.ts
+++ b/dashboard/frontend/src/utils/docsLinks.ts
@@ -1,0 +1,11 @@
+// Single source of truth for external documentation links surfaced in the
+// dashboard UI. Centralising these keeps "View Documentation" actions from
+// drifting to renamed or deleted docs pages.
+
+const DOCS_BASE_URL = 'https://vllm-sr.ai/docs'
+
+export const DOCS_LINKS = {
+  // Metrics (Grafana) and tracing (Jaeger) setup both live in the observability
+  // section of the "API and Observability" tutorial.
+  observability: `${DOCS_BASE_URL}/tutorials/global/api-and-observability#observability`,
+} as const


### PR DESCRIPTION
Closes #3112

## Purpose

The Monitoring (Grafana) and Tracing (Jaeger) empty states in the dashboard both point their **View Documentation** button at `https://vllm-sr.ai/docs/tutorials/observability/dashboard`. That path only exists in the archived v0.1/v0.2 docs and now returns 404, so an operator who has not configured Grafana or Jaeger cannot reach the setup docs from the empty state.

Affected modules: `dashboard/frontend` (Developer Experience & Ecosystem workgroup, `wg/developer-experience-ecosystem`).

Changes:
- Add `dashboard/frontend/src/utils/docsLinks.ts`, a single `DOCS_LINKS` constant for docs URLs surfaced in the dashboard UI, so `MonitoringPage` and `TracingPage` resolve the link from one place and cannot drift apart again.
- Point both empty states at the current observability tutorial, `https://vllm-sr.ai/docs/tutorials/global/api-and-observability#observability`, which documents both metrics (Grafana) and tracing (Jaeger) setup.
- Add a regression test in `EmbeddedServicePage.test.tsx` that fails if the shared constant or either page references the deleted `/tutorials/observability/dashboard` path.

## Test Plan

From `dashboard/frontend`:
- `npm run test:unit`
- `npm run type-check`
- `npx eslint .`
- `npx prettier --check` on the changed files

## Test Result

- `npm run test:unit`: 126 files, 490 tests passed (was 489; +1 new regression test).
- `npm run type-check`: passed.
- `npx eslint .`: passed, no warnings.
- `npx prettier --check`: all changed files already conform.
- Verified the new test fails when the link is reverted to the deleted path.