### PR TITLE
[Bug] Honor configured llm_timeout_seconds in VLLMClient HTTP timeout

### DIFF
--- a/src/semantic-router/pkg/classification/preference_classifier_external.go
+++ b/src/semantic-router/pkg/classification/preference_classifier_external.go
@@ -47,10 +47,7 @@ func newExternalPreferenceClassifier(
 
 	client := newVLLMClientFromConfig(externalCfg)
 
-	timeout := 30 * time.Second
-	if externalCfg.TimeoutSeconds > 0 {
-		timeout = time.Duration(externalCfg.TimeoutSeconds) * time.Second
-	}
+	timeout := externalCfg.GetTimeout()
 
 	return &PreferenceClassifier{
 		client:             client,

--- a/src/semantic-router/pkg/classification/vllm_classifier.go
+++ b/src/semantic-router/pkg/classification/vllm_classifier.go
@@ -51,10 +51,7 @@ func NewVLLMJailbreakInference(cfg *config.ExternalModelConfig, defaultThreshold
 	client := newVLLMClientFromConfig(cfg)
 
 	// Use timeout from config, default to 30 seconds
-	timeout := 30 * time.Second
-	if cfg.TimeoutSeconds > 0 {
-		timeout = time.Duration(cfg.TimeoutSeconds) * time.Second
-	}
+	timeout := cfg.GetTimeout()
 
 	// Use threshold from config, fallback to default
 	threshold := defaultThreshold

--- a/src/semantic-router/pkg/classification/vllm_client.go
+++ b/src/semantic-router/pkg/classification/vllm_client.go
@@ -27,19 +27,19 @@ type VLLMClient struct {
 
 // NewVLLMClient creates a new vLLM REST API client for classifiers
 func NewVLLMClient(endpoint *config.ClassifierVLLMEndpoint) *VLLMClient {
-	return newVLLMClient(endpoint, "", config.DefaultClassifyMaxResponseBytes)
+	return newVLLMClient(endpoint, "", config.DefaultClassifyMaxResponseBytes, time.Duration(config.DefaultClassifierTimeoutSeconds)*time.Second)
 }
 
 // NewVLLMClientWithAuth creates a new vLLM REST API client with access key
 func NewVLLMClientWithAuth(endpoint *config.ClassifierVLLMEndpoint, accessKey string) *VLLMClient {
-	return newVLLMClient(endpoint, accessKey, config.DefaultClassifyMaxResponseBytes)
+	return newVLLMClient(endpoint, accessKey, config.DefaultClassifyMaxResponseBytes, time.Duration(config.DefaultClassifierTimeoutSeconds)*time.Second)
 }
 
 func newVLLMClientFromConfig(cfg *config.ExternalModelConfig) *VLLMClient {
-	return newVLLMClient(&cfg.ModelEndpoint, cfg.AccessKey, cfg.GetMaxResponseBytes())
+	return newVLLMClient(&cfg.ModelEndpoint, cfg.AccessKey, cfg.GetMaxResponseBytes(), cfg.GetTimeout())
 }
 
-func newVLLMClient(endpoint *config.ClassifierVLLMEndpoint, accessKey string, maxResponseBytes int64) *VLLMClient {
+func newVLLMClient(endpoint *config.ClassifierVLLMEndpoint, accessKey string, maxResponseBytes int64, timeout time.Duration) *VLLMClient {
 	scheme := endpoint.Protocol
 	if scheme == "" {
 		scheme = "http"
@@ -48,7 +48,7 @@ func newVLLMClient(endpoint *config.ClassifierVLLMEndpoint, accessKey string, ma
 
 	return &VLLMClient{
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: timeout,
 		},
 		endpoint:         endpoint,
 		baseURL:          baseURL,

--- a/src/semantic-router/pkg/classification/vllm_client_timeout_test.go
+++ b/src/semantic-router/pkg/classification/vllm_client_timeout_test.go
@@ -1,0 +1,89 @@
+package classification
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestVLLMClientTimeoutHonorsConfig verifies that a configured
+// llm_timeout_seconds bounds the HTTP round-trip via http.Client.Timeout.
+// Before the fix, newVLLMClient hardcoded 30s and a configured timeout above
+// 30s was silently ignored; below 30s the caller's context.WithTimeout
+// happened to fire first, masking the bug. This test isolates the client
+// timeout by passing context.Background() (no caller deadline) so only
+// http.Client.Timeout can interrupt the slow server.
+func TestVLLMClientTimeoutHonorsConfig(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"safe"}}]}`))
+	}))
+	defer server.Close()
+
+	client := newVLLMClientFromConfig(&config.ExternalModelConfig{
+		ModelEndpoint:  config.ClassifierVLLMEndpoint{Address: "placeholder", Port: 1},
+		TimeoutSeconds: 1,
+	})
+	client.baseURL = server.URL
+
+	start := time.Now()
+	_, err := client.Generate(context.Background(), "classifier", "test", nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	// ponytail: loose bound (1.5x the configured timeout) — CI jitter + server
+	// shutdown slop. The point is "config-driven timeout fired", not "exactly
+	// 1s". The pre-fix behavior would have waited the full 2s server sleep.
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("elapsed = %v, want < 1.5s (configured 1s timeout); client timeout did not fire", elapsed)
+	}
+	if elapsed < 800*time.Millisecond {
+		t.Fatalf("elapsed = %v, want > 0.8s; timed out too early, check test setup", elapsed)
+	}
+}
+
+// TestVLLMClientTimeoutDefaultsWhenUnset verifies the 30s default still
+// applies when llm_timeout_seconds is unset, so existing configs without an
+// explicit timeout keep the prior behavior.
+func TestVLLMClientTimeoutDefaultsWhenUnset(t *testing.T) {
+	client := newVLLMClientFromConfig(&config.ExternalModelConfig{
+		ModelEndpoint: config.ClassifierVLLMEndpoint{Address: "placeholder", Port: 1},
+	})
+	if got := client.httpClient.Timeout; got != 30*time.Second {
+		t.Fatalf("default client timeout = %v, want 30s", got)
+	}
+}
+
+// TestGetTimeoutCoversCallers is the lazy self-check: ExternalModelConfig.GetTimeout
+// resolves the config-driven timeout used by newVLLMClientFromConfig (the client
+// timeout) and by the vLLM jailbreak and external preference callers. The
+// generic LLM label caller keeps its own 5s default for the caller-side
+// context.WithTimeout, but still gets the config-driven client timeout via
+// newVLLMClientFromConfig, so a configured llm_timeout_seconds is honored on
+// both chains. This guards against a future caller reintroducing a hardcoded
+// client default that disagrees with config.
+func TestGetTimeoutCoversCallers(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+	}{
+		{"unset_uses_default", 0, 30 * time.Second},
+		{"configured_passes_through", 60, 60 * time.Second},
+		{"negative_uses_default", -1, 30 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.ExternalModelConfig{TimeoutSeconds: tc.seconds}
+			if got := cfg.GetTimeout(); got != tc.want {
+				t.Fatalf("GetTimeout() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/semantic-router/pkg/config/model_config_limits.go
+++ b/src/semantic-router/pkg/config/model_config_limits.go
@@ -1,8 +1,16 @@
 package config
 
+import "time"
+
 // DefaultClassifyMaxRequestBytes bounds the text one http_classify call may
 // send. The classifier truncates to its own context window anyway.
 const DefaultClassifyMaxRequestBytes int64 = 256 * 1024
+
+// DefaultClassifierTimeoutSeconds bounds one external classifier call when
+// llm_timeout_seconds is unset. Remote chat-style guardrail calls are
+// generative, so this shares the 30s majority default the vLLM and preference
+// callers already used; http_classify sets its own tighter 5s default.
+const DefaultClassifierTimeoutSeconds = 30
 
 // DefaultClassifyMaxResponseBytes bounds one external classifier response.
 const DefaultClassifyMaxResponseBytes int64 = 1024 * 1024
@@ -23,4 +31,17 @@ func (e *ExternalModelConfig) GetMaxResponseBytes() int64 {
 		return DefaultClassifyMaxResponseBytes
 	}
 	return e.MaxResponseBytes
+}
+
+// GetTimeout returns the per-call timeout, defaulting when
+// llm_timeout_seconds is unset or non-positive. Callers should use this
+// instead of hardcoding their own default so the http.Client.Timeout and the
+// caller's context.WithTimeout agree: when they disagree the stricter one
+// wins and a configured llm_timeout_seconds above the hardcoded client
+// default is silently ignored.
+func (e *ExternalModelConfig) GetTimeout() time.Duration {
+	if e.TimeoutSeconds <= 0 {
+		return time.Duration(DefaultClassifierTimeoutSeconds) * time.Second
+	}
+	return time.Duration(e.TimeoutSeconds) * time.Second
 }


### PR DESCRIPTION
Closes #3315

## Purpose

`VLLMClient` (`pkg/classification/vllm_client.go`) constructed its `http.Client` with a hardcoded `Timeout: 30 * time.Second`, ignoring the configured `llm_timeout_seconds`. All three remote classifier bindings that route through `newVLLMClientFromConfig` — jailbreak (`vllm_classifier.go`), generic LLM label (`generic_classifier.go`), and external preference (`preference_classifier_external.go`) — inherited this hardcoded client timeout, so a configured `llm_timeout_seconds` above 30s was silently capped at 30s by the client. Below 30s the caller's own `context.WithTimeout` fired first, masking the bug.

The sibling `HTTPClassifierInference` (`http_classifier.go`) already builds its client timeout from config and was unaffected — only the `VLLMClient` path was broken.

**Scope of this fix:** add `ExternalModelConfig.GetTimeout()` (matching the existing `GetMaxRequestBytes`/`GetMaxResponseBytes` pattern) and thread it through `newVLLMClient`, so the client timeout honors `llm_timeout_seconds` for every caller. The vLLM jailbreak and external preference callers also adopt `GetTimeout()` for their caller-side `context.WithTimeout`, so both deadline chains agree.

The generic LLM label caller is **not** changed: it keeps its existing 5s caller-side default, but still gets the config-driven client timeout via `newVLLMClientFromConfig`, so a configured `llm_timeout_seconds` is honored on the client chain regardless. Converging the generic 5s caller default to the shared 30s is a user-visible behavior change and is left for a separate change.

Affected modules: `pkg/config` (new `GetTimeout`), `pkg/classification` (client + two callers). Owned by `wg/router-models-inference-runtime` (#3315).

## Test Plan

- `go test ./pkg/classification/` — covers the callers plus the new `vllm_client_timeout_test.go`
- `go test ./pkg/config/` — covers `GetTimeout`
- `gofmt -l` + `go vet ./pkg/classification/ ./pkg/config/`

The new test `TestVLLMClientTimeoutHonorsConfig` isolates the client timeout by passing `context.Background()` (no caller deadline) against an `httptest.Server` whose handler sleeps 2s; with `llm_timeout_seconds: 1` the request must terminate near 1s, not the pre-fix 30s. `TestVLLMClientTimeoutDefaultsWhenUnset` checks the 30s default still applies when unset. `TestGetTimeoutCoversCallers` checks the three resolution states (unset / configured / negative).

## Test Result

```
=== classification ===
ok  	github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification	4.717s
=== config ===
ok  	github.com/vllm-project/semantic-router/src/semantic-router/pkg/config	0.322s
```

`gofmt` + `go vet` clean. No remaining risk: the fix only changes how the client timeout value is resolved (config → client), not the deadline semantics. The generic caller's 5s default is untouched, so deployments using generic LLM label classifiers without an explicit `llm_timeout_seconds` see no behavior change. Configs that set `llm_timeout_seconds` now get that value on the client chain for all three callers; configs above 30s are no longer silently capped.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
