### PR TITLE
[Bug] Support native Istio sidecars in E2E checks

### DIFF
--- a/e2e/profiles/istio/runtime.go
+++ b/e2e/profiles/istio/runtime.go
@@ -373,7 +373,7 @@ func (p *Profile) verifyServiceHealth(ctx context.Context, opts *framework.Setup
 		"get", "pods",
 		"-n", semanticRouterNamespace,
 		"-l", "app.kubernetes.io/name=semantic-router",
-		"-o", "jsonpath={.items[*].status.containerStatuses[*].ready}")
+		"-o", "jsonpath={.items[*].status.containerStatuses[?(@.name==\"semantic-router\")].ready} {.items[*].status.containerStatuses[?(@.name==\"istio-proxy\")].ready} {.items[*].status.initContainerStatuses[?(@.name==\"istio-proxy\")].ready}")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to check pod readiness: %w (output: %s)", err, string(output))
@@ -399,7 +399,7 @@ func (p *Profile) verifySidecarInjection(ctx context.Context, opts *framework.Se
 		"get", "pods",
 		"-n", semanticRouterNamespace,
 		"-l", "app.kubernetes.io/name=semantic-router",
-		"-o", "jsonpath={.items[0].spec.containers[*].name}")
+		"-o", "jsonpath={.items[0].spec.containers[*].name} {.items[0].spec.initContainers[*].name}")
 	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to get pod containers: %w", err)

--- a/e2e/testcases/istio_sidecar_health_check.go
+++ b/e2e/testcases/istio_sidecar_health_check.go
@@ -3,8 +3,10 @@ package testcases
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -46,46 +48,13 @@ func testIstioSidecarHealthCheck(ctx context.Context, client *kubernetes.Clients
 
 	for _, pod := range pods.Items {
 		totalPods++
-		podHasSidecar := false
-		sidecarHealthy := false
-
-		// Check if the pod has an istio-proxy container
-		for _, container := range pod.Spec.Containers {
-			if container.Name == "istio-proxy" {
-				podHasSidecar = true
-				podsWithSidecar++
-
-				// Check if the istio-proxy container is ready
-				for _, status := range pod.Status.ContainerStatuses {
-					if status.Name == "istio-proxy" && status.Ready {
-						sidecarHealthy = true
-						healthySidecars++
-						break
-					}
-				}
-				break
-			}
+		details, err := verifyIstioProxy(pod, opts.Verbose)
+		if err != nil {
+			return err
 		}
-
-		if opts.Verbose {
-			fmt.Printf("[Test] Pod %s: sidecar_injected=%v, sidecar_healthy=%v\n",
-				pod.Name, podHasSidecar, sidecarHealthy)
-		}
-
-		sidecarDetails = append(sidecarDetails, map[string]interface{}{
-			"pod_name":         pod.Name,
-			"sidecar_injected": podHasSidecar,
-			"sidecar_healthy":  sidecarHealthy,
-			"pod_phase":        string(pod.Status.Phase),
-		})
-
-		if !podHasSidecar {
-			return fmt.Errorf("pod %s does not have istio-proxy sidecar injected", pod.Name)
-		}
-
-		if !sidecarHealthy {
-			return fmt.Errorf("pod %s has istio-proxy sidecar but it is not healthy", pod.Name)
-		}
+		podsWithSidecar++
+		healthySidecars++
+		sidecarDetails = append(sidecarDetails, details)
 	}
 
 	// Verify istio-injection label on namespace
@@ -116,4 +85,40 @@ func testIstioSidecarHealthCheck(ctx context.Context, client *kubernetes.Clients
 	}
 
 	return nil
+}
+
+func verifyIstioProxy(pod corev1.Pod, verbose bool) (map[string]interface{}, error) {
+	injected, ready := istioProxyStatus(pod)
+	if verbose {
+		fmt.Printf("[Test] Pod %s: sidecar_injected=%v, sidecar_healthy=%v\n", pod.Name, injected, ready)
+	}
+
+	details := map[string]interface{}{
+		"pod_name":         pod.Name,
+		"sidecar_injected": injected,
+		"sidecar_healthy":  ready,
+		"pod_phase":        string(pod.Status.Phase),
+	}
+	if !injected {
+		return details, fmt.Errorf("pod %s does not have istio-proxy sidecar injected", pod.Name)
+	}
+	if !ready {
+		return details, fmt.Errorf("pod %s has istio-proxy sidecar but it is not healthy", pod.Name)
+	}
+	return details, nil
+}
+
+func istioProxyStatus(pod corev1.Pod) (injected, ready bool) {
+	for _, container := range slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers) {
+		if container.Name != "istio-proxy" {
+			continue
+		}
+		for _, status := range slices.Concat(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses) {
+			if status.Name == "istio-proxy" {
+				return true, status.Ready
+			}
+		}
+		return true, false
+	}
+	return false, false
 }


### PR DESCRIPTION
Closes #3403

## Purpose

Update the Istio E2E environment checks to recognize `istio-proxy` when Kubernetes represents it as a native sidecar under `initContainers`.

The readiness check now selects `semantic-router` and `istio-proxy` by name across classic and native sidecar status fields, avoiding counting `istio-init` as the proxy.

## Test Plan

- Validate the JSONPath expressions against classic and native PodList fixtures using the Kubernetes `client-go` JSONPath parser.
- Run `cd e2e && go test ./profiles/istio -count=1`.
- Run `make agent-ci-gate CHANGED_FILES="e2e/profiles/istio/runtime.go"`.

## Test Result

- Classic and native sidecar JSONPath fixture checks passed.
- The Istio profile package compiled successfully.
- The agent CI gate passed.
---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
