### PR TITLE
[Docs] Add community.vllm-sr.ai link and Slack channel hyperlink to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ More announcements are available on the **[Blog](https://vllm-sr.ai/blog/)** and
 
 ## Community
 
-For questions, feedback, or to contribute, please join the `#semantic-router` channel in vLLM Slack.
+For questions, feedback, or to contribute, please join the [`#semantic-router`](https://vllm-dev.slack.com/archives/C09CTGF8KCN) channel in vLLM Slack.
+Track contributors, workgroups, and weekly activity at [community.vllm-sr.ai](https://community.vllm-sr.ai).
 
 ### Community Meetings
 


### PR DESCRIPTION
Closes #3439

## Purpose

The README Community section referenced the `#semantic-router` Slack channel as plain text and had no mention of the community dashboard.

This PR:
- Turns `#semantic-router` into a clickable link to `https://vllm-dev.slack.com/archives/C09CTGF8KCN`
- Adds a link to `https://community.vllm-sr.ai` for tracking contributors, workgroups, and weekly activity

No other content changes.

## Test Plan

Visual inspection of the rendered README diff.

## Test Result

Diff is a 2-line change to `README.md`. No logic or config affected.

Made with [Cursor](https://cursor.com)