### PR TITLE
[Bug] Refuse to write FP32 weights under an fp16 name in the CK graph rewrite

### DIFF
--- a/onnx-binding/ort-ck-flash-attn/README.md
+++ b/onnx-binding/ort-ck-flash-attn/README.md
@@ -42,6 +42,22 @@ python3 scripts/rewrite_graph.py \
 Use `--hdim` and `--local-attention` only when they match the source model's
 architecture. Keep the original SDPA model for correctness comparison.
 
+The input decides the output precision. The rewriter keeps the weights as it
+finds them and, for an FP32 graph, adds fp32↔fp16 casts around each
+`CKFlashAttention` node. A rewrite of the FP32 `model.onnx` must therefore be
+named `model_fa.onnx`; `model_fa_fp16.onnx` needs an FP16 input graph. The
+script refuses an fp16 name for an FP32 graph, because `find_onnx_models`
+ranks candidates by name alone.
+
+The matcher expects the attention subgraph of the FP32 `model.onnx` export:
+`Softmax` fed by `Add(MatMul(Mul(q), Mul(k)), mask)` and consumed directly by
+the AV `MatMul`. The published `model_sdpa_fp16.onnx` graphs differ (a NaN
+guard of `IsNaN` and `Where` between `Softmax` and the AV `MatMul`, or the
+scale applied after the QK `MatMul`) and are reported as
+`No attention blocks found`, so an FP16 FA artifact cannot be produced from
+them until the matcher covers that shape
+(vllm-project/semantic-router#3256).
+
 ## Load the custom op
 
 The Semantic Router ONNX binding reads `ORT_CK_FLASH_ATTN_LIB`:

--- a/onnx-binding/ort-ck-flash-attn/README.md
+++ b/onnx-binding/ort-ck-flash-attn/README.md
@@ -42,8 +42,8 @@ python3 scripts/rewrite_graph.py \
 Use `--hdim` and `--local-attention` only when they match the source model's
 architecture. Keep the original SDPA model for correctness comparison.
 
-The input decides the output precision. The rewriter keeps the weights as it
-finds them and, for an FP32 graph, adds fp32↔fp16 casts around each
+The input decides the output precision, read from its weight tensors. The
+rewriter keeps the weights as it finds them and, for an FP32 graph, adds fp32↔fp16 casts around each
 `CKFlashAttention` node. A rewrite of the FP32 `model.onnx` must therefore be
 named `model_fa.onnx`; `model_fa_fp16.onnx` needs an FP16 input graph. The
 script refuses an fp16 name for an FP32 graph, because `find_onnx_models`

--- a/onnx-binding/ort-ck-flash-attn/README.md
+++ b/onnx-binding/ort-ck-flash-attn/README.md
@@ -47,7 +47,9 @@ rewriter keeps the weights as it finds them and, for an FP32 graph, adds fp32↔
 `CKFlashAttention` node. A rewrite of the FP32 `model.onnx` must therefore be
 named `model_fa.onnx`; `model_fa_fp16.onnx` needs an FP16 input graph. The
 script refuses an fp16 name for an FP32 graph, because `find_onnx_models`
-ranks candidates by name alone.
+ranks candidates by name alone. `make ck-rewrite-test` runs the rewriter's
+unit tests (`scripts/test_rewrite_graph.py`); the changed-file gate runs them
+for any change under this directory.
 
 The matcher expects the attention subgraph of the FP32 `model.onnx` export:
 `Softmax` fed by `Add(MatMul(Mul(q), Mul(k)), mask)` and consumed directly by

--- a/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
@@ -296,6 +296,43 @@ def create_1d_padding_bias_nodes(graph):
     return nodes, unsqueeze_out
 
 
+def weight_precision(initializers):
+    """Return the one floating-point elem_type every weight tensor shares.
+
+    Integer initializers (shapes, gather indices) carry no precision and are
+    ignored. A graph with no floating-point weights, with more than one
+    floating-point precision, or with a precision the CK kernel does not take
+    (only FLOAT and FLOAT16 are) is refused, since neither name would describe
+    it.
+    """
+    counts = {}
+    for tensor in initializers:
+        if tensor.data_type in _FLOAT_TYPES:
+            counts[tensor.data_type] = counts.get(tensor.data_type, 0) + 1
+    if not counts:
+        raise ValueError("the graph holds no floating-point weight tensors")
+    if len(counts) > 1:
+        found = ", ".join(
+            f"{n} {TensorProto.DataType.Name(t)}" for t, n in sorted(counts.items())
+        )
+        raise ValueError(f"the graph mixes weight precisions: {found}")
+    (elem_type,) = counts
+    if elem_type not in (TensorProto.FLOAT, TensorProto.FLOAT16):
+        raise ValueError(
+            f"the graph holds {TensorProto.DataType.Name(elem_type)} weights; "
+            "CKFlashAttention takes FLOAT or FLOAT16"
+        )
+    return elem_type
+
+
+_FLOAT_TYPES = (
+    TensorProto.FLOAT,
+    TensorProto.FLOAT16,
+    TensorProto.BFLOAT16,
+    TensorProto.DOUBLE,
+)
+
+
 def output_precision_conflict(output_path, model_is_fp16):
     """Return a message when the output name claims a precision the graph lacks.
 
@@ -372,15 +409,14 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
     # Create 1-D padding bias nodes
     pad_bias_nodes, pad_bias_tensor = create_1d_padding_bias_nodes(graph)
 
-    # Build value_info type map for precision detection
-    vi_type_map = {}
-    for vi in graph.value_info:
-        if vi.type.HasField("tensor_type"):
-            vi_type_map[vi.name] = vi.type.tensor_type.elem_type
-
-    # Detect model precision from Q tensor of first block
-    first_q = blocks[0]["q_tensor"]
-    model_is_fp16 = vi_type_map.get(first_q) == TensorProto.FLOAT16
+    # Detect model precision from the weights themselves. value_info is
+    # optional and describes activations, so a valid FP16 export that carries
+    # none would read as FP32, and one activation cannot vouch for every weight.
+    try:
+        model_is_fp16 = weight_precision(graph.initializer) == TensorProto.FLOAT16
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
     if model_is_fp16:
         print("  Model precision: FP16 (skipping input/output Cast nodes)")
     else:

--- a/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
@@ -32,7 +32,7 @@ def build_maps(graph):
     return out2node, name2node
 
 
-def find_attention_blocks(graph, out2node):
+def find_attention_blocks(graph, out2node):  # noqa: C901,PLR0912
     blocks = []
     softmaxes = [n for n in graph.node if n.op_type == "Softmax"]
 
@@ -151,7 +151,7 @@ def classify_mask(mask_tensor_name, local_mask_name=None):
     return "unknown"
 
 
-def find_mask_only_nodes(graph, out2node):
+def find_mask_only_nodes(graph, out2node):  # noqa: C901
     """Find nodes that are exclusively part of the 2-D mask computation."""
     mask_roots = set()
     for n in graph.node:
@@ -179,7 +179,6 @@ def find_mask_only_nodes(graph, out2node):
                 trace_back(inp)
     ancestors.update(mask_roots)
 
-    all_node_names = {n.name for n in graph.node}
     mask_only = set()
     for name in ancestors:
         node = next((n for n in graph.node if n.name == name), None)
@@ -331,11 +330,13 @@ def enforce_output_precision(output_path, model_is_fp16):
         )
 
 
-def rewrite(model_path, output_path, hdim=64, local_attention=128):
+def rewrite(  # noqa: C901,PLR0912,PLR0915
+    model_path, output_path, hdim=64, local_attention=128
+):
     model = onnx.load(model_path)
     graph = model.graph
 
-    out2node, name2node = build_maps(graph)
+    out2node, _name2node = build_maps(graph)
     blocks = find_attention_blocks(graph, out2node)
 
     if not blocks:
@@ -392,7 +393,6 @@ def rewrite(model_path, output_path, hdim=64, local_attention=128):
     new_nodes = []
 
     for i, blk in enumerate(blocks):
-        layer_name = blk["softmax"].name.rsplit("/", 1)[0]
         mask_type = classify_mask(blk["mask_tensor"], local_mask_name)
 
         for key in (

--- a/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
@@ -297,6 +297,40 @@ def create_1d_padding_bias_nodes(graph):
     return nodes, unsqueeze_out
 
 
+def output_precision_conflict(output_path, model_is_fp16):
+    """Return a message when the output name claims a precision the graph lacks.
+
+    find_onnx_models ranks candidates by filename and puts model_fa_fp16.onnx
+    first whenever CK Flash Attention is available, so the name is a contract
+    rather than a label. The rewriter keeps the weights as it finds them and,
+    for an FP32 graph, only casts around each CKFlashAttention node. Running it
+    on model.onnx under an fp16 name is what produced the FP32
+    model_fa_fp16.onnx in five of the six published 32K heads (#3256): a valid
+    graph with twice the memory of the file its name promises.
+    """
+    name = os.path.basename(output_path).lower()
+    if "fp16" in name and not model_is_fp16:
+        return (
+            f"{output_path}: the input graph holds FP32 weights, so this file would "
+            "hold FP32 weights under an fp16 name. Name an FP32 rewrite "
+            "model_fa.onnx; an fp16 name needs an FP16 input graph."
+        )
+    return None
+
+
+def enforce_output_precision(output_path, model_is_fp16):
+    """Exit on an fp16 name over FP32 weights; warn on the reverse."""
+    conflict = output_precision_conflict(output_path, model_is_fp16)
+    if conflict:
+        print(f"error: {conflict}", file=sys.stderr)
+        sys.exit(1)
+    if model_is_fp16 and "fp16" not in os.path.basename(output_path).lower():
+        print(
+            f"warning: {output_path} will hold FP16 weights but its name does not "
+            "say so; find_onnx_models ranks FP16 candidates by name."
+        )
+
+
 def rewrite(model_path, output_path, hdim=64, local_attention=128):
     model = onnx.load(model_path)
     graph = model.graph
@@ -350,6 +384,8 @@ def rewrite(model_path, output_path, hdim=64, local_attention=128):
         print("  Model precision: FP16 (skipping input/output Cast nodes)")
     else:
         print("  Model precision: FP32 (adding fp32↔fp16 Cast nodes)")
+
+    enforce_output_precision(output_path, model_is_fp16)
 
     # Collect nodes to remove (attention subgraph)
     nodes_to_remove = set()

--- a/onnx-binding/ort-ck-flash-attn/scripts/test_rewrite_graph.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/test_rewrite_graph.py
@@ -7,7 +7,71 @@ Run from this directory with the rewriter's own dependencies installed:
 
 import unittest
 
-from rewrite_graph import output_precision_conflict
+import numpy as np
+from onnx import TensorProto, helper, numpy_helper
+from rewrite_graph import output_precision_conflict, weight_precision
+
+
+def graph_with_weights(*weights):
+    """A minimal graph whose only content is the given `(name, array)` weights.
+
+    No value_info is attached, the way an exporter that records no intermediate
+    tensor types leaves a graph.
+    """
+    initializers = [numpy_helper.from_array(a, name) for name, a in weights]
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1])
+    return helper.make_graph([], "weights", [x], [x], initializer=initializers)
+
+
+class WeightPrecision(unittest.TestCase):
+    def test_fp16_weights_read_as_fp16_without_value_info(self):
+        graph = graph_with_weights(
+            ("w1", np.zeros((2, 2), np.float16)),
+            ("w2", np.zeros((2,), np.float16)),
+            ("shape", np.array([1, 4], np.int64)),
+        )
+        self.assertEqual(weight_precision(graph.initializer), TensorProto.FLOAT16)
+        self.assertIsNone(
+            output_precision_conflict(
+                "out/model_fa_fp16.onnx",
+                weight_precision(graph.initializer) == TensorProto.FLOAT16,
+            )
+        )
+
+    def test_fp32_weights_read_as_fp32(self):
+        graph = graph_with_weights(
+            ("w1", np.zeros((2, 2), np.float32)),
+            ("shape", np.array([1, 4], np.int64)),
+        )
+        self.assertEqual(weight_precision(graph.initializer), TensorProto.FLOAT)
+        self.assertIsNotNone(
+            output_precision_conflict(
+                "out/model_fa_fp16.onnx",
+                weight_precision(graph.initializer) == TensorProto.FLOAT16,
+            )
+        )
+
+    def test_mixed_weights_are_refused(self):
+        graph = graph_with_weights(
+            ("w1", np.zeros((2, 2), np.float32)),
+            ("w2", np.zeros((2, 2), np.float32)),
+            ("w3", np.zeros((2,), np.float16)),
+        )
+        with self.assertRaises(ValueError) as refused:
+            weight_precision(graph.initializer)
+        self.assertIn("2 FLOAT", str(refused.exception))
+        self.assertIn("1 FLOAT16", str(refused.exception))
+
+    def test_graph_without_float_weights_is_refused(self):
+        graph = graph_with_weights(("shape", np.array([1, 4], np.int64)))
+        with self.assertRaises(ValueError):
+            weight_precision(graph.initializer)
+
+    def test_bfloat16_weights_are_refused(self):
+        tensor = helper.make_tensor("w", TensorProto.BFLOAT16, [1], [0])
+        with self.assertRaises(ValueError) as refused:
+            weight_precision([tensor])
+        self.assertIn("BFLOAT16", str(refused.exception))
 
 
 class OutputPrecisionConflict(unittest.TestCase):

--- a/onnx-binding/ort-ck-flash-attn/scripts/test_rewrite_graph.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/test_rewrite_graph.py
@@ -1,0 +1,42 @@
+"""Unit tests for rewrite_graph.py that need no model.
+
+Run from this directory with the rewriter's own dependencies installed:
+
+    python3 -m unittest test_rewrite_graph
+"""
+
+import unittest
+
+from rewrite_graph import output_precision_conflict
+
+
+class OutputPrecisionConflict(unittest.TestCase):
+    def test_fp32_graph_under_an_fp16_name_is_refused(self):
+        message = output_precision_conflict(
+            "out/model_fa_fp16.onnx", model_is_fp16=False
+        )
+        self.assertIsNotNone(message)
+        self.assertIn("FP32 weights under an fp16 name", message)
+        self.assertIn("model_fa.onnx", message)
+
+    def test_fp16_graph_under_an_fp16_name_passes(self):
+        self.assertIsNone(
+            output_precision_conflict("out/model_fa_fp16.onnx", model_is_fp16=True)
+        )
+
+    def test_fp32_graph_under_model_fa_passes(self):
+        self.assertIsNone(
+            output_precision_conflict("out/model_fa.onnx", model_is_fp16=False)
+        )
+
+    def test_name_check_ignores_case_and_directories(self):
+        self.assertIsNotNone(
+            output_precision_conflict("MODEL_FA_FP16.ONNX", model_is_fp16=False)
+        )
+        self.assertIsNone(
+            output_precision_conflict("fp16/model_fa.onnx", model_is_fp16=False)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/agent/task-matrix.yaml
+++ b/tools/agent/task-matrix.yaml
@@ -134,6 +134,16 @@ rules:
     feature_tests:
       - make test-binding-lora
     requires_local_smoke: false
+  - name: ck-flash-attn-rewriter
+    doc_only: false
+    loop_mode: completion
+    execution_plan_policy: long_horizon
+    paths:
+      - onnx-binding/ort-ck-flash-attn/**
+    fast_tests:
+      - make ck-rewrite-test
+    feature_tests: []
+    requires_local_smoke: false
   - name: dashboard
     doc_only: false
     loop_mode: completion

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -95,6 +95,18 @@ test-binding-minimal: $(if $(CI),rust-ci,rust) ## Run Go tests with minimal mode
 		cd candle-binding && CGO_ENABLED=1 go test -v -race \
 		-run "^Test(InitModel|Tokenization|Embeddings|Similarity|FindMostSimilar|ModernBERTClassifiers|ModernBertClassifier_ConcurrentClassificationSafety|ModernBERTPIITokenClassification|UtilityFunctions|ErrorHandling|Concurrency|MultiModalEmbeddingInit|MultiModalEncodeText|MultiModalInputValidation)$$"
 
+# The CK flash-attention graph rewriter is a Python script under onnx-binding;
+# its unit tests need onnx, which the agent venv does not carry by default.
+CK_REWRITE_SCRIPTS_DIR ?= onnx-binding/ort-ck-flash-attn/scripts
+CK_REWRITE_PYTHON_DEPS ?= onnx==1.22.0
+
+ck-rewrite-deps: agent-venv-install ## Install the CK graph rewriter test dependencies into the agent venv
+	@"$(AGENT_PYTHON)" -c "import onnx" 2>/dev/null || "$(AGENT_PYTHON)" -m pip install --quiet $(CK_REWRITE_PYTHON_DEPS)
+
+ck-rewrite-test: ck-rewrite-deps ## Run the CK flash-attention graph rewriter unit tests
+	@$(LOG_TARGET)
+	@cd $(CK_REWRITE_SCRIPTS_DIR) && "$(AGENT_PYTHON)" -m unittest test_rewrite_graph
+
 # Run every MULTIMODAL_MODEL_PATH-gated test against a local model copy:
 # the candle-binding Go tests (including the network-dependent image-encode
 # ones), the Go router integration tests in pkg/classification, and the


### PR DESCRIPTION
Related #3256

## Purpose

- `rewrite_graph.py` keeps the input's weight precision and only casts around each `CKFlashAttention` node, so running it on `model.onnx` with the output named `model_fa_fp16.onnx` writes FP32 weights under an fp16 name. That is how the five published files in #3256 were made: rewriting the feedback head's `model.onnx` reproduces its `model_fa_fp16.onnx` in size, op histogram and node names.
- Refuse an fp16 output name for an FP32 graph, with a message naming the fix (`model_fa.onnx`, or an FP16 input). Warn on the reverse.
- Read the precision from the initializers, not `value_info`: that field is optional and describes activations, so an FP16 export without it read as FP32 and one activation could not vouch for a mixed graph. Mixed, BFLOAT16 and no-float graphs are refused with the counts.
- Document the rule in the README, and that the published `model_sdpa_fp16.onnx` graphs are not matched by the rewriter (`No attention blocks found`), which is why `model.onnx` was used.
- Run `test_rewrite_graph.py` in CI. Nothing executed it before: the only task rule matching `onnx-binding/**` runs the Go binding suite, so the rewriter was linted and never tested. `make ck-rewrite-test` is now the fast test of a `ck-flash-attn-rewriter` rule for `onnx-binding/ort-ck-flash-attn/**`, so the quality job's changed-file gate (`make agent-ci-lint`) runs the suite for any change under that path.

## Test Plan

- `make ck-rewrite-test` (`python3 -m unittest test_rewrite_graph` in `onnx-binding/ort-ck-flash-attn/scripts` with the agent venv, which installs the pinned `onnx` on first use)
- `rewrite_graph.py` on the feedback `model.onnx` under both output names, and on the jailbreak and modality `model_sdpa_fp16.onnx`

## Test Result

- 9 passed, including value_info-free FP16, FP32, mixed, no-float and BFLOAT16 graphs; black, ruff, codespell, markdownlint and the structure gate are clean.
- The feedback `model.onnx` carries no `value_info` at all and reads FLOAT from its initializers. `model.onnx` → `model_fa_fp16.onnx` exits 1 with nothing written; → `model_fa.onnx` proceeds and matches the published file. Both SDPA files report `No attention blocks found`, on `main` and here alike.
- `agent_gate.py resolve` on this PR's files matches `rust-bindings` and `ck-flash-attn-rewriter` with `make ck-rewrite-test` among the fast tests; `make agent-validate` passes.


