### PR TITLE
[Feature] Wire Metal device selection into the router FFI device paths

### DIFF
--- a/candle-binding/src/classifiers/unified/model_managers.rs
+++ b/candle-binding/src/classifiers/unified/model_managers.rs
@@ -1,7 +1,7 @@
 //! Model-manager adapters used by the dual-path classifier.
 
 use super::UnifiedTaskResult;
-use crate::core::{ModelErrorType, UnifiedError};
+use crate::core::{resolve_device, ModelErrorType, UnifiedError};
 use crate::model_architectures::config::{LoRAConfig, TraditionalConfig};
 use crate::model_architectures::traits::TaskType;
 use crate::model_architectures::unified_interface::CoreModel;
@@ -78,11 +78,7 @@ impl LoRAModelManager {
         security_model_path: &str,
         use_cpu: bool,
     ) -> Result<Self, candle_core::Error> {
-        let device = if use_cpu {
-            Device::Cpu
-        } else {
-            Device::cuda_if_available(0).unwrap_or(Device::Cpu)
-        };
+        let device = resolve_device(use_cpu);
         let manager = Self {
             models: HashMap::new(),
             device,

--- a/candle-binding/src/core/device.rs
+++ b/candle-binding/src/core/device.rs
@@ -11,7 +11,9 @@ pub fn resolve_device(use_cpu: bool) -> Device {
     }
     #[cfg(feature = "metal")]
     {
-        Device::new_metal(0).unwrap_or(Device::Cpu)
+        let device = Device::new_metal(0).unwrap_or(Device::Cpu);
+        eprintln!("[candle-binding] inference device: {device:?}");
+        device
     }
     #[cfg(not(feature = "metal"))]
     {
@@ -87,5 +89,23 @@ pub fn drain_loader_queue(device: &Device) {
     #[cfg(not(feature = "metal"))]
     {
         let _ = device;
+    }
+}
+
+#[cfg(all(test, feature = "metal", target_os = "macos"))]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    #[test]
+    fn gpu_request_selects_metal() {
+        let device = resolve_device(false);
+        assert!(device.is_metal(), "expected Metal device, got {device:?}");
+    }
+
+    #[test]
+    fn cpu_request_stays_cpu() {
+        let device = resolve_device(true);
+        assert!(!device.is_metal());
     }
 }

--- a/candle-binding/src/core/similarity.rs
+++ b/candle-binding/src/core/similarity.rs
@@ -8,6 +8,8 @@ use hf_hub::{api::sync::Api, Repo, RepoType};
 use std::path::Path;
 use tokenizers::{Tokenizer, TruncationDirection, TruncationParams, TruncationStrategy};
 
+use crate::core::resolve_device;
+
 /// Structure to hold BERT model and tokenizer for semantic similarity
 ///
 /// This is the core similarity computation engine that provides embedding
@@ -37,11 +39,7 @@ impl BertSimilarity {
     /// let similarity = BertSimilarity::new("sentence-transformers/all-MiniLM-L6-v2", false)?;
     /// ```
     pub fn new(model_id: &str, use_cpu: bool) -> Result<Self> {
-        let device = if use_cpu {
-            Device::Cpu
-        } else {
-            Device::cuda_if_available(0)?
-        };
+        let device = resolve_device(use_cpu);
 
         // Default to a sentence transformer model if not specified or empty
         let model_id = if model_id.is_empty() {
@@ -125,7 +123,7 @@ impl BertSimilarity {
         } else {
             unsafe {
                 VarBuilder::from_mmaped_safetensors(
-                    &[weights_filename.clone()],
+                    std::slice::from_ref(&weights_filename),
                     DType::F32,
                     &device,
                 )?

--- a/candle-binding/src/ffi/embedding.rs
+++ b/candle-binding/src/ffi/embedding.rs
@@ -4,6 +4,7 @@
 //! intelligent embedding generation with automatic model selection.
 
 use crate::classifiers::unified::{DualPathUnifiedClassifier, EmbeddingRequirements};
+use crate::core::resolve_device;
 use crate::ffi::types::{
     BatchSimilarityResult, EmbeddingResult, EmbeddingSimilarityResult, SimilarityMatch,
 };
@@ -263,8 +264,6 @@ where
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn init_mmbert_embedding_model(model_path: *const c_char, use_cpu: bool) -> bool {
-    use candle_core::Device;
-
     if model_path.is_null() {
         eprintln!("Error: model_path is null");
         return false;
@@ -289,11 +288,7 @@ pub extern "C" fn init_mmbert_embedding_model(model_path: *const c_char, use_cpu
     }
 
     // Determine device
-    let device = if use_cpu {
-        Device::Cpu
-    } else {
-        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
-    };
+    let device = resolve_device(use_cpu);
 
     // Create or get factory
     let factory = if GLOBAL_MODEL_FACTORY.get().is_some() {
@@ -340,8 +335,6 @@ pub extern "C" fn init_embedding_models_with_mmbert(
     mmbert_model_path: *const c_char,
     use_cpu: bool,
 ) -> bool {
-    use candle_core::Device;
-
     if GLOBAL_MODEL_FACTORY.get().is_some() {
         eprintln!("WARNING: ModelFactory already initialized");
         return true;
@@ -386,11 +379,7 @@ pub extern "C" fn init_embedding_models_with_mmbert(
         return false;
     }
 
-    let device = if use_cpu {
-        Device::Cpu
-    } else {
-        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
-    };
+    let device = resolve_device(use_cpu);
 
     let mut factory = ModelFactory::new(device);
 
@@ -439,8 +428,6 @@ pub extern "C" fn init_embedding_models(
     gemma_model_path: *const c_char,
     use_cpu: bool,
 ) -> bool {
-    use candle_core::Device;
-
     // Check if already initialized (OnceLock can only be set once)
     if GLOBAL_MODEL_FACTORY.get().is_some() {
         eprintln!("WARNING: ModelFactory already initialized");
@@ -477,11 +464,7 @@ pub extern "C" fn init_embedding_models(
     }
 
     // Determine device
-    let device = if use_cpu {
-        Device::Cpu
-    } else {
-        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
-    };
+    let device = resolve_device(use_cpu);
 
     // Create ModelFactory
     let mut factory = ModelFactory::new(device);
@@ -1942,8 +1925,6 @@ pub extern "C" fn init_embedding_models_batched(
     max_wait_ms: u64,
     use_cpu: bool,
 ) -> bool {
-    use candle_core::Device;
-
     // Check if already initialized
     if GLOBAL_BATCHED_MODEL.get().is_some() {
         eprintln!("Warning: batched embedding model already initialized");
@@ -1967,11 +1948,7 @@ pub extern "C" fn init_embedding_models_batched(
     };
 
     // Determine device
-    let device = if use_cpu {
-        Device::Cpu
-    } else {
-        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
-    };
+    let device = resolve_device(use_cpu);
 
     // Load tokenizer
     let tokenizer_path = format!("{}/tokenizer.json", model_path);
@@ -2199,8 +2176,6 @@ pub extern "C" fn init_multimodal_embedding_model(
     model_path: *const c_char,
     use_cpu: bool,
 ) -> bool {
-    use candle_core::Device;
-
     if model_path.is_null() {
         eprintln!("Error: model_path is null");
         return false;
@@ -2222,11 +2197,7 @@ pub extern "C" fn init_multimodal_embedding_model(
         return true;
     }
 
-    let device = if use_cpu {
-        Device::Cpu
-    } else {
-        Device::cuda_if_available(0).unwrap_or(Device::Cpu)
-    };
+    let device = resolve_device(use_cpu);
 
     // If the main factory is NOT yet set, create a new one with the multimodal model.
     if GLOBAL_MODEL_FACTORY.get().is_none() {

--- a/candle-binding/src/ffi/mlp.rs
+++ b/candle-binding/src/ffi/mlp.rs
@@ -45,9 +45,17 @@ fn device_from_type(device_type: c_int) -> Device {
                 Device::Cpu
             }
         }
-        // Metal is not a supported cargo feature for this crate yet, so retain
-        // the existing CPU fallback without advertising a broken feature flag.
-        2 => Device::Cpu,
+        // Metal (Apple Silicon GPU; enabled via the `metal` cargo feature).
+        2 => {
+            #[cfg(feature = "metal")]
+            {
+                Device::new_metal(0).unwrap_or(Device::Cpu)
+            }
+            #[cfg(not(feature = "metal"))]
+            {
+                Device::Cpu
+            }
+        }
         _ => Device::Cpu,
     }
 }
@@ -229,5 +237,12 @@ mod tests {
         let handle = candle_mlp_new();
         assert_eq!(candle_mlp_is_trained(handle), 0);
         candle_mlp_free(handle);
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn test_device_type_2_is_metal() {
+        let device = device_from_type(2);
+        assert!(device.is_metal(), "expected Metal, got {device:?}");
     }
 }


### PR DESCRIPTION
Related #3516

## Purpose

The Metal device resolver added in [#3165 Add Metal (Apple Silicon) support to candle-binding](https://github.com/vllm-project/semantic-router/pull/3165) (`core::device::resolve_device`, bounded Metal inference thread pool, queue draining) was only wired into the ModernBERT loader. The router-facing FFI entrypoints that load embeddings, similarity, and MLP selectors still hardcoded a CUDA-or-CPU fallback, so on macOS (Apple Silicon) `use_cpu=false` ran on the CPU even when the binding is built with `--features metal`.

This slice routes every inference device-selection site through the shared `core::device::resolve_device`:

- `ffi/embedding.rs` — all `init_*_embedding*` entrypoints
- `core/similarity.rs` — `BertSimilarity::new`
- `classifiers/unified/model_managers.rs` — `LoRAModelManager`
- `ffi/mlp.rs` — `device_from_type(2)` (Metal selector device type; the Go binding already defines `MLPDeviceMetal`)
- `core/device.rs` — Metal-selection unit tests + a metal-build-only device log line

Non-macOS / non-metal builds are unchanged: the non-metal branch of `resolve_device` is identical to the previous inline code, so Linux/CUDA/ROCm and CPU-only behavior is byte-for-byte equivalent.

## Test Plan

- `cargo fmt` / `cargo check` / clippy pass under the CI toolchain (rust 1.90).
- Unit tests under `--features metal` on darwin/arm64: `resolve_device(false).is_metal()`, `resolve_device(true)` stays CPU, `device_from_type(2).is_metal()`.
- Runtime (Metal builds cannot run in this repo's CI — all runners are ubuntu-latest, no macOS runner): with the `metal` feature built, `InitModel(<MiniLM dir>, use_cpu=false)` + `GetEmbedding` logs `[candle-binding] inference device: Metal(MetalDevice(DeviceId(..)))` and returns a 384-dim embedding — a real BERT forward on the GPU.
- Full `cargo test --no-default-features --features metal --lib` shows zero regressions vs the base tree (identical failure set, all pre-existing metal-feature kernel gaps / missing local test fixtures unrelated to this slice).

## Test Result

All checks above pass locally on darwin/arm64 (rust 1.90 override = CI toolchain). Remaining risk: qwen3/gemma embedding kernels are not yet Metal-covered (tracked in #3516's qualification scope), so this PR only makes the device selection wiring correct — it does not claim full model coverage on Metal.
