### PR TITLE
[Docs] Clarify deployment and protocol compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
 
       - id: backend-target-compatibility
         name: backend target compatibility coverage
-        entry: python3 tools/ci/check_backend_target_compatibility.py
+        entry: .venv-agent/bin/python tools/ci/check_backend_target_compatibility.py
         language: system
         pass_filenames: false
         files: ^(\.pre-commit-config\.yaml$|config/config\.yaml$|src/vllm-sr/tests/test_config_generator\.py$|src/semantic-router/pkg/config/maintained_asset_contract_test\.go$|deploy/helm/testdata/backend-target-values\.yaml$|deploy/helm/validate-chart\.sh$|tools/make/helm\.mk$|deploy/operator/controllers/semanticrouter_controller_test\.go$|dashboard/frontend/src/pages/configPageModelFormSupport\.test\.ts$|dashboard/backend/handlers/config_update_test\.go$|website/docs/installation/backend-target-compatibility\.md$|tools/ci/check_backend_target_compatibility\.py$|tools/ci/tests/test_backend_target_compatibility\.py$)

--- a/tools/ci/tests/test_agent_make_contract.py
+++ b/tools/ci/tests/test_agent_make_contract.py
@@ -138,6 +138,12 @@ class AgentMakeContractTests(unittest.TestCase):
             ".venv-agent/bin/python tools/agent/scripts/precommit_tool.py website",
         )
 
+    def test_python_hooks_with_managed_dependencies_use_agent_venv(self) -> None:
+        self.assertEqual(
+            local_hook("backend-target-compatibility")["entry"],
+            ".venv-agent/bin/python tools/ci/check_backend_target_compatibility.py",
+        )
+
     def test_security_scan_is_not_forced_for_docs_only_changes(self) -> None:
         self.assertNotIn("always_run", local_hook("supply-chain-security-scan"))
 

--- a/website/docs/api/router.md
+++ b/website/docs/api/router.md
@@ -23,6 +23,10 @@ queries. See [Router management API](./apiserver).
 Other `/v1/*` paths fail closed. In particular, Router Replay paths are not
 available on a public inference listener.
 
+See [Protocol Compatibility](../installation/protocol-compatibility) for the
+client-to-backend translation matrix, backend `api_format` values, and
+field-level portability boundaries.
+
 ## Send a routed request
 
 Use an auto-model or recipe entrypoint when you want the router to select a

--- a/website/docs/installation/backend-target-compatibility.md
+++ b/website/docs/installation/backend-target-compatibility.md
@@ -7,13 +7,23 @@ description: See which backend target forms survive Docker, Helm, Operator, Dash
 
 Semantic Router uses `providers.models[].backend_refs[]` as the canonical
 contract between a logical model name and one or more physical inference
-targets. The same document can move through the CLI, Helm, and Dashboard. The
-Operator instead accepts Kubernetes discovery inputs and translates the
-supported subset into canonical backend references.
+targets.
 
 This matrix covers **configuration production and preservation**. It does not
-claim that an endpoint is reachable, healthy, compatible with a particular
-model, or eligible for inference-aware replica selection.
+claim that an endpoint is reachable, healthy, or compatible with a particular
+model protocol.
+
+## Choose the right matrix
+
+| Question | Source of truth |
+| --- | --- |
+| Which client endpoints and backend wire protocols work together? | [Protocol Compatibility](protocol-compatibility) |
+| Which target fields survive CLI, Helm, Operator, Dashboard, and recipe workflows? | This page |
+| Which deployment stacks and integrations does the project maintain? | [Deployment Support](support-matrix) |
+
+The same canonical document can move through the CLI, Helm, and Dashboard. The
+Operator instead accepts Kubernetes discovery inputs and translates its
+supported subset into canonical backend references.
 
 ## Status meanings
 
@@ -57,6 +67,7 @@ providers:
   models:
     - name: local/general
       provider_model_id: Qwen/Qwen3-8B
+      api_format: openai
       backend_refs:
         - name: primary
           endpoint: model-server.default.svc.cluster.local:8000
@@ -72,6 +83,7 @@ providers:
   models:
     - name: hosted/reasoning
       provider_model_id: provider/model-id
+      api_format: openai
       backend_refs:
         - name: hosted-primary
           base_url: https://provider.example/v1
@@ -88,27 +100,21 @@ For portable configuration, do not put a URL scheme or path in `endpoint`.
 Some local generation paths accept those forms, but not every maintained
 producer agrees on their meaning. `base_url` is the canonical URL form.
 
+`api_format` belongs to the model, not to an individual backend ref. It selects
+the backend request and response codec; `protocol` on a backend ref selects the
+HTTP transport. See [Protocol Compatibility](protocol-compatibility) before
+choosing `api_format`.
+
 ## Producer behavior
 
-### Docker and local CLI
+| Producer | Behavior and boundary |
+| --- | --- |
+| Docker / local CLI | Translates refs into Envoy clusters and routes. It preserves host, port, HTTP or HTTPS, weight, a shared path prefix, environment-resolved authorization, and shared extra headers. Referenced model servers must already be reachable. |
+| Helm | `configOverride` renders one complete canonical mapping without merging sample provider defaults. Reachability and model compatibility remain runtime checks. |
+| Operator | `spec.vllmEndpoints[]` is a Kubernetes discovery adapter, not a copy of the full provider schema. It emits the supported canonical subset described below. |
+| Dashboard | Reads and writes the supported canonical backend inventory, including provider identity, URL, auth metadata, API version, chat path, extra headers, and environment-key references. |
 
-The CLI translates canonical refs into Envoy clusters and routes. It preserves
-host, port, HTTP or HTTPS, weight, a shared path prefix, environment-resolved
-authorization, and shared extra request headers. A custom configuration does
-not start the referenced model servers; they must already be reachable from
-the local stack.
-
-### Helm
-
-`configOverride` is the portable Helm input. The chart renders that complete
-mapping atomically instead of merging it with sample provider defaults. The
-chart preserves canonical backend fields, but endpoint reachability and model
-compatibility remain runtime checks.
-
-### Operator and Kubernetes discovery
-
-The Operator's `spec.vllmEndpoints[]` API is a discovery adapter, not a second
-copy of the full provider schema. It currently supports:
+The Operator currently discovers:
 
 - a named Kubernetes Service;
 - a KServe `InferenceService`; and
@@ -123,13 +129,6 @@ KServe discovery currently assumes the conventional
 `<InferenceService>-predictor.<namespace>.svc.cluster.local:8443` HTTPS target.
 It does not resolve `status.url` or inspect the generated Service, so custom or
 named-predictor service layouts require an explicit Service backend instead.
-
-### Dashboard
-
-The model editor reads and writes the canonical backend fields, including
-provider identity, `base_url`, auth metadata, API version, chat path, extra
-headers, and environment-key references. Saving a model preserves fields in
-that supported inventory even when their values are unchanged.
 
 Unknown-field and supported-version parity across producers is tracked in
 [#2469](https://github.com/vllm-project/semantic-router/issues/2469). Until that
@@ -152,5 +151,5 @@ The repository exercises this matrix at five layers:
   reference configuration, which exercises weighted direct and rich URL
   targets.
 
-These checks prove translation and preservation. They do not replace a live
-request through the chosen backend.
+These checks prove configuration translation and preservation. They do not
+replace a direct backend protocol check or a live request through the Router.

--- a/website/docs/installation/configuration.md
+++ b/website/docs/installation/configuration.md
@@ -50,10 +50,13 @@ Provider pricing belongs beside each concrete model under
 `cached_input_per_1m`, and `cache_write_per_1m` rates. Routing model cards do not
 repeat deployment prices or credentials.
 
-See [Backend Target Compatibility](backend-target-compatibility) before moving
-provider bindings between Docker, Helm, the Operator, and Dashboard workflows.
-The matrix distinguishes canonical pass-through from Kubernetes discovery and
-records which URL, path, weight, and provider fields each surface preserves.
+Use [Protocol Compatibility](protocol-compatibility) to choose the model's
+backend `api_format`. Then see
+[Backend Target Compatibility](backend-target-compatibility) before moving its
+bindings between Docker, Helm, the Operator, and Dashboard workflows. The
+target matrix distinguishes canonical pass-through from Kubernetes discovery
+and records which URL, path, weight, and provider fields each surface
+preserves.
 
 Router-wide debugging surfaces stay closed by default.
 `global.services.observability.profiling` serves Go `pprof` endpoints, and only

--- a/website/docs/installation/deployment-options.md
+++ b/website/docs/installation/deployment-options.md
@@ -5,80 +5,61 @@ description: Choose a Docker, Kubernetes, or hardware-specific path for deployin
 
 # Choose a Deployment
 
-Semantic Router and its inference backends are separate services. Choose how to
-run the Router first, then connect model endpoints that it can reach.
+Choose two things independently:
 
-The deployment guides are organized into three paths: **Docker** for one host,
-**Kubernetes** for cluster-managed deployments, and **Hardware** for preparing
-GPU-backed model servers or accelerating Router-side models.
+1. where Semantic Router runs; and
+2. where the model backends run.
 
-Before choosing an option, check the
-[Deployment and Hardware Support Matrix](support-matrix) for its maintenance
-level, recurring evidence, version constraints, and production boundaries.
+The Router does not load or provision the model weights referenced by a custom
+configuration. It sends requests to reachable model endpoints, which can run on
+the same host, in a cluster, or behind a hosted API.
 
-## At a glance
+## Choose the Router topology
 
-| Deployment | Choose it when | Start here |
+| Need | Recommended path | Start here |
 | --- | --- | --- |
-| Docker | You are evaluating the Router, developing locally, or deploying on one host. | [Deploy with Docker](docker) |
-| Kubernetes | You need replicas, declarative rollouts, an operator, or an existing gateway or inference platform. | [Kubernetes](#kubernetes) |
-| Hardware | You need to start a vLLM backend on AMD or NVIDIA GPUs, or accelerate supported Router-side models. | [Hardware](#hardware) |
-
-## Docker
-
-`vllm-sr serve` starts the local Router, Envoy, Dashboard, and supporting
-services. It is the fastest path for configuration work, evaluation, and a
-single-host deployment.
-
-The command does not normally provision the provider models referenced by a
-custom config or built-in virtual model. Start those endpoints first, or bind
-the config to endpoints that already exist.
-
-Follow [Deploy with Docker](docker) for the stack lifecycle and backend
-networking. If you want a small local model server, add
-[Ollama](ollama). Both guides keep the Router and model-server responsibilities
-separate.
-
-## Kubernetes
-
-Choose the Kubernetes path that matches who should own the Router lifecycle:
-
-- Use the [CLI and Helm workflow](configuration-workflows#helm) when your team
-  already owns a complete canonical config and deploys releases through CLI or
-  GitOps automation.
-- Use the [Kubernetes Operator](k8s/operator) when Kubernetes should manage
-  `SemanticRouter` resources, discovery, and lifecycle.
-- Choose a supported [gateway](k8s/gateways) when Semantic Router must join an
-  existing traffic data plane.
-- Choose an [inference-platform integration](k8s/inference-platforms) when
-  another platform owns model deployment and replica scheduling.
+| Evaluate locally or run on one host | Docker stack managed by the CLI | [Deploy with Docker](docker) |
+| Deploy a complete canonical config through GitOps | Helm | [CLI and Helm workflow](configuration-workflows#helm) |
+| Let Kubernetes reconcile Router resources and discovery | Kubernetes Operator | [Kubernetes Operator](k8s/operator) |
+| Attach routing policy to an existing gateway | Gateway integration | [Gateways](k8s/gateways) |
+| Let another platform own model replicas and scheduling | Inference-platform integration | [Inference Platforms](k8s/inference-platforms) |
 
 Gateway and inference-platform integrations do not replace Router policy. They
-connect semantic model selection to infrastructure that already owns traffic
-or model-serving lifecycle.
+connect semantic model selection to infrastructure that owns traffic or model
+lifecycle.
 
-## Hardware
+Before committing to a path, check its project-maintained status, recurring
+test evidence, and external ownership boundary in the
+[Deployment Support](support-matrix).
 
-The Hardware guides prepare GPU-backed vLLM endpoints and explain when to run
-supported Router-side signal models on a GPU:
+## Choose the model backend
 
-- [AMD ROCm](amd-rocm) for vLLM on AMD Instinct GPUs;
-- [NVIDIA CUDA](nvidia-cuda) for vLLM on NVIDIA GPUs and optional CUDA
-  acceleration in the Router.
+| Backend situation | Start here |
+| --- | --- |
+| You already have a reachable model or provider endpoint | [Protocol Compatibility](protocol-compatibility), then [Backend Target Compatibility](backend-target-compatibility) |
+| You want a small local model for evaluation | [Local model with Ollama](ollama) |
+| You want to serve models on AMD Instinct | [AMD ROCm](amd-rocm) |
+| You want to serve models or accelerate Router-side models on NVIDIA | [NVIDIA CUDA](nvidia-cuda) |
+| A Kubernetes platform owns model deployment and replicas | [Inference Platforms](k8s/inference-platforms) |
 
-Hardware is not a separate Router topology. You can connect these model servers
-to either Docker or Kubernetes. Keep the Router on CPU unless measurements show
-that its local embeddings or classifiers benefit from sharing GPU capacity.
+Hardware is an overlay, not a separate Router topology. A GPU-backed model
+server can connect to either a Docker or Kubernetes Router deployment. Keep the
+Router on CPU unless measurements show that its local embeddings or classifiers
+benefit from GPU acceleration.
 
-Whichever hardware path you choose, test the model endpoint directly before
-testing it through the Router. Confirm that it supports the context, modality,
-tool, and protocol requirements declared by the recipe.
+Test a model endpoint directly before sending traffic through the Router. A
+configured URL is not proof that the backend implements the selected wire
+protocol or supports the recipe's context, modality, and tool requirements.
 
 ## Before production
 
-Review these areas before exposing a deployment:
+Before exposing a deployment:
 
-- [Configuration](configuration) for canonical YAML and environment bindings;
-- [Security Hardening](security-hardening) for trust boundaries and credentials;
-- [Data and Storage](storage-overview) for persistence and retention; and
-- [Upgrade and Rollback](upgrade-rollback) for version pinning and recovery.
+1. pin the Router, model server, model, and integration versions together;
+2. validate buffered, streaming, failure, and rollback behavior through the
+   actual data plane;
+3. move credentials into a secret manager; and
+4. review [Configuration](configuration),
+   [Security Hardening](security-hardening),
+   [Data and Storage](storage-overview), and
+   [Upgrade and Rollback](upgrade-rollback).

--- a/website/docs/installation/installation.md
+++ b/website/docs/installation/installation.md
@@ -149,8 +149,10 @@ vllm-sr config migrate --config old-config.yaml
 
 ## Next
 
-- [Choose a Deployment](deployment-options) for local, GPU, Kubernetes, and
-  gateway options.
+- [Choose a Deployment](deployment-options) for local, Kubernetes, gateway, and
+  model-hosting options.
+- [Protocol Compatibility](protocol-compatibility) for client endpoints,
+  backend API formats, and cross-protocol translation.
 - [Configuration](configuration) for canonical YAML, recipes, and environment
   bindings.
 - [Models, Entrypoints, and Serving](../tutorials/global/models-entrypoints-serving)

--- a/website/docs/installation/protocol-compatibility.md
+++ b/website/docs/installation/protocol-compatibility.md
@@ -1,0 +1,151 @@
+---
+title: Protocol Compatibility Matrix
+description: Match client-facing inference APIs to supported backend model protocols and understand cross-protocol feature boundaries.
+---
+
+# Protocol Compatibility Matrix
+
+Semantic Router supports three inference wire formats on both sides of the
+data plane. A client request is decoded into a protocol-neutral form, routing
+policy selects a model, and that model's `api_format` selects the backend codec.
+The response is translated back to the client's original format.
+
+```text
+client endpoint -> client codec -> routing -> backend codec -> model endpoint
+```
+
+Protocol compatibility is separate from target configuration and deployment
+support:
+
+- use [Backend Target Compatibility](backend-target-compatibility) for URLs,
+  weights, headers, discovery, and producer preservation; and
+- use [Deployment Support](support-matrix) for
+  project-maintained stacks, integrations, and hardware profiles.
+
+## Client-facing protocols
+
+| Client API | Inference endpoint | Buffered | Streaming | Availability |
+| --- | --- | --- | --- | --- |
+| OpenAI Chat Completions | `POST /v1/chat/completions` | Supported | Supported | Available on the public inference listener. |
+| OpenAI Responses | `POST /v1/responses` | Supported | Supported | Requires `global.services.response_api` and its store to be available. Router-owned object operations are not forwarded to a model backend. |
+| Anthropic Messages | `POST /v1/messages` | Supported | Supported | Send the Anthropic request shape and an appropriate `anthropic-version` header. Client authentication remains deployment-specific. |
+
+The public listener also serves `GET /v1/models`. See the
+[Router API](../api/router) for the complete method and path inventory,
+Responses object operations, and request examples.
+
+## Backend model protocols
+
+Set `api_format` on each `providers.models[]` entry. It describes the wire
+contract implemented by that model endpoint, not the provider brand.
+
+| `api_format` | Backend request and response shape | Default upstream path | Notes |
+| --- | --- | --- | --- |
+| `openai` | OpenAI Chat Completions | `/v1/chat/completions` | Default when `api_format` is omitted. `backend_refs[].chat_path` can override the Chat path. |
+| `responses` | OpenAI Responses | `/v1/responses` | The backend itself must implement the Responses wire contract; enabling the Router's Responses service does not add that API to a backend. |
+| `anthropic` | Anthropic Messages | `/v1/messages` | Configure provider authentication and required version headers on the backend ref. |
+
+These fields are easy to confuse:
+
+- model `api_format` selects the request, response, error, and streaming codec;
+- backend-ref `protocol` selects HTTP or HTTPS transport; and
+- backend-ref `provider` supplies provider-specific authentication and path
+  defaults. It does not prove that the endpoint implements an API format.
+
+For Responses and Messages backends, a path in `base_url` is retained and the
+protocol path is appended. `chat_path` applies only to Chat Completions.
+
+## Client-to-backend matrix
+
+Every client format can route to every backend format. Each cell is covered in
+both buffered and streaming mode.
+
+| Client protocol | `openai` backend | `responses` backend | `anthropic` backend |
+| --- | --- | --- | --- |
+| OpenAI Chat Completions | Supported | Supported through codec translation | Supported through codec translation |
+| OpenAI Responses | Supported through codec translation | Supported | Supported through codec translation |
+| Anthropic Messages | Supported through codec translation | Supported through codec translation | Supported |
+
+"Supported" means the Router owns the request, response, transport-error, and
+streaming translation path. It does not mean every field from one protocol can
+be represented by every other protocol, or that every model behind an endpoint
+supports the requested capability.
+
+## Feature portability
+
+The Router checks required semantics before encoding a backend request. A
+feature that the selected backend format cannot represent fails explicitly
+instead of being silently dropped.
+
+| Semantic feature | Chat Completions | Responses | Messages |
+| --- | --- | --- | --- |
+| Text, image input, and file input | Supported | Supported | Supported |
+| Tools, parallel tool calls, and strict tool schemas | Supported | Supported | Supported |
+| Strict JSON Schema output | Supported | Supported | Supported |
+| Buffered and streaming responses | Supported | Supported | Supported |
+| Reasoning content and effort | Supported | Supported | Supported |
+| JSON object mode without a schema | Supported | Supported | Not supported |
+| Audio input | Supported | Not supported | Not supported |
+| Hosted image-generation lifecycle | Not supported | Supported | Not supported |
+| Multiple response candidates | Supported | Not supported | Not supported |
+| Prompt-cache directives | Supported | Not supported | Supported |
+| Reasoning token budget | Supported extension | Not supported | Supported |
+| Seed and frequency or presence penalties | Supported | Not supported | Not supported |
+| `top_k` sampling | Not supported | Not supported | Supported |
+| Stop sequences | Supported | Not supported | Supported |
+| Native response or conversation state fields | Not supported | Supported | Not supported |
+
+This table describes codec representation, not model capability. For example,
+an OpenAI-compatible server can accept the Chat request shape while rejecting
+images or tools for a particular model. Qualify the actual endpoint and model
+revision before adding them to a routing pool.
+
+A Responses client can still use `previous_response_id` with a Chat
+Completions or Messages backend. The Router retrieves and materializes the
+retained history, removes Router-owned object controls, and then encodes the
+stateless request in the selected backend format.
+
+## Configure a backend format
+
+The client can use any supported client-facing endpoint; `api_format` controls
+what the selected backend receives:
+
+```yaml
+providers:
+  models:
+    - name: hosted/claude
+      provider_model_id: claude-model-id
+      api_format: anthropic
+      backend_refs:
+        - name: anthropic-primary
+          base_url: https://api.anthropic.com
+          provider: anthropic
+          api_key_env: ANTHROPIC_API_KEY
+          extra_headers:
+            anthropic-version: "2023-06-01"
+          weight: 100
+```
+
+Test the backend directly with its native path and a minimal request first.
+Then send the same semantic request through the Router using the client API that
+your application needs. A successful health check does not validate request
+schema, streaming, tools, or error translation.
+
+## Validation and failure behavior
+
+- Public requests are decoded into the neutral contract even when client and
+  backend formats match. Unknown or unsupported request fields fail closed.
+- Cross-protocol requests preserve shared semantics. Target-specific features
+  that cannot be represented return a typed protocol error.
+- The response keeps the client protocol's JSON or SSE shape. Provider
+  transport errors and incomplete streams are translated separately from
+  successful model responses.
+- `x-vsr-client-protocol`, `x-vsr-upstream-protocol`, and
+  `x-vsr-protocol-warnings` expose translation details when applicable. See
+  [VSR routing headers](../troubleshooting/vsr-headers).
+
+The repository verifies all three protocols pairwise in codec tests, at the
+Envoy ExtProc boundary, and in an 18-cell deployment matrix: three client
+formats by three backend formats by buffered or streaming mode. See the
+[implemented codec design](../proposals/multi-protocol-adaptor) for the full
+verification and extension contract.

--- a/website/docs/installation/support-matrix.md
+++ b/website/docs/installation/support-matrix.md
@@ -1,122 +1,109 @@
 ---
-title: Deployment and Hardware Support Matrix
-description: Understand which Semantic Router deployment options and hardware profiles are maintained, supported, experimental, or deprecated.
+title: Deployment Support
+description: See which deployment paths, integrations, examples, and hardware profiles the Semantic Router project maintains.
 ---
 
-# Deployment and Hardware Support Matrix
+# Deployment Support
 
-Use this page to choose a deployment option and understand what the Semantic
-Router project maintains. A documented option does not, by itself, make every
-platform version, image, model, or accelerator combination supported.
+Use this page to check which Router deployment paths and integrations the
+project maintains. It does not certify every platform, model server, model, or
+accelerator combination.
 
-For a task-oriented starting point, see [Choose a Deployment](deployment-options).
+If you are still choosing a topology, start with
+[Choose a Deployment](deployment-options). For wire formats and endpoint
+configuration, use [Protocol Compatibility](protocol-compatibility) and
+[Backend Target Compatibility](backend-target-compatibility).
 
-## Support levels
+## What each status means
 
-| Level | Project commitment |
+| Status | Meaning |
 | --- | --- |
-| Maintained reference stack | The project owns the installation or lifecycle contract and protects it with repository tests. Pin a Semantic Router release for production. |
-| Supported integration | The project maintains the Router-side attachment contract and documentation. The external platform keeps its own support matrix and lifecycle. |
-| Experimental example | The option demonstrates a feature or test topology. Review and adapt it; compatibility and production hardening are not guaranteed. |
-| Deprecated | The option remains temporarily for migration and has a documented replacement or removal path. |
+| Maintained reference stack | The project owns and tests the installation or lifecycle contract. |
+| Supported integration | The project tests the Router-side connection; the external platform owns its lifecycle. |
+| Experimental example | The files demonstrate a feature or test topology that you must qualify. |
+| Deprecated | The option remains temporarily for a documented migration. |
 
-Evidence labels describe the project's strongest recurring check. They do not
-prove that an arbitrary downstream environment passed:
+Evidence tags show the strongest recurring check: **PR CI** runs an end-to-end
+profile, **Contract** validates static contracts without the external platform,
+and **Manual** requires an opt-in environment.
 
-- **PR/full CI** means a registered end-to-end profile is selected in pull
-  request or full-CI coverage.
-- **Contract/build** means source, schema, rendering, image, or packaging
-  checks protect the option without running every external platform.
-- **Manual profile** means the project provides an opt-in test with external
-  prerequisites. It does not mean the profile passed in another environment.
-- **Documented example** means the project checks the files and documentation,
-  but operators own end-to-end qualification.
+## Use one tested version set
+
+For each linked option:
+
+1. use an external platform version named in its guide; if none is named,
+   treat your choice as unqualified until you test it;
+2. take every Semantic Router artifact you use—the CLI, chart, CRDs,
+   controller, and images—from one release; and
+3. test that exact set in your environment before upgrading any one component.
+
+Support covers that tested version set, not every version supported by the
+external project.
 
 ## Maintained reference stacks
 
-| Option | Classification | What the project maintains | Version, ownership, and evidence boundary |
-| --- | --- | --- | --- |
-| [Helm chart](configuration-workflows#helm) | Maintained reference stack | Router, optional Dashboard, ingress, autoscaling, persistence, and observability resources. | Use the chart from the same Semantic Router release and pin application images. The project owns the chart and Router lifecycle; the selected Gateway, Service, and storage remain separate. The [Helm safety gate](https://github.com/vllm-project/semantic-router/blob/main/tools/make/helm.mk) validates rendering, schema, and safety rules. |
-| [Local deployment](docker) | Maintained reference stack | Router, Envoy, Dashboard, and selected support services through `vllm-sr serve`. | Use same-release CLI and images; pin image digests for controlled deployments. The CLI owns the local stack lifecycle, while model endpoints remain separate. The [CLI integration workflow](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/integration-test-vllm-sr-cli.yml) exercises the lifecycle with real containers. Local defaults require hardening before production. |
-| [Kubernetes Operator](k8s/operator) | Maintained reference stack | Reconciliation of Router configuration, workload, Service, storage, autoscaling, and the project-owned `vllm.ai` routing APIs used by controllers and integrations. | Install the CRDs, controller, and Router images from one release. Kubernetes owns workload scheduling and the chosen gateway owns traffic. [Operator CI](https://github.com/vllm-project/semantic-router/blob/main/.github/workflows/operator-ci.yml) covers unit, generated-resource, image, API-schema, and cluster-reconciliation contracts. The routing APIs are components of these integrations, not a standalone deployment. |
+| Option | Classification | Project coverage |
+| --- | --- | --- |
+| [Helm chart](configuration-workflows#helm) | Maintained reference stack | **Contract.** Router, optional Dashboard, ingress, autoscaling, persistence, and observability resources. Gateways and storage remain external. |
+| [Local deployment](docker) | Maintained reference stack | **PR CI.** The CLI manages Router, Envoy, Dashboard, and support services. You provide custom model endpoints and harden local defaults. |
+| [Kubernetes Operator](k8s/operator) | Maintained reference stack | **PR CI + Contract.** The project owns CRDs, reconciliation, Router workloads, Services, and routing APIs. Kubernetes schedules workloads; your gateway carries traffic. |
 
 ## Supported integrations
 
-Each linked guide is authoritative for its current external platform versions.
-Pin that compatibility set together with the selected Semantic Router release.
-
-| Integration | Classification | Ownership and version boundary | Evidence and limits |
-| --- | --- | --- | --- |
-| [agentgateway](k8s/agentgateway) | Supported integration | agentgateway owns the Gateway API data plane; Semantic Router supplies ExtProc policy. Use the versions pinned by the guide. | PR/full CI profile. agentgateway requires `FullDuplexStreamed` rather than `Streamed` request bodies. |
-| [Envoy AI Gateway](k8s/ai-gateway) | Supported integration | Envoy AI Gateway and Envoy Gateway own provider traffic; Semantic Router supplies routing policy. Use the versions pinned by the guide. | Default and full-CI profile. Provider compatibility changes independently; verify the selected provider. |
-| [AIBrix](k8s/aibrix) | Supported integration | AIBrix owns model deployment, autoscaling, and replica routing; Semantic Router selects the model or pool. | PR/full CI profile. Pin one AIBrix release and do not treat this integration as a replacement for AIBrix's cluster and accelerator support matrix. |
-| [NVIDIA Dynamo](k8s/dynamo) | Supported integration | Dynamo owns graphs, workers, and frontend lifecycle; Semantic Router selects a model target. Use the versions pinned by the guide. | Manual profile because it requires a prepared Dynamo/GPU environment. The repository also retains a pinned Dynamo `0.6.1.post1` model-deployment fixture for historical testing; it is not compatible with the guide's current platform and is not a production deployment. |
-| [Istio Gateway](k8s/istio) | Supported integration | Istio's Gateway API data plane carries requests; Semantic Router is the ExtProc policy service. Use the versions pinned by the guide. | PR/full CI profile. Supplied model workloads need NVIDIA GPU capacity and are examples, not a general GPU guarantee. |
-| [llm-d](k8s/llm-d) | Supported integration | Semantic Router selects a logical model or pool; the Gateway route targets its `InferencePool`, and llm-d owns discovery, endpoint picking, and replica routing. The repository supplies both Router values and scheduler-manifest examples. | PR/full CI profile plus contract/build coverage. Match the APIs and images to one llm-d release, and do not apply competing direct-Service routes for the same traffic. |
-| [Streaming with Envoy AI Gateway](k8s/streamed-extproc) | Supported integration | Envoy AI Gateway owns streamed transport; Semantic Router processes the configured ExtProc body mode. | PR/full CI streaming profile. Pin both releases and test the body mode because streaming capabilities differ across gateways. |
-| [Valkey agentic memory](valkey-memory) | Supported integration | Semantic Router owns memory configuration; Valkey owns persistence, availability, and Search-module compatibility. | Contract and manual integration coverage. Credentials, retention, backup, tenant isolation, and end-to-end qualification remain operator responsibilities. |
-| [Responses API state with Redis](../tutorials/global/api-and-observability#response-api) | Supported integration | Semantic Router owns Responses API configuration; Redis owns durable conversation state. | Manual Redis profiles. Validate the selected Redis topology; production authentication, encryption, persistence, and eviction policy are not supplied by the examples. |
-| [Response cache](../tutorials/plugin/response-cache) | Supported integration | Semantic Router owns cache behavior and configuration; the selected external backend owns storage and availability. | Contract/manual coverage. Pin the backend and Router release, validate serialization and expiry behavior, and treat cached prompts and responses as sensitive data. |
-| [Valkey vector store](storage-overview) | Supported integration | Semantic Router owns vector-store references; Valkey owns indexing, durability, and access control. | Manual vector-store profiles. Pin Valkey, its Search module, the embedding model, and the Router release as one tested set. |
+| Integration | Classification | Project coverage |
+| --- | --- | --- |
+| [agentgateway](k8s/agentgateway) | Supported integration | **PR CI.** Router supplies ExtProc policy; agentgateway owns the data plane. Set request bodies to `FullDuplexStreamed`. |
+| [Envoy AI Gateway](k8s/ai-gateway) | Supported integration | **PR CI.** Router supplies routing policy; the gateways own provider traffic. Verify your provider separately. |
+| [AIBrix](k8s/aibrix) | Supported integration | **PR CI.** Router selects a model or pool; AIBrix owns deployment, autoscaling, and replicas. Use AIBrix's hardware support matrix. |
+| [NVIDIA Dynamo](k8s/dynamo) | Supported integration | **Manual.** Router selects a target; Dynamo owns graphs, workers, and frontends. Use the guide version; the older fixture is test-only. |
+| [Istio Gateway](k8s/istio) | Supported integration | **PR CI.** Router supplies ExtProc policy; Istio carries requests. Supplied GPU workloads are examples only. |
+| [llm-d](k8s/llm-d) | Supported integration | **PR CI + Contract.** Router selects a model or pool; llm-d owns discovery and replica routing. Do not add a competing direct-Service route. |
+| [Streaming with Envoy AI Gateway](k8s/streamed-extproc) | Supported integration | **PR CI.** The gateway streams transport; Router uses the configured ExtProc body mode. Test that mode explicitly. |
+| [Valkey agentic memory](valkey-memory) | Supported integration | **Contract + Manual.** Router owns memory behavior; Valkey owns persistence and Search. You own security, retention, and backup. |
+| [Responses API state with Redis](../tutorials/global/api-and-observability#response-api) | Supported integration | **Manual.** Router owns Responses behavior; Redis stores state. You own Redis security, persistence, and eviction. |
+| [Response cache](../tutorials/plugin/response-cache) | Supported integration | **Contract + Manual.** Router owns cache behavior; your backend owns storage and availability. Treat cached data as sensitive. |
+| [Valkey vector store](storage-overview) | Supported integration | **Manual.** Router owns store references; Valkey owns indexes and durability. Pin Valkey, Search, and the embedding model together. |
 
 ## Experimental examples
 
-| Example | Classification | Purpose | Production boundary |
-| --- | --- | --- | --- |
-| KServe example | Experimental example | Demonstrates KServe integration while KServe and the cluster own model serving. | Documented example and smoke helpers. Review platform versions, images, credentials, storage, and cleanup before use. |
-| OpenShift example | Experimental example | Adapts Kubernetes resources to OpenShift Routes and security constraints. | Documented example. Review images, Route TLS, credentials, SCCs, caches, and persistent data. |
-| Anthropic-compatible backend fixture | Experimental example | Provides an Anthropic-compatible backend for integration tests. | Test fixture only; it is not a production model service. |
-| Hallucination policy demo | Experimental example | Exercises fact-check gating and warning behavior. | Manual profile with model prerequisites. Validate model quality and failure policy for the deployment domain. |
-| Jailbreak error-handling demo | Experimental example | Exercises jailbreak-classifier failure behavior. | Manual failure-path profile. Do not treat the unreachable test endpoint or permissive policy as production hardening. |
-| LLM Katan development backends | Experimental example | Supplies lightweight OpenAI-compatible development backends. | Test fixture only; it does not represent production model quality, capacity, or availability. |
-| Observability demo | Experimental example | Demonstrates Prometheus, Grafana, alerts, and Dashboard wiring in a development cluster. | Documented example. Replace example hostnames, TLS material, credentials, retention, and insecure defaults. |
-| Response jailbreak demo | Experimental example | Exercises response jailbreak detection on model output past the classifier window. | PR E2E profile with a window-limited stand-in classifier. It is a test topology, not a guardrail model or production hardening. |
-| Responses API Kubernetes demo | Experimental example | Demonstrates Responses API persistence and restart behavior with Redis. | Manual profile. Harden Redis networking, authentication, encryption, persistence, and eviction policy. |
-| Route action demo | Experimental example | Demonstrates route-action behavior through a focused Kubernetes topology. | Test/example coverage only; compose it into a maintained stack before production use. |
-| Router replay recovery demo | Experimental example | Exercises management-boundary replay and restart recovery. | Manual profile. It is a recovery test topology, not a supported deployment platform. |
-| Routing strategy demos | Experimental example | Demonstrates focused routing-strategy configurations and test traffic. | Test/example coverage only. Validate policy quality and backend capacity with representative traffic. |
-| Local tools database | Experimental example | Provides local tool definitions used by examples and tests. | Local example data only. Use an authenticated, durable tool registry for production. |
+| Example | Classification | Use it for / not for |
+| --- | --- | --- |
+| KServe example | Experimental example | KServe integration smoke testing; not a qualified KServe or model-serving deployment. |
+| OpenShift example | Experimental example | Adapting resources to Routes and security constraints; not a hardened OpenShift profile. |
+| Anthropic-compatible backend fixture | Experimental example | Protocol integration tests; not a production model service. |
+| Hallucination policy demo | Experimental example | Fact-check policy behavior; not a qualified guardrail or model. |
+| Jailbreak error-handling demo | Experimental example | Classifier failure paths; not a secure production policy. |
+| LLM Katan development backends | Experimental example | Lightweight OpenAI-compatible test backends; not production inference. |
+| Observability demo | Experimental example | Prometheus, Grafana, alert, and Dashboard wiring; replace all example security and retention settings. |
+| Response jailbreak demo | Experimental example | Response-classifier window behavior; not a production guardrail model. |
+| Responses API Kubernetes demo | Experimental example | Redis persistence and restart behavior; not a hardened Redis deployment. |
+| Route action demo | Experimental example | Focused route-action behavior; compose it into a maintained stack before production. |
+| Router replay recovery demo | Experimental example | Replay and restart recovery; not a supported deployment platform. |
+| Routing strategy demos | Experimental example | Focused policy examples; qualify routing quality and backend capacity with representative traffic. |
+| Local tools database | Experimental example | Local tool definitions for examples and tests; use an authenticated, durable registry in production. |
 
-There are no currently shipped deployment options classified as **Deprecated**.
-Removed legacy behavior and migration guidance are recorded in
-[Upgrade and Rollback](upgrade-rollback). A future deprecated option must remain
-in this matrix until its documented removal.
+No shipped option is currently **Deprecated**. See
+[Upgrade and Rollback](upgrade-rollback) for migration guidance.
 
 ## Hardware overlays
 
-Hardware support applies to a deployment stack; it does not replace one.
-Semantic Router and the backend model server are also separate support
-boundaries.
+Hardware support applies to a deployment stack; it is not a separate Router
+topology. Router acceleration and backend model serving are also separate
+choices.
 
-| Hardware profile | Status | Deployment guidance | Qualification boundary |
-| --- | --- | --- | --- |
-| Linux x86-64 CPU | Maintained | Use the standard Router images, local CLI, Helm chart, or Operator. | The normal build, unit, CLI, and Kubernetes profiles provide the broadest recurring coverage. Backend model-server requirements are separate. |
-| Linux Arm64 CPU | Build-qualified | Standard Router, Dashboard, ExtProc, and Operator images are published as multi-architecture images where their release workflow declares Arm64. | Multi-architecture image publication is not a promise that every integration or optional native dependency passed on every Arm64 platform. |
-| NVIDIA CUDA on Linux x86-64 | Supported integration | Use the `vllm-sr-cuda` image for supported Router-side ONNX models, or keep the Router on CPU and connect a separately qualified NVIDIA vLLM backend. The current image is built on CUDA `12.4.1`. | Follow [NVIDIA CUDA](nvidia-cuda), verify the CUDA execution provider, and pin the image digest. GPU model serving follows vLLM's NVIDIA support matrix; presence here does not qualify every NVIDIA architecture. |
-| AMD ROCm on Linux x86-64 | Supported integration | Keep the Router on CPU or use the ROCm Router image for supported local models, and connect a separately qualified ROCm vLLM backend. | Follow [AMD ROCm](amd-rocm) and pin compatible Router, vLLM, ROCm, and model revisions. Hardware-specific runtime coverage is not a per-PR guarantee. |
-| AMD AI PC/NPU | Experimental, not qualified | Tracked by [issue #2373](https://github.com/vllm-project/semantic-router/issues/2373). | No maintained deployment contract or compatibility promise yet. |
-| NVIDIA DGX Spark Arm64 | Experimental, not qualified | Tracked by [issue #2374](https://github.com/vllm-project/semantic-router/issues/2374). | Arm64 image availability alone does not qualify CUDA, native dependencies, or end-to-end inference on this platform. |
-| Other accelerators and operating systems | Not qualified | No maintained Router deployment option is currently declared. | Open a qualification issue with reproducible hardware, software, image, and test evidence before documenting support. |
+| Hardware profile | Status | What is covered |
+| --- | --- | --- |
+| Linux x86-64 CPU | Maintained | The standard Router images, CLI, Helm chart, and Operator receive the broadest recurring coverage. Model-server requirements remain separate. |
+| Linux Arm64 CPU | Build-qualified | Release workflows publish multi-architecture images where declared. This does not qualify every integration or optional native dependency on Arm64. |
+| NVIDIA CUDA on Linux x86-64 | Supported integration | Follow [NVIDIA CUDA](nvidia-cuda) for supported Router-side models, or keep the Router on CPU and qualify a separate NVIDIA backend against vLLM's support matrix. |
+| AMD ROCm on Linux x86-64 | Supported integration | Follow [AMD ROCm](amd-rocm) for supported Router-side models and qualify the Router, vLLM, ROCm, and model revisions as one set. |
+| AMD AI PC/NPU | Experimental, not qualified | No maintained deployment contract yet; tracked by [issue #2373](https://github.com/vllm-project/semantic-router/issues/2373). |
+| NVIDIA DGX Spark Arm64 | Experimental, not qualified | Arm64 images do not qualify CUDA or end-to-end inference on this platform; tracked by [issue #2374](https://github.com/vllm-project/semantic-router/issues/2374). |
+| Other accelerators and operating systems | Not qualified | No maintained profile. Open a qualification issue with reproducible hardware, software, image, and test evidence. |
 
-## Configuration, dependencies, and security
+## Before production
 
-Use one canonical Router YAML document. The CLI may translate it into Helm
-values, and the Operator may reconcile it from a custom resource, but neither
-option should create a second hand-maintained routing schema. Runtime
-configuration examples are references consumed by complete configurations;
-they are not deployment manifests.
-
-External gateways, inference platforms, model servers, databases, storage
-classes, identity systems, and accelerator runtimes retain their own release
-and security policies. For production:
-
-1. pin the Semantic Router release, images or digests, external platform
-   versions, model revisions, and configuration together;
-2. test the backend directly before testing it through the Router;
-3. exercise health, streaming, failure, upgrade, and rollback behavior through
-   the actual data plane;
-4. move credentials into a secret manager and enable transport security,
-   network policy, authentication, and least privilege; and
-5. review [Security Hardening](security-hardening),
-   [Data and Storage](storage-overview), and
-   [Upgrade and Rollback](upgrade-rollback).
+Test the model endpoint directly, then exercise buffered, streaming, failure,
+upgrade, and rollback paths through the real data plane. Review
+[Security Hardening](security-hardening), [Data and Storage](storage-overview),
+and [Upgrade and Rollback](upgrade-rollback) for controls outside this matrix.

--- a/website/docs/overview/semantic-router-overview.md
+++ b/website/docs/overview/semantic-router-overview.md
@@ -70,7 +70,8 @@ without changing a public entrypoint.
 
 ## Request lifecycle
 
-1. A client sends a request to an OpenAI- or Anthropic-compatible endpoint.
+1. A client sends a request using OpenAI Chat Completions, OpenAI Responses, or
+   Anthropic Messages.
 2. Envoy presents the request to the Router.
 3. The requested model resolves to an entrypoint and its recipe.
 4. The Router extracts relevant signals and computes projections.
@@ -100,6 +101,10 @@ The Router can consider request semantics and configured runtime observations;
 it does not replace a backend scheduler. A deployment may therefore use
 Semantic Router to choose a model class and another component to choose a
 healthy replica of that model.
+
+The client and selected backend do not need to use the same wire format. See
+[Protocol Compatibility](../installation/protocol-compatibility) for the
+supported client endpoints, backend formats, and pairwise translation matrix.
 
 ## Next
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -33,9 +33,22 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'installation/installation',
-        'installation/deployment-options',
-        'installation/support-matrix',
-        'installation/backend-target-compatibility',
+        {
+          type: 'category',
+          label: 'Plan a Deployment',
+          items: [
+            'installation/deployment-options',
+            'installation/support-matrix',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Compatibility',
+          items: [
+            'installation/protocol-compatibility',
+            'installation/backend-target-compatibility',
+          ],
+        },
       ],
     },
     {


### PR DESCRIPTION
Related #2358

## Purpose

- Group deployment planning and compatibility pages into focused second-level navigation categories while preserving their public URLs.
- Add a client-to-backend protocol matrix for OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages, including backend `api_format` values, streaming coverage, and feature-portability boundaries.
- Retitle the support page to `Deployment Support`, reduce it from 2,014 to 1,218 words, and replace repeated or abstract boundaries with a three-step version rule and compact coverage tables.
- Clearly separate deployment support, protocol compatibility, and backend-target preservation.
- Run the backend-target compatibility hook with the repo-managed Python environment so its pinned PyYAML dependency is available, with a harness contract test to prevent regression.

## Test Plan

- `make agent-ci-gate ENV=cpu AGENT_BASE_REF=upstream/main` from a clean detached worktree
- `.venv-agent/bin/pre-commit run backend-target-compatibility --files website/docs/installation/backend-target-compatibility.md .pre-commit-config.yaml`
- `python3 tools/ci/check_deployment_support_matrix.py`
- `python3 tools/ci/check_backend_target_compatibility.py`
- `cd website && npm test`
- `cd website && npx docusaurus build --locale en`

## Test Result

All listed checks passed. The English website build completed with only the existing blog author and truncation-marker warnings.
