### PR TITLE
[Feature] Add Metal (Apple Silicon) support to candle-binding

### DIFF
--- a/candle-binding/Cargo.lock
+++ b/candle-binding/Cargo.lock
@@ -282,9 +282,21 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -293,6 +305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -360,6 +381,7 @@ dependencies = [
  "accelerate-src",
  "byteorder",
  "candle-kernels",
+ "candle-metal-kernels",
  "cudarc",
  "float8 0.4.2",
  "gemm",
@@ -369,6 +391,8 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
+ "objc2-foundation",
+ "objc2-metal",
  "rand",
  "rand_distr",
  "rayon",
@@ -376,6 +400,7 @@ dependencies = [
  "thiserror 1.0.69",
  "ug",
  "ug-cuda",
+ "ug-metal",
  "yoke 0.7.5",
  "zip",
 ]
@@ -400,16 +425,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-metal-kernels"
+version = "0.9.2-alpha.1"
+source = "git+https://github.com/huggingface/candle?tag=0.9.2-alpha.1#d312da234440ca64fb64c38ba57588a692f58caf"
+dependencies = [
+ "half",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+ "once_cell",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "candle-nn"
 version = "0.9.2-alpha.1"
 source = "git+https://github.com/huggingface/candle?tag=0.9.2-alpha.1#d312da234440ca64fb64c38ba57588a692f58caf"
 dependencies = [
  "accelerate-src",
  "candle-core",
+ "candle-metal-kernels",
  "half",
  "intel-mkl-src",
  "libc",
  "num-traits",
+ "objc2-metal",
  "rayon",
  "safetensors",
  "serde",
@@ -607,10 +648,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -866,6 +928,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1117,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1804,7 +1903,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -1862,6 +1961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1983,21 @@ checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.10.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -2060,6 +2183,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,14 +2255,12 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5a3fe998d50101ae009351fec56d88a69f4ed182e11000e711068c2f5abf72"
+checksum = "bdf88ddc01cc6bccbe1044adb6a29057333f523deadcb4953c011a73158cfa5e"
 dependencies = [
  "derive_builder",
  "getset",
- "once_cell",
- "regex",
  "serde",
  "serde_json",
  "strum",
@@ -2114,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "onig"
@@ -2124,7 +2307,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2256,7 +2439,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2479,7 +2662,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2525,7 +2708,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2534,7 +2717,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2705,7 +2888,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3055,6 +3238,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,7 +3274,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -3364,7 +3558,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -3460,6 +3654,20 @@ checksum = "9f0a1fa748f26166778c33b8498255ebb7c6bffb472bcc0a72839e07ebb1d9b5"
 dependencies = [
  "cudarc",
  "half",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
+]
+
+[[package]]
+name = "ug-metal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
+dependencies = [
+ "half",
+ "metal",
+ "objc",
  "serde",
  "thiserror 1.0.69",
  "ug",

--- a/candle-binding/Cargo.toml
+++ b/candle-binding/Cargo.toml
@@ -25,6 +25,9 @@ mkl = ["candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl"]
 # macOS Accelerate framework support for faster CPU inference
 # Enable with: cargo build --no-default-features --features accelerate
 accelerate = ["candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
+# Metal GPU support on Apple Silicon
+# Enable with: cargo build --no-default-features --features metal
+metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/candle-binding/README.md
+++ b/candle-binding/README.md
@@ -37,7 +37,10 @@ go test ./...
 On macOS, use `DYLD_LIBRARY_PATH` instead of `LD_LIBRARY_PATH`. Build with
 `--no-default-features --features metal` to run on the Apple Silicon GPU, or
 `--no-default-features --features accelerate` for CPU inference through
-Accelerate.
+Accelerate. Metal inference runs on a fixed thread pool of
+`METAL_MAX_CONCURRENCY` threads (default 8, max 32) because candle's Metal
+backend keeps one command buffer per OS thread and its single command queue
+deadlocks at 64 in-flight buffers.
 
 From the repository root, the maintained test entry points are:
 

--- a/candle-binding/README.md
+++ b/candle-binding/README.md
@@ -19,6 +19,9 @@ cargo build --release
 # CPU build on Linux
 cargo build --release --no-default-features
 
+# Metal GPU build on Apple Silicon
+cargo build --release --no-default-features --features metal
+
 # Rust tests
 cargo test --no-default-features
 ```
@@ -31,8 +34,10 @@ export LD_LIBRARY_PATH="$PWD/target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 go test ./...
 ```
 
-On macOS, use `DYLD_LIBRARY_PATH` instead of `LD_LIBRARY_PATH` and build with
-`--no-default-features --features accelerate` when Accelerate is available.
+On macOS, use `DYLD_LIBRARY_PATH` instead of `LD_LIBRARY_PATH`. Build with
+`--no-default-features --features metal` to run on the Apple Silicon GPU, or
+`--no-default-features --features accelerate` for CPU inference through
+Accelerate.
 
 From the repository root, the maintained test entry points are:
 

--- a/candle-binding/src/core/device.rs
+++ b/candle-binding/src/core/device.rs
@@ -1,0 +1,20 @@
+//! Device resolution shared by every model loader.
+
+use candle_core::Device;
+
+/// Resolve the inference device: CPU when `use_cpu`, otherwise the first
+/// available accelerator (Metal when built with the `metal` feature, CUDA
+/// otherwise), falling back to CPU when none is usable.
+pub fn resolve_device(use_cpu: bool) -> Device {
+    if use_cpu {
+        return Device::Cpu;
+    }
+    #[cfg(feature = "metal")]
+    {
+        Device::new_metal(0).unwrap_or(Device::Cpu)
+    }
+    #[cfg(not(feature = "metal"))]
+    {
+        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
+    }
+}

--- a/candle-binding/src/core/device.rs
+++ b/candle-binding/src/core/device.rs
@@ -18,3 +18,74 @@ pub fn resolve_device(use_cpu: bool) -> Device {
         Device::cuda_if_available(0).unwrap_or(Device::Cpu)
     }
 }
+
+#[cfg(feature = "metal")]
+mod metal_pool {
+    use std::sync::OnceLock;
+
+    /// candle's Metal backend keeps one open command buffer per OS thread on
+    /// the device's single command queue, which caps in-flight buffers at 64.
+    /// Every distinct thread that ever runs a forward permanently occupies one
+    /// slot, so unbounded caller threads (one per CGo call) deadlock the queue
+    /// regardless of how few run concurrently. Confining inference to a fixed
+    /// pool keeps the number of distinct threads, and therefore occupied
+    /// slots, small.
+    const DEFAULT_THREADS: usize = 8;
+    const MAX_THREADS: usize = 32;
+
+    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+
+    pub fn pool() -> &'static rayon::ThreadPool {
+        POOL.get_or_init(|| {
+            let threads = std::env::var("METAL_MAX_CONCURRENCY")
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .filter(|&value| value > 0)
+                .map(|value| value.min(MAX_THREADS))
+                .unwrap_or(DEFAULT_THREADS);
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .thread_name(|index| format!("metal-inference-{index}"))
+                .build()
+                .expect("failed to build Metal inference pool")
+        })
+    }
+}
+
+/// Run `operation` on the bounded Metal inference pool when `device` is
+/// Metal (`METAL_MAX_CONCURRENCY` threads, default 8, max 32); run it inline
+/// on every other device.
+pub fn run_on_inference_pool<R, F>(device: &Device, operation: F) -> R
+where
+    R: Send,
+    F: FnOnce() -> R + Send,
+{
+    #[cfg(feature = "metal")]
+    {
+        if device.is_metal() {
+            return metal_pool::pool().install(operation);
+        }
+        operation()
+    }
+    #[cfg(not(feature = "metal"))]
+    {
+        let _ = device;
+        operation()
+    }
+}
+
+/// Commit and drain any Metal work the calling thread queued during model
+/// loading. candle enqueues the device's first command buffer at creation,
+/// and an enqueued-but-uncommitted buffer blocks every later committed buffer
+/// on the same queue; without this drain, the loader thread's leftover buffer
+/// hangs the first pooled forward forever.
+pub fn drain_loader_queue(device: &Device) {
+    #[cfg(feature = "metal")]
+    if device.is_metal() {
+        let _ = device.synchronize();
+    }
+    #[cfg(not(feature = "metal"))]
+    {
+        let _ = device;
+    }
+}

--- a/candle-binding/src/core/mod.rs
+++ b/candle-binding/src/core/mod.rs
@@ -10,7 +10,7 @@ pub mod unified_error;
 // Re-export main similarity functionality for backward compatibility
 pub use similarity::{normalize_l2, BertSimilarity};
 
-pub use device::resolve_device;
+pub use device::{drain_loader_queue, resolve_device, run_on_inference_pool};
 
 // Re-export unified configuration loader
 pub use config_loader::{

--- a/candle-binding/src/core/mod.rs
+++ b/candle-binding/src/core/mod.rs
@@ -2,12 +2,15 @@
 
 // Core modules
 pub mod config_loader;
+pub mod device;
 pub mod similarity;
 pub mod tokenization;
 pub mod unified_error;
 
 // Re-export main similarity functionality for backward compatibility
 pub use similarity::{normalize_l2, BertSimilarity};
+
+pub use device::resolve_device;
 
 // Re-export unified configuration loader
 pub use config_loader::{

--- a/candle-binding/src/model_architectures/traditional/modernbert.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert.rs
@@ -19,7 +19,10 @@
 /// longer than 512 tokens. This cap matches `max_length` in tokenizer_config.json.
 pub(crate) const MAX_CLASSIFICATION_SEQ_LEN: usize = 512;
 
-use crate::core::{config_errors, processing_errors, resolve_device, ModelErrorType, UnifiedError};
+use crate::core::{
+    config_errors, drain_loader_queue, processing_errors, resolve_device, run_on_inference_pool,
+    ModelErrorType, UnifiedError,
+};
 use crate::model_error;
 use anyhow::{Error as E, Result};
 use candle_core::{DType, Device, IndexOp, Tensor, D};
@@ -807,6 +810,7 @@ impl TraditionalModernBertClassifier {
             })?,
         ) as Box<dyn DualPathTokenizer>;
 
+        drain_loader_queue(&device);
         Ok(Self {
             model,
             head,
@@ -1119,6 +1123,10 @@ impl TraditionalModernBertClassifier {
 
     /// classify_internal classifies text using real model inference - REAL IMPLEMENTATION
     fn classify_internal(&self, text: &str) -> Result<(usize, f32, Vec<f32>), candle_core::Error> {
+        run_on_inference_pool(&self.device, || self.classify_on_device(text))
+    }
+
+    fn classify_on_device(&self, text: &str) -> Result<(usize, f32, Vec<f32>), candle_core::Error> {
         // 1. Tokenize input text
         let tokenization_result = self.tokenizer.tokenize(text).map_err(|e| {
             let unified_err = processing_errors::tensor_operation("tokenization", &e.to_string());
@@ -1446,6 +1454,7 @@ impl TraditionalModernBertTokenClassifier {
         let classifier =
             FixedModernBertTokenClassifier::load_with_classes(vb.clone(), &config, num_classes)?;
 
+        drain_loader_queue(&device);
         Ok(Self {
             model,
             head,
@@ -1491,6 +1500,10 @@ impl TraditionalModernBertTokenClassifier {
 
     /// Classify tokens in text
     pub fn classify_tokens(&self, text: &str) -> Result<Vec<TokenEntityTuple>> {
+        run_on_inference_pool(&self.device, || self.classify_tokens_on_device(text))
+    }
+
+    fn classify_tokens_on_device(&self, text: &str) -> Result<Vec<TokenEntityTuple>> {
         // Tokenize the text
         let tokenization_result = self.tokenizer.tokenize(text)?;
 

--- a/candle-binding/src/model_architectures/traditional/modernbert.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert.rs
@@ -19,7 +19,7 @@
 /// longer than 512 tokens. This cap matches `max_length` in tokenizer_config.json.
 pub(crate) const MAX_CLASSIFICATION_SEQ_LEN: usize = 512;
 
-use crate::core::{config_errors, processing_errors, ModelErrorType, UnifiedError};
+use crate::core::{config_errors, processing_errors, resolve_device, ModelErrorType, UnifiedError};
 use crate::model_error;
 use anyhow::{Error as E, Result};
 use candle_core::{DType, Device, IndexOp, Tensor, D};
@@ -639,11 +639,7 @@ impl TraditionalModernBertClassifier {
         variant: ModernBertVariant,
     ) -> Result<Self, candle_core::Error> {
         // 1. Determine device
-        let device = if use_cpu {
-            Device::Cpu
-        } else {
-            Device::cuda_if_available(0).unwrap_or(Device::Cpu)
-        };
+        let device = resolve_device(use_cpu);
         // 2. Load config.json
         let config_path = format!("{}/config.json", model_path);
         let config_str = std::fs::read_to_string(&config_path).map_err(|_e| {
@@ -1375,11 +1371,7 @@ impl TraditionalModernBertTokenClassifier {
         use_cpu: bool,
         variant: ModernBertVariant,
     ) -> Result<Self> {
-        let device = if use_cpu {
-            Device::Cpu
-        } else {
-            Device::cuda_if_available(0)?
-        };
+        let device = resolve_device(use_cpu);
 
         // Load model configuration
         let config_path = std::path::Path::new(model_id).join("config.json");


### PR DESCRIPTION
Close #3160 

## Purpose

- Add optional Metal support for Candle on Apple Silicon.
- Use Metal for ModernBERT inference when CPU is disabled.
- Keep CPU fallback when the requested accelerator is unavailable.
- Run Metal inference on a fixed thread pool (`METAL_MAX_CONCURRENCY`, default 8, max 32) and drain the loader thread's command buffer, which removes the 64-worker deadlock.

## Benchmark Result

mmBERT-32K jailbreak classifier, 256 requests per point on Apple Silicon:

| Workers | CPU p50 | Metal p50 | CPU p99 | Metal p99 | CPU req/s | Metal req/s | Speedup |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 89ms | 56ms | 111ms | 68ms | 11.2 | 17.9 | 1.60x |
| 8 | 257ms | 125ms | 410ms | 166ms | 30.3 | 62.6 | 2.07x |
| 32 | 1.12s | 486ms | 2.23s | 570ms | 25.8 | 64.0 | 2.48x |
| 64 | 1.16s | 962ms-1.14s | 7.66s | 1.02-1.34s | 28.5 | 54.4-64.9 | 2.19x |
| 128 | 2.09s | 2.04s | 8.25s | 2.24s | 29.0 | 58.5 | 2.02x |

Metal columns are measured with the inference pool in place. 64 workers previously deadlocked candle's Metal backend deterministically (3/3 runs); with the pool it completes 3/3 runs, and 128 workers is also stable.

## Deadlock root cause

candle's Metal backend keeps one open command buffer per OS thread on the device's single command queue, and the queue caps in-flight buffers at 64. Every distinct thread that ever runs a forward permanently occupies one slot, so unbounded CGo caller threads deadlock the queue regardless of how few run concurrently. Concurrency bounds alone do not fix it; confining inference to a fixed thread pool does. The device's first command buffer is also enqueued at creation, so the loader drains its queue before handing the model over, otherwise the first pooled forward blocks forever.

## Test Plan

- Verify the Metal feature builds on Apple Silicon.
- Verify the non-Metal build still compiles.
- Verify the jailbreak classifier loads and runs on Metal.
- Verify 64 concurrent workers no longer deadlock.

## Test Result

- cargo build --release --no-default-features --features metal
- cargo check --no-default-features
- cargo fmt --check
- Pressure run at 1/8/32/64/128 workers: no deadlock, results above (64 workers repeated 3x)
