### PR TITLE
[Bug] Stop PyPI sim publish workflow from canceling itself mid-release

### DIFF
--- a/.github/workflows/pypi-publish-vllm-sr-sim.yml
+++ b/.github/workflows/pypi-publish-vllm-sr-sim.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #3513

## Purpose

`pypi-publish-vllm-sr-sim.yml` had `cancel-in-progress: true` on its workflow-level concurrency group, unlike every other publish/scheduled workflow in the repo (`release.yml`, `recipe-distribution.yml`, `nightly-build.yml`, `maintenance.yml`), which all use `false`. Two overlapping runs on the same ref (e.g. a repeated `workflow_dispatch`, or a re-pushed tag) could cancel a run mid-publish, between the PyPI upload and the GitHub release creation steps, leaving the release inconsistent. Fixed by flipping it to `false` so concurrent runs queue instead of canceling in progress. Owned by Data Plane & Networking (`wg/data-plane-networking`).

## Test Plan

- `tools/ci/validate_workflows.py` (workflow contract check)

## Test Result

`validate_workflows.py` passed for all 35 workflows. Change is a single-line flip with no functional side effects on the publish steps themselves.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
