### PR TITLE
[Community] Update Workgroup roster · 2026-09-01

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -65,11 +65,6 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/yaojiejia.png',
         profile: 'https://github.com/yaojiejia',
       },
-      {
-        name: 'wuli666',
-        avatar: 'https://github.com/wuli666.png',
-        profile: 'https://github.com/wuli666',
-      },
     ],
   },
   {
@@ -130,16 +125,6 @@ export const workGroups: WorkGroup[] = [
         name: 'Guan-Ming Chiu',
         avatar: 'https://github.com/guan404ming.png',
         profile: 'https://github.com/guan404ming',
-      },
-      {
-        name: 'Pranav Thakur',
-        avatar: 'https://github.com/pranavthakur0-0.png',
-        profile: 'https://github.com/pranavthakur0-0',
-      },
-      {
-        name: 'bugkeep',
-        avatar: 'https://github.com/bugkeep.png',
-        profile: 'https://github.com/bugkeep',
       },
     ],
   },
@@ -315,11 +300,6 @@ export const workGroups: WorkGroup[] = [
         name: 'Eda Zhou',
         avatar: 'https://github.com/edamamez.png',
         profile: 'https://github.com/edamamez',
-      },
-      {
-        name: 'wuli666',
-        avatar: 'https://github.com/wuli666.png',
-        profile: 'https://github.com/wuli666',
       },
     ],
   },

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -126,6 +126,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/guan404ming.png',
         profile: 'https://github.com/guan404ming',
       },
+      {
+        name: 'bugkeep',
+        avatar: 'https://github.com/bugkeep.png',
+        profile: 'https://github.com/bugkeep',
+      },
     ],
   },
   {

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -70,6 +70,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/wuli666.png',
         profile: 'https://github.com/wuli666',
       },
+      {
+        name: 'Mahdi Ghodsi',
+        avatar: 'https://github.com/Mahdi-CV.png',
+        profile: 'https://github.com/Mahdi-CV',
+      },
     ],
   },
   {
@@ -187,6 +192,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Bevisy.png',
         profile: 'https://github.com/Bevisy',
       },
+      {
+        name: 'bugkeep',
+        avatar: 'https://github.com/bugkeep.png',
+        profile: 'https://github.com/bugkeep',
+      },
     ],
   },
   {
@@ -265,6 +275,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/yaojiejia.png',
         profile: 'https://github.com/yaojiejia',
       },
+      {
+        name: 'Binbin Zhang',
+        avatar: 'https://github.com/Bevisy.png',
+        profile: 'https://github.com/Bevisy',
+      },
     ],
   },
   {
@@ -316,6 +331,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/wuli666.png',
         profile: 'https://github.com/wuli666',
       },
+      {
+        name: 'Park Soobin',
+        avatar: 'https://github.com/subin9.png',
+        profile: 'https://github.com/subin9',
+      },
     ],
   },
   {
@@ -346,6 +366,11 @@ export const workGroups: WorkGroup[] = [
         name: 'Nanasis',
         avatar: 'https://github.com/nanasis.png',
         profile: 'https://github.com/nanasis',
+      },
+      {
+        name: 'Hikari',
+        avatar: 'https://github.com/altale.png',
+        profile: 'https://github.com/altale',
       },
     ],
   },

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -70,11 +70,6 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/wuli666.png',
         profile: 'https://github.com/wuli666',
       },
-      {
-        name: 'Mahdi Ghodsi',
-        avatar: 'https://github.com/Mahdi-CV.png',
-        profile: 'https://github.com/Mahdi-CV',
-      },
     ],
   },
   {
@@ -191,11 +186,6 @@ export const workGroups: WorkGroup[] = [
         name: 'Binbin Zhang',
         avatar: 'https://github.com/Bevisy.png',
         profile: 'https://github.com/Bevisy',
-      },
-      {
-        name: 'bugkeep',
-        avatar: 'https://github.com/bugkeep.png',
-        profile: 'https://github.com/bugkeep',
       },
     ],
   },
@@ -331,11 +321,6 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/wuli666.png',
         profile: 'https://github.com/wuli666',
       },
-      {
-        name: 'Park Soobin',
-        avatar: 'https://github.com/subin9.png',
-        profile: 'https://github.com/subin9',
-      },
     ],
   },
   {
@@ -366,11 +351,6 @@ export const workGroups: WorkGroup[] = [
         name: 'Nanasis',
         avatar: 'https://github.com/nanasis.png',
         profile: 'https://github.com/nanasis',
-      },
-      {
-        name: 'Hikari',
-        avatar: 'https://github.com/altale.png',
-        profile: 'https://github.com/altale',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- require every roster target to match the contributor's genuine Workgroup application and qualifying contribution
- add @Bevisy to Agentic & Context using matching Agentic evidence
- remove three application-mismatched memberships introduced by #3262
- preserve @bugkeep in Router Models after a new first-person Router Models application completed the same-Workgroup evidence

## Eligible promotion

| Applicant | Workgroup | Role | Application | Qualifying contribution |
| --- | --- | --- | --- | --- |
| @Bevisy | Agentic & Context | Member | [Agentic & Context application](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5497454627) | [PR #3287](https://github.com/vllm-project/semantic-router/pull/3287) |

## Roster reconciliation

| Contributor | Result | Evidence |
| --- | --- | --- |
| @wuli666 | Remove MoM & Routing and Developer Experience & Ecosystem | Applications remain [Router Models](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5460563182) and [Agentic & Context](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5460567718) |
| @pranavthakur0-0 | Remove Router Models & Inference Runtime | Application remains [Agentic & Context](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5406937090) |
| @bugkeep | Preserve Router Models & Inference Runtime | New [Router Models application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5502678188) and matching [PR #3085](https://github.com/vllm-project/semantic-router/pull/3085) |

The earlier unmerged cross-Workgroup draft additions remain absent. All unrelated roster content and application-aligned memberships are preserved.

## Validation

- `git diff --check`
- Node v24.18.1: verified seven Workgroups, case-insensitive per-Workgroup login uniqueness, and the exact targeted memberships
- `make agent-report ENV=cpu CHANGED_FILES="website/src/data/workGroups.ts"` (lightweight docs-only classification)
- `make agent-ci-gate CHANGED_FILES="website/src/data/workGroups.ts"` (JavaScript/TypeScript lint, supply-chain scan, and structure checks passed)

Related #2965, #2966, #2970, #2987
