### PR TITLE
[Bug] Bound image generation response reads

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1489,6 +1489,7 @@ routing:
             default_height: 1024
             max_inference_steps: 30
             timeout_seconds: 60
+            max_response_bytes: 67108864
 
     - name: multimodal_route
       description: BOTH-modality route requiring text and image-capable execution.

--- a/src/semantic-router/pkg/config/image_gen_plugin.go
+++ b/src/semantic-router/pkg/config/image_gen_plugin.go
@@ -306,6 +306,9 @@ type ImageGenPluginConfig struct {
 
 	// Timeout in seconds
 	TimeoutSeconds int `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty"`
+
+	// Maximum response body size in bytes
+	MaxResponseBytes int64 `json:"max_response_bytes,omitempty" yaml:"max_response_bytes,omitempty"`
 }
 
 // VLLMOmniImageGenConfig represents configuration for vLLM-Omni image generation
@@ -403,21 +406,28 @@ func (c *ModalityDetectionConfig) Validate() error {
 	}
 
 	method := c.GetMethod()
+	if err := validateModalityDetectionMethod(method); err != nil {
+		return err
+	}
+	if err := c.validateMethodRequirements(method); err != nil {
+		return err
+	}
+	return c.validateThresholds(method)
+}
+
+func validateModalityDetectionMethod(method string) error {
 	if method == "" {
 		return fmt.Errorf("modality_detection.method is required (one of %q, %q, or %q)",
 			ModalityDetectionClassifier, ModalityDetectionKeyword, ModalityDetectionHybrid)
 	}
-
-	// Validate method value
-	switch method {
-	case ModalityDetectionClassifier, ModalityDetectionKeyword, ModalityDetectionHybrid:
-		// valid
-	default:
+	if method != ModalityDetectionClassifier && method != ModalityDetectionKeyword && method != ModalityDetectionHybrid {
 		return fmt.Errorf("modality_detection.method must be one of %q, %q, or %q, got %q",
 			ModalityDetectionClassifier, ModalityDetectionKeyword, ModalityDetectionHybrid, method)
 	}
+	return nil
+}
 
-	// Method-specific validation
+func (c *ModalityDetectionConfig) validateMethodRequirements(method string) error {
 	switch method {
 	case ModalityDetectionClassifier:
 		if c.Classifier == nil || c.Classifier.ModelPath == "" {
@@ -436,26 +446,19 @@ func (c *ModalityDetectionConfig) Validate() error {
 			return fmt.Errorf("modality_detection: method %q requires at least one of classifier.model_path or keywords to be configured", method)
 		}
 	}
+	return nil
+}
 
-	// Validate confidence threshold
-	if c.ConfidenceThreshold != 0 {
-		if c.ConfidenceThreshold < 0 || c.ConfidenceThreshold > 1 {
-			return fmt.Errorf("modality_detection.confidence_threshold must be between 0 and 1, got %.4f", c.ConfidenceThreshold)
-		}
+func (c *ModalityDetectionConfig) validateThresholds(method string) error {
+	if c.ConfidenceThreshold != 0 && (c.ConfidenceThreshold < 0 || c.ConfidenceThreshold > 1) {
+		return fmt.Errorf("modality_detection.confidence_threshold must be between 0 and 1, got %.4f", c.ConfidenceThreshold)
 	}
-
-	// confidence_threshold is required when the classifier is involved
 	if (method == ModalityDetectionClassifier || method == ModalityDetectionHybrid) && c.ConfidenceThreshold == 0 {
 		return fmt.Errorf("modality_detection.confidence_threshold is required when method is %q (e.g. 0.6)", method)
 	}
-
-	// lower_threshold_ratio validation
-	if c.LowerThresholdRatio != 0 {
-		if c.LowerThresholdRatio < 0 || c.LowerThresholdRatio > 1 {
-			return fmt.Errorf("modality_detection.lower_threshold_ratio must be between 0 and 1, got %.4f", c.LowerThresholdRatio)
-		}
+	if c.LowerThresholdRatio != 0 && (c.LowerThresholdRatio < 0 || c.LowerThresholdRatio > 1) {
+		return fmt.Errorf("modality_detection.lower_threshold_ratio must be between 0 and 1, got %.4f", c.LowerThresholdRatio)
 	}
-	// lower_threshold_ratio is required for hybrid (controls classifier-vs-keyword disagreement)
 	if method == ModalityDetectionHybrid && c.LowerThresholdRatio == 0 {
 		return fmt.Errorf("modality_detection.lower_threshold_ratio is required when method is %q (e.g. 0.7)", method)
 	}
@@ -472,7 +475,23 @@ func (c *ImageGenPluginConfig) Validate() error {
 	if c.Backend == "" {
 		return fmt.Errorf("image_gen backend is required when enabled")
 	}
+	if err := c.validateBackend(); err != nil {
+		return err
+	}
+	if c.MaxResponseBytes < 0 {
+		return fmt.Errorf("image_gen max_response_bytes must be non-negative")
+	}
 
+	if c.ModalityDetection != nil {
+		if err := c.ModalityDetection.Validate(); err != nil {
+			return fmt.Errorf("image_gen: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *ImageGenPluginConfig) validateBackend() error {
 	switch c.Backend {
 	case "vllm_omni":
 		vllmConfig, err := c.VLLMOmniBackendConfig()
@@ -493,13 +512,5 @@ func (c *ImageGenPluginConfig) Validate() error {
 	default:
 		return fmt.Errorf("unknown image_gen backend: %s", c.Backend)
 	}
-
-	// Validate modality detection if present
-	if c.ModalityDetection != nil {
-		if err := c.ModalityDetection.Validate(); err != nil {
-			return fmt.Errorf("image_gen: %w", err)
-		}
-	}
-
 	return nil
 }

--- a/src/semantic-router/pkg/config/image_gen_plugin_test.go
+++ b/src/semantic-router/pkg/config/image_gen_plugin_test.go
@@ -427,6 +427,18 @@ var _ = Describe("ImageGenPluginConfig.Validate", func() {
 		Expect(err.Error()).To(ContainSubstring("unknown image_gen backend"))
 	})
 
+	It("rejects a negative response limit", func() {
+		cfg := &ImageGenPluginConfig{
+			Enabled:          true,
+			Backend:          "vllm_omni",
+			BackendConfig:    MustStructuredPayload(&VLLMOmniImageGenConfig{BaseURL: "http://localhost:8001"}),
+			MaxResponseBytes: -1,
+		}
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("max_response_bytes must be non-negative"))
+	})
+
 	Context("with vllm_omni backend", func() {
 		It("passes with valid vllm_omni + valid modality detection", func() {
 			cfg := &ImageGenPluginConfig{

--- a/src/semantic-router/pkg/imagegen/backend_openai.go
+++ b/src/semantic-router/pkg/imagegen/backend_openai.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -14,12 +13,13 @@ import (
 
 // OpenAIBackend implements the Backend interface for OpenAI image generation
 type OpenAIBackend struct {
-	baseURL    string
-	apiKey     string
-	model      string
-	quality    string
-	style      string
-	httpClient *http.Client
+	baseURL          string
+	apiKey           string
+	model            string
+	quality          string
+	style            string
+	maxResponseBytes int64
+	httpClient       *http.Client
 }
 
 // NewOpenAIBackend creates a new OpenAI image generation backend
@@ -48,12 +48,18 @@ func NewOpenAIBackend(cfg *config.ImageGenPluginConfig) (Backend, error) {
 		model = "gpt-image-1"
 	}
 
+	maxResponseBytes, err := resolveImageGenMaxResponseBytes(cfg.MaxResponseBytes)
+	if err != nil {
+		return nil, err
+	}
+
 	return &OpenAIBackend{
-		baseURL: baseURL,
-		apiKey:  openaiConfig.APIKey,
-		model:   model,
-		quality: openaiConfig.Quality,
-		style:   openaiConfig.Style,
+		baseURL:          baseURL,
+		apiKey:           openaiConfig.APIKey,
+		model:            model,
+		quality:          openaiConfig.Quality,
+		style:            openaiConfig.Style,
+		maxResponseBytes: maxResponseBytes,
 		httpClient: &http.Client{
 			Timeout: timeout,
 		},
@@ -67,29 +73,7 @@ func (b *OpenAIBackend) Name() string {
 
 // GenerateImage generates an image using OpenAI's image generation API
 func (b *OpenAIBackend) GenerateImage(ctx context.Context, req *GenerateRequest) (*GenerateResponse, error) {
-	// Build OpenAI request
-	openaiReq := openAIImageRequest{
-		Model:  b.model,
-		Prompt: req.Prompt,
-		N:      1,
-		Size:   fmt.Sprintf("%dx%d", getIntOrDefault(req.Width, 1024), getIntOrDefault(req.Height, 1024)),
-	}
-
-	if req.Model != "" {
-		openaiReq.Model = req.Model
-	}
-
-	if req.Quality != "" {
-		openaiReq.Quality = req.Quality
-	} else if b.quality != "" {
-		openaiReq.Quality = b.quality
-	}
-
-	if req.Style != "" {
-		openaiReq.Style = req.Style
-	} else if b.style != "" {
-		openaiReq.Style = b.style
-	}
+	openaiReq := b.buildRequest(req)
 
 	// Serialize request
 	body, err := json.Marshal(openaiReq)
@@ -112,15 +96,9 @@ func (b *OpenAIBackend) GenerateImage(ctx context.Context, req *GenerateRequest)
 	}
 	defer resp.Body.Close()
 
-	// Read response body
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := readImageGenResponse(resp, b.maxResponseBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Check for errors
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, err
 	}
 
 	// Parse response
@@ -149,6 +127,32 @@ func (b *OpenAIBackend) GenerateImage(ctx context.Context, req *GenerateRequest)
 	}
 
 	return result, nil
+}
+
+func (b *OpenAIBackend) buildRequest(req *GenerateRequest) openAIImageRequest {
+	openaiReq := openAIImageRequest{
+		Model:  b.model,
+		Prompt: req.Prompt,
+		N:      1,
+		Size:   fmt.Sprintf("%dx%d", getIntOrDefault(req.Width, 1024), getIntOrDefault(req.Height, 1024)),
+	}
+
+	if req.Model != "" {
+		openaiReq.Model = req.Model
+	}
+
+	if req.Quality != "" {
+		openaiReq.Quality = req.Quality
+	} else if b.quality != "" {
+		openaiReq.Quality = b.quality
+	}
+
+	if req.Style != "" {
+		openaiReq.Style = req.Style
+	} else if b.style != "" {
+		openaiReq.Style = b.style
+	}
+	return openaiReq
 }
 
 // HealthCheck checks if the OpenAI API is accessible

--- a/src/semantic-router/pkg/imagegen/backend_vllm_omni.go
+++ b/src/semantic-router/pkg/imagegen/backend_vllm_omni.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -14,9 +13,10 @@ import (
 
 // VLLMOmniBackend implements the Backend interface for vLLM-Omni
 type VLLMOmniBackend struct {
-	baseURL    string
-	model      string
-	httpClient *http.Client
+	baseURL          string
+	model            string
+	maxResponseBytes int64
+	httpClient       *http.Client
 
 	// Default parameters
 	defaultSteps    int
@@ -40,9 +40,15 @@ func NewVLLMOmniBackend(cfg *config.ImageGenPluginConfig) (Backend, error) {
 		timeout = 120 * time.Second
 	}
 
+	maxResponseBytes, err := resolveImageGenMaxResponseBytes(cfg.MaxResponseBytes)
+	if err != nil {
+		return nil, err
+	}
+
 	return &VLLMOmniBackend{
-		baseURL: vllmConfig.BaseURL,
-		model:   vllmConfig.Model,
+		baseURL:          vllmConfig.BaseURL,
+		model:            vllmConfig.Model,
+		maxResponseBytes: maxResponseBytes,
 		httpClient: &http.Client{
 			Timeout: timeout,
 		},
@@ -101,15 +107,9 @@ func (b *VLLMOmniBackend) GenerateImage(ctx context.Context, req *GenerateReques
 		_ = resp.Body.Close()
 	}()
 
-	// Read response body
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := readImageGenResponse(resp, b.maxResponseBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Check for errors
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, err
 	}
 
 	// Parse response

--- a/src/semantic-router/pkg/imagegen/response_body.go
+++ b/src/semantic-router/pkg/imagegen/response_body.go
@@ -1,0 +1,36 @@
+package imagegen
+
+import (
+	"fmt"
+	"net/http"
+
+	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
+)
+
+const (
+	defaultImageGenMaxResponseBytes int64 = 64 * 1024 * 1024
+	maxImageGenErrorBodyBytes       int64 = 10 * 1024
+)
+
+func resolveImageGenMaxResponseBytes(maxResponseBytes int64) (int64, error) {
+	if maxResponseBytes < 0 {
+		return 0, fmt.Errorf("image_gen max_response_bytes must be non-negative")
+	}
+	if maxResponseBytes == 0 {
+		return defaultImageGenMaxResponseBytes, nil
+	}
+	return maxResponseBytes, nil
+}
+
+func readImageGenResponse(resp *http.Response, maxResponseBytes int64) ([]byte, error) {
+	if resp.StatusCode != http.StatusOK {
+		body, truncated := httputil.ReadTruncatedBody(resp.Body, maxImageGenErrorBodyBytes)
+		return nil, fmt.Errorf("request failed with status %d: %s (truncated=%t)", resp.StatusCode, string(body), truncated)
+	}
+
+	body, err := httputil.ReadLimitedBody(resp.Body, maxResponseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	return body, nil
+}

--- a/src/semantic-router/pkg/imagegen/response_body_test.go
+++ b/src/semantic-router/pkg/imagegen/response_body_test.go
@@ -1,0 +1,112 @@
+package imagegen
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestImageGenBackendsResponseLimit(t *testing.T) {
+	backends := []struct {
+		name     string
+		response string
+		new      func(*testing.T, string, int64) Backend
+	}{
+		{
+			name:     "openai",
+			response: `{"data":[{"url":"https://example.com/image.png"}]}`,
+			new: func(t *testing.T, baseURL string, maxResponseBytes int64) Backend {
+				t.Helper()
+				backend, err := NewOpenAIBackend(&config.ImageGenPluginConfig{
+					Backend:          "openai",
+					MaxResponseBytes: maxResponseBytes,
+					BackendConfig: config.MustStructuredPayload(&config.OpenAIImageGenConfig{
+						APIKey:  "test-key",
+						BaseURL: baseURL,
+					}),
+				})
+				if err != nil {
+					t.Fatalf("NewOpenAIBackend() error = %v", err)
+				}
+				return backend
+			},
+		},
+		{
+			name:     "vllm_omni",
+			response: `{"model":"test-model","choices":[{"message":{"content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,test"}}]}}]}`,
+			new: func(t *testing.T, baseURL string, maxResponseBytes int64) Backend {
+				t.Helper()
+				backend, err := NewVLLMOmniBackend(&config.ImageGenPluginConfig{
+					Backend:          "vllm_omni",
+					MaxResponseBytes: maxResponseBytes,
+					BackendConfig: config.MustStructuredPayload(&config.VLLMOmniImageGenConfig{
+						BaseURL: baseURL,
+					}),
+				})
+				if err != nil {
+					t.Fatalf("NewVLLMOmniBackend() error = %v", err)
+				}
+				return backend
+			},
+		},
+	}
+
+	for _, backendCase := range backends {
+		t.Run(backendCase.name, func(t *testing.T) {
+			testImageGenBackendResponseLimit(t, backendCase.response, backendCase.new)
+		})
+	}
+}
+
+func testImageGenBackendResponseLimit(t *testing.T, response string, newBackend func(*testing.T, string, int64) Backend) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, response)
+	}))
+	defer server.Close()
+
+	limits := []struct {
+		name             string
+		maxResponseBytes int64
+		wantErr          bool
+	}{
+		{name: "default"},
+		{name: "at limit", maxResponseBytes: int64(len(response))},
+		{name: "one byte over", maxResponseBytes: int64(len(response)) - 1, wantErr: true},
+	}
+	for _, limitCase := range limits {
+		t.Run(limitCase.name, func(t *testing.T) {
+			backend := newBackend(t, server.URL, limitCase.maxResponseBytes)
+			_, err := backend.GenerateImage(context.Background(), &GenerateRequest{Prompt: "test"})
+			if limitCase.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "response body exceeds limit") {
+					t.Fatalf("GenerateImage() error = %v, want response limit error", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GenerateImage() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestReadImageGenResponseTruncatesErrorBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(strings.NewReader(strings.Repeat("x", int(maxImageGenErrorBodyBytes)) + "tail")),
+	}
+
+	_, err := readImageGenResponse(resp, defaultImageGenMaxResponseBytes)
+	if err == nil || !strings.Contains(err.Error(), "truncated=true") {
+		t.Fatalf("readImageGenResponse() error = %v, want truncated error", err)
+	}
+	if strings.Contains(err.Error(), "tail") {
+		t.Fatalf("readImageGenResponse() included content beyond the error-body limit")
+	}
+}

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -1230,6 +1230,7 @@ class ImageGenPluginConfig(BaseModel):
     default_height: Optional[int] = Field(default=None, ge=1)
     max_inference_steps: Optional[int] = Field(default=None, ge=1)
     timeout_seconds: Optional[int] = Field(default=None, ge=1)
+    max_response_bytes: Optional[int] = Field(default=None, ge=0)
 
 
 class DecisionLearningAdaptationConfig(BaseModel):

--- a/src/vllm-sr/tests/test_plugin_parsing.py
+++ b/src/vllm-sr/tests/test_plugin_parsing.py
@@ -134,6 +134,7 @@ decisions:
         configuration:
           enabled: true
           backend: "openai"
+          max_response_bytes: 67108864
           backend_config:
             api_key: "test-key"
 providers:

--- a/website/docs/tutorials/plugin/image-gen.md
+++ b/website/docs/tutorials/plugin/image-gen.md
@@ -39,5 +39,6 @@ plugins:
 
 The selected backend receives the image prompt and generation parameters. Use
 an authenticated, trusted endpoint and apply request-side safety policy before
-this plugin. See a complete example:
+this plugin. `max_response_bytes` caps each OpenAI or vLLM-Omni response body;
+omitted or `0` uses 64 MiB. See a complete example:
 [`config/fragments/plugin/image-gen/basic.yaml`](https://github.com/vllm-project/semantic-router/blob/main/config/fragments/plugin/image-gen/basic.yaml).


### PR DESCRIPTION
Related #3097

## Purpose

- Bound OpenAI and vLLM-Omni image generation response bodies.
- Default unset or `0` to 64 MiB for backward compatibility.
- Truncate non-2xx error bodies.

## Test Plan

- Test default, exact-limit, over-limit, and error truncation behavior.
- Run `make agent-ci-gate`.

## Test Result

- All tests passed.