### PR TITLE
[Security] Replace hardcoded Grafana admin credential with per-stack secret

### DIFF
--- a/e2e/testing/vllm-sr-cli/test_integration_grafana_credentials.py
+++ b/e2e/testing/vllm-sr-cli/test_integration_grafana_credentials.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Real-daemon regression: a real Grafana container must boot and become ready
+when started exactly like ``container_start_grafana`` with the CLI's mounted
+password file and the rendered production ``grafana.serve.ini``.
+"""
+
+import base64
+import os
+import stat
+import time
+import unittest
+from pathlib import Path
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from cli import grafana_credentials as gc
+from cli.container_observability import render_observability_template
+from cli_test_base import (
+    HTTP_STATUS_OK,
+    CLITestBase,
+    stack_scoped_test_container_name,
+)
+
+# Keep in sync with `container_start_grafana` in
+# src/vllm-sr/cli/container_support_services.py.
+GRAFANA_IMAGE = "docker.io/grafana/grafana:11.5.1"
+GRAFANA_SERVE_INI_TEMPLATE = (
+    Path(gc.__file__).resolve().parent / "templates" / "grafana.serve.ini"
+)
+CONTAINER_GRAFANA_INI_PATH = "/etc/grafana/grafana.ini"
+# Org-admin API: anonymous Viewer is 403, anonymous disabled is 401, Admin is 200.
+GRAFANA_ORG_ADMIN_API = "/api/org/users"
+HTTP_STATUS_UNAUTHORIZED = 401
+HTTP_STATUS_FORBIDDEN = 403
+
+GRAFANA_CONTAINER_SUFFIX = "vllm-sr-cli-test-grafana"
+GRAFANA_READY_TIMEOUT = 180
+GRAFANA_START_COMMAND_TIMEOUT = 600
+
+integration_only = unittest.skipUnless(
+    os.environ.get("RUN_INTEGRATION_TESTS", "").lower() == "true",
+    "Integration tests disabled. Set RUN_INTEGRATION_TESTS=true to enable.",
+)
+
+
+class TestGrafanaPasswordFileContainer(CLITestBase):
+    """A real Grafana container must boot with the CLI's mounted password file."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.GRAFANA_CONTAINER_NAME = stack_scoped_test_container_name(
+            cls.runtime_stack.stack_name, GRAFANA_CONTAINER_SUFFIX
+        )
+
+    def tearDown(self):
+        self._run_subprocess(
+            [self.container_runtime, "rm", "-f", self.GRAFANA_CONTAINER_NAME],
+            timeout=30,
+        )
+        super().tearDown()
+
+    @integration_only
+    def test_grafana_boots_ready_with_the_mounted_password_file(self):
+        """Boot Grafana like serve: mounted secret plus rendered production ini.
+
+        Grafana runs as an unprivileged uid, so the file must be
+        container-readable (0644) rather than owner-only for the container to
+        reach readiness. The production ini must be mounted so anonymous
+        Admin cannot bypass the password-file credential.
+        """
+        self.print_test_header(
+            "grafana password file container startup",
+            "a real Grafana container becomes ready from the mounted secret "
+            "and production ini",
+        )
+
+        saved_override = os.environ.pop(gc.GRAFANA_ADMIN_PASSWORD_ENV, None)
+        try:
+            password_file = gc.ensure_grafana_admin_password_file(self.test_dir)
+            password = password_file.read_text(encoding="utf-8")
+        finally:
+            if saved_override is not None:
+                os.environ[gc.GRAFANA_ADMIN_PASSWORD_ENV] = saved_override
+
+        grafana_ini = Path(self.test_dir) / "grafana.serve.ini"
+        grafana_ini.write_text(
+            render_observability_template(
+                GRAFANA_SERVE_INI_TEMPLATE.read_text(encoding="utf-8"),
+                self.runtime_stack,
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(
+            stat.S_IMODE(password_file.stat().st_mode),
+            0o644,
+            "the mounted secret must be readable by the unprivileged Grafana uid",
+        )
+        self.assertEqual(
+            stat.S_IMODE(password_file.parent.stat().st_mode),
+            0o700,
+            "the state directory holding the secret must stay owner-only",
+        )
+
+        result = self._run_subprocess(
+            [
+                self.container_runtime,
+                "run",
+                "-d",
+                "--name",
+                self.GRAFANA_CONTAINER_NAME,
+                "-e",
+                f"{gc.GRAFANA_ADMIN_PASSWORD_FILE_ENV}="
+                f"{gc.CONTAINER_GRAFANA_PASSWORD_PATH}",
+                "-v",
+                (f"{password_file}:{gc.CONTAINER_GRAFANA_PASSWORD_PATH}:ro,z"),
+                "-v",
+                f"{grafana_ini}:{CONTAINER_GRAFANA_INI_PATH}:ro",
+                "-p",
+                "127.0.0.1::3000",
+                GRAFANA_IMAGE,
+            ],
+            timeout=GRAFANA_START_COMMAND_TIMEOUT,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"the Grafana container failed to start: {result.stderr}",
+        )
+        try:
+            self.assertTrue(
+                self.wait_for_container_running(
+                    timeout=120,
+                    container_name=self.GRAFANA_CONTAINER_NAME,
+                ),
+                "the Grafana container exited instead of becoming ready; the "
+                "bind-mounted password file may be unreadable by the "
+                "unprivileged Grafana uid",
+            )
+            host_port = self._published_host_port()
+            self.assertTrue(
+                self._wait_until_grafana_ready(host_port),
+                "the Grafana container never became ready; inspect the "
+                "container logs for a password-file read failure",
+            )
+
+            # Prove the mounted production ini denies unauthenticated admin
+            # access, and that the generated password still authenticates.
+            # With anonymous Viewer, a bad Basic credential falls through to
+            # Viewer (403) instead of 401; neither status is org-admin.
+            self.assertIn(
+                self._grafana_api_status(
+                    GRAFANA_ORG_ADMIN_API, host_port, password=None
+                ),
+                (HTTP_STATUS_UNAUTHORIZED, HTTP_STATUS_FORBIDDEN),
+                "unauthenticated callers must not receive org-admin access",
+            )
+            self.assertIn(
+                self._grafana_api_status(
+                    GRAFANA_ORG_ADMIN_API, host_port, "definitely-not-the-password"
+                ),
+                (HTTP_STATUS_UNAUTHORIZED, HTTP_STATUS_FORBIDDEN),
+                "an unknown admin password must not receive org-admin access",
+            )
+            self.assertEqual(
+                self._grafana_api_status(GRAFANA_ORG_ADMIN_API, host_port, password),
+                HTTP_STATUS_OK,
+                "the generated admin password from the mounted file was "
+                "rejected by a ready Grafana",
+            )
+        finally:
+            self._run_subprocess(
+                [self.container_runtime, "rm", "-f", self.GRAFANA_CONTAINER_NAME],
+                timeout=30,
+            )
+        self.print_test_result(
+            True,
+            "production ini denied unauthenticated admin; password-file admin worked",
+        )
+
+    def _published_host_port(self) -> str:
+        """Resolve the host port Docker assigned to the container's 3000."""
+        result = self._run_subprocess(
+            [
+                self.container_runtime,
+                "port",
+                self.GRAFANA_CONTAINER_NAME,
+                "3000",
+            ],
+            timeout=10,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"could not resolve the published Grafana port: {result.stderr}",
+        )
+        first_binding = result.stdout.strip().splitlines()[0]
+        return first_binding.rsplit(":", 1)[-1]
+
+    def _wait_until_grafana_ready(self, host_port: str) -> bool:
+        """Poll the unauthenticated health endpoint until Grafana answers."""
+        deadline = time.time() + GRAFANA_READY_TIMEOUT
+        while time.time() < deadline:
+            if (
+                self._grafana_api_status("/api/health", host_port, password=None)
+                == HTTP_STATUS_OK
+            ):
+                return True
+            time.sleep(2)
+        return False
+
+    def _grafana_api_status(
+        self, api_path: str, host_port: str, password: str | None
+    ) -> int | None:
+        """Return the HTTP status of *api_path*, or ``None`` when unreachable."""
+        url = f"http://127.0.0.1:{host_port}{api_path}"
+        headers = {}
+        if password is not None:
+            credentials = base64.b64encode(
+                f"{gc.GRAFANA_ADMIN_USER}:{password}".encode()
+            ).decode("ascii")
+            headers["Authorization"] = f"Basic {credentials}"
+        request = urllib_request.Request(url, headers=headers)
+        try:
+            with urllib_request.urlopen(request, timeout=5) as response:
+                return response.status
+        except urllib_error.HTTPError as error:
+            return error.code
+        except Exception:
+            return None

--- a/src/vllm-sr/cli/commands/runtime_paths.py
+++ b/src/vllm-sr/cli/commands/runtime_paths.py
@@ -316,8 +316,27 @@ def read_private_state_bytes(path: Path) -> bytes | None:
 
     Hardening is unconditional, so this must not be used on a file written with
     a relaxed ``mode`` for a container to read: reading it back would revoke the
-    access the relaxed mode exists to grant.
+    access the relaxed mode exists to grant. Use
+    :func:`read_container_readable_state_bytes` for those files instead.
     """
+
+    return _read_state_file_bytes(path, harden_permissions=True)
+
+
+def read_container_readable_state_bytes(path: Path) -> bytes | None:
+    """Read a container-readable state file without revoking its relaxed mode.
+
+    The owner-only reader above would chmod such a file back to 0600, revoking
+    the access the relaxed mode grants the container uid after bind mount. A
+    missing file returns ``None``; any mode other than the two this module
+    writes is a hard error.
+    """
+
+    return _read_state_file_bytes(path, harden_permissions=False)
+
+
+def _read_state_file_bytes(path: Path, *, harden_permissions: bool) -> bytes | None:
+    """Open one validated runtime-state file, optionally hardening its mode."""
 
     path = path.expanduser().absolute()
     directory = _create_or_harden_private_directory(path.parent)
@@ -343,7 +362,10 @@ def read_private_state_bytes(path: Path) -> bytes | None:
             raise ValueError(
                 f"Runtime state file exceeds {MAX_PRIVATE_STATE_BYTES} bytes: {path}"
             )
-        _harden_private_state_file(fd, info, path)
+        if harden_permissions:
+            _harden_private_state_file(fd, info, path)
+        else:
+            _reject_unexpected_state_file_mode(info, path)
         handle = os.fdopen(fd, "rb")
         fd = -1
         with handle:
@@ -351,6 +373,23 @@ def read_private_state_bytes(path: Path) -> bytes | None:
     finally:
         if fd >= 0:
             os.close(fd)
+
+
+def _reject_unexpected_state_file_mode(info: os.stat_result, path: Path) -> None:
+    """Fail closed unless a file carries one of the modes this module writes."""
+
+    current_user_id = _current_posix_user_id()
+    if current_user_id is None:
+        return
+    if info.st_uid != current_user_id:
+        raise ValueError(
+            f"Runtime state file must be owned by the current user: {path}"
+        )
+    if stat.S_IMODE(info.st_mode) not in {
+        PRIVATE_STATE_FILE_MODE,
+        CONTAINER_READABLE_STATE_FILE_MODE,
+    }:
+        raise ValueError(f"Runtime state file has unexpected permissions: {path}")
 
 
 def _harden_private_state_file(fd: int, info: os.stat_result, path: Path) -> None:

--- a/src/vllm-sr/cli/container_support_services.py
+++ b/src/vllm-sr/cli/container_support_services.py
@@ -20,6 +20,11 @@ from cli.container_observability import (
 )
 from cli.container_runtime import get_container_runtime
 from cli.container_services import _replace_existing_container
+from cli.grafana_credentials import (
+    CONTAINER_GRAFANA_PASSWORD_PATH,
+    GRAFANA_ADMIN_PASSWORD_FILE_ENV,
+    ensure_grafana_admin_password_file,
+)
 from cli.runtime_stack import RuntimeStackLayout, resolve_runtime_stack
 from cli.utils import get_logger
 
@@ -143,6 +148,12 @@ def container_start_grafana(
             stack_layout,
         )
 
+    # Resolves and materializes the admin password into a file the value is
+    # bind-mounted from, so the mount source always exists (never in argv/env).
+    password_file = ensure_grafana_admin_password_file(
+        config_dir, stack_layout=stack_layout
+    )
+
     cmd = [
         runtime,
         "run",
@@ -152,9 +163,12 @@ def container_start_grafana(
         "--network",
         network_name,
         "-e",
-        "GF_SECURITY_ADMIN_USER=admin",
-        "-e",
-        "GF_SECURITY_ADMIN_PASSWORD=admin",
+        f"{GRAFANA_ADMIN_PASSWORD_FILE_ENV}={CONTAINER_GRAFANA_PASSWORD_PATH}",
+        "-v",
+        (
+            f"{os.path.abspath(password_file)}:"
+            f"{CONTAINER_GRAFANA_PASSWORD_PATH}:ro,z"
+        ),
         "-e",
         f"PROMETHEUS_URL={stack_layout.prometheus_container_name}:9090",
         "-v",
@@ -168,7 +182,7 @@ def container_start_grafana(
         "-v",
         f"{os.path.abspath(os.path.join(grafana_dir, 'llm-router-dashboard.serve.json'))}:/etc/grafana/provisioning/dashboards/llm-router-dashboard.json:ro",
         "-p",
-        f"{stack_layout.grafana_port}:3000",
+        f"127.0.0.1:{stack_layout.grafana_port}:3000",
         "docker.io/grafana/grafana:11.5.1",
     ]
     return _run_service_start(cmd, "Grafana")

--- a/src/vllm-sr/cli/core.py
+++ b/src/vllm-sr/cli/core.py
@@ -282,6 +282,7 @@ def _start_vllm_sr_locked(
         dashboard_disabled,
         enable_observability,
         started_backends=started_backends,
+        state_root_dir=state_root_dir,
     )
 
 

--- a/src/vllm-sr/cli/grafana_credentials.py
+++ b/src/vllm-sr/cli/grafana_credentials.py
@@ -1,0 +1,70 @@
+"""Per-stack Grafana admin password for the local observability stack.
+
+Host ``GF_SECURITY_ADMIN_PASSWORD`` overwrites the file; otherwise a generated
+value is persisted and reused. The value reaches the container only through a
+bind-mounted file (``GF_SECURITY_ADMIN_PASSWORD__FILE``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from secrets import token_urlsafe
+
+from cli.commands.runtime_paths import (
+    CONTAINER_READABLE_STATE_FILE_MODE,
+    private_runtime_state_subdirectory,
+    read_container_readable_state_bytes,
+    write_private_state_bytes,
+)
+from cli.consts import DEFAULT_STACK_NAME
+from cli.runtime_stack import RuntimeStackLayout, resolve_runtime_stack
+
+GRAFANA_ADMIN_USER = "admin"
+GRAFANA_ADMIN_PASSWORD_ENV = "GF_SECURITY_ADMIN_PASSWORD"
+GRAFANA_ADMIN_PASSWORD_FILE_ENV = "GF_SECURITY_ADMIN_PASSWORD__FILE"
+
+SECRET_TOKEN_BYTES = 32
+
+CONTAINER_GRAFANA_PASSWORD_PATH = "/run/secrets/grafana-admin-password"
+
+GRAFANA_CREDENTIALS_DIRECTORY = "grafana-credentials"
+
+
+def _stack_filename(base: str, stack_layout: RuntimeStackLayout) -> str:
+    if stack_layout.stack_name == DEFAULT_STACK_NAME:
+        return base
+    return f"{base}.{stack_layout.stack_name}"
+
+
+def grafana_password_path(
+    state_root_dir: str | Path, *, stack_layout: RuntimeStackLayout | None = None
+) -> Path:
+    """Host path of the password file the Grafana container is mounted from."""
+    layout = stack_layout or resolve_runtime_stack()
+    return private_runtime_state_subdirectory(
+        state_root_dir, GRAFANA_CREDENTIALS_DIRECTORY
+    ) / _stack_filename("admin-password", layout)
+
+
+def ensure_grafana_admin_password_file(
+    state_root_dir: str | Path, *, stack_layout: RuntimeStackLayout | None = None
+) -> Path:
+    """Materialize the admin password into a container-readable file to mount.
+
+    Grafana runs as an unprivileged uid and cannot read a bind-mounted 0600
+    file; privacy comes from the enclosing owner-only directory.
+    """
+
+    layout = stack_layout or resolve_runtime_stack()
+    path = grafana_password_path(state_root_dir, stack_layout=layout)
+    explicit = os.getenv(GRAFANA_ADMIN_PASSWORD_ENV)
+    if explicit:
+        stored = explicit.encode("utf-8")
+    else:
+        stored = read_container_readable_state_bytes(path)
+        if stored is None:
+            stored = token_urlsafe(SECRET_TOKEN_BYTES).encode("utf-8")
+    # Rewriting every serve restores the value and its container-readable mode.
+    write_private_state_bytes(path, stored, mode=CONTAINER_READABLE_STATE_FILE_MODE)
+    return path

--- a/src/vllm-sr/cli/runtime_lifecycle.py
+++ b/src/vllm-sr/cli/runtime_lifecycle.py
@@ -27,6 +27,7 @@ from cli.container_cli import (
     container_stop_container,
     load_openclaw_registry,
 )
+from cli.grafana_credentials import grafana_password_path
 from cli.runtime_stack import RuntimeStackLayout
 from cli.terminal import echo, fields, heading, progress, success
 from cli.utils import get_logger
@@ -346,6 +347,7 @@ def log_runtime_summary(
     dashboard_disabled: bool,
     enable_observability: bool,
     started_backends: set[str] | None = None,
+    state_root_dir: str | None = None,
 ) -> None:
     """Print the local endpoints and common follow-up commands."""
     success("vLLM Semantic Router is running")
@@ -377,13 +379,21 @@ def log_runtime_summary(
     if enable_observability:
         echo()
         heading("Observability")
-        fields(
-            (
-                ("Jaeger UI", stack_layout.jaeger_ui_url),
-                ("Grafana", f"{stack_layout.grafana_url} (admin/admin)"),
-                ("Prometheus", stack_layout.prometheus_url),
+        observability = [
+            ("Jaeger UI", stack_layout.jaeger_ui_url),
+            ("Grafana", stack_layout.grafana_url),
+        ]
+        if state_root_dir is not None:
+            observability.append(
+                (
+                    "Grafana admin password file",
+                    str(
+                        grafana_password_path(state_root_dir, stack_layout=stack_layout)
+                    ),
+                )
             )
-        )
+        observability.append(("Prometheus", stack_layout.prometheus_url))
+        fields(observability)
 
     _log_runtime_commands(dashboard_disabled)
     _print_curl_example(listeners, stack_layout)

--- a/src/vllm-sr/cli/templates/grafana.serve.ini
+++ b/src/vllm-sr/cli/templates/grafana.serve.ini
@@ -2,37 +2,39 @@
 # This file configures Grafana to allow embedding in the dashboard
 
 [security]
-# Allow embedding Grafana in iframes
+# Allow embedding Grafana in the dashboard iframe (X-Frame-Options).
 allow_embedding = true
 
-# Set cookie SameSite attribute to none to allow cross-origin requests in iframes
-cookie_samesite = none
+# The dashboard embeds Grafana through the same-origin /embedded/grafana/
+# proxy, so Lax cookies work for the iframe and for the password-file admin
+# session. SameSite=None is not used: browsers require Secure with None, and
+# None would attach an admin session to cross-site HTTP requests.
+cookie_samesite = lax
 
-# Disable cookie secure flag for local development (set to true in production with HTTPS)
-# Note: When cookie_samesite=none, cookie_secure should be true in production
+# Local vllm-sr serve is HTTP. Secure cookies would not be stored.
 cookie_secure = false
 
 # Disable strict transport security for local development
 strict_transport_security = false
 
 [auth.anonymous]
-# Enable anonymous access for iframe embedding
+# Viewer-only anonymous access keeps the dashboard iframe working. The host
+# port is loopback-only; anonymous Admin would still bypass the password-file
+# credential for any local process that can reach it.
 enabled = true
-
-# Set the organization role for anonymous users to Admin for full access
-org_role = Admin
+org_role = Viewer
 
 # Set the home dashboard for anonymous users
 # This ensures anonymous users land on the correct dashboard
 org_name = Main Org.
 
 [auth]
-# Disable login form to allow anonymous access only
-disable_login_form = true
+# Keep the login form so the password-file admin can authenticate.
+disable_login_form = false
 
 [auth.basic]
-# Disable basic authentication
-enabled = false
+# Basic auth is how the mounted password-file credential protects the API.
+enabled = true
 
 [server]
 # Configure root URL for proxy access

--- a/src/vllm-sr/tests/test_grafana_credentials.py
+++ b/src/vllm-sr/tests/test_grafana_credentials.py
@@ -1,0 +1,224 @@
+"""Tests for per-stack Grafana admin credentials and the Grafana container wiring."""
+
+import configparser
+import os
+import stat
+from pathlib import Path
+
+from cli import container_support_services, runtime_lifecycle
+from cli import grafana_credentials as gc
+from cli.main import main
+from cli.runtime_stack import resolve_runtime_stack
+from click.testing import CliRunner
+
+GRAFANA_SERVE_INI_TEMPLATE = (
+    Path(gc.__file__).resolve().parent / "templates" / "grafana.serve.ini"
+)
+CONTAINER_GRAFANA_INI_PATH = "/etc/grafana/grafana.ini"
+
+
+def _file_mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _password(tmp_path: Path, layout) -> str:
+    return gc.ensure_grafana_admin_password_file(
+        tmp_path, stack_layout=layout
+    ).read_text(encoding="utf-8")
+
+
+def _parse_grafana_ini(path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+    read = parser.read(path)
+    assert read, f"failed to parse Grafana ini at {path}"
+    return parser
+
+
+def _assert_ini_denies_anonymous_admin(path: Path) -> None:
+    """Anonymous users may view dashboards; they must not be org admins."""
+    ini = _parse_grafana_ini(path)
+    assert ini.getboolean("auth.anonymous", "enabled") is True
+    assert ini.get("auth.anonymous", "org_role") == "Viewer"
+    assert ini.getboolean("auth.basic", "enabled") is True
+    assert ini.getboolean("auth", "disable_login_form") is False
+    assert ini.get("security", "cookie_samesite") == "lax"
+    assert ini.getboolean("security", "cookie_secure") is False
+
+
+def _monkeypatch_grafana_container(monkeypatch, captured, *, render_templates=False):
+    monkeypatch.setattr(
+        container_support_services, "get_container_runtime", lambda: "docker"
+    )
+    monkeypatch.setattr(
+        container_support_services, "_replace_existing_container", lambda _name: None
+    )
+    if not render_templates:
+        monkeypatch.setattr(
+            container_support_services, "_render_template_copy", lambda *_a, **_k: None
+        )
+    monkeypatch.setattr(
+        container_support_services,
+        "_run_service_start",
+        lambda cmd, _label: captured.update(cmd=cmd) or (0, "", ""),
+    )
+
+
+def test_fresh_stack_generates_and_reuses_a_container_readable_password_file(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.delenv(gc.GRAFANA_ADMIN_PASSWORD_ENV, raising=False)
+    layout = resolve_runtime_stack()
+    path = gc.grafana_password_path(tmp_path, stack_layout=layout)
+
+    first = _password(tmp_path, layout)
+    second = _password(tmp_path, layout)
+
+    assert len(first) >= 40
+    assert first == second, "a restart must keep the same credential"
+    assert path.exists()
+    assert _file_mode(path.parent) == 0o700
+    assert _file_mode(path) == 0o644
+    assert path.read_text(encoding="utf-8") == first
+    assert not path.read_bytes().endswith(b"\n")
+
+
+def test_explicit_env_password_is_materialized_for_the_container(
+    monkeypatch, tmp_path: Path
+):
+    explicit = "operator-provided-password"
+    monkeypatch.setenv(gc.GRAFANA_ADMIN_PASSWORD_ENV, explicit)
+    layout = resolve_runtime_stack()
+
+    path = gc.ensure_grafana_admin_password_file(tmp_path, stack_layout=layout)
+
+    assert path == gc.grafana_password_path(tmp_path, stack_layout=layout)
+    assert path.read_text(encoding="utf-8") == explicit
+    assert _password(tmp_path, layout) == explicit
+    assert _file_mode(path.parent) == 0o700
+    assert _file_mode(path) == 0o644
+    assert not path.read_bytes().endswith(b"\n")
+
+
+def test_each_stack_gets_its_own_password_file(monkeypatch, tmp_path: Path):
+    monkeypatch.delenv(gc.GRAFANA_ADMIN_PASSWORD_ENV, raising=False)
+    default_layout = resolve_runtime_stack()
+    custom_layout = resolve_runtime_stack(stack_name="team-b", port_offset=100)
+
+    default_path = gc.grafana_password_path(tmp_path, stack_layout=default_layout)
+    custom_path = gc.grafana_password_path(tmp_path, stack_layout=custom_layout)
+
+    assert default_path != custom_path
+    assert _password(tmp_path, default_layout) != _password(tmp_path, custom_layout)
+
+
+def test_grafana_container_reads_password_from_secret_file_never_argv(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.delenv(gc.GRAFANA_ADMIN_PASSWORD_ENV, raising=False)
+    captured: dict[str, object] = {}
+    _monkeypatch_grafana_container(monkeypatch, captured)
+    layout = resolve_runtime_stack()
+    (tmp_path / ".vllm-sr").mkdir(mode=0o700)
+
+    container_support_services.container_start_grafana(
+        "test-network", str(tmp_path), stack_layout=layout
+    )
+
+    command = list(captured["cmd"])
+    password = _password(tmp_path, layout)
+    mounted = gc.grafana_password_path(tmp_path, stack_layout=layout)
+    assert _file_mode(mounted) == 0o644
+    assert (
+        f"{gc.GRAFANA_ADMIN_PASSWORD_FILE_ENV}=" f"{gc.CONTAINER_GRAFANA_PASSWORD_PATH}"
+    ) in command
+    assert (
+        f"{tmp_path}/.vllm-sr/grafana-credentials/admin-password:"
+        f"{gc.CONTAINER_GRAFANA_PASSWORD_PATH}:ro,z"
+    ) in command
+    assert "GF_SECURITY_ADMIN_PASSWORD=admin" not in command
+    assert password not in command
+    assert not any(arg.startswith("GF_SECURITY_ADMIN_PASSWORD=") for arg in command)
+    assert not any(arg.startswith("GF_SECURITY_ADMIN_USER=") for arg in command)
+
+
+def test_grafana_container_mounts_the_explicit_password_file(monkeypatch, tmp_path):
+    explicit = "operator-supplied-password"
+    monkeypatch.setenv(gc.GRAFANA_ADMIN_PASSWORD_ENV, explicit)
+    captured: dict[str, object] = {}
+    _monkeypatch_grafana_container(monkeypatch, captured)
+    layout = resolve_runtime_stack()
+    (tmp_path / ".vllm-sr").mkdir(mode=0o700)
+
+    container_support_services.container_start_grafana(
+        "test-network", str(tmp_path), stack_layout=layout
+    )
+
+    command = list(captured["cmd"])
+    path = gc.grafana_password_path(tmp_path, stack_layout=layout)
+    assert path.is_file()
+    assert path.read_text(encoding="utf-8") == explicit
+    assert _file_mode(path) == 0o644
+    assert (
+        f"{gc.GRAFANA_ADMIN_PASSWORD_FILE_ENV}=" f"{gc.CONTAINER_GRAFANA_PASSWORD_PATH}"
+    ) in command
+    assert f"{path}:{gc.CONTAINER_GRAFANA_PASSWORD_PATH}:ro,z" in command
+    assert explicit not in command
+    assert not any(arg.startswith("GF_SECURITY_ADMIN_PASSWORD=") for arg in command)
+
+
+def test_shipped_grafana_ini_restricts_anonymous_users_to_viewer():
+    _assert_ini_denies_anonymous_admin(GRAFANA_SERVE_INI_TEMPLATE)
+
+
+def test_grafana_container_renders_and_mounts_ini_without_anonymous_admin(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.delenv(gc.GRAFANA_ADMIN_PASSWORD_ENV, raising=False)
+    captured: dict[str, object] = {}
+    _monkeypatch_grafana_container(monkeypatch, captured, render_templates=True)
+    layout = resolve_runtime_stack()
+    (tmp_path / ".vllm-sr").mkdir(mode=0o700)
+
+    container_support_services.container_start_grafana(
+        "test-network", str(tmp_path), stack_layout=layout
+    )
+
+    rendered = tmp_path / ".vllm-sr" / "grafana" / "grafana.serve.ini"
+    _assert_ini_denies_anonymous_admin(rendered)
+    command = list(captured["cmd"])
+    assert f"{os.path.abspath(rendered)}:{CONTAINER_GRAFANA_INI_PATH}:ro" in command
+    assert f"127.0.0.1:{layout.grafana_port}:3000" in command
+
+
+def test_runtime_summary_prints_the_admin_password_file_path_not_the_secret(
+    monkeypatch, tmp_path: Path, capsys
+):
+    explicit = "operator-supplied-password"
+    monkeypatch.setenv(gc.GRAFANA_ADMIN_PASSWORD_ENV, explicit)
+    stack_layout = resolve_runtime_stack(stack_name="terminal-test", port_offset=200)
+    password_file = gc.grafana_password_path(tmp_path, stack_layout=stack_layout)
+
+    runtime_lifecycle.log_runtime_summary(
+        [{"name": "http-8899", "port": 8899}],
+        stack_layout,
+        dashboard_disabled=False,
+        enable_observability=True,
+        started_backends={"postgres", "redis"},
+        state_root_dir=str(tmp_path),
+    )
+
+    captured = capsys.readouterr()
+    compact = "".join(captured.out.split())
+    assert stack_layout.grafana_url in captured.out
+    assert "Grafana admin password file" in captured.out
+    assert "grafana-credentials" in compact
+    assert password_file.name in captured.out
+    assert "(admin/admin)" not in captured.out
+    assert "generated admin password" not in captured.out
+    assert explicit not in captured.out
+
+
+def test_main_cli_help_does_not_mention_admin_password(monkeypatch):
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "admin/admin" not in result.output

--- a/src/vllm-sr/tests/test_runtime_lifecycle.py
+++ b/src/vllm-sr/tests/test_runtime_lifecycle.py
@@ -79,7 +79,7 @@ def test_wait_for_router_health_reads_bearer_from_container_environment(monkeypa
     assert "secret-value" not in repr(command)
 
 
-def test_runtime_summary_is_clean_human_stdout(capsys):
+def test_runtime_summary_is_clean_human_stdout(capsys, tmp_path):
     stack_layout = resolve_runtime_stack(stack_name="terminal-test", port_offset=200)
 
     runtime_lifecycle.log_runtime_summary(
@@ -88,6 +88,7 @@ def test_runtime_summary_is_clean_human_stdout(capsys):
         dashboard_disabled=False,
         enable_observability=True,
         started_backends={"postgres", "redis"},
+        state_root_dir=str(tmp_path),
     )
 
     captured = capsys.readouterr()
@@ -98,6 +99,7 @@ def test_runtime_summary_is_clean_human_stdout(capsys):
     assert "http://localhost:9099" in captured.out
     assert "Storage" in captured.out
     assert "Observability" in captured.out
+    assert "Grafana admin password file" in captured.out
     assert "Commands" in captured.out
     assert "Try it" in captured.out
 

--- a/src/vllm-sr/tests/test_runtime_paths.py
+++ b/src/vllm-sr/tests/test_runtime_paths.py
@@ -376,3 +376,52 @@ def test_materialize_uses_custom_host_state_without_container_path_leak(
 
     assert active == state_root / ".vllm-sr" / "runtime-config.audit-a.yaml"
     assert not (source.parent / ".vllm-sr").exists()
+
+
+def test_container_readable_state_reader_does_not_revoke_relaxed_mode(
+    tmp_path: Path,
+):
+    # Regression: reading a 0644 secret must not chmod it back to 0600.
+    target = tmp_path / "secret"
+    runtime_paths.write_private_state_bytes(
+        target,
+        b"value\n",
+        mode=runtime_paths.CONTAINER_READABLE_STATE_FILE_MODE,
+    )
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+    data = runtime_paths.read_container_readable_state_bytes(target)
+
+    assert data == b"value\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+def test_container_readable_state_reader_accepts_an_owner_only_file(
+    tmp_path: Path,
+):
+    target = tmp_path / "secret"
+    runtime_paths.write_private_state_bytes(target, b"value\n")
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    data = runtime_paths.read_container_readable_state_bytes(target)
+
+    assert data == b"value\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_container_readable_state_reader_returns_none_for_a_missing_file(
+    tmp_path: Path,
+):
+    target = tmp_path / "absent"
+    assert runtime_paths.read_container_readable_state_bytes(target) is None
+
+
+def test_container_readable_state_reader_rejects_an_unexpected_mode(
+    tmp_path: Path,
+):
+    target = tmp_path / "secret"
+    runtime_paths.write_private_state_bytes(target, b"value\n")
+    os.chmod(target, 0o666)
+
+    with pytest.raises(ValueError, match="unexpected permissions"):
+        runtime_paths.read_container_readable_state_bytes(target)


### PR DESCRIPTION
Closes #3276

## Purpose

Fixes a security weakness in the local support stack: Grafana was always started with a source-controlled `GF_SECURITY_ADMIN_PASSWORD=admin` and no way to override it. The mounted production `grafana.serve.ini` also granted anonymous users the Admin role, so a generated password would not have blocked administrator access.

Mirrors the generated-per-stack secret pattern already used for Postgres/Redis (#2485):

- **Explicit override wins**: an operator-set host `GF_SECURITY_ADMIN_PASSWORD` is used verbatim and materialized into the per-stack secret file, so the container always mounts a real source.
- **Otherwise generated per stack**: a 256-bit CSPRNG value minted once, persisted per stack, and reused on later `serve` calls so a restart keeps the same credential.
- **Never exposed**: the value is handed to Grafana only through a bind-mounted secret file (`GF_SECURITY_ADMIN_PASSWORD__FILE`), so it never reaches argv, `docker inspect .Config.Env`, a config file, or a log.
- **Well-defined lifecycle**: restarting keeps the same credential; the env overwrites that one file, and unsetting it reuses whatever is already persisted.
- **Anonymous is Viewer**: `grafana.serve.ini` keeps anonymous access for the dashboard iframe but not Admin; login form and basic auth stay enabled so the password-file admin can authenticate.
- **Loopback publish**: Grafana's host port binds to `127.0.0.1`.
- The serve summary prints the password file path, never the secret, and no longer advertises `(admin/admin)`.

Affected modules (Python CLI): 
- `src/vllm-sr/cli/grafana_credentials.py` (new) — per-stack Grafana admin password file (env overwrite or generated reuse)
- `src/vllm-sr/cli/commands/runtime_paths.py` — container-readable state-file reader that does not revoke 0644 on read-back
- `src/vllm-sr/cli/container_support_services.py` — `container_start_grafana` mounts the materialized secret file instead of injecting the credential directly, and publishes Grafana on loopback
- `src/vllm-sr/cli/templates/grafana.serve.ini` — anonymous Viewer, authenticated admin path
- `src/vllm-sr/cli/runtime_lifecycle.py` — print the password file path instead of `(admin/admin)`
- `src/vllm-sr/tests/test_grafana_credentials.py` (new) — regression coverage
- `e2e/testing/vllm-sr-cli/test_integration_grafana_credentials.py` (new) — real Grafana with the production ini; unauthenticated org-admin requests are denied

## Test Plan

```bash
cd src/vllm-sr
python3 -m pytest tests/test_grafana_credentials.py \
  tests/test_runtime_lifecycle.py \
  tests/test_container_services.py \
  tests/test_storage_secrets.py \
  tests/test_storage_backends.py \
  tests/test_runtime_support.py \
  tests/test_runtime_stack_naming.py \
  tests/test_grafana_dashboard_template.py -q
```

## Test Result

All 114 related tests pass. `test_grafana_credentials.py` adds nine cases covering generation/reuse, explicit-env materialization into the same per-stack file, per-stack isolation, container regressions proving both auto and explicit paths mount a real secret file while the password never appears in argv, production ini restricting anonymous users to Viewer with loopback publish, and the serve summary printing the password file path rather than the secret.
