### PR TITLE
[Feature] Add shared connector for remote Router Model calls

### DIFF
--- a/src/semantic-router/pkg/classification/category_remote_backend_test.go
+++ b/src/semantic-router/pkg/classification/category_remote_backend_test.go
@@ -24,14 +24,12 @@ func TestCategoryHTTPBackendPreservesNamedFullDistribution(t *testing.T) {
 
 	deadline := 1500
 	backend, err := newCategoryHTTPBackend(&config.ExternalModelConfig{
-		ModelEndpoint: config.ClassifierVLLMEndpoint{Address: "127.0.0.1", Port: 8080},
+		ModelEndpoint: endpointForTestServer(t, server),
 		ModelName:     "named-category-service",
 	}, mapping, time.Duration(deadline)*time.Millisecond)
 	if err != nil {
 		t.Fatalf("newCategoryHTTPBackend: %v", err)
 	}
-	backend.(*categoryHTTPBackend).backend.(*HTTPClassifierInference).baseURL = server.URL
-
 	result, err := backend.ClassifyWithProbabilities(context.Background(), "solve this")
 	if err != nil {
 		t.Fatalf("ClassifyWithProbabilities: %v", err)
@@ -60,14 +58,12 @@ func TestCategoryHTTPBackendPreservesCallerCancellation(t *testing.T) {
 		IdxToCategory: map[string]string{"0": "math", "1": "other"},
 	}
 	backend, err := newCategoryHTTPBackend(&config.ExternalModelConfig{
-		ModelEndpoint: config.ClassifierVLLMEndpoint{Address: "127.0.0.1", Port: 8080},
+		ModelEndpoint: endpointForTestServer(t, server),
 		ModelName:     "named-category-service",
 	}, mapping, time.Second)
 	if err != nil {
 		t.Fatalf("newCategoryHTTPBackend: %v", err)
 	}
-	backend.(*categoryHTTPBackend).backend.(*HTTPClassifierInference).baseURL = server.URL
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -102,7 +98,7 @@ func TestCategoryHTTPBackendDoesNotUseTop1FallbackOnDistributionError(t *testing
 	}
 }
 
-func TestCategoryHTTPBackendDistributionFailureMakesOneRequest(t *testing.T) {
+func TestCategoryHTTPBackendDistributionFailureDoesNotFallbackAfterConnectorRetry(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests.Add(1)
@@ -115,14 +111,12 @@ func TestCategoryHTTPBackendDistributionFailureMakesOneRequest(t *testing.T) {
 		IdxToCategory: map[string]string{"0": "math", "1": "other"},
 	}
 	backend, err := newCategoryHTTPBackend(&config.ExternalModelConfig{
-		ModelEndpoint: config.ClassifierVLLMEndpoint{Address: "127.0.0.1", Port: 8080},
+		ModelEndpoint: endpointForTestServer(t, server),
 		ModelName:     "named-category-service",
 	}, mapping, time.Second)
 	if err != nil {
 		t.Fatalf("newCategoryHTTPBackend: %v", err)
 	}
-	backend.(*categoryHTTPBackend).backend.(*HTTPClassifierInference).baseURL = server.URL
-
 	classifier := &Classifier{
 		Config: &config.RouterConfig{InlineModels: config.InlineModels{Classifier: config.Classifier{
 			CategoryModel: config.CategoryModel{},
@@ -136,8 +130,8 @@ func TestCategoryHTTPBackendDistributionFailureMakesOneRequest(t *testing.T) {
 		Metrics:           &SignalMetricsCollection{},
 	}
 	classifier.evaluateDomainSignal(context.Background(), results, &sync.Mutex{}, "one request")
-	if got := requests.Load(); got != 1 {
-		t.Fatalf("remote requests = %d, want 1", got)
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("remote requests = %d, want 2 connector attempts without a second classification call", got)
 	}
 	if _, ok := results.SignalErrors[config.SignalTypeDomain]; ok {
 		t.Fatalf("category failure unexpectedly recorded signal error %q", results.SignalErrors[config.SignalTypeDomain])

--- a/src/semantic-router/pkg/classification/classifier_lifecycle.go
+++ b/src/semantic-router/pkg/classification/classifier_lifecycle.go
@@ -2,7 +2,9 @@ package classification
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/modelruntime"
@@ -131,10 +133,31 @@ func (c *Classifier) defaultAPIRuntimeTasks() []modelruntime.Task {
 
 // Close releases the classifier's runtime resources.
 func (c *Classifier) Close() error {
-	if c == nil || c.mcpCategoryInitializer == nil {
+	if c == nil {
 		return nil
 	}
-	return c.mcpCategoryInitializer.Close()
+	var closeErrors []error
+	closeResource := func(name string, resource interface{}) {
+		closer, ok := resource.(interface{ Close() error })
+		if !ok || closer == nil {
+			return
+		}
+		if err := closer.Close(); err != nil {
+			closeErrors = append(closeErrors, fmt.Errorf("close %s: %w", name, err))
+		}
+	}
+
+	closeResource("MCP category classifier", c.mcpCategoryInitializer)
+	closeResource("jailbreak classifier", c.jailbreakInference)
+	genericNames := make([]string, 0, len(c.genericClassifiers))
+	for name := range c.genericClassifiers {
+		genericNames = append(genericNames, name)
+	}
+	sort.Strings(genericNames)
+	for _, name := range genericNames {
+		closeResource("generic classifier "+name, c.genericClassifiers[name])
+	}
+	return errors.Join(closeErrors...)
 }
 
 func (c *Classifier) runtimeTasks() []modelruntime.Task {

--- a/src/semantic-router/pkg/classification/generic_classifier_sequence.go
+++ b/src/semantic-router/pkg/classification/generic_classifier_sequence.go
@@ -80,3 +80,10 @@ func (c *sequenceLabelClassifier) Classify(
 	}
 	return labelClassification{Scores: scores}, nil
 }
+
+func (c *sequenceLabelClassifier) Close() error {
+	if c == nil {
+		return nil
+	}
+	return c.backend.Close()
+}

--- a/src/semantic-router/pkg/classification/generic_classifier_sequence_test.go
+++ b/src/semantic-router/pkg/classification/generic_classifier_sequence_test.go
@@ -22,13 +22,12 @@ func toxicityRule() config.ClassifierSignalRule {
 func newTestSequenceClassifier(t *testing.T, server *httptest.Server, rule config.ClassifierSignalRule) labelClassifier {
 	t.Helper()
 	classifier, err := newSequenceLabelClassifier(rule, &config.ExternalModelConfig{
-		ModelEndpoint: config.ClassifierVLLMEndpoint{Address: "placeholder", Port: 1},
+		ModelEndpoint: endpointForTestServer(t, server),
 		ModelRole:     config.ModelRoleClassification,
 	})
 	if err != nil {
 		t.Fatalf("failed to construct classifier: %v", err)
 	}
-	classifier.(*sequenceLabelClassifier).backend.baseURL = server.URL
 	return classifier
 }
 

--- a/src/semantic-router/pkg/classification/http_classifier.go
+++ b/src/semantic-router/pkg/classification/http_classifier.go
@@ -1,9 +1,9 @@
 package classification
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
-	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/modelruntime/connector"
 )
 
 // probabilitySumTolerance bounds how far an http_classify response's scores
@@ -58,13 +58,9 @@ type sequenceLabelMapping interface {
 // external model (a 14-label category classifier) during #2918, not just a
 // synthetic mock.
 type HTTPClassifierInference struct {
-	httpClient       *http.Client
-	baseURL          string
-	accessKey        string
-	timeout          time.Duration
-	maxRequestBytes  int64
-	maxResponseBytes int64
-	mapping          sequenceLabelMapping
+	connector *connector.Client
+	timeout   time.Duration
+	mapping   sequenceLabelMapping
 }
 
 // NewHTTPClassifierInference creates a new http_classify-backed inference
@@ -114,14 +110,21 @@ func newHTTPClassifierInference(cfg *config.ExternalModelConfig, mapping sequenc
 		timeout = time.Duration(cfg.TimeoutSeconds) * time.Second
 	}
 
+	remote, err := connector.New(baseURL, bearerAuthorizer(cfg.AccessKey), connector.Options{
+		AttemptTimeout:   timeout,
+		MaxRetries:       1,
+		MaxRequestBytes:  cfg.GetMaxRequestBytes(),
+		MaxResponseBytes: cfg.GetMaxResponseBytes(),
+		MaxErrorBytes:    maxClassifyErrorBodyBytes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create http_classify connector: %w", err)
+	}
+
 	return &HTTPClassifierInference{
-		httpClient:       &http.Client{Timeout: timeout},
-		baseURL:          baseURL,
-		accessKey:        cfg.AccessKey,
-		timeout:          timeout,
-		maxRequestBytes:  cfg.GetMaxRequestBytes(),
-		maxResponseBytes: cfg.GetMaxResponseBytes(),
-		mapping:          mapping,
+		connector: remote,
+		timeout:   timeout,
+		mapping:   mapping,
 	}, nil
 }
 
@@ -150,6 +153,13 @@ type httpClassifyLabelScore struct {
 	Score float32 `json:"score"`
 }
 
+var httpClassifyOperation = connector.Operation{
+	Name:      "http_classify",
+	Method:    http.MethodPost,
+	Path:      "/classify",
+	RetrySafe: true,
+}
+
 // Classify implements the SequenceClassifierBackend interface. It derives its
 // deadline from the caller's ctx (so the request can be cancelled if the
 // caller gives up first) bounded by h.timeout, rather than always running to
@@ -158,73 +168,52 @@ func (h *HTTPClassifierInference) Classify(ctx context.Context, text string) (Se
 	ctx, cancel := context.WithTimeout(ctx, h.timeout)
 	defer cancel()
 
-	httpReq, err := h.buildClassifyRequest(ctx, text)
-	if err != nil {
-		return SequenceClassificationResult{}, err
-	}
-
-	scores, err := h.doClassifyRequest(httpReq)
-	if err != nil {
-		return SequenceClassificationResult{}, err
-	}
-
-	return alignScoresToMapping(h.mapping, scores)
-}
-
-// buildClassifyRequest builds the outgoing http_classify HTTP request.
-func (h *HTTPClassifierInference) buildClassifyRequest(ctx context.Context, text string) (*http.Request, error) {
 	reqBody, err := json.Marshal(httpClassifyRequest{Inputs: text})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal http_classify request: %w", err)
+		return SequenceClassificationResult{}, fmt.Errorf("failed to marshal http_classify request: %w", err)
 	}
-	if int64(len(reqBody)) > h.maxRequestBytes {
-		return nil, fmt.Errorf(
-			"http_classify request body is %d bytes, exceeding the limit of %d bytes", len(reqBody), h.maxRequestBytes)
+	responseBody, err := h.connector.Do(ctx, httpClassifyOperation, reqBody)
+	if err != nil {
+		return SequenceClassificationResult{}, formatHTTPClassifyConnectorError(err)
 	}
 
-	url := fmt.Sprintf("%s/classify", h.baseURL)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http_classify request: %w", err)
+	var scores []httpClassifyLabelScore
+	if err := json.Unmarshal(responseBody, &scores); err != nil {
+		return SequenceClassificationResult{}, fmt.Errorf("failed to parse http_classify response: %w", err)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/json")
-	if h.accessKey != "" {
-		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", h.accessKey))
+	if len(scores) == 0 {
+		return SequenceClassificationResult{}, fmt.Errorf("http_classify response contained no labels")
 	}
-	return httpReq, nil
+	return alignScoresToMapping(h.mapping, scores)
 }
 
 const maxClassifyErrorBodyBytes int64 = 8 * 1024
 
-// doClassifyRequest sends the request and parses the label/score list from a
-// successful response.
-func (h *HTTPClassifierInference) doClassifyRequest(httpReq *http.Request) ([]httpClassifyLabelScore, error) {
-	resp, err := h.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("http_classify request failed: %w", err)
+func formatHTTPClassifyConnectorError(err error) error {
+	var connectorErr *connector.Error
+	if !errors.As(err, &connectorErr) {
+		return fmt.Errorf("http_classify request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	switch connectorErr.Kind {
+	case connector.KindStatus:
+		body, truncated := connectorErr.ResponseBody()
+		return fmt.Errorf(
+			"http_classify endpoint returned status %d: %s (truncated=%t): %w",
+			connectorErr.StatusCode, string(body), truncated, connectorErr,
+		)
+	case connector.KindResponse:
+		return fmt.Errorf("failed to read http_classify response: %w", connectorErr)
+	default:
+		return fmt.Errorf("http_classify request failed: %w", connectorErr)
+	}
+}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		errBody, truncated := httputil.ReadTruncatedBody(resp.Body, maxClassifyErrorBodyBytes)
-		return nil, fmt.Errorf(
-			"http_classify endpoint returned status %d: %s (truncated=%t)", resp.StatusCode, string(errBody), truncated)
+// Close releases idle connections owned by the remote connector.
+func (h *HTTPClassifierInference) Close() error {
+	if h == nil || h.connector == nil {
+		return nil
 	}
-
-	body, err := httputil.ReadLimitedBody(resp.Body, h.maxResponseBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read http_classify response: %w", err)
-	}
-
-	var scores []httpClassifyLabelScore
-	if err := json.Unmarshal(body, &scores); err != nil {
-		return nil, fmt.Errorf("failed to parse http_classify response: %w", err)
-	}
-	if len(scores) == 0 {
-		return nil, fmt.Errorf("http_classify response contained no labels")
-	}
-	return scores, nil
+	return h.connector.Close()
 }
 
 // alignScoresToMapping matches response labels against the configured label

--- a/src/semantic-router/pkg/classification/http_classifier_limits_test.go
+++ b/src/semantic-router/pkg/classification/http_classifier_limits_test.go
@@ -27,7 +27,7 @@ func inputForRequestBytes(t *testing.T, n int) string {
 func newLimitedTestInference(t *testing.T, server *httptest.Server, requestBytes, responseBytes int64) *HTTPClassifierInference {
 	t.Helper()
 	inf, err := NewHTTPClassifierInference(&config.ExternalModelConfig{
-		ModelEndpoint:    config.ClassifierVLLMEndpoint{Address: "placeholder", Port: 1},
+		ModelEndpoint:    endpointForTestServer(t, server),
 		ModelName:        "custom-classifier",
 		MaxRequestBytes:  requestBytes,
 		MaxResponseBytes: responseBytes,
@@ -35,58 +35,7 @@ func newLimitedTestInference(t *testing.T, server *httptest.Server, requestBytes
 	if err != nil {
 		t.Fatalf("failed to construct inference: %v", err)
 	}
-	inf.baseURL = server.URL
 	return inf
-}
-
-func TestNewHTTPClassifierInference_ByteLimitDefaults(t *testing.T) {
-	tests := []struct {
-		name            string
-		requestBytes    int64
-		responseBytes   int64
-		wantRequestMax  int64
-		wantResponseMax int64
-	}{
-		{
-			name:            "unset uses the http_classify defaults",
-			wantRequestMax:  config.DefaultClassifyMaxRequestBytes,
-			wantResponseMax: config.DefaultClassifyMaxResponseBytes,
-		},
-		{
-			name:            "explicit overrides win",
-			requestBytes:    4096,
-			responseBytes:   8192,
-			wantRequestMax:  4096,
-			wantResponseMax: 8192,
-		},
-		{
-			name:            "non-positive values fall back to the defaults",
-			requestBytes:    -1,
-			responseBytes:   -1,
-			wantRequestMax:  config.DefaultClassifyMaxRequestBytes,
-			wantResponseMax: config.DefaultClassifyMaxResponseBytes,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			inf, err := NewHTTPClassifierInference(&config.ExternalModelConfig{
-				ModelEndpoint:    config.ClassifierVLLMEndpoint{Address: "127.0.0.1", Port: 8080},
-				ModelName:        "custom-classifier",
-				MaxRequestBytes:  tt.requestBytes,
-				MaxResponseBytes: tt.responseBytes,
-			}, testJailbreakMapping())
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if inf.maxRequestBytes != tt.wantRequestMax {
-				t.Errorf("maxRequestBytes = %d, want %d", inf.maxRequestBytes, tt.wantRequestMax)
-			}
-			if inf.maxResponseBytes != tt.wantResponseMax {
-				t.Errorf("maxResponseBytes = %d, want %d", inf.maxResponseBytes, tt.wantResponseMax)
-			}
-		})
-	}
 }
 
 func TestHTTPClassifierInferenceClassify_RequestAtLimitIsSent(t *testing.T) {

--- a/src/semantic-router/pkg/classification/http_classifier_test.go
+++ b/src/semantic-router/pkg/classification/http_classifier_test.go
@@ -143,7 +143,6 @@ func TestHTTPClassifierInferenceDeadlineStopsSlowRequest(t *testing.T) {
 
 	inf := newTestHTTPClassifierInference(t, server, testJailbreakMapping())
 	inf.timeout = 25 * time.Millisecond
-	inf.httpClient.Timeout = inf.timeout
 	startedAt := time.Now()
 	_, err := inf.Classify(context.Background(), "slow request")
 	if err == nil {
@@ -187,13 +186,12 @@ func TestHTTPClassifierInferenceConcurrentClassify(t *testing.T) {
 func newTestHTTPClassifierInference(t *testing.T, server *httptest.Server, mapping sequenceLabelMapping) *HTTPClassifierInference {
 	t.Helper()
 	inf, err := NewHTTPClassifierInference(&config.ExternalModelConfig{
-		ModelEndpoint: config.ClassifierVLLMEndpoint{Address: "placeholder", Port: 1},
+		ModelEndpoint: endpointForTestServer(t, server),
 		ModelName:     "custom-classifier",
 	}, mapping)
 	if err != nil {
 		t.Fatalf("failed to construct inference: %v", err)
 	}
-	inf.baseURL = server.URL
 	return inf
 }
 

--- a/src/semantic-router/pkg/classification/remote_connector.go
+++ b/src/semantic-router/pkg/classification/remote_connector.go
@@ -1,0 +1,17 @@
+package classification
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+func bearerAuthorizer(accessKey string) func(context.Context, *http.Request) error {
+	if accessKey == "" {
+		return nil
+	}
+	return func(_ context.Context, request *http.Request) error {
+		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessKey))
+		return nil
+	}
+}

--- a/src/semantic-router/pkg/classification/remote_connector_lifecycle_test.go
+++ b/src/semantic-router/pkg/classification/remote_connector_lifecycle_test.go
@@ -1,0 +1,54 @@
+package classification
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+type closingSequenceBackend struct {
+	closed bool
+}
+
+func (b *closingSequenceBackend) Classify(context.Context, string) (SequenceClassificationResult, error) {
+	return SequenceClassificationResult{}, nil
+}
+
+func (b *closingSequenceBackend) Close() error {
+	b.closed = true
+	return nil
+}
+
+type closingLabelClassifier struct {
+	closed bool
+}
+
+func (c *closingLabelClassifier) Classify(context.Context, string) (labelClassification, error) {
+	return labelClassification{}, nil
+}
+
+func (c *closingLabelClassifier) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestClassifierCloseClosesRemoteClassifierResources(t *testing.T) {
+	jailbreak := &closingSequenceBackend{}
+	generic := &closingLabelClassifier{}
+	classifier, err := newClassifierWithOptions(
+		&config.RouterConfig{},
+		withJailbreak(nil, nil, jailbreak),
+		withGenericClassifiers(map[string]labelClassifier{"remote": generic}),
+	)
+	if err != nil {
+		t.Fatalf("newClassifierWithOptions() error = %v", err)
+	}
+
+	if err := classifier.Close(); err != nil {
+		t.Fatalf("Classifier.Close() error = %v", err)
+	}
+	if !jailbreak.closed || !generic.closed {
+		t.Fatalf("closed resources = jailbreak:%t generic:%t", jailbreak.closed, generic.closed)
+	}
+}

--- a/src/semantic-router/pkg/classification/remote_connector_test.go
+++ b/src/semantic-router/pkg/classification/remote_connector_test.go
@@ -1,0 +1,54 @@
+package classification
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func endpointForTestServer(t *testing.T, server *httptest.Server) config.ClassifierVLLMEndpoint {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	return config.ClassifierVLLMEndpoint{
+		Protocol: parsed.Scheme,
+		Address:  parsed.Hostname(),
+		Port:     port,
+	}
+}
+
+func TestHTTPClassifierRetriesTransientStatus(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]httpClassifyLabelScore{
+			{Label: "safe", Score: 0.9},
+			{Label: "jailbreak", Score: 0.1},
+		})
+	}))
+	defer server.Close()
+
+	inference := newTestHTTPClassifierInference(t, server, testJailbreakMapping())
+	if _, err := inference.Classify(context.Background(), "hello"); err != nil {
+		t.Fatalf("Classify() error = %v", err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+}

--- a/src/semantic-router/pkg/modelruntime/connector/connector.go
+++ b/src/semantic-router/pkg/modelruntime/connector/connector.go
@@ -1,0 +1,256 @@
+// Package connector provides the shared HTTP mechanics used by remote router
+// model protocol adapters.
+package connector
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// Operation describes one static operation in a remote model protocol.
+type Operation struct {
+	Name      string
+	Method    string
+	Path      string
+	RetrySafe bool
+}
+
+// Options defines bounded transport behavior. Byte limits and AttemptTimeout
+// must be positive; MaxRetries is the number of attempts after the first one.
+type Options struct {
+	AttemptTimeout   time.Duration
+	MaxRetries       int
+	MaxRequestBytes  int64
+	MaxResponseBytes int64
+	MaxErrorBytes    int64
+}
+
+// Client binds one deployment endpoint, its authentication hook, and bounded
+// transport policy. Protocol payloads remain owned by callers.
+type Client struct {
+	baseURL   *url.URL
+	authorize func(context.Context, *http.Request) error
+	options   Options
+	http      *http.Client
+}
+
+func New(
+	baseURL string,
+	authorize func(context.Context, *http.Request) error,
+	options Options,
+) (*Client, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("parse connector base URL: %w", err)
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return nil, fmt.Errorf("connector base URL must be an absolute HTTP(S) URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("connector base URL must not contain user info, query, or fragment")
+	}
+	if err := validateOptions(options); err != nil {
+		return nil, err
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	return &Client{
+		baseURL:   parsed,
+		authorize: authorize,
+		options:   options,
+		http:      &http.Client{Transport: transport},
+	}, nil
+}
+
+func validateOptions(options Options) error {
+	if options.AttemptTimeout <= 0 {
+		return fmt.Errorf("connector attempt timeout must be positive")
+	}
+	if options.MaxRetries < 0 {
+		return fmt.Errorf("connector max retries must not be negative")
+	}
+	if options.MaxRequestBytes <= 0 || options.MaxResponseBytes <= 0 || options.MaxErrorBytes <= 0 {
+		return fmt.Errorf("connector body limits must be positive")
+	}
+	return nil
+}
+
+// Do invokes an operation and returns its bounded successful response body.
+func (c *Client) Do(ctx context.Context, operation Operation, body []byte) ([]byte, error) {
+	if err := validateOperation(operation); err != nil {
+		return nil, &Error{Kind: KindRequest, Operation: operation.Name, Cause: err}
+	}
+	if int64(len(body)) > c.options.MaxRequestBytes {
+		return nil, &Error{
+			Kind:      KindRequest,
+			Operation: operation.Name,
+			Cause: fmt.Errorf(
+				"request body is %d bytes, exceeding the limit of %d bytes",
+				len(body), c.options.MaxRequestBytes,
+			),
+		}
+	}
+
+	for attempt := 1; ; attempt++ {
+		responseBody, connectorErr := c.doAttempt(ctx, operation, body, attempt)
+		if connectorErr == nil {
+			return responseBody, nil
+		}
+		if !connectorErr.Retryable || attempt > c.options.MaxRetries {
+			return nil, connectorErr
+		}
+		if err := waitBeforeRetry(ctx, attempt); err != nil {
+			return nil, &Error{
+				Kind:      KindTransport,
+				Operation: operation.Name,
+				Attempt:   attempt,
+				Cause:     err,
+			}
+		}
+	}
+}
+
+func validateOperation(operation Operation) error {
+	if strings.TrimSpace(operation.Name) == "" {
+		return fmt.Errorf("operation name is required")
+	}
+	if strings.TrimSpace(operation.Method) == "" {
+		return fmt.Errorf("operation method is required")
+	}
+	if !strings.HasPrefix(operation.Path, "/") || strings.ContainsAny(operation.Path, "?#") {
+		return fmt.Errorf("operation path must be an absolute path without query or fragment")
+	}
+	return nil
+}
+
+func (c *Client) doAttempt(
+	ctx context.Context,
+	operation Operation,
+	body []byte,
+	attempt int,
+) ([]byte, *Error) {
+	if ctx == nil {
+		return nil, &Error{Kind: KindRequest, Operation: operation.Name, Attempt: attempt, Cause: fmt.Errorf("context is nil")}
+	}
+	attemptCtx, cancel := context.WithTimeout(ctx, c.options.AttemptTimeout)
+	defer cancel()
+
+	request, connectorErr := c.newRequest(attemptCtx, operation, body, attempt)
+	if connectorErr != nil {
+		return nil, connectorErr
+	}
+	response, err := c.http.Do(request)
+	if err != nil {
+		return nil, &Error{
+			Kind:      KindTransport,
+			Operation: operation.Name,
+			Attempt:   attempt,
+			Retryable: operation.RetrySafe && ctx.Err() == nil && retryableTransportError(err),
+			Cause:     err,
+		}
+	}
+	defer response.Body.Close()
+	return c.readResponse(ctx, operation, response, attempt)
+}
+
+func (c *Client) newRequest(
+	ctx context.Context,
+	operation Operation,
+	body []byte,
+	attempt int,
+) (*http.Request, *Error) {
+	target := *c.baseURL
+	target.Path = path.Join(c.baseURL.Path, operation.Path)
+	target.RawPath = ""
+	request, err := http.NewRequestWithContext(ctx, operation.Method, target.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, &Error{Kind: KindRequest, Operation: operation.Name, Attempt: attempt, Cause: err}
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	if c.authorize != nil {
+		if err := c.authorize(ctx, request); err != nil {
+			return nil, &Error{Kind: KindAuthorization, Operation: operation.Name, Attempt: attempt, Cause: err}
+		}
+	}
+	return request, nil
+}
+
+func (c *Client) readResponse(
+	ctx context.Context,
+	operation Operation,
+	response *http.Response,
+	attempt int,
+) ([]byte, *Error) {
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		errorBody, truncated, readErr := readBounded(response.Body, c.options.MaxErrorBytes)
+		if readErr != nil {
+			return nil, &Error{
+				Kind:      KindResponse,
+				Operation: operation.Name,
+				Attempt:   attempt,
+				Retryable: operation.RetrySafe && ctx.Err() == nil,
+				Cause:     readErr,
+			}
+		}
+		return nil, &Error{
+			Kind:       KindStatus,
+			Operation:  operation.Name,
+			StatusCode: response.StatusCode,
+			Attempt:    attempt,
+			Retryable:  operation.RetrySafe && retryableStatus(response.StatusCode),
+			body:       errorBody,
+			truncated:  truncated,
+		}
+	}
+
+	responseBody, exceeded, err := readBounded(response.Body, c.options.MaxResponseBytes)
+	if err != nil {
+		return nil, &Error{
+			Kind:      KindResponse,
+			Operation: operation.Name,
+			Attempt:   attempt,
+			Retryable: operation.RetrySafe && ctx.Err() == nil,
+			Cause:     err,
+		}
+	}
+	if exceeded {
+		return nil, &Error{
+			Kind:      KindResponse,
+			Operation: operation.Name,
+			Attempt:   attempt,
+			Cause: fmt.Errorf(
+				"response body exceeds limit of %d bytes",
+				c.options.MaxResponseBytes,
+			),
+		}
+	}
+	return responseBody, nil
+}
+
+func readBounded(reader io.Reader, limit int64) ([]byte, bool, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(body)) <= limit {
+		return body, false, nil
+	}
+	return body[:limit], true, nil
+}
+
+// Close releases idle connections owned by this client. In-flight requests
+// remain governed by their contexts.
+func (c *Client) Close() error {
+	if c != nil && c.http != nil {
+		c.http.CloseIdleConnections()
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/modelruntime/connector/connector_test.go
+++ b/src/semantic-router/pkg/modelruntime/connector/connector_test.go
@@ -1,0 +1,306 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var testOperation = Operation{
+	Name:      "classify",
+	Method:    http.MethodPost,
+	Path:      "/classify",
+	RetrySafe: true,
+}
+
+func testOptions() Options {
+	return Options{
+		AttemptTimeout:   time.Second,
+		MaxRetries:       0,
+		MaxRequestBytes:  1024,
+		MaxResponseBytes: 1024,
+		MaxErrorBytes:    64,
+	}
+}
+
+func newTestClient(t *testing.T, server *httptest.Server, options Options) *Client {
+	t.Helper()
+	client, err := New(server.URL, nil, options)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestNewValidatesEndpointAndBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		options Options
+	}{
+		{name: "relative endpoint", baseURL: "localhost:8080", options: testOptions()},
+		{name: "unsupported scheme", baseURL: "grpc://localhost:8080", options: testOptions()},
+		{name: "missing attempt timeout", baseURL: "http://localhost:8080", options: func() Options {
+			options := testOptions()
+			options.AttemptTimeout = 0
+			return options
+		}()},
+		{name: "negative retries", baseURL: "http://localhost:8080", options: func() Options {
+			options := testOptions()
+			options.MaxRetries = -1
+			return options
+		}()},
+		{name: "missing body bound", baseURL: "http://localhost:8080", options: func() Options {
+			options := testOptions()
+			options.MaxResponseBytes = 0
+			return options
+		}()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := New(test.baseURL, nil, test.options); err == nil {
+				t.Fatal("New() error = nil, want validation failure")
+			}
+		})
+	}
+}
+
+func TestDoAppliesAuthAndPreservesBasePath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/models/classify" {
+			t.Errorf("path = %q, want /models/classify", request.URL.Path)
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		if got := request.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		body, _ := io.ReadAll(request.Body)
+		if string(body) != `{"input":"hello"}` {
+			t.Errorf("body = %q", body)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL+"/models", func(_ context.Context, request *http.Request) error {
+		request.Header.Set("Authorization", "Bearer token")
+		return nil
+	}, testOptions())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer client.Close()
+
+	body, err := client.Do(context.Background(), testOperation, []byte(`{"input":"hello"}`))
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("Do() body = %q", body)
+	}
+}
+
+func TestDoRejectsOversizedRequestBeforeSending(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("server received an oversized request")
+	}))
+	defer server.Close()
+	options := testOptions()
+	options.MaxRequestBytes = 3
+	client := newTestClient(t, server, options)
+
+	_, err := client.Do(context.Background(), testOperation, []byte("four"))
+	assertConnectorError(t, err, KindRequest, 0, false)
+}
+
+func TestDoRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("12345"))
+	}))
+	defer server.Close()
+	options := testOptions()
+	options.MaxResponseBytes = 4
+	client := newTestClient(t, server, options)
+
+	_, err := client.Do(context.Background(), testOperation, nil)
+	connectorErr := assertConnectorError(t, err, KindResponse, 1, false)
+	if !strings.Contains(connectorErr.Error(), "exceeds limit") {
+		t.Fatalf("error = %v, want response limit", connectorErr)
+	}
+}
+
+func TestDoBoundsStatusBodyWithoutExposingItInError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("secret-response"))
+	}))
+	defer server.Close()
+	options := testOptions()
+	options.MaxErrorBytes = 6
+	client := newTestClient(t, server, options)
+
+	_, err := client.Do(context.Background(), testOperation, nil)
+	connectorErr := assertConnectorError(t, err, KindStatus, 1, false)
+	if connectorErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d", connectorErr.StatusCode)
+	}
+	body, truncated := connectorErr.ResponseBody()
+	if string(body) != "secret" || !truncated {
+		t.Fatalf("ResponseBody() = %q, %t", body, truncated)
+	}
+	if strings.Contains(connectorErr.Error(), "secret") {
+		t.Fatalf("Error() exposed response body: %v", connectorErr)
+	}
+	body[0] = 'X'
+	bodyAgain, _ := connectorErr.ResponseBody()
+	if string(bodyAgain) != "secret" {
+		t.Fatal("ResponseBody() did not return a defensive copy")
+	}
+}
+
+func TestDoRetriesOnlyRetrySafeOperations(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		retrySafe    bool
+		wantAttempts int32
+		wantError    bool
+	}{
+		{name: "retry safe", retrySafe: true, wantAttempts: 2},
+		{name: "not retry safe", retrySafe: false, wantAttempts: 1, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testRetrySafety(t, test.retrySafe, test.wantAttempts, test.wantError)
+		})
+	}
+}
+
+func testRetrySafety(t *testing.T, retrySafe bool, wantAttempts int32, wantError bool) {
+	t.Helper()
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		attempt := attempts.Add(1)
+		body, _ := io.ReadAll(request.Body)
+		if string(body) != "payload" {
+			t.Errorf("attempt %d body = %q", attempt, body)
+		}
+		if attempt == 1 {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+	options := testOptions()
+	options.MaxRetries = 1
+	client := newTestClient(t, server, options)
+	operation := testOperation
+	operation.RetrySafe = retrySafe
+
+	body, err := client.Do(context.Background(), operation, []byte("payload"))
+	if wantError && err == nil {
+		t.Fatal("Do() error = nil")
+	}
+	if !wantError && (err != nil || string(body) != "ok") {
+		t.Fatalf("Do() = %q, %v", body, err)
+	}
+	if got := attempts.Load(); got != wantAttempts {
+		t.Fatalf("attempts = %d, want %d", got, wantAttempts)
+	}
+}
+
+func TestDoAuthorizesEveryAttempt(t *testing.T) {
+	var attempts atomic.Int32
+	var authorizations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+	options := testOptions()
+	options.MaxRetries = 1
+	client, err := New(server.URL, func(context.Context, *http.Request) error {
+		authorizations.Add(1)
+		return nil
+	}, options)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if _, err := client.Do(context.Background(), testOperation, nil); err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if got := authorizations.Load(); got != 2 {
+		t.Fatalf("authorization calls = %d, want 2", got)
+	}
+}
+
+func TestDoHonorsCallerCancellationDuringRetryDelay(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	options := testOptions()
+	options.MaxRetries = 5
+	client := newTestClient(t, server, options)
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(10*time.Millisecond, cancel)
+
+	_, err := client.Do(ctx, testOperation, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Do() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestDoReturnsAuthorizationFailureWithoutSending(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("server received a request after authorization failed")
+	}))
+	defer server.Close()
+	want := errors.New("credential unavailable")
+	client, err := New(server.URL, func(context.Context, *http.Request) error {
+		return want
+	}, testOptions())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = client.Do(context.Background(), testOperation, nil)
+	assertConnectorError(t, err, KindAuthorization, 1, false)
+	if !errors.Is(err, want) {
+		t.Fatalf("Do() error = %v, want wrapped authorization error", err)
+	}
+}
+
+func assertConnectorError(
+	t *testing.T,
+	err error,
+	kind ErrorKind,
+	attempt int,
+	retryable bool,
+) *Error {
+	t.Helper()
+	var connectorErr *Error
+	if !errors.As(err, &connectorErr) {
+		t.Fatalf("error = %T %v, want *connector.Error", err, err)
+	}
+	if connectorErr.Kind != kind || connectorErr.Attempt != attempt || connectorErr.Retryable != retryable {
+		t.Fatalf(
+			"error = %+v, want kind=%s attempt=%d retryable=%t",
+			connectorErr, kind, attempt, retryable,
+		)
+	}
+	return connectorErr
+}

--- a/src/semantic-router/pkg/modelruntime/connector/errors.go
+++ b/src/semantic-router/pkg/modelruntime/connector/errors.go
@@ -1,0 +1,53 @@
+package connector
+
+import "fmt"
+
+// ErrorKind identifies the stage at which a connector operation failed.
+type ErrorKind string
+
+const (
+	KindRequest       ErrorKind = "request"
+	KindAuthorization ErrorKind = "authorization"
+	KindTransport     ErrorKind = "transport"
+	KindStatus        ErrorKind = "status"
+	KindResponse      ErrorKind = "response"
+)
+
+// Error describes a connector failure without exposing a remote response body
+// through Error(). Call ResponseBody when a protocol adapter needs that body
+// for a bounded diagnostic.
+type Error struct {
+	Kind       ErrorKind
+	Operation  string
+	StatusCode int
+	Attempt    int
+	Retryable  bool
+	Cause      error
+
+	body      []byte
+	truncated bool
+}
+
+func (e *Error) Error() string {
+	prefix := fmt.Sprintf("connector operation %q failed", e.Operation)
+	if e.Attempt > 0 {
+		prefix = fmt.Sprintf("%s on attempt %d", prefix, e.Attempt)
+	}
+	if e.StatusCode != 0 {
+		return fmt.Sprintf("%s with HTTP status %d", prefix, e.StatusCode)
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", prefix, e.Cause)
+	}
+	return prefix
+}
+
+func (e *Error) Unwrap() error {
+	return e.Cause
+}
+
+// ResponseBody returns a copy of the bounded non-success response body and
+// reports whether the connector truncated it.
+func (e *Error) ResponseBody() ([]byte, bool) {
+	return append([]byte(nil), e.body...), e.truncated
+}

--- a/src/semantic-router/pkg/modelruntime/connector/retry.go
+++ b/src/semantic-router/pkg/modelruntime/connector/retry.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+)
+
+const maxRetryDelay = time.Second
+
+func retryableStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusRequestTimeout,
+		http.StatusTooEarly,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func retryableTransportError(err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func waitBeforeRetry(ctx context.Context, attempt int) error {
+	delay := 50 * time.Millisecond * time.Duration(1<<min(attempt-1, 4))
+	delay = min(delay, maxRetryDelay)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}


### PR DESCRIPTION
related #3128

## Purpose

Introduce a small shared outbound connector for remote Router Model deployments.

The connector owns transport concerns that should be consistent across remote model protocols:

- endpoint and authentication setup
- per-attempt deadlines and caller cancellation
- opt-in retries for retry-safe operations
- bounded request, response, and error bodies
- typed errors and connection lifecycle

This PR migrates `HTTPClassifierInference` as the representative production caller while keeping the `/classify` request/response schema, label mapping, and score validation in the classification adapter. Both jailbreak and generic/category sequence-classifier consumers continue to use their existing interfaces.

vLLM chat completion is intentionally left unchanged. Protocol neutrality is covered by connector contract tests rather than by expanding the production migration surface.

## Test Plan

- `gofmt -d pkg/modelruntime/connector pkg/classification/...`
- `go vet ./pkg/modelruntime/connector ./pkg/classification`
- `go test -race ./pkg/modelruntime/connector ./pkg/classification`
- `make agent-ci-gate AGENT_BOOTSTRAP_DONE=1 ENV=cpu CHANGED_FILES="<14 changed files>"`
- `make precommit-branch-gate AGENT_BASE_REF=origin/main`

## Test Result

- Formatting check passed.
- Targeted vet and race tests passed.
- Agent CI gate passed, including pre-commit, security scan, Go structural lint, structure checks, recipe conformance, Rust builds, and the complete `test-semantic-router` suite.
- The repository pre-commit branch gate passed in the official pre-commit image.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title does not stack prefixes
- [x] The PR links accepted issue #3128 with the Router Models and Inference Runtime owner
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope and validation

</details>
