### PR TITLE
[Bug] Open a PII entity on an orphan I- tag

### DIFF
--- a/candle-binding/src/model_architectures/traditional/modernbert.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert.rs
@@ -1273,19 +1273,61 @@ impl BioEntity {
     }
 }
 
+/// Trim surrounding whitespace from an entity span.
+///
+/// Sub-word tokenizers attach the preceding space to a word-initial token, so
+/// a `PERSON` span starts on the space before the name. Callers slice the text
+/// with these offsets, and PII masking then eats that space.
+fn trim_entity_span(text: &str, start: usize, end: usize) -> (usize, usize) {
+    let slice = &text[start..end];
+    let trimmed = slice.trim_matches(|c: char| c.is_whitespace());
+    if trimmed.is_empty() {
+        return (start, end);
+    }
+    let lead = slice.len() - slice.trim_start_matches(|c: char| c.is_whitespace()).len();
+    let trail = slice.len() - slice.trim_end_matches(|c: char| c.is_whitespace()).len();
+    (start + lead, end - trail)
+}
+
 /// Merge a sequence of BIO-labelled tokens into entities.
 ///
 /// `tokens` must already have special tokens removed and must be in text order.
 /// Offsets are byte offsets into `text`.
+///
+/// An `I-` tag that does not continue an open entity opens one of its own type.
+/// Models are not obliged to emit `B-`: the mmBERT-32K PII detector labels
+/// emails and domains with `I-` only, so requiring `B-` dropped them entirely.
 pub(crate) fn merge_bio_entities(text: &str, tokens: &[BioToken<'_>]) -> Vec<BioEntity> {
     let mut entities: Vec<BioEntity> = Vec::new();
     let mut current: Option<BioEntity> = None;
 
+    // Close `current`, trim its span and push it.
+    fn flush(text: &str, entities: &mut Vec<BioEntity>, entity: BioEntity) {
+        let mut entity = entity;
+        let (start, end) = trim_entity_span(text, entity.start, entity.end);
+        entity.start = start;
+        entity.end = end;
+        entity.text = text[start..end].to_string();
+        entities.push(entity);
+    }
+
     for token in tokens {
-        if let Some(entity_type) = token.label.strip_prefix("B-") {
-            // Beginning of a new entity.
+        let opens_new_entity = match token.label.strip_prefix("B-") {
+            Some(entity_type) => Some(entity_type),
+            None => match token.label.strip_prefix("I-") {
+                // Continues the open entity only when the type matches,
+                // otherwise it starts a new one.
+                Some(entity_type) => match current {
+                    Some(ref entity) if entity.entity_type == entity_type => None,
+                    _ => Some(entity_type),
+                },
+                None => None,
+            },
+        };
+
+        if let Some(entity_type) = opens_new_entity {
             if let Some(entity) = current.take() {
-                entities.push(entity);
+                flush(text, &mut entities, entity);
             }
             current = Some(BioEntity {
                 entity_type: entity_type.to_string(),
@@ -1295,30 +1337,23 @@ pub(crate) fn merge_bio_entities(text: &str, tokens: &[BioToken<'_>]) -> Vec<Bio
                 confidence: token.confidence,
                 token_count: 1,
             });
-        } else if let Some(entity_type) = token.label.strip_prefix("I-") {
-            // Continuation of the open entity, when the type matches.
+        } else if token.label.starts_with("I-") {
+            // Continuation of the open entity of the same type.
             if let Some(ref mut entity) = current {
-                if entity.entity_type == entity_type {
-                    entity.end = token.end;
-                    entity.text = text[entity.start..entity.end].to_string();
-                    entity.accumulate(token.confidence);
-                } else {
-                    // Different entity type: close the open entity, drop this token.
-                    entities.push(entity.clone());
-                    current = None;
-                }
+                entity.end = token.end;
+                entity.text = text[entity.start..entity.end].to_string();
+                entity.accumulate(token.confidence);
             }
-            // An I- tag with no open entity is ignored.
         } else {
             // O tag closes any open entity.
             if let Some(entity) = current.take() {
-                entities.push(entity);
+                flush(text, &mut entities, entity);
             }
         }
     }
 
     if let Some(entity) = current.take() {
-        entities.push(entity);
+        flush(text, &mut entities, entity);
     }
 
     entities

--- a/candle-binding/src/model_architectures/traditional/modernbert_test.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert_test.rs
@@ -1980,7 +1980,7 @@ fn test_modernbert_bio_entity_boundaries() {
             start: 0,
             end: 2,
             confidence: 0.9,
-        }, // orphan, ignored
+        }, // orphan -> opens PERSON
         BioToken {
             label: "B-PERSON",
             start: 3,
@@ -1992,7 +1992,7 @@ fn test_modernbert_bio_entity_boundaries() {
             start: 6,
             end: 8,
             confidence: 0.7,
-        }, // mismatch, closes
+        }, // type change -> closes PERSON, opens GPE
         BioToken {
             label: "B-GPE",
             start: 9,
@@ -2008,15 +2008,155 @@ fn test_modernbert_bio_entity_boundaries() {
     ];
 
     let entities = merge_bio_entities(text, &tokens);
-    assert_eq!(entities.len(), 2);
+    assert_eq!(entities.len(), 4);
 
     assert_eq!(entities[0].entity_type, "PERSON");
-    assert_eq!(entities[0].text, "bb");
+    assert_eq!(entities[0].text, "aa");
     assert_eq!(entities[0].token_count, 1);
-    assert!((entities[0].confidence - 0.8).abs() < 1e-6);
+    assert!((entities[0].confidence - 0.9).abs() < 1e-6);
 
-    assert_eq!(entities[1].entity_type, "GPE");
-    assert_eq!(entities[1].text, "dd");
+    assert_eq!(entities[1].entity_type, "PERSON");
+    assert_eq!(entities[1].text, "bb");
     assert_eq!(entities[1].token_count, 1);
-    assert!((entities[1].confidence - 0.6).abs() < 1e-6);
+    assert!((entities[1].confidence - 0.8).abs() < 1e-6);
+
+    assert_eq!(entities[2].entity_type, "GPE");
+    assert_eq!(entities[2].text, "cc");
+    assert_eq!(entities[2].token_count, 1);
+    assert!((entities[2].confidence - 0.7).abs() < 1e-6);
+
+    assert_eq!(entities[3].entity_type, "GPE");
+    assert_eq!(entities[3].text, "dd");
+    assert_eq!(entities[3].token_count, 1);
+    assert!((entities[3].confidence - 0.6).abs() < 1e-6);
+}
+
+/// The PII checkpoint labels emails with I- tags only, never B-.
+#[test]
+fn test_merge_bio_entities_orphan_i_tag_opens_entity() {
+    let text = "mail bob@example.org now";
+    let tokens = vec![
+        BioToken {
+            label: "O",
+            start: 0,
+            end: 4,
+            confidence: 0.99,
+        },
+        BioToken {
+            label: "I-EMAIL_ADDRESS",
+            start: 5,
+            end: 8,
+            confidence: 0.67,
+        },
+        BioToken {
+            label: "I-EMAIL_ADDRESS",
+            start: 8,
+            end: 9,
+            confidence: 0.64,
+        },
+        BioToken {
+            label: "I-EMAIL_ADDRESS",
+            start: 9,
+            end: 20,
+            confidence: 0.86,
+        },
+        BioToken {
+            label: "O",
+            start: 20,
+            end: 24,
+            confidence: 0.98,
+        },
+    ];
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0].entity_type, "EMAIL_ADDRESS");
+    assert_eq!(entities[0].text, "bob@example.org");
+    assert_eq!((entities[0].start, entities[0].end), (5, 20));
+}
+
+#[test]
+fn test_merge_bio_entities_type_change_on_i_tag_starts_new_entity() {
+    let text = "John Smith Berlin";
+    let tokens = vec![
+        BioToken {
+            label: "B-PERSON",
+            start: 0,
+            end: 4,
+            confidence: 0.9,
+        },
+        BioToken {
+            label: "I-PERSON",
+            start: 4,
+            end: 10,
+            confidence: 0.9,
+        },
+        BioToken {
+            label: "I-GPE",
+            start: 10,
+            end: 17,
+            confidence: 0.8,
+        },
+    ];
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 2);
+    assert_eq!(entities[0].entity_type, "PERSON");
+    assert_eq!(entities[0].text, "John Smith");
+    assert_eq!(entities[1].entity_type, "GPE");
+    assert_eq!(entities[1].text, "Berlin");
+}
+
+#[test]
+fn test_merge_bio_entities_trims_leading_space_from_span() {
+    let text = "Contact John Smith at noon";
+    let tokens = vec![
+        BioToken {
+            label: "O",
+            start: 0,
+            end: 7,
+            confidence: 0.99,
+        },
+        BioToken {
+            label: "B-PERSON",
+            start: 7,
+            end: 12,
+            confidence: 0.95,
+        },
+        BioToken {
+            label: "I-PERSON",
+            start: 12,
+            end: 18,
+            confidence: 0.93,
+        },
+        BioToken {
+            label: "O",
+            start: 18,
+            end: 26,
+            confidence: 0.99,
+        },
+    ];
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0].text, "John Smith");
+    assert_eq!((entities[0].start, entities[0].end), (8, 18));
+    let masked = format!(
+        "{}[PERSON]{}",
+        &text[..entities[0].start],
+        &text[entities[0].end..]
+    );
+    assert_eq!(masked, "Contact [PERSON] at noon");
+}
+
+/// Trimming must not produce an empty or inverted span.
+#[test]
+fn test_merge_bio_entities_whitespace_only_span_is_preserved() {
+    let text = "a   b";
+    let tokens = vec![BioToken {
+        label: "B-PERSON",
+        start: 1,
+        end: 4,
+        confidence: 0.5,
+    }];
+    let entities = merge_bio_entities(text, &tokens);
+    assert_eq!(entities.len(), 1);
+    assert!(entities[0].start < entities[0].end);
 }

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -676,7 +676,7 @@ config:
           description: Standard jailbreak detection
       pii:
         - name: pii_deny_all
-          threshold: 0.5
+          threshold: 0.7
           include_history: false
           description: Block all PII
       classifiers:


### PR DESCRIPTION
Fixes #3140

An `I-` tag with no matching open entity now starts one, instead of being dropped. Same for an `I-` whose type differs from the open entity. `openvino-binding` already decodes the same models this way.

The PII model labels emails and domains with `I-` only, so requiring `B-` made both types undetectable at any threshold.

Also trims whitespace from spans. The tokenizer puts the leading space inside the token, so masking ate it:

```
before: "Contact[PERSON_0] at sarah.chen@example.org or [PHONE_NUMBER_0]."
after:  "Contact [PERSON_0] at [EMAIL_ADDRESS_0] or [PHONE_NUMBER_0]."
```

142 labelled sentences, threshold 0.5:

```
recall     0.338 -> 0.643
precision  0.680 -> 0.522
EMAIL_ADDRESS 0/24 -> 21/24   STREET_ADDRESS 2/9 -> 9/9   DOMAIN_NAME 0/8 -> 6/8
```

### Threshold recalibration

The first revision dropped `domain-classify` and `plugin-config-variations` under their gates. The cause is the `ai-gateway` profile's `pii_deny_all` threshold of 0.5: with the merge fixed, PII fires on 83 of the 261 domain-classify prompts instead of 59, and the entities it newly finds are single tokens of noise, `STREET_ADDRESS '0'`, `DATE_TIME '°'`, `DOMAIN_NAME 'g'`.

That 0.5 was set in #681 for the previous PII model, `mom-pii-classifier`, which emits proper IOB2 (100% `B-` initial on EMAIL_ADDRESS, DOMAIN_NAME, CREDIT_CARD). #1553 swapped the model to `mmbert32k-pii-detector-merged` and carried the threshold across unchanged. Against a decoder that was discarding most spans it looked fine.

Raising it to 0.7 puts all three suites at or above where they are today:

```
                                upstream @0.5   this PR @0.7
domain-classify prompts flagged            59             53
plugin-config queries flagged               1              1
pii-detection cases detected            18/25          21/25
```

I did not add a two-token rule, for the reason you gave: it would discard valid single-token entities from other models.

One thing worth flagging on wording. Every shipped PII threshold is already 0.7 or higher (`config/config.yaml` and the privacy and agent recipes use 0.85, the module default is 0.9, multi-objective uses 0.7), and the deploy values do not set PII at all. `production-stack` runs `domain-classify` at 0.9 and does not regress, and `ml-model-selection` has no PII signal. So there was nothing miscalibrated on the shipped side; the only stale value is the one in the `ai-gateway` E2E profile. Happy to move it elsewhere if you meant something different.

Five new tests. `test_modernbert_bio_entity_boundaries` asserted that orphan and type-changing `I-` tags are discarded and now expects 4 entities instead of 2. I added that test in #3027 as a no-behaviour-change pin, so it was describing the bug.
