### PR TITLE
[Bug] Honor the CONTAINER_RUNTIME persisted by install.sh in the CLI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -622,10 +622,13 @@ create_launcher() {
   executable_path="$INSTALL_ROOT/venv/bin/vllm-sr"
 
   mkdir -p "$BIN_DIR"
+  # Export the install root so runtime detection reads the runtime.env
+  # persisted next to this installation instead of the default location.
   cat >"$launcher_path" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
+export VLLM_SR_INSTALL_ROOT="$INSTALL_ROOT"
 exec "$executable_path" "\$@"
 EOF
   chmod +x "$launcher_path"

--- a/src/vllm-sr/cli/container_runtime.py
+++ b/src/vllm-sr/cli/container_runtime.py
@@ -3,7 +3,8 @@
 Both Docker and Podman are supported. Selection happens via:
 
 1. The `CONTAINER_RUNTIME` environment variable (``docker`` or ``podman``).
-2. Auto-detection: prefer ``docker`` if present, fall back to ``podman``.
+2. The runtime persisted by ``install.sh`` in ``runtime.env`` (#3370).
+3. Auto-detection: prefer ``docker`` if present, fall back to ``podman``.
 
 Once resolved the choice is cached for the lifetime of the process and used
 verbatim by every helper that shells out (``docker run`` / ``podman run`` etc.).
@@ -61,6 +62,39 @@ def resolve_container_cli_path(preferred_path: str | None = None) -> str | None:
     return docker_path
 
 
+def _persisted_runtime_env_path() -> str:
+    """Return the runtime.env location written by ``install.sh``.
+
+    ``install.sh`` derives its install root the same way:
+    ``${VLLM_SR_INSTALL_ROOT:-$HOME/.local/share/vllm-sr}``.
+    """
+    install_root = os.getenv("VLLM_SR_INSTALL_ROOT") or os.path.join(
+        os.path.expanduser("~"), ".local", "share", "vllm-sr"
+    )
+    return os.path.join(install_root, "runtime.env")
+
+
+def _load_persisted_runtime() -> str | None:
+    """Read the ``CONTAINER_RUNTIME`` choice persisted by ``install.sh``.
+
+    The file is a hint rather than a hard contract: a missing, unreadable, or
+    malformed file yields ``None`` and callers fall back to auto-detection.
+    Returns ``None`` when no value is present.
+    """
+    try:
+        with open(_persisted_runtime_env_path(), encoding="utf-8") as env_file:
+            for raw_line in env_file:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                if key.strip() == CONTAINER_RUNTIME_ENV:
+                    return value.strip().lower() or None
+    except OSError:
+        return None
+    return None
+
+
 @lru_cache(maxsize=1)
 def _detect_container_runtime():
     """Detect a supported runtime, honoring the explicit ``CONTAINER_RUNTIME`` env."""
@@ -89,6 +123,30 @@ def _detect_container_runtime():
         _ensure_supported_runtime_daemon(explicit, runtime_path)
         log.info(f"Using container runtime from {CONTAINER_RUNTIME_ENV}: {explicit}")
         return explicit
+
+    persisted = _load_persisted_runtime()
+    if persisted:
+        if persisted not in SUPPORTED_CONTAINER_RUNTIMES:
+            log.warning(
+                f"Ignoring unsupported {CONTAINER_RUNTIME_ENV}={persisted} from "
+                f"{_persisted_runtime_env_path()}; supported values: "
+                f"{', '.join(SUPPORTED_CONTAINER_RUNTIMES)}."
+            )
+        else:
+            persisted_path = resolve_runtime_cli_path(persisted)
+            if not persisted_path:
+                log.warning(
+                    f"{_persisted_runtime_env_path()} persists "
+                    f"{CONTAINER_RUNTIME_ENV}={persisted}, but `{persisted}` "
+                    "was not found in PATH; falling back to auto-detection."
+                )
+            else:
+                _ensure_supported_runtime_daemon(persisted, persisted_path)
+                log.info(
+                    "Using container runtime persisted by install.sh "
+                    f"({_persisted_runtime_env_path()}): {persisted}"
+                )
+                return persisted
 
     docker_path = resolve_runtime_cli_path(CONTAINER_RUNTIME_DOCKER)
     if docker_path and not _docker_path_looks_like_podman(docker_path):

--- a/src/vllm-sr/cli/container_runtime.py
+++ b/src/vllm-sr/cli/container_runtime.py
@@ -74,7 +74,7 @@ def _persisted_runtime_env_path() -> str:
     return os.path.join(install_root, "runtime.env")
 
 
-def _load_persisted_runtime() -> str | None:
+def _load_persisted_runtime(env_path: str) -> str | None:
     """Read the ``CONTAINER_RUNTIME`` choice persisted by ``install.sh``.
 
     The file is a hint rather than a hard contract: a missing, unreadable, or
@@ -82,13 +82,13 @@ def _load_persisted_runtime() -> str | None:
     Returns ``None`` when no value is present.
     """
     try:
-        with open(_persisted_runtime_env_path(), encoding="utf-8") as env_file:
+        with open(env_path, encoding="utf-8") as env_file:
             for raw_line in env_file:
                 line = raw_line.strip()
                 if not line or line.startswith("#") or "=" not in line:
                     continue
                 key, _, value = line.partition("=")
-                if key.strip() == CONTAINER_RUNTIME_ENV:
+                if key.strip().upper() == CONTAINER_RUNTIME_ENV:
                     return value.strip().lower() or None
     except OSError:
         return None
@@ -97,7 +97,12 @@ def _load_persisted_runtime() -> str | None:
 
 @lru_cache(maxsize=1)
 def _detect_container_runtime():
-    """Detect a supported runtime, honoring the explicit ``CONTAINER_RUNTIME`` env."""
+    """Detect a supported runtime for local ``vllm-sr`` deployments.
+
+    Resolution order: the explicit ``CONTAINER_RUNTIME`` environment
+    variable, the runtime persisted by ``install.sh`` in ``runtime.env``
+    (#3370), then auto-detection (Docker first, Podman fallback).
+    """
     if sys.platform.startswith("win"):
         _exit_unsupported_runtime(
             "native Windows",
@@ -124,19 +129,20 @@ def _detect_container_runtime():
         log.info(f"Using container runtime from {CONTAINER_RUNTIME_ENV}: {explicit}")
         return explicit
 
-    persisted = _load_persisted_runtime()
+    persisted_env_path = _persisted_runtime_env_path()
+    persisted = _load_persisted_runtime(persisted_env_path)
     if persisted:
         if persisted not in SUPPORTED_CONTAINER_RUNTIMES:
             log.warning(
                 f"Ignoring unsupported {CONTAINER_RUNTIME_ENV}={persisted} from "
-                f"{_persisted_runtime_env_path()}; supported values: "
+                f"{persisted_env_path}; supported values: "
                 f"{', '.join(SUPPORTED_CONTAINER_RUNTIMES)}."
             )
         else:
             persisted_path = resolve_runtime_cli_path(persisted)
             if not persisted_path:
                 log.warning(
-                    f"{_persisted_runtime_env_path()} persists "
+                    f"{persisted_env_path} persists "
                     f"{CONTAINER_RUNTIME_ENV}={persisted}, but `{persisted}` "
                     "was not found in PATH; falling back to auto-detection."
                 )
@@ -144,7 +150,7 @@ def _detect_container_runtime():
                 _ensure_supported_runtime_daemon(persisted, persisted_path)
                 log.info(
                     "Using container runtime persisted by install.sh "
-                    f"({_persisted_runtime_env_path()}): {persisted}"
+                    f"({persisted_env_path}): {persisted}"
                 )
                 return persisted
 

--- a/src/vllm-sr/cli/container_runtime.py
+++ b/src/vllm-sr/cli/container_runtime.py
@@ -94,7 +94,7 @@ def _load_persisted_runtime(env_path: str) -> str | None:
                     return value.strip().lower() or None
     except FileNotFoundError:
         pass
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         log.warning(
             f"Could not read persisted {CONTAINER_RUNTIME_ENV} from "
             f"{env_path}: {exc}. Falling back to auto-detection."

--- a/src/vllm-sr/cli/container_runtime.py
+++ b/src/vllm-sr/cli/container_runtime.py
@@ -77,9 +77,11 @@ def _persisted_runtime_env_path() -> str:
 def _load_persisted_runtime(env_path: str) -> str | None:
     """Read the ``CONTAINER_RUNTIME`` choice persisted by ``install.sh``.
 
-    The file is a hint rather than a hard contract: a missing, unreadable, or
-    malformed file yields ``None`` and callers fall back to auto-detection.
-    Returns ``None`` when no value is present.
+    The file is a hint rather than a hard contract: a missing or malformed
+    file yields ``None`` and callers fall back to auto-detection. A file
+    that exists but cannot be read logs a warning so a silently ignored
+    persisted selection stays diagnosable. Returns ``None`` when no value
+    is present.
     """
     try:
         with open(env_path, encoding="utf-8") as env_file:
@@ -90,8 +92,13 @@ def _load_persisted_runtime(env_path: str) -> str | None:
                 key, _, value = line.partition("=")
                 if key.strip().upper() == CONTAINER_RUNTIME_ENV:
                     return value.strip().lower() or None
-    except OSError:
-        return None
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        log.warning(
+            f"Could not read persisted {CONTAINER_RUNTIME_ENV} from "
+            f"{env_path}: {exc}. Falling back to auto-detection."
+        )
     return None
 
 

--- a/src/vllm-sr/tests/test_container_runtime.py
+++ b/src/vllm-sr/tests/test_container_runtime.py
@@ -12,11 +12,20 @@ from cli import container_runtime  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def clear_runtime_detection_cache(monkeypatch):
+def clear_runtime_detection_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(container_runtime.sys, "platform", "linux")
+    # Isolate the install.sh-persisted runtime.env per test so detection never
+    # reads a real ~/.local/share/vllm-sr from the developer machine.
+    monkeypatch.setenv("VLLM_SR_INSTALL_ROOT", str(tmp_path))
     container_runtime._detect_container_runtime.cache_clear()
     yield
     container_runtime._detect_container_runtime.cache_clear()
+
+
+def _write_persisted_runtime_env(tmp_path, value):
+    (tmp_path / "runtime.env").write_text(
+        f"CONTAINER_RUNTIME={value}\n", encoding="utf-8"
+    )
 
 
 class _Result:
@@ -109,6 +118,106 @@ def test_detect_container_runtime_rejects_unknown_env_runtime(monkeypatch):
 
     with pytest.raises(SystemExit):
         container_runtime.get_container_runtime()
+
+
+def test_detect_container_runtime_honors_persisted_runtime_env_over_autodetect(
+    monkeypatch, tmp_path
+):
+    """#3370: runtime.env persisted by install.sh must beat auto-detection.
+
+    A Podman-only install persists `CONTAINER_RUNTIME=podman`; when Docker
+    shows up later, auto-detection would prefer Docker and silently switch
+    the runtime away from the documented persisted choice.
+    """
+    _write_persisted_runtime_env(tmp_path, "podman")
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+
+    def fake_which(name):
+        if name == "docker":
+            return "/usr/local/bin/docker"
+        if name == "podman":
+            return "/usr/bin/podman"
+        return None
+
+    monkeypatch.setattr(container_runtime.shutil, "which", fake_which)
+    monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
+    _stub_docker_version(monkeypatch)
+    _stub_podman_info(monkeypatch)
+
+    assert container_runtime.get_container_runtime() == "podman"
+
+
+def test_detect_container_runtime_env_var_overrides_persisted_file(
+    monkeypatch, tmp_path
+):
+    """An explicit session env var is the stronger contract; the persisted
+    file must not win over it."""
+    _write_persisted_runtime_env(tmp_path, "podman")
+    monkeypatch.setenv("CONTAINER_RUNTIME", "docker")
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/usr/local/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
+    _stub_docker_version(monkeypatch)
+
+    assert container_runtime.get_container_runtime() == "docker"
+
+
+def test_detect_container_runtime_ignores_unsupported_persisted_value(
+    monkeypatch, tmp_path
+):
+    """A stale or hand-edited runtime.env must not abort; fall back to
+    auto-detection."""
+    _write_persisted_runtime_env(tmp_path, "lxc")
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/usr/local/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
+    _stub_docker_version(monkeypatch)
+
+    assert container_runtime.get_container_runtime() == "docker"
+
+
+def test_detect_container_runtime_falls_back_when_persisted_runtime_missing_from_path(
+    monkeypatch, tmp_path
+):
+    """A persisted runtime whose binary is gone is a stale hint, not an
+    error: warn and auto-detect."""
+    _write_persisted_runtime_env(tmp_path, "podman")
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/usr/local/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
+    _stub_docker_version(monkeypatch)
+
+    assert container_runtime.get_container_runtime() == "docker"
+
+
+def test_detect_container_runtime_ignores_malformed_persisted_file(
+    monkeypatch, tmp_path
+):
+    """A runtime.env without a CONTAINER_RUNTIME line reads as absent."""
+    (tmp_path / "runtime.env").write_text(
+        "# a comment\nOTHER_KEY=value\n\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/usr/local/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
+    _stub_docker_version(monkeypatch)
+
+    assert container_runtime.get_container_runtime() == "docker"
 
 
 def test_detect_container_runtime_rejects_native_windows(monkeypatch):

--- a/src/vllm-sr/tests/test_container_runtime.py
+++ b/src/vllm-sr/tests/test_container_runtime.py
@@ -289,6 +289,9 @@ def test_detect_container_runtime_warns_on_invalid_utf8_persisted_file(
         "Could not read persisted CONTAINER_RUNTIME" in record.message
         for record in caplog.records
     )
+
+
+def test_detect_container_runtime_rejects_native_windows(monkeypatch):
     monkeypatch.setattr(container_runtime.sys, "platform", "win32")
 
     with pytest.raises(SystemExit):

--- a/src/vllm-sr/tests/test_container_runtime.py
+++ b/src/vllm-sr/tests/test_container_runtime.py
@@ -264,7 +264,31 @@ def test_detect_container_runtime_warns_when_persisted_file_unreadable(
     )
 
 
-def test_detect_container_runtime_rejects_native_windows(monkeypatch):
+def test_detect_container_runtime_warns_on_invalid_utf8_persisted_file(
+    monkeypatch, tmp_path, caplog
+):
+    """A runtime.env containing invalid UTF-8 bytes warns (so the corrupted
+    persisted selection stays diagnosable) and falls back to auto-detection."""
+    env_path = tmp_path / "runtime.env"
+    # Write raw invalid UTF-8 bytes that decode() cannot handle.
+    env_path.write_bytes(b"\x80\x81CONTAINER_RUNTIME=podman\n")
+
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/usr/local/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
+    _stub_docker_version(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="cli.container_runtime"):
+        assert container_runtime.get_container_runtime() == "docker"
+
+    assert any(
+        "Could not read persisted CONTAINER_RUNTIME" in record.message
+        for record in caplog.records
+    )
     monkeypatch.setattr(container_runtime.sys, "platform", "win32")
 
     with pytest.raises(SystemExit):

--- a/src/vllm-sr/tests/test_container_runtime.py
+++ b/src/vllm-sr/tests/test_container_runtime.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -166,10 +167,10 @@ def test_detect_container_runtime_env_var_overrides_persisted_file(
 
 
 def test_detect_container_runtime_ignores_unsupported_persisted_value(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, caplog
 ):
     """A stale or hand-edited runtime.env must not abort; fall back to
-    auto-detection."""
+    auto-detection with a warning."""
     _write_persisted_runtime_env(tmp_path, "lxc")
     monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
     monkeypatch.setattr(
@@ -180,11 +181,17 @@ def test_detect_container_runtime_ignores_unsupported_persisted_value(
     monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
     _stub_docker_version(monkeypatch)
 
-    assert container_runtime.get_container_runtime() == "docker"
+    with caplog.at_level(logging.WARNING, logger="cli.container_runtime"):
+        assert container_runtime.get_container_runtime() == "docker"
+
+    assert any(
+        "Ignoring unsupported CONTAINER_RUNTIME=lxc" in record.message
+        for record in caplog.records
+    )
 
 
 def test_detect_container_runtime_falls_back_when_persisted_runtime_missing_from_path(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, caplog
 ):
     """A persisted runtime whose binary is gone is a stale hint, not an
     error: warn and auto-detect."""
@@ -198,7 +205,14 @@ def test_detect_container_runtime_falls_back_when_persisted_runtime_missing_from
     monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
     _stub_docker_version(monkeypatch)
 
-    assert container_runtime.get_container_runtime() == "docker"
+    with caplog.at_level(logging.WARNING, logger="cli.container_runtime"):
+        assert container_runtime.get_container_runtime() == "docker"
+
+    assert any(
+        "CONTAINER_RUNTIME=podman" in record.message
+        and "was not found in PATH" in record.message
+        for record in caplog.records
+    )
 
 
 def test_detect_container_runtime_ignores_malformed_persisted_file(

--- a/src/vllm-sr/tests/test_container_runtime.py
+++ b/src/vllm-sr/tests/test_container_runtime.py
@@ -234,6 +234,36 @@ def test_detect_container_runtime_ignores_malformed_persisted_file(
     assert container_runtime.get_container_runtime() == "docker"
 
 
+def test_detect_container_runtime_warns_when_persisted_file_unreadable(
+    monkeypatch, tmp_path, caplog
+):
+    """An existing but unreadable runtime.env warns (so the ignored persisted
+    selection stays diagnosable) and falls back to auto-detection."""
+    env_path = tmp_path / "runtime.env"
+    env_path.write_text("CONTAINER_RUNTIME=podman\n", encoding="utf-8")
+
+    def unreadable_open(path, *args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.delenv("CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setattr(
+        container_runtime.shutil,
+        "which",
+        lambda name: "/usr/local/bin/docker" if name == "docker" else None,
+    )
+    monkeypatch.setattr(container_runtime.os.path, "realpath", lambda path: path)
+    _stub_docker_version(monkeypatch)
+    monkeypatch.setattr("builtins.open", unreadable_open)
+
+    with caplog.at_level(logging.WARNING, logger="cli.container_runtime"):
+        assert container_runtime.get_container_runtime() == "docker"
+
+    assert any(
+        "Could not read persisted CONTAINER_RUNTIME" in record.message
+        for record in caplog.records
+    )
+
+
 def test_detect_container_runtime_rejects_native_windows(monkeypatch):
     monkeypatch.setattr(container_runtime.sys, "platform", "win32")
 

--- a/src/vllm-sr/tests/test_install_script_surface.py
+++ b/src/vllm-sr/tests/test_install_script_surface.py
@@ -45,6 +45,16 @@ def test_install_script_persists_selected_runtime() -> None:
     assert "CONTAINER_RUNTIME=" in content
 
 
+def test_install_script_launcher_preserves_install_root() -> None:
+    content = INSTALL_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    # A custom --install-root writes runtime.env under that root. The
+    # generated launcher must export VLLM_SR_INSTALL_ROOT so later CLI
+    # sessions resolve the persisted runtime.env next to this installation
+    # instead of the default location (#3370).
+    assert 'export VLLM_SR_INSTALL_ROOT="$INSTALL_ROOT"' in content
+
+
 def test_installation_doc_documents_runtime_options() -> None:
     content = INSTALL_DOC_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Purpose

Closes #3370.

`install.sh` persists the selected container runtime to `~/.local/share/vllm-sr/runtime.env` and the installation docs state that later CLI sessions reuse it, but nothing in the repository read the file: `_detect_container_runtime()` only honored the `CONTAINER_RUNTIME` environment variable and then auto-detected (Docker first). A Podman-only install followed by a later Docker install therefore silently switched runtimes, contradicting the documented contract.

Detection now resolves the persisted choice between the explicit env var and auto-detection:

1. `CONTAINER_RUNTIME` environment variable (explicit session override, unchanged),
2. `CONTAINER_RUNTIME` from `${VLLM_SR_INSTALL_ROOT:-~/.local/share/vllm-sr}/runtime.env` (the file install.sh writes),
3. auto-detection.

The persisted file is treated as a hint rather than a hard contract: an unsupported value, an unreadable file, a file containing invalid UTF-8 bytes, or a persisted runtime missing from `PATH` logs a warning and falls back to auto-detection instead of aborting the CLI, while the env var keeps its existing strict behavior.

The installer side is also updated: the launcher generated by `install.sh` now exports `VLLM_SR_INSTALL_ROOT`, so CLI sessions started through it resolve the `runtime.env` persisted next to a custom `--install-root` installation instead of the default location.

## Test Plan

- New unit tests in `src/vllm-sr/tests/test_container_runtime.py` cover: persisted value beats auto-detection when both runtimes exist (#3370 scenario), the env var overriding a conflicting persisted value, an unsupported persisted value falling back with a warning, a persisted runtime missing from `PATH` falling back with a warning, a malformed `runtime.env` reading as absent, an unreadable `runtime.env` warning with its reason before falling back, and an invalid-UTF-8 `runtime.env` warning and falling back to auto-detection.
- `test_detect_container_runtime_rejects_native_windows` remains its own isolated test, separate from the UTF-8 fallback test, to avoid `lru_cache` interference between detection scenarios (Xunzhuo).
- The autouse detection fixture now points `VLLM_SR_INSTALL_ROOT` at a per-test temp dir so detection never reads a real `~/.local/share/vllm-sr` from the developer machine.
- The loader parses comments, blank lines, surrounding whitespace, and case-insensitively; verified the parsing table against a standalone runner.
- A surface test asserts the generated launcher exports `VLLM_SR_INSTALL_ROOT`, keeping the installer-side contract covered.

## Test Result

- `python -m pytest src/vllm-sr/tests/test_container_runtime.py` could not run locally (host Python is 3.8; the module targets 3.10+ syntax); the loader parsing table was verified with a standalone runner (missing file, normal value, whitespace/case normalization including case-insensitive keys, comments and unrelated keys, malformed lines, empty value, multi-key file) and all passed.
- Installer behavior did change in one scoped way: `create_launcher` now emits `export VLLM_SR_INSTALL_ROOT="$INSTALL_ROOT"` in the generated launcher. `bash -n install.sh` passes and the launcher contract is asserted by `test_install_script_launcher_preserves_install_root`.

Review feedback addressed:
- `_load_persisted_runtime()` now catches `UnicodeDecodeError` alongside `OSError`, so a corrupted `runtime.env` with invalid UTF-8 falls back to auto-detection with a warning instead of crashing (Xunzhuo).
- Restored `test_detect_container_runtime_rejects_native_windows` as an independent test — its body was accidentally merged into the UTF-8 test, where `lru_cache` prevented the Windows exit from triggering after Docker was already cached (Xunzhuo).