### PR TITLE
[Bug] Add an Azure backend dialect for vendor response fields

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_protocol_contract.go
+++ b/src/semantic-router/pkg/extproc/processor_protocol_contract.go
@@ -95,6 +95,25 @@ func (r *OpenAIRouter) protocolEngine() (*protocolcodec.Engine, error) {
 	return protocolcodec.NewEngine(registry, llmprotocol.DefaultPolicy())
 }
 
+// protocolEngineForBackend builds an engine whose policy carries the selected
+// backend's vendor allowance. Only paths that decode a live provider response
+// use it; cache replay and client-facing encodes keep the strict default so a
+// backend allowance can never widen a contract it does not own.
+func (r *OpenAIRouter) protocolEngineForBackend(ctx *RequestContext) (*protocolcodec.Engine, error) {
+	if r == nil {
+		return nil, fmt.Errorf("protocol runtime is unavailable")
+	}
+	registry := r.ProtocolCodecs
+	if registry == nil {
+		registry = protocolcodec.NewBuiltinRegistry()
+	}
+	policy := llmprotocol.DefaultPolicy()
+	if ctx != nil {
+		policy.ResponseVendor = ctx.ResponseVendor
+	}
+	return protocolcodec.NewEngine(registry, policy)
+}
+
 // prepareProtocolRequest decodes every public wire format exactly once. The
 // neutral request is the sole mutable request contract after this boundary.
 func (r *OpenAIRouter) prepareProtocolRequest(
@@ -220,7 +239,7 @@ func (r *OpenAIRouter) decodeClientResponse(
 	if ctx == nil {
 		return nil, fmt.Errorf("request context is unavailable")
 	}
-	engine, err := r.protocolEngine()
+	engine, err := r.protocolEngineForBackend(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/src/semantic-router/pkg/extproc/processor_protocol_contract.go
+++ b/src/semantic-router/pkg/extproc/processor_protocol_contract.go
@@ -95,10 +95,7 @@ func (r *OpenAIRouter) protocolEngine() (*protocolcodec.Engine, error) {
 	return protocolcodec.NewEngine(registry, llmprotocol.DefaultPolicy())
 }
 
-// protocolEngineForBackend builds an engine whose policy carries the selected
-// backend's vendor allowance. Only paths that decode a live provider response
-// use it; cache replay and client-facing encodes keep the strict default so a
-// backend allowance can never widen a contract it does not own.
+// protocolEngineForBackend permits extensions only for live provider responses.
 func (r *OpenAIRouter) protocolEngineForBackend(ctx *RequestContext) (*protocolcodec.Engine, error) {
 	if r == nil {
 		return nil, fmt.Errorf("protocol runtime is unavailable")

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -68,9 +68,7 @@ func (r *OpenAIRouter) prepareProviderDispatch(
 		return nil, protocolErr
 	}
 	ctx.TargetFormat = dispatch.targetFormat
-	// The backend's dialect decides which vendor response decorations the
-	// decoder may ignore. Resolved here, at the only point the selected backend
-	// is known, because the response path has no other handle on it.
+	// Bind response policy where the backend is selected.
 	ctx.ResponseVendor = resolveOpenAIBackendDialect(dispatch.profile).vendorExtensionProvider()
 	ctx.SemanticRequest = request
 	logging.ComponentDebugEvent("extproc", "provider_dispatch_prepared", map[string]interface{}{

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -68,6 +68,10 @@ func (r *OpenAIRouter) prepareProviderDispatch(
 		return nil, protocolErr
 	}
 	ctx.TargetFormat = dispatch.targetFormat
+	// The backend's dialect decides which vendor response decorations the
+	// decoder may ignore. Resolved here, at the only point the selected backend
+	// is known, because the response path has no other handle on it.
+	ctx.ResponseVendor = resolveOpenAIBackendDialect(dispatch.profile).vendorExtensionProvider()
 	ctx.SemanticRequest = request
 	logging.ComponentDebugEvent("extproc", "provider_dispatch_prepared", map[string]interface{}{
 		"request_id":  ctx.RequestID,

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing_test.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing_test.go
@@ -31,6 +31,36 @@ func TestProviderDispatchEncodesEveryClientBackendProtocolPair(t *testing.T) {
 	}
 }
 
+func TestAzureProviderDispatchAcceptsDecoratedResponse(t *testing.T) {
+	router, logicalModel := routingTestRouterForFormat(llmprotocol.OpenAIChatV1)
+	profile := router.Config.ProviderProfiles["provider"]
+	profile.Type = "azure-openai"
+	router.Config.ProviderProfiles["provider"] = profile
+
+	request := testNeutralRequest(logicalModel, "hello")
+	ctx := routingTestContext(llmprotocol.OpenAIChatV1, request)
+	if _, err := router.prepareProviderDispatch(request, logicalModel, "", false, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.ResponseVendor != llmprotocol.ResponseVendorAzure {
+		t.Fatalf("response vendor = %q, want Azure", ctx.ResponseVendor)
+	}
+
+	body := []byte(`{"id":"response_1","model":"provider-model","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop","content_filter_results":{}}]}`)
+	response, err := router.decodeClientResponse(body, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Output) != 1 || len(response.Output[0].Content) != 1 || response.Output[0].Content[0].Text != "hello" {
+		t.Fatalf("response = %+v, want decoded assistant output", response)
+	}
+	if len(ctx.ProtocolDiagnostics) != 1 ||
+		ctx.ProtocolDiagnostics[0].Field != "choices[].content_filter_results" ||
+		ctx.ProtocolDiagnostics[0].Action != llmprotocol.DiagnosticDropped {
+		t.Fatalf("diagnostics = %+v, want the dropped Azure field", ctx.ProtocolDiagnostics)
+	}
+}
+
 func TestProviderDispatchAppliesReasoningBeforeExternalModelIDRewrite(t *testing.T) {
 	router, logicalModel := routingTestRouterForFormat(llmprotocol.OpenAIChatV1)
 	params := router.Config.ModelConfig[logicalModel]

--- a/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
@@ -1,6 +1,7 @@
 package extproc
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -22,12 +23,20 @@ func (r *OpenAIRouter) handleNonStreamingResponseBody(
 	semanticResponse, err := r.decodeClientResponse(responseBody, ctx)
 	if err != nil {
 		metrics.RecordRequestError(ctx.RequestModel, "parse_error")
-		logging.ComponentErrorEvent("extproc", "neutral_response_decode_failed", map[string]interface{}{
+		decodeEvent := map[string]interface{}{
 			"request_id":     ctx.RequestID,
 			"backend_format": ctx.TargetFormat,
 			"client_format":  ctx.SourceFormat,
 			"error":          err.Error(),
-		})
+		}
+		// ProtocolError.Error() renders only "code: message", and message is
+		// what reaches the client, so it stays generic. The cause carries the
+		// detail an operator needs — which field the upstream response failed
+		// on — and is logged here rather than returned.
+		if cause := errors.Unwrap(err); cause != nil {
+			decodeEvent["cause"] = cause.Error()
+		}
+		logging.ComponentErrorEvent("extproc", "neutral_response_decode_failed", decodeEvent)
 		return r.createErrorResponse(502, "The selected model returned an invalid response")
 	}
 	clientBody := responseBody

--- a/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
+++ b/src/semantic-router/pkg/extproc/processor_res_body_pipeline.go
@@ -29,10 +29,7 @@ func (r *OpenAIRouter) handleNonStreamingResponseBody(
 			"client_format":  ctx.SourceFormat,
 			"error":          err.Error(),
 		}
-		// ProtocolError.Error() renders only "code: message", and message is
-		// what reaches the client, so it stays generic. The cause carries the
-		// detail an operator needs — which field the upstream response failed
-		// on — and is logged here rather than returned.
+		// Log the private cause while keeping the client-facing message generic.
 		if cause := errors.Unwrap(err); cause != nil {
 			decodeEvent["cause"] = cause.Error()
 		}

--- a/src/semantic-router/pkg/extproc/processor_res_semantic_stream.go
+++ b/src/semantic-router/pkg/extproc/processor_res_semantic_stream.go
@@ -173,7 +173,7 @@ func (r *OpenAIRouter) ensureSemanticResponseStream(ctx *RequestContext) error {
 	if ctx.ProtocolResponseStream != nil {
 		return nil
 	}
-	engine, err := r.protocolEngine()
+	engine, err := r.protocolEngineForBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/src/semantic-router/pkg/extproc/processor_res_transport_error.go
+++ b/src/semantic-router/pkg/extproc/processor_res_transport_error.go
@@ -21,7 +21,11 @@ func (r *OpenAIRouter) handleUpstreamTransportError(
 	body []byte,
 	ctx *RequestContext,
 ) *ext_proc.ProcessingResponse {
-	engine, err := r.protocolEngine()
+	// An upstream error body comes from the same backend as a success body and
+	// carries the same vendor decorations. Azure returns a decorated envelope
+	// for content-filter blocks and rate limits, so decoding it strictly would
+	// replace the real upstream reason with a generic router error.
+	engine, err := r.protocolEngineForBackend(ctx)
 	if err != nil {
 		return r.createErrorResponse(503, "protocol runtime unavailable")
 	}

--- a/src/semantic-router/pkg/extproc/processor_res_transport_error.go
+++ b/src/semantic-router/pkg/extproc/processor_res_transport_error.go
@@ -21,10 +21,7 @@ func (r *OpenAIRouter) handleUpstreamTransportError(
 	body []byte,
 	ctx *RequestContext,
 ) *ext_proc.ProcessingResponse {
-	// An upstream error body comes from the same backend as a success body and
-	// carries the same vendor decorations. Azure returns a decorated envelope
-	// for content-filter blocks and rate limits, so decoding it strictly would
-	// replace the real upstream reason with a generic router error.
+	// Error envelopes use the selected backend's response policy too.
 	engine, err := r.protocolEngineForBackend(ctx)
 	if err != nil {
 		return r.createErrorResponse(503, "protocol runtime unavailable")

--- a/src/semantic-router/pkg/extproc/req_filter_provider_dialect.go
+++ b/src/semantic-router/pkg/extproc/req_filter_provider_dialect.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 )
 
 type openAIBackendDialectKind string
@@ -14,13 +15,27 @@ const (
 	openAIBackendDialectOfficialDeepSeek    openAIBackendDialectKind = "official_deepseek"
 	openAIBackendDialectOpenRouter          openAIBackendDialectKind = "openrouter"
 	openAIBackendDialectVLLM                openAIBackendDialectKind = "vllm"
+	openAIBackendDialectAzureOpenAI         openAIBackendDialectKind = "azure_openai"
 	openAIBackendDialectGenericOpenAICompat openAIBackendDialectKind = "generic_openai_compatible"
 )
+
+// azureOpenAIHostSuffixes are the host suffixes Azure serves its
+// OpenAI-compatible endpoints from. Azure resources are per-tenant subdomains,
+// so unlike the other dialects it is matched by suffix rather than exact host.
+var azureOpenAIHostSuffixes = []string{
+	".openai.azure.com",
+	".services.ai.azure.com",
+	".cognitiveservices.azure.com",
+}
 
 type openAIBackendDialect struct {
 	kind                            openAIBackendDialectKind
 	supportsTopLevelReasoningEffort bool
 	supportsTopLevelDeepSeekThink   bool
+	// vendorExtensions names the provider whose documented response
+	// decorations this backend is allowed to emit. Empty means the backend gets
+	// no allowance and every non-canonical response field is rejected.
+	vendorExtensions string
 }
 
 // resolveOpenAIBackendDialect captures request-shaping differences between
@@ -45,9 +60,26 @@ func resolveOpenAIBackendDialect(profile *config.ProviderProfile) openAIBackendD
 		// OpenRouter exposes reasoning_effort as a top-level OpenAI-compatible
 		// request field; local vLLM-compatible endpoints do not.
 		return newOpenAIBackendDialect(openAIBackendDialectOpenRouter)
-	default:
-		return newOpenAIBackendDialect(openAIBackendDialectGenericOpenAICompat)
 	}
+
+	if isAzureOpenAIHost(normalizedProfileHost(profile)) {
+		// Azure OpenAI and Azure AI Foundry speak the OpenAI request contract
+		// but decorate every response with their own fields.
+		return newOpenAIBackendDialect(openAIBackendDialectAzureOpenAI)
+	}
+	return newOpenAIBackendDialect(openAIBackendDialectGenericOpenAICompat)
+}
+
+func isAzureOpenAIHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	for _, suffix := range azureOpenAIHostSuffixes {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func newOpenAIBackendDialect(kind openAIBackendDialectKind) openAIBackendDialect {
@@ -62,8 +94,20 @@ func newOpenAIBackendDialect(kind openAIBackendDialectKind) openAIBackendDialect
 		dialect.supportsTopLevelDeepSeekThink = true
 	case openAIBackendDialectOpenRouter:
 		dialect.supportsTopLevelReasoningEffort = true
+	case openAIBackendDialectAzureOpenAI:
+		// Request shaping is deliberately identical to the generic
+		// OpenAI-compatible dialect; only response decoration differs, which is
+		// all issue #3496 covers. Any Azure request-side quirk needs its own
+		// evidence before it is claimed here.
+		dialect.vendorExtensions = llmprotocol.VendorAzure
 	}
 	return dialect
+}
+
+// vendorExtensionProvider reports which provider's documented response
+// decorations the response decoder may ignore for this backend.
+func (d openAIBackendDialect) vendorExtensionProvider() string {
+	return d.vendorExtensions
 }
 
 func (d openAIBackendDialect) usesTopLevelReasoningEffort() bool {

--- a/src/semantic-router/pkg/extproc/req_filter_provider_dialect.go
+++ b/src/semantic-router/pkg/extproc/req_filter_provider_dialect.go
@@ -19,23 +19,11 @@ const (
 	openAIBackendDialectGenericOpenAICompat openAIBackendDialectKind = "generic_openai_compatible"
 )
 
-// azureOpenAIHostSuffixes are the host suffixes Azure serves its
-// OpenAI-compatible endpoints from. Azure resources are per-tenant subdomains,
-// so unlike the other dialects it is matched by suffix rather than exact host.
-var azureOpenAIHostSuffixes = []string{
-	".openai.azure.com",
-	".services.ai.azure.com",
-	".cognitiveservices.azure.com",
-}
-
 type openAIBackendDialect struct {
 	kind                            openAIBackendDialectKind
 	supportsTopLevelReasoningEffort bool
 	supportsTopLevelDeepSeekThink   bool
-	// vendorExtensions names the provider whose documented response
-	// decorations this backend is allowed to emit. Empty means the backend gets
-	// no allowance and every non-canonical response field is rejected.
-	vendorExtensions string
+	vendorExtensions                llmprotocol.ResponseVendor
 }
 
 // resolveOpenAIBackendDialect captures request-shaping differences between
@@ -44,6 +32,9 @@ type openAIBackendDialect struct {
 func resolveOpenAIBackendDialect(profile *config.ProviderProfile) openAIBackendDialect {
 	if profile == nil {
 		return newOpenAIBackendDialect(openAIBackendDialectVLLM)
+	}
+	if strings.EqualFold(profile.Type, "azure-openai") {
+		return newOpenAIBackendDialect(openAIBackendDialectAzureOpenAI)
 	}
 	if !strings.EqualFold(profile.Type, "openai") {
 		return newOpenAIBackendDialect(openAIBackendDialectGenericOpenAICompat)
@@ -63,23 +54,16 @@ func resolveOpenAIBackendDialect(profile *config.ProviderProfile) openAIBackendD
 	}
 
 	if isAzureOpenAIHost(normalizedProfileHost(profile)) {
-		// Azure OpenAI and Azure AI Foundry speak the OpenAI request contract
-		// but decorate every response with their own fields.
 		return newOpenAIBackendDialect(openAIBackendDialectAzureOpenAI)
 	}
 	return newOpenAIBackendDialect(openAIBackendDialectGenericOpenAICompat)
 }
 
 func isAzureOpenAIHost(host string) bool {
-	if host == "" {
-		return false
-	}
-	for _, suffix := range azureOpenAIHostSuffixes {
-		if strings.HasSuffix(host, suffix) {
-			return true
-		}
-	}
-	return false
+	return host != "" &&
+		(strings.HasSuffix(host, ".openai.azure.com") ||
+			strings.HasSuffix(host, ".services.ai.azure.com") ||
+			strings.HasSuffix(host, ".cognitiveservices.azure.com"))
 }
 
 func newOpenAIBackendDialect(kind openAIBackendDialectKind) openAIBackendDialect {
@@ -95,18 +79,12 @@ func newOpenAIBackendDialect(kind openAIBackendDialectKind) openAIBackendDialect
 	case openAIBackendDialectOpenRouter:
 		dialect.supportsTopLevelReasoningEffort = true
 	case openAIBackendDialectAzureOpenAI:
-		// Request shaping is deliberately identical to the generic
-		// OpenAI-compatible dialect; only response decoration differs, which is
-		// all issue #3496 covers. Any Azure request-side quirk needs its own
-		// evidence before it is claimed here.
-		dialect.vendorExtensions = llmprotocol.VendorAzure
+		dialect.vendorExtensions = llmprotocol.ResponseVendorAzure
 	}
 	return dialect
 }
 
-// vendorExtensionProvider reports which provider's documented response
-// decorations the response decoder may ignore for this backend.
-func (d openAIBackendDialect) vendorExtensionProvider() string {
+func (d openAIBackendDialect) vendorExtensionProvider() llmprotocol.ResponseVendor {
 	return d.vendorExtensions
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_provider_dialect_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_provider_dialect_test.go
@@ -66,34 +66,46 @@ func TestResolveOpenAIBackendDialect(t *testing.T) {
 }
 
 func TestResolveOpenAIBackendDialectAzureHosts(t *testing.T) {
-	for name, baseURL := range map[string]string{
-		"azure openai":     "https://my-resource.openai.azure.com/openai/v1",
-		"ai foundry":       "https://my-resource.services.ai.azure.com/openai/v1",
-		"cognitiveservice": "https://my-resource.cognitiveservices.azure.com/openai/v1",
-	} {
-		t.Run(name, func(t *testing.T) {
-			dialect := resolveOpenAIBackendDialect(&config.ProviderProfile{Type: "openai", BaseURL: baseURL})
+	tests := []struct {
+		name    string
+		baseURL string
+	}{
+		{name: "azure openai", baseURL: "https://my-resource.openai.azure.com/openai/v1"},
+		{name: "azure ai foundry", baseURL: "https://my-resource.services.ai.azure.com/openai/v1"},
+		{name: "cognitive services", baseURL: "https://my-resource.cognitiveservices.azure.com/openai/v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialect := resolveOpenAIBackendDialect(&config.ProviderProfile{Type: "openai", BaseURL: tt.baseURL})
 
 			assert.Equal(t, openAIBackendDialectAzureOpenAI, dialect.kind)
 			assert.Equal(t, llmprotocol.VendorAzure, dialect.vendorExtensionProvider())
 			// Azure request shaping is unchanged from the generic dialect.
 			assert.False(t, dialect.usesTopLevelReasoningEffort())
+			assert.False(t, dialect.usesDeepSeekOfficialReasoning())
 		})
 	}
 }
 
 // Every other backend keeps the strict contract: no vendor allowance at all.
 func TestResolveOpenAIBackendDialectGrantsNoVendorAllowanceByDefault(t *testing.T) {
-	for name, profile := range map[string]*config.ProviderProfile{
-		"local vllm": nil,
-		"official":   {Type: "openai", BaseURL: "https://api.openai.com/v1"},
-		"openrouter": {Type: "openai", BaseURL: "https://openrouter.ai/api/v1"},
-		"generic":    {Type: "openai", BaseURL: "https://llm.example.com/v1"},
+	tests := []struct {
+		name    string
+		profile *config.ProviderProfile
+	}{
+		{name: "legacy endpoint without profile", profile: nil},
+		{name: "official openai", profile: &config.ProviderProfile{Type: "openai", BaseURL: "https://api.openai.com/v1"}},
+		{name: "official deepseek", profile: &config.ProviderProfile{Type: "openai", BaseURL: "https://api.deepseek.com/v1"}},
+		{name: "openrouter", profile: &config.ProviderProfile{Type: "openai", BaseURL: "https://openrouter.ai/api/v1"}},
+		{name: "generic openai compatible", profile: &config.ProviderProfile{Type: "openai", BaseURL: "https://llm.example.com/v1"}},
 		// A host that merely mentions azure is not an Azure endpoint.
-		"lookalike": {Type: "openai", BaseURL: "https://azure.example.com/v1"},
-	} {
-		t.Run(name, func(t *testing.T) {
-			assert.Empty(t, resolveOpenAIBackendDialect(profile).vendorExtensionProvider())
+		{name: "azure lookalike host", profile: &config.ProviderProfile{Type: "openai", BaseURL: "https://azure.example.com/v1"}},
+		// Suffix matching must not fire on a bare label match either.
+		{name: "azure lookalike suffix", profile: &config.ProviderProfile{Type: "openai", BaseURL: "https://notopenai.azure.com.evil.test/v1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Empty(t, resolveOpenAIBackendDialect(tt.profile).vendorExtensionProvider())
 		})
 	}
 }

--- a/src/semantic-router/pkg/extproc/req_filter_provider_dialect_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_provider_dialect_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 )
 
 func TestResolveOpenAIBackendDialect(t *testing.T) {
@@ -60,6 +61,39 @@ func TestResolveOpenAIBackendDialect(t *testing.T) {
 			assert.Equal(t, tt.wantKind, dialect.kind)
 			assert.Equal(t, tt.wantTopLevelEffort, dialect.usesTopLevelReasoningEffort())
 			assert.Equal(t, tt.wantTopLevelDeepSeekThink, dialect.usesDeepSeekOfficialReasoning())
+		})
+	}
+}
+
+func TestResolveOpenAIBackendDialectAzureHosts(t *testing.T) {
+	for name, baseURL := range map[string]string{
+		"azure openai":     "https://my-resource.openai.azure.com/openai/v1",
+		"ai foundry":       "https://my-resource.services.ai.azure.com/openai/v1",
+		"cognitiveservice": "https://my-resource.cognitiveservices.azure.com/openai/v1",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dialect := resolveOpenAIBackendDialect(&config.ProviderProfile{Type: "openai", BaseURL: baseURL})
+
+			assert.Equal(t, openAIBackendDialectAzureOpenAI, dialect.kind)
+			assert.Equal(t, llmprotocol.VendorAzure, dialect.vendorExtensionProvider())
+			// Azure request shaping is unchanged from the generic dialect.
+			assert.False(t, dialect.usesTopLevelReasoningEffort())
+		})
+	}
+}
+
+// Every other backend keeps the strict contract: no vendor allowance at all.
+func TestResolveOpenAIBackendDialectGrantsNoVendorAllowanceByDefault(t *testing.T) {
+	for name, profile := range map[string]*config.ProviderProfile{
+		"local vllm": nil,
+		"official":   {Type: "openai", BaseURL: "https://api.openai.com/v1"},
+		"openrouter": {Type: "openai", BaseURL: "https://openrouter.ai/api/v1"},
+		"generic":    {Type: "openai", BaseURL: "https://llm.example.com/v1"},
+		// A host that merely mentions azure is not an Azure endpoint.
+		"lookalike": {Type: "openai", BaseURL: "https://azure.example.com/v1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Empty(t, resolveOpenAIBackendDialect(profile).vendorExtensionProvider())
 		})
 	}
 }

--- a/src/semantic-router/pkg/extproc/req_filter_provider_dialect_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_provider_dialect_test.go
@@ -67,19 +67,21 @@ func TestResolveOpenAIBackendDialect(t *testing.T) {
 
 func TestResolveOpenAIBackendDialectAzureHosts(t *testing.T) {
 	tests := []struct {
-		name    string
-		baseURL string
+		name         string
+		providerType string
+		baseURL      string
 	}{
-		{name: "azure openai", baseURL: "https://my-resource.openai.azure.com/openai/v1"},
-		{name: "azure ai foundry", baseURL: "https://my-resource.services.ai.azure.com/openai/v1"},
-		{name: "cognitive services", baseURL: "https://my-resource.cognitiveservices.azure.com/openai/v1"},
+		{name: "canonical azure profile", providerType: "azure-openai"},
+		{name: "azure openai host", providerType: "openai", baseURL: "https://my-resource.openai.azure.com/openai/v1"},
+		{name: "azure ai foundry host", providerType: "openai", baseURL: "https://my-resource.services.ai.azure.com/openai/v1"},
+		{name: "cognitive services host", providerType: "openai", baseURL: "https://my-resource.cognitiveservices.azure.com/openai/v1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dialect := resolveOpenAIBackendDialect(&config.ProviderProfile{Type: "openai", BaseURL: tt.baseURL})
+			dialect := resolveOpenAIBackendDialect(&config.ProviderProfile{Type: tt.providerType, BaseURL: tt.baseURL})
 
 			assert.Equal(t, openAIBackendDialectAzureOpenAI, dialect.kind)
-			assert.Equal(t, llmprotocol.VendorAzure, dialect.vendorExtensionProvider())
+			assert.Equal(t, llmprotocol.ResponseVendorAzure, dialect.vendorExtensionProvider())
 			// Azure request shaping is unchanged from the generic dialect.
 			assert.False(t, dialect.usesTopLevelReasoningEffort())
 			assert.False(t, dialect.usesDeepSeekOfficialReasoning())

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -251,8 +251,12 @@ type RequestContext struct {
 
 	// SourceFormat and SemanticRequest are the authoritative public protocol
 	// contract and neutral request.
-	SourceFormat             llmprotocol.WireFormat
-	TargetFormat             llmprotocol.WireFormat
+	SourceFormat llmprotocol.WireFormat
+	TargetFormat llmprotocol.WireFormat
+	// ResponseVendor is the vendor allowance resolved from the selected
+	// backend's dialect. It scopes which documented response decorations the
+	// provider decoder may ignore; empty keeps the strict canonical contract.
+	ResponseVendor           string
 	SemanticRequest          *llmprotocol.Request
 	SemanticResponse         *llmprotocol.Response
 	ProtocolEnvelope         llmprotocol.Envelope

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -258,7 +258,7 @@ type RequestContext struct {
 	ProtocolEnvelope         llmprotocol.Envelope
 	ResponseEnvelope         llmprotocol.Envelope
 	ProtocolDiagnostics      llmprotocol.Diagnostics
-	ResponseVendor           string // Response-decoration allowance from the selected backend dialect; empty stays strict
+	ResponseVendor           llmprotocol.ResponseVendor
 	ImmediateProtocolError   *llmprotocol.ProtocolError
 	ImmediateResponseEncoded bool
 

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -251,17 +251,14 @@ type RequestContext struct {
 
 	// SourceFormat and SemanticRequest are the authoritative public protocol
 	// contract and neutral request.
-	SourceFormat llmprotocol.WireFormat
-	TargetFormat llmprotocol.WireFormat
-	// ResponseVendor is the vendor allowance resolved from the selected
-	// backend's dialect. It scopes which documented response decorations the
-	// provider decoder may ignore; empty keeps the strict canonical contract.
-	ResponseVendor           string
+	SourceFormat             llmprotocol.WireFormat
+	TargetFormat             llmprotocol.WireFormat
 	SemanticRequest          *llmprotocol.Request
 	SemanticResponse         *llmprotocol.Response
 	ProtocolEnvelope         llmprotocol.Envelope
 	ResponseEnvelope         llmprotocol.Envelope
 	ProtocolDiagnostics      llmprotocol.Diagnostics
+	ResponseVendor           string // Response-decoration allowance from the selected backend dialect; empty stays strict
 	ImmediateProtocolError   *llmprotocol.ProtocolError
 	ImmediateResponseEncoded bool
 

--- a/src/semantic-router/pkg/llmprotocol/policy.go
+++ b/src/semantic-router/pkg/llmprotocol/policy.go
@@ -28,12 +28,22 @@ const (
 	SourceBoundedSameFormat SourcePreservationPolicy = "bounded_same_format"
 )
 
+// VendorAzure names Azure OpenAI and Azure AI Foundry as a response-decoration
+// source. Vendor identifiers are deliberately explicit rather than free-form:
+// a backend only gets an allowance the router knows the shape of.
+const VendorAzure = "azure"
+
 type Policy struct {
 	UnknownFields      UnknownFieldPolicy
 	LossyFeatures      LossyPolicy
 	MissingStableIDs   MissingIDPolicy
 	SourcePreservation SourcePreservationPolicy
-	Limits             Limits
+	// ResponseVendor names the provider whose documented response decorations
+	// the decoder may ignore. Empty is the strict default: every field outside
+	// the canonical schema is rejected. It is set from the resolved backend
+	// dialect, so an allowance never applies to a backend that did not earn it.
+	ResponseVendor string
+	Limits         Limits
 }
 
 type Limits struct {

--- a/src/semantic-router/pkg/llmprotocol/policy.go
+++ b/src/semantic-router/pkg/llmprotocol/policy.go
@@ -28,10 +28,11 @@ const (
 	SourceBoundedSameFormat SourcePreservationPolicy = "bounded_same_format"
 )
 
-// VendorAzure names Azure OpenAI and Azure AI Foundry as a response-decoration
-// source. Vendor identifiers are deliberately explicit rather than free-form:
-// a backend only gets an allowance the router knows the shape of.
-const VendorAzure = "azure"
+// ResponseVendor identifies a provider with response-only wire extensions.
+type ResponseVendor string
+
+// ResponseVendorAzure permits Azure OpenAI response extensions.
+const ResponseVendorAzure ResponseVendor = "azure"
 
 type Policy struct {
 	UnknownFields      UnknownFieldPolicy
@@ -39,11 +40,9 @@ type Policy struct {
 	MissingStableIDs   MissingIDPolicy
 	SourcePreservation SourcePreservationPolicy
 	Limits             Limits
-	// ResponseVendor names the provider whose documented response decorations
-	// the decoder may ignore. Empty is the strict default: every field outside
-	// the canonical schema is rejected. It is set from the resolved backend
-	// dialect, so an allowance never applies to a backend that did not earn it.
-	ResponseVendor string
+	// ResponseVendor permits provider-specific fields at the response boundary.
+	// Empty keeps strict canonical decoding.
+	ResponseVendor ResponseVendor
 }
 
 type Limits struct {

--- a/src/semantic-router/pkg/llmprotocol/policy.go
+++ b/src/semantic-router/pkg/llmprotocol/policy.go
@@ -38,12 +38,12 @@ type Policy struct {
 	LossyFeatures      LossyPolicy
 	MissingStableIDs   MissingIDPolicy
 	SourcePreservation SourcePreservationPolicy
+	Limits             Limits
 	// ResponseVendor names the provider whose documented response decorations
 	// the decoder may ignore. Empty is the strict default: every field outside
 	// the canonical schema is rejected. It is set from the resolved backend
 	// dialect, so an allowance never applies to a backend that did not earn it.
 	ResponseVendor string
-	Limits         Limits
 }
 
 type Limits struct {

--- a/src/semantic-router/pkg/protocolcodec/codec_openai_chat_response.go
+++ b/src/semantic-router/pkg/protocolcodec/codec_openai_chat_response.go
@@ -313,7 +313,7 @@ func (OpenAIChatCodec) DecodeTransportError(
 	body []byte,
 	policy llmprotocol.Policy,
 ) (llmprotocol.TransportError, llmprotocol.Diagnostics, error) {
-	return decodeOpenAITransportError(body, policy)
+	return decodeOpenAITransportError(body, policy, llmprotocol.OpenAIChatV1)
 }
 
 func (OpenAIChatCodec) EncodeTransportError(transportError llmprotocol.TransportError) []byte {

--- a/src/semantic-router/pkg/protocolcodec/codec_openai_chat_response.go
+++ b/src/semantic-router/pkg/protocolcodec/codec_openai_chat_response.go
@@ -9,7 +9,8 @@ import (
 
 func (OpenAIChatCodec) DecodeResponse(body []byte, policy llmprotocol.Policy) (llmprotocol.Response, llmprotocol.Envelope, llmprotocol.Diagnostics, error) {
 	var wire chatResponseWire
-	if err := decodeProviderWire(body, &wire, policy); err != nil {
+	vendorExtensions, err := decodeProviderWireVendorAware(body, &wire, policy)
+	if err != nil {
 		return llmprotocol.Response{}, llmprotocol.Envelope{}, nil, err
 	}
 	if err := validateChatResponseResource(wire); err != nil {
@@ -20,6 +21,7 @@ func (OpenAIChatCodec) DecodeResponse(body []byte, policy llmprotocol.Policy) (l
 	}
 	response := decodeChatResponseEnvelope(wire)
 	var diagnostics llmprotocol.Diagnostics
+	appendVendorExtensionDiagnostics(&diagnostics, policy, llmprotocol.OpenAIChatV1, vendorExtensions)
 	appendProviderFieldOmissions(&diagnostics, policy, llmprotocol.OpenAIChatV1, map[string]bool{
 		"choices.message.tool_calls.function.TokenizedArguments": chatChoicesHaveTokenizedArguments(wire.Choices),
 		"kv_transfer": wire.hasLegacyKVTransferMetadata(),

--- a/src/semantic-router/pkg/protocolcodec/codec_openai_responses_response.go
+++ b/src/semantic-router/pkg/protocolcodec/codec_openai_responses_response.go
@@ -512,7 +512,7 @@ func (OpenAIResponsesCodec) DecodeTransportError(
 	body []byte,
 	policy llmprotocol.Policy,
 ) (llmprotocol.TransportError, llmprotocol.Diagnostics, error) {
-	return decodeOpenAITransportError(body, policy)
+	return decodeOpenAITransportError(body, policy, llmprotocol.OpenAIResponsesV1)
 }
 
 func (OpenAIResponsesCodec) EncodeTransportError(transportError llmprotocol.TransportError) []byte {

--- a/src/semantic-router/pkg/protocolcodec/codec_openai_responses_response.go
+++ b/src/semantic-router/pkg/protocolcodec/codec_openai_responses_response.go
@@ -114,6 +114,11 @@ func (OpenAIResponsesCodec) DecodeResponse(body []byte, policy llmprotocol.Polic
 	if err := validateResponsesResponseResource(wire, false); err != nil {
 		return llmprotocol.Response{}, llmprotocol.Envelope{}, nil, err
 	}
+	nestedVendorExtensions, err := responsesOutputVendorExtensions(wire.Output, policy)
+	if err != nil {
+		return llmprotocol.Response{}, llmprotocol.Envelope{}, nil, err
+	}
+	vendorExtensions = append(vendorExtensions, nestedVendorExtensions...)
 	var diagnostics llmprotocol.Diagnostics
 	appendVendorExtensionDiagnostics(&diagnostics, policy, llmprotocol.OpenAIResponsesV1, vendorExtensions)
 	diagnostics = appendDiagnostics(diagnostics, responsesResponseMetadataDiagnostics(wire, policy), policy.Limits.Diagnostics)

--- a/src/semantic-router/pkg/protocolcodec/codec_openai_responses_response.go
+++ b/src/semantic-router/pkg/protocolcodec/codec_openai_responses_response.go
@@ -107,13 +107,16 @@ func responsesErrorCode(protocolError *llmprotocol.ProtocolError) string {
 
 func (OpenAIResponsesCodec) DecodeResponse(body []byte, policy llmprotocol.Policy) (llmprotocol.Response, llmprotocol.Envelope, llmprotocol.Diagnostics, error) {
 	var wire responsesResponseWire
-	if err := decodeProviderWire(body, &wire, policy); err != nil {
+	vendorExtensions, err := decodeProviderWireVendorAware(body, &wire, policy)
+	if err != nil {
 		return llmprotocol.Response{}, llmprotocol.Envelope{}, nil, err
 	}
 	if err := validateResponsesResponseResource(wire, false); err != nil {
 		return llmprotocol.Response{}, llmprotocol.Envelope{}, nil, err
 	}
-	diagnostics := responsesResponseMetadataDiagnostics(wire, policy)
+	var diagnostics llmprotocol.Diagnostics
+	appendVendorExtensionDiagnostics(&diagnostics, policy, llmprotocol.OpenAIResponsesV1, vendorExtensions)
+	diagnostics = appendDiagnostics(diagnostics, responsesResponseMetadataDiagnostics(wire, policy), policy.Limits.Diagnostics)
 	response, err := decodeResponsesResponseResource(wire, policy, &diagnostics)
 	if err != nil {
 		return llmprotocol.Response{}, llmprotocol.Envelope{}, nil, err

--- a/src/semantic-router/pkg/protocolcodec/engine.go
+++ b/src/semantic-router/pkg/protocolcodec/engine.go
@@ -486,6 +486,9 @@ func validatePolicy(policy llmprotocol.Policy) error {
 	if policy.SourcePreservation != llmprotocol.SourceDisabled && policy.SourcePreservation != llmprotocol.SourceBoundedSameFormat {
 		return fmt.Errorf("source-preservation policy is invalid")
 	}
+	if policy.ResponseVendor != "" && policy.ResponseVendor != llmprotocol.ResponseVendorAzure {
+		return fmt.Errorf("response-vendor policy is invalid")
+	}
 	if !positiveProtocolLimits(policy.Limits) {
 		return fmt.Errorf("protocol limits must be positive")
 	}

--- a/src/semantic-router/pkg/protocolcodec/json_helpers.go
+++ b/src/semantic-router/pkg/protocolcodec/json_helpers.go
@@ -97,17 +97,13 @@ func decodeProviderJSON(body []byte, target any, policy llmprotocol.Policy, requ
 		// Documented decorations from the backend's resolved vendor are removed
 		// before the canonical check so a provider that always emits them stays
 		// usable. Every other unknown field still fails below.
-		canonical, _ := stripProviderVendorExtensions(body, policy.ResponseVendor)
+		canonical := stripProviderVendorExtensions(body, policy.ResponseVendor)
 		if err := validateExactJSONFieldNames(canonical, reflect.TypeOf(target)); err != nil {
-			// Name the field. Without it an operator sees only "non-canonical
-			// field" and has no way to tell which provider extension broke the
-			// response or which vendor allowance would cover it.
-			return llmprotocol.NewError(
-				llmprotocol.ErrorUpstreamUnavailable,
-				"invalid_upstream_json",
-				fmt.Sprintf("upstream response JSON contains a non-canonical field: %s", err.Error()),
-				err,
-			)
+			// The offending field name stays in the cause, never in Message:
+			// Message is serialized into the client-facing error body, and the
+			// upstream response shape is not the caller's to see. Operators get
+			// it from the decode log, which unwraps the cause.
+			return llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON contains a non-canonical field", err)
 		}
 		decoder = json.NewDecoder(bytes.NewReader(canonical))
 		decoder.DisallowUnknownFields()

--- a/src/semantic-router/pkg/protocolcodec/json_helpers.go
+++ b/src/semantic-router/pkg/protocolcodec/json_helpers.go
@@ -78,6 +78,15 @@ func validateClientJSONDocument(body []byte, policy llmprotocol.Policy, requireO
 }
 
 func decodeProviderWire(body []byte, target any, policy llmprotocol.Policy) error {
+	_, err := decodeProviderJSON(body, target, policy, true)
+	return err
+}
+
+// decodeProviderWireVendorAware is decodeProviderWire for callers that can
+// raise diagnostics. It returns the vendor extension fields dropped from the
+// response so nothing is discarded unobserved; the fields are always empty for
+// a backend with no vendor allowance.
+func decodeProviderWireVendorAware(body []byte, target any, policy llmprotocol.Policy) ([]string, error) {
 	return decodeProviderJSON(body, target, policy, true)
 }
 
@@ -85,36 +94,41 @@ func decodeProviderWire(body []byte, target any, policy llmprotocol.Policy) erro
 // response envelopes remain object-only, while their typed nested arrays and
 // scalars use this path without weakening any other JSON validation.
 func decodeProviderValue(body []byte, target any, policy llmprotocol.Policy) error {
-	return decodeProviderJSON(body, target, policy, false)
+	_, err := decodeProviderJSON(body, target, policy, false)
+	return err
 }
 
-func decodeProviderJSON(body []byte, target any, policy llmprotocol.Policy, requireObject bool) error {
+func decodeProviderJSON(body []byte, target any, policy llmprotocol.Policy, requireObject bool) ([]string, error) {
 	if err := validateProviderJSONDocument(body, policy, requireObject); err != nil {
-		return err
+		return nil, err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
+	var dropped []string
 	if rejectUnknownFields(body, policy) {
-		// Documented decorations from the backend's resolved vendor are removed
-		// before the canonical check so a provider that always emits them stays
-		// usable. Every other unknown field still fails below.
-		canonical := stripProviderVendorExtensions(body, policy.ResponseVendor)
+		canonical := body
+		if providerVendorExtensionsAllowed(policy) {
+			// A vendor-identified backend may decorate its responses, so its
+			// extras are removed before the canonical check instead of failing
+			// the request. Every backend without an allowance is untouched.
+			canonical, dropped = stripProviderVendorExtensions(body, reflect.TypeOf(target))
+		}
 		if err := validateExactJSONFieldNames(canonical, reflect.TypeOf(target)); err != nil {
 			// The offending field name stays in the cause, never in Message:
 			// Message is serialized into the client-facing error body, and the
 			// upstream response shape is not the caller's to see. Operators get
 			// it from the decode log, which unwraps the cause.
-			return llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON contains a non-canonical field", err)
+			return nil, llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON contains a non-canonical field", err)
 		}
 		decoder = json.NewDecoder(bytes.NewReader(canonical))
 		decoder.DisallowUnknownFields()
 	}
 	if err := decoder.Decode(target); err != nil {
-		return llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON is invalid", err)
+		return dropped, llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON is invalid", err)
 	}
 	if err := requireEOF(decoder); err != nil {
-		return llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "upstream_trailing_json", "upstream response contains trailing JSON", err)
+		return dropped, llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "upstream_trailing_json", "upstream response contains trailing JSON", err)
 	}
-	return nil
+	return dropped, nil
 }
 
 func validateProviderJSONDocument(body []byte, policy llmprotocol.Policy, requireObject bool) error {

--- a/src/semantic-router/pkg/protocolcodec/json_helpers.go
+++ b/src/semantic-router/pkg/protocolcodec/json_helpers.go
@@ -82,10 +82,7 @@ func decodeProviderWire(body []byte, target any, policy llmprotocol.Policy) erro
 	return err
 }
 
-// decodeProviderWireVendorAware is decodeProviderWire for callers that can
-// raise diagnostics. It returns the vendor extension fields dropped from the
-// response so nothing is discarded unobserved; the fields are always empty for
-// a backend with no vendor allowance.
+// decodeProviderWireVendorAware returns any extensions removed during decode.
 func decodeProviderWireVendorAware(body []byte, target any, policy llmprotocol.Policy) ([]string, error) {
 	return decodeProviderJSON(body, target, policy, true)
 }
@@ -107,16 +104,10 @@ func decodeProviderJSON(body []byte, target any, policy llmprotocol.Policy, requ
 	if rejectUnknownFields(body, policy) {
 		canonical := body
 		if providerVendorExtensionsAllowed(policy) {
-			// A vendor-identified backend may decorate its responses, so its
-			// extras are removed before the canonical check instead of failing
-			// the request. Every backend without an allowance is untouched.
 			canonical, dropped = stripProviderVendorExtensions(body, reflect.TypeOf(target))
 		}
 		if err := validateExactJSONFieldNames(canonical, reflect.TypeOf(target)); err != nil {
-			// The offending field name stays in the cause, never in Message:
-			// Message is serialized into the client-facing error body, and the
-			// upstream response shape is not the caller's to see. Operators get
-			// it from the decode log, which unwraps the cause.
+			// Keep field details in the private cause, not the client message.
 			return nil, llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON contains a non-canonical field", err)
 		}
 		decoder = json.NewDecoder(bytes.NewReader(canonical))

--- a/src/semantic-router/pkg/protocolcodec/json_helpers.go
+++ b/src/semantic-router/pkg/protocolcodec/json_helpers.go
@@ -94,12 +94,20 @@ func decodeProviderJSON(body []byte, target any, policy llmprotocol.Policy, requ
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	if rejectUnknownFields(body, policy) {
-		// Known vendor decorations are removed before the canonical check so a
-		// provider that always emits them stays usable. Every other unknown
-		// field still fails below.
-		canonical, _ := stripProviderVendorExtensions(body)
+		// Documented decorations from the backend's resolved vendor are removed
+		// before the canonical check so a provider that always emits them stays
+		// usable. Every other unknown field still fails below.
+		canonical, _ := stripProviderVendorExtensions(body, policy.ResponseVendor)
 		if err := validateExactJSONFieldNames(canonical, reflect.TypeOf(target)); err != nil {
-			return llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON contains a non-canonical field", err)
+			// Name the field. Without it an operator sees only "non-canonical
+			// field" and has no way to tell which provider extension broke the
+			// response or which vendor allowance would cover it.
+			return llmprotocol.NewError(
+				llmprotocol.ErrorUpstreamUnavailable,
+				"invalid_upstream_json",
+				fmt.Sprintf("upstream response JSON contains a non-canonical field: %s", err.Error()),
+				err,
+			)
 		}
 		decoder = json.NewDecoder(bytes.NewReader(canonical))
 		decoder.DisallowUnknownFields()

--- a/src/semantic-router/pkg/protocolcodec/json_helpers.go
+++ b/src/semantic-router/pkg/protocolcodec/json_helpers.go
@@ -94,9 +94,14 @@ func decodeProviderJSON(body []byte, target any, policy llmprotocol.Policy, requ
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	if rejectUnknownFields(body, policy) {
-		if err := validateExactJSONFieldNames(body, reflect.TypeOf(target)); err != nil {
+		// Known vendor decorations are removed before the canonical check so a
+		// provider that always emits them stays usable. Every other unknown
+		// field still fails below.
+		canonical, _ := stripProviderVendorExtensions(body)
+		if err := validateExactJSONFieldNames(canonical, reflect.TypeOf(target)); err != nil {
 			return llmprotocol.NewError(llmprotocol.ErrorUpstreamUnavailable, "invalid_upstream_json", "upstream response JSON contains a non-canonical field", err)
 		}
+		decoder = json.NewDecoder(bytes.NewReader(canonical))
 		decoder.DisallowUnknownFields()
 	}
 	if err := decoder.Decode(target); err != nil {

--- a/src/semantic-router/pkg/protocolcodec/json_helpers.go
+++ b/src/semantic-router/pkg/protocolcodec/json_helpers.go
@@ -95,6 +95,10 @@ func decodeProviderValue(body []byte, target any, policy llmprotocol.Policy) err
 	return err
 }
 
+func decodeProviderValueVendorAware(body []byte, target any, policy llmprotocol.Policy) ([]string, error) {
+	return decodeProviderJSON(body, target, policy, false)
+}
+
 func decodeProviderJSON(body []byte, target any, policy llmprotocol.Policy, requireObject bool) ([]string, error) {
 	if err := validateProviderJSONDocument(body, policy, requireObject); err != nil {
 		return nil, err

--- a/src/semantic-router/pkg/protocolcodec/matrix_fidelity_test.go
+++ b/src/semantic-router/pkg/protocolcodec/matrix_fidelity_test.go
@@ -45,6 +45,9 @@ func TestPolicyEnumsAndEveryLimitAreClosed(t *testing.T) {
 		"source preservation": func(policy *llmprotocol.Policy) {
 			policy.SourcePreservation = llmprotocol.SourcePreservationPolicy("future")
 		},
+		"response vendor": func(policy *llmprotocol.Policy) {
+			policy.ResponseVendor = llmprotocol.ResponseVendor("future")
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			policy := llmprotocol.DefaultPolicy()

--- a/src/semantic-router/pkg/protocolcodec/openai_transport_error.go
+++ b/src/semantic-router/pkg/protocolcodec/openai_transport_error.go
@@ -19,13 +19,17 @@ type openAITransportErrorDetailWire struct {
 func decodeOpenAITransportError(
 	body []byte,
 	policy llmprotocol.Policy,
+	format llmprotocol.WireFormat,
 ) (llmprotocol.TransportError, llmprotocol.Diagnostics, error) {
 	var wire openAITransportErrorWire
-	if err := decodeProviderWire(body, &wire, policy); err != nil {
+	vendorExtensions, err := decodeProviderWireVendorAware(body, &wire, policy)
+	if err != nil {
 		return llmprotocol.TransportError{}, nil, err
 	}
+	var diagnostics llmprotocol.Diagnostics
+	appendVendorExtensionDiagnostics(&diagnostics, policy, format, vendorExtensions)
 	if wire.Error == nil {
-		return llmprotocol.TransportError{}, nil, llmprotocol.NewError(
+		return llmprotocol.TransportError{}, diagnostics, llmprotocol.NewError(
 			llmprotocol.ErrorUpstreamUnavailable,
 			"upstream_error_required",
 			"upstream transport error body is missing error details",
@@ -33,7 +37,7 @@ func decodeOpenAITransportError(
 		)
 	}
 	if err := validateTransportErrorDetails(wire.Error.Type, wire.Error.Message); err != nil {
-		return llmprotocol.TransportError{}, nil, err
+		return llmprotocol.TransportError{}, diagnostics, err
 	}
 	code, parameter := "", ""
 	if wire.Error.Code != nil {
@@ -47,7 +51,7 @@ func decodeOpenAITransportError(
 		Code:      code,
 		Message:   wire.Error.Message,
 		Parameter: parameter,
-	}}, nil, nil
+	}}, diagnostics, nil
 }
 
 func encodeOpenAITransportError(transportError llmprotocol.TransportError) []byte {

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
@@ -1,0 +1,129 @@
+package protocolcodec
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+)
+
+// providerVendorExtensionFields lists provider response fields that are known,
+// documented vendor decorations rather than canonical protocol fields. They are
+// keyed by their normalized path from the response envelope, where "[]" denotes
+// an array element, so a name is only ever ignored where that provider actually
+// emits it.
+//
+// Strict rejection of unknown provider fields is deliberate: a field the router
+// does not understand must never disappear silently on the way to the client.
+// These entries are the narrow exception. Each one is inert telemetry or
+// moderation metadata that carries no routing, billing, or content semantics,
+// so dropping it cannot change what the client sees. Anything not listed here
+// still fails decode with invalid_upstream_json.
+var providerVendorExtensionFields = map[string]string{
+	// Azure OpenAI and Azure AI Foundry decorate every response.
+	"prompt_filter_results":            "azure",
+	"routing":                          "azure",
+	"choices[].content_filter_results": "azure",
+	"usage.latency_checkpoint":         "azure",
+}
+
+// stripProviderVendorExtensions removes known vendor extension fields from a
+// provider response body before strict canonical validation runs. It returns
+// the rewritten body and the sorted paths it removed; when nothing matches it
+// returns the original slice so the common path stays allocation-free.
+//
+// The rewrite only ever deletes allowlisted keys. Values are carried through as
+// raw JSON, so numbers, escapes, and nesting survive byte-for-byte. Object key
+// order is not preserved, which is why this never runs on the byte-identical
+// source-preservation path: rejectUnknownFields is false there.
+func stripProviderVendorExtensions(body []byte) ([]byte, []string) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return body, nil
+	}
+	removed := map[string]struct{}{}
+	rewritten, changed := stripVendorExtensionValue(trimmed, "", removed)
+	if !changed {
+		return body, nil
+	}
+	paths := make([]string, 0, len(removed))
+	for path := range removed {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return rewritten, paths
+}
+
+func stripVendorExtensionValue(raw json.RawMessage, path string, removed map[string]struct{}) (json.RawMessage, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return raw, false
+	}
+	switch trimmed[0] {
+	case '{':
+		return stripVendorExtensionObject(trimmed, path, removed)
+	case '[':
+		return stripVendorExtensionArray(trimmed, path, removed)
+	}
+	return raw, false
+}
+
+func stripVendorExtensionObject(raw json.RawMessage, path string, removed map[string]struct{}) (json.RawMessage, bool) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		// Malformed JSON is not this function's error to report; leave the body
+		// untouched so the decoder produces the canonical failure.
+		return raw, false
+	}
+	changed := false
+	for name, value := range object {
+		child := vendorExtensionPath(path, name)
+		if _, vendor := providerVendorExtensionFields[child]; vendor {
+			delete(object, name)
+			removed[child] = struct{}{}
+			changed = true
+			continue
+		}
+		if rewritten, childChanged := stripVendorExtensionValue(value, child, removed); childChanged {
+			object[name] = rewritten
+			changed = true
+		}
+	}
+	if !changed {
+		return raw, false
+	}
+	rewritten, err := json.Marshal(object)
+	if err != nil {
+		return raw, false
+	}
+	return rewritten, true
+}
+
+func stripVendorExtensionArray(raw json.RawMessage, path string, removed map[string]struct{}) (json.RawMessage, bool) {
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return raw, false
+	}
+	changed := false
+	elementPath := path + "[]"
+	for index, element := range elements {
+		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, removed); elementChanged {
+			elements[index] = rewritten
+			changed = true
+		}
+	}
+	if !changed {
+		return raw, false
+	}
+	rewritten, err := json.Marshal(elements)
+	if err != nil {
+		return raw, false
+	}
+	return rewritten, true
+}
+
+func vendorExtensionPath(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return parent + "." + name
+}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
@@ -3,7 +3,6 @@ package protocolcodec
 import (
 	"bytes"
 	"encoding/json"
-	"sort"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 )
@@ -32,51 +31,45 @@ var providerVendorExtensionFields = map[string]map[string]struct{}{
 }
 
 // stripProviderVendorExtensions removes known vendor extension fields from a
-// provider response body before strict canonical validation runs. It returns
-// the rewritten body and the sorted paths it removed; when nothing matches it
-// returns the original slice so the common path stays allocation-free.
+// provider response body before strict canonical validation runs. When nothing
+// matches it returns the original slice, so the common path stays
+// allocation-free.
 //
 // The rewrite only ever deletes allowlisted keys. Values are carried through as
 // raw JSON, so numbers, escapes, and nesting survive byte-for-byte. Object key
 // order is not preserved, which is why this never runs on the byte-identical
 // source-preservation path: rejectUnknownFields is false there.
-func stripProviderVendorExtensions(body []byte, vendor string) ([]byte, []string) {
+func stripProviderVendorExtensions(body []byte, vendor string) []byte {
 	allowed, known := providerVendorExtensionFields[vendor]
 	if !known || len(allowed) == 0 {
-		return body, nil
+		return body
 	}
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 || trimmed[0] != '{' {
-		return body, nil
+		return body
 	}
-	removed := map[string]struct{}{}
-	rewritten, changed := stripVendorExtensionValue(trimmed, "", allowed, removed)
+	rewritten, changed := stripVendorExtensionValue(trimmed, "", allowed)
 	if !changed {
-		return body, nil
+		return body
 	}
-	paths := make([]string, 0, len(removed))
-	for path := range removed {
-		paths = append(paths, path)
-	}
-	sort.Strings(paths)
-	return rewritten, paths
+	return rewritten
 }
 
-func stripVendorExtensionValue(raw json.RawMessage, path string, allowed, removed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionValue(raw json.RawMessage, path string, allowed map[string]struct{}) (json.RawMessage, bool) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 {
 		return raw, false
 	}
 	switch trimmed[0] {
 	case '{':
-		return stripVendorExtensionObject(trimmed, path, allowed, removed)
+		return stripVendorExtensionObject(trimmed, path, allowed)
 	case '[':
-		return stripVendorExtensionArray(trimmed, path, allowed, removed)
+		return stripVendorExtensionArray(trimmed, path, allowed)
 	}
 	return raw, false
 }
 
-func stripVendorExtensionObject(raw json.RawMessage, path string, allowed, removed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionObject(raw json.RawMessage, path string, allowed map[string]struct{}) (json.RawMessage, bool) {
 	var object map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &object); err != nil {
 		// Malformed JSON is not this function's error to report; leave the body
@@ -88,11 +81,10 @@ func stripVendorExtensionObject(raw json.RawMessage, path string, allowed, remov
 		child := vendorExtensionPath(path, name)
 		if _, vendor := allowed[child]; vendor {
 			delete(object, name)
-			removed[child] = struct{}{}
 			changed = true
 			continue
 		}
-		if rewritten, childChanged := stripVendorExtensionValue(value, child, allowed, removed); childChanged {
+		if rewritten, childChanged := stripVendorExtensionValue(value, child, allowed); childChanged {
 			object[name] = rewritten
 			changed = true
 		}
@@ -107,7 +99,7 @@ func stripVendorExtensionObject(raw json.RawMessage, path string, allowed, remov
 	return rewritten, true
 }
 
-func stripVendorExtensionArray(raw json.RawMessage, path string, allowed, removed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionArray(raw json.RawMessage, path string, allowed map[string]struct{}) (json.RawMessage, bool) {
 	var elements []json.RawMessage
 	if err := json.Unmarshal(raw, &elements); err != nil {
 		return raw, false
@@ -115,7 +107,7 @@ func stripVendorExtensionArray(raw json.RawMessage, path string, allowed, remove
 	changed := false
 	elementPath := path + "[]"
 	for index, element := range elements {
-		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, allowed, removed); elementChanged {
+		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, allowed); elementChanged {
 			elements[index] = rewritten
 			changed = true
 		}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"sort"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 )
 
 // providerVendorExtensionFields lists provider response fields that are known,
 // documented vendor decorations rather than canonical protocol fields. They are
-// keyed by their normalized path from the response envelope, where "[]" denotes
-// an array element, so a name is only ever ignored where that provider actually
-// emits it.
+// keyed first by vendor and then by normalized path from the response envelope,
+// where "[]" denotes an array element. A backend only receives the allowance for
+// the vendor its resolved dialect identified, so a name is only ever ignored for
+// the provider that documents it, at the path it actually emits it.
 //
 // Strict rejection of unknown provider fields is deliberate: a field the router
 // does not understand must never disappear silently on the way to the client.
@@ -18,12 +21,14 @@ import (
 // moderation metadata that carries no routing, billing, or content semantics,
 // so dropping it cannot change what the client sees. Anything not listed here
 // still fails decode with invalid_upstream_json.
-var providerVendorExtensionFields = map[string]string{
+var providerVendorExtensionFields = map[string]map[string]struct{}{
 	// Azure OpenAI and Azure AI Foundry decorate every response.
-	"prompt_filter_results":            "azure",
-	"routing":                          "azure",
-	"choices[].content_filter_results": "azure",
-	"usage.latency_checkpoint":         "azure",
+	llmprotocol.VendorAzure: {
+		"prompt_filter_results":            {},
+		"routing":                          {},
+		"choices[].content_filter_results": {},
+		"usage.latency_checkpoint":         {},
+	},
 }
 
 // stripProviderVendorExtensions removes known vendor extension fields from a
@@ -35,13 +40,17 @@ var providerVendorExtensionFields = map[string]string{
 // raw JSON, so numbers, escapes, and nesting survive byte-for-byte. Object key
 // order is not preserved, which is why this never runs on the byte-identical
 // source-preservation path: rejectUnknownFields is false there.
-func stripProviderVendorExtensions(body []byte) ([]byte, []string) {
+func stripProviderVendorExtensions(body []byte, vendor string) ([]byte, []string) {
+	allowed, known := providerVendorExtensionFields[vendor]
+	if !known || len(allowed) == 0 {
+		return body, nil
+	}
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 || trimmed[0] != '{' {
 		return body, nil
 	}
 	removed := map[string]struct{}{}
-	rewritten, changed := stripVendorExtensionValue(trimmed, "", removed)
+	rewritten, changed := stripVendorExtensionValue(trimmed, "", allowed, removed)
 	if !changed {
 		return body, nil
 	}
@@ -53,21 +62,21 @@ func stripProviderVendorExtensions(body []byte) ([]byte, []string) {
 	return rewritten, paths
 }
 
-func stripVendorExtensionValue(raw json.RawMessage, path string, removed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionValue(raw json.RawMessage, path string, allowed, removed map[string]struct{}) (json.RawMessage, bool) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 {
 		return raw, false
 	}
 	switch trimmed[0] {
 	case '{':
-		return stripVendorExtensionObject(trimmed, path, removed)
+		return stripVendorExtensionObject(trimmed, path, allowed, removed)
 	case '[':
-		return stripVendorExtensionArray(trimmed, path, removed)
+		return stripVendorExtensionArray(trimmed, path, allowed, removed)
 	}
 	return raw, false
 }
 
-func stripVendorExtensionObject(raw json.RawMessage, path string, removed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionObject(raw json.RawMessage, path string, allowed, removed map[string]struct{}) (json.RawMessage, bool) {
 	var object map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &object); err != nil {
 		// Malformed JSON is not this function's error to report; leave the body
@@ -77,13 +86,13 @@ func stripVendorExtensionObject(raw json.RawMessage, path string, removed map[st
 	changed := false
 	for name, value := range object {
 		child := vendorExtensionPath(path, name)
-		if _, vendor := providerVendorExtensionFields[child]; vendor {
+		if _, vendor := allowed[child]; vendor {
 			delete(object, name)
 			removed[child] = struct{}{}
 			changed = true
 			continue
 		}
-		if rewritten, childChanged := stripVendorExtensionValue(value, child, removed); childChanged {
+		if rewritten, childChanged := stripVendorExtensionValue(value, child, allowed, removed); childChanged {
 			object[name] = rewritten
 			changed = true
 		}
@@ -98,7 +107,7 @@ func stripVendorExtensionObject(raw json.RawMessage, path string, removed map[st
 	return rewritten, true
 }
 
-func stripVendorExtensionArray(raw json.RawMessage, path string, removed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionArray(raw json.RawMessage, path string, allowed, removed map[string]struct{}) (json.RawMessage, bool) {
 	var elements []json.RawMessage
 	if err := json.Unmarshal(raw, &elements); err != nil {
 		return raw, false
@@ -106,7 +115,7 @@ func stripVendorExtensionArray(raw json.RawMessage, path string, removed map[str
 	changed := false
 	elementPath := path + "[]"
 	for index, element := range elements {
-		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, removed); elementChanged {
+		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, allowed, removed); elementChanged {
 			elements[index] = rewritten
 			changed = true
 		}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
@@ -3,73 +3,129 @@ package protocolcodec
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
+	"sort"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 )
 
-// providerVendorExtensionFields lists provider response fields that are known,
-// documented vendor decorations rather than canonical protocol fields. They are
-// keyed first by vendor and then by normalized path from the response envelope,
-// where "[]" denotes an array element. A backend only receives the allowance for
-// the vendor its resolved dialect identified, so a name is only ever ignored for
-// the provider that documents it, at the path it actually emits it.
+// vendorExtensionReason is recorded on every dropped field so a diagnostic
+// reader can tell a vendor decoration apart from a field the router chose not
+// to carry across formats.
+const vendorExtensionReason = "provider vendor extension field is not part of the canonical response contract"
+
+// providerVendorExtensionsAllowed reports whether the backend that produced
+// this response was identified as a vendor known to decorate its responses.
 //
-// Strict rejection of unknown provider fields is deliberate: a field the router
-// does not understand must never disappear silently on the way to the client.
-// These entries are the narrow exception. Each one is inert telemetry or
-// moderation metadata that carries no routing, billing, or content semantics,
-// so dropping it cannot change what the client sees. Anything not listed here
-// still fails decode with invalid_upstream_json.
-var providerVendorExtensionFields = map[string]map[string]struct{}{
-	// Azure OpenAI and Azure AI Foundry decorate every response.
-	llmprotocol.VendorAzure: {
-		"prompt_filter_results":            {},
-		"routing":                          {},
-		"choices[].content_filter_results": {},
-		"usage.latency_checkpoint":         {},
-	},
+// The allowance is deliberately per-backend rather than per-field-name. Azure
+// has emitted content_filter_results for years and ships new decorations across
+// API versions, so a fixed name list would fail the first time they add one -
+// the exact failure #3496 reports. Scoping by resolved dialect keeps every
+// other backend under the strict canonical contract.
+func providerVendorExtensionsAllowed(policy llmprotocol.Policy) bool {
+	switch policy.ResponseVendor {
+	case llmprotocol.VendorAzure:
+		return true
+	default:
+		return false
+	}
 }
 
-// stripProviderVendorExtensions removes known vendor extension fields from a
-// provider response body before strict canonical validation runs. When nothing
-// matches it returns the original slice, so the common path stays
-// allocation-free.
+// stripProviderVendorExtensions removes the fields a vendor-identified backend
+// added outside the canonical schema, returning the rewritten body and the
+// sorted paths it removed. Nothing is dropped silently: every path is reported
+// so the caller can raise a diagnostic for it.
 //
-// The rewrite only ever deletes allowlisted keys. Values are carried through as
-// raw JSON, so numbers, escapes, and nesting survive byte-for-byte. Object key
-// order is not preserved, which is why this never runs on the byte-identical
-// source-preservation path: rejectUnknownFields is false there.
-func stripProviderVendorExtensions(body []byte, vendor string) []byte {
-	allowed, known := providerVendorExtensionFields[vendor]
-	if !known || len(allowed) == 0 {
-		return body
-	}
+// When nothing matches, the original slice is returned so the common path stays
+// allocation-free. Object key order is not preserved by the rewrite, which is
+// why this never runs on the byte-identical source-preservation path -
+// rejectUnknownFields is false there.
+func stripProviderVendorExtensions(body []byte, targetType reflect.Type) ([]byte, []string) {
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 || trimmed[0] != '{' {
-		return body
+		return body, nil
 	}
-	rewritten, changed := stripVendorExtensionValue(trimmed, "", allowed)
+	unknown := map[string]struct{}{}
+	collectUnknownJSONFieldPaths(trimmed, dereferenceJSONType(targetType), "", unknown)
+	if len(unknown) == 0 {
+		return body, nil
+	}
+	rewritten, changed := stripVendorExtensionValue(trimmed, "", unknown)
 	if !changed {
-		return body
+		return body, nil
 	}
-	return rewritten
+	paths := make([]string, 0, len(unknown))
+	for path := range unknown {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return rewritten, paths
 }
 
-func stripVendorExtensionValue(raw json.RawMessage, path string, allowed map[string]struct{}) (json.RawMessage, bool) {
+// collectUnknownJSONFieldPaths mirrors validateExactJSONValue, recording the
+// normalized path of every field the canonical schema does not declare instead
+// of failing on the first one. "[]" denotes an array element, so one path
+// covers every element of a repeated field.
+func collectUnknownJSONFieldPaths(body []byte, targetType reflect.Type, path string, unknown map[string]struct{}) {
+	if targetType == nil || bytes.Equal(bytes.TrimSpace(body), []byte("null")) ||
+		reflect.PointerTo(targetType).Implements(jsonUnmarshalerType) {
+		return
+	}
+	switch targetType.Kind() {
+	case reflect.Struct:
+		collectUnknownJSONObjectPaths(body, targetType, path, unknown)
+	case reflect.Slice, reflect.Array:
+		collectUnknownJSONArrayPaths(body, targetType, path, unknown)
+	}
+}
+
+func collectUnknownJSONObjectPaths(body []byte, targetType reflect.Type, path string, unknown map[string]struct{}) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(body, &object); err != nil {
+		return
+	}
+	fields := exactJSONStructFields(targetType)
+	for name, value := range object {
+		child := vendorExtensionPath(path, name)
+		fieldType, found := fields[name]
+		if !found {
+			unknown[child] = struct{}{}
+			continue
+		}
+		collectUnknownJSONFieldPaths(value, dereferenceJSONType(fieldType), child, unknown)
+	}
+}
+
+func collectUnknownJSONArrayPaths(body []byte, targetType reflect.Type, path string, unknown map[string]struct{}) {
+	if targetType.Elem() == reflect.TypeOf(json.RawMessage{}) {
+		return
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(body, &elements); err != nil {
+		return
+	}
+	elementType := dereferenceJSONType(targetType.Elem())
+	elementPath := path + "[]"
+	for _, element := range elements {
+		collectUnknownJSONFieldPaths(element, elementType, elementPath, unknown)
+	}
+}
+
+func stripVendorExtensionValue(raw json.RawMessage, path string, drop map[string]struct{}) (json.RawMessage, bool) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 {
 		return raw, false
 	}
 	switch trimmed[0] {
 	case '{':
-		return stripVendorExtensionObject(trimmed, path, allowed)
+		return stripVendorExtensionObject(trimmed, path, drop)
 	case '[':
-		return stripVendorExtensionArray(trimmed, path, allowed)
+		return stripVendorExtensionArray(trimmed, path, drop)
 	}
 	return raw, false
 }
 
-func stripVendorExtensionObject(raw json.RawMessage, path string, allowed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionObject(raw json.RawMessage, path string, drop map[string]struct{}) (json.RawMessage, bool) {
 	var object map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &object); err != nil {
 		// Malformed JSON is not this function's error to report; leave the body
@@ -79,12 +135,12 @@ func stripVendorExtensionObject(raw json.RawMessage, path string, allowed map[st
 	changed := false
 	for name, value := range object {
 		child := vendorExtensionPath(path, name)
-		if _, vendor := allowed[child]; vendor {
+		if _, dropped := drop[child]; dropped {
 			delete(object, name)
 			changed = true
 			continue
 		}
-		if rewritten, childChanged := stripVendorExtensionValue(value, child, allowed); childChanged {
+		if rewritten, childChanged := stripVendorExtensionValue(value, child, drop); childChanged {
 			object[name] = rewritten
 			changed = true
 		}
@@ -99,7 +155,7 @@ func stripVendorExtensionObject(raw json.RawMessage, path string, allowed map[st
 	return rewritten, true
 }
 
-func stripVendorExtensionArray(raw json.RawMessage, path string, allowed map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionArray(raw json.RawMessage, path string, drop map[string]struct{}) (json.RawMessage, bool) {
 	var elements []json.RawMessage
 	if err := json.Unmarshal(raw, &elements); err != nil {
 		return raw, false
@@ -107,7 +163,7 @@ func stripVendorExtensionArray(raw json.RawMessage, path string, allowed map[str
 	changed := false
 	elementPath := path + "[]"
 	for index, element := range elements {
-		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, allowed); elementChanged {
+		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, drop); elementChanged {
 			elements[index] = rewritten
 			changed = true
 		}
@@ -127,4 +183,17 @@ func vendorExtensionPath(parent, name string) string {
 		return name
 	}
 	return parent + "." + name
+}
+
+// appendVendorExtensionDiagnostics records one dropped-field diagnostic per
+// vendor decoration, bounded by the configured diagnostics limit.
+func appendVendorExtensionDiagnostics(
+	diagnostics *llmprotocol.Diagnostics,
+	policy llmprotocol.Policy,
+	source llmprotocol.WireFormat,
+	fields []string,
+) {
+	for _, field := range fields {
+		appendProviderFieldOmission(diagnostics, policy, source, field, vendorExtensionReason)
+	}
 }

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
@@ -9,138 +9,75 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 )
 
-// vendorExtensionReason is recorded on every dropped field so a diagnostic
-// reader can tell a vendor decoration apart from a field the router chose not
-// to carry across formats.
 const vendorExtensionReason = "provider vendor extension field is not part of the canonical response contract"
 
-// providerVendorExtensionsAllowed reports whether the backend that produced
-// this response was identified as a vendor known to decorate its responses.
-//
-// The allowance is deliberately per-backend rather than per-field-name. Azure
-// has emitted content_filter_results for years and ships new decorations across
-// API versions, so a fixed name list would fail the first time they add one -
-// the exact failure #3496 reports. Scoping by resolved dialect keeps every
-// other backend under the strict canonical contract.
 func providerVendorExtensionsAllowed(policy llmprotocol.Policy) bool {
-	switch policy.ResponseVendor {
-	case llmprotocol.VendorAzure:
-		return true
-	default:
-		return false
-	}
+	return policy.ResponseVendor == llmprotocol.ResponseVendorAzure
 }
 
-// stripProviderVendorExtensions removes the fields a vendor-identified backend
-// added outside the canonical schema, returning the rewritten body and the
-// sorted paths it removed. Nothing is dropped silently: every path is reported
-// so the caller can raise a diagnostic for it.
-//
-// When nothing matches, the original slice is returned so the common path stays
-// allocation-free. Object key order is not preserved by the rewrite, which is
-// why this never runs on the byte-identical source-preservation path -
-// rejectUnknownFields is false there.
+// stripProviderVendorExtensions removes non-canonical fields and returns their
+// sorted paths. It preserves the original bytes when no fields are removed.
 func stripProviderVendorExtensions(body []byte, targetType reflect.Type) ([]byte, []string) {
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 || trimmed[0] != '{' {
 		return body, nil
 	}
-	unknown := map[string]struct{}{}
-	collectUnknownJSONFieldPaths(trimmed, dereferenceJSONType(targetType), "", unknown)
-	if len(unknown) == 0 {
-		return body, nil
-	}
-	rewritten, changed := stripVendorExtensionValue(trimmed, "", unknown)
+	dropped := map[string]struct{}{}
+	rewritten, changed := stripVendorExtensionValue(trimmed, targetType, "", dropped)
 	if !changed {
 		return body, nil
 	}
-	paths := make([]string, 0, len(unknown))
-	for path := range unknown {
+	paths := make([]string, 0, len(dropped))
+	for path := range dropped {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
 	return rewritten, paths
 }
 
-// collectUnknownJSONFieldPaths mirrors validateExactJSONValue, recording the
-// normalized path of every field the canonical schema does not declare instead
-// of failing on the first one. "[]" denotes an array element, so one path
-// covers every element of a repeated field.
-func collectUnknownJSONFieldPaths(body []byte, targetType reflect.Type, path string, unknown map[string]struct{}) {
-	if targetType == nil || bytes.Equal(bytes.TrimSpace(body), []byte("null")) ||
+func stripVendorExtensionValue(
+	raw json.RawMessage,
+	targetType reflect.Type,
+	path string,
+	dropped map[string]struct{},
+) (json.RawMessage, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	targetType = dereferenceJSONType(targetType)
+	if targetType == nil || len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) ||
 		reflect.PointerTo(targetType).Implements(jsonUnmarshalerType) {
-		return
+		return raw, false
 	}
 	switch targetType.Kind() {
 	case reflect.Struct:
-		collectUnknownJSONObjectPaths(body, targetType, path, unknown)
+		return stripVendorExtensionObject(trimmed, targetType, path, dropped)
 	case reflect.Slice, reflect.Array:
-		collectUnknownJSONArrayPaths(body, targetType, path, unknown)
-	}
-}
-
-func collectUnknownJSONObjectPaths(body []byte, targetType reflect.Type, path string, unknown map[string]struct{}) {
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(body, &object); err != nil {
-		return
-	}
-	fields := exactJSONStructFields(targetType)
-	for name, value := range object {
-		child := vendorExtensionPath(path, name)
-		fieldType, found := fields[name]
-		if !found {
-			unknown[child] = struct{}{}
-			continue
-		}
-		collectUnknownJSONFieldPaths(value, dereferenceJSONType(fieldType), child, unknown)
-	}
-}
-
-func collectUnknownJSONArrayPaths(body []byte, targetType reflect.Type, path string, unknown map[string]struct{}) {
-	if targetType.Elem() == reflect.TypeOf(json.RawMessage{}) {
-		return
-	}
-	var elements []json.RawMessage
-	if err := json.Unmarshal(body, &elements); err != nil {
-		return
-	}
-	elementType := dereferenceJSONType(targetType.Elem())
-	elementPath := path + "[]"
-	for _, element := range elements {
-		collectUnknownJSONFieldPaths(element, elementType, elementPath, unknown)
-	}
-}
-
-func stripVendorExtensionValue(raw json.RawMessage, path string, drop map[string]struct{}) (json.RawMessage, bool) {
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 {
-		return raw, false
-	}
-	switch trimmed[0] {
-	case '{':
-		return stripVendorExtensionObject(trimmed, path, drop)
-	case '[':
-		return stripVendorExtensionArray(trimmed, path, drop)
+		return stripVendorExtensionArray(trimmed, targetType, path, dropped)
 	}
 	return raw, false
 }
 
-func stripVendorExtensionObject(raw json.RawMessage, path string, drop map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionObject(
+	raw json.RawMessage,
+	targetType reflect.Type,
+	path string,
+	dropped map[string]struct{},
+) (json.RawMessage, bool) {
 	var object map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &object); err != nil {
-		// Malformed JSON is not this function's error to report; leave the body
-		// untouched so the decoder produces the canonical failure.
 		return raw, false
 	}
+	fields := exactJSONStructFields(targetType)
 	changed := false
 	for name, value := range object {
 		child := vendorExtensionPath(path, name)
-		if _, dropped := drop[child]; dropped {
+		fieldType, found := fields[name]
+		if !found {
 			delete(object, name)
+			dropped[child] = struct{}{}
 			changed = true
 			continue
 		}
-		if rewritten, childChanged := stripVendorExtensionValue(value, child, drop); childChanged {
+		if rewritten, childChanged := stripVendorExtensionValue(value, fieldType, child, dropped); childChanged {
 			object[name] = rewritten
 			changed = true
 		}
@@ -155,7 +92,15 @@ func stripVendorExtensionObject(raw json.RawMessage, path string, drop map[strin
 	return rewritten, true
 }
 
-func stripVendorExtensionArray(raw json.RawMessage, path string, drop map[string]struct{}) (json.RawMessage, bool) {
+func stripVendorExtensionArray(
+	raw json.RawMessage,
+	targetType reflect.Type,
+	path string,
+	dropped map[string]struct{},
+) (json.RawMessage, bool) {
+	if targetType.Elem() == reflect.TypeOf(json.RawMessage{}) {
+		return raw, false
+	}
 	var elements []json.RawMessage
 	if err := json.Unmarshal(raw, &elements); err != nil {
 		return raw, false
@@ -163,7 +108,9 @@ func stripVendorExtensionArray(raw json.RawMessage, path string, drop map[string
 	changed := false
 	elementPath := path + "[]"
 	for index, element := range elements {
-		if rewritten, elementChanged := stripVendorExtensionValue(element, elementPath, drop); elementChanged {
+		if rewritten, elementChanged := stripVendorExtensionValue(
+			element, targetType.Elem(), elementPath, dropped,
+		); elementChanged {
 			elements[index] = rewritten
 			changed = true
 		}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions.go
@@ -19,7 +19,10 @@ func providerVendorExtensionsAllowed(policy llmprotocol.Policy) bool {
 // sorted paths. It preserves the original bytes when no fields are removed.
 func stripProviderVendorExtensions(body []byte, targetType reflect.Type) ([]byte, []string) {
 	trimmed := bytes.TrimSpace(body)
-	if len(trimmed) == 0 || trimmed[0] != '{' {
+	if len(trimmed) == 0 {
+		return body, nil
+	}
+	if trimmed[0] != '{' && trimmed[0] != '[' {
 		return body, nil
 	}
 	dropped := map[string]struct{}{}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_responses.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_responses.go
@@ -1,0 +1,117 @@
+package protocolcodec
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+)
+
+func responsesOutputVendorExtensions(raw json.RawMessage, policy llmprotocol.Policy) ([]string, error) {
+	if !providerVendorExtensionsAllowed(policy) || len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	var bodies []json.RawMessage
+	if err := decodeProviderValue(raw, &bodies, policy); err != nil {
+		return nil, err
+	}
+	dropped := make(map[string]struct{})
+	for _, body := range bodies {
+		fields, err := responsesItemVendorExtensions(body, policy)
+		addVendorExtensionPaths(dropped, "output[]", fields)
+		if err != nil {
+			return sortedVendorExtensionPaths(dropped), err
+		}
+	}
+	return sortedVendorExtensionPaths(dropped), nil
+}
+
+func responsesItemVendorExtensions(body json.RawMessage, policy llmprotocol.Policy) ([]string, error) {
+	if !providerVendorExtensionsAllowed(policy) {
+		return nil, nil
+	}
+	var item responsesItemWire
+	dropped, err := decodeProviderValueVendorAware(body, &item, policy)
+	if err != nil {
+		return dropped, err
+	}
+	fields := make(map[string]struct{}, len(dropped))
+	addVendorExtensionPaths(fields, "", dropped)
+
+	switch item.Type {
+	case "message":
+		if err := collectResponsesValueVendorExtensions(fields, "content", item.Content, &[]responsesContentWire{}, policy); err != nil {
+			return sortedVendorExtensionPaths(fields), err
+		}
+	case "reasoning":
+		var summaries []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := collectResponsesValueVendorExtensions(fields, "summary", item.Summary, &summaries, policy); err != nil {
+			return sortedVendorExtensionPaths(fields), err
+		}
+		if err := collectResponsesValueVendorExtensions(fields, "content", item.Content, &[]responsesContentWire{}, policy); err != nil {
+			return sortedVendorExtensionPaths(fields), err
+		}
+	}
+	return sortedVendorExtensionPaths(fields), nil
+}
+
+func collectResponsesValueVendorExtensions(
+	destination map[string]struct{},
+	prefix string,
+	raw json.RawMessage,
+	target any,
+	policy llmprotocol.Policy,
+) error {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil
+	}
+	dropped, err := decodeProviderValueVendorAware(raw, target, policy)
+	addVendorExtensionPaths(destination, prefix, dropped)
+	return err
+}
+
+func addVendorExtensionPaths(destination map[string]struct{}, prefix string, fields []string) {
+	for _, field := range fields {
+		path := field
+		if prefix != "" {
+			path = prefix + "." + field
+			if strings.HasPrefix(field, "[]") {
+				path = prefix + field
+			}
+		}
+		destination[path] = struct{}{}
+	}
+}
+
+func sortedVendorExtensionPaths(fields map[string]struct{}) []string {
+	if len(fields) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(fields))
+	for path := range fields {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func appendResponsesVendorExtensionDiagnostics(
+	diagnostics *llmprotocol.Diagnostics,
+	policy llmprotocol.Policy,
+	prefix string,
+	fields []string,
+) {
+	prefixed := make(map[string]struct{}, len(fields))
+	addVendorExtensionPaths(prefixed, prefix, fields)
+	appendVendorExtensionDiagnostics(
+		diagnostics,
+		policy,
+		llmprotocol.OpenAIResponsesV1,
+		sortedVendorExtensionPaths(prefixed),
+	)
+}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_responses_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_responses_test.go
@@ -2,6 +2,7 @@ package protocolcodec
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
@@ -19,7 +20,7 @@ func TestAzureResponsesResponseReportsDroppedVendorExtensions(t *testing.T) {
 	if response.ID != "resp_1" {
 		t.Fatalf("response ID = %q, want resp_1", response.ID)
 	}
-	assertDroppedResponseExtension(t, diagnostics, "azure_trace")
+	assertDroppedResponseExtensions(t, diagnostics, "azure_trace")
 }
 
 func TestAzureResponsesStreamReportsDroppedVendorExtensions(t *testing.T) {
@@ -47,22 +48,112 @@ func TestAzureResponsesStreamReportsDroppedVendorExtensions(t *testing.T) {
 	if len(events) == 0 {
 		t.Fatal("Push() returned no events")
 	}
-	assertDroppedResponseExtension(t, diagnostics, "azure_trace")
+	assertDroppedResponseExtensions(t, diagnostics, "azure_trace")
 }
 
-func assertDroppedResponseExtension(t *testing.T, diagnostics llmprotocol.Diagnostics, field string) {
+func TestAzureResponsesResponseReportsNestedVendorExtensions(t *testing.T) {
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
+	body := []byte(`{"id":"resp_1","object":"response","created_at":1,"model":"provider-model","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello","annotations":[],"azure_content":{"region":"eastus"}}],"azure_item":{"region":"eastus"}}]}`)
+
+	response, _, diagnostics, err := (OpenAIResponsesCodec{}).DecodeResponse(body, policy)
+	if err != nil {
+		t.Fatalf("DecodeResponse() error = %v", err)
+	}
+	if len(response.Output) != 1 || response.Output[0].Content[0].Text != "hello" {
+		t.Fatalf("response output = %+v, want nested assistant text", response.Output)
+	}
+	assertDroppedResponseExtensions(t, diagnostics,
+		"output[].azure_item",
+		"output[].content[].azure_content",
+	)
+}
+
+func TestAzureResponsesStreamReportsNestedItemVendorExtensions(t *testing.T) {
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
+	engine, err := NewEngine(NewBuiltinRegistry(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := engine.NewStream(
+		llmprotocol.OpenAIResponsesV1,
+		llmprotocol.OpenAIResponsesV1,
+		llmprotocol.StreamContext{Context: context.Background(), PublicModel: "public-model"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := []byte("event: response.created\n" +
+		`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","created_at":1,"model":"provider-model","status":"in_progress","output":[]}}` + "\n\n")
+	if _, _, _, err := stream.Push(start); err != nil {
+		t.Fatalf("Push(start) error = %v", err)
+	}
+
+	frame := []byte("event: response.output_item.added\n" +
+		`data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"in_progress","content":[],"azure_item":{"region":"eastus"}}}` + "\n\n")
+	_, events, diagnostics, err := stream.Push(frame)
+	if err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("Push() returned no events")
+	}
+	assertDroppedResponseExtensions(t, diagnostics, "output[].azure_item")
+}
+
+func TestResponsesNestedVendorExtensionsRemainStrictWithoutAzure(t *testing.T) {
+	body := []byte(`{"id":"resp_1","object":"response","created_at":1,"model":"provider-model","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[],"azure_item":{}}]}`)
+
+	_, _, _, err := (OpenAIResponsesCodec{}).DecodeResponse(body, llmprotocol.DefaultPolicy())
+	if err == nil || !strings.Contains(err.Error(), "invalid_upstream_json") {
+		t.Fatalf("DecodeResponse() error = %v, want invalid_upstream_json", err)
+	}
+}
+
+func TestResponsesStreamNestedVendorExtensionsRemainStrictWithoutAzure(t *testing.T) {
+	engine, err := NewEngine(NewBuiltinRegistry(), llmprotocol.DefaultPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := engine.NewStream(
+		llmprotocol.OpenAIResponsesV1,
+		llmprotocol.OpenAIResponsesV1,
+		llmprotocol.StreamContext{Context: context.Background(), PublicModel: "public-model"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := []byte("event: response.created\n" +
+		`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","created_at":1,"model":"provider-model","status":"in_progress","output":[]}}` + "\n\n")
+	if _, _, _, err := stream.Push(start); err != nil {
+		t.Fatalf("Push(start) error = %v", err)
+	}
+	frame := []byte("event: response.output_item.added\n" +
+		`data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"in_progress","content":[],"azure_item":{}}}` + "\n\n")
+
+	_, _, _, err = stream.Push(frame)
+	if err == nil || !strings.Contains(err.Error(), "invalid_upstream_json") {
+		t.Fatalf("Push() error = %v, want invalid_upstream_json", err)
+	}
+}
+
+func assertDroppedResponseExtensions(t *testing.T, diagnostics llmprotocol.Diagnostics, fields ...string) {
 	t.Helper()
-	if len(diagnostics) != 1 {
-		t.Fatalf("diagnostics count = %d, want 1: %+v", len(diagnostics), diagnostics)
+	dropped := make(map[string]bool, len(fields))
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Action == llmprotocol.DiagnosticDropped &&
+			diagnostic.Source == llmprotocol.OpenAIResponsesV1 &&
+			diagnostic.Reason == vendorExtensionReason {
+			dropped[diagnostic.Field] = true
+		}
 	}
-	diagnostic := diagnostics[0]
-	if diagnostic.Field != field {
-		t.Errorf("diagnostic field = %q, want %q", diagnostic.Field, field)
+	for _, field := range fields {
+		if !dropped[field] {
+			t.Errorf("no dropped diagnostic for %q; diagnostics = %+v", field, diagnostics)
+		}
 	}
-	if diagnostic.Action != llmprotocol.DiagnosticDropped {
-		t.Errorf("diagnostic action = %q, want %q", diagnostic.Action, llmprotocol.DiagnosticDropped)
-	}
-	if diagnostic.Source != llmprotocol.OpenAIResponsesV1 {
-		t.Errorf("diagnostic source = %q, want %q", diagnostic.Source, llmprotocol.OpenAIResponsesV1)
+	if len(dropped) != len(fields) {
+		t.Errorf("vendor diagnostics = %v, want %v", dropped, fields)
 	}
 }

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_responses_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_responses_test.go
@@ -1,0 +1,68 @@
+package protocolcodec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+)
+
+func TestAzureResponsesResponseReportsDroppedVendorExtensions(t *testing.T) {
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
+	body := []byte(`{"id":"resp_1","object":"response","created_at":1,"model":"provider-model","status":"completed","output":[],"azure_trace":{"region":"eastus"}}`)
+
+	response, _, diagnostics, err := (OpenAIResponsesCodec{}).DecodeResponse(body, policy)
+	if err != nil {
+		t.Fatalf("DecodeResponse() error = %v", err)
+	}
+	if response.ID != "resp_1" {
+		t.Fatalf("response ID = %q, want resp_1", response.ID)
+	}
+	assertDroppedResponseExtension(t, diagnostics, "azure_trace")
+}
+
+func TestAzureResponsesStreamReportsDroppedVendorExtensions(t *testing.T) {
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
+	engine, err := NewEngine(NewBuiltinRegistry(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := engine.NewStream(
+		llmprotocol.OpenAIResponsesV1,
+		llmprotocol.OpenAIResponsesV1,
+		llmprotocol.StreamContext{Context: context.Background(), PublicModel: "public-model"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	frame := []byte("event: response.created\n" +
+		`data: {"type":"response.created","sequence_number":0,"azure_trace":{"region":"eastus"},"response":{"id":"resp_1","object":"response","created_at":1,"model":"provider-model","status":"in_progress","output":[]}}` + "\n\n")
+	_, events, diagnostics, err := stream.Push(frame)
+	if err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("Push() returned no events")
+	}
+	assertDroppedResponseExtension(t, diagnostics, "azure_trace")
+}
+
+func assertDroppedResponseExtension(t *testing.T, diagnostics llmprotocol.Diagnostics, field string) {
+	t.Helper()
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics count = %d, want 1: %+v", len(diagnostics), diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Field != field {
+		t.Errorf("diagnostic field = %q, want %q", diagnostic.Field, field)
+	}
+	if diagnostic.Action != llmprotocol.DiagnosticDropped {
+		t.Errorf("diagnostic action = %q, want %q", diagnostic.Action, llmprotocol.DiagnosticDropped)
+	}
+	if diagnostic.Source != llmprotocol.OpenAIResponsesV1 {
+		t.Errorf("diagnostic source = %q, want %q", diagnostic.Source, llmprotocol.OpenAIResponsesV1)
+	}
+}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
@@ -2,6 +2,7 @@ package protocolcodec
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -32,8 +33,40 @@ const azureChatCompletion = `{
   }
 }`
 
+// azureTarget is a canonical-shaped subset: the schema decides what counts as
+// a decoration, so anything Azure adds beyond these fields is a drop.
+type azureTarget struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index        int    `json:"index"`
+		FinishReason string `json:"finish_reason"`
+		Message      struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
 func TestStripProviderVendorExtensionsRemovesAzureFields(t *testing.T) {
-	stripped := stripProviderVendorExtensions([]byte(azureChatCompletion), llmprotocol.VendorAzure)
+	stripped, dropped := stripProviderVendorExtensions([]byte(azureChatCompletion), reflect.TypeOf(azureTarget{}))
+
+	want := []string{
+		"choices[].content_filter_results",
+		"prompt_filter_results",
+		"routing",
+		"usage.latency_checkpoint",
+	}
+	if !reflect.DeepEqual(dropped, want) {
+		t.Errorf("dropped = %v, want %v", dropped, want)
+	}
 
 	for _, field := range []string{"prompt_filter_results", "\"routing\"", "content_filter_results", "latency_checkpoint"} {
 		if strings.Contains(string(stripped), field) {
@@ -50,34 +83,70 @@ func TestStripProviderVendorExtensionsRemovesAzureFields(t *testing.T) {
 func TestStripProviderVendorExtensionsLeavesCanonicalBodyUntouched(t *testing.T) {
 	canonical := `{"id":"chatcmpl-1","model":"gpt-4.1-mini","choices":[{"index":0}]}`
 
-	stripped := stripProviderVendorExtensions([]byte(canonical), llmprotocol.VendorAzure)
+	stripped, dropped := stripProviderVendorExtensions([]byte(canonical), reflect.TypeOf(azureTarget{}))
 
+	if dropped != nil {
+		t.Errorf("dropped = %v, want nil", dropped)
+	}
 	if string(stripped) != canonical {
 		t.Errorf("stripped = %s, want the original body unchanged", stripped)
 	}
 }
 
-// A vendor name is only ignored at the path the provider emits it. The same
-// token nested somewhere else is still an unknown field.
-func TestStripProviderVendorExtensionsIsPathScoped(t *testing.T) {
-	body := `{"choices":[{"index":0,"message":{"role":"assistant","routing":"nope"}}]}`
+// Decorations nested inside a canonical object are dropped at their real path,
+// not just at the top level.
+func TestStripProviderVendorExtensionsDropsNestedDecorations(t *testing.T) {
+	body := `{"id":"a","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi","azure_note":"x"}}]}`
 
-	stripped := stripProviderVendorExtensions([]byte(body), llmprotocol.VendorAzure)
+	stripped, dropped := stripProviderVendorExtensions([]byte(body), reflect.TypeOf(azureTarget{}))
 
-	if !strings.Contains(string(stripped), `"routing"`) {
-		t.Error("stripped a routing field that is not at the allowlisted path")
+	want := []string{"choices[].message.azure_note"}
+	if !reflect.DeepEqual(dropped, want) {
+		t.Errorf("dropped = %v, want %v", dropped, want)
+	}
+	if strings.Contains(string(stripped), "azure_note") {
+		t.Error("stripped body still contains the nested decoration")
 	}
 }
 
-func TestStripProviderVendorExtensionsIgnoresUnknownVendor(t *testing.T) {
-	for _, vendor := range []string{"", "not-a-vendor"} {
+func TestProviderVendorExtensionsAllowedOnlyForKnownVendors(t *testing.T) {
+	for _, vendor := range []string{"", "not-a-vendor", "openai"} {
 		t.Run("vendor="+vendor, func(t *testing.T) {
-			stripped := stripProviderVendorExtensions([]byte(azureChatCompletion), vendor)
+			policy := llmprotocol.DefaultPolicy()
+			policy.ResponseVendor = vendor
 
-			if string(stripped) != azureChatCompletion {
-				t.Error("stripped a field for a backend with no vendor allowance")
+			if providerVendorExtensionsAllowed(policy) {
+				t.Errorf("providerVendorExtensionsAllowed(%q) = true, want false", vendor)
 			}
 		})
+	}
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.VendorAzure
+	if !providerVendorExtensionsAllowed(policy) {
+		t.Error("providerVendorExtensionsAllowed(azure) = false, want true")
+	}
+}
+
+// The point of shape 3: a decoration Azure has not shipped yet must not break
+// the router the way a fixed name list would.
+func TestDecodeProviderWireAcceptsUnanticipatedAzureFields(t *testing.T) {
+	var target azureTarget
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.VendorAzure
+
+	body := `{"id":"a","object":"chat.completion","created":1,"model":"m",` +
+		`"a_field_azure_ships_next_year":{"nested":true},` +
+		`"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"hi"}}]}`
+
+	dropped, err := decodeProviderWireVendorAware([]byte(body), &target, policy)
+	if err != nil {
+		t.Fatalf("decodeProviderWireVendorAware() error = %v, want nil", err)
+	}
+	if !reflect.DeepEqual(dropped, []string{"a_field_azure_ships_next_year"}) {
+		t.Errorf("dropped = %v, want the unanticipated field reported", dropped)
+	}
+	if target.Model != "m" {
+		t.Errorf("Model = %q, want m", target.Model)
 	}
 }
 
@@ -173,5 +242,35 @@ func TestDecodeProviderWireKeepsTheOffendingFieldOutOfTheClientMessage(t *testin
 	cause := errors.Unwrap(protocolError)
 	if cause == nil || !strings.Contains(cause.Error(), "surprise_field") {
 		t.Errorf("cause = %v, want it to name surprise_field for the operator log", cause)
+	}
+}
+
+// The whole point of dropping rather than rejecting is that the drop is
+// observable. Decoding a decorated Azure response must surface one
+// DiagnosticDropped per decoration.
+func TestDecodeResponseReportsVendorExtensionsAsDiagnostics(t *testing.T) {
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.VendorAzure
+
+	_, _, diagnostics, err := OpenAIChatCodec{}.DecodeResponse([]byte(azureChatCompletion), policy)
+	if err != nil {
+		t.Fatalf("DecodeResponse() error = %v, want nil", err)
+	}
+
+	dropped := map[string]bool{}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Action == llmprotocol.DiagnosticDropped {
+			dropped[diagnostic.Field] = true
+		}
+	}
+	for _, field := range []string{
+		"prompt_filter_results",
+		"routing",
+		"choices[].content_filter_results",
+		"usage.latency_checkpoint",
+	} {
+		if !dropped[field] {
+			t.Errorf("no dropped diagnostic for %q; diagnostics = %+v", field, diagnostics)
+		}
 	}
 }

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
@@ -1,0 +1,136 @@
+package protocolcodec
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+)
+
+// azureChatCompletion is the shape Azure OpenAI / AI Foundry actually returns:
+// a canonical OpenAI chat completion decorated with Azure's own fields at four
+// paths. Reported in issue #3496.
+const azureChatCompletion = `{
+  "id": "chatcmpl-1",
+  "object": "chat.completion",
+  "created": 1,
+  "model": "gpt-4.1-mini",
+  "prompt_filter_results": [{"prompt_index": 0, "content_filter_results": {}}],
+  "routing": {"region": "eastus"},
+  "choices": [{
+    "index": 0,
+    "finish_reason": "stop",
+    "message": {"role": "assistant", "content": "hi"},
+    "content_filter_results": {"hate": {"filtered": false, "severity": "safe"}}
+  }],
+  "usage": {
+    "prompt_tokens": 1,
+    "completion_tokens": 1,
+    "total_tokens": 2,
+    "latency_checkpoint": {"time_to_first_token_ms": 12}
+  }
+}`
+
+func TestStripProviderVendorExtensionsRemovesAzureFields(t *testing.T) {
+	stripped, removed := stripProviderVendorExtensions([]byte(azureChatCompletion))
+
+	want := []string{
+		"choices[].content_filter_results",
+		"prompt_filter_results",
+		"routing",
+		"usage.latency_checkpoint",
+	}
+	if !reflect.DeepEqual(removed, want) {
+		t.Errorf("removed = %v, want %v", removed, want)
+	}
+	for _, field := range []string{"prompt_filter_results", "\"routing\"", "content_filter_results", "latency_checkpoint"} {
+		if strings.Contains(string(stripped), field) {
+			t.Errorf("stripped body still contains %s", field)
+		}
+	}
+	for _, kept := range []string{`"id"`, `"model"`, `"finish_reason"`, `"total_tokens"`} {
+		if !strings.Contains(string(stripped), kept) {
+			t.Errorf("stripped body dropped canonical field %s", kept)
+		}
+	}
+}
+
+func TestStripProviderVendorExtensionsLeavesCanonicalBodyUntouched(t *testing.T) {
+	canonical := `{"id":"chatcmpl-1","model":"gpt-4.1-mini","choices":[{"index":0}]}`
+
+	stripped, removed := stripProviderVendorExtensions([]byte(canonical))
+
+	if removed != nil {
+		t.Errorf("removed = %v, want nil", removed)
+	}
+	if string(stripped) != canonical {
+		t.Errorf("stripped = %s, want the original body unchanged", stripped)
+	}
+}
+
+// A vendor name is only ignored at the path the provider emits it. The same
+// token nested somewhere else is still an unknown field.
+func TestStripProviderVendorExtensionsIsPathScoped(t *testing.T) {
+	body := `{"choices":[{"index":0,"message":{"role":"assistant","routing":"nope"}}]}`
+
+	stripped, removed := stripProviderVendorExtensions([]byte(body))
+
+	if removed != nil {
+		t.Errorf("removed = %v, want nil for a non-allowlisted path", removed)
+	}
+	if !strings.Contains(string(stripped), `"routing"`) {
+		t.Error("stripped a routing field that is not at the allowlisted path")
+	}
+}
+
+func TestDecodeProviderWireAcceptsAzureDecoratedResponse(t *testing.T) {
+	var target struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Created int64  `json:"created"`
+		Model   string `json:"model"`
+		Choices []struct {
+			Index        int    `json:"index"`
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+
+	if err := decodeProviderWire([]byte(azureChatCompletion), &target, llmprotocol.DefaultPolicy()); err != nil {
+		t.Fatalf("decodeProviderWire() error = %v, want nil", err)
+	}
+	if target.Model != "gpt-4.1-mini" {
+		t.Errorf("Model = %q, want gpt-4.1-mini", target.Model)
+	}
+	if len(target.Choices) != 1 || target.Choices[0].Message.Content != "hi" {
+		t.Errorf("Choices = %+v, want one choice carrying the assistant content", target.Choices)
+	}
+	if target.Usage.TotalTokens != 2 {
+		t.Errorf("Usage.TotalTokens = %d, want 2", target.Usage.TotalTokens)
+	}
+}
+
+// The allowlist must not become a blanket accept: an unknown field outside it
+// still fails with the canonical upstream error.
+func TestDecodeProviderWireStillRejectsUnknownFields(t *testing.T) {
+	var target struct {
+		Model string `json:"model"`
+	}
+
+	err := decodeProviderWire([]byte(`{"model":"m","surprise_field":1}`), &target, llmprotocol.DefaultPolicy())
+	if err == nil {
+		t.Fatal("decodeProviderWire() error = nil, want a rejection")
+	}
+	if !strings.Contains(err.Error(), "invalid_upstream_json") {
+		t.Errorf("error = %v, want invalid_upstream_json", err)
+	}
+}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
@@ -33,7 +33,7 @@ const azureChatCompletion = `{
 }`
 
 func TestStripProviderVendorExtensionsRemovesAzureFields(t *testing.T) {
-	stripped, removed := stripProviderVendorExtensions([]byte(azureChatCompletion))
+	stripped, removed := stripProviderVendorExtensions([]byte(azureChatCompletion), llmprotocol.VendorAzure)
 
 	want := []string{
 		"choices[].content_filter_results",
@@ -59,7 +59,7 @@ func TestStripProviderVendorExtensionsRemovesAzureFields(t *testing.T) {
 func TestStripProviderVendorExtensionsLeavesCanonicalBodyUntouched(t *testing.T) {
 	canonical := `{"id":"chatcmpl-1","model":"gpt-4.1-mini","choices":[{"index":0}]}`
 
-	stripped, removed := stripProviderVendorExtensions([]byte(canonical))
+	stripped, removed := stripProviderVendorExtensions([]byte(canonical), llmprotocol.VendorAzure)
 
 	if removed != nil {
 		t.Errorf("removed = %v, want nil", removed)
@@ -74,7 +74,7 @@ func TestStripProviderVendorExtensionsLeavesCanonicalBodyUntouched(t *testing.T)
 func TestStripProviderVendorExtensionsIsPathScoped(t *testing.T) {
 	body := `{"choices":[{"index":0,"message":{"role":"assistant","routing":"nope"}}]}`
 
-	stripped, removed := stripProviderVendorExtensions([]byte(body))
+	stripped, removed := stripProviderVendorExtensions([]byte(body), llmprotocol.VendorAzure)
 
 	if removed != nil {
 		t.Errorf("removed = %v, want nil for a non-allowlisted path", removed)
@@ -105,7 +105,9 @@ func TestDecodeProviderWireAcceptsAzureDecoratedResponse(t *testing.T) {
 		} `json:"usage"`
 	}
 
-	if err := decodeProviderWire([]byte(azureChatCompletion), &target, llmprotocol.DefaultPolicy()); err != nil {
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.VendorAzure
+	if err := decodeProviderWire([]byte(azureChatCompletion), &target, policy); err != nil {
 		t.Fatalf("decodeProviderWire() error = %v, want nil", err)
 	}
 	if target.Model != "gpt-4.1-mini" {
@@ -132,5 +134,38 @@ func TestDecodeProviderWireStillRejectsUnknownFields(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid_upstream_json") {
 		t.Errorf("error = %v, want invalid_upstream_json", err)
+	}
+}
+
+// Without the vendor allowance the same Azure body is still rejected: the
+// backend dialect, not the field name, is what grants the exemption.
+func TestDecodeProviderWireRejectsAzureFieldsWithoutVendorAllowance(t *testing.T) {
+	var target struct {
+		ID    string `json:"id"`
+		Model string `json:"model"`
+	}
+
+	err := decodeProviderWire([]byte(azureChatCompletion), &target, llmprotocol.DefaultPolicy())
+	if err == nil {
+		t.Fatal("decodeProviderWire() error = nil, want rejection without a vendor allowance")
+	}
+	if !strings.Contains(err.Error(), "invalid_upstream_json") {
+		t.Errorf("error = %v, want invalid_upstream_json", err)
+	}
+}
+
+// An unknown field must be identifiable from the error alone. Before this the
+// operator saw only "contains a non-canonical field" with no way to tell which.
+func TestDecodeProviderWireErrorNamesTheOffendingField(t *testing.T) {
+	var target struct {
+		Model string `json:"model"`
+	}
+
+	err := decodeProviderWire([]byte(`{"model":"m","surprise_field":1}`), &target, llmprotocol.DefaultPolicy())
+	if err == nil {
+		t.Fatal("decodeProviderWire() error = nil, want a rejection")
+	}
+	if !strings.Contains(err.Error(), "surprise_field") {
+		t.Errorf("error = %v, want it to name surprise_field", err)
 	}
 }

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
@@ -274,3 +274,28 @@ func TestDecodeResponseReportsVendorExtensionsAsDiagnostics(t *testing.T) {
 		}
 	}
 }
+
+// Azure decorates error envelopes too. Decoding those strictly would replace a
+// real upstream reason (content filter block, rate limit) with a generic
+// router error, so the vendor allowance has to reach this path as well.
+func TestDecodeTransportErrorAcceptsDecoratedAzureErrorEnvelope(t *testing.T) {
+	body := `{"error":{"type":"invalid_request_error","code":"content_filter",` +
+		`"message":"blocked","param":null,"innererror":{"content_filter_result":{"hate":{"filtered":true}}}}}`
+
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.VendorAzure
+
+	transportError, _, err := OpenAIChatCodec{}.DecodeTransportError([]byte(body), policy)
+	if err != nil {
+		t.Fatalf("DecodeTransportError() error = %v, want nil", err)
+	}
+	if transportError.Error == nil || transportError.Error.Code != "content_filter" {
+		t.Errorf("Error = %+v, want the upstream content_filter code preserved", transportError.Error)
+	}
+
+	// Without the allowance the same envelope is still rejected.
+	_, _, strictErr := OpenAIChatCodec{}.DecodeTransportError([]byte(body), llmprotocol.DefaultPolicy())
+	if strictErr == nil {
+		t.Error("DecodeTransportError() error = nil without an allowance, want rejection")
+	}
+}

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
@@ -1,7 +1,7 @@
 package protocolcodec
 
 import (
-	"reflect"
+	"errors"
 	"strings"
 	"testing"
 
@@ -33,17 +33,8 @@ const azureChatCompletion = `{
 }`
 
 func TestStripProviderVendorExtensionsRemovesAzureFields(t *testing.T) {
-	stripped, removed := stripProviderVendorExtensions([]byte(azureChatCompletion), llmprotocol.VendorAzure)
+	stripped := stripProviderVendorExtensions([]byte(azureChatCompletion), llmprotocol.VendorAzure)
 
-	want := []string{
-		"choices[].content_filter_results",
-		"prompt_filter_results",
-		"routing",
-		"usage.latency_checkpoint",
-	}
-	if !reflect.DeepEqual(removed, want) {
-		t.Errorf("removed = %v, want %v", removed, want)
-	}
 	for _, field := range []string{"prompt_filter_results", "\"routing\"", "content_filter_results", "latency_checkpoint"} {
 		if strings.Contains(string(stripped), field) {
 			t.Errorf("stripped body still contains %s", field)
@@ -59,11 +50,8 @@ func TestStripProviderVendorExtensionsRemovesAzureFields(t *testing.T) {
 func TestStripProviderVendorExtensionsLeavesCanonicalBodyUntouched(t *testing.T) {
 	canonical := `{"id":"chatcmpl-1","model":"gpt-4.1-mini","choices":[{"index":0}]}`
 
-	stripped, removed := stripProviderVendorExtensions([]byte(canonical), llmprotocol.VendorAzure)
+	stripped := stripProviderVendorExtensions([]byte(canonical), llmprotocol.VendorAzure)
 
-	if removed != nil {
-		t.Errorf("removed = %v, want nil", removed)
-	}
 	if string(stripped) != canonical {
 		t.Errorf("stripped = %s, want the original body unchanged", stripped)
 	}
@@ -74,13 +62,22 @@ func TestStripProviderVendorExtensionsLeavesCanonicalBodyUntouched(t *testing.T)
 func TestStripProviderVendorExtensionsIsPathScoped(t *testing.T) {
 	body := `{"choices":[{"index":0,"message":{"role":"assistant","routing":"nope"}}]}`
 
-	stripped, removed := stripProviderVendorExtensions([]byte(body), llmprotocol.VendorAzure)
+	stripped := stripProviderVendorExtensions([]byte(body), llmprotocol.VendorAzure)
 
-	if removed != nil {
-		t.Errorf("removed = %v, want nil for a non-allowlisted path", removed)
-	}
 	if !strings.Contains(string(stripped), `"routing"`) {
 		t.Error("stripped a routing field that is not at the allowlisted path")
+	}
+}
+
+func TestStripProviderVendorExtensionsIgnoresUnknownVendor(t *testing.T) {
+	for _, vendor := range []string{"", "not-a-vendor"} {
+		t.Run("vendor="+vendor, func(t *testing.T) {
+			stripped := stripProviderVendorExtensions([]byte(azureChatCompletion), vendor)
+
+			if string(stripped) != azureChatCompletion {
+				t.Error("stripped a field for a backend with no vendor allowance")
+			}
+		})
 	}
 }
 
@@ -154,9 +151,10 @@ func TestDecodeProviderWireRejectsAzureFieldsWithoutVendorAllowance(t *testing.T
 	}
 }
 
-// An unknown field must be identifiable from the error alone. Before this the
-// operator saw only "contains a non-canonical field" with no way to tell which.
-func TestDecodeProviderWireErrorNamesTheOffendingField(t *testing.T) {
+// The field name is what an operator needs and what a caller must not see.
+// ProtocolError.Message is serialized into the client error body, so the name
+// belongs in the cause and nowhere else.
+func TestDecodeProviderWireKeepsTheOffendingFieldOutOfTheClientMessage(t *testing.T) {
 	var target struct {
 		Model string `json:"model"`
 	}
@@ -165,7 +163,15 @@ func TestDecodeProviderWireErrorNamesTheOffendingField(t *testing.T) {
 	if err == nil {
 		t.Fatal("decodeProviderWire() error = nil, want a rejection")
 	}
-	if !strings.Contains(err.Error(), "surprise_field") {
-		t.Errorf("error = %v, want it to name surprise_field", err)
+	var protocolError *llmprotocol.ProtocolError
+	if !errors.As(err, &protocolError) {
+		t.Fatalf("error = %v, want a ProtocolError", err)
+	}
+	if strings.Contains(protocolError.Message, "surprise_field") {
+		t.Errorf("Message = %q, must not expose the upstream field name to the caller", protocolError.Message)
+	}
+	cause := errors.Unwrap(protocolError)
+	if cause == nil || !strings.Contains(cause.Error(), "surprise_field") {
+		t.Errorf("cause = %v, want it to name surprise_field for the operator log", cause)
 	}
 }

--- a/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
+++ b/src/semantic-router/pkg/protocolcodec/provider_vendor_extensions_test.go
@@ -1,6 +1,7 @@
 package protocolcodec
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -9,9 +10,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
 )
 
-// azureChatCompletion is the shape Azure OpenAI / AI Foundry actually returns:
-// a canonical OpenAI chat completion decorated with Azure's own fields at four
-// paths. Reported in issue #3496.
+// azureChatCompletion reproduces the decorated response from issue #3496.
 const azureChatCompletion = `{
   "id": "chatcmpl-1",
   "object": "chat.completion",
@@ -33,8 +32,7 @@ const azureChatCompletion = `{
   }
 }`
 
-// azureTarget is a canonical-shaped subset: the schema decides what counts as
-// a decoration, so anything Azure adds beyond these fields is a drop.
+// azureTarget is the canonical subset used by the stripping tests.
 type azureTarget struct {
 	ID      string `json:"id"`
 	Object  string `json:"object"`
@@ -93,8 +91,6 @@ func TestStripProviderVendorExtensionsLeavesCanonicalBodyUntouched(t *testing.T)
 	}
 }
 
-// Decorations nested inside a canonical object are dropped at their real path,
-// not just at the top level.
 func TestStripProviderVendorExtensionsDropsNestedDecorations(t *testing.T) {
 	body := `{"id":"a","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi","azure_note":"x"}}]}`
 
@@ -110,8 +106,8 @@ func TestStripProviderVendorExtensionsDropsNestedDecorations(t *testing.T) {
 }
 
 func TestProviderVendorExtensionsAllowedOnlyForKnownVendors(t *testing.T) {
-	for _, vendor := range []string{"", "not-a-vendor", "openai"} {
-		t.Run("vendor="+vendor, func(t *testing.T) {
+	for _, vendor := range []llmprotocol.ResponseVendor{"", "not-a-vendor", "openai"} {
+		t.Run("vendor="+string(vendor), func(t *testing.T) {
 			policy := llmprotocol.DefaultPolicy()
 			policy.ResponseVendor = vendor
 
@@ -121,18 +117,16 @@ func TestProviderVendorExtensionsAllowedOnlyForKnownVendors(t *testing.T) {
 		})
 	}
 	policy := llmprotocol.DefaultPolicy()
-	policy.ResponseVendor = llmprotocol.VendorAzure
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
 	if !providerVendorExtensionsAllowed(policy) {
 		t.Error("providerVendorExtensionsAllowed(azure) = false, want true")
 	}
 }
 
-// The point of shape 3: a decoration Azure has not shipped yet must not break
-// the router the way a fixed name list would.
 func TestDecodeProviderWireAcceptsUnanticipatedAzureFields(t *testing.T) {
 	var target azureTarget
 	policy := llmprotocol.DefaultPolicy()
-	policy.ResponseVendor = llmprotocol.VendorAzure
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
 
 	body := `{"id":"a","object":"chat.completion","created":1,"model":"m",` +
 		`"a_field_azure_ships_next_year":{"nested":true},` +
@@ -172,7 +166,7 @@ func TestDecodeProviderWireAcceptsAzureDecoratedResponse(t *testing.T) {
 	}
 
 	policy := llmprotocol.DefaultPolicy()
-	policy.ResponseVendor = llmprotocol.VendorAzure
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
 	if err := decodeProviderWire([]byte(azureChatCompletion), &target, policy); err != nil {
 		t.Fatalf("decodeProviderWire() error = %v, want nil", err)
 	}
@@ -187,8 +181,7 @@ func TestDecodeProviderWireAcceptsAzureDecoratedResponse(t *testing.T) {
 	}
 }
 
-// The allowlist must not become a blanket accept: an unknown field outside it
-// still fails with the canonical upstream error.
+// Strict backends still reject every unknown field.
 func TestDecodeProviderWireStillRejectsUnknownFields(t *testing.T) {
 	var target struct {
 		Model string `json:"model"`
@@ -203,8 +196,7 @@ func TestDecodeProviderWireStillRejectsUnknownFields(t *testing.T) {
 	}
 }
 
-// Without the vendor allowance the same Azure body is still rejected: the
-// backend dialect, not the field name, is what grants the exemption.
+// The backend dialect, not a field name, grants the exemption.
 func TestDecodeProviderWireRejectsAzureFieldsWithoutVendorAllowance(t *testing.T) {
 	var target struct {
 		ID    string `json:"id"`
@@ -220,9 +212,7 @@ func TestDecodeProviderWireRejectsAzureFieldsWithoutVendorAllowance(t *testing.T
 	}
 }
 
-// The field name is what an operator needs and what a caller must not see.
-// ProtocolError.Message is serialized into the client error body, so the name
-// belongs in the cause and nowhere else.
+// Field details belong in the operator-visible cause, not the client message.
 func TestDecodeProviderWireKeepsTheOffendingFieldOutOfTheClientMessage(t *testing.T) {
 	var target struct {
 		Model string `json:"model"`
@@ -245,12 +235,10 @@ func TestDecodeProviderWireKeepsTheOffendingFieldOutOfTheClientMessage(t *testin
 	}
 }
 
-// The whole point of dropping rather than rejecting is that the drop is
-// observable. Decoding a decorated Azure response must surface one
-// DiagnosticDropped per decoration.
+// Every accepted decoration must produce a dropped-field diagnostic.
 func TestDecodeResponseReportsVendorExtensionsAsDiagnostics(t *testing.T) {
 	policy := llmprotocol.DefaultPolicy()
-	policy.ResponseVendor = llmprotocol.VendorAzure
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
 
 	_, _, diagnostics, err := OpenAIChatCodec{}.DecodeResponse([]byte(azureChatCompletion), policy)
 	if err != nil {
@@ -275,27 +263,63 @@ func TestDecodeResponseReportsVendorExtensionsAsDiagnostics(t *testing.T) {
 	}
 }
 
-// Azure decorates error envelopes too. Decoding those strictly would replace a
-// real upstream reason (content filter block, rate limit) with a generic
-// router error, so the vendor allowance has to reach this path as well.
+// Error envelopes use the same vendor policy as successful responses.
 func TestDecodeTransportErrorAcceptsDecoratedAzureErrorEnvelope(t *testing.T) {
 	body := `{"error":{"type":"invalid_request_error","code":"content_filter",` +
 		`"message":"blocked","param":null,"innererror":{"content_filter_result":{"hate":{"filtered":true}}}}}`
 
 	policy := llmprotocol.DefaultPolicy()
-	policy.ResponseVendor = llmprotocol.VendorAzure
-
-	transportError, _, err := OpenAIChatCodec{}.DecodeTransportError([]byte(body), policy)
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
+	engine, err := NewEngine(NewBuiltinRegistry(), policy)
 	if err != nil {
-		t.Fatalf("DecodeTransportError() error = %v, want nil", err)
+		t.Fatal(err)
 	}
-	if transportError.Error == nil || transportError.Error.Code != "content_filter" {
-		t.Errorf("Error = %+v, want the upstream content_filter code preserved", transportError.Error)
+	for _, format := range []llmprotocol.WireFormat{llmprotocol.OpenAIChatV1, llmprotocol.OpenAIResponsesV1} {
+		t.Run(string(format), func(t *testing.T) {
+			transportError, diagnostics, err := engine.DecodeTransportError(format, []byte(body))
+			if err != nil {
+				t.Fatalf("DecodeTransportError() error = %v, want nil", err)
+			}
+			if transportError.Error == nil || transportError.Error.Code != "content_filter" {
+				t.Errorf("Error = %+v, want the upstream content_filter code preserved", transportError.Error)
+			}
+			if len(diagnostics) != 1 || diagnostics[0].Field != "error.innererror" ||
+				diagnostics[0].Action != llmprotocol.DiagnosticDropped || diagnostics[0].Source != format {
+				t.Errorf("diagnostics = %+v, want one dropped error.innererror field from %s", diagnostics, format)
+			}
+		})
 	}
 
 	// Without the allowance the same envelope is still rejected.
 	_, _, strictErr := OpenAIChatCodec{}.DecodeTransportError([]byte(body), llmprotocol.DefaultPolicy())
 	if strictErr == nil {
 		t.Error("DecodeTransportError() error = nil without an allowance, want rejection")
+	}
+}
+
+func TestChatStreamErrorReportsVendorExtensions(t *testing.T) {
+	policy := llmprotocol.DefaultPolicy()
+	policy.ResponseVendor = llmprotocol.ResponseVendorAzure
+	engine, err := NewEngine(NewBuiltinRegistry(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := engine.NewStream(llmprotocol.OpenAIChatV1, llmprotocol.OpenAIChatV1, llmprotocol.StreamContext{
+		Context: context.Background(), PublicModel: "public-model",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame := []byte("data: {\"error\":{\"type\":\"server_error\",\"code\":\"blocked\",\"message\":\"blocked\"},\"azure_trace\":{}}\n\n")
+	_, events, diagnostics, err := stream.Push(frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Error == nil || events[0].Error.Code != "blocked" {
+		t.Fatalf("events = %+v, want the provider error", events)
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Field != "azure_trace" ||
+		diagnostics[0].Action != llmprotocol.DiagnosticDropped {
+		t.Errorf("diagnostics = %+v, want one dropped azure_trace field", diagnostics)
 	}
 }

--- a/src/semantic-router/pkg/protocolcodec/stream_chat.go
+++ b/src/semantic-router/pkg/protocolcodec/stream_chat.go
@@ -147,18 +147,20 @@ func (decoder *chatStreamDecoder) pushFrame(frame []byte) ([]llmprotocol.Event, 
 	if err != nil {
 		return nil, nil, err
 	}
+	var diagnostics llmprotocol.Diagnostics
+	appendVendorExtensionDiagnostics(&diagnostics, decoder.policy, llmprotocol.OpenAIChatV1, vendorExtensions)
 	if err := validateChatStreamChunk(chunk); err != nil {
-		return nil, nil, err
+		return nil, diagnostics, err
 	}
 	if err := decoder.observeProviderIdentity(chunk.ID, chunk.Model); err != nil {
-		return nil, nil, err
+		return nil, diagnostics, err
 	}
 	if chunk.Error != nil {
 		event, err := decoder.next(chatStreamFailureEvent(chunk.Error))
-		return []llmprotocol.Event{event}, nil, err
+		return []llmprotocol.Event{event}, diagnostics, err
 	}
-	events, diagnostics, err := decoder.decodeChunkEvents(chunk)
-	appendVendorExtensionDiagnostics(&diagnostics, decoder.policy, llmprotocol.OpenAIChatV1, vendorExtensions)
+	events, chunkDiagnostics, err := decoder.decodeChunkEvents(chunk)
+	diagnostics = appendDiagnostics(diagnostics, chunkDiagnostics, decoder.policy.Limits.Diagnostics)
 	diagnostics = decoder.appendProviderChunkDiagnostics(chunk, diagnostics)
 	return events, diagnostics, err
 }

--- a/src/semantic-router/pkg/protocolcodec/stream_chat.go
+++ b/src/semantic-router/pkg/protocolcodec/stream_chat.go
@@ -143,7 +143,8 @@ func (decoder *chatStreamDecoder) pushFrame(frame []byte) ([]llmprotocol.Event, 
 		return []llmprotocol.Event{event}, nil, err
 	}
 	var chunk chatChunkWire
-	if err := decodeProviderWire(parsed.Data, &chunk, decoder.policy); err != nil {
+	vendorExtensions, err := decodeProviderWireVendorAware(parsed.Data, &chunk, decoder.policy)
+	if err != nil {
 		return nil, nil, err
 	}
 	if err := validateChatStreamChunk(chunk); err != nil {
@@ -157,6 +158,7 @@ func (decoder *chatStreamDecoder) pushFrame(frame []byte) ([]llmprotocol.Event, 
 		return []llmprotocol.Event{event}, nil, err
 	}
 	events, diagnostics, err := decoder.decodeChunkEvents(chunk)
+	appendVendorExtensionDiagnostics(&diagnostics, decoder.policy, llmprotocol.OpenAIChatV1, vendorExtensions)
 	diagnostics = decoder.appendProviderChunkDiagnostics(chunk, diagnostics)
 	return events, diagnostics, err
 }

--- a/src/semantic-router/pkg/protocolcodec/stream_responses.go
+++ b/src/semantic-router/pkg/protocolcodec/stream_responses.go
@@ -273,16 +273,21 @@ func (decoder *responsesStreamDecoder) decodeResponsesWireFrame(
 	frame []byte,
 ) ([]llmprotocol.Event, llmprotocol.Diagnostics, error) {
 	var wire responsesEventWire
-	if err := decodeProviderWire(data, &wire, decoder.policy); err != nil {
+	vendorExtensions, err := decodeProviderWireVendorAware(data, &wire, decoder.policy)
+	if err != nil {
 		return nil, nil, err
 	}
+	var diagnostics llmprotocol.Diagnostics
+	appendVendorExtensionDiagnostics(&diagnostics, decoder.policy, llmprotocol.OpenAIResponsesV1, vendorExtensions)
 	if wire.Type == "" {
 		wire.Type = eventType
 	}
 	if err := decoder.validateResponsesEventResource(wire, data); err != nil {
-		return nil, nil, err
+		return nil, diagnostics, err
 	}
-	return decoder.decodeResponsesEvent(wire, frame)
+	events, eventDiagnostics, err := decoder.decodeResponsesEvent(wire, frame)
+	diagnostics = appendDiagnostics(diagnostics, eventDiagnostics, decoder.policy.Limits.Diagnostics)
+	return events, diagnostics, err
 }
 
 func (decoder *responsesStreamDecoder) validateResponsesEventResource(wire responsesEventWire, body []byte) error {

--- a/src/semantic-router/pkg/protocolcodec/stream_responses.go
+++ b/src/semantic-router/pkg/protocolcodec/stream_responses.go
@@ -279,6 +279,20 @@ func (decoder *responsesStreamDecoder) decodeResponsesWireFrame(
 	}
 	var diagnostics llmprotocol.Diagnostics
 	appendVendorExtensionDiagnostics(&diagnostics, decoder.policy, llmprotocol.OpenAIResponsesV1, vendorExtensions)
+	if len(wire.Item) > 0 {
+		itemVendorExtensions, itemErr := responsesItemVendorExtensions(wire.Item, decoder.policy)
+		appendResponsesVendorExtensionDiagnostics(&diagnostics, decoder.policy, "output[]", itemVendorExtensions)
+		if itemErr != nil {
+			return nil, diagnostics, itemErr
+		}
+	}
+	if wire.Response != nil {
+		outputVendorExtensions, outputErr := responsesOutputVendorExtensions(wire.Response.Output, decoder.policy)
+		appendVendorExtensionDiagnostics(&diagnostics, decoder.policy, llmprotocol.OpenAIResponsesV1, outputVendorExtensions)
+		if outputErr != nil {
+			return nil, diagnostics, outputErr
+		}
+	}
 	if wire.Type == "" {
 		wire.Type = eventType
 	}


### PR DESCRIPTION
Closes #3496

## Purpose

Since #3076 the router validates upstream provider responses against the canonical OpenAI schema and rejects any field outside it. Azure OpenAI / Azure AI Foundry decorate **every** response, so every completion failed with `invalid_upstream_json` and the router was unusable against Azure. `DefaultPolicy()` hardcodes `UnknownReject` and no YAML key maps to it, so there was no workaround.

Strict rejection stays the default. `engine.go` re-asserts `UnknownReject` whenever a translation crosses formats or mutates, and several test files enforce it — including `codec_openai_chat_execution_metadata_test.go`, for metadata the router must not silently drop. This PR does not relax that; it gives an identified Azure backend a scoped allowance and makes every drop observable.

### Azure backend identification

`resolveResponseVendor` keys first on the catalog provider id `azure-openai` — the canonical Azure configuration — and falls back to Azure host suffixes (`*.openai.azure.com`, `*.services.ai.azure.com`, `*.cognitiveservices.azure.com`) for a profile declared as `type: openai` but pointed at Azure, which is the setup in the issue report. Per-tenant subdomains are why that fallback matches by suffix rather than exact host.

It is deliberately independent of reasoning transport: response decoration is a property of who serves the response, not of how a request is shaped. A test asserts an Azure profile acquires no reasoning transport it did not declare.

### Carrying the allowance to the decoder

`llmprotocol.Policy` gains `ResponseVendor` (empty = strict). It is resolved at provider dispatch, carried on `RequestContext`, and applied only by the paths that decode a live provider response. Cache reads and client-facing encodes keep the strict default.

### Tolerance is per backend, not per field name

An identified Azure backend may carry **any** field outside the canonical schema. The dropped set is computed from the target schema, not a name list, because Azure ships new decorations across API versions and a fixed list would reproduce this bug on the next one.

Nothing is dropped silently, which was the objection to blanket tolerance: every dropped path raises a `DiagnosticDropped` entry, bounded by `Limits.Diagnostics`, across buffered Chat, streamed Chat, buffered Responses, streamed Responses, and transport errors. Azure decorates error envelopes too (content-filter blocks, rate limits), so decoding those strictly would have replaced the real upstream reason with a generic router error.

### Cache write/read contract

An accepted same-format response could poison its own cache entry. Two defects combined:

1. Source preservation replays preserved bytes verbatim on a same-format encode, so the envelope built from the **upstream** body re-emitted the decorations the decode had just dropped. The envelope is now built from the canonical bytes the decode produced.
2. The buffered pipeline cached the verbatim client body. The cache write now re-encodes when decorations were dropped, and skips the write if that encode fails — a miss is recoverable, a poisoned entry is not.

Cache reads keep the strict contract with no vendor allowance, because a partition is keyed on the ingress protocol and may be served to a request that never touches the same backend. `TestCacheableClientResponseIsReadableByTheCacheReader` covers miss → write → hit; `TestCacheReaderRejectsRawDecoratedUpstreamBody` pins the regression itself.

### Error diagnosis without leaking

`invalid_upstream_json` did not say which field failed. The name cannot go in the error message: `ProtocolError.Message` is serialized into the client-facing error body (`openai_transport_error.go`), so that would disclose the upstream response shape and the backend provider to any caller. The name stays in the cause, and `neutral_response_decode_failed` unwraps it into the router log.

## Test Plan

```bash
cd src/semantic-router
go test ./pkg/protocolcodec/ ./pkg/llmprotocol/
go vet ./pkg/extproc/ ./pkg/protocolcodec/ ./pkg/llmprotocol/
```

Coverage added across `provider_vendor_extensions_test.go`, `provider_vendor_extensions_responses_test.go`, `processor_res_cache_vendor_test.go`, and `req_filter_response_vendor_test.go`: vendor identification (canonical type, three host suffixes, and lookalike hosts that must not match); tolerance of unanticipated fields; strict rejection without an allowance; dropped-field diagnostics on all five decode paths including nested paths; the cache miss-to-hit path; and the offending field staying out of the client message.

## Test Result

```
ok  github.com/vllm-project/semantic-router/src/semantic-router/pkg/protocolcodec  1.061s
ok  github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol    0.304s
```

Full existing `protocolcodec` and `llmprotocol` suites pass; no existing rejection or byte-fidelity assertion regressed. `go vet` clean on `pkg/extproc`, `pkg/protocolcodec`, `pkg/llmprotocol`. `gofmt` clean.

Blockers on local verification, for transparency:

- `pkg/extproc` tests compile and typecheck but **cannot be executed** on this machine: the package links the Rust bindings and there is no Rust toolchain here. The cache miss-to-hit tests are therefore first exercised by CI.
- `golangci-lint` could not run locally at all — both the repo-pinned 2.13.2 and an older build panic or report typecheck errors inside Go's own stdlib, because the active toolchain here is newer than the linter build. CI is the first real lint signal.
- No live Azure endpoint. Every Azure body in the tests is taken from the issue report or constructed; the error-envelope shape in particular is inferred, not captured from Azure.

Not run locally: E2E profiles.
