### PR TITLE
[Docs] Publish deployment and hardware support matrix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,15 @@ repos:
 
   - repo: local
     hooks:
+      - id: deployment-support-matrix
+        name: deployment support matrix coverage
+        entry: python3 tools/ci/check_deployment_support_matrix.py
+        language: system
+        pass_filenames: false
+        files: ^(\.pre-commit-config\.yaml$|deploy/|config/runtime/|website/docs/installation/support-matrix\.md$|tools/ci/check_deployment_support_matrix\.py$|tools/ci/tests/test_deployment_support_matrix\.py$)
+
+  - repo: local
+    hooks:
       - id: shellcheck
         name: shellcheck
         entry: make shellcheck

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,3 +16,9 @@ Router configuration is intentionally separate:
 Do not add prose-only guides, benchmark output, helper programs, or standalone
 router examples here. Public instructions belong in `website/` and repository
 automation belongs in `tools/`.
+
+The public
+[Deployment and Hardware Support Matrix](../website/docs/installation/support-matrix.md)
+is the canonical classification of these assets. Adding or removing a direct
+child of `deploy/` or `deploy/kubernetes/` requires updating that matrix; the
+repository's deployment-matrix check enforces complete coverage.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,6 +19,14 @@ automation belongs in `tools/`.
 
 The public
 [Deployment and Hardware Support Matrix](../website/docs/installation/support-matrix.md)
-is the canonical classification of these assets. Adding or removing a direct
-child of `deploy/` or `deploy/kubernetes/` requires updating that matrix; the
-repository's deployment-matrix check enforces complete coverage.
+is the canonical classification of these assets. Its rows use user-facing
+option names; `tools/ci/check_deployment_support_matrix.py` maps internal asset
+directories to those options without exposing repository layout in public docs.
+
+Adding or removing a direct child of `deploy/`, `deploy/kubernetes/`, or
+`config/runtime/` requires updating that mapping and, when it introduces a new
+option, the public matrix. Verify coverage from the repository root:
+
+```bash
+python3 tools/ci/check_deployment_support_matrix.py
+```

--- a/tools/ci/check_deployment_support_matrix.py
+++ b/tools/ci/check_deployment_support_matrix.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that deployment assets are classified in the public support matrix."""
+"""Verify deployment inventory coverage in the public support matrix."""
 
 from __future__ import annotations
 
@@ -14,14 +14,50 @@ CLASSIFICATIONS = {
     "Experimental example",
     "Deprecated",
 }
+
+# Public documentation names user-facing choices rather than repository paths.
+# This mapping is the contributor-side identity bridge; classifications remain
+# canonical in the public matrix. Multiple directories may back one choice.
+ASSET_LABELS = {
+    "deploy/helm/": "Helm chart",
+    "deploy/kserve/": "KServe example",
+    "deploy/local/": "Local deployment",
+    "deploy/openshift/": "OpenShift example",
+    "deploy/operator/": "Kubernetes Operator",
+    "deploy/kubernetes/agentgateway/": "agentgateway",
+    "deploy/kubernetes/ai-gateway/": "Envoy AI Gateway",
+    "deploy/kubernetes/aibrix/": "AIBrix",
+    "deploy/kubernetes/anthropic-backend/": "Anthropic-compatible backend fixture",
+    "deploy/kubernetes/crds/": "Kubernetes Operator",
+    "deploy/kubernetes/dynamo/": "NVIDIA Dynamo",
+    "deploy/kubernetes/hallucination/": "Hallucination policy demo",
+    "deploy/kubernetes/istio/": "Istio Gateway",
+    "deploy/kubernetes/jailbreak-onerror/": "Jailbreak error-handling demo",
+    "deploy/kubernetes/llm-d/": "llm-d",
+    "deploy/kubernetes/llm-katan/": "LLM Katan development backends",
+    "deploy/kubernetes/llmd-base/": "llm-d",
+    "deploy/kubernetes/observability/": "Observability demo",
+    "deploy/kubernetes/response-api/": "Responses API Kubernetes demo",
+    "deploy/kubernetes/route-action/": "Route action demo",
+    "deploy/kubernetes/router-replay/": "Router replay recovery demo",
+    "deploy/kubernetes/routing-strategies/": "Routing strategy demos",
+    "deploy/kubernetes/streaming/": "Streaming with Envoy AI Gateway",
+    "config/runtime/memory/": "Valkey agentic memory",
+    "config/runtime/response-api/": "Responses API state with Redis",
+    "config/runtime/response-cache/": "Response cache",
+    "config/runtime/tools/": "Local tools database",
+    "config/runtime/vector-store/": "Valkey vector store",
+}
+
 MATRIX_ROW = re.compile(
-    r"^\|\s*`(?P<path>(?:deploy|config/runtime)/[^`]+/)`\s*"
-    r"\|\s*(?P<classification>[^|]+?)\s*\|"
+    r"^\|\s*(?P<label>[^|]+?)\s*\|\s*(?P<classification>[^|]+?)\s*\|"
 )
+MARKDOWN_LINK = re.compile(r"^\[(?P<label>[^]]+)\]\([^)]+\)$")
+PUBLIC_REPO_PATH = re.compile(r"(?:deploy|config/runtime)/[^\s`|)]*")
 
 
 def discover_assets(repo_root: Path) -> set[str]:
-    """Return deploy and runtime-config directories requiring classification."""
+    """Return deployment and runtime-config directories requiring coverage."""
     assets = {
         f"deploy/{path.name}/"
         for path in (repo_root / "deploy").iterdir()
@@ -40,52 +76,96 @@ def discover_assets(repo_root: Path) -> set[str]:
     return assets
 
 
+def normalize_label(cell: str) -> str:
+    """Return the visible label from a plain-text or Markdown-link cell."""
+    cell = cell.strip()
+    match = MARKDOWN_LINK.fullmatch(cell)
+    return match.group("label") if match else cell
+
+
 def parse_matrix(matrix_path: Path) -> tuple[dict[str, str], list[str]]:
-    """Parse classified asset rows and return entries plus duplicate paths."""
+    """Return classified public options and duplicate option labels."""
     entries: dict[str, str] = {}
     duplicates: list[str] = []
+    in_inventory = False
+
     for line in matrix_path.read_text(encoding="utf-8").splitlines():
+        if line == "## Maintained reference stacks":
+            in_inventory = True
+            continue
+        if in_inventory and line == "## Hardware overlays":
+            break
+        if not in_inventory:
+            continue
+
         match = MATRIX_ROW.match(line)
         if match is None:
             continue
-        path = match.group("path")
-        if path in entries:
-            duplicates.append(path)
-        entries[path] = match.group("classification").strip()
+        label = normalize_label(match.group("label"))
+        classification = match.group("classification").strip()
+        if label.startswith("---") or classification == "Classification":
+            continue
+        if label in entries:
+            duplicates.append(label)
+        entries[label] = classification
+
     return entries, duplicates
 
 
-def validate(repo_root: Path, matrix_path: Path | None = None) -> list[str]:
-    """Return human-readable validation errors."""
+def validate(
+    repo_root: Path,
+    matrix_path: Path | None = None,
+    asset_labels: dict[str, str] | None = None,
+) -> list[str]:
+    """Return human-readable inventory and documentation validation errors."""
     matrix_path = matrix_path or repo_root / MATRIX_PATH
     if not matrix_path.is_file():
         return [f"support matrix is missing: {matrix_path}"]
 
-    expected = discover_assets(repo_root)
+    asset_labels = ASSET_LABELS if asset_labels is None else asset_labels
+    discovered_assets = discover_assets(repo_root)
+    registered_assets = set(asset_labels)
+    expected_options = set(asset_labels.values())
     entries, duplicates = parse_matrix(matrix_path)
-    actual = set(entries)
+    actual_options = set(entries)
     errors: list[str] = []
 
-    if duplicates:
-        errors.append("duplicate classifications: " + ", ".join(sorted(duplicates)))
+    unregistered_assets = discovered_assets - registered_assets
+    if unregistered_assets:
+        errors.append("unregistered assets: " + ", ".join(sorted(unregistered_assets)))
 
-    missing = expected - actual
-    if missing:
-        errors.append("unclassified assets: " + ", ".join(sorted(missing)))
-
-    unexpected = actual - expected
-    if unexpected:
+    stale_mappings = registered_assets - discovered_assets
+    if stale_mappings:
         errors.append(
-            "matrix entries without asset directories: " + ", ".join(sorted(unexpected))
+            "asset mappings without directories: " + ", ".join(sorted(stale_mappings))
         )
 
+    if duplicates:
+        errors.append("duplicate options: " + ", ".join(sorted(duplicates)))
+
+    missing_options = expected_options - actual_options
+    if missing_options:
+        errors.append("unclassified options: " + ", ".join(sorted(missing_options)))
+
+    unexpected_options = actual_options - expected_options
+    if unexpected_options:
+        errors.append("unexpected options: " + ", ".join(sorted(unexpected_options)))
+
     invalid = {
-        f"{path} ({classification})"
-        for path, classification in entries.items()
+        f"{label} ({classification})"
+        for label, classification in entries.items()
         if classification not in CLASSIFICATIONS
     }
     if invalid:
         errors.append("invalid classifications: " + ", ".join(sorted(invalid)))
+
+    exposed_paths = sorted(
+        set(PUBLIC_REPO_PATH.findall(matrix_path.read_text(encoding="utf-8")))
+    )
+    if exposed_paths:
+        errors.append(
+            "public matrix exposes repository paths: " + ", ".join(exposed_paths)
+        )
 
     return errors
 
@@ -115,7 +195,8 @@ def main() -> int:
 
     print(
         "deployment support matrix: "
-        f"all {len(discover_assets(repo_root))} assets are classified"
+        f"all {len(discover_assets(repo_root))} assets are classified across "
+        f"{len(set(ASSET_LABELS.values()))} user-facing options"
     )
     return 0
 

--- a/tools/ci/check_deployment_support_matrix.py
+++ b/tools/ci/check_deployment_support_matrix.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Verify that deployment assets are classified in the public support matrix."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+MATRIX_PATH = Path("website/docs/installation/support-matrix.md")
+CLASSIFICATIONS = {
+    "Maintained reference stack",
+    "Supported integration",
+    "Experimental example",
+    "Deprecated",
+}
+MATRIX_ROW = re.compile(
+    r"^\|\s*`(?P<path>(?:deploy|config/runtime)/[^`]+/)`\s*"
+    r"\|\s*(?P<classification>[^|]+?)\s*\|"
+)
+
+
+def discover_assets(repo_root: Path) -> set[str]:
+    """Return deploy and runtime-config directories requiring classification."""
+    assets = {
+        f"deploy/{path.name}/"
+        for path in (repo_root / "deploy").iterdir()
+        if path.is_dir() and path.name != "kubernetes"
+    }
+    assets.update(
+        f"deploy/kubernetes/{path.name}/"
+        for path in (repo_root / "deploy" / "kubernetes").iterdir()
+        if path.is_dir()
+    )
+    assets.update(
+        f"config/runtime/{path.name}/"
+        for path in (repo_root / "config" / "runtime").iterdir()
+        if path.is_dir()
+    )
+    return assets
+
+
+def parse_matrix(matrix_path: Path) -> tuple[dict[str, str], list[str]]:
+    """Parse classified asset rows and return entries plus duplicate paths."""
+    entries: dict[str, str] = {}
+    duplicates: list[str] = []
+    for line in matrix_path.read_text(encoding="utf-8").splitlines():
+        match = MATRIX_ROW.match(line)
+        if match is None:
+            continue
+        path = match.group("path")
+        if path in entries:
+            duplicates.append(path)
+        entries[path] = match.group("classification").strip()
+    return entries, duplicates
+
+
+def validate(repo_root: Path, matrix_path: Path | None = None) -> list[str]:
+    """Return human-readable validation errors."""
+    matrix_path = matrix_path or repo_root / MATRIX_PATH
+    if not matrix_path.is_file():
+        return [f"support matrix is missing: {matrix_path}"]
+
+    expected = discover_assets(repo_root)
+    entries, duplicates = parse_matrix(matrix_path)
+    actual = set(entries)
+    errors: list[str] = []
+
+    if duplicates:
+        errors.append("duplicate classifications: " + ", ".join(sorted(duplicates)))
+
+    missing = expected - actual
+    if missing:
+        errors.append("unclassified assets: " + ", ".join(sorted(missing)))
+
+    unexpected = actual - expected
+    if unexpected:
+        errors.append(
+            "matrix entries without asset directories: " + ", ".join(sorted(unexpected))
+        )
+
+    invalid = {
+        f"{path} ({classification})"
+        for path, classification in entries.items()
+        if classification not in CLASSIFICATIONS
+    }
+    if invalid:
+        errors.append("invalid classifications: " + ", ".join(sorted(invalid)))
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: inferred from this script)",
+    )
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        help="support matrix path (default: repository public documentation)",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    matrix_path = args.matrix.resolve() if args.matrix else None
+    errors = validate(repo_root, matrix_path)
+    if errors:
+        for error in errors:
+            print(f"deployment support matrix: {error}")
+        return 1
+
+    print(
+        "deployment support matrix: "
+        f"all {len(discover_assets(repo_root))} assets are classified"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/tests/test_deployment_support_matrix.py
+++ b/tools/ci/tests/test_deployment_support_matrix.py
@@ -1,0 +1,99 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools" / "ci" / "check_deployment_support_matrix.py"
+SPEC = importlib.util.spec_from_file_location(
+    "check_deployment_support_matrix", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+matrix_check = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(matrix_check)
+
+
+class DeploymentSupportMatrixTests(unittest.TestCase):
+    def make_repo(self, root: Path) -> Path:
+        for path in (
+            "deploy/helm",
+            "deploy/kubernetes/gateway",
+            "config/runtime/cache",
+        ):
+            (root / path).mkdir(parents=True)
+        return root
+
+    def write_matrix(self, root: Path, rows: list[tuple[str, str]]) -> Path:
+        path = root / "support-matrix.md"
+        path.write_text(
+            "\n".join(
+                [
+                    "| Asset path | Classification | Notes |",
+                    "| --- | --- | --- |",
+                    *[
+                        f"| `{asset}` | {classification} | Test row. |"
+                        for asset, classification in rows
+                    ],
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_complete_matrix_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_repo(Path(directory))
+            matrix = self.write_matrix(
+                root,
+                [
+                    ("deploy/helm/", "Maintained reference stack"),
+                    ("deploy/kubernetes/gateway/", "Supported integration"),
+                    ("config/runtime/cache/", "Experimental example"),
+                ],
+            )
+
+            self.assertEqual(matrix_check.validate(root, matrix), [])
+
+    def test_missing_asset_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_repo(Path(directory))
+            matrix = self.write_matrix(
+                root,
+                [
+                    ("deploy/helm/", "Maintained reference stack"),
+                    ("deploy/kubernetes/gateway/", "Supported integration"),
+                ],
+            )
+
+            self.assertEqual(
+                matrix_check.validate(root, matrix),
+                ["unclassified assets: config/runtime/cache/"],
+            )
+
+    def test_duplicate_unknown_path_and_invalid_class_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_repo(Path(directory))
+            matrix = self.write_matrix(
+                root,
+                [
+                    ("deploy/helm/", "Maintained"),
+                    ("deploy/helm/", "Maintained"),
+                    ("deploy/kubernetes/gateway/", "Supported integration"),
+                    ("config/runtime/cache/", "Experimental example"),
+                    ("deploy/removed/", "Deprecated"),
+                ],
+            )
+
+            errors = matrix_check.validate(root, matrix)
+            self.assertIn("duplicate classifications: deploy/helm/", errors)
+            self.assertIn(
+                "matrix entries without asset directories: deploy/removed/", errors
+            )
+            self.assertIn("invalid classifications: deploy/helm/ (Maintained)", errors)
+
+    def test_repository_matrix_is_complete(self) -> None:
+        self.assertEqual(matrix_check.validate(REPO_ROOT), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/tests/test_deployment_support_matrix.py
+++ b/tools/ci/tests/test_deployment_support_matrix.py
@@ -12,12 +12,20 @@ assert SPEC is not None and SPEC.loader is not None
 matrix_check = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(matrix_check)
 
+TEST_LABELS = {
+    "deploy/helm/": "Helm chart",
+    "deploy/kubernetes/gateway/": "Gateway integration",
+    "deploy/kubernetes/gateway-config/": "Gateway integration",
+    "config/runtime/cache/": "Cache example",
+}
+
 
 class DeploymentSupportMatrixTests(unittest.TestCase):
     def make_repo(self, root: Path) -> Path:
         for path in (
             "deploy/helm",
             "deploy/kubernetes/gateway",
+            "deploy/kubernetes/gateway-config",
             "config/runtime/cache",
         ):
             (root / path).mkdir(parents=True)
@@ -28,12 +36,16 @@ class DeploymentSupportMatrixTests(unittest.TestCase):
         path.write_text(
             "\n".join(
                 [
-                    "| Asset path | Classification | Notes |",
+                    "## Maintained reference stacks",
+                    "",
+                    "| Option | Classification | Notes |",
                     "| --- | --- | --- |",
                     *[
-                        f"| `{asset}` | {classification} | Test row. |"
-                        for asset, classification in rows
+                        f"| {label} | {classification} | Test row. |"
+                        for label, classification in rows
                     ],
+                    "",
+                    "## Hardware overlays",
                 ]
             ),
             encoding="utf-8",
@@ -46,50 +58,95 @@ class DeploymentSupportMatrixTests(unittest.TestCase):
             matrix = self.write_matrix(
                 root,
                 [
-                    ("deploy/helm/", "Maintained reference stack"),
-                    ("deploy/kubernetes/gateway/", "Supported integration"),
-                    ("config/runtime/cache/", "Experimental example"),
+                    ("[Helm chart](helm)", "Maintained reference stack"),
+                    ("Gateway integration", "Supported integration"),
+                    ("Cache example", "Experimental example"),
                 ],
             )
 
-            self.assertEqual(matrix_check.validate(root, matrix), [])
+            self.assertEqual(matrix_check.validate(root, matrix, TEST_LABELS), [])
 
-    def test_missing_asset_fails(self) -> None:
+    def test_missing_option_fails(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = self.make_repo(Path(directory))
             matrix = self.write_matrix(
                 root,
                 [
-                    ("deploy/helm/", "Maintained reference stack"),
-                    ("deploy/kubernetes/gateway/", "Supported integration"),
+                    ("Helm chart", "Maintained reference stack"),
+                    ("Gateway integration", "Supported integration"),
                 ],
             )
 
             self.assertEqual(
-                matrix_check.validate(root, matrix),
-                ["unclassified assets: config/runtime/cache/"],
+                matrix_check.validate(root, matrix, TEST_LABELS),
+                ["unclassified options: Cache example"],
             )
 
-    def test_duplicate_unknown_path_and_invalid_class_fail(self) -> None:
+    def test_duplicate_unknown_option_and_invalid_class_fail(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = self.make_repo(Path(directory))
             matrix = self.write_matrix(
                 root,
                 [
-                    ("deploy/helm/", "Maintained"),
-                    ("deploy/helm/", "Maintained"),
-                    ("deploy/kubernetes/gateway/", "Supported integration"),
-                    ("config/runtime/cache/", "Experimental example"),
-                    ("deploy/removed/", "Deprecated"),
+                    ("Helm chart", "Maintained"),
+                    ("Helm chart", "Maintained"),
+                    ("Gateway integration", "Supported integration"),
+                    ("Cache example", "Experimental example"),
+                    ("Removed option", "Deprecated"),
                 ],
             )
 
-            errors = matrix_check.validate(root, matrix)
-            self.assertIn("duplicate classifications: deploy/helm/", errors)
-            self.assertIn(
-                "matrix entries without asset directories: deploy/removed/", errors
+            errors = matrix_check.validate(root, matrix, TEST_LABELS)
+            self.assertIn("duplicate options: Helm chart", errors)
+            self.assertIn("unexpected options: Removed option", errors)
+            self.assertIn("invalid classifications: Helm chart (Maintained)", errors)
+
+    def test_unregistered_assets_and_stale_mappings_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_repo(Path(directory))
+            labels = {
+                "deploy/helm/": "Helm chart",
+                "deploy/kubernetes/gateway/": "Gateway integration",
+                "deploy/kubernetes/gateway-config/": "Gateway integration",
+                "deploy/removed/": "Removed option",
+            }
+            matrix = self.write_matrix(
+                root,
+                [
+                    ("Helm chart", "Maintained reference stack"),
+                    ("Gateway integration", "Supported integration"),
+                    ("Removed option", "Deprecated"),
+                ],
             )
-            self.assertIn("invalid classifications: deploy/helm/ (Maintained)", errors)
+
+            errors = matrix_check.validate(root, matrix, labels)
+            self.assertIn("unregistered assets: config/runtime/cache/", errors)
+            self.assertIn("asset mappings without directories: deploy/removed/", errors)
+
+    def test_public_matrix_rejects_repository_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_repo(Path(directory))
+            matrix = self.write_matrix(
+                root,
+                [
+                    ("Helm chart", "Maintained reference stack"),
+                    ("Gateway integration", "Supported integration"),
+                    ("Cache example", "Experimental example"),
+                ],
+            )
+            matrix.write_text(
+                matrix.read_text(encoding="utf-8")
+                + "\nDo not expose `deploy/kubernetes/gateway/` here.\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                matrix_check.validate(root, matrix, TEST_LABELS),
+                [
+                    "public matrix exposes repository paths: "
+                    "deploy/kubernetes/gateway/"
+                ],
+            )
 
     def test_repository_matrix_is_complete(self) -> None:
         self.assertEqual(matrix_check.validate(REPO_ROOT), [])

--- a/website/docs/installation/deployment-options.md
+++ b/website/docs/installation/deployment-options.md
@@ -12,7 +12,7 @@ The deployment guides are organized into three paths: **Docker** for one host,
 **Kubernetes** for cluster-managed deployments, and **Hardware** for preparing
 GPU-backed model servers or accelerating Router-side models.
 
-Before choosing an asset, check the
+Before choosing an option, check the
 [Deployment and Hardware Support Matrix](support-matrix) for its maintenance
 level, recurring evidence, version constraints, and production boundaries.
 

--- a/website/docs/installation/deployment-options.md
+++ b/website/docs/installation/deployment-options.md
@@ -12,6 +12,10 @@ The deployment guides are organized into three paths: **Docker** for one host,
 **Kubernetes** for cluster-managed deployments, and **Hardware** for preparing
 GPU-backed model servers or accelerating Router-side models.
 
+Before choosing an asset, check the
+[Deployment and Hardware Support Matrix](support-matrix) for its maintenance
+level, recurring evidence, version constraints, and production boundaries.
+
 ## At a glance
 
 | Deployment | Choose it when | Start here |

--- a/website/docs/installation/support-matrix.md
+++ b/website/docs/installation/support-matrix.md
@@ -1,0 +1,137 @@
+---
+title: Deployment and Hardware Support Matrix
+description: Understand which Semantic Router deployment assets and hardware paths are maintained, supported, experimental, or deprecated.
+---
+
+# Deployment and Hardware Support Matrix
+
+Use this page to determine what the Semantic Router project maintains and what
+you must validate for your environment. An asset being present in the
+repository does not, by itself, make every platform version, image, model, or
+accelerator combination supported.
+
+For a task-oriented starting point, see [Choose a Deployment](deployment-options).
+
+## Support levels
+
+| Level | Project commitment |
+| --- | --- |
+| Maintained reference stack | The project owns the installation or lifecycle contract and protects it with repository tests. Pin a Semantic Router release for production. |
+| Supported integration | The project maintains the Router-side attachment contract and documentation. The external platform keeps its own support matrix and lifecycle. |
+| Experimental example | The asset demonstrates a feature or test topology. Review and adapt it; compatibility and production hardening are not guaranteed. |
+| Deprecated | The asset remains temporarily for migration and has a documented replacement or removal path. |
+
+Evidence labels in the tables describe the repository's strongest recurring
+check. They are not proof that an arbitrary downstream cluster passed:
+
+- **PR/full CI** means a registered end-to-end profile is selected in pull
+  request or full-CI coverage.
+- **Contract/build** means source, schema, rendering, image, or packaging
+  checks protect the asset without running every external platform.
+- **Manual profile** means the repository provides an opt-in test with external
+  prerequisites. It does not mean the profile passed in another environment.
+- **Documented example** means the project checks the files and documentation,
+  but operators own end-to-end qualification.
+
+## Maintained reference stacks
+
+| Asset path | Classification | Capabilities | Ownership and data plane | Version or image policy | Evidence and limits |
+| --- | --- | --- | --- | --- | --- |
+| `deploy/helm/` | Maintained reference stack | Router, optional Dashboard, ingress, autoscaling, persistence, and observability resources. | The project owns the chart and Router lifecycle; the selected Gateway or Service remains the data plane. | Use the chart from the same Semantic Router release and pin application images. Chart dependencies are declared by the chart. | The [Helm safety gate](https://github.com/vllm-project/semantic-router/blob/main/tools/make/helm.mk) validates rendering, schema, and safety rules. External gateways and storage still require their own tests. |
+| `deploy/local/` | Maintained reference stack | Local Router, Envoy, Dashboard, and selected support services through `vllm-sr serve`. | The CLI owns the local stack lifecycle. Model endpoints remain separate. | Use same-release CLI and images; pin image digests for controlled deployments. | The [CLI integration workflow](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/integration-test-vllm-sr-cli.yml) exercises the lifecycle with real containers. Local defaults are for evaluation and development until hardened. |
+| `deploy/operator/` | Maintained reference stack | Reconciliation of Router configuration, workload, Service, storage, autoscaling, and optional platform resources. | The Operator reconciles `SemanticRouter` resources; Kubernetes owns workload scheduling and the chosen gateway owns traffic. | Install the CRD, controller, and Router images from one release. Pin the controller image and inspect samples before use. | [Operator CI](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/operator-ci.yml) covers unit, generated-resource, image, and cluster reconciliation contracts. Sample custom resources are not production values. |
+| `deploy/kubernetes/crds/` | Maintained reference stack | Kubernetes APIs for intelligent routing resources consumed by their controllers and integrations. | The project owns the API definitions; controllers or integrations own reconciliation and traffic. | Apply CRDs from the same release as the consuming controller or integration. | The [operator test contract](https://github.com/vllm-project/semantic-router/blob/main/tools/agent/test-domain-registry.yaml) protects generated schemas. The directory is not a standalone deployment. |
+
+## Supported integrations
+
+| Asset path | Classification | Ownership and data plane | Version or image policy | Evidence and limits |
+| --- | --- | --- | --- | --- |
+| `deploy/kubernetes/agentgateway/` | Supported integration | agentgateway owns the Gateway API data plane; Semantic Router supplies ExtProc policy. | The guide pins agentgateway `v1.4.1` and Gateway API `v1.6.0`; pin a Router release instead of `0.0.0-latest`. | PR/full CI profile. agentgateway requires `FullDuplexStreamed` rather than `Streamed` request bodies. |
+| `deploy/kubernetes/ai-gateway/` | Supported integration | Envoy AI Gateway and Envoy Gateway own provider traffic; Semantic Router supplies routing policy. | The guide pins Envoy AI Gateway `v1.0.0`, Envoy Gateway `v1.8.1`, Gateway API `v1.5.x`, and Kubernetes `1.32+`. | Default and full-CI profile. Provider compatibility changes independently; verify the selected provider. |
+| `deploy/kubernetes/aibrix/` | Supported integration | AIBrix owns model deployment, autoscaling, and replica routing; Semantic Router selects the model or pool. | Follow one supported AIBrix release and pin Router images and configuration to a tested set. | PR/full CI profile. The project does not replace AIBrix's cluster and accelerator support matrix. |
+| `deploy/kubernetes/dynamo/` | Supported integration | NVIDIA Dynamo owns graphs, workers, and frontend lifecycle; Semantic Router selects a model target. | The guide covers Dynamo `1.4.0`, Envoy Gateway `v1.9.0`, Gateway API `v1.6.1`, and Kubernetes `1.33`-`1.36`. | Manual profile because it requires a prepared Dynamo/GPU environment. Validate the selected Dynamo release separately. |
+| `deploy/kubernetes/istio/` | Supported integration | Istio's Gateway API data plane carries requests; Semantic Router is the ExtProc policy service. | The guide pins Istio `1.29.6`, Gateway API `v1.5.1`, and Kubernetes `1.31`-`1.35`. | PR/full CI profile. Supplied model workloads need NVIDIA GPU capacity and are examples, not a general GPU guarantee. |
+| `deploy/kubernetes/llm-d/` | Supported integration | llm-d owns model services, discovery, and replica routing; Semantic Router owns semantic model selection. | Choose one supported llm-d release and its matching APIs, gateway, and images; do not mix copied manifests across releases. | PR/full CI profile. llm-d's release-specific deployment and hardware requirements remain authoritative. |
+| `deploy/kubernetes/llmd-base/` | Supported integration | The llm-d Inference Scheduler chooses a replica after Semantic Router selects an `InferencePool`. | Match the `InferencePool` API and names to the selected llm-d release and pin all images. | Contract/build and shared gateway coverage. Do not apply competing direct-Service routes for the same traffic. |
+| `deploy/kubernetes/streaming/` | Supported integration | The selected Gateway owns streamed transport; Semantic Router processes the configured ExtProc body mode. | Pin the Router and gateway releases and use a body mode supported by that gateway. | PR/full CI streaming profile. Transport capabilities differ across gateways. |
+| `config/runtime/memory/` | Supported integration | Semantic Router owns memory configuration; Milvus or Valkey owns persistence and availability. | Pin the external service and client-compatible schema used by the selected Router release. | Contract and manual integration coverage. Credentials, retention, backup, and tenant isolation are operator responsibilities. |
+| `config/runtime/response-api/` | Supported integration | Semantic Router owns Response API configuration; Redis owns durable conversation state. | Use a Redis version and topology tested with the selected release. | Manual Redis profile. Production authentication, encryption, persistence, and eviction policy are not supplied by the example. |
+| `config/runtime/response-cache/` | Supported integration | Semantic Router owns cache configuration; the external cache owns storage and availability. | Pin the backend and Router release and validate serialization and expiry behavior. | Contract/manual coverage. Treat cached prompts and responses as sensitive data. |
+| `config/runtime/vector-store/` | Supported integration | Semantic Router owns vector-store references; the selected store owns indexing, durability, and access control. | Pin the store version, embedding model, and Router release as one tested set. | Manual vector-store profiles. Index compatibility and data migration remain operator responsibilities. |
+
+## Experimental examples
+
+| Asset path | Classification | Purpose and boundary | Evidence and production cautions |
+| --- | --- | --- | --- |
+| `deploy/kserve/` | Experimental example | Demonstrates KServe integration; KServe and the cluster own model serving. | Documented example and smoke helpers. Review platform versions, images, credentials, storage, and cleanup before use. |
+| `deploy/openshift/` | Experimental example | Adapts Kubernetes resources to OpenShift Routes and security constraints. | Documented example. Review images, Route TLS, credentials, SCCs, caches, and persistent data. |
+| `deploy/kubernetes/anthropic-backend/` | Experimental example | Provides an Anthropic-compatible backend fixture for integration tests. | Test fixture only; it is not a production model service. |
+| `deploy/kubernetes/hallucination/` | Experimental example | Exercises fact-check gating and warning behavior. | Manual profile with model prerequisites. Validate model quality and failure policy for the deployment domain. |
+| `deploy/kubernetes/jailbreak-onerror/` | Experimental example | Exercises jailbreak classifier error handling. | Manual failure-path profile. Do not treat the unreachable test endpoint or permissive policy as production hardening. |
+| `deploy/kubernetes/llm-katan/` | Experimental example | Supplies lightweight OpenAI-compatible development backends. | Test fixture only; it does not represent production model quality, capacity, or availability. |
+| `deploy/kubernetes/observability/` | Experimental example | Demonstrates Prometheus, Grafana, alerts, and Dashboard wiring in a development cluster. | Documented example. Replace example hostnames, TLS material, credentials, retention, and insecure defaults. |
+| `deploy/kubernetes/response-api/` | Experimental example | Demonstrates Response API persistence and restart behavior with Redis. | Manual profile. Harden Redis networking, authentication, encryption, persistence, and eviction policy. |
+| `deploy/kubernetes/route-action/` | Experimental example | Demonstrates route-action behavior through a focused Kubernetes topology. | Test/example coverage only; compose it into a maintained stack before production use. |
+| `deploy/kubernetes/router-replay/` | Experimental example | Exercises management-boundary replay and restart recovery. | Manual profile. It is a recovery test topology, not a supported deployment platform. |
+| `deploy/kubernetes/routing-strategies/` | Experimental example | Demonstrates focused routing-strategy configurations and test traffic. | Test/example coverage only. Validate policy quality and backend capacity with representative traffic. |
+| `config/runtime/tools/` | Experimental example | Provides a local tools database used by examples and tests. | Local example data only. Use an authenticated, durable tool registry for production. |
+
+There are no currently shipped deployment directories classified as
+**Deprecated**. Removed legacy behavior and migration guidance are recorded in
+[Upgrade and Rollback](upgrade-rollback). A future deprecated asset must remain
+in this matrix until its documented removal.
+
+## Hardware overlays
+
+Hardware support applies to a deployment stack; it does not replace one.
+Semantic Router and the backend model server are also separate support
+boundaries.
+
+| Hardware profile | Status | Maintained path and constraints | Qualification boundary |
+| --- | --- | --- | --- |
+| Linux x86-64 CPU | Maintained | Use the standard Router images, local CLI, Helm chart, or Operator. | The normal build, unit, CLI, and Kubernetes profiles provide the broadest recurring coverage. Backend model-server requirements are separate. |
+| Linux Arm64 CPU | Build-qualified | Standard Router, Dashboard, ExtProc, and Operator images are published as multi-architecture images where their release workflow declares Arm64. | Multi-architecture image publication is not a promise that every integration or optional native dependency passed on every Arm64 platform. |
+| NVIDIA CUDA on Linux x86-64 | Supported integration | Use the `vllm-sr-cuda` image for supported Router-side ONNX models, or keep the Router on CPU and connect a separately qualified NVIDIA vLLM backend. The current image is built on CUDA `12.4.1`. | Follow [NVIDIA CUDA](nvidia-cuda), verify the CUDA execution provider, and pin the image digest. GPU model serving follows vLLM's NVIDIA support matrix; presence here does not qualify every NVIDIA architecture. |
+| AMD ROCm on Linux x86-64 | Supported integration | Keep the Router on CPU or use the ROCm Router image for supported local models, and connect a separately qualified ROCm vLLM backend. | Follow [AMD ROCm](amd-rocm) and pin compatible Router, vLLM, ROCm, and model revisions. Hardware-specific runtime coverage is not a per-PR guarantee. |
+| AMD AI PC/NPU | Experimental, not qualified | Tracked by [issue #2373](https://github.com/vllm-project/semantic-router/issues/2373). | No maintained deployment contract or compatibility promise yet. |
+| NVIDIA DGX Spark Arm64 | Experimental, not qualified | Tracked by [issue #2374](https://github.com/vllm-project/semantic-router/issues/2374). | Arm64 image availability alone does not qualify CUDA, native dependencies, or end-to-end inference on this platform. |
+| Other accelerators and operating systems | Not qualified | No maintained Router deployment path is currently declared. | Open a qualification issue with reproducible hardware, software, image, and test evidence before documenting support. |
+
+## Configuration, dependencies, and security
+
+Use one canonical Router YAML document. The CLI may translate it into Helm
+values, and the Operator may reconcile it from a custom resource, but neither
+path should create a second hand-maintained routing schema. The assets under
+`config/runtime/` are references consumed by complete configurations; they are
+not deployment manifests.
+
+External gateways, inference platforms, model servers, databases, storage
+classes, identity systems, and accelerator runtimes retain their own release
+and security policies. For production:
+
+1. pin the Semantic Router release, images or digests, external platform
+   versions, model revisions, and configuration together;
+2. test the backend directly before testing it through the Router;
+3. exercise health, streaming, failure, upgrade, and rollback behavior through
+   the actual data plane;
+4. move credentials into a secret manager and enable transport security,
+   network policy, authentication, and least privilege; and
+5. review [Security Hardening](security-hardening),
+   [Data and Storage](storage-overview), and
+   [Upgrade and Rollback](upgrade-rollback).
+
+## Keeping the matrix complete
+
+Every direct child of `deploy/`, every direct child of `deploy/kubernetes/`,
+and every runtime integration under `config/runtime/` must appear exactly once
+in the tables above. When adding, removing, or changing one of those assets,
+update its classification and evidence here.
+
+Run the lightweight inventory check from the repository root:
+
+```bash
+python3 tools/ci/check_deployment_support_matrix.py
+```
+
+The repository pre-commit configuration runs the same check when deployment
+assets, runtime integration assets, or this page change.

--- a/website/docs/installation/support-matrix.md
+++ b/website/docs/installation/support-matrix.md
@@ -1,14 +1,13 @@
 ---
 title: Deployment and Hardware Support Matrix
-description: Understand which Semantic Router deployment assets and hardware paths are maintained, supported, experimental, or deprecated.
+description: Understand which Semantic Router deployment options and hardware profiles are maintained, supported, experimental, or deprecated.
 ---
 
 # Deployment and Hardware Support Matrix
 
-Use this page to determine what the Semantic Router project maintains and what
-you must validate for your environment. An asset being present in the
-repository does not, by itself, make every platform version, image, model, or
-accelerator combination supported.
+Use this page to choose a deployment option and understand what the Semantic
+Router project maintains. A documented option does not, by itself, make every
+platform version, image, model, or accelerator combination supported.
 
 For a task-oriented starting point, see [Choose a Deployment](deployment-options).
 
@@ -18,67 +17,68 @@ For a task-oriented starting point, see [Choose a Deployment](deployment-options
 | --- | --- |
 | Maintained reference stack | The project owns the installation or lifecycle contract and protects it with repository tests. Pin a Semantic Router release for production. |
 | Supported integration | The project maintains the Router-side attachment contract and documentation. The external platform keeps its own support matrix and lifecycle. |
-| Experimental example | The asset demonstrates a feature or test topology. Review and adapt it; compatibility and production hardening are not guaranteed. |
-| Deprecated | The asset remains temporarily for migration and has a documented replacement or removal path. |
+| Experimental example | The option demonstrates a feature or test topology. Review and adapt it; compatibility and production hardening are not guaranteed. |
+| Deprecated | The option remains temporarily for migration and has a documented replacement or removal path. |
 
-Evidence labels in the tables describe the repository's strongest recurring
-check. They are not proof that an arbitrary downstream cluster passed:
+Evidence labels describe the project's strongest recurring check. They do not
+prove that an arbitrary downstream environment passed:
 
 - **PR/full CI** means a registered end-to-end profile is selected in pull
   request or full-CI coverage.
 - **Contract/build** means source, schema, rendering, image, or packaging
-  checks protect the asset without running every external platform.
-- **Manual profile** means the repository provides an opt-in test with external
+  checks protect the option without running every external platform.
+- **Manual profile** means the project provides an opt-in test with external
   prerequisites. It does not mean the profile passed in another environment.
 - **Documented example** means the project checks the files and documentation,
   but operators own end-to-end qualification.
 
 ## Maintained reference stacks
 
-| Asset path | Classification | Capabilities | Ownership and data plane | Version or image policy | Evidence and limits |
-| --- | --- | --- | --- | --- | --- |
-| `deploy/helm/` | Maintained reference stack | Router, optional Dashboard, ingress, autoscaling, persistence, and observability resources. | The project owns the chart and Router lifecycle; the selected Gateway or Service remains the data plane. | Use the chart from the same Semantic Router release and pin application images. Chart dependencies are declared by the chart. | The [Helm safety gate](https://github.com/vllm-project/semantic-router/blob/main/tools/make/helm.mk) validates rendering, schema, and safety rules. External gateways and storage still require their own tests. |
-| `deploy/local/` | Maintained reference stack | Local Router, Envoy, Dashboard, and selected support services through `vllm-sr serve`. | The CLI owns the local stack lifecycle. Model endpoints remain separate. | Use same-release CLI and images; pin image digests for controlled deployments. | The [CLI integration workflow](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/integration-test-vllm-sr-cli.yml) exercises the lifecycle with real containers. Local defaults are for evaluation and development until hardened. |
-| `deploy/operator/` | Maintained reference stack | Reconciliation of Router configuration, workload, Service, storage, autoscaling, and optional platform resources. | The Operator reconciles `SemanticRouter` resources; Kubernetes owns workload scheduling and the chosen gateway owns traffic. | Install the CRD, controller, and Router images from one release. Pin the controller image and inspect samples before use. | [Operator CI](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/operator-ci.yml) covers unit, generated-resource, image, and cluster reconciliation contracts. Sample custom resources are not production values. |
-| `deploy/kubernetes/crds/` | Maintained reference stack | Kubernetes APIs for intelligent routing resources consumed by their controllers and integrations. | The project owns the API definitions; controllers or integrations own reconciliation and traffic. | Apply CRDs from the same release as the consuming controller or integration. | The [operator test contract](https://github.com/vllm-project/semantic-router/blob/main/tools/agent/test-domain-registry.yaml) protects generated schemas. The directory is not a standalone deployment. |
+| Option | Classification | What the project maintains | Version, ownership, and evidence boundary |
+| --- | --- | --- | --- |
+| [Helm chart](configuration-workflows#helm) | Maintained reference stack | Router, optional Dashboard, ingress, autoscaling, persistence, and observability resources. | Use the chart from the same Semantic Router release and pin application images. The project owns the chart and Router lifecycle; the selected Gateway, Service, and storage remain separate. The [Helm safety gate](https://github.com/vllm-project/semantic-router/blob/main/tools/make/helm.mk) validates rendering, schema, and safety rules. |
+| [Local deployment](docker) | Maintained reference stack | Router, Envoy, Dashboard, and selected support services through `vllm-sr serve`. | Use same-release CLI and images; pin image digests for controlled deployments. The CLI owns the local stack lifecycle, while model endpoints remain separate. The [CLI integration workflow](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/integration-test-vllm-sr-cli.yml) exercises the lifecycle with real containers. Local defaults require hardening before production. |
+| [Kubernetes Operator](k8s/operator) | Maintained reference stack | Reconciliation of Router configuration, workload, Service, storage, autoscaling, and the project-owned `vllm.ai` routing APIs used by controllers and integrations. | Install the CRDs, controller, and Router images from one release. Kubernetes owns workload scheduling and the chosen gateway owns traffic. [Operator CI](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/operator-ci.yml) covers unit, generated-resource, image, API-schema, and cluster-reconciliation contracts. The routing APIs are components of these integrations, not a standalone deployment. |
 
 ## Supported integrations
 
-| Asset path | Classification | Ownership and data plane | Version or image policy | Evidence and limits |
-| --- | --- | --- | --- | --- |
-| `deploy/kubernetes/agentgateway/` | Supported integration | agentgateway owns the Gateway API data plane; Semantic Router supplies ExtProc policy. | The guide pins agentgateway `v1.4.1` and Gateway API `v1.6.0`; pin a Router release instead of `0.0.0-latest`. | PR/full CI profile. agentgateway requires `FullDuplexStreamed` rather than `Streamed` request bodies. |
-| `deploy/kubernetes/ai-gateway/` | Supported integration | Envoy AI Gateway and Envoy Gateway own provider traffic; Semantic Router supplies routing policy. | The guide pins Envoy AI Gateway `v1.0.0`, Envoy Gateway `v1.8.1`, Gateway API `v1.5.x`, and Kubernetes `1.32+`. | Default and full-CI profile. Provider compatibility changes independently; verify the selected provider. |
-| `deploy/kubernetes/aibrix/` | Supported integration | AIBrix owns model deployment, autoscaling, and replica routing; Semantic Router selects the model or pool. | Follow one supported AIBrix release and pin Router images and configuration to a tested set. | PR/full CI profile. The project does not replace AIBrix's cluster and accelerator support matrix. |
-| `deploy/kubernetes/dynamo/` | Supported integration | NVIDIA Dynamo owns graphs, workers, and frontend lifecycle; Semantic Router selects a model target. | The guide covers Dynamo `1.4.0`, Envoy Gateway `v1.9.0`, Gateway API `v1.6.1`, and Kubernetes `1.33`-`1.36`. | Manual profile because it requires a prepared Dynamo/GPU environment. Validate the selected Dynamo release separately. |
-| `deploy/kubernetes/istio/` | Supported integration | Istio's Gateway API data plane carries requests; Semantic Router is the ExtProc policy service. | The guide pins Istio `1.29.6`, Gateway API `v1.5.1`, and Kubernetes `1.31`-`1.35`. | PR/full CI profile. Supplied model workloads need NVIDIA GPU capacity and are examples, not a general GPU guarantee. |
-| `deploy/kubernetes/llm-d/` | Supported integration | llm-d owns model services, discovery, and replica routing; Semantic Router owns semantic model selection. | Choose one supported llm-d release and its matching APIs, gateway, and images; do not mix copied manifests across releases. | PR/full CI profile. llm-d's release-specific deployment and hardware requirements remain authoritative. |
-| `deploy/kubernetes/llmd-base/` | Supported integration | The llm-d Inference Scheduler chooses a replica after Semantic Router selects an `InferencePool`. | Match the `InferencePool` API and names to the selected llm-d release and pin all images. | Contract/build and shared gateway coverage. Do not apply competing direct-Service routes for the same traffic. |
-| `deploy/kubernetes/streaming/` | Supported integration | The selected Gateway owns streamed transport; Semantic Router processes the configured ExtProc body mode. | Pin the Router and gateway releases and use a body mode supported by that gateway. | PR/full CI streaming profile. Transport capabilities differ across gateways. |
-| `config/runtime/memory/` | Supported integration | Semantic Router owns memory configuration; Milvus or Valkey owns persistence and availability. | Pin the external service and client-compatible schema used by the selected Router release. | Contract and manual integration coverage. Credentials, retention, backup, and tenant isolation are operator responsibilities. |
-| `config/runtime/response-api/` | Supported integration | Semantic Router owns Response API configuration; Redis owns durable conversation state. | Use a Redis version and topology tested with the selected release. | Manual Redis profile. Production authentication, encryption, persistence, and eviction policy are not supplied by the example. |
-| `config/runtime/response-cache/` | Supported integration | Semantic Router owns cache configuration; the external cache owns storage and availability. | Pin the backend and Router release and validate serialization and expiry behavior. | Contract/manual coverage. Treat cached prompts and responses as sensitive data. |
-| `config/runtime/vector-store/` | Supported integration | Semantic Router owns vector-store references; the selected store owns indexing, durability, and access control. | Pin the store version, embedding model, and Router release as one tested set. | Manual vector-store profiles. Index compatibility and data migration remain operator responsibilities. |
+Each linked guide is authoritative for its current external platform versions.
+Pin that compatibility set together with the selected Semantic Router release.
+
+| Integration | Classification | Ownership and version boundary | Evidence and limits |
+| --- | --- | --- | --- |
+| [agentgateway](k8s/agentgateway) | Supported integration | agentgateway owns the Gateway API data plane; Semantic Router supplies ExtProc policy. Use the versions pinned by the guide. | PR/full CI profile. agentgateway requires `FullDuplexStreamed` rather than `Streamed` request bodies. |
+| [Envoy AI Gateway](k8s/ai-gateway) | Supported integration | Envoy AI Gateway and Envoy Gateway own provider traffic; Semantic Router supplies routing policy. Use the versions pinned by the guide. | Default and full-CI profile. Provider compatibility changes independently; verify the selected provider. |
+| [AIBrix](k8s/aibrix) | Supported integration | AIBrix owns model deployment, autoscaling, and replica routing; Semantic Router selects the model or pool. | PR/full CI profile. Pin one AIBrix release and do not treat this integration as a replacement for AIBrix's cluster and accelerator support matrix. |
+| [NVIDIA Dynamo](k8s/dynamo) | Supported integration | Dynamo owns graphs, workers, and frontend lifecycle; Semantic Router selects a model target. Use the versions pinned by the guide. | Manual profile because it requires a prepared Dynamo/GPU environment. The repository also retains a pinned Dynamo `0.6.1.post1` model-deployment fixture for historical testing; it is not compatible with the guide's current platform and is not a production deployment. |
+| [Istio Gateway](k8s/istio) | Supported integration | Istio's Gateway API data plane carries requests; Semantic Router is the ExtProc policy service. Use the versions pinned by the guide. | PR/full CI profile. Supplied model workloads need NVIDIA GPU capacity and are examples, not a general GPU guarantee. |
+| [llm-d](k8s/llm-d) | Supported integration | Semantic Router selects a logical model or pool; the Gateway route targets its `InferencePool`, and llm-d owns discovery, endpoint picking, and replica routing. The repository supplies both Router values and scheduler-manifest examples. | PR/full CI profile plus contract/build coverage. Match the APIs and images to one llm-d release, and do not apply competing direct-Service routes for the same traffic. |
+| [Streaming with Envoy AI Gateway](k8s/streamed-extproc) | Supported integration | Envoy AI Gateway owns streamed transport; Semantic Router processes the configured ExtProc body mode. | PR/full CI streaming profile. Pin both releases and test the body mode because streaming capabilities differ across gateways. |
+| [Valkey agentic memory](valkey-memory) | Supported integration | Semantic Router owns memory configuration; Valkey owns persistence, availability, and Search-module compatibility. | Contract and manual integration coverage. Credentials, retention, backup, tenant isolation, and end-to-end qualification remain operator responsibilities. |
+| [Responses API state with Redis](../tutorials/global/api-and-observability#response-api) | Supported integration | Semantic Router owns Responses API configuration; Redis owns durable conversation state. | Manual Redis profiles. Validate the selected Redis topology; production authentication, encryption, persistence, and eviction policy are not supplied by the examples. |
+| [Response cache](../tutorials/plugin/response-cache) | Supported integration | Semantic Router owns cache behavior and configuration; the selected external backend owns storage and availability. | Contract/manual coverage. Pin the backend and Router release, validate serialization and expiry behavior, and treat cached prompts and responses as sensitive data. |
+| [Valkey vector store](storage-overview) | Supported integration | Semantic Router owns vector-store references; Valkey owns indexing, durability, and access control. | Manual vector-store profiles. Pin Valkey, its Search module, the embedding model, and the Router release as one tested set. |
 
 ## Experimental examples
 
-| Asset path | Classification | Purpose and boundary | Evidence and production cautions |
+| Example | Classification | Purpose | Production boundary |
 | --- | --- | --- | --- |
-| `deploy/kserve/` | Experimental example | Demonstrates KServe integration; KServe and the cluster own model serving. | Documented example and smoke helpers. Review platform versions, images, credentials, storage, and cleanup before use. |
-| `deploy/openshift/` | Experimental example | Adapts Kubernetes resources to OpenShift Routes and security constraints. | Documented example. Review images, Route TLS, credentials, SCCs, caches, and persistent data. |
-| `deploy/kubernetes/anthropic-backend/` | Experimental example | Provides an Anthropic-compatible backend fixture for integration tests. | Test fixture only; it is not a production model service. |
-| `deploy/kubernetes/hallucination/` | Experimental example | Exercises fact-check gating and warning behavior. | Manual profile with model prerequisites. Validate model quality and failure policy for the deployment domain. |
-| `deploy/kubernetes/jailbreak-onerror/` | Experimental example | Exercises jailbreak classifier error handling. | Manual failure-path profile. Do not treat the unreachable test endpoint or permissive policy as production hardening. |
-| `deploy/kubernetes/llm-katan/` | Experimental example | Supplies lightweight OpenAI-compatible development backends. | Test fixture only; it does not represent production model quality, capacity, or availability. |
-| `deploy/kubernetes/observability/` | Experimental example | Demonstrates Prometheus, Grafana, alerts, and Dashboard wiring in a development cluster. | Documented example. Replace example hostnames, TLS material, credentials, retention, and insecure defaults. |
-| `deploy/kubernetes/response-api/` | Experimental example | Demonstrates Response API persistence and restart behavior with Redis. | Manual profile. Harden Redis networking, authentication, encryption, persistence, and eviction policy. |
-| `deploy/kubernetes/route-action/` | Experimental example | Demonstrates route-action behavior through a focused Kubernetes topology. | Test/example coverage only; compose it into a maintained stack before production use. |
-| `deploy/kubernetes/router-replay/` | Experimental example | Exercises management-boundary replay and restart recovery. | Manual profile. It is a recovery test topology, not a supported deployment platform. |
-| `deploy/kubernetes/routing-strategies/` | Experimental example | Demonstrates focused routing-strategy configurations and test traffic. | Test/example coverage only. Validate policy quality and backend capacity with representative traffic. |
-| `config/runtime/tools/` | Experimental example | Provides a local tools database used by examples and tests. | Local example data only. Use an authenticated, durable tool registry for production. |
+| KServe example | Experimental example | Demonstrates KServe integration while KServe and the cluster own model serving. | Documented example and smoke helpers. Review platform versions, images, credentials, storage, and cleanup before use. |
+| OpenShift example | Experimental example | Adapts Kubernetes resources to OpenShift Routes and security constraints. | Documented example. Review images, Route TLS, credentials, SCCs, caches, and persistent data. |
+| Anthropic-compatible backend fixture | Experimental example | Provides an Anthropic-compatible backend for integration tests. | Test fixture only; it is not a production model service. |
+| Hallucination policy demo | Experimental example | Exercises fact-check gating and warning behavior. | Manual profile with model prerequisites. Validate model quality and failure policy for the deployment domain. |
+| Jailbreak error-handling demo | Experimental example | Exercises jailbreak-classifier failure behavior. | Manual failure-path profile. Do not treat the unreachable test endpoint or permissive policy as production hardening. |
+| LLM Katan development backends | Experimental example | Supplies lightweight OpenAI-compatible development backends. | Test fixture only; it does not represent production model quality, capacity, or availability. |
+| Observability demo | Experimental example | Demonstrates Prometheus, Grafana, alerts, and Dashboard wiring in a development cluster. | Documented example. Replace example hostnames, TLS material, credentials, retention, and insecure defaults. |
+| Responses API Kubernetes demo | Experimental example | Demonstrates Responses API persistence and restart behavior with Redis. | Manual profile. Harden Redis networking, authentication, encryption, persistence, and eviction policy. |
+| Route action demo | Experimental example | Demonstrates route-action behavior through a focused Kubernetes topology. | Test/example coverage only; compose it into a maintained stack before production use. |
+| Router replay recovery demo | Experimental example | Exercises management-boundary replay and restart recovery. | Manual profile. It is a recovery test topology, not a supported deployment platform. |
+| Routing strategy demos | Experimental example | Demonstrates focused routing-strategy configurations and test traffic. | Test/example coverage only. Validate policy quality and backend capacity with representative traffic. |
+| Local tools database | Experimental example | Provides local tool definitions used by examples and tests. | Local example data only. Use an authenticated, durable tool registry for production. |
 
-There are no currently shipped deployment directories classified as
-**Deprecated**. Removed legacy behavior and migration guidance are recorded in
-[Upgrade and Rollback](upgrade-rollback). A future deprecated asset must remain
+There are no currently shipped deployment options classified as **Deprecated**.
+Removed legacy behavior and migration guidance are recorded in
+[Upgrade and Rollback](upgrade-rollback). A future deprecated option must remain
 in this matrix until its documented removal.
 
 ## Hardware overlays
@@ -87,7 +87,7 @@ Hardware support applies to a deployment stack; it does not replace one.
 Semantic Router and the backend model server are also separate support
 boundaries.
 
-| Hardware profile | Status | Maintained path and constraints | Qualification boundary |
+| Hardware profile | Status | Deployment guidance | Qualification boundary |
 | --- | --- | --- | --- |
 | Linux x86-64 CPU | Maintained | Use the standard Router images, local CLI, Helm chart, or Operator. | The normal build, unit, CLI, and Kubernetes profiles provide the broadest recurring coverage. Backend model-server requirements are separate. |
 | Linux Arm64 CPU | Build-qualified | Standard Router, Dashboard, ExtProc, and Operator images are published as multi-architecture images where their release workflow declares Arm64. | Multi-architecture image publication is not a promise that every integration or optional native dependency passed on every Arm64 platform. |
@@ -95,15 +95,15 @@ boundaries.
 | AMD ROCm on Linux x86-64 | Supported integration | Keep the Router on CPU or use the ROCm Router image for supported local models, and connect a separately qualified ROCm vLLM backend. | Follow [AMD ROCm](amd-rocm) and pin compatible Router, vLLM, ROCm, and model revisions. Hardware-specific runtime coverage is not a per-PR guarantee. |
 | AMD AI PC/NPU | Experimental, not qualified | Tracked by [issue #2373](https://github.com/vllm-project/semantic-router/issues/2373). | No maintained deployment contract or compatibility promise yet. |
 | NVIDIA DGX Spark Arm64 | Experimental, not qualified | Tracked by [issue #2374](https://github.com/vllm-project/semantic-router/issues/2374). | Arm64 image availability alone does not qualify CUDA, native dependencies, or end-to-end inference on this platform. |
-| Other accelerators and operating systems | Not qualified | No maintained Router deployment path is currently declared. | Open a qualification issue with reproducible hardware, software, image, and test evidence before documenting support. |
+| Other accelerators and operating systems | Not qualified | No maintained Router deployment option is currently declared. | Open a qualification issue with reproducible hardware, software, image, and test evidence before documenting support. |
 
 ## Configuration, dependencies, and security
 
 Use one canonical Router YAML document. The CLI may translate it into Helm
 values, and the Operator may reconcile it from a custom resource, but neither
-path should create a second hand-maintained routing schema. The assets under
-`config/runtime/` are references consumed by complete configurations; they are
-not deployment manifests.
+option should create a second hand-maintained routing schema. Runtime
+configuration examples are references consumed by complete configurations;
+they are not deployment manifests.
 
 External gateways, inference platforms, model servers, databases, storage
 classes, identity systems, and accelerator runtimes retain their own release
@@ -119,19 +119,3 @@ and security policies. For production:
 5. review [Security Hardening](security-hardening),
    [Data and Storage](storage-overview), and
    [Upgrade and Rollback](upgrade-rollback).
-
-## Keeping the matrix complete
-
-Every direct child of `deploy/`, every direct child of `deploy/kubernetes/`,
-and every runtime integration under `config/runtime/` must appear exactly once
-in the tables above. When adding, removing, or changing one of those assets,
-update its classification and evidence here.
-
-Run the lightweight inventory check from the repository root:
-
-```bash
-python3 tools/ci/check_deployment_support_matrix.py
-```
-
-The repository pre-commit configuration runs the same check when deployment
-assets, runtime integration assets, or this page change.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -34,6 +34,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'installation/installation',
         'installation/deployment-options',
+        'installation/support-matrix',
       ],
     },
     {


### PR DESCRIPTION
Closes #3190

## Purpose

This change publishes one public source of truth for the repository's deployment options, integrations, runtime examples, and hardware overlays under the Enterprise & Environment workgroup (`wg/enterprise-environment`).

It:

- defines the maintained reference stack, supported integration, experimental example, and deprecated support levels;
- maps all 28 current deployment and runtime-integration asset directories to 26 clean, user-facing options;
- records ownership and data-plane boundaries, evidence strength, security responsibilities, and known limitations while delegating external version compatibility to the linked guides;
- separates CPU, NVIDIA CUDA, AMD ROCm, and currently unqualified hardware profiles without inferring support from manifest or image presence;
- links the matrix from the deployment chooser and sidebar, while keeping contributor-only repository mapping guidance in the deployment README; and
- adds a lightweight inventory check, unit coverage, and pre-commit trigger so new deployment surfaces cannot remain unclassified or expose internal repository paths in the public matrix.

This PR does not change Router runtime behavior or expand the backend-target compatibility scope tracked by #2376.

## Test Plan

```bash
python3 tools/ci/check_deployment_support_matrix.py
python3 -m unittest tools.ci.tests.test_deployment_support_matrix

changed_files='.pre-commit-config.yaml deploy/README.md tools/ci/check_deployment_support_matrix.py tools/ci/tests/test_deployment_support_matrix.py website/docs/installation/deployment-options.md website/docs/installation/support-matrix.md website/sidebars.ts'
CHANGED_FILES="$changed_files" AGENT_BASE_REF=upstream/main make agent-docs-ci-gate
CHANGED_FILES="$changed_files" AGENT_BASE_REF=upstream/main make agent-ci-gate

make docs-build
```

## Test Result

- Inventory check passed: all 28 assets map to 26 user-facing options.
- Deployment support matrix unit tests passed: 6/6, including path-leak rejection and many-assets-to-one-option coverage.
- Repository docs/harness gate passed, including 115 CI infrastructure tests and 21 harness-script tests.
- Changed-file lint passed for Markdown, YAML, TypeScript, Python, security scanning, and structure checks.
- The full English and Chinese Docusaurus production build passed.
- No live cluster or accelerator test was required because this PR changes documentation and repository validation only.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title does not stack prefixes
- [x] The PR links accepted issue #3190 with exactly one `wg/enterprise-environment` owner
- [x] The commits are signed off with `git commit -s`
- [x] Purpose, test plan, and results reflect the actual scope and validation

</details>
