### PR TITLE
[Feature] Add external gateway Responses state profile

### DIFF
--- a/deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml
+++ b/deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml
@@ -1,0 +1,106 @@
+replicaCount: 1
+
+# ExtProc-only Responses state and protocol conversion. The external gateway
+# owns the public listener, route, backend, credentials, and traffic policy.
+# Replace the chart's example routing config atomically. Using `config` here
+# would recursively merge in its placeholder default route and signals.
+configOverride:
+  version: v0.3
+  listeners: []
+  providers:
+    models:
+      # Protocol metadata only: intentionally no backend_refs or credentials.
+      - name: openai/gpt-oss-20b
+        api_format: openai
+  routing:
+    modelCards:
+      - name: openai/gpt-oss-20b
+  global:
+    router:
+      clear_route_cache: false
+      model_selection:
+        enabled: false
+    services:
+      response_api:
+        enabled: true
+        store_backend: memory
+        ttl_seconds: 86400
+        max_responses: 1000
+      router_replay:
+        enabled: false
+        store_backend: memory
+      observability:
+        tracing:
+          enabled: false
+    stores:
+      response_cache:
+        enabled: false
+      memory:
+        enabled: false
+    integrations:
+      tools:
+        enabled: false
+    model_catalog:
+      embeddings:
+        semantic:
+          qwen3_model_path: ""
+          gemma_model_path: ""
+          mmbert_model_path: ""
+          multimodal_model_path: ""
+          bert_model_path: ""
+          embedding_config:
+            preload_embeddings: false
+            enable_soft_matching: false
+      system:
+        prompt_guard: ""
+        domain_classifier: ""
+        pii_classifier: ""
+        fact_check_classifier: ""
+        hallucination_detector: ""
+        hallucination_explainer: ""
+        feedback_detector: ""
+      kbs: []
+      modules:
+        prompt_compression:
+          enabled: false
+        prompt_guard:
+          enabled: false
+          model_ref: ""
+          model_id: ""
+        classifier:
+          domain:
+            enabled: false
+            model_ref: ""
+            model_id: ""
+          mcp:
+            enabled: false
+          pii:
+            enabled: false
+            model_ref: ""
+            model_id: ""
+          preference:
+            use_contrastive: false
+            embedding_model: ""
+        hallucination_mitigation:
+          enabled: false
+          fact_check:
+            model_ref: ""
+            model_id: ""
+          detector:
+            model_ref: ""
+            model_id: ""
+          explainer:
+            model_ref: ""
+            model_id: ""
+        feedback_detector:
+          enabled: false
+          model_ref: ""
+          model_id: ""
+        modality_detector:
+          enabled: false
+
+service:
+  type: ClusterIP
+
+persistence:
+  enabled: false

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -115,6 +115,7 @@ until the selected cases are known to be isolated.
 ### Supported Profiles
 
 - **envoy-ai-gateway**: baseline routing, safety, cache, and decision contracts.
+- **external-gateway-responses**: ExtProc-only Responses create, get, and conversation chaining with external gateway-owned dispatch.
 - **dashboard**: dashboard API, validation, and routing-authoring contracts.
 - **aibrix**: AIBrix gateway and control-plane integration.
 - **routing-strategies**: keyword, entropy, and fallback routing.

--- a/e2e/profiles/all/imports.go
+++ b/e2e/profiles/all/imports.go
@@ -11,6 +11,7 @@ import (
 	dashboard "github.com/vllm-project/semantic-router/e2e/profiles/dashboard"
 	dynamicconfig "github.com/vllm-project/semantic-router/e2e/profiles/dynamic-config"
 	dynamo "github.com/vllm-project/semantic-router/e2e/profiles/dynamo"
+	externalgatewayresponses "github.com/vllm-project/semantic-router/e2e/profiles/external-gateway-responses"
 	hallucination "github.com/vllm-project/semantic-router/e2e/profiles/hallucination"
 	istio "github.com/vllm-project/semantic-router/e2e/profiles/istio"
 	jailbreakonerror "github.com/vllm-project/semantic-router/e2e/profiles/jailbreak-onerror"
@@ -71,6 +72,11 @@ func init() {
 	)
 	register("dynamic-config", func() framework.Profile { return dynamicconfig.NewProfile() }, framework.ProfileCapabilities{})
 	register("dynamo", func() framework.Profile { return dynamo.NewProfile() }, framework.ProfileCapabilities{RequiresGPU: true})
+	register(
+		"external-gateway-responses",
+		func() framework.Profile { return externalgatewayresponses.NewProfile() },
+		framework.ProfileCapabilities{LocalImages: mockVLLMLocalImages},
+	)
 	register(
 		"hallucination",
 		func() framework.Profile { return hallucination.NewProfile() },

--- a/e2e/profiles/all/imports_test.go
+++ b/e2e/profiles/all/imports_test.go
@@ -46,6 +46,21 @@ func TestEnvoyAIGatewayProfileKeepsKubernetesAlias(t *testing.T) {
 	}
 }
 
+func TestExternalGatewayResponsesProfileCoversStateContract(t *testing.T) {
+	profile, err := framework.NewProfileByName("external-gateway-responses")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"response-api-create",
+		"response-api-get",
+		"response-api-conversation-chaining",
+	}
+	if !reflect.DeepEqual(profile.GetTestCases(), want) {
+		t.Fatalf("external gateway Responses cases = %v, want %v", profile.GetTestCases(), want)
+	}
+}
+
 func TestProtocolCodecE2EMatrixProfilesAreClosed(t *testing.T) {
 	profiles := map[string][]string{
 		"response-api": {

--- a/e2e/profiles/external-gateway-responses/profile.go
+++ b/e2e/profiles/external-gateway-responses/profile.go
@@ -1,0 +1,59 @@
+package externalgatewayresponses
+
+import (
+	"context"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	gatewaystack "github.com/vllm-project/semantic-router/e2e/pkg/stacks/gateway"
+
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
+)
+
+const valuesFile = "deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml"
+
+var resourceManifests = []string{
+	"e2e/profiles/ai-gateway/gateway-resources/backend.yaml",
+	"deploy/kubernetes/ai-gateway/aigw-resources/gwapi-resources.yaml",
+	"e2e/profiles/ai-gateway/gateway-resources/responses-route.yaml",
+}
+
+// Profile verifies Responses state when an external gateway owns dispatch.
+type Profile struct {
+	stack *gatewaystack.Stack
+}
+
+func NewProfile() *Profile {
+	return &Profile{stack: gatewaystack.New(gatewaystack.Config{
+		Name:                     "external-gateway-responses",
+		SemanticRouterValuesFile: valuesFile,
+		ResourceManifests:        resourceManifests,
+	})}
+}
+
+func (p *Profile) Name() string {
+	return "external-gateway-responses"
+}
+
+func (p *Profile) Description() string {
+	return "Tests Responses state and conversion with external gateway-owned dispatch"
+}
+
+func (p *Profile) Setup(ctx context.Context, opts *framework.SetupOptions) error {
+	return p.stack.Setup(ctx, opts)
+}
+
+func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions) error {
+	return p.stack.Teardown(ctx, opts)
+}
+
+func (p *Profile) GetTestCases() []string {
+	return []string{
+		"response-api-create",
+		"response-api-get",
+		"response-api-conversation-chaining",
+	}
+}
+
+func (p *Profile) GetServiceConfig() framework.ServiceConfig {
+	return p.stack.ServiceConfig()
+}

--- a/src/semantic-router/pkg/config/external_gateway_responses_asset_test.go
+++ b/src/semantic-router/pkg/config/external_gateway_responses_asset_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+const externalGatewayResponsesValues = "deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml"
+
+func TestExternalGatewayResponsesProfileIsStateOnly(t *testing.T) {
+	cfg, err := ParseYAMLBytes(readValuesConfigAsset(t, externalGatewayResponsesValues))
+	if err != nil {
+		t.Fatalf("parse external gateway Responses profile: %v", err)
+	}
+
+	if cfg.ModelSelection.Enabled {
+		t.Fatal("external gateway Responses profile must not enable model selection")
+	}
+	if !cfg.ResponseAPI.Enabled {
+		t.Fatal("external gateway Responses profile must enable Responses state")
+	}
+	if cfg.ResponseAPI.StoreBackend != "memory" {
+		t.Fatalf("response store backend = %q, want memory for the minimal profile", cfg.ResponseAPI.StoreBackend)
+	}
+	if len(cfg.Listeners) != 0 {
+		t.Fatalf("external gateway owns public listeners, got %d Semantic Router listeners", len(cfg.Listeners))
+	}
+	if len(cfg.VLLMEndpoints) != 0 || len(cfg.ProviderProfiles) != 0 {
+		t.Fatalf("external gateway owns backends and credentials, got endpoints=%d provider_profiles=%d", len(cfg.VLLMEndpoints), len(cfg.ProviderProfiles))
+	}
+	if cfg.HasRoutingDecisions() || !reflect.DeepEqual(cfg.Signals, Signals{}) {
+		t.Fatalf("state-only profile must not declare decisions or routing signals: decisions=%d signals=%+v", len(cfg.AllRoutingDecisions()), cfg.Signals)
+	}
+
+	assertExternalGatewayModelMetadata(t, cfg)
+}
+
+func assertExternalGatewayModelMetadata(t *testing.T, cfg *RouterConfig) {
+	t.Helper()
+	const model = "openai/gpt-oss-20b"
+	if len(cfg.ModelConfig) != 1 {
+		t.Fatalf("model metadata entries = %d, want 1", len(cfg.ModelConfig))
+	}
+	if got := cfg.GetModelAPIFormat(model); got != APIFormatOpenAI {
+		t.Fatalf("model API format = %q, want %q", got, APIFormatOpenAI)
+	}
+	if endpoints := cfg.GetEndpointsForModel(model); len(endpoints) != 0 {
+		t.Fatalf("metadata-only model resolved %d Semantic Router endpoints", len(endpoints))
+	}
+}

--- a/src/semantic-router/pkg/config/maintained_asset_contract_test.go
+++ b/src/semantic-router/pkg/config/maintained_asset_contract_test.go
@@ -56,6 +56,7 @@ var maintainedEmbeddedConfigAssets = []string{
 var maintainedValuesConfigAssets = []string{
 	"deploy/helm/semantic-router/values.yaml",
 	"deploy/kubernetes/agentgateway/semantic-router-values/values.yaml",
+	"deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml",
 	"deploy/kubernetes/ai-gateway/semantic-router-values/values.yaml",
 	"deploy/kubernetes/aibrix/semantic-router-values/values.yaml",
 	"deploy/kubernetes/dynamo/semantic-router-values/values.yaml",
@@ -206,9 +207,12 @@ func readEmbeddedConfigAsset(t *testing.T, rel string) []byte {
 func readValuesConfigAsset(t *testing.T, rel string) []byte {
 	t.Helper()
 	root := decodeYAMLMap(t, mustReadRepoFile(t, rel), rel)
-	rawConfig, ok := root["config"]
+	rawConfig, ok := root["configOverride"]
+	if !ok || rawConfig == nil {
+		rawConfig, ok = root["config"]
+	}
 	if !ok {
-		t.Fatalf("%s is missing top-level config block", rel)
+		t.Fatalf("%s is missing top-level config or configOverride block", rel)
 	}
 	data, err := yamlv3.Marshal(rawConfig)
 	if err != nil {

--- a/src/semantic-router/pkg/extproc/processor_req_body.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body.go
@@ -113,7 +113,7 @@ func (r *OpenAIRouter) handleModelRouting(request *llmprotocol.Request, original
 	}
 	isEntrypoint := ctx.Routing.SelectedRecipe() != nil
 	executesLooper := r.routeExecutesLooper(ctx)
-	if !isEntrypoint && !executesLooper {
+	if !isEntrypoint && !executesLooper && !r.usesExternalGatewayDispatch(originalModel) {
 		if unavailable := r.unavailableModelResponse(originalModel, ctx); unavailable != nil {
 			return unavailable, nil
 		}
@@ -256,6 +256,9 @@ func (r *OpenAIRouter) handleSpecifiedModelRouting(request *llmprotocol.Request,
 		"request_id": ctx.RequestID,
 		"model":      originalModel,
 	})
+	if r.usesExternalGatewayDispatch(originalModel) {
+		return r.handleExternalGatewayModelRouting(request, originalModel, ctx)
+	}
 
 	// Reject models that are not configured. Without this guard an unknown
 	// model is forwarded with no resolvable backend credential and surfaces as

--- a/src/semantic-router/pkg/extproc/processor_req_body_external_gateway.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_external_gateway.go
@@ -1,0 +1,76 @@
+package extproc
+
+import (
+	"strings"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// usesExternalGatewayDispatch reports whether a concrete model is declared as
+// protocol metadata only. In this mode the external gateway owns the route,
+// backend, and credentials; Semantic Router owns only protocol conversion and
+// Responses object state.
+func (r *OpenAIRouter) usesExternalGatewayDispatch(model string) bool {
+	if r == nil || r.Config == nil || r.Config.ModelSelection.Enabled || len(r.Config.Listeners) != 0 {
+		return false
+	}
+	model = strings.TrimSpace(model)
+	if model == "" || len(r.Config.GetEndpointsForModel(model)) != 0 {
+		return false
+	}
+	_, configured := r.Config.ModelConfig[model]
+	return configured
+}
+
+func (r *OpenAIRouter) handleExternalGatewayModelRouting(
+	request *llmprotocol.Request,
+	model string,
+	ctx *RequestContext,
+) (*ext_proc.ProcessingResponse, error) {
+	targetFormat, err := wireFormatForModel(r.Config.GetModelAPIFormat(model))
+	if err != nil {
+		return nil, err
+	}
+	dispatch := &providerDispatch{
+		logicalModel:  model,
+		upstreamModel: model,
+		targetFormat:  targetFormat,
+	}
+	ctx.VSRSelectedModel = ""
+	ctx.VSRSelectedDecisionName = ""
+	ctx.VSRSelectedDecision = nil
+	ctx.VSRSelectedDecisionConfidence = 0
+	ctx.VSRSelectionMethod = ""
+	ctx.VSRSelectionReasoning = ""
+	ctx.VSREligibleModelRefs = nil
+	ctx.VSRReasoningMode = "off"
+
+	changed, err := r.prepareProviderRequest(request, dispatch, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		request.Generation++
+	}
+	ctx.TargetFormat = dispatch.targetFormat
+	ctx.SemanticRequest = request
+
+	ctx.RequestModel = model
+
+	state := &routeHeaderState{removeHeaders: []string{"content-length"}}
+	// Rewriting the protocol endpoint is part of request conversion. Envoy
+	// retains the already-selected route because this mode never clears the
+	// route cache, so upstream ownership remains with the external gateway.
+	setProviderRequestPath(&state.setHeaders, nil, targetFormat)
+	response := buildRequestBodyContinueResponse(state, nil, false)
+
+	logging.ComponentDebugEvent("extproc", "external_gateway_dispatch_prepared", map[string]interface{}{
+		"request_id":  ctx.RequestID,
+		"model":       model,
+		"wire_format": targetFormat,
+	})
+	return r.finalizeProviderDispatchResponse(dispatch, response, ctx)
+}

--- a/src/semantic-router/pkg/extproc/processor_req_body_external_gateway_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_external_gateway_test.go
@@ -1,0 +1,150 @@
+package extproc
+
+import (
+	"encoding/json"
+	"testing"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/entropy"
+)
+
+func TestExternalGatewayDispatchConvertsResponsesWithoutOwningBackend(t *testing.T) {
+	const model = "openai/gpt-oss-20b"
+	router := &OpenAIRouter{Config: &config.RouterConfig{
+		BackendModels: config.BackendModels{ModelConfig: map[string]config.ModelParams{
+			model: {APIFormat: config.APIFormatOpenAI},
+		}},
+		IntelligentRouting: config.IntelligentRouting{
+			ModelSelection: config.ModelSelectionConfig{Enabled: false},
+		},
+	}}
+	request := testNeutralRequest(model, "continue the conversation")
+	ctx := routingTestContext(llmprotocol.OpenAIResponsesV1, request)
+	ctx.VSRSelectedDecision = &config.Decision{Name: "must-not-run"}
+	ctx.VSRSelectedDecisionName = "must-not-run"
+	ctx.VSRSelectionMethod = "knn"
+
+	response, err := router.handleModelRouting(request, model, "", entropy.ReasoningDecision{}, "", ctx)
+	if err != nil {
+		t.Fatalf("handleModelRouting returned error: %v", err)
+	}
+	assertExternalGatewayDispatchMutation(t, response, model)
+	if ctx.TargetFormat != llmprotocol.OpenAIChatV1 {
+		t.Fatalf("target format = %q, want %q", ctx.TargetFormat, llmprotocol.OpenAIChatV1)
+	}
+	if ctx.VSRSelectedDecision != nil || ctx.VSRSelectedDecisionName != "" || ctx.VSRSelectionMethod != "" {
+		t.Fatal("external gateway dispatch retained Semantic Router selection state")
+	}
+}
+
+func assertExternalGatewayDispatchMutation(t *testing.T, response *ext_proc.ProcessingResponse, model string) {
+	t.Helper()
+	common := response.GetRequestBody().GetResponse()
+	if common.GetClearRouteCache() {
+		t.Fatal("external gateway dispatch must preserve the gateway-selected route")
+	}
+	headersByName := headerValuesByName(common.GetHeaderMutation().GetSetHeaders())
+	if got := headersByName[":path"]; got != "/v1/chat/completions" {
+		t.Fatalf("converted request path = %q, want /v1/chat/completions", got)
+	}
+	for _, name := range []string{headers.SelectedModel, "authorization", "x-api-key"} {
+		if value, ok := headersByName[name]; ok {
+			t.Fatalf("external gateway-owned header %q was mutated to %q", name, value)
+		}
+	}
+
+	var body struct {
+		Model    string `json:"model"`
+		Messages []struct {
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(common.GetBodyMutation().GetBody(), &body); err != nil {
+		t.Fatalf("decode converted request: %v", err)
+	}
+	if body.Model != model || len(body.Messages) != 1 || body.Messages[0].Content != "continue the conversation" {
+		t.Fatalf("unexpected converted request: %+v", body)
+	}
+}
+
+func TestExternalGatewayDispatchRequiresExplicitExtProcOnlyMetadataModel(t *testing.T) {
+	const model = "external-model"
+	tests := []struct {
+		name string
+		cfg  *config.RouterConfig
+		want bool
+	}{
+		{
+			name: "metadata-only model with selection disabled",
+			cfg: &config.RouterConfig{
+				BackendModels: config.BackendModels{ModelConfig: map[string]config.ModelParams{model: {APIFormat: config.APIFormatOpenAI}}},
+				IntelligentRouting: config.IntelligentRouting{
+					ModelSelection: config.ModelSelectionConfig{Enabled: false},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "selection enabled",
+			cfg: &config.RouterConfig{
+				BackendModels: config.BackendModels{ModelConfig: map[string]config.ModelParams{model: {APIFormat: config.APIFormatOpenAI}}},
+				IntelligentRouting: config.IntelligentRouting{
+					ModelSelection: config.ModelSelectionConfig{Enabled: true},
+				},
+			},
+		},
+		{
+			name: "router listener configured",
+			cfg: &config.RouterConfig{
+				BackendModels: config.BackendModels{ModelConfig: map[string]config.ModelParams{model: {APIFormat: config.APIFormatOpenAI}}},
+				APIServer:     config.APIServer{Listeners: []config.Listener{{Name: "http", Address: "0.0.0.0", Port: 8899}}},
+			},
+		},
+		{name: "model is not declared", cfg: &config.RouterConfig{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router := &OpenAIRouter{Config: test.cfg}
+			if got := router.usesExternalGatewayDispatch(model); got != test.want {
+				t.Fatalf("usesExternalGatewayDispatch() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestExternalGatewayResponsesRouterStartsWithoutModelSelectors(t *testing.T) {
+	const model = "openai/gpt-oss-20b"
+	cfg := &config.RouterConfig{
+		BackendModels: config.BackendModels{ModelConfig: map[string]config.ModelParams{
+			model: {APIFormat: config.APIFormatOpenAI},
+		}},
+		IntelligentRouting: config.IntelligentRouting{
+			ModelSelection: config.ModelSelectionConfig{Enabled: false},
+		},
+		ResponseAPI: config.ResponseAPIConfig{
+			Enabled:      true,
+			StoreBackend: "memory",
+			TTLSeconds:   86400,
+			MaxResponses: 1000,
+		},
+	}
+
+	components, err := buildRouterComponents(cfg)
+	if err != nil {
+		t.Fatalf("build state-only router components: %v", err)
+	}
+	if components.responseAPIFilter == nil {
+		t.Fatal("Responses state filter was not initialized")
+	}
+	if components.modelSelector != nil || len(components.recipeModelSelectors) != 0 || components.lookupTable != nil {
+		t.Fatal("state-only router initialized model-selection resources")
+	}
+	if err := components.buildRouter().Close(); err != nil {
+		t.Fatalf("close state-only router: %v", err)
+	}
+}

--- a/src/semantic-router/pkg/extproc/router_build.go
+++ b/src/semantic-router/pkg/extproc/router_build.go
@@ -213,8 +213,12 @@ func buildRouterComponents(cfg *config.RouterConfig) (*routerComponents, error) 
 	if components.replayRecorder != nil {
 		replayReaderForLookup = components.replayRecorder.Reader()
 	}
-	components.recipeModelSelectors, components.modelSelector, components.lookupTable, components.lookupTableCancel = createModelSelectorRegistries(cfg, replayReaderForLookup)
-	registerModelSelectorResources(components.resources, components.recipeModelSelectors, components.lookupTableCancel)
+	if cfg.ModelSelection.Enabled {
+		components.recipeModelSelectors, components.modelSelector, components.lookupTable, components.lookupTableCancel = createModelSelectorRegistries(cfg, replayReaderForLookup)
+		registerModelSelectorResources(components.resources, components.recipeModelSelectors, components.lookupTableCancel)
+	} else {
+		logging.ComponentEvent("extproc", "model_selection_disabled", map[string]interface{}{})
+	}
 
 	components.memoryStore, components.memoryExtractor = createMemoryRuntime(cfg)
 	if components.memoryStore != nil {

--- a/src/semantic-router/pkg/extproc/router_global_publication_test.go
+++ b/src/semantic-router/pkg/extproc/router_global_publication_test.go
@@ -30,7 +30,9 @@ func TestBuildRouterComponentsDoesNotPublishProcessGlobals(t *testing.T) {
 	previous := selection.NewRegistry()
 	selection.SetGlobalRegistry(previous)
 
-	cfg := &config.RouterConfig{}
+	cfg := &config.RouterConfig{IntelligentRouting: config.IntelligentRouting{
+		ModelSelection: config.ModelSelectionConfig{Enabled: true},
+	}}
 	components, err := buildRouterComponents(cfg)
 	require.NoError(t, err)
 	require.NotNil(t, components.modelSelector,

--- a/src/semantic-router/pkg/modeldownload/external_gateway_responses_asset_test.go
+++ b/src/semantic-router/pkg/modeldownload/external_gateway_responses_asset_test.go
@@ -1,0 +1,54 @@
+package modeldownload
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+func TestExternalGatewayResponsesProfileRequiresNoLocalModelDownloads(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file path")
+	}
+	valuesPath := filepath.Clean(filepath.Join(
+		filepath.Dir(file),
+		"../../../../deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml",
+	))
+	data, err := os.ReadFile(valuesPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", valuesPath, err)
+	}
+
+	var values struct {
+		Config         interface{} `yaml:"config"`
+		ConfigOverride interface{} `yaml:"configOverride"`
+	}
+	if err := yamlv3.Unmarshal(data, &values); err != nil {
+		t.Fatalf("decode Helm values: %v", err)
+	}
+	routerConfig := values.ConfigOverride
+	if routerConfig == nil {
+		routerConfig = values.Config
+	}
+	configYAML, err := yamlv3.Marshal(routerConfig)
+	if err != nil {
+		t.Fatalf("encode embedded Router config: %v", err)
+	}
+	cfg, err := config.ParseYAMLBytes(configYAML)
+	if err != nil {
+		t.Fatalf("parse embedded Router config: %v", err)
+	}
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("state-only profile requested local model downloads: %#v", specs)
+	}
+}

--- a/tools/agent/test-domain-registry.yaml
+++ b/tools/agent/test-domain-registry.yaml
@@ -347,6 +347,17 @@ profiles:
     paths:
       - e2e/profiles/category-remote-backend/**
       - e2e/testcases/category_backend_routing.go
+  external-gateway-responses:
+    owner: e2e
+    coverage_role: responses-state-with-external-dispatch
+    selection: pr
+    paths:
+      - e2e/profiles/external-gateway-responses/**
+      - deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml
+      - src/semantic-router/pkg/extproc/processor_req_body_external_gateway.go
+      - src/semantic-router/pkg/extproc/processor_req_body.go
+      - src/semantic-router/pkg/extproc/router_build.go
+      - src/semantic-router/pkg/modeldownload/external_gateway_responses_asset_test.go
   aibrix:
     owner: e2e
     coverage_role: aibrix-control-plane-and-gateway

--- a/website/docs/installation/k8s/ai-gateway.md
+++ b/website/docs/installation/k8s/ai-gateway.md
@@ -1,15 +1,15 @@
 ---
 title: Deploy with Envoy AI Gateway
-description: Use Semantic Router for model selection while Envoy AI Gateway owns provider and gateway policy.
+description: Use Semantic Router for model selection or Responses state while Envoy AI Gateway owns provider and gateway policy.
 ---
 
 # Deploy with Envoy AI Gateway
 
 Use this topology when Envoy AI Gateway already owns north-south traffic and
-provider integration, while Semantic Router should choose a model from the
-request's meaning. Envoy AI Gateway remains responsible for Gateway API
-resources, provider credentials, rate limits, and traffic policy. Semantic
-Router runs as an ExtProc service and returns the routing decision.
+provider integration. Semantic Router can either choose a model from the
+request's meaning or run only as an ExtProc service for OpenAI Responses state
+and protocol conversion. Envoy AI Gateway remains responsible for Gateway API
+resources, provider credentials, rate limits, and traffic policy.
 
 For large request bodies or streamed immediate responses from Semantic Router, also see [Streamed ExtProc and immediate responses](./streamed-extproc). That guide shows how to switch the ExtProc filter from `BUFFERED` to `STREAMED` request bodies and how streamed Chat Completions clients receive looper or `fast_response` immediate responses.
 
@@ -29,6 +29,49 @@ Provider support changes independently of Semantic Router. Use the
 [Envoy AI Gateway provider documentation](https://aigateway.envoyproxy.io/docs/capabilities/llm-integrations/supported-providers/)
 to choose an `AIServiceBackend` and credential policy, then bind the provider
 names to the aliases used by your Semantic Router configuration.
+
+## Responses state without model selection
+
+Use the
+[`responses-state.yaml`](https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml)
+profile when the external gateway already selects the route and backend, but
+clients need Semantic Router's OpenAI Responses implementation. The profile
+enables `POST /v1/responses`, `GET /v1/responses/{id}`, and
+`previous_response_id` conversation chaining. It converts Responses requests
+to the declared upstream wire format and converts upstream responses back to
+Responses objects.
+
+The ownership boundary is:
+
+| Concern | Owner |
+| --- | --- |
+| Public listener, Gateway/route, provider backend, credentials, rate limits, and traffic policy | External gateway |
+| Responses object storage, `previous_response_id` expansion, and request/response protocol conversion | Semantic Router ExtProc |
+
+This profile deliberately has no Semantic Router listener, backend reference,
+credential, routing signal, decision, or optional plugin. Model entries are
+protocol metadata only. Keep their names and `api_format` values aligned with
+the models accepted by the external gateway. Semantic Router rewrites the
+upstream API path as part of protocol conversion without clearing Envoy's route
+cache, so the route selected by the gateway remains authoritative.
+
+Install the chart with the state-only profile in place of the model-selection
+values used in Step 2:
+
+```bash
+helm install semantic-router oci://ghcr.io/vllm-project/charts/semantic-router \
+  --version 0.0.0-latest \
+  --namespace vllm-semantic-router-system \
+  --create-namespace \
+  -f https://raw.githubusercontent.com/vllm-project/semantic-router/refs/heads/main/deploy/kubernetes/ai-gateway/semantic-router-values/responses-state.yaml
+```
+
+The included in-memory response store is intended for a single-replica demo or
+local validation; state is lost on restart. Configure the Response API Redis
+backend for durable or replicated production deployments. The external
+gateway's ExtProc filter must send buffered request and response headers and
+bodies to Semantic Router, and its route for `/v1/responses` must select the
+intended provider backend before request-body conversion runs.
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #3169

## Purpose

Add a minimal, validator-valid ExtProc configuration profile for gateway-integrated deployments that need OpenAI Responses state and conversion without enabling Semantic Router model selection.

The profile keeps public listeners, routes, backends, credentials, and traffic policies under external-gateway ownership. Semantic Router owns only ExtProc request/response conversion and the configured Responses state backend. It does not enable Mixture-of-Models selection, routing signals, or unrelated plugins.

This also makes external-gateway dispatch bypass local-model availability checks and avoids constructing the model-selection registry when selection is disabled and no selector-dependent features are configured.

Owned by `wg/data-plane-networking` through accepted issue #3169.

## Test Plan

- `go test ./pkg/extproc ./pkg/config ./pkg/modeldownload`
- `make agent-validate`
- `make agent-lint` with the 15 affected PR files supplied through `CHANGED_FILES`
- `make e2e-test E2E_PROFILE=external-gateway-responses E2E_CLUSTER_NAME=semantic-router-e2e-3169 E2E_USE_EXISTING_CLUSTER=true E2E_KEEP_CLUSTER=false E2E_VERBOSE=true`
- `git diff --check`

## Test Result

- Relevant Go unit and maintained-asset tests passed.
- Agent validation and affected-file lint gates passed.
- The profile installed successfully on a live two-node Kind cluster.
- All 3 focused E2E cases passed: Responses create, Responses get, and `previous_response_id` conversation chaining.
- No remaining known blocker.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title uses one category and records affected modules in the PR body
- [x] The PR links accepted issue #3169 with owner `wg/data-plane-networking`
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect the actual scope and verification

</details>
