### PR TITLE
[Community] Add Hikari and Binbin Zhang to Data Plane & Networking members

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -162,6 +162,16 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/ZireaelK.png',
         profile: 'https://github.com/ZireaelK',
       },
+      {
+        name: 'Hikari',
+        avatar: 'https://github.com/altale.png',
+        profile: 'https://github.com/altale',
+      },
+      {
+        name: 'Binbin Zhang',
+        avatar: 'https://github.com/Bevisy.png',
+        profile: 'https://github.com/Bevisy',
+      },
     ],
   },
   {


### PR DESCRIPTION
Adds two confirmed Members to the Data Plane & Networking Workgroup roster.

Both self-nominated on #2967 and meet the Member criterion in #2978 (a Contributor with at least one merged commit, confirmed by a Lead):

- **[@altale](https://github.com/altale)** — #1667, #2886, #2738 merged. Backend engineer working on AI gateways; ~10h/week.
- **[@Bevisy](https://github.com/Bevisy)** — #3163 merged (removed the stale `image_gen` route plugin surface he reported in #3129). Picking up #3183 next; ~8-10h/week.

Related #2967
