### PR TITLE
[Bug] Enforce Fusion quorum over usable panel responses

### DIFF
--- a/e2e/profiles/looper/manifests/fake-backend.yaml
+++ b/e2e/profiles/looper/manifests/fake-backend.yaml
@@ -11,7 +11,10 @@ data:
     RESPONSES = {
         "ratings-model-a": ("answer-from-ratings-model-a", 3, 2),
         "ratings-model-b": ("answer-from-ratings-model-b", 7, 4),
+        "fusion-panel-valid": ("usable-fusion-panel-answer", 11, 3),
     }
+
+    FUSION_SYNTHESIZED_ANSWER = "unexpected-fusion-synthesized-answer"
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, format, *args):
@@ -46,6 +49,52 @@ data:
                 return
 
             model = payload.get("model")
+            if model == "fusion-panel-empty":
+                self.send_json(200, {
+                    "id": "chatcmpl-looper-e2e-fusion-panel-empty",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": model,
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 13,
+                        "completion_tokens": 0,
+                        "total_tokens": 13,
+                    },
+                })
+                return
+            if model == "fusion-panel-fail":
+                self.send_json(502, {"error": {"message": "synthetic panel failure"}})
+                return
+            if model == "fusion-judge":
+                messages = payload.get("messages", [])
+                prompt = messages[-1].get("content", "") if messages else ""
+                content = FUSION_SYNTHESIZED_ANSWER
+                if "return only valid JSON" in prompt:
+                    content = json.dumps({
+                        "consensus": ["unexpected analysis"],
+                        "contradictions": [],
+                        "partial_coverage": [],
+                        "unique_insights": [],
+                        "blind_spots": [],
+                    })
+                self.send_json(200, {
+                    "id": "chatcmpl-looper-e2e-fusion-judge",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {
+                        "prompt_tokens": 17,
+                        "completion_tokens": 5,
+                        "total_tokens": 22,
+                    },
+                })
+                return
             if model not in RESPONSES:
                 self.send_json(400, {"error": {"message": "unknown model"}})
                 return

--- a/e2e/profiles/looper/profile.go
+++ b/e2e/profiles/looper/profile.go
@@ -58,7 +58,12 @@ func (p *Profile) Teardown(ctx context.Context, opts *framework.TeardownOptions)
 }
 
 // GetTestCases returns the focused Looper contract tests.
-func (p *Profile) GetTestCases() []string { return []string{"looper-ratings-happy-path"} }
+func (p *Profile) GetTestCases() []string {
+	return []string{
+		"looper-ratings-happy-path",
+		"looper-fusion-usable-quorum",
+	}
+}
 
 // GetServiceConfig returns the shared gateway service configuration.
 func (p *Profile) GetServiceConfig() framework.ServiceConfig { return p.stack.ServiceConfig() }

--- a/e2e/profiles/looper/values.yaml
+++ b/e2e/profiles/looper/values.yaml
@@ -17,16 +17,49 @@ config:
           - name: looper-fake-backend
             endpoint: looper-fake-backend.default.svc.cluster.local:8000
             weight: 1
+      - name: fusion-panel-valid
+        provider_model_id: fusion-panel-valid
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
+      - name: fusion-panel-empty
+        provider_model_id: fusion-panel-empty
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
+      - name: fusion-panel-fail
+        provider_model_id: fusion-panel-fail
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
+      - name: fusion-judge
+        provider_model_id: fusion-judge
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
   routing:
     modelCards:
       - name: ratings-model-a
       - name: ratings-model-b
+      - name: fusion-panel-valid
+      - name: fusion-panel-empty
+      - name: fusion-panel-fail
+      - name: fusion-judge
     signals:
       keywords:
         - name: looper_ratings_probe_keywords
           operator: OR
           keywords:
             - __LOOPER_RATINGS_PROBE__
+          case_sensitive: true
+        - name: looper_fusion_quorum_probe_keywords
+          operator: OR
+          keywords:
+            - __LOOPER_FUSION_QUORUM_PROBE__
           case_sensitive: true
     decisions:
       - name: looper_ratings_decision
@@ -46,6 +79,32 @@ config:
           type: ratings
           ratings:
             max_concurrent: 2
+            on_error: skip
+      - name: looper_fusion_quorum_decision
+        description: Reject Fusion synthesis when usable panel responses do not meet quorum
+        priority: 110
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: looper_fusion_quorum_probe_keywords
+        modelRefs:
+          - model: fusion-panel-valid
+            use_reasoning: false
+          - model: fusion-panel-empty
+            use_reasoning: false
+          - model: fusion-panel-fail
+            use_reasoning: false
+        algorithm:
+          type: fusion
+          fusion:
+            model: fusion-judge
+            analysis_models:
+              - fusion-panel-valid
+              - fusion-panel-empty
+              - fusion-panel-fail
+            max_concurrent: 3
+            min_successful_responses: 2
             on_error: skip
       - name: default-route
         description: Fallback for unmatched profile traffic

--- a/e2e/testcases/looper_fusion_quorum.go
+++ b/e2e/testcases/looper_fusion_quorum.go
@@ -1,0 +1,67 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+const (
+	looperFusionQuorumProbeKeyword = "__LOOPER_FUSION_QUORUM_PROBE__"
+	looperFusionSynthesizedAnswer  = "unexpected-fusion-synthesized-answer"
+)
+
+type looperFusionErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
+}
+
+func init() {
+	pkgtestcases.Register("looper-fusion-usable-quorum", pkgtestcases.TestCase{
+		Description: "Reject Fusion synthesis when usable panel responses do not meet quorum",
+		Tags:        []string{"kubernetes", "routing", "looper", "fusion"},
+		Fn:          testLooperFusionUsableQuorum,
+	})
+}
+
+func testLooperFusionUsableQuorum(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stopPortForward, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopPortForward()
+
+	response, err := sendLocalChatCompletion(ctx, localPort, "MoM", looperFusionQuorumProbeKeyword, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("fusion quorum request failed: %w", err)
+	}
+	if response.StatusCode != http.StatusInternalServerError {
+		logUnexpectedChatCompletionStatus(opts.Verbose, response, "looper-fusion-usable-quorum")
+		return fmt.Errorf("fusion quorum status = %d, want %d", response.StatusCode, http.StatusInternalServerError)
+	}
+
+	var errorResponse looperFusionErrorResponse
+	if err := json.Unmarshal(response.Body, &errorResponse); err != nil {
+		return fmt.Errorf("decode fusion quorum error: %w", err)
+	}
+	if errorResponse.Error.Type != "server_error" {
+		return fmt.Errorf("error.type = %q, want server_error: %s", errorResponse.Error.Type, string(response.Body))
+	}
+	if strings.TrimSpace(errorResponse.Error.Message) == "" {
+		return fmt.Errorf("error.message is empty: %s", string(response.Body))
+	}
+	if strings.Contains(string(response.Body), looperFusionSynthesizedAnswer) {
+		return fmt.Errorf("fusion quorum error unexpectedly returned synthesized answer %q", looperFusionSynthesizedAnswer)
+	}
+
+	return nil
+}

--- a/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
+++ b/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
@@ -29,6 +29,7 @@ func buildReplayRouteDiagnostics(
 		DecisionPriority:               decisionPriority,
 		SelectionMethod:                ctx.VSRSelectionMethod,
 		SelectionReasoning:             ctx.VSRSelectionReasoning,
+		FusionQuorum:                   ctx.VSRFusionQuorum,
 		PromptHelperModel:              ctx.VSRPromptHelperModel,
 		PromptHelperPromptTokens:       ctx.VSRPromptHelperPromptTokens,
 		PromptHelperCompletionTokens:   ctx.VSRPromptHelperCompletionTokens,

--- a/src/semantic-router/pkg/extproc/req_filter_looper.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper.go
@@ -18,8 +18,6 @@ package extproc
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/openai/openai-go"
@@ -224,40 +222,6 @@ func (r *OpenAIRouter) executeLooperRequest(
 	return resp, nil
 }
 
-func (r *OpenAIRouter) looperExecutionErrorResponse(
-	err error,
-	originalModel string,
-	decision *config.Decision,
-	reqCtx *RequestContext,
-) *ext_proc.ProcessingResponse {
-	failureFields := map[string]interface{}{
-		"request_id": reqCtx.RequestID,
-		"decision":   decision.Name,
-		"algorithm":  decision.Algorithm.Type,
-		"error":      err.Error(),
-	}
-	executionEvidence, hasExecutionEvidence := looper.ConfidenceEvidenceFromError(err)
-	var evidenceArgs []looper.ConfidenceExecutionEvidence
-	if hasExecutionEvidence {
-		failureFields["models_used"] = executionEvidence.ModelsUsed
-		failureFields["iterations"] = executionEvidence.Iterations
-		failureFields["prompt_tokens"] = executionEvidence.Usage.PromptTokens
-		failureFields["completion_tokens"] = executionEvidence.Usage.CompletionTokens
-		failureFields["total_tokens"] = executionEvidence.Usage.TotalTokens
-		evidenceArgs = append(evidenceArgs, executionEvidence)
-	}
-	logging.ComponentErrorEvent("extproc", "looper_execution_failed", failureFields)
-	return r.recordLooperFailure(
-		reqCtx,
-		originalModel,
-		decision,
-		500,
-		"Looper execution failed: "+err.Error(),
-		"looper_execution_failed",
-		evidenceArgs...,
-	)
-}
-
 func (r *OpenAIRouter) recordSuccessfulLooperExecution(
 	resp *looper.Response,
 	originalModel string,
@@ -299,44 +263,6 @@ func (r *OpenAIRouter) recordSuccessfulLooperExecution(
 	if semanticResponse != nil {
 		r.scheduleSemanticResponseMemoryStore(reqCtx, semanticResponse)
 	}
-}
-
-func (r *OpenAIRouter) recordLooperFailure(
-	ctx *RequestContext,
-	originalModel string,
-	decision *config.Decision,
-	statusCode int,
-	message string,
-	reason string,
-	executionEvidence ...looper.ConfidenceExecutionEvidence,
-) *ext_proc.ProcessingResponse {
-	response := r.createErrorResponse(statusCode, message)
-	decisionName := ""
-	if decision != nil {
-		decisionName = decision.Name
-	}
-	if len(executionEvidence) > 0 && executionEvidence[0].Iterations > 0 {
-		evidence := executionEvidence[0]
-		algorithm := "confidence"
-		ctx.VSRSelectionMethod = algorithm
-		ctx.VSRSelectionReasoning = boundedSelectionReasoning(fmt.Sprintf(
-			"%s execution failed after %d call attempts; completed models: %s",
-			algorithm,
-			evidence.Iterations,
-			strings.Join(evidence.ModelsUsed, ","),
-		))
-	}
-	r.startRouterReplay(ctx, originalModel, "", decisionName)
-	if len(executionEvidence) > 0 {
-		r.updateLooperReplayUsage(ctx, executionEvidence[0].Usage)
-	}
-	r.updateRouterReplayStatus(ctx, statusCode, false)
-	if immediate := response.GetImmediateResponse(); immediate != nil {
-		r.attachRouterReplayResponse(ctx, immediate.Body, false)
-	}
-	r.finalizeRouterReplay(ctx, routerreplay.LifecycleFailed, reason)
-	addRouterReplayHeaderToImmediateResponse(response, ctx.RouterReplayID)
-	return response
 }
 
 func (r *OpenAIRouter) updateLooperReplayUsage(ctx *RequestContext, usage looper.TokenUsage) {

--- a/src/semantic-router/pkg/extproc/req_filter_looper_failure.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_failure.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extproc
+
+import (
+	"fmt"
+	"strings"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+)
+
+type looperFailureEvidence struct {
+	algorithm    string
+	modelsUsed   []string
+	iterations   int
+	usage        looper.TokenUsage
+	fusionQuorum *routerreplay.FusionQuorumDiagnostics
+}
+
+func (r *OpenAIRouter) looperExecutionErrorResponse(
+	err error,
+	originalModel string,
+	decision *config.Decision,
+	reqCtx *RequestContext,
+) *ext_proc.ProcessingResponse {
+	failureFields := map[string]interface{}{
+		"request_id": reqCtx.RequestID,
+		"decision":   decision.Name,
+		"algorithm":  decision.Algorithm.Type,
+		"error":      err.Error(),
+	}
+
+	evidence, hasEvidence := looperFailureEvidenceFromError(err)
+	var evidenceArgs []looperFailureEvidence
+	if hasEvidence {
+		evidence.addLogFields(failureFields)
+		evidenceArgs = append(evidenceArgs, evidence)
+	}
+
+	logging.ComponentErrorEvent("extproc", "looper_execution_failed", failureFields)
+	return r.recordLooperFailure(
+		reqCtx,
+		originalModel,
+		decision,
+		500,
+		"Looper execution failed: "+err.Error(),
+		"looper_execution_failed",
+		evidenceArgs...,
+	)
+}
+
+func looperFailureEvidenceFromError(err error) (looperFailureEvidence, bool) {
+	if evidence, ok := looper.ConfidenceEvidenceFromError(err); ok {
+		return looperFailureEvidence{
+			algorithm:  config.DecisionAlgorithmConfidence,
+			modelsUsed: append([]string(nil), evidence.ModelsUsed...),
+			iterations: evidence.Iterations,
+			usage:      evidence.Usage,
+		}, true
+	}
+	if evidence, ok := looper.FusionQuorumEvidenceFromError(err); ok {
+		return looperFailureEvidence{
+			algorithm:    config.DecisionAlgorithmFusion,
+			usage:        evidence.Usage,
+			fusionQuorum: fusionQuorumDiagnostics(evidence),
+		}, true
+	}
+	return looperFailureEvidence{}, false
+}
+
+func fusionQuorumDiagnostics(evidence looper.FusionQuorumEvidence) *routerreplay.FusionQuorumDiagnostics {
+	attempts := make([]routerreplay.FusionPanelAttemptDiagnostics, len(evidence.Attempts))
+	for index, attempt := range evidence.Attempts {
+		attempts[index] = routerreplay.FusionPanelAttemptDiagnostics{
+			Model:            attempt.Model,
+			State:            string(attempt.State),
+			PromptTokens:     attempt.Usage.PromptTokens,
+			CompletionTokens: attempt.Usage.CompletionTokens,
+			TotalTokens:      attempt.Usage.TotalTokens,
+		}
+	}
+	return &routerreplay.FusionQuorumDiagnostics{
+		RequiredCount: evidence.RequiredCount,
+		UsableCount:   evidence.UsableCount,
+		Attempts:      attempts,
+	}
+}
+
+func (evidence looperFailureEvidence) addLogFields(fields map[string]interface{}) {
+	fields["prompt_tokens"] = evidence.usage.PromptTokens
+	fields["completion_tokens"] = evidence.usage.CompletionTokens
+	fields["total_tokens"] = evidence.usage.TotalTokens
+	if evidence.algorithm == config.DecisionAlgorithmConfidence {
+		fields["models_used"] = evidence.modelsUsed
+		fields["iterations"] = evidence.iterations
+	}
+	if evidence.fusionQuorum != nil {
+		fields["fusion_quorum"] = evidence.fusionQuorum
+	}
+}
+
+func (r *OpenAIRouter) recordLooperFailure(
+	ctx *RequestContext,
+	originalModel string,
+	decision *config.Decision,
+	statusCode int,
+	message string,
+	reason string,
+	executionEvidence ...looperFailureEvidence,
+) *ext_proc.ProcessingResponse {
+	response := r.createErrorResponse(statusCode, message)
+	decisionName := ""
+	if decision != nil {
+		decisionName = decision.Name
+	}
+	if len(executionEvidence) > 0 {
+		applyLooperFailureEvidence(ctx, executionEvidence[0])
+	}
+
+	r.startRouterReplay(ctx, originalModel, "", decisionName)
+	if len(executionEvidence) > 0 {
+		r.updateLooperReplayUsage(ctx, executionEvidence[0].usage)
+	}
+	r.updateRouterReplayStatus(ctx, statusCode, false)
+	if immediate := response.GetImmediateResponse(); immediate != nil {
+		r.attachRouterReplayResponse(ctx, immediate.Body, false)
+	}
+	r.finalizeRouterReplay(ctx, routerreplay.LifecycleFailed, reason)
+	addRouterReplayHeaderToImmediateResponse(response, ctx.RouterReplayID)
+	return response
+}
+
+func applyLooperFailureEvidence(ctx *RequestContext, evidence looperFailureEvidence) {
+	switch evidence.algorithm {
+	case config.DecisionAlgorithmConfidence:
+		if evidence.iterations <= 0 {
+			return
+		}
+		ctx.VSRSelectionMethod = evidence.algorithm
+		ctx.VSRSelectionReasoning = boundedSelectionReasoning(fmt.Sprintf(
+			"%s execution failed after %d call attempts; completed models: %s",
+			evidence.algorithm,
+			evidence.iterations,
+			strings.Join(evidence.modelsUsed, ","),
+		))
+	case config.DecisionAlgorithmFusion:
+		if evidence.fusionQuorum == nil {
+			return
+		}
+		ctx.VSRSelectionMethod = evidence.algorithm
+		ctx.VSRSelectionReasoning = boundedSelectionReasoning(fmt.Sprintf(
+			"fusion panel quorum not met: %d/%d usable responses",
+			evidence.fusionQuorum.UsableCount,
+			evidence.fusionQuorum.RequiredCount,
+		))
+		ctx.VSRFusionQuorum = evidence.fusionQuorum
+	}
+}

--- a/src/semantic-router/pkg/extproc/req_filter_looper_fusion_replay_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_fusion_replay_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extproc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
+)
+
+const (
+	fusionReplayAnswerCanary    = "candidate-answer-canary-must-not-escape"
+	fusionReplayReasoningCanary = "candidate-reasoning-canary-must-not-escape"
+	fusionReplayErrorCanary     = "provider-error-body-canary-must-not-escape"
+)
+
+func TestHandleFusionQuorumFailurePersistsAccountingAndAttempts(t *testing.T) {
+	core, observedLogs := observer.New(zapcore.DebugLevel)
+	restoreLogger := zap.ReplaceGlobals(zap.New(core))
+	defer restoreLogger()
+
+	var judgeCalls atomic.Int64
+	server := newFusionQuorumReplayServer(t, &judgeCalls)
+	defer server.Close()
+
+	replayConfig := config.DefaultRouterReplayPluginConfig()
+	router := &OpenAIRouter{
+		Config: &config.RouterConfig{
+			Looper: config.LooperConfig{Endpoint: server.URL},
+		},
+		ReplayRecorder: routerreplay.NewRecorder(store.NewMemoryStore(10, 0)),
+	}
+	decision := &config.Decision{
+		Name: "fusion-quorum-route",
+		Algorithm: &config.AlgorithmConfig{
+			Type: config.DecisionAlgorithmFusion,
+			Fusion: &config.FusionAlgorithmConfig{
+				Model:                  "judge",
+				AnalysisModels:         []string{"panel-a", "panel-b", "panel-c"},
+				MaxConcurrent:          3,
+				MinSuccessfulResponses: 2,
+				OnError:                config.FusionOnErrorSkip,
+			},
+		},
+	}
+	request := testNeutralRequest("router-entrypoint", "hello")
+	requestContext := &RequestContext{
+		RequestID:                "replay-fusion-quorum",
+		Headers:                  map[string]string{},
+		SourceFormat:             llmprotocol.OpenAIChatV1,
+		SemanticRequest:          request,
+		RouterReplayPluginConfig: &replayConfig,
+		VSRSelectedDecision:      decision,
+	}
+
+	response, err := router.handleLooperExecution(context.Background(), request, decision, requestContext)
+	if err != nil {
+		t.Fatalf("handleLooperExecution: %v", err)
+	}
+	if got := response.GetImmediateResponse().GetStatus().GetCode(); got != typev3.StatusCode_InternalServerError {
+		t.Fatalf("Fusion quorum failure status = %v, want %v", got, typev3.StatusCode_InternalServerError)
+	}
+	if got := judgeCalls.Load(); got != 0 {
+		t.Fatalf("judge calls = %d, want 0 below panel quorum", got)
+	}
+
+	record, found := router.ReplayRecorder.GetRecord(requestContext.RouterReplayID)
+	if !found {
+		t.Fatalf("Replay record %q not found", requestContext.RouterReplayID)
+	}
+	assertFusionQuorumFailureRecord(t, record)
+
+	entries := observedLogs.FilterMessage("looper_execution_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("looper_execution_failed entries = %d, want 1", len(entries))
+	}
+	logFields := jsonObject(t, entries[0].ContextMap())
+	assertFusionQuorumDiagnostics(t, logFields, "fusion_quorum")
+	assertJSONNumber(t, logFields, "prompt_tokens", 30)
+	assertJSONNumber(t, logFields, "completion_tokens", 5)
+	assertJSONNumber(t, logFields, "total_tokens", 35)
+
+	assertFusionFailureDoesNotLeakPanelContent(t, response, record, logFields)
+}
+
+func newFusionQuorumReplayServer(t *testing.T, judgeCalls *atomic.Int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Errorf("decode Fusion request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		switch payload.Model {
+		case "panel-a":
+			writeFusionReplayCompletion(w, payload.Model, []map[string]interface{}{{
+				"index": 0,
+				"message": map[string]interface{}{
+					"role":              "assistant",
+					"content":           fusionReplayAnswerCanary,
+					"reasoning_content": fusionReplayReasoningCanary,
+				},
+				"finish_reason": "stop",
+			}}, map[string]int64{"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12})
+		case "panel-b":
+			writeFusionReplayCompletion(w, payload.Model, []map[string]interface{}{}, map[string]int64{
+				"prompt_tokens": 20, "completion_tokens": 3, "total_tokens": 23,
+			})
+		case "panel-c":
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(fusionReplayErrorCanary))
+		case "judge":
+			judgeCalls.Add(1)
+			writeFusionReplayCompletion(w, payload.Model, []map[string]interface{}{{
+				"index": 0,
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": "unexpected synthesized answer",
+				},
+				"finish_reason": "stop",
+			}}, map[string]int64{"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+		default:
+			t.Errorf("unexpected Fusion model call %q", payload.Model)
+			http.Error(w, "unexpected model", http.StatusInternalServerError)
+		}
+	}))
+}
+
+func writeFusionReplayCompletion(
+	w http.ResponseWriter,
+	model string,
+	choices []map[string]interface{},
+	usage map[string]int64,
+) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":      "chatcmpl-fusion-replay",
+		"object":  "chat.completion",
+		"created": 1,
+		"model":   model,
+		"choices": choices,
+		"usage":   usage,
+	})
+}
+
+func assertFusionQuorumFailureRecord(t *testing.T, record store.Record) {
+	t.Helper()
+	assertFusionQuorumReplayTerminal(t, record)
+	assertFusionQuorumReplayUsage(t, record)
+	assertFusionQuorumReplayDiagnostics(t, record)
+}
+
+func assertFusionQuorumReplayTerminal(t *testing.T, record store.Record) {
+	t.Helper()
+	if record.ResponseStatus != http.StatusInternalServerError || record.LifecycleState != routerreplay.LifecycleFailed {
+		t.Fatalf("Replay terminal state = status %d / %q, want 500 / %q", record.ResponseStatus, record.LifecycleState, routerreplay.LifecycleFailed)
+	}
+	if record.EndedAt == nil || record.TerminalReason != "looper_execution_failed" {
+		t.Fatalf("Replay terminal metadata = ended_at %v / reason %q", record.EndedAt, record.TerminalReason)
+	}
+	if record.SelectedModel != "" {
+		t.Fatalf("Fusion quorum failure recorded selected model %q", record.SelectedModel)
+	}
+}
+
+func assertFusionQuorumReplayUsage(t *testing.T, record store.Record) {
+	t.Helper()
+	assertReplayTokenCount(t, "prompt", record.PromptTokens, 30)
+	assertReplayTokenCount(t, "completion", record.CompletionTokens, 5)
+	assertReplayTokenCount(t, "total", record.TotalTokens, 35)
+	if record.ActualCost != nil || record.BaselineCost != nil || record.CostSavings != nil {
+		t.Fatalf("Fusion panel usage invented aggregate cost: actual %v baseline %v savings %v", record.ActualCost, record.BaselineCost, record.CostSavings)
+	}
+}
+
+func assertReplayTokenCount(t *testing.T, name string, got *int, want int) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Fatalf("Replay %s tokens = %v, want %d", name, got, want)
+	}
+}
+
+func assertFusionQuorumReplayDiagnostics(t *testing.T, record store.Record) {
+	t.Helper()
+	if record.SelectionMethod != config.DecisionAlgorithmFusion {
+		t.Fatalf("Replay selection method = %q, want fusion", record.SelectionMethod)
+	}
+
+	recordJSON := jsonObject(t, record)
+	routeDiagnostics := requiredJSONObject(t, recordJSON, "route_diagnostics")
+	if got, _ := routeDiagnostics["selection_method"].(string); got != config.DecisionAlgorithmFusion {
+		t.Fatalf("route_diagnostics.selection_method = %q, want fusion", got)
+	}
+	if reasoning, _ := routeDiagnostics["selection_reasoning"].(string); !strings.Contains(reasoning, "1/2 usable responses") {
+		t.Fatalf("route_diagnostics.selection_reasoning = %q, want bounded quorum summary", reasoning)
+	}
+	assertFusionQuorumDiagnostics(t, routeDiagnostics, "fusion_quorum")
+}
+
+func assertFusionQuorumDiagnostics(t *testing.T, parent map[string]interface{}, key string) {
+	t.Helper()
+	diagnostics := requiredJSONObject(t, parent, key)
+	assertJSONNumber(t, diagnostics, "required_count", 2)
+	assertJSONNumber(t, diagnostics, "usable_count", 1)
+	attempts, ok := diagnostics["attempts"].([]interface{})
+	if !ok || len(attempts) != 3 {
+		t.Fatalf("%s.attempts = %#v, want three ordered attempts", key, diagnostics["attempts"])
+	}
+
+	wants := []struct {
+		model      string
+		state      string
+		prompt     float64
+		completion float64
+		total      float64
+		hasUsage   bool
+	}{
+		{model: "panel-a", state: "usable", prompt: 10, completion: 2, total: 12, hasUsage: true},
+		{model: "panel-b", state: "unusable", prompt: 20, completion: 3, total: 23, hasUsage: true},
+		{model: "panel-c", state: "failed"},
+	}
+	for index, want := range wants {
+		attempt, ok := attempts[index].(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s.attempts[%d] = %#v, want object", key, index, attempts[index])
+		}
+		if got, _ := attempt["model"].(string); got != want.model {
+			t.Fatalf("%s.attempts[%d].model = %q, want %q", key, index, got, want.model)
+		}
+		if got, _ := attempt["state"].(string); got != want.state {
+			t.Fatalf("%s.attempts[%d].state = %q, want %q", key, index, got, want.state)
+		}
+		if want.hasUsage {
+			assertJSONNumber(t, attempt, "prompt_tokens", want.prompt)
+			assertJSONNumber(t, attempt, "completion_tokens", want.completion)
+			assertJSONNumber(t, attempt, "total_tokens", want.total)
+		} else {
+			assertAbsentOrZeroJSONNumber(t, attempt, "prompt_tokens")
+			assertAbsentOrZeroJSONNumber(t, attempt, "completion_tokens")
+			assertAbsentOrZeroJSONNumber(t, attempt, "total_tokens")
+		}
+		if _, exists := attempt["error"]; exists {
+			t.Fatalf("%s.attempts[%d] exposed error text: %#v", key, index, attempt["error"])
+		}
+	}
+}
+
+func assertFusionFailureDoesNotLeakPanelContent(
+	t *testing.T,
+	response interface{},
+	record store.Record,
+	logFields map[string]interface{},
+) {
+	t.Helper()
+	combined := fmt.Sprintf("response=%s\nrecord=%s\nlogs=%s", jsonBytes(t, response), jsonBytes(t, record), jsonBytes(t, logFields))
+	for _, canary := range []string{fusionReplayAnswerCanary, fusionReplayReasoningCanary, fusionReplayErrorCanary} {
+		if strings.Contains(combined, canary) {
+			t.Fatalf("Fusion quorum failure exposed private canary %q: %s", canary, combined)
+		}
+	}
+}
+
+func jsonObject(t *testing.T, value interface{}) map[string]interface{} {
+	t.Helper()
+	var object map[string]interface{}
+	if err := json.Unmarshal(jsonBytes(t, value), &object); err != nil {
+		t.Fatalf("decode JSON object: %v", err)
+	}
+	return object
+}
+
+func jsonBytes(t *testing.T, value interface{}) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encode JSON: %v", err)
+	}
+	return encoded
+}
+
+func requiredJSONObject(t *testing.T, parent map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	value, ok := parent[key].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s = %#v, want object", key, parent[key])
+	}
+	return value
+}
+
+func assertJSONNumber(t *testing.T, object map[string]interface{}, key string, want float64) {
+	t.Helper()
+	got, ok := object[key].(float64)
+	if !ok || got != want {
+		t.Fatalf("%s = %#v, want %.0f", key, object[key], want)
+	}
+}
+
+func assertAbsentOrZeroJSONNumber(t *testing.T, object map[string]interface{}, key string) {
+	t.Helper()
+	value, exists := object[key]
+	if !exists {
+		return
+	}
+	if got, ok := value.(float64); !ok || got != 0 {
+		t.Fatalf("%s = %#v, want absent or zero", key, value)
+	}
+}

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -126,6 +126,7 @@ type RequestContext struct {
 	VSRSelectedModel                string                                      // The model selected by VSR
 	VSRSelectionMethod              string                                      // Model selection algorithm used (e.g., "elo", "static", "router_dc")
 	VSRSelectionReasoning           string                                      // Bounded human-readable selector rationale for replay
+	VSRFusionQuorum                 *routerreplay.FusionQuorumDiagnostics       // Content-free Fusion panel quorum evidence for replay
 	VSRPromptHelperModel            string                                      // Concrete prompt-selector helper model
 	VSRPromptHelperPromptTokens     int64                                       // Prompt tokens consumed by the helper
 	VSRPromptHelperCompletionTokens int64                                       // Completion tokens consumed by the helper

--- a/src/semantic-router/pkg/looper/fusion.go
+++ b/src/semantic-router/pkg/looper/fusion.go
@@ -79,13 +79,6 @@ type FusionTrace struct {
 	Grounding      *FusionGroundingTrace `json:"grounding,omitempty"`
 }
 
-type fusionPanelResult struct {
-	index int
-	model string
-	resp  *ModelResponse
-	err   error
-}
-
 func (l *FusionLooper) Execute(ctx context.Context, req *Request) (*Response, error) {
 	l.client.SetDecisionName(req.DecisionName)
 	l.client.SetFusionDepth(1)
@@ -112,21 +105,21 @@ func (l *FusionLooper) Execute(ctx context.Context, req *Request) (*Response, er
 		"streaming":       req.IsStreaming,
 	})
 
-	panelResponses, failedModels, err := l.executeFusionPanel(ctx, req, cfg)
+	panel, err := l.executeFusionPanel(ctx, req, cfg)
 	if err != nil {
-		if cfg.OnError == config.FusionOnErrorFail || len(panelResponses) == 0 {
-			return nil, err
-		}
+		return nil, err
+	}
+	if len(panel.failedModels) > 0 {
 		logging.ComponentWarnEvent("looper", "fusion_panel_partial", map[string]interface{}{
 			"decision":  req.DecisionName,
-			"responses": len(panelResponses),
-			"error":     err.Error(),
+			"responses": len(panel.responses),
+			"failures":  len(panel.failedModels),
 		})
 	}
 
 	// Grounding (optional) ranks/filters the panel before the judge. It makes no
 	// model calls, so usage is summed from the full panel (the real cost paid).
-	groundedPanel, groundingScores, groundingMode, err := l.applyGrounding(req, cfg, panelResponses)
+	groundedPanel, groundingScores, groundingMode, err := l.applyGrounding(req, cfg, panel.responses)
 	if err != nil {
 		return nil, err
 	}
@@ -136,9 +129,9 @@ func (l *FusionLooper) Execute(ctx context.Context, req *Request) (*Response, er
 	if err != nil {
 		return nil, err
 	}
-	usage := SumUsage(panelResponses...).Add(analysisResp, finalResp)
+	usage := panel.usage.Add(analysisResp, finalResp)
 
-	trace := buildFusionTrace(cfg, groundedPanel, failedModels, analysis, groundingMode, groundingScores)
+	trace := buildFusionTrace(cfg, groundedPanel, panel.failedModels, analysis, groundingMode, groundingScores)
 	modelsUsed := orderedFusionModelsUsed(cfg.AnalysisModels, cfg.Model)
 	iterations := len(cfg.AnalysisModels) + 2
 
@@ -157,131 +150,6 @@ func (l *FusionLooper) validateFusionModels(cfg fusionExecutionConfig) error {
 		}
 	}
 	return nil
-}
-
-func (l *FusionLooper) executeFusionPanel(
-	ctx context.Context,
-	req *Request,
-	cfg fusionExecutionConfig,
-) ([]*ModelResponse, []FusionFailedModel, error) {
-	// Paired multi-arm evaluation supplies the panel verbatim so every arm
-	// synthesizes from a byte-identical panel (see bench/grounded_fusion). Skip
-	// the live model calls and feed the cached panel straight into grounding +
-	// synthesis, which are source-agnostic over []*ModelResponse.
-	if len(req.CachedPanel) > 0 {
-		return req.CachedPanel, nil, nil
-	}
-
-	panelCtx := ctx
-	cancel := func() {}
-	if cfg.RoundTimeoutSeconds > 0 {
-		panelCtx, cancel = context.WithTimeout(ctx, time.Duration(cfg.RoundTimeoutSeconds)*time.Second)
-	}
-	defer cancel()
-
-	results := make(chan fusionPanelResult, len(cfg.AnalysisModels))
-	sem := make(chan struct{}, cfg.MaxConcurrent)
-	for i, model := range cfg.AnalysisModels {
-		go func(index int, modelName string) {
-			select {
-			case sem <- struct{}{}:
-			case <-panelCtx.Done():
-				results <- fusionPanelResult{index: index, model: modelName, err: panelCtx.Err()}
-				return
-			}
-			defer func() { <-sem }()
-			resp, err := l.callFusionModel(panelCtx, req, req.OriginalRequest, cfg, modelName, false, false, index+1, cfg.AnalysisOverrides[modelName])
-			results <- fusionPanelResult{index: index, model: modelName, resp: resp, err: err}
-		}(i, model)
-	}
-
-	collector := newFusionPanelCollector(cfg, cancel)
-	for range cfg.AnalysisModels {
-		select {
-		case result := <-results:
-			responses, err, done := collector.handleResult(result)
-			if done {
-				return responses, collector.failed, err
-			}
-		case <-panelCtx.Done():
-			responses, err := collector.handleTimeout(panelCtx.Err())
-			return responses, collector.failed, err
-		}
-	}
-
-	responses := collector.responses()
-	if len(responses) == 0 {
-		return nil, collector.failed, fmt.Errorf("fusion panel failed: all %d analysis models failed", len(cfg.AnalysisModels))
-	}
-	return responses, collector.failed, nil
-}
-
-type fusionPanelCollector struct {
-	cfg       fusionExecutionConfig
-	cancel    context.CancelFunc
-	ordered   []*ModelResponse
-	failed    []FusionFailedModel
-	successes int
-}
-
-func newFusionPanelCollector(cfg fusionExecutionConfig, cancel context.CancelFunc) *fusionPanelCollector {
-	return &fusionPanelCollector{
-		cfg:     cfg,
-		cancel:  cancel,
-		ordered: make([]*ModelResponse, len(cfg.AnalysisModels)),
-	}
-}
-
-func (c *fusionPanelCollector) handleResult(result fusionPanelResult) ([]*ModelResponse, error, bool) {
-	if result.err != nil {
-		c.failed = append(c.failed, FusionFailedModel{Model: result.model, Error: result.err.Error()})
-		if c.cfg.OnError == config.FusionOnErrorFail {
-			c.cancel()
-			return nil, fmt.Errorf("fusion panel model %q failed: %w", result.model, result.err), true
-		}
-		return nil, nil, false
-	}
-	c.ordered[result.index] = result.resp
-	c.successes++
-	if c.successes < c.cfg.MinSuccessfulResponses {
-		return nil, nil, false
-	}
-	c.logQuorum()
-	c.cancel()
-	return c.responses(), nil, true
-}
-
-func (c *fusionPanelCollector) handleTimeout(err error) ([]*ModelResponse, error) {
-	responses := c.responses()
-	if len(responses) > 0 && c.cfg.OnError != config.FusionOnErrorFail {
-		c.failed = append(c.failed, FusionFailedModel{Model: "panel", Error: err.Error()})
-		return responses, err
-	}
-	return nil, err
-}
-
-func (c *fusionPanelCollector) responses() []*ModelResponse {
-	return compactFusionPanelResponses(c.ordered)
-}
-
-func (c *fusionPanelCollector) logQuorum() {
-	if c.successes >= len(c.cfg.AnalysisModels) {
-		return
-	}
-	logging.ComponentEvent("looper", "fusion_panel_quorum_reached", map[string]interface{}{
-		"responses": c.successes,
-		"panel":     len(c.cfg.AnalysisModels),
-	})
-}
-
-func compactFusionPanelResponses(ordered []*ModelResponse) []*ModelResponse {
-	responses := make([]*ModelResponse, 0, len(ordered))
-	for _, resp := range ordered {
-		if resp != nil {
-			responses = append(responses, resp)
-		}
-	}
-	return responses
 }
 
 func (l *FusionLooper) callFusionModel(

--- a/src/semantic-router/pkg/looper/fusion_cached_panel_test.go
+++ b/src/semantic-router/pkg/looper/fusion_cached_panel_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -139,6 +140,52 @@ func TestFusionExecute_CachedPanelSkipsLiveCalls(t *testing.T) {
 	// Usage = cached panel (12+23) + two judge calls (34 each via fusionTestUsage).
 	usage := body["usage"].(map[string]interface{})
 	assert.Equal(t, float64(12+23+34+34), usage["total_tokens"])
+}
+
+func TestFusionExecute_CachedPanelBelowUsableQuorumFailsBeforeJudge(t *testing.T) {
+	var judgeCalls atomic.Int64
+	server := newFusionStubServer(t, func(model, prompt string) (string, int) {
+		judgeCalls.Add(1)
+		return "unexpected judge response", http.StatusOK
+	})
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.CachedPanel = []*ModelResponse{
+		{Model: "panel-a", Content: "usable", Usage: TokenUsage{PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12}},
+		{Model: "panel-b", Content: "  \n ", Usage: TokenUsage{PromptTokens: 20, CompletionTokens: 3, TotalTokens: 23}},
+	}
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b"},
+			MinSuccessfulResponses: 2,
+		},
+	}
+
+	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.Error(t, err)
+	assert.Zero(t, judgeCalls.Load())
+	evidence, ok := FusionQuorumEvidenceFromError(err)
+	require.True(t, ok)
+	assert.Equal(t, 1, evidence.UsableCount)
+	assert.Equal(t, TokenUsage{PromptTokens: 30, CompletionTokens: 5, TotalTokens: 35}, evidence.Usage)
+	assert.Equal(t, FusionPanelAttemptUnusable, evidence.Attempts[1].State)
+}
+
+func TestFusionExecute_CachedReasoningOnlyResponseMeetsQuorum(t *testing.T) {
+	panel := []*ModelResponse{
+		{Model: "panel-a", ReasoningContent: "reasoning-only evidence", Usage: TokenUsage{TotalTokens: 7}},
+		{Model: "panel-b", Content: "ordinary answer", Usage: TokenUsage{TotalTokens: 9}},
+	}
+
+	body, judgePrompts := runCachedPanelArm(t, panel, nil, nil)
+	require.Len(t, judgePrompts, 2)
+	assert.Contains(t, judgePrompts[0], "reasoning-only evidence")
+	choices := body["choices"].([]interface{})
+	message := choices[0].(map[string]interface{})["message"].(map[string]interface{})
+	assert.Equal(t, "final answer", message["content"])
 }
 
 // TestFusionExecute_CachedPanel_ArmIsolation_BvsC proves arms B (plain fusion)

--- a/src/semantic-router/pkg/looper/fusion_panel.go
+++ b/src/semantic-router/pkg/looper/fusion_panel.go
@@ -1,0 +1,398 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+)
+
+// FusionPanelAttemptState classifies one panel model's terminal outcome.
+type FusionPanelAttemptState string
+
+const (
+	// FusionPanelAttemptUsable means the response supplied non-empty assistant content or reasoning.
+	FusionPanelAttemptUsable FusionPanelAttemptState = "usable"
+	// FusionPanelAttemptUnusable means a successful call supplied no usable assistant text.
+	FusionPanelAttemptUnusable FusionPanelAttemptState = "unusable"
+	// FusionPanelAttemptFailed means the call failed before producing a parsed response.
+	FusionPanelAttemptFailed FusionPanelAttemptState = "failed"
+	// FusionPanelAttemptTimedOut means the attempt ended at the panel deadline.
+	FusionPanelAttemptTimedOut FusionPanelAttemptState = "timed_out"
+	// FusionPanelAttemptCancelled means the parent context cancelled the attempt.
+	FusionPanelAttemptCancelled FusionPanelAttemptState = "cancelled"
+)
+
+// FusionPanelAttemptEvidence records content-free outcome and accounting data
+// for one panel model. It intentionally excludes response bodies.
+type FusionPanelAttemptEvidence struct {
+	Model string
+	State FusionPanelAttemptState
+	Error string
+	Usage TokenUsage
+}
+
+// FusionQuorumEvidence records the content-free panel evidence available when
+// Fusion cannot meet its configured usable-response quorum.
+type FusionQuorumEvidence struct {
+	RequiredCount int
+	UsableCount   int
+	Attempts      []FusionPanelAttemptEvidence
+	Usage         TokenUsage
+}
+
+// FusionQuorumError reports an unmet usable-response quorum while retaining
+// content-free per-attempt evidence for internal callers.
+type FusionQuorumError struct {
+	cause    error
+	evidence FusionQuorumEvidence
+}
+
+func (e *FusionQuorumError) Error() string {
+	if e == nil {
+		return "fusion panel quorum not met"
+	}
+	message := fmt.Sprintf(
+		"fusion panel quorum not met: got %d usable response%s, require %d",
+		e.evidence.UsableCount,
+		pluralSuffix(e.evidence.UsableCount),
+		e.evidence.RequiredCount,
+	)
+	if e.cause != nil {
+		return message + ": " + e.cause.Error()
+	}
+	return message
+}
+
+func (e *FusionQuorumError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// Evidence returns a defensive copy of the content-free panel evidence.
+func (e *FusionQuorumError) Evidence() FusionQuorumEvidence {
+	if e == nil {
+		return FusionQuorumEvidence{}
+	}
+	evidence := e.evidence
+	evidence.Attempts = append([]FusionPanelAttemptEvidence(nil), evidence.Attempts...)
+	return evidence
+}
+
+// FusionQuorumEvidenceFromError extracts Fusion panel accounting from a typed
+// quorum error, including when another error wraps it.
+func FusionQuorumEvidenceFromError(err error) (FusionQuorumEvidence, bool) {
+	var quorumErr *FusionQuorumError
+	if !errors.As(err, &quorumErr) {
+		return FusionQuorumEvidence{}, false
+	}
+	return quorumErr.Evidence(), true
+}
+
+type fusionPanelResult struct {
+	index int
+	model string
+	resp  *ModelResponse
+	err   error
+}
+
+type fusionPanelOutcome struct {
+	responses    []*ModelResponse
+	failedModels []FusionFailedModel
+	attempts     []FusionPanelAttemptEvidence
+	usage        TokenUsage
+}
+
+func (l *FusionLooper) executeFusionPanel(
+	ctx context.Context,
+	req *Request,
+	cfg fusionExecutionConfig,
+) (fusionPanelOutcome, error) {
+	// Paired multi-arm evaluation supplies the panel verbatim so every arm
+	// synthesizes from a byte-identical panel (see bench/grounded_fusion). The
+	// cached values still pass through the same usability and quorum checks, but
+	// need not contain the live client's Parsed representation.
+	if req.CachedPanel != nil {
+		return collectCachedFusionPanel(req.CachedPanel, cfg)
+	}
+
+	panelCtx := ctx
+	cancel := func() {}
+	if cfg.RoundTimeoutSeconds > 0 {
+		panelCtx, cancel = context.WithTimeout(ctx, time.Duration(cfg.RoundTimeoutSeconds)*time.Second)
+	}
+	defer cancel()
+
+	results := make(chan fusionPanelResult, len(cfg.AnalysisModels))
+	sem := make(chan struct{}, cfg.MaxConcurrent)
+	for i, model := range cfg.AnalysisModels {
+		go func(index int, modelName string) {
+			select {
+			case sem <- struct{}{}:
+			case <-panelCtx.Done():
+				results <- fusionPanelResult{index: index, model: modelName, err: panelCtx.Err()}
+				return
+			}
+			defer func() { <-sem }()
+			resp, err := l.callFusionModel(panelCtx, req, req.OriginalRequest, cfg, modelName, false, false, index+1, cfg.AnalysisOverrides[modelName])
+			results <- fusionPanelResult{index: index, model: modelName, resp: resp, err: err}
+		}(i, model)
+	}
+
+	collector := newFusionPanelCollector(cfg, cancel)
+	for range cfg.AnalysisModels {
+		select {
+		case result := <-results:
+			done, err := collector.handleResult(result)
+			if done {
+				return collector.outcome(), err
+			}
+		case <-panelCtx.Done():
+			collector.handleContextDone(panelCtx.Err())
+			outcome := collector.outcome()
+			return outcome, newFusionQuorumError(cfg.MinSuccessfulResponses, outcome, panelCtx.Err())
+		}
+	}
+
+	outcome := collector.outcome()
+	if len(outcome.responses) < cfg.MinSuccessfulResponses {
+		return outcome, newFusionQuorumError(cfg.MinSuccessfulResponses, outcome, nil)
+	}
+	return outcome, nil
+}
+
+func collectCachedFusionPanel(
+	panel []*ModelResponse,
+	cfg fusionExecutionConfig,
+) (fusionPanelOutcome, error) {
+	collector := newFusionPanelCollectorForModels(cachedFusionPanelModels(panel, cfg), cfg, func() {})
+	for index, response := range panel {
+		model := collector.attempts[index].Model
+		_, err := collector.handleResult(fusionPanelResult{
+			index: index,
+			model: model,
+			resp:  response,
+		})
+		if err != nil {
+			return collector.outcome(), err
+		}
+	}
+	outcome := collector.outcome()
+	if len(outcome.responses) < cfg.MinSuccessfulResponses {
+		return outcome, newFusionQuorumError(cfg.MinSuccessfulResponses, outcome, nil)
+	}
+	return outcome, nil
+}
+
+func cachedFusionPanelModels(panel []*ModelResponse, cfg fusionExecutionConfig) []string {
+	models := make([]string, len(panel))
+	for index, response := range panel {
+		if response != nil && strings.TrimSpace(response.Model) != "" {
+			models[index] = response.Model
+			continue
+		}
+		if index < len(cfg.AnalysisModels) {
+			models[index] = cfg.AnalysisModels[index]
+			continue
+		}
+		models[index] = fmt.Sprintf("cached-panel-%d", index+1)
+	}
+	return models
+}
+
+type fusionPanelCollector struct {
+	cfg       fusionExecutionConfig
+	cancel    context.CancelFunc
+	ordered   []*ModelResponse
+	attempts  []FusionPanelAttemptEvidence
+	completed []bool
+	usable    int
+	usage     TokenUsage
+}
+
+func newFusionPanelCollector(cfg fusionExecutionConfig, cancel context.CancelFunc) *fusionPanelCollector {
+	return newFusionPanelCollectorForModels(cfg.AnalysisModels, cfg, cancel)
+}
+
+func newFusionPanelCollectorForModels(
+	models []string,
+	cfg fusionExecutionConfig,
+	cancel context.CancelFunc,
+) *fusionPanelCollector {
+	attempts := make([]FusionPanelAttemptEvidence, len(models))
+	for index, model := range models {
+		attempts[index].Model = model
+	}
+	return &fusionPanelCollector{
+		cfg:       cfg,
+		cancel:    cancel,
+		ordered:   make([]*ModelResponse, len(models)),
+		attempts:  attempts,
+		completed: make([]bool, len(models)),
+	}
+}
+
+func (c *fusionPanelCollector) handleResult(result fusionPanelResult) (bool, error) {
+	if result.index < 0 || result.index >= len(c.attempts) || c.completed[result.index] {
+		return false, nil
+	}
+
+	evidence := &c.attempts[result.index]
+	if strings.TrimSpace(result.model) != "" {
+		evidence.Model = result.model
+	}
+	c.completed[result.index] = true
+	if result.resp != nil {
+		evidence.Usage = result.resp.Usage
+		c.usage = c.usage.Add(result.resp)
+	}
+
+	if result.err != nil {
+		evidence.State = fusionPanelErrorState(result.err)
+		evidence.Error = result.err.Error()
+		if c.cfg.OnError == config.FusionOnErrorFail {
+			c.cancel()
+			return true, fmt.Errorf("fusion panel model %q failed: %w", evidence.Model, result.err)
+		}
+		return false, nil
+	}
+	if !isUsableFusionPanelResponse(result.resp) {
+		evidence.State = FusionPanelAttemptUnusable
+		evidence.Error = "response contained no usable assistant content or reasoning"
+		if c.cfg.OnError == config.FusionOnErrorFail {
+			c.cancel()
+			return true, fmt.Errorf("fusion panel model %q returned no usable assistant content or reasoning", evidence.Model)
+		}
+		return false, nil
+	}
+
+	evidence.State = FusionPanelAttemptUsable
+	c.ordered[result.index] = result.resp
+	c.usable++
+	if c.usable < c.cfg.MinSuccessfulResponses {
+		return false, nil
+	}
+	c.logQuorum()
+	c.cancel()
+	return true, nil
+}
+
+func (c *fusionPanelCollector) handleContextDone(err error) {
+	state := FusionPanelAttemptCancelled
+	if errors.Is(err, context.DeadlineExceeded) {
+		state = FusionPanelAttemptTimedOut
+	}
+	for index := range c.attempts {
+		if c.completed[index] {
+			continue
+		}
+		c.completed[index] = true
+		c.attempts[index].State = state
+		c.attempts[index].Error = err.Error()
+	}
+}
+
+func (c *fusionPanelCollector) outcome() fusionPanelOutcome {
+	attempts := append([]FusionPanelAttemptEvidence(nil), c.attempts...)
+	return fusionPanelOutcome{
+		responses:    compactUsableFusionPanelResponses(c.ordered),
+		failedModels: failedFusionPanelModels(attempts),
+		attempts:     attempts,
+		usage:        c.usage,
+	}
+}
+
+func (c *fusionPanelCollector) logQuorum() {
+	if c.usable >= len(c.attempts) {
+		return
+	}
+	logging.ComponentEvent("looper", "fusion_panel_quorum_reached", map[string]interface{}{
+		"responses": c.usable,
+		"panel":     len(c.attempts),
+	})
+}
+
+func isUsableFusionPanelResponse(response *ModelResponse) bool {
+	if response == nil {
+		return false
+	}
+	return strings.TrimSpace(response.Content) != "" || strings.TrimSpace(response.ReasoningContent) != ""
+}
+
+func compactUsableFusionPanelResponses(ordered []*ModelResponse) []*ModelResponse {
+	responses := make([]*ModelResponse, 0, len(ordered))
+	for _, response := range ordered {
+		if !isUsableFusionPanelResponse(response) {
+			continue
+		}
+		responses = append(responses, response)
+	}
+	return responses
+}
+
+func failedFusionPanelModels(attempts []FusionPanelAttemptEvidence) []FusionFailedModel {
+	failed := make([]FusionFailedModel, 0, len(attempts))
+	for _, attempt := range attempts {
+		if attempt.State == "" || attempt.State == FusionPanelAttemptUsable {
+			continue
+		}
+		failed = append(failed, FusionFailedModel{Model: attempt.Model, Error: attempt.Error})
+	}
+	return failed
+}
+
+func fusionPanelErrorState(err error) FusionPanelAttemptState {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return FusionPanelAttemptTimedOut
+	case errors.Is(err, context.Canceled):
+		return FusionPanelAttemptCancelled
+	default:
+		return FusionPanelAttemptFailed
+	}
+}
+
+func newFusionQuorumError(
+	required int,
+	outcome fusionPanelOutcome,
+	cause error,
+) error {
+	return &FusionQuorumError{
+		cause: cause,
+		evidence: FusionQuorumEvidence{
+			RequiredCount: required,
+			UsableCount:   len(outcome.responses),
+			Attempts:      append([]FusionPanelAttemptEvidence(nil), outcome.attempts...),
+			Usage:         outcome.usage,
+		},
+	}
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/src/semantic-router/pkg/looper/fusion_panel_malformed_test.go
+++ b/src/semantic-router/pkg/looper/fusion_panel_malformed_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestFusionLooperMalformedHTTPSuccessDoesNotMeetQuorum(t *testing.T) {
+	var judgeCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		switch payload.Model {
+		case "panel-a":
+			writeFusionTestCompletion(w, payload.Model, "panel a answer", http.StatusOK)
+		case "panel-b":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[`))
+		case "panel-c":
+			writeFusionTestCompletion(w, payload.Model, "failed", http.StatusBadGateway)
+		case "judge":
+			judgeCalls.Add(1)
+			writeFusionTestCompletion(w, payload.Model, "unexpected judge response", http.StatusOK)
+		default:
+			t.Errorf("unexpected model call: %s", payload.Model)
+		}
+	}))
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b", "panel-c"},
+			MaxConcurrent:          3,
+			MinSuccessfulResponses: 2,
+			OnError:                config.FusionOnErrorSkip,
+		},
+	}
+
+	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, "fusion panel quorum not met: got 1 usable response, require 2", err.Error())
+	assert.Zero(t, judgeCalls.Load(), "judge must not run below panel quorum")
+
+	evidence, ok := FusionQuorumEvidenceFromError(err)
+	require.True(t, ok)
+	assert.Equal(t, 2, evidence.RequiredCount)
+	assert.Equal(t, 1, evidence.UsableCount)
+	assert.Equal(t, fusionTestTokenUsage("panel-a"), evidence.Usage)
+	require.Len(t, evidence.Attempts, 3)
+	assert.Equal(t, []FusionPanelAttemptState{
+		FusionPanelAttemptUsable,
+		FusionPanelAttemptFailed,
+		FusionPanelAttemptFailed,
+	}, []FusionPanelAttemptState{
+		evidence.Attempts[0].State,
+		evidence.Attempts[1].State,
+		evidence.Attempts[2].State,
+	})
+	assert.Contains(t, evidence.Attempts[1].Error, "failed to parse response")
+	assert.Contains(t, evidence.Attempts[2].Error, "request failed with status 502")
+}

--- a/src/semantic-router/pkg/looper/fusion_panel_test.go
+++ b/src/semantic-router/pkg/looper/fusion_panel_test.go
@@ -1,0 +1,372 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestIsUsableFusionPanelResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *ModelResponse
+		want     bool
+	}{
+		{name: "nil response", response: nil, want: false},
+		{name: "empty response", response: &ModelResponse{}, want: false},
+		{name: "empty content", response: &ModelResponse{Content: ""}, want: false},
+		{name: "whitespace content", response: &ModelResponse{Content: " \n\t "}, want: false},
+		{name: "whitespace reasoning", response: &ModelResponse{ReasoningContent: " \n\t "}, want: false},
+		{name: "tool only", response: &ModelResponse{HasToolCalls: true}, want: false},
+		{name: "content", response: &ModelResponse{Content: "answer"}, want: true},
+		{name: "reasoning only", response: &ModelResponse{ReasoningContent: "reasoning"}, want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isUsableFusionPanelResponse(test.response))
+		})
+	}
+}
+
+func TestFusionQuorumEvidenceIsContentFreeAndDefensive(t *testing.T) {
+	cause := context.DeadlineExceeded
+	quorumErr := newFusionQuorumError(2, fusionPanelOutcome{
+		responses: []*ModelResponse{{Content: "private panel answer"}},
+		attempts: []FusionPanelAttemptEvidence{
+			{
+				Model: "panel-a",
+				State: FusionPanelAttemptUsable,
+				Usage: TokenUsage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5},
+			},
+			{
+				Model: "panel-b",
+				State: FusionPanelAttemptTimedOut,
+				Error: "context deadline exceeded",
+			},
+		},
+		usage: TokenUsage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5},
+	}, cause)
+
+	assert.ErrorIs(t, quorumErr, cause)
+	assert.Equal(t, "fusion panel quorum not met: got 1 usable response, require 2: context deadline exceeded", quorumErr.Error())
+
+	evidence, ok := FusionQuorumEvidenceFromError(fmt.Errorf("wrapped: %w", quorumErr))
+	require.True(t, ok)
+	assert.Equal(t, 2, evidence.RequiredCount)
+	assert.Equal(t, 1, evidence.UsableCount)
+	assert.Equal(t, TokenUsage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5}, evidence.Usage)
+	assert.NotContains(t, fmt.Sprintf("%+v", evidence), "private panel answer")
+
+	evidence.Attempts[0].Model = "mutated"
+	again, ok := FusionQuorumEvidenceFromError(quorumErr)
+	require.True(t, ok)
+	assert.Equal(t, "panel-a", again.Attempts[0].Model)
+}
+
+func TestFusionLooperRejectsPanelBelowUsableQuorum(t *testing.T) {
+	var judgeCalls atomic.Int64
+	server := newFusionStubServer(t, func(model, prompt string) (string, int) {
+		switch model {
+		case "panel-a":
+			return "panel a answer", http.StatusOK
+		case "panel-b", "panel-c":
+			return "failed", http.StatusBadGateway
+		case "judge":
+			judgeCalls.Add(1)
+			if strings.Contains(prompt, "return only valid JSON") {
+				return `{"consensus":["a"],"contradictions":[],"partial_coverage":[],"unique_insights":[],"blind_spots":[]}`, http.StatusOK
+			}
+			return "unexpected synthesis", http.StatusOK
+		default:
+			return "unexpected model", http.StatusInternalServerError
+		}
+	})
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b", "panel-c"},
+			MaxConcurrent:          3,
+			MinSuccessfulResponses: 2,
+			OnError:                config.FusionOnErrorSkip,
+		},
+	}
+
+	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fusion panel quorum not met")
+	assert.Zero(t, judgeCalls.Load(), "judge must not run below panel quorum")
+}
+
+func TestFusionLooperEmptyPanelResponseDoesNotMeetQuorum(t *testing.T) {
+	var judgeCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		switch payload.Model {
+		case "panel-a":
+			writeFusionTestCompletion(w, payload.Model, "panel a answer", http.StatusOK)
+		case "panel-b":
+			writeFusionEmptyCompletion(w, payload.Model)
+		case "panel-c":
+			writeFusionTestCompletion(w, payload.Model, "failed", http.StatusBadGateway)
+		case "judge":
+			judgeCalls.Add(1)
+			writeFusionTestCompletion(w, payload.Model, "unexpected judge response", http.StatusOK)
+		default:
+			t.Errorf("unexpected model call: %s", payload.Model)
+			writeFusionTestCompletion(w, payload.Model, "unexpected model", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b", "panel-c"},
+			MaxConcurrent:          3,
+			MinSuccessfulResponses: 2,
+			OnError:                config.FusionOnErrorSkip,
+		},
+	}
+
+	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, "fusion panel quorum not met: got 1 usable response, require 2", err.Error())
+	assert.Zero(t, judgeCalls.Load(), "judge must not run below panel quorum")
+
+	evidence, ok := FusionQuorumEvidenceFromError(err)
+	require.True(t, ok)
+	assert.Equal(t, 2, evidence.RequiredCount)
+	assert.Equal(t, 1, evidence.UsableCount)
+	assert.Equal(t, TokenUsage{PromptTokens: 30, CompletionTokens: 5, TotalTokens: 35}, evidence.Usage)
+	require.Len(t, evidence.Attempts, 3)
+	assert.Equal(t, []FusionPanelAttemptState{
+		FusionPanelAttemptUsable,
+		FusionPanelAttemptUnusable,
+		FusionPanelAttemptFailed,
+	}, []FusionPanelAttemptState{
+		evidence.Attempts[0].State,
+		evidence.Attempts[1].State,
+		evidence.Attempts[2].State,
+	})
+	assert.Equal(t, fusionTestTokenUsage("panel-b"), evidence.Attempts[1].Usage)
+}
+
+func TestFusionLooperRecordsUnusablePanelResponseWhenQuorumMet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model    string `json:"model"`
+			Messages []struct {
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		switch payload.Model {
+		case "panel-a", "panel-b":
+			time.Sleep(50 * time.Millisecond)
+			writeFusionTestCompletion(w, payload.Model, payload.Model+" answer", http.StatusOK)
+		case "panel-c":
+			writeFusionEmptyCompletion(w, payload.Model)
+		case "judge":
+			prompt := payload.Messages[len(payload.Messages)-1].Content
+			if strings.Contains(prompt, "return only valid JSON") {
+				writeFusionTestCompletion(w, payload.Model, `{"consensus":["a+b"],"contradictions":[],"partial_coverage":[],"unique_insights":[],"blind_spots":[]}`, http.StatusOK)
+				return
+			}
+			writeFusionTestCompletion(w, payload.Model, "final from usable panel", http.StatusOK)
+		default:
+			t.Errorf("unexpected model call: %s", payload.Model)
+		}
+	}))
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b", "panel-c"},
+			MaxConcurrent:          3,
+			MinSuccessfulResponses: 2,
+			OnError:                config.FusionOnErrorSkip,
+		},
+	}
+
+	resp, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "final from usable panel", extractMessageContent(t, resp.Body))
+	assert.Equal(t, TokenUsage{PromptTokens: 91, CompletionTokens: 14, TotalTokens: 105}, resp.Usage)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	fusionTrace := body["fusion"].(map[string]interface{})
+	require.Len(t, fusionTrace["responses"], 2)
+	require.Len(t, fusionTrace["failed_models"], 1)
+	failed := fusionTrace["failed_models"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "panel-c", failed["model"])
+	assert.Contains(t, failed["error"], "no usable assistant content")
+}
+
+func TestFusionLooperOnErrorFailStopsAtUnusableResponse(t *testing.T) {
+	var judgeCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		switch payload.Model {
+		case "panel-a":
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(time.Second):
+				writeFusionTestCompletion(w, payload.Model, "too late", http.StatusOK)
+			}
+		case "panel-b":
+			writeFusionEmptyCompletion(w, payload.Model)
+		case "judge":
+			judgeCalls.Add(1)
+			writeFusionTestCompletion(w, payload.Model, "unexpected judge response", http.StatusOK)
+		default:
+			t.Errorf("unexpected model call: %s", payload.Model)
+		}
+	}))
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b"},
+			MaxConcurrent:          2,
+			MinSuccessfulResponses: 1,
+			OnError:                config.FusionOnErrorFail,
+		},
+	}
+
+	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `fusion panel model "panel-b" returned no usable assistant content`)
+	assert.Zero(t, judgeCalls.Load())
+}
+
+func TestFusionLooperTimeoutBelowQuorumPreservesPanelEvidence(t *testing.T) {
+	var judgeCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		switch payload.Model {
+		case "panel-a":
+			writeFusionTestCompletion(w, payload.Model, "panel a answer", http.StatusOK)
+		case "panel-b":
+			<-r.Context().Done()
+		case "judge":
+			judgeCalls.Add(1)
+			writeFusionTestCompletion(w, payload.Model, "unexpected judge response", http.StatusOK)
+		default:
+			t.Errorf("unexpected model call: %s", payload.Model)
+		}
+	}))
+	defer server.Close()
+
+	req := newFusionTestRequest()
+	req.Algorithm = &config.AlgorithmConfig{
+		Type: "fusion",
+		Fusion: &config.FusionAlgorithmConfig{
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b"},
+			MaxConcurrent:          2,
+			MinSuccessfulResponses: 2,
+			OnError:                config.FusionOnErrorSkip,
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(ctx, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Zero(t, judgeCalls.Load(), "judge must not run below panel quorum")
+
+	evidence, ok := FusionQuorumEvidenceFromError(err)
+	require.True(t, ok)
+	assert.Equal(t, 1, evidence.UsableCount)
+	assert.Equal(t, fusionTestTokenUsage("panel-a"), evidence.Usage)
+	require.Len(t, evidence.Attempts, 2)
+	assert.Equal(t, FusionPanelAttemptUsable, evidence.Attempts[0].State)
+	assert.Equal(t, FusionPanelAttemptTimedOut, evidence.Attempts[1].State)
+}
+
+func writeFusionEmptyCompletion(w http.ResponseWriter, model string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":      "chatcmpl-empty",
+		"object":  "chat.completion",
+		"created": 1,
+		"model":   model,
+		"choices": []interface{}{},
+		"usage":   fusionTestUsage(model),
+	})
+}
+
+func extractMessageContent(t *testing.T, body []byte) string {
+	t.Helper()
+	var payload struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.NotEmpty(t, payload.Choices)
+	return payload.Choices[0].Message.Content
+}
+
+func fusionTestTokenUsage(model string) TokenUsage {
+	usage := fusionTestUsage(model)
+	return TokenUsage{
+		PromptTokens:     usage["prompt_tokens"],
+		CompletionTokens: usage["completion_tokens"],
+		TotalTokens:      usage["total_tokens"],
+	}
+}

--- a/src/semantic-router/pkg/looper/fusion_test.go
+++ b/src/semantic-router/pkg/looper/fusion_test.go
@@ -83,6 +83,7 @@ func TestFusionLooperRecordsPartialPanelFailures(t *testing.T) {
 	server := newFusionStubServer(t, func(model, prompt string) (string, int) {
 		switch model {
 		case "panel-a":
+			time.Sleep(50 * time.Millisecond)
 			return "panel a answer", http.StatusOK
 		case "panel-b":
 			return "failed", http.StatusBadGateway
@@ -101,8 +102,9 @@ func TestFusionLooperRecordsPartialPanelFailures(t *testing.T) {
 	req.Algorithm = &config.AlgorithmConfig{
 		Type: "fusion",
 		Fusion: &config.FusionAlgorithmConfig{
-			Model:          "judge",
-			AnalysisModels: []string{"panel-a", "panel-b"},
+			Model:                  "judge",
+			AnalysisModels:         []string{"panel-a", "panel-b"},
+			MinSuccessfulResponses: 1,
 		},
 	}
 
@@ -604,7 +606,14 @@ func TestFusionLooperAllPanelFailuresReturnError(t *testing.T) {
 
 	_, err := NewFusionLooper(&config.LooperConfig{Endpoint: server.URL}).Execute(context.Background(), req)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "all 2 analysis models failed")
+	assert.Equal(t, "fusion panel quorum not met: got 0 usable responses, require 2", err.Error())
+	var quorumErr *FusionQuorumError
+	require.ErrorAs(t, err, &quorumErr)
+	evidence := quorumErr.Evidence()
+	assert.Equal(t, 0, evidence.UsableCount)
+	require.Len(t, evidence.Attempts, 2)
+	assert.Equal(t, FusionPanelAttemptFailed, evidence.Attempts[0].State)
+	assert.Equal(t, FusionPanelAttemptFailed, evidence.Attempts[1].State)
 }
 
 func TestFusionLooperUsesDecisionModelRefs(t *testing.T) {
@@ -757,20 +766,6 @@ func writeFusionTestCompletion(w http.ResponseWriter, model string, content stri
 		},
 		"usage": fusionTestUsage(model),
 	})
-}
-
-func extractMessageContent(t *testing.T, body []byte) string {
-	t.Helper()
-	var payload struct {
-		Choices []struct {
-			Message struct {
-				Content string `json:"content"`
-			} `json:"message"`
-		} `json:"choices"`
-	}
-	require.NoError(t, json.Unmarshal(body, &payload))
-	require.NotEmpty(t, payload.Choices)
-	return payload.Choices[0].Message.Content
 }
 
 func fusionTestUsage(model string) map[string]int64 {

--- a/src/semantic-router/pkg/looper/looper.go
+++ b/src/semantic-router/pkg/looper/looper.go
@@ -71,10 +71,10 @@ type Request struct {
 	// Fusion carries request-level plugins[].id=fusion overrides.
 	Fusion *config.FusionRequestConfig
 
-	// CachedPanel, when non-nil, is used verbatim as the fusion panel instead of
-	// calling the analysis models. It exists for paired multi-arm evaluation where
-	// every arm must synthesize from a byte-identical panel (see
-	// bench/grounded_fusion). Nil in production; only the fusioneval driver sets it.
+	// CachedPanel, when non-nil, replaces live Fusion analysis-model calls. Its
+	// entries still undergo the normal usability and quorum checks before every
+	// arm synthesizes from the same retained panel (see bench/grounded_fusion).
+	// Nil in production; only the fusioneval driver sets it.
 	CachedPanel []*ModelResponse
 }
 

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -45,6 +45,8 @@ type (
 	LearningRescueDiagnostics     = store.LearningRescueDiagnostics
 	LearningSamplingDiagnostics   = store.LearningSamplingDiagnostics
 	Outcome                       = store.Outcome
+	FusionPanelAttemptDiagnostics = store.FusionPanelAttemptDiagnostics
+	FusionQuorumDiagnostics       = store.FusionQuorumDiagnostics
 	RouteDiagnostics              = store.RouteDiagnostics
 	RoutingRecord                 = store.Record
 	ToolTrace                     = store.ToolTrace

--- a/src/semantic-router/pkg/routerreplay/redaction/redaction_test.go
+++ b/src/semantic-router/pkg/routerreplay/redaction/redaction_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
 )
 
 func TestRedactResponseBodyRemovesTrajectoryContentAndArguments(t *testing.T) {
@@ -125,5 +127,47 @@ func assertRedactedOutcome(t *testing.T, record map[string]any) {
 	}
 	if outcome["source"] != "user" || outcome["target"] != "model" || outcome["verdict"] != "failed" {
 		t.Fatalf("outcome structure changed: %#v", outcome)
+	}
+}
+
+func TestRedactResponseBodyRetainsFusionQuorumDiagnostics(t *testing.T) {
+	const private = "private-fusion-selection-reason"
+	body, err := json.Marshal(store.Record{
+		ID: "fusion-quorum",
+		RouteDiagnostics: &store.RouteDiagnostics{
+			SelectionMethod:    "fusion",
+			SelectionReasoning: private,
+			FusionQuorum: &store.FusionQuorumDiagnostics{
+				RequiredCount: 2,
+				UsableCount:   1,
+				Attempts: []store.FusionPanelAttemptDiagnostics{
+					{Model: "panel-a", State: "usable", PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12},
+					{Model: "panel-b", State: "unusable", PromptTokens: 20, CompletionTokens: 3, TotalTokens: 23},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal Fusion Replay record: %v", err)
+	}
+
+	redacted := mustRedactChanged(t, body)
+	if bytes.Contains(redacted, []byte(private)) {
+		t.Fatalf("redacted Fusion record retained free text: %s", redacted)
+	}
+	record := decodeRedactedRecord(t, redacted)
+	routeDiagnostics := record["route_diagnostics"].(map[string]any)
+	if routeDiagnostics["selection_reasoning"] != "" {
+		t.Fatalf("selection reasoning was not cleared: %#v", routeDiagnostics["selection_reasoning"])
+	}
+	quorum := routeDiagnostics["fusion_quorum"].(map[string]any)
+	if quorum["required_count"] != float64(2) || quorum["usable_count"] != float64(1) {
+		t.Fatalf("Fusion quorum counts changed during redaction: %#v", quorum)
+	}
+	attempts := quorum["attempts"].([]any)
+	second := attempts[1].(map[string]any)
+	if second["model"] != "panel-b" || second["state"] != "unusable" ||
+		second["prompt_tokens"] != float64(20) || second["completion_tokens"] != float64(3) || second["total_tokens"] != float64(23) {
+		t.Fatalf("Fusion attempt diagnostics changed during redaction: %#v", second)
 	}
 }

--- a/src/semantic-router/pkg/routerreplay/store/fusion_quorum_diagnostics.go
+++ b/src/semantic-router/pkg/routerreplay/store/fusion_quorum_diagnostics.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+// FusionQuorumDiagnostics captures content-free evidence for a Fusion panel
+// that did not produce enough usable responses.
+type FusionQuorumDiagnostics struct {
+	RequiredCount int                             `json:"required_count"`
+	UsableCount   int                             `json:"usable_count"`
+	Attempts      []FusionPanelAttemptDiagnostics `json:"attempts,omitempty"`
+}
+
+// FusionPanelAttemptDiagnostics captures the terminal state and reported token
+// usage for one Fusion panel call. It intentionally has no response or error
+// text fields.
+type FusionPanelAttemptDiagnostics struct {
+	Model            string `json:"model"`
+	State            string `json:"state"`
+	PromptTokens     int64  `json:"prompt_tokens,omitempty"`
+	CompletionTokens int64  `json:"completion_tokens,omitempty"`
+	TotalTokens      int64  `json:"total_tokens,omitempty"`
+}
+
+func cloneFusionQuorumDiagnostics(value *FusionQuorumDiagnostics) *FusionQuorumDiagnostics {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	cloned.Attempts = append([]FusionPanelAttemptDiagnostics(nil), value.Attempts...)
+	return &cloned
+}

--- a/src/semantic-router/pkg/routerreplay/store/fusion_quorum_diagnostics_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/fusion_quorum_diagnostics_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFusionQuorumDiagnosticsJSONRoundTrip(t *testing.T) {
+	record := Record{
+		ID: "fusion-quorum",
+		RouteDiagnostics: &RouteDiagnostics{
+			SelectionMethod: "fusion",
+			FusionQuorum: &FusionQuorumDiagnostics{
+				RequiredCount: 2,
+				UsableCount:   1,
+				Attempts: []FusionPanelAttemptDiagnostics{
+					{Model: "panel-a", State: "usable", PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12},
+					{Model: "panel-b", State: "unusable", PromptTokens: 20, CompletionTokens: 3, TotalTokens: 23},
+					{Model: "panel-c", State: "failed"},
+				},
+			},
+		},
+	}
+
+	decoded := roundTripRecord(t, record)
+	assertFusionQuorumDiagnosticsRoundTrip(t, decoded.RouteDiagnostics)
+}
+
+func assertFusionQuorumDiagnosticsRoundTrip(t *testing.T, diagnostics *RouteDiagnostics) {
+	t.Helper()
+	if diagnostics == nil || diagnostics.FusionQuorum == nil {
+		t.Fatalf("Fusion quorum diagnostics missing after round trip: %+v", diagnostics)
+	}
+	quorum := diagnostics.FusionQuorum
+	if quorum.RequiredCount != 2 || quorum.UsableCount != 1 || len(quorum.Attempts) != 3 {
+		t.Fatalf("Fusion quorum diagnostics changed after round trip: %+v", quorum)
+	}
+	assertFusionAttemptRoundTrip(t, quorum.Attempts[1])
+}
+
+func assertFusionAttemptRoundTrip(t *testing.T, got FusionPanelAttemptDiagnostics) {
+	t.Helper()
+	if got.Model != "panel-b" || got.State != "unusable" || got.PromptTokens != 20 ||
+		got.CompletionTokens != 3 || got.TotalTokens != 23 {
+		t.Fatalf("Fusion attempt changed after round trip: %+v", got)
+	}
+}
+
+func TestCloneRecordDeepCopiesFusionQuorumDiagnostics(t *testing.T) {
+	record := Record{RouteDiagnostics: &RouteDiagnostics{
+		FusionQuorum: &FusionQuorumDiagnostics{
+			RequiredCount: 2,
+			UsableCount:   1,
+			Attempts: []FusionPanelAttemptDiagnostics{{
+				Model: "panel-a", State: "usable", TotalTokens: 12,
+			}},
+		},
+	}}
+
+	cloned := cloneRecord(record)
+	if cloned.RouteDiagnostics == nil || cloned.RouteDiagnostics.FusionQuorum == nil {
+		t.Fatal("cloned record lost Fusion quorum diagnostics")
+	}
+	if cloned.RouteDiagnostics.FusionQuorum == record.RouteDiagnostics.FusionQuorum {
+		t.Fatal("Fusion quorum diagnostics pointer was not cloned")
+	}
+	if &cloned.RouteDiagnostics.FusionQuorum.Attempts[0] == &record.RouteDiagnostics.FusionQuorum.Attempts[0] {
+		t.Fatal("Fusion quorum attempt slice was not cloned")
+	}
+
+	cloned.RouteDiagnostics.FusionQuorum.RequiredCount = 9
+	cloned.RouteDiagnostics.FusionQuorum.Attempts[0].Model = "mutated"
+	if record.RouteDiagnostics.FusionQuorum.RequiredCount != 2 ||
+		record.RouteDiagnostics.FusionQuorum.Attempts[0].Model != "panel-a" {
+		t.Fatalf("clone mutation changed original Fusion diagnostics: %+v", record.RouteDiagnostics.FusionQuorum)
+	}
+}
+
+func TestFusionQuorumDiagnosticsOldRecordCompatibility(t *testing.T) {
+	var record Record
+	if err := json.Unmarshal([]byte(`{
+		"id":"legacy-record",
+		"route_diagnostics":{"selection_method":"fusion"}
+	}`), &record); err != nil {
+		t.Fatalf("unmarshal legacy record: %v", err)
+	}
+	if record.RouteDiagnostics == nil {
+		t.Fatal("legacy route diagnostics missing")
+	}
+	if record.RouteDiagnostics.FusionQuorum != nil {
+		t.Fatalf("legacy record invented Fusion quorum diagnostics: %+v", record.RouteDiagnostics.FusionQuorum)
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -115,51 +115,52 @@ type ToolTraceStep struct {
 // and memory outcome in a stable replay-facing shape. Detailed per-candidate
 // learning diagnostics live in the typed Learning block.
 type RouteDiagnostics struct {
-	Decision                       string                 `json:"decision,omitempty"`
-	DecisionTier                   int                    `json:"decision_tier,omitempty"`
-	DecisionPriority               int                    `json:"decision_priority,omitempty"`
-	SelectionMethod                string                 `json:"selection_method,omitempty"`
-	SelectionReasoning             string                 `json:"selection_reasoning,omitempty"`
-	PromptHelperModel              string                 `json:"prompt_helper_model,omitempty"`
-	PromptHelperPromptTokens       int64                  `json:"prompt_helper_prompt_tokens,omitempty"`
-	PromptHelperCompletionTokens   int64                  `json:"prompt_helper_completion_tokens,omitempty"`
-	PromptHelperTotalTokens        int64                  `json:"prompt_helper_total_tokens,omitempty"`
-	PromptHelperLatencyMs          int64                  `json:"prompt_helper_latency_ms,omitempty"`
-	OriginalModel                  string                 `json:"original_model,omitempty"`
-	ProposalModel                  string                 `json:"proposal_model,omitempty"`
-	PreviousModel                  string                 `json:"previous_model,omitempty"`
-	SelectedModel                  string                 `json:"selected_model,omitempty"`
-	SessionPolicyApplied           bool                   `json:"session_policy_applied,omitempty"`
-	SessionAction                  string                 `json:"session_action,omitempty"`
-	SessionPhase                   string                 `json:"session_phase,omitempty"`
-	SessionReason                  string                 `json:"session_reason,omitempty"`
-	HardLockReason                 string                 `json:"hard_lock_reason,omitempty"`
-	DecisionReason                 string                 `json:"decision_reason,omitempty"`
-	MemoryBackend                  string                 `json:"memory_backend,omitempty"`
-	MemoryStatus                   string                 `json:"memory_status,omitempty"`
-	MemoryReason                   string                 `json:"memory_reason,omitempty"`
-	MemoryFallbackReason           string                 `json:"memory_fallback_reason,omitempty"`
-	MemoryFailOpen                 bool                   `json:"memory_fail_open,omitempty"`
-	MemoryResultCount              int                    `json:"memory_result_count,omitempty"`
-	ContextCompressionApplied      bool                   `json:"context_compression_applied,omitempty"`
-	ContextCompressionBefore       int                    `json:"context_compression_tokens_before,omitempty"`
-	ContextCompressionAfter        int                    `json:"context_compression_tokens_after,omitempty"`
-	ContextCompressionMessages     int                    `json:"context_compression_messages,omitempty"`
-	ContextCompressionFormat       string                 `json:"context_compression_format,omitempty"`
-	ContextCompressionOmitted      int                    `json:"context_compression_omitted_chunks,omitempty"`
-	ContextCompressionSkipReason   string                 `json:"context_compression_skip_reason,omitempty"`
-	ContextCompressionStrategy     string                 `json:"context_compression_strategy,omitempty"`
-	ContextCompressionBudgetMode   string                 `json:"context_compression_budget_mode,omitempty"`
-	ContextCompressionTokenSource  string                 `json:"context_compression_token_source,omitempty"`
-	ContextCompressionTrigger      string                 `json:"context_compression_trigger,omitempty"`
-	ContextCompressionRevision     string                 `json:"context_compression_revision,omitempty"`
-	ContextCompressionRecoveryKeys int                    `json:"context_compression_recovery_keys,omitempty"`
-	ContextCompressionQuality      string                 `json:"context_compression_quality,omitempty"`
-	ContextCompressionFallback     string                 `json:"context_compression_fallback,omitempty"`
-	ContextCompressionCostSaved    float64                `json:"context_compression_cost_saved,omitempty"`
-	Annotations                    map[string]interface{} `json:"annotations,omitempty"`
-	SignalErrors                   map[string]string      `json:"signal_errors,omitempty"`
-	AppliedUnknownPolicies         map[string]string      `json:"applied_unknown_policies,omitempty"`
+	Decision                       string                   `json:"decision,omitempty"`
+	DecisionTier                   int                      `json:"decision_tier,omitempty"`
+	DecisionPriority               int                      `json:"decision_priority,omitempty"`
+	SelectionMethod                string                   `json:"selection_method,omitempty"`
+	SelectionReasoning             string                   `json:"selection_reasoning,omitempty"`
+	FusionQuorum                   *FusionQuorumDiagnostics `json:"fusion_quorum,omitempty"`
+	PromptHelperModel              string                   `json:"prompt_helper_model,omitempty"`
+	PromptHelperPromptTokens       int64                    `json:"prompt_helper_prompt_tokens,omitempty"`
+	PromptHelperCompletionTokens   int64                    `json:"prompt_helper_completion_tokens,omitempty"`
+	PromptHelperTotalTokens        int64                    `json:"prompt_helper_total_tokens,omitempty"`
+	PromptHelperLatencyMs          int64                    `json:"prompt_helper_latency_ms,omitempty"`
+	OriginalModel                  string                   `json:"original_model,omitempty"`
+	ProposalModel                  string                   `json:"proposal_model,omitempty"`
+	PreviousModel                  string                   `json:"previous_model,omitempty"`
+	SelectedModel                  string                   `json:"selected_model,omitempty"`
+	SessionPolicyApplied           bool                     `json:"session_policy_applied,omitempty"`
+	SessionAction                  string                   `json:"session_action,omitempty"`
+	SessionPhase                   string                   `json:"session_phase,omitempty"`
+	SessionReason                  string                   `json:"session_reason,omitempty"`
+	HardLockReason                 string                   `json:"hard_lock_reason,omitempty"`
+	DecisionReason                 string                   `json:"decision_reason,omitempty"`
+	MemoryBackend                  string                   `json:"memory_backend,omitempty"`
+	MemoryStatus                   string                   `json:"memory_status,omitempty"`
+	MemoryReason                   string                   `json:"memory_reason,omitempty"`
+	MemoryFallbackReason           string                   `json:"memory_fallback_reason,omitempty"`
+	MemoryFailOpen                 bool                     `json:"memory_fail_open,omitempty"`
+	MemoryResultCount              int                      `json:"memory_result_count,omitempty"`
+	ContextCompressionApplied      bool                     `json:"context_compression_applied,omitempty"`
+	ContextCompressionBefore       int                      `json:"context_compression_tokens_before,omitempty"`
+	ContextCompressionAfter        int                      `json:"context_compression_tokens_after,omitempty"`
+	ContextCompressionMessages     int                      `json:"context_compression_messages,omitempty"`
+	ContextCompressionFormat       string                   `json:"context_compression_format,omitempty"`
+	ContextCompressionOmitted      int                      `json:"context_compression_omitted_chunks,omitempty"`
+	ContextCompressionSkipReason   string                   `json:"context_compression_skip_reason,omitempty"`
+	ContextCompressionStrategy     string                   `json:"context_compression_strategy,omitempty"`
+	ContextCompressionBudgetMode   string                   `json:"context_compression_budget_mode,omitempty"`
+	ContextCompressionTokenSource  string                   `json:"context_compression_token_source,omitempty"`
+	ContextCompressionTrigger      string                   `json:"context_compression_trigger,omitempty"`
+	ContextCompressionRevision     string                   `json:"context_compression_revision,omitempty"`
+	ContextCompressionRecoveryKeys int                      `json:"context_compression_recovery_keys,omitempty"`
+	ContextCompressionQuality      string                   `json:"context_compression_quality,omitempty"`
+	ContextCompressionFallback     string                   `json:"context_compression_fallback,omitempty"`
+	ContextCompressionCostSaved    float64                  `json:"context_compression_cost_saved,omitempty"`
+	Annotations                    map[string]interface{}   `json:"annotations,omitempty"`
+	SignalErrors                   map[string]string        `json:"signal_errors,omitempty"`
+	AppliedUnknownPolicies         map[string]string        `json:"applied_unknown_policies,omitempty"`
 }
 
 // HallucinationSpan is a single unsupported span with its NLI explanation,
@@ -534,6 +535,7 @@ func cloneRouteDiagnostics(value *RouteDiagnostics) *RouteDiagnostics {
 		return nil
 	}
 	cloned := *value
+	cloned.FusionQuorum = cloneFusionQuorumDiagnostics(value.FusionQuorum)
 	cloned.Annotations = cloneInterfaceMap(value.Annotations)
 	cloned.SignalErrors = cloneStringMap(value.SignalErrors)
 	cloned.AppliedUnknownPolicies = cloneStringMap(value.AppliedUnknownPolicies)

--- a/website/docs/tutorials/algorithm/looper/fusion.md
+++ b/website/docs/tutorials/algorithm/looper/fusion.md
@@ -14,15 +14,28 @@ The same runtime also supports a direct Fusion model slug through `global.integr
 - Keeps Fusion policy inside vLLM-SR decisions: `vllm-sr/auto` can choose any route, while `vllm-sr/fusion` intelligently chooses among Fusion routes only.
 - Lets clients override the judge, analysis panel, templates, trace flags, and
   grounding policy per request with `plugins[].id = fusion`.
-- Degrades on partial panel failures while preserving failed model metadata.
+- Continues after partial panel failures only when the remaining usable
+  responses meet quorum, while preserving failed model metadata.
 
 ## Algorithm Principle
 
 Fusion executes a three-stage flow:
 
-1. **Panel**: dispatch the original request to the configured analysis models in parallel.
+1. **Panel**: dispatch the original request to the configured analysis models in parallel and require the configured usable-response quorum.
 2. **Judge analysis**: ask the judge model for structured JSON covering consensus, contradictions, partial coverage, unique insights, and blind spots.
 3. **Final synthesis**: ask the judge/calling model to write the user-facing answer using the panel responses and structured analysis.
+
+A panel response is usable only when its assistant `content` or
+`reasoning_content` is non-empty after trimming whitespace. Fusion checks
+`min_successful_responses` against those usable responses before grounding,
+judge analysis, or final synthesis. `on_error: skip` skips an individual failed
+or unusable response; it does not allow synthesis below quorum.
+
+When Router Replay is enabled, a below-quorum failure records the aggregate
+panel token usage on the Replay record and stores the required count, usable
+count, and ordered per-attempt model, state, and reported token usage under
+`route_diagnostics.fusion_quorum`. These diagnostics do not store panel answer
+content, reasoning, prompt data, raw response bodies, or error text.
 
 ## Execution Flow
 
@@ -42,14 +55,15 @@ flowchart TD
     K --> H
     H --> L[Apply request plugin overrides]
     L --> M[Run analysis panel concurrently]
-    M --> N{Any panel success?}
-    N -- No --> O[Return typed Fusion error]
-    N -- Yes --> P[Judge structured analysis]
-    P --> Q{JSON parsed?}
-    Q -- Yes --> R[Final synthesis with structured analysis]
-    Q -- No --> S[Final synthesis from raw panel responses]
-    R --> T[Return final answer + optional fusion trace]
-    S --> T
+    M --> N{Usable responses meet quorum?}
+    N -- No --> O[Return typed Fusion quorum error]
+    N -- Yes --> P[Apply optional grounding]
+    P --> Q[Judge structured analysis]
+    Q --> R{JSON parsed?}
+    R -- Yes --> S[Final synthesis with structured analysis]
+    R -- No --> T[Final synthesis from raw panel responses]
+    S --> U[Return final answer + optional fusion trace]
+    T --> U
 ```
 
 ## What Problem Does It Solve?
@@ -222,11 +236,11 @@ Request-level override:
 | `max_concurrent` | int | panel size | Maximum concurrent panel calls |
 | `max_completion_tokens` | int | request default | Max completion tokens applied to Fusion subrequests |
 | `round_timeout_seconds` | int | wait for all | Stop waiting for a panel round after this many seconds |
-| `min_successful_responses` | int | panel size | Continue once this many panel responses succeed |
+| `min_successful_responses` | int | panel size | Continue only after this many responses contain non-empty assistant content or reasoning after trimming whitespace |
 | `temperature` | float | request default | Temperature applied to Fusion subrequests |
 | `include_analysis` | bool | `true` | Include structured judge analysis in the response trace |
 | `include_intermediate_responses` | bool | `true` | Include raw panel responses in the response trace |
-| `on_error` | string | `skip` | `skip` partial panel failures or `fail` on the first panel error |
+| `on_error` | string | `skip` | `skip` individual failed or unusable panel responses while still enforcing quorum, or `fail` on the first such response |
 | `analysis_template` | string | built-in | Custom judge analysis prompt with `{{original}}` and `{{responses}}` |
 | `synthesis_template` | string | built-in | Custom final prompt with `{{original}}`, `{{responses}}`, and `{{analysis}}` |
 | `judge_prompt_version` | string | `fusion-v1` | Version marker included in Fusion response trace |
@@ -239,6 +253,9 @@ Best practice:
 - Prefer sparse request overrides (set only the field you need) to preserve decision defaults through field-wise merge.
 - Keep `min_successful_responses` at or below the effective panel size. Invalid
   quorums are rejected; the Router does not lower them automatically.
+- A partial panel continues only when its usable responses still satisfy
+  `min_successful_responses`; otherwise Fusion returns an error without running
+  grounding or either judge call.
 
 ## Grounding-Aware Synthesis
 
@@ -255,6 +272,10 @@ Policy (how the scores are used):
 - `weight` (default) — keep every response and instruct the judge to weight each panel answer by its score, while explicitly protecting a correct lone dissenter.
 - `annotate` — keep every response and pass the scores to the judge as notes, without a weighting instruction.
 - `filter` — hard-drop responses scoring below `min_score` (always keeping `min_keep`); only this policy uses `min_score`/`min_keep`.
+
+The usable-response quorum is checked on the original panel before grounding.
+If the `filter` policy later removes responses, Fusion does not run a second
+quorum check on the reduced judge input.
 
 > Grounding measures faithfulness/consistency, not truth. With no authoritative source it can down-weight the least-supported responses, not certify correctness. **Hard-dropping** the least mutually-consistent response (the `filter` policy) measurably *hurts* on contested factual questions — three models can be confidently wrong together while the lone dissenter is right — so the default is `weight`. See `bench/grounded_fusion/FINDINGS.md` for the evaluation behind this default.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #3374
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

Enforce Fusion's `min_successful_responses` quorum over usable panel responses.

A panel response is usable only when its `content` or `reasoning_content` remains non-empty after trimming whitespace. Empty choices, whitespace-only responses, tool-only responses, malformed payloads, timeouts, and failed requests do not count toward quorum.

When the usable response count is below quorum:

- Return a typed `FusionQuorumError` with safe per-attempt evidence and aggregate panel usage.
- Stop before grounding, judge analysis, and final synthesis.
- Preserve `on_error: fail` fail-fast behavior.
- Allow `on_error: skip` to skip individual failed attempts, but not the overall quorum requirement.

Responses that satisfy quorum retain their configured ordering and existing early-cancellation behavior. Cached panel responses use the same usability and quorum rules.

This change also adds Fusion unit and E2E coverage and updates the Fusion documentation. It does not add fallback behavior, new configuration fields, a shared panel executor, or generic Replay tracing.

The accepted issue is owned by `wg/mom-routing`.

## Test Plan

```bash
cd src/semantic-router

go test ./pkg/looper \
  -run '^(TestFusion|TestIsUsable)' \
  -count=1

go test ./pkg/looper \
  -run '^(TestFusionLooperRejectsPanelBelowUsableQuorum|TestFusionLooperEmptyPanelResponseDoesNotMeetQuorum|TestFusionLooperMalformedHTTPSuccessDoesNotMeetQuorum|TestFusionLooperAllPanelFailuresReturnError)$' \
  -count=20

go test -race ./pkg/looper \
  -run '^(TestFusionLooperMalformedHTTPSuccessDoesNotMeetQuorum|TestFusionLooperEmptyPanelResponseDoesNotMeetQuorum|TestFusionLooperTimeoutBelowQuorumPreservesPanelEvidence|TestFusionLooperPanelQuorumSkipsSlowWorker)$' \
  -count=1

go vet ./pkg/looper

cd ../..

make test-semantic-router
make build-e2e

make e2e-test-only \
  E2E_PROFILE=looper \
  E2E_TESTS=looper-fusion-usable-quorum \
  E2E_KEEP_CLUSTER=true

CHANGED_FILES="e2e/profiles/looper/manifests/fake-backend.yaml,e2e/profiles/looper/profile.go,e2e/profiles/looper/values.yaml,e2e/testcases/looper_fusion_quorum.go,src/semantic-router/pkg/looper/fusion.go,src/semantic-router/pkg/looper/fusion_cached_panel_test.go,src/semantic-router/pkg/looper/fusion_panel.go,src/semantic-router/pkg/looper/fusion_panel_malformed_test.go,src/semantic-router/pkg/looper/fusion_panel_test.go,src/semantic-router/pkg/looper/fusion_test.go,src/semantic-router/pkg/looper/looper.go,website/docs/tutorials/algorithm/looper/fusion.md"

make agent-e2e-affected CHANGED_FILES="$CHANGED_FILES"
make agent-lint AGENT_SKIP_PRECOMMIT_BASELINE=1 CHANGED_FILES="$CHANGED_FILES"
make agent-fast-gate AGENT_SKIP_PRECOMMIT_BASELINE=1 CHANGED_FILES="$CHANGED_FILES"
make check-go-mod-tidy
git diff --check upstream/main
```

## Test Result

The new quorum regression test failed before the implementation with:

```text
An error is expected but got nil
```

Results after the implementation:

- Fusion targeted unit tests: passed.
- Fusion quorum tests repeated 20 times: passed.
- Fusion targeted race tests: passed.
- `go vet ./pkg/looper`: passed.
- `make test-semantic-router`: passed.
- `make build-e2e`: passed.
- Targeted `looper-fusion-usable-quorum` E2E: passed, 1/1.
- Affected Looper E2E suite: passed, 2/2.
- Agent lint and fast gate: passed.
- Package-scoped `golangci-lint`: passed with 0 issues.
- `make check-go-mod-tidy`: passed.
- `git diff --check upstream/main`: passed.

The public OpenAI-compatible gateway maps the internal typed quorum failure to HTTP 500 with `type: server_error` and a generic message. The E2E test verifies that public contract. Unit tests verify the internal quorum counts, typed evidence, parser error retention, usage accounting, and that the judge is not called.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.