### PR TITLE
[Docs] Link the Slack channel and community dashboard from the README Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ More announcements are available on the **[Blog](https://vllm-sr.ai/blog/)** and
 
 ## Community
 
-For questions, feedback, or to contribute, please join the `#semantic-router` channel in vLLM Slack.
+For questions, feedback, or to contribute, please join the [`#semantic-router`](https://vllm-dev.slack.com/archives/C09CTGF8KCN) channel in vLLM Slack.
+
+To track contributors, workgroups, and weekly activity, visit [community.vllm-sr.ai](https://community.vllm-sr.ai).
 
 ### Community Meetings
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Closes #3439

## Purpose

The README `## Community` section named the `#semantic-router` Slack channel as plain text and did not mention the community dashboard.

This PR makes `#semantic-router` a link to `https://vllm-dev.slack.com/archives/C09CTGF8KCN` (the same URL already used in the header badge) and adds one sentence linking [community.vllm-sr.ai](https://community.vllm-sr.ai) for contributors, workgroups, and weekly activity. No other content changes.

## Test Plan

- Render the diff and confirm both links resolve.
- `markdownlint README.md` on the touched lines.

## Test Result

- `curl -L https://community.vllm-sr.ai` returns 200. The Slack URL redirects to the vllm-dev workspace sign-in with the channel preserved, which is Slack's behaviour for an anonymous request, and matches the URL already used at `README.md:13`.
- markdownlint reports no findings on lines 82 to 84. The three pre-existing MD033 inline-HTML findings at lines 127 to 129 are untouched by this change.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.

