### PR TITLE
[CI/Build] Isolate memory integration cleanup

### DIFF
--- a/e2e/testing/run_memory_integration.sh
+++ b/e2e/testing/run_memory_integration.sh
@@ -256,6 +256,7 @@ else
 fi
 make -C "${REPO_ROOT}" start-milvus \
     MILVUS_CONTAINER_NAME="${MILVUS_CONTAINER_NAME}" \
+    MILVUS_BIND_HOST="127.0.0.1" \
     MILVUS_PORT="${MILVUS_PORT}" \
     MILVUS_HEALTH_PORT="${MILVUS_HEALTH_PORT}" \
     MILVUS_DATA_DIR="${TEST_DIR}/milvus-data" \

--- a/e2e/testing/run_memory_integration.sh
+++ b/e2e/testing/run_memory_integration.sh
@@ -9,20 +9,35 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 DOCKER_REGISTRY="${DOCKER_REGISTRY:-ghcr.io/vllm-project/semantic-router}"
 DOCKER_TAG="${DOCKER_TAG:-latest}"
 VLLM_SR_IMAGE="${VLLM_SR_IMAGE:-ghcr.io/vllm-project/semantic-router/vllm-sr:latest}"
-VLLM_SR_STACK_NAME="${VLLM_SR_STACK_NAME:-vllm-sr}"
+VLLM_SR_STACK_NAME="${VLLM_SR_STACK_NAME:-vllm-sr-memory-$$}"
+VLLM_SR_PORT_OFFSET="${VLLM_SR_PORT_OFFSET:-0}"
+VLLM_SR_RUN_ID="${VLLM_SR_RUN_ID:-memory-$$}"
+export VLLM_SR_STACK_NAME VLLM_SR_PORT_OFFSET VLLM_SR_RUN_ID
 if [[ "${VLLM_SR_STACK_NAME}" == "vllm-sr" ]]; then
     VLLM_SR_NETWORK="${VLLM_SR_NETWORK:-vllm-sr-network}"
+    VLLM_SR_ROUTER_CONTAINER_NAME="vllm-sr-router-container"
+    VLLM_SR_ENVOY_CONTAINER_NAME="vllm-sr-envoy-container"
+    VLLM_SR_DASHBOARD_CONTAINER_NAME="vllm-sr-dashboard-container"
 else
     VLLM_SR_NETWORK="${VLLM_SR_NETWORK:-${VLLM_SR_STACK_NAME}-vllm-sr-network}"
+    VLLM_SR_ROUTER_CONTAINER_NAME="${VLLM_SR_STACK_NAME}-vllm-sr-router-container"
+    VLLM_SR_ENVOY_CONTAINER_NAME="${VLLM_SR_STACK_NAME}-vllm-sr-envoy-container"
+    VLLM_SR_DASHBOARD_CONTAINER_NAME="${VLLM_SR_STACK_NAME}-vllm-sr-dashboard-container"
 fi
+STACK_SUFFIX="${VLLM_SR_STACK_NAME}-memory"
+LLM_KATAN_CONTAINER_NAME="${LLM_KATAN_CONTAINER_NAME:-${STACK_SUFFIX}-llm-katan}"
+MILVUS_CONTAINER_NAME="${MILVUS_CONTAINER_NAME:-${STACK_SUFFIX}-milvus}"
+LLM_KATAN_HOST_PORT="${LLM_KATAN_HOST_PORT:-$((8000 + VLLM_SR_PORT_OFFSET))}"
+MILVUS_PORT=$((19530 + VLLM_SR_PORT_OFFSET))
+MILVUS_HEALTH_PORT=$((9091 + VLLM_SR_PORT_OFFSET))
+ROUTER_ENDPOINT_PORT=$((8888 + VLLM_SR_PORT_OFFSET))
 
 TEST_DIR="${MEMORY_TEST_DIR:-$(mktemp -d -t vsr-memory-test-XXXXXX)}"
 PID_FILE="${TEST_DIR}/serve.pid"
 SERVE_LOG="${TEST_DIR}/serve.log"
 CONFIG_FILE="${TEST_DIR}/config.yaml"
 KEEP_TEST_DIR="${KEEP_MEMORY_TEST_DIR:-0}"
-ROUTER_API_HEALTH_URL="${ROUTER_API_HEALTH_URL:-http://localhost:8080/ready}"
-LLM_KATAN_HOST_PORT="${LLM_KATAN_HOST_PORT:-8000}"
+ROUTER_API_HEALTH_URL="${ROUTER_API_HEALTH_URL:-http://localhost:$((8080 + VLLM_SR_PORT_OFFSET))/ready}"
 MODEL_DIR="${MEMORY_TEST_MODEL_DIR:-${TEST_DIR}/models}"
 if [[ "${MODEL_DIR}" != /* ]]; then
     MODEL_DIR="${REPO_ROOT}/${MODEL_DIR}"
@@ -31,6 +46,20 @@ MODEL_MOUNT_DIR="${TEST_DIR}/models"
 USE_DETERMINISTIC_MEMORY_EMBEDDINGS="${USE_DETERMINISTIC_MEMORY_EMBEDDINGS:-0}"
 
 VLLM_SR_PID=""
+
+container_owned_by_run() {
+    local container_name="$1"
+    local labels
+    labels="$(${CONTAINER_RUNTIME} inspect --format '{{index .Config.Labels "com.vllm.semantic-router.managed"}} {{index .Config.Labels "com.vllm.semantic-router.stack"}} {{index .Config.Labels "com.vllm.semantic-router.run"}}' "${container_name}" 2>/dev/null || true)"
+    [[ "${labels}" == "true ${VLLM_SR_STACK_NAME} ${VLLM_SR_RUN_ID}" ]]
+}
+
+network_owned_by_run() {
+    local network_name="$1"
+    local labels
+    labels="$(${CONTAINER_RUNTIME} network inspect --format '{{index .Labels "com.vllm.semantic-router.managed"}} {{index .Labels "com.vllm.semantic-router.stack"}} {{index .Labels "com.vllm.semantic-router.run"}}' "${network_name}" 2>/dev/null || true)"
+    [[ "${labels}" == "true ${VLLM_SR_STACK_NAME} ${VLLM_SR_RUN_ID}" ]]
+}
 
 reclaim_test_dir_permissions() {
     local host_uid host_gid
@@ -74,14 +103,35 @@ cleanup() {
     # Dump container logs BEFORE stopping/removing them so CI can collect them.
     local log_dump_dir="${REPO_ROOT}/logs"
     mkdir -p "${log_dump_dir}" 2>/dev/null || true
-    for c in vllm-sr-router-container vllm-sr-envoy-container vllm-sr-dashboard-container vllm-sr-container llm-katan milvus-semantic-cache; do
+    for c in "${VLLM_SR_ROUTER_CONTAINER_NAME}" "${VLLM_SR_ENVOY_CONTAINER_NAME}" "${VLLM_SR_DASHBOARD_CONTAINER_NAME}" "${LLM_KATAN_CONTAINER_NAME}" "${MILVUS_CONTAINER_NAME}"; do
         "${CONTAINER_RUNTIME}" logs "$c" > "${log_dump_dir}/${c}.predump.log" 2>&1 || true
     done
 
-    vllm-sr stop >/dev/null 2>&1 || true
-    "${CONTAINER_RUNTIME}" stop llm-katan >/dev/null 2>&1 || true
-    "${CONTAINER_RUNTIME}" rm llm-katan >/dev/null 2>&1 || true
-    make -C "${REPO_ROOT}" stop-milvus >/dev/null 2>&1 || true
+    if container_owned_by_run "${LLM_KATAN_CONTAINER_NAME}"; then
+        "${CONTAINER_RUNTIME}" stop "${LLM_KATAN_CONTAINER_NAME}" >/dev/null 2>&1 || true
+        "${CONTAINER_RUNTIME}" rm "${LLM_KATAN_CONTAINER_NAME}" >/dev/null 2>&1 || true
+    elif "${CONTAINER_RUNTIME}" inspect "${LLM_KATAN_CONTAINER_NAME}" >/dev/null 2>&1; then
+        echo "Refusing to remove ${LLM_KATAN_CONTAINER_NAME}: ownership labels do not match" >&2
+    fi
+    make -C "${REPO_ROOT}" stop-milvus \
+        MILVUS_CONTAINER_NAME="${MILVUS_CONTAINER_NAME}" \
+        MILVUS_DATA_DIR="${TEST_DIR}/milvus-data" \
+        MILVUS_STACK_NAME="${VLLM_SR_STACK_NAME}" \
+        MILVUS_RUN_ID="${VLLM_SR_RUN_ID}" >/dev/null || true
+
+    # A failure before serve starts must not let vllm-sr stop target an older
+    # stack that happens to use the caller-supplied name.
+    if [[ -n "${VLLM_SR_PID}" ]]; then
+        vllm-sr stop >/dev/null 2>&1 || true
+    fi
+
+    # vllm-sr stop normally removes this network. Remove a pre-serve leftover
+    # only after this integration run proves exact stack/run ownership.
+    if network_owned_by_run "${VLLM_SR_NETWORK}"; then
+        "${CONTAINER_RUNTIME}" network rm "${VLLM_SR_NETWORK}" >/dev/null 2>&1 || true
+    elif "${CONTAINER_RUNTIME}" network inspect "${VLLM_SR_NETWORK}" >/dev/null 2>&1; then
+        echo "Refusing to remove ${VLLM_SR_NETWORK}: ownership labels do not match" >&2
+    fi
 
     if [[ "${KEEP_TEST_DIR}" == "1" ]]; then
         echo "Preserving memory integration artifacts at ${TEST_DIR}"
@@ -204,7 +254,13 @@ else
         fi
     fi
 fi
-make -C "${REPO_ROOT}" start-milvus
+make -C "${REPO_ROOT}" start-milvus \
+    MILVUS_CONTAINER_NAME="${MILVUS_CONTAINER_NAME}" \
+    MILVUS_PORT="${MILVUS_PORT}" \
+    MILVUS_HEALTH_PORT="${MILVUS_HEALTH_PORT}" \
+    MILVUS_DATA_DIR="${TEST_DIR}/milvus-data" \
+    MILVUS_STACK_NAME="${VLLM_SR_STACK_NAME}" \
+    MILVUS_RUN_ID="${VLLM_SR_RUN_ID}"
 
 # Double-check Milvus readiness with pymilvus probe (gRPC-level, not just HTTP)
 echo "Verifying Milvus gRPC readiness via pymilvus..."
@@ -212,7 +268,7 @@ for attempt in $(seq 1 30); do
     if python3 -c "
 from pymilvus import connections
 try:
-    connections.connect('default', host='localhost', port='19530', timeout=5)
+    connections.connect('default', host='localhost', port=${MILVUS_PORT}, timeout=5)
     connections.disconnect('default')
     print('Milvus gRPC connection verified')
 except Exception as e:
@@ -222,28 +278,38 @@ except Exception as e:
     fi
     if [ "${attempt}" -eq 30 ]; then
         echo "ERROR: Milvus gRPC not ready after 30 attempts"
-        "${CONTAINER_RUNTIME}" logs milvus-semantic-cache 2>&1 | tail -30 || true
+        "${CONTAINER_RUNTIME}" logs "${MILVUS_CONTAINER_NAME}" 2>&1 | tail -30 || true
         exit 1
     fi
     sleep 2
 done
 
 cp "${REPO_ROOT}/e2e/config/config.memory-user.yaml" "${CONFIG_FILE}"
-python3 -c 'from pathlib import Path; path = Path("'"${CONFIG_FILE}"'"); t = path.read_text(); t = t.replace("host.docker.internal:8000", "llm-katan:8000"); t = t.replace("host.docker.internal:19530", "vllm-sr-milvus:19530"); path.write_text(t)'
+python3 -c 'from pathlib import Path; path = Path("'"${CONFIG_FILE}"'"); t = path.read_text(); t = t.replace("host.docker.internal:8000", "'"${LLM_KATAN_CONTAINER_NAME}"':8000"); t = t.replace("host.docker.internal:19530", "'"${MILVUS_CONTAINER_NAME}"':19530"); path.write_text(t)'
 
 if ! "${CONTAINER_RUNTIME}" network inspect "${VLLM_SR_NETWORK}" >/dev/null 2>&1; then
-    "${CONTAINER_RUNTIME}" network create "${VLLM_SR_NETWORK}" >/dev/null
+    "${CONTAINER_RUNTIME}" network create \
+        --label com.vllm.semantic-router.managed=true \
+        --label com.vllm.semantic-router.stack="${VLLM_SR_STACK_NAME}" \
+        --label com.vllm.semantic-router.run="${VLLM_SR_RUN_ID}" \
+        "${VLLM_SR_NETWORK}" >/dev/null
+elif ! network_owned_by_run "${VLLM_SR_NETWORK}"; then
+    echo "Refusing to use ${VLLM_SR_NETWORK}: ownership labels do not match" >&2
+    exit 1
 fi
 
 # Connect the externally-started Milvus to the vllm-sr network so the router
 # container can reach it by the name vllm-sr serve expects.
-"${CONTAINER_RUNTIME}" network connect --alias vllm-sr-milvus "${VLLM_SR_NETWORK}" milvus-semantic-cache 2>/dev/null || true
-echo "Milvus connected to ${VLLM_SR_NETWORK} as vllm-sr-milvus"
+"${CONTAINER_RUNTIME}" network connect --alias "${MILVUS_CONTAINER_NAME}" "${VLLM_SR_NETWORK}" "${MILVUS_CONTAINER_NAME}" 2>/dev/null || true
+echo "Milvus connected to ${VLLM_SR_NETWORK} as ${MILVUS_CONTAINER_NAME}"
 
-"${CONTAINER_RUNTIME}" run -d --name llm-katan \
+"${CONTAINER_RUNTIME}" run -d --name "${LLM_KATAN_CONTAINER_NAME}" \
+    --label com.vllm.semantic-router.managed=true \
+    --label com.vllm.semantic-router.stack="${VLLM_SR_STACK_NAME}" \
+    --label com.vllm.semantic-router.run="${VLLM_SR_RUN_ID}" \
     --network "${VLLM_SR_NETWORK}" \
-    --network-alias llm-katan \
-    -p "${LLM_KATAN_HOST_PORT}:8000" \
+    --network-alias "${LLM_KATAN_CONTAINER_NAME}" \
+    -p "127.0.0.1:${LLM_KATAN_HOST_PORT}:8000" \
     "${DOCKER_REGISTRY}/llm-katan:${DOCKER_TAG}" \
     llm-katan --model dummy --host 0.0.0.0 --port 8000 --served-model-name qwen3 --backend echo >/dev/null
 
@@ -253,9 +319,9 @@ for _ in $(seq 1 30); do
         break
     fi
 
-    if ! "${CONTAINER_RUNTIME}" ps --filter "name=llm-katan" --format '{{.Names}}' | grep -q '^llm-katan$'; then
+    if ! "${CONTAINER_RUNTIME}" ps --filter "name=${LLM_KATAN_CONTAINER_NAME}" --format '{{.Names}}' | grep -q "^${LLM_KATAN_CONTAINER_NAME}$"; then
         echo "llm-katan container exited unexpectedly"
-        "${CONTAINER_RUNTIME}" logs llm-katan || true
+        "${CONTAINER_RUNTIME}" logs "${LLM_KATAN_CONTAINER_NAME}" || true
         exit 1
     fi
 
@@ -264,7 +330,7 @@ done
 
 if ! curl -s "http://localhost:${LLM_KATAN_HOST_PORT}/health" >/dev/null 2>&1; then
     echo "llm-katan did not become healthy"
-    "${CONTAINER_RUNTIME}" logs llm-katan || true
+    "${CONTAINER_RUNTIME}" logs "${LLM_KATAN_CONTAINER_NAME}" || true
     exit 1
 fi
 
@@ -307,8 +373,8 @@ fi
 
 cd "${REPO_ROOT}/e2e/testing"
 PYTHONUNBUFFERED=1 \
-ROUTER_ENDPOINT=http://localhost:8888 \
+ROUTER_ENDPOINT="http://localhost:${ROUTER_ENDPOINT_PORT}" \
 ROUTER_HEALTH_ENDPOINT="${ROUTER_API_HEALTH_URL}" \
-MILVUS_ADDRESS=localhost:19530 \
+MILVUS_ADDRESS="localhost:${MILVUS_PORT}" \
 MILVUS_COLLECTION=memory_test_ci \
 python3 09-memory-features-test.py

--- a/src/vllm-sr/tests/test_local_dev_make_surface.py
+++ b/src/vllm-sr/tests/test_local_dev_make_surface.py
@@ -91,6 +91,16 @@ def test_milvus_data_path_is_safe_when_workspace_contains_spaces() -> None:
     assert 'rm -rf "$(MILVUS_DATA_DIR)"' in content
 
 
+def test_memory_harness_keeps_loopback_binding_out_of_legacy_milvus_defaults() -> None:
+    milvus_make = MILVUS_MK_PATH.read_text(encoding="utf-8")
+    script = MEMORY_INTEGRATION_PATH.read_text(encoding="utf-8")
+
+    assert "MILVUS_BIND_HOST ?=" in milvus_make
+    assert "MILVUS_PUBLISH_HOST = $(if $(MILVUS_BIND_HOST)," in milvus_make
+    assert "-p 127.0.0.1:$(MILVUS_PORT):19530" not in milvus_make
+    assert 'MILVUS_BIND_HOST="127.0.0.1"' in script
+
+
 def test_cli_integration_uses_an_isolated_runtime_stack() -> None:
     content = DOCKER_MK_PATH.read_text(encoding="utf-8")
     target = content.split("vllm-sr-test-integration:", 1)[1].split(

--- a/src/vllm-sr/tests/test_local_dev_make_surface.py
+++ b/src/vllm-sr/tests/test_local_dev_make_surface.py
@@ -83,6 +83,14 @@ def test_memory_cleanup_attests_fixture_ownership_before_deletion() -> None:
     assert "com.vllm.semantic-router.run" in stop_target
 
 
+def test_milvus_data_path_is_safe_when_workspace_contains_spaces() -> None:
+    content = MILVUS_MK_PATH.read_text(encoding="utf-8")
+
+    assert 'mkdir -p "$(MILVUS_DATA_DIR)"' in content
+    assert '-v "$(MILVUS_DATA_DIR):/var/lib/milvus:z"' in content
+    assert 'rm -rf "$(MILVUS_DATA_DIR)"' in content
+
+
 def test_cli_integration_uses_an_isolated_runtime_stack() -> None:
     content = DOCKER_MK_PATH.read_text(encoding="utf-8")
     target = content.split("vllm-sr-test-integration:", 1)[1].split(

--- a/src/vllm-sr/tests/test_local_dev_make_surface.py
+++ b/src/vllm-sr/tests/test_local_dev_make_surface.py
@@ -4,6 +4,8 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 DOCKER_MK_PATH = REPO_ROOT / "tools" / "make" / "docker.mk"
 AGENT_MK_PATH = REPO_ROOT / "tools" / "make" / "agent.mk"
 ENVIRONMENTS_DOC_PATH = REPO_ROOT / "tools" / "agent" / "docs" / "environments.md"
+MEMORY_INTEGRATION_PATH = REPO_ROOT / "e2e" / "testing" / "run_memory_integration.sh"
+MILVUS_MK_PATH = REPO_ROOT / "tools" / "make" / "milvus.mk"
 
 
 def test_split_topology_defaults_to_rebuilding_router_image() -> None:
@@ -43,6 +45,42 @@ def test_memory_integration_uses_installed_agent_venv_cli() -> None:
     assert "vllm-sr-install-cli" in target
     assert 'PATH="$(AGENT_VENV)/bin:$$PATH" \\' in target
     assert "run_memory_integration.sh" in target
+
+
+def test_memory_integration_propagates_one_stack_run_and_port_identity() -> None:
+    make_content = DOCKER_MK_PATH.read_text(encoding="utf-8")
+    target = make_content.split("memory-test-integration:", 1)[1]
+
+    assert 'VLLM_SR_STACK_NAME="$${VLLM_SR_STACK_NAME:-}"' in target
+    assert 'VLLM_SR_PORT_OFFSET="$${VLLM_SR_PORT_OFFSET:-}"' in target
+    assert 'VLLM_SR_RUN_ID="$${VLLM_SR_RUN_ID:-}"' in target
+
+    script = MEMORY_INTEGRATION_PATH.read_text(encoding="utf-8")
+    assert 'VLLM_SR_STACK_NAME="${VLLM_SR_STACK_NAME:-vllm-sr-memory-$$}"' in script
+    assert 'VLLM_SR_RUN_ID="${VLLM_SR_RUN_ID:-memory-$$}"' in script
+    assert 'STACK_SUFFIX="${VLLM_SR_STACK_NAME}-memory"' in script
+    assert "19530 + VLLM_SR_PORT_OFFSET" in script
+    assert "9091 + VLLM_SR_PORT_OFFSET" in script
+
+
+def test_memory_cleanup_attests_fixture_ownership_before_deletion() -> None:
+    script = MEMORY_INTEGRATION_PATH.read_text(encoding="utf-8")
+    cleanup = script.split("cleanup() {", 1)[1].split("trap cleanup", 1)[0]
+
+    assert 'container_owned_by_run "${LLM_KATAN_CONTAINER_NAME}"' in cleanup
+    assert 'network_owned_by_run "${VLLM_SR_NETWORK}"' in cleanup
+    assert 'if [[ -n "${VLLM_SR_PID}" ]]' in cleanup
+    assert 'MILVUS_STACK_NAME="${VLLM_SR_STACK_NAME}"' in cleanup
+    assert 'MILVUS_RUN_ID="${VLLM_SR_RUN_ID}"' in cleanup
+    assert "stop llm-katan" not in cleanup
+    assert "rm llm-katan" not in cleanup
+    assert "milvus-semantic-cache" not in cleanup
+
+    milvus_make = MILVUS_MK_PATH.read_text(encoding="utf-8")
+    stop_target = milvus_make.split("stop-milvus:", 1)[1].split("restart-milvus:", 1)[0]
+    assert "com.vllm.semantic-router.managed" in stop_target
+    assert "com.vllm.semantic-router.stack" in stop_target
+    assert "com.vllm.semantic-router.run" in stop_target
 
 
 def test_cli_integration_uses_an_isolated_runtime_stack() -> None:

--- a/tools/agent/docs/environments.md
+++ b/tools/agent/docs/environments.md
@@ -28,6 +28,21 @@ the shared-environment symlink without overwriting local files.
   and `make agent-serve-local ENV=cpu AGENT_STACK_NAME=lane-b AGENT_PORT_OFFSET=200`
 - Use the same `AGENT_STACK_NAME` and `AGENT_PORT_OFFSET` values with `make agent-smoke-local` and `make agent-stop-local`
 
+### Shared-host memory integration
+
+Use a distinct integration stack, port offset, and run ID for each concurrent
+host invocation:
+
+```bash
+VLLM_SR_STACK_NAME=memory-a VLLM_SR_PORT_OFFSET=2400 VLLM_SR_RUN_ID=memory-a-001 make memory-test-integration
+```
+
+The harness derives its network, Milvus, llm-katan, and temporary data names
+from that identity. Teardown removes auxiliary containers and networks only
+when their stack and run labels match. This first slice does not change the
+general CLI integration or local-agent lifecycle; those remain follow-up work
+under issue #2487.
+
 ## `amd-local`
 
 - Build with `make vllm-sr-dev VLLM_SR_PLATFORM=amd`

--- a/tools/make/docker.mk
+++ b/tools/make/docker.mk
@@ -520,5 +520,8 @@ memory-test-integration: vllm-sr-build vllm-sr-envoy-build vllm-sr-dashboard-bui
 	VLLM_SR_ROUTER_IMAGE=$(VLLM_SR_ROUTER_IMAGE) \
 	VLLM_SR_ENVOY_IMAGE=$(VLLM_SR_ENVOY_IMAGE) \
 	VLLM_SR_DASHBOARD_IMAGE=$(VLLM_SR_DASHBOARD_IMAGE) \
+	VLLM_SR_STACK_NAME="$${VLLM_SR_STACK_NAME:-}" \
+	VLLM_SR_PORT_OFFSET="$${VLLM_SR_PORT_OFFSET:-}" \
+	VLLM_SR_RUN_ID="$${VLLM_SR_RUN_ID:-}" \
 	PATH="$(AGENT_VENV)/bin:$$PATH" \
 	bash e2e/testing/run_memory_integration.sh

--- a/tools/make/milvus.mk
+++ b/tools/make/milvus.mk
@@ -5,12 +5,14 @@
 ##@ Milvus
 
 MILVUS_CONTAINER_NAME ?= milvus-semantic-cache
+MILVUS_BIND_HOST ?=
 MILVUS_PORT ?= 19530
 MILVUS_HEALTH_PORT ?= 9091
 MILVUS_DATA_DIR ?= /tmp/milvus-data
 MILVUS_STACK_NAME ?=
 MILVUS_RUN_ID ?=
 MILVUS_LABEL_ARGS = $(if $(MILVUS_STACK_NAME),--label com.vllm.semantic-router.managed=true --label com.vllm.semantic-router.stack=$(MILVUS_STACK_NAME) $(if $(MILVUS_RUN_ID),--label com.vllm.semantic-router.run=$(MILVUS_RUN_ID),),)
+MILVUS_PUBLISH_HOST = $(if $(MILVUS_BIND_HOST),$(MILVUS_BIND_HOST):,)
 
 # Milvus container management
 start-milvus: ## Start Milvus container for testing
@@ -25,8 +27,8 @@ start-milvus: ## Start Milvus container for testing
 		-e ETCD_CONFIG_PATH=/milvus/configs/advanced/etcd.yaml \
 		-e COMMON_STORAGETYPE=local \
 		-e CLUSTER_ENABLED=false \
-		-p 127.0.0.1:$(MILVUS_PORT):19530 \
-		-p 127.0.0.1:$(MILVUS_HEALTH_PORT):9091 \
+		-p $(MILVUS_PUBLISH_HOST)$(MILVUS_PORT):19530 \
+		-p $(MILVUS_PUBLISH_HOST)$(MILVUS_HEALTH_PORT):9091 \
 		-v "$(MILVUS_DATA_DIR):/var/lib/milvus:z" \
 		milvusdb/milvus:v2.3.3 \
 		milvus run standalone

--- a/tools/make/milvus.mk
+++ b/tools/make/milvus.mk
@@ -15,7 +15,7 @@ MILVUS_LABEL_ARGS = $(if $(MILVUS_STACK_NAME),--label com.vllm.semantic-router.m
 # Milvus container management
 start-milvus: ## Start Milvus container for testing
 	@$(LOG_TARGET)
-	@mkdir -p $(MILVUS_DATA_DIR)
+	@mkdir -p "$(MILVUS_DATA_DIR)"
 	@$(CONTAINER_RUNTIME) run -d \
 		--name $(MILVUS_CONTAINER_NAME) \
 		$(MILVUS_LABEL_ARGS) \
@@ -27,7 +27,7 @@ start-milvus: ## Start Milvus container for testing
 		-e CLUSTER_ENABLED=false \
 		-p 127.0.0.1:$(MILVUS_PORT):19530 \
 		-p 127.0.0.1:$(MILVUS_HEALTH_PORT):9091 \
-		-v $(MILVUS_DATA_DIR):/var/lib/milvus:z \
+		-v "$(MILVUS_DATA_DIR):/var/lib/milvus:z" \
 		milvusdb/milvus:v2.3.3 \
 		milvus run standalone
 	@echo "Waiting for Milvus to be ready (up to 120s)..."
@@ -66,7 +66,7 @@ stop-milvus: ## Stop and remove Milvus container
 		$(CONTAINER_RUNTIME) stop $(MILVUS_CONTAINER_NAME) || true; \
 		$(CONTAINER_RUNTIME) rm $(MILVUS_CONTAINER_NAME) || true; \
 	fi
-	@rm -rf $(MILVUS_DATA_DIR) 2>/dev/null || sudo -n rm -rf $(MILVUS_DATA_DIR) || true
+	@rm -rf "$(MILVUS_DATA_DIR)" 2>/dev/null || sudo -n rm -rf "$(MILVUS_DATA_DIR)" || true
 	@echo "Milvus container stopped and removed"
 
 restart-milvus: stop-milvus start-milvus ## Restart Milvus container

--- a/tools/make/milvus.mk
+++ b/tools/make/milvus.mk
@@ -4,33 +4,42 @@
 
 ##@ Milvus
 
+MILVUS_CONTAINER_NAME ?= milvus-semantic-cache
+MILVUS_PORT ?= 19530
+MILVUS_HEALTH_PORT ?= 9091
+MILVUS_DATA_DIR ?= /tmp/milvus-data
+MILVUS_STACK_NAME ?=
+MILVUS_RUN_ID ?=
+MILVUS_LABEL_ARGS = $(if $(MILVUS_STACK_NAME),--label com.vllm.semantic-router.managed=true --label com.vllm.semantic-router.stack=$(MILVUS_STACK_NAME) $(if $(MILVUS_RUN_ID),--label com.vllm.semantic-router.run=$(MILVUS_RUN_ID),),)
+
 # Milvus container management
 start-milvus: ## Start Milvus container for testing
 	@$(LOG_TARGET)
-	@mkdir -p /tmp/milvus-data
+	@mkdir -p $(MILVUS_DATA_DIR)
 	@$(CONTAINER_RUNTIME) run -d \
-		--name milvus-semantic-cache \
+		--name $(MILVUS_CONTAINER_NAME) \
+		$(MILVUS_LABEL_ARGS) \
 		--security-opt seccomp:unconfined \
 		-e ETCD_USE_EMBED=true \
 		-e ETCD_DATA_DIR=/var/lib/milvus/etcd \
 		-e ETCD_CONFIG_PATH=/milvus/configs/advanced/etcd.yaml \
 		-e COMMON_STORAGETYPE=local \
 		-e CLUSTER_ENABLED=false \
-		-p 19530:19530 \
-		-p 9091:9091 \
-		-v /tmp/milvus-data:/var/lib/milvus:z \
+		-p 127.0.0.1:$(MILVUS_PORT):19530 \
+		-p 127.0.0.1:$(MILVUS_HEALTH_PORT):9091 \
+		-v $(MILVUS_DATA_DIR):/var/lib/milvus:z \
 		milvusdb/milvus:v2.3.3 \
 		milvus run standalone
 	@echo "Waiting for Milvus to be ready (up to 120s)..."
 	@elapsed=0; \
 	while [ $$elapsed -lt 120 ]; do \
-		if curl -sf http://localhost:9091/healthz >/dev/null 2>&1; then \
+		if curl -sf http://localhost:$(MILVUS_HEALTH_PORT)/healthz >/dev/null 2>&1; then \
 			echo "Milvus healthy after $${elapsed}s"; \
 			break; \
 		fi; \
-		if ! $(CONTAINER_RUNTIME) ps --filter "name=milvus-semantic-cache" --format '{{.Names}}' | grep -q milvus-semantic-cache; then \
+		if ! $(CONTAINER_RUNTIME) ps --filter "name=$(MILVUS_CONTAINER_NAME)" --format '{{.Names}}' | grep -q '^$(MILVUS_CONTAINER_NAME)$$'; then \
 			echo "ERROR: Milvus container exited unexpectedly"; \
-			$(CONTAINER_RUNTIME) logs milvus-semantic-cache 2>&1 | tail -20 || true; \
+			$(CONTAINER_RUNTIME) logs $(MILVUS_CONTAINER_NAME) 2>&1 | tail -20 || true; \
 			exit 1; \
 		fi; \
 		sleep 5; \
@@ -39,25 +48,34 @@ start-milvus: ## Start Milvus container for testing
 	done; \
 	if [ $$elapsed -ge 120 ]; then \
 		echo "ERROR: Milvus did not become healthy within 120s"; \
-		$(CONTAINER_RUNTIME) logs milvus-semantic-cache 2>&1 | tail -30 || true; \
+		$(CONTAINER_RUNTIME) logs $(MILVUS_CONTAINER_NAME) 2>&1 | tail -30 || true; \
 		exit 1; \
 	fi
-	@echo "Milvus available at localhost:19530"
+	@echo "Milvus available at localhost:$(MILVUS_PORT)"
 
 stop-milvus: ## Stop and remove Milvus container
 	@$(LOG_TARGET)
-	@$(CONTAINER_RUNTIME) stop milvus-semantic-cache || true
-	@$(CONTAINER_RUNTIME) rm milvus-semantic-cache || true
-	@rm -rf /tmp/milvus-data 2>/dev/null || sudo -n rm -rf /tmp/milvus-data || true
+	@if $(CONTAINER_RUNTIME) inspect $(MILVUS_CONTAINER_NAME) >/dev/null 2>&1; then \
+		if [ -n "$(MILVUS_STACK_NAME)" ]; then \
+			LABELS="$$($(CONTAINER_RUNTIME) inspect --format '{{json .Config.Labels}}' $(MILVUS_CONTAINER_NAME) 2>/dev/null || true)"; \
+			if ! echo "$$LABELS" | grep -Fq '"com.vllm.semantic-router.managed":"true"' || ! echo "$$LABELS" | grep -Fq '"com.vllm.semantic-router.stack":"$(MILVUS_STACK_NAME)"' || { [ -n "$(MILVUS_RUN_ID)" ] && ! echo "$$LABELS" | grep -Fq '"com.vllm.semantic-router.run":"$(MILVUS_RUN_ID)"'; }; then \
+				echo "Refusing to remove $(MILVUS_CONTAINER_NAME): ownership labels do not match" >&2; \
+				exit 1; \
+			fi; \
+		fi; \
+		$(CONTAINER_RUNTIME) stop $(MILVUS_CONTAINER_NAME) || true; \
+		$(CONTAINER_RUNTIME) rm $(MILVUS_CONTAINER_NAME) || true; \
+	fi
+	@rm -rf $(MILVUS_DATA_DIR) 2>/dev/null || sudo -n rm -rf $(MILVUS_DATA_DIR) || true
 	@echo "Milvus container stopped and removed"
 
 restart-milvus: stop-milvus start-milvus ## Restart Milvus container
 
 milvus-status: ## Show status of Milvus container
 	@$(LOG_TARGET)
-	@if $(CONTAINER_RUNTIME) ps --filter "name=milvus-semantic-cache" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | grep -q milvus-semantic-cache; then \
+	@if $(CONTAINER_RUNTIME) ps --filter "name=$(MILVUS_CONTAINER_NAME)" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | grep -q $(MILVUS_CONTAINER_NAME); then \
 		echo "Milvus container is running:"; \
-		$(CONTAINER_RUNTIME) ps --filter "name=milvus-semantic-cache" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"; \
+		$(CONTAINER_RUNTIME) ps --filter "name=$(MILVUS_CONTAINER_NAME)" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"; \
 	else \
 		echo "Milvus container is not running"; \
 		echo "Run 'make start-milvus' to start it"; \


### PR DESCRIPTION
Related to #2487.

## Current slice

- give each memory integration invocation a stack, run ID, and port offset
- derive its Milvus container, llm-katan container, network, host ports, and test data path from that identity
- label auxiliary containers and networks with their stack/run ownership
- require exact ownership labels before cleanup removes those resources
- quote configurable Milvus data paths so workspaces containing spaces remain valid Docker mount arguments
- keep the existing `start-milvus` / `stop-milvus` names, ports, data path, and all-interface port exposure for callers outside this harness; the isolated memory harness opts into loopback binding

## Feedback and follow-up plan

For this draft, feedback is requested on the stack/run label contract, derived fixture names, and Make interface. If that direction is accepted, the remaining migration will be split into reviewable follow-up PRs:

- **CLI integration fixture**
  - pass a unique stack name, run ID, and port offset through `vllm-sr-test-integration` and its test base
  - derive test-only container, network, temporary-state, and artifact names from that identity
  - add interrupted-run and two-concurrent-stack regressions proving one fixture cannot clean up the other
- **General CLI runtime lifecycle**
  - centralize ownership-label creation and inspection
  - label CLI-managed router, Envoy, dashboard, observability, storage, application-network, and data-network resources
  - require exact managed/stack/run ownership before replacement, stop, removal, or rollback cleanup
  - fail closed on missing or mismatched ownership while preserving the existing default-stack naming contract
- **Local agent workflows**
  - propagate agent stack, run, and port identities consistently through `agent-dev`, `agent-serve-local`, `agent-smoke-local`, and `agent-stop-local`
  - namespace state, logs, generated configuration, and rollback artifacts per run
  - exercise two concurrent local-agent lanes and interrupted startup cleanup
- **Closeout**
  - update the shared-host documentation and end-to-end coverage for the final contract
  - close #2487 only after the follow-up slices are accepted and complete

## Test result

Passed locally:

- `make agent-validate`
- `make vllm-sr-test`: 40 executed, 9 integration-only skipped, 0 failures/errors
- `pytest -q src/vllm-sr/tests/test_local_dev_make_surface.py`: 9 passed
- `make agent-lint SKIP=shellcheck AGENT_BASE_REF=origin/main`
  - Black, Ruff, Markdown formatting, structure/architecture checks, and the supply-chain AST scan passed
  - shellcheck was skipped because it is not installed on this host
- `bash -n e2e/testing/run_memory_integration.sh`
- dry-run expansion of `start-milvus` confirmed the legacy all-interface ports and the harness-specific loopback/offset ports
- `git diff --check`
- default Milvus compatibility smoke: `start-milvus`, status, HTTP health, published-port inspection, and `stop-milvus` all passed
  - legacy ports remained `0.0.0.0/[::]:19530` and `0.0.0.0/[::]:9091`
- full `memory-test-integration` on Docker Engine 29.5.2, ARM64 via Colima, using deterministic embeddings
  - stack `pr3446-memory-e2e`, run `pr3446-local-4`, port offset `12000`
  - Milvus HTTP health and pymilvus gRPC readiness passed
  - Milvus used `127.0.0.1:31530` and `127.0.0.1:21091`; router health/API used the corresponding offset ports
  - live inspection confirmed exact `managed=true`, stack, and run labels on Milvus, llm-katan, and the fixture network
  - 15 memory storage, retrieval, isolation, content-integrity, plugin-combination, and per-decision tests passed; 0 failures/errors
  - teardown removed all scoped containers, networks, and data; the pre-existing Kind cluster remained running

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The PR links an `accepted` issue with exactly one recognized owner (`xuuuge`, `wg/evaluation-quality`)
- [x] Every commit is signed off with `git commit -s`
- [x] Purpose, scope, follow-up plan, and test results match this five-file slice

</details>