### PR TITLE
[Bug] Key RouterDC affinity on a SHA-256 digest of the full query instead of its 32-byte prefix

### DIFF
--- a/src/semantic-router/pkg/selection/router_dc.go
+++ b/src/semantic-router/pkg/selection/router_dc.go
@@ -18,6 +18,8 @@ package selection
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strings"
@@ -439,13 +441,11 @@ func (r *RouterDCSelector) applySoftmax(scores map[string]float64) map[string]fl
 	return result
 }
 
-// hashQuery creates a simple hash for query tracking
+// hashQuery returns a hex-encoded SHA-256 digest of the full query so that
+// affinity is keyed per query rather than per shared prefix.
 func (r *RouterDCSelector) hashQuery(query string) string {
-	// Simple hash for query grouping (could use more sophisticated methods)
-	if len(query) < 32 {
-		return fmt.Sprintf("%x", query)
-	}
-	return fmt.Sprintf("%x", query[:32])
+	sum := sha256.Sum256([]byte(query))
+	return hex.EncodeToString(sum[:])
 }
 
 // defaultSelection returns the first configured candidate when embedding-based

--- a/src/semantic-router/pkg/selection/router_dc_test.go
+++ b/src/semantic-router/pkg/selection/router_dc_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selection
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// sharedPrefix is longer than the 32-byte window the old hashQuery truncated to.
+const sharedPrefix = "You are a helpful assistant. Answer the user request: "
+
+func TestRouterDCSelector_HashQueryDistinguishesSharedPrefix(t *testing.T) {
+	selector := NewRouterDCSelector(DefaultRouterDCConfig())
+
+	poem := sharedPrefix + "write a poem about the ocean"
+	sql := sharedPrefix + "SQL to drop the production users table"
+
+	poemHash := selector.hashQuery(poem)
+	sqlHash := selector.hashQuery(sql)
+
+	if poemHash == sqlHash {
+		t.Fatalf("queries sharing a %d-byte prefix hashed to the same key %q", len(sharedPrefix), poemHash)
+	}
+	if again := selector.hashQuery(poem); again != poemHash {
+		t.Fatalf("hashQuery is not stable: %q != %q", again, poemHash)
+	}
+	if len(poemHash) != 64 || strings.Trim(poemHash, "0123456789abcdef") != "" {
+		t.Fatalf("expected 64-char lowercase hex SHA-256 digest, got %q", poemHash)
+	}
+}
+
+func TestRouterDCSelector_UpdateFeedbackKeysAffinityPerQuery(t *testing.T) {
+	selector := NewRouterDCSelector(DefaultRouterDCConfig())
+	ctx := context.Background()
+
+	poem := sharedPrefix + "write a poem about the ocean"
+	sql := sharedPrefix + "SQL to drop the production users table"
+
+	if err := selector.UpdateFeedback(ctx, &Feedback{Query: poem, WinnerModel: "poet"}); err != nil {
+		t.Fatalf("UpdateFeedback(poem) error = %v", err)
+	}
+	if err := selector.UpdateFeedback(ctx, &Feedback{Query: sql, WinnerModel: "dba"}); err != nil {
+		t.Fatalf("UpdateFeedback(sql) error = %v", err)
+	}
+
+	selector.affinityMu.RLock()
+	defer selector.affinityMu.RUnlock()
+
+	if got := len(selector.affinityMatrix); got != 2 {
+		t.Fatalf("expected 2 affinity buckets, got %d: %v", got, selector.affinityMatrix)
+	}
+
+	poemBucket := selector.affinityMatrix[selector.hashQuery(poem)]
+	sqlBucket := selector.affinityMatrix[selector.hashQuery(sql)]
+
+	if poemBucket["poet"] == 0 || poemBucket["dba"] != 0 {
+		t.Fatalf("poem bucket should only hold poet affinity, got %v", poemBucket)
+	}
+	if sqlBucket["dba"] == 0 || sqlBucket["poet"] != 0 {
+		t.Fatalf("sql bucket should only hold dba affinity, got %v", sqlBucket)
+	}
+}


### PR DESCRIPTION
Closes #3452

## Purpose

`RouterDCSelector.hashQuery` in `src/semantic-router/pkg/selection/router_dc.go` hex-encoded the first 32 bytes of the query instead of hashing it. Every query that shared a 32-byte prefix, such as anything behind a system prompt or template, collapsed into one `affinityMatrix` bucket, so `UpdateFeedback` learned affinity per prefix rather than per query.

This change keys affinity on a hex-encoded SHA-256 digest of the full query, matching the digest pattern already used in `pkg/cache` and `pkg/config`. The 32-byte truncation and its length branch are removed. A new `router_dc_test.go` covers the hash and the feedback path.



## Test Plan

```bash
cd src/semantic-router
export LD_LIBRARY_PATH=$PWD/../../ml-binding/target/release:$PWD/../../candle-binding/target/release:$PWD/../../nlp-binding/target/release
CGO_ENABLED=1 go test ./pkg/selection/ -run 'TestRouterDCSelector_' -count=1 -v
CGO_ENABLED=1 go test ./pkg/selection/ -count=1
gofmt -l pkg/selection/ && go vet ./pkg/selection/
```
The two new tests were also run against the previous hashQuery implementation to confirm they fail without the fix.

## Test Result

- Both tests fail on the previous implementation: queries sharing a 54-byte prefix produced the same key and landed in one bucket.
- Full pkg/selection package passes.
- gofmt and go vet are clean.
- golangci-lint run ./pkg/selection/ reports three pre-existing errcheck findings in router_r1_client.go, which this PR does not touch.


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category ...
- [x] The title does not stack prefixes ...
- [x] The PR links an accepted issue with exactly one owner ...
- [x] Commits in this PR are signed off with git commit -s
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope ...

</details>