### PR TITLE
[Bug] Pin CentOS base image to a resolvable stream10 digest with shell and dnf

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream10
+FROM quay.io/centos/centos:stream10-development@sha256:556c6f559c63a24e52843778ed7ee0887be572f7df4219a971d2b2820bbb6675
 
 RUN dnf -y update && \
     dnf -y install epel-release && \

--- a/tools/docker/Dockerfile.extproc
+++ b/tools/docker/Dockerfile.extproc
@@ -475,7 +475,7 @@ RUN cd src/semantic-router && \
 # ============================================================================
 # Final stage: runtime image (candle on all platforms, onnx + openvino on amd64 only)
 # ============================================================================
-FROM quay.io/centos/centos:stream10
+FROM quay.io/centos/centos:stream10-development@sha256:556c6f559c63a24e52843778ed7ee0887be572f7df4219a971d2b2820bbb6675
 
 # Install runtime dependencies including OpenSSL, Python and HuggingFace CLI
 RUN dnf update -y && \


### PR DESCRIPTION
Fixes #3312

### Problem

quay.io/centos/centos:stream10 was re-pushed to a manifest whose only
outer layer expands to blobs/, index.json and oci-layout instead of a
root filesystem, so /bin/sh is absent and the first RUN in the final
stage cannot start. Both occurrences in this repo are immediately
followed by a RUN dnf ..., so both break the same way:

  tools/docker/Dockerfile:1
  tools/docker/Dockerfile.extproc:478

The digest suggested in the issue (sha256:ad14f7d9...) is no longer
resolvable — Quay returns not found, while other digests in the same
repository pull fine, so the manifest appears to have been garbage
collected after the tag moved off it. Pinning to it would not unblock
CI.

### Change

Pin both occurrences to stream10-development by digest:

  quay.io/centos/centos:stream10-development@sha256:556c6f55...

### Verification

Per the request in the issue, both /bin/sh and dnf are confirmed present
in the pinned image:

  $ docker create --platform linux/amd64 --name probe \
      quay.io/centos/centos:stream10-development
  $ docker export probe | tar -tf - | grep -E '^(usr/)?bin/(sh|dnf)$'
  usr/bin/dnf
  usr/bin/sh

Filesystem probe rather than an exec check because every Stream 10 / RHEL
10 image requires x86-64-v3, which my arm64 emulation layer doesn't
provide — Red Hat's own ubi10 fails identically on my machine, so this is
a local limitation, not a property of the image. CI runners are x86 and
support v3.

For reference, what else I checked:

  stream10            no /bin/sh (current, broken)
  10                  same digest as stream10, no /bin/sh
  stream10-minimal    no /bin/sh — so the bad push hit the minimal tag too
  stream10-development /bin/sh + dnf present  <- chosen
  stream9             /bin/sh + dnf, fully verified by exec
  ubi10               /bin/sh + dnf present

### Why this option

Smallest change that unblocks: same version line, one digest per file, no
package version churn.

  - stream9 would work and is the only one I could verify by execution,
    but it's a major version drop and would shift gcc / python3 / openssl
    versions.
  - ubi10 is arguably the better long-term base, but tools/docker/Dockerfile
    does `dnf -y install epel-release`, which needs different handling on
    UBI. That's not a change I can validate locally.

stream10-development is a development stream, so this is an unblock rather
than the end state — switching back to stream10 once upstream fixes the
published artifact would be the natural follow-up. Happy to switch to
ubi10 or stream9 instead if you'd prefer.

### Follow-up worth filing separately

Automated digest bumps (Renovate/Dependabot) for base images, so a silent
retag lands in one reviewable PR with CI on it instead of reddening every
open PR at once.