### PR TITLE
[CI/Build] Isolate Community Label Sync concurrency

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -12,10 +12,6 @@ on:
     - cron: "17 * * * *"
   workflow_dispatch:
 
-concurrency:
-  group: community-label-sync
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
@@ -29,6 +25,11 @@ jobs:
       && github.event.workflow_run.pull_requests[0] != null)
       || (github.event_name == 'check_suite'
       && github.event.check_suite.pull_requests[0] != null)
+    # Serialize duplicate lifecycle events for one PR without blocking other PRs
+    # or the scheduled queue reconciliation job.
+    concurrency:
+      group: community-label-sync-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.check_suite.pull_requests[0].number || github.run_id }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,6 +52,9 @@ jobs:
     if: >-
       github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: community-label-sync-sweep
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tools/ci/tests/test_workflow_permissions.py
+++ b/tools/ci/tests/test_workflow_permissions.py
@@ -4,6 +4,8 @@ import sys
 import unittest
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "tools" / "ci"))
 
@@ -85,6 +87,33 @@ class ReusableWorkflowPermissionTests(unittest.TestCase):
         )
 
         self.assertEqual(errors, [])
+
+
+class CommunityLabelSyncConcurrencyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        path = REPO_ROOT / ".github" / "workflows" / "community-labels.yml"
+        self.data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    def test_pr_events_and_scheduled_sweep_use_independent_job_concurrency(
+        self,
+    ) -> None:
+        self.assertNotIn("concurrency", self.data)
+        jobs = self.data["jobs"]
+        pr_concurrency = jobs["pull-request-state"]["concurrency"]
+        sweep_concurrency = jobs["pull-request-sweep"]["concurrency"]
+
+        self.assertIn(
+            "github.event.workflow_run.pull_requests[0].number",
+            pr_concurrency["group"],
+        )
+        self.assertIn(
+            "github.event.check_suite.pull_requests[0].number",
+            pr_concurrency["group"],
+        )
+        self.assertEqual(sweep_concurrency["group"], "community-label-sync-sweep")
+        self.assertNotEqual(pr_concurrency["group"], sweep_concurrency["group"])
+        self.assertFalse(pr_concurrency["cancel-in-progress"])
+        self.assertFalse(sweep_concurrency["cancel-in-progress"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3258

## Purpose

Move Community Label Sync concurrency from one workflow-wide lane to two workload-specific job lanes. Duplicate lifecycle events serialize per pull request, while the scheduled/manual full-queue sweep runs independently. A workflow contract test prevents the shared top-level group from returning.

Owned by `wg/evaluation-quality`.

## Test Plan

- `python3 -m unittest tools.ci.tests.test_workflow_permissions -v`
- `python3 tools/ci/validate_workflows.py`
- `make agent-lint`
- `make agent-ci-gate CHANGED_FILES=".github/workflows/community-labels.yml tools/ci/tests/test_workflow_permissions.py"`

## Test Result

- 3 workflow-permission/concurrency tests passed.
- All 35 workflow contracts passed.
- Repository lint passed.
- The final agent gate reaches `make agent-validate` and is blocked by a pre-existing `main` regression from #3229: `tools/agent/test-domain-registry.yaml` still requires `src/vllm-sr/**/*memory*` after the last matching file was deleted. No unrelated workaround is included here.
- Draft until the queued `/accept` workflow for #3258 applies the `accepted` transition.