### PR TITLE
[CI/Build] Stop scheduled workflows from running in forks

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -19,12 +19,13 @@ jobs:
   pull-request-state:
     name: Synchronize pull request state
     if: >-
-      (github.event_name == 'workflow_run'
+      github.repository == 'vllm-project/semantic-router'
+      && ((github.event_name == 'workflow_run'
       && (github.event.workflow_run.event == 'pull_request'
       || github.event.workflow_run.event == 'pull_request_review')
       && github.event.workflow_run.pull_requests[0] != null)
       || (github.event_name == 'check_suite'
-      && github.event.check_suite.pull_requests[0] != null)
+      && github.event.check_suite.pull_requests[0] != null))
     # Serialize duplicate lifecycle events for one PR without blocking other PRs
     # or the scheduled queue reconciliation job.
     concurrency:
@@ -50,7 +51,8 @@ jobs:
   pull-request-sweep:
     name: Reconcile pull request labels
     if: >-
-      github.event_name == 'schedule'
+      (github.repository == 'vllm-project/semantic-router'
+      && github.event_name == 'schedule')
       || github.event_name == 'workflow_dispatch'
     concurrency:
       group: community-label-sync-sweep

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -29,7 +29,8 @@ jobs:
   board:
     name: Maintainer board
     if: >-
-      github.event.schedule == '0 8 * * *'
+      (github.repository == 'vllm-project/semantic-router'
+        && github.event.schedule == '0 8 * * *')
       || (github.event_name == 'workflow_dispatch'
         && (inputs.task == 'all' || inputs.task == 'board'))
     permissions:
@@ -44,7 +45,8 @@ jobs:
   stale:
     name: Stale lifecycle
     if: >-
-      github.event.schedule == '0 8 * * *'
+      (github.repository == 'vllm-project/semantic-router'
+        && github.event.schedule == '0 8 * * *')
       || (github.event_name == 'workflow_dispatch'
         && (inputs.task == 'all' || inputs.task == 'stale'))
     permissions:
@@ -57,7 +59,8 @@ jobs:
   translation:
     name: Translation status
     if: >-
-      github.event.schedule == '0 1 * * 1'
+      (github.repository == 'vllm-project/semantic-router'
+        && github.event.schedule == '0 1 * * 1')
       || (github.event_name == 'workflow_dispatch'
         && (inputs.task == 'all' || inputs.task == 'translation'))
     permissions:
@@ -69,7 +72,8 @@ jobs:
   leaderboard:
     name: Contributor leaderboard
     if: >-
-      github.event.schedule == '0 1 * * 1'
+      (github.repository == 'vllm-project/semantic-router'
+        && github.event.schedule == '0 1 * * 1')
       || (github.event_name == 'workflow_dispatch'
         && (inputs.task == 'all' || inputs.task == 'leaderboard'))
     permissions:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,16 +15,25 @@ concurrency:
 jobs:
   core:
     name: Nightly core gate
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/test-and-build.yml
     secrets: inherit
 
   dashboard:
     name: Nightly dashboard
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     uses: ./.github/workflows/dashboard-test.yml
 
   e2e:
     name: Nightly E2E
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     uses: ./.github/workflows/integration-test-k8s.yml
     with:
@@ -33,16 +42,25 @@ jobs:
 
   cli:
     name: Nightly CLI
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     uses: ./.github/workflows/integration-test-vllm-sr-cli.yml
 
   memory:
     name: Nightly memory
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     uses: ./.github/workflows/integration-test-memory.yml
 
   operator:
     name: Nightly operator
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     uses: ./.github/workflows/operator-ci.yml
     with:
@@ -58,11 +76,17 @@ jobs:
 
   performance:
     name: Nightly performance
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     uses: ./.github/workflows/performance-test.yml
 
   router-learning:
     name: Nightly router learning
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     uses: ./.github/workflows/router-learning-eval.yml
     with:
@@ -70,6 +94,9 @@ jobs:
 
   docker:
     name: Nightly Docker images
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     permissions:
       contents: read
@@ -83,6 +110,9 @@ jobs:
 
   helm:
     name: Nightly Helm chart
+    if: >-
+      github.repository == 'vllm-project/semantic-router'
+      || github.event_name == 'workflow_dispatch'
     needs: core
     permissions:
       contents: read


### PR DESCRIPTION
<!-- markdownlint-disable -->
Closes #3400

## Purpose

Adds a repository check to the scheduled jobs in `nightly-build.yml` (10 jobs), `maintenance.yml` (4 jobs), and `community-labels.yml` (2 jobs), so they only run on `vllm-project/semantic-router`. `workflow_dispatch` still works in forks so a fork owner can run them on purpose. Same guard `pypi-publish-vllm-sr-sim.yml` already uses. Module: `.github/workflows`. Workgroup: Developer Experience & Ecosystem.

## Test Plan

```
python3 tools/ci/validate_workflows.py
yamllint --config-file=tools/linter/yaml/.yamllint .github/workflows/nightly-build.yml .github/workflows/maintenance.yml .github/workflows/community-labels.yml
```

## Test Result

```
workflow contract validation passed, 35 workflows
yamllint clean
```

All 16 jobs across the three workflows carry the guard, and `community-labels.yml` is also guarded on its `workflow_run` and `check_suite` paths, which fire in forks too.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [ ] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
