### PR TITLE
[Test] Add Istio native-sidecar fixtures

### DIFF
--- a/e2e/profiles/istio/runtime.go
+++ b/e2e/profiles/istio/runtime.go
@@ -18,6 +18,8 @@ const (
 	timeoutSemanticRouterDeploy = 20 * time.Minute
 	timeoutGatewayReady         = 5 * time.Minute
 	timeoutStabilization        = 60 * time.Second
+	sidecarReadinessJSONPath    = `{.items[*].status.containerStatuses[?(@.name=="semantic-router")].ready} {.items[*].status.containerStatuses[?(@.name=="istio-proxy")].ready} {.items[*].status.initContainerStatuses[?(@.name=="istio-proxy")].ready}`
+	sidecarContainerJSONPath    = `{.items[0].spec.containers[*].name} {.items[0].spec.initContainers[*].name}`
 )
 
 func (p *Profile) failSetup(ctx context.Context, opts *framework.SetupOptions, state *setupState, err error) error {
@@ -373,7 +375,7 @@ func (p *Profile) verifyServiceHealth(ctx context.Context, opts *framework.Setup
 		"get", "pods",
 		"-n", semanticRouterNamespace,
 		"-l", "app.kubernetes.io/name=semantic-router",
-		"-o", "jsonpath={.items[*].status.containerStatuses[?(@.name==\"semantic-router\")].ready} {.items[*].status.containerStatuses[?(@.name==\"istio-proxy\")].ready} {.items[*].status.initContainerStatuses[?(@.name==\"istio-proxy\")].ready}")
+		"-o", "jsonpath="+sidecarReadinessJSONPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to check pod readiness: %w (output: %s)", err, string(output))
@@ -399,7 +401,7 @@ func (p *Profile) verifySidecarInjection(ctx context.Context, opts *framework.Se
 		"get", "pods",
 		"-n", semanticRouterNamespace,
 		"-l", "app.kubernetes.io/name=semantic-router",
-		"-o", "jsonpath={.items[0].spec.containers[*].name} {.items[0].spec.initContainers[*].name}")
+		"-o", "jsonpath="+sidecarContainerJSONPath)
 	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to get pod containers: %w", err)

--- a/e2e/profiles/istio/runtime_test.go
+++ b/e2e/profiles/istio/runtime_test.go
@@ -1,0 +1,104 @@
+package istio
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+func TestSidecarJSONPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		podList         string
+		wantContainers  []string
+		wantReadyStates []string
+	}{
+		{
+			name: "classic sidecar",
+			podList: `{
+				"apiVersion": "v1",
+				"kind": "PodList",
+				"items": [{
+					"metadata": {"name": "classic-sidecar"},
+					"spec": {
+						"containers": [
+							{"name": "semantic-router"},
+							{"name": "istio-proxy"}
+						],
+						"initContainers": [{"name": "istio-init"}]
+					},
+					"status": {
+						"containerStatuses": [
+							{"name": "semantic-router", "ready": true},
+							{"name": "istio-proxy", "ready": true}
+						],
+						"initContainerStatuses": [{"name": "istio-init", "ready": false}]
+					}
+				}]
+			}`,
+			wantContainers:  []string{"semantic-router", "istio-proxy", "istio-init"},
+			wantReadyStates: []string{"true", "true"},
+		},
+		{
+			name: "native sidecar",
+			podList: `{
+				"apiVersion": "v1",
+				"kind": "PodList",
+				"items": [{
+					"metadata": {"name": "native-sidecar"},
+					"spec": {
+						"containers": [{"name": "semantic-router"}],
+						"initContainers": [
+							{"name": "istio-init"},
+							{"name": "istio-proxy", "restartPolicy": "Always"}
+						]
+					},
+					"status": {
+						"containerStatuses": [{"name": "semantic-router", "ready": true}],
+						"initContainerStatuses": [
+							{"name": "istio-init", "ready": false},
+							{"name": "istio-proxy", "ready": true}
+						]
+					}
+				}]
+			}`,
+			wantContainers:  []string{"semantic-router", "istio-init", "istio-proxy"},
+			wantReadyStates: []string{"true", "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var podList any
+			if err := json.Unmarshal([]byte(tt.podList), &podList); err != nil {
+				t.Fatalf("unmarshal PodList fixture: %v", err)
+			}
+
+			if got := executeJSONPath(t, sidecarContainerJSONPath, podList); !slices.Equal(got, tt.wantContainers) {
+				t.Errorf("sidecar containers = %v, want %v", got, tt.wantContainers)
+			}
+			if got := executeJSONPath(t, sidecarReadinessJSONPath, podList); !slices.Equal(got, tt.wantReadyStates) {
+				t.Errorf("sidecar readiness = %v, want %v", got, tt.wantReadyStates)
+			}
+		})
+	}
+}
+
+func executeJSONPath(t *testing.T, expression string, input any) []string {
+	t.Helper()
+
+	parser := jsonpath.New(t.Name())
+	if err := parser.Parse(expression); err != nil {
+		t.Fatalf("parse JSONPath %q: %v", expression, err)
+	}
+
+	var output bytes.Buffer
+	if err := parser.Execute(&output, input); err != nil {
+		t.Fatalf("execute JSONPath %q: %v", expression, err)
+	}
+	return strings.Fields(output.String())
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
Related #3403

## Purpose

follow up of [PR #3419's review](https://github.com/vllm-project/semantic-router/pull/3419#pullrequestreview-5100910089). add a testcase for it

This adds test coverage for the existing #3419 behavior without changing the runtime query semantics. 

## Test Plan

- `cd e2e && go test ./profiles/istio -count=1 -v`
- `cd e2e && go test ./profiles/istio -count=10`
- `make build-e2e`
- `make agent-report ENV=cpu CHANGED_FILES="e2e/profiles/istio/runtime.go e2e/profiles/istio/runtime_test.go"`
- `make agent-ci-gate ENV=cpu AGENT_BASE_REF=upstream/main CHANGED_FILES="e2e/profiles/istio/runtime.go e2e/profiles/istio/runtime_test.go"`
- `git diff --check`

## Test Result

all passed.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one recognized owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.