### PR TITLE
[Bug] Expose vLLM-Omni inline image base64

### DIFF
--- a/src/semantic-router/pkg/imagegen/backend_vllm_omni.go
+++ b/src/semantic-router/pkg/imagegen/backend_vllm_omni.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/imageurl"
 )
 
 // VLLMOmniBackend implements the Backend interface for vLLM-Omni
@@ -125,10 +127,20 @@ func (b *VLLMOmniBackend) GenerateImage(ctx context.Context, req *GenerateReques
 	}
 
 	return &GenerateResponse{
-		ImageURL: imageURL,
-		Model:    vllmResp.Model,
-		Backend:  b.Name(),
+		ImageURL:    imageURL,
+		ImageBase64: inlineImageBase64(imageURL),
+		Model:       vllmResp.Model,
+		Backend:     b.Name(),
 	}, nil
+}
+
+func inlineImageBase64(imageURL string) string {
+	canonical, ok := imageurl.CanonicalDataURL(imageURL)
+	if !ok {
+		return ""
+	}
+	_, payload, _ := strings.Cut(canonical, ",")
+	return payload
 }
 
 // HealthCheck checks if the vLLM-Omni server is healthy

--- a/src/semantic-router/pkg/imagegen/backend_vllm_omni_test.go
+++ b/src/semantic-router/pkg/imagegen/backend_vllm_omni_test.go
@@ -118,11 +118,35 @@ func TestVLLMOmniBackend_GenerateImage(t *testing.T) {
 	if resp.ImageURL != "data:image/png;base64,iVBORw0KGgo=" {
 		t.Errorf("unexpected image URL: %s", resp.ImageURL)
 	}
+	if resp.ImageBase64 != "iVBORw0KGgo=" {
+		t.Errorf("unexpected image base64: %s", resp.ImageBase64)
+	}
 	if resp.Backend != "vllm_omni" {
 		t.Errorf("expected backend vllm_omni, got %s", resp.Backend)
 	}
 
 	assertVLLMOmniRequest(t, <-received, req, seed)
+}
+
+func TestInlineImageBase64(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageURL string
+		want     string
+	}{
+		{name: "inline PNG", imageURL: "data:image/png;base64,aGVsbG8=", want: "aGVsbG8="},
+		{name: "uppercase data URL", imageURL: "DATA:IMAGE/WEBP;BASE64,AbCdEfGh", want: "AbCdEfGh"},
+		{name: "remote URL", imageURL: "https://example.com/image.png"},
+		{name: "non-image data URL", imageURL: "data:text/plain;base64,aGVsbG8="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := inlineImageBase64(tt.imageURL); got != tt.want {
+				t.Fatalf("inlineImageBase64(%q) = %q, want %q", tt.imageURL, got, tt.want)
+			}
+		})
+	}
 }
 
 func assertVLLMOmniRequest(t *testing.T, request vllmOmniRequest, req *GenerateRequest, seed int) {


### PR DESCRIPTION
Related #3030

## Purpose

Normalize inline vLLM-Omni image output with the shared `GenerateResponse` contract.

vLLM-Omni returns generated images as `data:image/...;base64,...` URLs. This change preserves `ImageURL` and also populates `ImageBase64`, matching the OpenAI backend response shape. Only allowlisted inline image data URLs are extracted; remote and non-image URLs leave `ImageBase64` empty.

The response shape follows the [vLLM-Omni text-to-image serving contract](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/examples/online_serving/text_to_image.md).

## Test Plan

- `/opt/homebrew/bin/go test ./pkg/imagegen`
- `make agent-lint ENV=cpu CHANGED_FILES="src/semantic-router/pkg/imagegen/backend_vllm_omni.go src/semantic-router/pkg/imagegen/backend_vllm_omni_test.go"`
- `make agent-ci-gate ENV=cpu CHANGED_FILES="src/semantic-router/pkg/imagegen/backend_vllm_omni.go src/semantic-router/pkg/imagegen/backend_vllm_omni_test.go"`
- Build and start the repository-standard CPU local stack with `make agent-feature-gate ENV=cpu ...`, then inspect all runtime services.

## Test Result

- Package tests, agent lint, and agent CI gate pass.
- The full CPU local image flow built successfully without a GPU.
- Router, Envoy, Dashboard, fleet simulator, Redis, Jaeger, Prometheus, and Grafana all started successfully; Router became ready after one second.
- The current `agent-smoke-local` target false-times out because it matches legacy colon-formatted `vllm-sr status` output while the CLI now prints aligned fields. This is unrelated to the image response change and will be split into a follow-up fix.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title does not stack prefixes
- [x] The PR links accepted issue #3030 with one `wg/mom-routing` owner label
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect the actual scope and results

</details>