### PR TITLE
[Feature] Type the on_unknown policy contract

### DIFF
--- a/src/semantic-router/pkg/classification/classifier_signal_decision_test.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_decision_test.go
@@ -76,7 +76,7 @@ func TestEvaluateDecisionWithEngineAppliesOnUnknown(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected fail_request error")
 	}
-	if signals.AppliedUnknownPolicies["guarded"] != config.RuleOnUnknownFailRequest {
+	if signals.AppliedUnknownPolicies["guarded"] != string(config.RuleOnUnknownFailRequest) {
 		t.Fatalf("applied policies = %v", signals.AppliedUnknownPolicies)
 	}
 }

--- a/src/semantic-router/pkg/config/decision_config.go
+++ b/src/semantic-router/pkg/config/decision_config.go
@@ -1,10 +1,31 @@
 package config
 
-const (
-	RuleOnUnknownNoMatch     = "no_match"
-	RuleOnUnknownMatch       = "match"
-	RuleOnUnknownFailRequest = "fail_request"
+import (
+	"slices"
+	"strings"
 )
+
+type UnknownPolicy string
+
+const (
+	RuleOnUnknownNoMatch     UnknownPolicy = "no_match"
+	RuleOnUnknownMatch       UnknownPolicy = "match"
+	RuleOnUnknownFailRequest UnknownPolicy = "fail_request"
+)
+
+var UnknownPolicies = []UnknownPolicy{RuleOnUnknownNoMatch, RuleOnUnknownMatch, RuleOnUnknownFailRequest}
+
+func (p UnknownPolicy) IsValid() bool {
+	return slices.Contains(UnknownPolicies, p)
+}
+
+func UnknownPolicyChoices() string {
+	names := make([]string, len(UnknownPolicies))
+	for i, policy := range UnknownPolicies {
+		names[i] = string(policy)
+	}
+	return strings.Join(names[:len(names)-1], ", ") + ", or " + names[len(names)-1]
+}
 
 // Decision represents a routing decision that combines multiple rules with boolean logic.
 type Decision struct {
@@ -174,7 +195,7 @@ type RuleNode struct {
 	Label      string            `yaml:"label,omitempty" json:"label,omitempty"`
 	Predicate  *NumericPredicate `yaml:"predicate,omitempty" json:"predicate,omitempty"`
 	OnError    string            `yaml:"on_error,omitempty" json:"on_error,omitempty"`
-	OnUnknown  string            `yaml:"on_unknown,omitempty" json:"on_unknown,omitempty"`
+	OnUnknown  UnknownPolicy     `yaml:"on_unknown,omitempty" json:"on_unknown,omitempty"`
 	Operator   string            `yaml:"operator,omitempty" json:"operator,omitempty"`
 	Conditions []RuleNode        `yaml:"conditions,omitempty" json:"conditions,omitempty"`
 }

--- a/src/semantic-router/pkg/config/unknown_policy_test.go
+++ b/src/semantic-router/pkg/config/unknown_policy_test.go
@@ -1,0 +1,17 @@
+package config
+
+import "testing"
+
+func TestUnknownPolicyValues(t *testing.T) {
+	for _, policy := range UnknownPolicies {
+		if !policy.IsValid() {
+			t.Fatalf("%q must be valid", policy)
+		}
+	}
+	if UnknownPolicy("allow").IsValid() || UnknownPolicy("").IsValid() {
+		t.Fatal("unlisted values must be invalid")
+	}
+	if got := UnknownPolicyChoices(); got != "no_match, match, or fail_request" {
+		t.Fatalf("choices = %q", got)
+	}
+}

--- a/src/semantic-router/pkg/config/validator_decision.go
+++ b/src/semantic-router/pkg/config/validator_decision.go
@@ -65,10 +65,8 @@ func validateDecisionRuleNode(cfg *RouterConfig, decisionName string, node *Rule
 		if !root {
 			return fmt.Errorf("decision '%s': on_unknown is only supported on the root rules node", decisionName)
 		}
-		switch node.OnUnknown {
-		case RuleOnUnknownNoMatch, RuleOnUnknownMatch, RuleOnUnknownFailRequest:
-		default:
-			return fmt.Errorf("decision '%s': rules on_unknown must be no_match, match, or fail_request", decisionName)
+		if !node.OnUnknown.IsValid() {
+			return fmt.Errorf("decision '%s': rules on_unknown must be %s", decisionName, UnknownPolicyChoices())
 		}
 		if ruleTreeSetsOnError(node) {
 			return fmt.Errorf("decision '%s': condition on_error has no effect when rules.on_unknown is set; remove one of them", decisionName)

--- a/src/semantic-router/pkg/decision/engine.go
+++ b/src/semantic-router/pkg/decision/engine.go
@@ -31,6 +31,18 @@ import (
 
 var ErrDecisionUnresolved = errors.New("decision unresolved")
 
+type DecisionUnresolvedError struct {
+	Decision string
+}
+
+func (e *DecisionUnresolvedError) Error() string {
+	return fmt.Sprintf("decision %q could not be resolved because a signal evaluator failed: %v", e.Decision, ErrDecisionUnresolved)
+}
+
+func (e *DecisionUnresolvedError) Unwrap() error {
+	return ErrDecisionUnresolved
+}
+
 // DecisionEngine evaluates routing decisions based on rule combinations
 type DecisionEngine struct {
 	keywordRules   []config.KeywordRule
@@ -141,7 +153,7 @@ type resolvedDecisionEvaluation struct {
 	evaluation    nodeEvaluation
 	trace         *TraceNode
 	originalState evaluationState
-	policy        string
+	policy        config.UnknownPolicy
 }
 
 // DecisionResult represents the result of decision evaluation
@@ -223,14 +235,14 @@ func (e *DecisionEngine) evaluateDecisions(
 		decision := &e.decisions[i]
 		resolved, err := e.evaluateConfiguredDecision(decision, signals, withTrace)
 		if resolved.policy != "" {
-			output.diagnostics.AppliedUnknownPolicies[decision.Name] = resolved.policy
+			output.diagnostics.AppliedUnknownPolicies[decision.Name] = string(resolved.policy)
 		}
 		if withTrace {
 			output.traces = append(output.traces, newDecisionTrace(
 				decision,
 				resolved.evaluation,
 				resolved.originalState,
-				resolved.policy,
+				string(resolved.policy),
 				resolved.trace,
 			))
 		}
@@ -312,8 +324,8 @@ func (e *DecisionEngine) resolveUnknown(
 	signals *SignalMatches,
 	evaluation nodeEvaluation,
 	withTrace bool,
-) (nodeEvaluation, *TraceNode, string, error) {
-	policy := strings.TrimSpace(decision.Rules.OnUnknown)
+) (nodeEvaluation, *TraceNode, config.UnknownPolicy, error) {
+	policy := config.UnknownPolicy(strings.TrimSpace(string(decision.Rules.OnUnknown)))
 	if policy == "" {
 		var legacy nodeEvaluation
 		var legacyTrace *TraceNode
@@ -340,7 +352,7 @@ func (e *DecisionEngine) resolveUnknown(
 		evaluation.scored = false
 		return evaluation, nil, policy, nil
 	case config.RuleOnUnknownFailRequest:
-		return evaluation, nil, policy, fmt.Errorf("decision %q could not be resolved because a signal evaluator failed: %w", decision.Name, ErrDecisionUnresolved)
+		return evaluation, nil, policy, &DecisionUnresolvedError{Decision: decision.Name}
 	default:
 		return evaluation, nil, policy, fmt.Errorf("decision %q has invalid on_unknown policy %q", decision.Name, policy)
 	}

--- a/src/semantic-router/pkg/decision/engine_unknown_test.go
+++ b/src/semantic-router/pkg/decision/engine_unknown_test.go
@@ -119,7 +119,7 @@ func TestOnUnknownPolicies(t *testing.T) {
 	signals := &SignalMatches{SignalErrors: map[string]string{"classifier:risk": "timeout"}}
 	tests := []struct {
 		name      string
-		policy    string
+		policy    config.UnknownPolicy
 		wantMatch bool
 		wantError bool
 	}{
@@ -139,7 +139,7 @@ func TestOnUnknownPolicies(t *testing.T) {
 			if (result != nil) != test.wantMatch {
 				t.Fatalf("result = %#v, wantMatch %v", result, test.wantMatch)
 			}
-			if diagnostics.AppliedUnknownPolicies["route"] != test.policy {
+			if diagnostics.AppliedUnknownPolicies["route"] != string(test.policy) {
 				t.Fatalf("applied policies = %v, want %q", diagnostics.AppliedUnknownPolicies, test.policy)
 			}
 		})
@@ -222,6 +222,10 @@ func TestFailRequestOverridesHigherPriorityMatch(t *testing.T) {
 			if !errors.Is(err, ErrDecisionUnresolved) || result != nil {
 				t.Fatalf("result = %#v, error = %v", result, err)
 			}
+			var unresolved *DecisionUnresolvedError
+			if !errors.As(err, &unresolved) || unresolved.Decision != "guarded" {
+				t.Fatalf("error = %#v", err)
+			}
 		})
 	}
 }
@@ -241,13 +245,13 @@ func TestUnknownTraceRecordsErrorAndPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(traces) != 1 || traces[0].State != "unknown" || traces[0].OnUnknown != config.RuleOnUnknownNoMatch {
+	if len(traces) != 1 || traces[0].State != "unknown" || traces[0].OnUnknown != string(config.RuleOnUnknownNoMatch) {
 		t.Fatalf("traces = %#v", traces)
 	}
 	if traces[0].RootTrace == nil || traces[0].RootTrace.SignalError != "timeout" {
 		t.Fatalf("root trace = %#v", traces[0].RootTrace)
 	}
-	if diagnostics.AppliedUnknownPolicies["route"] != config.RuleOnUnknownNoMatch {
+	if diagnostics.AppliedUnknownPolicies["route"] != string(config.RuleOnUnknownNoMatch) {
 		t.Fatalf("diagnostics = %#v", diagnostics)
 	}
 }

--- a/src/semantic-router/pkg/dsl/compiler_routes.go
+++ b/src/semantic-router/pkg/dsl/compiler_routes.go
@@ -20,7 +20,7 @@ func (c *Compiler) compileRoute(r *RouteDecl) config.Decision {
 		Tier:        r.Tier,
 		Rules:       c.compileRouteRules(r),
 	}
-	decision.Rules.OnUnknown = r.OnUnknown
+	decision.Rules.OnUnknown = config.UnknownPolicy(r.OnUnknown)
 
 	for _, m := range r.Models {
 		c.appendModelRef(&decision, m)

--- a/src/semantic-router/pkg/dsl/decompiler_convert.go
+++ b/src/semantic-router/pkg/dsl/decompiler_convert.go
@@ -337,7 +337,7 @@ func (d *decompiler) decisionToRoute(dec *config.Decision) *RouteDecl {
 	route := &RouteDecl{
 		Name:        dec.Name,
 		Description: dec.Description,
-		OnUnknown:   dec.Rules.OnUnknown,
+		OnUnknown:   string(dec.Rules.OnUnknown),
 		Priority:    dec.Priority,
 		Tier:        dec.Tier,
 	}

--- a/src/semantic-router/pkg/dsl/validator.go
+++ b/src/semantic-router/pkg/dsl/validator.go
@@ -523,11 +523,9 @@ func (v *Validator) checkRouteConstraints(r *RouteDecl) {
 		)
 	}
 
-	switch r.OnUnknown {
-	case "", config.RuleOnUnknownNoMatch, config.RuleOnUnknownMatch, config.RuleOnUnknownFailRequest:
-	default:
+	if r.OnUnknown != "" && !config.UnknownPolicy(r.OnUnknown).IsValid() {
 		v.addDiag(DiagConstraint, r.Pos,
-			fmt.Sprintf("%s: on_unknown must be no_match, match, or fail_request, got %q", context, r.OnUnknown),
+			fmt.Sprintf("%s: on_unknown must be %s, got %q", context, config.UnknownPolicyChoices(), r.OnUnknown),
 			nil,
 		)
 	}

--- a/src/semantic-router/pkg/k8s/converter.go
+++ b/src/semantic-router/pkg/k8s/converter.go
@@ -77,7 +77,7 @@ func (c *CRDConverter) convertDecision(decision v1alpha1.Decision) (config.Decis
 		Priority:    int(decision.Priority),
 		Rules: config.RuleCombination{
 			Operator:   decision.Signals.Operator,
-			OnUnknown:  decision.Signals.OnUnknown,
+			OnUnknown:  config.UnknownPolicy(decision.Signals.OnUnknown),
 			Conditions: make([]config.RuleCondition, 0),
 		},
 		ModelRefs: make([]config.ModelRef, 0),

--- a/src/semantic-router/pkg/k8s/converter_test.go
+++ b/src/semantic-router/pkg/k8s/converter_test.go
@@ -59,7 +59,7 @@ func TestConvertDecisionPreservesOnUnknown(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "fail_request", decision.Rules.OnUnknown)
+	assert.Equal(t, config.RuleOnUnknownFailRequest, decision.Rules.OnUnknown)
 }
 
 // TestConverterWithTestData tests the converter with input/output test data

--- a/src/vllm-sr/cli/config_contract.py
+++ b/src/vllm-sr/cli/config_contract.py
@@ -17,6 +17,9 @@ ClassifierSignalType = Literal[
     "sequence_classifier",
 ]
 
+UNKNOWN_POLICY_VALUES = ("no_match", "match", "fail_request")
+UnknownPolicy = Literal["no_match", "match", "fail_request"]
+
 CONDITION_TYPE_DOMAIN = "domain"
 CONDITION_TYPE_PROJECTION = "projection"
 

--- a/src/vllm-sr/cli/models.py
+++ b/src/vllm-sr/cli/models.py
@@ -21,6 +21,7 @@ from .config_contract import (
     CLASSIFIER_TYPE_LLM,
     CLASSIFIER_TYPE_LOCAL,
     ClassifierSignalType,
+    UnknownPolicy,
 )
 
 RoutingStrategy = Literal["priority", "confidence"]
@@ -618,7 +619,7 @@ class Condition(BaseModel):
     label: Optional[str] = None
     predicate: Optional[NumericPredicate] = None
     on_error: Optional[Literal["no_match", "match"]] = None
-    on_unknown: Optional[Literal["no_match", "match", "fail_request"]] = None
+    on_unknown: Optional[UnknownPolicy] = None
     operator: Optional[str] = None
     conditions: Optional[List["Condition"]] = None
 
@@ -685,7 +686,7 @@ class Rules(BaseModel):
 
     operator: str = "AND"
     conditions: List[Condition] = Field(default_factory=list)
-    on_unknown: Optional[Literal["no_match", "match", "fail_request"]] = None
+    on_unknown: Optional[UnknownPolicy] = None
 
     @model_validator(mode="before")
     @classmethod

--- a/src/vllm-sr/tests/test_config_contract.py
+++ b/src/vllm-sr/tests/test_config_contract.py
@@ -1,12 +1,21 @@
+from typing import get_args
+
 import pytest
 from cli.algorithms import AlgorithmConfig
 from cli.config_contract import (
     LEGACY_SIGNAL_KEY_TO_CANONICAL,
+    UNKNOWN_POLICY_VALUES,
+    UnknownPolicy,
     build_projection_reference_index,
     build_signal_reference_index,
     signal_reference_exists,
 )
 from cli.models import Decision, Projections, Signals
+
+
+def test_unknown_policy_literal_matches_allowed_values():
+    assert get_args(UnknownPolicy) == UNKNOWN_POLICY_VALUES
+    assert UNKNOWN_POLICY_VALUES == ("no_match", "match", "fail_request")
 
 
 def test_legacy_signal_inventory_covers_flat_authz_and_context_blocks():


### PR DESCRIPTION
Related #3267

## Purpose

- Add `config.UnknownPolicy` as the single allowed-values source for config and DSL validators.
- Replace the formatted fail_request error with typed `decision.DecisionUnresolvedError`; text unchanged.
- Mirror the values in the CLI config contract.

## Test Plan

- `go test ./pkg/config/ ./pkg/dsl/ ./pkg/decision/ ./pkg/k8s/`
- `pytest tests/test_config_contract.py tests/test_cli_models.py`

## Test Result

- Passed.