### PR TITLE
[Test] Accept PathLike inputs in Podman socket test

### DIFF
--- a/src/vllm-sr/tests/test_openclaw_podman_socket.py
+++ b/src/vllm-sr/tests/test_openclaw_podman_socket.py
@@ -131,11 +131,13 @@ def test_container_start_vllm_sr_warns_when_podman_socket_missing(
     monkeypatch.delenv("VLLM_SR_CONTAINER_SOCKET", raising=False)
     real_exists = os.path.exists
 
-    def fake_exists(path: str) -> bool:
-        if "podman.sock" in path or "docker.sock" in path:
+    def fake_exists(path: str | os.PathLike[str]) -> bool:
+        path_text = os.fspath(path)
+        if "podman.sock" in path_text or "docker.sock" in path_text:
             return False
         return real_exists(path)
 
+    assert fake_exists(config_path)
     monkeypatch.setattr(os.path, "exists", fake_exists)
     _stub_runtime_images(monkeypatch)
     captured = _capture_run_commands(monkeypatch)


### PR DESCRIPTION
Closes #3157

## Purpose

- Accept both string and `os.PathLike` inputs in the Podman socket test double.
- Normalize paths with `os.fspath()` before checking socket names.
- Add a direct `Path` probe so the Python 3.14 regression stays covered.
- Owned by `wg/developer-experience-ecosystem`.

## Test Plan

- `cd src/vllm-sr && ../../.venv-agent/bin/python -m pytest tests/test_openclaw_podman_socket.py -q`
- `make agent-ci-gate ENV=cpu CHANGED_FILES="src/vllm-sr/tests/test_openclaw_podman_socket.py"`
- Build and start the local CPU Docker stack, then run the smoke-equivalent service, container, dashboard, and startup-log checks.

## Test Result

- Focused Python 3.14 test: 3 passed.
- Agent CI gate passed; the CLI suite ran 39 tests with 9 skips and 0 failures.
- CPU Docker images built successfully; Router, Envoy, Dashboard, and Fleet Sim all reported Running, and the equivalent local smoke checks passed.
- The API-only Docker routing integration passed. Model-loading integration cases exceeded the 5-minute startup window while downloading mmBERT ONNX assets; the canonical smoke helper also still matches the previous CLI status wording. Both are unrelated existing harness/environment blockers.
