### PR TITLE
[Feature] Explain on_unknown options in the decision editor

### DIFF
--- a/dashboard/frontend/src/pages/ConfigPageDecisionsSection.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageDecisionsSection.tsx
@@ -632,7 +632,7 @@ export default function ConfigPageDecisionsSection({
         type: 'select',
         options: ['', 'no_match', 'match', 'fail_request'],
         description:
-          'When a classifier fails: no_match skips this decision, match selects it, fail_request rejects the request with 503. Empty keeps condition on_error.',
+          'When a signal evaluator fails: no_match skips this decision, match selects it, fail_request rejects the request with 503. Empty keeps condition on_error.',
       },
       {
         name: 'conditions',

--- a/dashboard/frontend/src/pages/ConfigPageDecisionsSection.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageDecisionsSection.tsx
@@ -631,7 +631,8 @@ export default function ConfigPageDecisionsSection({
         label: 'On Unknown',
         type: 'select',
         options: ['', 'no_match', 'match', 'fail_request'],
-        description: 'Resolve classifier backend failures after the complete rule tree is evaluated.',
+        description:
+          'When a classifier fails: no_match skips this decision, match selects it, fail_request rejects the request with 503. Empty keeps condition on_error.',
       },
       {
         name: 'conditions',

--- a/dashboard/frontend/src/pages/configPageDecisionOnUnknownHelp.test.ts
+++ b/dashboard/frontend/src/pages/configPageDecisionOnUnknownHelp.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('decision editor on_unknown help', () => {
+  it('explains every on_unknown option in plain language', () => {
+    const source = readFileSync(
+      new URL('./ConfigPageDecisionsSection.tsx', import.meta.url),
+      'utf8',
+    )
+    const field = source.slice(source.indexOf("name: 'on_unknown'"))
+    const description = field.slice(0, field.indexOf('},'))
+    expect(description).toContain('no_match skips this decision')
+    expect(description).toContain('match selects it')
+    expect(description).toContain('fail_request rejects the request')
+    expect(description).toContain('Empty keeps condition on_error')
+  })
+})

--- a/dashboard/frontend/src/pages/configPageDecisionOnUnknownHelp.test.ts
+++ b/dashboard/frontend/src/pages/configPageDecisionOnUnknownHelp.test.ts
@@ -9,6 +9,8 @@ describe('decision editor on_unknown help', () => {
     )
     const field = source.slice(source.indexOf("name: 'on_unknown'"))
     const description = field.slice(0, field.indexOf('},'))
+    expect(description).toContain('When a signal evaluator fails')
+    expect(description).not.toContain('classifier')
     expect(description).toContain('no_match skips this decision')
     expect(description).toContain('match selects it')
     expect(description).toContain('fail_request rejects the request')


### PR DESCRIPTION
Related #3267

## Purpose

- Describe each `on_unknown` option in plain language in the decision editor select.
- Cover the wording with a source-contract test.

<img width="980" height="752" alt="pr3309-on-unknown-help-v2" src="https://github.com/user-attachments/assets/e2cd5919-aed6-48c3-8c3e-f1ba5b54ec24" />


## Test Plan

- `npx vitest run src/pages/configPageDecisionOnUnknownHelp.test.ts`
- `npx tsc --noEmit`

## Test Result

- Passed.