### PR TITLE
[Bug] Remove unread single-field config knobs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1198,7 +1198,6 @@ routing:
               collection: docs
               reuse_cache_connection: true
               content_field: content
-              metadata_field: metadata
               filter_expression: locale == "es"
 
     - name: admin_adaptive_route
@@ -1604,11 +1603,6 @@ global:
         cost_weight: 0.1
         quality_gap_threshold: 0.08
         normalize_scores: true
-      momentum:
-        enabled: false
-        attack: 0.7
-        release: 0.3
-        threshold: 0.6
       ml:
         models_path: models/model-selection
         model_type: mmbert
@@ -1719,7 +1713,6 @@ global:
           enabled: true
           time_windows: [1m, 5m, 1h]
           update_interval: 30s
-          model_metrics: true
           queue_depth_estimation: true
           max_models: 50
       profiling:
@@ -2453,10 +2446,6 @@ global:
         feedback_mapping_path: models/mmbert32k-feedback-detector-merged/feedback_mapping.json
       modality_detector:
         enabled: true
-        prompt_prefixes:
-          - generate an image of
-          - draw
-          - create a picture of
         method: hybrid
         classifier:
           model_path: models/mmbert32k-modality-router-merged

--- a/config/fragments/plugin/rag/milvus.yaml
+++ b/config/fragments/plugin/rag/milvus.yaml
@@ -11,4 +11,3 @@ plugin:
       collection: docs
       reuse_cache_connection: true
       content_field: content
-      metadata_field: metadata

--- a/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
+++ b/dashboard/frontend/src/pages/configPageRouterDefaultsSupport.ts
@@ -475,10 +475,6 @@ function summaryForKey(key: RouterSystemKey, data: unknown): RouterSectionSummar
       return [
         { label: 'Enabled', value: stringOrFallback(section?.enabled, 'Disabled') },
         { label: 'Method', value: stringOrFallback(section?.method) },
-        {
-          label: 'Prompt prefixes',
-          value: `${Array.isArray(section?.prompt_prefixes) ? section.prompt_prefixes.length : 0}`,
-        },
       ]
     case 'observability':
       return [
@@ -945,7 +941,6 @@ function fieldsForKey(key: RouterSystemKey): FieldConfig[] {
     case 'modality_detector':
       return [
         { name: 'enabled', label: 'Enable Modality Detector', type: 'boolean' },
-        routerStructuredField(key, 'prompt_prefixes'),
         {
           name: 'method',
           label: 'Detection Method',

--- a/dashboard/frontend/src/pages/configPageRouterStructuredSchema.ts
+++ b/dashboard/frontend/src/pages/configPageRouterStructuredSchema.ts
@@ -214,7 +214,6 @@ const metricsSchema = object('Metrics', {
     enabled: boolean('Enabled'),
     time_windows: stringList('Time Windows', '5m'),
     update_interval: text('Update Interval'),
-    model_metrics: boolean('Model Metrics'),
     queue_depth_estimation: boolean('Queue Depth Estimation'),
     max_models: number('Max Models', { min: 1 }),
   }),
@@ -513,11 +512,6 @@ export const ROUTER_STRUCTURED_FIELDS: Partial<
     },
   },
   modality_detector: {
-    prompt_prefixes: {
-      label: 'Prompt Prefixes',
-      description: 'Prefixes that indicate a modality-specific request.',
-      schema: stringList('Prompt Prefix', 'generate an image of '),
-    },
     classifier: {
       label: 'Classifier',
       description: 'Modality classifier model and device.',

--- a/dashboard/frontend/src/pages/configPageSupport.ts
+++ b/dashboard/frontend/src/pages/configPageSupport.ts
@@ -470,7 +470,6 @@ export interface ObservabilityConfig {
       enabled?: boolean
       time_windows?: string[]
       update_interval?: string
-      model_metrics?: boolean
       queue_depth_estimation?: boolean
       max_models?: number
     }
@@ -592,7 +591,6 @@ export interface ModalityDetectionConfig {
 
 export interface ModalityDetectorConfig {
   enabled?: boolean
-  prompt_prefixes?: string[]
   method?: string
   classifier?: ModalityClassifierConfig
   keywords?: string[]

--- a/deploy/kubernetes/observability/dashboard/config.yaml
+++ b/deploy/kubernetes/observability/dashboard/config.yaml
@@ -170,7 +170,6 @@ global:
           enabled: true
           time_windows: [1m, 5m, 15m, 1h]
           update_interval: 30s
-          model_metrics: true
           queue_depth_estimation: true
           max_models: 50
   stores:

--- a/src/semantic-router/pkg/config/image_gen_plugin.go
+++ b/src/semantic-router/pkg/config/image_gen_plugin.go
@@ -19,11 +19,6 @@ type ModalityDetectorConfig struct {
 	// Enabled activates the modality detector. When false, modality signals are not evaluated.
 	Enabled bool `yaml:"enabled" json:"enabled"`
 
-	// PromptPrefixes are prefix strings stripped from the user prompt before
-	// sending it to the generation backend (e.g. "generate an image of ", "draw ").
-	// Matched case-insensitively; the first match is stripped. Optional.
-	PromptPrefixes []string `yaml:"prompt_prefixes,omitempty" json:"prompt_prefixes,omitempty"`
-
 	// Detection configuration (inlined from ModalityDetectionConfig)
 	ModalityDetectionConfig `yaml:",inline"`
 }

--- a/src/semantic-router/pkg/config/observability_config.go
+++ b/src/semantic-router/pkg/config/observability_config.go
@@ -36,7 +36,6 @@ type WindowedMetricsConfig struct {
 	Enabled              bool     `yaml:"enabled"`
 	TimeWindows          []string `yaml:"time_windows,omitempty"`
 	UpdateInterval       string   `yaml:"update_interval,omitempty"`
-	ModelMetrics         bool     `yaml:"model_metrics"`
 	QueueDepthEstimation bool     `yaml:"queue_depth_estimation"`
 	MaxModels            int      `yaml:"max_models,omitempty"`
 }

--- a/src/semantic-router/pkg/config/rag_plugin_backends.go
+++ b/src/semantic-router/pkg/config/rag_plugin_backends.go
@@ -7,7 +7,6 @@ type MilvusRAGConfig struct {
 	Collection           string `json:"collection" yaml:"collection"`
 	ReuseCacheConnection bool   `json:"reuse_cache_connection,omitempty" yaml:"reuse_cache_connection,omitempty"`
 	ContentField         string `json:"content_field,omitempty" yaml:"content_field,omitempty"`
-	MetadataField        string `json:"metadata_field,omitempty" yaml:"metadata_field,omitempty"`
 	FilterExpression     string `json:"filter_expression,omitempty" yaml:"filter_expression,omitempty"`
 }
 

--- a/src/semantic-router/pkg/config/selection_config.go
+++ b/src/semantic-router/pkg/config/selection_config.go
@@ -16,7 +16,6 @@ type ModelSelectionConfig struct {
 	ML       MLSelectionConfig       `yaml:"ml,omitempty"`
 
 	SessionAware SessionAwareSelectionConfig `yaml:"-"`
-	Momentum     MomentumSelectionConfig     `yaml:"momentum,omitempty"`
 
 	// ModelSwitchGate configures session-aware stay-vs-switch evaluation.
 	ModelSwitchGate ModelSwitchGateConfig `yaml:"-"`
@@ -78,14 +77,6 @@ type HandoffPenaltyOverride struct {
 type RemainingTurnPriorOverride struct {
 	IntentOrDomain string  `yaml:"intent_or_domain"`
 	Value          float64 `yaml:"value"`
-}
-
-// MomentumSelectionConfig configures Conversational Routing Momentum (CRM).
-type MomentumSelectionConfig struct {
-	Enabled   bool    `yaml:"enabled,omitempty"`
-	Attack    float64 `yaml:"attack,omitempty"`
-	Release   float64 `yaml:"release,omitempty"`
-	Threshold float64 `yaml:"threshold,omitempty"`
 }
 
 // ModelSwitchGateConfig configures auditable session-aware model switching.

--- a/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/01-basic.yaml
@@ -155,7 +155,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/02-keyword-only.yaml
@@ -138,7 +138,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/03-embedding-only.yaml
@@ -139,7 +139,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/04-domain-only.yaml
@@ -144,7 +144,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/05-keyword-embedding.yaml
@@ -144,7 +144,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/06-keyword-domain.yaml
@@ -150,7 +150,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/07-domain-embedding.yaml
@@ -144,7 +144,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/08-keyword-embedding-domain.yaml
@@ -156,7 +156,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/09-keyword-plugin.yaml
@@ -119,7 +119,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/10-embedding-plugin.yaml
@@ -120,7 +120,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/11-domain-plugin.yaml
@@ -120,7 +120,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/12-keyword-embedding-plugin.yaml
@@ -132,7 +132,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/13-keyword-domain-plugin.yaml
@@ -133,7 +133,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/14-domain-embedding-plugin.yaml
@@ -130,7 +130,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/15-keyword-embedding-domain-plugin.yaml
@@ -198,7 +198,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/16-keyword-embedding-domain-no-plugin.yaml
@@ -172,7 +172,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/src/semantic-router/pkg/k8s/testdata/output/17-embedding-multimodal.yaml
+++ b/src/semantic-router/pkg/k8s/testdata/output/17-embedding-multimodal.yaml
@@ -166,7 +166,6 @@ global:
       metrics:
         windowed_metrics:
           enabled: false
-          model_metrics: false
           queue_depth_estimation: false
       profiling:
         enabled: false

--- a/website/docs/tutorials/plugin/rag.md
+++ b/website/docs/tutorials/plugin/rag.md
@@ -65,7 +65,6 @@ plugins:
         collection: docs
         reuse_cache_connection: true
         content_field: content
-        metadata_field: metadata
 ```
 
 **Qdrant backend:**


### PR DESCRIPTION
Related #3329

## Purpose

- Remove four config fields the loader accepts but the runtime never reads: `modality_detector.prompt_prefixes`, `observability.windowed_metrics.model_metrics`, `model_selection.momentum.*`, and the Milvus RAG `metadata_field`.
- Drop them from the reference config, deploy config, RAG fragment and doc, and the dashboard form; regenerate the k8s converter goldens.

## Test Plan

- `go test ./pkg/config/ ./pkg/k8s/`

## Test Result

- Passed.
