### PR TITLE
[Bug] Use an effective complexity threshold in signal examples

### DIFF
--- a/bench/cpu-vs-gpu/config-bench-candle.yaml
+++ b/bench/cpu-vs-gpu/config-bench-candle.yaml
@@ -898,7 +898,7 @@ data:
               - other
         complexity:
           - name: needs_reasoning
-            threshold: 0.7
+            threshold: 0.10
             description: Escalate difficult or multi-step prompts.
             hard:
               candidates:
@@ -5190,7 +5190,7 @@ data:
               - other
         complexity:
           - name: needs_reasoning
-            threshold: 0.7
+            threshold: 0.10
             description: Escalate difficult or multi-step prompts.
             hard:
               candidates:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -363,7 +363,7 @@ routing:
 
     complexity:
       - name: needs_reasoning
-        threshold: 0.75
+        threshold: 0.10
         description: Escalate multi-step reasoning or synthesis-heavy prompts.
         hard:
           candidates:

--- a/config/fragments/signal/complexity/escalation.yaml
+++ b/config/fragments/signal/complexity/escalation.yaml
@@ -2,7 +2,7 @@ routing:
   signals:
     complexity:
       - name: needs_reasoning
-        threshold: 0.75
+        threshold: 0.10
         description: Escalate multi-step reasoning or synthesis-heavy prompts.
         hard:
           candidates:

--- a/deploy/kserve/example-multi-model-config.yaml
+++ b/deploy/kserve/example-multi-model-config.yaml
@@ -60,7 +60,7 @@ data:
               - other
         complexity:
           - name: needs_reasoning
-            threshold: 0.7
+            threshold: 0.10
             description: Escalate difficult or multi-step prompts.
             hard:
               candidates:

--- a/website/docs/tutorials/signal/learned/complexity.md
+++ b/website/docs/tutorials/signal/learned/complexity.md
@@ -31,7 +31,7 @@ routing:
   signals:
     complexity:
       - name: needs_reasoning
-        threshold: 0.75
+        threshold: 0.10
         description: Escalate multi-step reasoning or synthesis-heavy prompts.
         hard:
           candidates:
@@ -44,6 +44,27 @@ routing:
             - quick summary
             - simple rewrite
 ```
+
+`threshold` is a margin, not a similarity cutoff. The router scores the request
+against the `hard` and the `easy` candidate banks, then compares the two:
+
+```text
+signal = hard_bank_score - easy_bank_score
+
+signal >  threshold  -> hard
+signal < -threshold  -> easy
+otherwise            -> medium
+```
+
+Because the two banks can assign similar baseline scores, subtracting their
+scores may produce a margin much smaller than either individual score. In one
+calibration run using the candidate banks above, the largest observed absolute
+margin across eight prompts was `0.197`; none reached the `hard` or `easy` band
+with a threshold of `0.75`.
+
+Treat `0.10` as a starting point rather than a universal default. Measure the
+margin on representative traffic and tune the threshold for the configured
+candidate banks and embedding model.
 
 A rule emits a suffixed name. Decisions must reference
 `<rule>:easy`, `<rule>:medium`, or `<rule>:hard`:


### PR DESCRIPTION
Closes #3246

## Purpose

The `complexity` signal derives its difficulty band from the **margin** between
the hard and easy prototype banks, not from an absolute similarity score:

```go
// src/semantic-router/pkg/classification/complexity_rule_scoring.go:41
return hardScore, easyScore, hardScore.Score - easyScore.Score
```

```go
// src/semantic-router/pkg/classification/complexity_rule_scoring.go:73-81
func classifyComplexityDifficulty(threshold float32, signal float64) string {
	if signal > float64(threshold) {
		return "hard"
	}
	if signal < -float64(threshold) {
		return "easy"
	}
	return "medium"
}
```

Because the two banks can assign similar baseline scores, subtracting them can
produce a margin much smaller than either individual score.

The shipped examples set `threshold` to `0.70` or `0.75`. In the calibration run
recorded in #3246, the largest absolute margin observed across eight prompts was
`0.197`, and no prompt reached the `hard` or `easy` band at `0.75`. Prompts
containing the hard candidate phrases verbatim were classified `medium`, so the
`needs_reasoning:hard` decision condition did not match and the escalation model
was never selected. A reader who copies one of these examples gets a complexity
rule that appears healthy while never escalating.

For contrast, maintained recipe configurations use complexity thresholds in the
`0.08`-`0.15` range, including the agent, balance, privacy, multi-objective,
and built-in mom-v1 recipes.

This PR sets the example thresholds to `0.10` and documents that `threshold` is
a margin, presented as a starting point to calibrate rather than a universal
default.

**Scope note.** A repository-wide scan after filing #3246 found two additional
active occurrences in `bench/cpu-vs-gpu/config-bench-candle.yaml`. This PR
updates all active configuration and documentation surfaces.

Historical v0.3 English and translated documentation snapshots are intentionally
unchanged because they describe the configuration shipped with that release.

Affected modules: `config`, `deploy`, `bench`, `website`.
Owning Workgroup: `wg/mom-routing` (per issue #3246).

### Files changed

| File | Change |
| --- | --- |
| `config/config.yaml` | `needs_reasoning` threshold `0.75` -> `0.10` |
| `config/fragments/signal/complexity/escalation.yaml` | `needs_reasoning` threshold `0.75` -> `0.10` |
| `deploy/kserve/example-multi-model-config.yaml` | `needs_reasoning` threshold `0.7` -> `0.10` |
| `bench/cpu-vs-gpu/config-bench-candle.yaml` | `needs_reasoning` threshold `0.7` -> `0.10` (two occurrences) |
| `website/docs/tutorials/signal/learned/complexity.md` | threshold `0.75` -> `0.10`, plus a section explaining the margin semantics and the need to calibrate |

## Test Plan

1. Confirm no active complexity rule retains an ineffective threshold, using a
   YAML parser that also descends into ConfigMap-embedded `config.yaml` strings
   and Markdown fenced blocks (a plain `grep` misreads nearby
   `similarity_threshold`, `best_weight`, and `embeddings` values).
2. Verify the changed YAML still parses.
3. Run the reference config contract test:
   `go test ./pkg/config/... -run TestReferenceConfig -count=1`
4. Run the harness lint gate for the changed files:
   `make agent-ci-lint CHANGED_FILES="..."`
5. Run the docs gate: `make agent-docs-ci-gate AGENT_BASE_REF=origin/main`
6. Ask the harness what this change surface requires:
   `make agent-report ENV=cpu CHANGED_FILES="..."`
7. Check whitespace: `git diff --check origin/main..HEAD`

## Test Result

**1. Structural scan** — 27 complexity rules found across all YAML (including
ConfigMap-embedded configs). After the change, **0** active rules have a
threshold above `0.5`. The only remaining occurrences are the three intentionally
excluded historical snapshots under `website/versioned_docs/version-v0.3/` and
`website/i18n/zh-Hans/`.

**2. YAML parses**

```text
OK  config/config.yaml (1 docs)
OK  config/fragments/signal/complexity/escalation.yaml (1 docs)
OK  deploy/kserve/example-multi-model-config.yaml (1 docs)
OK  bench/cpu-vs-gpu/config-bench-candle.yaml (49 docs)
```

**3. Reference config contract test** — passes

```text
ok  github.com/vllm-project/semantic-router/src/semantic-router/pkg/config  0.075s
```

**4. `make agent-ci-lint`** — exit `0`

```text
md fmt.......................................Passed
yaml/yml fmt.................................Passed
```

**5. `make agent-docs-ci-gate AGENT_BASE_REF=origin/main`** — exit `2`, blocked
by a pre-existing failure unrelated to this change. See "Blocker" below.

**6. `make agent-report`** — classifies the change as `documentation-only`;
impacted surfaces `router_config_contract, docs_examples`; required surfaces
`none`; fast tests `none`; feature tests `none`; local smoke `not required`.

**7. `git diff --check origin/main..HEAD`** — clean.

**Measured behavior.** The calibration data is the eight-prompt table recorded in
#3246, measured on a running router with the shipped candidate banks and read
from the router's own `complexity_rule_scoring.go:101` log line:

- Largest absolute margin observed: `0.197`
- Bands at `0.75`: **0 of 8** non-medium
- Bands at `0.10`: **4 of 8** non-medium (2 `easy`, 2 `hard`)

Rows 6 and 7 of that table are the decisive cases: they contain the hard-bank
candidate phrases verbatim, score `+0.156` and `+0.151`, and still do not reach
the `hard` band at `0.75`. Row 2 shows the mechanism directly, with `hard` and
`easy` both `0.361` cancelling to `-0.001`.

**Remaining risk.** `0.10` matches the calibrated range already shipped in the
maintained recipes, but the correct threshold depends on the candidate banks,
the embedding model, and the traffic. The documentation change states this and
directs readers to measure rather than implying `0.10` is universal.

**Blocker encountered (pre-existing, unrelated to this PR).**
`make agent-docs-ci-gate AGENT_BASE_REF=origin/main` fails during
`agent-validate` with:

```text
ERROR: Pattern has no matches: src/vllm-sr/**/*memory*
```

The pattern is `tools/agent/test-domain-registry.yaml:187`. Commit `2e79a811`
("Remove unused cli serve.py and models_memory.py (#3211)") deleted
`models_memory.py`, the only file under `src/vllm-sr/` matching that glob, so the
registry entry no longer resolves. This reproduces on a pristine `origin/main`
with no local changes and is not introduced by this PR; fixing the registry entry
belongs to a separate harness change. The focused gate for the changed files,
`make agent-ci-lint`, passes.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category: `[Bug]`
- [x] Title does not stack prefixes
- [x] Links accepted issue #3246 with exactly one owner (`wg/mom-routing`)
- [x] Commit signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect actual scope, commands, and blockers

</details>
