### PR TITLE
[Bug] Honor vector_store upload limits in the files API

### DIFF
--- a/src/semantic-router/pkg/apiserver/route_files.go
+++ b/src/semantic-router/pkg/apiserver/route_files.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"net/http"
 	"path/filepath"
 	"slices"
@@ -32,8 +33,9 @@ import (
 )
 
 const (
-	maxUploadSize        = 50 * 1024 * 1024 // 50MB
-	multipartMemoryLimit = 8 * 1024 * 1024
+	megabyte             int64 = 1024 * 1024
+	maxUploadSize              = 50 * megabyte
+	multipartMemoryLimit       = 8 * 1024 * 1024
 )
 
 // allowedExtensions defines the document types that can be uploaded for
@@ -78,18 +80,22 @@ func allowedExtensionList(purpose string, documentExtensions map[string]bool) st
 	return strings.Join(slices.Sorted(maps.Keys(documentExtensions)), ", ")
 }
 
+func uploadMaxBytes(maxFileSizeMB int) int64 {
+	if maxFileSizeMB <= 0 || int64(maxFileSizeMB) > math.MaxInt64/megabyte {
+		return maxUploadSize
+	}
+	return int64(maxFileSizeMB) * megabyte
+}
+
 func (s *ClassificationAPIServer) uploadLimits() (int64, map[string]bool) {
-	maxBytes := int64(maxUploadSize)
+	cfg := s.currentConfig()
+	if cfg == nil || cfg.VectorStore == nil {
+		return maxUploadSize, allowedExtensions
+	}
 	documentExtensions := allowedExtensions
-	if s == nil || s.config == nil || s.config.VectorStore == nil {
-		return maxBytes, documentExtensions
-	}
-	if s.config.VectorStore.MaxFileSizeMB > 0 {
-		maxBytes = int64(s.config.VectorStore.MaxFileSizeMB) * 1024 * 1024
-	}
-	if len(s.config.VectorStore.SupportedFormats) > 0 {
-		documentExtensions = make(map[string]bool, len(s.config.VectorStore.SupportedFormats))
-		for _, format := range s.config.VectorStore.SupportedFormats {
+	if len(cfg.VectorStore.SupportedFormats) > 0 {
+		documentExtensions = make(map[string]bool, len(cfg.VectorStore.SupportedFormats))
+		for _, format := range cfg.VectorStore.SupportedFormats {
 			ext := strings.ToLower(strings.TrimSpace(format))
 			if ext != "" && !strings.HasPrefix(ext, ".") {
 				ext = "." + ext
@@ -97,7 +103,7 @@ func (s *ClassificationAPIServer) uploadLimits() (int64, map[string]bool) {
 			documentExtensions[ext] = true
 		}
 	}
-	return maxBytes, documentExtensions
+	return uploadMaxBytes(cfg.VectorStore.MaxFileSizeMB), documentExtensions
 }
 
 // SetFileStore sets the global file store for the API server.
@@ -123,7 +129,7 @@ func (s *ClassificationAPIServer) handleUploadFile(w http.ResponseWriter, r *htt
 			return
 		}
 		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_INPUT",
-			fmt.Sprintf("failed to parse multipart form (max size: %dMB): %s", maxBytes/(1024*1024), err.Error()))
+			fmt.Sprintf("failed to parse multipart form (max size: %dMB): %s", maxBytes/megabyte, err.Error()))
 		return
 	}
 	if r.MultipartForm != nil {

--- a/src/semantic-router/pkg/apiserver/route_files.go
+++ b/src/semantic-router/pkg/apiserver/route_files.go
@@ -21,8 +21,10 @@ package apiserver
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -62,18 +64,40 @@ const purposeVision = "vision"
 
 // uploadExtensionAllowed reports whether a file extension may be uploaded for
 // the given purpose: images for vision, documents for everything else.
-func uploadExtensionAllowed(ext, purpose string) bool {
+func uploadExtensionAllowed(ext, purpose string, documentExtensions map[string]bool) bool {
 	if purpose == purposeVision {
 		return imageExtensions[ext]
 	}
-	return allowedExtensions[ext]
+	return documentExtensions[ext]
 }
 
-func allowedExtensionList(purpose string) string {
+func allowedExtensionList(purpose string, documentExtensions map[string]bool) string {
 	if purpose == purposeVision {
 		return ".png, .jpg, .jpeg, .gif, .webp"
 	}
-	return ".txt, .md, .json, .csv, .html"
+	return strings.Join(slices.Sorted(maps.Keys(documentExtensions)), ", ")
+}
+
+func (s *ClassificationAPIServer) uploadLimits() (int64, map[string]bool) {
+	maxBytes := int64(maxUploadSize)
+	documentExtensions := allowedExtensions
+	if s == nil || s.config == nil || s.config.VectorStore == nil {
+		return maxBytes, documentExtensions
+	}
+	if s.config.VectorStore.MaxFileSizeMB > 0 {
+		maxBytes = int64(s.config.VectorStore.MaxFileSizeMB) * 1024 * 1024
+	}
+	if len(s.config.VectorStore.SupportedFormats) > 0 {
+		documentExtensions = make(map[string]bool, len(s.config.VectorStore.SupportedFormats))
+		for _, format := range s.config.VectorStore.SupportedFormats {
+			ext := strings.ToLower(strings.TrimSpace(format))
+			if ext != "" && !strings.HasPrefix(ext, ".") {
+				ext = "." + ext
+			}
+			documentExtensions[ext] = true
+		}
+	}
+	return maxBytes, documentExtensions
 }
 
 // SetFileStore sets the global file store for the API server.
@@ -88,8 +112,9 @@ func (s *ClassificationAPIServer) handleUploadFile(w http.ResponseWriter, r *htt
 		return
 	}
 
+	maxBytes, documentExtensions := s.uploadLimits()
 	// Limit upload size.
-	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
 
 	if err := r.ParseMultipartForm(multipartMemoryLimit); err != nil {
 		var maxBytesErr *http.MaxBytesError
@@ -98,7 +123,7 @@ func (s *ClassificationAPIServer) handleUploadFile(w http.ResponseWriter, r *htt
 			return
 		}
 		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_INPUT",
-			fmt.Sprintf("failed to parse multipart form (max size: %dMB): %s", maxUploadSize/(1024*1024), err.Error()))
+			fmt.Sprintf("failed to parse multipart form (max size: %dMB): %s", maxBytes/(1024*1024), err.Error()))
 		return
 	}
 	if r.MultipartForm != nil {
@@ -132,9 +157,9 @@ func (s *ClassificationAPIServer) handleUploadFile(w http.ResponseWriter, r *htt
 
 	// Validate extension against the purpose.
 	ext := strings.ToLower(filepath.Ext(header.Filename))
-	if !uploadExtensionAllowed(ext, purpose) {
+	if !uploadExtensionAllowed(ext, purpose, documentExtensions) {
 		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_FILE_TYPE",
-			fmt.Sprintf("unsupported file type for purpose %q: %s (allowed: %s)", purpose, ext, allowedExtensionList(purpose)))
+			fmt.Sprintf("unsupported file type for purpose %q: %s (allowed: %s)", purpose, ext, allowedExtensionList(purpose, documentExtensions)))
 		return
 	}
 

--- a/src/semantic-router/pkg/apiserver/route_files_test.go
+++ b/src/semantic-router/pkg/apiserver/route_files_test.go
@@ -5,9 +5,11 @@ package apiserver
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
@@ -173,5 +175,67 @@ func TestHandleUploadFileHonorsVectorStoreLimits(t *testing.T) {
 	rr = uploadFile(t, apiServer, "big.pdf", bytes.Repeat([]byte("x"), 1024*1024+1), "assistants")
 	if rr.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("expected 413 above max_file_size_mb, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func vectorStoreUploadConfig(maxFileSizeMB int, formats ...string) *config.RouterConfig {
+	return &config.RouterConfig{VectorStore: &config.VectorStoreConfig{
+		MaxFileSizeMB:    maxFileSizeMB,
+		SupportedFormats: formats,
+	}}
+}
+
+func TestUploadMaxBytesFallsBackOnOverflow(t *testing.T) {
+	if got := uploadMaxBytes(math.MaxInt); got != maxUploadSize {
+		t.Fatalf("expected overflowing max_file_size_mb to fall back to %d, got %d", maxUploadSize, got)
+	}
+	if got := uploadMaxBytes(0); got != maxUploadSize {
+		t.Fatalf("expected unset max_file_size_mb to fall back to %d, got %d", maxUploadSize, got)
+	}
+	if got := uploadMaxBytes(3); got != 3*megabyte {
+		t.Fatalf("expected 3MB, got %d", got)
+	}
+}
+
+func TestHandleUploadFileUsesResolvedRuntimeConfig(t *testing.T) {
+	apiServer, _ := newFileUploadServer(t)
+	staleCfg := vectorStoreUploadConfig(1, ".pdf")
+	liveCfg := vectorStoreUploadConfig(1, ".txt")
+	apiServer.config = staleCfg
+	apiServer.runtimeConfig = newLiveRuntimeConfig(staleCfg, func() *config.RouterConfig { return liveCfg }, nil)
+
+	rr := uploadFile(t, apiServer, "notes.txt", []byte("text"), "assistants")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected live config formats to win, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleUploadFileHonorsPublishedConfigMutation(t *testing.T) {
+	apiServer, _ := newFileUploadServer(t)
+	apiServer.config = vectorStoreUploadConfig(1, ".pdf")
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				apiServer.publishConfigMutation(vectorStoreUploadConfig(1, ".txt"))
+			}
+		}
+	}()
+	for range 5 {
+		uploadFile(t, apiServer, "notes.txt", []byte("text"), "assistants")
+	}
+	close(done)
+	wg.Wait()
+
+	rr := uploadFile(t, apiServer, "notes.txt", []byte("text"), "assistants")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected published formats to apply, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/src/semantic-router/pkg/apiserver/route_files_test.go
+++ b/src/semantic-router/pkg/apiserver/route_files_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerruntime"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/vectorstore"
 )
@@ -149,5 +150,28 @@ func TestHandleUploadFileRejectsDocumentsForVisionPurpose(t *testing.T) {
 	rr := uploadFile(t, apiServer, "notes.txt", []byte("not an image"), "vision")
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleUploadFileHonorsVectorStoreLimits(t *testing.T) {
+	apiServer, _ := newFileUploadServer(t)
+	apiServer.config = &config.RouterConfig{VectorStore: &config.VectorStoreConfig{
+		MaxFileSizeMB:    1,
+		SupportedFormats: []string{".pdf"},
+	}}
+
+	rr := uploadFile(t, apiServer, "notes.txt", []byte("text"), "assistants")
+	if rr.Code != http.StatusBadRequest || !bytes.Contains(rr.Body.Bytes(), []byte("allowed: .pdf")) {
+		t.Fatalf("expected .txt rejected with configured formats, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = uploadFile(t, apiServer, "doc.pdf", []byte("%PDF-1.4"), "assistants")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected .pdf accepted, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = uploadFile(t, apiServer, "big.pdf", bytes.Repeat([]byte("x"), 1024*1024+1), "assistants")
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 above max_file_size_mb, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/src/semantic-router/pkg/apiserver/route_files_test.go
+++ b/src/semantic-router/pkg/apiserver/route_files_test.go
@@ -233,6 +233,7 @@ func TestHandleUploadFileHonorsPublishedConfigMutation(t *testing.T) {
 	}
 	close(done)
 	wg.Wait()
+	apiServer.publishConfigMutation(vectorStoreUploadConfig(1, ".txt"))
 
 	rr := uploadFile(t, apiServer, "notes.txt", []byte("text"), "assistants")
 	if rr.Code != http.StatusOK {


### PR DESCRIPTION
Related #3329

## Purpose

- Make `/v1/files` honor `vector_store.max_file_size_mb` and `vector_store.supported_formats`; today both are accepted but the upload path hardcodes 50MB and a fixed extension list.
- Unset config keeps the previous defaults.

## Test Plan

- `go test ./pkg/apiserver/`

## Test Result

- Passed.