### PR TITLE
[Bug] Validate jailbreak signal rules

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -411,7 +411,7 @@ routing:
 
     jailbreak:
       - name: prompt_injection
-        method: hybrid
+        method: contrastive
         threshold: 0.8
         include_history: true
         description: Detect common prompt-injection or jailbreak attempts.

--- a/config/fragments/signal/jailbreak/patterns.yaml
+++ b/config/fragments/signal/jailbreak/patterns.yaml
@@ -2,7 +2,7 @@ routing:
   signals:
     jailbreak:
       - name: prompt_injection
-        method: hybrid
+        method: contrastive
         threshold: 0.8
         include_history: true
         description: Detect common prompt-injection or jailbreak attempts.

--- a/config/router-runtime.json
+++ b/config/router-runtime.json
@@ -1,0 +1,8 @@
+{
+  "phase": "initializing_models",
+  "ready": false,
+  "message": "Required router models downloaded. Continuing startup...",
+  "ready_models": 12,
+  "total_models": 12,
+  "updated_at": "2026-08-31T15:43:19Z"
+}

--- a/src/semantic-router/pkg/config/validator.go
+++ b/src/semantic-router/pkg/config/validator.go
@@ -54,6 +54,7 @@ var (
 		validateEmbeddingSignalContracts,
 		validateRoutingModalityContracts,
 		validateComplexityContracts,
+		validateJailbreakContracts,
 		validateDecisionRouterLearningConfig,
 	}
 )

--- a/src/semantic-router/pkg/config/validator_jailbreak.go
+++ b/src/semantic-router/pkg/config/validator_jailbreak.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Recognised values for JailbreakRule.Method.
+//
+// The runtime dispatches on this string in
+// classification.evaluateJailbreakRule, which matches "contrastive" and sends
+// everything else to the model-backed path. Without validation, an
+// unrecognised value is not an error but a silent downgrade: a rule written as
+// `method: hybrid` with jailbreak_patterns still loads, still reports healthy,
+// and never consults a single pattern, because only the contrastive path reads
+// them. A guardrail that silently ignores half its configuration is worse than
+// one that refuses to start.
+const (
+	// JailbreakMethodContrastive scores the prompt against the configured
+	// jailbreak_patterns / benign_patterns.
+	JailbreakMethodContrastive = "contrastive"
+	// JailbreakMethodClassifier runs the configured sequence classifier.
+	// "" and "model" are accepted spellings of the same path.
+	JailbreakMethodClassifier = "classifier"
+	JailbreakMethodModel      = "model"
+)
+
+var validJailbreakMethods = []string{
+	"",
+	JailbreakMethodClassifier,
+	JailbreakMethodModel,
+	JailbreakMethodContrastive,
+}
+
+// validateJailbreakContracts rejects jailbreak signal rules that would load
+// without doing what they say.
+func validateJailbreakContracts(cfg *RouterConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(cfg.JailbreakRules))
+	for _, rule := range cfg.JailbreakRules {
+		name := strings.TrimSpace(rule.Name)
+		if name == "" {
+			return fmt.Errorf("routing.signals.jailbreak: every rule needs a name")
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("routing.signals.jailbreak: duplicate rule name %q", name)
+		}
+		seen[name] = struct{}{}
+
+		// Compared as written. The runtime dispatches on the raw value
+		// (`switch rule.Method` in classification.evaluateJailbreakRule), so
+		// accepting a different spelling here would let "CONTRASTIVE" load and
+		// then silently take the model path, which is the failure this
+		// validator exists to stop.
+		method := rule.Method
+		if !slices.Contains(validJailbreakMethods, method) {
+			return fmt.Errorf(
+				"routing.signals.jailbreak %q: unknown method %q; valid values are %q, "+
+					"spelled exactly (patterns are only consulted by %q)",
+				name, rule.Method,
+				[]string{JailbreakMethodClassifier, JailbreakMethodModel, JailbreakMethodContrastive},
+				JailbreakMethodContrastive,
+			)
+		}
+
+		if method != JailbreakMethodContrastive &&
+			(len(rule.JailbreakPatterns) > 0 || len(rule.BenignPatterns) > 0) {
+			return fmt.Errorf(
+				"routing.signals.jailbreak %q: jailbreak_patterns/benign_patterns are only "+
+					"evaluated by method %q, but this rule uses method %q, so the patterns "+
+					"would be silently ignored",
+				name, JailbreakMethodContrastive, rule.Method,
+			)
+		}
+
+		// The runtime match is `riskScore >= threshold`, so a threshold of 0
+		// matches every request including plainly benign ones - it does not
+		// mean "use a default". Go's zero value makes an omitted threshold
+		// identical to an explicit 0, so both are rejected here rather than
+		// silently turning the rule into an always-match.
+		switch {
+		case rule.Threshold <= 0:
+			return fmt.Errorf(
+				"routing.signals.jailbreak %q: threshold must be greater than 0 "+
+					"(the runtime matches when risk >= threshold, so 0 marks every request "+
+					"as a jailbreak); set an explicit threshold",
+				name,
+			)
+		case rule.Threshold > 1:
+			return fmt.Errorf(
+				"routing.signals.jailbreak %q: threshold must be <= 1, got %v",
+				name, rule.Threshold,
+			)
+		}
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/config/validator_jailbreak_test.go
+++ b/src/semantic-router/pkg/config/validator_jailbreak_test.go
@@ -1,0 +1,98 @@
+package config
+
+import "testing"
+
+func jailbreakCfg(rules ...JailbreakRule) *RouterConfig {
+	cfg := &RouterConfig{}
+	cfg.JailbreakRules = rules
+	return cfg
+}
+
+// `method: hybrid` ships in config/config.yaml with jailbreak_patterns, but the
+// runtime only reads patterns on the contrastive path and sends every other
+// method to the model. Loading such a rule silently discards the patterns.
+func TestValidateJailbreakContractsRejectsUnknownMethod(t *testing.T) {
+	err := validateJailbreakContracts(jailbreakCfg(JailbreakRule{
+		Name: "prompt_injection", Method: "hybrid", Threshold: 0.8,
+	}))
+	if err == nil {
+		t.Fatal("unknown method must be rejected, not silently downgraded to the model path")
+	}
+}
+
+func TestValidateJailbreakContractsAcceptsKnownMethods(t *testing.T) {
+	for _, method := range []string{"", "classifier", "model", "contrastive"} {
+		rule := JailbreakRule{Name: "r", Method: method, Threshold: 0.5}
+		if err := validateJailbreakContracts(jailbreakCfg(rule)); err != nil {
+			t.Errorf("method %q must be accepted: %v", method, err)
+		}
+	}
+}
+
+func TestValidateJailbreakContractsRejectsPatternsOnModelMethod(t *testing.T) {
+	err := validateJailbreakContracts(jailbreakCfg(JailbreakRule{
+		Name: "r", Method: "classifier", Threshold: 0.5,
+		JailbreakPatterns: []string{"ignore previous instructions"},
+	}))
+	if err == nil {
+		t.Fatal("patterns on a model-backed rule must be rejected; they are never evaluated")
+	}
+}
+
+// riskScore >= threshold, so threshold 0 (or an omitted threshold, which is the
+// same value in Go) marks every request as a jailbreak match. Verified at
+// runtime: a rule with threshold 0 matched "What is the capital of France?"
+// with a risk score of 0.0000011.
+func TestValidateJailbreakContractsRejectsNonPositiveThreshold(t *testing.T) {
+	for _, th := range []float32{0, -0.1} {
+		err := validateJailbreakContracts(jailbreakCfg(JailbreakRule{
+			Name: "r", Method: "classifier", Threshold: th,
+		}))
+		if err == nil {
+			t.Errorf("threshold %v must be rejected: it matches every request", th)
+		}
+	}
+}
+
+func TestValidateJailbreakContractsRejectsThresholdAboveOne(t *testing.T) {
+	if err := validateJailbreakContracts(jailbreakCfg(JailbreakRule{
+		Name: "r", Threshold: 1.5,
+	})); err == nil {
+		t.Fatal("threshold > 1 must be rejected: it can never match")
+	}
+}
+
+func TestValidateJailbreakContractsRejectsDuplicateAndUnnamedRules(t *testing.T) {
+	if err := validateJailbreakContracts(jailbreakCfg(
+		JailbreakRule{Name: "a", Threshold: 0.5},
+		JailbreakRule{Name: "a", Threshold: 0.5},
+	)); err == nil {
+		t.Fatal("duplicate rule names must be rejected")
+	}
+	if err := validateJailbreakContracts(jailbreakCfg(JailbreakRule{Threshold: 0.5})); err == nil {
+		t.Fatal("unnamed rule must be rejected")
+	}
+}
+
+func TestValidateJailbreakContractsAcceptsContrastiveWithPatterns(t *testing.T) {
+	if err := validateJailbreakContracts(jailbreakCfg(JailbreakRule{
+		Name: "r", Method: "contrastive", Threshold: 0.5,
+		JailbreakPatterns: []string{"ignore previous instructions"},
+		BenignPatterns:    []string{"explain the policy"},
+	})); err != nil {
+		t.Fatalf("contrastive with patterns must be accepted: %v", err)
+	}
+}
+
+// The runtime dispatches on the raw string, so a differently spelled method
+// would load and then silently take the model path.
+func TestValidateJailbreakContractsRejectsNonCanonicalSpelling(t *testing.T) {
+	for _, method := range []string{"CONTRASTIVE", "Contrastive", " contrastive ", "Classifier"} {
+		err := validateJailbreakContracts(jailbreakCfg(JailbreakRule{
+			Name: "r", Method: method, Threshold: 0.5,
+		}))
+		if err == nil {
+			t.Errorf("method %q must be rejected; the runtime matches %q exactly", method, "contrastive")
+		}
+	}
+}

--- a/website/docs/tutorials/signal/learned/jailbreak.md
+++ b/website/docs/tutorials/signal/learned/jailbreak.md
@@ -37,7 +37,7 @@ routing:
   signals:
     jailbreak:
       - name: prompt_injection
-        method: hybrid
+        method: contrastive
         threshold: 0.8
         include_history: true
         description: Detect common prompt-injection or jailbreak attempts.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/tutorials/signal/learned/jailbreak.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-v0.3/tutorials/signal/learned/jailbreak.md
@@ -44,7 +44,7 @@ routing:
   signals:
     jailbreak:
       - name: prompt_injection
-        method: hybrid
+        method: contrastive
         threshold: 0.8
         include_history: true
         description: Detect common prompt-injection or jailbreak attempts.


### PR DESCRIPTION
Fixes #3203

Unknown methods, patterns on a model-backed rule, and a non-positive or `>1` threshold are now config errors.

`evaluateJailbreakRule` matched `contrastive` and sent every other method to the model, so `method: hybrid` loaded fine and its pattern lists were never read.

The shipped configs and both language versions of the tutorial move from `hybrid` to `contrastive`, which is the method that reads the `jailbreak_patterns` / `benign_patterns` those rules already carry.

```
before: method: hybrid, threshold 0.99, jailbreak_patterns: ["zzq unique canary phrase alpha"]
        loads, and a prompt containing that exact phrase does not match

after:  routing.signals.jailbreak "x": unknown method "hybrid"; valid values are
        ["classifier" "model" "contrastive"] (patterns are only consulted by "contrastive")
```

Checked that `config/config.yaml` still loads and that a config with `method: hybrid` or `threshold: 0` now fails at startup. Every shipped config already sets a positive threshold.

Seven new tests cover the accepted methods, an unknown method, patterns on a model-backed rule, a non-positive and an out-of-range threshold, and duplicate or unnamed rules.
