### PR TITLE
[Community] Update Workgroup roster · 2026-09-01

### DIFF
--- a/tools/agent/test-domain-registry.yaml
+++ b/tools/agent/test-domain-registry.yaml
@@ -184,7 +184,7 @@ domains:
       - src/semantic-router/pkg/sessiontelemetry/*memory*
       - src/semantic-router/pkg/vectorstore/*memory*
       - src/semantic-router/pkg/cache/*memory*
-      - src/vllm-sr/**/*memory*
+      - src/vllm-sr/cli/models.py
       - tools/make/milvus.mk
       - e2e/testing/09-memory-features-test.py
       - e2e/testing/run_memory_integration.sh

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -65,6 +65,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/yaojiejia.png',
         profile: 'https://github.com/yaojiejia',
       },
+      {
+        name: 'wuli666',
+        avatar: 'https://github.com/wuli666.png',
+        profile: 'https://github.com/wuli666',
+      },
     ],
   },
   {
@@ -126,6 +131,16 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/guan404ming.png',
         profile: 'https://github.com/guan404ming',
       },
+      {
+        name: 'Pranav Thakur',
+        avatar: 'https://github.com/pranavthakur0-0.png',
+        profile: 'https://github.com/pranavthakur0-0',
+      },
+      {
+        name: 'bugkeep',
+        avatar: 'https://github.com/bugkeep.png',
+        profile: 'https://github.com/bugkeep',
+      },
     ],
   },
   {
@@ -166,6 +181,11 @@ export const workGroups: WorkGroup[] = [
         name: 'Hikari',
         avatar: 'https://github.com/altale.png',
         profile: 'https://github.com/altale',
+      },
+      {
+        name: 'Binbin Zhang',
+        avatar: 'https://github.com/Bevisy.png',
+        profile: 'https://github.com/Bevisy',
       },
     ],
   },
@@ -290,6 +310,11 @@ export const workGroups: WorkGroup[] = [
         name: 'Eda Zhou',
         avatar: 'https://github.com/edamamez.png',
         profile: 'https://github.com/edamamez',
+      },
+      {
+        name: 'wuli666',
+        avatar: 'https://github.com/wuli666.png',
+        profile: 'https://github.com/wuli666',
       },
     ],
   },

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -162,6 +162,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/ZireaelK.png',
         profile: 'https://github.com/ZireaelK',
       },
+      {
+        name: 'Hikari',
+        avatar: 'https://github.com/altale.png',
+        profile: 'https://github.com/altale',
+      },
     ],
   },
   {
@@ -309,6 +314,13 @@ export const workGroups: WorkGroup[] = [
         name: 'FAUST',
         avatar: 'https://github.com/FAUST-BENCHOU.png',
         profile: 'https://github.com/FAUST-BENCHOU',
+      },
+    ],
+    members: [
+      {
+        name: 'Nanasis',
+        avatar: 'https://github.com/nanasis.png',
+        profile: 'https://github.com/nanasis',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add all currently eligible Workgroup Members in one roster batch
- route applicants to the Workgroup that owns their merged contribution
- preserve the original application task state when its requested Workgroup differs
- keep the memory CI domain aligned with the live CLI schema after the obsolete `models_memory.py` module was removed

## Evidence

| Applicant | Workgroup | Role | Application | Qualifying contribution |
| --- | --- | --- | --- | --- |
| @altale | Data Plane & Networking | Member | [charter comment](https://github.com/vllm-project/semantic-router/issues/2967#issuecomment-5479295071) | [#2738](https://github.com/vllm-project/semantic-router/pull/2738) |
| @Bevisy | Data Plane & Networking | Member | [charter comment](https://github.com/vllm-project/semantic-router/issues/2967#issuecomment-5463243407) | [#3163](https://github.com/vllm-project/semantic-router/pull/3163) |
| @wuli666 | Developer Experience & Ecosystem | Member | [Router Models application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5460563182), [Agentic application](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5460567718) | [#3161](https://github.com/vllm-project/semantic-router/pull/3161), [#3154](https://github.com/vllm-project/semantic-router/pull/3154) |
| @wuli666 | MoM & Routing | Member | [Router Models application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5460563182), [Agentic application](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5460567718) | [#3144](https://github.com/vllm-project/semantic-router/pull/3144) |
| @pranavthakur0-0 | Router Models & Inference Runtime | Member | [charter comment](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5406937090) | [#2526](https://github.com/vllm-project/semantic-router/pull/2526) |
| @bugkeep | Router Models & Inference Runtime | Member | [charter comment](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5460906437) | [#3085](https://github.com/vllm-project/semantic-router/pull/3085) |
| @nanasis | Evaluation & Quality | Member | [charter comment](https://github.com/vllm-project/semantic-router/issues/2969#issuecomment-5447793466) | [#3124](https://github.com/vllm-project/semantic-router/pull/3124) |

PR #2526 predates canonical Workgroup labeling; its detector backend and inference-runtime boundary were resolved by manual diff review.

The CI registry previously selected a deleted `src/vllm-sr/**/*memory*` path. The live `MemoryPluginConfig` schema is now in `src/vllm-sr/cli/models.py`, so the memory integration selector points there.

## Validation

- Workgroup roster structure and per-Workgroup duplicate-login check
- `git diff --check`
- `make agent-validate`
- `make agent-ci-gate CHANGED_FILES="tools/agent/test-domain-registry.yaml website/src/data/workGroups.ts"`
- DCO sign-off verified

Related #2965, #2966, #2967, #2969, #2970, #2987
