### PR TITLE
[Bug] Advertise each embedding model's configured sequence limit

### DIFF
--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -1754,6 +1754,30 @@ pub extern "C" fn free_batch_similarity_result(result: *mut BatchSimilarityResul
     }
 }
 
+/// One entry of the models-info table.
+///
+/// `limits` is `Some((max_position_embeddings, hidden_size))` from the loaded
+/// model's config and `None` when the model is not loaded, in which case both
+/// numbers are reported as 0 and the path as empty.
+pub(crate) fn embedding_model_info(
+    name: &str,
+    path: Option<&str>,
+    limits: Option<(usize, usize)>,
+) -> crate::ffi::types::EmbeddingModelInfo {
+    use std::ffi::CString;
+    let (max_sequence_length, default_dimension) = match limits {
+        Some((max_positions, hidden)) => (max_positions as i32, hidden as i32),
+        None => (0, 0),
+    };
+    crate::ffi::types::EmbeddingModelInfo {
+        model_name: CString::new(name).unwrap().into_raw(),
+        is_loaded: limits.is_some(),
+        max_sequence_length,
+        default_dimension,
+        model_path: CString::new(path.unwrap_or("")).unwrap().into_raw(),
+    }
+}
+
 /// Get information about loaded embedding models
 ///
 /// This function returns metadata about all available embedding models,
@@ -1770,7 +1794,6 @@ pub extern "C" fn get_embedding_models_info(
     result: *mut crate::ffi::types::EmbeddingModelsInfoResult,
 ) -> i32 {
     use crate::ffi::types::{EmbeddingModelInfo, EmbeddingModelsInfoResult};
-    use std::ffi::CString;
 
     if result.is_null() {
         eprintln!("Error: null pointer passed to get_embedding_models_info");
@@ -1789,52 +1812,20 @@ pub extern "C" fn get_embedding_models_info(
         }
     };
 
-    // Check which models are loaded
-    let qwen3_loaded = factory.get_qwen3_model().is_some();
-    let gemma_loaded = factory.get_gemma_model().is_some();
+    // The limits come from each loaded model's own config.json, not from
+    // constants: `max_position_embeddings` is what the RoPE cache and the
+    // position guard are sized for, and `hidden_size` is the default dimension.
+    let qwen3_limits = factory
+        .get_qwen3_model()
+        .map(|m| (m.config().max_position_embeddings, m.config().hidden_size));
+    let gemma_limits = factory
+        .get_gemma_model()
+        .map(|m| (m.config().max_position_embeddings, m.config().hidden_size));
 
-    // Get model paths from factory
-    let qwen3_path = factory.get_qwen3_model_path();
-    let gemma_path = factory.get_gemma_model_path();
-
-    // Create model info array
-    let mut models_vec = Vec::new();
-
-    // Qwen3 model info
-    {
-        let model_name = CString::new("qwen3").unwrap();
-        let model_path = if let Some(path) = qwen3_path {
-            CString::new(path).unwrap()
-        } else {
-            CString::new("").unwrap()
-        };
-
-        models_vec.push(EmbeddingModelInfo {
-            model_name: model_name.into_raw(),
-            is_loaded: qwen3_loaded,
-            max_sequence_length: if qwen3_loaded { 32768 } else { 0 },
-            default_dimension: if qwen3_loaded { 1024 } else { 0 },
-            model_path: model_path.into_raw(),
-        });
-    }
-
-    // Gemma model info
-    {
-        let model_name = CString::new("gemma").unwrap();
-        let model_path = if let Some(path) = gemma_path {
-            CString::new(path).unwrap()
-        } else {
-            CString::new("").unwrap()
-        };
-
-        models_vec.push(EmbeddingModelInfo {
-            model_name: model_name.into_raw(),
-            is_loaded: gemma_loaded,
-            max_sequence_length: if gemma_loaded { 8192 } else { 0 },
-            default_dimension: if gemma_loaded { 768 } else { 0 },
-            model_path: model_path.into_raw(),
-        });
-    }
+    let models_vec = vec![
+        embedding_model_info("qwen3", factory.get_qwen3_model_path(), qwen3_limits),
+        embedding_model_info("gemma", factory.get_gemma_model_path(), gemma_limits),
+    ];
 
     let num_models = models_vec.len() as i32;
     let models_ptr = Box::into_raw(models_vec.into_boxed_slice()) as *mut EmbeddingModelInfo;

--- a/candle-binding/src/ffi/embedding_test.rs
+++ b/candle-binding/src/ffi/embedding_test.rs
@@ -182,3 +182,29 @@ fn test_check_position_limit_names_length_and_limit(
         "error must name the limit: {err}"
     );
 }
+
+/// The models-info table advertises what the loaded config declares, and zeros
+/// for a model that is not loaded (issue #3407).
+#[rstest]
+#[case::loaded(Some("/models/qwen3"), Some((32768usize, 1024usize)), true, 32768, 1024, "/models/qwen3")]
+#[case::gemma_2k(Some("/models/gemma"), Some((2048usize, 768usize)), true, 2048, 768, "/models/gemma")]
+#[case::not_loaded(None, None, false, 0, 0, "")]
+fn test_embedding_model_info_reports_the_loaded_config(
+    #[case] path: Option<&str>,
+    #[case] limits: Option<(usize, usize)>,
+    #[case] loaded: bool,
+    #[case] max_len: i32,
+    #[case] dim: i32,
+    #[case] want_path: &str,
+) {
+    let info = embedding_model_info("qwen3", path, limits);
+    assert_eq!(info.is_loaded, loaded);
+    assert_eq!(info.max_sequence_length, max_len);
+    assert_eq!(info.default_dimension, dim);
+    unsafe {
+        let name = CString::from_raw(info.model_name);
+        let got_path = CString::from_raw(info.model_path);
+        assert_eq!(name.to_str().unwrap(), "qwen3");
+        assert_eq!(got_path.to_str().unwrap(), want_path);
+    }
+}

--- a/candle-binding/src/model_architectures/embedding/qwen3_embedding.rs
+++ b/candle-binding/src/model_architectures/embedding/qwen3_embedding.rs
@@ -1722,6 +1722,12 @@ impl Qwen3EmbeddingModel {
         &self.tokenizer_config
     }
 
+    /// Model configuration as loaded from `config.json`; `max_position_embeddings`
+    /// is the sequence length the RoPE cache and the position guard are built for.
+    pub fn config(&self) -> &Qwen3EmbeddingConfig {
+        &self.config
+    }
+
     /// Get number of transformer layers
     pub fn num_layers(&self) -> usize {
         self.layers.len()


### PR DESCRIPTION
Closes #3407

Builds on #3460 (first two commits); this PR is the third.

## Purpose

- `get_embedding_models_info` hardcodes 32768 for Qwen3 and 8192 for Gemma. Gemma's config says 2048, so the API advertises a length the model rejects.
- Read `max_position_embeddings` and `hidden_size` from the loaded model's config instead.

## Test Plan

- `cargo test --release --no-default-features --lib test_embedding_model_info`

## Test Result

- 3/3: loaded model reports its config, a 2048-position Gemma reports 2048, an unloaded model reports zeros.

