### PR TITLE
[Community] Update Workgroup roster · 2026-09-02

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -65,16 +65,6 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/yaojiejia.png',
         profile: 'https://github.com/yaojiejia',
       },
-      {
-        name: 'wuli666',
-        avatar: 'https://github.com/wuli666.png',
-        profile: 'https://github.com/wuli666',
-      },
-      {
-        name: 'Mahdi Ghodsi',
-        avatar: 'https://github.com/Mahdi-CV.png',
-        profile: 'https://github.com/Mahdi-CV',
-      },
     ],
   },
   {
@@ -212,21 +202,6 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Bevisy.png',
         profile: 'https://github.com/Bevisy',
       },
-      {
-        name: 'yaojiejia',
-        avatar: 'https://github.com/yaojiejia.png',
-        profile: 'https://github.com/yaojiejia',
-      },
-      {
-        name: 'Guan-Ming Chiu',
-        avatar: 'https://github.com/guan404ming.png',
-        profile: 'https://github.com/guan404ming',
-      },
-      {
-        name: 'bugkeep',
-        avatar: 'https://github.com/bugkeep.png',
-        profile: 'https://github.com/bugkeep',
-      },
     ],
   },
   {
@@ -268,11 +243,6 @@ export const workGroups: WorkGroup[] = [
         name: 'Pranav Thakur',
         avatar: 'https://github.com/pranavthakur0-0.png',
         profile: 'https://github.com/pranavthakur0-0',
-      },
-      {
-        name: 'PepperoniBlvd',
-        avatar: 'https://github.com/PepperoniBlvd.png',
-        profile: 'https://github.com/PepperoniBlvd',
       },
     ],
   },
@@ -366,16 +336,6 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Zi-Yi-Ming.png',
         profile: 'https://github.com/Zi-Yi-Ming',
       },
-      {
-        name: 'wuli666',
-        avatar: 'https://github.com/wuli666.png',
-        profile: 'https://github.com/wuli666',
-      },
-      {
-        name: 'Park Soobin',
-        avatar: 'https://github.com/subin9.png',
-        profile: 'https://github.com/subin9',
-      },
     ],
   },
   {
@@ -406,16 +366,6 @@ export const workGroups: WorkGroup[] = [
         name: 'Nanasis',
         avatar: 'https://github.com/nanasis.png',
         profile: 'https://github.com/nanasis',
-      },
-      {
-        name: 'yaojiejia',
-        avatar: 'https://github.com/yaojiejia.png',
-        profile: 'https://github.com/yaojiejia',
-      },
-      {
-        name: 'Hikari',
-        avatar: 'https://github.com/altale.png',
-        profile: 'https://github.com/altale',
       },
     ],
   },

--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -65,6 +65,16 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/yaojiejia.png',
         profile: 'https://github.com/yaojiejia',
       },
+      {
+        name: 'wuli666',
+        avatar: 'https://github.com/wuli666.png',
+        profile: 'https://github.com/wuli666',
+      },
+      {
+        name: 'Mahdi Ghodsi',
+        avatar: 'https://github.com/Mahdi-CV.png',
+        profile: 'https://github.com/Mahdi-CV',
+      },
     ],
   },
   {
@@ -131,6 +141,31 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/bugkeep.png',
         profile: 'https://github.com/bugkeep',
       },
+      {
+        name: 'JiaoliangYu',
+        avatar: 'https://github.com/JiaoliangYu.png',
+        profile: 'https://github.com/JiaoliangYu',
+      },
+      {
+        name: 'Xuetao Li',
+        avatar: 'https://github.com/Alanxtl.png',
+        profile: 'https://github.com/Alanxtl',
+      },
+      {
+        name: 'Nanasis',
+        avatar: 'https://github.com/nanasis.png',
+        profile: 'https://github.com/nanasis',
+      },
+      {
+        name: 'karthikeyan1592',
+        avatar: 'https://github.com/karthikeyan1592.png',
+        profile: 'https://github.com/karthikeyan1592',
+      },
+      {
+        name: 'Binbin Zhang',
+        avatar: 'https://github.com/Bevisy.png',
+        profile: 'https://github.com/Bevisy',
+      },
     ],
   },
   {
@@ -177,6 +212,21 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Bevisy.png',
         profile: 'https://github.com/Bevisy',
       },
+      {
+        name: 'yaojiejia',
+        avatar: 'https://github.com/yaojiejia.png',
+        profile: 'https://github.com/yaojiejia',
+      },
+      {
+        name: 'Guan-Ming Chiu',
+        avatar: 'https://github.com/guan404ming.png',
+        profile: 'https://github.com/guan404ming',
+      },
+      {
+        name: 'bugkeep',
+        avatar: 'https://github.com/bugkeep.png',
+        profile: 'https://github.com/bugkeep',
+      },
     ],
   },
   {
@@ -218,6 +268,11 @@ export const workGroups: WorkGroup[] = [
         name: 'Pranav Thakur',
         avatar: 'https://github.com/pranavthakur0-0.png',
         profile: 'https://github.com/pranavthakur0-0',
+      },
+      {
+        name: 'PepperoniBlvd',
+        avatar: 'https://github.com/PepperoniBlvd.png',
+        profile: 'https://github.com/PepperoniBlvd',
       },
     ],
   },
@@ -306,6 +361,21 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/edamamez.png',
         profile: 'https://github.com/edamamez',
       },
+      {
+        name: 'ZiYiMing',
+        avatar: 'https://github.com/Zi-Yi-Ming.png',
+        profile: 'https://github.com/Zi-Yi-Ming',
+      },
+      {
+        name: 'wuli666',
+        avatar: 'https://github.com/wuli666.png',
+        profile: 'https://github.com/wuli666',
+      },
+      {
+        name: 'Park Soobin',
+        avatar: 'https://github.com/subin9.png',
+        profile: 'https://github.com/subin9',
+      },
     ],
   },
   {
@@ -336,6 +406,16 @@ export const workGroups: WorkGroup[] = [
         name: 'Nanasis',
         avatar: 'https://github.com/nanasis.png',
         profile: 'https://github.com/nanasis',
+      },
+      {
+        name: 'yaojiejia',
+        avatar: 'https://github.com/yaojiejia.png',
+        profile: 'https://github.com/yaojiejia',
+      },
+      {
+        name: 'Hikari',
+        avatar: 'https://github.com/altale.png',
+        profile: 'https://github.com/altale',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add six applicants with substantive merged contributions owned by the exact Workgroup they applied to
- require a genuine target-Workgroup application for every roster entry; contribution ownership alone never creates membership intent
- preserve unrelated roster content and ordering

## Evidence

| Applicant | Workgroup | Role | Application | Qualifying same-Workgroup contribution |
| --- | --- | --- | --- | --- |
| @JiaoliangYu | Router Models & Inference Runtime | Member | [application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5488044964) | [PR #3328](https://github.com/vllm-project/semantic-router/pull/3328) |
| @Alanxtl | Router Models & Inference Runtime | Member | [application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5491103581) | [PR #3318](https://github.com/vllm-project/semantic-router/pull/3318) |
| @nanasis | Router Models & Inference Runtime | Member | [application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5506979355) | [PR #3316](https://github.com/vllm-project/semantic-router/pull/3316) |
| @karthikeyan1592 | Router Models & Inference Runtime | Member | [application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5508868078) | [PR #3319](https://github.com/vllm-project/semantic-router/pull/3319) |
| @Bevisy | Router Models & Inference Runtime | Member | [application](https://github.com/vllm-project/semantic-router/issues/2966#issuecomment-5511367813) | [PR #3321](https://github.com/vllm-project/semantic-router/pull/3321) |
| @Zi-Yi-Ming | Developer Experience & Ecosystem | Member | [application](https://github.com/vllm-project/semantic-router/issues/2970#issuecomment-5504805799) | [PR #3294](https://github.com/vllm-project/semantic-router/pull/3294) |

## Validation

- `git diff --check`
- Node v24.18.1: verified seven Workgroups, case-insensitive per-Workgroup login uniqueness, and all six exact application/contribution additions
- `make agent-report ENV=cpu CHANGED_FILES="website/src/data/workGroups.ts"`
- `make agent-ci-gate CHANGED_FILES="website/src/data/workGroups.ts"`

Related #2966, #2970
