### PR TITLE
[Bug] Pin Jaeger all-in-one image to 1.76.0

### DIFF
--- a/src/vllm-sr/cli/container_support_services.py
+++ b/src/vllm-sr/cli/container_support_services.py
@@ -51,7 +51,7 @@ def container_start_jaeger(
         f"{stack_layout.jaeger_otlp_port}:4317",
         "-p",
         f"{stack_layout.jaeger_ui_port}:16686",
-        "docker.io/jaegertracing/all-in-one:latest",
+        "docker.io/jaegertracing/all-in-one:1.76.0",
     ]
     return _run_service_start(cmd, "Jaeger")
 

--- a/src/vllm-sr/tests/test_container_support_services.py
+++ b/src/vllm-sr/tests/test_container_support_services.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from cli import container_support_services  # noqa: E402
+from cli.runtime_stack import resolve_runtime_stack  # noqa: E402
+
+
+def test_container_start_jaeger_uses_pinned_image(monkeypatch):
+    commands = []
+    monkeypatch.setattr(
+        container_support_services, "get_container_runtime", lambda: "docker"
+    )
+    monkeypatch.setattr(
+        container_support_services, "_replace_existing_container", lambda name: None
+    )
+    monkeypatch.setattr(
+        container_support_services,
+        "_run_service_start",
+        lambda cmd, service: commands.append(cmd) or True,
+    )
+
+    container_support_services.container_start_jaeger(
+        stack_layout=resolve_runtime_stack()
+    )
+
+    (cmd,) = commands
+    assert "docker.io/jaegertracing/all-in-one:1.76.0" in cmd
+
+
+def test_support_service_images_never_float():
+    source = Path(container_support_services.__file__).read_text(encoding="utf-8")
+    assert ":latest" not in source


### PR DESCRIPTION
Closes #3275

## Purpose

The local support stack started Jaeger from `docker.io/jaegertracing/all-in-one:latest`, while the neighboring support images are pinned (`prom/prometheus:v2.53.0`, `grafana/grafana:11.5.1`). The floating tag is non-reproducible and hides that it points at the EOL Jaeger v1 line.

This pins `container_start_jaeger` in `src/vllm-sr/cli/container_support_services.py` to `all-in-one:1.76.0` — the version `latest` resolves to today (identical amd64 digest `sha256:968b31672...` on Docker Hub), so runtime behavior is unchanged and the tested dependency is now explicit. Migrating to Jaeger v2 stays out of scope per the issue.

Adds `tests/test_container_support_services.py`: one test asserting the rendered `run` command uses the pinned image, and one guard asserting no support-service image in the module floats on `:latest`.

Owned by the `wg/enterprise-environment` accepted issue #3275.

Note: `deploy/openshift/observability/jaeger/deployment.yaml` also references `all-in-one:latest`; left untouched since the issue bounds this fix to the local support stack.

## Test Plan

```
cd src/vllm-sr
python -m pytest tests/test_container_support_services.py tests/test_container_services.py -q
black --check cli/container_support_services.py tests/test_container_support_services.py
```

## Test Result

- `tests/test_container_support_services.py`: 2 passed
- `tests/test_container_services.py`: 11 passed
- `black --check`: unchanged

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
