### PR TITLE
[Bug] Bound batch classification by max_batch_size

### DIFF
--- a/src/semantic-router/pkg/apiserver/route_classify.go
+++ b/src/semantic-router/pkg/apiserver/route_classify.go
@@ -181,6 +181,13 @@ func (s *ClassificationAPIServer) parseBatchClassificationRequest(w http.Respons
 		return BatchClassificationRequest{}, false
 	}
 
+	if maxBatchSize := s.maxBatchSize(); maxBatchSize > 0 && len(req.Texts) > maxBatchSize {
+		metrics.RecordBatchClassificationError("unified", "batch_too_large")
+		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_INPUT",
+			fmt.Sprintf("texts array exceeds max_batch_size %d", maxBatchSize))
+		return BatchClassificationRequest{}, false
+	}
+
 	if validateErr := validateTaskType(req.TaskType); validateErr != nil {
 		metrics.RecordBatchClassificationError("unified", "invalid_task_type")
 		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_TASK_TYPE", validateErr.Error())
@@ -188,6 +195,13 @@ func (s *ClassificationAPIServer) parseBatchClassificationRequest(w http.Respons
 	}
 
 	return req, true
+}
+
+func (s *ClassificationAPIServer) maxBatchSize() int {
+	if s.config == nil {
+		return 0
+	}
+	return s.config.API.BatchClassification.MaxBatchSize
 }
 
 func (s *ClassificationAPIServer) ensureUnifiedClassifierAvailable(w http.ResponseWriter) bool {

--- a/src/semantic-router/pkg/apiserver/route_classify.go
+++ b/src/semantic-router/pkg/apiserver/route_classify.go
@@ -198,10 +198,11 @@ func (s *ClassificationAPIServer) parseBatchClassificationRequest(w http.Respons
 }
 
 func (s *ClassificationAPIServer) maxBatchSize() int {
-	if s.config == nil {
+	cfg := s.currentConfig()
+	if cfg == nil {
 		return 0
 	}
-	return s.config.API.BatchClassification.MaxBatchSize
+	return cfg.API.BatchClassification.MaxBatchSize
 }
 
 func (s *ClassificationAPIServer) ensureUnifiedClassifierAvailable(w http.ResponseWriter) bool {

--- a/src/semantic-router/pkg/apiserver/route_classify_test.go
+++ b/src/semantic-router/pkg/apiserver/route_classify_test.go
@@ -165,6 +165,34 @@ func batchClassificationConfigCases() []batchClassificationConfigCase {
 			},
 			config: batchClassificationMetricsConfig(),
 		},
+		{
+			batchClassificationHTTPCase: batchClassificationHTTPCase{
+				name:           "Batch at max_batch_size passes the bound",
+				requestBody:    marshalBatchTexts(3),
+				expectedStatus: http.StatusServiceUnavailable,
+				expectedError:  batchClassifierUnavailableMessage,
+			},
+			config: batchClassificationMaxBatchSizeConfig(3),
+		},
+		{
+			batchClassificationHTTPCase: batchClassificationHTTPCase{
+				name:           "Batch above max_batch_size is rejected",
+				requestBody:    marshalBatchTexts(4),
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "texts array exceeds max_batch_size 3",
+			},
+			config: batchClassificationMaxBatchSizeConfig(3),
+		},
+	}
+}
+
+func batchClassificationMaxBatchSizeConfig(maxBatchSize int) *config.RouterConfig {
+	return &config.RouterConfig{
+		APIServer: config.APIServer{
+			API: config.APIConfig{
+				BatchClassification: config.BatchClassificationConfig{MaxBatchSize: maxBatchSize},
+			},
+		},
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/route_classify_test.go
+++ b/src/semantic-router/pkg/apiserver/route_classify_test.go
@@ -186,6 +186,19 @@ func batchClassificationConfigCases() []batchClassificationConfigCase {
 	}
 }
 
+func TestBatchClassificationMaxBatchSizeFollowsRuntimeConfig(t *testing.T) {
+	apiServer := newBatchClassificationTestServer(batchClassificationMaxBatchSizeConfig(0))
+	live := batchClassificationMaxBatchSizeConfig(3)
+	apiServer.runtimeConfig = newLiveRuntimeConfig(nil, func() *config.RouterConfig { return live }, nil)
+
+	runBatchClassificationHTTPCase(t, apiServer, batchClassificationHTTPCase{
+		name:           "Resolver config bounds the batch",
+		requestBody:    marshalBatchTexts(4),
+		expectedStatus: http.StatusBadRequest,
+		expectedError:  "texts array exceeds max_batch_size 3",
+	})
+}
+
 func batchClassificationMaxBatchSizeConfig(maxBatchSize int) *config.RouterConfig {
 	return &config.RouterConfig{
 		APIServer: config.APIServer{

--- a/website/docs/tutorials/global/api-and-observability.md
+++ b/website/docs/tutorials/global/api-and-observability.md
@@ -60,6 +60,9 @@ global:
         max_concurrency: 8
 ```
 
+`max_batch_size` bounds `texts` per `/api/v1/classify/batch` request. Larger
+batches return `400 INVALID_INPUT`.
+
 ### Response API
 
 ```yaml


### PR DESCRIPTION
Related #3329

## Purpose

- Make the batch classification API honor the configured `max_batch_size`; today the field is accepted but never enforced.
- Oversized batches now get a clear client error instead of silently running unbounded.

## Test Plan

- `go test ./pkg/apiserver/`

## Test Result

- Passed.