### PR TITLE
[Bug] Scan the whole text in the PII classification API

### DIFF
--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -24,6 +24,8 @@ var BaselineRouterContract = []string{
 	"pii-detection",
 	// PII entity positions are code-point offsets (issue #3146)
 	"pii-entity-offsets",
+	// PII past the classifier's sequence limit is still detected (issue #3364)
+	"pii-long-text",
 	"jailbreak-detection",
 	"decision-priority-selection",
 	"plugin-chain-execution",

--- a/e2e/testcases/pii_long_text.go
+++ b/e2e/testcases/pii_long_text.go
@@ -1,0 +1,80 @@
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("pii-long-text", pkgtestcases.TestCase{
+		Description: "Verify /api/v1/classify/pii detects entities past the classifier's sequence limit",
+		Tags:        []string{"kubernetes", "apiserver", "classification", "pii", "api"},
+		Fn:          testPIILongText,
+	})
+}
+
+// The PII token classifier truncates at its own sequence limit, so a single
+// classification call only ever scores the start of a long text. This drives the
+// endpoint with the entity placed past that limit, which no mocked backend can
+// reproduce: the truncation lives in the tokenizer.
+func testPIILongText(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	opts pkgtestcases.TestCaseOptions,
+) error {
+	session, err := fixtures.OpenRouterAPISession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	httpClient := session.HTTPClient(60 * time.Second)
+	url := session.URL("/api/v1/classify/pii")
+
+	// Filler carries no names, numbers or dates, so any entity reported here
+	// belongs to the trailing secret.
+	sentences := []string{
+		"Sailors used the stars to navigate before mechanical instruments existed. ",
+		"The compass then made direction independent of a clear night sky. ",
+		"Radio beacons later fixed a position without any view of the horizon. ",
+		"Satellite systems eventually replaced every one of the earlier techniques. ",
+	}
+	var builder strings.Builder
+	for i := 0; i < 96; i++ {
+		builder.WriteString(sentences[i%len(sentences)])
+	}
+	filler := builder.String()
+
+	const secret = "Contact John Doe at john.doe@example.com or 555-123-4567."
+	text := filler + secret
+	secretStart := utf8.RuneCountInString(filler)
+
+	entities, err := classifyPIIWithPositions(ctx, httpClient, url, text)
+	if err != nil {
+		return err
+	}
+	if len(entities) == 0 {
+		return fmt.Errorf(
+			"expected PII past the classifier sequence limit to be detected in a %d-rune text, got none",
+			utf8.RuneCountInString(text))
+	}
+	if err := assertRuneOffsets(text, entities); err != nil {
+		return err
+	}
+
+	for _, entity := range entities {
+		if *entity.StartPos >= secretStart {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"expected an entity at or past rune %d, where the trailing secret starts, got %v",
+		secretStart, entities)
+}

--- a/src/semantic-router/pkg/classification/classifier_pii_long_text_realmodel_test.go
+++ b/src/semantic-router/pkg/classification/classifier_pii_long_text_realmodel_test.go
@@ -1,0 +1,148 @@
+package classification
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// realPIIModelPath resolves the on-disk mmBERT-32K PII model, honoring the
+// VLLM_SR_PII_MODEL override and otherwise looking for the repo-root models/
+// download. It returns "" when the model is not present.
+func realPIIModelPath() string {
+	if p := os.Getenv("VLLM_SR_PII_MODEL"); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+		return ""
+	}
+	// go test runs with the package directory as the working directory.
+	def := filepath.Join("..", "..", "..", "..", "models", "mmbert32k-pii-detector-merged")
+	if _, err := os.Stat(def); err == nil {
+		return def
+	}
+	return ""
+}
+
+// setupRealPIIClassifier initializes the real mmBERT-32K PII model and builds a
+// Classifier wired to the real inference backend. It skips the test when the
+// model is not present (e.g. minimal-model CI).
+func setupRealPIIClassifier(t *testing.T) *Classifier {
+	t.Helper()
+
+	modelPath := realPIIModelPath()
+	if modelPath == "" {
+		t.Skip("mmBERT-32K PII model not present; set VLLM_SR_PII_MODEL or run `make download-mmbert-32k-merged`")
+	}
+
+	mappingPath := filepath.Join(modelPath, "pii_type_mapping.json")
+	mapping, err := LoadPIIMapping(mappingPath)
+	if err != nil {
+		t.Fatalf("load PII mapping %q: %v", mappingPath, err)
+	}
+
+	if err := candle_binding.InitMmBert32KPIIClassifier(modelPath, true); err != nil {
+		t.Fatalf("init mmBERT-32K PII classifier: %v", err)
+	}
+
+	cfg := &config.RouterConfig{}
+	cfg.PIIModel.ModelID = modelPath
+	cfg.PIIModel.UseCPU = true
+	cfg.PIIModel.UseMmBERT32K = true
+	cfg.PIIModel.Threshold = 0.5
+	cfg.PIIMappingPath = mappingPath
+
+	classifier, err := newClassifierWithOptions(cfg,
+		withPII(mapping, &MmBERT32KPIIInitializerImpl{}, &MmBERT32KPIIInferenceImpl{}),
+	)
+	if err != nil {
+		t.Fatalf("build classifier: %v", err)
+	}
+	return classifier
+}
+
+// coversSpan reports whether any detection overlaps [start, end) in text, and
+// that its own offsets index the original text. The real model can also flag
+// entities inside the filler, so this asks about the planted span rather than
+// demanding an exact detection count.
+func coversSpan(t *testing.T, text string, detections []PIIDetection, start, end int) bool {
+	t.Helper()
+	for _, d := range detections {
+		if d.Start < 0 || d.End > len(text) || d.Start >= d.End {
+			t.Errorf("detection offsets outside the original text: [%d-%d] for a text of %d bytes",
+				d.Start, d.End, len(text))
+			continue
+		}
+		if d.Start < end && start < d.End {
+			return true
+		}
+	}
+	return false
+}
+
+// The defect this guards is in the tokenizer, so it only reproduces against the
+// real model: a mocked backend never truncates. PII inside the model's window is
+// found either way; PII past it is what a single call loses.
+func TestClassifyPIIWithDetails_RealModelFindsPIIPastTheWindow(t *testing.T) {
+	classifier := setupRealPIIClassifier(t)
+
+	const secret = "Contact John Doe at john.doe@example.com or 555-123-4567."
+
+	// Filler deliberately carries no names, numbers or dates: the model flags
+	// those, and the assertion below is about the planted span only.
+	sentences := []string{
+		"Sailors used the stars to navigate before mechanical instruments existed. ",
+		"The compass then made direction independent of a clear night sky. ",
+		"Radio beacons later fixed a position without any view of the horizon. ",
+		"Satellite systems eventually replaced every one of the earlier techniques. ",
+	}
+	var builder strings.Builder
+	for i := 0; i < 96; i++ {
+		builder.WriteString(sentences[i%len(sentences)])
+	}
+	filler := builder.String()
+
+	t.Run("inside the window", func(t *testing.T) {
+		text := secret + " " + filler
+		detections, err := classifier.ClassifyPIIWithDetails(text)
+		if err != nil {
+			t.Fatalf("ClassifyPIIWithDetails: %v", err)
+		}
+		if !coversSpan(t, text, detections, 0, len(secret)) {
+			t.Fatalf("PII at the head of the text must be detected; got %d detections", len(detections))
+		}
+	})
+
+	t.Run("past the window", func(t *testing.T) {
+		text := filler + " " + secret
+		start := strings.Index(text, secret)
+
+		detections, err := classifier.ClassifyPIIWithDetails(text)
+		if err != nil {
+			t.Fatalf("ClassifyPIIWithDetails: %v", err)
+		}
+		t.Logf("text = %d bytes, chunks = %d, detections = %d",
+			len(text), len(piiSignalChunkSpans(text)), len(detections))
+		for _, d := range detections {
+			t.Logf("  %-14s [%d-%d] %q %.3f", d.EntityType, d.Start, d.End, d.Text, d.Confidence)
+		}
+
+		if !coversSpan(t, text, detections, start, start+len(secret)) {
+			t.Fatalf("PII past the model window must be detected; got %d detections", len(detections))
+		}
+
+		// Offsets are remapped from a chunk onto the original text. The entity
+		// text the model reported has to slice back out of the original at the
+		// reported offsets, or masked_text and start_position are wrong.
+		for _, d := range detections {
+			if got := text[d.Start:d.End]; got != d.Text {
+				t.Errorf("offsets must index the original text: text[%d:%d] = %q, entity text %q",
+					d.Start, d.End, got, d.Text)
+			}
+		}
+	})
+}

--- a/src/semantic-router/pkg/classification/classifier_pii_long_text_test.go
+++ b/src/semantic-router/pkg/classification/classifier_pii_long_text_test.go
@@ -1,0 +1,202 @@
+package classification
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// truncatingPIIInference stands in for the real classifier: it scores only the
+// first windowRunes of whatever it is handed, the way the tokenizer truncates at
+// MAX_CLASSIFICATION_SEQ_LEN, and reports byte offsets relative to that text.
+type truncatingPIIInference struct {
+	windowRunes int
+	entityText  string
+	seen        []string
+}
+
+func (t *truncatingPIIInference) ClassifyTokens(text string) (candle_binding.TokenClassificationResult, error) {
+	t.seen = append(t.seen, text)
+
+	runes := []rune(text)
+	if len(runes) > t.windowRunes {
+		runes = runes[:t.windowRunes]
+	}
+	scored := string(runes)
+
+	var entities []candle_binding.TokenEntity
+	for from := 0; ; {
+		index := strings.Index(scored[from:], t.entityText)
+		if index < 0 {
+			break
+		}
+		start := from + index
+		entities = append(entities, candle_binding.TokenEntity{
+			EntityType: "EMAIL",
+			Text:       t.entityText,
+			Start:      start,
+			End:        start + len(t.entityText),
+			Confidence: 0.99,
+		})
+		from = start + len(t.entityText)
+	}
+	return candle_binding.TokenClassificationResult{Entities: entities}, nil
+}
+
+func newLongTextPIIClassifier(entityText string) (*Classifier, *truncatingPIIInference) {
+	// ~512 tokens of prose, the sequence limit the classifier is built with.
+	model := &truncatingPIIInference{windowRunes: 2048, entityText: entityText}
+
+	cfg := &config.RouterConfig{}
+	cfg.PIIModel.ModelID = "test-pii-model"
+	cfg.PIIMappingPath = "test-pii-mapping-path"
+	cfg.PIIModel.Threshold = 0.7
+
+	classifier, _ := newClassifierWithOptions(cfg,
+		withPII(&PIIMapping{
+			LabelToIdx: map[string]int{"PERSON": 0, "EMAIL": 1},
+			IdxToLabel: map[string]string{"0": "PERSON", "1": "EMAIL"},
+		}, &MockPIIInitializer{}, model),
+	)
+	return classifier, model
+}
+
+func longPIIFiller(sentences int) string {
+	var builder strings.Builder
+	for i := 0; i < sentences; i++ {
+		fmt.Fprintf(&builder, "Sailors in year %d used the stars, then the compass, then radio beacons. ", 1500+i)
+	}
+	return builder.String()
+}
+
+// The classification API must not answer on the first chunk alone. The routing
+// signal already scans every chunk; both surfaces have to see the same text.
+// One entity sits inside the model window and one well past it, so this also
+// pins that detections stay ordered by position now that they arrive per chunk.
+func TestClassifyPIIWithDetails_DetectsEntityPastTheModelWindow(t *testing.T) {
+	const entity = "my contact is alice@corp.example"
+	text := entity + " " + longPIIFiller(400) + " " + entity
+
+	classifier, model := newLongTextPIIClassifier(entity)
+
+	detections, err := classifier.ClassifyPIIWithDetails(text)
+	if err != nil {
+		t.Fatalf("ClassifyPIIWithDetails: %v", err)
+	}
+
+	if len(model.seen) < 2 {
+		t.Fatalf("a long text must be scanned in chunks; got %d call(s)", len(model.seen))
+	}
+	if len(detections) != 2 {
+		t.Fatalf("expected both the leading and the trailing entity, got %d detections", len(detections))
+	}
+	if detections[0].Start >= detections[1].Start {
+		t.Errorf("detections must stay ordered by position, got starts %d then %d",
+			detections[0].Start, detections[1].Start)
+	}
+	for i, detection := range detections {
+		if got := text[detection.Start:detection.End]; got != entity {
+			t.Errorf("detection %d: offsets must index the original text: text[%d:%d] = %q, want %q",
+				i, detection.Start, detection.End, got, entity)
+		}
+	}
+}
+
+// Offsets are byte offsets while chunking works in runes, so a multi-byte text
+// is the case that catches a rune/byte mix-up.
+func TestClassifyPIIWithDetails_OffsetsAreCorrectInMultibyteText(t *testing.T) {
+	const entity = "連絡先は alice@corp.example です"
+
+	var builder strings.Builder
+	for i := 0; i < 400; i++ {
+		fmt.Fprintf(&builder, "%d年に船乗りは星を使い、次に羅針盤を使い、そして無線標識を使いました。", 1500+i)
+	}
+	text := builder.String() + entity
+
+	classifier, _ := newLongTextPIIClassifier(entity)
+
+	detections, err := classifier.ClassifyPIIWithDetails(text)
+	if err != nil {
+		t.Fatalf("ClassifyPIIWithDetails: %v", err)
+	}
+	if len(detections) != 1 {
+		t.Fatalf("expected 1 detection, got %d", len(detections))
+	}
+	if got := text[detections[0].Start:detections[0].End]; got != entity {
+		t.Errorf("offsets must index the original text: text[%d:%d] = %q, want %q",
+			detections[0].Start, detections[0].End, got, entity)
+	}
+}
+
+// Chunks overlap by piiSignalChunkOverlapRunes, so an entity in that window is
+// classified twice and must still be reported once.
+func TestClassifyPIIWithDetails_ReportsAnOverlappedEntityOnce(t *testing.T) {
+	const entity = "my contact is alice@corp.example"
+	filler := []rune(longPIIFiller(400))
+
+	text, spansContaining := "", 0
+	for insertAt := 0; insertAt < len(filler); insertAt++ {
+		candidate := string(filler[:insertAt]) + entity + string(filler[insertAt:])
+		if n := spansFullyContaining(candidate, entity); n >= 2 {
+			text, spansContaining = candidate, n
+			break
+		}
+	}
+	if text == "" {
+		t.Fatal("no insertion point put the entity inside two overlapping chunks")
+	}
+	t.Logf("entity falls inside %d chunks", spansContaining)
+
+	classifier, _ := newLongTextPIIClassifier(entity)
+
+	detections, err := classifier.ClassifyPIIWithDetails(text)
+	if err != nil {
+		t.Fatalf("ClassifyPIIWithDetails: %v", err)
+	}
+	if len(detections) != 1 {
+		t.Fatalf("an entity in the overlap window must be reported once, got %d detections", len(detections))
+	}
+	if got := text[detections[0].Start:detections[0].End]; got != entity {
+		t.Errorf("offsets must index the original text: text[%d:%d] = %q, want %q",
+			detections[0].Start, detections[0].End, got, entity)
+	}
+}
+
+func spansFullyContaining(text, entity string) int {
+	count := 0
+	for _, span := range piiSignalChunkSpans(text) {
+		if strings.Contains(span.Text, entity) {
+			count++
+		}
+	}
+	return count
+}
+
+// A text that fits in one chunk must still take exactly one call with the text
+// unchanged: chunking is for long input only.
+func TestClassifyPIIWithDetails_ShortTextTakesASingleCall(t *testing.T) {
+	const entity = "my contact is alice@corp.example"
+	text := "Hello, " + entity + ", thanks."
+
+	classifier, model := newLongTextPIIClassifier(entity)
+
+	detections, err := classifier.ClassifyPIIWithDetails(text)
+	if err != nil {
+		t.Fatalf("ClassifyPIIWithDetails: %v", err)
+	}
+	if len(model.seen) != 1 {
+		t.Fatalf("a short text must take one call, got %d", len(model.seen))
+	}
+	if model.seen[0] != text {
+		t.Errorf("a short text must be classified unchanged: got %q", model.seen[0])
+	}
+	if len(detections) != 1 {
+		t.Fatalf("expected 1 detection, got %d", len(detections))
+	}
+	if got := text[detections[0].Start:detections[0].End]; got != entity {
+		t.Errorf("text[%d:%d] = %q, want %q", detections[0].Start, detections[0].End, got, entity)
+	}
+}

--- a/src/semantic-router/pkg/classification/classifier_pii_ops.go
+++ b/src/semantic-router/pkg/classification/classifier_pii_ops.go
@@ -2,6 +2,7 @@ package classification
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -73,34 +74,9 @@ func (c *Classifier) ClassifyPIIWithDetailsAndThreshold(text string, threshold f
 		return []PIIDetection{}, nil
 	}
 
-	// Use PII token classifier for entity detection
-	tokenResult, err := c.piiInference.ClassifyTokens(text)
+	detections, err := c.scanPIIChunks(text, threshold)
 	if err != nil {
-		return nil, fmt.Errorf("PII token classification error: %w", err)
-	}
-
-	if len(tokenResult.Entities) > 0 {
-		logging.Infof("PII token classification found %d entities", len(tokenResult.Entities))
-	}
-
-	// Convert token entities to PII detections, filtering by threshold
-	// Translate class_X format to named types using PII mapping
-	var detections []PIIDetection
-	for _, entity := range tokenResult.Entities {
-		if entity.Confidence >= threshold {
-			// Translate entity type from class_X format to named type (e.g., class_6 → DATE_TIME)
-			translatedType := c.PIIMapping.TranslatePIIType(entity.EntityType)
-			detection := PIIDetection{
-				EntityType: translatedType,
-				Start:      entity.Start,
-				End:        entity.End,
-				Text:       entity.Text,
-				Confidence: entity.Confidence,
-			}
-			detections = append(detections, detection)
-			logging.Infof("Detected PII entity: %s → %s ('%s') at [%d-%d] with confidence %.3f",
-				entity.EntityType, translatedType, entity.Text, entity.Start, entity.End, entity.Confidence)
-		}
+		return nil, err
 	}
 
 	if len(detections) > 0 {
@@ -117,6 +93,81 @@ func (c *Classifier) ClassifyPIIWithDetailsAndThreshold(text string, threshold f
 	}
 
 	return detections, nil
+}
+
+// scanPIIChunks runs PII token classification over the whole text.
+//
+// The classifier truncates at MAX_CLASSIFICATION_SEQ_LEN, so one call over a
+// long text only ever scores its start. The PII routing signal already scans in
+// bounded overlapping chunks (evaluatePIISignal); this does the same, and maps
+// every entity back onto the original text because this surface reports
+// positions and the routing signal does not.
+func (c *Classifier) scanPIIChunks(text string, threshold float32) ([]PIIDetection, error) {
+	var detections []PIIDetection
+	seen := make(map[piiDetectionKey]int)
+	classified := 0
+
+	for _, span := range piiSignalChunkSpans(text) {
+		tokenResult, err := c.piiInference.ClassifyTokens(span.Text)
+		if err != nil {
+			return nil, fmt.Errorf("PII token classification error: %w", err)
+		}
+
+		classified += len(tokenResult.Entities)
+
+		for _, entity := range tokenResult.Entities {
+			if entity.Confidence < threshold {
+				continue
+			}
+
+			// Translate entity type from class_X format to named type (e.g., class_6 → DATE_TIME)
+			translatedType := c.PIIMapping.TranslatePIIType(entity.EntityType)
+			detection := PIIDetection{
+				EntityType: translatedType,
+				Start:      span.StartByte + entity.Start,
+				End:        span.StartByte + entity.End,
+				Text:       entity.Text,
+				Confidence: entity.Confidence,
+			}
+
+			// Chunks overlap, so an entity inside the overlap window is reported
+			// by both chunks. Keep one detection at the higher confidence.
+			key := piiDetectionKey{translatedType, detection.Start, detection.End}
+			if existing, reported := seen[key]; reported {
+				if detection.Confidence > detections[existing].Confidence {
+					detections[existing].Confidence = detection.Confidence
+				}
+				continue
+			}
+			seen[key] = len(detections)
+			detections = append(detections, detection)
+
+			logging.Infof("Detected PII entity: %s → %s ('%s') at [%d-%d] with confidence %.3f",
+				entity.EntityType, translatedType, entity.Text, detection.Start, detection.End, entity.Confidence)
+		}
+	}
+
+	if classified > 0 {
+		logging.Infof("PII token classification found %d entities", classified)
+	}
+
+	// A single call returned entities in ascending position; keep that contract
+	// now that they arrive chunk by chunk.
+	sort.SliceStable(detections, func(i, j int) bool {
+		if detections[i].Start != detections[j].Start {
+			return detections[i].Start < detections[j].Start
+		}
+		return detections[i].End < detections[j].End
+	})
+
+	return detections, nil
+}
+
+// piiDetectionKey identifies one entity occurrence in the original text.
+type piiDetectionKey struct {
+	entityType string
+	start      int
+	end        int
 }
 
 // DetectPIIInContent performs PII classification on all provided content

--- a/src/semantic-router/pkg/classification/classifier_signal_text_window.go
+++ b/src/semantic-router/pkg/classification/classifier_signal_text_window.go
@@ -2,6 +2,7 @@ package classification
 
 import (
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
@@ -72,34 +73,73 @@ func piiSignalChunks(text string) []string {
 	)
 }
 
+// piiSignalChunkSpans is piiSignalChunks with offsets, for callers that report
+// entity positions. It does not de-duplicate: two identical chunks are at
+// different offsets, and both of those positions are real.
+func piiSignalChunkSpans(text string) []signalChunkSpan {
+	return securitySignalChunkSpans(text, piiSignalChunkBudget, piiSignalChunkOverlapRunes)
+}
+
 func jailbreakSignalChunks(text string) []string {
 	return uniqueSignalChunks(
 		securitySignalChunks(text, jailbreakSignalChunkBudget, jailbreakSignalOverlapRunes),
 	)
 }
 
+// signalChunkSpan is one chunk together with its byte offset in the text it was
+// cut from. Callers that report positions back to a client need the offset to
+// map a chunk-relative entity onto the original text.
+type signalChunkSpan struct {
+	Text      string
+	StartByte int
+}
+
 // securitySignalChunks scans the entire input in bounded, overlapping pieces.
 // Unlike semantic intent signals, security detection cannot safely discard the
 // middle of a long prompt.
 func securitySignalChunks(text string, budget, overlapRunes int) []string {
+	spans := securitySignalChunkSpans(text, budget, overlapRunes)
+	if spans == nil {
+		return nil
+	}
+	chunks := make([]string, len(spans))
+	for i, span := range spans {
+		chunks[i] = span.Text
+	}
+	return chunks
+}
+
+// securitySignalChunkSpans is securitySignalChunks with each chunk's byte
+// offset in text. An entity found at offset e in span s sits at
+// s.StartByte + e in the original text.
+func securitySignalChunkSpans(text string, budget, overlapRunes int) []signalChunkSpan {
 	runes := []rune(text)
 	if len(runes) == 0 {
 		return nil
 	}
 	if securitySignalChunkUnits(runes) <= budget {
-		return []string{text}
+		return []signalChunkSpan{{Text: text, StartByte: 0}}
 	}
 
-	chunks := make([]string, 0, (len(runes)/1024)+1)
+	spans := make([]signalChunkSpan, 0, (len(runes)/1024)+1)
+	// Chunk starts only ever move forward, so one cursor converts them to byte
+	// offsets without a per-rune index.
+	startByte, counted := 0, 0
 	for start := 0; start < len(runes); {
+		for ; counted < start; counted++ {
+			startByte += utf8.RuneLen(runes[counted])
+		}
 		end := securitySignalChunkEnd(runes, start, budget)
-		chunks = append(chunks, string(runes[start:end]))
+		spans = append(spans, signalChunkSpan{
+			Text:      string(runes[start:end]),
+			StartByte: startByte,
+		})
 		if end == len(runes) {
 			break
 		}
 		start = max(start+1, end-overlapRunes)
 	}
-	return chunks
+	return spans
 }
 
 func securitySignalChunkEnd(runes []rune, start, budget int) int {


### PR DESCRIPTION
Fixes #3364

`ClassifyPIIWithDetailsAndThreshold` classified in one call, and the PII token classifier is built with `max_length = MAX_CLASSIFICATION_SEQ_LEN` (512) and right truncation, so `/api/v1/classify/pii` only saw the start of a long text. PII past that point came back absent, and `masked_text` came back with it unmasked. #3206 fixed the same split on the jailbreak side, where the routing signal already chunked and the classification API did not.

`piiSignalChunks` could not be reused as it stands. It returns `[]string` with no offsets and de-duplicates identical chunks, which discards the mapping from a chunk back to its position in the original text. The routing signal never needed that mapping, because `evaluatePIIRule` reads entity types and confidences only. This surface reports positions, and `buildMaskedPIIText` slices the original text with them. So `securitySignalChunkSpans` returns each chunk with its byte offset, `securitySignalChunks` is expressed in terms of it so there is still one walk, and every entity maps back with `span.StartByte + entity.Start`.

Chunks overlap, so an entity inside the overlap window is classified twice. Detections are de-duplicated on `(type, start, end)` keeping the higher confidence, then sorted by position, which is the order a single call produced.

6898 bytes of prose with `Contact John Doe at john.doe@example.com or 555-123-4567.` appended past the limit, against the real mmBERT-32K PII model, 18 chunks:

```
before   0 detections

after    PERSON         [6849-6857] "John Doe"     0.963
         EMAIL_ADDRESS  [6861-6869] "john.doe"     0.623
         DOMAIN_NAME    [6869-6870] "@"            0.576
         EMAIL_ADDRESS  [6870-6881] "example.com"  0.757
         PHONE_NUMBER   [6885-6897] "555-123-4567" 0.975
```

Every detection satisfies `text[start:end] == entity text` against the original string, so the remap holds under the real tokenizer and not only under a stub. The same entity placed before the limit is detected either way. Short texts still take a single call with the text unchanged.

The defect is in the tokenizer, so a mocked backend cannot reproduce it. One test runs the real model and skips when it is absent, following `classifier_jailbreak_risk_realmodel_test.go`. Four more run against a stub that truncates the same way: an entity past the window is found while one inside it still is and both stay ordered, offsets survive a multi-byte text, an entity in the overlap window is reported once, and a short text stays one call. A new e2e case `pii-long-text` drives `/api/v1/classify/pii` with the entity past the limit and checks the code-point offsets. It is registered in `BaselineRouterContract` next to `pii-entity-offsets`, and neither is on the fixed list the PR lane runs (`ENVOY_AI_GATEWAY_CI_TESTS` in `integration-test-k8s.yml`), so CI has not executed it. I could not run it against a cluster either; `make e2e-test E2E_PROFILE=envoy-ai-gateway E2E_TESTS=pii-long-text` is the command.

No existing test changed.

#3364 also names `AnalyzeContentForPII` and `DetectPIIInContent`. They carry the same single-call shape, but no production caller reaches them today — only `ClassifyPIIWithDetails{,AndThreshold}`, from `services/classification_pii.go`. Same asymmetry, different change, so they are untouched here.

One limit worth writing down rather than rediscovering. An entity is only guaranteed to fall inside a single chunk if it is no longer than `piiSignalChunkOverlapRunes` (64). Sweeping one across the text a rune at a time, 64 and 65 runes miss nothing in 800 consecutive positions, 70 runes misses 8, 80 runes misses 25. Real PII entities are far shorter, so the constant is unchanged here. Raising it is a separate question, because the routing signal shares the walk.

