### PR TITLE
[Community] Add truddy0 to the MoM & Routing roster

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -65,6 +65,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/yaojiejia.png',
         profile: 'https://github.com/yaojiejia',
       },
+      {
+        name: 'Hui Ding',
+        avatar: 'https://github.com/truddy0.png',
+        profile: 'https://github.com/truddy0',
+      },
     ],
   },
   {


### PR DESCRIPTION
Adds @truddy0 as a Member of the MoM & Routing Workgroup.

Related #2965

| Applicant | Workgroup | Role | Application | Qualifying contribution |
| --- | --- | --- | --- | --- |
| [@truddy0](https://github.com/truddy0) | MoM & Routing | Member | [charter application](https://github.com/vllm-project/semantic-router/issues/2965#issuecomment-5553611695) | [#3445](https://github.com/vllm-project/semantic-router/pull/3445) |

Membership becomes canonical only after this PR merges.