### PR TITLE
[Test] Add runtime-derived E2E execution-graph audit and drift gates

### DIFF
--- a/e2e/cmd/e2e-audit/main.go
+++ b/e2e/cmd/e2e-audit/main.go
@@ -1,0 +1,42 @@
+// e2e/cmd/e2e-audit/main.go
+
+// Command e2e-audit emits the runtime-derived E2E execution graph as
+// deterministic JSON on stdout: registered testcases, canonical registered
+// profiles, each profile's resolved GetTestCases selection, and the derived
+// drift sets. The output is generated audit evidence for issue #2379 and is
+// never committed as a source of truth.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/verification"
+
+	_ "github.com/vllm-project/semantic-router/e2e/profiles/all"
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
+)
+
+func main() {
+	inventory, err := verification.BuildInventory()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e-audit: %v\n", err)
+		os.Exit(1)
+	}
+
+	output := struct {
+		verification.Inventory
+		Unreachable []string `json:"registered_but_unreachable"`
+	}{
+		Inventory:   inventory,
+		Unreachable: inventory.Unreachable(),
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(output); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e-audit: encoding inventory: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/e2e/cmd/e2e-audit/main.go
+++ b/e2e/cmd/e2e-audit/main.go
@@ -2,21 +2,35 @@
 
 // Command e2e-audit emits the runtime-derived E2E execution graph as
 // deterministic JSON on stdout: registered testcases, canonical registered
-// profiles, each profile's resolved GetTestCases selection, and the derived
-// drift sets. The output is generated audit evidence for issue #2379 and is
-// never committed as a source of truth.
+// profiles, each profile's resolved GetTestCases selection, the derived
+// drift sets, and the explicit per-profile CI selection overrides with
+// their drift diagnosis. The output is generated audit evidence for issue
+// #2379 and is never committed as a source of truth.
 package main
 
 import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 
 	"github.com/vllm-project/semantic-router/e2e/pkg/verification"
-
 	_ "github.com/vllm-project/semantic-router/e2e/profiles/all"
 	_ "github.com/vllm-project/semantic-router/e2e/testcases"
 )
+
+// ciOverrideReport is the audit view of one explicit CI override: the list
+// itself, the bounded exclusions recorded for it, and the three drift
+// directions Gate D enforces (all empty on a consistent contract).
+type ciOverrideReport struct {
+	Profile            string   `json:"profile"`
+	CITests            []string `json:"ci_tests"`
+	RecordedExclusions []string `json:"recorded_exclusions"`
+	OmittedUnrecorded  []string `json:"omitted_unrecorded"`
+	StaleExclusions    []string `json:"stale_exclusions"`
+	Phantom            []string `json:"phantom"`
+}
 
 func main() {
 	inventory, err := verification.BuildInventory()
@@ -25,12 +39,51 @@ func main() {
 		os.Exit(1)
 	}
 
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e-audit: %v\n", err)
+		os.Exit(1)
+	}
+	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "integration-test-k8s.yml")
+	overrides, err := verification.LoadCIOverrides(workflowPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e-audit: %v\n", err)
+		os.Exit(1)
+	}
+
+	selections := make(map[string][]string, len(inventory.Profiles))
+	for _, profile := range inventory.Profiles {
+		selections[profile.Name] = profile.TestCases
+	}
+
+	overrideReports := make([]ciOverrideReport, 0, len(overrides))
+	for _, override := range overrides {
+		exclusions := verification.KnownCIExclusions[override.Profile]
+		recorded := make([]string, 0, len(exclusions))
+		for name := range exclusions {
+			recorded = append(recorded, name)
+		}
+		sort.Strings(recorded)
+
+		drift := verification.DiagnoseCIOverrideDrift(selections[override.Profile], override.TestCases, exclusions)
+		overrideReports = append(overrideReports, ciOverrideReport{
+			Profile:            override.Profile,
+			CITests:            override.TestCases,
+			RecordedExclusions: recorded,
+			OmittedUnrecorded:  drift.OmittedUnrecorded,
+			StaleExclusions:    drift.StaleExclusions,
+			Phantom:            drift.Phantom,
+		})
+	}
+
 	output := struct {
 		verification.Inventory
-		Unreachable []string `json:"registered_but_unreachable"`
+		Unreachable []string           `json:"registered_but_unreachable"`
+		CIOverrides []ciOverrideReport `json:"ci_overrides"`
 	}{
 		Inventory:   inventory,
 		Unreachable: inventory.Unreachable(),
+		CIOverrides: overrideReports,
 	}
 
 	encoder := json.NewEncoder(os.Stdout)
@@ -38,5 +91,25 @@ func main() {
 	if err := encoder.Encode(output); err != nil {
 		fmt.Fprintf(os.Stderr, "e2e-audit: encoding inventory: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// findRepoRoot walks upward from the working directory to the enclosing git
+// checkout, so the command resolves repository files regardless of which
+// module directory it is invoked from.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolving working directory: %w", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, ".git")); statErr == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no git checkout found above the working directory; run e2e-audit from inside the repository")
+		}
+		dir = parent
 	}
 }

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
@@ -44,7 +45,6 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect

--- a/e2e/pkg/verification/ciexclusions.go
+++ b/e2e/pkg/verification/ciexclusions.go
@@ -1,0 +1,59 @@
+// e2e/pkg/verification/ciexclusions.go
+
+package verification
+
+// CIExclusion bounds one selected-but-CI-omitted testcase to a disposition:
+// either an issue that owns deciding its re-inclusion (Issue) or a
+// documented reason the omission is deliberate today (Rationale). Exactly
+// one of the two must be set.
+type CIExclusion struct {
+	Issue     int
+	Rationale string
+}
+
+// KnownCIExclusions is, per profile with an explicit CI override, the exact
+// set of testcases the profile selects at runtime that the override omits
+// from CI execution on main.
+//
+// Like KnownUnreachableDebt, this table is a ratchet, not an allowlist: Gate
+// D requires the actual excluded set to equal these keys in both directions.
+// A testcase newly selected by the profile but omitted from the CI list
+// fails the gate until it is added to the list or bounded here (the
+// silent-omission scenario); an entry whose testcase joins the CI list or
+// leaves the profile selection also fails the gate until it is deleted. The
+// table can only shrink intentionally, and a profile whose override is
+// removed from the workflow must have its whole table deleted with it.
+var KnownCIExclusions = map[string]map[string]CIExclusion{
+	// The envoy-ai-gateway override currently runs 17 of the profile's 34
+	// selected testcases in CI. #2379 (the coverage epic) owns the
+	// disposition of the issue-bounded entries: re-inclusion in the
+	// explicit list, or hand-off to a coverage-family child issue.
+	"envoy-ai-gateway": {
+		"anthropic-messages-protocol-headers": {Issue: 2379},
+		"anthropic-messages-request":          {Issue: 2379},
+		"anthropic-messages-response-shape":   {Issue: 2379},
+		"anthropic-messages-streaming":        {Issue: 2379},
+		"apiserver-classification-endpoints":  {Issue: 2379},
+		"chat-completions-structured-output":  {Issue: 2379},
+		"entrypoint-recipe-routing":           {Issue: 2379},
+		"llm-classifier-distribution-routing": {Issue: 2379},
+		"looper-latency-token-headers":        {Issue: 2379},
+		"protocol-codec-openai-regression":    {Issue: 2379},
+		"retention-directive":                 {Issue: 2379},
+		"sequence-classifier-routing":         {Issue: 2379},
+		"session-pricing-chat-completions":    {Issue: 2379},
+		"session-pricing-response-api":        {Issue: 2379},
+		"session-telemetry-metrics":           {Issue: 2379},
+
+		// The workflow's own comment above the override deliberately skips
+		// stress / pressure coverage "until the suite is stable again";
+		// re-inclusion is a CI-owner decision tracked by that comment, not
+		// a coverage gap this gate should force.
+		"chat-completions-progressive-stress": {
+			Rationale: "the workflow's ENVOY_AI_GATEWAY_CI_TESTS override deliberately skips stress / pressure coverage until the suite is stable again (see the comment above the list in integration-test-k8s.yml); re-inclusion is a CI-owner decision",
+		},
+		"chat-completions-stress-request": {
+			Rationale: "the workflow's ENVOY_AI_GATEWAY_CI_TESTS override deliberately skips stress / pressure coverage until the suite is stable again (see the comment above the list in integration-test-k8s.yml); re-inclusion is a CI-owner decision",
+		},
+	},
+}

--- a/e2e/pkg/verification/cioverrides.go
+++ b/e2e/pkg/verification/cioverrides.go
@@ -1,0 +1,139 @@
+// e2e/pkg/verification/cioverrides.go
+
+package verification
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ciOverridePattern matches explicit per-profile CI selection overrides in
+// the integration workflow: shell assignments of the form
+//
+//	<PROFILE>_CI_TESTS="case-a,case-b,..."
+//
+// The owning profile is derived from the variable prefix (upper snake to
+// lower kebab), e.g. ENVOY_AI_GATEWAY_CI_TESTS -> envoy-ai-gateway. Deriving
+// the binding from the variable name keeps this loader convention-based
+// rather than hand-maintained: a future override that follows the same
+// convention is picked up (and gated) automatically, and a prefix that
+// matches no registered profile fails Gate D loudly.
+var ciOverridePattern = regexp.MustCompile(`(?m)^\s*([A-Z0-9_]+)_CI_TESTS="([^"]*)"`)
+
+// CIOverride records one explicit CI selection override: the exact testcase
+// list the workflow runs for a profile instead of the profile's full
+// runtime GetTestCases selection.
+type CIOverride struct {
+	Profile   string   `json:"profile"`
+	TestCases []string `json:"test_cases"`
+}
+
+// LoadCIOverrides parses the CI workflow at path and returns the explicit
+// per-profile selection overrides, sorted by profile. An empty result is a
+// legitimate state (no override in force: CI runs each profile's complete
+// selection); a missing or unreadable workflow file is a hard error.
+func LoadCIOverrides(path string) ([]CIOverride, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading CI workflow %s: %w", path, err)
+	}
+
+	matches := ciOverridePattern.FindAllStringSubmatch(string(raw), -1)
+	overrides := make([]CIOverride, 0, len(matches))
+	seen := make(map[string]bool, len(matches))
+	for _, match := range matches {
+		profile := strings.ReplaceAll(strings.ToLower(match[1]), "_", "-")
+		if seen[profile] {
+			return nil, fmt.Errorf("CI workflow %s declares multiple %s_CI_TESTS overrides for profile %q", path, match[1], profile)
+		}
+		seen[profile] = true
+		overrides = append(overrides, CIOverride{
+			Profile:   profile,
+			TestCases: dedupSorted(splitCommaList(match[2])),
+		})
+	}
+	sort.Slice(overrides, func(i, j int) bool { return overrides[i].Profile < overrides[j].Profile })
+	return overrides, nil
+}
+
+// CIOverrideDrift is the per-profile diagnosis of an explicit CI override
+// against the profile's runtime selection and its bounded exclusion table.
+type CIOverrideDrift struct {
+	// OmittedUnrecorded lists testcases selected by the profile, absent
+	// from the explicit CI list, and not recorded in the exclusion table:
+	// the silent-omission scenario (a testcase added to the profile but
+	// never executed in CI, with no gate noticing).
+	OmittedUnrecorded []string
+
+	// StaleExclusions lists exclusion-table entries that no longer describe
+	// an exclusion: the testcase is now on the CI list, or the profile no
+	// longer selects it.
+	StaleExclusions []string
+
+	// Phantom lists CI-list entries the profile does not select at
+	// runtime: names that CI asks for but the execution graph cannot
+	// resolve to a selected testcase.
+	Phantom []string
+}
+
+// DiagnoseCIOverrideDrift computes the drift between one profile's runtime
+// selection, its explicit CI list, and its bounded exclusion table. It is a
+// pure function over its inputs so the omission, stale, and phantom
+// scenarios can be pinned by synthetic tests independently of the live
+// registries.
+func DiagnoseCIOverrideDrift(selected, ciList []string, exclusions map[string]CIExclusion) CIOverrideDrift {
+	selectedSet := toSet(selected)
+	ciSet := toSet(ciList)
+
+	drift := CIOverrideDrift{
+		OmittedUnrecorded: []string{},
+		StaleExclusions:   []string{},
+		Phantom:           []string{},
+	}
+
+	for name := range selectedSet {
+		if ciSet[name] {
+			continue
+		}
+		if _, recorded := exclusions[name]; !recorded {
+			drift.OmittedUnrecorded = append(drift.OmittedUnrecorded, name)
+		}
+	}
+	for name := range exclusions {
+		if !selectedSet[name] || ciSet[name] {
+			drift.StaleExclusions = append(drift.StaleExclusions, name)
+		}
+	}
+	for name := range ciSet {
+		if !selectedSet[name] {
+			drift.Phantom = append(drift.Phantom, name)
+		}
+	}
+
+	sort.Strings(drift.OmittedUnrecorded)
+	sort.Strings(drift.StaleExclusions)
+	sort.Strings(drift.Phantom)
+	return drift
+}
+
+func splitCommaList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func toSet(values []string) map[string]bool {
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		set[value] = true
+	}
+	return set
+}

--- a/e2e/pkg/verification/debt.go
+++ b/e2e/pkg/verification/debt.go
@@ -1,0 +1,61 @@
+// e2e/pkg/verification/debt.go
+
+package verification
+
+// UnreachableDebt bounds one registered-but-unreachable testcase to a
+// disposition: either a child issue that owns resolving it (Issue) or a
+// documented reason it is manual-only today (Rationale). Exactly one of the
+// two must be set.
+//
+// A child issue owning an entry means the family owns the disposition of the
+// legacy testcase; it does not promise the child issue must preserve that
+// exact testcase. Removal, rename, or replacement remain valid resolutions —
+// each of which must also delete the entry here.
+type UnreachableDebt struct {
+	Issue     int
+	Rationale string
+}
+
+// KnownUnreachableDebt is the exact set of registered-but-unreachable
+// testcases on main, recorded as audit findings for issue #2379.
+//
+// This table is a debt ratchet, not an allowlist: the gate requires the
+// actual unreachable set to equal these keys in both directions. A newly
+// unreachable testcase fails the gate until it gets a profile mapping or a
+// bounded disposition here; a resolved testcase also fails the gate until
+// its stale entry is deleted. The table can only shrink intentionally.
+var KnownUnreachableDebt = map[string]UnreachableDebt{
+	// #3179 — selector algorithm coverage owns disposition of the legacy
+	// core-selection cases (several reference algorithms that no longer
+	// exist in the runtime decision-algorithm catalog).
+	"core-selection-static":       {Issue: 3179},
+	"core-selection-elo":          {Issue: 3179},
+	"core-selection-elo-feedback": {Issue: 3179},
+	"core-selection-routerdc":     {Issue: 3179},
+	"core-selection-automix":      {Issue: 3179},
+	"core-selection-hybrid":       {Issue: 3179},
+	"core-selection-thompson":     {Issue: 3179},
+	"core-selection-gmtrouter":    {Issue: 3179},
+	"core-selection-router-r1":    {Issue: 3179},
+
+	// #3178 — signal / classification-family coverage owns disposition of
+	// the MCP classification cases (no registered profile deploys an MCP
+	// classifier stack) and the superseded authz signal case.
+	"mcp-http-classification":      {Issue: 3178},
+	"mcp-stdio-classification":     {Issue: 3178},
+	"mcp-model-reasoning":          {Issue: 3178},
+	"mcp-fallback-behavior":        {Issue: 3178},
+	"mcp-probability-distribution": {Issue: 3178},
+	"authz-rbac-routing":           {Issue: 3178},
+
+	// #3180 — decision plugin coverage owns disposition of the legacy
+	// OpenAI-backed RAG case.
+	"rag-openai": {Issue: 3180},
+
+	// Documented manual-only rationale: mirrors the authz-rbac profile
+	// contract, where direct client identity headers are stripped by the
+	// production anti-spoofing path.
+	"ratelimit-limitor": {
+		Rationale: "direct x-authz-* client identity headers are stripped by the production anti-spoofing path, so this testcase cannot run under the authz-rbac profile until identity is supplied by a trusted post-auth source / owning profile",
+	},
+}

--- a/e2e/pkg/verification/gates_ci_test.go
+++ b/e2e/pkg/verification/gates_ci_test.go
@@ -1,0 +1,160 @@
+// e2e/pkg/verification/gates_ci_test.go
+
+package verification
+
+// Gate D below extends the derived execution contract with the fourth
+// selection layer: explicit per-profile CI overrides declared in the
+// integration workflow. Registration side effects for the live gate come
+// from the blank imports in gates_test.go (both files link into the same
+// test binary). The synthetic pin tests at the bottom exercise the pure
+// drift diagnosis against fixed inputs, so the omission, stale, and phantom
+// scenarios stay pinned regardless of live registry state.
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// Gate D: explicit CI selection overrides are part of the derived contract.
+//
+// For every override the workflow declares, the set of testcases the profile
+// selects at runtime but the override omits must equal the profile's
+// KnownCIExclusions keys in both directions (the same ratchet discipline as
+// Gate A), and the override must not name testcases the profile does not
+// select (no allowlist, the same discipline as Gate B). An exclusion table
+// for a profile with no override in force is stale as a whole.
+func TestGateDCIOverridesMatchKnownExclusions(t *testing.T) {
+	inventory := buildInventoryForTest(t)
+
+	workflowPath := filepath.Join(repoRootForTest(t), ".github", "workflows", "integration-test-k8s.yml")
+	overrides, err := LoadCIOverrides(workflowPath)
+	if err != nil {
+		t.Fatalf("loading explicit CI overrides: %v", err)
+	}
+
+	selections := make(map[string][]string, len(inventory.Profiles))
+	for _, profile := range inventory.Profiles {
+		selections[profile.Name] = profile.TestCases
+	}
+
+	overriddenProfiles := make(map[string]bool, len(overrides))
+	for _, override := range overrides {
+		overriddenProfiles[override.Profile] = true
+
+		selected, registered := selections[override.Profile]
+		if !registered {
+			t.Errorf("CI workflow declares an override for profile %q which has no runtime registration; fix the variable prefix or register the profile", override.Profile)
+			continue
+		}
+
+		drift := DiagnoseCIOverrideDrift(selected, override.TestCases, KnownCIExclusions[override.Profile])
+		for _, name := range drift.OmittedUnrecorded {
+			t.Errorf("profile %q selects testcase %q but the explicit CI list omits it and KnownCIExclusions records no bounded exclusion; add it to the CI list or record a disposition", override.Profile, name)
+		}
+		for _, name := range drift.StaleExclusions {
+			t.Errorf("KnownCIExclusions entry %q/%q is stale: the testcase is now on the CI list or no longer selected by the profile; delete the resolved entry", override.Profile, name)
+		}
+		for _, name := range drift.Phantom {
+			t.Errorf("explicit CI list for profile %q names %q which the profile does not select at runtime; fix the name or the profile selection", override.Profile, name)
+		}
+	}
+
+	for profile := range KnownCIExclusions {
+		if !overriddenProfiles[profile] {
+			t.Errorf("KnownCIExclusions records exclusions for profile %q but the CI workflow declares no override for it; delete the stale table", profile)
+		}
+	}
+}
+
+// Every exclusion entry must carry exactly one bounded disposition: an
+// owning issue XOR a documented rationale.
+func TestGateDExclusionEntriesAreBounded(t *testing.T) {
+	for profile, exclusions := range KnownCIExclusions {
+		for name, exclusion := range exclusions {
+			hasIssue := exclusion.Issue != 0
+			hasRationale := exclusion.Rationale != ""
+			if hasIssue == hasRationale {
+				t.Errorf("KnownCIExclusions entry %q/%q must set exactly one of Issue or Rationale", profile, name)
+			}
+		}
+	}
+}
+
+// Synthetic pin: the review's omission scenario. A testcase added to a
+// profile but omitted from the explicit CI list, with no recorded
+// exclusion, must surface as drift instead of passing silently.
+func TestCIOverrideDriftPinsOmissionScenario(t *testing.T) {
+	drift := DiagnoseCIOverrideDrift(
+		[]string{"case-kept", "case-added-but-omitted"},
+		[]string{"case-kept"},
+		map[string]CIExclusion{},
+	)
+	assertDrift(t, drift, CIOverrideDrift{
+		OmittedUnrecorded: []string{"case-added-but-omitted"},
+		StaleExclusions:   []string{},
+		Phantom:           []string{},
+	})
+}
+
+// Synthetic pin: both stale-exclusion causes. An entry resolves when its
+// testcase joins the CI list or when the profile stops selecting it; either
+// way the stale entry must surface until deleted.
+func TestCIOverrideDriftPinsStaleExclusions(t *testing.T) {
+	drift := DiagnoseCIOverrideDrift(
+		[]string{"case-kept", "case-promoted"},
+		[]string{"case-kept", "case-promoted"},
+		map[string]CIExclusion{
+			"case-promoted":   {Issue: 1},
+			"case-deselected": {Issue: 1},
+		},
+	)
+	assertDrift(t, drift, CIOverrideDrift{
+		OmittedUnrecorded: []string{},
+		StaleExclusions:   []string{"case-deselected", "case-promoted"},
+		Phantom:           []string{},
+	})
+}
+
+// Synthetic pin: the phantom direction. A CI-list name the profile does not
+// select must surface as drift with no allowlist.
+func TestCIOverrideDriftPinsPhantom(t *testing.T) {
+	drift := DiagnoseCIOverrideDrift(
+		[]string{"case-kept"},
+		[]string{"case-kept", "case-phantom"},
+		map[string]CIExclusion{},
+	)
+	assertDrift(t, drift, CIOverrideDrift{
+		OmittedUnrecorded: []string{},
+		StaleExclusions:   []string{},
+		Phantom:           []string{"case-phantom"},
+	})
+}
+
+// Synthetic pin: a consistent contract diagnoses clean, including a
+// recorded exclusion that is genuinely in force.
+func TestCIOverrideDriftCleanContract(t *testing.T) {
+	drift := DiagnoseCIOverrideDrift(
+		[]string{"case-kept", "case-excluded"},
+		[]string{"case-kept"},
+		map[string]CIExclusion{
+			"case-excluded": {Issue: 1},
+		},
+	)
+	assertDrift(t, drift, CIOverrideDrift{
+		OmittedUnrecorded: []string{},
+		StaleExclusions:   []string{},
+		Phantom:           []string{},
+	})
+}
+
+func assertDrift(t *testing.T, got, want CIOverrideDrift) {
+	t.Helper()
+	sort.Strings(want.OmittedUnrecorded)
+	sort.Strings(want.StaleExclusions)
+	sort.Strings(want.Phantom)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("drift diagnosis mismatch:\n  got:  %+v\n  want: %+v", got, want)
+	}
+}

--- a/e2e/pkg/verification/gates_test.go
+++ b/e2e/pkg/verification/gates_test.go
@@ -1,0 +1,166 @@
+// e2e/pkg/verification/gates_test.go
+
+package verification
+
+// The gates below enforce the three execution-graph invariants frozen for
+// issue #2379 PR1. Registration side effects are provided here, at the test
+// entrypoint, via the blank imports — the verification package itself owns
+// no registration.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+
+	_ "github.com/vllm-project/semantic-router/e2e/profiles/all"
+	_ "github.com/vllm-project/semantic-router/e2e/testcases"
+)
+
+func buildInventoryForTest(t *testing.T) Inventory {
+	t.Helper()
+	inventory, err := BuildInventory()
+	if err != nil {
+		t.Fatalf("building runtime execution inventory: %v", err)
+	}
+	return inventory
+}
+
+// Gate A: registered-but-unreachable is an exact bounded debt ratchet.
+//
+// The invariant is unreachable == keys(KnownUnreachableDebt), checked in both
+// directions: a newly unreachable testcase fails until it gets a profile
+// mapping or a bounded disposition, and a resolved testcase fails until its
+// stale debt entry is deleted. The debt table can only shrink intentionally.
+func TestGateARegisteredButUnreachableMatchesKnownDebt(t *testing.T) {
+	inventory := buildInventoryForTest(t)
+
+	unreachable := make(map[string]bool)
+	for _, name := range inventory.Unreachable() {
+		unreachable[name] = true
+	}
+
+	unexpected := make([]string, 0)
+	for name := range unreachable {
+		if _, ok := KnownUnreachableDebt[name]; !ok {
+			unexpected = append(unexpected, name)
+		}
+	}
+	sort.Strings(unexpected)
+	for _, name := range unexpected {
+		t.Errorf("testcase %q is registered but unreachable from every registered profile; map it from a profile's GetTestCases() or record a bounded disposition in KnownUnreachableDebt", name)
+	}
+
+	stale := make([]string, 0)
+	for name := range KnownUnreachableDebt {
+		if !unreachable[name] {
+			stale = append(stale, name)
+		}
+	}
+	sort.Strings(stale)
+	for _, name := range stale {
+		t.Errorf("KnownUnreachableDebt entry %q is stale: the testcase is now reachable (or no longer registered); delete the resolved debt entry", name)
+	}
+}
+
+// Every debt entry must carry exactly one bounded disposition: an owning
+// child issue XOR a documented manual rationale.
+func TestGateADebtEntriesAreBounded(t *testing.T) {
+	for name, debt := range KnownUnreachableDebt {
+		hasIssue := debt.Issue != 0
+		hasRationale := debt.Rationale != ""
+		if hasIssue == hasRationale {
+			t.Errorf("KnownUnreachableDebt entry %q must set exactly one of Issue or Rationale", name)
+		}
+	}
+}
+
+// Gate B: selected-but-unregistered is empty, immediately and with no
+// allowlist. This catches typos, stale testmatrix entries, and profile
+// selections pointing at deleted registrations.
+func TestGateBSelectedButUnregisteredIsEmpty(t *testing.T) {
+	inventory := buildInventoryForTest(t)
+	for _, name := range inventory.SelectedButUnregistered {
+		profiles := make([]string, 0)
+		for _, profile := range inventory.Profiles {
+			for _, selected := range profile.TestCases {
+				if selected == name {
+					profiles = append(profiles, profile.Name)
+				}
+			}
+		}
+		t.Errorf("profile selection references unregistered testcase %q (selected by: %v); fix the name or register the testcase", name, profiles)
+	}
+}
+
+// Gate C: runtime profile registration and the CI/profile registry agree
+// exactly. This replaces source-regex reasoning about the Go execution side
+// with actual runtime registration; the existing Python validation lane keeps
+// its transitive registry <-> repo-manifest checks unchanged.
+func TestGateCRuntimeProfilesMatchTestDomainRegistry(t *testing.T) {
+	registryProfiles := loadTestDomainRegistryProfiles(t)
+
+	runtimeProfiles := make(map[string]bool)
+	for _, name := range framework.RegisteredProfileNames() {
+		runtimeProfiles[name] = true
+	}
+
+	missingFromRegistry := make([]string, 0)
+	for name := range runtimeProfiles {
+		if !registryProfiles[name] {
+			missingFromRegistry = append(missingFromRegistry, name)
+		}
+	}
+	sort.Strings(missingFromRegistry)
+	for _, name := range missingFromRegistry {
+		t.Errorf("runtime-registered profile %q is missing from tools/agent/test-domain-registry.yaml", name)
+	}
+
+	missingFromRuntime := make([]string, 0)
+	for name := range registryProfiles {
+		if !runtimeProfiles[name] {
+			missingFromRuntime = append(missingFromRuntime, name)
+		}
+	}
+	sort.Strings(missingFromRuntime)
+	for _, name := range missingFromRuntime {
+		t.Errorf("tools/agent/test-domain-registry.yaml profile %q has no runtime registration in e2e/profiles/all", name)
+	}
+}
+
+func loadTestDomainRegistryProfiles(t *testing.T) map[string]bool {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolving caller path for repo root")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	registryPath := filepath.Join(repoRoot, "tools", "agent", "test-domain-registry.yaml")
+
+	raw, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", registryPath, err)
+	}
+
+	var registry struct {
+		Profiles map[string]any `yaml:"profiles"`
+	}
+	if err := yaml.Unmarshal(raw, &registry); err != nil {
+		t.Fatalf("parsing %s: %v", registryPath, err)
+	}
+	if len(registry.Profiles) == 0 {
+		t.Fatalf("%s declares no profiles; refusing to compare against an empty registry", registryPath)
+	}
+
+	profiles := make(map[string]bool, len(registry.Profiles))
+	for name := range registry.Profiles {
+		profiles[name] = true
+	}
+	return profiles
+}

--- a/e2e/pkg/verification/gates_test.go
+++ b/e2e/pkg/verification/gates_test.go
@@ -2,10 +2,11 @@
 
 package verification
 
-// The gates below enforce the three execution-graph invariants frozen for
-// issue #2379 PR1. Registration side effects are provided here, at the test
-// entrypoint, via the blank imports — the verification package itself owns
-// no registration.
+// The gates in this file enforce the execution-graph invariants frozen for
+// issue #2379 PR1 (Gates A-C); Gate D, the explicit CI override layer of the
+// derived contract, lives in gates_ci_test.go. Registration side effects are
+// provided here, at the test entrypoint, via the blank imports — the
+// verification package itself owns no registration.
 
 import (
 	"os"
@@ -17,7 +18,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
-
 	_ "github.com/vllm-project/semantic-router/e2e/profiles/all"
 	_ "github.com/vllm-project/semantic-router/e2e/testcases"
 )
@@ -29,6 +29,15 @@ func buildInventoryForTest(t *testing.T) Inventory {
 		t.Fatalf("building runtime execution inventory: %v", err)
 	}
 	return inventory
+}
+
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolving caller path for repo root")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
 }
 
 // Gate A: registered-but-unreachable is an exact bounded debt ratchet.
@@ -98,12 +107,13 @@ func TestGateBSelectedButUnregisteredIsEmpty(t *testing.T) {
 	}
 }
 
-// Gate C: runtime profile registration and the CI/profile registry agree
-// exactly. This replaces source-regex reasoning about the Go execution side
-// with actual runtime registration; the existing Python validation lane keeps
-// its transitive registry <-> repo-manifest checks unchanged.
-func TestGateCRuntimeProfilesMatchTestDomainRegistry(t *testing.T) {
-	registryProfiles := loadTestDomainRegistryProfiles(t)
+// Gate C: runtime profile registration and the repository domain registry
+// (tools/agent/domains.yaml, the successor of test-domain-registry.yaml)
+// agree exactly. This replaces source-regex reasoning about the Go execution
+// side with actual runtime registration; the existing Python validation lane
+// keeps its transitive registry <-> repo checks unchanged.
+func TestGateCRuntimeProfilesMatchDomainRegistry(t *testing.T) {
+	registryProfiles := loadDomainRegistryProfiles(t)
 
 	runtimeProfiles := make(map[string]bool)
 	for _, name := range framework.RegisteredProfileNames() {
@@ -118,7 +128,7 @@ func TestGateCRuntimeProfilesMatchTestDomainRegistry(t *testing.T) {
 	}
 	sort.Strings(missingFromRegistry)
 	for _, name := range missingFromRegistry {
-		t.Errorf("runtime-registered profile %q is missing from tools/agent/test-domain-registry.yaml", name)
+		t.Errorf("runtime-registered profile %q is missing from tools/agent/domains.yaml", name)
 	}
 
 	missingFromRuntime := make([]string, 0)
@@ -129,19 +139,14 @@ func TestGateCRuntimeProfilesMatchTestDomainRegistry(t *testing.T) {
 	}
 	sort.Strings(missingFromRuntime)
 	for _, name := range missingFromRuntime {
-		t.Errorf("tools/agent/test-domain-registry.yaml profile %q has no runtime registration in e2e/profiles/all", name)
+		t.Errorf("tools/agent/domains.yaml profile %q has no runtime registration in e2e/profiles/all", name)
 	}
 }
 
-func loadTestDomainRegistryProfiles(t *testing.T) map[string]bool {
+func loadDomainRegistryProfiles(t *testing.T) map[string]bool {
 	t.Helper()
 
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("resolving caller path for repo root")
-	}
-	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
-	registryPath := filepath.Join(repoRoot, "tools", "agent", "test-domain-registry.yaml")
+	registryPath := filepath.Join(repoRootForTest(t), "tools", "agent", "domains.yaml")
 
 	raw, err := os.ReadFile(registryPath)
 	if err != nil {

--- a/e2e/pkg/verification/inventory.go
+++ b/e2e/pkg/verification/inventory.go
@@ -1,0 +1,152 @@
+// e2e/pkg/verification/inventory.go
+
+// Package verification derives read-only views of the E2E execution graph
+// from runtime sources of truth and gates their consistency.
+//
+// It OWNS: derived views of existing E2E registrations, reachability
+// analysis, and consistency diagnostics.
+//
+// It DOES NOT OWN: testcase registration, profile registration, testcase
+// selection, CI profile selection, or runtime surface catalogs. Arrows only
+// point inward: this package reads the registries (testcases.List,
+// framework.RegisteredProfileNames + Profile.GetTestCases) and never becomes
+// a configuration owner. Callers that need registration side effects (the
+// e2e-audit command and the gate tests) blank-import the registration
+// packages themselves.
+//
+// The generated inventory is an output, never a checked-in source of truth.
+// See issue #2379.
+package verification
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/framework"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+// ProfileCoverage records the testcases one canonical registered profile
+// resolves to at runtime via GetTestCases (including shared testmatrix groups,
+// which are expanded transitively by the profile implementations themselves).
+type ProfileCoverage struct {
+	Name      string   `json:"name"`
+	TestCases []string `json:"test_cases"`
+}
+
+// TestcaseCoverage records which canonical profiles select one registered
+// testcase. An empty Profiles list means the testcase is registered but
+// unreachable from every registered profile.
+type TestcaseCoverage struct {
+	Name     string   `json:"name"`
+	Profiles []string `json:"profiles"`
+}
+
+// Inventory is the runtime-derived execution graph.
+type Inventory struct {
+	Profiles  []ProfileCoverage  `json:"profiles"`
+	Testcases []TestcaseCoverage `json:"testcases"`
+
+	// SelectedButUnregistered lists names returned by some profile's
+	// GetTestCases that no registered testcase carries (typos, stale
+	// testmatrix entries, selections pointing at deleted registrations).
+	SelectedButUnregistered []string `json:"selected_but_unregistered"`
+}
+
+// BuildInventory enumerates the registered testcases and canonical registered
+// profiles and derives the execution graph. It requires the registration
+// packages to have been imported by the caller; it fails loudly if either
+// registry is empty rather than reporting a trivially empty graph.
+func BuildInventory() (Inventory, error) {
+	registered := registeredTestcaseNames()
+	if len(registered) == 0 {
+		return Inventory{}, fmt.Errorf("testcase registry is empty; the caller must blank-import the e2e/testcases registration package")
+	}
+
+	profileNames := framework.RegisteredProfileNames()
+	if len(profileNames) == 0 {
+		return Inventory{}, fmt.Errorf("profile registry is empty; the caller must blank-import the e2e/profiles/all registration package")
+	}
+	sort.Strings(profileNames)
+
+	inventory := Inventory{
+		Profiles:  make([]ProfileCoverage, 0, len(profileNames)),
+		Testcases: make([]TestcaseCoverage, 0, len(registered)),
+	}
+
+	selectedBy := make(map[string][]string, len(registered))
+	for _, profileName := range profileNames {
+		profile, err := framework.NewProfileByName(profileName)
+		if err != nil {
+			return Inventory{}, fmt.Errorf("instantiating registered profile %q: %w", profileName, err)
+		}
+		selected := dedupSorted(profile.GetTestCases())
+		inventory.Profiles = append(inventory.Profiles, ProfileCoverage{
+			Name:      profileName,
+			TestCases: selected,
+		})
+		for _, testcase := range selected {
+			selectedBy[testcase] = append(selectedBy[testcase], profileName)
+		}
+	}
+
+	registeredSet := make(map[string]bool, len(registered))
+	for _, name := range registered {
+		registeredSet[name] = true
+		profiles := selectedBy[name]
+		if profiles == nil {
+			profiles = []string{}
+		}
+		inventory.Testcases = append(inventory.Testcases, TestcaseCoverage{
+			Name:     name,
+			Profiles: profiles,
+		})
+	}
+
+	for selected := range selectedBy {
+		if !registeredSet[selected] {
+			inventory.SelectedButUnregistered = append(inventory.SelectedButUnregistered, selected)
+		}
+	}
+	sort.Strings(inventory.SelectedButUnregistered)
+	if inventory.SelectedButUnregistered == nil {
+		inventory.SelectedButUnregistered = []string{}
+	}
+
+	return inventory, nil
+}
+
+// Unreachable returns the registered testcases no profile selects, sorted.
+func (inv Inventory) Unreachable() []string {
+	unreachable := make([]string, 0)
+	for _, testcase := range inv.Testcases {
+		if len(testcase.Profiles) == 0 {
+			unreachable = append(unreachable, testcase.Name)
+		}
+	}
+	sort.Strings(unreachable)
+	return unreachable
+}
+
+func registeredTestcaseNames() []string {
+	testcases := pkgtestcases.List()
+	names := make([]string, 0, len(testcases))
+	for _, testcase := range testcases {
+		names = append(names, testcase.Name)
+	}
+	return dedupSorted(names)
+}
+
+func dedupSorted(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/tools/make/e2e.mk
+++ b/tools/make/e2e.mk
@@ -1,3 +1,4 @@
+# tools/make/e2e.mk
 # ======== e2e.mk ========
 # = E2E Testing Framework =
 # ======== e2e.mk ========
@@ -22,6 +23,13 @@ build-e2e: ## Build the E2E test binary
 	@$(LOG_TARGET)
 	@echo "Building E2E test binary..."
 	@cd e2e && go build -o ../bin/e2e ./cmd/e2e
+	@$(MAKE) e2e-coverage-check
+
+.PHONY: e2e-coverage-check
+e2e-coverage-check: ## Run the runtime-derived E2E coverage drift gates (no cluster required)
+	@$(LOG_TARGET)
+	@echo "Running E2E coverage drift gates..."
+	@cd e2e && go test -count=1 ./pkg/verification/
 
 # Run E2E tests
 e2e-test: ## Run E2E tests (PROFILE=envoy-ai-gateway by default)

--- a/tools/make/e2e.mk
+++ b/tools/make/e2e.mk
@@ -1,4 +1,3 @@
-# tools/make/e2e.mk
 # ======== e2e.mk ========
 # = E2E Testing Framework =
 # ======== e2e.mk ========


### PR DESCRIPTION
## Summary

E2E testcase registration, profile selection, and CI selection can drift independently. In particular, adding a testcase to a profile does not guarantee that an explicit CI override will include it.

This PR adds a generated execution-graph audit and four consistency gates as the first slice of #2379. It uses the existing registrations and selections, with two small tables recording dispositions for known gaps.

Following review, Gate D checks explicit `*_CI_TESTS` overrides in `integration-test-k8s.yml`. Since that review, main replaced the explicit `ENVOY_AI_GATEWAY_CI_TESTS` list with the `baseline-suite` input (`E2E_BASELINE_SUITE`), so the recorded exclusions left with the override: the branch is rebased onto c16c21f3b, `KnownCIExclusions` is empty, and the `pii-remote-backend` runtime profile is registered in `tools/agent/domains.yaml`.

## What it checks

| Gate | Check |
| --- | --- |
| A | Registered testcases that no profile selects must exactly match `KnownUnreachableDebt`. |
| B | Every testcase selected by a profile must be registered. |
| C | Runtime profile names must exactly match the profile keys in `tools/agent/domains.yaml`. |
| D | Testcases omitted by an explicit `*_CI_TESTS` override must exactly match that profile's `KnownCIExclusions`, and the override must not name cases the profile does not select. Current main declares no such override, so the table is empty and the gate is armed for any future one. |

The owning issues can resolve these cases through profile mapping, removal, rename, or replacement.

## Verification

Local verification on the rebased tree (main c16c21f3b, head 0f2ec4566):

- Audit output: 33 canonical profiles, 176 registered testcases, no selected-but-unregistered names, and exactly 17 registered-but-unreachable cases.
- CI override output: no explicit override on main, no recorded exclusions, all drift sets empty.
- Two consecutive audit runs produced byte-identical JSON.
- `make e2e-coverage-check` and `make build-e2e` passed; `tools/agent/domains.yaml` passes the harness registry validation.
- Committed synthetic pins in `gates_ci_test.go` cover Gate D's omission, stale-exclusion, and phantom-entry directions against a future explicit override.

## Scope

This PR checks execution-graph consistency. Runtime behavior and surface-level coverage gaps remain with the existing coverage issues, including #2859, #3181, and #3182.

The `baseline-suite` selector (`testmatrix.BaselineCases` in the runner) is a runtime selection layer the audit does not model yet; it is a candidate follow-up slice under #2379 rather than part of this PR.

A testmatrix group referenced by no profile is outside the transitive audit; none were found at the audited snapshot. The existing Python registry checks in `tools/ci/domain_registry.py` remain in place.

`gopkg.in/yaml.v3` moves from an indirect to a direct dependency because Gate C reads the registry YAML.

Related #2379
