### PR TITLE
[BugFix] Ship the OpenVINO router backend in image build

### DIFF
--- a/src/semantic-router/pkg/modelruntime/router_runtime.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime.go
@@ -182,6 +182,11 @@ func embeddingRuntimeTasks(
 		logEmbeddingRuntimeStart(component, cfg, paths)
 		return tracker.snapshot(), remoteEmbeddingRuntimeTask(cfg, component, tracker), tracker
 	}
+	// OpenVINO model initialization belongs to the classifier runtime. Do not
+	// send its model paths through the Candle-only shared runtime.
+	if cfg.EmbeddingModels.EmbeddingBackend() == config.EmbeddingBackendOpenVINO {
+		return EmbeddingRuntimeState{}, nil, nil
+	}
 	if !paths.hasConfiguredModels() {
 		return EmbeddingRuntimeState{}, nil, nil
 	}

--- a/src/semantic-router/pkg/modelruntime/router_runtime_test.go
+++ b/src/semantic-router/pkg/modelruntime/router_runtime_test.go
@@ -71,6 +71,21 @@ func TestEmbeddingRuntimeTasksUseOnlyRemoteProviderWhenConfigured(t *testing.T) 
 	}
 }
 
+func TestEmbeddingRuntimeTasksDoNotUseCandleForOpenVINO(t *testing.T) {
+	cfg := &config.RouterConfig{InlineModels: config.InlineModels{EmbeddingModels: config.EmbeddingModels{
+		Qwen3ModelPath: "models/openvino-embedding",
+		EmbeddingConfig: config.HNSWConfig{
+			Backend:   config.EmbeddingBackendOpenVINO,
+			ModelType: config.EmbeddingModelTypeQwen3,
+		},
+	}}}
+
+	_, tasks, _ := embeddingRuntimeTasks(cfg, "test", resolveEmbeddingPaths(cfg))
+	if len(tasks) != 0 {
+		t.Fatalf("embeddingRuntimeTasks() returned %d task(s), want no Candle tasks for OpenVINO", len(tasks))
+	}
+}
+
 func TestPrepareRouterRuntimeProbesRemoteEmbeddingProvider(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeRuntimeEmbeddingResponse(t, w, []float64{0.1, 0.2})

--- a/tools/docker/Dockerfile.extproc
+++ b/tools/docker/Dockerfile.extproc
@@ -310,9 +310,25 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
         ls -la libopenvino_semantic_router.so; \
     fi
 
+# Collect the CPU runtime needed by the tagged router binary. Keep the
+# directory present on arm64 so later cross-stage copies remain valid while
+# OpenVINO stays unsupported there.
+RUN mkdir -p /app/openvino-runtime && \
+    if [ "$TARGETARCH" != "arm64" ]; then \
+        ov_libs="$(python3 -c 'import openvino, os; print(os.path.join(os.path.dirname(openvino.__file__), "libs"))')" && \
+        ov_tokenizers="$(python3 -c 'import openvino_tokenizers, os; print(os.path.join(os.path.dirname(openvino_tokenizers.__file__), "lib"))')" && \
+        cp -a \
+            "$ov_libs"/libopenvino.so.* \
+            "$ov_libs"/libopenvino_auto_plugin.so \
+            "$ov_libs"/libopenvino_intel_cpu_plugin.so \
+            "$ov_libs"/libopenvino_ir_frontend.so.* \
+            "$ov_libs"/libtbb.so.* \
+            "$ov_tokenizers"/libopenvino_tokenizers.so \
+            /app/openvino-runtime/; \
+    fi
 
 # ============================================================================
-# Stage 5: Build Go application (candle on all platforms, onnx on amd64 only)
+# Stage 5: Build Go application (candle on all platforms, onnx/openvino on amd64 only)
 # ============================================================================
 ARG BUILDPLATFORM
 FROM --platform=$BUILDPLATFORM golang:1.25 AS go-builder
@@ -338,6 +354,7 @@ COPY onnx-binding/go.mod onnx-binding/semantic-router.go onnx-binding/
 COPY ml-binding/go.mod ml-binding/ml_binding.go ml-binding/
 COPY nlp-binding/go.mod nlp-binding/nlp_binding.go nlp-binding/nlp_binding_mock.go nlp-binding/
 COPY openvino-binding/go.mod openvino-binding/semantic-router.go openvino-binding/
+COPY openvino-binding/cpp/include/ openvino-binding/cpp/include/
 
 # Download Go dependencies (cached layer)
 # Pipe falls back to direct on any proxy error; comma only on 404 and 410
@@ -400,20 +417,21 @@ RUN mkdir -p /app/nlp-binding/target/release && \
 
 # Copy openvino-binding library (x86_64 only, built with CMake not Rust)
 COPY --from=openvino-builder /app/openvino-binding/build/ /tmp/openvino-build/
+COPY --from=openvino-builder /app/openvino-runtime/ /app/openvino-runtime/
 RUN mkdir -p /app/openvino-binding/build && \
     if [ "$TARGETARCH" = "arm64" ]; then \
         echo "Skipping OpenVINO library copy for arm64."; \
     else \
-        cp /tmp/openvino-build/libopenvino_semantic_router.so /app/openvino-binding/build/ 2>/dev/null && \
+        cp -a /tmp/openvino-build/libopenvino_semantic_router.so* /app/openvino-binding/build/ 2>/dev/null && \
         echo "=== OpenVINO library staged ===" && \
-        ls -la /app/openvino-binding/build/libopenvino_semantic_router.so || \
+        ls -la /app/openvino-binding/build/libopenvino_semantic_router.so* || \
         echo "Warning: OpenVINO library not found (build may have been skipped)"; \
     fi && \
     rm -rf /tmp/openvino-build
 
 # Set environment variables for CGO to find the libraries
 ENV CGO_ENABLED=1
-ENV LD_LIBRARY_PATH=/app/candle-binding/target/release:/app/onnx-binding/target/release:/app/ml-binding/target/release:/app/nlp-binding/target/release:/app/openvino-binding/build
+ENV LD_LIBRARY_PATH=/app/candle-binding/target/release:/app/onnx-binding/target/release:/app/ml-binding/target/release:/app/nlp-binding/target/release:/app/openvino-binding/build:/app/openvino-runtime
 ENV GOOS=linux
 ENV GOFLAGS=-buildvcs=false
 
@@ -453,12 +471,13 @@ RUN mkdir -p /app/lib && \
     cp /app/ml-binding/target/release/libml_semantic_router.so /app/lib/ && \
     cp /app/nlp-binding/target/release/libnlp_binding.so /app/lib/ && \
     if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Skipping ONNX runtime library staging on arm64."; \
+        echo "Skipping ONNX and OpenVINO runtime library staging on arm64."; \
     else \
         cp /app/onnx-binding/target/release/libonnx_semantic_router.so /app/lib/ && \
-        (cp /app/onnx-binding/target/release/libonnxruntime*.so* /app/lib/ 2>/dev/null || true); \
+        (cp /app/onnx-binding/target/release/libonnxruntime*.so* /app/lib/ 2>/dev/null || true) && \
+        cp -a /app/openvino-binding/build/libopenvino_semantic_router.so* /app/lib/ && \
+        cp -a /app/openvino-runtime/. /app/lib/; \
     fi && \
-    (cp /app/openvino-binding/build/libopenvino_semantic_router.so /app/lib/ 2>/dev/null || echo "OpenVINO library not staged (arm64 or build skipped)") && \
     echo "=== Libraries staged ===" && ls -la /app/lib/
 
 # Build the onnx router binary (uses go.onnx.mod which replaces candle-binding => onnx-binding)
@@ -470,6 +489,16 @@ RUN cd src/semantic-router && \
         CGO_CFLAGS="-I/app/onnx-binding" \
         CGO_LDFLAGS="-L/app/onnx-binding/target/release -L/app/ml-binding/target/release -L/app/nlp-binding/target/release -lonnx_semantic_router -lml_semantic_router -lnlp_binding" \
         go build -modfile=go.onnx.mod -tags=onnx -ldflags="-w -s" -o ../../bin/router-onnx ./cmd; \
+    fi
+
+# Build the OpenVINO router binary with the real CGO implementation enabled.
+RUN cd src/semantic-router && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        echo "Skipping OpenVINO router build on arm64."; \
+    else \
+        echo "Building OpenVINO binary for AMD64..." && \
+        CGO_LDFLAGS="-L/app/openvino-binding/build -L/app/openvino-runtime -L/app/candle-binding/target/release -L/app/ml-binding/target/release -L/app/nlp-binding/target/release -Wl,-rpath-link,/app/openvino-runtime -lopenvino_semantic_router -lcandle_semantic_router -lml_semantic_router -lnlp_binding -lstdc++ -lm" \
+        go build -tags=openvino -ldflags="-w -s" -o ../../bin/router-openvino ./cmd; \
     fi
 
 # ============================================================================
@@ -499,6 +528,22 @@ COPY config/config.yaml /app/config/
 COPY config/knowledge_bases/ /app/config/knowledge_bases/
 
 ENV LD_LIBRARY_PATH=/app/lib
+ENV OPENVINO_TOKENIZERS_LIB=/app/lib/libopenvino_tokenizers.so
+
+ARG TARGETARCH
+
+# Keep the advertised amd64 OpenVINO backend honest: image validation must fail
+# if its binary or dynamically loaded CPU runtime is incomplete.
+RUN if [ "$TARGETARCH" != "arm64" ]; then \
+        test -x /app/router-openvino && \
+        test -e /app/lib/libopenvino_semantic_router.so.0 && \
+        test -f /app/lib/libopenvino_intel_cpu_plugin.so && \
+        test -f /app/lib/libopenvino_ir_frontend.so.2510 && \
+        test -f "$OPENVINO_TOKENIZERS_LIB" && \
+        test -z "$(ldd /app/router-openvino | grep 'not found' || true)" && \
+        test -z "$(ldd /app/lib/libopenvino_semantic_router.so | grep 'not found' || true)"; \
+    fi
+
 # Default to candle binding; set AI_BINDING=onnx or openvino for alternative backends
 ENV AI_BINDING=candle
 

--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -26,8 +26,8 @@ case "$AI_BINDING" in
 esac
 
 if [[ ! -f "$BINARY" ]]; then
-  echo "[entrypoint] Binary not found: $BINARY (AI_BINDING=$AI_BINDING)" >&2
-  echo "[entrypoint] Falling back to candle binding..." >&2
+  echo "[entrypoint] ERROR: requested AI_BINDING='$AI_BINDING' is unavailable because $BINARY is missing." >&2
+  echo "[entrypoint] ERROR: falling back to AI_BINDING=candle; the effective backend differs from the requested backend." >&2
   BINARY=/app/router-candle
   AI_BINDING=candle
   if [[ ! -f "$BINARY" ]]; then


### PR DESCRIPTION
Related to #2668

## Purpose

Ship the OpenVINO router path already advertised by the amd64 extproc image instead of leaving `AI_BINDING=openvino` without a corresponding binary.

- build `router-openvino` with the real `openvino` CGO implementation
- package the minimal OpenVINO CPU runtime, tokenizer extension, IR frontend, and wrapper SONAME links
- fail the image build when the OpenVINO binary or dynamic dependencies are incomplete
- keep the existing missing-binary fallback while explicitly reporting that the effective backend changed to Candle
- prevent configurations declaring `backend: openvino` from entering the shared Candle-only embedding initialization path

OpenVINO remains unsupported on arm64. Shared tools/cache consumers remain unready rather than being falsely advertised as OpenVINO-capable; routing embedding classifiers use the existing OpenVINO runtime path.

Owned by the Router Models & Inference Runtime Workgroup.

## Test Plan

- `make agent-validate`
- `make agent-lint`
- `make test-semantic-router`
- `make agent-dev ENV=cpu`
- `make agent-serve-local ENV=cpu`
- `make agent-smoke-local ENV=cpu`
- `make agent-ci-gate CHANGED_FILES="tools/docker/Dockerfile.extproc tools/docker/entrypoint.sh src/semantic-router/pkg/modelruntime/router_runtime.go src/semantic-router/pkg/modelruntime/router_runtime_test.go"`
- build the amd64 extproc image and inspect `ldd` for `router-openvino` and `libopenvino_semantic_router.so`
- start the image with an `all-MiniLM-L6-v2` OpenVINO fixture and preload one embedding candidate

## Test Result

- all repository validation commands above passed
- final image contains an executable `router-openvino`; Docker build-time dependency assertions passed
- `ldd` reported no unresolved dependencies for the OpenVINO binary or wrapper
- real CPU initialization loaded the OpenVINO tokenizer extension, CPU plugin, model, and infer-request pool
- candidate preload returned a 384-dimensional embedding through `backend=openvino`
- clean OpenVINO smoke performed no Candle embedding initialization, no fallback, and no model download
- canonical Candle CPU build/serve/smoke remained healthy

Remaining boundary: OpenVINO is packaged only for amd64, matching the existing project support boundary.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title does not stack prefixes
- [x] The PR links accepted issue #2668 with exactly one Workgroup owner
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect the actual scope and results

</details>
