### PR TITLE
[CI/Build] Preserve Maintainer Workgroup reclassification

### DIFF
--- a/tools/agent/docs/maintainer-ops.md
+++ b/tools/agent/docs/maintainer-ops.md
@@ -185,9 +185,9 @@ perform only deterministic intake-state normalization. They enforce this
 contract without making roadmap, priority, or close decisions:
 
 - issue forms start at `needs-acceptance` and use the proposed Workgroup only
-  to seed an otherwise unowned issue; once a Workgroup label exists it is the
-  triage source of truth, so Maintainer reclassification is not reverted from
-  stale form text;
+  to seed an otherwise unowned issue; once any recognized owner exists (a
+  Workgroup or `owner/maintainers`) it is the triage source of truth, so
+  Maintainer reclassification is not reverted from stale form text;
 - `/accept` lets a collaborator with write, maintain, or admin permission accept
   an issue that already has exactly one recognized owner: one Workgroup for
   project work or `owner/maintainers` for repository governance;

--- a/tools/agent/docs/maintainer-ops.md
+++ b/tools/agent/docs/maintainer-ops.md
@@ -184,7 +184,10 @@ local `apply` command after maintainer review when mutations are intended.
 perform only deterministic intake-state normalization. They enforce this
 contract without making roadmap, priority, or close decisions:
 
-- issue forms start at `needs-acceptance` and propose one Workgroup;
+- issue forms start at `needs-acceptance` and use the proposed Workgroup only
+  to seed an otherwise unowned issue; once a Workgroup label exists it is the
+  triage source of truth, so Maintainer reclassification is not reverted from
+  stale form text;
 - `/accept` lets a collaborator with write, maintain, or admin permission accept
   an issue that already has exactly one recognized owner: one Workgroup for
   project work or `owner/maintainers` for repository governance;

--- a/tools/ci/community_lifecycle_policy.py
+++ b/tools/ci/community_lifecycle_policy.py
@@ -230,14 +230,28 @@ def normalize_proposed_workgroup(
     issue: dict[str, Any],
     *,
     accepted: bool,
+    event_action: str,
+    event_label: str | None,
+    actor_can_manage: bool,
 ) -> set[str]:
+    """Seed an unowned issue from its form without undoing Maintainer triage."""
+
     workgroups = labels.intersection(WORKGROUP_LABELS)
     form_workgroup = proposed_workgroup(issue.get("body"))
-    if accepted or not form_workgroup or workgroups == {form_workgroup}:
+    if accepted or not form_workgroup or workgroups:
         return workgroups
-    plan.remove_labels.update(workgroups - {form_workgroup})
+
+    # A Workgroup selected in the issue form is only the initial proposal. If a
+    # Maintainer removes that owner while reclassifying the issue, do not race
+    # the following label addition by restoring the stale form choice.
+    if (
+        actor_can_manage
+        and event_action == "unlabeled"
+        and event_label in WORKGROUP_LABELS
+    ):
+        return workgroups
+
     plan.add_labels.add(form_workgroup)
-    labels.difference_update(workgroups)
     labels.add(form_workgroup)
     return {form_workgroup}
 
@@ -335,7 +349,15 @@ def plan_issue(
     )
 
     accepted = ACCEPTED in labels
-    workgroups = normalize_proposed_workgroup(plan, labels, issue, accepted=accepted)
+    workgroups = normalize_proposed_workgroup(
+        plan,
+        labels,
+        issue,
+        accepted=accepted,
+        event_action=event_action,
+        event_label=event_label,
+        actor_can_manage=actor_can_manage,
+    )
     owners = labels.intersection(OWNER_LABELS)
     if accepted and len(owners) != 1:
         plan.remove_labels.add(ACCEPTED)

--- a/tools/ci/community_lifecycle_policy.py
+++ b/tools/ci/community_lifecycle_policy.py
@@ -237,18 +237,15 @@ def normalize_proposed_workgroup(
     """Seed an unowned issue from its form without undoing Maintainer triage."""
 
     workgroups = labels.intersection(WORKGROUP_LABELS)
+    owners = labels.intersection(OWNER_LABELS)
     form_workgroup = proposed_workgroup(issue.get("body"))
-    if accepted or not form_workgroup or workgroups:
+    if accepted or not form_workgroup or owners:
         return workgroups
 
     # A Workgroup selected in the issue form is only the initial proposal. If a
     # Maintainer removes that owner while reclassifying the issue, do not race
     # the following label addition by restoring the stale form choice.
-    if (
-        actor_can_manage
-        and event_action == "unlabeled"
-        and event_label in WORKGROUP_LABELS
-    ):
+    if actor_can_manage and event_action == "unlabeled" and event_label in OWNER_LABELS:
         return workgroups
 
     plan.add_labels.add(form_workgroup)

--- a/tools/ci/tests/test_community_lifecycle.py
+++ b/tools/ci/tests/test_community_lifecycle.py
@@ -86,6 +86,37 @@ MoM & Routing
         )
         self.assertNotIn("wg/enterprise-environment", plan.add_labels)
 
+    def test_maintainer_owner_overrides_stale_form_workgroup(self) -> None:
+        issue = {
+            "body": "### Proposed Workgroup\n\nEnterprise & Environment\n",
+            "labels": labels("needs-acceptance", "owner/maintainers"),
+            "assignees": [],
+            "milestone": None,
+        }
+        plan = community_lifecycle.plan_issue(
+            issue,
+            event_action="labeled",
+            event_label="owner/maintainers",
+            actor_can_manage=True,
+        )
+        self.assertNotIn("wg/enterprise-environment", plan.add_labels)
+        self.assertNotIn("owner/maintainers", plan.remove_labels)
+
+    def test_maintainer_can_remove_owner_without_form_race(self) -> None:
+        issue = {
+            "body": "### Proposed Workgroup\n\nEnterprise & Environment\n",
+            "labels": labels("needs-acceptance"),
+            "assignees": [],
+            "milestone": None,
+        }
+        plan = community_lifecycle.plan_issue(
+            issue,
+            event_action="unlabeled",
+            event_label="owner/maintainers",
+            actor_can_manage=True,
+        )
+        self.assertNotIn("wg/enterprise-environment", plan.add_labels)
+
     def test_multiple_workgroups_are_not_resolved_from_stale_form_data(self) -> None:
         issue = {
             "body": "### Proposed Workgroup\n\nEnterprise & Environment\n",

--- a/tools/ci/tests/test_community_lifecycle.py
+++ b/tools/ci/tests/test_community_lifecycle.py
@@ -55,6 +55,61 @@ MoM & Routing
             {"needs-acceptance", "wg/evaluation-quality"},
         )
 
+    def test_maintainer_reclassification_overrides_form_workgroup(self) -> None:
+        issue = {
+            "body": "### Proposed Workgroup\n\nEnterprise & Environment\n",
+            "labels": labels("needs-acceptance", "wg/data-plane-networking"),
+            "assignees": [],
+            "milestone": None,
+        }
+        plan = community_lifecycle.plan_issue(
+            issue,
+            event_action="labeled",
+            event_label="wg/data-plane-networking",
+            actor_can_manage=True,
+        )
+        self.assertNotIn("wg/enterprise-environment", plan.add_labels)
+        self.assertNotIn("wg/data-plane-networking", plan.remove_labels)
+
+    def test_maintainer_can_remove_stale_form_workgroup_before_relabeling(self) -> None:
+        issue = {
+            "body": "### Proposed Workgroup\n\nEnterprise & Environment\n",
+            "labels": labels("needs-acceptance"),
+            "assignees": [],
+            "milestone": None,
+        }
+        plan = community_lifecycle.plan_issue(
+            issue,
+            event_action="unlabeled",
+            event_label="wg/enterprise-environment",
+            actor_can_manage=True,
+        )
+        self.assertNotIn("wg/enterprise-environment", plan.add_labels)
+
+    def test_multiple_workgroups_are_not_resolved_from_stale_form_data(self) -> None:
+        issue = {
+            "body": "### Proposed Workgroup\n\nEnterprise & Environment\n",
+            "labels": labels(
+                "needs-acceptance",
+                "wg/enterprise-environment",
+                "wg/data-plane-networking",
+            ),
+            "assignees": [],
+            "milestone": None,
+        }
+        plan = community_lifecycle.plan_issue(
+            issue,
+            event_action="labeled",
+            event_label="wg/data-plane-networking",
+            actor_can_manage=True,
+        )
+        self.assertFalse(
+            plan.add_labels.intersection(community_lifecycle.WORKGROUP_LABELS)
+        )
+        self.assertFalse(
+            plan.remove_labels.intersection(community_lifecycle.WORKGROUP_LABELS)
+        )
+
     def test_unaccepted_issue_cannot_be_assigned_or_prioritized(self) -> None:
         issue = {
             "body": "",


### PR DESCRIPTION
## Summary

- treat the issue-form Workgroup choice as an initial seed rather than a permanent owner
- preserve Maintainer owner reclassification across subsequent lifecycle events
- avoid racing a Maintainer who removes the stale proposed owner before adding the replacement
- document the triage precedence and add regression coverage

## Validation

- `python3 tools/ci/tests/test_community_lifecycle.py`
- `make agent-validate`
- `make agent-ci-gate CHANGED_FILES="tools/ci/community_lifecycle_policy.py tools/ci/tests/test_community_lifecycle.py tools/agent/docs/maintainer-ops.md"`

Closes #3270