### PR TITLE
[Bug] Finalize replay as failed on fail_request 503

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_decision_unresolved_replay_test.go
+++ b/src/semantic-router/pkg/extproc/processor_decision_unresolved_replay_test.go
@@ -1,0 +1,80 @@
+package extproc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/decision"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
+)
+
+func TestRespondDecisionUnresolvedFinalizesReplayAsFailed(t *testing.T) {
+	recorder := routerreplay.NewRecorder(store.NewMemoryStore(10, 0))
+	router := &OpenAIRouter{ReplayRecorder: recorder}
+
+	replayConfig := config.DefaultRouterReplayPluginConfig()
+	replayConfig.Enabled = true
+	replayConfig.CaptureResponseBody = true
+	ctx := &RequestContext{
+		RequestID:                 "unresolved-request",
+		SourceFormat:              llmprotocol.OpenAIChatV1,
+		SemanticRequest:           testNeutralRequest("entrypoint-model", "hello"),
+		RouterReplayPluginConfig:  &replayConfig,
+		VSRAppliedUnknownPolicies: map[string]string{"guarded": "fail_request"},
+	}
+
+	decisionErr := fmt.Errorf(
+		"decision evaluation failed: %w",
+		decision.ErrDecisionUnresolved,
+	)
+	resp := router.respondDecisionUnresolved(ctx, "entrypoint-model", decisionErr)
+
+	if ctx.RouterReplayID == "" {
+		t.Fatal("expected the 503 path to create a replay record")
+	}
+	record, found := recorder.GetRecord(ctx.RouterReplayID)
+	if !found {
+		t.Fatalf("replay record %q not found", ctx.RouterReplayID)
+	}
+	if record.LifecycleState != routerreplay.LifecycleFailed {
+		t.Fatalf("lifecycle state = %q, want %q", record.LifecycleState, routerreplay.LifecycleFailed)
+	}
+	if record.RouteDiagnostics == nil ||
+		record.RouteDiagnostics.AppliedUnknownPolicies["guarded"] != "fail_request" {
+		t.Fatalf("route diagnostics = %+v, want applied unknown policy guarded=fail_request", record.RouteDiagnostics)
+	}
+
+	immediate := resp.GetImmediateResponse()
+	if immediate == nil {
+		t.Fatal("expected an immediate 503 response")
+	}
+	var replayHeader string
+	for _, option := range immediate.GetHeaders().GetSetHeaders() {
+		if option.GetHeader().GetKey() == headers.RouterReplayID {
+			replayHeader = string(option.GetHeader().GetRawValue())
+		}
+	}
+	if replayHeader != ctx.RouterReplayID {
+		t.Fatalf("replay header = %q, want %q", replayHeader, ctx.RouterReplayID)
+	}
+}
+
+func TestRespondDecisionUnresolvedKeepsErrorResponseShape(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{RequestID: "no-replay"}
+
+	resp := router.respondDecisionUnresolved(ctx, "model", decision.ErrDecisionUnresolved)
+
+	immediate := resp.GetImmediateResponse()
+	if immediate == nil {
+		t.Fatal("expected an immediate response")
+	}
+	body := string(immediate.GetBody())
+	if body == "" || ctx.RouterReplayID != "" {
+		t.Fatalf("body = %q, replay id = %q; want body without a replay record", body, ctx.RouterReplayID)
+	}
+}

--- a/src/semantic-router/pkg/extproc/processor_decision_unresolved_replay_test.go
+++ b/src/semantic-router/pkg/extproc/processor_decision_unresolved_replay_test.go
@@ -43,6 +43,9 @@ func TestRespondDecisionUnresolvedFinalizesReplayAsFailed(t *testing.T) {
 	if record.LifecycleState != routerreplay.LifecycleFailed {
 		t.Fatalf("lifecycle state = %q, want %q", record.LifecycleState, routerreplay.LifecycleFailed)
 	}
+	if record.TerminalReason != "decision_unresolved" {
+		t.Fatalf("terminal reason = %q, want %q", record.TerminalReason, "decision_unresolved")
+	}
 	if record.RouteDiagnostics == nil ||
 		record.RouteDiagnostics.AppliedUnknownPolicies["guarded"] != "fail_request" {
 		t.Fatalf("route diagnostics = %+v, want applied unknown policy guarded=fail_request", record.RouteDiagnostics)

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
 )
 
 func (r *OpenAIRouter) extractRequestSignalSnapshot(
@@ -59,14 +60,7 @@ func (r *OpenAIRouter) runRequestPreRoutingStages(
 		}
 		logging.Errorf("[Request Body] Decision evaluation failed: %v", decisionErr)
 		if errors.Is(decisionErr, decision.ErrDecisionUnresolved) {
-			resp := r.createErrorResponse(503, decisionErr.Error())
-			if ctx.RouterReplayPluginConfig == nil {
-				ctx.RouterReplayPluginConfig = r.Config.EffectiveRouterReplayConfig(nil)
-			}
-			r.startRouterReplay(ctx, originalModel, "", "")
-			r.updateRouterReplayStatus(ctx, 503, false)
-			addRouterReplayHeaderToImmediateResponse(resp, ctx.RouterReplayID)
-			return requestDecisionState{}, resp
+			return requestDecisionState{}, r.respondDecisionUnresolved(ctx, originalModel, decisionErr)
 		}
 		return requestDecisionState{}, r.createErrorResponse(403, decisionErr.Error())
 	}
@@ -106,6 +100,27 @@ func (r *OpenAIRouter) runRequestPreRoutingStages(
 		reasoningDecision: reasoningDecision,
 		selectedModel:     selectedModel,
 	}, nil
+}
+
+// respondDecisionUnresolved builds the fail_request 503 and finalizes the
+// replay record as failed, matching the looper-failure path.
+func (r *OpenAIRouter) respondDecisionUnresolved(
+	ctx *RequestContext,
+	originalModel string,
+	decisionErr error,
+) *ext_proc.ProcessingResponse {
+	resp := r.createErrorResponse(503, decisionErr.Error())
+	if ctx.RouterReplayPluginConfig == nil {
+		ctx.RouterReplayPluginConfig = r.Config.EffectiveRouterReplayConfig(nil)
+	}
+	r.startRouterReplay(ctx, originalModel, "", "")
+	r.updateRouterReplayStatus(ctx, 503, false)
+	if immediate := resp.GetImmediateResponse(); immediate != nil {
+		r.attachRouterReplayResponse(ctx, immediate.Body, false)
+	}
+	r.finalizeRouterReplay(ctx, routerreplay.LifecycleFailed, "decision_unresolved")
+	addRouterReplayHeaderToImmediateResponse(resp, ctx.RouterReplayID)
+	return resp
 }
 
 func applyRequestContextEstimate(snapshot *requestSignalSnapshot, ctx *RequestContext) {

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -118,6 +118,8 @@ func (r *OpenAIRouter) respondDecisionUnresolved(
 	if immediate := resp.GetImmediateResponse(); immediate != nil {
 		r.attachRouterReplayResponse(ctx, immediate.Body, false)
 	}
+	// Failed, not aborted: the router itself rejected the request with a
+	// terminal 503; aborted is reserved for streams that end early.
 	r.finalizeRouterReplay(ctx, routerreplay.LifecycleFailed, "decision_unresolved")
 	addRouterReplayHeaderToImmediateResponse(resp, ctx.RouterReplayID)
 	return resp


### PR DESCRIPTION
Closes #3212

## Purpose

- Finalize the replay record as `failed` on the `fail_request` 503 path, matching the looper-failure path; it previously settled as `aborted / stream_ended_before_terminal_response`.
- Attach the 503 response body to the record and extract the path into `respondDecisionUnresolved`.
- Add extproc tests pinning the record state, the replay header, and `VSRAppliedUnknownPolicies`.

## Test Plan

- Verify the 503 path creates a replay record finalized as `failed` with the applied unknown policies and the replay header.
- Verify the 503 response shape is unchanged when replay is disabled.

## Test Result

- `go test ./pkg/extproc/`
- `gofmt`, `golangci-lint` clean on touched files