### PR TITLE
[Bug] Collapse repeated version segment when resolving backend chat path

### DIFF
--- a/src/semantic-router/pkg/config/config_test.go
+++ b/src/semantic-router/pkg/config/config_test.go
@@ -3649,6 +3649,27 @@ model_config:
 				Expect(path).To(Equal("/v1/chat/completions"))
 			})
 
+			It("should not double the version segment for a versioned base_url", func() {
+				for _, tc := range []struct {
+					providerType string
+					baseURL      string
+					expected     string
+				}{
+					{"anthropic", "https://api.anthropic.com/v1", "/v1/messages"},
+					{"anthropic", "https://api.anthropic.com", "/v1/messages"},
+					{"minimax", "https://api.minimax.io/v1", "/v1/chat/completions"},
+					{"minimax", "https://api.minimax.io", "/v1/chat/completions"},
+					{"openai", "https://api.openai.com/v1", "/v1/chat/completions"},
+					{"anthropic", "https://gateway.example.com/openai/v1", "/openai/v1/messages"},
+					{"anthropic", "https://gateway.example.com/v1beta", "/v1beta/v1/messages"},
+					{"anthropic", "https://api.anthropic.com/v1/", "/v1/messages"},
+				} {
+					path, err := (&ProviderProfile{Type: tc.providerType, BaseURL: tc.baseURL}).ResolveChatPath()
+					Expect(err).NotTo(HaveOccurred(), "%s %s", tc.providerType, tc.baseURL)
+					Expect(path).To(Equal(tc.expected), "%s %s", tc.providerType, tc.baseURL)
+				}
+			})
+
 			It("should append api-version for azure-openai", func() {
 				profile := &ProviderProfile{
 					Type:       "azure-openai",

--- a/src/semantic-router/pkg/config/helper.go
+++ b/src/semantic-router/pkg/config/helper.go
@@ -738,7 +738,8 @@ func (p *ProviderProfile) ResolveAuthHeader() (string, string, error) {
 //
 // Resolution order (no silent fallback):
 //  1. Explicit ChatPath field on the profile (used as-is, plus ?api-version for azure-openai).
-//  2. base_url path + type-default suffix from providerTypeRegistry.
+//  2. base_url path + type-default suffix from providerTypeRegistry, with a
+//     version segment repeated by both sides collapsed to one.
 //  3. Type-default suffix alone if base_url has no path component.
 //
 // Returns error if the type is not recognised or base_url is unparsable.
@@ -761,10 +762,7 @@ func (p *ProviderProfile) ResolveChatPath() (string, error) {
 		return path, nil
 	}
 
-	suffix := info.ChatPath
-	if p.Type == "azure-openai" && p.APIVersion != "" {
-		suffix += "?api-version=" + p.APIVersion
-	}
+	path := info.ChatPath
 
 	// Prepend base_url path component if present
 	if p.BaseURL != "" {
@@ -772,10 +770,30 @@ func (p *ProviderProfile) ResolveChatPath() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("cannot parse base_url %q: %w", p.BaseURL, err)
 		}
-		if u.Path != "" && u.Path != "/" {
-			return strings.TrimRight(u.Path, "/") + suffix, nil
-		}
+		path = joinProviderBasePath(u.Path, path)
 	}
 
-	return suffix, nil
+	if p.Type == "azure-openai" && p.APIVersion != "" {
+		path += "?api-version=" + p.APIVersion
+	}
+
+	return path, nil
+}
+
+// joinProviderBasePath prefixes a type-default endpoint suffix with the
+// base_url path component.
+//
+// Some type suffixes carry the API version and some expect it from base_url,
+// so the documented versioned API root (https://provider.example/v1) would
+// double it for the former. Collapse the repeat, matching providerProtocolPath
+// in pkg/extproc so both upstream-URL builders agree.
+func joinProviderBasePath(basePath, suffix string) string {
+	basePath = strings.TrimRight(basePath, "/")
+	if basePath == "" {
+		return suffix
+	}
+	if strings.HasSuffix(basePath, "/v1") && strings.HasPrefix(suffix, "/v1/") {
+		return basePath + strings.TrimPrefix(suffix, "/v1")
+	}
+	return basePath + suffix
 }

--- a/website/docs/troubleshooting/common-errors.md
+++ b/website/docs/troubleshooting/common-errors.md
@@ -310,6 +310,12 @@ Use `base_url` when the provider requires a complete API root such as
 `https://provider.example/v1`. Use a hostname reachable from the Router
 network; `localhost` refers to the Router container itself.
 
+The version segment in that API root is accepted for every provider `type`.
+Types whose own endpoint suffix already carries the version, such as
+`anthropic` and `minimax`, do not repeat it, so both
+`https://provider.example/v1` and `https://provider.example` resolve to the
+same upstream path.
+
 See [Container connectivity](./container-connectivity) for end-to-end checks.
 
 ## A classifier or embedding model cannot load


### PR DESCRIPTION
Closes #3065

## Purpose

`providers.models[].backend_refs[].base_url` needed `/v1` for OpenAI-format backends but had to omit it for Anthropic-format ones. Giving an `anthropic` backend the complete API root that [`common-errors.md`](https://github.com/vllm-project/semantic-router/blob/main/website/docs/troubleshooting/common-errors.md) documents produced a doubled version segment upstream.

Reproduced on `main` @ `6ffc9c68` against `ProviderProfile.ResolveChatPath` (`src/semantic-router/pkg/config/helper.go`):

```
type=anthropic  base_url=https://backend.example.com/v1  -> /v1/v1/messages   <- bug
type=anthropic  base_url=https://backend.example.com     -> /v1/messages
type=openai     base_url=https://backend.example.com/v1  -> /v1/chat/completions
```

**Root cause.** `providerTypeRegistry` stores the version inside the per-type suffix for some types and not others:

```go
"openai":    {..., ChatPath: "/chat/completions"},      // version comes from base_url
"anthropic": {..., ChatPath: "/v1/messages"},           // version is in the suffix
"minimax":   {..., ChatPath: "/v1/chat/completions"},   // same shape as anthropic
```

`ResolveChatPath` concatenated the `base_url` path and the suffix with no reconciliation, so whether `/v1` belonged in `base_url` silently depended on the type. `minimax` shares anthropic's shape, so this was never a two-provider issue.

**The rule already existed on the other upstream-URL path.** `providerProtocolPath` (`src/semantic-router/pkg/extproc/processor_req_body_routing.go`) already collapses the duplicate for protocol dispatch. The two builders simply disagreed with each other.

**Fix.** Apply that same de-duplication in `ResolveChatPath` via a new `joinProviderBasePath` helper, so a trailing `/v1` on `base_url` is never doubled and the documented spelling works for every provider type.

Collapsing was chosen over declaring one convention canonical deliberately: redefining `base_url` to mean server-root for OpenAI (or versioned-root for Anthropic) would silently re-route every deployment already using the current convention, whereas de-duplication accepts the documented spelling and changes no working deployment's upstream path. If you would rather declare a single convention with a deprecation warning for the other spelling, I am happy to rewrite it that way — that is a config-semantics call that should be yours.

The helper extraction is not cosmetic: the inline form pushed `ResolveChatPath` past the repo's `cyclop` (13 > 12) and `nestif` limits under `make agent-lint`.

### Out of scope

`type=openai` with an unversioned `base_url` still resolves to `/chat/completions` with no version segment. Injecting `/v1` there would require declaring the convention this PR avoids declaring, and would break `azure-openai`, `bedrock`, `gemini`, and `vertex-ai`, which share the same suffix but not the same API root shape. Since the docs already define `base_url` as the complete API root, that case is a misconfiguration rather than a defect. Happy to file it separately if you disagree.

Consolidating `joinProviderBasePath` and `providerProtocolPath` into one shared helper is also left out — `pkg/extproc` imports `pkg/config` and not the reverse, so it is a wider refactor than this bug needs, and it would overlap #3292, which is reworking the Envoy-side rewrite path.

## Test Plan

- New table-driven spec in `src/semantic-router/pkg/config/config_test.go` covering `anthropic` / `minimax` / `openai` against both versioned and unversioned `base_url`, plus the cases that must **not** collapse (`/openai/v1`, `/v1beta`) and a trailing-slash root.
- Existing `ResolveChatPath` specs, including the `azure-openai` `?api-version` case and the explicit `ChatPath` override, kept unchanged as regression cover.
- `make agent-report ENV=cpu CHANGED_FILES="..."` → primary skill `config-platform-change`.
- `make agent-ci-gate CHANGED_FILES="src/semantic-router/pkg/config/helper.go src/semantic-router/pkg/config/config_test.go website/docs/troubleshooting/common-errors.md"`.

## Test Result

`make agent-ci-gate` passes (exit 0): baseline pre-commit, Go structural lint, `recipe-conformance-static`, `test-semantic-router`, and `dashboard-check` all green. The two `golangci-lint` findings on the first attempt (`cyclop` 13 > 12 and `nestif` on the `base_url` block) are resolved by the helper extraction.

The new spec was confirmed to actually cover the bug: with the `helper.go` change stashed it fails with `/v1/v1/messages` for `anthropic` + `https://api.anthropic.com/v1`, and passes with the change applied.

No E2E update: `ResolveChatPath` behavior changes only for a `base_url` spelling that is currently broken, and no repo-owned config, recipe, or E2E profile uses it. The `dashboard/backend` caller (`handlers/model_verification_service.go`) picks the fix up unchanged and its suite passes.

No remaining blocker.
