### PR TITLE
[Docs] Add Chinese documentation entrypoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 <p><strong>Make Your Mixture-of-Models Programmable.</strong></p>
 
 <p>
+  <b>English</b> · <a href="https://vllm-sr.ai/zh-Hans/">简体中文文档</a>
+</p>
+
+<p>
   <a href="https://vllm-sr.ai">Documentation</a> |
   <a href="https://app.vllm-sr.ai/playground">Playground</a> |
   <a href="https://vllm-sr.ai/blog/">Blog</a> |


### PR DESCRIPTION
Closes #3358
Related #3074

## Purpose

Add Chinese documentation entrypoint in repository `README.md` pointing to the official `zh-Hans` website documentation (`https://vllm-sr.ai/zh-Hans/`), fulfilling bounded child issue #3358 under parent Epic #3074.

## Test Plan

- Verified link to `https://vllm-sr.ai/zh-Hans/` renders correctly in `README.md`.
- Ensured no non-allowlisted root files exist (`README.zh.md` removed per root allowlist policy).
- Rebased branch cleanly onto latest `upstream/main`.

## Test Result

- Root placement validation satisfied (zero new root files).
- CI docs gate passes.
- Links correctly to the maintained Docusaurus locale (`https://vllm-sr.ai/zh-Hans/`).