### PR TITLE
[Community] Update Workgroup roster · 2026-09-04

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -202,6 +202,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Bevisy.png',
         profile: 'https://github.com/Bevisy',
       },
+      {
+        name: 'Xuge',
+        avatar: 'https://github.com/xuuuge.png',
+        profile: 'https://github.com/xuuuge',
+      },
     ],
   },
   {
@@ -290,6 +295,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Bevisy.png',
         profile: 'https://github.com/Bevisy',
       },
+      {
+        name: 'Shrek Luzz',
+        avatar: 'https://github.com/Zheng-Lu.png',
+        profile: 'https://github.com/Zheng-Lu',
+      },
     ],
   },
   {
@@ -371,6 +381,11 @@ export const workGroups: WorkGroup[] = [
         name: 'Nanasis',
         avatar: 'https://github.com/nanasis.png',
         profile: 'https://github.com/nanasis',
+      },
+      {
+        name: 'pikachu',
+        avatar: 'https://github.com/yu3zhang1.png',
+        profile: 'https://github.com/yu3zhang1',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add all currently eligible Workgroup Members
- preserve unrelated Workgroup roster content and ordering

## Evidence

| Applicant | Workgroup | Role | Application | Qualifying contribution |
| --- | --- | --- | --- | --- |
| @xuuuge | Data Plane & Networking | Member | [application](https://github.com/vllm-project/semantic-router/issues/2967#issuecomment-5455167570) | [PR #3300](https://github.com/vllm-project/semantic-router/pull/3300) |
| @Zheng-Lu | Agentic & Context | Member | [application](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5533961421) | [PR #3304](https://github.com/vllm-project/semantic-router/pull/3304) |
| @yu3zhang1 | Evaluation & Quality | Member | [application](https://github.com/vllm-project/semantic-router/issues/2969#issuecomment-5459689355) | [PR #3399](https://github.com/vllm-project/semantic-router/pull/3399) |

## Validation

- `git diff --check`
- exact seven-Workgroup roster uniqueness and target-entry checks
- `make agent-report`
- `make agent-ci-gate ENV=cpu CHANGED_FILES="website/src/data/workGroups.ts"`
- repository pre-commit hooks

Related #2967, #2987, #2969

<!-- workgroup-operations:roster -->