### PR TITLE
[Bug] Remove the obsolete Operator-only setup-dirs initContainer

### DIFF
--- a/deploy/operator/controllers/semanticrouter_controller_test.go
+++ b/deploy/operator/controllers/semanticrouter_controller_test.go
@@ -270,6 +270,15 @@ func TestGenerateDeployment(t *testing.T) {
 	if deployment.Namespace != "default" {
 		t.Errorf("expected namespace 'default', got '%s'", deployment.Namespace)
 	}
+
+	// The Router starts directly and has no supervisor-directory dependency,
+	// so the Operator must not inject the obsolete setup-dirs initContainer.
+	// Helm renders the same runtime requirement without an initContainer.
+	for _, initContainer := range deployment.Spec.Template.Spec.InitContainers {
+		if initContainer.Name == "setup-dirs" {
+			t.Errorf("unexpected setup-dirs initContainer in rendered PodSpec")
+		}
+	}
 }
 
 func TestGetPodSecurityContext(t *testing.T) {

--- a/deploy/operator/controllers/semanticrouter_pod.go
+++ b/deploy/operator/controllers/semanticrouter_pod.go
@@ -58,7 +58,6 @@ func (r *SemanticRouterReconciler) generateDeployment(sr *vllmv1alpha1.SemanticR
 					ServiceAccountName: saName,
 					SecurityContext:    r.getPodSecurityContext(sr),
 					ImagePullSecrets:   sr.Spec.ImagePullSecrets,
-					InitContainers:     r.generateInitContainers(),
 					Containers:         r.generateContainers(sr, gatewayMode),
 					Volumes:            r.generateVolumes(sr, gatewayMode),
 					NodeSelector:       sr.Spec.NodeSelector,
@@ -397,36 +396,6 @@ func (r *SemanticRouterReconciler) generateVolumeMounts(sr *vllmv1alpha1.Semanti
 		{
 			Name:      "models-volume",
 			MountPath: "/app/models",
-		},
-	}
-}
-
-func (r *SemanticRouterReconciler) generateInitContainers() []corev1.Container {
-	return []corev1.Container{
-		{
-			Name:  "setup-dirs",
-			Image: "registry.access.redhat.com/ubi9/ubi-minimal:latest",
-			Command: []string{
-				"sh",
-				"-c",
-				"mkdir -p /var/log/supervisor",
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "var-log",
-					MountPath: "/var/log",
-				},
-				{
-					Name:      "var-run",
-					MountPath: "/var/run",
-				},
-			},
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: func() *bool { b := false; return &b }(),
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
-			},
 		},
 	}
 }


### PR DESCRIPTION
Closes #2582

<!-- markdownlint-disable -->

<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

The Operator unconditionally injected a `setup-dirs` initContainer that ran `mkdir -p /var/log/supervisor` from `registry.access.redhat.com/ubi9/ubi-minimal:latest`. The Router starts directly and has no supervisor-directory dependency:

- That `mkdir` was the only reference to supervisor in production code. The remaining matches in the tree are two dashboard tests asserting `supervisorctl` is *not* used, and one CI log-collection line for the local Docker container, which is a different runtime path from the Operator-managed Pod.
- No Dockerfile in the repository runs `supervisord`. The default Operator image `ghcr.io/vllm-project/semantic-router/extproc:latest` (`controllers/constants.go`) is built from `tools/docker/Dockerfile.extproc`, which uses `ENTRYPOINT ["/app/entrypoint.sh"]`.
- Helm already renders the same runtime requirement without an initContainer and records the reason in `deploy/helm/semantic-router/values.yaml` and `templates/deployment.yaml`.

Every Operator deployment therefore carried an unrelated floating image pull, an extra startup dependency, and a supply-chain surface that Helm does not have, plus a parity gap between the two deployment paths.

Remove `generateInitContainers` and its single call site in `generateDeployment`, and assert in `TestGenerateDeployment` that the rendered PodSpec carries no `setup-dirs` initContainer.

The `var-run` and `var-log` volumes are intentionally unchanged. The Router container mounts both in `generateVolumeMounts`, so this removes only the initContainer that created an unread directory inside them.

Affected module: `deploy/operator/controllers`. Owning Workgroup: `wg/enterprise-environment` (accepted issue #2582, parent epic #3043).

<!-- What changes, why is it needed, which modules are affected, and which accepted issue/Workgroup owns it? -->

## Test Plan

- `cd deploy/operator && gofmt -l .`
- `cd deploy/operator && go vet ./...`
- `cd deploy/operator && golangci-lint run --timeout=5m` (v2.5.0, matching `operator-ci.yml`)
- `cd deploy/operator && go test -race ./controllers/...`
- `cd deploy/operator && make manifests && git diff --exit-code`
- Negative check: temporarily reintroduce a `setup-dirs` initContainer and confirm `TestGenerateDeployment` fails.
- `grep -rn 'supervisor' --include='*.go' --include='*.yaml' --include='Dockerfile*' .` to confirm no remaining production dependency.

<!-- List the commands or manual checks that cover the affected behavior. -->

## Test Result

- `gofmt` and `go vet` clean; `golangci-lint` v2.5.0 reported `0 issues`.
- `go test -race ./controllers/...` ok (2.458s). The existing suite passes unchanged, confirming no current test depended on the initContainer.
- `make manifests` produced no CRD or RBAC drift.
- Negative check failed as expected before revert, confirming the new assertion is not vacuous:
  `semanticrouter_controller_test.go:279: unexpected setup-dirs initContainer in rendered PodSpec`
- No remaining production reference to supervisor. `deploy/operator/controllers/semanticrouter_pod.go` goes from 432 to 401 lines.
- No behavior change to serve, cache search, or PII paths; this only affects the Operator-rendered PodSpec.

<!-- Record the actual outcome and any remaining risk or blocker. -->

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
