### PR TITLE
[Bug] Bound OpenAI-compatible embedding responses

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2157,6 +2157,7 @@ global:
           api_key_env: EMBEDDING_API_KEY
           timeout_seconds: 5
           max_retries: 2
+          max_response_bytes: 16777216
           dimensions: 1024
     system:
       prompt_guard: models/mmbert32k-jailbreak-detector-merged

--- a/dashboard/frontend/src/pages/ConfigPageRouterStructuredEditor.test.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageRouterStructuredEditor.test.tsx
@@ -65,6 +65,7 @@ describe('ConfigPageRouterStructuredEditor', () => {
           base_url: 'https://embedding.example.com/v1',
           model: 'text-embedding-3-small',
           api_key_env: 'OPENAI_API_KEY',
+          max_response_bytes: 16777216,
           dimensions: 1536,
         }}
         onChange={vi.fn()}
@@ -74,6 +75,7 @@ describe('ConfigPageRouterStructuredEditor', () => {
     expect(markup).toContain('Base URL')
     expect(markup).toContain('text-embedding-3-small')
     expect(markup).toContain('OPENAI_API_KEY')
+    expect(markup).toContain('Max Response Bytes')
     expect(markup).not.toContain('<textarea')
   })
 })

--- a/dashboard/frontend/src/pages/configPageEmbeddingStructuredSchema.ts
+++ b/dashboard/frontend/src/pages/configPageEmbeddingStructuredSchema.ts
@@ -33,6 +33,7 @@ export const EMBEDDING_MODELS_STRUCTURED_FIELDS: Record<string, RouterStructured
       api_key_env: text('API Key Environment Variable', { placeholder: 'OPENAI_API_KEY' }),
       timeout_seconds: number('Timeout Seconds', { min: 0 }),
       max_retries: number('Max Retries', { min: 0 }),
+      max_response_bytes: number('Max Response Bytes', { min: 0 }),
       dimensions: number('Dimensions', { min: 1 }),
     }),
   },

--- a/dashboard/frontend/src/pages/configPageSupport.ts
+++ b/dashboard/frontend/src/pages/configPageSupport.ts
@@ -446,6 +446,7 @@ export interface EmbeddingEndpointConfig {
   api_key_env?: string
   timeout_seconds?: number
   max_retries?: number
+  max_response_bytes?: number
   dimensions?: number
 }
 

--- a/deploy/operator/api/v1alpha1/semanticrouter_types.go
+++ b/deploy/operator/api/v1alpha1/semanticrouter_types.go
@@ -1203,6 +1203,11 @@ type EmbeddingEndpointConfig struct {
 	// +optional
 	MaxRetries int `json:"max_retries,omitempty"`
 
+	// MaxResponseBytes caps the size of each embedding response body.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxResponseBytes int64 `json:"max_response_bytes,omitempty"`
+
 	// Dimensions requests a provider-side output dimension when supported.
 	// +kubebuilder:validation:Minimum=1
 	// +optional

--- a/deploy/operator/api/v1alpha1/semanticrouter_types_test.go
+++ b/deploy/operator/api/v1alpha1/semanticrouter_types_test.go
@@ -79,15 +79,16 @@ func TestEmbeddingModelsConfig(t *testing.T) {
 					TargetDimension: 1024,
 				},
 				Endpoint: &EmbeddingEndpointConfig{
-					BaseURL:        "http://embedding-service:8000/v1",
-					Model:          "BAAI/bge-m3",
-					APIKeyEnv:      "EMBEDDING_API_KEY",
-					TimeoutSeconds: 5,
-					MaxRetries:     2,
-					Dimensions:     1024,
+					BaseURL:          "http://embedding-service:8000/v1",
+					Model:            "BAAI/bge-m3",
+					APIKeyEnv:        "EMBEDDING_API_KEY",
+					TimeoutSeconds:   5,
+					MaxRetries:       2,
+					MaxResponseBytes: 16777216,
+					Dimensions:       1024,
 				},
 			},
-			want: `{"embedding_config":{"backend":"openai_compatible","model_type":"remote","target_dimension":1024},"endpoint":{"base_url":"http://embedding-service:8000/v1","model":"BAAI/bge-m3","api_key_env":"EMBEDDING_API_KEY","timeout_seconds":5,"max_retries":2,"dimensions":1024}}`,
+			want: `{"embedding_config":{"backend":"openai_compatible","model_type":"remote","target_dimension":1024},"endpoint":{"base_url":"http://embedding-service:8000/v1","model":"BAAI/bge-m3","api_key_env":"EMBEDDING_API_KEY","timeout_seconds":5,"max_retries":2,"max_response_bytes":16777216,"dimensions":1024}}`,
 		},
 	}
 
@@ -120,12 +121,13 @@ func TestEmbeddingModelsConfigDeepCopyWithRemoteEndpoint(t *testing.T) {
 			TargetDimension: 1024,
 		},
 		Endpoint: &EmbeddingEndpointConfig{
-			BaseURL:        "http://embedding-service:8000/v1",
-			Model:          "BAAI/bge-m3",
-			APIKeyEnv:      "EMBEDDING_API_KEY",
-			TimeoutSeconds: 5,
-			MaxRetries:     2,
-			Dimensions:     1024,
+			BaseURL:          "http://embedding-service:8000/v1",
+			Model:            "BAAI/bge-m3",
+			APIKeyEnv:        "EMBEDDING_API_KEY",
+			TimeoutSeconds:   5,
+			MaxRetries:       2,
+			MaxResponseBytes: 16777216,
+			Dimensions:       1024,
 		},
 	}
 
@@ -156,12 +158,13 @@ func TestEmbeddingModelsConfigDeepCopyWithRemoteEndpoint(t *testing.T) {
 
 func TestEmbeddingEndpointConfigDeepCopy(t *testing.T) {
 	original := &EmbeddingEndpointConfig{
-		BaseURL:        "http://embedding-service:8000/v1",
-		Model:          "BAAI/bge-m3",
-		APIKeyEnv:      "EMBEDDING_API_KEY",
-		TimeoutSeconds: 5,
-		MaxRetries:     2,
-		Dimensions:     1024,
+		BaseURL:          "http://embedding-service:8000/v1",
+		Model:            "BAAI/bge-m3",
+		APIKeyEnv:        "EMBEDDING_API_KEY",
+		TimeoutSeconds:   5,
+		MaxRetries:       2,
+		MaxResponseBytes: 16777216,
+		Dimensions:       1024,
 	}
 
 	copy := original.DeepCopy()

--- a/deploy/operator/bundle/manifests/vllm.ai_semanticrouters.yaml
+++ b/deploy/operator/bundle/manifests/vllm.ai_semanticrouters.yaml
@@ -1391,6 +1391,12 @@ spec:
                               dimension when supported.
                             minimum: 1
                             type: integer
+                          max_response_bytes:
+                            description: MaxResponseBytes caps the size of each embedding
+                              response body.
+                            format: int64
+                            minimum: 0
+                            type: integer
                           max_retries:
                             description: MaxRetries is the maximum number of retry
                               attempts for embedding calls.

--- a/deploy/operator/config/crd/bases/vllm.ai_semanticrouters.yaml
+++ b/deploy/operator/config/crd/bases/vllm.ai_semanticrouters.yaml
@@ -1387,6 +1387,12 @@ spec:
                               dimension when supported.
                             minimum: 1
                             type: integer
+                          max_response_bytes:
+                            description: MaxResponseBytes caps the size of each embedding
+                              response body.
+                            format: int64
+                            minimum: 0
+                            type: integer
                           max_retries:
                             description: MaxRetries is the maximum number of retry
                               attempts for embedding calls.

--- a/src/semantic-router/pkg/config/embedding_config.go
+++ b/src/semantic-router/pkg/config/embedding_config.go
@@ -13,12 +13,13 @@ const (
 
 // EmbeddingEndpointConfig defines an external embedding provider endpoint.
 type EmbeddingEndpointConfig struct {
-	BaseURL        string `yaml:"base_url,omitempty"`
-	Model          string `yaml:"model,omitempty"`
-	APIKeyEnv      string `yaml:"api_key_env,omitempty"`
-	TimeoutSeconds int    `yaml:"timeout_seconds,omitempty"`
-	MaxRetries     int    `yaml:"max_retries,omitempty"`
-	Dimensions     int    `yaml:"dimensions,omitempty"`
+	BaseURL          string `yaml:"base_url,omitempty"`
+	Model            string `yaml:"model,omitempty"`
+	APIKeyEnv        string `yaml:"api_key_env,omitempty"`
+	TimeoutSeconds   int    `yaml:"timeout_seconds,omitempty"`
+	MaxRetries       int    `yaml:"max_retries,omitempty"`
+	MaxResponseBytes int64  `yaml:"max_response_bytes,omitempty"`
+	Dimensions       int    `yaml:"dimensions,omitempty"`
 }
 
 func (e EmbeddingModels) EmbeddingBackend() string {

--- a/src/semantic-router/pkg/config/validator_embedding.go
+++ b/src/semantic-router/pkg/config/validator_embedding.go
@@ -70,6 +70,9 @@ func validateRemoteEmbeddingEndpoint(endpoint EmbeddingEndpointConfig) []string 
 	if endpoint.MaxRetries < 0 {
 		problems = append(problems, "endpoint.max_retries must be non-negative")
 	}
+	if endpoint.MaxResponseBytes < 0 {
+		problems = append(problems, "endpoint.max_response_bytes must be non-negative")
+	}
 	return problems
 }
 

--- a/src/semantic-router/pkg/config/validator_embedding_test.go
+++ b/src/semantic-router/pkg/config/validator_embedding_test.go
@@ -164,10 +164,11 @@ func TestValidateEmbeddingContracts_RejectsInvalidRemoteEmbeddingProvider(t *tes
 					TargetDimension: 768,
 				},
 				Endpoint: EmbeddingEndpointConfig{
-					BaseURL:        "example.test/v1",
-					Dimensions:     1536,
-					TimeoutSeconds: -1,
-					MaxRetries:     -1,
+					BaseURL:          "example.test/v1",
+					Dimensions:       1536,
+					TimeoutSeconds:   -1,
+					MaxRetries:       -1,
+					MaxResponseBytes: -1,
 				},
 			},
 		},
@@ -183,6 +184,7 @@ func TestValidateEmbeddingContracts_RejectsInvalidRemoteEmbeddingProvider(t *tes
 		"endpoint.model",
 		"endpoint.timeout_seconds",
 		"endpoint.max_retries",
+		"endpoint.max_response_bytes",
 		"endpoint.dimensions (1536)",
 		"embedding_config.model_type",
 	} {

--- a/src/semantic-router/pkg/embedding/openai_provider.go
+++ b/src/semantic-router/pkg/embedding/openai_provider.go
@@ -15,13 +15,15 @@ import (
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
 )
 
 const (
-	maxErrorBodyBytes     = 4096
-	defaultTimeoutSeconds = 10
-	baseRetryDelay        = 50 * time.Millisecond
-	maxRetryDelay         = 500 * time.Millisecond
+	maxErrorBodyBytes       = 4096
+	defaultTimeoutSeconds   = 10
+	defaultMaxResponseBytes = 16 * 1024 * 1024
+	baseRetryDelay          = 50 * time.Millisecond
+	maxRetryDelay           = 500 * time.Millisecond
 )
 
 type OpenAICompatibleConfig struct {
@@ -30,6 +32,7 @@ type OpenAICompatibleConfig struct {
 	APIKeyEnv         string
 	TimeoutSeconds    int
 	MaxRetries        int
+	MaxResponseBytes  int64
 	Dimensions        int
 	ExpectedDimension int
 	HTTPClient        *http.Client
@@ -41,6 +44,7 @@ type OpenAICompatibleProvider struct {
 	apiKeyEnv         string
 	timeout           time.Duration
 	maxRetries        int
+	maxResponseBytes  int64
 	dimensions        int
 	expectedDimension int
 	client            *http.Client
@@ -83,6 +87,10 @@ func NewOpenAICompatibleProvider(cfg OpenAICompatibleConfig) (*OpenAICompatibleP
 	if cfg.TimeoutSeconds < 0 {
 		return nil, fmt.Errorf("embedding endpoint timeout_seconds must be non-negative")
 	}
+	maxResponseBytes, err := resolveMaxResponseBytes(cfg.MaxResponseBytes)
+	if err != nil {
+		return nil, err
+	}
 
 	timeoutSeconds := cfg.TimeoutSeconds
 	if timeoutSeconds == 0 {
@@ -104,10 +112,21 @@ func NewOpenAICompatibleProvider(cfg OpenAICompatibleConfig) (*OpenAICompatibleP
 		apiKeyEnv:         strings.TrimSpace(cfg.APIKeyEnv),
 		timeout:           timeout,
 		maxRetries:        max(0, cfg.MaxRetries),
+		maxResponseBytes:  maxResponseBytes,
 		dimensions:        cfg.Dimensions,
 		expectedDimension: cfg.ExpectedDimension,
 		client:            client,
 	}, nil
+}
+
+func resolveMaxResponseBytes(maxResponseBytes int64) (int64, error) {
+	if maxResponseBytes < 0 {
+		return 0, fmt.Errorf("embedding endpoint max_response_bytes must be non-negative")
+	}
+	if maxResponseBytes == 0 {
+		return defaultMaxResponseBytes, nil
+	}
+	return maxResponseBytes, nil
 }
 
 func (p *OpenAICompatibleProvider) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -209,14 +228,27 @@ func (p *OpenAICompatibleProvider) embedBatchOnce(ctx context.Context, texts []s
 		return nil, responseError(resp)
 	}
 
-	var decoded embeddingsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("decode embedding response: %w", err)
+	decoded, err := decodeEmbeddingResponse(resp.Body, p.maxResponseBytes)
+	if err != nil {
+		return nil, err
 	}
 	if decoded.Error != nil && decoded.Error.Message != "" {
 		return nil, fmt.Errorf("embedding provider error: %s", decoded.Error.Message)
 	}
 	return p.parseEmbeddings(decoded.Data, len(texts))
+}
+
+func decodeEmbeddingResponse(body io.Reader, maxResponseBytes int64) (embeddingsResponse, error) {
+	responseBody, err := httputil.ReadLimitedBody(body, maxResponseBytes)
+	if err != nil {
+		return embeddingsResponse{}, fmt.Errorf("read embedding response: %w", err)
+	}
+
+	var decoded embeddingsResponse
+	if err := json.NewDecoder(bytes.NewReader(responseBody)).Decode(&decoded); err != nil {
+		return embeddingsResponse{}, fmt.Errorf("decode embedding response: %w", err)
+	}
+	return decoded, nil
 }
 
 func (p *OpenAICompatibleProvider) parseEmbeddings(data []embeddingDatum, expectedCount int) ([][]float32, error) {

--- a/src/semantic-router/pkg/embedding/openai_provider_test.go
+++ b/src/semantic-router/pkg/embedding/openai_provider_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
 func TestOpenAICompatibleProviderEmbedBatch(t *testing.T) {
@@ -180,11 +182,66 @@ func TestOpenAICompatibleProviderDimensionMismatch(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleProviderResponseLimit(t *testing.T) {
+	responseBody, err := json.Marshal(embeddingsResponse{
+		Data: []embeddingDatum{{Index: 0, Embedding: []float64{0.1, 0.2}}},
+	})
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(responseBody)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name             string
+		maxResponseBytes int64
+		wantErr          bool
+	}{
+		{name: "at limit", maxResponseBytes: int64(len(responseBody))},
+		{name: "one byte over", maxResponseBytes: int64(len(responseBody)) - 1, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewProvider(config.EmbeddingModels{
+				EmbeddingConfig: config.HNSWConfig{
+					Backend:         config.EmbeddingBackendOpenAICompatible,
+					TargetDimension: 2,
+				},
+				Endpoint: config.EmbeddingEndpointConfig{
+					BaseURL:          server.URL,
+					Model:            "embedding-model",
+					MaxResponseBytes: tt.maxResponseBytes,
+				},
+			}, ProviderOptions{})
+			if err != nil {
+				t.Fatalf("NewProvider() error = %v", err)
+			}
+
+			embedding, err := provider.Embed(context.Background(), "hello")
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "response body exceeds limit") {
+					t.Fatalf("Embed() error = %v, want response limit error", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Embed() error = %v", err)
+			}
+			if len(embedding) != 2 {
+				t.Fatalf("embedding length = %d, want 2", len(embedding))
+			}
+		})
+	}
+}
+
 func TestNewOpenAICompatibleProviderValidatesConfig(t *testing.T) {
 	cases := []OpenAICompatibleConfig{
 		{Model: "embedding-model"},
 		{BaseURL: "localhost:8000", Model: "embedding-model"},
 		{BaseURL: "http://localhost:8000", Dimensions: 2, ExpectedDimension: 3},
+		{BaseURL: "http://localhost:8000", Model: "embedding-model", MaxResponseBytes: -1},
 		{BaseURL: "http://localhost:8000"},
 	}
 	for _, cfg := range cases {

--- a/src/semantic-router/pkg/embedding/provider.go
+++ b/src/semantic-router/pkg/embedding/provider.go
@@ -113,6 +113,7 @@ func openAICompatibleConfigFromModels(models config.EmbeddingModels, client *htt
 		APIKeyEnv:         models.Endpoint.APIKeyEnv,
 		TimeoutSeconds:    models.Endpoint.TimeoutSeconds,
 		MaxRetries:        models.Endpoint.MaxRetries,
+		MaxResponseBytes:  models.Endpoint.MaxResponseBytes,
 		Dimensions:        models.Endpoint.Dimensions,
 		ExpectedDimension: expectedDimension,
 		HTTPClient:        client,

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -333,6 +333,7 @@ class EmbeddingEndpointConfig(BaseModel):
     api_key_env: Optional[str] = None
     timeout_seconds: Optional[int] = Field(default=None, ge=0)
     max_retries: Optional[int] = Field(default=None, ge=0)
+    max_response_bytes: Optional[int] = Field(default=None, ge=0)
     dimensions: Optional[int] = Field(default=None, ge=1)
 
 

--- a/src/vllm-sr/tests/test_config_file_loaders.py
+++ b/src/vllm-sr/tests/test_config_file_loaders.py
@@ -205,6 +205,7 @@ def test_embedding_models_config_accepts_remote_endpoint() -> None:
             "api_key_env": "EMBEDDING_API_KEY",
             "timeout_seconds": 5,
             "max_retries": 2,
+            "max_response_bytes": 16777216,
             "dimensions": 1024,
         },
     )
@@ -214,6 +215,7 @@ def test_embedding_models_config_accepts_remote_endpoint() -> None:
     assert dumped["embedding_config"]["model_type"] == "remote"
     assert dumped["endpoint"]["base_url"] == "http://embedding-service:8000/v1"
     assert dumped["endpoint"]["api_key_env"] == "EMBEDDING_API_KEY"
+    assert dumped["endpoint"]["max_response_bytes"] == 16777216
 
 
 def test_parse_user_config_accepts_decision_learning_controls(

--- a/website/docs/tutorials/global/remote-embeddings.md
+++ b/website/docs/tutorials/global/remote-embeddings.md
@@ -58,12 +58,14 @@ global:
           api_key_env: EMBEDDING_API_KEY
           timeout_seconds: 10
           max_retries: 2
+          max_response_bytes: 16777216
           dimensions: 1536
 ```
 
 The Router appends `/embeddings` unless `base_url` already ends with that path.
 When both dimensions are set, `endpoint.dimensions` and
 `embedding_config.target_dimension` must match.
+`max_response_bytes` caps each provider response; omitted or `0` uses 16 MiB.
 
 Embedding signals do not change:
 


### PR DESCRIPTION
Related #3097

## Purpose

- Bound OpenAI-compatible embedding responses with a configurable 16 MiB default.
- Keep unset or `0` backward compatible.

## Test Plan

- `make agent-ci-gate CHANGED_FILES="<PR files>"`

## Test Result

- Passed.