### PR TITLE
[Community] Make Workgroup issue labels self-maintaining

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -76,6 +76,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 tools/ci/community_lifecycle.py sync-issue --event "$GITHUB_EVENT_PATH"
 
+  issue-kind:
+    name: Enforce issue kind label
+    if: >-
+      github.event_name == 'issues'
+      && github.event.action == 'edited'
+      && github.event.changes.title != null
+      && github.event.changes.body == null
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Synchronize structural issue kind
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 tools/ci/community_lifecycle.py sync-issue-kind --event "$GITHUB_EVENT_PATH"
+
   issue-acceptance:
     name: Accept scoped issue
     if: >-
@@ -113,7 +133,6 @@ jobs:
             /unassign
             /lgtm
             /approve
-            /area
             /priority
             /remove
             /close

--- a/.prowlabels.yaml
+++ b/.prowlabels.yaml
@@ -1,26 +1,7 @@
-area:
-  - core
-  - research
-  - observability
-  - networking
-  - bench
-  - environment
-  - user-experience
-  - docs
-  - test-and-release
-
 priority:
   - P0
   - P1
   - P2
-
-track:
-  - contracts
-  - ops
-  - performance
-  - research-to-product
-  - hardening
-  - security
 
 wg:
   - mom-routing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ tool-mandated entrypoints. The executable allowlist is in
 - Drive the active task to its reported completion boundary: fix failures and rerun the applicable gates until the current change or subtask is done, and do not hand off on the first failing run.
 - Treat docs-only and website-only edits as lightweight unless the task matrix says otherwise.
 - Contributor workflow, issue or PR intake rules, and maintainer label taxonomy live in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/**`, and `.prowlabels.yaml`; commits intended for PRs must use `git commit -s`.
+- GitHub work uses one `wg/*` owner and an `epic` structural label for `[Epic]` issues. Do not recreate the retired `area/*` or `track/*` taxonomies; navigate work through Workgroup and Epic relationships instead.
 - Keep commits reviewable and logically coherent. Each commit must build and lint, describe why the change exists, and avoid unrelated drive-by cleanup.
 - Keep PR blast radius aligned with the requested behavior; couple subsystems only when their contracts change together.
 - Maintainer release, issue, PR, stale-work, and daily-board workflows live in [tools/agent/docs/maintainer-ops.md](tools/agent/docs/maintainer-ops.md) and write local state only under `.agent-harness/maintainer/` unless an explicit reviewed apply step mutates GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ needs-acceptance -> accepted -> ready-for-dev -> in-progress -> closed
 - A release milestone is a time-bound commitment and is applied only after
   acceptance.
 
+Project work has exactly one `wg/*` owner. A bounded parent outcome uses an
+`[Epic]` title and the automatically synchronized `epic` label; implementation
+issues are linked below it as sub-issues. The retired `area/*` and `track/*`
+taxonomies are not part of the repository contract and must not be recreated.
+
 Do not begin a non-trivial implementation or open a PR until the tracking issue
 is accepted. PRs must link an accepted issue with exactly one Workgroup owner;
 the Community check enforces this contract.

--- a/tools/agent/docs/README.md
+++ b/tools/agent/docs/README.md
@@ -23,6 +23,7 @@ Current maintainer rule:
 
 - one active release plan per release
 - one active debt plan for non-release debt
+- one `wg/*` owner per project issue, with `[Epic]` parents marked by `epic`
 - generated issue/PR board under `.agent-harness/maintainer/`
 
 ## Contributor

--- a/tools/agent/docs/governance.md
+++ b/tools/agent/docs/governance.md
@@ -32,6 +32,8 @@ This document defines how the repository's agent rules are layered and maintaine
 - Record long-horizon loop execution in [plans/README.md](plans/README.md) and the plan files it indexes.
 - Record durable operating rules in the relevant governance doc rather than in a
   separate decision-log layer.
+- Organize GitHub work through one `wg/*` owner and an `epic` structural label
+  on `[Epic]` issues. Do not add parallel `area/*` or `track/*` taxonomies.
 - Keep release execution in one plan per release. Keep unrelated architecture
   debt in the single current debt plan.
 - Keep daily issue and PR state out of git under `.agent-harness/maintainer/`.

--- a/tools/agent/docs/maintainer-ops.md
+++ b/tools/agent/docs/maintainer-ops.md
@@ -35,7 +35,12 @@ must not be committed.
 
 ## Maintainer Label View
 
-Maintainers do not need to scan every area label. The daily operating view is:
+The issue tree uses one structural path: one `wg/*` owner, then an `epic`
+parent where the work belongs to a bounded outcome. `[Epic]` titles and the
+`epic` label are synchronized automatically. The retired `area/*` and
+`track/*` taxonomies must not be recreated.
+
+The daily operating view is:
 
 - `needs-acceptance`: decide whether the issue fits the roadmap, which one
   Workgroup owns it, and whether to accept, request information, backlog, or
@@ -83,7 +88,7 @@ Maintainer ops owns two release-management actions that should not appear as
 active release-plan tasks:
 
 - Sync GitHub milestone, issue, PR, label, review, and CI state into the local
-  board and classify the result by release track.
+  board and classify the result by lifecycle and milestone state.
 - Propose missing release seed issues from the active release plan, review the
   dry-run payload, and apply only after explicit maintainer approval.
 

--- a/tools/agent/maintainer-policy.yaml
+++ b/tools/agent/maintainer-policy.yaml
@@ -10,6 +10,8 @@ labels:
   issue_defaults:
     feature: enhancement
     bug: bug
+  structure:
+    epic: epic
   lifecycle:
     needs_acceptance: needs-acceptance
     accepted: accepted
@@ -36,26 +38,6 @@ labels:
     - wg/developer-experience-ecosystem
     - wg/evaluation-quality
   maintainer_owner: owner/maintainers
-
-release_tracks:
-  contracts:
-    label: track/contracts
-    description: API, config, deployment, and control-plane contracts.
-  ops:
-    label: track/ops
-    description: Release channels, upgrades, rollback, and production operations.
-  performance:
-    label: track/performance
-    description: Native/runtime parity and performance validation.
-  research-to-product:
-    label: track/research-to-product
-    description: Research work graduating into supported open-source behavior.
-  hardening:
-    label: track/hardening
-    description: Dashboard, eval, RAG, memory, protocol, and runtime hardening.
-  security:
-    label: track/security
-    description: Security, RBAC, observability, and E2E closure.
 
 staleness:
   issue_stale_days: 90

--- a/tools/agent/scripts/maintainer_board.py
+++ b/tools/agent/scripts/maintainer_board.py
@@ -569,9 +569,6 @@ def create_issue_actions(
             if not item["matches"]
         ]
     labels = [policy["labels"]["lifecycle"]["needs_acceptance"]]
-    track = policy.get("release_tracks", {}).get(args.track or "")
-    if track and track.get("label"):
-        labels.append(track["label"])
     if args.labels:
         labels.extend(args.labels.split(","))
     actions = []
@@ -580,8 +577,6 @@ def create_issue_actions(
         body = (
             "## Scope\n\n"
             f"{task}\n\n"
-            "## Release Track\n\n"
-            f"{args.track or 'unclassified'}\n\n"
             "## Validation\n\n"
             "Use the release plan and affected module gates to define the final test plan.\n"
         )
@@ -721,7 +716,6 @@ def build_parser() -> argparse.ArgumentParser:
     create.add_argument("--release-plan", required=True)
     create.add_argument("--milestone", default=None)
     create.add_argument("--output-dir", default=None)
-    create.add_argument("--track", default=None)
     create.add_argument("--prefix", default="[Release]")
     create.add_argument("--labels", default=None)
     create.add_argument("--include-matched", action="store_true")

--- a/tools/agent/scripts/tests/test_maintainer_board.py
+++ b/tools/agent/scripts/tests/test_maintainer_board.py
@@ -1,0 +1,55 @@
+import argparse
+import importlib
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+maintainer_board = importlib.import_module("maintainer_board")
+
+
+class MaintainerBoardIssueCreationTests(unittest.TestCase):
+    def test_release_issue_creation_has_no_parallel_track_taxonomy(self) -> None:
+        args = argparse.Namespace(
+            release_plan="unused.md",
+            include_matched=True,
+            labels="wg/evaluation-quality",
+            prefix="[Release]",
+            milestone=None,
+        )
+        policy = {
+            "labels": {"lifecycle": {"needs_acceptance": "needs-acceptance"}},
+            "public_artifact_policy": {},
+        }
+        with mock.patch.object(
+            maintainer_board, "open_release_tasks", return_value=["Qualify v1"]
+        ):
+            actions = maintainer_board.create_issue_actions(args, policy)
+
+        self.assertEqual(
+            actions[0]["labels"],
+            ["needs-acceptance", "wg/evaluation-quality"],
+        )
+        self.assertNotIn("Release Track", actions[0]["body"])
+
+    def test_track_argument_is_rejected_instead_of_kept_for_compatibility(self) -> None:
+        parser = maintainer_board.build_parser()
+        with mock.patch("sys.stderr", new=io.StringIO()), self.assertRaises(SystemExit):
+            parser.parse_args(
+                [
+                    "create-issues",
+                    "--release-plan",
+                    "release.md",
+                    "--track",
+                    "ops",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/agent/skills/maintainer/issue-pr-management/SKILL.md
+++ b/tools/agent/skills/maintainer/issue-pr-management/SKILL.md
@@ -57,8 +57,11 @@ description: Manages GitHub issue and pull-request lifecycle including creation,
    - Anyone with repository write permission may comment `/accept` after
      confirming scope and exactly one owning `wg/*` label; the workflow then
      replaces `needs-acceptance` with `accepted`.
-   - Use `.prowlabels.yaml` for command-driven `area/*` and `priority/*`
-     taxonomy; do not treat those labels as lifecycle state.
+   - Use exactly one `wg/*` label for project ownership. `[Epic]` issues carry
+     the automatically synchronized `epic` label; do not recreate the retired
+     `area/*` or `track/*` taxonomies.
+   - Use `.prowlabels.yaml` for command-driven `priority/*` taxonomy; do not
+     treat priority as lifecycle state.
    - Use `ready-for-dev` only for accepted, unassigned work with review
      capacity. `help wanted` and `good first issue` are curated subsets.
    - Do not invent labels outside the repository taxonomy unless the maintainer explicitly asks for a new label.

--- a/tools/ci/community_lifecycle.py
+++ b/tools/ci/community_lifecycle.py
@@ -12,12 +12,14 @@ from community_lifecycle_github import (
     GitHubClient,
     accept_issue_event,
     sync_issue_event,
+    sync_issue_kind_event,
     sync_pull_request_event,
     sync_pull_request_queue,
     validate_pull_request_event,
     validate_title_event,
 )
 from community_lifecycle_policy import (
+    EPIC,
     MAINTAINER_OWNER,
     OWNER_LABELS,
     PR_STATE_LABELS,
@@ -26,12 +28,15 @@ from community_lifecycle_policy import (
     evaluate_issue_acceptance,
     evaluate_pull_request,
     extract_related_issue_numbers,
+    is_epic_title,
     plan_issue,
+    plan_issue_kind,
     proposed_workgroup,
     title_format_error,
 )
 
 __all__ = [
+    "EPIC",
     "MAINTAINER_OWNER",
     "OWNER_LABELS",
     "PR_STATE_LABELS",
@@ -40,7 +45,9 @@ __all__ = [
     "evaluate_issue_acceptance",
     "evaluate_pull_request",
     "extract_related_issue_numbers",
+    "is_epic_title",
     "plan_issue",
+    "plan_issue_kind",
     "proposed_workgroup",
     "title_format_error",
 ]
@@ -56,6 +63,7 @@ def build_parser() -> argparse.ArgumentParser:
         "command",
         choices=(
             "sync-issue",
+            "sync-issue-kind",
             "accept-issue",
             "validate-pr",
             "sync-pr",
@@ -76,6 +84,8 @@ def main() -> int:
     client = GitHubClient()
     if args.command == "sync-issue":
         sync_issue_event(client, event)
+    elif args.command == "sync-issue-kind":
+        sync_issue_kind_event(client, event)
     elif args.command == "accept-issue":
         accept_issue_event(client, event)
     elif args.command == "validate-pr":

--- a/tools/ci/community_lifecycle_github.py
+++ b/tools/ci/community_lifecycle_github.py
@@ -22,6 +22,7 @@ from community_lifecycle_policy import (
     extract_related_issue_numbers,
     label_names,
     plan_issue,
+    plan_issue_kind,
     title_format_error,
 )
 
@@ -147,6 +148,17 @@ def sync_issue_event(client: GitHubClient, event: dict[str, Any]) -> None:
         )
     for code, message in plan.comments:
         comment_once(client, repo, number, code, message)
+
+
+def sync_issue_kind_event(client: GitHubClient, event: dict[str, Any]) -> None:
+    """Synchronize only structural kind metadata for a title-only edit."""
+
+    repo = repository_name(event)
+    number = int(event["issue"]["number"])
+    issue = client.request(f"repos/{repo}/issues/{number}")
+    plan = plan_issue_kind(issue)
+    remove_labels(client, repo, number, plan.remove_labels)
+    add_labels(client, repo, number, plan.add_labels)
 
 
 def accept_issue_event(client: GitHubClient, event: dict[str, Any]) -> None:

--- a/tools/ci/community_lifecycle_policy.py
+++ b/tools/ci/community_lifecycle_policy.py
@@ -16,6 +16,7 @@ RELEASE_BLOCKER = "release-blocker"
 BACKLOG = "backlog"
 CLOSE_CANDIDATE = "close-candidate"
 STALE = "stale"
+EPIC = "epic"
 
 WORKGROUP_LABELS = (
     "wg/mom-routing",
@@ -89,6 +90,13 @@ def title_format_error(title: str | None) -> str | None:
     return None
 
 
+def is_epic_title(title: str | None) -> bool:
+    """Return whether the normalized title declares an Epic work item."""
+
+    match = TITLE_PREFIX_PATTERN.match(title or "")
+    return bool(match and match.group("category").strip().casefold() == "epic")
+
+
 def label_names(item: dict[str, Any]) -> set[str]:
     return {
         label["name"] if isinstance(label, dict) else str(label)
@@ -148,6 +156,19 @@ class IssueAcceptanceEvaluation:
     valid: bool
     error: str | None = None
     owner_label: str | None = None
+
+
+def plan_issue_kind(issue: dict[str, Any]) -> IssuePlan:
+    """Keep the structural Epic label aligned with the issue title."""
+
+    plan = IssuePlan()
+    labels = label_names(issue)
+    if is_epic_title(issue.get("title")):
+        if EPIC not in labels:
+            plan.add_labels.add(EPIC)
+    elif EPIC in labels:
+        plan.remove_labels.add(EPIC)
+    return plan
 
 
 def evaluate_issue_acceptance(
@@ -297,6 +318,9 @@ def plan_issue(
 
     plan = IssuePlan()
     labels = label_names(issue)
+    kind_plan = plan_issue_kind(issue)
+    plan.add_labels.update(kind_plan.add_labels)
+    plan.remove_labels.update(kind_plan.remove_labels)
     assignees = {
         assignee.get("login", "")
         for assignee in issue.get("assignees", [])

--- a/tools/ci/tests/test_community_lifecycle.py
+++ b/tools/ci/tests/test_community_lifecycle.py
@@ -276,6 +276,23 @@ MoM & Routing
         self.assertFalse(evaluation.valid)
         self.assertIn("bracketed category", evaluation.error or "")
 
+    def test_epic_title_adds_the_structural_label(self) -> None:
+        plan = community_lifecycle.plan_issue_kind(
+            {"title": "[Epic] Make routing behavior measurable", "labels": []}
+        )
+        self.assertEqual(plan.add_labels, {"epic"})
+        self.assertEqual(plan.remove_labels, set())
+
+    def test_non_epic_title_removes_the_structural_label(self) -> None:
+        plan = community_lifecycle.plan_issue_kind(
+            {
+                "title": "[Feature] Make routing behavior measurable",
+                "labels": labels("epic"),
+            }
+        )
+        self.assertEqual(plan.add_labels, set())
+        self.assertEqual(plan.remove_labels, {"epic"})
+
     def test_pr_requires_an_accepted_linked_issue(self) -> None:
         pull_request = {"draft": False, "user": {"type": "User"}}
         evaluation = community_lifecycle.evaluate_pull_request(
@@ -479,6 +496,18 @@ MoM & Routing
             set(policy["labels"]["pr_state"].values()),
             set(community_lifecycle.PR_STATE_LABELS),
         )
+        self.assertEqual(policy["labels"]["structure"]["epic"], "epic")
+
+    def test_retired_parallel_taxonomies_are_not_declared(self) -> None:
+        policy = yaml.safe_load(
+            (REPO_ROOT / "tools/agent/maintainer-policy.yaml").read_text()
+        )
+        prow_labels = yaml.safe_load((REPO_ROOT / ".prowlabels.yaml").read_text())
+        self.assertNotIn("release_tracks", policy)
+        self.assertNotIn("area", prow_labels)
+        self.assertNotIn("track", prow_labels)
+        community_workflow = (REPO_ROOT / ".github/workflows/community.yml").read_text()
+        self.assertNotIn("/area", community_workflow)
 
 
 class FakePullRequestApi:

--- a/website/blog/2026-08-24-join-vllm-sr-workgroups.md
+++ b/website/blog/2026-08-24-join-vllm-sr-workgroups.md
@@ -30,7 +30,7 @@ A routed request crosses several responsibilities:
    capacity, and deployment policy.
 3. **Router Models & Inference Runtime** produces the signals used to route.
 4. **MoM & Routing** chooses models and multi-model strategies.
-5. **Agentic & Context** manages context and chooses or composes agents.
+5. **Agentic & Context** manages bounded context, memory, and session continuity.
 6. **Data Plane & Networking** executes the chosen path.
 7. **Evaluation & Quality** measures results and catches regressions.
 
@@ -73,6 +73,7 @@ compressed, or operate a hosted service.
 ### Owned Epics
 
 - [Define portable MoM model pools, routing recipes, evaluation, and model cards](https://github.com/vllm-project/semantic-router/issues/2971)
+- [Make routing decisions, model eligibility, and fallback behavior correct](https://github.com/vllm-project/semantic-router/issues/3202)
 - [Optimize routing recipes through an offline-to-online lifecycle](https://github.com/vllm-project/semantic-router/issues/2238)
 - [Optimize model-pool members against Mixture-of-Models objectives](https://github.com/vllm-project/semantic-router/issues/3041)
 - [Advance bounded multi-model collaboration algorithms](https://github.com/vllm-project/semantic-router/issues/3037)
@@ -110,9 +111,14 @@ the tensor engines and GPU schedulers it integrates with.
 ### Owned Epics
 
 - [Build an extensible inference runtime for Router Models](https://github.com/vllm-project/semantic-router/issues/2782)
-- [Improve current Router Models and develop routing-native model families](https://github.com/vllm-project/semantic-router/issues/2974)
-- [Build a reproducible SLM self-improvement and Router Model fine-tuning pipeline](https://github.com/vllm-project/semantic-router/issues/2975)
-- [Harden multimodal and image-routing signal robustness](https://github.com/vllm-project/semantic-router/issues/2347)
+- [Make multimodal Router Model inference correct and discoverable](https://github.com/vllm-project/semantic-router/issues/2347)
+- [Unify native Router Model adapters and capability discovery](https://github.com/vllm-project/semantic-router/issues/2396)
+- [Unify built-in classifier backend and result contracts](https://github.com/vllm-project/semantic-router/issues/2760)
+- [Add a model-managed cross-encoder reranking runtime](https://github.com/vllm-project/semantic-router/issues/2247)
+- [Qualify the MIGraphX-first ONNX Runtime path](https://github.com/vllm-project/semantic-router/issues/2395)
+- [Measure and improve built-in Router Model quality](https://github.com/vllm-project/semantic-router/issues/3194)
+- [Develop routing-native Router Model families beyond BERT](https://github.com/vllm-project/semantic-router/issues/2974)
+- [Build a reproducible Router Model training and artifact pipeline](https://github.com/vllm-project/semantic-router/issues/2975)
 
 ## [Data Plane & Networking](https://github.com/vllm-project/semantic-router/issues/2967)
 
@@ -146,6 +152,7 @@ MoM recipe.
 
 - [Support standalone and gateway-integrated data plane modes](https://github.com/vllm-project/semantic-router/issues/1138)
 - [Connect semantic routing to inference-aware backend selection](https://github.com/vllm-project/semantic-router/issues/2332)
+- [Make provider capabilities, protocol codecs, and backend dispatch explicit](https://github.com/vllm-project/semantic-router/issues/2358)
 - [Make semantic caching safe, measurable, and lifecycle-aware](https://github.com/vllm-project/semantic-router/issues/3036)
 - [Optimize data-plane performance, streaming, and failure recovery](https://github.com/vllm-project/semantic-router/issues/2992)
 
@@ -200,45 +207,48 @@ rather than publishing private product plans.
 
 ## [Agentic & Context](https://github.com/vllm-project/semantic-router/issues/2987)
 
-> **Mission:** Manage context and safely select, hand off, and compose agent
-> backends for long-running workloads.
+> **Mission:** Optimize bounded context, memory, session continuity, and safe
+> model or workflow switching for long-running workloads.
 
-![A long session is protected and optimized before the Router selects, hands off to, or composes agent backends within explicit limits](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/agentic-context.svg)
+![A long session is protected and optimized while the Router preserves bounded context, memory, and continuity](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/agentic-context.svg)
 
 ### The problem
 
 Long-running work accumulates messages, memory, tool output, cost, and risk.
-Important instructions can be lost, while the best model or agent may change as
-the task evolves. The Router must handle those changes without becoming a
-general-purpose agent framework.
+Important instructions can be lost, and model or workflow changes can break
+tool loops or provider state. The Router needs bounded continuity contracts
+without becoming a general-purpose agent framework.
 
 ### What this Workgroup owns
 
 - Context compression, pruning, memory selection, prompt restructuring, and
   protection of critical instructions.
-- Session budgets, state boundaries, retention, recovery, and graceful
-  degradation.
-- Agent selection, fallback, handoff, and bounded multi-agent composition.
-- Safe model or workflow switching as a session evolves, with measurable task,
-  cost, latency, and safety outcomes.
+- Prompt-visible Router Memory with explicit persistence and lifecycle receipts.
+- Session budgets, state boundaries, retention, tool-loop continuity, recovery,
+  and graceful degradation.
+- Safe model or workflow switching as a session evolves.
+- Typed task, context-portability, capability, and collaboration receipts that
+  external agent runtimes can consume.
 
 ### What it does not own
 
-This Workgroup does not build an unrestricted agent orchestrator, own all MoM
-selection algorithms, transport KV caches between models, automate CLI
-installation, or allow silent lossy transformation and unbounded online
+This Workgroup does not select, invoke, host, or compose agent endpoints inside
+the Router. It does not build an agent endpoint catalog, unrestricted agent
+orchestrator, tool platform, or workflow engine; own general MoM selection;
+transport KV caches; or allow silent lossy transformation and unbounded online
 training.
 
 ### Owned Epics
 
 - [Optimize context for long-session and agentic workloads](https://github.com/vllm-project/semantic-router/issues/2984)
-- [Enable agent-based routing and multi-agent composition](https://github.com/vllm-project/semantic-router/issues/2994)
-- [Develop safe model and workflow switching for long-running agents](https://github.com/vllm-project/semantic-router/issues/2973)
+- [Stabilize prompt-visible Router Memory for production use](https://github.com/vllm-project/semantic-router/issues/2339)
+- [Govern long-session state, continuity, and model switching](https://github.com/vllm-project/semantic-router/issues/2973)
+- [Define agent-aware Router contracts and bounded external collaboration](https://github.com/vllm-project/semantic-router/issues/2994)
 
 ## [Developer Experience & Ecosystem](https://github.com/vllm-project/semantic-router/issues/2970)
 
-> **Mission:** Make vLLM Semantic Router easy to discover, install, configure,
-> extend, and operate.
+> **Mission:** Make vLLM Semantic Router easy to adopt, configure, extend,
+> diagnose, and contribute to.
 
 ![A developer journey connects discovery, installation, configuration, the first routed request, understanding, sharing, and contribution](/img/blog/vllm/2026-08-24-workgroups-invitation/workgroups/developer-experience-ecosystem.svg)
 
@@ -251,12 +261,14 @@ on it without reverse-engineering the repository.
 
 ### What this Workgroup owns
 
-- Installation, configuration, deployment, tuning, diagnosis, and operation
-  through the CLI, Dashboard, and APIs.
+- One supported first-run path through the CLI, configuration, recipes, errors,
+  and troubleshooting.
+- Dashboard configuration and diagnostics built on canonical Router and
+  deployment contracts.
 - An agent-facing skill for deployment, recipe generation, evaluation, tuning,
   and reviewed operations.
-- Documentation, reference recipes, tutorials, model cards, blogs, videos, and
-  use-case sharing.
+- Documentation, localization, integration guides, Router Model development
+  guides, technical content, and contributor entry points.
 - Clear extension and contribution paths for models, runtimes, gateways, and
   deployment systems.
 
@@ -269,9 +281,11 @@ policy, and quality standards owned by other Workgroups.
 ### Owned Epics
 
 - [Build agent-assisted vLLM-SR deployment, recipe, evaluation, and tuning workflows](https://github.com/vllm-project/semantic-router/issues/2977)
-- [Make Dashboard APIs and editing workflows contract-driven](https://github.com/vllm-project/semantic-router/issues/3167)
 - [Reduce time to the first successful routed request](https://github.com/vllm-project/semantic-router/issues/2690)
-- [Publish maintained reference recipes and end-to-end tutorials](https://github.com/vllm-project/semantic-router/issues/2334)
+- [Make Dashboard configuration and diagnostics use canonical Router contracts](https://github.com/vllm-project/semantic-router/issues/3167)
+- [Restore and maintain current zh-Hans documentation](https://github.com/vllm-project/semantic-router/issues/3074)
+- [Publish verified ecosystem integration and Router Model development guides](https://github.com/vllm-project/semantic-router/issues/3223)
+- [Remove stale parallel surfaces and contributor dead ends](https://github.com/vllm-project/semantic-router/issues/3224)
 
 ## [Evaluation & Quality](https://github.com/vllm-project/semantic-router/issues/2969)
 
@@ -309,8 +323,9 @@ model research itself. It defines shared measurement and gates.
 
 - [Build reproducible decision-level routing evaluation](https://github.com/vllm-project/semantic-router/issues/2333)
 - [Evaluate each Mixture-of-Models as a first-class model](https://github.com/vllm-project/semantic-router/issues/3038)
-- [Establish cross-platform performance regression coverage](https://github.com/vllm-project/semantic-router/issues/1510)
+- [Establish cross-platform performance benchmark coverage and reporting](https://github.com/vllm-project/semantic-router/issues/1510)
 - [Expand end-to-end quality coverage across Router, Dashboard, and deployments](https://github.com/vllm-project/semantic-router/issues/1519)
+- [Build efficient, reliable, and explainable CI gates](https://github.com/vllm-project/semantic-router/issues/3177)
 
 ## How Workgroups Operate
 

--- a/website/blog/2026-08-24-join-vllm-sr-workgroups.md
+++ b/website/blog/2026-08-24-join-vllm-sr-workgroups.md
@@ -35,8 +35,9 @@ A routed request crosses several responsibilities:
 7. **Evaluation & Quality** measures results and catches regressions.
 
 They form one system, separated by responsibility rather than isolated code
-ownership. Every Epic below has one owning Workgroup. Dependencies on other
-groups are recorded as shared interfaces in the linked charter.
+ownership. Every Epic in the live views below has one owning Workgroup.
+Dependencies on other groups are recorded as shared interfaces in the linked
+charter.
 
 Choose the direction that matches the problem you want to solve. GitHub labels
 on each linked Epic are the source of truth for acceptance and delivery status.
@@ -72,14 +73,7 @@ compressed, or operate a hosted service.
 
 ### Owned Epics
 
-- [Define portable MoM model pools, routing recipes, evaluation, and model cards](https://github.com/vllm-project/semantic-router/issues/2971)
-- [Make routing decisions, model eligibility, and fallback behavior correct](https://github.com/vllm-project/semantic-router/issues/3202)
-- [Optimize routing recipes through an offline-to-online lifecycle](https://github.com/vllm-project/semantic-router/issues/2238)
-- [Optimize model-pool members against Mixture-of-Models objectives](https://github.com/vllm-project/semantic-router/issues/3041)
-- [Advance bounded multi-model collaboration algorithms](https://github.com/vllm-project/semantic-router/issues/3037)
-- [Enable safe cross-model KV-cache reuse](https://github.com/vllm-project/semantic-router/issues/2976)
-- [Enable vLLM-Omni backends and modality-aware MoM pools](https://github.com/vllm-project/semantic-router/issues/3030)
-- [Reuse validated reasoning experiences for small-model inference](https://github.com/vllm-project/semantic-router/issues/3031)
+[View all current MoM & Routing Epics](https://github.com/vllm-project/semantic-router/issues?q=is%3Aissue+is%3Aopen+label%3Aepic+label%3Awg%2Fmom-routing)
 
 ## [Router Models & Inference Runtime](https://github.com/vllm-project/semantic-router/issues/2966)
 
@@ -110,15 +104,7 @@ the tensor engines and GPU schedulers it integrates with.
 
 ### Owned Epics
 
-- [Build an extensible inference runtime for Router Models](https://github.com/vllm-project/semantic-router/issues/2782)
-- [Make multimodal Router Model inference correct and discoverable](https://github.com/vllm-project/semantic-router/issues/2347)
-- [Unify native Router Model adapters and capability discovery](https://github.com/vllm-project/semantic-router/issues/2396)
-- [Unify built-in classifier backend and result contracts](https://github.com/vllm-project/semantic-router/issues/2760)
-- [Add a model-managed cross-encoder reranking runtime](https://github.com/vllm-project/semantic-router/issues/2247)
-- [Qualify the MIGraphX-first ONNX Runtime path](https://github.com/vllm-project/semantic-router/issues/2395)
-- [Measure and improve built-in Router Model quality](https://github.com/vllm-project/semantic-router/issues/3194)
-- [Develop routing-native Router Model families beyond BERT](https://github.com/vllm-project/semantic-router/issues/2974)
-- [Build a reproducible Router Model training and artifact pipeline](https://github.com/vllm-project/semantic-router/issues/2975)
+[View all current Router Models & Inference Runtime Epics](https://github.com/vllm-project/semantic-router/issues?q=is%3Aissue+is%3Aopen+label%3Aepic+label%3Awg%2Frouter-models-inference-runtime)
 
 ## [Data Plane & Networking](https://github.com/vllm-project/semantic-router/issues/2967)
 
@@ -150,11 +136,7 @@ MoM recipe.
 
 ### Owned Epics
 
-- [Support standalone and gateway-integrated data plane modes](https://github.com/vllm-project/semantic-router/issues/1138)
-- [Connect semantic routing to inference-aware backend selection](https://github.com/vllm-project/semantic-router/issues/2332)
-- [Make provider capabilities, protocol codecs, and backend dispatch explicit](https://github.com/vllm-project/semantic-router/issues/2358)
-- [Make semantic caching safe, measurable, and lifecycle-aware](https://github.com/vllm-project/semantic-router/issues/3036)
-- [Optimize data-plane performance, streaming, and failure recovery](https://github.com/vllm-project/semantic-router/issues/2992)
+[View all current Data Plane & Networking Epics](https://github.com/vllm-project/semantic-router/issues?q=is%3Aissue+is%3Aopen+label%3Aepic+label%3Awg%2Fdata-plane-networking)
 
 ## [Enterprise & Environment](https://github.com/vllm-project/semantic-router/issues/2968)
 
@@ -199,11 +181,7 @@ rather than publishing private product plans.
 
 ### Owned Epics
 
-- [Secure management, identity, and audit boundaries](https://github.com/vllm-project/semantic-router/issues/3166)
-- [Build versioned configuration activation and rollback](https://github.com/vllm-project/semantic-router/issues/2326)
-- [Define deployment architecture and reference stacks across environments and hardware](https://github.com/vllm-project/semantic-router/issues/3043)
-- [Establish production observability and supported-environment qualification](https://github.com/vllm-project/semantic-router/issues/2993)
-- [Build workload-driven capacity planning for inference fleets](https://github.com/vllm-project/semantic-router/issues/3091)
+[View all current Enterprise & Environment Epics](https://github.com/vllm-project/semantic-router/issues?q=is%3Aissue+is%3Aopen+label%3Aepic+label%3Awg%2Fenterprise-environment)
 
 ## [Agentic & Context](https://github.com/vllm-project/semantic-router/issues/2987)
 
@@ -240,10 +218,7 @@ training.
 
 ### Owned Epics
 
-- [Optimize context for long-session and agentic workloads](https://github.com/vllm-project/semantic-router/issues/2984)
-- [Stabilize prompt-visible Router Memory for production use](https://github.com/vllm-project/semantic-router/issues/2339)
-- [Govern long-session state, continuity, and model switching](https://github.com/vllm-project/semantic-router/issues/2973)
-- [Define agent-aware Router contracts and bounded external collaboration](https://github.com/vllm-project/semantic-router/issues/2994)
+[View all current Agentic & Context Epics](https://github.com/vllm-project/semantic-router/issues?q=is%3Aissue+is%3Aopen+label%3Aepic+label%3Awg%2Fagentic-context)
 
 ## [Developer Experience & Ecosystem](https://github.com/vllm-project/semantic-router/issues/2970)
 
@@ -280,12 +255,7 @@ policy, and quality standards owned by other Workgroups.
 
 ### Owned Epics
 
-- [Build agent-assisted vLLM-SR deployment, recipe, evaluation, and tuning workflows](https://github.com/vllm-project/semantic-router/issues/2977)
-- [Reduce time to the first successful routed request](https://github.com/vllm-project/semantic-router/issues/2690)
-- [Make Dashboard configuration and diagnostics use canonical Router contracts](https://github.com/vllm-project/semantic-router/issues/3167)
-- [Restore and maintain current zh-Hans documentation](https://github.com/vllm-project/semantic-router/issues/3074)
-- [Publish verified ecosystem integration and Router Model development guides](https://github.com/vllm-project/semantic-router/issues/3223)
-- [Remove stale parallel surfaces and contributor dead ends](https://github.com/vllm-project/semantic-router/issues/3224)
+[View all current Developer Experience & Ecosystem Epics](https://github.com/vllm-project/semantic-router/issues?q=is%3Aissue+is%3Aopen+label%3Aepic+label%3Awg%2Fdeveloper-experience-ecosystem)
 
 ## [Evaluation & Quality](https://github.com/vllm-project/semantic-router/issues/2969)
 
@@ -321,11 +291,7 @@ model research itself. It defines shared measurement and gates.
 
 ### Owned Epics
 
-- [Build reproducible decision-level routing evaluation](https://github.com/vllm-project/semantic-router/issues/2333)
-- [Evaluate each Mixture-of-Models as a first-class model](https://github.com/vllm-project/semantic-router/issues/3038)
-- [Establish cross-platform performance benchmark coverage and reporting](https://github.com/vllm-project/semantic-router/issues/1510)
-- [Expand end-to-end quality coverage across Router, Dashboard, and deployments](https://github.com/vllm-project/semantic-router/issues/1519)
-- [Build efficient, reliable, and explainable CI gates](https://github.com/vllm-project/semantic-router/issues/3177)
+[View all current Evaluation & Quality Epics](https://github.com/vllm-project/semantic-router/issues?q=is%3Aissue+is%3Aopen+label%3Aepic+label%3Awg%2Fevaluation-quality)
 
 ## How Workgroups Operate
 

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -211,11 +211,11 @@ export const workGroups: WorkGroup[] = [
     name: 'Agentic & Context',
     label: 'wg/agentic-context',
     charterIssue: 2987,
-    goal: 'Manage context and safely select, hand off, and compose agent backends for long-running workloads.',
+    goal: 'Optimize bounded context, memory, and session continuity for long-running and agentic workloads.',
     scope: [
-      'Context optimization, memory, and session state',
-      'Agent backend selection, handoff, and composition',
-      'Bounded multi-agent collaboration and long-session model or workflow switching',
+      'Context optimization, prompt-visible memory, and session state',
+      'Session budgets, tool-loop continuity, and safe model or workflow switching',
+      'Typed agent-aware boundaries and bounded collaboration receipts for external runtimes',
     ],
     leads: [
       {
@@ -247,11 +247,11 @@ export const workGroups: WorkGroup[] = [
     name: 'Developer Experience & Ecosystem',
     label: 'wg/developer-experience-ecosystem',
     charterIssue: 2970,
-    goal: 'Make vLLM Semantic Router easy to adopt, configure, extend, deploy, tune, and operate.',
+    goal: 'Make vLLM Semantic Router easy to adopt, configure, extend, diagnose, and contribute to.',
     scope: [
-      'CLI, Dashboard, APIs, configuration, recipes, and errors',
-      'Agent skill and ecosystem integrations for deployment, tuning, and operations',
-      'Documentation, blogs, video tutorials, and use-case sharing',
+      'First-run CLI, configuration, recipes, errors, and troubleshooting',
+      'Dashboard workflows built on canonical Router and deployment contracts',
+      'Reviewed agent-assisted workflows, documentation, localization, and ecosystem guides',
     ],
     leads: [
       {
@@ -293,11 +293,11 @@ export const workGroups: WorkGroup[] = [
     name: 'Evaluation & Quality',
     label: 'wg/evaluation-quality',
     charterIssue: 2969,
-    goal: 'Provide common evaluation and quality gates across every project direction.',
+    goal: 'Make every supported capability measurable and every change verifiable.',
     scope: [
-      'MoM, Router Model, agent, context, and workflow evaluation',
-      'Model cards, benchmarks, and reproducibility',
-      'CI, E2E, compatibility, and regression gates',
+      'Decision-level routing and first-class MoM evaluation',
+      'Performance coverage, reports, baselines, and hardware qualification',
+      'CI, behavioral E2E, compatibility, security, and regression gates',
     ],
     leads: [
       {

--- a/website/src/pages/community/contributing.tsx
+++ b/website/src/pages/community/contributing.tsx
@@ -3,6 +3,7 @@ import Layout from '@theme/Layout'
 import Translate from '@docusaurus/Translate'
 import Link from '@docusaurus/Link'
 import CommunityLayout from '@site/src/components/community/CommunityLayout'
+import { workGroups } from '@site/src/data/workGroups'
 import styles from './community-page.module.css'
 
 const Contributing: React.FC = () => {
@@ -316,23 +317,20 @@ pre-commit install && pre-commit run --all-files`}
 
           <section className={styles.section}>
             <h2>
-              <Translate id="contributing.workGroups.title">Working Group Areas</Translate>
+              <Translate id="contributing.workGroups.title">Workgroup ownership</Translate>
             </h2>
             <p>
               <Translate id="contributing.workGroups.desc.prefix">Consider joining one of our</Translate>
               {' '}
               <Link to="/community/work-groups"><Translate id="contributing.workGroups.link">Working Groups</Translate></Link>
               {' '}
-              <Translate id="contributing.workGroups.desc.suffix">to focus your contributions:</Translate>
+              <Translate id="contributing.workGroups.desc.suffix">to find the owning direction and its current Epics:</Translate>
             </p>
             <div className={styles.tagGrid}>
-              <span className={styles.tag}>area/docs</span>
-              <span className={styles.tag}>area/environment</span>
-              <span className={styles.tag}>area/core</span>
-              <span className={styles.tag}>area/networking</span>
-              <span className={styles.tag}>area/bench</span>
-              <span className={styles.tag}>area/test-and-release</span>
-              <span className={styles.tag}>area/user-experience</span>
+              {workGroups.map(group => (
+                <span key={group.label} className={styles.tag}>{group.label}</span>
+              ))}
+              <span className={styles.tag}>epic</span>
             </div>
           </section>
 

--- a/website/src/pages/community/work-groups.module.css
+++ b/website/src/pages/community/work-groups.module.css
@@ -193,6 +193,12 @@
   white-space: nowrap;
 }
 
+.groupLinks {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: end;
+}
+
 .person {
   display: inline-flex;
   gap: 0.4rem;
@@ -302,6 +308,10 @@
 
   .groupFooter {
     grid-template-columns: 1fr;
+  }
+
+  .groupLinks {
+    justify-items: start;
   }
 
   .rules {

--- a/website/src/pages/community/work-groups.tsx
+++ b/website/src/pages/community/work-groups.tsx
@@ -124,6 +124,7 @@ function WorkGroupRow({
   index: number
 }): ReactNode {
   const charterUrl = `${GITHUB_BASE}/issues/${group.charterIssue}`
+  const epicsUrl = `${GITHUB_BASE}/issues?q=${encodeURIComponent(`is:issue is:open label:epic label:${group.label}`)}`
 
   return (
     <article className={styles.workGroup} id={group.id}>
@@ -171,9 +172,14 @@ function WorkGroupRow({
               emptyId="workGroups.roster.forming"
             />
           </div>
-          <a className={styles.charterLink} href={charterUrl}>
-            <Translate id="workGroups.group.charterLink">Charter & self-nomination →</Translate>
-          </a>
+          <div className={styles.groupLinks}>
+            <a className={styles.charterLink} href={epicsUrl}>
+              <Translate id="workGroups.group.epicsLink">Current Epics →</Translate>
+            </a>
+            <a className={styles.charterLink} href={charterUrl}>
+              <Translate id="workGroups.group.charterLink">Charter & self-nomination →</Translate>
+            </a>
+          </div>
         </footer>
       </div>
     </article>


### PR DESCRIPTION
## Purpose

Make the Workgroup issue tree the single navigation and ownership model for project work: `wg/*` → `epic` → linked implementation issues.

This retires the parallel `area/*` and `track/*` taxonomies, prevents their reintroduction, and removes manually duplicated Epic lists that drift from GitHub state.

Related #2287

## Changes

- remove `area/*` and `track/*` declarations, commands, release-track policy, and compatibility paths;
- automatically add `epic` to `[Epic]` issues and remove it when an issue is no longer an Epic, including title-only edits;
- replace static Epic inventories in Workgroup charters, the roadmap, invitation article, and Workgroups page with live `epic` + `wg/*` queries;
- align `AGENTS.md`, contributor guidance, maintainer policy, agent skills, and maintainer docs with the Workgroup/Epic contract;
- update the public Workgroup descriptions to the current reviewed scopes.

The live repository migration is also complete: all 15 legacy `area/*` and `track/*` labels were deleted, all 46 current and historical `[Epic]` issues were labeled, and the seven Workgroup charter issues plus roadmap #2287 now use live Epic views.

## Validation

- `python3 -m unittest tools.ci.tests.test_community_lifecycle tools.agent.scripts.tests.test_maintainer_board`
- `make agent-validate`
- `make agent-ci-gate CHANGED_FILES="<changed files>"`
- `make agent-docs-ci-gate AGENT_BASE_REF=upstream/main`
- commit-time pre-commit hooks

All applicable local governance, documentation, website, formatting, security, and agent-contract checks passed.
