### PR TITLE
[Bug] roll back applied blocks on recovery-store failure in context_compression

### DIFF
--- a/src/semantic-router/pkg/contextcompression/service.go
+++ b/src/semantic-router/pkg/contextcompression/service.go
@@ -118,6 +118,9 @@ func (s *Service) executePlan(
 			&recoveryBytes,
 		)
 		if applyErr != nil {
+			for _, applied := range appliedCandidates {
+				applied.block.SetText(applied.originalText)
+			}
 			return result, appliedCandidates, applyErr
 		}
 		if !applied {

--- a/src/semantic-router/pkg/contextcompression/service_test.go
+++ b/src/semantic-router/pkg/contextcompression/service_test.go
@@ -419,3 +419,55 @@ func TestServiceReportsRecoveryBackendFailure(t *testing.T) {
 		t.Fatalf("backend failure result = %#v", result)
 	}
 }
+
+func TestServiceRollsBackAppliedBlocksOnRecoveryFailure(t *testing.T) {
+	firstContent := strings.Repeat("first recoverable output ", 200)
+	secondContent := strings.Repeat("second output ", 200)
+	body := map[string]interface{}{
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "question"},
+			map[string]interface{}{
+				"role":         "tool",
+				"tool_call_id": "call_1",
+				"content":      firstContent,
+			},
+			map[string]interface{}{
+				"role":         "tool",
+				"tool_call_id": "call_2",
+				"content":      secondContent,
+			},
+		},
+	}
+	ir := ParseRequestIR(body, Provenance{})
+	store := &testRecoveryStore{}
+	result := NewService().Apply(context.Background(), Request{
+		Scope:    "scope",
+		Request:  ir,
+		Recovery: store,
+		Policy: Policy{
+			Mode: ModeAlways,
+			Targets: Targets{
+				ToolOutputs: TargetPolicy{
+					Mode:         TargetRecoverable,
+					MinTokens:    10,
+					TargetTokens: 20,
+				},
+			},
+			Recovery: RecoveryPolicy{
+				Enabled:            true,
+				MaxBytesPerRequest: len(firstContent),
+			},
+		},
+		TokenCounter: HeuristicTokenCounter{},
+	})
+	if result.Failure == nil {
+		t.Fatalf("expected failure from recovery byte-limit, got %#v", result)
+	}
+	firstBlock := ir.Messages[1].Blocks[0]
+	if firstBlock.Text != firstContent {
+		t.Fatalf("first block not rolled back after recovery failure: got %q, want %q", firstBlock.Text[:80], firstContent[:80])
+	}
+	if len(store.entries) != 1 {
+		t.Fatalf("store should retain the first committed entry, got %d", len(store.entries))
+	}
+}


### PR DESCRIPTION
Closes #3278

## Purpose

`executePlan` returned the error from a failing recoverable candidate without restoring blocks already mutated by earlier candidates in the same batch. Under the default `failure_mode: fail_open`, the request was forwarded with a partially compressed body while the receipt reported `Applied = false` / `Failure != nil` — the body and receipt disagreed, and the original text of already-applied blocks was lost (recovery keys are only injected on the success path).

Restore all already-applied candidates in the `applyErr` branch of `executePlan`, reusing the existing rollback pattern from `finalizeResult`.

Two related design questions (wiring `SkipRecoveryUnavailable`, skip-vs-abort on store `Put` failure) are left as open items on #3278 for the Workgroup; this PR only fixes the rollback gap.

Module: `pkg/contextcompression`.

## Test Plan

```bash
cd src/semantic-router
go test ./pkg/contextcompression/... -count=1
```

`TestServiceRollsBackAppliedBlocksOnRecoveryFailure`: two recoverable tool-output blocks; the first stores successfully and is applied, the second exceeds `recovery.max_bytes_per_request` and errors. Verifies the first block is restored to its original text and the committed store entry is retained.

## Test Result

```
ok   github.com/vllm-project/semantic-router/src/semantic-router/pkg/contextcompression   2.880s
```

Verified the test fails on current main (block left as compressed placeholder) and passes with this fix. `fail_open` now forwards a body identical to the original request on recovery-store failure.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category (`[Bug]`)
- [x] The title does not stack prefixes
- [x] The PR links an `accepted` issue with exactly one owner (#3278, `wg/agentic-context`)
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>