### PR TITLE
[Bug] Keep the dashboard account panel within the viewport

### DIFF
--- a/dashboard/frontend/src/components/LayoutAccountControl.module.css
+++ b/dashboard/frontend/src/components/LayoutAccountControl.module.css
@@ -99,7 +99,6 @@
   display: flex;
   flex-direction: column;
   width: min(390px, calc(100vw - 2rem));
-  max-height: min(620px, calc(100dvh - 5.5rem));
   overflow: hidden;
   color: #f5f5f7;
   background: #101012;
@@ -123,20 +122,27 @@
 }
 
 .dialogHeader {
-  top: 78px;
-  right: clamp(1rem, 3.5vw, 4.5rem);
+  top: 48px;
+  right: 1rem;
+  bottom: 1rem;
   transform-origin: top right;
 }
 
+.dialog.dialogHeader {
+  max-height: 620px;
+}
+
 .dialogRail {
+  top: 1rem;
   bottom: 1rem;
   left: 68px;
-  max-height: calc(100dvh - 2rem);
+  max-height: 620px;
   transform-origin: bottom left;
 }
 
 .header {
   display: grid;
+  flex: 0 0 auto;
   grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 0.85rem;
   align-items: center;
@@ -222,10 +228,12 @@
 }
 
 .body {
+  flex: 1 1 auto;
   min-height: 0;
   padding: 1rem 1.1rem;
   overflow-y: auto;
   overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .permissionsSection,
@@ -332,6 +340,7 @@
 }
 
 .footer {
+  flex: 0 0 auto;
   padding: 0.85rem 1.1rem 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
@@ -376,9 +385,14 @@
     justify-content: center;
   }
 
-  .dialogHeader {
-    top: 64px;
-    right: 0.75rem;
+}
+
+@media (max-height: 700px) and (min-width: 521px) {
+  .dialog.dialogHeader {
+    top: 0.5rem;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    max-height: none;
   }
 }
 
@@ -390,13 +404,18 @@
   .dialog,
   .dialogHeader,
   .dialogRail {
-    top: auto;
+    top: 0.5rem;
     right: 0.5rem;
     bottom: 0.5rem;
     left: 0.5rem;
     width: auto;
-    max-height: calc(100dvh - 1rem);
+    max-height: none;
     transform-origin: bottom center;
+  }
+
+  .dialog.dialogHeader,
+  .dialog.dialogRail {
+    max-height: none;
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #3397
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

Fix the Dashboard account details panel so it remains fully visible across browser heights.

This change:

- constrains the panel to the current viewport;
- keeps the identity header and Logout footer visible;
- makes the permissions section the independently scrollable region;
- reduces excessive right spacing;
- uses consistent top, right, and bottom margins in low-height and mobile viewports;
- preserves a capped panel height on larger desktop viewports.

The change is limited to the Dashboard frontend account panel styles in
`dashboard/frontend/src/components/LayoutAccountControl.module.css`.

Issue owner: `wg/developer-experience-ecosystem` on #3397 .

## Test Plan

- Run the focused account control tests:

  ```bash
  cd dashboard/frontend
  npx vitest run \
    src/components/LayoutAccountControl.test.tsx \
    src/components/LayoutAccountControlSupport.test.ts
  ```

- Run frontend lint:

  ```bash
  cd dashboard/frontend
  npm run lint
  ```

- Check formatting and whitespace:

  ```bash
  git diff --check
  ```

- Manually open the account panel with a permission list that requires scrolling
  and verify the following viewport sizes:

  - `1044x900`
  - `1044x650`
  - `500x491`
  - `375x320`

- At each size, verify that:

  - the panel does not leave the viewport;
  - the Logout action remains visible;
  - only the permissions region scrolls;
  - low-height top, right, and bottom spacing is visually consistent.

## Test Result

- Focused account control tests passed: 2 test files, 5 tests.
- Frontend ESLint passed.
- `git diff --check` passed.
- Browser validation passed at all four tested viewport sizes.
- The panel remained inside the viewport, the Logout footer stayed visible, and
  the permissions region remained independently scrollable.

`npm run type-check` is currently blocked on case-insensitive macOS filesystems
by existing case-only filename collisions:

- `EvaluationOverview.tsx` and `evaluationOverview.ts`
- `EvaluationRunLedger.tsx` and `evaluationRunLedger.ts`

This blocker is unrelated to the account panel CSS change.

Before change:
<img width="1588" height="1652" alt="image" src="https://github.com/user-attachments/assets/024a1dff-8451-4ff9-9f3a-72c7cc96e85e" />


After change:

Maximum height set, middle scroll area adapts:
<img width="1882" height="1494" alt="image" src="https://github.com/user-attachments/assets/e9474689-8d21-4de0-852a-b025e61108c4" />


Now even small resolution panels won't be truncated:
<img width="1908" height="1036" alt="image" src="https://github.com/user-attachments/assets/400c18c6-63ef-4e02-9cd7-83307e61c5f4" />


Mobile like:
<img width="1098" height="1772" alt="image" src="https://github.com/user-attachments/assets/ffff75f8-6683-4df8-b64b-a2659b2d1a01" />

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.