### PR TITLE
[Bug] Default local Envoy logging to info

### DIFF
--- a/e2e/testing/vllm-sr-cli/cli_test_base.py
+++ b/e2e/testing/vllm-sr-cli/cli_test_base.py
@@ -337,6 +337,7 @@ class CLITestBase(unittest.TestCase):
         endpoint: str = "host.docker.internal:8000",
         base_url: str | None = None,
         provider: str | None = None,
+        api_key_env: str | None = None,
         api_only: bool = False,
         managed_storage: bool = False,
     ) -> str:
@@ -357,6 +358,8 @@ class CLITestBase(unittest.TestCase):
             backend_ref["protocol"] = "http"
         if provider is not None:
             backend_ref["provider"] = provider
+        if api_key_env is not None:
+            backend_ref["api_key_env"] = api_key_env
 
         config = {
             "version": "v0.3",

--- a/e2e/testing/vllm-sr-cli/mock_openai_upstream.py
+++ b/e2e/testing/vllm-sr-cli/mock_openai_upstream.py
@@ -1,10 +1,18 @@
 """Minimal OpenAI-compatible upstream used by vllm-sr CLI integration tests."""
 
+import os
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
 class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
+        expected_authorization = os.getenv("MOCK_EXPECT_AUTHORIZATION")
+        if expected_authorization is not None:
+            authorization = self.headers.get("Authorization", "")
+            if authorization != f"Bearer {expected_authorization}":
+                self.send_error(401)
+                return
+            print("authorization-canary-received", flush=True)
         length = int(self.headers.get("Content-Length", "0"))
         self.rfile.read(length)
         print(self.path, flush=True)

--- a/e2e/testing/vllm-sr-cli/serve_session.py
+++ b/e2e/testing/vllm-sr-cli/serve_session.py
@@ -89,6 +89,7 @@ class ServeSessionMixin:
         endpoint: str = "host.docker.internal:8000",
         base_url: str | None = None,
         provider: str | None = None,
+        api_key_env: str | None = None,
         api_only: bool = False,
         managed_storage: bool = False,
         ensure_models_dir: bool = False,
@@ -98,6 +99,7 @@ class ServeSessionMixin:
             endpoint=endpoint,
             base_url=base_url,
             provider=provider,
+            api_key_env=api_key_env,
             api_only=api_only,
             managed_storage=managed_storage,
         )

--- a/e2e/testing/vllm-sr-cli/test_integration.py
+++ b/e2e/testing/vllm-sr-cli/test_integration.py
@@ -72,9 +72,16 @@ class TestServeIntegration(ServeSessionMixin, CLITestBase):
         self.assertEqual(process.communicate.call_count, 2)
 
     @contextmanager
-    def _running_mock_upstream(self, container_name: str):
+    def _running_mock_upstream(
+        self, container_name: str, *, expected_authorization: str | None = None
+    ):
         """Run the mock OpenAI upstream on the active stack network."""
         image = os.getenv(MOCK_OPENAI_IMAGE_ENV, DEFAULT_MOCK_OPENAI_IMAGE)
+        expected_authorization_env = (
+            ["-e", f"MOCK_EXPECT_AUTHORIZATION={expected_authorization}"]
+            if expected_authorization is not None
+            else []
+        )
         result = self._run_subprocess(
             [
                 self.container_runtime,
@@ -86,6 +93,7 @@ class TestServeIntegration(ServeSessionMixin, CLITestBase):
                 self.runtime_stack.network_name,
                 "-v",
                 f"{MOCK_OPENAI_SERVER_PATH}:/mock_openai_upstream.py:ro",
+                *expected_authorization_env,
                 "--entrypoint",
                 "python3",
                 image,
@@ -133,7 +141,9 @@ class TestServeIntegration(ServeSessionMixin, CLITestBase):
             )
         return "\n".join(diagnostics)
 
-    def _send_mock_chat_completion(self, mock_container: str):
+    def _send_mock_chat_completion(
+        self, mock_container: str, *, redact_values: tuple[str, ...] = ()
+    ):
         """Send a chat request, retrying until the local stack is ready."""
         listener_port = 8888 + self.runtime_stack.port_offset
         request = urllib_request.Request(
@@ -171,6 +181,8 @@ class TestServeIntegration(ServeSessionMixin, CLITestBase):
                 self.ENVOY_CONTAINER_NAME,
             )
         )
+        for value in redact_values:
+            diagnostics = diagnostics.replace(value, "[redacted]")
         self.fail(f"request did not reach mock upstream: {last_error}\n{diagnostics}")
 
     def _mock_upstream_paths(self, mock_container: str) -> set[str]:
@@ -379,6 +391,64 @@ class TestServeIntegration(ServeSessionMixin, CLITestBase):
             print("  ✓ HF_TOKEN has correct value")
 
         self.print_test_result(True, "Environment variable passed to container")
+
+    @unittest.skipUnless(
+        os.environ.get("RUN_INTEGRATION_TESTS", "").lower() == "true",
+        "Integration tests disabled. Set RUN_INTEGRATION_TESTS=true to enable.",
+    )
+    def test_envoy_log_level_is_safe_and_provider_key_is_not_logged(self):
+        """Use a synthetic provider key to exercise the safe Envoy default."""
+        canary = "synthetic-provider-key-canary"
+        with self._running_serve(
+            env={"PROVIDER_KEY_CANARY": canary},
+            base_url=(
+                f"http://{self.runtime_stack.stack_name}-envoy-log-upstream:"
+                f"{MOCK_OPENAI_SERVER_PORT}"
+            ),
+            provider="openai",
+            api_key_env="PROVIDER_KEY_CANARY",
+            api_only=True,
+        ):
+            return_code, command, stderr = self.inspect_container(
+                "{{json .Config.Cmd}}",
+                container_name=self.ENVOY_CONTAINER_NAME,
+            )
+            self.assertEqual(return_code, 0, stderr)
+            self.assertIn("--log-level", command)
+            self.assertIn('"info"', command)
+
+            mock_container = f"{self.runtime_stack.stack_name}-envoy-log-upstream"
+            with self._running_mock_upstream(
+                mock_container, expected_authorization=canary
+            ):
+                self._send_mock_chat_completion(mock_container, redact_values=(canary,))
+                upstream_logs = self._run_subprocess(
+                    [self.container_runtime, "logs", mock_container],
+                    timeout=10,
+                )
+                self.assertEqual(upstream_logs.returncode, 0, upstream_logs.stderr)
+                self.assertIn(
+                    "authorization-canary-received",
+                    upstream_logs.stdout + upstream_logs.stderr,
+                )
+
+            logs = self._run_subprocess(
+                [self.container_runtime, "logs", self.ENVOY_CONTAINER_NAME],
+                timeout=10,
+            )
+            self.assertEqual(logs.returncode, 0, logs.stderr)
+            combined_logs = logs.stdout + logs.stderr
+            canary_absent = canary not in combined_logs
+            redacted_logs = combined_logs.replace(canary, "<redacted-canary>")
+            self.assertTrue(canary_absent, msg=redacted_logs)
+
+        with self._running_serve(env={"VLLM_SR_ENVOY_LOG_LEVEL": "DeBuG"}):
+            return_code, command, stderr = self.inspect_container(
+                "{{json .Config.Cmd}}",
+                container_name=self.ENVOY_CONTAINER_NAME,
+            )
+            self.assertEqual(return_code, 0, stderr)
+            self.assertIn('"debug"', command)
 
     @unittest.skipUnless(
         os.environ.get("RUN_INTEGRATION_TESTS", "").lower() == "true",

--- a/src/vllm-sr/cli/commands/runtime_support.py
+++ b/src/vllm-sr/cli/commands/runtime_support.py
@@ -76,6 +76,7 @@ PASSTHROUGH_ENV_RULES = (
     ("SR_LOG_ENCODING", False),
     ("SR_LOG_DEVELOPMENT", False),
     ("SR_LOG_ADD_CALLER", False),
+    ("VLLM_SR_ENVOY_LOG_LEVEL", False),
 )
 
 _STATIC_SENSITIVE = frozenset(name for name, masked in PASSTHROUGH_ENV_RULES if masked)

--- a/src/vllm-sr/cli/container_start.py
+++ b/src/vllm-sr/cli/container_start.py
@@ -58,6 +58,12 @@ from cli.utils import get_logger
 
 log = get_logger(__name__)
 
+ENVOY_LOG_LEVEL_ENV = "VLLM_SR_ENVOY_LOG_LEVEL"
+DEFAULT_ENVOY_LOG_LEVEL = "info"
+VALID_ENVOY_LOG_LEVELS = frozenset(
+    {"trace", "debug", "info", "warn", "warning", "error", "critical", "off"}
+)
+
 
 def container_start_vllm_sr(
     config_file,
@@ -79,6 +85,7 @@ def container_start_vllm_sr(
     """Start the runtime containers and return code, stdout, and stderr."""
     runtime = get_container_runtime()
     env_vars = dict(env_vars or {})
+    envoy_log_level = _resolve_envoy_log_level(env_vars)
     stack_layout = stack_layout or resolve_runtime_stack()
     resolve_runtime_topology(topology)
 
@@ -124,6 +131,7 @@ def container_start_vllm_sr(
         openclaw_network_name=openclaw_network_name,
         stack_layout=stack_layout,
         storage_secret_names=tuple(storage_secret_values),
+        envoy_log_level=envoy_log_level,
     )
 
     log.info(f"Starting vLLM Semantic Router runtime with {runtime}...")
@@ -201,6 +209,7 @@ def _resolve_container_specs(
     openclaw_network_name: str | None,
     stack_layout: RuntimeStackLayout,
     storage_secret_names: tuple[str, ...] = (),
+    envoy_log_level: str = DEFAULT_ENVOY_LOG_LEVEL,
 ):
     runtime_images = get_runtime_images(
         image=image,
@@ -225,6 +234,7 @@ def _resolve_container_specs(
         openclaw_network_name=openclaw_network_name,
         stack_layout=stack_layout,
         storage_secret_names=storage_secret_names,
+        envoy_log_level=envoy_log_level,
     )
 
 
@@ -243,6 +253,7 @@ def _runtime_container_specs(
     openclaw_network_name: str | None,
     stack_layout: RuntimeStackLayout,
     storage_secret_names: tuple[str, ...] = (),
+    envoy_log_level: str = DEFAULT_ENVOY_LOG_LEVEL,
 ):
     listener_port = _primary_listener_port(listeners)
     management_listener = _managed_management_listener(
@@ -282,6 +293,7 @@ def _runtime_container_specs(
         runtime_paths=runtime_paths,
         setup_mode=setup_mode,
         stack_layout=stack_layout,
+        envoy_log_level=envoy_log_level,
     )
 
     specs = [
@@ -396,6 +408,7 @@ def _build_envoy_runtime_command(
     runtime_paths: dict[str, str],
     setup_mode: bool,
     stack_layout: RuntimeStackLayout,
+    envoy_log_level: str,
 ):
     service_entrypoint, service_args = bounded_log_spool_entrypoint(
         "/usr/local/bin/envoy",
@@ -403,7 +416,7 @@ def _build_envoy_runtime_command(
             "-c",
             "/etc/envoy/envoy.yaml",
             "--log-level",
-            "debug",
+            envoy_log_level,
         ],
     )
     return _build_service_run_command(
@@ -588,6 +601,22 @@ def _build_dashboard_runtime_env(
         "OPENCLAW_MODEL_GATEWAY_CONTAINER_NAME", stack_layout.envoy_container_name
     )
     return dashboard_env
+
+
+def _resolve_envoy_log_level(env_vars: dict[str, str]) -> str:
+    """Resolve and validate Envoy's bounded log-level override."""
+    raw_level = env_vars.get(ENVOY_LOG_LEVEL_ENV, os.getenv(ENVOY_LOG_LEVEL_ENV))
+    if raw_level is None:
+        return DEFAULT_ENVOY_LOG_LEVEL
+
+    log_level = raw_level.strip().lower()
+    if log_level not in VALID_ENVOY_LOG_LEVELS:
+        allowed = ", ".join(sorted(VALID_ENVOY_LOG_LEVELS))
+        raise ValueError(
+            f"Invalid {ENVOY_LOG_LEVEL_ENV} value {raw_level!r}. "
+            f"Expected one of: {allowed}."
+        )
+    return log_level
 
 
 def _resolve_platform(env_vars):

--- a/src/vllm-sr/tests/test_runtime_support.py
+++ b/src/vllm-sr/tests/test_runtime_support.py
@@ -85,6 +85,19 @@ def test_append_passthrough_env_vars_includes_router_logging_settings(monkeypatc
     assert env_vars["SR_LOG_ENCODING"] == "console"
 
 
+def test_append_passthrough_env_vars_includes_envoy_log_level_without_changing_router_level(
+    monkeypatch,
+):
+    monkeypatch.setenv("SR_LOG_LEVEL", "debug")
+    monkeypatch.setenv("VLLM_SR_ENVOY_LOG_LEVEL", "WARNING")
+
+    env_vars: dict[str, str] = {}
+    append_passthrough_env_vars(env_vars)
+
+    assert env_vars["SR_LOG_LEVEL"] == "debug"
+    assert env_vars["VLLM_SR_ENVOY_LOG_LEVEL"] == "WARNING"
+
+
 def test_append_passthrough_env_vars_forwards_keys_named_by_trusted_source_config(
     monkeypatch, tmp_path
 ):

--- a/src/vllm-sr/tests/test_split_runtime_stack.py
+++ b/src/vllm-sr/tests/test_split_runtime_stack.py
@@ -117,6 +117,7 @@ def test_container_start_vllm_sr_sets_split_service_urls_for_dashboard(
     assert "127.0.0.1:9190:9190" in router_cmd
     envoy_cmd = _find_container_run_cmd(captured, "vllm-sr-envoy-container")
     assert "0.0.0.0:8899:8899" in envoy_cmd
+    assert envoy_cmd[envoy_cmd.index("--log-level") + 1] == "info"
 
     for component, command in (
         ("router", router_cmd),
@@ -146,6 +147,51 @@ def test_container_start_vllm_sr_sets_split_service_urls_for_dashboard(
         for value in _option_values(dashboard_cmd, "-e")
     )
     assert "--group-add" in envoy_cmd
+
+
+def test_split_runtime_uses_explicit_envoy_log_level(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "version: v0.1\nlisteners:\n  - name: http-8899\n    address: 0.0.0.0\n    port: 8899\n"
+    )
+    monkeypatch.setenv("VLLM_SR_ENVOY_LOG_LEVEL", "DeBuG")
+    monkeypatch.setattr(container_start, "get_container_runtime", lambda: "docker")
+    monkeypatch.setattr(
+        container_start,
+        "get_runtime_images",
+        lambda **_kwargs: {"router": "test-image", "envoy": "test-image"},
+    )
+    captured = _capture_run_commands(monkeypatch)
+    _stub_valid_container_cli(monkeypatch, tmp_path)
+
+    container_cli.container_start_vllm_sr(
+        str(config_path),
+        {},
+        [{"name": "http-8899", "address": "0.0.0.0", "port": 8899}],
+        network_name="vllm-sr-network",
+        minimal=True,
+    )
+
+    envoy_cmd = _find_container_run_cmd(captured, "vllm-sr-envoy-container")
+    assert envoy_cmd[envoy_cmd.index("--log-level") + 1] == "debug"
+
+
+def test_split_runtime_rejects_invalid_envoy_log_level_before_preparing_paths(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("VLLM_SR_ENVOY_LOG_LEVEL", "verbose")
+    monkeypatch.setattr(
+        container_start,
+        "_prepare_runtime_paths",
+        lambda *args, **kwargs: pytest.fail("runtime paths should not be prepared"),
+    )
+
+    with pytest.raises(ValueError, match="Invalid VLLM_SR_ENVOY_LOG_LEVEL"):
+        container_start.container_start_vllm_sr(
+            str(tmp_path / "config.yaml"),
+            {},
+            [{"name": "http-8899", "address": "0.0.0.0", "port": 8899}],
+        )
 
 
 def test_split_runtime_honors_management_listener_port(tmp_path, monkeypatch):

--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -65,6 +65,11 @@ Dashboard available without allowing configuration changes. Pin images and
 review [Security Hardening](security-hardening) before exposing a listener
 beyond a trusted host.
 
+Envoy uses the safe `info` log level by default. To troubleshoot temporarily,
+set `VLLM_SR_ENVOY_LOG_LEVEL=debug` before starting the stack, then unset it
+when finished: debug logging can expose forwarded request headers, including
+provider `Authorization` headers, in logs.
+
 ## When to move to Kubernetes
 
 Docker does not provide multi-node scheduling, rolling deployment control, or


### PR DESCRIPTION
Closes #3274

## Purpose

`vllm-sr serve` currently starts the local Envoy sidecar with `--log-level debug`, which can expose forwarded provider authorization headers in container logs. This patch makes `info` the safe default while preserving an explicit, validated `VLLM_SR_ENVOY_LOG_LEVEL` opt-in for troubleshooting.

Affected modules: local CLI startup, runtime environment passthrough, CLI integration tests, and Docker installation documentation. The linked issue is accepted, ready-for-dev, and owned by `wg/enterprise-environment`.

## Test Plan

- Focused Python tests for Envoy command construction, default/explicit/invalid log levels, runtime passthrough, and unchanged Router `SR_LOG_LEVEL` behavior.
- CLI harness tests for the synthetic provider-key path, including non-secret authorization receipt and redacted failure diagnostics.
- `make agent-report ENV=cpu CHANGED_FILES="src/vllm-sr/cli/container_start.py,src/vllm-sr/cli/commands/runtime_support.py,src/vllm-sr/tests/test_split_runtime_stack.py,src/vllm-sr/tests/test_runtime_support.py,e2e/testing/vllm-sr-cli/cli_test_base.py,e2e/testing/vllm-sr-cli/serve_session.py,e2e/testing/vllm-sr-cli/test_integration.py,e2e/testing/vllm-sr-cli/mock_openai_upstream.py,website/docs/installation/docker.md"`
- `make agent-validate`
- Ruff, Black, Python compilation, and `git diff --check`.
- The repository's Docker-backed feature/integration gates remain to be run in CI or a Docker-enabled environment.

## Test Result

- `make agent-report`: passed.
- Focused Python tests: 45 passed.
- CLI harness unit tests: 13 passed.
- Python compilation: passed.
- Ruff: passed.
- Black verification: passed.
- `make agent-validate`: passed.
- `git diff --check`: passed.
- `make agent-lint`: blocked because `.venv-agent/bin/python` is missing and the repository requested `make precommit-install`.
- Docker live E2E, `agent-ci-gate`, and `agent-feature-gate` were not run locally because Docker availability was not established.
- Synthetic credentials are never printed; the E2E assertion redacts failure diagnostics.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] PR links an accepted issue with exactly one Workgroup owner
- [x] Commit is signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect the actual scope and limitations

</details>