### PR TITLE
[Test] Failing test for missing include_usage on replay-eligible streaming dispatch

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_protocol_matrix_test.go
+++ b/src/semantic-router/pkg/extproc/processor_protocol_matrix_test.go
@@ -172,6 +172,80 @@ func assertExtProcStructuredOutputPair(
 	assertExtProcStructuredOutputRequest(t, decoded, streaming)
 }
 
+// A same-format streaming Chat request that nothing mutated is byte-replay
+// eligible: the neutral request and its source envelope share Generation 1, so
+// EncodeRequest forwards the original client bytes verbatim. The Router forces
+// stream_options.include_usage on dispatch so accounting can observe
+// authoritative tokens, and that forcing must survive replay. This pins that
+// the dispatch body carries the usage request even when the client omitted it.
+func TestExtProcDispatchForcesIncludeUsageOnReplayEligibleStream(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{
+		SourceFormat: llmprotocol.OpenAIChatV1,
+		TargetFormat: llmprotocol.OpenAIChatV1,
+		RequestID:    "request_replay_include_usage",
+		TraceContext: t.Context(),
+	}
+	// No stream_options in the client body, and no mutation before dispatch, so
+	// the request keeps decode-time Generation 1 and stays replay eligible.
+	body := []byte(`{"model":"public-model","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	request, immediate := router.prepareProtocolRequest(body, ctx)
+	if immediate != nil || request == nil {
+		t.Fatalf("streaming request was rejected: request=%+v immediate=%+v", request, immediate)
+	}
+	if request.StreamOptions.IncludeUsage != nil {
+		t.Fatalf("client omitted stream_options but decode set include_usage: %+v", request.StreamOptions)
+	}
+
+	dispatch, err := router.encodeDispatchRequest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decoded, _, _, err := protocolcodec.NewBuiltinEngine().DecodeRequest(llmprotocol.OpenAIChatV1, dispatch)
+	if err != nil {
+		t.Fatalf("dispatch request does not satisfy Chat Completions: %v\n%s", err, dispatch)
+	}
+	if decoded.StreamOptions.IncludeUsage == nil || !*decoded.StreamOptions.IncludeUsage {
+		t.Fatalf("dispatch dropped the forced usage request on replay: %s", dispatch)
+	}
+	// The client preference is untouched, so client-facing rendering still omits
+	// the usage chunk. Only the backend dispatch carries the forced flag.
+	if ctx.SemanticRequest.StreamOptions.IncludeUsage != nil {
+		t.Fatalf("forcing usage on dispatch mutated the retained client preference: %+v", ctx.SemanticRequest.StreamOptions)
+	}
+}
+
+// When the client already asked for usage, the forcing is a no-op and byte
+// replay must be preserved: re-encoding a large accepted body just to restate a
+// flag it already carries would defeat the optimization. This guards that the
+// dispatch body is byte-identical to the original client body in that case.
+func TestExtProcDispatchPreservesReplayWhenClientRequestsUsage(t *testing.T) {
+	router := &OpenAIRouter{}
+	ctx := &RequestContext{
+		SourceFormat: llmprotocol.OpenAIChatV1,
+		TargetFormat: llmprotocol.OpenAIChatV1,
+		RequestID:    "request_replay_client_usage",
+		TraceContext: t.Context(),
+	}
+	body := []byte(`{"model":"public-model","messages":[{"role":"user","content":"hello"}],"stream":true,"stream_options":{"include_usage":true}}`)
+	request, immediate := router.prepareProtocolRequest(body, ctx)
+	if immediate != nil || request == nil {
+		t.Fatalf("streaming request was rejected: request=%+v immediate=%+v", request, immediate)
+	}
+	if request.StreamOptions.IncludeUsage == nil || !*request.StreamOptions.IncludeUsage {
+		t.Fatalf("client requested usage but decode did not record it: %+v", request.StreamOptions)
+	}
+
+	dispatch, err := router.encodeDispatchRequest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dispatch, body) {
+		t.Fatalf("byte replay was not preserved for a client that already requested usage:\n got=%s\nwant=%s", dispatch, body)
+	}
+}
+
 // Streaming translation is stateful, so it needs an independent 3x3 matrix at
 // the ExtProc seam rather than relying on buffered coverage or codec-only tests.
 func TestExtProcStreamingResponseProtocolMatrix(t *testing.T) {


### PR DESCRIPTION
Related #3331

## Purpose

This PR is a draft that documents the bug in #3331 and gives whoever picks it up a red test to start from after issue is accepted.

## Test Plan

Two tests in `pkg/extproc`, both running a request through `prepareProtocolRequest` and `encodeDispatchRequest`, the same code production dispatch uses.

- `TestExtProcDispatchForcesIncludeUsageOnReplayEligibleStream`: a streaming Chat request without `stream_options` stays replay-eligible, and the dispatch body reaches the backend without the forced `include_usage`. Fails on main by design; this is the bug.
- `TestExtProcDispatchPreservesReplayWhenClientRequestsUsage`: when the client already asked for usage, byte replay is preserved. Passes today, and guards the optimization for any future fix.

The failing test also pins two side contracts: the dispatch body stays valid Chat Completions JSON (it is decoded back through the codec engine), and forcing the flag never leaks into the retained client preference.


## Test Result

`go test ./pkg/extproc/` on this branch: the first test fails (expected red until a fix lands), the second passes, the rest of the suite is unaffected.


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [ ] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
