### PR TITLE
[Bug] Sanitize Postgres-hostile text in Router Replay writes

### DIFF
--- a/src/semantic-router/pkg/routerreplay/store/postgres.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres.go
@@ -375,6 +375,7 @@ func (p *PostgresStore) UpdateLifecycle(
 		return err
 	}
 	defer release()
+	reason = sanitizePostgresText(reason)
 	//nolint:gosec // tableName is validated during store creation
 	query := fmt.Sprintf(`
 		UPDATE %s
@@ -410,6 +411,7 @@ func (p *PostgresStore) AttachRequest(ctx context.Context, id string, body strin
 		return err
 	}
 	defer release()
+	body = sanitizePostgresText(body)
 	//nolint:gosec // tableName is validated during store creation
 	query := fmt.Sprintf(`
 		UPDATE %s
@@ -449,6 +451,7 @@ func (p *PostgresStore) AttachResponse(ctx context.Context, id string, body stri
 		return err
 	}
 	defer release()
+	body = sanitizePostgresText(body)
 	//nolint:gosec // tableName is validated during store creation
 	query := fmt.Sprintf(`
 		UPDATE %s

--- a/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_record_row.go
@@ -118,7 +118,7 @@ func marshalPostgresInsertJSON(record Record, out *postgresInsertRecord) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal %s: %w", field.name, err)
 		}
-		*field.target = encoded
+		*field.target = sanitizePostgresJSON(encoded)
 	}
 	return nil
 }
@@ -137,6 +137,11 @@ func preparePostgresInsertRecord(record Record) (Record, error) {
 	if record.LifecycleState == "" {
 		record.LifecycleState = LifecycleInProgress
 	}
+	record.RequestBody = sanitizePostgresText(record.RequestBody)
+	record.ResponseBody = sanitizePostgresText(record.ResponseBody)
+	record.Prompt = sanitizePostgresText(record.Prompt)
+	record.ToolDefinitions = sanitizePostgresText(record.ToolDefinitions)
+	record.TerminalReason = sanitizePostgresText(record.TerminalReason)
 	return record, nil
 }
 

--- a/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize.go
@@ -26,6 +26,13 @@ func sanitizePostgresText(s string) string {
 // "unsupported Unicode escape sequence". json.Marshal already replaces invalid
 // UTF-8 with the replacement character, so \u0000 is the only jsonb-hostile
 // artifact left.
+//
+// Only a \u0000 that is itself a JSON escape (an odd number of backslashes
+// precedes it) encodes an actual NUL byte and is removed. A literal string
+// value containing the text "\u0000" marshals with an escaped backslash
+// (\\u0000, an even run), so the match falls on an escaped backslash and must
+// be preserved — stripping it there would leave a dangling backslash and
+// corrupt the JSON.
 func sanitizePostgresJSON(b []byte) []byte {
 	if len(b) == 0 {
 		return b
@@ -34,5 +41,22 @@ func sanitizePostgresJSON(b []byte) []byte {
 	if !bytes.Contains(b, nul) {
 		return b
 	}
-	return bytes.ReplaceAll(b, nul, nil)
+	out := make([]byte, 0, len(b))
+	for i := 0; i < len(b); {
+		if bytes.HasPrefix(b[i:], nul) {
+			// Count the backslashes already emitted directly before this one.
+			backslashes := 0
+			for j := len(out) - 1; j >= 0 && out[j] == '\\'; j-- {
+				backslashes++
+			}
+			if backslashes%2 == 0 {
+				// Real escaped NUL: drop the whole \u0000 sequence.
+				i += len(nul)
+				continue
+			}
+		}
+		out = append(out, b[i])
+		i++
+	}
+	return out
 }

--- a/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize.go
@@ -1,0 +1,38 @@
+package store
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// sanitizePostgresText makes a string safe for a Postgres text column. Postgres
+// cannot store NUL bytes and rejects invalid UTF-8 byte sequences, so a replay
+// body carrying either (for example PDF-derived text) fails at insert time and
+// the record is lost. NUL bytes are dropped and invalid UTF-8 is replaced with
+// the Unicode replacement character; the remaining content is preserved.
+func sanitizePostgresText(s string) string {
+	if s == "" {
+		return s
+	}
+	if !strings.ContainsRune(s, 0) && utf8.ValidString(s) {
+		return s
+	}
+	return strings.ToValidUTF8(strings.ReplaceAll(s, "\x00", ""), "\uFFFD")
+}
+
+// sanitizePostgresJSON removes NUL escape sequences from marshaled JSON before
+// it is bound to a Postgres jsonb column, which rejects \u0000 with
+// "unsupported Unicode escape sequence". json.Marshal already replaces invalid
+// UTF-8 with the replacement character, so \u0000 is the only jsonb-hostile
+// artifact left.
+func sanitizePostgresJSON(b []byte) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	nul := []byte(`\u0000`)
+	if !bytes.Contains(b, nul) {
+		return b
+	}
+	return bytes.ReplaceAll(b, nul, nil)
+}

--- a/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -49,6 +50,44 @@ func TestSanitizePostgresJSONRemovesNULEscape(t *testing.T) {
 	}
 	if want := []byte(`{"k":"ab"}`); !bytes.Equal(got, want) {
 		t.Fatalf("sanitizePostgresJSON = %q, want %q", got, want)
+	}
+}
+
+// TestSanitizePostgresJSONPreservesLiteralEscape guards the case where a valid
+// replay value's text literally contains the six characters \u0000. json.Marshal
+// escapes the backslash, so the encoded bytes hold \\u0000 (an even backslash
+// run) — that match is an escaped backslash, not a NUL escape, and must be kept.
+// A blind replace would delete the second backslash, leave the first escaping
+// the closing quote, and produce JSON that PostgreSQL rejects. A real NUL byte
+// still marshals to \u0000 (an odd backslash run) and must be dropped.
+func TestSanitizePostgresJSONPreservesLiteralEscape(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want string // decoded value expected back after sanitize + Unmarshal
+	}{
+		{"literal backslash-u0000 preserved", `abc\u0000def`, `abc\u0000def`},
+		{"real nul stripped", "a\x00b", "ab"},
+		{"real nul next to literal escape", "a\x00b\\u0000c", `ab\u0000c`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(map[string]string{"k": tc.val})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := sanitizePostgresJSON(encoded)
+			var back map[string]string
+			if err := json.Unmarshal(got, &back); err != nil {
+				t.Fatalf("sanitized JSON is invalid: %v (in=%q got=%q)", err, encoded, got)
+			}
+			if back["k"] != tc.want {
+				t.Fatalf("value corrupted: got %q, want %q (sanitized=%q)", back["k"], tc.want, got)
+			}
+			if bytes.Contains(got, []byte("\\u0000\\u0000")) {
+				t.Fatalf("unexpected doubled escape: %q", got)
+			}
+		})
 	}
 }
 

--- a/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/postgres_text_sanitize_test.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSanitizePostgresTextStripsNULAndInvalidUTF8(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii unchanged", "hello world", "hello world"},
+		{"valid multibyte unchanged", "héllo — 世界", "héllo — 世界"},
+		{"empty unchanged", "", ""},
+		{"nul byte dropped", "a\x00b", "ab"},
+		{"truncated utf8 replaced", "x\xef\xbfy", "x\uFFFDy"},
+		{"lone continuation replaced", "a\x80b", "a\uFFFDb"},
+		{"nul and invalid combined", "p\x00q\xffr", "pq\uFFFDr"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizePostgresText(tc.in)
+			if got != tc.want {
+				t.Fatalf("sanitizePostgresText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.ContainsRune(got, 0) {
+				t.Fatalf("sanitized text still contains a NUL byte: %q", got)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("sanitized text is not valid UTF-8: %q", got)
+			}
+		})
+	}
+}
+
+func TestSanitizePostgresJSONRemovesNULEscape(t *testing.T) {
+	clean := []byte(`{"k":"value"}`)
+	if got := sanitizePostgresJSON(clean); !bytes.Equal(got, clean) {
+		t.Fatalf("clean JSON altered: got %q want %q", got, clean)
+	}
+	dirty := []byte(`{"k":"a\u0000b"}`)
+	got := sanitizePostgresJSON(dirty)
+	if bytes.Contains(got, []byte(`\u0000`)) {
+		t.Fatalf("sanitized JSON still contains a NUL escape: %q", got)
+	}
+	if want := []byte(`{"k":"ab"}`); !bytes.Equal(got, want) {
+		t.Fatalf("sanitizePostgresJSON = %q, want %q", got, want)
+	}
+}
+
+// TestPostgresInsertRecordSanitizesUntrustedText proves the store boundary no
+// longer forwards Postgres-hostile bytes. A record whose body carries a NUL
+// byte or truncated UTF-8 (as PDF-derived text does) previously failed at
+// insert with "invalid byte sequence for encoding UTF8" / "unsupported Unicode
+// escape sequence" and was silently dropped; after preparation the bound
+// arguments are safe to store.
+func TestPostgresInsertRecordSanitizesUntrustedText(t *testing.T) {
+	built, err := newPostgresInsertRecord(Record{
+		RequestBody:  "prompt\x00tail",
+		ResponseBody: "resp\xef\xbfbody",
+		SessionPolicy: map[string]interface{}{
+			"note": "policy\x00value",
+		},
+	})
+	if err != nil {
+		t.Fatalf("newPostgresInsertRecord returned error: %v", err)
+	}
+
+	if got := built.record.RequestBody; strings.ContainsRune(got, 0) {
+		t.Fatalf("request body still contains a NUL byte: %q", got)
+	}
+	if got := built.record.ResponseBody; !utf8.ValidString(got) {
+		t.Fatalf("response body is not valid UTF-8: %q", got)
+	}
+	if bytes.Contains(built.sessionPolicyJSON, []byte(`\u0000`)) {
+		t.Fatalf("session policy JSON still contains a NUL escape: %q", built.sessionPolicyJSON)
+	}
+}


### PR DESCRIPTION
Closes #3427

## Purpose

Router Replay wrote request/response content into Postgres without normalizing
text that Postgres cannot store. A replay record containing a NUL byte or
invalid UTF-8 (as PDF-derived text carries) failed at insert time while the
routed completion still succeeded, so the row was silently absent from
`router_replay_records`:

```
error: failed to insert record: pq: unsupported Unicode escape sequence
error: failed to insert record: pq: invalid byte sequence for encoding "UTF8": 0xef 0xbf
```

This sanitizes untrusted text at the Postgres store boundary (owned by
wg/enterprise-environment, the accepted issue):

- text columns (`request_body`, `response_body`, `prompt`, `tool_definitions`,
  `terminal_reason`): drop NUL bytes and replace invalid UTF-8 with the Unicode
  replacement character via `strings.ToValidUTF8`, preserving the rest.
- jsonb columns: strip `\u0000` escapes from the marshaled JSON, which Postgres
  rejects with "unsupported Unicode escape sequence" (`json.Marshal` already
  replaces invalid UTF-8, so `\u0000` is the only jsonb-hostile artifact left).

Applied in `preparePostgresInsertRecord`/`marshalPostgresInsertJSON` (the `Add`
path) and in the incremental `AttachRequest`/`AttachResponse`/`UpdateLifecycle`
writers. Clean input is returned unchanged.

## Test Plan

```
cd src/semantic-router
go test ./pkg/routerreplay/store/
go test ./pkg/routerreplay/store/ -run 'Sanitize|InsertRecordSanitizes' -v
```

RED→GREEN: reverting the sanitizers to identity makes the new tests fail
(`sanitizePostgresText("a\x00b") = "a\x00b", want "ab"`; `request body still
contains a NUL byte`); restoring passes.

## Test Result

```
ok  github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store  0.432s
```

New tests pass; full `store` package suite green; `go build`, `go vet`, and
`gofmt -l` clean on the touched files. Not run: a live-Postgres integration
insert (no Postgres in this environment) — the fix is verified at the store
boundary where the bad bytes are prepared for binding.

Happy to adjust naming or scope.

---

🤖 Generated with assistance from an AI coding tool; authored, reviewed, and
verified by me.
