### PR TITLE
[Bug] Remove unreachable Python CLI symbols after dead-file cleanup

### DIFF
--- a/src/vllm-sr/cli/commands/recipe_learning.py
+++ b/src/vllm-sr/cli/commands/recipe_learning.py
@@ -265,27 +265,6 @@ def write_candidate_recipes(artifact: dict[str, Any], output_dir: Path) -> None:
         )
 
 
-def summarize_recipe_learning_artifact(artifact: dict[str, Any]) -> str:
-    metrics = artifact["metrics"]["overall"]
-    findings = artifact["findings"]
-    lines = [
-        "Router Learning recipe analysis",
-        f"records: {artifact['metrics']['records']}",
-        f"learning coverage: {metrics['learning_coverage']:.2f}",
-        f"outcome coverage: {metrics['outcome_coverage']:.2f}",
-        f"switch rate: {metrics['switch_rate']:.2f}",
-        f"cache preservation: {metrics['cache_preservation']:.2f}",
-        f"cost savings: {metrics['cost_savings']:.6f}",
-        f"findings: {len(findings)}",
-        f"candidate recipes: {len(artifact['candidate_recipes'])}",
-    ]
-    for item in findings[:5]:
-        lines.append(
-            f"- [{item['severity']}] {item['decision']}: {item['type']} - {item['message']}"
-        )
-    return "\n".join(lines)
-
-
 @click.command("recipe-learning")
 @click.option(
     "--replay-file",

--- a/src/vllm-sr/cli/commands/runtime.py
+++ b/src/vllm-sr/cli/commands/runtime.py
@@ -63,7 +63,7 @@ RUNTIME_HELP = (
 
 
 def _build_backend(target: str | None, **k8s_kwargs):
-    """Instantiate the right DeploymentBackend for *target*."""
+    """Instantiate the deployment backend for *target*."""
     resolved = resolve_target(target)
     if resolved == "k8s":
         from cli.k8s_backend import K8sBackend  # noqa: PLC0415

--- a/src/vllm-sr/cli/commands/runtime_paths.py
+++ b/src/vllm-sr/cli/commands/runtime_paths.py
@@ -24,7 +24,6 @@ MAX_PROVENANCE_BYTES = 64 * 1024
 _SHA256_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _PRIVATE_STATE_DIRECTORY = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _PRIVATE_DIRECTORY_MODE = 0o700
-_RECIPE_ASSET_MODE = 0o644
 STATE_ROOT_DIR_ENV = "VLLM_SR_STATE_ROOT_DIR"
 PRIVATE_STATE_FILE_MODE = 0o600
 CONTAINER_READABLE_STATE_FILE_MODE = 0o644
@@ -284,22 +283,6 @@ def write_runtime_config_bytes(path: Path, data: bytes) -> Path:
             f"Runtime config parent must be an owned directory: {path.parent}"
         )
     _atomic_write_private_bytes(path, data)
-    return path
-
-
-def write_runtime_recipe_asset_bytes(path: Path, data: bytes) -> Path:
-    """Atomically write an embedded Recipe asset inside a private directory.
-
-    The containing runtime-state directories remain owner-only. Files use the
-    read-only asset mode expected by the non-root Dashboard after bind mount.
-    """
-
-    path = path.expanduser().absolute()
-    if path.parent.is_symlink() or not path.parent.is_dir():
-        raise ValueError(
-            f"Runtime Recipe parent must be an owned directory: {path.parent}"
-        )
-    _atomic_write_bytes(path, data, _RECIPE_ASSET_MODE)
     return path
 
 

--- a/src/vllm-sr/cli/config_contract.py
+++ b/src/vllm-sr/cli/config_contract.py
@@ -147,17 +147,6 @@ def iter_condition_leaves(conditions: Any) -> Iterable[Any]:
             yield condition
 
 
-def iter_named_signal_entries(signals: Any) -> Iterable[tuple[str, str]]:
-    """Yield canonical signal family keys and declared signal names."""
-    if not signals:
-        return
-    for spec in SIGNAL_FAMILY_SPECS:
-        for signal in getattr(signals, spec.signal_attr, None) or []:
-            name = getattr(signal, "name", None)
-            if name:
-                yield spec.canonical_key, name
-
-
 def build_signal_reference_index(signals: Any) -> dict[str, set[str]]:
     """Index valid decision references by canonical condition type."""
     names: dict[str, set[str]] = {}

--- a/src/vllm-sr/cli/consts.py
+++ b/src/vllm-sr/cli/consts.py
@@ -1,7 +1,5 @@
 """Constants for vLLM Semantic Router CLI."""
 
-from cli import __version__
-
 # Docker image configuration
 VLLM_SR_CONTAINER_IMAGE_DEFAULT = "ghcr.io/vllm-project/semantic-router/vllm-sr:latest"
 VLLM_SR_CONTAINER_IMAGE_ROCM = (
@@ -10,14 +8,10 @@ VLLM_SR_CONTAINER_IMAGE_ROCM = (
 VLLM_SR_CONTAINER_IMAGE_CUDA = (
     "ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:latest"
 )
-VLLM_SR_ROUTER_CONTAINER_IMAGE_DEFAULT = VLLM_SR_CONTAINER_IMAGE_DEFAULT
-VLLM_SR_ROUTER_CONTAINER_IMAGE_ROCM = VLLM_SR_CONTAINER_IMAGE_ROCM
 VLLM_SR_ENVOY_CONTAINER_IMAGE_DEFAULT = "envoyproxy/envoy:v1.34-latest"
 VLLM_SR_DASHBOARD_CONTAINER_IMAGE_DEFAULT = (
     "ghcr.io/vllm-project/semantic-router/dashboard:latest"
 )
-VLLM_SR_CONTAINER_IMAGE_DEV = "vllm-sr:dev"
-VLLM_SR_CONTAINER_IMAGE_RELEASE = f"vllm-sr:{__version__}"
 DEFAULT_STACK_NAME = "vllm-sr"
 PLATFORM_AMD = "amd"
 PLATFORM_NVIDIA = "nvidia"
@@ -31,10 +25,6 @@ IMAGE_PULL_POLICY_IF_NOT_PRESENT = "ifnotpresent"
 IMAGE_PULL_POLICY_NEVER = "never"
 DEFAULT_IMAGE_PULL_POLICY = IMAGE_PULL_POLICY_ALWAYS
 
-# Service names
-SERVICE_NAME_ROUTER = "router"
-SERVICE_NAME_ENVOY = "envoy"
-
 # Default ports
 DEFAULT_ENVOY_PORT = 9901
 DEFAULT_ROUTER_PORT = 50051
@@ -47,11 +37,6 @@ DEFAULT_MILVUS_PORT = 19530
 # Health check
 HEALTH_CHECK_TIMEOUT = 1800  # 5 minutes (increased for model loading)
 HEALTH_CHECK_INTERVAL = 2
-
-# Log prefixes
-LOG_PREFIX_ROUTER = "[router]"
-LOG_PREFIX_ENVOY = "[envoy]"
-LOG_PREFIX_ACCESS = "[access_logs]"
 
 # File descriptor limits
 DEFAULT_NOFILE_LIMIT = 65536

--- a/src/vllm-sr/cli/container_backend.py
+++ b/src/vllm-sr/cli/container_backend.py
@@ -15,7 +15,7 @@ log = get_logger(__name__)
 
 
 class ContainerBackend:
-    """DeploymentBackend implementation for local Docker workflows."""
+    """Local Docker deployment backend."""
 
     def deploy(
         self,

--- a/src/vllm-sr/cli/deployment_backend.py
+++ b/src/vllm-sr/cli/deployment_backend.py
@@ -2,46 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol
-
-
-class DeploymentBackend(Protocol):
-    """Interface that all deployment targets (Docker, Kubernetes) must implement."""
-
-    def deploy(
-        self,
-        config_file: str,
-        env_vars: dict[str, str] | None = None,
-        *,
-        image: str | None = None,
-        pull_policy: str | None = None,
-        enable_observability: bool = True,
-        **kwargs: Any,
-    ) -> None:
-        """Deploy the full vLLM Semantic Router stack."""
-        ...
-
-    def teardown(self) -> None:
-        """Tear down the running stack."""
-        ...
-
-    def logs(self, service: str, follow: bool = False) -> None:
-        """Stream logs for a specific service."""
-        ...
-
-    def status(self, service: str = "all") -> None:
-        """Show status of deployed services."""
-        ...
-
-    def get_dashboard_url(self) -> str | None:
-        """Return the dashboard URL, or None if unavailable."""
-        ...
-
-    def is_running(self) -> bool:
-        """Return True if the stack is currently running."""
-        ...
-
-
 VALID_TARGETS = ("docker", "k8s")
 DEFAULT_TARGET = "docker"
 

--- a/src/vllm-sr/cli/evaluation/constants.py
+++ b/src/vllm-sr/cli/evaluation/constants.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 SCHEMA_VERSION = "evaluation.v1"
-ENGINE_VERSION = "1"
 
 TRACK_IDS = (
     "routing",

--- a/src/vllm-sr/cli/evaluation/live_chat.py
+++ b/src/vllm-sr/cli/evaluation/live_chat.py
@@ -7,7 +7,6 @@ from typing import Any
 from cli.evaluation.contract_validation import derived_portable_id
 from cli.evaluation.contracts import CaseGrading, CaseVisible
 from cli.evaluation.http_client import EvaluationHTTPClient, HTTPResult
-from cli.evaluation.target_arm_resolution import resolve_target_arm
 from cli.evaluation.target_contracts import EvaluationTargetArm
 
 
@@ -113,14 +112,3 @@ def arm_accounting(
         + output_tokens * arm.output_cost_per_million_tokens_usd
     ) / 1_000_000
     return input_tokens, output_tokens, runtime_cost
-
-
-def result_accounting(
-    result: HTTPResult,
-    arms: tuple[EvaluationTargetArm, ...],
-) -> tuple[int | None, int | None, float | None]:
-    arm = resolve_target_arm(result.headers.get("x-vsr-selected-model"), arms)
-    if arm is None:
-        input_tokens, output_tokens = token_usage(result.payload)
-        return input_tokens, output_tokens, None
-    return arm_accounting(arm, result)

--- a/src/vllm-sr/cli/evaluation/metric_core.py
+++ b/src/vllm-sr/cli/evaluation/metric_core.py
@@ -45,11 +45,6 @@ def mean_with_count(values: Iterable[float]) -> tuple[float | None, int]:
     return sum(rows) / len(rows), len(rows)
 
 
-def _sum_available(values: Iterable[float | None]) -> float | None:
-    rows = [value for value in values if value is not None]
-    return canonical_ordered_float_sum(rows) if rows else None
-
-
 def complete_sum(values: Iterable[float | None]) -> float | None:
     """Sum a ledger only when every observation carries an explicit value."""
 

--- a/src/vllm-sr/cli/evaluation/paired_statistics.py
+++ b/src/vllm-sr/cli/evaluation/paired_statistics.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Callable
 from dataclasses import dataclass
-from types import MappingProxyType
 from typing import Literal
 
 from cli.evaluation.evidence import ExecutionRecord
@@ -117,9 +116,6 @@ _STATISTICS = (
         "record",
         _violation,
     ),
-)
-PAIRED_STATISTIC_REGISTRY = MappingProxyType(
-    {statistic.metric_id: statistic for statistic in _STATISTICS}
 )
 
 

--- a/src/vllm-sr/cli/evaluation/target_contracts.py
+++ b/src/vllm-sr/cli/evaluation/target_contracts.py
@@ -37,17 +37,6 @@ class HTTPServiceEndpoint(StrictModel):
         return validate_http_origin(value, label="endpoint URL")
 
 
-class ModelArm(StrictModel):
-    schema_version: Literal[SCHEMA_VERSION] = SCHEMA_VERSION
-    id: str
-    model: str = Field(min_length=1)
-    endpoint: HTTPServiceEndpoint | None = None
-    input_cost_per_million_tokens_usd: float = Field(default=0, ge=0)
-    output_cost_per_million_tokens_usd: float = Field(default=0, ge=0)
-
-    _id = field_validator("id")(validate_portable_id)
-
-
 class PoolDefinition(StrictModel):
     schema_version: Literal[SCHEMA_VERSION] = SCHEMA_VERSION
     id: str

--- a/src/vllm-sr/cli/k8s_backend.py
+++ b/src/vllm-sr/cli/k8s_backend.py
@@ -119,7 +119,7 @@ def _dashboard_management_extra_env(
 
 
 class K8sBackend:
-    """DeploymentBackend implementation for Kubernetes via Helm."""
+    """Kubernetes deployment backend implemented through Helm."""
 
     def __init__(
         self,
@@ -136,7 +136,7 @@ class K8sBackend:
         self.profile = profile
         self.chart_dir = chart_dir or self._find_chart_dir()
 
-    # -- DeploymentBackend interface ------------------------------------------
+    # -- Deployment operations ------------------------------------------------
 
     def deploy(
         self,

--- a/src/vllm-sr/cli/parser.py
+++ b/src/vllm-sr/cli/parser.py
@@ -9,7 +9,6 @@ from cli.config_contract import (
     LEGACY_PROVIDER_DEFAULT_KEYS,
     LEGACY_PROVIDER_MODEL_SURFACE_KEYS,
     LEGACY_SIGNAL_KEY_TO_CANONICAL,
-    iter_named_signal_entries,
     iter_routing_profiles,
 )
 from cli.models import RouterLearningConfig, UserConfig
@@ -465,7 +464,6 @@ def parse_user_config(config_path: str, *, log_summary: bool = True) -> UserConf
         raise ConfigParseError(f"Invalid YAML syntax: {e}")
     except Exception as e:
         raise ConfigParseError(f"Failed to read configuration file: {e}")
-
     if not data:
         raise ConfigParseError("Configuration file is empty")
 
@@ -505,26 +503,6 @@ def parse_user_config(config_path: str, *, log_summary: bool = True) -> UserConf
         raise ConfigParseError(f"Unexpected error during validation: {e}")
 
 
-def detect_config_format(data: Dict[str, Any]) -> str:
-    """
-    Detect configuration format (new vs legacy).
-
-    Args:
-        data: Configuration data dictionary
-
-    Returns:
-        str: "new" or "legacy"
-    """
-    # New format has 'version' field starting with 'v'
-    if (
-        "version" in data
-        and isinstance(data["version"], str)
-        and data["version"].startswith("v")
-    ):
-        return "new"
-    return "legacy"
-
-
 def load_config_file(config_path: str) -> Dict[str, Any]:
     """
     Load configuration file as dictionary.
@@ -551,75 +529,3 @@ def load_config_file(config_path: str) -> Dict[str, Any]:
         raise ConfigParseError(f"Invalid YAML syntax: {e}")
     except Exception as e:
         raise ConfigParseError(f"Failed to read configuration file: {e}")
-
-
-def validate_signal_uniqueness(config: UserConfig) -> list:
-    """
-    Validate that signal names are unique across all signal types.
-
-    Args:
-        config: User configuration
-
-    Returns:
-        list: List of validation errors (empty if valid)
-    """
-    errors = []
-    seen = {}
-
-    if not config.signals:
-        return errors
-
-    for family, signal_name in iter_named_signal_entries(config.signals):
-        if signal_name in seen:
-            errors.append(
-                f"Duplicate signal name '{signal_name}' in {family} "
-                f"(already defined in {seen[signal_name]})"
-            )
-        seen[signal_name] = family
-
-    return errors
-
-
-def validate_domain_uniqueness(config: UserConfig) -> list:
-    """
-    Validate that domain names are unique.
-
-    Args:
-        config: User configuration
-
-    Returns:
-        list: List of validation errors (empty if valid)
-    """
-    errors = []
-
-    if not config.signals or not config.signals.domains:
-        return errors
-
-    seen = set()
-    for domain in config.signals.domains:
-        if domain.name in seen:
-            errors.append(f"Duplicate domain name '{domain.name}'")
-        seen.add(domain.name)
-
-    return errors
-
-
-def validate_model_uniqueness(config: UserConfig) -> list:
-    """
-    Validate that model names are unique.
-
-    Args:
-        config: User configuration
-
-    Returns:
-        list: List of validation errors (empty if valid)
-    """
-    errors = []
-    seen = set()
-
-    for model in config.providers.models:
-        if model.name in seen:
-            errors.append(f"Duplicate model name '{model.name}'")
-        seen.add(model.name)
-
-    return errors

--- a/src/vllm-sr/cli/recipe_directory.py
+++ b/src/vllm-sr/cli/recipe_directory.py
@@ -6,12 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 RECIPE_CONFIG_FILENAME = "config.yaml"
-RECIPE_SIBLING_FILENAMES = (
-    "metadata.yaml",
-    "probes.yaml",
-    "recipe.dsl",
-    "README.md",
-)
 
 
 class RecipeDirectoryError(ValueError):

--- a/src/vllm-sr/cli/utils.py
+++ b/src/vllm-sr/cli/utils.py
@@ -2,13 +2,9 @@
 
 import logging
 import os
-import time
-from http import HTTPStatus
-from importlib import import_module
 
 import yaml
 
-from cli.consts import DEFAULT_ENVOY_PORT
 from cli.terminal import TerminalLogHandler
 
 
@@ -58,89 +54,3 @@ def load_config(config_file):
     """Load and parse YAML config file."""
     with open(config_file) as f:
         return yaml.safe_load(f)
-
-
-def health_check_endpoint(url, timeout=5):
-    """
-    Check if an endpoint is healthy.
-
-    Args:
-        url: URL to check
-        timeout: Request timeout in seconds
-
-    Returns:
-        True if healthy, False otherwise
-    """
-    try:
-        requests = import_module("requests")
-        response = requests.get(url, timeout=timeout)
-        return response.status_code == HTTPStatus.OK
-    except Exception:
-        return False
-
-
-def wait_for_healthy(url, timeout=120, interval=2, logger=None):
-    """
-    Wait for an endpoint to become healthy.
-
-    Args:
-        url: URL to check
-        timeout: Maximum time to wait in seconds
-        interval: Check interval in seconds
-        logger: Logger instance
-
-    Returns:
-        True if healthy, False if timeout
-    """
-    if logger is None:
-        logger = get_logger(__name__)
-
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        if health_check_endpoint(url):
-            logger.info(f"Endpoint {url} is healthy")
-            return True
-        time.sleep(interval)
-
-    logger.error(f"✗ Endpoint {url} failed to become healthy after {timeout}s")
-    return False
-
-
-def stream_logs_from_file(log_file, follow=False):
-    """
-    Stream logs from a file.
-
-    Args:
-        log_file: Path to log file
-        follow: Whether to follow the file (tail -f behavior)
-    """
-    if not os.path.exists(log_file):
-        return
-
-    with open(log_file) as f:
-        # Read existing content
-        for line in f:
-            print(line, end="")
-
-        # Follow mode
-        if follow:
-            while True:
-                line = f.readline()
-                if line:
-                    print(line, end="")
-                else:
-                    time.sleep(0.1)
-
-
-def get_envoy_port(config):
-    """Get Envoy listen port from config or use default."""
-    # Try to read from listeners configuration
-    listeners = config.get("listeners", [])
-    if listeners and len(listeners) > 0:
-        # Get port from first listener
-        port = listeners[0].get("port")
-        if port:
-            return port
-
-    # Fall back to default
-    return DEFAULT_ENVOY_PORT

--- a/src/vllm-sr/cli/validator.py
+++ b/src/vllm-sr/cli/validator.py
@@ -1,7 +1,6 @@
 """Configuration validator for vLLM Semantic Router."""
 
 from typing import Any, List
-from cli.config_contract import iter_routing_profiles
 from cli.models import (
     UserConfig,
     PluginType,
@@ -70,11 +69,6 @@ ALGORITHM_CONFIG_BLOCKS = (
     "multi_factor",
     "prompt",
 )
-
-
-def _iter_profile_decisions(config: UserConfig):
-    for _, routing in iter_routing_profiles(config):
-        yield from routing.decisions
 
 
 VALID_ALGORITHM_TYPES = {

--- a/src/vllm-sr/cli/validator_latency.py
+++ b/src/vllm-sr/cli/validator_latency.py
@@ -16,34 +16,6 @@ def _all_decisions(config: UserConfig):
             yield field_prefix, decision
 
 
-def _iter_condition_nodes(conditions):
-    if not conditions:
-        return
-    for condition in conditions:
-        yield condition
-        if getattr(condition, "conditions", None):
-            yield from _iter_condition_nodes(condition.conditions)
-
-
-def validate_latency_compatibility(
-    config: UserConfig,
-) -> list[ValidationError]:
-    errors: list[ValidationError] = []
-    for field_prefix, decision in _all_decisions(config):
-        has_legacy_conditions = any(
-            (condition.type or "").strip().lower() == "latency"
-            for condition in _iter_condition_nodes(decision.rules.conditions)
-        )
-        if has_legacy_conditions:
-            errors.append(
-                ValidationError(
-                    "legacy latency config is no longer supported; use decision.algorithm.type=latency_aware and remove conditions.type=latency",
-                    field=f"{field_prefix}.{decision.name}.rules.conditions",
-                )
-            )
-    return errors
-
-
 def validate_latency_aware_algorithm_config(
     config: UserConfig,
 ) -> list[ValidationError]:


### PR DESCRIPTION
Closes #3435

## Purpose

Follow-up to #3211: remove repository-unreachable symbol-level leftovers under `src/vllm-sr/cli` that are not referenced by the live Click command graph, subprocess entrypoints, Go-launched Python modules, release tooling, or tests.

This PR deletes confirmed dead helpers, contracts, registries, and constants across parser/validator/runtime/evaluation/deployment modules, removes imports that became unused, and preserves deliberate compatibility exports. There is no user-visible CLI, configuration, API, or deployment behavior change.

## Test Plan

- Python CLI lint and affected unit tests for `src/vllm-sr/cli`
- Repository CI gate for the touched Python CLI surface

## Test Result

Pending CI on this PR.


Made with [Cursor](https://cursor.com)