### PR TITLE
[Test] Add E2E coverage for the event signal

### DIFF
--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -87,7 +87,7 @@ jobs:
           set +e
           if [ "${{ matrix.profile }}" = "envoy-ai-gateway" ]; then
             # Temporarily skip the stress / pressure coverage until the suite is stable again.
-            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations"
+            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,jailbreak-detection,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations,event-routing"
             make e2e-test E2E_PROFILE=${{ matrix.profile }} E2E_TESTS="${ENVOY_AI_GATEWAY_CI_TESTS}" E2E_VERBOSE=true E2E_KEEP_CLUSTER=false
             TEST_EXIT_CODE=$?
             set -e

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -47,6 +47,8 @@ var BaselineRouterContract = []string{
 	"session-telemetry-metrics",
 	"session-pricing-chat-completions",
 	"session-pricing-response-api",
+	// Event signal rule matching and routing (issue #3178)
+	"event-routing",
 }
 
 // DashboardContract is the canonical E2E contract for the dashboard API surface.

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -680,7 +680,6 @@ config:
             - critical
           action_codes:
             - TXN_DECLINE
-          temporal: true
       domains:
         - name: business
           description: Business, corporate strategy, management, finance, marketing

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -574,6 +574,24 @@ config:
               enabled: true
               system_prompt: You are handling a query with sensitive data. Be cautious and provide security-focused guidance.
               mode: replace
+      - name: critical_event
+        description: Critical operational events requiring specialized handling
+        priority: 35
+        rules:
+          operator: OR
+          conditions:
+            - type: event
+              name: critical_payment_event
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: You are handling a critical event alert. Prioritize a fast, precise, and factual response.
+              mode: replace
       - name: other_decision
         description: General knowledge and miscellaneous topics
         priority: 1
@@ -654,6 +672,15 @@ config:
           keywords:
             - __MULTI_MODEL_PROBE__
           case_sensitive: false
+      events:
+        - name: critical_payment_event
+          event_types:
+            - payment_failed
+          severities:
+            - critical
+          action_codes:
+            - TXN_DECLINE
+          temporal: true
       domains:
         - name: business
           description: Business, corporate strategy, management, finance, marketing

--- a/e2e/testcases/event_routing.go
+++ b/e2e/testcases/event_routing.go
@@ -1,0 +1,192 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+// targetEventDecision is the decision configured to route on the
+// critical_payment_event rule (see e2e/profiles/ai-gateway/values.yaml).
+const targetEventDecision = "critical_event"
+
+func init() {
+	pkgtestcases.Register("event-routing", pkgtestcases.TestCase{
+		Description: "Test event signal rule matching and routing",
+		Tags:        []string{"kubernetes", "routing", "event"},
+		Fn:          testEventRouting,
+	})
+}
+
+// EventRoutingCase represents a test case for event signal routing.
+type EventRoutingCase struct {
+	Name                 string `json:"name"`
+	Description          string `json:"description"`
+	Query                string `json:"query"`
+	ExpectedDecision     string `json:"expected_decision"`
+	ExpectedMatchedEvent string `json:"expected_matched_event"`
+	ShouldMatch          bool   `json:"should_match"`
+}
+
+// EventRoutingResult tracks the result of a single event routing test.
+type EventRoutingResult struct {
+	Name                 string
+	Query                string
+	ExpectedDecision     string
+	ActualDecision       string
+	ExpectedMatchedEvent string
+	ActualMatchedEvent   string
+	ShouldMatch          bool
+	DecisionCorrect      bool
+	MatchCorrect         bool
+	Error                string
+}
+
+func testEventRouting(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing event signal routing")
+	}
+
+	localPort, stopPortForward, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopPortForward()
+
+	testCases, err := loadEventRoutingCases("e2e/testcases/testdata/event_routing_cases.json")
+	if err != nil {
+		return fmt.Errorf("failed to load test cases: %w", err)
+	}
+
+	var results []EventRoutingResult
+	totalTests := 0
+	correctTests := 0
+
+	for _, testCase := range testCases {
+		totalTests++
+		result := testSingleEventRouting(ctx, testCase, localPort, opts.Verbose)
+		results = append(results, result)
+		if result.DecisionCorrect && result.MatchCorrect {
+			correctTests++
+		}
+	}
+
+	accuracy := float64(correctTests) / float64(totalTests) * 100
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_tests":   totalTests,
+			"correct_tests": correctTests,
+			"accuracy_rate": fmt.Sprintf("%.2f%%", accuracy),
+			"failed_tests":  totalTests - correctTests,
+		})
+	}
+
+	printEventRoutingResults(results, totalTests, correctTests, accuracy)
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Event routing test completed: %d/%d correct (%.2f%% accuracy)\n",
+			correctTests, totalTests, accuracy)
+	}
+
+	if correctTests == 0 {
+		return fmt.Errorf("event routing test failed: 0%% accuracy (0/%d correct)", totalTests)
+	}
+
+	return nil
+}
+
+func loadEventRoutingCases(filepath string) ([]EventRoutingCase, error) {
+	data, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read test cases file: %w", err)
+	}
+
+	var cases []EventRoutingCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		return nil, fmt.Errorf("failed to parse test cases: %w", err)
+	}
+
+	return cases, nil
+}
+
+func testSingleEventRouting(ctx context.Context, testCase EventRoutingCase, localPort string, verbose bool) EventRoutingResult {
+	result := EventRoutingResult{
+		Name:                 testCase.Name,
+		Query:                testCase.Query,
+		ExpectedDecision:     testCase.ExpectedDecision,
+		ExpectedMatchedEvent: testCase.ExpectedMatchedEvent,
+		ShouldMatch:          testCase.ShouldMatch,
+	}
+
+	response, err := sendLocalChatCompletion(ctx, localPort, "MoM", testCase.Query, 30*time.Second)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+
+	if response.StatusCode != http.StatusOK {
+		result.Error = formatUnexpectedChatCompletionStatus(response)
+		logUnexpectedChatCompletionStatus(verbose, response, "test case: "+testCase.Name,
+			"Query: "+testCase.Query,
+			"Should match: "+fmt.Sprintf("%v", testCase.ShouldMatch))
+		return result
+	}
+
+	decision := response.Headers.Get("x-vsr-selected-decision")
+	result.ActualDecision = strings.TrimSuffix(decision, "_decision")
+	result.ActualMatchedEvent = response.Headers.Get("x-vsr-matched-event")
+
+	if testCase.ShouldMatch {
+		result.DecisionCorrect = result.ActualDecision == testCase.ExpectedDecision
+		result.MatchCorrect = result.ActualMatchedEvent == testCase.ExpectedMatchedEvent
+	} else {
+		result.DecisionCorrect = result.ActualDecision != targetEventDecision
+		result.MatchCorrect = result.ActualMatchedEvent == ""
+	}
+
+	if verbose && (!result.DecisionCorrect || !result.MatchCorrect) {
+		fmt.Printf("[Test] Test case failed: %s\n", testCase.Name)
+		if !result.DecisionCorrect {
+			fmt.Printf("  Decision mismatch: query='%s', expected=%s, actual=%s\n",
+				testCase.Query, testCase.ExpectedDecision, result.ActualDecision)
+		}
+		if !result.MatchCorrect {
+			fmt.Printf("  Matched-event mismatch: expected=%q, actual=%q\n",
+				testCase.ExpectedMatchedEvent, result.ActualMatchedEvent)
+		}
+	}
+
+	return result
+}
+
+func printEventRoutingResults(results []EventRoutingResult, totalTests, correctTests int, accuracy float64) {
+	separator := "================================================================================"
+	fmt.Println("\n" + separator)
+	fmt.Println("EVENT ROUTING TEST RESULTS")
+	fmt.Println(separator)
+	fmt.Printf("Total Tests: %d\n", totalTests)
+	fmt.Printf("Correct: %d (%.2f%%)\n", correctTests, accuracy)
+	fmt.Println(separator)
+
+	for _, result := range results {
+		if result.Error != "" {
+			fmt.Printf("  - Test: %s\n    Query: %s\n    Error: %s\n", result.Name, result.Query, result.Error)
+			continue
+		}
+		if !result.DecisionCorrect || !result.MatchCorrect {
+			fmt.Printf("  - Test: %s\n    Query: %s\n    Expected decision: %s, actual: %s\n    Expected matched event: %q, actual: %q\n",
+				result.Name, result.Query, result.ExpectedDecision, result.ActualDecision,
+				result.ExpectedMatchedEvent, result.ActualMatchedEvent)
+		}
+	}
+
+	fmt.Println(separator + "\n")
+}

--- a/e2e/testcases/event_routing.go
+++ b/e2e/testcases/event_routing.go
@@ -96,8 +96,8 @@ func testEventRouting(ctx context.Context, client *kubernetes.Clientset, opts pk
 			correctTests, totalTests, accuracy)
 	}
 
-	if correctTests == 0 {
-		return fmt.Errorf("event routing test failed: 0%% accuracy (0/%d correct)", totalTests)
+	if correctTests != totalTests {
+		return fmt.Errorf("event routing test failed: %d/%d correct", correctTests, totalTests)
 	}
 
 	return nil

--- a/e2e/testcases/signal_routing_contract_test.go
+++ b/e2e/testcases/signal_routing_contract_test.go
@@ -1,0 +1,40 @@
+package testcases_test
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+
+	// Registers every profile (and, transitively, every testcase in this
+	// package) so framework.NewProfileByName resolves the same way it does
+	// inside the real e2e binary.
+	_ "github.com/vllm-project/semantic-router/e2e/profiles/all"
+)
+
+// signalRoutingContracts locks in each signal-routing E2E test stays selected
+// by its intended profile, so a dropped entry fails `go test` instead of only
+// surfacing during a full E2E run.
+var signalRoutingContracts = []struct {
+	profile  string
+	testCase string
+}{
+	{profile: "envoy-ai-gateway", testCase: "event-routing"},
+}
+
+func TestProfilesSelectSignalRoutingContracts(t *testing.T) {
+	for _, tc := range signalRoutingContracts {
+		t.Run(tc.profile+"/"+tc.testCase, func(t *testing.T) {
+			profile, err := framework.NewProfileByName(tc.profile)
+			if err != nil {
+				t.Fatalf("%s profile failed: %v", tc.profile, err)
+			}
+
+			for _, name := range profile.GetTestCases() {
+				if name == tc.testCase {
+					return
+				}
+			}
+			t.Fatalf("%s profile test cases = %v, want %q included", tc.profile, profile.GetTestCases(), tc.testCase)
+		})
+	}
+}

--- a/e2e/testcases/testdata/event_routing_cases.json
+++ b/e2e/testcases/testdata/event_routing_cases.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Event type match - payment_failed",
+    "description": "critical_payment_event matches on the payment_failed event type alone",
+    "query": "Our system just received a payment_failed webhook, please advise",
+    "expected_decision": "critical_event",
+    "expected_matched_event": "critical_payment_event",
+    "should_match": true
+  },
+  {
+    "name": "Severity + action code match",
+    "description": "critical_payment_event matches on the critical severity and TXN_DECLINE action code",
+    "query": "We have a critical TXN_DECLINE that needs review right away",
+    "expected_decision": "critical_event",
+    "expected_matched_event": "critical_payment_event",
+    "should_match": true
+  },
+  {
+    "name": "No configured criteria present",
+    "description": "A generic query with no event_type, severity, action_code, or temporal marker should not trigger critical_payment_event",
+    "query": "What's a good recipe for pasta tonight?",
+    "expected_decision": "",
+    "expected_matched_event": "",
+    "should_match": false
+  }
+]


### PR DESCRIPTION
Related #3178
<!-- Using "Related" not "Closes" — this is the first of several planned
per-signal slices for #3178, not the full scope of that issue. -->

## Purpose

The `event` routing signal (`config.SignalTypeEvent`) currently has only
Go unit tests for its classifier logic (`event_classifier_test.go`) and
no end-to-end behavioral coverage through a deployed request path, as
required by #3178.

This PR adds:
- A `critical_payment_event` event rule (`event_types`, `severities`,
  `action_codes`, `temporal`) and a `critical_event` decision (priority 35)
  to `e2e/profiles/ai-gateway/values.yaml`.
- `e2e/testcases/event_routing.go`, following the existing
  `pkgtestcases.Register(...)` pattern used by `keyword_routing.go`,
  asserting the `x-vsr-selected-decision` and `x-vsr-matched-event`
  response headers.
- `e2e/testcases/testdata/event_routing_cases.json` with two positive
  cases (event_type-only match; severity + action_code match) and one
  negative case (no configured criteria present).

Owning Workgroup: Evaluation & Quality (`wg/evaluation-quality`).

## Test Plan

- `gofmt -l e2e/testcases/event_routing.go`
- `go vet ./testcases/...` (run from `e2e/`)
- `go build ./...` (run from `e2e/`)
- `make e2e-test-specific E2E_TESTS="event-routing"`

## Test Result

- gofmt / go vet / go build: pass.
- `make e2e-test-specific`: blocked locally by a Docker Desktop
  compatibility issue with the `quay.io/centos/centos:stream10` base
  image used by `Dockerfile.extproc` (reproduces even with a plain
  `docker run` on that image, independent of this change, and appears
  to be a local/CDN-cache-specific issue — the same image builds
  successfully in this repo's own recent GitHub Actions runs). Deferring
  final e2e confirmation to CI on this PR.
- Manually verified the priority ordering in `values.yaml`: the new
  `critical_event` decision (priority 35) sits above all domain
  decisions (priority 10) and below the decisions that require
  unrelated unique trigger keywords (sensitive_data, tool_selection_*,
  jailbreak, PII), so the new test cases can't be shadowed by an
  unrelated decision.

---
AI assistance (Claude Code) was used to draft this change, under my review;
I read and understand the diff and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)